### PR TITLE
ci(coverage): only report codecov on push to main

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,8 +3,6 @@ name: Coverage
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

- Removes the `pull_request` trigger from `.github/workflows/coverage.yml` so the Coverage workflow only fires on push to `main`.
- The workflow now runs codecov upload and `cargo llvm-cov` instrumentation exclusively for `main` branch updates — no longer on PRs, no longer on other branches, no scheduled runs (none were configured).
- **Behavior change:** PR coverage comments / status checks from Codecov will no longer appear on pull requests. Coverage will only update when commits land on `main`.

## File changed

`.github/workflows/coverage.yml`

### Before

```yaml
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]
```

### After

```yaml
on:
  push:
    branches: [main]
```

## Required status checks

`main` is not currently a protected branch (`gh api repos/zackees/zccache/branches/main/protection` returns 404 / "Branch not protected"), so this change does not break any required status check. If branch protection is added later, do not require the `Coverage` / `Code Coverage` check on PRs since it no longer runs there.

## Test plan

- [ ] Verify Actions run after merge: a push to `main` triggers the `Coverage` workflow.
- [ ] Open a no-op PR (or wait for the next one) and confirm the `Coverage` workflow does not fire.
- [ ] Confirm Codecov dashboard still receives reports from `main` pushes.

Generated with Claude Code