### PR TITLE
chore: bump version 1.7.0 -> 1.7.1

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -124,6 +124,13 @@ runs:
         soldr cargo build --release --target ${{ inputs.target }} -p zccache-daemon
         soldr cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint
 
+        # Stop the zccache daemon inline before this step exits. Without
+        # this, the daemon can hold file handles in target/ that break
+        # downstream staging / packaging — on Windows specifically this
+        # blocks actions/upload-artifact (#299). Matches the pattern used
+        # in ci-check.yml's Test step.
+        zccache stop 2>/dev/null || true
+
     # Windows DLL load smoke gate (see zccache#269). If the just-built
     # `zccache.exe` cannot complete loader init on this host, `--version`
     # exits non-zero before any Rust code runs and the release stops here
@@ -163,6 +170,10 @@ runs:
         soldr cargo build --release --target ${{ inputs.target }} -p zccache-cli --features python --lib
         soldr cargo build --release --target ${{ inputs.target }} -p zccache-watcher --features python --lib
         soldr cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint --features python --lib
+
+        # Stop the zccache daemon inline before this step exits — same
+        # rationale as the prior "Build release binaries" step.
+        zccache stop 2>/dev/null || true
 
     - name: Stage artifacts
       shell: bash

--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: ""
   cache_key:
-    description: Cache key suffix for setup-soldr caches.
+    description: Cache key suffix passed to Swatinem/rust-cache as shared-key.
     required: true
   include_python:
     description: Build and stage Python extension artifacts.
@@ -56,17 +56,16 @@ runs:
       with:
         python-version: ${{ inputs.python_version }}
 
-    - name: Setup Soldr
-      uses: zackees/setup-soldr@v0
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
       with:
-        version: "0.7.18"
         toolchain: 1.94.1
-        cache: true
-        cache-key-suffix: ${{ inputs.cache_key }}
+        targets: ${{ inputs.target }}
 
-    - name: Ensure target stdlib is installed
-      shell: bash
-      run: rustup target add ${{ inputs.target }}
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: ${{ inputs.cache_key }}
 
     - name: Install musl tools
       if: inputs.target == 'x86_64-unknown-linux-musl'
@@ -120,16 +119,9 @@ runs:
         if [[ "${{ inputs.target }}" == *pc-windows-msvc ]]; then
           export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=+crt-static"
         fi
-        soldr cargo build --release --target ${{ inputs.target }} -p zccache-cli
-        soldr cargo build --release --target ${{ inputs.target }} -p zccache-daemon
-        soldr cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint
-
-        # Stop the zccache daemon inline before this step exits. Without
-        # this, the daemon can hold file handles in target/ that break
-        # downstream staging / packaging — on Windows specifically this
-        # blocks actions/upload-artifact (#299). Matches the pattern used
-        # in ci-check.yml's Test step.
-        zccache stop 2>/dev/null || true
+        cargo build --release --target ${{ inputs.target }} -p zccache-cli
+        cargo build --release --target ${{ inputs.target }} -p zccache-daemon
+        cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint
 
     # Windows DLL load smoke gate (see zccache#269). If the just-built
     # `zccache.exe` cannot complete loader init on this host, `--version`
@@ -160,20 +152,16 @@ runs:
       env:
         PYO3_PYTHON: python
       run: |
-        HOST_TARGET=$(soldr --no-cache rustc -vV | awk '/^host: / { print $2 }')
+        HOST_TARGET=$(rustc -vV | awk '/^host: / { print $2 }')
         if [ "$HOST_TARGET" != "${{ inputs.target }}" ]; then
           export PYO3_CROSS=1
           export PYO3_CROSS_PYTHON_VERSION="${{ inputs.python_version }}"
           export PYO3_CROSS_PYTHON_IMPLEMENTATION=CPython
         fi
 
