### PR TITLE
feat(daemon): add compiler child priority policy

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,6 @@
+# Codex Hooks
+
+Local Codex hook configuration for this repository.
+
+`hooks.json` mirrors `.claude/settings.json` for the shared PreToolUse guard in
+`ci/hooks/tool_guard.py`.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run python ci/hooks/tool_guard.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3516,6 +3516,7 @@ dependencies = [
  "clap",
  "dashmap",
  "filetime",
+ "libc",
  "mimalloc",
  "rayon",
  "serde",

--- a/README.md
+++ b/README.md
@@ -287,6 +287,23 @@ Checked flags include `-I`, `-isystem`, `-iquote`, `-idirafter`, `-include`,
 `-include-pch`, `-imacros`, `-F`, `-iframework`, `-imsvc`, and MSVC `/I`.
 Response-file arguments are checked after expansion by the daemon.
 
+### Compiler child priority
+
+Compiler and linker subprocesses run with `ZCCACHE_COMPILE_PRIORITY=low` by
+default so interactive work stays responsive while cache misses compile in the
+background. Set the variable on the build command or in the daemon environment
+to override it:
+
+| Value | Behavior |
+|-------|----------|
+| `low` | Default. Lower compiler priority (`nice +10` on Unix/macOS, `BELOW_NORMAL_PRIORITY_CLASS` on Windows). |
+| `normal` | Preserve the inherited process priority for maximum throughput. |
+| `idle` | More conservative background mode (`nice +19` on Unix/macOS, `IDLE_PRIORITY_CLASS` on Windows). |
+| `high` | Higher-priority mode for real-time benchmarking (`nice -5` on Unix/macOS where permitted, `HIGH_PRIORITY_CLASS` on Windows). |
+
+Unsupported priority changes fail soft with a daemon log message and do not
+break compilation. Invalid values warn and fall back to `low`.
+
 <details>
 <summary>Bash integration</summary>
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -24,7 +24,7 @@ Python scripts for development tooling. Rust commands go through `soldr <tool>` 
 
 ## Hooks (`ci/hooks/`)
 
-Claude Code hooks that enforce project conventions:
+Claude Code and Codex hooks that enforce project conventions:
 
 - **tool_guard.py** - PreToolUse: blocks bare `cargo`/`rustc`, legacy root trampolines, and `uv run cargo`/`uv run rustc` (must use `soldr`) and bare `python`/`pip` (must use `uv`)
 - **lint.py** - PostToolUse: auto-formats + runs clippy on edited `.rs` files

--- a/ci/env.py
+++ b/ci/env.py
@@ -18,7 +18,10 @@ def clean_env() -> dict[str, str]:
 def rustc_host() -> str | None:
     soldr = shutil.which("soldr")
     if soldr is None:
-        raise FileNotFoundError("Cannot find soldr. Run `uv sync` or ./install.")
+        raise FileNotFoundError(
+            "Cannot find soldr on PATH. Install the global soldr tool before "
+            "running Rust development commands."
+        )
 
     result = subprocess.run(
         [soldr, "--no-cache", "rustc", "-vV"],

--- a/ci/hooks/README.md
+++ b/ci/hooks/README.md
@@ -1,5 +1,6 @@
-# Claude Code Hooks
+# Agent Hooks
 
-Python scripts invoked by Claude Code hooks (configured in `.claude/settings.json`).
+Python scripts invoked by Claude Code and Codex hooks. Claude Code loads
+`.claude/settings.json`; Codex loads `.codex/hooks.json`.
 
 All hooks are executed via `uv run` to ensure consistent Python environment.

--- a/ci/soldr.py
+++ b/ci/soldr.py
@@ -17,8 +17,8 @@ def soldr_executable() -> str:
     soldr = shutil.which("soldr")
     if soldr is None:
         print(
-            "error: `soldr` not found on PATH. Run `uv sync` (or ./install) "
-            "to install the dev dependencies.",
+            "error: `soldr` not found on PATH. Install the global soldr tool "
+            "before running Rust development commands.",
             file=sys.stderr,
         )
         raise SystemExit(1)

--- a/crates/zccache-daemon/Cargo.toml
+++ b/crates/zccache-daemon/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemallocator = { workspace = true }
+libc = "0.2"
 
 [[bin]]
 name = "zccache-daemon"

--- a/crates/zccache-daemon/src/process.rs
+++ b/crates/zccache-daemon/src/process.rs
@@ -9,9 +9,110 @@ use std::sync::OnceLock;
 #[cfg(windows)]
 use std::os::windows::io::AsRawHandle;
 
-/// Wait for a synchronous command while registering it with the daemon's
-/// platform process group/container when supported.
-pub(crate) fn command_output(cmd: &mut std::process::Command) -> io::Result<Output> {
+pub(crate) const COMPILE_PRIORITY_ENV: &str = "ZCCACHE_COMPILE_PRIORITY";
+
+/// Priority policy for compiler/linker child processes owned by the daemon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompilePriority {
+    Normal,
+    Low,
+    Idle,
+    High,
+}
+
+impl Default for CompilePriority {
+    fn default() -> Self {
+        Self::Low
+    }
+}
+
+impl CompilePriority {
+    pub(crate) fn parse(value: &str) -> Result<Self, CompilePriorityParseError> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "normal" => Ok(Self::Normal),
+            "low" => Ok(Self::Low),
+            "idle" => Ok(Self::Idle),
+            "high" => Ok(Self::High),
+            other => Err(CompilePriorityParseError {
+                value: other.to_string(),
+            }),
+        }
+    }
+
+    pub(crate) fn from_client_env(env: Option<&[(String, String)]>) -> Self {
+        if let Some(value) = env.and_then(|vars| {
+            vars.iter()
+                .find(|(key, _)| key == COMPILE_PRIORITY_ENV)
+                .map(|(_, value)| value.as_str())
+        }) {
+            return Self::parse_or_warn(value);
+        }
+
+        match std::env::var(COMPILE_PRIORITY_ENV) {
+            Ok(value) => Self::parse_or_warn(&value),
+            Err(_) => Self::Low,
+        }
+    }
+
+    fn parse_or_warn(value: &str) -> Self {
+        match Self::parse(value) {
+            Ok(priority) => priority,
+            Err(e) => {
+                tracing::warn!(
+                    env = COMPILE_PRIORITY_ENV,
+                    value = %e.value,
+                    "invalid compiler child priority; using low"
+                );
+                Self::Low
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn parse_optional(value: Option<&str>) -> Result<Self, CompilePriorityParseError> {
+        match value {
+            Some(value) => Self::parse(value),
+            None => Ok(Self::Low),
+        }
+    }
+
+    #[cfg(unix)]
+    fn unix_nice_value(self) -> Option<i32> {
+        match self {
+            Self::Normal => None,
+            Self::Low => Some(10),
+            Self::Idle => Some(19),
+            // Higher priorities commonly require extra privileges; failures are
+            // logged and compilation continues at the inherited priority.
+            Self::High => Some(-5),
+        }
+    }
+
+    #[cfg(windows)]
+    fn windows_priority_class(self) -> Option<u32> {
+        use windows_sys::Win32::System::Threading::{
+            BELOW_NORMAL_PRIORITY_CLASS, HIGH_PRIORITY_CLASS, IDLE_PRIORITY_CLASS,
+        };
+
+        match self {
+            Self::Normal => None,
+            Self::Low => Some(BELOW_NORMAL_PRIORITY_CLASS),
+            Self::Idle => Some(IDLE_PRIORITY_CLASS),
+            Self::High => Some(HIGH_PRIORITY_CLASS),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CompilePriorityParseError {
+    value: String,
+}
+
+/// Wait for a synchronous command after applying a compiler child priority.
+pub(crate) fn command_output_with_priority(
+    cmd: &mut std::process::Command,
+    priority: CompilePriority,
+) -> io::Result<Output> {
     #[cfg(windows)]
     {
         use std::process::Stdio;
@@ -21,18 +122,39 @@ pub(crate) fn command_output(cmd: &mut std::process::Command) -> io::Result<Outp
         cmd.stderr(Stdio::piped());
         let child = cmd.spawn()?;
         assign_child_to_daemon_job(child.as_raw_handle());
+        apply_priority_to_child_windows(child.as_raw_handle(), priority);
         child.wait_with_output()
     }
 
-    #[cfg(not(windows))]
+    #[cfg(unix)]
     {
+        use std::process::Stdio;
+
+        cmd.stdin(Stdio::null());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        let child = cmd.spawn()?;
+        apply_priority_to_child_unix(child.id(), priority);
+        child.wait_with_output()
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        if priority != CompilePriority::Normal {
+            tracing::debug!(
+                ?priority,
+                "compiler child priority is unsupported on this platform"
+            );
+        }
         cmd.output()
     }
 }
 
-/// Wait for an async command while registering it with the daemon's platform
-/// process group/container when supported.
-pub(crate) async fn tokio_command_output(cmd: &mut tokio::process::Command) -> io::Result<Output> {
+/// Wait for an async command after applying a compiler child priority.
+pub(crate) async fn tokio_command_output_with_priority(
+    cmd: &mut tokio::process::Command,
+    priority: CompilePriority,
+) -> io::Result<Output> {
     #[cfg(windows)]
     {
         use std::process::Stdio;
@@ -43,11 +165,26 @@ pub(crate) async fn tokio_command_output(cmd: &mut tokio::process::Command) -> i
         let child = cmd.spawn()?;
         if let Some(handle) = child.raw_handle() {
             assign_child_to_daemon_job(handle);
+            apply_priority_to_child_windows(handle, priority);
         }
         child.wait_with_output().await
     }
 
-    #[cfg(not(windows))]
+    #[cfg(unix)]
+    {
+        use std::process::Stdio;
+
+        cmd.stdin(Stdio::null());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        let child = cmd.spawn()?;
+        if let Some(pid) = child.id() {
+            apply_priority_to_child_unix(pid, priority);
+        }
+        child.wait_with_output().await
+    }
+
+    #[cfg(not(any(unix, windows)))]
     {
         cmd.output().await
     }
@@ -61,6 +198,45 @@ fn assign_child_to_daemon_job(raw_handle: std::os::windows::io::RawHandle) {
 
     if let Err(e) = job.assign(raw_handle) {
         tracing::debug!("failed to assign child process to daemon job: {e}");
+    }
+}
+
+#[cfg(unix)]
+fn apply_priority_to_child_unix(pid: u32, priority: CompilePriority) {
+    let Some(nice) = priority.unix_nice_value() else {
+        return;
+    };
+
+    let rc = unsafe { libc::setpriority(libc::PRIO_PROCESS, pid as libc::id_t, nice) };
+    if rc != 0 {
+        tracing::debug!(
+            ?priority,
+            pid,
+            nice,
+            error = %io::Error::last_os_error(),
+            "failed to set compiler child priority"
+        );
+    }
+}
+
+#[cfg(windows)]
+fn apply_priority_to_child_windows(
+    raw_handle: std::os::windows::io::RawHandle,
+    priority: CompilePriority,
+) {
+    let Some(priority_class) = priority.windows_priority_class() else {
+        return;
+    };
+
+    use windows_sys::Win32::System::Threading::SetPriorityClass;
+
+    let ok = unsafe { SetPriorityClass(raw_handle.cast::<std::ffi::c_void>(), priority_class) };
+    if ok == 0 {
+        tracing::debug!(
+            ?priority,
+            error = %io::Error::last_os_error(),
+            "failed to set compiler child priority"
+        );
     }
 }
 
@@ -148,3 +324,83 @@ unsafe impl Send for WindowsJob {}
 
 #[cfg(windows)]
 unsafe impl Sync for WindowsJob {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_compile_priority_values() {
+        assert_eq!(
+            CompilePriority::parse("normal").unwrap(),
+            CompilePriority::Normal
+        );
+        assert_eq!(CompilePriority::parse("LOW").unwrap(), CompilePriority::Low);
+        assert_eq!(
+            CompilePriority::parse(" idle ").unwrap(),
+            CompilePriority::Idle
+        );
+        assert_eq!(
+            CompilePriority::parse("high").unwrap(),
+            CompilePriority::High
+        );
+        assert!(CompilePriority::parse("fast").is_err());
+    }
+
+    #[test]
+    fn absent_compile_priority_defaults_to_low() {
+        assert_eq!(
+            CompilePriority::parse_optional(None).unwrap(),
+            CompilePriority::Low
+        );
+    }
+
+    #[test]
+    fn client_env_selects_high_mode() {
+        let env = vec![(COMPILE_PRIORITY_ENV.to_string(), "high".to_string())];
+        assert_eq!(
+            CompilePriority::from_client_env(Some(&env)),
+            CompilePriority::High
+        );
+    }
+
+    #[test]
+    fn client_env_invalid_value_falls_back_to_low() {
+        let env = vec![(COMPILE_PRIORITY_ENV.to_string(), "fast".to_string())];
+        assert_eq!(
+            CompilePriority::from_client_env(Some(&env)),
+            CompilePriority::Low
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_priority_mapping_is_explicit() {
+        assert_eq!(CompilePriority::Normal.unix_nice_value(), None);
+        assert_eq!(CompilePriority::Low.unix_nice_value(), Some(10));
+        assert_eq!(CompilePriority::Idle.unix_nice_value(), Some(19));
+        assert_eq!(CompilePriority::High.unix_nice_value(), Some(-5));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_priority_mapping_is_explicit() {
+        use windows_sys::Win32::System::Threading::{
+            BELOW_NORMAL_PRIORITY_CLASS, HIGH_PRIORITY_CLASS, IDLE_PRIORITY_CLASS,
+        };
+
+        assert_eq!(CompilePriority::Normal.windows_priority_class(), None);
+        assert_eq!(
+            CompilePriority::Low.windows_priority_class(),
+            Some(BELOW_NORMAL_PRIORITY_CLASS)
+        );
+        assert_eq!(
+            CompilePriority::Idle.windows_priority_class(),
+            Some(IDLE_PRIORITY_CLASS)
+        );
+        assert_eq!(
+            CompilePriority::High.windows_priority_class(),
+            Some(HIGH_PRIORITY_CLASS)
+        );
+    }
+}

--- a/crates/zccache-daemon/src/process.rs
+++ b/crates/zccache-daemon/src/process.rs
@@ -12,18 +12,13 @@ use std::os::windows::io::AsRawHandle;
 pub(crate) const COMPILE_PRIORITY_ENV: &str = "ZCCACHE_COMPILE_PRIORITY";
 
 /// Priority policy for compiler/linker child processes owned by the daemon.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) enum CompilePriority {
     Normal,
+    #[default]
     Low,
     Idle,
     High,
-}
-
-impl Default for CompilePriority {
-    fn default() -> Self {
-        Self::Low
-    }
 }
 
 impl CompilePriority {

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -21,6 +21,7 @@ use zccache_watcher::{NotifyWatcher, SettleBuffer, SettledEvent};
 
 use crate::compile_journal::{extract_outcome, CompileJournal, JournalContext, JournalEntry};
 use crate::fingerprint::FingerprintManager;
+use crate::process::CompilePriority;
 use crate::stats::{HitPhases, MissPhases, PhaseProfiler, StatsCollector};
 
 /// RAII guard that decrements `in_flight_bytes` on drop, even during panic unwind.
@@ -1845,7 +1846,8 @@ async fn run_tool_passthrough(
 
     apply_client_env_sync(&mut cmd, env.as_deref(), lineage);
 
-    match crate::process::command_output(&mut cmd) {
+    let priority = CompilePriority::from_client_env(env.as_deref());
+    match crate::process::command_output_with_priority(&mut cmd, priority) {
         Ok(output) => Response::LinkResult {
             exit_code: output.status.code().unwrap_or(1),
             stdout: Arc::new(output.stdout),
@@ -1927,7 +1929,8 @@ async fn run_post_link_deploy_hook(
         "running post-link deploy hook"
     );
 
-    match crate::process::command_output(&mut cmd) {
+    let priority = CompilePriority::from_client_env(env);
+    match crate::process::command_output_with_priority(&mut cmd, priority) {
         Ok(out) if out.status.success() => {
             tracing::debug!(
                 program = %program,
@@ -3133,6 +3136,7 @@ async fn handle_compile(
 
     // Discover system includes for this compiler (cached per compiler path)
     let t_system_includes = std::time::Instant::now();
+    let compiler_priority = CompilePriority::from_client_env(client_env.as_deref());
     let system_includes = {
         let mut cache = state.system_includes.lock().await;
         let lineage_for_probe = lineage.clone();
@@ -3143,7 +3147,7 @@ async fn handle_compile(
                     let mut cmd = std::process::Command::new(c);
                     cmd.args(&disc_args);
                     lineage_for_probe.apply_to_sync(&mut cmd, None);
-                    crate::process::command_output(&mut cmd)
+                    crate::process::command_output_with_priority(&mut cmd, compiler_priority)
                 };
                 match output {
                     Ok(out) => {
@@ -3738,7 +3742,9 @@ async fn handle_compile(
     }
     apply_client_env(&mut cmd, &client_env, &lineage);
     let t_compiler_process = std::time::Instant::now();
-    let result = crate::process::tokio_command_output(&mut cmd).await;
+    let compiler_priority = CompilePriority::from_client_env(client_env.as_deref());
+    let result =
+        crate::process::tokio_command_output_with_priority(&mut cmd, compiler_priority).await;
     let compiler_process_ns = t_compiler_process.elapsed().as_nanos() as u64;
 
     let output = match result {
@@ -4798,7 +4804,9 @@ async fn handle_compile_multi(
         cmd.args(&compiler_args).current_dir(&cwd_path);
     }
     apply_client_env(&mut cmd, &client_env, &lineage);
-    let result = crate::process::tokio_command_output(&mut cmd).await;
+    let compiler_priority = CompilePriority::from_client_env(client_env.as_deref());
+    let result =
+        crate::process::tokio_command_output_with_priority(&mut cmd, compiler_priority).await;
 
     let output = match result {
         Ok(o) => o,
@@ -5054,7 +5062,9 @@ async fn run_compiler_direct(
         cmd.args(args).current_dir(cwd);
     }
     apply_client_env(&mut cmd, client_env, &lineage);
-    let result = crate::process::tokio_command_output(&mut cmd).await;
+    let compiler_priority = CompilePriority::from_client_env(client_env.as_deref());
+    let result =
+        crate::process::tokio_command_output_with_priority(&mut cmd, compiler_priority).await;
 
     match result {
         Ok(output) => {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 dependencies = []
 
 [dependency-groups]
-dev = ["pillow>=11.0", "soldr>=0.7.18"]
+dev = ["pillow>=11.0"]
 
 [project.scripts]
 run_zccache = "ci.soldr:run_zccache"


### PR DESCRIPTION
## Summary

- Add `ZCCACHE_COMPILE_PRIORITY=normal|low|idle|high` for daemon-owned compiler/linker child processes.
- Default to `low` unconditionally, with explicit Unix/macOS nice values and Windows priority classes.
- Apply the policy through centralized process helpers used by compile misses, multi-file misses, direct passthrough compiles, include discovery, linker passthrough, and post-link hooks.
- Add Codex PreToolUse hook config mirroring the existing Claude hook so future agent Rust commands are forced through `soldr` instead of bare GNU-host cargo.
- Document the env var, default, values, and platform mappings.

Closes #216.

## Test Plan

- [x] `soldr --no-cache rustc -vV` (confirmed `host: x86_64-pc-windows-msvc`)
- [x] `soldr cargo fmt --all --check`
- [x] `soldr cargo test -p zccache-daemon --lib`
- [x] `soldr cargo test -p zccache-daemon process::tests --lib`
- [x] `soldr cargo clippy -p zccache-daemon --all-targets -- -D warnings`
- [x] `git diff --check`

Full `bash lint` still fails in this nested `.claude/worktrees/...` checkout while formatting the excluded dylint crate: Cargo resolves `dylints/ban_std_pathbuf` against the parent checkout workspace at `C:\Users\niteris\dev\zccache\Cargo.toml`. The changed daemon crate passes fmt, tests, and clippy through `soldr` with the MSVC host.