### PR TITLE
ci: run perf guard compilers at benchmark priority

### DIFF
--- a/ci/perf_guard.py
+++ b/ci/perf_guard.py
@@ -102,9 +102,7 @@ def run_benchmarks_once(
     benchmark_binary: Path | None = None,
 ) -> tuple[int, str]:
     cache_dir = Path(tempfile.mkdtemp(prefix="zccache-perf-guard-cache-"))
-    env = os.environ.copy()
-    env["ZCCACHE_CACHE_DIR"] = str(cache_dir)
-    env.pop("RUSTC_WRAPPER", None)
+    env = _benchmark_env(cache_dir, language)
 
     try:
         outputs: list[str] = []
@@ -132,6 +130,16 @@ def run_benchmarks_once(
     log_path.write_text(output, encoding="utf-8")
     print(output, end="")
     return returncode, output
+
+
+def _benchmark_env(cache_dir: Path, language: str | None) -> dict[str, str]:
+    env = os.environ.copy()
+    env["ZCCACHE_CACHE_DIR"] = str(cache_dir)
+    env["ZCCACHE_COMPILE_PRIORITY"] = "high"
+    if language == "rust":
+        env["ZCCACHE_PROFILE_RUST_MISS"] = "1"
+    env.pop("RUSTC_WRAPPER", None)
+    return env
 
 
 def _required_rows(

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -336,3 +336,23 @@ def test_prebuilt_benchmark_binary_commands_are_filtered():
             "--test-threads=1",
         ],
     ]
+
+
+def test_benchmark_env_uses_realtime_priority_and_profiles_rust(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("RUSTC_WRAPPER", "sccache")
+
+    env = perf_guard._benchmark_env(tmp_path, "rust")
+
+    assert env["ZCCACHE_CACHE_DIR"] == str(tmp_path)
+    assert env["ZCCACHE_COMPILE_PRIORITY"] == "high"
+    assert env["ZCCACHE_PROFILE_RUST_MISS"] == "1"
+    assert "RUSTC_WRAPPER" not in env
+
+
+def test_benchmark_env_does_not_enable_rust_profile_for_other_languages(tmp_path):
+    env = perf_guard._benchmark_env(tmp_path, "c++")
+
+    assert env["ZCCACHE_COMPILE_PRIORITY"] == "high"
+    assert "ZCCACHE_PROFILE_RUST_MISS" not in env

--- a/crates/zccache-daemon/src/process.rs
+++ b/crates/zccache-daemon/src/process.rs
@@ -49,6 +49,15 @@ impl CompilePriority {
         }
     }
 
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Normal => "normal",
+            Self::Low => "low",
+            Self::Idle => "idle",
+            Self::High => "high",
+        }
+    }
+
     fn parse_or_warn(value: &str) -> Self {
         match Self::parse(value) {
             Ok(priority) => priority,
@@ -340,6 +349,14 @@ mod tests {
             CompilePriority::High
         );
         assert!(CompilePriority::parse("fast").is_err());
+    }
+
+    #[test]
+    fn formats_compile_priority_for_profiles() {
+        assert_eq!(CompilePriority::Normal.as_str(), "normal");
+        assert_eq!(CompilePriority::Low.as_str(), "low");
+        assert_eq!(CompilePriority::Idle.as_str(), "idle");
+        assert_eq!(CompilePriority::High.as_str(), "high");
     }
 
     #[test]

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -2533,17 +2533,38 @@ fn persist_artifact_output(cache_path: &Path, payload: &[u8]) -> std::io::Result
     result
 }
 
