### PR TITLE
fix(cli): retry daemon startup while it warms up

### DIFF
--- a/crates/zccache-cli/src/lib.rs
+++ b/crates/zccache-cli/src/lib.rs
@@ -425,8 +425,10 @@ async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
     }
 
     if let Some(pid) = zccache_ipc::check_running_daemon() {
+        let mut backoff = std::time::Duration::from_millis(100);
         for _ in 0..20 {
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            tokio::time::sleep(backoff).await;
+            backoff = (backoff * 2).min(std::time::Duration::from_millis(500));
             match check_daemon_version(endpoint).await {
                 VersionCheck::Ok | VersionCheck::DaemonNewer => return Ok(()),
                 VersionCheck::DaemonOlder { daemon_ver } => {
@@ -446,7 +448,7 @@ async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
             }
         }
         return Err(format!(
-            "daemon process {pid} exists but not accepting connections"
+            "daemon process {pid} exists but not accepting connections after retrying"
         ));
     }
 
@@ -820,6 +822,63 @@ pub fn fingerprint_invalidate(endpoint: Option<&str>, cache_file: &Path) -> Resu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set_cache_dir(value: &std::path::Path) -> Self {
+            let lock = ENV_LOCK.lock().unwrap();
+            let previous = std::env::var_os(zccache_core::config::CACHE_DIR_ENV);
+            std::env::set_var(zccache_core::config::CACHE_DIR_ENV, value);
+            Self {
+                _lock: lock,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(zccache_core::config::CACHE_DIR_ENV, value),
+                None => std::env::remove_var(zccache_core::config::CACHE_DIR_ENV),
+            }
+        }
+    }
+
+    fn fake_status() -> zccache_protocol::DaemonStatus {
+        zccache_protocol::DaemonStatus {
+            version: zccache_core::VERSION.to_string(),
+            artifact_count: 0,
+            cache_size_bytes: 0,
+            metadata_entries: 0,
+            uptime_secs: 0,
+            cache_hits: 0,
+            cache_misses: 0,
+            total_compilations: 0,
+            non_cacheable: 0,
+            compile_errors: 0,
+            time_saved_ms: 0,
+            total_links: 0,
+            link_hits: 0,
+            link_misses: 0,
+            link_non_cacheable: 0,
+            dep_graph_contexts: 0,
+            dep_graph_files: 0,
+            sessions_total: 0,
+            sessions_active: 0,
+            cache_dir: zccache_core::config::default_cache_dir().into(),
+            dep_graph_version: 0,
+            dep_graph_disk_size: 0,
+        }
+    }
 
     #[test]
     fn infer_download_path_keeps_url_filename() {
@@ -863,5 +922,47 @@ mod tests {
         );
         let file_name = path.file_name().unwrap().to_string_lossy();
         assert!(file_name.ends_with("-toolchain.tar.zst"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn client_start_waits_for_delayed_listener() {
+        let endpoint = zccache_ipc::unique_test_endpoint();
+        let cache_root = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set_cache_dir(cache_root.path());
+        let lock_path = zccache_ipc::lock_file_path();
+
+        std::fs::write(&lock_path, std::process::id().to_string()).unwrap();
+
+        let ep = endpoint.clone();
+        let cache_dir = cache_root.path().to_path_buf();
+        let server = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+            let mut listener = zccache_ipc::IpcListener::bind(&ep).unwrap();
+            let mut conn = listener.accept().await.unwrap();
+
+            let req: Option<zccache_protocol::Request> = conn.recv().await.unwrap();
+            assert_eq!(req, Some(zccache_protocol::Request::Status));
+
+            conn.send(&zccache_protocol::Response::Status(
+                zccache_protocol::DaemonStatus {
+                    cache_dir: cache_dir.into(),
+                    ..fake_status()
+                },
+            ))
+            .await
+            .unwrap();
+        });
+
+        let result = tokio::task::spawn_blocking(move || client_start(Some(&endpoint)))
+            .await
+            .unwrap();
+        let _ = std::fs::remove_file(&lock_path);
+        server.await.unwrap();
+
+        assert!(
+            result.is_ok(),
+            "expected delayed daemon to be accepted: {result:?}"
+        );
     }
 }

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -2541,8 +2541,10 @@ async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
 
     // Check lock file for a running daemon we just can't reach yet
     if let Some(pid) = zccache_ipc::check_running_daemon() {
+        let mut backoff = std::time::Duration::from_millis(100);
         for _ in 0..20 {
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            tokio::time::sleep(backoff).await;
+            backoff = (backoff * 2).min(std::time::Duration::from_millis(500));
             match check_daemon_version(endpoint).await {
                 VersionCheck::Ok => return Ok(()),
                 VersionCheck::DaemonNewer { daemon_ver } => {
@@ -2573,7 +2575,7 @@ async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
             }
         }
         return Err(format!(
-            "daemon process {pid} exists but not accepting connections"
+            "daemon process {pid} exists but not accepting connections after retrying"
         ));
     }
 
@@ -2795,6 +2797,63 @@ fn init_tracing() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set_cache_dir(value: &std::path::Path) -> Self {
+            let lock = ENV_LOCK.lock().unwrap();
+            let previous = std::env::var_os(zccache_core::config::CACHE_DIR_ENV);
+            std::env::set_var(zccache_core::config::CACHE_DIR_ENV, value);
+            Self {
+                _lock: lock,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(zccache_core::config::CACHE_DIR_ENV, value),
+                None => std::env::remove_var(zccache_core::config::CACHE_DIR_ENV),
+            }
+        }
+    }
+
+    fn fake_status() -> zccache_protocol::DaemonStatus {
+        zccache_protocol::DaemonStatus {
+            version: zccache_core::VERSION.to_string(),
+            artifact_count: 0,
+            cache_size_bytes: 0,
+            metadata_entries: 0,
+            uptime_secs: 0,
+            cache_hits: 0,
+            cache_misses: 0,
+            total_compilations: 0,
+            non_cacheable: 0,
+            compile_errors: 0,
+            time_saved_ms: 0,
+            total_links: 0,
+            link_hits: 0,
+            link_misses: 0,
+            link_non_cacheable: 0,
+            dep_graph_contexts: 0,
+            dep_graph_files: 0,
+            sessions_total: 0,
+            sessions_active: 0,
+            cache_dir: zccache_core::config::default_cache_dir().into(),
+            dep_graph_version: 0,
+            dep_graph_disk_size: 0,
+        }
+    }
 
     #[test]
     fn split_leading_strict_paths_supports_equals_form() {
@@ -2870,6 +2929,46 @@ mod tests {
     fn exit_code_257_keeps_low_byte() {
         // 257 & 0xFF == 1, non-zero, so kept as-is.
         assert_eq!(exit_code_from_i32(257), ExitCode::from(1));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn ensure_daemon_waits_for_delayed_listener() {
+        let endpoint = zccache_ipc::unique_test_endpoint();
+        let cache_root = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set_cache_dir(cache_root.path());
+        let lock_path = zccache_ipc::lock_file_path();
+
+        std::fs::write(&lock_path, std::process::id().to_string()).unwrap();
+
+        let ep = endpoint.clone();
+        let cache_dir = cache_root.path().to_path_buf();
+        let server = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+            let mut listener = zccache_ipc::IpcListener::bind(&ep).unwrap();
+            let mut conn = listener.accept().await.unwrap();
+
+            let req: Option<zccache_protocol::Request> = conn.recv().await.unwrap();
+            assert_eq!(req, Some(zccache_protocol::Request::Status));
+
+            conn.send(&zccache_protocol::Response::Status(
+                zccache_protocol::DaemonStatus {
+                    cache_dir: cache_dir.into(),
+                    ..fake_status()
+                },
+            ))
+            .await
+            .unwrap();
+        });
+
+        let result = ensure_daemon(&endpoint).await;
+        let _ = std::fs::remove_file(&lock_path);
+        server.await.unwrap();
+
+        assert!(
+            result.is_ok(),
+            "expected delayed daemon to be accepted: {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #81.\n\nSummary:\n- Add bounded exponential backoff to the startup path when a daemon PID exists but the endpoint is not ready yet.\n- Keep the existing stale-daemon recovery behavior intact.\n- Add regression tests in both the library and CLI startup copies that delay the listener becoming available and verify startup still succeeds.\n\nValidation:\n- cargo fmt --all --check\n- cargo test -p zccache-cli --lib client_start_waits_for_delayed_listener\n- cargo test -p zccache-cli --bin zccache ensure_daemon_waits_for_delayed_listener