### PR TITLE
feat(ipc): opt-in per-recv timeout to bound client request/response

### DIFF
--- a/crates/zccache-cli/src/lib.rs
+++ b/crates/zccache-cli/src/lib.rs
@@ -333,14 +333,18 @@ enum VersionCheck {
 async fn connect_client(
     endpoint: &str,
 ) -> Result<zccache_ipc::IpcConnection, zccache_ipc::IpcError> {
-    zccache_ipc::connect(endpoint).await
+    let mut conn = zccache_ipc::connect(endpoint).await?;
+    conn.set_recv_timeout(zccache_ipc::DEFAULT_CLIENT_RECV_TIMEOUT);
+    Ok(conn)
 }
 
 #[cfg(windows)]
 async fn connect_client(
     endpoint: &str,
 ) -> Result<zccache_ipc::IpcClientConnection, zccache_ipc::IpcError> {
-    zccache_ipc::connect(endpoint).await
+    let mut conn = zccache_ipc::connect(endpoint).await?;
+    conn.set_recv_timeout(zccache_ipc::DEFAULT_CLIENT_RECV_TIMEOUT);
+    Ok(conn)
 }
 
 async fn check_daemon_version(endpoint: &str) -> VersionCheck {
@@ -787,6 +791,12 @@ pub fn client_session_end(
 /// permanently busy), and `BrokenPipe` (race: pipe vanished between
 /// open and use). Other errors (`TimedOut`, protocol mismatches, etc.)
 /// are NOT daemon-gone — they should still fail loudly.
+///
+/// `IpcError::Timeout` is explicitly **NOT** in the unreachable set. A
+/// timed-out recv means we connected successfully but the peer did not
+/// respond in the configured window — that's either a hung daemon (a
+/// real fault) or a per-call budget that was too tight (caller error).
+/// Either way: propagate, don't silently swallow.
 ///
 /// Used by `session_end_idempotent` (issue #159) and the CLI's
 /// `cmd_session_end` (issue #150 / #151) to map "the daemon already
@@ -1236,6 +1246,21 @@ mod tests {
     fn is_daemon_unreachable_recognizes_broken_pipe() {
         let err = zccache_ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::BrokenPipe));
         assert!(is_daemon_unreachable_err(&err));
+    }
+
+    /// `IpcError::Timeout` is explicitly NOT daemon-unreachable. A
+    /// timed-out recv means we connected successfully but the peer did
+    /// not respond — that's a hung-daemon fault, not a vanished daemon.
+    /// Soldr's at-exit `session_end` path classifies vanished-daemon as
+    /// a no-op; if `Timeout` were misclassified here, a stuck daemon
+    /// would be silently swallowed and the user would never see it.
+    #[test]
+    fn is_daemon_unreachable_timeout_is_not_unreachable() {
+        let err = zccache_ipc::IpcError::Timeout(std::time::Duration::from_secs(5));
+        assert!(
+            !is_daemon_unreachable_err(&err),
+            "Timeout must propagate as a real fault, not be swallowed as daemon-unreachable"
+        );
     }
 
     /// Mapping ENOENT through `from_raw_os_error` must yield the same

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -4501,16 +4501,29 @@ fn which_on_path(name: &str) -> Option<NormalizedPath> {
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
 /// Platform-correct connect (returns different types on Unix vs Windows).
+///
+/// All in-process IPC sites in `main.rs` route through this helper, so a
+/// single `set_recv_timeout` call here applies the 5-minute default to
+/// every CLI subcommand: Status, Shutdown, Clear, SessionStart,
+/// SessionStats, FingerprintCheck/Mark/Invalidate, and — critically —
+/// the Compile / CompileEphemeral / LinkEphemeral hot paths where the
+/// daemon does the actual rustc/clang invocation and only responds when
+/// done. The 300s budget accommodates the slowest legitimate unity / LTO
+/// workload while still bounding "alive but stuck" hangs.
 #[cfg(unix)]
 async fn connect(endpoint: &str) -> Result<zccache_ipc::IpcConnection, zccache_ipc::IpcError> {
-    zccache_ipc::connect(endpoint).await
+    let mut conn = zccache_ipc::connect(endpoint).await?;
+    conn.set_recv_timeout(zccache_ipc::DEFAULT_CLIENT_RECV_TIMEOUT);
+    Ok(conn)
 }
 
 #[cfg(windows)]
 async fn connect(
     endpoint: &str,
 ) -> Result<zccache_ipc::IpcClientConnection, zccache_ipc::IpcError> {
-    zccache_ipc::connect(endpoint).await
+    let mut conn = zccache_ipc::connect(endpoint).await?;
+    conn.set_recv_timeout(zccache_ipc::DEFAULT_CLIENT_RECV_TIMEOUT);
+    Ok(conn)
 }
 
 fn resolve_endpoint(explicit: Option<&str>) -> String {

--- a/crates/zccache-daemon/src/main.rs
+++ b/crates/zccache-daemon/src/main.rs
@@ -115,6 +115,9 @@ async fn query_daemon_status(
     endpoint: &str,
 ) -> Result<zccache_protocol::DaemonStatus, Box<dyn std::error::Error>> {
     let mut conn = zccache_ipc::connect(endpoint).await?;
+    // Client-style round trip: opt into the 5-minute default so a hung
+    // daemon surfaces as a Timeout rather than blocking forever.
+    conn.set_recv_timeout(zccache_ipc::DEFAULT_CLIENT_RECV_TIMEOUT);
     conn.send(&zccache_protocol::Request::Status).await?;
     let resp: Option<zccache_protocol::Response> = conn.recv().await?;
     match resp {

--- a/crates/zccache-ipc/src/error.rs
+++ b/crates/zccache-ipc/src/error.rs
@@ -14,4 +14,14 @@ pub enum IpcError {
 
     #[error("endpoint error: {0}")]
     Endpoint(String),
+
+    /// `recv` exceeded the configured timeout while waiting for a response.
+    ///
+    /// Distinct from peer-death (which surfaces as `Io` from the OS closing
+    /// the socket / pipe). A `Timeout` means we successfully connected, the
+    /// peer is presumably still alive, but it didn't respond in the allotted
+    /// time — caller should treat this as a real fault, not as
+    /// daemon-unreachable.
+    #[error("recv timed out after {0:?}")]
+    Timeout(std::time::Duration),
 }

--- a/crates/zccache-ipc/src/lib.rs
+++ b/crates/zccache-ipc/src/lib.rs
@@ -12,7 +12,9 @@ pub mod transport;
 pub use error::IpcError;
 #[cfg(windows)]
 pub use transport::IpcClientConnection;
-pub use transport::{connect, unique_test_endpoint, IpcConnection, IpcListener};
+pub use transport::{
+    connect, unique_test_endpoint, IpcConnection, IpcListener, DEFAULT_CLIENT_RECV_TIMEOUT,
+};
 
 use zccache_core::NormalizedPath;
 

--- a/crates/zccache-ipc/src/transport.rs
+++ b/crates/zccache-ipc/src/transport.rs
@@ -4,10 +4,36 @@
 //! and Unix domain sockets on Unix. Messages are length-prefixed
 //! bincode via `zccache-protocol`.
 
+use std::time::Duration;
+
 use bytes::BytesMut;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::error::IpcError;
+
+/// Suggested per-recv timeout for client-side request/response IPC.
+///
+/// Five minutes. Covers the slowest legitimate workload — unity / LTO
+/// builds where the daemon runs the compile inline and only responds when
+/// the linker finishes — while still bounding the rare "daemon alive but
+/// stuck" failure mode.
+///
+/// **This is an opt-in default; the IPC layer does not apply it on its
+/// own.** Callers that want timeout enforcement must call
+/// `set_recv_timeout(DEFAULT_CLIENT_RECV_TIMEOUT)` after connecting (or
+/// pass a per-call value to `recv_with_timeout`). Server-side and
+/// idle-style readers leave the field as `None` and keep the historical
+/// unbounded behavior. Peer death is OS-detected and surfaces as
+/// `IpcError::Io(_)` or `IpcError::ConnectionClosed` without involving
+/// this timeout.
+///
+/// Five minutes is intentionally generous. If a real workload exceeds it,
+/// switch that single call site to `recv_with_timeout` with a longer
+/// budget rather than bumping the const — the const is also the upper
+/// bound on hung-daemon detection latency for `ensure_daemon`'s
+/// auto-recovery path, and shortening it is the easier fix once the
+/// daemon side is fast enough.
+pub const DEFAULT_CLIENT_RECV_TIMEOUT: Duration = Duration::from_secs(300);
 
 // ── Platform-specific connection inner ──────────────────────────────
 
@@ -26,6 +52,10 @@ pub struct IpcConnection {
     reader: tokio::io::ReadHalf<StreamType>,
     writer: tokio::io::WriteHalf<StreamType>,
     read_buf: BytesMut,
+    /// Optional default timeout for `recv`. `None` means unbounded
+    /// (today's historical behavior, kept for server-side and other
+    /// idle-style readers). Set via `set_recv_timeout`.
+    recv_timeout: Option<Duration>,
 }
 
 /// Client-side IPC connection (Windows uses a different type).
@@ -34,6 +64,8 @@ pub struct IpcClientConnection {
     reader: tokio::io::ReadHalf<tokio::net::windows::named_pipe::NamedPipeClient>,
     writer: tokio::io::WriteHalf<tokio::net::windows::named_pipe::NamedPipeClient>,
     read_buf: BytesMut,
+    /// Optional default timeout for `recv`. See `IpcConnection::recv_timeout`.
+    recv_timeout: Option<Duration>,
 }
 
 // ── IpcConnection impl (server-side on Windows, both on Unix) ───────
@@ -47,10 +79,57 @@ impl IpcConnection {
         Ok(())
     }
 
+    /// Configure the default timeout applied to subsequent `recv` calls.
+    ///
+    /// Until called, `recv` is unbounded (today's behavior). After this
+    /// call, `recv` returns `Err(IpcError::Timeout(_))` if the next
+    /// message does not arrive within `timeout`. Use this once after
+    /// `connect()` on the client side to bound request/response round
+    /// trips. Server-side readers should leave it unset.
+    pub fn set_recv_timeout(&mut self, timeout: Duration) {
+        self.recv_timeout = Some(timeout);
+    }
+
+    /// Clear the default `recv` timeout, restoring unbounded behavior.
+    pub fn clear_recv_timeout(&mut self) {
+        self.recv_timeout = None;
+    }
+
+    /// Current default `recv` timeout. `None` means unbounded.
+    pub fn recv_timeout(&self) -> Option<Duration> {
+        self.recv_timeout
+    }
+
     /// Receive a deserializable message from the connection.
     ///
-    /// Returns `None` if the connection was closed cleanly.
+    /// Returns `None` if the connection was closed cleanly. If a default
+    /// timeout has been configured via [`Self::set_recv_timeout`] and the
+    /// next message does not arrive within that window, returns
+    /// `Err(IpcError::Timeout(_))`.
     pub async fn recv<T: serde::de::DeserializeOwned>(&mut self) -> Result<Option<T>, IpcError> {
+        match self.recv_timeout {
+            Some(t) => self.recv_with_timeout(t).await,
+            None => self.recv_loop().await,
+        }
+    }
+
+    /// Receive a deserializable message with a per-call timeout override.
+    ///
+    /// Independent of any default set via [`Self::set_recv_timeout`].
+    pub async fn recv_with_timeout<T: serde::de::DeserializeOwned>(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<Option<T>, IpcError> {
+        match tokio::time::timeout(timeout, self.recv_loop()).await {
+            Ok(result) => result,
+            Err(_) => Err(IpcError::Timeout(timeout)),
+        }
+    }
+
+    /// The recv read loop, factored out so both `recv` and
+    /// `recv_with_timeout` share the same implementation. Always
+    /// unbounded — the wrapping methods add the deadline.
+    async fn recv_loop<T: serde::de::DeserializeOwned>(&mut self) -> Result<Option<T>, IpcError> {
         loop {
             if let Some(msg) = zccache_protocol::decode_message::<T>(&mut self.read_buf)? {
                 return Ok(Some(msg));
@@ -80,10 +159,48 @@ impl IpcClientConnection {
         Ok(())
     }
 
+    /// See [`IpcConnection::set_recv_timeout`].
+    pub fn set_recv_timeout(&mut self, timeout: Duration) {
+        self.recv_timeout = Some(timeout);
+    }
+
+    /// See [`IpcConnection::clear_recv_timeout`].
+    pub fn clear_recv_timeout(&mut self) {
+        self.recv_timeout = None;
+    }
+
+    /// See [`IpcConnection::recv_timeout`].
+    pub fn recv_timeout(&self) -> Option<Duration> {
+        self.recv_timeout
+    }
+
     /// Receive a deserializable message from the connection.
     ///
-    /// Returns `None` if the connection was closed cleanly.
+    /// Returns `None` if the connection was closed cleanly. If a default
+    /// timeout has been configured via [`Self::set_recv_timeout`] and the
+    /// next message does not arrive within that window, returns
+    /// `Err(IpcError::Timeout(_))`.
     pub async fn recv<T: serde::de::DeserializeOwned>(&mut self) -> Result<Option<T>, IpcError> {
+        match self.recv_timeout {
+            Some(t) => self.recv_with_timeout(t).await,
+            None => self.recv_loop().await,
+        }
+    }
+
+    /// Receive a deserializable message with a per-call timeout override.
+    ///
+    /// Independent of any default set via [`Self::set_recv_timeout`].
+    pub async fn recv_with_timeout<T: serde::de::DeserializeOwned>(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<Option<T>, IpcError> {
+        match tokio::time::timeout(timeout, self.recv_loop()).await {
+            Ok(result) => result,
+            Err(_) => Err(IpcError::Timeout(timeout)),
+        }
+    }
+
+    async fn recv_loop<T: serde::de::DeserializeOwned>(&mut self) -> Result<Option<T>, IpcError> {
         loop {
             if let Some(msg) = zccache_protocol::decode_message::<T>(&mut self.read_buf)? {
                 return Ok(Some(msg));
@@ -177,6 +294,7 @@ impl IpcListener {
                 reader,
                 writer,
                 read_buf: BytesMut::with_capacity(4096),
+                recv_timeout: None,
             })
         }
         #[cfg(windows)]
@@ -202,6 +320,7 @@ impl IpcListener {
                 reader,
                 writer,
                 read_buf: BytesMut::with_capacity(4096),
+                recv_timeout: None,
             })
         }
     }
@@ -221,6 +340,7 @@ pub async fn connect(endpoint: &str) -> Result<IpcConnection, IpcError> {
         reader,
         writer,
         read_buf: BytesMut::with_capacity(4096),
+        recv_timeout: None,
     })
 }
 
@@ -274,6 +394,7 @@ pub async fn connect(endpoint: &str) -> Result<IpcClientConnection, IpcError> {
         reader,
         writer,
         read_buf: BytesMut::with_capacity(4096),
+        recv_timeout: None,
     })
 }
 

--- a/crates/zccache-ipc/tests/README.md
+++ b/crates/zccache-ipc/tests/README.md
@@ -1,0 +1,8 @@
+# `zccache-ipc` integration tests
+
+Each `.rs` file here compiles to its own test binary that exercises the
+public surface of `zccache-ipc`.
+
+- `timeout.rs` — `recv` timeout behavior: unbounded default, opt-in
+  `set_recv_timeout`, per-call `recv_with_timeout`, and the
+  peer-death-is-not-timeout invariant.

--- a/crates/zccache-ipc/tests/timeout.rs
+++ b/crates/zccache-ipc/tests/timeout.rs
@@ -1,0 +1,194 @@
+//! Integration tests for the per-recv timeout API on `IpcConnection` /
+//! `IpcClientConnection`. Validates four invariants:
+//!
+//! 1. The default is **unbounded** — preserves today's behavior for
+//!    callers that don't opt in (server-side `handle_connection`,
+//!    `zccache-download-client`).
+//! 2. `set_recv_timeout` is honored — once the caller opts in, a
+//!    `recv` that doesn't complete in time returns `Err(Timeout)`.
+//! 3. `recv_with_timeout` works independent of any stored default.
+//! 4. **Peer death surfaces as `Io` / `ConnectionClosed`, not
+//!    `Timeout`.** The OS closes the socket / pipe when a process dies;
+//!    the timeout is reserved for the rare "alive but stuck" failure
+//!    mode.
+
+use std::time::{Duration, Instant};
+
+use zccache_ipc::{connect, unique_test_endpoint, IpcError, IpcListener};
+use zccache_protocol::{Request, Response};
+
+/// Default-unbounded: no `set_recv_timeout` call → `recv` waits as long
+/// as needed. Listener delays 200ms before responding. With the new
+/// `Option<Duration> = None` default, the client should still complete
+/// successfully, matching today's behavior. This is the regression
+/// guard for server-side and download-client callers that share the
+/// IPC types and rely on unbounded reads.
+#[tokio::test]
+async fn recv_unbounded_by_default() {
+    let endpoint = unique_test_endpoint();
+    let mut listener = IpcListener::bind(&endpoint).unwrap();
+
+    let server = tokio::spawn(async move {
+        let mut conn = listener.accept().await.unwrap();
+        let msg: Option<Request> = conn.recv().await.unwrap();
+        assert_eq!(msg, Some(Request::Ping));
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        conn.send(&Response::Pong).await.unwrap();
+    });
+
+    let mut client = connect(&endpoint).await.unwrap();
+    assert!(
+        client.recv_timeout().is_none(),
+        "fresh connect must default to unbounded (None)"
+    );
+    client.send(&Request::Ping).await.unwrap();
+
+    let resp: Option<Response> = client.recv().await.unwrap();
+    assert_eq!(resp, Some(Response::Pong));
+    server.await.unwrap();
+}
+
+/// `set_recv_timeout` opt-in: listener accepts but never responds.
+/// Client opts into a 200ms deadline. `recv` returns `Err(Timeout(_))`
+/// within a generous 2s wall-clock budget.
+#[tokio::test]
+async fn recv_honors_set_recv_timeout() {
+    let endpoint = unique_test_endpoint();
+    let mut listener = IpcListener::bind(&endpoint).unwrap();
+
+    let server = tokio::spawn(async move {
+        let _conn = listener.accept().await.unwrap();
+        // Hold the connection alive without sending anything. Drop is
+        // delayed long enough that the client's timeout fires first.
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    let mut client = connect(&endpoint).await.unwrap();
+    client.set_recv_timeout(Duration::from_millis(200));
+    assert_eq!(client.recv_timeout(), Some(Duration::from_millis(200)));
+    client.send(&Request::Ping).await.unwrap();
+
+    let start = Instant::now();
+    let result: Result<Option<Response>, _> = client.recv().await;
+    let elapsed = start.elapsed();
+
+    match result {
+        Err(IpcError::Timeout(d)) => {
+            assert_eq!(
+                d,
+                Duration::from_millis(200),
+                "Timeout must carry the configured deadline"
+            );
+        }
+        other => panic!("expected Err(Timeout(200ms)), got {other:?}"),
+    }
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "recv timeout firing took {elapsed:?}; expected <2s"
+    );
+
+    drop(client);
+    server.await.unwrap();
+}
+
+/// Per-call override: `recv_with_timeout(t)` works even when no default
+/// was set via `set_recv_timeout`. Proves the override is independent
+/// of the stored field.
+#[tokio::test]
+async fn recv_with_timeout_works_without_default() {
+    let endpoint = unique_test_endpoint();
+    let mut listener = IpcListener::bind(&endpoint).unwrap();
+
+    let server = tokio::spawn(async move {
+        let _conn = listener.accept().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    let mut client = connect(&endpoint).await.unwrap();
+    assert!(
+        client.recv_timeout().is_none(),
+        "must start without default"
+    );
+    client.send(&Request::Ping).await.unwrap();
+
+    let start = Instant::now();
+    let result: Result<Option<Response>, _> =
+        client.recv_with_timeout(Duration::from_millis(200)).await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        matches!(result, Err(IpcError::Timeout(_))),
+        "expected Err(Timeout(_)), got {result:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "recv_with_timeout firing took {elapsed:?}; expected <2s"
+    );
+
+    drop(client);
+    server.await.unwrap();
+}
+
+/// Regression guard: a normal-latency response within the configured
+/// window must NOT trip the timeout. Without this guard, a tight-loop
+/// race where the timer fires between read syscalls could surface a
+/// spurious `Timeout` even when the peer responded in time.
+#[tokio::test]
+async fn recv_does_not_timeout_on_normal_response() {
+    let endpoint = unique_test_endpoint();
+    let mut listener = IpcListener::bind(&endpoint).unwrap();
+
+    let server = tokio::spawn(async move {
+        let mut conn = listener.accept().await.unwrap();
+        let msg: Option<Request> = conn.recv().await.unwrap();
+        assert_eq!(msg, Some(Request::Ping));
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        conn.send(&Response::Pong).await.unwrap();
+    });
+
+    let mut client = connect(&endpoint).await.unwrap();
+    client.set_recv_timeout(Duration::from_secs(1));
+    client.send(&Request::Ping).await.unwrap();
+
+    let resp: Option<Response> = client.recv().await.unwrap();
+    assert_eq!(resp, Some(Response::Pong));
+    server.await.unwrap();
+}
+
+/// Peer death is OS-detected: when the listener drops mid-recv, the
+/// kernel closes the socket / pipe. The client's recv surfaces this as
+/// `Ok(None)` (clean close) or `Err(Io(_))` / `Err(ConnectionClosed)` —
+/// **never** `Err(Timeout(_))`. Documents the invariant the user asked
+/// about: timeouts protect against "alive but stuck" only; death is the
+/// OS's job.
+#[tokio::test]
+async fn recv_reports_io_err_when_peer_dies() {
+    let endpoint = unique_test_endpoint();
+    let mut listener = IpcListener::bind(&endpoint).unwrap();
+
+    let server = tokio::spawn(async move {
+        // Accept then immediately drop the connection, simulating a
+        // peer that died mid-conversation.
+        let _conn = listener.accept().await.unwrap();
+    });
+
+    let mut client = connect(&endpoint).await.unwrap();
+    client.set_recv_timeout(Duration::from_secs(5));
+
+    // Give the server task time to drop its connection.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let result: Result<Option<Response>, _> = client.recv().await;
+    match result {
+        Ok(None) => {}                        // Clean close before timeout — acceptable.
+        Err(IpcError::Io(_)) => {}            // BrokenPipe / similar — acceptable.
+        Err(IpcError::ConnectionClosed) => {} // Mid-frame close — acceptable.
+        Err(IpcError::Timeout(_)) => panic!(
+            "peer-death must NOT surface as Timeout — that would mean we treated \
+             OS-level connection close as a stuck-but-alive failure"
+        ),
+        other => panic!("unexpected recv result: {other:?}"),
+    }
+
+    server.await.unwrap();
+}


### PR DESCRIPTION
## Summary

`IpcConnection::recv` and `IpcClientConnection::recv` were unbounded read loops. A client waiting on a hung daemon waited forever. This PR adds an opt-in per-recv timeout and wires every client-side IPC site (`zccache-cli` and the `zccache-daemon status` subcommand) to a 5-minute default.

- **Default:** `DEFAULT_CLIENT_RECV_TIMEOUT = 300s` — generous enough for unity / LTO builds where the daemon runs rustc / clang inline and responds only when done; tight enough to bound \"alive but stuck\" hangs.
- **API:** opt-in. The connection field is `Option<Duration>`; `None` means unbounded (today's behavior). `set_recv_timeout` opts in; `recv_with_timeout(t)` is a per-call override.
- **Peer death** is OS-detected (`Io` / `ConnectionClosed`) — the timeout is reserved for the rare alive-but-stuck case. Locked by a regression test.

## Behavior unchanged

- **Server-side `handle_connection` recv** stays unbounded for idle-style reads between requests. The default is `None`; the server-side accept path never opts in.
- **`zccache-download-client`** keeps unbounded recv. Default is `None`, so behavior is byte-identical to today.
- Test \`recv_unbounded_by_default\` regression-locks both above.

## Files modified

| File | Change |
|---|---|
| \`zccache-ipc/src/error.rs\` | New \`IpcError::Timeout(Duration)\` variant |
| \`zccache-ipc/src/transport.rs\` | Const, fields, accessors, recv wrapping, \`recv_with_timeout\`, factored \`recv_loop\` helper |
| \`zccache-ipc/src/lib.rs\` | Re-export \`DEFAULT_CLIENT_RECV_TIMEOUT\` |
| \`zccache-ipc/tests/timeout.rs\` | 5 new integration tests |
| \`zccache-cli/src/lib.rs\` | \`connect_client()\` opts in; doc comment update; new unit test |
| \`zccache-cli/src/main.rs\` | The single \`connect()\` helper opts in — covers every CLI subcommand including Compile / CompileEphemeral / LinkEphemeral |
| \`zccache-daemon/src/main.rs\` | \`query_daemon_status\` opts in |

## Test plan

- [x] \`cargo check --workspace --all-targets\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps\` clean
- [x] \`cargo test --workspace --lib\` green
- [x] \`cargo test -p zccache-ipc\` — 9 lib + 5 new integration + 0 doctests, all green
- [ ] CI: Linux, macOS, Windows

## Why a Timeout is not classified as daemon-unreachable

\`is_daemon_unreachable_err\` (zccache-cli/src/lib.rs:786) classifies connect-time errors that mean \"the daemon process is entirely gone.\" \`Timeout\` is **excluded** — a timed-out recv means we connected successfully but the peer didn't respond. That's either a hung daemon (a real fault) or a per-call budget that was too tight. Either way we propagate, never silently swallow it. New unit test \`is_daemon_unreachable_timeout_is_not_unreachable\` locks this contract.

## Note: pre-existing clippy errors

Local \`cargo clippy --workspace --all-targets -- -D warnings\` flags 4 errors that exist on \`main\` independently of this PR (verified by stashing the branch's diff and re-running). CI on main is currently green despite them — clippy version drift between local and CI. The companion PR (spawn-daemon hardening) clears them; this PR doesn't add new lint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)