### PR TITLE
perf(gha): handle build scripts in snapshot-fp; drop blanket touch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -415,33 +415,27 @@ runs:
           zccache warm --target-dir "$TARGET" || true
           # Per-crate fingerprint revalidation — the content-hash analogue
           # of cargo's nightly `-Z checksum-freshness`. For each crate in
-          # the manifest written at save time, recompute blake3 of every
-          # tracked workspace source. If all hashes still match → bump
-          # that crate's dep-info mtime to "future" so cargo's normal
-          # `source.mtime > dep_info.mtime` check skips rustc. Crates with
-          # any mismatch are left alone → cargo correctly invokes rustc.
-          # Missing manifest (older snapshot) is a silent no-op: cargo
-          # falls through to its baseline check (overbuild but correct).
+          # the sidecar manifest written at save time, recompute blake3 of
+          # every tracked workspace source. If all hashes still match →
+          # bump that crate's freshness anchors (in-fingerprint dep-info
+          # files for lib/bin/test/build-script-compile, plus the `output`
+          # file referenced by RerunIfChanged for build-script-run) so
+          # cargo's normal `source.mtime > anchor.mtime` check trusts the
+          # cache. Crates with any mismatch are left alone → cargo
+          # correctly invokes rustc and/or reruns build scripts. Missing
+          # manifest (snapshot saved by an older daemon) is a silent
+          # no-op: cargo falls through to its baseline check (overbuild
+          # but correct).
+          #
+          # No blanket `find ... touch '+1 min'` follows. snapshot-fp-validate
+          # covers every freshness signal cargo uses for workspace crates,
+          # so there is nothing left to forge — see PR #279 for the
+          # original underbuild bug a blanket touch caused.
           zccache snapshot-fp-validate \
             --target-dir "$TARGET" \
             --workspace-root "$GITHUB_WORKSPACE" \
             --stamp-seconds-ahead 60 \
             || true
-          # Touch restored *output* files (rlib/rmeta/build artifacts) to ONE
-          # fixed future timestamp so cargo's "output newer than source"
-          # check passes for unchanged crates after restore. Plain 'touch'
-          # gives 1ms differences between files, which cargo interprets as
-          # "dep newer than output" → dirty.
-          #
-          # EXCLUDE .fingerprint/ from the stamping pass. Those directories
-          # hold the dep-info files cargo uses to decide whether to re-invoke
-          # rustc at all: snapshot-fp-validate above has already future-
-          # stamped only the dep-info files of unchanged crates. A blanket
-          # touch here would clobber that decision and silently underbuild
-          # changed crates — see PR #279 for the bug and rationale.
-          STAMP=$(date -d '+1 minute' +%Y%m%d%H%M.%S 2>/dev/null || date -v+1M +%Y%m%d%H%M.%S)
-          find "$TARGET" -type f -not -path '*/.fingerprint/*' \
-            -exec touch -t "$STAMP" {} + 2>/dev/null || true
         fi
 
     # --- Start daemon ---

--- a/crates/zccache-cli/src/snapshot_fp.rs
+++ b/crates/zccache-cli/src/snapshot_fp.rs
@@ -1,45 +1,53 @@
 //! Per-crate fingerprint revalidation for `zccache`-managed target snapshots.
 //!
-//! ## Why this exists
+//! # Why this exists
 //!
 //! `actions/checkout` writes every source file with mtime ≈ "now", and
 //! `actions/cache` brings a `target/` snapshot back with mtimes from when
 //! that snapshot was originally tarred (always in the past). Cargo's
 //! freshness check (`source.mtime > dep_info.mtime → rebuild`) then sees
-//! every source as newer than every fingerprint and cold-rebuilds the
-//! whole workspace. The `action.yml` workaround — touching every file in
-//! `target/` to "now + 1 minute" — defeats the check too aggressively:
-//! cargo trusts the cache even for crates whose source actually changed,
-//! silently linking the previous commit's compiled binary against the new
-//! source tree.
+//! every source as newer than every fingerprint anchor and cold-rebuilds
+//! the whole workspace. The original `action.yml` workaround — touching
+//! every file in `target/` to "now + 1 minute" — defeated the check too
+//! aggressively: cargo trusted the cache even for crates whose source had
+//! actually changed, silently linking the previous commit's compiled
+//! binary against the new source tree (see PR #279 for the bug).
 //!
 //! The optimal fix is to use a content hash instead of mtime to decide
 //! freshness. Stable cargo doesn't support that (`-Z checksum-freshness`
-//! is nightly-only), so we replicate the same idea in a sidecar:
+//! is nightly-only), so we replicate the same idea per crate in a sidecar:
 //!
-//!   1. **Save side** (`snapshot_fp::record`): before tarring, walk every
-//!      `target/debug/.fingerprint/<crate>-*` directory. For each, find
-//!      the matching `target/debug/deps/<crate>-*.d` Makefile dep file
-//!      (rustc-emitted, easy to parse) and blake3-hash every tracked
-//!      source under the workspace root. Emit a JSON sidecar at
-//!      `<target>/<MANIFEST_FILENAME>` listing per-crate (fp_dir,
-//!      dep_info_files, source_path → blake3) entries.
+//! * **Save side** (`record`): before tarring, walk every cargo fingerprint
+//!   dir under `target/<profile>/.fingerprint/`. For each compilation unit
+//!   tracked by that fingerprint, find its source-input list and
+//!   blake3-hash every workspace-local source. Emit a JSON sidecar at
+//!   `<target>/<MANIFEST_FILENAME>` listing per-crate
+//!   `(fingerprint_dir, stamp_targets, source_path → blake3)` entries.
+//! * **Restore side** (`validate`): rehash every recorded source in
+//!   parallel. For each crate where *every* tracked source still matches
+//!   its recorded hash, future-stamp that crate's `stamp_targets` so
+//!   cargo trusts the cache. Crates with any mismatch are left untouched
+//!   so cargo's normal stale check correctly rebuilds them.
 //!
