### PR TITLE
chore(release): bump workspace to 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "md5",
  "serde_json",
@@ -3452,7 +3452,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "blake3",
  "clap",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "clang",
  "tempfile",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "bincode",
  "clap",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "blake3",
  "dashmap",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "clap",
  "serde",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "clap",
  "dashmap",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "clap",
  "criterion",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -3688,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "bytes",
  "serde",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["dylints/ban_std_pathbuf"]
 
 [workspace.package]
-version = "1.3.10"
+version = "1.4.0"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump `[workspace.package].version` from 1.3.10 → 1.4.0 (and refresh Cargo.lock).
- Minor bump because of the namespaced blake3-keyed K/V store (#133), spawn-lineage env propagation (#131), and the daemon unlock-exe / release-cwd port (#135) since 1.3.10. Also includes #136 (PID-exe verification) and #137 (idempotent session-end).

## Release plan
After merge, tag `v1.4.0` to trigger `.github/workflows/release.yml`, which validates the version, builds wheels, publishes PyPI + crates.io, and creates the GitHub release per CLAUDE.md.

## Test plan
- [x] `soldr cargo check --workspace --all-targets` clean
- [ ] release.yml runs green after tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)