### PR TITLE
feat(bench): replace text stats with generated image

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,46 +58,10 @@ zccache --version
 
 [![Latest zccache benchmark stats](https://raw.githubusercontent.com/zackees/zccache/benchmark-stats/benchmark.jpg)](https://zackees.github.io/zccache/)
 
-Latest rendered report: [zackees.github.io/zccache](https://zackees.github.io/zccache/)
-
-50 files per benchmark, median of 5 trials. Run it yourself: `./perf`
-
-### Cache Hit (warm cache)
-
-| Benchmark | Bare Compiler | sccache | zccache | vs sccache | vs bare |
-|:----------|-------------:|--------:|--------:|-----------:|--------:|
-| **C++ single-file** | 11.705s | 1.576s | **0.050s** | **32x** | **236x** |
-| **C++ multi-file** | 11.553s | 11.530s | **0.017s** | **695x** | **696x** |
-| **C++ response-file (single)** | 12.540s | 1.558s | **0.047s** | **33x** | **267x** |
-| **C++ response-file (multi)** | 12.049s | 12.434s | **0.019s** | **669x** | **648x** |
-| **Rust build** | 6.592s | 8.604s | **0.045s** | **193x** | **148x** |
-| **Rust check** | 3.716s | 5.922s | **0.049s** | **121x** | **76x** |
-
-### Cache Miss (cold compile)
-
-| Benchmark | Bare Compiler | sccache | zccache | vs sccache | vs bare |
-|:----------|-------------:|--------:|--------:|-----------:|--------:|
-| C++ single-file | 12.641s | 20.632s | 13.430s | 1.5x | 0.9x |
-| C++ multi-file | 11.358s | 11.759s | 12.867s | 0.9x | 0.9x |
-| C++ response-file (single) | 12.063s | 20.607s | 14.087s | 1.5x | 0.9x |
-| C++ response-file (multi) | 13.030s | 25.303s | 13.975s | 1.8x | 0.9x |
-| Rust build | 7.119s | 10.023s | 8.507s | 1.2x | 0.8x |
-| Rust check | 4.289s | 7.056s | 5.060s | 1.4x | 0.8x |
-
-<details>
-<summary>Benchmark details</summary>
-
-- **Single-file** = 50 sequential `clang++ -c unit.cpp` invocations
-- **Multi-file** = one `clang++ -c *.cpp` invocation (sccache cannot cache these — its "warm" time is a full recompile)
-- **Response-file** = args via nested `.rsp` files: 200 `-D` defines + 50 `-I` paths + 30 warning flags (~283 expanded args)
-- **Rust build** = `--emit=dep-info,metadata,link` (cargo build)
-- **Rust check** = `--emit=dep-info,metadata` (cargo check)
-- **Cold** = first compile (empty cache). **Warm** = median of 5 subsequent runs.
-- sccache gets cache hits but each hit still costs ~170ms subprocess overhead. zccache serves hits in ~1ms via in-process IPC.
-
-</details>
-
----
+The benchmark image is generated from the latest scheduled run and replaces
+hand-maintained text stats. Full results and machine-readable JSON are published
+at [zackees.github.io/zccache](https://zackees.github.io/zccache/). Run the same
+suite locally with `./perf`.
 
 ### Why is zccache so much faster on warm hits?
 

--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -482,6 +482,28 @@ def _font(size: int, bold: bool = False) -> Any:
     return ImageFont.load_default()
 
 
+def _truncate(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return value[: max(0, limit - 3)].rstrip() + "..."
+
+
+def build_image_rows(results: list[dict[str, Any]]) -> list[dict[str, str]]:
+    labels = {"c": "C", "c++": "C++", "rust": "Rust"}
+    return [
+        {
+            "language": labels.get(str(row["language"]), str(row["language"])),
+            "scenario": f"{row['benchmark_label']} - {row['scenario']}",
+            "bare": _format_seconds(row["bare_seconds"]),
+            "sccache": _format_seconds(row["sccache_seconds"]),
+            "zccache": _format_seconds(row["zccache_seconds"]),
+            "vs_sccache": _format_ratio(row["zccache_vs_sccache_ratio"]),
+            "vs_bare": _format_ratio(row["zccache_vs_bare_ratio"]),
+        }
+        for row in results
+    ]
+
+
 def render_jpg(payload: dict[str, Any], path: Path) -> None:
     try:
         from PIL import Image, ImageDraw
@@ -491,55 +513,70 @@ def render_jpg(payload: dict[str, Any], path: Path) -> None:
             "or `python -m pip install Pillow`."
         ) from exc
 
-    width, height = 1200, 630
+    rows = build_image_rows(payload["results"])
+    width = 1600
+    row_h = 44
+    table_y = 174
+    header_h = 44
+    footer_h = 90
+    height = max(760, table_y + header_h + row_h * max(1, len(rows)) + footer_h)
     image = Image.new("RGB", (width, height), "#f7f8f8")
     draw = ImageDraw.Draw(image)
-    title_font = _font(42, bold=True)
+    title_font = _font(44, bold=True)
     subtitle_font = _font(22)
-    header_font = _font(20, bold=True)
+    header_font = _font(19, bold=True)
     row_font = _font(18)
-    small_font = _font(15)
+    row_bold_font = _font(18, bold=True)
+    small_font = _font(16)
 
-    draw.rectangle((0, 0, width, 96), fill="#202426")
-    draw.text((42, 26), "zccache benchmark stats", font=title_font, fill="#ffffff")
+    draw.rectangle((0, 0, width, 108), fill="#202426")
+    draw.text((42, 28), "zccache benchmark stats", font=title_font, fill="#ffffff")
     metadata = payload["metadata"]
     sha = (metadata.get("git_sha") or "n/a")[:12]
     draw.text(
-        (42, 106),
+        (42, 120),
         f"Generated {metadata['generated_at']} | {metadata.get('git_ref') or 'n/a'} | {sha}",
         font=subtitle_font,
         fill="#38464b",
     )
 
-    warm_rows = [row for row in payload["results"] if row["mode"] == "warm"]
-    display_rows = warm_rows[:6]
-    x0, y0 = 42, 166
+    x0, y0 = 42, table_y
     table_w = width - 84
-    row_h = 54
-    headers = ["Scenario", "Bare", "sccache", "zccache", "vs sccache"]
-    widths = [430, 145, 145, 145, 220]
+    headers = ["Lang", "Scenario", "Bare", "sccache", "zccache", "vs sccache", "vs bare"]
+    widths = [96, 520, 145, 145, 145, 190, 190]
 
-    draw.rounded_rectangle((x0, y0, x0 + table_w, y0 + 42), radius=8, fill="#e9eef0")
-    x = x0 + 16
+    draw.rounded_rectangle((x0, y0, x0 + table_w, y0 + header_h), radius=8, fill="#dfe7ea")
+    x = x0 + 14
     for header, col_w in zip(headers, widths):
-        draw.text((x, y0 + 11), header, font=header_font, fill="#202426")
+        draw.text((x, y0 + 12), header, font=header_font, fill="#202426")
         x += col_w
 
-    y = y0 + 42
-    for index, row in enumerate(display_rows):
+    y = y0 + header_h
+    if not rows:
+        draw.rectangle((x0, y, x0 + table_w, y + row_h), fill="#ffffff")
+        draw.text(
+            (x0 + 14, y + 12),
+            "Benchmark data is not available yet.",
+            font=row_font,
+            fill="#202426",
+        )
+    for index, row in enumerate(rows):
         fill = "#ffffff" if index % 2 == 0 else "#f1f4f5"
         draw.rectangle((x0, y, x0 + table_w, y + row_h), fill=fill)
         values = [
-            f"{row['benchmark_label']} - {row['scenario']}",
-            _format_seconds(row["bare_seconds"]),
-            _format_seconds(row["sccache_seconds"]),
-            _format_seconds(row["zccache_seconds"]),
-            _format_ratio(row["zccache_vs_sccache_ratio"]),
+            row["language"],
+            _truncate(row["scenario"], 58),
+            row["bare"],
+            row["sccache"],
+            row["zccache"],
+            row["vs_sccache"],
+            row["vs_bare"],
         ]
-        x = x0 + 16
-        for value, col_w in zip(values, widths):
-            color = "#0f6b44" if value == values[3] else "#202426"
-            draw.text((x, y + 15), value[:44], font=row_font, fill=color)
+        x = x0 + 14
+        for column_index, (value, col_w) in enumerate(zip(values, widths)):
+            color = "#0f6b44" if column_index == 4 else "#202426"
+            font = row_bold_font if column_index in {0, 4} else row_font
+            draw.text((x, y + 12), value, font=font, fill=color)
             x += col_w
         y += row_h
 
@@ -551,8 +588,8 @@ def render_jpg(payload: dict[str, Any], path: Path) -> None:
         )
     else:
         line = "Benchmark data is not available yet."
-    draw.rounded_rectangle((42, height - 92, width - 42, height - 34), radius=8, fill="#202426")
-    draw.text((62, height - 75), line[:118], font=small_font, fill="#ffffff")
+    draw.rounded_rectangle((42, height - 72, width - 42, height - 24), radius=8, fill="#202426")
+    draw.text((62, height - 57), _truncate(line, 150), font=small_font, fill="#ffffff")
 
     path.parent.mkdir(parents=True, exist_ok=True)
     image.save(path, format="JPEG", quality=90, optimize=True)

--- a/ci/tests/test_benchmark_stats.py
+++ b/ci/tests/test_benchmark_stats.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ci import benchmark_stats
 
 
@@ -76,3 +78,45 @@ def test_render_html_links_json_stats():
     assert 'href="latest.json"' in html
     assert 'src="benchmark.jpg"' in html
     assert "Rust rustc" in html
+
+
+def test_image_rows_cover_c_cpp_and_rust_stats():
+    rows = benchmark_stats.parse_benchmark_log(SAMPLE_LOG)
+    image_rows = benchmark_stats.build_image_rows(rows)
+
+    assert {row["language"] for row in image_rows} == {"C", "C++", "Rust"}
+    assert any("C inline args - Single-file, Warm" == row["scenario"] for row in image_rows)
+    assert any(
+        "C++ response files - Single-file RSP, Cold" == row["scenario"]
+        for row in image_rows
+    )
+    assert any("Rust rustc - Build, Warm" == row["scenario"] for row in image_rows)
+
+
+def test_write_outputs_creates_timestamped_benchmark_image(tmp_path):
+    pytest.importorskip("PIL")
+    rows = benchmark_stats.parse_benchmark_log(SAMPLE_LOG)
+    payload = benchmark_stats.build_payload(
+        rows,
+        {
+            "generated_at": "2026-05-13T00:00:00+00:00",
+            "repository": "zackees/zccache",
+            "git_sha": "abcdef1234567890",
+            "git_ref": "main",
+            "run_url": "https://example.invalid/run",
+            "runner": {"platform": "test", "os": "test", "arch": "x64", "cpu_count": 1},
+            "versions": {"soldr": None, "rustc": None, "clang": None, "sccache": None},
+            "benchmark_command": "soldr --no-cache cargo test ...",
+            "pages_url": "https://zackees.github.io/zccache/",
+            "raw_image_url": (
+                "https://raw.githubusercontent.com/zackees/zccache/"
+                "benchmark-stats/benchmark.jpg"
+            ),
+        },
+    )
+
+    benchmark_stats.write_outputs(payload, tmp_path)
+
+    assert (tmp_path / "latest.json").is_file()
+    assert (tmp_path / "index.html").is_file()
+    assert (tmp_path / "benchmark.jpg").stat().st_size > 0


### PR DESCRIPTION
## Summary
- Replace README static benchmark tables with the generated benchmark image/report link.
- Render the benchmark JPG as a timestamped C/C++/Rust table from the JSON payload.
- Add tests for image row coverage and generated benchmark artifacts.

## Direct branch push
- Seeded `benchmark-stats` directly with `.nojekyll`, `index.html`, `latest.json`, and `benchmark.jpg`.
- Stable image URL: https://raw.githubusercontent.com/zackees/zccache/benchmark-stats/benchmark.jpg

Closes #213

## Tests
- `uv run --with pytest --with pillow pytest ci\tests\test_benchmark_stats.py ci\tests\test_perf_guard.py`
- `python -m py_compile ci\benchmark_stats.py ci\tests\test_benchmark_stats.py`
- `git diff --check`