### PR TITLE
fix(dylint): migrate zccache-ci home_dir + allowlist legacy clap surface

### DIFF
--- a/crates/zccache-ci/src/lib.rs
+++ b/crates/zccache-ci/src/lib.rs
@@ -29,9 +29,9 @@ use std::env;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
-use zccache_core::NormalizedPath;
 use std::process::{Child, Command};
 use std::time::{Duration, Instant};
+use zccache_core::NormalizedPath;
 
 use wait_timeout::ChildExt;
 

--- a/crates/zccache-ci/src/lib.rs
+++ b/crates/zccache-ci/src/lib.rs
@@ -28,7 +28,8 @@
 use std::env;
 use std::fs;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use zccache_core::NormalizedPath;
 use std::process::{Child, Command};
 use std::time::{Duration, Instant};
 
@@ -345,9 +346,9 @@ fn dump_relevant_processes() {
     }
 }
 
-fn home_dir() -> Option<PathBuf> {
+fn home_dir() -> Option<NormalizedPath> {
     let key = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
-    env::var_os(key).map(PathBuf::from)
+    env::var_os(key).map(|os| NormalizedPath::new(Path::new(&os)))
 }
 
 fn dump_daemon_lock() {

--- a/dylints/ban_std_pathbuf/src/allowlist.txt
+++ b/dylints/ban_std_pathbuf/src/allowlist.txt
@@ -4,3 +4,20 @@ crates/zccache-download-cli/src/main.rs
 crates/zccache-download-daemon/src/lib.rs
 crates/zccache-cli/src/lib.rs
 crates/zccache-cli/src/symbols.rs
+# The cli's `main.rs`, `python.rs`, and `snapshot_fp.rs` carry the legacy
+# clap surface plus the pyo3 bindings; migrating their `PathBuf` fields to
+# `NormalizedPath` interacts with clap's `value_parser`, pyo3's `IntoPy`
+# bounds, and the downstream cargo-fingerprint consumers that flow through
+# raw paths. Track migration separately so the lint can keep catching new
+# violations elsewhere.
+crates/zccache-cli/src/main.rs
+crates/zccache-cli/src/python.rs
+crates/zccache-cli/src/snapshot_fp.rs
+# Daemon server still spawns child processes and hands them raw PathBuf
+# command lines; migration depends on the IPC types adopting
+# NormalizedPath end-to-end.
+crates/zccache-daemon/src/server.rs
+# zccache-download holds the FetchRequest archive_path / destination
+# fields as PathBuf; the download daemon serializes those over the wire,
+# so the migration is a protocol-shaped change.
+crates/zccache-download/src/lib.rs


### PR DESCRIPTION
## Summary

Next batch of `ban_std_pathbuf` violations that surfaced once the multi-library alias loop in #295 / #297 actually got the lint running end-to-end.

### Migration

- `zccache-ci::home_dir()` returned `Option<PathBuf>`. Switched to `Option<NormalizedPath>` — all four callers chain `.join(...)` which `NormalizedPath` supports natively.

### Allowlist (with per-entry rationale)

- `zccache-cli/src/main.rs`, `python.rs`, `snapshot_fp.rs` — clap's `value_parser`, pyo3's `IntoPy` bounds, and the cargo-fingerprint downstream consumers all flow through raw `PathBuf` today. Migration is its own piece of work, tracked separately.
- `zccache-daemon/src/server.rs` — daemon hands child processes raw `PathBuf` command lines; migrating depends on the IPC types going first.
- `zccache-download/src/lib.rs` — `FetchRequest`'s `archive_path` / `destination` are wire-serialized, so the migration is a protocol-shaped change.

This unblocks the Dylint job without papering over the underlying lint policy — every new use outside the allowlist still fails.

## Test plan

- [x] `cargo check -p zccache-ci` clean after the `home_dir` migration.
- [x] `cargo clippy -p zccache-ci --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all --check` clean.
- [ ] Dylint CI on push to main: expect green this time. If another file surfaces, the per-file allowlist policy applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)