### PR TITLE
perf(depgraph): hash-fallback in check_diagnostic; warm 30s→12s, gate 3x→4.5x

### DIFF
--- a/.github/workflows/perf-rust-cluster.yml
+++ b/.github/workflows/perf-rust-cluster.yml
@@ -569,7 +569,7 @@ jobs:
         include:
           - platform: linux
             runs_on: ubuntu-24.04
-            min_speedup: "3.0"
+            min_speedup: "4.5"
     runs-on: ${{ matrix.runs_on }}
     steps:
       - name: Gate cell against resolved scope

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3813,6 +3813,7 @@ dependencies = [
  "bincode",
  "bytes",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "zccache-core",

--- a/ci/perf_local.py
+++ b/ci/perf_local.py
@@ -290,6 +290,30 @@ def render_summary(results_dir: Path, scenario: str, fixture: str) -> int:
     if report is None:
         report = {}
 
+    # `last-session-stats.json` is zccache's own JSON output (written by
+    # `zccache session-end --json`); it includes `phase_profile` from
+    # PROTOCOL_VERSION 9 onward. Soldr's `cache report` is the
+    # canonical structured form but it copies a fixed set of keys into
+    # `last_session` and strips unknown fields, so a fresh phase_profile
+    # field arrives in `last-session-stats.json` before it surfaces in
+    # the report block. Pull it directly to avoid that lag.
+    if "phase_profile" not in report:
+        stats_candidates = [
+            results_dir / "warm-zccache-logs" / "last-session-stats.json",
+            results_dir / "b-zccache-logs" / "last-session-stats.json",
+        ]
+        for candidate in stats_candidates:
+            if not candidate.is_file():
+                continue
+            try:
+                raw = json.loads(candidate.read_text())
+            except json.JSONDecodeError:
+                continue
+            phase = raw.get("phase_profile")
+            if phase is not None:
+                report["phase_profile"] = phase
+                break
+
     compiles = report.get("compilations")
     hits = report.get("hits")
     misses = report.get("misses")
@@ -301,7 +325,7 @@ def render_summary(results_dir: Path, scenario: str, fixture: str) -> int:
     daemon_rss = result.get("peak_daemon_rss_bytes")
     compile_rss = result.get("peak_compile_rss_bytes")
 
-    threshold = 3.0
+    threshold = 4.5
     verdict = "PASS" if speedup >= threshold else "FAIL"
 
     print()
@@ -337,7 +361,72 @@ def render_summary(results_dir: Path, scenario: str, fixture: str) -> int:
         f"bytes_W={fmt_bytes(bytes_w)} daemon_RSS={fmt_bytes(daemon_rss)}"
     )
 
+    render_phase_breakdown(report.get("phase_profile"))
+
     return 0 if verdict == "PASS" else 1
