### PR TITLE
perf(io): parallelize watcher cold-scan + zccache warm restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3330,6 +3330,7 @@ version = "1.6.0"
 dependencies = [
  "blake3",
  "clap",
+ "criterion",
  "flate2",
  "fs2",
  "jwalk",
@@ -3620,11 +3621,13 @@ dependencies = [
 name = "zccache-watcher"
 version = "1.6.0"
 dependencies = [
+ "criterion",
  "globset",
  "jwalk",
  "notify",
  "pyo3",
  "pyo3-build-config",
+ "rayon",
  "tempfile",
  "thiserror",
  "tokio",

--- a/crates/zccache-cli/Cargo.toml
+++ b/crates/zccache-cli/Cargo.toml
@@ -63,5 +63,12 @@ path = "src/main.rs"
 # Touching this comment busts the cached Cargo fingerprint that was holding
 # a stale unit-test binary in target-snapshot CI jobs (see PR #257).
 
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "warm_restore"
+harness = false
+
 [build-dependencies]
 pyo3-build-config = "0.23"

--- a/crates/zccache-cli/benches/README.md
+++ b/crates/zccache-cli/benches/README.md
@@ -1,0 +1,18 @@
+# zccache-cli benches
+
+Criterion micro-benchmark for the `zccache warm` cache-restore fan-out.
+
+| Bench | Measures |
+|---|---|
+| `warm_restore` | Per-output `remove_file + hard_link + open + set_times` over N entries, serial vs `rayon::par_iter` |
+
+Run:
+
+```bash
+soldr cargo bench -p zccache-cli --bench warm_restore
+```
+
+Each entry is independent; restore order doesn't matter. CI cache restores
+can be 1k–5k outputs, so the per-file syscall cost dominates wall-clock time.
+
+Counts: 100 / 1000 / 5000.

--- a/crates/zccache-cli/benches/warm_restore.rs
+++ b/crates/zccache-cli/benches/warm_restore.rs
@@ -1,0 +1,110 @@
+//! Micro-benchmark for `zccache warm` restore fan-out.
+//!
+//! `restore_artifacts` in `crates/zccache-cli/src/main.rs` iterates over
+//! cached artifacts and, for each output, does
+//! `remove_file (if exists) + hard_link (fallback copy) + open + set_times`.
+//! Each entry is independent. CI cache restores can be 1k–5k entries; the
+//! per-file syscalls dominate.
+//!
+//! This bench mirrors that syscall sequence and compares a serial loop
+//! against `rayon::par_iter`. Counts: 100 / 1000 / 5000.
+
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rayon::prelude::*;
+
+const COUNTS: &[usize] = &[100, 1000, 5000];
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    work: Vec<(PathBuf, PathBuf)>,
+    file_times: std::fs::FileTimes,
+}
+
+impl Fixture {
+    fn new(n: usize) -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cache_dir = tmp.path().join("cache");
+        let dst_dir = tmp.path().join("dst");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::create_dir_all(&dst_dir).unwrap();
+
+        let mut work = Vec::with_capacity(n);
+        for i in 0..n {
+            let src = cache_dir.join(format!("a_{i:05}"));
+            // Small payloads — warm-restore artifacts are typically
+            // rlibs/rmetas; the per-file cost is dominated by syscalls
+            // (hard_link + open + set_times), not bytes.
+            std::fs::write(&src, b"// fake rlib bytes\n").unwrap();
+            let dst = dst_dir.join(format!("a_{i:05}.rlib"));
+            work.push((src, dst));
+        }
+
+        let now = SystemTime::now();
+        let file_times = std::fs::FileTimes::new()
+            .set_accessed(now)
+            .set_modified(now);
+        Self {
+            _tmp: tmp,
+            work,
+            file_times,
+        }
+    }
+
+    fn reset(&self) {
+        for (_, dst) in &self.work {
+            let _ = std::fs::remove_file(dst);
+        }
+    }
+}
+
+fn restore_one(src: &std::path::Path, dst: &std::path::Path, file_times: std::fs::FileTimes) {
+    if dst.exists() {
+        let _ = std::fs::remove_file(dst);
+    }
+    if std::fs::hard_link(src, dst).is_err() {
+        let _ = std::fs::copy(src, dst);
+    }
+    if let Ok(f) = std::fs::File::open(dst) {
+        let _ = f.set_times(file_times);
+    }
+}
+
+fn restore_serial(fx: &Fixture) {
+    for (src, dst) in &fx.work {
+        restore_one(src, dst, fx.file_times);
+    }
+}
+
+fn restore_parallel(fx: &Fixture) {
+    fx.work.par_iter().for_each(|(src, dst)| {
+        restore_one(src, dst, fx.file_times);
+    });
+}
+
+fn bench_warm_restore(c: &mut Criterion) {
+    let mut group = c.benchmark_group("warm_restore");
+    group.sample_size(20);
+
+    for &n in COUNTS {
+        let fx = Fixture::new(n);
+        group.bench_with_input(BenchmarkId::new("serial", n), &n, |b, _| {
+            b.iter(|| {
+                fx.reset();
+                restore_serial(black_box(&fx));
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("parallel", n), &n, |b, _| {
+            b.iter(|| {
+                fx.reset();
+                restore_parallel(black_box(&fx));
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_warm_restore);
+criterion_main!(benches);

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -2108,69 +2108,93 @@ fn warm_target(
         .set_accessed(now)
         .set_modified(now);
 
-    let mut restored = 0u64;
-    let mut skipped = 0u64;
-    let mut errors = 0u64;
-
+    // Flatten the artifact → output-name nesting into a single Vec of
+    // (src, dst, name) so we can parallelize the per-file work below.
+    // Each entry is independent: a hardlink + touch of one cache file
+    // into one output path. CI cache restores can be 1k–5k entries, and
+    // the per-file syscalls (remove_file + hard_link + open + set_times)
+    // dominate; rayon takes us from ~100 µs/file serial to N_cores-way
+    // parallel on warm OS cache.
+    let total_outputs: usize = artifacts
+        .iter()
+        .map(|(_, idx)| idx.output_names.len())
+        .sum();
+    let mut work: Vec<(std::path::PathBuf, std::path::PathBuf, String)> =
+        Vec::with_capacity(total_outputs);
     for (key_hex, idx) in &artifacts {
         for (i, name) in idx.output_names.iter().enumerate() {
-            let src = artifact_dir.join(format!("{key_hex}_{i}"));
-            let dst = deps_dir.join(name.as_str());
-
-            // Skip if artifact doesn't match any crate in the lockfile
-            if let Some(ref allowed) = allowed_crates {
-                if !artifact_matches_lockfile(name, allowed) {
-                    skipped += 1;
-                    continue;
-                }
-            }
-
-            // Skip if source payload does not exist on disk.
-            if !src.exists() {
-                skipped += 1;
-                continue;
-            }
-
-            // Remove existing file at destination (hardlink will fail if it exists).
-            if dst.exists() {
-                if let Err(e) = std::fs::remove_file(&dst) {
-                    eprintln!(
-                        "zccache warm: failed to remove existing {}: {e}",
-                        dst.display()
-                    );
-                    errors += 1;
-                    continue;
-                }
-            }
-
-            // Try hardlink first, fall back to copy.
-            let linked = std::fs::hard_link(&src, &dst).is_ok();
-            if !linked {
-                if let Err(e) = std::fs::copy(&src, &dst) {
-                    eprintln!(
-                        "zccache warm: failed to copy {} -> {}: {e}",
-                        src.display(),
-                        dst.display()
-                    );
-                    errors += 1;
-                    continue;
-                }
-            }
-
-            // Touch the just-hardlinked dst to bump the underlying inode's
-            // mtime, which propagates to the artifact-cache file via the
-            // shared-inode hardlink. See the comment on `file_times` above
-            // — this is the LRU recency signal for eviction, not a
-            // cargo-freshness hack.
-            if let Ok(f) = std::fs::File::open(&dst) {
-                let _ = f.set_times(file_times);
-            }
-
-            restored += 1;
+            work.push((
+                artifact_dir.join(format!("{key_hex}_{i}")),
+                deps_dir.join(name.as_str()),
+                name.clone(),
+            ));
         }
     }
 
-    Ok((restored, skipped, errors))
+    use rayon::prelude::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    let restored = AtomicU64::new(0);
+    let skipped = AtomicU64::new(0);
+    let errors = AtomicU64::new(0);
+
+    work.par_iter().for_each(|(src, dst, name)| {
+        // Skip if artifact doesn't match any crate in the lockfile.
+        if let Some(ref allowed) = allowed_crates {
+            if !artifact_matches_lockfile(name, allowed) {
+                skipped.fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+        }
+
+        // Skip if source payload does not exist on disk.
+        if !src.exists() {
+            skipped.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+
+        // Remove existing file at destination (hardlink will fail if it exists).
+        if dst.exists() {
+            if let Err(e) = std::fs::remove_file(dst) {
+                eprintln!(
+                    "zccache warm: failed to remove existing {}: {e}",
+                    dst.display()
+                );
+                errors.fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+        }
+
+        // Try hardlink first, fall back to copy.
+        let linked = std::fs::hard_link(src, dst).is_ok();
+        if !linked {
+            if let Err(e) = std::fs::copy(src, dst) {
+                eprintln!(
+                    "zccache warm: failed to copy {} -> {}: {e}",
+                    src.display(),
+                    dst.display()
+                );
+                errors.fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+        }
+
+        // Touch the just-hardlinked dst to bump the underlying inode's
+        // mtime, which propagates to the artifact-cache file via the
+        // shared-inode hardlink. See the comment on `file_times` above
+        // — this is the LRU recency signal for eviction, not a
+        // cargo-freshness hack.
+        if let Ok(f) = std::fs::File::open(dst) {
+            let _ = f.set_times(file_times);
+        }
+
+        restored.fetch_add(1, Ordering::Relaxed);
+    });
+
+    Ok((
+        restored.into_inner(),
+        skipped.into_inner(),
+        errors.into_inner(),
+    ))
 }
 
 async fn cmd_session_start(

--- a/crates/zccache-watcher/Cargo.toml
+++ b/crates/zccache-watcher/Cargo.toml
@@ -25,10 +25,16 @@ zccache-fscache = { workspace = true }
 pyo3 = { version = "0.23", features = ["extension-module", "generate-import-lib", "abi3-py310"], optional = true }
 jwalk = { workspace = true }
 globset = "0.4"
+rayon = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
 zccache-hash = { workspace = true }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "scan_metadata"
+harness = false
 
 [build-dependencies]
 pyo3-build-config = "0.23"

--- a/crates/zccache-watcher/benches/README.md
+++ b/crates/zccache-watcher/benches/README.md
@@ -1,0 +1,20 @@
+# zccache-watcher benches
+
+Criterion micro-benchmark for the polling watcher's cold-scan metadata fetch.
+
+| Bench | Measures |
+|---|---|
+| `scan_metadata` | Per-file `path.metadata()` over N pre-discovered paths, serial vs `rayon::par_iter` |
+
+Run:
+
+```bash
+soldr cargo bench -p zccache-watcher --bench scan_metadata
+```
+
+Each metadata syscall is independent. On Windows the per-stat cost is
+dominated by Defender / antivirus interception (5–20 µs each), so this
+is the dominant cost in `polling_watcher::scan_snapshot` on cold start
+for repos with thousands of tracked files.
+
+Counts: 100 / 1000 / 5000 — covers tiny / typical / large repos.

--- a/crates/zccache-watcher/benches/scan_metadata.rs
+++ b/crates/zccache-watcher/benches/scan_metadata.rs
@@ -1,0 +1,103 @@
+//! Micro-benchmark for the watcher cold-scan metadata-fetch step.
+//!
+//! `scan_snapshot` in `polling_watcher.rs` walks the tracked tree and
+//! calls `path.metadata()` per file. On Windows the per-stat cost is
+//! dominated by Defender / antivirus interception (5–20 µs each), so a
+//! 10k-file repo can spend 50–200 ms in this step alone on cold start.
+//!
+//! This bench measures the syscall pattern only (not the jwalk
+//! traversal): given N pre-discovered file paths, time
+//! `paths.iter().map(metadata)` versus `paths.par_iter().map(metadata)`.
+//!
+//! Counts: 100, 1000, 5000 — covers tiny / typical / large repos.
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rayon::prelude::*;
+
+const COUNTS: &[usize] = &[100, 1000, 5000];
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    paths: Vec<PathBuf>,
+}
+
+impl Fixture {
+    fn new(n: usize) -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut paths = Vec::with_capacity(n);
+        // Spread the files across nested subdirectories so the bench
+        // exercises a realistic directory layout (cold-cache stat behavior
+        // can differ on the same vs. different directories on NTFS).
+        for i in 0..n {
+            let sub = tmp.path().join(format!("d{:02}", i % 32));
+            std::fs::create_dir_all(&sub).unwrap();
+            let p = sub.join(format!("f_{i:05}.rs"));
+            std::fs::write(&p, b"// content\n").unwrap();
+            paths.push(p);
+        }
+        Self { _tmp: tmp, paths }
+    }
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct FileState {
+    mtime_ns: u128,
+    size: u64,
+}
+
+fn stat_one(path: &std::path::Path) -> Option<FileState> {
+    let m = path.metadata().ok()?;
+    Some(FileState {
+        mtime_ns: m
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map_or(0, |d| d.as_nanos()),
+        size: m.len(),
+    })
+}
+
+fn stat_serial(fx: &Fixture) -> Vec<FileState> {
+    fx.paths.iter().filter_map(|p| stat_one(p)).collect()
+}
+
+fn stat_parallel(fx: &Fixture) -> Vec<FileState> {
+    fx.paths.par_iter().filter_map(|p| stat_one(p)).collect()
+}
+
+fn bench_scan_metadata(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scan_metadata");
+    // 5000-file warm-up is slow; tighten sample budget so the bench
+    // completes in reasonable time on CI hosts.
+    group.sample_size(20);
+
+    for &n in COUNTS {
+        let fx = Fixture::new(n);
+        // Warm the OS cache once so the comparison isn't dominated by
+        // cold-cache noise — that's a separate experiment that doesn't
+        // discriminate the parallel speedup at all.
+        let _warm: Vec<_> = fx.paths.iter().filter_map(|p| p.metadata().ok()).collect();
+        let _ = SystemTime::now(); // suppress unused import on some hosts
+
+        group.bench_with_input(BenchmarkId::new("serial", n), &n, |b, _| {
+            b.iter(|| {
+                let v = stat_serial(black_box(&fx));
+                black_box(v);
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("parallel", n), &n, |b, _| {
+            b.iter(|| {
+                let v = stat_parallel(black_box(&fx));
+                black_box(v);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_scan_metadata);
+criterion_main!(benches);

--- a/crates/zccache-watcher/src/polling_watcher.rs
+++ b/crates/zccache-watcher/src/polling_watcher.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -486,6 +486,8 @@ fn has_glob_meta(pattern: &str) -> bool {
 }
 
 fn scan_snapshot(config: &ScanConfig) -> HashMap<NormalizedPath, FileState> {
+    use rayon::prelude::*;
+
     let mut result = HashMap::new();
 
     for base in &config.include_folders {
@@ -519,17 +521,35 @@ fn scan_snapshot(config: &ScanConfig) -> HashMap<NormalizedPath, FileState> {
                 });
             });
 
-        for entry in walker.into_iter().flatten() {
-            if !entry.file_type.is_file() {
-                continue;
-            }
-            let path = entry.path();
-            let rel = rel_string(&config.root, &path);
-            if config.exclude_globs.is_match(&rel) || !config.include_globs.is_match(&rel) {
-                continue;
-            }
-            if let Ok(metadata) = path.metadata() {
-                result.insert(
+        // Step 1: collect the candidate file paths from the (already-parallel)
+        // jwalk traversal. Applying the include/exclude globs here is cheap
+        // (string match) and avoids an extra `metadata()` syscall for files
+        // we'd just drop.
+        let candidates: Vec<PathBuf> = walker
+            .into_iter()
+            .flatten()
+            .filter_map(|entry| {
+                if !entry.file_type.is_file() {
+                    return None;
+                }
+                let path = entry.path();
+                let rel = rel_string(&config.root, &path);
+                if config.exclude_globs.is_match(&rel) || !config.include_globs.is_match(&rel) {
+                    return None;
+                }
+                Some(path)
+            })
+            .collect();
+
+        // Step 2: fetch metadata in parallel. Each `metadata()` is an
+        // independent syscall — on Windows this is the dominant cost
+        // (Defender intercepts every stat). Skip files whose metadata
+        // can't be read (deleted between walk and stat).
+        let pairs: Vec<(NormalizedPath, FileState)> = candidates
+            .par_iter()
+            .filter_map(|path| {
+                let metadata = path.metadata().ok()?;
+                Some((
                     NormalizedPath::new(path),
                     FileState {
                         mtime_ns: metadata
@@ -539,9 +559,11 @@ fn scan_snapshot(config: &ScanConfig) -> HashMap<NormalizedPath, FileState> {
                             .map_or(0, |duration| duration.as_nanos()),
                         size: metadata.len(),
                     },
-                );
-            }
-        }
+                ))
+            })
+            .collect();
+
+        result.extend(pairs);
     }
 
     result


### PR DESCRIPTION
## Summary

Two more cold-path parallelization wins, following the pattern set by [#284](https://github.com/zackees/zccache/pull/284) and [#285](https://github.com/zackees/zccache/pull/285).

1. **Polling watcher cold-scan** — `polling_watcher::scan_snapshot` (`crates/zccache-watcher/src/polling_watcher.rs:488`) now collects jwalk entries into a `Vec`, then fetches metadata via `rayon::par_iter`. Each `path.metadata()` syscall is independent.

2. **`zccache warm` restore** — `restore_artifacts` (`crates/zccache-cli/src/main.rs:2027`) flattens the artifact → output-name nesting into one `Vec<(src, dst, name)>`, then runs the per-file work (`remove_file` + `hard_link`/`copy` + `open` + `set_times`) via `rayon::par_iter`. `AtomicU64` counters preserve the restored/skipped/errors accounting.

## Why these are big wins on Windows specifically

Every per-file syscall on Windows hits Defender / AMSI interception (5–30 µs each). Running them serially serializes the interception cost; running N in parallel amortizes it across cores while one thread is blocked in the kernel filter. The watcher bench shows this dramatically — **5.31x at N=5000** — because the cost is essentially all in the filter, with no NTFS directory lock contention to worry about (pure read-only stat).

## Bench results (criterion, Windows / NTFS, 8 cores, Defender active)

### `scan_metadata` — watcher cold-scan
| N | serial | parallel | speedup |
|---|---|---|---|
| 100 | 1.97 ms | 627 µs | **3.14x** |
| 1000 | 23.09 ms | 4.91 ms | **4.71x** |
| 5000 | 141.64 ms | 26.67 ms | **5.31x** |

### `warm_restore` — CI cache restore (remove + hardlink + open + set_times)
| N | serial | parallel | speedup |
|---|---|---|---|
| 100 | 50.15 ms | 37.14 ms | 1.35x |
| 1000 | 484.09 ms | 270.66 ms | **1.79x** |
| 5000 | 2.36 s | 1.38 s | **1.71x** (saves ~1 s) |

The warm-restore speedup is more modest because each entry does directory-metadata writes (`remove_file`, `hard_link`) that NTFS partially serializes on the destination directory lock — but the saved wall-clock is still ~1 s on a 5 k-output restore, visible in CI.

## Files changed

- `crates/zccache-watcher/src/polling_watcher.rs` — `scan_snapshot` rewrite (split walk → collect → parallel stat)
- `crates/zccache-watcher/Cargo.toml` — add `rayon` workspace dep + register `scan_metadata` bench
- `crates/zccache-watcher/benches/{scan_metadata.rs,README.md}` (new)
- `crates/zccache-cli/src/main.rs` — `restore_artifacts` rewrite (flatten → par_iter, AtomicU64 counters)
- `crates/zccache-cli/Cargo.toml` — register `warm_restore` bench
- `crates/zccache-cli/benches/{warm_restore.rs,README.md}` (new)
- `Cargo.lock` — criterion dev-deps

## Test plan

- [x] `soldr cargo check -p zccache-watcher -p zccache-cli --all-targets` — clean
- [x] `soldr cargo clippy -p zccache-watcher -p zccache-cli --all-targets -- -D warnings` — clean
- [x] `soldr cargo fmt --all -- --check` — clean
- [x] `soldr cargo test -p zccache-watcher --lib` — 59/59 pass
- [ ] CI to run full test suite on Linux/macOS/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)