### PR TITLE
feat(cli,daemon): relocate daemon exe to global runtime-binaries dir

### DIFF
--- a/crates/zccache-cli/src/lib.rs
+++ b/crates/zccache-cli/src/lib.rs
@@ -532,8 +532,95 @@ fn apply_cli_spawn_lineage(cmd: &mut std::process::Command) {
     cmd.env(ENV_CLIENT_PID, cli_pid.to_string());
 }
 
+/// Subdir of the zccache global cache directory where the CLI stores
+/// per-launch copies of the daemon binary. The daemon runs from one of
+/// these copies, never from the install path (e.g. `Scripts/zccache-daemon.exe`),
+/// so `pip install --upgrade zccache` can always overwrite the install
+/// path regardless of whether a daemon is alive. See issue #134.
+const RUNTIME_BINARIES_SUBDIR: &str = "runtime-binaries";
+
+/// Returns `<global_cache_dir>/runtime-binaries`.
+#[must_use]
+pub fn runtime_binaries_dir() -> NormalizedPath {
+    zccache_core::config::default_cache_dir().join(RUNTIME_BINARIES_SUBDIR)
+}
+
+/// Copy `canonical` (the daemon binary at its install location) to a unique
+/// path inside [`runtime_binaries_dir`] and return the new path. The caller
+/// then spawns from the returned path so the install location is never
+/// file-locked by a running daemon.
+///
+/// On copy failure the caller should fall back to spawning `canonical`
+/// directly; the in-place `unlock_exe()` in the daemon then handles the
+/// lock removal as a fallback.
+pub fn prepare_daemon_exe(canonical: &Path) -> Result<std::path::PathBuf, std::io::Error> {
+    prepare_daemon_exe_in(canonical, runtime_binaries_dir().as_path())
+}
+
+/// Test seam for [`prepare_daemon_exe`]: copies `canonical` into `dir`
+/// (which is created if missing) and returns the destination path.
+pub fn prepare_daemon_exe_in(
+    canonical: &Path,
+    dir: &Path,
+) -> Result<std::path::PathBuf, std::io::Error> {
+    std::fs::create_dir_all(dir)?;
+
+    // Per-launch unique name. PID alone is reused across reboots; xor with
+    // the current nanos timestamp to keep collisions rare even when several
+    // CLI processes spawn back-to-back.
+    let rand_id: u32 = std::process::id()
+        ^ std::time::UNIX_EPOCH
+            .elapsed()
+            .unwrap_or_default()
+            .subsec_nanos();
+    let extension = canonical.extension().and_then(|s| s.to_str()).unwrap_or("");
+    let file_name = if extension.is_empty() {
+        format!("zccache-daemon.{rand_id}")
+    } else {
+        format!("zccache-daemon.{rand_id}.{extension}")
+    };
+    let dest = dir.join(&file_name);
+    std::fs::copy(canonical, &dest)?;
+    Ok(dest)
+}
+
+/// Best-effort delete every entry in [`runtime_binaries_dir`]. On Windows
+/// the kernel refuses to delete a file with an open handle, so files
+/// belonging to a *currently running* daemon are silently skipped — no PID
+/// tracking, no sidecar files. Cheap enough to call before every spawn.
+pub fn gc_runtime_binaries() {
+    gc_runtime_binaries_in(runtime_binaries_dir().as_path());
+}
+
+/// Test seam for [`gc_runtime_binaries`].
+pub fn gc_runtime_binaries_in(dir: &Path) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let _ = std::fs::remove_file(entry.path());
+    }
+}
+
 fn spawn_daemon(bin: &Path, endpoint: &str) -> Result<(), String> {
-    let mut cmd = std::process::Command::new(bin);
+    // GC before the new spawn so the dir doesn't grow unbounded across
+    // crash-loop scenarios. Live daemons are skipped (locked files).
+    gc_runtime_binaries();
+
+    // Prefer to spawn from a relocated copy in the zccache global dir.
+    // Fall back to the canonical install path if the copy fails — the
+    // daemon's own `unlock_exe()` then handles the in-place rename.
+    let bin_owned: std::path::PathBuf;
+    let spawn_bin: &Path = match prepare_daemon_exe(bin) {
+        Ok(p) => {
+            bin_owned = p;
+            &bin_owned
+        }
+        Err(_) => bin,
+    };
+
+    let mut cmd = std::process::Command::new(spawn_bin);
     cmd.args(["--foreground", "--endpoint", endpoint]);
     cmd.stdin(std::process::Stdio::null());
     cmd.stdout(std::process::Stdio::null());
@@ -907,5 +994,84 @@ mod tests {
         );
         let file_name = path.file_name().unwrap().to_string_lossy();
         assert!(file_name.ends_with("-toolchain.tar.zst"));
+    }
+
+    #[test]
+    fn prepare_daemon_exe_in_copies_to_target_dir() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("zccache-daemon.exe");
+        std::fs::write(&src, b"fake-daemon-bytes").expect("write source");
+
+        let dest_dir = tmp.path().join("runtime-binaries");
+        let copied =
+            prepare_daemon_exe_in(&src, &dest_dir).expect("prepare_daemon_exe_in succeeds");
+
+        assert!(
+            copied.is_file(),
+            "copy at {} should exist",
+            copied.display()
+        );
+        assert_eq!(
+            copied.parent().unwrap(),
+            dest_dir,
+            "copy should land inside dest_dir"
+        );
+        assert!(
+            copied
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .starts_with("zccache-daemon."),
+            "filename should start with zccache-daemon., got {}",
+            copied.display()
+        );
+        assert!(
+            copied.extension().and_then(|s| s.to_str()) == Some("exe"),
+            "extension should be preserved"
+        );
+        assert_eq!(
+            std::fs::read(&copied).unwrap(),
+            b"fake-daemon-bytes",
+            "copy contents should match source"
+        );
+    }
+
+    #[test]
+    fn prepare_daemon_exe_in_creates_missing_dest_dir() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("zccache-daemon");
+        std::fs::write(&src, b"x").expect("write source");
+
+        let dest_dir = tmp.path().join("nested").join("runtime-binaries");
+        assert!(!dest_dir.exists(), "precondition: dest_dir does not exist");
+
+        let copied = prepare_daemon_exe_in(&src, &dest_dir).expect("create + copy");
+        assert!(dest_dir.is_dir(), "dest_dir should now exist");
+        assert!(copied.is_file());
+    }
+
+    #[test]
+    fn gc_runtime_binaries_in_removes_unlocked_entries() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let dir = tmp.path().join("runtime-binaries");
+        std::fs::create_dir_all(&dir).expect("create dir");
+
+        let a = dir.join("zccache-daemon.111.exe");
+        let b = dir.join("zccache-daemon.222.exe");
+        std::fs::write(&a, b"a").unwrap();
+        std::fs::write(&b, b"b").unwrap();
+
+        gc_runtime_binaries_in(&dir);
+
+        assert!(!a.exists(), "{} should be GC'd", a.display());
+        assert!(!b.exists(), "{} should be GC'd", b.display());
+        assert!(dir.is_dir(), "directory itself remains");
+    }
+
+    #[test]
+    fn gc_runtime_binaries_in_is_noop_for_missing_dir() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let dir = tmp.path().join("does-not-exist");
+        gc_runtime_binaries_in(&dir);
     }
 }

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -3491,7 +3491,20 @@ fn which_on_path(name: &str) -> Option<NormalizedPath> {
 /// inherits these handles, the parent hangs forever waiting for pipe closure
 /// because the daemon never exits.
 fn spawn_daemon(bin: &std::path::Path, endpoint: &str) -> Result<(), String> {
-    let mut cmd = std::process::Command::new(bin);
+    // Best-effort: GC stale copies, then spawn from a fresh copy in the
+    // zccache global runtime-binaries dir so the install path stays
+    // overwritable. See issue #134.
+    zccache_cli::gc_runtime_binaries();
+    let bin_owned: std::path::PathBuf;
+    let spawn_bin: &std::path::Path = match zccache_cli::prepare_daemon_exe(bin) {
+        Ok(p) => {
+            bin_owned = p;
+            &bin_owned
+        }
+        Err(_) => bin,
+    };
+
+    let mut cmd = std::process::Command::new(spawn_bin);
     cmd.args(["--foreground", "--endpoint", endpoint]);
 
     // Detach stdio so the daemon doesn't hold our console

--- a/crates/zccache-daemon/README.md
+++ b/crates/zccache-daemon/README.md
@@ -1,3 +1,41 @@
 # zccache-daemon
 
 Tokio async runtime, IPC server, orchestrates all subsystems.
+
+## How the daemon avoids file-locking the install path on Windows
+
+A running Windows process file-locks its own executable, which means a
+naive `pip install --upgrade zccache` would fail to overwrite
+`Scripts/zccache-daemon.exe` while a daemon is alive. zccache solves this
+in two layers:
+
+1. **CLI relocates the daemon binary before spawning** (primary path).
+   `zccache_cli::prepare_daemon_exe` copies the daemon binary from its
+   install path into `<global_cache_dir>/runtime-binaries/zccache-daemon.<rand>.<ext>`,
+   and the CLI spawns from that copy. The install path is never executed
+   in place, so it stays overwritable. Stale copies are cleaned up by
+   `zccache_cli::gc_runtime_binaries` on every spawn — locked files
+   (currently-running daemons) are silently skipped by the OS.
+
+2. **Daemon's `unlock_exe()` is the fallback for direct invocations.**
+   When a user manually runs `zccache-daemon.exe` (rare), the binary is
+   still on the install path. `unlock_exe()` (in `src/trampoline.rs`)
+   renames it to `<install>.exe.old.<rand>` and copies a fresh unlocked
+   file back. The running process keeps executing from the renamed file.
+   When the daemon is launched normally via the CLI, `current_exe()`
+   already lives under `runtime-binaries/`, so `unlock_exe()` short-circuits
+   to a no-op.
+
+`release_cwd()` (also in `src/trampoline.rs`) chdir's to `std::env::temp_dir()`
+so the daemon stops pinning whatever directory the launcher happened to be
+in (e.g. a project's `.venv`). Both run as the very first lines of `main()`,
+before tracing init or any IPC bind.
+
+### Opt-out
+
+Set `ZCCACHE_NO_UNLOCK=1` to skip the in-place rename/copy in `unlock_exe()`.
+The CLI's relocation step always runs (no opt-out) since it's now the
+primary mechanism. The cwd release runs unconditionally.
+
+See issue #134 for background; PR #135 ported `unlock_exe()`/`release_cwd()`
+from [clud](https://github.com/zackees/clud)'s `clud-bin/src/trampoline.rs`.

--- a/crates/zccache-daemon/src/trampoline.rs
+++ b/crates/zccache-daemon/src/trampoline.rs
@@ -57,6 +57,13 @@ pub fn unlock_exe() {
         Err(_) => return,
     };
 
+    // If the CLI already relocated us into `<global>/runtime-binaries/`
+    // before spawning, the install path is already unlocked. No rename
+    // needed — short-circuit. See issue #134.
+    if exe_is_under_runtime_binaries(&my_exe) {
+        return;
+    }
+
     // Rename zccache-daemon.exe → zccache-daemon.exe.old.<rand>. We keep
     // running from the renamed file.
     let rand_id: u32 = std::process::id()
@@ -95,6 +102,27 @@ pub fn unlock_exe() {
 /// that dir until the daemon exits. Cheap one-liner, runs on every OS.
 pub fn release_cwd() {
     let _ = std::env::set_current_dir(std::env::temp_dir());
+}
+
+/// True if `exe` lives directly inside `<global_cache_dir>/runtime-binaries/`,
+/// i.e. the CLI already copied us out of the install path. Compared
+/// against the canonicalized cache dir to be robust to symlinks and
+/// short-name (8.3) tilde expansion on Windows.
+fn exe_is_under_runtime_binaries(exe: &Path) -> bool {
+    let runtime_dir = zccache_core::config::default_cache_dir().join("runtime-binaries");
+    let runtime_canon = match fs::canonicalize(&runtime_dir) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    let exe_parent = match exe.parent() {
+        Some(p) => p,
+        None => return false,
+    };
+    let exe_parent_canon = match fs::canonicalize(exe_parent) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    exe_parent_canon == runtime_canon
 }
 
 /// Delete stale .old files next to the exe. Best-effort — locked files skipped.

--- a/crates/zccache-daemon/tests/exe_overwrite.rs
+++ b/crates/zccache-daemon/tests/exe_overwrite.rs
@@ -1,0 +1,76 @@
+//! Regression test for `trampoline::unlock_exe()`.
+//!
+//! On Windows the OS file-locks a running executable, so without
+//! `unlock_exe()` `pip install --upgrade zccache` would fail to overwrite
+//! `Scripts/zccache-daemon.exe` while the daemon is alive. `unlock_exe()`
+//! sidesteps the lock by renaming the canonical path to
+//! `zccache-daemon.exe.old.<rand>` and copying back; the running process
+//! keeps executing from the renamed file and the canonical path is now an
+//! unlocked copy.
+//!
+//! This test proves the lock was actually lifted by trying to overwrite
+//! the canonical path while the daemon is running.
+//!
+//! Windows-only: on Unix, running binaries can be replaced freely so the
+//! test would pass without proving anything.
+//!
+//! See issue #134 / PR #135.
+
+#![cfg(windows)]
+
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+#[test]
+fn daemon_exe_path_is_overwritable_while_running() {
+    let daemon_src = env!("CARGO_BIN_EXE_zccache-daemon");
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let dest = tmp.path().join("zccache-daemon.exe");
+    std::fs::copy(daemon_src, &dest).expect("copy daemon binary into tempdir");
+
+    let endpoint = zccache_ipc::unique_test_endpoint();
+    let cache_dir = tmp.path().join("cache");
+    std::fs::create_dir_all(&cache_dir).expect("create per-test cache dir");
+
+    let mut child = Command::new(&dest)
+        .args(["--foreground", "--endpoint", &endpoint])
+        .env("ZCCACHE_CACHE_DIR", &cache_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon");
+
+    // Poll until the canonical path is overwritable. unlock_exe() runs
+    // synchronously at the top of main(), but the daemon hasn't necessarily
+    // reached it yet at the instant spawn() returns. If the daemon ever
+    // exits before the overwrite succeeds, fail loudly — that would mean
+    // the file is overwritable for the wrong reason.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut last_err: Option<std::io::Error> = None;
+    let overwrote = loop {
+        if let Some(status) = child.try_wait().expect("query daemon child") {
+            let _ = child.wait();
+            panic!("daemon exited prematurely (status {status:?}); last write error: {last_err:?}");
+        }
+        match std::fs::write(&dest, b"replaced") {
+            Ok(()) => break true,
+            Err(e) => last_err = Some(e),
+        }
+        if Instant::now() >= deadline {
+            break false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    };
+
+    // The daemon is running from `<tmp>/zccache-daemon.exe.old.<rand>`,
+    // so killing by PID still works even though the canonical path now
+    // contains "replaced".
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        overwrote,
+        "daemon exe path remained locked after spawn — last error: {last_err:?}"
+    );
+}


### PR DESCRIPTION
Closes #134. Implements the design from https://github.com/zackees/zccache/issues/134#issuecomment-4416401831.

## Summary
- **CLI \`prepare_daemon_exe()\`** copies the daemon binary from its install path (e.g. \`Scripts/zccache-daemon.exe\`) to \`<global_cache_dir>/runtime-binaries/zccache-daemon.<rand>.<ext>\` and the CLI spawns from that copy. The install path is never executed in place, so \`pip install --upgrade zccache\` always works.
- **\`gc_runtime_binaries()\`** runs on every spawn — \`fs::remove_file\` on every entry. Locked files (live daemons) are silently skipped by the OS, so no PID tracking or sidecar files are needed.
- **Daemon \`unlock_exe()\`** short-circuits when \`current_exe()\` lives under \`runtime-binaries/\`. It remains as a fallback for direct invocations of \`zccache-daemon.exe\`.
- README rewritten to document the two-layer flow + \`ZCCACHE_NO_UNLOCK\` opt-out.

## Test plan
- [x] 4 new unit tests in \`zccache-cli\`: \`prepare_daemon_exe_in_copies_to_target_dir\`, \`prepare_daemon_exe_in_creates_missing_dest_dir\`, \`gc_runtime_binaries_in_removes_unlocked_entries\`, \`gc_runtime_binaries_in_is_noop_for_missing_dir\` — all pass.
- [x] New \`crates/zccache-daemon/tests/exe_overwrite.rs\` (Windows-only) validates the daemon's fallback in-place rename path — passes.
- [x] \`soldr cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`soldr cargo fmt --all -- --check\` clean.
- [x] Existing \`tests/cwd_release.rs\` regression unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)