### PR TITLE
perf(ci): split Test job from Check to meet 2-minute target (#106)

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -24,6 +24,51 @@ jobs:
           cache: true
       - name: Check
         run: soldr cargo check --workspace --all-targets
+      - name: Stop zccache before cache save
+        if: always()
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import subprocess
+
+          status = subprocess.run(
+              ["soldr", "status", "--json"],
+              capture_output=True,
+              text=True,
+              check=False,
+          )
+          if status.returncode != 0:
+              raise SystemExit(0)
+
+          try:
+              payload = json.loads(status.stdout)
+          except json.JSONDecodeError:
+              raise SystemExit(0)
+
+          zccache = payload.get("zccache") or {}
+          binary = zccache.get("binary_path")
+          cache_dir = zccache.get("cache_dir") or zccache.get("state_dir")
+          if not binary:
+              raise SystemExit(0)
+
+          env = os.environ.copy()
+          if cache_dir:
+              env["ZCCACHE_CACHE_DIR"] = cache_dir
+          subprocess.run([binary, "stop"], env=env, check=False)
+          PY
+
+  test:
+    name: Test
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v0
+        with:
+          version: "0.7.14"
+          toolchain: 1.94.1
+          cache: true
       - name: Test
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

Closes the gap toward #106: warm `Check` jobs were over 2 minutes mostly because `cargo test --workspace --no-fail-fast` ran inside the same job as `cargo check`. This PR moves the test step into a separate `test` job that runs in parallel, so each platform `Check` job reports compile status under 2 minutes.

## Rationale (why this over alternatives)

Measured the latest warm-cache `main` runs:

| Platform | Total | setup-soldr | Check step | Test step |
|---|---|---|---|---|
| linux (run 25643337173)   | 1m52s | 56s | 7s   | 40s   |
| macos (run 25643337181)   | 3m40s | 64s | 17s  | 2m6s  |
| windows (run 25643337180) | 9m26s | 32s | 2m27s | 6m15s (fail) |

The Test step dominates everywhere except Windows (where Check itself is ~2m27s). Splitting Test out is the highest-leverage move and matches the issue's suggestion: "tests should be split into faster platform smoke checks plus a full test job."

Considered and rejected:
- Drop `--all-targets` from Check: loses test-build coverage on PRs; small wins.
- Drop the `Stop zccache` shim: only ~1s on Linux/macOS.
- Cache layout tuning: already tried in #105 and is at current best.

## Expected per-platform impact (warm cache)

| Platform | Check job before | Check job after | Delta |
|---|---|---|---|
| linux / Check   | 1m52s | ~1m12s | -40s   |
| macos / Check   | 3m40s | ~1m34s | -2m6s  |
| windows / Check | 5m22s* | ~3m   | -2m22s |

\*Windows Check job total prior to Test step start (latest warm run). Windows Check step alone is ~2m27s — still over the bar, but Test failure is no longer coupled to the Check signal.

The new `Test` job still pays the full test-compile-and-run cost, but it runs in parallel and no longer blocks the Check criterion.

## Test plan
- [ ] PR run: confirm `linux / Check` warm-cache duration ~1m12s
- [ ] PR run: confirm `macos / Check` warm-cache duration ~1m34s
- [ ] PR run: confirm `windows / Check` warm-cache duration ~3m or less
- [ ] PR run: confirm new `test` job runs (and that Windows Test still fails — pre-existing red, not blocking)
- [ ] Cache restore-keys: both jobs hit the same warm cache (parallel `setup-soldr`)

Refs: #106 #101 #105