### PR TITLE
perf(ci): drop --all-targets from Check to cut Windows over-budget (#106)

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -23,7 +23,7 @@ jobs:
           toolchain: 1.94.1
           cache: true
       - name: Check
-        run: soldr cargo check --workspace --all-targets
+        run: soldr cargo check --workspace
       - name: Stop zccache before cache save
         if: always()
         shell: bash


### PR DESCRIPTION
## Summary

- Check existed as a fast compile gate; `--all-targets` pulled in tests/benches/examples which the parallel Test job (added in #161) already covers
- Drops one flag from `ci-check.yml` — Check is now a true lib+bins smoke check
- No coverage lost: Test still does `cargo test --workspace`, runs at the same time as Check, so time-to-detection of a broken test build is unchanged

## Why now

Per the issue (#106) acceptance criteria, each platform Check should land ~2 minutes warm. Current main:

| Platform | Check job (warm) | Check step alone |
|---|---|---|
| linux / Check | 1m9s | 7s |
| macos / Check | 1m29s | 14s |
| windows / Check | **3m41s** | **2m45s** |

(Source: run 25650455876, 25650455892, 25650455878)

Linux + macOS already meet target; Windows alone is over by ~1m40s, with the `cargo check` step itself responsible for ~2m45s of wall time. #161 considered dropping `--all-targets` but rejected it on a "small wins" hunch without measuring. This PR empirically tests that on the slow path.

If Windows drops to ~2m or less here, this closes the gap. If the savings really are small, we'll know that the bottleneck is not in test-target compilation and can rule it out.

## Test plan
- [ ] PR run: confirm `windows / Check` warm-cache duration drops materially from baseline 3m41s — target ~2m
- [ ] PR run: confirm `linux / Check` and `macos / Check` stay under 2m
- [ ] PR run: confirm `Test` job still catches test compile errors (Test compiles tests via `cargo test --workspace`)

Refs: #106 #161