### PR TITLE
ci: print perf guard benchmark summary before failing

### DIFF
--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -115,9 +115,10 @@ jobs:
         run: chmod +x perf-guard-bin/perf_bench_test
 
       - name: Run perf regression guard
+        id: perf_guard
         shell: bash
         run: |
-          set -euo pipefail
+          set +e
           python3 -m ci.perf_guard \
             --run-benchmarks \
             --language "${{ matrix.language }}" \
@@ -128,6 +129,9 @@ jobs:
             --attempts 3 \
             --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
             --output-dir perf-guard-output
+          status=$?
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          exit 0
 
       - name: Upload perf guard artifacts
         if: always()
@@ -136,3 +140,31 @@ jobs:
           name: perf-guard-${{ matrix.artifact }}-output
           path: perf-guard-output
           if-no-files-found: warn
+
+      - name: Print perf guard result
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          summary_path="perf-guard-output/perf-guard-summary.md"
+          result_path="perf-guard-output/perf-guard-result.txt"
+          status="${{ steps.perf_guard.outputs.status }}"
+          if [[ -f "$summary_path" ]]; then
+            cat "$summary_path"
+          fi
+          if [[ -f "$result_path" ]]; then
+            result="$(cat "$result_path")"
+          else
+            result="PERF GUARD FAILED: no perf guard result was produced."
+            status=1
+          fi
+          if [[ -z "$status" ]]; then
+            status=1
+          fi
+          if [[ "$status" != "0" ]]; then
+            echo "::error title=Perf guard failed::$result"
+            echo "$result"
+            exit 1
+          fi
+          echo "::notice title=Perf guard ok::$result"
+          echo "$result"

--- a/ci/perf_guard.py
+++ b/ci/perf_guard.py
@@ -264,7 +264,103 @@ def format_report(
         lines.extend(["", "### Failed benchmark attempts", ""])
         lines.extend(f"- Attempt {attempt}" for attempt in report.command_failures)
 
+    lines.extend(["", format_benchmark_summary(report).rstrip()])
+
     return "\n".join(lines) + "\n"
+
+
+def _format_status_check(status: ScenarioStatus) -> str:
+    actual = "n/a" if status.best_ratio is None else f"{status.best_ratio:.3f}x"
+    return (
+        f"{status.language} {status.benchmark_label} / {status.scenario} "
+        f"vs {status.baseline_label}: expected >= {status.threshold:.2f}x, "
+        f"actual {actual}"
+    )
+
+
+def _format_status_summary_line(status: ScenarioStatus) -> str:
+    attempt = "n/a" if status.best_attempt is None else str(status.best_attempt)
+    state = "PASS" if status.passed else "FAIL"
+    return (
+        f"- {state}: {_format_status_check(status)} "
+        f"(best attempt {attempt}; seen {status.attempts_seen})"
+    )
+
+
+def format_benchmark_summary(report: GuardReport) -> str:
+    passed = [status for status in report.statuses if status.passed]
+    failed = [status for status in report.statuses if not status.passed]
+    lines = [
+        "### Benchmark summary",
+        "",
+        f"- Passed checks: {len(passed)}",
+        f"- Failed checks: {len(failed)}",
+    ]
+
+    if report.missing_requirements:
+        lines.append(f"- Missing coverage: {', '.join(report.missing_requirements)}")
+    else:
+        lines.append("- Missing coverage: none")
+
+    if report.command_failures:
+        attempts = ", ".join(str(attempt) for attempt in report.command_failures)
+        lines.append(f"- Failed benchmark attempts: {attempts}")
+    else:
+        lines.append("- Failed benchmark attempts: none")
+
+    if failed:
+        lines.extend(["", "#### Failed checks", ""])
+        lines.extend(_format_status_summary_line(status) for status in failed)
+
+    if passed:
+        lines.extend(["", "#### Passed checks", ""])
+        lines.extend(_format_status_summary_line(status) for status in passed)
+
+    return "\n".join(lines) + "\n"
+
+
+def format_final_status(report: GuardReport) -> str:
+    if report.passed:
+        weakest = min(
+            report.statuses,
+            key=lambda status: (
+                float("inf")
+                if status.best_ratio is None
+                else status.best_ratio / status.threshold
+            ),
+        )
+        return (
+            "PERF GUARD OK: all checks meet configured floors; weakest check "
+            f"{_format_status_check(weakest)}."
+        )
+
+    failed_statuses = [status for status in report.statuses if not status.passed]
+    if failed_statuses:
+        worst = min(
+            failed_statuses,
+            key=lambda status: (
+                -1.0 if status.best_ratio is None else status.best_ratio / status.threshold
+            ),
+        )
+        count = len(failed_statuses)
+        return (
+            f"PERF GUARD FAILED: {count} check{'s' if count != 1 else ''} "
+            f"below floor; worst {_format_status_check(worst)}."
+        )
+
+    if report.missing_requirements:
+        missing = ", ".join(report.missing_requirements)
+        return f"PERF GUARD FAILED: missing required benchmark coverage for {missing}."
+
+    if report.command_failures:
+        attempts = ", ".join(str(attempt) for attempt in report.command_failures)
+        return (
+            "PERF GUARD FAILED: benchmark command failed on all "
+            f"{report.attempt_count} attempt{'s' if report.attempt_count != 1 else ''} "
+            f"({attempts})."
+        )
+
+    return "PERF GUARD FAILED: no benchmark rows were parsed."
 
 
 def format_report_json(
@@ -358,6 +454,11 @@ def write_report_json(
             cold_sccache_threshold=cold_sccache_threshold,
         ),
     )
+
+
+def write_final_status(output_dir: Path, final_status: str) -> None:
+    path = output_dir / "perf-guard-result.txt"
+    path.write_text(final_status + "\n", encoding="utf-8")
 
 
 def _append_step_summary(markdown: str) -> None:
@@ -526,8 +627,9 @@ def main() -> int:
         args.cold_bare_threshold,
         args.cold_sccache_threshold,
     )
