### PR TITLE
ci: keep benchmark diagnostics non-fatal

### DIFF
--- a/.github/workflows/bench-action.yml
+++ b/.github/workflows/bench-action.yml
@@ -305,17 +305,18 @@ jobs:
 
           echo ""
           echo "=== Cargo output ==="
-          grep -E "Compiling|Finished|Fresh" /tmp/cargo-fingerprint.log | head -20
+          grep -E "Compiling|Finished|Fresh" /tmp/cargo-fingerprint.log | head -20 || true
 
           echo ""
           echo "=== Why dirty? (fingerprint trace) ==="
-          grep -iE "dirty|stale|newer than|fingerprint.*changed|is newer" /tmp/cargo-fingerprint.log | head -20
+          grep -iE "dirty|stale|newer than|fingerprint.*changed|is newer" /tmp/cargo-fingerprint.log | head -20 || true
 
           echo ""
           echo "=== Full fingerprint trace (first 50 lines) ==="
           head -50 /tmp/cargo-fingerprint.log
 
-          COMPILING=$(grep -c "Compiling" /tmp/cargo-fingerprint.log || echo 0)
+          COMPILING=$(grep -c "Compiling" /tmp/cargo-fingerprint.log || true)
+          COMPILING=${COMPILING:-0}
           if [ "$COMPILING" -gt 0 ]; then
             echo "::warning::Recompiled $COMPILING crates (expected 0 with restored target)"
           else


### PR DESCRIPTION
## Summary
- Fix the benchmark cached-target job by making diagnostic grep pipelines non-fatal when there are no matching fingerprint lines.
- Keep the cargo build itself as the command that determines benchmark step success or failure.
- Fix the zero-match compilation counter so it does not emit duplicate zero output.

## Investigation
- Failing job: https://github.com/zackees/zccache/actions/runs/25819814825/job/75858144714
- The cargo build finished successfully, then the `Why dirty?` diagnostic grep returned 1 because there were no dirty/stale fingerprint lines under `set -e -o pipefail`.

## Tests
- RED: reproduced the empty `grep | head` diagnostic pipeline exiting 1 under `set -e -o pipefail`.
- GREEN: verified the same empty diagnostic pipeline succeeds with `|| true`.
- Verified zero-match `COMPILING` counter behavior.
- `git diff --check`