### PR TITLE
fix(gha): preserve fingerprint mtimes on target-snapshot restore

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -413,11 +413,25 @@ runs:
         TARGET="${{ inputs.target-dir }}"
         if [ -d "$TARGET" ]; then
           zccache warm --target-dir "$TARGET" || true
-          # Touch all target files to ONE fixed timestamp so cargo sees
-          # consistent mtimes. Plain 'touch' gives 1ms differences between
-          # files, which cargo interprets as "dep newer than output" → dirty.
+          # Touch restored *output* files (rlib/rmeta/build artifacts) to ONE
+          # fixed future timestamp so cargo's "output newer than source"
+          # check passes for unchanged crates after restore. Plain 'touch'
+          # gives 1ms differences between files, which cargo interprets as
+          # "dep newer than output" → dirty.
+          #
+          # EXCLUDE .fingerprint/ from the stamping pass. Those directories
+          # hold the dep-info files cargo uses to decide whether to re-invoke
+          # rustc at all: if their mtime is newer than every source file,
+          # cargo trusts the cached binary and skips the build — even when
+          # the source actually changed. With the restore-key fallback
+          # enabled (target-restore-fallback: "true"), a snapshot from a
+          # previous commit with the same Cargo.lock will then be linked
+          # against the current source layout, surfacing as panics with
+          # line numbers from the old source. Preserving the fingerprint
+          # mtimes lets cargo's normal staleness check run.
           STAMP=$(date -d '+1 minute' +%Y%m%d%H%M.%S 2>/dev/null || date -v+1M +%Y%m%d%H%M.%S)
-          find "$TARGET" -type f -exec touch -t "$STAMP" {} + 2>/dev/null || true
+          find "$TARGET" -type f -not -path '*/.fingerprint/*' \
+            -exec touch -t "$STAMP" {} + 2>/dev/null || true
         fi
 
     # --- Start daemon ---


### PR DESCRIPTION
## Summary
- When `cache-target: "true"` + `target-restore-fallback: "true"`, the action restored a `target/` snapshot from a previous commit and then touched **every** file (including `target/debug/.fingerprint/<crate>-*/dep-<crate>`) to `now + 1 minute`. Cargo's incremental check trusted that future mtime over the just-checked-out source files and **skipped rustc entirely** — linking the *previous* commit's binaries against the current source layout.
- Exclude `*/.fingerprint/*` from the touch pass. Output files (rlib/rmeta/build artifacts) still get the future stamp so the original "output newer than source" optimization works for unchanged crates. Fingerprint dep-info files keep their snapshot mtime — older than the newly-checked-out changed sources, so cargo correctly detects the change and re-invokes rustc.

## Symptom (observed during PR #278)
All three test workflows (`linux / Test`, `macos / Test`, `windows / Test`) failed identically on a fresh commit, with panic line numbers and error strings matching the *previous* commit's source — including string literals that the new commit had explicitly changed. Bumping \`Cargo.lock\` to bust the restore-key chain was the workaround; this PR makes that workaround unnecessary.

## Test plan
The bug only manifests in a CI caching layer, so end-to-end CI is the only real test:

- [ ] After this merges, branch off main and push a single-line edit to a test in \`crates/zccache-cli/src/main.rs\` (e.g. flip an assertion, or add a \`panic!("intentional")\`). The change MUST show up in the test failure log on linux/macos/windows.
- [ ] Confirm CI is still fast on unchanged-source PRs (the restore-key fallback should still hit when no source changed; the touch still applies to rlibs so cargo still skips relinking).
- [ ] No regression in the \`Test zccache-action\` self-test workflow.

## Follow-up (separate PR)
Defensive layer: add a workspace-source-tree hash to the restore-key fallback chain so a re-introduction of this class of bug doesn't silently re-occur. Not included here to keep the fix focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)