### PR TITLE
feat(daemon): port clud's unlock_exe + release_cwd to free launch handles

### DIFF
--- a/crates/zccache-daemon/src/lib.rs
+++ b/crates/zccache-daemon/src/lib.rs
@@ -15,6 +15,7 @@ mod process;
 pub mod server;
 pub mod side_effect;
 pub mod stats;
+pub mod trampoline;
 
 pub use event_log::EventLogger;
 pub use server::DaemonServer;

--- a/crates/zccache-daemon/src/main.rs
+++ b/crates/zccache-daemon/src/main.rs
@@ -2,6 +2,10 @@
 //!
 //! The daemon maintains in-memory caches, manages the artifact store,
 //! runs the file watcher, and handles IPC requests from CLI/wrappers.
+//!
+//! On the long-lived foreground path, the daemon releases its launch
+//! handles (exe file lock on Windows, implicit cwd handle on all OSes)
+//! via [`zccache_daemon::trampoline`] before entering [`run_server`].
 
 #[cfg(unix)]
 #[global_allocator]
@@ -50,6 +54,11 @@ fn main() {
 
     if args.foreground {
         init_tracing(&args.log_level);
+        // Long-lived process: release exe-file lock and cwd handle so
+        // `pip install --upgrade zccache` and `rm -rf <project>` can
+        // succeed while the daemon is running. See issue #134.
+        zccache_daemon::trampoline::unlock_exe();
+        zccache_daemon::trampoline::release_cwd();
         run_server(args);
     } else {
         print_status(&args);

--- a/crates/zccache-daemon/src/trampoline.rs
+++ b/crates/zccache-daemon/src/trampoline.rs
@@ -1,0 +1,165 @@
+//! Windows exe unlock + cwd release for the long-running zccache daemon.
+//!
+//! Problem: On Windows, running executables are file-locked. `pip install
+//! --upgrade zccache` fails if the daemon is running because it can't
+//! overwrite Scripts/zccache-daemon.exe. Likewise, a running process holds
+//! an implicit kernel handle on its current working directory, so launching
+//! the daemon from a project dir blocks deletion of that dir until the
+//! daemon exits.
+//!
+//! Solution: This module is a verbatim port of clud's same-named pattern
+//! at `crates/clud-bin/src/trampoline.rs` (see the `unlock_exe` and
+//! `gc_old_files` functions there). On launch, the daemon renames itself
+//! (Scripts/zccache-daemon.exe → zccache-daemon.exe.old.<rand>), then
+//! copies a fresh unlocked copy back to Scripts/zccache-daemon.exe. The
+//! running process continues from the renamed file. No child process, no
+//! handle transfer.
+//!
+//! Result: Scripts/zccache-daemon.exe is always an unlocked copy. pip
+//! install always works. Each running instance locks its own
+//! zccache-daemon.exe.old.<rand> file.
+//!
+//! IMPORTANT: Every operation is best-effort. If anything fails, the app
+//! continues normally — it just won't get the lock-free install benefit.
+//!
+//! On Linux/macOS: `unlock_exe` is a no-op (Unix allows deleting running
+//! binaries). `release_cwd` runs on every OS — it's cheap and the
+//! Windows-specific motivation (cwd handle pinning) is the primary driver.
+
+use std::fs;
+use std::path::Path;
+
+/// Unlock the running daemon binary on Windows so it can be replaced by
+/// `pip install --upgrade zccache` while we keep running. Verbatim port of
+/// clud's `unlock_exe()` (`crates/clud-bin/src/trampoline.rs:141`):
+/// rename `zccache-daemon.exe` → `zccache-daemon.exe.old.<rand>`, copy
+/// back so the canonical path is unlocked, then GC stale `.old.*` siblings
+/// in a background thread. Best-effort — no panics on failure.
+///
+/// No-op on non-Windows. Set `ZCCACHE_NO_UNLOCK=1` to opt out (mirrors
+/// clud's `CLUD_NO_UNLOCK`).
+pub fn unlock_exe() {
+    if !cfg!(target_os = "windows") {
+        return;
+    }
+
+    // Escape hatch for CI / test harnesses that spawn many short-lived
+    // zccache invocations: the rename+copy+GC dance on every start costs
+    // real time and (under investigation in clud's #37) appears to keep
+    // stdout/stderr pipe handles open on Windows GHA runners so Python's
+    // subprocess.run never sees EOF. Set `ZCCACHE_NO_UNLOCK=1` to disable.
+    if std::env::var_os("ZCCACHE_NO_UNLOCK").is_some() {
+        return;
+    }
+
+    let my_exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    // Rename zccache-daemon.exe → zccache-daemon.exe.old.<rand>. We keep
+    // running from the renamed file.
+    let rand_id: u32 = std::process::id()
+        ^ (std::time::UNIX_EPOCH
+            .elapsed()
+            .unwrap_or_default()
+            .subsec_nanos());
+    let old_exe = my_exe.with_extension(format!("exe.old.{rand_id}"));
+
+    if fs::rename(&my_exe, &old_exe).is_err() {
+        tracing::warn!(
+            "could not unlock exe for hot-reload; pip install may fail while zccache is running"
+        );
+        return;
+    }
+
+    // Copy back: zccache-daemon.exe.old.<rand> → zccache-daemon.exe (new
+    // file, unlocked).
+    let _ = fs::copy(&old_exe, &my_exe);
+
+    // GC stale .old files in background. Fire and forget.
+    let parent = match my_exe.parent() {
+        Some(p) => p.to_path_buf(),
+        None => return,
+    };
+    let stem = match my_exe.file_name().and_then(|n| n.to_str()) {
+        Some(s) => s.to_string(),
+        None => return,
+    };
+    std::thread::spawn(move || gc_old_files(&parent, &stem));
+}
+
+/// Release the launch-cwd handle by chdir-ing to the OS temp dir. On
+/// Windows a running process holds an implicit kernel handle on its
+/// cwd, so launching the daemon from a project dir blocks deletion of
+/// that dir until the daemon exits. Cheap one-liner, runs on every OS.
+pub fn release_cwd() {
+    let _ = std::env::set_current_dir(std::env::temp_dir());
+}
+
+/// Delete stale .old files next to the exe. Best-effort — locked files skipped.
+fn gc_old_files(dir: &Path, stem: &str) {
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.starts_with(stem) && name_str.contains(".old") {
+            let _ = fs::remove_file(entry.path());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gc_old_files() {
+        let tmp = std::env::temp_dir().join("zccache-unlock-test");
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).unwrap();
+
+        // Simulate: stem.exe + two stale .old files
+        fs::write(tmp.join("stem.exe"), b"current").unwrap();
+        fs::write(tmp.join("stem.exe.old.1"), b"old1").unwrap();
+        fs::write(tmp.join("stem.exe.old.2"), b"old2").unwrap();
+        fs::write(tmp.join("other.exe"), b"unrelated").unwrap();
+
+        gc_old_files(&tmp, "stem.exe");
+
+        assert!(tmp.join("stem.exe").is_file()); // untouched
+        assert!(!tmp.join("stem.exe.old.1").exists()); // cleaned
+        assert!(!tmp.join("stem.exe.old.2").exists()); // cleaned
+        assert!(tmp.join("other.exe").is_file()); // untouched
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_gc_missing_dir() {
+        // Should not panic on nonexistent directory.
+        gc_old_files(Path::new("/nonexistent/dir"), "stem.exe");
+    }
+
+    #[test]
+    fn test_release_cwd_changes_dir() {
+        let tmp = std::env::temp_dir().join("zccache-release-cwd-test");
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).unwrap();
+
+        // Resolve via canonicalize so the comparison is robust against
+        // symlinked temp dirs (e.g. /var → /private/var on macOS).
+        let tmp_canon = fs::canonicalize(&tmp).unwrap();
+        std::env::set_current_dir(&tmp_canon).unwrap();
+        assert_eq!(std::env::current_dir().unwrap(), tmp_canon);
+
+        release_cwd();
+
+        assert_ne!(std::env::current_dir().unwrap(), tmp_canon);
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+}

--- a/crates/zccache-daemon/tests/cwd_release.rs
+++ b/crates/zccache-daemon/tests/cwd_release.rs
@@ -1,0 +1,42 @@
+//! Regression test for `trampoline::release_cwd()`.
+//!
+//! Verifies that after the daemon's launch path calls `release_cwd()`,
+//! the process is no longer holding an implicit handle on its launch
+//! cwd: the cwd has moved off the temporary directory and dropping the
+//! `TempDir` cleans up successfully (on Windows this would have failed
+//! before the fix).
+//!
+//! Threads within a test binary share process-wide cwd, so even though
+//! cargo runs test binaries in parallel, multiple tests inside *this*
+//! binary must serialize. Guarded by a local static `Mutex` to avoid
+//! pulling in `serial_test` as a dependency.
+
+use std::sync::Mutex;
+
+static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+#[test]
+fn release_cwd_moves_off_tempdir() {
+    let _guard = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let dir_canon = dir
+        .path()
+        .canonicalize()
+        .expect("canonicalize tempdir path");
+
+    std::env::set_current_dir(&dir_canon).expect("chdir into tempdir");
+
+    zccache_daemon::trampoline::release_cwd();
+
+    let now = std::env::current_dir().expect("read current_dir after release");
+    let now_canon = now.canonicalize().expect("canonicalize current_dir");
+    assert_ne!(
+        now_canon, dir_canon,
+        "release_cwd() should have moved cwd off the launch tempdir"
+    );
+
+    // Drop the TempDir last; on Windows this would have failed before
+    // the fix because the process held an implicit handle on `dir`.
+    drop(dir);
+}


### PR DESCRIPTION
## Summary

Closes the second-half of #134. The zccache-daemon is long-lived and on Windows held two implicit handles on the directory it was launched from:

1. **The `.exe` file lock** — `pip install --upgrade zccache` fails because it can't overwrite `Scripts/zccache-daemon.exe`.
2. **The cwd handle** — `rm -rf <project>` fails when the daemon was launched from inside the project tree.

Ports clud's `unlock_exe()` pattern verbatim (see `clud-bin/src/trampoline.rs:141-200`) and adds a tiny `release_cwd()` companion. Both fire only from the long-lived `--foreground` branch of `main()`; the short-lived status path doesn't pay the cost.

### What `unlock_exe()` does (verbatim from clud)

- Windows-only; no-op on Linux/macOS where running binaries can be replaced freely.
- `rename` `zccache-daemon.exe` → `zccache-daemon.exe.old.<pid ^ unix_nanos>` so the canonical path is freed up.
- `copy` the renamed file back to `zccache-daemon.exe`. The running daemon keeps executing from the `.old.<rand>` file; the canonical path is now an unlocked file that an installer can overwrite.
- Background-thread `gc_old_files()` deletes any sibling `*.old.*` files. Locked ones (live processes) are silently skipped.
- `ZCCACHE_NO_UNLOCK=1` env var opts out (mirrors clud's `CLUD_NO_UNLOCK`).

### What `release_cwd()` does

- `let _ = std::env::set_current_dir(std::env::temp_dir());`
- Runs on every OS. Releases the implicit kernel handle on whatever dir the daemon was spawned from, so that dir can be deleted while the daemon is alive.

### Why both, not just unlock_exe

clud doesn't need the cwd release because its only pinning concern is overwriting the .exe via the package installer. zccache hits both pinning classes — exe overwrite **and** project-dir deletion — so it needs both fixes. Each is one cheap call.

### Wiring

```rust
// crates/zccache-daemon/src/main.rs
fn main() {
    let args = Args::parse();

    if args.foreground {
        init_tracing(&args.log_level);
        // Long-lived process: release exe-file lock and cwd handle so
        // upgrades and `rm -rf <project>` can succeed while the daemon
        // is running. See issue #134.
        zccache_daemon::trampoline::unlock_exe();
        zccache_daemon::trampoline::release_cwd();
        run_server(args);
    } else {
        print_status(&args);
    }
}
```

CLI is unchanged — it's ephemeral and doesn't pin anything long enough to matter.

## Test plan
- [x] Inline unit tests in `crates/zccache-daemon/src/trampoline.rs`:
  - `test_gc_old_files` — three siblings (`stem.exe`, `stem.exe.old.1`, `stem.exe.old.2`, `other.exe`); `gc_old_files` deletes the `.old.*` and leaves `stem.exe` and `other.exe` alone.
  - `test_gc_missing_dir` — no panic on nonexistent dir.
  - `test_release_cwd_changes_dir` — set cwd to a tempdir; `release_cwd()` moves it elsewhere.
- [x] Regression test `crates/zccache-daemon/tests/cwd_release.rs` — chdir into a `tempfile::TempDir`, call `release_cwd()`, drop the TempDir. On Windows this would have failed before the fix. Serialized via a local `static Mutex<()>` (no `serial_test` dep added).
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `soldr cargo fmt --all -- --check` clean.

Skipped per the working agreement: didn't run the test suite locally; CI exercises both unit + integration on Linux/macOS/Windows.

## Followups (not in scope)

- Telemetry: log how often `unlock_exe()` finds + GCs stale `.old.*` siblings, so we can size the worry about stale-exe accumulation.
- Verify on a real Windows runner that an upgrade install succeeds while the daemon is running. Tracking via the issue.

Generated with [Claude Code](https://claude.com/claude-code)
