### PR TITLE
Bundle link side-effect artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3523,7 +3523,6 @@ dependencies = [
  "tracing-subscriber",
  "windows-sys 0.59.0",
  "zccache-artifact",
- "zccache-cli",
  "zccache-compiler",
  "zccache-core",
  "zccache-depgraph",

--- a/README.md
+++ b/README.md
@@ -126,6 +126,20 @@ The difference comes from **architecture**, not better caching:
 | **clippy** | Lint results cached |
 | **Rust check & build** | `cargo check` and `cargo build` with extern crate content hashing |
 
+### Link-Time Side Effects
+
+Linker drivers sometimes create more than the named `-o` output. Windows and
+MinGW toolchains may deploy runtime DLLs next to an executable, MSVC links may
+emit PDB files, and Emscripten links may create `.wasm`, `.map`, or `.js`
+sidecars. If a cache hit restored only the primary binary, those sibling files
+could be missing even though the cached binary itself was correct.
+
+For link invocations, zccache snapshots the output directory before running the
+real linker, records sibling files created or changed by a successful link, and
+stores them with the primary link artifact. Later cache hits restore the full
+artifact set to the output directory, so tools such as `clang-tool-chain` runtime
+deployment work without per-build-system post-link hooks.
+
 ## Install
 
 ```bash

--- a/crates/zccache-daemon/Cargo.toml
+++ b/crates/zccache-daemon/Cargo.toml
@@ -50,5 +50,4 @@ windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Securit
 
 [dev-dependencies]
 tempfile = { workspace = true }
-zccache-cli = { workspace = true }
 zccache-test-support = { workspace = true }

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -4450,6 +4450,154 @@ mod tests {
         assert!(cache.is_empty());
     }
 
+    struct CacheDirEnvGuard {
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl CacheDirEnvGuard {
+        fn set(path: &Path) -> Self {
+            let previous = std::env::var_os(zccache_core::config::CACHE_DIR_ENV);
+            std::env::set_var(zccache_core::config::CACHE_DIR_ENV, path);
+            Self { previous }
+        }
+    }
+
+    impl Drop for CacheDirEnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(previous) => std::env::set_var(zccache_core::config::CACHE_DIR_ENV, previous),
+                None => std::env::remove_var(zccache_core::config::CACHE_DIR_ENV),
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn write_fake_linker(dir: &Path) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tool = dir.join("clang");
+        std::fs::write(
+            &tool,
+            r#"#!/bin/sh
+out=
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+        shift
+        out=$1
+    fi
+    shift || true
+done
+if [ -z "$out" ]; then
+    exit 2
+fi
+out_dir=$(dirname "$out")
+printf 'binary\n' > "$out"
+printf 'debug\n' > "$out_dir/app.pdb"
+printf 'map\n' > "$out_dir/app.wasm.map"
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&tool).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&tool, perms).unwrap();
+        tool
+    }
+
+    #[cfg(windows)]
+    fn write_fake_linker(dir: &Path) -> std::path::PathBuf {
+        let tool = dir.join("clang.cmd");
+        std::fs::write(
+            &tool,
+            r#"@echo off
+set "OUT=%~2"
+if "%OUT%"=="" exit /b 2
+> "%OUT%" echo binary
+for %%I in ("%OUT%") do set "OUTDIR=%%~dpI"
+> "%OUTDIR%app.pdb" echo debug
+> "%OUTDIR%app.wasm.map" echo map
+exit /b 0
+"#,
+        )
+        .unwrap();
+        tool
+    }
+
+    #[tokio::test]
+    async fn link_cache_hit_restores_sibling_side_effects() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fake_linker = write_fake_linker(tmp.path());
+        let input = tmp.path().join("main.o");
+        let output = tmp.path().join("app.exe");
+        let pdb = tmp.path().join("app.pdb");
+        let wasm_map = tmp.path().join("app.wasm.map");
+        std::fs::write(&input, b"fake object").unwrap();
+
+        let _cache_dir = CacheDirEnvGuard::set(&tmp.path().join("zccache-cache"));
+        let server = DaemonServer::bind(&zccache_ipc::unique_test_endpoint()).unwrap();
+        let args = vec![
+            "-o".to_string(),
+            output.to_string_lossy().into_owned(),
+            input.to_string_lossy().into_owned(),
+        ];
+
+        let first = handle_link_ephemeral(
+            &server.state,
+            std::process::id(),
+            &fake_linker,
+            &args,
+            tmp.path(),
+            None,
+        )
+        .await;
+        match first {
+            Response::LinkResult {
+                exit_code, cached, ..
+            } => {
+                assert_eq!(exit_code, 0);
+                assert!(!cached, "first link should populate the cache");
+            }
+            other => panic!("expected LinkResult, got: {other:?}"),
+        }
+        assert!(
+            output.exists(),
+            "fresh link should create the primary output"
+        );
+        assert!(pdb.exists(), "fresh link should create a PDB sidecar");
+        assert!(
+            wasm_map.exists(),
+            "fresh link should create a wasm map sidecar"
+        );
+
+        std::fs::remove_file(&pdb).unwrap();
+        std::fs::remove_file(&wasm_map).unwrap();
+
+        let second = handle_link_ephemeral(
+            &server.state,
+            std::process::id(),
+            &fake_linker,
+            &args,
+            tmp.path(),
+            None,
+        )
+        .await;
+        match second {
+            Response::LinkResult {
+                exit_code, cached, ..
+            } => {
+                assert_eq!(exit_code, 0);
+                assert!(cached, "second link should be served from cache");
+            }
+            other => panic!("expected LinkResult, got: {other:?}"),
+        }
+
+        assert!(output.exists(), "cache hit should keep the primary output");
+        assert!(pdb.exists(), "cache hit should restore the PDB sidecar");
+        assert!(
+            wasm_map.exists(),
+            "cache hit should restore the wasm map sidecar"
+        );
+    }
+
     #[cfg(windows)]
     #[test]
     fn request_fingerprint_normalizes_equivalent_windows_paths() {

--- a/crates/zccache-daemon/src/side_effect.rs
+++ b/crates/zccache-daemon/src/side_effect.rs
@@ -1,10 +1,11 @@
-//! Before/after directory scan for side-effect file detection.
+//! Before/after directory scan for link side-effect file detection.
 //!
 //! When compiler wrappers (e.g., ctc-clang++) link a binary, their post-link
-//! hooks may deploy runtime DLLs alongside the output. These "side-effect"
-//! files are not declared in linker arguments, so they cannot be discovered
-//! by parsing. Instead, we snapshot the output directory before and after
-//! the link, and treat new shared-library files as side effects to cache.
+//! hooks may deploy runtime DLLs, PDBs, Emscripten sidecars, or other files
+//! alongside the output. These "side-effect" files are not declared in linker
+//! arguments, so they cannot be discovered by parsing. Instead, we snapshot
+//! the output directory before and after the link, and treat new or changed
+//! sibling files as side effects to cache.
 
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
@@ -60,30 +61,8 @@ pub fn snapshot_directory(dir: &Path) -> DirSnapshot {
     snap
 }
 
-/// Returns `true` if `name` has a shared-library extension (`.dll`, `.so`,
-/// `.dylib`, or versioned `.so.N.N.N`).
-fn has_shared_lib_extension(name: &OsStr) -> bool {
-    let s = name.to_string_lossy();
-    let lower = s.to_ascii_lowercase();
-
-    if lower.ends_with(".dll") || lower.ends_with(".dylib") {
-        return true;
-    }
-    // Exact `.so` or versioned `.so.1`, `.so.1.2.3`, etc.
-    if lower.ends_with(".so") {
-        return true;
-    }
-    // Versioned: contains `.so.` followed by digits/dots
-    if let Some(pos) = lower.find(".so.") {
-        let after = &lower[pos + 4..];
-        return !after.is_empty() && after.chars().all(|c| c.is_ascii_digit() || c == '.');
-    }
-    false
-}
-
 /// Re-scan `dir` and return files that are new or changed since `before`,
-/// filtering to shared-library extensions and excluding `primary_name` and
-/// anything in `already_captured`.
+/// excluding `primary_name` and anything in `already_captured`.
 pub fn detect_side_effects(
     before: &DirSnapshot,
     dir: &Path,
@@ -97,11 +76,6 @@ pub fn detect_side_effects(
 
         // Skip the primary output and already-captured secondaries.
         if name == primary_name || already_captured.contains(&name) {
-            continue;
-        }
-
-        // Only shared-library extensions.
-        if !has_shared_lib_extension(&name) {
             continue;
         }
 
@@ -212,7 +186,7 @@ mod tests {
     }
 
     #[test]
-    fn non_shared_lib_excluded() {
+    fn non_shared_sibling_detected() {
         let dir = TempDir::new().unwrap();
         let snap = snapshot_directory(dir.path());
 
@@ -223,35 +197,11 @@ mod tests {
         let found =
             detect_side_effects(&snap, dir.path(), OsStr::new("app.exe"), &HashSet::new()).unwrap();
 
-        assert!(found.is_empty());
-    }
-
-    #[test]
-    fn versioned_so_detected() {
-        let dir = TempDir::new().unwrap();
-        let snap = snapshot_directory(dir.path());
-
-        fs::write(dir.path().join("libasan.so"), b"so").unwrap();
-        fs::write(dir.path().join("libasan.so.6"), b"so6").unwrap();
-        fs::write(dir.path().join("libasan.so.6.0.0"), b"so600").unwrap();
-
-        let found =
-            detect_side_effects(&snap, dir.path(), OsStr::new("app"), &HashSet::new()).unwrap();
-
         assert_eq!(found.len(), 3);
-    }
-
-    #[test]
-    fn dylib_detected() {
-        let dir = TempDir::new().unwrap();
-        let snap = snapshot_directory(dir.path());
-
-        fs::write(dir.path().join("libasan.dylib"), b"dylib").unwrap();
-
-        let found =
-            detect_side_effects(&snap, dir.path(), OsStr::new("app"), &HashSet::new()).unwrap();
-
-        assert_eq!(found.len(), 1);
+        let names: HashSet<_> = found.iter().map(|f| f.file_name.clone()).collect();
+        assert!(names.contains(OsStr::new("debug.pdb")));
+        assert!(names.contains(OsStr::new("build.log")));
+        assert!(names.contains(OsStr::new("output.obj")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #33.

- Broaden link side-effect capture from shared-library siblings only to all new or changed sibling files in the link output directory, still bounded by the existing size/count limits.
- Add a daemon regression test with a fake linker that creates `.pdb` and `.wasm.map` sidecars, deletes them, then verifies a cache hit restores them.
- Document link-time side-effect bundling in the README.
- Remove an unused `zccache-cli` dev-dependency from `zccache-daemon`; daemon tests shell out to `cargo build -p zccache-cli` where needed and do not import that crate.

## Verification

- `cargo fmt --all`
- `cargo test -p zccache-daemon link_cache_hit_restores_sibling_side_effects --lib -- --test-threads=1`
- `cargo test -p zccache-daemon side_effect::tests --lib -- --test-threads=1`
- `cargo check --workspace`
- `cargo test -p zccache-daemon --lib -- --test-threads=1`
- `git diff --check`
- `cargo metadata --no-deps --format-version 1`