### PR TITLE
ci: use hot setup-soldr target cache

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -22,10 +22,7 @@ jobs:
           version: v0.7.8
           toolchain: 1.94.1
           cache: true
-          target-cache-mode: full
-          target-cache-paths: |
-            target/debug
-            target/x86_64-pc-windows-msvc/debug
+          target-cache-mode: hot
       - name: Check
         run: soldr cargo check --workspace --all-targets
       - name: Test


### PR DESCRIPTION
## Summary
- switch CI Check from full setup-soldr target caching to hot target caching
- keep the soldr pin and zccache shutdown logic from PR #101

## Rationale
PR #101 proved that pinning soldr fixes the managed-zccache bootstrap loop, but the full target cache still restores 10-12 GB on warm runs. That kept Linux and Windows above the ~2 minute target:

- macOS: 1m43s
- Linux: 2m32s
- Windows: 2m54s

`target-cache-mode: hot` should keep Cargo freshness metadata without paying the full target archive restore cost.

## Validation
- `python` YAML parse for `.github/workflows/ci-check.yml`
- `actionlint .github/workflows/ci-check.yml`
- `git diff --check`