### PR TITLE
perf(io): parallelize cache-hit writes, link reads, and header scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3516,6 +3516,7 @@ version = "1.6.0"
 dependencies = [
  "bincode",
  "clap",
+ "criterion",
  "dashmap",
  "filetime",
  "libc",
@@ -3549,6 +3550,7 @@ name = "zccache-depgraph"
 version = "1.6.0"
 dependencies = [
  "blake3",
+ "criterion",
  "dashmap",
  "rayon",
  "rkyv",

--- a/crates/zccache-daemon/Cargo.toml
+++ b/crates/zccache-daemon/Cargo.toml
@@ -53,3 +53,12 @@ windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Securit
 [dev-dependencies]
 tempfile = { workspace = true }
 zccache-test-support = { workspace = true }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "write_payloads"
+harness = false
+
+[[bench]]
+name = "read_outputs"
+harness = false

--- a/crates/zccache-daemon/benches/README.md
+++ b/crates/zccache-daemon/benches/README.md
@@ -1,0 +1,21 @@
+# zccache-daemon benches
+
+Criterion micro-benchmarks for hot-path I/O fan-out in the daemon. Each bench
+defines a `serial` and `parallel` implementation of the same workload and runs
+them under criterion so the speedup ratio is visible in one report.
+
+| Bench | Measures | Why it exists |
+|---|---|---|
+| `write_payloads` | hardlink-or-copy of N cache files to N output paths | Cache-hit payload write fan-out (see `write_cached_output` in `src/server.rs`) |
+| `read_outputs` | `fs::read` of N output files into in-memory buffers | Link cache-populate read fan-out (see `handle_link_ephemeral` in `src/server.rs`) |
+
+Run all benches:
+
+```bash
+soldr cargo bench -p zccache-daemon --bench write_payloads
+soldr cargo bench -p zccache-daemon --bench read_outputs
+```
+
+`N = 1` is the regression guard for the single-output `.o` compile path —
+the parallel variant must not be meaningfully slower than the serial variant
+when there is only one item.

--- a/crates/zccache-daemon/benches/read_outputs.rs
+++ b/crates/zccache-daemon/benches/read_outputs.rs
@@ -1,0 +1,75 @@
+//! Micro-benchmark for link cache-populate read fan-out.
+//!
+//! On a successful link, `handle_link_ephemeral` (crates/zccache-daemon/src/server.rs)
+//! reads the primary output, every secondary output (e.g., MSVC `.lib`/`.exp`),
+//! and every detected side-effect file. Those reads currently run serially
+//! before the daemon returns `LinkResult` to the client. This bench measures
+//! the speedup of doing them in parallel via `rayon::par_iter`.
+//!
+//! Sizing follows the same matrix as `write_payloads.rs`:
+//! - N = 1: regression guard for single-output paths
+//! - N = 3: MSVC link with `.lib` + `.exp`
+//! - N = 5: link with a couple of side-effect DLLs
+//! - N = 10: link saturated with side-effects
+
+use std::path::PathBuf;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rayon::prelude::*;
+
+const PAYLOAD_SIZE: usize = 1024 * 1024; // 1 MiB
+const COUNTS: &[usize] = &[1, 3, 5, 10];
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    paths: Vec<PathBuf>,
+}
+
+impl Fixture {
+    fn new(n: usize) -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let payload = vec![0x42u8; PAYLOAD_SIZE];
+        let paths: Vec<PathBuf> = (0..n)
+            .map(|i| {
+                let p = tmp.path().join(format!("out_{i}"));
+                std::fs::write(&p, &payload).unwrap();
+                p
+            })
+            .collect();
+        Self { _tmp: tmp, paths }
+    }
+}
+
+fn read_serial(fx: &Fixture) -> Vec<Vec<u8>> {
+    fx.paths.iter().map(|p| std::fs::read(p).unwrap()).collect()
+}
+
+fn read_parallel(fx: &Fixture) -> Vec<Vec<u8>> {
+    fx.paths
+        .par_iter()
+        .map(|p| std::fs::read(p).unwrap())
+        .collect()
+}
+
+fn bench_read_outputs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("read_outputs");
+    for &n in COUNTS {
+        let fx = Fixture::new(n);
+        group.bench_with_input(BenchmarkId::new("serial", n), &n, |b, _| {
+            b.iter(|| {
+                let v = read_serial(black_box(&fx));
+                black_box(v);
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("parallel", n), &n, |b, _| {
+            b.iter(|| {
+                let v = read_parallel(black_box(&fx));
+                black_box(v);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_read_outputs);
+criterion_main!(benches);

--- a/crates/zccache-daemon/benches/write_payloads.rs
+++ b/crates/zccache-daemon/benches/write_payloads.rs
@@ -44,9 +44,7 @@ impl Fixture {
                 p
             })
             .collect();
-        let out_paths: Vec<PathBuf> = (0..n)
-            .map(|i| out_dir.join(format!("out_{i}")))
-            .collect();
+        let out_paths: Vec<PathBuf> = (0..n).map(|i| out_dir.join(format!("out_{i}"))).collect();
         Self {
             _tmp: tmp,
             cache_files,

--- a/crates/zccache-daemon/benches/write_payloads.rs
+++ b/crates/zccache-daemon/benches/write_payloads.rs
@@ -1,0 +1,113 @@
+//! Micro-benchmark for cache-hit payload write fan-out.
+//!
+//! Measures the speedup of writing N cached output files in parallel
+//! (`rayon::par_iter`) versus serially (a plain `for` loop). Both
+//! implementations call `std::fs::hard_link` with `std::fs::write` as the
+//! fallback — the same syscall sequence the daemon uses in
+//! `write_cached_output` (see crates/zccache-daemon/src/server.rs).
+//!
+//! - N = 1: single-output `.o` compile (the common case, regression guard)
+//! - N = 3: MSVC link with `.lib` + `.exp` secondary outputs
+//! - N = 5: link with a couple of side-effect DLLs
+//! - N = 10: link saturated with side-effects (MAX_SIDE_EFFECT_COUNT)
+//!
+//! Each payload is a 1 MiB blob — large enough to stress the kernel's
+//! hardlink/copy fast path without dominating measurement noise from
+//! filesystem flushing.
+
+use std::path::PathBuf;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rayon::prelude::*;
+
+const PAYLOAD_SIZE: usize = 1024 * 1024; // 1 MiB
+const COUNTS: &[usize] = &[1, 3, 5, 10];
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    cache_files: Vec<PathBuf>,
+    out_paths: Vec<PathBuf>,
+}
+
+impl Fixture {
+    fn new(n: usize) -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cache_dir = tmp.path().join("cache");
+        let out_dir = tmp.path().join("out");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::create_dir_all(&out_dir).unwrap();
+        let payload = vec![0x42u8; PAYLOAD_SIZE];
+        let cache_files: Vec<PathBuf> = (0..n)
+            .map(|i| {
+                let p = cache_dir.join(format!("payload_{i}"));
+                std::fs::write(&p, &payload).unwrap();
+                p
+            })
+            .collect();
+        let out_paths: Vec<PathBuf> = (0..n)
+            .map(|i| out_dir.join(format!("out_{i}")))
+            .collect();
+        Self {
+            _tmp: tmp,
+            cache_files,
+            out_paths,
+        }
+    }
+
+    fn reset_outputs(&self) {
+        for p in &self.out_paths {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+}
+
+/// Mirrors the production `write_cached_output` syscall sequence:
+/// 1. hardlink, 2. remove + retry hardlink, 3. fallback to copy.
+fn write_one(cache: &std::path::Path, out: &std::path::Path) -> std::io::Result<()> {
+    if std::fs::hard_link(cache, out).is_ok() {
+        return Ok(());
+    }
+    let _ = std::fs::remove_file(out);
+    if std::fs::hard_link(cache, out).is_ok() {
+        return Ok(());
+    }
+    std::fs::copy(cache, out).map(|_| ())
+}
+
+fn write_serial(fx: &Fixture) {
+    for (cache, out) in fx.cache_files.iter().zip(fx.out_paths.iter()) {
+        write_one(cache, out).unwrap();
+    }
+}
+
+fn write_parallel(fx: &Fixture) {
+    fx.cache_files
+        .par_iter()
+        .zip(fx.out_paths.par_iter())
+        .for_each(|(cache, out)| {
+            write_one(cache, out).unwrap();
+        });
+}
+
+fn bench_write_payloads(c: &mut Criterion) {
+    let mut group = c.benchmark_group("write_payloads");
+    for &n in COUNTS {
+        let fx = Fixture::new(n);
+        group.bench_with_input(BenchmarkId::new("serial", n), &n, |b, _| {
+            b.iter(|| {
+                fx.reset_outputs();
+                write_serial(black_box(&fx));
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("parallel", n), &n, |b, _| {
+            b.iter(|| {
+                fx.reset_outputs();
+                write_parallel(black_box(&fx));
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_write_payloads);
+criterion_main!(benches);

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -2081,9 +2081,8 @@ async fn handle_link_ephemeral(
         )
         .unwrap_or_default();
 
-        let mut read_targets: Vec<(String, std::path::PathBuf)> = Vec::with_capacity(
-            1 + parsed_tool.secondary_outputs.len() + side_effects.len(),
-        );
+        let mut read_targets: Vec<(String, std::path::PathBuf)> =
+            Vec::with_capacity(1 + parsed_tool.secondary_outputs.len() + side_effects.len());
         read_targets.push((
             primary_name_os.to_string_lossy().into_owned(),
             std::path::PathBuf::from(output_path.as_path()),
@@ -4596,7 +4595,8 @@ async fn handle_compile(
                                 let t_write_output = std::time::Instant::now();
                                 let secondary_dir =
                                     output_path.parent().unwrap_or(cwd).to_path_buf();
-                                let targets: Vec<(NormalizedPath, NormalizedPath)> = (0..payloads.len())
+                                let targets: Vec<(NormalizedPath, NormalizedPath)> = (0..payloads
+                                    .len())
                                     .map(|i| {
                                         let out: NormalizedPath = if i == 0 {
                                             output_path.clone()

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -1973,26 +1973,22 @@ async fn handle_link_ephemeral(
             } else {
                 cwd_path.join(&parsed_tool.output_file).into()
             };
-            let mut write_ok = true;
-            for (i, payload) in payloads.iter().enumerate() {
-                let target = if payloads.len() == 1 {
-                    output_path.clone()
-                } else {
-                    output_path
-                        .parent()
-                        .unwrap_or(cwd_path)
-                        .join(&names[i])
-                        .into()
-                };
-                if let Some(parent) = target.parent() {
-                    std::fs::create_dir_all(parent).ok();
-                }
-                let cache_file = state.artifact_dir.join(format!("{key_hex}_{i}"));
-                if write_cached_payload(&target, &cache_file, payload).is_err() {
-                    write_ok = false;
-                    break;
-                }
-            }
+            let targets: Vec<(NormalizedPath, NormalizedPath)> = (0..payloads.len())
+                .map(|i| {
+                    let target: NormalizedPath = if payloads.len() == 1 {
+                        output_path.clone()
+                    } else {
+                        output_path
+                            .parent()
+                            .unwrap_or(cwd_path)
+                            .join(&names[i])
+                            .into()
+                    };
+                    let cache_file = state.artifact_dir.join(format!("{key_hex}_{i}"));
+                    (target, cache_file)
+                })
+                .collect();
+            let write_ok = write_payloads_par(&targets, &payloads);
             if write_ok {
                 return Response::LinkResult {
                     exit_code,
@@ -2057,68 +2053,96 @@ async fn handle_link_ephemeral(
         ..
     } = result
     {
-        if let Ok(data) = std::fs::read(&output_path) {
-            let mut outputs = vec![ArtifactOutput {
-                name: parsed_tool
-                    .output_file
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .into_owned(),
-                data: Arc::new(data),
-            }];
+        // Enumerate (name, path) for primary + declared secondaries +
+        // detected side-effects in cache-index order so that `outputs[i]`
+        // maps to `{key}_i` on disk after the parallel reads below. Missing
+        // secondaries and read errors are dropped (preserves the prior
+        // serial behavior). Side-effect detection uses the full set of
+        // declared output names so it doesn't double-capture them.
+        let primary_name_os = parsed_tool
+            .output_file
+            .file_name()
+            .unwrap_or_default()
+            .to_os_string();
+        let already_captured: std::collections::HashSet<std::ffi::OsString> =
+            std::iter::once(primary_name_os.clone())
+                .chain(
+                    parsed_tool
+                        .secondary_outputs
+                        .iter()
+                        .filter_map(|s| s.file_name().map(|n| n.to_os_string())),
+                )
+                .collect();
+        let side_effects = crate::side_effect::detect_side_effects(
+            &dir_snapshot,
+            output_dir,
+            &primary_name_os,
+            &already_captured,
+        )
+        .unwrap_or_default();
 
-            // Collect secondary outputs (e.g., MSVC import lib + .exp)
-            for secondary in &parsed_tool.secondary_outputs {
-                let sec_path = if secondary.is_absolute() {
-                    secondary.clone()
-                } else {
-                    cwd_path.join(secondary).into()
-                };
-                if let Ok(sec_data) = std::fs::read(&sec_path) {
-                    outputs.push(ArtifactOutput {
-                        name: secondary
-                            .file_name()
-                            .unwrap_or_default()
-                            .to_string_lossy()
-                            .into_owned(),
-                        data: Arc::new(sec_data),
-                    });
-                }
-                // Missing secondary outputs are silently skipped —
-                // e.g., .exp may not always be generated.
-            }
-
-            // Detect side-effect files deployed by compiler wrapper post-link hooks
-            // (e.g., ASan runtime DLLs copied next to the output binary).
-            let primary_name = parsed_tool
-                .output_file
+        let mut read_targets: Vec<(String, std::path::PathBuf)> = Vec::with_capacity(
+            1 + parsed_tool.secondary_outputs.len() + side_effects.len(),
+        );
+        read_targets.push((
+            primary_name_os.to_string_lossy().into_owned(),
+            std::path::PathBuf::from(output_path.as_path()),
+        ));
+        for secondary in &parsed_tool.secondary_outputs {
+            let sec_path = if secondary.is_absolute() {
+                secondary.to_path_buf()
+            } else {
+                cwd_path.join(secondary)
+            };
+            let name = secondary
                 .file_name()
                 .unwrap_or_default()
-                .to_os_string();
-            let already_captured: std::collections::HashSet<std::ffi::OsString> = outputs
+                .to_string_lossy()
+                .into_owned();
+            read_targets.push((name, sec_path));
+        }
+        for se in &side_effects {
+            read_targets.push((
+                se.file_name.to_string_lossy().into_owned(),
+                std::path::PathBuf::from(se.path.as_path()),
+            ));
+        }
+
+        // Read all output files; preserve order. Falls back to a serial
+        // loop when there's only the primary output — rayon dispatch cost
+        // (~150 µs) is comparable to one fs::read for small outputs.
+        let reads: Vec<Option<ArtifactOutput>> = if read_targets.len() <= 1 {
+            read_targets
                 .iter()
-                .map(|o| std::ffi::OsString::from(&o.name))
-                .collect();
-            if let Ok(side_effects) = crate::side_effect::detect_side_effects(
-                &dir_snapshot,
-                output_dir,
-                &primary_name,
-                &already_captured,
-            ) {
-                for se in &side_effects {
-                    if let Ok(data) = std::fs::read(&se.path) {
-                        tracing::debug!(
-                            file = %se.file_name.to_string_lossy(),
-                            size = data.len(),
-                            "caching side-effect file"
-                        );
-                        outputs.push(ArtifactOutput {
-                            name: se.file_name.to_string_lossy().into_owned(),
-                            data: Arc::new(data),
-                        });
-                    }
-                }
+                .map(|(name, path)| {
+                    std::fs::read(path).ok().map(|data| ArtifactOutput {
+                        name: name.clone(),
+                        data: Arc::new(data),
+                    })
+                })
+                .collect()
+        } else {
+            use rayon::prelude::*;
+            read_targets
+                .par_iter()
+                .map(|(name, path)| {
+                    std::fs::read(path).ok().map(|data| ArtifactOutput {
+                        name: name.clone(),
+                        data: Arc::new(data),
+                    })
+                })
+                .collect()
+        };
+
+        // Primary read gates the cache populate. If it fails, the link
+        // succeeded but the output file is no longer readable — skip
+        // caching, same as the prior serial behavior.
+        if reads.first().and_then(|r| r.as_ref()).is_some() {
+            let outputs: Vec<ArtifactOutput> = reads.into_iter().flatten().collect();
+            // Log side-effect captures (preserves prior tracing).
+            let side_effect_start = 1 + parsed_tool.secondary_outputs.len();
+            for o in outputs.iter().skip(side_effect_start) {
+                tracing::debug!(file = %o.name, size = o.data.len(), "caching side-effect file");
             }
 
             let artifact = ArtifactData {
@@ -3123,6 +3147,46 @@ fn write_cached_payload(
         CachedPayload::Bytes(data) => write_cached_output(out_path, cache_file, data),
         CachedPayload::File(path) => write_cached_file(out_path, path),
     }
+}
+
+/// Write a batch of cached payloads to their target paths in parallel.
+///
+/// `targets[i]` is the `(out_path, cache_file)` pair for `payloads[i]`. The
+/// parent of each `out_path` is created if it does not exist (matches the
+/// per-site behavior of the link-hit path). Returns `true` iff every write
+/// succeeded; `false` on first failure (callers either fall through to a
+/// fallback path or ignore the result, mirroring the prior serial loops).
+///
+/// Threshold: rayon is only used when `targets.len() >= 4`. For N ≤ 3 the
+/// per-iteration thread-pool dispatch cost (~300 µs) is comparable to the
+/// hardlink syscalls themselves, so a serial loop is faster. The
+/// `benches/write_payloads.rs` micro-benchmark sets this cut-off
+/// empirically on the Windows / NTFS host.
+const PAR_WRITE_THRESHOLD: usize = 4;
+
+fn write_payloads_par<P, Q>(targets: &[(P, Q)], payloads: &[CachedPayload]) -> bool
+where
+    P: AsRef<Path> + Sync,
+    Q: AsRef<Path> + Sync,
+{
+    debug_assert_eq!(targets.len(), payloads.len());
+    let write_one = |out: &Path, cache: &Path, payload: &CachedPayload| -> bool {
+        if let Some(parent) = out.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        write_cached_payload(out, cache, payload).is_ok()
+    };
+    if targets.len() < PAR_WRITE_THRESHOLD {
+        return targets
+            .iter()
+            .zip(payloads.iter())
+            .all(|((out, cache), payload)| write_one(out.as_ref(), cache.as_ref(), payload));
+    }
+    use rayon::prelude::*;
+    targets
+        .par_iter()
+        .zip(payloads.par_iter())
+        .all(|((out, cache), payload)| write_one(out.as_ref(), cache.as_ref(), payload))
 }
 
 fn break_output_hardlink_before_compile(path: &Path) -> std::io::Result<()> {
@@ -4530,24 +4594,22 @@ async fn handle_compile(
 
                                 // Write output
                                 let t_write_output = std::time::Instant::now();
-                                let mut write_ok = true;
                                 let secondary_dir =
                                     output_path.parent().unwrap_or(cwd).to_path_buf();
-                                for (i, payload) in payloads.iter().enumerate() {
-                                    let out_path = if i == 0 {
-                                        output_path.clone()
-                                    } else {
-                                        secondary_dir.join(&names[i]).into()
-                                    };
-                                    let cache_file =
-                                        state.artifact_dir.join(format!("{artifact_key_hex}_{i}"));
-                                    if write_cached_payload(&out_path, &cache_file, payload)
-                                        .is_err()
-                                    {
-                                        write_ok = false;
-                                        break;
-                                    }
-                                }
+                                let targets: Vec<(NormalizedPath, NormalizedPath)> = (0..payloads.len())
+                                    .map(|i| {
+                                        let out: NormalizedPath = if i == 0 {
+                                            output_path.clone()
+                                        } else {
+                                            secondary_dir.join(&names[i]).into()
+                                        };
+                                        let cache_file = state
+                                            .artifact_dir
+                                            .join(format!("{artifact_key_hex}_{i}"));
+                                        (out, cache_file)
+                                    })
+                                    .collect();
+                                let write_ok = write_payloads_par(&targets, &payloads);
                                 if write_ok {
                                     let write_output_ns =
                                         t_write_output.elapsed().as_nanos() as u64;
@@ -4808,25 +4870,24 @@ async fn handle_compile(
                         // Drop the DashMap reference before doing more work
                         drop(cached_ref);
 
-                        let mut write_ok = true;
                         let secondary_dir = if is_rustc {
                             output_path.parent().unwrap_or(&cwd_path).to_path_buf()
                         } else {
                             cwd_path.clone().to_path_buf()
                         };
-                        for (i, payload) in payloads.iter().enumerate() {
-                            let out_path = if i == 0 {
-                                output_path.clone()
-                            } else {
-                                secondary_dir.join(&names[i]).into()
-                            };
-                            let cache_file =
-                                state.artifact_dir.join(format!("{artifact_key_hex}_{i}"));
-                            if write_cached_payload(&out_path, &cache_file, payload).is_err() {
-                                write_ok = false;
-                                break;
-                            }
-                        }
+                        let targets: Vec<(NormalizedPath, NormalizedPath)> = (0..payloads.len())
+                            .map(|i| {
+                                let out: NormalizedPath = if i == 0 {
+                                    output_path.clone()
+                                } else {
+                                    secondary_dir.join(&names[i]).into()
+                                };
+                                let cache_file =
+                                    state.artifact_dir.join(format!("{artifact_key_hex}_{i}"));
+                                (out, cache_file)
+                            })
+                            .collect();
+                        let write_ok = write_payloads_par(&targets, &payloads);
                         if !write_ok {
                             // Fall through to slow path on write failure
                         } else {
@@ -5077,24 +5138,24 @@ async fn handle_compile(
                     let artifact_bytes: u64 = cached_ref.meta.total_size;
                     drop(cached_ref);
 
-                    let mut write_ok = true;
                     let secondary_dir = if is_rustc {
                         output_path.parent().unwrap_or(&cwd_path).to_path_buf()
                     } else {
                         cwd_path.clone().to_path_buf()
                     };
-                    for (i, payload) in payloads.iter().enumerate() {
-                        let out_path = if i == 0 {
-                            output_path.clone()
-                        } else {
-                            secondary_dir.join(&names[i]).into()
-                        };
-                        let cache_file = state.artifact_dir.join(format!("{artifact_key_hex}_{i}"));
-                        if write_cached_payload(&out_path, &cache_file, payload).is_err() {
-                            write_ok = false;
-                            break;
-                        }
-                    }
+                    let targets: Vec<(NormalizedPath, NormalizedPath)> = (0..payloads.len())
+                        .map(|i| {
+                            let out: NormalizedPath = if i == 0 {
+                                output_path.clone()
+                            } else {
+                                secondary_dir.join(&names[i]).into()
+                            };
+                            let cache_file =
+                                state.artifact_dir.join(format!("{artifact_key_hex}_{i}"));
+                            (out, cache_file)
+                        })
+                        .collect();
+                    let write_ok = write_payloads_par(&targets, &payloads);
                     if !write_ok {
                         // Fall through to compile on write failure
                     } else {
@@ -6008,16 +6069,19 @@ fn check_unit_cache(
                         let stderr = cached_ref.stderr.clone();
                         drop(cached_ref);
 
-                        for (i, payload) in payloads.iter().enumerate() {
-                            let out_path = if i == 0 {
-                                output_path.clone()
-                            } else {
-                                cwd_path.join(&names[i]).into()
-                            };
-                            let cache_file =
-                                state.artifact_dir.join(format!("{artifact_key_hex}_{i}"));
-                            let _ = write_cached_payload(&out_path, &cache_file, payload);
-                        }
+                        let targets: Vec<(NormalizedPath, NormalizedPath)> = (0..payloads.len())
+                            .map(|i| {
+                                let out: NormalizedPath = if i == 0 {
+                                    output_path.clone()
+                                } else {
+                                    cwd_path.join(&names[i]).into()
+                                };
+                                let cache_file =
+                                    state.artifact_dir.join(format!("{artifact_key_hex}_{i}"));
+                                (out, cache_file)
+                            })
+                            .collect();
+                        let _ = write_payloads_par(&targets, &payloads);
 
                         state.stats.record_hit(0, artifact_bytes);
                         state.profiler.record_hit(&HitPhases {
@@ -6118,15 +6182,18 @@ fn check_unit_cache(
                 let stderr = cached_ref.stderr.clone();
                 drop(cached_ref);
 
-                for (i, payload) in payloads.iter().enumerate() {
-                    let out_path = if i == 0 {
-                        output_path.clone()
-                    } else {
-                        cwd_path.join(&names[i]).into()
-                    };
-                    let cache_file = state.artifact_dir.join(format!("{artifact_key_hex}_{i}"));
-                    let _ = write_cached_payload(&out_path, &cache_file, payload);
-                }
+                let targets: Vec<(NormalizedPath, NormalizedPath)> = (0..payloads.len())
+                    .map(|i| {
+                        let out: NormalizedPath = if i == 0 {
+                            output_path.clone()
+                        } else {
+                            cwd_path.join(&names[i]).into()
+                        };
+                        let cache_file = state.artifact_dir.join(format!("{artifact_key_hex}_{i}"));
+                        (out, cache_file)
+                    })
+                    .collect();
+                let _ = write_payloads_par(&targets, &payloads);
 
                 state.stats.record_hit(0, artifact_bytes);
 

--- a/crates/zccache-depgraph/Cargo.toml
+++ b/crates/zccache-depgraph/Cargo.toml
@@ -25,3 +25,8 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "scan_recursive"
+harness = false

--- a/crates/zccache-depgraph/benches/README.md
+++ b/crates/zccache-depgraph/benches/README.md
@@ -1,0 +1,26 @@
+# zccache-depgraph benches
+
+Criterion micro-benchmarks for the recursive `#include` scanner.
+
+| Bench | Measures |
+|---|---|
+| `scan_recursive` | `scan_recursive` over a synthetic header tree (small + large fixtures) |
+
+Run:
+
+```bash
+soldr cargo bench -p zccache-depgraph --bench scan_recursive
+```
+
+Capture a baseline on the pre-change commit, then re-run on the implementation
+commit to see the speedup:
+
+```bash
+soldr cargo bench -p zccache-depgraph --bench scan_recursive -- --save-baseline pre
+# ... apply the impl change ...
+soldr cargo bench -p zccache-depgraph --bench scan_recursive -- --baseline pre
+```
+
+The `small_depth3_fanout3` fixture is the regression guard for small TUs;
+`large_depth5_fanout4` (~250 headers) is the workload that demonstrates the
+parallel BFS win.

--- a/crates/zccache-depgraph/benches/scan_recursive.rs
+++ b/crates/zccache-depgraph/benches/scan_recursive.rs
@@ -1,0 +1,125 @@
+//! Criterion bench for `scan_recursive` on synthetic header trees.
+//!
+//! `scan_recursive` is the entrypoint for recursive `#include` scanning
+//! during compile cache MISSES (see crates/zccache-depgraph/src/scanner.rs).
+//! Two fixtures exercise it:
+//!
+//! - `small_120_files` — ~120 unique headers, regression guard for small TUs.
+//! - `large_1300_files` — ~1300 unique headers, mimics STL-heavy C++ TUs where
+//!   parallelizing the read+parse step is the win.
+//!
+//! All headers live in a single flat directory and use quoted includes
+//! (`#include "h_<id>.h"`) so they resolve via the including file's own
+//! directory (no `-I` flag needed) — see `resolve_include` in scanner.rs.
+//!
+//! Run with: `soldr cargo bench -p zccache-depgraph --bench scan_recursive`.
+//! Save a baseline on the pre-change commit with `-- --save-baseline pre`,
+//! then re-run after the impl change with `-- --baseline pre`.
+
+use std::path::{Path, PathBuf};
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use zccache_depgraph::scanner::scan_recursive;
+use zccache_depgraph::search_paths::IncludeSearchPaths;
+
+/// Build a tree of `#include "h_<id>.h"` headers in a single flat directory.
+///
+/// Returns the path of the root header (which transitively pulls in every
+/// other header via quoted includes). Quoted includes are resolved against
+/// the including file's own directory, so a flat layout means every
+/// `#include` resolves without needing any `-I` search path.
+///
+/// Header bodies include enough lines (~30) of pretend declarations to
+/// approximate the size of a small real-world header — pure-`#include`
+/// files would be unrealistically cheap to read.
+fn build_tree(root: &Path, depth: usize, fan_out: usize) -> (PathBuf, usize) {
+    std::fs::create_dir_all(root).unwrap();
+    let mut counter: u32 = 0;
+
+    fn next(counter: &mut u32) -> u32 {
+        *counter += 1;
+        *counter
+    }
+
+    fn rec(dir: &Path, depth: usize, fan_out: usize, counter: &mut u32) -> u32 {
+        let my_id = next(counter);
+        let my_path = dir.join(format!("h_{my_id:05}.h"));
+
+        let filler = (0..30)
+            .map(|j| format!("static int filler_{my_id}_{j} = {j};\n"))
+            .collect::<String>();
+
+        if depth == 0 {
+            let body = format!("// leaf {my_id}\n{filler}");
+            std::fs::write(&my_path, body).unwrap();
+            return my_id;
+        }
+
+        let mut content = String::new();
+        for _ in 0..fan_out {
+            let child_id = rec(dir, depth - 1, fan_out, counter);
+            content.push_str(&format!("#include \"h_{child_id:05}.h\"\n"));
+        }
+        content.push_str(&filler);
+        std::fs::write(&my_path, content).unwrap();
+        my_id
+    }
+
+    let root_id = rec(root, depth, fan_out, &mut counter);
+    let root_path = root.join(format!("h_{root_id:05}.h"));
+    (root_path, counter as usize)
+}
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    root_header: PathBuf,
+    search: IncludeSearchPaths,
+    file_count: usize,
+}
+
+impl Fixture {
+    fn new(depth: usize, fan_out: usize) -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let inc_dir = tmp.path().join("inc");
+        let (root_header, file_count) = build_tree(&inc_dir, depth, fan_out);
+        // Quoted includes resolve via the including file's dir, so the search
+        // paths are intentionally empty.
+        let search = IncludeSearchPaths::default();
+        Self {
+            _tmp: tmp,
+            root_header,
+            search,
+            file_count,
+        }
+    }
+}
+
+fn bench_scan_recursive(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scan_recursive");
+    group.sample_size(20);
+
+    // depth=3, fan_out=3 → ~40 headers (1+3+9+27 = 40). Regression guard.
+    let small = Fixture::new(3, 3);
+    let small_name = format!("small_{}_files", small.file_count);
+    group.bench_function(&small_name, |b| {
+        b.iter(|| {
+            let r = scan_recursive(black_box(&small.root_header), black_box(&small.search));
+            black_box(r);
+        });
+    });
+
+    // depth=5, fan_out=4 → ~1300 headers. Heavy C++ TU workload.
+    let large = Fixture::new(5, 4);
+    let large_name = format!("large_{}_files", large.file_count);
+    group.bench_function(&large_name, |b| {
+        b.iter(|| {
+            let r = scan_recursive(black_box(&large.root_header), black_box(&large.search));
+            black_box(r);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_scan_recursive);
+criterion_main!(benches);

--- a/crates/zccache-depgraph/src/scanner.rs
+++ b/crates/zccache-depgraph/src/scanner.rs
@@ -4,7 +4,6 @@
 //! and string literals. Does not evaluate preprocessor conditionals â€”
 //! all `#include` directives are returned unconditionally.
 
-use std::collections::HashSet;
 use std::path::Path;
 
 use crate::search_paths::IncludeSearchPaths;
@@ -156,75 +155,119 @@ pub fn resolve_include(
 /// Recursively scan a source file for all transitive includes.
 ///
 /// Builds the full include list by scanning the source file, resolving
-/// each `#include`, then scanning each resolved header, and so on.
-/// Uses a visited set to handle circular includes.
+/// each `#include`, then scanning each resolved header, and so on, using
+/// a parallel BFS over per-level frontiers. Headers within a frontier are
+/// read and parsed in parallel via rayon; new resolutions feed the next
+/// frontier. A `DashSet` deduplicates so each header is scanned exactly
+/// once across the DAG, even with circular or diamond includes.
+///
+/// `resolved` returns in BFS-level order (was DFS-post-order before
+/// parallelization). Callers in `graph.rs` only iterate the list to hash
+/// all files; no order invariant is broken.
 pub fn scan_recursive(source: &Path, search: &IncludeSearchPaths) -> ScanResult {
-    let mut resolved = Vec::new();
-    let mut unresolved = Vec::new();
-    let mut has_computed = false;
-    let mut visited = HashSet::new();
+    use dashmap::DashSet;
+    use rayon::prelude::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Mutex;
 
-    // Mark the source itself as visited so we don't re-scan it.
+    let visited: DashSet<NormalizedPath> = DashSet::new();
+    let resolved: Mutex<Vec<NormalizedPath>> = Mutex::new(Vec::new());
+    let unresolved: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    let has_computed = AtomicBool::new(false);
+
+    // Mark the source itself as visited so we don't re-scan it via a
+    // self-include chain.
     if let Some(abs) = try_normalize(source) {
         visited.insert(abs);
     }
 
-    scan_recursive_inner(
-        source,
-        search,
-        &mut resolved,
-        &mut unresolved,
-        &mut has_computed,
-        &mut visited,
-    );
+    let mut frontier: Vec<NormalizedPath> = vec![NormalizedPath::from(source)];
+    while !frontier.is_empty() {
+        let next: Vec<NormalizedPath> = frontier
+            .par_iter()
+            .flat_map_iter(|file| {
+                scan_one_level(
+                    file.as_path(),
+                    search,
+                    &visited,
+                    &resolved,
+                    &unresolved,
+                    &has_computed,
+                )
+            })
+            .collect();
+        frontier = next;
+    }
 
     ScanResult {
-        resolved,
-        unresolved,
-        has_computed,
+        resolved: resolved.into_inner().expect("resolved mutex poisoned"),
+        unresolved: unresolved.into_inner().expect("unresolved mutex poisoned"),
+        has_computed: has_computed.load(Ordering::Relaxed),
     }
 }
 
-fn scan_recursive_inner(
+/// Scan one file: read it, parse `#include`s, resolve each, and return the
+/// list of newly-discovered resolved paths for the next frontier level.
+///
+/// All four shared collections take exactly one lock per scanned file: the
+/// per-file results are buffered locally and pushed in a single batch at
+/// the end. This keeps Mutex contention proportional to (file count) and
+/// not to (include count).
+fn scan_one_level(
     file: &Path,
     search: &IncludeSearchPaths,
-    resolved: &mut Vec<NormalizedPath>,
-    unresolved: &mut Vec<String>,
-    has_computed: &mut bool,
-    visited: &mut HashSet<NormalizedPath>,
-) {
+    visited: &dashmap::DashSet<NormalizedPath>,
+    resolved: &std::sync::Mutex<Vec<NormalizedPath>>,
+    unresolved: &std::sync::Mutex<Vec<String>>,
+    has_computed: &std::sync::atomic::AtomicBool,
+) -> Vec<NormalizedPath> {
     let directives = match scan_includes(file) {
         Ok(d) => d,
-        Err(_) => return,
+        Err(_) => return Vec::new(),
     };
 
     let file_dir = file.parent().unwrap_or(Path::new("."));
 
+    let mut new_for_next: Vec<NormalizedPath> = Vec::new();
+    let mut local_resolved: Vec<NormalizedPath> = Vec::new();
+    let mut local_unresolved: Vec<String> = Vec::new();
+    let mut saw_computed = false;
+
     for directive in &directives {
         match &directive.kind {
             IncludeKind::Computed(_) => {
-                *has_computed = true;
+                saw_computed = true;
             }
             _ => {
                 if let Some(abs_path) = resolve_include(directive, search, file_dir) {
                     if visited.insert(abs_path.clone()) {
-                        resolved.push(abs_path.clone());
-                        // Recurse into the resolved header.
-                        scan_recursive_inner(
-                            &abs_path,
-                            search,
-                            resolved,
-                            unresolved,
-                            has_computed,
-                            visited,
-                        );
+                        local_resolved.push(abs_path.clone());
+                        new_for_next.push(abs_path);
                     }
                 } else {
-                    unresolved.push(directive.path.clone());
+                    local_unresolved.push(directive.path.clone());
                 }
             }
         }
     }
+
+    if !local_resolved.is_empty() {
+        resolved
+            .lock()
+            .expect("resolved mutex poisoned")
+            .extend(local_resolved);
+    }
+    if !local_unresolved.is_empty() {
+        unresolved
+            .lock()
+            .expect("unresolved mutex poisoned")
+            .extend(local_unresolved);
+    }
+    if saw_computed {
+        has_computed.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    new_for_next
 }
 
 // â”€â”€ Helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€


### PR DESCRIPTION
## Summary

Three parallelization wins on the daemon hot path, each gated by an `N`-based threshold so the dominant single-output `.o` compile takes no overhead:

1. **Cache-hit payload writes** — new `write_payloads_par` helper in `crates/zccache-daemon/src/server.rs` replaces six serial `for (i, payload) in payloads.iter().enumerate() { write_cached_payload(...) }` loops (at lines 1977, 4536, 4817, 5086, 6011, 6121 before refactor). Parallel for `N >= 4`; falls back to inline serial below — empirically tuned on NTFS hardlink behavior. Preserves the call-site error semantics: sites 1977/4536/4817/5086 fall through on first failure; sites 6011/6121 (request-cache fast paths) ignore write errors.

2. **Link cache-populate reads** — `handle_link_ephemeral` (line ~2056) now batches all `fs::read` calls (primary output + declared secondaries + detected side-effects) into one `rayon::par_iter().collect()` that preserves output ordering. `N == 1` keeps the serial fast path.

3. **Recursive `#include` scan** — `scan_recursive` in `crates/zccache-depgraph/src/scanner.rs` rewritten from serial DFS to parallel BFS-by-frontier. State: `DashSet<NormalizedPath>` for visited, `Mutex<Vec<>>` for resolved/unresolved, `AtomicBool` for has_computed. Per-file results are buffered locally and pushed in a single mutex acquire per file. Order of `resolved` changes from DFS-post-order to BFS-level-order — confirmed not semantically significant for cache keys (callers in `graph.rs` iterate the list to hash files; no order invariant).

## Benchmark results (criterion, Windows / NTFS host, 8 cores)

### `write_payloads` — N cached 1 MiB payloads via hardlink + copy fallback
| N | serial | parallel | speedup |
|---|---|---|---|
| 3 | 3.09 ms | 3.40 ms | 0.91x — *threshold falls back to serial in prod* |
| 5 | 5.61 ms | 4.22 ms | **1.33x** |
| 10 | 13.86 ms | 7.80 ms | **1.78x** |

### `read_outputs` — N 1 MiB `fs::read` calls (OS cache warm)
| N | serial | parallel | speedup |
|---|---|---|---|
| 1 | 488 µs | 647 µs | 0.75x — *N=1 fast-path in prod stays serial* |
| 3 | 2.81 ms | 1.77 ms | **1.59x** |
| 5 | 4.08 ms | 4.22 ms | 0.97x (wide CI) |
| 10 | 5.69 ms | 4.74 ms | **1.20x** |

### `scan_recursive` — synthetic header tree (OS cache warm)
| fixture | baseline (serial DFS) | after (parallel BFS) | change |
|---|---|---|---|
| `small_40_files` | 5.35 ms | 2.66 ms | **−54%, 2.0x** (p=0.00) |
| `large_1365_files` | 192.65 ms | 55.13 ms | **−71%, 3.5x** (p=0.00) |

## Files changed

- `crates/zccache-daemon/src/server.rs` — `write_payloads_par` helper, 6 call-site refactors, link cache-populate read refactor
- `crates/zccache-depgraph/src/scanner.rs` — `scan_recursive` parallel BFS rewrite
- `crates/zccache-{daemon,depgraph}/Cargo.toml` — register criterion + benches
- `crates/zccache-daemon/benches/{write_payloads.rs,read_outputs.rs,README.md}` (new)
- `crates/zccache-depgraph/benches/{scan_recursive.rs,README.md}` (new)

## Test plan

- [x] `soldr cargo check --workspace --all-targets` — clean
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` — clean (2m 02s)
- [x] `RUSTDOCFLAGS="-D warnings" soldr cargo doc --workspace --no-deps` — clean
- [x] 335 daemon + depgraph lib tests pass (`soldr cargo test -p zccache-daemon -p zccache-depgraph --lib`)
- [x] 37 scanner tests pass (DAG cycles, dedup, computed includes, transitive)
- [ ] CI to run `./test --full` including integration + perf

A local `./test` showed a pre-existing failure in `crates/zccache-cli/tests/installers.rs` due to a broken `clang_tool_chain_bins` Python install on the dev machine — unrelated to this PR (no installer or wrapper files touched). CI will verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)