### PR TITLE
Fix dylint nightly cargo invocation

### DIFF
--- a/ci/lint.py
+++ b/ci/lint.py
@@ -56,6 +56,13 @@ def run_cmd_capture(cmd):
     )
 
 
+def dylint_env():
+    """Run cargo-dylint under the nightly toolchain without using +toolchain syntax."""
+    env = self_build_env()
+    env["RUSTUP_TOOLCHAIN"] = DYLINT_TOOLCHAIN
+    return env
+
+
 def ensure_dylint_aliases():
     """Create cargo-dylint's expected `name@toolchain` aliases when missing."""
     libraries_root = SCRIPT_DIR / "target" / "dylint" / "libraries"
@@ -141,13 +148,27 @@ def lint_dylint_only():
     if result != 0:
         return result
 
-    # Dylint needs rustup's cargo shim so its nested rust-toolchain files are honored.
-    dylint_cmd = ["cargo", f"+{DYLINT_TOOLCHAIN}", "dylint", "--all", "--workspace"]
-    result = run_cmd_capture(dylint_cmd)
+    dylint_cmd = cargo_command("dylint", "--all", "--workspace")
+    result = subprocess.run(
+        dylint_cmd,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=str(SCRIPT_DIR),
+        env=dylint_env(),
+        capture_output=True,
+    )
     sys.stdout.write(result.stdout)
     sys.stderr.write(result.stderr)
     if result.returncode != 0 and ensure_dylint_aliases():
-        result = run_cmd(dylint_cmd)
+        result = subprocess.run(
+            dylint_cmd,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=str(SCRIPT_DIR),
+            env=dylint_env(),
+        )
     return result.returncode
 
 


### PR DESCRIPTION
## Summary
- run cargo-dylint with RUSTUP_TOOLCHAIN=nightly-2025-09-18 instead of cargo +nightly syntax
- preserve the alias-repair retry path under the same nightly environment

## Failure
The Dylint job failed because Cargo treated +nightly-2025-09-18 as a subcommand when invoked through the current soldr/setup path:

`
error: no such command: '+nightly-2025-09-18'
help: invoke cargo through rustup to handle +toolchain directives
`

## Verification
- uv run python -m compileall ci/lint.py
- rg -n '\\+nightly|cargo \\+|DYLINT_TOOLCHAIN' .github ci
- git diff --check