### PR TITLE
fix(daemon,ci): tolerate unknown sessions and stop killing soldr's daemon (closes #166, #167)

### DIFF
--- a/crates/zccache-ci/src/lib.rs
+++ b/crates/zccache-ci/src/lib.rs
@@ -490,14 +490,18 @@ pub fn kill_pids_and_wait(pids: &[u32], timeout: Duration) {
 }
 
 /// Kill every running `zccache-daemon`, wait for them to actually exit, and
-/// remove the stale `daemon.lock` file. Used by the stop hook before invoking
-/// cargo so the build can replace the daemon binary on Windows without racing
-/// the dying process.
+/// remove the stale `daemon.lock` file. Intended for callers that need to
+/// replace the daemon binary on Windows without racing the dying process.
 ///
 /// See issue #152: prior to this, `kill_daemon` returned immediately after
 /// `process.kill()` and left the lock file pointing at the just-killed PID,
 /// causing `cargo check` to fail with "cannot connect to daemon at \\.\\pipe\\..."
 /// because parallel rustc workers raced the half-dead daemon.
+///
+/// WARNING: Do not call from the stop hook unless your stage actually
+/// rebuilds `zccache-daemon.exe` — see issue #167 for why blanket calls
+/// broke soldr session continuity (and triggered the #166 "unknown session"
+/// failures downstream).
 pub fn kill_daemon() {
     let pids = find_daemon_pids();
     if pids.is_empty() {

--- a/crates/zccache-ci/src/main.rs
+++ b/crates/zccache-ci/src/main.rs
@@ -18,7 +18,7 @@ use std::fs;
 use std::path::Path;
 use std::process::{Command, ExitCode};
 
-use zccache_ci::{kill_daemon, reap_orphan_daemons, resolve_timeout, StageOutcome, StageRunner};
+use zccache_ci::{reap_orphan_daemons, resolve_timeout, StageOutcome, StageRunner};
 use zccache_core::NormalizedPath;
 
 fn project_root() -> NormalizedPath {
@@ -177,11 +177,16 @@ fn main() -> ExitCode {
     // Ensure all spawned cargo/rustc processes find the rustup toolchain
     activate_rustup_toolchain(&root);
 
-    // First reap any zccache-daemon whose parent PID is gone — these are
-    // true orphans from a previous force-killed agent turn. Then kill any
-    // remaining daemon so cargo can replace the exe on Windows.
+    // Reap any zccache-daemon whose parent PID is gone — these are true
+    // orphans from a previous force-killed agent turn. We deliberately do
+    // NOT also kill live daemons: every stage below is `cargo check` /
+    // `clippy` / `cargo test --exclude zccache-daemon`, none of which
+    // rebuild `zccache-daemon.exe`, so there is no binary to unlock. The
+    // prior blanket `kill_daemon()` here took down the soldr-managed daemon
+    // mid-build and broke session continuity. If a future stage rebuilds
+    // the daemon crate, call `kill_daemon()` immediately before that stage
+    // only — never globally at startup. See issues #166 and #167.
     let _ = reap_orphan_daemons();
-    kill_daemon();
 
     // Run every stage under a shared wall-clock deadline (default 300s,
     // overridable via env var). On timeout the entire process tree is killed

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -2757,12 +2757,13 @@ async fn handle_compile(
 
     state.stats.record_compilation();
 
-    // Verify session exists
-    if !state.sessions.exists(&sid) {
-        return Response::Error {
-            message: format!("unknown session: {session_id}"),
-        };
-    }
+    // Note: we do not require `state.sessions.exists(&sid)` here. A daemon
+    // restart (e.g. zccache-ci killing the daemon to unlock target binaries
+    // on Windows) drops the session map but client wrappers keep using the
+    // session UUID they were issued. The session-stat and touch helpers
+    // below already no-op for unknown sessions, so the compile itself
+    // proceeds; only per-session stats are lost. Mirrors PR #137's
+    // idempotent SessionEnd fix. See issues #166 and #167.
 
     let compiler: NormalizedPath = compiler_path.into();
 
@@ -5163,6 +5164,62 @@ exit /b 0
                     );
                 }
                 other => panic!("expected SessionEnded for unknown UUID, got: {other:?}"),
+            }
+
+            shutdown.notify_one();
+            server_handle.await.unwrap();
+        })
+        .await;
+    }
+
+    /// Regression for #166 — Compile on an unknown session must not fail with
+    /// "unknown session", mirroring #137's SessionEnd idempotency. Triggered
+    /// when zccache-ci kills the daemon mid-build (#167).
+    ///
+    /// The daemon used to short-circuit Compile with `Response::Error` if the
+    /// session UUID was unknown. After a daemon restart, soldr-managed rustc
+    /// wrappers keep using the old session UUID and would all fail; soldr in
+    /// turn exits 1 and the whole build breaks. We now let the compile
+    /// proceed; only per-session stats are lost.
+    #[tokio::test]
+    #[ignore] // integration-level: starts real daemon with IPC
+    async fn cli_compile_unknown_uuid_is_idempotent() {
+        zccache_test_support::test_timeout(async {
+            let tmp = tempfile::tempdir().unwrap();
+            // Use an isolated cache dir so we don't clash with any
+            // production daemon holding the global redb lock.
+            let _cache_dir = CacheDirEnvGuard::set(&tmp.path().join("zccache-cache"));
+
+            let (endpoint, server_handle, shutdown) = start_daemon().await;
+            let mut client = zccache_ipc::connect(&endpoint).await.unwrap();
+
+            let cwd = tmp.path().to_string_lossy().into_owned();
+
+            // Send a Compile with a well-formed UUID the daemon has never
+            // seen. We intentionally pass a bogus compiler path and trivial
+            // args — the only assertion is that we don't get the
+            // "unknown session" Error response that the pre-#166 code emitted
+            // before any real compilation work began.
+            client
+                .send(&Request::Compile {
+                    session_id: "00000000-0000-0000-0000-000000000000".to_string(),
+                    args: vec!["--version".to_string()],
+                    cwd: cwd.clone().into(),
+                    compiler: "/nonexistent/compiler".to_string().into(),
+                    env: None,
+                })
+                .await
+                .unwrap();
+
+            // Any non-Error response is acceptable — typically a
+            // CompileResult with a non-zero exit code because the compiler
+            // path is bogus. The key invariant is the absence of the
+            // pre-#166 "unknown session" hard error.
+            if let Some(Response::Error { message }) = client.recv().await.unwrap() {
+                assert!(
+                    !message.contains("unknown session"),
+                    "Compile must not fail with 'unknown session' on an unknown UUID, got: {message}"
+                );
             }
 
             shutdown.notify_one();


### PR DESCRIPTION
## Summary

Two coupled fixes for the soldr/zccache daemon-restart conflict surfaced in #166 and #167.

- **#167 (root cause)** — `crates/zccache-ci/src/main.rs`: drop the unconditional `kill_daemon()` at stop-hook startup. Every stage today is `cargo check` / `clippy` / `cargo test --exclude zccache-daemon`; none rebuild `zccache-daemon.exe`, so killing the daemon was unnecessary and actively broke soldr's session.
- **#166 (defensive)** — `crates/zccache-daemon/src/server.rs`: the Compile handler returned a hard `Response::Error { \"unknown session: <uuid>\" }` for unknown sessions. Mirror PR #137's idempotent SessionEnd fix and let the compile proceed; `record_session_stat` / `touch` / `session_client_pid` already no-op on unknown sessions, so only per-session stats are lost — never the build itself.

## Why both at once

They're the same bug viewed from opposite ends:

1. `kill_daemon()` (in #167) is the trigger.
2. The hard error in `handle_compile` (in #166) is the failure mode that made the trigger fatal.

Fixing only #167 leaves the next caller that legitimately needs to kill the daemon (Windows binary replacement, antivirus quarantine, OS restart) producing the same crash. Fixing only #166 leaves zccache-ci silently nuking soldr's session every stop hook and cold-compiling the world. Together they make stop-hook behaviour both correct and resilient.

## Changes

| File | Change |
|---|---|
| `crates/zccache-ci/src/main.rs` | Drop `kill_daemon()` from startup; keep `reap_orphan_daemons()`. Update surrounding comment. Drop the now-unused `kill_daemon` import. |
| `crates/zccache-ci/src/lib.rs` | Update `kill_daemon` doc comment with a WARNING pointing at #167. Function itself unchanged — still public and tested. |
| `crates/zccache-daemon/src/server.rs` | Replace the 5-line unknown-session check in `handle_compile` with an explanatory comment. Add regression test `cli_compile_unknown_uuid_is_idempotent` mirroring the existing `cli_session_end_unknown_uuid_is_idempotent` pattern. |

Net: **+80 / -14** across 3 files.

## Verification (local, Windows)

- `soldr cargo check --workspace --all-targets` — pass
- `soldr cargo clippy --workspace --all-targets -- -D warnings` — pass
- `soldr cargo fmt --all --check` — clean
- `soldr cargo test -p zccache-daemon --lib` — 148 pass / 0 fail / 10 ignored
- `soldr cargo test -p zccache-daemon --lib -- cli_compile_unknown_uuid_is_idempotent --include-ignored` — pass
- `soldr cargo test -p zccache-ci --lib` — 10 pass / 0 fail

## Test plan
- [ ] CI: workspace check + clippy + fmt clean across Linux / macOS / Windows
- [ ] CI: `zccache-daemon` and `zccache-ci` library tests pass
- [ ] Integration job: the new `cli_compile_unknown_uuid_is_idempotent` test (covered by `cargo test --workspace`) passes when `#[ignore]` tests are executed
- [ ] Manual: stop-hook on Windows no longer logs `unknown session: <uuid>` failures from `rustc -vV` probes

## Related

- Closes #166
- Closes #167
- Mirrors #137 / a6c8876 (SessionEnd idempotency)
- Cross-references zackees/soldr#265 (proposed soldr-side resync hardening — complementary, not blocking)