### PR TITLE
chore(release): bump zccache to 1.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ci"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "libc",
  "md5",
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "blake3",
  "clap",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-compiler"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "clang",
  "tempfile",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "crash-handler",
  "libc",
@@ -3593,7 +3593,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "bincode",
  "clap",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-cli"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "clap",
  "serde",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-client"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "dashmap",
  "flate2",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-daemon"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "clap",
  "dashmap",
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -3732,7 +3732,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "clap",
  "criterion",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "bincode",
  "dashmap",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "bytes",
  "serde",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-symbols"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "tempfile",
  "zccache-core",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "tempfile",
  "tokio",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "criterion",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.8.2"
+version = "1.9.0"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Minor bump covering this OODA loop's perf wins on the cold-tar-untar-warm scenario.

| revision | warm | speedup |
|---|---:|---:|
| 1.8.2 (pre-OODA) | 30.7 s | 2.49x |
| + PR #344 (hash-fallback) | 12.1 s | 5.35x |
| + PR #345 (proc-macro caching) | 9.1 s | 7.53x |
| + PR #346 (bin + preserve mtime) | **9.8 s** | **10.74x** |

## Why minor bump (1.9.0, not 1.8.3)

- **PROTOCOL_VERSION 8 → 9** (PR #344). Wire-format change covered by the daemon's version-mismatch check, so it's not a breaking client change, but it's a visible compatibility boundary.
- **Behavior change**: proc-macro and `bin` compiles now hit the cache; the daemon also stops bumping mtime on materialize. Downstream build systems that relied on `mtime = now` to detect "the artifact was just produced" will see the cache file's stored mtime instead. The new CLAUDE.md "Preserve cache-file mtime on hits" convention documents the rationale.

## Release plan

After this PR merges, push tag `1.9.0` to trigger `.github/workflows/release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)