-//!   2. **Restore side** (`snapshot_fp::validate`): after the snapshot is
-//!      extracted, recompute current hashes for every source in the
-//!      manifest (parallel via rayon). For each crate where **every**
-//!      tracked source still matches its recorded hash, future-stamp its
-//!      `dep_info_files` so cargo trusts the cache. Crates with any
-//!      mismatch are left alone — cargo's normal stale check then
-//!      correctly rebuilds them.
+//! ## Fingerprint kinds handled
 //!
-//! Output mtimes (`.rlib`/`.rmeta`/build artifacts) are handled by the
-//! existing post-restore touch step in `action.yml`, which already
-//! excludes `.fingerprint/` (see #279). The two layers compose cleanly:
-//! outputs always future-stamped; fingerprints future-stamped *only* for
-//! crates we can prove are still fresh.
+//! 1. **Library / bin / test compilation** (cargo's `CheckDepInfo`
+//!    LocalFingerprint). The dep file lives at
+//!    `<fp_dir>/dep-{lib,bin,test}-<...>`; the matching `.d` Makefile is
+//!    at `target/<profile>/deps/<fp_dir>.d`.
+//! 2. **Build script compilation** (also `CheckDepInfo`). The dep file
+//!    is `<fp_dir>/dep-build-script-build-script-build`; the `.d` file
+//!    lives at `target/<profile>/build/<fp_dir>/build_script_build-<hash>.d`.
+//! 3. **Build script execution** (`RerunIfChanged`). No `.d` file; the
+//!    json fingerprint lists `paths` relative to the crate's manifest
+//!    directory and an `output` file in `target/<profile>/build/<fp_dir>/`
+//!    that cargo treats as the freshness anchor.
+//!
+//! Together these cover every freshness signal cargo uses for workspace
+//! crates, so the blanket post-restore `find ... -touch '+1 min'` step in
+//! `action.yml` is no longer necessary.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::FileTimes;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -48,24 +56,28 @@ use std::time::{Duration, SystemTime};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-/// Default name of the sidecar manifest, written under `<target>/`. Lives
-/// inside `target/` so it rides the existing snapshot tar without needing
+/// Name of the sidecar manifest, written under `<target>/`. Lives inside
+/// `target/` so it rides the existing snapshot tar without needing
 /// special handling in `prepare-target-snapshot.sh`.
 pub const MANIFEST_FILENAME: &str = ".zccache-fp-manifest.json";
 
 /// Manifest schema version. Bump if you change the layout. `validate`
 /// refuses to operate on unknown versions and exits cleanly so a snapshot
 /// saved by an older daemon doesn't poison a new run.
-const MANIFEST_VERSION: u32 = 1;
+///
+/// v2: generalised `dep_info_files` (list of names inside the fingerprint
+/// dir) into `stamp_targets` (list of paths relative to target_dir) so we
+/// can address both the in-fingerprint anchors used by `CheckDepInfo` and
+/// the `out`-style anchor files used by `RerunIfChanged`.
+const MANIFEST_VERSION: u32 = 2;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Manifest {
     pub version: u32,
-    /// Informational; ISO8601 timestamp at record time.
+    /// Informational; `epoch:<unix-seconds>` at record time.
     pub saved_at: String,
-    /// Absolute workspace root recorded at save time. The manifest stores
-    /// every source path relative to this so restore on a different runner
-    /// (different home dir, etc.) can re-anchor.
+    /// Workspace root recorded at save time (forward-slash path). Stored
+    /// for diagnostics; restore re-anchors against the runtime workspace.
     pub workspace_root: String,
     pub crates: Vec<CrateEntry>,
 }