-fn persist_artifact_file(cache_path: &Path, source_path: &Path) -> std::io::Result<()> {
+#[derive(Clone, Copy, Debug, Default)]
+struct PersistArtifactFileStats {
+    hardlink_count: u64,
+    copy_count: u64,
+    copy_bytes: u64,
+}
+
+fn persist_artifact_file(
+    cache_path: &Path,
+    source_path: &Path,
+) -> std::io::Result<PersistArtifactFileStats> {
     if let Some(parent) = cache_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
 
     let tmp_path = artifact_persist_tmp_path(cache_path);
     let result = (|| match std::fs::hard_link(source_path, &tmp_path) {
-        Ok(()) => replace_artifact_cache_file(&tmp_path, cache_path),
+        Ok(()) => {
+            replace_artifact_cache_file(&tmp_path, cache_path)?;
+            Ok(PersistArtifactFileStats {
+                hardlink_count: 1,
+                ..PersistArtifactFileStats::default()
+            })
+        }
         Err(_) => {
-            std::fs::copy(source_path, &tmp_path)?;
-            replace_artifact_cache_file(&tmp_path, cache_path)
+            let copy_bytes = std::fs::copy(source_path, &tmp_path)?;
+            replace_artifact_cache_file(&tmp_path, cache_path)?;
+            Ok(PersistArtifactFileStats {
+                copy_count: 1,
+                copy_bytes,
+                ..PersistArtifactFileStats::default()
+            })
         }
     })();
     if result.is_err() {
@@ -4047,6 +4068,7 @@ async fn handle_compile(
     } else {
         vec![output_path.clone()]
     };
+    let t_break_outputs = std::time::Instant::now();
     for path in &output_paths {
         if let Err(e) = break_output_hardlink_before_compile(path) {
             return Response::Error {
@@ -4057,6 +4079,7 @@ async fn handle_compile(
             };
         }
     }
+    let break_outputs_ns = t_break_outputs.elapsed().as_nanos() as u64;
 
     let mut cmd = tokio::process::Command::new(&compiler);
     if let Some(ref rsp) = _rsp_guard {
@@ -4310,6 +4333,15 @@ async fn handle_compile(
         let mut artifact_build_ns = 0;
         let mut persist_enqueue_ns = 0;
         let mut artifact_insert_stats_ns = 0;
+        let mut artifact_meta_build_ns = 0;
+        let mut rust_snapshot_ns = 0;
+        let mut rust_snapshot_hardlink_count = 0;
+        let mut rust_snapshot_copy_count = 0;
+        let mut rust_snapshot_copy_bytes = 0;
+        let mut rust_snapshot_error_count = 0;
+        let mut artifact_index_build_ns = 0;
+        let mut artifact_index_persist_ns = 0;
+        let mut artifact_memory_insert_ns = 0;
         if let Some(artifact_key) = artifact_key_result {
             let artifact_key_hex = artifact_key.hash().to_hex();
             let ctx_hex = &context_key.hash().to_hex()[..8];
@@ -4336,6 +4368,7 @@ async fn handle_compile(
             // Build artifact — multi-output for Rustc, single output for C/C++.
             let t_artifact_build = std::time::Instant::now();
             if let Some(ref all_outputs) = rustc_all_outputs {
+                let t_artifact_meta_build = std::time::Instant::now();
                 let artifact_bytes: u64 = all_outputs.iter().map(|o| o.size).sum();
                 let output_names: Vec<String> =
                     all_outputs.iter().map(|o| o.name.clone()).collect();
@@ -4343,23 +4376,35 @@ async fn handle_compile(
                 let payload_paths: Vec<NormalizedPath> = (0..all_outputs.len())
                     .map(|i| state.artifact_dir.join(format!("{artifact_key_hex}_{i}")))
                     .collect();
+                artifact_meta_build_ns = t_artifact_meta_build.elapsed().as_nanos() as u64;
 
                 let mut snapshot_ok = true;
+                let t_rust_snapshot = std::time::Instant::now();
                 for (output, cache_path) in all_outputs.iter().zip(payload_paths.iter()) {
-                    if let Err(e) = persist_artifact_file(cache_path, &output.path) {
-                        snapshot_ok = false;
-                        tracing::warn!(
-                            source = %output.path.display(),
-                            cache = %cache_path.display(),
-                            "failed to snapshot rustc output: {e}"
-                        );
-                        break;
+                    match persist_artifact_file(cache_path, &output.path) {
+                        Ok(stats) => {
+                            rust_snapshot_hardlink_count += stats.hardlink_count;
+                            rust_snapshot_copy_count += stats.copy_count;
+                            rust_snapshot_copy_bytes += stats.copy_bytes;
+                        }
+                        Err(e) => {
+                            rust_snapshot_error_count += 1;
+                            snapshot_ok = false;
+                            tracing::warn!(
+                                source = %output.path.display(),
+                                cache = %cache_path.display(),
+                                "failed to snapshot rustc output: {e}"
+                            );
+                            break;
+                        }
                     }
                 }
+                rust_snapshot_ns = t_rust_snapshot.elapsed().as_nanos() as u64;
                 artifact_build_ns = t_artifact_build.elapsed().as_nanos() as u64;
 
                 let t_artifact_insert_stats = std::time::Instant::now();
                 if snapshot_ok {
+                    let t_artifact_index_build = std::time::Instant::now();
                     let meta = ArtifactIndex::new(
                         output_names,
                         output_sizes,
@@ -4367,14 +4412,21 @@ async fn handle_compile(
                         Arc::clone(&stderr),
                         exit_code,
                     );
+                    artifact_index_build_ns = t_artifact_index_build.elapsed().as_nanos() as u64;
+                    let t_artifact_index_persist = std::time::Instant::now();
                     if let Err(e) = state.artifact_store.insert(&artifact_key_hex, &meta) {
                         tracing::warn!(
                             key = %artifact_key_hex,
                             "failed to persist artifact index: {e}"
                         );
                     }
+                    artifact_index_persist_ns =
+                        t_artifact_index_persist.elapsed().as_nanos() as u64;
+                    let t_artifact_memory_insert = std::time::Instant::now();
                     let cached = CachedArtifact::from_file_payloads(meta, payload_paths);
                     state.artifacts.insert(artifact_key_hex, cached);
+                    artifact_memory_insert_ns =
+                        t_artifact_memory_insert.elapsed().as_nanos() as u64;
                 }
 
                 let latency_ns = compile_start.elapsed().as_nanos() as u64;
@@ -4509,18 +4561,24 @@ async fn handle_compile(
             eprintln!(
                 concat!(
                     "zccache_rust_miss_profile ",
-                    "mode={} total_ns={} pre_exec_ns={} system_includes_ns={} ",
+                    "mode={} compiler_priority={} total_ns={} pre_exec_ns={} system_includes_ns={} ",
                     "system_watch_ns={} parse_args_ns={} build_context_ns={} ",
                     "hash_source_ns={} hash_headers_ns={} depgraph_check_ns={} ",
-                    "pre_exec_other_ns={} compiler_prep_ns={} compiler_process_ns={} ",
+                    "pre_exec_other_ns={} break_outputs_ns={} compiler_prep_ns={} compiler_process_ns={} ",
                     "post_exec_ns={} apply_changes_ns={} collect_outputs_ns={} ",
                     "outputs={} output_bytes={} include_scan_ns={} ",
                     "register_tracked_ns={} dep_dirs_ns={} hash_all_ns={} ",
                     "artifact_store_ns={} depgraph_update_ns={} artifact_build_ns={} ",
+                    "artifact_meta_build_ns={} rust_snapshot_ns={} ",
+                    "rust_snapshot_hardlink_count={} rust_snapshot_copy_count={} ",
+                    "rust_snapshot_copy_bytes={} rust_snapshot_error_count={} ",
                     "persist_enqueue_ns={} artifact_insert_stats_ns={} ",
+                    "artifact_index_build_ns={} artifact_index_persist_ns={} ",
+                    "artifact_memory_insert_ns={} ",
                     "artifact_store_other_ns={} unaccounted_ns={}"
                 ),
                 rust_profile_mode,
+                compiler_priority.as_str(),
                 total_ns,
                 pre_exec_ns,
                 system_includes_ns,
@@ -4531,6 +4589,7 @@ async fn handle_compile(
                 hash_headers_ns,
                 depgraph_check_ns,
                 pre_exec_other_ns,
+                break_outputs_ns,
                 compiler_prep_ns,
                 compiler_process_ns,
                 post_exec_ns,
@@ -4545,8 +4604,17 @@ async fn handle_compile(
                 artifact_store_ns,
                 depgraph_update_ns,
                 artifact_build_ns,
+                artifact_meta_build_ns,
+                rust_snapshot_ns,
+                rust_snapshot_hardlink_count,
+                rust_snapshot_copy_count,
+                rust_snapshot_copy_bytes,
+                rust_snapshot_error_count,
                 persist_enqueue_ns,
                 artifact_insert_stats_ns,
+                artifact_index_build_ns,
+                artifact_index_persist_ns,
+                artifact_memory_insert_ns,
                 artifact_store_other_ns,
                 unaccounted_ns,
             );
@@ -6872,6 +6940,26 @@ exit /b 0
             !same_file(&out, &cache),
             "cache path replacement should break the hardlink relationship"
         );
+    }
+
+    #[test]
+    fn persist_artifact_file_reports_hardlink_snapshot_stats() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("libunit.rlib");
+        let cache = dir.path().join("artifact-key_0");
+        let content = b"compiled rust artifact";
+        std::fs::write(&source, content).unwrap();
+
+        let stats = persist_artifact_file(&cache, &source).unwrap();
+
+        assert_eq!(std::fs::read(&cache).unwrap(), content);
+        assert!(
+            same_file(&source, &cache),
+            "same-directory snapshots should use a hardlink"
+        );
+        assert_eq!(stats.hardlink_count, 1);
+        assert_eq!(stats.copy_count, 0);
+        assert_eq!(stats.copy_bytes, 0);
     }
 
     /// Regression test for issue #197: a cache hit hardlinks the target

--- a/crates/zccache-daemon/tests/rustc_issue_210_async_populate_test.rs
+++ b/crates/zccache-daemon/tests/rustc_issue_210_async_populate_test.rs
@@ -25,18 +25,36 @@ fn env_lock() -> &'static Mutex<()> {
 struct CacheEnvGuard {
     _lock: MutexGuard<'static, ()>,
     old_cache_dir: Option<String>,
+    old_profile_rust_miss: Option<String>,
+    old_compile_priority: Option<String>,
 }
 
 impl CacheEnvGuard {
     fn new(cache_dir: &Path) -> Self {
+        Self::new_inner(cache_dir, false)
+    }
+
+    fn new_profiled(cache_dir: &Path) -> Self {
+        Self::new_inner(cache_dir, true)
+    }
+
+    fn new_inner(cache_dir: &Path, profiled: bool) -> Self {
         let lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
         let old_cache_dir = std::env::var(zccache_core::config::CACHE_DIR_ENV).ok();
+        let old_profile_rust_miss = std::env::var("ZCCACHE_PROFILE_RUST_MISS").ok();
+        let old_compile_priority = std::env::var("ZCCACHE_COMPILE_PRIORITY").ok();
         unsafe {
             std::env::set_var(zccache_core::config::CACHE_DIR_ENV, cache_dir);
+            if profiled {
+                std::env::set_var("ZCCACHE_PROFILE_RUST_MISS", "1");
+                std::env::set_var("ZCCACHE_COMPILE_PRIORITY", "high");
+            }
         }
         Self {
             _lock: lock,
             old_cache_dir,
+            old_profile_rust_miss,
+            old_compile_priority,
         }
     }
 }
@@ -47,6 +65,14 @@ impl Drop for CacheEnvGuard {
             match &self.old_cache_dir {
                 Some(value) => std::env::set_var(zccache_core::config::CACHE_DIR_ENV, value),
                 None => std::env::remove_var(zccache_core::config::CACHE_DIR_ENV),
+            }
+            match &self.old_profile_rust_miss {
+                Some(value) => std::env::set_var("ZCCACHE_PROFILE_RUST_MISS", value),
+                None => std::env::remove_var("ZCCACHE_PROFILE_RUST_MISS"),
+            }
+            match &self.old_compile_priority {
+                Some(value) => std::env::set_var("ZCCACHE_COMPILE_PRIORITY", value),
+                None => std::env::remove_var("ZCCACHE_COMPILE_PRIORITY"),
             }
         }
     }
@@ -227,6 +253,45 @@ async fn wait_for_rust_artifacts(client: &mut ClientConn) -> Vec<RustArtifactInf
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
     list_rust_artifacts(client).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn profiled_rust_build_miss_populates_artifact() {
+    let rustc = match zccache_test_support::find_rustc() {
+        Some(path) => path,
+        None => return,
+    };
+
+    zccache_test_support::test_timeout(async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let _cache_env = CacheEnvGuard::new_profiled(&tmp.path().join("cache"));
+        let src = tmp.path().join("lib.rs");
+        let out_dir = tmp.path().join("deps");
+        std::fs::create_dir_all(&out_dir).unwrap();
+        write_lib(&src, 232);
+
+        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let mut client = zccache_ipc::connect(&endpoint).await.unwrap();
+        let session_id = start_session(&mut client).await;
+        let args = cargo_build_args(&src, &out_dir, "profile232", "profile232");
+
+        let (exit_code, cached) =
+            compile(&mut client, &session_id, &rustc, &args, tmp.path()).await;
+        assert_eq!(exit_code, 0);
+        assert!(!cached, "profiled build-mode cold compile should miss");
+
+        let artifacts = list_rust_artifacts(&mut client).await;
+        let names = artifact_names(&artifacts);
+        assert!(
+            names
+                .iter()
+                .any(|name| name.ends_with("libprofile232-profile232.rlib")),
+            "profiled build miss should publish the rlib artifact; names={names:?}"
+        );
+
+        stop_daemon(server_handle, shutdown).await;
+    })
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary
- Run perf-guard benchmark commands with `ZCCACHE_COMPILE_PRIORITY=high` so wall-clock perf checks do not compare low-priority zccache compiler children against normal-priority bare rustc/sccache.
- Enable `ZCCACHE_PROFILE_RUST_MISS=1` automatically for Rust perf-guard runs.
- Expand Rust miss profile output with compiler priority, output-detach timing, Rust payload snapshot hardlink/copy counts, and artifact index timing.

Closes #232

## Profiling Notes
- Current daemon default remains `low`; only the perf guard benchmark environment opts into the existing high benchmark mode.
- Local Windows sanity showed the likely culprit was compiler child priority, not Rust artifact snapshotting. With high priority, Rust `Build, Cold` improved to passing locally: `0.892x` vs bare and `1.077x` vs sccache.
- The new profile line showed Rust build snapshots using hardlinks (`rust_snapshot_hardlink_count=3`, `rust_snapshot_copy_count=0`) and only a few ms in snapshot/index work per miss.

## Test Plan
- [x] `python -m pytest ci/tests/test_perf_guard.py`
- [x] `cargo test -p zccache-daemon process::tests --lib`
- [x] `cargo test -p zccache-daemon --lib`
- [x] `cargo test -p zccache-daemon --test rustc_issue_210_async_populate_test profiled_rust_build_miss_populates_artifact -- --nocapture`
- [x] `cargo test -p zccache-daemon --test rustc_issue_210_async_populate_test -- --ignored --nocapture`
- [x] `cargo test -p zccache-daemon`
- [x] `python -m ci.perf_guard --run-benchmarks --language rust --bare-threshold 1.5 --sccache-threshold 1.5 --cold-bare-threshold 0.85 --cold-sccache-threshold 1.0 --attempts 1 --benchmark-binary <local perf_bench_test.exe> --output-dir perf-guard-output` (Windows sanity; Build, Cold passed, Check, Cold was 0.831x vs the 0.85x bare floor on a single attempt)