+
+
+def render_phase_breakdown(phase_profile) -> None:
+    """Print a phase-breakdown table from `SessionStats.phase_profile`.
+
+    Skipped silently when the daemon didn't populate the field (old
+    PROTOCOL_VERSION) or when both hit and miss counts are zero.
+    """
+    if not isinstance(phase_profile, dict):
+        return
+    hit_count = int(phase_profile.get("hit_count") or 0)
+    miss_count = int(phase_profile.get("miss_count") or 0)
+    if hit_count == 0 and miss_count == 0:
+        return
+
+    # (label, total-ns, denom-count). Hit phases use hit_count for the
+    # per-event average; miss phases use miss_count. The two metadata-cache
+    # sub-phases are summed so the table speaks the language used in design
+    # discussion ("metadata cache (source+hdrs)").
+    src_ns = int(phase_profile.get("hash_source_ns") or 0)
+    hdr_ns = int(phase_profile.get("hash_headers_ns") or 0)
+    rows = [
+        ("parse_args",                  int(phase_profile.get("parse_args_ns") or 0),           hit_count),
+        ("build_context",               int(phase_profile.get("build_context_ns") or 0),         hit_count),
+        ("metadata cache (source+hdrs)", src_ns + hdr_ns,                                        hit_count),
+        ("depgraph_check",              int(phase_profile.get("depgraph_check_ns") or 0),        hit_count),
+        ("request_cache_lookup",        int(phase_profile.get("request_cache_lookup_ns") or 0),  hit_count),
+        ("cross_root_validate",         int(phase_profile.get("cross_root_validate_ns") or 0),   hit_count),
+        ("artifact_lookup",             int(phase_profile.get("artifact_lookup_ns") or 0),       hit_count),
+        ("write_output (materialize)",  int(phase_profile.get("write_output_ns") or 0),          hit_count),
+        ("bookkeeping",                 int(phase_profile.get("bookkeeping_ns") or 0),           hit_count),
+        ("compiler_exec",               int(phase_profile.get("compiler_exec_ns") or 0),         miss_count),
+        ("include_scan",                int(phase_profile.get("include_scan_ns") or 0),          miss_count),
+        ("hash_all",                    int(phase_profile.get("hash_all_ns") or 0),              miss_count),
+        ("artifact_store",              int(phase_profile.get("artifact_store_ns") or 0),        miss_count),
+    ]
+    rows.sort(key=lambda r: r[1], reverse=True)
+
+    print()
+    print(
+        f"### Phase breakdown (warm-side daemon — {hit_count} hits, {miss_count} misses)"
+    )
+    print()
+    print("| Phase | Total ms | Avg per event (µs) |")
+    print("| --- | ---: | ---: |")
+    for label, total_ns, denom in rows:
+        if total_ns == 0:
+            continue
+        total_ms = total_ns / 1_000_000
+        if denom > 0:
+            avg_us = total_ns / denom / 1_000
+            avg_cell = f"{avg_us:.1f}"
+        else:
+            avg_cell = "—"
+        print(f"| {label} | {total_ms:.1f} | {avg_cell} |")
+
+    total_hit_ns = int(phase_profile.get("total_hit_ns") or 0)
+    total_miss_ns = int(phase_profile.get("total_miss_ns") or 0)
+    print()
+    print(
+        f"total_hit_ns={total_hit_ns / 1_000_000:.1f}ms "
+        f"total_miss_ns={total_miss_ns / 1_000_000:.1f}ms"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/ci/tests/test_perf_local.py
+++ b/ci/tests/test_perf_local.py
@@ -164,12 +164,12 @@ def _write_scenario_results(
 
 
 def test_render_summary_pass_at_threshold(tmp_path, capsys):
-    """speedup >= 3.0x must return 0 (PASS)."""
+    """speedup >= 4.5x must return 0 (PASS)."""
     results_dir = _write_scenario_results(
         tmp_path,
         "cold-tar-untar-warm",
-        cold_ms=60_000,
-        warm_ms=20_000,  # 3.0x exactly
+        cold_ms=90_000,
+        warm_ms=20_000,  # 4.5x exactly
         cache_report={
             "compilations": 100,
             "hits": 95,
@@ -187,12 +187,12 @@ def test_render_summary_pass_at_threshold(tmp_path, capsys):
     assert rc == 0
     out = capsys.readouterr().out
     assert "**PASS**" in out
-    assert "3.00x" in out
+    assert "4.50x" in out
     assert "95 (95.0%)" in out  # hits cell shows count + ratio inline
 
 
 def test_render_summary_fail_below_threshold(tmp_path, capsys):
-    """speedup < 3.0x must return 1 (FAIL)."""
+    """speedup < 4.5x must return 1 (FAIL)."""
     results_dir = _write_scenario_results(
         tmp_path,
         "cold-tar-untar-warm",
@@ -247,8 +247,8 @@ def test_render_summary_handles_worktree_share_a_b_keys(tmp_path, capsys):
     results_dir = _write_scenario_results(
         tmp_path,
         "worktree-share",
-        cold_ms=12_000,
-        warm_ms=3_000,  # b/a = 4x
+        cold_ms=18_000,
+        warm_ms=3_000,  # b/a = 6x — above the 4.5x gate
         cache_report={
             "compilations": 50,
             "hits": 40,
@@ -266,7 +266,7 @@ def test_render_summary_handles_worktree_share_a_b_keys(tmp_path, capsys):
     assert rc == 0
     out = capsys.readouterr().out
     assert "**PASS**" in out
-    assert "4.00x" in out
+    assert "6.00x" in out
 
 
 def test_render_summary_missing_result_json_fails(tmp_path, capsys):
@@ -312,3 +312,142 @@ def test_render_summary_bad_timing_fails(tmp_path, capsys):
 def test_docker_available_returns_bool():
     result = perf_local.docker_available()
     assert isinstance(result, bool)
+
+
+# ── render_phase_breakdown ────────────────────────────────────────────────────
+#
+# Drives directly off `SessionStats.phase_profile` (added in
+# PROTOCOL_VERSION 9). Renders a phase-sorted table so a perf operator can
+# spot the dominant warm-rebuild cost without leaving the harness output.
+
+
+def _phase_profile_with_writeoutput_dominant() -> dict:
+    """Realistic-shape PhaseProfileSummary where write_output dominates.
+
+    Numbers are sized so the table sort order is deterministic without being
+    too close to overflow-readable values. Totals are in nanoseconds (the
+    wire format)."""
+    return {
+        "hit_count": 100,
+        "miss_count": 5,
+        "parse_args_ns":           5_000_000,    # 5ms
+        "build_context_ns":       12_000_000,    # 12ms
+        "hash_source_ns":         80_000_000,    # 80ms
+        "hash_headers_ns":        76_000_000,    # 76ms — sums w/ source to 156ms
+        "depgraph_check_ns":     198_000_000,    # 198ms
+        "request_cache_lookup_ns": 4_000_000,    # 4ms
+        "cross_root_validate_ns":  8_000_000,
+        "artifact_lookup_ns":     42_000_000,    # 42ms
+        "write_output_ns":       312_000_000,    # 312ms — dominant
+        "bookkeeping_ns":          3_000_000,
+        "total_hit_ns":          740_000_000,
+        "compiler_exec_ns":      900_000_000,    # 900ms across 5 misses
+        "include_scan_ns":        25_000_000,
+        "hash_all_ns":            12_000_000,
+        "artifact_store_ns":      18_000_000,
+        "total_miss_ns":         955_000_000,
+    }
+
+
+def test_render_summary_includes_phase_breakdown(tmp_path, capsys):
+    """When the daemon supplies phase_profile, render_summary appends a
+    phase breakdown table sorted by total descending."""
+    results_dir = _write_scenario_results(
+        tmp_path,
+        "cold-tar-untar-warm",
+        cold_ms=60_000,
+        warm_ms=10_000,  # 6x — PASS, irrelevant to this assertion
+        cache_report={
+            "compilations": 105,
+            "hits": 100,
+            "misses": 5,
+            "non_cacheable": 0,
+            "errors": 0,
+            "bytes_written": 0,
+            "time_saved_ms": 0,
+            "unique_sources": 100,
+            "phase_profile": _phase_profile_with_writeoutput_dominant(),
+        },
+    )
+    rc = perf_local.render_summary(results_dir, "cold-tar-untar-warm", "medium")
+    assert rc == 0
+    out = capsys.readouterr().out
+
+    assert "Phase breakdown" in out
+    assert "100 hits, 5 misses" in out
+    # write_output is the dominant hit phase — 312 ms total
+    assert "write_output (materialize)" in out
+    assert "312.0" in out
+    # Combined source+headers hash row appears with summed total (156 ms)
+    assert "metadata cache (source+hdrs)" in out
+    assert "156.0" in out
+    # compiler_exec on the miss path (900 ms) shows up
+    assert "compiler_exec" in out
+    assert "900.0" in out
+    # Bookkeeping (~3 ms) still renders (tiny totals are not suppressed
+    # unless they are exactly zero).
+    assert "bookkeeping" in out
+
+    # Sort order: the first phase-table row after the header must be the
+    # largest total (compiler_exec at 900ms beats write_output at 312ms).
+    breakdown = out.split("Phase breakdown", 1)[1]
+    first_data_row = next(
+        line for line in breakdown.splitlines()
+        if line.startswith("| ") and "Phase" not in line and "---" not in line
+    )
+    assert "compiler_exec" in first_data_row
+
+
+def test_render_summary_handles_absent_phase_profile(tmp_path, capsys):
+    """Old daemons (PROTOCOL_VERSION <= 8) don't populate phase_profile.
+    Old reports also lack the field. The summary still renders cleanly
+    with no phase-breakdown section."""
+    results_dir = _write_scenario_results(
+        tmp_path,
+        "cold-tar-untar-warm",
+        cold_ms=60_000,
+        warm_ms=10_000,
+        cache_report={
+            "compilations": 50,
+            "hits": 48,
+            "misses": 2,
+            "non_cacheable": 0,
+            "errors": 0,
+            "bytes_written": 0,
+            "time_saved_ms": 0,
+            "unique_sources": 48,
+            # No phase_profile key — emulating an old daemon report.
+        },
+    )
+    rc = perf_local.render_summary(results_dir, "cold-tar-untar-warm", "medium")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "**PASS**" in out
+    assert "Phase breakdown" not in out
+
+
+def test_render_summary_skips_phase_breakdown_when_all_counts_zero(tmp_path, capsys):
+    """A daemon that started but processed no compiles will emit
+    phase_profile with all zeros. Don't print a useless empty table."""
+    empty_profile = {k: 0 for k in _phase_profile_with_writeoutput_dominant()}
+    results_dir = _write_scenario_results(
+        tmp_path,
+        "cold-tar-untar-warm",
+        cold_ms=60_000,
+        warm_ms=10_000,
+        cache_report={
+            "compilations": 0,
+            "hits": 0,
+            "misses": 0,
+            "non_cacheable": 0,
+            "errors": 0,
+            "bytes_written": 0,
+            "time_saved_ms": 0,
+            "unique_sources": 0,
+            "phase_profile": empty_profile,
+        },
+    )
+    rc = perf_local.render_summary(results_dir, "cold-tar-untar-warm", "medium")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Phase breakdown" not in out

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -4012,6 +4012,15 @@ fn session_stats_json(
     } else {
         None
     };
+    // `phase_profile` reaches downstream consumers (soldr's
+    // `last-session-stats.json`, perf-harness `render_summary`) through
+    // this JSON. Emit the full struct when populated so each consumer
+    // can pick fields without a separate IPC roundtrip.
+    let phase_profile = stats
+        .phase_profile
+        .as_ref()
+        .map(phase_profile_summary_json)
+        .unwrap_or(serde_json::Value::Null);
     serde_json::json!({
         "status": "ok",
         "session_id": session_id,
@@ -4026,6 +4035,32 @@ fn session_stats_json(
         "bytes_read": stats.bytes_read,
         "bytes_written": stats.bytes_written,
         "hit_rate": hit_rate,
+        "phase_profile": phase_profile,
+    })
+}
+
+fn phase_profile_summary_json(
+    p: &zccache_protocol::PhaseProfileSummary,
+) -> serde_json::Value {
+    serde_json::json!({
+        "hit_count": p.hit_count,
+        "miss_count": p.miss_count,
+        "parse_args_ns": p.parse_args_ns,
+        "build_context_ns": p.build_context_ns,
+        "hash_source_ns": p.hash_source_ns,
+        "hash_headers_ns": p.hash_headers_ns,
+        "depgraph_check_ns": p.depgraph_check_ns,
+        "request_cache_lookup_ns": p.request_cache_lookup_ns,
+        "cross_root_validate_ns": p.cross_root_validate_ns,
+        "artifact_lookup_ns": p.artifact_lookup_ns,
+        "write_output_ns": p.write_output_ns,
+        "bookkeeping_ns": p.bookkeeping_ns,
+        "total_hit_ns": p.total_hit_ns,
+        "compiler_exec_ns": p.compiler_exec_ns,
+        "include_scan_ns": p.include_scan_ns,
+        "hash_all_ns": p.hash_all_ns,
+        "artifact_store_ns": p.artifact_store_ns,
+        "total_miss_ns": p.total_miss_ns,
     })
 }
 
@@ -5387,6 +5422,7 @@ mod tests {
             unique_sources: 8,
             bytes_read: 1024,
             bytes_written: 2048,
+            phase_profile: None,
         };
         let json = session_stats_json("session-123", &stats);
         assert_eq!(json["status"], "ok");
@@ -6452,6 +6488,7 @@ mod tests {
             unique_sources: 8,
             bytes_read: 1024,
             bytes_written: 2048,
+            phase_profile: None,
         };
         let stats_json = session_stats_json("session-123", &stats);
         std::fs::write(&path, serde_json::to_string_pretty(&stats_json).unwrap()).unwrap();

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -4039,9 +4039,7 @@ fn session_stats_json(
     })
 }
 
-fn phase_profile_summary_json(
-    p: &zccache_protocol::PhaseProfileSummary,
-) -> serde_json::Value {
+fn phase_profile_summary_json(p: &zccache_protocol::PhaseProfileSummary) -> serde_json::Value {
     serde_json::json!({
         "hit_count": p.hit_count,
         "miss_count": p.miss_count,

--- a/crates/zccache-cli/src/main.rs
+++ b/crates/zccache-cli/src/main.rs
@@ -1716,7 +1716,7 @@ struct AnalyzeReport {
     miss_crate_counts: std::collections::HashMap<String, u64>,
     /// Issue #256: per-crate hit/miss/wall-clock rollup used by the
     /// default human-readable table. Keyed by crate_name (or
-    /// "<unknown>" when the journal line lacks one).
+    /// `<unknown>` when the journal line lacks one).
     by_crate: std::collections::HashMap<String, CrateBucket>,
 }
 

--- a/crates/zccache-daemon/src/compile_journal.rs
+++ b/crates/zccache-daemon/src/compile_journal.rs
@@ -951,6 +951,7 @@ mod tests {
                     unique_sources: 0,
                     bytes_read: 0,
                     bytes_written: 0,
+                    phase_profile: None,
                 }),
             },
         ];

--- a/crates/zccache-daemon/src/crash.rs
+++ b/crates/zccache-daemon/src/crash.rs
@@ -9,7 +9,7 @@
 //! delegate to the shared core implementation, and the daemon's
 //! `main.rs` still installs them in the same order it always has.
 //!
-//! New code should call [`zccache_core::crash::install("zccache-daemon")`]
+//! New code should call `zccache_core::crash::install("zccache-daemon")`
 //! once at the top of `main` and rely on the returned `CrashGuard` to
 //! keep handlers registered.
 

--- a/crates/zccache-daemon/src/main.rs
+++ b/crates/zccache-daemon/src/main.rs
@@ -221,9 +221,20 @@ fn run_server(args: Args) {
         match outcome {
             zccache_depgraph::DepGraphLoadOutcome::Loaded { graph } => {
                 let stats = graph.stats();
+                let (cold_ctxs, warm_ctxs, stale_ctxs) = graph.state_breakdown();
+                let ctxs_with_key = graph.contexts_with_artifact_key();
+                // State breakdown explains why cold_skip fires after load:
+                // an `is_cold` check only returns false for Warm contexts,
+                // so cold/stale contexts will take the cold_skip branch on
+                // the first warm-side compile and miss regardless of what
+                // the artifact_store knows.
                 tracing::info!(
                     contexts = stats.context_count,
                     files = stats.file_count,
+                    cold = cold_ctxs,
+                    warm = warm_ctxs,
+                    stale = stale_ctxs,
+                    with_artifact_key = ctxs_with_key,
                     elapsed_ms = start.elapsed().as_millis() as u64,
                     "loaded depgraph from disk"
                 );

--- a/crates/zccache-daemon/src/server.rs
+++ b/crates/zccache-daemon/src/server.rs
@@ -1374,13 +1374,25 @@ impl DaemonServer {
                     if let Some(parent) = path.parent() {
                         std::fs::create_dir_all(parent).ok();
                     }
+                    let (cold_ctxs, warm_ctxs, stale_ctxs) =
+                        self.state.dep_graph.state_breakdown();
+                    let ctxs_with_key = self.state.dep_graph.contexts_with_artifact_key();
                     match zccache_depgraph::save_to_file(&self.state.dep_graph, &path) {
                         Ok(()) => {
                             self.state
                                 .dep_graph_persisted
                                 .store(true, Ordering::Release);
+                            // State breakdown lets a future warm-side daemon
+                            // explain its cold_skip miss rate: if cold_ctxs
+                            // is high relative to warm_ctxs, the warm side
+                            // will take the cold_skip branch for those keys
+                            // and never consult the artifact_store.
                             tracing::info!(
                                 elapsed_ms = start.elapsed().as_millis() as u64,
+                                cold = cold_ctxs,
+                                warm = warm_ctxs,
+                                stale = stale_ctxs,
+                                with_artifact_key = ctxs_with_key,
                                 "depgraph saved"
                             );
                         }
@@ -1832,6 +1844,10 @@ async fn handle_connection(
                                     unique_sources: f.unique_sources,
                                     bytes_read: f.bytes_read,
                                     bytes_written: f.bytes_written,
+                                    // Daemon-wide phase totals — see
+                                    // PhaseProfileSummary doc for the
+                                    // single-vs-multi-session caveat.
+                                    phase_profile: Some(state.profiler.totals_snapshot().into()),
                                 }
                             });
                             Response::SessionStatsResult { stats }
@@ -1869,6 +1885,7 @@ async fn handle_connection(
                                     unique_sources: f.unique_sources,
                                     bytes_read: f.bytes_read,
                                     bytes_written: f.bytes_written,
+                                    phase_profile: Some(state.profiler.totals_snapshot().into()),
                                 }
                             });
                             Response::SessionEnded { stats }

--- a/crates/zccache-daemon/src/stats.rs
+++ b/crates/zccache-daemon/src/stats.rs
@@ -703,7 +703,10 @@ mod tests {
             summary.request_cache_lookup_ns,
             totals.request_cache_lookup_ns
         );
-        assert_eq!(summary.cross_root_validate_ns, totals.cross_root_validate_ns);
+        assert_eq!(
+            summary.cross_root_validate_ns,
+            totals.cross_root_validate_ns
+        );
         assert_eq!(summary.artifact_lookup_ns, totals.artifact_lookup_ns);
         assert_eq!(summary.write_output_ns, totals.write_output_ns);
         assert_eq!(summary.bookkeeping_ns, totals.bookkeeping_ns);

--- a/crates/zccache-daemon/src/stats.rs
+++ b/crates/zccache-daemon/src/stats.rs
@@ -327,6 +327,44 @@ impl PhaseProfiler {
         self.miss_count.store(0, Ordering::Relaxed);
     }
 
+    /// Return a snapshot of raw phase-timing totals (not averaged).
+    ///
+    /// Used by [`crate::server`]'s `SessionEnd` / `SessionStats` handlers
+    /// to populate [`zccache_protocol::SessionStats::phase_profile`]. The
+    /// caller divides by `hit_count` / `miss_count` if it wants averages —
+    /// the existing [`snapshot`] does that, but pre-averaged values can't
+    /// be summed if a downstream tool ever wants to combine results from
+    /// multiple sessions. Keep the wire format raw and let consumers
+    /// average.
+    ///
+    /// Returns counts as they currently sit in the atomics; no clamping
+    /// to `max(1)` as in [`snapshot`].
+    ///
+    /// [`snapshot`]: PhaseProfiler::snapshot
+    #[must_use]
+    pub fn totals_snapshot(&self) -> PhaseTotals {
+        PhaseTotals {
+            hit_count: self.count.load(Ordering::Relaxed),
+            miss_count: self.miss_count.load(Ordering::Relaxed),
+            parse_args_ns: self.parse_args_ns.load(Ordering::Relaxed),
+            build_context_ns: self.build_context_ns.load(Ordering::Relaxed),
+            hash_source_ns: self.hash_source_ns.load(Ordering::Relaxed),
+            hash_headers_ns: self.hash_headers_ns.load(Ordering::Relaxed),
+            depgraph_check_ns: self.depgraph_check_ns.load(Ordering::Relaxed),
+            request_cache_lookup_ns: self.request_cache_lookup_ns.load(Ordering::Relaxed),
+            cross_root_validate_ns: self.cross_root_validate_ns.load(Ordering::Relaxed),
+            artifact_lookup_ns: self.artifact_lookup_ns.load(Ordering::Relaxed),
+            write_output_ns: self.write_output_ns.load(Ordering::Relaxed),
+            bookkeeping_ns: self.bookkeeping_ns.load(Ordering::Relaxed),
+            total_hit_ns: self.total_hit_ns.load(Ordering::Relaxed),
+            compiler_exec_ns: self.compiler_exec_ns.load(Ordering::Relaxed),
+            include_scan_ns: self.include_scan_ns.load(Ordering::Relaxed),
+            hash_all_ns: self.hash_all_ns.load(Ordering::Relaxed),
+            artifact_store_ns: self.artifact_store_ns.load(Ordering::Relaxed),
+            total_miss_ns: self.total_miss_ns.load(Ordering::Relaxed),
+        }
+    }
+
     /// Return a snapshot of average phase durations.
     #[must_use]
     pub fn snapshot(&self) -> ProfileSnapshot {
@@ -383,6 +421,57 @@ pub struct MissPhases {
     pub hash_all_ns: u64,
     pub artifact_store_ns: u64,
     pub total_ns: u64,
+}
+
+/// Raw phase-timing totals — symmetric to [`ProfileSnapshot`] but without
+/// the per-compile averaging. The struct layout intentionally mirrors
+/// [`zccache_protocol::PhaseProfileSummary`] so the conversion is
+/// field-for-field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PhaseTotals {
+    pub hit_count: u64,
+    pub miss_count: u64,
+    pub parse_args_ns: u64,
+    pub build_context_ns: u64,
+    pub hash_source_ns: u64,
+    pub hash_headers_ns: u64,
+    pub depgraph_check_ns: u64,
+    pub request_cache_lookup_ns: u64,
+    pub cross_root_validate_ns: u64,
+    pub artifact_lookup_ns: u64,
+    pub write_output_ns: u64,
+    pub bookkeeping_ns: u64,
+    pub total_hit_ns: u64,
+    pub compiler_exec_ns: u64,
+    pub include_scan_ns: u64,
+    pub hash_all_ns: u64,
+    pub artifact_store_ns: u64,
+    pub total_miss_ns: u64,
+}
+
+impl From<PhaseTotals> for zccache_protocol::PhaseProfileSummary {
+    fn from(t: PhaseTotals) -> Self {
+        Self {
+            hit_count: t.hit_count,
+            miss_count: t.miss_count,
+            parse_args_ns: t.parse_args_ns,
+            build_context_ns: t.build_context_ns,
+            hash_source_ns: t.hash_source_ns,
+            hash_headers_ns: t.hash_headers_ns,
+            depgraph_check_ns: t.depgraph_check_ns,
+            request_cache_lookup_ns: t.request_cache_lookup_ns,
+            cross_root_validate_ns: t.cross_root_validate_ns,
+            artifact_lookup_ns: t.artifact_lookup_ns,
+            write_output_ns: t.write_output_ns,
+            bookkeeping_ns: t.bookkeeping_ns,
+            total_hit_ns: t.total_hit_ns,
+            compiler_exec_ns: t.compiler_exec_ns,
+            include_scan_ns: t.include_scan_ns,
+            hash_all_ns: t.hash_all_ns,
+            artifact_store_ns: t.artifact_store_ns,
+            total_miss_ns: t.total_miss_ns,
+        }
+    }
 }
 
 /// Averaged profile snapshot.
@@ -559,6 +648,94 @@ mod tests {
         let s = p.snapshot();
         assert_eq!(s.hit_count, 0);
         assert_eq!(s.miss_count, 0);
+    }
+
+    #[test]
+    fn totals_snapshot_round_trips_to_phase_profile_summary() {
+        // Records one hit and one miss with distinct values in every field,
+        // then verifies that `totals_snapshot()` returns the raw atomics
+        // (not averaged) and that the protocol-crate `From` conversion
+        // preserves every field. This is the wire-format proof for the
+        // observability path: PhaseProfiler atomics → PhaseTotals →
+        // protocol::PhaseProfileSummary → JSON in last-session-stats.json.
+        let p = PhaseProfiler::new();
+        p.record_hit(&HitPhases {
+            parse_args_ns: 11,
+            build_context_ns: 22,
+            hash_source_ns: 33,
+            hash_headers_ns: 44,
+            depgraph_check_ns: 55,
+            request_cache_lookup_ns: 66,
+            cross_root_validate_ns: 77,
+            artifact_lookup_ns: 88,
+            write_output_ns: 99,
+            bookkeeping_ns: 101,
+            total_ns: 596,
+        });
+        p.record_miss(&MissPhases {
+            compiler_exec_ns: 1_000,
+            include_scan_ns: 2_000,
+            hash_all_ns: 3_000,
+            artifact_store_ns: 4_000,
+            total_ns: 10_000,
+        });
+
+        let totals = p.totals_snapshot();
+        assert_eq!(totals.hit_count, 1);
+        assert_eq!(totals.miss_count, 1);
+        // Raw totals — NOT averaged. snapshot() would divide by hit_count.
+        assert_eq!(totals.parse_args_ns, 11);
+        assert_eq!(totals.write_output_ns, 99);
+        assert_eq!(totals.total_hit_ns, 596);
+        assert_eq!(totals.compiler_exec_ns, 1_000);
+        assert_eq!(totals.total_miss_ns, 10_000);
+
+        // From-impl preserves every field for the protocol crate.
+        let summary: zccache_protocol::PhaseProfileSummary = totals.clone().into();
+        assert_eq!(summary.hit_count, totals.hit_count);
+        assert_eq!(summary.miss_count, totals.miss_count);
+        assert_eq!(summary.parse_args_ns, totals.parse_args_ns);
+        assert_eq!(summary.build_context_ns, totals.build_context_ns);
+        assert_eq!(summary.hash_source_ns, totals.hash_source_ns);
+        assert_eq!(summary.hash_headers_ns, totals.hash_headers_ns);
+        assert_eq!(summary.depgraph_check_ns, totals.depgraph_check_ns);
+        assert_eq!(
+            summary.request_cache_lookup_ns,
+            totals.request_cache_lookup_ns
+        );
+        assert_eq!(summary.cross_root_validate_ns, totals.cross_root_validate_ns);
+        assert_eq!(summary.artifact_lookup_ns, totals.artifact_lookup_ns);
+        assert_eq!(summary.write_output_ns, totals.write_output_ns);
+        assert_eq!(summary.bookkeeping_ns, totals.bookkeeping_ns);
+        assert_eq!(summary.total_hit_ns, totals.total_hit_ns);
+        assert_eq!(summary.compiler_exec_ns, totals.compiler_exec_ns);
+        assert_eq!(summary.include_scan_ns, totals.include_scan_ns);
+        assert_eq!(summary.hash_all_ns, totals.hash_all_ns);
+        assert_eq!(summary.artifact_store_ns, totals.artifact_store_ns);
+        assert_eq!(summary.total_miss_ns, totals.total_miss_ns);
+    }
+
+    #[test]
+    fn totals_snapshot_reflects_reset() {
+        let p = PhaseProfiler::new();
+        p.record_hit(&HitPhases {
+            parse_args_ns: 100,
+            build_context_ns: 200,
+            hash_source_ns: 300,
+            hash_headers_ns: 400,
+            depgraph_check_ns: 500,
+            request_cache_lookup_ns: 0,
+            cross_root_validate_ns: 0,
+            artifact_lookup_ns: 600,
+            write_output_ns: 700,
+            bookkeeping_ns: 800,
+            total_ns: 3600,
+        });
+        assert_eq!(p.totals_snapshot().total_hit_ns, 3600);
+        p.reset();
+        let totals = p.totals_snapshot();
+        assert_eq!(totals.hit_count, 0);
+        assert_eq!(totals.total_hit_ns, 0);
     }
 
     #[test]

--- a/crates/zccache-depgraph/src/graph.rs
+++ b/crates/zccache-depgraph/src/graph.rs
@@ -285,19 +285,40 @@ impl DepGraph {
             return CacheVerdict::NeedsPreprocessor;
         }
 
+        // Helper: a file is fresh if the journal hasn't seen it change
+        // since `since` OR — when the journal has no opinion (post-restart
+        // cold journal, the watcher dropped events, etc.) — if its current
+        // content hash matches the hash we stored at last `update()`.
+        // The journal is in-memory and starts empty after every daemon
+        // restart; without this fallback, every cached header reports
+        // "changed" and every Warm context degrades to HeadersChanged.
+        let fresh_or_hash_match = |path: &NormalizedPath| -> bool {
+            if is_fresh(path) {
+                return true;
+            }
+            let current = match get_hash(path) {
+                Some(h) => h,
+                None => return false,
+            };
+            entry
+                .last_file_hashes
+                .iter()
+                .any(|(p, h)| p == path && *h == current)
+        };
+
         // Check source file freshness.
-        let source_fresh = is_fresh(&entry.context.source_file);
+        let source_fresh = fresh_or_hash_match(&entry.context.source_file);
 
         // Check all headers.
         let mut changed_headers = Vec::new();
         for header in &entry.resolved_includes {
-            if !is_fresh(header) {
+            if !fresh_or_hash_match(header) {
                 changed_headers.push(header.clone());
             }
         }
         // Also check force-included files (PCH, -include).
         for fi in &entry.context.force_includes {
-            if !is_fresh(fi) {
+            if !fresh_or_hash_match(fi) {
                 changed_headers.push(fi.clone());
             }
         }
@@ -401,19 +422,36 @@ impl DepGraph {
             );
         }
 
+        // See `check()` above for the rationale — content-hash fallback
+        // catches the post-restart empty-journal case where every header
+        // would otherwise look "changed".
+        let fresh_or_hash_match = |path: &NormalizedPath| -> bool {
+            if is_fresh(path) {
+                return true;
+            }
+            let current = match get_hash(path) {
+                Some(h) => h,
+                None => return false,
+            };
+            entry
+                .last_file_hashes
+                .iter()
+                .any(|(p, h)| p == path && *h == current)
+        };
+
         // Check source file freshness.
-        let source_fresh = is_fresh(&entry.context.source_file);
+        let source_fresh = fresh_or_hash_match(&entry.context.source_file);
 
         // Check all headers.
         let mut changed_headers = Vec::new();
         for header in &entry.resolved_includes {
-            if !is_fresh(header) {
+            if !fresh_or_hash_match(header) {
                 changed_headers.push(header.clone());
             }
         }
         // Also check force-included files (PCH, -include).
         for fi in &entry.context.force_includes {
-            if !is_fresh(fi) {
+            if !fresh_or_hash_match(fi) {
                 changed_headers.push(fi.clone());
             }
         }
@@ -720,6 +758,41 @@ impl DepGraph {
         self.contexts.get(key).map(|e| e.state)
     }
 
+    /// Count contexts by state. Returned as `(cold, warm, stale)`.
+    ///
+    /// Used by the daemon's depgraph save / load logging to diagnose
+    /// post-save / post-load state distribution — specifically to find
+    /// out whether contexts are getting persisted as Warm (so `is_cold`
+    /// returns `false` after restore, enabling the cache lookup path)
+    /// or as Cold (so every warm-side compile takes the `cold_skip`
+    /// branch and misses regardless of artifact-store state).
+    #[must_use]
+    pub fn state_breakdown(&self) -> (usize, usize, usize) {
+        let mut cold = 0usize;
+        let mut warm = 0usize;
+        let mut stale = 0usize;
+        for entry in self.contexts.iter() {
+            match entry.value().state {
+                ContextState::Cold => cold += 1,
+                ContextState::Warm => warm += 1,
+                ContextState::Stale => stale += 1,
+            }
+        }
+        (cold, warm, stale)
+    }
+
+    /// Number of contexts whose `artifact_key` is set. Combined with
+    /// `state_breakdown()` this distinguishes contexts that have a
+    /// computed key (a successful prior compile) from contexts that
+    /// were registered but never reached a Warm state.
+    #[must_use]
+    pub fn contexts_with_artifact_key(&self) -> usize {
+        self.contexts
+            .iter()
+            .filter(|e| e.value().artifact_key.is_some())
+            .count()
+    }
+
     /// Get the resolved includes for a context.
     #[must_use]
     pub fn get_includes(&self, key: &ContextKey) -> Option<Vec<NormalizedPath>> {
@@ -900,9 +973,19 @@ mod tests {
         };
         graph.update(&key, scan, dummy_hash);
 
-        // Source is stale, headers are fresh.
+        // Source is stale-by-watcher AND its content hash now differs from
+        // the stored hash (post-fallback semantics: a header/source is
+        // only "changed" if journal says stale AND the content hash also
+        // moved).
         let is_fresh = |p: &Path| p != Path::new("/src/a.c");
-        let verdict = graph.check(&key, is_fresh, dummy_hash);
+        let changed_source_hash = |p: &Path| -> Option<ContentHash> {
+            if p == Path::new("/src/a.c") {
+                Some(zccache_hash::hash_bytes(b"source-modified"))
+            } else {
+                dummy_hash(p)
+            }
+        };
+        let verdict = graph.check(&key, is_fresh, changed_source_hash);
         assert!(matches!(verdict, CacheVerdict::SourceChanged { .. }));
     }
 
@@ -921,15 +1004,49 @@ mod tests {
         };
         graph.update(&key, scan, dummy_hash);
 
-        // b.h is stale.
+        // b.h is stale-by-watcher AND its current content hash differs
+        // from the stored hash (so the hash-fallback also flags it).
         let is_fresh = |p: &Path| p != Path::new("/inc/b.h");
-        let verdict = graph.check(&key, is_fresh, dummy_hash);
+        let changed_b_hash = |p: &Path| -> Option<ContentHash> {
+            if p == Path::new("/inc/b.h") {
+                Some(zccache_hash::hash_bytes(b"b-modified"))
+            } else {
+                dummy_hash(p)
+            }
+        };
+        let verdict = graph.check(&key, is_fresh, changed_b_hash);
         match verdict {
             CacheVerdict::HeadersChanged { changed } => {
                 assert_eq!(changed, vec![NormalizedPath::from("/inc/b.h")]);
             }
             other => panic!("expected HeadersChanged, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn warm_context_header_stale_by_watcher_but_hash_unchanged_returns_hit() {
+        // Regression guard for the journal-cold-after-restart fix:
+        // an empty in-memory journal post-restart makes `is_fresh` return
+        // false for every path, but if the content hash still matches the
+        // stored one we must treat the file as fresh-by-content. Before
+        // the fix, every cached header was reported as HeadersChanged and
+        // every Warm context degraded to a miss on the warm side of the
+        // cold-tar-untar-warm perf scenario.
+        let graph = DepGraph::new();
+        let key = graph.register(make_ctx("/src/a.c"));
+
+        let scan = ScanResult {
+            resolved: vec![NormalizedPath::from("/inc/b.h")],
+            unresolved: Vec::new(),
+            has_computed: false,
+        };
+        graph.update(&key, scan, dummy_hash);
+
+        // Journal claims b.h has changed (it's never been seen), but
+        // dummy_hash returns the same hash for the same path — so the
+        // content didn't actually change.
+        let verdict = graph.check(&key, never_fresh, dummy_hash);
+        assert!(matches!(verdict, CacheVerdict::Hit { .. }));
     }
 
     #[test]
@@ -1014,7 +1131,17 @@ mod tests {
         graph.update(&key, scan, dummy_hash);
         assert_eq!(graph.get_state(&key), Some(ContextState::Warm));
 
-        graph.check(&key, never_fresh, dummy_hash);
+        // Both the watcher AND the content hash say h.h changed — the
+        // hash-fallback can't rescue this one, so the verdict is
+        // HeadersChanged and the entry flips to Stale.
+        let changed_h_hash = |p: &Path| -> Option<ContentHash> {
+            if p == Path::new("/h.h") {
+                Some(zccache_hash::hash_bytes(b"h-modified"))
+            } else {
+                dummy_hash(p)
+            }
+        };
+        graph.check(&key, never_fresh, changed_h_hash);
         assert_eq!(graph.get_state(&key), Some(ContextState::Stale));
     }
 

--- a/crates/zccache-fscache/src/persistence.rs
+++ b/crates/zccache-fscache/src/persistence.rs
@@ -58,8 +58,8 @@ use zccache_core::NormalizedPath;
 
 /// On-disk format version for the persisted [`MetadataCache`] snapshot.
 ///
-/// Bump this whenever the layout of [`PersistedMetadata`] or
-/// [`PersistedEntry`] changes in a way that older daemons cannot read.
+/// Bump this whenever the layout of `PersistedMetadata` or
+/// `PersistedEntry` changes in a way that older daemons cannot read.
 /// Mismatches are handled by [`MetadataCache::load_from_disk`] returning
 /// `Err`; the caller (daemon) treats that as "start empty".
 pub const FORMAT_VERSION: u32 = 1;

--- a/crates/zccache-protocol/Cargo.toml
+++ b/crates/zccache-protocol/Cargo.toml
@@ -19,3 +19,4 @@ zccache-core = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/zccache-protocol/src/lib.rs
+++ b/crates/zccache-protocol/src/lib.rs
@@ -10,7 +10,12 @@ pub use messages::*;
 /// Protocol version number. Bump this when the wire format changes:
 /// new/removed/reordered enum variants or struct field changes.
 /// Patch releases that don't change the protocol keep the same version.
-pub const PROTOCOL_VERSION: u32 = 8;
+///
+/// v9 (current): `SessionStats` gained `phase_profile: Option<PhaseProfileSummary>`
+///                so per-session aggregate phase timing reaches clients.
+/// v8: `Compile` / `CompileEphemeral` gained `stdin: Vec<u8>` and
+///     `ArtifactPayload` replaced `ArtifactOutput.data: Arc<Vec<u8>>`.
+pub const PROTOCOL_VERSION: u32 = 9;
 
 use bytes::{Buf, BufMut, BytesMut};
 

--- a/crates/zccache-protocol/src/messages.rs
+++ b/crates/zccache-protocol/src/messages.rs
@@ -363,7 +363,7 @@ pub struct SessionStats {
     pub phase_profile: Option<PhaseProfileSummary>,
 }
 
-/// Aggregate phase-timing totals from the daemon's [`PhaseProfiler`].
+/// Aggregate phase-timing totals from the daemon's PhaseProfiler.
 ///
 /// Totals are in nanoseconds. Divide hit-path totals by `hit_count` and
 /// miss-path totals by `miss_count` to derive per-compile averages.

--- a/crates/zccache-protocol/src/messages.rs
+++ b/crates/zccache-protocol/src/messages.rs
@@ -351,6 +351,67 @@ pub struct SessionStats {
     pub bytes_read: u64,
     /// Total artifact bytes stored into cache.
     pub bytes_written: u64,
+    /// Daemon-wide phase-timing aggregate. `None` from older daemons that
+    /// don't populate the field; `Some` from PROTOCOL_VERSION >= 9 daemons.
+    ///
+    /// Aggregate is daemon-wide totals since the last
+    /// `PhaseProfiler::reset()` (which is called on `Request::Clear`). For
+    /// fresh-daemon perf scenarios this is equivalent to "this session's
+    /// phase totals". For long-lived daemons handling overlapping sessions,
+    /// totals cross-contaminate — that's acceptable for v1 and revisited if
+    /// a real consumer needs per-session isolation.
+    pub phase_profile: Option<PhaseProfileSummary>,
+}
+
+/// Aggregate phase-timing totals from the daemon's [`PhaseProfiler`].
+///
+/// Totals are in nanoseconds. Divide hit-path totals by `hit_count` and
+/// miss-path totals by `miss_count` to derive per-compile averages.
+///
+/// Use case: a perf harness collects this from a warm-rebuild session to
+/// identify which phase dominates the warm-side wall time (e.g.
+/// `write_output_ns` for artifact materialization vs `depgraph_check_ns`
+/// for depgraph lookups).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PhaseProfileSummary {
+    /// Number of cache-hit compiles that contributed to the hit-path totals.
+    pub hit_count: u64,
+    /// Number of cache-miss compiles that contributed to the miss-path totals.
+    pub miss_count: u64,
+    // ── Hit-path totals (ns) ──
+    /// Argument parsing.
+    pub parse_args_ns: u64,
+    /// Build compile context + register with depgraph.
+    pub build_context_ns: u64,
+    /// Source-file hash via the metadata cache fast path.
+    pub hash_source_ns: u64,
+    /// Header hashes via the metadata cache fast path.
+    pub hash_headers_ns: u64,
+    /// Depgraph verdict lookup.
+    pub depgraph_check_ns: u64,
+    /// Request-level cache lookup.
+    pub request_cache_lookup_ns: u64,
+    /// Cross-root request validation.
+    pub cross_root_validate_ns: u64,
+    /// In-memory artifact-store lookup.
+    pub artifact_lookup_ns: u64,
+    /// Write cached outputs to disk (hardlink-first, copy fallback).
+    pub write_output_ns: u64,
+    /// Stats recording + session bookkeeping.
+    pub bookkeeping_ns: u64,
+    /// Wall-clock total of the hit path.
+    pub total_hit_ns: u64,
+    // ── Miss-path totals (ns) ──
+    /// Run the actual compiler subprocess.
+    pub compiler_exec_ns: u64,
+    /// Scan included files post-compile.
+    pub include_scan_ns: u64,
+    /// Hash all inputs for the artifact key.
+    pub hash_all_ns: u64,
+    /// Persist the new artifact to disk.
+    pub artifact_store_ns: u64,
+    /// Wall-clock total of the miss path.
+    pub total_miss_ns: u64,
 }
 
 /// Where an artifact output's bytes live on the daemon's filesystem at the
@@ -449,6 +510,7 @@ mod tests {
             unique_sources: 42,
             bytes_read: 1024 * 1024,
             bytes_written: 512 * 1024,
+            phase_profile: None,
         };
         roundtrip(&stats);
     }
@@ -466,8 +528,67 @@ mod tests {
             unique_sources: 0,
             bytes_read: 0,
             bytes_written: 0,
+            phase_profile: None,
         };
         roundtrip(&stats);
+    }
+
+    #[test]
+    fn session_stats_with_phase_profile_roundtrip() {
+        // Regression guard for PROTOCOL_VERSION 9 — a populated phase_profile
+        // must round-trip both bincode (IPC wire) and serde-json (the form
+        // soldr writes to last-session-stats.json).
+        let stats = SessionStats {
+            duration_ms: 12345,
+            compilations: 146,
+            hits: 103,
+            misses: 12,
+            non_cacheable: 31,
+            errors: 3,
+            time_saved_ms: 223,
+            unique_sources: 115,
+            bytes_read: 143_812_577,
+            bytes_written: 62_500_000,
+            phase_profile: Some(PhaseProfileSummary {
+                hit_count: 103,
+                miss_count: 12,
+                parse_args_ns: 4_000_000,
+                build_context_ns: 19_000_000,
+                hash_source_ns: 6_000_000,
+                hash_headers_ns: 11_000_000,
+                depgraph_check_ns: 28_000_000,
+                request_cache_lookup_ns: 2_500_000,
+                cross_root_validate_ns: 1_200_000,
+                artifact_lookup_ns: 8_700_000,
+                write_output_ns: 540_000_000,
+                bookkeeping_ns: 3_300_000,
+                total_hit_ns: 623_700_000,
+                compiler_exec_ns: 11_400_000_000,
+                include_scan_ns: 270_000_000,
+                hash_all_ns: 95_000_000,
+                artifact_store_ns: 120_000_000,
+                total_miss_ns: 11_885_000_000,
+            }),
+        };
+        roundtrip(&stats);
+
+        // serde-json round-trip — written to last-session-stats.json and
+        // read by both `zccache analyze` and the perf harness's
+        // `perf_local.py render_summary`.
+        let json = serde_json::to_string(&stats).expect("serialize");
+        let decoded: SessionStats = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(stats, decoded);
+
+        // An old-daemon-style JSON that omits phase_profile must decode to
+        // None (back-compat with PROTOCOL_VERSION 8 consumers that haven't
+        // upgraded the field expectation).
+        let legacy = r#"{
+            "duration_ms": 0, "compilations": 0, "hits": 0, "misses": 0,
+            "non_cacheable": 0, "errors": 0, "time_saved_ms": 0,
+            "unique_sources": 0, "bytes_read": 0, "bytes_written": 0
+        }"#;
+        let decoded: SessionStats = serde_json::from_str(legacy).expect("legacy decode");
+        assert!(decoded.phase_profile.is_none());
     }
 
     #[test]
@@ -574,6 +695,7 @@ mod tests {
             unique_sources: 30,
             bytes_read: 2_000_000,
             bytes_written: 500_000,
+            phase_profile: None,
         };
         let resp = Response::SessionEnded { stats: Some(stats) };
         roundtrip(&resp);
@@ -678,6 +800,7 @@ mod tests {
             unique_sources: 9,
             bytes_read: 50_000,
             bytes_written: 20_000,
+            phase_profile: None,
         };
         roundtrip(&Response::SessionStatsResult { stats: Some(stats) });
         roundtrip(&Response::SessionStatsResult { stats: None });
@@ -748,10 +871,12 @@ mod tests {
 
     // Compile-time check: PROTOCOL_VERSION must be positive.
     const _: () = assert!(crate::PROTOCOL_VERSION > 0);
-    // Compile-time check: PROTOCOL_VERSION == 8 after Compile/CompileEphemeral
-    // gained `stdin: Vec<u8>` and ArtifactPayload replaced
-    // ArtifactOutput.data: Arc<Vec<u8>> (issue #296 Option B).
-    const _FINGERPRINT_VERSION: () = assert!(crate::PROTOCOL_VERSION == 8);
+    // Compile-time check: PROTOCOL_VERSION == 9 after SessionStats gained
+    // `phase_profile: Option<PhaseProfileSummary>` (perf observability for
+    // per-session phase aggregates). v8 was the prior pin after
+    // Compile/CompileEphemeral gained `stdin: Vec<u8>` and ArtifactPayload
+    // replaced ArtifactOutput.data: Arc<Vec<u8>> (issue #296 Option B).
+    const _FINGERPRINT_VERSION: () = assert!(crate::PROTOCOL_VERSION == 9);
 
     #[test]
     fn fingerprint_check_roundtrip() {


### PR DESCRIPTION
## Summary

- **Root cause**: warm-side `check_diagnostic` consulted only the in-memory `journal.changed_since(path)` to decide header freshness. Journal is not persisted, so after the warm daemon restarts it has no entries and conservatively reports every cached dep `.rmeta` as changed → every Warm context degrades to `HeadersChanged` → cacheable misses on 12 heavy crates (tokio, rustls, ring, hyper-util, …). 27.4 s of unnecessary `rustc` per warm run.
- **Fix**: when the journal can't speak for a path, fall back to comparing the current content hash against `entry.last_file_hashes`. Same correctness invariant, no false positives across restarts.
- **Gate bump**: 3.0x → 4.5x in both `ci/perf_local.py` and `.github/workflows/perf-rust-cluster.yml` to lock in the new floor with headroom.

## Measured impact

Local Docker harness, `cold-tar-untar-warm × medium × linux`:

| Metric              | Before  | After     |
|---------------------|--------:|----------:|
| Verdict             | FAIL    | **PASS**  |
| Speedup             | 2.49x   | **5.35x** |
| Warm wall time      | 30.68 s | 12.08 s   |
| Misses (cacheable)  | 12      | **0**     |
| `compiler_exec_ns`  | 27.4 s  | 0 s       |

Remaining 12 s is dominated by the 31 non-cacheable compiles (proc-macros, build scripts, `-vV`/`--version` probes) — fair target for the next OODA iteration.

## Observability shipped alongside (kept because every perf fix needs it)

- `SessionStats.phase_profile` end-to-end (**PROTOCOL_VERSION 8 → 9**): 17 ns-resolution counters across hit/miss phases reach the CLI's `session-stats --json` output → through `soldr` to `last-session-stats.json` → into the harness summary as a sorted phase-breakdown table.
- `DepGraph::state_breakdown()` + `contexts_with_artifact_key()` and daemon load-time logging — answers "did the depgraph restore as Warm?" without reading bytes off disk.
- `ci/perf_local.py render_summary` falls back to reading `phase_profile` directly from `warm-zccache-logs/last-session-stats.json` — works the day zccache adds a field, not the day soldr passes it through (filed as [soldr#430](https://github.com/zackees/soldr/issues/430)).

## Perf-unit-test guard

Per CLAUDE.md "every perf fix lands with a perf unit test":
- `crates/zccache-depgraph/src/graph.rs::tests::warm_context_header_stale_by_watcher_but_hash_unchanged_returns_hit` calls `check()` with `never_fresh` + a stable hash and asserts `CacheVerdict::Hit`. Reverting the fallback flips this red because the verdict regresses to `HeadersChanged`.
- Three existing depgraph tests updated to the post-fallback semantics (a header must be journal-stale **and** content-different to be flagged changed).

## Branch name

`perf/linux-medium-cold` — targets the single cluster cell that surfaced the regression so a full sweep isn't needed for the validation run.

## Test plan

- [x] `soldr cargo test -p zccache-depgraph` — 341 passed
- [x] `soldr cargo test -p zccache-daemon --lib` — 226 passed
- [x] `soldr cargo test -p zccache-protocol` — 38 passed
- [x] `uv run pytest ci/tests/test_perf_local.py` — 28 passed
- [x] `soldr cargo check --workspace --all-targets` — clean
- [x] Local Docker harness `cold-tar-untar-warm × medium` — PASS 5.35x
- [ ] `perf-rust-cluster.yml` cell — confirm 5x+ ratio on Linux runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)