### PR TITLE
ci: publish perf guard json artifacts

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,4 +6,4 @@ GitHub Actions workflow definitions.
 - **ci-check.yml** - Reusable check/test workflow used by the OS-specific CI workflows.
 - **clippy.yml** - Runs Clippy on pushes to main for the README status badge.
 - **benchmark-stats.yml** - Manual/scheduled zccache vs bare compiler vs sccache benchmark publisher for the README image and rendered stats page.
-- **perf-guard.yml** - Manual/automatic Rust, C, and C++ perf-regression guard that fails below the zccache vs bare compiler or pinned-sccache speed floors.
+- **perf-guard.yml** - Manual/automatic Rust, C, and C++ perf-regression guard that fails below the zccache vs bare compiler or pinned-sccache speed floors and uploads Markdown/JSON run artifacts.

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -66,7 +66,7 @@ jobs:
             --attempts 3 \
             --output-dir perf-guard-output
 
-      - name: Upload perf guard logs
+      - name: Upload perf guard artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Linux](https://github.com/zackees/zccache/actions/workflows/ci-linux.yml/badge.svg)](https://github.com/zackees/zccache/actions/workflows/ci-linux.yml)
 [![macOS](https://github.com/zackees/zccache/actions/workflows/ci-macos.yml/badge.svg)](https://github.com/zackees/zccache/actions/workflows/ci-macos.yml)
 [![Windows](https://github.com/zackees/zccache/actions/workflows/ci-windows.yml/badge.svg)](https://github.com/zackees/zccache/actions/workflows/ci-windows.yml)
+[![Perf Guard](https://github.com/zackees/zccache/actions/workflows/perf-guard.yml/badge.svg?branch=main)](https://github.com/zackees/zccache/actions/workflows/perf-guard.yml?query=branch%3Amain)
 [![Clippy](https://github.com/zackees/zccache/actions/workflows/clippy.yml/badge.svg?branch=main)](https://github.com/zackees/zccache/actions/workflows/clippy.yml?query=branch%3Amain)
 [![Dylint](https://img.shields.io/github/actions/workflow/status/zackees/zccache/ci.yml?branch=main&event=push&job=Dylint&label=dylint)](https://github.com/zackees/zccache/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
 [![codecov](https://codecov.io/gh/zackees/zccache/branch/main/graph/badge.svg)](https://codecov.io/gh/zackees/zccache)

--- a/ci/perf_guard.py
+++ b/ci/perf_guard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import shutil
 import subprocess
@@ -62,7 +63,7 @@ class GuardReport:
         return (
             not self.missing_requirements
             and len(self.command_failures) < self.attempt_count
-            and self.statuses
+            and bool(self.statuses)
             and all(status.passed for status in self.statuses)
         )
 
@@ -214,6 +215,79 @@ def format_report(
     return "\n".join(lines) + "\n"
 
 
+def format_report_json(
+    report: GuardReport,
+    bare_threshold: float,
+    sccache_threshold: float,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "passed": report.passed,
+        "thresholds": {
+            "bare": bare_threshold,
+            "sccache": sccache_threshold,
+        },
+        "attempt_count": report.attempt_count,
+        "command_failures": report.command_failures,
+        "missing_requirements": report.missing_requirements,
+        "statuses": [
+            {
+                "passed": status.passed,
+                "benchmark": status.key.benchmark,
+                "benchmark_label": status.benchmark_label,
+                "language": status.language,
+                "mode": status.mode,
+                "scenario": status.scenario,
+                "baseline": status.baseline,
+                "baseline_label": status.baseline_label,
+                "threshold": status.threshold,
+                "best_ratio": status.best_ratio,
+                "best_attempt": status.best_attempt,
+                "attempts_seen": status.attempts_seen,
+            }
+            for status in report.statuses
+        ],
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_attempt_json(
+    output_dir: Path,
+    attempt: int,
+    rows: list[dict[str, Any]],
+    returncode: int | None,
+    *,
+    source: str,
+) -> None:
+    _write_json(
+        output_dir / f"attempt-{attempt}.json",
+        {
+            "schema_version": 1,
+            "attempt": attempt,
+            "source": source,
+            "returncode": returncode,
+            "row_count": len(rows),
+            "rows": rows,
+        },
+    )
+
+
+def write_report_json(
+    output_dir: Path,
+    report: GuardReport,
+    bare_threshold: float,
+    sccache_threshold: float,
+) -> None:
+    _write_json(
+        output_dir / "perf-guard-summary.json",
+        format_report_json(report, bare_threshold, sccache_threshold),
+    )
+
+
 def _append_step_summary(markdown: str) -> None:
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not summary_path:
@@ -242,6 +316,13 @@ def _run_attempts(
         returncode, output = run_benchmarks_once(log_path)
         rows = benchmark_stats.parse_benchmark_log(output)
         parsed_attempts.append(rows)
+        write_attempt_json(
+            output_dir,
+            attempt,
+            rows,
+            returncode,
+            source="benchmark-run",
+        )
         if returncode != 0:
             command_failures.append(attempt)
 
@@ -283,6 +364,13 @@ def main() -> int:
     args.output_dir.mkdir(parents=True, exist_ok=True)
     if args.input_log:
         attempts = _load_input_log(args.input_log)
+        write_attempt_json(
+            args.output_dir,
+            1,
+            attempts[0],
+            None,
+            source="input-log",
+        )
         command_failures: list[int] = []
     else:
         attempts, command_failures = _run_attempts(
@@ -301,6 +389,7 @@ def main() -> int:
     markdown = format_report(report, args.bare_threshold, args.sccache_threshold)
     report_path = args.output_dir / "perf-guard-summary.md"
     report_path.write_text(markdown, encoding="utf-8")
+    write_report_json(args.output_dir, report, args.bare_threshold, args.sccache_threshold)
     print(markdown)
     _append_step_summary(markdown)
 

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -1,3 +1,5 @@
+import json
+
 from ci import benchmark_stats, perf_guard
 
 
@@ -123,3 +125,52 @@ def test_report_marks_failed_rows():
     markdown = perf_guard.format_report(report, 1.5, 1.5)
 
     assert "| FAIL | rust | Rust rustc | Build, Cold | Bare rustc | 1.286x | 1.50x | 1 | 1 |" in markdown
+
+
+def test_report_json_marks_thresholds_and_failed_statuses():
+    report = perf_guard.evaluate_attempts([rows(FAILING_RUST_LOG)], threshold=1.5)
+    payload = perf_guard.format_report_json(report, 1.5, 1.5)
+
+    assert payload["schema_version"] == 1
+    assert payload["passed"] is False
+    assert payload["thresholds"] == {"bare": 1.5, "sccache": 1.5}
+    failing = [
+        status
+        for status in payload["statuses"]
+        if status["language"] == "rust"
+        and status["scenario"] == "Build, Cold"
+        and not status["passed"]
+    ]
+    assert {status["baseline"] for status in failing} == {"bare", "sccache"}
+
+
+def test_report_json_passed_is_boolean_when_no_rows_parse():
+    report = perf_guard.evaluate_attempts([[]], threshold=1.5)
+    payload = perf_guard.format_report_json(report, 1.5, 1.5)
+
+    assert payload["passed"] is False
+
+
+def test_writes_perf_guard_json_artifacts(tmp_path):
+    parsed_rows = rows(PASSING_LOG)
+    report = perf_guard.evaluate_attempts([parsed_rows], threshold=1.5)
+
+    perf_guard.write_attempt_json(
+        tmp_path,
+        1,
+        parsed_rows,
+        0,
+        source="unit-test",
+    )
+    perf_guard.write_report_json(tmp_path, report, 1.5, 1.5)
+
+    attempt_payload = json.loads((tmp_path / "attempt-1.json").read_text(encoding="utf-8"))
+    summary_payload = json.loads(
+        (tmp_path / "perf-guard-summary.json").read_text(encoding="utf-8")
+    )
+
+    assert attempt_payload["source"] == "unit-test"
+    assert attempt_payload["returncode"] == 0
+    assert attempt_payload["row_count"] == len(parsed_rows)
+    assert summary_payload["passed"] is True
+    assert all(status["passed"] for status in summary_payload["statuses"])


### PR DESCRIPTION
## Summary
- Add the Perf Guard workflow badge to the README.
- Write per-attempt `attempt-N.json` files and a final `perf-guard-summary.json` from `ci.perf_guard`.
- Rename the workflow upload step to reflect that the `perf-guard-output` artifact contains logs, Markdown, and JSON.

## Tests
- `uv run --with pytest pytest ci\tests\test_perf_guard.py ci\tests\test_benchmark_stats.py`
- `python -m py_compile ci\perf_guard.py ci\tests\test_perf_guard.py`
- `git diff --check`