### PR TITLE
ci: fix pinned sccache release tag

### DIFF
--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@v0.0.10
         with:
-          version: "0.10.0"
+          version: "v0.10.0"
 
       - name: Install benchmark tools
         shell: bash


### PR DESCRIPTION
## Summary
- Fix the Perf Guard sccache pin to use the actual release tag `v0.10.0`.

## Investigation
- Failed run: https://github.com/zackees/zccache/actions/runs/25834472137/job/75906391369?pr=208
- `mozilla-actions/sccache-action@v0.0.10` used the input directly in the release URL.
- The previous input `0.10.0` produced a 404 for `/releases/download/0.10.0/sccache-0.10.0-x86_64-unknown-linux-musl.tar.gz`.
- The actual sccache release tag and asset names use `v0.10.0`.

## Tests
- `git diff --check`
- Verified `.github/workflows/perf-guard.yml` now pins `version: v0.10.0`.

Refs #205