### PR TITLE
chore(release): bump workspace to 1.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "bincode",
  "blake3",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "libc",
  "md5",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "blake3",
  "clap",
@@ -3485,7 +3485,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "clang",
  "tempfile",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "serde",
  "tempfile",
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "bincode",
  "clap",
@@ -3540,7 +3540,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "blake3",
  "dashmap",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "blake3",
  "bytes",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "clap",
  "serde",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "clap",
  "dashmap",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "bincode",
  "bytes",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "clap",
  "criterion",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3677,7 +3677,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "blake3",
  "criterion",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "bytes",
  "serde",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "bincode",
  "bytes",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["dylints/ban_std_pathbuf"]
 
 [workspace.package]
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Patch bump (`1.4.0` → `1.4.1`). Once merged, push tag `v1.4.1` to trigger `release-auto.yml` for PyPI + crates.io + GitHub release.

## Contents since v1.4.0

- fix(daemon,ci): tolerate unknown sessions and stop killing soldr's daemon — #168 (closes #166, #167)
- feat(cli): expose `session_end_idempotent` for all daemon callers — #163 (closes #159)
- fix(daemon): deterministic flush primitive for event log — #162 (#146)
- feat(cli,daemon): relocate daemon exe to global runtime-binaries dir — #158
- fix(depgraph): normalize workspace-path inputs out of rustc cache key — #160 (#139)
- perf(ci): trim platform Test, drop `--all-targets`, split Test/Check — #161, #164, #165
- chore(ci): drop invalid target-cache-paths from build-target action — #157
- chore(gitignore): ignore Claude Code per-session runtime locks — #156

## Why patch (not minor)

Per request — the user prefers a patch bump here. (Note: #158 and #163 are `feat:` commits, so a minor bump 1.5.0 would also be defensible by strict semver; 1.4.1 is fine if downstream callers aren't relying on the new public API yet.)

## Verification
- `soldr cargo check --workspace` clean (5.9s).
- `Cargo.lock` regenerated; all `zccache-*` crates show `version = "1.4.1"`.

## Test plan
- [ ] CI green on this PR (Linux/macOS Check + Test, Integration, Coverage, MSRV, Formatting)
- [ ] After merge: push tag `v1.4.1`, `release-auto.yml` validates metadata, builds artifacts, publishes PyPI + crates.io, creates GitHub release