### PR TITLE
Fix stale PR cache restore fallback policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Test Dylint Library
         run: cargo +nightly-2025-09-18 test --manifest-path dylints/ban_std_pathbuf/Cargo.toml
       - name: Run Dylint
-        run: cargo dylint --all --workspace
+        run: python3 ci/lint.py --dylint-only
 
   msrv:
     name: MSRV (1.75)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Test Dylint Library
         run: cargo +nightly-2025-09-18 test --manifest-path dylints/ban_std_pathbuf/Cargo.toml
       - name: Run Dylint
-        run: python3 ci/lint.py --dylint-only
+        run: python3 -m ci.lint --dylint-only
 
   msrv:
     name: MSRV (1.75)

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ How it works:
 1. First run: cold build, populates zccache compilation cache + saves target metadata
 2. Second run: restores target metadata → `zccache warm` fills in `.rlib` files from compilation cache → touches timestamps → `cargo build` → `Finished in 0.18s`
 
-`zccache warm` reads the on-disk artifact index (no daemon needed) and filters by `Cargo.lock` — only restores artifacts matching crates in your lockfile. Safe with shared caches across projects.
+`zccache warm` reads the on-disk artifact index (no daemon needed) and filters by `Cargo.lock` — only restores artifacts matching crates in your lockfile. That is a speed optimization, not a full integrity-verification pass: warmed artifacts are trusted and Cargo is expected to reject or rebuild anything incompatible.
 
 ### Inputs
 
@@ -433,10 +433,39 @@ How it works:
 | `cache-cargo-registry` | `true` | Cache cargo registry index + crate files + git deps |
 | `cache-compilation` | `true` | Cache compilation units via zccache daemon |
 | `cache-target` | `true` | Cache target metadata + run `zccache warm` |
+| `compilation-restore-fallback` | `true` | Allow prefix fallback for compilation cache restores |
+| `target-restore-fallback` | `false` | Allow prefix fallback for target metadata restores |
 | `target-dir` | `target` | Path to the cargo target directory |
 | `shared-key` | `""` | Extra key for matrix isolation (typically the target triple) |
 | `zccache-version` | `latest` | Version to install |
 | `save-cache` | `true` | Set `false` for PR builds (restore-only, saves cache budget) |
+
+### Restore policy
+
+The action now treats the two cache layers differently:
+
+- Compilation cache fallback stays enabled by default. That preserves fast incremental reuse across nearby commits while still letting zccache validate cache hits when `rustc` actually runs.
+- Target metadata fallback is disabled by default. Reusing stale Cargo fingerprints and build-script outputs across different source trees can make a PR merge ref look fresh when it is not.
+
+If you want the old fastest-possible behavior for developer CI, opt back in explicitly:
+
+```yaml
+- uses: zackees/zccache@main
+  with:
+    compilation-restore-fallback: true
+    target-restore-fallback: true
+```
+
+If you want a more release-hardened setup, prefer exact restores and avoid target metadata entirely:
+
+```yaml
+- uses: zackees/zccache@main
+  with:
+    cache-target: false
+    compilation-restore-fallback: false
+```
+
+This project is optimized for developer speed, not full artifact attestation. `zccache warm` does not checksum every restored object on every run, and the action does not try to prove cache integrity before building. If you need that level of assurance, disable the speed-focused layers for that workflow.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,20 @@ inputs:
       Only caches lightweight metadata, not full .rlib files.
     required: false
     default: "true"
+  compilation-restore-fallback:
+    description: >
+      Whether restore-key fallback is allowed for the zccache compilation cache.
+      Keep "true" for faster incremental CI across commits. Set to "false" for
+      exact-key-only restores.
+    required: false
+    default: "true"
+  target-restore-fallback:
+    description: >
+      Whether restore-key fallback is allowed for cargo target metadata.
+      Default "false" because fallback metadata can be stale for changed source
+      trees, especially on pull_request merge refs.
+    required: false
+    default: "false"
   target-dir:
     description: >
       Path to the cargo target directory.
@@ -91,11 +105,19 @@ runs:
         fi
 
         echo "compilation-key=${PREFIX}-${{ github.sha }}" >> "$GITHUB_OUTPUT"
-        echo "compilation-restore=${PREFIX}-" >> "$GITHUB_OUTPUT"
+        if [ "${{ inputs.compilation-restore-fallback }}" = "true" ]; then
+          echo "compilation-restore=${PREFIX}-" >> "$GITHUB_OUTPUT"
+        else
+          echo "compilation-restore=" >> "$GITHUB_OUTPUT"
+        fi
         echo "registry-key=cargo-registry-${OS}-${ARCH}-${LOCK_HASH}" >> "$GITHUB_OUTPUT"
         echo "registry-restore=cargo-registry-${OS}-${ARCH}-" >> "$GITHUB_OUTPUT"
         echo "target-key=cargo-target-${OS}-${ARCH}-${LOCK_HASH}-${{ github.sha }}" >> "$GITHUB_OUTPUT"
-        echo "target-restore=cargo-target-${OS}-${ARCH}-${LOCK_HASH}-" >> "$GITHUB_OUTPUT"
+        if [ "${{ inputs.target-restore-fallback }}" = "true" ]; then
+          echo "target-restore=cargo-target-${OS}-${ARCH}-${LOCK_HASH}-" >> "$GITHUB_OUTPUT"
+        else
+          echo "target-restore=" >> "$GITHUB_OUTPUT"
+        fi
 
     # --- Layer 1: Restore zccache compilation cache ---
     - name: Restore zccache compilation cache

--- a/action/README.md
+++ b/action/README.md
@@ -32,6 +32,10 @@ steps:
 |---|---|---|
 | `cache-cargo-registry` | `true` | Cache `~/.cargo/registry/` and `~/.cargo/git/` |
 | `cache-compilation` | `true` | Cache compilation units via zccache daemon |
+| `cache-target` | `true` | Cache target metadata + run `zccache warm` |
+| `compilation-restore-fallback` | `true` | Allow prefix fallback for compilation cache restores |
+| `target-restore-fallback` | `false` | Allow prefix fallback for target metadata restores |
+| `target-dir` | `target` | Path to the cargo target directory |
 | `shared-key` | `""` | Extra cache key for matrix isolation |
 | `zccache-version` | `latest` | PyPI version to install |
 | `save-cache` | `true` | Set `false` for PR builds (restore-only) |
@@ -42,13 +46,14 @@ steps:
 |---|---|
 | `cache-hit-compilation` | Whether zccache cache was restored |
 | `cache-hit-registry` | Whether cargo registry cache was restored |
+| `cache-hit-target` | Whether target metadata cache was restored |
 
 ## Architecture
 
 The action has two parts because composite actions lack `post` steps:
 
