### PR TITLE
Add hot target snapshot mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ How it works:
 | `cache-cargo-registry` | `true` | Cache cargo registry index + crate files + git deps |
 | `cache-compilation` | `true` | Cache compilation units via zccache daemon |
 | `cache-target` | `false` | Cache target snapshot + run `zccache warm`; opt in only for workflows where target snapshots are worth the disk budget |
+| `target-snapshot-mode` | `hot` | `hot` saves Cargo metadata plus target files read or modified during the job; `full` saves the pruned target tree |
 | `target-snapshot-max-size` | `2GiB` | Skip or fail target snapshot save when the pruned snapshot exceeds this size; use `0` for unlimited |
 | `target-snapshot-too-large` | `skip` | `skip` oversized target snapshots or `fail` cleanup |
 | `target-prune-incremental` | `true` | Remove `target/**/incremental` before creating a snapshot |
@@ -489,7 +490,7 @@ The action now treats the two cache layers differently:
 
 - Compilation cache fallback stays enabled by default. That preserves fast incremental reuse across nearby commits while still letting zccache validate cache hits when `rustc` actually runs.
 - Target snapshot fallback is disabled by default. Reusing stale Cargo fingerprints and build-script outputs across different source trees can make a PR merge ref look fresh when it is not.
-- Target snapshots are disabled by default because Cargo does not garbage collect `target/`. Most CI should use the compilation and registry caches only. Enable `cache-target: true` for jobs where skipping Cargo fingerprint work matters enough to spend extra cache and runner disk.
+- Target snapshots are disabled by default because Cargo does not garbage collect `target/`. When enabled, the default `target-snapshot-mode: hot` saves Cargo freshness metadata plus target files read or modified during the job instead of archiving the whole tree. Use `target-snapshot-mode: full` only for tightly scoped jobs where the target directory is known to stay bounded.
 - Target snapshot saves prune `target/**/incremental` by default, can optionally prune `target/**/build/*/out`, and skip saving when the pruned snapshot exceeds `target-snapshot-max-size`.
 
 If you want the old fastest-possible behavior for developer CI, opt back in explicitly:

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,13 @@ inputs:
       suffixes. Set to "0" or "unlimited" to disable the size guard.
     required: false
     default: "2GiB"
+  target-snapshot-mode:
+    description: >
+      Target snapshot mode when cache-target is true. "hot" saves Cargo
+      metadata plus files read or modified during the job using atime/mtime
+      checks. "full" saves the pruned target tree.
+    required: false
+    default: "hot"
   target-snapshot-too-large:
     description: >
       Behavior when the target snapshot exceeds target-snapshot-max-size.
@@ -342,9 +349,11 @@ runs:
         echo "${{ inputs.cache-target }}" > ~/.zccache-action-state/cache-target
         echo "${{ inputs.target-dir }}" > ~/.zccache-action-state/target-dir
         echo "${{ inputs.target-snapshot-max-size }}" > ~/.zccache-action-state/target-snapshot-max-size
+        echo "${{ inputs.target-snapshot-mode }}" > ~/.zccache-action-state/target-snapshot-mode
         echo "${{ inputs.target-snapshot-too-large }}" > ~/.zccache-action-state/target-snapshot-too-large
         echo "${{ inputs.target-prune-incremental }}" > ~/.zccache-action-state/target-prune-incremental
         echo "${{ inputs.target-prune-build-script-out }}" > ~/.zccache-action-state/target-prune-build-script-out
+        date +%s > ~/.zccache-action-state/target-cache-marker-epoch
 
 branding:
   icon: "zap"

--- a/action/cleanup/README.md
+++ b/action/cleanup/README.md
@@ -17,10 +17,14 @@ Always call with `if: always()`:
 2. Stops the zccache daemon
 3. Saves compilation cache to GHA cache
 4. Saves cargo registry cache to GHA cache
-5. If `cache-target: true`, prunes and bounds the cargo target snapshot before saving
+5. If `cache-target: true`, selects, prunes, and bounds the cargo target snapshot before saving
 6. Cleans up temporary state files
 
 Cache keys are read from state written by the setup action (`~/.zccache-action-state/`).
