### PR TITLE
ci: add compiler perf regression guard

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,3 +6,4 @@ GitHub Actions workflow definitions.
 - **ci-check.yml** - Reusable check/test workflow used by the OS-specific CI workflows.
 - **clippy.yml** - Runs Clippy on pushes to main for the README status badge.
 - **benchmark-stats.yml** - Manual/scheduled zccache vs bare compiler vs sccache benchmark publisher for the README image and rendered stats page.
+- **perf-guard.yml** - Manual/automatic Rust, C, and C++ perf-regression guard that fails below the zccache vs bare compiler speed floor.

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -1,0 +1,72 @@
+name: Perf Guard
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "action.yml"
+      - "action/**"
+      - "ci/**"
+      - "crates/**"
+      - ".github/workflows/perf-guard.yml"
+  pull_request:
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "action.yml"
+      - "action/**"
+      - "ci/**"
+      - "crates/**"
+      - ".github/workflows/perf-guard.yml"
+
+concurrency:
+  group: perf-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  perf-guard:
+    name: Rust/C/C++ speed floor
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: zackees/setup-soldr@v0
+        with:
+          cache: false
+          build-cache: false
+          target-cache: false
+
+      - uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Install benchmark tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y clang
+
+      - name: Run perf regression guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m ci.perf_guard \
+            --run-benchmarks \
+            --threshold 1.5 \
+            --attempts 3 \
+            --output-dir perf-guard-output
+
+      - name: Upload perf guard logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-guard-output
+          path: perf-guard-output
+          if-no-files-found: warn

--- a/ci/README.md
+++ b/ci/README.md
@@ -8,6 +8,7 @@ Python scripts for development tooling. Rust commands go through `soldr <tool>` 
 - **`./test`** - Workspace tests, supports per-crate filtering
 - **`./perf`** - Performance benchmarks (zccache vs sccache vs bare clang)
 - **`python -m ci.benchmark_stats`** - Generates `index.html`, `latest.json`, and `benchmark.jpg` from perf output for the published benchmark report
+- **`python -m ci.perf_guard`** - Fails CI when Rust, C, or C++ zccache benchmark rows fall below the bare-compiler speed floor
 
 ## Release Automation
 

