### PR TITLE
Route Rust toolchain trampolines through soldr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ zccache is a local-first compiler cache daemon (11 crates). See @docs/CLAUDE.md 
 
 ## Essential Rules
 
-- **Always use the project-root trampolines** (`_cargo`, `_rustc`, `_rustfmt`) to execute Rust commands. Bare cargo/rustc and `uv run cargo` are blocked by hook. Trampolines prepend the shared rustup proxy location so the pinned toolchain is always used. Usage: `./_cargo check --workspace`.
+- **Always use the project-root trampolines** (`_cargo`, `_rustc`, `_rustfmt`) or `soldr <tool>` directly to execute Rust commands. Bare cargo/rustc and `uv run cargo` are blocked by hook. Both forms dispatch through [soldr](https://github.com/zackees/soldr), which resolves each tool via `rustup which` so the rustup-managed toolchain is always used; the cargo path passes `--no-cache` so the previous bare-cargo semantics are preserved. Usage: `./_cargo check --workspace` or `soldr cargo check --workspace`.
 - **Always use `uv` for Python.** Bare `python`/`pip` are blocked by hook. Use `uv run ...` or `uv pip ...`.
 - MSRV: 1.75 | Edition: 2021 | Toolchain: stable (clippy + rustfmt)
 - CI: Linux, macOS, Windows. All warnings denied (`RUSTFLAGS="-D warnings"`)

--- a/CODEX.md
+++ b/CODEX.md
@@ -3,9 +3,9 @@ Read [CLAUDE.md](./CLAUDE.md) first. The following conventions are mandatory in 
 ## Rust commands
 
 - Do not run bare `cargo`, `rustc`, or `rustfmt`.
-- Always use the project-root trampolines: `./_cargo`, `./_rustc`, `./_rustfmt`.
-- In this Windows environment, the repo is using the rustup-managed `x86_64-pc-windows-msvc` toolchain pinned by `rust-toolchain.toml`. Do not assume GNU or try to find `gcc`.
-- The trampolines set up the correct rustup environment and are the contract enforced by repo hooks.
+- Always use the project-root trampolines (`./_cargo`, `./_rustc`, `./_rustfmt`) or `soldr <tool>` directly. Both forms resolve through [soldr](https://github.com/zackees/soldr), which calls `rustup which` to pick the rustup-managed toolchain.
+- In this Windows environment, the repo is using the rustup-managed `x86_64-pc-windows-msvc` toolchain pinned by `rust-toolchain.toml`. Do not assume GNU or try to find `gcc`. soldr also enforces MSVC on Windows by default.
+- The trampolines set up the correct rustup environment and are the contract enforced by repo hooks. The `./_cargo` path uses `soldr --no-cache cargo` so the previous bare-cargo semantics are preserved.
 
 Examples:
 

--- a/_cargo
+++ b/_cargo
@@ -1,22 +1,12 @@
 #!/bin/bash
-# Trampoline: prefer the repo-local rustup proxy when present.
+# Trampoline: runs cargo through soldr so the rustup-managed toolchain is
+# always used. --no-cache keeps soldr's RUSTC_WRAPPER / managed-zccache
+# path off so this trampoline has the same semantics as bare cargo.
+#
+# The repo-local .rustup / .cargo detection is preserved here so vendored
+# toolchain layouts (if present) still override the user-global location.
+# soldr's `rustup which` honors these env vars.
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-
-if [ -n "${CARGO_HOME:-}" ]; then
-  CARGO_BIN="$CARGO_HOME/bin"
-elif [ -d "$SCRIPT_DIR/.cargo/bin" ]; then
-  CARGO_BIN="$SCRIPT_DIR/.cargo/bin"
-elif [ -n "${HOME:-}" ] && [ -d "$HOME/.cargo/bin" ]; then
-  CARGO_BIN="$HOME/.cargo/bin"
-elif [ -n "${USERPROFILE:-}" ] && [ -d "$USERPROFILE/.cargo/bin" ]; then
-  CARGO_BIN="$USERPROFILE/.cargo/bin"
-else
-  CARGO_BIN=""
-fi
-
-if [ -n "$CARGO_BIN" ]; then
-  export PATH="$CARGO_BIN:$PATH"
-fi
 
 if [ -z "${RUSTUP_HOME:-}" ] && [ -d "$SCRIPT_DIR/.rustup" ]; then
   export RUSTUP_HOME="$SCRIPT_DIR/.rustup"
@@ -26,14 +16,4 @@ if [ -z "${CARGO_HOME:-}" ] && [ -d "$SCRIPT_DIR/.cargo" ]; then
   export CARGO_HOME="$SCRIPT_DIR/.cargo"
 fi
 
-if [ -n "$CARGO_BIN" ]; then
-  TOOL_PATH="$CARGO_BIN/cargo"
-  if [ -x "$TOOL_PATH.exe" ]; then
-    TOOL_PATH="$TOOL_PATH.exe"
-  fi
-  if [ -x "$TOOL_PATH" ]; then
-    exec "$TOOL_PATH" "$@"
-  fi
-fi
-
-exec cargo "$@"
+exec uv run soldr --no-cache cargo "$@"

--- a/_rustc
+++ b/_rustc
@@ -1,22 +1,10 @@
 #!/bin/bash
-# Trampoline: prefers the repo-local rustup proxy when present.
+# Trampoline: runs rustc through soldr so the rustup-managed toolchain is
+# always used. soldr resolves rustc via `rustup which`.
+#
+# Repo-local .rustup / .cargo detection is preserved here so vendored
+# toolchain layouts (if present) still override the user-global location.
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-
-if [ -n "${CARGO_HOME:-}" ]; then
-  CARGO_BIN="$CARGO_HOME/bin"
-elif [ -d "$SCRIPT_DIR/.cargo/bin" ]; then
-  CARGO_BIN="$SCRIPT_DIR/.cargo/bin"
-elif [ -n "${HOME:-}" ] && [ -d "$HOME/.cargo/bin" ]; then
-  CARGO_BIN="$HOME/.cargo/bin"
-elif [ -n "${USERPROFILE:-}" ] && [ -d "$USERPROFILE/.cargo/bin" ]; then
-  CARGO_BIN="$USERPROFILE/.cargo/bin"
-else
-  CARGO_BIN=""
-fi
-
-if [ -n "$CARGO_BIN" ]; then
-  export PATH="$CARGO_BIN:$PATH"
-fi
 
 if [ -z "${RUSTUP_HOME:-}" ] && [ -d "$SCRIPT_DIR/.rustup" ]; then
   export RUSTUP_HOME="$SCRIPT_DIR/.rustup"
@@ -26,14 +14,4 @@ if [ -z "${CARGO_HOME:-}" ] && [ -d "$SCRIPT_DIR/.cargo" ]; then
   export CARGO_HOME="$SCRIPT_DIR/.cargo"
 fi
 
-if [ -n "$CARGO_BIN" ]; then
-  TOOL_PATH="$CARGO_BIN/rustc"
-  if [ -x "$TOOL_PATH.exe" ]; then
-    TOOL_PATH="$TOOL_PATH.exe"
-  fi
-  if [ -x "$TOOL_PATH" ]; then
-    exec "$TOOL_PATH" "$@"
-  fi
-fi
-
-exec rustc "$@"
+exec uv run soldr rustc "$@"

--- a/_rustfmt
+++ b/_rustfmt
@@ -1,22 +1,10 @@
 #!/bin/bash
-# Trampoline: prefers the repo-local rustup proxy when present.
+# Trampoline: runs rustfmt through soldr so the rustup-managed toolchain
+# is always used. soldr resolves rustfmt via `rustup which`.
+#
+# Repo-local .rustup / .cargo detection is preserved here so vendored
+# toolchain layouts (if present) still override the user-global location.
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-
-if [ -n "${CARGO_HOME:-}" ]; then
-  CARGO_BIN="$CARGO_HOME/bin"
-elif [ -d "$SCRIPT_DIR/.cargo/bin" ]; then
-  CARGO_BIN="$SCRIPT_DIR/.cargo/bin"
-elif [ -n "${HOME:-}" ] && [ -d "$HOME/.cargo/bin" ]; then
-  CARGO_BIN="$HOME/.cargo/bin"
-elif [ -n "${USERPROFILE:-}" ] && [ -d "$USERPROFILE/.cargo/bin" ]; then
-  CARGO_BIN="$USERPROFILE/.cargo/bin"
-else
-  CARGO_BIN=""
-fi
-
-if [ -n "$CARGO_BIN" ]; then
-  export PATH="$CARGO_BIN:$PATH"
-fi
 
 if [ -z "${RUSTUP_HOME:-}" ] && [ -d "$SCRIPT_DIR/.rustup" ]; then
   export RUSTUP_HOME="$SCRIPT_DIR/.rustup"
@@ -26,14 +14,4 @@ if [ -z "${CARGO_HOME:-}" ] && [ -d "$SCRIPT_DIR/.cargo" ]; then
   export CARGO_HOME="$SCRIPT_DIR/.cargo"
 fi
 
-if [ -n "$CARGO_BIN" ]; then
-  TOOL_PATH="$CARGO_BIN/rustfmt"
-  if [ -x "$TOOL_PATH.exe" ]; then
-    TOOL_PATH="$TOOL_PATH.exe"
-  fi
-  if [ -x "$TOOL_PATH" ]; then
-    exec "$TOOL_PATH" "$@"
-  fi
-fi
-
-exec rustfmt "$@"
+exec uv run soldr rustfmt "$@"

--- a/ci/hooks/tool_guard.py
+++ b/ci/hooks/tool_guard.py
@@ -22,7 +22,7 @@ PYTHON_TOOLS = {"python", "python3", "pip", "pip3"}
 # Trampoline scripts at project root that normalize the toolchain PATH
 RUST_TRAMPOLINES = {"_cargo", "_rustc", "_rustfmt"}
 
-ALLOWED_PREFIXES = ("uv run ", "uv pip ")
+ALLOWED_PREFIXES = ("uv run ", "uv pip ", "soldr ")
 
 
 FORBIDDEN_SCRIPT_DIRS = re.compile(
@@ -98,14 +98,20 @@ def check_command(command):
                 trampoline = f"_{tool}" if f"_{tool}" in RUST_TRAMPOLINES else "_cargo"
                 return (
                     tool,
-                    f"Use `./{trampoline} ...` instead of `uv run {tool} ...`. "
-                    f"Trampolines ensure the correct rustup toolchain is on PATH.",
+                    f"Use `./{trampoline} ...` or `soldr {tool} ...` instead "
+                    f"of `uv run {tool} ...`. Both resolve the rustup-managed "
+                    f"toolchain; `uv run <rust-tool>` bypasses that.",
                 )
             # Other uv run commands are fine (uv run python, uv run --script, etc.)
             continue
 
         # Allow uv pip
         if seg.startswith("uv pip "):
+            continue
+
+        # Allow `soldr ...` — soldr resolves the rustup-managed toolchain
+        # the same way the _cargo / _rustc / _rustfmt trampolines do.
+        if seg.startswith("soldr "):
             continue
 
         # Block bare Rust tools

--- a/ci/trampoline.py
+++ b/ci/trampoline.py
@@ -1,64 +1,79 @@
 """Rust toolchain trampolines.
 
-Helper functions that activate the repo-local rustup toolchain before
-executing Rust tools. The primary PATH setup is also shared via `ci.env`.
-These trampolines are used by the remaining project scripts (`run_zccache`,
-`run_zccache_daemon`) which wrap `cargo run` invocations.
+Routes cargo/rustc/rustfmt/clippy-driver through soldr so the
+rustup-managed toolchain is always used, without this module having to
+resolve tool paths manually. `ci.env.activate()` is still called first so
+repo-local `.rustup` / `.cargo` layouts (vendored toolchains) win over
+the user-global location — soldr's `rustup which` honors those env vars.
+
+Why soldr:
+- soldr resolves each tool via `rustup which`, matching the existing
+  behavior this module used to implement by hand.
+- `soldr --no-cache cargo` preserves prior bare-cargo semantics (no
+  RUSTC_WRAPPER, no managed zccache inserted). Adopting soldr's built-in
+  zccache wrapper here would wrap zccache's own build in a
+  previous-version zccache — technically fine, but a deliberate
+  decision, not a side effect.
 """
 
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
-from ci.env import activate, ensure_windows_msvc, require_tool_path
+from ci.env import activate
 
 
-def _run_tool(tool_name):
-    """Prepend .cargo/bin to PATH and exec the given tool."""
-    activate()
-    try:
-        tool = require_tool_path(tool_name)
-        ensure_windows_msvc()
-    except (FileNotFoundError, RuntimeError) as exc:
-        print(f"error: {exc}", file=sys.stderr)
+def _soldr_prefix(no_cache: bool):
+    """Return the argv prefix that runs soldr, with `--no-cache` if asked."""
+    if not shutil.which("soldr"):
+        print(
+            "error: `soldr` not found on PATH. Run `uv sync` (or ./install) "
+            "to install the dev dependencies, which pulls soldr in.",
+            file=sys.stderr,
+        )
         sys.exit(1)
+    prefix = ["soldr"]
+    if no_cache:
+        prefix.append("--no-cache")
+    return prefix
 
-    result = subprocess.run([str(tool)] + sys.argv[1:], env=os.environ.copy())
+
+def _run_via_soldr(subcommand: str, *, no_cache: bool):
+    """Exec `soldr [--no-cache] <subcommand> <argv...>`."""
+    activate()
+    cmd = _soldr_prefix(no_cache) + [subcommand] + sys.argv[1:]
+    result = subprocess.run(cmd, env=os.environ.copy())
     sys.exit(result.returncode)
 
 
 def cargo():
-    _run_tool("cargo")
+    # --no-cache keeps soldr's RUSTC_WRAPPER / zccache path off, matching
+    # the previous bare-cargo behavior of this trampoline.
+    _run_via_soldr("cargo", no_cache=True)
 
 
 def rustc():
-    _run_tool("rustc")
+    _run_via_soldr("rustc", no_cache=False)
 
 
 def rustfmt():
-    _run_tool("rustfmt")
+    _run_via_soldr("rustfmt", no_cache=False)
 
 
 def clippy_driver():
-    _run_tool("clippy-driver")
+    _run_via_soldr("clippy-driver", no_cache=False)
 
 
 def _run_cargo_bin(package):
-    """Run a cargo binary with the correct toolchain on PATH."""
+    """Run a cargo binary with the correct toolchain via soldr."""
     activate()
-    try:
-        cargo = require_tool_path("cargo")
-        ensure_windows_msvc()
-    except (FileNotFoundError, RuntimeError) as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        sys.exit(1)
-
     extra = sys.argv[1:]
-    # Strip leading '--' that uv inserts
+    # Strip leading '--' that uv inserts.
     if extra and extra[0] == "--":
         extra = extra[1:]
-    cmd = [str(cargo), "run", "-p", package]
+    cmd = _soldr_prefix(no_cache=True) + ["cargo", "run", "-p", package]
     if extra:
         cmd.append("--")
         cmd.extend(extra)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,11 @@ name = "zccache"
 dynamic = ["version"]
 description = "A high-performance local compiler cache daemon"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = []
+
+[dependency-groups]
+dev = ["soldr>=0.7.0"]
 
 [project.scripts]
 run_zccache = "ci.trampoline:run_zccache"


### PR DESCRIPTION
## Summary

Replaces zccache's hand-rolled PATH-munging trampolines with calls to [soldr](https://github.com/zackees/soldr) v0.7.0. soldr resolves each toolchain binary via \`rustup which\`, so the rustup-managed toolchain is always used without per-call environment shaping. Parallel to the FastLED/fbuild migration. Closes #30.

Nice closing of the loop: soldr already fetches and invokes zccache as its managed \`RUSTC_WRAPPER\`. Having zccache itself build through soldr closes the circle.

## Changes

- **\`ci/trampoline.py\`**: \`cargo\` / \`rustc\` / \`rustfmt\` / \`clippy_driver\` exec \`soldr [--no-cache] <subcommand>\` instead of discovering \`cargo_bin\` and calling \`ensure_windows_msvc\` (soldr already enforces MSVC on Windows). \`cargo\` passes \`--no-cache\` so soldr's own RUSTC_WRAPPER / managed-zccache path is not inserted — prior bare-cargo semantics preserved. \`_run_cargo_bin\` (backing \`run_zccache\` / \`run_zccache_daemon\` / \`run_zccache_fingerprint\` / \`check_on_stop\`) also routes through soldr. \`ci.env.activate()\` is still called first so repo-local \`.rustup\` / \`.cargo\` layouts still win — soldr's \`rustup which\` honors those env vars.
- **\`_cargo\` / \`_rustc\` / \`_rustfmt\` bash shims**: preserve the repo-local \`RUSTUP_HOME\` / \`CARGO_HOME\` detection (vendored toolchain support) and then \`exec uv run soldr [--no-cache] <subcommand>\`. The hand-rolled cargo_bin probe is removed.
- **\`ci/hooks/tool_guard.py\`**: accepts \`soldr ...\` as a valid top-level invocation alongside \`./_cargo\` / \`./_rustc\` / \`./_rustfmt\`. \`uv run cargo\` remains blocked, but the message now points at either \`./_cargo\` or \`soldr cargo\`.
- **\`pyproject.toml\`**: pulls \`soldr>=0.7.0\` as a dev dependency and bumps \`requires-python\` from 3.9 → 3.10 (soldr wheels require 3.10+).
- **Docs**: \`CLAUDE.md\` and \`CODEX.md\` list \`soldr <tool>\` as an approved form.

## Verification

- [x] \`uv sync\` pulls \`soldr 0.7.0\` into the dev env
- [x] \`./_cargo check --workspace --all-targets\` — full 11-crate workspace passes in 1m08s
- [x] \`uv run soldr --version\` → \`soldr 0.7.0\`
- [x] \`./_rustc --version\` → \`rustc 1.94.1\` (correct rustup toolchain)
- [x] \`./_cargo --version\` → \`cargo 1.94.1\`
- [x] \`tool_guard.check_command\`:
  - blocks bare \`cargo build\` ✓
  - allows \`./_cargo build\` ✓
  - allows \`soldr cargo build\` ✓
  - allows \`soldr --no-cache cargo build\` ✓
  - allows \`soldr rustc --version\` ✓
  - still blocks \`uv run cargo build\` ✓ (with new error message pointing at \`./_cargo\` or \`soldr cargo\`)

## Risk / rollback

Minimal — soldr's \`rustup which\` resolver mirrors what the hand-rolled trampolines already did. Revert is a one-commit rollback.

Closes #30