### PR TITLE
Report rust-plan backend runtime errors as JSON

### DIFF
--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -414,6 +414,53 @@ enum RustPlanBackendArg {
     Gha,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RustPlanRuntimeErrorKind {
+    Unavailable,
+    Failure,
+}
+
+#[derive(Debug)]
+enum RustPlanRuntimeError {
+    Backend {
+        backend: RustPlanBackendArg,
+        kind: RustPlanRuntimeErrorKind,
+        message: String,
+    },
+}
+
+impl RustPlanRuntimeError {
+    fn backend(&self) -> RustPlanBackendArg {
+        match self {
+            Self::Backend { backend, .. } => *backend,
+        }
+    }
+
+    fn kind(&self) -> RustPlanRuntimeErrorKind {
+        match self {
+            Self::Backend { kind, .. } => *kind,
+        }
+    }
+
+    fn message(&self) -> &str {
+        match self {
+            Self::Backend { message, .. } => message,
+        }
+    }
+
+    fn with_kind(self, kind: RustPlanRuntimeErrorKind) -> Self {
+        match self {
+            Self::Backend {
+                backend, message, ..
+            } => Self::Backend {
+                backend,
+                kind,
+                message,
+            },
+        }
+    }
+}
+
 /// Known subcommand names for auto-detect.
 const KNOWN_SUBCOMMANDS: &[&str] = &[
     "start",
@@ -1779,6 +1826,7 @@ async fn cmd_rust_plan(action: RustPlanCommands) -> ExitCode {
                 Ok(plan) => plan,
                 Err(code) => return code,
             };
+            let backend = resolve_rust_plan_backend(backend);
             match run_rust_plan_restore(&plan, cache_dir.as_path(), backend).await {
                 Ok(mut summary) => {
                     enrich_rust_plan_summary(
@@ -1792,7 +1840,14 @@ async fn cmd_rust_plan(action: RustPlanCommands) -> ExitCode {
                     ExitCode::SUCCESS
                 }
                 Err(err) => {
-                    print_rust_plan_error(RustPlanOperation::Restore, &err, json);
+                    print_rust_plan_runtime_error(
+                        RustPlanOperation::Restore,
+                        &plan,
+                        cache_dir.as_path(),
+                        backend,
+                        &err,
+                        json,
+                    );
                     ExitCode::FAILURE
                 }
             }
@@ -1811,6 +1866,7 @@ async fn cmd_rust_plan(action: RustPlanCommands) -> ExitCode {
                 Ok(plan) => plan,
                 Err(code) => return code,
             };
+            let backend = resolve_rust_plan_backend(backend);
             match run_rust_plan_save(&plan, cache_dir.as_path(), backend).await {
                 Ok(mut summary) => {
                     enrich_rust_plan_summary(
@@ -1824,7 +1880,14 @@ async fn cmd_rust_plan(action: RustPlanCommands) -> ExitCode {
                     ExitCode::SUCCESS
                 }
                 Err(err) => {
-                    print_rust_plan_error(RustPlanOperation::Save, &err, json);
+                    print_rust_plan_runtime_error(
+                        RustPlanOperation::Save,
+                        &plan,
+                        cache_dir.as_path(),
+                        backend,
+                        &err,
+                        json,
+                    );
                     ExitCode::FAILURE
                 }
             }
@@ -1856,9 +1919,10 @@ async fn run_rust_plan_restore(
     plan: &RustArtifactPlanV1,
     cache_dir: &Path,
     backend: RustPlanBackendArg,
-) -> Result<RustPlanSummary, RustPlanError> {
-    match resolve_rust_plan_backend(backend) {
-        RustPlanBackendArg::Local => restore_rust_plan_local(plan, cache_dir),
+) -> Result<RustPlanSummary, RustPlanRuntimeError> {
+    match backend {
+        RustPlanBackendArg::Local => restore_rust_plan_local(plan, cache_dir)
+            .map_err(|err| rust_plan_backend_failure(backend, err.to_string())),
         RustPlanBackendArg::Gha => restore_rust_plan_gha(plan, cache_dir).await,
         RustPlanBackendArg::Auto => unreachable!("auto backend is resolved before execution"),
     }
@@ -1868,9 +1932,10 @@ async fn run_rust_plan_save(
     plan: &RustArtifactPlanV1,
     cache_dir: &Path,
     backend: RustPlanBackendArg,
-) -> Result<RustPlanSummary, RustPlanError> {
-    match resolve_rust_plan_backend(backend) {
-        RustPlanBackendArg::Local => save_rust_plan_local(plan, cache_dir),
+) -> Result<RustPlanSummary, RustPlanRuntimeError> {
+    match backend {
+        RustPlanBackendArg::Local => save_rust_plan_local(plan, cache_dir)
+            .map_err(|err| rust_plan_backend_failure(backend, err.to_string())),
         RustPlanBackendArg::Gha => save_rust_plan_gha(plan, cache_dir).await,
         RustPlanBackendArg::Auto => unreachable!("auto backend is resolved before execution"),
     }
@@ -1891,7 +1956,7 @@ fn rust_plan_gha_version(cache_key: &str) -> String {
 async fn restore_rust_plan_gha(
     plan: &RustArtifactPlanV1,
     cache_dir: &Path,
-) -> Result<RustPlanSummary, RustPlanError> {
+) -> Result<RustPlanSummary, RustPlanRuntimeError> {
     let cache_key = rust_plan_cache_key(plan);
     let version = rust_plan_gha_version(&cache_key);
     let cache = GhaCache::from_env().map_err(rust_plan_gha_error)?;
@@ -1900,7 +1965,8 @@ async fn restore_rust_plan_gha(
         .await
         .map_err(rust_plan_gha_error)?
     else {
-        let mut summary = restore_rust_plan_local(plan, cache_dir)?;
+        let mut summary = restore_rust_plan_local(plan, cache_dir)
+            .map_err(|err| rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()))?;
         summary.set_backend("gha", Some(cache_key), Some(version));
         summary.record_skip("<gha-cache>", "backend_cache_miss");
         return Ok(summary);
@@ -1908,14 +1974,21 @@ async fn restore_rust_plan_gha(
 
     let bundle_dir = rust_plan_bundle_dir(cache_dir, &cache_key);
     if bundle_dir.exists() {
-        std::fs::remove_dir_all(&bundle_dir)?;
+        std::fs::remove_dir_all(&bundle_dir)
+            .map_err(|err| rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()))?;
     }
-    let bundle_parent = bundle_dir
-        .parent()
-        .ok_or_else(|| RustPlanError::InvalidPlan("invalid rust-plan bundle path".to_string()))?;
-    std::fs::create_dir_all(bundle_parent)?;
-    tar_gz_decode(&data, bundle_parent)?;
-    let mut summary = restore_rust_plan_local(plan, cache_dir)?;
+    let bundle_parent = bundle_dir.parent().ok_or_else(|| {
+        rust_plan_backend_failure(
+            RustPlanBackendArg::Gha,
+            "invalid rust-plan bundle path".to_string(),
+        )
+    })?;
+    std::fs::create_dir_all(bundle_parent)
+        .map_err(|err| rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()))?;
+    tar_gz_decode(&data, bundle_parent)
+        .map_err(|err| rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()))?;
+    let mut summary = restore_rust_plan_local(plan, cache_dir)
+        .map_err(|err| rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()))?;
     summary.set_backend("gha", Some(cache_key), Some(version));
     Ok(summary)
 }
@@ -1923,11 +1996,13 @@ async fn restore_rust_plan_gha(
 async fn save_rust_plan_gha(
     plan: &RustArtifactPlanV1,
     cache_dir: &Path,
-) -> Result<RustPlanSummary, RustPlanError> {
-    let summary = save_rust_plan_local(plan, cache_dir)?;
+) -> Result<RustPlanSummary, RustPlanRuntimeError> {
+    let summary = save_rust_plan_local(plan, cache_dir)
+        .map_err(|err| rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()))?;
     let cache_key = summary.cache_key.clone();
     let bundle_dir = rust_plan_bundle_dir(cache_dir, &cache_key);
-    let data = tar_gz_encode(&bundle_dir)?;
+    let data = tar_gz_encode(&bundle_dir)
+        .map_err(|err| rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()))?;
     let version = rust_plan_gha_version(&cache_key);
     let cache = GhaCache::from_env().map_err(rust_plan_gha_error)?;
     cache
@@ -1939,8 +2014,77 @@ async fn save_rust_plan_gha(
     Ok(summary)
 }
 
-fn rust_plan_gha_error(err: GhaError) -> RustPlanError {
-    RustPlanError::InvalidPlan(format!("GHA cache backend error: {err}"))
+fn rust_plan_gha_error(err: GhaError) -> RustPlanRuntimeError {
+    let kind = if matches!(&err, GhaError::NotAvailable) {
+        RustPlanRuntimeErrorKind::Unavailable
+    } else {
+        RustPlanRuntimeErrorKind::Failure
+    };
+    rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()).with_kind(kind)
+}
+
+fn rust_plan_backend_failure(backend: RustPlanBackendArg, message: String) -> RustPlanRuntimeError {
+    RustPlanRuntimeError::Backend {
+        backend,
+        kind: RustPlanRuntimeErrorKind::Failure,
+        message,
+    }
+}
+
+fn rust_plan_runtime_error_message(err: &RustPlanRuntimeError) -> String {
+    let backend = match err.backend() {
+        RustPlanBackendArg::Local => "local",
+        RustPlanBackendArg::Gha => "GHA",
+        RustPlanBackendArg::Auto => unreachable!("auto backend is resolved before execution"),
+    };
+    let kind = match err.kind() {
+        RustPlanRuntimeErrorKind::Unavailable => "unavailable",
+        RustPlanRuntimeErrorKind::Failure => "failure",
+    };
+    format!("{backend} cache backend {kind}: {}", err.message())
+}
+
+fn rust_plan_runtime_failure_summary(
+    operation: RustPlanOperation,
+    plan: &RustArtifactPlanV1,
+    cache_dir: &Path,
+    backend: RustPlanBackendArg,
+    err: &RustPlanRuntimeError,
+) -> RustPlanSummary {
+    let mut summary = RustPlanSummary::validation_success(plan, cache_dir);
+    summary.operation = operation;
+    summary.backend = match backend {
+        RustPlanBackendArg::Local => "local".to_string(),
+        RustPlanBackendArg::Gha => "gha".to_string(),
+        RustPlanBackendArg::Auto => unreachable!("auto backend is resolved before execution"),
+    };
+    if matches!(backend, RustPlanBackendArg::Gha) {
+        let cache_key = summary.cache_key.clone();
+        summary.backend_cache_key = Some(cache_key.clone());
+        summary.backend_cache_version = Some(rust_plan_gha_version(&cache_key));
+    }
+    summary.compatibility.status = "error".to_string();
+    summary.compatibility.errors = vec![rust_plan_runtime_error_message(err)];
+    summary
+}
+
+fn print_rust_plan_runtime_error(
+    operation: RustPlanOperation,
+    plan: &RustArtifactPlanV1,
+    cache_dir: &Path,
+    backend: RustPlanBackendArg,
+    err: &RustPlanRuntimeError,
+    json: bool,
+) {
+    if json {
+        let summary = rust_plan_runtime_failure_summary(operation, plan, cache_dir, backend, err);
+        print_rust_plan_summary(&summary, true);
+    } else {
+        eprintln!(
+            "zccache rust-plan: {}",
+            rust_plan_runtime_error_message(err)
+        );
+    }
 }
 
 async fn enrich_rust_plan_summary(

--- a/crates/zccache-cli/tests/rust_plan_lifecycle.rs
+++ b/crates/zccache-cli/tests/rust_plan_lifecycle.rs
@@ -18,6 +18,18 @@ fn cargo_bin() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("cargo"))
 }
 
+fn rust_plan_output<F>(args: &[&str], configure: F) -> Output
+where
+    F: FnOnce(&mut Command),
+{
+    let mut cmd = Command::new(zccache_bin());
+    cmd.args(["rust-plan"]);
+    cmd.args(args);
+    configure(&mut cmd);
+    cmd.output()
+        .unwrap_or_else(|err| panic!("failed to run zccache rust-plan: {err}"))
+}
+
 fn write_file(path: &Path, contents: &str) {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).expect("create parent directories");
@@ -389,6 +401,159 @@ fn rust_plan_validate_json_reports_compatibility_error_without_cache_mutation() 
     assert!(
         !cache_dir.exists(),
         "validate compatibility failures should not create or mutate the cache directory"
+    );
+}
+
+#[test]
+fn rust_plan_auto_backend_without_gha_env_uses_local_backend() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let cache_dir = root.join("cache");
+    let target_dir = root.join("target");
+    write_synthetic_full_target(&target_dir);
+
+    let plan = synthetic_full_plan(root, &target_dir);
+    let plan_path = root.join("auto-plan.json");
+    write_file(
+        &plan_path,
+        &serde_json::to_string_pretty(&plan).expect("serialize plan"),
+    );
+
+    let plan_path_str = plan_path.to_string_lossy().to_string();
+    let cache_dir_str = cache_dir.to_string_lossy().to_string();
+    let output = rust_plan_output(
+        &[
+            "save",
+            "--plan",
+            &plan_path_str,
+            "--json",
+            "--backend",
+            "auto",
+            "--cache-dir",
+            &cache_dir_str,
+        ],
+        |cmd| {
+            cmd.env_remove("ACTIONS_CACHE_URL");
+            cmd.env_remove("ACTIONS_RUNTIME_TOKEN");
+        },
+    );
+    assert!(output.status.success(), "auto backend save should succeed");
+
+    let summary: Value =
+        serde_json::from_slice(&output.stdout).expect("parse rust-plan auto backend JSON");
+    assert_eq!(json_str(&summary, "operation"), "save");
+    assert_eq!(json_str(&summary, "backend"), "local");
+    assert!(summary["backend_cache_key"].is_null());
+    assert!(summary["backend_cache_version"].is_null());
+    assert!(!json_str(&summary, "cache_key").is_empty());
+}
+
+#[test]
+fn rust_plan_explicit_gha_backend_without_env_reports_backend_unavailable() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let cache_dir = root.join("cache");
+    let plan = synthetic_full_plan(root, &root.join("target"));
+    let plan_path = root.join("gha-plan.json");
+    write_file(
+        &plan_path,
+        &serde_json::to_string_pretty(&plan).expect("serialize plan"),
+    );
+
+    let plan_path_str = plan_path.to_string_lossy().to_string();
+    let cache_dir_str = cache_dir.to_string_lossy().to_string();
+    let output = rust_plan_output(
+        &[
+            "restore",
+            "--plan",
+            &plan_path_str,
+            "--json",
+            "--backend",
+            "gha",
+            "--cache-dir",
+            &cache_dir_str,
+        ],
+        |cmd| {
+            cmd.env_remove("ACTIONS_CACHE_URL");
+            cmd.env_remove("ACTIONS_RUNTIME_TOKEN");
+        },
+    );
+    assert!(
+        !output.status.success(),
+        "explicit gha backend should fail without env"
+    );
+
+    let summary: Value =
+        serde_json::from_slice(&output.stdout).expect("parse rust-plan gha failure JSON");
+    assert_eq!(json_str(&summary, "operation"), "restore");
+    assert_eq!(json_str(&summary, "backend"), "gha");
+    assert!(!json_str(&summary, "cache_key").is_empty());
+    assert!(!summary["backend_cache_key"].is_null());
+    assert!(!summary["backend_cache_version"].is_null());
+    let compatibility = json_object(&summary, "compatibility");
+    assert_eq!(
+        compatibility.get("status").and_then(Value::as_str),
+        Some("error")
+    );
+    let error_text = compatibility
+        .get("errors")
+        .and_then(Value::as_array)
+        .expect("compatibility errors")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        error_text.contains("GHA cache backend unavailable"),
+        "expected backend unavailable wording: {error_text}"
+    );
+}
+
+#[test]
+fn rust_plan_session_stats_lookup_errors_surface_in_json() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let cache_dir = root.join("cache");
+    let plan = synthetic_full_plan(root, &root.join("target"));
+    let plan_path = root.join("stats-plan.json");
+    write_file(
+        &plan_path,
+        &serde_json::to_string_pretty(&plan).expect("serialize plan"),
+    );
+
+    let plan_path_str = plan_path.to_string_lossy().to_string();
+    let cache_dir_str = cache_dir.to_string_lossy().to_string();
+    let output = rust_plan_output(
+        &[
+            "validate",
+            "--plan",
+            &plan_path_str,
+            "--json",
+            "--session-id",
+            "session-123",
+            "--endpoint",
+            "tcp:127.0.0.1:9",
+            "--cache-dir",
+            &cache_dir_str,
+        ],
+        |_| {},
+    );
+    assert!(output.status.success(), "validate should still succeed");
+
+    let summary: Value =
+        serde_json::from_slice(&output.stdout).expect("parse rust-plan session-stats JSON");
+    let stats = json_object(&summary, "compile_cache_stats");
+    assert_eq!(stats.get("status").and_then(Value::as_str), Some("error"));
+    assert_eq!(
+        stats.get("session_id").and_then(Value::as_str),
+        Some("session-123")
+    );
+    assert!(
+        stats
+            .get("error")
+            .and_then(Value::as_str)
+            .is_some_and(|error| error.contains("cannot connect to daemon at tcp:127.0.0.1:9")),
+        "expected endpoint lookup failure to be surfaced in compile_cache_stats"
     );
 }
 


### PR DESCRIPTION
## Summary
- preserve resolved backend identity when rust-plan backend runtime errors occur
- include GHA cache key/version in JSON summaries for explicit GHA backend failures
- add CLI lifecycle tests for auto fallback, explicit GHA unavailable JSON, and session stats lookup errors

## Tests
- cargo test -p zccache-cli --test rust_plan_lifecycle rust_plan_
- cargo test -p zccache-cli --bin zccache rust_plan_
- git diff --check