### PR TITLE
Fix #36: assert wheel script metadata in release flow

### DIFF
--- a/ci/release_workflow.py
+++ b/ci/release_workflow.py
@@ -373,7 +373,37 @@ def build_wheel(
         writer.writerow((f"{dist_info}/RECORD", "", ""))
         whl.writestr(f"{dist_info}/RECORD", buf.getvalue().encode())
 
+    assert_wheel_script_metadata(wheel_path)
     return wheel_path
+
+
+def assert_wheel_script_metadata(wheel_path: Path) -> None:
+    """Reopen a built wheel and validate executable script metadata."""
+
+    exec_mask = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    script_entries: list[str] = []
+
+    with zipfile.ZipFile(wheel_path) as whl:
+        for info in whl.infolist():
+            if ".data/scripts/" not in info.filename:
+                continue
+
+            script_entries.append(info.filename)
+            mode = info.external_attr >> 16
+            has_exec_bit = bool(mode & exec_mask)
+            is_regular_file = stat.S_ISREG(mode)
+            if info.create_system != 3 or not is_regular_file or not has_exec_bit:
+                raise SystemExit(
+                    "ERROR: invalid wheel script metadata for "
+                    f"{wheel_path.name}:{info.filename} "
+                    f"(create_system={info.create_system}, mode={oct(mode)}, "
+                    f"is_regular_file={is_regular_file}, has_exec_bit={has_exec_bit})"
+                )
+
+    if not script_entries:
+        raise SystemExit(
+            f"ERROR: no wheel script entries found in {wheel_path.name}"
+        )
 
 
 def build_all_wheels(

--- a/ci/tests/test_release_workflow.py
+++ b/ci/tests/test_release_workflow.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from ci.release_workflow import assert_wheel_script_metadata
+
+
+def _write_wheel(path: Path, *, create_system: int, mode: int) -> None:
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as whl:
+        info = zipfile.ZipInfo("zccache-1.2.3.data/scripts/zccache")
+        info.create_system = create_system
+        info.external_attr = mode << 16
+        info.compress_type = zipfile.ZIP_DEFLATED
+        whl.writestr(info, b"#!/bin/sh\n")
+
+
+def test_assert_wheel_script_metadata_accepts_executable_unix_entries(
+    tmp_path: Path,
+) -> None:
+    wheel_path = tmp_path / "zccache-1.2.3-py3-none-manylinux_2_17_x86_64.whl"
+    _write_wheel(wheel_path, create_system=3, mode=0o100755)
+
+    assert_wheel_script_metadata(wheel_path)
+
+
+def test_assert_wheel_script_metadata_rejects_bad_script_metadata(
+    tmp_path: Path,
+) -> None:
+    wheel_path = tmp_path / "zccache-1.2.3-py3-none-manylinux_2_17_x86_64.whl"
+    _write_wheel(wheel_path, create_system=0, mode=0o100644)
+
+    with pytest.raises(
+        SystemExit,
+        match=(
+            r"invalid wheel script metadata for "
+            r"zccache-1\.2\.3-py3-none-manylinux_2_17_x86_64\.whl:"
+            r"zccache-1\.2\.3\.data/scripts/zccache "
+            r"\(create_system=0, mode=0o100644, "
+            r"is_regular_file=True, has_exec_bit=False\)"
+        ),
+    ):
+        assert_wheel_script_metadata(wheel_path)


### PR DESCRIPTION
Add a post-build assertion that reopens each generated wheel and verifies every .data/scripts/* entry is marked as a Unix regular file with at least one execute bit and create_system == 3.\n\nValidation:\n- python -m pytest ci/tests/test_release_workflow.py\n- python -m py_compile ci/release_workflow.py ci/tests/test_release_workflow.py\n\nFixes #36.