### PR TITLE
ci: smoke test installed wheel scripts

### DIFF
--- a/ci/release_workflow.py
+++ b/ci/release_workflow.py
@@ -13,6 +13,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import tempfile
 import time
 import tomllib
 import urllib.error
@@ -374,6 +375,7 @@ def build_wheel(
         whl.writestr(f"{dist_info}/RECORD", buf.getvalue().encode())
 
     assert_wheel_script_metadata(wheel_path)
+    assert_installed_wheel_scripts_executable(wheel_path)
     return wheel_path
 
 
@@ -404,6 +406,74 @@ def assert_wheel_script_metadata(wheel_path: Path) -> None:
         raise SystemExit(
             f"ERROR: no wheel script entries found in {wheel_path.name}"
         )
+
+
+def assert_installed_wheel_scripts_executable(wheel_path: Path) -> None:
+    """Install a built wheel into a scratch target and validate script modes."""
+
+    if not _can_smoke_install_wheel_on_host(wheel_path):
+        return
+
+    exec_mask = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    script_names: list[str] = []
+
+    with zipfile.ZipFile(wheel_path) as whl:
+        for info in whl.infolist():
+            if ".data/scripts/" not in info.filename:
+                continue
+            script_names.append(Path(info.filename).name)
+
+    if not script_names:
+        raise SystemExit(
+            f"ERROR: no wheel script entries found in {wheel_path.name}"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="zccache-wheel-install-") as tmp:
+        target = Path(tmp) / "target"
+        run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--no-deps",
+                "--target",
+                str(target),
+                str(wheel_path),
+            ]
+        )
+
+        scripts_dir = target / "bin"
+        for script_name in script_names:
+            installed = scripts_dir / script_name
+            if not installed.is_file():
+                raise SystemExit(
+                    "ERROR: installed wheel script missing for "
+                    f"{wheel_path.name}:{script_name} at {installed}"
+                )
+            mode = installed.stat().st_mode
+            if not stat.S_ISREG(mode) or not mode & exec_mask:
+                raise SystemExit(
+                    "ERROR: installed wheel script is not executable for "
+                    f"{wheel_path.name}:{script_name} "
+                    f"(path={installed}, mode={oct(mode)})"
+                )
+
+
+def _can_smoke_install_wheel_on_host(wheel_path: Path) -> bool:
+    """Return true when pip can install this wheel on the current host."""
+
+    name = wheel_path.name
+    if os.name == "nt":
+        return False
+    if "-py3-none-any.whl" in name:
+        return True
+    if sys.platform.startswith("linux"):
+        return "manylinux" in name or "musllinux" in name
+    if sys.platform == "darwin":
+        return "macosx" in name
+    return False
 
 
 def build_all_wheels(

--- a/ci/tests/test_release_workflow.py
+++ b/ci/tests/test_release_workflow.py
@@ -1,20 +1,49 @@
 from __future__ import annotations
 
+import csv
+import io
+import os
 import zipfile
 from pathlib import Path
 
 import pytest
 
-from ci.release_workflow import assert_wheel_script_metadata
+from ci.release_workflow import (
+    assert_installed_wheel_scripts_executable,
+    assert_wheel_script_metadata,
+)
 
 
-def _write_wheel(path: Path, *, create_system: int, mode: int) -> None:
+def _write_wheel(
+    path: Path,
+    *,
+    create_system: int,
+    mode: int,
+    include_dist_info: bool = False,
+) -> None:
     with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as whl:
         info = zipfile.ZipInfo("zccache-1.2.3.data/scripts/zccache")
         info.create_system = create_system
         info.external_attr = mode << 16
         info.compress_type = zipfile.ZIP_DEFLATED
         whl.writestr(info, b"#!/bin/sh\n")
+        if include_dist_info:
+            metadata = b"Metadata-Version: 2.1\nName: zccache\nVersion: 1.2.3\n"
+            wheel = (
+                b"Wheel-Version: 1.0\n"
+                b"Generator: zccache-test\n"
+                b"Root-Is-Purelib: false\n"
+                b"Tag: py3-none-any\n"
+            )
+            whl.writestr("zccache-1.2.3.dist-info/METADATA", metadata)
+            whl.writestr("zccache-1.2.3.dist-info/WHEEL", wheel)
+            record = io.StringIO()
+            writer = csv.writer(record, lineterminator="\n")
+            writer.writerow(("zccache-1.2.3.data/scripts/zccache", "", ""))
+            writer.writerow(("zccache-1.2.3.dist-info/METADATA", "", ""))
+            writer.writerow(("zccache-1.2.3.dist-info/WHEEL", "", ""))
+            writer.writerow(("zccache-1.2.3.dist-info/RECORD", "", ""))
+            whl.writestr("zccache-1.2.3.dist-info/RECORD", record.getvalue())
 
 
 def test_assert_wheel_script_metadata_accepts_executable_unix_entries(
@@ -43,3 +72,21 @@ def test_assert_wheel_script_metadata_rejects_bad_script_metadata(
         ),
     ):
         assert_wheel_script_metadata(wheel_path)
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows install targets do not expose POSIX execute bits",
+)
+def test_assert_installed_wheel_scripts_executable_accepts_pip_target_install(
+    tmp_path: Path,
+) -> None:
+    wheel_path = tmp_path / "zccache-1.2.3-py3-none-any.whl"
+    _write_wheel(
+        wheel_path,
+        create_system=3,
+        mode=0o100755,
+        include_dist_info=True,
+    )
+
+    assert_installed_wheel_scripts_executable(wheel_path)


### PR DESCRIPTION
## Summary
- add a post-build smoke check that installs host-compatible wheels into a scratch `pip --target` directory
- verify installed `.data/scripts/*` entries land under `bin/` as regular executable files
- keep the existing zip metadata check for every wheel, while skipping native install smoke tests for wheels pip cannot install on the current host

## Issue selection
I scanned the open issues and chose the remaining small, concrete part of #36. The main wheel metadata assertion and version single-source cleanup are already present on `main`; this adds the issue's requested install-target regression check.

Closes #36.

## Verification
- `uv run --with pytest python -m pytest ci/tests/test_release_workflow.py`
- `uv run python -m ci.release_checks`
- `git diff --check`