+
+The default target snapshot mode is `hot`: cleanup saves Cargo metadata and
+files read or modified after setup using access and modification times. Set
+`target-snapshot-mode: full` in the main action to save the pruned target tree.
 
 ## Target Snapshot Outputs
 

--- a/action/cleanup/action.yml
+++ b/action/cleanup/action.yml
@@ -53,9 +53,11 @@ runs:
           echo "cache-target=$(cat "$STATE_DIR/cache-target" 2>/dev/null || echo 'false')" >> "$GITHUB_OUTPUT"
           echo "target-dir=$(cat "$STATE_DIR/target-dir" 2>/dev/null || echo 'target')" >> "$GITHUB_OUTPUT"
           echo "target-snapshot-max-size=$(cat "$STATE_DIR/target-snapshot-max-size" 2>/dev/null || echo '2GiB')" >> "$GITHUB_OUTPUT"
+          echo "target-snapshot-mode=$(cat "$STATE_DIR/target-snapshot-mode" 2>/dev/null || echo 'hot')" >> "$GITHUB_OUTPUT"
           echo "target-snapshot-too-large=$(cat "$STATE_DIR/target-snapshot-too-large" 2>/dev/null || echo 'skip')" >> "$GITHUB_OUTPUT"
           echo "target-prune-incremental=$(cat "$STATE_DIR/target-prune-incremental" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
           echo "target-prune-build-script-out=$(cat "$STATE_DIR/target-prune-build-script-out" 2>/dev/null || echo 'false')" >> "$GITHUB_OUTPUT"
+          echo "target-cache-marker-epoch=$(cat "$STATE_DIR/target-cache-marker-epoch" 2>/dev/null || echo '0')" >> "$GITHUB_OUTPUT"
         else
           echo "save-cache=false" >> "$GITHUB_OUTPUT"
           echo "cache-compilation=false" >> "$GITHUB_OUTPUT"
@@ -87,9 +89,11 @@ runs:
       env:
         TARGET_DIR: ${{ steps.state.outputs.target-dir }}
         TARGET_SNAPSHOT_MAX_SIZE: ${{ steps.state.outputs.target-snapshot-max-size }}
+        TARGET_SNAPSHOT_MODE: ${{ steps.state.outputs.target-snapshot-mode }}
         TARGET_SNAPSHOT_TOO_LARGE: ${{ steps.state.outputs.target-snapshot-too-large }}
         TARGET_PRUNE_INCREMENTAL: ${{ steps.state.outputs.target-prune-incremental }}
         TARGET_PRUNE_BUILD_SCRIPT_OUT: ${{ steps.state.outputs.target-prune-build-script-out }}
+        TARGET_HOT_MARKER_EPOCH: ${{ steps.state.outputs.target-cache-marker-epoch }}
       run: |
         bash "$GITHUB_ACTION_PATH/prepare-target-snapshot.sh"
 

--- a/action/cleanup/prepare-target-snapshot.sh
+++ b/action/cleanup/prepare-target-snapshot.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 parse_size_bytes() {
   local raw="${1:-0}"
   raw="${raw//[[:space:]]/}"
@@ -188,8 +190,18 @@ finish_too_large() {
 
 TARGET="${TARGET_DIR:-${TARGET:-target}}"
 SNAPSHOT_DIR="${TARGET_SNAPSHOT_DIR:-$HOME/.zccache-target-meta}"
+SNAPSHOT_MODE="$(printf '%s' "${TARGET_SNAPSHOT_MODE:-hot}" | tr '[:upper:]' '[:lower:]')"
+HOT_MARKER_EPOCH="${TARGET_HOT_MARKER_EPOCH:-0}"
 MAX_SIZE="${TARGET_SNAPSHOT_MAX_SIZE:-2GiB}"
 TOO_LARGE_POLICY="$(printf '%s' "${TARGET_SNAPSHOT_TOO_LARGE:-skip}" | tr '[:upper:]' '[:lower:]')"
+
+case "$SNAPSHOT_MODE" in
+  "hot"|"full") ;;
+  *)
+    echo "Invalid target snapshot mode: $SNAPSHOT_MODE" >&2
+    exit 2
+    ;;
+esac
 
 case "$TOO_LARGE_POLICY" in
   "skip"|"fail") ;;
