### PR TITLE
Remove legacy soldr wrapper overrides

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -6,4 +6,4 @@ Hook scripts that enforce project standards automatically.
 - **lint.py** - PostToolUse: auto-formats + runs clippy on edited .rs files
 - **readme_guard.py** - PostToolUse: ensures every directory has a README.md
 - **check-on-start.py** - SessionStart: captures git fingerprint
-- **Stop hook** - `SOLDR_RUSTC_WRAPPER=none soldr cargo run -p zccache-ci`: runs full workspace lint + tests
+- **Stop hook** - `soldr cargo run -p zccache-ci`: runs full workspace lint + tests

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,7 +50,7 @@
           },
           {
             "type": "command",
-            "command": "SOLDR_RUSTC_WRAPPER=none soldr cargo run -p zccache-ci",
+            "command": "soldr cargo run -p zccache-ci",
             "timeout": 600
           }
         ]

--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -64,10 +64,6 @@ runs:
         cache-key-suffix: ${{ inputs.cache_key }}
         target-cache-paths: target/${{ inputs.target }}
 
-    - name: Disable soldr zccache wrapper for zccache self-build
-      shell: bash
-      run: echo "SOLDR_RUSTC_WRAPPER=none" >> "$GITHUB_ENV"
-
     - name: Ensure target stdlib is installed
       shell: bash
       run: rustup target add ${{ inputs.target }}

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -10,7 +10,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
-  SOLDR_RUSTC_WRAPPER: none
 
 jobs:
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
-  SOLDR_RUSTC_WRAPPER: none
 
 jobs:
   fmt:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,7 +7,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
-  SOLDR_RUSTC_WRAPPER: none
 
 jobs:
   clippy:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,8 +20,6 @@ jobs:
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: coverage
-      - name: Disable soldr zccache wrapper for zccache self-build
-        run: echo "SOLDR_RUSTC_WRAPPER=none" >> "$GITHUB_ENV"
       - name: Install Rust coverage component
         run: rustup component add llvm-tools-preview
       - name: Install cargo-llvm-cov

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,11 +17,11 @@ zccache is a local-first compiler cache daemon (11 crates). See @docs/CLAUDE.md 
 ./test --integration        # integration tests only (need clang on PATH)
 ./test --full               # unit + integration + stress + perf tests
 ./test -p <crate> -- <test_name>
-SOLDR_RUSTC_WRAPPER=none soldr cargo check --workspace --all-targets
-SOLDR_RUSTC_WRAPPER=none soldr cargo clippy --workspace --all-targets -- -D warnings
+soldr cargo check --workspace --all-targets
+soldr cargo clippy --workspace --all-targets -- -D warnings
 soldr cargo fmt --all
-RUSTDOCFLAGS="-D warnings" SOLDR_RUSTC_WRAPPER=none soldr cargo doc --workspace --no-deps
-SOLDR_RUSTC_WRAPPER=none soldr cargo bench -p zccache-hash
+RUSTDOCFLAGS="-D warnings" soldr cargo doc --workspace --no-deps
+soldr cargo bench -p zccache-hash
 ./perf                      # performance benchmark (zccache vs sccache vs bare clang)
 ```
 
@@ -63,7 +63,7 @@ Hooks are in `ci/hooks/` (Python) and `crates/zccache-ci` (Rust):
 - **PostToolUse**: `ci/hooks/lint.py` auto-formats + runs clippy on edited `.rs` files
 - **PostToolUse**: `ci/hooks/readme_guard.py` errors if directory lacks README.md
 - **SessionStart**: `ci/hooks/check-on-start.py` captures git fingerprint
-- **Stop**: `SOLDR_RUSTC_WRAPPER=none soldr cargo run -p zccache-ci` runs lint + unit tests in parallel (skips if no changes)
+- **Stop**: `soldr cargo run -p zccache-ci` runs lint + unit tests in parallel (skips if no changes)
 
 ## Language Policy
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -5,22 +5,22 @@ Read [CLAUDE.md](./CLAUDE.md) first. The following conventions are mandatory in 
 - Do not run bare `cargo`, `rustc`, or `rustfmt`.
 - Always use `soldr <tool>` directly. soldr resolves repo-local `.cargo` / `.rustup` homes and the rustup-managed toolchain pinned by `rust-toolchain.toml`.
 - In this Windows environment, the repo is using the rustup-managed `x86_64-pc-windows-msvc` toolchain pinned by `rust-toolchain.toml`. Do not assume GNU or try to find `gcc`. soldr also enforces MSVC on Windows by default.
-- zccache self-builds should set `SOLDR_RUSTC_WRAPPER=none` when invoking `soldr cargo ...` so soldr does not wrap the current zccache build in a previous zccache release.
+- Keep soldr's default Rust compiler wrapper enabled for normal `soldr cargo ...` commands. Set `SOLDR_RUSTC_WRAPPER=none` only as an explicit diagnostic escape hatch when debugging wrapper behavior.
 
 Examples:
 
 ```bash
