### PR TITLE
perf(cli,cleanup): native parallel target/ walk via zccache snapshot-bytes (#189 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3460,6 +3460,7 @@ dependencies = [
  "blake3",
  "clap",
  "flate2",
+ "jwalk",
  "mimalloc",
  "pyo3",
  "pyo3-build-config",

--- a/action/cleanup/prepare-target-snapshot.sh
+++ b/action/cleanup/prepare-target-snapshot.sh
@@ -80,10 +80,15 @@ format_bytes() {
 }
 
 # Sum every regular file under `target/`, excluding `incremental/` (and
-# optionally `*/build/*/out`). One Python process spawn — replaces the
-# previous `find | while wc -c` loop that paid 30–50ms of Git-Bash
-# process-spawn cost per file on Windows, dominating cleanup runtime
-# (~80–90s on a typical workspace target/). See zccache#189.
+# optionally `*/build/*/out`). Prefers the native `zccache snapshot-bytes`
+# subcommand (jwalk + rayon parallel walk) when the binary is on PATH —
+# that's the fast path in CI where the action has already installed
+# zccache. Falls back to a single-process Python `os.walk` for test
+# environments and local dev where zccache isn't installed yet.
+#
+# Why native: on Windows, per-file `CreateFile` + Defender callback
+# latency dominates the walk. Single-threaded `os.walk` serializes them;
+# jwalk overlaps via rayon across all cores. See zccache#189.
 #
 # Only used in full mode; hot mode already gets its candidate bytes from
 # `select-hot-target.py`'s JSON output.
@@ -93,6 +98,21 @@ snapshot_candidate_bytes() {
   if is_true "${TARGET_PRUNE_BUILD_SCRIPT_OUT:-false}"; then
     prune_build_out=1
   fi
+
+  if command -v zccache >/dev/null 2>&1; then
+    local args=(snapshot-bytes --target "$target" --prune-incremental)
+    if [ "$prune_build_out" = "1" ]; then
+      args+=(--prune-build-script-out)
+    fi
+    local total
+    if total="$(zccache "${args[@]}" 2>/dev/null)" && [ -n "$total" ]; then
+      printf '%s\n' "$total"
+      return 0
+    fi
+    # Native path errored — fall through to Python so callers still get a
+    # valid byte count and the cleanup step doesn't fail.
+  fi
+
   python - "$target" "$prune_build_out" <<'PY'
 import os
 import sys
@@ -102,7 +122,7 @@ prune_build_out = sys.argv[2] == "1"
 total = 0
 seen_inodes = set()
 for root, dirs, files in os.walk(target):
-    # Mirror the bash `find -prune` semantics: skip `incremental` and
+    # Mirror the native walker's prune semantics: skip `incremental` and
     # optionally any `out` directory that sits under a `build/<pkg>/` path.
     pruned = []
     for d in dirs:
@@ -111,7 +131,6 @@ for root, dirs, files in os.walk(target):
             continue
         if prune_build_out and d == "out":
             # `*/build/*/out` — match only if parent's parent is `build`.
-            parent = os.path.basename(root)
             grandparent = os.path.basename(os.path.dirname(root))
             if grandparent == "build":
                 pruned.append(d)

--- a/crates/zccache-cli/Cargo.toml
+++ b/crates/zccache-cli/Cargo.toml
@@ -34,6 +34,7 @@ zccache-download-client = { workspace = true }
 zccache-gha = { workspace = true }
 serde_json = { workspace = true }
 rayon = { workspace = true }
+jwalk = { workspace = true }
 tar = { workspace = true }
 flate2 = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -23,7 +23,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 static GLOBAL_WIN: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use clap::{Parser, Subcommand, ValueEnum};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use zccache_artifact::{
     restore_rust_plan_local, rust_plan_bundle_dir, rust_plan_cache_key, save_rust_plan_local,
@@ -36,9 +36,6 @@ use zccache_cli::{
 use zccache_compiler::strict_paths::StrictPathsMode;
 use zccache_core::NormalizedPath;
 use zccache_gha::{GhaCache, GhaError};
-
-#[cfg(test)]
-use std::path::PathBuf;
 
 /// zccache -- fast local compiler cache.
 #[derive(Debug, Parser)]
@@ -246,6 +243,23 @@ enum Commands {
         /// IPC endpoint (default: platform-specific).
         #[arg(long)]
         endpoint: Option<String>,
+    },
+    /// Sum byte size of regular files under a target directory, with optional
+    /// pruning. Used by `action/cleanup/prepare-target-snapshot.sh` instead of
+    /// Python `os.walk` because jwalk parallelizes readdir+stat across cores —
+    /// big win on Windows where per-file Defender callbacks dominate the walk.
+    /// Prints total bytes as a decimal integer on stdout. See zccache#189.
+    #[command(name = "snapshot-bytes")]
+    SnapshotBytes {
+        /// Directory to walk.
+        #[arg(long)]
+        target: PathBuf,
+        /// Skip `incremental/` directories during the walk.
+        #[arg(long)]
+        prune_incremental: bool,
+        /// Skip `*/build/*/out/` directories during the walk.
+        #[arg(long)]
+        prune_build_script_out: bool,
     },
 }
 
@@ -798,6 +812,11 @@ fn main() -> ExitCode {
             let target_dir = absolute_path(&target_dir);
             cmd_warm(&target_dir, &profile)
         }
+        Commands::SnapshotBytes {
+            target,
+            prune_incremental,
+            prune_build_script_out,
+        } => cmd_snapshot_bytes(&target, prune_incremental, prune_build_script_out),
     }
 }
 
@@ -1799,6 +1818,115 @@ fn flag_truthy(value: Option<&str>) -> bool {
 
 fn env_flag_truthy(name: &str) -> bool {
     flag_truthy(std::env::var(name).ok().as_deref())
+}
+
+/// Parallel walk of `target` summing the bytes of every regular file, with
+/// optional pruning. Uses jwalk for parallel readdir + stat (rayon under the
+/// hood) — on Windows this hides per-file Defender callback latency that
+/// dominates the single-threaded `os.walk` baseline. See zccache#189.
+fn cmd_snapshot_bytes(
+    target: &Path,
+    prune_incremental: bool,
+    prune_build_script_out: bool,
+) -> ExitCode {
+    match snapshot_bytes_walk(target, prune_incremental, prune_build_script_out) {
+        Ok(total) => {
+            println!("{total}");
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("zccache snapshot-bytes: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn snapshot_bytes_walk(
+    target: &Path,
+    prune_incremental: bool,
+    prune_build_script_out: bool,
+) -> std::io::Result<u64> {
+    use jwalk::WalkDirGeneric;
+    use std::sync::Mutex;
+
+    if !target.exists() {
+        return Ok(0);
+    }
+
+    // Dedup by (dev, inode) so hardlinked files don't double-count.
+    let seen: Mutex<std::collections::HashSet<(u64, u64)>> = Mutex::new(Default::default());
+
+    let walker = WalkDirGeneric::<((), Option<u64>)>::new(target).process_read_dir(
+        move |_depth, parent_path, _read_dir_state, children| {
+            for child in children.iter_mut() {
+                let Ok(entry) = child.as_mut() else { continue };
+                if !entry.file_type().is_dir() {
+                    continue;
+                }
+                let name = entry.file_name().to_string_lossy().into_owned();
+                if prune_incremental && name == "incremental" {
+                    entry.read_children_path = None;
+                    continue;
+                }
+                if prune_build_script_out && name == "out" {
+                    // `*/build/*/out` — only prune if grandparent is `build`.
+                    if let Some(grandparent) = parent_path.parent() {
+                        if grandparent.file_name().and_then(|s| s.to_str()) == Some("build") {
+                            entry.read_children_path = None;
+                        }
+                    }
+                }
+            }
+        },
+    );
+
+    let mut total: u64 = 0;
+    for entry in walker {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(err) => {
+                // Tolerate per-entry stat failures the same way `os.walk` does
+                // in the bash fallback: skip and continue. We only bail on
+                // catastrophic root-level failure (handled by walker init).
+                eprintln!("zccache snapshot-bytes: skip entry: {err}");
+                continue;
+            }
+        };
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let meta = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if let Some(key) = file_identity(&meta) {
+            let mut seen_guard = seen.lock().expect("seen mutex poisoned");
+            if !seen_guard.insert(key) {
+                continue;
+            }
+        }
+        total = total.saturating_add(meta.len());
+    }
+    Ok(total)
+}
+
+#[cfg(unix)]
+fn file_identity(meta: &std::fs::Metadata) -> Option<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+    Some((meta.dev(), meta.ino()))
+}
+
+#[cfg(windows)]
+fn file_identity(_meta: &std::fs::Metadata) -> Option<(u64, u64)> {
+    // Windows file IDs require a separate Win32 call; not worth the cost just
+    // for hardlink dedup in a target/ tree. Cargo doesn't hardlink within
+    // `target/` in practice, so the dedup is a no-op here.
+    None
+}
+
+#[cfg(not(any(unix, windows)))]
+fn file_identity(_meta: &std::fs::Metadata) -> Option<(u64, u64)> {
+    None
 }
 
 fn cmd_cargo_registry_save(key: &str, cargo_home: Option<&str>) -> ExitCode {
@@ -4662,5 +4790,81 @@ mod tests {
         ] {
             assert!(!flag_truthy(Some(v)), "expected falsy: {v:?}");
         }
+    }
+
+    // ─── snapshot-bytes parallel walk (issue #189) ──────────────────────
+
+    fn write_file(path: &Path, bytes: &[u8]) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("mkdir -p");
+        }
+        std::fs::write(path, bytes).expect("write file");
+    }
+
+    /// Empty / missing target dir returns 0 bytes (mirrors os.walk behavior).
+    #[test]
+    fn snapshot_bytes_missing_target_is_zero() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let missing = tmp.path().join("nope");
+        assert_eq!(snapshot_bytes_walk(&missing, true, false).unwrap(), 0);
+    }
+
+    /// Sums regular files. `--prune-incremental` removes `incremental/`
+    /// directories from the walk entirely.
+    #[test]
+    fn snapshot_bytes_prunes_incremental() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let target = tmp.path();
+        write_file(&target.join("debug/deps/libfoo.rlib"), &[0u8; 100]);
+        write_file(&target.join("debug/incremental/foo/state.bin"), &[0u8; 999]);
+        write_file(
+            &target.join("release/incremental/bar/state.bin"),
+            &[0u8; 999],
+        );
+
+        let with_prune = snapshot_bytes_walk(target, true, false).unwrap();
+        assert_eq!(with_prune, 100, "incremental should be excluded");
+
+        let without_prune = snapshot_bytes_walk(target, false, false).unwrap();
+        assert_eq!(
+            without_prune,
+            100 + 999 + 999,
+            "without prune, all files counted"
+        );
+    }
+
+    /// `--prune-build-script-out` removes `*/build/*/out/` only. A bare `out/`
+    /// outside that pattern stays in the count.
+    #[test]
+    fn snapshot_bytes_prunes_build_script_out_only_under_build() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let target = tmp.path();
+        write_file(
+            &target.join("debug/build/libz-sys-abc/out/native/libz.a"),
+            &[0u8; 500],
+        );
+        write_file(
+            &target.join("debug/build/libz-sys-abc/build-script-build"),
+            &[0u8; 50],
+        );
+        // `out/` that is NOT under `build/<pkg>/` should not be pruned.
+        write_file(&target.join("debug/deps/some/out/data.bin"), &[0u8; 7]);
+
+        let pruned = snapshot_bytes_walk(target, true, true).unwrap();
+        assert_eq!(
+            pruned,
+            50 + 7,
+            "only build/<pkg>/out should be pruned; deps/some/out kept"
+        );
+
+        let kept = snapshot_bytes_walk(target, true, false).unwrap();
+        assert_eq!(kept, 500 + 50 + 7);
+    }
+
+    /// Walker tolerates an entirely empty tree — returns 0, doesn't error.
+    #[test]
+    fn snapshot_bytes_empty_target_is_zero() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert_eq!(snapshot_bytes_walk(tmp.path(), true, false).unwrap(), 0);
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to [#192](https://github.com/zackees/zccache/pull/192). That PR collapsed three walks to one but the remaining walk was still single-threaded Python \`os.walk\`. On Windows each \`stat\`/\`open\` triggers a Defender real-time-scan callback that serializes against the next syscall — wall-clock cost is bounded by walker throughput, not CPU.

This PR adds **\`zccache snapshot-bytes\`** — a parallel walk via \`jwalk\` (rayon-scheduled), same speedup pattern as [#178](https://github.com/zackees/zccache/pull/178) (rust-plan parallel save). Bash script calls the native binary first, falls back to Python when \`zccache\` isn't on PATH.

## Changes

### \`crates/zccache-cli/src/main.rs\` — new subcommand

\`\`\`
zccache snapshot-bytes \
  --target <DIR> \
  [--prune-incremental] \
  [--prune-build-script-out]
\`\`\`

- Uses \`jwalk::WalkDirGeneric::process_read_dir\` to skip pruned dirs **before** descent (cheaper than walking-then-filtering)
- Hardlink dedup by \`(dev, ino)\` on Unix; no-op on Windows (target/ doesn't contain hardlinks in practice; \`GetFileInformationByHandle\` isn't worth the cost just for this)
- Prints total bytes as decimal on stdout
- Mirrors the bash prune semantics: \`*/build/*/out\` matches only when grandparent is \`build/\`

### \`action/cleanup/prepare-target-snapshot.sh\` — call native, fall back to Python

\`\`\`bash
if command -v zccache >/dev/null 2>&1; then
  if total=\"\$(zccache snapshot-bytes --target \"\$target\" ...)\" && [ -n \"\$total\" ]; then
    printf '%s\n' \"\$total\"
    return 0
  fi
  # fall through to Python on error
fi
python - ...
\`\`\`

In CI the action installs \`zccache\` before any builds, so the fast path is always taken in production. The Python fallback keeps the bash test suite runnable on machines without \`zccache\`.

## Tests

**4 new Rust unit tests** for \`snapshot_bytes_walk\`:
- \`snapshot_bytes_missing_target_is_zero\` — common cold-cache path
- \`snapshot_bytes_prunes_incremental\` — flag on/off comparison
- \`snapshot_bytes_prunes_build_script_out_only_under_build\` — verifies \`*/build/*/out\` semantics (bare \`out/\` not pruned)
- \`snapshot_bytes_empty_target_is_zero\` — edge case

All 32 zccache-cli unit tests pass. All 6 bash tests in \`action/cleanup/tests/test_prepare_target_snapshot.sh\` pass — exercise the native path locally (where \`zccache\` is on PATH) and the Python fallback on machines without it.

## Expected impact (on top of #192)

| Stage | Before #192 | After #192 | After this PR |
|---|---|---|---|
| Windows / Check cleanup | ~1m57s | ~30s (estimated) | ~10-15s (estimated) |

The gap closes proportionally with runner core count (\`ubuntu-latest\` = 4 vCPU, \`windows-latest\` = 4 vCPU). On parallel hardware with Defender, the win is most visible on Windows.

## Tracking

- Parent: [#191](https://github.com/zackees/zccache/issues/191) (Windows CI 3-5× slower than Linux)
- Closes the follow-up scope of [#189](https://github.com/zackees/zccache/issues/189) — \"better: fold byte accounting into a native walker\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)