### PR TITLE
feat(symbols): release marker + zccache symbolicate <dump>

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -298,6 +298,52 @@ runs:
           exit 1
         fi
 
+    - name: Build release stamping helper (native host)
+      shell: bash
+      run: |
+        # `zccache-stamp` appends a 128-byte release marker to each
+        # binary. Built for the HOST (no --target) so we don't need
+        # the target's runtime to run the helper itself. Just appends
+        # bytes — never executes the (possibly cross-compiled) target.
+        cargo build --release --bin zccache-stamp
+
+    - name: Stamp release binaries with release marker
+      shell: bash
+      run: |
+        # Host-binary path: same `target/release` on every runner.
+        # On Windows runners the helper has a `.exe` suffix; on
+        # Linux/macOS it doesn't.
+        case "$RUNNER_OS" in
+          Windows) STAMP="target/release/zccache-stamp.exe" ;;
+          *)       STAMP="target/release/zccache-stamp" ;;
+        esac
+        if [ ! -x "$STAMP" ] && [ ! -e "$STAMP" ]; then
+          echo "::error::zccache-stamp not found at $STAMP" >&2
+          exit 1
+        fi
+        # We stamp the *target* binaries after stripping (so the stamp
+        # isn't clipped) and before archiving (so the archive carries
+        # the stamped bytes). Build timestamp captured once for all
+        # three binaries so they share the same provenance footer.
+        NOW="$(date -u +%s)"
+        VERSION="${{ inputs.version }}"
+        if [ -z "$VERSION" ]; then
+          VERSION=$(python -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('Cargo.toml').read_text(encoding='utf-8'))['workspace']['package']['version'])")
+        fi
+        for bin in zccache zccache-daemon zccache-fp; do
+          BIN_PATH="staging/${bin}${{ inputs.binary_ext }}"
+          if [ ! -e "$BIN_PATH" ]; then
+            echo "::error::binary missing for stamping: $BIN_PATH" >&2
+            exit 1
+          fi
+          "$STAMP" \
+            --binary "$BIN_PATH" \
+            --sha "$GITHUB_SHA" \
+            --version "$VERSION" \
+            --triple "${{ inputs.target }}" \
+            --timestamp "$NOW"
+        done
+
     - name: Package standalone archive
       shell: bash
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3560,6 +3560,7 @@ dependencies = [
  "zccache-hash",
  "zccache-ipc",
  "zccache-protocol",
+ "zccache-symbols",
  "zip",
 ]
 
