### PR TITLE
chore(deps): update Cargo.lock for 1.2.12 version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "bincode",
  "redb",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "md5",
  "serde_json",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "blake3",
  "clap",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "clang",
  "tempfile",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "serde",
  "tempfile",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "bincode",
  "clap",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "blake3",
  "dashmap",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "blake3",
  "bytes",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "clap",
  "serde",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "clap",
  "dashmap",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "bincode",
  "bytes",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "clap",
  "criterion",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3674,7 +3674,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "reqwest",
  "serde",
@@ -3687,7 +3687,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "blake3",
  "criterion",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "bytes",
  "serde",
@@ -3712,7 +3712,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "bincode",
  "bytes",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.2.11"
+version = "1.2.12"
 dependencies = [
  "globset",
  "jwalk",


### PR DESCRIPTION
Internal crate references in Cargo.lock still pointed at 1.2.11 after the workspace.version bump landed in the 1.2.12 publish. Regenerated the lockfile to sync — no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)