--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -48,6 +48,12 @@ BENCHMARK_COMMAND = [
 
 
 TABLES = {
+    "## C Benchmark:": {
+        "id": "c-inline",
+        "label": "C inline args",
+        "language": "c",
+        "bare_label": "Bare clang",
+    },
     "## Benchmark:": {
         "id": "cpp-inline",
         "label": "C++ inline args",

--- a/ci/perf.py
+++ b/ci/perf.py
@@ -1,6 +1,7 @@
 """Run performance benchmarks (zccache vs sccache vs bare compiler).
 
-Three benchmarks:
+Four benchmarks:
+  - perf_c_zccache_vs_bare: C inline args
   - perf_warm_cache_zccache_vs_sccache: C++ inline args (single-file + multi-file)
   - perf_response_file: C++ large nested response files (~283 expanded args)
   - perf_rustc_zccache_vs_sccache: Rust compilation (50 .rs lib files)

--- a/ci/perf_guard.py
+++ b/ci/perf_guard.py
@@ -1,0 +1,258 @@
+"""Fail CI when zccache performance drops below the bare-compiler floor."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ci import benchmark_stats
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "perf-guard-output"
+DEFAULT_THRESHOLD = 1.5
+DEFAULT_ATTEMPTS = 3
+REQUIRED_LANGUAGES = ("c", "c++", "rust")
+REQUIRED_MODES = ("cold", "warm")
+
+
+@dataclass(frozen=True)
+class ScenarioKey:
+    benchmark: str
+    scenario: str
+
+
+@dataclass
+class ScenarioStatus:
+    key: ScenarioKey
+    benchmark_label: str
+    language: str
+    mode: str
+    scenario: str
+    bare_label: str
+    best_ratio: float | None = None
+    best_attempt: int | None = None
+    attempts_seen: int = 0
+
+    @property
+    def passed(self) -> bool:
+        return self.best_ratio is not None and self.best_ratio >= self.threshold
+
+    threshold: float = DEFAULT_THRESHOLD
+
+
+@dataclass
+class GuardReport:
+    statuses: list[ScenarioStatus]
+    missing_requirements: list[str]
+    command_failures: list[int]
+    attempt_count: int
+
+    @property
+    def passed(self) -> bool:
+        return (
+            not self.missing_requirements
+            and len(self.command_failures) < self.attempt_count
+            and self.statuses
+            and all(status.passed for status in self.statuses)
+        )
+
+
+def run_benchmarks_once(log_path: Path) -> tuple[int, str]:
+    cache_dir = Path(tempfile.mkdtemp(prefix="zccache-perf-guard-cache-"))
+    env = os.environ.copy()
+    env["ZCCACHE_CACHE_DIR"] = str(cache_dir)
+    env.pop("RUSTC_WRAPPER", None)
+
+    try:
+        result = subprocess.run(
+            benchmark_stats.BENCHMARK_COMMAND,
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+    finally:
+        shutil.rmtree(cache_dir, ignore_errors=True)
+
+    output = result.stdout
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(output, encoding="utf-8")
+    print(output, end="")
+    return result.returncode, output
+
+
+def _required_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        row
+        for row in rows
+        if row.get("language") in REQUIRED_LANGUAGES and row.get("mode") in REQUIRED_MODES
+    ]
+
+
+def evaluate_attempts(
+    attempts: list[list[dict[str, Any]]],
+    *,
+    threshold: float = DEFAULT_THRESHOLD,
+    command_failures: list[int] | None = None,
+) -> GuardReport:
+    statuses: dict[ScenarioKey, ScenarioStatus] = {}
+    language_modes: set[tuple[str, str]] = set()
+
+    for attempt_index, rows in enumerate(attempts, start=1):
+        for row in _required_rows(rows):
+            language = str(row["language"])
+            mode = str(row["mode"])
+            language_modes.add((language, mode))
+            key = ScenarioKey(str(row["benchmark"]), str(row["scenario"]))
+            status = statuses.get(key)
+            if status is None:
+                status = ScenarioStatus(
+                    key=key,
+                    benchmark_label=str(row["benchmark_label"]),
+                    language=language,
+                    mode=mode,
+                    scenario=str(row["scenario"]),
+                    bare_label=str(row["bare_label"]),
+                    threshold=threshold,
+                )
+                statuses[key] = status
+            status.attempts_seen += 1
+
+            ratio = row.get("zccache_vs_bare_ratio")
+            if isinstance(ratio, int | float):
+                if status.best_ratio is None or ratio > status.best_ratio:
+                    status.best_ratio = float(ratio)
+                    status.best_attempt = attempt_index
+
+    missing = [
+        f"{language} {mode}"
+        for language in REQUIRED_LANGUAGES
+        for mode in REQUIRED_MODES
+        if (language, mode) not in language_modes
+    ]
+
+    ordered = sorted(
+        statuses.values(),
+        key=lambda item: (item.language, item.benchmark_label, item.mode, item.scenario),
+    )
+    return GuardReport(
+        statuses=ordered,
+        missing_requirements=missing,
+        command_failures=command_failures or [],
+        attempt_count=len(attempts),
+    )
+
+
+def format_report(report: GuardReport, threshold: float) -> str:
+    lines = [
+        "## zccache perf guard",
+        "",
+        f"Threshold: bare compiler / zccache >= {threshold:.2f}x",
+        "",
+        "| Status | Language | Benchmark | Scenario | Best ratio | Attempt | Seen |",
+        "|---|---|---|---|---:|---:|---:|",
+    ]
+    for status in report.statuses:
+        state = "PASS" if status.passed else "FAIL"
+        ratio = "n/a" if status.best_ratio is None else f"{status.best_ratio:.3f}x"
+        attempt = "n/a" if status.best_attempt is None else str(status.best_attempt)
+        lines.append(
+            "| "
+            f"{state} | {status.language} | {status.benchmark_label} | "
+            f"{status.scenario} | {ratio} | {attempt} | {status.attempts_seen} |"
+        )
+
+    if report.missing_requirements:
+        lines.extend(["", "### Missing required coverage", ""])
+        lines.extend(f"- {item}" for item in report.missing_requirements)
+
+    if report.command_failures:
+        lines.extend(["", "### Failed benchmark attempts", ""])
+        lines.extend(f"- Attempt {attempt}" for attempt in report.command_failures)
+
+    return "\n".join(lines) + "\n"
+
+
+def _append_step_summary(markdown: str) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a", encoding="utf-8") as handle:
+        handle.write(markdown)
+
+
+def _load_input_log(path: Path) -> list[list[dict[str, Any]]]:
+    text = path.read_text(encoding="utf-8")
+    return [benchmark_stats.parse_benchmark_log(text)]
+
+
+def _run_attempts(output_dir: Path, attempts: int) -> tuple[list[list[dict[str, Any]]], list[int]]:
+    parsed_attempts: list[list[dict[str, Any]]] = []
+    command_failures: list[int] = []
+
+    for attempt in range(1, attempts + 1):
+        log_path = output_dir / f"attempt-{attempt}.log"
+        print(f"=== Perf guard attempt {attempt}/{attempts} ===")
+        returncode, output = run_benchmarks_once(log_path)
+        rows = benchmark_stats.parse_benchmark_log(output)
+        parsed_attempts.append(rows)
+        if returncode != 0:
+            command_failures.append(attempt)
+
+        interim = evaluate_attempts(parsed_attempts, command_failures=command_failures)
+        if returncode == 0 and interim.passed:
+            break
+
+    return parsed_attempts, command_failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-log", type=Path, help="Evaluate a saved benchmark log.")
+    parser.add_argument("--run-benchmarks", action="store_true", help="Run perf benchmarks.")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
+    parser.add_argument("--attempts", type=int, default=DEFAULT_ATTEMPTS)
+    args = parser.parse_args()
+
+    if args.threshold <= 0:
+        parser.error("--threshold must be greater than zero")
+    if args.attempts < 1:
+        parser.error("--attempts must be at least 1")
+    if bool(args.input_log) == bool(args.run_benchmarks):
+        parser.error("use exactly one of --input-log or --run-benchmarks")
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    if args.input_log:
+        attempts = _load_input_log(args.input_log)
+        command_failures: list[int] = []
+    else:
+        attempts, command_failures = _run_attempts(args.output_dir, args.attempts)
+
+    report = evaluate_attempts(
+        attempts,
+        threshold=args.threshold,
+        command_failures=command_failures,
+    )
+    markdown = format_report(report, args.threshold)
+    report_path = args.output_dir / "perf-guard-summary.md"
+    report_path.write_text(markdown, encoding="utf-8")
+    print(markdown)
+    _append_step_summary(markdown)
+
+    return 0 if report.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tests/test_benchmark_stats.py
+++ b/ci/tests/test_benchmark_stats.py
@@ -2,6 +2,13 @@ from ci import benchmark_stats
 
 
 SAMPLE_LOG = """
+## C Benchmark: 50 .c files, 5 warm trials
+
+| Scenario | Bare clang | sccache | zccache | vs sccache | vs bare clang |
+|:---------|----------:|--------:|--------:|-----------:|--------------:|
+| Single-file, Cold | 3.000s | — | 2.000s | — | 1.5x faster |
+| Single-file, Warm | 3.000s | — | **0.050s** | — | **60x faster** |
+
 ## Benchmark: 50 C++ files, 5 warm trials
 
 | Scenario | Bare Clang | sccache | zccache | vs sccache | vs bare clang |
@@ -28,12 +35,17 @@ SAMPLE_LOG = """
 def test_parse_benchmark_log_extracts_all_tables():
     rows = benchmark_stats.parse_benchmark_log(SAMPLE_LOG)
 
-    assert len(rows) == 6
+    assert len(rows) == 8
     assert {row["benchmark"] for row in rows} == {
+        "c-inline",
         "cpp-inline",
         "cpp-response-file",
         "rust",
     }
+
+    c_warm = [row for row in rows if row["benchmark"] == "c-inline" and row["mode"] == "warm"][0]
+    assert c_warm["language"] == "c"
+    assert c_warm["zccache_vs_bare_ratio"] == 60.0
 
     rust_warm = [row for row in rows if row["scenario"] == "Build, Warm"][0]
     assert rust_warm["language"] == "rust"

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -1,0 +1,107 @@
+from ci import benchmark_stats, perf_guard
+
+
+PASSING_LOG = """
+## C Benchmark: 50 .c files, 5 warm trials
+
+| Scenario | Bare clang | sccache | zccache | vs sccache | vs bare clang |
+|:---------|----------:|--------:|--------:|-----------:|--------------:|
+| Single-file, Cold | 3.000s | — | 2.000s | — | 1.5x faster |
+| Single-file, Warm | 3.000s | — | **1.000s** | — | **3.0x faster** |
+
+## Benchmark: 50 C++ files, 5 warm trials
+
+| Scenario | Bare Clang | sccache | zccache | vs sccache | vs bare clang |
+|:---------|----------:|--------:|--------:|-----------:|--------------:|
+| Single-file, Cold | 6.000s | 7.000s | 4.000s | 1.8x faster | 1.5x faster |
+| Single-file, Warm | 6.000s | 1.500s | **0.050s** | **30x faster** | **120x faster** |
+
+## Rust Benchmark: 50 .rs files, 5 warm trials
+
+| Scenario | Bare rustc | sccache | zccache | vs sccache | vs bare rustc |
+|:---------|----------:|--------:|--------:|-----------:|--------------:|
+| Build, Cold | 9.000s | 10.000s | 6.000s | 1.7x faster | 1.5x faster |
+| Build, Warm | 9.000s | 8.000s | **0.100s** | **80x faster** | **90x faster** |
+"""
+
+
+FAILING_RUST_LOG = PASSING_LOG.replace(
+    "| Build, Cold | 9.000s | 10.000s | 6.000s | 1.7x faster | 1.5x faster |",
+    "| Build, Cold | 9.000s | 10.000s | 7.000s | 1.4x faster | 1.3x faster |",
+)
+
+
+MISSING_C_LOG = """
+## Benchmark: 50 C++ files, 5 warm trials
+
+| Scenario | Bare Clang | sccache | zccache | vs sccache | vs bare clang |
+|:---------|----------:|--------:|--------:|-----------:|--------------:|
+| Single-file, Cold | 6.000s | 7.000s | 4.000s | 1.8x faster | 1.5x faster |
+| Single-file, Warm | 6.000s | 1.500s | **0.050s** | **30x faster** | **120x faster** |
+
+## Rust Benchmark: 50 .rs files, 5 warm trials
+
+| Scenario | Bare rustc | sccache | zccache | vs sccache | vs bare rustc |
+|:---------|----------:|--------:|--------:|-----------:|--------------:|
+| Build, Cold | 9.000s | 10.000s | 6.000s | 1.7x faster | 1.5x faster |
+| Build, Warm | 9.000s | 8.000s | **0.100s** | **80x faster** | **90x faster** |
+"""
+
+
+def rows(log: str):
+    return benchmark_stats.parse_benchmark_log(log)
+
+
+def test_exact_threshold_passes():
+    report = perf_guard.evaluate_attempts([rows(PASSING_LOG)], threshold=1.5)
+
+    assert report.passed
+    assert not report.missing_requirements
+
+
+def test_below_threshold_fails():
+    report = perf_guard.evaluate_attempts([rows(FAILING_RUST_LOG)], threshold=1.5)
+
+    assert not report.passed
+    failing = [status for status in report.statuses if not status.passed]
+    assert [(status.language, status.scenario) for status in failing] == [("rust", "Build, Cold")]
+
+
+def test_retry_passes_when_later_attempt_clears_threshold():
+    report = perf_guard.evaluate_attempts(
+        [rows(FAILING_RUST_LOG), rows(PASSING_LOG)],
+        threshold=1.5,
+    )
+
+    assert report.passed
+    rust_cold = [
+        status
+        for status in report.statuses
+        if status.language == "rust" and status.scenario == "Build, Cold"
+    ][0]
+    assert rust_cold.best_attempt == 2
+    assert rust_cold.best_ratio == 1.5
+
+
+def test_missing_required_language_mode_fails():
+    report = perf_guard.evaluate_attempts([rows(MISSING_C_LOG)], threshold=1.5)
+
+    assert not report.passed
+    assert report.missing_requirements == ["c cold", "c warm"]
+
+
+def test_all_command_failures_fail_even_when_rows_parse():
+    report = perf_guard.evaluate_attempts(
+        [rows(PASSING_LOG), rows(PASSING_LOG)],
+        threshold=1.5,
+        command_failures=[1, 2],
+    )
+
+    assert not report.passed
+
+
+def test_report_marks_failed_rows():
+    report = perf_guard.evaluate_attempts([rows(FAILING_RUST_LOG)], threshold=1.5)
+    markdown = perf_guard.format_report(report, 1.5)
+
+    assert "| FAIL | rust | Rust rustc | Build, Cold | 1.286x | 1 | 1 |" in markdown

--- a/crates/zccache-daemon/tests/perf_bench_test.rs
+++ b/crates/zccache-daemon/tests/perf_bench_test.rs
@@ -1,6 +1,7 @@
 //! Performance benchmark: warm-cache compilation latency.
 //!
-//! Three benchmarks:
+//! Four benchmarks:
+//!   - `perf_c_zccache_vs_bare`: C single-file compilation (inline args)
 //!   - `perf_warm_cache_zccache_vs_sccache`: C++ single-file vs multi-file (inline args)
 //!   - `perf_response_file`: C++ same workload but args passed via large nested response files
 //!   - `perf_rustc_zccache_vs_sccache`: Rust single-file compilation (lib crates)
@@ -145,6 +146,140 @@ fn clean_objects(dir: &Path) {
 
 fn source_names() -> Vec<String> {
     (0..NUM_FILES).map(|i| format!("unit_{i:03}.cpp")).collect()
+}
+
+fn c_source_names() -> Vec<String> {
+    (0..NUM_FILES).map(|i| format!("unit_{i:03}.c")).collect()
+}
+
+fn generate_c_project(dir: &Path) {
+    let incdir = dir.join("include");
+    std::fs::create_dir_all(&incdir).unwrap();
+
+    std::fs::write(
+        incdir.join("common_c.h"),
+        r#"#pragma once
+#include <stdint.h>
+#include <math.h>
+
+static inline uint64_t bench_mix(uint64_t x) {
+    x ^= x >> 33;
+    x *= 0xff51afd7ed558ccdULL;
+    x ^= x >> 33;
+    x *= 0xc4ceb9fe1a85ec53ULL;
+    x ^= x >> 33;
+    return x;
+}
+"#,
+    )
+    .unwrap();
+
+    for i in 0..NUM_FILES {
+        let content = format!(
+            r#"#include "common_c.h"
+
+double compute_{i:03}(int n) {{
+    double acc = (double)n * 0.{i:03}1;
+    for (int j = 0; j < 32; ++j) {{
+        acc += sin((double)bench_mix((uint64_t)(n + j + {i})) * 1e-18);
+    }}
+    return acc;
+}}
+"#,
+        );
+        std::fs::write(dir.join(format!("unit_{i:03}.c")), content).unwrap();
+    }
+}
+
+fn nuke_and_regenerate_c(dir: &Path) {
+    for entry in std::fs::read_dir(dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_dir() {
+            std::fs::remove_dir_all(&path).unwrap();
+        } else {
+            std::fs::remove_file(&path).unwrap();
+        }
+    }
+    generate_c_project(dir);
+}
+
+fn warmup_c_compiler(compiler: &str, dir: &Path) {
+    let src = dir.join("unit_000.c");
+    let obj = dir.join("_warmup.o");
+    let status = std::process::Command::new(compiler)
+        .args(["-c", "-Iinclude", "-O2", "-std=c11"])
+        .arg(&src)
+        .arg("-o")
+        .arg(&obj)
+        .current_dir(dir)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .expect("C warmup compile failed");
+    assert!(status.success(), "C warmup compile failed");
+    let _ = std::fs::remove_file(&obj);
+}
+
+fn baseline_c_single(compiler: &str, cwd: &Path, sources: &[String]) -> Duration {
+    clean_objects(cwd);
+    let start = Instant::now();
+    for src in sources {
+        let status = std::process::Command::new(compiler)
+            .args([
+                "-c",
+                src,
+                "-o",
+                &src.replace(".c", ".o"),
+                "-Iinclude",
+                "-O2",
+                "-std=c11",
+            ])
+            .current_dir(cwd)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("failed to run C compiler");
+        assert!(status.success(), "C compile failed for {src}");
+    }
+    start.elapsed()
+}
+
+async fn zccache_compile_c_single(
+    client: &mut ClientConn,
+    session_id: &str,
+    compiler: &str,
+    cwd: &str,
+    sources: &[String],
+) -> Duration {
+    clean_objects(Path::new(cwd));
+    let start = Instant::now();
+    for src in sources {
+        client
+            .send(&Request::Compile {
+                session_id: session_id.to_string(),
+                args: vec![
+                    "-c".into(),
+                    src.clone(),
+                    "-o".into(),
+                    src.replace(".c", ".o"),
+                    "-Iinclude".into(),
+                    "-O2".into(),
+                    "-std=c11".into(),
+                ],
+                cwd: cwd.into(),
+                compiler: compiler.to_string().into(),
+                env: None,
+            })
+            .await
+            .unwrap();
+        match client.recv().await.unwrap() {
+            Some(Response::CompileResult { exit_code, .. }) => {
+                assert_eq!(exit_code, 0, "C compile failed for {src}");
+            }
+            other => panic!("expected CompileResult, got: {other:?}"),
+        }
+    }
+    start.elapsed()
 }
 
 // ── zccache benchmarks (in-process daemon, no subprocess overhead) ──────
@@ -581,6 +716,121 @@ fn fmt_ratio(baseline: Duration, test: Duration, bold: bool) -> String {
 }
 
 // ── Main benchmark ──────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_c_zccache_vs_bare --nocapture --ignored
+async fn perf_c_zccache_vs_bare() {
+    zccache_test_support::ensure_clang_tool_chain_on_path();
+    let compiler_path = match zccache_test_support::find_on_path("clang") {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: no C compiler found");
+            return;
+        }
+    };
+    let compiler = compiler_path.to_string_lossy().to_string();
+    let sources = c_source_names();
+
+    eprintln!();
+    eprintln!("================================================================");
+    eprintln!("  C COMPILATION BENCHMARK");
+    eprintln!("  {NUM_FILES} .c files | {WARM_TRIALS} warm trials");
+    eprintln!("  Compiler: {compiler}");
+    eprintln!("================================================================");
+    eprintln!();
+
+    let bl_dir = zccache_test_support::temp_cache_dir().unwrap();
+    generate_c_project(bl_dir.path());
+
+    eprintln!("  [1/2] Bare clang");
+    nuke_and_regenerate_c(bl_dir.path());
+    warmup_c_compiler(&compiler, bl_dir.path());
+    let bl_cold = baseline_c_single(&compiler, bl_dir.path(), &sources);
+    eprintln!("        cold:  {}", fmt_dur(bl_cold));
+
+    let bl_warm = baseline_c_single(&compiler, bl_dir.path(), &sources);
+    eprintln!("        warm:  {}", fmt_dur(bl_warm));
+    eprintln!();
+    drop(bl_dir);
+
+    let zc_dir = zccache_test_support::temp_cache_dir().unwrap();
+    generate_c_project(zc_dir.path());
+    let zc_cwd = zc_dir.path().to_string_lossy().into_owned();
+
+    eprintln!("  [2/2] zccache");
+    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let mut client = zccache_ipc::connect(&endpoint).await.unwrap();
+
+    client
+        .send(&Request::SessionStart {
+            client_pid: std::process::id(),
+            working_dir: zc_cwd.clone().into(),
+            log_file: None,
+            track_stats: true,
+            journal_path: None,
+        })
+        .await
+        .unwrap();
+    let session_id = match client.recv().await.unwrap() {
+        Some(Response::SessionStarted { session_id, .. }) => session_id,
+        other => panic!("expected SessionStarted, got: {other:?}"),
+    };
+
+    nuke_and_regenerate_c(zc_dir.path());
+    warmup_c_compiler(&compiler, zc_dir.path());
+    let zc_cold =
+        zccache_compile_c_single(&mut client, &session_id, &compiler, &zc_cwd, &sources).await;
+    eprintln!("        cold:  {}", fmt_dur(zc_cold));
+
+    let mut zc_warm = Vec::with_capacity(WARM_TRIALS);
+    for _ in 0..WARM_TRIALS {
+        zc_warm.push(
+            zccache_compile_c_single(&mut client, &session_id, &compiler, &zc_cwd, &sources).await,
+        );
+    }
+    print_trials("warm:", &zc_warm);
+
+    client
+        .send(&Request::SessionEnd {
+            session_id: session_id.clone(),
+        })
+        .await
+        .unwrap();
+    let _ = client.recv::<Response>().await;
+
+    shutdown.notify_one();
+    server_handle.await.unwrap();
+
+    let dash = "\u{2014}";
+    let zc_warm_med = median(&zc_warm);
+    let vs_bare_cold = fmt_ratio(bl_cold, zc_cold, false);
+    let vs_bare_warm = fmt_ratio(bl_warm, zc_warm_med, true);
+
+    eprintln!();
+    eprintln!("## C Benchmark: {NUM_FILES} .c files, {WARM_TRIALS} warm trials");
+    eprintln!();
+    eprintln!("| Scenario | Bare clang | sccache | zccache | vs sccache | vs bare clang |");
+    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|");
+    eprintln!(
+        "| Single-file, Cold | {} | {} | {} | {} | {} |",
+        fmt_dur(bl_cold),
+        dash,
+        fmt_dur(zc_cold),
+        dash,
+        vs_bare_cold,
+    );
+    eprintln!(
+        "| Single-file, Warm | {} | {} | **{}** | {} | {} |",
+        fmt_dur(bl_warm),
+        dash,
+        fmt_dur(zc_warm_med),
+        dash,
+        vs_bare_warm,
+    );
+    eprintln!();
+    eprintln!("> **Cold** = first compile (empty cache). **Warm** = median of {WARM_TRIALS} subsequent runs.");
+    eprintln!();
+}
 
 #[tokio::test]
 #[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- --nocapture --ignored


### PR DESCRIPTION
## Summary
- Add a dedicated `perf-guard.yml` workflow that runs automatically on perf-sensitive PR/push changes and manually via `workflow_dispatch`.
- Add `ci.perf_guard` to retry the ignored benchmark suite up to 3 times and fail any Rust/C/C++ cold or warm row below `bare / zccache >= 1.5x`.
- Add a C clang benchmark table alongside the existing C++ and Rust perf tables, and update benchmark parsing/tests/docs.

## Notes
- This is intentionally a strict automatic gate per #205; current cold-path regressions may cause it to fail until the underlying performance fixes land.
- sccache remains parsed/reported when present, but the failure threshold is only zccache vs bare compiler.

## Tests
- `uv run --with pytest pytest ci\tests\test_benchmark_stats.py ci\tests\test_perf_guard.py`
- `uv run python -m py_compile ci\benchmark_stats.py ci\perf_guard.py ci\tests\test_perf_guard.py`
- `soldr --no-cache cargo test -p zccache-daemon --test perf_bench_test --no-run`
- `soldr --no-cache cargo fmt --all -- --check`
- `git diff --check`

Closes #205