### PR TITLE
perf-cluster: AND-style gate — speedup >= min_speedup AND optional warm_ms <= max

### DIFF
--- a/.github/workflows/perf-rust-cluster.yml
+++ b/.github/workflows/perf-rust-cluster.yml
@@ -571,7 +571,22 @@ jobs:
         include:
           - platform: linux
             runs_on: ubuntu-24.04
+            # Every scenario gates on speedup >= min_speedup.
             min_speedup: "4.5"
+            # Optional per-scenario warm-ms ceiling. Combined with
+            # the speedup gate as AND (gate fails if either fails).
+            # Empty string = no warm-ms ceiling for that scenario.
+            #
+            # restore-no-clean-warm: 1500ms — cold-side compile time
+            # dominates the speedup ratio, so a real 20× warm
+            # regression would still pass a speedup-only gate.
+            # The warm-ms ceiling is the binding constraint here.
+            # 1500ms is conservative; tighten once GHA noise is
+            # known. See PERF.md.
+            max_warm_ms_cold: ""
+            max_warm_ms_restore: "1500"
+            max_warm_ms_worktree: ""
+            max_warm_ms_touch: ""
     runs-on: ${{ matrix.runs_on }}
     steps:
       - name: Gate cell against resolved scope
@@ -611,10 +626,14 @@ jobs:
       - name: Evaluate scenarios for ${{ matrix.platform }}
         if: steps.gate.outputs.selected == 'true'
         env:
-          MIN_SPEEDUP:   ${{ matrix.min_speedup }}
-          REQ_FIXTURES:  ${{ needs.setup.outputs.fixtures }}
-          REQ_SCENARIOS: ${{ needs.setup.outputs.scenarios }}
-          M_PLATFORM:    ${{ matrix.platform }}
+          MIN_SPEEDUP:          ${{ matrix.min_speedup }}
+          MAX_WARM_MS_COLD:     ${{ matrix.max_warm_ms_cold }}
+          MAX_WARM_MS_RESTORE:  ${{ matrix.max_warm_ms_restore }}
+          MAX_WARM_MS_WORKTREE: ${{ matrix.max_warm_ms_worktree }}
+          MAX_WARM_MS_TOUCH:    ${{ matrix.max_warm_ms_touch }}
+          REQ_FIXTURES:         ${{ needs.setup.outputs.fixtures }}
+          REQ_SCENARIOS:        ${{ needs.setup.outputs.scenarios }}
+          M_PLATFORM:           ${{ matrix.platform }}
         run: |
           set -uo pipefail
 
@@ -630,9 +649,22 @@ jobs:
           # stabilize (see workflow header).
           mode_for() {
             case "$1" in
-              cold-tar-untar-warm) echo "fail" ;;
+              cold-tar-untar-warm|restore-no-clean-warm) echo "fail" ;;
               worktree-share|touch-no-change) echo "warn" ;;
               *) echo "warn" ;;
+            esac
+          }
+
+          # Optional per-scenario warm-ms ceiling (combined as AND
+          # with the speedup gate). Empty = no ceiling for that
+          # scenario.
+          max_warm_ms_for() {
+            case "$1" in
+              cold-tar-untar-warm)   echo "${MAX_WARM_MS_COLD}" ;;
+              restore-no-clean-warm) echo "${MAX_WARM_MS_RESTORE}" ;;
+              worktree-share)        echo "${MAX_WARM_MS_WORKTREE}" ;;
+              touch-no-change)       echo "${MAX_WARM_MS_TOUCH}" ;;
+              *)                     echo "" ;;
             esac
           }
 
@@ -702,11 +734,15 @@ jobs:
           # GHA annotations (::error / ::warning). Includes every
           # field the table shows so the annotation in the sidebar
           # tells the full story without opening the step summary.
