### PR TITLE
perf(compiler): cache proc-macro compiles — warm 12s→9s, speedup 5.35x→7.53x

### DIFF
--- a/crates/zccache-compiler/src/lib.rs
+++ b/crates/zccache-compiler/src/lib.rs
@@ -469,8 +469,28 @@ pub fn parse_invocation(compiler: &str, args: &[String]) -> ParsedInvocation {
     })
 }
 
-/// Cacheable rustc crate types: these don't invoke the system linker.
-const RUSTC_CACHEABLE_CRATE_TYPES: &[&str] = &["lib", "rlib", "staticlib"];
+/// Cacheable rustc crate types.
+///
+/// - `lib`, `rlib`, `staticlib`: archive outputs, no system linker.
+/// - `proc-macro`: a host-side dylib loaded by rustc at compile time.
+///   The output is a single deterministic shared library; sccache
+///   caches the same set. The artifact key already covers source
+///   content, deps, and compiler identity, so the safety contract
+///   is the same as any other rustc invocation.
+const RUSTC_CACHEABLE_CRATE_TYPES: &[&str] = &["lib", "rlib", "staticlib", "proc-macro"];
+
+/// Host dynamic-library file-name pattern for proc-macros, matching
+/// rustc's output naming. Linux/macOS use the `lib` prefix; Windows
+/// doesn't.
+fn rustc_proc_macro_filename(crate_name: &str, extra: &str) -> String {
+    if cfg!(target_os = "windows") {
+        format!("{crate_name}{extra}.dll")
+    } else if cfg!(target_os = "macos") {
+        format!("lib{crate_name}{extra}.dylib")
+    } else {
+        format!("lib{crate_name}{extra}.so")
+    }
+}
 
 /// Rustc flags that take a following argument (value in next argv element).
 const RUSTC_FLAGS_WITH_VALUE: &[&str] = &[
@@ -662,18 +682,14 @@ fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedInvocation {
         }
     }
 
-    // Determine primary output extension based on --emit and --crate-type.
-    // If --emit includes "link", the primary is rlib/staticlib.
-    // If --emit is metadata-only (no link), the primary is rmeta.
+    // Determine primary output filename based on --emit and --crate-type.
+    // - `--emit metadata` (no link) → rmeta sidecar
+    // - `proc-macro` → host-side dylib (.so/.dylib/.dll, lib prefix on unix)
+    // - `staticlib` → static archive (.a)
+    // - everything else cacheable → rlib
     let has_link_emit = emit_types.iter().any(|t| t == "link");
