### PR TITLE
feat(daemon): persist dep graph across daemon restarts

### DIFF
--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -1123,10 +1123,14 @@ async fn cmd_status(endpoint: &str, json: bool) -> ExitCode {
             {
                 let disk_info = if s.dep_graph_disk_size > 0 {
                     format!(
-                        "v{}, {} on disk",
+                        "v{}, persisted, {} on disk",
                         s.dep_graph_version,
                         format_bytes(s.dep_graph_disk_size)
                     )
+                } else if s.dep_graph_persisted {
+                    // Save has flushed at least once, but the file metadata
+                    // call lost a race (e.g. rename window) — still persisted.
+                    format!("v{}, persisted", s.dep_graph_version)
                 } else {
                     format!("v{}, not persisted", s.dep_graph_version)
                 };

--- a/crates/zccache-cli/src/python.rs
+++ b/crates/zccache-cli/src/python.rs
@@ -74,6 +74,8 @@ pub struct NativeDaemonStatus {
     dep_graph_version: u32,
     #[pyo3(get)]
     dep_graph_disk_size: u64,
+    #[pyo3(get)]
+    dep_graph_persisted: bool,
 }
 
 impl From<zccache_protocol::DaemonStatus> for NativeDaemonStatus {
@@ -101,6 +103,7 @@ impl From<zccache_protocol::DaemonStatus> for NativeDaemonStatus {
             cache_dir: value.cache_dir.display().to_string(),
             dep_graph_version: value.dep_graph_version,
             dep_graph_disk_size: value.dep_graph_disk_size,
+            dep_graph_persisted: value.dep_graph_persisted,
         }
     }
 }

--- a/crates/zccache-daemon/src/compile_journal.rs
+++ b/crates/zccache-daemon/src/compile_journal.rs
@@ -601,6 +601,7 @@ mod tests {
                 cache_dir: NormalizedPath::from(""),
                 dep_graph_version: 0,
                 dep_graph_disk_size: 0,
+                dep_graph_persisted: false,
             }),
             Response::LookupResult(LR::Miss),
             Response::StoreResult(SR::Stored),

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -396,6 +396,14 @@ struct SharedState {
     artifacts_loaded: AtomicBool,
     /// Fingerprint manager: tracks per-watch dirty state for `zccache fp` commands.
     fingerprint: FingerprintManager,
+    /// Whether the in-memory dep graph is backed by a persisted snapshot.
+    ///
+    /// Set to `true` when the graph is loaded from disk on startup (via
+    /// `set_dep_graph`) or when a periodic/shutdown save completes
+    /// successfully. Surfaced in `DaemonStatus.dep_graph_persisted` so the
+    /// CLI can distinguish "persisted graph" from "first-run, not yet flushed"
+    /// without inferring it from the on-disk file size.
+    dep_graph_persisted: AtomicBool,
 }
 
 /// Pre-computed compile request data for the request-level fast path.
@@ -654,6 +662,7 @@ impl DaemonServer {
                 artifact_store,
                 artifacts_loaded: AtomicBool::new(false),
                 fingerprint: FingerprintManager::new(),
+                dep_graph_persisted: AtomicBool::new(false),
             }),
         })
     }
@@ -667,10 +676,12 @@ impl DaemonServer {
     /// Replace the dependency graph with a pre-loaded one.
     ///
     /// Must be called before `run()` (while this is the only Arc holder).
+    /// Marks the graph as persisted because it was restored from disk.
     pub fn set_dep_graph(&mut self, graph: zccache_depgraph::DepGraph) {
         let state =
             Arc::get_mut(&mut self.state).expect("set_dep_graph must be called before run()");
         state.dep_graph = graph;
+        state.dep_graph_persisted.store(true, Ordering::Release);
     }
 
     /// Get a snapshot of the phase profiler (for benchmarks).
@@ -879,7 +890,10 @@ impl DaemonServer {
                         std::fs::create_dir_all(parent).ok();
                     }
                     match zccache_depgraph::save_to_file(&state.dep_graph, &path) {
-                        Ok(()) => tracing::debug!("periodic depgraph save"),
+                        Ok(()) => {
+                            state.dep_graph_persisted.store(true, Ordering::Release);
+                            tracing::debug!("periodic depgraph save");
+                        }
                         Err(e) => tracing::warn!("periodic depgraph save failed: {e}"),
                     }
                 }
