### PR TITLE
chore(release): bump zccache to 1.4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "bincode",
  "blake3",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "libc",
  "md5",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "blake3",
  "clap",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "clang",
  "tempfile",
@@ -3499,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "serde",
  "tempfile",
@@ -3510,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "bincode",
  "clap",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "blake3",
  "dashmap",
@@ -3561,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "blake3",
  "bytes",
@@ -3577,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "clap",
  "serde",
@@ -3587,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "clap",
  "dashmap",
@@ -3632,7 +3632,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "bincode",
  "bytes",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "clap",
  "criterion",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "reqwest",
  "serde",
@@ -3693,7 +3693,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "blake3",
  "criterion",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "bytes",
  "serde",
@@ -3719,7 +3719,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "bincode",
  "bytes",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3741,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["dylints/ban_std_pathbuf"]
 
 [workspace.package]
-version = "1.4.5"
+version = "1.4.6"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump the zccache workspace version from 1.4.5 to 1.4.6.
- Refresh Cargo.lock workspace package entries to 1.4.6.

## Test plan
- uv run python -c "from ci.release_checks import validate_release_versions; validate_release_versions(); print('release version metadata ok')"
- soldr --no-cache cargo check -p zccache-core --locked
- git diff --check
- uv run python -c "from ci.release_checks import validate_release_metadata; validate_release_metadata(); print('release metadata ok')"