-SOLDR_RUSTC_WRAPPER=none soldr cargo check --workspace --all-targets
-SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-download
-SOLDR_RUSTC_WRAPPER=none soldr cargo build -p zccache-cli
+soldr cargo check --workspace --all-targets
+soldr cargo test -p zccache-download
+soldr cargo build -p zccache-cli
 soldr cargo fmt --all
 ```
 
 PowerShell example:
 
 ```powershell
-$env:SOLDR_RUSTC_WRAPPER = "none"; soldr cargo check -p zccache-download-client
-$env:SOLDR_RUSTC_WRAPPER = "none"; soldr cargo test -p zccache-download
+soldr cargo check -p zccache-download-client
+soldr cargo test -p zccache-download
 ```
 
 ## Python Commands
@@ -34,7 +34,7 @@ $env:SOLDR_RUSTC_WRAPPER = "none"; soldr cargo test -p zccache-download
 - Prefer `./test` for repo-standard test execution.
 - Use `./test --integration` for ignored integration tests.
 - Use `./test --full` for the larger suite.
-- Use `SOLDR_RUSTC_WRAPPER=none soldr cargo test ...` when you need targeted crate/test execution.
+- Use `soldr cargo test ...` when you need targeted crate/test execution.
 
 ## Practical Rule
 

--- a/ci/soldr.py
+++ b/ci/soldr.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from ci.env import clean_env
 
 REPO_ROOT = Path(__file__).parent.parent.resolve()
-SELF_BUILD_WRAPPER = "none"
 
 
 def soldr_executable() -> str:
@@ -27,9 +26,7 @@ def soldr_executable() -> str:
 
 
 def self_build_env() -> dict[str, str]:
-    env = clean_env()
-    env.setdefault("SOLDR_RUSTC_WRAPPER", SELF_BUILD_WRAPPER)
-    return env
+    return clean_env()
 
 
 def cargo_command(*args: str) -> list[str]:

--- a/crates/zccache-compiler/tests/response_file_adversarial.rs
+++ b/crates/zccache-compiler/tests/response_file_adversarial.rs
@@ -10,8 +10,8 @@
 //! - File content edge cases (empty, whitespace-only, BOM, CRLF)
 //! - Integration with `parse_invocation` through response files
 //!
-//! Run all:    SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-compiler --test response_file_adversarial -- --nocapture
-//! Run single: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-compiler --test response_file_adversarial -- <test_name> --nocapture
+//! Run all:    soldr cargo test -p zccache-compiler --test response_file_adversarial -- --nocapture
+//! Run single: soldr cargo test -p zccache-compiler --test response_file_adversarial -- <test_name> --nocapture
 
 use std::path::Path;
 use zccache_compiler::response_file::{

--- a/crates/zccache-daemon/tests/adversarial_corner_cases.rs
+++ b/crates/zccache-daemon/tests/adversarial_corner_cases.rs
@@ -5,8 +5,8 @@
 //! - Cache persistence across session boundaries
 //! - Thundering herd (concurrent same-file compilation from multiple sessions)
 //!
-//! Run all:    SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test adversarial_corner_cases -- --nocapture
-//! Run single: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test adversarial_corner_cases -- <test_name> --nocapture
+//! Run all:    soldr cargo test -p zccache-daemon --test adversarial_corner_cases -- --nocapture
+//! Run single: soldr cargo test -p zccache-daemon --test adversarial_corner_cases -- <test_name> --nocapture
 
 use std::path::Path;
 use std::sync::Arc;

--- a/crates/zccache-daemon/tests/adversarial_mutations.rs
+++ b/crates/zccache-daemon/tests/adversarial_mutations.rs
@@ -6,8 +6,8 @@
 //! (touch/delete-recreate with same content), independent file isolation,
 //! include-path differentiation, and preprocessor-flag differentiation.
 //!
-//! Run all:    SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test adversarial_mutations -- --nocapture
-//! Run single: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test adversarial_mutations -- <test_name> --nocapture
+//! Run all:    soldr cargo test -p zccache-daemon --test adversarial_mutations -- --nocapture
+//! Run single: soldr cargo test -p zccache-daemon --test adversarial_mutations -- <test_name> --nocapture
 
 use std::path::Path;
 use zccache_core::NormalizedPath;

--- a/crates/zccache-daemon/tests/cold_path_profile_test.rs
+++ b/crates/zccache-daemon/tests/cold_path_profile_test.rs
@@ -8,7 +8,7 @@
 //!   - Artifact persistence overhead
 //!   - Scaling behavior (10, 50, 100, 200 files)
 //!
-//! Run with: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test cold_path_profile_test -- --nocapture --ignored
+//! Run with: soldr cargo test -p zccache-daemon --test cold_path_profile_test -- --nocapture --ignored
 
 use std::path::Path;
 use std::sync::Arc;

--- a/crates/zccache-daemon/tests/ninja_rebuild_test.rs
+++ b/crates/zccache-daemon/tests/ninja_rebuild_test.rs
@@ -10,8 +10,8 @@
 //! Each invocation goes through the real CLI binary in drop-in wrapper mode,
 //! exercising the full `CompileEphemeral` single-roundtrip IPC path.
 //!
-//! Run all:    SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test ninja_rebuild_test -- --nocapture
-//! Run stress: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test ninja_rebuild_test -- --ignored --nocapture
+//! Run all:    soldr cargo test -p zccache-daemon --test ninja_rebuild_test -- --nocapture
+//! Run stress: soldr cargo test -p zccache-daemon --test ninja_rebuild_test -- --ignored --nocapture
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -707,7 +707,7 @@ async fn ninja_clear_forces_cold_rebuild() {
 
 /// Stress test: 250 files with heavy bodies, cold + warm + warm.
 ///
-/// Run:  SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test ninja_rebuild_test -- stress_large_project --ignored --nocapture
+/// Run:  soldr cargo test -p zccache-daemon --test ninja_rebuild_test -- stress_large_project --ignored --nocapture
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore]
 async fn stress_large_project_cold_warm() {
@@ -798,7 +798,7 @@ async fn stress_large_project_cold_warm() {
 /// Benchmark: 100 files, medium bodies, cold + 5 warm iterations.
 /// Prints per-iteration timing for trend analysis.
 ///
-/// Run:  SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test ninja_rebuild_test -- bench_medium --ignored --nocapture
+/// Run:  soldr cargo test -p zccache-daemon --test ninja_rebuild_test -- bench_medium --ignored --nocapture
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore]
 async fn bench_medium_project_warm_iterations() {
@@ -911,7 +911,7 @@ fn find_ninja() -> Option<NormalizedPath> {
 ///   4. `ninja -t clean` + `ninja` warm rebuild (all cache hits)
 ///   5. Verify warm is significantly faster than cold
 ///
-/// Run:  SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test ninja_rebuild_test -- meson_ninja_cold --ignored --nocapture
+/// Run:  soldr cargo test -p zccache-daemon --test ninja_rebuild_test -- meson_ninja_cold --ignored --nocapture
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore]
 async fn meson_ninja_cold_then_warm_rebuild() {
@@ -1026,7 +1026,7 @@ async fn meson_ninja_cold_then_warm_rebuild() {
 
 /// Meson+ninja benchmark: larger project, cold + 3 warm iterations.
 ///
-/// Run:  SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test ninja_rebuild_test -- meson_ninja_bench --ignored --nocapture
+/// Run:  soldr cargo test -p zccache-daemon --test ninja_rebuild_test -- meson_ninja_bench --ignored --nocapture
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore]
 async fn meson_ninja_bench_warm_iterations() {

--- a/crates/zccache-daemon/tests/perf_bench_test.rs
+++ b/crates/zccache-daemon/tests/perf_bench_test.rs
@@ -7,7 +7,7 @@
 //!
 //! Each tool gets its own fresh zccache-prefixed tempdir to avoid OS page cache cross-contamination.
 //!
-//! Run with: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test perf_bench_test -- --nocapture --ignored
+//! Run with: soldr cargo test -p zccache-daemon --test perf_bench_test -- --nocapture --ignored
 
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -583,7 +583,7 @@ fn fmt_ratio(baseline: Duration, test: Duration, bold: bool) -> String {
 // ── Main benchmark ──────────────────────────────────────────────────────
 
 #[tokio::test]
-#[ignore] // Run explicitly: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test perf_bench_test -- --nocapture --ignored
+#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- --nocapture --ignored
 async fn perf_warm_cache_zccache_vs_sccache() {
     let compiler_path = match zccache_test_support::find_clang() {
         Some(p) => p,
@@ -915,7 +915,7 @@ async fn perf_warm_cache_zccache_vs_sccache() {
 // ── Response-file benchmark (separate test) ─────────────────────────────
 
 #[tokio::test]
-#[ignore] // Run explicitly: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_response_file --nocapture --ignored
+#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_response_file --nocapture --ignored
 async fn perf_response_file() {
     let compiler_path = match zccache_test_support::find_clang() {
         Some(p) => p,

--- a/crates/zccache-daemon/tests/perf_test.rs
+++ b/crates/zccache-daemon/tests/perf_test.rs
@@ -1,7 +1,7 @@
 //! Performance comparison: bare clang vs sccache vs zccache.
 //!
 //! Three-way benchmark measuring compile latency across cache-miss and cache-hit scenarios.
-//! Run with: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test perf_test -- --nocapture --ignored
+//! Run with: soldr cargo test -p zccache-daemon --test perf_test -- --nocapture --ignored
 
 use std::time::Instant;
 use zccache_core::NormalizedPath;
@@ -578,7 +578,7 @@ fn print_three_way(bare: &BenchResult, sccache: &BenchResult, zccache: &BenchRes
 
 /// Full three-way benchmark: bare clang vs sccache vs zccache.
 ///
-/// Run with: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test perf_test -- perf_full_benchmark --nocapture --ignored
+/// Run with: soldr cargo test -p zccache-daemon --test perf_test -- perf_full_benchmark --nocapture --ignored
 #[tokio::test]
 #[ignore]
 async fn perf_full_benchmark() {

--- a/crates/zccache-daemon/tests/profile_multi_test.rs
+++ b/crates/zccache-daemon/tests/profile_multi_test.rs
@@ -1,6 +1,6 @@
 //! Profile the multi-file warm cache path to identify bottlenecks.
 //!
-//! Run: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test profile_multi_test -- --nocapture --ignored
+//! Run: soldr cargo test -p zccache-daemon --test profile_multi_test -- --nocapture --ignored
 
 use std::sync::Arc;
 use std::time::Instant;

--- a/crates/zccache-daemon/tests/profile_test.rs
+++ b/crates/zccache-daemon/tests/profile_test.rs
@@ -1,6 +1,6 @@
 //! Profiling stress test: drives many compilations and reports phase-level timing breakdown.
 //!
-//! Run with: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test profile_test -- --nocapture --ignored
+//! Run with: soldr cargo test -p zccache-daemon --test profile_test -- --nocapture --ignored
 
 use zccache_daemon::DaemonServer;
 use zccache_protocol::{Request, Response};
@@ -198,7 +198,7 @@ fn print_profile(profile: &zccache_daemon::ProfileSnapshot) {
 
 /// Profiling stress test: cold + warm compilations with phase-level timing breakdown.
 ///
-/// Run with: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test profile_test -- --nocapture --ignored
+/// Run with: soldr cargo test -p zccache-daemon --test profile_test -- --nocapture --ignored
 #[tokio::test]
 #[ignore]
 async fn profile_compile_phases() {

--- a/crates/zccache-daemon/tests/response_file_cache.rs
+++ b/crates/zccache-daemon/tests/response_file_cache.rs
@@ -3,8 +3,8 @@
 //! Verifies that the daemon correctly expands response files before computing
 //! cache keys, so that changes to response file content invalidate the cache.
 //!
-//! Run all:    SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test response_file_cache -- --ignored --nocapture
-//! Run single: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test response_file_cache -- <test_name> --ignored --nocapture
+//! Run all:    soldr cargo test -p zccache-daemon --test response_file_cache -- --ignored --nocapture
+//! Run single: soldr cargo test -p zccache-daemon --test response_file_cache -- <test_name> --ignored --nocapture
 
 use std::path::Path;
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};

--- a/crates/zccache-daemon/tests/rustc_adversarial_test.rs
+++ b/crates/zccache-daemon/tests/rustc_adversarial_test.rs
@@ -9,8 +9,8 @@
 //! - CARGO_* env vars in cache key
 //! - --remap-path-prefix in cache key
 //!
-//! Run all:    SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test rustc_adversarial_test -- --nocapture --ignored --test-threads=1
-//! Run single: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test rustc_adversarial_test -- <test_name> --nocapture --ignored
+//! Run all:    soldr cargo test -p zccache-daemon --test rustc_adversarial_test -- --nocapture --ignored --test-threads=1
+//! Run single: soldr cargo test -p zccache-daemon --test rustc_adversarial_test -- <test_name> --nocapture --ignored
 
 use zccache_core::NormalizedPath;
 use zccache_daemon::DaemonServer;

--- a/crates/zccache-daemon/tests/watcher_adversarial.rs
+++ b/crates/zccache-daemon/tests/watcher_adversarial.rs
@@ -6,8 +6,8 @@
 //! covered: header edits, touch-without-change, deep directories, ephemeral
 //! file creation/deletion, and multi-session cache sharing.
 //!
-//! Run all:    SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test watcher_adversarial -- --nocapture
-//! Run single: SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-daemon --test watcher_adversarial -- <test_name> --nocapture
+//! Run all:    soldr cargo test -p zccache-daemon --test watcher_adversarial -- --nocapture
+//! Run single: soldr cargo test -p zccache-daemon --test watcher_adversarial -- <test_name> --nocapture
 
 use std::path::Path;
 use std::sync::Arc;

--- a/crates/zccache-depgraph/tests/README.md
+++ b/crates/zccache-depgraph/tests/README.md
@@ -5,7 +5,7 @@ Integration and stress tests for the dependency graph crate.
 ## Test Files
 
 - **`stress_test.rs`** — Stress tests for concurrent depgraph operations.
-  Run with: `./test --full` or `SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-depgraph --test stress_test -- --ignored`
+  Run with: `./test --full` or `soldr cargo test -p zccache-depgraph --test stress_test -- --ignored`
 
 - **`depfile_integration_test.rs`** — Integration tests that exercise the full depfile pipeline: compile with `-MD -MF`, parse the resulting `.d` file, and verify resolved includes match expectations. Requires GCC or Clang installed.
-  Run with: `SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-depgraph --test depfile_integration_test -- --ignored`
+  Run with: `soldr cargo test -p zccache-depgraph --test depfile_integration_test -- --ignored`

--- a/crates/zccache-depgraph/tests/depfile_integration_test.rs
+++ b/crates/zccache-depgraph/tests/depfile_integration_test.rs
@@ -1,7 +1,7 @@
 //! Integration tests for depfile parsing with real compilers.
 //!
 //! These tests require GCC or Clang to be installed. Run with:
-//! `SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-depgraph --test depfile_integration_test -- --ignored`
+//! `soldr cargo test -p zccache-depgraph --test depfile_integration_test -- --ignored`
 
 use std::process::Command;
 use tempfile::TempDir;

--- a/crates/zccache-depgraph/tests/stress_test.rs
+++ b/crates/zccache-depgraph/tests/stress_test.rs
@@ -1,7 +1,7 @@
 //! Integration, stress, and adversarial tests for zccache-depgraph.
 //!
 //! All tests are `#[ignore]` — run with `uv run test --full` or
