### PR TITLE
ci: make crates publish reruns idempotent

### DIFF
--- a/ci/release_workflow.py
+++ b/ci/release_workflow.py
@@ -204,7 +204,7 @@ def crate_version_exists(name: str, version: str) -> bool:
         raise
 
 
-def check_crates_versions(version: str) -> set[str]:
+def check_crates_versions(version: str, *, fail_if_all_exist: bool = True) -> set[str]:
     log(f"\n=== Pre-check crates.io for Rust crates {version} ===")
     existing: list[str] = []
     for crate in RUST_PUBLISH_ORDER:
@@ -217,11 +217,14 @@ def check_crates_versions(version: str) -> set[str]:
         except (urllib.error.URLError, TimeoutError) as e:
             log(f"  WARNING: Could not reach crates.io for {crate} ({e})")
 
-    if len(existing) == len(RUST_PUBLISH_ORDER):
-        log("  ERROR: all publishable crates already exist on crates.io")
-        raise SystemExit(1)
+    all_crates_exist = len(existing) == len(RUST_PUBLISH_ORDER)
+    if all_crates_exist:
+        if fail_if_all_exist:
+            log("  ERROR: all publishable crates already exist on crates.io")
+            raise SystemExit(1)
+        log("  All publishable crates already exist on crates.io; nothing to publish.")
 
-    if existing:
+    if existing and not all_crates_exist:
         log("  Resuming partial crates.io release; already-published crates will be skipped.")
 
     return set(existing)
@@ -572,7 +575,7 @@ def command_publish_crates(_: argparse.Namespace) -> None:
     if not os.environ.get("CARGO_REGISTRY_TOKEN"):
         raise SystemExit("ERROR: CARGO_REGISTRY_TOKEN is required for crates.io publish")
     version = read_workspace_version()
-    existing_crates = check_crates_versions(version)
+    existing_crates = check_crates_versions(version, fail_if_all_exist=False)
     publish_rust_crates(version, existing_crates)
 
 

--- a/ci/tests/test_release_workflow.py
+++ b/ci/tests/test_release_workflow.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from ci import release_workflow
 from ci.release_workflow import (
     assert_installed_wheel_scripts_executable,
     assert_wheel_script_metadata,
@@ -90,3 +91,25 @@ def test_assert_installed_wheel_scripts_executable_accepts_pip_target_install(
     )
 
     assert_installed_wheel_scripts_executable(wheel_path)
+
+
+def test_check_crates_versions_fails_preflight_when_all_crates_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(release_workflow, "RUST_PUBLISH_ORDER", ["zccache-a", "zccache-b"])
+    monkeypatch.setattr(release_workflow, "crate_version_exists", lambda _name, _version: True)
+
+    with pytest.raises(SystemExit):
+        release_workflow.check_crates_versions("1.2.3")
+
+
+def test_check_crates_versions_allows_publish_resume_when_all_crates_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(release_workflow, "RUST_PUBLISH_ORDER", ["zccache-a", "zccache-b"])
+    monkeypatch.setattr(release_workflow, "crate_version_exists", lambda _name, _version: True)
+
+    assert release_workflow.check_crates_versions(
+        "1.2.3",
+        fail_if_all_exist=False,
+    ) == {"zccache-a", "zccache-b"}


### PR DESCRIPTION
## Summary
- keep `check-registries` strict when every publishable crate already exists on crates.io
- let the `publish-crates` command treat an all-existing crates.io set as a completed no-op
- add tests for the split preflight vs publish-resume behavior

## Investigation
The failed job was `Publish crates.io` in run `24795083905` / job `72607567915`. It checked version `1.3.7`, found every publishable crate already existed on crates.io, then exited with `ERROR: all publishable crates already exist on crates.io`. That is correct for early preflight, but wrong for a resumed publish job: this job already skips individual existing crates, so the all-existing case should also succeed and allow the release workflow to continue.

## Verification
- `uv run --with pytest python -m pytest ci/tests/test_release_workflow.py`
- `uv run python -m ci.release_checks`
- `git diff --check`
