### PR TITLE
Add strict path validation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,22 @@ The first build (cold cache) runs at near-bare speed. Subsequent rebuilds
 (`ninja -t clean && ninja`, or touching source files) serve cached artifacts
 via hardlinks in under a second.
 
+**Strict path validation:** Set `ZCCACHE_STRICT_PATHS` or pass
+`--strict-paths=<off|consistent|absolute>` before the compiler name to catch
+non-normalized include paths before the real compiler runs:
+
+```bash
+ZCCACHE_STRICT_PATHS=consistent ninja
+zccache --strict-paths=absolute clang++ -IC:/project/src -c main.cpp
+```
+
+`consistent` rejects include path flags that mix separator styles or spell the
+same canonical path in more than one way, for example `-IC:/repo/./src` and
+`-IC:/repo/src` in the same invocation. `absolute` also requires path flags such
+as `-I`, `-isystem`, `-include`, and `-include-pch` to be forward-slash absolute
+paths without `/./` or `/../` segments. Violations exit non-zero with the
+offending flag and full caller command.
+
 **Single-roundtrip IPC:** In drop-in mode, zccache sends a single
 `CompileEphemeral` message that combines session creation, compilation, and
 session teardown — eliminating 2 of 3 IPC roundtrips per invocation.

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -47,6 +47,10 @@ struct Cli {
     #[arg(long)]
     show_stats: bool,
 
+    /// Validate compiler include path flags before dispatching.
+    #[arg(long, value_name = "MODE", value_parser = ["off", "consistent", "absolute"])]
+    strict_paths: Option<String>,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -101,6 +105,9 @@ enum Commands {
     },
     /// Wrap a compiler invocation (explicit mode).
     Wrap {
+        /// Validate compiler include path flags before dispatching.
+        #[arg(long, value_name = "MODE", value_parser = ["off", "consistent", "absolute"])]
+        strict_paths: Option<String>,
         /// The compiler and its arguments.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
@@ -327,6 +334,26 @@ const KNOWN_SUBCOMMANDS: &[&str] = &[
     "-V",
 ];
 
+fn split_leading_strict_paths(args: &[String]) -> (Option<String>, usize) {
+    if args.len() <= 1 {
+        return (None, 1);
+    }
+
+    let Some(arg) = args.get(1) else {
+        return (None, 1);
+    };
+    if let Some(value) = arg.strip_prefix("--strict-paths=") {
+        return (Some(value.to_string()), 2);
+    }
+    if arg == "--strict-paths" {
+        if let Some(value) = args.get(2) {
+            return (Some(value.clone()), 3);
+        }
+        return (Some(String::new()), 2);
+    }
+    (None, 1)
+}
+
 fn absolute_path(path: &str) -> NormalizedPath {
     let path = Path::new(path);
     if path.is_absolute() {
@@ -356,11 +383,12 @@ fn main() -> ExitCode {
 
     // Auto-detect: if first arg isn't a known subcommand or a --flag, enter wrap mode.
     // e.g., `zccache clang++ -c foo.cpp -o foo.o`
-    if args.len() > 1
-        && !KNOWN_SUBCOMMANDS.contains(&args[1].as_str())
-        && !args[1].starts_with("--")
+    let (auto_strict_paths, auto_wrap_start) = split_leading_strict_paths(&args);
+    if args.len() > auto_wrap_start
+        && !KNOWN_SUBCOMMANDS.contains(&args[auto_wrap_start].as_str())
+        && !args[auto_wrap_start].starts_with("--")
     {
-        return run_wrap(&args[1..]);
+        return run_wrap(&args[auto_wrap_start..], auto_strict_paths.as_deref());
     }
 
     let cli = Cli::parse();
@@ -377,6 +405,7 @@ fn main() -> ExitCode {
         return run_async(cmd_status(&endpoint));
     }
 
+    let global_strict_paths = cli.strict_paths.clone();
     let command = match cli.command {
         Some(cmd) => cmd,
         None => {
@@ -502,7 +531,10 @@ fn main() -> ExitCode {
             let endpoint = resolve_endpoint(endpoint.as_deref());
             run_async(cmd_session_stats(&endpoint, session_id))
         }
-        Commands::Wrap { args } => run_wrap(&args),
+        Commands::Wrap { strict_paths, args } => run_wrap(
+            &args,
+            strict_paths.as_deref().or(global_strict_paths.as_deref()),
+        ),
         Commands::Inspect { key } => {
             eprintln!("zccache inspect {key}: not yet implemented");
             ExitCode::FAILURE
@@ -2013,7 +2045,7 @@ fn run_tool_direct(tool: &Path, args: &[String]) -> ExitCode {
 ///
 /// If ZCCACHE_SESSION_ID is set, uses that session and sends the tool
 /// as a per-request override. If unset, auto-creates an ephemeral session.
-fn run_wrap(args: &[String]) -> ExitCode {
+fn run_wrap(args: &[String], strict_paths_arg: Option<&str>) -> ExitCode {
     if args.is_empty() {
         eprintln!("usage: zccache <compiler|tool> <args...>");
         return ExitCode::FAILURE;
@@ -2062,6 +2094,18 @@ fn run_wrap(args: &[String]) -> ExitCode {
     }
 
     // Otherwise, treat as a compiler invocation
+    let strict_mode = match resolve_strict_path_mode(strict_paths_arg) {
+        Ok(mode) => mode,
+        Err(message) => {
+            eprintln!("zccache: {message}");
+            return ExitCode::FAILURE;
+        }
+    };
+    if let Err(violation) = validate_compiler_paths(strict_mode, &tool_args, &cwd, args) {
+        eprintln!("{violation}");
+        return ExitCode::FAILURE;
+    }
+
     match std::env::var("ZCCACHE_SESSION_ID") {
         Ok(session_id) => {
             if session_id.is_empty() {
@@ -2088,6 +2132,47 @@ fn run_wrap(args: &[String]) -> ExitCode {
             ))
         }
     }
+}
+
+fn resolve_strict_path_mode(
+    cli_value: Option<&str>,
+) -> Result<zccache_compiler::strict_paths::StrictPathMode, String> {
+    let raw = cli_value
+        .map(ToOwned::to_owned)
+        .or_else(|| std::env::var(zccache_compiler::strict_paths::STRICT_PATHS_ENV).ok())
+        .unwrap_or_else(|| "off".to_string());
+
+    zccache_compiler::strict_paths::StrictPathMode::parse(&raw).ok_or_else(|| {
+        format!("invalid --strict-paths value `{raw}` (expected off, consistent, or absolute)")
+    })
+}
+
+fn validate_compiler_paths(
+    mode: zccache_compiler::strict_paths::StrictPathMode,
+    tool_args: &[String],
+    cwd: &Path,
+    full_args: &[String],
+) -> Result<(), String> {
+    if mode == zccache_compiler::strict_paths::StrictPathMode::Off {
+        return Ok(());
+    }
+
+    let args_for_validation =
+        zccache_compiler::response_file::expand_response_files_in(tool_args, cwd)
+            .unwrap_or_else(|_| tool_args.to_vec());
+
+    zccache_compiler::strict_paths::validate_strict_paths(&args_for_validation, cwd, mode).map_err(
+        |err| {
+            format!(
+                "zccache: {} flag `{}` violates --strict-paths={} ({}).\n         Caller: {}",
+                err.flag,
+                err.path,
+                err.mode.as_str(),
+                err.reason,
+                full_args.join(" ")
+            )
+        },
+    )
 }
 
 /// Resolve a compiler name/path to an absolute path.
@@ -2710,6 +2795,42 @@ fn init_tracing() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn split_leading_strict_paths_supports_equals_form() {
+        let args = vec![
+            "zccache".to_string(),
+            "--strict-paths=absolute".to_string(),
+            "clang++".to_string(),
+        ];
+
+        let (mode, start) = split_leading_strict_paths(&args);
+
+        assert_eq!(mode.as_deref(), Some("absolute"));
+        assert_eq!(start, 2);
+    }
+
+    #[test]
+    fn split_leading_strict_paths_supports_space_form() {
+        let args = vec![
+            "zccache".to_string(),
+            "--strict-paths".to_string(),
+            "consistent".to_string(),
+            "clang++".to_string(),
+        ];
+
+        let (mode, start) = split_leading_strict_paths(&args);
+
+        assert_eq!(mode.as_deref(), Some("consistent"));
+        assert_eq!(start, 3);
+    }
+
+    #[test]
+    fn resolve_strict_path_mode_rejects_invalid_cli_value() {
+        let err = resolve_strict_path_mode(Some("sometimes")).unwrap_err();
+
+        assert!(err.contains("invalid --strict-paths value"));
+    }
 
     #[test]
     fn exit_code_zero_stays_zero() {

--- a/crates/zccache-compiler/src/lib.rs
+++ b/crates/zccache-compiler/src/lib.rs
@@ -10,6 +10,7 @@ pub mod parse_archiver;
 pub mod parse_linker;
 pub mod parse_rustfmt;
 pub mod response_file;
+pub mod strict_paths;
 
 use std::sync::Arc;
 use zccache_core::NormalizedPath;

--- a/crates/zccache-compiler/src/strict_paths.rs
+++ b/crates/zccache-compiler/src/strict_paths.rs
@@ -1,0 +1,457 @@
+//! Strict validation for compiler path flags.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Environment variable used by the CLI to enable strict path validation.
+pub const STRICT_PATHS_ENV: &str = "ZCCACHE_STRICT_PATHS";
+
+/// Strict path validation policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StrictPathMode {
+    /// Disable validation.
+    Off,
+    /// Reject inconsistent include path spellings that can defeat `#pragma once`.
+    Consistent,
+    /// Require forward-slash absolute include paths with no `.` or `..` segments.
+    Absolute,
+}
+
+impl StrictPathMode {
+    /// Parse a mode string.
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "" | "off" | "0" | "false" | "no" => Some(Self::Off),
+            "consistent" => Some(Self::Consistent),
+            "absolute" | "strict" | "1" | "true" | "yes" => Some(Self::Absolute),
+            _ => None,
+        }
+    }
+
+    /// Return the canonical CLI spelling.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Consistent => "consistent",
+            Self::Absolute => "absolute",
+        }
+    }
+}
+
+/// A strict path validation failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StrictPathViolation {
+    /// Flag that introduced the offending path.
+    pub flag: String,
+    /// Offending path value.
+    pub path: String,
+    /// Active validation mode.
+    pub mode: StrictPathMode,
+    /// Human-readable reason.
+    pub reason: String,
+}
+
+/// Validate compiler path flags according to `mode`.
+pub fn validate_strict_paths(
+    args: &[String],
+    cwd: &Path,
+    mode: StrictPathMode,
+) -> Result<(), StrictPathViolation> {
+    if mode == StrictPathMode::Off {
+        return Ok(());
+    }
+
+    let paths = collect_path_flags(args);
+    if mode == StrictPathMode::Absolute {
+        for path_flag in &paths {
+            validate_absolute(path_flag, mode)?;
+        }
+    }
+
+    if mode == StrictPathMode::Consistent || mode == StrictPathMode::Absolute {
+        validate_consistent(&paths, cwd, mode)?;
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct PathFlag {
+    flag: String,
+    path: String,
+}
+
+fn collect_path_flags(args: &[String]) -> Vec<PathFlag> {
+    let mut result = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+
+        if takes_next_path(arg) {
+            if let Some(path) = args.get(i + 1) {
+                result.push(PathFlag {
+                    flag: arg.clone(),
+                    path: path.clone(),
+                });
+                i += 2;
+                continue;
+            }
+        }
+
+        if let Some((flag, path)) = split_joined_path_flag(arg) {
+            result.push(PathFlag {
+                flag: flag.to_string(),
+                path: path.to_string(),
+            });
+        }
+
+        i += 1;
+    }
+    result
+}
+
+fn takes_next_path(arg: &str) -> bool {
+    matches!(
+        arg,
+        "-I" | "/I"
+            | "-isystem"
+            | "-iquote"
+            | "-idirafter"
+            | "-include"
+            | "-include-pch"
+            | "-isysroot"
+            | "-imsvc"
+            | "/imsvc"
+            | "-F"
+            | "-iframework"
+    )
+}
+
+fn split_joined_path_flag(arg: &str) -> Option<(&'static str, &str)> {
+    for prefix in ["-isystem", "-iquote", "-idirafter", "-imsvc", "/imsvc"] {
+        if let Some(path) = arg.strip_prefix(prefix) {
+            if !path.is_empty() {
+                return Some((prefix, path));
+            }
+        }
+    }
+
+    if let Some(path) = arg.strip_prefix("--include-directory=") {
+        if !path.is_empty() {
+            return Some(("--include-directory", path));
+        }
+    }
+
+    if let Some(path) = arg.strip_prefix("/I") {
+        if !path.is_empty() {
+            return Some(("/I", path));
+        }
+    }
+
+    if let Some(path) = arg.strip_prefix("-I") {
+        if !path.is_empty() {
+            return Some(("-I", path));
+        }
+    }
+
+    if let Some(path) = arg.strip_prefix("-F") {
+        if !path.is_empty() {
+            return Some(("-F", path));
+        }
+    }
+
+    None
+}
+
+fn validate_absolute(
+    path_flag: &PathFlag,
+    mode: StrictPathMode,
+) -> Result<(), StrictPathViolation> {
+    if path_flag.path.contains('\\') {
+        return Err(violation(
+            path_flag,
+            mode,
+            "expected forward-slash absolute path",
+        ));
+    }
+    if !is_absolute_like(&path_flag.path) {
+        return Err(violation(
+            path_flag,
+            mode,
+            "expected forward-slash absolute path",
+        ));
+    }
+    if has_dot_segment(&path_flag.path) {
+        return Err(violation(
+            path_flag,
+            mode,
+            "expected normalized path without /./ or /../ segments",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_consistent(
+    paths: &[PathFlag],
+    cwd: &Path,
+    mode: StrictPathMode,
+) -> Result<(), StrictPathViolation> {
+    let mut style: Option<SeparatorStyle> = None;
+    let mut seen: HashMap<String, &PathFlag> = HashMap::new();
+
+    for path_flag in paths {
+        match separator_style(&path_flag.path) {
+            SeparatorStyle::Mixed => {
+                return Err(violation(
+                    path_flag,
+                    mode,
+                    "mixed forward-slash and backslash separators",
+                ));
+            }
+            SeparatorStyle::Forward | SeparatorStyle::Backslash => {
+                let current = separator_style(&path_flag.path);
+                if let Some(expected) = style {
+                    if current != expected {
+                        return Err(violation(
+                            path_flag,
+                            mode,
+                            "include path separator style differs from earlier path flags",
+                        ));
+                    }
+                } else {
+                    style = Some(current);
+                }
+            }
+            SeparatorStyle::None => {}
+        }
+
+        let key = canonical_key(&path_flag.path, cwd);
+        if let Some(previous) = seen.get(&key) {
+            if previous.path != path_flag.path {
+                return Err(StrictPathViolation {
+                    flag: path_flag.flag.clone(),
+                    path: path_flag.path.clone(),
+                    mode,
+                    reason: format!(
+                        "same canonical path was already passed as `{}` via {}",
+                        previous.path, previous.flag
+                    ),
+                });
+            }
+        } else {
+            seen.insert(key, path_flag);
+        }
+    }
+
+    Ok(())
+}
+
+fn violation(path_flag: &PathFlag, mode: StrictPathMode, reason: &str) -> StrictPathViolation {
+    StrictPathViolation {
+        flag: path_flag.flag.clone(),
+        path: path_flag.path.clone(),
+        mode,
+        reason: reason.to_string(),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SeparatorStyle {
+    None,
+    Forward,
+    Backslash,
+    Mixed,
+}
+
+fn separator_style(path: &str) -> SeparatorStyle {
+    match (path.contains('/'), path.contains('\\')) {
+        (false, false) => SeparatorStyle::None,
+        (true, false) => SeparatorStyle::Forward,
+        (false, true) => SeparatorStyle::Backslash,
+        (true, true) => SeparatorStyle::Mixed,
+    }
+}
+
+fn is_absolute_like(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    path.starts_with('/')
+        || path.starts_with("//")
+        || (bytes.len() >= 3
+            && bytes[0].is_ascii_alphabetic()
+            && bytes[1] == b':'
+            && (bytes[2] == b'/' || bytes[2] == b'\\'))
+}
+
+fn has_dot_segment(path: &str) -> bool {
+    path.split(['/', '\\'])
+        .any(|segment| segment == "." || segment == "..")
+}
+
+fn canonical_key(path: &str, cwd: &Path) -> String {
+    let mut value = path.replace('\\', "/");
+    let windows_like = has_drive_prefix(&value) || path.contains('\\');
+    if !is_absolute_like(&value) {
+        let cwd = cwd.to_string_lossy().replace('\\', "/");
+        value = format!("{cwd}/{value}");
+    }
+
+    let mut prefix = String::new();
+    let mut rest = value.as_str();
+    if has_drive_prefix(rest) {
+        prefix = rest[..2].to_ascii_lowercase();
+        rest = &rest[2..];
+    } else if rest.starts_with("//") {
+        prefix = "//".to_string();
+        rest = rest.trim_start_matches('/');
+    } else if rest.starts_with('/') {
+        prefix = "/".to_string();
+        rest = rest.trim_start_matches('/');
+    }
+
+    let mut segments: Vec<&str> = Vec::new();
+    for segment in rest.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                segments.pop();
+            }
+            _ => segments.push(segment),
+        }
+    }
+
+    let mut key = if prefix.is_empty() {
+        segments.join("/")
+    } else if prefix == "/" || prefix == "//" {
+        format!("{prefix}{}", segments.join("/"))
+    } else {
+        format!("{prefix}/{}", segments.join("/"))
+    };
+    if windows_like {
+        key.make_ascii_lowercase();
+    }
+    key
+}
+
+fn has_drive_prefix(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn absolute_rejects_relative_include() {
+        let err = validate_strict_paths(
+            &args(&["-c", "main.cpp", "-Iinclude"]),
+            Path::new("/work"),
+            StrictPathMode::Absolute,
+        )
+        .unwrap_err();
+        assert_eq!(err.flag, "-I");
+        assert_eq!(err.path, "include");
+        assert!(err.reason.contains("absolute"));
+    }
+
+    #[test]
+    fn absolute_rejects_dot_segments() {
+        let err = validate_strict_paths(
+            &args(&["-IC:/Users/me/project/./src", "main.cpp"]),
+            Path::new("C:/Users/me/project"),
+            StrictPathMode::Absolute,
+        )
+        .unwrap_err();
+        assert_eq!(err.path, "C:/Users/me/project/./src");
+        assert!(err.reason.contains("normalized"));
+    }
+
+    #[test]
+    fn absolute_rejects_backslashes() {
+        let err = validate_strict_paths(
+            &args(&["-I", r"C:\Users\me\project\src", "main.cpp"]),
+            Path::new("C:/Users/me/project"),
+            StrictPathMode::Absolute,
+        )
+        .unwrap_err();
+        assert_eq!(err.flag, "-I");
+        assert!(err.reason.contains("forward-slash"));
+    }
+
+    #[test]
+    fn consistent_rejects_mixed_separators_in_one_path() {
+        let err = validate_strict_paths(
+            &args(&["-Ici/meson/native\\fastled.dll.p", "main.cpp"]),
+            Path::new("C:/Users/me/project"),
+            StrictPathMode::Consistent,
+        )
+        .unwrap_err();
+        assert_eq!(err.flag, "-I");
+        assert!(err.reason.contains("mixed"));
+    }
+
+    #[test]
+    fn consistent_rejects_same_path_with_different_spellings() {
+        let err = validate_strict_paths(
+            &args(&[
+                "-IC:/Users/me/fastled6/./src",
+                "-I",
+                "C:/Users/me/fastled6/src",
+                "main.cpp",
+            ]),
+            Path::new("C:/Users/me/fastled6"),
+            StrictPathMode::Consistent,
+        )
+        .unwrap_err();
+        assert_eq!(err.flag, "-I");
+        assert_eq!(err.path, "C:/Users/me/fastled6/src");
+        assert!(err.reason.contains("same canonical path"));
+    }
+
+    #[test]
+    fn consistent_accepts_repeated_identical_path() {
+        validate_strict_paths(
+            &args(&["-I", "src", "-I", "src", "main.cpp"]),
+            Path::new("/work"),
+            StrictPathMode::Consistent,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn strict_paths_catches_paths_inside_response_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("flags.rsp"),
+            "-IC:/Users/me/fastled6/./src -IC:/Users/me/fastled6/src",
+        )
+        .unwrap();
+        let expanded =
+            crate::response_file::expand_response_files_in(&args(&["@flags.rsp"]), dir.path())
+                .unwrap();
+
+        let err =
+            validate_strict_paths(&expanded, dir.path(), StrictPathMode::Consistent).unwrap_err();
+
+        assert_eq!(err.flag, "-I");
+        assert_eq!(err.path, "C:/Users/me/fastled6/src");
+        assert!(err.reason.contains("same canonical path"));
+    }
+
+    #[test]
+    fn off_ignores_violations() {
+        validate_strict_paths(
+            &args(&["-Ici/meson/native\\fastled.dll.p", "main.cpp"]),
+            Path::new("/work"),
+            StrictPathMode::Off,
+        )
+        .unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- add `--strict-paths=<off|consistent|absolute>` and `ZCCACHE_STRICT_PATHS` for compiler wrapper invocations
- validate include-like compiler path flags before dispatch, including mixed separators and duplicate canonical paths with different spellings
- document strict path mode and add focused unit coverage for CLI parsing, response files, and Windows-style path hazards

Fixes #32.

## Verification
- `bash ./_cargo fmt --all -- --check`
- `bash ./_cargo test -p zccache-compiler strict_paths`
- `bash ./_cargo test -p zccache-cli strict_path`
- `bash ./_cargo clippy -p zccache-compiler -p zccache-cli -- -D warnings`
- `git diff --check`

Note: I cleared generated Cargo incremental files under `target/x86_64-pc-windows-msvc/debug/incremental` after the local disk filled and clippy failed to write its query cache. No tracked files were removed.
