### PR TITLE
fix(ci): three trivial main-CI reds (#143, #144, #147)

### DIFF
--- a/crates/zccache-daemon/src/trampoline.rs
+++ b/crates/zccache-daemon/src/trampoline.rs
@@ -10,14 +10,14 @@
 //! Solution: This module is a verbatim port of clud's same-named pattern
 //! at `crates/clud-bin/src/trampoline.rs` (see the `unlock_exe` and
 //! `gc_old_files` functions there). On launch, the daemon renames itself
-//! (Scripts/zccache-daemon.exe → zccache-daemon.exe.old.<rand>), then
+//! (`Scripts/zccache-daemon.exe` → `zccache-daemon.exe.old.<rand>`), then
 //! copies a fresh unlocked copy back to Scripts/zccache-daemon.exe. The
 //! running process continues from the renamed file. No child process, no
 //! handle transfer.
 //!
 //! Result: Scripts/zccache-daemon.exe is always an unlocked copy. pip
 //! install always works. Each running instance locks its own
-//! zccache-daemon.exe.old.<rand> file.
+//! `zccache-daemon.exe.old.<rand>` file.
 //!
 //! IMPORTANT: Every operation is best-effort. If anything fails, the app
 //! continues normally — it just won't get the lock-free install benefit.

--- a/crates/zccache-ipc/src/lib.rs
+++ b/crates/zccache-ipc/src/lib.rs
@@ -359,10 +359,6 @@ mod tests {
             Path::new("/usr/bin/zccache-daemon"),
             "zccache-daemon"
         ));
-        assert!(exe_stem_matches(
-            Path::new(r"C:\bin\zccache-daemon.exe"),
-            "zccache-daemon"
-        ));
         // A different binary at the same PID must not be accepted.
         assert!(!exe_stem_matches(
             Path::new("/usr/bin/bash"),
@@ -370,6 +366,19 @@ mod tests {
         ));
         assert!(!exe_stem_matches(
             Path::new("/usr/bin/zccache-daemon-x"),
+            "zccache-daemon"
+        ));
+    }
+
+    /// Windows-only: backslash-separated paths require the OS-native
+    /// `Path::file_name` semantics. On Unix `\` is a regular filename
+    /// character, so the same assertion would fail there (issue #143).
+    #[cfg(windows)]
+    #[test]
+    fn exe_stem_matches_strips_exe_suffix_on_windows() {
+        use std::path::Path;
+        assert!(exe_stem_matches(
+            Path::new(r"C:\bin\zccache-daemon.exe"),
             "zccache-daemon"
         ));
     }

--- a/crates/zccache-ipc/src/lib.rs
+++ b/crates/zccache-ipc/src/lib.rs
@@ -221,12 +221,14 @@ fn exe_stem_matches(path: &std::path::Path, expected_stem: &str) -> bool {
 }
 
 #[cfg(target_os = "linux")]
