### PR TITLE
docs(claude): refresh CLAUDE.md + crates/CLAUDE.md after 21-crate workspace + LOC discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 # CLAUDE.md
 
-zccache is a local-first compiler cache daemon (11 crates). See @docs/CLAUDE.md for which architecture doc to read based on what you're working on, and where to document new features.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+zccache is a local-first compiler cache (21 crates) for C/C++/Rust/Emscripten, inspired by sccache but optimized for warm-hit latency. Architecture: a persistent `zccache-daemon` holds an in-memory metadata cache and a filesystem watcher; the `zccache` CLI (binary in `zccache-cli`) shells out per compile but talks to the daemon over a single length-prefixed bincode IPC roundtrip (Unix sockets / Windows named pipes via `zccache-ipc`). The daemon is lazily started by the CLI when not running. See @docs/CLAUDE.md for which architecture doc to read based on what you're working on, and where to document new features.
 
 > [!IMPORTANT]
 > ## Performance work → read [PERF.md](PERF.md) FIRST
@@ -90,6 +92,7 @@ Hooks are in `ci/hooks/` (Python) and `crates/zccache-ci` (Rust):
 - **PreToolUse**: `ci/hooks/tool_guard.py` blocks bare Rust commands (must use `soldr`) and bare `python`/`pip` (must use `uv`)
 - **PostToolUse**: `ci/hooks/lint.py` auto-formats + runs clippy on edited `.rs` files
 - **PostToolUse**: `ci/hooks/readme_guard.py` errors if directory lacks README.md
+- **PostToolUse**: `ci/hooks/loc_guard.py` warns when an edited source file exceeds 1,000 LOC and hard-blocks (exit 2) above 1,500 LOC — split into focused submodules before the file crosses the threshold
 - **SessionStart**: `ci/hooks/check-on-start.py` captures git fingerprint
 - **Stop**: `soldr cargo run -p zccache-ci` runs lint + unit tests in parallel (skips if no changes)
 
@@ -112,6 +115,7 @@ Hooks are in `ci/hooks/` (Python) and `crates/zccache-ci` (Rust):
 - **Protocol version bump required on wire format changes.** When changing `Request`, `Response`, or any struct serialized over IPC, bump `PROTOCOL_VERSION` in `zccache-protocol`. See DD-018.
 - **Zero extra roundtrips.** Never add a separate handshake, version check, or metadata query that requires its own IPC roundtrip. Piggyback on existing messages instead. Example: protocol version is embedded in every message frame, not fetched via a separate Status request. If you need new metadata exchanged between CLI and daemon, add it to the framing layer or to an existing request/response - never introduce a new preliminary exchange.
 - **Avoid gratuitous `clone()`.** Do not clone to placate the borrow checker - restructure code instead. Prefer: moves over clones for single-use values, `&str`/`&Path` over owned types in function signatures that only read, `Arc::clone(&x)` over cloning the inner data then wrapping. Cloning is acceptable when data genuinely needs to exist in two places (e.g., inserting into a map while retaining a copy, or moving into a spawned task). Every `clone()` on a `Vec`, `String`, or `PathBuf` should be justified - if you can't explain why both the original and the copy are needed, eliminate it.
+- **No source file over 1,000 LOC.** Enforced by the `loc_guard.py` PostToolUse hook (warns >1K, blocks >1.5K). The split pattern is "convert `foo.rs` → `foo/mod.rs` + per-domain files alongside, with tests in a `tests/` subdirectory". PRs #355–#363 are the precedents (server.rs, cli/main.rs, perf_bench_test.rs, compiler/lib.rs, server/{tests,mod}.rs, compile_journal.rs, depgraph/snapshot.rs). Re-export `pub` items from `mod.rs` so the public path is unchanged.
 - **Preserve cache-file mtime on hits — never stamp `now()`.** Materializing a cached artifact (`write_cached_output`, `write_cached_file`, `write_cached_payload`, `write_payloads_par`) must leave the resulting file's mtime equal to the cache file's stored mtime. The hardlink fast path already inherits the cache mtime; do not add a `touch_mtime` / `set_file_mtime(_, now())` after the link. **Why:** cargo's incremental fingerprint records the artifact's mtime at first compile and treats a later "newer" mtime as evidence the artifact was externally modified — invalidating the downstream graph and paying re-link / re-fingerprint cost that fully cancels the cache savings. Measured in iter7 of the cold-tar-untar-warm OODA loop: switching `touch_mtime` to a no-op cut per-hit overhead from 5.9 ms to 2.8 ms and recovered the bin-caching win (warm 11.6 s → 9.8 s on the same code). The named `touch_mtime` seam is kept as a marker so the rule is greppable; if a future cc/cpp consumer needs `mtime = now()` semantics for make/ninja, gate it on the consumer rather than re-globalizing the behavior.
 
 ## Core Principles

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -1,35 +1,92 @@
 # Crates Architecture
 
