### PR TITLE
fix(watcher): drop transient PathBuf in polling scan

### DIFF
--- a/crates/zccache-watcher/src/polling_watcher.rs
+++ b/crates/zccache-watcher/src/polling_watcher.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -524,8 +524,10 @@ fn scan_snapshot(config: &ScanConfig) -> HashMap<NormalizedPath, FileState> {
         // Step 1: collect the candidate file paths from the (already-parallel)
         // jwalk traversal. Applying the include/exclude globs here is cheap
         // (string match) and avoids an extra `metadata()` syscall for files
-        // we'd just drop.
-        let candidates: Vec<PathBuf> = walker
+        // we'd just drop. Normalize at collection time so step 2's parallel
+        // metadata fetch already operates on the watcher's canonical key
+        // type.
+        let candidates: Vec<NormalizedPath> = walker
             .into_iter()
             .flatten()
             .filter_map(|entry| {
@@ -537,7 +539,7 @@ fn scan_snapshot(config: &ScanConfig) -> HashMap<NormalizedPath, FileState> {
                 if config.exclude_globs.is_match(&rel) || !config.include_globs.is_match(&rel) {
                     return None;
                 }
-                Some(path)
+                Some(NormalizedPath::new(&path))
             })
             .collect();
 
@@ -550,7 +552,7 @@ fn scan_snapshot(config: &ScanConfig) -> HashMap<NormalizedPath, FileState> {
             .filter_map(|path| {
                 let metadata = path.metadata().ok()?;
                 Some((
-                    NormalizedPath::new(path),
+                    path.clone(),
                     FileState {
                         mtime_ns: metadata
                             .modified()


### PR DESCRIPTION
## Summary

Next `ban_std_pathbuf` violation surfacing after #290 cleared the way. `crates/zccache-watcher/src/polling_watcher.rs:528` collected a transient `Vec<PathBuf>` between the jwalk traversal and the parallel `metadata()` fetch, even though every downstream consumer immediately converted to `NormalizedPath`. Collect directly into `Vec<NormalizedPath>`:

- Step 1 (filter): `Some(NormalizedPath::new(&path))` — same allocation the old code did one step later.
- Step 2 (metadata): `path.metadata()` works via `Deref<Target = Path>` on `NormalizedPath`; the pair clone replaces the old `NormalizedPath::new(path)`.

No behavior change, one less type in the pipeline, and one fewer raw `PathBuf` outside the allowlist.

## Test plan

- [x] `cargo test -p zccache-watcher --lib` — 59/59 pass.
- [x] `cargo clippy -p zccache-watcher --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all --check` clean.
- [ ] Dylint CI on push to main: this is the next `PathBuf` outside the allowlist that the lint was already running and complaining about after the alias-loop fix in #293 / #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)