### PR TITLE
feat: add Rust path remap auto support

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,16 +295,18 @@ export ZCCACHE_WORKTREE_ROOT="$PWD"
 RUSTC_WRAPPER=zccache cargo build
 ```
 
-For the planned path-remap feature, the common setup should be just:
+For Rust projects, use the same path-remap directive:
 
 ```bash
 export ZCCACHE_PATH_REMAP=auto
+RUSTC_WRAPPER=zccache cargo build
 ```
 
-In auto mode, zccache should discover the Git worktree root automatically on
-macOS, Linux, and Windows. Set `ZCCACHE_WORKTREE_ROOT` only as an advanced
-override for non-Git checkouts or unusual build layouts where automatic root
-detection is not reliable.
+In auto mode, zccache discovers the Git worktree root automatically on macOS,
+Linux, and Windows, then adds a root-covering rustc `--remap-path-prefix=...=.`
+when needed. Set `ZCCACHE_WORKTREE_ROOT` only as an advanced override for
+non-Git checkouts or unusual build layouts where automatic root detection is
+not reliable.
 
 `ZCCACHE_PATH_REMAP=auto` tells zccache to apply compiler-specific path remaps
 when it can prove they are safe, such as C/C++ `-ffile-prefix-map`, Rust

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -3108,6 +3108,15 @@ fn normalize_request_path_value(value: &str, key_root: Option<&Path>) -> Option<
     None
 }
 
+fn normalize_rust_remap_path_prefix_value_for_key(
+    value: &str,
+    key_root: Option<&Path>,
+) -> Option<String> {
+    let (old, new) = value.split_once('=')?;
+    normalize_request_path_value(old, key_root)
+        .map(|normalized_old| format!("{normalized_old}={new}"))
+}
+
 const CC_PREFIX_MAP_FLAGS: &[&str] = &[
     "-ffile-prefix-map",
     "-fmacro-prefix-map",
@@ -3156,6 +3165,138 @@ fn compiler_supports_ffile_prefix_map(compiler_path: &Path) -> bool {
     )
 }
 
+fn rust_remap_value_matches_old(value: &str, old: &Path) -> bool {
+    let Some((existing_old, _)) = value.split_once('=') else {
+        return false;
+    };
+    let existing_old = Path::new(existing_old);
+    existing_old.is_absolute() && same_key_path(existing_old, old)
+}
+
+fn rust_remap_values_have_old<'a>(
+    values: impl IntoIterator<Item = &'a String>,
+    old: &Path,
+) -> bool {
+    values
+        .into_iter()
+        .any(|value| rust_remap_value_matches_old(value, old))
+}
+
+fn rust_args_have_remap_for_old(args: &[String], old: &Path) -> bool {
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+        if arg == "--remap-path-prefix" {
+            if let Some(value) = args.get(i + 1) {
+                if rust_remap_value_matches_old(value, old) {
+                    return true;
+                }
+            }
+            i += 2;
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("--remap-path-prefix=") {
+            if rust_remap_value_matches_old(value, old) {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+fn compiler_is_rustc_like(compiler_path: &Path) -> bool {
+    zccache_compiler::detect_family(&compiler_path.to_string_lossy())
+        == zccache_compiler::CompilerFamily::Rustc
+}
+
+fn rustc_request_key_root(
+    args: &[String],
+    worktree_root: Option<&NormalizedPath>,
+) -> Option<NormalizedPath> {
+    let root = worktree_root?;
+    rust_args_have_remap_for_old(args, root.as_path()).then(|| root.clone())
+}
+
+fn rustc_context_key_root(
+    remap_path_prefixes: &[String],
+    worktree_root: Option<&NormalizedPath>,
+) -> Option<NormalizedPath> {
+    let root = worktree_root?;
+    rust_remap_values_have_old(remap_path_prefixes.iter(), root.as_path()).then(|| root.clone())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RustRemapGate {
+    Ok,
+    Missing,
+    OldOutsideRoot,
+    Malformed,
+}
+
+impl RustRemapGate {
+    fn as_str(self) -> &'static str {
+        match self {
+            RustRemapGate::Ok => "rust_remap_gate_ok",
+            RustRemapGate::Missing => "rust_remap_missing",
+            RustRemapGate::OldOutsideRoot => "rust_remap_old_outside_root",
+            RustRemapGate::Malformed => "rust_remap_malformed",
+        }
+    }
+}
+
+fn rust_remap_gate(
+    remap_path_prefixes: &[String],
+    worktree_root: Option<&NormalizedPath>,
+) -> RustRemapGate {
+    let Some(root) = worktree_root else {
+        return RustRemapGate::Missing;
+    };
+    let root_key = zccache_core::path::normalize_for_key(root.as_path());
+    let root_child_prefix = format!("{root_key}/");
+    let mut saw_malformed = false;
+    let mut saw_external = false;
+
+    for value in remap_path_prefixes {
+        let Some((old, _new)) = value.split_once('=') else {
+            saw_malformed = true;
+            continue;
+        };
+        let old_path = Path::new(old);
+        if !old_path.is_absolute() {
+            saw_malformed = true;
+            continue;
+        }
+        let old_key = zccache_core::path::normalize_for_key(old_path);
+        if old_key == root_key {
+            return RustRemapGate::Ok;
+        }
+        if !old_key.starts_with(&root_child_prefix) {
+            saw_external = true;
+        }
+    }
+
+    if saw_malformed {
+        RustRemapGate::Malformed
+    } else if saw_external {
+        RustRemapGate::OldOutsideRoot
+    } else {
+        RustRemapGate::Missing
+    }
+}
+
+fn request_key_root(
+    compiler_path: &Path,
+    args: &[String],
+    worktree_root: Option<&NormalizedPath>,
+) -> Option<NormalizedPath> {
+    if compiler_is_rustc_like(compiler_path) {
+        rustc_request_key_root(args, worktree_root)
+    } else {
+        worktree_root.cloned()
+    }
+}
+
 fn effective_compile_args(
     expanded_args: &[String],
     compiler_path: &Path,
@@ -3164,7 +3305,7 @@ fn effective_compile_args(
     client_env: Option<&[(String, String)]>,
 ) -> Vec<String> {
     let mut effective = expanded_args.to_vec();
-    if !path_remap_auto_enabled(client_env) || !compiler_supports_ffile_prefix_map(compiler_path) {
+    if !path_remap_auto_enabled(client_env) {
         return effective;
     }
 
@@ -3173,6 +3314,18 @@ fn effective_compile_args(
     };
 
     let root_path = root.as_path();
+    if compiler_is_rustc_like(compiler_path) {
+        if !rust_args_have_remap_for_old(&effective, root_path) {
+            effective.push("--remap-path-prefix".to_string());
+            effective.push(format!("{}=.", root_path.to_string_lossy()));
+        }
+        return effective;
+    }
+
+    if !compiler_supports_ffile_prefix_map(compiler_path) {
+        return effective;
+    }
+
     if !has_ffile_prefix_map_for_old(&effective, root_path) {
         effective.push(format!(
             "-ffile-prefix-map={}={}",
@@ -3199,6 +3352,14 @@ fn normalize_request_arg(arg: &str, key_root: Option<&Path>) -> String {
 
     if let Some(normalized) = normalize_cc_prefix_map_arg_for_key(arg, Some(root)) {
         return normalized;
+    }
+
+    if let Some(value) = arg.strip_prefix("--remap-path-prefix=") {
+        if let Some(normalized) = normalize_rust_remap_path_prefix_value_for_key(value, Some(root))
+        {
+            return format!("--remap-path-prefix={normalized}");
+        }
+        return arg.to_string();
     }
 
     if let Some(normalized) = normalize_request_path_value(arg, Some(root)) {
@@ -3565,10 +3726,25 @@ fn request_fingerprint(
     let compiler = zccache_core::path::normalize_for_key(compiler);
     h.update(compiler.as_bytes());
     h.update(&[0]);
-    for arg in args {
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+        if arg == "--remap-path-prefix" {
+            h.update(arg.as_bytes());
+            h.update(&[0]);
+            if let Some(value) = args.get(i + 1) {
+                let value = normalize_rust_remap_path_prefix_value_for_key(value, key_root)
+                    .unwrap_or_else(|| value.clone());
+                h.update(value.as_bytes());
+                h.update(&[0]);
+            }
+            i += 2;
+            continue;
+        }
         let arg = normalize_request_arg(arg, key_root);
         h.update(arg.as_bytes());
         h.update(&[0]);
+        i += 1;
     }
     let cwd = normalize_path_for_request_key(cwd, key_root);
     h.update(cwd.as_bytes());
@@ -3733,6 +3909,8 @@ async fn handle_compile(
         worktree_root.as_ref(),
         client_env.as_deref(),
     );
+    let request_cache_key_root =
+        request_key_root(compiler_path, &effective_args, worktree_root.as_ref());
 
     // Snap the journal clock once so all file hashes in this request see a
     // consistent view (avoids per-file current_clock() syscalls).
@@ -3748,16 +3926,20 @@ async fn handle_compile(
             compiler_path,
             &effective_args,
             cwd,
-            worktree_root.as_deref(),
+            request_cache_key_root.as_deref(),
             client_env.as_deref(),
         );
         if let Some(req_entry) = state.request_cache.get(&request_fp) {
-            if request_cache_entry_matches_root(&req_entry, worktree_root.as_ref()) {
+            if request_cache_entry_matches_root(&req_entry, request_cache_key_root.as_ref()) {
                 if let Some(fh_entry) = state.fast_hit_cache.get(&req_entry.context_key) {
                     let artifact_key_hex = &fh_entry.artifact_key_hex;
-                    let source_path = req_entry.source_path.resolve(worktree_root.as_deref());
-                    let output_path = req_entry.output_path.resolve(worktree_root.as_deref());
-                    let same_root = req_entry.root.as_ref() == worktree_root.as_ref();
+                    let source_path = req_entry
+                        .source_path
+                        .resolve(request_cache_key_root.as_deref());
+                    let output_path = req_entry
+                        .output_path
+                        .resolve(request_cache_key_root.as_deref());
+                    let same_root = req_entry.root.as_ref() == request_cache_key_root.as_ref();
                     let inputs_match = if same_root {
                         context_files_fresh(
                             state,
@@ -3769,7 +3951,7 @@ async fn handle_compile(
                         request_cache_artifact_matches(
                             state,
                             &req_entry,
-                            worktree_root.as_ref(),
+                            request_cache_key_root.as_ref(),
                             artifact_key_hex,
                             snap_clock,
                         )
@@ -3949,7 +4131,6 @@ async fn handle_compile(
     let parse_args_ns = t0.elapsed().as_nanos() as u64;
 
     let cwd_path: NormalizedPath = cwd.into();
-    let key_root = worktree_root.as_ref().unwrap_or(&cwd_path);
     let source_path = if compilation.source_file.is_absolute() {
         compilation.source_file.clone()
     } else {
@@ -3971,12 +4152,13 @@ async fn handle_compile(
         env_slice,
         &state.compiler_hash_cache,
     );
+    let default_key_root = worktree_root.clone().unwrap_or_else(|| cwd_path.clone());
     let (ctx, dep_flags, rustc_args_opt, context_key, worktree_equivalent_context) =
         match build_result {
             BuildContextResult::Cc { ctx, dep_flags } => {
                 let registration = state
                     .dep_graph
-                    .register_with_root_result(ctx.clone(), Some(key_root.clone()));
+                    .register_with_root_result(ctx.clone(), Some(default_key_root.clone()));
                 (
                     ctx,
                     dep_flags,
@@ -3990,11 +4172,20 @@ async fn handle_compile(
                 compat_ctx,
                 rustc_args,
             } => {
-                let key = rustc_ctx.context_key_with_root(Some(key_root));
+                let remap_gate =
+                    rust_remap_gate(&rustc_args.remap_path_prefixes, worktree_root.as_ref());
+                write_session_log(
+                    &state.sessions,
+                    &sid,
+                    &format!("[DIAG] {}", remap_gate.as_str()),
+                );
+                let rustc_key_root =
+                    rustc_context_key_root(&rustc_args.remap_path_prefixes, worktree_root.as_ref());
+                let key = rustc_ctx.context_key_with_root(rustc_key_root.as_deref());
                 let registration = state.dep_graph.register_with_key_and_root_result(
                     key,
                     compat_ctx.clone(),
-                    Some(key_root.clone()),
+                    rustc_key_root.clone(),
                 );
                 (
                     compat_ctx,
@@ -4110,7 +4301,7 @@ async fn handle_compile(
                                 compiler_path,
                                 &effective_args,
                                 cwd,
-                                Some(key_root.as_path()),
+                                request_cache_key_root.as_deref(),
                                 client_env.as_deref(),
                             );
                             let input_paths =
@@ -4122,7 +4313,7 @@ async fn handle_compile(
                                     &source_path,
                                     &output_path,
                                     input_paths,
-                                    Some(key_root),
+                                    request_cache_key_root.as_ref(),
                                 ),
                             );
 
@@ -4386,7 +4577,7 @@ async fn handle_compile(
                             compiler_path,
                             &effective_args,
                             cwd,
-                            Some(key_root.as_path()),
+                            request_cache_key_root.as_deref(),
                             client_env.as_deref(),
                         );
                         let input_paths =
@@ -4398,7 +4589,7 @@ async fn handle_compile(
                                 &source_path,
                                 &output_path,
                                 input_paths,
-                                Some(key_root),
+                                request_cache_key_root.as_ref(),
                             ),
                         );
 
@@ -6518,6 +6709,74 @@ exit /b 0
     }
 
     #[test]
+    fn request_fingerprint_normalizes_rust_remap_detached_old_side() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_a = tmp.path().join("workspace-a");
+        let root_b = tmp.path().join("workspace-b");
+        let args_a = vec![
+            "--remap-path-prefix".to_string(),
+            format!("{}=.", root_a.display()),
+        ];
+        let args_b = vec![
+            "--remap-path-prefix".to_string(),
+            format!("{}=.", root_b.display()),
+        ];
+
+        let a = request_fingerprint(Path::new("rustc"), &args_a, &root_a, Some(&root_a), None);
+        let b = request_fingerprint(Path::new("rustc"), &args_b, &root_b, Some(&root_b), None);
+
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn request_fingerprint_normalizes_rust_remap_equals_old_side() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_a = tmp.path().join("workspace-a");
+        let root_b = tmp.path().join("workspace-b");
+        let args_a = vec![format!("--remap-path-prefix={}=.", root_a.display())];
+        let args_b = vec![format!("--remap-path-prefix={}=.", root_b.display())];
+
+        let a = request_fingerprint(Path::new("rustc"), &args_a, &root_a, Some(&root_a), None);
+        let b = request_fingerprint(Path::new("rustc"), &args_b, &root_b, Some(&root_b), None);
+
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn request_fingerprint_preserves_rust_remap_new_prefixes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_a = tmp.path().join("workspace-a");
+        let root_b = tmp.path().join("workspace-b");
+        let args_a = vec![format!("--remap-path-prefix={}=.", root_a.display())];
+        let args_b = vec![format!("--remap-path-prefix={}=/src", root_b.display())];
+
+        let a = request_fingerprint(Path::new("rustc"), &args_a, &root_a, Some(&root_a), None);
+        let b = request_fingerprint(Path::new("rustc"), &args_b, &root_b, Some(&root_b), None);
+
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn request_fingerprint_keeps_malformed_rust_remap_detached_values_distinct() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_a = tmp.path().join("workspace-a");
+        let root_b = tmp.path().join("workspace-b");
+        let args_a = vec![
+            "--remap-path-prefix".to_string(),
+            root_a.to_string_lossy().into_owned(),
+        ];
+        let args_b = vec![
+            "--remap-path-prefix".to_string(),
+            root_b.to_string_lossy().into_owned(),
+        ];
+
+        let a = request_fingerprint(Path::new("rustc"), &args_a, &root_a, Some(&root_a), None);
+        let b = request_fingerprint(Path::new("rustc"), &args_b, &root_b, Some(&root_b), None);
+
+        assert_ne!(a, b);
+    }
+
+    #[test]
     fn effective_compile_args_auto_adds_root_and_cwd_maps() {
         let tmp = tempfile::tempdir().unwrap();
         let root_path = tmp.path().join("workspace");
@@ -6537,6 +6796,57 @@ exit /b 0
         assert!(effective.contains(&"-c".to_string()));
         assert!(effective.contains(&format!("-ffile-prefix-map={}=.", root_path.display())));
         assert!(effective.contains(&format!("-ffile-prefix-map={}=.", cwd.display())));
+    }
+
+    #[test]
+    fn effective_compile_args_auto_adds_rust_root_remap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_path = tmp.path().join("workspace");
+        let root = NormalizedPath::new(&root_path);
+        let env = vec![(PATH_REMAP_ENV.to_string(), "auto".to_string())];
+        let args = vec![
+            "--crate-type".to_string(),
+            "lib".to_string(),
+            "src/lib.rs".to_string(),
+        ];
+
+        let effective = effective_compile_args(
+            &args,
+            Path::new("rustc"),
+            &root_path,
+            Some(&root),
+            Some(&env),
+        );
+
+        assert_eq!(
+            &effective[effective.len() - 2..],
+            &[
+                "--remap-path-prefix".to_string(),
+                format!("{}=.", root_path.display())
+            ]
+        );
+    }
+
+    #[test]
+    fn effective_compile_args_auto_keeps_existing_rust_root_remap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_path = tmp.path().join("workspace");
+        let root = NormalizedPath::new(&root_path);
+        let env = vec![(PATH_REMAP_ENV.to_string(), "auto".to_string())];
+        let args = vec![
+            format!("--remap-path-prefix={}=/src", root_path.display()),
+            "src/lib.rs".to_string(),
+        ];
+
+        let effective = effective_compile_args(
+            &args,
+            Path::new("clippy-driver"),
+            &root_path,
+            Some(&root),
+            Some(&env),
+        );
+
+        assert_eq!(effective, args);
     }
 
     #[test]

--- a/crates/zccache-daemon/tests/rustc_cache_test.rs
+++ b/crates/zccache-daemon/tests/rustc_cache_test.rs
@@ -72,13 +72,24 @@ async fn compile(
     args: &[&str],
     cwd: &std::path::Path,
 ) -> (i32, bool) {
+    compile_with_env(client, session_id, compiler, args, cwd, None).await
+}
+
+async fn compile_with_env(
+    client: &mut ClientConn,
+    session_id: &str,
+    compiler: &str,
+    args: &[&str],
+    cwd: &std::path::Path,
+    env: Option<Vec<(String, String)>>,
+) -> (i32, bool) {
     client
         .send(&Request::Compile {
             session_id: session_id.to_string(),
             args: args.iter().map(|s| s.to_string()).collect(),
             cwd: cwd.to_path_buf().into(),
             compiler: NormalizedPath::new(compiler),
-            env: None,
+            env,
         })
         .await
         .unwrap();
@@ -90,6 +101,10 @@ async fn compile(
         Some(Response::Error { message }) => panic!("compile error: {message}"),
         other => panic!("unexpected response: {other:?}"),
     }
+}
+
+fn path_remap_auto_env() -> Vec<(String, String)> {
+    vec![("ZCCACHE_PATH_REMAP".to_string(), "auto".to_string())]
 }
 
 fn init_git_root(root: &std::path::Path) -> bool {
@@ -146,13 +161,63 @@ fn remove_file_if_exists(path: &std::path::Path) {
     }
 }
 
-async fn compile_worktree_dep(
+fn write_path_sensitive_lib(root: &std::path::Path, value: i32) -> std::path::PathBuf {
+    let src_dir = root.join("src");
+    let target_dir = root.join("target");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::create_dir_all(&target_dir).unwrap();
+    let src = src_dir.join("lib.rs");
+    std::fs::write(
+        &src,
+        format!(
+            "#[used]\npub static SOURCE_FILE: &str = file!();\npub fn value() -> i32 {{ {value} }}\n"
+        ),
+    )
+    .unwrap();
+    src
+}
+
+fn bytes_contain_path(bytes: &[u8], path: &std::path::Path) -> bool {
+    let haystack = String::from_utf8_lossy(bytes);
+    let path = path.to_string_lossy();
+    haystack.contains(path.as_ref()) || haystack.contains(&path.replace('\\', "/"))
+}
+
+async fn compile_path_sensitive_lib(
     client: &mut ClientConn,
     session_id: &str,
     compiler: &str,
     root: &std::path::Path,
+    extra_args: &[String],
+    env: Option<Vec<(String, String)>>,
 ) -> (i32, bool) {
-    compile(
+    let src = root.join("src/lib.rs");
+    let output = root.join("target/libpathremap.rlib");
+    let src = src.to_string_lossy().to_string();
+    let output = output.to_string_lossy().to_string();
+    let mut args = vec![
+        "--edition".to_string(),
+        "2021".to_string(),
+        "--crate-type".to_string(),
+        "lib".to_string(),
+        "--crate-name".to_string(),
+        "pathremap".to_string(),
+        "--emit=link".to_string(),
+    ];
+    args.extend(extra_args.iter().cloned());
+    args.extend([src, "-o".to_string(), output]);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    compile_with_env(client, session_id, compiler, &arg_refs, root, env).await
+}
+
+async fn compile_worktree_dep_with_env(
+    client: &mut ClientConn,
+    session_id: &str,
+    compiler: &str,
+    root: &std::path::Path,
+    env: Option<Vec<(String, String)>>,
+) -> (i32, bool) {
+    compile_with_env(
         client,
         session_id,
         compiler,
@@ -169,17 +234,19 @@ async fn compile_worktree_dep(
             "target/libdep.rlib",
         ],
         root,
+        env,
     )
     .await
 }
 
-async fn compile_worktree_app(
+async fn compile_worktree_app_with_env(
     client: &mut ClientConn,
     session_id: &str,
     compiler: &str,
     root: &std::path::Path,
+    env: Option<Vec<(String, String)>>,
 ) -> (i32, bool) {
-    compile(
+    compile_with_env(
         client,
         session_id,
         compiler,
@@ -198,6 +265,7 @@ async fn compile_worktree_app(
             "target/libapp.rlib",
         ],
         root,
+        env,
     )
     .await
 }
@@ -722,20 +790,38 @@ async fn test_rustc_sibling_git_worktree_equivalent_cache_sharing() {
         let app_a = root_a.join("target/libapp.rlib");
         let app_b = root_b.join("target/libapp.rlib");
 
-        let (exit_code, cached) =
-            compile_worktree_dep(&mut client_a, &session_a, &rustc_str, &root_a).await;
+        let (exit_code, cached) = compile_worktree_dep_with_env(
+            &mut client_a,
+            &session_a,
+            &rustc_str,
+            &root_a,
+            Some(path_remap_auto_env()),
+        )
+        .await;
         assert_eq!(exit_code, 0, "A dependency compile should succeed");
         assert!(!cached, "A dependency compile should be a cold miss");
         assert!(dep_a.exists(), "A dependency output should exist");
 
-        let (exit_code, cached) =
-            compile_worktree_app(&mut client_a, &session_a, &rustc_str, &root_a).await;
+        let (exit_code, cached) = compile_worktree_app_with_env(
+            &mut client_a,
+            &session_a,
+            &rustc_str,
+            &root_a,
+            Some(path_remap_auto_env()),
+        )
+        .await;
         assert_eq!(exit_code, 0, "A app compile should succeed");
         assert!(!cached, "A app compile should be a cold miss");
         let app_a_original = std::fs::read(&app_a).unwrap();
 
-        let (exit_code, cached) =
-            compile_worktree_dep(&mut client_b, &session_b, &rustc_str, &root_b).await;
+        let (exit_code, cached) = compile_worktree_dep_with_env(
+            &mut client_b,
+            &session_b,
+            &rustc_str,
+            &root_b,
+            Some(path_remap_auto_env()),
+        )
+        .await;
         assert_eq!(
             exit_code, 0,
             "B equivalent dependency compile should succeed"
@@ -746,8 +832,14 @@ async fn test_rustc_sibling_git_worktree_equivalent_cache_sharing() {
         );
         assert!(dep_b.exists(), "B dependency output should be restored");
 
-        let (exit_code, cached) =
-            compile_worktree_app(&mut client_b, &session_b, &rustc_str, &root_b).await;
+        let (exit_code, cached) = compile_worktree_app_with_env(
+            &mut client_b,
+            &session_b,
+            &rustc_str,
+            &root_b,
+            Some(path_remap_auto_env()),
+        )
+        .await;
         assert_eq!(exit_code, 0, "B equivalent app compile should succeed");
         assert!(
             cached,
@@ -758,8 +850,14 @@ async fn test_rustc_sibling_git_worktree_equivalent_cache_sharing() {
         tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
         write_worktree_project(&root_b, 7, 2);
         remove_file_if_exists(&app_b);
-        let (exit_code, cached) =
-            compile_worktree_app(&mut client_b, &session_b, &rustc_str, &root_b).await;
+        let (exit_code, cached) = compile_worktree_app_with_env(
+            &mut client_b,
+            &session_b,
+            &rustc_str,
+            &root_b,
+            Some(path_remap_auto_env()),
+        )
+        .await;
         assert_eq!(
             exit_code, 0,
             "B app compile after source edit should succeed"
@@ -771,16 +869,28 @@ async fn test_rustc_sibling_git_worktree_equivalent_cache_sharing() {
         remove_file_if_exists(&dep_b);
         remove_file_if_exists(&app_b);
 
-        let (exit_code, cached) =
-            compile_worktree_dep(&mut client_b, &session_b, &rustc_str, &root_b).await;
+        let (exit_code, cached) = compile_worktree_dep_with_env(
+            &mut client_b,
+            &session_b,
+            &rustc_str,
+            &root_b,
+            Some(path_remap_auto_env()),
+        )
+        .await;
         assert_eq!(
             exit_code, 0,
             "B dependency compile after dependency edit should succeed"
         );
         assert!(!cached, "B dependency edit should miss");
 
-        let (exit_code, cached) =
-            compile_worktree_app(&mut client_b, &session_b, &rustc_str, &root_b).await;
+        let (exit_code, cached) = compile_worktree_app_with_env(
+            &mut client_b,
+            &session_b,
+            &rustc_str,
+            &root_b,
+            Some(path_remap_auto_env()),
+        )
+        .await;
         assert_eq!(
             exit_code, 0,
             "B app compile after dependency edit should succeed"
@@ -791,8 +901,14 @@ async fn test_rustc_sibling_git_worktree_equivalent_cache_sharing() {
         );
 
         remove_file_if_exists(&app_a);
-        let (exit_code, cached) =
-            compile_worktree_app(&mut client_a, &session_a, &rustc_str, &root_a).await;
+        let (exit_code, cached) = compile_worktree_app_with_env(
+            &mut client_a,
+            &session_a,
+            &rustc_str,
+            &root_a,
+            Some(path_remap_auto_env()),
+        )
+        .await;
         assert_eq!(exit_code, 0, "A original app compile should still succeed");
         assert!(
             cached,
@@ -802,6 +918,183 @@ async fn test_rustc_sibling_git_worktree_equivalent_cache_sharing() {
             std::fs::read(&app_a).unwrap(),
             app_a_original,
             "A cached output should remain byte-identical after B misses"
+        );
+
+        shutdown.notify_one();
+        server_handle.await.unwrap();
+    })
+    .await;
+}
+
+/// Issue #229: auto-remap should make path-sensitive Rust outputs stable
+/// enough to share across sibling Git roots.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore] // integration-level: starts real daemon with IPC + rustc
+async fn test_rustc_path_remap_auto_file_macro_hits_across_sibling_git_roots() {
+    let rustc = match zccache_test_support::find_rustc() {
+        Some(p) => p,
+        None => {
+            eprintln!("skipping test: rustc not found");
+            return;
+        }
+    };
+
+    zccache_test_support::test_timeout(async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_a = tmp.path().join("worktree-a");
+        let root_b = tmp.path().join("worktree-b");
+
+        if !init_git_root(&root_a) || !init_git_root(&root_b) {
+            return;
+        }
+
+        write_path_sensitive_lib(&root_a, 7);
+        write_path_sensitive_lib(&root_b, 7);
+
+        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let mut client_a = zccache_ipc::connect(&endpoint).await.unwrap();
+        let mut client_b = zccache_ipc::connect(&endpoint).await.unwrap();
+        let session_a = start_session_in(&mut client_a, &root_a).await;
+        let session_b = start_session_in(&mut client_b, &root_b).await;
+
+        let rustc_str = rustc.to_string_lossy().to_string();
+        let output_a = root_a.join("target/libpathremap.rlib");
+        let output_b = root_b.join("target/libpathremap.rlib");
+
+        let (exit_code, cached) = compile_path_sensitive_lib(
+            &mut client_a,
+            &session_a,
+            &rustc_str,
+            &root_a,
+            &[],
+            Some(path_remap_auto_env()),
+        )
+        .await;
+        assert_eq!(exit_code, 0, "A path-sensitive compile should succeed");
+        assert!(!cached, "A path-sensitive compile should be a cold miss");
+        let bytes_a = std::fs::read(&output_a).unwrap();
+        assert!(
+            !bytes_contain_path(&bytes_a, &root_a),
+            "auto-remap output should not embed A's physical root"
+        );
+
+        let (exit_code, cached) = compile_path_sensitive_lib(
+            &mut client_b,
+            &session_b,
+            &rustc_str,
+            &root_b,
+            &[],
+            Some(path_remap_auto_env()),
+        )
+        .await;
+        assert_eq!(exit_code, 0, "B equivalent compile should succeed");
+        assert!(
+            cached,
+            "B equivalent compile should hit A's root-remapped cache entry"
+        );
+        let bytes_b = std::fs::read(&output_b).unwrap();
+        assert_eq!(bytes_a, bytes_b, "restored output should be byte-identical");
+        assert!(
+            !bytes_contain_path(&bytes_b, &root_a) && !bytes_contain_path(&bytes_b, &root_b),
+            "restored output should contain the mapped path, not either physical root"
+        );
+
+        shutdown.notify_one();
+        server_handle.await.unwrap();
+    })
+    .await;
+}
+
+/// Issue #229: without a root-covering Rust remap, path-sensitive outputs must
+/// not share across sibling roots. Different remap destination prefixes must
+/// also remain cache-significant.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore] // integration-level: starts real daemon with IPC + rustc
+async fn test_rustc_path_remap_conservative_cross_root_misses() {
+    let rustc = match zccache_test_support::find_rustc() {
+        Some(p) => p,
+        None => {
+            eprintln!("skipping test: rustc not found");
+            return;
+        }
+    };
+
+    zccache_test_support::test_timeout(async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_a = tmp.path().join("worktree-a");
+        let root_b = tmp.path().join("worktree-b");
+
+        if !init_git_root(&root_a) || !init_git_root(&root_b) {
+            return;
+        }
+
+        write_path_sensitive_lib(&root_a, 7);
+        write_path_sensitive_lib(&root_b, 7);
+
+        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let mut client_a = zccache_ipc::connect(&endpoint).await.unwrap();
+        let mut client_b = zccache_ipc::connect(&endpoint).await.unwrap();
+        let session_a = start_session_in(&mut client_a, &root_a).await;
+        let session_b = start_session_in(&mut client_b, &root_b).await;
+        let rustc_str = rustc.to_string_lossy().to_string();
+        let output_b = root_b.join("target/libpathremap.rlib");
+
+        let (exit_code, cached) =
+            compile_path_sensitive_lib(&mut client_a, &session_a, &rustc_str, &root_a, &[], None)
+                .await;
+        assert_eq!(exit_code, 0, "A no-remap compile should succeed");
+        assert!(!cached, "A no-remap compile should be a cold miss");
+
+        let (exit_code, cached) =
+            compile_path_sensitive_lib(&mut client_b, &session_b, &rustc_str, &root_b, &[], None)
+                .await;
+        assert_eq!(exit_code, 0, "B no-remap compile should succeed");
+        assert!(
+            !cached,
+            "B no-remap compile should miss instead of sharing path-sensitive output"
+        );
+        let no_remap_b = std::fs::read(&output_b).unwrap();
+        assert!(
+            bytes_contain_path(&no_remap_b, &root_b),
+            "no-remap B output should be compiled for B's physical root"
+        );
+
+        remove_file_if_exists(&root_a.join("target/libpathremap.rlib"));
+        remove_file_if_exists(&output_b);
+        let remap_a = vec![format!(
+            "--remap-path-prefix={}=/stable-a",
+            root_a.display()
+        )];
+        let remap_b = vec![format!(
+            "--remap-path-prefix={}=/stable-b",
+            root_b.display()
+        )];
+
+        let (exit_code, cached) = compile_path_sensitive_lib(
+            &mut client_a,
+            &session_a,
+            &rustc_str,
+            &root_a,
+            &remap_a,
+            None,
+        )
+        .await;
+        assert_eq!(exit_code, 0, "A manual-remap compile should succeed");
+        assert!(!cached, "A manual-remap compile should miss");
+
+        let (exit_code, cached) = compile_path_sensitive_lib(
+            &mut client_b,
+            &session_b,
+            &rustc_str,
+            &root_b,
+            &remap_b,
+            None,
+        )
+        .await;
+        assert_eq!(exit_code, 0, "B manual-remap compile should succeed");
+        assert!(
+            !cached,
+            "different --remap-path-prefix destinations must not share"
         );
 
         shutdown.notify_one();

--- a/crates/zccache-depgraph/src/context.rs
+++ b/crates/zccache-depgraph/src/context.rs
@@ -1133,6 +1133,20 @@ mod tests {
     }
 
     #[test]
+    fn rustc_context_key_with_root_normalizes_root_remap_left_side() {
+        let mut ctx_a = make_rustc_context("/workspace-a/crates/demo/src/lib.rs", "2021");
+        ctx_a.remap_path_prefixes = vec!["/workspace-a=.".to_string()];
+        let mut ctx_b = make_rustc_context("/workspace-b/crates/demo/src/lib.rs", "2021");
+        ctx_b.remap_path_prefixes = vec!["/workspace-b=.".to_string()];
+
+        assert_eq!(
+            ctx_a.context_key_with_root(Some(Path::new("/workspace-a"))),
+            ctx_b.context_key_with_root(Some(Path::new("/workspace-b"))),
+            "root-covering remaps should hash equivalently across roots"
+        );
+    }
+
+    #[test]
     fn rustc_context_key_with_root_keeps_external_remap_left_sides_distinct() {
         let mut ctx_a = make_rustc_context("/workspace-a/crates/demo/src/lib.rs", "2021");
         ctx_a.remap_path_prefixes = vec!["/external-a=/src".to_string()];
@@ -1157,6 +1171,34 @@ mod tests {
             ctx_a.context_key_with_root(Some(Path::new("/workspace-a"))),
             ctx_b.context_key_with_root(Some(Path::new("/workspace-b"))),
             "only the remap left side is root-normalized"
+        );
+    }
+
+    #[test]
+    fn rustc_context_key_with_root_preserves_remap_right_side() {
+        let mut ctx_a = make_rustc_context("/workspace-a/crates/demo/src/lib.rs", "2021");
+        ctx_a.remap_path_prefixes = vec!["/workspace-a=.".to_string()];
+        let mut ctx_b = make_rustc_context("/workspace-b/crates/demo/src/lib.rs", "2021");
+        ctx_b.remap_path_prefixes = vec!["/workspace-b=/src".to_string()];
+
+        assert_ne!(
+            ctx_a.context_key_with_root(Some(Path::new("/workspace-a"))),
+            ctx_b.context_key_with_root(Some(Path::new("/workspace-b"))),
+            "different remap new prefixes must remain cache-significant"
+        );
+    }
+
+    #[test]
+    fn rustc_context_key_with_root_keeps_malformed_remaps_distinct() {
+        let mut ctx_a = make_rustc_context("/workspace-a/crates/demo/src/lib.rs", "2021");
+        ctx_a.remap_path_prefixes = vec!["/workspace-a".to_string()];
+        let mut ctx_b = make_rustc_context("/workspace-b/crates/demo/src/lib.rs", "2021");
+        ctx_b.remap_path_prefixes = vec!["/workspace-b".to_string()];
+
+        assert_ne!(
+            ctx_a.context_key_with_root(Some(Path::new("/workspace-a"))),
+            ctx_b.context_key_with_root(Some(Path::new("/workspace-b"))),
+            "malformed remap values should not be root-normalized"
         );
     }
 

--- a/crates/zccache-depgraph/src/rustc_args.rs
+++ b/crates/zccache-depgraph/src/rustc_args.rs
@@ -777,4 +777,13 @@ mod tests {
         );
         assert_eq!(parsed.remap_path_prefixes, vec!["/home/user=/anon"]);
     }
+
+    #[test]
+    fn remap_path_prefix_equals_form_parsed() {
+        let parsed = parse_rustc_args(
+            &args(&["--remap-path-prefix=/home/user=/anon", "src/lib.rs"]),
+            &cwd(),
+        );
+        assert_eq!(parsed.remap_path_prefixes, vec!["/home/user=/anon"]);
+    }
 }


### PR DESCRIPTION
Closes #229.

## Summary
- add `ZCCACHE_PATH_REMAP=auto` support for rustc/clippy by injecting a root-covering `--remap-path-prefix <worktree-root>=.` when needed
- gate Rust cross-root request/context sharing on a root-covering remap, normalize detached and equals `--remap-path-prefix` forms, preserve the destination prefix, and keep malformed/external values conservative
- add Rust parser/context/request-fingerprint tests plus ignored rustc integration tests for `file!()` auto-remap hits, no-remap misses, different destination-prefix misses, and existing sibling dependency invalidation
- update README Rust worktree-sharing docs for the now-supported auto directive

## Validation
- `cargo test -p zccache-depgraph remap_path_prefix`
- `cargo test -p zccache-depgraph rustc_context_key_with_root`
- `cargo test -p zccache-daemon rust_remap`
- `cargo test -p zccache-daemon effective_compile_args_auto_`
- `cargo test -p zccache-daemon --test rustc_cache_test test_rustc_path_remap_auto_file_macro_hits_across_sibling_git_roots -- --ignored --nocapture`
- `cargo test -p zccache-daemon --test rustc_cache_test test_rustc_path_remap_conservative_cross_root_misses -- --ignored --nocapture`
- `cargo test -p zccache-daemon --test rustc_cache_test test_rustc_sibling_git_worktree_equivalent_cache_sharing -- --ignored --nocapture`
- `cargo test -p zccache-daemon --test rustc_adversarial_test rustc_remap_path_prefix_affects_cache_key -- --ignored --nocapture`
- `cargo test -p zccache-daemon --test stress_test path_remap_auto_compiles_file_macro_stably_across_git_roots -- --ignored --nocapture`
- `cargo test -p zccache-daemon --test link_cache_test test_link_path_remap_auto_hits_across_sibling_git_roots -- --ignored --nocapture`
- `cargo test -p zccache-daemon --test perf_bench_test perf_rustc_zccache_vs_sccache -- --ignored --nocapture`

## Benchmark
Rust benchmark on this machine (`C:\ProgramData\chocolatey\bin\rustc.exe`), 50 `.rs` files, 5 warm trials:

| Scenario | Bare rustc | sccache | zccache | vs sccache | vs bare rustc |
|:---------|----------:|--------:|--------:|-----------:|--------------:|
| Build, Cold | 6.727s | 8.303s | 7.710s | 1.1x faster | 1.1x slower |
| Build, Warm | 6.344s | 7.448s | **0.135s** | **55x faster** | **47x faster** |
| Check, Cold | 4.345s | 5.796s | 5.147s | 1.1x faster | 1.2x slower |
| Check, Warm | 4.025s | 4.983s | **0.103s** | **49x faster** | **39x faster** |

Build mode is `--emit=dep-info,metadata,link`; check mode is `--emit=dep-info,metadata`.
