### PR TITLE
Fix macOS installer test flake and use setup-soldr

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: ""
   cache_key:
-    description: Cache key suffix for Swatinem/rust-cache.
+    description: Cache key suffix for setup-soldr caches.
     required: true
   include_python:
     description: Build and stage Python extension artifacts.
@@ -56,12 +56,13 @@ runs:
       with:
         python-version: ${{ inputs.python_version }}
 
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+    - name: Setup Soldr
+      uses: zackees/setup-soldr@v0
       with:
         toolchain: 1.85.1
-        components: rustfmt,clippy
-        targets: ${{ inputs.target }}
+        cache: true
+        cache-key-suffix: ${{ inputs.cache_key }}
+        target-cache-paths: target/${{ inputs.target }}
 
     - name: Activate repo-local Rust toolchain
       shell: bash
@@ -70,11 +71,6 @@ runs:
     - name: Ensure target stdlib is installed
       shell: bash
       run: rustup target add ${{ inputs.target }}
-
-    - name: Restore Rust cache
-      uses: Swatinem/rust-cache@v2
-      with:
-        key: ${{ inputs.cache_key }}
 
     - name: Install musl tools
       if: inputs.target == 'x86_64-unknown-linux-musl'
@@ -111,9 +107,9 @@ runs:
       env:
         PYO3_PYTHON: python
       run: |
-        cargo build --release --target ${{ inputs.target }} -p zccache-cli
-        cargo build --release --target ${{ inputs.target }} -p zccache-daemon
-        cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint
+        soldr cargo build --release --target ${{ inputs.target }} -p zccache-cli
+        soldr cargo build --release --target ${{ inputs.target }} -p zccache-daemon
+        soldr cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint
 
     - name: Build Python extension artifacts
       if: inputs.include_python == 'true'
@@ -128,9 +124,9 @@ runs:
           export PYO3_CROSS_PYTHON_IMPLEMENTATION=CPython
         fi
 
-        cargo build --release --target ${{ inputs.target }} -p zccache-cli --features python --lib
-        cargo build --release --target ${{ inputs.target }} -p zccache-watcher --features python --lib
-        cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint --features python --lib
+        soldr cargo build --release --target ${{ inputs.target }} -p zccache-cli --features python --lib
+        soldr cargo build --release --target ${{ inputs.target }} -p zccache-watcher --features python --lib
+        soldr cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint --features python --lib
 
     - name: Stage artifacts
       shell: bash

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,19 +17,20 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: zackees/setup-soldr@v0
         with:
-          components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
+          cache: true
+      - name: Install Rust components
+        run: rustup component add clippy rustfmt
       - name: Check
-        run: cargo check --workspace --all-targets
+        run: soldr cargo check --workspace --all-targets
       - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: soldr cargo clippy --workspace --all-targets -- -D warnings
       - name: Test
         shell: bash
         run: |
           set +e
-          cargo test --workspace --no-fail-fast 2>&1 | tee test-output.txt
+          soldr cargo test --workspace --no-fail-fast 2>&1 | tee test-output.txt
           status=${PIPESTATUS[0]}
           if [ $status -ne 0 ]; then
             {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,31 +16,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: zackees/setup-soldr@v0
         with:
-          components: rustfmt
+          cache: true
+          build-cache: false
+          target-cache: false
+      - name: Install Rust components
+        run: rustup component add rustfmt
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        run: soldr cargo fmt --all -- --check
 
   dylint:
     name: Dylint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: zackees/setup-soldr@v0
         with:
-          toolchain: nightly-2025-09-18
-          components: llvm-tools-preview, rust-src, rustc-dev
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: dylint
+          cache: true
+          cache-key-suffix: dylint
+      - name: Install Dylint nightly toolchain
+        run: rustup toolchain install nightly-2025-09-18 --component llvm-tools-preview --component rust-src --component rustc-dev --profile minimal
+      - name: Install stable Rust components
+        run: rustup component add rustfmt
       - name: Install Dylint
-        run: cargo install cargo-dylint dylint-link --version 5.0.0
+        run: soldr cargo install cargo-dylint dylint-link --version 5.0.0
       - name: Check Dylint Library Formatting
-        run: cargo fmt --manifest-path dylints/ban_std_pathbuf/Cargo.toml --all -- --check
+        run: soldr cargo fmt --manifest-path dylints/ban_std_pathbuf/Cargo.toml --all -- --check
       - name: Test Dylint Library
-        run: cargo +nightly-2025-09-18 test --manifest-path dylints/ban_std_pathbuf/Cargo.toml
+        run: soldr cargo +nightly-2025-09-18 test --manifest-path dylints/ban_std_pathbuf/Cargo.toml
       - name: Run Dylint
         run: python3 -m ci.lint --dylint-only
 
@@ -49,10 +53,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.75.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: zackees/setup-soldr@v0
+        with:
+          cache: true
+          toolchain: 1.75.0
+          cache-key-suffix: msrv
       - name: Check MSRV
-        run: cargo check --workspace
+        run: soldr cargo check --workspace
 
   docs:
     name: Documentation
@@ -61,7 +68,9 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: zackees/setup-soldr@v0
+        with:
+          cache: true
+          cache-key-suffix: docs
       - name: Build docs
-        run: cargo doc --workspace --no-deps
+        run: soldr cargo doc --workspace --no-deps

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: zackees/setup-soldr@v0
         with:
-          components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: coverage
+          cache: true
+          cache-key-suffix: coverage
+      - name: Install Rust coverage component
+        run: rustup component add llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate coverage
-        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+        run: soldr cargo llvm-cov --workspace --lcov --output-path lcov.info
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/crates/zccache-cli/build.rs
+++ b/crates/zccache-cli/build.rs
@@ -1,4 +1,7 @@
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_PYTHON");
+
     if std::env::var_os("CARGO_FEATURE_PYTHON").is_some() {
         pyo3_build_config::add_extension_module_link_args();
     }

--- a/crates/zccache-cli/tests/installers.rs
+++ b/crates/zccache-cli/tests/installers.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::process::Command;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    Arc,
+    Arc, Mutex, OnceLock,
 };
 use std::thread::{self, JoinHandle};
 
