### PR TITLE
fix(publish): S_IFREG + create_system=3 on wheel scripts (1.2.13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "bincode",
  "redb",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "md5",
  "serde_json",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "blake3",
  "clap",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "clang",
  "tempfile",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "serde",
  "tempfile",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "bincode",
  "clap",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "blake3",
  "dashmap",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "blake3",
  "bytes",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "clap",
  "serde",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "clap",
  "dashmap",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "bincode",
  "bytes",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "clap",
  "criterion",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3674,7 +3674,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "reqwest",
  "serde",
@@ -3687,7 +3687,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "blake3",
  "criterion",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "bytes",
  "serde",
@@ -3712,7 +3712,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "bincode",
  "bytes",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.2.12"
+version = "1.2.13"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["dylints/ban_std_pathbuf"]
 
 [workspace.package]
-version = "1.2.12"
+version = "1.2.13"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT OR Apache-2.0"
@@ -66,24 +66,24 @@ sevenz-rust = "0.6"
 rkyv = { version = "0.7", features = ["validation"] }
 tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
 mimalloc = "0.1"
-zccache-core = { version = "=1.2.12", path = "crates/zccache-core" }
-zccache-hash = { version = "=1.2.12", path = "crates/zccache-hash" }
-zccache-protocol = { version = "=1.2.12", path = "crates/zccache-protocol" }
-zccache-download-protocol = { version = "=1.2.12", path = "crates/zccache-download-protocol" }
-zccache-download = { version = "=1.2.12", path = "crates/zccache-download" }
-zccache-download-client = { version = "=1.2.12", path = "crates/zccache-download-client" }
-zccache-download-daemon = { version = "=1.2.12", path = "crates/zccache-download-daemon" }
-zccache-fscache = { version = "=1.2.12", path = "crates/zccache-fscache" }
-zccache-artifact = { version = "=1.2.12", path = "crates/zccache-artifact" }
-zccache-depgraph = { version = "=1.2.12", path = "crates/zccache-depgraph" }
-zccache-watcher = { version = "=1.2.12", path = "crates/zccache-watcher" }
-zccache-compiler = { version = "=1.2.12", path = "crates/zccache-compiler" }
-zccache-ipc = { version = "=1.2.12", path = "crates/zccache-ipc" }
-zccache-daemon = { version = "=1.2.12", path = "crates/zccache-daemon" }
-zccache-cli = { version = "=1.2.12", path = "crates/zccache-cli" }
-zccache-test-support = { version = "=1.2.12", path = "crates/zccache-test-support" }
-zccache-fingerprint = { version = "=1.2.12", path = "crates/zccache-fingerprint" }
-zccache-gha = { version = "=1.2.12", path = "crates/zccache-gha" }
+zccache-core = { version = "=1.2.13", path = "crates/zccache-core" }
+zccache-hash = { version = "=1.2.13", path = "crates/zccache-hash" }
+zccache-protocol = { version = "=1.2.13", path = "crates/zccache-protocol" }
+zccache-download-protocol = { version = "=1.2.13", path = "crates/zccache-download-protocol" }
+zccache-download = { version = "=1.2.13", path = "crates/zccache-download" }
+zccache-download-client = { version = "=1.2.13", path = "crates/zccache-download-client" }
+zccache-download-daemon = { version = "=1.2.13", path = "crates/zccache-download-daemon" }
+zccache-fscache = { version = "=1.2.13", path = "crates/zccache-fscache" }
+zccache-artifact = { version = "=1.2.13", path = "crates/zccache-artifact" }
+zccache-depgraph = { version = "=1.2.13", path = "crates/zccache-depgraph" }
+zccache-watcher = { version = "=1.2.13", path = "crates/zccache-watcher" }
+zccache-compiler = { version = "=1.2.13", path = "crates/zccache-compiler" }
+zccache-ipc = { version = "=1.2.13", path = "crates/zccache-ipc" }
+zccache-daemon = { version = "=1.2.13", path = "crates/zccache-daemon" }
+zccache-cli = { version = "=1.2.13", path = "crates/zccache-cli" }
+zccache-test-support = { version = "=1.2.13", path = "crates/zccache-test-support" }
+zccache-fingerprint = { version = "=1.2.13", path = "crates/zccache-fingerprint" }
+zccache-gha = { version = "=1.2.13", path = "crates/zccache-gha" }
 
 # Vendored notify with fixes for Windows ReadDirectoryChangesW:
 # 1. Detect buffer overflow (bytes_written == 0) and report as error

--- a/ci/publish.py
+++ b/ci/publish.py
@@ -851,7 +851,20 @@ def build_wheel(
     for pt in plat_tags:
         wheel_meta += f"Tag: py3-none-{pt}\n"
 
-    exec_perms = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
+    # Both bits are required for pip/installer to chmod +x on Linux/macOS:
+    #   - create_system=3 tells the unpacker to interpret external_attr as
+    #     Unix mode bits (default is 0 = DOS attributes, ignored as perms).
+    #   - S_IFREG is the file-type bit; pip's installer calls stat.S_ISREG()
+    #     on the upper 16 bits and falls back to umask defaults (0o644) if
+    #     it's missing, even when mode bits are set to 0o755.
+    # Reference: uv/ruff/maturin wheels all ship external_attr=0x81ed0000.
+    # See zackees/self#25 for the ecosystem-wide audit.
+    exec_perms = (
+        stat.S_IFREG
+        | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
+        | stat.S_IRGRP | stat.S_IXGRP
+        | stat.S_IROTH | stat.S_IXOTH
+    )
 
     WHEEL_DIR.mkdir(parents=True, exist_ok=True)
     wheel_path = WHEEL_DIR / wheel_filename
@@ -862,6 +875,7 @@ def build_wheel(
             data = binary.read_bytes()
             arcname = f"{data_dir}/scripts/{binary.name}"
             info = zipfile.ZipInfo(arcname)
+            info.create_system = 3
             info.external_attr = exec_perms << 16
             info.compress_type = zipfile.ZIP_DEFLATED
             whl.writestr(info, data)


### PR DESCRIPTION
## Summary

Every zccache Linux/macOS wheel shipped to PyPI has had the bundled `zccache` binary install without execute permissions:

```
/usr/local/bin/zccache: Permission denied (exit 126)
```

Two bits both need to be set for pip's wheel installer to apply the script's mode bits; both were missing in `ci/publish.py`:

1. **`info.create_system = 3`** (Unix). The default is 0 (DOS), under which pip interprets `external_attr` as DOS file attributes rather than Unix mode, so the perm bits are ignored entirely.
2. **`stat.S_IFREG`** (regular-file type bit, `0o100000`) OR-ed into the mode. pip calls `stat.S_ISREG()` on the upper 16 bits of `external_attr` before applying the mode; without IFREG the test returns False and pip falls back to umask defaults (`0o644`) even when `0o755` is set.

With both corrected, script entries now ship `external_attr=0x81ed0000` — byte-identical to `uv` / `ruff` / `maturin`-built wheels.

## Context

Surfaced during the FastLED/fbuild 2.1.20 postmortem ([FastLED/fbuild#143](https://github.com/FastLED/fbuild/pull/143)). fbuild had the same S_IFREG bug but did set `create_system=3`. zccache is missing **both**, which means its wheels have been broken on non-Windows essentially since the publish script was written.

Ecosystem-wide audit tracking issue: [zackees/self#25](https://github.com/zackees/self/issues/25).

## Also included: version bump to 1.2.13

1.2.12's PyPI filenames are permanently burned — PyPI doesn't allow re-uploading, so shipping the fix requires a fresh version. `Cargo.toml` workspace version + all 18 `=1.2.12` intra-workspace pins + `Cargo.lock` bumped.

## Verification

Rebuild any wheel locally from `dist/` and check:

```python
import zipfile, stat
with zipfile.ZipFile('dist/wheels/zccache-1.2.13-py3-none-manylinux_2_17_x86_64.whl') as z:
    for i in z.infolist():
        if '.data/scripts/' in i.filename:
            m = i.external_attr >> 16
            ok = i.create_system == 3 and stat.S_ISREG(m) and m & 0o100
            print(f'{i.filename}: external_attr=0x{i.external_attr:08x}  ok={ok}')
```

Expected (post-fix): `external_attr=0x81ed0000  ok=True`.
Previously: `external_attr=0x01ed0000  ok=False` (and `create_system=0`, so the `S_ISREG` test wasn't even the first failure — the `create_system` guard fails first).

## Test plan

- [x] `cargo check --workspace` clean after version bumps
- [x] `uv lock` clean
- [ ] `./publish` cuts 1.2.13 and Step 6 (or equivalent post-upload check) passes
- [ ] `pip install zccache==1.2.13 && zccache --help` on Linux returns exit 0

## Follow-ups for the wider audit

Per [zackees/self#25](https://github.com/zackees/self/issues/25):

- [ ] Add a post-build assertion to `ci/publish.py` that rejects any wheel whose `.data/scripts/*` entries don't have `create_system=3` and `S_ISREG(mode) and mode & 0o100`. Turns this bug class into a build-time failure.
- [ ] Consider landing a canonical `publish.py` in `zackees/python-rust-build-chain` so future Rust+Python repos copy a known-good pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)