### PR TITLE
Fix macOS debug sidecar staging

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -193,11 +193,11 @@ runs:
         mkdir -p staging-debug
         copy_debug() {
           local src="$1"
-          if [ -e "$src" ]; then
+          if [ -e "$src" ] || [ -L "$src" ]; then
             if [ -d "$src" ]; then
-              cp -R "$src" staging-debug/
+              cp -RL "$src" staging-debug/
             else
-              cp "$src" staging-debug/
+              cp -L "$src" staging-debug/
             fi
           fi
         }

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -127,6 +127,16 @@ def test_stage_debug_tree_handles_dsym_directories(tmp_path: Path) -> None:
         )
 
 
+def test_build_target_dereferences_debug_sidecar_symlinks() -> None:
+    action = (
+        Path(__file__).resolve().parents[2]
+        / ".github/actions/build-target/action.yml"
+    ).read_text(encoding="utf-8")
+
+    assert 'cp -RL "$src" staging-debug/' in action
+    assert 'cp -L "$src" staging-debug/' in action
+
+
 def test_stage_debug_tree_skips_empty_input(tmp_path: Path) -> None:
     debug_input_dir = tmp_path / "staging-debug"
     output_dir = tmp_path / "output"


### PR DESCRIPTION
## Summary
- dereference debug sidecar symlinks while staging release artifacts
- add a regression assertion for the build-target action

## Context
The zccache 1.4.7 auto-release failed on the macOS build jobs after #251 because staging-debug contained .dSYM symlinks whose targets were outside the packaged staging tree. package_release.py then failed with FileNotFoundError while trying to copy staging-debug/zccache.dSYM.

## Test plan
- python -m pytest ci/tests/test_package_release.py
- git diff --check

Refs zackees/setup-soldr#83
Refs https://github.com/zackees/zccache/actions/runs/25864410894