@@ -228,16 +240,44 @@ if is_true "${TARGET_PRUNE_BUILD_SCRIPT_OUT:-false}"; then
 fi
 
 CANDIDATE_BYTES="$(snapshot_candidate_bytes "$TARGET")"
-if [ "$MAX_BYTES" -gt 0 ] && [ "$CANDIDATE_BYTES" -gt "$MAX_BYTES" ]; then
+if [ "$SNAPSHOT_MODE" = "full" ] && [ "$MAX_BYTES" -gt 0 ] && [ "$CANDIDATE_BYTES" -gt "$MAX_BYTES" ]; then
   finish_too_large "$CANDIDATE_BYTES"
 fi
 
-tar_excludes=(--exclude='incremental' --exclude='*/incremental')
-if is_true "${TARGET_PRUNE_BUILD_SCRIPT_OUT:-false}"; then
-  tar_excludes+=(--exclude='*/build/*/out')
+if [ "$SNAPSHOT_MODE" = "hot" ]; then
+  LIST_FILE="$SNAPSHOT_DIR/hot-target-files.list"
+  selector_args=(
+    "$SCRIPT_DIR/select-hot-target.py"
+    --target "$TARGET"
+    --marker-epoch "$HOT_MARKER_EPOCH"
+    --list-file "$LIST_FILE"
+  )
+  if is_true "${TARGET_PRUNE_BUILD_SCRIPT_OUT:-false}"; then
+    selector_args+=(--prune-build-script-out)
+  fi
+  HOT_STATS="$(python "${selector_args[@]}")"
+  CANDIDATE_BYTES="$(python - "$HOT_STATS" <<'PY'
+import json
+import sys
+print(json.loads(sys.argv[1])["selected_bytes"])
+PY
+)"
+  if [ "$MAX_BYTES" -gt 0 ] && [ "$CANDIDATE_BYTES" -gt "$MAX_BYTES" ]; then
+    finish_too_large "$CANDIDATE_BYTES"
+  fi
+  if [ ! -s "$LIST_FILE" ]; then
+    finish_skipped "no-hot-target-files"
+  fi
+  tar_command=(tar -cf "$SNAPSHOT_TAR" -C "$TARGET" --null -T "$LIST_FILE")
+else
+  tar_args=(--exclude='incremental' --exclude='*/incremental' -C "$TARGET" .)
+  if is_true "${TARGET_PRUNE_BUILD_SCRIPT_OUT:-false}"; then
+    tar_args=(--exclude='incremental' --exclude='*/incremental' --exclude='*/build/*/out' -C "$TARGET" .)
+  fi
+  tar_command=(tar -cf "$SNAPSHOT_TAR" "${tar_args[@]}")
 fi
 
-if ! tar "${tar_excludes[@]}" -cf "$SNAPSHOT_TAR" -C "$TARGET" . 2>/dev/null; then
+if ! "${tar_command[@]}" 2>/dev/null; then
   rm -f -- "$SNAPSHOT_TAR"
   finish_skipped "tar-failed"
 fi

