### PR TITLE
feat(cli): zccache cache-root introspection + write-path audit (#275)

### DIFF
--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -333,6 +333,20 @@ enum Commands {
         #[command(subcommand)]
         action: SymbolsCommands,
     },
+    /// Print the resolved cache root directory and exit.
+    ///
+    /// Reads `ZCCACHE_CACHE_DIR` (or falls back to the platform default) and
+    /// prints the absolute path. Wrappers like [soldr](https://github.com/zackees/soldr)
+    /// use this to verify at runtime that their cache-redirect env var was
+    /// honored by whichever `zccache` binary is on PATH. See issue #275.
+    #[command(name = "cache-root")]
+    CacheRoot {
+        /// Emit `{"cache_root": "<abs>", "source": "<src>"}` instead of the
+        /// plain path. `source` is one of `env:ZCCACHE_CACHE_DIR`,
+        /// `colocate:cross_volume`, `default:platform_dirs`.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -660,6 +674,7 @@ const KNOWN_SUBCOMMANDS: &[&str] = &[
     "snapshot-fp-record",
     "snapshot-fp-validate",
     "symbols",
+    "cache-root",
     "help",
     "--help",
     "-h",
@@ -967,7 +982,26 @@ fn main() -> ExitCode {
             } => cmd_symbols_install(version, target, prefix, force),
             SymbolsCommands::Symbolicate { dumps } => cmd_symbols_symbolicate(dumps),
         },
+        Commands::CacheRoot { json } => cmd_cache_root(json),
     }
+}
+
+/// Print the resolved cache root and how it was determined. Issue #275:
+/// soldr (and any other wrapper) calls this to confirm at runtime that the
+/// zccache binary on PATH honored `ZCCACHE_CACHE_DIR` before trusting the
+/// Defender-exclusion contract.
+fn cmd_cache_root(json: bool) -> ExitCode {
+    let (root, source) = zccache_core::config::resolve_cache_root();
+    if json {
+        let payload = serde_json::json!({
+            "cache_root": root.as_path(),
+            "source": source.as_str(),
+        });
+        println!("{}", serde_json::to_string(&payload).unwrap_or_default());
+    } else {
+        println!("{}", root.display());
+    }
+    ExitCode::SUCCESS
 }
 
 fn cmd_symbols_symbolicate(dumps: Vec<PathBuf>) -> ExitCode {

--- a/crates/zccache-cli/tests/cache_root.rs
+++ b/crates/zccache-cli/tests/cache_root.rs
@@ -1,0 +1,137 @@
+//! Integration tests for the `zccache cache-root` introspection
+//! subcommand. Issue #275: soldr (and any other wrapper) shells out to
+//! this to verify at runtime that its `ZCCACHE_CACHE_DIR` redirect was
+//! honored by the binary on PATH.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use zccache_core::NormalizedPath;
+
+fn zccache_bin() -> NormalizedPath {
+    let mut path = std::env::current_exe()
+        .expect("current_exe")
+        .parent()
+        .expect("parent of test binary")
+        .parent()
+        .expect("target dir")
+        .to_path_buf();
+    if cfg!(windows) {
+        path.push("zccache.exe");
+    } else {
+        path.push("zccache");
+    }
+    assert!(
+        path.exists(),
+        "zccache binary not found at {path:?}. Run `cargo build` first."
+    );
+    NormalizedPath::new(path)
+}
+
+fn run_cache_root(cache_dir: Option<&Path>, json: bool) -> std::process::Output {
+    let bin = zccache_bin();
+    let mut cmd = Command::new(bin.as_path());
+    match cache_dir {
+        Some(p) => {
+            cmd.env("ZCCACHE_CACHE_DIR", p);
+        }
+        None => {
+            cmd.env_remove("ZCCACHE_CACHE_DIR");
+        }
+    }
+    cmd.env_remove("ZCCACHE_COLOCATE");
+    cmd.arg("cache-root");
+    if json {
+        cmd.arg("--json");
+    }
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    cmd.output().expect("spawn zccache cache-root")
+}
+
+#[test]
+fn cache_root_default_prints_absolute_path() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let want = temp.path().join("zc");
+    let out = run_cache_root(Some(&want), false);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    let want_str = want.to_string_lossy().to_string();
+    assert_eq!(
+        stdout, want_str,
+        "stdout `{stdout}` should equal `{want_str}`"
+    );
+}
+
+#[test]
+fn cache_root_env_branch_reports_env_source() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let want = temp.path().join("zc");
+    let out = run_cache_root(Some(&want), true);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("--json must emit valid JSON");
+    assert_eq!(v["source"], "env:ZCCACHE_CACHE_DIR");
+    let got = v["cache_root"].as_str().expect("cache_root is a string");
+    assert_eq!(Path::new(got), want.as_path());
+}
+
+#[test]
+fn cache_root_default_branch_reports_default_source_when_env_unset() {
+    let out = run_cache_root(None, true);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("--json must emit valid JSON");
+    assert_eq!(v["source"], "default:platform_dirs");
+    assert!(
+        v["cache_root"].as_str().is_some(),
+        "cache_root must be present and stringy"
+    );
+}
+
+#[test]
+fn cache_root_relative_env_path_is_absolute_in_output() {
+    // `ZCCACHE_CACHE_DIR=./relative-zc` should still print an absolute
+    // path so wrappers don't have to re-resolve it against the cwd.
+    let temp = tempfile::tempdir().expect("tempdir");
+    let bin = zccache_bin();
+    let out = Command::new(bin.as_path())
+        .env("ZCCACHE_CACHE_DIR", "relative-zc")
+        .env_remove("ZCCACHE_COLOCATE")
+        .current_dir(temp.path())
+        .arg("cache-root")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn zccache cache-root");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    assert!(
+        Path::new(&stdout).is_absolute(),
+        "stdout `{stdout}` must be an absolute path"
+    );
+    assert!(
+        stdout.ends_with("relative-zc"),
+        "stdout `{stdout}` should end with the relative override stem"
+    );
+}

