### PR TITLE
chore(deps): bump running-process-core 3.2 → 3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -3472,7 +3472,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "libc",
  "md5",
@@ -3485,7 +3485,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "blake3",
  "clap",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "clang",
  "tempfile",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "bincode",
  "clap",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "clap",
  "serde",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "clap",
  "dashmap",
@@ -3672,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "clap",
  "criterion",
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "bytes",
  "serde",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "criterion",
  "globset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "running-process-core"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce223866d57eeb453b34bf5ec6d632616f76d3bdbcbc8a19a9511fe3e9c85d95"
+checksum = "4e7281b95e4dc54c3863d12892d3c4ce60517e88eb5c41f233844bd713817ce3"
 dependencies = [
  "libc",
  "portable-pty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.7.2"
+version = "1.8.0"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ sevenz-rust = "0.6"
 rkyv = { version = "0.7", features = ["validation"] }
 tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
 mimalloc = "0.1"
-running-process-core = "3.2"
+running-process-core = "3.3"
 zccache-core = { path = "crates/zccache-core" }
 zccache-hash = { path = "crates/zccache-hash" }
 zccache-protocol = { path = "crates/zccache-protocol" }

--- a/crates/zccache-cli/src/lib.rs
+++ b/crates/zccache-cli/src/lib.rs
@@ -704,8 +704,11 @@ pub fn spawn_daemon(bin: &Path, endpoint: &str) -> Result<(), String> {
     let log_path = allocate_daemon_spawn_log_path();
     let log_arg = log_path.to_string_lossy().into_owned();
 
-    // Delegate the actual spawn to `running_process_core::sanitized::spawn`.
-    // That helper handles both platform-specific quirks the daemon hits:
+    // Delegate the actual spawn to `running_process_core::spawn_daemon`
+    // (renamed from `sanitized::spawn` in the 3.2 → 3.3 reshape — same
+    // semantics, lives in the `spawn` module now and is re-exported at
+    // the crate root). That helper handles both platform-specific quirks
+    // the daemon hits:
     //  • Windows: STARTUPINFOEX + PROC_THREAD_ATTRIBUTE_HANDLE_LIST so
     //    grandparent pipe handles (e.g. Python's
     //    `subprocess.Popen(stdout=PIPE)` further up the chain) don't
@@ -714,7 +717,7 @@ pub fn spawn_daemon(bin: &Path, endpoint: &str) -> Result<(), String> {
     //    fd > 2 between fork and exec so the same orphan-handle issue
     //    doesn't bite on macOS in particular.
     //
-    // SanitizedChild always opens NUL for its stdio at the spawn site;
+    // `DaemonChild` always opens NUL for its stdio at the spawn site;
     // the daemon then redirects its own stdout + stderr to `--log-file`
     // once it's running.
     let mut cmd = std::process::Command::new(spawn_bin);
@@ -736,7 +739,7 @@ pub fn spawn_daemon(bin: &Path, endpoint: &str) -> Result<(), String> {
             cmd.env(k, v);
         }
     }
-    running_process_core::sanitized::spawn(&mut cmd)
+    running_process_core::spawn_daemon(&mut cmd)
         .map(|_child| ())
         .map_err(|e| format!("failed to spawn daemon (sanitized): {e}"))
 }


### PR DESCRIPTION
## Summary
- running-process-core 3.3 reshaped the sanitized-spawn surface: `sanitized::spawn` is gone, replaced by `running_process_core::spawn_daemon` (re-exported from a new `spawn` module). Identical semantics — detached + sanitized handle inheritance + NUL stdio + `CREATE_NO_WINDOW`/`DETACHED_PROCESS`/`CREATE_NEW_PROCESS_GROUP` on Windows + `setsid()` + close-all-fds on Unix.
- Single call site: the CLI's `spawn_daemon` in `crates/zccache-cli/src/lib.rs`.

## Test plan
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zccache-cli --test wrapper_passthrough -- --ignored` 3/3 green locally (Windows) — byte-for-byte stdin/stdout/stderr passthrough through the swapped spawn helper still works
- [ ] CI: `wrapper-e2e` matrix on ubuntu-latest / macos-14 / windows-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)