### PR TITLE
ci: color perf guard failures red

### DIFF
--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -149,8 +149,18 @@ jobs:
           summary_path="perf-guard-output/perf-guard-summary.md"
           result_path="perf-guard-output/perf-guard-result.txt"
           status="${{ steps.perf_guard.outputs.status }}"
+          print_fail_colored() {
+            local line
+            while IFS= read -r line || [[ -n "$line" ]]; do
+              if [[ "$line" == *FAIL* ]]; then
+                printf '\033[31m%s\033[0m\n' "$line"
+              else
+                printf '%s\n' "$line"
+              fi
+            done
+          }
           if [[ -f "$summary_path" ]]; then
-            cat "$summary_path"
+            print_fail_colored < "$summary_path"
           fi
           if [[ -f "$result_path" ]]; then
             result="$(cat "$result_path")"
@@ -163,8 +173,8 @@ jobs:
           fi
           if [[ "$status" != "0" ]]; then
             echo "::error title=Perf guard failed::$result"
-            echo "$result"
+            printf '%s\n' "$result" | print_fail_colored
             exit 1
           fi
           echo "::notice title=Perf guard ok::$result"
-          echo "$result"
+          printf '%s\n' "$result" | print_fail_colored


### PR DESCRIPTION
## Summary
- Color any printed perf guard summary/result line containing FAIL in red using ANSI escapes.
- Keep GitHub workflow annotations plain while coloring human-readable log output.

## Test plan
- Bash assertion for print_fail_colored helper
- PYTHONPATH=. uv run pytest ci/tests/test_perf_guard.py
- git diff --check