### PR TITLE
chore(release): bump workspace to 1.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "bincode",
  "blake3",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "libc",
  "md5",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "blake3",
  "clap",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "clang",
  "tempfile",
@@ -3499,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "serde",
  "tempfile",
@@ -3510,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "bincode",
  "clap",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "blake3",
  "dashmap",
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "blake3",
  "bytes",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "clap",
  "serde",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "clap",
  "dashmap",
@@ -3631,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "bincode",
  "bytes",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "clap",
  "criterion",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "reqwest",
  "serde",
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "blake3",
  "criterion",
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "bytes",
  "serde",
@@ -3718,7 +3718,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "bincode",
  "bytes",
@@ -3729,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["dylints/ban_std_pathbuf"]
 
 [workspace.package]
-version = "1.4.4"
+version = "1.4.5"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Workspace patch bump 1.4.4 → 1.4.5. Auto-Release fires on merge.

## What's in this release

- **perf(profile): debug=line-tables-only for dev profile** ([#187](https://github.com/zackees/zccache/pull/187))
  - Keeps panic backtraces (file:line preserved), drops DWARF variable/type tables
  - ~30–50% smaller \`target/\`, ~10–20% faster compile

- **chore(deps): bump soldr 0.7.16 → 0.7.18** ([#188](https://github.com/zackees/zccache/pull/188))
  - soldr's parallel thin-slice bundle walk ([soldr#275](https://github.com/zackees/soldr/pull/275))
  - \`SOLDR_TARGET_CACHE_TAR_THREADS\` validation ([soldr#273](https://github.com/zackees/soldr/pull/273))
  - Windows-arm64 zstd installer ([soldr#274](https://github.com/zackees/soldr/pull/274))

- **perf(cleanup): collapse 3 target/ walks to 1** ([#192](https://github.com/zackees/zccache/pull/192), closes [#189](https://github.com/zackees/zccache/issues/189))
  - Python implementation; eliminates ~106s Windows cleanup drag

- **perf(ci): target-restore-fallback for Check + Test** ([#193](https://github.com/zackees/zccache/pull/193), closes [#190](https://github.com/zackees/zccache/issues/190))
  - Warm Windows runs reuse the previous commit's target snapshot

- **perf(cli,cleanup): native parallel target/ walk via \`zccache snapshot-bytes\`** ([#194](https://github.com/zackees/zccache/pull/194))
  - jwalk + rayon parallel walk; overlaps Defender callbacks across cores on Windows

## Tracking umbrella

- [#191](https://github.com/zackees/zccache/issues/191) — Windows CI 3-5× slower than Linux. All repo-side checklist items now landed.

## Test plan

- [ ] CI green on all platforms
- [ ] After merge, verify Auto-Release publishes PyPI 1.4.5, crates.io 1.4.5, GitHub release v1.4.5
- [ ] Measure first warm-cache Windows / Check run on \`main\` — expected substantial drop from the pre-#192/#193/#194 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)