-//! `SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-depgraph --test stress_test -- --ignored`.
+//! `soldr cargo test -p zccache-depgraph --test stress_test -- --ignored`.
 
 use std::collections::HashSet;
 use std::path::Path;

--- a/crates/zccache-hash/benches/README.md
+++ b/crates/zccache-hash/benches/README.md
@@ -2,4 +2,4 @@
 
 Criterion benchmarks for `zccache-hash`.
 
-Run with: `SOLDR_RUSTC_WRAPPER=none soldr cargo bench -p zccache-hash`
+Run with: `soldr cargo bench -p zccache-hash`

--- a/crates/zccache-watcher/tests/README.md
+++ b/crates/zccache-watcher/tests/README.md
@@ -6,8 +6,8 @@ Adversarial and stress tests for the file watcher subsystem (fscache + watcher).
 
 ```bash
 # Run all stress/adversarial tests
-SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-watcher --test stress_test -- --ignored
+soldr cargo test -p zccache-watcher --test stress_test -- --ignored
 
 # Run a specific test
-SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-watcher --test stress_test -- --ignored stress_concurrent_lookups
+soldr cargo test -p zccache-watcher --test stress_test -- --ignored stress_concurrent_lookups
 ```

--- a/crates/zccache-watcher/tests/stress_test.rs
+++ b/crates/zccache-watcher/tests/stress_test.rs
@@ -1,7 +1,7 @@
 //! Adversarial and stress tests for the file watcher subsystem.
 //!
 //! These tests are `#[ignore]`d so they don't run during normal `cargo test`.
