### PR TITLE
fix: satisfy clippy strict path validation

### DIFF
--- a/crates/zccache-compiler/src/strict_paths.rs
+++ b/crates/zccache-compiler/src/strict_paths.rs
@@ -192,9 +192,7 @@ fn validate_consistent(
 }
 
 fn validate_absolute(flag: &PathFlag) -> Result<(), StrictPathsViolation> {
-    let reason = if flag.path.contains('\\') {
-        Some("expected forward-slash absolute path")
-    } else if !is_forward_absolute(&flag.path) {
+    let reason = if flag.path.contains('\\') || !is_forward_absolute(&flag.path) {
         Some("expected forward-slash absolute path")
     } else if has_dot_component(&flag.path) {
         Some("expected normalized path without /./ or /../ components")


### PR DESCRIPTION
## Summary
- fix clippy::if_same_then_else in strict path absolute validation
- combine duplicate absolute-path rejection branches with the same diagnostic

## Verification
- cargo fmt --all -- --check
- CARGO_TARGET_DIR=C:\Users\niteris\dev\zccache-clippy-fix-target rustup run 1.94.1-x86_64-pc-windows-gnu cargo clippy -p zccache-compiler --all-targets -- -D warnings

Note: direct cargo on this machine mixed GNU/MSVC toolchains due the repo rust-toolchain override, so verification used rustup run with a matching GNU toolchain.