### PR TITLE
Bump version to 1.3.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "bincode",
  "redb",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "md5",
  "serde_json",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "blake3",
  "clap",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "clang",
  "tempfile",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "serde",
  "tempfile",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "bincode",
  "clap",
@@ -3537,7 +3537,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "blake3",
  "dashmap",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "blake3",
  "bytes",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "clap",
  "serde",
@@ -3581,7 +3581,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "clap",
  "dashmap",
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "bincode",
  "bytes",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "clap",
  "criterion",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3674,7 +3674,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "reqwest",
  "serde",
@@ -3687,7 +3687,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "blake3",
  "criterion",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "bytes",
  "serde",
@@ -3713,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "bincode",
  "bytes",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["dylints/ban_std_pathbuf"]
 
 [workspace.package]
-version = "1.3.7"
+version = "1.3.8"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![crates.io: zccache-core](https://img.shields.io/crates/v/zccache-core)](https://crates.io/crates/zccache-core)
 [![crates.io: zccache-cli](https://img.shields.io/crates/v/zccache-cli)](https://crates.io/crates/zccache-cli)
 [![crates.io: zccache-daemon](https://img.shields.io/crates/v/zccache-daemon)](https://crates.io/crates/zccache-daemon)
-[![Rust Workspace Version](https://img.shields.io/badge/rust%20workspace-1.3.7-orange)](https://crates.io/search?q=zccache)
+[![Rust Workspace Version](https://img.shields.io/badge/rust%20workspace-1.3.8-orange)](https://crates.io/search?q=zccache)
 [![GitHub Action](https://github.com/zackees/zccache/actions/workflows/test-action.yml/badge.svg)](https://github.com/zackees/zccache/actions/workflows/test-action.yml)
 
 ![C/C++](https://img.shields.io/badge/C%2FC%2B%2B-555?logo=c%2B%2B&logoColor=white)


### PR DESCRIPTION
## Summary

- Bump workspace package version from `1.3.7` to `1.3.8`.
- Refresh workspace package versions in `Cargo.lock`.
- Update the README workspace-version badge.

## Verification

- `uvx --from soldr soldr cargo update -w --offline`
- `uvx --from soldr soldr cargo check -p zccache-core --locked`
- `uv run python -m ci.release_checks`
- `git diff --check`

Generated `.venv`, `uv.lock`, and `target` artifacts were removed after verification.