-//! Run with: `SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache-watcher --test stress_test -- --ignored`
+//! Run with: `soldr cargo test -p zccache-watcher --test stress_test -- --ignored`
 
 use std::fs;
 use std::sync::Arc;

--- a/docs/FEASIBILITY-native-pypi-shims.md
+++ b/docs/FEASIBILITY-native-pypi-shims.md
@@ -114,7 +114,7 @@ All wheels use the `py3-none-{platform}` tag since there's no Python ABI depende
 ### What Stays the Same
 
 - All 11 Rust crates - no changes
-- `SOLDR_RUSTC_WRAPPER=none soldr cargo` development workflow - no changes
+- `soldr cargo` development workflow - no changes
 - CI hooks (tool_guard, lint, readme_guard) - no changes
 - Cargo.toml workspace - no changes
 
@@ -122,7 +122,7 @@ All wheels use the `py3-none-{platform}` tag since there's no Python ABI depende
 
 The existing `ci/soldr.py` dev helpers serve a **different purpose** - they run local zccache binaries through `soldr cargo run`. They are NOT distribution shims. These two concerns are orthogonal:
 
-- **Development**: `SOLDR_RUSTC_WRAPPER=none soldr cargo build` uses soldr for toolchain resolution
+- **Development**: `soldr cargo build` uses soldr for toolchain resolution and the default soldr-managed compiler wrapper
 - **Distribution**: `pip install zccache` installs the native binary from the maturin-built wheel
 
 The dev helpers stay as development infrastructure. They don't ship in the wheel.

