### PR TITLE
feat(cli): expose session_end_idempotent for all daemon callers (closes #159)

### DIFF
--- a/crates/zccache-cli/src/lib.rs
+++ b/crates/zccache-cli/src/lib.rs
@@ -1074,4 +1074,56 @@ mod tests {
         let dir = tmp.path().join("does-not-exist");
         gc_runtime_binaries_in(&dir);
     }
+
+    /// Issue #159: `session_end_idempotent` is the shared library entry
+    /// point for ending a session — used by the CLI `session-end` command
+    /// AND by tools like soldr that call into the library directly. When
+    /// the daemon process is gone (pipe / socket missing), this function
+    /// must return `Ok(None)` rather than propagating the connect-time
+    /// I/O error. Soldr's at-exit `rust-plan save` previously failed
+    /// Windows CI because its in-process session-end did NOT go through
+    /// `cmd_session_end` (which is gated to the CLI subprocess path) and
+    /// so the #151 idempotency fix didn't apply.
+    #[test]
+    fn session_end_idempotent_swallows_vanished_daemon() {
+        // Construct an endpoint that is guaranteed to have no listener —
+        // a unique pipe / socket name with no server bound to it.
+        let endpoint = zccache_ipc::unique_test_endpoint();
+        let session_id = "00000000-0000-0000-0000-000000000000";
+
+        let result = session_end_idempotent(&endpoint, session_id);
+
+        assert!(
+            matches!(result, Ok(None)),
+            "vanished daemon must produce Ok(None) (success no-op), got {result:?}"
+        );
+    }
+
+    /// Control: non-unreachable errors (the function shouldn't be a
+    /// blanket "ignore everything"). We can't easily synthesize a live
+    /// daemon error here, but we can at least assert the routing via the
+    /// helper used inside the function: connect-time `TimedOut` must NOT
+    /// be classified as unreachable, so the function would propagate it
+    /// (rather than silently return Ok(None)). This guards against a
+    /// regression where someone widens the unreachable set to "any I/O
+    /// error".
+    #[test]
+    fn session_end_idempotent_treats_timeout_as_real_error() {
+        let err = zccache_ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::TimedOut));
+        assert!(
+            !is_daemon_unreachable_err(&err),
+            "TimedOut must NOT be classified as daemon-unreachable; session_end_idempotent \
+             would otherwise silently swallow real timeouts"
+        );
+    }
+
+    /// Control: protocol-layer errors (malformed framing, closed
+    /// connection mid-response) must NOT be classified as unreachable.
+    #[test]
+    fn session_end_idempotent_treats_protocol_errors_as_real() {
+        let err = zccache_ipc::IpcError::ConnectionClosed;
+        assert!(!is_daemon_unreachable_err(&err));
+        let err = zccache_ipc::IpcError::Endpoint("bogus".into());
+        assert!(!is_daemon_unreachable_err(&err));
+    }
 }

--- a/crates/zccache-cli/src/lib.rs
+++ b/crates/zccache-cli/src/lib.rs
@@ -798,6 +798,111 @@ pub fn client_session_end(
     })
 }
 
