### PR TITLE
chore(release): bump zccache to 1.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "bincode",
  "blake3",
@@ -3472,7 +3472,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "libc",
  "md5",
@@ -3485,7 +3485,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "blake3",
  "clap",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "clang",
  "tempfile",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "serde",
  "tempfile",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "bincode",
  "clap",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "blake3",
  "criterion",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "blake3",
  "bytes",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "clap",
  "serde",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "clap",
  "dashmap",
@@ -3672,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "bincode",
  "bytes",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "clap",
  "criterion",
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "dashmap",
  "rayon",
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "blake3",
  "criterion",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "bytes",
  "serde",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "bincode",
  "bytes",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "criterion",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.8.0"
+version = "1.8.1"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- bump workspace version from `1.8.0` to `1.8.1`
- refresh `Cargo.lock` path package versions for the workspace crates

Follows #318.

## Tests
- `cargo fmt --package zccache-cli --check`
- `cargo check -p zccache-cli --locked`