### PR TITLE
ci: share perf guard benchmark binary

### DIFF
--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -21,9 +21,53 @@ permissions:
   contents: read
 
 jobs:
+  build-perf-benchmark:
+    name: Build perf benchmark binary
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: zackees/setup-soldr@v0
+        with:
+          cache: false
+          build-cache: false
+          target-cache: false
+
+      - name: Build perf benchmark binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          soldr --no-cache cargo test -p zccache-daemon --test perf_bench_test --no-run
+          bench_bin="$(
+            find target/debug/deps \
+              -maxdepth 1 \
+              -type f \
+              -name 'perf_bench_test-*' \
+              -perm -111 \
+              | head -n 1
+          )"
+          if [[ -z "$bench_bin" ]]; then
+            echo "perf_bench_test binary was not found" >&2
+            exit 1
+          fi
+          mkdir -p perf-guard-bin
+          cp "$bench_bin" perf-guard-bin/perf_bench_test
+          chmod +x perf-guard-bin/perf_bench_test
+
+      - name: Upload perf benchmark binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-guard-binary
+          path: perf-guard-bin/perf_bench_test
+          if-no-files-found: error
+
   perf-guard:
     name: ${{ matrix.label }} speed floor
     if: github.ref == 'refs/heads/main'
+    needs: build-perf-benchmark
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
@@ -60,6 +104,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang
 
+      - name: Download perf benchmark binary
+        uses: actions/download-artifact@v7
+        with:
+          name: perf-guard-binary
+          path: perf-guard-bin
+
+      - name: Prepare perf benchmark binary
+        shell: bash
+        run: chmod +x perf-guard-bin/perf_bench_test
+
       - name: Run perf regression guard
         shell: bash
         run: |
@@ -70,6 +124,7 @@ jobs:
             --bare-threshold 1.5 \
             --sccache-threshold 1.5 \
             --attempts 3 \
+            --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
             --output-dir perf-guard-output
 
       - name: Upload perf guard artifacts

--- a/ci/perf_guard.py
+++ b/ci/perf_guard.py
@@ -68,13 +68,35 @@ class GuardReport:
         )
 
 
-def _benchmark_commands(language: str | None) -> list[list[str]]:
+def _benchmark_binary_command(benchmark_binary: Path, test_name: str | None = None) -> list[str]:
+    command = [str(benchmark_binary)]
+    if test_name is not None:
+        command.append(test_name)
+    command.extend(["--nocapture", "--ignored", "--test-threads=1"])
+    return command
+
+
+def _benchmark_commands(
+    language: str | None,
+    benchmark_binary: Path | None = None,
+) -> list[list[str]]:
+    if benchmark_binary is not None:
+        if language is None:
+            return [_benchmark_binary_command(benchmark_binary)]
+        return [
+            _benchmark_binary_command(benchmark_binary, test_name)
+            for test_name in benchmark_stats.BENCHMARK_TESTS_BY_LANGUAGE[language]
+        ]
     if language is None:
         return [benchmark_stats.BENCHMARK_COMMAND]
     return benchmark_stats.benchmark_commands_for_language(language)
 
 
-def run_benchmarks_once(log_path: Path, language: str | None = None) -> tuple[int, str]:
+def run_benchmarks_once(
+    log_path: Path,
+    language: str | None = None,
+    benchmark_binary: Path | None = None,
+) -> tuple[int, str]:
     cache_dir = Path(tempfile.mkdtemp(prefix="zccache-perf-guard-cache-"))
     env = os.environ.copy()
     env["ZCCACHE_CACHE_DIR"] = str(cache_dir)
