### PR TITLE
fix(daemon): auto-classify warm + warn on bad persisted depgraph (#320)

### DIFF
--- a/crates/zccache-daemon/src/main.rs
+++ b/crates/zccache-daemon/src/main.rs
@@ -198,16 +198,23 @@ fn run_server(args: Args) {
         .expect("failed to create tokio runtime");
 
     // Load dep graph from disk (before entering async block).
-    let dep_graph = if args.no_depgraph_cache {
-        let path = zccache_depgraph::depgraph_file_path();
+    //
+    // Issue #320: a fresh daemon pointed at a populated cache dir is auto-
+    // classified as warm by loading the persisted graph here. On version
+    // mismatch or corruption the outcome carries a warning that we surface
+    // both on stderr (for operators) and via the daemon server (which forwards
+    // it into per-session logs) so the cold fallback is never silent.
+    let path = zccache_depgraph::depgraph_file_path();
+    let (dep_graph, depgraph_load_warning) = if args.no_depgraph_cache {
         let _ = std::fs::remove_file(&path);
         tracing::info!("depgraph cache disabled — starting with empty graph");
-        None
+        (None, None)
     } else {
-        let path = zccache_depgraph::depgraph_file_path();
         let start = std::time::Instant::now();
-        match zccache_depgraph::load_from_file(&path) {
-            Ok(graph) => {
+        let outcome = zccache_depgraph::classify_load(&path);
+        let warning = outcome.warning(&path);
+        match outcome {
+            zccache_depgraph::DepGraphLoadOutcome::Loaded { graph } => {
                 let stats = graph.stats();
                 tracing::info!(
                     contexts = stats.context_count,
@@ -215,24 +222,30 @@ fn run_server(args: Args) {
                     elapsed_ms = start.elapsed().as_millis() as u64,
                     "loaded depgraph from disk"
                 );
-                Some(graph)
+                (Some(graph), None)
             }
-            Err(zccache_depgraph::SnapshotError::Io(ref e))
-                if e.kind() == std::io::ErrorKind::NotFound =>
-            {
-                None
-            }
-            Err(zccache_depgraph::SnapshotError::VersionMismatch { file, expected }) => {
+            zccache_depgraph::DepGraphLoadOutcome::Missing => (None, None),
+            zccache_depgraph::DepGraphLoadOutcome::VersionMismatch {
+                file_version,
+                expected_version,
+            } => {
                 tracing::warn!(
-                    file_version = file,
-                    expected_version = expected,
+                    file_version,
+                    expected_version,
                     "depgraph version mismatch — starting with empty graph"
                 );
-                None
+                if let Some(ref w) = warning {
+                    eprintln!("{w}");
+                }
+                (None, warning)
             }
-            Err(e) => {
-                tracing::warn!("depgraph load failed: {e} — starting with empty graph");
-                None
+            zccache_depgraph::DepGraphLoadOutcome::Corrupt { ref message }
+            | zccache_depgraph::DepGraphLoadOutcome::IoError { ref message } => {
+                tracing::warn!("depgraph load failed: {message} — starting with empty graph");
+                if let Some(ref w) = warning {
+                    eprintln!("{w}");
+                }
+                (None, warning)
             }
         }
     };
@@ -250,6 +263,14 @@ fn run_server(args: Args) {
         // Inject pre-loaded dep graph if we have one.
         if let Some(graph) = dep_graph {
             server.set_dep_graph(graph);
+        }
+
+        // Forward any depgraph load warning so SessionStart can mirror it
+        // into the per-session log (`last-session.log`). Without this the
+        // cold fallback after a version-mismatch / corrupt file would be
+        // invisible to operators looking at per-build logs.
+        if let Some(warning) = depgraph_load_warning {
+            server.set_depgraph_load_warning(warning);
         }
 
         // Wire up Ctrl+C to trigger graceful shutdown

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -606,6 +606,14 @@ struct SharedState {
     /// CLI can distinguish "persisted graph" from "first-run, not yet flushed"
     /// without inferring it from the on-disk file size.
     dep_graph_persisted: AtomicBool,
+    /// Optional load-time warning to mirror into every session log.
+    ///
+    /// Populated by `set_depgraph_load_warning` when the daemon's startup load
+    /// of the persisted depgraph fell back to a cold session (version
+    /// mismatch, corrupt header, or unexpected I/O error). The string is
+    /// emitted once per session into the per-session log (`last-session.log`)
+    /// at `SessionStart` time so the cold fallback is never silent. Issue #320.
+    depgraph_load_warning: Mutex<Option<String>>,
 }
 
 /// Pre-computed compile request data for the request-level fast path.
@@ -921,6 +929,7 @@ impl DaemonServer {
                 artifacts_loaded: AtomicBool::new(false),
                 fingerprint: FingerprintManager::new(),
                 dep_graph_persisted: AtomicBool::new(false),
+                depgraph_load_warning: Mutex::new(None),
             }),
         })
     }
@@ -940,6 +949,21 @@ impl DaemonServer {
             Arc::get_mut(&mut self.state).expect("set_dep_graph must be called before run()");
         state.dep_graph = graph;
         state.dep_graph_persisted.store(true, Ordering::Release);
+    }
+
+    /// Record a load-time depgraph warning to mirror into per-session logs.
+    ///
+    /// Called by the daemon's startup path after [`zccache_depgraph::classify_load`]
+    /// returns a non-`Loaded` outcome that warrants surfacing (version
+    /// mismatch, corruption, I/O error). The warning is appended to each
+    /// session's log file at `SessionStart` so a cold fallback caused by a
+    /// stale or corrupt `depgraph.bin` is visible to operators. Issue #320.
+    ///
+    /// Must be called before `run()` (while this is the only `Arc` holder).
+    pub fn set_depgraph_load_warning(&mut self, warning: String) {
+        let state = Arc::get_mut(&mut self.state)
+            .expect("set_depgraph_load_warning must be called before run()");
+        *state.depgraph_load_warning.get_mut() = Some(warning);
     }
 
     /// Get a snapshot of the phase profiler (for benchmarks).
@@ -2566,6 +2590,19 @@ async fn handle_session_start(
             root: resolve_worktree_root(working_dir, None),
         },
     );
+
+    // Mirror any depgraph load-time warning into this session's log so
+    // the cold fallback after a version-mismatch / corrupt depgraph.bin
+    // is visible to operators reading `last-session.log`. Issue #320.
+    {
+        let warning_opt = {
+            let guard = state.depgraph_load_warning.lock().await;
+            guard.clone()
+        };
+        if let Some(warning) = warning_opt {
+            write_session_log(&state.sessions, &session_id, &warning);
+        }
+    }
 
     // Watch the working directory for file changes.
     watch_directory(state, working_dir).await;

--- a/crates/zccache-daemon/tests/depgraph_warm_classify_test.rs
+++ b/crates/zccache-daemon/tests/depgraph_warm_classify_test.rs
@@ -1,0 +1,288 @@
+//! Integration tests for issue #320 - Option 2.
+//!
+//! A fresh daemon pointed at a populated cache dir must auto-classify the
+//! session as warm by loading the persisted `depgraph.bin` written by a prior
+//! session. Version-mismatch and corrupt files must fall back to cold AND
+//! emit a clear warning visible in the per-session `last-session.log`.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+use zccache_core::NormalizedPath;
+use zccache_daemon::DaemonServer;
+use zccache_depgraph::{
+    classify_load, depgraph_file_path, save_to_file, CompileContext, ContextState, DepGraph,
+    DepGraphLoadOutcome, IncludeSearchPaths, DEPGRAPH_VERSION,
+};
+use zccache_protocol::{Request, Response};
+
+static ENV_SERIAL: Mutex<()> = Mutex::new(());
+
+struct CacheDirGuard {
+    _tmp: tempfile::TempDir,
+    prev: Option<std::ffi::OsString>,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+impl CacheDirGuard {
+    fn new() -> Self {
+        let lock = ENV_SERIAL.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::TempDir::new().unwrap();
+        let prev = std::env::var_os(zccache_core::config::CACHE_DIR_ENV);
+        std::env::set_var(zccache_core::config::CACHE_DIR_ENV, tmp.path());
+        Self {
+            _tmp: tmp,
+            prev,
+            _lock: lock,
+        }
+    }
+}
+
+impl Drop for CacheDirGuard {
+    fn drop(&mut self) {
+        match self.prev.take() {
+            Some(v) => std::env::set_var(zccache_core::config::CACHE_DIR_ENV, v),
+            None => std::env::remove_var(zccache_core::config::CACHE_DIR_ENV),
+        }
+    }
+}
+
+fn make_ctx(source: &str) -> CompileContext {
+    CompileContext {
+        source_file: NormalizedPath::from(source),
+        include_search: IncludeSearchPaths::default(),
+        defines: Vec::new(),
+        flags: Vec::new(),
+        force_includes: Vec::new(),
+        unknown_flags: Vec::new(),
+    }
+}
+
+async fn start_daemon_with_warning(
+    endpoint: &str,
+    warning: Option<String>,
+    preloaded_graph: Option<DepGraph>,
+) -> (JoinHandle<()>, Arc<Notify>) {
+    let mut server = DaemonServer::bind(endpoint).unwrap();
+    if let Some(graph) = preloaded_graph {
+        server.set_dep_graph(graph);
+    }
+    if let Some(w) = warning {
+        server.set_depgraph_load_warning(w);
+    }
+    let shutdown = server.shutdown_handle();
+    let handle = tokio::spawn(async move {
+        server.run(0).await.unwrap();
+    });
+    (handle, shutdown)
+}
+
+async fn start_session_and_capture_log(endpoint: &str, log_file: &std::path::Path) -> String {
+    let mut client = zccache_ipc::connect(endpoint).await.unwrap();
+    client
+        .send(&Request::SessionStart {
+            client_pid: std::process::id(),
+            working_dir: std::env::temp_dir().to_string_lossy().into_owned().into(),
+            log_file: Some(log_file.to_string_lossy().into_owned().into()),
+            track_stats: false,
+            journal_path: None,
+        })
+        .await
+        .unwrap();
+    match client.recv().await.unwrap() {
+        Some(Response::SessionStarted { .. }) => {}
+        other => panic!("unexpected: {other:?}"),
+    }
+    if log_file.exists() {
+        std::fs::read_to_string(log_file).unwrap_or_default()
+    } else {
+        String::new()
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn valid_depgraph_makes_session_warm() {
+    let _guard = CacheDirGuard::new();
+
+    let graph = DepGraph::new();
+    let key = graph.register(make_ctx("/src/main.cpp"));
+    graph.update(
+        &key,
+        zccache_depgraph::ScanResult {
+            resolved: vec![NormalizedPath::from("/inc/a.h")],
+            unresolved: Vec::new(),
+            has_computed: false,
+        },
+        |_| Some(zccache_hash::hash_bytes(b"x")),
+    );
+    assert_eq!(graph.get_state(&key), Some(ContextState::Warm));
+
+    let path = depgraph_file_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    save_to_file(&graph, &path).unwrap();
+
+    let outcome = classify_load(&path);
+    let loaded = match outcome {
+        DepGraphLoadOutcome::Loaded { graph } => graph,
+        other => panic!("expected Loaded, got {other:?}"),
+    };
+    assert_eq!(loaded.stats().context_count, 1);
+    assert_eq!(loaded.get_state(&key), Some(ContextState::Warm));
+    assert!(!loaded.is_cold(&key), "reloaded context must be warm");
+}
+
+#[tokio::test]
+#[ignore]
+async fn corrupt_depgraph_emits_warning_in_session_log() {
+    let _guard = CacheDirGuard::new();
+
+    let path = depgraph_file_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(&path, [0xFFu8, 0xFF, 0xFF, 0xFF, b'n', b'o', b't']).unwrap();
+
+    let outcome = classify_load(&path);
+    assert!(matches!(outcome, DepGraphLoadOutcome::Corrupt { .. }));
+    let warning = outcome.warning(&path).expect("corrupt must warn");
+
+    let endpoint = zccache_ipc::unique_test_endpoint();
+    let (handle, shutdown) = start_daemon_with_warning(&endpoint, Some(warning), None).await;
+
+    let log_path: PathBuf =
+        std::env::temp_dir().join(format!("zccache_320_corrupt_{}.log", std::process::id()));
+    let _ = std::fs::remove_file(&log_path);
+
+    let log_contents = start_session_and_capture_log(&endpoint, &log_path).await;
+
+    assert!(
+        log_contents.contains("corrupt"),
+        "session log must mention corruption: {log_contents:?}"
+    );
+    assert!(
+        log_contents.contains("treating session as cold"),
+        "session log must mention cold fallback: {log_contents:?}"
+    );
+
+    shutdown.notify_one();
+    handle.await.unwrap();
+    let _ = std::fs::remove_file(&log_path);
+}
+
+#[tokio::test]
+#[ignore]
+async fn version_mismatch_depgraph_emits_warning_in_session_log() {
+    let _guard = CacheDirGuard::new();
+
+    let path = depgraph_file_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    let mut data = Vec::new();
+    data.extend_from_slice(&[0x5A, 0x43, 0x44, 0x47]);
+    data.extend_from_slice(&99u32.to_le_bytes());
+    data.extend_from_slice(&0u64.to_le_bytes());
+    std::fs::write(&path, &data).unwrap();
+
+    let outcome = classify_load(&path);
+    match &outcome {
+        DepGraphLoadOutcome::VersionMismatch {
+            file_version: 99,
+            expected_version,
+        } => assert_eq!(*expected_version, DEPGRAPH_VERSION),
+        other => panic!("expected VersionMismatch, got {other:?}"),
+    }
+    let warning = outcome.warning(&path).expect("must warn");
+
+    let endpoint = zccache_ipc::unique_test_endpoint();
+    let (handle, shutdown) = start_daemon_with_warning(&endpoint, Some(warning), None).await;
+
+    let log_path: PathBuf =
+        std::env::temp_dir().join(format!("zccache_320_vmm_{}.log", std::process::id()));
+    let _ = std::fs::remove_file(&log_path);
+
+    let log_contents = start_session_and_capture_log(&endpoint, &log_path).await;
+
+    assert!(
+        log_contents.contains("version 99"),
+        "session log must mention file version: {log_contents:?}"
+    );
+    assert!(
+        log_contents.contains("treating session as cold"),
+        "session log must mention cold fallback: {log_contents:?}"
+    );
+
+    shutdown.notify_one();
+    handle.await.unwrap();
+    let _ = std::fs::remove_file(&log_path);
+}
+
+#[tokio::test]
+#[ignore]
+async fn missing_depgraph_emits_no_warning() {
+    let _guard = CacheDirGuard::new();
+
+    let path = depgraph_file_path();
+    assert!(!path.exists(), "precondition: no depgraph on disk");
+
+    let outcome = classify_load(&path);
+    assert!(matches!(outcome, DepGraphLoadOutcome::Missing));
+    assert!(outcome.warning(&path).is_none());
+
+    let endpoint = zccache_ipc::unique_test_endpoint();
+    let (handle, shutdown) = start_daemon_with_warning(&endpoint, None, None).await;
+
+    let log_path: PathBuf =
+        std::env::temp_dir().join(format!("zccache_320_missing_{}.log", std::process::id()));
+    let _ = std::fs::remove_file(&log_path);
+
+    let log_contents = start_session_and_capture_log(&endpoint, &log_path).await;
+
+    assert!(
+        !log_contents.contains("depgraph"),
+        "missing depgraph must produce no session-log warning: {log_contents:?}"
+    );
+
+    shutdown.notify_one();
+    handle.await.unwrap();
+    let _ = std::fs::remove_file(&log_path);
+}
+
+#[tokio::test]
+#[ignore]
+async fn loaded_graph_with_missing_artifact_is_still_warm() {
+    let _guard = CacheDirGuard::new();
+
+    let graph = DepGraph::new();
+    let key = graph.register(make_ctx("/src/orphan.cpp"));
+    graph.update(
+        &key,
+        zccache_depgraph::ScanResult {
+            resolved: Vec::new(),
+            unresolved: Vec::new(),
+            has_computed: false,
+        },
+        |_| Some(zccache_hash::hash_bytes(b"orphan")),
+    );
+
+    let path = depgraph_file_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    save_to_file(&graph, &path).unwrap();
+
+    let outcome = classify_load(&path);
+    let loaded = match outcome {
+        DepGraphLoadOutcome::Loaded { graph } => graph,
+        other => panic!("expected Loaded, got {other:?}"),
+    };
+
+    assert!(
+        !loaded.is_cold(&key),
+        "context must be warm-classified even when artifact bytes are missing",
+    );
+}

--- a/crates/zccache-depgraph/src/lib.rs
+++ b/crates/zccache-depgraph/src/lib.rs
@@ -34,7 +34,8 @@ pub use session::{
     FinalizedSessionStats, Session, SessionConfig, SessionId, SessionManager, SessionStatsTracker,
 };
 pub use snapshot::{
-    depgraph_file_path, load_from_file, save_to_file, SnapshotError, DEPGRAPH_VERSION,
+    classify_load, depgraph_file_path, load_from_file, save_to_file, DepGraphLoadOutcome,
+    SnapshotError, DEPGRAPH_VERSION,
 };
 pub use system_includes::{discovery_args, parse_system_include_output, SystemIncludeCache};
 pub use watcher_support::WatchSet;

--- a/crates/zccache-depgraph/src/snapshot.rs
+++ b/crates/zccache-depgraph/src/snapshot.rs
@@ -323,6 +323,105 @@ pub fn save_to_file(graph: &DepGraph, path: &Path) -> Result<(), SnapshotError> 
     Ok(())
 }
 
+/// Outcome of attempting to load the persisted depgraph from a cache directory.
+///
+/// Returned by [`classify_load`] so the daemon can both seed its in-memory
+/// graph and surface the load result to operators (stderr + `last-session.log`).
+/// The variants mirror the failure modes the daemon must handle distinctly:
+///
+/// - `Loaded` — file present, magic + version + payload all valid; the graph
+///   is ready to serve hits from the very first lookup.
+/// - `Missing` — no `depgraph.bin` in the cache dir. Genuine cold start.
+/// - `VersionMismatch` — file present but the embedded version tag does not
+///   match this build. The on-disk format changed since the prior session.
+/// - `Corrupt` — magic mismatch, truncated, or payload validation failed.
+/// - `IoError` — any other I/O failure reading the file.
+#[derive(Debug)]
+pub enum DepGraphLoadOutcome {
+    Loaded {
+        graph: DepGraph,
+    },
+    Missing,
+    VersionMismatch {
+        file_version: u32,
+        expected_version: u32,
+    },
+    Corrupt {
+        message: String,
+    },
+    IoError {
+        message: String,
+    },
+}
+
+impl DepGraphLoadOutcome {
+    /// Returns the loaded graph if this outcome is `Loaded`, else `None`.
+    #[must_use]
+    pub fn into_graph(self) -> Option<DepGraph> {
+        match self {
+            Self::Loaded { graph } => Some(graph),
+            _ => None,
+        }
+    }
+
+    /// Returns a human-readable warning message for non-`Loaded`, non-`Missing`
+    /// outcomes. Used by the daemon to emit a clear notice on stderr AND in the
+    /// per-session log so operators can see exactly why the warm-load failed
+    /// and the session fell back to cold behavior.
+    #[must_use]
+    pub fn warning(&self, path: &Path) -> Option<String> {
+        match self {
+            Self::Loaded { .. } | Self::Missing => None,
+            Self::VersionMismatch {
+                file_version,
+                expected_version,
+            } => Some(format!(
+                "warning: persisted depgraph at {} has version {file_version}, expected {expected_version}; treating session as cold",
+                path.display()
+            )),
+            Self::Corrupt { message } => Some(format!(
+                "warning: persisted depgraph at {} is corrupt ({message}); treating session as cold",
+                path.display()
+            )),
+            Self::IoError { message } => Some(format!(
+                "warning: failed to read persisted depgraph at {} ({message}); treating session as cold",
+                path.display()
+            )),
+        }
+    }
+}
+
+/// Classify a load attempt at `path` into a structured outcome.
+///
+/// This is the load-and-classify helper called by the daemon at startup so a
+/// fresh session pointed at a populated cache dir is automatically treated as
+/// warm — no caller-side opt-in required. See issue #320.
+///
+/// On non-`Loaded` outcomes the returned value carries enough information to
+/// generate a stderr/session-log warning via [`DepGraphLoadOutcome::warning`].
+#[must_use]
+pub fn classify_load(path: &Path) -> DepGraphLoadOutcome {
+    match load_from_file(path) {
+        Ok(graph) => DepGraphLoadOutcome::Loaded { graph },
+        Err(SnapshotError::Io(ref e)) if e.kind() == std::io::ErrorKind::NotFound => {
+            DepGraphLoadOutcome::Missing
+        }
+        Err(SnapshotError::Io(e)) => DepGraphLoadOutcome::IoError {
+            message: e.to_string(),
+        },
+        Err(SnapshotError::VersionMismatch { file, expected }) => {
+            DepGraphLoadOutcome::VersionMismatch {
+                file_version: file,
+                expected_version: expected,
+            }
+        }
+        Err(SnapshotError::BadMagic) => DepGraphLoadOutcome::Corrupt {
+            message: "bad magic bytes".into(),
+        },
+        Err(SnapshotError::Corrupt(message)) => DepGraphLoadOutcome::Corrupt { message },
+    }
+}
+
 /// Load the dependency graph from disk, validating header and payload.
 pub fn load_from_file(path: &Path) -> Result<DepGraph, SnapshotError> {
     let data = std::fs::read(path)?;
@@ -1879,5 +1978,91 @@ mod tests {
             load_from_file(&path).is_err(),
             "overflow-inducing payload_len must be rejected"
         );
+    }
+
+    // ── classify_load tests (issue #320) ─────────────────────────────────────
+
+    #[test]
+    fn classify_load_missing_returns_missing() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("absent.bin");
+
+        let outcome = classify_load(&path);
+        assert!(matches!(outcome, DepGraphLoadOutcome::Missing));
+        assert!(outcome.warning(&path).is_none(), "Missing must not warn");
+        assert!(outcome.into_graph().is_none());
+    }
+
+    #[test]
+    fn classify_load_valid_returns_loaded() {
+        let dir = TempDir::new().unwrap();
+        let path = test_path(&dir);
+
+        let graph = DepGraph::new();
+        let _ = graph.register(make_ctx("/src/main.cpp"));
+        save_to_file(&graph, &path).unwrap();
+
+        let outcome = classify_load(&path);
+        assert!(matches!(outcome, DepGraphLoadOutcome::Loaded { .. }));
+        assert!(outcome.warning(&path).is_none(), "Loaded must not warn");
+        let loaded = outcome.into_graph().expect("Loaded must yield graph");
+        assert_eq!(loaded.stats().context_count, 1);
+    }
+
+    #[test]
+    fn classify_load_version_mismatch_warns() {
+        let dir = TempDir::new().unwrap();
+        let path = test_path(&dir);
+
+        let mut data = Vec::new();
+        data.extend_from_slice(&DEPGRAPH_MAGIC);
+        data.extend_from_slice(&99u32.to_le_bytes());
+        data.extend_from_slice(&0u64.to_le_bytes());
+        std::fs::write(&path, &data).unwrap();
+
+        let outcome = classify_load(&path);
+        match &outcome {
+            DepGraphLoadOutcome::VersionMismatch {
+                file_version: 99,
+                expected_version,
+            } => {
+                assert_eq!(*expected_version, DEPGRAPH_VERSION);
+            }
+            other => panic!("expected VersionMismatch, got {other:?}"),
+        }
+        let warning = outcome.warning(&path).expect("must warn");
+        assert!(warning.contains("version 99"));
+        assert!(warning.contains("treating session as cold"));
+    }
+
+    #[test]
+    fn classify_load_bad_magic_is_corrupt() {
+        let dir = TempDir::new().unwrap();
+        let path = test_path(&dir);
+
+        let mut data = Vec::new();
+        data.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF]);
+        data.extend_from_slice(&DEPGRAPH_VERSION.to_le_bytes());
+        data.extend_from_slice(&0u64.to_le_bytes());
+        std::fs::write(&path, &data).unwrap();
+
+        let outcome = classify_load(&path);
+        assert!(matches!(outcome, DepGraphLoadOutcome::Corrupt { .. }));
+        let warning = outcome.warning(&path).expect("must warn");
+        assert!(warning.contains("corrupt"));
+        assert!(warning.contains("treating session as cold"));
+    }
+
+    #[test]
+    fn classify_load_truncated_is_corrupt() {
+        let dir = TempDir::new().unwrap();
+        let path = test_path(&dir);
+
+        // Too small to even hold the header.
+        std::fs::write(&path, [0x5Au8, 0x43, 0x44]).unwrap();
+
+        let outcome = classify_load(&path);
+        assert!(matches!(outcome, DepGraphLoadOutcome::Corrupt { .. }));
+        assert!(outcome.warning(&path).is_some());
     }
 }


### PR DESCRIPTION
Closes #320.

## Summary

zccache v1.8.1 emitted `verdict=Cold reason=cold_skip` for every lookup on
warm rebuilds even when the persisted `depgraph.bin` from a prior session was
present. The daemon was already loading the depgraph at startup, but a load
failure (version mismatch / corruption) only logged via `tracing::warn!`,
which gets swallowed by the daemon's `detach_stdio()` — so the cold fallback
was invisible in both stderr and `last-session.log`.

This PR ships **Option 2** from the issue: classify the session by what is on
disk, not by session lineage. No new flag, no protocol version bump.

## Changes

- **`zccache-depgraph`** — new `classify_load(path) -> DepGraphLoadOutcome`
  with structured `Loaded` / `Missing` / `VersionMismatch` / `Corrupt` /
  `IoError` variants. Each non-`Loaded` variant emits a human-readable
  warning via `DepGraphLoadOutcome::warning(path)`. Unit-tested in
  `snapshot.rs`.
- **`zccache-daemon` main.rs** — replace ad-hoc load+log with
  `classify_load`. Print the warning to stderr at startup AND forward it to
  `DaemonServer::set_depgraph_load_warning` so the daemon mirrors it into
  every session log at `SessionStart`. The cold fallback is now visible in
  `last-session.log`.
- **`zccache-daemon` server.rs** — new `depgraph_load_warning:
  Mutex<Option<String>>` field on `SharedState`; `handle_session_start`
  appends the stashed warning to the session log on the first write.
- **Integration tests** (`tests/depgraph_warm_classify_test.rs`) — five
  ignored-by-default tests covering the acceptance criteria:
  - valid persisted file → context reloads as `Warm`, `is_cold` returns
    `false` (AC #1, #2, #3).
  - corrupt file → warning string lands in the session log + cold fallback
    (AC #4).
  - version-mismatched file → warning lands + cold fallback (AC #4).
  - missing file → no warning, behavior unchanged (AC #5).
  - loaded depgraph references missing artifact → still warm-classified
    (artifact existence is a downstream miss).

## Non-changes

- `PROTOCOL_VERSION` unchanged — no wire format change.
- `--no-depgraph-cache` path is preserved verbatim.
- Existing `depgraph_persistence_test` integration tests still pass.

## Test plan

- [x] `soldr cargo fmt --all`
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings`
- [x] `soldr cargo test --workspace --lib` — 1370+ unit tests pass, including
  five new `classify_load_*` tests in `snapshot.rs`.
- [x] `soldr cargo test -p zccache-daemon --test depgraph_warm_classify_test
  -- --ignored` — all 5 new integration tests pass.
- [x] `soldr cargo test -p zccache-daemon --test depgraph_persistence_test
  -- --ignored` — existing 3 persistence tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)