+21 crates split into two product surfaces: the **compile cache** (`zccache-daemon` + `zccache-cli`, plus their library subsystems) and a separate **download cache** (`zccache-download-daemon` + `zccache-download-cli`, plus their library subsystems). A few utility binaries (`zccache-fp`, `zccache-stamp`) and one CI lib (`zccache-ci`) round out the workspace.
+
 ## Dependency Graph
 
 ```
-zccache-daemon (bin) ─────────────────────────────────────────┐
-  ├─ zccache-ipc ─── zccache-protocol ─── zccache-core       │
-  ├─ zccache-fscache ─── zccache-core                        │
-  ├─ zccache-artifact ─── zccache-hash ─── zccache-core      │
-  ├─ zccache-watcher ─── zccache-fscache                     │
-  └─ zccache-compiler ─── zccache-hash                       │
-                                                              │
-zccache-cli (bin: "zccache") ─────────────────────────────────┤
-  ├─ zccache-ipc                                              │
-  ├─ zccache-protocol                                         │
-  └─ zccache-core                                             │
-                                                              │
-zccache-test-support (test utilities) ────────────────────────┘
+APPLICATION BINARIES
+────────────────────
+zccache-cli (bin "zccache")  ──┐
+  deps: artifact, compiler, core, hash, ipc, protocol,
+        download, download-client, gha, symbols      │
+                                                      │
+zccache-daemon (bin)  ─────────┤
+  deps: artifact, compiler, core, hash, ipc, protocol,
+        fscache, watcher, depgraph, fingerprint,      │
+        test-support (dev only)                       │
+                                                      │
+zccache-download-daemon (bin)  ┤  deps: core, ipc, download, download-protocol
+zccache-download-cli (bin "zccache-download")  ┤  deps: download, download-client
+                                                      │
+SIDECAR BINARIES                                      │
+────────────────                                      │
+zccache-fp (in zccache-fingerprint)  ┤  deps: core, hash
+zccache-stamp (in zccache-symbols)   ┤  deps: core
+                                                      │
+COMPILE-CACHE SUBSYSTEM LIBS                          │
+────────────────────────────                          │
+zccache-artifact ───── hash ──── core
+zccache-compiler ──── hash
+zccache-fscache ───── core
+zccache-watcher ───── fscache
+zccache-depgraph ──── hash, core
+zccache-fingerprint ── hash, core
+zccache-protocol ──── core
+zccache-ipc ──────── protocol, core
+                                                      │
+DOWNLOAD-CACHE SUBSYSTEM LIBS                         │
+─────────────────────────────                         │
+zccache-download ──── core
+zccache-download-protocol ─── download, core
+zccache-download-client  ──── download, download-protocol,
+                              download-daemon, core, ipc
+                                                      │
+SHARED FOUNDATIONS                                    │
+──────────────────                                    │
+zccache-core   (Error/Result, Config, NormalizedPath)
+zccache-hash   (blake3 ContentHash, CacheKeyBuilder)
+                                                      │
+OTHER                                                 │
+─────                                                 │
+zccache-gha          (lib, no internal deps)
+zccache-symbols      (lib + zccache-stamp bin)
+zccache-ci           (lib, used by Stop hook — core, ipc)
+zccache-test-support (dev-only test utilities)
 ```
 
 ## Crate Responsibilities
 
+### Shared foundations
 - **zccache-core** — Shared error types (`Error`/`Result`), `Config`, `NormalizedPath` for cross-platform path handling
 - **zccache-hash** — `ContentHash` (blake3), `CacheKeyBuilder` with domain-separated deterministic hashing
-- **zccache-protocol** — `Request`/`Response` enums, `ArtifactData`, length-prefixed bincode framing
+
+### Compile-cache subsystem libs
+- **zccache-protocol** — `Request`/`Response` enums, `ArtifactData`, length-prefixed bincode framing; bump `PROTOCOL_VERSION` on any wire-format change
 - **zccache-ipc** — Platform IPC endpoint discovery (`default_endpoint()`: Unix sockets vs named pipes)
 - **zccache-fscache** — `MetadataCache` (DashMap-backed) with `Confidence` levels and time-based decay