-1. **`zackees/zccache`** (setup) — restores caches, installs zccache, starts daemon
-2. **`zackees/zccache/action/cleanup`** (teardown) — stops daemon, saves caches
+1. **`zackees/zccache`** (setup) restores caches, installs zccache, warms target metadata, and starts the daemon.
+2. **`zackees/zccache/action/cleanup`** (teardown) stops the daemon and saves caches.
 
 The cleanup action must be called with `if: always()` to ensure caches are saved even on failure.
 
@@ -58,5 +63,12 @@ The cleanup action must be called with `if: always()` to ensure caches are saved
 |---|---|---|
 | zccache compilation | Per-unit `.o`/`.rlib` files (~1ms hit) | sccache (~170ms hit) |
 | Cargo registry | `~/.cargo/registry/` + `~/.cargo/git/` | Swatinem/rust-cache |
+| Target metadata | `target/` fingerprints, dep-info, build outputs | Cargo fingerprint recomputation |
 
 State is passed from setup to cleanup via `~/.zccache-action-state/`.
+
+### Restore policy
+
+- `compilation-restore-fallback: true` keeps the speed-first behavior for incremental CI.
+- `target-restore-fallback: false` is the default because stale Cargo metadata is not safe to prefix-restore across different source trees.
+- For release-hardened builds, prefer `cache-target: false` and exact-key-only restores.

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -43,11 +43,8 @@ def run_cmd_capture(cmd):
     )
 
 
-def ensure_windows_dylint_aliases():
-    """Create cargo-dylint's expected `name@toolchain.dll` aliases on Windows."""
-    if os.name != "nt":
-        return False
-
+def ensure_dylint_aliases():
+    """Create cargo-dylint's expected `name@toolchain` aliases when missing."""
     libraries_root = SCRIPT_DIR / "target" / "dylint" / "libraries"
     if not libraries_root.is_dir():
         return False
@@ -59,16 +56,43 @@ def ensure_windows_dylint_aliases():
         release_dir = toolchain_dir / "release"
         if not release_dir.is_dir():
             continue
-        suffix = f"@{toolchain_dir.name}.dll"
-        for dll in release_dir.glob("*.dll"):
-            if "@" in dll.stem:
+        for library in release_dir.iterdir():
+            if not library.is_file():
                 continue
-            alias = dll.with_name(f"{dll.stem}{suffix}")
+            if library.suffix not in {".dll", ".dylib", ".so"}:
+                continue
+            if "@" in library.stem:
+                continue
+            alias = library.with_name(
+                f"{library.stem}@{toolchain_dir.name}{library.suffix}"
+            )
             if alias.exists():
                 continue
-            alias.write_bytes(dll.read_bytes())
+            alias.write_bytes(library.read_bytes())
             created = True
     return created
+
+
+def lint_dylint_only():
+    """Run workspace dylint, retrying after alias repair if cargo-dylint misses it."""
+    if which("cargo-dylint") is None:
+        print(
+            "cargo-dylint is required for workspace linting. Install with "
+            "'cargo install cargo-dylint dylint-link'.",
+            file=sys.stderr,
+        )
+        return 1
+
+    result = run_cmd_capture([
+        "cargo", "dylint", "--all", "--workspace",
+    ])
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    if result.returncode != 0 and ensure_dylint_aliases():
+        result = run_cmd([
+            "cargo", "dylint", "--all", "--workspace",
+        ])
+    return result.returncode
 
 
 def detect_crate(file_path):
@@ -134,26 +158,9 @@ def lint_workspace():
     if result.returncode != 0:
         return result.returncode
 
-    if which("cargo-dylint") is None:
-        print(
-            "cargo-dylint is required for workspace linting. Install with "
-            "'cargo install cargo-dylint dylint-link'.",
-            file=sys.stderr,
-        )
-        return 1
-
-    result = run_cmd_capture([
-        "cargo", "dylint", "--all", "--workspace",
-    ])
-    sys.stdout.write(result.stdout)
-    sys.stderr.write(result.stderr)
-    if result.returncode != 0:
-        if ensure_windows_dylint_aliases():
-            result = run_cmd([
-                "cargo", "dylint", "--all", "--workspace",
-            ])
-        if result.returncode != 0:
-            return result.returncode
+    result = lint_dylint_only()
+    if result != 0:
+        return result
 
     env = clean_env()
     env["RUSTDOCFLAGS"] = "-D warnings"
@@ -192,6 +199,9 @@ def main():
 
     if args and args[0].endswith(".rs"):
         return lint_single_file(args[0])
