### PR TITLE
ci: automate full release workflow

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -40,6 +40,9 @@ outputs:
   standalone_dir:
     description: Directory containing packaged standalone archives.
     value: ${{ steps.paths.outputs.standalone_dir }}
+  standalone_archive:
+    description: Path to the packaged standalone archive file.
+    value: ${{ steps.package.outputs.archive }}
 
 runs:
   using: composite
@@ -175,15 +178,17 @@ runs:
         fi
 
     - name: Package standalone archive
+      id: package
       shell: bash
       run: |
         VERSION="${{ inputs.version }}"
         if [ -z "$VERSION" ]; then
           VERSION=$(python -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('Cargo.toml').read_text(encoding='utf-8'))['workspace']['package']['version'])")
         fi
-        python ci/package_release.py \
+        ARCHIVE=$(python ci/package_release.py \
           --version "$VERSION" \
           --target "${{ inputs.target }}" \
           --binary-ext "${{ inputs.binary_ext }}" \
           --input-dir staging \
-          --output-dir standalone
+          --output-dir standalone)
+        echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,5 +95,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: release-${{ matrix.target }}
-          path: ${{ steps.build_target.outputs.standalone_dir }}/
+          path: ${{ steps.build_target.outputs.standalone_archive }}
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,16 @@
-name: Release Standalone Binaries
+name: Release
 
 on:
   push:
     tags:
       - "[0-9]*"
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to publish, for example 1.2.15 or v1.2.15
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -16,9 +22,65 @@ env:
   RUSTUP_HOME: ${{ github.workspace }}/.rustup
 
 jobs:
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.meta.outputs.release_tag }}
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.1
+
+      - name: Validate release metadata
+        run: |
+          python - <<'PY'
+          from ci.release_checks import validate_release_metadata
+          validate_release_metadata()
+          PY
+
+      - name: Validate tag matches workspace version
+        id: meta
+        shell: bash
+        env:
+          RAW_TAG: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
+        run: |
+          VERSION="$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+          data = tomllib.loads(Path("Cargo.toml").read_text(encoding="utf-8"))
+          print(data["workspace"]["package"]["version"])
+          PY
+          )"
+          TAG="${RAW_TAG#refs/tags/}"
+          NORMALIZED_TAG="${TAG#v}"
+
+          if [ -z "$NORMALIZED_TAG" ]; then
+            echo "Release tag is empty" >&2
+            exit 1
+          fi
+
+          if [ "$NORMALIZED_TAG" != "$VERSION" ]; then
+            echo "Tag $TAG does not match workspace version $VERSION" >&2
+            exit 1
+          fi
+
+          echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    needs: preflight
     strategy:
       fail-fast: false
       matrix:
@@ -26,54 +88,176 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             binary_ext: ""
+            include_python: "false"
+            upload_binaries: "false"
+            upload_release: "true"
 
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             binary_ext: ""
-            cross: true
             linker: aarch64-unknown-linux-musl-gcc
             strip: aarch64-unknown-linux-musl-strip
+            include_python: "false"
+            upload_binaries: "false"
+            upload_release: "true"
+
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            binary_ext: ""
+            include_python: "true"
+            upload_binaries: "true"
+            upload_release: "false"
+
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            binary_ext: ""
+            linker: aarch64-linux-gnu-gcc
+            strip: aarch64-linux-gnu-strip
+            include_python: "true"
+            upload_binaries: "true"
+            upload_release: "false"
 
           - target: x86_64-apple-darwin
             os: macos-14
             binary_ext: ""
+            include_python: "true"
+            upload_binaries: "true"
+            upload_release: "true"
 
           - target: aarch64-apple-darwin
             os: macos-latest
             binary_ext: ""
+            include_python: "true"
+            upload_binaries: "true"
+            upload_release: "true"
 
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             binary_ext: ".exe"
+            include_python: "true"
+            upload_binaries: "true"
+            upload_release: "true"
 
           - target: aarch64-pc-windows-msvc
             os: windows-latest
             binary_ext: ".exe"
