### PR TITLE
chore(deps): bump soldr minimum to 0.7.14

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -59,6 +59,7 @@ runs:
     - name: Setup Soldr
       uses: zackees/setup-soldr@v0
       with:
+        version: "0.7.14"
         toolchain: 1.94.1
         cache: true
         cache-key-suffix: ${{ inputs.cache_key }}

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
+          version: "0.7.14"
           toolchain: 1.94.1
           cache: true
       - name: Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: zackees/setup-soldr@v0
         with:
+          version: "0.7.14"
           toolchain: 1.94.1
           cache: true
           build-cache: false
@@ -35,6 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: zackees/setup-soldr@v0
         with:
+          version: "0.7.14"
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: dylint
@@ -64,6 +66,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: zackees/setup-soldr@v0
         with:
+          version: "0.7.14"
           cache: true
           toolchain: 1.94.1
           cache-key-suffix: msrv
@@ -79,6 +82,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: zackees/setup-soldr@v0
         with:
+          version: "0.7.14"
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: docs

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: zackees/setup-soldr@v0
         with:
+          version: "0.7.14"
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: clippy

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
+          version: "0.7.14"
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 dependencies = []
 
 [dependency-groups]
-dev = ["soldr>=0.7.6"]
+dev = ["soldr>=0.7.14"]
 
 [project.scripts]
 run_zccache = "ci.soldr:run_zccache"


### PR DESCRIPTION
## Summary

Two changes:

1. **`pyproject.toml`**: Bumps the dev-dep minimum from `soldr>=0.7.6` to `soldr>=0.7.14` so local contributors get the new soldr after `uv sync`.
2. **`.github/workflows/*.yml` + `.github/actions/build-target/action.yml`**: Pins `version: "0.7.14"` on every `zackees/setup-soldr@v0` invocation. The v0 floating tag on setup-soldr still defaults to `0.7.11` (its `v0`-tagged `action.yml` has not been refreshed even though `main` defaults to 0.7.14), so CI was installing the old soldr in spite of the upstream release. Explicit `version:` overrides this.

- Release notes: https://github.com/zackees/soldr/releases/tag/v0.7.14
- Bundled zccache bump landed in soldr 0.7.12 ([release notes](https://github.com/zackees/soldr/releases/tag/v0.7.12)), which mentions "Release soldr 0.7.12 with zccache 1.4.0".

## Expected effect

`windows / Check` on main has been red with:

> `soldr: zccache session-end ... failed: cannot connect to daemon at ...`

That error came from soldr 0.7.11's bundled zccache 1.3.10 failing the session-end teardown when the daemon had already exited. zccache 1.4.0 ships the idempotent session-end fixes from #137 (daemon-side) and #151 (CLI-side when the daemon is gone), so this error should disappear and `windows / Check` should go green.

Verified on the first push of this PR that the workflow_dispatch'd `setup-soldr@v0` resolved to `soldr 0.7.11` (bundled `zccache 1.3.10`), which is why the workflow pin was added in the second commit.

## Test plan

- [x] Local `soldr cargo fmt --all -- --check`
- [x] Local `soldr cargo check --workspace --all-targets`
- [x] Local `soldr cargo clippy --workspace --all-targets -- -D warnings`
- [x] Confirmed `uv run soldr --version` reports `soldr 0.7.14` after `uv sync`
- [ ] CI `windows / Check` goes green
- [ ] CI logs show `soldr version=v0.7.14` and `fetched managed zccache 1.4.0`

Note: `Code Coverage` may stay red on `event_log::test_rotation_triggers_at_threshold` (#146 flake) - pre-existing, unrelated.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>