### PR TITLE
feat(compiler): support clang-cl / MSVC argument parsing on Windows

### DIFF
--- a/crates/zccache-compiler/src/lib.rs
+++ b/crates/zccache-compiler/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod arduino;
 pub mod parse_archiver;
 pub mod parse_linker;
+pub mod parse_msvc;
 pub mod parse_rustfmt;
 pub mod response_file;
 pub mod strict_paths;
@@ -168,6 +169,12 @@ pub fn detect_family(compiler: &str) -> CompilerFamily {
         || name.starts_with("clippy-driver-")
     {
         CompilerFamily::Rustc
+    } else if is_clang_cl_name(name) {
+        // `clang-cl` speaks MSVC argument syntax. It must be classified as
+        // Msvc so the MSVC parser handles `/Fo`, `/c`, etc. Misclassifying
+        // it as Clang caused issue #261 (Windows builds with 0 cached / 0
+        // cold / 0 non-cacheable despite total > 0).
+        CompilerFamily::Msvc
     } else if name.contains("clang") || name == "emcc" || name == "em++" {
         CompilerFamily::Clang
     } else if name.eq_ignore_ascii_case("cl") {
@@ -175,6 +182,15 @@ pub fn detect_family(compiler: &str) -> CompilerFamily {
     } else {
         CompilerFamily::Gcc
     }
+}
+
+/// Whether the executable basename refers to clang-cl (the MSVC-syntax driver).
+///
+/// Matches `clang-cl`, `clang-cl-17`, `Clang-CL.EXE`, etc. `name` is the
+/// stem with any final `.<ext>` already stripped by `detect_family`.
+fn is_clang_cl_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower == "clang-cl" || lower.starts_with("clang-cl-")
 }
 
 /// Check if a path looks like a C/C++ source file.
@@ -292,6 +308,19 @@ pub fn parse_invocation(compiler: &str, args: &[String]) -> ParsedInvocation {
     // Rustc has a completely different invocation model â€” dispatch early.
     if family == CompilerFamily::Rustc {
         return parse_rustc_invocation(compiler, args);
+    }
+
+    // MSVC / clang-cl use Windows-style slash flags (`/c`, `/Fo:foo.obj`).
+    // Dispatch to the MSVC classifier on:
+    //   1. Detected MSVC family (cl.exe, clang-cl.exe), OR
+    //   2. Any compiler whose argv contains MSVC-style flags. This catches
+    //      the case where a build system invokes `clang` (not `clang-cl`)
+    //      but passes `/c` and `/Fo`, which still triggers MSVC mode in
+    //      clang. Without this dispatch the GCC parser would silently drop
+    //      `/c` and the invocation would be misclassified as a link step.
+    //      Issue #261.
+    if family == CompilerFamily::Msvc || parse_msvc::looks_like_msvc_args(args) {
+        return parse_msvc::parse_msvc_invocation(compiler, args, family);
     }
 
     let mut has_c_flag = false;
@@ -2167,5 +2196,230 @@ mod tests {
             }
             other => panic!("expected cacheable, got: {other:?}"),
         }
