### PR TITLE
ci: split perf guard by language

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,4 +6,4 @@ GitHub Actions workflow definitions.
 - **ci-check.yml** - Reusable check/test workflow used by the OS-specific CI workflows.
 - **clippy.yml** - Runs Clippy on pushes to main for the README status badge.
 - **benchmark-stats.yml** - Manual/scheduled zccache vs bare compiler vs sccache benchmark publisher for the README image and rendered stats page.
-- **perf-guard.yml** - Manual/automatic Rust, C, and C++ perf-regression guard that fails below the zccache vs bare compiler or pinned-sccache speed floors and uploads Markdown/JSON run artifacts.
+- **perf-guard.yml** - Main-only Rust, C, and C++ perf-regression guard that runs language jobs in parallel, fails below the zccache vs bare compiler or pinned-sccache speed floors, and uploads Markdown/JSON run artifacts.

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -12,15 +12,6 @@ on:
       - "ci/**"
       - "crates/**"
       - ".github/workflows/perf-guard.yml"
-  pull_request:
-    paths:
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "action.yml"
-      - "action/**"
-      - "ci/**"
-      - "crates/**"
-      - ".github/workflows/perf-guard.yml"
 
 concurrency:
   group: perf-guard-${{ github.ref }}
@@ -31,9 +22,23 @@ permissions:
 
 jobs:
   perf-guard:
-    name: Rust/C/C++ speed floor
+    name: ${{ matrix.label }} speed floor
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: c
+            label: C
+            artifact: c
+          - language: c++
+            label: C++
+            artifact: cpp
+          - language: rust
+            label: Rust
+            artifact: rust
 
     steps:
       - uses: actions/checkout@v6
@@ -61,6 +66,7 @@ jobs:
           set -euo pipefail
           python3 -m ci.perf_guard \
             --run-benchmarks \
+            --language "${{ matrix.language }}" \
             --bare-threshold 1.5 \
             --sccache-threshold 1.5 \
             --attempts 3 \
@@ -70,6 +76,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: perf-guard-output
+          name: perf-guard-${{ matrix.artifact }}-output
           path: perf-guard-output
           if-no-files-found: warn

--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -31,7 +31,7 @@ DEFAULT_PAGES_URL = "https://zackees.github.io/zccache/"
 DEFAULT_RAW_IMAGE_URL = (
     "https://raw.githubusercontent.com/zackees/zccache/benchmark-stats/benchmark.jpg"
 )
