### PR TITLE
perf(gha): per-crate fingerprint revalidation via blake3 sidecar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,6 +3466,7 @@ dependencies = [
  "pyo3",
  "pyo3-build-config",
  "rayon",
+ "serde",
  "serde_json",
  "tar",
  "tempfile",

--- a/action.yml
+++ b/action.yml
@@ -413,6 +413,20 @@ runs:
         TARGET="${{ inputs.target-dir }}"
         if [ -d "$TARGET" ]; then
           zccache warm --target-dir "$TARGET" || true
+          # Per-crate fingerprint revalidation — the content-hash analogue
+          # of cargo's nightly `-Z checksum-freshness`. For each crate in
+          # the manifest written at save time, recompute blake3 of every
+          # tracked workspace source. If all hashes still match → bump
+          # that crate's dep-info mtime to "future" so cargo's normal
+          # `source.mtime > dep_info.mtime` check skips rustc. Crates with
+          # any mismatch are left alone → cargo correctly invokes rustc.
+          # Missing manifest (older snapshot) is a silent no-op: cargo
+          # falls through to its baseline check (overbuild but correct).
+          zccache snapshot-fp-validate \
+            --target-dir "$TARGET" \
+            --workspace-root "$GITHUB_WORKSPACE" \
+            --stamp-seconds-ahead 60 \
+            || true
           # Touch restored *output* files (rlib/rmeta/build artifacts) to ONE
           # fixed future timestamp so cargo's "output newer than source"
           # check passes for unchanged crates after restore. Plain 'touch'
@@ -421,14 +435,10 @@ runs:
           #
           # EXCLUDE .fingerprint/ from the stamping pass. Those directories
           # hold the dep-info files cargo uses to decide whether to re-invoke
-          # rustc at all: if their mtime is newer than every source file,
-          # cargo trusts the cached binary and skips the build — even when
-          # the source actually changed. With the restore-key fallback
-          # enabled (target-restore-fallback: "true"), a snapshot from a
-          # previous commit with the same Cargo.lock will then be linked
-          # against the current source layout, surfacing as panics with
-          # line numbers from the old source. Preserving the fingerprint
-          # mtimes lets cargo's normal staleness check run.
+          # rustc at all: snapshot-fp-validate above has already future-
+          # stamped only the dep-info files of unchanged crates. A blanket
+          # touch here would clobber that decision and silently underbuild
+          # changed crates — see PR #279 for the bug and rationale.
           STAMP=$(date -d '+1 minute' +%Y%m%d%H%M.%S 2>/dev/null || date -v+1M +%Y%m%d%H%M.%S)
           find "$TARGET" -type f -not -path '*/.fingerprint/*' \
             -exec touch -t "$STAMP" {} + 2>/dev/null || true

--- a/action/cleanup/action.yml
+++ b/action/cleanup/action.yml
@@ -105,6 +105,22 @@ runs:
           ~/.cargo/git/db/
         key: ${{ steps.state.outputs.registry-key }}
 
+    # Record per-crate source content hashes BEFORE tarring so the
+    # post-restore validation step on the next run can selectively
+    # future-stamp dep-info files for crates whose sources still match.
+    # The manifest lives under `<target>/.zccache-fp-manifest.json` so it
+    # rides the existing tar without special inclusion rules. Failure is
+    # logged but never fatal — without the manifest the restore side
+    # falls back to cargo's normal mtime check (overbuild but correct).
+    - name: Record fingerprint source hashes
+      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-target == 'true'
+      shell: bash
+      run: |
+        zccache snapshot-fp-record \
+          --target-dir "${{ steps.state.outputs.target-dir }}" \
+          --workspace-root "$GITHUB_WORKSPACE" \
+          || true
+
     - name: Create target snapshot
       id: target-snapshot
       if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-target == 'true'

--- a/action/cleanup/select-hot-target.py
+++ b/action/cleanup/select-hot-target.py
@@ -7,7 +7,13 @@ import os
 from pathlib import Path
 
 
-MUST_KEEP_NAMES = {"CACHEDIR.TAG", ".rustc_info.json"}
+MUST_KEEP_NAMES = {
+    "CACHEDIR.TAG",
+    ".rustc_info.json",
+    # Sidecar manifest written by `zccache snapshot-fp-record`. Must ride
+    # the tar so `snapshot-fp-validate` on the restore side can read it.
+    ".zccache-fp-manifest.json",
+}
 MUST_KEEP_SUFFIXES = {".d", ".rmeta"}
 BUILD_METADATA_NAMES = {"output", "invoked.timestamp", "root-output"}
 

--- a/crates/zccache-cli/Cargo.toml
+++ b/crates/zccache-cli/Cargo.toml
@@ -23,6 +23,7 @@ tracing-subscriber = { workspace = true }
 clap = { workspace = true }
 thiserror = { workspace = true }
 blake3 = { workspace = true }
+serde = { workspace = true }
 zccache-core = { workspace = true }
 zccache-artifact = { workspace = true }
 zccache-compiler = { workspace = true }

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -22,6 +22,8 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL_WIN: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+mod snapshot_fp;
+
 use clap::{Parser, Subcommand, ValueEnum};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -281,6 +283,48 @@ enum Commands {
         /// Skip `*/build/*/out/` directories during the walk.
         #[arg(long)]
         prune_build_script_out: bool,
+    },
+    /// Pre-tar: record blake3 hashes of every workspace source tracked by
+    /// each crate's cargo dep-info. The sidecar manifest written under
+    /// `<target>/.zccache-fp-manifest.json` lets `snapshot-fp-validate`
+    /// (run post-restore on a different runner) decide *per crate* which
+    /// fingerprints still match the current source tree. See the rationale
+    /// in `snapshot_fp.rs`.
+    #[command(name = "snapshot-fp-record")]
+    SnapshotFpRecord {
+        /// Cargo target directory (default: ./target).
+        #[arg(long, default_value = "target")]
+        target_dir: PathBuf,
+        /// Workspace root (paths in the manifest are stored relative to this).
+        /// Defaults to the current working directory.
+        #[arg(long)]
+        workspace_root: Option<PathBuf>,
+        /// Build profile under target/ to walk (default: debug).
+        #[arg(long, default_value = "debug")]
+        profile: String,
+        /// Manifest output path (default: `<target>/.zccache-fp-manifest.json`).
+        #[arg(long)]
+        manifest_path: Option<PathBuf>,
+    },
+    /// Post-restore: read the manifest and bump only the dep-info mtimes of
+    /// crates whose every tracked source still matches its recorded hash.
+    /// Crates with any mismatch are left alone so cargo's normal
+    /// `source.mtime > dep_info.mtime → rebuild` check fires for them.
+    #[command(name = "snapshot-fp-validate")]
+    SnapshotFpValidate {
+        #[arg(long, default_value = "target")]
+        target_dir: PathBuf,
+        #[arg(long)]
+        workspace_root: Option<PathBuf>,
+        #[arg(long, default_value = "debug")]
+        profile: String,
+        #[arg(long)]
+        manifest_path: Option<PathBuf>,
+        /// How far in the future (seconds) to stamp clean crates' dep-info
+        /// files. Default 60 matches the existing post-restore touch step
+        /// in `action.yml` so output and fingerprint mtimes line up.
+        #[arg(long, default_value_t = 60)]
+        stamp_seconds_ahead: u64,
     },
 }
 