+    }
+
+    // ─── clang-cl / MSVC dispatch (issue #261) ───────────────────────────
+
+    #[test]
+    fn detect_clang_cl_is_msvc() {
+        // clang-cl speaks MSVC argv syntax — must be classified as Msvc so
+        // the MSVC parser handles `/Fo`, `/c`, etc. Issue #261.
+        assert_eq!(detect_family("clang-cl"), CompilerFamily::Msvc);
+        assert_eq!(detect_family("clang-cl.exe"), CompilerFamily::Msvc);
+        assert_eq!(detect_family("Clang-CL.EXE"), CompilerFamily::Msvc);
+        assert_eq!(
+            detect_family("C:\\Program Files\\LLVM\\bin\\clang-cl.exe"),
+            CompilerFamily::Msvc
+        );
+        // Versioned clang-cl.
+        assert_eq!(detect_family("clang-cl-17"), CompilerFamily::Msvc);
+        assert_eq!(detect_family("clang-cl-18.exe"), CompilerFamily::Msvc);
+        // Plain clang remains Clang, not Msvc.
+        assert_eq!(detect_family("clang"), CompilerFamily::Clang);
+        assert_eq!(detect_family("clang++"), CompilerFamily::Clang);
+        assert_eq!(detect_family("clang-17"), CompilerFamily::Clang);
+    }
+
+    #[test]
+    fn clang_cl_compile_classified_as_cacheable() {
+        // The exact symptom from issue #261: clang-cl invocations with
+        // MSVC-style `/c`, `/Fo:`, etc. must land in the Cacheable bucket,
+        // not be silently dropped.
+        let result = parse_invocation("clang-cl", &args(&["/c", "/Fo:hello.obj", "hello.c"]));
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.source_file, NormalizedPath::new("hello.c"));
+                assert_eq!(c.output_file, NormalizedPath::new("hello.obj"));
+                assert_eq!(c.family, CompilerFamily::Msvc);
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cl_compile_classified_as_cacheable() {
+        // Plain `cl.exe` (not clang-cl) with MSVC flags.
+        let result = parse_invocation(
+            "cl.exe",
+            &args(&["/c", "/EHsc", "/std:c++17", "/Fo:hello.obj", "hello.cpp"]),
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.source_file, NormalizedPath::new("hello.cpp"));
+                assert_eq!(c.output_file, NormalizedPath::new("hello.obj"));
+                assert_eq!(c.family, CompilerFamily::Msvc);
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clang_with_msvc_style_args_falls_back_to_msvc_parser() {
+        // Some build systems invoke plain `clang` but pass `/c` and `/Fo`
+        // (which clang understands when targeting MSVC). Without the
+        // heuristic dispatch the GCC parser silently drops `/c` and the
+        // invocation gets misclassified as a link.
+        let result = parse_invocation("clang", &args(&["/c", "/Fo:hello.obj", "hello.c"]));
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.source_file, NormalizedPath::new("hello.c"));
+                assert_eq!(c.output_file, NormalizedPath::new("hello.obj"));
+                // family stays Clang because the executable is `clang`,
+                // even though we dispatch to the MSVC parser.
+                assert_eq!(c.family, CompilerFamily::Clang);
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clang_cl_no_c_flag_classified_as_non_cacheable() {
+        // Link-only clang-cl invocation must end up in `non-cacheable`,
+        // not be silently dropped.
+        let result = parse_invocation("clang-cl", &args(&["hello.c", "/Fe:hello.exe"]));
+        assert!(matches!(result, ParsedInvocation::NonCacheable { .. }));
+    }
+
+    #[test]
+    fn clang_cl_help_query_is_non_cacheable() {
+        let result = parse_invocation("clang-cl", &args(&["/?"]));
+        assert!(matches!(result, ParsedInvocation::NonCacheable { .. }));
+    }
+
+    #[test]
+    fn clang_cl_version_query_is_non_cacheable() {
+        let result = parse_invocation("clang-cl", &args(&["--version"]));
+        assert!(matches!(result, ParsedInvocation::NonCacheable { .. }));
+    }
+
+    #[test]
+    fn clang_cl_with_d_macro_space_separated() {
+        // `/D NAME=VAL` must consume both elements so the value isn't
+        // misclassified as a source.
+        let result = parse_invocation(
+            "clang-cl",
+            &args(&["/c", "/D", "NDEBUG=1", "/Fo:hello.obj", "hello.c"]),
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.source_file, NormalizedPath::new("hello.c"));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clang_cl_with_i_path_containing_spaces() {
+        let result = parse_invocation(
+            "clang-cl",
+            &args(&[
+                "/c",
+                "/I",
+                "C:\\Program Files\\include",
+                "/Fo:hello.obj",
+                "hello.c",
+            ]),
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.source_file, NormalizedPath::new("hello.c"));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clang_cl_mixed_dash_and_slash_flags() {
+        // `cc-rs` produces invocations with both `-D` and `/c` mixed.
+        let result = parse_invocation(
+            "clang-cl",
+            &args(&["/c", "-DFOO=1", "/DBAR=2", "/Fo:hello.obj", "hello.c"]),
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.source_file, NormalizedPath::new("hello.c"));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clang_cl_unknown_slash_flag_preserved_not_dropped() {
+        let result = parse_invocation(
+            "clang-cl",
+            &args(&["/c", "/XYZUnknown", "/Fo:hello.obj", "hello.c"]),
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert!(c.unknown_flags.contains(&"/XYZUnknown".to_string()));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clang_cl_multi_file_classified() {
+        let result = parse_invocation("clang-cl", &args(&["/c", "a.c", "b.c"]));
+        match result {
+            ParsedInvocation::MultiFile { compilations, .. } => {
+                assert_eq!(compilations.len(), 2);
+                assert_eq!(compilations[0].output_file, NormalizedPath::new("a.obj"));
+                assert_eq!(compilations[1].output_file, NormalizedPath::new("b.obj"));
+            }
+            other => panic!("expected MultiFile, got: {other:?}"),
+        }
+    }
+
+    // ─── Invariant: classification is total (issue #261) ─────────────────
+    //
+    // For every parseable invocation we must return exactly one of
+    // `Cacheable`, `MultiFile`, or `NonCacheable`. Nothing silently drops.
+    // The daemon's `total_compilations` counter must always match
+    // `cached + cold + non_cacheable + errors`. This is enforced at the
+    // daemon layer; here we just guarantee the parser never produces a
+    // shape that lets the daemon skip classification.
+
+    fn assert_classifies(compiler: &str, argv: &[&str]) {
+        let result = parse_invocation(compiler, &args(argv));
+        match result {
+            ParsedInvocation::Cacheable(_)
+            | ParsedInvocation::MultiFile { .. }
+            | ParsedInvocation::NonCacheable { .. } => (),
+        }
+    }
+
+    #[test]
+    fn invariant_every_clang_cl_shape_classifies() {
+        // No matter what we throw at clang-cl, the parser MUST produce one
+        // of the three classification outcomes. This prevents the issue
+        // #261 silent-drop regression from ever reappearing.
+        assert_classifies("clang-cl", &["/c", "/Fo:foo.obj", "foo.c"]);
+        assert_classifies("clang-cl", &["-c", "-o", "foo.obj", "foo.c"]);
+        assert_classifies("clang-cl", &["/c", "foo.c", "bar.cpp"]);
+        assert_classifies("clang-cl", &[]);
+        assert_classifies("clang-cl", &["--version"]);
+        assert_classifies("clang-cl", &["/?"]);
+        assert_classifies("clang-cl", &["/c"]);
+        assert_classifies("clang-cl", &["foo.c"]);
+        assert_classifies("clang-cl", &["/E", "foo.c"]);
+        assert_classifies(
+            "clang-cl",
+            &[
+                "/c",
+                "/EHsc",
+                "/std:c++17",
+                "/MD",
+                "/W4",
+                "/Zi",
+                "/Fd:vc.pdb",
+                "/Fo:hello.obj",
+                "/showIncludes",
+                "hello.cpp",
+            ],
+        );
+        assert_classifies(
+            "C:\\Program Files\\LLVM\\bin\\clang-cl.exe",
+            &["/c", "/Fo:foo.obj", "foo.c"],
+        );
     }
 }

--- a/crates/zccache-compiler/src/parse_msvc.rs
+++ b/crates/zccache-compiler/src/parse_msvc.rs
@@ -1,0 +1,805 @@
+//! MSVC / clang-cl invocation classifier.
+//!
+//! This module handles the **cacheability classification** for compilers
+//! that speak MSVC argument syntax (`cl.exe`, `clang-cl.exe`).
+//!
+//! It is intentionally separate from `zccache-depgraph::msvc_args`, which is
+//! the much heavier parser that extracts include search paths, defines, and
+//! cache-key inputs for an already-classified compilation.
+//!
+//! The job here is much narrower:
+//!   1. Determine whether the invocation is a compile-only step (has `/c`).
+//!   2. Locate the input source file(s).
+//!   3. Locate the output object path (`/Fo:` etc.).
+//!   4. Reject obvious non-cacheable shapes (link-only, `/E`, `/help`, ...).
+//!
+//! Both `cl.exe` and `clang-cl.exe` accept many flags with either `/` or `-`
+//! prefix; we treat both prefixes identically. We also accept the GCC-style
+//! `-o`/`-c` aliases that clang-cl honors so that mixed-style invocations
+//! (very common in `cc-rs`) classify correctly.
+
+use std::sync::Arc;
+
+use zccache_core::NormalizedPath;
+
+use crate::{CacheableCompilation, CompilerFamily, ParsedInvocation};
+
+/// Source file extensions recognised by the MSVC / clang-cl parser.
+///
+/// Kept aligned with `zccache_depgraph::msvc_args::is_source_file`. Comparison
+/// is case-insensitive because Windows users frequently use `.C`, `.CPP` etc.
+const MSVC_SOURCE_EXTENSIONS: &[&str] = &[
+    "c", "cc", "cpp", "cxx", "c++", "cppm", "ixx", "m", "mm", "i", "ii", "s", "sx",
+];
+
+/// Returns `true` when the argument looks like a flag (either prefix style).
+fn is_flag(arg: &str) -> bool {
+    arg.starts_with('/') || arg.starts_with('-')
+}
+
+/// Strip either `/` or `-` prefix and return the remainder.
+fn flag_body(arg: &str) -> &str {
+    arg.strip_prefix('/')
+        .or_else(|| arg.strip_prefix('-'))
+        .unwrap_or(arg)
+}
+
+/// Returns `Some(rest)` when `arg` matches `/<head><rest>` or `-<head><rest>`.
+fn strip_flag<'a>(arg: &'a str, head: &str) -> Option<&'a str> {
+    if let Some(rest) = arg.strip_prefix('/') {
+        return rest.strip_prefix(head);
+    }
+    if let Some(rest) = arg.strip_prefix('-') {
+        return rest.strip_prefix(head);
+    }
+    None
+}
+
+/// Returns `true` when `arg` is exactly `/X` or `-X`.
+fn is_exact_flag(arg: &str, head: &str) -> bool {
+    matches!(arg.strip_prefix('/'), Some(rest) if rest == head)
+        || matches!(arg.strip_prefix('-'), Some(rest) if rest == head)
+}
+
+/// Detect whether a file path looks like a C/C++ source file.
+fn is_msvc_source_file(path: &str) -> bool {
+    if let Some(ext) = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+    {
+        let lower = ext.to_ascii_lowercase();
+        MSVC_SOURCE_EXTENSIONS.contains(&lower.as_str())
+    } else {
+        false
+    }
+}
+
+/// Heuristic for detecting MSVC-style flags in an argv list.
+///
+/// Used by the family dispatcher to fall back to the MSVC classifier when
+/// `clang-cl` is invoked with `/c`, `/Fo`, `/std:c++17`, etc.
+///
+/// Anything matching `/<letter>...` that is not a Unix-style filesystem path
+/// (`/usr/include`, `/path/to/foo`) counts as an MSVC flag. We are deliberately
+/// conservative: a single `/showIncludes` or `/Fo<x>` is enough.
+#[must_use]
+pub fn looks_like_msvc_args(args: &[String]) -> bool {
+    args.iter().any(|arg| {
+        if !arg.starts_with('/') {
+            return false;
+        }
+        // Reject Unix paths like /usr/include or /opt/foo: they contain '/'
+        // after the first character. MSVC flags are dense (`/Fo:`, `/EHsc`).
+        let rest = &arg[1..];
+        if rest.is_empty() {
+            return false;
+        }
+        // First character must be alpha (MSVC flags always start with a letter).
+        let first = rest.chars().next().unwrap_or(' ');
+        if !first.is_ascii_alphabetic() {
+            return false;
+        }
+        // Reject if it looks like an absolute Unix path: `/abs/...` where the
+        // first segment is short and the path keeps going.  We treat
+        // `/Foobar:abc` (no extra `/`) as a flag, and `/usr/include` as a path.
+        // Concretely: if there's a `/` later in the arg, treat as a path.
+        if rest.contains('/') {
+            return false;
+        }
+        true
+    })
+}
+
+/// Default output for an MSVC-style compile with no explicit `/Fo` flag.
+///
+/// MSVC emits `<stem>.obj` next to the source by default; we follow the same
+/// convention as the GCC path and use `<stem>.obj` in the cwd. This keeps the
+/// daemon's output reconstruction logic uniform.
+fn msvc_default_output(source: &str) -> String {
+    let stem = std::path::Path::new(source)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("a");
+    format!("{stem}.obj")
+}
+
+/// Parse an MSVC / clang-cl compiler invocation for cacheability.
+///
+/// `compiler` is the executable path. `family` should be `CompilerFamily::Msvc`
+/// or, for `clang-cl`, may be `CompilerFamily::Clang` — both are accepted.
+///
+/// The caller is expected to have already expanded `@response_files`.
+#[must_use]
+pub fn parse_msvc_invocation(
+    compiler: &str,
+    args: &[String],
+    family: CompilerFamily,
+) -> ParsedInvocation {
+    let mut has_c_flag = false;
+    let mut output_file: Option<String> = None;
+    let mut source_files: Vec<(String, usize)> = Vec::new();
+    let mut unknown_flags: Vec<String> = Vec::new();
+    // Pending source-language override from /Tc<file> / /Tp<file>.
+    // Those flags both name and language-tag the file in one go.
+
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+
+        // Empty arg — skip (rare, but defensive).
+        if arg.is_empty() {
+            i += 1;
+            continue;
+        }
+
+        // ── Non-cacheable invocations ───────────────────────────────────
+        // Preprocess-only modes.
+        if is_exact_flag(arg, "E") || is_exact_flag(arg, "EP") || is_exact_flag(arg, "P") {
+            return ParsedInvocation::NonCacheable {
+                reason: format!("preprocessing-only flag: {arg}"),
+            };
+        }
+
+        // Help / version queries: `/?`, `/help`, `--version`, `--help`,
+        // `-v`/`/v` (some build systems probe this).
+        if arg == "/?"
+            || is_exact_flag(arg, "help")
+            || is_exact_flag(arg, "HELP")
+            || arg == "--version"
+            || arg == "--help"
+        {
+            return ParsedInvocation::NonCacheable {
+                reason: format!("help/version query: {arg}"),
+            };
+        }
+
+        // ── Compile-only flag (/c or -c). MSVC, clang-cl, and `cc-rs` all
+        // pass this verbatim. Both prefixes accepted.
+        if is_exact_flag(arg, "c") {
+            has_c_flag = true;
+            i += 1;
+            continue;
+        }
+
+        // ── Output object path: `/Fo<path>`, `/Fo:<path>`, `/Fo <path>` ──
+        // Both `/Fo` and `-Fo` are honored by clang-cl.
+        // Also `/Fobuild/foo.obj` (no separator) is valid for MSVC.
+        if let Some(rest) = strip_flag(arg, "Fo") {
+            // `/Fo` (next arg), `/Fo:<path>` or `/Fo<path>` (concatenated)
+            if rest.is_empty() {
+                if let Some(next) = args.get(i + 1) {
+                    output_file = Some(next.clone());
+                    i += 2;
+                    continue;
+                }
+                i += 1;
+                continue;
+            }
+            let path = rest.strip_prefix(':').unwrap_or(rest);
+            output_file = Some(path.to_string());
+            i += 1;
+            continue;
+        }
+
+        // ── Executable / linker outputs (non-cacheable if no /c). ────────
+        // /Fe<path> => exe output. We still record the argument so we can
+        // detect that this is a link invocation rather than a compile.
+        if strip_flag(arg, "Fe").is_some() {
+            unknown_flags.push(arg.clone());
+            i += 1;
+            continue;
+        }
+        // /Fd<path> => PDB output (debug info). Tracked but otherwise ignored.
+        if strip_flag(arg, "Fd").is_some() {
+            unknown_flags.push(arg.clone());
+            i += 1;
+            continue;
+        }
+        // /Fp<path> => PCH output path. Tracked but ignored for classification.
+        if strip_flag(arg, "Fp").is_some() {
+            unknown_flags.push(arg.clone());
+            i += 1;
+            continue;
+        }
+
+        // ── GCC-style aliases (clang-cl accepts both prefixes). ──────────
+        // `-o <path>` (with space) and `-o<path>` (concatenated). MSVC `cl.exe`
+        // does NOT accept `-o`, but clang-cl does.
+        if arg == "-o" {
+            if let Some(next) = args.get(i + 1) {
+                output_file = Some(next.clone());
+                i += 2;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+        if let Some(path) = arg.strip_prefix("-o") {
+            if !path.is_empty() {
+                output_file = Some(path.to_string());
+                i += 1;
+                continue;
+            }
+        }
+
+        // ── Language-override / explicit source flags ────────────────────
+        // /Tc<file>     — treat <file> as C source.
+        // /Tp<file>     — treat <file> as C++ source.
+        // /Tc <file>    — same, space separated.
+        // /Tp <file>    — same, space separated.
+        // /TC           — treat all following as C.
+        // /TP           — treat all following as C++.
+        if let Some(rest) = strip_flag(arg, "Tc") {
+            if rest.is_empty() {
+                if let Some(next) = args.get(i + 1) {
+                    source_files.push((next.clone(), i + 1));
+                    i += 2;
+                    continue;
+                }
+                i += 1;
+                continue;
+            }
+            source_files.push((rest.to_string(), i));
+            i += 1;
+            continue;
+        }
+        if let Some(rest) = strip_flag(arg, "Tp") {
+            if rest.is_empty() {
+                if let Some(next) = args.get(i + 1) {
+                    source_files.push((next.clone(), i + 1));
+                    i += 2;
+                    continue;
+                }
+                i += 1;
+                continue;
+            }
+            source_files.push((rest.to_string(), i));
+            i += 1;
+            continue;
+        }
+        if is_exact_flag(arg, "TC") || is_exact_flag(arg, "TP") {
+            unknown_flags.push(arg.clone());
+            i += 1;
+            continue;
+        }
+
+        // ── Flags that take a value in the *next* argv element ───────────
+        // For MSVC, `/D NAME`, `/U NAME`, `/I path`, `/FI <file>` all support
+        // the space-separated form. We must consume both elements so the
+        // value isn't misclassified as a source file.
+        if is_exact_flag(arg, "D")
+            || is_exact_flag(arg, "U")
+            || is_exact_flag(arg, "I")
+            || is_exact_flag(arg, "FI")
+        {
+            unknown_flags.push(arg.clone());
+            if let Some(next) = args.get(i + 1) {
+                unknown_flags.push(next.clone());
+                i += 2;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+
+        // ── Generic flag passthrough ─────────────────────────────────────
+        if is_flag(arg) {
+            // `/showIncludes`, `/nologo`, `/MD`, `/MT`, `/O2`, `/W4`, etc.
+            // All are passed to the compiler via `original_args`; we just
+            // track them so they aren't misclassified as sources.
+            // Note: starts with `/` *might* be a unix path. Treat anything
+            // matching a known shape as a flag, otherwise fall through.
+            // We are permissive here — anything starting with `/` that has
+            // no extra `/` characters is a flag (Unix paths typically have
+            // multiple `/`). This matches `looks_like_msvc_args`.
+            let body = flag_body(arg);
+            let has_inner_slash = body.contains('/');
+            let looks_like_msvc_flag = !has_inner_slash
+                && body
+                    .chars()
+                    .next()
+                    .map(|c| c.is_ascii_alphabetic() || c == '?')
+                    .unwrap_or(false);
+            if arg.starts_with('-') || looks_like_msvc_flag {
+                unknown_flags.push(arg.clone());
+                i += 1;
+                continue;
+            }
+            // It looked like a flag but contains inner `/` — could be a path.
+            // Fall through to source-file detection below.
+        }
+
+        // ── Positional argument: source file candidate ───────────────────
+        if is_msvc_source_file(arg) {
+            source_files.push((arg.clone(), i));
+        } else {
+            // Unknown positional (e.g., import library, .obj file). For
+            // strict accounting, surface these via `unknown_flags` so
+            // nothing is silently dropped.
+            unknown_flags.push(arg.clone());
+        }
+
+        i += 1;
+    }
+
+    // ── Classification ──────────────────────────────────────────────────
+    if !has_c_flag {
+        return ParsedInvocation::NonCacheable {
+            reason: "no /c flag (likely a link invocation)".to_string(),
+        };
+    }
+    if source_files.is_empty() {
+        return ParsedInvocation::NonCacheable {
+            reason: "no source file found in MSVC/clang-cl invocation".to_string(),
+        };
+    }
+
+    // Multi-file invocations: when `cl.exe` or `clang-cl` are given multiple
+    // sources with `/c`, each becomes a separate `.obj`. MSVC names them by
+    // stem in the cwd just like gcc.
+    if source_files.len() > 1 {
+        let source_indices: Vec<usize> = source_files.iter().map(|(_, idx)| *idx).collect();
+        let shared_args: Arc<[String]> = Arc::from(args.to_vec());
+        let compilations = source_files
+            .iter()
+            .map(|(src, _)| CacheableCompilation {
+                compiler: NormalizedPath::new(compiler),
+                family,
+                source_file: NormalizedPath::new(src),
+                output_file: NormalizedPath::new(msvc_default_output(src)),
+                original_args: Arc::clone(&shared_args),
+                unknown_flags: unknown_flags.clone(),
+            })
+            .collect();
+        return ParsedInvocation::MultiFile {
+            compilations,
+            original_args: shared_args,
+            source_indices,
+        };
+    }
+
+    let (source, _) = source_files.into_iter().next().unwrap();
+    let output = output_file.unwrap_or_else(|| msvc_default_output(&source));
+
+    ParsedInvocation::Cacheable(CacheableCompilation {
+        compiler: NormalizedPath::new(compiler),
+        family,
+        source_file: NormalizedPath::new(source),
+        output_file: NormalizedPath::new(output),
+        original_args: Arc::from(args.to_vec()),
+        unknown_flags,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(s: &[&str]) -> Vec<String> {
+        s.iter().map(|x| x.to_string()).collect()
+    }
+
+    // ── looks_like_msvc_args ────────────────────────────────────────────
+
+    #[test]
+    fn looks_like_msvc_detects_slash_c() {
+        assert!(looks_like_msvc_args(&args(&["/c", "foo.c"])));
+    }
+
+    #[test]
+    fn looks_like_msvc_detects_fo() {
+        assert!(looks_like_msvc_args(&args(&["/Fo:out.obj", "foo.c"])));
+    }
+
+    #[test]
+    fn looks_like_msvc_rejects_unix_paths() {
+        // /usr/include should NOT be treated as an MSVC flag.
+        assert!(!looks_like_msvc_args(&args(&[
+            "-c",
+            "/usr/include/foo.c",
+            "-o",
+            "foo.o"
+        ])));
+    }
+
+    #[test]
+    fn looks_like_msvc_rejects_pure_gcc() {
+        assert!(!looks_like_msvc_args(&args(&[
+            "-c", "foo.c", "-o", "foo.o", "-O2", "-Wall"
+        ])));
+    }
+
+    #[test]
+    fn looks_like_msvc_mixed_dash_and_slash() {
+        // Some build systems mix conventions: `-D` plus `/c`.
+        assert!(looks_like_msvc_args(&args(&["-DFOO=1", "/c", "foo.c"])));
+    }
+
+    // ── Cacheable single-file invocations ───────────────────────────────
+
+    #[test]
+    fn basic_clang_cl_compile_with_slash_fo_colon() {
+        // The canonical clang-cl shape from the issue.
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&["/c", "/Fo:hello.obj", "hello.c"]),
+            CompilerFamily::Msvc,
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.source_file, NormalizedPath::new("hello.c"));
+                assert_eq!(c.output_file, NormalizedPath::new("hello.obj"));
+                assert_eq!(c.family, CompilerFamily::Msvc);
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn slash_fo_concatenated_no_separator() {
+        // `/Fohello.obj` (no separator) is valid MSVC syntax.
+        let result = parse_msvc_invocation(
+            "cl",
+            &args(&["/c", "/Fohello.obj", "hello.c"]),
+            CompilerFamily::Msvc,
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.output_file, NormalizedPath::new("hello.obj"));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn slash_fo_space_separated() {
+        // `/Fo build/hello.obj` (space) - clang-cl accepts both.
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&["/c", "/Fo", "build/hello.obj", "hello.c"]),
+            CompilerFamily::Msvc,
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.output_file, NormalizedPath::new("build/hello.obj"));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dash_fo_alias_accepted() {
+        // clang-cl accepts -Fo as well as /Fo.
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&["-c", "-Fo:hello.obj", "hello.c"]),
+            CompilerFamily::Msvc,
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.output_file, NormalizedPath::new("hello.obj"));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gcc_style_dash_o_accepted_for_clang_cl() {
+        // clang-cl also honors `-o`. Confirm we don't drop it.
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&["-c", "-o", "hello.obj", "hello.c"]),
+            CompilerFamily::Msvc,
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.output_file, NormalizedPath::new("hello.obj"));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn default_output_when_no_fo() {
+        let result =
+            parse_msvc_invocation("clang-cl", &args(&["/c", "hello.c"]), CompilerFamily::Msvc);
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                // Default MSVC output is <stem>.obj
+                assert_eq!(c.output_file, NormalizedPath::new("hello.obj"));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cpp_with_ehsc_and_std() {
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&[
+                "/c",
+                "/EHsc",
+                "/std:c++17",
+                "/MD",
+                "/W4",
+                "/Fo:hello.obj",
+                "hello.cpp",
+            ]),
+            CompilerFamily::Msvc,
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.source_file, NormalizedPath::new("hello.cpp"));
+                assert_eq!(c.output_file, NormalizedPath::new("hello.obj"));
+                // /EHsc, /std:c++17, /MD, /W4 must be preserved.
+                assert!(c.unknown_flags.contains(&"/EHsc".to_string()));
+                assert!(c.unknown_flags.contains(&"/std:c++17".to_string()));
+                assert!(c.unknown_flags.contains(&"/MD".to_string()));
+                assert!(c.unknown_flags.contains(&"/W4".to_string()));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn d_macro_with_value_space_separated() {
+        // `/D NAME=VALUE` is consumed as a single 2-element flag — the value
+        // must NOT be misclassified as a source file.
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&["/c", "/D", "FOO=1", "/Fo:hello.obj", "hello.c"]),
+            CompilerFamily::Msvc,
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.source_file, NormalizedPath::new("hello.c"));
+                assert!(c.unknown_flags.contains(&"/D".to_string()));
+                assert!(c.unknown_flags.contains(&"FOO=1".to_string()));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn i_path_with_space_and_spaces_in_path() {
+        // `/I path with spaces` — path is the next arg.
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&[
+                "/c",
+                "/I",
+                "C:\\Program Files\\include",
+                "/Fo:hello.obj",
+                "hello.c",
+            ]),
+            CompilerFamily::Msvc,
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.source_file, NormalizedPath::new("hello.c"));
+                assert!(c.unknown_flags.contains(&"/I".to_string()));
+                assert!(c
+                    .unknown_flags
+                    .contains(&"C:\\Program Files\\include".to_string()));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mixed_dash_and_slash_flags() {
+        // Both prefixes coexist in a single invocation (very common in `cc-rs`).
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&["/c", "-DFOO=1", "/DBAR=2", "/Fo:hello.obj", "hello.c"]),
+            CompilerFamily::Msvc,
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.source_file, NormalizedPath::new("hello.c"));
+                assert!(c.unknown_flags.contains(&"-DFOO=1".to_string()));
+                assert!(c.unknown_flags.contains(&"/DBAR=2".to_string()));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_slash_flag_does_not_drop_invocation() {
+        // /XYZUnknown should be preserved in unknown_flags and the
+        // invocation classified, never silently dropped.
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&["/c", "/XYZUnknown", "/Fo:hello.obj", "hello.c"]),
+            CompilerFamily::Msvc,
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert!(c.unknown_flags.contains(&"/XYZUnknown".to_string()));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn debug_info_flags() {
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&["/c", "/Zi", "/Fd:vc.pdb", "/Fo:hello.obj", "hello.c"]),
+            CompilerFamily::Msvc,
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.output_file, NormalizedPath::new("hello.obj"));
+                assert!(c.unknown_flags.contains(&"/Zi".to_string()));
+                assert!(c.unknown_flags.contains(&"/Fd:vc.pdb".to_string()));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn show_includes_kept() {
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&["/c", "/showIncludes", "/Fo:hello.obj", "hello.c"]),
+            CompilerFamily::Msvc,
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert!(c.unknown_flags.contains(&"/showIncludes".to_string()));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    // ── /Tc and /Tp ─────────────────────────────────────────────────────
+
+    #[test]
+    fn slash_tc_concatenated_source() {
+        // `/Tchello.c` — source name is concatenated.
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&["/c", "/Tchello.c", "/Fo:hello.obj"]),
+            CompilerFamily::Msvc,
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.source_file, NormalizedPath::new("hello.c"));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn slash_tp_space_separated_source() {
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&["/c", "/Tp", "hello.cpp", "/Fo:hello.obj"]),
+            CompilerFamily::Msvc,
+        );
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(c.source_file, NormalizedPath::new("hello.cpp"));
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+
+    // ── Multi-file ──────────────────────────────────────────────────────
+
+    #[test]
+    fn multi_file_msvc_split() {
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&["/c", "a.c", "b.c"]),
+            CompilerFamily::Msvc,
+        );
+        match result {
+            ParsedInvocation::MultiFile {
+                compilations,
+                source_indices,
+                ..
+            } => {
+                assert_eq!(compilations.len(), 2);
+                assert_eq!(compilations[0].source_file, NormalizedPath::new("a.c"));
+                assert_eq!(compilations[0].output_file, NormalizedPath::new("a.obj"));
+                assert_eq!(compilations[1].source_file, NormalizedPath::new("b.c"));
+                assert_eq!(compilations[1].output_file, NormalizedPath::new("b.obj"));
+                assert_eq!(source_indices, vec![1, 2]);
+            }
+            other => panic!("expected MultiFile, got: {other:?}"),
+        }
+    }
+
+    // ── Non-cacheable invocations ───────────────────────────────────────
+
+    #[test]
+    fn no_slash_c_is_non_cacheable() {
+        // No /c => link invocation.
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&["hello.c", "/Fe:hello.exe"]),
+            CompilerFamily::Msvc,
+        );
+        assert!(matches!(result, ParsedInvocation::NonCacheable { .. }));
+    }
+
+    #[test]
+    fn slash_e_preprocess_only_is_non_cacheable() {
+        let result =
+            parse_msvc_invocation("clang-cl", &args(&["/E", "hello.c"]), CompilerFamily::Msvc);
+        assert!(matches!(result, ParsedInvocation::NonCacheable { .. }));
+    }
+
+    #[test]
+    fn slash_p_preprocess_to_file_is_non_cacheable() {
+        let result =
+            parse_msvc_invocation("clang-cl", &args(&["/P", "hello.c"]), CompilerFamily::Msvc);
+        assert!(matches!(result, ParsedInvocation::NonCacheable { .. }));
+    }
+
+    #[test]
+    fn slash_help_is_non_cacheable() {
+        let result = parse_msvc_invocation("clang-cl", &args(&["/?"]), CompilerFamily::Msvc);
+        assert!(matches!(result, ParsedInvocation::NonCacheable { .. }));
+    }
+
+    #[test]
+    fn dash_dash_version_is_non_cacheable() {
+        // `clang-cl --version` should be classified, not silently dropped.
+        let result = parse_msvc_invocation("clang-cl", &args(&["--version"]), CompilerFamily::Msvc);
+        assert!(matches!(result, ParsedInvocation::NonCacheable { .. }));
+    }
+
+    #[test]
+    fn no_source_file_is_non_cacheable() {
+        let result = parse_msvc_invocation(
+            "clang-cl",
+            &args(&["/c", "/Fo:foo.obj"]),
+            CompilerFamily::Msvc,
+        );
+        assert!(matches!(result, ParsedInvocation::NonCacheable { .. }));
+    }
+
+    // ── Original args preserved verbatim ────────────────────────────────
+
+    #[test]
+    fn original_args_preserved_for_compiler_fallback() {
+        let input = args(&[
+            "/c",
+            "/EHsc",
+            "/std:c++17",
+            "/Fo:hello.obj",
+            "/DDEBUG=1",
+            "hello.cpp",
+        ]);
+        let result = parse_msvc_invocation("clang-cl", &input, CompilerFamily::Msvc);
+        match result {
+            ParsedInvocation::Cacheable(c) => {
+                assert_eq!(*c.original_args, *input);
+            }
+            other => panic!("expected cacheable, got: {other:?}"),
+        }
+    }
+}

