### PR TITLE
fix(daemon): set CREATE_NO_WINDOW on every child the daemon spawns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,11 @@ members = [
     "crates/zccache-fingerprint",
     "crates/zccache-gha",
 ]
-exclude = ["dylints/ban_std_pathbuf", "dylints/ban_unrooted_tempdir"]
+exclude = [
+    "dylints/ban_std_pathbuf",
+    "dylints/ban_unrooted_tempdir",
+    "dylints/ban_raw_subprocess_in_daemon",
+]
 
 [workspace.package]
 version = "1.7.1"

--- a/crates/zccache-daemon/src/process.rs
+++ b/crates/zccache-daemon/src/process.rs
@@ -236,6 +236,32 @@ pub(crate) struct CompilePriorityParseError {
     value: String,
 }
 
+/// Windows process creation flags applied to daemon-spawned children.
+///
+/// Currently always returns `CREATE_NO_WINDOW` (`0x08000000`). When the
+/// daemon is launched detached (no console attached), spawning a
+/// console-subsystem child like rustc / cl / clang without this flag
+/// causes Windows to allocate a fresh console window for the child —
+/// a visible flash per cache-miss compile in the soldr + rustc +
+/// zccache call chain. Setting `CREATE_NO_WINDOW` suppresses that
+/// allocation; stdio already flows through the pipes the helpers
+/// attach, so no output is lost.
+///
+/// `priority` is a parameter so future priority bits (`IDLE_PRIORITY_CLASS`,
+/// `BELOW_NORMAL_PRIORITY_CLASS`, etc.) can be OR'd in directly at the
+/// `CreateProcessW` call rather than via the separate post-spawn
+/// `SetPriorityClass` we use today. Unused today — kept for API
+/// stability so the call sites don't change shape later.
+#[cfg(windows)]
+fn child_creation_flags(_priority: CompilePriority) -> u32 {
+    /// `CREATE_NO_WINDOW` from `windows_sys::Win32::System::Threading`.
+    /// Hardcoded here because the daemon doesn't otherwise pull in
+    /// `windows-sys` and a single u32 constant doesn't justify the dep.
+    /// Value verified against the Windows SDK header `winbase.h`.
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    CREATE_NO_WINDOW
+}
+
 /// Wait for a synchronous command after applying a compiler child priority.
 pub(crate) fn command_output_with_priority(
     cmd: &mut std::process::Command,
@@ -246,11 +272,13 @@ pub(crate) fn command_output_with_priority(
 
     #[cfg(windows)]
     {
+        use std::os::windows::process::CommandExt;
         use std::process::Stdio;
 
         cmd.stdin(Stdio::null());
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
+        cmd.creation_flags(child_creation_flags(priority));
         let child = cmd.spawn()?;
         assign_child_to_daemon_job(child.as_raw_handle());
         apply_priority_to_child_windows(child.as_raw_handle(), priority);
@@ -296,6 +324,7 @@ pub(crate) async fn tokio_command_output_with_priority(
         cmd.stdin(Stdio::null());
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
+        cmd.creation_flags(child_creation_flags(priority));
         let child = cmd.spawn()?;
         if let Some(handle) = child.raw_handle() {
             assign_child_to_daemon_job(handle);
@@ -682,5 +711,48 @@ mod tests {
             CompilePriority::High.windows_priority_class(),
             Some(HIGH_PRIORITY_CLASS)
         );
+    }
+
+    // ── Console-window suppression (Windows only) ───────────────────────
+    //
+    // When the daemon is launched detached (no console attached) and then
+    // spawns a console-subsystem child like rustc / cl / clang via
+    // `command_output_with_priority` or `tokio_command_output_with_priority`,
+    // Windows allocates a fresh console window for the child *unless* the
+    // creation flags include `CREATE_NO_WINDOW`. The console window flashes
+    // for the lifetime of the child — visible whenever cargo hits a cache
+    // miss and the daemon executes the compiler inline. Reported by the
+    // soldr + rustc + zccache workflow.
+    //
+    // The end-to-end behavior (child having no console window) is hard to
+    // test inside `cargo test` because the test runner's own stdio
+    // capture makes the test binary console-less, so a child spawned
+    // without `CREATE_NO_WINDOW` reads as console-less too — false green.
+    // Instead we unit-test the helper that *computes* the creation flags
+    // the spawn site applies. If that helper returns the right bits,
+    // `cmd.creation_flags(...)` puts them on the CreateProcessW call.
+
+    /// `child_creation_flags` must include `CREATE_NO_WINDOW` (`0x08000000`)
+    /// regardless of priority. Without that bit set, a detached daemon's
+    /// `command_output_with_priority` spawn allocates a console window per
+    /// child (the soldr + rustc cache-miss flash).
+    #[cfg(windows)]
+    #[test]
+    fn child_creation_flags_includes_create_no_window() {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        for priority in [
+            CompilePriority::Normal,
+            CompilePriority::Low,
+            CompilePriority::Idle,
+            CompilePriority::High,
+        ] {
+            let flags = child_creation_flags(priority);
+            assert_eq!(
+                flags & CREATE_NO_WINDOW,
+                CREATE_NO_WINDOW,
+                "child_creation_flags({priority:?}) = 0x{flags:08x} must set CREATE_NO_WINDOW (0x08000000) \
+                 to suppress the per-child console flash a detached daemon would otherwise produce"
+            );
+        }
     }
 }

--- a/dylints/ban_raw_subprocess_in_daemon/Cargo.toml
+++ b/dylints/ban_raw_subprocess_in_daemon/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ban_raw_subprocess_in_daemon"
+version = "0.1.0"
+description = "Ban raw std/tokio Command spawn/output/status in zccache-daemon production code"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# Match the dylint_linting pin used by the sibling dylints — same toolchain
+# (rust-toolchain.toml here), same upstream commit.
+dylint_linting = { git = "https://github.com/trailofbits/dylint", rev = "4bd91ce7729b74c7ee5664bbb588f7baf30b4a09" }
+
+[dev-dependencies]
+dylint_testing = { git = "https://github.com/trailofbits/dylint", rev = "4bd91ce7729b74c7ee5664bbb588f7baf30b4a09" }
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/dylints/ban_raw_subprocess_in_daemon/README.md
+++ b/dylints/ban_raw_subprocess_in_daemon/README.md
@@ -1,0 +1,52 @@
+# ban_raw_subprocess_in_daemon
+
+This lint forbids the daemon production code from spawning child processes
+via `std::process::Command::{spawn, output, status}` or
+`tokio::process::Command::{spawn, output, status}` directly. Every child
+process the daemon launches **must** go through the blessed helpers in
+`crates/zccache-daemon/src/process.rs`:
+
+| Use case          | Helper                                |
+| ----------------- | ------------------------------------- |
+| Synchronous spawn | `command_output_with_priority(cmd, p)` |
+| Async spawn       | `tokio_command_output_with_priority(cmd, p).await` |
+
+## Why
+
+The daemon is launched detached (no console attached). On Windows, a
+console-subsystem child spawned from a console-less parent without the
+`CREATE_NO_WINDOW` flag triggers the OS to allocate a fresh console
+window for the child — a visible flash per cache-miss compile in the
+`soldr → cargo → rustc → zccache-cli → daemon → rustc` call chain.
+
+The helpers in `process.rs` apply `CREATE_NO_WINDOW` (and consistent
+stdio piping, Job Object containment, child-priority adjustment). Bypassing
+them silently regresses one or more of those invariants. This lint catches
+the bypass at compile time.
+
+## Scope
+
+The lint fires only on source files under `crates/zccache-daemon/src/`.
+Other crates (cli, ci, fingerprint, …) are out of scope: the cli already
+has its own sanitized spawn (`spawn_daemon_windows::spawn_daemon_sanitized`)
+for the daemon-launching hop, and the other crates don't spawn compilers.
+
+## Allowlist
+
+`src/allowlist.txt` lists the daemon source files that are exempt:
+
+- `process.rs` — the blessed helpers themselves call `.spawn()` /
+  `.output()` internally; that's the entire point.
+- `server.rs`, `lineage.rs` — contain `#[cfg(test)]` modules with
+  `Command::new("chmod" / "echo").status()` / `.output()`. Test code
+  doesn't ship in the production binary so the console-flash bug
+  doesn't apply there. (A future improvement could detect `#[cfg(test)]`
+  scope programmatically and remove these entries.)
+
+## Adding a new spawn site
+
+If you genuinely need a new daemon-side spawn pattern that the existing
+helpers don't cover, **extend `process.rs`** with a new helper that
+applies the same defaults (`CREATE_NO_WINDOW`, piped stdio, Job Object
+attach, priority) and route the call site through it. Do not add the file
+to the allowlist.

--- a/dylints/ban_raw_subprocess_in_daemon/rust-toolchain.toml
+++ b/dylints/ban_raw_subprocess_in_daemon/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2026-03-26"
+components = ["llvm-tools-preview", "rust-src", "rustc-dev"]

--- a/dylints/ban_raw_subprocess_in_daemon/src/README.md
+++ b/dylints/ban_raw_subprocess_in_daemon/src/README.md
@@ -1,0 +1,15 @@
+# ban_raw_subprocess_in_daemon — sources
+
+- `lib.rs` — late-pass `LintContext` visitor that fires on `MethodCall`
+  expressions whose resolved DefId matches one of `BANNED_METHOD_PATHS`
+  (`Command::spawn`/`output`/`status` on both `std::process` and
+  `tokio::process`). Matching is exact — any other method on those types
+  (`wait_with_output`, `kill`, `try_wait`, …) is intentionally not banned.
+- `allowlist.txt` — newline-separated tail-suffix matches for source files
+  that pre-date the lint or legitimately need to call the banned APIs (the
+  blessed helpers themselves; in-source `#[cfg(test)]` modules). New
+  production code should NEVER be added here — route the spawn through
+  `crates/zccache-daemon/src/process.rs` helpers instead.
+
+See the parent directory's `README.md` for the user-facing rationale and
+the table of replacements.

--- a/dylints/ban_raw_subprocess_in_daemon/src/allowlist.txt
+++ b/dylints/ban_raw_subprocess_in_daemon/src/allowlist.txt
@@ -1,0 +1,26 @@
+# Each non-empty, non-comment line is matched against the tail of each
+# source file path (slashes normalized to /). The lint only fires on
+# files under `crates/zccache-daemon/src/`; anywhere else is out of
+# scope and does not need an entry here.
+#
+# Add an entry ONLY for files that legitimately need to bypass the
+# helpers in `crates/zccache-daemon/src/process.rs`. Include an inline
+# comment explaining why.
+
+# The blessed helpers themselves call `.spawn()` / `.output()` /
+# `wait_with_output()` internally — that's the entire point. This is
+# the only production file that should reference Command::spawn et al.
+crates/zccache-daemon/src/process.rs
+
+# server.rs has `#[cfg(test)]` modules that spawn `chmod` for fixture
+# setup (test-only, Unix-only — doesn't ship in the binary, doesn't hit
+# the Windows console-flash code path). Production spawn sites in this
+# file all route through `process::command_output_with_priority` and
+# `process::tokio_command_output_with_priority`, which don't trigger
+# the lint at all (the lint targets `cmd.spawn()` etc. — not the helper
+# call).
+crates/zccache-daemon/src/server.rs
+
+# lineage.rs has `#[cfg(test)]` modules that spawn `echo` to validate
+# env-var application. Test-only fixtures.
+crates/zccache-daemon/src/lineage.rs

--- a/dylints/ban_raw_subprocess_in_daemon/src/lib.rs
+++ b/dylints/ban_raw_subprocess_in_daemon/src/lib.rs
@@ -1,0 +1,178 @@
+#![feature(rustc_private)]
+
+extern crate rustc_errors;
+extern crate rustc_hir;
+extern crate rustc_span;
+
+use rustc_errors::DiagDecorator;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_span::{symbol::Symbol, FileName, RemapPathScopeComponents};
+
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// Bans method calls `Command::spawn`, `Command::output`, and
+    /// `Command::status` on `std::process::Command` and
+    /// `tokio::process::Command` in `zccache-daemon` production code.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// The daemon is launched detached (no console attached). On Windows
+    /// spawning a console-subsystem child from a console-less parent
+    /// without `CREATE_NO_WINDOW` causes the OS to allocate a fresh
+    /// console window for the child — a visible flash per cache-miss
+    /// compile in the `soldr -> cargo -> rustc -> zccache-cli -> daemon
+    /// -> rustc` chain.
+    ///
+    /// The blessed helpers in `crates/zccache-daemon/src/process.rs`
+    /// (`command_output_with_priority`, `tokio_command_output_with_priority`)
+    /// apply `CREATE_NO_WINDOW` along with consistent stdio piping, a
+    /// Job Object attach, and child-priority adjustment. Bypassing them
+    /// silently regresses one or more of those invariants.
+    ///
+    /// ### Known problems
+    ///
+    /// Test code inside `#[cfg(test)]` modules is exempted only at the
+    /// file level via `src/allowlist.txt`; the lint does not yet detect
+    /// `#[cfg(test)]` scope programmatically.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore
+    /// let mut cmd = std::process::Command::new("rustc");
+    /// cmd.args(["--version"]);
+    /// let output = cmd.output().unwrap();
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```rust,ignore
+    /// let mut cmd = std::process::Command::new("rustc");
+    /// cmd.args(["--version"]);
+    /// let output = crate::process::command_output_with_priority(
+    ///     &mut cmd,
+    ///     crate::process::CompilePriority::Normal,
+    /// )
+    /// .unwrap();
+    /// ```
+    pub BAN_RAW_SUBPROCESS_IN_DAEMON,
+    Deny,
+    "ban raw Command::{spawn, output, status} in zccache-daemon production code"
+}
+
+/// Each entry is a fully-qualified path to a banned method. Matching is
+/// exact. We deliberately list `std::process::Command::*` and
+/// `tokio::process::Command::*` separately — they are distinct types with
+/// distinct DefIds — and intentionally omit other methods on `Command`
+/// (e.g. `args`, `env`, `current_dir`) and on `Child` (e.g.
+/// `wait_with_output`, `kill`). The bug class is at *spawn time*; once
+/// you have a `Child`, `CREATE_NO_WINDOW` is already decided.
+const BANNED_METHOD_PATHS: &[&[&str]] = &[
+    &["std", "process", "Command", "spawn"],
+    &["std", "process", "Command", "output"],
+    &["std", "process", "Command", "status"],
+    &["tokio", "process", "Command", "spawn"],
+    &["tokio", "process", "Command", "output"],
+    &["tokio", "process", "Command", "status"],
+];
+
+const ALLOWLIST: &str = include_str!("allowlist.txt");
+
+/// Only daemon production code is in scope. Other crates have their own
+/// spawn discipline (cli has `spawn_daemon_windows::spawn_daemon_sanitized`;
+/// the ci/fingerprint crates don't spawn compilers).
+const DAEMON_SOURCE_PREFIX: &str = "crates/zccache-daemon/src/";
+
+impl<'tcx> LateLintPass<'tcx> for BanRawSubprocessInDaemon {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        let filename = source_filename(cx, expr.span);
+        let normalized = normalize_slashes(&filename);
+
+        // Out-of-scope file → never fires.
+        if !normalized.contains(DAEMON_SOURCE_PREFIX) {
+            return;
+        }
+
+        // Allowlisted file → exempt by configuration.
+        if is_allowlisted(&normalized) {
+            return;
+        }
+
+        // Method call on a `Command`? Resolve to the canonical DefId and
+        // compare to each banned path. `type_dependent_def_id` returns
+        // the DefId of the method actually resolved by the trait/inherent
+        // method resolver, so an alias or re-export still resolves to the
+        // canonical `std::process::Command::spawn` path.
+        if let ExprKind::MethodCall(_segment, _receiver, _args, _span) = expr.kind {
+            if let Some(def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id) {
+                for banned in BANNED_METHOD_PATHS {
+                    if def_path_equals(cx, def_id, banned) {
+                        emit_lint(cx, expr.span, banned);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn emit_lint(cx: &LateContext<'_>, span: rustc_span::Span, banned: &[&str]) {
+    let joined = banned.join("::");
+    cx.opt_span_lint(
+        BAN_RAW_SUBPROCESS_IN_DAEMON,
+        Some(span),
+        DiagDecorator(move |diag| {
+            diag.primary_message(format!(
+                "`{joined}` bypasses the daemon's spawn discipline; route through \
+                 `crate::process::command_output_with_priority` (sync) or \
+                 `crate::process::tokio_command_output_with_priority` (async) so \
+                 CREATE_NO_WINDOW, Job Object attach, and priority are applied"
+            ));
+        }),
+    );
+}
+
+fn source_filename(cx: &LateContext<'_>, span: rustc_span::Span) -> String {
+    match cx.sess().source_map().span_to_filename(span) {
+        FileName::Real(real_filename) => real_filename
+            .local_path()
+            .map(|path| path.to_string_lossy().into_owned())
+            .unwrap_or_else(|| {
+                real_filename
+                    .path(RemapPathScopeComponents::DIAGNOSTICS)
+                    .to_string_lossy()
+                    .into_owned()
+            }),
+        filename => filename
+            .display(RemapPathScopeComponents::DIAGNOSTICS)
+            .to_string(),
+    }
+}
+
+fn is_allowlisted(normalized: &str) -> bool {
+    ALLOWLIST
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .any(|allowed| normalized.ends_with(allowed))
+}
+
+fn normalize_slashes(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+fn def_path_equals(
+    cx: &LateContext<'_>,
+    def_id: rustc_hir::def_id::DefId,
+    expected: &[&str],
+) -> bool {
+    let def_path = cx.get_def_path(def_id);
+    if def_path.len() != expected.len() {
+        return false;
+    }
+    def_path
+        .iter()
+        .zip(expected.iter())
+        .all(|(actual, expected_segment)| *actual == Symbol::intern(expected_segment))
+}


### PR DESCRIPTION
## Summary

Fixes the console-window flash that appears for every cache-miss compile in the soldr + rustc + zccache call chain.

## Root cause

The daemon is launched detached (no console attached) by `zccache-cli::spawn_daemon`. When the daemon then spawns a console-subsystem child (rustc, cl, clang) via `std::process::Command::spawn` or `tokio::process::Command::spawn`, Windows allocates a fresh console window for the child unless the creation flags include \`CREATE_NO_WINDOW\` (\`0x08000000\`). None of the daemon spawn sites set that flag.

## Fix

- New \`child_creation_flags(priority) -> u32\` helper in \`process.rs\` that returns \`CREATE_NO_WINDOW\` today; \`priority\` is plumbed through for future direct-at-CreateProcessW priority bits.
- Both \`command_output_with_priority\` (sync) and \`tokio_command_output_with_priority\` (async) now call \`cmd.creation_flags(child_creation_flags(priority))\` before \`cmd.spawn()\`.

## Coverage

Every production daemon-side spawn that hits Windows console allocation flows through one of these two helpers. The other \`Command::new(...)\` references in the daemon are either:
- inside \`#[test]\` blocks (lineage.rs, server.rs test module), or
- \`chmod\` (Unix-only)

No remaining unhardened production spawn site on Windows.

## TDD

1. **RED** — Added \`child_creation_flags_includes_create_no_window\` unit test asserting \`flags & 0x08000000 == 0x08000000\` for every \`CompilePriority\`. With the helper stubbed to \`return 0\`, the test failed:
   \`\`\`
   assertion left == right failed
     left: 0
     right: 134217728
   \`\`\`
2. Wired the helper into both call sites.
3. **GREEN** — Flipped the helper body to \`CREATE_NO_WINDOW\`. Test passes.
4. \`cargo test -p zccache-daemon --lib\` — 218 passed, 0 failed.

## Why unit-test rather than integration probe

Initial attempt used a PowerShell child that \`GetConsoleWindow()\`'d via P/Invoke. False green: \`cargo test\` runs the test binary without its own console attached, so any spawned child reads as console-less anyway regardless of \`CREATE_NO_WINDOW\`. The unit test on the flag-computation function is the deterministic signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)