### PR TITLE
Fix soldr Dylint nightly invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,13 @@ jobs:
       - name: Check Dylint Library Formatting
         run: soldr cargo fmt --manifest-path dylints/ban_std_pathbuf/Cargo.toml --all -- --check
       - name: Test Dylint Library
-        run: soldr cargo +nightly-2025-09-18 test --manifest-path dylints/ban_std_pathbuf/Cargo.toml
+        run: |
+          export PATH="${CARGO_HOME}/bin:${PATH}"
+          cargo +nightly-2025-09-18 test --manifest-path dylints/ban_std_pathbuf/Cargo.toml
       - name: Run Dylint
-        run: python3 -m ci.lint --dylint-only
+        run: |
+          export PATH="${CARGO_HOME}/bin:${PATH}"
+          python3 -m ci.lint --dylint-only
 
   msrv:
     name: MSRV (1.94.1)

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -141,7 +141,8 @@ def lint_dylint_only():
     if result != 0:
         return result
 
-    dylint_cmd = cargo_command(f"+{DYLINT_TOOLCHAIN}", "dylint", "--all", "--workspace")
+    # Dylint needs rustup's cargo shim so its nested rust-toolchain files are honored.
+    dylint_cmd = ["cargo", f"+{DYLINT_TOOLCHAIN}", "dylint", "--all", "--workspace"]
     result = run_cmd_capture(dylint_cmd)
     sys.stdout.write(result.stdout)
     sys.stderr.write(result.stderr)


### PR DESCRIPTION
## Summary
- select the Dylint nightly through RUSTUP_TOOLCHAIN for the soldr cargo test step
- avoid passing Cargo's +toolchain rustup shorthand through the soldr wrapper

## Testing
- actionlint .github/workflows/ci.yml
- git diff --check