### PR TITLE
fix(daemon): drop stale cargo jobserver env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "bincode",
  "blake3",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "libc",
  "md5",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "blake3",
  "clap",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "clang",
  "tempfile",
@@ -3499,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "serde",
  "tempfile",
@@ -3510,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "bincode",
  "clap",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "blake3",
  "dashmap",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "blake3",
  "bytes",
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "clap",
  "serde",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "clap",
  "dashmap",
@@ -3633,7 +3633,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "bincode",
  "bytes",
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "clap",
  "criterion",
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "reqwest",
  "serde",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "blake3",
  "criterion",
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "bytes",
  "serde",
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "bincode",
  "bytes",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3742,7 +3742,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["dylints/ban_std_pathbuf"]
 
 [workspace.package]
-version = "1.4.6"
+version = "1.4.7"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -5308,10 +5308,19 @@ fn apply_client_env(
     if let Some(vars) = client_env {
         cmd.env_clear();
         for (key, val) in vars {
-            cmd.env(key, val);
+            if client_env_var_is_safe_to_replay(key) {
+                cmd.env(key, val);
+            }
         }
     }
     lineage.apply_to_tokio(cmd, client_env.as_deref());
+}
+
+/// Cargo jobserver env vars name process-local file descriptors. The daemon
+/// receives those names through IPC, not the fds themselves, so replaying them
+/// into daemon-spawned compilers produces Cargo's stale-jobserver warning.
+fn client_env_var_is_safe_to_replay(key: &str) -> bool {
+    !matches!(key, "MAKEFLAGS" | "CARGO_MAKEFLAGS")
 }
 
 /// Sync-command counterpart of [`apply_client_env`].
@@ -5323,7 +5332,9 @@ fn apply_client_env_sync(
     if let Some(vars) = client_env {
         cmd.env_clear();
         for (key, val) in vars {
-            cmd.env(key, val);
+            if client_env_var_is_safe_to_replay(key) {
+                cmd.env(key, val);
+            }
         }
     }
     lineage.apply_to_sync(cmd, client_env);
@@ -6196,6 +6207,91 @@ mod tests {
         let mut bytes = [0; 32];
         bytes[..8].copy_from_slice(&(index as u64).to_le_bytes());
         ContentHash::from_bytes(bytes)
+    }
+
+    fn collect_command_env<'a, I>(envs: I) -> Vec<(String, String)>
+    where
+        I: Iterator<Item = (&'a std::ffi::OsStr, Option<&'a std::ffi::OsStr>)>,
+    {
+        envs.filter_map(|(key, value)| {
+            Some((
+                key.to_string_lossy().into_owned(),
+                value?.to_string_lossy().into_owned(),
+            ))
+        })
+        .collect()
+    }
+
+    fn env_value<'a>(envs: &'a [(String, String)], key: &str) -> Option<&'a str> {
+        envs.iter()
+            .find(|(name, _)| name == key)
+            .map(|(_, value)| value.as_str())
+    }
+
+    fn jobserver_client_env() -> Vec<(String, String)> {
+        vec![
+            ("PATH".to_string(), "/usr/bin".to_string()),
+            (
+                "MAKEFLAGS".to_string(),
+                "-j --jobserver-auth=8,9".to_string(),
+            ),
+            (
+                "CARGO_MAKEFLAGS".to_string(),
+                "-j --jobserver-fds=8,9 --jobserver-auth=8,9".to_string(),
+            ),
+            (
+                "CARGO_MANIFEST_DIR".to_string(),
+                "/tmp/workspace".to_string(),
+            ),
+        ]
+    }
+
+    fn test_lineage() -> crate::lineage::Lineage {
+        crate::lineage::Lineage {
+            daemon_pid: 100,
+            client_pid: Some(50),
+            session_id: Some("test-session".to_string()),
+        }
+    }
+
+    #[test]
+    fn apply_client_env_filters_stale_jobserver_vars_for_compiler_spawns() {
+        let env = jobserver_client_env();
+        let mut cmd = tokio::process::Command::new("env");
+        apply_client_env(&mut cmd, &Some(env), &test_lineage());
+
+        let envs = collect_command_env(cmd.as_std().get_envs());
+        assert_eq!(env_value(&envs, "PATH"), Some("/usr/bin"));
+        assert_eq!(
+            env_value(&envs, "CARGO_MANIFEST_DIR"),
+            Some("/tmp/workspace")
+        );
+        assert_eq!(env_value(&envs, "MAKEFLAGS"), None);
+        assert_eq!(env_value(&envs, "CARGO_MAKEFLAGS"), None);
+        assert_eq!(
+            env_value(&envs, crate::lineage::ENV_DAEMON_PID),
+            Some("100")
+        );
+    }
+
+    #[test]
+    fn apply_client_env_sync_filters_stale_jobserver_vars_for_tool_spawns() {
+        let env = jobserver_client_env();
+        let mut cmd = std::process::Command::new("env");
+        apply_client_env_sync(&mut cmd, Some(&env), &test_lineage());
+
+        let envs = collect_command_env(cmd.get_envs());
+        assert_eq!(env_value(&envs, "PATH"), Some("/usr/bin"));
+        assert_eq!(
+            env_value(&envs, "CARGO_MANIFEST_DIR"),
+            Some("/tmp/workspace")
+        );
+        assert_eq!(env_value(&envs, "MAKEFLAGS"), None);
+        assert_eq!(env_value(&envs, "CARGO_MAKEFLAGS"), None);
+        assert_eq!(
+            env_value(&envs, crate::lineage::ENV_DAEMON_PID),
+            Some("100")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes zackees/setup-soldr#83 downstream root cause after soldr v0.7.19.

## Summary
- filter `MAKEFLAGS` and `CARGO_MAKEFLAGS` when the daemon replays client env into compiler/tool child processes
- keep normal Cargo env, PATH, and zccache lineage propagation intact
- bump workspace version to `1.4.7` so the auto-release workflow publishes the fix after merge

## Why
Cargo jobserver env vars name process-local fds. zccache receives those vars over IPC from the wrapper client, but the daemon process does not receive the fds. Replaying them into daemon-spawned `rustc` processes causes the `failed to connect to jobserver` warnings seen through `soldr cargo`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p zccache-daemon`
- [x] `CARGO_TARGET_DIR=E:\codex-targets\zccache-jobserver cargo check -p zccache-daemon`
- [x] `CARGO_TARGET_DIR=E:\codex-targets\zccache-jobserver cargo test -p zccache-daemon stale_jobserver_vars`

Note: the first `cargo check -p zccache-daemon` attempt without `CARGO_TARGET_DIR` failed with Windows `os error 112` because C: had no free space; reran successfully with target artifacts on E:.