### PR TITLE
chore: bump version 1.6.0 -> 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "libc",
  "md5",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "blake3",
  "clap",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "clang",
  "tempfile",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "bincode",
  "clap",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3456,7 +3456,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "clap",
  "serde",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3493,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "clap",
  "dashmap",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "clap",
  "criterion",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "bytes",
  "serde",
@@ -3598,7 +3598,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "criterion",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["dylints/ban_std_pathbuf", "dylints/ban_unrooted_tempdir"]
 
 [workspace.package]
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Minor bump for the changes shipped since 1.6.0.

### Features
- feat(symbols): cache downloads under \`~/.zccache/symbols/\` + dylint guard (#288)
- feat(journal): extend \`JournalEntry\` with optional profile-mode fields (#271)

### Performance
- perf(io): parallelize cache-hit writes, link reads, and header scan (#284)
- perf(daemon): parallelize \`persist_artifact_payloads\` (#285)
- perf(io): parallelize watcher cold-scan and \`zccache warm\` restore (#287)

### Fixes
- fix(cli): use \`PROC_THREAD_ATTRIBUTE_HANDLE_LIST\` to spawn the daemon (#289/#291)
- fix(artifact): migrate \`ArtifactStore::path\` to \`NormalizedPath\` (#290)

### Notes
- All workspace crates inherit \`version.workspace = true\` from root \`Cargo.toml\`, so this single edit bumps all 16 crates simultaneously.
- The release flow (\`.github/workflows/release.yml\`) will pick up the new version on the next tag push (\`1.7.0\` or \`v1.7.0\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)