### PR TITLE
Prefix comparative perf temp dirs

### DIFF
--- a/crates/zccache-daemon/tests/perf_bench_test.rs
+++ b/crates/zccache-daemon/tests/perf_bench_test.rs
@@ -5,7 +5,7 @@
 //!   - `perf_response_file`: C++ same workload but args passed via large nested response files
 //!   - `perf_rustc_zccache_vs_sccache`: Rust single-file compilation (lib crates)
 //!
-//! Each tool gets its own fresh tempdir to avoid OS page cache cross-contamination.
+//! Each tool gets its own fresh zccache-prefixed tempdir to avoid OS page cache cross-contamination.
 //!
 //! Run with: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test perf_bench_test -- --nocapture --ignored
 
@@ -604,7 +604,7 @@ async fn perf_warm_cache_zccache_vs_sccache() {
     eprintln!();
 
     // ── Baseline (fresh dir) ──────────────────────────────────────────
-    let bl_dir = tempfile::tempdir().unwrap();
+    let bl_dir = zccache_test_support::temp_cache_dir().unwrap();
     generate_project(bl_dir.path());
 
     eprintln!("  [1/3] Bare clang (baseline)");
@@ -635,11 +635,11 @@ async fn perf_warm_cache_zccache_vs_sccache() {
     let sccache_multi_times;
 
     if let Some(sccache_bin) = find_sccache() {
-        let sc_dir = tempfile::tempdir().unwrap();
+        let sc_dir = zccache_test_support::temp_cache_dir().unwrap();
         generate_project(sc_dir.path());
 
         // Use a fresh cache dir so previous sccache usage doesn't pollute results.
-        let sc_cache_dir = tempfile::tempdir().unwrap();
+        let sc_cache_dir = zccache_test_support::temp_cache_dir().unwrap();
         let sc_cache_str = sc_cache_dir.path().to_string_lossy().into_owned();
 
         // Set SCCACHE_DIR for this process so both server and client see it.
@@ -734,7 +734,7 @@ async fn perf_warm_cache_zccache_vs_sccache() {
     }
 
     // ── zccache (fresh dir, in-process daemon) ────────────────────────
-    let zc_dir = tempfile::tempdir().unwrap();
+    let zc_dir = zccache_test_support::temp_cache_dir().unwrap();
     generate_project(zc_dir.path());
     let zc_cwd = zc_dir.path().to_string_lossy().into_owned();
 
@@ -939,7 +939,7 @@ async fn perf_response_file() {
     eprintln!();
 
     // ── Baseline RSP (fresh dir) ─────────────────────────────────────
-    let bl_dir = tempfile::tempdir().unwrap();
+    let bl_dir = zccache_test_support::temp_cache_dir().unwrap();
     generate_project(bl_dir.path());
     generate_response_files(bl_dir.path());
 
@@ -970,11 +970,11 @@ async fn perf_response_file() {
     let sccache_multi_times;
 
     if let Some(sccache_bin) = find_sccache() {
-        let sc_dir = tempfile::tempdir().unwrap();
+        let sc_dir = zccache_test_support::temp_cache_dir().unwrap();
         generate_project(sc_dir.path());
         generate_response_files(sc_dir.path());
 
-        let sc_cache_dir = tempfile::tempdir().unwrap();
+        let sc_cache_dir = zccache_test_support::temp_cache_dir().unwrap();
         let sc_cache_str = sc_cache_dir.path().to_string_lossy().into_owned();
         std::env::set_var("SCCACHE_DIR", &sc_cache_str);
 
@@ -1060,7 +1060,7 @@ async fn perf_response_file() {
     }
 
     // ── zccache RSP (fresh dir, in-process daemon) ───────────────────
-    let zc_dir = tempfile::tempdir().unwrap();
+    let zc_dir = zccache_test_support::temp_cache_dir().unwrap();
     generate_project(zc_dir.path());
     generate_response_files(zc_dir.path());
     let zc_cwd = zc_dir.path().to_string_lossy().into_owned();
@@ -1480,7 +1480,7 @@ async fn perf_rustc_zccache_vs_sccache() {
     eprintln!("  ─── Build mode (cargo build) ───");
     eprintln!();
 
-    let bl_dir = tempfile::tempdir().unwrap();
+    let bl_dir = zccache_test_support::temp_cache_dir().unwrap();
     generate_rust_project(bl_dir.path());
     eprintln!("  [1/3] Bare rustc");
     warmup_rustc(&rc, bl_dir.path());
@@ -1494,9 +1494,9 @@ async fn perf_rustc_zccache_vs_sccache() {
     let build_sc_cold;
     let build_sc_warm;
     if let Some(ref scc_bin) = find_sccache() {
-        let sd = tempfile::tempdir().unwrap();
+        let sd = zccache_test_support::temp_cache_dir().unwrap();
         generate_rust_project(sd.path());
-        let scd = tempfile::tempdir().unwrap();
+        let scd = zccache_test_support::temp_cache_dir().unwrap();
         let scd_s = scd.path().to_string_lossy().into_owned();
         std::env::set_var("SCCACHE_DIR", &scd_s);
         eprintln!("  [2/3] sccache");
@@ -1544,7 +1544,7 @@ async fn perf_rustc_zccache_vs_sccache() {
         build_sc_warm = None;
     }
 
-    let zd = tempfile::tempdir().unwrap();
+    let zd = zccache_test_support::temp_cache_dir().unwrap();
     generate_rust_project(zd.path());
     let zc = zd.path().to_string_lossy().into_owned();
     eprintln!("  [3/3] zccache");
@@ -1579,7 +1579,7 @@ async fn perf_rustc_zccache_vs_sccache() {
     eprintln!("  ─── Check mode (cargo check) ───");
     eprintln!();
 
-    let bl_dir2 = tempfile::tempdir().unwrap();
+    let bl_dir2 = zccache_test_support::temp_cache_dir().unwrap();
     generate_rust_project(bl_dir2.path());
     eprintln!("  [1/3] Bare rustc");
     warmup_rustc(&rc, bl_dir2.path());
@@ -1593,9 +1593,9 @@ async fn perf_rustc_zccache_vs_sccache() {
     let check_sc_cold;
     let check_sc_warm;
     if let Some(ref scc_bin) = find_sccache() {
-        let sd = tempfile::tempdir().unwrap();
+        let sd = zccache_test_support::temp_cache_dir().unwrap();
         generate_rust_project(sd.path());
-        let scd = tempfile::tempdir().unwrap();
+        let scd = zccache_test_support::temp_cache_dir().unwrap();
         let scd_s = scd.path().to_string_lossy().into_owned();
         std::env::set_var("SCCACHE_DIR", &scd_s);
         eprintln!("  [2/3] sccache");

--- a/crates/zccache-daemon/tests/perf_test.rs
+++ b/crates/zccache-daemon/tests/perf_test.rs
@@ -597,9 +597,9 @@ async fn perf_full_benchmark() {
         }
     };
 
-    let bare_dir = tempfile::tempdir().unwrap();
-    let sccache_dir = tempfile::tempdir().unwrap();
-    let zccache_dir = tempfile::tempdir().unwrap();
+    let bare_dir = zccache_test_support::temp_cache_dir().unwrap();
+    let sccache_dir = zccache_test_support::temp_cache_dir().unwrap();
+    let zccache_dir = zccache_test_support::temp_cache_dir().unwrap();
 
     generate_test_files(bare_dir.path(), FILE_COUNT);
     generate_test_files(sccache_dir.path(), FILE_COUNT);
@@ -652,7 +652,7 @@ async fn perf_sanity_check() {
         }
     };
 
-    let tmp = tempfile::tempdir().unwrap();
+    let tmp = zccache_test_support::temp_cache_dir().unwrap();
     generate_test_files(tmp.path(), 1);
     let cwd = tmp.path().to_string_lossy().into_owned();
 
@@ -689,7 +689,7 @@ async fn perf_sanity_check() {
     println!("sccache stats:\n{stats_text}");
 
     // zccache: cold then warm
-    let zcc_tmp = tempfile::tempdir().unwrap();
+    let zcc_tmp = zccache_test_support::temp_cache_dir().unwrap();
     generate_test_files(zcc_tmp.path(), 1);
     let zcc_cwd = zcc_tmp.path().to_string_lossy().into_owned();
     let log = zcc_tmp.path().join("log.txt");

--- a/crates/zccache-test-support/src/lib.rs
+++ b/crates/zccache-test-support/src/lib.rs
@@ -4,6 +4,7 @@
 //! daemon lifecycle management, and test fixtures.
 
 use std::path::Path;
+use std::time::{Duration, SystemTime};
 use zccache_core::NormalizedPath;
 
 // ─── Tool discovery ─────────────────────────────────────────────────────────
@@ -143,7 +144,52 @@ pub async fn test_timeout<F: std::future::Future<Output = ()>>(f: F) {
 ///
 /// Returns an error if the temp directory cannot be created.
 pub fn temp_cache_dir() -> std::io::Result<tempfile::TempDir> {
-    tempfile::Builder::new().prefix("zccache-test-").tempdir()
+    use std::sync::Once;
+
+    const TEMP_PREFIX: &str = "zccache-test-";
+    const STALE_AFTER: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+    static CLEANUP_ONCE: Once = Once::new();
+    CLEANUP_ONCE.call_once(|| cleanup_stale_temp_dirs(TEMP_PREFIX, STALE_AFTER));
+
+    tempfile::Builder::new().prefix(TEMP_PREFIX).tempdir()
+}
+
+fn cleanup_stale_temp_dirs(prefix: &str, stale_after: Duration) {
+    let root = std::env::temp_dir();
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return;
+    };
+    let now = SystemTime::now();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if !name.starts_with(prefix) {
+            continue;
+        }
+
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        if !metadata.is_dir() {
+            continue;
+        }
+
+        let Ok(modified) = metadata.modified() else {
+            continue;
+        };
+        let Ok(age) = now.duration_since(modified) else {
+            continue;
+        };
+        if age < stale_after {
+            continue;
+        }
+
+        let _ = std::fs::remove_dir_all(path);
+    }
 }
 
 /// Initialize tracing for tests (only installs once).


### PR DESCRIPTION
Closes #26.

Summary:
- Move comparative perf/test scratch dirs onto the shared zccache-prefixed temp helper.
- Add one-time stale temp-dir cleanup for the zccache test temp prefix.
- Keep sccache benchmark cache/work dirs under the same zccache-owned prefix.

Validation:
- cargo fmt --all --check
- cargo test -p zccache-test-support --lib --no-run
- cargo test -p zccache-daemon --test perf_test --no-run
- cargo test -p zccache-daemon --test perf_bench_test --no-run