### PR TITLE
feat(cli): honor SOLDR_SKIP_CARGO_REGISTRY_SAVE — no-op cargo-registry save when set (closes #184)

### DIFF
--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -1785,7 +1785,33 @@ fn cargo_registry_cache_dir() -> Result<NormalizedPath, String> {
         .join("cargo-registry"))
 }
 
+/// Matches setup-soldr's boolean env-var normalization: `1`, `true`, `yes`,
+/// `on` (case-insensitive) are truthy; anything else (including `None`,
+/// empty, `0`, `false`, `no`, `off`) is falsy. See zccache#184.
+fn flag_truthy(value: Option<&str>) -> bool {
+    let Some(raw) = value else { return false };
+    let trimmed = raw.trim();
+    matches!(trimmed, "1")
+        || trimmed.eq_ignore_ascii_case("true")
+        || trimmed.eq_ignore_ascii_case("yes")
+        || trimmed.eq_ignore_ascii_case("on")
+}
+
+fn env_flag_truthy(name: &str) -> bool {
+    flag_truthy(std::env::var(name).ok().as_deref())
+}
+
 fn cmd_cargo_registry_save(key: &str, cargo_home: Option<&str>) -> ExitCode {
+    // setup-soldr#70's payload C migration: when setup-soldr owns
+    // `~/.cargo/registry` caching with fast-zstd, double-saving here just
+    // burns CPU on the same bytes. Caller signals takeover via env var.
+    if env_flag_truthy("SOLDR_SKIP_CARGO_REGISTRY_SAVE") {
+        println!(
+            "cargo-registry save: skipping (SOLDR_SKIP_CARGO_REGISTRY_SAVE=1) \
+             — caller owns the cache layer"
+        );
+        return ExitCode::SUCCESS;
+    }
     let cargo_home = match resolve_cargo_home(cargo_home) {
         Ok(p) => p,
         Err(e) => {
@@ -4615,5 +4641,26 @@ mod tests {
             elapsed < std::time::Duration::from_secs(5),
             "wait took {elapsed:?}, exceeding reasonable slack on 1s timeout"
         );
+    }
+
+    /// Exercises both branches of the setup-soldr-compatible bool grammar.
+    /// Tests the pure function so we don't have to mutate process env vars
+    /// — that's a documented foot-gun in cargo's parallel test runner.
+    #[test]
+    fn flag_truthy_matches_setup_soldr_normalization() {
+        // Truthy variants
+        for v in ["1", "true", "True", "TRUE", "yes", "YES", "on", "On"] {
+            assert!(flag_truthy(Some(v)), "expected truthy: {v:?}");
+        }
+        // Whitespace tolerated
+        assert!(flag_truthy(Some("  true  ")));
+
+        // Falsy / "leave behavior unchanged" variants
+        assert!(!flag_truthy(None));
+        for v in [
+            "", "0", "false", "False", "no", "off", "OFF", "garbage", "2",
+        ] {
+            assert!(!flag_truthy(Some(v)), "expected falsy: {v:?}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes [#184](https://github.com/zackees/zccache/issues/184). Adds a coordination env var so [setup-soldr#70](https://github.com/zackees/setup-soldr/issues/70) can take ownership of \`~/.cargo/registry\` caching with fast zstd without double-saving against zccache's gzip-fast path.

When \`SOLDR_SKIP_CARGO_REGISTRY_SAVE\` is truthy in the process env, \`zccache cargo-registry save\`:
- exits 0 immediately
- prints \`cargo-registry save: skipping (SOLDR_SKIP_CARGO_REGISTRY_SAVE=1) — caller owns the cache layer\`

Unset / empty / \`0\` / \`false\` / \`no\` / \`off\` keeps the current behavior. \`cargo-registry restore\` is unaffected — setup-soldr's restore-side auto-detect handles both \`.tar.zst\` (new) and \`.tar.gz\` (legacy) so older cache entries still work during migration.

## Grammar

Matches setup-soldr's existing bool normalization. Case-insensitive truthy: \`1\`, \`true\`, \`yes\`, \`on\`. Leading/trailing whitespace tolerated.

## Implementation

Split into a testable pure function plus a thin env-reading wrapper:

\`\`\`rust
fn flag_truthy(value: Option<&str>) -> bool { ... }
fn env_flag_truthy(name: &str) -> bool {
    flag_truthy(std::env::var(name).ok().as_deref())
}
\`\`\`

Splitting avoids the parallel-test env-var foot-gun (same pattern as \`parse_rust_plan_tar_threads\` from #178). One unit test exercises the full grammar — both branches.

## Tests

\`soldr cargo test -p zccache-cli --bin zccache --lib\` → **28 pass**, 0 fail, 1 ignored. New: \`flag_truthy_matches_setup_soldr_normalization\`.

## Test plan

- [ ] CI green
- [ ] Once a zccache release shipping this flag is out, the companion setup-soldr follow-up (\"flip cargo-registry-cache default to true once zccache supports skip flag\") can land

🤖 Generated with [Claude Code](https://claude.com/claude-code)