### PR TITLE
perf(ci): enable target-restore-fallback for Check + Test jobs (closes #190)

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           shared-key: check-${{ inputs.os }}
           cache-target: "true"
+          # Opt into restore-key fallback so commits whose deps are unchanged
+          # reuse the previous run's target snapshot instead of cold-building.
+          # action.yml's primary key includes ${{ github.sha }}, so without
+          # this every commit cold-builds. See #190.
+          target-restore-fallback: "true"
       - name: Check
         shell: bash
         run: |
@@ -52,6 +57,7 @@ jobs:
         with:
           shared-key: test-${{ inputs.os }}
           cache-target: "true"
+          target-restore-fallback: "true"
       # Platform Test runs unit tests in libraries and binaries only — it
       # intentionally does NOT compile the integration test binaries under
       # `crates/*/tests/`. Most of those binaries' tests are #[ignore]'d, but


### PR DESCRIPTION
## Summary

Closes [#190](https://github.com/zackees/zccache/issues/190). One workflow-level toggle that lets warm Windows runs reuse the previous commit's \`target/\` snapshot instead of cold-building every commit.

## Root cause

\`action.yml\` builds the cargo-target cache key with \`\${{ github.sha }}\` baked into the primary key (line 154):

\`\`\`
target-key=\${TGT_PREFIX}-\${LOCK_HASH}-\${{ github.sha }}
\`\`\`

And \`target-restore-fallback\` defaults to \`"false"\` (line 71). When fallback is off the action emits an empty \`target-restore\` list, so the only allowed restore is an exact-key match — which can't happen on a fresh commit because the SHA just changed.

Result on Windows: every commit cold-builds the workspace, costing ~2m30s per Check job.

## Fix

Pass \`target-restore-fallback: "true"\` to the two \`./\` invocations in \`.github/workflows/ci-check.yml\` (Check job + Test job). Action.yml is untouched — external \`./\` consumers keep the cautious default; only zccache's own CI flips it on.

## Why opt-in at the workflow level, not flip the action default

\`action.yml:66–69\` warns:

> fallback snapshots can be stale for changed source trees, especially on pull_request merge refs

That caution is real for external consumers who may have weirder source-tree shapes (e.g. PRs that move large directories). zccache's own workflow doesn't hit those patterns — Check / Test are simple \`cargo check/test --workspace --lib --bins\` invocations, and cargo's own fingerprint checks force rebuilds for any genuinely-stale crate. Worst case from a stale fallback is a wasted rebuild that we'd have done cold anyway.

## Expected impact

~1–2 minutes saved on warm Windows Check + Test. First run after merge will still cold-build (priming the new fallback keys), second run is the decisive measurement.

## Trip-wire

If the warm-run cargo step time spikes (stale snapshot inducing more wasted rebuilds than the cold-build it replaces), back this PR out and escalate to #190's Option B (drop SHA from primary key entirely).

## Related

- Tracking: [#191](https://github.com/zackees/zccache/issues/191)
- Companion: [#189](https://github.com/zackees/zccache/issues/189) / [#192](https://github.com/zackees/zccache/pull/192) (previous PR — cleanup snapshot walks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)