### PR TITLE
Centralize internal dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,24 +66,24 @@ sevenz-rust = "0.6"
 rkyv = { version = "0.7", features = ["validation"] }
 tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
 mimalloc = "0.1"
-zccache-core = { version = "=1.3.5", path = "crates/zccache-core" }
-zccache-hash = { version = "=1.3.5", path = "crates/zccache-hash" }
-zccache-protocol = { version = "=1.3.5", path = "crates/zccache-protocol" }
-zccache-download-protocol = { version = "=1.3.5", path = "crates/zccache-download-protocol" }
-zccache-download = { version = "=1.3.5", path = "crates/zccache-download" }
-zccache-download-client = { version = "=1.3.5", path = "crates/zccache-download-client" }
-zccache-download-daemon = { version = "=1.3.5", path = "crates/zccache-download-daemon" }
-zccache-fscache = { version = "=1.3.5", path = "crates/zccache-fscache" }
-zccache-artifact = { version = "=1.3.5", path = "crates/zccache-artifact" }
-zccache-depgraph = { version = "=1.3.5", path = "crates/zccache-depgraph" }
-zccache-watcher = { version = "=1.3.5", path = "crates/zccache-watcher" }
-zccache-compiler = { version = "=1.3.5", path = "crates/zccache-compiler" }
-zccache-ipc = { version = "=1.3.5", path = "crates/zccache-ipc" }
-zccache-daemon = { version = "=1.3.5", path = "crates/zccache-daemon" }
-zccache-cli = { version = "=1.3.5", path = "crates/zccache-cli" }
-zccache-test-support = { version = "=1.3.5", path = "crates/zccache-test-support" }
-zccache-fingerprint = { version = "=1.3.5", path = "crates/zccache-fingerprint" }
-zccache-gha = { version = "=1.3.5", path = "crates/zccache-gha" }
+zccache-core = { path = "crates/zccache-core" }
+zccache-hash = { path = "crates/zccache-hash" }
+zccache-protocol = { path = "crates/zccache-protocol" }
+zccache-download-protocol = { path = "crates/zccache-download-protocol" }
+zccache-download = { path = "crates/zccache-download" }
+zccache-download-client = { path = "crates/zccache-download-client" }
+zccache-download-daemon = { path = "crates/zccache-download-daemon" }
+zccache-fscache = { path = "crates/zccache-fscache" }
+zccache-artifact = { path = "crates/zccache-artifact" }
+zccache-depgraph = { path = "crates/zccache-depgraph" }
+zccache-watcher = { path = "crates/zccache-watcher" }
+zccache-compiler = { path = "crates/zccache-compiler" }
+zccache-ipc = { path = "crates/zccache-ipc" }
+zccache-daemon = { path = "crates/zccache-daemon" }
+zccache-cli = { path = "crates/zccache-cli" }
+zccache-test-support = { path = "crates/zccache-test-support" }
+zccache-fingerprint = { path = "crates/zccache-fingerprint" }
+zccache-gha = { path = "crates/zccache-gha" }
 
 # Vendored notify with fixes for Windows ReadDirectoryChangesW:
 # 1. Detect buffer overflow (bytes_written == 0) and report as error

--- a/ci/bump.py
+++ b/ci/bump.py
@@ -7,6 +7,7 @@
 
 All other version references derive from it automatically:
   - Rust crates: workspace inheritance (version.workspace = true)
+  - Rust internal dependencies: release publish flow stamps exact pins
   - Maturin Python packages: dynamic = ["version"] reads Cargo.toml
   - Root pyproject.toml: setup.py reads Cargo.toml at build time
 
@@ -59,15 +60,13 @@ def bump(current: str, part: str) -> str:
     return ".".join(map(str, parts))
 
 
-def write_version(current: str, new_version: str) -> None:
+def write_version(new_version: str) -> None:
     text = CARGO_TOML.read_text()
     # Update [workspace.package] version
     text, count = VERSION_RE.subn(rf"\g<1>{new_version}\3", text)
     if count != 1:
         print("ERROR: Failed to update workspace version in Cargo.toml", file=sys.stderr)
         sys.exit(1)
-    # Update pinned workspace dependency versions: version = "=X.Y.Z"
-    text = text.replace(f'version = "={current}"', f'version = "={new_version}"')
     CARGO_TOML.write_text(text)
 
 
@@ -91,7 +90,7 @@ def main() -> None:
         print(f"Version is already {current}")
         return
 
-    write_version(current, new_version)
+    write_version(new_version)
     print(f"{current} -> {new_version}")
 
 

--- a/ci/release_checks.py
+++ b/ci/release_checks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import tomllib
 from pathlib import Path
@@ -35,6 +36,11 @@ DYNAMIC_VERSION_PYPROJECTS = (
     ROOT / "crates" / "zccache-watcher" / "pyproject.toml",
     ROOT / "crates" / "zccache-fingerprint" / "pyproject.toml",
 )
+INTERNAL_CRATE_PREFIX = "zccache-"
+WORKSPACE_DEPENDENCY_RE = re.compile(
+    r"^(?P<name>zccache-[A-Za-z0-9_-]+)\s*=\s*\{\s*(?P<body>[^{}\n]*)\s*\}\s*$",
+    re.MULTILINE,
+)
 
 
 class ReleaseCheckError(RuntimeError):
@@ -62,6 +68,79 @@ def read_workspace_metadata() -> dict[str, Any]:
     return json.loads(result.stdout)
 
 
