### PR TITLE
ci: skip cross-arch wheel install smoke tests

### DIFF
--- a/ci/release_workflow.py
+++ b/ci/release_workflow.py
@@ -9,6 +9,7 @@ import hashlib
 import io
 import json
 import os
+import platform as platform_module
 import shutil
 import stat
 import subprocess
@@ -472,11 +473,41 @@ def _can_smoke_install_wheel_on_host(wheel_path: Path) -> bool:
         return False
     if "-py3-none-any.whl" in name:
         return True
+
+    platform_tags = _wheel_platform_tags(name)
+    host_arch = _normalized_host_arch()
     if sys.platform.startswith("linux"):
-        return "manylinux" in name or "musllinux" in name
+        return any(
+            (
+                tag.startswith(("manylinux", "musllinux", "linux"))
+                and tag.endswith(f"_{host_arch}")
+            )
+            for tag in platform_tags
+        )
     if sys.platform == "darwin":
-        return "macosx" in name
+        return any(
+            tag.startswith("macosx") and tag.endswith(f"_{host_arch}")
+            for tag in platform_tags
+        )
     return False
+
+
+def _wheel_platform_tags(wheel_name: str) -> list[str]:
+    if not wheel_name.endswith(".whl"):
+        return []
+    parts = wheel_name[:-4].split("-")
+    if len(parts) < 5:
+        return []
+    return parts[-1].split(".")
+
+
+def _normalized_host_arch() -> str:
+    machine = platform_module.machine().lower().replace("-", "_")
+    return {
+        "amd64": "x86_64",
+        "x64": "x86_64",
+        "arm64": "aarch64",
+    }.get(machine, machine)
 
 
 def build_all_wheels(

--- a/ci/tests/test_release_workflow.py
+++ b/ci/tests/test_release_workflow.py
@@ -93,6 +93,31 @@ def test_assert_installed_wheel_scripts_executable_accepts_pip_target_install(
     assert_installed_wheel_scripts_executable(wheel_path)
 
 
+def test_can_smoke_install_wheel_on_host_rejects_cross_arch_linux_wheel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(release_workflow.os, "name", "posix")
+    monkeypatch.setattr(release_workflow.sys, "platform", "linux")
+    monkeypatch.setattr(release_workflow.platform_module, "machine", lambda: "x86_64")
+
+    assert release_workflow._can_smoke_install_wheel_on_host(
+        Path("zccache-1.2.3-py3-none-manylinux_2_17_x86_64.whl")
+    )
+    assert not release_workflow._can_smoke_install_wheel_on_host(
+        Path("zccache-1.2.3-py3-none-manylinux_2_17_aarch64.whl")
+    )
+
+
+def test_can_smoke_install_wheel_on_host_accepts_pure_python_wheel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(release_workflow.os, "name", "posix")
+
+    assert release_workflow._can_smoke_install_wheel_on_host(
+        Path("zccache-1.2.3-py3-none-any.whl")
+    )
+
+
 def test_check_crates_versions_fails_preflight_when_all_crates_exist(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- investigate release job 72611124959 failing during PyPI wheel assembly
- keep zip metadata validation for all wheels
- only run the pip install smoke test for wheels matching the current host OS and architecture
- add regression coverage for Linux x86_64 rejecting the aarch64 manylinux wheel

## Verification
- python -m pytest ci/tests/test_release_workflow.py