--- a/action/cleanup/select-hot-target.py
+++ b/action/cleanup/select-hot-target.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+
+MUST_KEEP_NAMES = {"CACHEDIR.TAG", ".rustc_info.json"}
+MUST_KEEP_SUFFIXES = {".d", ".rmeta"}
+BUILD_METADATA_NAMES = {"output", "invoked.timestamp", "root-output"}
+
+
+def _is_incremental(path: Path) -> bool:
+    return "incremental" in path.parts
+
+
+def _is_build_out(path: Path) -> bool:
+    return "build" in path.parts and "out" in path.parts
+
+
+def _is_cargo_metadata(path: Path) -> bool:
+    if path.name in MUST_KEEP_NAMES:
+        return True
+    if path.suffix in MUST_KEEP_SUFFIXES:
+        return True
+    if ".fingerprint" in path.parts:
+        return True
+    return "build" in path.parts and path.name in BUILD_METADATA_NAMES
+
+
+def select_hot_files(
+    target: Path,
+    marker_epoch: float,
+    prune_build_script_out: bool,
+) -> tuple[list[str], dict[str, int]]:
+    selected: list[str] = []
+    seen_inodes: set[tuple[int, int]] = set()
+    stats = {
+        "visited_files": 0,
+        "selected_files": 0,
+        "selected_bytes": 0,
+        "skipped_files": 0,
+        "skipped_bytes": 0,
+        "metadata_files": 0,
+        "hot_files": 0,
+    }
+
+    for file_path in target.rglob("*"):
+        if not file_path.is_file():
+            continue
+        rel = file_path.relative_to(target)
+        stats["visited_files"] += 1
+        try:
+            stat = file_path.stat()
+        except OSError:
+            stats["skipped_files"] += 1
+            continue
+
+        inode_key = (stat.st_dev, stat.st_ino)
+        size = 0 if inode_key in seen_inodes else stat.st_size
+        seen_inodes.add(inode_key)
+
+        if _is_incremental(rel) or (prune_build_script_out and _is_build_out(rel)):
+            stats["skipped_files"] += 1
+            stats["skipped_bytes"] += size
+            continue
+
+        metadata = _is_cargo_metadata(rel)
+        hot = marker_epoch > 0 and (
+            stat.st_mtime >= marker_epoch or stat.st_atime >= marker_epoch
+        )
+        if not metadata and not hot:
+            stats["skipped_files"] += 1
+            stats["skipped_bytes"] += size
+            continue
+
+        selected.append(rel.as_posix())
+        stats["selected_files"] += 1
+        stats["selected_bytes"] += size
+        if metadata:
+            stats["metadata_files"] += 1
+        if hot:
+            stats["hot_files"] += 1
+
+    return selected, stats
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--marker-epoch", type=float, default=0)
+    parser.add_argument("--prune-build-script-out", action="store_true")
+    parser.add_argument("--list-file", required=True)
+    args = parser.parse_args()
+
+    selected, stats = select_hot_files(
+        target=Path(args.target),
+        marker_epoch=args.marker_epoch,
+        prune_build_script_out=args.prune_build_script_out,
+    )
+    list_file = Path(args.list_file)
+    list_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(list_file, "wb") as fh:
+        for item in selected:
+            fh.write(os.fsencode(item))
+            fh.write(b"\0")
+    print(json.dumps(stats, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/action/cleanup/tests/test_prepare_target_snapshot.sh
+++ b/action/cleanup/tests/test_prepare_target_snapshot.sh
@@ -64,6 +64,8 @@ run_prepare() {
   TARGET_SNAPSHOT_TOO_LARGE="${4:-skip}" \
   TARGET_PRUNE_INCREMENTAL="${5:-true}" \
   TARGET_PRUNE_BUILD_SCRIPT_OUT="${6:-false}" \
+  TARGET_SNAPSHOT_MODE="${8:-full}" \
+  TARGET_HOT_MARKER_EPOCH="${9:-0}" \
   GITHUB_OUTPUT="$7" \
   bash "$SCRIPT"
 }
@@ -86,7 +88,7 @@ test_prunes_incremental_and_excludes_from_tar() {
   make_file "$target/debug/incremental/foo/s-cache.bin" 64
   make_file "$target/release/incremental/bar/s-cache.bin" 32
 
-  run_prepare "$target" "$snapshot" 0 skip true false "$output"
+  run_prepare "$target" "$snapshot" 0 skip true false "$output" full
 
   assert_file_missing "$target/debug/incremental"
   assert_file_missing "$target/release/incremental"
@@ -111,7 +113,7 @@ test_optionally_prunes_build_script_out() {
   make_file "$target/debug/build/libz-sys-abc/build-script-build" 8
   make_file "$target/debug/deps/libz_sys.rlib" 8
 
-  run_prepare "$target" "$snapshot" 0 skip true true "$output"
+  run_prepare "$target" "$snapshot" 0 skip true true "$output" full
 
   assert_file_missing "$target/debug/build/libz-sys-abc/out"
   assert_file_exists "$snapshot/target-meta.tar"
@@ -131,7 +133,7 @@ test_oversize_skip_does_not_create_tar() {
 
   make_file "$target/debug/deps/libhuge.rlib" 64
 
-  run_prepare "$target" "$snapshot" 16B skip true false "$output"
+  run_prepare "$target" "$snapshot" 16B skip true false "$output" full
 
   assert_file_missing "$snapshot/target-meta.tar"
   assert_contains "$output" "snapshot-saved=false"
@@ -147,7 +149,7 @@ test_oversize_fail_returns_nonzero() {
 
   make_file "$target/debug/deps/libhuge.rlib" 64
 
-  if run_prepare "$target" "$snapshot" 16B fail true false "$output"; then
+  if run_prepare "$target" "$snapshot" 16B fail true false "$output" full; then
     fail "expected oversize fail policy to return non-zero"
   fi
 
@@ -156,10 +158,55 @@ test_oversize_fail_returns_nonzero() {
   assert_contains "$output" "snapshot-skipped-reason=target-too-large"
 }
 
+test_hot_mode_selects_metadata_and_accessed_files() {
+  local tmp target snapshot output listing marker
+  tmp="$(new_tmp)"
+  target="$tmp/target"
+  snapshot="$tmp/snapshot"
+  output="$tmp/output"
+  listing="$tmp/listing"
+  marker="$(python - <<'PY'
+import time
+print(int(time.time()) + 100000)
+PY
+)"
+
+  make_file "$target/debug/deps/libstale.rlib" 128
+  make_file "$target/debug/deps/libhot.rlib" 16
+  make_file "$target/debug/deps/libmeta.rmeta" 8
+  make_file "$target/debug/.fingerprint/pkg/hash" 8
+  make_file "$target/debug/incremental/pkg/s-cache.bin" 64
+
+  python - "$target" "$marker" <<'PY'
+import os
+import pathlib
+import sys
+
+target = pathlib.Path(sys.argv[1])
+marker = int(sys.argv[2])
+old = marker - 100
+for item in target.rglob("*"):
+    if item.is_file():
+        os.utime(item, (old, old))
+os.utime(target / "debug" / "deps" / "libhot.rlib", (old, marker + 10))
+PY
+
+  run_prepare "$target" "$snapshot" 0 skip true false "$output" hot "$marker"
+
+  assert_file_exists "$snapshot/target-meta.tar"
+  tar_listing "$snapshot/target-meta.tar" "$listing"
+  assert_contains "$listing" "debug/deps/libhot.rlib"
+  assert_contains "$listing" "debug/deps/libmeta.rmeta"
+  assert_contains "$listing" "debug/.fingerprint/pkg/hash"
+  assert_not_contains "$listing" "debug/deps/libstale.rlib"
+  assert_not_contains "$listing" "incremental"
+}
+
 test_parse_size
 test_prunes_incremental_and_excludes_from_tar
 test_optionally_prunes_build_script_out
 test_oversize_skip_does_not_create_tar
 test_oversize_fail_returns_nonzero
+test_hot_mode_selects_metadata_and_accessed_files
 
 echo "prepare-target-snapshot tests passed"


### PR DESCRIPTION
## Summary

- add target-snapshot-mode with hot as the default for opt-in target snapshots
- add a selector that saves Cargo metadata plus files read or modified after setup using atime/mtime and inode accounting
- pass the setup marker timestamp through cleanup and keep full snapshot mode available
- document hot vs full target snapshots

Closes #71.

## Validation

- bash -n action/cleanup/prepare-target-snapshot.sh
- bash action/cleanup/tests/test_prepare_target_snapshot.sh
- python -m py_compile action/cleanup/select-hot-target.py
- git diff --check