### PR TITLE
ci(release): trigger on plain semver tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release Standalone Binaries
 on:
   push:
     tags:
+      - "[0-9]*"
       - "v*"
 
 permissions:


### PR DESCRIPTION
## Summary
- allow the release workflow to run on plain semver tags like \1.2.15\
- keep existing \*\ support intact
- align workflow triggering with the existing GitHub release/tag naming that soldr consumes

## Verification
- git diff --check
- parsed .github/workflows/release.yml with PyYAML
