### PR TITLE
feat: add worktree-aware cache sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,51 @@ daemon state, and the default daemon endpoint. Separate cache roots therefore
 use separate daemon instances unless `ZCCACHE_ENDPOINT` is explicitly set.
 Relative override paths are normalized against the current working directory.
 
+### Worktree cache sharing
+
+zccache can share cache entries across sibling Git worktrees when the compile is
+equivalent. This targets multi-agent workflows where several checkouts of the
+same repository build the same Rust crates under different absolute paths. The
+daemon detects the enclosing Git root for each compile request, normalizes
+project-local source, dependency, cwd, and safe path arguments relative to that
+root, and writes cache hits back to the output paths requested by the current
+worktree.
+
+Set `ZCCACHE_WORKTREE_ROOT` when automatic Git-root detection is not reliable
+or when a wrapper/test needs to define the normalization root explicitly:
+
+```bash
+export ZCCACHE_WORKTREE_ROOT="$PWD"
+RUSTC_WRAPPER=zccache cargo build
+```
+
+The override should point at the logical project root shared by equivalent
+worktrees. Paths under that root may be normalized for cache identity. Paths
+outside that root remain absolute unless zccache has a specific safe rule for
+them, so toolchain files, sysroots, generated files outside the checkout, and
+other external inputs do not accidentally become shared.
+
+Worktree sharing is intentionally conservative. If zccache cannot prove that a
+compile is root-equivalent, it falls back to the existing path-specific cache key
+or records a miss. Diagnostics and session logs distinguish normal same-root
+hits from worktree-equivalent hits and report conservative reasons such as:
+
+- `git_root_unavailable` - no Git root and no explicit `ZCCACHE_WORKTREE_ROOT`.
+- `path_outside_root` - an input path is outside the detected/overridden root.
+- `path_sensitive_arg` - flags such as `--remap-path-prefix`, debug path flags,
+  or unknown absolute path-bearing options could affect emitted output.
+- `content_hash_mismatch` - root-relative paths match but file contents differ.
+- `toolchain_mismatch` - the compiler or relevant toolchain inputs differ.
+- `unsupported_language` - the invocation is not covered by the worktree-aware
+  normalization rules.
+
+The supported worktree-equivalent paths are Rust `rustc` compilation, including
+dependency artifacts used through `--extern`, and C/C++ compilation through the
+existing depgraph context/artifact keys. The request-level fast path only serves
+cross-root hits after validating the current worktree's recorded input hashes;
+otherwise zccache falls back to the normal depgraph check or a path-specific
+miss.
+
 ### Strict path validation
 
 Use `--strict-paths` or `ZCCACHE_STRICT_PATHS` to fail fast when compiler path

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -58,6 +58,8 @@ const EPHEMERAL_CACHE_MAX_AGE: std::time::Duration = std::time::Duration::from_s
 const REQUEST_CACHE_MAX_ENTRIES: usize = 4096;
 const RSP_CACHE_MAX_ENTRIES: usize = 1024;
 const RUST_MISS_PROFILE_ENV: &str = "ZCCACHE_PROFILE_RUST_MISS";
+const WORKTREE_ROOT_ENV: &str = "ZCCACHE_WORKTREE_ROOT";
+const REQUEST_ROOT_MARKER: &str = "$ZCCACHE_WORKTREE_ROOT";
 
 #[derive(Clone)]
 struct RspDependency {
@@ -389,9 +391,42 @@ struct SharedState {
 /// Pre-computed compile request data for the request-level fast path.
 struct RequestCacheEntry {
     context_key: ContextKey,
-    source_path: NormalizedPath,
-    output_path: NormalizedPath,
+    root: Option<NormalizedPath>,
+    source_path: CachedRequestPath,
+    output_path: CachedRequestPath,
+    input_paths: Vec<CachedRequestPath>,
+    cross_root_shareable: bool,
     cached_at: std::time::Instant,
+}
+
+#[derive(Clone)]
+enum CachedRequestPath {
+    RootRelative(NormalizedPath),
+    Absolute(NormalizedPath),
+}
+
+impl CachedRequestPath {
+    fn capture(path: &Path, key_root: Option<&Path>) -> Self {
+        if let Some(root) = key_root {
+            if let Ok(relative) = path.strip_prefix(root) {
+                return Self::RootRelative(NormalizedPath::new(relative));
+            }
+        }
+        Self::Absolute(NormalizedPath::new(path))
+    }
+
+    fn resolve(&self, key_root: Option<&Path>) -> NormalizedPath {
+        match (self, key_root) {
+            (Self::RootRelative(relative), Some(root)) => root.join(relative).into(),
+            (Self::RootRelative(relative), None) | (Self::Absolute(relative), _) => {
+                relative.clone()
+            }
+        }
+    }
+
+    fn is_root_relative(&self) -> bool {
+        matches!(self, Self::RootRelative(_))
+    }
 }
 
 /// The daemon server that listens for IPC connections.
@@ -2958,25 +2993,226 @@ fn context_files_fresh(
     true
 }
 
+fn client_env_value<'a>(client_env: Option<&'a [(String, String)]>, name: &str) -> Option<&'a str> {
+    client_env?
+        .iter()
+        .find_map(|(key, value)| (key == name).then_some(value.as_str()))
+        .filter(|value| !value.is_empty())
+}
+
+fn resolve_worktree_root(
+    cwd: &Path,
+    client_env: Option<&[(String, String)]>,
+) -> Option<NormalizedPath> {
+    if let Some(value) = client_env_value(client_env, WORKTREE_ROOT_ENV) {
+        let configured = Path::new(value);
+        let root = if configured.is_absolute() {
+            configured.to_path_buf()
+        } else {
+            cwd.join(configured)
+        };
+        if root.is_dir() {
+            return Some(root.into());
+        }
+    }
+
+    find_git_root(cwd)
+}
+
+fn find_git_root(cwd: &Path) -> Option<NormalizedPath> {
+    for candidate in cwd.ancestors() {
+        let dot_git = candidate.join(".git");
+        if dot_git.is_dir() || dot_git.is_file() {
+            return Some(candidate.into());
+        }
+    }
+    None
+}
+
+fn normalize_path_for_request_key(path: &Path, key_root: Option<&Path>) -> String {
+    if let Some(root) = key_root {
+        if let Ok(relative) = path.strip_prefix(root) {
+            let relative = zccache_core::path::normalize_for_key(relative);
+            if relative.is_empty() {
+                return REQUEST_ROOT_MARKER.to_string();
+            }
+            return format!("{REQUEST_ROOT_MARKER}/{relative}");
+        }
+    }
+    zccache_core::path::normalize_for_key(path)
+}
+
+fn normalize_request_path_value(value: &str, key_root: Option<&Path>) -> Option<String> {
+    let path = Path::new(value);
+    if path.is_absolute() {
+        return Some(normalize_path_for_request_key(path, key_root));
+    }
+    None
+}
+
+fn normalize_request_arg(arg: &str, key_root: Option<&Path>) -> String {
+    let Some(root) = key_root else {
+        return arg.to_string();
+    };
+
+    if let Some(normalized) = normalize_request_path_value(arg, Some(root)) {
+        return normalized;
+    }
+
+    if let Some(rest) = arg.strip_prefix("-I").filter(|rest| !rest.is_empty()) {
+        if let Some(normalized) = normalize_request_path_value(rest, Some(root)) {
+            return format!("-I{normalized}");
+        }
+    }
+
+    if let Some((left, right)) = arg.split_once('=') {
+        if let Some(normalized_left) = normalize_request_path_value(left, Some(root)) {
+            return format!("{normalized_left}={right}");
+        }
+        if let Some(normalized_right) = normalize_request_path_value(right, Some(root)) {
+            return format!("{left}={normalized_right}");
+        }
+    }
+
+    arg.to_string()
+}
+
+fn request_env_fingerprint_vars(client_env: Option<&[(String, String)]>) -> Vec<(&str, &str)> {
+    let mut vars: Vec<(&str, &str)> = client_env
+        .into_iter()
+        .flatten()
+        .filter_map(|(key, value)| {
+            let key = key.as_str();
+            let include = key.starts_with("CARGO_")
+                && key != "CARGO_MAKEFLAGS"
+                && key != "CARGO_INCREMENTAL"
+                && key != "CARGO_MANIFEST_DIR"
+                && key != "CARGO_MANIFEST_PATH";
+            include.then_some((key, value.as_str()))
+        })
+        .collect();
+    vars.sort_unstable();
+    vars
+}
+
 /// Compute a fast fingerprint of a compile request for the request-level cache.
 ///
 /// Streams bytes directly into blake3 without intermediate buffer allocation.
 /// Zero-alloc: ~100ns for 10 args, ~500ns for 300 args.
 /// Callers should pass the fully expanded argv so response-file content
 /// changes also invalidate the request-level fast path.
