### PR TITLE
ci: restore full setup-soldr target cache

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -22,7 +22,10 @@ jobs:
           version: v0.7.8
           toolchain: 1.94.1
           cache: true
-          target-cache-mode: hot
+          target-cache-mode: full
+          target-cache-paths: |
+            target/debug
+            target/x86_64-pc-windows-msvc/debug
       - name: Check
         run: soldr cargo check --workspace --all-targets
       - name: Test


### PR DESCRIPTION
## Summary
- restore the full target-cache configuration from PR #101
- keep the soldr version pin and managed-zccache stop logic

## Rationale
PR #102 switched the job to `target-cache-mode: hot`, but the warm rerun was worse:

- Linux: 4m16s
- macOS: 5m25s
- Windows: 8m37s

The full target cache remains the better repo-side mitigation while zackees/soldr#214 tracks the setup-soldr action-level cache issue.

## Validation
- `python` YAML parse for `.github/workflows/ci-check.yml`
- `actionlint .github/workflows/ci-check.yml`
- `git diff --check`