### PR TITLE
chore: drop Stop hook from settings.json + gitignore settings.local.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,22 +34,6 @@
           }
         ]
       }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "soldr cargo fmt --all",
-            "timeout": 60
-          },
-          {
-            "type": "command",
-            "command": "soldr cargo run -p zccache-ci",
-            "timeout": 600
-          }
-        ]
-      }
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,11 @@ Thumbs.db
 .cache/
 
 # Claude Code runtime state (settings.json/rules/hooks ARE tracked,
-# but per-session locks/state files are not)
+# but per-session locks/state files and per-user local overrides are not)
 .claude/scheduled_tasks.lock
 .claude/scheduled_tasks/
 .claude/worktrees/
+.claude/settings.local.json
 
 # Project-local toolchain caches (managed by soldr)
 .cargo/


### PR DESCRIPTION
## Summary

Two small config-only changes that have been sitting dirty in the working tree for the entire session:

1. **Remove the Stop hook from `.claude/settings.json`.** It ran `cargo fmt` + `cargo run -p zccache-ci` after every assistant turn. On Windows that pops a console window per child for the duration of the run. The pops were intrusive enough that the hook was disabled locally via the gitignored `.claude/settings.local.json` override mechanism. Promote the disable to the shared config so the team-wide default matches what everyone is running.

2. **Add `.claude/settings.local.json` to `.gitignore`.** This is the intended per-user override sink — if a contributor wants the Stop hook re-enabled (or any other personal hook tweak) they create it locally and the new gitignore line keeps it out of git.

## Out of scope

- Hook discipline for Rust toolchain enforcement (`ci/hooks/tool_guard.py`) is untouched.
- No code changes. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)