### PR TITLE
Bound target snapshots and align MSRV

### DIFF
--- a/.github/workflows/bench-action.yml
+++ b/.github/workflows/bench-action.yml
@@ -172,6 +172,7 @@ jobs:
       - uses: ./
         with:
           shared-key: bench
+          cache-target: "true"
 
       - name: "Cold build"
         id: cold
@@ -239,6 +240,7 @@ jobs:
       - uses: ./
         with:
           shared-key: bench
+          cache-target: "true"
 
       - name: "Diagnostics: target restore status"
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,14 @@ jobs:
         run: python3 -m ci.lint --dylint-only
 
   msrv:
-    name: MSRV (1.75)
+    name: MSRV (1.94.1)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: zackees/setup-soldr@v0
         with:
           cache: true
-          toolchain: 1.75.0
+          toolchain: 1.94.1
           cache-key-suffix: msrv
       - name: Check MSRV
         run: soldr cargo check --workspace

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -23,6 +23,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  target-snapshot-gc:
+    name: "Target snapshot GC unit tests"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run target snapshot GC unit tests
+        shell: bash
+        run: bash action/cleanup/tests/test_prepare_target_snapshot.sh
+
   test-action:
     name: "${{ matrix.name }}"
     runs-on: ${{ matrix.os }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ zccache is a local-first compiler cache daemon (11 crates). See @docs/CLAUDE.md 
 
 - **Always use the project-root trampolines** (`_cargo`, `_rustc`, `_rustfmt`) or `soldr <tool>` directly to execute Rust commands. Bare cargo/rustc and `uv run cargo` are blocked by hook. Both forms dispatch through [soldr](https://github.com/zackees/soldr), which resolves each tool via `rustup which` so the rustup-managed toolchain is always used; the cargo path passes `--no-cache` so the previous bare-cargo semantics are preserved. Usage: `./_cargo check --workspace` or `soldr cargo check --workspace`.
 - **Always use `uv` for Python.** Bare `python`/`pip` are blocked by hook. Use `uv run ...` or `uv pip ...`.
-- MSRV: 1.75 | Edition: 2021 | Toolchain: stable (clippy + rustfmt)
+- MSRV: 1.94.1 | Edition: 2021 | Toolchain: 1.94.1 (clippy + rustfmt)
 - CI: Linux, macOS, Windows. All warnings denied (`RUSTFLAGS="-D warnings"`)
 - Every directory with files must have a README.md (enforced by hook)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = ["dylints/ban_std_pathbuf"]
 [workspace.package]
 version = "1.3.6"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/zackees/zccache"
 homepage = "https://github.com/zackees/zccache"
@@ -94,8 +94,8 @@ notify = { path = "vendor/notify" }
 [workspace.metadata.dylint]
 libraries = [{ path = "dylints/*" }]
 
-# Note: workspace.lints requires Rust 1.74+. If your toolchain is older,
-# these are ignored. Lint configuration is also enforced via CI clippy flags.
+# The workspace MSRV tracks rust-toolchain.toml. Lint configuration is also
+# enforced via CI clippy flags.
 #
 # [workspace.lints.rust]
 # unsafe_code = "deny"

--- a/README.md
+++ b/README.md
@@ -427,7 +427,8 @@ jobs:
 
 ### What it does
 
-The action provides three cache layers plus `zccache warm` for near-instant subsequent builds:
+The action provides two default cache layers, plus an opt-in target snapshot layer
+and `zccache warm` for near-instant subsequent builds:
 
 | Layer | What | Replaces | Effect |
 |---|---|---|---|
@@ -436,12 +437,13 @@ The action provides three cache layers plus `zccache warm` for near-instant subs
 | **Target snapshot cache** | `target/` tarball excluding `incremental/` | (new) | Cargo sees target outputs and fingerprints together |
 | **`zccache warm`** | Backfills `target/deps/` from compilation cache | (new) | Restores missing artifacts before cargo runs |
 
-On setup, the action restores the compilation and registry caches. Target
-snapshots are opt-in: when `cache-target: true` is set, the action extracts the
-target snapshot, runs `zccache warm` to backfill cached `.rlib`/`.rmeta` files,
-touches all timestamps to a single consistent value, and starts the daemon.
+On setup, the action restores the compilation and registry caches, installs
+zccache, and starts the daemon. When `cache-target: true` is set, it also
+extracts the target snapshot, runs `zccache warm` to backfill cached
+`.rlib`/`.rmeta` files, and touches all timestamps to a single consistent value.
 
-On cleanup: stops daemon and saves the enabled caches.
+On cleanup: stops daemon and saves the enabled caches. Target snapshots are
+pruned and size-checked before save.
 
 ### CI benchmark results
 
@@ -455,7 +457,7 @@ Measured on `ubuntu-24.04` building `zccache-core` (14 crates):
 **15x faster than sccache on subsequent CI runs.** Zero recompilation — cargo sees all fingerprints as fresh and prints `Finished` immediately.
 
 How it works:
-1. First run with `cache-target: true`: cold build, populates zccache compilation cache and saves a target snapshot.
+1. First run with `cache-target: true`: cold build, populates zccache compilation cache and saves a bounded target snapshot.
 2. Second run with `cache-target: true`: restores the target snapshot, runs `zccache warm` as a backfill, touches timestamps, then `cargo build` finishes without recompilation.
 
 `zccache warm` reads the on-disk artifact index (no daemon needed) and filters by `Cargo.lock` — only restores artifacts matching crates in your lockfile. That is a speed optimization, not a full integrity-verification pass: warmed artifacts are trusted and Cargo is expected to reject or rebuild anything incompatible.
@@ -466,7 +468,11 @@ How it works:
 |---|---|---|
 | `cache-cargo-registry` | `true` | Cache cargo registry index + crate files + git deps |
 | `cache-compilation` | `true` | Cache compilation units via zccache daemon |
-| `cache-target` | `false` | Cache target snapshot + run `zccache warm`; opt-in because `target/` has no bounded garbage collection yet ([zackees/zccache#65](https://github.com/zackees/zccache/issues/65)) |
+| `cache-target` | `false` | Cache target snapshot + run `zccache warm`; opt in only for workflows where target snapshots are worth the disk budget |
+| `target-snapshot-max-size` | `2GiB` | Skip or fail target snapshot save when the pruned snapshot exceeds this size; use `0` for unlimited |
+| `target-snapshot-too-large` | `skip` | `skip` oversized target snapshots or `fail` cleanup |
+| `target-prune-incremental` | `true` | Remove `target/**/incremental` before creating a snapshot |
+| `target-prune-build-script-out` | `false` | Remove `target/**/build/*/out` before creating a snapshot |
 | `compilation-restore-fallback` | `true` | Allow prefix fallback for compilation cache restores |
 | `target-restore-fallback` | `false` | Allow prefix fallback for target snapshot restores |
 | `target-dir` | `target` | Path to the cargo target directory |
@@ -480,6 +486,8 @@ The action now treats the two cache layers differently:
 
 - Compilation cache fallback stays enabled by default. That preserves fast incremental reuse across nearby commits while still letting zccache validate cache hits when `rustc` actually runs.
 - Target snapshot fallback is disabled by default. Reusing stale Cargo fingerprints and build-script outputs across different source trees can make a PR merge ref look fresh when it is not.
+- Target snapshots are disabled by default because Cargo does not garbage collect `target/`. Most CI should use the compilation and registry caches only. Enable `cache-target: true` for jobs where skipping Cargo fingerprint work matters enough to spend extra cache and runner disk.
+- Target snapshot saves prune `target/**/incremental` by default, can optionally prune `target/**/build/*/out`, and skip saving when the pruned snapshot exceeds `target-snapshot-max-size`.
 
 If you want the old fastest-possible behavior for developer CI, opt back in explicitly:
 
@@ -491,7 +499,7 @@ If you want the old fastest-possible behavior for developer CI, opt back in expl
     target-restore-fallback: true
 ```
 
-The default avoids target snapshots entirely until [zackees/zccache#65](https://github.com/zackees/zccache/issues/65) adds bounded garbage collection for accumulated profiles, test binaries, build-script outputs, and target triples. For release-hardened setup, keep the default and prefer exact compilation-cache restores:
+If you want a more release-hardened setup, keep target snapshots disabled and prefer exact restores:
 
 ```yaml
 - uses: zackees/zccache@main
@@ -513,8 +521,8 @@ This project is optimized for developer speed, not full artifact attestation. `z
 
 Composite GitHub Actions don't support `post` steps (automatic cleanup). The action is split into:
 
-1. **`zackees/zccache`** — setup: restore caches, install zccache, warm target, start daemon, set `RUSTC_WRAPPER`
-2. **`zackees/zccache/action/cleanup`** — teardown: print stats, stop daemon, save caches
+1. **`zackees/zccache`** — setup: restore caches, install zccache, optionally warm target, start daemon, set `RUSTC_WRAPPER`
+2. **`zackees/zccache/action/cleanup`** — teardown: print stats, stop daemon, prune and save enabled caches
 
 The cleanup action **must** be called with `if: always()` to ensure caches are saved even on failure.
 

--- a/action.yml
+++ b/action.yml
@@ -22,10 +22,30 @@ inputs:
     description: >
       Cache a target/ snapshot (excluding incremental/) and run zccache warm.
       Allows cargo to skip invoking rustc entirely on warm builds. Disabled by
-      default because Cargo target directories do not garbage collect
-      themselves and can grow to multi-GB snapshots that exhaust hosted
-      runners. Enable only for bounded workflows until zackees/zccache#65 is
-      resolved.
+      default because Cargo target directories can grow to multi-GB snapshots.
+    required: false
+    default: "false"
+  target-snapshot-max-size:
+    description: >
+      Maximum target snapshot size after pruning. Supports B, KiB, MiB, and GiB
+      suffixes. Set to "0" or "unlimited" to disable the size guard.
+    required: false
+    default: "2GiB"
+  target-snapshot-too-large:
+    description: >
+      Behavior when the target snapshot exceeds target-snapshot-max-size.
+      Use "skip" to skip saving or "fail" to fail cleanup.
+    required: false
+    default: "skip"
+  target-prune-incremental:
+    description: >
+      Remove target/**/incremental directories before creating a target snapshot.
+    required: false
+    default: "true"
+  target-prune-build-script-out:
+    description: >
+      Remove target/**/build/*/out directories before creating a target snapshot.
+      This can reclaim native build trees, but may force build scripts to rerun.
     required: false
     default: "false"
   compilation-restore-fallback:
@@ -174,6 +194,18 @@ runs:
         TARGET="${{ inputs.target-dir }}"
         META_TAR="$HOME/.zccache-target-meta/target-meta.tar"
         if [ -f "$META_TAR" ]; then
+          MAX_BYTES="$(bash "${{ github.action_path }}/action/cleanup/prepare-target-snapshot.sh" --parse-size "${{ inputs.target-snapshot-max-size }}")"
+          TAR_BYTES="$(wc -c < "$META_TAR" | tr -d '[:space:]')"
+          if [ "$MAX_BYTES" -gt 0 ] && [ "$TAR_BYTES" -gt "$MAX_BYTES" ]; then
+            rm -f "$META_TAR"
+            TOO_LARGE_POLICY="$(printf '%s' "${{ inputs.target-snapshot-too-large }}" | tr '[:upper:]' '[:lower:]')"
+            if [ "$TOO_LARGE_POLICY" = "fail" ]; then
+              echo "ERROR: restored target snapshot exceeds target-snapshot-max-size ($TAR_BYTES > $MAX_BYTES)"
+              exit 1
+            fi
+            echo "Skipping oversized restored target snapshot ($TAR_BYTES > $MAX_BYTES)"
+            exit 0
+          fi
           mkdir -p "$TARGET"
           tar xf "$META_TAR" -C "$TARGET" 2>/dev/null || true
           echo "Restored target snapshot ($(du -sh "$META_TAR" | cut -f1))"
@@ -309,6 +341,10 @@ runs:
         echo "${{ inputs.cache-cargo-registry }}" > ~/.zccache-action-state/cache-registry
         echo "${{ inputs.cache-target }}" > ~/.zccache-action-state/cache-target
         echo "${{ inputs.target-dir }}" > ~/.zccache-action-state/target-dir
+        echo "${{ inputs.target-snapshot-max-size }}" > ~/.zccache-action-state/target-snapshot-max-size
+        echo "${{ inputs.target-snapshot-too-large }}" > ~/.zccache-action-state/target-snapshot-too-large
+        echo "${{ inputs.target-prune-incremental }}" > ~/.zccache-action-state/target-prune-incremental
+        echo "${{ inputs.target-prune-build-script-out }}" > ~/.zccache-action-state/target-prune-build-script-out
 
 branding:
   icon: "zap"

--- a/action/README.md
+++ b/action/README.md
@@ -32,7 +32,11 @@ steps:
 |---|---|---|
 | `cache-cargo-registry` | `true` | Cache `~/.cargo/registry/` and `~/.cargo/git/` |
 | `cache-compilation` | `true` | Cache compilation units via zccache daemon |
-| `cache-target` | `false` | Cache target snapshot + run `zccache warm`; opt-in until [zackees/zccache#65](https://github.com/zackees/zccache/issues/65) adds bounded target snapshot GC |
+| `cache-target` | `false` | Cache target snapshot + run `zccache warm`; opt in only for workflows where target snapshots are worth the disk budget |
+| `target-snapshot-max-size` | `2GiB` | Skip or fail target snapshot save when the pruned snapshot exceeds this size; use `0` for unlimited |
+| `target-snapshot-too-large` | `skip` | `skip` oversized target snapshots or `fail` cleanup |
+| `target-prune-incremental` | `true` | Remove `target/**/incremental` before creating a snapshot |
+| `target-prune-build-script-out` | `false` | Remove `target/**/build/*/out` before creating a snapshot |
 | `compilation-restore-fallback` | `true` | Allow prefix fallback for compilation cache restores |
 | `target-restore-fallback` | `false` | Allow prefix fallback for target snapshot restores |
 | `target-dir` | `target` | Path to the cargo target directory |
@@ -67,9 +71,14 @@ The cleanup action must be called with `if: always()` to ensure caches are saved
 
 State is passed from setup to cleanup via `~/.zccache-action-state/`.
 
+Target snapshots are disabled by default because Cargo does not garbage collect
+`target/`. Most CI should keep the compilation and registry caches enabled and
+leave `cache-target: false`. Enable target snapshots only for jobs where skipping
+Cargo fingerprint work matters enough to spend extra cache and runner disk.
+
 ### Restore policy
 
 - `compilation-restore-fallback: true` keeps the speed-first behavior for incremental CI.
 - `target-restore-fallback: false` is the default because stale Cargo target snapshots are not safe to prefix-restore across different source trees.
-- `cache-target: false` is the default because Cargo target directories can accumulate stale outputs without bounded cleanup; see [zackees/zccache#65](https://github.com/zackees/zccache/issues/65).
-- For release-hardened builds, keep target snapshots disabled and use exact-key-only restores.
+- Target snapshot saves prune `target/**/incremental` by default and skip saving when the snapshot is larger than `target-snapshot-max-size`.
+- For release-hardened builds, keep `cache-target: false` and use exact-key-only restores.

--- a/action/cleanup/README.md
+++ b/action/cleanup/README.md
@@ -17,6 +17,20 @@ Always call with `if: always()`:
 2. Stops the zccache daemon
 3. Saves compilation cache to GHA cache
 4. Saves cargo registry cache to GHA cache
-5. Cleans up temporary state files
+5. If `cache-target: true`, prunes and bounds the cargo target snapshot before saving
+6. Cleans up temporary state files
 
 Cache keys are read from state written by the setup action (`~/.zccache-action-state/`).
+
+## Target Snapshot Outputs
+
+When target snapshots are enabled, cleanup exposes:
+
+| Output | Description |
+|---|---|
+| `target-snapshot-saved` | Whether a target snapshot tarball was created for saving |
+| `target-snapshot-skipped-reason` | Why target snapshot creation was skipped |
+| `target-snapshot-bytes` | Size in bytes of the target snapshot tarball |
+| `target-snapshot-candidate-bytes` | Estimated payload bytes after pruning |
+| `target-pruned-dirs` | Number of pruned target directories |
+| `target-pruned-bytes` | Estimated bytes removed before snapshot creation |

--- a/action/cleanup/action.yml
+++ b/action/cleanup/action.yml
@@ -4,6 +4,26 @@ description: >
   Use this as the last step in every job that uses zackees/zccache.
   Must run with `if: always()` to ensure cleanup on failure.
 
+outputs:
+  target-snapshot-saved:
+    description: "Whether a target snapshot tarball was created for saving"
+    value: ${{ steps.target-snapshot.outputs.snapshot-saved }}
+  target-snapshot-skipped-reason:
+    description: "Why target snapshot creation was skipped, when applicable"
+    value: ${{ steps.target-snapshot.outputs.snapshot-skipped-reason }}
+  target-snapshot-bytes:
+    description: "Size in bytes of the target snapshot tarball"
+    value: ${{ steps.target-snapshot.outputs.snapshot-bytes }}
+  target-snapshot-candidate-bytes:
+    description: "Estimated target snapshot payload bytes after pruning"
+    value: ${{ steps.target-snapshot.outputs.candidate-bytes }}
+  target-pruned-dirs:
+    description: "Number of target directories pruned before snapshot creation"
+    value: ${{ steps.target-snapshot.outputs.pruned-dirs }}
+  target-pruned-bytes:
+    description: "Estimated bytes pruned before snapshot creation"
+    value: ${{ steps.target-snapshot.outputs.pruned-bytes }}
+
 runs:
   using: "composite"
   steps:
@@ -32,6 +52,10 @@ runs:
           echo "cache-registry=$(cat "$STATE_DIR/cache-registry" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
           echo "cache-target=$(cat "$STATE_DIR/cache-target" 2>/dev/null || echo 'false')" >> "$GITHUB_OUTPUT"
           echo "target-dir=$(cat "$STATE_DIR/target-dir" 2>/dev/null || echo 'target')" >> "$GITHUB_OUTPUT"
+          echo "target-snapshot-max-size=$(cat "$STATE_DIR/target-snapshot-max-size" 2>/dev/null || echo '2GiB')" >> "$GITHUB_OUTPUT"
+          echo "target-snapshot-too-large=$(cat "$STATE_DIR/target-snapshot-too-large" 2>/dev/null || echo 'skip')" >> "$GITHUB_OUTPUT"
+          echo "target-prune-incremental=$(cat "$STATE_DIR/target-prune-incremental" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
+          echo "target-prune-build-script-out=$(cat "$STATE_DIR/target-prune-build-script-out" 2>/dev/null || echo 'false')" >> "$GITHUB_OUTPUT"
         else
           echo "save-cache=false" >> "$GITHUB_OUTPUT"
           echo "cache-compilation=false" >> "$GITHUB_OUTPUT"
@@ -57,28 +81,20 @@ runs:
         key: ${{ steps.state.outputs.registry-key }}
 
     - name: Create target snapshot
+      id: target-snapshot
       if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-target == 'true'
       shell: bash
+      env:
+        TARGET_DIR: ${{ steps.state.outputs.target-dir }}
+        TARGET_SNAPSHOT_MAX_SIZE: ${{ steps.state.outputs.target-snapshot-max-size }}
+        TARGET_SNAPSHOT_TOO_LARGE: ${{ steps.state.outputs.target-snapshot-too-large }}
+        TARGET_PRUNE_INCREMENTAL: ${{ steps.state.outputs.target-prune-incremental }}
+        TARGET_PRUNE_BUILD_SCRIPT_OUT: ${{ steps.state.outputs.target-prune-build-script-out }}
       run: |
-        TARGET="${{ steps.state.outputs.target-dir }}"
-        SNAPSHOT_DIR="$HOME/.zccache-target-meta"
-        rm -rf "$SNAPSHOT_DIR"
-        mkdir -p "$SNAPSHOT_DIR"
-        if [ -d "$TARGET" ]; then
-          # Target snapshots are opt-in until zackees/zccache#65 adds bounded GC.
-          # Tar target/ excluding only incremental compilation data.
-          # zccache warm restores .rlib/.rmeta from its artifact cache
-          # when available, but the tar keeps them too as a fallback.
-          # The tar includes proc-macro .so/.dll files as well.
-          tar cf "$SNAPSHOT_DIR/target-meta.tar" -C "$TARGET" \
-            --exclude='incremental' \
-            . 2>/dev/null || true
-          SIZE=$(du -sh "$SNAPSHOT_DIR/target-meta.tar" 2>/dev/null | cut -f1 || echo "?")
-          echo "Saved target snapshot ($SIZE)"
-        fi
+        bash "$GITHUB_ACTION_PATH/prepare-target-snapshot.sh"
 
     - name: Save cargo target snapshot
-      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-target == 'true'
+      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-target == 'true' && steps.target-snapshot.outputs.snapshot-saved == 'true'
       uses: actions/cache/save@v4
       with:
         path: ~/.zccache-target-meta

--- a/action/cleanup/prepare-target-snapshot.sh
+++ b/action/cleanup/prepare-target-snapshot.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+parse_size_bytes() {
+  local raw="${1:-0}"
+  raw="${raw//[[:space:]]/}"
+  local value
+  value="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+
+  case "$value" in
+    ""|"0"|"false"|"none"|"unlimited")
+      printf '0\n'
+      return 0
+      ;;
+  esac
+
+  if [[ ! "$value" =~ ^([0-9]+)([a-z]*)$ ]]; then
+    echo "Invalid target snapshot size: $raw" >&2
+    return 2
+  fi
+
+  local number="${BASH_REMATCH[1]}"
+  local unit="${BASH_REMATCH[2]}"
+  local multiplier
+  case "$unit" in
+    ""|"b") multiplier=1 ;;
+    "k"|"kb"|"kib") multiplier=1024 ;;
+    "m"|"mb"|"mib") multiplier=$((1024 * 1024)) ;;
+    "g"|"gb"|"gib") multiplier=$((1024 * 1024 * 1024)) ;;
+    *)
+      echo "Invalid target snapshot size unit: $raw" >&2
+      return 2
+      ;;
+  esac
+
+  printf '%s\n' "$((number * multiplier))"
+}
+
+if [ "${1:-}" = "--parse-size" ]; then
+  parse_size_bytes "${2:-${TARGET_SNAPSHOT_MAX_SIZE:-0}}"
+  exit $?
+fi
+
+is_true() {
+  local value
+  value="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
+  case "$value" in
+    "1"|"true"|"yes"|"on") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+write_output() {
+  local name="$1"
+  local value="$2"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$name" "$value" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+format_bytes() {
+  awk -v bytes="$1" '
+    BEGIN {
+      split("B KiB MiB GiB TiB", units, " ");
+      value = bytes + 0;
+      unit = 1;
+      while (value >= 1024 && unit < 5) {
+        value /= 1024;
+        unit++;
+      }
+      if (unit == 1) {
+        printf "%d %s", value, units[unit];
+      } else {
+        printf "%.1f %s", value, units[unit];
+      }
+    }
+  ' 2>/dev/null || printf '%s B' "$1"
+}
+
+sum_file_bytes_from_find() {
+  local total=0
+  local file size
+  while IFS= read -r -d '' file; do
+    size="$(wc -c < "$file" | tr -d '[:space:]')" || size=0
+    total=$((total + size))
+  done
+  printf '%s\n' "$total"
+}
+
+directory_bytes() {
+  local dir="$1"
+  find "$dir" -type f -print0 2>/dev/null | sum_file_bytes_from_find
+}
+
+snapshot_candidate_bytes() {
+  local target="$1"
+  if is_true "${TARGET_PRUNE_BUILD_SCRIPT_OUT:-false}"; then
+    find "$target" \
+      \( -type d -name incremental -o -type d -path '*/build/*/out' \) -prune \
+      -o -type f -print0 2>/dev/null | sum_file_bytes_from_find
+  else
+    find "$target" \
+      -type d -name incremental -prune \
+      -o -type f -print0 2>/dev/null | sum_file_bytes_from_find
+  fi
+}
+
+prune_dirs() {
+  local target="$1"
+  local find_kind="$2"
+  local count=0
+  local bytes=0
+  local dir dir_bytes
+
+  if [ "$find_kind" = "incremental" ]; then
+    while IFS= read -r -d '' dir; do
+      dir_bytes="$(directory_bytes "$dir")"
+      rm -rf -- "$dir"
+      count=$((count + 1))
+      bytes=$((bytes + dir_bytes))
+    done < <(find "$target" -type d -name incremental -prune -print0 2>/dev/null)
+  elif [ "$find_kind" = "build-out" ]; then
+    while IFS= read -r -d '' dir; do
+      dir_bytes="$(directory_bytes "$dir")"
+      rm -rf -- "$dir"
+      count=$((count + 1))
+      bytes=$((bytes + dir_bytes))
+    done < <(find "$target" -type d -path '*/build/*/out' -prune -print0 2>/dev/null)
+  else
+    echo "unknown prune kind: $find_kind" >&2
+    return 2
+  fi
+
+  printf '%s %s\n' "$count" "$bytes"
+}
+
+emit_outputs() {
+  write_output "snapshot-saved" "$SNAPSHOT_SAVED"
+  write_output "snapshot-skipped-reason" "$SNAPSHOT_SKIPPED_REASON"
+  write_output "snapshot-bytes" "$SNAPSHOT_BYTES"
+  write_output "candidate-bytes" "$CANDIDATE_BYTES"
+  write_output "pruned-dirs" "$PRUNED_DIRS"
+  write_output "pruned-bytes" "$PRUNED_BYTES"
+}
+
+append_summary() {
+  if [ -z "${GITHUB_STEP_SUMMARY:-}" ]; then
+    return 0
+  fi
+
+  {
+    echo "### zccache target snapshot"
+    echo ""
+    echo "- saved: $SNAPSHOT_SAVED"
+    if [ -n "$SNAPSHOT_SKIPPED_REASON" ]; then
+      echo "- skipped: $SNAPSHOT_SKIPPED_REASON"
+    fi
+    echo "- pruned directories: $PRUNED_DIRS"
+    echo "- pruned bytes: $PRUNED_BYTES ($(format_bytes "$PRUNED_BYTES"))"
+    echo "- candidate bytes: $CANDIDATE_BYTES ($(format_bytes "$CANDIDATE_BYTES"))"
+    echo "- snapshot bytes: $SNAPSHOT_BYTES ($(format_bytes "$SNAPSHOT_BYTES"))"
+  } >> "$GITHUB_STEP_SUMMARY"
+}
+
+finish_skipped() {
+  SNAPSHOT_SAVED=false
+  SNAPSHOT_SKIPPED_REASON="$1"
+  emit_outputs
+  append_summary
+  echo "Skipped target snapshot: $SNAPSHOT_SKIPPED_REASON"
+  exit 0
+}
+
+finish_too_large() {
+  local bytes="$1"
+  local message="target snapshot exceeds limit: $(format_bytes "$bytes") > $(format_bytes "$MAX_BYTES")"
+  SNAPSHOT_SAVED=false
+  SNAPSHOT_SKIPPED_REASON="target-too-large"
+  emit_outputs
+  append_summary
+  if [ "$TOO_LARGE_POLICY" = "fail" ]; then
+    echo "$message" >&2
+    exit 1
+  fi
+  echo "$message; skipping save"
+  exit 0
+}
+
+TARGET="${TARGET_DIR:-${TARGET:-target}}"
+SNAPSHOT_DIR="${TARGET_SNAPSHOT_DIR:-$HOME/.zccache-target-meta}"
+MAX_SIZE="${TARGET_SNAPSHOT_MAX_SIZE:-2GiB}"
+TOO_LARGE_POLICY="$(printf '%s' "${TARGET_SNAPSHOT_TOO_LARGE:-skip}" | tr '[:upper:]' '[:lower:]')"
+
+case "$TOO_LARGE_POLICY" in
+  "skip"|"fail") ;;
+  *)
+    echo "Invalid target snapshot too-large policy: $TOO_LARGE_POLICY" >&2
+    exit 2
+    ;;
+esac
+
+MAX_BYTES="$(parse_size_bytes "$MAX_SIZE")"
+SNAPSHOT_TAR="$SNAPSHOT_DIR/target-meta.tar"
+SNAPSHOT_SAVED=false
+SNAPSHOT_SKIPPED_REASON=""
+SNAPSHOT_BYTES=0
+CANDIDATE_BYTES=0
+PRUNED_DIRS=0
+PRUNED_BYTES=0
+
+rm -rf -- "$SNAPSHOT_DIR"
+mkdir -p -- "$SNAPSHOT_DIR"
+
+if [ ! -d "$TARGET" ]; then
+  finish_skipped "missing-target-dir"
+fi
+
+if is_true "${TARGET_PRUNE_INCREMENTAL:-true}"; then
+  read -r count bytes < <(prune_dirs "$TARGET" "incremental")
+  PRUNED_DIRS=$((PRUNED_DIRS + count))
+  PRUNED_BYTES=$((PRUNED_BYTES + bytes))
+fi
+
+if is_true "${TARGET_PRUNE_BUILD_SCRIPT_OUT:-false}"; then
+  read -r count bytes < <(prune_dirs "$TARGET" "build-out")
+  PRUNED_DIRS=$((PRUNED_DIRS + count))
+  PRUNED_BYTES=$((PRUNED_BYTES + bytes))
+fi
+
+CANDIDATE_BYTES="$(snapshot_candidate_bytes "$TARGET")"
+if [ "$MAX_BYTES" -gt 0 ] && [ "$CANDIDATE_BYTES" -gt "$MAX_BYTES" ]; then
+  finish_too_large "$CANDIDATE_BYTES"
+fi
+
+tar_excludes=(--exclude='incremental' --exclude='*/incremental')
+if is_true "${TARGET_PRUNE_BUILD_SCRIPT_OUT:-false}"; then
+  tar_excludes+=(--exclude='*/build/*/out')
+fi
+
+if ! tar "${tar_excludes[@]}" -cf "$SNAPSHOT_TAR" -C "$TARGET" . 2>/dev/null; then
+  rm -f -- "$SNAPSHOT_TAR"
+  finish_skipped "tar-failed"
+fi
+
+SNAPSHOT_BYTES="$(wc -c < "$SNAPSHOT_TAR" | tr -d '[:space:]')"
+if [ "$MAX_BYTES" -gt 0 ] && [ "$SNAPSHOT_BYTES" -gt "$MAX_BYTES" ]; then
+  rm -f -- "$SNAPSHOT_TAR"
+  finish_too_large "$SNAPSHOT_BYTES"
+fi
+
+SNAPSHOT_SAVED=true
+emit_outputs
+append_summary
+echo "Saved target snapshot ($(format_bytes "$SNAPSHOT_BYTES")); pruned $PRUNED_DIRS dirs ($(format_bytes "$PRUNED_BYTES"))"

--- a/action/cleanup/tests/README.md
+++ b/action/cleanup/tests/README.md
@@ -1,0 +1,4 @@
+# Cleanup Action Tests
+
+Shell unit tests for target snapshot pruning and size-limit behavior used by the
+cleanup action.

--- a/action/cleanup/tests/test_prepare_target_snapshot.sh
+++ b/action/cleanup/tests/test_prepare_target_snapshot.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT="$ROOT/action/cleanup/prepare-target-snapshot.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file_exists() {
+  [ -f "$1" ] || fail "expected file to exist: $1"
+}
+
+assert_file_missing() {
+  [ ! -e "$1" ] || fail "expected path to be missing: $1"
+}
+
+assert_contains() {
+  local file="$1"
+  local text="$2"
+  grep -Fq "$text" "$file" || fail "expected $file to contain: $text"
+}
+
+assert_not_contains() {
+  local file="$1"
+  local text="$2"
+  if grep -Fq "$text" "$file"; then
+    fail "expected $file not to contain: $text"
+  fi
+}
+
+make_file() {
+  local path="$1"
+  local bytes="$2"
+  mkdir -p "$(dirname "$path")"
+  python - "$path" "$bytes" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+size = int(sys.argv[2])
+path.write_bytes(b"x" * size)
+PY
+}
+
+new_tmp() {
+  local dir
+  dir="$(mktemp -d)"
+  echo "$dir"
+}
+
+tar_listing() {
+  local tar_path="$1"
+  local output="$2"
+  tar tf "$tar_path" | sed 's#^\./##' > "$output"
+}
+
+run_prepare() {
+  TARGET_DIR="$1" \
+  TARGET_SNAPSHOT_DIR="$2" \
+  TARGET_SNAPSHOT_MAX_SIZE="${3:-0}" \
+  TARGET_SNAPSHOT_TOO_LARGE="${4:-skip}" \
+  TARGET_PRUNE_INCREMENTAL="${5:-true}" \
+  TARGET_PRUNE_BUILD_SCRIPT_OUT="${6:-false}" \
+  GITHUB_OUTPUT="$7" \
+  bash "$SCRIPT"
+}
+
+test_parse_size() {
+  [ "$(bash "$SCRIPT" --parse-size 2GiB)" = "2147483648" ] || fail "2GiB parse failed"
+  [ "$(bash "$SCRIPT" --parse-size 16kb)" = "16384" ] || fail "16kb parse failed"
+  [ "$(bash "$SCRIPT" --parse-size unlimited)" = "0" ] || fail "unlimited parse failed"
+}
+
+test_prunes_incremental_and_excludes_from_tar() {
+  local tmp target snapshot output listing
+  tmp="$(new_tmp)"
+  target="$tmp/target"
+  snapshot="$tmp/snapshot"
+  output="$tmp/output"
+  listing="$tmp/listing"
+
+  make_file "$target/debug/deps/libfoo.rlib" 8
+  make_file "$target/debug/incremental/foo/s-cache.bin" 64
+  make_file "$target/release/incremental/bar/s-cache.bin" 32
+
+  run_prepare "$target" "$snapshot" 0 skip true false "$output"
+
+  assert_file_missing "$target/debug/incremental"
+  assert_file_missing "$target/release/incremental"
+  assert_file_exists "$snapshot/target-meta.tar"
+  assert_contains "$output" "snapshot-saved=true"
+  assert_contains "$output" "pruned-dirs=2"
+
+  tar_listing "$snapshot/target-meta.tar" "$listing"
+  assert_contains "$listing" "debug/deps/libfoo.rlib"
+  assert_not_contains "$listing" "incremental"
+}
+
+test_optionally_prunes_build_script_out() {
+  local tmp target snapshot output listing
+  tmp="$(new_tmp)"
+  target="$tmp/target"
+  snapshot="$tmp/snapshot"
+  output="$tmp/output"
+  listing="$tmp/listing"
+
+  make_file "$target/debug/build/libz-sys-abc/out/native/libz.a" 32
+  make_file "$target/debug/build/libz-sys-abc/build-script-build" 8
+  make_file "$target/debug/deps/libz_sys.rlib" 8
+
+  run_prepare "$target" "$snapshot" 0 skip true true "$output"
+
+  assert_file_missing "$target/debug/build/libz-sys-abc/out"
+  assert_file_exists "$snapshot/target-meta.tar"
+
+  tar_listing "$snapshot/target-meta.tar" "$listing"
+  assert_not_contains "$listing" "debug/build/libz-sys-abc/out"
+  assert_contains "$listing" "debug/build/libz-sys-abc/build-script-build"
+  assert_contains "$listing" "debug/deps/libz_sys.rlib"
+}
+
+test_oversize_skip_does_not_create_tar() {
+  local tmp target snapshot output
+  tmp="$(new_tmp)"
+  target="$tmp/target"
+  snapshot="$tmp/snapshot"
+  output="$tmp/output"
+
+  make_file "$target/debug/deps/libhuge.rlib" 64
+
+  run_prepare "$target" "$snapshot" 16B skip true false "$output"
+
+  assert_file_missing "$snapshot/target-meta.tar"
+  assert_contains "$output" "snapshot-saved=false"
+  assert_contains "$output" "snapshot-skipped-reason=target-too-large"
+}
+
+test_oversize_fail_returns_nonzero() {
+  local tmp target snapshot output
+  tmp="$(new_tmp)"
+  target="$tmp/target"
+  snapshot="$tmp/snapshot"
+  output="$tmp/output"
+
+  make_file "$target/debug/deps/libhuge.rlib" 64
+
+  if run_prepare "$target" "$snapshot" 16B fail true false "$output"; then
+    fail "expected oversize fail policy to return non-zero"
+  fi
+
+  assert_file_missing "$snapshot/target-meta.tar"
+  assert_contains "$output" "snapshot-saved=false"
+  assert_contains "$output" "snapshot-skipped-reason=target-too-large"
+}
+
+test_parse_size
+test_prunes_incremental_and_excludes_from_tar
+test_optionally_prunes_build_script_out
+test_oversize_skip_does_not_create_tar
+test_oversize_fail_returns_nonzero
+
+echo "prepare-target-snapshot tests passed"

--- a/crates/zccache-depgraph/src/context.rs
+++ b/crates/zccache-depgraph/src/context.rs
@@ -894,7 +894,7 @@ mod tests {
     fn rustc_compiler_hash_affects_key() {
         let ctx1 = make_rustc_context("/src/lib.rs", "2021");
         let mut ctx2 = make_rustc_context("/src/lib.rs", "2021");
-        ctx2.compiler_hash = Some(zccache_hash::hash_bytes(b"rustc-1.75.0"));
+        ctx2.compiler_hash = Some(zccache_hash::hash_bytes(b"rustc-1.94.1"));
         assert_ne!(
             ctx1.context_key(),
             ctx2.context_key(),
@@ -905,9 +905,9 @@ mod tests {
     #[test]
     fn rustc_different_compiler_versions_different_key() {
         let mut ctx1 = make_rustc_context("/src/lib.rs", "2021");
-        ctx1.compiler_hash = Some(zccache_hash::hash_bytes(b"rustc-1.75.0"));
+        ctx1.compiler_hash = Some(zccache_hash::hash_bytes(b"rustc-1.94.1"));
         let mut ctx2 = make_rustc_context("/src/lib.rs", "2021");
-        ctx2.compiler_hash = Some(zccache_hash::hash_bytes(b"rustc-1.76.0"));
+        ctx2.compiler_hash = Some(zccache_hash::hash_bytes(b"rustc-1.94.2"));
         assert_ne!(ctx1.context_key(), ctx2.context_key());
     }
 

--- a/crates/zccache-fingerprint/src/file_lock.rs
+++ b/crates/zccache-fingerprint/src/file_lock.rs
@@ -32,7 +32,7 @@ fn open_lock_file(cache_path: &Path) -> io::Result<File> {
 }
 
 // Use UFCS to call fs2 trait methods, avoiding ambiguity with
-// std::fs::File inherent methods added in Rust 1.89 (MSRV is 1.75).
+// std::fs::File inherent methods added in Rust 1.89.
 
 fn try_lock_shared(file: &File) -> io::Result<()> {
     fs2::FileExt::try_lock_shared(file)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,7 +28,7 @@ This document describes the phased implementation plan for **zccache**, a high-p
   - `cargo clippy --all-targets --all-features -- -D warnings`
   - `cargo fmt --all -- --check`
   - `cargo test --workspace`
-  - MSRV check (1.75+)
+  - MSRV check (1.94.1)
   - Matrix: Linux (ubuntu-latest), macOS (macos-latest), Windows (windows-latest)
 - `.rustfmt.toml` with project conventions
 - Clippy configuration (`clippy.toml` or workspace-level `Cargo.toml` lint settings)


### PR DESCRIPTION
## Summary
- add bounded target snapshot creation for the cleanup action with incremental pruning, optional build-script output pruning, max-size enforcement, and snapshot stats outputs
- make target snapshots opt-in by default while keeping benchmark workflows explicitly opted in
- add shell unit coverage for target snapshot pruning/exclusion and oversize skip/fail behavior
- align workspace MSRV and stale docs/comments with the pinned Rust 1.94.1 toolchain

Fixes #65.

## Verification
- `bash action/cleanup/tests/test_prepare_target_snapshot.sh`
- `actionlint`
- `./_cargo metadata --no-deps --format-version 1`
- `./_cargo test -p zccache-depgraph rustc_compiler_hash_affects_key rustc_different_compiler_versions_different_key`
- `git diff --check`