### PR TITLE
feat(bench): sibling git workspace + path-remap-auto benchmarks

### DIFF
--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -54,8 +54,15 @@ BENCHMARK_BASE_COMMAND = [
 ]
 BENCHMARK_TESTS_BY_LANGUAGE = {
     "c": ("perf_c_zccache_vs_bare",),
-    "c++": ("perf_warm_cache_zccache_vs_sccache", "perf_response_file"),
-    "rust": ("perf_rustc_zccache_vs_sccache",),
+    "c++": (
+        "perf_warm_cache_zccache_vs_sccache",
+        "perf_response_file",
+        "perf_cpp_sibling_remap_warm",
+    ),
+    "rust": (
+        "perf_rustc_zccache_vs_sccache",
+        "perf_rustc_sibling_remap_warm",
+    ),
 }
 BENCHMARK_COMMAND = [
     *BENCHMARK_BASE_COMMAND,
@@ -85,9 +92,21 @@ TABLES = {
         "language": "c++",
         "bare_label": "Bare clang",
     },
+    "## C++ Sibling-Workspace Remap Benchmark:": {
+        "id": "cpp-sibling-remap",
+        "label": "C++ sibling git remap",
+        "language": "c++",
+        "bare_label": "Bare clang",
+    },
     "## Rust Benchmark:": {
         "id": "rust",
         "label": "Rust rustc",
+        "language": "rust",
+        "bare_label": "Bare rustc",
+    },
+    "## Rust Sibling-Workspace Remap Benchmark:": {
+        "id": "rust-sibling-remap",
+        "label": "Rust sibling git remap",
         "language": "rust",
         "bare_label": "Bare rustc",
     },

--- a/ci/tests/README.md
+++ b/ci/tests/README.md
@@ -1,0 +1,12 @@
+# CI Script Tests
+
+Python-level pytest suites that exercise the CI helper modules in `ci/`
+(packaging, perf-guard parsing, release workflow). These are infrastructure
+tests for the CI scripts themselves — not project tests. Per project policy,
+all benchmarks and application tests are written in Rust.
+
+Run with:
+
+```bash
+uv run pytest ci/tests
+```

--- a/ci/tests/test_benchmark_stats.py
+++ b/ci/tests/test_benchmark_stats.py
@@ -33,6 +33,18 @@ SAMPLE_LOG = """
 |:---------|----------:|--------:|--------:|-----------:|--------------:|
 | Build, Cold | 8.165s | 9.634s | 41.624s | 4.3x slower | 5.1x slower |
 | Build, Warm | 7.018s | 8.236s | **0.123s** | **67x faster** | **57x faster** |
+
+## C++ Sibling-Workspace Remap Benchmark: 50 .cpp files, 5 warm trials
+
+| Scenario | Bare clang | sccache | zccache | vs sccache | vs bare clang |
+|:---------|----------:|--------:|--------:|-----------:|--------------:|
+| Sibling-workspace, Warm | 11.812s | 1.602s | **0.052s** | **31x faster** | **227x faster** |
+
+## Rust Sibling-Workspace Remap Benchmark: 50 .rs files, 5 warm trials
+
+| Scenario | Bare rustc | sccache | zccache | vs sccache | vs bare rustc |
+|:---------|----------:|--------:|--------:|-----------:|--------------:|
+| Sibling-workspace, Warm | 7.142s | 8.301s | **0.127s** | **65x faster** | **56x faster** |
 """
 
 
@@ -62,12 +74,14 @@ def sample_payload():
 def test_parse_benchmark_log_extracts_all_tables():
     rows = benchmark_stats.parse_benchmark_log(SAMPLE_LOG)
 
-    assert len(rows) == 8
+    assert len(rows) == 10
     assert {row["benchmark"] for row in rows} == {
         "c-inline",
         "cpp-inline",
         "cpp-response-file",
+        "cpp-sibling-remap",
         "rust",
+        "rust-sibling-remap",
     }
 
     c_warm = [row for row in rows if row["benchmark"] == "c-inline" and row["mode"] == "warm"][0]
@@ -78,6 +92,16 @@ def test_parse_benchmark_log_extracts_all_tables():
     assert rust_warm["language"] == "rust"
     assert rust_warm["zccache_seconds"] == 0.123
     assert rust_warm["zccache_vs_sccache_ratio"] == 66.959
+
+    cpp_remap = [row for row in rows if row["benchmark"] == "cpp-sibling-remap"][0]
+    assert cpp_remap["mode"] == "warm"
+    assert cpp_remap["language"] == "c++"
+    assert cpp_remap["zccache_seconds"] == 0.052
+
+    rust_remap = [row for row in rows if row["benchmark"] == "rust-sibling-remap"][0]
+    assert rust_remap["mode"] == "warm"
+    assert rust_remap["language"] == "rust"
+    assert rust_remap["zccache_seconds"] == 0.127
 
 
 def test_group_results_by_language_returns_expected_buckets():
@@ -91,7 +115,7 @@ def test_group_results_by_language_returns_expected_buckets():
         "C++",
         "Rust",
     }
