### PR TITLE
Support cache-root overrides and target snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "bincode",
  "redb",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "md5",
  "serde_json",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "blake3",
  "clap",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "clang",
  "tempfile",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "bincode",
  "clap",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "blake3",
  "dashmap",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "clap",
  "serde",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "clap",
  "dashmap",
@@ -3627,18 +3627,19 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "bincode",
  "bytes",
  "serde",
+ "tempfile",
  "zccache-core",
  "zccache-download",
 ]
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "clap",
  "criterion",
@@ -3661,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3674,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -3687,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -3699,10 +3700,11 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "bytes",
  "serde",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",
@@ -3712,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -3723,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3734,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.2.15"
+version = "1.3.0"
 dependencies = [
  "globset",
  "jwalk",

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Recommended project-local config:
 rustc-wrapper = "zccache"
 
 [env]
-ZCCACHE_DIR = { value = "/tmp/.zccache", force = false }
+ZCCACHE_CACHE_DIR = { value = "/tmp/.zccache", force = false }
 ```
 
 Supports `--emit=metadata` (`cargo check`), `--emit=dep-info,metadata,link` (`cargo build`),
@@ -254,6 +254,23 @@ zccache status
 ```
 
 </details>
+
+### Cache root override
+
+Set `ZCCACHE_CACHE_DIR` to isolate every zccache cache and state path under a
+specific root:
+
+```bash
+export ZCCACHE_CACHE_DIR="$HOME/.soldr/cache/zccache"
+zccache start
+zccache status
+```
+
+When set and non-empty, the override is used for `artifacts/`, `tmp/`,
+`depgraph/`, `index.redb`, `crashes/`, `logs/`, daemon lock files, download
+daemon state, and the default daemon endpoint. Separate cache roots therefore
+use separate daemon instances unless `ZCCACHE_ENDPOINT` is explicitly set.
+Relative override paths are normalized against the current working directory.
 
 <details>
 <summary>Bash integration</summary>
@@ -402,10 +419,12 @@ The action provides three cache layers plus `zccache warm` for near-instant subs
 |---|---|---|---|
 | **Compilation cache** | Per-unit `.o`/`.rlib` files via zccache daemon | sccache | ~1ms per cache hit vs ~170ms for sccache |
 | **Cargo registry cache** | `~/.cargo/registry/` + `~/.cargo/git/` | Swatinem/rust-cache | Avoids re-downloading crates |
-| **Target metadata cache** | `target/` fingerprints, build script outputs, dep-info | (new) | Cargo skips fingerprint recomputation |
-| **`zccache warm`** | Pre-populates `target/deps/` from compilation cache | (new) | Cargo sees all artifacts as fresh |
+| **Target snapshot cache** | `target/` tarball excluding `incremental/` | (new) | Cargo sees target outputs and fingerprints together |
+| **`zccache warm`** | Backfills `target/deps/` from compilation cache | (new) | Restores missing artifacts before cargo runs |
 
-On setup, the action: restores all three caches → runs `zccache warm` to fill in `.rlib`/`.rmeta` files → touches all timestamps to a single consistent value → starts the daemon.
+On setup, the action restores all three caches, extracts the target snapshot,
+runs `zccache warm` to backfill cached `.rlib`/`.rmeta` files, touches all
+timestamps to a single consistent value, and starts the daemon.
 
 On cleanup: stops daemon → saves all three caches.
 
@@ -421,8 +440,8 @@ Measured on `ubuntu-24.04` building `zccache-core` (14 crates):
 **15x faster than sccache on subsequent CI runs.** Zero recompilation — cargo sees all fingerprints as fresh and prints `Finished` immediately.
 
 How it works:
-1. First run: cold build, populates zccache compilation cache + saves target metadata
-2. Second run: restores target metadata → `zccache warm` fills in `.rlib` files from compilation cache → touches timestamps → `cargo build` → `Finished in 0.18s`
+1. First run: cold build, populates zccache compilation cache and saves a target snapshot.
+2. Second run: restores the target snapshot, runs `zccache warm` as a backfill, touches timestamps, then `cargo build` finishes without recompilation.
 
 `zccache warm` reads the on-disk artifact index (no daemon needed) and filters by `Cargo.lock` — only restores artifacts matching crates in your lockfile. That is a speed optimization, not a full integrity-verification pass: warmed artifacts are trusted and Cargo is expected to reject or rebuild anything incompatible.
 
@@ -432,9 +451,9 @@ How it works:
 |---|---|---|
 | `cache-cargo-registry` | `true` | Cache cargo registry index + crate files + git deps |
 | `cache-compilation` | `true` | Cache compilation units via zccache daemon |
-| `cache-target` | `true` | Cache target metadata + run `zccache warm` |
+| `cache-target` | `true` | Cache target snapshot + run `zccache warm` |
 | `compilation-restore-fallback` | `true` | Allow prefix fallback for compilation cache restores |
-| `target-restore-fallback` | `false` | Allow prefix fallback for target metadata restores |
+| `target-restore-fallback` | `false` | Allow prefix fallback for target snapshot restores |
 | `target-dir` | `target` | Path to the cargo target directory |
 | `shared-key` | `""` | Extra key for matrix isolation (typically the target triple) |
 | `zccache-version` | `latest` | Version to install |
@@ -445,7 +464,7 @@ How it works:
 The action now treats the two cache layers differently:
 
 - Compilation cache fallback stays enabled by default. That preserves fast incremental reuse across nearby commits while still letting zccache validate cache hits when `rustc` actually runs.
-- Target metadata fallback is disabled by default. Reusing stale Cargo fingerprints and build-script outputs across different source trees can make a PR merge ref look fresh when it is not.
+- Target snapshot fallback is disabled by default. Reusing stale Cargo fingerprints and build-script outputs across different source trees can make a PR merge ref look fresh when it is not.
 
 If you want the old fastest-possible behavior for developer CI, opt back in explicitly:
 
@@ -456,7 +475,7 @@ If you want the old fastest-possible behavior for developer CI, opt back in expl
     target-restore-fallback: true
 ```
 
-If you want a more release-hardened setup, prefer exact restores and avoid target metadata entirely:
+If you want a more release-hardened setup, prefer exact restores and avoid target snapshots entirely:
 
 ```yaml
 - uses: zackees/zccache@main
@@ -473,7 +492,7 @@ This project is optimized for developer speed, not full artifact attestation. `z
 |---|---|
 | `cache-hit-compilation` | Whether the zccache compilation cache was restored |
 | `cache-hit-registry` | Whether the cargo registry cache was restored |
-| `cache-hit-target` | Whether the target metadata cache was restored |
+| `cache-hit-target` | Whether the target snapshot cache was restored |
 
 ### Why two parts?
 

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,8 @@ inputs:
     default: "true"
   cache-target:
     description: >
-      Cache cargo target/ metadata (fingerprints, dep-info, build script outputs).
+      Cache a target/ snapshot (excluding incremental/) and run zccache warm.
       Allows cargo to skip invoking rustc entirely on warm builds.
-      Only caches lightweight metadata, not full .rlib files.
     required: false
     default: "true"
   compilation-restore-fallback:
@@ -34,9 +33,9 @@ inputs:
     default: "true"
   target-restore-fallback:
     description: >
-      Whether restore-key fallback is allowed for cargo target metadata.
-      Default "false" because fallback metadata can be stale for changed source
-      trees, especially on pull_request merge refs.
+      Whether restore-key fallback is allowed for cargo target snapshots.
+      Default "false" because fallback snapshots can be stale for changed
+      source trees, especially on pull_request merge refs.
     required: false
     default: "false"
   target-dir:
@@ -72,7 +71,7 @@ outputs:
     description: "Whether the cargo registry cache was restored"
     value: ${{ steps.restore-registry.outputs.cache-hit }}
   cache-hit-target:
-    description: "Whether the cargo target metadata cache was restored"
+    description: "Whether the cargo target snapshot cache was restored"
     value: ${{ steps.restore-target.outputs.cache-hit }}
 
 runs:
@@ -151,10 +150,10 @@ runs:
         key: ${{ steps.keys.outputs.registry-key }}
         restore-keys: ${{ steps.keys.outputs.registry-restore }}
 
-    # --- Layer 3: Restore cargo target metadata ---
-    # Restores lightweight target metadata (fingerprints, build script outputs,
-    # dep-info). The heavy .rlib/.rmeta files are filled in by `zccache warm`.
-    - name: Restore cargo target metadata
+    # --- Layer 3: Restore cargo target snapshot ---
+    # Restores target/ as a single tarball (excluding incremental/). `zccache warm`
+    # also fills in cached artifacts from the compilation cache when available.
+    - name: Restore cargo target snapshot
       id: restore-target
       if: inputs.cache-target == 'true'
       uses: actions/cache/restore@v4
@@ -163,7 +162,7 @@ runs:
         key: ${{ steps.keys.outputs.target-key }}
         restore-keys: ${{ steps.keys.outputs.target-restore }}
 
-    - name: Extract target metadata
+    - name: Extract target snapshot
       if: inputs.cache-target == 'true'
       shell: bash
       run: |
@@ -172,7 +171,7 @@ runs:
         if [ -f "$META_TAR" ]; then
           mkdir -p "$TARGET"
           tar xf "$META_TAR" -C "$TARGET" 2>/dev/null || true
-          echo "Restored target metadata ($(du -sh "$META_TAR" | cut -f1))"
+          echo "Restored target snapshot ($(du -sh "$META_TAR" | cut -f1))"
         fi
 
     # --- Install zccache ---

--- a/action/README.md
+++ b/action/README.md
@@ -32,9 +32,9 @@ steps:
 |---|---|---|
 | `cache-cargo-registry` | `true` | Cache `~/.cargo/registry/` and `~/.cargo/git/` |
 | `cache-compilation` | `true` | Cache compilation units via zccache daemon |
-| `cache-target` | `true` | Cache target metadata + run `zccache warm` |
+| `cache-target` | `true` | Cache target snapshot + run `zccache warm` |
 | `compilation-restore-fallback` | `true` | Allow prefix fallback for compilation cache restores |
-| `target-restore-fallback` | `false` | Allow prefix fallback for target metadata restores |
+| `target-restore-fallback` | `false` | Allow prefix fallback for target snapshot restores |
 | `target-dir` | `target` | Path to the cargo target directory |
 | `shared-key` | `""` | Extra cache key for matrix isolation |
 | `zccache-version` | `latest` | PyPI version to install |
@@ -46,13 +46,13 @@ steps:
 |---|---|
 | `cache-hit-compilation` | Whether zccache cache was restored |
 | `cache-hit-registry` | Whether cargo registry cache was restored |
-| `cache-hit-target` | Whether target metadata cache was restored |
+| `cache-hit-target` | Whether target snapshot cache was restored |
 
 ## Architecture
 
 The action has two parts because composite actions lack `post` steps:
 
-1. **`zackees/zccache`** (setup) restores caches, installs zccache, warms target metadata, and starts the daemon.
+1. **`zackees/zccache`** (setup) restores caches, installs zccache, restores the target snapshot, runs `zccache warm`, and starts the daemon.
 2. **`zackees/zccache/action/cleanup`** (teardown) stops the daemon and saves caches.
 
 The cleanup action must be called with `if: always()` to ensure caches are saved even on failure.
@@ -63,12 +63,12 @@ The cleanup action must be called with `if: always()` to ensure caches are saved
 |---|---|---|
 | zccache compilation | Per-unit `.o`/`.rlib` files (~1ms hit) | sccache (~170ms hit) |
 | Cargo registry | `~/.cargo/registry/` + `~/.cargo/git/` | Swatinem/rust-cache |
-| Target metadata | `target/` fingerprints, dep-info, build outputs | Cargo fingerprint recomputation |
+| Target snapshot | `target/` tarball excluding `incremental/` | Cargo fingerprint recomputation |
 
 State is passed from setup to cleanup via `~/.zccache-action-state/`.
 
 ### Restore policy
 
 - `compilation-restore-fallback: true` keeps the speed-first behavior for incremental CI.
-- `target-restore-fallback: false` is the default because stale Cargo metadata is not safe to prefix-restore across different source trees.
+- `target-restore-fallback: false` is the default because stale Cargo target snapshots are not safe to prefix-restore across different source trees.
 - For release-hardened builds, prefer `cache-target: false` and exact-key-only restores.

--- a/action/cleanup/action.yml
+++ b/action/cleanup/action.yml
@@ -56,7 +56,7 @@ runs:
           ~/.cargo/git/db/
         key: ${{ steps.state.outputs.registry-key }}
 
-    - name: Create target metadata snapshot
+    - name: Create target snapshot
       if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-target == 'true'
       shell: bash
       run: |
@@ -66,17 +66,17 @@ runs:
         mkdir -p "$SNAPSHOT_DIR"
         if [ -d "$TARGET" ]; then
           # Tar target/ excluding only incremental compilation data.
-          # zccache warm restores .rlib/.rmeta from its artifact cache,
-          # but we keep them in the tar too as a fallback. The tar
-          # includes proc-macro .so/.dll which warm also restores.
+          # zccache warm restores .rlib/.rmeta from its artifact cache
+          # when available, but the tar keeps them too as a fallback.
+          # The tar includes proc-macro .so/.dll files as well.
           tar cf "$SNAPSHOT_DIR/target-meta.tar" -C "$TARGET" \
             --exclude='incremental' \
             . 2>/dev/null || true
           SIZE=$(du -sh "$SNAPSHOT_DIR/target-meta.tar" 2>/dev/null | cut -f1 || echo "?")
-          echo "Saved target metadata snapshot ($SIZE)"
+          echo "Saved target snapshot ($SIZE)"
         fi
 
-    - name: Save cargo target metadata
+    - name: Save cargo target snapshot
       if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-target == 'true'
       uses: actions/cache/save@v4
       with:

--- a/crates/zccache-core/src/config.rs
+++ b/crates/zccache-core/src/config.rs
@@ -1,6 +1,11 @@
 //! Configuration types for zccache.
 
 use crate::NormalizedPath;
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+/// Environment variable used to override the zccache cache root.
+pub const CACHE_DIR_ENV: &str = "ZCCACHE_CACHE_DIR";
 
 /// Top-level configuration for zccache.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -42,10 +47,24 @@ impl Default for Config {
     }
 }
 
-/// Returns the default cache directory path: `~/.zccache` on all platforms.
+/// Returns the configured cache directory path.
+///
+/// If `ZCCACHE_CACHE_DIR` is set and non-empty, it is used as the cache root.
+/// Relative override paths are made absolute against the current working
+/// directory so the daemon and CLI derive the same subpaths when spawned
+/// together. If unset, this falls back to `~/.zccache` on all platforms.
 #[must_use]
 pub fn default_cache_dir() -> NormalizedPath {
+    if let Some(cache_dir) = cache_dir_override() {
+        return cache_dir;
+    }
     dirs_fallback().join(".zccache")
+}
+
+/// Returns the cache directory override from `ZCCACHE_CACHE_DIR`, if set.
+#[must_use]
+pub fn cache_dir_override() -> Option<NormalizedPath> {
+    cache_dir_from_env_value(std::env::var_os(CACHE_DIR_ENV))
 }
 
 /// Returns the directory for content-addressed compiled outputs.
@@ -147,14 +166,100 @@ fn dirs_fallback() -> NormalizedPath {
         .unwrap_or_else(|_| ".".into())
 }
 
+fn cache_dir_from_env_value(value: Option<OsString>) -> Option<NormalizedPath> {
+    let value = value?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(normalize_cache_dir_override(PathBuf::from(value)))
+}
+
+fn normalize_cache_dir_override(path: PathBuf) -> NormalizedPath {
+    if path.is_absolute() {
+        path.into()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_default()
+            .join(path)
+            .into()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set_cache_dir(value: &std::path::Path) -> Self {
+            let lock = ENV_LOCK.lock().unwrap();
+            let previous = std::env::var_os(CACHE_DIR_ENV);
+            std::env::set_var(CACHE_DIR_ENV, value);
+            Self {
+                _lock: lock,
+                previous,
+            }
+        }
+
+        fn remove_cache_dir() -> Self {
+            let lock = ENV_LOCK.lock().unwrap();
+            let previous = std::env::var_os(CACHE_DIR_ENV);
+            std::env::remove_var(CACHE_DIR_ENV);
+            Self {
+                _lock: lock,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(CACHE_DIR_ENV, value),
+                None => std::env::remove_var(CACHE_DIR_ENV),
+            }
+        }
+    }
 
     #[test]
     fn default_cache_dir_ends_with_zccache() {
+        let _env = EnvGuard::remove_cache_dir();
         let dir = default_cache_dir();
         assert!(dir.ends_with(".zccache"));
+    }
+
+    #[test]
+    fn cache_dir_override_uses_non_empty_env_value() {
+        let root = tempfile::tempdir().unwrap();
+        let override_dir = root.path().join("zc");
+        let _env = EnvGuard::set_cache_dir(&override_dir);
+
+        assert_eq!(default_cache_dir(), override_dir);
+        assert_eq!(artifacts_dir(), override_dir.join("artifacts"));
+        assert_eq!(tmp_dir(), override_dir.join("tmp"));
+        assert_eq!(depgraph_dir(), override_dir.join("depgraph"));
+        assert_eq!(index_path(), override_dir.join("index.redb"));
+        assert_eq!(crash_dump_dir(), override_dir.join("crashes"));
+        assert_eq!(log_dir(), override_dir.join("logs"));
+    }
+
+    #[test]
+    fn cache_dir_override_ignores_empty_env_value() {
+        assert!(cache_dir_from_env_value(Some(OsString::new())).is_none());
+    }
+
+    #[test]
+    fn relative_cache_dir_override_is_made_absolute() {
+        let override_dir = cache_dir_from_env_value(Some(OsString::from("target/../zc"))).unwrap();
+        assert!(override_dir.is_absolute());
+        assert!(override_dir.ends_with("zc"));
     }
 
     #[test]

--- a/crates/zccache-core/src/config.rs
+++ b/crates/zccache-core/src/config.rs
@@ -2,7 +2,6 @@
 
 use crate::NormalizedPath;
 use std::ffi::OsString;
-use std::path::PathBuf;
 
 /// Environment variable used to override the zccache cache root.
 pub const CACHE_DIR_ENV: &str = "ZCCACHE_CACHE_DIR";
@@ -171,10 +170,10 @@ fn cache_dir_from_env_value(value: Option<OsString>) -> Option<NormalizedPath> {
     if value.is_empty() {
         return None;
     }
-    Some(normalize_cache_dir_override(PathBuf::from(value)))
+    Some(normalize_cache_dir_override(std::path::Path::new(&value)))
 }
 
-fn normalize_cache_dir_override(path: PathBuf) -> NormalizedPath {
+fn normalize_cache_dir_override(path: &std::path::Path) -> NormalizedPath {
     if path.is_absolute() {
         path.into()
     } else {

--- a/crates/zccache-core/src/lib.rs
+++ b/crates/zccache-core/src/lib.rs
@@ -9,7 +9,7 @@ pub mod path;
 pub mod version;
 
 pub use error::{Error, Result};
-pub use path::{normalize, normalize_for_key, normalize_msys_path, NormalizedPath};
+pub use path::{normalize, normalize_for_key, normalize_msys_path, stable_path_id, NormalizedPath};
 
 /// The version string from Cargo.toml (workspace version).
 ///

--- a/crates/zccache-core/src/path.rs
+++ b/crates/zccache-core/src/path.rs
@@ -259,6 +259,25 @@ pub fn normalize_for_key(path: &Path) -> String {
     }
 }
 
+/// Return a compact, stable identifier for a path.
+///
+/// This is intended for filesystem-derived runtime names such as Windows named
+/// pipes where the full normalized path may be too long or contain invalid
+/// characters. It is not a cryptographic digest.
+#[must_use]
+pub fn stable_path_id(path: &Path) -> String {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    let key = normalize_for_key(path);
+    let mut hash = FNV_OFFSET;
+    for byte in key.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    format!("{hash:016x}")
+}
+
 /// Convert an MSYS2/Git Bash style path to a native Windows path.
 ///
 /// `/c/Users/foo` → `C:\Users\foo`
@@ -363,5 +382,12 @@ mod tests {
         // /usr/bin/gcc — bytes[2] is 's', not '/', so NOT a drive letter path
         let result = normalize_msys_path("/usr/bin/gcc");
         assert_eq!(result, "/usr/bin/gcc");
+    }
+
+    #[test]
+    fn stable_path_id_is_compact_and_deterministic() {
+        let path = Path::new("a/./b/../cache");
+        assert_eq!(stable_path_id(path), stable_path_id(path));
+        assert_eq!(stable_path_id(path).len(), 16);
     }
 }

--- a/crates/zccache-download-protocol/Cargo.toml
+++ b/crates/zccache-download-protocol/Cargo.toml
@@ -15,3 +15,6 @@ bincode = { workspace = true }
 bytes = { workspace = true }
 zccache-download = { workspace = true }
 zccache-core = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/zccache-download-protocol/src/daemon_mgmt.rs
+++ b/crates/zccache-download-protocol/src/daemon_mgmt.rs
@@ -5,6 +5,10 @@ use zccache_core::NormalizedPath;
 
 /// Return the default IPC endpoint for the download daemon.
 pub fn default_endpoint() -> String {
+    if let Some(cache_dir) = zccache_core::config::cache_dir_override() {
+        return endpoint_for_cache_dir(&cache_dir);
+    }
+
     #[cfg(unix)]
     {
         if let Ok(runtime_dir) = std::env::var("XDG_RUNTIME_DIR") {
@@ -17,6 +21,21 @@ pub fn default_endpoint() -> String {
     {
         let username = std::env::var("USERNAME").unwrap_or_else(|_| String::from("unknown"));
         format!(r"\\.\pipe\zccache-download-{username}")
+    }
+}
+
+fn endpoint_for_cache_dir(cache_dir: &std::path::Path) -> String {
+    #[cfg(unix)]
+    {
+        cache_dir
+            .join("download-daemon.sock")
+            .to_string_lossy()
+            .into_owned()
+    }
+    #[cfg(windows)]
+    {
+        let suffix = zccache_core::stable_path_id(cache_dir);
+        format!(r"\\.\pipe\zccache-download-{suffix}")
     }
 }
 
@@ -44,4 +63,63 @@ pub fn read_lock_file_pid() -> Option<u32> {
     std::fs::read_to_string(lock_file_path())
         .ok()
         .and_then(|s| s.trim().parse::<u32>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set_cache_dir(value: &std::path::Path) -> Self {
+            let lock = ENV_LOCK.lock().unwrap();
+            let previous = std::env::var_os(zccache_core::config::CACHE_DIR_ENV);
+            std::env::set_var(zccache_core::config::CACHE_DIR_ENV, value);
+            Self {
+                _lock: lock,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(zccache_core::config::CACHE_DIR_ENV, value),
+                None => std::env::remove_var(zccache_core::config::CACHE_DIR_ENV),
+            }
+        }
+    }
+
+    #[test]
+    fn cache_dir_override_moves_download_endpoint_and_lock_file() {
+        let root = tempfile::tempdir().unwrap();
+        let cache_dir = root.path().join("zc");
+        let _env = EnvGuard::set_cache_dir(&cache_dir);
+
+        let endpoint = default_endpoint();
+        #[cfg(unix)]
+        assert_eq!(
+            endpoint,
+            cache_dir
+                .join("download-daemon.sock")
+                .to_string_lossy()
+                .into_owned()
+        );
+        #[cfg(windows)]
+        {
+            assert!(endpoint.starts_with(r"\\.\pipe\zccache-download-"));
+            assert!(endpoint.ends_with(&zccache_core::stable_path_id(&cache_dir)));
+        }
+
+        assert_eq!(lock_file_path(), cache_dir.join("download-daemon.lock"));
+    }
 }

--- a/crates/zccache-ipc/Cargo.toml
+++ b/crates/zccache-ipc/Cargo.toml
@@ -18,3 +18,6 @@ bytes = { workspace = true }
 serde = { workspace = true }
 zccache-protocol = { workspace = true }
 zccache-core = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/zccache-ipc/src/lib.rs
+++ b/crates/zccache-ipc/src/lib.rs
@@ -21,8 +21,15 @@ use zccache_core::NormalizedPath;
 /// - Linux: `$XDG_RUNTIME_DIR/zccache/sock` or `/tmp/zccache-$USER/sock`
 /// - macOS: `/tmp/zccache-$USER/sock`
 /// - Windows: `\\.\pipe\zccache-{username}`
+///
+/// If `ZCCACHE_CACHE_DIR` is set, the endpoint is derived from that cache root
+/// so independently managed cache roots get independent daemon instances.
 #[must_use]
 pub fn default_endpoint() -> String {
+    if let Some(cache_dir) = zccache_core::config::cache_dir_override() {
+        return endpoint_for_cache_dir(&cache_dir);
+    }
+
     #[cfg(unix)]
     {
         if let Ok(runtime_dir) = std::env::var("XDG_RUNTIME_DIR") {
@@ -38,9 +45,25 @@ pub fn default_endpoint() -> String {
     }
 }
 
+fn endpoint_for_cache_dir(cache_dir: &std::path::Path) -> String {
+    #[cfg(unix)]
+    {
+        cache_dir.join("daemon.sock").to_string_lossy().into_owned()
+    }
+    #[cfg(windows)]
+    {
+        let suffix = zccache_core::stable_path_id(cache_dir);
+        format!(r"\\.\pipe\zccache-{suffix}")
+    }
+}
+
 /// Returns the path for the daemon lock file.
 #[must_use]
 pub fn lock_file_path() -> NormalizedPath {
+    if let Some(cache_dir) = zccache_core::config::cache_dir_override() {
+        return cache_dir.join("daemon.lock");
+    }
+
     #[cfg(unix)]
     {
         let endpoint = default_endpoint();
@@ -175,5 +198,68 @@ pub fn check_running_daemon() -> Option<u32> {
             let _ = std::fs::remove_file(&endpoint);
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set_cache_dir(value: &std::path::Path) -> Self {
+            let lock = ENV_LOCK.lock().unwrap();
+            let previous = std::env::var_os(zccache_core::config::CACHE_DIR_ENV);
+            std::env::set_var(zccache_core::config::CACHE_DIR_ENV, value);
+            Self {
+                _lock: lock,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(zccache_core::config::CACHE_DIR_ENV, value),
+                None => std::env::remove_var(zccache_core::config::CACHE_DIR_ENV),
+            }
+        }
+    }
+
+    #[test]
+    fn cache_dir_override_moves_endpoint_and_lock_file() {
+        let root = tempfile::tempdir().unwrap();
+        let cache_dir = root.path().join("zc");
+        let _env = EnvGuard::set_cache_dir(&cache_dir);
+
+        let endpoint = default_endpoint();
+        #[cfg(unix)]
+        assert_eq!(
+            endpoint,
+            cache_dir.join("daemon.sock").to_string_lossy().into_owned()
+        );
+        #[cfg(windows)]
+        {
+            assert!(endpoint.starts_with(r"\\.\pipe\zccache-"));
+            assert!(endpoint.ends_with(&zccache_core::stable_path_id(&cache_dir)));
+        }
+
+        assert_eq!(lock_file_path(), cache_dir.join("daemon.lock"));
+    }
+
+    #[test]
+    fn different_cache_roots_get_different_endpoints() {
+        let a = NormalizedPath::from("/tmp/zccache-a");
+        let b = NormalizedPath::from("/tmp/zccache-b");
+        assert_ne!(endpoint_for_cache_dir(&a), endpoint_for_cache_dir(&b));
     }
 }

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -674,10 +674,38 @@ v1 is deliberately minimal. The goal is a correct, useful tool for the most comm
 - `~/.zccache/` is visible and unambiguous on all platforms, consistent with tools like `.cargo/`, `.rustup/`, `.npm/`.
 - Centralizing path accessors prevents ad-hoc `.join("artifacts")` scattered across crates.
 
-**What does NOT change:**
-- IPC endpoints (`default_endpoint()`): socket paths and named pipes stay as-is (they are runtime IPC, not cache storage).
-- Unix lock file: stays adjacent to socket, not in cache dir.
+**What does NOT change by default:**
+- IPC endpoints (`default_endpoint()`): socket paths and named pipes stay as-is unless `ZCCACHE_CACHE_DIR` is set.
+- Unix lock file: stays adjacent to the default socket unless `ZCCACHE_CACHE_DIR` is set.
 
 **Consequences:**
 - Existing caches at old platform-specific locations are orphaned. Users must manually delete them or re-warm.
 - `~` on Windows resolves via `%USERPROFILE%` (typically `C:\Users\<name>`), which always exists.
+
+---
+
+## DD-021: Supported `ZCCACHE_CACHE_DIR` Cache Root Override
+
+**Context:** Managed build wrappers need to isolate their zccache artifacts and
+daemon state from a user's direct zccache usage. Rewriting `HOME` or
+`USERPROFILE` is too broad because it can affect compiler child processes and
+still only redirects zccache indirectly.
+
+**Decision:** `ZCCACHE_CACHE_DIR` is the supported cache-root override. When set
+and non-empty, all paths derived from `zccache_core::config::default_cache_dir()`
+use that root directly, including artifacts, temp files, depgraph state,
+`index.redb`, crash dumps, logs, cargo/download helper state, and lock files.
+Relative values are normalized against the current working directory.
+
+Default daemon endpoints also derive from the override. On Unix, zccache uses a
+socket under the cache root; on Windows, named pipe names include a stable path
+identifier derived from the cache root. This gives separate cache roots separate
+daemon instances unless an explicit endpoint is supplied.
+
+**Consequences:**
+- Existing users with no override keep the same `~/.zccache` cache root and
+  default runtime endpoints.
+- Managed wrappers can set one environment variable for CLI, wrapper, daemon,
+  status, clear, warm, and download helper commands.
+- Explicit `ZCCACHE_ENDPOINT` and `ZCCACHE_DOWNLOAD_ENDPOINT` still take
+  precedence for callers that need custom IPC routing.


### PR DESCRIPTION
## Summary

- Add supported `ZCCACHE_CACHE_DIR` handling for the cache root and all derived paths.
- Derive default zccache and download-daemon endpoints from the override so separate cache roots get separate daemon instances.
- Document the override and clarify that the action caches a target snapshot, with `zccache warm` as a backfill.
- Add focused tests for overridden cache paths, Windows daemon lock paths, and endpoint isolation.

## Validation

- `cargo fmt`
- `cargo test -p zccache-core -p zccache-ipc -p zccache-download-protocol`
- `cargo test -p zccache-cli warm`
- `cargo check -p zccache-cli -p zccache-daemon`
- `git diff --check`

Note: a direct `cargo build -p zccache-cli -p zccache-daemon` smoke build is currently blocked in this local Windows/MinGW environment by an existing `zccache_cli.dll` cdylib linker failure; `cargo check` and the targeted tests pass.

Fixes #51
Fixes #18