--- a/crates/zccache-core/src/config.rs
+++ b/crates/zccache-core/src/config.rs
@@ -74,16 +74,66 @@ pub fn default_cache_dir() -> NormalizedPath {
 }
 
 fn default_cache_dir_from_env_value(value: Option<OsString>) -> NormalizedPath {
+    resolve_cache_root_from_env_value(value).0
+}
+
+/// How [`resolve_cache_root`] determined the active cache root path.
+///
+/// Exposed via `zccache cache-root --json` (issue #275) so wrappers like
+/// [soldr](https://github.com/zackees/soldr) can confirm at runtime that
+/// `ZCCACHE_CACHE_DIR` actually took effect. Older zccache binaries on PATH
+/// that ignore the env var would surface here as `Default` instead of `Env`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheRootSource {
+    /// `ZCCACHE_CACHE_DIR` was set and non-empty.
+    Env,
+    /// Same-volume colocation kicked in (`ZCCACHE_COLOCATE`) because the
+    /// CWD lives on a different volume from `$HOME`. See issue #296.
+    Colocated,
+    /// Plain default: `~/.zccache` (or `.zccache` next to the binary if
+    /// `$HOME`/`$USERPROFILE` cannot be resolved).
+    Default,
+}
+
+impl CacheRootSource {
+    /// Stable wire string, matched by soldr's runtime verification. Format:
+    /// `env:ZCCACHE_CACHE_DIR`, `colocate:cross_volume`, `default:platform_dirs`.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Env => "env:ZCCACHE_CACHE_DIR",
+            Self::Colocated => "colocate:cross_volume",
+            Self::Default => "default:platform_dirs",
+        }
+    }
+}
+
+impl std::fmt::Display for CacheRootSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Returns the cache root + the rule that resolved it.
+///
+/// Equivalent to [`default_cache_dir`] but also reports which branch fired.
+/// Used by `zccache cache-root --json` (issue #275).
+#[must_use]
+pub fn resolve_cache_root() -> (NormalizedPath, CacheRootSource) {
+    resolve_cache_root_from_env_value(std::env::var_os(CACHE_DIR_ENV))
+}
+
+fn resolve_cache_root_from_env_value(value: Option<OsString>) -> (NormalizedPath, CacheRootSource) {
     if let Some(p) = cache_dir_from_env_value(value) {
-        return p;
+        return (p, CacheRootSource::Env);
     }
     let home = dirs_fallback();
     if colocate_enabled() {
         if let Some(p) = colocated_cache_dir(&home) {
-            return p;
+            return (p, CacheRootSource::Colocated);
         }
     }
-    home.join(".zccache")
+    (home.join(".zccache"), CacheRootSource::Default)
 }
 
 /// True when `ZCCACHE_COLOCATE` is set to a non-empty, non-"0" value.