@@ -3810,6 +3811,14 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror 2.0.18",
+ "zccache-core",
+]
+
+[[package]]
+name = "zccache-symbols"
+version = "1.8.1"
+dependencies = [
+ "tempfile",
  "zccache-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/zccache-ci",
     "crates/zccache-fingerprint",
     "crates/zccache-gha",
+    "crates/zccache-symbols",
 ]
 exclude = [
     "dylints/ban_std_pathbuf",
@@ -89,6 +90,7 @@ zccache-cli = { path = "crates/zccache-cli" }
 zccache-test-support = { path = "crates/zccache-test-support" }
 zccache-fingerprint = { path = "crates/zccache-fingerprint" }
 zccache-gha = { path = "crates/zccache-gha" }
+zccache-symbols = { path = "crates/zccache-symbols" }
 
 # Vendored notify with fixes for Windows ReadDirectoryChangesW:
 # 1. Detect buffer overflow (bytes_written == 0) and report as error

--- a/crates/zccache-cli/Cargo.toml
+++ b/crates/zccache-cli/Cargo.toml
@@ -33,6 +33,7 @@ zccache-ipc = { workspace = true }
 zccache-download = { workspace = true }
 zccache-download-client = { workspace = true }
 zccache-gha = { workspace = true }
+zccache-symbols = { workspace = true }
 running-process-core = { workspace = true }
 serde_json = { workspace = true }
 rayon = { workspace = true }

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -357,6 +357,19 @@ enum SymbolsCommands {
         #[arg(long)]
         force: bool,
     },
+    /// Resolve symbols for one or more crash dumps. Reads the release
+    /// marker appended to the running zccache binary to determine which
+    /// version + target's symbol archive to fetch; the archive is cached
+    /// under `<cache>/symbols/<v>-<triple>/` (one copy per build) and a
+    /// `<dump>.symref` sidecar is written next to each crash dump
+    /// pointing at the cached symbol directory. If the running binary
+    /// is a dev build (no release marker), reports that and exits — use
+    /// the local `target/release/*.{pdb,dwp,dSYM}` manually.
+    Symbolicate {
+        /// One or more crash dump paths (`crash-*.txt` or `crash-*.dmp`).
+        #[arg(required = true)]
+        dumps: Vec<PathBuf>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -952,7 +965,92 @@ fn main() -> ExitCode {
                 prefix,
                 force,
             } => cmd_symbols_install(version, target, prefix, force),
+            SymbolsCommands::Symbolicate { dumps } => cmd_symbols_symbolicate(dumps),
         },
+    }
+}
+
+fn cmd_symbols_symbolicate(dumps: Vec<PathBuf>) -> ExitCode {
+    let marker = match zccache_symbols::read_marker_from_current_exe() {
+        Some(m) => m,
+        None => {
+            eprintln!(
+                "zccache symbolicate: this binary has no release marker (dev build). \
+                 No automatic symbol fetch possible — use the local \
+                 target/release/zccache.{{pdb,dwp,dSYM}} manually."
+            );
+            return ExitCode::from(2);
+        }
+    };
+
+    // Cache layout: `<cache>/symbols/<version>-<triple>/`. One symbol
+    // copy per build, referenced from each crash via a `.symref`
+    // sidecar — true dedup. The existing `symbols::install` is the
+    // battle-tested fetch path; we just point its `--prefix` at our
+    // shared dir.
+    let cache_root: PathBuf = zccache_core::config::default_cache_dir().into_path_buf();
+    let symbols_dir =
+        zccache_symbols::symbols_dir_for(&cache_root, &marker.version, &marker.triple);
+    let symbols_dir_path: PathBuf = symbols_dir.into_path_buf();
+
+    let opts = SymbolsInstallOptions {
+        version: Some(marker.version.clone()),
+        target: Some(marker.triple.clone()),
+        prefix: Some(symbols_dir_path.clone()),
+        force: false,
+        lock_behavior: zccache_cli::symbols::LockBehavior::Wait,
+    };
+    let report = match symbols::install(opts) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("zccache symbolicate: failed to install symbols: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if let Err(e) = zccache_symbols::mark_ready(&symbols_dir_path) {
+        eprintln!(
+            "zccache symbolicate: warning — failed to write .ready sentinel in {}: {e}",
+            symbols_dir_path.display()
+        );
+    }
+
+    println!(
+        "zccache symbolicate: symbols at {} (version {} / {})",
+        symbols_dir_path.display(),
+        marker.version,
+        marker.triple,
+    );
+    if !report.skipped_already_present {
+        let source = if report.cache_hit {
+            "cached archive"
+        } else {
+            "GitHub release"
+        };
+        println!(
+            "  (downloaded {} sidecar(s) from {})",
+            report.installed.len(),
+            source,
+        );
+    }
+
+    let mut had_error = false;
+    for dump in dumps {
+        match zccache_symbols::write_symref_sidecar(&dump, &symbols_dir_path) {
+            Ok(sidecar) => println!("  wrote {}", sidecar.display()),
+            Err(e) => {
+                eprintln!(
+                    "zccache symbolicate: failed to write sidecar for {}: {e}",
+                    dump.display()
+                );
+                had_error = true;
+            }
+        }
+    }
+    if had_error {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
     }
 }
 

--- a/crates/zccache-symbols/Cargo.toml
+++ b/crates/zccache-symbols/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "zccache-symbols"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+description = "Release-build marker, symbol cache, and symbol-archive fetcher for zccache"
+
+[lib]
+name = "zccache_symbols"
+path = "src/lib.rs"
+
+[dependencies]
+zccache-core = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[[bin]]
+name = "zccache-stamp"
+path = "src/bin/stamp.rs"

