### PR TITLE
Fix release archive names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["dylints/ban_std_pathbuf"]
 
 [workspace.package]
-version = "1.3.9"
+version = "1.3.10"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![crates.io: zccache-core](https://img.shields.io/crates/v/zccache-core)](https://crates.io/crates/zccache-core)
 [![crates.io: zccache-cli](https://img.shields.io/crates/v/zccache-cli)](https://crates.io/crates/zccache-cli)
 [![crates.io: zccache-daemon](https://img.shields.io/crates/v/zccache-daemon)](https://crates.io/crates/zccache-daemon)
-[![Rust Workspace Version](https://img.shields.io/badge/rust%20workspace-1.3.9-orange)](https://crates.io/search?q=zccache)
+[![Rust Workspace Version](https://img.shields.io/badge/rust%20workspace-1.3.10-orange)](https://crates.io/search?q=zccache)
 [![GitHub Action](https://github.com/zackees/zccache/actions/workflows/test-action.yml/badge.svg)](https://github.com/zackees/zccache/actions/workflows/test-action.yml)
 
 ![C/C++](https://img.shields.io/badge/C%2FC%2B%2B-555?logo=c%2B%2B&logoColor=white)

--- a/ci/package_release.py
+++ b/ci/package_release.py
@@ -49,7 +49,7 @@ def stage_tree(version: str, target: str, binary_ext: str, input_dir: Path, outp
 
 
 def write_tarball(stage_dir: Path, archive_base: Path) -> Path:
-    archive_path = archive_base.with_suffix(".tar.gz")
+    archive_path = archive_base.parent / f"{archive_base.name}.tar.gz"
     if archive_path.exists():
         archive_path.unlink()
     with tarfile.open(archive_path, "w:gz") as tar:
@@ -58,7 +58,7 @@ def write_tarball(stage_dir: Path, archive_base: Path) -> Path:
 
 
 def write_zip(stage_dir: Path, archive_base: Path) -> Path:
-    archive_path = archive_base.with_suffix(".zip")
+    archive_path = archive_base.parent / f"{archive_base.name}.zip"
     if archive_path.exists():
         archive_path.unlink()
     with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib.util
+import tarfile
+import zipfile
+from pathlib import Path
+
+
+def _load_package_release():
+    module_path = Path(__file__).resolve().parents[1] / "package_release.py"
+    spec = importlib.util.spec_from_file_location("package_release", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+package_release = _load_package_release()
+
+
+def _write_fake_binary(path: Path) -> None:
+    path.write_bytes(b"binary\n")
+
+
+def test_write_tarball_preserves_full_version_and_target(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    for name in package_release.INCLUDE:
+        _write_fake_binary(input_dir / name)
+
+    stage_dir, archive_base = package_release.stage_tree(
+        version="1.3.10",
+        target="x86_64-unknown-linux-musl",
+        binary_ext="",
+        input_dir=input_dir,
+        output_dir=output_dir,
+    )
+    archive = package_release.write_tarball(stage_dir, archive_base)
+
+    assert archive.name == "zccache-v1.3.10-x86_64-unknown-linux-musl.tar.gz"
+
+    with tarfile.open(archive, "r:gz") as tf:
+        assert tf.getmember("zccache-v1.3.10-x86_64-unknown-linux-musl/zccache")
+
+
+def test_write_zip_preserves_full_version_and_target(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    for name in package_release.INCLUDE:
+        _write_fake_binary(input_dir / f"{name}.exe")
+
+    stage_dir, archive_base = package_release.stage_tree(
+        version="1.3.10",
+        target="x86_64-pc-windows-msvc",
+        binary_ext=".exe",
+        input_dir=input_dir,
+        output_dir=output_dir,
+    )
+    archive = package_release.write_zip(stage_dir, archive_base)
+
+    assert archive.name == "zccache-v1.3.10-x86_64-pc-windows-msvc.zip"
+
+    with zipfile.ZipFile(archive) as zf:
+        assert "zccache-v1.3.10-x86_64-pc-windows-msvc/zccache.exe" in zf.namelist()


### PR DESCRIPTION
## Summary
- preserve the full semver in packaged release archive names
- include the target triple in the archive root and output filename
- add regression coverage for Linux tarballs and Windows zip archives

## Validation
- `python -m pytest ci/tests/test_package_release.py`
- `git diff --check origin/main...HEAD`

## Context
- required upstream prerequisite for `zackees/soldr#227`
- closes the release-surface mismatch called out from `zackees/setup-soldr#48`