### PR TITLE
fix(ci): force-kill orphan zccache-daemon before upload-artifact (#299)

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -328,3 +328,36 @@ runs:
         # fail the job. The bounded poll inside `zccache stop` is the real
         # safeguard.
         zccache stop || true
+
+        # Defense-in-depth force-kill for orphan zccache-daemon processes.
+        #
+        # setup-soldr ships a managed zccache binary built from an older
+        # zccache release (pre-#291). That older daemon's spawn path went
+        # through std::process::Command which inherits the parent's
+        # inheritable handles — including a Python pipe write-end leaked
+        # down the soldr -> cargo -> rustc chain. Result: the
+        # setup-soldr-spawned daemon can survive a graceful `zccache stop`
+        # (the new daemon respawns on a connection attempt, or a child
+        # process is holding the IPC handle), and on Windows it then
+        # randomly locks files in the build's staging dir long enough to
+        # break `actions/upload-artifact@v7` with a silent failure (only
+        # "Root directory input is valid!" then nothing — see release-auto
+        # run 26094070914 / job 76727133236).
+        #
+        # The taskkill/pkill below force-kills any straggler so the
+        # composite ends with zero zccache-daemon processes, removing the
+        # upload-artifact flake source. Both commands tolerate "process
+        # not found" (the common case once `zccache stop` worked).
+        #
+        # Tracking removal: zccache#299. Once setup-soldr bumps its
+        # managed zccache to >= 1.7.0 (which has the
+        # PROC_THREAD_ATTRIBUTE_HANDLE_LIST fix from #291), this block
+        # becomes redundant and should be deleted.
+        case "$RUNNER_OS" in
+          Windows)
+            taskkill //F //IM zccache-daemon.exe //T 2>/dev/null || true
+            ;;
+          Linux|macOS)
+            pkill -KILL -x zccache-daemon 2>/dev/null || true
+            ;;
+        esac


### PR DESCRIPTION
Fixes the upload-artifact silent-failure on Windows x86_64 release builds. Tracking-issue + revert plan: #299.

## The failure

Release-auto run for 1.7.0 (`gh run view 26094070914`) failed on \`Build (x86_64-pc-windows-msvc)\` at the \`actions/upload-artifact@v7\` step with the classic silent-failure signature:

\`\`\`
With the provided path, there will be 6 files uploaded
Artifact name is valid!
Root directory input is valid!
<step ends, conclusion=failure, no further log output>
\`\`\`

Build itself succeeded — the binaries existed in the staging dir. aarch64-pc-windows-msvc, also Windows, succeeded against the same workflow with the same matrix entries.

## Root cause

Both Windows shards have an orphan \`zccache-daemon\` process surviving past the build-target composite's graceful \`zccache stop\`. End-of-job cleanup confirms it both times:

\`\`\`
aarch64 (PASS): Terminate orphan process: pid (7580) (zccache-daemon.509886872)
x86_64  (FAIL): Terminate orphan process: pid (1504) (zccache-daemon.108178804)
\`\`\`

The orphan is a setup-soldr-managed zccache daemon, currently built from a release that predates #291. That older daemon's \`spawn_daemon\` path uses \`std::process::Command\`, which calls \`CreateProcessW(bInheritHandles=TRUE)\` — and inherits the parent's pipe handles down the soldr → cargo → rustc chain. Exactly the bug documented in #289.

The daemon survives \`zccache stop\` (a new daemon respawns on a connection attempt, or a child process still holds the IPC handle). On Windows it can intermittently lock a file in the staging dir long enough to break \`actions/upload-artifact@v7\` — non-deterministically, hence the asymmetry between aarch64 (lucky) and x86_64 (unlucky) on the same run.

## The patch

After the existing graceful \`zccache stop\`, force-kill any straggler:

\`\`\`yaml
case \"\$RUNNER_OS\" in
  Windows)     taskkill //F //IM zccache-daemon.exe //T 2>/dev/null || true ;;
  Linux|macOS) pkill -KILL -x zccache-daemon 2>/dev/null || true ;;
esac
\`\`\`

Both branches tolerate \"process not found\" (the common case once \`zccache stop\` worked), so this is a no-op when not needed. The composite now ends with zero \`zccache-daemon\` processes, removing the only known confound for the upload-artifact flake.

## Why this is temporary

The proper fix lives in setup-soldr: ship a daemon binary built from zccache >= 1.7.0, which includes the #291 \`PROC_THREAD_ATTRIBUTE_HANDLE_LIST\` change. Once that ships, the setup-soldr-managed daemon will no longer inherit orphan pipe handles, \`zccache stop\` will be sufficient on its own, and this taskkill belt becomes redundant. #299 tracks the cleanup.

## Test plan

- [x] YAML parses (`pyyaml` round-trip)
- [ ] CI to validate the action's existing matrix
- [ ] Once merged, re-run release-auto for 1.7.0 (or trigger via tag push) and verify the Windows x86_64 build's upload-artifact step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)