### PR TITLE
Update Dylint nightly for MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           cache: true
           cache-key-suffix: dylint
       - name: Install Dylint nightly toolchain
-        run: rustup toolchain install nightly-2025-09-18 --component llvm-tools-preview --component rust-src --component rustc-dev --profile minimal
+        run: rustup toolchain install nightly-2026-03-26 --component llvm-tools-preview --component rust-src --component rustc-dev --profile minimal
       - name: Install stable Rust components
         run: rustup component add rustfmt
       - name: Install Dylint
@@ -49,7 +49,7 @@ jobs:
       - name: Test Dylint Library
         run: |
           export PATH="${CARGO_HOME}/bin:${PATH}"
-          cargo +nightly-2025-09-18 test --manifest-path dylints/ban_std_pathbuf/Cargo.toml
+          cargo +nightly-2026-03-26 test --manifest-path dylints/ban_std_pathbuf/Cargo.toml
       - name: Run Dylint
         run: |
           export PATH="${CARGO_HOME}/bin:${PATH}"

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -17,7 +17,7 @@ from ci.release_checks import ReleaseCheckError, validate_release_metadata
 from ci.soldr import cargo_command, rust_tool_command, self_build_env
 
 SCRIPT_DIR = Path(__file__).parent.parent.resolve()
-DYLINT_TOOLCHAIN = "nightly-2025-09-18"
+DYLINT_TOOLCHAIN = "nightly-2026-03-26"
 DYLINT_COMPONENTS = ["llvm-tools-preview", "rust-src", "rustc-dev"]
 
 

--- a/dylints/ban_std_pathbuf/rust-toolchain.toml
+++ b/dylints/ban_std_pathbuf/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-09-18"
+channel = "nightly-2026-03-26"
 components = ["llvm-tools-preview", "rust-src", "rustc-dev"]


### PR DESCRIPTION
## Summary
- move the Dylint nightly pin to nightly-2026-03-26 so the workspace Dylint pass satisfies rust-version 1.94.1
- keep Dylint's nightly-only commands on the rustup Cargo shim because soldr cannot forward cargo +toolchain syntax and Dylint relies on nested rust-toolchain resolution

## Testing
- python -m py_compile ci/lint.py
- actionlint .github/workflows/ci.yml
- git diff --check