-fn daemon_exe_for_pid(pid: u32) -> Option<std::path::PathBuf> {
-    std::fs::read_link(format!("/proc/{pid}/exe")).ok()
+fn daemon_exe_for_pid(pid: u32) -> Option<NormalizedPath> {
+    std::fs::read_link(format!("/proc/{pid}/exe"))
+        .ok()
+        .map(NormalizedPath::from)
 }
 
 #[cfg(target_os = "macos")]
-fn daemon_exe_for_pid(_pid: u32) -> Option<std::path::PathBuf> {
+fn daemon_exe_for_pid(_pid: u32) -> Option<NormalizedPath> {
     // proc_pidpath is the right call but pulling in libc/libproc just for
     // CI-recycle defense isn't worth it on macOS, where this failure mode
     // hasn't been observed. Fall back to alive-only.
@@ -234,7 +236,7 @@ fn daemon_exe_for_pid(_pid: u32) -> Option<std::path::PathBuf> {
 }
 
 #[cfg(windows)]
-fn daemon_exe_for_pid(pid: u32) -> Option<std::path::PathBuf> {
+fn daemon_exe_for_pid(pid: u32) -> Option<NormalizedPath> {
     extern "system" {
         fn OpenProcess(access: u32, inherit: i32, pid: u32) -> isize;
         fn CloseHandle(handle: isize) -> i32;
@@ -261,12 +263,12 @@ fn daemon_exe_for_pid(pid: u32) -> Option<std::path::PathBuf> {
         }
         use std::os::windows::ffi::OsStringExt;
         let os = std::ffi::OsString::from_wide(&buf[..size as usize]);
-        Some(std::path::PathBuf::from(os))
+        Some(NormalizedPath::new(&os))
     }
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
-fn daemon_exe_for_pid(_pid: u32) -> Option<std::path::PathBuf> {
+fn daemon_exe_for_pid(_pid: u32) -> Option<NormalizedPath> {
     None
 }
 


### PR DESCRIPTION
## Summary

Three independent, trivial fixes batched into one PR. Each is its own commit; squash-merge will preserve `Closes #N` in the squashed body.

- **#143** `fix(ipc): gate Windows-style path test under #[cfg(windows)]`  
  `exe_stem_matches_strips_exe_suffix_and_compares_basename` asserted on `C:\bin\zccache-daemon.exe`. On Unix `\` is not a path separator, so `Path::file_name()` returns the entire string. Split the Windows-only assertion into a separate `#[cfg(windows)]` test; the Unix-path assertions remain unconditional.

- **#144** `fix(daemon): wrap <rand> placeholder in backticks for rustdoc`  
  Module-level docs in `crates/zccache-daemon/src/trampoline.rs` lines 13 and 20 contained bare `<rand>`. With `RUSTDOCFLAGS=-D warnings`, rustdoc fails on `unclosed HTML tag`. Wrapped both in inline code spans. Verified with `RUSTDOCFLAGS=-D warnings soldr cargo doc --workspace --no-deps`.

- **#147** `fix(ipc): return NormalizedPath from daemon_exe_for_pid`  
  All four cfg-gated `daemon_exe_for_pid` definitions returned `Option<std::path::PathBuf>`, which the workspace `ban_std_pathbuf` dylint denies. Switched to `Option<NormalizedPath>` (the repo's standard, per `dylints/ban_std_pathbuf/src/lib.rs` docs). The Windows arm uses `NormalizedPath::new(&os)` (relying on `OsString: AsRef<Path>`) to avoid leaving any `PathBuf::*` expression in the source that would also trip the dylint's `check_expr` arm. `exe_stem_matches` keeps its `&Path` parameter — `NormalizedPath` derefs to `Path`.

## Verification

Local checks on Windows:
- `soldr cargo check --workspace --all-targets` ✓
- `soldr cargo clippy --workspace --all-targets -- -D warnings` ✓
- `soldr cargo fmt --all -- --check` ✓
- `RUSTDOCFLAGS="-D warnings" soldr cargo doc --workspace --no-deps` ✓ (catches #144)
- `soldr cargo test -p zccache-ipc --lib` ✓ (9 passed, including the new `exe_stem_matches_strips_exe_suffix_on_windows`)
- `./test` ✓ except pre-existing `p2_windows_long_path_spill` (deferred #145, unrelated)

Dylint not run locally due to a Windows-only environment issue with `ci/build_dylint_driver.py` setup. CI handles this. The change is structural — there is no remaining `PathBuf` token in `crates/zccache-ipc/src/lib.rs`.

## Expected CI deltas

These should turn green:
- `Documentation` (was red on rustdoc `<rand>`)
- `Dylint` (was red on `ban_std_pathbuf`)
- `linux/Check` and `macos/Check` (were red on the backslash-path test)

The remaining reds (`Code Coverage` long-path, `windows/Check` flake) are tracked separately under #145/#146 and stay deferred.

## Test plan

- [x] Workspace check + clippy + fmt + doc + lib tests pass locally
- [ ] CI: Documentation green
- [ ] CI: Dylint green
- [ ] CI: linux/Check + macos/Check turn green (or narrow to other failures)

Closes #143
Closes #144
Closes #147