### PR TITLE
feat(release): ship split debug symbols for downstream profiling

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -151,20 +151,77 @@ runs:
           fi
         fi
 
+        # Use --strip-debug to drop DWARF sections without removing the
+        # function-name symbol table that profilers read. With
+        # [profile.release] split-debuginfo = "packed" the binary already
+        # ships without embedded debug info on Linux/macOS, so this is mostly
+        # belt-and-suspenders. Fall back to plain `strip` when the
+        # cross-tool doesn't support the flag.
         STRIP="${{ inputs.strip }}"
         if [ -z "$STRIP" ]; then
           STRIP="strip"
         fi
+        do_strip() {
+          if "$STRIP" --strip-debug "$1" 2>/dev/null; then
+            return 0
+          fi
+          "$STRIP" "$1" 2>/dev/null || true
+        }
         if command -v "$STRIP" &> /dev/null; then
-          $STRIP staging/zccache${{ inputs.binary_ext }} || true
-          $STRIP staging/zccache-daemon${{ inputs.binary_ext }} || true
-          $STRIP staging/zccache-fp${{ inputs.binary_ext }} || true
+          do_strip staging/zccache${{ inputs.binary_ext }}
+          do_strip staging/zccache-daemon${{ inputs.binary_ext }}
+          do_strip staging/zccache-fp${{ inputs.binary_ext }}
           if [ "${{ inputs.include_python }}" = "true" ]; then
-            $STRIP staging/python/zccache/_native.* || true
-            $STRIP staging/python/zccache/fingerprint/_native.* || true
-            $STRIP staging/python/zccache/watcher/_native.* || true
+            for native in staging/python/zccache/_native.* \
+                          staging/python/zccache/fingerprint/_native.* \
+                          staging/python/zccache/watcher/_native.*; do
+              [ -e "$native" ] && do_strip "$native"
+            done
           fi
         fi
+
+    - name: Stage debug-symbol sidecars
+      shell: bash
+      run: |
+        # Collect per-binary debug files into staging-debug/ for packaging as
+        # a separate "-debug" archive in the next step. Files come from the
+        # split-debuginfo = "packed" profile setting:
+        #   Linux:        <bin>.dwp
+        #   macOS:        <bin>.dSYM/   (directory)
+        #   Windows MSVC: <bin>.pdb     (Cargo's default already)
+        rm -rf staging-debug
+        mkdir -p staging-debug
+        copy_debug() {
+          local src="$1"
+          if [ -e "$src" ]; then
+            if [ -d "$src" ]; then
+              cp -R "$src" staging-debug/
+            else
+              cp "$src" staging-debug/
+            fi
+          fi
+        }
+        TARGET_DIR="target/${{ inputs.target }}/release"
+        TARGET="${{ inputs.target }}"
+        case "$TARGET" in
+          *pc-windows-msvc)
+            copy_debug "$TARGET_DIR/zccache.pdb"
+            copy_debug "$TARGET_DIR/zccache-daemon.pdb"
+            copy_debug "$TARGET_DIR/zccache-fp.pdb"
+            ;;
+          *apple-darwin)
+            copy_debug "$TARGET_DIR/zccache.dSYM"
+            copy_debug "$TARGET_DIR/zccache-daemon.dSYM"
+            copy_debug "$TARGET_DIR/zccache-fp.dSYM"
+            ;;
+          *)
+            copy_debug "$TARGET_DIR/zccache.dwp"
+            copy_debug "$TARGET_DIR/zccache-daemon.dwp"
+            copy_debug "$TARGET_DIR/zccache-fp.dwp"
+            ;;
+        esac
+        echo "Staged debug sidecars:"
+        ls -la staging-debug || true
 
     - name: Package standalone archive
       shell: bash
@@ -178,6 +235,7 @@ runs:
           --target "${{ inputs.target }}" \
           --binary-ext "${{ inputs.binary_ext }}" \
           --input-dir staging \
+          --debug-input-dir staging-debug \
           --output-dir standalone
 
     # The setup-soldr post-step that runs after this composite finishes will

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,3 +119,17 @@ libraries = [{ path = "dylints/*" }]
 # that pipeline.
 [profile.dev]
 debug = "line-tables-only"
+
+# Release builds keep function-name + source-line debug info so external
+# profilers (perf, samply, Instruments, WPA, ETW) can attribute samples to
+# functions and lines. The debug info is split into a per-binary sidecar:
+#   - Linux:        <binary>.dwp (DWARF package, requires rust-dwp at build)
+#   - macOS:        <binary>.dSYM/ (debug symbol bundle, dsymutil)
+#   - Windows MSVC: <binary>.pdb  (already the default, kept explicit)
+# The shipped binary stays slim because the debug info is in the sidecar.
+# Runtime is unaffected — the sidecar is not loaded at execution time.
+# Override with CARGO_PROFILE_RELEASE_DEBUG=none cargo build --release for a
+# smallest-possible binary when no profiling is needed.
+[profile.release]
+debug = "line-tables-only"
+split-debuginfo = "packed"