@@ -13,6 +13,11 @@ use tempfile::TempDir;
 use zccache_core::NormalizedPath;
 
 const VERSION: &str = "1.2.3";
+
+fn installer_test_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
 
 fn workspace_root() -> NormalizedPath {
     NormalizedPath::new(
@@ -259,6 +264,7 @@ fn add_directory_to_zip(
 #[cfg(unix)]
 #[test]
 fn install_sh_installs_release_archive() {
+    let _guard = installer_test_lock().lock().expect("installer test lock");
     let temp = TempDir::new().expect("tempdir");
     let release_root = temp.path().join("release");
     fs::create_dir_all(&release_root).expect("create release root");
@@ -318,6 +324,7 @@ fn install_sh_installs_release_archive() {
 #[cfg(unix)]
 #[test]
 fn install_sh_supports_global_mode() {
+    let _guard = installer_test_lock().lock().expect("installer test lock");
     let temp = TempDir::new().expect("tempdir");
     let release_root = temp.path().join("release");
     fs::create_dir_all(&release_root).expect("create release root");
@@ -362,6 +369,7 @@ fn install_sh_supports_global_mode() {
 #[cfg(windows)]
 #[test]
 fn install_ps1_installs_release_archive() {
+    let _guard = installer_test_lock().lock().expect("installer test lock");
     let temp = TempDir::new().expect("tempdir");
     let release_root = temp.path().join("release");
     fs::create_dir_all(&release_root).expect("create release root");
@@ -425,6 +433,7 @@ fn install_ps1_installs_release_archive() {
 #[cfg(windows)]
 #[test]
 fn install_ps1_supports_global_mode() {
+    let _guard = installer_test_lock().lock().expect("installer test lock");
     let temp = TempDir::new().expect("tempdir");
     let release_root = temp.path().join("release");
     fs::create_dir_all(&release_root).expect("create release root");

--- a/crates/zccache-fingerprint/build.rs
+++ b/crates/zccache-fingerprint/build.rs
@@ -1,4 +1,7 @@
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_PYTHON");
+
     if std::env::var_os("CARGO_FEATURE_PYTHON").is_some() {
         pyo3_build_config::add_extension_module_link_args();
     }

--- a/crates/zccache-watcher/build.rs
+++ b/crates/zccache-watcher/build.rs
@@ -1,4 +1,7 @@
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_PYTHON");
+
     if std::env::var_os("CARGO_FEATURE_PYTHON").is_some() {
         pyo3_build_config::add_extension_module_link_args();
     }


### PR DESCRIPTION
## Summary

- Use `zackees/setup-soldr@v0` for CI/build cargo paths so zccache builds can reuse Soldr-managed zccache and target caches.
- Narrow Python-gated build script rerun inputs to `build.rs` and `CARGO_FEATURE_PYTHON`.
- Serialize installer integration tests so their local mock download servers and installer subprocesses do not race under the default parallel test harness.

Fixes the macOS installer failure from https://github.com/zackees/zccache/actions/runs/24764669913.

## Verification

- `cargo fmt --all --check`
- `python -c "import yaml; import sys; [yaml.safe_load(open(p, encoding='utf-8')) for p in sys.argv[1:]]" .github/workflows/ci-check.yml .github/workflows/ci.yml .github/workflows/coverage.yml .github/actions/build-target/action.yml`
- `git diff --check`
- `cargo test -p zccache-cli --test installers -- --test-threads=2`
- `cargo check --locked -p zccache-cli -p zccache-fingerprint -p zccache-watcher`