-        soldr cargo build --release --target ${{ inputs.target }} -p zccache-cli --features python --lib
-        soldr cargo build --release --target ${{ inputs.target }} -p zccache-watcher --features python --lib
-        soldr cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint --features python --lib
-
-        # Stop the zccache daemon inline before this step exits — same
-        # rationale as the prior "Build release binaries" step.
-        zccache stop 2>/dev/null || true
+        cargo build --release --target ${{ inputs.target }} -p zccache-cli --features python --lib
+        cargo build --release --target ${{ inputs.target }} -p zccache-watcher --features python --lib
+        cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint --features python --lib
 
     - name: Stage artifacts
       shell: bash
@@ -325,50 +313,3 @@ runs:
           --debug-input-dir staging-debug \
           --output-dir standalone
 
-    # The setup-soldr post-step that runs after this composite finishes will
-    # tar `$SOLDR_CACHE_DIR/cache/zccache/` for the actions/cache save. On
-    # Windows that tar fails with EBUSY on `index.redb` if the zccache daemon
-    # is still alive holding the redb exclusive lock. `zccache stop` now waits
-    # until the IPC endpoint is gone and the redb file is openable. See #182
-    # and run https://github.com/zackees/zccache/actions/runs/25765121262/job/75675819635.
-    - name: Shutdown zccache daemon before cache save
-      if: always()
-      shell: bash
-      run: |
-        # `|| true` so a never-started daemon (e.g. cold cache hit) doesn't
-        # fail the job. The bounded poll inside `zccache stop` is the real
-        # safeguard.
-        zccache stop || true
-
-        # Defense-in-depth force-kill for orphan zccache-daemon processes.
-        #
-        # setup-soldr ships a managed zccache binary built from an older
-        # zccache release (pre-#291). That older daemon's spawn path went
-        # through std::process::Command which inherits the parent's
-        # inheritable handles — including a Python pipe write-end leaked
-        # down the soldr -> cargo -> rustc chain. Result: the
-        # setup-soldr-spawned daemon can survive a graceful `zccache stop`
-        # (the new daemon respawns on a connection attempt, or a child
-        # process is holding the IPC handle), and on Windows it then
-        # randomly locks files in the build's staging dir long enough to
-        # break `actions/upload-artifact@v7` with a silent failure (only
-        # "Root directory input is valid!" then nothing — see release-auto
-        # run 26094070914 / job 76727133236).
-        #
-        # The taskkill/pkill below force-kills any straggler so the
-        # composite ends with zero zccache-daemon processes, removing the
-        # upload-artifact flake source. Both commands tolerate "process
-        # not found" (the common case once `zccache stop` worked).
-        #
-        # Tracking removal: zccache#299. Once setup-soldr bumps its
-        # managed zccache to >= 1.7.0 (which has the
-        # PROC_THREAD_ATTRIBUTE_HANDLE_LIST fix from #291), this block
-        # becomes redundant and should be deleted.
-        case "$RUNNER_OS" in
-          Windows)
-            taskkill //F //IM zccache-daemon.exe //T 2>/dev/null || true
-            ;;
-          Linux|macOS)
-            pkill -KILL -x zccache-daemon 2>/dev/null || true
-            ;;
-        esac

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -23,7 +23,6 @@ jobs:
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: check-${{ inputs.os }}
-          enable: false
       - name: Check
         shell: bash
         run: |
@@ -45,7 +44,6 @@ jobs:
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: test-${{ inputs.os }}
-          enable: false
       # Platform Test runs unit tests in libraries and binaries only — it
       # intentionally does NOT compile the integration test binaries under
       # `crates/*/tests/`. Most of those binaries' tests are #[ignore]'d, but

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -68,15 +68,15 @@ jobs:
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
           fi
-          exit $status
 
