### PR TITLE
feat: enforce strict path validation in daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,30 @@ daemon state, and the default daemon endpoint. Separate cache roots therefore
 use separate daemon instances unless `ZCCACHE_ENDPOINT` is explicitly set.
 Relative override paths are normalized against the current working directory.
 
+### Strict path validation
+
+Use `--strict-paths` or `ZCCACHE_STRICT_PATHS` to fail fast when compiler path
+flags are spelled in ways that can confuse `#pragma once` on Windows.
+
+```bash
+zccache --strict-paths=absolute clang++ -c src/main.cpp -IC:/work/project/include
+ZCCACHE_STRICT_PATHS=consistent ninja
+```
+
+Modes:
+
+- `off` disables validation.
+- `consistent` allows relative or absolute paths, but rejects mixed `/` and `\`
+  separators within one path or across checked path flags in the same
+  invocation.
+- `absolute` requires checked path flags to be forward-slash absolute paths
+  with no `/./` or `/../` components. `ZCCACHE_STRICT_PATHS=1` maps to this
+  mode.
+
+Checked flags include `-I`, `-isystem`, `-iquote`, `-idirafter`, `-include`,
+`-include-pch`, `-imacros`, `-F`, `-iframework`, `-imsvc`, and MSVC `/I`.
+Response-file arguments are checked after expansion by the daemon.
+
 <details>
 <summary>Bash integration</summary>
 
@@ -593,10 +617,9 @@ ZCCACHE_STRICT_PATHS=consistent ninja
 zccache --strict-paths=absolute clang++ -IC:/project/src -c main.cpp
 ```
 
-`consistent` rejects include path flags that mix separator styles or spell the
-same canonical path in more than one way, for example `-IC:/repo/./src` and
-`-IC:/repo/src` in the same invocation. `absolute` also requires path flags such
-as `-I`, `-isystem`, `-include`, and `-include-pch` to be forward-slash absolute
+`consistent` rejects checked path flags that mix separator styles within one
+path or across the same invocation. `absolute` also requires path flags such as
+`-I`, `-isystem`, `-include`, and `-include-pch` to be forward-slash absolute
 paths without `/./` or `/../` segments. Violations exit non-zero with the
 offending flag and full caller command.
 

--- a/crates/zccache-cli/README.md
+++ b/crates/zccache-cli/README.md
@@ -9,7 +9,13 @@ sccache-compatible flags that work without a subcommand:
 ```bash
 zccache --clear       # Clear the entire artifact cache (same as `zccache clear`)
 zccache --show-stats  # Show daemon and cache statistics (same as `zccache status`)
+zccache --strict-paths=absolute clang++ -c foo.cpp -IC:/repo/include
 ```
+
+`--strict-paths=<off|consistent|absolute>` validates compiler path flags before
+dispatch. `consistent` rejects mixed separator styles; `absolute` additionally
+requires forward-slash absolute paths with no `/./` or `/../` components. The
+same mode can be set for a build with `ZCCACHE_STRICT_PATHS`.
 
 ## Session Commands
 

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -29,6 +29,7 @@ use zccache_cli::{
     client_download, run_ino_convert_cached, ArchiveFormat, DownloadParams, DownloadSource,
     InoConvertOptions, WaitMode,
 };
+use zccache_compiler::strict_paths::StrictPathsMode;
 use zccache_core::NormalizedPath;
 use zccache_gha::{GhaCache, GhaError};
 
@@ -47,8 +48,14 @@ struct Cli {
     #[arg(long)]
     show_stats: bool,
 
-    /// Validate compiler include path flags before dispatching.
-    #[arg(long, value_name = "MODE", value_parser = ["off", "consistent", "absolute"])]
+    /// Validate compiler path flag spelling: off, consistent, or absolute.
+    #[arg(
+        long,
+        value_name = "MODE",
+        num_args = 0..=1,
+        default_missing_value = "absolute",
+        require_equals = true
+    )]
     strict_paths: Option<String>,
 
     #[command(subcommand)]
@@ -105,8 +112,14 @@ enum Commands {
     },
     /// Wrap a compiler invocation (explicit mode).
     Wrap {
-        /// Validate compiler include path flags before dispatching.
-        #[arg(long, value_name = "MODE", value_parser = ["off", "consistent", "absolute"])]
+        /// Validate compiler path flag spelling: off, consistent, or absolute.
+        #[arg(
+            long,
+            value_name = "MODE",
+            num_args = 0..=1,
+            default_missing_value = "absolute",
+            require_equals = true
+        )]
         strict_paths: Option<String>,
         /// The compiler and its arguments.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -334,26 +347,6 @@ const KNOWN_SUBCOMMANDS: &[&str] = &[
     "-V",
 ];
 