-          # All inputs come from this loop iteration's scope.
+          # All inputs come from this loop iteration's scope; `need`
+          # is the per-scenario threshold label (e.g. ">=4.5x" or
+          # "<=1500ms") so the annotation is accurate for both
+          # speedup-gated and absolute-warm-gated scenarios.
           fmt_annotation() {
-            printf '%s/%s: speedup=%sx (need >=%sx); cold=%s warm=%s; compiles=%s hits=%s misses=%s ignored=%s errors=%s; hit=%s miss=%s ignore=%s; bytes_W=%s bytes_R=%s; time_saved=%s; daemon_RSS=%s compile_RSS=%s' \
+            local need="$1"
+            printf '%s/%s: speedup=%sx (need %s); cold=%s warm=%s; compiles=%s hits=%s misses=%s ignored=%s errors=%s; hit=%s miss=%s ignore=%s; bytes_W=%s bytes_R=%s; time_saved=%s; daemon_RSS=%s compile_RSS=%s' \
               "${fixture}" "${scenario}" \
-              "${speedup}" "${MIN_SPEEDUP}" \
+              "${speedup}" "${need}" \
               "$(fmt_ms "${cold_ms}")" "$(fmt_ms "${warm_ms}")" \
               "${compiles:-—}" "${hits:-—}" "${misses:-—}" "${non_cache:-—}" "${errs:-—}" \
               "$(fmt_pct "${hit_rate}")" "$(ratio_pct "${misses}" "${compiles}")" "$(ratio_pct "${non_cache}" "${compiles}")" \
@@ -760,11 +796,18 @@ jobs:
           # "—" when the underlying JSON is missing). Kept inline so
           # the column order is in one place; any new column gets
           # added here + in the header above.
+          #
+          # `need` (second arg) is the threshold-label cell, e.g.
+          # ">=4.5x" for speedup-gated scenarios or "<=1500ms" for
+          # the absolute-warm-ms gate on restore-no-clean-warm.
+          # Pre-result rows (MISSING / BAD-JSON / BAD-WARM) pass "—"
+          # since the threshold isn't applicable.
           emit_row() {
             local verdict="$1"
+            local need="${2:-—}"
             printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
               "${fixture}" "${scenario}" \
-              "$(fmt_verdict "${verdict}")" "${speedup:-—}x" ">=${MIN_SPEEDUP}x" \
+              "$(fmt_verdict "${verdict}")" "${speedup:-—}x" "${need}" \
               "$(fmt_ms "${cold_ms}")" "$(fmt_ms "${warm_ms}")" \
               "${compiles:-—}" \
               "$(fmt_count_pct "${hits}" "${compiles}")" \
@@ -791,7 +834,7 @@ jobs:
               continue
             fi
 
-            for scenario in cold-tar-untar-warm worktree-share touch-no-change; do
+            for scenario in cold-tar-untar-warm worktree-share touch-no-change restore-no-clean-warm; do
               if ! in_subset "${REQ_SCENARIOS}" "${scenario}"; then
                 echo "scenario ${scenario} not selected by dispatch input; skipping"
                 continue
@@ -876,23 +919,45 @@ jobs:
               fi
 
               speedup="$(awk -v c="${cold_ms}" -v w="${warm_ms}" 'BEGIN { printf "%.2f", c / w }')"
-              pass="$(awk -v s="${speedup}" -v t="${MIN_SPEEDUP}" 'BEGIN { print (s >= t) ? "1" : "0" }')"
 
-              if [[ "${pass}" == "1" ]]; then
-                emit_row "PASS"
-                echo "PASS  ${fixture}/${scenario}: speedup=${speedup}x (need >=${MIN_SPEEDUP}x), cold=$(fmt_ms "${cold_ms}") warm=$(fmt_ms "${warm_ms}"), hits=${hits:-?}/${compiles:-?} ($(fmt_pct "${hit_rate}"))"
+              # Uniform AND-style gate:
+              #   pass = (speedup >= min_speedup) AND (warm_ms <= max_warm_ms)
+              # The warm-ms half is optional and only evaluated for
+              # scenarios that opt in (via the matrix `max_warm_ms_<scen>`
+              # field, surfaced here by `max_warm_ms_for`). Scenarios
+              # with no warm-ms ceiling gate on speedup only.
+              #
+              # Why both: some scenarios (e.g. restore-no-clean-warm)
+              # have cold-side compile noise that dominates the speedup
+              # ratio, so a real warm regression can hide behind a still-
+              # passing speedup ratio. The warm-ms ceiling catches that.
+              # Others (cold-tar-untar-warm) want speedup as the signal
+              # of cache contribution and don't need a warm-ms ceiling.
+              speedup_pass="$(awk -v s="${speedup}" -v t="${MIN_SPEEDUP}" 'BEGIN { print (s >= t) ? "1" : "0" }')"
+              max_warm="$(max_warm_ms_for "${scenario}")"
+              warm_pass="1"
+              warm_clause=""
+              if [[ -n "${max_warm}" ]]; then
+                warm_pass="$(awk -v w="${warm_ms}" -v t="${max_warm}" 'BEGIN { print (w+0 <= t+0) ? "1" : "0" }')"
+                warm_clause=" AND <=${max_warm}ms"
+              fi
+              need=">=${MIN_SPEEDUP}x${warm_clause}"
+
+              if [[ "${speedup_pass}" == "1" && "${warm_pass}" == "1" ]]; then
+                emit_row "PASS" "${need}"
+                echo "PASS  ${fixture}/${scenario}: speedup=${speedup}x warm=$(fmt_ms "${warm_ms}") (need ${need}), cold=$(fmt_ms "${cold_ms}"), hits=${hits:-?}/${compiles:-?} ($(fmt_pct "${hit_rate}"))"
               else
                 if [[ "${mode}" == "fail" ]]; then
-                  emit_row "FAIL"
-                  echo "::error::$(fmt_annotation)"
+                  emit_row "FAIL" "${need}"
+                  echo "::error::$(fmt_annotation "${need}")"
                   status=1
                 else
-                  emit_row "WARN"
+                  emit_row "WARN" "${need}"
                   # Soft gate: emit a warning that still has the
                   # full context, so a future tightening to a hard
                   # gate (see workflow header) doesn't need a
                   # message rewrite.
-                  echo "::warning::$(fmt_annotation) [soft gate — not failing today]"
+                  echo "::warning::$(fmt_annotation "${need}") [soft gate — not failing today]"
                 fi
               fi
             done

--- a/PERF.md
+++ b/PERF.md
@@ -144,11 +144,36 @@ Short tokens keep the branch name unambiguous (the real names contain hyphens th
 
 ## Gate semantics
 
-- **`cold-tar-untar-warm` < 3x** (cold/warm ratio in the Evaluate step) → **fails the workflow**. Hard gate.
-- **`worktree-share` < 3x** → emits `::warning::`, doesn't fail. Soft gate today; promotes to hard once the baseline stabilizes.
-- **`touch-no-change` < 3x** → same as worktree-share, soft today.
+Every scenario gates on **`speedup >= min_speedup` AND (optionally) `warm_ms
+<= max_warm_ms_<scen>`** — both must hold for PASS. The warm-ms ceiling is
+opt-in per scenario; scenarios with no ceiling gate on speedup alone.
 
-Threshold lives on the `evaluate` matrix row (`min_speedup: "3.0"`).
+Linux thresholds today:
+
+| Scenario | min_speedup | max_warm_ms | Mode |
+|---|---:|---:|---|
+| `cold-tar-untar-warm` | `4.5x` | — | **hard** (fails workflow) |
+| `restore-no-clean-warm` | `4.5x` | `1500ms` | **hard** (fails workflow) |
+| `worktree-share` | `4.5x` | — | soft (`::warning::`) |
+| `touch-no-change` | `4.5x` | — | soft (`::warning::`) |
+
+Why both gates instead of speedup-only: some scenarios have cold-side compile
+time that dominates the speedup ratio (e.g. `restore-no-clean-warm`: cargo
+populates `target/` from scratch on cold, so a real 20× warm regression — warm
+going from 75 ms back to 1500 ms — still reports a ~40x speedup and passes a
+speedup-only gate cleanly). The warm-ms ceiling catches user-visible regressions
+that hide behind a high ratio. Other scenarios (`cold-tar-untar-warm`) want
+speedup as the signal of cache contribution and don't currently set a warm-ms
+ceiling.
+
+Thresholds live on the `evaluate` matrix row (`min_speedup`,
+`max_warm_ms_<scen>`). Each platform row carries its own values; the workflow
+has only `linux` today, so the numbers above are linux-tuned. mac-arm / win
+rows will need their own thresholds because per-OS variance on the noise floor
+is significant. To add a warm-ms ceiling to a scenario that doesn't have one,
+set the corresponding `max_warm_ms_<scen>` field in the matrix include to a
+non-empty value (e.g. `"2000"`); the gate code picks it up via
+`max_warm_ms_for`.
 
 ## Reading the run
 


### PR DESCRIPTION
## Summary

Closes a structural gap in the Evaluate job's gate logic: scenarios where cold-side compile time dominates the speedup ratio (notably `restore-no-clean-warm`) could hide a 20× warm-time regression behind a still-passing 40x+ speedup ratio. Adds a per-scenario warm-ms ceiling combined as **AND** with the existing speedup gate. The warm-ms ceiling is opt-in — scenarios without one keep their previous speedup-only behavior.

User direction: "the speed gates should have an optional max time they run for on the warm version. for example 30x speed AND < 1s."

## What changes in `.github/workflows/perf-rust-cluster.yml`

1. **Matrix include block** gains `max_warm_ms_<scenario>` fields (`cold`, `restore`, `worktree`, `touch`). Empty string = no ceiling for that scenario. Today only `max_warm_ms_restore="1500"` is set; the rest are placeholders for future opt-in.
2. **New env bindings** for each ceiling.
3. **New `max_warm_ms_for()` helper** next to `mode_for()` — keeps the per-scenario dispatch in one place.
4. **Promote `restore-no-clean-warm` to hard-gated** mode in `mode_for` (it was unwired; default was `warn`).
5. **Fix PR #350 oversight**: the evaluator scenario loop at line 794 hard-coded the original three scenarios and never picked up `restore-no-clean-warm`. Add it to the loop.
6. **Rewrite the gate computation as a uniform AND**:
   ```
   pass = speedup_pass AND warm_pass
   ```
   `warm_pass` is 1 when no ceiling is set (no-op). The "Need" cell now renders `>=4.5x AND <=1500ms` when both gates apply, or just `>=4.5x` otherwise.
7. **`emit_row` gains an optional `need` second arg.** Pre-result rows (MISSING / BAD-JSON / BAD-WARM) keep working — they default to "—".
8. **`fmt_annotation` takes the threshold label as an argument** instead of inlining `>=${MIN_SPEEDUP}x`, so the GHA `::error::` / `::warning::` annotation reads accurately for AND-gated scenarios.

## What changes in `PERF.md`

Rewrites the "Gate semantics" section to describe the AND-style gate (was speedup-only). Adds a table mapping each scenario to its current `min_speedup` + `max_warm_ms_<scen>` + mode. Also fixes stale 3x / `min_speedup: "3.0"` references (the real values have been `4.5x` since PR #344 raised the gate).

| Scenario | min_speedup | max_warm_ms | Mode |
|---|---:|---:|---|
| `cold-tar-untar-warm` | `4.5x` | — | **hard** |
| `restore-no-clean-warm` | `4.5x` | `1500ms` | **hard** |
| `worktree-share` | `4.5x` | — | soft |
| `touch-no-change` | `4.5x` | — | soft |

## Threshold value — why 1500ms

- Local Docker (linux, medium fixture): warm 74-75ms across iter9 / iter9b runs (stable).
- GHA Linux is slower and noisier; realistic healthy ceiling ~300ms.
- `1500ms` = ~5× headroom over that ceiling, ~20× over local Docker. Catches catastrophic regressions (warm seconds) without false-failing on first runs.
- Tighten in a follow-up once 5–10 real GHA runs establish a noise band. Probable end-state: ~500ms.

## How to add a warm-ms ceiling to another scenario

Set the corresponding `max_warm_ms_<scen>` field on the matrix include to a non-empty string:

```yaml
matrix:
  include:
    - platform: linux
      runs_on: ubuntu-24.04
      min_speedup: "4.5"
      max_warm_ms_cold: "30000"   # e.g. cold-tar-untar-warm warm <= 30s
      max_warm_ms_restore: "1500"
      max_warm_ms_worktree: ""
      max_warm_ms_touch: ""
```

`max_warm_ms_for()` already routes the scenario name to the corresponding env var; no other code changes needed.

## Verification

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/perf-rust-cluster.yml'))"` — YAML parses clean.
- [x] Cross-check: all four `max_warm_ms_<scen>` keys line up matrix → env → `max_warm_ms_for` function.
- [x] `emit_row` + `fmt_annotation` signature changes don't break MISSING / BAD-JSON / BAD-WARM rows — those call `emit_row` without a `need` arg; the default "—" applies.
- [ ] Workflow dispatch on `main` once merged: `gh workflow run perf-rust-cluster.yml --ref main -f scenarios=restore-no-clean-warm -f fixtures=medium -f platforms=linux` — confirm Need cell reads `>=4.5x AND <=1500ms` and the run passes.
- [ ] Throwaway-branch FAIL test: temporarily set `max_warm_ms_restore: "50"`, dispatch, confirm `::error::` and red status. Revert before merging the throwaway branch.

Closes zccache#348 follow-up (gate-promotion item from PR #350).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
