### PR TITLE
feat(observability): session-start --profile + zccache analyze rollup

### DIFF
--- a/crates/zccache-cli/src/lib.rs
+++ b/crates/zccache-cli/src/lib.rs
@@ -893,6 +893,7 @@ pub fn client_session_start(
             log_file,
             track_stats,
             journal_path,
+            profile: false,
         })
         .await
         .map_err(|e| format!("failed to send to daemon: {e}"))?;

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -89,6 +89,23 @@ enum Commands {
         /// Print the analysis as a JSON document on stdout.
         #[arg(long)]
         json: bool,
+        /// Restrict the rollup to a single session id.
+        #[arg(long)]
+        session: Option<String>,
+        /// Restrict the rollup to a single crate by `--crate-name`.
+        #[arg(long = "crate")]
+        crate_name: Option<String>,
+        /// Restrict the rollup to one outcome class: `hit`, `miss`,
+        /// or `non-cacheable` (errors and link records pass through).
+        #[arg(long)]
+        outcome: Option<String>,
+        /// Sort order for the human-readable per-crate table.
+        /// One of `wall-clock` (default), `misses`, `hits`.
+        #[arg(long, default_value = "wall-clock")]
+        sort: String,
+        /// Limit the per-crate table to the top N rows.
+        #[arg(long)]
+        top: Option<usize>,
     },
     /// Clear the artifact cache.
     Clear,
@@ -110,6 +127,14 @@ enum Commands {
         /// Write a per-session JSONL compile journal to this path (must end in .jsonl).
         #[arg(long)]
         journal: Option<String>,
+        /// Issue #256: opt in to the extended journal schema.
+        /// When set, every compile journal line written for this
+        /// session also carries `crate_name`, `crate_type`,
+        /// `output_ext`, and `self_profile_ns` span timings.
+        /// When omitted, behavior is identical to releases before
+        /// the flag existed (no new allocations, no extra fields).
+        #[arg(long)]
+        profile: bool,
     },
     /// End a build session.
     #[command(name = "session-end")]
@@ -755,7 +780,25 @@ fn main() -> ExitCode {
             let endpoint = resolve_endpoint(None);
             run_async(cmd_status(&endpoint, json))
         }