@@ -511,6 +561,72 @@ mod tests {
     fn default_cache_dir_ends_with_zccache() {
         let dir = default_cache_dir_from_env_value(None);
         assert!(dir.ends_with(".zccache"));
+    }
+
+    #[test]
+    fn resolve_cache_root_env_branch() {
+        let root = tempfile::tempdir().unwrap();
+        let want = root.path().join("zc");
+        let (dir, src) = resolve_cache_root_from_env_value(Some(want.clone().into_os_string()));
+        assert_eq!(dir, want);
+        assert_eq!(src, CacheRootSource::Env);
+        assert_eq!(src.as_str(), "env:ZCCACHE_CACHE_DIR");
+    }
+
+    #[test]
+    fn resolve_cache_root_default_branch_when_env_unset() {
+        std::env::remove_var(COLOCATE_ENV);
+        let (dir, src) = resolve_cache_root_from_env_value(None);
+        assert!(dir.ends_with(".zccache"));
+        assert_eq!(src, CacheRootSource::Default);
+        assert_eq!(src.as_str(), "default:platform_dirs");
+    }
+
+    #[test]
+    fn resolve_cache_root_default_branch_when_env_empty() {
+        std::env::remove_var(COLOCATE_ENV);
+        let (_dir, src) = resolve_cache_root_from_env_value(Some(OsString::new()));
+        assert_eq!(src, CacheRootSource::Default);
+    }
+
+    #[test]
+    fn cache_root_source_display_matches_as_str() {
+        assert_eq!(CacheRootSource::Env.to_string(), "env:ZCCACHE_CACHE_DIR");
+        assert_eq!(
+            CacheRootSource::Colocated.to_string(),
+            "colocate:cross_volume"
+        );
+        assert_eq!(
+            CacheRootSource::Default.to_string(),
+            "default:platform_dirs"
+        );
+    }
+
+    /// Every well-known subpath that the daemon/CLI persistently writes to
+    /// MUST live under the resolved cache root. This is the soldr/Defender
+    /// exclusion contract from issue #275: one directory the wrapper can
+    /// exclude and trust that no zccache write escapes it.
+    #[test]
+    fn cache_root_invariant_all_subpaths_rooted() {
+        let (_temp, cache) = temp_cache_dir();
+        let subs: [(NormalizedPath, &str); 8] = [
+            (artifacts_dir_from_cache_dir(&cache), "artifacts/"),
+            (tmp_dir_from_cache_dir(&cache), "tmp/"),
+            (depfile_dir_from_cache_dir(&cache), "tmp/depfiles/"),
+            (depgraph_dir_from_cache_dir(&cache), "depgraph/"),
+            (log_dir_from_cache_dir(&cache), "logs/"),
+            (crash_dump_dir_from_cache_dir(&cache), "crashes/"),
+            (symbols_cache_dir_from_cache_dir(&cache), "symbols/"),
+            (index_path_from_cache_dir(&cache), "index.bin"),
+        ];
+        for (p, label) in &subs {
+            assert!(
+                p.starts_with(&cache),
+                "{label} ({}) must be under cache root ({})",
+                p.display(),
+                cache.display()
+            );
+        }
     }
 
     #[test]

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -1963,7 +1963,15 @@ async fn handle_link_ephemeral(
                         "link non-cacheable, passing through"
                     );
                     state.stats.record_link_non_cacheable();
-                    return run_tool_passthrough(tool, args, cwd, env, &lineage).await;
+                    return run_tool_passthrough(
+                        tool,
+                        args,
+                        cwd,
+                        env,
+                        &lineage,
+                        state.depfile_tmpdir.as_path(),
+                    )
+                    .await;
                 }
             }
         }
@@ -1987,7 +1995,15 @@ async fn handle_link_ephemeral(
         Some(h) => h,
         None => {
             tracing::warn!("cannot hash tool {}", tool.display());
-            return run_tool_passthrough(tool, args, cwd, env, &lineage).await;
+            return run_tool_passthrough(
+                tool,
+                args,
+                cwd,
+                env,
+                &lineage,
+                state.depfile_tmpdir.as_path(),
+            )
+            .await;
         }
     };
 
@@ -2032,7 +2048,15 @@ async fn handle_link_ephemeral(
                     "cannot hash input file {}: skipping cache",
                     input_path.display()
                 );
-                return run_tool_passthrough(tool, args, cwd, env, &lineage).await;
+                return run_tool_passthrough(
+                    tool,
+                    args,
+                    cwd,
+                    env,
+                    &lineage,
+                    state.depfile_tmpdir.as_path(),
+                )
+                .await;
             }
         };
         key_builder = key_builder.input(input_hash);