-fn split_leading_strict_paths(args: &[String]) -> (Option<String>, usize) {
-    if args.len() <= 1 {
-        return (None, 1);
-    }
-
-    let Some(arg) = args.get(1) else {
-        return (None, 1);
-    };
-    if let Some(value) = arg.strip_prefix("--strict-paths=") {
-        return (Some(value.to_string()), 2);
-    }
-    if arg == "--strict-paths" {
-        if let Some(value) = args.get(2) {
-            return (Some(value.clone()), 3);
-        }
-        return (Some(String::new()), 2);
-    }
-    (None, 1)
-}
-
 fn absolute_path(path: &str) -> NormalizedPath {
     let path = Path::new(path);
     if path.is_absolute() {
@@ -383,15 +376,23 @@ fn main() -> ExitCode {
 
     // Auto-detect: if first arg isn't a known subcommand or a --flag, enter wrap mode.
     // e.g., `zccache clang++ -c foo.cpp -o foo.o`
-    let (auto_strict_paths, auto_wrap_start) = split_leading_strict_paths(&args);
-    if args.len() > auto_wrap_start
-        && !KNOWN_SUBCOMMANDS.contains(&args[auto_wrap_start].as_str())
-        && !args[auto_wrap_start].starts_with("--")
-    {
-        return run_wrap(&args[auto_wrap_start..], auto_strict_paths.as_deref());
+    match strip_leading_strict_paths_flags(&args[1..]) {
+        Ok((strict_paths, wrapper_args))
+            if !wrapper_args.is_empty()
+                && !KNOWN_SUBCOMMANDS.contains(&wrapper_args[0].as_str())
+                && !wrapper_args[0].starts_with("--") =>
+        {
+            return run_wrap(&wrapper_args, strict_paths);
+        }
+        Err(err) => {
+            eprintln!("zccache: {err}");
+            return ExitCode::FAILURE;
+        }
+        _ => {}
     }
 
     let cli = Cli::parse();
+    let global_strict_paths = cli.strict_paths.clone();
 
     init_tracing();
 
@@ -405,7 +406,6 @@ fn main() -> ExitCode {
         return run_async(cmd_status(&endpoint));
     }
 
-    let global_strict_paths = cli.strict_paths.clone();
     let command = match cli.command {
         Some(cmd) => cmd,
         None => {
@@ -531,10 +531,18 @@ fn main() -> ExitCode {
             let endpoint = resolve_endpoint(endpoint.as_deref());
             run_async(cmd_session_stats(&endpoint, session_id))
         }
-        Commands::Wrap { strict_paths, args } => run_wrap(
-            &args,
-            strict_paths.as_deref().or(global_strict_paths.as_deref()),
-        ),
+        Commands::Wrap { strict_paths, args } => {
+            let strict_paths = match parse_optional_strict_paths(
+                strict_paths.as_deref().or(global_strict_paths.as_deref()),
+            ) {
+                Ok(mode) => mode,
+                Err(err) => {
+                    eprintln!("zccache: {err}");
+                    return ExitCode::FAILURE;
+                }
+            };
+            run_wrap(&args, strict_paths)
+        }
         Commands::Inspect { key } => {
             eprintln!("zccache inspect {key}: not yet implemented");
             ExitCode::FAILURE
@@ -2035,6 +2043,57 @@ fn run_tool_direct(tool: &Path, args: &[String]) -> ExitCode {
 
 // ─── Wrap (compiler wrapper) ───────────────────────────────────────────────
 
+fn strip_leading_strict_paths_flags(
+    args: &[String],
+) -> Result<(Option<StrictPathsMode>, Vec<String>), String> {
+    let mut strict_paths = None;
+    let mut index = 0;
+
+    while let Some(arg) = args.get(index) {
+        if arg == "--strict-paths" {
+            strict_paths = Some(StrictPathsMode::Absolute);
+            index += 1;
+        } else if let Some(value) = arg.strip_prefix("--strict-paths=") {
+            strict_paths = Some(StrictPathsMode::parse(value).map_err(|err| err.to_string())?);
+            index += 1;
+        } else {
+            break;
+        }
+    }
+
+    Ok((strict_paths, args[index..].to_vec()))
+}
+
+fn parse_optional_strict_paths(value: Option<&str>) -> Result<Option<StrictPathsMode>, String> {
+    value
+        .map(|value| StrictPathsMode::parse(value).map_err(|err| err.to_string()))
+        .transpose()
+}
+
+fn effective_strict_paths_mode(
+    strict_paths_override: Option<StrictPathsMode>,
+) -> Result<StrictPathsMode, String> {
+    if let Some(mode) = strict_paths_override {
+        return Ok(mode);
+    }
+
+    match std::env::var("ZCCACHE_STRICT_PATHS") {
+        Ok(value) => StrictPathsMode::parse(&value).map_err(|err| err.to_string()),
+        Err(std::env::VarError::NotPresent) => Ok(StrictPathsMode::Off),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            Err("ZCCACHE_STRICT_PATHS is not valid Unicode".to_string())
+        }
+    }
+}
+
+fn set_client_env(env: &mut Vec<(String, String)>, key: &str, value: String) {
+    if let Some((_, existing)) = env.iter_mut().find(|(env_key, _)| env_key == key) {
+        *existing = value;
+    } else {
+        env.push((key.to_string(), value));
+    }
+}
+
 /// Wrap a compiler or tool invocation.
 ///
 /// `args` is the full command: ["clang++", "-c", "foo.cpp", "-o", "foo.o"]
@@ -2045,7 +2104,7 @@ fn run_tool_direct(tool: &Path, args: &[String]) -> ExitCode {
 ///
 /// If ZCCACHE_SESSION_ID is set, uses that session and sends the tool
 /// as a per-request override. If unset, auto-creates an ephemeral session.
-fn run_wrap(args: &[String], strict_paths_arg: Option<&str>) -> ExitCode {
+fn run_wrap(args: &[String], strict_paths_override: Option<StrictPathsMode>) -> ExitCode {
     if args.is_empty() {
         eprintln!("usage: zccache <compiler|tool> <args...>");
         return ExitCode::FAILURE;
@@ -2055,6 +2114,14 @@ fn run_wrap(args: &[String], strict_paths_arg: Option<&str>) -> ExitCode {
     if std::env::var("ZCCACHE_DISABLE").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true")) {
         return run_passthrough(args);
     }
+
+    let strict_paths_mode = match effective_strict_paths_mode(strict_paths_override) {
+        Ok(mode) => mode,
+        Err(err) => {
+            eprintln!("zccache: {err}");
+            return ExitCode::FAILURE;
+        }
+    };
 
     // Normalize MSYS paths (e.g. /c/Users/... → C:\Users\...) on Windows,
     // then resolve to an absolute path so the daemon can find it.
@@ -2067,7 +2134,14 @@ fn run_wrap(args: &[String], strict_paths_arg: Option<&str>) -> ExitCode {
 
     let cwd = std::env::current_dir().unwrap_or_default();
 
-    let client_env: Vec<(String, String)> = std::env::vars().collect();
+    let mut client_env: Vec<(String, String)> = std::env::vars().collect();
+    if let Some(mode) = strict_paths_override {
+        set_client_env(
+            &mut client_env,
+            "ZCCACHE_STRICT_PATHS",
+            mode.as_str().to_string(),
+        );
+    }
     let endpoint = resolve_endpoint(None);
 
     // Release the CWD handle on the build directory. On Windows, a process's
@@ -2093,19 +2167,12 @@ fn run_wrap(args: &[String], strict_paths_arg: Option<&str>) -> ExitCode {
         ));
     }
 
-    // Otherwise, treat as a compiler invocation
-    let strict_mode = match resolve_strict_path_mode(strict_paths_arg) {
-        Ok(mode) => mode,
-        Err(message) => {
-            eprintln!("zccache: {message}");
-            return ExitCode::FAILURE;
-        }
-    };
-    if let Err(violation) = validate_compiler_paths(strict_mode, &tool_args, &cwd, args) {
-        eprintln!("{violation}");
+    if let Err(err) = zccache_compiler::strict_paths::validate_args(&tool_args, strict_paths_mode) {
+        eprintln!("{}", err.diagnostic(&args[0], &tool_args));
         return ExitCode::FAILURE;
     }
 
+    // Otherwise, treat as a compiler invocation
     match std::env::var("ZCCACHE_SESSION_ID") {
         Ok(session_id) => {
             if session_id.is_empty() {
@@ -2132,47 +2199,6 @@ fn run_wrap(args: &[String], strict_paths_arg: Option<&str>) -> ExitCode {
             ))
         }
     }
-}
-
-fn resolve_strict_path_mode(
-    cli_value: Option<&str>,
-) -> Result<zccache_compiler::strict_paths::StrictPathMode, String> {
-    let raw = cli_value
-        .map(ToOwned::to_owned)
-        .or_else(|| std::env::var(zccache_compiler::strict_paths::STRICT_PATHS_ENV).ok())
-        .unwrap_or_else(|| "off".to_string());
-
-    zccache_compiler::strict_paths::StrictPathMode::parse(&raw).ok_or_else(|| {
-        format!("invalid --strict-paths value `{raw}` (expected off, consistent, or absolute)")
-    })
-}
-
-fn validate_compiler_paths(
-    mode: zccache_compiler::strict_paths::StrictPathMode,
-    tool_args: &[String],
-    cwd: &Path,
-    full_args: &[String],
-) -> Result<(), String> {
-    if mode == zccache_compiler::strict_paths::StrictPathMode::Off {
-        return Ok(());
-    }
-
-    let args_for_validation =
-        zccache_compiler::response_file::expand_response_files_in(tool_args, cwd)
-            .unwrap_or_else(|_| tool_args.to_vec());
-
-    zccache_compiler::strict_paths::validate_strict_paths(&args_for_validation, cwd, mode).map_err(
-        |err| {
-            format!(
-                "zccache: {} flag `{}` violates --strict-paths={} ({}).\n         Caller: {}",
-                err.flag,
-                err.path,
-                err.mode.as_str(),
-                err.reason,
-                full_args.join(" ")
-            )
-        },
-    )
 }
 
 /// Resolve a compiler name/path to an absolute path.
@@ -2541,10 +2567,8 @@ async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
 
     // Check lock file for a running daemon we just can't reach yet
     if let Some(pid) = zccache_ipc::check_running_daemon() {
-        let mut backoff = std::time::Duration::from_millis(100);
         for _ in 0..20 {
-            tokio::time::sleep(backoff).await;
-            backoff = (backoff * 2).min(std::time::Duration::from_millis(500));
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             match check_daemon_version(endpoint).await {
                 VersionCheck::Ok => return Ok(()),
                 VersionCheck::DaemonNewer { daemon_ver } => {
@@ -2575,7 +2599,7 @@ async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
             }
         }
         return Err(format!(
-            "daemon process {pid} exists but not accepting connections after retrying"
+            "daemon process {pid} exists but not accepting connections"
         ));
     }
 
@@ -2797,99 +2821,6 @@ fn init_tracing() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsString;
-    use std::sync::{Mutex, MutexGuard};
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct EnvGuard {
-        _lock: MutexGuard<'static, ()>,
-        previous: Option<OsString>,
-    }
-
-    impl EnvGuard {
-        fn set_cache_dir(value: &std::path::Path) -> Self {
-            let lock = ENV_LOCK.lock().unwrap();
-            let previous = std::env::var_os(zccache_core::config::CACHE_DIR_ENV);
-            std::env::set_var(zccache_core::config::CACHE_DIR_ENV, value);
-            Self {
-                _lock: lock,
-                previous,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.previous {
-                Some(value) => std::env::set_var(zccache_core::config::CACHE_DIR_ENV, value),
-                None => std::env::remove_var(zccache_core::config::CACHE_DIR_ENV),
-            }
-        }
-    }
-
-    fn fake_status() -> zccache_protocol::DaemonStatus {
-        zccache_protocol::DaemonStatus {
-            version: zccache_core::VERSION.to_string(),
-            artifact_count: 0,
-            cache_size_bytes: 0,
-            metadata_entries: 0,
-            uptime_secs: 0,
-            cache_hits: 0,
-            cache_misses: 0,
-            total_compilations: 0,
-            non_cacheable: 0,
-            compile_errors: 0,
-            time_saved_ms: 0,
-            total_links: 0,
-            link_hits: 0,
-            link_misses: 0,
-            link_non_cacheable: 0,
-            dep_graph_contexts: 0,
-            dep_graph_files: 0,
-            sessions_total: 0,
-            sessions_active: 0,
-            cache_dir: zccache_core::config::default_cache_dir(),
-            dep_graph_version: 0,
-            dep_graph_disk_size: 0,
-        }
-    }
-
-    #[test]
-    fn split_leading_strict_paths_supports_equals_form() {
-        let args = vec![
-            "zccache".to_string(),
-            "--strict-paths=absolute".to_string(),
-            "clang++".to_string(),
-        ];
-
-        let (mode, start) = split_leading_strict_paths(&args);
-
-        assert_eq!(mode.as_deref(), Some("absolute"));
-        assert_eq!(start, 2);
-    }
-
-    #[test]
-    fn split_leading_strict_paths_supports_space_form() {
-        let args = vec![
-            "zccache".to_string(),
-            "--strict-paths".to_string(),
-            "consistent".to_string(),
-            "clang++".to_string(),
-        ];
-
-        let (mode, start) = split_leading_strict_paths(&args);
-
-        assert_eq!(mode.as_deref(), Some("consistent"));
-        assert_eq!(start, 3);
-    }
-
-    #[test]
-    fn resolve_strict_path_mode_rejects_invalid_cli_value() {
-        let err = resolve_strict_path_mode(Some("sometimes")).unwrap_err();
-
-        assert!(err.contains("invalid --strict-paths value"));
-    }
 
     #[test]
     fn exit_code_zero_stays_zero() {
@@ -2929,46 +2860,6 @@ mod tests {
     fn exit_code_257_keeps_low_byte() {
         // 257 & 0xFF == 1, non-zero, so kept as-is.
         assert_eq!(exit_code_from_i32(257), ExitCode::from(1));
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn ensure_daemon_waits_for_delayed_listener() {
-        let endpoint = zccache_ipc::unique_test_endpoint();
-        let cache_root = tempfile::tempdir().unwrap();
-        let _env = EnvGuard::set_cache_dir(cache_root.path());
-        let lock_path = zccache_ipc::lock_file_path();
-
-        std::fs::write(&lock_path, std::process::id().to_string()).unwrap();
-
-        let ep = endpoint.clone();
-        let cache_dir = cache_root.path().to_path_buf();
-        let server = tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-
-            let mut listener = zccache_ipc::IpcListener::bind(&ep).unwrap();
-            let mut conn = listener.accept().await.unwrap();
-
-            let req: Option<zccache_protocol::Request> = conn.recv().await.unwrap();
-            assert_eq!(req, Some(zccache_protocol::Request::Status));
-
-            conn.send(&zccache_protocol::Response::Status(
-                zccache_protocol::DaemonStatus {
-                    cache_dir: cache_dir.into(),
-                    ..fake_status()
-                },
-            ))
-            .await
-            .unwrap();
-        });
-
-        let result = ensure_daemon(&endpoint).await;
-        let _ = std::fs::remove_file(&lock_path);
-        server.await.unwrap();
-
-        assert!(
-            result.is_ok(),
-            "expected delayed daemon to be accepted: {result:?}"
-        );
     }
 
     #[test]

--- a/crates/zccache-compiler/src/strict_paths.rs
+++ b/crates/zccache-compiler/src/strict_paths.rs
@@ -1,35 +1,48 @@
-//! Strict validation for compiler path flags.
+//! Strict compiler path flag validation.
+//!
+//! This catches include/force-include path spellings that can make compilers
+//! see one physical header through multiple raw path strings.
 
-use std::collections::HashMap;
-use std::path::Path;
+use std::fmt;
 
-/// Environment variable used by the CLI to enable strict path validation.
-pub const STRICT_PATHS_ENV: &str = "ZCCACHE_STRICT_PATHS";
-
-/// Strict path validation policy.
+/// Validation policy for compiler path flags.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StrictPathMode {
-    /// Disable validation.
+pub enum StrictPathsMode {
+    /// Do not validate path spellings.
     Off,
-    /// Reject inconsistent include path spellings that can defeat `#pragma once`.
+    /// Require all checked path flags to use one separator style.
     Consistent,
-    /// Require forward-slash absolute include paths with no `.` or `..` segments.
+    /// Require forward-slash absolute paths with no `.` or `..` components.
     Absolute,
 }
 
-impl StrictPathMode {
-    /// Parse a mode string.
-    #[must_use]
-    pub fn parse(value: &str) -> Option<Self> {
-        match value.to_ascii_lowercase().as_str() {
-            "" | "off" | "0" | "false" | "no" => Some(Self::Off),
-            "consistent" => Some(Self::Consistent),
-            "absolute" | "strict" | "1" | "true" | "yes" => Some(Self::Absolute),
-            _ => None,
+impl StrictPathsMode {
+    /// Parse a `--strict-paths` / `ZCCACHE_STRICT_PATHS` value.
+    pub fn parse(value: &str) -> Result<Self, StrictPathsParseError> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => Ok(Self::Absolute),
+            "0" | "false" | "no" | "off" => Ok(Self::Off),
+            "consistent" => Ok(Self::Consistent),
+            "absolute" | "strict" => Ok(Self::Absolute),
+            other => Err(StrictPathsParseError {
+                value: other.to_string(),
+            }),
         }
     }
 
-    /// Return the canonical CLI spelling.
+    /// Read a mode from an environment-like key/value list.
+    pub fn from_env_vars<'a>(
+        vars: impl IntoIterator<Item = (&'a str, &'a str)>,
+    ) -> Result<Self, StrictPathsParseError> {
+        for (key, value) in vars {
+            if key == "ZCCACHE_STRICT_PATHS" {
+                return Self::parse(value);
+            }
+        }
+        Ok(Self::Off)
+    }
+
+    /// Canonical command-line spelling for diagnostics and env forwarding.
     #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {
@@ -40,41 +53,102 @@ impl StrictPathMode {
     }
 }
 
-/// A strict path validation failure.
+/// Invalid strict-path mode value.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StrictPathViolation {
-    /// Flag that introduced the offending path.
-    pub flag: String,
-    /// Offending path value.
-    pub path: String,
-    /// Active validation mode.
-    pub mode: StrictPathMode,
-    /// Human-readable reason.
-    pub reason: String,
+pub struct StrictPathsParseError {
+    value: String,
 }
 
-/// Validate compiler path flags according to `mode`.
-pub fn validate_strict_paths(
-    args: &[String],
-    cwd: &Path,
-    mode: StrictPathMode,
-) -> Result<(), StrictPathViolation> {
-    if mode == StrictPathMode::Off {
+impl fmt::Display for StrictPathsParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid strict paths mode '{}'; expected off, consistent, or absolute",
+            self.value
+        )
+    }
+}
+
+impl std::error::Error for StrictPathsParseError {}
+
+/// A strict-path validation failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StrictPathsViolation {
+    /// Mode that rejected the flag.
+    pub mode: StrictPathsMode,
+    /// Offending compiler flag as it appeared in argv.
+    pub flag: String,
+    /// Path value extracted from the flag.
+    pub path: String,
+    reason: String,
+}
+
+impl StrictPathsViolation {
+    /// Render a user-facing diagnostic with the wrapped compiler invocation.
+    #[must_use]
+    pub fn diagnostic(&self, compiler: &str, args: &[String]) -> String {
+        let mut caller_parts = Vec::with_capacity(args.len() + 1);
+        caller_parts.push(shell_quote(compiler));
+        caller_parts.extend(args.iter().map(|arg| shell_quote(arg)));
+        format!(
+            "zccache: {} flag `{}` violates --strict-paths={} ({}).\n         Caller: {}",
+            self.flag_name(),
+            self.flag,
+            self.mode.as_str(),
+            self.reason,
+            caller_parts.join(" ")
+        )
+    }
+
+    fn flag_name(&self) -> &str {
+        const FLAG_NAMES: &[&str] = &[
+            "-include-pch",
+            "-include",
+            "-idirafter",
+            "-iframework",
+            "-isystem",
+            "-iquote",
+            "-imacros",
+            "-imsvc",
+            "-I",
+            "-F",
+            "/I",
+        ];
+        FLAG_NAMES
+            .iter()
+            .copied()
+            .find(|name| self.flag == *name || self.flag.starts_with(&format!("{name} ")))
+            .or_else(|| {
+                FLAG_NAMES
+                    .iter()
+                    .copied()
+                    .find(|name| self.flag.starts_with(*name))
+            })
+            .unwrap_or(self.flag.as_str())
+    }
+}
+
+/// Validate path-bearing compiler flags in `args`.
+pub fn validate_args(args: &[String], mode: StrictPathsMode) -> Result<(), StrictPathsViolation> {
+    if mode == StrictPathsMode::Off {
         return Ok(());
     }
 
-    let paths = collect_path_flags(args);
-    if mode == StrictPathMode::Absolute {
-        for path_flag in &paths {
-            validate_absolute(path_flag, mode)?;
+    let mut style: Option<SeparatorStyle> = None;
+    for flag in collect_path_flags(args) {
+        match mode {
+            StrictPathsMode::Off => {}
+            StrictPathsMode::Consistent => validate_consistent(&flag, &mut style)?,
+            StrictPathsMode::Absolute => validate_absolute(&flag)?,
         }
     }
-
-    if mode == StrictPathMode::Consistent || mode == StrictPathMode::Absolute {
-        validate_consistent(&paths, cwd, mode)?;
-    }
-
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SeparatorStyle {
+    Forward,
+    Backslash,
 }
 
 #[derive(Debug)]
@@ -83,16 +157,108 @@ struct PathFlag {
     path: String,
 }
 
+fn validate_consistent(
+    flag: &PathFlag,
+    style: &mut Option<SeparatorStyle>,
+) -> Result<(), StrictPathsViolation> {
+    let has_forward = flag.path.contains('/');
+    let has_backslash = flag.path.contains('\\');
+
+    if has_forward && has_backslash {
+        return Err(StrictPathsViolation {
+            mode: StrictPathsMode::Consistent,
+            flag: flag.flag.clone(),
+            path: flag.path.clone(),
+            reason: "expected one separator style per path".to_string(),
+        });
+    }
+
+    let Some(current) = separator_style(&flag.path) else {
+        return Ok(());
+    };
+    match *style {
+        Some(expected) if expected != current => Err(StrictPathsViolation {
+            mode: StrictPathsMode::Consistent,
+            flag: flag.flag.clone(),
+            path: flag.path.clone(),
+            reason: "expected all checked paths to use the same separator style".to_string(),
+        }),
+        Some(_) => Ok(()),
+        None => {
+            *style = Some(current);
+            Ok(())
+        }
+    }
+}
+
+fn validate_absolute(flag: &PathFlag) -> Result<(), StrictPathsViolation> {
+    let reason = if flag.path.contains('\\') {
+        Some("expected forward-slash absolute path")
+    } else if !is_forward_absolute(&flag.path) {
+        Some("expected forward-slash absolute path")
+    } else if has_dot_component(&flag.path) {
+        Some("expected normalized path without /./ or /../ components")
+    } else {
+        None
+    };
+
+    match reason {
+        Some(reason) => Err(StrictPathsViolation {
+            mode: StrictPathsMode::Absolute,
+            flag: flag.flag.clone(),
+            path: flag.path.clone(),
+            reason: reason.to_string(),
+        }),
+        None => Ok(()),
+    }
+}
+
+fn separator_style(path: &str) -> Option<SeparatorStyle> {
+    if path.contains('/') {
+        Some(SeparatorStyle::Forward)
+    } else if path.contains('\\') {
+        Some(SeparatorStyle::Backslash)
+    } else {
+        None
+    }
+}
+
+fn is_forward_absolute(path: &str) -> bool {
+    if path.starts_with('/') {
+        return true;
+    }
+
+    let bytes = path.as_bytes();
+    bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'/'
+}
+
+fn has_dot_component(path: &str) -> bool {
+    path.split('/')
+        .any(|component| component == "." || component == "..")
+}
+
 fn collect_path_flags(args: &[String]) -> Vec<PathFlag> {
-    let mut result = Vec::new();
+    let mut flags = Vec::new();
     let mut i = 0;
     while i < args.len() {
         let arg = &args[i];
 
-        if takes_next_path(arg) {
+        if matches!(
+            arg.as_str(),
+            "-I" | "-F"
+                | "-isystem"
+                | "-iquote"
+                | "-idirafter"
+                | "-iframework"
+                | "-imsvc"
+                | "-include"
+                | "-include-pch"
+                | "-imacros"
+                | "/I"
+        ) {
             if let Some(path) = args.get(i + 1) {
-                result.push(PathFlag {
-                    flag: arg.clone(),
+                flags.push(PathFlag {
+                    flag: format!("{arg} {path}"),
                     path: path.clone(),
                 });
                 i += 2;
@@ -100,358 +266,190 @@ fn collect_path_flags(args: &[String]) -> Vec<PathFlag> {
             }
         }
 
-        if let Some((flag, path)) = split_joined_path_flag(arg) {
-            result.push(PathFlag {
-                flag: flag.to_string(),
+        if let Some(path) = arg.strip_prefix("-I").filter(|path| !path.is_empty()) {
+            flags.push(PathFlag {
+                flag: arg.clone(),
                 path: path.to_string(),
+            });
+        } else if let Some(path) = arg.strip_prefix("-F").filter(|path| !path.is_empty()) {
+            flags.push(PathFlag {
+                flag: arg.clone(),
+                path: path.to_string(),
+            });
+        } else if let Some(path) = arg
+            .strip_prefix("/I")
+            .filter(|path| !path.is_empty() && !path.starts_with(':'))
+        {
+            flags.push(PathFlag {
+                flag: arg.clone(),
+                path: path.to_string(),
+            });
+        } else if let Some(path) = joined_path_flag(arg) {
+            flags.push(PathFlag {
+                flag: arg.clone(),
+                path,
             });
         }
 
         i += 1;
     }
-    result
+    flags
 }
 
-fn takes_next_path(arg: &str) -> bool {
-    matches!(
-        arg,
-        "-I" | "/I"
-            | "-isystem"
-            | "-iquote"
-            | "-idirafter"
-            | "-include"
-            | "-include-pch"
-            | "-isysroot"
-            | "-imsvc"
-            | "/imsvc"
-            | "-F"
-            | "-iframework"
-    )
-}
+fn joined_path_flag(arg: &str) -> Option<String> {
+    const PREFIXES: &[&str] = &[
+        "-isystem",
+        "-iquote",
+        "-idirafter",
+        "-iframework",
+        "-imsvc",
+        "/imsvc",
+    ];
 
-fn split_joined_path_flag(arg: &str) -> Option<(&'static str, &str)> {
-    for prefix in ["-isystem", "-iquote", "-idirafter", "-imsvc", "/imsvc"] {
-        if let Some(path) = arg.strip_prefix(prefix) {
-            if !path.is_empty() {
-                return Some((prefix, path));
-            }
+    for prefix in PREFIXES {
+        if let Some(path) = arg.strip_prefix(prefix).filter(|path| !path.is_empty()) {
+            return Some(path.strip_prefix('=').unwrap_or(path).to_string());
         }
     }
-
-    if let Some(path) = arg.strip_prefix("--include-directory=") {
-        if !path.is_empty() {
-            return Some(("--include-directory", path));
-        }
-    }
-
-    if let Some(path) = arg.strip_prefix("/I") {
-        if !path.is_empty() {
-            return Some(("/I", path));
-        }
-    }
-
-    if let Some(path) = arg.strip_prefix("-I") {
-        if !path.is_empty() {
-            return Some(("-I", path));
-        }
-    }
-
-    if let Some(path) = arg.strip_prefix("-F") {
-        if !path.is_empty() {
-            return Some(("-F", path));
-        }
-    }
-
     None
 }
 
-fn validate_absolute(
-    path_flag: &PathFlag,
-    mode: StrictPathMode,
-) -> Result<(), StrictPathViolation> {
-    if path_flag.path.contains('\\') {
-        return Err(violation(
-            path_flag,
-            mode,
-            "expected forward-slash absolute path",
-        ));
-    }
-    if !is_absolute_like(&path_flag.path) {
-        return Err(violation(
-            path_flag,
-            mode,
-            "expected forward-slash absolute path",
-        ));
-    }
-    if has_dot_segment(&path_flag.path) {
-        return Err(violation(
-            path_flag,
-            mode,
-            "expected normalized path without /./ or /../ segments",
-        ));
-    }
-    Ok(())
-}
-
-fn validate_consistent(
-    paths: &[PathFlag],
-    cwd: &Path,
-    mode: StrictPathMode,
-) -> Result<(), StrictPathViolation> {
-    let mut style: Option<SeparatorStyle> = None;
-    let mut seen: HashMap<String, &PathFlag> = HashMap::new();
-
-    for path_flag in paths {
-        match separator_style(&path_flag.path) {
-            SeparatorStyle::Mixed => {
-                return Err(violation(
-                    path_flag,
-                    mode,
-                    "mixed forward-slash and backslash separators",
-                ));
-            }
-            SeparatorStyle::Forward | SeparatorStyle::Backslash => {
-                let current = separator_style(&path_flag.path);
-                if let Some(expected) = style {
-                    if current != expected {
-                        return Err(violation(
-                            path_flag,
-                            mode,
-                            "include path separator style differs from earlier path flags",
-                        ));
-                    }
-                } else {
-                    style = Some(current);
-                }
-            }
-            SeparatorStyle::None => {}
-        }
-
-        let key = canonical_key(&path_flag.path, cwd);
-        if let Some(previous) = seen.get(&key) {
-            if previous.path != path_flag.path {
-                return Err(StrictPathViolation {
-                    flag: path_flag.flag.clone(),
-                    path: path_flag.path.clone(),
-                    mode,
-                    reason: format!(
-                        "same canonical path was already passed as `{}` via {}",
-                        previous.path, previous.flag
-                    ),
-                });
-            }
-        } else {
-            seen.insert(key, path_flag);
-        }
-    }
-
-    Ok(())
-}
-
-fn violation(path_flag: &PathFlag, mode: StrictPathMode, reason: &str) -> StrictPathViolation {
-    StrictPathViolation {
-        flag: path_flag.flag.clone(),
-        path: path_flag.path.clone(),
-        mode,
-        reason: reason.to_string(),
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SeparatorStyle {
-    None,
-    Forward,
-    Backslash,
-    Mixed,
-}
-
-fn separator_style(path: &str) -> SeparatorStyle {
-    match (path.contains('/'), path.contains('\\')) {
-        (false, false) => SeparatorStyle::None,
-        (true, false) => SeparatorStyle::Forward,
-        (false, true) => SeparatorStyle::Backslash,
-        (true, true) => SeparatorStyle::Mixed,
-    }
-}
-
-fn is_absolute_like(path: &str) -> bool {
-    let bytes = path.as_bytes();
-    path.starts_with('/')
-        || path.starts_with("//")
-        || (bytes.len() >= 3
-            && bytes[0].is_ascii_alphabetic()
-            && bytes[1] == b':'
-            && (bytes[2] == b'/' || bytes[2] == b'\\'))
-}
-
-fn has_dot_segment(path: &str) -> bool {
-    path.split(['/', '\\'])
-        .any(|segment| segment == "." || segment == "..")
-}
-
-fn canonical_key(path: &str, cwd: &Path) -> String {
-    let mut value = path.replace('\\', "/");
-    let windows_like = has_drive_prefix(&value) || path.contains('\\');
-    if !is_absolute_like(&value) {
-        let cwd = cwd.to_string_lossy().replace('\\', "/");
-        value = format!("{cwd}/{value}");
-    }
-
-    let mut prefix = String::new();
-    let mut rest = value.as_str();
-    if has_drive_prefix(rest) {
-        prefix = rest[..2].to_ascii_lowercase();
-        rest = &rest[2..];
-    } else if rest.starts_with("//") {
-        prefix = "//".to_string();
-        rest = rest.trim_start_matches('/');
-    } else if rest.starts_with('/') {
-        prefix = "/".to_string();
-        rest = rest.trim_start_matches('/');
-    }
-
-    let mut segments: Vec<&str> = Vec::new();
-    for segment in rest.split('/') {
-        match segment {
-            "" | "." => {}
-            ".." => {
-                segments.pop();
-            }
-            _ => segments.push(segment),
-        }
-    }
-
-    let mut key = if prefix.is_empty() {
-        segments.join("/")
-    } else if prefix == "/" || prefix == "//" {
-        format!("{prefix}{}", segments.join("/"))
+fn shell_quote(value: &str) -> String {
+    if value.is_empty()
+        || value
+            .chars()
+            .any(|c| c.is_whitespace() || matches!(c, '"' | '\'' | '`' | '$'))
+    {
+        format!("\"{}\"", value.replace('"', "\\\""))
     } else {
-        format!("{prefix}/{}", segments.join("/"))
-    };
-    if windows_like {
-        key.make_ascii_lowercase();
+        value.to_string()
     }
-    key
-}
-
-fn has_drive_prefix(path: &str) -> bool {
-    let bytes = path.as_bytes();
-    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
 
-    fn args(values: &[&str]) -> Vec<String> {
-        values.iter().map(ToString::to_string).collect()
+    fn args(s: &[&str]) -> Vec<String> {
+        s.iter().map(|arg| (*arg).to_string()).collect()
     }
 
     #[test]
     fn absolute_rejects_relative_include() {
-        let err = validate_strict_paths(
-            &args(&["-c", "main.cpp", "-Iinclude"]),
-            Path::new("/work"),
-            StrictPathMode::Absolute,
+        let err = validate_args(
+            &args(&["-c", "foo.cpp", "-Iinclude"]),
+            StrictPathsMode::Absolute,
         )
         .unwrap_err();
-        assert_eq!(err.flag, "-I");
-        assert_eq!(err.path, "include");
+        assert_eq!(err.flag, "-Iinclude");
         assert!(err.reason.contains("absolute"));
     }
 
     #[test]
-    fn absolute_rejects_dot_segments() {
-        let err = validate_strict_paths(
-            &args(&["-IC:/Users/me/project/./src", "main.cpp"]),
-            Path::new("C:/Users/me/project"),
-            StrictPathMode::Absolute,
+    fn absolute_rejects_backslash_include() {
+        let err = validate_args(
+            &args(&["-c", "foo.cpp", r"-IC:\work\project\include"]),
+            StrictPathsMode::Absolute,
         )
         .unwrap_err();
-        assert_eq!(err.path, "C:/Users/me/project/./src");
-        assert!(err.reason.contains("normalized"));
+        assert_eq!(err.flag, r"-IC:\work\project\include");
     }
 
     #[test]
-    fn absolute_rejects_backslashes() {
-        let err = validate_strict_paths(
-            &args(&["-I", r"C:\Users\me\project\src", "main.cpp"]),
-            Path::new("C:/Users/me/project"),
-            StrictPathMode::Absolute,
+    fn absolute_rejects_dot_component() {
+        let err = validate_args(
+            &args(&["-c", "foo.cpp", "-IC:/work/project/./include"]),
+            StrictPathsMode::Absolute,
         )
         .unwrap_err();
-        assert_eq!(err.flag, "-I");
-        assert!(err.reason.contains("forward-slash"));
+        assert_eq!(err.path, "C:/work/project/./include");
+        assert!(err.reason.contains("/./"));
     }
 
     #[test]
-    fn consistent_rejects_mixed_separators_in_one_path() {
-        let err = validate_strict_paths(
-            &args(&["-Ici/meson/native\\fastled.dll.p", "main.cpp"]),
-            Path::new("C:/Users/me/project"),
-            StrictPathMode::Consistent,
-        )
-        .unwrap_err();
-        assert_eq!(err.flag, "-I");
-        assert!(err.reason.contains("mixed"));
-    }
-
-    #[test]
-    fn consistent_rejects_same_path_with_different_spellings() {
-        let err = validate_strict_paths(
+    fn absolute_accepts_forward_windows_and_unix_paths() {
+        validate_args(
             &args(&[
-                "-IC:/Users/me/fastled6/./src",
-                "-I",
-                "C:/Users/me/fastled6/src",
-                "main.cpp",
+                "-IC:/work/project/include",
+                "-isystem",
+                "/opt/sdk/include",
+                "-include-pch",
+                "C:/work/project/pch.h.pch",
             ]),
-            Path::new("C:/Users/me/fastled6"),
-            StrictPathMode::Consistent,
+            StrictPathsMode::Absolute,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn consistent_rejects_mixed_separators_within_one_path() {
+        let err = validate_args(
+            &args(&["-c", "foo.cpp", r"-Ici/meson/native\fastled.dll.p"]),
+            StrictPathsMode::Consistent,
         )
         .unwrap_err();
-        assert_eq!(err.flag, "-I");
-        assert_eq!(err.path, "C:/Users/me/fastled6/src");
-        assert!(err.reason.contains("same canonical path"));
+        assert!(err.reason.contains("one separator style"));
     }
 
     #[test]
-    fn consistent_accepts_repeated_identical_path() {
-        validate_strict_paths(
-            &args(&["-I", "src", "-I", "src", "main.cpp"]),
-            Path::new("/work"),
-            StrictPathMode::Consistent,
+    fn consistent_rejects_different_styles_across_flags() {
+        let err = validate_args(
+            &args(&["-IC:/work/project/include", r"-IC:\work\project\generated"]),
+            StrictPathsMode::Consistent,
+        )
+        .unwrap_err();
+        assert!(err.reason.contains("same separator style"));
+    }
+
+    #[test]
+    fn validates_joined_path_flags() {
+        for flag in [
+            "-isysteminclude",
+            "-isystem=include",
+            "-iquoteinclude",
+            "-idirafterinclude",
+            "-iframeworkinclude",
+            "-imsvcinclude",
+        ] {
+            let err = validate_args(&args(&["-c", "foo.cpp", flag]), StrictPathsMode::Absolute)
+                .unwrap_err();
+            assert_eq!(err.flag, flag);
+            assert_eq!(err.path, "include");
+        }
+    }
+
+    #[test]
+    fn consistent_allows_styleless_relative_paths() {
+        validate_args(
+            &args(&["-Iinclude", "-isystem", "generated"]),
+            StrictPathsMode::Consistent,
         )
         .unwrap();
     }
 
     #[test]
-    fn strict_paths_catches_paths_inside_response_file() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            dir.path().join("flags.rsp"),
-            "-IC:/Users/me/fastled6/./src -IC:/Users/me/fastled6/src",
+    fn diagnostic_includes_caller() {
+        let err = validate_args(
+            &args(&["-c", "foo.cpp", "-Irelative"]),
+            StrictPathsMode::Absolute,
         )
-        .unwrap();
-        let expanded =
-            crate::response_file::expand_response_files_in(&args(&["@flags.rsp"]), dir.path())
-                .unwrap();
-
-        let err =
-            validate_strict_paths(&expanded, dir.path(), StrictPathMode::Consistent).unwrap_err();
-
-        assert_eq!(err.flag, "-I");
-        assert_eq!(err.path, "C:/Users/me/fastled6/src");
-        assert!(err.reason.contains("same canonical path"));
+        .unwrap_err();
+        let diagnostic = err.diagnostic("clang++", &args(&["-c", "foo.cpp", "-Irelative"]));
+        assert!(diagnostic.contains("violates --strict-paths=absolute"));
+        assert!(diagnostic.contains("Caller: clang++ -c foo.cpp -Irelative"));
     }
 
     #[test]
-    fn off_ignores_violations() {
-        validate_strict_paths(
-            &args(&["-Ici/meson/native\\fastled.dll.p", "main.cpp"]),
-            Path::new("/work"),
-            StrictPathMode::Off,
-        )
-        .unwrap();
+    fn parse_env_aliases() {
+        assert_eq!(
+            StrictPathsMode::parse("1").unwrap(),
+            StrictPathsMode::Absolute
+        );
+        assert_eq!(
+            StrictPathsMode::parse("consistent").unwrap(),
+            StrictPathsMode::Consistent
+        );
+        assert_eq!(StrictPathsMode::parse("off").unwrap(), StrictPathsMode::Off);
+        assert!(StrictPathsMode::parse("sometimes").is_err());
     }
 }

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -2590,6 +2590,30 @@ fn request_fingerprint(compiler: &Path, args: &[String], cwd: &Path) -> ContentH
     h.finalize()
 }
 
+fn strict_paths_mode_from_client_env(
+    client_env: Option<&[(String, String)]>,
+) -> Result<zccache_compiler::strict_paths::StrictPathsMode, String> {
+    let Some(env) = client_env else {
+        return Ok(zccache_compiler::strict_paths::StrictPathsMode::Off);
+    };
+    zccache_compiler::strict_paths::StrictPathsMode::from_env_vars(
+        env.iter()
+            .map(|(key, value)| (key.as_str(), value.as_str())),
+    )
+    .map_err(|err| err.to_string())
+}
+
+fn compile_failure_stderr(message: String) -> Response {
+    let mut stderr = message.into_bytes();
+    stderr.push(b'\n');
+    Response::CompileResult {
+        exit_code: 1,
+        stdout: Arc::new(Vec::new()),
+        stderr: Arc::new(stderr),
+        cached: false,
+    }
+}
+
 /// Handle a Compile request: parse args, check depgraph, run compiler or return cached.
 async fn handle_compile(
     state_arc: &Arc<SharedState>,
@@ -2612,6 +2636,17 @@ async fn handle_compile(
     // Expand response files before request-level caching so `@file` mutations
     // can't reuse stale fast-hit entries keyed only by raw argv.
     let expanded_args = expand_args_cached(state, args, cwd);
+
+    let strict_paths_mode = match strict_paths_mode_from_client_env(client_env.as_deref()) {
+        Ok(mode) => mode,
+        Err(err) => return compile_failure_stderr(format!("zccache: {err}")),
+    };
+    if let Err(err) =
+        zccache_compiler::strict_paths::validate_args(&expanded_args, strict_paths_mode)
+    {
+        let compiler = compiler_path.display().to_string();
+        return compile_failure_stderr(err.diagnostic(&compiler, &expanded_args));
+    }
 
     // ── Ultra-fast request-level cache ────────────────────────────────
     // If we've seen this exact (compiler, args, cwd) before AND the fast-hit


### PR DESCRIPTION
## Summary
- carry forward the dirty strict-path validation changes into a PR
- parse --strict-paths into a typed mode and forward explicit CLI settings through client env
- validate expanded compiler args in the daemon so response-file paths are checked after expansion
- document strict path modes and checked path flags

## Verification
- cargo fmt --all -- --check
- CARGO_TARGET_DIR=C:\Users\niteris\dev\zccache-dirty-pr-target cargo test -p zccache-compiler strict_paths
- CARGO_TARGET_DIR=C:\Users\niteris\dev\zccache-dirty-pr-target cargo test -p zccache-cli --no-run
- CARGO_TARGET_DIR=C:\Users\niteris\dev\zccache-dirty-pr-target cargo test -p zccache-daemon --no-run