### PR TITLE
ci: add Windows ARM64 coverage to test-action.yml (closes #12)

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -55,6 +55,9 @@ jobs:
           - name: Windows x86_64
             os: windows-2025
             target: x86_64-pc-windows-msvc
+          - name: Windows ARM64
+            os: windows-2025
+            target: aarch64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Adds the missing `aarch64-pc-windows-msvc` matrix entry to `.github/workflows/test-action.yml` so the action validation workflow covers all six issue-defined platforms.

Validation:
- `git diff --check -- .github/workflows/test-action.yml`
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/test-action.yml', 'r', encoding='utf-8')); print('YAML OK')"`
