### PR TITLE
Release 1.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "bincode",
  "redb",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "md5",
  "serde_json",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "blake3",
  "clap",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "clang",
  "tempfile",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "serde",
  "tempfile",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "bincode",
  "clap",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "blake3",
  "dashmap",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "blake3",
  "bytes",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "clap",
  "serde",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "clap",
  "dashmap",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "bincode",
  "bytes",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "clap",
  "criterion",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "reqwest",
  "serde",
@@ -3688,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "blake3",
  "criterion",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "bytes",
  "serde",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "bincode",
  "bytes",
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["dylints/ban_std_pathbuf"]
 
 [workspace.package]
-version = "1.3.4"
+version = "1.3.5"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT OR Apache-2.0"
@@ -66,24 +66,24 @@ sevenz-rust = "0.6"
 rkyv = { version = "0.7", features = ["validation"] }
 tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
 mimalloc = "0.1"
-zccache-core = { version = "=1.3.4", path = "crates/zccache-core" }
-zccache-hash = { version = "=1.3.4", path = "crates/zccache-hash" }
-zccache-protocol = { version = "=1.3.4", path = "crates/zccache-protocol" }
-zccache-download-protocol = { version = "=1.3.4", path = "crates/zccache-download-protocol" }
-zccache-download = { version = "=1.3.4", path = "crates/zccache-download" }
-zccache-download-client = { version = "=1.3.4", path = "crates/zccache-download-client" }
-zccache-download-daemon = { version = "=1.3.4", path = "crates/zccache-download-daemon" }
-zccache-fscache = { version = "=1.3.4", path = "crates/zccache-fscache" }
-zccache-artifact = { version = "=1.3.4", path = "crates/zccache-artifact" }
-zccache-depgraph = { version = "=1.3.4", path = "crates/zccache-depgraph" }
-zccache-watcher = { version = "=1.3.4", path = "crates/zccache-watcher" }
-zccache-compiler = { version = "=1.3.4", path = "crates/zccache-compiler" }
-zccache-ipc = { version = "=1.3.4", path = "crates/zccache-ipc" }
-zccache-daemon = { version = "=1.3.4", path = "crates/zccache-daemon" }
-zccache-cli = { version = "=1.3.4", path = "crates/zccache-cli" }
-zccache-test-support = { version = "=1.3.4", path = "crates/zccache-test-support" }
-zccache-fingerprint = { version = "=1.3.4", path = "crates/zccache-fingerprint" }
-zccache-gha = { version = "=1.3.4", path = "crates/zccache-gha" }
+zccache-core = { version = "=1.3.5", path = "crates/zccache-core" }
+zccache-hash = { version = "=1.3.5", path = "crates/zccache-hash" }
+zccache-protocol = { version = "=1.3.5", path = "crates/zccache-protocol" }
+zccache-download-protocol = { version = "=1.3.5", path = "crates/zccache-download-protocol" }
+zccache-download = { version = "=1.3.5", path = "crates/zccache-download" }
+zccache-download-client = { version = "=1.3.5", path = "crates/zccache-download-client" }
+zccache-download-daemon = { version = "=1.3.5", path = "crates/zccache-download-daemon" }
+zccache-fscache = { version = "=1.3.5", path = "crates/zccache-fscache" }
+zccache-artifact = { version = "=1.3.5", path = "crates/zccache-artifact" }
+zccache-depgraph = { version = "=1.3.5", path = "crates/zccache-depgraph" }
+zccache-watcher = { version = "=1.3.5", path = "crates/zccache-watcher" }
+zccache-compiler = { version = "=1.3.5", path = "crates/zccache-compiler" }
+zccache-ipc = { version = "=1.3.5", path = "crates/zccache-ipc" }
+zccache-daemon = { version = "=1.3.5", path = "crates/zccache-daemon" }
+zccache-cli = { version = "=1.3.5", path = "crates/zccache-cli" }
+zccache-test-support = { version = "=1.3.5", path = "crates/zccache-test-support" }
+zccache-fingerprint = { version = "=1.3.5", path = "crates/zccache-fingerprint" }
+zccache-gha = { version = "=1.3.5", path = "crates/zccache-gha" }
 
 # Vendored notify with fixes for Windows ReadDirectoryChangesW:
 # 1. Detect buffer overflow (bytes_written == 0) and report as error

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![crates.io: zccache-core](https://img.shields.io/crates/v/zccache-core)](https://crates.io/crates/zccache-core)
 [![crates.io: zccache-cli](https://img.shields.io/crates/v/zccache-cli)](https://crates.io/crates/zccache-cli)
 [![crates.io: zccache-daemon](https://img.shields.io/crates/v/zccache-daemon)](https://crates.io/crates/zccache-daemon)
-[![Rust Workspace Version](https://img.shields.io/badge/rust%20workspace-1.3.4-orange)](https://crates.io/search?q=zccache)
+[![Rust Workspace Version](https://img.shields.io/badge/rust%20workspace-1.3.5-orange)](https://crates.io/search?q=zccache)
 [![GitHub Action](https://github.com/zackees/zccache/actions/workflows/test-action.yml/badge.svg)](https://github.com/zackees/zccache/actions/workflows/test-action.yml)
 
 ![C/C++](https://img.shields.io/badge/C%2FC%2B%2B-555?logo=c%2B%2B&logoColor=white)

--- a/ci/README.md
+++ b/ci/README.md
@@ -16,7 +16,7 @@ Python scripts for development tooling. Project-root trampolines (`_cargo`, `_ru
 - **Canonical workflow** - `.github/workflows/release-auto.yml` is the only supported release entrypoint
 - **Workflow helper** - `ci/release_workflow.py` provides preflight checks, wheel assembly, and crates publish helpers for the release workflow only
 - **Fast fail** - preflight checks PyPI and crates.io before any build fan-out and stops if the current version is already published
-- **Trigger** - push a tag matching the workspace version (`1.3.4` or `v1.3.4`)
+- **Trigger** - push a tag matching the workspace version (`1.3.5` or `v1.3.5`)
 - **Manual runs** - `Run workflow` can leave `tag` empty; the workflow derives the current workspace version from the selected branch and fails if that version already has a published GitHub release
 - **PyPI** - use Trusted Publishing with GitHub environment `pypi` and workflow `.github/workflows/release-auto.yml`
 - **crates.io** - add repository secret `CARGO_REGISTRY_TOKEN`


### PR DESCRIPTION
## Summary
- bump zccache workspace version to 1.3.5
- refresh Cargo.lock workspace package versions
- update README badge and release docs example

## Validation
- uv sync --refresh (run multiple times)
- release metadata check
- PyPI/crates.io availability check for 1.3.5
- git diff --check