-BENCHMARK_COMMAND = [
+BENCHMARK_BASE_COMMAND = [
     "soldr",
     "--no-cache",
     "cargo",
@@ -40,6 +40,14 @@ BENCHMARK_COMMAND = [
     "zccache-daemon",
     "--test",
     "perf_bench_test",
+]
+BENCHMARK_TESTS_BY_LANGUAGE = {
+    "c": ("perf_c_zccache_vs_bare",),
+    "c++": ("perf_warm_cache_zccache_vs_sccache", "perf_response_file"),
+    "rust": ("perf_rustc_zccache_vs_sccache",),
+}
+BENCHMARK_COMMAND = [
+    *BENCHMARK_BASE_COMMAND,
     "--",
     "--nocapture",
     "--ignored",
@@ -73,6 +81,27 @@ TABLES = {
         "bare_label": "Bare rustc",
     },
 }
+
+
+def benchmark_command_for_test(test_name: str) -> list[str]:
+    return [
+        *BENCHMARK_BASE_COMMAND,
+        "--",
+        test_name,
+        "--nocapture",
+        "--ignored",
+        "--test-threads=1",
+    ]
+
+
+def benchmark_commands_for_language(language: str) -> list[list[str]]:
+    try:
+        test_names = BENCHMARK_TESTS_BY_LANGUAGE[language]
+    except KeyError as exc:
+        supported = ", ".join(sorted(BENCHMARK_TESTS_BY_LANGUAGE))
+        message = f"unsupported benchmark language {language!r}; expected {supported}"
+        raise ValueError(message) from exc
+    return [benchmark_command_for_test(test_name) for test_name in test_names]
 
 
 def _utc_now() -> str:

--- a/ci/perf_guard.py
+++ b/ci/perf_guard.py
@@ -68,39 +68,54 @@ class GuardReport:
         )
 
 
-def run_benchmarks_once(log_path: Path) -> tuple[int, str]:
+def _benchmark_commands(language: str | None) -> list[list[str]]:
+    if language is None:
+        return [benchmark_stats.BENCHMARK_COMMAND]
+    return benchmark_stats.benchmark_commands_for_language(language)
+
+
+def run_benchmarks_once(log_path: Path, language: str | None = None) -> tuple[int, str]:
     cache_dir = Path(tempfile.mkdtemp(prefix="zccache-perf-guard-cache-"))
     env = os.environ.copy()
     env["ZCCACHE_CACHE_DIR"] = str(cache_dir)
     env.pop("RUSTC_WRAPPER", None)
 
     try:
-        result = subprocess.run(
-            benchmark_stats.BENCHMARK_COMMAND,
-            cwd=REPO_ROOT,
-            env=env,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            check=False,
-        )
+        outputs: list[str] = []
+        returncode = 0
+        for command in _benchmark_commands(language):
+            result = subprocess.run(
+                command,
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+            outputs.append(result.stdout)
+            if result.returncode != 0 and returncode == 0:
+                returncode = result.returncode
     finally:
         shutil.rmtree(cache_dir, ignore_errors=True)
 
-    output = result.stdout
+    output = "".join(outputs)
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text(output, encoding="utf-8")
     print(output, end="")
-    return result.returncode, output
+    return returncode, output
 
 
-def _required_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _required_rows(
+    rows: list[dict[str, Any]],
+    languages: tuple[str, ...],
+) -> list[dict[str, Any]]:
     return [
         row
         for row in rows
-        if row.get("language") in REQUIRED_LANGUAGES and row.get("mode") in REQUIRED_MODES
+        if row.get("language") in languages and row.get("mode") in REQUIRED_MODES
     ]
 
 
@@ -111,6 +126,7 @@ def evaluate_attempts(
     bare_threshold: float = DEFAULT_BARE_THRESHOLD,
     sccache_threshold: float = DEFAULT_SCCACHE_THRESHOLD,
     command_failures: list[int] | None = None,
+    languages: tuple[str, ...] = REQUIRED_LANGUAGES,
 ) -> GuardReport:
     if threshold is not None:
         bare_threshold = threshold
@@ -119,7 +135,7 @@ def evaluate_attempts(
     language_modes: set[tuple[str, str]] = set()
 
     for attempt_index, rows in enumerate(attempts, start=1):
-        for row in _required_rows(rows):
+        for row in _required_rows(rows, languages):
             language = str(row["language"])
             mode = str(row["mode"])
             language_modes.add((language, mode))
@@ -156,7 +172,7 @@ def evaluate_attempts(
 
     missing = [
         f"{language} {mode}"
-        for language in REQUIRED_LANGUAGES
+        for language in languages
         for mode in REQUIRED_MODES
         if (language, mode) not in language_modes
     ]
@@ -219,10 +235,12 @@ def format_report_json(
     report: GuardReport,
     bare_threshold: float,
     sccache_threshold: float,
+    languages: tuple[str, ...] = REQUIRED_LANGUAGES,
 ) -> dict[str, Any]:
     return {
         "schema_version": 1,
         "passed": report.passed,
+        "languages": list(languages),
         "thresholds": {
             "bare": bare_threshold,
             "sccache": sccache_threshold,
@@ -262,6 +280,7 @@ def write_attempt_json(
     returncode: int | None,
     *,
     source: str,
+    language: str | None = None,
 ) -> None:
     _write_json(
         output_dir / f"attempt-{attempt}.json",
@@ -269,6 +288,7 @@ def write_attempt_json(
             "schema_version": 1,
             "attempt": attempt,
             "source": source,
+            "language": language,
             "returncode": returncode,
             "row_count": len(rows),
             "rows": rows,
@@ -281,10 +301,11 @@ def write_report_json(
     report: GuardReport,
     bare_threshold: float,
     sccache_threshold: float,
+    languages: tuple[str, ...] = REQUIRED_LANGUAGES,
 ) -> None:
     _write_json(
         output_dir / "perf-guard-summary.json",
-        format_report_json(report, bare_threshold, sccache_threshold),
+        format_report_json(report, bare_threshold, sccache_threshold, languages),
     )
 
 
@@ -306,6 +327,8 @@ def _run_attempts(
     attempts: int,
     bare_threshold: float,
     sccache_threshold: float,
+    languages: tuple[str, ...],
+    benchmark_language: str | None,
 ) -> tuple[list[list[dict[str, Any]]], list[int]]:
     parsed_attempts: list[list[dict[str, Any]]] = []
     command_failures: list[int] = []
@@ -313,7 +336,7 @@ def _run_attempts(
     for attempt in range(1, attempts + 1):
         log_path = output_dir / f"attempt-{attempt}.log"
         print(f"=== Perf guard attempt {attempt}/{attempts} ===")
-        returncode, output = run_benchmarks_once(log_path)
+        returncode, output = run_benchmarks_once(log_path, benchmark_language)
         rows = benchmark_stats.parse_benchmark_log(output)
         parsed_attempts.append(rows)
         write_attempt_json(
@@ -322,6 +345,7 @@ def _run_attempts(
             rows,
             returncode,
             source="benchmark-run",
+            language=benchmark_language,
         )
         if returncode != 0:
             command_failures.append(attempt)
@@ -331,6 +355,7 @@ def _run_attempts(
             bare_threshold=bare_threshold,
             sccache_threshold=sccache_threshold,
             command_failures=command_failures,
+            languages=languages,
         )
         if returncode == 0 and interim.passed:
             break
@@ -347,6 +372,11 @@ def main() -> int:
     parser.add_argument("--bare-threshold", type=float, default=DEFAULT_BARE_THRESHOLD)
     parser.add_argument("--sccache-threshold", type=float, default=DEFAULT_SCCACHE_THRESHOLD)
     parser.add_argument("--attempts", type=int, default=DEFAULT_ATTEMPTS)
+    parser.add_argument(
+        "--language",
+        choices=REQUIRED_LANGUAGES,
+        help="Run and require only one benchmark language.",
+    )
     args = parser.parse_args()
 
     if args.threshold is not None:
@@ -361,6 +391,7 @@ def main() -> int:
     if bool(args.input_log) == bool(args.run_benchmarks):
         parser.error("use exactly one of --input-log or --run-benchmarks")
 
+    languages = (args.language,) if args.language else REQUIRED_LANGUAGES
     args.output_dir.mkdir(parents=True, exist_ok=True)
     if args.input_log:
         attempts = _load_input_log(args.input_log)
@@ -370,6 +401,7 @@ def main() -> int:
             attempts[0],
             None,
             source="input-log",
+            language=args.language,
         )
         command_failures: list[int] = []
     else:
@@ -378,6 +410,8 @@ def main() -> int:
             args.attempts,
             args.bare_threshold,
             args.sccache_threshold,
+            languages,
+            args.language,
         )
 
     report = evaluate_attempts(
@@ -385,11 +419,18 @@ def main() -> int:
         bare_threshold=args.bare_threshold,
         sccache_threshold=args.sccache_threshold,
         command_failures=command_failures,
+        languages=languages,
     )
     markdown = format_report(report, args.bare_threshold, args.sccache_threshold)
     report_path = args.output_dir / "perf-guard-summary.md"
     report_path.write_text(markdown, encoding="utf-8")
-    write_report_json(args.output_dir, report, args.bare_threshold, args.sccache_threshold)
+    write_report_json(
+        args.output_dir,
+        report,
+        args.bare_threshold,
+        args.sccache_threshold,
+        languages,
+    )
     print(markdown)
     _append_step_summary(markdown)
 

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -110,6 +110,18 @@ def test_missing_required_language_mode_fails():
     assert report.missing_requirements == ["c cold", "c warm"]
 
 
+def test_language_filter_requires_only_selected_language():
+    report = perf_guard.evaluate_attempts(
+        [rows(MISSING_C_LOG)],
+        threshold=1.5,
+        languages=("rust",),
+    )
+
+    assert report.passed
+    assert not report.missing_requirements
+    assert {status.language for status in report.statuses} == {"rust"}
+
+
 def test_all_command_failures_fail_even_when_rows_parse():
     report = perf_guard.evaluate_attempts(
         [rows(PASSING_LOG), rows(PASSING_LOG)],
@@ -133,6 +145,7 @@ def test_report_json_marks_thresholds_and_failed_statuses():
 
     assert payload["schema_version"] == 1
     assert payload["passed"] is False
+    assert payload["languages"] == ["c", "c++", "rust"]
     assert payload["thresholds"] == {"bare": 1.5, "sccache": 1.5}
     failing = [
         status
@@ -161,8 +174,9 @@ def test_writes_perf_guard_json_artifacts(tmp_path):
         parsed_rows,
         0,
         source="unit-test",
+        language="c",
     )
-    perf_guard.write_report_json(tmp_path, report, 1.5, 1.5)
+    perf_guard.write_report_json(tmp_path, report, 1.5, 1.5, ("c",))
 
     attempt_payload = json.loads((tmp_path / "attempt-1.json").read_text(encoding="utf-8"))
     summary_payload = json.loads(
@@ -170,7 +184,22 @@ def test_writes_perf_guard_json_artifacts(tmp_path):
     )
 
     assert attempt_payload["source"] == "unit-test"
+    assert attempt_payload["language"] == "c"
     assert attempt_payload["returncode"] == 0
     assert attempt_payload["row_count"] == len(parsed_rows)
     assert summary_payload["passed"] is True
+    assert summary_payload["languages"] == ["c"]
     assert all(status["passed"] for status in summary_payload["statuses"])
+
+
+def test_benchmark_language_commands_are_filtered():
+    c_commands = benchmark_stats.benchmark_commands_for_language("c")
+    cpp_commands = benchmark_stats.benchmark_commands_for_language("c++")
+    rust_commands = benchmark_stats.benchmark_commands_for_language("rust")
+
+    assert [command[-4] for command in c_commands] == ["perf_c_zccache_vs_bare"]
+    assert [command[-4] for command in cpp_commands] == [
+        "perf_warm_cache_zccache_vs_sccache",
+        "perf_response_file",
+    ]
+    assert [command[-4] for command in rust_commands] == ["perf_rustc_zccache_vs_sccache"]


### PR DESCRIPTION
## Summary
- Split the perf guard workflow into parallel C, C++, and Rust matrix jobs.
- Remove the `pull_request` trigger and add a main-branch job guard so perf guard only runs on `main` or main-branch manual dispatches.
- Add `ci.perf_guard --language` so each job runs only its language-specific ignored benchmark tests.
- Keep separate uploaded artifacts per language job.

## Tests
- `uv run --with pytest pytest ci\tests\test_perf_guard.py ci\tests\test_benchmark_stats.py`
- `python -m py_compile ci\benchmark_stats.py ci\perf_guard.py ci\tests\test_perf_guard.py`
- `git diff --check`