+/// Is this connect-time error a "daemon process is gone entirely" error?
+///
+/// The conservative set: `NotFound` (Unix socket missing, Windows pipe
+/// missing), `ConnectionRefused` (Unix socket exists but no listener;
+/// Windows backoff helper synthesizes this when all pipe instances are
+/// permanently busy), and `BrokenPipe` (race: pipe vanished between
+/// open and use). Other errors (`TimedOut`, protocol mismatches, etc.)
+/// are NOT daemon-gone — they should still fail loudly.
+///
+/// Used by `session_end_idempotent` (issue #159) and the CLI's
+/// `cmd_session_end` (issue #150 / #151) to map "the daemon already
+/// died" connect-time failures onto a success no-op. Other request
+/// types keep their existing strict error semantics.
+#[must_use]
+pub fn is_daemon_unreachable_err(err: &zccache_ipc::IpcError) -> bool {
+    use std::io::ErrorKind;
+    match err {
+        zccache_ipc::IpcError::Io(io) => matches!(
+            io.kind(),
+            ErrorKind::NotFound | ErrorKind::ConnectionRefused | ErrorKind::BrokenPipe
+        ),
+        _ => false,
+    }
+}
+
+/// End a session, treating a vanished daemon as success.
+///
+/// This is the shared library entry point for ending a session. It is
+/// the contract used by the CLI's `zccache session-end <uuid>`
+/// subcommand AND by any in-process caller (e.g. soldr's at-exit
+/// `rust-plan save`) — both must agree on what "the daemon already
+/// died" means.
+///
+/// # Return shape
+///
+/// - `Ok(Some(stats))` — daemon was reached and returned stats for the
+///   session.
+/// - `Ok(None)` — daemon was reached but returned no stats (session
+///   was tracked without stats), OR the daemon was unreachable at
+///   connect time. Both are no-ops from the caller's perspective:
+///   the session is implicitly ended when the daemon dies (see #137
+///   for the daemon-side mirror), and a caller that just wants to
+///   "end the session, don't care if the daemon is still alive"
+///   should treat both as success.
+/// - `Err(IpcError)` — anything else: timeouts, protocol mismatches,
+///   send/recv mid-conversation failures, daemon error responses.
+///   These are real faults and must be surfaced.
+///
+/// # Why a separate function
+///
+/// Issue #159: soldr was failing Windows CI on every main commit
+/// because its in-process session-end (called from `rust-plan save`)
+/// did not share code with `cmd_session_end`, so #151's
+/// connect-failure idempotency only applied to the CLI subprocess
+/// path. Promoting this contract to the library lets all callers —
+/// current and future — share the same behavior.
+pub fn session_end_idempotent(
+    endpoint: &str,
+    session_id: &str,
+) -> Result<Option<zccache_protocol::SessionStats>, zccache_ipc::IpcError> {
+    let endpoint = endpoint.to_string();
+    let session_id = session_id.to_string();
+
+    // Build a dedicated current-thread runtime. Can't use the existing
+    // `run_async` helper because its `Output = Result<T, String>` shape
+    // doesn't compose with our `Result<_, IpcError>` return type.
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| {
+            zccache_ipc::IpcError::Endpoint(format!("failed to create tokio runtime: {e}"))
+        })?;
+
+    runtime.block_on(async move {
+        let mut conn = match connect_client(&endpoint).await {
+            Ok(c) => c,
+            Err(e) => {
+                if is_daemon_unreachable_err(&e) {
+                    eprintln!(
+                        "session-end: daemon unreachable at {endpoint}, treating session {session_id} as ended"
+                    );
+                    return Ok(None);
+                }
+                return Err(e);
+            }
+        };
+
+        conn.send(&zccache_protocol::Request::SessionEnd {
+            session_id: session_id.clone(),
+        })
+        .await?;
+
+        match conn.recv::<zccache_protocol::Response>().await? {
+            Some(zccache_protocol::Response::SessionEnded { stats }) => Ok(stats),
+            Some(zccache_protocol::Response::Error { message }) => Err(
+                zccache_ipc::IpcError::Endpoint(format!("session-end failed: {message}")),
+            ),
+            None => Err(zccache_ipc::IpcError::ConnectionClosed),
+            Some(other) => Err(zccache_ipc::IpcError::Endpoint(format!(
+                "unexpected response from daemon: {other:?}"
+            ))),
+        }
+    })
+}
+
 pub fn client_session_stats(
     endpoint: Option<&str>,
     session_id: &str,
@@ -1125,5 +1230,48 @@ mod tests {
         assert!(!is_daemon_unreachable_err(&err));
         let err = zccache_ipc::IpcError::Endpoint("bogus".into());
         assert!(!is_daemon_unreachable_err(&err));
+    }
+
+    /// Issue #150: connect-time errors that mean "daemon process is gone
+    /// entirely" must be classified as unreachable so the idempotent
+    /// session-end paths (`session_end_idempotent` + the CLI's
+    /// `cmd_session_end` wrapper) can fall through to the success path.
+    /// The set covers every shape `connect()` actually returns when the
+    /// pipe / socket is missing or has no listener.
+    #[test]
+    fn is_daemon_unreachable_recognizes_not_found() {
+        let err = zccache_ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::NotFound));
+        assert!(is_daemon_unreachable_err(&err));
+    }
+
+    #[test]
+    fn is_daemon_unreachable_recognizes_connection_refused() {
+        let err =
+            zccache_ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::ConnectionRefused));
+        assert!(is_daemon_unreachable_err(&err));
+    }
+
+    #[test]
+    fn is_daemon_unreachable_recognizes_broken_pipe() {
+        let err = zccache_ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::BrokenPipe));
+        assert!(is_daemon_unreachable_err(&err));
+    }
+
+    /// Mapping ENOENT through `from_raw_os_error` must yield the same
+    /// classification as constructing from `ErrorKind::NotFound`. This
+    /// guards against platform variance (macOS / Linux / Windows could
+    /// in principle synthesize a different kind for the same errno).
+    #[test]
+    fn is_daemon_unreachable_recognizes_raw_enoent() {
+        // ENOENT == 2 on every Unix; on Windows ERROR_FILE_NOT_FOUND == 2 too.
+        let err = zccache_ipc::IpcError::Io(std::io::Error::from_raw_os_error(2));
+        assert!(
+            is_daemon_unreachable_err(&err),
+            "errno 2 must map to a kind in the unreachable set; got kind={:?}",
+            match &err {
+                zccache_ipc::IpcError::Io(io) => io.kind(),
+                _ => unreachable!(),
+            }
+        );
     }
 }

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -30,8 +30,8 @@ use zccache_artifact::{
     RustArtifactPlanV1, RustPlanError, RustPlanOperation, RustPlanSummary,
 };
 use zccache_cli::{
-    client_download, run_ino_convert_cached, ArchiveFormat, DownloadParams, DownloadSource,
-    InoConvertOptions, WaitMode,
+    client_download, run_ino_convert_cached, session_end_idempotent, ArchiveFormat, DownloadParams,
+    DownloadSource, InoConvertOptions, WaitMode,
 };
 use zccache_compiler::strict_paths::StrictPathsMode;
 use zccache_core::NormalizedPath;
