### PR TITLE
fix(release): ship per-binary PDBs + add zccache symbols install (#276)

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -228,7 +228,17 @@ runs:
         # split-debuginfo = "packed" profile setting:
         #   Linux:        <bin>.dwp
         #   macOS:        <bin>.dSYM/   (directory)
-        #   Windows MSVC: <bin>.pdb     (Cargo's default already)
+        #   Windows MSVC: <bin>.pdb
+        #
+        # Windows PDB naming: rustc's MSVC linker writes PDBs using the
+        # underscored crate name, not the [[bin]] name. So:
+        #   zccache-daemon.exe  ->  zccache_daemon.pdb
+        #   zccache-fp.exe      ->  zccache_fp.pdb
+        # `zccache.exe` is the exception because its [[bin]] name has no
+        # hyphens. Windbg/cdb find a PDB by GUID via the codeview record
+        # embedded in the PE, so the underscored filename on disk still
+        # resolves for `zccache-daemon.exe`. See zccache#276 for the
+        # missing-PDB regression that motivated this naming fix.
         rm -rf staging-debug
         mkdir -p staging-debug
         copy_debug() {
@@ -246,8 +256,8 @@ runs:
         case "$TARGET" in
           *pc-windows-msvc)
             copy_debug "$TARGET_DIR/zccache.pdb"
-            copy_debug "$TARGET_DIR/zccache-daemon.pdb"
-            copy_debug "$TARGET_DIR/zccache-fp.pdb"
+            copy_debug "$TARGET_DIR/zccache_daemon.pdb"
+            copy_debug "$TARGET_DIR/zccache_fp.pdb"
             ;;
           *apple-darwin)
             copy_debug "$TARGET_DIR/zccache.dSYM"
@@ -262,6 +272,32 @@ runs:
         esac
         echo "Staged debug sidecars:"
         ls -la staging-debug || true