-    let primary_ext = if !has_link_emit && emit_types.iter().any(|t| t == "metadata") {
-        "rmeta"
-    } else {
-        match crate_types.first().map(|s| s.as_str()) {
-            Some("staticlib") => "a",
-            _ => "rlib",
-        }
-    };
+    let is_proc_macro = crate_types.iter().any(|t| t == "proc-macro");
+    let metadata_only = !has_link_emit && emit_types.iter().any(|t| t == "metadata");
 
     // Derive output path
     let output = if let Some(o) = output_file {
@@ -681,9 +697,18 @@ fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedInvocation {
     } else if let Some(ref dir) = out_dir {
         let name = crate_name.as_deref().unwrap_or("unknown");
         let suffix = extra_filename.as_deref().unwrap_or("");
+        let filename = if metadata_only {
+            format!("lib{name}{suffix}.rmeta")
+        } else if is_proc_macro {
+            rustc_proc_macro_filename(name, suffix)
+        } else if crate_types.iter().any(|t| t == "staticlib") {
+            format!("lib{name}{suffix}.a")
+        } else {
+            format!("lib{name}{suffix}.rlib")
+        };
         // Use NormalizedPath::join to handle platform path separators correctly
         NormalizedPath::new(dir)
-            .join(format!("lib{name}{suffix}.{primary_ext}"))
+            .join(filename)
             .to_string_lossy()
             .into_owned()
     } else {
@@ -693,7 +718,16 @@ fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedInvocation {
                 .and_then(|s| s.to_str())
                 .unwrap_or("unknown")
         });
-        format!("lib{name}.{primary_ext}")
+        let filename = if metadata_only {
+            format!("lib{name}.rmeta")
+        } else if is_proc_macro {
+            rustc_proc_macro_filename(name, "")
+        } else if crate_types.iter().any(|t| t == "staticlib") {
+            format!("lib{name}.a")
+        } else {
+            format!("lib{name}.rlib")
+        };
+        filename
     };
 
     ParsedInvocation::Cacheable(CacheableCompilation {
@@ -1498,12 +1532,61 @@ mod tests {
     }
 
     #[test]
-    fn rustc_proc_macro_is_non_cacheable() {
+    fn rustc_proc_macro_is_cacheable() {
+        // Proc-macros are host-side dylibs whose output is deterministic for
+        // a given source + dep set + rustc — caching them is the same
+        // safety contract as any other rustc invocation. Targets the
+        // 18× proc-macro non-cacheables on the warm-rebuild scenario.
         let result = parse_invocation(
             "rustc",
             &args(&["--crate-type", "proc-macro", "src/lib.rs"]),
         );
-        assert!(matches!(result, ParsedInvocation::NonCacheable { .. }));
+        assert!(matches!(result, ParsedInvocation::Cacheable(_)));
+    }
+
+    #[test]
+    fn rustc_proc_macro_primary_output_uses_dylib_extension() {
+        // Without this, the daemon's `collect_rustc_output_files` would
+        // stat a non-existent `.rlib` path post-compile, return an empty
+        // outputs vec, and take the early-return branch that skips
+        // `dep_graph.update()` — leaving the context Cold forever and
+        // causing every warm rebuild to recompile the proc-macro
+        // (regression observed in the iter4 OODA pass).
+        let result = parse_invocation(
+            "rustc",
+            &args(&[
+                "--crate-name",
+                "serde_derive",
+                "--crate-type",
+                "proc-macro",
+                "--out-dir",
+                "/tmp/deps",
+                "-C",
+                "extra-filename=-abc123",
+                "/path/to/src/lib.rs",
+            ]),
+        );
+        let cc = match result {
+            ParsedInvocation::Cacheable(c) => c,
+            other => panic!("expected cacheable, got: {other:?}"),
+        };
+        let out = cc.output_file.to_string_lossy();
+        if cfg!(target_os = "windows") {
+            assert!(
+                out.ends_with("serde_derive-abc123.dll"),
+                "expected proc-macro .dll, got {out}"
+            );
+        } else if cfg!(target_os = "macos") {
+            assert!(
+                out.ends_with("libserde_derive-abc123.dylib"),
+                "expected proc-macro .dylib, got {out}"
+            );
+        } else {
+            assert!(
+                out.ends_with("libserde_derive-abc123.so"),
+                "expected proc-macro .so, got {out}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add `proc-macro` to `RUSTC_CACHEABLE_CRATE_TYPES` and teach `parse_rustc_invocation` to derive the host-side dylib filename (`lib{name}{extra}.{so,dylib,dll}`, no `lib` prefix on Windows) so the primary output path matches what rustc actually writes for `--crate-type=proc-macro`.

## Why a one-line allowlist flip wasn't enough (iter4 regressed)

A naive `RUSTC_CACHEABLE_CRATE_TYPES += "proc-macro"` flipped classification but left the parser computing `lib{name}{extra}.rlib` as the primary output. rustc emitted the `.so`; the daemon's `collect_rustc_output_files` stat'd the non-existent `.rlib`, got an empty Vec, took the early-return that skips `dep_graph.update()`, and every proc-macro context stayed Cold across runs. Warm side recompiled them anyway and paid the new classification overhead. Net regression (5.35x → 5.21x, warm 12s → 15s) — reverted.

## Measured impact

Local Docker harness, `cold-tar-untar-warm × medium × linux`:

| Metric          | iter1 (main) | **iter5** |
|-----------------|-------------:|----------:|
| Verdict         | PASS         | **PASS**  |
| Speedup         | 5.35x        | **7.53x** |
| Cold            | 64s          | 68s       |
| Warm            | 12.1s        | **9.09s** |
| Hits            | 115          | **124**   |
| Misses          | 0            | 0         |
| Non-cacheable   | 31           | **22**    |

The 9 proc-macro crates (serde_derive, clap_derive, thiserror_impl, yoke_derive, zerofrom_derive, zerovec_derive, displaydoc, tokio_macros, tracing_attributes) now reach the `update()` → Warm-state path on cold, serialize to disk, restore as Warm on warm load, and hit `fast_key_match` instead of `cold_skip`-ing into a recompile.

## Per-platform test

`rustc_proc_macro_primary_output_uses_dylib_extension` asserts the right extension for the current host (`.dll` on Windows, `.dylib` on macOS, `.so` elsewhere). CI runs all three platforms.

## Perf-unit-test guard

Two tests cover the regression vector:
- `rustc_proc_macro_is_cacheable` (was `_is_non_cacheable`, flipped) — catches accidental re-listing of proc-macro as non-cacheable.
- `rustc_proc_macro_primary_output_uses_dylib_extension` — catches a silent reversion of the output-name fix, which is the exact failure mode iter4 hit (compile completes but `update()` is skipped because the daemon can't find the expected output file).

## Branch name

`perf/linux-medium-cold-iter5` — targets the single cluster cell that surfaced both the regression and the fix.

## Test plan

- [x] `soldr cargo test -p zccache-compiler` — 316 + 107 + 2 + 10 passed
- [x] `soldr cargo test -p zccache-daemon --lib` — 226 passed
- [x] Local Docker harness — PASS 7.53x (need ≥4.5x)
- [ ] perf-rust-cluster cell — confirm ≥5x on Linux runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)