### PR TITLE
docs(warm): clarify mtime touch is LRU recency, not cargo freshness

### DIFF
--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -2005,6 +2005,16 @@ fn warm_target(
     let deps_dir = target_dir.join(profile).join("deps");
     std::fs::create_dir_all(&deps_dir)
         .map_err(|e| format!("failed to create {}: {e}", deps_dir.display()))?;
+    // mtime bump below is the LRU recency signal for zccache's *own*
+    // artifact-cache eviction (see `crates/zccache-daemon/src/eviction.rs`,
+    // which picks the highest mtime across an artifact group as last-use).
+    // We hardlink each artifact-cache file into target/, which shares an
+    // inode with the cache file — so touching the dst here also bumps the
+    // cache file's mtime, telling eviction "this artifact was just used,
+    // don't evict it". NOT a cargo-freshness signal: cargo never
+    // mtime-checks rlib outputs (they're content-keyed by their filename
+    // hash), so don't be tempted to remove this thinking it duplicates
+    // snapshot-fp-validate. Doing so would silently regress eviction.
     let now = std::time::SystemTime::now();
     let file_times = std::fs::FileTimes::new()
         .set_accessed(now)
@@ -2059,7 +2069,11 @@ fn warm_target(
                 }
             }
 
-            // Touch mtime to current time so cargo sees the file as fresh.
+            // Touch the just-hardlinked dst to bump the underlying inode's
+            // mtime, which propagates to the artifact-cache file via the
+            // shared-inode hardlink. See the comment on `file_times` above
+            // — this is the LRU recency signal for eviction, not a
+            // cargo-freshness hack.
             if let Ok(f) = std::fs::File::open(&dst) {
                 let _ = f.set_times(file_times);
             }


### PR DESCRIPTION
## Summary
While auditing `zccache warm` after the snapshot-fp work, the `FileTimes::set_modified(now).set_accessed(now)` call on each just-hardlinked artifact looks like another freshness forgery for cargo. It isn't — it's the LRU recency signal for zccache's *own* artifact-cache eviction.

* `warm` hardlinks `~/.zccache/artifacts/<key>_<i>` into `target/<profile>/deps/<name>` → shared inode.
* `crates/zccache-daemon/src/eviction.rs:240-244` picks the highest mtime across an artifact's data files as "last-used".
* Touching the dst bumps the shared inode → eviction sees recent mtime → keeps the artifact.

Cargo, meanwhile, never mtime-checks rlib outputs. They're content-keyed by their filename hash; cargo's freshness decision is the dep-info-file mtime (now managed per-crate by `snapshot-fp-validate` after #281 / #282).

Updates the in-source comments to record the actual purpose so a future cleanup doesn't repeat the mis-reading and accidentally delete it as redundant. No behaviour change.

## Test plan
- [x] Tests pass (the touch is unchanged, only its rationale comment moved)
- [x] Clippy clean
- Not a CI behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
