### PR TITLE
fix(artifact): use verbatim (\?\) paths for KvStore on Windows

### DIFF
--- a/crates/zccache-artifact/src/kv.rs
+++ b/crates/zccache-artifact/src/kv.rs
@@ -16,6 +16,48 @@ use std::sync::Arc;
 use redb::{Database, ReadableTable, TableDefinition};
 use serde::{Deserialize, Serialize};
 
+/// Windows long-path (`\\?\`) helpers. On non-Windows platforms every entry
+/// point is a no-op pass-through.
+mod long_path {
+    use std::path::{Path, PathBuf};
+
+    /// Normalize `dir` so that paths joined off it can exceed `MAX_PATH`
+    /// without tripping the legacy Win32 path APIs used by transitive crates
+    /// (notably `tempfile`'s rename-on-persist call into `MoveFileExW`).
+    ///
+    /// On Windows we canonicalize to a verbatim (`\\?\`-prefixed) form so that
+    /// every `path.join(...)` we do downstream inherits the prefix. On Unix
+    /// this is a pure clone — long paths are not a thing there.
+    ///
+    /// The dir must already exist; callers in this crate `create_dir_all`
+    /// first.
+    pub(super) fn ensure_long_path(dir: &Path) -> std::io::Result<PathBuf> {
+        #[cfg(windows)]
+        {
+            // `fs::canonicalize` on Windows returns the verbatim form
+            // (`\\?\C:\...` or `\\?\UNC\...`), which is exactly what we need.
+            // If the path already starts with `\\?\` we keep it as-is.
+            if starts_with_verbatim(dir) {
+                return Ok(dir.to_path_buf());
+            }
+            std::fs::canonicalize(dir)
+        }
+        #[cfg(not(windows))]
+        {
+            Ok(dir.to_path_buf())
+        }
+    }
+
+    #[cfg(windows)]
+    fn starts_with_verbatim(p: &Path) -> bool {
+        // OsStr equality is byte-wise on Windows for the ASCII prefix; using
+        // `to_string_lossy` is fine here because we only inspect the leading
+        // four ASCII bytes.
+        let s = p.as_os_str().to_string_lossy();
+        s.starts_with(r"\\?\")
+    }
+}
+
 const KV_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("kv");
 
 /// Inline-vs-spill threshold. Values ≤ this stay in redb; larger values
@@ -212,8 +254,12 @@ impl KvStore {
 
     /// Open at an explicit dir. Creates the dir + redb file if missing.
     pub fn open<P: AsRef<Path>>(dir: P) -> KvResult<Self> {
-        let dir = dir.as_ref().to_path_buf();
+        let mut dir = dir.as_ref().to_path_buf();
         std::fs::create_dir_all(&dir)?;
+        // On Windows, normalize to a `\\?\`-prefixed (verbatim) form so that
+        // every spill path joined off `cache_dir` exceeds `MAX_PATH` safely.
+        // No-op on Unix.
+        dir = long_path::ensure_long_path(&dir)?;
         let db_path = dir.join("index.redb");
         let db = Database::create(&db_path).map_err(|e| KvError::Redb(e.to_string()))?;
         let store = Self {
@@ -228,8 +274,12 @@ impl KvStore {
     /// [`ArtifactStore`](crate::ArtifactStore)). Both stores see each other's
     /// commits; spill files live under `cache_dir/kv/...`.
     pub fn from_database<P: AsRef<Path>>(db: Arc<Database>, cache_dir: P) -> KvResult<Self> {
-        let cache_dir = cache_dir.as_ref().to_path_buf();
+        let mut cache_dir = cache_dir.as_ref().to_path_buf();
         std::fs::create_dir_all(&cache_dir)?;
+        // Match the verbatim normalization done by [`KvStore::open`] so callers
+        // who route long paths through `from_database` get the same long-path
+        // safety on Windows.
+        cache_dir = long_path::ensure_long_path(&cache_dir)?;
         let store = Self {
             db,
             cache_dir: Arc::new(cache_dir),

--- a/crates/zccache-artifact/tests/kv_stress.rs
+++ b/crates/zccache-artifact/tests/kv_stress.rs
@@ -242,6 +242,50 @@ fn p2_windows_long_path_spill() {
     assert_eq!(got, payload);
 }
 
+#[cfg(windows)]
+#[test]
+fn p2b_windows_spill_remove_and_clear_at_long_path() {
+    // Lock in the long-path safety beyond plain put/get: remove + clear_namespace
+    // both reach into spill_path() too. Build a path whose final spill file
+    // strictly exceeds the 260-char `MAX_PATH` ceiling, then exercise every
+    // code path that joins off the store root.
+    let base = tempfile::tempdir().unwrap();
+    let mut deep = base.path().to_path_buf();
+    while deep.to_string_lossy().len() < 220 {
+        deep = deep.join("very-long-segment");
+    }
+    std::fs::create_dir_all(&deep).unwrap();
+    let s = KvStore::open(&deep).unwrap();
+
+    // Sanity: we want the spill path to definitely exceed legacy MAX_PATH so
+    // the test would actually catch a regression of the `\\?\` fix.
+    let k = key_from(b"p2b");
+    let probe = deep
+        .join("kv")
+        .join("ns")
+        .join(format!("{}.bin", k.to_hex()));
+    assert!(
+        probe.to_string_lossy().len() > 260,
+        "test setup must produce a path >260 chars, got {} chars",
+        probe.to_string_lossy().len()
+    );
+
+    let payload = vec![7u8; INLINE_THRESHOLD + 8];
+    s.put("ns", &k, &payload).unwrap();
+    let got = s.get("ns", &k).unwrap().unwrap();
+    assert_eq!(got, payload);
+
+    // remove must succeed on the long path (touches spill_path()).
+    s.remove("ns", &k).unwrap();
+    assert!(s.get("ns", &k).unwrap().is_none());
+
+    // clear_namespace removes the entire <ns> dir under kv/ — also a long path.
+    let k2 = key_from(b"p2b-2");
+    s.put("ns", &k2, &vec![3u8; INLINE_THRESHOLD + 3]).unwrap();
+    s.clear_namespace("ns").unwrap();
+    assert!(s.get("ns", &k2).unwrap().is_none());
+}
+
 #[cfg(unix)]
 #[test]
 fn p4_symlinked_store_dir() {


### PR DESCRIPTION
Closes #145.

## Summary

`kv_stress::p2_windows_long_path_spill` was failing on Windows CI with
`ERROR_PATH_NOT_FOUND` whenever the resolved spill file path exceeded
`MAX_PATH` (260 chars). The failing call is `tempfile::NamedTempFile::persist`,
which routes through `fs::rename` -> `MoveFileExW`. Modern `std::fs` auto-prefixes
`\?\` for many absolute Windows paths, but neither `MoveFileExW` from
`tempfile`'s persist nor every redb path call benefits from that.

## Root cause

`KvStore::put` builds `<cache_dir>/kv/<ns>/<64-hex>.bin`. With a deep tempdir,
the final path crosses 260 chars. Without the verbatim (`\?\`) prefix on the
base, every transitive Win32 call that does not opt into the long-path
auto-prefix fails with `ERROR_PATH_NOT_FOUND` (code 3).

## Fix

Pre-canonicalize the store root in `KvStore::open` and `KvStore::from_database`
via `std::fs::canonicalize`, which on Windows returns the verbatim form
(`\?\C:\...` or `\?\UNC\...`). `Path::join` preserves the verbatim prefix,
so every downstream join (`spill_path`, the `ns_dir` cleanup in
`clear_namespace`, the `index.redb` location) is long-path safe.

Helper lives in a private nested `long_path` module at the top of `kv.rs`.
- On Windows: `fs::canonicalize` (idempotent if already verbatim).
- On Unix: pure clone (no-op).
- ~30 lines, no new dependency.

## Considered and rejected

- **Surgical `\?\` prefix only at spill sites.** More code, easy to miss a
  call site (`remove`, `clear_namespace`, future ones). The whole-store
  normalization is cleaner and self-documenting.
- **Add the `dunce` crate.** It would centralize the prefix decision but adds
  a dependency for ~10 lines of inline logic and would still need a
  Windows-only call site here.
- **Mark the test `#[ignore]`.** Hides the real defect; rejected by the issue
  author too.

## Tests

- Existing `p2_windows_long_path_spill` now passes on Windows (verified
  locally: `soldr cargo test -p zccache-artifact --test kv_stress -- p2`).
- New `p2b_windows_spill_remove_and_clear_at_long_path` exercises `remove`
  and `clear_namespace` on a path strictly > 260 chars, asserting the test
  setup actually crosses `MAX_PATH` so a regression of the verbatim-path fix
  would fail this test rather than silently shrink to a happy case.
- Both tests are `#[cfg(windows)]` only.

## Test plan

- [x] `soldr cargo check --workspace --all-targets`
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings`
- [x] `soldr cargo fmt --all -- --check`
- [x] `soldr cargo test -p zccache-artifact` (54 unit + 5 stress on Windows)
- [ ] CI: `windows / Check` green is the key signal.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>