@@ -568,6 +612,9 @@ const KNOWN_SUBCOMMANDS: &[&str] = &[
     "gha-cache",
     "rust-plan",
     "warm",
+    "snapshot-bytes",
+    "snapshot-fp-record",
+    "snapshot-fp-validate",
     "help",
     "--help",
     "-h",
@@ -841,6 +888,25 @@ fn main() -> ExitCode {
             prune_incremental,
             prune_build_script_out,
         } => cmd_snapshot_bytes(&target, prune_incremental, prune_build_script_out),
+        Commands::SnapshotFpRecord {
+            target_dir,
+            workspace_root,
+            profile,
+            manifest_path,
+        } => cmd_snapshot_fp_record(&target_dir, workspace_root, &profile, manifest_path),
+        Commands::SnapshotFpValidate {
+            target_dir,
+            workspace_root,
+            profile,
+            manifest_path,
+            stamp_seconds_ahead,
+        } => cmd_snapshot_fp_validate(
+            &target_dir,
+            workspace_root,
+            &profile,
+            manifest_path,
+            stamp_seconds_ahead,
+        ),
     }
 }
 
@@ -2397,6 +2463,62 @@ fn cmd_snapshot_bytes(
         }
         Err(err) => {
             eprintln!("zccache snapshot-bytes: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn cmd_snapshot_fp_record(
+    target_dir: &Path,
+    workspace_root: Option<PathBuf>,
+    profile: &str,
+    manifest_path: Option<PathBuf>,
+) -> ExitCode {
+    let workspace = workspace_root.unwrap_or_else(|| std::env::current_dir().expect("cwd"));
+    let manifest = manifest_path.unwrap_or_else(|| target_dir.join(snapshot_fp::MANIFEST_FILENAME));
+    match snapshot_fp::record(target_dir, &workspace, &manifest, profile) {
+        Ok(stats) => {
+            eprintln!(
+                "zccache snapshot-fp-record: wrote {} ({} crates, {} sources)",
+                manifest.display(),
+                stats.crates_recorded,
+                stats.sources_hashed,
+            );
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("zccache snapshot-fp-record: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn cmd_snapshot_fp_validate(
+    target_dir: &Path,
+    workspace_root: Option<PathBuf>,
+    profile: &str,
+    manifest_path: Option<PathBuf>,
+    stamp_seconds_ahead: u64,
+) -> ExitCode {
+    let workspace = workspace_root.unwrap_or_else(|| std::env::current_dir().expect("cwd"));
+    let manifest = manifest_path.unwrap_or_else(|| target_dir.join(snapshot_fp::MANIFEST_FILENAME));
+    match snapshot_fp::validate(
+        target_dir,
+        &workspace,
+        &manifest,
+        profile,
+        stamp_seconds_ahead,
+    ) {
+        Ok(stats) => {
+            eprintln!(
+                "zccache snapshot-fp-validate: {} clean / {} dirty",
+                stats.crates_clean,
+                stats.crates_dirty(),
+            );
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("zccache snapshot-fp-validate: {e}");
             ExitCode::FAILURE
         }
     }

--- a/crates/zccache-cli/src/snapshot_fp.rs
+++ b/crates/zccache-cli/src/snapshot_fp.rs
@@ -1,0 +1,473 @@
+//! Per-crate fingerprint revalidation for `zccache`-managed target snapshots.
+//!
+//! ## Why this exists
+//!
+//! `actions/checkout` writes every source file with mtime ≈ "now", and
+//! `actions/cache` brings a `target/` snapshot back with mtimes from when
+//! that snapshot was originally tarred (always in the past). Cargo's
+//! freshness check (`source.mtime > dep_info.mtime → rebuild`) then sees
+//! every source as newer than every fingerprint and cold-rebuilds the
+//! whole workspace. The `action.yml` workaround — touching every file in
+//! `target/` to "now + 1 minute" — defeats the check too aggressively:
+//! cargo trusts the cache even for crates whose source actually changed,
+//! silently linking the previous commit's compiled binary against the new
+//! source tree.
+//!
+//! The optimal fix is to use a content hash instead of mtime to decide
+//! freshness. Stable cargo doesn't support that (`-Z checksum-freshness`
+//! is nightly-only), so we replicate the same idea in a sidecar:
+//!
+//!   1. **Save side** (`snapshot_fp::record`): before tarring, walk every
+//!      `target/debug/.fingerprint/<crate>-*` directory. For each, find
+//!      the matching `target/debug/deps/<crate>-*.d` Makefile dep file
+//!      (rustc-emitted, easy to parse) and blake3-hash every tracked
+//!      source under the workspace root. Emit a JSON sidecar at
+//!      `<target>/<MANIFEST_FILENAME>` listing per-crate (fp_dir,
+//!      dep_info_files, source_path → blake3) entries.
+//!
+//!   2. **Restore side** (`snapshot_fp::validate`): after the snapshot is
+//!      extracted, recompute current hashes for every source in the
+//!      manifest (parallel via rayon). For each crate where **every**
+//!      tracked source still matches its recorded hash, future-stamp its
+//!      `dep_info_files` so cargo trusts the cache. Crates with any
+//!      mismatch are left alone — cargo's normal stale check then
+//!      correctly rebuilds them.
+//!
+//! Output mtimes (`.rlib`/`.rmeta`/build artifacts) are handled by the
+//! existing post-restore touch step in `action.yml`, which already
+//! excludes `.fingerprint/` (see #279). The two layers compose cleanly:
+//! outputs always future-stamped; fingerprints future-stamped *only* for
+//! crates we can prove are still fresh.
+
+use std::collections::BTreeMap;
+use std::fs::FileTimes;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// Default name of the sidecar manifest, written under `<target>/`. Lives
+/// inside `target/` so it rides the existing snapshot tar without needing
+/// special handling in `prepare-target-snapshot.sh`.
+pub const MANIFEST_FILENAME: &str = ".zccache-fp-manifest.json";
+
+/// Manifest schema version. Bump if you change the layout. `validate`
+/// refuses to operate on unknown versions and exits cleanly so a snapshot
+/// saved by an older daemon doesn't poison a new run.
+const MANIFEST_VERSION: u32 = 1;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Manifest {
+    pub version: u32,
+    /// Informational; ISO8601 timestamp at record time.
+    pub saved_at: String,
+    /// Absolute workspace root recorded at save time. The manifest stores
+    /// every source path relative to this so restore on a different runner
+    /// (different home dir, etc.) can re-anchor.
+    pub workspace_root: String,
+    pub crates: Vec<CrateEntry>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CrateEntry {
+    /// Directory name under `target/<profile>/.fingerprint/`, e.g.
+    /// `zccache-daemon-0020565b109aa8e3`.
+    pub fingerprint_dir: String,
+    /// File names within `fingerprint_dir` that cargo treats as the
+    /// staleness anchor for this crate (`dep-*` files). All of these get
+    /// touched together if the crate is unchanged.
+    pub dep_info_files: Vec<String>,
+    /// Workspace-relative source paths → blake3 hex digest.
+    pub sources: BTreeMap<String, String>,
+}
+
+/// Walk `target/<profile>/.fingerprint/` and the sibling `deps/` directory
+/// to build the manifest. Hashing runs in parallel.
+pub fn record(
+    target_dir: &Path,
+    workspace_root: &Path,
+    manifest_path: &Path,
+    profile: &str,
+) -> io::Result<RecordStats> {
+    let fp_root = target_dir.join(profile).join(".fingerprint");
+    let deps_root = target_dir.join(profile).join("deps");
+    if !fp_root.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("fingerprint dir not found: {}", fp_root.display()),
+        ));
+    }
+
+    // Phase 1: enumerate (fingerprint_dir, dep_info_files, .d_file) triples.
+    let crate_dirs: Vec<(String, Vec<String>, PathBuf)> = std::fs::read_dir(&fp_root)?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .filter_map(|e| {
+            let dir_name = e.file_name().to_string_lossy().into_owned();
+            let dep_info_files: Vec<String> = std::fs::read_dir(e.path())
+                .ok()?
+                .filter_map(|f| f.ok())
+                .map(|f| f.file_name().to_string_lossy().into_owned())
+                .filter(|n| n.starts_with("dep-"))
+                .collect();
+            if dep_info_files.is_empty() {
+                return None;
+            }
+            let d_file = deps_root.join(format!("{dir_name}.d"));
+            if !d_file.is_file() {
+                return None;
+            }
+            Some((dir_name, dep_info_files, d_file))
+        })
+        .collect();
+
+    // Phase 2: parse each .d file and hash every workspace source. Parallel
+    // across crates AND across sources within a crate.
+    let workspace_root = workspace_root
+        .canonicalize()
+        .unwrap_or_else(|_| workspace_root.to_path_buf());
+    let entries: Vec<CrateEntry> = crate_dirs
+        .par_iter()
+        .filter_map(|(dir_name, dep_info_files, d_file)| {
+            let content = std::fs::read_to_string(d_file).ok()?;
+            let sources = parse_d_file(&content);
+            let hashed: BTreeMap<String, String> = sources
+                .par_iter()
+                .filter_map(|src| {
+                    let canon = src.canonicalize().ok()?;
+                    let rel = canon.strip_prefix(&workspace_root).ok()?;
+                    // Skip cargo registry / git-vendored deps: they're pinned
+                    // by Cargo.lock (which is part of the cache key), so they
+                    // can't drift between save and restore. Hashing them just
+                    // bloats the manifest.
+                    if is_vendored_dep(rel) {
+                        return None;
+                    }
+                    let bytes = std::fs::read(&canon).ok()?;
+                    let hash = blake3::hash(&bytes).to_hex().to_string();
+                    let key = path_to_unix(rel);
+                    Some((key, hash))
+                })
+                .collect();
+            if hashed.is_empty() {
+                // Crate has no workspace-local sources (pure registry deps).
+                // We can't prove freshness from workspace content, so omit
+                // the crate from the manifest entirely → validate leaves
+                // its fingerprint alone (cargo's normal check applies).
+                return None;
+            }
+            Some(CrateEntry {
+                fingerprint_dir: dir_name.clone(),
+                dep_info_files: dep_info_files.clone(),
+                sources: hashed,
+            })
+        })
+        .collect();
+
+    let stats = RecordStats {
+        crates_recorded: entries.len(),
+        sources_hashed: entries.iter().map(|c| c.sources.len()).sum(),
+    };
+
+    let manifest = Manifest {
+        version: MANIFEST_VERSION,
+        saved_at: chrono_like_now(),
+        workspace_root: path_to_unix(&workspace_root),
+        crates: entries,
+    };
+
+    if let Some(parent) = manifest_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let serialized = serde_json::to_string(&manifest)
+        .map_err(|e| io::Error::other(format!("serialize manifest: {e}")))?;
+    std::fs::write(manifest_path, serialized)?;
+
+    Ok(stats)
+}
+
+#[derive(Debug, Default)]
+pub struct RecordStats {
+    pub crates_recorded: usize,
+    pub sources_hashed: usize,
+}
+
+/// Read the manifest written by `record` and selectively bump `dep-*`
+/// mtimes for crates whose tracked sources still match their recorded
+/// hash. Crates with any mismatch are left untouched (cargo will detect
+/// staleness via its normal `source.mtime > dep_info.mtime` check).
+pub fn validate(
+    target_dir: &Path,
+    workspace_root: &Path,
+    manifest_path: &Path,
+    profile: &str,
+    stamp_seconds_ahead: u64,
+) -> io::Result<ValidateStats> {
+    let manifest_bytes = match std::fs::read(manifest_path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            // No manifest in the snapshot — snapshot was saved by an
+            // older daemon. Safe behaviour: do nothing; cargo's normal
+            // mtime check fires (overbuild but correct).
+            return Ok(ValidateStats::default());
+        }
+        Err(e) => return Err(e),
+    };
+    let manifest: Manifest = match serde_json::from_slice(&manifest_bytes) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(
+                path = %manifest_path.display(),
+                "manifest parse failed, leaving fingerprints alone: {e}"
+            );
+            return Ok(ValidateStats::default());
+        }
+    };
+    if manifest.version != MANIFEST_VERSION {
+        tracing::warn!(
+            recorded = manifest.version,
+            current = MANIFEST_VERSION,
+            "manifest version mismatch, leaving fingerprints alone",
+        );
+        return Ok(ValidateStats::default());
+    }
+
+    let workspace_root = workspace_root
+        .canonicalize()
+        .unwrap_or_else(|_| workspace_root.to_path_buf());
+    let fp_root = target_dir.join(profile).join(".fingerprint");
+    let stamp_time = SystemTime::now() + Duration::from_secs(stamp_seconds_ahead);
+    let file_times = FileTimes::new()
+        .set_modified(stamp_time)
+        .set_accessed(stamp_time);
+
+    let results: Vec<bool> = manifest
+        .crates
+        .par_iter()
+        .map(|entry| {
+            let all_unchanged = entry.sources.par_iter().all(|(rel, expected_hex)| {
+                let abs = workspace_root.join(rel);
+                match std::fs::read(&abs) {
+                    Ok(bytes) => blake3::hash(&bytes).to_hex().to_string() == *expected_hex,
+                    Err(_) => false,
+                }
+            });
+            if all_unchanged {
+                for dep_file in &entry.dep_info_files {
+                    let path = fp_root.join(&entry.fingerprint_dir).join(dep_file);
+                    if let Ok(file) = std::fs::OpenOptions::new().write(true).open(&path) {
+                        let _ = file.set_times(file_times);
+                    }
+                }
+            }
+            all_unchanged
+        })
+        .collect();
+
+    Ok(ValidateStats {
+        crates_total: manifest.crates.len(),
+        crates_clean: results.iter().filter(|c| **c).count(),
+    })
+}
+
+#[derive(Debug, Default)]
+pub struct ValidateStats {
+    pub crates_total: usize,
+    pub crates_clean: usize,
+}
+
+impl ValidateStats {
+    pub fn crates_dirty(&self) -> usize {
+        self.crates_total - self.crates_clean
+    }
+}
+
+/// Parse rustc's Makefile-format `.d` dep file. Format:
+///
+/// ```text
+/// <output_path>: <dep1> <dep2> <dep3...>
+/// ```
+///
+/// Spaces inside paths are backslash-escaped (`\ `), per Make convention.
+/// Multiple lines may appear; cargo emits one line per output product.
+fn parse_d_file(content: &str) -> Vec<PathBuf> {
+    let mut out = std::collections::HashSet::<PathBuf>::new();
+    for line in content.lines() {
+        // Find the ": " that separates outputs from dependencies. Windows
+        // paths contain ":" (drive letter), so we can't just split on ':'.
+        let Some(idx) = line.find(": ") else { continue };
+        let deps_str = &line[idx + 2..];
+        let mut buf = String::new();
+        let mut chars = deps_str.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\\' && chars.peek().map(|&n| n == ' ').unwrap_or(false) {
+                buf.push(' ');
+                chars.next();
+            } else if c.is_whitespace() {
+                if !buf.is_empty() {
+                    out.insert(PathBuf::from(&buf));
+                    buf.clear();
+                }
+            } else {
+                buf.push(c);
+            }
+        }
+        if !buf.is_empty() {
+            out.insert(PathBuf::from(&buf));
+        }
+    }
+    out.into_iter().collect()
+}
+
+/// Path → forward-slash UTF-8 string. The manifest must be cross-platform
+/// (Linux save, Windows restore, and vice-versa). Also strips any Windows
+/// extended-length prefix (`\\?\`) that `canonicalize` adds, so the same
+/// manifest reads cleanly on either OS.
+fn path_to_unix(p: &Path) -> String {
+    let s = p.to_string_lossy();
+    let s = s.strip_prefix(r"\\?\").unwrap_or(&s);
+    s.replace('\\', "/")
+}
+
+/// True if `rel` (workspace-relative) points into a cargo registry or git
+/// vendored-dep tree. Those are pinned by `Cargo.lock` and don't drift
+/// between snapshot save and restore.
+fn is_vendored_dep(rel: &Path) -> bool {
+    let s = path_to_unix(rel);
+    s.starts_with(".cargo/registry/")
+        || s.starts_with(".cargo/git/")
+        || s.contains("/.cargo/registry/")
+        || s.contains("/.cargo/git/")
+}
+
+/// Best-effort ISO-8601-ish timestamp without pulling chrono in as a dep.
+fn chrono_like_now() -> String {
+    let secs = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format!("epoch:{secs}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write(path: &Path, content: &str) {
+        if let Some(p) = path.parent() {
+            std::fs::create_dir_all(p).unwrap();
+        }
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+    }
+
+    fn make_synthetic_target(root: &Path, source_content: &str) -> (PathBuf, PathBuf) {
+        let workspace = root.join("workspace");
+        let target = workspace.join("target");
+        let profile = "debug";
+        let fp_dir = target.join(profile).join(".fingerprint").join("foo-abcd");
+        let deps_dir = target.join(profile).join("deps");
+        std::fs::create_dir_all(&fp_dir).unwrap();
+        std::fs::create_dir_all(&deps_dir).unwrap();
+        // Synthetic source under workspace
+        let src = workspace.join("crates/foo/src/lib.rs");
+        write(&src, source_content);
+        // dep-* file (cargo's binary-format anchor — we only use its mtime)
+        write(&fp_dir.join("dep-lib-foo"), "dummy");
+        // .d makefile (the file `record` actually parses)
+        let canon_src = src.canonicalize().unwrap();
+        let d_content = format!(
+            "{}: {}\n",
+            deps_dir.join("libfoo-abcd.rmeta").display(),
+            canon_src.display()
+        );
+        write(&deps_dir.join("foo-abcd.d"), &d_content);
+        (workspace, target)
+    }
+
+    #[test]
+    fn record_and_validate_unchanged_crate_is_clean() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (workspace, target) = make_synthetic_target(tmp.path(), "fn main() {}\n");
+
+        let manifest = target.join(MANIFEST_FILENAME);
+        let stats = record(&target, &workspace, &manifest, "debug").unwrap();
+        assert_eq!(stats.crates_recorded, 1);
+        assert_eq!(stats.sources_hashed, 1);
+
+        // Mtime before validate
+        let dep_path = target.join("debug/.fingerprint/foo-abcd/dep-lib-foo");
+        let before = std::fs::metadata(&dep_path).unwrap().modified().unwrap();
+
+        // Validate without modifying source — should touch the dep-info.
+        let stats = validate(&target, &workspace, &manifest, "debug", 60).unwrap();
+        assert_eq!(stats.crates_clean, 1);
+        assert_eq!(stats.crates_dirty(), 0);
+
+        let after = std::fs::metadata(&dep_path).unwrap().modified().unwrap();
+        assert!(after > before, "dep-info mtime should have been bumped");
+    }
+
+    #[test]
+    fn validate_dirty_crate_is_left_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (workspace, target) = make_synthetic_target(tmp.path(), "fn main() {}\n");
+        let manifest = target.join(MANIFEST_FILENAME);
+        record(&target, &workspace, &manifest, "debug").unwrap();
+
+        let dep_path = target.join("debug/.fingerprint/foo-abcd/dep-lib-foo");
+        let before = std::fs::metadata(&dep_path).unwrap().modified().unwrap();
+        // Simulate a source edit (different content → different hash).
+        std::thread::sleep(Duration::from_millis(20));
+        std::fs::write(
+            workspace.join("crates/foo/src/lib.rs"),
+            "fn main() { println!(\"hi\"); }\n",
+        )
+        .unwrap();
+
+        let stats = validate(&target, &workspace, &manifest, "debug", 60).unwrap();
+        assert_eq!(
+            stats.crates_clean, 0,
+            "modified source should leave crate dirty"
+        );
+        assert_eq!(stats.crates_dirty(), 1);
+
+        let after = std::fs::metadata(&dep_path).unwrap().modified().unwrap();
+        assert_eq!(after, before, "dirty crate's dep-info mtime must not move");
+    }
+
+    #[test]
+    fn validate_missing_manifest_is_silent_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stats = validate(
+            tmp.path(),
+            tmp.path(),
+            &tmp.path().join(".missing"),
+            "debug",
+            60,
+        )
+        .unwrap();
+        assert_eq!(stats.crates_total, 0);
+    }
+
+    #[test]
+    fn parse_d_file_handles_unix_and_windows_paths() {
+        let content = "/tmp/out: /a/b.rs /a/c.rs\nC:\\out: C:\\a\\b.rs C:\\a\\c.rs\n";
+        let parsed = parse_d_file(content);
+        assert!(parsed.iter().any(|p| p == Path::new("/a/b.rs")));
+        assert!(parsed.iter().any(|p| p == Path::new("/a/c.rs")));
+        assert!(parsed.iter().any(|p| p == Path::new("C:\\a\\b.rs")));
+        assert!(parsed.iter().any(|p| p == Path::new("C:\\a\\c.rs")));
+    }
+
+    #[test]
+    fn parse_d_file_handles_escaped_spaces() {
+        // Path with literal space in it: "/a path/foo.rs"
+        let content = "/out: /a\\ path/foo.rs\n";
+        let parsed = parse_d_file(content);
+        assert!(parsed.iter().any(|p| p == Path::new("/a path/foo.rs")));
+    }
+}


