### PR TITLE
docs(readme): sub-agent / parallel-worktree recipe for ZCCACHE_PATH_REMAP=auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,68 @@ cross-root hits after validating the current worktree's recorded input hashes;
 otherwise zccache falls back to the normal depgraph check or a path-specific
 miss.
 
+#### Sub-agent / parallel-worktree recipe
+
+The typical multi-agent workflow runs one sub-agent per `git worktree`, all
+checked out from the same repository under sibling paths. Without remap, every
+worktree has different absolute compile inputs, so each agent pays full compile
+cost even when source contents are identical. With `ZCCACHE_PATH_REMAP=auto`
+exported once at the orchestrator level, every sub-agent's compile in every
+worktree shares the same logical cache.
+
+1. Create the worktrees. Anything `git worktree add` produces (or a sibling
+   `git clone`) works — zccache auto-detects each enclosing Git root:
+
+   ```bash
+   git worktree add ../agent-a -b agent-a main
+   git worktree add ../agent-b -b agent-b main
+   git worktree add ../agent-c -b agent-c main
+   ```
+
+2. Export the remap directive once, before launching the agents. Every
+   sub-process inherits it; no per-worktree configuration is required:
+
+   ```bash
+   export ZCCACHE_PATH_REMAP=auto
+   export RUSTC_WRAPPER=zccache              # Rust projects
+   # For C/C++, point your build to zccache (e.g. CMAKE_C_COMPILER_LAUNCHER=zccache).
+   ```
+
+3. Launch sub-agents in their own worktrees in parallel. The first agent to
+   compile a unit populates the cache; the others get worktree-equivalent
+   hits even though their absolute paths differ:
+
+   ```bash
+   (cd ../agent-a && agent-runner ...) &
+   (cd ../agent-b && agent-runner ...) &
+   (cd ../agent-c && agent-runner ...) &
+   wait
+   ```
+
+4. Verify it is working. `zccache status` reports worktree-equivalent hits
+   separately from same-root hits, and per-session logs include the gate
+   reason if a request fell back (`path_outside_root`,
+   `content_hash_mismatch`, `toolchain_mismatch`, etc. — see the list above).
+
+A few things worth knowing:
+
+- One daemon, one cache. All worktrees share the same zccache daemon and
+  artifact store by default — do not set `ZCCACHE_CACHE_DIR` per worktree, or
+  you defeat the sharing.
+- Auto-detection finds the worktree root via `.git` (file or directory), so
+  `git worktree`-linked checkouts and plain clones both work. Use
+  `ZCCACHE_WORKTREE_ROOT="$PWD"` only when detection is unreliable (non-Git
+  checkouts or unusual layouts).
+- Same-content guarantee. Cross-worktree hits validate content hashes for
+  every input. If two worktrees have diverged on a file, the second compile
+  misses and recompiles — the cache cannot be poisoned across siblings (the
+  invariant fixed in #197).
+- Measured win. The
+  [`perf_cpp_sibling_remap_warm` / `perf_rustc_sibling_remap_warm`](crates/zccache-daemon/tests/perf_bench_test.rs)
+  benchmarks (introduced in #238) confirm warm-state hits across sibling
+  worktrees run an order of magnitude faster than bare compiles and sccache
+  even though sccache cannot share across sibling roots at all.
+
 ### Strict path validation
 
 Use `--strict-paths` or `ZCCACHE_STRICT_PATHS` to fail fast when compiler path

--- a/README.md
+++ b/README.md
@@ -422,10 +422,25 @@ A few things worth knowing:
 - One daemon, one cache. All worktrees share the same zccache daemon and
   artifact store by default — do not set `ZCCACHE_CACHE_DIR` per worktree, or
   you defeat the sharing.
-- Auto-detection finds the worktree root via `.git` (file or directory), so
-  `git worktree`-linked checkouts and plain clones both work. Use
-  `ZCCACHE_WORKTREE_ROOT="$PWD"` only when detection is unreliable (non-Git
-  checkouts or unusual layouts).
+- Auto-detection requires a Git checkout. The daemon walks ancestors of the
+  compile cwd looking for `.git` (file or directory), so plain `git clone`
+  and `git worktree add` checkouts both work, but raw source trees
+  (tarball extracts, archive payloads, custom build layouts with no `.git`)
+  do not. For those, set `ZCCACHE_WORKTREE_ROOT="$PWD"` (or any absolute
+  path) to the logical project root you want cache keys normalized against.
+  Without either a detected Git root or an explicit override,
+  `ZCCACHE_PATH_REMAP=auto` is a no-op and the session log reports
+  `git_root_unavailable`.
+- User-supplied remap flags take precedence. If your build already passes
+  `-ffile-prefix-map=<root>=...` (C/C++/Emscripten) or
+  `--remap-path-prefix=<root>=...` (Rust) where `<root>` is the auto-detected
+  worktree root, zccache uses your flag as-is and does not inject a
+  duplicate. The check is per-flag and per-path: only `-ffile-prefix-map` /
+  `--remap-path-prefix` matching the worktree root suppress auto-injection;
+  related flags like `-fdebug-prefix-map`, `-fmacro-prefix-map`,
+  `-fcoverage-prefix-map`, and `-fprofile-prefix-map` do not. If cwd differs
+  from the detected root and you have not supplied a matching
+  `-ffile-prefix-map=<cwd>=.`, zccache may still inject one for that path.
 - Same-content guarantee. Cross-worktree hits validate content hashes for
   every input. If two worktrees have diverged on a file, the second compile
   misses and recompiles — the cache cannot be poisoned across siblings (the

--- a/README.md
+++ b/README.md
@@ -366,9 +366,40 @@ worktree shares the same logical cache.
 
    ```bash
    export ZCCACHE_PATH_REMAP=auto
-   export RUSTC_WRAPPER=zccache              # Rust projects
-   # For C/C++, point your build to zccache (e.g. CMAKE_C_COMPILER_LAUNCHER=zccache).
    ```
+
+   Then wire zccache into the build the same way you would for a single
+   checkout. For Rust:
+
+   ```bash
+   export RUSTC_WRAPPER=zccache
+   ```
+
+   For C/C++, use the launcher pattern your build system already supports
+   (Make and Ninja pick `CC`/`CXX` up automatically):
+
+   ```bash
+   # Make / Ninja / plain shell
+   export CC="zccache clang"
+   export CXX="zccache clang++"
+   ```
+
+   ```cmake
+   # CMake — set once, applies to every target
+   set(CMAKE_C_COMPILER_LAUNCHER zccache)
+   set(CMAKE_CXX_COMPILER_LAUNCHER zccache)
+   ```
+
+   For Emscripten, swap in `emcc` / `em++`:
+
+   ```bash
+   export CC="zccache emcc"
+   export CXX="zccache em++"
+   ```
+
+   The `ZCCACHE_PATH_REMAP=auto` export is what unlocks cross-worktree
+   sharing for whichever language the agent compiles; the wrapper choice is
+   just the normal single-checkout setup.
 
 3. Launch sub-agents in their own worktrees in parallel. The first agent to
    compile a unit populates the cache; the others get worktree-equivalent


### PR DESCRIPTION
## Summary

Adds a copy-pasteable recipe to the Worktree cache sharing section of the
README that walks through the multi-sub-agent workflow that motivated the
worktree-aware fast path:

- One sub-agent per `git worktree`, all checked out from the same repo
- Single `ZCCACHE_PATH_REMAP=auto` export at the orchestrator level
- No per-worktree configuration
- Verification via `zccache status` + the existing gate-reason list

Also calls out the three things that are easy to get wrong:

- Don't set `ZCCACHE_CACHE_DIR` per worktree (defeats sharing)
- Auto-detection works via `.git`; `ZCCACHE_WORKTREE_ROOT` is the override
- Cross-worktree hits validate content hashes — cache cannot be poisoned
  across siblings (#197 invariant)

Links the measured-win claim to the sibling-workspace benchmarks added in
#238 so readers can see the numbers.

## Background

This stitches together what already exists in the codebase for users who
arrive at the README asking "how do I make my multi-agent setup share
cache?" — the underlying feature already shipped via #215 (worktree-aware
fast path), #227 (C/C++ prefix-map), #229 (Rust remap-path-prefix), and
#226 (worktree-aware cache sharing). The README already documents the
flags; this PR adds the workflow recipe.

## Test plan

- [x] README renders cleanly (62 insertions; pure prose + code blocks)
- [x] Cross-references to issues/PRs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)