-    assert [len(groups[language]) for language in groups] == [2, 4, 2]
+    assert [len(groups[language]) for language in groups] == [2, 5, 3]
 
 
 def test_render_html_links_json_stats_and_language_images_only():

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -313,8 +313,12 @@ def test_benchmark_language_commands_are_filtered():
     assert [command[-4] for command in cpp_commands] == [
         "perf_warm_cache_zccache_vs_sccache",
         "perf_response_file",
+        "perf_cpp_sibling_remap_warm",
     ]
-    assert [command[-4] for command in rust_commands] == ["perf_rustc_zccache_vs_sccache"]
+    assert [command[-4] for command in rust_commands] == [
+        "perf_rustc_zccache_vs_sccache",
+        "perf_rustc_sibling_remap_warm",
+    ]
 
 
 def test_prebuilt_benchmark_binary_commands_are_filtered():
@@ -331,6 +335,13 @@ def test_prebuilt_benchmark_binary_commands_are_filtered():
         [
             "perf_bench_test",
             "perf_response_file",
+            "--nocapture",
+            "--ignored",
+            "--test-threads=1",
+        ],
+        [
+            "perf_bench_test",
+            "perf_cpp_sibling_remap_warm",
             "--nocapture",
             "--ignored",
             "--test-threads=1",

--- a/crates/zccache-daemon/tests/perf_bench_test.rs
+++ b/crates/zccache-daemon/tests/perf_bench_test.rs
@@ -2101,3 +2101,481 @@ async fn perf_rustc_zccache_vs_sccache() {
     }
     eprintln!();
 }
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Sibling git workspace + ZCCACHE_PATH_REMAP=auto benchmarks.
+//
+// These benchmarks measure warm-state compile latency when zccache shares cache
+// entries across two sibling git roots via path-remap auto. Bare and sccache
+// run their normal same-workspace warm trials in workspace B (they cannot
+// share across sibling roots). zccache is primed from workspace A, then warm
+// trials measure compiles in workspace B that should hit the sibling cache.
+// ═════════════════════════════════════════════════════════════════════════════
+
+fn make_git_workspace(dir: &Path) {
+    std::fs::create_dir_all(dir.join(".git")).unwrap();
+}
+
+fn path_remap_auto_env() -> Vec<(String, String)> {
+    let mut env: Vec<(String, String)> = std::env::vars_os()
+        .filter_map(|(key, value)| {
+            let key = key.into_string().ok()?;
+            let value = value.into_string().ok()?;
+            let is_zccache_root = key.eq_ignore_ascii_case("ZCCACHE_WORKTREE_ROOT");
+            let is_zccache_remap = key.eq_ignore_ascii_case("ZCCACHE_PATH_REMAP");
+            (!is_zccache_root && !is_zccache_remap).then_some((key, value))
+        })
+        .collect();
+    env.push(("ZCCACHE_PATH_REMAP".to_string(), "auto".to_string()));
+    env
+}
+
+async fn zccache_compile_cpp_single_with_env(
+    client: &mut ClientConn,
+    session_id: &str,
+    compiler: &str,
+    cwd: &str,
+    sources: &[String],
+    env: Vec<(String, String)>,
+) -> Duration {
+    clean_objects(Path::new(cwd));
+    let start = Instant::now();
+    for src in sources {
+        client
+            .send(&Request::Compile {
+                session_id: session_id.to_string(),
+                args: vec![
+                    "-c".into(),
+                    src.clone(),
+                    "-o".into(),
+                    src.replace(".cpp", ".o"),
+                    "-Iinclude".into(),
+                    "-O2".into(),
+                    "-std=c++17".into(),
+                ],
+                cwd: cwd.into(),
+                compiler: compiler.to_string().into(),
+                env: Some(env.clone()),
+            })
+            .await
+            .unwrap();
+        match client.recv().await.unwrap() {
+            Some(Response::CompileResult { exit_code, .. }) => {
+                assert_eq!(exit_code, 0, "compile failed for {src}");
+            }
+            other => panic!("expected CompileResult, got: {other:?}"),
+        }
+    }
+    start.elapsed()
+}
+
+async fn start_zccache_session(client: &mut ClientConn, working_dir: &str) -> String {
+    client
+        .send(&Request::SessionStart {
+            client_pid: std::process::id(),
+            working_dir: working_dir.into(),
+            log_file: None,
+            track_stats: true,
+            journal_path: None,
+        })
+        .await
+        .unwrap();
+    match client.recv().await.unwrap() {
+        Some(Response::SessionStarted { session_id, .. }) => session_id,
+        other => panic!("expected SessionStarted, got: {other:?}"),
+    }
+}
+
+async fn end_zccache_session(client: &mut ClientConn, session_id: String) {
+    client
+        .send(&Request::SessionEnd { session_id })
+        .await
+        .unwrap();
+    let _ = client.recv::<Response>().await;
+}
+
+/// C++ sibling-workspace remap benchmark. Warm-only. Compares zccache (with
+/// ZCCACHE_PATH_REMAP=auto, primed from sibling workspace A) against bare clang
+/// and sccache (each warm in workspace B).
+#[tokio::test]
+#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_cpp_sibling_remap_warm --nocapture --ignored
+async fn perf_cpp_sibling_remap_warm() {
+    let compiler_path = match zccache_test_support::find_clang() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: no C++ compiler found");
+            return;
+        }
+    };
+    let compiler = compiler_path.to_string_lossy().to_string();
+    let sources = source_names();
+
+    eprintln!();
+    eprintln!("================================================================");
+    eprintln!("  C++ SIBLING-WORKSPACE REMAP BENCHMARK (warm-only)");
+    eprintln!("  {NUM_FILES} .cpp files | {WARM_TRIALS} warm trials | ZCCACHE_PATH_REMAP=auto");
+    eprintln!("  Compiler: {compiler}");
+    eprintln!("================================================================");
+    eprintln!();
+
+    // Use one parent tempdir so sibling roots are filesystem-adjacent.
+    let parent = zccache_test_support::temp_cache_dir().unwrap();
+    let workspace_a = parent.path().join("workspace-a");
+    let workspace_b = parent.path().join("workspace-b");
+    std::fs::create_dir_all(&workspace_a).unwrap();
+    std::fs::create_dir_all(&workspace_b).unwrap();
+    make_git_workspace(&workspace_a);
+    make_git_workspace(&workspace_b);
+    generate_project(&workspace_a);
+    generate_project(&workspace_b);
+
+    // ── Bare clang warm in workspace B ─────────────────────────────────
+    eprintln!("  [1/3] Bare clang (workspace B, warm)");
+    warmup_compiler(&compiler, &workspace_b);
+    let _ = baseline_single(&compiler, &workspace_b, &sources); // discard cold
+    let mut bl_warm = Vec::with_capacity(WARM_TRIALS);
+    for _ in 0..WARM_TRIALS {
+        bl_warm.push(baseline_single(&compiler, &workspace_b, &sources));
+    }
+    print_trials("warm:", &bl_warm);
+    eprintln!();
+
+    // ── sccache warm in workspace B ────────────────────────────────────
+    let sccache_warm = if let Some(sccache_bin) = find_sccache() {
+        let sc_cache_dir = zccache_test_support::temp_cache_dir().unwrap();
+        let sc_cache_str = sc_cache_dir.path().to_string_lossy().into_owned();
+        std::env::set_var("SCCACHE_DIR", &sc_cache_str);
+        eprintln!("  [2/3] sccache (workspace B, warm)");
+        let _ = std::process::Command::new(&sccache_bin)
+            .arg("--stop-server")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        let _ = std::process::Command::new(&sccache_bin)
+            .arg("--start-server")
+            .env("SCCACHE_DIR", &sc_cache_str)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        warmup_compiler(&compiler, &workspace_b);
+        let _ = sccache_compile_single(&sccache_bin, &compiler, &workspace_b, &sources); // discard cold
+        let mut warm = Vec::with_capacity(WARM_TRIALS);
+        for _ in 0..WARM_TRIALS {
+            warm.push(sccache_compile_single(
+                &sccache_bin,
+                &compiler,
+                &workspace_b,
+                &sources,
+            ));
+        }
+        print_trials("warm:", &warm);
+        let _ = std::process::Command::new(&sccache_bin)
+            .arg("--stop-server")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        std::env::remove_var("SCCACHE_DIR");
+        eprintln!();
+        Some(warm)
+    } else {
+        eprintln!("  [2/3] sccache: not found, skipping\n");
+        None
+    };
+
+    // ── zccache primed from workspace A, warm in workspace B ───────────
+    eprintln!("  [3/3] zccache (prime: workspace A, warm: workspace B, remap=auto)");
+    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let mut client = zccache_ipc::connect(&endpoint).await.unwrap();
+
+    let workspace_a_str = workspace_a.to_string_lossy().into_owned();
+    let workspace_b_str = workspace_b.to_string_lossy().into_owned();
+    let session_a = start_zccache_session(&mut client, &workspace_a_str).await;
+
+    // Prime: compile in workspace A (cold miss + populates remap-keyed cache).
+    warmup_compiler(&compiler, &workspace_a);
+    let _ = zccache_compile_cpp_single_with_env(
+        &mut client,
+        &session_a,
+        &compiler,
+        &workspace_a_str,
+        &sources,
+        path_remap_auto_env(),
+    )
+    .await;
+    end_zccache_session(&mut client, session_a).await;
+
+    let session_b = start_zccache_session(&mut client, &workspace_b_str).await;
+    // First compile in B should already hit the sibling cache entry from A.
+    let _ = zccache_compile_cpp_single_with_env(
+        &mut client,
+        &session_b,
+        &compiler,
+        &workspace_b_str,
+        &sources,
+        path_remap_auto_env(),
+    )
+    .await;
+
+    let mut zc_warm = Vec::with_capacity(WARM_TRIALS);
+    for _ in 0..WARM_TRIALS {
+        zc_warm.push(
+            zccache_compile_cpp_single_with_env(
+                &mut client,
+                &session_b,
+                &compiler,
+                &workspace_b_str,
+                &sources,
+                path_remap_auto_env(),
+            )
+            .await,
+        );
+    }
+    print_trials("warm:", &zc_warm);
+
+    end_zccache_session(&mut client, session_b).await;
+    shutdown.notify_one();
+    server_handle.await.unwrap();
+
+    // ── Report ─────────────────────────────────────────────────────────
+    let dash = "\u{2014}";
+    let bl_warm_med = median(&bl_warm);
+    let zc_warm_med = median(&zc_warm);
+    let sccache_warm_str = sccache_warm.as_ref().map(|t| fmt_dur(median(t)));
+    let vs_sccache = sccache_warm
+        .as_ref()
+        .map(|t| fmt_ratio(median(t), zc_warm_med, true));
+    let vs_bare = fmt_ratio(bl_warm_med, zc_warm_med, true);
+
+    eprintln!();
+    eprintln!(
+        "## C++ Sibling-Workspace Remap Benchmark: {NUM_FILES} .cpp files, {WARM_TRIALS} warm trials"
+    );
+    eprintln!();
+    eprintln!("| Scenario | Bare clang | sccache | zccache | vs sccache | vs bare clang |");
+    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|");
+    eprintln!(
+        "| Sibling-workspace, Warm | {} | {} | **{}** | {} | {} |",
+        fmt_dur(bl_warm_med),
+        sccache_warm_str.as_deref().unwrap_or(dash),
+        fmt_dur(zc_warm_med),
+        vs_sccache.as_deref().unwrap_or(dash),
+        vs_bare,
+    );
+    eprintln!();
+    eprintln!(
+        "> Sibling-workspace = two adjacent git roots; zccache primed from workspace A, warm trials measured in workspace B with `ZCCACHE_PATH_REMAP=auto`. Bare/sccache run their normal same-workspace warm trials in workspace B."
+    );
+    eprintln!();
+}
+
+/// Rust sibling-workspace remap benchmark. Warm-only. Compares zccache (with
+/// ZCCACHE_PATH_REMAP=auto, primed from sibling workspace A) against bare rustc
+/// and sccache (each warm in workspace B).
+#[tokio::test]
+#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_rustc_sibling_remap_warm --nocapture --ignored
+async fn perf_rustc_sibling_remap_warm() {
+    let rustc_path = match zccache_test_support::find_rustc() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: rustc not found");
+            return;
+        }
+    };
+    let rc = rustc_path.to_string_lossy().to_string();
+    let srcs = rust_source_names();
+
+    eprintln!();
+    eprintln!("================================================================");
+    eprintln!("  RUST SIBLING-WORKSPACE REMAP BENCHMARK (warm-only)");
+    eprintln!(
+        "  {RUSTC_NUM_FILES} .rs files | {RUSTC_WARM_TRIALS} warm trials | ZCCACHE_PATH_REMAP=auto"
+    );
+    eprintln!("  Compiler: {rc}");
+    eprintln!("================================================================");
+    eprintln!();
+
+    let parent = zccache_test_support::temp_cache_dir().unwrap();
+    let workspace_a = parent.path().join("workspace-a");
+    let workspace_b = parent.path().join("workspace-b");
+    std::fs::create_dir_all(&workspace_a).unwrap();
+    std::fs::create_dir_all(&workspace_b).unwrap();
+    make_git_workspace(&workspace_a);
+    make_git_workspace(&workspace_b);
+    generate_rust_project(&workspace_a);
+    generate_rust_project(&workspace_b);
+
+    // ── Bare rustc warm in workspace B ─────────────────────────────────
+    eprintln!("  [1/3] Bare rustc (workspace B, warm)");
+    warmup_rustc(&rc, &workspace_b);
+    let _ = run_rustc_batch(&rc, &workspace_b, &srcs, rustc_args_for); // discard cold
+    let mut bl_warm = Vec::with_capacity(RUSTC_WARM_TRIALS);
+    for _ in 0..RUSTC_WARM_TRIALS {
+        bl_warm.push(run_rustc_batch(&rc, &workspace_b, &srcs, rustc_args_for));
+    }
+    print_trials("warm:", &bl_warm);
+    eprintln!();
+
+    // ── sccache warm in workspace B ────────────────────────────────────
+    let sccache_warm = if let Some(scc_bin) = find_sccache() {
+        let scd = zccache_test_support::temp_cache_dir().unwrap();
+        let scd_s = scd.path().to_string_lossy().into_owned();
+        std::env::set_var("SCCACHE_DIR", &scd_s);
+        eprintln!("  [2/3] sccache (workspace B, warm)");
+        let _ = std::process::Command::new(&scc_bin)
+            .arg("--stop-server")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        let _ = std::process::Command::new(&scc_bin)
+            .arg("--start-server")
+            .env("SCCACHE_DIR", &scd_s)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        warmup_rustc(&rc, &workspace_b);
+        let _ = run_sccache_rustc_batch(&scc_bin, &rc, &workspace_b, &srcs, rustc_args_for);
+        let mut warm = Vec::with_capacity(RUSTC_WARM_TRIALS);
+        for _ in 0..RUSTC_WARM_TRIALS {
+            warm.push(run_sccache_rustc_batch(
+                &scc_bin,
+                &rc,
+                &workspace_b,
+                &srcs,
+                rustc_args_for,
+            ));
+        }
+        print_trials("warm:", &warm);
+        let _ = std::process::Command::new(&scc_bin)
+            .arg("--stop-server")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        std::env::remove_var("SCCACHE_DIR");
+        eprintln!();
+        Some(warm)
+    } else {
+        eprintln!("  [2/3] sccache: not found, skipping\n");
+        None
+    };
+
+    // ── zccache primed from workspace A, warm in workspace B ───────────
+    eprintln!("  [3/3] zccache (prime: workspace A, warm: workspace B, remap=auto)");
+    let (ep, sh, sd) = start_daemon().await;
+    let mut cl = zccache_ipc::connect(&ep).await.unwrap();
+    let workspace_a_str = workspace_a.to_string_lossy().into_owned();
+    let workspace_b_str = workspace_b.to_string_lossy().into_owned();
+
+    let session_a = start_zccache_session(&mut cl, &workspace_a_str).await;
+    warmup_rustc(&rc, &workspace_a);
+    let _ = run_zccache_rustc_batch_with_env(
+        &mut cl,
+        &session_a,
+        &rc,
+        &workspace_a_str,
+        &srcs,
+        rustc_args_for,
+        path_remap_auto_env(),
+    )
+    .await;
+    end_zccache_session(&mut cl, session_a).await;
+
+    let session_b = start_zccache_session(&mut cl, &workspace_b_str).await;
+    // First compile in B should hit sibling cache entries from A.
+    let _ = run_zccache_rustc_batch_with_env(
+        &mut cl,
+        &session_b,
+        &rc,
+        &workspace_b_str,
+        &srcs,
+        rustc_args_for,
+        path_remap_auto_env(),
+    )
+    .await;
+    let mut zc_warm = Vec::with_capacity(RUSTC_WARM_TRIALS);
+    for _ in 0..RUSTC_WARM_TRIALS {
+        zc_warm.push(
+            run_zccache_rustc_batch_with_env(
+                &mut cl,
+                &session_b,
+                &rc,
+                &workspace_b_str,
+                &srcs,
+                rustc_args_for,
+                path_remap_auto_env(),
+            )
+            .await,
+        );
+    }
+    print_trials("warm:", &zc_warm);
+
+    end_zccache_session(&mut cl, session_b).await;
+    sd.notify_one();
+    sh.await.unwrap();
+
+    // ── Report ─────────────────────────────────────────────────────────
+    let dash = "\u{2014}";
+    let bl_med = median(&bl_warm);
+    let zc_med = median(&zc_warm);
+    let sccache_warm_str = sccache_warm.as_ref().map(|t| fmt_dur(median(t)));
+    let vs_sccache = sccache_warm
+        .as_ref()
+        .map(|t| fmt_ratio(median(t), zc_med, true));
+    let vs_bare = fmt_ratio(bl_med, zc_med, true);
+
+    eprintln!();
+    eprintln!(
+        "## Rust Sibling-Workspace Remap Benchmark: {RUSTC_NUM_FILES} .rs files, {RUSTC_WARM_TRIALS} warm trials"
+    );
+    eprintln!();
+    eprintln!("| Scenario | Bare rustc | sccache | zccache | vs sccache | vs bare rustc |");
+    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|");
+    eprintln!(
+        "| Sibling-workspace, Warm | {} | {} | **{}** | {} | {} |",
+        fmt_dur(bl_med),
+        sccache_warm_str.as_deref().unwrap_or(dash),
+        fmt_dur(zc_med),
+        vs_sccache.as_deref().unwrap_or(dash),
+        vs_bare,
+    );
+    eprintln!();
+    eprintln!(
+        "> Sibling-workspace = two adjacent git roots; zccache primed from workspace A, warm trials measured in workspace B with `ZCCACHE_PATH_REMAP=auto`. Bare/sccache run their normal same-workspace warm trials in workspace B."
+    );
+    eprintln!();
+}
+
+async fn run_zccache_rustc_batch_with_env(
+    client: &mut ClientConn,
+    sid: &str,
+    rc: &str,
+    cwd: &str,
+    srcs: &[String],
+    args_fn: fn(&str, &str, &str) -> Vec<String>,
+    env: Vec<(String, String)>,
+) -> Duration {
+    clean_rlibs(Path::new(cwd));
+    let deps = Path::new(cwd).join("deps");
+    let deps_s = deps.to_string_lossy().to_string();
+    let start = Instant::now();
+    for (i, src) in srcs.iter().enumerate() {
+        let cn = format!("unit_{i:03}");
+        let args = args_fn(&cn, src, &deps_s);
+        client
+            .send(&Request::Compile {
+                session_id: sid.to_string(),
+                args,
+                cwd: cwd.into(),
+                compiler: rc.to_string().into(),
+                env: Some(env.clone()),
+            })
+            .await
+            .unwrap();
+        match client.recv().await.unwrap() {
+            Some(Response::CompileResult { exit_code, .. }) => {
+                assert_eq!(exit_code, 0, "zccache rustc failed for {src}")
+            }
+            other => panic!("expected CompileResult, got: {other:?}"),
+        }
+    }
+    start.elapsed()
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -55,3 +55,33 @@ Shared libraries (.so, .dylib, .dll) and executables are Phase 2.
   - test_ar_non_cacheable_passthrough: ar t → passthrough with output
   - test_link_stats_in_status: verify DaemonStatus.total_links increments
   - Also fixed: daemon_start tests now #[ignore] (were causing flaky failures)
+
+---
+
+# Sibling Git Workspace + Path Remap Auto Benchmarks
+
+Add benchmark scenarios that exercise `ZCCACHE_PATH_REMAP=auto` across sibling
+git workspaces. Compare warm-state performance against bare compiler and
+sccache. Cold rows are intentionally omitted — the new feature only changes
+warm-state cache identity.
+
+## Scope
+
+- C++ (clang++, 50 files): single-file warm.
+- Rust (rustc, build emit-link, 50 files): warm only.
+- Each benchmark sets up two sibling git roots (`workspace-a` / `workspace-b`),
+  primes zccache from workspace A, then measures warm trials in workspace B.
+- Bare and sccache run warm trials in workspace B using their normal
+  same-workspace warm semantics (they cannot share across sibling roots).
+
+## Plan
+
+- [x] Step 1: Add `perf_cpp_sibling_remap_warm` test
+      (`crates/zccache-daemon/tests/perf_bench_test.rs`). Verified locally:
+      zccache 0.695s vs bare 11.353s (16x) vs sccache 1.420s (2x).
+- [x] Step 2: Add `perf_rustc_sibling_remap_warm` test. Verified locally:
+      zccache 0.195s vs bare 5.909s (30x) vs sccache 7.447s (38x).
+- [x] Step 3: Update `ci/benchmark_stats.py` TABLES dict and
+      `BENCHMARK_TESTS_BY_LANGUAGE`. Updated `ci/tests/test_perf_guard.py`
+      and `ci/tests/test_benchmark_stats.py` fixtures/assertions.
+- [x] Step 4: Verified pytest passes (37/37 + 1 skipped) and clippy clean.


### PR DESCRIPTION
## Summary

- Adds two warm-only benchmarks (`perf_cpp_sibling_remap_warm`,
  `perf_rustc_sibling_remap_warm`) that exercise `ZCCACHE_PATH_REMAP=auto`
  across two sibling git roots. zccache is primed from workspace A; warm
  trials measure compiles in workspace B that hit the sibling cache.
- Bare clang++/rustc and sccache run normal same-workspace warm trials in
  workspace B for comparison (they cannot share across sibling roots).
- Updates `ci/benchmark_stats.py` (TABLES + `BENCHMARK_TESTS_BY_LANGUAGE`)
  so the new markdown tables are parsed and emitted in benchmark artifacts.

Local results:

| Lang | Bare | sccache | zccache (remap, sibling-primed) |
|---|---:|---:|---:|
| C++ | 11.353s | 1.420s | **0.695s** (16x / 2x) |
| Rust | 5.909s | 7.447s | **0.195s** (30x / 38x) |

## Test plan

- [x] `soldr cargo check -p zccache-daemon --tests`
- [x] `soldr cargo clippy -p zccache-daemon --tests -- -D warnings`
- [x] `soldr cargo fmt --all`
- [x] `PYTHONPATH=. uv run pytest ci/tests -q` (37 passed, 1 skipped)
- [x] `soldr --no-cache cargo test -p zccache-daemon --test perf_bench_test -- perf_cpp_sibling_remap_warm --nocapture --ignored`
- [x] `soldr --no-cache cargo test -p zccache-daemon --test perf_bench_test -- perf_rustc_sibling_remap_warm --nocapture --ignored`
- [ ] Perf guard CI run picks up the new rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)