@@ -917,10 +931,15 @@ impl DaemonServer {
                         std::fs::create_dir_all(parent).ok();
                     }
                     match zccache_depgraph::save_to_file(&self.state.dep_graph, &path) {
-                        Ok(()) => tracing::info!(
-                            elapsed_ms = start.elapsed().as_millis() as u64,
-                            "depgraph saved"
-                        ),
+                        Ok(()) => {
+                            self.state
+                                .dep_graph_persisted
+                                .store(true, Ordering::Release);
+                            tracing::info!(
+                                elapsed_ms = start.elapsed().as_millis() as u64,
+                                "depgraph saved"
+                            );
+                        }
                         Err(e) => tracing::warn!("depgraph save failed: {e}"),
                     }
 
@@ -1169,6 +1188,7 @@ async fn handle_connection(
                             .metadata()
                             .map(|m| m.len())
                             .unwrap_or(0),
+                        dep_graph_persisted: state.dep_graph_persisted.load(Ordering::Acquire),
                     }),
                     None,
                 )

--- a/crates/zccache-daemon/tests/depgraph_persistence_test.rs
+++ b/crates/zccache-daemon/tests/depgraph_persistence_test.rs
@@ -1,0 +1,237 @@
+//! Integration test: dep graph persists across daemon restarts.
+//!
+//! Verifies the fix for issue #262 — fresh daemon starts no longer have to
+//! re-seed the dep graph by recompiling once. After a graceful shutdown the
+//! daemon flushes the dep graph to `<cache_dir>/depgraph/depgraph.bin`; the
+//! next daemon process loads it back and reports `dep_graph_persisted = true`
+//! over the IPC `Status` response.
+//!
+//! Run: soldr cargo test -p zccache-daemon --test depgraph_persistence_test -- --ignored --nocapture
+
+use std::sync::{Arc, Mutex};
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+use zccache_core::NormalizedPath;
+use zccache_daemon::DaemonServer;
+use zccache_depgraph::{CompileContext, DepGraph, IncludeSearchPaths};
+use zccache_protocol::{DaemonStatus, Request, Response};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Serialize tests that depend on the process-global `ZCCACHE_CACHE_DIR` env
+/// variable. They cannot run in parallel because the daemon reads the cache
+/// dir on every IPC request, and other tests in this binary need their own
+/// view.
+static ENV_SERIAL: Mutex<()> = Mutex::new(());
+
+struct CacheDirGuard {
+    _tmp: tempfile::TempDir,
+    prev: Option<std::ffi::OsString>,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+impl CacheDirGuard {
+    fn new() -> Self {
+        let lock = ENV_SERIAL.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::TempDir::new().unwrap();
+        let prev = std::env::var_os(zccache_core::config::CACHE_DIR_ENV);
+        std::env::set_var(zccache_core::config::CACHE_DIR_ENV, tmp.path());
+        Self {
+            _tmp: tmp,
+            prev,
+            _lock: lock,
+        }
+    }
+}
+
+impl Drop for CacheDirGuard {
+    fn drop(&mut self) {
+        match self.prev.take() {
+            Some(v) => std::env::set_var(zccache_core::config::CACHE_DIR_ENV, v),
+            None => std::env::remove_var(zccache_core::config::CACHE_DIR_ENV),
+        }
+    }
+}
+
+async fn start_daemon(endpoint: &str) -> (JoinHandle<()>, Arc<Notify>) {
+    let mut server = DaemonServer::bind(endpoint).unwrap();
+    let shutdown = server.shutdown_handle();
+    let handle = tokio::spawn(async move {
+        server.run(0).await.unwrap();
+    });
+    (handle, shutdown)
+}
+
+async fn start_daemon_with_preloaded_graph(
+    endpoint: &str,
+    graph: DepGraph,
+) -> (JoinHandle<()>, Arc<Notify>) {
+    let mut server = DaemonServer::bind(endpoint).unwrap();
+    server.set_dep_graph(graph);
+    let shutdown = server.shutdown_handle();
+    let handle = tokio::spawn(async move {
+        server.run(0).await.unwrap();
+    });
+    (handle, shutdown)
+}
+
+async fn get_status(endpoint: &str) -> DaemonStatus {
+    let mut client = zccache_ipc::connect(endpoint).await.unwrap();
+    client.send(&Request::Status).await.unwrap();
+    match client.recv().await.unwrap() {
+        Some(Response::Status(s)) => s,
+        other => panic!("unexpected response: {other:?}"),
+    }
+}
+
+fn make_ctx(source: &str) -> CompileContext {
+    CompileContext {
+        source_file: NormalizedPath::from(source),
+        include_search: IncludeSearchPaths::default(),
+        defines: Vec::new(),
+        flags: Vec::new(),
+        force_includes: Vec::new(),
+        unknown_flags: Vec::new(),
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+/// Fresh daemon with no on-disk snapshot reports `dep_graph_persisted = false`.
+#[tokio::test]
+#[ignore] // integration: starts real daemon, mutates ZCCACHE_CACHE_DIR
+async fn fresh_daemon_reports_not_persisted() {
+    let _guard = CacheDirGuard::new();
+    let endpoint = zccache_ipc::unique_test_endpoint();
+    let (handle, shutdown) = start_daemon(&endpoint).await;
+
+    let status = get_status(&endpoint).await;
+    assert!(
+        !status.dep_graph_persisted,
+        "fresh daemon must report dep_graph_persisted = false, got: {status:?}",
+    );
+    assert_eq!(status.dep_graph_disk_size, 0);
+    assert_eq!(status.dep_graph_version, zccache_depgraph::DEPGRAPH_VERSION);
+    // Issue #262 explicitly checked that the (cached, cold, non-cacheable)
+    // counters coexist with the persisted state.
+    assert_eq!(status.cache_hits, 0);
+    assert_eq!(status.cache_misses, 0);
+    assert_eq!(status.non_cacheable, 0);
+
+    shutdown.notify_one();
+    handle.await.unwrap();
+}
+
+/// Daemon that was started with a preloaded graph immediately reports persisted=true.
+#[tokio::test]
+#[ignore]
+async fn preloaded_graph_reports_persisted() {
+    let _guard = CacheDirGuard::new();
+
+    // Pre-populate a graph and save it (so the on-disk file exists too).
+    let graph = DepGraph::new();
+    let _ = graph.register(make_ctx("/src/main.cpp"));
+    let path = zccache_depgraph::depgraph_file_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    zccache_depgraph::save_to_file(&graph, &path).unwrap();
+
+    // Re-load to simulate the daemon's own startup path.
+    let loaded = zccache_depgraph::load_from_file(&path).unwrap();
+    assert_eq!(loaded.stats().context_count, 1);
+
+    let endpoint = zccache_ipc::unique_test_endpoint();
+    let (handle, shutdown) = start_daemon_with_preloaded_graph(&endpoint, loaded).await;
+
+    let status = get_status(&endpoint).await;
+    assert!(
+        status.dep_graph_persisted,
+        "preloaded daemon must report dep_graph_persisted = true, got: {status:?}",
+    );
+    assert!(
+        status.dep_graph_disk_size > 0,
+        "snapshot file must be visible on disk, got size 0",
+    );
+    assert_eq!(status.dep_graph_contexts, 1, "context survived the load");
+    assert_eq!(status.cache_hits, 0);
+    assert_eq!(status.cache_misses, 0);
+    assert_eq!(status.non_cacheable, 0);
+
+    shutdown.notify_one();
+    handle.await.unwrap();
+}
+
+/// Full lifecycle: daemon-with-graph → graceful shutdown (flushes snapshot)
+/// → snapshot file on disk → new daemon with the same cache_dir loads it
+/// → reports `dep_graph_persisted = true` and the graph contents survive.
+///
+/// We use a *separate* cache_dir for the second daemon and copy the snapshot
+/// file across to avoid redb index lock contention on Windows when the first
+/// daemon's background tasks haven't fully drained.
+#[tokio::test]
+#[ignore]
+async fn shutdown_save_restore_roundtrip() {
+    // ── Phase 1: daemon with preloaded graph, then shutdown ─────────
+    let guard1 = CacheDirGuard::new();
+    let graph = DepGraph::new();
+    let _ = graph.register(make_ctx("/src/foo.cpp"));
+    let _ = graph.register(make_ctx("/src/bar.cpp"));
+    assert_eq!(graph.stats().context_count, 2);
+
+    let endpoint1 = zccache_ipc::unique_test_endpoint();
+    let (handle1, shutdown1) = start_daemon_with_preloaded_graph(&endpoint1, graph).await;
+
+    let status1 = get_status(&endpoint1).await;
+    assert_eq!(status1.dep_graph_contexts, 2);
+    assert!(
+        status1.dep_graph_persisted,
+        "preloaded daemon should already report persisted=true",
+    );
+
+    let saved_path = zccache_depgraph::depgraph_file_path();
+    shutdown1.notify_one();
+    handle1.await.unwrap();
+
+    assert!(
+        saved_path.exists(),
+        "shutdown should have flushed depgraph to {}",
+        saved_path.display(),
+    );
+    let saved_bytes = std::fs::read(&saved_path).unwrap();
+    drop(guard1); // Release ZCCACHE_CACHE_DIR before the next phase claims it.
+
+    // ── Phase 2: brand-new cache_dir, plant the saved snapshot, start a
+    //    completely fresh daemon → load_from_file → report persisted. ───
+    let guard2 = CacheDirGuard::new();
+    let new_path = zccache_depgraph::depgraph_file_path();
+    if let Some(parent) = new_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(&new_path, &saved_bytes).unwrap();
+
+    let loaded = zccache_depgraph::load_from_file(&new_path).unwrap();
+    assert_eq!(loaded.stats().context_count, 2, "loaded graph survived");
+
+    let endpoint2 = zccache_ipc::unique_test_endpoint();
+    let (handle2, shutdown2) = start_daemon_with_preloaded_graph(&endpoint2, loaded).await;
+    let status2 = get_status(&endpoint2).await;
+
+    assert!(
+        status2.dep_graph_persisted,
+        "restarted daemon must report dep_graph_persisted = true after loading from disk",
+    );
+    assert_eq!(
+        status2.dep_graph_contexts, 2,
+        "restarted graph keeps both contexts",
+    );
+    // (0 cached, 0 cold, 0 non-cacheable) counters and persisted state coexist.
+    assert_eq!(status2.cache_hits, 0);
+    assert_eq!(status2.cache_misses, 0);
+    assert_eq!(status2.non_cacheable, 0);
+    assert!(status2.dep_graph_disk_size > 0);
+
+    shutdown2.notify_one();
+    handle2.await.unwrap();
+    drop(guard2);
+}

--- a/crates/zccache-protocol/src/lib.rs
+++ b/crates/zccache-protocol/src/lib.rs
@@ -10,7 +10,7 @@ pub use messages::*;
 /// Protocol version number. Bump this when the wire format changes:
 /// new/removed/reordered enum variants or struct field changes.
 /// Patch releases that don't change the protocol keep the same version.
-pub const PROTOCOL_VERSION: u32 = 6;
+pub const PROTOCOL_VERSION: u32 = 7;
 
 use bytes::{Buf, BufMut, BytesMut};
 

--- a/crates/zccache-protocol/src/messages.rs
+++ b/crates/zccache-protocol/src/messages.rs
@@ -270,6 +270,12 @@ pub struct DaemonStatus {
     pub dep_graph_version: u32,
     /// Size of the depgraph snapshot file on disk (0 = not persisted).
     pub dep_graph_disk_size: u64,
+    /// Whether the in-memory dep graph is backed by a persisted snapshot.
+    ///
+    /// `true` if the graph was loaded from disk on startup OR has been
+    /// successfully written to disk since startup (periodic save or shutdown).
+    /// `false` on a fresh daemon that has not yet flushed its first snapshot.
+    pub dep_graph_persisted: bool,
 }
 
 /// Result of a cache lookup.
@@ -423,6 +429,7 @@ mod tests {
             cache_dir: "/home/user/.zccache".into(),
             dep_graph_version: 1,
             dep_graph_disk_size: 2_500_000,
+            dep_graph_persisted: true,
         };
         roundtrip(&status);
     }
@@ -659,14 +666,15 @@ mod tests {
             cache_dir: "".into(),
             dep_graph_version: 0,
             dep_graph_disk_size: 0,
+            dep_graph_persisted: false,
         };
         roundtrip(&with_version);
     }
 
     // Compile-time check: PROTOCOL_VERSION must be positive.
     const _: () = assert!(crate::PROTOCOL_VERSION > 0);
-    // Compile-time check: PROTOCOL_VERSION == 6 after ListRustArtifacts addition.
-    const _FINGERPRINT_VERSION: () = assert!(crate::PROTOCOL_VERSION == 6);
+    // Compile-time check: PROTOCOL_VERSION == 7 after dep_graph_persisted addition.
+    const _FINGERPRINT_VERSION: () = assert!(crate::PROTOCOL_VERSION == 7);
 
     #[test]
     fn fingerprint_check_roundtrip() {

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -600,7 +600,7 @@ v1 is deliberately minimal. The goal is a correct, useful tool for the most comm
 **Consequences:**
 - Disk usage is slightly higher (~1x metadata overhead per artifact).
 - `zccache clear` must delete `.meta` files alongside output files (already handled).
-- Dep graph is NOT persisted — cold compiles still re-discover include dependencies. Only the artifact data survives restarts.
+- Dep graph IS persisted across daemon restarts (issue #262, `<cache_dir>/depgraph/depgraph.bin`). The daemon flushes on graceful shutdown and every 5 minutes while running; the next start loads the snapshot, rejects any version mismatch (`DEPGRAPH_VERSION`), and falls back to an empty graph on any other error. `DaemonStatus.dep_graph_persisted` exposes this state to `zccache status`.
 
 ---
 

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -115,6 +115,17 @@ The in-memory metadata cache is **not persisted**. After a daemon restart, the c
 
 This is a deliberate design choice. Persisting the metadata cache would add complexity (serialization, staleness on restart) for marginal benefit — the cache warms up within one full build.
 
+### Dep Graph Recovery
+
+The dep graph **is** persisted across daemon restarts (issue #262). At graceful shutdown, and again every 5 minutes while running, the daemon flushes the current `DepGraph` to `<cache_dir>/depgraph/depgraph.bin` using a rkyv zero-copy snapshot. The on-disk format carries a magic header (`ZCDG`) plus a `DEPGRAPH_VERSION` (currently 4) so old snapshots written by an incompatible build are rejected rather than misread.
+
+On startup, the daemon attempts to load the snapshot:
+
+- **Success:** the in-memory graph is populated from the file and `DaemonStatus.dep_graph_persisted` reports `true`. CI runs that restore `<cache_dir>` from a cache store skip the cold-seed compile entirely.
+- **Missing file / `VersionMismatch` / corrupt bytes:** a warning is logged and the daemon starts with an empty graph (the pre-fix behavior).
+
+The `dep_graph_persisted` flag is also flipped to `true` when a periodic or shutdown save completes successfully, so a daemon that started cold but has since flushed reports itself as persisted. `zccache status` surfaces this as either `vN, persisted, X.YZ MB on disk` or `vN, not persisted`.
+
 ### Artifact Store Recovery
 
 **Orphaned temp directories:** On startup, `{cache_root}/tmp/` is deleted recursively. This removes any incomplete artifact writes from a previous crash.


### PR DESCRIPTION
Closes #262.

## Summary

- Surfaces authoritative dep-graph persistence state via the existing `Status` IPC response (zero new roundtrips). `SharedState.dep_graph_persisted` (AtomicBool) is set to `true` when `set_dep_graph()` preloads a graph from disk and when the periodic / shutdown save succeeds.
- `zccache status` now renders `vN, persisted, X.YZ MB on disk` or `vN, not persisted` using the new flag (no more disk-size proxy that races with first-save timing).
- Bumps `PROTOCOL_VERSION` 6 -> 7 because `DaemonStatus` gained `dep_graph_persisted: bool`. Compile-time `_FINGERPRINT_VERSION` assert updated to match.
- On-disk format already lives at `<cache_dir>/depgraph/depgraph.bin` with magic header `ZCDG` + `DEPGRAPH_VERSION = 4`; missing / wrong-version / corrupt files log a warning and start with an empty graph (unchanged behavior, now documented in `docs/architecture/runtime.md`).

## On-disk format & version handling

| Outcome | Behavior |
|---|---|
| Success | In-memory graph populated, `dep_graph_persisted = true` |
| Missing file | Warning logged, empty graph, `dep_graph_persisted = false` |
| `VersionMismatch` | Warning logged, empty graph, `dep_graph_persisted = false` |
| Corrupt bytes | Warning logged, empty graph, `dep_graph_persisted = false` |

After any successful periodic / shutdown save the flag flips to `true`, so a cold-started daemon that has since flushed reports itself as persisted.

## Tests

New `crates/zccache-daemon/tests/depgraph_persistence_test.rs` covers:

- [x] `fresh_daemon_reports_not_persisted` - fresh daemon, no snapshot file -> `persisted = false`
- [x] `preloaded_graph_reports_persisted` - daemon started with preloaded graph -> `persisted = true`, disk size > 0
- [x] `shutdown_save_restore_roundtrip` - daemon1 shutdown flushes snapshot, copy bytes to a new cache_dir, daemon2 loads it -> `persisted = true`, both contexts survive, `(0 cached, 0 cold, 0 non-cacheable)` counters preserved

## Test plan

- [x] `soldr cargo fmt --all`
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings`
- [x] `soldr cargo test --workspace` (all unit tests pass)
- [x] `soldr cargo test -p zccache-daemon --test depgraph_persistence_test -- --ignored --nocapture` (3/3 pass)
- [x] Verified `(0,0,0)` cache counters coexist with persisted state in the integration tests

## Protocol bump

`PROTOCOL_VERSION` bumped 6 -> 7 (DD-018). Old CLIs talking to a new daemon (or vice versa) will be rejected by the framing-layer version check, consistent with every other wire-format change.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>