### PR TITLE
fix(daemon): artifact lookup falls through to on-disk store on DashMap miss

### DIFF
--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -608,6 +608,54 @@ struct SharedState {
     dep_graph_persisted: AtomicBool,
 }
 
+/// Look up an artifact by key, falling through to the on-disk
+/// [`ArtifactStore`] when the in-memory [`SharedState::artifacts`] DashMap
+/// has not yet been hydrated.
+///
+/// # Why the fallthrough is required
+///
+/// Daemon startup spawns a background task that copies every entry from
+/// `state.artifact_store` (loaded synchronously by `ArtifactStore::open`)
+/// into `state.artifacts`. The daemon begins accepting IPC requests
+/// immediately, before that background task finishes. Without this
+/// helper, the warm-after-restore window (`soldr load` → first compile)
+/// reports MISS on every lookup until the DashMap catches up — measured
+/// at 0/115 hits on the medium fixture's `cold-tar-untar-warm`
+/// scenario (perf-cluster run 26255457227).
+///
+/// The DashMap is a cache *of* the on-disk store; the on-disk store is
+/// the source of truth for artifact existence. Lookups now:
+/// 1. Hit the in-memory DashMap (fast path; populated by stores +
+///    background load).
+/// 2. On miss, consult the in-memory hashmap that backs
+///    [`ArtifactStore::open`] (also fast — already hydrated from
+///    `index.bin` at daemon bind time).
+/// 3. On disk-store hit, hydrate the DashMap so subsequent lookups
+///    skip the fallback entirely.
+///
+/// # Why two `get_mut` calls
+///
+/// DashMap forbids holding a shard lock (`get_mut` returns a guard
+/// holding it) across an `insert` on the same map — that would
+/// deadlock. We release the first guard's `None` arm, do the
+/// disk-store lookup + insert, then take a fresh `get_mut` to hand
+/// back. The `insert` + re-`get_mut` is on the cold path (DashMap
+/// miss + disk-store hit), so the extra hash is dwarfed by the
+/// hardlink/write work that follows.
+fn lookup_artifact_with_disk_fallback<'a>(
+    state: &'a SharedState,
+    key_hex: &str,
+) -> Option<dashmap::mapref::one::RefMut<'a, String, CachedArtifact>> {
+    if let Some(entry) = state.artifacts.get_mut(key_hex) {
+        return Some(entry);
+    }
+    let meta = state.artifact_store.get(key_hex)?;
+    state
+        .artifacts
+        .insert(key_hex.to_string(), CachedArtifact::from_index(meta));
+    state.artifacts.get_mut(key_hex)
+}
+
 /// Pre-computed compile request data for the request-level fast path.
 struct RequestCacheEntry {
     context_key: ContextKey,
@@ -946,6 +994,41 @@ impl DaemonServer {
     #[must_use]
     pub fn profile_snapshot(&self) -> crate::stats::ProfileSnapshot {
         self.state.profiler.snapshot()
+    }
+
+    /// Test-only seam: exercise the DashMap → on-disk-`ArtifactStore`
+    /// fallback used by every artifact-lookup site.
+    ///
+    /// Returns `true` if the key is found either in the in-memory
+    /// `artifacts` DashMap or in the on-disk artifact store (in which
+    /// case the DashMap is hydrated as a side-effect). Lets perf tests
+    /// assert that warm-after-restore lookups hit the on-disk store
+    /// without spinning up an IPC server + real compile.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn test_lookup_artifact(&self, key_hex: &str) -> bool {
+        lookup_artifact_with_disk_fallback(&self.state, key_hex).is_some()
+    }
+
+    /// Test-only seam: report whether the background artifact-load
+    /// task has finished hydrating `state.artifacts`. Used by
+    /// `perf_artifact_fallback_test.rs` to assert that the fallback
+    /// path is the one being exercised (not the post-load fast path).
+    #[doc(hidden)]
+    #[must_use]
+    pub fn test_artifacts_loaded(&self) -> bool {
+        self.state.artifacts_loaded.load(Ordering::Acquire)
+    }
+
+    /// Test-only seam: report the number of entries currently in the
+    /// in-memory `state.artifacts` DashMap. Lets the perf test assert
+    /// that a fresh bind (before `run()`) starts with an empty
+    /// DashMap, proving that any subsequent hit comes from the
+    /// on-disk fallback path.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn test_artifacts_len(&self) -> usize {
+        self.state.artifacts.len()
     }
 
     /// Run the server, accepting connections until shutdown is signaled.
