### PR TITLE
chore(ci): silence stale-jobserver warnings in build-target action

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -98,10 +98,25 @@ runs:
         TARGET_UPPER=$(echo "${{ inputs.target }}" | tr '[:lower:]-' '[:upper:]_')
         echo "CARGO_TARGET_${TARGET_UPPER}_LINKER=${{ inputs.linker }}" >> "$GITHUB_ENV"
 
+    # `setup-soldr@v0` runs an inner cargo (via pip/maturin or cargo-binstall)
+    # during its install step. That cargo opens a jobserver at fds 8,9 and
+    # exports `CARGO_MAKEFLAGS=-j --jobserver-fds=8,9 --jobserver-auth=8,9`
+    # into the runner environment. By the time these release `soldr cargo build`
+    # steps run, those fds are closed, so cargo emits one
+    #   warning: failed to connect to jobserver from environment variable
+    #            `CARGO_MAKEFLAGS=…`: Bad file descriptor (os error 9)
+    # per invocation, which Cargo then deduplicates as
+    #   warning: <crate> generated 1 warning (1 duplicate)
+    # across every rustc compile in the dep graph — turning a single harmless
+    # warning into thousands of log lines. Cargo falls back to its own
+    # jobserver, so the build is correct; we just clear the inherited vars to
+    # cut the noise.
     - name: Build release binaries
       shell: bash
       env:
         PYO3_PYTHON: python
+        CARGO_MAKEFLAGS: ""
+        MAKEFLAGS: ""
       run: |
         soldr cargo build --release --target ${{ inputs.target }} -p zccache-cli
         soldr cargo build --release --target ${{ inputs.target }} -p zccache-daemon
@@ -112,6 +127,8 @@ runs:
       shell: bash
       env:
         PYO3_PYTHON: python
+        CARGO_MAKEFLAGS: ""
+        MAKEFLAGS: ""
       run: |
         HOST_TARGET=$(soldr --no-cache rustc -vV | awk '/^host: / { print $2 }')
         if [ "$HOST_TARGET" != "${{ inputs.target }}" ]; then


### PR DESCRIPTION
## Summary

Clears `CARGO_MAKEFLAGS` and `MAKEFLAGS` before each `soldr cargo build` in `.github/actions/build-target/action.yml` to cut thousands of log lines from every Auto-Release Linux/musl build.

## Root cause

`setup-soldr@v0` runs an inner cargo during its install step (via pip+maturin or cargo-binstall). That cargo opens a jobserver at fds 8,9 and exports

```
CARGO_MAKEFLAGS="-j --jobserver-fds=8,9 --jobserver-auth=8,9"
```

into the runner environment. By the time the release `soldr cargo build` steps run, those fds are closed, so cargo emits one

```
warning: failed to connect to jobserver from environment variable
         `CARGO_MAKEFLAGS=…`: Bad file descriptor (os error 9)
note: the build environment is likely misconfigured
```

per invocation. Cargo then deduplicates that single warning as `warning: <crate> generated 1 warning (1 duplicate)` across **every** rustc compile in the dep graph — turning one harmless message into a wall of noise that drowns out actual errors.

Cargo falls back to its own jobserver, so builds are correct. This is purely log hygiene.

## Verification

Pre-existing. Counted `failed to connect to jobserver` occurrences across recent Auto-Release runs (Build (x86_64-unknown-linux-musl) job log):

| Release | Run | Jobserver warnings |
|---|---|---|
| v1.4.2 | 25700528552 | 3 |
| v1.4.3 (in flight) | 25765121262 | 3+ |

3 matches the number of sequential `soldr cargo build` invocations in the step. Each opens a fresh cargo that sees the stale env var.

## Test plan

- [ ] Next Auto-Release run shows 0 jobserver warnings in the Build (x86_64-unknown-linux-musl) job log
- [ ] Other build targets unchanged (this only quiets the noise; build success criteria are the same)

🤖 Generated with [Claude Code](https://claude.com/claude-code)