### PR TITLE
perf-local: mount persistent /cargo-home volume — no-op build 33s→7s

### DIFF
--- a/ci/docker/README.md
+++ b/ci/docker/README.md
@@ -34,6 +34,9 @@ All volumes are managed by the orchestrator. The layout under `<repo>/.perf-loca
 ├── target/
 │   ├── soldr/                  # persistent cargo target/ for soldr (musl)
 │   └── zccache/                # persistent cargo target/ for zccache (gnu)
+├── cargo-home/                 # persistent CARGO_HOME (registry index + crate sources)
+│   ├── soldr/                  # so no-op rebuilds don't re-fetch ~175 MiB per run
+│   └── zccache/
 ├── binaries/
 │   ├── soldr/soldr             # static soldr binary produced by builder
 │   └── zccache/                # zccache trio produced by builder
@@ -43,6 +46,13 @@ All volumes are managed by the orchestrator. The layout under `<repo>/.perf-loca
 └── results/
     └── <scenario>/             # result.json + cache reports per run
 ```
+
+The `cargo-home/` volumes are required for fast incremental rebuilds: the
+Dockerfiles set `ENV CARGO_HOME=/cargo-home` so cargo's fingerprint check
+loads registry sources from there. Without a host-side mount, every run
+starts with an empty registry and pays a re-download + re-fingerprint
+cost (~20-25s for soldr, ~30s for zccache). Persisting them drops no-op
+rebuilds to under 15s wall time on Docker-for-Windows.
 
 Everything under `.perf-local/` is `.gitignore`d.
 

--- a/ci/perf_local.py
+++ b/ci/perf_local.py
@@ -146,12 +146,19 @@ def ensure_soldr_source() -> Path:
 def ensure_volume_dirs() -> dict[str, Path]:
     """Create the .perf-local/ volume tree, return a name->path map."""
     layout = {
-        "soldr_src":      PERF_LOCAL / "soldr-src",
-        "target_soldr":   PERF_LOCAL / "target" / "soldr",
-        "target_zccache": PERF_LOCAL / "target" / "zccache",
-        "bin_soldr":      PERF_LOCAL / "binaries" / "soldr",
-        "bin_zccache":    PERF_LOCAL / "binaries" / "zccache",
-        "results":        PERF_LOCAL / "results",
+        "soldr_src":         PERF_LOCAL / "soldr-src",
+        "target_soldr":      PERF_LOCAL / "target" / "soldr",
+        "target_zccache":    PERF_LOCAL / "target" / "zccache",
+        # CARGO_HOME volumes. The Dockerfiles set `ENV CARGO_HOME=/cargo-home`
+        # so cargo's registry index + crate sources land here. Without a
+        # host-side mount, every container starts with an empty CARGO_HOME
+        # and re-fetches ~175 MiB to revalidate fingerprints — measured at
+        # +28s per no-op build. Persisting it cuts no-op builds to seconds.
+        "cargo_home_soldr":   PERF_LOCAL / "cargo-home" / "soldr",
+        "cargo_home_zccache": PERF_LOCAL / "cargo-home" / "zccache",
+        "bin_soldr":         PERF_LOCAL / "binaries" / "soldr",
+        "bin_zccache":       PERF_LOCAL / "binaries" / "zccache",
+        "results":           PERF_LOCAL / "results",
     }
     for path in layout.values():
         path.mkdir(parents=True, exist_ok=True)
@@ -174,9 +181,10 @@ def run_soldr_builder(layout: dict[str, Path]) -> None:
     print(f"[perf-local] building soldr binary -> {layout['bin_soldr']}")
     run([
         "docker", "run", "--rm",
-        "-v", host_volume(layout["soldr_src"],    "/src", "ro"),
-        "-v", host_volume(layout["target_soldr"], "/target"),
-        "-v", host_volume(layout["bin_soldr"],    "/out"),
+        "-v", host_volume(layout["soldr_src"],        "/src", "ro"),
+        "-v", host_volume(layout["target_soldr"],     "/target"),
+        "-v", host_volume(layout["cargo_home_soldr"], "/cargo-home"),
+        "-v", host_volume(layout["bin_soldr"],        "/out"),
         IMAGE_SOLDR,
     ])
 
@@ -185,9 +193,10 @@ def run_zccache_builder(layout: dict[str, Path]) -> None:
     print(f"[perf-local] building zccache trio -> {layout['bin_zccache']}")
     run([
         "docker", "run", "--rm",
-        "-v", host_volume(REPO_ROOT,                "/src", "ro"),
-        "-v", host_volume(layout["target_zccache"], "/target"),
-        "-v", host_volume(layout["bin_zccache"],    "/out"),
+        "-v", host_volume(REPO_ROOT,                    "/src", "ro"),
+        "-v", host_volume(layout["target_zccache"],     "/target"),
+        "-v", host_volume(layout["cargo_home_zccache"], "/cargo-home"),
+        "-v", host_volume(layout["bin_zccache"],        "/out"),
         IMAGE_ZCCACHE,
     ])
 


### PR DESCRIPTION
## Summary
- The docker perf harness Dockerfiles already set `ENV CARGO_HOME=/cargo-home` and the comments said "keep them in a volume so a fresh container reuses last run's downloaded crates" — but `perf_local.py` was never mounting a host-side volume there. Every container started with an empty registry and re-fetched ~175 MiB to revalidate fingerprints.
- Add `cargo-home/{soldr,zccache}` to the volume layout and mount it in both builder containers.

## Measurements (Docker-for-Windows)
| Build | Before | After (warm) | Δ |
|---|---:|---:|---:|
| `soldr-builder` no-op | 33.0s | **7.0s** | -79% |
| `zccache-builder` no-op | ~30s | **10.3s** | -66% |
| End-to-end `perf_local.py` (no source change) | ~143s | **101s** | -29% |

End-to-end scenario still PASSes at 8.84× speedup (gate 4.50×).

## Cold-recovery note
The very first run after introducing the volume rebuilds everything (~3 min) because cargo's fingerprints reference registry paths and the previous location was ephemeral. After that one-time cost, all subsequent no-op runs are seconds.

## Test plan
- [x] `uv run python ci/perf_local.py` — warm run completes in 101s, PASS verdict
- [x] Direct `docker run zccache-perf-soldr-builder` confirms 7s no-op rebuild
- [x] Direct `docker run zccache-perf-zccache-builder` confirms 10s no-op rebuild
- [ ] Confirm CI on this PR is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)