### PR TITLE
chore(release): bump workspace to 1.4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ Thumbs.db
 # but per-session locks/state files are not)
 .claude/scheduled_tasks.lock
 .claude/scheduled_tasks/
+.claude/worktrees/
 
 # Project-local toolchain caches (managed by soldr)
 .cargo/
@@ -28,6 +29,10 @@ Thumbs.db
 
 # zccache cache directory
 .zccache/
+
+# Local bench scratch (Stop-hook cold-cache benchmark output + helper script)
+tasks/bench-output/
+tasks/bench-stop-hook.sh
 
 # Cargo lock is checked in for binaries
 # (workspace contains binary crates)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "bincode",
  "blake3",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "libc",
  "md5",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "blake3",
  "clap",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "clang",
  "tempfile",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "serde",
  "tempfile",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "bincode",
  "clap",
@@ -3541,7 +3541,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "blake3",
  "dashmap",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "blake3",
  "bytes",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "clap",
  "serde",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "clap",
  "dashmap",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "bincode",
  "bytes",
@@ -3642,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "clap",
  "criterion",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "reqwest",
  "serde",
@@ -3691,7 +3691,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "blake3",
  "criterion",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "bytes",
  "serde",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "bincode",
  "bytes",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["dylints/ban_std_pathbuf"]
 
 [workspace.package]
-version = "1.4.2"
+version = "1.4.3"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Workspace patch bump 1.4.2 → 1.4.3. Auto-Release will fire on merge (detect-bump trigger from a659804).

## What's in this release

- **perf(rust-plan): parallel file copy/hash loop** ([#178](https://github.com/zackees/zccache/pull/178), closes [#177](https://github.com/zackees/zccache/issues/177))
  - `save_rust_plan_local` now uses rayon to spread per-file work across N reader threads
  - Honors `SOLDR_TARGET_CACHE_TAR_THREADS` (forwarded by soldr#273) with `ZCCACHE_RUST_PLAN_TAR_THREADS` as a higher-priority alias
  - Default vCPU-bounded, capped at 8 (diminishing returns past that on Windows per soldr#272)
  - `1` is a clean sequential escape hatch
  - Deterministic: manifest entries preserve `select_artifacts`'s sort by `relative_path`
  - Expected to cut Windows CI's `rust-plan save` step substantially once a soldr release bundles this

- **perf(ci): dogfood `./` action for Check/Test** ([#173](https://github.com/zackees/zccache/pull/173), partial [#106](https://github.com/zackees/zccache/issues/106))
  - PR-time CI now uses this repo's own zccache GHA action instead of `zackees/setup-soldr@v0`
  - Linux Check 1:36 warm (−24s), macOS Test 2:37 warm (−1:39), Linux Test 2:38 warm (−35s)
  - Windows still over-budget — remaining bottleneck is fast-compression (tracked in [setup-soldr#70](https://github.com/zackees/setup-soldr/issues/70))

## Housekeeping

`.gitignore` now silences three local-dev paths so `git status` stays clean across sessions:
- `.claude/worktrees/` — Claude Code runtime worktree dir
- `tasks/bench-output/` — output of the local Stop-hook cold-cache bench
- `tasks/bench-stop-hook.sh` — the bench script itself

## Test plan

- [ ] CI green on all platforms
- [ ] After merge, verify Auto-Release workflow publishes PyPI 1.4.3, crates.io 1.4.3, GitHub release v1.4.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)