### PR TITLE
fix: remove redundant cache dir conversion

### DIFF
--- a/crates/zccache-cli/src/lib.rs
+++ b/crates/zccache-cli/src/lib.rs
@@ -874,7 +874,7 @@ mod tests {
             dep_graph_files: 0,
             sessions_total: 0,
             sessions_active: 0,
-            cache_dir: zccache_core::config::default_cache_dir().into(),
+            cache_dir: zccache_core::config::default_cache_dir(),
             dep_graph_version: 0,
             dep_graph_disk_size: 0,
         }

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -2849,7 +2849,7 @@ mod tests {
             dep_graph_files: 0,
             sessions_total: 0,
             sessions_active: 0,
-            cache_dir: zccache_core::config::default_cache_dir().into(),
+            cache_dir: zccache_core::config::default_cache_dir(),
             dep_graph_version: 0,
             dep_graph_disk_size: 0,
         }


### PR DESCRIPTION
## Summary
- remove redundant `.into()` calls on `default_cache_dir()` in the CLI status test helpers
- fixes the Rust 1.94 Clippy `useless_conversion` failures in the Clippy workflow

## Verification
- `cargo fmt --check`
- `git diff --check`
- `soldr cargo clippy --workspace --all-targets --target-dir C:\Users\niteris\dev\zccache-clippy-local-target -- -D warnings`

## Local run note
- `soldr` was invoked from the local soldr source build because it is not installed on PATH here.
- The rustup shim path was prepended so soldr used the coherent `x86_64-pc-windows-msvc` Cargo/Rustc pair instead of the Chocolatey GNU binaries currently earlier on PATH.