### PR TITLE
chore(ci): drop invalid target-cache-paths from build-target action

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -63,7 +63,6 @@ runs:
         toolchain: 1.94.1
         cache: true
         cache-key-suffix: ${{ inputs.cache_key }}
-        target-cache-paths: target/${{ inputs.target }}
 
     - name: Ensure target stdlib is installed
       shell: bash


### PR DESCRIPTION
## Summary

`zackees/setup-soldr@v0` does not accept `target-cache-paths`. The valid input set is `version, repo, ref, cache, cache-dir, cache-key-suffix, toolchain, toolchain-file, trust-mode, timestamps, lockfile, build-cache, build-cache-mode, target-cache, target-cache-mode, target-dir`.

The line at `.github/actions/build-target/action.yml:66` was silently ignored — the action emitted a workflow warning on every build:

\`\`\`
! Unexpected input(s) 'target-cache-paths', valid inputs are ['version', ...]
\`\`\`

Per-target cache isolation is **already** handled correctly by `cache-key-suffix: \${{ inputs.cache_key }}` where `cache_key = matrix.target`. Each cross-compile target therefore gets its own scoped cache.

## Effect

- Removes the warning noise from build / release-auto runs.
- No behavior change — the line was a no-op.

## Test plan

- [ ] PR CI runs to completion with no new failures introduced.
- [ ] `build-target` composite action still passes (it's exercised by `build.yml` workflow_dispatch and by `release-auto.yml` build job — neither runs on PRs, so this lands on faith + the next release).