### PR TITLE
perf(ci): dogfood ./ action for Check/Test to hit 2-min target (#106)

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,65 +17,41 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          version: "0.7.16"
           toolchain: 1.94.1
-          cache: true
+      - name: Setup zccache
+        uses: ./
+        with:
+          shared-key: check-${{ inputs.os }}
+          cache-target: "true"
       - name: Check
         shell: bash
         run: |
           start=$SECONDS
-          soldr cargo check --workspace
+          cargo check --workspace
           status=$?
           dur=$((SECONDS - start))
           echo "- **${{ inputs.os }} / Check**: ${dur}s" >> "$GITHUB_STEP_SUMMARY"
           exit $status
-      - name: Stop zccache before cache save
-        if: always()
-        shell: bash
-        run: |
-          python - <<'PY'
-          import json
-          import os
-          import subprocess
-
-          status = subprocess.run(
-              ["soldr", "status", "--json"],
-              capture_output=True,
-              text=True,
-              check=False,
-          )
-          if status.returncode != 0:
-              raise SystemExit(0)
-
-          try:
-              payload = json.loads(status.stdout)
-          except json.JSONDecodeError:
-              raise SystemExit(0)
-
-          zccache = payload.get("zccache") or {}
-          binary = zccache.get("binary_path")
-          cache_dir = zccache.get("cache_dir") or zccache.get("state_dir")
-          if not binary:
-              raise SystemExit(0)
-
-          env = os.environ.copy()
-          if cache_dir:
-              env["ZCCACHE_CACHE_DIR"] = cache_dir
-          subprocess.run([binary, "stop"], env=env, check=False)
-          PY
+      - if: always()
+        uses: ./action/cleanup
 
   test:
     name: Test
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          version: "0.7.16"
           toolchain: 1.94.1
-          cache: true
+      - name: Setup zccache
+        uses: ./
+        with:
+          shared-key: test-${{ inputs.os }}
+          cache-target: "true"
       # Platform Test runs unit tests in libraries and binaries only — it
       # intentionally does NOT compile the integration test binaries under
       # `crates/*/tests/`. Most of those binaries' tests are #[ignore]'d, but
@@ -87,78 +63,19 @@ jobs:
         run: |
           set +e
           start=$SECONDS
-          soldr cargo test --workspace --lib --bins --no-fail-fast 2>&1 | tee test-output.txt
+          cargo test --workspace --lib --bins --no-fail-fast 2>&1 | tee test-output.txt
           status=${PIPESTATUS[0]}
           dur=$((SECONDS - start))
           echo "- **${{ inputs.os }} / Test**: ${dur}s" >> "$GITHUB_STEP_SUMMARY"
-
-          # Soldr 0.7.14 ships a bundled zccache 1.4.0 whose `client_session_end`
-          # was not yet idempotent against a vanished daemon (fixed upstream in
-          # #170; will arrive in CI once a future soldr release bundles
-          # zccache 1.4.1+). Until then, soldr exits non-zero from its at-exit
-          # session-end on Windows even when every `cargo test` passed:
-          #
-          #   soldr: zccache session-end <uuid> failed:
-          #     cannot connect to daemon at \\.\pipe\zccache-…: I/O error: …
-          #
-          # Treat this single, well-defined teardown error as a non-failure
-          # — but only if cargo itself reported no failed tests.
-          if [ $status -ne 0 ]; then
-            test_failure=0
-            if grep -qE "test result: FAILED|panicked at" test-output.txt; then
-              test_failure=1
-            fi
-            soldr_teardown_only=0
-            if grep -q "soldr: zccache session-end .* failed: cannot connect to daemon" test-output.txt; then
-              soldr_teardown_only=1
-            fi
-            if [ $test_failure -eq 0 ] && [ $soldr_teardown_only -eq 1 ]; then
-              echo "::warning::soldr at-exit session-end failed on a vanished daemon — treating as success (all cargo tests passed). Fix lands when soldr bundles zccache 1.4.1+ (#170)."
-              status=0
-            fi
-          fi
 
           if [ $status -ne 0 ]; then
             {
               echo '## Test Failures'
               echo '```'
-              # Extract the "failures:" summary blocks (test names + assertion details)
               awk '/^failures:$/,/^test result:/' test-output.txt
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
           fi
           exit $status
-      - name: Stop zccache before cache save
-        if: always()
-        shell: bash
-        run: |
-          python - <<'PY'
-          import json
-          import os
-          import subprocess
-
-          status = subprocess.run(
-              ["soldr", "status", "--json"],
-              capture_output=True,
-              text=True,
-              check=False,
-          )
-          if status.returncode != 0:
-              raise SystemExit(0)
-
-          try:
-              payload = json.loads(status.stdout)
-          except json.JSONDecodeError:
-              raise SystemExit(0)
-
-          zccache = payload.get("zccache") or {}
-          binary = zccache.get("binary_path")
-          cache_dir = zccache.get("cache_dir") or zccache.get("state_dir")
-          if not binary:
-              raise SystemExit(0)
-
-          env = os.environ.copy()
-          if cache_dir:
-              env["ZCCACHE_CACHE_DIR"] = cache_dir
-          subprocess.run([binary, "stop"], env=env, check=False)
-          PY
+      - if: always()
+        uses: ./action/cleanup

--- a/crates/zccache-ci/src/main.rs
+++ b/crates/zccache-ci/src/main.rs
@@ -228,7 +228,14 @@ fn main() -> ExitCode {
             let mut xcheck_cmd = build_cmd(
                 &root,
                 "soldr",
-                &["cargo", "check", "--target", target, "--workspace", "--all-targets"],
+                &[
+                    "cargo",
+                    "check",
+                    "--target",
+                    target,
+                    "--workspace",
+                    "--all-targets",
+                ],
             );
             let xcheck_outcome = runner.run("cross-check-linux", &mut xcheck_cmd);
             if let Some(code) = handle_outcome("cross-check-linux", xcheck_outcome) {


### PR DESCRIPTION
## Summary

- Rewires `ci-check.yml` to use this repo's own `./` action (with `cache-target: true`) instead of `zackees/setup-soldr@v0`. The `./` action sets `RUSTC_WRAPPER=zccache`, restores a `target/` snapshot, runs `zccache warm` to fill `.rlib`/`.rmeta` from the artifact cache, and touches every restored target file to a single future timestamp so cargo's fingerprint sees nothing dirty.
- On warm runs `cargo check --workspace` should collapse from ~135s on Windows to seconds. This is the path the `bench-action.yml` "no-op rebuild" measurement shows running in ms.
- Closes the way toward issue #106's 2-minute acceptance criterion. Bonus: every PR now dogfoods the action that downstream users rely on.

## Baseline (top of `main`, commit a659804)

| Job | Total | `cargo` step |
|---|---|---|
| macOS Check | 1:45 ✅ | 58s |
| Linux Check | 2:00 ⚠️ | 69s |
| Windows Check | 3:15 ❌ | **135s** |

## Why the PR #102 'hot' regression doesn't apply

PR #102 tried `setup-soldr@v0`'s `target-cache-mode: hot` — a different implementation that has no `zccache warm` and no mtime normalization, and regressed to Linux 4:16 / macOS 5:25 / Windows 8:37. This PR uses **this repo's `./` action**, whose `target-snapshot-mode: hot` is exercised cross-platform every PR via `test-action.yml` (Linux x64/arm, macOS 14/15, Windows 2025 x64/arm).

## Side wins

- Drops the 30-line `python - <<'PY'` "Stop zccache before cache save" block on each job in favor of `./action/cleanup`.
- Drops the soldr at-exit `session-end` teardown carve-out introduced in a659804 — no soldr in CI means no soldr-bundled-zccache teardown errors.
- Splits Check / Test cache namespaces (`shared-key: check-${{ inputs.os }}` vs `test-${{ inputs.os }}`) so a slow-warming Test cache can't poison Check.

## Test plan

- [ ] First-run (cold) numbers recorded — expected similar to today.
- [ ] Empty-commit pushed; second-run (warm) numbers recorded.
- [ ] All three `Check` jobs <= 2:00 warm. (decisive measurement)
- [ ] Verify `RUSTC_WRAPPER=zccache` appears in the runner setup logs.
- [ ] If Windows regresses, revert and document.

Closes (partial) #106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)