-- **zccache-artifact** — Content-addressed disk store with 2-level hex sharding, redb index for LRU eviction
+- **zccache-artifact** — Content-addressed disk store with 2-level hex sharding, redb index for LRU eviction; also Rust-plan bundle save/restore
 - **zccache-watcher** — `FileWatcher` trait over notify crate; dedicated OS thread, events via tokio channel
-- **zccache-compiler** — `CompilerFamily` detection, `ParsedInvocation` for cacheability checks
-- **zccache-daemon** — Tokio async runtime, IPC server, orchestrates all subsystems
-- **zccache-cli** — Subcommands: start, stop, status, clear, wrap, inspect
+- **zccache-compiler** — `CompilerFamily` detection, `ParsedInvocation` for cacheability checks (clang/gcc/msvc/rustc/clang-cl), plus `parse_linker`, `parse_archiver`, `parse_msvc`, `parse_rustfmt`, `response_file`, `strict_paths`, `arduino` submodules
+- **zccache-depgraph** — Persistent dependency graph for cache invalidation; snapshot save/load, dep walker
+- **zccache-fingerprint** — File fingerprinting engine + `zccache-fp` CLI for inspecting/marking fingerprints
+
+### Compile-cache application binaries
+- **zccache-daemon** — Tokio async runtime, IPC server, orchestrates all compile-cache subsystems
+- **zccache-cli** — `zccache` binary: subcommands (start/stop/status/clear/analyze/warm/session/snapshot/cargo-registry/gha/rust-plan/fp/symbols), compiler wrapper mode, daemon lifecycle, GHA + Rust-plan save/restore
+
+### Download-cache (separate daemon for fetching cached artifact archives)
+- **zccache-download** — Core download engine and types
+- **zccache-download-protocol** — IPC protocol for download daemon
+- **zccache-download-client** — Rust client API for the download daemon
+- **zccache-download-daemon** — Per-user `zccache-download-daemon` binary
+- **zccache-download-cli** — `zccache-download` CLI binary
+
+### Other
+- **zccache-symbols** — Release-build marker, symbol cache, and symbol-archive fetcher; ships `zccache-stamp` CI helper
+- **zccache-gha** — GitHub Actions Cache API client (used by both daemons for shared caching)
+- **zccache-ci** — Stop-hook helper (process/thread dumping) run after every Claude Code Stop event
+- **zccache-test-support** — Shared test utilities (dev-dependency only)
 
 ## Key Design Patterns
 
@@ -43,6 +100,6 @@ zccache-test-support (test utilities) ──────────────
 
 **Concurrency:** Tokio tasks for IPC, DashMap for metadata cache (sharded lock-free reads), redb MVCC for artifact index, file watcher on dedicated OS thread.
 
-## Current Status
+## File-size discipline
 
-Phase 0 (scaffolding) is complete. All 11 crates are stubbed with real types, traits, and tests. Phase 1 (daemon + CLI + IPC) is next. See @docs/ROADMAP.md for the full phased plan.
+No source file > 1,000 LOC. Enforced by `ci/hooks/loc_guard.py` (warns >1K, blocks >1.5K). When a file approaches the cap, convert it to a directory module: `foo.rs` → `foo/mod.rs` + per-domain files alongside, with tests in a `tests/` subdirectory. Re-export `pub` items from `mod.rs` so the public path is unchanged. Precedents: PRs #355–#363 split server.rs, cli/main.rs, perf_bench_test.rs, compiler/lib.rs, server/{tests,mod}.rs, compile_journal.rs, and depgraph/snapshot.rs.


### PR DESCRIPTION
## Summary

- **Top-level `CLAUDE.md`** — adds the /init prefix; expands the one-line description with the warm-hit-latency architecture rationale; fixes stale "11 crates" → 21; adds `ci/hooks/loc_guard.py` to the Hooks section; adds a "No source file over 1,000 LOC" convention noting the directory-module split pattern and precedent PRs (#355–#363).
- **`crates/CLAUDE.md`** — rebuilds the dependency graph for all 21 crates grouped by purpose (compile cache vs download cache surfaces); adds responsibilities for the 10 newer crates (depgraph, fingerprint, symbols, gha, ci, the download-* family); replaces the long-stale "Phase 0 / Phase 1" status with a File-size discipline section.

Pure docs. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)