--- a/crates/zccache-symbols/README.md
+++ b/crates/zccache-symbols/README.md
@@ -1,0 +1,42 @@
+# zccache-symbols
+
+Release-build marker, symbol cache, and symbol-archive fetcher.
+
+## Wire format
+
+Release binaries carry a fixed 96-byte footer appended after every other
+section the OS loader looks at. PE/ELF/Mach-O all tolerate trailing
+bytes past what their headers describe, so the OS loader ignores the
+footer and just reads it back at runtime via `current_exe()`.
+
+```
+[  0.. 40]  git SHA hex (40 chars, NUL-padded if short)
+[ 40.. 56]  semver version ("1.7.2"), NUL-padded
+[ 56.. 88]  rustc target triple, NUL-padded
+[ 88.. 96]  build timestamp (u64 LE, unix seconds)
+[ 96..120]  reserved zeros (forward-compat)
+[120..128]  magic = b"ZCCSYMv1"
+```
+
+Absence of the magic at byte 88..96 means "this is a dev build" — the
+caller skips the auto-fetch path entirely and tells the user to use
+local `target/release/*.{pdb,dwp,dSYM}` instead.
+
+## Stamping
+
+`zccache-stamp` (binary in this crate) is run on the release runner
+after stripping but before archiving. Cross-compile-safe: it doesn't
+execute the target binary, just appends bytes.
+
+## Lazy fetch
+
+The fetch itself lives in `zccache-cli::symbols::install` (cross-process
+locked, archive-cached, atomic-rename). `zccache symbolicate <dump>`
+reads the marker from `current_exe()`, calls `install()` with a prefix
+of `<cache>/symbols/<v>-<triple>/`, then writes the sidecar.
+
+## Placement
+
+Each crash dump gets a `<dump>.symref` sidecar next to it containing
+the absolute path to the extracted symbol directory. Symbols live ONCE
+in `<cache>/symbols/` and are referenced per-crash — no duplication.

--- a/crates/zccache-symbols/src/README.md
+++ b/crates/zccache-symbols/src/README.md
@@ -1,0 +1,9 @@
+# zccache-symbols source
+
+- `lib.rs` — crate root, re-exports
+- `marker.rs` — read/write the 128-byte release footer
+- `cache.rs` — symbol cache directory layout and `.symref` sidecars
+- `bin/stamp.rs` — `zccache-stamp` CI helper that appends the footer
+
+The actual symbol-archive download lives in `zccache-cli::symbols`, not
+here.

--- a/crates/zccache-symbols/src/bin/README.md
+++ b/crates/zccache-symbols/src/bin/README.md
@@ -1,0 +1,5 @@
+# zccache-symbols binaries
+
+- `stamp.rs` — `zccache-stamp` helper invoked by CI to append the 96-byte
+  release footer (git SHA, version, target triple, build timestamp,
+  magic) to a built binary. Must run after stripping and before packaging.

--- a/crates/zccache-symbols/src/bin/stamp.rs
+++ b/crates/zccache-symbols/src/bin/stamp.rs
@@ -1,0 +1,106 @@
+//! `zccache-stamp` — CI helper that appends the 96-byte release marker
+//! to a built binary.
+//!
+//! Run after stripping but before archiving. Cross-compile-safe: only
+//! appends bytes, never executes the target binary.
+//!
+//! ```text
+//! zccache-stamp \
+//!     --binary path/to/zccache.exe \
+//!     --sha $GITHUB_SHA \
+//!     --version 1.7.2 \
+//!     --triple x86_64-pc-windows-msvc \
+//!     --timestamp 1700000000
+//! ```
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+use zccache_symbols::marker::{write_marker_to_binary, ReleaseMarker};
+
+fn parse_args() -> Result<Args, String> {
+    let mut binary = None;
+    let mut sha = None;
+    let mut version = None;
+    let mut triple = None;
+    let mut timestamp = None;
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        let take_value =
+            |a: &mut std::iter::Skip<std::env::Args>, name: &str| -> Result<String, String> {
+                a.next().ok_or_else(|| format!("missing value for {name}"))
+            };
+        match arg.as_str() {
+            "--binary" => binary = Some(PathBuf::from(take_value(&mut args, &arg)?)),
+            "--sha" => sha = Some(take_value(&mut args, &arg)?),
+            "--version" => version = Some(take_value(&mut args, &arg)?),
+            "--triple" => triple = Some(take_value(&mut args, &arg)?),
+            "--timestamp" => {
+                timestamp = Some(
+                    take_value(&mut args, &arg)?
+                        .parse::<u64>()
+                        .map_err(|e| format!("--timestamp: {e}"))?,
+                )
+            }
+            "--help" | "-h" => {
+                print_usage();
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown flag: {other}")),
+        }
+    }
+    Ok(Args {
+        binary: binary.ok_or("--binary is required")?,
+        sha: sha.ok_or("--sha is required")?,
+        version: version.ok_or("--version is required")?,
+        triple: triple.ok_or("--triple is required")?,
+        timestamp: timestamp.ok_or("--timestamp is required")?,
+    })
+}
+
+struct Args {
+    binary: PathBuf,
+    sha: String,
+    version: String,
+    triple: String,
+    timestamp: u64,
+}
+
+fn print_usage() {
+    eprintln!(
+        "zccache-stamp --binary <path> --sha <hex40> --version <semver> \\\n\
+         \t--triple <rustc-target-triple> --timestamp <unix-secs>"
+    );
+}
+
+fn main() -> ExitCode {
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("zccache-stamp: {e}");
+            print_usage();
+            return ExitCode::from(2);
+        }
+    };
+
+    let marker = ReleaseMarker {
+        git_sha: args.sha,
+        version: args.version,
+        triple: args.triple,
+        build_timestamp: args.timestamp,
+    };
+
+    if let Err(e) = write_marker_to_binary(&args.binary, &marker) {
+        eprintln!(
+            "zccache-stamp: failed to append marker to {}: {e}",
+            args.binary.display()
+        );
+        return ExitCode::from(1);
+    }
+    println!(
+        "stamped {} ({} bytes appended)",
+        args.binary.display(),
+        zccache_symbols::marker::MARKER_SIZE
+    );
+    ExitCode::SUCCESS
+}

