### PR TITLE
Native GHA cache backend for the zccache action

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,13 +441,18 @@ and `zccache warm` for near-instant subsequent builds:
 | **Target snapshot cache** | `target/` tarball excluding `incremental/` | (new) | Cargo sees target outputs and fingerprints together |
 | **`zccache warm`** | Backfills `target/deps/` from compilation cache | (new) | Restores missing artifacts before cargo runs |
 
-On setup, the action restores the compilation and registry caches, installs
-zccache, and starts the daemon. When `cache-target: true` is set, it also
-extracts the target snapshot, runs `zccache warm` to backfill cached
-`.rlib`/`.rmeta` files, and touches all timestamps to a single consistent value.
+On setup, the action installs zccache, then restores caches through the native
+`zccache gha-cache` backend when the GitHub Actions cache runtime is available.
+When that runtime is missing, it falls back to `actions/cache`. When
+`cache-target: true` is set, it also extracts the target snapshot, runs
+`zccache warm` to backfill cached `.rlib`/`.rmeta` files, and touches all
+timestamps to a single consistent value.
 
-On cleanup: stops daemon and saves the enabled caches. Target snapshots are
-pruned and size-checked before save.
+On cleanup: stops daemon and saves the enabled caches. The native backend saves
+the compilation cache, the cargo registry archive, and the optional target
+snapshot without requiring manual cache steps in the workflow. When prefix
+restore-fallback is enabled, the action still uses `actions/cache` for that
+fallback path. Target snapshots are pruned and size-checked before save.
 
 ### CI benchmark results
 