--- a/crates/zccache-compiler/tests/clang_cl_classification.rs
+++ b/crates/zccache-compiler/tests/clang_cl_classification.rs
@@ -1,0 +1,216 @@
+//! Adversarial classification tests for clang-cl / MSVC argument parsing.
+//!
+//! Issue #261: on Windows MSVC builds, clang-cl invocations were arriving at
+//! the daemon (the compilation counter incremented) but never landing in any
+//! outcome bucket (`cached`, `cold`, or `non-cacheable`). The root cause was
+//! that `parse_invocation` only understood GCC-style flags; clang-cl's
+//! `/c`, `/Fo:`, `/EHsc`, etc. silently dropped through the parser, leaving
+//! the invocation unclassified.
+//!
+//! These tests exercise the contract that fix introduces:
+//!   1. Every clang-cl / cl.exe invocation that reaches `parse_invocation`
+//!      must produce exactly one of `Cacheable`, `MultiFile`, `NonCacheable`.
+//!      No invocation is silently dropped.
+//!   2. The canonical clang-cl compile shape (`/c /Fo:out.obj src.c`) MUST
+//!      classify as `Cacheable` with the correct source and output paths.
+//!   3. Argument shapes that real build systems (cc-rs, ninja, MSBuild)
+//!      generate must classify correctly — including response files,
+//!      mixed `-`/`/` prefixes, and the `/Tc`/`/Tp` source-language flags.
+
+use std::path::Path;
+
+use zccache_compiler::response_file::expand_response_files_in;
+use zccache_compiler::{parse_invocation, CompilerFamily, ParsedInvocation};
+use zccache_core::NormalizedPath;
+
+fn s(v: &[&str]) -> Vec<String> {
+    v.iter().map(|x| x.to_string()).collect()
+}
+
+/// Trip the classification invariant: every invocation must classify into
+/// exactly one of the three buckets. This is the contract that keeps the
+/// daemon's `total_compilations == cached + cold + non_cacheable` invariant
+/// holding (issue #261).
+fn assert_classifies(compiler: &str, argv: &[&str]) {
+    let result = parse_invocation(compiler, &s(argv));
+    match result {
+        ParsedInvocation::Cacheable(_)
+        | ParsedInvocation::MultiFile { .. }
+        | ParsedInvocation::NonCacheable { .. } => (),
+    }
+}
+
+// ─── Issue #261 canonical shapes ────────────────────────────────────────
+
+#[test]
+fn issue_261_clang_cl_classifies_as_cacheable() {
+    // The exact shape that produced "2 total, 0 cached, 0 cold, 0
+    // non-cacheable" in the issue. Must now be Cacheable.
+    let result = parse_invocation("clang-cl", &s(&["/c", "/Fo:hello.obj", "hello.c"]));
+    match result {
+        ParsedInvocation::Cacheable(c) => {
+            assert_eq!(c.family, CompilerFamily::Msvc);
+            assert_eq!(c.source_file, NormalizedPath::new("hello.c"));
+            assert_eq!(c.output_file, NormalizedPath::new("hello.obj"));
+        }
+        other => panic!("expected Cacheable, got: {other:?}"),
+    }
+}
+
+#[test]
+fn issue_261_clang_cl_exe_path_with_spaces() {
+    // clang-cl is often invoked via its full path under `C:\Program Files`.
+    let result = parse_invocation(
+        "C:\\Program Files\\LLVM\\bin\\clang-cl.exe",
+        &s(&["/c", "/Fo:hello.obj", "hello.c"]),
+    );
+    assert!(matches!(result, ParsedInvocation::Cacheable(_)));
+}
+
+#[test]
+fn issue_261_cc_rs_style_invocation() {
+    // Mirror what `cc-rs` generates for an `x86_64-pc-windows-msvc` target.
+    let argv = &[
+        "-nologo",
+        "-MD",
+        "-Z7",
+        "-Brepro",
+        "/I",
+        "C:\\src\\zlib\\include",
+        "-W4",
+        "-DZLIB_DEBUG=1",
+        "/c",
+        "/Fo:zlib-out\\adler32.obj",
+        "C:\\src\\zlib\\adler32.c",
+    ];
+    let result = parse_invocation("clang-cl", &s(argv));
+    match result {
+        ParsedInvocation::Cacheable(c) => {
+            assert_eq!(c.family, CompilerFamily::Msvc);
+            assert_eq!(
+                c.source_file,
+                NormalizedPath::new("C:\\src\\zlib\\adler32.c")
+            );
+            assert_eq!(c.output_file, NormalizedPath::new("zlib-out\\adler32.obj"));
+        }
+        other => panic!("expected Cacheable, got: {other:?}"),
+    }
+}
+
+// ─── Classification invariant fuzzing ───────────────────────────────────
+
+#[test]
+fn invariant_random_shapes_classify() {
+    // Hand-picked shapes that cover the corners of the parser. Each one
+    // MUST classify (never silently drop). This is the fuzz-style guard
+    // that satisfies the issue's request: "Add an assertion or a fuzz
+    // test that guarantees this invariant."
+    let shapes: &[&[&str]] = &[
+        &[],
+        &["/?"],
+        &["--help"],
+        &["--version"],
+        &["/c"],
+        &["foo.c"],
+        &["/c", "foo.c"],
+        &["/c", "/Fo:foo.obj", "foo.c"],
+        &["/c", "/Fo", "foo.obj", "foo.c"],
+        &["-c", "-o", "foo.obj", "foo.c"],
+        &["-c", "-Fo:foo.obj", "foo.c"],
+        &["/c", "/Tcfoo.c", "/Fo:foo.obj"],
+        &["/c", "/Tp", "foo.cpp", "/Fo:foo.obj"],
+        &["/c", "a.c", "b.c", "c.c"],
+        &["/c", "/EHsc", "/std:c++17", "/Fo:foo.obj", "foo.cpp"],
+        &["/E", "foo.c"],
+        &["/P", "foo.c"],
+        &["/EP", "foo.c"],
+        &["/c", "/D", "FOO=1", "/I", "C:\\inc", "/Fo:foo.obj", "foo.c"],
+        // Mixed prefixes
+        &["/c", "-DFOO", "/DBAR", "/Fo:foo.obj", "foo.c"],
+        // Unknown slash flags
+        &["/c", "/SomeUnknownFlag", "/Fo:foo.obj", "foo.c"],
+        // Just a /Fe (link) — must be non-cacheable
+        &["/Fe:foo.exe", "foo.c"],
+        // .C and .CPP uppercase extensions
+        &["/c", "/Fo:foo.obj", "FOO.C"],
+        &["/c", "/Fo:foo.obj", "FOO.CPP"],
+    ];
+    for shape in shapes {
+        assert_classifies("clang-cl", shape);
+        assert_classifies("cl.exe", shape);
+    }
+}
+
+// ─── Response files (`@file`) ──────────────────────────────────────────
+
+#[test]
+fn response_file_with_msvc_flags_classifies() {
+    // Build a response file containing MSVC-style args and exercise the
+    // full expand → parse pipeline (which is what the daemon does in
+    // `handle_compile`).
+    let tmp = tempfile::tempdir().unwrap();
+    let rsp_path = tmp.path().join("compile.rsp");
+    std::fs::write(&rsp_path, "/c /Fo:hello.obj /EHsc /std:c++17 hello.cpp\n").unwrap();
+
+    let argv = s(&[format!("@{}", rsp_path.display()).as_str()]);
+    let expanded = expand_response_files_in(&argv, tmp.path()).unwrap();
+    let result = parse_invocation("clang-cl", &expanded);
+    match result {
+        ParsedInvocation::Cacheable(c) => {
+            assert_eq!(c.source_file, NormalizedPath::new("hello.cpp"));
+            assert_eq!(c.output_file, NormalizedPath::new("hello.obj"));
+        }
+        other => panic!("expected Cacheable, got: {other:?}"),
+    }
+}
+
+// ─── /Tc and /Tp source-language flags ──────────────────────────────────
+
+#[test]
+fn tc_inline_source_classifies() {
+    let result = parse_invocation("clang-cl", &s(&["/c", "/Tchello.c", "/Fo:hello.obj"]));
+    match result {
+        ParsedInvocation::Cacheable(c) => {
+            assert_eq!(c.source_file, NormalizedPath::new("hello.c"));
+        }
+        other => panic!("expected Cacheable, got: {other:?}"),
+    }
+}
+
+#[test]
+fn tp_space_separated_source_classifies() {
+    let result = parse_invocation("clang-cl", &s(&["/c", "/Tp", "hello.cpp", "/Fo:hello.obj"]));
+    match result {
+        ParsedInvocation::Cacheable(c) => {
+            assert_eq!(c.source_file, NormalizedPath::new("hello.cpp"));
+        }
+        other => panic!("expected Cacheable, got: {other:?}"),
+    }
+}
+
+// ─── Negative classifications ───────────────────────────────────────────
+
+#[test]
+fn link_only_classifies_as_non_cacheable() {
+    let result = parse_invocation("clang-cl", &s(&["foo.obj", "/Fe:foo.exe"]));
+    assert!(matches!(result, ParsedInvocation::NonCacheable { .. }));
+}
+
+#[test]
+fn preprocess_only_classifies_as_non_cacheable() {
+    let result = parse_invocation("clang-cl", &s(&["/E", "foo.c"]));
+    assert!(matches!(result, ParsedInvocation::NonCacheable { .. }));
+}
+
+#[test]
+fn version_query_classifies_as_non_cacheable() {
+    let result = parse_invocation("clang-cl", &s(&["--version"]));
+    assert!(matches!(result, ParsedInvocation::NonCacheable { .. }));
+}
+
+// ─── Suppress unused warnings on non-Windows. ───────────────────────────
+
+#[allow(dead_code)]
+fn _silence_path_import() {
+    let _ = Path::new(".");
+}


