### PR TITLE
fix(windows): resolve STATUS_DLL_INIT_FAILED on Windows MSVC build

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -98,14 +98,54 @@ runs:
         TARGET_UPPER=$(echo "${{ inputs.target }}" | tr '[:lower:]-' '[:upper:]_')
         echo "CARGO_TARGET_${TARGET_UPPER}_LINKER=${{ inputs.linker }}" >> "$GITHUB_ENV"
 
+    # Static-link the MSVC C runtime (vcruntime + UCRT) for Windows release
+    # binaries. Without `+crt-static` the published `zccache.exe` declares
+    # imports against `VCRUNTIME140.dll` and the `api-ms-win-crt-*` UCRT
+    # API-set forwarders; on runner images where any of those DLLs is
+    # missing or version-skewed, the Windows loader rejects the image
+    # before `main` with `STATUS_DLL_INIT_FAILED` (exit `-1073741502` /
+    # `0xC0000142`). Self-contained CRT linkage is the standard approach
+    # for distributable Rust binaries on Windows (rustc/cargo/rustup all
+    # ship this way). See zccache#269.
+    #
+    # We DO NOT apply +crt-static to the Python extension (.pyd) builds
+    # below — those load into the host Python process and must share its
+    # C runtime. Static CRT linkage is appended to RUSTFLAGS only for the
+    # standalone binary build step.
     - name: Build release binaries
       shell: bash
       env:
         PYO3_PYTHON: python
       run: |
+        if [[ "${{ inputs.target }}" == *pc-windows-msvc ]]; then
+          export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=+crt-static"
+        fi
         soldr cargo build --release --target ${{ inputs.target }} -p zccache-cli
         soldr cargo build --release --target ${{ inputs.target }} -p zccache-daemon
         soldr cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint
+
+    # Windows DLL load smoke gate (see zccache#269). If the just-built
+    # `zccache.exe` cannot complete loader init on this host, `--version`
+    # exits non-zero before any Rust code runs and the release stops here
+    # rather than shipping a binary that will fail in CI consumers. Other
+    # platforms run the same check for symmetry but the Windows leg is
+    # the one that actually catches the regression. ARM64 Windows builds
+    # are cross-compiled on x64 runners and so cannot exec the binary on
+    # this leg — skip the smoke for that target only.
+    - name: Smoke test built binary
+      shell: bash
+      run: |
+        case "${{ inputs.target }}" in
+          aarch64-pc-windows-msvc|aarch64-unknown-linux-musl|aarch64-unknown-linux-gnu)
+            # Cross-compiled; skip exec on host. TODO: when matrix gains
+            # an arm64 runner, gate aarch64-pc-windows-msvc through it.
+            echo "Skipping smoke test for cross-compiled target ${{ inputs.target }}"
+            exit 0
+            ;;
+        esac
+        BIN="target/${{ inputs.target }}/release/zccache${{ inputs.binary_ext }}"
+        echo "Smoke test: $BIN --version"
+        "$BIN" --version
 
     - name: Build Python extension artifacts
       if: inputs.include_python == 'true'


### PR DESCRIPTION
## Summary

Fixes #269. Windows MSVC release binaries were exiting `-1073741502`
(`0xC0000142` / `STATUS_DLL_INIT_FAILED`) on CI runners — the Windows
loader rejected the image before `main` ran.

### Root cause

Published `zccache.exe`, `zccache-daemon.exe`, and `zccache-fp.exe` had
import-table dependencies on `VCRUNTIME140.dll` and the
`api-ms-win-crt-*-l1-1-0.dll` UCRT API-set forwarders. On runner images
where any of those DLLs is missing or version-skewed (e.g. the failing
windows-2025 image used by zackees/soldr PR #308 runs
[25907556419/job/76143968484](https://github.com/zackees/soldr/actions/runs/25907556419/job/76143968484)
and [/job/76143968433](https://github.com/zackees/soldr/actions/runs/25907556419/job/76143968433)),
the loader refuses to map the image and the process exits before any
Rust code runs.

`dumpbin /dependents` on the shipped 1.5.0 x86_64-pc-windows-msvc
zccache.exe before this PR:

```
kernel32.dll
bcryptprimitives.dll
api-ms-win-core-synch-l1-2-0.dll
advapi32.dll
ws2_32.dll
crypt32.dll
bcrypt.dll
ntdll.dll
VCRUNTIME140.dll          <-- gone after this PR
api-ms-win-crt-runtime-l1-1-0.dll    <-- gone
api-ms-win-crt-convert-l1-1-0.dll    <-- gone
api-ms-win-crt-stdio-l1-1-0.dll      <-- gone
api-ms-win-crt-string-l1-1-0.dll     <-- gone
api-ms-win-crt-math-l1-1-0.dll       <-- gone
api-ms-win-crt-locale-l1-1-0.dll     <-- gone
api-ms-win-crt-heap-l1-1-0.dll       <-- gone
```

### Fix

- Append `-C target-feature=+crt-static` to `RUSTFLAGS` in the
  `Build release binaries` step of `.github/actions/build-target/action.yml`
  when the target triple ends in `pc-windows-msvc`. This statically
  links the MSVC C runtime and the UCRT so the produced exe has no
  load-time dependency on any VCRUNTIME/UCRT DLL being preinstalled.
  Self-contained CRT linkage is the standard approach for distributable
  Rust binaries on Windows (rustc, cargo, and rustup all ship this way).
- The flag is **not** propagated to the Python extension (`.pyd`)
  build step — those load into the host Python process and must share
  its dynamic C runtime.

### Smoke gate

Added a `Smoke test built binary` step that runs `./zccache --version`
on the freshly built binary. If the binary can't complete loader init,
this catches the regression at release time and blocks publishing —
exactly the gate #269 asked for. The step is a no-op for cross-compiled
targets that can't be executed on the build host (`aarch64-pc-windows-msvc`,
`aarch64-unknown-linux-*`); a TODO is left so the arm64 Windows leg can
be re-enabled once the matrix includes an arm64 runner.

### Verification

- Local Windows MSVC release build with the new RUSTFLAGS:
  `dumpbin /dependents` confirms `VCRUNTIME140.dll` and all
  `api-ms-win-crt-*` deps are gone.
- The produced `zccache.exe --version` exits 0.
- `soldr cargo fmt --all -- --check` clean.
- `soldr cargo clippy -p zccache-cli --release --target x86_64-pc-windows-msvc -- -D warnings` clean.

## Test plan

- [ ] Trigger `Build Native Binaries` workflow on this branch.
- [ ] Confirm the `Smoke test built binary` step passes on
      `x86_64-pc-windows-msvc` and `x86_64-unknown-linux-*` legs.
- [ ] Confirm the produced Windows zip contains a `zccache.exe` whose
      `dumpbin /dependents` no longer lists `VCRUNTIME140.dll` or any
      `api-ms-win-crt-*` DLL.
- [ ] Re-run a downstream consumer (zackees/soldr build workflow) against
      the rebuilt zccache and confirm `zccache stop` no longer exits
      `-1073741502`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)