-fn request_fingerprint(compiler: &Path, args: &[String], cwd: &Path) -> ContentHash {
+fn request_fingerprint(
+    compiler: &Path,
+    args: &[String],
+    cwd: &Path,
+    key_root: Option<&Path>,
+    client_env: Option<&[(String, String)]>,
+) -> ContentHash {
     let mut h = zccache_hash::StreamHasher::new();
-    h.update(b"zccache-request-v1\0");
+    h.update(b"zccache-request-v2\0");
     let compiler = zccache_core::path::normalize_for_key(compiler);
     h.update(compiler.as_bytes());
     h.update(&[0]);
     for arg in args {
+        let arg = normalize_request_arg(arg, key_root);
         h.update(arg.as_bytes());
         h.update(&[0]);
     }
-    let cwd = zccache_core::path::normalize_for_key(cwd);
+    let cwd = normalize_path_for_request_key(cwd, key_root);
     h.update(cwd.as_bytes());
+    h.update(&[0]);
+    for (key, value) in request_env_fingerprint_vars(client_env) {
+        h.update(key.as_bytes());
+        h.update(b"=");
+        h.update(value.as_bytes());
+        h.update(&[0]);
+    }
     h.finalize()
+}
+
+fn request_cache_input_paths(
+    state: &SharedState,
+    context_key: &ContextKey,
+    source_path: &NormalizedPath,
+    ctx: &CompileContext,
+) -> Vec<NormalizedPath> {
+    let mut paths = Vec::new();
+    paths.push(source_path.clone());
+    if let Some(includes) = state.dep_graph.get_includes(context_key) {
+        paths.extend(includes.iter().cloned());
+    }
+    paths.extend(ctx.force_includes.iter().cloned());
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+fn request_cache_entry(
+    context_key: ContextKey,
+    source_path: &NormalizedPath,
+    output_path: &NormalizedPath,
+    input_paths: Vec<NormalizedPath>,
+    key_root: Option<&NormalizedPath>,
+) -> RequestCacheEntry {
+    let root = key_root.cloned();
+    let root_path = key_root.map(|root| root.as_path());
+    let source_path = CachedRequestPath::capture(source_path, root_path);
+    let output_path = CachedRequestPath::capture(output_path, root_path);
+    let input_paths: Vec<CachedRequestPath> = input_paths
+        .iter()
+        .map(|path| CachedRequestPath::capture(path, root_path))
+        .collect();
+    let cross_root_shareable = root.is_some()
+        && source_path.is_root_relative()
+        && output_path.is_root_relative()
+        && input_paths.iter().all(CachedRequestPath::is_root_relative);
+
+    RequestCacheEntry {
+        context_key,
+        root,
+        source_path,
+        output_path,
+        input_paths,
+        cross_root_shareable,
+        cached_at: std::time::Instant::now(),
+    }
+}
+
+fn request_cache_entry_matches_root(
+    entry: &RequestCacheEntry,
+    key_root: Option<&NormalizedPath>,
+) -> bool {
+    if entry.root.as_ref() == key_root {
+        return true;
+    }
+    entry.cross_root_shareable && entry.root.is_some() && key_root.is_some()
+}
+
+fn request_cache_artifact_matches(
+    state: &SharedState,
+    entry: &RequestCacheEntry,
+    key_root: Option<&NormalizedPath>,
+    expected_artifact_key_hex: &str,
+    clock: Clock,
+) -> bool {
+    let Some(root) = key_root else {
+        return false;
+    };
+    let mut file_hashes = Vec::with_capacity(entry.input_paths.len());
+    for cached_path in &entry.input_paths {
+        let path = cached_path.resolve(Some(root));
+        let Ok(hash) = hash_file(&state.cache_system, &path, clock) else {
+            return false;
+        };
+        file_hashes.push((path, hash));
+    }
+
+    let artifact_key = zccache_depgraph::compute_artifact_key(
+        &entry.context_key,
+        &mut file_hashes,
+        Some(root.as_path()),
+    );
+    artifact_key.hash().to_hex() == expected_artifact_key_hex
 }
 
 fn strict_paths_mode_from_client_env(
@@ -3037,71 +3273,123 @@ async fn handle_compile(
         return compile_failure_stderr(err.diagnostic(&compiler, &expanded_args));
     }
 
+    let worktree_root = resolve_worktree_root(cwd, client_env.as_deref());
+
+    // Snap the journal clock once so all file hashes in this request see a
+    // consistent view (avoids per-file current_clock() syscalls).
+    let snap_clock = state.cache_system.current_clock();
+
     // ── Ultra-fast request-level cache ────────────────────────────────
     // If we've seen this exact (compiler, args, cwd) before AND the fast-hit
     // cache still holds a valid entry, skip ALL heavy work: system include
     // discovery, watch_directories, response file expansion, arg parsing,
     // context building, and dep_graph registration.
     if state.watcher_active.load(Ordering::Acquire) {
-        let request_fp = request_fingerprint(compiler_path, &expanded_args, cwd);
+        let request_fp = request_fingerprint(
+            compiler_path,
+            &expanded_args,
+            cwd,
+            worktree_root.as_deref(),
+            client_env.as_deref(),
+        );
         if let Some(req_entry) = state.request_cache.get(&request_fp) {
-            if let Some(fh_entry) = state.fast_hit_cache.get(&req_entry.context_key) {
-                if cache_entry_fresh_at(compile_start, fh_entry.cached_at, FAST_HIT_MAX_AGE)
-                    && context_files_fresh(
-                        state,
-                        &req_entry.context_key,
-                        &req_entry.source_path,
-                        fh_entry.clock,
-                    )
-                {
+            if request_cache_entry_matches_root(&req_entry, worktree_root.as_ref()) {
+                if let Some(fh_entry) = state.fast_hit_cache.get(&req_entry.context_key) {
                     let artifact_key_hex = &fh_entry.artifact_key_hex;
-                    if let Some(mut cached_ref) = state.artifacts.get_mut(artifact_key_hex) {
-                        cached_ref.last_used = std::time::Instant::now();
-                        let loaded =
-                            ensure_payloads(&mut cached_ref, &state.artifact_dir, artifact_key_hex)
-                                .is_some();
-                        if loaded {
-                            let payloads = Arc::clone(cached_ref.payloads.as_ref().unwrap());
-                            let names = Arc::clone(&cached_ref.meta.output_names);
-                            let exit_code = cached_ref.meta.exit_code;
-                            let stdout = cached_ref.stdout.clone();
-                            let stderr = cached_ref.stderr.clone();
-                            let artifact_bytes: u64 = cached_ref.meta.total_size;
-                            // Drop the DashMap reference before doing more work
-                            drop(cached_ref);
+                    let source_path = req_entry.source_path.resolve(worktree_root.as_deref());
+                    let output_path = req_entry.output_path.resolve(worktree_root.as_deref());
+                    let same_root = req_entry.root.as_ref() == worktree_root.as_ref();
+                    let inputs_match = if same_root {
+                        context_files_fresh(
+                            state,
+                            &req_entry.context_key,
+                            &source_path,
+                            fh_entry.clock,
+                        )
+                    } else {
+                        request_cache_artifact_matches(
+                            state,
+                            &req_entry,
+                            worktree_root.as_ref(),
+                            artifact_key_hex,
+                            snap_clock,
+                        )
+                    };
+                    if cache_entry_fresh_at(compile_start, fh_entry.cached_at, FAST_HIT_MAX_AGE)
+                        && cache_entry_fresh_at(
+                            compile_start,
+                            req_entry.cached_at,
+                            EPHEMERAL_CACHE_MAX_AGE,
+                        )
+                        && inputs_match
+                    {
+                        if let Some(mut cached_ref) = state.artifacts.get_mut(artifact_key_hex) {
+                            cached_ref.last_used = std::time::Instant::now();
+                            let loaded = ensure_payloads(
+                                &mut cached_ref,
+                                &state.artifact_dir,
+                                artifact_key_hex,
+                            )
+                            .is_some();
+                            if loaded {
+                                let payloads = Arc::clone(cached_ref.payloads.as_ref().unwrap());
+                                let names = Arc::clone(&cached_ref.meta.output_names);
+                                let exit_code = cached_ref.meta.exit_code;
+                                let stdout = cached_ref.stdout.clone();
+                                let stderr = cached_ref.stderr.clone();
+                                let artifact_bytes: u64 = cached_ref.meta.total_size;
+                                // Drop the DashMap reference before doing more work
+                                drop(cached_ref);
 
-                            // Write output
-                            let mut write_ok = true;
-                            let secondary_dir =
-                                req_entry.output_path.parent().unwrap_or(cwd).to_path_buf();
-                            for (i, payload) in payloads.iter().enumerate() {
-                                let out_path = if i == 0 {
-                                    req_entry.output_path.clone()
-                                } else {
-                                    secondary_dir.join(&names[i]).into()
-                                };
-                                let cache_file =
-                                    state.artifact_dir.join(format!("{artifact_key_hex}_{i}"));
-                                if write_cached_payload(&out_path, &cache_file, payload).is_err() {
-                                    write_ok = false;
-                                    break;
+                                // Write output
+                                let mut write_ok = true;
+                                let secondary_dir =
+                                    output_path.parent().unwrap_or(cwd).to_path_buf();
+                                for (i, payload) in payloads.iter().enumerate() {
+                                    let out_path = if i == 0 {
+                                        output_path.clone()
+                                    } else {
+                                        secondary_dir.join(&names[i]).into()
+                                    };
+                                    let cache_file =
+                                        state.artifact_dir.join(format!("{artifact_key_hex}_{i}"));
+                                    if write_cached_payload(&out_path, &cache_file, payload)
+                                        .is_err()
+                                    {
+                                        write_ok = false;
+                                        break;
+                                    }
                                 }
-                            }
-                            if write_ok {
-                                state.stats.record_compilation();
-                                let latency_ns = compile_start.elapsed().as_nanos() as u64;
-                                state.stats.record_hit(latency_ns, artifact_bytes);
-                                let src = req_entry.source_path.clone();
-                                record_session_stat(&state.sessions, &sid, move |t| {
-                                    t.record_hit(src, latency_ns, artifact_bytes);
-                                });
+                                if write_ok {
+                                    state.stats.record_compilation();
+                                    let latency_ns = compile_start.elapsed().as_nanos() as u64;
+                                    state.stats.record_hit(latency_ns, artifact_bytes);
+                                    let src = source_path.clone();
+                                    record_session_stat(&state.sessions, &sid, move |t| {
+                                        t.record_hit(src, latency_ns, artifact_bytes);
+                                    });
+                                    write_session_log(
+                                        &state.sessions,
+                                        &sid,
+                                        &format!(
+                                            "[{}] {} -> {}",
+                                            if same_root {
+                                                "HIT_REQUEST"
+                                            } else {
+                                                "HIT_WORKTREE_REQUEST"
+                                            },
+                                            source_path.display(),
+                                            output_path.display()
+                                        ),
+                                    );
 
-                                return Response::CompileResult {
-                                    exit_code,
-                                    stdout,
-                                    stderr,
-                                    cached: true,
-                                };
+                                    return Response::CompileResult {
+                                        exit_code,
+                                        stdout,
+                                        stderr,
+                                        cached: true,
+                                    };
+                                }
                             }
                         }
                     }
@@ -3109,10 +3397,6 @@ async fn handle_compile(
             }
         }
     }
-
-    // Snap the journal clock once so all file hashes in this request see a
-    // consistent view (avoids per-file current_clock() syscalls).
-    let snap_clock = state.cache_system.current_clock();
 
     state.stats.record_compilation();
 
@@ -3194,6 +3478,7 @@ async fn handle_compile(
                 original_args,
                 source_indices,
                 cwd.into(),
+                worktree_root.clone(),
                 system_includes,
                 client_env,
                 compile_start,
@@ -3204,6 +3489,7 @@ async fn handle_compile(
     let parse_args_ns = t0.elapsed().as_nanos() as u64;
 
     let cwd_path: NormalizedPath = cwd.into();
+    let key_root = worktree_root.as_ref().unwrap_or(&cwd_path);
     let source_path = if compilation.source_file.is_absolute() {
         compilation.source_file.clone()
     } else {
@@ -3225,27 +3511,40 @@ async fn handle_compile(
         env_slice,
         &state.compiler_hash_cache,
     );
-    let (ctx, dep_flags, rustc_args_opt, context_key) = match build_result {
-        BuildContextResult::Cc { ctx, dep_flags } => {
-            let key = state
-                .dep_graph
-                .register_with_root(ctx.clone(), Some(cwd_path.clone()));
-            (ctx, dep_flags, None, key)
-        }
-        BuildContextResult::Rustc {
-            rustc_ctx,
-            compat_ctx,
-            rustc_args,
-        } => {
-            let key = rustc_ctx.context_key();
-            state.dep_graph.register_with_key_and_root(
-                key,
-                compat_ctx.clone(),
-                Some(cwd_path.clone()),
-            );
-            (compat_ctx, UserDepFlags::default(), Some(rustc_args), key)
-        }
-    };
+    let (ctx, dep_flags, rustc_args_opt, context_key, worktree_equivalent_context) =
+        match build_result {
+            BuildContextResult::Cc { ctx, dep_flags } => {
+                let registration = state
+                    .dep_graph
+                    .register_with_root_result(ctx.clone(), Some(key_root.clone()));
+                (
+                    ctx,
+                    dep_flags,
+                    None,
+                    registration.key,
+                    registration.rebased_from_equivalent_root,
+                )
+            }
+            BuildContextResult::Rustc {
+                rustc_ctx,
+                compat_ctx,
+                rustc_args,
+            } => {
+                let key = rustc_ctx.context_key_with_root(Some(key_root));
+                let registration = state.dep_graph.register_with_key_and_root_result(
+                    key,
+                    compat_ctx.clone(),
+                    Some(key_root.clone()),
+                );
+                (
+                    compat_ctx,
+                    UserDepFlags::default(),
+                    Some(rustc_args),
+                    registration.key,
+                    registration.rebased_from_equivalent_root,
+                )
+            }
+        };
     let is_rustc = rustc_args_opt.is_some();
     let rust_profile_enabled = is_rustc && std::env::var_os(RUST_MISS_PROFILE_ENV).is_some();
     let rust_profile_mode = rustc_args_opt
@@ -3335,22 +3634,36 @@ async fn handle_compile(
                                 &state.sessions,
                                 &sid,
                                 &format!(
-                                    "[HIT_FAST] {} -> {}",
+                                    "[{}] {} -> {}",
+                                    if worktree_equivalent_context {
+                                        "HIT_WORKTREE_FAST"
+                                    } else {
+                                        "HIT_FAST"
+                                    },
                                     source_path.display(),
                                     output_path.display()
                                 ),
                             );
                             let bookkeeping_ns = t7.elapsed().as_nanos() as u64;
 
-                            let rfp = request_fingerprint(compiler_path, &expanded_args, cwd);
+                            let rfp = request_fingerprint(
+                                compiler_path,
+                                &expanded_args,
+                                cwd,
+                                Some(key_root.as_path()),
+                                client_env.as_deref(),
+                            );
+                            let input_paths =
+                                request_cache_input_paths(state, &context_key, &source_path, &ctx);
                             state.request_cache.insert(
                                 rfp,
-                                RequestCacheEntry {
+                                request_cache_entry(
                                     context_key,
-                                    source_path: source_path.clone(),
-                                    output_path: output_path.clone(),
-                                    cached_at: std::time::Instant::now(),
-                                },
+                                    &source_path,
+                                    &output_path,
+                                    input_paths,
+                                    Some(key_root),
+                                ),
                             );
 
                             let total_ns = compile_start.elapsed().as_nanos() as u64;
@@ -3586,7 +3899,12 @@ async fn handle_compile(
                             &state.sessions,
                             &sid,
                             &format!(
-                                "[HIT] {} -> {}",
+                                "[{}] {} -> {}",
+                                if worktree_equivalent_context {
+                                    "HIT_WORKTREE"
+                                } else {
+                                    "HIT"
+                                },
                                 source_path.display(),
                                 output_path.display()
                             ),
@@ -3604,15 +3922,24 @@ async fn handle_compile(
                             },
                         );
 
-                        let rfp = request_fingerprint(compiler_path, &expanded_args, cwd);
+                        let rfp = request_fingerprint(
+                            compiler_path,
+                            &expanded_args,
+                            cwd,
+                            Some(key_root.as_path()),
+                            client_env.as_deref(),
+                        );
+                        let input_paths =
+                            request_cache_input_paths(state, &context_key, &source_path, &ctx);
                         state.request_cache.insert(
                             rfp,
-                            RequestCacheEntry {
+                            request_cache_entry(
                                 context_key,
-                                source_path: source_path.clone(),
-                                output_path: output_path.clone(),
-                                cached_at: std::time::Instant::now(),
-                            },
+                                &source_path,
+                                &output_path,
+                                input_paths,
+                                Some(key_root),
+                            ),
                         );
 
                         // Record phase profile
@@ -4318,6 +4645,7 @@ fn check_unit_cache(
     state: &SharedState,
     compilation: &zccache_compiler::CacheableCompilation,
     cwd_path: &Path,
+    key_root: &NormalizedPath,
     system_includes: &[NormalizedPath],
     shared_base: Option<&CompileContext>,
     cache_now: Instant,
@@ -4362,7 +4690,7 @@ fn check_unit_cache(
     let t_ctx = t0.elapsed();
     let context_key = state
         .dep_graph
-        .register_with_root(ctx.clone(), Some(cwd_path.into()));
+        .register_with_root(ctx.clone(), Some(key_root.clone()));
     let t_register = t0.elapsed();
 
     // ── Ultra-fast path: per-file freshness skip ────────────────────
@@ -4565,6 +4893,7 @@ async fn handle_compile_multi(
     original_args: Arc<[String]>,
     source_indices: Vec<usize>,
     cwd_path: NormalizedPath,
+    worktree_root: Option<NormalizedPath>,
     system_includes: Vec<NormalizedPath>,
     client_env: Option<Vec<(String, String)>>,
     compile_start: Instant,
@@ -4572,6 +4901,7 @@ async fn handle_compile_multi(
     let snap_clock = state.cache_system.current_clock();
     let mut all_stdout = Vec::new();
     let mut all_stderr = Vec::new();
+    let key_root = worktree_root.as_ref().unwrap_or(&cwd_path).clone();
 
     // ── Pre-parse shared args once for all units ─────────────────────
     // All units share the same original_args (via Arc) — only source/output
@@ -4599,6 +4929,7 @@ async fn handle_compile_multi(
     for (idx, compilation) in compilations.iter().enumerate() {
         let state = Arc::clone(&state);
         let cwd_path = cwd_path.clone();
+        let key_root = key_root.clone();
         let system_includes = system_includes.clone();
         let compilation = compilation.clone();
         let shared_base = Arc::clone(&shared_base);
@@ -4610,6 +4941,7 @@ async fn handle_compile_multi(
                     &state,
                     &compilation,
                     &cwd_path,
+                    &key_root,
                     &system_includes,
                     Some(&shared_base),
                     cache_now,
@@ -5100,10 +5432,16 @@ mod tests {
     }
 
     fn test_request_entry(cached_at: std::time::Instant) -> RequestCacheEntry {
+        let context_key = test_context_key("/tmp/source.c");
+        let source_path: NormalizedPath = "/tmp/source.c".into();
+        let output_path: NormalizedPath = "/tmp/source.o".into();
         RequestCacheEntry {
-            context_key: test_context_key("/tmp/source.c"),
-            source_path: "/tmp/source.c".into(),
-            output_path: "/tmp/source.o".into(),
+            context_key,
+            root: None,
+            source_path: CachedRequestPath::capture(&source_path, None),
+            output_path: CachedRequestPath::capture(&output_path, None),
+            input_paths: vec![CachedRequestPath::capture(&source_path, None)],
+            cross_root_shareable: false,
             cached_at,
         }
     }
@@ -5527,13 +5865,141 @@ exit /b 0
             Path::new(r"C:\LLVM\bin\clang++.exe"),
             &args,
             Path::new(r"C:\Work\Project"),
+            None,
+            None,
         );
         let b = request_fingerprint(
             Path::new("c:/llvm/bin/clang++.exe"),
             &args,
             Path::new("c:/work/project"),
+            None,
+            None,
         );
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn find_git_root_detects_git_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("repo");
+        let nested = root.join("crates/demo");
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::create_dir_all(&nested).unwrap();
+
+        assert_eq!(find_git_root(&nested), Some(root.into()));
+    }
+
+    #[test]
+    fn resolve_worktree_root_prefers_client_env_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = tmp.path().join("repo/subdir");
+        let override_root = tmp.path().join("override-root");
+        std::fs::create_dir_all(&cwd).unwrap();
+        std::fs::create_dir_all(&override_root).unwrap();
+        std::fs::create_dir_all(tmp.path().join("repo/.git")).unwrap();
+        let env = vec![(
+            WORKTREE_ROOT_ENV.to_string(),
+            override_root.to_string_lossy().into_owned(),
+        )];
+
+        assert_eq!(
+            resolve_worktree_root(&cwd, Some(&env)),
+            Some(override_root.into())
+        );
+    }
+
+    #[test]
+    fn request_fingerprint_matches_equivalent_roots_for_safe_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_a = tmp.path().join("workspace-a");
+        let root_b = tmp.path().join("workspace-b");
+        let include_a = root_a.join("include");
+        let include_b = root_b.join("include");
+        let source_a = root_a.join("src/main.cpp");
+        let source_b = root_b.join("src/main.cpp");
+        let output_a = root_a.join("build/main.o");
+        let output_b = root_b.join("build/main.o");
+
+        let args_a = vec![
+            "-I".to_string(),
+            include_a.to_string_lossy().into_owned(),
+            "-c".to_string(),
+            source_a.to_string_lossy().into_owned(),
+            "-o".to_string(),
+            output_a.to_string_lossy().into_owned(),
+        ];
+        let args_b = vec![
+            "-I".to_string(),
+            include_b.to_string_lossy().into_owned(),
+            "-c".to_string(),
+            source_b.to_string_lossy().into_owned(),
+            "-o".to_string(),
+            output_b.to_string_lossy().into_owned(),
+        ];
+
+        let a = request_fingerprint(
+            Path::new("/usr/bin/clang++"),
+            &args_a,
+            &root_a,
+            Some(&root_a),
+            None,
+        );
+        let b = request_fingerprint(
+            Path::new("/usr/bin/clang++"),
+            &args_b,
+            &root_b,
+            Some(&root_b),
+            None,
+        );
+
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn request_fingerprint_keeps_external_paths_distinct() {
+        let args_a = vec!["-I".to_string(), "/external-a/include".to_string()];
+        let args_b = vec!["-I".to_string(), "/external-b/include".to_string()];
+
+        let a = request_fingerprint(
+            Path::new("/usr/bin/clang++"),
+            &args_a,
+            Path::new("/workspace-a"),
+            Some(Path::new("/workspace-a")),
+            None,
+        );
+        let b = request_fingerprint(
+            Path::new("/usr/bin/clang++"),
+            &args_b,
+            Path::new("/workspace-b"),
+            Some(Path::new("/workspace-b")),
+            None,
+        );
+
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn request_fingerprint_includes_rust_key_env() {
+        let args = vec!["src/lib.rs".to_string()];
+        let env_a = vec![("CARGO_PKG_VERSION".to_string(), "1.0.0".to_string())];
+        let env_b = vec![("CARGO_PKG_VERSION".to_string(), "1.0.1".to_string())];
+
+        let a = request_fingerprint(
+            Path::new("/usr/bin/rustc"),
+            &args,
+            Path::new("/workspace"),
+            Some(Path::new("/workspace")),
+            Some(&env_a),
+        );
+        let b = request_fingerprint(
+            Path::new("/usr/bin/rustc"),
+            &args,
+            Path::new("/workspace"),
+            Some(Path::new("/workspace")),
+            Some(&env_b),
+        );
+
+        assert_ne!(a, b);
     }
 
     #[tokio::test]

--- a/crates/zccache-daemon/tests/rustc_cache_test.rs
+++ b/crates/zccache-daemon/tests/rustc_cache_test.rs
@@ -45,6 +45,25 @@ async fn start_session(client: &mut ClientConn) -> String {
     }
 }
 
+/// Helper: start session with an explicit working directory.
+async fn start_session_in(client: &mut ClientConn, working_dir: &std::path::Path) -> String {
+    client
+        .send(&Request::SessionStart {
+            client_pid: std::process::id(),
+            working_dir: working_dir.to_path_buf().into(),
+            log_file: None,
+            track_stats: false,
+            journal_path: None,
+        })
+        .await
+        .unwrap();
+
+    match client.recv().await.unwrap() {
+        Some(Response::SessionStarted { session_id, .. }) => session_id,
+        other => panic!("expected SessionStarted, got: {other:?}"),
+    }
+}
+
 /// Helper: compile via IPC and return (exit_code, cached).
 async fn compile(
     client: &mut ClientConn,
@@ -71,6 +90,116 @@ async fn compile(
         Some(Response::Error { message }) => panic!("compile error: {message}"),
         other => panic!("unexpected response: {other:?}"),
     }
+}
+
+fn init_git_root(root: &std::path::Path) -> bool {
+    std::fs::create_dir_all(root).unwrap();
+    match std::process::Command::new("git")
+        .arg("init")
+        .arg("--quiet")
+        .arg(root)
+        .status()
+    {
+        Ok(status) if status.success() => true,
+        Ok(status) => {
+            eprintln!("skipping test: git init failed with status {status}");
+            false
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!("skipping test: git not found");
+            false
+        }
+        Err(err) => panic!("failed to run git init: {err}"),
+    }
+}
+
+fn write_worktree_project(
+    root: &std::path::Path,
+    dep_value: i32,
+    app_increment: i32,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let src_dir = root.join("src");
+    let target_dir = root.join("target");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::create_dir_all(&target_dir).unwrap();
+
+    let dep_src = src_dir.join("dep.rs");
+    let app_src = src_dir.join("lib.rs");
+    std::fs::write(
+        &dep_src,
+        format!("pub fn value() -> i32 {{ {dep_value} }}\n"),
+    )
+    .unwrap();
+    std::fs::write(
+        &app_src,
+        format!("extern crate dep;\npub fn answer() -> i32 {{ dep::value() + {app_increment} }}\n"),
+    )
+    .unwrap();
+    (dep_src, app_src)
+}
+
+fn remove_file_if_exists(path: &std::path::Path) {
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => panic!("failed to remove {}: {err}", path.display()),
+    }
+}
+
+async fn compile_worktree_dep(
+    client: &mut ClientConn,
+    session_id: &str,
+    compiler: &str,
+    root: &std::path::Path,
+) -> (i32, bool) {
+    compile(
+        client,
+        session_id,
+        compiler,
+        &[
+            "--edition",
+            "2021",
+            "--crate-type",
+            "lib",
+            "--crate-name",
+            "dep",
+            "--emit=link",
+            "src/dep.rs",
+            "-o",
+            "target/libdep.rlib",
+        ],
+        root,
+    )
+    .await
+}
+
+async fn compile_worktree_app(
+    client: &mut ClientConn,
+    session_id: &str,
+    compiler: &str,
+    root: &std::path::Path,
+) -> (i32, bool) {
+    compile(
+        client,
+        session_id,
+        compiler,
+        &[
+            "--edition",
+            "2021",
+            "--crate-type",
+            "lib",
+            "--crate-name",
+            "app",
+            "--emit=link",
+            "--extern",
+            "dep=target/libdep.rlib",
+            "src/lib.rs",
+            "-o",
+            "target/libapp.rlib",
+        ],
+        root,
+    )
+    .await
 }
 
 /// Simplest possible rustc caching test:
@@ -541,6 +670,138 @@ async fn test_rustc_extern_change_invalidates() {
         assert!(
             !cached,
             "crate B should be cache miss after extern A changed"
+        );
+
+        shutdown.notify_one();
+        server_handle.await.unwrap();
+    })
+    .await;
+}
+
+/// Acceptance test for issue #215.
+///
+/// The daemon should auto-detect each sibling Git root as the worktree
+/// normalization root, share equivalent Rust compile artifacts across roots,
+/// and fall back to a miss when B's project-local source or dependency content
+/// changes.
+///
+/// This intentionally leaves `ZCCACHE_WORKTREE_ROOT` unset so the automatic Git
+/// root path is covered.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore] // integration-level: starts real daemon with IPC + rustc
+async fn test_rustc_sibling_git_worktree_equivalent_cache_sharing() {
+    let rustc = match zccache_test_support::find_rustc() {
+        Some(p) => p,
+        None => {
+            eprintln!("skipping test: rustc not found");
+            return;
+        }
+    };
+
+    zccache_test_support::test_timeout(async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_a = tmp.path().join("worktree-a");
+        let root_b = tmp.path().join("worktree-b");
+
+        if !init_git_root(&root_a) || !init_git_root(&root_b) {
+            return;
+        }
+
+        write_worktree_project(&root_a, 7, 1);
+        write_worktree_project(&root_b, 7, 1);
+
+        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let mut client_a = zccache_ipc::connect(&endpoint).await.unwrap();
+        let mut client_b = zccache_ipc::connect(&endpoint).await.unwrap();
+        let session_a = start_session_in(&mut client_a, &root_a).await;
+        let session_b = start_session_in(&mut client_b, &root_b).await;
+
+        let rustc_str = rustc.to_string_lossy().to_string();
+        let dep_a = root_a.join("target/libdep.rlib");
+        let dep_b = root_b.join("target/libdep.rlib");
+        let app_a = root_a.join("target/libapp.rlib");
+        let app_b = root_b.join("target/libapp.rlib");
+
+        let (exit_code, cached) =
+            compile_worktree_dep(&mut client_a, &session_a, &rustc_str, &root_a).await;
+        assert_eq!(exit_code, 0, "A dependency compile should succeed");
+        assert!(!cached, "A dependency compile should be a cold miss");
+        assert!(dep_a.exists(), "A dependency output should exist");
+
+        let (exit_code, cached) =
+            compile_worktree_app(&mut client_a, &session_a, &rustc_str, &root_a).await;
+        assert_eq!(exit_code, 0, "A app compile should succeed");
+        assert!(!cached, "A app compile should be a cold miss");
+        let app_a_original = std::fs::read(&app_a).unwrap();
+
+        let (exit_code, cached) =
+            compile_worktree_dep(&mut client_b, &session_b, &rustc_str, &root_b).await;
+        assert_eq!(
+            exit_code, 0,
+            "B equivalent dependency compile should succeed"
+        );
+        assert!(
+            cached,
+            "B equivalent dependency compile should hit A's worktree-equivalent entry"
+        );
+        assert!(dep_b.exists(), "B dependency output should be restored");
+
+        let (exit_code, cached) =
+            compile_worktree_app(&mut client_b, &session_b, &rustc_str, &root_b).await;
+        assert_eq!(exit_code, 0, "B equivalent app compile should succeed");
+        assert!(
+            cached,
+            "B equivalent app compile should hit A's worktree-equivalent entry"
+        );
+        assert!(app_b.exists(), "B app output should be restored");
+
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        write_worktree_project(&root_b, 7, 2);
+        remove_file_if_exists(&app_b);
+        let (exit_code, cached) =
+            compile_worktree_app(&mut client_b, &session_b, &rustc_str, &root_b).await;
+        assert_eq!(
+            exit_code, 0,
+            "B app compile after source edit should succeed"
+        );
+        assert!(!cached, "B source edit should force a conservative miss");
+
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        write_worktree_project(&root_b, 99, 1);
+        remove_file_if_exists(&dep_b);
+        remove_file_if_exists(&app_b);
+
+        let (exit_code, cached) =
+            compile_worktree_dep(&mut client_b, &session_b, &rustc_str, &root_b).await;
+        assert_eq!(
+            exit_code, 0,
+            "B dependency compile after dependency edit should succeed"
+        );
+        assert!(!cached, "B dependency edit should miss");
+
+        let (exit_code, cached) =
+            compile_worktree_app(&mut client_b, &session_b, &rustc_str, &root_b).await;
+        assert_eq!(
+            exit_code, 0,
+            "B app compile after dependency edit should succeed"
+        );
+        assert!(
+            !cached,
+            "B app should miss when its root-relative dependency content changes"
+        );
+
+        remove_file_if_exists(&app_a);
+        let (exit_code, cached) =
+            compile_worktree_app(&mut client_a, &session_a, &rustc_str, &root_a).await;
+        assert_eq!(exit_code, 0, "A original app compile should still succeed");
+        assert!(
+            cached,
+            "B edits must not poison A's original worktree-equivalent cache entry"
+        );
+        assert_eq!(
+            std::fs::read(&app_a).unwrap(),
+            app_a_original,
+            "A cached output should remain byte-identical after B misses"
         );
 
         shutdown.notify_one();

--- a/crates/zccache-depgraph/src/context.rs
+++ b/crates/zccache-depgraph/src/context.rs
@@ -140,6 +140,22 @@ fn normalize_key_path(path: &Path, key_root: Option<&Path>) -> String {
     normalize_for_key(path)
 }
 
+fn normalize_remap_path_prefix_for_key(remap: &str, key_root: Option<&Path>) -> String {
+    let Some(root) = key_root else {
+        return remap.to_string();
+    };
+    let Some((from, to)) = remap.split_once('=') else {
+        return remap.to_string();
+    };
+
+    let from_path = Path::new(from);
+    if from_path.strip_prefix(root).is_ok() {
+        format!("{}={}", normalize_key_path(from_path, key_root), to)
+    } else {
+        remap.to_string()
+    }
+}
+
 /// Compute the context key for a C/C++ compilation context.
 ///
 /// When `key_root` is provided, paths under that root are hashed relative to it
@@ -370,6 +386,16 @@ impl RustcCompileContext {
     /// Uses a different domain tag from C/C++ to avoid collisions.
     #[must_use]
     pub fn context_key(&self) -> ContextKey {
+        self.context_key_with_root(None)
+    }
+
+    /// Compute the context key, optionally normalizing project-local paths.
+    ///
+    /// When `key_root` is provided, source paths and safe path-bearing key
+    /// fields under that root are hashed relative to it so equivalent
+    /// workspaces can share cache keys across root-directory renames.
+    #[must_use]
+    pub fn context_key_with_root(&self, key_root: Option<&Path>) -> ContextKey {
         let mut hasher = blake3::Hasher::new();
 
         hasher.update(b"zccache-rustc-context-key-v2\0");
@@ -381,8 +407,8 @@ impl RustcCompileContext {
             hasher.update(b"\0");
         }
 
-        // Source file (absolute path).
-        let source_file = normalize_for_key(&self.source_file);
+        // Source file.
+        let source_file = normalize_key_path(&self.source_file, key_root);
         hasher.update(source_file.as_bytes());
         hasher.update(b"\0");
 
@@ -493,9 +519,22 @@ impl RustcCompileContext {
 
         // --remap-path-prefix values (sorted, affect embedded paths in output).
         hasher.update(b"remap\0");
-        for remap in &self.remap_path_prefixes {
-            hasher.update(remap.as_bytes());
-            hasher.update(b"\0");
+        if key_root.is_some() {
+            let mut remap_path_prefixes: Vec<String> = self
+                .remap_path_prefixes
+                .iter()
+                .map(|remap| normalize_remap_path_prefix_for_key(remap, key_root))
+                .collect();
+            remap_path_prefixes.sort();
+            for remap in &remap_path_prefixes {
+                hasher.update(remap.as_bytes());
+                hasher.update(b"\0");
+            }
+        } else {
+            for remap in &self.remap_path_prefixes {
+                hasher.update(remap.as_bytes());
+                hasher.update(b"\0");
+            }
         }
 
         // CARGO_* environment variables (sorted, affect env!() macro output).
@@ -529,7 +568,27 @@ pub fn compute_rustc_artifact_key<P: AsRef<Path> + Ord>(
     file_hashes: &mut [(P, ContentHash)],
     extern_hashes: &mut [(String, ContentHash)],
 ) -> ArtifactKey {
-    file_hashes.sort_by(|a, b| a.0.cmp(&b.0));
+    compute_rustc_artifact_key_with_root(context_key, file_hashes, extern_hashes, None)
+}
+
+/// Compute the rustc artifact key, optionally normalizing project-local files.
+///
+/// When `key_root` is provided, source and dependency file paths under that
+/// root are hashed relative to it. Extern hashes remain keyed by crate name.
+pub fn compute_rustc_artifact_key_with_root<P: AsRef<Path> + Ord>(
+    context_key: &ContextKey,
+    file_hashes: &mut [(P, ContentHash)],
+    extern_hashes: &mut [(String, ContentHash)],
+    key_root: Option<&Path>,
+) -> ArtifactKey {
+    if key_root.is_some() {
+        file_hashes.sort_by(|a, b| {
+            normalize_key_path(a.0.as_ref(), key_root)
+                .cmp(&normalize_key_path(b.0.as_ref(), key_root))
+        });
+    } else {
+        file_hashes.sort_by(|a, b| a.0.cmp(&b.0));
+    }
     extern_hashes.sort_by(|a, b| a.0.cmp(&b.0));
 
     let mut hasher = blake3::Hasher::new();
@@ -539,7 +598,7 @@ pub fn compute_rustc_artifact_key<P: AsRef<Path> + Ord>(
 
     // Source + dependency file hashes.
     for (path, hash) in file_hashes.iter() {
-        let path = normalize_for_key(path.as_ref());
+        let path = normalize_key_path(path.as_ref(), key_root);
         hasher.update(path.as_bytes());
         hasher.update(b"\0");
         hasher.update(hash.as_bytes());
@@ -935,6 +994,83 @@ mod tests {
     }
 
     #[test]
+    fn rustc_context_key_delegates_to_rootless_helper() {
+        let ctx = make_rustc_context("/src/lib.rs", "2021");
+        assert_eq!(ctx.context_key(), ctx.context_key_with_root(None));
+    }
+
+    #[test]
+    fn rustc_context_key_with_root_matches_equivalent_roots() {
+        let ctx_a = make_rustc_context("/workspace-a/crates/demo/src/lib.rs", "2021");
+        let ctx_b = make_rustc_context("/workspace-b/crates/demo/src/lib.rs", "2021");
+
+        assert_ne!(
+            ctx_a.context_key(),
+            ctx_b.context_key(),
+            "rootless rustc context keys should keep the existing absolute-path behavior"
+        );
+        assert_eq!(
+            ctx_a.context_key_with_root(Some(Path::new("/workspace-a"))),
+            ctx_b.context_key_with_root(Some(Path::new("/workspace-b"))),
+            "source paths under equivalent roots should hash relative to those roots"
+        );
+    }
+
+    #[test]
+    fn rustc_context_key_with_root_keeps_external_sources_distinct() {
+        let ctx_a = make_rustc_context("/external-a/generated/lib.rs", "2021");
+        let ctx_b = make_rustc_context("/external-b/generated/lib.rs", "2021");
+
+        assert_ne!(
+            ctx_a.context_key_with_root(Some(Path::new("/workspace-a"))),
+            ctx_b.context_key_with_root(Some(Path::new("/workspace-b"))),
+            "sources outside the supplied roots must retain absolute path identity"
+        );
+    }
+
+    #[test]
+    fn rustc_context_key_with_root_normalizes_remap_left_side_under_root() {
+        let mut ctx_a = make_rustc_context("/workspace-a/crates/demo/src/lib.rs", "2021");
+        ctx_a.remap_path_prefixes = vec!["/workspace-a=/src".to_string()];
+        let mut ctx_b = make_rustc_context("/workspace-b/crates/demo/src/lib.rs", "2021");
+        ctx_b.remap_path_prefixes = vec!["/workspace-b=/src".to_string()];
+
+        assert_eq!(
+            ctx_a.context_key_with_root(Some(Path::new("/workspace-a"))),
+            ctx_b.context_key_with_root(Some(Path::new("/workspace-b"))),
+            "remap left sides under the root should hash relative to the root"
+        );
+    }
+
+    #[test]
+    fn rustc_context_key_with_root_keeps_external_remap_left_sides_distinct() {
+        let mut ctx_a = make_rustc_context("/workspace-a/crates/demo/src/lib.rs", "2021");
+        ctx_a.remap_path_prefixes = vec!["/external-a=/src".to_string()];
+        let mut ctx_b = make_rustc_context("/workspace-b/crates/demo/src/lib.rs", "2021");
+        ctx_b.remap_path_prefixes = vec!["/external-b=/src".to_string()];
+
+        assert_ne!(
+            ctx_a.context_key_with_root(Some(Path::new("/workspace-a"))),
+            ctx_b.context_key_with_root(Some(Path::new("/workspace-b"))),
+            "remap left sides outside the root should keep absolute path identity"
+        );
+    }
+
+    #[test]
+    fn rustc_context_key_with_root_does_not_normalize_remap_right_side() {
+        let mut ctx_a = make_rustc_context("/workspace-a/crates/demo/src/lib.rs", "2021");
+        ctx_a.remap_path_prefixes = vec!["/workspace-a=/workspace-a".to_string()];
+        let mut ctx_b = make_rustc_context("/workspace-b/crates/demo/src/lib.rs", "2021");
+        ctx_b.remap_path_prefixes = vec!["/workspace-b=/workspace-b".to_string()];
+
+        assert_ne!(
+            ctx_a.context_key_with_root(Some(Path::new("/workspace-a"))),
+            ctx_b.context_key_with_root(Some(Path::new("/workspace-b"))),
+            "only the remap left side is root-normalized"
+        );
+    }
+
+    #[test]
     fn rustc_different_edition_different_key() {
         let k1 = make_rustc_context("/src/lib.rs", "2021").context_key();
         let k2 = make_rustc_context("/src/lib.rs", "2024").context_key();
@@ -1243,5 +1379,57 @@ mod tests {
             &mut [("serde".to_string(), ext_hash)],
         );
         assert_eq!(ak1, ak2);
+    }
+
+    #[test]
+    fn rustc_artifact_key_with_root_matches_equivalent_source_and_dependency_paths() {
+        let ctx_a = make_rustc_context("/workspace-a/crates/demo/src/lib.rs", "2021");
+        let ctx_b = make_rustc_context("/workspace-b/crates/demo/src/lib.rs", "2021");
+        let root_a = Path::new("/workspace-a");
+        let root_b = Path::new("/workspace-b");
+
+        let ck_a = ctx_a.context_key_with_root(Some(root_a));
+        let ck_b = ctx_b.context_key_with_root(Some(root_b));
+        assert_eq!(ck_a, ck_b);
+
+        let src_hash = zccache_hash::hash_bytes(b"source");
+        let dep_hash = zccache_hash::hash_bytes(b"dependency");
+        let ext_hash = zccache_hash::hash_bytes(b"extern");
+
+        let ak_a = compute_rustc_artifact_key_with_root(
+            &ck_a,
+            &mut [
+                (
+                    NormalizedPath::from("/workspace-a/crates/demo/src/lib.rs"),
+                    src_hash,
+                ),
+                (
+                    NormalizedPath::from("/workspace-a/crates/demo/src/generated.rs"),
+                    dep_hash,
+                ),
+            ],
+            &mut [("serde".to_string(), ext_hash)],
+            Some(root_a),
+        );
+        let ak_b = compute_rustc_artifact_key_with_root(
+            &ck_b,
+            &mut [
+                (
+                    NormalizedPath::from("/workspace-b/crates/demo/src/generated.rs"),
+                    dep_hash,
+                ),
+                (
+                    NormalizedPath::from("/workspace-b/crates/demo/src/lib.rs"),
+                    src_hash,
+                ),
+            ],
+            &mut [("serde".to_string(), ext_hash)],
+            Some(root_b),
+        );
+
+        assert_eq!(
+            ak_a, ak_b,
+            "source and dependency files under equivalent roots should hash relative to those roots"
+        );
     }
 }

--- a/crates/zccache-depgraph/src/graph.rs
+++ b/crates/zccache-depgraph/src/graph.rs
@@ -111,6 +111,26 @@ pub struct DepGraph {
     misses: AtomicU64,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct ContextRegistration {
+    pub key: ContextKey,
+    pub rebased_from_equivalent_root: bool,
+}
+
+fn rebase_project_path(
+    path: &NormalizedPath,
+    old_root: Option<&NormalizedPath>,
+    new_root: Option<&NormalizedPath>,
+) -> NormalizedPath {
+    match (old_root, new_root) {
+        (Some(old_root), Some(new_root)) => path
+            .strip_prefix(old_root)
+            .map(|relative| new_root.join(relative))
+            .unwrap_or_else(|_| path.clone()),
+        _ => path.clone(),
+    }
+}
+
 impl DepGraph {
     /// Create a new empty dependency graph.
     #[must_use]
@@ -137,8 +157,16 @@ impl DepGraph {
         ctx: CompileContext,
         key_root: Option<NormalizedPath>,
     ) -> ContextKey {
+        self.register_with_root_result(ctx, key_root).key
+    }
+
+    pub fn register_with_root_result(
+        &self,
+        ctx: CompileContext,
+        key_root: Option<NormalizedPath>,
+    ) -> ContextRegistration {
         let key = compute_context_key(&ctx, key_root.as_deref());
-        self.register_with_key_and_root(key, ctx, key_root)
+        self.register_with_key_and_root_result(key, ctx, key_root)
     }
 
     /// Register a compilation context with a precomputed key.
@@ -156,19 +184,60 @@ impl DepGraph {
         ctx: CompileContext,
         key_root: Option<NormalizedPath>,
     ) -> ContextKey {
-        self.contexts.entry(key).or_insert_with(|| ContextEntry {
-            context: ctx,
-            key_root,
-            resolved_includes: Vec::new(),
-            unresolved_includes: Vec::new(),
-            has_computed_includes: false,
-            artifact_key: None,
-            last_file_hashes: Vec::new(),
-            last_accessed: Instant::now(),
-            state: ContextState::Cold,
-        });
+        self.register_with_key_and_root_result(key, ctx, key_root)
+            .key
+    }
 
-        key
+    pub fn register_with_key_and_root_result(
+        &self,
+        key: ContextKey,
+        ctx: CompileContext,
+        key_root: Option<NormalizedPath>,
+    ) -> ContextRegistration {
+        let mut rebased_from_equivalent_root = false;
+        self.contexts
+            .entry(key)
+            .and_modify(|entry| {
+                if entry.context.source_file != ctx.source_file || entry.key_root != key_root {
+                    let old_root = entry.key_root.clone();
+                    rebased_from_equivalent_root =
+                        old_root.is_some() && key_root.is_some() && old_root != key_root;
+                    entry.resolved_includes = entry
+                        .resolved_includes
+                        .iter()
+                        .map(|path| rebase_project_path(path, old_root.as_ref(), key_root.as_ref()))
+                        .collect();
+                    entry.last_file_hashes = entry
+                        .last_file_hashes
+                        .iter()
+                        .map(|(path, hash)| {
+                            (
+                                rebase_project_path(path, old_root.as_ref(), key_root.as_ref()),
+                                *hash,
+                            )
+                        })
+                        .collect();
+                    entry.context = ctx.clone();
+                    entry.key_root = key_root.clone();
+                }
+                entry.last_accessed = Instant::now();
+            })
+            .or_insert_with(|| ContextEntry {
+                context: ctx,
+                key_root,
+                resolved_includes: Vec::new(),
+                unresolved_includes: Vec::new(),
+                has_computed_includes: false,
+                artifact_key: None,
+                last_file_hashes: Vec::new(),
+                last_accessed: Instant::now(),
+                state: ContextState::Cold,
+            });
+
+        ContextRegistration {
+            key,
+            rebased_from_equivalent_root,
+        }
     }
 
     /// Returns `true` if the context has never been updated (no artifact key).


### PR DESCRIPTION
Closes #215.

## Summary
- detect a per-request worktree root from `ZCCACHE_WORKTREE_ROOT` or the nearest Git root
- normalize project-local request, Rust context, Rust artifact, and C/C++ depgraph keys across equivalent checkout roots
- rebase equivalent-root depgraph state before serving hits into the current worktree
- add diagnostics for worktree-equivalent hits and document the behavior/safety limits
- add unit coverage plus an ignored real-rustc sibling-worktree integration test

## Parallel work
- depgraph worker added root-aware Rust context/artifact keys and equivalence tests
- daemon/server work added request-level normalization, root detection, validated cross-root request hits, and C/C++ path plumbing
- docs/test worker added README guidance and the real sibling-worktree integration coverage

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo check -p zccache-daemon`
- [x] `cargo test -p zccache-depgraph`
- [x] `cargo test -p zccache-daemon --lib`
- [x] `cargo test -p zccache-daemon --test rustc_cache_test --no-run`
- [x] `cargo test -p zccache-daemon --test rustc_cache_test`
- [x] `cargo test -p zccache-daemon --test rustc_cache_test test_rustc_sibling_git_worktree_equivalent_cache_sharing -- --ignored --nocapture`
- [x] `cargo test -p zccache-daemon --test stress_test adversarial_workspace_rename_hits_cache -- --ignored --nocapture`
- [x] `git diff --check`
- [x] `bash lint` from a sibling non-nested verification worktree
- [x] `ZCCACHE_DISABLE=1 bash test`