### PR DESCRIPTION
Closes #261.

## Summary

- Adds an MSVC / clang-cl argument classifier so Windows builds with `clang-cl` (and `cl.exe`) land in the correct `cached` / `cold` / `non-cacheable` bucket. Before this change, `parse_invocation` only understood GCC-style flags; clang-cl's `/c`, `/Fo:`, `/EHsc`, ... dropped through silently, producing the reported \"2 total compilations, 0 cached, 0 cold, 0 non-cacheable\" symptom.
- `detect_family` now recognises `clang-cl` (and `clang-cl-17`, `Clang-CL.EXE`, the full-path variant under `C:\Program Files\LLVM\bin\`, etc.) as `CompilerFamily::Msvc`.
- `parse_invocation` dispatches to the new MSVC parser when **either** the family is `Msvc` **or** the argv contains MSVC-style flags. That covers the case where a build system invokes `clang` but passes `/c` / `/Fo` (which `clang` itself accepts in MSVC mode).
- New `parse_msvc` module classifies the full clang-cl flag surface used in real builds: `/c`, `/Fo`/`/Fo:`/`/Fo <path>`, `/Fe`, `/Fd`, `/Fp`, `/Tc`, `/Tp` (joined and space-separated), `/D`/`/U`/`/I`/`/FI`, `/E` / `/EP` / `/P`, `/showIncludes`, `/EHsc`, `/std:c++17`, response files (`@file`), mixed `-`/`/` prefixes, and unknown `/X` flags.

## Tests

- `crates/zccache-compiler/tests/clang_cl_classification.rs` (new) — issue #261 canonical shapes, cc-rs / ninja / response-file shapes, `/Tc` and `/Tp` source-language flags, plus a fuzz-style `invariant_random_shapes_classify` that walks ~25 argv shapes and asserts every one classifies into exactly one bucket. This is the invariant requested in the issue (`total = cached + cold + non-cacheable`).
- ~30 unit tests in `parse_msvc` cover individual flag handling, and `lib.rs` gains coverage of the dispatcher and family detection.
- All existing unit tests still pass (`./test`).

## What is not in this PR

- The issue also asks for a Windows perf-guard leg covering C/C++/Rust/Emscripten with clang-cl. The current perf-guard infrastructure (`perf-guard.yml` + `perf_bench_test.rs`) is Linux-only and hard-coded to `ubuntu-24.04` with `clang`, so adding a Windows + clang-cl leg is a substantial separate effort (new runner matrix, new benchmark fixtures, new floors). Filing as follow-up — happy to do it in a focused PR.

## Test plan

- [x] `soldr cargo test -p zccache-compiler --test clang_cl_classification` — 10/10 pass
- [x] `soldr cargo test -p zccache-compiler` — 434/434 pass
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `soldr cargo fmt --all` clean
- [x] `./test` (workspace unit tests) — all green