--- a/crates/zccache-symbols/src/cache.rs
+++ b/crates/zccache-symbols/src/cache.rs
@@ -1,0 +1,88 @@
+//! Symbol cache layout and per-crash `.symref` sidecars.
+//!
+//! Symbols live ONCE on disk under `<cache>/symbols/<v>-<triple>/`.
+//! Each crash dump gets a `<dump>.symref` sidecar next to it containing
+//! the absolute path to that directory — true dedup, portable across
+//! all OSes without needing symlinks (Windows symlinks require dev mode
+//! or admin).
+
+use std::path::{Path, PathBuf};
+use zccache_core::NormalizedPath;
+
+/// Sentinel file written after a successful extract. Its presence
+/// declares the directory "complete and ready to consume." Absence
+/// means either we've never fetched, or the previous fetch was
+/// interrupted mid-extract — either way, re-fetch.
+pub const READY_SENTINEL: &str = ".ready";
+
+/// Returns the canonical cache directory for the symbols matching a
+/// given `version` + target `triple`. Does NOT create the directory.
+#[must_use]
+pub fn symbols_dir_for(cache_root: &Path, version: &str, triple: &str) -> NormalizedPath {
+    NormalizedPath::from(
+        cache_root
+            .join("symbols")
+            .join(format!("{version}-{triple}")),
+    )
+}
+
+/// True if the directory exists AND has the `.ready` sentinel — i.e. a
+/// previous fetch completed atomically.
+#[must_use]
+pub fn is_ready(symbols_dir: &Path) -> bool {
+    symbols_dir.join(READY_SENTINEL).exists()
+}
+
+/// Drop the `.ready` sentinel into `symbols_dir`. Caller has already
+/// extracted the archive into this directory.
+pub fn mark_ready(symbols_dir: &Path) -> std::io::Result<()> {
+    std::fs::write(symbols_dir.join(READY_SENTINEL), b"")
+}
+
+/// Write a `<dump>.symref` next to `dump_path` whose contents are the
+/// absolute path to the symbol directory (plus a trailing newline so
+/// `cat` output stays tidy). The "no duplicates" half of the
+/// placement contract.
+pub fn write_symref_sidecar(dump_path: &Path, symbols_dir: &Path) -> std::io::Result<PathBuf> {
+    let mut sidecar = dump_path.as_os_str().to_owned();
+    sidecar.push(".symref");
+    let sidecar_path = PathBuf::from(sidecar);
+    let body = format!("{}\n", symbols_dir.display());
+    std::fs::write(&sidecar_path, body)?;
+    Ok(sidecar_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn symbols_dir_layout() {
+        let dir = symbols_dir_for(Path::new("/tmp/zc"), "1.7.2", "x86_64-pc-windows-msvc");
+        assert!(dir.ends_with("symbols/1.7.2-x86_64-pc-windows-msvc"));
+    }
+
+    #[test]
+    fn ready_sentinel_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("symbols");
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(!is_ready(&dir));
+        mark_ready(&dir).unwrap();
+        assert!(is_ready(&dir));
+    }
+
+    #[test]
+    fn symref_sidecar_records_absolute_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dump = tmp.path().join("crash-1700000000.dmp");
+        std::fs::write(&dump, b"fake dump").unwrap();
+        let symbols = tmp.path().join("symbols").join("1.7.2-host");
+        std::fs::create_dir_all(&symbols).unwrap();
+        let sidecar = write_symref_sidecar(&dump, &symbols).unwrap();
+        assert_eq!(sidecar.file_name().unwrap(), "crash-1700000000.dmp.symref");
+        let content = std::fs::read_to_string(&sidecar).unwrap();
+        assert!(content.contains(symbols.to_str().unwrap()));
+        assert!(content.ends_with('\n'));
+    }
+}