-        Commands::Analyze { journal, json } => cmd_analyze(&journal, json),
+        Commands::Analyze {
+            journal,
+            json,
+            session,
+            crate_name,
+            outcome,
+            sort,
+            top,
+        } => cmd_analyze(
+            &journal,
+            AnalyzeOptions {
+                json,
+                session,
+                crate_name,
+                outcome,
+                sort,
+                top,
+            },
+        ),
         Commands::Clear => {
             let endpoint = resolve_endpoint(None);
             run_async(cmd_clear(&endpoint))
@@ -824,6 +867,7 @@ fn main() -> ExitCode {
             endpoint,
             stats,
             journal,
+            profile,
         } => {
             let endpoint = resolve_endpoint(endpoint.as_deref());
             let cwd = cwd
@@ -843,6 +887,7 @@ fn main() -> ExitCode {
                 log.as_deref(),
                 stats,
                 journal,
+                profile,
             ))
         }
         Commands::SessionEnd {
@@ -1450,12 +1495,60 @@ fn print_status_error_json(endpoint: &str, message: &str) {
     print_json_value(&value);
 }
 
-fn cmd_analyze(journal_path: &str, json: bool) -> ExitCode {
-    let report = match analyze_journal(journal_path) {
+/// Filters and sort/limit knobs for `zccache analyze`. Constructed
+/// from the matching CLI flags (issue #256). All filters are
+/// permissive: when `None`/missing on a journal line the filter
+/// passes (so legacy journals that lack `crate_name` still flow
+/// through when no `--crate` is supplied).
+pub struct AnalyzeOptions {
+    pub json: bool,
+    pub session: Option<String>,
+    pub crate_name: Option<String>,
+    pub outcome: Option<String>,
+    pub sort: String,
+    pub top: Option<usize>,
+}
+
+impl AnalyzeOptions {
+    fn sort_mode(&self) -> AnalyzeSort {
+        match self.sort.as_str() {
+            "misses" => AnalyzeSort::Misses,
+            "hits" => AnalyzeSort::Hits,
+            _ => AnalyzeSort::WallClock,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnalyzeSort {
+    WallClock,
+    Misses,
+    Hits,
+}
+
+fn cmd_analyze(journal_path: &str, opts: AnalyzeOptions) -> ExitCode {
+    let report = match analyze_journal_with(journal_path, &opts) {
         Ok(report) => report,
+        Err(AnalyzeError::Read(err)) if matches!(err.kind(), std::io::ErrorKind::NotFound) => {
+            // Missing journal: per issue #256 acceptance criteria the
+            // analyzer exits 0 with a `(no journal)` message so callers
+            // can scaffold the file before the first build runs.
+            if opts.json {
+                print_json_value(&serde_json::json!({
+                    "status": "ok",
+                    "schema_version": 1,
+                    "journal_path": journal_path,
+                    "line_count": 0,
+                    "note": "(no journal)",
+                }));
+            } else {
+                println!("zccache analyze: {journal_path}: (no journal)");
+            }
+            return ExitCode::SUCCESS;
+        }
         Err(e) => {
             let message = format_analyze_error(journal_path, &e);
-            if json {
+            if opts.json {
                 print_json_value(&analyze_error_json(journal_path, &e));
             } else {
                 eprintln!("{message}");
@@ -1464,10 +1557,10 @@ fn cmd_analyze(journal_path: &str, json: bool) -> ExitCode {
         }
     };
 
-    if json {
+    if opts.json {
         print_json_value(&report.to_json(journal_path));
     } else {
-        report.print_human(journal_path);
+        report.print_human_by_crate(journal_path, &opts);
     }
     ExitCode::SUCCESS
 }
@@ -1547,6 +1640,18 @@ struct AnalyzeReport {
     /// Per-crate-name miss counts. Bounded by HashMap during accumulation,
     /// surfaced as a sorted top-N in the report.
     miss_crate_counts: std::collections::HashMap<String, u64>,
+    /// Issue #256: per-crate hit/miss/wall-clock rollup used by the
+    /// default human-readable table. Keyed by crate_name (or
+    /// "<unknown>" when the journal line lacks one).
+    by_crate: std::collections::HashMap<String, CrateBucket>,
+}
+
+#[derive(Debug, Default, Clone)]
+struct CrateBucket {
+    hits: u64,
+    misses: u64,
+    errors: u64,
+    total_ns: u128,
 }
 
 #[derive(Debug, Default)]
@@ -1605,6 +1710,13 @@ impl AnalyzeReport {
         let crate_type = extract_flag_value(&args, "--crate-type");
         let extension_bucket = classify_extension(outcome, &crate_type);
 
+        // Issue #256: roll every compile entry up into a per-crate
+        // bucket so the human-readable table can group by crate.
+        // Falls back to "<unknown>" so journal lines lacking a
+        // crate name still appear in the rollup.
+        let crate_key = crate_name
+            .clone()
+            .unwrap_or_else(|| "<unknown>".to_string());
         match outcome {
             "hit" => {
                 self.compile_count += 1;
@@ -1612,6 +1724,9 @@ impl AnalyzeReport {
                 let bucket = self.by_extension.entry(extension_bucket).or_default();
                 bucket.hits += 1;
                 bucket.total_ns = bucket.total_ns.saturating_add(latency_ns);
+                let cb = self.by_crate.entry(crate_key).or_default();
+                cb.hits += 1;
+                cb.total_ns = cb.total_ns.saturating_add(latency_ns);
             }
             "miss" => {
                 self.compile_count += 1;
@@ -1622,10 +1737,16 @@ impl AnalyzeReport {
                 if let Some(name) = &crate_name {
                     *self.miss_crate_counts.entry(name.clone()).or_default() += 1;
                 }
+                let cb = self.by_crate.entry(crate_key).or_default();
+                cb.misses += 1;
+                cb.total_ns = cb.total_ns.saturating_add(latency_ns);
             }
             "error" => {
                 self.compile_count += 1;
                 self.error_count += 1;
+                let cb = self.by_crate.entry(crate_key).or_default();
+                cb.errors += 1;
+                cb.total_ns = cb.total_ns.saturating_add(latency_ns);
             }
             "link_hit" => {
                 self.link_count += 1;
@@ -1768,9 +1889,32 @@ impl AnalyzeReport {
             "by_tool_calls": by_tool_calls,
             "top_slowest": slowest,
             "top_miss_crates": top_miss_crates,
+            "by_crate": self.by_crate_json(),
         })
     }
 
+    fn by_crate_json(&self) -> serde_json::Value {
+        let mut rows: Vec<(&String, &CrateBucket)> = self.by_crate.iter().collect();
+        rows.sort_by(|a, b| b.1.total_ns.cmp(&a.1.total_ns).then_with(|| a.0.cmp(b.0)));
+        serde_json::Value::Array(
+            rows.into_iter()
+                .map(|(name, b)| {
+                    serde_json::json!({
+                        "crate_name": name,
+                        "hits": b.hits,
+                        "misses": b.misses,
+                        "errors": b.errors,
+                        "total_ms": (b.total_ns / 1_000_000) as u64,
+                    })
+                })
+                .collect(),
+        )
+    }
+
+    /// Legacy human printer, kept for reference and reused by
+    /// older tests. The default `cmd_analyze` path uses
+    /// [`Self::print_human_by_crate`] instead.
+    #[allow(dead_code)]
     fn print_human(&self, journal_path: &str) {
         println!("zccache analyze: {journal_path}");
         println!(
@@ -1841,8 +1985,211 @@ impl AnalyzeReport {
             }
         }
     }
+
+    /// Issue #256: default human-readable rollup grouped by crate
+    /// name and sorted by the AnalyzeOptions sort knob. Empty input
+    /// after filtering prints a header line plus an empty-table
+    /// marker so scripts can distinguish "no entries matched" from
+    /// "no journal file" (the latter is short-circuited by cmd_analyze).
+    fn print_human_by_crate(&self, journal_path: &str, opts: &AnalyzeOptions) {
+        println!("zccache analyze: {journal_path}");
+        println!(
+            "  lines: {} parsed; compiles: {} (hits {} / misses {} / errors {}); links: {} (hits {} / misses {})",
+            self.parsed_count,
+            self.compile_count,
+            self.hit_count,
+            self.miss_count,
+            self.error_count,
+            self.link_count,
+            self.link_hit_count,
+            self.link_miss_count,
+        );
+        if let Some(rate) = self.hit_rate() {
+            println!("  hit rate: {:.1}%", rate * 100.0);
+        }
+        println!(
+            "  total wall-clock: {} ms",
+            self.total_latency_ns / 1_000_000
+        );
+
+        let rows = self.crate_rows(opts);
+        if rows.is_empty() {
+            println!("  (no rows after filters)");
+            return;
+        }
+        println!();
+        println!("  by crate (sorted by {}):", opts.sort);
+        println!(
+            "    {col:<32}  hits={h:>6}  misses={m:>6}  errors={e:>4}  ms",
+            col = "crate",
+            h = "h",
+            m = "m",
+            e = "e",
+        );
+        for row in &rows {
+            println!(
+                "    {:<32}  hits={:>6}  misses={:>6}  errors={:>4}  ms={}",
+                row.crate_name,
+                row.hits,
+                row.misses,
+                row.errors,
+                row.total_ns / 1_000_000
+            );
+        }
+    }
+
+    /// Issue #256: build a sorted, optionally-truncated per-crate view
+    /// over `self.by_crate`. Splitting this off the printer keeps the
+    /// sorting logic testable without a stdout fixture.
+    fn crate_rows(&self, opts: &AnalyzeOptions) -> Vec<CrateRow> {
+        let mut rows: Vec<CrateRow> = self
+            .by_crate
+            .iter()
+            .map(|(name, b)| CrateRow {
+                crate_name: name.clone(),
+                hits: b.hits,
+                misses: b.misses,
+                errors: b.errors,
+                total_ns: b.total_ns,
+            })
+            .collect();
+        match opts.sort_mode() {
+            AnalyzeSort::WallClock => rows.sort_by(|a, b| {
+                b.total_ns
+                    .cmp(&a.total_ns)
+                    .then_with(|| a.crate_name.cmp(&b.crate_name))
+            }),
+            AnalyzeSort::Misses => rows.sort_by(|a, b| {
+                b.misses
+                    .cmp(&a.misses)
+                    .then_with(|| a.crate_name.cmp(&b.crate_name))
+            }),
+            AnalyzeSort::Hits => rows.sort_by(|a, b| {
+                b.hits
+                    .cmp(&a.hits)
+                    .then_with(|| a.crate_name.cmp(&b.crate_name))
+            }),
+        }
+        if let Some(n) = opts.top {
+            rows.truncate(n);
+        }
+        rows
+    }
 }
 
+/// One row of the per-crate rollup. Public-within-crate so tests can
+/// pin sort order without going through stdout.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrateRow {
+    pub crate_name: String,
+    pub hits: u64,
+    pub misses: u64,
+    pub errors: u64,
+    pub total_ns: u128,
+}
+
+/// Issue #256: streaming analyze with optional filters. Skips
+/// journal lines that fail the `session`/`crate`/`outcome` filter
+/// without counting them in the line tallies. Truncated or malformed
+/// lines emit a single stderr warning per occurrence and are skipped.
+fn analyze_journal_with(
+    journal_path: &str,
+    opts: &AnalyzeOptions,
+) -> Result<AnalyzeReport, AnalyzeError> {
+    let content = std::fs::read_to_string(journal_path).map_err(AnalyzeError::Read)?;
+    let mut report = AnalyzeReport::default();
+    let mut malformed = 0u64;
+    for line in content.lines() {
+        report.line_count += 1;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<serde_json::Value>(trimmed) {
+            Ok(value) => {
+                if !is_compile_journal_entry(&value) {
+                    continue;
+                }
+                if !analyze_passes_filters(&value, opts) {
+                    continue;
+                }
+                report.ingest(&value);
+            }
+            Err(_) => {
+                malformed += 1;
+            }
+        }
+    }
+    if malformed > 0 {
+        eprintln!("zccache analyze: skipped {malformed} malformed line(s)");
+    }
+    if report.parsed_count == 0 {
+        // When filters are active, an empty result is a legitimate
+        // zero-row report rather than an input-classification error.
+        let any_filter =
+            opts.session.is_some() || opts.crate_name.is_some() || opts.outcome.is_some();
+        if any_filter {
+            return Ok(report);
+        }
+        return Err(classify_analyze_input_without_entries(
+            content.trim(),
+            report.line_count,
+        ));
+    }
+    Ok(report)
+}
+
+/// Apply the analyze filter flags to a parsed journal value.
+/// Filters are conjunctive; missing values on the line are
+/// treated as non-matches so a `--crate foo` filter never
+/// matches a record without a `crate_name`.
+fn analyze_passes_filters(value: &serde_json::Value, opts: &AnalyzeOptions) -> bool {
+    if let Some(want) = &opts.session {
+        let got = value.get("session_id").and_then(|v| v.as_str());
+        if got != Some(want.as_str()) {
+            return false;
+        }
+    }
+    if let Some(want) = &opts.crate_name {
+        let direct = value
+            .get("crate_name")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let derived = direct.or_else(|| {
+            let args: Vec<String> = value
+                .get("args")
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default();
+            extract_flag_value(&args, "--crate-name")
+        });
+        if derived.as_deref() != Some(want.as_str()) {
+            return false;
+        }
+    }
+    if let Some(want) = &opts.outcome {
+        let got = value.get("outcome").and_then(|v| v.as_str()).unwrap_or("");
+        let matches_outcome = match want.as_str() {
+            "hit" => got == "hit" || got == "link_hit",
+            "miss" => got == "miss" || got == "link_miss",
+            "non-cacheable" => got == "error",
+            other => got == other,
+        };
+        if !matches_outcome {
+            return false;
+        }
+    }
+    true
+}
+
+/// Legacy unfiltered analyze entry point. Production callers use
+/// [`analyze_journal_with`]; the tests pinned to this function pre-date
+/// the filter flags and keep the simpler signature.
+#[allow(dead_code)]
 fn analyze_journal(journal_path: &str) -> Result<AnalyzeReport, AnalyzeError> {
     let content = std::fs::read_to_string(journal_path).map_err(AnalyzeError::Read)?;
     let mut report = AnalyzeReport::default();
@@ -2393,6 +2740,7 @@ async fn cmd_session_start(
     log: Option<&Path>,
     track_stats: bool,
     journal: Option<NormalizedPath>,
+    profile: bool,
 ) -> ExitCode {
     if let Err(e) = ensure_daemon(endpoint).await {
         eprintln!("zccache[err][D]: cannot start daemon at {endpoint}: {e}");
@@ -2414,6 +2762,7 @@ async fn cmd_session_start(
             log_file: log.map(NormalizedPath::from),
             track_stats,
             journal_path: journal,
+            profile,
         })
         .await
     {
@@ -4993,6 +5342,76 @@ mod tests {
         ));
     }
 
+    // Issue #256 -- CLI flag parsing for session-start --profile
+    // and the new zccache analyze filter/sort flags.
+
+    #[test]
+    fn session_start_profile_flag_defaults_to_false() {
+        let cli = Cli::try_parse_from(["zccache", "session-start"]).unwrap();
+        match cli.command {
+            Some(Commands::SessionStart { profile, .. }) => assert!(!profile),
+            other => panic!("expected SessionStart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_start_profile_flag_parses_when_set() {
+        let cli = Cli::try_parse_from(["zccache", "session-start", "--profile"]).unwrap();
+        match cli.command {
+            Some(Commands::SessionStart { profile, .. }) => assert!(profile),
+            other => panic!("expected SessionStart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn analyze_parses_session_crate_outcome_sort_top_flags() {
+        let cli = Cli::try_parse_from([
+            "zccache",
+            "analyze",
+            "x.jsonl",
+            "--session",
+            "s1",
+            "--crate",
+            "soldr_cli",
+            "--outcome",
+            "miss",
+            "--sort",
+            "misses",
+            "--top",
+            "5",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(Commands::Analyze {
+                session,
+                crate_name,
+                outcome,
+                sort,
+                top,
+                ..
+            }) => {
+                assert_eq!(session.as_deref(), Some("s1"));
+                assert_eq!(crate_name.as_deref(), Some("soldr_cli"));
+                assert_eq!(outcome.as_deref(), Some("miss"));
+                assert_eq!(sort, "misses");
+                assert_eq!(top, Some(5));
+            }
+            other => panic!("expected Analyze, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn analyze_sort_defaults_to_wall_clock() {
+        let cli = Cli::try_parse_from(["zccache", "analyze", "x.jsonl"]).unwrap();
+        match cli.command {
+            Some(Commands::Analyze { sort, top, .. }) => {
+                assert_eq!(sort, "wall-clock");
+                assert!(top.is_none());
+            }
+            other => panic!("expected Analyze, got {other:?}"),
+        }
+    }
+
     #[test]
     fn session_stats_unavailable_json_has_scrapeable_status() {
         let json = session_stats_unavailable_json("session-123", "stats_not_enabled");
@@ -6035,5 +6454,184 @@ mod tests {
         assert_eq!(report.line_count, 3);
         assert_eq!(report.parsed_count, 1);
         assert_eq!(report.hit_count, 1);
+    }
+
+    // Issue #256 -- AnalyzeOptions filtering, per-crate rollup, sort.
+
+    fn make_journal_line_full(
+        outcome: &str,
+        compiler: &str,
+        crate_name: &str,
+        crate_type: &str,
+        latency_ns: u128,
+        session_id: Option<&str>,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "ts": "2026-05-14T18:00:00Z",
+            "outcome": outcome,
+            "compiler": compiler,
+            "args": [
+                "--crate-name", crate_name,
+                "--crate-type", crate_type,
+                "--edition=2021",
+            ],
+            "cwd": "/repo",
+            "exit_code": 0,
+            "session_id": session_id,
+            "latency_ns": latency_ns as u64,
+        })
+    }
+
+    fn write_fixture_journal(
+        entries: &[serde_json::Value],
+    ) -> (tempfile::TempDir, std::path::PathBuf) {
+        use std::io::Write;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("fixture.jsonl");
+        let mut f = std::fs::File::create(&path).unwrap();
+        for e in entries {
+            writeln!(f, "{}", serde_json::to_string(e).unwrap()).unwrap();
+        }
+        drop(f);
+        (tmp, path)
+    }
+
+    fn default_opts() -> AnalyzeOptions {
+        AnalyzeOptions {
+            json: false,
+            session: None,
+            crate_name: None,
+            outcome: None,
+            sort: "wall-clock".into(),
+            top: None,
+        }
+    }
+
+    #[test]
+    fn analyze_by_crate_default_sorts_by_wall_clock_desc() {
+        let entries = vec![
+            make_journal_line_full("hit", "/rustc", "alpha", "lib", 200_000_000, None),
+            make_journal_line_full("miss", "/rustc", "alpha", "lib", 100_000_000, None),
+            make_journal_line_full("hit", "/rustc", "beta", "bin", 500_000_000, None),
+        ];
+        let (_tmp, path) = write_fixture_journal(&entries);
+        let report = analyze_journal_with(path.to_str().unwrap(), &default_opts()).expect("ok");
+        let rows = report.crate_rows(&default_opts());
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].crate_name, "beta");
+        assert_eq!(rows[1].crate_name, "alpha");
+        assert_eq!(rows[0].total_ns, 500_000_000);
+        assert_eq!(rows[1].total_ns, 300_000_000);
+    }
+
+    #[test]
+    fn analyze_sort_misses_orders_by_miss_count() {
+        let entries = vec![
+            make_journal_line_full("miss", "/rustc", "a", "lib", 10, None),
+            make_journal_line_full("miss", "/rustc", "a", "lib", 10, None),
+            make_journal_line_full("miss", "/rustc", "b", "lib", 10, None),
+        ];
+        let (_tmp, path) = write_fixture_journal(&entries);
+        let mut opts = default_opts();
+        opts.sort = "misses".into();
+        let report = analyze_journal_with(path.to_str().unwrap(), &opts).expect("ok");
+        let rows = report.crate_rows(&opts);
+        assert_eq!(rows[0].crate_name, "a");
+        assert_eq!(rows[0].misses, 2);
+        assert_eq!(rows[1].crate_name, "b");
+        assert_eq!(rows[1].misses, 1);
+    }
+
+    #[test]
+    fn analyze_top_truncates_rows() {
+        let mut entries = Vec::new();
+        for i in 0..5 {
+            entries.push(make_journal_line_full(
+                "hit",
+                "/rustc",
+                &format!("c{i}"),
+                "lib",
+                100 * (i as u128 + 1),
+                None,
+            ));
+        }
+        let (_tmp, path) = write_fixture_journal(&entries);
+        let mut opts = default_opts();
+        opts.top = Some(2);
+        let report = analyze_journal_with(path.to_str().unwrap(), &opts).expect("ok");
+        let rows = report.crate_rows(&opts);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].crate_name, "c4");
+        assert_eq!(rows[1].crate_name, "c3");
+    }
+
+    #[test]
+    fn analyze_session_filter_excludes_other_sessions() {
+        let entries = vec![
+            make_journal_line_full("hit", "/rustc", "a", "lib", 1, Some("s1")),
+            make_journal_line_full("hit", "/rustc", "b", "lib", 1, Some("s2")),
+        ];
+        let (_tmp, path) = write_fixture_journal(&entries);
+        let mut opts = default_opts();
+        opts.session = Some("s1".into());
+        let report = analyze_journal_with(path.to_str().unwrap(), &opts).expect("ok");
+        let rows = report.crate_rows(&opts);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].crate_name, "a");
+    }
+
+    #[test]
+    fn analyze_crate_filter_matches_by_crate_name_arg() {
+        let entries = vec![
+            make_journal_line_full("hit", "/rustc", "needle", "lib", 1, None),
+            make_journal_line_full("hit", "/rustc", "other", "lib", 1, None),
+        ];
+        let (_tmp, path) = write_fixture_journal(&entries);
+        let mut opts = default_opts();
+        opts.crate_name = Some("needle".into());
+        let report = analyze_journal_with(path.to_str().unwrap(), &opts).expect("ok");
+        assert_eq!(report.hit_count, 1);
+        assert_eq!(report.parsed_count, 1);
+    }
+
+    #[test]
+    fn analyze_outcome_filter_miss_includes_link_miss() {
+        let entries = vec![
+            make_journal_line_full("hit", "/rustc", "a", "lib", 1, None),
+            make_journal_line_full("miss", "/rustc", "a", "lib", 1, None),
+            make_journal_line_full("link_miss", "/lld", "a", "lib", 1, None),
+        ];
+        let (_tmp, path) = write_fixture_journal(&entries);
+        let mut opts = default_opts();
+        opts.outcome = Some("miss".into());
+        let report = analyze_journal_with(path.to_str().unwrap(), &opts).expect("ok");
+        // Both `miss` and `link_miss` flow through; the `hit` is excluded.
+        assert_eq!(report.miss_count, 1);
+        assert_eq!(report.link_miss_count, 1);
+        assert_eq!(report.hit_count, 0);
+    }
+
+    #[test]
+    fn analyze_options_sort_mode_defaults_to_wall_clock() {
+        let opts = default_opts();
+        assert_eq!(opts.sort_mode(), AnalyzeSort::WallClock);
+        let mut opts = default_opts();
+        opts.sort = "nonsense".into();
+        // Unknown sort key falls back to wall-clock.
+        assert_eq!(opts.sort_mode(), AnalyzeSort::WallClock);
+    }
+
+    #[test]
+    fn analyze_filters_returning_empty_are_ok_not_error() {
+        // Issue #256: when filters select zero rows the report is empty
+        // but the run still succeeds. Without filters, the legacy
+        // input-classification error fires instead.
+        let entries = vec![make_journal_line_full("hit", "/rustc", "a", "lib", 1, None)];
+        let (_tmp, path) = write_fixture_journal(&entries);
+        let mut opts = default_opts();
+        opts.crate_name = Some("does-not-exist".into());
+        let report = analyze_journal_with(path.to_str().unwrap(), &opts).expect("filtered ok");
+        assert_eq!(report.parsed_count, 0);
+        assert!(report.crate_rows(&opts).is_empty());
     }
 }

--- a/crates/zccache-daemon/src/compile_journal.rs
+++ b/crates/zccache-daemon/src/compile_journal.rs
@@ -183,6 +183,66 @@ impl JournalEntry {
             self_profile_ns: None,
         }
     }
+
+    /// Issue #256: populate the extended profile-mode fields on an entry.
+    ///
+    /// Called only when the owning session opted in via
+    /// `session-start --profile`. Pure transformation - no I/O.
+    /// `spans` is owned by the compile handler; passing `None`
+    /// emits a record without `self_profile_ns`.
+    #[must_use]
+    pub fn with_profile_fields(mut self, spans: Option<SelfProfileSpans>) -> Self {
+        let derived_name = derive_crate_name(&self.args);
+        let derived_type = derive_crate_type(&self.args);
+        self.output_ext = derive_output_ext(derived_type).map(str::to_string);
+        self.crate_type = derived_type.map(str::to_string);
+        self.crate_name = derived_name;
+        self.self_profile_ns = spans.map(SelfProfileSpans::finish);
+        self
+    }
+}
+
+/// Issue #256: accumulator for the four `self_profile_ns` span buckets.
+///
+/// Use `handle_compile` to time the hashing, lookup, decompress,
+/// and store phases and call the matching `add_*_ns` method.
+/// Buckets that never receive a sample serialize as `0`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SelfProfileSpans {
+    pub hash_inputs_ns: u128,
+    pub lookup_ns: u128,
+    pub decompress_ns: u128,
+    pub store_ns: u128,
+}
+
+impl SelfProfileSpans {
+    /// Freeze the accumulated counters into the wire shape.
+    #[must_use]
+    pub fn finish(self) -> SelfProfileNs {
+        SelfProfileNs {
+            hash_inputs: self.hash_inputs_ns,
+            lookup: self.lookup_ns,
+            decompress: self.decompress_ns,
+            store: self.store_ns,
+        }
+    }
+
+    /// Add to the `hash_inputs` bucket.
+    pub fn add_hash_inputs_ns(&mut self, ns: u128) {
+        self.hash_inputs_ns = self.hash_inputs_ns.saturating_add(ns);
+    }
+    /// Add to the `lookup` bucket.
+    pub fn add_lookup_ns(&mut self, ns: u128) {
+        self.lookup_ns = self.lookup_ns.saturating_add(ns);
+    }
+    /// Add to the `decompress` bucket.
+    pub fn add_decompress_ns(&mut self, ns: u128) {
+        self.decompress_ns = self.decompress_ns.saturating_add(ns);
+    }
+    /// Add to the `store` bucket.
+    pub fn add_store_ns(&mut self, ns: u128) {
+        self.store_ns = self.store_ns.saturating_add(ns);
+    }
 }
 
 // ─── Derivation helpers (pure functions, no daemon state) ──────────────────
@@ -1902,5 +1962,110 @@ mod tests {
             "expected at most {JOURNAL_MAX_FILES} rotated files, got {}",
             remaining.len()
         );
+    }
+
+    // Issue #256 -- with_profile_fields and SelfProfileSpans.
+
+    fn make_ctx(args: Vec<&str>) -> JournalContext {
+        JournalContext {
+            compiler: "/usr/bin/rustc".to_string(),
+            args: args.into_iter().map(String::from).collect(),
+            cwd: "/proj".to_string(),
+            env: None,
+            session_id: Some("session-1".to_string()),
+        }
+    }
+
+    #[test]
+    fn with_profile_fields_populates_crate_name_type_and_ext() {
+        let ctx = make_ctx(vec![
+            "--crate-name",
+            "soldr_cli",
+            "--crate-type",
+            "bin",
+            "src/main.rs",
+        ]);
+        let entry = JournalEntry::new(ctx, "hit", 0, 1_234, None).with_profile_fields(None);
+        assert_eq!(entry.crate_name.as_deref(), Some("soldr_cli"));
+        assert_eq!(entry.crate_type.as_deref(), Some("bin"));
+        assert_eq!(entry.output_ext.as_deref(), Some("exe"));
+        assert!(entry.self_profile_ns.is_none());
+    }
+
+    #[test]
+    fn with_profile_fields_threads_self_profile_spans() {
+        let ctx = make_ctx(vec!["--crate-name", "x", "--crate-type", "lib"]);
+        let mut spans = SelfProfileSpans::default();
+        spans.add_hash_inputs_ns(11);
+        spans.add_lookup_ns(22);
+        spans.add_decompress_ns(33);
+        spans.add_store_ns(44);
+        let entry = JournalEntry::new(ctx, "hit", 0, 0, None).with_profile_fields(Some(spans));
+        let sp = entry.self_profile_ns.unwrap();
+        assert_eq!(sp.hash_inputs, 11);
+        assert_eq!(sp.lookup, 22);
+        assert_eq!(sp.decompress, 33);
+        assert_eq!(sp.store, 44);
+    }
+
+    #[test]
+    fn legacy_entry_without_with_profile_fields_omits_all_new_fields() {
+        // Issue #256 acceptance criterion: when --profile is OFF the
+        // journal record must serialize without crate_name, crate_type,
+        // output_ext, self_profile_ns, or miss_diff.
+        let ctx = make_ctx(vec!["--crate-name", "x", "--crate-type", "lib"]);
+        let entry = JournalEntry::new(ctx, "hit", 0, 5, None);
+        let json = serde_json::to_string(&entry).unwrap();
+        for absent in [
+            "\"crate_name\"",
+            "\"crate_type\"",
+            "\"output_ext\"",
+            "\"miss_diff\"",
+            "\"self_profile_ns\"",
+        ] {
+            assert!(
+                !json.contains(absent),
+                "non-profile entry must omit {absent}, got: {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn profile_entry_roundtrips_through_serde() {
+        // Issue #256 acceptance criterion: a journal line with every
+        // extended field set must serialize and deserialize losslessly.
+        let ctx = make_ctx(vec!["--crate-name", "y", "--crate-type", "proc-macro"]);
+        let mut spans = SelfProfileSpans::default();
+        spans.add_hash_inputs_ns(100);
+        spans.add_lookup_ns(200);
+        let mut entry = JournalEntry::new(ctx, "miss", 0, 999, Some(miss_reason::UNKNOWN))
+            .with_profile_fields(Some(spans));
+        entry.miss_diff = Some(MissDiff {
+            changed_files: vec!["src/lib.rs".to_string()],
+            changed_flags: vec!["-C".into(), "debuginfo=2".into()],
+            changed_deps: vec!["serde@1.0.213".into()],
+        });
+        let json = serde_json::to_string(&entry).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["crate_name"], "y");
+        assert_eq!(v["crate_type"], "proc-macro");
+        assert_eq!(v["output_ext"], "so");
+        assert_eq!(v["miss_reason"], "unknown");
+        assert_eq!(v["miss_diff"]["changed_files"][0], "src/lib.rs");
+        assert_eq!(v["miss_diff"]["changed_flags"][1], "debuginfo=2");
+        assert_eq!(v["miss_diff"]["changed_deps"][0], "serde@1.0.213");
+        assert_eq!(v["self_profile_ns"]["hash_inputs"], 100);
+        assert_eq!(v["self_profile_ns"]["lookup"], 200);
+    }
+
+    #[test]
+    fn self_profile_spans_saturate_on_overflow() {
+        // Issue #256: span accumulator must not panic when a malformed
+        // measurement returns u128::MAX. Saturating arithmetic preserves
+        // the journal contract: a span never observes a smaller value.
+        let mut spans = SelfProfileSpans::default();
+        spans.add_hash_inputs_ns(u128::MAX);
+        spans.add_hash_inputs_ns(5);
+        assert_eq!(spans.hash_inputs_ns, u128::MAX);
     }
 }

--- a/crates/zccache-daemon/src/event_log.rs
+++ b/crates/zccache-daemon/src/event_log.rs
@@ -579,6 +579,7 @@ mod tests {
             log_file: Some(session_log.to_path_buf().into()),
             track_stats: false,
             journal_path: None,
+            profile: false,
         });
         let sid_str = sid.to_string();
 

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -1530,6 +1530,7 @@ async fn handle_connection(
                 log_file,
                 track_stats,
                 journal_path,
+                profile,
             } => {
                 state.stats.record_session();
                 (
@@ -1540,6 +1541,7 @@ async fn handle_connection(
                         log_file,
                         track_stats,
                         journal_path,
+                        profile,
                     )
                     .await,
                     None,
@@ -1766,19 +1768,27 @@ async fn handle_connection(
         if let Some(ctx) = journal_ctx {
             if let Some((outcome, exit_code, miss_reason)) = extract_outcome(&response) {
                 let latency_ns = journal_start.elapsed().as_nanos();
-                // Look up session journal path for per-session logging.
-                let session_journal_path = ctx.session_id.as_ref().and_then(|sid| {
-                    sid.parse::<SessionId>().ok().and_then(|parsed| {
-                        state
-                            .sessions
-                            .get(&parsed)
-                            .and_then(|s| s.journal_path.clone())
-                    })
-                });
-                state.journal.log(
-                    &JournalEntry::new(ctx, outcome, exit_code, latency_ns, miss_reason),
-                    session_journal_path.as_deref(),
-                );
+                // Look up session journal path + extended-journal opt-in
+                // in the same query so the session map is touched once.
+                let (session_journal_path, profile_on) = ctx
+                    .session_id
+                    .as_ref()
+                    .and_then(|sid| sid.parse::<SessionId>().ok())
+                    .and_then(|parsed| state.sessions.get(&parsed))
+                    .map(|s| (s.journal_path.clone(), s.profile))
+                    .unwrap_or((None, false));
+                let entry = JournalEntry::new(ctx, outcome, exit_code, latency_ns, miss_reason);
+                // Issue #256: extended-journal fields are populated only
+                // for sessions that opted in via session-start --profile.
+                // Self-profile span timings ride along when the compile
+                // handler captured them (currently None until follow-up
+                // wave wires the compile-handler instrumentation).
+                let entry = if profile_on {
+                    entry.with_profile_fields(None)
+                } else {
+                    entry
+                };
+                state.journal.log(&entry, session_journal_path.as_deref());
             }
         }
 
@@ -1869,7 +1879,7 @@ async fn handle_compile_ephemeral(
     // 1. Start ephemeral session (inline, no IPC roundtrip)
     state.stats.record_session();
     let session_resp =
-        handle_session_start(state, client_pid, working_dir, None, false, None).await;
+        handle_session_start(state, client_pid, working_dir, None, false, None, false).await;
     let session_id = match session_resp {
         Response::SessionStarted { session_id, .. } => session_id,
         Response::Error { message } => return Response::Error { message },
@@ -2468,6 +2478,7 @@ async fn handle_session_start(
     log_file: Option<NormalizedPath>,
     track_stats: bool,
     journal_path: Option<NormalizedPath>,
+    profile: bool,
 ) -> Response {
     let session_config = zccache_depgraph::SessionConfig {
         client_pid,
@@ -2475,6 +2486,7 @@ async fn handle_session_start(
         log_file,
         track_stats,
         journal_path,
+        profile,
     };
 
     let session_id = state.sessions.create(session_config);
@@ -8381,6 +8393,7 @@ exit /b 0
                     log_file: Some(log.to_string_lossy().into_owned().into()),
                     track_stats: false,
                     journal_path: None,
+                    profile: false,
                 })
                 .await
                 .unwrap();
@@ -8657,6 +8670,7 @@ exit /b 0
                     log_file: None,
                     track_stats: false,
                     journal_path: None,
+                    profile: false,
                 })
                 .await
                 .unwrap();
@@ -8748,6 +8762,7 @@ exit /b 0
                     log_file: None,
                     track_stats: false,
                     journal_path: None,
+                    profile: false,
                 })
                 .await
                 .unwrap();
@@ -8816,6 +8831,7 @@ exit /b 0
                     log_file: None,
                     track_stats: true,
                     journal_path: None,
+                    profile: false,
                 })
                 .await
                 .unwrap();

--- a/crates/zccache-daemon/tests/adversarial_corner_cases.rs
+++ b/crates/zccache-daemon/tests/adversarial_corner_cases.rs
@@ -48,6 +48,7 @@ async fn start_session(
             log_file: Some(log_file.to_string().into()),
             track_stats: false,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();

--- a/crates/zccache-daemon/tests/adversarial_mutations.rs
+++ b/crates/zccache-daemon/tests/adversarial_mutations.rs
@@ -50,6 +50,7 @@ async fn start_session(
             log_file: Some(log_file.to_string().into()),
             track_stats: false,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();

--- a/crates/zccache-daemon/tests/cold_path_profile_test.rs
+++ b/crates/zccache-daemon/tests/cold_path_profile_test.rs
@@ -170,6 +170,7 @@ async fn start_session(client: &mut ClientConn, cwd: &str) -> String {
             log_file: None,
             track_stats: true,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();
@@ -704,6 +705,7 @@ async fn start_session_inline(client: &mut ClientConn, cwd: &str) -> String {
             log_file: None,
             track_stats: true,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();

--- a/crates/zccache-daemon/tests/integration_test.rs
+++ b/crates/zccache-daemon/tests/integration_test.rs
@@ -78,6 +78,7 @@ async fn test_session_start_with_nonexistent_compiler() {
                 log_file: None,
                 track_stats: false,
                 journal_path: None,
+                profile: false,
             })
             .await
             .unwrap();
@@ -138,6 +139,7 @@ async fn test_session_start_with_clang_toolchain() {
                 log_file: None,
                 track_stats: false,
                 journal_path: None,
+                profile: false,
             })
             .await
             .unwrap();
@@ -164,6 +166,7 @@ async fn test_session_start_with_clang_toolchain() {
                 log_file: None,
                 track_stats: false,
                 journal_path: None,
+                profile: false,
             })
             .await
             .unwrap();
@@ -211,6 +214,7 @@ async fn test_full_client_flow() {
                 log_file: None,
                 track_stats: false,
                 journal_path: None,
+                profile: false,
             })
             .await
             .unwrap();
@@ -280,6 +284,7 @@ int main() {
                 log_file: Some(log_file.to_string_lossy().into_owned().into()),
                 track_stats: false,
                 journal_path: None,
+                profile: false,
             })
             .await
             .unwrap();

--- a/crates/zccache-daemon/tests/ninja_rebuild_test.rs
+++ b/crates/zccache-daemon/tests/ninja_rebuild_test.rs
@@ -185,6 +185,7 @@ async fn build_all_ipc(
             log_file: None,
             track_stats: true,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();
@@ -566,6 +567,7 @@ async fn ninja_concurrent_cold_build() {
             log_file: None,
             track_stats: false,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();

--- a/crates/zccache-daemon/tests/pch_cache_test.rs
+++ b/crates/zccache-daemon/tests/pch_cache_test.rs
@@ -38,6 +38,7 @@ async fn start_session(client: &mut ClientConn, cwd: &str, log_file: &str) -> St
             log_file: Some(log_file.to_string().into()),
             track_stats: false,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();

--- a/crates/zccache-daemon/tests/perf_bench_test.rs
+++ b/crates/zccache-daemon/tests/perf_bench_test.rs
@@ -1571,6 +1571,7 @@ async fn perf_c_zccache_vs_bare() {
             log_file: None,
             track_stats: true,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();
@@ -1810,6 +1811,7 @@ async fn perf_warm_cache_zccache_vs_sccache() {
             log_file: None,
             track_stats: true,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();
@@ -2136,6 +2138,7 @@ async fn perf_response_file() {
             log_file: None,
             track_stats: true,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();
@@ -2621,6 +2624,7 @@ async fn perf_rustc_zccache_vs_sccache() {
         log_file: None,
         track_stats: true,
         journal_path: None,
+        profile: false,
     })
     .await
     .unwrap();
@@ -2898,6 +2902,7 @@ async fn start_zccache_session(client: &mut ClientConn, working_dir: &str) -> St
             log_file: None,
             track_stats: true,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();

--- a/crates/zccache-daemon/tests/perf_test.rs
+++ b/crates/zccache-daemon/tests/perf_test.rs
@@ -91,6 +91,7 @@ async fn start_session(
             log_file: Some(log_file.to_string().into()),
             track_stats: false,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();

--- a/crates/zccache-daemon/tests/profile_multi_test.rs
+++ b/crates/zccache-daemon/tests/profile_multi_test.rs
@@ -94,6 +94,7 @@ async fn profile_multi_file_warm_path() {
             log_file: None,
             track_stats: true,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();

--- a/crates/zccache-daemon/tests/profile_test.rs
+++ b/crates/zccache-daemon/tests/profile_test.rs
@@ -27,6 +27,7 @@ async fn start_session(client: &mut ClientConn, _clang: &std::path::Path, cwd: &
             log_file: None,
             track_stats: true,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();

--- a/crates/zccache-daemon/tests/response_file_cache.rs
+++ b/crates/zccache-daemon/tests/response_file_cache.rs
@@ -90,6 +90,7 @@ async fn start_session(
             log_file: Some(log_file.to_string().into()),
             track_stats: false,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();

--- a/crates/zccache-daemon/tests/rustc_adversarial_test.rs
+++ b/crates/zccache-daemon/tests/rustc_adversarial_test.rs
@@ -45,6 +45,7 @@ async fn do_start_session(client: &mut ClientConn, cwd: &str) -> String {
             log_file: None,
             track_stats: false,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();

--- a/crates/zccache-daemon/tests/rustc_cache_test.rs
+++ b/crates/zccache-daemon/tests/rustc_cache_test.rs
@@ -35,6 +35,7 @@ async fn start_session(client: &mut ClientConn) -> String {
             log_file: None,
             track_stats: false,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();
@@ -54,6 +55,7 @@ async fn start_session_in(client: &mut ClientConn, working_dir: &std::path::Path
             log_file: None,
             track_stats: false,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();

--- a/crates/zccache-daemon/tests/rustc_issue_210_async_populate_test.rs
+++ b/crates/zccache-daemon/tests/rustc_issue_210_async_populate_test.rs
@@ -105,6 +105,7 @@ async fn start_session(client: &mut ClientConn) -> String {
             log_file: None,
             track_stats: false,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();

--- a/crates/zccache-daemon/tests/session_stats_test.rs
+++ b/crates/zccache-daemon/tests/session_stats_test.rs
@@ -120,6 +120,7 @@ async fn session_stats_mid_session_query() {
                 log_file: None,
                 track_stats: true,
                 journal_path: None,
+                profile: false,
             })
             .await
             .unwrap();
@@ -215,6 +216,7 @@ async fn session_stats_not_tracked_returns_none() {
                 log_file: None,
                 track_stats: false,
                 journal_path: None,
+                profile: false,
             })
             .await
             .unwrap();

--- a/crates/zccache-daemon/tests/stress_test.rs
+++ b/crates/zccache-daemon/tests/stress_test.rs
@@ -45,6 +45,7 @@ async fn start_session(
             log_file: Some(log_file.to_string().into()),
             track_stats: false,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();

--- a/crates/zccache-daemon/tests/watcher_adversarial.rs
+++ b/crates/zccache-daemon/tests/watcher_adversarial.rs
@@ -50,6 +50,7 @@ async fn start_session(
             log_file: Some(log_file.to_string().into()),
             track_stats: false,
             journal_path: None,
+            profile: false,
         })
         .await
         .unwrap();

--- a/crates/zccache-depgraph/src/session.rs
+++ b/crates/zccache-depgraph/src/session.rs
@@ -167,6 +167,10 @@ pub struct SessionConfig {
     pub track_stats: bool,
     /// Path for per-session JSONL compile journal (must end in .jsonl).
     pub journal_path: Option<NormalizedPath>,
+    /// Issue #256: opt in to the extended journal schema. When true,
+    /// the daemon populates crate_name, crate_type, output_ext, and
+    /// self_profile_ns on every compile-journal line for this session.
+    pub profile: bool,
 }
 
 /// An active session.
@@ -190,6 +194,8 @@ pub struct Session {
     pub stats_tracker: Option<SessionStatsTracker>,
     /// Path to the per-session JSONL journal file (if journal was requested).
     pub journal_path: Option<NormalizedPath>,
+    /// Issue #256: extended-journal opt-in. See SessionConfig::profile.
+    pub profile: bool,
 }
 
 /// Manages active sessions.
@@ -234,6 +240,7 @@ impl SessionManager {
             last_activity: now,
             stats_tracker,
             journal_path,
+            profile: config.profile,
         };
 
         self.sessions.insert(id, session);
@@ -370,6 +377,7 @@ mod tests {
             log_file: None,
             track_stats: false,
             journal_path: None,
+            profile: false,
         }
     }
 

--- a/crates/zccache-depgraph/tests/stress_test.rs
+++ b/crates/zccache-depgraph/tests/stress_test.rs
@@ -408,6 +408,7 @@ End of search list.
         log_file: None,
         track_stats: false,
         journal_path: None,
+        profile: false,
     });
     assert!(mgr.exists(&session_id));
 
@@ -764,6 +765,7 @@ fn stress_concurrent_session_operations() {
                     log_file: None,
                     track_stats: false,
                     journal_path: None,
+                    profile: false,
                 });
                 ids.push(id);
                 mgr.touch(&id);

--- a/crates/zccache-protocol/src/messages.rs
+++ b/crates/zccache-protocol/src/messages.rs
@@ -37,6 +37,12 @@ pub enum Request {
         track_stats: bool,
         /// Path for per-session JSONL compile journal (must end in .jsonl).
         journal_path: Option<NormalizedPath>,
+        /// Issue #256: opt in to the extended journal schema. When true,
+        /// the daemon populates crate_name, crate_type, output_ext, and
+        /// self_profile_ns on every compile journal line for the duration
+        /// of this session. When false, behavior is identical to releases
+        /// before the flag existed (no new allocations, no new fields).
+        profile: bool,
     },
     /// Compile a source file within an existing session.
     Compile {
@@ -502,6 +508,7 @@ mod tests {
             log_file: None,
             track_stats: true,
             journal_path: None,
+            profile: false,
         };
         roundtrip(&req);
 
@@ -511,6 +518,7 @@ mod tests {
             log_file: None,
             track_stats: false,
             journal_path: None,
+            profile: false,
         };
         roundtrip(&req_no_stats);
     }
@@ -523,6 +531,7 @@ mod tests {
             log_file: None,
             track_stats: false,
             journal_path: Some("/tmp/build.jsonl".into()),
+            profile: false,
         };
         roundtrip(&req);
 
@@ -532,6 +541,7 @@ mod tests {
             log_file: None,
             track_stats: false,
             journal_path: None,
+            profile: false,
         };
         roundtrip(&req_no_journal);
     }

--- a/docs/journal-schema.md
+++ b/docs/journal-schema.md
@@ -47,6 +47,40 @@ The Rust source of truth is the `miss_reason` module in
 `crates/zccache-daemon/src/compile_journal.rs`. `miss_reason::ALL` is the
 append-only iteration of the closed set.
 
+## Issue #256: `session-start --profile` and the extended schema
+
+The optional fields `crate_name`, `crate_type`, `output_ext`,
+`miss_diff`, and `self_profile_ns` are populated only when the
+session was created with `zccache session-start --profile`.
+Without the flag, the journal record uses the legacy lean shape
+and incurs zero new allocations on the daemon hot path.
+
+`crate_name`, `crate_type`, and `output_ext` are derived from the
+rustc argument vector by the `derive_crate_name` /
+`derive_crate_type` / `derive_output_ext` helpers in
+`crates/zccache-daemon/src/compile_journal.rs`. `crate_type` takes
+one of `lib`, `bin`, `proc-macro`, `build-script`, `test`,
+`bench`, `example`; the matching `output_ext` is `rlib`, `exe`,
+`so` for proc-macro, etc.
+
+`self_profile_ns` is a four-bucket nanosecond histogram of the
+daemon-internal phases for a single compile:
+
+- `hash_inputs` -- time spent computing the cache key inputs.
+- `lookup` -- time spent in the artifact/depgraph lookup path.
+- `decompress` -- time spent decompressing an artifact on a hit.
+- `store` -- time spent persisting an artifact on a miss.
+
+Buckets that did not run for a given compile serialize as `0`.
+
+`miss_diff` is an evidence bucket: only the dimension that flipped
+is populated. Empty arrays are omitted from serialization.
+
+The `zccache analyze` subcommand rolls journals up offline and
+reads only the documented fields; it tolerates malformed lines
+(emits a stderr warning and skips the row) and missing journals
+(exits zero with a `(no journal)` message).
+
 ## Stability & versioning
 
 The journal is **additive-by-default**: new optional fields may appear in


### PR DESCRIPTION
Closes #256.

## Summary

Wires the opt-in extended journal schema from `zccache session-start --profile` end-to-end and adds filter/sort/top flags to the offline `zccache analyze` rollup. When the flag is OFF, behaviour and journal shape are byte-identical to releases before this PR.

## What's in

- `Request::SessionStart` gains `profile: bool` (PROTOCOL_VERSION 8 → 9, DD-018). `SessionConfig` and `Session` carry the flag through to the daemon's journal-write site.
- `JournalEntry::with_profile_fields(...)` populates `crate_name`, `crate_type`, `output_ext`, and `self_profile_ns` from the rustc argument vector. A new `SelfProfileSpans` accumulator gives the compile handler (next wave) a place to time the hash/lookup/decompress/store phases without changing the journal-write API.
- `zccache analyze` learns `--session`, `--crate`, `--outcome` (`hit`/`miss`/`non-cacheable`), `--sort` (`wall-clock`/`misses`/`hits`), and `--top N`. Default human view groups by crate sorted by wall-clock descending. Missing journal → exit 0 with `(no journal)`. Malformed lines → single stderr warning + skip.
- `docs/journal-schema.md` documents the opt-in fields and their gating.

## Tests added

- `compile_journal`: 5 tests for `with_profile_fields`, the `SelfProfileSpans` accumulator, the legacy-record contract (no profile fields when `--profile` is off), and a full roundtrip with `miss_diff` populated.
- `analyze`: 8 fixture-driven tests covering per-crate sort orders, `--top` truncation, session/crate/outcome filters, and the "filtered to empty" case.
- CLI: 4 `clap::try_parse_from` tests for `session-start --profile` and the new analyze flags.

## Test plan

- [x] `soldr cargo fmt --all`
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings`
- [x] `soldr cargo test --workspace --lib` (all crates green; compile_journal 68 ✓, cli 65 ✓, depgraph etc all pass)
- [ ] CI runs full integration suite

## Out of scope (follow-up)

- Compile-handler instrumentation that actually populates `self_profile_ns` with real timings (the field and the accumulator are wired; the call-site timing spans inside `handle_compile` are the next wave).
- `miss_diff` evidence collection at the cache-key-comparison site (the field is wired; population is the next wave). When `--profile` is on but no diff is computed, the field is omitted (skip_serializing_if).

🤖 Generated with [Claude Code](https://claude.com/claude-code)