### PR TITLE
Make target snapshot cache opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,11 +436,12 @@ The action provides three cache layers plus `zccache warm` for near-instant subs
 | **Target snapshot cache** | `target/` tarball excluding `incremental/` | (new) | Cargo sees target outputs and fingerprints together |
 | **`zccache warm`** | Backfills `target/deps/` from compilation cache | (new) | Restores missing artifacts before cargo runs |
 
-On setup, the action restores all three caches, extracts the target snapshot,
-runs `zccache warm` to backfill cached `.rlib`/`.rmeta` files, touches all
-timestamps to a single consistent value, and starts the daemon.
+On setup, the action restores the compilation and registry caches. Target
+snapshots are opt-in: when `cache-target: true` is set, the action extracts the
+target snapshot, runs `zccache warm` to backfill cached `.rlib`/`.rmeta` files,
+touches all timestamps to a single consistent value, and starts the daemon.
 
-On cleanup: stops daemon → saves all three caches.
+On cleanup: stops daemon and saves the enabled caches.
 
 ### CI benchmark results
 
@@ -454,8 +455,8 @@ Measured on `ubuntu-24.04` building `zccache-core` (14 crates):
 **15x faster than sccache on subsequent CI runs.** Zero recompilation — cargo sees all fingerprints as fresh and prints `Finished` immediately.
 
 How it works:
-1. First run: cold build, populates zccache compilation cache and saves a target snapshot.
-2. Second run: restores the target snapshot, runs `zccache warm` as a backfill, touches timestamps, then `cargo build` finishes without recompilation.
+1. First run with `cache-target: true`: cold build, populates zccache compilation cache and saves a target snapshot.
+2. Second run with `cache-target: true`: restores the target snapshot, runs `zccache warm` as a backfill, touches timestamps, then `cargo build` finishes without recompilation.
 
 `zccache warm` reads the on-disk artifact index (no daemon needed) and filters by `Cargo.lock` — only restores artifacts matching crates in your lockfile. That is a speed optimization, not a full integrity-verification pass: warmed artifacts are trusted and Cargo is expected to reject or rebuild anything incompatible.
 
@@ -465,7 +466,7 @@ How it works:
 |---|---|---|
 | `cache-cargo-registry` | `true` | Cache cargo registry index + crate files + git deps |
 | `cache-compilation` | `true` | Cache compilation units via zccache daemon |
