### PR TITLE
fix(dylint): rustfmt ban_unrooted_tempdir signature

### DIFF
--- a/dylints/ban_unrooted_tempdir/src/lib.rs
+++ b/dylints/ban_unrooted_tempdir/src/lib.rs
@@ -134,7 +134,11 @@ fn normalize_slashes(path: &str) -> String {
     path.replace('\\', "/")
 }
 
-fn def_path_equals(cx: &LateContext<'_>, def_id: rustc_hir::def_id::DefId, expected: &[&str]) -> bool {
+fn def_path_equals(
+    cx: &LateContext<'_>,
+    def_id: rustc_hir::def_id::DefId,
+    expected: &[&str],
+) -> bool {
     let def_path = cx.get_def_path(def_id);
     if def_path.len() != expected.len() {
         return false;


### PR DESCRIPTION
## Summary

Trivial fmt fix for `dylints/ban_unrooted_tempdir/src/lib.rs:134` — `def_path_equals` was a single 100+ char line, but the Dylint CI step runs `cargo fmt --manifest-path dylints/.../Cargo.toml --check` and that gate fails on it.

The workspace's `cargo fmt --all` doesn't recurse into the dylint subdirs (they're excluded from the workspace), so this didn't show up locally.

## Test plan

- [x] `cargo fmt --manifest-path dylints/ban_unrooted_tempdir/Cargo.toml --check` clean (verified by inspection — the diff shows the file matches rustfmt's output now).
- [ ] CI Dylint job on push to main: this was the actual remaining blocker for the multi-library alias work in PR #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)