### PR TITLE
ci: use full setup-soldr target cache

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           toolchain: 1.94.1
           cache: true
+          target-cache-mode: full
       - name: Check
         run: soldr cargo check --workspace --all-targets
       - name: Test
@@ -39,3 +40,7 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
           exit $status
+      - name: Stop zccache before cache save
+        if: always()
+        shell: bash
+        run: soldr --no-cache zccache stop || zccache stop || true


### PR DESCRIPTION
## Summary
- switch the reusable Linux/macOS/Windows check workflow to `setup-soldr` full target caching
- stop zccache explicitly before `actions/cache` post-save hooks run

## Why
PR #94 showed `zackees/setup-soldr@v0` resolved to the current v0.2.0 commit, so the workflow is not using a stale action. The slow path was that `soldr cargo check --workspace --all-targets` rebuilt the workspace:

- Windows #94: setup 1m15s, check 7m57s, test 5m27s, total 15m44s
- Linux #94: setup 26s, check 5m37s, test 3m03s, total 9m20s
- macOS #94: setup 21s, check 4m37s, test 2m49s, total 8m04s

The logs also showed the hot target cache was restored, but Windows still compiled from proc-macro2 upward, and the build cache was only ~41 KiB. Windows post-cache also hit `index.redb: Device or resource busy`, because zccache was still running when cache save started.

Using `target-cache-mode: full` should let warm branch runs restore the actual target artifacts instead of only lightweight Cargo metadata. Stopping zccache before post-cache save should allow the Soldr-owned zccache cache to be archived cleanly.

## Validation
- `git diff --check`
- YAML parse of `.github/workflows/ci-check.yml`
- `actionlint .github/workflows/ci-check.yml`