-| `cache-target` | `true` | Cache target snapshot + run `zccache warm` |
+| `cache-target` | `false` | Cache target snapshot + run `zccache warm`; opt-in because `target/` has no bounded garbage collection yet ([zackees/zccache#65](https://github.com/zackees/zccache/issues/65)) |
 | `compilation-restore-fallback` | `true` | Allow prefix fallback for compilation cache restores |
 | `target-restore-fallback` | `false` | Allow prefix fallback for target snapshot restores |
 | `target-dir` | `target` | Path to the cargo target directory |
@@ -485,16 +486,16 @@ If you want the old fastest-possible behavior for developer CI, opt back in expl
 ```yaml
 - uses: zackees/zccache@main
   with:
+    cache-target: true
     compilation-restore-fallback: true
     target-restore-fallback: true
 ```
 
-If you want a more release-hardened setup, prefer exact restores and avoid target snapshots entirely:
+The default avoids target snapshots entirely until [zackees/zccache#65](https://github.com/zackees/zccache/issues/65) adds bounded garbage collection for accumulated profiles, test binaries, build-script outputs, and target triples. For release-hardened setup, keep the default and prefer exact compilation-cache restores:
 
 ```yaml
 - uses: zackees/zccache@main
   with:
-    cache-target: false
     compilation-restore-fallback: false
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -21,9 +21,13 @@ inputs:
   cache-target:
     description: >
       Cache a target/ snapshot (excluding incremental/) and run zccache warm.
-      Allows cargo to skip invoking rustc entirely on warm builds.
+      Allows cargo to skip invoking rustc entirely on warm builds. Disabled by
+      default because Cargo target directories do not garbage collect
+      themselves and can grow to multi-GB snapshots that exhaust hosted
+      runners. Enable only for bounded workflows until zackees/zccache#65 is
+      resolved.
     required: false
-    default: "true"
+    default: "false"
   compilation-restore-fallback:
     description: >
       Whether restore-key fallback is allowed for the zccache compilation cache.
@@ -153,6 +157,7 @@ runs:
     # --- Layer 3: Restore cargo target snapshot ---
     # Restores target/ as a single tarball (excluding incremental/). `zccache warm`
     # also fills in cached artifacts from the compilation cache when available.
+    # Opt-in until zackees/zccache#65 adds bounded target snapshot GC.
     - name: Restore cargo target snapshot
       id: restore-target
       if: inputs.cache-target == 'true'
@@ -263,7 +268,8 @@ runs:
 
     # --- Pre-populate target/ from zccache before daemon starts ---
     # warm reads the redb index directly (no daemon needed), fills in
-    # .rlib/.rmeta from cached artifacts, and touches mtimes.
+    # .rlib/.rmeta from cached artifacts, and touches mtimes. This is tied to
+    # target snapshot caching, which stays opt-in until zackees/zccache#65.
     - name: Warm target from zccache
       if: inputs.cache-target == 'true'
       shell: bash

--- a/action/README.md
+++ b/action/README.md
@@ -32,7 +32,7 @@ steps:
 |---|---|---|
 | `cache-cargo-registry` | `true` | Cache `~/.cargo/registry/` and `~/.cargo/git/` |
 | `cache-compilation` | `true` | Cache compilation units via zccache daemon |
-| `cache-target` | `true` | Cache target snapshot + run `zccache warm` |
+| `cache-target` | `false` | Cache target snapshot + run `zccache warm`; opt-in until [zackees/zccache#65](https://github.com/zackees/zccache/issues/65) adds bounded target snapshot GC |
 | `compilation-restore-fallback` | `true` | Allow prefix fallback for compilation cache restores |
 | `target-restore-fallback` | `false` | Allow prefix fallback for target snapshot restores |
 | `target-dir` | `target` | Path to the cargo target directory |
@@ -52,7 +52,7 @@ steps:
 
 The action has two parts because composite actions lack `post` steps:
 
-1. **`zackees/zccache`** (setup) restores caches, installs zccache, restores the target snapshot, runs `zccache warm`, and starts the daemon.
+1. **`zackees/zccache`** (setup) restores caches, installs zccache, and starts the daemon. When `cache-target: true` is set, it also restores the target snapshot and runs `zccache warm`.
 2. **`zackees/zccache/action/cleanup`** (teardown) stops the daemon and saves caches.
 
 The cleanup action must be called with `if: always()` to ensure caches are saved even on failure.
@@ -71,4 +71,5 @@ State is passed from setup to cleanup via `~/.zccache-action-state/`.
 
 - `compilation-restore-fallback: true` keeps the speed-first behavior for incremental CI.
 - `target-restore-fallback: false` is the default because stale Cargo target snapshots are not safe to prefix-restore across different source trees.
-- For release-hardened builds, prefer `cache-target: false` and exact-key-only restores.
+- `cache-target: false` is the default because Cargo target directories can accumulate stale outputs without bounded cleanup; see [zackees/zccache#65](https://github.com/zackees/zccache/issues/65).
+- For release-hardened builds, keep target snapshots disabled and use exact-key-only restores.

--- a/action/cleanup/action.yml
+++ b/action/cleanup/action.yml
@@ -30,7 +30,7 @@ runs:
           echo "save-cache=$(cat "$STATE_DIR/save-cache" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
           echo "cache-compilation=$(cat "$STATE_DIR/cache-compilation" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
           echo "cache-registry=$(cat "$STATE_DIR/cache-registry" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
-          echo "cache-target=$(cat "$STATE_DIR/cache-target" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
+          echo "cache-target=$(cat "$STATE_DIR/cache-target" 2>/dev/null || echo 'false')" >> "$GITHUB_OUTPUT"
           echo "target-dir=$(cat "$STATE_DIR/target-dir" 2>/dev/null || echo 'target')" >> "$GITHUB_OUTPUT"
         else
           echo "save-cache=false" >> "$GITHUB_OUTPUT"
@@ -65,6 +65,7 @@ runs:
         rm -rf "$SNAPSHOT_DIR"
         mkdir -p "$SNAPSHOT_DIR"
         if [ -d "$TARGET" ]; then
+          # Target snapshots are opt-in until zackees/zccache#65 adds bounded GC.
           # Tar target/ excluding only incremental compilation data.
           # zccache warm restores .rlib/.rmeta from its artifact cache
           # when available, but the tar keeps them too as a fallback.


### PR DESCRIPTION
## Summary
- make target snapshot caching opt-in instead of enabled by default
- keep compilation and registry caches enabled while avoiding unbounded target/ snapshots by default
- make cleanup default to not saving target snapshots if setup state is missing
- cross-reference zackees/zccache#65

## Verification
- git diff --check
- actionlint