### PR TITLE
Add rust-plan backend diagnostics

### DIFF
--- a/crates/zccache-artifact/src/rust_plan.rs
+++ b/crates/zccache-artifact/src/rust_plan.rs
@@ -262,7 +262,10 @@ pub struct RustPlanSummary {
     pub skipped_samples: Vec<RustPlanSkippedSample>,
     #[serde(default)]
     pub key_input_mismatches: Vec<String>,
+    pub backend: String,
     pub cache_key: String,
+    pub backend_cache_key: Option<String>,
+    pub backend_cache_version: Option<String>,
     pub archive_path: Option<NormalizedPath>,
     pub journal_log_path: Option<NormalizedPath>,
     pub target_artifact_effectiveness: RustPlanArtifactEffectiveness,
@@ -306,7 +309,10 @@ impl RustPlanSummary {
             skipped_reasons: BTreeMap::new(),
             skipped_samples: Vec::new(),
             key_input_mismatches: Vec::new(),
+            backend: "unknown".to_string(),
             cache_key: String::new(),
+            backend_cache_key: None,
+            backend_cache_version: None,
             archive_path: None,
             journal_log_path: None,
             target_artifact_effectiveness: RustPlanArtifactEffectiveness {
@@ -344,7 +350,10 @@ impl RustPlanSummary {
             skipped_reasons: BTreeMap::new(),
             skipped_samples: Vec::new(),
             key_input_mismatches: Vec::new(),
+            backend: "local".to_string(),
             cache_key,
+            backend_cache_key: None,
+            backend_cache_version: None,
             archive_path,
             journal_log_path,
             target_artifact_effectiveness: RustPlanArtifactEffectiveness {
@@ -365,6 +374,23 @@ impl RustPlanSummary {
                 reason: reason.to_string(),
             });
         }
+    }
+
+    /// Record a skipped artifact or backend miss in an operation summary.
+    pub fn record_skip(&mut self, path: impl Into<String>, reason: &'static str) {
+        self.skip(path, reason);
+    }
+
+    /// Set the backend identity fields in an operation summary.
+    pub fn set_backend(
+        &mut self,
+        backend: impl Into<String>,
+        backend_cache_key: Option<String>,
+        backend_cache_version: Option<String>,
+    ) {
+        self.backend = backend.into();
+        self.backend_cache_key = backend_cache_key;
+        self.backend_cache_version = backend_cache_version;
     }
 
     fn refresh_effectiveness(&mut self, eligible: u64) {
@@ -1038,6 +1064,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let plan = sample_plan(dir.path(), RustPlanMode::Thin);
         let summary = restore_rust_plan_local(&plan, &dir.path().join("cache")).unwrap();
+        assert_eq!(summary.backend, "local");
         assert_eq!(summary.restored_file_count, 0);
         assert_eq!(
             summary
@@ -1045,6 +1072,30 @@ mod tests {
                 .get("artifact_absent_from_restored_plan"),
             Some(&1)
         );
+    }
+
+    #[test]
+    fn summary_records_backend_identity_and_manual_skips() {
+        let dir = tempfile::tempdir().unwrap();
+        let plan = sample_plan(dir.path(), RustPlanMode::Thin);
+        let mut summary = RustPlanSummary::validation_success(&plan, &dir.path().join("cache"));
+        assert_eq!(summary.backend, "local");
+        assert!(summary.backend_cache_key.is_none());
+
+        summary.set_backend(
+            "gha",
+            Some("rust-plan-v1-key".to_string()),
+            Some("version".to_string()),
+        );
+        summary.record_skip("<gha-cache>", "backend_cache_miss");
+
+        assert_eq!(summary.backend, "gha");
+        assert_eq!(
+            summary.backend_cache_key.as_deref(),
+            Some("rust-plan-v1-key")
+        );
+        assert_eq!(summary.backend_cache_version.as_deref(), Some("version"));
+        assert_eq!(summary.skipped_reasons.get("backend_cache_miss"), Some(&1));
     }
 
     #[test]

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -1884,19 +1884,26 @@ fn resolve_rust_plan_backend(backend: RustPlanBackendArg) -> RustPlanBackendArg 
     }
 }
 
+fn rust_plan_gha_version(cache_key: &str) -> String {
+    GhaCache::version_hash(&["zccache-rust-plan-v1", cache_key])
+}
+
 async fn restore_rust_plan_gha(
     plan: &RustArtifactPlanV1,
     cache_dir: &Path,
 ) -> Result<RustPlanSummary, RustPlanError> {
     let cache_key = rust_plan_cache_key(plan);
-    let version = GhaCache::version_hash(&["zccache-rust-plan-v1", &cache_key]);
+    let version = rust_plan_gha_version(&cache_key);
     let cache = GhaCache::from_env().map_err(rust_plan_gha_error)?;
     let Some(data) = cache
         .restore(&cache_key, &version)
         .await
         .map_err(rust_plan_gha_error)?
     else {
-        return restore_rust_plan_local(plan, cache_dir);
+        let mut summary = restore_rust_plan_local(plan, cache_dir)?;
+        summary.set_backend("gha", Some(cache_key), Some(version));
+        summary.record_skip("<gha-cache>", "backend_cache_miss");
+        return Ok(summary);
     };
 
     let bundle_dir = rust_plan_bundle_dir(cache_dir, &cache_key);
@@ -1908,7 +1915,9 @@ async fn restore_rust_plan_gha(
         .ok_or_else(|| RustPlanError::InvalidPlan("invalid rust-plan bundle path".to_string()))?;
     std::fs::create_dir_all(bundle_parent)?;
     tar_gz_decode(&data, bundle_parent)?;
-    restore_rust_plan_local(plan, cache_dir)
+    let mut summary = restore_rust_plan_local(plan, cache_dir)?;
+    summary.set_backend("gha", Some(cache_key), Some(version));
+    Ok(summary)
 }
 
 async fn save_rust_plan_gha(
@@ -1919,12 +1928,14 @@ async fn save_rust_plan_gha(
     let cache_key = summary.cache_key.clone();
     let bundle_dir = rust_plan_bundle_dir(cache_dir, &cache_key);
     let data = tar_gz_encode(&bundle_dir)?;
-    let version = GhaCache::version_hash(&["zccache-rust-plan-v1", &cache_key]);
+    let version = rust_plan_gha_version(&cache_key);
     let cache = GhaCache::from_env().map_err(rust_plan_gha_error)?;
     cache
         .save(&cache_key, &version, &data)
         .await
         .map_err(rust_plan_gha_error)?;
+    let mut summary = summary;
+    summary.set_backend("gha", Some(cache_key), Some(version));
     Ok(summary)
 }
 
@@ -2036,7 +2047,14 @@ fn print_rust_plan_summary(summary: &RustPlanSummary, json: bool) {
         summary.compatibility.status
     );
     println!("  mode: {}", summary.mode);
+    println!("  backend: {}", summary.backend);
     println!("  cache key: {}", summary.cache_key);
+    if let Some(key) = &summary.backend_cache_key {
+        println!("  backend cache key: {key}");
+    }
+    if let Some(version) = &summary.backend_cache_version {
+        println!("  backend cache version: {version}");
+    }
     if let Some(path) = &summary.archive_path {
         println!("  bundle: {}", path.display());
     }
@@ -3389,6 +3407,13 @@ mod tests {
         assert_eq!(json["hits"], 7);
         assert_eq!(json["misses"], 3);
         assert_eq!(json["hit_rate"].as_f64().unwrap(), 0.7);
+    }
+
+    #[test]
+    fn rust_plan_gha_version_is_stable_for_backend_diagnostics() {
+        let key = "rust-plan-v1-test";
+        assert_eq!(rust_plan_gha_version(key), rust_plan_gha_version(key));
+        assert_ne!(rust_plan_gha_version(key), rust_plan_gha_version("other"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds backend identity to Rust artifact plan summaries for issue #110.

- Adds backend, backend_cache_key, and backend_cache_version fields to rust-plan JSON summaries.
- Marks GHA save/restore summaries with GHA cache key/version.
- Reports GHA restore misses as backend_cache_miss while preserving local bundle fallback behavior.
- Prints backend identity in human-readable rust-plan output.

## Tests

- cargo test -p zccache-artifact rust_plan
- cargo test -p zccache-cli rust_plan
- git diff --check