@@ -73,18 +85,20 @@ pub struct Manifest {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CrateEntry {
     /// Directory name under `target/<profile>/.fingerprint/`, e.g.
-    /// `zccache-daemon-0020565b109aa8e3`.
+    /// `zccache-daemon-0020565b109aa8e3`. Diagnostic only.
     pub fingerprint_dir: String,
-    /// File names within `fingerprint_dir` that cargo treats as the
-    /// staleness anchor for this crate (`dep-*` files). All of these get
-    /// touched together if the crate is unchanged.
-    pub dep_info_files: Vec<String>,
-    /// Workspace-relative source paths → blake3 hex digest.
+    /// Files to future-stamp if *every* recorded source still matches its
+    /// hash. Paths are stored relative to `target_dir`. Lib/bin/test
+    /// entries point at the in-`.fingerprint/` anchor; build-script-run
+    /// entries point at the output file referenced by `RerunIfChanged`.
+    pub stamp_targets: Vec<String>,
+    /// Workspace-relative source path → blake3 hex digest.
     pub sources: BTreeMap<String, String>,
 }
 
-/// Walk `target/<profile>/.fingerprint/` and the sibling `deps/` directory
-/// to build the manifest. Hashing runs in parallel.
+/// Walk `target/<profile>/.fingerprint/` and emit a manifest covering
+/// every CheckDepInfo / RerunIfChanged fingerprint with workspace-local
+/// source inputs. Hashing runs in parallel.
 pub fn record(
     target_dir: &Path,
     workspace_root: &Path,
@@ -92,77 +106,46 @@ pub fn record(
     profile: &str,
 ) -> io::Result<RecordStats> {
     let fp_root = target_dir.join(profile).join(".fingerprint");
-    let deps_root = target_dir.join(profile).join("deps");
     if !fp_root.is_dir() {
         return Err(io::Error::new(
             io::ErrorKind::NotFound,
             format!("fingerprint dir not found: {}", fp_root.display()),
         ));
     }
-
-    // Phase 1: enumerate (fingerprint_dir, dep_info_files, .d_file) triples.
-    let crate_dirs: Vec<(String, Vec<String>, PathBuf)> = std::fs::read_dir(&fp_root)?
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().is_dir())
-        .filter_map(|e| {
-            let dir_name = e.file_name().to_string_lossy().into_owned();
-            let dep_info_files: Vec<String> = std::fs::read_dir(e.path())
-                .ok()?
-                .filter_map(|f| f.ok())
-                .map(|f| f.file_name().to_string_lossy().into_owned())
-                .filter(|n| n.starts_with("dep-"))
-                .collect();
-            if dep_info_files.is_empty() {
-                return None;
-            }
-            let d_file = deps_root.join(format!("{dir_name}.d"));
-            if !d_file.is_file() {
-                return None;
-            }
-            Some((dir_name, dep_info_files, d_file))
-        })
-        .collect();
-
-    // Phase 2: parse each .d file and hash every workspace source. Parallel
-    // across crates AND across sources within a crate.
+    let deps_root = target_dir.join(profile).join("deps");
+    let build_root = target_dir.join(profile).join("build");
     let workspace_root = workspace_root
         .canonicalize()
         .unwrap_or_else(|_| workspace_root.to_path_buf());
-    let entries: Vec<CrateEntry> = crate_dirs
+
+    // For RerunIfChanged we need to resolve `paths` (relative to the
+    // crate's manifest directory) against the workspace. Discover the
+    // package-name → manifest-dir mapping once up front.
+    let manifest_dirs = discover_workspace_crates(&workspace_root);
+
+    // Phase 1: scan each `<fp_dir>/` for processable units.
+    let fp_dirs: Vec<PathBuf> = std::fs::read_dir(&fp_root)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+
+    // Phase 2: process all units in parallel. A single fingerprint dir
+    // can produce *multiple* manifest entries — e.g. one for the build
+    // script's compilation (`dep-build-script-build-script-build`) and
+    // one for its execution (`run-build-script-build-script-build.json`).
+    let entries: Vec<CrateEntry> = fp_dirs
         .par_iter()
-        .filter_map(|(dir_name, dep_info_files, d_file)| {
-            let content = std::fs::read_to_string(d_file).ok()?;
-            let sources = parse_d_file(&content);
-            let hashed: BTreeMap<String, String> = sources
-                .par_iter()
-                .filter_map(|src| {
-                    let canon = src.canonicalize().ok()?;
-                    let rel = canon.strip_prefix(&workspace_root).ok()?;
-                    // Skip cargo registry / git-vendored deps: they're pinned
-                    // by Cargo.lock (which is part of the cache key), so they
-                    // can't drift between save and restore. Hashing them just
-                    // bloats the manifest.
-                    if is_vendored_dep(rel) {
-                        return None;
-                    }
-                    let bytes = std::fs::read(&canon).ok()?;
-                    let hash = blake3::hash(&bytes).to_hex().to_string();
-                    let key = path_to_unix(rel);
-                    Some((key, hash))
-                })
-                .collect();
-            if hashed.is_empty() {
-                // Crate has no workspace-local sources (pure registry deps).
-                // We can't prove freshness from workspace content, so omit
-                // the crate from the manifest entirely → validate leaves
-                // its fingerprint alone (cargo's normal check applies).
-                return None;
-            }
-            Some(CrateEntry {
-                fingerprint_dir: dir_name.clone(),
-                dep_info_files: dep_info_files.clone(),
-                sources: hashed,
-            })
+        .flat_map(|fp_dir| {
+            process_fingerprint_dir(
+                fp_dir,
+                &fp_root,
+                &deps_root,
+                &build_root,
+                &workspace_root,
+                &manifest_dirs,
+                profile,
+            )
         })
         .collect();
 
@@ -194,25 +177,304 @@ pub struct RecordStats {
     pub sources_hashed: usize,
 }
 
-/// Read the manifest written by `record` and selectively bump `dep-*`
-/// mtimes for crates whose tracked sources still match their recorded
-/// hash. Crates with any mismatch are left untouched (cargo will detect
-/// staleness via its normal `source.mtime > dep_info.mtime` check).
+/// Inspect a single `<fp_root>/<fp_dir>` and return zero or more entries
+/// for the manifest.
+fn process_fingerprint_dir(
+    fp_dir: &Path,
+    fp_root: &Path,
+    deps_root: &Path,
+    build_root: &Path,
+    workspace_root: &Path,
+    manifest_dirs: &HashMap<String, PathBuf>,
+    profile: &str,
+) -> Vec<CrateEntry> {
+    let Some(dir_name) = fp_dir.file_name().and_then(|n| n.to_str()) else {
+        return vec![];
+    };
+    let mut entries = Vec::new();
+
+    // List of (dep_file_basename, .d_path) for CheckDepInfo-style units.
+    let mut depinfo_units: Vec<(String, PathBuf)> = Vec::new();
+    let mut has_run_build_script = false;
+
+    let Ok(read_dir) = std::fs::read_dir(fp_dir) else {
+        return vec![];
+    };
+    for entry in read_dir.filter_map(|e| e.ok()) {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name == "run-build-script-build-script-build.json" {
+            has_run_build_script = true;
+        } else if name == "dep-build-script-build-script-build" {
+            // Build-script compilation. .d file lives in build/<dir>/.
+            if let Some(d_file) = first_buildscript_d_file(build_root, dir_name) {
+                depinfo_units.push((name, d_file));
+            }
+        } else if name.starts_with("dep-") {
+            // Lib/bin/test compilation. .d file lives in deps/<dir>.d.
+            let d_file = deps_root.join(format!("{dir_name}.d"));
+            if d_file.is_file() {
+                depinfo_units.push((name, d_file));
+            }
+        }
+    }
+
+    // Group CheckDepInfo units of the same fingerprint dir into one
+    // entry, since they share the same source-input list (they're all
+    // for the same compilation invocation).
+    if !depinfo_units.is_empty() {
+        // All depinfo units in the same fp_dir reference the same .d file
+        // by definition. Use the first.
+        let d_file = depinfo_units[0].1.clone();
+        if let Some(sources) = hash_d_file_sources(&d_file, workspace_root) {
+            let stamp_targets: Vec<String> = depinfo_units
+                .iter()
+                .map(|(name, _)| {
+                    let abs = fp_root.join(dir_name).join(name);
+                    relativize_to_target(&abs, target_dir_from_fp_root(fp_root, profile))
+                })
+                .collect();
+            entries.push(CrateEntry {
+                fingerprint_dir: dir_name.to_string(),
+                stamp_targets,
+                sources,
+            });
+        }
+    }
+
+    if has_run_build_script {
+        if let Some(entry) =
+            process_run_build_script(fp_dir, dir_name, workspace_root, manifest_dirs)
+        {
+            entries.push(entry);
+        }
+    }
+
+    entries
+}
+
+fn target_dir_from_fp_root<'a>(fp_root: &'a Path, _profile: &str) -> &'a Path {
+    // fp_root = <target>/<profile>/.fingerprint
+    // target  = parent of <profile>
+    fp_root.parent().and_then(|p| p.parent()).unwrap_or(fp_root)
+}
+
+/// Resolve an absolute path under target/ to a target-relative
+/// forward-slash string.
+fn relativize_to_target(abs: &Path, target_dir: &Path) -> String {
+    let abs = abs.canonicalize().unwrap_or_else(|_| abs.to_path_buf());
+    let target = target_dir
+        .canonicalize()
+        .unwrap_or_else(|_| target_dir.to_path_buf());
+    match abs.strip_prefix(&target) {
+        Ok(rel) => path_to_unix(rel),
+        Err(_) => path_to_unix(abs.as_path()),
+    }
+}
+
+/// Pick the first build-script `.d` file inside
+/// `<build_root>/<dir_name>/`. Cargo emits `build_script_<scriptname>-<hash>.d`
+/// — we don't care about the exact name, only that it lists the script's
+/// source inputs.
+fn first_buildscript_d_file(build_root: &Path, dir_name: &str) -> Option<PathBuf> {
+    let bs_dir = build_root.join(dir_name);
+    let read_dir = std::fs::read_dir(&bs_dir).ok()?;
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("d") {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Parse a `.d` Makefile, hash each tracked workspace-local source, and
+/// return the (workspace-relative path → blake3 hex) map. Returns `None`
+/// if no workspace-local source was found (so the crate is omitted from
+/// the manifest — cargo's normal mtime check applies).
+fn hash_d_file_sources(d_file: &Path, workspace_root: &Path) -> Option<BTreeMap<String, String>> {
+    let content = std::fs::read_to_string(d_file).ok()?;
+    let sources = parse_d_file(&content);
+    let hashed: BTreeMap<String, String> = sources
+        .par_iter()
+        .filter_map(|src| {
+            let canon = src.canonicalize().ok()?;
+            let rel = canon.strip_prefix(workspace_root).ok()?;
+            if is_vendored_dep(rel) {
+                return None;
+            }
+            let bytes = std::fs::read(&canon).ok()?;
+            let hash = blake3::hash(&bytes).to_hex().to_string();
+            Some((path_to_unix(rel), hash))
+        })
+        .collect();
+    if hashed.is_empty() {
+        None
+    } else {
+        Some(hashed)
+    }
+}
+
+/// Read the `run-build-script-build-script-build.json` file in `fp_dir`
+/// and emit an entry covering its `RerunIfChanged` local fingerprints.
+fn process_run_build_script(
+    fp_dir: &Path,
+    dir_name: &str,
+    workspace_root: &Path,
+    manifest_dirs: &HashMap<String, PathBuf>,
+) -> Option<CrateEntry> {
+    let json_path = fp_dir.join("run-build-script-build-script-build.json");
+    let content = std::fs::read_to_string(&json_path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let local = value.get("local")?.as_array()?;
+
+    // Find the package's manifest dir from the fingerprint dir name. The
+    // dir name is `<package>-<16-hex-hash>`.
+    let pkg_name = strip_hash_suffix(dir_name)?;
+    let manifest_dir = manifest_dirs.get(pkg_name)?;
+
+    let mut sources = BTreeMap::new();
+    let mut stamp_targets: Vec<String> = Vec::new();
+    for item in local {
+        let Some(rerun) = item.get("RerunIfChanged") else {
+            continue;
+        };
+        let output = rerun
+            .get("output")
+            .and_then(|v| v.as_str())
+            .map(|s| s.replace('\\', "/"));
+        if let Some(out) = output {
+            stamp_targets.push(out);
+        }
+        let Some(paths) = rerun.get("paths").and_then(|p| p.as_array()) else {
+            continue;
+        };
+        for p in paths {
+            let Some(rel) = p.as_str() else { continue };
+            let abs = manifest_dir.join(rel);
+            let Ok(canon) = abs.canonicalize() else {
+                continue;
+            };
+            let Ok(ws_rel) = canon.strip_prefix(workspace_root) else {
+                continue;
+            };
+            if is_vendored_dep(ws_rel) {
+                continue;
+            }
+            let Ok(bytes) = std::fs::read(&canon) else {
+                continue;
+            };
+            let hash = blake3::hash(&bytes).to_hex().to_string();
+            sources.insert(path_to_unix(ws_rel), hash);
+        }
+    }
+
+    if sources.is_empty() || stamp_targets.is_empty() {
+        return None;
+    }
+    Some(CrateEntry {
+        fingerprint_dir: dir_name.to_string(),
+        stamp_targets,
+        sources,
+    })
+}
+
+/// `<crate>-<hex16>` → `Some("<crate>")`. Returns `None` if the suffix
+/// isn't a plausible cargo fingerprint hash.
+fn strip_hash_suffix(s: &str) -> Option<&str> {
+    let idx = s.rfind('-')?;
+    let (name, hash) = s.split_at(idx);
+    let hash = &hash[1..];
+    if hash.len() == 16 && hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(name)
+    } else {
+        None
+    }
+}
+
+/// Walk `workspace_root` for `Cargo.toml` files and build a
+/// `package_name → manifest_dir` map. Skips `target/`, `.cargo/`, `.git/`,
+/// `node_modules/`, and dot-directories.
+fn discover_workspace_crates(workspace_root: &Path) -> HashMap<String, PathBuf> {
+    use jwalk::WalkDirGeneric;
+    let mut map: HashMap<String, PathBuf> = HashMap::new();
+    let walker: WalkDirGeneric<((), ())> = WalkDirGeneric::new(workspace_root)
+        .skip_hidden(false)
+        .process_read_dir(|_depth, _parent, _, children| {
+            children.retain(|c| match c {
+                Ok(e) => {
+                    let name = e.file_name();
+                    let name_str = name.to_string_lossy();
+                    !matches!(
+                        name_str.as_ref(),
+                        "target" | ".cargo" | ".git" | "node_modules" | ".venv"
+                    )
+                }
+                Err(_) => false,
+            });
+        });
+    for entry in walker.into_iter().filter_map(|e| e.ok()) {
+        if entry.file_name() != "Cargo.toml" {
+            continue;
+        }
+        let path = entry.path();
+        let Some(pkg_name) = parse_package_name(&path) else {
+            continue;
+        };
+        let Some(dir) = path.parent() else { continue };
+        map.insert(pkg_name, dir.to_path_buf());
+    }
+    map
+}
+
+/// Minimal TOML parser that pulls only `[package].name = "..."`. Avoids
+/// adding a `toml` dep for a one-field lookup. Returns `None` if the file
+/// has no `[package]` section, no `name` key, or uses workspace inheritance
+/// (`name.workspace = true`).
+fn parse_package_name(toml_path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(toml_path).ok()?;
+    let mut in_package = false;
+    for raw in content.lines() {
+        let line = raw.split('#').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+        if line.starts_with('[') {
+            in_package = line == "[package]";
+            continue;
+        }
+        if !in_package {
+            continue;
+        }
+        let Some(rest) = line.strip_prefix("name") else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix('=') else {
+            // `name.workspace = true` lands here — workspace inheritance
+            // we don't resolve, so skip.
+            continue;
+        };
+        let val = rest.trim();
+        let val = val.trim_matches(|c: char| c == '"' || c == '\'');
+        if !val.is_empty() {
+            return Some(val.to_string());
+        }
+    }
+    None
+}
+
+/// Read the manifest written by `record` and selectively bump
+/// `stamp_targets` mtimes for crates whose tracked sources still match.
 pub fn validate(
     target_dir: &Path,
     workspace_root: &Path,
     manifest_path: &Path,
-    profile: &str,
+    _profile: &str,
     stamp_seconds_ahead: u64,
 ) -> io::Result<ValidateStats> {
     let manifest_bytes = match std::fs::read(manifest_path) {
         Ok(b) => b,
-        Err(e) if e.kind() == io::ErrorKind::NotFound => {
-            // No manifest in the snapshot — snapshot was saved by an
-            // older daemon. Safe behaviour: do nothing; cargo's normal
-            // mtime check fires (overbuild but correct).
-            return Ok(ValidateStats::default());
-        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(ValidateStats::default()),
         Err(e) => return Err(e),
     };
     let manifest: Manifest = match serde_json::from_slice(&manifest_bytes) {
@@ -237,7 +499,9 @@ pub fn validate(
     let workspace_root = workspace_root
         .canonicalize()
         .unwrap_or_else(|_| workspace_root.to_path_buf());
-    let fp_root = target_dir.join(profile).join(".fingerprint");
+    let target_dir = target_dir
+        .canonicalize()
+        .unwrap_or_else(|_| target_dir.to_path_buf());
     let stamp_time = SystemTime::now() + Duration::from_secs(stamp_seconds_ahead);
     let file_times = FileTimes::new()
         .set_modified(stamp_time)
@@ -255,9 +519,9 @@ pub fn validate(
                 }
             });
             if all_unchanged {
-                for dep_file in &entry.dep_info_files {
-                    let path = fp_root.join(&entry.fingerprint_dir).join(dep_file);
-                    if let Ok(file) = std::fs::OpenOptions::new().write(true).open(&path) {
+                for stamp_rel in &entry.stamp_targets {
+                    let stamp_abs = target_dir.join(stamp_rel);
+                    if let Ok(file) = std::fs::OpenOptions::new().write(true).open(&stamp_abs) {
                         let _ = file.set_times(file_times);
                     }
                 }
@@ -290,13 +554,10 @@ impl ValidateStats {
 /// <output_path>: <dep1> <dep2> <dep3...>
 /// ```
 ///
-/// Spaces inside paths are backslash-escaped (`\ `), per Make convention.
-/// Multiple lines may appear; cargo emits one line per output product.
+/// Spaces inside paths are backslash-escaped (`\ `).
 fn parse_d_file(content: &str) -> Vec<PathBuf> {
     let mut out = std::collections::HashSet::<PathBuf>::new();
     for line in content.lines() {
-        // Find the ": " that separates outputs from dependencies. Windows
-        // paths contain ":" (drive letter), so we can't just split on ':'.
         let Some(idx) = line.find(": ") else { continue };
         let deps_str = &line[idx + 2..];
         let mut buf = String::new();
@@ -321,10 +582,9 @@ fn parse_d_file(content: &str) -> Vec<PathBuf> {
     out.into_iter().collect()
 }
 
-/// Path → forward-slash UTF-8 string. The manifest must be cross-platform
-/// (Linux save, Windows restore, and vice-versa). Also strips any Windows
-/// extended-length prefix (`\\?\`) that `canonicalize` adds, so the same
-/// manifest reads cleanly on either OS.
+/// Path → forward-slash UTF-8 string. The manifest must be cross-platform.
+/// Strips the Windows `\\?\` extended-length prefix that `canonicalize`
+/// emits.
 fn path_to_unix(p: &Path) -> String {
     let s = p.to_string_lossy();
     let s = s.strip_prefix(r"\\?\").unwrap_or(&s);
@@ -342,7 +602,7 @@ fn is_vendored_dep(rel: &Path) -> bool {
         || s.contains("/.cargo/git/")
 }
 
-/// Best-effort ISO-8601-ish timestamp without pulling chrono in as a dep.
+/// Best-effort timestamp without pulling chrono in as a dep.
 fn chrono_like_now() -> String {
     let secs = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -364,79 +624,171 @@ mod tests {
         f.write_all(content.as_bytes()).unwrap();
     }
 
-    fn make_synthetic_target(root: &Path, source_content: &str) -> (PathBuf, PathBuf) {
+    /// Synthetic layout for a single lib crate "foo" at `workspace/crates/foo/`.
+    fn make_synthetic_lib(root: &Path, source_content: &str) -> (PathBuf, PathBuf) {
         let workspace = root.join("workspace");
         let target = workspace.join("target");
-        let profile = "debug";
-        let fp_dir = target.join(profile).join(".fingerprint").join("foo-abcd");
-        let deps_dir = target.join(profile).join("deps");
+        let fp_dir = target.join("debug/.fingerprint/foo-abcdef0123456789");
+        let deps_dir = target.join("debug/deps");
         std::fs::create_dir_all(&fp_dir).unwrap();
         std::fs::create_dir_all(&deps_dir).unwrap();
-        // Synthetic source under workspace
         let src = workspace.join("crates/foo/src/lib.rs");
         write(&src, source_content);
-        // dep-* file (cargo's binary-format anchor — we only use its mtime)
-        write(&fp_dir.join("dep-lib-foo"), "dummy");
-        // .d makefile (the file `record` actually parses)
+        write(
+            &workspace.join("crates/foo/Cargo.toml"),
+            "[package]\nname = \"foo\"\nversion = \"0.1.0\"\n",
+        );
+        write(&fp_dir.join("dep-lib-foo"), "anchor");
         let canon_src = src.canonicalize().unwrap();
         let d_content = format!(
             "{}: {}\n",
-            deps_dir.join("libfoo-abcd.rmeta").display(),
+            deps_dir.join("libfoo-abcdef0123456789.rmeta").display(),
             canon_src.display()
         );
-        write(&deps_dir.join("foo-abcd.d"), &d_content);
+        write(&deps_dir.join("foo-abcdef0123456789.d"), &d_content);
         (workspace, target)
     }
 
     #[test]
-    fn record_and_validate_unchanged_crate_is_clean() {
+    fn record_and_validate_unchanged_lib_is_clean() {
         let tmp = tempfile::tempdir().unwrap();
-        let (workspace, target) = make_synthetic_target(tmp.path(), "fn main() {}\n");
-
+        let (workspace, target) = make_synthetic_lib(tmp.path(), "fn main() {}\n");
         let manifest = target.join(MANIFEST_FILENAME);
         let stats = record(&target, &workspace, &manifest, "debug").unwrap();
         assert_eq!(stats.crates_recorded, 1);
         assert_eq!(stats.sources_hashed, 1);
 
-        // Mtime before validate
-        let dep_path = target.join("debug/.fingerprint/foo-abcd/dep-lib-foo");
+        let dep_path = target.join("debug/.fingerprint/foo-abcdef0123456789/dep-lib-foo");
         let before = std::fs::metadata(&dep_path).unwrap().modified().unwrap();
-
-        // Validate without modifying source — should touch the dep-info.
         let stats = validate(&target, &workspace, &manifest, "debug", 60).unwrap();
         assert_eq!(stats.crates_clean, 1);
         assert_eq!(stats.crates_dirty(), 0);
-
         let after = std::fs::metadata(&dep_path).unwrap().modified().unwrap();
-        assert!(after > before, "dep-info mtime should have been bumped");
+        assert!(after > before);
     }
 
     #[test]
-    fn validate_dirty_crate_is_left_alone() {
+    fn validate_dirty_lib_is_left_alone() {
         let tmp = tempfile::tempdir().unwrap();
-        let (workspace, target) = make_synthetic_target(tmp.path(), "fn main() {}\n");
+        let (workspace, target) = make_synthetic_lib(tmp.path(), "fn main() {}\n");
         let manifest = target.join(MANIFEST_FILENAME);
         record(&target, &workspace, &manifest, "debug").unwrap();
 
-        let dep_path = target.join("debug/.fingerprint/foo-abcd/dep-lib-foo");
+        let dep_path = target.join("debug/.fingerprint/foo-abcdef0123456789/dep-lib-foo");
         let before = std::fs::metadata(&dep_path).unwrap().modified().unwrap();
-        // Simulate a source edit (different content → different hash).
         std::thread::sleep(Duration::from_millis(20));
         std::fs::write(
             workspace.join("crates/foo/src/lib.rs"),
             "fn main() { println!(\"hi\"); }\n",
         )
         .unwrap();
+        let stats = validate(&target, &workspace, &manifest, "debug", 60).unwrap();
+        assert_eq!(stats.crates_clean, 0);
+        assert_eq!(stats.crates_dirty(), 1);
+        let after = std::fs::metadata(&dep_path).unwrap().modified().unwrap();
+        assert_eq!(after, before);
+    }
+
+    /// Synthetic build-script COMPILATION fingerprint: dep file inside
+    /// the fingerprint dir, .d file under `target/<profile>/build/<dir>/`.
+    #[test]
+    fn record_handles_build_script_compilation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        let target = workspace.join("target");
+        let fp_dir = target.join("debug/.fingerprint/bar-fedcba9876543210");
+        let build_dir = target.join("debug/build/bar-fedcba9876543210");
+        std::fs::create_dir_all(&fp_dir).unwrap();
+        std::fs::create_dir_all(&build_dir).unwrap();
+        let src = workspace.join("crates/bar/build.rs");
+        write(
+            &src,
+            "fn main() { println!(\"cargo:rerun-if-changed=build.rs\"); }\n",
+        );
+        write(
+            &workspace.join("crates/bar/Cargo.toml"),
+            "[package]\nname = \"bar\"\nversion = \"0.1.0\"\n",
+        );
+        write(
+            &fp_dir.join("dep-build-script-build-script-build"),
+            "anchor",
+        );
+        let canon_src = src.canonicalize().unwrap();
+        let d_content = format!(
+            "{}: {}\n",
+            build_dir
+                .join("build_script_build-fedcba9876543210")
+                .display(),
+            canon_src.display()
+        );
+        write(
+            &build_dir.join("build_script_build-fedcba9876543210.d"),
+            &d_content,
+        );
+
+        let manifest = target.join(MANIFEST_FILENAME);
+        let stats = record(&target, &workspace, &manifest, "debug").unwrap();
+        assert_eq!(stats.crates_recorded, 1);
+        assert_eq!(stats.sources_hashed, 1);
+
+        let m: Manifest = serde_json::from_slice(&std::fs::read(&manifest).unwrap()).unwrap();
+        assert_eq!(m.crates[0].fingerprint_dir, "bar-fedcba9876543210");
+        assert!(m.crates[0].stamp_targets[0].contains(
+            "debug/.fingerprint/bar-fedcba9876543210/dep-build-script-build-script-build"
+        ));
 
         let stats = validate(&target, &workspace, &manifest, "debug", 60).unwrap();
-        assert_eq!(
-            stats.crates_clean, 0,
-            "modified source should leave crate dirty"
-        );
-        assert_eq!(stats.crates_dirty(), 1);
+        assert_eq!(stats.crates_clean, 1);
+    }
 
-        let after = std::fs::metadata(&dep_path).unwrap().modified().unwrap();
-        assert_eq!(after, before, "dirty crate's dep-info mtime must not move");
+    /// Synthetic run-build-script (RerunIfChanged) fingerprint: json
+    /// describes paths relative to the crate manifest dir + an output
+    /// file under `build/<dir>/`.
+    #[test]
+    fn record_handles_run_build_script() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        let target = workspace.join("target");
+        let fp_dir = target.join("debug/.fingerprint/baz-0123456789abcdef");
+        let build_dir = target.join("debug/build/baz-0123456789abcdef");
+        std::fs::create_dir_all(&fp_dir).unwrap();
+        std::fs::create_dir_all(&build_dir).unwrap();
+        write(&workspace.join("crates/baz/build.rs"), "fn main() {}\n");
+        write(
+            &workspace.join("crates/baz/Cargo.toml"),
+            "[package]\nname = \"baz\"\nversion = \"0.1.0\"\n",
+        );
+        let output_file = build_dir.join("output");
+        write(&output_file, "build-output");
+
+        let json = serde_json::json!({
+            "local": [
+                {
+                    "RerunIfChanged": {
+                        "output": "debug/build/baz-0123456789abcdef/output",
+                        "paths": ["build.rs"],
+                    }
+                }
+            ]
+        });
+        write(
+            &fp_dir.join("run-build-script-build-script-build.json"),
+            &serde_json::to_string(&json).unwrap(),
+        );
+
+        let manifest = target.join(MANIFEST_FILENAME);
+        let stats = record(&target, &workspace, &manifest, "debug").unwrap();
+        assert_eq!(stats.crates_recorded, 1);
+        assert_eq!(stats.sources_hashed, 1);
+
+        let m: Manifest = serde_json::from_slice(&std::fs::read(&manifest).unwrap()).unwrap();
+        assert!(m.crates[0].stamp_targets[0].contains("debug/build/baz-0123456789abcdef/output"));
+
+        let before = std::fs::metadata(&output_file).unwrap().modified().unwrap();
+        let stats = validate(&target, &workspace, &manifest, "debug", 60).unwrap();
+        assert_eq!(stats.crates_clean, 1);
+        let after = std::fs::metadata(&output_file).unwrap().modified().unwrap();
+        assert!(after > before, "output file mtime should be bumped");
     }
 
     #[test]
@@ -465,9 +817,42 @@ mod tests {
 
     #[test]
     fn parse_d_file_handles_escaped_spaces() {
-        // Path with literal space in it: "/a path/foo.rs"
         let content = "/out: /a\\ path/foo.rs\n";
         let parsed = parse_d_file(content);
         assert!(parsed.iter().any(|p| p == Path::new("/a path/foo.rs")));
+    }
+
+    #[test]
+    fn strip_hash_suffix_classifies_correctly() {
+        assert_eq!(strip_hash_suffix("foo-0123456789abcdef"), Some("foo"));
+        assert_eq!(
+            strip_hash_suffix("zccache-cli-0123456789abcdef"),
+            Some("zccache-cli")
+        );
+        assert_eq!(strip_hash_suffix("foo-bar"), None);
+        assert_eq!(strip_hash_suffix("noseparator"), None);
+        // Too short
+        assert_eq!(strip_hash_suffix("foo-abc"), None);
+        // Non-hex
+        assert_eq!(strip_hash_suffix("foo-zzzzzzzzzzzzzzzz"), None);
+    }
+
+    #[test]
+    fn parse_package_name_skips_workspace_inherit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("Cargo.toml");
+        write(
+            &p,
+            "[package]\nname.workspace = true\nversion.workspace = true\n",
+        );
+        assert_eq!(parse_package_name(&p), None);
+    }
+
+    #[test]
+    fn parse_package_name_reads_explicit_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("Cargo.toml");
+        write(&p, "[package]\nname = \"my-crate\"\nversion = \"0.1.0\"\n");
+        assert_eq!(parse_package_name(&p), Some("my-crate".to_string()));
     }
 }


### PR DESCRIPTION
## Summary
Extends #281's content-hash freshness mechanism to cover every cargo staleness signal for workspace crates, then deletes the post-restore blanket `find ... -touch '+1 min'` from `action.yml`. No mtime forgery remains beyond the per-crate anchors snapshot-fp-validate decides are still fresh.

## What's new vs #281
| Fingerprint kind | Status in #281 | Status in this PR |
|---|---|---|
| **lib / bin / test compilation** (`CheckDepInfo`, `.d` in `deps/`) | ✓ handled | ✓ |
| **Build script compilation** (`CheckDepInfo`, `.d` in `build/<dir>/`) | ✗ | ✓ new |
| **Build script execution** (`RerunIfChanged`, `paths` in JSON) | ✗ | ✓ new |
| **Other** (rlib/rmeta linker outputs) | not freshness signals; cargo doesn't mtime-check them | unchanged |

## Manifest schema bump (v1 → v2)
`dep_info_files: Vec<String>` (names inside `<fp_dir>/`) generalised to `stamp_targets: Vec<String>` (paths relative to `target_dir`). Lets one schema address both in-fingerprint anchors (CheckDepInfo) and `build/<dir>/output` anchors (RerunIfChanged). Older v1 manifests trigger a warning + silent fallback to cargo's baseline mtime check (overbuild but correct).

## Workspace crate discovery
`RerunIfChanged.paths` are relative to the crate's *manifest dir*, not the workspace root or target. `record` walks the workspace once for `**/Cargo.toml`, parses just `[package].name` manually (no `toml` dep added), and builds a name → dir map. Crates using workspace-inherited `name.workspace = true` are skipped.

## Action change
`action.yml` no longer runs:
```bash
find "$TARGET" -type f -not -path '*/.fingerprint/*' -exec touch -t "$STAMP" {} +
```
`snapshot-fp-validate` is now the sole stamper. The only remaining post-restore mtime mutation lives inside `zccache warm` (it stamps newly-hardlinked artifact-cache rlibs to "now", which is orthogonal — it's not about snapshot freshness).

## Tests
- 5 existing tests pass (lib unchanged-vs-dirty, parser, missing manifest)
- 3 new tests: build-script compilation, RerunIfChanged (output file gets bumped), helper-fn coverage
- Live smoke on this repo's `target/`: 28 crates / 48 sources / 9.5 KB manifest / 725 ms record

## Test plan
- [x] Unit tests pass + clippy clean on `zccache-cli`
- [ ] CI: single-line edit to one workspace crate → only that crate rebuilds (other workspace crates AND their build scripts stay cached)
- [ ] CI: no-source PR → all crates clean, zero rustc invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
