### PR TITLE
feat: add C/C++ path remap auto for compile and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,20 @@ project-local source, dependency, cwd, and safe path arguments relative to that
 root, and writes cache hits back to the output paths requested by the current
 worktree.
 
+For C/C++ projects, enable compiler path remapping so path-sensitive outputs
+such as `__FILE__`, debug/source paths, and compatible link search paths can
+share cache entries across equivalent Git roots:
+
+```bash
+export ZCCACHE_PATH_REMAP=auto
+```
+
+In auto mode, zccache discovers the enclosing Git root and internally adds
+root/cwd `-ffile-prefix-map=...=.` arguments for GCC/Clang-family compile
+misses. The original build files do not need to inject those flags themselves.
+For link requests, zccache normalizes proven workspace-local input/search paths
+for cache identity while preserving physical output and runtime-facing paths.
+
 Set `ZCCACHE_WORKTREE_ROOT` when automatic Git-root detection is not reliable
 or when a wrapper/test needs to define the normalization root explicitly:
 

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -60,7 +60,10 @@ const REQUEST_CACHE_MAX_ENTRIES: usize = 4096;
 const RSP_CACHE_MAX_ENTRIES: usize = 1024;
 const RUST_MISS_PROFILE_ENV: &str = "ZCCACHE_PROFILE_RUST_MISS";
 const WORKTREE_ROOT_ENV: &str = "ZCCACHE_WORKTREE_ROOT";
+const PATH_REMAP_ENV: &str = "ZCCACHE_PATH_REMAP";
 const REQUEST_ROOT_MARKER: &str = "$ZCCACHE_WORKTREE_ROOT";