+
+    if args == ["--dylint-only"]:
+        return lint_dylint_only()
 
     return lint_workspace()
 

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -846,7 +846,11 @@ fn cmd_warm(target_dir: &Path, profile: &str) -> ExitCode {
         if cwd.exists() {
             Some(cwd.to_path_buf())
         } else if let Some(ref p) = parent {
-            if p.exists() { Some(p.clone()) } else { None }
+            if p.exists() {
+                Some(p.clone())
+            } else {
+                None
+            }
         } else {
             None
         }
@@ -859,9 +863,7 @@ fn cmd_warm(target_dir: &Path, profile: &str) -> ExitCode {
         lockfile.as_deref(),
     ) {
         Ok((restored, skipped, errors)) => {
-            println!(
-                "zccache warm: restored {restored} files, skipped {skipped}, errors {errors}"
-            );
+            println!("zccache warm: restored {restored} files, skipped {skipped}, errors {errors}");
             if errors > 0 {
                 ExitCode::FAILURE
             } else {
@@ -1433,10 +1435,7 @@ fn cmd_cargo_registry_restore(key: &str, cargo_home: Option<&str>) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    println!(
-        "restored cargo registry from {}",
-        archive_path.display()
-    );
+    println!("restored cargo registry from {}", archive_path.display());
     ExitCode::SUCCESS
 }
 
@@ -2779,22 +2778,46 @@ mod tests {
 
         // Verify counts
         assert_eq!(errors, 0, "should have 0 errors");
-        assert_eq!(restored, 5, "should restore all 5 files (3 serde + 1 proc_macro2 + 1 C++ .o)");
+        assert_eq!(
+            restored, 5,
+            "should restore all 5 files (3 serde + 1 proc_macro2 + 1 C++ .o)"
+        );
         assert_eq!(skipped, 0, "all payloads exist on disk");
 
         // Verify files exist at correct paths
         let deps = target_dir.join("debug").join("deps");
-        assert!(deps.join("libserde-abc123.rlib").exists(), "serde rlib missing");
-        assert!(deps.join("libserde-abc123.rmeta").exists(), "serde rmeta missing");
-        assert!(deps.join("serde-abc123.d").exists(), "serde dep-info missing");
-        assert!(deps.join("libproc_macro2-def456.rlib").exists(), "proc_macro2 rlib missing");
+        assert!(
+            deps.join("libserde-abc123.rlib").exists(),
+            "serde rlib missing"
+        );
+        assert!(
+            deps.join("libserde-abc123.rmeta").exists(),
+            "serde rmeta missing"
+        );
+        assert!(
+            deps.join("serde-abc123.d").exists(),
+            "serde dep-info missing"
+        );
+        assert!(
+            deps.join("libproc_macro2-def456.rlib").exists(),
+            "proc_macro2 rlib missing"
+        );
 
         // Verify content is correct
-        assert_eq!(std::fs::read(deps.join("libserde-abc123.rlib")).unwrap(), b"rlib-content");
-        assert_eq!(std::fs::read(deps.join("libproc_macro2-def456.rlib")).unwrap(), b"proc-macro2-rlib");
+        assert_eq!(
+            std::fs::read(deps.join("libserde-abc123.rlib")).unwrap(),
+            b"rlib-content"
+        );
+        assert_eq!(
+            std::fs::read(deps.join("libproc_macro2-def456.rlib")).unwrap(),
+            b"proc-macro2-rlib"
+        );
 
         // Verify C++ artifact IS restored (warm restores everything, not just Rust)
-        assert!(deps.join("foo.o").exists(), "C++ .o file should also be in deps/");
+        assert!(
+            deps.join("foo.o").exists(),
+            "C++ .o file should also be in deps/"
+        );
         assert_eq!(std::fs::read(deps.join("foo.o")).unwrap(), b"object-file");
 
         // Verify mtime is recent (within 5 seconds)
@@ -2859,36 +2882,72 @@ mod tests {
 
         // serde (in a typical Cargo.lock)
         let k1 = "aaaa0001";
-        store.insert(k1, &zccache_artifact::ArtifactIndex::new(
-            vec!["libserde-abc123.rlib".into(), "libserde-abc123.rmeta".into(), "serde-abc123.d".into()],
-            vec![100, 50, 10], vec![], vec![], 0,
-        )).unwrap();
+        store
+            .insert(
+                k1,
+                &zccache_artifact::ArtifactIndex::new(
+                    vec![
+                        "libserde-abc123.rlib".into(),
+                        "libserde-abc123.rmeta".into(),
+                        "serde-abc123.d".into(),
+                    ],
+                    vec![100, 50, 10],
+                    vec![],
+                    vec![],
+                    0,
+                ),
+            )
+            .unwrap();
         std::fs::write(artifact_dir.join(format!("{k1}_0")), b"serde-rlib").unwrap();
         std::fs::write(artifact_dir.join(format!("{k1}_1")), b"serde-rmeta").unwrap();
         std::fs::write(artifact_dir.join(format!("{k1}_2")), b"serde-d").unwrap();
 
         // proc-macro2 (hyphen → underscore in filename)
         let k2 = "aaaa0002";
-        store.insert(k2, &zccache_artifact::ArtifactIndex::new(
-            vec!["libproc_macro2-def456.rlib".into()],
-            vec![200], vec![], vec![], 0,
-        )).unwrap();
+        store
+            .insert(
+                k2,
+                &zccache_artifact::ArtifactIndex::new(
+                    vec!["libproc_macro2-def456.rlib".into()],
+                    vec![200],
+                    vec![],
+                    vec![],
+                    0,
+                ),
+            )
+            .unwrap();
         std::fs::write(artifact_dir.join(format!("{k2}_0")), b"proc-macro2-rlib").unwrap();
 
         // tokio (NOT in our test lockfile)
         let k3 = "aaaa0003";
-        store.insert(k3, &zccache_artifact::ArtifactIndex::new(
-            vec!["libtokio-ghi789.rlib".into()],
-            vec![300], vec![], vec![], 0,
-        )).unwrap();
+        store
+            .insert(
+                k3,
+                &zccache_artifact::ArtifactIndex::new(
+                    vec!["libtokio-ghi789.rlib".into()],
+                    vec![300],
+                    vec![],
+                    vec![],
+                    0,
+                ),
+            )
+            .unwrap();
         std::fs::write(artifact_dir.join(format!("{k3}_0")), b"tokio-rlib").unwrap();
 
         // C++ object file (no crate name pattern)
         let k4 = "aaaa0004";
-        store.insert(k4, &zccache_artifact::ArtifactIndex::new(
-            vec!["foo.o".into()],
-            vec![50], vec![], vec![], 0,
-        )).unwrap();
+        store
+            .insert(
+                k4,
+                &zccache_artifact::ArtifactIndex::new(
+                    vec!["foo.o".into()],
+                    vec![50],
+                    vec![],
+                    vec![],
+                    0,
+                ),
+            )
+            .unwrap();
         std::fs::write(artifact_dir.join(format!("{k4}_0")), b"cpp-object").unwrap();
 
         drop(store);
@@ -2915,7 +2974,10 @@ mod tests {
         let lf = write_lockfile(dir.path(), &["serde", "proc-macro2", "unicode-ident"]);
         let crates = parse_lockfile_crates(&lf).unwrap();
         assert!(crates.contains("serde"));
-        assert!(crates.contains("proc_macro2"), "hyphens should be underscores");
+        assert!(
+            crates.contains("proc_macro2"),
+            "hyphens should be underscores"
+        );
         assert!(crates.contains("unicode_ident"));
         assert!(!crates.contains("tokio"), "tokio not in lockfile");
     }
@@ -2929,7 +2991,10 @@ mod tests {
         assert!(artifact_matches_lockfile("libserde-abc123.rlib", &allowed));
         assert!(artifact_matches_lockfile("libserde-abc123.rmeta", &allowed));
         assert!(artifact_matches_lockfile("serde-abc123.d", &allowed));
-        assert!(artifact_matches_lockfile("libproc_macro2-def456.rlib", &allowed));
+        assert!(artifact_matches_lockfile(
+            "libproc_macro2-def456.rlib",
+            &allowed
+        ));
         assert!(!artifact_matches_lockfile("libtokio-ghi789.rlib", &allowed));
         // No hash separator → allowed (could be build script output)
         assert!(artifact_matches_lockfile("build_script_build", &allowed));
@@ -2943,15 +3008,20 @@ mod tests {
         let (index_path, artifact_dir) = make_test_store(dir.path());
         let target_dir = dir.path().join("target");
 
-        let (restored, _, _) = warm_target(
-            &index_path, &artifact_dir, &target_dir, "debug", None,
-        ).unwrap();
+        let (restored, _, _) =
+            warm_target(&index_path, &artifact_dir, &target_dir, "debug", None).unwrap();
 
         let deps = target_dir.join("debug").join("deps");
         assert_eq!(restored, 6, "without lockfile: restore all 6 files");
         assert!(deps.join("libserde-abc123.rlib").exists());
-        assert!(deps.join("libtokio-ghi789.rlib").exists(), "tokio restored without filter");
-        assert!(deps.join("foo.o").exists(), "C++ file restored without filter");
+        assert!(
+            deps.join("libtokio-ghi789.rlib").exists(),
+            "tokio restored without filter"
+        );
+        assert!(
+            deps.join("foo.o").exists(),
+            "C++ file restored without filter"
+        );
     }
 
     #[test]
@@ -2962,16 +3032,27 @@ mod tests {
         let lockfile = write_lockfile(dir.path(), &["serde", "proc-macro2"]);
 
         let (restored, skipped, _) = warm_target(
-            &index_path, &artifact_dir, &target_dir, "debug", Some(&lockfile),
-        ).unwrap();
+            &index_path,
+            &artifact_dir,
+            &target_dir,
+            "debug",
+            Some(&lockfile),
+        )
+        .unwrap();
 
         let deps = target_dir.join("debug").join("deps");
         // serde (3) + proc-macro2 (1) + foo.o (1, no hash separator = allowed)
         assert_eq!(restored, 5);
         assert!(deps.join("libserde-abc123.rlib").exists());
         assert!(deps.join("libproc_macro2-def456.rlib").exists());
-        assert!(!deps.join("libtokio-ghi789.rlib").exists(), "tokio NOT in lockfile");
-        assert!(deps.join("foo.o").exists(), "no hash separator = allowed through");
+        assert!(
+            !deps.join("libtokio-ghi789.rlib").exists(),
+            "tokio NOT in lockfile"
+        );
+        assert!(
+            deps.join("foo.o").exists(),
+            "no hash separator = allowed through"
+        );
         assert!(skipped > 0, "tokio should be skipped");
     }
 
@@ -2989,13 +3070,20 @@ mod tests {
         let lockfile = write_lockfile(dir.path(), &["serde"]);
 
         let (restored, _, _) = warm_target(
-            &index_path, &artifact_dir, &target_dir, "debug", Some(&lockfile),
-        ).unwrap();
+            &index_path,
+            &artifact_dir,
+            &target_dir,
+            "debug",
+            Some(&lockfile),
+        )
+        .unwrap();
 
         let deps = target_dir.join("debug").join("deps");
         assert!(deps.join("libserde-abc123.rlib").exists());
-        assert!(!deps.join("libtokio-ghi789.rlib").exists(),
-            "removed crate must NOT be restored");
+        assert!(
+            !deps.join("libtokio-ghi789.rlib").exists(),
+            "removed crate must NOT be restored"
+        );
         // serde (3) + foo.o (1, no hash separator = allowed)
         assert_eq!(restored, 4);
     }
@@ -3017,12 +3105,19 @@ mod tests {
         // Now warm with lockfile that excludes tokio
         let lockfile = write_lockfile(dir.path(), &["serde"]);
         warm_target(
-            &index_path, &artifact_dir, &target_dir, "debug", Some(&lockfile),
-        ).unwrap();
+            &index_path,
+            &artifact_dir,
+            &target_dir,
+            "debug",
+            Some(&lockfile),
+        )
+        .unwrap();
 
         // Stale file still there (warm doesn't delete)
-        assert!(deps.join("libtokio-ghi789.rlib").exists(),
-            "warm doesn't clean up stale files — cargo ignores them");
+        assert!(
+            deps.join("libtokio-ghi789.rlib").exists(),
+            "warm doesn't clean up stale files — cargo ignores them"
+        );
         // But it wasn't overwritten with fresh content
         assert_eq!(
             std::fs::read(deps.join("libtokio-ghi789.rlib")).unwrap(),
@@ -3046,18 +3141,34 @@ mod tests {
 
         // Old version's artifact (different hash suffix)
         let k_old = "bbbb0001";
-        store.insert(k_old, &zccache_artifact::ArtifactIndex::new(
-            vec!["libserde-old111.rlib".into()],
-            vec![100], vec![], vec![], 0,
-        )).unwrap();
+        store
+            .insert(
+                k_old,
+                &zccache_artifact::ArtifactIndex::new(
+                    vec!["libserde-old111.rlib".into()],
+                    vec![100],
+                    vec![],
+                    vec![],
+                    0,
+                ),
+            )
+            .unwrap();
         std::fs::write(artifact_dir.join(format!("{k_old}_0")), b"old-serde").unwrap();
 
         // New version's artifact (different hash suffix)
         let k_new = "bbbb0002";
-        store.insert(k_new, &zccache_artifact::ArtifactIndex::new(
-            vec!["libserde-new222.rlib".into()],
-            vec![100], vec![], vec![], 0,
-        )).unwrap();
+        store
+            .insert(
+                k_new,
+                &zccache_artifact::ArtifactIndex::new(
+                    vec!["libserde-new222.rlib".into()],
+                    vec![100],
+                    vec![],
+                    vec![],
+                    0,
+                ),
+            )
+            .unwrap();
         std::fs::write(artifact_dir.join(format!("{k_new}_0")), b"new-serde").unwrap();
 
         drop(store);
@@ -3066,8 +3177,13 @@ mod tests {
         let lockfile = write_lockfile(dir.path(), &["serde"]);
 
         let (restored, _, _) = warm_target(
-            &index_path, &artifact_dir, &target_dir, "debug", Some(&lockfile),
-        ).unwrap();
+            &index_path,
+            &artifact_dir,
+            &target_dir,
+            "debug",
+            Some(&lockfile),
+        )
+        .unwrap();
 
         let deps = target_dir.join("debug").join("deps");
         // Both old and new are restored — cargo will use the one matching
@@ -3092,26 +3208,35 @@ mod tests {
 
         let store = zccache_artifact::ArtifactStore::open(&index_path).unwrap();
         let key = "cccc0001";
-        store.insert(key, &zccache_artifact::ArtifactIndex::new(
-            vec!["libserde-abc123.rlib".into()],
-            vec![1000], // Claims 1000 bytes
-            vec![], vec![], 0,
-        )).unwrap();
+        store
+            .insert(
+                key,
+                &zccache_artifact::ArtifactIndex::new(
+                    vec!["libserde-abc123.rlib".into()],
+                    vec![1000], // Claims 1000 bytes
+                    vec![],
+                    vec![],
+                    0,
+                ),
+            )
+            .unwrap();
         // But payload is only 5 bytes (corrupted/truncated)
         std::fs::write(artifact_dir.join(format!("{key}_0")), b"short").unwrap();
         drop(store);
 
         let target_dir = dir.path().join("target");
-        let (restored, _, errors) = warm_target(
-            &index_path, &artifact_dir, &target_dir, "debug", None,
-        ).unwrap();
+        let (restored, _, errors) =
+            warm_target(&index_path, &artifact_dir, &target_dir, "debug", None).unwrap();
 
         // Warm restores it without error (it doesn't validate content)
         assert_eq!(restored, 1);
         assert_eq!(errors, 0);
         // Cargo will detect the corruption via its own hash check and rebuild
         let deps = target_dir.join("debug").join("deps");
-        assert_eq!(std::fs::read(deps.join("libserde-abc123.rlib")).unwrap(), b"short");
+        assert_eq!(
+            std::fs::read(deps.join("libserde-abc123.rlib")).unwrap(),
+            b"short"
+        );
     }
 
     #[test]
@@ -3123,8 +3248,13 @@ mod tests {
         let lockfile = write_lockfile(dir.path(), &[]);
 
         let (restored, skipped, _) = warm_target(
-            &index_path, &artifact_dir, &target_dir, "debug", Some(&lockfile),
-        ).unwrap();
+            &index_path,
+            &artifact_dir,
+            &target_dir,
+            "debug",
+            Some(&lockfile),
+        )
+        .unwrap();
 
         // foo.o has no hash separator → allowed through. Everything else skipped.
         assert_eq!(restored, 1, "only foo.o (no hash separator) passes");

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -23,7 +23,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 static GLOBAL_WIN: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use clap::{Parser, Subcommand};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::ExitCode;
 use zccache_cli::{
     client_download, run_ino_convert_cached, ArchiveFormat, DownloadParams, DownloadSource,
@@ -31,6 +31,9 @@ use zccache_cli::{
 };
 use zccache_core::NormalizedPath;
 use zccache_gha::{GhaCache, GhaError};
+
+#[cfg(test)]
+use std::path::PathBuf;
 
 /// zccache -- fast local compiler cache.
 #[derive(Debug, Parser)]

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -1295,27 +1295,29 @@ fn cmd_crashes(clear: bool) -> ExitCode {
 
 /// Resolve the cargo home directory from an explicit argument, the `CARGO_HOME`
 /// env var, or the default `~/.cargo`.
-fn resolve_cargo_home(explicit: Option<&str>) -> Result<PathBuf, String> {
+fn resolve_cargo_home(explicit: Option<&str>) -> Result<NormalizedPath, String> {
     if let Some(p) = explicit {
-        return Ok(PathBuf::from(p));
+        return Ok(NormalizedPath::from(p));
     }
     if let Ok(ch) = std::env::var("CARGO_HOME") {
         if !ch.is_empty() {
-            return Ok(PathBuf::from(ch));
+            return Ok(NormalizedPath::from(ch));
         }
     }
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .map_err(|_| "cannot determine home directory (set HOME or CARGO_HOME)".to_string())?;
-    Ok(PathBuf::from(home).join(".cargo"))
+    Ok(NormalizedPath::from(home).join(".cargo"))
 }
 
 /// Directory where cargo-registry archives are stored.
-fn cargo_registry_cache_dir() -> Result<PathBuf, String> {
+fn cargo_registry_cache_dir() -> Result<NormalizedPath, String> {
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .map_err(|_| "cannot determine home directory (set HOME)".to_string())?;
-    Ok(PathBuf::from(home).join(".zccache").join("cargo-registry"))
+    Ok(NormalizedPath::from(home)
+        .join(".zccache")
+        .join("cargo-registry"))
 }
 
 fn cmd_cargo_registry_save(key: &str, cargo_home: Option<&str>) -> ExitCode {
@@ -1344,7 +1346,7 @@ fn cmd_cargo_registry_save(key: &str, cargo_home: Option<&str>) -> ExitCode {
 
     // Collect paths to archive.
     let subdirs: &[&str] = &["registry/index", "registry/cache", "git/db"];
-    let mut paths: Vec<(PathBuf, String)> = Vec::new();
+    let mut paths: Vec<(NormalizedPath, String)> = Vec::new();
     for subdir in subdirs {
         let p = cargo_home.join(subdir);
         if p.exists() {

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -856,7 +856,7 @@ fn cmd_warm(target_dir: &Path, profile: &str) -> ExitCode {
         artifact_dir.as_ref(),
         target_dir,
         profile,
-        lockfile.as_deref().map(|p| p.as_ref()),
+        lockfile.as_deref(),
     ) {
         Ok((restored, skipped, errors)) => {
             println!(

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -1101,10 +1101,7 @@ async fn handle_connection(
                         });
                     }
                 }
-                (
-                    Response::RustArtifactList { artifacts },
-                    None,
-                )
+                (Response::RustArtifactList { artifacts }, None)
             }
         };
 
@@ -4979,9 +4976,8 @@ mod tests {
         write_cached_output(&out, &cache, content).unwrap();
 
         // Output must have recent mtime, NOT the 2001 mtime from the cache file.
-        let out_mtime = filetime::FileTime::from_last_modification_time(
-            &std::fs::metadata(&out).unwrap(),
-        );
+        let out_mtime =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&out).unwrap());
         let now = filetime::FileTime::now();
         let diff = now.unix_seconds() - out_mtime.unix_seconds();
 
@@ -5013,9 +5009,8 @@ mod tests {
         // Second delivery: same_file path should still refresh mtime
         write_cached_output(&out, &cache, content).unwrap();
 
-        let out_mtime = filetime::FileTime::from_last_modification_time(
-            &std::fs::metadata(&out).unwrap(),
-        );
+        let out_mtime =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&out).unwrap());
         let now = filetime::FileTime::now();
         let diff = now.unix_seconds() - out_mtime.unix_seconds();
 
@@ -5035,9 +5030,8 @@ mod tests {
         let content = b"data from memory";
         write_cached_output(&out, &cache, content).unwrap();
 
-        let out_mtime = filetime::FileTime::from_last_modification_time(
-            &std::fs::metadata(&out).unwrap(),
-        );
+        let out_mtime =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&out).unwrap());
         let now = filetime::FileTime::now();
         let diff = now.unix_seconds() - out_mtime.unix_seconds();
 

--- a/crates/zccache-download-client/src/artifact.rs
+++ b/crates/zccache-download-client/src/artifact.rs
@@ -1074,6 +1074,9 @@ mod tests {
             ready_rx
                 .recv_timeout(Duration::from_secs(1))
                 .expect("test http server failed to start");
+            wait_for_test_http_server(&addr, &config.path);
+            request_count.store(0, Ordering::Relaxed);
+            range_request_count.store(0, Ordering::Relaxed);
             Self {
                 url,
                 request_count,
@@ -1090,6 +1093,58 @@ mod tests {
         fn range_request_count(&self) -> usize {
             self.range_request_count.load(Ordering::Relaxed)
         }
+    }
+
+    fn wait_for_test_http_server(addr: &std::net::SocketAddr, path: &str) {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let request = format!("HEAD /{path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+        while Instant::now() < deadline {
+            match TcpStream::connect(addr) {
+                Ok(mut stream) => {
+                    if stream
+                        .set_read_timeout(Some(Duration::from_millis(100)))
+                        .is_err()
+                    {
+                        thread::sleep(Duration::from_millis(10));
+                        continue;
+                    }
+                    if stream
+                        .set_write_timeout(Some(Duration::from_millis(100)))
+                        .is_err()
+                    {
+                        thread::sleep(Duration::from_millis(10));
+                        continue;
+                    }
+                    if stream.write_all(request.as_bytes()).is_err() {
+                        thread::sleep(Duration::from_millis(10));
+                        continue;
+                    }
+                    let mut response = Vec::new();
+                    let mut buf = [0u8; 256];
+                    loop {
+                        match stream.read(&mut buf) {
+                            Ok(0) => break,
+                            Ok(n) => {
+                                response.extend_from_slice(&buf[..n]);
+                                if response.windows(4).any(|window| window == b"\r\n\r\n") {
+                                    return;
+                                }
+                            }
+                            Err(err)
+                                if err.kind() == io::ErrorKind::WouldBlock
+                                    || err.kind() == io::ErrorKind::TimedOut =>
+                            {
+                                break;
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                }
+                Err(_) => {}
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        panic!("test http server at {addr} did not respond in time");
     }
 
     impl Drop for TestHttpServer {

--- a/crates/zccache-download-client/src/artifact.rs
+++ b/crates/zccache-download-client/src/artifact.rs
@@ -1099,48 +1099,45 @@ mod tests {
         let deadline = Instant::now() + Duration::from_secs(1);
         let request = format!("HEAD /{path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
         while Instant::now() < deadline {
-            match TcpStream::connect(addr) {
-                Ok(mut stream) => {
-                    if stream
-                        .set_read_timeout(Some(Duration::from_millis(100)))
-                        .is_err()
-                    {
-                        thread::sleep(Duration::from_millis(10));
-                        continue;
-                    }
-                    if stream
-                        .set_write_timeout(Some(Duration::from_millis(100)))
-                        .is_err()
-                    {
-                        thread::sleep(Duration::from_millis(10));
-                        continue;
-                    }
-                    if stream.write_all(request.as_bytes()).is_err() {
-                        thread::sleep(Duration::from_millis(10));
-                        continue;
-                    }
-                    let mut response = Vec::new();
-                    let mut buf = [0u8; 256];
-                    loop {
-                        match stream.read(&mut buf) {
-                            Ok(0) => break,
-                            Ok(n) => {
-                                response.extend_from_slice(&buf[..n]);
-                                if response.windows(4).any(|window| window == b"\r\n\r\n") {
-                                    return;
-                                }
+            if let Ok(mut stream) = TcpStream::connect(addr) {
+                if stream
+                    .set_read_timeout(Some(Duration::from_millis(100)))
+                    .is_err()
+                {
+                    thread::sleep(Duration::from_millis(10));
+                    continue;
+                }
+                if stream
+                    .set_write_timeout(Some(Duration::from_millis(100)))
+                    .is_err()
+                {
+                    thread::sleep(Duration::from_millis(10));
+                    continue;
+                }
+                if stream.write_all(request.as_bytes()).is_err() {
+                    thread::sleep(Duration::from_millis(10));
+                    continue;
+                }
+                let mut response = Vec::new();
+                let mut buf = [0u8; 256];
+                loop {
+                    match stream.read(&mut buf) {
+                        Ok(0) => break,
+                        Ok(n) => {
+                            response.extend_from_slice(&buf[..n]);
+                            if response.windows(4).any(|window| window == b"\r\n\r\n") {
+                                return;
                             }
-                            Err(err)
-                                if err.kind() == io::ErrorKind::WouldBlock
-                                    || err.kind() == io::ErrorKind::TimedOut =>
-                            {
-                                break;
-                            }
-                            Err(_) => break,
                         }
+                        Err(err)
+                            if err.kind() == io::ErrorKind::WouldBlock
+                                || err.kind() == io::ErrorKind::TimedOut =>
+                        {
+                            break;
+                        }
+                        Err(_) => break,
                     }
                 }
-                Err(_) => {}
             }
             thread::sleep(Duration::from_millis(10));
         }

--- a/crates/zccache-download-client/src/artifact.rs
+++ b/crates/zccache-download-client/src/artifact.rs
@@ -1046,7 +1046,9 @@ mod tests {
             let range_request_count_clone = Arc::clone(&range_request_count);
             let shutdown_clone = Arc::clone(&shutdown);
             let config_for_thread = config.clone();
+            let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
             let thread = thread::spawn(move || {
+                ready_tx.send(()).unwrap();
                 while !shutdown_clone.load(Ordering::Relaxed) {
                     match listener.accept() {
                         Ok((stream, _)) => {
@@ -1069,6 +1071,9 @@ mod tests {
                     }
                 }
             });
+            ready_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("test http server failed to start");
             Self {
                 url,
                 request_count,

--- a/crates/zccache-download-client/src/artifact.rs
+++ b/crates/zccache-download-client/src/artifact.rs
@@ -1064,7 +1064,17 @@ mod tests {
                                 );
                             });
                         }
-                        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                        Err(err)
+                            if matches!(
+                                err.kind(),
+                                io::ErrorKind::WouldBlock
+                                    | io::ErrorKind::Interrupted
+                                    | io::ErrorKind::ConnectionAborted
+                                    | io::ErrorKind::ConnectionReset
+                            ) =>
+                        {
+                            // Windows can surface transient listener errors while the probe
+                            // connection is racing with the first real client request.
                             thread::sleep(Duration::from_millis(10));
                         }
                         Err(_) => break,

--- a/crates/zccache-download-daemon/src/main.rs
+++ b/crates/zccache-download-daemon/src/main.rs
@@ -41,10 +41,7 @@ fn print_status(args: &Args) {
     println!("zccache-download-daemon v{}", env!("CARGO_PKG_VERSION"));
     println!();
     println!("  endpoint:   {endpoint}");
-    println!(
-        "  lock file:  {}",
-        daemon_mgmt::lock_file_path().display()
-    );
+    println!("  lock file:  {}", daemon_mgmt::lock_file_path().display());
     match query_daemon_status(&endpoint) {
         Ok(status) => {
             println!("  status:     running");
@@ -59,9 +56,7 @@ fn print_status(args: &Args) {
 }
 
 /// Connect to a running daemon over IPC and query its status.
-fn query_daemon_status(
-    endpoint: &str,
-) -> Result<zccache_download::DownloadDaemonStatus, String> {
+fn query_daemon_status(endpoint: &str) -> Result<zccache_download::DownloadDaemonStatus, String> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -84,9 +79,7 @@ fn query_daemon_status(
 }
 
 fn run_server(args: Args) {
-    let endpoint = args
-        .endpoint
-        .unwrap_or_else(daemon_mgmt::default_endpoint);
+    let endpoint = args.endpoint.unwrap_or_else(daemon_mgmt::default_endpoint);
     let pid = std::process::id();
     if let Err(err) = daemon_mgmt::write_lock_file(pid) {
         tracing::warn!("failed to write download daemon lock file: {err}");

--- a/crates/zccache-gha/src/client.rs
+++ b/crates/zccache-gha/src/client.rs
@@ -64,10 +64,8 @@ impl GhaCache {
     /// Returns `Err(GhaError::NotAvailable)` when not running inside GitHub
     /// Actions (i.e., the required env vars are missing).
     pub fn from_env() -> Result<Self, GhaError> {
-        let base_url =
-            std::env::var("ACTIONS_CACHE_URL").map_err(|_| GhaError::NotAvailable)?;
-        let token =
-            std::env::var("ACTIONS_RUNTIME_TOKEN").map_err(|_| GhaError::NotAvailable)?;
+        let base_url = std::env::var("ACTIONS_CACHE_URL").map_err(|_| GhaError::NotAvailable)?;
+        let token = std::env::var("ACTIONS_RUNTIME_TOKEN").map_err(|_| GhaError::NotAvailable)?;
 
         let client = Client::builder()
             .user_agent("zccache")
@@ -83,8 +81,7 @@ impl GhaCache {
 
     /// Check whether GHA cache env vars are present.
     pub fn is_available() -> bool {
-        std::env::var("ACTIONS_CACHE_URL").is_ok()
-            && std::env::var("ACTIONS_RUNTIME_TOKEN").is_ok()
+        std::env::var("ACTIONS_CACHE_URL").is_ok() && std::env::var("ACTIONS_RUNTIME_TOKEN").is_ok()
     }
 
     fn api_url(&self, path: &str) -> String {
@@ -187,11 +184,7 @@ impl GhaCache {
     }
 
     /// Restore a blob from the GHA cache. Returns `None` if no entry was found.
-    pub async fn restore(
-        &self,
-        key: &str,
-        version: &str,
-    ) -> Result<Option<Vec<u8>>, GhaError> {
+    pub async fn restore(&self, key: &str, version: &str) -> Result<Option<Vec<u8>>, GhaError> {
         let url = self.api_url(&format!("cache?keys={key}&version={version}"));
         let resp = self
             .client
@@ -229,9 +222,45 @@ impl GhaCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        old_cache_url: Option<String>,
+        old_runtime_token: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn new() -> Self {
+            Self {
+                _lock: env_lock().lock().unwrap(),
+                old_cache_url: std::env::var("ACTIONS_CACHE_URL").ok(),
+                old_runtime_token: std::env::var("ACTIONS_RUNTIME_TOKEN").ok(),
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.old_cache_url {
+                Some(value) => std::env::set_var("ACTIONS_CACHE_URL", value),
+                None => std::env::remove_var("ACTIONS_CACHE_URL"),
+            }
+            match &self.old_runtime_token {
+                Some(value) => std::env::set_var("ACTIONS_RUNTIME_TOKEN", value),
+                None => std::env::remove_var("ACTIONS_RUNTIME_TOKEN"),
+            }
+        }
+    }
 
     #[test]
     fn is_available_returns_false_without_env_vars() {
+        let _guard = EnvGuard::new();
         // Clear env vars in case they happen to be set.
         std::env::remove_var("ACTIONS_CACHE_URL");
         std::env::remove_var("ACTIONS_RUNTIME_TOKEN");
@@ -255,6 +284,7 @@ mod tests {
 
     #[test]
     fn from_env_returns_not_available_without_env_vars() {
+        let _guard = EnvGuard::new();
         std::env::remove_var("ACTIONS_CACHE_URL");
         std::env::remove_var("ACTIONS_RUNTIME_TOKEN");
         let err = GhaCache::from_env().unwrap_err();
@@ -266,23 +296,22 @@ mod tests {
 
     #[test]
     fn from_env_returns_not_available_with_partial_env() {
+        let _guard = EnvGuard::new();
         // Only one of the two vars set.
         std::env::set_var("ACTIONS_CACHE_URL", "https://example.com");
         std::env::remove_var("ACTIONS_RUNTIME_TOKEN");
         let err = GhaCache::from_env().unwrap_err();
         assert!(matches!(err, GhaError::NotAvailable));
-        std::env::remove_var("ACTIONS_CACHE_URL");
     }
 
     #[test]
     fn from_env_succeeds_with_both_env_vars() {
+        let _guard = EnvGuard::new();
         std::env::set_var("ACTIONS_CACHE_URL", "https://example.com/cache/");
         std::env::set_var("ACTIONS_RUNTIME_TOKEN", "test-token");
         let cache = GhaCache::from_env().expect("should succeed with both vars set");
         // Verify trailing slash is stripped.
         assert_eq!(cache.base_url, "https://example.com/cache");
         assert_eq!(cache.token, "test-token");
-        std::env::remove_var("ACTIONS_CACHE_URL");
-        std::env::remove_var("ACTIONS_RUNTIME_TOKEN");
     }
 }

--- a/crates/zccache-protocol/src/messages.rs
+++ b/crates/zccache-protocol/src/messages.rs
@@ -220,9 +220,7 @@ pub enum Response {
     FingerprintAck,
     /// List of cached Rust artifacts.
     /// NOTE: Appended at end to preserve bincode variant indices.
-    RustArtifactList {
-        artifacts: Vec<RustArtifactInfo>,
-    },
+    RustArtifactList { artifacts: Vec<RustArtifactInfo> },
 }
 
 /// Daemon status information.
@@ -761,9 +759,7 @@ mod tests {
             ],
         });
         // Empty list
-        roundtrip(&Response::RustArtifactList {
-            artifacts: vec![],
-        });
+        roundtrip(&Response::RustArtifactList { artifacts: vec![] });
     }
 
     #[test]

--- a/dylints/ban_std_pathbuf/src/lib.rs
+++ b/dylints/ban_std_pathbuf/src/lib.rs
@@ -150,6 +150,62 @@ impl CurrentDirGuard {
 }
 
 #[cfg(test)]
+fn prepare_dylint_library() {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let status = std::process::Command::new("cargo")
+        .arg("build")
+        .current_dir(manifest_dir)
+        .status()
+        .expect("cargo build should start");
+    assert!(status.success(), "cargo build should succeed");
+
+    let toolchain = std::env::var("RUSTUP_TOOLCHAIN").expect("RUSTUP_TOOLCHAIN should be set");
+    let library_name = env!("CARGO_PKG_NAME").replace('-', "_");
+    let target_debug = manifest_dir.join("target").join("debug");
+    let expected = target_debug.join(format!(
+        "{}{}@{}{}",
+        std::env::consts::DLL_PREFIX,
+        library_name,
+        toolchain,
+        std::env::consts::DLL_SUFFIX
+    ));
+    if expected.exists() {
+        return;
+    }
+
+    let plain = target_debug.join(format!(
+        "{}{}{}",
+        std::env::consts::DLL_PREFIX,
+        library_name,
+        std::env::consts::DLL_SUFFIX
+    ));
+    if plain.exists() {
+        std::fs::copy(&plain, &expected).expect("toolchain-suffixed dylint library should be copied");
+        return;
+    }
+
+    let deps_dir = target_debug.join("deps");
+    for entry in std::fs::read_dir(&deps_dir).expect("deps dir should be readable") {
+        let path = entry.expect("deps entry should be readable").path();
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if name.starts_with(&format!("{}{}", std::env::consts::DLL_PREFIX, library_name))
+            && name.ends_with(std::env::consts::DLL_SUFFIX)
+        {
+            std::fs::copy(&path, &expected)
+                .expect("hashed dylint library should be copied to the expected filename");
+            return;
+        }
+    }
+
+    panic!(
+        "could not find a built dylint library to copy into {}",
+        expected.display()
+    );
+}
+
+#[cfg(test)]
 impl Drop for CurrentDirGuard {
     fn drop(&mut self) {
         std::env::set_current_dir(&self.0).expect("current dir should be restored");
@@ -159,5 +215,6 @@ impl Drop for CurrentDirGuard {
 #[test]
 fn ui() {
     let _guard = CurrentDirGuard::set(std::path::Path::new(env!("CARGO_MANIFEST_DIR")));
+    prepare_dylint_library();
     dylint_testing::ui_test(env!("CARGO_PKG_NAME"), "ui");
 }

--- a/dylints/ban_std_pathbuf/src/lib.rs
+++ b/dylints/ban_std_pathbuf/src/lib.rs
@@ -137,7 +137,59 @@ fn def_path_starts_with(
             .all(|(actual, expected)| *actual == Symbol::intern(expected))
 }
 
+#[cfg(test)]
+fn ensure_suffixed_library_exists() {
+    use std::path::PathBuf;
+
+    let toolchain = match std::env::var("RUSTUP_TOOLCHAIN") {
+        Ok(value) => value,
+        Err(_) => return,
+    };
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let target_debug = manifest_dir.join("target").join("debug");
+    let extension = if cfg!(target_os = "windows") {
+        "dll"
+    } else if cfg!(target_os = "macos") {
+        "dylib"
+    } else {
+        "so"
+    };
+    let stem = if cfg!(target_os = "windows") {
+        env!("CARGO_PKG_NAME").to_string()
+    } else {
+        format!("lib{}", env!("CARGO_PKG_NAME"))
+    };
+    let expected = target_debug.join(format!("{stem}@{toolchain}.{extension}"));
+    if expected.exists() {
+        return;
+    }
+
+    let direct = target_debug.join(format!("{stem}.{extension}"));
+    if direct.exists() {
+        let _ = std::fs::copy(&direct, &expected);
+        return;
+    }
+
+    for directory in [target_debug.join("deps"), target_debug.clone()] {
+        let Ok(entries) = std::fs::read_dir(directory) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            if name.starts_with(&stem) && name.ends_with(&format!(".{extension}")) {
+                let _ = std::fs::copy(&path, &expected);
+                return;
+            }
+        }
+    }
+}
+
 #[test]
 fn ui() {
+    ensure_suffixed_library_exists();
     dylint_testing::ui_test(env!("CARGO_PKG_NAME"), "ui");
 }

--- a/dylints/ban_std_pathbuf/src/lib.rs
+++ b/dylints/ban_std_pathbuf/src/lib.rs
@@ -180,7 +180,8 @@ fn prepare_dylint_library() {
         std::env::consts::DLL_SUFFIX
     ));
     if plain.exists() {
-        std::fs::copy(&plain, &expected).expect("toolchain-suffixed dylint library should be copied");
+        std::fs::copy(&plain, &expected)
+            .expect("toolchain-suffixed dylint library should be copied");
         return;
     }
 

--- a/dylints/ban_std_pathbuf/src/lib.rs
+++ b/dylints/ban_std_pathbuf/src/lib.rs
@@ -138,58 +138,26 @@ fn def_path_starts_with(
 }
 
 #[cfg(test)]
-fn ensure_suffixed_library_exists() {
-    use std::path::PathBuf;
+struct CurrentDirGuard(std::path::PathBuf);
 
-    let toolchain = match std::env::var("RUSTUP_TOOLCHAIN") {
-        Ok(value) => value,
-        Err(_) => return,
-    };
-
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let target_debug = manifest_dir.join("target").join("debug");
-    let extension = if cfg!(target_os = "windows") {
-        "dll"
-    } else if cfg!(target_os = "macos") {
-        "dylib"
-    } else {
-        "so"
-    };
-    let stem = if cfg!(target_os = "windows") {
-        env!("CARGO_PKG_NAME").to_string()
-    } else {
-        format!("lib{}", env!("CARGO_PKG_NAME"))
-    };
-    let expected = target_debug.join(format!("{stem}@{toolchain}.{extension}"));
-    if expected.exists() {
-        return;
+#[cfg(test)]
+impl CurrentDirGuard {
+    fn set(path: &std::path::Path) -> Self {
+        let previous = std::env::current_dir().expect("current dir should be readable");
+        std::env::set_current_dir(path).expect("current dir should switch to manifest dir");
+        Self(previous)
     }
+}
 
-    let direct = target_debug.join(format!("{stem}.{extension}"));
-    if direct.exists() {
-        let _ = std::fs::copy(&direct, &expected);
-        return;
-    }
-
-    for directory in [target_debug.join("deps"), target_debug.clone()] {
-        let Ok(entries) = std::fs::read_dir(directory) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
-                continue;
-            };
-            if name.starts_with(&stem) && name.ends_with(&format!(".{extension}")) {
-                let _ = std::fs::copy(&path, &expected);
-                return;
-            }
-        }
+#[cfg(test)]
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.0).expect("current dir should be restored");
     }
 }
 
 #[test]
 fn ui() {
-    ensure_suffixed_library_exists();
+    let _guard = CurrentDirGuard::set(std::path::Path::new(env!("CARGO_MANIFEST_DIR")));
     dylint_testing::ui_test(env!("CARGO_PKG_NAME"), "ui");
 }


### PR DESCRIPTION
## Summary
- add explicit restore fallback controls for compilation and target caches
- default target metadata fallback to exact-key-only restores to avoid stale PR merge-ref state
- document speed-first vs release-hardened cache configurations

## Testing
- git diff --check
- parse action.yml with PyYAML

Closes #22.