-      # Stop the zccache daemon spawned during testing. Without this, the
-      # orphan daemon can hold open file handles in $TARGET that block the
-      # runner's post-job cleanup (and on Windows specifically prevented
-      # upload-artifact from packaging the target directory — see #299).
-      # `|| true` so a missing or already-stopped daemon never fails the
-      # job. `if: always()` so it runs after test failures too.
-      - name: Stop zccache daemon
-        if: always()
-        shell: bash
-        run: zccache stop 2>/dev/null || true
+          # Stop the zccache daemon before the step exits. Without this,
+          # the orphan daemon can hold open file handles in target/ that
+          # block the runner's post-job cleanup — on Windows this
+          # specifically prevented upload-artifact from packaging the
+          # target directory (see #299). Inline (not a separate step) so
+          # the daemon is stopped within the same shell context as the
+          # test run, before the step terminates. `|| true` so a missing
+          # or already-stopped daemon never masks the test exit code.
+          zccache stop 2>/dev/null || true
+
+          exit $status

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,17 +17,17 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          version: "0.7.18"
           toolchain: 1.94.1
-          cache: false
-          cache-key-suffix: check-${{ inputs.os }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: check-${{ inputs.os }}
       - name: Check
         shell: bash
         run: |
           start=$SECONDS
-          soldr cargo check --workspace
+          cargo check --workspace
           status=$?
           dur=$((SECONDS - start))
           echo "- **${{ inputs.os }} / Check**: ${dur}s" >> "$GITHUB_STEP_SUMMARY"
@@ -38,12 +38,12 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          version: "0.7.18"
           toolchain: 1.94.1
-          cache: false
-          cache-key-suffix: test-${{ inputs.os }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: test-${{ inputs.os }}
       # Platform Test runs unit tests in libraries and binaries only — it
       # intentionally does NOT compile the integration test binaries under
       # `crates/*/tests/`. Most of those binaries' tests are #[ignore]'d, but
@@ -55,7 +55,7 @@ jobs:
         run: |
           set +e
           start=$SECONDS
-          soldr cargo test --workspace --lib --bins --no-fail-fast 2>&1 | tee test-output.txt
+          cargo test --workspace --lib --bins --no-fail-fast 2>&1 | tee test-output.txt
           status=${PIPESTATUS[0]}
           dur=$((SECONDS - start))
           echo "- **${{ inputs.os }} / Test**: ${dur}s" >> "$GITHUB_STEP_SUMMARY"
@@ -68,15 +68,5 @@ jobs:
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
           fi
-
-          # Stop the zccache daemon before the step exits. Without this,
-          # the orphan daemon can hold open file handles in target/ that
-          # block the runner's post-job cleanup — on Windows this
-          # specifically prevented upload-artifact from packaging the
-          # target directory (see #299). Inline (not a separate step) so
-          # the daemon is stopped within the same shell context as the
-          # test run, before the step terminates. `|| true` so a missing
-          # or already-stopped daemon never masks the test exit code.
-          zccache stop 2>/dev/null || true
 
           exit $status

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -69,3 +69,14 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
           exit $status
+
+      # Stop the zccache daemon spawned during testing. Without this, the
+      # orphan daemon can hold open file handles in $TARGET that block the
+      # runner's post-job cleanup (and on Windows specifically prevented
+      # upload-artifact from packaging the target directory — see #299).
+      # `|| true` so a missing or already-stopped daemon never fails the
+      # job. `if: always()` so it runs after test failures too.
+      - name: Stop zccache daemon
+        if: always()
+        shell: bash
+        run: zccache stop 2>/dev/null || true

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,47 +17,33 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: zackees/setup-soldr@v0
         with:
+          version: "0.7.18"
           toolchain: 1.94.1
-      - name: Setup zccache
-        uses: ./
-        with:
-          shared-key: check-${{ inputs.os }}
-          cache-target: "true"
-          # Opt into restore-key fallback so commits whose deps are unchanged
-          # reuse the previous run's target snapshot instead of cold-building.
-          # action.yml's primary key includes ${{ github.sha }}, so without
-          # this every commit cold-builds. See #190.
-          target-restore-fallback: "true"
+          cache: true
+          cache-key-suffix: check-${{ inputs.os }}
       - name: Check
         shell: bash
         run: |
           start=$SECONDS
-          cargo check --workspace
+          soldr cargo check --workspace
           status=$?
           dur=$((SECONDS - start))
           echo "- **${{ inputs.os }} / Check**: ${dur}s" >> "$GITHUB_STEP_SUMMARY"
           exit $status
-      - if: always()
-        uses: ./action/cleanup
 
   test:
     name: Test
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: zackees/setup-soldr@v0
         with:
+          version: "0.7.18"
           toolchain: 1.94.1
-      - name: Setup zccache
-        uses: ./
-        with:
-          shared-key: test-${{ inputs.os }}
-          cache-target: "true"
-          target-restore-fallback: "true"
+          cache: true
+          cache-key-suffix: test-${{ inputs.os }}
       # Platform Test runs unit tests in libraries and binaries only — it
       # intentionally does NOT compile the integration test binaries under
       # `crates/*/tests/`. Most of those binaries' tests are #[ignore]'d, but
@@ -69,7 +55,7 @@ jobs:
         run: |
           set +e
           start=$SECONDS
-          cargo test --workspace --lib --bins --no-fail-fast 2>&1 | tee test-output.txt
+          soldr cargo test --workspace --lib --bins --no-fail-fast 2>&1 | tee test-output.txt
           status=${PIPESTATUS[0]}
           dur=$((SECONDS - start))
           echo "- **${{ inputs.os }} / Test**: ${dur}s" >> "$GITHUB_STEP_SUMMARY"
@@ -83,5 +69,3 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
           exit $status
-      - if: always()
-        uses: ./action/cleanup

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -23,6 +23,7 @@ jobs:
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: check-${{ inputs.os }}
+          enable: false
       - name: Check
         shell: bash
         run: |
@@ -44,6 +45,7 @@ jobs:
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: test-${{ inputs.os }}
+          enable: false
       # Platform Test runs unit tests in libraries and binaries only — it
       # intentionally does NOT compile the integration test binaries under
       # `crates/*/tests/`. Most of those binaries' tests are #[ignore]'d, but

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           version: "0.7.18"
           toolchain: 1.94.1
-          cache: true
+          cache: false
           cache-key-suffix: check-${{ inputs.os }}
       - name: Check
         shell: bash
@@ -42,7 +42,7 @@ jobs:
         with:
           version: "0.7.18"
           toolchain: 1.94.1
-          cache: true
+          cache: false
           cache-key-suffix: test-${{ inputs.os }}
       # Platform Test runs unit tests in libraries and binaries only — it
       # intentionally does NOT compile the integration test binaries under

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bincode",
  "blake3",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "libc",
  "md5",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "blake3",
  "clap",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "clang",
  "tempfile",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "serde",
  "tempfile",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bincode",
  "clap",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "blake3",
  "criterion",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "blake3",
  "bytes",
@@ -3456,7 +3456,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "clap",
  "serde",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3493,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "clap",
  "dashmap",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bincode",
  "bytes",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "clap",
  "criterion",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "blake3",
  "criterion",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bytes",
  "serde",
@@ -3598,7 +3598,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bincode",
  "bytes",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "criterion",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["dylints/ban_std_pathbuf", "dylints/ban_unrooted_tempdir"]
 
 [workspace.package]
-version = "1.7.0"
+version = "1.7.1"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Patch release covering the IPC recv-timeout work (#306):

- Opt-in per-recv timeout on `IpcConnection` / `IpcClientConnection`
- Bounds client request/response round trips at 5 minutes by default
- Peer-death stays OS-detected; server-side and `zccache-download-client` recv behavior unchanged

## Test plan

- [x] `cargo check --workspace --all-targets` clean at 1.7.1
- [ ] CI: Linux, macOS, Windows
- [ ] Auto-release workflow picks up 1.7.1 tag once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)