### PR TITLE
ci: gate perf guard against pinned sccache

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,4 +6,4 @@ GitHub Actions workflow definitions.
 - **ci-check.yml** - Reusable check/test workflow used by the OS-specific CI workflows.
 - **clippy.yml** - Runs Clippy on pushes to main for the README status badge.
 - **benchmark-stats.yml** - Manual/scheduled zccache vs bare compiler vs sccache benchmark publisher for the README image and rendered stats page.
-- **perf-guard.yml** - Manual/automatic Rust, C, and C++ perf-regression guard that fails below the zccache vs bare compiler speed floor.
+- **perf-guard.yml** - Manual/automatic Rust, C, and C++ perf-regression guard that fails below the zccache vs bare compiler or pinned-sccache speed floors.

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -45,6 +45,8 @@ jobs:
           target-cache: false
 
       - uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: "0.10.0"
 
       - name: Install benchmark tools
         shell: bash
@@ -59,7 +61,8 @@ jobs:
           set -euo pipefail
           python3 -m ci.perf_guard \
             --run-benchmarks \
-            --threshold 1.5 \
+            --bare-threshold 1.5 \
+            --sccache-threshold 1.5 \
             --attempts 3 \
             --output-dir perf-guard-output
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -8,7 +8,7 @@ Python scripts for development tooling. Rust commands go through `soldr <tool>` 
 - **`./test`** - Workspace tests, supports per-crate filtering
 - **`./perf`** - Performance benchmarks (zccache vs sccache vs bare clang)
 - **`python -m ci.benchmark_stats`** - Generates `index.html`, `latest.json`, and `benchmark.jpg` from perf output for the published benchmark report
-- **`python -m ci.perf_guard`** - Fails CI when Rust, C, or C++ zccache benchmark rows fall below the bare-compiler speed floor
+- **`python -m ci.perf_guard`** - Fails CI when Rust, C, or C++ zccache benchmark rows fall below the bare-compiler or pinned-sccache speed floors
 
 ## Release Automation
 

--- a/ci/perf_guard.py
+++ b/ci/perf_guard.py
@@ -1,4 +1,4 @@
-"""Fail CI when zccache performance drops below the bare-compiler floor."""
+"""Fail CI when zccache performance drops below compiler-cache speed floors."""
 
 from __future__ import annotations
 
@@ -16,7 +16,9 @@ from ci import benchmark_stats
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUTPUT_DIR = REPO_ROOT / "perf-guard-output"
-DEFAULT_THRESHOLD = 1.5
+DEFAULT_BARE_THRESHOLD = 1.5
+DEFAULT_SCCACHE_THRESHOLD = 1.5
+DEFAULT_THRESHOLD = DEFAULT_BARE_THRESHOLD
 DEFAULT_ATTEMPTS = 3
 REQUIRED_LANGUAGES = ("c", "c++", "rust")
 REQUIRED_MODES = ("cold", "warm")
@@ -26,6 +28,7 @@ REQUIRED_MODES = ("cold", "warm")
 class ScenarioKey:
     benchmark: str
     scenario: str
+    baseline: str
 
 
 @dataclass
@@ -35,7 +38,9 @@ class ScenarioStatus:
     language: str
     mode: str
     scenario: str
-    bare_label: str
+    baseline: str
+    baseline_label: str
+    threshold: float
     best_ratio: float | None = None
     best_attempt: int | None = None
     attempts_seen: int = 0
@@ -43,8 +48,6 @@ class ScenarioStatus:
     @property
     def passed(self) -> bool:
         return self.best_ratio is not None and self.best_ratio >= self.threshold
-
-    threshold: float = DEFAULT_THRESHOLD
 
 
 @dataclass
@@ -103,9 +106,14 @@ def _required_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
 def evaluate_attempts(
     attempts: list[list[dict[str, Any]]],
     *,
-    threshold: float = DEFAULT_THRESHOLD,
+    threshold: float | None = None,
+    bare_threshold: float = DEFAULT_BARE_THRESHOLD,
+    sccache_threshold: float = DEFAULT_SCCACHE_THRESHOLD,
     command_failures: list[int] | None = None,
 ) -> GuardReport:
+    if threshold is not None:
+        bare_threshold = threshold
+        sccache_threshold = threshold
     statuses: dict[ScenarioKey, ScenarioStatus] = {}
     language_modes: set[tuple[str, str]] = set()
 
