### PR TITLE
fix(daemon): make session-end idempotent for unknown UUIDs

### DIFF
--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -1117,9 +1117,15 @@ async fn handle_connection(
                             });
                             Response::SessionEnded { stats }
                         } else {
-                            Response::Error {
-                                message: format!("unknown session: {session_id}"),
-                            }
+                            // Idempotent: session-end on an unknown session is a
+                            // no-op success. The session may have been implicitly
+                            // ended when a previous daemon process exited (e.g.
+                            // killed by zccache-ci to unlock target binaries on
+                            // Windows). Returning an error here would surface as a
+                            // spurious failure in build wrappers like soldr that
+                            // call session-end at process exit. No stats are
+                            // returned because the session state is gone.
+                            Response::SessionEnded { stats: None }
                         }
                     }
                     Err(_) => Response::Error {
@@ -5095,7 +5101,7 @@ exit /b 0
         .await;
     }
 
-    /// Ending a nonexistent session returns an error.
+    /// Ending a session with a malformed (non-UUID) ID returns an error.
     #[tokio::test]
     #[ignore] // integration-level: starts real daemon with IPC
     async fn cli_session_end_invalid_id() {
@@ -5118,6 +5124,45 @@ exit /b 0
                     );
                 }
                 other => panic!("expected Error, got: {other:?}"),
+            }
+
+            shutdown.notify_one();
+            server_handle.await.unwrap();
+        })
+        .await;
+    }
+
+    /// Ending an unknown session (well-formed UUID, but daemon has no record
+    /// of it) is idempotent and returns SessionEnded { stats: None }.
+    ///
+    /// This simulates the scenario where the daemon was restarted between
+    /// `session-start` and `session-end` (e.g. zccache-ci kills the daemon
+    /// mid-build to unlock target binaries on Windows). Build wrappers like
+    /// soldr call `session-end` at process exit and must not see a spurious
+    /// failure when the in-memory session is gone.
+    #[tokio::test]
+    #[ignore] // integration-level: starts real daemon with IPC
+    async fn cli_session_end_unknown_uuid_is_idempotent() {
+        zccache_test_support::test_timeout(async {
+            let (endpoint, server_handle, shutdown) = start_daemon().await;
+            let mut client = zccache_ipc::connect(&endpoint).await.unwrap();
+
+            client
+                .send(&Request::SessionEnd {
+                    // A well-formed UUID that the daemon has never seen.
+                    session_id: "00000000-0000-0000-0000-000000000000".to_string(),
+                })
+                .await
+                .unwrap();
+
+            match client.recv().await.unwrap() {
+                Some(Response::SessionEnded { stats }) => {
+                    assert!(
+                        stats.is_none(),
+                        "no stats expected for unknown session, got: {stats:?}"
+                    );
+                }
+                other => panic!("expected SessionEnded for unknown UUID, got: {other:?}"),
             }
 
             shutdown.notify_one();

--- a/docs/architecture/ipc.md
+++ b/docs/architecture/ipc.md
@@ -51,7 +51,7 @@ per invocation.
 1. `zccache session-start [--stats] [--log FILE]` → `Request::SessionStart` → `Response::SessionStarted { session_id }`.
 2. Build system sets `ZCCACHE_SESSION_ID=<uuid>`. Each compiler invocation sends `Request::Compile`.
 3. `zccache session-stats <id>` → `Request::SessionStats` → `Response::SessionStatsResult`. Non-destructive; session stays active. Returns `Option<SessionStats>` (`None` if `--stats` was not used at start).
-4. `zccache session-end <id>` → `Request::SessionEnd` → `Response::SessionEnded { stats }`. Removes the session.
+4. `zccache session-end <id>` → `Request::SessionEnd` → `Response::SessionEnded { stats }`. Removes the session. Idempotent: ending a UUID the daemon does not know returns `SessionEnded { stats: None }` rather than an error so wrappers can safely call `session-end` after a daemon restart (e.g. zccache-ci killing the daemon to unlock target binaries on Windows).
 
 **Daemon side:**
 1. Acquire lock file (write PID).


### PR DESCRIPTION
## Summary

- Treat `Request::SessionEnd` on an unknown (but well-formed) UUID as an idempotent no-op success (`Response::SessionEnded { stats: None }`) instead of returning `Response::Error`.
- Malformed (non-UUID) session IDs still return an error — only the unknown-but-valid path is now tolerant.

## Why

The Stop hook (which runs `zccache-ci`) failed with:

```
Killing running daemon (PID 34544) to unlock target binaries
Killing running daemon (PID 10632) to unlock target binaries
Running full workspace checks (changes detected)
... checks succeed ...
error: process didn't exit successfully: `soldr.exe 'rustc.exe' -vV` (exit code: 1)
--- stderr
zccache error: unknown session: 215436b6-e51c-4acf-8367-d2663cf417a9

Doc check failed — skipping tests
soldr: zccache session-end 215436b6-... failed: session-end failed: unknown session: 215436b6-...
```

`zccache-ci` kills the running daemon(s) mid-run so cargo can replace the target binaries on Windows. Sessions are tracked in the daemon's in-memory state, so once the daemon dies all session IDs are forgotten. Build wrappers like `soldr` keep `ZCCACHE_SESSION_ID` in the child environment and then call `zccache session-end <id>` at exit, hitting a fresh daemon that has no record of the UUID. The result was a spurious failure that broke the Stop hook chain.

This matches CLAUDE.md's "Speed above all. Ship fast" + "Simplicity first. No over-engineering." principle. We're not persisting sessions across restarts — we just acknowledge that a session whose daemon already died is implicitly ended, so cleanup at exit should succeed.

## Changes

- `crates/zccache-daemon/src/server.rs`: `SessionEnd` returns `SessionEnded { stats: None }` when the session doesn't exist (only when the UUID parses).
- `crates/zccache-daemon/src/server.rs`: New `cli_session_end_unknown_uuid_is_idempotent` integration test.
- `crates/zccache-daemon/src/server.rs`: Update existing `cli_session_end_invalid_id` doc-comment so it accurately reflects what it tests (malformed-UUID error path).
- `docs/architecture/ipc.md`: Record the new idempotent contract.

## Test plan

- [x] `soldr cargo check --workspace --all-targets` — clean
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `soldr cargo fmt --all` — no changes after running
- [x] `./test` — passes (one pre-existing `p2_windows_long_path_spill` failure in `zccache-artifact` kv_stress, unrelated to this change and reproducible on `main`)
- [ ] CI on the PR runs full matrix (Linux/macOS/Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)