+const LINK_PATH_REMAP_AUTO_KEY_FLAG: &str = "zccache:path-remap=auto";
+const LINK_PATH_REMAP_ROOT_SPECIFIC_FLAG: &str = "zccache:path-remap=root-specific";
 
 #[derive(Clone)]
 struct RspDependency {
@@ -1495,6 +1498,12 @@ async fn handle_link_ephemeral(
     use zccache_compiler::parse_linker::{parse_linker_invocation, ParsedLinkerInvocation};
 
     state.stats.record_link();
+    let worktree_root = resolve_worktree_root(cwd, env.as_deref());
+    let link_path_remap_key_root = if path_remap_auto_enabled(env.as_deref()) {
+        worktree_root.as_deref()
+    } else {
+        None
+    };
 
     // 1. Parse the tool invocation — try archiver first, then linker
     struct ParsedTool {
@@ -1573,13 +1582,33 @@ async fn handle_link_ephemeral(
 
     // 4. Hash all input files
     let cwd_path = std::path::Path::new(cwd);
+    let link_key_plan = build_link_path_remap_key_plan(
+        &parsed_tool.cache_relevant_flags,
+        cwd_path,
+        link_path_remap_key_root,
+    );
     let mut key_builder = zccache_hash::link_cache_key::LinkCacheKeyBuilder::new().tool(tool_hash);
 
-    for flag in &parsed_tool.cache_relevant_flags {
+    if link_path_remap_key_root.is_some() {
+        key_builder = key_builder.flag(LINK_PATH_REMAP_AUTO_KEY_FLAG);
+    }
+    if link_key_plan.root_specific {
+        let root_identity = link_path_remap_key_root
+            .map(zccache_core::path::normalize_for_key)
+            .unwrap_or_default();
+        key_builder = key_builder.flag(format!(
+            "{LINK_PATH_REMAP_ROOT_SPECIFIC_FLAG}:{root_identity}"
+        ));
+    }
+    for flag in &link_key_plan.flags {
         key_builder = key_builder.flag(flag);
     }
 
-    for input in &parsed_tool.input_files {
+    for input in parsed_tool
+        .input_files
+        .iter()
+        .chain(link_key_plan.extra_input_files.iter())
+    {
         let input_path = if input.is_absolute() {
             input.clone()
         } else {
@@ -3003,6 +3032,11 @@ fn client_env_value<'a>(client_env: Option<&'a [(String, String)]>, name: &str) 
         .filter(|value| !value.is_empty())
 }
 
+fn path_remap_auto_enabled(client_env: Option<&[(String, String)]>) -> bool {
+    client_env_value(client_env, PATH_REMAP_ENV)
+        .is_some_and(|value| value.eq_ignore_ascii_case("auto"))
+}
+
 fn resolve_worktree_root(
     cwd: &Path,
     client_env: Option<&[(String, String)]>,
@@ -3053,10 +3087,98 @@ fn normalize_request_path_value(value: &str, key_root: Option<&Path>) -> Option<
     None
 }
 
+const CC_PREFIX_MAP_FLAGS: &[&str] = &[
+    "-ffile-prefix-map",
+    "-fmacro-prefix-map",
+    "-fdebug-prefix-map",
+    "-fcoverage-prefix-map",
+    "-fprofile-prefix-map",
+];
+
+fn split_cc_prefix_map_arg(arg: &str) -> Option<(&'static str, &str, &str)> {
+    for flag in CC_PREFIX_MAP_FLAGS {
+        if let Some(rest) = arg
+            .strip_prefix(*flag)
+            .and_then(|rest| rest.strip_prefix('='))
+        {
+            if let Some((old, new)) = rest.split_once('=') {
+                return Some((*flag, old, new));
+            }
+        }
+    }
+    None
+}
+
+fn normalize_cc_prefix_map_arg_for_key(arg: &str, key_root: Option<&Path>) -> Option<String> {
+    let (flag, old, new) = split_cc_prefix_map_arg(arg)?;
+    normalize_request_path_value(old, key_root)
+        .map(|normalized_old| format!("{flag}={normalized_old}={new}"))
+}
+
+fn same_key_path(left: &Path, right: &Path) -> bool {
+    zccache_core::path::normalize_for_key(left) == zccache_core::path::normalize_for_key(right)
+}
+
+fn has_ffile_prefix_map_for_old(args: &[String], old: &Path) -> bool {
+    args.iter().any(|arg| {
+        let Some((flag, existing_old, _)) = split_cc_prefix_map_arg(arg) else {
+            return false;
+        };
+        flag == "-ffile-prefix-map" && same_key_path(Path::new(existing_old), old)
+    })
+}
+
+fn compiler_supports_ffile_prefix_map(compiler_path: &Path) -> bool {
+    matches!(
+        zccache_compiler::detect_family(&compiler_path.to_string_lossy()),
+        zccache_compiler::CompilerFamily::Clang | zccache_compiler::CompilerFamily::Gcc
+    )
+}
+
+fn effective_compile_args(
+    expanded_args: &[String],
+    compiler_path: &Path,
+    cwd: &Path,
+    worktree_root: Option<&NormalizedPath>,
+    client_env: Option<&[(String, String)]>,
+) -> Vec<String> {
+    let mut effective = expanded_args.to_vec();
+    if !path_remap_auto_enabled(client_env) || !compiler_supports_ffile_prefix_map(compiler_path) {
+        return effective;
+    }
+
+    let Some(root) = worktree_root else {
+        return effective;
+    };
+
+    let root_path = root.as_path();
+    if !has_ffile_prefix_map_for_old(&effective, root_path) {
+        effective.push(format!(
+            "-ffile-prefix-map={}={}",
+            root_path.to_string_lossy(),
+            "."
+        ));
+    }
+
+    if !same_key_path(root_path, cwd) && !has_ffile_prefix_map_for_old(&effective, cwd) {
+        effective.push(format!(
+            "-ffile-prefix-map={}={}",
+            cwd.to_string_lossy(),
+            "."
+        ));
+    }
+
+    effective
+}
+
 fn normalize_request_arg(arg: &str, key_root: Option<&Path>) -> String {
     let Some(root) = key_root else {
         return arg.to_string();
     };
+
+    if let Some(normalized) = normalize_cc_prefix_map_arg_for_key(arg, Some(root)) {
+        return normalized;
+    }
 
     if let Some(normalized) = normalize_request_path_value(arg, Some(root)) {
         return normalized;
@@ -3065,6 +3187,12 @@ fn normalize_request_arg(arg: &str, key_root: Option<&Path>) -> String {
     if let Some(rest) = arg.strip_prefix("-I").filter(|rest| !rest.is_empty()) {
         if let Some(normalized) = normalize_request_path_value(rest, Some(root)) {
             return format!("-I{normalized}");
+        }
+    }
+
+    if let Some(rest) = arg.strip_prefix("-L").filter(|rest| !rest.is_empty()) {
+        if let Some(normalized) = normalize_request_path_value(rest, Some(root)) {
+            return format!("-L{normalized}");
         }
     }
 
@@ -3078,6 +3206,306 @@ fn normalize_request_arg(arg: &str, key_root: Option<&Path>) -> String {
     }
 
     arg.to_string()
+}
+
+fn normalize_link_path_value_for_key(value: &str, key_root: Option<&Path>) -> String {
+    let Some(root) = key_root else {
+        return value.to_string();
+    };
+
+    normalize_request_path_value(value, Some(root)).unwrap_or_else(|| value.to_string())
+}
+
+fn normalize_link_flag_atom_for_key(atom: &str, key_root: Option<&Path>) -> String {
+    let Some(root) = key_root else {
+        return atom.to_string();
+    };
+
+    if let Some(normalized) = normalize_cc_prefix_map_arg_for_key(atom, Some(root)) {
+        return normalized;
+    }
+
+    if let Some(rest) = atom.strip_prefix("-L").filter(|rest| !rest.is_empty()) {
+        if let Some(normalized) = normalize_request_path_value(rest, Some(root)) {
+            return format!("-L{normalized}");
+        }
+    }
+
+    for prefix in [
+        "--library-path=",
+        "--version-script=",
+        "--script=",
+        "--sysroot=",
+    ] {
+        if let Some(rest) = atom.strip_prefix(prefix) {
+            if let Some(normalized) = normalize_request_path_value(rest, Some(root)) {
+                return format!("{prefix}{normalized}");
+            }
+        }
+    }
+
+    for prefix in ["/LIBPATH:", "/DEF:"] {
+        if atom
+            .get(..prefix.len())
+            .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
+        {
+            let rest = &atom[prefix.len()..];
+            if let Some(normalized) = normalize_request_path_value(rest, Some(root)) {
+                return format!("{}{normalized}", &atom[..prefix.len()]);
+            }
+        }
+    }
+
+    if let Some((left, right)) = atom.split_once('=') {
+        if let Some(normalized_right) = normalize_request_path_value(right, Some(root)) {
+            return format!("{left}={normalized_right}");
+        }
+    }
+
+    atom.to_string()
+}
+
+fn normalize_wl_flag_for_key(flag: &str, key_root: Option<&Path>) -> String {
+    let mut parts: Vec<String> = flag.split(',').map(|part| part.to_string()).collect();
+
+    let mut i = 1;
+    while i < parts.len() {
+        let normalize = matches!(
+            parts[i].as_str(),
+            "-L" | "-T" | "--script" | "--version-script" | "--library-path" | "--sysroot"
+        );
+        if normalize && i + 1 < parts.len() {
+            parts[i + 1] = normalize_link_path_value_for_key(&parts[i + 1], key_root);
+            i += 2;
+            continue;
+        }
+        parts[i] = normalize_link_flag_atom_for_key(&parts[i], key_root);
+        i += 1;
+    }
+
+    parts.join(",")
+}
+
+fn normalize_link_cache_flag_for_key(flag: &str, key_root: Option<&Path>) -> String {
+    if flag.starts_with("-Wl,") {
+        normalize_wl_flag_for_key(flag, key_root)
+    } else {
+        normalize_link_flag_atom_for_key(flag, key_root)
+    }
+}
+
+fn normalize_link_cache_flags_for_key(flags: &[String], key_root: Option<&Path>) -> Vec<String> {
+    let mut normalized = Vec::with_capacity(flags.len());
+    let mut previous_path_flag = false;
+
+    for flag in flags {
+        if previous_path_flag {
+            normalized.push(normalize_link_path_value_for_key(flag, key_root));
+            previous_path_flag = false;
+            continue;
+        }
+
+        normalized.push(normalize_link_cache_flag_for_key(flag, key_root));
+        previous_path_flag = matches!(
+            flag.as_str(),
+            "-L" | "-T" | "--script" | "--version-script" | "--library-path" | "-isysroot"
+        ) || flag.eq_ignore_ascii_case("/DEF");
+    }
+
+    normalized
+}
+
+#[derive(Debug, Default)]
+struct LinkSearchAnalysis {
+    search_dirs: Vec<NormalizedPath>,
+    lib_names: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+struct LinkPathRemapKeyPlan {
+    flags: Vec<String>,
+    extra_input_files: Vec<NormalizedPath>,
+    root_specific: bool,
+}
+
+fn link_path_to_absolute(path: &Path, cwd: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
+fn path_is_under_root(path: &Path, root: &Path) -> bool {
+    path.strip_prefix(root).is_ok()
+}
+
+fn push_link_search_dir(analysis: &mut LinkSearchAnalysis, value: &str) {
+    analysis.search_dirs.push(NormalizedPath::new(value));
+}
+
+fn push_link_lib_name(analysis: &mut LinkSearchAnalysis, value: &str) {
+    if !value.is_empty() {
+        analysis.lib_names.push(value.to_string());
+    }
+}
+
+fn analyze_link_search_flags(flags: &[String]) -> LinkSearchAnalysis {
+    let mut analysis = LinkSearchAnalysis::default();
+    let mut previous_search_dir_flag = false;
+
+    for flag in flags {
+        if previous_search_dir_flag {
+            push_link_search_dir(&mut analysis, flag);
+            previous_search_dir_flag = false;
+            continue;
+        }
+
+        match flag.as_str() {
+            "-L" | "--library-path" => {
+                previous_search_dir_flag = true;
+                continue;
+            }
+            _ => {}
+        }
+
+        if let Some(rest) = flag.strip_prefix("-L").filter(|rest| !rest.is_empty()) {
+            push_link_search_dir(&mut analysis, rest);
+            continue;
+        }
+        if let Some(rest) = flag.strip_prefix("--library-path=") {
+            push_link_search_dir(&mut analysis, rest);
+            continue;
+        }
+        if let Some(rest) = flag.strip_prefix("-l").filter(|rest| !rest.is_empty()) {
+            push_link_lib_name(&mut analysis, rest);
+            continue;
+        }
+
+        if let Some(rest) = flag.strip_prefix("-Wl,") {
+            let parts: Vec<&str> = rest.split(',').collect();
+            let mut i = 0;
+            while i < parts.len() {
+                match parts[i] {
+                    "-L" | "--library-path" => {
+                        if i + 1 < parts.len() {
+                            push_link_search_dir(&mut analysis, parts[i + 1]);
+                        }
+                        i += 2;
+                        continue;
+                    }
+                    "-l" => {
+                        if i + 1 < parts.len() {
+                            push_link_lib_name(&mut analysis, parts[i + 1]);
+                        }
+                        i += 2;
+                        continue;
+                    }
+                    part => {
+                        if let Some(rest) = part.strip_prefix("-L").filter(|s| !s.is_empty()) {
+                            push_link_search_dir(&mut analysis, rest);
+                        } else if let Some(rest) = part
+                            .strip_prefix("--library-path=")
+                            .filter(|s| !s.is_empty())
+                        {
+                            push_link_search_dir(&mut analysis, rest);
+                        } else if let Some(rest) = part.strip_prefix("-l").filter(|s| !s.is_empty())
+                        {
+                            push_link_lib_name(&mut analysis, rest);
+                        }
+                    }
+                }
+                i += 1;
+            }
+        }
+    }
+
+    analysis
+}
+
+fn link_library_candidate_names(lib: &str) -> Vec<String> {
+    if let Some(exact) = lib.strip_prefix(':') {
+        return vec![exact.to_string()];
+    }
+
+    vec![
+        format!("lib{lib}.a"),
+        format!("lib{lib}.so"),
+        format!("lib{lib}.dylib"),
+        format!("{lib}.lib"),
+        format!("lib{lib}.dll.a"),
+        format!("{lib}.dll.a"),
+    ]
+}
+
+fn resolve_link_library(
+    lib: &str,
+    search_dirs: &[NormalizedPath],
+    cwd: &Path,
+) -> Option<NormalizedPath> {
+    let candidate_names = link_library_candidate_names(lib);
+    for dir in search_dirs {
+        let abs_dir = link_path_to_absolute(dir.as_path(), cwd);
+        for name in &candidate_names {
+            let candidate = abs_dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate.into());
+            }
+        }
+    }
+    None
+}
+
+fn build_link_path_remap_key_plan(
+    flags: &[String],
+    cwd: &Path,
+    key_root: Option<&Path>,
+) -> LinkPathRemapKeyPlan {
+    let analysis = analyze_link_search_flags(flags);
+    let normalized_flags = normalize_link_cache_flags_for_key(flags, key_root);
+    let Some(root) = key_root else {
+        return LinkPathRemapKeyPlan {
+            flags: normalized_flags,
+            ..Default::default()
+        };
+    };
+
+    let root_local_search = analysis.search_dirs.iter().any(|dir| {
+        let abs_dir = link_path_to_absolute(dir.as_path(), cwd);
+        path_is_under_root(&abs_dir, root)
+    });
+    let mut extra_input_files = Vec::new();
+    let mut root_specific = false;
+
+    if root_local_search && analysis.lib_names.is_empty() {
+        root_specific = true;
+    }
+
+    for lib in &analysis.lib_names {
+        match resolve_link_library(lib, &analysis.search_dirs, cwd) {
+            Some(path) => {
+                let abs_path = link_path_to_absolute(path.as_path(), cwd);
+                if path_is_under_root(&abs_path, root) {
+                    extra_input_files.push(abs_path.into());
+                } else if root_local_search {
+                    root_specific = true;
+                }
+            }
+            None if root_local_search => {
+                root_specific = true;
+            }
+            None => {}
+        }
+    }
+
+    extra_input_files.sort();
+    extra_input_files.dedup();
+
+    LinkPathRemapKeyPlan {
+        flags: normalized_flags,
+        extra_input_files,
+        root_specific,
+    }
 }
 
 fn request_env_fingerprint_vars(client_env: Option<&[(String, String)]>) -> Vec<(&str, &str)> {
@@ -3277,6 +3705,13 @@ async fn handle_compile(
     }
 
     let worktree_root = resolve_worktree_root(cwd, client_env.as_deref());
+    let effective_args = effective_compile_args(
+        &expanded_args,
+        compiler_path,
+        cwd,
+        worktree_root.as_ref(),
+        client_env.as_deref(),
+    );
 
     // Snap the journal clock once so all file hashes in this request see a
     // consistent view (avoids per-file current_clock() syscalls).
@@ -3290,7 +3725,7 @@ async fn handle_compile(
     if state.watcher_active.load(Ordering::Acquire) {
         let request_fp = request_fingerprint(
             compiler_path,
-            &expanded_args,
+            &effective_args,
             cwd,
             worktree_root.as_deref(),
             client_env.as_deref(),
@@ -3458,7 +3893,7 @@ async fn handle_compile(
     // ── Phase: expand response files + parse args ─────────────────────
     let t0 = std::time::Instant::now();
     let compiler_str = compiler.to_str().unwrap_or("");
-    let parsed = zccache_compiler::parse_invocation(compiler_str, &expanded_args);
+    let parsed = zccache_compiler::parse_invocation(compiler_str, &effective_args);
     let compilation = match parsed {
         zccache_compiler::ParsedInvocation::Cacheable(c) => c,
         zccache_compiler::ParsedInvocation::NonCacheable { reason } => {
@@ -3652,7 +4087,7 @@ async fn handle_compile(
 
                             let rfp = request_fingerprint(
                                 compiler_path,
-                                &expanded_args,
+                                &effective_args,
                                 cwd,
                                 Some(key_root.as_path()),
                                 client_env.as_deref(),
@@ -3928,7 +4363,7 @@ async fn handle_compile(
 
                         let rfp = request_fingerprint(
                             compiler_path,
-                            &expanded_args,
+                            &effective_args,
                             cwd,
                             Some(key_root.as_path()),
                             client_env.as_deref(),
@@ -4024,9 +4459,9 @@ async fn handle_compile(
     // Only allocates when extra_args is non-empty.
     let combined_args;
     let rsp_args: &[String] = if extra_args.is_empty() {
-        &expanded_args
+        &effective_args
     } else {
-        combined_args = [expanded_args.as_slice(), extra_args.as_slice()].concat();
+        combined_args = [effective_args.as_slice(), extra_args.as_slice()].concat();
         &combined_args
     };
 
@@ -4062,7 +4497,7 @@ async fn handle_compile(
     if let Some(ref rsp) = _rsp_guard {
         cmd.arg(rsp.at_arg()).current_dir(cwd);
     } else {
-        cmd.args(&expanded_args).current_dir(cwd);
+        cmd.args(&effective_args).current_dir(cwd);
         if !extra_args.is_empty() {
             cmd.args(&extra_args);
         }
@@ -5986,6 +6421,96 @@ exit /b 0
         );
 
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn request_fingerprint_normalizes_cc_prefix_map_old_side() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_a = tmp.path().join("workspace-a");
+        let root_b = tmp.path().join("workspace-b");
+        let args_a = vec![format!("-ffile-prefix-map={}=.", root_a.display())];
+        let args_b = vec![format!("-ffile-prefix-map={}=.", root_b.display())];
+
+        let a = request_fingerprint(
+            Path::new("/usr/bin/clang++"),
+            &args_a,
+            &root_a,
+            Some(&root_a),
+            None,
+        );
+        let b = request_fingerprint(
+            Path::new("/usr/bin/clang++"),
+            &args_b,
+            &root_b,
+            Some(&root_b),
+            None,
+        );
+
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn effective_compile_args_auto_adds_root_and_cwd_maps() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_path = tmp.path().join("workspace");
+        let cwd = root_path.join("build");
+        let root = NormalizedPath::new(&root_path);
+        let env = vec![(PATH_REMAP_ENV.to_string(), "auto".to_string())];
+        let args = vec!["-c".to_string(), "src/main.cc".to_string()];
+
+        let effective = effective_compile_args(
+            &args,
+            Path::new("/usr/bin/clang++"),
+            &cwd,
+            Some(&root),
+            Some(&env),
+        );
+
+        assert!(effective.contains(&"-c".to_string()));
+        assert!(effective.contains(&format!("-ffile-prefix-map={}=.", root_path.display())));
+        assert!(effective.contains(&format!("-ffile-prefix-map={}=.", cwd.display())));
+    }
+
+    #[test]
+    fn link_flag_normalization_keeps_outputs_root_specific() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("workspace-a");
+        let lib = root.join("lib");
+        let version_map = root.join("link/version.map");
+        let more_lib = root.join("more-lib");
+        let wasm_map = root.join("link/wasm.map");
+        let app_map = root.join("build/app.map");
+        let app_lib = root.join("build/app.lib");
+        let app_pdb = root.join("build/app.pdb");
+        let app_def = root.join("link/app.def");
+        let flags = vec![
+            "-L".to_string(),
+            lib.to_string_lossy().into_owned(),
+            "--version-script".to_string(),
+            version_map.to_string_lossy().into_owned(),
+            format!(
+                "-Wl,-L,{},--version-script,{}",
+                more_lib.display(),
+                wasm_map.display()
+            ),
+            format!("-Wl,-Map,{}", app_map.display()),
+            format!("/IMPLIB:{}", app_lib.display()),
+            format!("/PDB:{}", app_pdb.display()),
+            format!("/DEF:{}", app_def.display()),
+        ];
+
+        let normalized = normalize_link_cache_flags_for_key(&flags, Some(&root));
+
+        assert_eq!(normalized[1], "$ZCCACHE_WORKTREE_ROOT/lib");
+        assert_eq!(normalized[3], "$ZCCACHE_WORKTREE_ROOT/link/version.map");
+        assert_eq!(
+            normalized[4],
+            "-Wl,-L,$ZCCACHE_WORKTREE_ROOT/more-lib,--version-script,$ZCCACHE_WORKTREE_ROOT/link/wasm.map"
+        );
+        assert_eq!(normalized[5], format!("-Wl,-Map,{}", app_map.display()));
+        assert_eq!(normalized[6], format!("/IMPLIB:{}", app_lib.display()));
+        assert_eq!(normalized[7], format!("/PDB:{}", app_pdb.display()));
+        assert_eq!(normalized[8], "/DEF:$ZCCACHE_WORKTREE_ROOT/link/app.def");
     }
 
     #[test]

--- a/crates/zccache-daemon/tests/link_cache_test.rs
+++ b/crates/zccache-daemon/tests/link_cache_test.rs
@@ -28,6 +28,110 @@ fn write_fake_objects(dir: &std::path::Path, names: &[&str]) {
     }
 }
 
+fn run_test_command(cmd: &mut std::process::Command, description: &str) -> Result<(), String> {
+    let output = cmd
+        .output()
+        .map_err(|e| format!("failed to run {description}: {e}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    Err(format!(
+        "{description} failed with status {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    ))
+}
+
+fn setup_equivalent_c_root(
+    compiler: &std::path::Path,
+    archiver: &std::path::Path,
+    root: &std::path::Path,
+) -> Result<(), String> {
+    std::fs::create_dir_all(root.join(".git")).unwrap();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::create_dir_all(root.join("build")).unwrap();
+    std::fs::create_dir_all(root.join("lib")).unwrap();
+    std::fs::write(
+        root.join("src/main.c"),
+        "int dep(void);\nint main(void) { return dep(); }\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("src/dep.c"), "int dep(void) { return 0; }\n").unwrap();
+
+    let mut cmd = std::process::Command::new(compiler);
+    cmd.args(["-g0", "-c", "src/main.c", "-o", "build/main.o"])
+        .current_dir(root);
+    run_test_command(&mut cmd, "compile test object")?;
+
+    let mut cmd = std::process::Command::new(compiler);
+    cmd.args(["-g0", "-c", "src/dep.c", "-o", "build/dep.o"])
+        .current_dir(root);
+    run_test_command(&mut cmd, "compile test library object")?;
+
+    let mut cmd = std::process::Command::new(archiver);
+    cmd.args(["rcsD", "lib/libdep.a", "build/dep.o"])
+        .current_dir(root);
+    if run_test_command(&mut cmd, "archive test library").is_ok() {
+        return Ok(());
+    }
+
+    let mut cmd = std::process::Command::new(archiver);
+    cmd.args(["rcs", "lib/libdep.a", "build/dep.o"])
+        .current_dir(root);
+    run_test_command(&mut cmd, "archive test library")
+}
+
+fn linked_binary_name(stem: &str) -> String {
+    if cfg!(windows) {
+        format!("{stem}.exe")
+    } else {
+        stem.to_string()
+    }
+}
+
+fn compiler_driver_link_args(root: &std::path::Path, output: &std::path::Path) -> Vec<String> {
+    vec![
+        "-o".to_string(),
+        output.to_string_lossy().into_owned(),
+        "build/main.o".to_string(),
+        format!("-L{}", root.join("lib").to_string_lossy()),
+        "-ldep".to_string(),
+    ]
+}
+
+fn compiler_driver_link_is_feasible(
+    compiler: &std::path::Path,
+    archiver: &std::path::Path,
+) -> Result<(), String> {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("repo");
+    setup_equivalent_c_root(compiler, archiver, &root)?;
+
+    let output = root.join("build").join(linked_binary_name("probe"));
+    let args = compiler_driver_link_args(&root, &output);
+    let mut cmd = std::process::Command::new(compiler);
+    cmd.args(&args).current_dir(&root);
+    run_test_command(&mut cmd, "probe compiler-driver link")?;
+    std::fs::remove_file(output).ok();
+    Ok(())
+}
+
+fn client_env_with_path_remap_auto() -> Vec<(String, String)> {
+    let mut env: Vec<(String, String)> = std::env::vars_os()
+        .filter_map(|(key, value)| {
+            let key = key.into_string().ok()?;
+            let value = value.into_string().ok()?;
+            let zccache_root_var = key.eq_ignore_ascii_case("ZCCACHE_WORKTREE_ROOT");
+            let zccache_remap_var = key.eq_ignore_ascii_case("ZCCACHE_PATH_REMAP");
+            (!zccache_root_var && !zccache_remap_var).then_some((key, value))
+        })
+        .collect();
+    env.push(("ZCCACHE_PATH_REMAP".to_string(), "auto".to_string()));
+    env
+}
+
 #[tokio::test]
 #[ignore] // Integration test — starts a real daemon. Run with `test --full`.
 async fn test_ar_cache_miss_then_hit() {
@@ -130,6 +234,161 @@ async fn test_ar_cache_miss_then_hit() {
     assert_eq!(
         first_contents, second_contents,
         "cached archive should be byte-identical"
+    );
+
+    shutdown.notify_one();
+    server_handle.await.unwrap();
+}
+
+#[tokio::test]
+#[ignore] // Integration test — starts a real daemon + compiler driver. Run with `test --full`.
+async fn test_link_path_remap_auto_hits_across_sibling_git_roots() {
+    let archiver = match zccache_test_support::find_on_path("ar")
+        .or_else(|| zccache_test_support::find_on_path("llvm-ar"))
+    {
+        Some(path) => path,
+        None => {
+            eprintln!("skipping test: neither ar nor llvm-ar found on PATH");
+            return;
+        }
+    };
+    let mut skipped = Vec::new();
+    let mut selected_compiler = None;
+    for name in ["clang", "gcc"] {
+        let Some(path) = zccache_test_support::find_on_path(name) else {
+            skipped.push(format!("{name}: not found on PATH"));
+            continue;
+        };
+        match compiler_driver_link_is_feasible(&path, &archiver) {
+            Ok(()) => {
+                selected_compiler = Some(path);
+                break;
+            }
+            Err(e) => skipped.push(format!("{name}: {e}")),
+        }
+    }
+
+    let compiler_path = match selected_compiler {
+        Some(path) => path,
+        None => {
+            eprintln!(
+                "skipping test: no usable clang/gcc compiler-driver link found\n{}",
+                skipped.join("\n")
+            );
+            return;
+        }
+    };
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root_a = tmp.path().join("workspace-a");
+    let root_b = tmp.path().join("workspace-b");
+    setup_equivalent_c_root(&compiler_path, &archiver, &root_a).unwrap();
+    setup_equivalent_c_root(&compiler_path, &archiver, &root_b).unwrap();
+
+    let object_a = std::fs::read(root_a.join("build/main.o")).unwrap();
+    let object_b = std::fs::read(root_b.join("build/main.o")).unwrap();
+    if object_a != object_b {
+        eprintln!("skipping test: compiler produced root-specific object bytes");
+        return;
+    }
+    let lib_a = std::fs::read(root_a.join("lib/libdep.a")).unwrap();
+    let lib_b = std::fs::read(root_b.join("lib/libdep.a")).unwrap();
+    if lib_a != lib_b {
+        eprintln!("skipping test: archiver produced root-specific library bytes");
+        return;
+    }
+
+    let output_a = root_a.join("build").join(linked_binary_name("app"));
+    let output_b = root_b.join("build").join(linked_binary_name("app"));
+    assert_ne!(
+        output_a, output_b,
+        "test must use distinct physical output paths"
+    );
+
+    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let mut client = zccache_ipc::connect(&endpoint).await.unwrap();
+
+    // Clear persisted artifacts to ensure test isolation from prior runs.
+    client.send(&Request::Clear).await.unwrap();
+    let _: Option<Response> = client.recv().await.unwrap();
+
+    let remap_env = client_env_with_path_remap_auto();
+
+    // First root: populate the link cache. The absolute -L path is under root A.
+    client
+        .send(&Request::LinkEphemeral {
+            client_pid: std::process::id(),
+            tool: compiler_path.to_string_lossy().into_owned().into(),
+            args: compiler_driver_link_args(&root_a, &output_a),
+            cwd: root_a.to_string_lossy().into_owned().into(),
+            env: Some(remap_env.clone()),
+        })
+        .await
+        .unwrap();
+
+    let resp = client.recv().await.unwrap();
+    match resp {
+        Some(Response::LinkResult {
+            exit_code,
+            cached,
+            warning,
+            ..
+        }) => {
+            assert_eq!(exit_code, 0, "first compiler-driver link should succeed");
+            assert!(!cached, "first link in root A should be a cache miss");
+            assert!(
+                warning.is_none(),
+                "deterministic compiler-driver link should not warn"
+            );
+        }
+        other => panic!("expected LinkResult, got: {other:?}"),
+    }
+
+    assert!(output_a.exists(), "root A output should exist after miss");
+    assert!(
+        !output_b.exists(),
+        "root B output should not exist before its link"
+    );
+    let first_contents = std::fs::read(&output_a).unwrap();
+
+    // Second root: same object bytes and root-equivalent -L path should hit.
+    client
+        .send(&Request::LinkEphemeral {
+            client_pid: std::process::id(),
+            tool: compiler_path.to_string_lossy().into_owned().into(),
+            args: compiler_driver_link_args(&root_b, &output_b),
+            cwd: root_b.to_string_lossy().into_owned().into(),
+            env: Some(remap_env),
+        })
+        .await
+        .unwrap();
+
+    let resp = client.recv().await.unwrap();
+    match resp {
+        Some(Response::LinkResult {
+            exit_code, cached, ..
+        }) => {
+            assert_eq!(exit_code, 0, "cached compiler-driver link should succeed");
+            assert!(
+                cached,
+                "ZCCACHE_PATH_REMAP=auto should make root-equivalent -L flags hit"
+            );
+        }
+        other => panic!("expected LinkResult, got: {other:?}"),
+    }
+
+    assert!(
+        output_a.exists(),
+        "cache hit in root B should preserve root A output"
+    );
+    assert!(
+        output_b.exists(),
+        "cache hit should restore output at root B's physical path"
+    );
+    assert_eq!(
+        first_contents,
+        std::fs::read(&output_b).unwrap(),
+        "root B hit should restore the cached root A link output"
     );
 
     shutdown.notify_one();

--- a/crates/zccache-daemon/tests/stress_test.rs
+++ b/crates/zccache-daemon/tests/stress_test.rs
@@ -63,13 +63,24 @@ async fn compile(
     args: &[&str],
     cwd: &str,
 ) -> (i32, bool) {
+    compile_with_env(client, session_id, compiler, args, cwd, None).await
+}
+
+async fn compile_with_env(
+    client: &mut ClientConn,
+    session_id: &str,
+    compiler: &str,
+    args: &[&str],
+    cwd: &str,
+    env: Option<Vec<(String, String)>>,
+) -> (i32, bool) {
     client
         .send(&Request::Compile {
             session_id: session_id.to_string(),
             args: args.iter().map(|s| s.to_string()).collect(),
             cwd: cwd.to_string().into(),
             compiler: compiler.to_string().into(),
-            env: None,
+            env,
         })
         .await
         .unwrap();
@@ -80,6 +91,28 @@ async fn compile(
         Some(Response::Error { message }) => panic!("compile error: {message}"),
         other => panic!("expected CompileResult, got: {other:?}"),
     }
+}
+
+fn client_env_with_path_remap_auto() -> Vec<(String, String)> {
+    let mut env: Vec<(String, String)> = std::env::vars_os()
+        .filter_map(|(key, value)| {
+            let key = key.into_string().ok()?;
+            let value = value.into_string().ok()?;
+            let root_var = key.eq_ignore_ascii_case("ZCCACHE_WORKTREE_ROOT");
+            let remap_var = key.eq_ignore_ascii_case("ZCCACHE_PATH_REMAP");
+            (!root_var && !remap_var).then_some((key, value))
+        })
+        .collect();
+    env.push(("ZCCACHE_PATH_REMAP".to_string(), "auto".to_string()));
+    env
+}
+
+fn bytes_contain(haystack: &[u8], needle: &str) -> bool {
+    let needle = needle.as_bytes();
+    !needle.is_empty()
+        && haystack
+            .windows(needle.len())
+            .any(|window| window == needle)
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -841,6 +874,98 @@ async fn adversarial_workspace_rename_hits_cache() {
         std::fs::read(&obj_a).unwrap(),
         std::fs::read(&obj_b).unwrap()
     );
+
+    shutdown.notify_one();
+    server_handle.await.unwrap();
+}
+
+#[tokio::test]
+#[ignore] // integration: spawns clang twice, run with --full
+async fn path_remap_auto_compiles_file_macro_stably_across_git_roots() {
+    let clang = match zccache_test_support::find_clang() {
+        Some(p) => p,
+        None => return,
+    };
+    let tmp = tempfile::tempdir().unwrap();
+    let ws_a = tmp.path().join("workspace-a");
+    let ws_b = tmp.path().join("workspace-b");
+    let src_rel = std::path::Path::new("src").join("main.cpp");
+    let obj_rel = std::path::Path::new("build").join("main.o");
+    for ws in [&ws_a, &ws_b] {
+        std::fs::create_dir_all(ws.join(".git")).unwrap();
+        std::fs::create_dir_all(ws.join("src")).unwrap();
+        std::fs::create_dir_all(ws.join("build")).unwrap();
+        std::fs::write(
+            ws.join(&src_rel),
+            "const char* source_file = __FILE__;\nint main() { return source_file[0] == 0; }\n",
+        )
+        .unwrap();
+    }
+    let log = tmp.path().join("path-remap-auto.log");
+
+    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let env = client_env_with_path_remap_auto();
+
+    let mut client_a = zccache_ipc::connect(&endpoint).await.unwrap();
+    let cwd_a = ws_a.to_string_lossy().into_owned();
+    let (sid_a, comp_a) =
+        start_session(&mut client_a, &clang, &cwd_a, &log.to_string_lossy()).await;
+    let src_a = ws_a.join(&src_rel);
+    let obj_a = ws_a.join(&obj_rel);
+    let (ec, cached) = compile_with_env(
+        &mut client_a,
+        &sid_a,
+        &comp_a,
+        &[
+            "-g0",
+            "-c",
+            &src_a.to_string_lossy(),
+            "-o",
+            &obj_a.to_string_lossy(),
+        ],
+        &cwd_a,
+        Some(env.clone()),
+    )
+    .await;
+    assert_eq!(ec, 0);
+    assert!(!cached);
+    let obj_a_bytes = std::fs::read(&obj_a).unwrap();
+    assert!(
+        !bytes_contain(&obj_a_bytes, &ws_a.to_string_lossy()),
+        "auto path remap should keep root A out of __FILE__ object bytes"
+    );
+    assert!(
+        !bytes_contain(&obj_a_bytes, &ws_a.to_string_lossy().replace('\\', "/")),
+        "auto path remap should keep slash-normalized root A out of __FILE__ object bytes"
+    );
+
+    let mut client_b = zccache_ipc::connect(&endpoint).await.unwrap();
+    let cwd_b = ws_b.to_string_lossy().into_owned();
+    let (sid_b, comp_b) =
+        start_session(&mut client_b, &clang, &cwd_b, &log.to_string_lossy()).await;
+    let src_b = ws_b.join(&src_rel);
+    let obj_b = ws_b.join(&obj_rel);
+    let (ec, cached) = compile_with_env(
+        &mut client_b,
+        &sid_b,
+        &comp_b,
+        &[
+            "-g0",
+            "-c",
+            &src_b.to_string_lossy(),
+            "-o",
+            &obj_b.to_string_lossy(),
+        ],
+        &cwd_b,
+        Some(env),
+    )
+    .await;
+    assert_eq!(ec, 0);
+    assert!(
+        cached,
+        "ZCCACHE_PATH_REMAP=auto should make equivalent __FILE__ compiles hit"
+    );
+    assert_eq!(obj_a_bytes, std::fs::read(&obj_b).unwrap());
 
     shutdown.notify_one();
     server_handle.await.unwrap();

--- a/crates/zccache-depgraph/src/context.rs
+++ b/crates/zccache-depgraph/src/context.rs
@@ -156,6 +156,28 @@ fn normalize_remap_path_prefix_for_key(remap: &str, key_root: Option<&Path>) -> 
     }
 }
 
+fn normalize_cxx_prefix_map_flag_for_key(flag: &str, key_root: Option<&Path>) -> String {
+    const PREFIX_MAP_FLAGS: [&str; 5] = [
+        "-ffile-prefix-map=",
+        "-fdebug-prefix-map=",
+        "-fmacro-prefix-map=",
+        "-fcoverage-prefix-map=",
+        "-fprofile-prefix-map=",
+    ];
+
+    for prefix in PREFIX_MAP_FLAGS {
+        if let Some(remap) = flag.strip_prefix(prefix) {
+            return format!(
+                "{}{}",
+                prefix,
+                normalize_remap_path_prefix_for_key(remap, key_root)
+            );
+        }
+    }
+
+    flag.to_string()
+}
+
 /// Compute the context key for a C/C++ compilation context.
 ///
 /// When `key_root` is provided, paths under that root are hashed relative to it
@@ -201,6 +223,7 @@ pub fn compute_context_key(ctx: &CompileContext, key_root: Option<&Path>) -> Con
 
     hasher.update(b"flags\0");
     for flag in &ctx.flags {
+        let flag = normalize_cxx_prefix_map_flag_for_key(flag, key_root);
         hasher.update(flag.as_bytes());
         hasher.update(b"\0");
     }
@@ -213,6 +236,7 @@ pub fn compute_context_key(ctx: &CompileContext, key_root: Option<&Path>) -> Con
 
     hasher.update(b"unknown\0");
     for flag in &ctx.unknown_flags {
+        let flag = normalize_cxx_prefix_map_flag_for_key(flag, key_root);
         hasher.update(flag.as_bytes());
         hasher.update(b"\0");
     }
@@ -851,6 +875,72 @@ mod tests {
         let key_b = compute_context_key(&ctx_b, Some(Path::new("/workspace-b")));
 
         assert_eq!(key_a, key_b);
+    }
+
+    #[test]
+    fn cxx_context_key_with_root_normalizes_file_prefix_map_roots() {
+        let mut ctx_a = make_context("/workspace-a/src/main.cpp", &[], &[]);
+        ctx_a.flags = vec!["-ffile-prefix-map=/workspace-a=.".to_string()];
+        let mut ctx_b = make_context("/workspace-b/src/main.cpp", &[], &[]);
+        ctx_b.flags = vec!["-ffile-prefix-map=/workspace-b=.".to_string()];
+
+        assert_eq!(
+            compute_context_key(&ctx_a, Some(Path::new("/workspace-a"))),
+            compute_context_key(&ctx_b, Some(Path::new("/workspace-b"))),
+            "equivalent file-prefix-map old prefixes under the key root should match"
+        );
+    }
+
+    #[test]
+    fn cxx_context_key_with_root_preserves_file_prefix_map_new_prefixes() {
+        let mut ctx_a = make_context("/workspace-a/src/main.cpp", &[], &[]);
+        ctx_a.flags = vec!["-ffile-prefix-map=/workspace-a=.".to_string()];
+        let mut ctx_b = make_context("/workspace-b/src/main.cpp", &[], &[]);
+        ctx_b.flags = vec!["-ffile-prefix-map=/workspace-b=/src".to_string()];
+
+        assert_ne!(
+            compute_context_key(&ctx_a, Some(Path::new("/workspace-a"))),
+            compute_context_key(&ctx_b, Some(Path::new("/workspace-b"))),
+            "different file-prefix-map new prefixes should remain key-significant"
+        );
+    }
+
+    #[test]
+    fn cxx_context_key_with_root_keeps_external_file_prefix_map_old_prefixes_distinct() {
+        let mut ctx_a = make_context("/workspace-a/src/main.cpp", &[], &[]);
+        ctx_a.flags = vec!["-ffile-prefix-map=/external-a=.".to_string()];
+        let mut ctx_b = make_context("/workspace-b/src/main.cpp", &[], &[]);
+        ctx_b.flags = vec!["-ffile-prefix-map=/external-b=.".to_string()];
+
+        assert_ne!(
+            compute_context_key(&ctx_a, Some(Path::new("/workspace-a"))),
+            compute_context_key(&ctx_b, Some(Path::new("/workspace-b"))),
+            "file-prefix-map old prefixes outside the key root should keep absolute identity"
+        );
+    }
+
+    #[test]
+    fn cxx_context_key_with_root_normalizes_prefix_maps_in_unknown_flags() {
+        let mut ctx_a = make_context("/workspace-a/src/main.cpp", &[], &[]);
+        ctx_a.unknown_flags = vec![
+            "-fcoverage-prefix-map=/workspace-a=/coverage".to_string(),
+            "-fdebug-prefix-map=/workspace-a=/debug".to_string(),
+            "-fmacro-prefix-map=/workspace-a=/macro".to_string(),
+            "-fprofile-prefix-map=/workspace-a=/profile".to_string(),
+        ];
+        let mut ctx_b = make_context("/workspace-b/src/main.cpp", &[], &[]);
+        ctx_b.unknown_flags = vec![
+            "-fcoverage-prefix-map=/workspace-b=/coverage".to_string(),
+            "-fdebug-prefix-map=/workspace-b=/debug".to_string(),
+            "-fmacro-prefix-map=/workspace-b=/macro".to_string(),
+            "-fprofile-prefix-map=/workspace-b=/profile".to_string(),
+        ];
+
+        assert_eq!(
+            compute_context_key(&ctx_a, Some(Path::new("/workspace-a"))),
+            compute_context_key(&ctx_b, Some(Path::new("/workspace-b"))),
+            "C/C++ prefix-map flags should normalize under unknown_flags"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements `ZCCACHE_PATH_REMAP=auto` for the C/C++ worktree optimization path from #227, including the link-phase checklist in https://github.com/zackees/zccache/issues/227#issuecomment-4447861421.

- Adds automatic GCC/Clang-family compile miss args: `-ffile-prefix-map=<git-root>=.` and, when different, `-ffile-prefix-map=<cwd>=.`.
- Normalizes C/C++ prefix-map flags in request fingerprints and depgraph context keys so equivalent roots share cache identity while different destination prefixes still miss.
- Adds conservative link cache-key remapping for workspace-local input/search paths under `ZCCACHE_PATH_REMAP=auto`.
- Hashes resolved root-local `-l` libraries discovered through `-L` before allowing cross-root link sharing.
- Keeps physical output/runtime-facing link paths root-specific, including map, PDB, import-lib, and similar output paths.
- Documents the new C/C++ auto-remap switch in the worktree cache sharing README section.

## Subagent Work

- Compile/remap explorer mapped the existing C/C++ arg parsing, request fingerprint, and worktree-root paths.
- Link explorer mapped linker parsing, key construction, and unsafe output/runtime path cases.
- Depgraph worker implemented C/C++ prefix-map normalization tests in `context.rs`.
- Link-test worker added the sibling-root `ZCCACHE_PATH_REMAP=auto` link integration test.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p zccache-depgraph --lib -- --nocapture`
- `cargo test -p zccache-daemon --lib -- --nocapture`
- `cargo test -p zccache-daemon --test link_cache_test --no-run`
- `cargo test -p zccache-daemon --test stress_test path_remap_auto_compiles_file_macro_stably_across_git_roots -- --ignored --nocapture --test-threads=1`
- `cargo test -p zccache-daemon --test link_cache_test test_link_path_remap_auto_hits_across_sibling_git_roots -- --ignored --nocapture --test-threads=1`

## Timed Proof

- Compile remap proof: cargo harness `6386 ms`, test body `0.20 s`; verifies `__FILE__` root removal and sibling-root cache hit.
- Link remap proof: cargo harness `1831 ms`, test body `1.02 s`; verifies root A link miss, root B link hit with root-equivalent `-L` and resolved `-ldep` library.

Closes #227.