### PR TITLE
perf(profile): dev profile uses debug=line-tables-only — keep stack traces, drop DWARF dead weight

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,3 +106,16 @@ libraries = [{ path = "dylints/*" }]
 # pedantic = { level = "warn", priority = -1 }
 # nursery = { level = "warn", priority = -1 }
 # unwrap_used = "warn"
+
+# Keep just enough debug info for readable stack traces (function names +
+# source-line numbers) while dropping the DWARF variable/type tables that
+# dominate `target/` size. Trade-off: in-process debuggers like rust-gdb lose
+# variable inspection. Override locally with `CARGO_PROFILE_DEV_DEBUG=full
+# cargo …` when you need full debug info for a single build.
+#
+# `profile.test` inherits from `profile.dev`, so CI test compiles pick this up
+# too. Why this matters here: `target/` ships through setup-soldr's post-job
+# cache tar on every Windows runner, and DWARF bytes are pure dead weight in
+# that pipeline.
+[profile.dev]
+debug = "line-tables-only"


### PR DESCRIPTION
## Summary

Switch \`[profile.dev]\` from the cargo default (\`debug = \"full\"\`) to \`debug = \"line-tables-only\"\`. Keeps the minimum required for readable stack traces — function symbols + source-line tables — and drops the DWARF type/variable tables that dominate \`target/\` size.

## Why

Default debug info is dead weight for our workflow:

- Tests in CI don't run under \`rust-gdb\`. They print on failure.
- Local devs almost always debug via \`println!\`, \`tracing\`, or \`dbg!\`.
- DWARF type/variable tables can be 30–50% of \`target/\` bytes.

That weight hits us **three ways** on every Windows CI run:

1. setup-soldr's post-job tar of \`\$SOLDR_CACHE_DIR/cache/zccache/\` pays per byte (issue #182 territory)
2. setup-soldr's target-cache restore on warm runs reads those bytes back
3. local rustc spends time emitting the metadata to disk

Switching to line-tables-only directly attacks all three.

## What's preserved

- **Panic backtraces with file:line still work** — that's exactly what line tables encode.
- \`debug_assertions\` is unchanged (still on in dev) — overflow checks, integer panics, etc.
- \`profile.release\` is untouched — shipped binaries are identical.

## What's lost

- \`rust-gdb\`/\`lldb\` variable inspection becomes much coarser (no struct field walking, no local-variable names).
- For the rare debugger session, override per-invocation: \`CARGO_PROFILE_DEV_DEBUG=full cargo build\`.

## Cargo profile inheritance

\`profile.test\` inherits from \`profile.dev\`, so CI test compiles get this automatically. No workflow changes required.

## Verification

- \`soldr cargo check --workspace --all-targets\` — clean (cold rebuild as expected; profile change invalidates cache keys)
- \`soldr cargo test -p zccache-hash --lib\` — 18/18 pass
- \`soldr cargo fmt --all -- --check\` — clean

## Test plan

- [ ] CI green
- [ ] On next warm-cache run, observe target/ size reduction in any cache-save logs (setup-soldr's per-job summary surfaces footprint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)