+        # Fail the build if a target's debug sidecars are missing entirely.
+        # On Windows in particular, silent misses regressed zccache#276 where
+        # only zccache.pdb shipped while the daemon/fp PDBs were skipped.
+        if [ -z "$(ls -A staging-debug 2>/dev/null)" ]; then
+          echo "::error::No debug sidecars staged for target $TARGET" >&2
+          exit 1
+        fi
+        # Per-binary completeness check: each of the three bins must have a
+        # matching sidecar present. Failing here surfaces naming drift (e.g.
+        # the rustc PDB-name convention change that caused zccache#276)
+        # before it ships to a release.
+        case "$TARGET" in
+          *pc-windows-msvc) require=("zccache.pdb" "zccache_daemon.pdb" "zccache_fp.pdb") ;;
+          *apple-darwin)    require=("zccache.dSYM" "zccache-daemon.dSYM" "zccache-fp.dSYM") ;;
+          *)                require=("zccache.dwp" "zccache-daemon.dwp" "zccache-fp.dwp") ;;
+        esac
+        missing=()
+        for entry in "${require[@]}"; do
+          if [ ! -e "staging-debug/$entry" ]; then
+            missing+=("$entry")
+          fi
+        done
+        if [ ${#missing[@]} -gt 0 ]; then
+          echo "::error::Missing debug sidecars for $TARGET: ${missing[*]}" >&2
+          exit 1
+        fi
 
     - name: Package standalone archive
       shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,7 +187,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.4.2",
+ "constant_time_eq",
  "cpufeatures",
 ]
 
@@ -262,25 +251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "bzip2"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
-dependencies = [
- "bzip2-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,8 +263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -344,16 +312,6 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
 ]
 
 [[package]]
@@ -422,12 +380,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "constant_time_eq"
@@ -607,12 +559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deflate64"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,7 +586,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -971,15 +916,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,15 +1165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,16 +1220,6 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -1444,17 +1361,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baab2bbbd7d75a144d671e9ff79270e903957d92fb7386fd39034c709bd2661"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -1644,16 +1550,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,12 +1560,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plain"
@@ -2343,17 +2233,6 @@ dependencies = [
  "nt-time",
  "sha2",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -3392,15 +3271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
-
-[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3461,11 +3331,13 @@ dependencies = [
  "blake3",
  "clap",
  "flate2",
+ "fs2",
  "jwalk",
  "mimalloc",
  "pyo3",
  "pyo3-build-config",
  "rayon",
+ "reqwest",
  "serde",
  "serde_json",
  "tar",
@@ -3806,20 +3678,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "zerotrie"
@@ -3860,28 +3718,15 @@ version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
 dependencies = [
- "aes",
  "arbitrary",
- "bzip2",
- "constant_time_eq 0.3.1",
  "crc32fast",
  "crossbeam-utils",
- "deflate64",
  "displaydoc",
  "flate2",
- "getrandom 0.3.4",
- "hmac",
  "indexmap",
- "lzma-rs",
  "memchr",
- "pbkdf2",
- "sha1",
  "thiserror",
- "time",
- "xz2",
- "zeroize",
  "zopfli",
- "zstd",
 ]
 
 [[package]]
@@ -3900,32 +3745,4 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/crates/zccache-cli/Cargo.toml
+++ b/crates/zccache-cli/Cargo.toml
@@ -39,6 +39,9 @@ jwalk = { workspace = true }
 tar = { workspace = true }
 flate2 = { workspace = true }
 tempfile = { workspace = true }
+reqwest = { workspace = true }
+zip = { workspace = true }
+fs2 = { workspace = true }
 pyo3 = { version = "0.23", features = ["extension-module", "generate-import-lib", "abi3-py310"], optional = true }
 
 [target.'cfg(unix)'.dependencies]
@@ -59,9 +62,6 @@ path = "src/main.rs"
 # 1.5.0: adds `zccache status --json` and the `zccache analyze` subcommand.
 # Touching this comment busts the cached Cargo fingerprint that was holding
 # a stale unit-test binary in target-snapshot CI jobs (see PR #257).
-
-[dev-dependencies]
-zip = "2"
 
 [build-dependencies]
 pyo3-build-config = "0.23"

--- a/crates/zccache-cli/build.rs
+++ b/crates/zccache-cli/build.rs
@@ -5,4 +5,10 @@ fn main() {
     if std::env::var_os("CARGO_FEATURE_PYTHON").is_some() {
         pyo3_build_config::add_extension_module_link_args();
     }
+
+    // Expose the build's target triple at runtime so `zccache symbols install`
+    // can construct the matching GitHub Release asset URL without asking the
+    // user to type it. `TARGET` is set by cargo for build scripts.
+    let target = std::env::var("TARGET").expect("cargo sets TARGET for build scripts");
+    println!("cargo:rustc-env=ZCCACHE_BUILD_TARGET={target}");
 }

--- a/crates/zccache-cli/src/lib.rs
+++ b/crates/zccache-cli/src/lib.rs
@@ -6,6 +6,8 @@ use zccache_core::NormalizedPath;
 #[cfg(feature = "python")]
 mod python;
 
+pub mod symbols;
+
 pub use zccache_download_client::{
     ArchiveFormat, DownloadSource, FetchRequest, FetchResult, FetchState, FetchStateKind,
     FetchStatus, WaitMode,

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -31,6 +31,7 @@ use zccache_artifact::{
     restore_rust_plan_local, rust_plan_bundle_dir, rust_plan_cache_key, save_rust_plan_local,
     RustArtifactPlanV1, RustPlanError, RustPlanOperation, RustPlanSummary,
 };
+use zccache_cli::symbols::{self, InstallOptions as SymbolsInstallOptions};
 use zccache_cli::{
     client_download, run_ino_convert_cached, session_end_idempotent, ArchiveFormat, DownloadParams,
     DownloadSource, InoConvertOptions, WaitMode,
@@ -326,6 +327,36 @@ enum Commands {
         #[arg(long, default_value_t = 60)]
         stamp_seconds_ahead: u64,
     },
+    /// Download and install matching debug symbols (PDB/dSYM/dwp) next to
+    /// the running zccache binary. See `zccache#276`.
+    Symbols {
+        #[command(subcommand)]
+        action: SymbolsCommands,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum SymbolsCommands {
+    /// Download the matching `-debug` archive from the GitHub release and
+    /// drop the per-binary sidecars next to the running zccache executable
+    /// so cdb/WinDbg (or perf/lldb) can resolve symbols.
+    Install {
+        /// Override the release version to fetch (defaults to the running
+        /// binary's compile-time `CARGO_PKG_VERSION`).
+        #[arg(long)]
+        version: Option<String>,
+        /// Override the Rust target triple (defaults to the running binary's
+        /// compile-time `ZCCACHE_BUILD_TARGET`).
+        #[arg(long)]
+        target: Option<String>,
+        /// Install into this directory instead of the directory containing
+        /// the running zccache executable.
+        #[arg(long)]
+        prefix: Option<PathBuf>,
+        /// Re-download even if matching sidecars are already present.
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -615,6 +646,7 @@ const KNOWN_SUBCOMMANDS: &[&str] = &[
     "snapshot-bytes",
     "snapshot-fp-record",
     "snapshot-fp-validate",
+    "symbols",
     "help",
     "--help",
     "-h",
@@ -648,6 +680,12 @@ fn exit_code_from_i32(code: i32) -> ExitCode {
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
+
+    // Best-effort: if the user opted in via env, fetch matching debug
+    // sidecars before doing anything else so the very first command's
+    // failure (if any) lands with resolvable symbols. Idempotent — skips
+    // when already installed. See `zccache_cli::symbols`.
+    symbols::maybe_auto_install();
 
     // Auto-detect: if first arg isn't a known subcommand or a --flag, enter wrap mode.
     // e.g., `zccache clang++ -c foo.cpp -o foo.o`
@@ -907,6 +945,56 @@ fn main() -> ExitCode {
             manifest_path,
             stamp_seconds_ahead,
         ),
+        Commands::Symbols { action } => match action {
+            SymbolsCommands::Install {
+                version,
+                target,
+                prefix,
+                force,
+            } => cmd_symbols_install(version, target, prefix, force),
+        },
+    }
+}
+
+fn cmd_symbols_install(
+    version: Option<String>,
+    target: Option<String>,
+    prefix: Option<PathBuf>,
+    force: bool,
+) -> ExitCode {
+    let opts = SymbolsInstallOptions {
+        version,
+        target,
+        prefix,
+        force,
+        // The user invoked the subcommand directly; wait for any peer
+        // install to finish rather than skipping silently.
+        lock_behavior: zccache_cli::symbols::LockBehavior::Wait,
+    };
+    match symbols::install(opts) {
+        Ok(report) => {
+            if report.skipped_already_present {
+                println!(
+                    "zccache symbols: already installed in {}",
+                    report.prefix.display()
+                );
+            } else {
+                println!(
+                    "zccache symbols: installed {} sidecar(s) into {} (from {})",
+                    report.installed.len(),
+                    report.prefix.display(),
+                    report.url,
+                );
+                for path in &report.installed {
+                    println!("  {}", path.display());
+                }
+            }
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("zccache symbols install: {err}");
+            ExitCode::FAILURE
+        }
     }
 }
 

--- a/crates/zccache-cli/src/symbols.rs
+++ b/crates/zccache-cli/src/symbols.rs
@@ -1,0 +1,662 @@
+//! Download and install matching debug symbols for the running zccache build.
+//!
+//! Motivation (zccache#276): when zccache.exe / zccache-daemon.exe faults on
+//! Windows, the embedded CodeView record points at compile-time paths in
+//! `target/.../release/deps/` that don't exist on the user's machine. Without
+//! the matching `.pdb` files, cdb/WinDbg cannot resolve function names and
+//! the stack trace is only RVAs. The release build now ships a separate
+//! `<root>-debug.zip` (or `.tar.gz`) archive with the per-binary sidecars;
+//! this module gives users a one-shot way to download the archive that
+//! matches their installed binary and drop the sidecars next to the exe so
+//! `dbghelp` finds them via its same-directory fallback.
+//!
+//! The build's version and target triple are embedded at compile time
+//! (`CARGO_PKG_VERSION` and `ZCCACHE_BUILD_TARGET` from `build.rs`) so the
+//! defaults always match the running binary.
+
+use std::env;
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+
+const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+const BUILD_TARGET: &str = env!("ZCCACHE_BUILD_TARGET");
+const RELEASE_BASE_URL: &str = "https://github.com/zackees/zccache/releases/download";
+const LOCK_FILENAME: &str = ".zccache-symbols.lock";
+
+/// Env var that, when set to a non-empty value, makes `zccache.exe` install
+/// missing debug symbols next to itself on startup. Idempotent — installs are
+/// skipped when the sidecars are already present.
+pub const AUTO_INSTALL_ENV: &str = "ZCCACHE_AUTO_INSTALL_SYMBOLS";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LockBehavior {
+    /// Block until the install lock is acquired. Used for the explicit
+    /// `zccache symbols install` subcommand.
+    #[default]
+    Wait,
+    /// Try once; if another process holds the lock, return without doing
+    /// any work. Used for the auto-install hot path so compile-loop wrappers
+    /// don't all pile up on a single download.
+    SkipIfBusy,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct InstallOptions {
+    /// Version to fetch. Defaults to the running binary's version.
+    pub version: Option<String>,
+    /// Target triple to fetch. Defaults to the running binary's build target.
+    pub target: Option<String>,
+    /// Directory to drop sidecars into. Defaults to the directory containing
+    /// the running zccache executable.
+    pub prefix: Option<PathBuf>,
+    /// Re-download even if matching sidecars are already present.
+    pub force: bool,
+    /// What to do when another zccache process is already mid-install.
+    pub lock_behavior: LockBehavior,
+}
+
+#[derive(Debug)]
+pub struct InstallReport {
+    pub prefix: PathBuf,
+    pub installed: Vec<PathBuf>,
+    pub skipped_already_present: bool,
+    /// Set when `LockBehavior::SkipIfBusy` and another process is currently
+    /// holding the install lock. Caller can choose to retry later.
+    pub skipped_lock_busy: bool,
+    pub url: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SymbolsError {
+    #[error("unable to locate the running zccache binary: {0}")]
+    LocateExe(#[source] io::Error),
+    #[error("network error fetching {url}: {source}")]
+    Fetch {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("release asset returned HTTP {status} for {url}")]
+    HttpStatus { url: String, status: u16 },
+    #[error("io error writing {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("zip error: {0}")]
+    Zip(#[from] zip::result::ZipError),
+    #[error("archive contained no debug sidecars (expected .pdb/.dwp/.dSYM entries)")]
+    EmptyArchive,
+    #[error("tokio runtime error: {0}")]
+    Runtime(#[source] io::Error),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ArchiveKind {
+    /// Windows `-debug.zip` containing `.pdb` files.
+    WindowsPdb,
+    /// macOS `-debug.tar.gz` containing `.dSYM` bundles.
+    MacOsDsym,
+    /// Linux `-debug.tar.gz` containing `.dwp` files.
+    LinuxDwp,
+}
+
+impl ArchiveKind {
+    fn for_target(target: &str) -> Self {
+        if target.contains("pc-windows") {
+            Self::WindowsPdb
+        } else if target.contains("apple-darwin") || target.contains("apple-ios") {
+            Self::MacOsDsym
+        } else {
+            Self::LinuxDwp
+        }
+    }
+
+    fn file_extension(self) -> &'static str {
+        match self {
+            Self::WindowsPdb => "zip",
+            Self::MacOsDsym | Self::LinuxDwp => "tar.gz",
+        }
+    }
+
+    /// Sidecar filenames expected next to the binaries after extraction.
+    /// Matches `.github/actions/build-target/action.yml` — the producer
+    /// side. Keep in sync.
+    fn expected_sidecars(self) -> &'static [&'static str] {
+        match self {
+            // rustc's MSVC linker writes PDBs using the underscored crate
+            // name (zccache#276): `zccache-daemon.exe` -> `zccache_daemon.pdb`.
+            Self::WindowsPdb => &["zccache.pdb", "zccache_daemon.pdb", "zccache_fp.pdb"],
+            Self::MacOsDsym => &["zccache.dSYM", "zccache-daemon.dSYM", "zccache-fp.dSYM"],
+            Self::LinuxDwp => &["zccache.dwp", "zccache-daemon.dwp", "zccache-fp.dwp"],
+        }
+    }
+}
+
+fn resolved_prefix(opts_prefix: Option<&Path>) -> Result<PathBuf, SymbolsError> {
+    if let Some(p) = opts_prefix {
+        return Ok(p.to_path_buf());
+    }
+    let exe = env::current_exe().map_err(SymbolsError::LocateExe)?;
+    Ok(exe
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from(".")))
+}
+
+fn build_url(version: &str, target: &str, kind: ArchiveKind) -> String {
+    // GitHub release tags omit the `v` (e.g. `1.6.0`) but asset filenames
+    // include it (e.g. `zccache-v1.6.0-...`). Build both sides correctly.
+    let tag = version;
+    let ext = kind.file_extension();
+    format!(
+        "{base}/{tag}/zccache-v{version}-{target}-debug.{ext}",
+        base = RELEASE_BASE_URL,
+    )
+}
+
+fn all_sidecars_present(prefix: &Path, kind: ArchiveKind) -> bool {
+    kind.expected_sidecars()
+        .iter()
+        .all(|name| prefix.join(name).exists())
+}
+
+/// Synchronous entry point. Wraps the async download in a private tokio
+/// runtime so callers don't need an executor handy.
+pub fn install(opts: InstallOptions) -> Result<InstallReport, SymbolsError> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(SymbolsError::Runtime)?;
+    runtime.block_on(install_async(opts))
+}
+
+pub async fn install_async(opts: InstallOptions) -> Result<InstallReport, SymbolsError> {
+    let version = opts
+        .version
+        .clone()
+        .unwrap_or_else(|| PKG_VERSION.to_string());
+    let target = opts
+        .target
+        .clone()
+        .unwrap_or_else(|| BUILD_TARGET.to_string());
+    let prefix = resolved_prefix(opts.prefix.as_deref())?;
+    let kind = ArchiveKind::for_target(&target);
+    let url = build_url(&version, &target, kind);
+
+    // Lock-free fast path: avoids creating a lockfile when symbols are
+    // already installed (the common steady-state).
+    if !opts.force && all_sidecars_present(&prefix, kind) {
+        return Ok(InstallReport {
+            prefix,
+            installed: Vec::new(),
+            skipped_already_present: true,
+            skipped_lock_busy: false,
+            url,
+        });
+    }
+
+    fs::create_dir_all(&prefix).map_err(|e| SymbolsError::Io {
+        path: prefix.clone(),
+        source: e,
+    })?;
+
+    // Cross-process lock so two concurrent zccache invocations don't both
+    // download the same archive and race on extraction. The lock is an OS
+    // advisory lock on the lockfile handle (fs2 -> LockFileEx on Windows,
+    // fcntl on Unix); the kernel releases it when the File handle drops,
+    // when the process exits cleanly, when it panics, or when it's killed
+    // with SIGKILL / TerminateProcess. There is no stale-lockfile cleanup
+    // needed.
+    let lockfile_path = prefix.join(LOCK_FILENAME);
+    let lockfile = open_lockfile(&lockfile_path)?;
+    if !acquire_exclusive(&lockfile, opts.lock_behavior)? {
+        return Ok(InstallReport {
+            prefix,
+            installed: Vec::new(),
+            skipped_already_present: false,
+            skipped_lock_busy: true,
+            url,
+        });
+    }
+
+    // Re-check under the lock: another process may have completed the
+    // install between our fast-path check and acquiring the lock.
+    if !opts.force && all_sidecars_present(&prefix, kind) {
+        return Ok(InstallReport {
+            prefix,
+            installed: Vec::new(),
+            skipped_already_present: true,
+            skipped_lock_busy: false,
+            url,
+        });
+    }
+
+    let client = reqwest::Client::builder()
+        .user_agent(concat!("zccache/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| SymbolsError::Fetch {
+            url: url.clone(),
+            source: e,
+        })?;
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| SymbolsError::Fetch {
+            url: url.clone(),
+            source: e,
+        })?;
+    if !response.status().is_success() {
+        return Err(SymbolsError::HttpStatus {
+            url: url.clone(),
+            status: response.status().as_u16(),
+        });
+    }
+    let bytes = response.bytes().await.map_err(|e| SymbolsError::Fetch {
+        url: url.clone(),
+        source: e,
+    })?;
+
+    let installed = match kind {
+        ArchiveKind::WindowsPdb => extract_zip(&bytes, &prefix)?,
+        ArchiveKind::MacOsDsym | ArchiveKind::LinuxDwp => extract_targz(&bytes, &prefix)?,
+    };
+
+    if installed.is_empty() {
+        return Err(SymbolsError::EmptyArchive);
+    }
+
+    // Lock released on `lockfile` drop here.
+    drop(lockfile);
+
+    Ok(InstallReport {
+        prefix,
+        installed,
+        skipped_already_present: false,
+        skipped_lock_busy: false,
+        url,
+    })
+}
+
+fn open_lockfile(path: &Path) -> Result<File, SymbolsError> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+        .map_err(|e| SymbolsError::Io {
+            path: path.to_path_buf(),
+            source: e,
+        })
+}
+
+/// Acquire the install lock. Returns `Ok(true)` on success, `Ok(false)` only
+/// when `SkipIfBusy` and another holder is present. Other errors propagate
+/// as `SymbolsError::Io` so a permission problem surfaces clearly.
+fn acquire_exclusive(file: &File, behavior: LockBehavior) -> Result<bool, SymbolsError> {
+    // fs2 trait methods are called via UFCS to avoid the ambiguity with
+    // `std::fs::File::try_lock_exclusive` that landed in Rust 1.89.
+    match behavior {
+        LockBehavior::SkipIfBusy => match fs2::FileExt::try_lock_exclusive(file) {
+            Ok(()) => Ok(true),
+            Err(err) if is_would_block(&err) => Ok(false),
+            Err(err) => Err(SymbolsError::Io {
+                path: PathBuf::from(LOCK_FILENAME),
+                source: err,
+            }),
+        },
+        LockBehavior::Wait => fs2::FileExt::lock_exclusive(file)
+            .map(|()| true)
+            .map_err(|err| SymbolsError::Io {
+                path: PathBuf::from(LOCK_FILENAME),
+                source: err,
+            }),
+    }
+}
+
+fn is_would_block(err: &io::Error) -> bool {
+    if matches!(
+        err.kind(),
+        io::ErrorKind::WouldBlock | io::ErrorKind::ResourceBusy
+    ) {
+        return true;
+    }
+    // Windows: `LockFileEx` with `LOCKFILE_FAIL_IMMEDIATELY` returns
+    // `ERROR_LOCK_VIOLATION (33)`, which std currently surfaces as
+    // `ErrorKind::Uncategorized`. Treat it as "would block".
+    #[cfg(windows)]
+    {
+        if matches!(err.raw_os_error(), Some(33)) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Extract `.pdb` files from a zip into `prefix`. Strips the archive's
+/// top-level directory (`zccache-vX.Y.Z-<target>-debug/`) so files land
+/// directly next to the binaries. Each file is written via tempfile + rename
+/// so an interrupted install can't leave a partial PDB that subsequent
+/// `all_sidecars_present` checks would treat as complete.
+fn extract_zip(bytes: &[u8], prefix: &Path) -> Result<Vec<PathBuf>, SymbolsError> {
+    let cursor = io::Cursor::new(bytes);
+    let mut archive = zip::ZipArchive::new(cursor)?;
+    let mut installed = Vec::new();
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i)?;
+        if entry.is_dir() {
+            continue;
+        }
+        let raw_name = match entry.enclosed_name() {
+            Some(p) => p.to_path_buf(),
+            None => continue,
+        };
+        // Keep only the trailing path component for PDB sidecars; debuggers
+        // search by basename in the binary's directory.
+        let leaf = match raw_name.file_name() {
+            Some(n) => Path::new(n).to_path_buf(),
+            None => continue,
+        };
+        if !is_debug_sidecar(&leaf) {
+            continue;
+        }
+        let dest = prefix.join(&leaf);
+        write_atomically(&dest, &mut entry)?;
+        installed.push(dest);
+    }
+    Ok(installed)
+}
+
+/// Write a single file via a same-directory tempfile + rename. On Windows
+/// `NamedTempFile::persist` uses `MoveFileExW(MOVEFILE_REPLACE_EXISTING)`
+/// which is atomic for any concurrent reader.
+fn write_atomically(dest: &Path, src: &mut dyn io::Read) -> Result<(), SymbolsError> {
+    let parent = dest.parent().unwrap_or(Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(parent).map_err(|e| SymbolsError::Io {
+        path: parent.to_path_buf(),
+        source: e,
+    })?;
+    io::copy(src, tmp.as_file_mut()).map_err(|e| SymbolsError::Io {
+        path: tmp.path().to_path_buf(),
+        source: e,
+    })?;
+    tmp.persist(dest).map_err(|e| SymbolsError::Io {
+        path: dest.to_path_buf(),
+        source: e.error,
+    })?;
+    Ok(())
+}
+
+/// Extract `.dwp` files or `.dSYM` bundles from a gzip-compressed tarball.
+fn extract_targz(bytes: &[u8], prefix: &Path) -> Result<Vec<PathBuf>, SymbolsError> {
+    let cursor = io::Cursor::new(bytes);
+    let decoder = flate2::read::GzDecoder::new(cursor);
+    let mut archive = tar::Archive::new(decoder);
+    let mut installed = Vec::new();
+    for entry in archive.entries().map_err(|e| SymbolsError::Io {
+        path: prefix.to_path_buf(),
+        source: e,
+    })? {
+        let mut entry = entry.map_err(|e| SymbolsError::Io {
+            path: prefix.to_path_buf(),
+            source: e,
+        })?;
+        let raw_path = match entry.path() {
+            Ok(p) => p.into_owned(),
+            Err(_) => continue,
+        };
+        let components: Vec<_> = raw_path.components().collect();
+        // The archive layout is `<root>/<sidecar...>`. Strip the top-level
+        // wrapper directory so contents land directly under `prefix`.
+        if components.len() < 2 {
+            continue;
+        }
+        let inner: PathBuf = components[1..]
+            .iter()
+            .map(|c| c.as_os_str())
+            .collect::<PathBuf>();
+        // Filter: top-level sidecar entry must look like a debug file or
+        // dSYM bundle root. Children of dSYM bundles are copied verbatim
+        // once the bundle root is allowed through.
+        let first_inner = match inner.components().next() {
+            Some(c) => Path::new(c.as_os_str()).to_path_buf(),
+            None => continue,
+        };
+        if !is_debug_sidecar(&first_inner) {
+            continue;
+        }
+        let dest = prefix.join(&inner);
+        if entry.header().entry_type().is_dir() {
+            fs::create_dir_all(&dest).map_err(|e| SymbolsError::Io {
+                path: dest.clone(),
+                source: e,
+            })?;
+            continue;
+        }
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent).map_err(|e| SymbolsError::Io {
+                path: parent.to_path_buf(),
+                source: e,
+            })?;
+        }
+        entry.unpack(&dest).map_err(|e| SymbolsError::Io {
+            path: dest.clone(),
+            source: e,
+        })?;
+        // Record the bundle root once, not every file inside it.
+        if inner.components().count() == 1 {
+            installed.push(dest);
+        }
+    }
+    Ok(installed)
+}
+
+fn is_debug_sidecar(leaf: &Path) -> bool {
+    matches!(
+        leaf.extension().and_then(|s| s.to_str()),
+        Some("pdb" | "dwp" | "dSYM")
+    )
+}
+
+/// Called from `main()` when the auto-install env var is set. Best-effort:
+/// any failure is reported to stderr so a transient network blip on
+/// startup doesn't break the user's actual command. The fast-path (already
+/// installed) is silent so the env var can stay set permanently without
+/// adding noise to every invocation.
+///
+/// Concurrency model for compile-loop wrappers: this uses
+/// `LockBehavior::SkipIfBusy` so when many zccache invocations start in
+/// parallel only the first one downloads; the rest see the lock and return
+/// immediately. Once the winner finishes, the next invocation takes the
+/// silent fast path.
+pub fn maybe_auto_install() {
+    if env::var_os(AUTO_INSTALL_ENV).is_none_or(|v| v.is_empty()) {
+        return;
+    }
+    // Fast-path sidecar-presence check before reporting any activity, so a
+    // permanently-set env var stays quiet once symbols are installed.
+    let kind = ArchiveKind::for_target(BUILD_TARGET);
+    if let Ok(prefix) = resolved_prefix(None) {
+        if all_sidecars_present(&prefix, kind) {
+            return;
+        }
+    }
+    let opts = InstallOptions {
+        lock_behavior: LockBehavior::SkipIfBusy,
+        ..InstallOptions::default()
+    };
+    match install(opts) {
+        Ok(report) if report.skipped_lock_busy => {
+            // Another zccache is already installing — don't block this one's
+            // actual command. The next invocation will see the result.
+            eprintln!(
+                "zccache: another process is installing debug sidecars in {}, skipping",
+                report.prefix.display()
+            );
+        }
+        Ok(report) if report.skipped_already_present => {
+            // Race: another process completed between fast-path check and
+            // post-lock re-check. Nothing more to do, stay quiet.
+        }
+        Ok(report) => {
+            eprintln!(
+                "zccache: installed {} debug sidecar(s) into {}",
+                report.installed.len(),
+                report.prefix.display()
+            );
+        }
+        Err(err) => {
+            eprintln!("zccache: debug symbol auto-install failed: {err}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn archive_kind_for_target() {
+        assert!(matches!(
+            ArchiveKind::for_target("x86_64-pc-windows-msvc"),
+            ArchiveKind::WindowsPdb
+        ));
+        assert!(matches!(
+            ArchiveKind::for_target("aarch64-pc-windows-msvc"),
+            ArchiveKind::WindowsPdb
+        ));
+        assert!(matches!(
+            ArchiveKind::for_target("x86_64-apple-darwin"),
+            ArchiveKind::MacOsDsym
+        ));
+        assert!(matches!(
+            ArchiveKind::for_target("aarch64-unknown-linux-musl"),
+            ArchiveKind::LinuxDwp
+        ));
+        assert!(matches!(
+            ArchiveKind::for_target("x86_64-unknown-linux-gnu"),
+            ArchiveKind::LinuxDwp
+        ));
+    }
+
+    #[test]
+    fn build_url_windows_uses_zip_and_v_prefix() {
+        let url = build_url("1.6.0", "x86_64-pc-windows-msvc", ArchiveKind::WindowsPdb);
+        assert_eq!(
+            url,
+            "https://github.com/zackees/zccache/releases/download/1.6.0/zccache-v1.6.0-x86_64-pc-windows-msvc-debug.zip"
+        );
+    }
+
+    #[test]
+    fn build_url_linux_uses_tar_gz() {
+        let url = build_url("1.6.0", "x86_64-unknown-linux-musl", ArchiveKind::LinuxDwp);
+        assert!(url.ends_with(".tar.gz"));
+        assert!(url.contains("zccache-v1.6.0-x86_64-unknown-linux-musl-debug"));
+    }
+
+    #[test]
+    fn expected_sidecars_use_underscored_pdb_names_on_windows() {
+        // Regression guard for zccache#276: rustc's MSVC PDB filename uses
+        // the underscored crate name, not the [[bin]] name.
+        let names = ArchiveKind::WindowsPdb.expected_sidecars();
+        assert!(names.contains(&"zccache.pdb"));
+        assert!(names.contains(&"zccache_daemon.pdb"));
+        assert!(names.contains(&"zccache_fp.pdb"));
+    }
+
+    #[test]
+    fn is_debug_sidecar_recognizes_extensions() {
+        assert!(is_debug_sidecar(Path::new("zccache.pdb")));
+        assert!(is_debug_sidecar(Path::new("zccache-daemon.dwp")));
+        assert!(is_debug_sidecar(Path::new("zccache-fp.dSYM")));
+        assert!(!is_debug_sidecar(Path::new("zccache.exe")));
+        assert!(!is_debug_sidecar(Path::new("README.md")));
+    }
+
+    #[test]
+    fn skips_install_when_sidecars_already_present() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for name in ArchiveKind::WindowsPdb.expected_sidecars() {
+            fs::write(dir.path().join(name), b"stub").unwrap();
+        }
+        assert!(all_sidecars_present(dir.path(), ArchiveKind::WindowsPdb));
+    }
+
+    #[test]
+    fn detects_missing_sidecar() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(dir.path().join("zccache.pdb"), b"stub").unwrap();
+        // missing daemon + fp
+        assert!(!all_sidecars_present(dir.path(), ArchiveKind::WindowsPdb));
+    }
+
+    /// A second `try_lock_exclusive` while the first holder is alive must
+    /// fail — the regression we'd be guarding against is a stale-flag
+    /// implementation that lets two installers run concurrently.
+    #[test]
+    fn lockfile_blocks_second_try_lock() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock = dir.path().join(LOCK_FILENAME);
+        let first = open_lockfile(&lock).expect("open lock 1");
+        assert!(acquire_exclusive(&first, LockBehavior::SkipIfBusy).unwrap());
+
+        let second = open_lockfile(&lock).expect("open lock 2");
+        assert!(
+            !acquire_exclusive(&second, LockBehavior::SkipIfBusy).unwrap(),
+            "second process should have been told the lock is busy"
+        );
+    }
+
+    /// When the holder drops the file handle (or the process dies — same
+    /// kernel-level behavior), the lock must become available again
+    /// without any cleanup step.
+    #[test]
+    fn lockfile_released_on_handle_drop() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock = dir.path().join(LOCK_FILENAME);
+
+        {
+            let first = open_lockfile(&lock).expect("open lock 1");
+            assert!(acquire_exclusive(&first, LockBehavior::SkipIfBusy).unwrap());
+            // handle drops here — kernel releases the advisory lock.
+        }
+
+        let second = open_lockfile(&lock).expect("open lock 2");
+        assert!(
+            acquire_exclusive(&second, LockBehavior::SkipIfBusy).unwrap(),
+            "lock should be free after first holder drops the handle"
+        );
+    }
+
+    /// Atomic-write helper must materialize the destination file only after
+    /// the source is fully copied. We assert via post-state, not timing —
+    /// just confirm the destination has the right contents.
+    #[test]
+    fn write_atomically_persists_full_contents() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("zccache.pdb");
+        let mut src: &[u8] = b"PDB-payload";
+        write_atomically(&dest, &mut src).unwrap();
+        assert_eq!(fs::read(&dest).unwrap(), b"PDB-payload");
+    }
+
+    /// The non-blocking path used by auto-install must not return
+    /// `Ok(true)` when the lock is contended. Couples to
+    /// `is_would_block` correctly mapping the platform error code.
+    #[test]
+    fn skip_if_busy_classifies_contended_lock_as_skip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock = dir.path().join(LOCK_FILENAME);
+        let holder = open_lockfile(&lock).unwrap();
+        assert!(acquire_exclusive(&holder, LockBehavior::SkipIfBusy).unwrap());
+
+        let challenger = open_lockfile(&lock).unwrap();
+        let got = acquire_exclusive(&challenger, LockBehavior::SkipIfBusy).unwrap();
+        assert!(!got, "challenger must see SkipIfBusy -> Ok(false)");
+    }
+}


### PR DESCRIPTION
## Summary

Two related changes for the Windows debugging story tracked in #276.

- **Action fix** — 1.6.0's Windows debug zip shipped only `zccache.pdb` because the staging step looked for hyphenated names. rustc's MSVC linker emits PDBs using the underscored crate name (`zccache_daemon.pdb`, `zccache_fp.pdb`), independent of the `[[bin]]` exe name. Switched to the actual filenames and added a per-target completeness assertion so future naming drift fails the build.
- **`zccache symbols install`** — downloads `zccache-v<ver>-<target>-debug.{zip|tar.gz}` from the GitHub release and unpacks PDBs/dSYM/dwp sidecars next to the running executable so cdb/WinDbg finds them via `dbghelp`'s same-directory fallback. Version and target are embedded at build time via `build.rs`.
- **`ZCCACHE_AUTO_INSTALL_SYMBOLS=1`** — runs the install at startup. Lock-free fast path stays silent once sidecars are present.

## Concurrency

Advisory lock via `fs2` on `.zccache-symbols.lock` next to the binaries:
- Auto-install path uses `SkipIfBusy` so compile-loop wrappers don't all pile onto one download.
- Explicit subcommand uses `Wait`.
- Lock is OS-level — kernel releases on handle drop, clean exit, panic, OOM, or `SIGKILL`/`TerminateProcess`.
- Extraction uses tempfile + rename so an interrupted install can't leave a partial PDB that the next existence check would treat as complete.

## Test plan

- [x] Unit tests: 11 tests in `symbols::tests` covering URL format, target classification, sidecar names, lock contention, lock release on drop, atomic-write contents.
- [x] Local end-to-end: `zccache symbols install --prefix /tmp/...` against the live 1.6.0 release URL — downloads + extracts.
- [x] Concurrency: 4 parallel `ZCCACHE_AUTO_INSTALL_SYMBOLS=1 zccache --version` invocations against an empty prefix — one downloads, the other three print "another process is installing… skipping". Final state: exactly one valid `zccache.pdb`.
- [x] Idempotency: 4 parallel invocations with all 3 stub sidecars present — all silent, fast-path skip.
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- [ ] Next tagged release verifies the action fix end-to-end: confirm `zccache-v<next>-x86_64-pc-windows-msvc-debug.zip` contains all 3 PDBs (was only 1 in 1.6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)