### PR DESCRIPTION
## Summary
Replaces #279's blanket "don't touch fingerprints" with a per-crate decision based on **blake3 of source content** — a stable-cargo replica of nightly's \`-Z checksum-freshness\`.

- **Save side**: \`zccache snapshot-fp-record\` walks each cargo fingerprint dir, parses its rustc-emitted \`.d\` Makefile, blake3-hashes every workspace-local source (skipping vendored \`.cargo/registry/\` paths), writes a JSON sidecar at \`<target>/.zccache-fp-manifest.json\` that rides the existing snapshot tar.
- **Restore side**: \`zccache snapshot-fp-validate\` rehashes every recorded source in parallel. Crates where **every** source still matches → future-stamp their \`dep-*\` files so cargo trusts the cache. Crates with any mismatch → leave alone so cargo invokes rustc.

## What changes for users
| Scenario | Before #279 | #279 | This PR |
|---|---|---|---|
| Unchanged sources | Skip rustc (fast) | Cargo re-fingerprints every crate (slow) | Skip rustc (fast) ✓ |
| Changed sources in 1 crate | **Silently links old binary (BUG)** | Re-fingerprints every crate (slow but correct) | Re-fingerprints only changed crate (correct & fast) ✓ |
| Missing manifest (snapshot from older daemon) | n/a | n/a | Falls back to #279 behaviour ✓ |

## Bench (this workspace's \`target/\`)
- \`snapshot-fp-record\`: 350 ms, 6.2 KB manifest, 38 workspace sources hashed
- \`snapshot-fp-validate\`: 37 ms (all clean)

## Files
- \`crates/zccache-cli/src/snapshot_fp.rs\` (new, +473 / 5 unit tests)
- Two new subcommands in \`crates/zccache-cli/src/main.rs\`
- Wired in \`action.yml\` (validate between warm + touch) and \`action/cleanup/action.yml\` (record before tar)
- \`action/cleanup/select-hot-target.py\`: keep the manifest in hot-mode tars

Closes #280. Builds on #279 — that PR's conservative "rebuild everything" is now the fallback path when the manifest is absent or unparseable.

## Test plan
- [x] 5 unit tests
- [x] Local smoke against this repo's \`target/\`
- [x] cargo clippy + fmt clean
- [ ] CI: push a single-line test edit; only that crate rebuilds
- [ ] CI: unchanged-source PR hits the fast path (clean count > 0 in validate log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)