### PR TITLE
feat(cli): zccache defender-exclusions helper (closes #273)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,35 @@ stores them with the primary link artifact. Later cache hits restore the full
 artifact set to the output directory, so tools such as `clang-tool-chain` runtime
 deployment work without per-build-system post-link hooks.
 
+### Windows: Defender exclusions
+
+Windows Defender's real-time scanner inspects every freshly written file before
+the write returns. zccache writes hundreds of `.rmeta` / `.rlib` / `.o` files per
+cold build, and on an unexcluded cache directory each one pays the Defender
+round-trip — multi-minute slowdowns are routine and invisible to zccache's own
+telemetry (the daemon sees its writes complete normally; the wall clock balloons
+between `write()` and the bytes reaching disk).
+
+The fix is a one-time exclusion. zccache ships a helper so you don't have to
+hand-craft the PowerShell:
+
+```powershell
+# Show whether the cache root is excluded. Read-only — no elevation needed.
+zccache defender-exclusions check
+
+# Add the exclusion. Requires an elevated PowerShell or Administrator cmd.
+zccache defender-exclusions add
+
+# Undo.
+zccache defender-exclusions remove
+```
+
+On Windows, the daemon prints a one-line stderr warning at startup if the cache
+directory isn't excluded yet. Silence it with `ZCCACHE_QUIET=1`. The
+`defender-exclusions` subcommand is available on every platform — non-Windows
+hosts print `Defender exclusion is Windows-only.` and exit 0 so cross-platform
+scripts can call it unconditionally.
+
 ## Install
 
 ```bash

--- a/crates/zccache-cli/src/defender.rs
+++ b/crates/zccache-cli/src/defender.rs
@@ -1,0 +1,166 @@
+//! `zccache defender-exclusions` CLI commands (issue #273).
+//!
+//! Thin shell over [`zccache_core::defender`]. The path-set computation,
+//! token elevation check, and PowerShell subprocess plumbing all live in
+//! `zccache-core` so the daemon's first-run banner can reuse them.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+use zccache_core::defender::{
+    add_exclusions, compute_exclusion_paths, is_elevated, query_excluded, remove_exclusions,
+    ExclusionStatus,
+};
+
+/// Stderr line printed when an unprivileged caller runs `add` or `remove`.
+const REELEVATE_MSG: &str = "zccache defender-exclusions: this command requires administrator \
+elevation. Re-run from an elevated PowerShell or Administrator cmd.";
+
+/// Cache root used by every subcommand. Centralized so a future
+/// `zccache cache-root` (issue #275) only changes one site.
+fn resolved_cache_root() -> PathBuf {
+    zccache_core::config::default_cache_dir().into_path_buf()
+}
+
+/// On non-Windows, every subcommand prints the same one-liner and exits
+/// cleanly so cross-platform scripts can call `defender-exclusions add`
+/// unconditionally without branching on OS.
+fn windows_only_noop() -> ExitCode {
+    println!("Defender exclusion is Windows-only.");
+    ExitCode::SUCCESS
+}
+
+pub fn cmd_check(json: bool) -> ExitCode {
+    if !cfg!(windows) {
+        if json {
+            let doc = serde_json::json!({
+                "supported": false,
+                "platform": std::env::consts::OS,
+                "message": "Defender exclusion is Windows-only.",
+            });
+            println!("{doc}");
+            return ExitCode::SUCCESS;
+        }
+        return windows_only_noop();
+    }
+
+    let cache_root = resolved_cache_root();
+    let paths = compute_exclusion_paths(&cache_root);
+
+    match query_excluded(&paths) {
+        Ok(statuses) => {
+            if json {
+                print_check_json(&cache_root, &statuses, None);
+            } else {
+                print_check_human(&cache_root, &statuses);
+            }
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            if json {
+                let placeholders: Vec<ExclusionStatus> = paths
+                    .iter()
+                    .map(|p| ExclusionStatus {
+                        path: p.clone(),
+                        excluded: false,
+                    })
+                    .collect();
+                print_check_json(&cache_root, &placeholders, Some(&err.to_string()));
+            } else {
+                eprintln!("zccache defender-exclusions: {err}");
+            }
+            // Failing to query is not fatal — return non-zero so scripts
+            // can distinguish "all excluded" (0) from "unknown" (2).
+            ExitCode::from(2)
+        }
+    }
+}
+
+pub fn cmd_add() -> ExitCode {
+    if !cfg!(windows) {
+        return windows_only_noop();
+    }
+    if !is_elevated() {
+        eprintln!("{REELEVATE_MSG}");
+        return ExitCode::FAILURE;
+    }
+    let cache_root = resolved_cache_root();
+    let paths = compute_exclusion_paths(&cache_root);
+    match add_exclusions(&paths) {
+        Ok(()) => {
+            for p in &paths {
+                println!("added: {}", p.display());
+            }
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("zccache defender-exclusions add: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+pub fn cmd_remove() -> ExitCode {
+    if !cfg!(windows) {
+        return windows_only_noop();
+    }
+    if !is_elevated() {
+        eprintln!("{REELEVATE_MSG}");
+        return ExitCode::FAILURE;
+    }
+    let cache_root = resolved_cache_root();
+    let paths = compute_exclusion_paths(&cache_root);
+    match remove_exclusions(&paths) {
+        Ok(()) => {
+            for p in &paths {
+                println!("removed: {}", p.display());
+            }
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("zccache defender-exclusions remove: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn print_check_human(cache_root: &std::path::Path, statuses: &[ExclusionStatus]) {
+    println!("cache root: {}", cache_root.display());
+    println!("paths checked:");
+    for s in statuses {
+        let tag = if s.excluded { "yes" } else { "no" };
+        println!("  [{tag:3}] {}", s.path.display());
+    }
+    let any_unexcluded = statuses.iter().any(|s| !s.excluded);
+    if any_unexcluded {
+        println!();
+        println!(
+            "hint: run 'zccache defender-exclusions add' from an elevated shell \
+             to exclude these paths."
+        );
+    }
+}
+
+fn print_check_json(
+    cache_root: &std::path::Path,
+    statuses: &[ExclusionStatus],
+    error: Option<&str>,
+) {
+    let paths: Vec<serde_json::Value> = statuses
+        .iter()
+        .map(|s| {
+            serde_json::json!({
+                "path": s.path.display().to_string(),
+                "excluded": s.excluded,
+            })
+        })
+        .collect();
+    let doc = serde_json::json!({
+        "supported": true,
+        "platform": std::env::consts::OS,
+        "cache_root": cache_root.display().to_string(),
+        "paths": paths,
+        "all_excluded": statuses.iter().all(|s| s.excluded) && !statuses.is_empty(),
+        "error": error,
+    });
+    println!("{doc}");
+}

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -22,6 +22,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL_WIN: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+mod defender;
 mod snapshot_fp;
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -372,6 +373,13 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Inspect or modify Windows Defender real-time-scan exclusions for the
+    /// cache root. No-ops cleanly on non-Windows. See `zccache#273`.
+    #[command(name = "defender-exclusions")]
+    DefenderExclusions {
+        #[command(subcommand)]
+        action: DefenderExclusionsCommands,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -409,6 +417,25 @@ enum SymbolsCommands {
         #[arg(required = true)]
         dumps: Vec<PathBuf>,
     },
+}
+
+#[derive(Debug, Subcommand)]
+enum DefenderExclusionsCommands {
+    /// Print whether the resolved cache root (and any sibling `runtime/`)
+    /// is on Defender's exclusion list. Non-destructive — no elevation
+    /// needed. Use `--json` for machine-readable output.
+    Check {
+        /// Emit a JSON document on stdout instead of human-readable text.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Add the cache root (and any sibling `runtime/`) to Defender's
+    /// exclusion list. Requires administrator elevation; exits non-zero
+    /// with instructions when run from a non-elevated shell.
+    Add,
+    /// Remove the cache root (and any sibling `runtime/`) from Defender's
+    /// exclusion list. Requires administrator elevation.
+    Remove,
 }
 
 #[derive(Debug, Subcommand)]
@@ -700,6 +727,7 @@ const KNOWN_SUBCOMMANDS: &[&str] = &[
     "snapshot-fp-validate",
     "symbols",
     "cache-root",
+    "defender-exclusions",
     "help",
     "--help",
     "-h",
@@ -1035,6 +1063,11 @@ fn main() -> ExitCode {
             SymbolsCommands::Symbolicate { dumps } => cmd_symbols_symbolicate(dumps),
         },
         Commands::CacheRoot { json } => cmd_cache_root(json),
+        Commands::DefenderExclusions { action } => match action {
+            DefenderExclusionsCommands::Check { json } => defender::cmd_check(json),
+            DefenderExclusionsCommands::Add => defender::cmd_add(),
+            DefenderExclusionsCommands::Remove => defender::cmd_remove(),
+        },
     }
 }
 

--- a/crates/zccache-cli/tests/defender_exclusions.rs
+++ b/crates/zccache-cli/tests/defender_exclusions.rs
@@ -1,0 +1,85 @@
+//! Integration tests for `zccache defender-exclusions` (issue #273).
+//!
+//! On non-Windows the subcommand must be a clean no-op so cross-platform
+//! scripts can invoke it unconditionally. On Windows runners we only
+//! exercise the read-only `check` mode — the destructive `add`/`remove`
+//! verbs touch real machine state and need an admin shell, so we stay
+//! out of them in CI.
+
+use std::process::Command;
+
+fn zccache_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_zccache")
+}
+
+#[cfg(not(windows))]
+#[test]
+fn non_windows_check_exits_zero_with_known_message() {
+    let out = Command::new(zccache_bin())
+        .args(["defender-exclusions", "check"])
+        .output()
+        .expect("spawn zccache");
+    assert!(
+        out.status.success(),
+        "expected exit 0, got {:?}; stderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Defender exclusion is Windows-only."),
+        "stdout={stdout}"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn non_windows_check_json_emits_supported_false() {
+    let out = Command::new(zccache_bin())
+        .args(["defender-exclusions", "check", "--json"])
+        .output()
+        .expect("spawn zccache");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid json");
+    assert_eq!(v["supported"], serde_json::Value::Bool(false));
+    assert!(v["message"].as_str().unwrap_or("").contains("Windows-only"));
+}
+
+#[cfg(not(windows))]
+#[test]
+fn non_windows_add_and_remove_exit_zero() {
+    for sub in ["add", "remove"] {
+        let out = Command::new(zccache_bin())
+            .args(["defender-exclusions", sub])
+            .output()
+            .expect("spawn zccache");
+        assert!(out.status.success(), "{sub} should no-op on non-Windows");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("Defender exclusion is Windows-only."),
+            "{sub} stdout={stdout}"
+        );
+    }
+}
+
+/// On Windows runners `check` is read-only and must not crash.
+///
+/// Either Defender responds (exit 0) or PowerShell/Defender isn't
+/// reachable in the runner environment (exit 2 — "unknown"). Anything
+/// else is a regression.
+#[cfg(windows)]
+#[test]
+fn windows_check_is_safe_to_invoke() {
+    let out = Command::new(zccache_bin())
+        .args(["defender-exclusions", "check"])
+        .output()
+        .expect("spawn zccache");
+    let code = out.status.code().unwrap_or(-1);
+    assert!(
+        code == 0 || code == 2,
+        "unexpected exit {code}; stdout={}; stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/crates/zccache-core/Cargo.toml
+++ b/crates/zccache-core/Cargo.toml
@@ -29,4 +29,9 @@ libc = "0.2"
 tempfile = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Threading",
+] }

