### PR TITLE
fix(cli): auto-recover on protocol mismatch (#27)

### DIFF
--- a/crates/zccache-cli/src/lib.rs
+++ b/crates/zccache-cli/src/lib.rs
@@ -382,20 +382,44 @@ async fn spawn_and_wait(endpoint: &str) -> Result<(), String> {
     Err("daemon started but not accepting connections after 10s".to_string())
 }
 
+/// Stop a stale daemon that is unreachable or version-incompatible.
+async fn stop_stale_daemon(endpoint: &str) {
+    if let Ok(mut conn) = connect_client(endpoint).await {
+        let _ = conn.send(&zccache_protocol::Request::Shutdown).await;
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+
+    if let Some(pid) = zccache_ipc::check_running_daemon() {
+        if zccache_ipc::force_kill_process(pid).is_ok() {
+            for _ in 0..50 {
+                if !zccache_ipc::is_process_alive(pid) {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        }
+        zccache_ipc::remove_lock_file();
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+}
+
 async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
     match check_daemon_version(endpoint).await {
         VersionCheck::Ok | VersionCheck::DaemonNewer => return Ok(()),
         VersionCheck::DaemonOlder { daemon_ver } => {
-            return Err(format!(
-                "daemon v{daemon_ver} is older than client v{}. Run `zccache stop` first.",
-                zccache_core::VERSION,
-            ));
+            tracing::info!(
+                daemon_ver,
+                client_ver = zccache_core::VERSION,
+                "daemon is older than client, auto-recovering"
+            );
+            stop_stale_daemon(endpoint).await;
+            return spawn_and_wait(endpoint).await;
         }
         VersionCheck::CommError => {
-            return Err(
-                "cannot communicate with daemon (possible protocol mismatch). Run `zccache stop` first."
-                    .to_string(),
-            );
+            tracing::info!("cannot communicate with daemon, auto-recovering");
+            stop_stale_daemon(endpoint).await;
+            return spawn_and_wait(endpoint).await;
         }
         VersionCheck::Unreachable => {}
     }
@@ -406,16 +430,17 @@ async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
             match check_daemon_version(endpoint).await {
                 VersionCheck::Ok | VersionCheck::DaemonNewer => return Ok(()),
                 VersionCheck::DaemonOlder { daemon_ver } => {
-                    return Err(format!(
-                        "daemon v{daemon_ver} is older than client v{}. Run `zccache stop` first.",
-                        zccache_core::VERSION,
-                    ));
+                    tracing::info!(
+                        daemon_ver,
+                        client_ver = zccache_core::VERSION,
+                        "daemon is older than client during startup, auto-recovering"
+                    );
+                    stop_stale_daemon(endpoint).await;
+                    return spawn_and_wait(endpoint).await;
                 }
                 VersionCheck::CommError => {
-                    return Err(
-                        "cannot communicate with daemon (possible protocol mismatch). Run `zccache stop` first."
-                            .to_string(),
-                    );
+                    stop_stale_daemon(endpoint).await;
+                    return spawn_and_wait(endpoint).await;
                 }
                 VersionCheck::Unreachable => continue,
             }

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -2393,6 +2393,36 @@ async fn spawn_and_wait(endpoint: &str) -> Result<(), String> {
 /// Handles concurrent calls gracefully: when multiple processes race to start
 /// the daemon, only one wins the bind. The losers detect this and connect to
 /// the winning daemon instead of failing.
+/// Stop a stale daemon that is unreachable or version-incompatible.
+///
+/// Attempts graceful shutdown via IPC first, then falls back to force-killing
+/// the process via the lock file PID. Waits for the endpoint to be released.
+async fn stop_stale_daemon(endpoint: &str) {
+    // Try graceful shutdown via IPC
+    if let Ok(mut conn) = connect(endpoint).await {
+        let _ = conn.send(&zccache_protocol::Request::Shutdown).await;
+        // Give it a moment to process the shutdown
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+
+    // Force-kill via lock file PID if the daemon is still alive
+    if let Some(pid) = zccache_ipc::check_running_daemon() {
+        tracing::debug!(pid, "force-killing stale daemon process");
+        if zccache_ipc::force_kill_process(pid).is_ok() {
+            for _ in 0..50 {
+                if !zccache_ipc::is_process_alive(pid) {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        }
+        zccache_ipc::remove_lock_file();
+    }
+
+    // Wait briefly for the endpoint (named pipe / socket) to be fully released
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+}
+
 async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
     // Fast path: connect + version check
     match check_daemon_version(endpoint).await {
@@ -2406,18 +2436,18 @@ async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
             return Ok(());
         }
         VersionCheck::DaemonOlder { daemon_ver } => {
-            return Err(format!(
-                "daemon v{daemon_ver} is older than client v{}. \
-                 Run `zccache stop` first.",
-                zccache_core::VERSION,
-            ));
+            tracing::info!(
+                daemon_ver,
+                client_ver = zccache_core::VERSION,
+                "daemon is older than client, auto-recovering"
+            );
+            stop_stale_daemon(endpoint).await;
+            return spawn_and_wait(endpoint).await;
         }
         VersionCheck::CommError => {
-            return Err(
-                "cannot communicate with daemon (possible protocol mismatch). \
-                 Run `zccache stop` first."
-                    .to_string(),
-            );
+            tracing::info!("cannot communicate with daemon, auto-recovering");
+            stop_stale_daemon(endpoint).await;
+            return spawn_and_wait(endpoint).await;
         }
         VersionCheck::Unreachable => {
             // Fall through to lock-file check / spawn
@@ -2439,18 +2469,20 @@ async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
                     return Ok(());
                 }
                 VersionCheck::DaemonOlder { daemon_ver } => {
-                    return Err(format!(
-                        "daemon v{daemon_ver} is older than client v{}. \
-                         Run `zccache stop` first.",
-                        zccache_core::VERSION,
-                    ));
+                    tracing::info!(
+                        daemon_ver,
+                        client_ver = zccache_core::VERSION,
+                        "daemon is older than client during startup, auto-recovering"
+                    );
+                    stop_stale_daemon(endpoint).await;
+                    return spawn_and_wait(endpoint).await;
                 }
                 VersionCheck::CommError => {
-                    return Err(
-                        "cannot communicate with daemon (possible protocol mismatch). \
-                         Run `zccache stop` first."
-                            .to_string(),
+                    tracing::info!(
+                        "cannot communicate with daemon during startup, auto-recovering"
                     );
+                    stop_stale_daemon(endpoint).await;
+                    return spawn_and_wait(endpoint).await;
                 }
                 VersionCheck::Unreachable => continue,
             }

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -3265,4 +3265,51 @@ mod tests {
         assert_eq!(restored, 1, "only foo.o (no hash separator) passes");
         assert!(skipped > 0);
     }
+
+    // ── Protocol mismatch recovery (issue #27) ──────────────────
+
+    /// Regression test for <https://github.com/zackees/zccache/issues/27>.
+    ///
+    /// When a stale daemon is running but can't communicate (protocol mismatch
+    /// or corrupt pipe), `ensure_daemon` should auto-recover instead of telling
+    /// the user to manually run `zccache stop`.
+    ///
+    /// This test creates a fake "stale daemon" — an IPC listener that accepts
+    /// connections and immediately drops them, causing `check_daemon_version`
+    /// to return `CommError`. We then verify that `ensure_daemon` does NOT
+    /// return the "Run `zccache stop` first" error.
+    #[tokio::test]
+    #[ignore] // Integration test — needs daemon binary. Run with `test --full`.
+    async fn ensure_daemon_auto_recovers_on_comm_error() {
+        let endpoint = zccache_ipc::unique_test_endpoint();
+
+        // Spawn a fake stale daemon: accepts one connection, drops it (CommError),
+        // then shuts down so the endpoint is released for the real daemon.
+        let ep = endpoint.clone();
+        let mut listener = zccache_ipc::IpcListener::bind(&ep).unwrap();
+        let server = tokio::spawn(async move {
+            // Accept the connection from check_daemon_version, drop it immediately
+            let _ = listener.accept().await;
+            // Listener drops here, releasing the endpoint
+        });
+
+        // Give the listener time to be ready
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let result = ensure_daemon(&endpoint).await;
+
+        // Ensure server task has completed
+        let _ = server.await;
+
+        // The OLD behavior (bug): returns Err("...Run `zccache stop` first.")
+        // The NEW behavior (fix): auto-recovers — either succeeds or fails
+        // for a different reason (e.g., daemon binary not found).
+        if let Err(msg) = &result {
+            assert!(
+                !msg.contains("zccache stop"),
+                "Bug #27: ensure_daemon requires manual `zccache stop` instead of \
+                 auto-recovering on protocol mismatch: {msg}"
+            );
+        }
+    }
 }

--- a/crates/zccache-fingerprint/pyproject.toml
+++ b/crates/zccache-fingerprint/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "zccache-fingerprint"
-version = "1.2.8"
+version = "1.2.9"
 description = "Fast file fingerprinting backed by blake3"
 requires-python = ">=3.10"
 license = "MIT OR Apache-2.0"

--- a/crates/zccache-watcher/pyproject.toml
+++ b/crates/zccache-watcher/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "zccache-watcher"
-version = "1.2.8"
+version = "1.2.9"
 description = "Cross-platform filesystem watcher backed by zccache"
 requires-python = ">=3.10"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zccache"
-version = "1.2.8"
+version = "1.2.9"
 description = "A high-performance local compiler cache daemon"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- Adds failing test (RED) for issue #27: `ensure_daemon` should auto-recover when a stale daemon causes `CommError` instead of requiring manual `zccache stop`
- Fix will follow in subsequent commit

## Test plan
- [x] RED test confirms the bug: `ensure_daemon_auto_recovers_on_comm_error` fails with the expected "Run `zccache stop` first" error
- [ ] Implement auto-recovery in `ensure_daemon`
- [ ] GREEN: test passes after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)