--- a/crates/zccache-symbols/src/lib.rs
+++ b/crates/zccache-symbols/src/lib.rs
@@ -1,0 +1,17 @@
+//! Release-build marker and per-crash sidecar primitives.
+//!
+//! See [`crate::marker`] for the 128-byte footer format that
+//! distinguishes a release-built `zccache.exe` from a local dev build,
+//! and [`crate::cache`] for the `<cache>/symbols/<v>-<triple>/` layout
+//! and the `<dump>.symref` sidecar that points each crash dump at its
+//! shared symbol directory.
+//!
+//! The actual symbol-archive *fetch* lives in `zccache-cli::symbols`
+//! (cross-process locked, atomic-renamed, archive-cached). This crate
+//! deliberately doesn't duplicate that machinery.
+
+pub mod cache;
+pub mod marker;
+
+pub use cache::{is_ready, mark_ready, symbols_dir_for, write_symref_sidecar, READY_SENTINEL};
+pub use marker::{read_marker_from_current_exe, read_marker_from_path, ReleaseMarker};

--- a/crates/zccache-symbols/src/marker.rs
+++ b/crates/zccache-symbols/src/marker.rs
@@ -1,0 +1,209 @@
+//! 128-byte release footer appended to the end of distributed zccache
+//! binaries. Read at runtime via `current_exe()` to discover the
+//! version, target triple, and source revision the binary was built
+//! from. The shipped GitHub release of that exact version+triple
+//! carries matching debug symbols.
+//!
+//! ## Format
+//!
+//! ```text
+//! [  0.. 40]  git SHA hex (NUL-padded if short)
+//! [ 40.. 56]  semver version, NUL-padded
+//! [ 56.. 88]  rustc target triple, NUL-padded (longest seen: 26 bytes,
+//!             slot sized for forward-compat)
+//! [ 88.. 96]  build timestamp (u64 LE, unix seconds)
+//! [ 96..120]  reserved zeros (forward-compat)
+//! [120..128]  magic = b"ZCCSYMv1"
+//! ```
+//!
+//! Absence of the magic means "dev build" — callers fall back to local
+//! `target/release/*.{pdb,dwp,dSYM}` rather than attempting any fetch.
+
+use std::fs::OpenOptions;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::Path;
+
+pub const MARKER_MAGIC: &[u8; 8] = b"ZCCSYMv1";
+pub const MARKER_SIZE: usize = 128;
+
+const OFFSET_SHA: usize = 0;
+const OFFSET_VERSION: usize = 40;
+const OFFSET_TRIPLE: usize = 56;
+const OFFSET_TIMESTAMP: usize = 88;
+const OFFSET_MAGIC: usize = 120;
+
+const SHA_LEN: usize = 40;
+const VERSION_LEN: usize = 16;
+const TRIPLE_LEN: usize = 32;
+
+/// Parsed release marker fields. All string fields are stripped of
+/// trailing NULs the on-disk format uses for padding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseMarker {
+    pub git_sha: String,
+    pub version: String,
+    pub triple: String,
+    pub build_timestamp: u64,
+}
+
+/// Read the marker from the currently-running executable.
+///
+/// Returns `None` if the binary is too small, the magic doesn't match
+/// (dev build), or the file can't be read.
+#[must_use]
+pub fn read_marker_from_current_exe() -> Option<ReleaseMarker> {
+    let exe = std::env::current_exe().ok()?;
+    read_marker_from_path(&exe)
+}
+
+/// Read the marker from a specific path. Used by tests and by `zccache
+/// symbolicate` when the user passes `--binary <path>` explicitly.
+#[must_use]
+pub fn read_marker_from_path(path: &Path) -> Option<ReleaseMarker> {
+    let mut file = std::fs::File::open(path).ok()?;
+    let len = file.metadata().ok()?.len();
+    if len < MARKER_SIZE as u64 {
+        return None;
+    }
+    file.seek(SeekFrom::End(-(MARKER_SIZE as i64))).ok()?;
+    let mut buf = [0u8; MARKER_SIZE];
+    file.read_exact(&mut buf).ok()?;
+    decode_footer(&buf)
+}
+
+/// Append a marker footer to `path`. The caller is responsible for
+/// running this AFTER any stripping step — strip would clip the footer.
+/// And BEFORE any signing step (Authenticode/codesign cover trailing
+/// bytes), once we sign artifacts at all.
+///
+/// Errors if the file can't be opened for append, or if a string field
+/// exceeds its on-disk slot.
+pub fn write_marker_to_binary(path: &Path, marker: &ReleaseMarker) -> std::io::Result<()> {
+    let footer = encode_footer(marker)?;
+    let mut file = OpenOptions::new().append(true).open(path)?;
+    file.write_all(&footer)?;
+    file.flush()?;
+    Ok(())
+}
+
+fn decode_footer(buf: &[u8; MARKER_SIZE]) -> Option<ReleaseMarker> {
+    if &buf[OFFSET_MAGIC..OFFSET_MAGIC + 8] != MARKER_MAGIC {
+        return None;
+    }
+    let git_sha = decode_nul_padded(&buf[OFFSET_SHA..OFFSET_SHA + SHA_LEN])?;
+    let version = decode_nul_padded(&buf[OFFSET_VERSION..OFFSET_VERSION + VERSION_LEN])?;
+    let triple = decode_nul_padded(&buf[OFFSET_TRIPLE..OFFSET_TRIPLE + TRIPLE_LEN])?;
+    let mut ts_bytes = [0u8; 8];
+    ts_bytes.copy_from_slice(&buf[OFFSET_TIMESTAMP..OFFSET_TIMESTAMP + 8]);
+    let build_timestamp = u64::from_le_bytes(ts_bytes);
+    Some(ReleaseMarker {
+        git_sha,
+        version,
+        triple,
+        build_timestamp,
+    })
+}
+
+fn encode_footer(marker: &ReleaseMarker) -> std::io::Result<[u8; MARKER_SIZE]> {
+    let mut out = [0u8; MARKER_SIZE];
+    write_nul_padded(
+        &mut out[OFFSET_SHA..OFFSET_SHA + SHA_LEN],
+        &marker.git_sha,
+        "git_sha",
+    )?;
+    write_nul_padded(
+        &mut out[OFFSET_VERSION..OFFSET_VERSION + VERSION_LEN],
+        &marker.version,
+        "version",
+    )?;
+    write_nul_padded(
+        &mut out[OFFSET_TRIPLE..OFFSET_TRIPLE + TRIPLE_LEN],
+        &marker.triple,
+        "triple",
+    )?;
+    out[OFFSET_TIMESTAMP..OFFSET_TIMESTAMP + 8]
+        .copy_from_slice(&marker.build_timestamp.to_le_bytes());
+    out[OFFSET_MAGIC..OFFSET_MAGIC + 8].copy_from_slice(MARKER_MAGIC);
+    Ok(out)
+}
+
+fn decode_nul_padded(slice: &[u8]) -> Option<String> {
+    let end = slice.iter().position(|&b| b == 0).unwrap_or(slice.len());
+    std::str::from_utf8(&slice[..end]).ok().map(str::to_owned)
+}
+
+fn write_nul_padded(dest: &mut [u8], value: &str, field: &str) -> std::io::Result<()> {
+    let bytes = value.as_bytes();
+    if bytes.len() > dest.len() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "{field}: {} bytes exceeds slot size {}",
+                bytes.len(),
+                dest.len()
+            ),
+        ));
+    }
+    dest[..bytes.len()].copy_from_slice(bytes);
+    // Remaining bytes left as zero from `[0u8; MARKER_SIZE]` init.
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_marker() -> ReleaseMarker {
+        ReleaseMarker {
+            git_sha: "032432c000000000000000000000000000000000".to_string(),
+            version: "1.7.2".to_string(),
+            triple: "x86_64-pc-windows-msvc".to_string(),
+            build_timestamp: 1_700_000_000,
+        }
+    }
+
+    #[test]
+    fn roundtrip_encode_decode() {
+        let m = sample_marker();
+        let footer = encode_footer(&m).unwrap();
+        assert_eq!(footer.len(), MARKER_SIZE);
+        assert_eq!(&footer[OFFSET_MAGIC..OFFSET_MAGIC + 8], MARKER_MAGIC);
+        let parsed = decode_footer(&footer).unwrap();
+        assert_eq!(parsed, m);
+    }
+
+    #[test]
+    fn triple_too_long_errors() {
+        let mut m = sample_marker();
+        m.triple = "x86_64-some-extremely-long-triple-that-cannot-fit".to_string();
+        assert!(encode_footer(&m).is_err());
+    }
+
+    #[test]
+    fn missing_magic_returns_none() {
+        let mut buf = [0u8; MARKER_SIZE];
+        buf[OFFSET_VERSION..OFFSET_VERSION + 5].copy_from_slice(b"1.7.2");
+        // magic slot left as zeros — should not parse
+        assert!(decode_footer(&buf).is_none());
+    }
+
+    #[test]
+    fn write_marker_appends_to_file() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"existing binary contents goes here")
+            .unwrap();
+        let path = tmp.into_temp_path();
+        let m = sample_marker();
+        write_marker_to_binary(&path, &m).unwrap();
+        let parsed = read_marker_from_path(&path).unwrap();
+        assert_eq!(parsed, m);
+    }
+
+    #[test]
+    fn short_file_returns_none() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"tiny").unwrap();
+        let path = tmp.into_temp_path();
+        assert!(read_marker_from_path(&path).is_none());
+    }
+}

