### PR TITLE
chore(deps): bump soldr from 0.7.16 to 0.7.18

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -59,7 +59,7 @@ runs:
     - name: Setup Soldr
       uses: zackees/setup-soldr@v0
       with:
-        version: "0.7.16"
+        version: "0.7.18"
         toolchain: 1.94.1
         cache: true
         cache-key-suffix: ${{ inputs.cache_key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: zackees/setup-soldr@v0
         with:
-          version: "0.7.16"
+          version: "0.7.18"
           toolchain: 1.94.1
           cache: true
           build-cache: false
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: zackees/setup-soldr@v0
         with:
-          version: "0.7.16"
+          version: "0.7.18"
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: dylint
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: zackees/setup-soldr@v0
         with:
-          version: "0.7.16"
+          version: "0.7.18"
           cache: true
           toolchain: 1.94.1
           cache-key-suffix: msrv
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: zackees/setup-soldr@v0
         with:
-          version: "0.7.16"
+          version: "0.7.18"
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: docs

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: zackees/setup-soldr@v0
         with:
-          version: "0.7.16"
+          version: "0.7.18"
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: clippy

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: zackees/setup-soldr@v0
         with:
-          version: "0.7.16"
+          version: "0.7.18"
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: coverage

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: zackees/setup-soldr@v0
         with:
-          version: "0.7.16"
+          version: "0.7.18"
           toolchain: 1.94.1
           cache: true
       - name: Test (full workspace)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 dependencies = []
 
 [dependency-groups]
-dev = ["soldr>=0.7.16"]
+dev = ["soldr>=0.7.18"]
 
 [project.scripts]
 run_zccache = "ci.soldr:run_zccache"


### PR DESCRIPTION
## Summary

Bumps the soldr CLI pin in 7 workflow files + the dev dep in \`pyproject.toml\` from \`0.7.16\` to \`0.7.18\`. Picks up the cross-repo perf and correctness work that's been gating Windows CI throughput.

\`setup-soldr@v0\` floating major tag is already on v0.5.0; no action ref change required. \`ci-check.yml\` doesn't pin soldr — PR #173 moved it to the dogfooded \`./\` action.

## What lands

From [soldr v0.7.17](https://github.com/zackees/soldr/releases/tag/v0.7.17):

- **[zackees/soldr#274](https://github.com/zackees/soldr/pull/274)** — install \`zstd.exe\` on \`windows-arm64\` before \`actions/cache\` runs. Closes the codec half of [zackees/setup-soldr#70](https://github.com/zackees/setup-soldr/issues/70). \`actions/cache@v4\` now picks zstd over gzip on the slowest runner family.
- **[zackees/soldr#273](https://github.com/zackees/soldr/pull/273)** — front-door validation for \`SOLDR_TARGET_CACHE_TAR_THREADS\` (\`auto\` / \`1\` / positive integer). Pairs with the env-var grammar this repo's rust-plan walk already honors ([#178](https://github.com/zackees/zccache/pull/178)).
- **[zackees/soldr#275](https://github.com/zackees/soldr/pull/275)** — parallel thin-slice bundle walk via rayon. soldr-side companion to [#177](https://github.com/zackees/zccache/issues/177)/[#178](https://github.com/zackees/zccache/pull/178).
- chore: bump managed zccache 1.4.2 → 1.4.3 (zackees/soldr#276).

From [soldr v0.7.18](https://github.com/zackees/soldr/releases/tag/v0.7.18):

- **chore: bump managed zccache 1.4.3 → 1.4.4** (zackees/soldr#279). Brings the bundled binary current with this repo's release line — rust-plan parallel walk, \`zccache stop\` redb-release poll ([#183](https://github.com/zackees/zccache/pull/183)), and \`SOLDR_SKIP_CARGO_REGISTRY_SAVE\` flag ([#185](https://github.com/zackees/zccache/pull/185)).
- test(cli): isolate fake-toolchain tests from inherited cache-mode env (zackees/soldr#278).

## Upstream issues this completes

Both filed during the recent Windows-CI perf cluster, both closed by the time of this release:

- zackees/setup-soldr#70 — fast-zstd target-cache codec
- zackees/setup-soldr#71 — CARGO_MAKEFLAGS leak into \`\$GITHUB_ENV\`

## Test plan

- [ ] CI green
- [ ] Verify Auto-Release Windows builds emit zero \`failed to connect to jobserver\` warnings (setup-soldr#71 fix)
- [ ] Verify Auto-Release Windows builds no longer fail on \`index.redb\` EBUSY in the post-job tar — now using bundled zccache 1.4.4 with redb-release poll
- [ ] Compare warm-cache cache-save step time vs current baseline on \`windows-arm64\` Build job (zstd codec is the expected win)

🤖 Generated with [Claude Code](https://claude.com/claude-code)