@@ -2123,7 +2206,7 @@ async fn handle_link_ephemeral(
     let key_hex = cache_key.to_hex();
 
     // 5. Cache lookup
-    if let Some(mut entry) = state.artifacts.get_mut(&key_hex) {
+    if let Some(mut entry) = lookup_artifact_with_disk_fallback(state, &key_hex) {
         entry.last_used = std::time::Instant::now();
         // Load payloads from disk if not already loaded.
         let loaded = ensure_payloads(&mut entry, &state.artifact_dir, &key_hex).is_some();
@@ -4813,7 +4896,9 @@ async fn handle_compile(
                         && inputs_match
                     {
                         let t_artifact_lookup = std::time::Instant::now();
-                        if let Some(mut cached_ref) = state.artifacts.get_mut(artifact_key_hex) {
+                        if let Some(mut cached_ref) =
+                            lookup_artifact_with_disk_fallback(state, artifact_key_hex)
+                        {
                             cached_ref.last_used = std::time::Instant::now();
                             let loaded = ensure_payloads(
                                 &mut cached_ref,
@@ -5101,7 +5186,9 @@ async fn handle_compile(
                 let t5 = std::time::Instant::now();
                 // Write directly from DashMap reference — avoids cloning the
                 // entire CachedArtifact (including all .o data, ~50-200KB).
-                if let Some(mut cached_ref) = state.artifacts.get_mut(artifact_key_hex) {
+                if let Some(mut cached_ref) =
+                    lookup_artifact_with_disk_fallback(state, artifact_key_hex)
+                {
                     cached_ref.last_used = std::time::Instant::now();
                     let artifact_lookup_ns = t5.elapsed().as_nanos() as u64;
                     let t6 = std::time::Instant::now();
@@ -5370,7 +5457,9 @@ async fn handle_compile(
             // ── Phase: artifact lookup + write ─────────────────────────
             let t5 = std::time::Instant::now();
             let artifact_key_hex = artifact_key.hash().to_hex();
-            if let Some(mut cached_ref) = state.artifacts.get_mut(&artifact_key_hex) {
+            if let Some(mut cached_ref) =
+                lookup_artifact_with_disk_fallback(state, &artifact_key_hex)
+            {
                 cached_ref.last_used = std::time::Instant::now();
                 let artifact_lookup_ns = t5.elapsed().as_nanos() as u64;
 
@@ -6318,7 +6407,9 @@ fn check_unit_cache(
                 // cloning all .o data (~50-200KB per file) into PendingWrite.
                 // Each check_unit_cache runs in its own spawn_blocking task,
                 // so writes are already parallel across units.
-                if let Some(mut cached_ref) = state.artifacts.get_mut(artifact_key_hex) {
+                if let Some(mut cached_ref) =
+                    lookup_artifact_with_disk_fallback(state, artifact_key_hex)
+                {
                     cached_ref.last_used = std::time::Instant::now();
                     let loaded =
                         ensure_payloads(&mut cached_ref, &state.artifact_dir, artifact_key_hex)
@@ -6431,7 +6522,7 @@ fn check_unit_cache(
     | zccache_depgraph::CacheVerdict::SourceChanged { artifact_key } = verdict
     {
         let artifact_key_hex = artifact_key.hash().to_hex();
-        if let Some(mut cached_ref) = state.artifacts.get_mut(&artifact_key_hex) {
+        if let Some(mut cached_ref) = lookup_artifact_with_disk_fallback(state, &artifact_key_hex) {
             cached_ref.last_used = std::time::Instant::now();
             let t_lookup = t0.elapsed();
             let loaded =

--- a/crates/zccache-daemon/tests/perf_artifact_fallback_test.rs
+++ b/crates/zccache-daemon/tests/perf_artifact_fallback_test.rs
@@ -1,0 +1,169 @@
+//! Perf regression test for the DashMap → on-disk-`ArtifactStore`
+//! lookup fallthrough.
+//!
+//! regression test for the cold-tar-untar-warm warm-side 0% hit rate
+//! measured on run 26255457227
+//!
+//! Background
+//! ----------
+//! Daemon startup loads the on-disk `index.bin` synchronously inside
+//! `ArtifactStore::open`, then *asynchronously* mirrors those entries
+//! into `state.artifacts` (a `DashMap`) via a background task. Every
+//! artifact-lookup site historically went `state.artifacts.get_mut`
+//! and treated `None` as MISS — so the warm-after-restore window
+//! (`soldr load` → first compile, before the background task has
+//! drained) reported a cache miss on every key, even though the
+//! entry was already present in the on-disk store.
+//!
+//! Measured on perf-cluster run 26255457227 (medium fixture,
+//! `cold-tar-untar-warm` scenario): 0 hits / 115 cacheable lookups
+//! on the warm-side daemon. Cold and warm cache keys matched
+//! byte-for-byte (115/115 ctx + 115/115 artifact_key) — the lookup
+//! itself was the bug.
+//!
+//! What this test asserts (see inline asserts for the details):
+//!
+//! - A fresh daemon, bound at a `cache_dir` whose `index.bin` has been
+//!   pre-populated, sees an empty in-memory DashMap.
+//! - The lookup helper returns `Some` anyway — proof that the fallthrough
+//!   to the on-disk `ArtifactStore` works.
+//! - After the first fallthrough, the DashMap is hydrated, so a
+//!   subsequent lookup hits the fast path (DashMap len == 1).
+//! - The fallback lookup completes inside a 50 ms budget. The on-disk
+//!   store is itself an in-memory hashmap (hydrated by
+//!   `ArtifactStore::open`), so the cost is a DashMap miss + a hashmap
+//!   hit + a tiny `from_index` conversion + an insert. 50 ms is
+//!   generous against the actual single-digit-µs cost; the budget
+//!   catches accidentally re-introducing a disk read or a blocking
+//!   syscall on the lookup hot path.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+use zccache_artifact::{ArtifactIndex, ArtifactStore};
+use zccache_core::NormalizedPath;
+use zccache_daemon::DaemonServer;
+
+/// Cache layout helper: pre-populate `index.bin` with one entry
+/// keyed `key_hex` and return the cache_dir the daemon should bind
+/// against.
+fn seed_cache_dir(dir: &TempDir, key_hex: &str) -> NormalizedPath {
+    let cache_dir = NormalizedPath::new(dir.path());
+    let artifact_dir = zccache_core::config::artifacts_dir_from_cache_dir(&cache_dir);
+    std::fs::create_dir_all(&artifact_dir).expect("create artifact dir");
+
+    // Write the payload file the daemon expects at `{artifact_dir}/{key}_0`.
+    // The actual byte contents don't matter for this test — we never load
+    // the payload — but the file's *size* must match
+    // `ArtifactIndex::output_sizes[0]` so `ensure_payloads` would accept
+    // it on a real cache-hit codepath. We use a 4-byte payload for clarity.
+    let payload: &[u8] = b"abcd";
+    let payload_path = artifact_dir.join(format!("{key_hex}_0"));
+    std::fs::write(payload_path.as_path(), payload).expect("write payload");
+
+    // Build a one-entry `index.bin` with `ArtifactStore`, then drop the
+    // store so the daemon's own `ArtifactStore::open` reads the blob
+    // from disk like a fresh restore.
+    let index_path = zccache_core::config::index_path_from_cache_dir(&cache_dir);
+    {
+        let store = ArtifactStore::open(index_path.as_path()).expect("open store");
+        let meta = ArtifactIndex::new(
+            vec!["foo.o".to_string()],
+            vec![payload.len() as u64],
+            b"compiler stdout".to_vec(),
+            b"compiler stderr".to_vec(),
+            0,
+        );
+        store.insert(key_hex, &meta);
+        store.flush().expect("flush index.bin");
+    }
+    assert!(index_path.exists(), "seeded index.bin should exist on disk");
+
+    cache_dir
+}
+
+#[tokio::test]
+async fn perf_artifact_lookup_hits_before_background_load_completes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // 32-byte hex string — same shape `ContentHash::to_hex` would
+    // produce on a real cache entry. Content is irrelevant; we only
+    // need it to round-trip through `index.bin`.
+    let key_hex = "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abcd";
+    let cache_dir = seed_cache_dir(&dir, key_hex);
+
+    let endpoint = zccache_ipc::unique_test_endpoint();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).expect("bind daemon");
+
+    // Critical invariant 1: the in-memory DashMap is empty immediately
+    // after `bind_with_cache_dir`. The background-load task does not
+    // run until `server.run(...)` is awaited; this proves the next
+    // lookup MUST go through the on-disk fallback to succeed.
+    assert_eq!(
+        server.test_artifacts_len(),
+        0,
+        "DashMap should be empty before the background load runs"
+    );
+    assert!(
+        !server.test_artifacts_loaded(),
+        "artifacts_loaded flag should still be false (background task hasn't run)"
+    );
+
+    // Critical invariant 2: lookup hits via the on-disk fallback,
+    // not via the DashMap (which we just asserted is empty).
+    let t0 = Instant::now();
+    let found = server.test_lookup_artifact(key_hex);
+    let lookup_elapsed = t0.elapsed();
+    assert!(
+        found,
+        "lookup must hit via on-disk fallback; got MISS — regression of run 26255457227"
+    );
+
+    // Critical invariant 3: the fallback path hydrates the DashMap
+    // so subsequent lookups skip the fallback entirely.
+    assert_eq!(
+        server.test_artifacts_len(),
+        1,
+        "DashMap should be populated by the fallback's side-effect"
+    );
+
+    // Critical invariant 4: budget. The fallback is a DashMap miss +
+    // an in-memory hashmap hit + a from_index conversion + an insert.
+    // Nothing on this path should hit disk. 50 ms is generous; the
+    // measured cost is in single-digit µs. A breach means someone
+    // accidentally added a `std::fs::read` or a `spawn_blocking` on
+    // the lookup hot path.
+    const BUDGET: Duration = Duration::from_millis(50);
+    assert!(
+        lookup_elapsed < BUDGET,
+        "on-disk fallback lookup took {lookup_elapsed:?}, budget is {BUDGET:?}"
+    );
+
+    // Sanity: a second lookup also hits, and now goes through the
+    // DashMap fast path (we can't directly observe the path taken,
+    // but `test_artifacts_len` confirmed the hydration).
+    assert!(
+        server.test_lookup_artifact(key_hex),
+        "second lookup must hit via DashMap fast path"
+    );
+
+    // Negative control: an unrelated key returns MISS — neither path
+    // makes up an entry that wasn't seeded.
+    let other_key = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    assert!(
+        !server.test_lookup_artifact(other_key),
+        "unknown keys must still MISS — fallback shouldn't synthesize entries"
+    );
+    assert_eq!(
+        server.test_artifacts_len(),
+        1,
+        "MISS must not insert into the DashMap"
+    );
+
+    // Cleanup: drop the server so its background tasks (none have
+    // started, but `Arc` cycles still need releasing) can unwind.
+    drop(server);
+
+    // Belt-and-suspenders: keep the temp dir alive for the asserts above.
+    let _ = Arc::new(dir);
+}


### PR DESCRIPTION
## Summary

- Warm-after-restore daemon now hits the on-disk `ArtifactStore` when the in-memory `state.artifacts` DashMap hasn't been hydrated yet, instead of returning a spurious MISS during the background-load race window.
- All 6 artifact-lookup sites in `server.rs` now go through a single helper `lookup_artifact_with_disk_fallback(state, key)` that hydrates the DashMap on disk-store hit, so the next lookup takes the fast path.
- New perf unit test asserts a fresh daemon serves a cached key on the first lookup after `index.bin` restore, with a 50ms budget on the fallback path.

## The measurement (perf-cluster run 26255457227)

Medium fixture, `cold-tar-untar-warm` scenario:

| Side | Hits | Cacheable lookups | Hit rate | Speedup |
|---|---|---|---|---|
| Cold | — | 115 | n/a | baseline |
| Warm (after `soldr load`) | **0** | **115** | **0.0%** | 1.15x (gate: 3x) |

Cold and warm journals showed identical cache keys (115/115 ctx, 115/115 artifact_key). The keys were correct; the lookup was the bug.

## Root cause

`crates/zccache-daemon/src/server.rs:1043` spawns a background task that mirrors the on-disk `ArtifactStore` into the in-memory `DashMap<String, CachedArtifact>`. The daemon accepts IPC requests immediately, before that task drains. Every lookup site went `state.artifacts.get_mut(key)` and treated `None` as MISS — so the entire warm-after-restore window reported MISS even though the entry was already in `state.artifact_store` (which `ArtifactStore::open` hydrates synchronously at bind time).

## The fix

Architecturally the `DashMap` is a cache of the on-disk store. Lookups now:

1. Hit the in-memory `DashMap` (fast path — populated by stores and background load).
2. On miss, hit `state.artifact_store.get(key)` (also fast — an in-memory `DashMap` itself, hydrated at `bind_with_cache_dir`).
3. On disk-store hit, insert into `state.artifacts` so future lookups skip step 2.

The background-load task is now a pure warm-up optimization. The two-phase `get_mut` → `insert` → `get_mut` pattern is required because DashMap forbids holding a shard `RefMut` across an `insert` on the same map.

Helper-fn pattern, not inlined: a single `lookup_artifact_with_disk_fallback` helper lives next to `SharedState`, and every site (six in total — line numbers from the original report: 2126, 4816, 5104, 5373, 6321, 6434) calls it. This keeps the borrow-checker-aware two-phase dance in one place and stays uniform across the six sites.

## Test plan

- [x] `soldr cargo check --workspace --all-targets` — clean
- [x] `soldr cargo clippy -p zccache-daemon --all-targets -- -D warnings` — clean
- [x] `soldr cargo fmt --all` — formatted
- [x] `soldr cargo test -p zccache-daemon --lib` — 223 passed, 0 failed
- [x] `soldr cargo test -p zccache-artifact` — 5 passed, 0 failed
- [x] `soldr cargo test -p zccache-daemon --test perf_artifact_fallback_test -- --nocapture` — 1 passed in 0.02s
- [ ] Perf cluster: re-run the medium / cold-tar-untar-warm scenario on the same fixture used for run 26255457227 — expect ≥3x warm-side speedup (currently 1.15x).

The new test (`perf_artifact_lookup_hits_before_background_load_completes`) does not call `server.run()`; it asserts the empty-DashMap invariant up-front, calls the test seam, and proves both that the fallback hits and that it hydrates the DashMap (len 0 → 1) — directly exercising the warm-after-restore race window.

## Files modified

- `crates/zccache-daemon/src/server.rs` — new `lookup_artifact_with_disk_fallback` helper, three `#[doc(hidden)] pub` test seams (`test_lookup_artifact`, `test_artifacts_loaded`, `test_artifacts_len`), and 6 call-site swaps.
- `crates/zccache-daemon/tests/perf_artifact_fallback_test.rs` — new perf regression test, marked with the run ID and the bug it prevents.

Per PERF.md "Preventing regressions — add a perf unit test."

🤖 Generated with [Claude Code](https://claude.com/claude-code)