--- a/crates/zccache-symbols/tests/README.md
+++ b/crates/zccache-symbols/tests/README.md
@@ -1,0 +1,7 @@
+# zccache-symbols tests
+
+Integration tests for the marker + sidecar pieces. The fetch side is
+covered by `zccache-cli`'s own tests.
+
+- `stamp_roundtrip.rs` — invoke `zccache-stamp` on a fixture file, then
+  parse the marker back via `read_marker_from_path`.

--- a/crates/zccache-symbols/tests/stamp_roundtrip.rs
+++ b/crates/zccache-symbols/tests/stamp_roundtrip.rs
@@ -1,0 +1,57 @@
+//! Spawn `zccache-stamp` against a fixture binary then assert the
+//! reader sees exactly the fields we wrote. This is the contract the
+//! CI workflow relies on — produced by the stamp binary, consumed by
+//! `read_marker_from_path` in the daemon and CLI.
+
+use std::io::Write;
+use zccache_symbols::marker::{read_marker_from_path, MARKER_SIZE};
+
+#[test]
+fn stamp_then_read_returns_same_fields() {
+    let mut tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    tmp.write_all(b"pretend this is a real release binary")
+        .unwrap();
+    let path = tmp.into_temp_path();
+
+    let stamp_bin = env!("CARGO_BIN_EXE_zccache-stamp");
+    let status = std::process::Command::new(stamp_bin)
+        .arg("--binary")
+        .arg(&path)
+        .arg("--sha")
+        .arg("032432c000000000000000000000000000000000")
+        .arg("--version")
+        .arg("1.7.2")
+        .arg("--triple")
+        .arg("x86_64-pc-windows-msvc")
+        .arg("--timestamp")
+        .arg("1700000000")
+        .status()
+        .expect("spawn zccache-stamp");
+    assert!(
+        status.success(),
+        "zccache-stamp exited non-zero: {status:?}"
+    );
+
+    let marker = read_marker_from_path(&path).expect("marker should be present");
+    assert_eq!(marker.git_sha, "032432c000000000000000000000000000000000");
+    assert_eq!(marker.version, "1.7.2");
+    assert_eq!(marker.triple, "x86_64-pc-windows-msvc");
+    assert_eq!(marker.build_timestamp, 1_700_000_000);
+
+    let size = std::fs::metadata(&path).unwrap().len();
+    assert!(
+        size as usize >= MARKER_SIZE,
+        "file should be at least MARKER_SIZE bytes after stamping"
+    );
+}
+
+#[test]
+fn unstamped_file_returns_none() {
+    let mut tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    // Pad with enough bytes that the read_marker_from_path doesn't
+    // short-circuit on the "too small" path — we want it to actually
+    // look at the last 128 bytes and find no magic.
+    tmp.write_all(&vec![0u8; 256]).unwrap();
+    let path = tmp.into_temp_path();
+    assert!(read_marker_from_path(&path).is_none());
+}

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -16,6 +16,7 @@ Architecture docs are split by subsystem. Read only what's relevant to your curr
 | `zccache-hash` | [overview.md](architecture/overview.md) (2.8) |
 | `zccache-compiler` | [overview.md](architecture/overview.md) (2.9), [data-flow.md](architecture/data-flow.md) |
 | `zccache-core` | [overview.md](architecture/overview.md) |
