### PR TITLE
fix(daemon): detach inherited stdio at startup (#276)

### DIFF
--- a/crates/zccache-daemon/src/main.rs
+++ b/crates/zccache-daemon/src/main.rs
@@ -53,6 +53,14 @@ fn main() {
     let args = Args::parse();
 
     if args.foreground {
+        // FIRST thing in the long-lived path: drop any stdio handles we
+        // inherited from the spawning process. Without this, an orphaned
+        // daemon keeps its grandparent's pipe write ends alive and the
+        // grandparent's pipe reader (e.g. `subprocess.Popen(stdout=PIPE)`)
+        // never sees EOF after the parent exits. See issue #276. Must run
+        // before init_tracing() so the subscriber's stdout/stderr writes
+        // land in the null device too.
+        zccache_daemon::trampoline::detach_stdio();
         init_tracing(&args.log_level);
         // Long-lived process: release exe-file lock and cwd handle so
         // `pip install --upgrade zccache` and `rm -rf <project>` can

--- a/crates/zccache-daemon/src/trampoline.rs
+++ b/crates/zccache-daemon/src/trampoline.rs
@@ -104,6 +104,124 @@ pub fn release_cwd() {
     let _ = std::env::set_current_dir(std::env::temp_dir());
 }
 
+/// Detach inherited stdio (stdin/stdout/stderr) by re-opening them to the
+/// platform null device (`/dev/null` on Unix, `NUL` on Windows). This
+/// closes whatever file descriptors / handles the daemon inherited from
+/// its spawning process, releasing any pipe write ends in particular.
+///
+/// Without this, a grandparent process that reads the daemon's
+/// (inherited) stdout via a pipe — e.g. Python's
+/// `subprocess.Popen(["soldr", "cargo", "build", ...], stdout=PIPE)` —
+/// never observes EOF after the parent exits, because the orphaned daemon
+/// keeps the pipe's write end alive indefinitely. See issue #276 for the
+/// real-world hang this fix prevents (47+ minute waits on Windows).
+///
+/// Called once, very early in the daemon binary's `main()` before the
+/// tracing subscriber is installed, so the subscriber's stdout/stderr
+/// writes go to the null device from the start. Do not move this later:
+/// any code that writes via `println!` / `tracing` between startup and
+/// the detach point would still hit the inherited pipe and defeat the
+/// purpose.
+///
+/// Best-effort — no panics on failure. A best-effort detach is strictly
+/// better than no detach, and any platform where this fails is a platform
+/// where the original pipe write end could not have been opened anyway.
+pub fn detach_stdio() {
+    #[cfg(unix)]
+    detach_stdio_unix();
+
+    #[cfg(windows)]
+    detach_stdio_windows();
+}
+
+#[cfg(unix)]
+fn detach_stdio_unix() {
+    // SAFETY: open/dup2/close are async-signal-safe and we're running on
+    // the main thread with no other threads spawned yet. Failure of any
+    // step is logged at debug level (we cannot use tracing here — it
+    // hasn't been initialised — and we deliberately don't write to
+    // stderr, since that's exactly what we're trying to detach).
+    unsafe {
+        let null = libc::open(c"/dev/null".as_ptr(), libc::O_RDWR);
+        if null < 0 {
+            return;
+        }
+        let _ = libc::dup2(null, libc::STDIN_FILENO);
+        let _ = libc::dup2(null, libc::STDOUT_FILENO);
+        let _ = libc::dup2(null, libc::STDERR_FILENO);
+        if null > libc::STDERR_FILENO {
+            let _ = libc::close(null);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn detach_stdio_windows() {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use std::ptr;
+
+    extern "system" {
+        fn CreateFileW(
+            lp_file_name: *const u16,
+            dw_desired_access: u32,
+            dw_share_mode: u32,
+            lp_security_attributes: *mut std::ffi::c_void,
+            dw_creation_disposition: u32,
+            dw_flags_and_attributes: u32,
+            h_template_file: *mut std::ffi::c_void,
+        ) -> *mut std::ffi::c_void;
+        fn GetStdHandle(n_std_handle: u32) -> *mut std::ffi::c_void;
+        fn SetStdHandle(n_std_handle: u32, h_handle: *mut std::ffi::c_void) -> i32;
+        fn CloseHandle(h_object: *mut std::ffi::c_void) -> i32;
+    }
+
+    const GENERIC_READ: u32 = 0x8000_0000;
+    const GENERIC_WRITE: u32 = 0x4000_0000;
+    const FILE_SHARE_READ: u32 = 0x0000_0001;
+    const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+    const OPEN_EXISTING: u32 = 3;
+    const STD_INPUT_HANDLE: u32 = 0xFFFF_FFF6; // (DWORD)-10
+    const STD_OUTPUT_HANDLE: u32 = 0xFFFF_FFF5; // (DWORD)-11
+    const STD_ERROR_HANDLE: u32 = 0xFFFF_FFF4; // (DWORD)-12
+    const INVALID_HANDLE_VALUE: *mut std::ffi::c_void = -1isize as *mut std::ffi::c_void;
+
+    let nul: Vec<u16> = OsStr::new("NUL").encode_wide().chain(Some(0)).collect();
+
+    // Replace each std handle with a fresh handle to NUL. Open one fresh
+    // NUL handle per slot so closing the old one (which may be the same
+    // underlying object on consoles) doesn't invalidate the others.
+    for (slot, access) in [
+        (STD_INPUT_HANDLE, GENERIC_READ),
+        (STD_OUTPUT_HANDLE, GENERIC_WRITE),
+        (STD_ERROR_HANDLE, GENERIC_WRITE),
+    ] {
+        // SAFETY: we own the std handle slots for this process; no other
+        // thread is touching them this early in startup.
+        unsafe {
+            let nul_handle = CreateFileW(
+                nul.as_ptr(),
+                access,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                ptr::null_mut(),
+                OPEN_EXISTING,
+                0,
+                ptr::null_mut(),
+            );
+            if nul_handle.is_null() || nul_handle == INVALID_HANDLE_VALUE {
+                continue;
+            }
+            let old = GetStdHandle(slot);
+            let _ = SetStdHandle(slot, nul_handle);
+            // GetStdHandle returns NULL when no handle is set and
+            // INVALID_HANDLE_VALUE on error; neither is closeable.
+            if !old.is_null() && old != INVALID_HANDLE_VALUE {
+                let _ = CloseHandle(old);
+            }
+        }
+    }
+}
+
 /// True if `exe` lives directly inside `<global_cache_dir>/runtime-binaries/`,
 /// i.e. the CLI already copied us out of the install path. Compared
 /// against the canonicalized cache dir to be robust to symlinks and

--- a/crates/zccache-daemon/tests/stdio_detach.rs
+++ b/crates/zccache-daemon/tests/stdio_detach.rs
@@ -1,0 +1,87 @@
+//! Regression test for `trampoline::detach_stdio()`.
+//!
+//! The daemon must release any stdio handles it inherited from its parent
+//! at startup. Otherwise a grandparent process that reads those pipes
+//! (e.g. Python's `subprocess.Popen(..., stdout=PIPE)` wrapping
+//! `soldr cargo build`) never observes EOF on its read end after the
+//! parent exits — the orphaned daemon keeps the pipe's write end open
+//! indefinitely.
+//!
+//! Test strategy: spawn the daemon binary with `Stdio::piped()` for
+//! stdin/stdout/stderr. We hold the read ends; the daemon inherits the
+//! write ends. After `detach_stdio()` runs in the daemon, our reader
+//! threads see EOF and unblock. Without the fix this test hangs until
+//! the cleanup `kill` (which we count as a failure).
+//!
+//! See issue #276.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn daemon_releases_inherited_stdout_and_stderr_pipes() {
+    let daemon_bin = env!("CARGO_BIN_EXE_zccache-daemon");
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let cache_dir = tmp.path().join("cache");
+    std::fs::create_dir_all(&cache_dir).expect("create cache dir");
+
+    let endpoint = zccache_ipc::unique_test_endpoint();
+
+    let mut child = Command::new(daemon_bin)
+        .args(["--foreground", "--endpoint", &endpoint])
+        .env("ZCCACHE_CACHE_DIR", &cache_dir)
+        // Skip the Windows exe rename dance; irrelevant to this regression
+        // and avoids touching the cargo target dir from inside the test.
+        .env("ZCCACHE_NO_UNLOCK", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn daemon");
+
+    let stdout = child.stdout.take().expect("take child stdout");
+    let stderr = child.stderr.take().expect("take child stderr");
+
+    let (tx_out, rx_out) = mpsc::channel::<()>();
+    thread::spawn(move || {
+        let mut sink = stdout;
+        let mut buf = Vec::new();
+        let _ = sink.read_to_end(&mut buf);
+        let _ = tx_out.send(());
+    });
+
+    let (tx_err, rx_err) = mpsc::channel::<()>();
+    thread::spawn(move || {
+        let mut sink = stderr;
+        let mut buf = Vec::new();
+        let _ = sink.read_to_end(&mut buf);
+        let _ = tx_err.send(());
+    });
+
+    // The daemon's detach_stdio() runs at the top of main(); reaching it is
+    // a few hundred microseconds. 10 s is generous enough for slow CI yet
+    // short enough that a hang is unambiguous.
+    let timeout = Duration::from_secs(10);
+    let stdout_eof = rx_out.recv_timeout(timeout).is_ok();
+    let stderr_eof = rx_err.recv_timeout(timeout).is_ok();
+
+    // Tear down before asserting so we never leave a daemon behind.
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        stdout_eof,
+        "daemon did not close its inherited stdout within {timeout:?}; \
+         a grandparent process reading this pipe would hang indefinitely. \
+         See issue #276."
+    );
+    assert!(
+        stderr_eof,
+        "daemon did not close its inherited stderr within {timeout:?}; \
+         a grandparent process reading this pipe would hang indefinitely. \
+         See issue #276."
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #276 — the daemon was holding grandparent processes' pipe write ends open after the parent exited, so any `subprocess.Popen(stdout=PIPE)` wrapper around `soldr cargo build` (and similar chains) hung indefinitely on `proc.stdout.read()` — 47+ minutes observed in real benchmarks.

- Add `zccache_daemon::trampoline::detach_stdio()`: reopens stdin/stdout/stderr to the platform null device (`/dev/null` on Unix via `dup2`, `NUL` on Windows via `CreateFileW`+`SetStdHandle`) and closes the inherited file descriptors / handles.
- Call it at the **very top** of the daemon's `--foreground` startup, before `init_tracing()`, so the tracing subscriber's later writes land in the null device too. The doc comment on `detach_stdio` and the call-site comment in `main.rs` both explain why the ordering matters, to prevent a future "let's pipe daemon logs to the parent" change from quietly reintroducing the hang.
- This is the issue's recommended Option A (defensive fix in the daemon) rather than Option B (every spawn site does it perfectly).

## Test plan

TDD: red → green.

- [x] **RED**: added `crates/zccache-daemon/tests/stdio_detach.rs` that spawns the daemon binary with `Stdio::piped()` for stdin/stdout/stderr, then asserts `read_to_end` on the child's stdout/stderr returns EOF within 10 s. Without the fix, the test hangs the full 10 s and fails with `daemon did not close its inherited stdout within 10s; ...`.
- [x] **GREEN**: with the fix, the test passes in <50 ms (read returns 0 immediately after the daemon detaches).
- [x] `soldr cargo test -p zccache-daemon` — 190 lib unit tests + all trampoline/integration tests (`cwd_release`, `exe_overwrite`, `stdio_detach`) pass; no regressions.
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `soldr cargo fmt --all -- --check` — clean.
- [x] `RUSTDOCFLAGS=\"-D warnings\" soldr cargo doc -p zccache-daemon --no-deps` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)