@@ -83,7 +105,7 @@ def run_benchmarks_once(log_path: Path, language: str | None = None) -> tuple[in
     try:
         outputs: list[str] = []
         returncode = 0
-        for command in _benchmark_commands(language):
+        for command in _benchmark_commands(language, benchmark_binary):
             result = subprocess.run(
                 command,
                 cwd=REPO_ROOT,
@@ -329,6 +351,7 @@ def _run_attempts(
     sccache_threshold: float,
     languages: tuple[str, ...],
     benchmark_language: str | None,
+    benchmark_binary: Path | None,
 ) -> tuple[list[list[dict[str, Any]]], list[int]]:
     parsed_attempts: list[list[dict[str, Any]]] = []
     command_failures: list[int] = []
@@ -336,7 +359,7 @@ def _run_attempts(
     for attempt in range(1, attempts + 1):
         log_path = output_dir / f"attempt-{attempt}.log"
         print(f"=== Perf guard attempt {attempt}/{attempts} ===")
-        returncode, output = run_benchmarks_once(log_path, benchmark_language)
+        returncode, output = run_benchmarks_once(log_path, benchmark_language, benchmark_binary)
         rows = benchmark_stats.parse_benchmark_log(output)
         parsed_attempts.append(rows)
         write_attempt_json(
@@ -344,7 +367,7 @@ def _run_attempts(
             attempt,
             rows,
             returncode,
-            source="benchmark-run",
+            source="benchmark-binary" if benchmark_binary else "benchmark-run",
             language=benchmark_language,
         )
         if returncode != 0:
@@ -373,6 +396,11 @@ def main() -> int:
     parser.add_argument("--sccache-threshold", type=float, default=DEFAULT_SCCACHE_THRESHOLD)
     parser.add_argument("--attempts", type=int, default=DEFAULT_ATTEMPTS)
     parser.add_argument(
+        "--benchmark-binary",
+        type=Path,
+        help="Run a prebuilt perf_bench_test binary instead of invoking cargo test.",
+    )
+    parser.add_argument(
         "--language",
         choices=REQUIRED_LANGUAGES,
         help="Run and require only one benchmark language.",
@@ -390,6 +418,10 @@ def main() -> int:
         parser.error("--attempts must be at least 1")
     if bool(args.input_log) == bool(args.run_benchmarks):
         parser.error("use exactly one of --input-log or --run-benchmarks")
+    if args.benchmark_binary and not args.run_benchmarks:
+        parser.error("--benchmark-binary requires --run-benchmarks")
+    if args.benchmark_binary and not args.benchmark_binary.is_file():
+        parser.error(f"--benchmark-binary does not exist: {args.benchmark_binary}")
 
     languages = (args.language,) if args.language else REQUIRED_LANGUAGES
     args.output_dir.mkdir(parents=True, exist_ok=True)
@@ -412,6 +444,7 @@ def main() -> int:
             args.sccache_threshold,
             languages,
             args.language,
+            args.benchmark_binary,
         )
 
     report = evaluate_attempts(

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 from ci import benchmark_stats, perf_guard
 
@@ -203,3 +204,24 @@ def test_benchmark_language_commands_are_filtered():
         "perf_response_file",
     ]
     assert [command[-4] for command in rust_commands] == ["perf_rustc_zccache_vs_sccache"]
+
+
+def test_prebuilt_benchmark_binary_commands_are_filtered():
+    commands = perf_guard._benchmark_commands("c++", Path("perf_bench_test"))
+
+    assert commands == [
+        [
+            "perf_bench_test",
+            "perf_warm_cache_zccache_vs_sccache",
+            "--nocapture",
+            "--ignored",
+            "--test-threads=1",
+        ],
+        [
+            "perf_bench_test",
+            "perf_response_file",
+            "--nocapture",
+            "--ignored",
+            "--test-threads=1",
+        ],
+    ]


### PR DESCRIPTION
## Summary
- build the perf benchmark test binary once in a dedicated perf guard job
- upload the binary and reuse it from each language matrix job
- let ci.perf_guard run a prebuilt benchmark binary while preserving per-language test filters

Refs #210

## Test plan
- [x] python -m pytest ci/tests/test_perf_guard.py
- [x] ./lint
- [x] parsed .github/workflows/perf-guard.yml with PyYAML