+| `zccache-symbols` | Crate README — 128-byte release footer, `<dump>.symref` sidecars, `zccache-stamp` CI helper |
 | Perf measurement workflows | [/PERF.md](../PERF.md) — `perf-rust-cluster.yml`, scenarios, gate semantics |
 | Platform-specific issues | [portability.md](architecture/portability.md) |
 | Compile journal record shape | [journal-schema.md](journal-schema.md) |


### PR DESCRIPTION
## Summary

Adds the "this is a release build, fetch symbols from GitHub" flow asked for in the crash-handler conversation. A 128-byte footer appended to release binaries (capturing `git_sha`, `version`, `triple`, `build_ts`, magic at `[120..128]`) lets `zccache.exe` self-inspect: if the magic is there, it was minted by the GitHub release pipeline and matching symbols are downloadable; if not, dev build, hands off.

```
[  0.. 40]  git SHA hex (NUL-padded if short)
[ 40.. 56]  semver version, NUL-padded
[ 56.. 88]  rustc target triple, NUL-padded (32 bytes for longest triple)
[ 88.. 96]  build timestamp (u64 LE, unix seconds)
[ 96..120]  reserved zeros (forward-compat)
[120..128]  magic = b"ZCCSYMv1"
```

PE/ELF/Mach-O loaders all ignore trailing bytes past what their headers describe, so the footer is invisible to `current_exe()` execution. Stamping must happen AFTER strip (which would clip the footer) and BEFORE any signing (Authenticode/codesign cover trailing bytes); zccache doesn't sign today.

