### PR TITLE
chore(ci): upgrade third-party GitHub Actions to latest

### DIFF
--- a/.github/workflows/bench-action.yml
+++ b/.github/workflows/bench-action.yml
@@ -110,7 +110,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.94.1
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: "Cold build"
         id: cold

--- a/.github/workflows/bench-fingerprint.yml
+++ b/.github/workflows/bench-fingerprint.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.94.1
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: "Build 1: cold (populates sccache)"
         run: cargo build -p $BUILD_TARGET

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Generate coverage
         run: soldr cargo llvm-cov --workspace --lcov --output-path lcov.info
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info


### PR DESCRIPTION
## Summary

Audited every \`uses:\` reference across \`.github/\` and bumped the two third-party actions that had updates available. Everything else is already on a major-version floating tag pointing at current latest.

## Bumps applied

| Action | Before | After | Notes |
|---|---|---|---|
| \`mozilla-actions/sccache-action\` | \`v0.0.9\` (2025-06-18) | \`v0.0.10\` (2026-04-22) | Patch bump |
| \`codecov/codecov-action\` | \`v5\` | \`v6\` | Node 20 → 24 runtime bump only; no input or behavior changes per [v6.0.0 release notes](https://github.com/codecov/codecov-action/releases/tag/v6.0.0). Same Node 24 wave as a659804. |

## Call sites

- \`mozilla-actions/sccache-action@v0.0.10\` — \`bench-action.yml\`, \`bench-fingerprint.yml\` (the sccache reference benchmark)
- \`codecov/codecov-action@v6\` — \`coverage.yml\` (coverage upload to Codecov)

## Already at current major (no change)

- \`actions/checkout@v6\`, \`actions/setup-python@v6\`, \`actions/upload-artifact@v7\`, \`actions/download-artifact@v8\`, \`actions/cache@v5\` — all updated by a659804
- \`zackees/setup-soldr@v0\` — floating major, already current
- \`dtolnay/rust-toolchain@stable\` — floating tag
- \`pypa/gh-action-pypi-publish@release/v1\` — release-branch reference
- \`taiki-e/install-action@cargo-llvm-cov\` — tool-name tag

## Test plan

- [ ] CI green on this PR
- [ ] Coverage upload still works (\`coverage.yml\` exercises the codecov v6 bump)
- [ ] Bench action workflow runs cleanly (\`bench-action.yml\` exercises the sccache bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)