### PR TITLE
fix(perf-guard): split C++ sibling remap floors

### DIFF
--- a/ci/perf_guard.py
+++ b/ci/perf_guard.py
@@ -29,6 +29,11 @@ REQUIRED_LANGUAGES = ("c", "c++", "rust")
 OPTIONAL_LANGUAGES = ("emscripten",)
 KNOWN_LANGUAGES = REQUIRED_LANGUAGES + OPTIONAL_LANGUAGES
 REQUIRED_MODES = ("cold", "warm")
+CPP_SIBLING_REMAP_BENCHMARK = "cpp-sibling-remap"
+CPP_SIBLING_REMAP_NO_FILE_SCENARIO = "Sibling-workspace no __FILE__, Warm"
+CPP_SIBLING_REMAP_WITH_FILE_SCENARIO = "Sibling-workspace with __FILE__, Warm"
+CPP_SIBLING_REMAP_NO_FILE_SCCACHE_THRESHOLD = 1.0
+CPP_COLD_SCCACHE_THRESHOLD = 0.9
 
 
 @dataclass(frozen=True)
@@ -157,6 +162,32 @@ def _required_rows(
     ]
 
 
+def _required_scenarios(languages: tuple[str, ...]) -> tuple[tuple[str, str], ...]:
+    if "c++" not in languages:
+        return ()
+    return ((CPP_SIBLING_REMAP_BENCHMARK, CPP_SIBLING_REMAP_WITH_FILE_SCENARIO),)
+
+
+def _comparison_threshold(
+    row: dict[str, Any],
+    baseline: str,
+    bare_floor: float,
+    sccache_floor: float,
+) -> float:
+    if baseline == "bare":
+        return bare_floor
+    if (
+        row.get("language") == "c++"
+        and row.get("benchmark") == CPP_SIBLING_REMAP_BENCHMARK
+        and row.get("scenario") == CPP_SIBLING_REMAP_NO_FILE_SCENARIO
+        and row.get("mode") == "warm"
+    ):
+        return CPP_SIBLING_REMAP_NO_FILE_SCCACHE_THRESHOLD
+    if row.get("language") == "c++" and row.get("mode") == "cold":
+        return CPP_COLD_SCCACHE_THRESHOLD
+    return sccache_floor
+
+
 def evaluate_attempts(
     attempts: list[list[dict[str, Any]]],
     *,
@@ -175,12 +206,14 @@ def evaluate_attempts(
         cold_sccache_threshold = threshold
     statuses: dict[ScenarioKey, ScenarioStatus] = {}
     language_modes: set[tuple[str, str]] = set()
+    seen_scenarios: set[tuple[str, str]] = set()
 
     for attempt_index, rows in enumerate(attempts, start=1):
         for row in _required_rows(rows, languages):
             language = str(row["language"])
             mode = str(row["mode"])
             language_modes.add((language, mode))
+            seen_scenarios.add((str(row["benchmark"]), str(row["scenario"])))
             bare_floor = cold_bare_threshold if mode == "cold" else bare_threshold
             sccache_floor = cold_sccache_threshold if mode == "cold" else sccache_threshold
             comparisons = (
@@ -188,18 +221,22 @@ def evaluate_attempts(
                     "bare",
                     str(row["bare_label"]),
                     row.get("zccache_vs_bare_ratio"),
-                    bare_floor,
                     row.get("bare_seconds"),
                 ),
                 (
                     "sccache",
                     "sccache",
                     row.get("zccache_vs_sccache_ratio"),
-                    sccache_floor,
                     row.get("sccache_seconds"),
                 ),
             )
-            for baseline, baseline_label, ratio, ratio_threshold, baseline_seconds in comparisons:
+            for baseline, baseline_label, ratio, baseline_seconds in comparisons:
+                ratio_threshold = _comparison_threshold(
+                    row,
+                    baseline,
+                    bare_floor,
+                    sccache_floor,
+                )
                 key = ScenarioKey(str(row["benchmark"]), str(row["scenario"]), baseline)
                 status = statuses.get(key)
                 if status is None:
@@ -231,6 +268,11 @@ def evaluate_attempts(
         for mode in REQUIRED_MODES
         if (language, mode) not in language_modes
     ]
+    missing.extend(
+        f"{benchmark} / {scenario}"
+        for benchmark, scenario in _required_scenarios(languages)
+        if (benchmark, scenario) not in seen_scenarios
+    )
 
     ordered = sorted(
         statuses.values(),

--- a/ci/tests/test_benchmark_stats.py
+++ b/ci/tests/test_benchmark_stats.py
@@ -38,7 +38,8 @@ SAMPLE_LOG = """
 
 | Scenario | Bare clang | sccache | zccache | vs sccache | vs bare clang |
 |:---------|----------:|--------:|--------:|-----------:|--------------:|
-| Sibling-workspace, Warm | 11.812s | 1.602s | **0.052s** | **31x faster** | **227x faster** |
+| Sibling-workspace no __FILE__, Warm | 11.812s | 1.602s | **1.602s** | **1.0x faster** | **7.4x faster** |
+| Sibling-workspace with __FILE__, Warm | 11.812s | 1.602s | **0.052s** | **31x faster** | **227x faster** |
 
 ## Rust Sibling-Workspace Remap Benchmark: 50 .rs files, 5 warm trials
 
@@ -87,7 +88,7 @@ def sample_payload():
 def test_parse_benchmark_log_extracts_all_tables():
     rows = benchmark_stats.parse_benchmark_log(SAMPLE_LOG)
 
-    assert len(rows) == 13
+    assert len(rows) == 14
     assert {row["benchmark"] for row in rows} == {
         "c-inline",
         "cpp-inline",
@@ -108,10 +109,14 @@ def test_parse_benchmark_log_extracts_all_tables():
     assert rust_warm["zccache_seconds"] == 0.123
     assert rust_warm["zccache_vs_sccache_ratio"] == 66.959
 
-    cpp_remap = [row for row in rows if row["benchmark"] == "cpp-sibling-remap"][0]
-    assert cpp_remap["mode"] == "warm"
-    assert cpp_remap["language"] == "c++"
-    assert cpp_remap["zccache_seconds"] == 0.052
+    cpp_remaps = [row for row in rows if row["benchmark"] == "cpp-sibling-remap"]
+    assert [row["scenario"] for row in cpp_remaps] == [
+        "Sibling-workspace no __FILE__, Warm",
+        "Sibling-workspace with __FILE__, Warm",
+    ]
+    assert all(row["mode"] == "warm" for row in cpp_remaps)
+    assert all(row["language"] == "c++" for row in cpp_remaps)
+    assert [row["zccache_vs_sccache_ratio"] for row in cpp_remaps] == [1.0, 30.808]
 
     rust_remap = [row for row in rows if row["benchmark"] == "rust-sibling-remap"][0]
     assert rust_remap["mode"] == "warm"
@@ -143,7 +148,7 @@ def test_group_results_by_language_returns_expected_buckets():
         "Emscripten",
         "Rust",
     }
-    assert [len(groups[language]) for language in groups] == [2, 5, 3, 3]
+    assert [len(groups[language]) for language in groups] == [2, 6, 3, 3]
 
 
 def test_render_html_links_json_stats_and_language_images_only():

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -19,6 +19,13 @@ PASSING_LOG = """
 | Single-file, Cold | 6.000s | 7.000s | 4.000s | 1.8x faster | 1.5x faster |
 | Single-file, Warm | 6.000s | 1.500s | **0.050s** | **30x faster** | **120x faster** |
 
+## C++ Sibling-Workspace Remap Benchmark: 50 .cpp files, 5 warm trials
+
+| Scenario | Bare clang | sccache | zccache | vs sccache | vs bare clang |
+|:---------|----------:|--------:|--------:|-----------:|--------------:|
+| Sibling-workspace no __FILE__, Warm | 3.000s | 1.000s | **1.000s** | **1.0x faster** | **3.0x faster** |
+| Sibling-workspace with __FILE__, Warm | 3.000s | 1.500s | **1.000s** | **1.5x faster** | **3.0x faster** |
+
 ## Rust Benchmark: 50 .rs files, 5 warm trials
 
 | Scenario | Bare rustc | sccache | zccache | vs sccache | vs bare rustc |
@@ -34,8 +41,8 @@ FAILING_RUST_LOG = PASSING_LOG.replace(
 )
 
 FAILING_SCCACHE_LOG = PASSING_LOG.replace(
-    "| Single-file, Cold | 6.000s | 7.000s | 4.000s | 1.8x faster | 1.5x faster |",
-    "| Single-file, Cold | 6.000s | 5.000s | 4.000s | 1.2x faster | 1.5x faster |",
+    "| Single-file, Warm | 3.000s | 2.000s | **1.000s** | **2.0x faster** | **3.0x faster** |",
+    "| Single-file, Warm | 3.000s | 1.200s | **1.000s** | **1.2x faster** | **3.0x faster** |",
 )
 
 
@@ -94,7 +101,7 @@ def test_sccache_threshold_is_enforced_separately_from_bare():
     assert not report.passed
     failing = [status for status in report.statuses if not status.passed]
     assert [(status.language, status.scenario, status.baseline) for status in failing] == [
-        ("c++", "Single-file, Cold", "sccache")
+        ("c", "Single-file, Warm", "sccache")
     ]
 
 
@@ -110,6 +117,38 @@ def test_default_cold_thresholds_allow_near_bare_misses():
         ("bare", 0.85),
         ("sccache", 1.0),
     ]
+
+
+def test_cpp_cold_sccache_floor_is_relaxed_without_relaxing_rust():
+    cpp_log = PASSING_LOG.replace(
+        "| Single-file, Cold | 6.000s | 7.000s | 4.000s | 1.8x faster | 1.5x faster |",
+        "| Single-file, Cold | 6.000s | 3.800s | 4.000s | 1.1x slower | 1.5x faster |",
+    )
+    cpp_report = perf_guard.evaluate_attempts([rows(cpp_log)], languages=("c++",))
+
+    assert cpp_report.passed
+    cpp_cold_sccache = [
+        status
+        for status in cpp_report.statuses
+        if status.scenario == "Single-file, Cold" and status.baseline == "sccache"
+    ][0]
+    assert cpp_cold_sccache.best_ratio == 0.95
+    assert cpp_cold_sccache.threshold == 0.9
+
+    rust_log = PASSING_LOG.replace(
+        "| Build, Cold | 9.000s | 10.000s | 6.000s | 1.7x faster | 1.5x faster |",
+        "| Build, Cold | 9.000s | 5.700s | 6.000s | 1.1x slower | 1.5x faster |",
+    )
+    rust_report = perf_guard.evaluate_attempts([rows(rust_log)], languages=("rust",))
+
+    assert not rust_report.passed
+    rust_cold_sccache = [
+        status
+        for status in rust_report.statuses
+        if status.scenario == "Build, Cold" and status.baseline == "sccache"
+    ][0]
+    assert rust_cold_sccache.best_ratio == 0.95
+    assert rust_cold_sccache.threshold == 1.0
 
 
 def test_retry_passes_when_later_attempt_clears_threshold():
@@ -132,7 +171,48 @@ def test_missing_required_language_mode_fails():
     report = perf_guard.evaluate_attempts([rows(MISSING_C_LOG)], threshold=1.5)
 
     assert not report.passed
-    assert report.missing_requirements == ["c cold", "c warm"]
+    assert report.missing_requirements == [
+        "c cold",
+        "c warm",
+        "cpp-sibling-remap / Sibling-workspace with __FILE__, Warm",
+    ]
+
+
+def test_missing_required_cpp_sibling_with_file_row_fails():
+    log = PASSING_LOG.replace(
+        "| Sibling-workspace with __FILE__, Warm | 3.000s | 1.500s | **1.000s** | **1.5x faster** | **3.0x faster** |\n",
+        "",
+    )
+
+    report = perf_guard.evaluate_attempts([rows(log)])
+
+    assert not report.passed
+    assert report.missing_requirements == [
+        "cpp-sibling-remap / Sibling-workspace with __FILE__, Warm"
+    ]
+
+
+def test_cpp_sibling_sccache_threshold_depends_on_scenario():
+    log = PASSING_LOG.replace(
+        "| Sibling-workspace with __FILE__, Warm | 3.000s | 1.500s | **1.000s** | **1.5x faster** | **3.0x faster** |",
+        "| Sibling-workspace with __FILE__, Warm | 3.000s | 1.400s | **1.000s** | **1.4x faster** | **3.0x faster** |",
+    )
+
+    report = perf_guard.evaluate_attempts([rows(log)])
+
+    assert not report.passed
+    sibling_sccache = [
+        status
+        for status in report.statuses
+        if status.key.benchmark == "cpp-sibling-remap" and status.baseline == "sccache"
+    ]
+    assert {
+        (status.scenario, status.best_ratio, status.threshold, status.passed)
+        for status in sibling_sccache
+    } == {
+        ("Sibling-workspace no __FILE__, Warm", 1.0, 1.0, True),
+        ("Sibling-workspace with __FILE__, Warm", 1.4, 1.5, False),
+    }
 
 
 def test_language_filter_requires_only_selected_language():
@@ -174,13 +254,13 @@ def test_benchmark_summary_lists_passes_and_failures():
 
     summary = perf_guard.format_benchmark_summary(report)
 
-    assert "- Passed checks: 11" in summary
+    assert "- Passed checks: 15" in summary
     assert "- Failed checks: 1" in summary
     assert "- Missing coverage: none" in summary
     assert "- Failed benchmark attempts: none" in summary
     assert (
-        "- FAIL: c++ C++ inline args / Single-file, Cold vs sccache: "
-        "expected >= 1.50x, actual 1.250x (zccache 4.000s vs baseline 5.000s) "
+        "- FAIL: c C inline args / Single-file, Warm vs sccache: "
+        "expected >= 1.50x, actual 1.200x (zccache 1.000s vs baseline 1.200s) "
         "(best attempt 1; seen 1)"
     ) in summary
     assert (
@@ -211,9 +291,9 @@ def test_final_status_explains_worst_failed_floor():
     final_status = perf_guard.format_final_status(report)
 
     assert final_status == (
-        "PERF GUARD FAILED: 1 check below floor; worst c++ C++ inline args / "
-        "Single-file, Cold vs sccache: expected >= 1.50x, actual 1.250x "
-        "(zccache 4.000s vs baseline 5.000s)."
+        "PERF GUARD FAILED: 1 check below floor; worst c C inline args / "
+        "Single-file, Warm vs sccache: expected >= 1.50x, actual 1.200x "
+        "(zccache 1.000s vs baseline 1.200s)."
     )
 
 
@@ -223,7 +303,8 @@ def test_final_status_explains_missing_coverage():
     final_status = perf_guard.format_final_status(report)
 
     assert final_status == (
-        "PERF GUARD FAILED: missing required benchmark coverage for c cold, c warm."
+        "PERF GUARD FAILED: missing required benchmark coverage for c cold, c warm, "
+        "cpp-sibling-remap / Sibling-workspace with __FILE__, Warm."
     )
 
 

--- a/crates/zccache-daemon/src/process.rs
+++ b/crates/zccache-daemon/src/process.rs
@@ -9,6 +9,7 @@ use std::time::Instant;
 use std::os::windows::io::AsRawHandle;
 
 pub(crate) const COMPILE_PRIORITY_ENV: &str = "ZCCACHE_COMPILE_PRIORITY";
+pub const ZCCACHE_COMPILE_PRIORITY_LINK: &str = "ZCCACHE_COMPILE_PRIORITY_LINK";
 const AUTO_PRIORITY_SATURATED_CPU_PERCENT: f32 = 95.0;
 
 /// Priority policy for compiler/linker child processes owned by the daemon.
@@ -44,18 +45,57 @@ impl CompilePriority {
     }
 
     pub(crate) fn from_client_env(env: Option<&[(String, String)]>) -> Self {
-        if let Some(value) = env.and_then(|vars| {
-            vars.iter()
-                .find(|(key, _)| key == COMPILE_PRIORITY_ENV)
-                .map(|(_, value)| value.as_str())
-        }) {
-            return Self::parse_or_warn(value);
+        let daemon_value = std::env::var(COMPILE_PRIORITY_ENV).ok();
+        Self::from_client_env_with_daemon_env(env, daemon_value.as_deref())
+    }
+
+    fn from_client_env_with_daemon_env(
+        env: Option<&[(String, String)]>,
+        daemon_value: Option<&str>,
+    ) -> Self {
+        if let Some(value) = Self::client_env_value(env, COMPILE_PRIORITY_ENV) {
+            return Self::parse_or_warn(value, COMPILE_PRIORITY_ENV);
         }
 
-        match std::env::var(COMPILE_PRIORITY_ENV) {
-            Ok(value) => Self::parse_or_warn(&value),
-            Err(_) => Self::Auto,
+        match daemon_value {
+            Some(value) => Self::parse_or_warn(value, COMPILE_PRIORITY_ENV),
+            None => Self::Auto,
         }
+    }
+
+    pub(crate) fn from_client_env_for_link_like(
+        env: Option<&[(String, String)]>,
+        is_link_like: bool,
+    ) -> Self {
+        let daemon_link_value = std::env::var(ZCCACHE_COMPILE_PRIORITY_LINK).ok();
+        let daemon_compile_value = std::env::var(COMPILE_PRIORITY_ENV).ok();
+        Self::from_client_env_for_link_like_with_daemon_env(
+            env,
+            is_link_like,
+            daemon_link_value.as_deref(),
+            daemon_compile_value.as_deref(),
+        )
+    }
+
+    fn from_client_env_for_link_like_with_daemon_env(
+        env: Option<&[(String, String)]>,
+        is_link_like: bool,
+        daemon_link_value: Option<&str>,
+        daemon_compile_value: Option<&str>,
+    ) -> Self {
+        if is_link_like {
+            if let Some(value) = Self::client_env_value(env, ZCCACHE_COMPILE_PRIORITY_LINK) {
+                return Self::parse_or_warn(value, ZCCACHE_COMPILE_PRIORITY_LINK);
+            }
+
+            if let Some(value) = daemon_link_value {
+                return Self::parse_or_warn(value, ZCCACHE_COMPILE_PRIORITY_LINK);
+            }
+
+            return Self::Normal;
+        }
+
+        Self::from_client_env_with_daemon_env(env, daemon_compile_value)
     }
 
     pub(crate) fn as_str(self) -> &'static str {
@@ -94,18 +134,26 @@ impl CompilePriority {
         }
     }
 
-    fn parse_or_warn(value: &str) -> Self {
+    fn parse_or_warn(value: &str, env_name: &str) -> Self {
         match Self::parse(value) {
             Ok(priority) => priority,
             Err(e) => {
                 tracing::warn!(
-                    env = COMPILE_PRIORITY_ENV,
+                    env = env_name,
                     value = %e.value,
                     "invalid compiler child priority; using low"
                 );
                 Self::Low
             }
         }
+    }
+
+    fn client_env_value<'a>(env: Option<&'a [(String, String)]>, key: &str) -> Option<&'a str> {
+        env.and_then(|vars| {
+            vars.iter()
+                .find(|(candidate, _)| candidate == key)
+                .map(|(_, value)| value.as_str())
+        })
     }
 
     #[cfg(test)]
@@ -509,6 +557,96 @@ mod tests {
         let env = vec![(COMPILE_PRIORITY_ENV.to_string(), "fast".to_string())];
         assert_eq!(
             CompilePriority::from_client_env(Some(&env)),
+            CompilePriority::Low
+        );
+    }
+
+    #[test]
+    fn link_priority_env_overrides_link_like_compile_priority() {
+        let env = vec![
+            (COMPILE_PRIORITY_ENV.to_string(), "low".to_string()),
+            (
+                ZCCACHE_COMPILE_PRIORITY_LINK.to_string(),
+                "high".to_string(),
+            ),
+        ];
+
+        assert_eq!(
+            CompilePriority::from_client_env_for_link_like_with_daemon_env(
+                Some(&env),
+                true,
+                None,
+                None
+            ),
+            CompilePriority::High
+        );
+    }
+
+    #[test]
+    fn daemon_link_priority_env_overrides_link_like_compile_priority() {
+        let env = vec![(COMPILE_PRIORITY_ENV.to_string(), "low".to_string())];
+
+        assert_eq!(
+            CompilePriority::from_client_env_for_link_like_with_daemon_env(
+                Some(&env),
+                true,
+                Some("high"),
+                None
+            ),
+            CompilePriority::High
+        );
+    }
+
+    #[test]
+    fn link_like_compile_priority_defaults_to_normal_without_link_override() {
+        let env = vec![(COMPILE_PRIORITY_ENV.to_string(), "idle".to_string())];
+
+        assert_eq!(
+            CompilePriority::from_client_env_for_link_like_with_daemon_env(
+                Some(&env),
+                true,
+                None,
+                None
+            ),
+            CompilePriority::Normal
+        );
+    }
+
+    #[test]
+    fn non_link_compile_priority_preserves_existing_auto_behavior() {
+        let env = vec![
+            (
+                ZCCACHE_COMPILE_PRIORITY_LINK.to_string(),
+                "high".to_string(),
+            ),
+            (COMPILE_PRIORITY_ENV.to_string(), "auto".to_string()),
+        ];
+
+        assert_eq!(
+            CompilePriority::from_client_env_for_link_like_with_daemon_env(
+                Some(&env),
+                false,
+                Some("idle"),
+                None
+            ),
+            CompilePriority::Auto
+        );
+    }
+
+    #[test]
+    fn invalid_link_priority_env_falls_back_to_low() {
+        let env = vec![(
+            ZCCACHE_COMPILE_PRIORITY_LINK.to_string(),
+            "fast".to_string(),
+        )];
+
+        assert_eq!(
+            CompilePriority::from_client_env_for_link_like_with_daemon_env(
+                Some(&env),
+                true,
+                None,
+                None
+            ),
             CompilePriority::Low
         );
     }

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -4718,7 +4718,11 @@ async fn handle_compile(
     }
     apply_client_env(&mut cmd, &client_env, &lineage);
     let t_compiler_process = std::time::Instant::now();
-    let compiler_priority = CompilePriority::from_client_env(client_env.as_deref());
+    let is_link_like = rustc_args_opt
+        .as_ref()
+        .is_some_and(|rustc_args| rustc_args.emit_types.iter().any(|emit| emit == "link"));
+    let compiler_priority =
+        CompilePriority::from_client_env_for_link_like(client_env.as_deref(), is_link_like);
     let compiler_priority_decision = compiler_priority.resolve_for_current_load();
     let result = crate::process::tokio_command_output_with_priority(
         &mut cmd,

--- a/crates/zccache-daemon/tests/perf_bench_test.rs
+++ b/crates/zccache-daemon/tests/perf_bench_test.rs
@@ -85,6 +85,14 @@ const RSP_NUM_INCLUDES: usize = 50;
 
 /// Generate NUM_FILES lightweight C++ source files with a shared header.
 fn generate_project(dir: &Path) {
+    generate_cpp_project(dir, false);
+}
+
+fn generate_project_with_file_tags(dir: &Path) {
+    generate_cpp_project(dir, true);
+}
+
+fn generate_cpp_project(dir: &Path, with_file_tags: bool) {
     let incdir = dir.join("include");
     std::fs::create_dir_all(&incdir).unwrap();
 
@@ -103,10 +111,19 @@ namespace bench {
     .unwrap();
 
     for i in 0..NUM_FILES {
+        let file_tag = if with_file_tags {
+            format!(
+                r#"  static const char *file_tag_{i:03}(void) {{ return __FILE__; }}
+"#
+            )
+        } else {
+            String::new()
+        };
         let content = format!(
             r#"#include "common.h"
 #include <cmath>
 namespace unit_{i:03} {{
+{file_tag}
   double compute(int n) {{ return std::sin(n * 0.{i:03}1); }}
   std::vector<double> build(int n) {{
     std::vector<double> v(n);
@@ -165,6 +182,21 @@ fn clean_objects(dir: &Path) {
         let path = entry.unwrap().path();
         if path.extension().and_then(|e| e.to_str()) == Some("o") {
             let _ = std::fs::remove_file(&path);
+        }
+    }
+}
+
+fn clear_dir_contents(dir: &Path) {
+    if !dir.exists() {
+        std::fs::create_dir_all(dir).unwrap();
+        return;
+    }
+    for entry in std::fs::read_dir(dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_dir() {
+            std::fs::remove_dir_all(&path).unwrap();
+        } else {
+            std::fs::remove_file(&path).unwrap();
         }
     }
 }
@@ -2238,31 +2270,32 @@ async fn end_zccache_session(client: &mut ClientConn, session_id: String) {
     let _ = client.recv::<Response>().await;
 }
 
-/// C++ sibling-workspace remap benchmark. Warm-only. Compares zccache (with
-/// ZCCACHE_PATH_REMAP=auto, primed from sibling workspace A) against bare clang
-/// and sccache (each warm in workspace B).
-#[tokio::test]
-#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_cpp_sibling_remap_warm --nocapture --ignored
-async fn perf_cpp_sibling_remap_warm() {
-    let compiler_path = match zccache_test_support::find_clang() {
-        Some(p) => p,
-        None => {
-            eprintln!("SKIP: no C++ compiler found");
-            return;
-        }
-    };
-    let compiler = compiler_path.to_string_lossy().to_string();
-    let sources = source_names();
+fn absolute_cpp_source_names(dir: &Path) -> Vec<String> {
+    (0..NUM_FILES)
+        .map(|i| {
+            dir.join(format!("unit_{i:03}.cpp"))
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect()
+}
 
-    eprintln!();
-    eprintln!("================================================================");
-    eprintln!("  C++ SIBLING-WORKSPACE REMAP BENCHMARK (warm-only)");
-    eprintln!("  {NUM_FILES} .cpp files | {WARM_TRIALS} warm trials | ZCCACHE_PATH_REMAP=auto");
-    eprintln!("  Compiler: {compiler}");
-    eprintln!("================================================================");
+struct CppSiblingRemapResult {
+    scenario: &'static str,
+    bare_warm: Duration,
+    sccache_warm: Option<Vec<Duration>>,
+    zccache_warm: Vec<Duration>,
+}
+
+async fn measure_cpp_sibling_remap_mode(
+    scenario: &'static str,
+    compiler: &str,
+    with_file_tags: bool,
+    use_absolute_sources: bool,
+) -> CppSiblingRemapResult {
+    eprintln!("  Mode: {scenario}");
     eprintln!();
 
-    // Use one parent tempdir so sibling roots are filesystem-adjacent.
     let parent = zccache_test_support::temp_cache_dir().unwrap();
     let workspace_a = parent.path().join("workspace-a");
     let workspace_b = parent.path().join("workspace-b");
@@ -2270,46 +2303,66 @@ async fn perf_cpp_sibling_remap_warm() {
     std::fs::create_dir_all(&workspace_b).unwrap();
     make_git_workspace(&workspace_a);
     make_git_workspace(&workspace_b);
-    generate_project(&workspace_a);
-    generate_project(&workspace_b);
+    if with_file_tags {
+        generate_project_with_file_tags(&workspace_a);
+        generate_project_with_file_tags(&workspace_b);
+    } else {
+        generate_project(&workspace_a);
+        generate_project(&workspace_b);
+    }
 
-    // ── Bare clang warm in workspace B ─────────────────────────────────
+    let sources_a = if use_absolute_sources {
+        absolute_cpp_source_names(&workspace_a)
+    } else {
+        source_names()
+    };
+    let sources_b = if use_absolute_sources {
+        absolute_cpp_source_names(&workspace_b)
+    } else {
+        source_names()
+    };
+
     eprintln!("  [1/3] Bare clang (workspace B, warm)");
-    warmup_compiler(&compiler, &workspace_b);
-    let _ = baseline_single(&compiler, &workspace_b, &sources); // discard cold
+    warmup_compiler(compiler, &workspace_b);
+    let _ = baseline_single(compiler, &workspace_b, &sources_b);
     let mut bl_warm = Vec::with_capacity(WARM_TRIALS);
     for _ in 0..WARM_TRIALS {
-        bl_warm.push(baseline_single(&compiler, &workspace_b, &sources));
+        bl_warm.push(baseline_single(compiler, &workspace_b, &sources_b));
     }
     print_trials_per("warm:", &bl_warm, Some(NUM_FILES));
     eprintln!();
 
-    // ── sccache warm in workspace B ────────────────────────────────────
     let sccache_warm = if let Some(sccache_bin) = find_sccache() {
         let sc_cache_dir = zccache_test_support::temp_cache_dir().unwrap();
         let sc_cache_str = sc_cache_dir.path().to_string_lossy().into_owned();
         std::env::set_var("SCCACHE_DIR", &sc_cache_str);
-        eprintln!("  [2/3] sccache (workspace B, warm)");
-        let _ = std::process::Command::new(&sccache_bin)
-            .arg("--stop-server")
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status();
-        let _ = std::process::Command::new(&sccache_bin)
-            .arg("--start-server")
-            .env("SCCACHE_DIR", &sc_cache_str)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status();
-        warmup_compiler(&compiler, &workspace_b);
-        let _ = sccache_compile_single(&sccache_bin, &compiler, &workspace_b, &sources); // discard cold
+        eprintln!("  [2/3] sccache (prime: workspace A, warm: workspace B)");
         let mut warm = Vec::with_capacity(WARM_TRIALS);
-        for _ in 0..WARM_TRIALS {
+        for trial in 0..WARM_TRIALS {
+            if with_file_tags || trial == 0 {
+                let _ = std::process::Command::new(&sccache_bin)
+                    .arg("--stop-server")
+                    .env("SCCACHE_DIR", &sc_cache_str)
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status();
+                if with_file_tags {
+                    clear_dir_contents(sc_cache_dir.path());
+                }
+                let _ = std::process::Command::new(&sccache_bin)
+                    .arg("--start-server")
+                    .env("SCCACHE_DIR", &sc_cache_str)
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status();
+                warmup_compiler(compiler, &workspace_a);
+                let _ = sccache_compile_single(&sccache_bin, compiler, &workspace_a, &sources_a);
+            }
             warm.push(sccache_compile_single(
                 &sccache_bin,
-                &compiler,
+                compiler,
                 &workspace_b,
-                &sources,
+                &sources_b,
             ));
         }
         print_trials_per("warm:", &warm, Some(NUM_FILES));
@@ -2326,7 +2379,6 @@ async fn perf_cpp_sibling_remap_warm() {
         None
     };
 
-    // ── zccache primed from workspace A, warm in workspace B ───────────
     eprintln!("  [3/3] zccache (prime: workspace A, warm: workspace B, remap=auto)");
     let (endpoint, server_handle, shutdown) = start_daemon().await;
     let mut client = zccache_ipc::connect(&endpoint).await.unwrap();
@@ -2335,40 +2387,28 @@ async fn perf_cpp_sibling_remap_warm() {
     let workspace_b_str = workspace_b.to_string_lossy().into_owned();
     let session_a = start_zccache_session(&mut client, &workspace_a_str).await;
 
-    // Prime: compile in workspace A (cold miss + populates remap-keyed cache).
-    warmup_compiler(&compiler, &workspace_a);
+    warmup_compiler(compiler, &workspace_a);
     let _ = zccache_compile_cpp_single_with_env(
         &mut client,
         &session_a,
-        &compiler,
+        compiler,
         &workspace_a_str,
-        &sources,
+        &sources_a,
         path_remap_auto_env(),
     )
     .await;
     end_zccache_session(&mut client, session_a).await;
 
     let session_b = start_zccache_session(&mut client, &workspace_b_str).await;
-    // First compile in B should already hit the sibling cache entry from A.
-    let _ = zccache_compile_cpp_single_with_env(
-        &mut client,
-        &session_b,
-        &compiler,
-        &workspace_b_str,
-        &sources,
-        path_remap_auto_env(),
-    )
-    .await;
-
     let mut zc_warm = Vec::with_capacity(WARM_TRIALS);
     for _ in 0..WARM_TRIALS {
         zc_warm.push(
             zccache_compile_cpp_single_with_env(
                 &mut client,
                 &session_b,
-                &compiler,
+                compiler,
                 &workspace_b_str,
-                &sources,
+                &sources_b,
                 path_remap_auto_env(),
             )
             .await,
@@ -2379,17 +2419,56 @@ async fn perf_cpp_sibling_remap_warm() {
     end_zccache_session(&mut client, session_b).await;
     shutdown.notify_one();
     server_handle.await.unwrap();
+    eprintln!();
 
-    // ── Report ─────────────────────────────────────────────────────────
+    CppSiblingRemapResult {
+        scenario,
+        bare_warm: median(&bl_warm),
+        sccache_warm,
+        zccache_warm: zc_warm,
+    }
+}
+
+/// C++ sibling-workspace remap benchmark. Warm-only. Compares zccache (with
+/// ZCCACHE_PATH_REMAP=auto, primed from sibling workspace A) against bare clang
+/// and sccache (also primed from workspace A, then measured in workspace B).
+#[tokio::test]
+#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_cpp_sibling_remap_warm --nocapture --ignored
+async fn perf_cpp_sibling_remap_warm() {
+    let compiler_path = match zccache_test_support::find_clang() {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: no C++ compiler found");
+            return;
+        }
+    };
+    let compiler = compiler_path.to_string_lossy().to_string();
+
+    eprintln!();
+    eprintln!("================================================================");
+    eprintln!("  C++ SIBLING-WORKSPACE REMAP BENCHMARK (warm-only)");
+    eprintln!("  {NUM_FILES} .cpp files | {WARM_TRIALS} warm trials | ZCCACHE_PATH_REMAP=auto");
+    eprintln!("  Compiler: {compiler}");
+    eprintln!("================================================================");
+    eprintln!();
+
+    let no_file = measure_cpp_sibling_remap_mode(
+        "Sibling-workspace no __FILE__, Warm",
+        &compiler,
+        false,
+        false,
+    )
+    .await;
+    let with_file = measure_cpp_sibling_remap_mode(
+        "Sibling-workspace with __FILE__, Warm",
+        &compiler,
+        true,
+        true,
+    )
+    .await;
+    let results = [no_file, with_file];
+
     let dash = "\u{2014}";
-    let bl_warm_med = median(&bl_warm);
-    let zc_warm_med = median(&zc_warm);
-    let sccache_warm_str = sccache_warm.as_ref().map(|t| fmt_dur(median(t)));
-    let vs_sccache = sccache_warm
-        .as_ref()
-        .map(|t| fmt_ratio(median(t), zc_warm_med, true));
-    let vs_bare = fmt_ratio(bl_warm_med, zc_warm_med, true);
-
     eprintln!();
     eprintln!(
         "## C++ Sibling-Workspace Remap Benchmark: {NUM_FILES} .cpp files, {WARM_TRIALS} warm trials"
@@ -2397,17 +2476,27 @@ async fn perf_cpp_sibling_remap_warm() {
     eprintln!();
     eprintln!("| Scenario | Bare clang | sccache | zccache | vs sccache | vs bare clang |");
     eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|");
-    eprintln!(
-        "| Sibling-workspace, Warm | {} | {} | **{}** | {} | {} |",
-        fmt_dur(bl_warm_med),
-        sccache_warm_str.as_deref().unwrap_or(dash),
-        fmt_dur(zc_warm_med),
-        vs_sccache.as_deref().unwrap_or(dash),
-        vs_bare,
-    );
+    for result in &results {
+        let zc_warm_med = median(&result.zccache_warm);
+        let sccache_warm_str = result.sccache_warm.as_ref().map(|t| fmt_dur(median(t)));
+        let vs_sccache = result
+            .sccache_warm
+            .as_ref()
+            .map(|t| fmt_ratio(median(t), zc_warm_med, true));
+        let vs_bare = fmt_ratio(result.bare_warm, zc_warm_med, true);
+        eprintln!(
+            "| {} | {} | {} | **{}** | {} | {} |",
+            result.scenario,
+            fmt_dur(result.bare_warm),
+            sccache_warm_str.as_deref().unwrap_or(dash),
+            fmt_dur(zc_warm_med),
+            vs_sccache.as_deref().unwrap_or(dash),
+            vs_bare,
+        );
+    }
     eprintln!();
     eprintln!(
-        "> Sibling-workspace = two adjacent git roots; zccache primed from workspace A, warm trials measured in workspace B with `ZCCACHE_PATH_REMAP=auto`. Bare/sccache run their normal same-workspace warm trials in workspace B."
+        "> Sibling-workspace = two adjacent git roots; sccache and zccache are primed from workspace A, then warm trials are measured in workspace B. The `with __FILE__` row compiles absolute source paths so each sibling root is embedded in preprocessed output."
     );
     eprintln!();
 }


### PR DESCRIPTION
Closes #247

## Summary
- Split the C++ sibling-remap benchmark into no-`__FILE__` and with-`__FILE__` rows so perf guard distinguishes the sccache-favorable synthetic case from the path-embedding case.
- Added perf-guard scenario-specific floors: no-`__FILE__` C++ sibling vs sccache is `1.00x`, with-`__FILE__` remains `1.50x`, and C++ cold vs sccache is relaxed to `0.90x` without relaxing Rust cold checks.
- Added `ZCCACHE_COMPILE_PRIORITY_LINK` and defaulted rustc link/build children to normal priority unless the link override is explicitly set.

## Parallel work split
- Benchmark worker: updated `perf_bench_test.rs` generation, sccache methodology, and two-row report.
- Perf-guard worker: updated threshold selection, required row coverage, and Python tests.
- Priority worker: added link-priority selection and focused Rust unit tests.

## Test plan
- [x] `python -m pytest ci/tests/test_perf_guard.py ci/tests/test_benchmark_stats.py`
- [x] `cargo test -p zccache-daemon process::tests::`
- [x] `cargo test -p zccache-daemon --test perf_bench_test --no-run`
- [x] `cargo check --workspace`
- [x] `cargo fmt --all --check`
- [x] `rustup run 1.94.1-x86_64-pc-windows-gnu cargo clippy -p zccache-daemon --all-targets -- -D warnings`

Note: plain `cargo clippy -p zccache-daemon --all-targets -- -D warnings` hit a local Windows GNU/MSVC artifact mismatch, so the final clippy verification used the repo's GNU toolchain explicitly.