@@ -526,8 +531,8 @@ This project is optimized for developer speed, not full artifact attestation. `z
 
 Composite GitHub Actions don't support `post` steps (automatic cleanup). The action is split into:
 
-1. **`zackees/zccache`** — setup: restore caches, install zccache, optionally warm target, start daemon, set `RUSTC_WRAPPER`
-2. **`zackees/zccache/action/cleanup`** — teardown: print stats, stop daemon, prune and save enabled caches
+1. **`zackees/zccache`** — setup: install zccache, restore caches through the native GHA cache backend when available, optionally warm target, start daemon, set `RUSTC_WRAPPER`
+2. **`zackees/zccache/action/cleanup`** — teardown: print stats, stop daemon, prune and save enabled caches through the same backend
 
 The cleanup action **must** be called with `if: always()` to ensure caches are saved even on failure.
 

--- a/action.yml
+++ b/action.yml
@@ -97,13 +97,13 @@ inputs:
 outputs:
   cache-hit-compilation:
     description: "Whether the zccache compilation cache was restored"
-    value: ${{ steps.restore-zccache.outputs.cache-hit }}
+    value: ${{ steps.restore-zccache-native.outputs.cache-hit == 'true' && 'true' || steps.restore-zccache-fallback.outputs.cache-hit == 'true' && 'true' || steps.restore-zccache-cache.outputs.cache-hit == 'true' && 'true' || 'false' }}
   cache-hit-registry:
     description: "Whether the cargo registry cache was restored"
-    value: ${{ steps.restore-registry.outputs.cache-hit }}
+    value: ${{ steps.restore-registry-native.outputs.cache-hit == 'true' && 'true' || steps.restore-registry-cache.outputs.cache-hit == 'true' && 'true' || 'false' }}
   cache-hit-target:
     description: "Whether the cargo target snapshot cache was restored"
-    value: ${{ steps.restore-target.outputs.cache-hit }}
+    value: ${{ steps.restore-target-native.outputs.cache-hit == 'true' && 'true' || steps.restore-target-fallback.outputs.cache-hit == 'true' && 'true' || steps.restore-target-cache.outputs.cache-hit == 'true' && 'true' || 'false' }}
 
 runs:
   using: "composite"
@@ -158,64 +158,14 @@ runs:
           echo "target-restore=" >> "$GITHUB_OUTPUT"
         fi
 
-    # --- Layer 1: Restore zccache compilation cache ---
-    - name: Restore zccache compilation cache
-      id: restore-zccache
-      if: inputs.cache-compilation == 'true'
-      uses: actions/cache/restore@v4
-      with:
-        path: ~/.zccache
-        key: ${{ steps.keys.outputs.compilation-key }}
-        restore-keys: ${{ steps.keys.outputs.compilation-restore }}
-
-    # --- Layer 2: Restore cargo registry cache ---
-    - name: Restore cargo registry cache
-      id: restore-registry
-      if: inputs.cache-cargo-registry == 'true'
-      uses: actions/cache/restore@v4
-      with:
-        path: |
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-        key: ${{ steps.keys.outputs.registry-key }}
-        restore-keys: ${{ steps.keys.outputs.registry-restore }}
-
-    # --- Layer 3: Restore cargo target snapshot ---
-    # Restores target/ as a single tarball (excluding incremental/). `zccache warm`
-    # also fills in cached artifacts from the compilation cache when available.
-    # Opt-in until zackees/zccache#65 adds bounded target snapshot GC.
-    - name: Restore cargo target snapshot
-      id: restore-target
-      if: inputs.cache-target == 'true'
-      uses: actions/cache/restore@v4
-      with:
-        path: ~/.zccache-target-meta
-        key: ${{ steps.keys.outputs.target-key }}
-        restore-keys: ${{ steps.keys.outputs.target-restore }}
-
-    - name: Extract target snapshot
-      if: inputs.cache-target == 'true'
+    - name: Detect cache backend
+      id: cache-backend
       shell: bash
       run: |
-        TARGET="${{ inputs.target-dir }}"
-        META_TAR="$HOME/.zccache-target-meta/target-meta.tar"
-        if [ -f "$META_TAR" ]; then
-          MAX_BYTES="$(bash "${{ github.action_path }}/action/cleanup/prepare-target-snapshot.sh" --parse-size "${{ inputs.target-snapshot-max-size }}")"
-          TAR_BYTES="$(wc -c < "$META_TAR" | tr -d '[:space:]')"
-          if [ "$MAX_BYTES" -gt 0 ] && [ "$TAR_BYTES" -gt "$MAX_BYTES" ]; then
-            rm -f "$META_TAR"
-            TOO_LARGE_POLICY="$(printf '%s' "${{ inputs.target-snapshot-too-large }}" | tr '[:upper:]' '[:lower:]')"
-            if [ "$TOO_LARGE_POLICY" = "fail" ]; then
-              echo "ERROR: restored target snapshot exceeds target-snapshot-max-size ($TAR_BYTES > $MAX_BYTES)"
-              exit 1
-            fi
-            echo "Skipping oversized restored target snapshot ($TAR_BYTES > $MAX_BYTES)"
-            exit 0
-          fi
-          mkdir -p "$TARGET"
-          tar xf "$META_TAR" -C "$TARGET" 2>/dev/null || true
-          echo "Restored target snapshot ($(du -sh "$META_TAR" | cut -f1))"
+        if [ -n "${ACTIONS_CACHE_URL:-}" ] && [ -n "${ACTIONS_RUNTIME_TOKEN:-}" ]; then
+          echo "backend=native" >> "$GITHUB_OUTPUT"
+        else
+          echo "backend=actions-cache" >> "$GITHUB_OUTPUT"
         fi
 
     # --- Install zccache ---
@@ -305,6 +255,153 @@ runs:
         # Verify install
         which zccache || { echo "ERROR: zccache not found on PATH"; echo "PATH=$PATH"; exit 1; }
 
+    # --- Layer 1: Restore zccache compilation cache ---
+    - name: Restore zccache compilation cache
+      id: restore-zccache-native
+      if: steps.cache-backend.outputs.backend == 'native' && inputs.cache-compilation == 'true'
+      shell: bash
+      run: |
+        set +e
+        OUTPUT="$(zccache gha-cache restore \
+          --key "${{ steps.keys.outputs.compilation-key }}" \
+          --path "$HOME/.zccache" 2>&1)"
+        STATUS=$?
+        set -e
+        printf '%s\n' "$OUTPUT"
+        if [ "$STATUS" -eq 0 ]; then
+          echo "cache-hit=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if printf '%s\n' "$OUTPUT" | grep -qi "cache miss"; then
+          echo "cache-hit=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        exit "$STATUS"
+
+    - name: Restore zccache compilation cache fallback
+      id: restore-zccache-fallback
+      if: steps.cache-backend.outputs.backend == 'native' && inputs.cache-compilation == 'true' && inputs.compilation-restore-fallback == 'true' && steps.restore-zccache-native.outputs.cache-hit != 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.zccache
+        key: ${{ steps.keys.outputs.compilation-key }}
+        restore-keys: ${{ steps.keys.outputs.compilation-restore }}
+
+    - name: Restore zccache compilation cache
+      id: restore-zccache-cache
+      if: steps.cache-backend.outputs.backend != 'native' && inputs.cache-compilation == 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.zccache
+        key: ${{ steps.keys.outputs.compilation-key }}
+        restore-keys: ${{ steps.keys.outputs.compilation-restore }}
+
+    # --- Layer 2: Restore cargo registry cache ---
+    - name: Restore cargo registry archive
+      id: restore-registry-native
+      if: steps.cache-backend.outputs.backend == 'native' && inputs.cache-cargo-registry == 'true'
+      shell: bash
+      run: |
+        set +e
+        OUTPUT="$(zccache gha-cache restore \
+          --key "${{ steps.keys.outputs.registry-key }}" \
+          --path "$HOME/.zccache/cargo-registry" 2>&1)"
+        STATUS=$?
+        set -e
+        printf '%s\n' "$OUTPUT"
+        if [ "$STATUS" -eq 0 ]; then
+          zccache cargo-registry restore \
+            --key "${{ steps.keys.outputs.registry-key }}" \
+            --cargo-home "$HOME/.cargo"
+          echo "cache-hit=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if printf '%s\n' "$OUTPUT" | grep -qi "cache miss"; then
+          echo "cache-hit=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        exit "$STATUS"
+
+    - name: Restore cargo registry cache
+      id: restore-registry-cache
+      if: steps.cache-backend.outputs.backend != 'native' && inputs.cache-cargo-registry == 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ steps.keys.outputs.registry-key }}
+        restore-keys: ${{ steps.keys.outputs.registry-restore }}
+
+    # --- Layer 3: Restore cargo target snapshot ---
+    # Restores target/ as a single tarball (excluding incremental/). `zccache warm`
+    # also fills in cached artifacts from the compilation cache when available.
+    # Opt-in until zackees/zccache#65 adds bounded target snapshot GC.
+    - name: Restore cargo target snapshot
+      id: restore-target-native
+      if: steps.cache-backend.outputs.backend == 'native' && inputs.cache-target == 'true'
+      shell: bash
+      run: |
+        set +e
+        OUTPUT="$(zccache gha-cache restore \
+          --key "${{ steps.keys.outputs.target-key }}" \
+          --path "$HOME/.zccache-target-meta" 2>&1)"
+        STATUS=$?
+        set -e
+        printf '%s\n' "$OUTPUT"
+        if [ "$STATUS" -eq 0 ]; then
+          echo "cache-hit=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if printf '%s\n' "$OUTPUT" | grep -qi "cache miss"; then
+          echo "cache-hit=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        exit "$STATUS"
+
+    - name: Restore cargo target snapshot fallback
+      id: restore-target-fallback
+      if: steps.cache-backend.outputs.backend == 'native' && inputs.cache-target == 'true' && inputs.target-restore-fallback == 'true' && steps.restore-target-native.outputs.cache-hit != 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.zccache-target-meta
+        key: ${{ steps.keys.outputs.target-key }}
+        restore-keys: ${{ steps.keys.outputs.target-restore }}
+
+    - name: Restore cargo target snapshot
+      id: restore-target-cache
+      if: steps.cache-backend.outputs.backend != 'native' && inputs.cache-target == 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.zccache-target-meta
+        key: ${{ steps.keys.outputs.target-key }}
+        restore-keys: ${{ steps.keys.outputs.target-restore }}
+
+    - name: Extract target snapshot
+      if: inputs.cache-target == 'true'
+      shell: bash
+      run: |
+        TARGET="${{ inputs.target-dir }}"
+        META_TAR="$HOME/.zccache-target-meta/target-meta.tar"
+        if [ -f "$META_TAR" ]; then
+          MAX_BYTES="$(bash "${{ github.action_path }}/action/cleanup/prepare-target-snapshot.sh" --parse-size "${{ inputs.target-snapshot-max-size }}")"
+          TAR_BYTES="$(wc -c < "$META_TAR" | tr -d '[:space:]')"
+          if [ "$MAX_BYTES" -gt 0 ] && [ "$TAR_BYTES" -gt "$MAX_BYTES" ]; then
+            rm -f "$META_TAR"
+            TOO_LARGE_POLICY="$(printf '%s' "${{ inputs.target-snapshot-too-large }}" | tr '[:upper:]' '[:lower:]')"
+            if [ "$TOO_LARGE_POLICY" = "fail" ]; then
+              echo "ERROR: restored target snapshot exceeds target-snapshot-max-size ($TAR_BYTES > $MAX_BYTES)"
+              exit 1
+            fi
+            echo "Skipping oversized restored target snapshot ($TAR_BYTES > $MAX_BYTES)"
+            exit 0
+          fi
+          mkdir -p "$TARGET"
+          tar xf "$META_TAR" -C "$TARGET" 2>/dev/null || true
+          echo "Restored target snapshot ($(du -sh "$META_TAR" | cut -f1))"
+        fi
+
     # --- Pre-populate target/ from zccache before daemon starts ---
     # warm reads the redb index directly (no daemon needed), fills in
     # .rlib/.rmeta from cached artifacts, and touches mtimes. This is tied to
@@ -353,6 +450,7 @@ runs:
         echo "${{ inputs.target-snapshot-too-large }}" > ~/.zccache-action-state/target-snapshot-too-large
         echo "${{ inputs.target-prune-incremental }}" > ~/.zccache-action-state/target-prune-incremental
         echo "${{ inputs.target-prune-build-script-out }}" > ~/.zccache-action-state/target-prune-build-script-out
+        echo "${{ steps.cache-backend.outputs.backend }}" > ~/.zccache-action-state/cache-backend
         date +%s > ~/.zccache-action-state/target-cache-marker-epoch
 
 branding:

--- a/action/README.md
+++ b/action/README.md
@@ -56,8 +56,8 @@ steps:
 
 The action has two parts because composite actions lack `post` steps:
 
-1. **`zackees/zccache`** (setup) restores caches, installs zccache, and starts the daemon. When `cache-target: true` is set, it also restores the target snapshot and runs `zccache warm`.
-2. **`zackees/zccache/action/cleanup`** (teardown) stops the daemon and saves caches.
+1. **`zackees/zccache`** (setup) installs zccache, restores caches through the native GHA cache backend when available, and starts the daemon. When `cache-target: true` is set, it also restores the target snapshot and runs `zccache warm`.
+2. **`zackees/zccache/action/cleanup`** (teardown) stops the daemon and saves caches through the same backend.
 
 The cleanup action must be called with `if: always()` to ensure caches are saved even on failure.
 
@@ -70,6 +70,11 @@ The cleanup action must be called with `if: always()` to ensure caches are saved
 | Target snapshot | `target/` tarball excluding `incremental/` | Cargo fingerprint recomputation |
 
 State is passed from setup to cleanup via `~/.zccache-action-state/`.
+On GitHub Actions, the action prefers `zccache gha-cache restore/save` so users do
+not need to add `actions/cache` steps themselves. It falls back to
+`actions/cache` when the runner does not expose the GHA cache runtime, and it
+still uses `actions/cache` for prefix restore-key fallback when those inputs are
+enabled.
 
 Target snapshots are disabled by default because Cargo does not garbage collect
 `target/`. Most CI should keep the compilation and registry caches enabled and

--- a/action/cleanup/action.yml
+++ b/action/cleanup/action.yml
@@ -47,6 +47,7 @@ runs:
           echo "compilation-key=$(cat "$STATE_DIR/compilation-key" 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
           echo "registry-key=$(cat "$STATE_DIR/registry-key" 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
           echo "target-key=$(cat "$STATE_DIR/target-key" 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
+          echo "cache-backend=$(cat "$STATE_DIR/cache-backend" 2>/dev/null || echo 'actions-cache')" >> "$GITHUB_OUTPUT"
           echo "save-cache=$(cat "$STATE_DIR/save-cache" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
           echo "cache-compilation=$(cat "$STATE_DIR/cache-compilation" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
           echo "cache-registry=$(cat "$STATE_DIR/cache-registry" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
@@ -59,6 +60,7 @@ runs:
           echo "target-prune-build-script-out=$(cat "$STATE_DIR/target-prune-build-script-out" 2>/dev/null || echo 'false')" >> "$GITHUB_OUTPUT"
           echo "target-cache-marker-epoch=$(cat "$STATE_DIR/target-cache-marker-epoch" 2>/dev/null || echo '0')" >> "$GITHUB_OUTPUT"
         else
+          echo "cache-backend=actions-cache" >> "$GITHUB_OUTPUT"
           echo "save-cache=false" >> "$GITHUB_OUTPUT"
           echo "cache-compilation=false" >> "$GITHUB_OUTPUT"
           echo "cache-registry=false" >> "$GITHUB_OUTPUT"
@@ -66,14 +68,35 @@ runs:
         fi
 
     - name: Save zccache compilation cache
-      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-compilation == 'true'
+      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-backend == 'native' && steps.state.outputs.cache-compilation == 'true'
+      shell: bash
+      run: |
+        zccache gha-cache save \
+          --key "${{ steps.state.outputs.compilation-key }}" \
+          --path "$HOME/.zccache"
+
+    - name: Save zccache compilation cache
+      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-backend != 'native' && steps.state.outputs.cache-compilation == 'true'
       uses: actions/cache/save@v4
       with:
         path: ~/.zccache
         key: ${{ steps.state.outputs.compilation-key }}
 
+    - name: Save cargo registry archive
+      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-backend == 'native' && steps.state.outputs.cache-registry == 'true'
+      shell: bash
+      run: |
+        zccache cargo-registry save \
+          --key "${{ steps.state.outputs.registry-key }}" \
+          --cargo-home "$HOME/.cargo"
+        if [ -f "$HOME/.zccache/cargo-registry/${{ steps.state.outputs.registry-key }}.tar.gz" ]; then
+          zccache gha-cache save \
+            --key "${{ steps.state.outputs.registry-key }}" \
+            --path "$HOME/.zccache/cargo-registry"
+        fi
+
     - name: Save cargo registry cache
-      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-registry == 'true'
+      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-backend != 'native' && steps.state.outputs.cache-registry == 'true'
       uses: actions/cache/save@v4
       with:
         path: |
@@ -98,7 +121,15 @@ runs:
         bash "$GITHUB_ACTION_PATH/prepare-target-snapshot.sh"
 
     - name: Save cargo target snapshot
-      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-target == 'true' && steps.target-snapshot.outputs.snapshot-saved == 'true'
+      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-backend == 'native' && steps.state.outputs.cache-target == 'true' && steps.target-snapshot.outputs.snapshot-saved == 'true'
+      shell: bash
+      run: |
+        zccache gha-cache save \
+          --key "${{ steps.state.outputs.target-key }}" \
+          --path "$HOME/.zccache-target-meta"
+
+    - name: Save cargo target snapshot
+      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-backend != 'native' && steps.state.outputs.cache-target == 'true' && steps.target-snapshot.outputs.snapshot-saved == 'true'
       uses: actions/cache/save@v4
       with:
         path: ~/.zccache-target-meta

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -4430,14 +4430,18 @@ mod tests {
     #[test]
     fn trim_request_cache_removes_old_entries() {
         let cache = DashMap::new();
-        let now = std::time::Instant::now();
-        cache.insert(ContentHash::from_bytes([1; 32]), test_request_entry(now));
+        let max_age = std::time::Duration::from_millis(1);
         cache.insert(
             ContentHash::from_bytes([2; 32]),
-            test_request_entry(now - std::time::Duration::from_secs(600)),
+            test_request_entry(std::time::Instant::now()),
+        );
+        std::thread::sleep(max_age * 2);
+        cache.insert(
+            ContentHash::from_bytes([1; 32]),
+            test_request_entry(std::time::Instant::now()),
         );
 
-        let removed = trim_request_cache(&cache, EPHEMERAL_CACHE_MAX_AGE);
+        let removed = trim_request_cache(&cache, max_age);
 
         assert_eq!(removed, 1);
         assert_eq!(cache.len(), 1);


### PR DESCRIPTION
Fixes #11

Use zccache gha-cache restore/save in the public GitHub Action path when the runner exposes the GHA cache runtime. Keep ctions/cache only as a fallback for missing runtime support and prefix restore-key fallback. Update the action docs to describe the native path and the cleanup flow.