### PR TITLE
fix(release): restore split-debuginfo = "packed" so release sidecar staging passes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,11 +125,19 @@ libraries = [{ path = "dylints/*" }]
 [profile.dev]
 debug = "line-tables-only"
 
-# Release builds keep only `file:line` debug info inline — enough for a
-# panic backtrace or a profiler to attribute a sample to source, and
-# nothing else. No DWARF variable/type tables, no separate sidecar
-# (`.dwp` / `.dSYM` / `.pdb`) — the shipped binary is the whole story.
+# Release builds keep only `file:line` debug info — enough for a panic
+# backtrace or a profiler to attribute a sample to source, and nothing
+# else (no DWARF variable/type tables). The info is split into a
+# per-binary sidecar so the shipped binary stays slim:
+#   - Linux:        `<binary>.dwp`  (DWARF package, requires rust-dwp)
+#   - macOS:        `<binary>.dSYM/` (dsymutil bundle)
+#   - Windows MSVC: `<binary>.pdb`  (always emitted by msvc, kept explicit)
+# The release workflow stages each sidecar alongside its binary
+# (`.github/workflows/release.yml` — "Stage debug sidecars" step), and
+# `zccache symbols install` lazily downloads the matching sidecar at
+# runtime when a backtrace needs symbolicating.
 # Override with `CARGO_PROFILE_RELEASE_DEBUG=none cargo build --release`
-# for a smallest-possible binary when not even line info is needed.
+# for a smallest-possible binary when even line info isn't needed.
 [profile.release]
 debug = "line-tables-only"
+split-debuginfo = "packed"


### PR DESCRIPTION
## Summary
- PR #312 dropped `split-debuginfo = "packed"` from `[profile.release]`. That broke `.github/workflows/release.yml`'s sidecar-staging step (`::error::No debug sidecars staged for target <triple>`) — the 1.8.0 release attempt failed 6/8 build legs before I cancelled it.
- Restore the line. The shipped binary still carries only `file:line` debug info (`debug = "line-tables-only"` unchanged); the sidecar holds the same bytes externally so `zccache symbols install` can lazily download them when needed.
- Comment updated to document the sidecar arrangement.

## Test plan
- [x] `soldr cargo check --workspace` clean
- [ ] Re-tag 1.8.0 at the merge commit; `Auto-Release` workflow goes green end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)