@@ -2089,7 +2113,15 @@ async fn handle_link_ephemeral(
                 };
             }
             // Fall through to passthrough if write failed
-            return run_tool_passthrough(tool, args, cwd, env, &lineage).await;
+            return run_tool_passthrough(
+                tool,
+                args,
+                cwd,
+                env,
+                &lineage,
+                state.depfile_tmpdir.as_path(),
+            )
+            .await;
         }
         // Payloads missing — treat as cache miss, fall through
     }
@@ -2123,7 +2155,15 @@ async fn handle_link_ephemeral(
     // Clone env for the hook (we need to re-use it; passthrough consumes env).
     let env_for_hook = env.clone();
 
-    let result = run_tool_passthrough(tool, args, cwd, env, &lineage).await;
+    let result = run_tool_passthrough(
+        tool,
+        args,
+        cwd,
+        env,
+        &lineage,
+        state.depfile_tmpdir.as_path(),
+    )
+    .await;
 
     // 6b. Invoke optional post-link deploy command on successful link.
     // This handles the case where the compiler driver does NOT auto-deploy
@@ -2323,16 +2363,21 @@ fn hash_file_via_cache(state: &SharedState, path: &Path) -> Option<ContentHash> 
 }
 
 /// Run a tool directly (passthrough) and return a LinkResult response.