--- a/install
+++ b/install
@@ -325,7 +325,7 @@ def verify() -> bool:
         warn('  export PATH="$CARGO_HOME/bin:$PATH"')
 
     log("")
-    log("Done. Run: SOLDR_RUSTC_WRAPPER=none soldr cargo check --workspace")
+    log("Done. Run: soldr cargo check --workspace")
     return True
 
 
@@ -346,7 +346,7 @@ def main() -> None:
         warn("")
         warn("Restart your terminal, then run:")
         warn("  rustc --version")
-        warn("  SOLDR_RUSTC_WRAPPER=none soldr cargo check --workspace")
+        warn("  soldr cargo check --workspace")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #89.

## Summary

- Remove `SOLDR_RUSTC_WRAPPER=none` from CI workflows and the release build-target composite action so setup-soldr can use its default managed zccache wrapper.
- Stop injecting the override from `ci/soldr.py`, so local `./test`/`./lint` helper paths also use the default soldr environment.
- Update docs, hook settings, install guidance, and test comments to present `soldr cargo ...` as the normal path. The only remaining mention documents `SOLDR_RUSTC_WRAPPER=none` as an explicit diagnostic escape hatch.

## Verification

All verification was run with `SOLDR_RUSTC_WRAPPER` unset and with the repo rustup-managed MSVC toolchain first on `PATH`.

- `git diff --check`
- `uv run --group dev soldr cargo check --workspace --all-targets`
- `uv run --group dev soldr cargo test --workspace --no-fail-fast`
- `uvx --from soldr soldr cargo build -p zccache-cli`

The soldr runs reported `soldr: using managed zccache 1.3.7`.

Note: after cleaning local Cargo artifacts to recover disk space, one build attempt hit a stale soldr zccache metadata reference. `uvx --from soldr soldr clean` cleared the managed zccache cache, and the targeted build then passed.