## What ships

| Piece | Location |
|---|---|
| `zccache-symbols` crate (`marker`, `cache`, `READY_SENTINEL`) | `crates/zccache-symbols/` |
| `zccache-stamp` CI helper binary | `crates/zccache-symbols/src/bin/stamp.rs` |
| New CLI subcommand `zccache symbols symbolicate <dump>` | `crates/zccache-cli/src/main.rs` |
| CI: stamp every release binary between strip and archive | `.github/actions/build-target/action.yml` |

The `symbolicate` subcommand:
1. Reads the marker from `current_exe()`. If absent: prints "dev build, use local `target/release/*.{pdb,dwp,dSYM}` manually" and exits 2.
2. Otherwise calls the existing battle-tested `zccache_cli::symbols::install()` (cross-process locked, archive-cached, atomic-rename, used by `zccache symbols install`) with `--prefix <cache>/symbols/<v>-<triple>/`. The existing flow already implements the "all sidecars present → short-circuit" dedup, so the second `symbolicate` skips the network entirely.
3. Writes a `<dump>.symref` next to each input crash dump containing the absolute path to the symbol dir. Truly no duplicates — symbols live ONCE in `<cache>/symbols/`, each crash gets a tiny pointer file.

The user can then open the dump in WinDbg / `minidump-stackwalk` against the symref-pointed directory.

## Manual smoke (Windows, against the live 1.7.2 GitHub release)

```
$ zccache-stamp --binary zccache.exe --sha 032432c000000000000000000000000000000000 \
    --version 1.7.2 --triple x86_64-pc-windows-msvc --timestamp 1700000000
stamped C:/.../zccache.exe (128 bytes appended)

$ zccache.exe symbols symbolicate fakecrash.dmp
zccache symbolicate: symbols at C:\Users\niteris\.zccache\symbols\1.7.2-x86_64-pc-windows-msvc (version 1.7.2 / x86_64-pc-windows-msvc)
  (downloaded 3 sidecar(s) from GitHub release)
  wrote fakecrash.dmp.symref

$ cat fakecrash.dmp.symref
C:\Users\niteris\.zccache\symbols\1.7.2-x86_64-pc-windows-msvc

$ ls $HOME/.zccache/symbols/1.7.2-x86_64-pc-windows-msvc/
zccache.pdb  zccache_daemon.pdb  zccache_fp.pdb

# Idempotency: no "downloaded ... sidecar(s)" line on the second call.
$ zccache.exe symbols symbolicate fakecrash.dmp
zccache symbolicate: symbols at C:\...\.zccache\symbols\1.7.2-x86_64-pc-windows-msvc (version 1.7.2 / x86_64-pc-windows-msvc)
  wrote fakecrash.dmp.symref
```

Dev-build path (no stamp):

```
$ target/debug/zccache.exe symbols symbolicate fakecrash.dmp
zccache symbolicate: this binary has no release marker (dev build). No automatic symbol fetch possible — use the local target/release/zccache.{pdb,dwp,dSYM} manually.
$ echo $?
2
```

## Tests

- `cargo test -p zccache-symbols` — 10 tests pass (8 unit + 2 integration). The integration test spawns `zccache-stamp` on a fixture file and asserts the parsed fields round-trip.
- `cargo clippy -p zccache-symbols -p zccache-cli --all-targets -- -D warnings` — clean.

## Out of scope

- Daemon auto-write of `.symref` next to fresh crash dumps when symbols are already cached. Per the agreed plan ("Footer + fetch + placement only"), the explicit `symbolicate` command covers this.
- Stackwalker / `crash-<ts>.symbolicated.txt` output. WinDbg / `minidump-stackwalk` consume the symref-pointed dir directly.
- Code-signing-aware stamp ordering. We don't sign artifacts today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
