### PR TITLE
fix(action): include shared-key in registry/target cache keys (#38)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,14 +82,22 @@ runs:
       id: keys
       shell: bash
       run: |
-        # Build a composite key from OS, arch, shared-key, and cargo lock hash
+        # Build a composite key from OS, arch, shared-key, and cargo lock hash.
+        # `shared-key` is folded into every key so matrix builds disambiguate
+        # per-target. Without it, jobs sharing runner.os/runner.arch (e.g.
+        # x86_64-unknown-linux-musl + aarch64-unknown-linux-musl both on
+        # ubuntu-latest → runner.arch=X64) collide on `Unable to reserve cache`.
         OS="${{ runner.os }}"
         ARCH="${{ runner.arch }}"
         SHARED="${{ inputs.shared-key }}"
         if [ -n "$SHARED" ]; then
           PREFIX="zccache-${OS}-${ARCH}-${SHARED}"
+          REG_PREFIX="cargo-registry-${OS}-${ARCH}-${SHARED}"
+          TGT_PREFIX="cargo-target-${OS}-${ARCH}-${SHARED}"
         else
           PREFIX="zccache-${OS}-${ARCH}"
+          REG_PREFIX="cargo-registry-${OS}-${ARCH}"
+          TGT_PREFIX="cargo-target-${OS}-${ARCH}"
         fi
 
         # Hash Cargo.lock for registry cache key (falls back if no lock file)
@@ -110,11 +118,11 @@ runs:
         else
           echo "compilation-restore=" >> "$GITHUB_OUTPUT"
         fi
-        echo "registry-key=cargo-registry-${OS}-${ARCH}-${LOCK_HASH}" >> "$GITHUB_OUTPUT"
-        echo "registry-restore=cargo-registry-${OS}-${ARCH}-" >> "$GITHUB_OUTPUT"
-        echo "target-key=cargo-target-${OS}-${ARCH}-${LOCK_HASH}-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+        echo "registry-key=${REG_PREFIX}-${LOCK_HASH}" >> "$GITHUB_OUTPUT"
+        echo "registry-restore=${REG_PREFIX}-" >> "$GITHUB_OUTPUT"
+        echo "target-key=${TGT_PREFIX}-${LOCK_HASH}-${{ github.sha }}" >> "$GITHUB_OUTPUT"
         if [ "${{ inputs.target-restore-fallback }}" = "true" ]; then
-          echo "target-restore=cargo-target-${OS}-${ARCH}-${LOCK_HASH}-" >> "$GITHUB_OUTPUT"
+          echo "target-restore=${TGT_PREFIX}-${LOCK_HASH}-" >> "$GITHUB_OUTPUT"
         else
           echo "target-restore=" >> "$GITHUB_OUTPUT"
         fi

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -5271,7 +5271,10 @@ mod tests {
             .unwrap();
 
         let env = vec![
-            ("PATH".to_string(), std::env::var("PATH").unwrap_or_default()),
+            (
+                "PATH".to_string(),
+                std::env::var("PATH").unwrap_or_default(),
+            ),
             ("ZCCACHE_TEST_MARKER".to_string(), "hello-hook".to_string()),
         ];
         run_post_link_deploy_hook(&script.to_string_lossy(), &output, Some(&env)).await;


### PR DESCRIPTION
## Summary

Fixes #38. Registry and target cache keys now include the `shared-key` segment, matching what the zccache compilation key already does. Without this, matrix builds collide on the registry/target keys whenever they share `runner.os` / `runner.arch`, surfacing as `Cache save failed` annotations.

## Root cause

`action.yml:113-117` (before this PR):

\`\`\`yaml
echo \"registry-key=cargo-registry-\${OS}-\${ARCH}-\${LOCK_HASH}\" >> \"\$GITHUB_OUTPUT\"
echo \"registry-restore=cargo-registry-\${OS}-\${ARCH}-\" >> \"\$GITHUB_OUTPUT\"
echo \"target-key=cargo-target-\${OS}-\${ARCH}-\${LOCK_HASH}-\${{ github.sha }}\" >> \"\$GITHUB_OUTPUT\"
\`\`\`

`\${SHARED}` was already computed for the compilation `PREFIX` but never used in the registry / target keys. Hoisting `REG_PREFIX` and `TGT_PREFIX` next to it folds the segment in.

## Concrete repro

[FastLED/fbuild run 24624186789](https://github.com/FastLED/fbuild/actions/runs/24624186789) — 4-job matrix (4 distinct targets, 3 distinct runners) emitted 8 `Cache save failed` annotations across the run:

\`\`\`
Failed to save: Unable to reserve cache with key cargo-registry-Linux-X64-ee6e6bffb3d63fe6,
another job may be creating this cache.
Failed to save: Unable to reserve cache with key cargo-target-Linux-X64-ee6e6bffb3d63fe6-...,
another job may be creating this cache.
\`\`\`

Both Linux jobs (musl x86_64 + cross musl aarch64) ran on `ubuntu-latest` so `runner.arch=X64` for both → identical target/registry keys despite distinct `shared-key` values.

## After this PR

Per-target `shared-key` values disambiguate the cache keys, so each matrix job reserves its own slot and saves successfully. Behavior with `shared-key` unset is unchanged (falls back to OS/arch only, matching pre-PR behavior).

## Test plan

- [x] Diff is minimal — only the key composition changed; restore logic and cache layers untouched
- [ ] Bump zccache version and re-run FastLED/fbuild's `Build Native Binaries` to confirm the warnings disappear
- [ ] Existing `test-action.yml` matrix continues to pass (no changes expected since it doesn't share runner.arch across distinct shared-keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)