### PR TITLE
chore(gitignore): ignore Claude Code per-session runtime locks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ Thumbs.db
 # Session cache (hook fingerprints)
 .cache/
 
+# Claude Code runtime state (settings.json/rules/hooks ARE tracked,
+# but per-session locks/state files are not)
+.claude/scheduled_tasks.lock
+.claude/scheduled_tasks/
+
 # Project-local toolchain caches (managed by soldr)
 .cargo/
 .rustup/


### PR DESCRIPTION
## Summary
- `.claude/scheduled_tasks.lock` is created at runtime by Claude Code's slash-command scheduler. It was untracked-but-not-ignored, so it polluted \`git status --porcelain\` between session-start (\`check-on-start.py\`) and Stop (\`zccache-ci\`).
- That fingerprint mismatch flipped the stop hook from \`Skip\` into the **Full** path: lint + \`cargo check --target x86_64-unknown-linux-musl --workspace --all-targets\` + \`cargo test --workspace --lib\`. The Linux cross-compile alone runs ~5–10 min on Windows even with cache.
- Symptom: the stop hook was taking 10+ minutes on every conversation turn, even when nothing in the working tree had actually changed.

Ignoring the lock (and the \`scheduled_tasks/\` state dir that shows up the same way) keeps the porcelain fingerprint stable across the session. Tracked \`.claude/\` files (\`settings.json\`, \`rules/\`, \`hooks/\`, the various \`README.md\`s) are untouched.

## Test plan
- [x] \`git status --porcelain\` returns empty after the .gitignore change while the lock file is on disk.
- [x] No tracked .claude/ files are now ignored (\`git ls-files .claude/\` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)