### PR TITLE
chore(release): bump workspace to 1.4.2 + idempotent session-end fixes

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -91,6 +91,33 @@ jobs:
           status=${PIPESTATUS[0]}
           dur=$((SECONDS - start))
           echo "- **${{ inputs.os }} / Test**: ${dur}s" >> "$GITHUB_STEP_SUMMARY"
+
+          # Soldr 0.7.14 ships a bundled zccache 1.4.0 whose `client_session_end`
+          # was not yet idempotent against a vanished daemon (fixed upstream in
+          # #170; will arrive in CI once a future soldr release bundles
+          # zccache 1.4.1+). Until then, soldr exits non-zero from its at-exit
+          # session-end on Windows even when every `cargo test` passed:
+          #
+          #   soldr: zccache session-end <uuid> failed:
+          #     cannot connect to daemon at \\.\pipe\zccache-…: I/O error: …
+          #
+          # Treat this single, well-defined teardown error as a non-failure
+          # — but only if cargo itself reported no failed tests.
+          if [ $status -ne 0 ]; then
+            test_failure=0
+            if grep -qE "test result: FAILED|panicked at" test-output.txt; then
+              test_failure=1
+            fi
+            soldr_teardown_only=0
+            if grep -q "soldr: zccache session-end .* failed: cannot connect to daemon" test-output.txt; then
+              soldr_teardown_only=1
+            fi
+            if [ $test_failure -eq 0 ] && [ $soldr_teardown_only -eq 1 ]; then
+              echo "::warning::soldr at-exit session-end failed on a vanished daemon — treating as success (all cargo tests passed). Fix lands when soldr bundles zccache 1.4.1+ (#170)."
+              status=0
+            fi
+          fi
+
           if [ $status -ne 0 ]; then
             {
               echo '## Test Failures'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "bincode",
  "blake3",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "libc",
  "md5",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "blake3",
  "clap",
@@ -3485,7 +3485,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "clang",
  "tempfile",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "serde",
  "tempfile",
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "bincode",
  "clap",
@@ -3540,7 +3540,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "blake3",
  "dashmap",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "blake3",
  "bytes",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "clap",
  "serde",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "clap",
  "dashmap",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "bincode",
  "bytes",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "clap",
  "criterion",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3677,7 +3677,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "reqwest",
  "serde",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "blake3",
  "criterion",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "bytes",
  "serde",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "bincode",
  "bytes",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["dylints/ban_std_pathbuf"]
 
 [workspace.package]
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/crates/zccache-cli/src/lib.rs
+++ b/crates/zccache-cli/src/lib.rs
@@ -772,30 +772,21 @@ pub fn client_session_start(
     })
 }
 
+/// End a session — daemon-unreachable is treated as a successful no-op.
+///
+/// Thin `String`-error wrapper around [`session_end_idempotent`]. All in-process
+/// callers (Python bindings, soldr, future tools) route through here, so the
+/// idempotency contract that #151 / #159 established for the CLI subprocess
+/// path applies equally to library users. Without this, soldr's at-exit
+/// `zccache session-end` from `rust-plan save` fails Windows CI with
+/// "cannot connect to daemon at \\.\pipe\zccache-…" when the daemon already
+/// exited — every workspace test passed but teardown failed.
 pub fn client_session_end(
     endpoint: Option<&str>,
     session_id: &str,
 ) -> Result<Option<zccache_protocol::SessionStats>, String> {
     let endpoint = resolve_endpoint(endpoint);
-    let session_id = session_id.to_string();
-    run_async(async move {
-        let mut conn = connect_client(&endpoint)
-            .await
-            .map_err(|e| format!("cannot connect to daemon at {endpoint}: {e}"))?;
-        conn.send(&zccache_protocol::Request::SessionEnd {
-            session_id: session_id.clone(),
-        })
-        .await
-        .map_err(|e| format!("failed to send to daemon: {e}"))?;
-
-        match conn.recv::<zccache_protocol::Response>().await {
-            Ok(Some(zccache_protocol::Response::SessionEnded { stats })) => Ok(stats),
-            Ok(Some(zccache_protocol::Response::Error { message })) => Err(message),
-            Ok(None) => Err("lost connection to daemon (no response received)".to_string()),
-            Ok(Some(other)) => Err(format!("unexpected response from daemon: {other:?}")),
-            Err(e) => Err(format!("broken connection to daemon: {e}")),
-        }
-    })
+    session_end_idempotent(&endpoint, session_id).map_err(|e| e.to_string())
 }
 
 /// Is this connect-time error a "daemon process is gone entirely" error?
@@ -1272,6 +1263,26 @@ mod tests {
                 zccache_ipc::IpcError::Io(io) => io.kind(),
                 _ => unreachable!(),
             }
+        );
+    }
+
+    /// Regression: `client_session_end` is the in-process library entry point
+    /// used by Python bindings and external tools (soldr's `rust-plan save`).
+    /// It must mirror `session_end_idempotent` — a vanished daemon is a no-op
+    /// success, not a hard error. Before this fix, soldr called
+    /// `client_session_end`, got `Err("cannot connect to daemon at …")`,
+    /// surfaced it as "soldr: zccache session-end … failed: …", and Windows
+    /// Test failed teardown even after every workspace test passed.
+    #[test]
+    fn client_session_end_swallows_vanished_daemon() {
+        let endpoint = zccache_ipc::unique_test_endpoint();
+        let session_id = "00000000-0000-0000-0000-000000000000";
+
+        let result = client_session_end(Some(&endpoint), session_id);
+
+        assert!(
+            matches!(result, Ok(None)),
+            "vanished daemon must produce Ok(None) (success no-op), got {result:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Bump workspace version to 1.4.2 to ship the unreleased session-end fixes
- `fix(cli)`: `client_session_end` is now idempotent on a vanished daemon (a245e18)
- `ci(check)`: tolerate soldr's at-exit session-end teardown when the daemon already exited (be16278)

## Release
After merge, push tag `v1.4.2` (or `1.4.2`) to trigger `.github/workflows/release.yml`, which publishes PyPI + crates.io and creates the GitHub release.

## Test plan
- [ ] CI green on all platforms
- [ ] Workspace version matches tag at release time

🤖 Generated with [Claude Code](https://claude.com/claude-code)