--- a/ci/package_release.py
+++ b/ci/package_release.py
@@ -20,6 +20,16 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--binary-ext", default="", help="Executable suffix, e.g. .exe")
     parser.add_argument("--input-dir", type=Path, required=True, help="Directory containing built binaries")
     parser.add_argument("--output-dir", type=Path, required=True, help="Directory to write archives into")
+    parser.add_argument(
+        "--debug-input-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Optional directory with per-binary debug symbol files "
+            "(.dwp/.dSYM/.pdb). When set, an additional <root>-debug archive is "
+            "produced alongside the regular binary archive."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -67,6 +77,41 @@ def write_zip(stage_dir: Path, archive_base: Path) -> Path:
     return archive_path
 
 
+def stage_debug_tree(
+    version: str,
+    target: str,
+    debug_input_dir: Path,
+    output_dir: Path,
+) -> tuple[Path, Path] | None:
+    """Stage debug-symbol sidecars into <root>-debug for a separate archive.
+
+    Copies anything present in the debug input dir (.dwp/.dSYM/.pdb). Returns
+    None when the input dir is empty so the caller can skip packaging an empty
+    archive.
+    """
+    if not debug_input_dir.exists():
+        return None
+    entries = [path for path in debug_input_dir.iterdir() if not path.name.startswith(".")]
+    if not entries:
+        return None
+
+    tag = normalize_version(version)
+    root_name = f"zccache-{tag}-{target}-debug"
+    stage_dir = output_dir / root_name
+    if stage_dir.exists():
+        shutil.rmtree(stage_dir)
+    stage_dir.mkdir(parents=True)
+
+    for entry in entries:
+        target_path = stage_dir / entry.name
+        if entry.is_dir():
+            shutil.copytree(entry, target_path)
+        else:
+            shutil.copy2(entry, target_path)
+
+    return stage_dir, output_dir / root_name
+
+
 def main() -> None:
     args = parse_args()
     output_dir = args.output_dir.resolve()
@@ -86,6 +131,21 @@ def main() -> None:
         archive = write_tarball(stage_dir, archive_base)
 
     print(archive)
+
+    if args.debug_input_dir is not None:
+        debug_staged = stage_debug_tree(
+            version=args.version,
+            target=args.target,
+            debug_input_dir=args.debug_input_dir.resolve(),
+            output_dir=output_dir,
+        )
+        if debug_staged is not None:
+            debug_stage_dir, debug_archive_base = debug_staged
+            if args.binary_ext == ".exe":
+                debug_archive = write_zip(debug_stage_dir, debug_archive_base)
+            else:
+                debug_archive = write_tarball(debug_stage_dir, debug_archive_base)
+            print(debug_archive)
 
 
 if __name__ == "__main__":

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -69,3 +69,92 @@ def test_write_zip_preserves_full_version_and_target(tmp_path: Path) -> None:
 
     with zipfile.ZipFile(archive) as zf:
         assert "zccache-v1.3.10-x86_64-pc-windows-msvc/zccache.exe" in zf.namelist()
+
+
+def test_stage_debug_tree_packages_dwp_files(tmp_path: Path) -> None:
+    debug_input_dir = tmp_path / "staging-debug"
+    output_dir = tmp_path / "output"
+    debug_input_dir.mkdir()
+    output_dir.mkdir()
+
+    for name in package_release.INCLUDE:
+        (debug_input_dir / f"{name}.dwp").write_bytes(b"dwp\n")
+
+    result = package_release.stage_debug_tree(
+        version="1.3.10",
+        target="x86_64-unknown-linux-gnu",
+        debug_input_dir=debug_input_dir,
+        output_dir=output_dir,
+    )
+    assert result is not None
+    debug_stage_dir, debug_archive_base = result
+    archive = package_release.write_tarball(debug_stage_dir, debug_archive_base)
+
+    assert archive.name == "zccache-v1.3.10-x86_64-unknown-linux-gnu-debug.tar.gz"
+    with tarfile.open(archive, "r:gz") as tf:
+        members = {member.name for member in tf.getmembers()}
+        for name in package_release.INCLUDE:
+            assert (
+                f"zccache-v1.3.10-x86_64-unknown-linux-gnu-debug/{name}.dwp" in members
+            )
+
+
+def test_stage_debug_tree_handles_dsym_directories(tmp_path: Path) -> None:
+    debug_input_dir = tmp_path / "staging-debug"
+    output_dir = tmp_path / "output"
+    debug_input_dir.mkdir()
+    output_dir.mkdir()
+
+    dsym = debug_input_dir / "zccache.dSYM"
+    (dsym / "Contents/Resources/DWARF").mkdir(parents=True)
+    (dsym / "Contents/Resources/DWARF/zccache").write_bytes(b"dwarf\n")
+
+    result = package_release.stage_debug_tree(
+        version="1.3.10",
+        target="x86_64-apple-darwin",
+        debug_input_dir=debug_input_dir,
+        output_dir=output_dir,
+    )
+    assert result is not None
+    debug_stage_dir, debug_archive_base = result
+    archive = package_release.write_tarball(debug_stage_dir, debug_archive_base)
+
+    with tarfile.open(archive, "r:gz") as tf:
+        members = {member.name for member in tf.getmembers()}
+        assert (
+            "zccache-v1.3.10-x86_64-apple-darwin-debug/zccache.dSYM/"
+            "Contents/Resources/DWARF/zccache" in members
+        )
+
+
+def test_stage_debug_tree_skips_empty_input(tmp_path: Path) -> None:
+    debug_input_dir = tmp_path / "staging-debug"
+    output_dir = tmp_path / "output"
+    debug_input_dir.mkdir()
+    output_dir.mkdir()
+
+    assert (
+        package_release.stage_debug_tree(
+            version="1.3.10",
+            target="x86_64-unknown-linux-gnu",
+            debug_input_dir=debug_input_dir,
+            output_dir=output_dir,
+        )
+        is None
+    )
+
+
+def test_stage_debug_tree_skips_missing_input(tmp_path: Path) -> None:
+    missing = tmp_path / "nope"
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    assert (
+        package_release.stage_debug_tree(
+            version="1.3.10",
+            target="x86_64-unknown-linux-gnu",
+            debug_input_dir=missing,
+            output_dir=output_dir,
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary

Release builds now produce a per-binary debug-info sidecar so external
profilers (perf, samply, Instruments, WPA, ETW, etc.) can attribute
samples to function names + source line numbers - without bloating the
shipped binary. Sidecars are packaged as a separate `-debug.tar.gz` /
`-debug.zip` archive in every GitHub Release, so soldr (or any
downstream) can opt to download symbols only when profiling.

### What changes

| Layer | Change |
|---|---|
| `Cargo.toml` | New `[profile.release]`: `debug = "line-tables-only"` + `split-debuginfo = "packed"` |
| `.github/actions/build-target/action.yml` | Stage `*.dwp` / `*.dSYM` / `*.pdb` into `staging-debug/`. Switch `strip` to `strip --strip-debug` so the function-name symbol table stays in the shipped binary. |
| `ci/package_release.py` | New `--debug-input-dir` flag emits an additional `<root>-debug.tar.gz` / `.zip` archive. |
| CI pytest suite | Coverage for the new `stage_debug_tree` helper (dwp, dSYM, empty, missing). |

### Sidecar layout per target

| Target | Sidecar file | Notes |
|---|---|---|
| Linux | `<bin>.dwp` | Requires `rust-dwp` (bundled with rustup since 1.76 via llvm-tools). |
| macOS | `<bin>.dSYM/` | `dsymutil` bundle (directory). |
| Windows MSVC | `<bin>.pdb` | Already the MSVC default; explicit setting keeps line tables only. |

### Runtime impact

Zero. The sidecar is in a non-loadable segment of the ELF/Mach-O binary
on Linux/macOS (`.debug_line` only), or in a separate `.pdb` file on
Windows. The OS never maps it into memory; the CPU never touches it. A
profiler reads it out-of-band when resolving a sample address.

### Binary size

Local Windows verification (soldr cargo build --release -p zccache-cli):

\`\`\`
zccache.exe   9.3M (unchanged)
zccache.pdb    35M (new, separate file)
\`\`\`

`zccache.exe` itself is unchanged. The `.pdb` is the bulky part, but
that's a separate file; users only download it when profiling.

On Linux/macOS the `.dwp` / `.dSYM` are smaller because
line-tables-only is more granular than the MSVC PDB minimum. Final
size depends on the toolchain - CI will produce the real numbers.

### Soldr integration (follow-up, separate repo)

This PR makes the symbols **available** in the Release. Soldr can keep
installing only the binary archive today; a follow-up in the soldr repo
can teach it to optionally download the matching `-debug` archive and
place the sidecars beside the installed binary so profilers pick them
up automatically.

## Verification

- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings`
- [x] `soldr cargo fmt --all -- --check`
- [x] `PYTHONPATH=. uv run pytest ci` (41 passed, 1 skipped)
- [x] Local Windows release build produces `zccache.exe` (9.3 MB) +
      `zccache.pdb` (35 MB) - sidecar found at the expected path the
      action.yml stages from.
- [ ] CI matrix build will validate Linux `.dwp` and macOS `.dSYM`
      production.

## Override

For the smallest-possible binary when no profiling is desired:

\`\`\`bash
CARGO_PROFILE_RELEASE_DEBUG=none cargo build --release
\`\`\`

Generated with Claude Code