### PR TITLE
chore(release): bump workspace to 1.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "bincode",
  "blake3",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "libc",
  "md5",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "blake3",
  "clap",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "clang",
  "tempfile",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "serde",
  "tempfile",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "bincode",
  "clap",
@@ -3541,7 +3541,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "blake3",
  "dashmap",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "blake3",
  "bytes",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "clap",
  "serde",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "clap",
  "dashmap",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "bincode",
  "bytes",
@@ -3642,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "clap",
  "criterion",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "reqwest",
  "serde",
@@ -3691,7 +3691,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "blake3",
  "criterion",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "bytes",
  "serde",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "bincode",
  "bytes",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["dylints/ban_std_pathbuf"]
 
 [workspace.package]
-version = "1.4.3"
+version = "1.4.4"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Workspace patch bump 1.4.3 → 1.4.4. Auto-Release fires on merge.

## What's in this release

- **fix(cli,ci): \`zccache stop\` waits for redb index lock release** ([#183](https://github.com/zackees/zccache/pull/183), closes [#182](https://github.com/zackees/zccache/issues/182))
  - \`cmd_stop\` now bounded-polls (10s default, \`ZCCACHE_STOP_TIMEOUT_SECS\` override) until the IPC endpoint is unreachable AND \`index.redb\` can be opened by another process
  - \`build-target/action.yml\` gains a tail \`Shutdown zccache daemon before cache save\` step so setup-soldr's post-job tar no longer races the daemon on Windows
  - Eliminates the \`Device or resource busy\` failure on \`index.redb\` in Auto-Release Windows builds

- **feat(cli): \`SOLDR_SKIP_CARGO_REGISTRY_SAVE\` coordination flag** ([#185](https://github.com/zackees/zccache/pull/185), closes [#184](https://github.com/zackees/zccache/issues/184))
  - When truthy (1/true/yes/on, case-insensitive), \`zccache cargo-registry save\` returns 0 immediately
  - Lets [setup-soldr#70](https://github.com/zackees/setup-soldr/issues/70) take ownership of \`~/.cargo/registry\` caching with fast zstd without doubling up the compression pass

## Test plan

- [ ] CI green on all platforms
- [ ] After merge, verify Auto-Release publishes PyPI 1.4.4, crates.io 1.4.4, GitHub release v1.4.4
- [ ] First Windows Auto-Release build after this lands: no \`Read error … Device or resource busy\` on the post-job tar

🤖 Generated with [Claude Code](https://claude.com/claude-code)