### PR TITLE
fix(dylint): allowlist zccache-core/src/config.rs for ban_std_pathbuf

### DIFF
--- a/dylints/ban_std_pathbuf/src/allowlist.txt
+++ b/dylints/ban_std_pathbuf/src/allowlist.txt
@@ -1,4 +1,9 @@
 crates/zccache-core/src/path.rs
+# `config::volume_root` constructs a path component-by-component (Prefix +
+# RootDir) which is exactly what `PathBuf::push` is for. NormalizedPath
+# doesn't expose mutation, so the assembly stays on raw PathBuf and the
+# result is wrapped into NormalizedPath at the boundary.
+crates/zccache-core/src/config.rs
 crates/zccache-download-client/src/artifact.rs
 crates/zccache-download-cli/src/main.rs
 crates/zccache-download-daemon/src/lib.rs


### PR DESCRIPTION
## Summary

`volume_root` (added by #298) constructs a path component-by-component using `PathBuf::push`. `NormalizedPath` is deliberately immutable, so the workspace pattern is to do the assembly on raw `PathBuf` and wrap at the boundary — which is what `colocated_cache_dir` in the same file already does for the result.

`crates/zccache-core/src/path.rs` is already on the allowlist for the same structural reason: it's where the path primitives live, so raw `PathBuf` *is* the working type there.

## Test plan

- [ ] Dylint CI on push to main: this should be the next blocker after #303 cleared the daemon's `ban_unrooted_tempdir` violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)