### PR TITLE
fix(ci): dylint driver must use rustup run, not cargo +<toolchain>

### DIFF
--- a/ci/build_dylint_driver.py
+++ b/ci/build_dylint_driver.py
@@ -27,8 +27,12 @@ def run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
 
 
 def rustc_host() -> str:
+    # Invoke rustc through `rustup run` so the call works even when PATH
+    # is fronted by shims (e.g. soldr) that do not understand the
+    # `+<toolchain>` directive that only the rustup `cargo`/`rustc`
+    # wrappers parse.
     output = subprocess.check_output(
-        ["rustc", f"+{TOOLCHAIN_CHANNEL}", "-vV"],
+        ["rustup", "run", TOOLCHAIN_CHANNEL, "rustc", "-vV"],
         text=True,
     )
     for line in output.splitlines():
@@ -122,7 +126,17 @@ def main() -> int:
             rpath = f"-C link-args=-Wl,-rpath,{toolchain_root / 'lib'}"
             env["RUSTFLAGS"] = f"{env.get('RUSTFLAGS', '')} {rpath}".strip()
 
-        run(["cargo", f"+{TOOLCHAIN_CHANNEL}", "build"], cwd=package, env=env)
+        # Use `rustup run` instead of `cargo +<toolchain>` because the
+        # cargo on PATH may be a shim (e.g. soldr's) that does not parse
+        # the `+<toolchain>` directive — that directive is only honored
+        # by the rustup-managed cargo wrapper. `rustup run` selects the
+        # toolchain explicitly and works regardless of which `cargo`
+        # comes first on PATH.
+        run(
+            ["rustup", "run", TOOLCHAIN_CHANNEL, "cargo", "build"],
+            cwd=package,
+            env=env,
+        )
 
         exe_suffix = ".exe" if os.name == "nt" else ""
         built_driver = package / "target" / "debug" / f"dylint_driver-{full_toolchain}{exe_suffix}"

--- a/ci/tests/test_build_dylint_driver.py
+++ b/ci/tests/test_build_dylint_driver.py
@@ -1,0 +1,51 @@
+"""Regression tests for ci/build_dylint_driver.py.
+
+The driver build must not invoke `cargo +<toolchain>` directly because
+CI runners front PATH with `cargo` shims (e.g. soldr's) that do not
+understand the `+<toolchain>` directive — only the rustup-managed
+`cargo` wrapper does. Use `rustup run <toolchain> cargo ...` instead so
+the toolchain is selected via rustup regardless of PATH ordering.
+
+See: failing CI run
+https://github.com/zackees/zccache/actions/runs/25892828715/job/76099518521
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ci import build_dylint_driver
+
+
+SCRIPT_PATH = Path(build_dylint_driver.__file__)
+SCRIPT_TEXT = SCRIPT_PATH.read_text(encoding="utf-8")
+
+
+def test_script_does_not_invoke_cargo_with_plus_toolchain() -> None:
+    """`cargo +<toolchain>` is broken under PATH shims; must use rustup run."""
+    assert 'f"+{TOOLCHAIN_CHANNEL}"' not in SCRIPT_TEXT, (
+        "build_dylint_driver.py must not use `cargo +<toolchain>` or "
+        "`rustc +<toolchain>` — those only work through the rustup wrapper, "
+        "and CI runners may have a non-rustup `cargo`/`rustc` shim first on "
+        "PATH. Use `rustup run <toolchain> cargo ...` instead."
+    )
+
+
+def test_script_invokes_cargo_via_rustup_run() -> None:
+    assert '"rustup", "run", TOOLCHAIN_CHANNEL, "cargo", "build"' in SCRIPT_TEXT, (
+        "build_dylint_driver.py should invoke cargo as "
+        "`rustup run <TOOLCHAIN_CHANNEL> cargo build`."
+    )
+
+
+def test_script_invokes_rustc_via_rustup_run() -> None:
+    assert '"rustup", "run", TOOLCHAIN_CHANNEL, "rustc", "-vV"' in SCRIPT_TEXT, (
+        "build_dylint_driver.py should invoke rustc as "
+        "`rustup run <TOOLCHAIN_CHANNEL> rustc -vV`."
+    )
+
+
+def test_toolchain_channel_is_pinned() -> None:
+    # Sanity: the constant exists and is a non-empty nightly channel.
+    channel = build_dylint_driver.TOOLCHAIN_CHANNEL
+    assert isinstance(channel, str) and channel.startswith("nightly-"), channel


### PR DESCRIPTION
## Summary

- The `Dylint > Build compatible Dylint driver` step on `main` was failing with `error: no such command: '+nightly-2026-03-26'`. The script invoked `cargo +<toolchain> build`, but PATH on the runner is fronted by the soldr cargo shim, which does not parse the `+<toolchain>` directive (only the rustup-managed `cargo`/`rustc` wrappers do).
- Switched both the cargo build and the host-triple probe in `ci/build_dylint_driver.py` to `rustup run <TOOLCHAIN_CHANNEL> ...`, which selects the toolchain explicitly via rustup regardless of which `cargo`/`rustc` is first on PATH.
- Added a regression check under `ci/tests/` that asserts the script no longer uses the broken `+<toolchain>` form and uses the canonical `rustup run` invocation instead.

Failing run: https://github.com/zackees/zccache/actions/runs/25892828715/job/76099518521

## Test plan

- [ ] `Dylint` workflow succeeds on this PR (in particular the `Build compatible Dylint driver` step).
- [ ] CI helper test suite (`uv run pytest ci/`) passes the new regression assertions.

Generated with Claude Code.