+            include_python: "true"
+            upload_binaries: "true"
+            upload_release: "true"
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.release_tag }}
+
       - uses: ./.github/actions/build-target
         id: build_target
         with:
           target: ${{ matrix.target }}
           binary_ext: ${{ matrix.binary_ext }}
           cache_key: release-${{ matrix.target }}
+          include_python: ${{ matrix.include_python }}
           linker: ${{ matrix.linker || '' }}
           strip: ${{ matrix.strip || '' }}
-          version: ${{ github.ref_name }}
+          version: ${{ needs.preflight.outputs.version }}
+
+      - uses: actions/upload-artifact@v4
+        if: matrix.upload_binaries == 'true'
+        with:
+          name: binaries-${{ matrix.target }}
+          path: ${{ steps.build_target.outputs.staging_dir }}/
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v4
+        if: matrix.upload_release == 'true'
+        with:
+          name: release-${{ matrix.target }}
+          path: ${{ steps.build_target.outputs.standalone_archive }}
+          if-no-files-found: error
+
+  build-wheels:
+    name: Build PyPI Wheels
+    runs-on: ubuntu-latest
+    needs: [preflight, build]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.release_tag }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: binaries-*
+          path: artifact-downloads
+
+      - name: Build wheels from downloaded artifacts
+        run: ./publish --skip-rust --dry-run --artifact-download-dir artifact-downloads
 
       - uses: actions/upload-artifact@v4
         with:
-          name: release-${{ matrix.target }}
-          path: ${{ steps.build_target.outputs.standalone_dir }}/
+          name: pypi-wheels
+          path: dist/wheels/*
           if-no-files-found: error
 
-  publish:
-    name: Publish GitHub Release
+  publish-pypi:
+    name: Publish PyPI
     runs-on: ubuntu-latest
-    needs: build
+    needs: [preflight, build-wheels]
+    environment: pypi
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pypi-wheels
+          path: dist/wheels
+
+      - name: Publish wheel distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/wheels/
+          print-hash: true
+          skip-existing: true
+
+  publish-crates:
+    name: Publish crates.io
+    runs-on: ubuntu-latest
+    needs: [preflight, publish-pypi]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.release_tag }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.1
+
+      - name: Publish crates to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: ./publish --skip-pypi
+
+  publish-release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    needs: [preflight, build, publish-pypi, publish-crates]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.release_tag }}
 
       - uses: actions/download-artifact@v4
         with:
@@ -91,9 +275,26 @@ jobs:
         shell: bash
         run: |
           cd release-assets
-          sha256sum * > SHA256SUMS
+          find . -maxdepth 1 -type f -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
 
       - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.preflight.outputs.release_tag }}
+          name: zccache ${{ needs.preflight.outputs.version }}
+          body: |
+            ## Install
+
+            ```bash
+            curl -LsSf https://github.com/zackees/zccache/releases/latest/download/install.sh | sh
+            ```
+
+            ```powershell
+            powershell -ExecutionPolicy Bypass -c "irm https://github.com/zackees/zccache/releases/latest/download/install.ps1 | iex"
+            ```
+
+            GitHub Marketplace publication remains a manual GitHub UI step:
+            open the generated release, select `Publish this action to the GitHub Marketplace`,
+            choose categories, and publish.
           files: release-assets/*
+          fail_on_unmatched_files: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ uv run python ci/build_dist.py --run-id <run_id>
 uv run python ci/build_dist.py --skip-build
 ```
 
-- **Workflow**: `.github/workflows/build.yml` (workflow_dispatch, 6 targets)
+- **Workflow**: `.github/workflows/build.yml` (workflow_dispatch, 8 targets)
 - **Script**: `ci/build_dist.py` — orchestrates `gh` CLI to trigger, wait, download, organize
 - **Output**: `dist/` with per-platform subdirs + `manifest.json` (gitignored)
 - **Targets**: linux-x86_64, linux-aarch64, macos-x86_64, macos-aarch64, windows-x86_64, windows-arm64
@@ -55,6 +55,11 @@ uv run python ci/build_dist.py --skip-build
 - **Pre-check**: Fails fast if version from `pyproject.toml` already exists on PyPI
 - **Pipeline**: Triggers GH Actions build → waits → downloads artifacts → builds platform wheels → uploads via `uv publish`
 - **Auth**: `UV_PUBLISH_TOKEN`, `~/.pypirc`, or interactive prompt
+- **Automation**: `.github/workflows/release.yml` is the canonical tag-driven release workflow. It validates release metadata, builds wheel/release artifacts, publishes PyPI wheels, publishes Rust crates, and creates the GitHub release.
+- **Tag rule**: Push `1.2.15` or `v1.2.15`; the workflow normalizes the tag and requires it to match `[workspace.package].version` in `Cargo.toml`.
+- **PyPI setup**: Prefer Trusted Publishing. Configure PyPI to trust repo `zackees/zccache`, workflow `.github/workflows/release.yml`, environment `pypi`.
+- **crates.io setup**: Add GitHub Actions secret `CARGO_REGISTRY_TOKEN` from https://crates.io/me.
+- **Marketplace**: GitHub Marketplace publishing is not API-automated. After the workflow creates the GitHub release, open that release in GitHub, select `Publish this action to the GitHub Marketplace`, choose categories, and publish.
 
 ## Hooks (enforced automatically)
 

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,0 +1,158 @@
+# Next Steps
+
+Here is the exact checklist.
+
+1. Get the repo changes onto GitHub.
+
+Commit and push the release automation changes, ideally to `main`:
+
+- [action.yml](/C:/Users/niteris/dev/zccache/action.yml)
+- [.github/workflows/release.yml](/C:/Users/niteris/dev/zccache/.github/workflows/release.yml)
+- [.github/workflows/build.yml](/C:/Users/niteris/dev/zccache/.github/workflows/build.yml)
+- [.github/actions/build-target/action.yml](/C:/Users/niteris/dev/zccache/.github/actions/build-target/action.yml)
+- [ci/publish.py](/C:/Users/niteris/dev/zccache/ci/publish.py)
+
+2. Create the GitHub environment for PyPI.
+
+In `zackees/zccache`:
+`Settings` -> `Environments` -> `New environment`
+
+Create:
+`pypi`
+
+You do not need to add any secret there for PyPI if we use Trusted Publishing.
+
+Optional: add required reviewers if you want manual approval before publish.
+
+3. Register GitHub as a Trusted Publisher on PyPI.
+
+In PyPI, open the `zccache` project:
+`https://pypi.org/manage/project/zccache/`
+
+Then:
+`Publishing` -> `Add a publisher` -> `GitHub Actions`
+
+Use these values:
+
+- Owner: `zackees`
+- Repository name: `zccache`
+- Workflow:
+  If PyPI asks for the workflow filename, use `release.yml`
+  If it asks for the workflow path, use `.github/workflows/release.yml`
+- Environment name: `pypi`
+
+That is the PyPI setup. No PyPI token is needed.
+
+4. Create the crates.io token.
+
+Go to:
+`https://crates.io/me`
+
+Create a new API token.
+Copy it immediately, because crates.io only shows it once.
+
+5. Add the crates.io token to GitHub.
+
+In `zackees/zccache`:
+`Settings` -> `Secrets and variables` -> `Actions` -> `New repository secret`
+
+Create:
+
+- Name: `CARGO_REGISTRY_TOKEN`
+- Value: the crates.io token you just made
+
+6. Re-run the `1.2.15` release with the fixed workflow.
+
+Because `1.2.15` already exists as a tag and the old workflow failed, do this:
+
+- Go to `Actions`
+- Open workflow `Release`
+- Click `Run workflow`
+- Branch: `main`
+- Input `tag`: `1.2.15`
+
+That will:
+
+- build release artifacts
+- build wheels
+- publish to PyPI
+- publish crates to crates.io
+- create the GitHub release
+
+7. Publish the action to GitHub Marketplace.
+
+This part is still manual in GitHub’s UI.
+
+After the workflow creates the GitHub release:
+
+- open the new release page
+- check `Publish this action to the GitHub Marketplace`
+- choose categories
+- publish
+
+8. Verify the result.
+
+Check:
+
+- GitHub Releases shows `1.2.15` as latest
+- PyPI shows `zccache 1.2.15`
+- crates.io shows the `1.2.15` crates
+- the repo page no longer looks stuck on `1.2.8`
+
+## GitHub follow-up after creating the crates.io token
+
+1. Add the crates.io token as a repo secret.
+
+In `zackees/zccache`:
+`Settings` -> `Secrets and variables` -> `Actions` -> `New repository secret`
+
+Set:
+
+- Name: `CARGO_REGISTRY_TOKEN`
+- Secret: paste the crates.io token
+
+2. Create the PyPI environment.
+
+In `zackees/zccache`:
+`Settings` -> `Environments` -> `New environment`
+
+Create:
+
+- `pypi`
+
+You do not need to add a PyPI token there.
+
+3. Push the release workflow changes if you have not already.
+
+The repo must include the updated:
+
+- `.github/workflows/release.yml`
+- `.github/workflows/build.yml`
+- `.github/actions/build-target/action.yml`
+- `action.yml`
+- `ci/publish.py`
+
+4. Set up PyPI Trusted Publishing.
+
+On PyPI for project `zccache`, add a GitHub Actions trusted publisher with:
+
+- Owner: `zackees`
+- Repository: `zccache`
+- Workflow: `release.yml` or `.github/workflows/release.yml`
+- Environment: `pypi`
+
+5. Re-run the release workflow for the existing tag.
+
+In GitHub:
+`Actions` -> `Release` -> `Run workflow`
+
+Use:
+
+- Branch: `main`
+- Tag input: `1.2.15`
+
+6. After the workflow succeeds, publish to Marketplace manually.
+
+Open the generated GitHub release and check:
+
+- `Publish this action to the GitHub Marketplace`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![crates.io: zccache-core](https://img.shields.io/crates/v/zccache-core)](https://crates.io/crates/zccache-core)
 [![crates.io: zccache-cli](https://img.shields.io/crates/v/zccache-cli)](https://crates.io/crates/zccache-cli)
 [![crates.io: zccache-daemon](https://img.shields.io/crates/v/zccache-daemon)](https://crates.io/crates/zccache-daemon)
-[![Rust Workspace Version](https://img.shields.io/badge/rust%20workspace-1.2.3-orange)](https://crates.io/search?q=zccache)
+[![Rust Workspace Version](https://img.shields.io/badge/rust%20workspace-1.2.15-orange)](https://crates.io/search?q=zccache)
 [![GitHub Action](https://github.com/zackees/zccache/actions/workflows/test-action.yml/badge.svg)](https://github.com/zackees/zccache/actions/workflows/test-action.yml)
 
 ![C/C++](https://img.shields.io/badge/C%2FC%2B%2B-555?logo=c%2B%2B&logoColor=white)

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,5 @@
 name: "zccache"
+author: "Zachary Vorhies"
 description: >
   Unified Rust compilation + dependency caching for GitHub Actions.
   Replaces both mozilla-actions/sccache-action and Swatinem/rust-cache
@@ -303,3 +304,7 @@ runs:
         echo "${{ inputs.cache-cargo-registry }}" > ~/.zccache-action-state/cache-registry
         echo "${{ inputs.cache-target }}" > ~/.zccache-action-state/cache-target
         echo "${{ inputs.target-dir }}" > ~/.zccache-action-state/target-dir
+
+branding:
+  icon: "zap"
+  color: "orange"

--- a/ci/README.md
+++ b/ci/README.md
@@ -11,6 +11,16 @@ Python scripts for development tooling. Project-root trampolines (`_cargo`, `_ru
 - **`./test`** — Workspace tests, supports per-crate filtering
 - **`./perf`** — Performance benchmarks (zccache vs sccache vs bare clang)
 
+## Release Automation
+
+- **`./publish`** â€” Local release operator path; can also build wheels from pre-downloaded `binaries-*` artifacts via `--artifact-download-dir`
+- **Canonical workflow** â€” `.github/workflows/release.yml`
+- **Trigger** â€” push a tag matching the workspace version (`1.2.15` or `v1.2.15`)
+- **PyPI** â€” use Trusted Publishing with GitHub environment `pypi` and workflow `.github/workflows/release.yml`
+- **crates.io** â€” add repository secret `CARGO_REGISTRY_TOKEN`
+- **GitHub Release** â€” created automatically with standalone archives, installer scripts, and `SHA256SUMS`
+- **Marketplace** â€” still manual in the GitHub UI; edit the generated GitHub release and check `Publish this action to the GitHub Marketplace`
+
 ## Hooks (`ci/hooks/`)
 
 Claude Code hooks that enforce project conventions:

--- a/ci/publish.py
+++ b/ci/publish.py
@@ -18,6 +18,8 @@ Usage:
     ./publish --dry-run        # build and verify publishability without uploading
     ./publish --skip-pypi      # publish only Rust crates
     ./publish --skip-rust      # publish only PyPI wheels
+    ./publish --skip-rust --artifact-download-dir artifact-downloads
+                               # build wheels from pre-downloaded binaries-* artifacts
 """
 
 from __future__ import annotations
@@ -35,6 +37,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import tempfile
 import time
 import tomllib
 import urllib.error
@@ -761,22 +764,22 @@ def trigger_and_wait(repo: str, version: str) -> int | None:
 # ---------------------------------------------------------------------------
 
 
-def download_artifacts(repo: str, run_id: int, head_sha: str, version: str) -> None:
-    """Download build artifacts and organize into dist/."""
-    log(f"\n=== Step 3: Download artifacts from run {run_id} ===")
-
+def organize_downloaded_artifacts(
+    artifacts_root: Path,
+    repo: str,
+    run_id: int | None,
+    head_sha: str,
+    version: str,
+) -> None:
+    """Copy downloaded binaries-* artifacts into dist/ in the expected layout."""
     if DIST_DIR.exists():
         shutil.rmtree(DIST_DIR)
     DIST_DIR.mkdir()
 
-    tmp = DIST_DIR / "_tmp"
-    tmp.mkdir()
-    run(["gh", "run", "download", str(run_id), "--repo", repo, "--dir", str(tmp)])
-
     found = 0
     missing: list[str] = []
     for artifact_name, subdir in ARTIFACT_MAP.items():
-        src = tmp / artifact_name
+        src = artifacts_root / artifact_name
         if not src.exists():
             log(f"  MISSING: {artifact_name}")
             missing.append(artifact_name)
@@ -803,7 +806,6 @@ def download_artifacts(repo: str, run_id: int, head_sha: str, version: str) -> N
 
         found += 1
 
-    shutil.rmtree(tmp)
     log(f"  {found}/{len(ARTIFACT_MAP)} platforms downloaded")
 
     if missing:
@@ -812,6 +814,18 @@ def download_artifacts(repo: str, run_id: int, head_sha: str, version: str) -> N
         sys.exit(1)
 
     write_dist_manifest(repo, run_id, head_sha, version)
+
+
+def download_artifacts(repo: str, run_id: int, head_sha: str, version: str) -> None:
+    """Download build artifacts and organize them into dist/."""
+    log(f"\n=== Step 3: Download artifacts from run {run_id} ===")
+
+    tmp = Path(tempfile.mkdtemp(prefix="zccache-artifacts-"))
+    try:
+        run(["gh", "run", "download", str(run_id), "--repo", repo, "--dir", str(tmp)])
+        organize_downloaded_artifacts(tmp, repo, run_id, head_sha, version)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
 
 
 # ---------------------------------------------------------------------------
@@ -1082,6 +1096,14 @@ def main() -> None:
     parser.add_argument("--dry-run", action="store_true", help="Build wheels but do not upload.")
     parser.add_argument("--skip-pypi", action="store_true", help="Skip the PyPI release flow.")
     parser.add_argument("--skip-rust", action="store_true", help="Skip the crates.io release flow.")
+    parser.add_argument(
+        "--artifact-download-dir",
+        help=(
+            "Directory containing pre-downloaded GitHub Actions artifacts named "
+            "binaries-<target>. When set, PyPI packaging reuses those artifacts "
+            "instead of triggering build.yml."
+        ),
+    )
     args = parser.parse_args()
 
     run_pypi = not args.skip_pypi
@@ -1090,7 +1112,7 @@ def main() -> None:
         log("ERROR: Nothing to do. Remove one of --skip-pypi / --skip-rust.")
         sys.exit(1)
 
-    if run_pypi:
+    if run_pypi and not args.artifact_download_dir:
         try:
             run_capture(["gh", "--version"])
         except FileNotFoundError:
@@ -1126,7 +1148,7 @@ def main() -> None:
             )
             sys.exit(1)
 
-        if run_pypi:
+        if run_pypi and not args.artifact_download_dir:
             # GH Actions builds from the remote branch, so local-only changes
             # produce binaries with stale version strings baked in.
             dirty_entries = get_publish_blocking_dirty_entries()
@@ -1146,11 +1168,19 @@ def main() -> None:
 
     if run_pypi:
         head_sha = run_capture(["git", "rev-parse", "HEAD"])
-        run_id = trigger_and_wait(repo, version)
-        if run_id is not None:
-            download_artifacts(repo, run_id, head_sha, version)
+        if args.artifact_download_dir:
+            artifact_download_dir = Path(args.artifact_download_dir).expanduser().resolve()
+            if not artifact_download_dir.is_dir():
+                log(f"ERROR: Artifact directory does not exist: {artifact_download_dir}")
+                sys.exit(1)
+            log(f"\n=== Step 3: Prepare dist/ from {artifact_download_dir} ===")
+            organize_downloaded_artifacts(artifact_download_dir, repo, None, head_sha, version)
         else:
-            write_dist_manifest(repo, None, head_sha, version)
+            run_id = trigger_and_wait(repo, version)
+            if run_id is not None:
+                download_artifacts(repo, run_id, head_sha, version)
+            else:
+                write_dist_manifest(repo, None, head_sha, version)
         wheels = build_all_wheels(name, version, summary, requires_python, readme)
         wheels_to_upload = [wheel for wheel in wheels if wheel.name not in existing_pypi_files]
 


### PR DESCRIPTION
## Summary
- automate the full tag-driven release pipeline in `.github/workflows/release.yml`
- publish PyPI wheels from downloaded build artifacts and crates.io crates from the same release workflow
- fix GitHub release asset handling and add action marketplace metadata/documentation

## Details
- isolate standalone release uploads to archive files only so checksum generation and GitHub release publishing no longer fail on directories
- extend `ci/publish.py` with `--artifact-download-dir` so wheel packaging can reuse already-downloaded `binaries-*` artifacts inside GitHub Actions
- add `author` and `branding` to `action.yml` so the action is ready for GitHub Marketplace publishing
- document the exact remaining manual Marketplace handoff in repo docs and `NEXT_STEPS.md`

## Verification
- `uv run python -m py_compile ci/publish.py`
- YAML parsed successfully for `.github/workflows/release.yml`, `.github/workflows/build.yml`, `.github/actions/build-target/action.yml`, and `action.yml`

## Follow-up
- once this PR is merged, rerun the `Release` workflow for tag `1.2.15`
- after the GitHub release is created, publish it to GitHub Marketplace from the release UI