@@ -114,26 +122,36 @@ def evaluate_attempts(
             language = str(row["language"])
             mode = str(row["mode"])
             language_modes.add((language, mode))
-            key = ScenarioKey(str(row["benchmark"]), str(row["scenario"]))
-            status = statuses.get(key)
-            if status is None:
-                status = ScenarioStatus(
-                    key=key,
-                    benchmark_label=str(row["benchmark_label"]),
-                    language=language,
-                    mode=mode,
-                    scenario=str(row["scenario"]),
-                    bare_label=str(row["bare_label"]),
-                    threshold=threshold,
-                )
-                statuses[key] = status
-            status.attempts_seen += 1
+            comparisons = (
+                ("bare", str(row["bare_label"]), row.get("zccache_vs_bare_ratio"), bare_threshold),
+                (
+                    "sccache",
+                    "sccache",
+                    row.get("zccache_vs_sccache_ratio"),
+                    sccache_threshold,
+                ),
+            )
+            for baseline, baseline_label, ratio, ratio_threshold in comparisons:
+                key = ScenarioKey(str(row["benchmark"]), str(row["scenario"]), baseline)
+                status = statuses.get(key)
+                if status is None:
+                    status = ScenarioStatus(
+                        key=key,
+                        benchmark_label=str(row["benchmark_label"]),
+                        language=language,
+                        mode=mode,
+                        scenario=str(row["scenario"]),
+                        baseline=baseline,
+                        baseline_label=baseline_label,
+                        threshold=ratio_threshold,
+                    )
+                    statuses[key] = status
+                status.attempts_seen += 1
 
-            ratio = row.get("zccache_vs_bare_ratio")
-            if isinstance(ratio, int | float):
-                if status.best_ratio is None or ratio > status.best_ratio:
-                    status.best_ratio = float(ratio)
-                    status.best_attempt = attempt_index
+                if isinstance(ratio, int | float):
+                    if status.best_ratio is None or ratio > status.best_ratio:
+                        status.best_ratio = float(ratio)
+                        status.best_attempt = attempt_index
 
     missing = [
         f"{language} {mode}"
@@ -144,7 +162,13 @@ def evaluate_attempts(
 
     ordered = sorted(
         statuses.values(),
-        key=lambda item: (item.language, item.benchmark_label, item.mode, item.scenario),
+        key=lambda item: (
+            item.language,
+            item.benchmark_label,
+            item.mode,
+            item.scenario,
+            item.baseline,
+        ),
     )
     return GuardReport(
         statuses=ordered,
@@ -154,14 +178,19 @@ def evaluate_attempts(
     )
 
 
-def format_report(report: GuardReport, threshold: float) -> str:
+def format_report(
+    report: GuardReport,
+    bare_threshold: float,
+    sccache_threshold: float,
+) -> str:
     lines = [
         "## zccache perf guard",
         "",
-        f"Threshold: bare compiler / zccache >= {threshold:.2f}x",
+        f"Bare threshold: bare compiler / zccache >= {bare_threshold:.2f}x",
+        f"sccache threshold: pinned sccache / zccache >= {sccache_threshold:.2f}x",
         "",
-        "| Status | Language | Benchmark | Scenario | Best ratio | Attempt | Seen |",
-        "|---|---|---|---|---:|---:|---:|",
+        "| Status | Language | Benchmark | Scenario | Baseline | Best ratio | Threshold | Attempt | Seen |",
+        "|---|---|---|---|---|---:|---:|---:|---:|",
     ]
     for status in report.statuses:
         state = "PASS" if status.passed else "FAIL"
@@ -170,7 +199,8 @@ def format_report(report: GuardReport, threshold: float) -> str:
         lines.append(
             "| "
             f"{state} | {status.language} | {status.benchmark_label} | "
-            f"{status.scenario} | {ratio} | {attempt} | {status.attempts_seen} |"
+            f"{status.scenario} | {status.baseline_label} | {ratio} | "
+            f"{status.threshold:.2f}x | {attempt} | {status.attempts_seen} |"
         )
 
     if report.missing_requirements:
@@ -197,7 +227,12 @@ def _load_input_log(path: Path) -> list[list[dict[str, Any]]]:
     return [benchmark_stats.parse_benchmark_log(text)]
 
 
-def _run_attempts(output_dir: Path, attempts: int) -> tuple[list[list[dict[str, Any]]], list[int]]:
+def _run_attempts(
+    output_dir: Path,
+    attempts: int,
+    bare_threshold: float,
+    sccache_threshold: float,
+) -> tuple[list[list[dict[str, Any]]], list[int]]:
     parsed_attempts: list[list[dict[str, Any]]] = []
     command_failures: list[int] = []
 
@@ -210,7 +245,12 @@ def _run_attempts(output_dir: Path, attempts: int) -> tuple[list[list[dict[str, 
         if returncode != 0:
             command_failures.append(attempt)
 
-        interim = evaluate_attempts(parsed_attempts, command_failures=command_failures)
+        interim = evaluate_attempts(
+            parsed_attempts,
+            bare_threshold=bare_threshold,
+            sccache_threshold=sccache_threshold,
+            command_failures=command_failures,
+        )
         if returncode == 0 and interim.passed:
             break
 
@@ -222,12 +262,19 @@ def main() -> int:
     parser.add_argument("--input-log", type=Path, help="Evaluate a saved benchmark log.")
     parser.add_argument("--run-benchmarks", action="store_true", help="Run perf benchmarks.")
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
-    parser.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
+    parser.add_argument("--threshold", type=float, help="Set both thresholds to this value.")
+    parser.add_argument("--bare-threshold", type=float, default=DEFAULT_BARE_THRESHOLD)
+    parser.add_argument("--sccache-threshold", type=float, default=DEFAULT_SCCACHE_THRESHOLD)
     parser.add_argument("--attempts", type=int, default=DEFAULT_ATTEMPTS)
     args = parser.parse_args()
 
-    if args.threshold <= 0:
-        parser.error("--threshold must be greater than zero")
+    if args.threshold is not None:
+        args.bare_threshold = args.threshold
+        args.sccache_threshold = args.threshold
+    if args.bare_threshold <= 0:
+        parser.error("--bare-threshold must be greater than zero")
+    if args.sccache_threshold <= 0:
+        parser.error("--sccache-threshold must be greater than zero")
     if args.attempts < 1:
         parser.error("--attempts must be at least 1")
     if bool(args.input_log) == bool(args.run_benchmarks):
@@ -238,14 +285,20 @@ def main() -> int:
         attempts = _load_input_log(args.input_log)
         command_failures: list[int] = []
     else:
-        attempts, command_failures = _run_attempts(args.output_dir, args.attempts)
+        attempts, command_failures = _run_attempts(
+            args.output_dir,
+            args.attempts,
+            args.bare_threshold,
+            args.sccache_threshold,
+        )
 
     report = evaluate_attempts(
         attempts,
-        threshold=args.threshold,
+        bare_threshold=args.bare_threshold,
+        sccache_threshold=args.sccache_threshold,
         command_failures=command_failures,
     )
-    markdown = format_report(report, args.threshold)
+    markdown = format_report(report, args.bare_threshold, args.sccache_threshold)
     report_path = args.output_dir / "perf-guard-summary.md"
     report_path.write_text(markdown, encoding="utf-8")
     print(markdown)

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -6,8 +6,8 @@ PASSING_LOG = """
 
 | Scenario | Bare clang | sccache | zccache | vs sccache | vs bare clang |
 |:---------|----------:|--------:|--------:|-----------:|--------------:|
-| Single-file, Cold | 3.000s | — | 2.000s | — | 1.5x faster |
-| Single-file, Warm | 3.000s | — | **1.000s** | — | **3.0x faster** |
+| Single-file, Cold | 3.000s | 3.200s | 2.000s | 1.6x faster | 1.5x faster |
+| Single-file, Warm | 3.000s | 2.000s | **1.000s** | **2.0x faster** | **3.0x faster** |
 
 ## Benchmark: 50 C++ files, 5 warm trials
 
@@ -28,6 +28,11 @@ PASSING_LOG = """
 FAILING_RUST_LOG = PASSING_LOG.replace(
     "| Build, Cold | 9.000s | 10.000s | 6.000s | 1.7x faster | 1.5x faster |",
     "| Build, Cold | 9.000s | 10.000s | 7.000s | 1.4x faster | 1.3x faster |",
+)
+
+FAILING_SCCACHE_LOG = PASSING_LOG.replace(
+    "| Single-file, Cold | 6.000s | 7.000s | 4.000s | 1.8x faster | 1.5x faster |",
+    "| Single-file, Cold | 6.000s | 5.000s | 4.000s | 1.2x faster | 1.5x faster |",
 )
 
 
@@ -64,7 +69,20 @@ def test_below_threshold_fails():
 
     assert not report.passed
     failing = [status for status in report.statuses if not status.passed]
-    assert [(status.language, status.scenario) for status in failing] == [("rust", "Build, Cold")]
+    assert [(status.language, status.scenario, status.baseline) for status in failing] == [
+        ("rust", "Build, Cold", "bare"),
+        ("rust", "Build, Cold", "sccache"),
+    ]
+
+
+def test_sccache_threshold_is_enforced_separately_from_bare():
+    report = perf_guard.evaluate_attempts([rows(FAILING_SCCACHE_LOG)], threshold=1.5)
+
+    assert not report.passed
+    failing = [status for status in report.statuses if not status.passed]
+    assert [(status.language, status.scenario, status.baseline) for status in failing] == [
+        ("c++", "Single-file, Cold", "sccache")
+    ]
 
 
 def test_retry_passes_when_later_attempt_clears_threshold():
@@ -102,6 +120,6 @@ def test_all_command_failures_fail_even_when_rows_parse():
 
 def test_report_marks_failed_rows():
     report = perf_guard.evaluate_attempts([rows(FAILING_RUST_LOG)], threshold=1.5)
-    markdown = perf_guard.format_report(report, 1.5)
+    markdown = perf_guard.format_report(report, 1.5, 1.5)
 
-    assert "| FAIL | rust | Rust rustc | Build, Cold | 1.286x | 1 | 1 |" in markdown
+    assert "| FAIL | rust | Rust rustc | Build, Cold | Bare rustc | 1.286x | 1.50x | 1 | 1 |" in markdown

--- a/crates/zccache-daemon/tests/perf_bench_test.rs
+++ b/crates/zccache-daemon/tests/perf_bench_test.rs
@@ -244,6 +244,36 @@ fn baseline_c_single(compiler: &str, cwd: &Path, sources: &[String]) -> Duration
     start.elapsed()
 }
 
+fn sccache_compile_c_single(
+    sccache: &Path,
+    compiler: &str,
+    cwd: &Path,
+    sources: &[String],
+) -> Duration {
+    clean_objects(cwd);
+    let start = Instant::now();
+    for src in sources {
+        let status = std::process::Command::new(sccache)
+            .args([
+                compiler,
+                "-c",
+                src,
+                "-o",
+                &src.replace(".c", ".o"),
+                "-Iinclude",
+                "-O2",
+                "-std=c11",
+            ])
+            .current_dir(cwd)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("failed to run sccache for C");
+        assert!(status.success(), "sccache C compile failed for {src}");
+    }
+    start.elapsed()
+}
+
 async fn zccache_compile_c_single(
     client: &mut ClientConn,
     session_id: &str,
@@ -734,7 +764,7 @@ async fn perf_c_zccache_vs_bare() {
     eprintln!();
     eprintln!("================================================================");
     eprintln!("  C COMPILATION BENCHMARK");
-    eprintln!("  {NUM_FILES} .c files | {WARM_TRIALS} warm trials");
+    eprintln!("  {NUM_FILES} .c files | {WARM_TRIALS} warm trials | each tool in its own tempdir");
     eprintln!("  Compiler: {compiler}");
     eprintln!("================================================================");
     eprintln!();
@@ -753,11 +783,70 @@ async fn perf_c_zccache_vs_bare() {
     eprintln!();
     drop(bl_dir);
 
+    let sccache_cold;
+    let sccache_warm;
+    if let Some(sccache_bin) = find_sccache() {
+        let sc_dir = zccache_test_support::temp_cache_dir().unwrap();
+        generate_c_project(sc_dir.path());
+
+        let sc_cache_dir = zccache_test_support::temp_cache_dir().unwrap();
+        let sc_cache_str = sc_cache_dir.path().to_string_lossy().into_owned();
+        std::env::set_var("SCCACHE_DIR", &sc_cache_str);
+
+        eprintln!("  [2/3] sccache ({})", sccache_bin.display());
+        let _ = std::process::Command::new(&sccache_bin)
+            .arg("--stop-server")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        if sc_cache_dir.path().exists() {
+            let _ = std::fs::remove_dir_all(sc_cache_dir.path());
+            let _ = std::fs::create_dir_all(sc_cache_dir.path());
+        }
+        let _ = std::process::Command::new(&sccache_bin)
+            .arg("--start-server")
+            .env("SCCACHE_DIR", &sc_cache_str)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+
+        nuke_and_regenerate_c(sc_dir.path());
+        warmup_c_compiler(&compiler, sc_dir.path());
+        let cold = sccache_compile_c_single(&sccache_bin, &compiler, sc_dir.path(), &sources);
+        eprintln!("        cold:  {}", fmt_dur(cold));
+        sccache_cold = Some(cold);
+
+        let mut times = Vec::with_capacity(WARM_TRIALS);
+        for _ in 0..WARM_TRIALS {
+            times.push(sccache_compile_c_single(
+                &sccache_bin,
+                &compiler,
+                sc_dir.path(),
+                &sources,
+            ));
+        }
+        print_trials("warm:", &times);
+        sccache_warm = Some(times);
+
+        let _ = std::process::Command::new(&sccache_bin)
+            .arg("--stop-server")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        std::env::remove_var("SCCACHE_DIR");
+        eprintln!();
+    } else {
+        eprintln!("  [2/3] sccache: not found, skipping");
+        eprintln!();
+        sccache_cold = None;
+        sccache_warm = None;
+    }
+
     let zc_dir = zccache_test_support::temp_cache_dir().unwrap();
     generate_c_project(zc_dir.path());
     let zc_cwd = zc_dir.path().to_string_lossy().into_owned();
 
-    eprintln!("  [2/2] zccache");
+    eprintln!("  [3/3] zccache");
     let (endpoint, server_handle, shutdown) = start_daemon().await;
     let mut client = zccache_ipc::connect(&endpoint).await.unwrap();
 
@@ -801,10 +890,16 @@ async fn perf_c_zccache_vs_bare() {
     shutdown.notify_one();
     server_handle.await.unwrap();
 
-    let dash = "\u{2014}";
     let zc_warm_med = median(&zc_warm);
     let vs_bare_cold = fmt_ratio(bl_cold, zc_cold, false);
     let vs_bare_warm = fmt_ratio(bl_warm, zc_warm_med, true);
+    let dash = "\u{2014}";
+    let sccache_cold_str = sccache_cold.map(fmt_dur);
+    let sccache_warm_str = sccache_warm.as_ref().map(|times| fmt_dur(median(times)));
+    let vs_sccache_cold = sccache_cold.map(|duration| fmt_ratio(duration, zc_cold, false));
+    let vs_sccache_warm = sccache_warm
+        .as_ref()
+        .map(|times| fmt_ratio(median(times), zc_warm_med, true));
 
     eprintln!();
     eprintln!("## C Benchmark: {NUM_FILES} .c files, {WARM_TRIALS} warm trials");
@@ -814,17 +909,17 @@ async fn perf_c_zccache_vs_bare() {
     eprintln!(
         "| Single-file, Cold | {} | {} | {} | {} | {} |",
         fmt_dur(bl_cold),
-        dash,
+        sccache_cold_str.as_deref().unwrap_or(dash),
         fmt_dur(zc_cold),
-        dash,
+        vs_sccache_cold.as_deref().unwrap_or(dash),
         vs_bare_cold,
     );
     eprintln!(
         "| Single-file, Warm | {} | {} | **{}** | {} | {} |",
         fmt_dur(bl_warm),
-        dash,
+        sccache_warm_str.as_deref().unwrap_or(dash),
         fmt_dur(zc_warm_med),
-        dash,
+        vs_sccache_warm.as_deref().unwrap_or(dash),
         vs_bare_warm,
     );
     eprintln!();


### PR DESCRIPTION
## Summary
- Pin the Perf Guard workflow to `sccache 0.10.0` instead of the action default.
- Add a separate pinned-sccache speed floor: `sccache_seconds / zccache_seconds >= 1.5`.
- Add sccache timings to the C benchmark table so Rust, C, and C++ rows are all checked against both bare and sccache baselines.

## Why
#207 only gated zccache against bare compiler speed. That could miss a regression where zccache remains faster than bare but falls behind sccache.

## Tests
- `uv run --with pytest pytest ci\tests\test_benchmark_stats.py ci\tests\test_perf_guard.py`
- `uv run python -m py_compile ci\benchmark_stats.py ci\perf_guard.py ci\tests\test_perf_guard.py`
- `soldr --no-cache cargo fmt --all -- --check`
- `soldr --no-cache cargo test -p zccache-daemon --test perf_bench_test --no-run`
- `git diff --check origin/main..HEAD`

Refs #205