### PR TITLE
ci: run benchmark stats daily

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -3,7 +3,7 @@ name: Benchmark Stats
 on:
   workflow_dispatch:
   schedule:
-    - cron: "17 9 * * 1"
+    - cron: "17 9 * * *"
 
 concurrency:
   group: benchmark-stats-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Change the benchmark stats scheduled workflow from weekly to daily.
- Keep manual workflow_dispatch support unchanged.

## Tests
- git diff --check

Refs #201