### PR TITLE
feat(bench, perf-guard): report per-call latency and absolute times

### DIFF
--- a/ci/perf_guard.py
+++ b/ci/perf_guard.py
@@ -51,6 +51,8 @@ class ScenarioStatus:
     best_ratio: float | None = None
     best_attempt: int | None = None
     attempts_seen: int = 0
+    best_zccache_seconds: float | None = None
+    best_baseline_seconds: float | None = None
 
     @property
     def passed(self) -> bool:
@@ -182,15 +184,22 @@ def evaluate_attempts(
             bare_floor = cold_bare_threshold if mode == "cold" else bare_threshold
             sccache_floor = cold_sccache_threshold if mode == "cold" else sccache_threshold
             comparisons = (
-                ("bare", str(row["bare_label"]), row.get("zccache_vs_bare_ratio"), bare_floor),
+                (
+                    "bare",
+                    str(row["bare_label"]),
+                    row.get("zccache_vs_bare_ratio"),
+                    bare_floor,
+                    row.get("bare_seconds"),
+                ),
                 (
                     "sccache",
                     "sccache",
                     row.get("zccache_vs_sccache_ratio"),
                     sccache_floor,
+                    row.get("sccache_seconds"),
                 ),
             )
-            for baseline, baseline_label, ratio, ratio_threshold in comparisons:
+            for baseline, baseline_label, ratio, ratio_threshold, baseline_seconds in comparisons:
                 key = ScenarioKey(str(row["benchmark"]), str(row["scenario"]), baseline)
                 status = statuses.get(key)
                 if status is None:
@@ -211,6 +220,10 @@ def evaluate_attempts(
                     if status.best_ratio is None or ratio > status.best_ratio:
                         status.best_ratio = float(ratio)
                         status.best_attempt = attempt_index
+                        if isinstance(row.get("zccache_seconds"), int | float):
+                            status.best_zccache_seconds = float(row["zccache_seconds"])
+                        if isinstance(baseline_seconds, int | float):
+                            status.best_baseline_seconds = float(baseline_seconds)
 
     missing = [
         f"{language} {mode}"
@@ -237,6 +250,14 @@ def evaluate_attempts(
     )
 
 
+def _format_seconds(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    if value >= 1.0:
+        return f"{value:.3f}s"
+    return f"{value * 1000:.1f}ms"
+
+
 def format_report(
     report: GuardReport,
     bare_threshold: float,
@@ -252,17 +273,19 @@ def format_report(
         f"Cold bare threshold: bare compiler / zccache >= {cold_bare_threshold:.2f}x",
         f"Cold sccache threshold: pinned sccache / zccache >= {cold_sccache_threshold:.2f}x",
         "",
-        "| Status | Language | Benchmark | Scenario | Baseline | Best ratio | Threshold | Attempt | Seen |",
-        "|---|---|---|---|---|---:|---:|---:|---:|",
+        "| Status | Language | Benchmark | Scenario | Baseline | zccache | baseline | Ratio | Threshold | Attempt | Seen |",
+        "|---|---|---|---|---|---:|---:|---:|---:|---:|---:|",
     ]
     for status in report.statuses:
         state = "PASS" if status.passed else "FAIL"
         ratio = "n/a" if status.best_ratio is None else f"{status.best_ratio:.3f}x"
+        zc_time = _format_seconds(status.best_zccache_seconds)
+        bl_time = _format_seconds(status.best_baseline_seconds)
         attempt = "n/a" if status.best_attempt is None else str(status.best_attempt)
         lines.append(
             "| "
             f"{state} | {status.language} | {status.benchmark_label} | "
-            f"{status.scenario} | {status.baseline_label} | {ratio} | "
+            f"{status.scenario} | {status.baseline_label} | {zc_time} | {bl_time} | {ratio} | "
             f"{status.threshold:.2f}x | {attempt} | {status.attempts_seen} |"
         )
 
@@ -281,10 +304,12 @@ def format_report(
 
 def _format_status_check(status: ScenarioStatus) -> str:
     actual = "n/a" if status.best_ratio is None else f"{status.best_ratio:.3f}x"
+    zc_time = _format_seconds(status.best_zccache_seconds)
+    bl_time = _format_seconds(status.best_baseline_seconds)
     return (
         f"{status.language} {status.benchmark_label} / {status.scenario} "
         f"vs {status.baseline_label}: expected >= {status.threshold:.2f}x, "
-        f"actual {actual}"
+        f"actual {actual} (zccache {zc_time} vs baseline {bl_time})"
     )
 
 

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -161,7 +161,9 @@ def test_report_marks_failed_rows():
     report = perf_guard.evaluate_attempts([rows(FAILING_RUST_LOG)], threshold=1.5)
     markdown = perf_guard.format_report(report, 1.5, 1.5, 1.5, 1.5)
 
-    assert "| FAIL | rust | Rust rustc | Build, Cold | Bare rustc | 1.286x | 1.50x | 1 | 1 |" in markdown
+    assert (
+        "| FAIL | rust | Rust rustc | Build, Cold | Bare rustc | 7.000s | 9.000s | 1.286x | 1.50x | 1 | 1 |"
+    ) in markdown
     assert "### Benchmark summary" in markdown
     assert "#### Failed checks" in markdown
     assert "#### Passed checks" in markdown
@@ -178,11 +180,13 @@ def test_benchmark_summary_lists_passes_and_failures():
     assert "- Failed benchmark attempts: none" in summary
     assert (
         "- FAIL: c++ C++ inline args / Single-file, Cold vs sccache: "
-        "expected >= 1.50x, actual 1.250x (best attempt 1; seen 1)"
+        "expected >= 1.50x, actual 1.250x (zccache 4.000s vs baseline 5.000s) "
+        "(best attempt 1; seen 1)"
     ) in summary
     assert (
         "- PASS: c C inline args / Single-file, Warm vs Bare clang: "
-        "expected >= 1.50x, actual 3.000x (best attempt 1; seen 1)"
+        "expected >= 1.50x, actual 3.000x (zccache 1.000s vs baseline 3.000s) "
+        "(best attempt 1; seen 1)"
     ) in summary
 
 
@@ -197,7 +201,7 @@ def test_final_status_explains_pass_with_weakest_check():
     assert final_status == (
         "PERF GUARD OK: all checks meet configured floors; weakest check "
         "c C inline args / Single-file, Cold vs Bare clang: expected >= 0.85x, "
-        "actual 0.909x."
+        "actual 0.909x (zccache 3.300s vs baseline 3.000s)."
     )
 
 
@@ -208,7 +212,8 @@ def test_final_status_explains_worst_failed_floor():
 
     assert final_status == (
         "PERF GUARD FAILED: 1 check below floor; worst c++ C++ inline args / "
-        "Single-file, Cold vs sccache: expected >= 1.50x, actual 1.250x."
+        "Single-file, Cold vs sccache: expected >= 1.50x, actual 1.250x "
+        "(zccache 4.000s vs baseline 5.000s)."
     )
 
 

--- a/crates/zccache-daemon/tests/perf_bench_test.rs
+++ b/crates/zccache-daemon/tests/perf_bench_test.rs
@@ -736,15 +736,34 @@ fn fmt_dur(d: Duration) -> String {
 }
 
 fn print_trials(label: &str, times: &[Duration]) {
+    print_trials_per(label, times, None);
+}
+
+/// Like `print_trials` but also reports per-call latency when `files_per_trial`
+/// is known. Useful when a single trial sums N sequential cache lookups so the
+/// reader can see whether the per-call cost is in the expected ~1ms range or
+/// taking a slow path.
+fn print_trials_per(label: &str, times: &[Duration], files_per_trial: Option<usize>) {
     let med = median(times);
     let min = times.iter().min().unwrap();
     let max = times.iter().max().unwrap();
-    eprintln!(
-        "        {label:<14}{} ({} \u{2013} {})",
-        fmt_dur(med),
-        fmt_dur(*min),
-        fmt_dur(*max),
-    );
+    if let Some(n) = files_per_trial {
+        let per_call_ms = (med.as_secs_f64() / n as f64) * 1000.0;
+        eprintln!(
+            "        {label:<14}{} ({} \u{2013} {}) -> {:.2} ms/call \u{00d7} {n}",
+            fmt_dur(med),
+            fmt_dur(*min),
+            fmt_dur(*max),
+            per_call_ms,
+        );
+    } else {
+        eprintln!(
+            "        {label:<14}{} ({} \u{2013} {})",
+            fmt_dur(med),
+            fmt_dur(*min),
+            fmt_dur(*max),
+        );
+    }
 }
 
 fn fmt_ratio(baseline: Duration, test: Duration, bold: bool) -> String {
@@ -2262,7 +2281,7 @@ async fn perf_cpp_sibling_remap_warm() {
     for _ in 0..WARM_TRIALS {
         bl_warm.push(baseline_single(&compiler, &workspace_b, &sources));
     }
-    print_trials("warm:", &bl_warm);
+    print_trials_per("warm:", &bl_warm, Some(NUM_FILES));
     eprintln!();
 
     // ── sccache warm in workspace B ────────────────────────────────────
@@ -2293,7 +2312,7 @@ async fn perf_cpp_sibling_remap_warm() {
                 &sources,
             ));
         }
-        print_trials("warm:", &warm);
+        print_trials_per("warm:", &warm, Some(NUM_FILES));
         let _ = std::process::Command::new(&sccache_bin)
             .arg("--stop-server")
             .stdout(std::process::Stdio::null())
@@ -2355,7 +2374,7 @@ async fn perf_cpp_sibling_remap_warm() {
             .await,
         );
     }
-    print_trials("warm:", &zc_warm);
+    print_trials_per("warm:", &zc_warm, Some(NUM_FILES));
 
     end_zccache_session(&mut client, session_b).await;
     shutdown.notify_one();
@@ -2437,7 +2456,7 @@ async fn perf_rustc_sibling_remap_warm() {
     for _ in 0..RUSTC_WARM_TRIALS {
         bl_warm.push(run_rustc_batch(&rc, &workspace_b, &srcs, rustc_args_for));
     }
-    print_trials("warm:", &bl_warm);
+    print_trials_per("warm:", &bl_warm, Some(RUSTC_NUM_FILES));
     eprintln!();
 
     // ── sccache warm in workspace B ────────────────────────────────────
@@ -2469,7 +2488,7 @@ async fn perf_rustc_sibling_remap_warm() {
                 rustc_args_for,
             ));
         }
-        print_trials("warm:", &warm);
+        print_trials_per("warm:", &warm, Some(RUSTC_NUM_FILES));
         let _ = std::process::Command::new(&scc_bin)
             .arg("--stop-server")
             .stdout(std::process::Stdio::null())
@@ -2531,7 +2550,7 @@ async fn perf_rustc_sibling_remap_warm() {
             .await,
         );
     }
-    print_trials("warm:", &zc_warm);
+    print_trials_per("warm:", &zc_warm, Some(RUSTC_NUM_FILES));
 
     end_zccache_session(&mut cl, session_b).await;
     sd.notify_one();
@@ -2883,7 +2902,7 @@ async fn perf_emcc_sibling_remap_warm() {
     for _ in 0..WARM_TRIALS {
         bl_warm.push(baseline_single(&compiler, &workspace_b, &sources));
     }
-    print_trials("warm:", &bl_warm);
+    print_trials_per("warm:", &bl_warm, Some(NUM_FILES));
     eprintln!();
 
     // ── sccache em++ warm in workspace B ──────────────────────────────
@@ -2914,7 +2933,7 @@ async fn perf_emcc_sibling_remap_warm() {
                 &sources,
             ));
         }
-        print_trials("warm:", &warm);
+        print_trials_per("warm:", &warm, Some(NUM_FILES));
         let _ = std::process::Command::new(&sccache_bin)
             .arg("--stop-server")
             .stdout(std::process::Stdio::null())
@@ -2972,7 +2991,7 @@ async fn perf_emcc_sibling_remap_warm() {
             .await,
         );
     }
-    print_trials("warm:", &zc_warm);
+    print_trials_per("warm:", &zc_warm, Some(NUM_FILES));
 
     end_zccache_session(&mut client, session_b).await;
     shutdown.notify_one();


### PR DESCRIPTION
## Why

CI run 25846596734's C++ perf-guard surfaced:

\`\`\`
| FAIL | c++ | C++ sibling git remap | Sibling-workspace, Warm | sccache | 0.604x | 1.50x | 2 | 3 |
\`\`\`

That's only a ratio. From the underlying row the actual numbers were
\`zccache 0.633s\` and \`sccache 0.366s\` over 50 sequential single-file
compiles — i.e. **~13 ms per cache-hit call**, ~10x slower than the
~1 ms a warm zccache hit should take. The summary table hid that:
without the raw times, the failure looks like \"zccache is 1.7x slower
than sccache here\" instead of \"zccache's per-call cost on Linux is
broken and slower than even sccache's subprocess spawn overhead.\"

This PR doesn't fix the underlying perf bug — it makes the bug visible
in CI output so the next fix has data to work against. Follow-up issue
tracking the per-call regression will be filed separately.

## Changes

- **\`print_trials_per\`** in \`crates/zccache-daemon/tests/perf_bench_test.rs\` —
  new variant of \`print_trials\` that, given \`files_per_trial\`, appends
  \`-> N.NN ms/call x F\` to each warm/cold trial line. All 9 single-file
  sibling-remap callsites (C++, Rust, Emscripten) switched over. The
  existing per-trial median is unchanged; the per-call number is added.

- **\`perf_guard\` markdown table** gains \`zccache\` and \`baseline\` time
  columns alongside the existing \`Ratio\` / \`Threshold\` columns:

  | Status | Language | Benchmark | Scenario | Baseline | zccache | baseline | Ratio | Threshold | Attempt | Seen |
  |---|---|---|---|---|---:|---:|---:|---:|---:|---:|
  | FAIL | c++ | C++ sibling git remap | Sibling-workspace, Warm | sccache | 633.0ms | 366.0ms | 0.604x | 1.50x | 2 | 3 |

- **Final-status one-liner** appends raw times to the status check:

  > PERF GUARD FAILED: 1 check below floor; worst c++ C++ sibling git remap / Sibling-workspace, Warm vs sccache: expected >= 1.50x, actual 0.604x (zccache 633.0ms vs baseline 366.0ms).

- **\`ScenarioStatus\`** carries \`best_zccache_seconds\` and
  \`best_baseline_seconds\` alongside \`best_ratio\` / \`best_attempt\`,
  populated from the same row that produced the best ratio.

- **\`_format_seconds\`** helper: >=1s as \`N.NNNs\`, <1s as \`N.Nms\` —
  matches what the benchmark tables already emit.

## Verification

- [x] \`soldr cargo check -p zccache-daemon --tests\`
- [x] \`soldr cargo clippy -p zccache-daemon --tests -- -D warnings\`
- [x] \`soldr cargo fmt --all\`
- [x] \`PYTHONPATH=. uv run pytest ci/tests -q\` (37 passed, 1 skipped)
- [x] Local run on Windows:
      \`soldr --no-cache cargo test -p zccache-daemon --test perf_bench_test -- perf_cpp_sibling_remap_warm --nocapture --ignored\`

  \`\`\`
  [1/3] Bare clang (workspace B, warm)
        warm:         11.612s (11.498s - 11.672s) -> 232.24 ms/call x 50
  [2/3] sccache (workspace B, warm)
        warm:         1.560s (1.553s - 1.589s) -> 31.20 ms/call x 50
  [3/3] zccache (prime: workspace A, warm: workspace B, remap=auto)
        warm:         0.758s (0.731s - 0.773s) -> 15.17 ms/call x 50
  \`\`\`

  Windows zccache: ~15 ms/call (beats sccache). Linux CI zccache:
  ~13 ms/call (loses to sccache). Both far above the ~1 ms target — the
  follow-up issue will dig into why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)