### PR TITLE
Move Clippy out of PR checks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,4 +2,6 @@
 
 GitHub Actions workflow definitions.
 
-- **ci.yml** — Runs check, clippy, test, fmt, MSRV, and doc builds on Linux/macOS/Windows.
+- **ci.yml** — Runs fmt, Dylint, MSRV, and doc builds on main and pull requests.
+- **ci-check.yml** — Reusable check/test workflow used by the OS-specific CI workflows.
+- **clippy.yml** — Runs Clippy on pushes to main for the README status badge.

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -22,12 +22,8 @@ jobs:
         with:
           toolchain: 1.94.1
           cache: true
-      - name: Install Rust components
-        run: rustup component add clippy rustfmt
       - name: Check
         run: soldr cargo check --workspace --all-targets
-      - name: Clippy
-        run: soldr cargo clippy --workspace --all-targets -- -D warnings
       - name: Test
         shell: bash
         run: |

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,26 @@
+name: Clippy
+
+on:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+  SOLDR_RUSTC_WRAPPER: none
+
+jobs:
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: zackees/setup-soldr@v0
+        with:
+          toolchain: 1.94.1
+          cache: true
+          cache-key-suffix: clippy
+      - name: Install Clippy
+        run: rustup component add clippy
+      - name: Run Clippy
+        run: soldr cargo clippy --workspace --all-targets -- -D warnings

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Linux](https://github.com/zackees/zccache/actions/workflows/ci-linux.yml/badge.svg)](https://github.com/zackees/zccache/actions/workflows/ci-linux.yml)
 [![macOS](https://github.com/zackees/zccache/actions/workflows/ci-macos.yml/badge.svg)](https://github.com/zackees/zccache/actions/workflows/ci-macos.yml)
 [![Windows](https://github.com/zackees/zccache/actions/workflows/ci-windows.yml/badge.svg)](https://github.com/zackees/zccache/actions/workflows/ci-windows.yml)
+[![Clippy](https://github.com/zackees/zccache/actions/workflows/clippy.yml/badge.svg?branch=main)](https://github.com/zackees/zccache/actions/workflows/clippy.yml?query=branch%3Amain)
 [![Dylint](https://img.shields.io/github/actions/workflow/status/zackees/zccache/ci.yml?branch=main&event=push&job=Dylint&label=dylint)](https://github.com/zackees/zccache/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
 [![codecov](https://codecov.io/gh/zackees/zccache/branch/main/graph/badge.svg)](https://codecov.io/gh/zackees/zccache)
 [![PyPI](https://img.shields.io/pypi/v/zccache)](https://pypi.org/project/zccache/)


### PR DESCRIPTION
## Summary
- remove Clippy from the reusable OS check/test workflow used by pull requests
- add a dedicated clippy.yml workflow that runs only on pushes to main
- add a README Clippy status badge for the main-branch workflow

## Validation
- git diff --check -- .github/workflows/ci-check.yml .github/workflows/clippy.yml .github/workflows/README.md README.md

generated follow-up from PR #85 CI discussion