### PR TITLE
fix(daemon): deterministic flush primitive for event log (#146)

### DIFF
--- a/crates/zccache-daemon/src/event_log.rs
+++ b/crates/zccache-daemon/src/event_log.rs
@@ -87,6 +87,13 @@ enum LogMessage {
         line: String,
         session_log_path: Option<NormalizedPath>,
     },
+    /// Synchronization sentinel: when the writer thread receives this, all
+    /// previously-queued `Write` messages have already been processed
+    /// (channels are FIFO). The writer signals completion by sending `()` on
+    /// the embedded ack channel, which the caller of `EventLogger::flush()`
+    /// blocks on. This eliminates the sleep-based "wait for the writer to
+    /// catch up" pattern in tests and any future flush call sites.
+    Flush(std::sync::mpsc::SyncSender<()>),
 }
 
 // ─── EventLogger ────────────────────────────────────────────────────────────
@@ -182,6 +189,31 @@ impl EventLogger {
             });
         }
     }
+
+    /// Block the calling thread until the background writer has processed
+    /// every message queued before this call.
+    ///
+    /// Implemented by posting a `Flush` sentinel and waiting on the worker's
+    /// acknowledgement. Because `tokio::sync::mpsc::UnboundedSender` preserves
+    /// FIFO ordering, all prior `Write` messages — including the ones whose
+    /// processing triggers file rotation — have already been applied to disk
+    /// by the time the sentinel is observed.
+    ///
+    /// No-op on a noop logger (no worker thread to synchronize with).
+    pub fn flush(&self) {
+        let Some(tx) = &self.sender else {
+            return;
+        };
+        let (ack_tx, ack_rx) = std::sync::mpsc::sync_channel::<()>(0);
+        if tx.send(LogMessage::Flush(ack_tx)).is_err() {
+            // Worker thread is gone — nothing to wait on.
+            return;
+        }
+        // If the worker drops the sender without sending (e.g. panic during
+        // shutdown), `recv()` returns Err and we fall through without blocking
+        // forever.
+        let _ = ack_rx.recv();
+    }
 }
 
 // ─── Background writer thread ───────────────────────────────────────────────
@@ -210,6 +242,12 @@ fn writer_thread(mut rx: mpsc::UnboundedReceiver<LogMessage>, mut writer: LogWri
                 if let Some(path) = session_log_path {
                     write_to_file(&path, &line);
                 }
+            }
+            LogMessage::Flush(ack) => {
+                // All earlier `Write` messages have been drained above —
+                // signal completion. Best-effort: if the caller has already
+                // dropped the receiver, send() fails and we drop the ack.
+                let _ = ack.send(());
             }
         }
     }

--- a/crates/zccache-daemon/src/event_log.rs
+++ b/crates/zccache-daemon/src/event_log.rs
@@ -377,9 +377,10 @@ fn write_to_file(path: &Path, line: &str) {
 mod tests {
     use super::*;
 
-    /// Give the background thread time to drain the channel and complete I/O.
-    fn flush_logger(_logger: &EventLogger) {
-        std::thread::sleep(Duration::from_millis(200));
+    /// Block until the background writer thread has processed all events
+    /// queued up to this point. Implemented by `EventLogger::flush()`.
+    fn flush_logger(logger: &EventLogger) {
+        logger.flush();
     }
 
     #[test]
@@ -436,6 +437,41 @@ mod tests {
         );
         assert!(line.contains("pch.h"), "source file: {line}");
         assert!(line.contains("reason=pch-generation"), "reason: {line}");
+    }
+
+    #[test]
+    fn test_flush_is_deterministic_no_sleep_required() {
+        // RED-then-GREEN regression for #146.
+        //
+        // The previous `flush_logger` was a blind 200ms sleep, which races with
+        // the background writer on slow CI runners. `EventLogger::flush()` must
+        // be a real sync primitive: queue N events, call flush(), and the file
+        // contents must be on disk *immediately* — no polling, no tolerance.
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().to_path_buf();
+        let logger = EventLogger::new(log_dir.clone().into(), 100, 3);
+
+        for i in 0..20 {
+            logger.log_daemon_event(&format!("event {i} with some padding to fill space"));
+        }
+        logger.flush();
+
+        // No sleep, no retry. If flush() is not deterministic, this fails.
+        let main_log = log_dir.join("daemon.log");
+        assert!(
+            main_log.exists(),
+            "daemon.log must exist immediately after flush()"
+        );
+
+        let rotated: Vec<_> = fs::read_dir(&log_dir)
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().starts_with("daemon.log."))
+            .collect();
+        assert!(
+            !rotated.is_empty(),
+            "at least one rotated file must be visible immediately after flush()"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replaces the 200 ms blind `thread::sleep` in `flush_logger` with a real cross-thread sync primitive on `EventLogger`. Fixes the slow-CI race in `event_log::tests::test_rotation_triggers_at_threshold` where the background writer was still mid-rotation when the sleep elapsed, leaving `daemon.log` renamed but not yet recreated.

- Adds `EventLogger::flush()` (public).
- Adds `LogMessage::Flush(std::sync::mpsc::SyncSender<()>)` sentinel. The worker drains it after all earlier `Write` messages (channels are FIFO) and signals back; the caller blocks on the ack. On-disk state — including rotation triggered by queued writes — is fully committed by the time `flush()` returns.
- New regression test `test_flush_is_deterministic_no_sleep_required` asserts the file is on disk **immediately** after `flush()` returns (no polling, no tolerance).
- The pre-existing `flush_logger` test helper now delegates to `EventLogger::flush()` — no other call sites need to change.

## TDD log

- **RED** (`1d45b1c`): rewires `flush_logger` to call `EventLogger::flush()`, which does not exist yet → compile error.
- **GREEN** (`7696fde`): implements the sync primitive; all 11 `event_log` tests + all 148 daemon lib tests pass.

## Test plan

- [x] `soldr cargo test -p zccache-daemon event_log`
- [x] `soldr cargo test -p zccache-daemon --lib` (148 passed)
- [x] `soldr cargo check --workspace --all-targets`
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings`
- [x] `soldr cargo fmt --all -- --check`

Closes #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)