+def _internal_workspace_dependencies(
+    workspace_data: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    workspace_deps = workspace_data["workspace"].get("dependencies", {})
+    return {
+        name: spec
+        for name, spec in workspace_deps.items()
+        if name.startswith(INTERNAL_CRATE_PREFIX)
+        and isinstance(spec, dict)
+        and "path" in spec
+    }
+
+
+def stamp_internal_dependency_versions(manifest_path: Path | None = None) -> list[str]:
+    """Add exact internal dependency pins for crates.io publishing.
+
+    Cargo cannot inherit `[workspace.package].version` inside dependency specs.
+    The checked-in manifest omits those copied literals; release publishing calls
+    this helper in its disposable checkout before `cargo package`/`publish`.
+    """
+
+    manifest_path = manifest_path or ROOT / "Cargo.toml"
+    workspace_data = _read_toml(manifest_path)
+    version = workspace_data["workspace"]["package"]["version"]
+    expected_dependency_version = f"={version}"
+    internal_deps = _internal_workspace_dependencies(workspace_data)
+    pending = set(internal_deps)
+
+    def stamp_line(match: re.Match[str]) -> str:
+        name = match.group("name")
+        if name not in internal_deps:
+            return match.group(0)
+        pending.discard(name)
+        body = match.group("body").strip()
+        if re.search(r"\bversion\s*=", body):
+            body = re.sub(
+                r'\bversion\s*=\s*"[^"]*"',
+                f'version = "{expected_dependency_version}"',
+                body,
+                count=1,
+            )
+        else:
+            body = f'version = "{expected_dependency_version}", {body}'
+        return f"{name} = {{ {body} }}"
+
+    text = manifest_path.read_text(encoding="utf-8")
+    text = WORKSPACE_DEPENDENCY_RE.sub(stamp_line, text)
+    if pending:
+        raise ReleaseCheckError(
+            "Could not stamp internal dependency version(s): "
+            + ", ".join(sorted(pending))
+        )
+
+    manifest_path.write_text(text, encoding="utf-8")
+
+    stamped_data = _read_toml(manifest_path)
+    errors = []
+    for name, spec in _internal_workspace_dependencies(stamped_data).items():
+        actual = spec.get("version")
+        if actual != expected_dependency_version:
+            errors.append(
+                f"workspace dependency {name} has version {actual}, "
+                f"expected {expected_dependency_version}"
+            )
+
+    if errors:
+        raise ReleaseCheckError(
+            "Stamped dependency version checks failed:\n  - "
+            + "\n  - ".join(errors)
+        )
+    return sorted(internal_deps)
+
+
 def validate_release_versions() -> None:
     workspace_data = _read_toml(ROOT / "Cargo.toml")
     workspace_version = workspace_data["workspace"]["package"]["version"]
@@ -82,18 +161,11 @@ def validate_release_versions() -> None:
                 f"{rel_path} has no version and does not declare it as dynamic"
             )
 
-    expected_dependency_version = f"={workspace_version}"
-    workspace_deps = workspace_data["workspace"].get("dependencies", {})
-    for name, spec in workspace_deps.items():
-        if not name.startswith("zccache-"):
-            continue
-        if not isinstance(spec, dict) or "path" not in spec:
-            continue
-        actual = spec.get("version")
-        if actual != expected_dependency_version:
+    for name, spec in _internal_workspace_dependencies(workspace_data).items():
+        if "version" in spec:
             errors.append(
-                f"workspace dependency {name} has version {actual}, "
-                f"expected {expected_dependency_version}"
+                f"workspace dependency {name} duplicates version {spec['version']}; "
+                "omit it and let the release publish flow stamp exact pins"
             )
 
     if errors:

--- a/ci/release_workflow.py
+++ b/ci/release_workflow.py
@@ -26,6 +26,7 @@ from ci.release_checks import (
     RUST_PUBLISH_ORDER,
     ReleaseCheckError,
     read_workspace_version,
+    stamp_internal_dependency_versions,
     validate_release_metadata,
 )
 
@@ -406,8 +407,15 @@ def build_all_wheels(
 def verify_rust_crates_locally() -> None:
     try:
         validate_release_metadata()
+        stamped = stamp_internal_dependency_versions()
     except ReleaseCheckError as e:
         raise SystemExit(f"ERROR: {e}") from e
+
+    if stamped:
+        log(
+            "  Stamped exact internal dependency versions for crates.io publish: "
+            + ", ".join(stamped)
+        )
 
     for crate in RUST_PUBLISH_ORDER:
         run(["cargo", "package", "--allow-dirty", "--no-verify", "-p", crate, "--list"], cwd=ROOT)


### PR DESCRIPTION
## Summary

- Remove repeated exact internal crate dependency versions from `[workspace.dependencies]`
- Keep `[workspace.package].version` as the checked-in source of truth for project version bumps
- Stamp exact `=version` pins only in the release publish checkout before `cargo package` / `cargo publish`, since Cargo does not support inheriting the package version inside dependency specs
- Update release validation so copied internal dependency versions fail fast if they are reintroduced

Closes #55

## Verification

- `cargo metadata --no-deps --format-version 1`
- `python -m compileall ci`
- inline `validate_release_metadata()` check
- `cargo check --workspace`
- temporary clean worktree: `stamp_internal_dependency_versions()` then `cargo package --allow-dirty --no-verify -p <crate> --list` for all 19 crates in `RUST_PUBLISH_ORDER`