+    final_status = format_final_status(report)
     report_path = args.output_dir / "perf-guard-summary.md"
-    report_path.write_text(markdown, encoding="utf-8")
+    report_path.write_text(markdown + "\n" + final_status + "\n", encoding="utf-8")
     write_report_json(
         args.output_dir,
         report,
@@ -537,8 +639,10 @@ def main() -> int:
         cold_bare_threshold=args.cold_bare_threshold,
         cold_sccache_threshold=args.cold_sccache_threshold,
     )
+    write_final_status(args.output_dir, final_status)
     print(markdown)
-    _append_step_summary(markdown)
+    print(final_status)
+    _append_step_summary(markdown + "\n" + final_status + "\n")
 
     return 0 if report.passed else 1
 

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -162,6 +162,64 @@ def test_report_marks_failed_rows():
     markdown = perf_guard.format_report(report, 1.5, 1.5, 1.5, 1.5)
 
     assert "| FAIL | rust | Rust rustc | Build, Cold | Bare rustc | 1.286x | 1.50x | 1 | 1 |" in markdown
+    assert "### Benchmark summary" in markdown
+    assert "#### Failed checks" in markdown
+    assert "#### Passed checks" in markdown
+
+
+def test_benchmark_summary_lists_passes_and_failures():
+    report = perf_guard.evaluate_attempts([rows(FAILING_SCCACHE_LOG)], threshold=1.5)
+
+    summary = perf_guard.format_benchmark_summary(report)
+
+    assert "- Passed checks: 11" in summary
+    assert "- Failed checks: 1" in summary
+    assert "- Missing coverage: none" in summary
+    assert "- Failed benchmark attempts: none" in summary
+    assert (
+        "- FAIL: c++ C++ inline args / Single-file, Cold vs sccache: "
+        "expected >= 1.50x, actual 1.250x (best attempt 1; seen 1)"
+    ) in summary
+    assert (
+        "- PASS: c C inline args / Single-file, Warm vs Bare clang: "
+        "expected >= 1.50x, actual 3.000x (best attempt 1; seen 1)"
+    ) in summary
+
+
+def test_final_status_explains_pass_with_weakest_check():
+    report = perf_guard.evaluate_attempts(
+        [rows(NEAR_BARE_COLD_C_LOG)],
+        languages=("c",),
+    )
+
+    final_status = perf_guard.format_final_status(report)
+
+    assert final_status == (
+        "PERF GUARD OK: all checks meet configured floors; weakest check "
+        "c C inline args / Single-file, Cold vs Bare clang: expected >= 0.85x, "
+        "actual 0.909x."
+    )
+
+
+def test_final_status_explains_worst_failed_floor():
+    report = perf_guard.evaluate_attempts([rows(FAILING_SCCACHE_LOG)], threshold=1.5)
+
+    final_status = perf_guard.format_final_status(report)
+
+    assert final_status == (
+        "PERF GUARD FAILED: 1 check below floor; worst c++ C++ inline args / "
+        "Single-file, Cold vs sccache: expected >= 1.50x, actual 1.250x."
+    )
+
+
+def test_final_status_explains_missing_coverage():
+    report = perf_guard.evaluate_attempts([rows(MISSING_C_LOG)], threshold=1.5)
+
+    final_status = perf_guard.format_final_status(report)
+
+    assert final_status == (
+        "PERF GUARD FAILED: missing required benchmark coverage for c cold, c warm."
+    )
 
 
 def test_report_json_marks_thresholds_and_failed_statuses():
@@ -234,6 +292,16 @@ def test_writes_perf_guard_json_artifacts(tmp_path):
     assert summary_payload["passed"] is True
     assert summary_payload["languages"] == ["c"]
     assert all(status["passed"] for status in summary_payload["statuses"])
+
+
+def test_writes_perf_guard_final_status_artifact(tmp_path):
+    final_status = "PERF GUARD OK: all checks meet configured floors."
+
+    perf_guard.write_final_status(tmp_path, final_status)
+
+    assert (tmp_path / "perf-guard-result.txt").read_text(encoding="utf-8") == (
+        final_status + "\n"
+    )
 
 
 def test_benchmark_language_commands_are_filtered():


### PR DESCRIPTION
## Summary

- Adds an explicit benchmark summary section to perf guard output, with pass/fail counts and failed checks listed first.
- Writes a one-line perf guard result artifact and reprints the full summary in a final workflow step before applying the exit status.
- Covers pass, fail, missing-coverage, and result-artifact formatting in tests.

## Test plan

- `PYTHONPATH=$PWD uv run pytest ci/tests/test_perf_guard.py`
- `git diff --check`