### PR TITLE
feat(bench): Emscripten benchmarks + ZCCACHE_PATH_REMAP=auto coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ zccache --version
 
 [![Latest zccache C++ benchmark stats](https://raw.githubusercontent.com/zackees/zccache/benchmark-stats/benchmark-cpp.jpg)](https://github.com/zackees/zccache/tree/benchmark-stats)
 
+[![Latest zccache Emscripten benchmark stats](https://raw.githubusercontent.com/zackees/zccache/benchmark-stats/benchmark-emscripten.jpg)](https://github.com/zackees/zccache/tree/benchmark-stats)
+
 [![Latest zccache Rust benchmark stats](https://raw.githubusercontent.com/zackees/zccache/benchmark-stats/benchmark-rust.jpg)](https://github.com/zackees/zccache/tree/benchmark-stats)
 
 The benchmark images are generated from the latest scheduled run and replace

--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -30,11 +30,17 @@ DEFAULT_OUTPUT_DIR = REPO_ROOT / "benchmark-stats"
 DEFAULT_PAGES_URL = "https://zackees.github.io/zccache/"
 DEFAULT_RAW_IMAGE_BASE_URL = "https://raw.githubusercontent.com/zackees/zccache/benchmark-stats"
 BENCHMARK_STATS_BRANCH_URL = "https://github.com/zackees/zccache/tree/benchmark-stats"
-LANGUAGES = ("c", "c++", "rust")
-LANGUAGE_LABELS = {"c": "C", "c++": "C++", "rust": "Rust"}
+LANGUAGES = ("c", "c++", "emscripten", "rust")
+LANGUAGE_LABELS = {
+    "c": "C",
+    "c++": "C++",
+    "emscripten": "Emscripten",
+    "rust": "Rust",
+}
 LANGUAGE_IMAGE_FILES = {
     "c": "benchmark-c.jpg",
     "c++": "benchmark-cpp.jpg",
+    "emscripten": "benchmark-emscripten.jpg",
     "rust": "benchmark-rust.jpg",
 }
 RATIO_COLORS = {
@@ -58,6 +64,10 @@ BENCHMARK_TESTS_BY_LANGUAGE = {
         "perf_warm_cache_zccache_vs_sccache",
         "perf_response_file",
         "perf_cpp_sibling_remap_warm",
+    ),
+    "emscripten": (
+        "perf_emcc_warm_cache_zccache_vs_sccache",
+        "perf_emcc_sibling_remap_warm",
     ),
     "rust": (
         "perf_rustc_zccache_vs_sccache",
@@ -97,6 +107,18 @@ TABLES = {
         "label": "C++ sibling git remap",
         "language": "c++",
         "bare_label": "Bare clang",
+    },
+    "## Emscripten Benchmark:": {
+        "id": "emscripten",
+        "label": "Emscripten em++",
+        "language": "emscripten",
+        "bare_label": "Bare em++",
+    },
+    "## Emscripten Sibling-Workspace Remap Benchmark:": {
+        "id": "emscripten-sibling-remap",
+        "label": "Emscripten sibling git remap",
+        "language": "emscripten",
+        "bare_label": "Bare em++",
     },
     "## Rust Benchmark:": {
         "id": "rust",

--- a/ci/perf_guard.py
+++ b/ci/perf_guard.py
@@ -26,6 +26,8 @@ DEFAULT_SCCACHE_THRESHOLD = DEFAULT_WARM_SCCACHE_THRESHOLD
 DEFAULT_THRESHOLD = DEFAULT_WARM_BARE_THRESHOLD
 DEFAULT_ATTEMPTS = 3
 REQUIRED_LANGUAGES = ("c", "c++", "rust")
+OPTIONAL_LANGUAGES = ("emscripten",)
+KNOWN_LANGUAGES = REQUIRED_LANGUAGES + OPTIONAL_LANGUAGES
 REQUIRED_MODES = ("cold", "warm")
 
 
@@ -566,7 +568,7 @@ def main() -> int:
     )
     parser.add_argument(
         "--language",
-        choices=REQUIRED_LANGUAGES,
+        choices=KNOWN_LANGUAGES,
         help="Run and require only one benchmark language.",
     )
     args = parser.parse_args()

--- a/ci/tests/test_benchmark_stats.py
+++ b/ci/tests/test_benchmark_stats.py
@@ -45,6 +45,19 @@ SAMPLE_LOG = """
 | Scenario | Bare rustc | sccache | zccache | vs sccache | vs bare rustc |
 |:---------|----------:|--------:|--------:|-----------:|--------------:|
 | Sibling-workspace, Warm | 7.142s | 8.301s | **0.127s** | **65x faster** | **56x faster** |
+
+## Emscripten Benchmark: 50 .cpp files, 5 warm trials
+
+| Scenario | Bare em++ | sccache | zccache | vs sccache | vs bare em++ |
+|:---------|---------:|--------:|--------:|-----------:|-------------:|
+| Single-file, Cold | 14.301s | 21.118s | 15.420s | 1.4x faster | 1.1x slower |
+| Single-file, Warm | 13.802s | 1.703s | **0.061s** | **28x faster** | **226x faster** |
+
+## Emscripten Sibling-Workspace Remap Benchmark: 50 .cpp files, 5 warm trials
+
+| Scenario | Bare em++ | sccache | zccache | vs sccache | vs bare em++ |
+|:---------|---------:|--------:|--------:|-----------:|-------------:|
+| Sibling-workspace, Warm | 13.654s | 1.712s | **0.063s** | **27x faster** | **217x faster** |
 """
 
 
@@ -74,12 +87,14 @@ def sample_payload():
 def test_parse_benchmark_log_extracts_all_tables():
     rows = benchmark_stats.parse_benchmark_log(SAMPLE_LOG)
 
-    assert len(rows) == 10
+    assert len(rows) == 13
     assert {row["benchmark"] for row in rows} == {
         "c-inline",
         "cpp-inline",
         "cpp-response-file",
         "cpp-sibling-remap",
+        "emscripten",
+        "emscripten-sibling-remap",
         "rust",
         "rust-sibling-remap",
     }
@@ -103,19 +118,32 @@ def test_parse_benchmark_log_extracts_all_tables():
     assert rust_remap["language"] == "rust"
     assert rust_remap["zccache_seconds"] == 0.127
 
+    em_warm = [row for row in rows if row["benchmark"] == "emscripten" and row["mode"] == "warm"][
+        0
+    ]
+    assert em_warm["language"] == "emscripten"
+    assert em_warm["bare_label"] == "Bare em++"
+    assert em_warm["zccache_seconds"] == 0.061
+
+    em_remap = [row for row in rows if row["benchmark"] == "emscripten-sibling-remap"][0]
+    assert em_remap["mode"] == "warm"
+    assert em_remap["language"] == "emscripten"
+    assert em_remap["zccache_seconds"] == 0.063
+
 
 def test_group_results_by_language_returns_expected_buckets():
     rows = benchmark_stats.parse_benchmark_log(SAMPLE_LOG)
 
     groups = benchmark_stats.group_results_by_language(rows)
 
-    assert list(groups) == ["c", "c++", "rust"]
+    assert list(groups) == ["c", "c++", "emscripten", "rust"]
     assert {benchmark_stats.LANGUAGE_LABELS[language] for language in groups} == {
         "C",
         "C++",
+        "Emscripten",
         "Rust",
     }
-    assert [len(groups[language]) for language in groups] == [2, 5, 3]
+    assert [len(groups[language]) for language in groups] == [2, 5, 3, 3]
 
 
 def test_render_html_links_json_stats_and_language_images_only():
@@ -134,7 +162,12 @@ def test_image_rows_cover_c_cpp_and_rust_stats():
     rows = benchmark_stats.parse_benchmark_log(SAMPLE_LOG)
     image_rows = benchmark_stats.build_image_rows(rows)
 
-    assert {row["language"] for row in image_rows} == {"C", "C++", "Rust"}
+    assert {row["language"] for row in image_rows} == {
+        "C",
+        "C++",
+        "Emscripten",
+        "Rust",
+    }
     assert any("C inline args - Single-file, Warm" == row["scenario"] for row in image_rows)
     assert any(
         row["compact_label"] == "inline args"

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -315,6 +315,11 @@ def test_benchmark_language_commands_are_filtered():
         "perf_response_file",
         "perf_cpp_sibling_remap_warm",
     ]
+    em_commands = benchmark_stats.benchmark_commands_for_language("emscripten")
+    assert [command[-4] for command in em_commands] == [
+        "perf_emcc_warm_cache_zccache_vs_sccache",
+        "perf_emcc_sibling_remap_warm",
+    ]
     assert [command[-4] for command in rust_commands] == [
         "perf_rustc_zccache_vs_sccache",
         "perf_rustc_sibling_remap_warm",

--- a/crates/zccache-daemon/tests/perf_bench_test.rs
+++ b/crates/zccache-daemon/tests/perf_bench_test.rs
@@ -53,6 +53,31 @@ fn find_sccache() -> Option<NormalizedPath> {
     None
 }
 
+fn find_empp() -> Option<NormalizedPath> {
+    if let Some(p) = zccache_test_support::find_on_path("em++") {
+        return Some(p);
+    }
+    let extra: &[&str] = if cfg!(windows) {
+        &[
+            "C:/emsdk/upstream/emscripten",
+            "C:/Program Files/emsdk/upstream/emscripten",
+        ]
+    } else {
+        &[
+            "/usr/local/emsdk/upstream/emscripten",
+            "/opt/emsdk/upstream/emscripten",
+        ]
+    };
+    let suffix = if cfg!(windows) { ".bat" } else { "" };
+    for dir in extra {
+        let candidate = NormalizedPath::new(format!("{dir}/em++{suffix}"));
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
 /// Number of synthetic `-D` defines in the large response file.
 const RSP_NUM_DEFINES: usize = 200;
 /// Number of synthetic `-I` include paths in the large response file.
@@ -2578,4 +2603,409 @@ async fn run_zccache_rustc_batch_with_env(
         }
     }
     start.elapsed()
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Emscripten (emcc/em++) benchmarks.
+//
+// emcc/em++ are detected by zccache as Clang-family, so the C++ compile flow
+// applies as-is. These benchmarks exercise the Emscripten suite end-to-end
+// (single-file + multi-file warm-cache compile) and verify path-remap auto
+// works across sibling git worktrees.
+// ═════════════════════════════════════════════════════════════════════════════
+
+/// Emscripten warm-cache benchmark: bare em++ vs sccache vs zccache.
+/// Mirrors `perf_warm_cache_zccache_vs_sccache` (C++) but uses em++.
+#[tokio::test]
+#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_emcc_warm_cache_zccache_vs_sccache --nocapture --ignored
+async fn perf_emcc_warm_cache_zccache_vs_sccache() {
+    let compiler_path = match find_empp() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: em++ not found (install emsdk and source emsdk_env)");
+            return;
+        }
+    };
+    let compiler = compiler_path.to_string_lossy().to_string();
+    let sources = source_names();
+
+    eprintln!();
+    eprintln!("================================================================");
+    eprintln!("  EMSCRIPTEN COMPILATION BENCHMARK");
+    eprintln!("  {NUM_FILES} .cpp files | {WARM_TRIALS} warm trials");
+    eprintln!("  Compiler: {compiler}");
+    eprintln!("================================================================");
+    eprintln!();
+
+    // ── Bare em++ ────────────────────────────────────────────────────
+    let bl_dir = zccache_test_support::temp_cache_dir().unwrap();
+    generate_project(bl_dir.path());
+
+    eprintln!("  [1/3] Bare em++ (baseline)");
+    nuke_and_regenerate(bl_dir.path());
+    warmup_compiler(&compiler, bl_dir.path());
+    let bl_cold_single = baseline_single(&compiler, bl_dir.path(), &sources);
+    eprintln!("        single cold:  {}", fmt_dur(bl_cold_single));
+    let bl_warm_single = baseline_single(&compiler, bl_dir.path(), &sources);
+    eprintln!("        single warm:  {}", fmt_dur(bl_warm_single));
+
+    nuke_and_regenerate(bl_dir.path());
+    warmup_compiler(&compiler, bl_dir.path());
+    let bl_cold_multi = baseline_multi(&compiler, bl_dir.path(), &sources);
+    eprintln!("        multi cold:   {}", fmt_dur(bl_cold_multi));
+    let bl_warm_multi = baseline_multi(&compiler, bl_dir.path(), &sources);
+    eprintln!("        multi warm:   {}", fmt_dur(bl_warm_multi));
+    eprintln!();
+    drop(bl_dir);
+
+    // ── sccache em++ ──────────────────────────────────────────────────
+    let sccache_cold_single;
+    let sccache_warm_single;
+    let sccache_cold_multi;
+    let sccache_warm_multi;
+    if let Some(sccache_bin) = find_sccache() {
+        let sc_dir = zccache_test_support::temp_cache_dir().unwrap();
+        generate_project(sc_dir.path());
+
+        let sc_cache_dir = zccache_test_support::temp_cache_dir().unwrap();
+        let sc_cache_str = sc_cache_dir.path().to_string_lossy().into_owned();
+        std::env::set_var("SCCACHE_DIR", &sc_cache_str);
+
+        eprintln!("  [2/3] sccache em++ ({})", sccache_bin.display());
+
+        let stop_purge_start = |sccache: &Path, cache_dir: &str| {
+            let _ = std::process::Command::new(sccache)
+                .arg("--stop-server")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status();
+            if Path::new(cache_dir).exists() {
+                let _ = std::fs::remove_dir_all(cache_dir);
+                let _ = std::fs::create_dir_all(cache_dir);
+            }
+            let _ = std::process::Command::new(sccache)
+                .arg("--start-server")
+                .env("SCCACHE_DIR", cache_dir)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status();
+        };
+
+        stop_purge_start(&sccache_bin, &sc_cache_str);
+        nuke_and_regenerate(sc_dir.path());
+        warmup_compiler(&compiler, sc_dir.path());
+        let cold = sccache_compile_single(&sccache_bin, &compiler, sc_dir.path(), &sources);
+        eprintln!("        single cold:  {}", fmt_dur(cold));
+        sccache_cold_single = Some(cold);
+        let mut warm = Vec::with_capacity(WARM_TRIALS);
+        for _ in 0..WARM_TRIALS {
+            warm.push(sccache_compile_single(
+                &sccache_bin,
+                &compiler,
+                sc_dir.path(),
+                &sources,
+            ));
+        }
+        print_trials("single warm:", &warm);
+        sccache_warm_single = Some(warm);
+
+        stop_purge_start(&sccache_bin, &sc_cache_str);
+        nuke_and_regenerate(sc_dir.path());
+        warmup_compiler(&compiler, sc_dir.path());
+        let cold = sccache_compile_multi(&sccache_bin, &compiler, sc_dir.path(), &sources);
+        eprintln!("        multi cold:   {}", fmt_dur(cold));
+        sccache_cold_multi = Some(cold);
+        let mut warm = Vec::with_capacity(WARM_TRIALS);
+        for _ in 0..WARM_TRIALS {
+            warm.push(sccache_compile_multi(
+                &sccache_bin,
+                &compiler,
+                sc_dir.path(),
+                &sources,
+            ));
+        }
+        print_trials("multi warm:", &warm);
+        sccache_warm_multi = Some(warm);
+
+        let _ = std::process::Command::new(&sccache_bin)
+            .arg("--stop-server")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        std::env::remove_var("SCCACHE_DIR");
+        eprintln!();
+    } else {
+        eprintln!("  [2/3] sccache: not found, skipping\n");
+        sccache_cold_single = None;
+        sccache_warm_single = None;
+        sccache_cold_multi = None;
+        sccache_warm_multi = None;
+    }
+
+    // ── zccache em++ ──────────────────────────────────────────────────
+    let zc_dir = zccache_test_support::temp_cache_dir().unwrap();
+    generate_project(zc_dir.path());
+    let zc_cwd = zc_dir.path().to_string_lossy().into_owned();
+
+    eprintln!("  [3/3] zccache em++");
+    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let mut client = zccache_ipc::connect(&endpoint).await.unwrap();
+    let session_id = start_zccache_session(&mut client, &zc_cwd).await;
+
+    nuke_and_regenerate(zc_dir.path());
+    warmup_compiler(&compiler, zc_dir.path());
+    let zc_cold_single =
+        zccache_compile_single(&mut client, &session_id, &compiler, &zc_cwd, &sources).await;
+    eprintln!("        single cold:  {}", fmt_dur(zc_cold_single));
+    let mut zc_warm_single = Vec::with_capacity(WARM_TRIALS);
+    for _ in 0..WARM_TRIALS {
+        zc_warm_single.push(
+            zccache_compile_single(&mut client, &session_id, &compiler, &zc_cwd, &sources).await,
+        );
+    }
+    print_trials("single warm:", &zc_warm_single);
+
+    nuke_and_regenerate(zc_dir.path());
+    warmup_compiler(&compiler, zc_dir.path());
+    let zc_cold_multi =
+        zccache_compile_multi(&mut client, &session_id, &compiler, &zc_cwd, &sources).await;
+    eprintln!("        multi cold:   {}", fmt_dur(zc_cold_multi));
+    let mut zc_warm_multi = Vec::with_capacity(WARM_TRIALS);
+    for _ in 0..WARM_TRIALS {
+        zc_warm_multi.push(
+            zccache_compile_multi(&mut client, &session_id, &compiler, &zc_cwd, &sources).await,
+        );
+    }
+    print_trials("multi warm:", &zc_warm_multi);
+
+    end_zccache_session(&mut client, session_id).await;
+    shutdown.notify_one();
+    server_handle.await.unwrap();
+
+    // ── Report ────────────────────────────────────────────────────────
+    let dash = "\u{2014}";
+    let zc_single_med = median(&zc_warm_single);
+    let zc_multi_med = median(&zc_warm_multi);
+    let sc_warm_single_str = sccache_warm_single.as_ref().map(|t| fmt_dur(median(t)));
+    let sc_warm_multi_str = sccache_warm_multi.as_ref().map(|t| fmt_dur(median(t)));
+    let sc_cold_single_str = sccache_cold_single.map(fmt_dur);
+    let sc_cold_multi_str = sccache_cold_multi.map(fmt_dur);
+    let vs_sccache_cold_single = sccache_cold_single.map(|d| fmt_ratio(d, zc_cold_single, false));
+    let vs_sccache_cold_multi = sccache_cold_multi.map(|d| fmt_ratio(d, zc_cold_multi, false));
+    let vs_sccache_warm_single = sccache_warm_single
+        .as_ref()
+        .map(|t| fmt_ratio(median(t), zc_single_med, true));
+    let vs_sccache_warm_multi = sccache_warm_multi
+        .as_ref()
+        .map(|t| fmt_ratio(median(t), zc_multi_med, true));
+
+    eprintln!();
+    eprintln!("## Emscripten Benchmark: {NUM_FILES} .cpp files, {WARM_TRIALS} warm trials");
+    eprintln!();
+    eprintln!("| Scenario | Bare em++ | sccache | zccache | vs sccache | vs bare em++ |");
+    eprintln!("|:---------|---------:|--------:|--------:|-----------:|-------------:|");
+    eprintln!(
+        "| Single-file, Cold | {} | {} | {} | {} | {} |",
+        fmt_dur(bl_cold_single),
+        sc_cold_single_str.as_deref().unwrap_or(dash),
+        fmt_dur(zc_cold_single),
+        vs_sccache_cold_single.as_deref().unwrap_or(dash),
+        fmt_ratio(bl_cold_single, zc_cold_single, false),
+    );
+    eprintln!(
+        "| Single-file, Warm | {} | {} | **{}** | {} | {} |",
+        fmt_dur(bl_warm_single),
+        sc_warm_single_str.as_deref().unwrap_or(dash),
+        fmt_dur(zc_single_med),
+        vs_sccache_warm_single.as_deref().unwrap_or(dash),
+        fmt_ratio(bl_warm_single, zc_single_med, true),
+    );
+    eprintln!(
+        "| Multi-file, Cold | {} | {} | {} | {} | {} |",
+        fmt_dur(bl_cold_multi),
+        sc_cold_multi_str.as_deref().unwrap_or(dash),
+        fmt_dur(zc_cold_multi),
+        vs_sccache_cold_multi.as_deref().unwrap_or(dash),
+        fmt_ratio(bl_cold_multi, zc_cold_multi, false),
+    );
+    eprintln!(
+        "| Multi-file, Warm | {} | {} | **{}** | {} | {} |",
+        fmt_dur(bl_warm_multi),
+        sc_warm_multi_str.as_deref().unwrap_or(dash),
+        fmt_dur(zc_multi_med),
+        vs_sccache_warm_multi.as_deref().unwrap_or(dash),
+        fmt_ratio(bl_warm_multi, zc_multi_med, true),
+    );
+    eprintln!();
+    eprintln!("> **Cold** = first compile (empty cache). **Warm** = median of {WARM_TRIALS} subsequent runs.");
+    eprintln!();
+}
+
+/// Emscripten sibling-workspace remap benchmark. Warm-only. Verifies
+/// `ZCCACHE_PATH_REMAP=auto` injects `-ffile-prefix-map` for em++ (Clang-family)
+/// so equivalent compiles share cache across sibling git roots.
+#[tokio::test]
+#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_emcc_sibling_remap_warm --nocapture --ignored
+async fn perf_emcc_sibling_remap_warm() {
+    let compiler_path = match find_empp() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: em++ not found (install emsdk and source emsdk_env)");
+            return;
+        }
+    };
+    let compiler = compiler_path.to_string_lossy().to_string();
+    let sources = source_names();
+
+    eprintln!();
+    eprintln!("================================================================");
+    eprintln!("  EMSCRIPTEN SIBLING-WORKSPACE REMAP BENCHMARK (warm-only)");
+    eprintln!("  {NUM_FILES} .cpp files | {WARM_TRIALS} warm trials | ZCCACHE_PATH_REMAP=auto");
+    eprintln!("  Compiler: {compiler}");
+    eprintln!("================================================================");
+    eprintln!();
+
+    let parent = zccache_test_support::temp_cache_dir().unwrap();
+    let workspace_a = parent.path().join("workspace-a");
+    let workspace_b = parent.path().join("workspace-b");
+    std::fs::create_dir_all(&workspace_a).unwrap();
+    std::fs::create_dir_all(&workspace_b).unwrap();
+    make_git_workspace(&workspace_a);
+    make_git_workspace(&workspace_b);
+    generate_project(&workspace_a);
+    generate_project(&workspace_b);
+
+    // ── Bare em++ warm in workspace B ─────────────────────────────────
+    eprintln!("  [1/3] Bare em++ (workspace B, warm)");
+    warmup_compiler(&compiler, &workspace_b);
+    let _ = baseline_single(&compiler, &workspace_b, &sources);
+    let mut bl_warm = Vec::with_capacity(WARM_TRIALS);
+    for _ in 0..WARM_TRIALS {
+        bl_warm.push(baseline_single(&compiler, &workspace_b, &sources));
+    }
+    print_trials("warm:", &bl_warm);
+    eprintln!();
+
+    // ── sccache em++ warm in workspace B ──────────────────────────────
+    let sccache_warm = if let Some(sccache_bin) = find_sccache() {
+        let sc_cache_dir = zccache_test_support::temp_cache_dir().unwrap();
+        let sc_cache_str = sc_cache_dir.path().to_string_lossy().into_owned();
+        std::env::set_var("SCCACHE_DIR", &sc_cache_str);
+        eprintln!("  [2/3] sccache em++ (workspace B, warm)");
+        let _ = std::process::Command::new(&sccache_bin)
+            .arg("--stop-server")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        let _ = std::process::Command::new(&sccache_bin)
+            .arg("--start-server")
+            .env("SCCACHE_DIR", &sc_cache_str)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        warmup_compiler(&compiler, &workspace_b);
+        let _ = sccache_compile_single(&sccache_bin, &compiler, &workspace_b, &sources);
+        let mut warm = Vec::with_capacity(WARM_TRIALS);
+        for _ in 0..WARM_TRIALS {
+            warm.push(sccache_compile_single(
+                &sccache_bin,
+                &compiler,
+                &workspace_b,
+                &sources,
+            ));
+        }
+        print_trials("warm:", &warm);
+        let _ = std::process::Command::new(&sccache_bin)
+            .arg("--stop-server")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        std::env::remove_var("SCCACHE_DIR");
+        eprintln!();
+        Some(warm)
+    } else {
+        eprintln!("  [2/3] sccache: not found, skipping\n");
+        None
+    };
+
+    // ── zccache primed from workspace A, warm in workspace B ──────────
+    eprintln!("  [3/3] zccache em++ (prime: workspace A, warm: workspace B, remap=auto)");
+    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let mut client = zccache_ipc::connect(&endpoint).await.unwrap();
+
+    let workspace_a_str = workspace_a.to_string_lossy().into_owned();
+    let workspace_b_str = workspace_b.to_string_lossy().into_owned();
+    let session_a = start_zccache_session(&mut client, &workspace_a_str).await;
+    warmup_compiler(&compiler, &workspace_a);
+    let _ = zccache_compile_cpp_single_with_env(
+        &mut client,
+        &session_a,
+        &compiler,
+        &workspace_a_str,
+        &sources,
+        path_remap_auto_env(),
+    )
+    .await;
+    end_zccache_session(&mut client, session_a).await;
+
+    let session_b = start_zccache_session(&mut client, &workspace_b_str).await;
+    let _ = zccache_compile_cpp_single_with_env(
+        &mut client,
+        &session_b,
+        &compiler,
+        &workspace_b_str,
+        &sources,
+        path_remap_auto_env(),
+    )
+    .await;
+    let mut zc_warm = Vec::with_capacity(WARM_TRIALS);
+    for _ in 0..WARM_TRIALS {
+        zc_warm.push(
+            zccache_compile_cpp_single_with_env(
+                &mut client,
+                &session_b,
+                &compiler,
+                &workspace_b_str,
+                &sources,
+                path_remap_auto_env(),
+            )
+            .await,
+        );
+    }
+    print_trials("warm:", &zc_warm);
+
+    end_zccache_session(&mut client, session_b).await;
+    shutdown.notify_one();
+    server_handle.await.unwrap();
+
+    // ── Report ────────────────────────────────────────────────────────
+    let dash = "\u{2014}";
+    let bl_warm_med = median(&bl_warm);
+    let zc_warm_med = median(&zc_warm);
+    let sccache_warm_str = sccache_warm.as_ref().map(|t| fmt_dur(median(t)));
+    let vs_sccache = sccache_warm
+        .as_ref()
+        .map(|t| fmt_ratio(median(t), zc_warm_med, true));
+    let vs_bare = fmt_ratio(bl_warm_med, zc_warm_med, true);
+
+    eprintln!();
+    eprintln!(
+        "## Emscripten Sibling-Workspace Remap Benchmark: {NUM_FILES} .cpp files, {WARM_TRIALS} warm trials"
+    );
+    eprintln!();
+    eprintln!("| Scenario | Bare em++ | sccache | zccache | vs sccache | vs bare em++ |");
+    eprintln!("|:---------|---------:|--------:|--------:|-----------:|-------------:|");
+    eprintln!(
+        "| Sibling-workspace, Warm | {} | {} | **{}** | {} | {} |",
+        fmt_dur(bl_warm_med),
+        sccache_warm_str.as_deref().unwrap_or(dash),
+        fmt_dur(zc_warm_med),
+        vs_sccache.as_deref().unwrap_or(dash),
+        vs_bare,
+    );
+    eprintln!();
+    eprintln!(
+        "> Sibling-workspace = two adjacent git roots; zccache primed from workspace A, warm trials measured in workspace B with `ZCCACHE_PATH_REMAP=auto`. Bare/sccache run their normal same-workspace warm trials in workspace B."
+    );
+    eprintln!();
 }


### PR DESCRIPTION
## Summary

emcc/em++ are detected by zccache as Clang-family compilers, so the C/C++
compile flow — including the \`-ffile-prefix-map=<root>=.\` auto-injection
that backs \`ZCCACHE_PATH_REMAP=auto\` — already applies as-is. This PR adds
benchmarks that prove it and exercise the Emscripten suite end-to-end.

- \`perf_emcc_warm_cache_zccache_vs_sccache\` — single-file + multi-file
  cold/warm, bare em++ vs sccache vs zccache. Emits
  \`## Emscripten Benchmark:\` table.
- \`perf_emcc_sibling_remap_warm\` — two sibling git roots; zccache primed
  from workspace A, warm trials measured in workspace B with
  \`ZCCACHE_PATH_REMAP=auto\`. Emits \`## Emscripten Sibling-Workspace Remap
  Benchmark:\` table.

Both tests skip cleanly when \`em++\` is not on PATH.

CI wiring:

- \`ci/benchmark_stats.py\`: register \`emscripten\` language and
  \`benchmark-emscripten.jpg\` image; two new TABLES entries; two new
  \`BENCHMARK_TESTS_BY_LANGUAGE\` entries.
- \`ci/perf_guard.py\`: split \`REQUIRED_LANGUAGES\` (C/C++/Rust) from
  \`OPTIONAL_LANGUAGES\` (Emscripten) so the guard stays green on CI hosts
  without emsdk; \`--language emscripten\` is selectable when emsdk is
  present.
- \`ci/tests\`: SAMPLE_LOG fixture extended; parse/group/image-row asserts
  updated; perf-guard command-list test updated.
- README Performance section: Emscripten benchmark badge added so the
  readme-image test passes.

## Verification

- [x] \`soldr cargo check -p zccache-daemon --tests\`
- [x] \`soldr cargo clippy -p zccache-daemon --tests -- -D warnings\`
- [x] \`soldr cargo fmt --all\`
- [x] \`PYTHONPATH=. uv run pytest ci/tests -q\` (37 passed, 1 skipped)
- [x] \`soldr --no-cache cargo test -p zccache-daemon --test perf_bench_test -- perf_emcc --nocapture --ignored\` (skipped cleanly: em++ not on local PATH)
- [ ] Measured numbers on a host with emsdk (CI will fill this in once it
      picks up the new language).

## Background — does path-remap-auto actually work for Emscripten?

Code trace:

- \`crates/zccache-compiler/src/lib.rs\` — \`detect_family(\"emcc\")\` and
  \`detect_family(\"em++\")\` both return \`CompilerFamily::Clang\`.
- \`crates/zccache-daemon/src/server.rs::compiler_supports_ffile_prefix_map\`
  — returns true for \`Clang | Gcc\`.
- \`crates/zccache-daemon/src/server.rs::effective_compile_args\` — when
  \`ZCCACHE_PATH_REMAP=auto\` is set and a Git root is detected, injects
  \`-ffile-prefix-map=<root>=.\` for any Clang-family compiler.

So Emscripten gets the same treatment as native clang++ — these
benchmarks are coverage on existing behavior, not new wiring.

## Follow-ups

- #240 — clarify \`-ffile-prefix-map\` precedence rules (per-flag, per-path).
- #241 — add link/archive perf benchmarks for C/C++/Emscripten/Rust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)