### PR TITLE
ci: skip workflows on docs-only and other non-functional changes

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -3,8 +3,30 @@ name: Linux
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
 
 jobs:
   linux:

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -3,8 +3,30 @@ name: macOS
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
 
 jobs:
   macos:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -3,8 +3,30 @@ name: Windows
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
 
 jobs:
   windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,30 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -3,6 +3,17 @@ name: Clippy
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,17 @@ name: Coverage
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,29 @@ name: Integration
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
 
 concurrency:
   group: integration-${{ github.ref }}

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -12,8 +12,30 @@ name: Wrapper end-to-end
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
 
 jobs:
   wrapper-e2e:


### PR DESCRIPTION
## Summary

Skip GitHub Actions runs on commits and PRs whose diff touches **only** non-functional files (Markdown, license/contributor metadata, dotfile config, and `tasks/**` planning scratch). Implemented with `paths-ignore` on each affected workflow's `push` and `pull_request` triggers — semantics: if every changed file matches the ignore list the workflow does not run; one file outside the list and the workflow runs normally.

Same ordered ignore list applied to every edited workflow so future maintainers can diff them:

- `**/*.md`
- `LICENSE*`, `NOTICE*`, `AUTHORS*`, `CODEOWNERS`, `CONTRIBUTING*`
- `.gitignore`, `.gitattributes`, `.editorconfig`
- `tasks/**`

### Workflows edited (trigger-level `paths-ignore`)

- `.github/workflows/ci-linux.yml`
- `.github/workflows/ci-macos.yml`
- `.github/workflows/ci-windows.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/clippy.yml`
- `.github/workflows/coverage.yml`
- `.github/workflows/integration.yml`
- `.github/workflows/wrapper-e2e.yml`

### Workflows deliberately left alone

- `perf-rust-cluster.yml` — PERF.md guarantees `main` always runs the full sweep; adding `paths-ignore` would silently break that contract.
- `release-auto.yml` — gated on workspace version-bump detection and tag pushes; docs-only commits are already a no-op via the `detect-bump` job, and the workflow needs to fire on tag push regardless of paths.
- `bench-action.yml`, `perf-guard.yml`, `test-action.yml` — already use `paths:` allowlists scoped to code paths, so docs-only changes never trigger them.
- `bench-fingerprint.yml`, `benchmark-stats.yml`, `build.yml` — `workflow_dispatch` / `schedule` only, no push or PR triggers to filter.
- `ci-check.yml` — `workflow_call` only (reusable workflow invoked by `ci-linux/macos/windows.yml`); the callers do the filtering.

### Branch protection / required checks

`gh api repos/zackees/zccache/branches/main/protection` returns `404 Branch not protected`, so `main` has no required status checks. Plain `paths-ignore` on triggers is safe — no risk of branch protection blocking docs-only PRs from merging because of skipped checks. No early-gate or docs-only companion workflow was needed.

## Test plan

- [ ] Confirm CI is **not** triggered by this PR's follow-up docs-only commits (if any).
- [ ] After merge, push a docs-only commit (e.g. README typo) to `main` and confirm only `perf-rust-cluster` and `release-auto` (the latter no-ops via version-bump detection) react.
- [ ] Push a Rust commit and confirm the full filtered set (`ci`, `ci-linux/macos/windows`, `clippy`, `coverage`, `integration`, `wrapper-e2e`) runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)