--- a/crates/zccache-core/src/defender.rs
+++ b/crates/zccache-core/src/defender.rs
@@ -1,0 +1,423 @@
+//! Windows Defender exclusion helper (issue #273).
+//!
+//! Cold zccache builds on Windows pay a multi-minute penalty when Defender
+//! real-time-scans every freshly written `.rmeta` / `.rlib` / `.o` file in
+//! the cache directory. The fix is a one-time `Add-MpPreference
+//! -ExclusionPath` against the cache root.
+//!
+//! This module exposes:
+//! - [`compute_exclusion_paths`] — the set of paths that should be excluded
+//!   for a given cache root (the root itself plus sibling dirs).
+//! - [`is_elevated`] — Windows token-elevation check (always `true` off Windows).
+//! - [`is_quiet_env`] — honours `ZCCACHE_QUIET=1` to suppress the daemon
+//!   first-run banner.
+//! - Windows-only [`query_excluded`] / [`add_exclusions`] / [`remove_exclusions`]
+//!   — thin wrappers around PowerShell's `Get-MpPreference` /
+//!   `Add-MpPreference` / `Remove-MpPreference`. Non-Windows builds get
+//!   no-op stubs that report the platform as unsupported.
+//!
+//! Subprocess errors (PowerShell missing, Defender service down, access
+//! denied) surface as [`DefenderError`] and are never treated as fatal at
+//! call sites — a perf hint is not worth crashing the daemon.
+
+use std::path::{Path, PathBuf};
+
+/// Suppression env var for the daemon's first-run "not excluded" banner.
+///
+/// Any non-empty value other than `"0"` silences the banner. CI / scripted
+/// callers can set this once and forget. The user-visible `defender-exclusions
+/// check` subcommand is unaffected — it always prints.
+pub const QUIET_ENV: &str = "ZCCACHE_QUIET";
+
+/// Returns the de-duplicated set of paths that should be on Defender's
+/// exclusion list for a given resolved cache root.
+///
+/// The cache root itself is always included. A sibling `runtime/`
+/// directory (managed-binary cache from soldr-style integrations) is
+/// included when it currently exists on disk — there is no point asking
+/// Defender to exclude a path that the daemon never writes into.
+///
+/// Pure function — no I/O beyond `Path::exists()`. Stable ordering so the
+/// JSON output of `defender-exclusions check` is reproducible.
+#[must_use]
+pub fn compute_exclusion_paths(cache_root: &Path) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::with_capacity(2);
+    out.push(cache_root.to_path_buf());
+
+    if let Some(parent) = cache_root.parent() {
+        let runtime = parent.join("runtime");
+        if runtime.exists() && runtime != cache_root {
+            out.push(runtime);
+        }
+    }
+
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// True when the running process has elevated (administrator) rights.
+///
+/// On Windows we query the process token for `TokenElevation`. On every
+/// other platform we return `true` — non-Windows callers never need
+/// elevation for the Defender flow because the flow is a no-op there.
+#[cfg(windows)]
+#[must_use]
+pub fn is_elevated() -> bool {
+    use std::mem::size_of;
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows_sys::Win32::Security::{
+        GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY,
+    };
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    unsafe {
+        let mut token: HANDLE = std::ptr::null_mut();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
+            return false;
+        }
+        let mut elevation = TOKEN_ELEVATION { TokenIsElevated: 0 };
+        let mut size: u32 = 0;
+        #[allow(clippy::cast_possible_truncation)]
+        let ok = GetTokenInformation(
+            token,
+            TokenElevation,
+            std::ptr::from_mut::<TOKEN_ELEVATION>(&mut elevation).cast(),
+            size_of::<TOKEN_ELEVATION>() as u32,
+            &mut size,
+        );
+        CloseHandle(token);
+        ok != 0 && elevation.TokenIsElevated != 0
+    }
+}
+
+#[cfg(not(windows))]
+#[must_use]
+pub fn is_elevated() -> bool {
+    true
+}
+
+/// True when `ZCCACHE_QUIET` is set to a non-empty value other than `"0"`.
+#[must_use]
+pub fn is_quiet_env() -> bool {
+    quiet_value_silences(std::env::var(QUIET_ENV).ok().as_deref())
+}
+
+/// Predicate version of [`is_quiet_env`] that operates on a borrowed
+/// value instead of reading the process environment — lets unit tests
+/// exercise the rule without `unsafe` env mutation.
+#[must_use]
+pub fn quiet_value_silences(value: Option<&str>) -> bool {
+    value.is_some_and(|v| !v.is_empty() && v != "0")
+}
+
+/// Emit a single stderr line if the daemon's cache root is not on the
+/// Windows Defender exclusion list. Best-effort: any query failure is
+/// silenced (the banner is a perf hint, not a diagnostic the operator
+/// asked for). No-ops cleanly off Windows and when
+/// [`QUIET_ENV`] is set.
+///
+/// Called from `zccache-daemon`'s `run_server` so the warning lands on
+/// the daemon's redirected stderr — eventually the user's terminal — on
+/// every fresh start.
+pub fn maybe_emit_first_run_banner(cache_root: &Path) {
+    if !cfg!(windows) {
+        return;
+    }
+    if is_quiet_env() {
+        return;
+    }
+    let paths = compute_exclusion_paths(cache_root);
+    let Ok(statuses) = query_excluded(&paths) else {
+        return;
+    };
+    let cache_root_excluded = statuses
+        .iter()
+        .find(|s| s.path == cache_root)
+        .is_some_and(|s| s.excluded);
+    if !cache_root_excluded {
+        eprintln!(
+            "warning: zccache cache dir is not in Windows Defender exclusion list. \
+             Run 'zccache defender-exclusions add' (as administrator) to fix."
+        );
+    }
+}
+
+/// Errors returned by the Windows Defender PowerShell wrappers.
+#[derive(Debug)]
+pub enum DefenderError {
+    /// The current platform is not Windows. Callers should treat this as
+    /// a clean no-op (print the platform message, exit 0) rather than a
+    /// failure.
+    Unsupported,
+    /// `powershell.exe` could not be located on PATH.
+    PowerShellNotFound,
+    /// `powershell.exe` exited non-zero.
+    PowerShellFailed {
+        exit_code: Option<i32>,
+        stderr: String,
+    },
+    /// PowerShell stdout could not be parsed.
+    OutputParse(String),
+    /// An I/O error occurred spawning or reading from the child process.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for DefenderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unsupported => write!(f, "Defender exclusion is Windows-only."),
+            Self::PowerShellNotFound => write!(
+                f,
+                "powershell.exe not found on PATH (required to query Windows Defender)"
+            ),
+            Self::PowerShellFailed { exit_code, stderr } => {
+                write!(f, "powershell exited")?;
+                if let Some(code) = exit_code {
+                    write!(f, " with code {code}")?;
+                }
+                let trimmed = stderr.trim();
+                if !trimmed.is_empty() {
+                    write!(f, ": {trimmed}")?;
+                }
+                Ok(())
+            }
+            Self::OutputParse(msg) => write!(f, "failed to parse PowerShell output: {msg}"),
+            Self::Io(err) => write!(f, "io error invoking powershell: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for DefenderError {}
+
+impl From<std::io::Error> for DefenderError {
+    fn from(value: std::io::Error) -> Self {
+        if value.kind() == std::io::ErrorKind::NotFound {
+            Self::PowerShellNotFound
+        } else {
+            Self::Io(value)
+        }
+    }
+}
+
+/// Status of a single path in Defender's exclusion list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExclusionStatus {
+    pub path: PathBuf,
+    pub excluded: bool,
+}
+
+#[cfg(windows)]
+mod windows_impl {
+    use super::{DefenderError, ExclusionStatus};
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    /// Run `Get-MpPreference | Select-Object -ExpandProperty ExclusionPath`
+    /// once and check membership locally. One subprocess regardless of how
+    /// many paths are being checked — Defender's exclusion list is small
+    /// and stable.
+    pub fn query_excluded(paths: &[PathBuf]) -> Result<Vec<ExclusionStatus>, DefenderError> {
+        let raw = run_powershell(&[
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "(Get-MpPreference).ExclusionPath",
+        ])?;
+        let excluded: Vec<String> = raw
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect();
+        Ok(paths
+            .iter()
+            .map(|p| ExclusionStatus {
+                path: p.clone(),
+                excluded: path_matches_any(p, &excluded),
+            })
+            .collect())
+    }
+
+    pub fn add_exclusions(paths: &[PathBuf]) -> Result<(), DefenderError> {
+        for p in paths {
+            let arg = quote_for_powershell(p);
+            run_powershell(&[
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                &format!("Add-MpPreference -ExclusionPath {arg}"),
+            ])?;
+        }
+        Ok(())
+    }
+
+    pub fn remove_exclusions(paths: &[PathBuf]) -> Result<(), DefenderError> {
+        for p in paths {
+            let arg = quote_for_powershell(p);
+            run_powershell(&[
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                &format!("Remove-MpPreference -ExclusionPath {arg}"),
+            ])?;
+        }
+        Ok(())
+    }
+
+    fn run_powershell(args: &[&str]) -> Result<String, DefenderError> {
+        let output = Command::new("powershell.exe").args(args).output()?;
+        if !output.status.success() {
+            return Err(DefenderError::PowerShellFailed {
+                exit_code: output.status.code(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            });
+        }
+        String::from_utf8(output.stdout).map_err(|e| DefenderError::OutputParse(e.to_string()))
+    }
+
+    /// Defender exclusion paths are stored in whatever form the user
+    /// supplied to `Add-MpPreference`. Normalise both sides before
+    /// comparing so `C:\Users\me\.zccache` matches `C:/Users/me/.zccache`
+    /// and trailing separators don't cause false negatives.
+    fn path_matches_any(needle: &Path, haystack: &[String]) -> bool {
+        let needle_norm = normalize_for_compare(needle);
+        haystack
+            .iter()
+            .any(|h| normalize_for_compare(Path::new(h)) == needle_norm)
+    }
+
+    fn normalize_for_compare(p: &Path) -> String {
+        let s: String = p.to_string_lossy().replace('/', "\\");
+        let trimmed = s.trim_end_matches('\\');
+        trimmed.to_ascii_lowercase()
+    }
+
+    fn quote_for_powershell(p: &Path) -> String {
+        // Single-quote so PowerShell does not expand `$`; double single
+        // quotes inside escape the quote character. Paths in Windows do
+        // not contain single quotes in practice, but guard anyway.
+        let s = p.to_string_lossy();
+        format!("'{}'", s.replace('\'', "''"))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn normalize_for_compare_canonicalizes() {
+            assert_eq!(
+                normalize_for_compare(Path::new("C:/Users/me/.zccache")),
+                normalize_for_compare(Path::new("C:\\Users\\me\\.zccache\\"))
+            );
+        }
+
+        #[test]
+        fn path_matches_any_is_case_insensitive() {
+            let cands = vec!["C:\\Users\\Me\\.zccache".to_string()];
+            assert!(path_matches_any(Path::new("c:/users/me/.zccache"), &cands));
+        }
+
+        #[test]
+        fn quote_for_powershell_escapes_single_quote() {
+            let p = Path::new("C:/it's/weird");
+            assert_eq!(quote_for_powershell(p), "'C:/it''s/weird'");
+        }
+    }
+}
+
+#[cfg(windows)]
+pub use windows_impl::{add_exclusions, query_excluded, remove_exclusions};
+
+#[cfg(not(windows))]
+pub fn query_excluded(_paths: &[PathBuf]) -> Result<Vec<ExclusionStatus>, DefenderError> {
+    Err(DefenderError::Unsupported)
+}
+
+#[cfg(not(windows))]
+pub fn add_exclusions(_paths: &[PathBuf]) -> Result<(), DefenderError> {
+    Err(DefenderError::Unsupported)
+}
+
+#[cfg(not(windows))]
+pub fn remove_exclusions(_paths: &[PathBuf]) -> Result<(), DefenderError> {
+    Err(DefenderError::Unsupported)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn compute_paths_includes_cache_root() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("cache");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let paths = compute_exclusion_paths(&root);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], root);
+    }
+
+    #[test]
+    fn compute_paths_picks_up_sibling_runtime() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("cache");
+        let runtime = tmp.path().join("runtime");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&runtime).unwrap();
+
+        let paths = compute_exclusion_paths(&root);
+        assert_eq!(paths.len(), 2);
+        assert!(paths.iter().any(|p| p == &root));
+        assert!(paths.iter().any(|p| p == &runtime));
+    }
+
+    #[test]
+    fn compute_paths_skips_missing_runtime() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("cache");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let paths = compute_exclusion_paths(&root);
+        assert_eq!(paths.len(), 1);
+    }
+
+    #[test]
+    fn compute_paths_is_deduped_and_sorted() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("cache");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let paths = compute_exclusion_paths(&root);
+        let mut sorted = paths.clone();
+        sorted.sort();
+        assert_eq!(paths, sorted);
+    }
+
+    #[test]
+    fn quiet_value_silences_only_for_meaningful_values() {
+        assert!(!quiet_value_silences(None));
+        assert!(!quiet_value_silences(Some("")));
+        assert!(!quiet_value_silences(Some("0")));
+        assert!(quiet_value_silences(Some("1")));
+        assert!(quiet_value_silences(Some("true")));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn non_windows_is_elevated_true() {
+        // Non-Windows always reports elevated so the Defender flow no-ops
+        // cleanly on macOS / Linux.
+        assert!(is_elevated());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn non_windows_query_returns_unsupported() {
+        let err = query_excluded(&[PathBuf::from("/tmp/x")]).unwrap_err();
+        assert!(matches!(err, DefenderError::Unsupported));
+        assert_eq!(format!("{err}"), "Defender exclusion is Windows-only.");
+    }
+}

--- a/crates/zccache-core/src/lib.rs
+++ b/crates/zccache-core/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod config;
 pub mod crash;
+pub mod defender;
 pub mod error;
 pub mod lifecycle;
 pub mod path;

--- a/crates/zccache-daemon/src/main.rs
+++ b/crates/zccache-daemon/src/main.rs
@@ -171,6 +171,12 @@ fn run_server(args: Args) {
 
     tracing::info!(%endpoint, idle_timeout, "zccache-daemon starting");
 
+    // Issue #273: on Windows, warn once on stderr if the cache dir is
+    // not on Defender's exclusion list. Non-fatal; no-ops off Windows
+    // and when `ZCCACHE_QUIET` is set.
+    let cache_root = zccache_core::config::default_cache_dir();
+    zccache_core::defender::maybe_emit_first_run_banner(cache_root.as_path());
+
     // Persist a "spawn" lifecycle event to disk. tracing logs go to
     // stderr which is detached to NUL, so this file-based sink is the
     // only way an operator (or CI) can correlate daemon lifetime with

--- a/crates/zccache-daemon/tests/depgraph_warm_classify_test.rs
+++ b/crates/zccache-daemon/tests/depgraph_warm_classify_test.rs
@@ -87,6 +87,7 @@ async fn start_session_and_capture_log(endpoint: &str, log_file: &std::path::Pat
             log_file: Some(log_file.to_string_lossy().into_owned().into()),
             track_stats: false,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();


### PR DESCRIPTION
Closes #273

## Summary

Cold zccache builds on Windows pay multi-minute Defender real-time-scan
penalties on every cached artifact write. zccache's own telemetry can't see
it (the daemon sees writes complete; wall clock balloons between `write()`
and the bytes landing on disk). One-time Defender exclusion fixes it
completely, but most users don't know to set one.

Add a `zccache defender-exclusions` subcommand with three modes that
collapse the fix into a single, copy-pasteable command:

- `check` — print exclusion status (human-readable + `--json`),
  non-destructive, no elevation required.
- `add` — add the cache root (and any sibling `runtime/`) via
  `Add-MpPreference -ExclusionPath`. Requires admin; exits non-zero with
  a "re-run from elevated shell" message otherwise — never attempts UAC.
- `remove` — symmetric undo of `add`.

Non-Windows hosts print `Defender exclusion is Windows-only.` and exit 0,
so cross-platform scripts can call the subcommand unconditionally.

The Windows daemon emits a one-line stderr warning on startup when the
cache root isn't excluded. Suppressible via `ZCCACHE_QUIET=1`. Non-fatal.

Path-set computation, token-elevation detection
(`GetTokenInformation`/`TokenElevation`), the quiet-env predicate, and the
PowerShell subprocess plumbing live in `zccache-core::defender` so the
daemon's first-run banner and the CLI subcommands share one
implementation.

## Test plan

- [x] `soldr cargo test -p zccache-core --lib` — 65 passed (incl. 8 new
  `defender::*` unit tests covering path-set computation, quiet-env
  predicate, Windows path matching/quoting, and the non-Windows
  unsupported path).
- [x] `soldr cargo test -p zccache-cli --test defender_exclusions` —
  integration test for non-Windows (no-op behavior, exit code, JSON
  shape) and Windows (read-only `check` smoke).
- [x] `soldr cargo test -p zccache-cli --lib` and `--bin zccache` — 31 +
  53 passed, no regressions.
- [x] `soldr cargo test -p zccache-daemon --lib` — 223 passed.
- [x] `soldr cargo clippy -p zccache-core -p zccache-cli -p zccache-daemon
  --all-targets -- -D warnings` — clean.
- [x] `soldr cargo fmt --all -- --check` — clean.
- [x] `RUSTDOCFLAGS="-D warnings" soldr cargo doc --no-deps` — clean.
- [x] Manual smoke on Windows: `zccache defender-exclusions check`,
  `--json`, and unelevated `add` (correctly errors with re-elevate
  message and exit 1).

## Notes

- Wire-format unchanged; no `PROTOCOL_VERSION` bump needed.
- `zccache-core` gains `Win32_Security` and `Win32_System_Threading`
  windows-sys features for the elevation check.
- README has a new "Windows: Defender exclusions" subsection under
  "Performance" explaining the perf cost and the fix command.