@@ -716,7 +716,7 @@ fn main() -> ExitCode {
             endpoint,
         } => {
             let endpoint = resolve_endpoint(endpoint.as_deref());
-            run_async(cmd_session_end(&endpoint, session_id))
+            cmd_session_end(&endpoint, session_id)
         }
         Commands::SessionStatsCmd {
             session_id,
@@ -1508,78 +1508,40 @@ async fn cmd_session_start(
     }
 }
 
-async fn cmd_session_end(endpoint: &str, session_id: String) -> ExitCode {
-    let mut conn = match connect(endpoint).await {
-        Ok(c) => c,
-        Err(e) => {
-            // Daemon-gone case: mirror #137's idempotency at the connection
-            // layer. If the daemon process exited entirely (pipe / socket
-            // missing, or no listener) before soldr's at-exit
-            // `session-end` hits, treat it as success — the session is
-            // implicitly ended when the daemon dies. Other errors (timeout,
-            // protocol mismatch, etc.) still fail loudly. See issue #150.
-            if is_daemon_unreachable_err(&e) {
-                eprintln!(
-                    "session-end: daemon unreachable at {endpoint}, treating session {session_id} as ended"
-                );
-                return ExitCode::SUCCESS;
-            }
-            eprintln!("cannot connect to daemon at {endpoint}: {e}");
-            return ExitCode::FAILURE;
-        }
-    };
-
-    if let Err(e) = conn
-        .send(&zccache_protocol::Request::SessionEnd {
-            session_id: session_id.clone(),
-        })
-        .await
-    {
-        eprintln!("zccache: failed to send to daemon: {e}");
-        return ExitCode::FAILURE;
-    }
-
-    let recv_result = match conn.recv().await {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("zccache: broken connection to daemon: {e}");
-            return ExitCode::FAILURE;
-        }
-    };
-    match recv_result {
-        Some(zccache_protocol::Response::SessionEnded { stats }) => {
-            if let Some(s) = stats {
-                let total = s.hits + s.misses;
-                let hit_rate = if total > 0 {
-                    format!("{:.1}%", s.hits as f64 / total as f64 * 100.0)
-                } else {
-                    "n/a".to_string()
-                };
-                eprintln!(
-                    "Session {session_id} complete ({})",
-                    format_duration_ms(s.duration_ms)
-                );
-                eprintln!(
-                    "  {} compilations: {} hits, {} misses, {} non-cacheable",
-                    s.compilations, s.hits, s.misses, s.non_cacheable
-                );
-                eprintln!("  Hit rate: {hit_rate}");
-                if s.time_saved_ms > 0 {
-                    eprintln!("  Time saved: ~{}", format_duration_ms(s.time_saved_ms));
-                }
+fn cmd_session_end(endpoint: &str, session_id: String) -> ExitCode {
+    // Thin wrapper around the shared library entry point. All daemon
+    // callers (CLI, soldr, future tools) must agree on what "the daemon
+    // is gone" means — see `session_end_idempotent` for the contract
+    // and issue #159 for why this lives in the library.
+    match session_end_idempotent(endpoint, &session_id) {
+        Ok(Some(s)) => {
+            let total = s.hits + s.misses;
+            let hit_rate = if total > 0 {
+                format!("{:.1}%", s.hits as f64 / total as f64 * 100.0)
+            } else {
+                "n/a".to_string()
+            };
+            eprintln!(
+                "Session {session_id} complete ({})",
+                format_duration_ms(s.duration_ms)
+            );
+            eprintln!(
+                "  {} compilations: {} hits, {} misses, {} non-cacheable",
+                s.compilations, s.hits, s.misses, s.non_cacheable
+            );
+            eprintln!("  Hit rate: {hit_rate}");
+            if s.time_saved_ms > 0 {
+                eprintln!("  Time saved: ~{}", format_duration_ms(s.time_saved_ms));
             }
             ExitCode::SUCCESS
         }
-        Some(zccache_protocol::Response::Error { message }) => {
-            eprintln!("session-end failed: {message}");
-            ExitCode::FAILURE
-        }
-        None => {
-            eprintln!("zccache: lost connection to daemon (no response received)");
-            ExitCode::FAILURE
-        }
-        Some(other) => {
-            eprintln!("zccache: unexpected response from daemon: {other:?}");
+        // `Ok(None)` covers both:
+        //   - daemon was unreachable (already logged by the library), and
+        //   - daemon was reached but had no stats for this session.
+        // Both are no-op successes.
+        Ok(None) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("zccache: session-end failed: {e}");
             ExitCode::FAILURE
         }
     }
@@ -3638,28 +3600,6 @@ async fn connect(
     zccache_ipc::connect(endpoint).await
 }
 
-/// Is this connect-time error a "daemon process is gone entirely" error?
-///
-/// The conservative set: `NotFound` (Unix socket missing, Windows pipe
-/// missing), `ConnectionRefused` (Unix socket exists but no listener;
-/// Windows backoff helper synthesizes this when all pipe instances are
-/// permanently busy), and `BrokenPipe` (race: pipe vanished between
-/// open and use). Other errors (`TimedOut`, protocol mismatches, etc.)
-/// are NOT daemon-gone — they should still fail loudly.
-///
-/// Used by `session-end` only (issue #150) — other request types keep
-/// their existing strict error semantics.
-fn is_daemon_unreachable_err(err: &zccache_ipc::IpcError) -> bool {
-    use std::io::ErrorKind;
-    match err {
-        zccache_ipc::IpcError::Io(io) => matches!(
-            io.kind(),
-            ErrorKind::NotFound | ErrorKind::ConnectionRefused | ErrorKind::BrokenPipe
-        ),
-        _ => false,
-    }
-}
-
 fn resolve_endpoint(explicit: Option<&str>) -> String {
     if let Some(ep) = explicit {
         return ep.to_string();
@@ -3727,66 +3667,6 @@ fn init_tracing() {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Issue #150: connect-time errors that mean "daemon process is gone
-    /// entirely" must be classified as unreachable so `cmd_session_end`
-    /// can fall through to the idempotent success path. The set covers
-    /// every shape `connect()` actually returns when the pipe / socket
-    /// is missing or has no listener.
-    #[test]
-    fn is_daemon_unreachable_recognizes_not_found() {
-        let err = zccache_ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::NotFound));
-        assert!(is_daemon_unreachable_err(&err));
-    }
-
-    #[test]
-    fn is_daemon_unreachable_recognizes_connection_refused() {
-        let err =
-            zccache_ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::ConnectionRefused));
-        assert!(is_daemon_unreachable_err(&err));
-    }
-
-    #[test]
-    fn is_daemon_unreachable_recognizes_broken_pipe() {
-        let err = zccache_ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::BrokenPipe));
-        assert!(is_daemon_unreachable_err(&err));
-    }
-
-    /// Mapping ENOENT through `from_raw_os_error` must yield the same
-    /// classification as constructing from `ErrorKind::NotFound`. This
-    /// guards against platform variance (macOS / Linux / Windows could
-    /// in principle synthesize a different kind for the same errno).
-    #[test]
-    fn is_daemon_unreachable_recognizes_raw_enoent() {
-        // ENOENT == 2 on every Unix; on Windows ERROR_FILE_NOT_FOUND == 2 too.
-        let err = zccache_ipc::IpcError::Io(std::io::Error::from_raw_os_error(2));
-        assert!(
-            is_daemon_unreachable_err(&err),
-            "errno 2 must map to a kind in the unreachable set; got kind={:?}",
-            match &err {
-                zccache_ipc::IpcError::Io(io) => io.kind(),
-                _ => unreachable!(),
-            }
-        );
-    }
-
-    /// Timeouts must NOT be classified as unreachable — those are real
-    /// faults and should propagate as exit 1.
-    #[test]
-    fn is_daemon_unreachable_rejects_timeout() {
-        let err = zccache_ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::TimedOut));
-        assert!(!is_daemon_unreachable_err(&err));
-    }
-
-    /// Protocol errors (malformed framing, version skew) must NOT be
-    /// classified as unreachable.
-    #[test]
-    fn is_daemon_unreachable_rejects_non_io_variants() {
-        let err = zccache_ipc::IpcError::ConnectionClosed;
-        assert!(!is_daemon_unreachable_err(&err));
-        let err = zccache_ipc::IpcError::Endpoint("bogus".into());
-        assert!(!is_daemon_unreachable_err(&err));
-    }
 
     #[test]
     fn exit_code_zero_stays_zero() {


### PR DESCRIPTION
## Summary

Promotes the session-end "daemon unreachable = success no-op" contract from a CLI-private helper to a shared library entry point so all daemon callers — CLI, soldr, future tools — agree on the same semantics.

Closes #159.

## Why

#151 made `zccache session-end <uuid>` idempotent at the connect-failure layer. But Windows CI keeps failing at the very end of every run with:

```
soldr: zccache session-end ... failed: cannot connect to daemon at \.\pipe\zccache-...
```

That failure is **not** from soldr exec'ing `zccache.exe session-end` — it's soldr calling the same code path **inside its own process via the library**. `cmd_session_end` never runs, so the #151 idempotency fix doesn't apply.

## What

- **Library**: new `pub fn session_end_idempotent(endpoint, session_id) -> Result<Option<SessionStats>, IpcError>`. On connect-time `NotFound | ConnectionRefused | BrokenPipe` it returns `Ok(None)`. On `SessionEnded` it returns `Ok(stats)`. Other errors propagate.
- **Library**: `is_daemon_unreachable_err` promoted from `main.rs`-private to `pub` in `lib.rs` so the same classification is shared.
- **CLI**: `cmd_session_end` rewritten as a thin wrapper that calls the library function and preserves the existing CLI stderr output (session duration, compilation counts, hit rate, time saved).
- **Tests**: classification tests (NotFound / ConnectionRefused / BrokenPipe / raw ENOENT / TimedOut / ConnectionClosed / Endpoint) moved from `main.rs::tests` to `lib.rs::tests` so they cover the public API directly. Plus new tests for `session_end_idempotent` against a vanished pipe (RED test of TDD).

Soldr adopting the new function is **out of scope** (separate repo). This PR is the library-side prerequisite.

## TDD

- **RED** (`2270d1d`): added `session_end_idempotent_swallows_vanished_daemon` + control tests asserting the function returns `Ok(None)` against a guaranteed-unbound endpoint. Confirmed failure: `cannot find function session_end_idempotent in this scope`.
- **GREEN** (`b74e658`): implemented the library function and reduced `cmd_session_end` to a thin wrapper. All 15 lib tests pass.

## Test plan

- [x] `soldr cargo check --workspace --all-targets`
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings`
- [x] `soldr cargo fmt --all -- --check`
- [x] `soldr cargo test -p zccache-cli --lib` — 15/15 passing
- [x] `soldr cargo test --workspace --lib` — 59 watcher tests + all others passing
- [x] CLI stderr format preserved: `Session <uuid> complete (<dur>)`, `<n> compilations: ...`, `Hit rate: ...`, `Time saved: ...`
- [ ] Integration test `tests/session_end.rs::session_end_with_unreachable_daemon_is_idempotent` (ignored, runs under `./test --integration`) still passes — covered by the existing CLI wrapper which routes through the new library function

## Out of scope (will follow up separately)

- Soldr adoption of `session_end_idempotent` — that's a separate repo and requires a new zccache release first.
- The Windows / Check CI red on main caused by soldr's bundled zccache: same reason — needs a zccache release + soldr release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)