+///
+/// `tmp_dir` is where the synthesized Windows response file lands when the
+/// command line exceeds the OS limit. Production callers pass the daemon's
+/// `state.depfile_tmpdir` (under the cache root) so the contents are
+/// covered by the wrapper's Defender exclusion — see issue #275.
 async fn run_tool_passthrough(
     tool: &Path,
     args: &[String],
     cwd: &Path,
     env: Option<Vec<(String, String)>>,
     lineage: &crate::lineage::Lineage,
+    tmp_dir: &Path,
 ) -> Response {
-    let tmp_dir = std::env::temp_dir();
     let _rsp_guard =
-        match zccache_compiler::response_file::write_response_file_if_needed(args, &tmp_dir) {
+        match zccache_compiler::response_file::write_response_file_if_needed(args, tmp_dir) {
             Ok(guard) => guard,
             Err(e) => {
                 return Response::Error {
@@ -4900,6 +4945,7 @@ async fn handle_compile(
                 &sid,
                 &client_env,
                 &stdin,
+                state.depfile_tmpdir.as_path(),
             )
             .await;
         }
@@ -5169,6 +5215,7 @@ async fn handle_compile(
                     &sid,
                     &client_env,
                     &stdin,
+                    state.depfile_tmpdir.as_path(),
                 )
                 .await;
             }
@@ -7010,6 +7057,11 @@ async fn handle_compile_multi(
 }
 
 /// Run the compiler directly without caching.
+///
+/// `tmp_dir` is where the synthesized Windows response file lands when the
+/// command line exceeds the OS limit. Production callers pass the daemon's
+/// `state.depfile_tmpdir` (under the cache root) so the contents are
+/// covered by the wrapper's Defender exclusion — see issue #275.
 #[allow(clippy::too_many_arguments)] // Mirrors handle_compile's surface — refactor parked.
 async fn run_compiler_direct(
     compiler: &NormalizedPath,
@@ -7019,10 +7071,10 @@ async fn run_compiler_direct(
     sid: &SessionId,
     client_env: &Option<Vec<(String, String)>>,
     stdin_bytes: &[u8],
+    tmp_dir: &Path,
 ) -> Response {
-    let tmp_dir = std::env::temp_dir();
     let _rsp_guard =
-        match zccache_compiler::response_file::write_response_file_if_needed(args, &tmp_dir) {
+        match zccache_compiler::response_file::write_response_file_if_needed(args, tmp_dir) {
             Ok(guard) => guard,
             Err(e) => {
                 return Response::Error {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,6 +23,7 @@ This document is the index for zccache's architecture specification. Each subsys
 - **File change detection** → [metadata-cache.md](architecture/metadata-cache.md)
 - **Disk cache & eviction** → [artifact-store.md](architecture/artifact-store.md)
 - **Thread safety & crash safety** → [runtime.md](architecture/runtime.md)
+- **Where zccache writes on disk (`ZCCACHE_CACHE_DIR` contract)** → [runtime.md § Cache root invariants](architecture/runtime.md#cache-root-invariants)
 - **Windows/macOS/Linux differences** → [portability.md](architecture/portability.md)
 - **Compile journal fields & `miss_reason` enum** → [journal-schema.md](journal-schema.md)
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -20,6 +20,7 @@ Architecture docs are split by subsystem. Read only what's relevant to your curr
 | Perf measurement workflows | [/PERF.md](../PERF.md) — `perf-rust-cluster.yml`, scenarios, gate semantics |
 | Platform-specific issues | [portability.md](architecture/portability.md) |
 | Compile journal record shape | [journal-schema.md](journal-schema.md) |
+| `ZCCACHE_CACHE_DIR` contract + `zccache cache-root` | [runtime.md § Cache root invariants](architecture/runtime.md#cache-root-invariants) |
 
 ## Where to document new features
 

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -142,3 +142,81 @@ The `dep_graph_persisted` flag is also flipped to `true` when a periodic or shut
 **Index-artifact divergence:** If the daemon crashed after writing the artifact directory but before inserting the redb entry, the artifact exists on disk but is not in the index. This is a harmless orphan; it wastes disk space but does not cause incorrect behavior. A periodic (or on-demand) maintenance task can scan the artifact directories and reconcile with the index:
 - Artifact on disk but not in index: add to index.
 - Entry in index but no artifact on disk: remove from index.
+
+---
+
+## Cache root invariants
+
+The "cache root" is the directory resolved by
+[`zccache_core::config::resolve_cache_root`][resolve]. Wrappers (notably
+[soldr](https://github.com/zackees/soldr)) excludable this single directory
+from Windows Defender / on-access scanners and trust that **no zccache
+persistent write escapes it**. Issue #275 closes that contract.
+
+[resolve]: ../../crates/zccache-core/src/config.rs
+
+### Resolution rules
+
+| Source | When it fires | `cache-root --json` value |
+|---|---|---|
+| `ZCCACHE_CACHE_DIR` | Env var set and non-empty | `env:ZCCACHE_CACHE_DIR` |
+| Same-volume colocation | `ZCCACHE_COLOCATE` is truthy *and* CWD is on a different volume from `$HOME` (issue #296) | `colocate:cross_volume` |
+| Default | Otherwise | `default:platform_dirs` (`~/.zccache`) |
+
+`zccache cache-root` (default) prints the resolved absolute path; `--json`
+adds the `source` field so wrappers can verify at runtime that their
+redirect was honored.
+
+### Persistent writes — exhaustive table
+
+Every persistent write the daemon and CLI perform lands under the resolved
+cache root via one of the helpers in `zccache_core::config`:
+
+| Subpath | Owner | Resolver |
+|---|---|---|
+| `artifacts/` | daemon — content-addressed artifact store + sibling tmp files for atomic rename | `artifacts_dir_from_cache_dir` |
+| `tmp/` | daemon — recursively wiped on startup (orphaned in-progress writes) | `tmp_dir_from_cache_dir` |
+| `tmp/depfiles/<pid>-<instance>/` | daemon — compiler-injected depfiles and Windows response files (`*.rsp`) | `depfile_dir_from_cache_dir` |
+| `depgraph/depgraph.bin` | daemon — rkyv snapshot of the dep graph | `depgraph_file_path` |
+| `logs/daemon.log[.<ts>]` | daemon — rolling event log | `log_dir_from_cache_dir` |
+| `logs/daemon-lifecycle.log[.1]` | daemon + CLI — JSONL lifecycle events (spawn / shutdown / version mismatch) | `lifecycle::log_file_path` |
+| `logs/compile_journal.jsonl` + per-session `*.jsonl` | daemon — compile decisions | derives from `log_dir_from_cache_dir` |
+| `crashes/crash-*.{txt,dmp}` + `.reported` | daemon — panic & signal dumps | `crash_dump_dir_from_cache_dir` |
+| `symbols/<version>-<triple>/` + `.symref` sidecars next to dumps | CLI — `zccache symbols install` + `symbolicate` | `symbols_cache_dir_from_cache_dir` |
+| `index.bin` (+ sibling tmp) | daemon — bincode artifact index, atomic-rename writes | `index_path_from_cache_dir` |
+| `ino/<key>.ino.cpp` | CLI — Arduino preprocessor cache | `default_cache_dir().join("ino")` |
+| `kv/<namespace>/<hex>.bin` | CLI — namespaced key/value store | derives from `default_cache_dir` |
+| `daemon.lock` | CLI + daemon — PID lock | `lock_file_path` |
+| `daemon.sock` (Unix, only when env override is set) | daemon — IPC socket co-located with the cache root | `default_endpoint` |
+
+The cache-root-rooted invariant for the well-known subpaths is asserted in
+the unit test `cache_root_invariant_all_subpaths_rooted` in
+`crates/zccache-core/src/config.rs`.
+
+### Legitimate exceptions (documented and stable)
+
+A small set of writes is intentionally *outside* the cache root. soldr
+excludes these separately if Defender scanning ever becomes an issue:
+
+- **IPC socket (Unix, no env override):** `$XDG_RUNTIME_DIR/zccache/sock`
+  or `/tmp/zccache-$USER/sock`. The socket inode lives in `tmpfs` on Linux
+  so it is not a real on-disk write. When `ZCCACHE_CACHE_DIR` is set, the
+  socket moves into `<cache>/daemon.sock` automatically — see
+  `zccache_ipc::endpoint_for_cache_dir`.
+- **Named pipe (Windows):** `\\.\pipe\zccache-<username>` (default) or
+  `\\.\pipe\zccache-<stable-id>` (when `ZCCACHE_CACHE_DIR` is set). Named
+  pipes have no filesystem footprint — nothing for Defender to scan.
+- **OS-managed working directory (`std::env::set_current_dir(temp_dir())`):**
+  the daemon's `trampoline::release_cwd()` chdirs the process to `$TMPDIR`
+  *only* to release the inherited CWD handle. No file is written there.
+- **`.claude/`, `target/`, scratch tempdirs in dev-mode tests:** test code
+  paths and dev tooling. Production runtime never writes here. The
+  `ban_unrooted_tempdir` dylint blocks new ad-hoc `tempfile::tempdir()`
+  call sites in production code; legacy call sites are listed explicitly
+  in `dylints/ban_unrooted_tempdir/src/allowlist.txt`.
+
+Any new persistent write must either pick a helper from the table above or
+get its own row plus a one-line justification here. The dylint catches
+unrooted `$TMPDIR` writes at compile time, but it cannot catch writes that
+hardcode an absolute path outside the cache root — those have to be caught
+in review against this section.


### PR DESCRIPTION
Closes #275.

## Summary

Adds a new `zccache cache-root` introspection subcommand and audits every
persistent write site to confirm nothing escapes the resolved cache root.
This unblocks the soldr Defender-exclusion contract (soldr#358) by giving
the wrapper a deterministic way to verify the redirect.

- `zccache cache-root` prints the absolute resolved path.
- `zccache cache-root --json` emits
  `{"cache_root":"<abs>", "source":"env:ZCCACHE_CACHE_DIR" | "colocate:cross_volume" | "default:platform_dirs"}`.
- Routed `run_tool_passthrough` + `run_compiler_direct` off
  `std::env::temp_dir()` and onto `state.depfile_tmpdir` (under the cache
  root) for the Windows response-file writes. These were the only two
  persistent escapes found in `zccache-daemon` / `zccache-compiler` /
  `zccache-artifact` / `zccache-fscache` / `zccache-fingerprint` /
  `zccache-watcher`.
- New `Cache root invariants` section in
  `docs/architecture/runtime.md` documents the exhaustive write-path
  table and the legitimate exceptions (IPC socket on Unix, named pipe on
  Windows, the cwd swap in `release_cwd`).
- No protocol change: the CLI resolves the cache root locally.

## Test plan

- [x] `soldr cargo test -p zccache-core --lib` — 62 pass (incl. new
  `cache_root_invariant_all_subpaths_rooted` + the 4 `resolve_cache_root_*`
  unit tests).
- [x] `soldr cargo test -p zccache-cli --test cache_root` — 4 pass.
- [x] `soldr cargo test -p zccache-daemon --lib` — 223 pass, no regressions
  from the `run_tool_passthrough` / `run_compiler_direct` signature
  changes.
- [x] `soldr cargo test --workspace --lib` — all green.
- [x] `RUSTFLAGS=\"-D warnings\" soldr cargo build -p zccache-cli -p zccache-daemon -p zccache-core` clean.
- [x] `RUSTFLAGS=\"-D warnings\" soldr cargo clippy --workspace --all-targets -- -D warnings` clean.

## Wrapper verification (post-merge)

```
$ zccache cache-root
/home/user/.zccache
$ ZCCACHE_CACHE_DIR=/tmp/foo zccache cache-root --json
{"cache_root":"/tmp/foo","source":"env:ZCCACHE_CACHE_DIR"}
```

Cross-references: zackees/soldr#358, zccache#273.