### PR TITLE
fix(monocrate): post-migration build errors from waves #366–#372

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3495,367 +3495,81 @@ dependencies = [
 ]
 
 [[package]]
-name = "zccache-artifact"
+name = "zccache"
 version = "1.9.0"
 dependencies = [
  "bincode",
  "blake3",
+ "bytes",
+ "clang",
+ "clap",
+ "crash-handler",
+ "criterion",
  "dashmap",
+ "filetime",
+ "flate2",
+ "fs2",
+ "futures",
+ "globset",
+ "jwalk",
+ "libc",
+ "lzma-rs",
+ "md5",
+ "memmap2",
+ "mimalloc",
+ "notify",
  "rayon",
  "redb",
+ "reqwest",
+ "rkyv",
+ "running-process-core",
+ "ruzstd",
+ "sadness-generator",
  "serde",
  "serde_json",
+ "sevenz-rust",
+ "sha2",
+ "sysinfo 0.33.1",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
+ "tikv-jemallocator",
+ "tokio",
+ "tokio-util",
  "tracing",
- "zccache-core",
- "zccache-hash",
-]
-
-[[package]]
-name = "zccache-ci"
-version = "1.9.0"
-dependencies = [
- "libc",
- "md5",
- "serde_json",
- "sysinfo 0.33.1",
+ "tracing-subscriber",
+ "uuid",
  "wait-timeout",
- "zccache-core",
- "zccache-ipc",
+ "windows-sys 0.59.0",
+ "zccache",
+ "zip",
 ]
 
 [[package]]
 name = "zccache-cli"
 version = "1.9.0"
 dependencies = [
- "blake3",
- "clap",
- "criterion",
- "flate2",
- "fs2",
- "jwalk",
- "mimalloc",
  "pyo3",
  "pyo3-build-config",
- "rayon",
- "reqwest",
- "running-process-core",
- "sadness-generator",
- "serde",
- "serde_json",
- "tar",
- "tempfile",
- "thiserror 2.0.18",
- "tikv-jemallocator",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "windows-sys 0.59.0",
- "zccache-artifact",
- "zccache-compiler",
- "zccache-core",
- "zccache-download",
- "zccache-download-client",
- "zccache-gha",
- "zccache-hash",
- "zccache-ipc",
- "zccache-protocol",
- "zccache-symbols",
- "zip",
-]
-
-[[package]]
-name = "zccache-compiler"
-version = "1.9.0"
-dependencies = [
- "clang",
- "tempfile",
- "thiserror 2.0.18",
- "tracing",
- "zccache-core",
- "zccache-hash",
-]
-
-[[package]]
-name = "zccache-core"
-version = "1.9.0"
-dependencies = [
- "crash-handler",
- "libc",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 2.0.18",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "zccache-daemon"
-version = "1.9.0"
-dependencies = [
- "bincode",
- "clap",
- "criterion",
- "dashmap",
- "filetime",
- "libc",
- "mimalloc",
- "rayon",
- "running-process-core",
- "sadness-generator",
- "serde",
- "serde_json",
- "sysinfo 0.33.1",
- "tempfile",
- "thiserror 2.0.18",
- "tikv-jemallocator",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "windows-sys 0.59.0",
- "zccache-artifact",
- "zccache-compiler",
- "zccache-core",
- "zccache-depgraph",
- "zccache-fingerprint",
- "zccache-fscache",
- "zccache-hash",
- "zccache-ipc",
- "zccache-protocol",
- "zccache-test-support",
- "zccache-watcher",
-]
-
-[[package]]
-name = "zccache-depgraph"
-version = "1.9.0"
-dependencies = [
- "blake3",
- "criterion",
- "dashmap",
- "rayon",
- "rkyv",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 2.0.18",
- "tracing",
- "uuid",
- "zccache-core",
- "zccache-hash",
-]
-
-[[package]]
-name = "zccache-download"
-version = "1.9.0"
-dependencies = [
- "blake3",
- "bytes",
- "futures",
- "reqwest",
- "serde",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "zccache-core",
-]
-
-[[package]]
-name = "zccache-download-cli"
-version = "1.9.0"
-dependencies = [
- "clap",
- "serde",
- "zccache-download",
- "zccache-download-client",
-]
-
-[[package]]
-name = "zccache-download-client"
-version = "1.9.0"
-dependencies = [
- "dashmap",
- "flate2",
- "fs2",
- "lzma-rs",
- "reqwest",
- "ruzstd",
- "serde",
- "serde_json",
- "sevenz-rust",
- "sha2",
- "tar",
- "tempfile",
- "tokio",
- "tokio-util",
- "tracing",
- "zccache-core",
- "zccache-download",
- "zccache-download-daemon",
- "zccache-download-protocol",
- "zccache-ipc",
- "zip",
-]
-
-[[package]]
-name = "zccache-download-daemon"
-version = "1.9.0"
-dependencies = [
- "clap",
- "dashmap",
- "mimalloc",
- "tikv-jemallocator",
- "tokio",
- "tokio-util",
- "tracing",
- "tracing-subscriber",
- "zccache-core",
- "zccache-download",
- "zccache-download-protocol",
- "zccache-ipc",
-]
-
-[[package]]
-name = "zccache-download-protocol"
-version = "1.9.0"
-dependencies = [
- "bincode",
- "bytes",
- "serde",
- "tempfile",
- "zccache-core",
- "zccache-download",
+ "zccache",
 ]
 
 [[package]]
 name = "zccache-fingerprint"
 version = "1.9.0"
 dependencies = [
- "clap",
- "criterion",
- "fs2",
- "globset",
- "jwalk",
- "mimalloc",
  "pyo3",
  "pyo3-build-config",
- "rayon",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 2.0.18",
- "tikv-jemallocator",
- "tracing",
- "zccache-core",
- "zccache-hash",
-]
-
-[[package]]
-name = "zccache-fscache"
-version = "1.9.0"
-dependencies = [
- "bincode",
- "dashmap",
- "rayon",
- "serde",
- "tempfile",
- "tracing",
- "zccache-core",
- "zccache-hash",
-]
-
-[[package]]
-name = "zccache-gha"
-version = "1.9.0"
-dependencies = [
- "reqwest",
- "serde",
- "serde_json",
- "sha2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "zccache-hash"
-version = "1.9.0"
-dependencies = [
- "blake3",
- "criterion",
- "memmap2",
- "serde",
- "tempfile",
- "zccache-core",
-]
-
-[[package]]
-name = "zccache-ipc"
-version = "1.9.0"
-dependencies = [
- "bytes",
- "serde",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "zccache-core",
- "zccache-protocol",
-]
-
-[[package]]
-name = "zccache-protocol"
-version = "1.9.0"
-dependencies = [
- "bincode",
- "bytes",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 2.0.18",
- "zccache-core",
-]
-
-[[package]]
-name = "zccache-symbols"
-version = "1.9.0"
-dependencies = [
- "tempfile",
- "zccache-core",
-]
-
-[[package]]
-name = "zccache-test-support"
-version = "1.9.0"
-dependencies = [
- "tempfile",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "zccache-core",
+ "zccache",
 ]
 
 [[package]]
 name = "zccache-watcher"
 version = "1.9.0"
 dependencies = [
- "criterion",
- "globset",
- "jwalk",
- "notify",
  "pyo3",
  "pyo3-build-config",
- "rayon",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "zccache-core",
- "zccache-fscache",
- "zccache-hash",
+ "zccache",
 ]
 
 [[package]]

--- a/crates/zccache-cli/src/lib.rs
+++ b/crates/zccache-cli/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "python")]
+
 use std::path::PathBuf;
 
 use pyo3::exceptions::{PyOSError, PyRuntimeError};

--- a/crates/zccache-fingerprint/src/lib.rs
+++ b/crates/zccache-fingerprint/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "python")]
+
 //! PyO3 cdylib for the fingerprint engine.
 //!
 //! The Rust fingerprint engine itself lives in

--- a/crates/zccache-watcher/src/lib.rs
+++ b/crates/zccache-watcher/src/lib.rs
@@ -5,6 +5,8 @@
 //! extension module so the polished `zccache.watcher` Python package can
 //! `import zccache.watcher._native`.
 
+#![cfg(feature = "python")]
+
 use std::path::PathBuf;
 use std::time::Duration;
 

--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -94,6 +94,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_Security",
     "Win32_Storage_FileSystem",
+    "Win32_System_JobObjects",
     "Win32_System_Threading",
 ] }
 

--- a/crates/zccache/benches/fingerprint.rs
+++ b/crates/zccache/benches/fingerprint.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use tempfile::TempDir;
-use zccache_fingerprint::{walk_files, walk_files_glob, HashCache, TwoLayerCache};
+use zccache::fingerprint::{walk_files, walk_files_glob, HashCache, TwoLayerCache};
 
 /// Create a synthetic directory tree with `n` files.
 fn create_synthetic_tree(dir: &Path, n: usize) {
@@ -157,7 +157,7 @@ fn bench_two_layer_fast_path(c: &mut Criterion) {
         b.iter(|| {
             let cache = TwoLayerCache::new(cache_file.clone());
             let decision = cache.try_skip_fast(src.path()).unwrap();
-            assert_eq!(decision, Some(zccache_fingerprint::CacheDecision::Skip));
+            assert_eq!(decision, Some(zccache::fingerprint::CacheDecision::Skip));
         });
     });
 }

--- a/crates/zccache/benches/scan_recursive.rs
+++ b/crates/zccache/benches/scan_recursive.rs
@@ -19,8 +19,8 @@
 use std::path::{Path, PathBuf};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use zccache_depgraph::scanner::scan_recursive;
-use zccache_depgraph::search_paths::IncludeSearchPaths;
+use zccache::depgraph::scanner::scan_recursive;
+use zccache::depgraph::search_paths::IncludeSearchPaths;
 
 /// Build a tree of `#include "h_<id>.h"` headers in a single flat directory.
 ///

--- a/crates/zccache/src/artifact/kv.rs
+++ b/crates/zccache/src/artifact/kv.rs
@@ -15,14 +15,14 @@ use std::sync::Arc;
 
 use redb::{Database, ReadableTable, TableDefinition};
 use serde::{Deserialize, Serialize};
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Windows long-path (`\\?\`) helpers. On non-Windows platforms every entry
 /// point is a no-op pass-through.
 mod long_path {
     use std::path::Path;
 
-    use zccache::core::NormalizedPath;
+    use crate::core::NormalizedPath;
 
     /// Normalize `dir` so that paths joined off it can exceed `MAX_PATH`
     /// without tripping the legacy Win32 path APIs used by transitive crates
@@ -251,7 +251,7 @@ pub struct KvStore {
 impl KvStore {
     /// Open under the canonical zccache root (`default_cache_dir()`).
     pub fn open_default() -> KvResult<Self> {
-        let dir = zccache::core::config::default_cache_dir();
+        let dir = crate::core::config::default_cache_dir();
         Self::open(dir)
     }
 

--- a/crates/zccache/src/artifact/mod.rs
+++ b/crates/zccache/src/artifact/mod.rs
@@ -23,7 +23,7 @@ pub use rust_plan::{
 pub use store::{ArtifactIndex, ArtifactStore};
 
 use std::path::Path;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Configuration for the artifact store.
 #[derive(Debug, Clone)]
@@ -49,14 +49,14 @@ impl ArtifactStoreLegacy {
     /// Open or create an artifact store at the given configuration.
     ///
     /// Creates the cache directory if it does not exist.
-    pub fn open(config: ArtifactStoreConfig) -> zccache::core::Result<Self> {
+    pub fn open(config: ArtifactStoreConfig) -> crate::core::Result<Self> {
         std::fs::create_dir_all(&config.cache_dir)?;
         Ok(Self { config })
     }
 
     /// Returns the path where an artifact with the given key would be stored.
     #[must_use]
-    pub fn artifact_path(&self, key: &zccache::hash::ContentHash) -> NormalizedPath {
+    pub fn artifact_path(&self, key: &crate::hash::ContentHash) -> NormalizedPath {
         let shards = key.shard_prefix(2, 1);
         self.config
             .cache_dir
@@ -68,7 +68,7 @@ impl ArtifactStoreLegacy {
 
     /// Check if an artifact exists for the given cache key.
     #[must_use]
-    pub fn contains(&self, key: &zccache::hash::ContentHash) -> bool {
+    pub fn contains(&self, key: &crate::hash::ContentHash) -> bool {
         self.artifact_path(key).exists()
     }
 

--- a/crates/zccache/src/artifact/rust_plan.rs
+++ b/crates/zccache/src/artifact/rust_plan.rs
@@ -8,7 +8,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use rayon::prelude::*;
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
-use zccache::core::{normalize_for_key, NormalizedPath};
+use crate::core::{normalize_for_key, NormalizedPath};
 
 /// Upper bound on save-time worker threads. Beyond this Windows filter-driver
 /// serialization dominates and extra threads stop helping (see issue #177 and
@@ -598,7 +598,7 @@ pub fn rust_plan_identity_hash(plan: &RustArtifactPlanV1) -> String {
         "cache_schema_version": plan.cache_schema_version,
     });
     let bytes = serde_json::to_vec(&payload).unwrap_or_default();
-    zccache::hash::hash_bytes(&bytes).to_hex()
+    crate::hash::hash_bytes(&bytes).to_hex()
 }
 
 /// Bundle directory for a plan cache key.
@@ -710,7 +710,7 @@ fn bundle_one_artifact(
     }
     std::fs::copy(&sel.source_path, &dst)?;
     let size = std::fs::metadata(&sel.source_path)?.len();
-    let content_hash = zccache::hash::hash_file(&sel.source_path)?.to_hex();
+    let content_hash = crate::hash::hash_file(&sel.source_path)?.to_hex();
     Ok(RustBundledArtifact {
         relative_path: sel.relative_path.clone(),
         class: sel.class,
@@ -827,7 +827,7 @@ pub fn restore_rust_plan_local(
             );
             continue;
         }
-        let Ok(content_hash) = zccache::hash::hash_file(&src).map(|hash| hash.to_hex()) else {
+        let Ok(content_hash) = crate::hash::hash_file(&src).map(|hash| hash.to_hex()) else {
             summary.skip(
                 &artifact.relative_path,
                 "restored_payload_missing_or_corrupt",

--- a/crates/zccache/src/artifact/store.rs
+++ b/crates/zccache/src/artifact/store.rs
@@ -28,7 +28,7 @@
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};

--- a/crates/zccache/src/bin/zccache-download-daemon.rs
+++ b/crates/zccache/src/bin/zccache-download-daemon.rs
@@ -90,7 +90,7 @@ fn run_server(args: Args) {
         .build()
         .expect("failed to create runtime");
     rt.block_on(async move {
-        let mut server = match zccache_download_daemon::DownloadDaemon::bind(&endpoint) {
+        let mut server = match zccache::download_daemon::DownloadDaemon::bind(&endpoint) {
             Ok(server) => server,
             Err(err) => {
                 eprintln!("failed to bind download daemon at {endpoint}: {err}");

--- a/crates/zccache/src/bin/zccache-fp.rs
+++ b/crates/zccache/src/bin/zccache-fp.rs
@@ -171,7 +171,7 @@ fn run_mark(
 ) -> Result<ExitCode, FingerprintError> {
     // Auto-detect cache type from pending file so users don't need to pass
     // --cache-type on mark-success/mark-failure (fixes #1 in BUGS.md).
-    let cache_type = match zccache_fingerprint::detect_pending_type(cache_file) {
+    let cache_type = match zccache::fingerprint::detect_pending_type(cache_file) {
         Some("hash") => CacheType::Hash,
         Some("two-layer") => CacheType::TwoLayer,
         _ => cache_type.clone(),

--- a/crates/zccache/src/bin/zccache-stamp.rs
+++ b/crates/zccache/src/bin/zccache-stamp.rs
@@ -100,7 +100,7 @@ fn main() -> ExitCode {
     println!(
         "stamped {} ({} bytes appended)",
         args.binary.display(),
-        zccache_symbols::marker::MARKER_SIZE
+        zccache::symbols::marker::MARKER_SIZE
     );
     ExitCode::SUCCESS
 }

--- a/crates/zccache/src/ci/mod.rs
+++ b/crates/zccache/src/ci/mod.rs
@@ -31,7 +31,7 @@ use std::io::Write;
 use std::path::Path;
 use std::process::{Child, Command};
 use std::time::{Duration, Instant};
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use wait_timeout::ChildExt;
 
@@ -448,7 +448,7 @@ fn find_daemon_pids() -> Vec<u32> {
 /// Send a kill to each PID and poll until every PID is confirmed dead, or
 /// `timeout` elapses. Returns once every PID is gone (or once we time out).
 ///
-/// Uses [`zccache::ipc::force_kill_process`] (TerminateProcess on Windows,
+/// Uses [`crate::ipc::force_kill_process`] (TerminateProcess on Windows,
 /// SIGKILL on Unix) rather than sysinfo's `Process::kill`, which has been
 /// observed to silently fail to terminate Windows console children spawned via
 /// `cmd /C` in tests — the kill bool returned `true` but the process kept
@@ -461,7 +461,7 @@ pub fn kill_pids_and_wait(pids: &[u32], timeout: Duration) {
     }
 
     for pid in pids {
-        if let Err(e) = zccache::ipc::force_kill_process(*pid) {
+        if let Err(e) = crate::ipc::force_kill_process(*pid) {
             eprintln!("force_kill_process({pid}) failed: {e}");
         }
     }
@@ -469,7 +469,7 @@ pub fn kill_pids_and_wait(pids: &[u32], timeout: Duration) {
     let deadline = Instant::now() + timeout;
     let poll = Duration::from_millis(25);
     loop {
-        let any_alive = pids.iter().any(|pid| zccache::ipc::is_process_alive(*pid));
+        let any_alive = pids.iter().any(|pid| crate::ipc::is_process_alive(*pid));
         if !any_alive {
             return;
         }
@@ -477,7 +477,7 @@ pub fn kill_pids_and_wait(pids: &[u32], timeout: Duration) {
             let still_alive: Vec<u32> = pids
                 .iter()
                 .copied()
-                .filter(|pid| zccache::ipc::is_process_alive(*pid))
+                .filter(|pid| crate::ipc::is_process_alive(*pid))
                 .collect();
             eprintln!(
                 "Warning: daemon PIDs still alive after {}ms: {:?}",
@@ -508,14 +508,14 @@ pub fn kill_daemon() {
     if pids.is_empty() {
         // No daemon running. The lock file may still be stale from a prior
         // crash, so remove it defensively.
-        zccache::ipc::remove_lock_file();
+        crate::ipc::remove_lock_file();
         return;
     }
     for pid in &pids {
         eprintln!("Killing running daemon (PID {pid}) to unlock target binaries");
     }
     kill_pids_and_wait(&pids, KILL_DAEMON_WAIT);
-    zccache::ipc::remove_lock_file();
+    crate::ipc::remove_lock_file();
 }
 
 // ---------------------------------------------------------------------------
@@ -716,7 +716,7 @@ mod tests {
         let pid = child.id();
 
         assert!(
-            zccache::ipc::is_process_alive(pid),
+            crate::ipc::is_process_alive(pid),
             "spawned child PID {pid} should be alive"
         );
 
@@ -730,7 +730,7 @@ mod tests {
         waiter.join().expect("reaper thread panicked");
 
         assert!(
-            !zccache::ipc::is_process_alive(pid),
+            !crate::ipc::is_process_alive(pid),
             "PID {pid} still alive after kill_pids_and_wait returned"
         );
     }

--- a/crates/zccache/src/cli/commands/cache_ops.rs
+++ b/crates/zccache/src/cli/commands/cache_ops.rs
@@ -15,7 +15,7 @@ pub(crate) async fn cmd_clear(endpoint: &str) -> ExitCode {
         }
     };
 
-    if let Err(e) = conn.send(&zccache::protocol::Request::Clear).await {
+    if let Err(e) = conn.send(&crate::protocol::Request::Clear).await {
         eprintln!("zccache[err][S]: failed to send to daemon: {e}");
         return ExitCode::FAILURE;
     }
@@ -27,7 +27,7 @@ pub(crate) async fn cmd_clear(endpoint: &str) -> ExitCode {
         }
     };
     match recv_result {
-        Some(zccache::protocol::Response::Cleared {
+        Some(crate::protocol::Response::Cleared {
             artifacts_removed,
             metadata_cleared,
             dep_graph_contexts_cleared,
@@ -59,7 +59,7 @@ pub(crate) async fn cmd_clear(endpoint: &str) -> ExitCode {
 pub(crate) fn cmd_kv(action: super::args::KvCommands) -> ExitCode {
     use super::args::KvCommands;
     use std::io::{Read, Write};
-    use zccache::artifact::{Key, KvError, KvStore};
+    use crate::artifact::{Key, KvError, KvStore};
 
     fn open_store() -> Result<KvStore, ExitCode> {
         match KvStore::open_default() {
@@ -227,8 +227,8 @@ pub(crate) fn cmd_kv(action: super::args::KvCommands) -> ExitCode {
 }
 
 pub(crate) fn cmd_warm(target_dir: &Path, profile: &str) -> ExitCode {
-    let cache_dir = zccache::core::config::default_cache_dir();
-    let index_path = zccache::core::config::index_path_from_cache_dir(&cache_dir);
+    let cache_dir = crate::core::config::default_cache_dir();
+    let index_path = crate::core::config::index_path_from_cache_dir(&cache_dir);
     let artifact_dir = cache_dir.join("artifacts");
     // Look for Cargo.lock in cwd or next to target_dir
     let lockfile = {
@@ -324,7 +324,7 @@ pub(crate) fn warm_target(
         return Err(format!("no artifact index at {}", index_path.display()));
     }
 
-    let store = zccache::artifact::ArtifactStore::open(index_path)
+    let store = crate::artifact::ArtifactStore::open(index_path)
         .map_err(|e| format!("failed to open artifact index: {e}"))?;
 
     let all_entries = store.load_all();
@@ -449,7 +449,7 @@ pub(crate) fn warm_target(
 }
 
 pub(crate) fn cmd_crashes(clear: bool) -> ExitCode {
-    let crash_dir = zccache::core::config::crash_dump_dir();
+    let crash_dir = crate::core::config::crash_dump_dir();
 
     if clear {
         let count = match std::fs::read_dir(&crash_dir) {
@@ -511,7 +511,7 @@ pub(crate) fn cmd_crashes(clear: bool) -> ExitCode {
 /// zccache binary on PATH honored `ZCCACHE_CACHE_DIR` before trusting the
 /// Defender-exclusion contract.
 pub(crate) fn cmd_cache_root(json: bool) -> ExitCode {
-    let (root, source) = zccache::core::config::resolve_cache_root();
+    let (root, source) = crate::core::config::resolve_cache_root();
     if json {
         let payload = serde_json::json!({
             "cache_root": root.as_path(),

--- a/crates/zccache/src/cli/commands/cargo_registry.rs
+++ b/crates/zccache/src/cli/commands/cargo_registry.rs
@@ -1,7 +1,7 @@
 //! `zccache cargo-registry` subcommands: save / restore / hash / clean.
 
 use std::process::ExitCode;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use super::util::{env_flag_truthy, format_bytes};
 
@@ -169,7 +169,7 @@ pub(crate) fn cmd_cargo_registry_hash(lockfile: &str) -> ExitCode {
         eprintln!("lockfile not found: {lockfile}");
         return ExitCode::FAILURE;
     }
-    let hash = match zccache::hash::hash_file(path) {
+    let hash = match crate::hash::hash_file(path) {
         Ok(h) => h,
         Err(e) => {
             eprintln!("zccache cargo-registry hash: failed to hash {lockfile}: {e}");

--- a/crates/zccache/src/cli/commands/daemon.rs
+++ b/crates/zccache/src/cli/commands/daemon.rs
@@ -1,7 +1,7 @@
 //! Daemon lifecycle: start, stop, version probing, ensure-running, binary discovery.
 
 use std::process::ExitCode;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use super::util::{connect, resolve_endpoint, run_async};
 
@@ -27,16 +27,16 @@ pub(crate) async fn check_daemon_version(endpoint: &str) -> VersionCheck {
         Ok(c) => c,
         Err(_) => return VersionCheck::Unreachable,
     };
-    if conn.send(&zccache::protocol::Request::Status).await.is_err() {
+    if conn.send(&crate::protocol::Request::Status).await.is_err() {
         return VersionCheck::CommError;
     }
-    match conn.recv::<zccache::protocol::Response>().await {
-        Ok(Some(zccache::protocol::Response::Status(s))) => {
-            if s.version == zccache::core::VERSION {
+    match conn.recv::<crate::protocol::Response>().await {
+        Ok(Some(crate::protocol::Response::Status(s))) => {
+            if s.version == crate::core::VERSION {
                 return VersionCheck::Ok;
             }
-            let client_ver = zccache::core::version::current();
-            match zccache::core::version::Version::parse(&s.version) {
+            let client_ver = crate::core::version::current();
+            match crate::core::version::Version::parse(&s.version) {
                 Some(daemon_ver) => match daemon_ver.cmp(&client_ver) {
                     std::cmp::Ordering::Equal => VersionCheck::Ok,
                     std::cmp::Ordering::Greater => VersionCheck::DaemonNewer {
@@ -64,8 +64,8 @@ pub(crate) async fn spawn_and_wait(endpoint: &str, reason: &str) -> Result<(), S
     // can correlate each CLI decision with the resulting daemon PID
     // by parsing the single `daemon-lifecycle.log`. See zccache#323
     // for the diagnostic gap that motivated this.
-    zccache::core::lifecycle::write_event(
-        zccache::core::lifecycle::EVENT_SPAWN_ATTEMPT,
+    crate::core::lifecycle::write_event(
+        crate::core::lifecycle::EVENT_SPAWN_ATTEMPT,
         serde_json::json!({
             "reason": reason,
             "endpoint": endpoint,
@@ -90,23 +90,23 @@ pub(crate) async fn spawn_and_wait(endpoint: &str, reason: &str) -> Result<(), S
 pub(crate) async fn stop_stale_daemon(endpoint: &str) {
     // Try graceful shutdown via IPC
     if let Ok(mut conn) = connect(endpoint).await {
-        let _ = conn.send(&zccache::protocol::Request::Shutdown).await;
+        let _ = conn.send(&crate::protocol::Request::Shutdown).await;
         // Give it a moment to process the shutdown
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     }
 
     // Force-kill via lock file PID if the daemon is still alive
-    if let Some(pid) = zccache::ipc::check_running_daemon() {
+    if let Some(pid) = crate::ipc::check_running_daemon() {
         tracing::debug!(pid, "force-killing stale daemon process");
-        if zccache::ipc::force_kill_process(pid).is_ok() {
+        if crate::ipc::force_kill_process(pid).is_ok() {
             for _ in 0..50 {
-                if !zccache::ipc::is_process_alive(pid) {
+                if !crate::ipc::is_process_alive(pid) {
                     break;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }
         }
-        zccache::ipc::remove_lock_file();
+        crate::ipc::remove_lock_file();
     }
 
     // Wait briefly for the endpoint (named pipe / socket) to be fully released
@@ -129,7 +129,7 @@ pub(crate) async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
         VersionCheck::DaemonNewer { daemon_ver } => {
             tracing::debug!(
                 daemon_ver,
-                client_ver = zccache::core::VERSION,
+                client_ver = crate::core::VERSION,
                 "daemon is newer than client, proceeding"
             );
             return Ok(());
@@ -137,13 +137,13 @@ pub(crate) async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
         VersionCheck::DaemonOlder { daemon_ver } => {
             tracing::info!(
                 daemon_ver,
-                client_ver = zccache::core::VERSION,
+                client_ver = crate::core::VERSION,
                 "daemon is older than client, auto-recovering"
             );
             stop_stale_daemon(endpoint).await;
             return spawn_and_wait(
                 endpoint,
-                zccache::core::lifecycle::REASON_REPLACED_STALE_VERSION,
+                crate::core::lifecycle::REASON_REPLACED_STALE_VERSION,
             )
             .await;
         }
@@ -152,7 +152,7 @@ pub(crate) async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
             stop_stale_daemon(endpoint).await;
             return spawn_and_wait(
                 endpoint,
-                zccache::core::lifecycle::REASON_REPLACED_COMM_ERROR,
+                crate::core::lifecycle::REASON_REPLACED_COMM_ERROR,
             )
             .await;
         }
@@ -162,7 +162,7 @@ pub(crate) async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
     }
 
     // Check lock file for a running daemon we just can't reach yet
-    if let Some(pid) = zccache::ipc::check_running_daemon() {
+    if let Some(pid) = crate::ipc::check_running_daemon() {
         for _ in 0..20 {
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             match check_daemon_version(endpoint).await {
@@ -170,7 +170,7 @@ pub(crate) async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
                 VersionCheck::DaemonNewer { daemon_ver } => {
                     tracing::debug!(
                         daemon_ver,
-                        client_ver = zccache::core::VERSION,
+                        client_ver = crate::core::VERSION,
                         "daemon is newer than client, proceeding"
                     );
                     return Ok(());
@@ -178,13 +178,13 @@ pub(crate) async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
                 VersionCheck::DaemonOlder { daemon_ver } => {
                     tracing::info!(
                         daemon_ver,
-                        client_ver = zccache::core::VERSION,
+                        client_ver = crate::core::VERSION,
                         "daemon is older than client during startup, auto-recovering"
                     );
                     stop_stale_daemon(endpoint).await;
                     return spawn_and_wait(
                         endpoint,
-                        zccache::core::lifecycle::REASON_REPLACED_STALE_VERSION,
+                        crate::core::lifecycle::REASON_REPLACED_STALE_VERSION,
                     )
                     .await;
                 }
@@ -195,7 +195,7 @@ pub(crate) async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
                     stop_stale_daemon(endpoint).await;
                     return spawn_and_wait(
                         endpoint,
-                        zccache::core::lifecycle::REASON_REPLACED_COMM_ERROR,
+                        crate::core::lifecycle::REASON_REPLACED_COMM_ERROR,
                     )
                     .await;
                 }
@@ -208,7 +208,7 @@ pub(crate) async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
     }
 
     // No daemon running — spawn one
-    spawn_and_wait(endpoint, zccache::core::lifecycle::REASON_INITIAL_START).await
+    spawn_and_wait(endpoint, crate::core::lifecycle::REASON_INITIAL_START).await
 }
 
 /// Find the daemon binary. Looks next to the CLI binary first, then on PATH.
@@ -271,7 +271,7 @@ pub(crate) async fn cmd_stop(endpoint: &str) -> ExitCode {
     let mut conn = match connect(endpoint).await {
         Ok(c) => c,
         Err(_) => {
-            let Some(pid) = zccache::ipc::check_running_daemon() else {
+            let Some(pid) = crate::ipc::check_running_daemon() else {
                 eprintln!("daemon not running at {endpoint}");
                 // No daemon — but the index file might still be there from a
                 // crashed prior run. Probe once so callers (CI tar) can rely
@@ -280,11 +280,11 @@ pub(crate) async fn cmd_stop(endpoint: &str) -> ExitCode {
                 return ExitCode::SUCCESS;
             };
 
-            match zccache::ipc::force_kill_process(pid) {
+            match crate::ipc::force_kill_process(pid) {
                 Ok(()) => {
                     for _ in 0..50 {
-                        if !zccache::ipc::is_process_alive(pid) {
-                            zccache::ipc::remove_lock_file();
+                        if !crate::ipc::is_process_alive(pid) {
+                            crate::ipc::remove_lock_file();
                             eprintln!(
                                 "daemon process {pid} terminated after IPC connection failed"
                             );
@@ -309,7 +309,7 @@ pub(crate) async fn cmd_stop(endpoint: &str) -> ExitCode {
         }
     };
 
-    if let Err(e) = conn.send(&zccache::protocol::Request::Shutdown).await {
+    if let Err(e) = conn.send(&crate::protocol::Request::Shutdown).await {
         eprintln!("zccache[err][S]: failed to send to daemon: {e}");
         return ExitCode::FAILURE;
     }
@@ -321,7 +321,7 @@ pub(crate) async fn cmd_stop(endpoint: &str) -> ExitCode {
         }
     };
     match recv_result {
-        Some(zccache::protocol::Response::ShuttingDown) => {
+        Some(crate::protocol::Response::ShuttingDown) => {
             // The daemon acknowledges `Shutdown` immediately and continues
             // teardown asynchronously. On Windows the redb index lock is held
             // until the daemon process actually exits and `Drop` fires. Wait

--- a/crates/zccache/src/cli/commands/fp.rs
+++ b/crates/zccache/src/cli/commands/fp.rs
@@ -28,7 +28,7 @@ pub(crate) async fn cmd_fp_check(
         }
     };
 
-    let request = zccache::protocol::Request::FingerprintCheck {
+    let request = crate::protocol::Request::FingerprintCheck {
         cache_file: cache_file.into(),
         cache_type: cache_type.to_string(),
         root: root.into(),
@@ -42,8 +42,8 @@ pub(crate) async fn cmd_fp_check(
         return ExitCode::from(2);
     }
 
-    match conn.recv::<zccache::protocol::Response>().await {
-        Ok(Some(zccache::protocol::Response::FingerprintCheckResult {
+    match conn.recv::<crate::protocol::Response>().await {
+        Ok(Some(crate::protocol::Response::FingerprintCheckResult {
             decision,
             reason,
             changed_files,
@@ -64,7 +64,7 @@ pub(crate) async fn cmd_fp_check(
                 ExitCode::SUCCESS
             }
         }
-        Ok(Some(zccache::protocol::Response::Error { message })) => {
+        Ok(Some(crate::protocol::Response::Error { message })) => {
             eprintln!("zccache fp: daemon error: {message}");
             ExitCode::from(2)
         }
@@ -94,11 +94,11 @@ pub(crate) async fn cmd_fp_mark(endpoint: &str, cache_file: &Path, success: bool
     };
 
     let request = if success {
-        zccache::protocol::Request::FingerprintMarkSuccess {
+        crate::protocol::Request::FingerprintMarkSuccess {
             cache_file: cache_file.into(),
         }
     } else {
-        zccache::protocol::Request::FingerprintMarkFailure {
+        crate::protocol::Request::FingerprintMarkFailure {
             cache_file: cache_file.into(),
         }
     };
@@ -108,8 +108,8 @@ pub(crate) async fn cmd_fp_mark(endpoint: &str, cache_file: &Path, success: bool
         return ExitCode::from(2);
     }
 
-    match conn.recv::<zccache::protocol::Response>().await {
-        Ok(Some(zccache::protocol::Response::FingerprintAck)) => {
+    match conn.recv::<crate::protocol::Response>().await {
+        Ok(Some(crate::protocol::Response::FingerprintAck)) => {
             let label = if success {
                 "mark-success"
             } else {
@@ -118,7 +118,7 @@ pub(crate) async fn cmd_fp_mark(endpoint: &str, cache_file: &Path, success: bool
             eprintln!("zccache fp: {label}");
             ExitCode::SUCCESS
         }
-        Ok(Some(zccache::protocol::Response::Error { message })) => {
+        Ok(Some(crate::protocol::Response::Error { message })) => {
             eprintln!("zccache fp: daemon error: {message}");
             ExitCode::from(2)
         }
@@ -147,7 +147,7 @@ pub(crate) async fn cmd_fp_invalidate(endpoint: &str, cache_file: &Path) -> Exit
         }
     };
 
-    let request = zccache::protocol::Request::FingerprintInvalidate {
+    let request = crate::protocol::Request::FingerprintInvalidate {
         cache_file: cache_file.into(),
     };
 
@@ -156,12 +156,12 @@ pub(crate) async fn cmd_fp_invalidate(endpoint: &str, cache_file: &Path) -> Exit
         return ExitCode::from(2);
     }
 
-    match conn.recv::<zccache::protocol::Response>().await {
-        Ok(Some(zccache::protocol::Response::FingerprintAck)) => {
+    match conn.recv::<crate::protocol::Response>().await {
+        Ok(Some(crate::protocol::Response::FingerprintAck)) => {
             eprintln!("zccache fp: invalidated");
             ExitCode::SUCCESS
         }
-        Ok(Some(zccache::protocol::Response::Error { message })) => {
+        Ok(Some(crate::protocol::Response::Error { message })) => {
             eprintln!("zccache fp: daemon error: {message}");
             ExitCode::from(2)
         }

--- a/crates/zccache/src/cli/commands/gha.rs
+++ b/crates/zccache/src/cli/commands/gha.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 use std::process::ExitCode;
-use zccache::gha::{GhaCache, GhaError};
+use crate::gha::{GhaCache, GhaError};
 
 use super::targz::{tar_gz_decode, tar_gz_encode};
 

--- a/crates/zccache/src/cli/commands/mod.rs
+++ b/crates/zccache/src/cli/commands/mod.rs
@@ -6,7 +6,7 @@
 
 use std::path::Path;
 use std::process::ExitCode;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 pub(crate) mod analyze;
 pub(crate) mod args;
@@ -43,7 +43,7 @@ pub fn run() -> ExitCode {
     // Best-effort: if the user opted in via env, fetch matching debug
     // sidecars before doing anything else so the very first command's
     // failure (if any) lands with resolvable symbols. Idempotent — skips
-    // when already installed. See `zccache::cli::symbols`.
+    // when already installed. See `crate::cli::symbols`.
     symbols_lib::maybe_auto_install();
 
     // Auto-detect: if first arg isn't a known subcommand or a --flag, enter wrap mode.

--- a/crates/zccache/src/cli/commands/rust_plan.rs
+++ b/crates/zccache/src/cli/commands/rust_plan.rs
@@ -2,12 +2,12 @@
 
 use std::path::Path;
 use std::process::ExitCode;
-use zccache::artifact::{
+use crate::artifact::{
     restore_rust_plan_local, rust_plan_bundle_dir, rust_plan_cache_key, save_rust_plan_local,
     RustArtifactPlanV1, RustPlanError, RustPlanOperation, RustPlanSummary,
 };
-use zccache::core::NormalizedPath;
-use zccache::gha::{GhaCache, GhaError};
+use crate::core::NormalizedPath;
+use crate::gha::{GhaCache, GhaError};
 
 use super::args::{RustPlanBackendArg, RustPlanCommands};
 use super::session::query_session_stats_json;
@@ -175,7 +175,7 @@ pub(crate) async fn cmd_rust_plan(action: RustPlanCommands) -> ExitCode {
 fn resolve_rust_plan_cache_dir(explicit: Option<&str>) -> NormalizedPath {
     explicit
         .map(NormalizedPath::from)
-        .unwrap_or_else(|| zccache::core::config::default_cache_dir().join("rust-artifacts"))
+        .unwrap_or_else(|| crate::core::config::default_cache_dir().join("rust-artifacts"))
 }
 
 fn load_rust_plan_for_cli(

--- a/crates/zccache/src/cli/commands/session.rs
+++ b/crates/zccache/src/cli/commands/session.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 use std::process::ExitCode;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use super::daemon::ensure_daemon;
 use super::util::{connect, format_duration_ms, print_json_value};
@@ -30,7 +30,7 @@ pub(crate) async fn cmd_session_start(
     };
 
     if let Err(e) = conn
-        .send(&zccache::protocol::Request::SessionStart {
+        .send(&crate::protocol::Request::SessionStart {
             client_pid: std::process::id(),
             working_dir: cwd.into(),
             log_file: log.map(NormalizedPath::from),
@@ -52,7 +52,7 @@ pub(crate) async fn cmd_session_start(
         }
     };
     match recv_result {
-        Some(zccache::protocol::Response::SessionStarted {
+        Some(crate::protocol::Response::SessionStarted {
             session_id,
             journal_path,
         }) => {
@@ -77,7 +77,7 @@ pub(crate) async fn cmd_session_start(
             }
             ExitCode::SUCCESS
         }
-        Some(zccache::protocol::Response::Error { message }) => {
+        Some(crate::protocol::Response::Error { message }) => {
             eprintln!("session-start failed: {message}");
             ExitCode::FAILURE
         }
@@ -142,7 +142,7 @@ pub(crate) async fn cmd_session_stats(endpoint: &str, session_id: String, json: 
     };
 
     if let Err(e) = conn
-        .send(&zccache::protocol::Request::SessionStats {
+        .send(&crate::protocol::Request::SessionStats {
             session_id: session_id.clone(),
         })
         .await
@@ -169,7 +169,7 @@ pub(crate) async fn cmd_session_stats(endpoint: &str, session_id: String, json: 
         }
     };
     match recv_result {
-        Some(zccache::protocol::Response::SessionStatsResult { stats }) => {
+        Some(crate::protocol::Response::SessionStatsResult { stats }) => {
             if let Some(s) = stats {
                 if json {
                     print_session_stats_json(&session_id, &s);
@@ -183,7 +183,7 @@ pub(crate) async fn cmd_session_stats(endpoint: &str, session_id: String, json: 
             }
             ExitCode::SUCCESS
         }
-        Some(zccache::protocol::Response::Error { message }) => {
+        Some(crate::protocol::Response::Error { message }) => {
             if json {
                 print_session_stats_error_json(&session_id, &message);
             } else {
@@ -214,7 +214,7 @@ pub(crate) async fn cmd_session_stats(endpoint: &str, session_id: String, json: 
 
 pub(crate) fn print_session_stats_human(
     session_id: &str,
-    stats: &zccache::protocol::SessionStats,
+    stats: &crate::protocol::SessionStats,
     state: &str,
 ) {
     let total = stats.hits + stats.misses;
@@ -245,7 +245,7 @@ pub(crate) fn print_session_stats_human(
     }
 }
 
-pub(crate) fn print_session_stats_json(session_id: &str, stats: &zccache::protocol::SessionStats) {
+pub(crate) fn print_session_stats_json(session_id: &str, stats: &crate::protocol::SessionStats) {
     print_json_value(&session_stats_json(session_id, stats));
 }
 
@@ -275,7 +275,7 @@ pub(crate) fn session_stats_error_json(session_id: &str, error: &str) -> serde_j
 
 pub(crate) fn session_stats_json(
     session_id: &str,
-    stats: &zccache::protocol::SessionStats,
+    stats: &crate::protocol::SessionStats,
 ) -> serde_json::Value {
     let total = stats.hits + stats.misses;
     let hit_rate = if total > 0 {
@@ -311,7 +311,7 @@ pub(crate) fn session_stats_json(
 }
 
 pub(crate) fn phase_profile_summary_json(
-    p: &zccache::protocol::PhaseProfileSummary,
+    p: &crate::protocol::PhaseProfileSummary,
 ) -> serde_json::Value {
     serde_json::json!({
         "hit_count": p.hit_count,
@@ -357,12 +357,12 @@ pub(crate) async fn query_session_stats_json(
 pub(crate) async fn query_session_stats(
     endpoint: &str,
     session_id: &str,
-) -> Result<Option<zccache::protocol::SessionStats>, String> {
+) -> Result<Option<crate::protocol::SessionStats>, String> {
     let mut conn = connect(endpoint)
         .await
         .map_err(|err| format!("cannot connect to daemon at {endpoint}: {err}"))?;
 
-    conn.send(&zccache::protocol::Request::SessionStats {
+    conn.send(&crate::protocol::Request::SessionStats {
         session_id: session_id.to_string(),
     })
     .await
@@ -373,8 +373,8 @@ pub(crate) async fn query_session_stats(
         .await
         .map_err(|err| format!("broken daemon connection: {err}"))?;
     match recv_result {
-        Some(zccache::protocol::Response::SessionStatsResult { stats }) => Ok(stats),
-        Some(zccache::protocol::Response::Error { message }) => Err(message),
+        Some(crate::protocol::Response::SessionStatsResult { stats }) => Ok(stats),
+        Some(crate::protocol::Response::Error { message }) => Err(message),
         Some(other) => Err(format!("unexpected daemon response: {other:?}")),
         None => Err("lost connection to daemon (no response). Often a daemon-CLI protocol version mismatch — try `zccache stop`".to_string()),
     }

--- a/crates/zccache/src/cli/commands/status.rs
+++ b/crates/zccache/src/cli/commands/status.rs
@@ -18,7 +18,7 @@ pub(crate) async fn cmd_status(endpoint: &str, json: bool) -> ExitCode {
         }
     };
 
-    if let Err(e) = conn.send(&zccache::protocol::Request::Status).await {
+    if let Err(e) = conn.send(&crate::protocol::Request::Status).await {
         let message = format!("zccache: failed to send to daemon: {e}");
         if json {
             print_status_error_json(endpoint, &message);
@@ -40,7 +40,7 @@ pub(crate) async fn cmd_status(endpoint: &str, json: bool) -> ExitCode {
         }
     };
     match recv_result {
-        Some(zccache::protocol::Response::Status(s)) => {
+        Some(crate::protocol::Response::Status(s)) => {
             if json {
                 print_status_ok_json(endpoint, &s);
                 return ExitCode::SUCCESS;
@@ -59,7 +59,7 @@ pub(crate) async fn cmd_status(endpoint: &str, json: bool) -> ExitCode {
                 } else {
                     &s.version
                 },
-                zccache::protocol::PROTOCOL_VERSION,
+                crate::protocol::PROTOCOL_VERSION,
                 endpoint,
                 format_uptime(s.uptime_secs)
             );
@@ -147,7 +147,7 @@ pub(crate) async fn cmd_status(endpoint: &str, json: bool) -> ExitCode {
     }
 }
 
-fn print_status_ok_json(endpoint: &str, s: &zccache::protocol::DaemonStatus) {
+fn print_status_ok_json(endpoint: &str, s: &crate::protocol::DaemonStatus) {
     let total = s.cache_hits + s.cache_misses;
     let hit_rate = if total > 0 {
         Some(s.cache_hits as f64 / total as f64)
@@ -163,7 +163,7 @@ fn print_status_ok_json(endpoint: &str, s: &zccache::protocol::DaemonStatus) {
     let value = serde_json::json!({
         "status": "ok",
         "endpoint": endpoint,
-        "protocol_version": zccache::protocol::PROTOCOL_VERSION,
+        "protocol_version": crate::protocol::PROTOCOL_VERSION,
         "hit_rate": hit_rate,
         "link_hit_rate": link_hit_rate,
         "daemon": s,

--- a/crates/zccache/src/cli/commands/symbols.rs
+++ b/crates/zccache/src/cli/commands/symbols.rs
@@ -6,7 +6,7 @@ use std::process::ExitCode;
 use super::super::symbols::{self, InstallOptions as SymbolsInstallOptions};
 
 pub(crate) fn cmd_symbols_symbolicate(dumps: Vec<PathBuf>) -> ExitCode {
-    let marker = match zccache::symbols::read_marker_from_current_exe() {
+    let marker = match crate::symbols::read_marker_from_current_exe() {
         Some(m) => m,
         None => {
             eprintln!(
@@ -23,9 +23,9 @@ pub(crate) fn cmd_symbols_symbolicate(dumps: Vec<PathBuf>) -> ExitCode {
     // sidecar — true dedup. The existing `symbols::install` is the
     // battle-tested fetch path; we just point its `--prefix` at our
     // shared dir.
-    let cache_root: PathBuf = zccache::core::config::default_cache_dir().into_path_buf();
+    let cache_root: PathBuf = crate::core::config::default_cache_dir().into_path_buf();
     let symbols_dir =
-        zccache::symbols::symbols_dir_for(&cache_root, &marker.version, &marker.triple);
+        crate::symbols::symbols_dir_for(&cache_root, &marker.version, &marker.triple);
     let symbols_dir_path: PathBuf = symbols_dir.into_path_buf();
 
     let opts = SymbolsInstallOptions {
@@ -43,7 +43,7 @@ pub(crate) fn cmd_symbols_symbolicate(dumps: Vec<PathBuf>) -> ExitCode {
         }
     };
 
-    if let Err(e) = zccache::symbols::mark_ready(&symbols_dir_path) {
+    if let Err(e) = crate::symbols::mark_ready(&symbols_dir_path) {
         eprintln!(
             "zccache symbolicate: warning — failed to write .ready sentinel in {}: {e}",
             symbols_dir_path.display()
@@ -71,7 +71,7 @@ pub(crate) fn cmd_symbols_symbolicate(dumps: Vec<PathBuf>) -> ExitCode {
 
     let mut had_error = false;
     for dump in dumps {
-        match zccache::symbols::write_symref_sidecar(&dump, &symbols_dir_path) {
+        match crate::symbols::write_symref_sidecar(&dump, &symbols_dir_path) {
             Ok(sidecar) => println!("  wrote {}", sidecar.display()),
             Err(e) => {
                 eprintln!(

--- a/crates/zccache/src/cli/commands/tests/analyze.rs
+++ b/crates/zccache/src/cli/commands/tests/analyze.rs
@@ -227,7 +227,7 @@ fn analyze_journal_missing_file_has_structured_error_hint() {
 fn analyze_journal_rejects_session_stats_json() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let path = tmp.path().join("last-session-stats.json");
-    let stats = zccache::protocol::SessionStats {
+    let stats = crate::protocol::SessionStats {
         duration_ms: 1000,
         compilations: 10,
         hits: 7,

--- a/crates/zccache/src/cli/commands/tests/args_parsing.rs
+++ b/crates/zccache/src/cli/commands/tests/args_parsing.rs
@@ -83,7 +83,7 @@ fn rust_plan_cli_parses_validate_restore_save() {
 
 #[test]
 fn rust_plan_session_stats_json_separates_compile_cache_stats() {
-    let stats = zccache::protocol::SessionStats {
+    let stats = crate::protocol::SessionStats {
         duration_ms: 1000,
         compilations: 10,
         hits: 7,

--- a/crates/zccache/src/cli/commands/tests/cache_ops.rs
+++ b/crates/zccache/src/cli/commands/tests/cache_ops.rs
@@ -16,11 +16,11 @@ fn warm_restores_rust_artifacts_to_correct_paths() {
     std::fs::create_dir_all(&artifact_dir).unwrap();
 
     // Create a fake artifact store with two Rust crates
-    let store = zccache::artifact::ArtifactStore::open(&index_path).unwrap();
+    let store = crate::artifact::ArtifactStore::open(&index_path).unwrap();
 
     // Artifact 1: libserde-abc123.rlib + libserde-abc123.rmeta + serde-abc123.d
     let key1 = "aaaaaaaabbbbbbbb";
-    let idx1 = zccache::artifact::ArtifactIndex::new(
+    let idx1 = crate::artifact::ArtifactIndex::new(
         vec![
             "libserde-abc123.rlib".to_string(),
             "libserde-abc123.rmeta".to_string(),
@@ -39,7 +39,7 @@ fn warm_restores_rust_artifacts_to_correct_paths() {
 
     // Artifact 2: libproc_macro2-def456.rlib
     let key2 = "ccccccccdddddddd";
-    let idx2 = zccache::artifact::ArtifactIndex::new(
+    let idx2 = crate::artifact::ArtifactIndex::new(
         vec!["libproc_macro2-def456.rlib".to_string()],
         vec![200],
         vec![],
@@ -51,7 +51,7 @@ fn warm_restores_rust_artifacts_to_correct_paths() {
 
     // Artifact 3: NOT Rust (C++ object file) — should be filtered out
     let key3 = "eeeeeeeeffffffff";
-    let idx3 = zccache::artifact::ArtifactIndex::new(
+    let idx3 = crate::artifact::ArtifactIndex::new(
         vec!["foo.o".to_string()],
         vec![300],
         vec![],
@@ -129,9 +129,9 @@ fn warm_skips_missing_payloads() {
 
     std::fs::create_dir_all(&artifact_dir).unwrap();
 
-    let store = zccache::artifact::ArtifactStore::open(&index_path).unwrap();
+    let store = crate::artifact::ArtifactStore::open(&index_path).unwrap();
     let key = "1111111122222222";
-    let idx = zccache::artifact::ArtifactIndex::new(
+    let idx = crate::artifact::ArtifactIndex::new(
         vec!["libfoo-xyz.rlib".to_string()],
         vec![100],
         vec![],

--- a/crates/zccache/src/cli/commands/tests/daemon.rs
+++ b/crates/zccache/src/cli/commands/tests/daemon.rs
@@ -19,12 +19,12 @@ use super::super::daemon::{ensure_daemon, wait_for_daemon_teardown};
 #[tokio::test]
 #[ignore] // Integration test — needs daemon binary. Run with `test --full`.
 async fn ensure_daemon_auto_recovers_on_comm_error() {
-    let endpoint = zccache::ipc::unique_test_endpoint();
+    let endpoint = crate::ipc::unique_test_endpoint();
 
     // Spawn a fake stale daemon: accepts one connection, drops it (CommError),
     // then shuts down so the endpoint is released for the real daemon.
     let ep = endpoint.clone();
-    let mut listener = zccache::ipc::IpcListener::bind(&ep).unwrap();
+    let mut listener = crate::ipc::IpcListener::bind(&ep).unwrap();
     let server = tokio::spawn(async move {
         // Accept the connection from check_daemon_version, drop it immediately
         let _ = listener.accept().await;

--- a/crates/zccache/src/cli/commands/tests/warm_lockfile.rs
+++ b/crates/zccache/src/cli/commands/tests/warm_lockfile.rs
@@ -15,13 +15,13 @@ fn make_test_store(dir: &Path) -> (PathBuf, PathBuf) {
     let index_path = cache_dir.join("index.bin");
     std::fs::create_dir_all(&artifact_dir).unwrap();
 
-    let store = zccache::artifact::ArtifactStore::open(&index_path).unwrap();
+    let store = crate::artifact::ArtifactStore::open(&index_path).unwrap();
 
     // serde (in a typical Cargo.lock)
     let k1 = "aaaa0001";
     store.insert(
         k1,
-        &zccache::artifact::ArtifactIndex::new(
+        &crate::artifact::ArtifactIndex::new(
             vec![
                 "libserde-abc123.rlib".into(),
                 "libserde-abc123.rmeta".into(),
@@ -41,7 +41,7 @@ fn make_test_store(dir: &Path) -> (PathBuf, PathBuf) {
     let k2 = "aaaa0002";
     store.insert(
         k2,
-        &zccache::artifact::ArtifactIndex::new(
+        &crate::artifact::ArtifactIndex::new(
             vec!["libproc_macro2-def456.rlib".into()],
             vec![200],
             vec![],
@@ -55,7 +55,7 @@ fn make_test_store(dir: &Path) -> (PathBuf, PathBuf) {
     let k3 = "aaaa0003";
     store.insert(
         k3,
-        &zccache::artifact::ArtifactIndex::new(
+        &crate::artifact::ArtifactIndex::new(
             vec!["libtokio-ghi789.rlib".into()],
             vec![300],
             vec![],
@@ -69,7 +69,7 @@ fn make_test_store(dir: &Path) -> (PathBuf, PathBuf) {
     let k4 = "aaaa0004";
     store.insert(
         k4,
-        &zccache::artifact::ArtifactIndex::new(vec!["foo.o".into()], vec![50], vec![], vec![], 0),
+        &crate::artifact::ArtifactIndex::new(vec!["foo.o".into()], vec![50], vec![], vec![], 0),
     );
     std::fs::write(artifact_dir.join(format!("{k4}_0")), b"cpp-object").unwrap();
 
@@ -261,13 +261,13 @@ fn adversarial_version_bump_old_artifact_in_cache() {
     let index_path = cache_dir.join("index.bin");
     std::fs::create_dir_all(&artifact_dir).unwrap();
 
-    let store = zccache::artifact::ArtifactStore::open(&index_path).unwrap();
+    let store = crate::artifact::ArtifactStore::open(&index_path).unwrap();
 
     // Old version's artifact (different hash suffix)
     let k_old = "bbbb0001";
     store.insert(
         k_old,
-        &zccache::artifact::ArtifactIndex::new(
+        &crate::artifact::ArtifactIndex::new(
             vec!["libserde-old111.rlib".into()],
             vec![100],
             vec![],
@@ -281,7 +281,7 @@ fn adversarial_version_bump_old_artifact_in_cache() {
     let k_new = "bbbb0002";
     store.insert(
         k_new,
-        &zccache::artifact::ArtifactIndex::new(
+        &crate::artifact::ArtifactIndex::new(
             vec!["libserde-new222.rlib".into()],
             vec![100],
             vec![],
@@ -327,11 +327,11 @@ fn adversarial_corrupted_cache_file() {
     let index_path = cache_dir.join("index.bin");
     std::fs::create_dir_all(&artifact_dir).unwrap();
 
-    let store = zccache::artifact::ArtifactStore::open(&index_path).unwrap();
+    let store = crate::artifact::ArtifactStore::open(&index_path).unwrap();
     let key = "cccc0001";
     store.insert(
         key,
-        &zccache::artifact::ArtifactIndex::new(
+        &crate::artifact::ArtifactIndex::new(
             vec!["libserde-abc123.rlib".into()],
             vec![1000], // Claims 1000 bytes
             vec![],

--- a/crates/zccache/src/cli/commands/util.rs
+++ b/crates/zccache/src/cli/commands/util.rs
@@ -4,7 +4,7 @@
 
 use std::path::Path;
 use std::process::ExitCode;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 pub(crate) fn absolute_path(path: &str) -> NormalizedPath {
     let path = Path::new(path);
@@ -53,7 +53,7 @@ pub(crate) fn resolve_endpoint(explicit: Option<&str>) -> String {
     if let Ok(ep) = std::env::var("ZCCACHE_ENDPOINT") {
         return ep;
     }
-    zccache::ipc::default_endpoint()
+    crate::ipc::default_endpoint()
 }
 
 /// Platform-correct connect (returns different types on Unix vs Windows).
@@ -69,18 +69,18 @@ pub(crate) fn resolve_endpoint(explicit: Option<&str>) -> String {
 #[cfg(unix)]
 pub(crate) async fn connect(
     endpoint: &str,
-) -> Result<zccache::ipc::IpcConnection, zccache::ipc::IpcError> {
-    let mut conn = zccache::ipc::connect(endpoint).await?;
-    conn.set_recv_timeout(zccache::ipc::DEFAULT_CLIENT_RECV_TIMEOUT);
+) -> Result<crate::ipc::IpcConnection, crate::ipc::IpcError> {
+    let mut conn = crate::ipc::connect(endpoint).await?;
+    conn.set_recv_timeout(crate::ipc::DEFAULT_CLIENT_RECV_TIMEOUT);
     Ok(conn)
 }
 
 #[cfg(windows)]
 pub(crate) async fn connect(
     endpoint: &str,
-) -> Result<zccache::ipc::IpcClientConnection, zccache::ipc::IpcError> {
-    let mut conn = zccache::ipc::connect(endpoint).await?;
-    conn.set_recv_timeout(zccache::ipc::DEFAULT_CLIENT_RECV_TIMEOUT);
+) -> Result<crate::ipc::IpcClientConnection, crate::ipc::IpcError> {
+    let mut conn = crate::ipc::connect(endpoint).await?;
+    conn.set_recv_timeout(crate::ipc::DEFAULT_CLIENT_RECV_TIMEOUT);
     Ok(conn)
 }
 

--- a/crates/zccache/src/cli/commands/wrap.rs
+++ b/crates/zccache/src/cli/commands/wrap.rs
@@ -5,8 +5,8 @@
 
 use std::path::Path;
 use std::process::ExitCode;
-use zccache::compiler::strict_paths::StrictPathsMode;
-use zccache::core::NormalizedPath;
+use crate::compiler::strict_paths::StrictPathsMode;
+use crate::core::NormalizedPath;
 
 use super::daemon::{ensure_daemon, which_on_path};
 use super::util::{connect, exit_code_from_i32, resolve_endpoint, run_async, slurp_stdin_if_piped};
@@ -39,7 +39,7 @@ fn run_passthrough(args: &[String]) -> ExitCode {
 /// preserving their mtime and avoiding unnecessary downstream rebuilds.
 /// After formatting, the new content hash of each file is stored in the cache.
 fn run_rustfmt_cached(rustfmt_path: &Path, args: &[String], cwd: &Path) -> ExitCode {
-    use zccache::compiler::parse_rustfmt::{find_rustfmt_config, parse_rustfmt_invocation};
+    use crate::compiler::parse_rustfmt::{find_rustfmt_config, parse_rustfmt_invocation};
 
     let parsed = match parse_rustfmt_invocation(args) {
         Some(p) => p,
@@ -52,11 +52,11 @@ fn run_rustfmt_cached(rustfmt_path: &Path, args: &[String], cwd: &Path) -> ExitC
     // Build format context: rustfmt binary identity + config + flags.
     // Changes to any of these invalidate the entire format cache scope.
     let context_hash = {
-        let mut hasher = zccache::hash::StreamHasher::new();
+        let mut hasher = crate::hash::StreamHasher::new();
         hasher.update(b"zccache-fmt-v1");
 
         // Hash rustfmt binary content for version identity
-        if let Ok(bin_hash) = zccache::hash::hash_file(rustfmt_path) {
+        if let Ok(bin_hash) = crate::hash::hash_file(rustfmt_path) {
             hasher.update(bin_hash.as_bytes());
         } else {
             hasher.update(b"unknown-binary");
@@ -68,7 +68,7 @@ fn run_rustfmt_cached(rustfmt_path: &Path, args: &[String], cwd: &Path) -> ExitC
             .clone()
             .or_else(|| find_rustfmt_config(cwd));
         if let Some(ref cfg) = config_path {
-            if let Ok(cfg_hash) = zccache::hash::hash_file(cfg) {
+            if let Ok(cfg_hash) = crate::hash::hash_file(cfg) {
                 hasher.update(cfg_hash.as_bytes());
             }
         }
@@ -83,7 +83,7 @@ fn run_rustfmt_cached(rustfmt_path: &Path, args: &[String], cwd: &Path) -> ExitC
     };
 
     // Format cache directory: {cache_dir}/fmt/{context_hash}/
-    let cache_dir = zccache::core::config::default_cache_dir()
+    let cache_dir = crate::core::config::default_cache_dir()
         .join("fmt")
         .join(&context_hash);
 
@@ -93,7 +93,7 @@ fn run_rustfmt_cached(rustfmt_path: &Path, args: &[String], cwd: &Path) -> ExitC
     // Resolve source files to absolute paths and check cache (parallel)
     use rayon::prelude::*;
 
-    let results: Vec<(NormalizedPath, bool, Option<zccache::hash::ContentHash>)> = parsed
+    let results: Vec<(NormalizedPath, bool, Option<crate::hash::ContentHash>)> = parsed
         .source_files
         .par_iter()
         .map(|src| {
@@ -102,7 +102,7 @@ fn run_rustfmt_cached(rustfmt_path: &Path, args: &[String], cwd: &Path) -> ExitC
             } else {
                 cwd.join(src).into()
             };
-            let (is_hit, hash) = match zccache::hash::hash_file(&abs) {
+            let (is_hit, hash) = match crate::hash::hash_file(&abs) {
                 Ok(content_hash) => {
                     let marker = cache_dir.join(content_hash.to_hex());
                     (marker.exists(), Some(content_hash))
@@ -114,7 +114,7 @@ fn run_rustfmt_cached(rustfmt_path: &Path, args: &[String], cwd: &Path) -> ExitC
         .collect();
 
     let mut miss_files: Vec<NormalizedPath> = Vec::new();
-    let mut all_files: Vec<(NormalizedPath, bool, Option<zccache::hash::ContentHash>)> = Vec::new();
+    let mut all_files: Vec<(NormalizedPath, bool, Option<crate::hash::ContentHash>)> = Vec::new();
     for (abs, is_hit, hash) in results {
         if !is_hit {
             miss_files.push(abs.clone());
@@ -163,7 +163,7 @@ fn run_rustfmt_cached(rustfmt_path: &Path, args: &[String], cwd: &Path) -> ExitC
             let new_hash = if parsed.check_mode {
                 *cached_hash
             } else {
-                zccache::hash::hash_file(abs).ok()
+                crate::hash::hash_file(abs).ok()
             };
             if let Some(h) = new_hash {
                 let marker = cache_dir.join(h.to_hex());
@@ -180,7 +180,7 @@ fn run_rustfmt_on_files(
     rustfmt_path: &Path,
     original_args: &[String],
     files: &[NormalizedPath],
-    parsed: &zccache::compiler::parse_rustfmt::ParsedRustfmt,
+    parsed: &crate::compiler::parse_rustfmt::ParsedRustfmt,
 ) -> Result<i32, std::io::Error> {
     // Reconstruct args: flags + the miss files (not the original file list)
     let mut cmd = std::process::Command::new(rustfmt_path);
@@ -321,13 +321,13 @@ pub(crate) fn run_wrap(
     let _ = std::env::set_current_dir(std::env::temp_dir());
 
     // Check if this is a rustfmt invocation — handle via format cache path
-    if zccache::compiler::detect_family(&args[0]).is_formatter() {
+    if crate::compiler::detect_family(&args[0]).is_formatter() {
         return run_rustfmt_cached(&wrapped_tool, &tool_args, &cwd);
     }
 
     // Check if this is an archiver or linker tool (including gcc -shared)
-    if zccache::compiler::parse_archiver::is_archiver(&args[0])
-        || zccache::compiler::parse_linker::is_link_invocation(&args[0], &tool_args)
+    if crate::compiler::parse_archiver::is_archiver(&args[0])
+        || crate::compiler::parse_linker::is_link_invocation(&args[0], &tool_args)
     {
         return run_async(cmd_link_ephemeral(
             &endpoint,
@@ -338,7 +338,7 @@ pub(crate) fn run_wrap(
         ));
     }
 
-    if let Err(err) = zccache::compiler::strict_paths::validate_args(&tool_args, strict_paths_mode) {
+    if let Err(err) = crate::compiler::strict_paths::validate_args(&tool_args, strict_paths_mode) {
         eprintln!("{}", err.diagnostic(&args[0], &tool_args));
         return ExitCode::FAILURE;
     }
@@ -375,7 +375,7 @@ pub(crate) fn run_wrap(
 /// Resolve a compiler name/path to an absolute path.
 /// Normalizes MSYS paths on Windows, then searches PATH if not already absolute.
 fn resolve_compiler_path(compiler: &str) -> NormalizedPath {
-    let normalized = zccache::core::path::normalize_msys_path(compiler);
+    let normalized = crate::core::path::normalize_msys_path(compiler);
     let path = Path::new(&normalized);
 
     // Already absolute — return as-is.
@@ -408,7 +408,7 @@ async fn cmd_compile(
     };
 
     if let Err(e) = conn
-        .send(&zccache::protocol::Request::Compile {
+        .send(&crate::protocol::Request::Compile {
             session_id: session_id.to_string(),
             args,
             cwd,
@@ -430,7 +430,7 @@ async fn cmd_compile(
         }
     };
     match recv_result {
-        Some(zccache::protocol::Response::CompileResult {
+        Some(crate::protocol::Response::CompileResult {
             exit_code,
             stdout,
             stderr,
@@ -442,7 +442,7 @@ async fn cmd_compile(
             let _ = std::io::stderr().write_all(&stderr);
             exit_code_from_i32(exit_code)
         }
-        Some(zccache::protocol::Response::Error { message }) => {
+        Some(crate::protocol::Response::Error { message }) => {
             eprintln!("zccache[err][E]: daemon error: {message}");
             ExitCode::FAILURE
         }
@@ -481,7 +481,7 @@ async fn cmd_compile_ephemeral(
 
     let stdin_bytes = slurp_stdin_if_piped();
     if let Err(e) = conn
-        .send(&zccache::protocol::Request::CompileEphemeral {
+        .send(&crate::protocol::Request::CompileEphemeral {
             client_pid: std::process::id(),
             working_dir: cwd.clone(),
             compiler: compiler.into(),
@@ -504,7 +504,7 @@ async fn cmd_compile_ephemeral(
         }
     };
     match recv_result {
-        Some(zccache::protocol::Response::CompileResult {
+        Some(crate::protocol::Response::CompileResult {
             exit_code,
             stdout,
             stderr,
@@ -515,7 +515,7 @@ async fn cmd_compile_ephemeral(
             let _ = std::io::stderr().write_all(&stderr);
             exit_code_from_i32(exit_code)
         }
-        Some(zccache::protocol::Response::Error { message }) => {
+        Some(crate::protocol::Response::Error { message }) => {
             eprintln!("zccache[err][E]: daemon error: {message}");
             ExitCode::FAILURE
         }
@@ -551,7 +551,7 @@ async fn cmd_link_ephemeral(
     };
 
     if let Err(e) = conn
-        .send(&zccache::protocol::Request::LinkEphemeral {
+        .send(&crate::protocol::Request::LinkEphemeral {
             client_pid: std::process::id(),
             tool: tool.into(),
             args,
@@ -572,7 +572,7 @@ async fn cmd_link_ephemeral(
         }
     };
     match recv_result {
-        Some(zccache::protocol::Response::LinkResult {
+        Some(crate::protocol::Response::LinkResult {
             exit_code,
             stdout,
             stderr,
@@ -587,7 +587,7 @@ async fn cmd_link_ephemeral(
             }
             exit_code_from_i32(exit_code)
         }
-        Some(zccache::protocol::Response::Error { message }) => {
+        Some(crate::protocol::Response::Error { message }) => {
             eprintln!("zccache[err][E]: daemon error: {message}");
             ExitCode::FAILURE
         }

--- a/crates/zccache/src/cli/defender.rs
+++ b/crates/zccache/src/cli/defender.rs
@@ -1,12 +1,12 @@
 //! `zccache defender-exclusions` CLI commands (issue #273).
 //!
-//! Thin shell over [`zccache::core::defender`]. The path-set computation,
+//! Thin shell over [`crate::core::defender`]. The path-set computation,
 //! token elevation check, and PowerShell subprocess plumbing all live in
 //! `zccache-core` so the daemon's first-run banner can reuse them.
 
 use std::path::PathBuf;
 use std::process::ExitCode;
-use zccache::core::defender::{
+use crate::core::defender::{
     add_exclusions, compute_exclusion_paths, is_elevated, query_excluded, remove_exclusions,
     ExclusionStatus,
 };
@@ -18,7 +18,7 @@ elevation. Re-run from an elevated PowerShell or Administrator cmd.";
 /// Cache root used by every subcommand. Centralized so a future
 /// `zccache cache-root` (issue #275) only changes one site.
 fn resolved_cache_root() -> PathBuf {
-    zccache::core::config::default_cache_dir().into_path_buf()
+    crate::core::config::default_cache_dir().into_path_buf()
 }
 
 /// On non-Windows, every subcommand prints the same one-liner and exits

--- a/crates/zccache/src/cli/mod.rs
+++ b/crates/zccache/src/cli/mod.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::missing_errors_doc)]
 
 use std::path::Path;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 pub mod commands;
 pub mod defender;
@@ -17,7 +17,7 @@ pub use runtime::{
     run_async, runtime_binaries_dir, spawn_daemon,
 };
 
-pub use zccache::download_client::{
+pub use crate::download_client::{
     ArchiveFormat, DownloadSource, FetchRequest, FetchResult, FetchState, FetchStateKind,
     FetchStatus, WaitMode,
 };
@@ -80,8 +80,8 @@ pub fn run_ino_convert_cached(
     output: &Path,
     options: &InoConvertOptions,
 ) -> Result<InoConvertResult, Box<dyn std::error::Error>> {
-    let input_hash = zccache::hash::hash_file(input)?;
-    let mut hasher = zccache::hash::StreamHasher::new();
+    let input_hash = crate::hash::hash_file(input)?;
+    let mut hasher = crate::hash::StreamHasher::new();
     hasher.update(b"zccache-ino-convert-v1");
     hasher.update(input_hash.as_bytes());
     hasher.update(input.as_os_str().to_string_lossy().as_bytes());
@@ -90,7 +90,7 @@ pub fn run_ino_convert_cached(
     } else {
         b"no-arduino-h"
     });
-    if let Some(libclang_hash) = zccache::compiler::arduino::libclang_hash() {
+    if let Some(libclang_hash) = crate::compiler::arduino::libclang_hash() {
         hasher.update(libclang_hash.as_bytes());
     }
     for arg in &options.clang_args {
@@ -99,7 +99,7 @@ pub fn run_ino_convert_cached(
     }
     let cache_key = hasher.finalize().to_hex();
 
-    let cache_dir = zccache::core::config::default_cache_dir().join("ino");
+    let cache_dir = crate::core::config::default_cache_dir().join("ino");
     std::fs::create_dir_all(&cache_dir)?;
     let cached_cpp = cache_dir.join(format!("{cache_key}.ino.cpp"));
 
@@ -107,9 +107,9 @@ pub fn run_ino_convert_cached(
         return restore_cached_ino_output(&cached_cpp, output);
     }
 
-    let generated = zccache::compiler::arduino::generate_ino_cpp(
+    let generated = crate::compiler::arduino::generate_ino_cpp(
         input,
-        &zccache::compiler::arduino::ArduinoConversionOptions {
+        &crate::compiler::arduino::ArduinoConversionOptions {
             clang_args: options.clang_args.clone(),
             inject_arduino_include: options.inject_arduino_include,
         },
@@ -127,8 +127,8 @@ fn restore_cached_ino_output(
     output: &Path,
 ) -> Result<InoConvertResult, Box<dyn std::error::Error>> {
     if output.exists() {
-        let output_hash = zccache::hash::hash_file(output)?;
-        let cached_hash = zccache::hash::hash_file(cached_cpp)?;
+        let output_hash = crate::hash::hash_file(output)?;
+        let cached_hash = crate::hash::hash_file(cached_cpp)?;
         if output_hash == cached_hash {
             return Ok(InoConvertResult {
                 cache_hit: true,
@@ -166,7 +166,7 @@ fn resolve_endpoint(explicit: Option<&str>) -> String {
     if let Ok(ep) = std::env::var("ZCCACHE_ENDPOINT") {
         return ep;
     }
-    zccache::ipc::default_endpoint()
+    crate::ipc::default_endpoint()
 }
 
 pub fn infer_download_archive_path(
@@ -174,7 +174,7 @@ pub fn infer_download_archive_path(
     archive_format: ArchiveFormat,
 ) -> std::path::PathBuf {
     let file_name = infer_download_file_name(source, archive_format);
-    zccache::core::config::default_cache_dir()
+    crate::core::config::default_cache_dir()
         .join("downloads")
         .join("artifacts")
         .join(file_name)
@@ -204,7 +204,7 @@ pub fn client_download(
     params: DownloadParams,
 ) -> Result<FetchResult, String> {
     let request = build_download_request(params);
-    let client = zccache::download_client::DownloadClient::new(endpoint.map(ToOwned::to_owned));
+    let client = crate::download_client::DownloadClient::new(endpoint.map(ToOwned::to_owned));
     client.fetch(request)
 }
 
@@ -213,7 +213,7 @@ pub fn client_download_exists(
     params: DownloadParams,
 ) -> Result<FetchState, String> {
     let request = build_download_request(params);
-    let client = zccache::download_client::DownloadClient::new(endpoint.map(ToOwned::to_owned));
+    let client = crate::download_client::DownloadClient::new(endpoint.map(ToOwned::to_owned));
     client.exists(&request)
 }
 
@@ -337,12 +337,12 @@ pub fn client_stop(endpoint: Option<&str>) -> Result<bool, String> {
             Ok(c) => c,
             Err(_) => return Ok(false),
         };
-        conn.send(&zccache::protocol::Request::Shutdown)
+        conn.send(&crate::protocol::Request::Shutdown)
             .await
             .map_err(|e| format!("failed to send to daemon: {e}"))?;
-        match conn.recv::<zccache::protocol::Response>().await {
-            Ok(Some(zccache::protocol::Response::ShuttingDown)) => Ok(true),
-            Ok(Some(zccache::protocol::Response::Error { message })) => Err(message),
+        match conn.recv::<crate::protocol::Response>().await {
+            Ok(Some(crate::protocol::Response::ShuttingDown)) => Ok(true),
+            Ok(Some(crate::protocol::Response::Error { message })) => Err(message),
             Ok(None) => Err("lost connection to daemon (no response received)".to_string()),
             Ok(Some(other)) => Err(format!("unexpected response from daemon: {other:?}")),
             Err(e) => Err(format!("broken connection to daemon: {e}")),
@@ -350,18 +350,18 @@ pub fn client_stop(endpoint: Option<&str>) -> Result<bool, String> {
     })
 }
 
-pub fn client_status(endpoint: Option<&str>) -> Result<zccache::protocol::DaemonStatus, String> {
+pub fn client_status(endpoint: Option<&str>) -> Result<crate::protocol::DaemonStatus, String> {
     let endpoint = resolve_endpoint(endpoint);
     run_async(async move {
         let mut conn = connect_client(&endpoint)
             .await
             .map_err(|e| format!("daemon not running at {endpoint}: {e}"))?;
-        conn.send(&zccache::protocol::Request::Status)
+        conn.send(&crate::protocol::Request::Status)
             .await
             .map_err(|e| format!("failed to send to daemon: {e}"))?;
-        match conn.recv::<zccache::protocol::Response>().await {
-            Ok(Some(zccache::protocol::Response::Status(status))) => Ok(status),
-            Ok(Some(zccache::protocol::Response::Error { message })) => Err(message),
+        match conn.recv::<crate::protocol::Response>().await {
+            Ok(Some(crate::protocol::Response::Status(status))) => Ok(status),
+            Ok(Some(crate::protocol::Response::Error { message })) => Err(message),
             Ok(None) => Err("lost connection to daemon (no response received)".to_string()),
             Ok(Some(other)) => Err(format!("unexpected response from daemon: {other:?}")),
             Err(e) => Err(format!("broken connection to daemon: {e}")),
@@ -386,7 +386,7 @@ pub fn client_session_start(
         let mut conn = connect_client(&endpoint)
             .await
             .map_err(|e| format!("cannot connect to daemon at {endpoint}: {e}"))?;
-        conn.send(&zccache::protocol::Request::SessionStart {
+        conn.send(&crate::protocol::Request::SessionStart {
             client_pid: std::process::id(),
             working_dir: cwd.into(),
             log_file,
@@ -397,15 +397,15 @@ pub fn client_session_start(
         .await
         .map_err(|e| format!("failed to send to daemon: {e}"))?;
 
-        match conn.recv::<zccache::protocol::Response>().await {
-            Ok(Some(zccache::protocol::Response::SessionStarted {
+        match conn.recv::<crate::protocol::Response>().await {
+            Ok(Some(crate::protocol::Response::SessionStarted {
                 session_id,
                 journal_path,
             })) => Ok(SessionStartResponse {
                 session_id,
                 journal_path: journal_path.map(|p| p.display().to_string()),
             }),
-            Ok(Some(zccache::protocol::Response::Error { message })) => Err(message),
+            Ok(Some(crate::protocol::Response::Error { message })) => Err(message),
             Ok(None) => Err("lost connection to daemon (no response received)".to_string()),
             Ok(Some(other)) => Err(format!("unexpected response from daemon: {other:?}")),
             Err(e) => Err(format!("broken connection to daemon: {e}")),
@@ -425,7 +425,7 @@ pub fn client_session_start(
 pub fn client_session_end(
     endpoint: Option<&str>,
     session_id: &str,
-) -> Result<Option<zccache::protocol::SessionStats>, String> {
+) -> Result<Option<crate::protocol::SessionStats>, String> {
     let endpoint = resolve_endpoint(endpoint);
     session_end_idempotent(&endpoint, session_id).map_err(|e| e.to_string())
 }
@@ -450,10 +450,10 @@ pub fn client_session_end(
 /// died" connect-time failures onto a success no-op. Other request
 /// types keep their existing strict error semantics.
 #[must_use]
-pub fn is_daemon_unreachable_err(err: &zccache::ipc::IpcError) -> bool {
+pub fn is_daemon_unreachable_err(err: &crate::ipc::IpcError) -> bool {
     use std::io::ErrorKind;
     match err {
-        zccache::ipc::IpcError::Io(io) => matches!(
+        crate::ipc::IpcError::Io(io) => matches!(
             io.kind(),
             ErrorKind::NotFound | ErrorKind::ConnectionRefused | ErrorKind::BrokenPipe
         ),
@@ -495,7 +495,7 @@ pub fn is_daemon_unreachable_err(err: &zccache::ipc::IpcError) -> bool {
 pub fn session_end_idempotent(
     endpoint: &str,
     session_id: &str,
-) -> Result<Option<zccache::protocol::SessionStats>, zccache::ipc::IpcError> {
+) -> Result<Option<crate::protocol::SessionStats>, crate::ipc::IpcError> {
     let endpoint = endpoint.to_string();
     let session_id = session_id.to_string();
 
@@ -506,7 +506,7 @@ pub fn session_end_idempotent(
         .enable_all()
         .build()
         .map_err(|e| {
-            zccache::ipc::IpcError::Endpoint(format!("failed to create tokio runtime: {e}"))
+            crate::ipc::IpcError::Endpoint(format!("failed to create tokio runtime: {e}"))
         })?;
 
     runtime.block_on(async move {
@@ -523,18 +523,18 @@ pub fn session_end_idempotent(
             }
         };
 
-        conn.send(&zccache::protocol::Request::SessionEnd {
+        conn.send(&crate::protocol::Request::SessionEnd {
             session_id: session_id.clone(),
         })
         .await?;
 
-        match conn.recv::<zccache::protocol::Response>().await? {
-            Some(zccache::protocol::Response::SessionEnded { stats }) => Ok(stats),
-            Some(zccache::protocol::Response::Error { message }) => Err(
-                zccache::ipc::IpcError::Endpoint(format!("session-end failed: {message}")),
+        match conn.recv::<crate::protocol::Response>().await? {
+            Some(crate::protocol::Response::SessionEnded { stats }) => Ok(stats),
+            Some(crate::protocol::Response::Error { message }) => Err(
+                crate::ipc::IpcError::Endpoint(format!("session-end failed: {message}")),
             ),
-            None => Err(zccache::ipc::IpcError::ConnectionClosed),
-            Some(other) => Err(zccache::ipc::IpcError::Endpoint(format!(
+            None => Err(crate::ipc::IpcError::ConnectionClosed),
+            Some(other) => Err(crate::ipc::IpcError::Endpoint(format!(
                 "unexpected response from daemon: {other:?}"
             ))),
         }
@@ -544,22 +544,22 @@ pub fn session_end_idempotent(
 pub fn client_session_stats(
     endpoint: Option<&str>,
     session_id: &str,
-) -> Result<Option<zccache::protocol::SessionStats>, String> {
+) -> Result<Option<crate::protocol::SessionStats>, String> {
     let endpoint = resolve_endpoint(endpoint);
     let session_id = session_id.to_string();
     run_async(async move {
         let mut conn = connect_client(&endpoint)
             .await
             .map_err(|e| format!("cannot connect to daemon at {endpoint}: {e}"))?;
-        conn.send(&zccache::protocol::Request::SessionStats {
+        conn.send(&crate::protocol::Request::SessionStats {
             session_id: session_id.clone(),
         })
         .await
         .map_err(|e| format!("failed to send to daemon: {e}"))?;
 
-        match conn.recv::<zccache::protocol::Response>().await {
-            Ok(Some(zccache::protocol::Response::SessionStatsResult { stats })) => Ok(stats),
-            Ok(Some(zccache::protocol::Response::Error { message })) => Err(message),
+        match conn.recv::<crate::protocol::Response>().await {
+            Ok(Some(crate::protocol::Response::SessionStatsResult { stats })) => Ok(stats),
+            Ok(Some(crate::protocol::Response::Error { message })) => Err(message),
             Ok(None) => Err("lost connection to daemon (no response received)".to_string()),
             Ok(Some(other)) => Err(format!("unexpected response from daemon: {other:?}")),
             Err(e) => Err(format!("broken connection to daemon: {e}")),
@@ -597,7 +597,7 @@ pub fn fingerprint_check(
             .await
             .map_err(|e| format!("cannot connect to daemon at {endpoint}: {e}"))?;
 
-        conn.send(&zccache::protocol::Request::FingerprintCheck {
+        conn.send(&crate::protocol::Request::FingerprintCheck {
             cache_file: cache_file.into(),
             cache_type,
             root: root.into(),
@@ -608,8 +608,8 @@ pub fn fingerprint_check(
         .await
         .map_err(|e| format!("failed to send to daemon: {e}"))?;
 
-        match conn.recv::<zccache::protocol::Response>().await {
-            Ok(Some(zccache::protocol::Response::FingerprintCheckResult {
+        match conn.recv::<crate::protocol::Response>().await {
+            Ok(Some(crate::protocol::Response::FingerprintCheckResult {
                 decision,
                 reason,
                 changed_files,
@@ -618,7 +618,7 @@ pub fn fingerprint_check(
                 reason,
                 changed_files,
             }),
-            Ok(Some(zccache::protocol::Response::Error { message })) => Err(message),
+            Ok(Some(crate::protocol::Response::Error { message })) => Err(message),
             Ok(None) => Err("lost connection to daemon (no response received)".to_string()),
             Ok(Some(other)) => Err(format!("unexpected response from daemon: {other:?}")),
             Err(e) => Err(format!("broken connection to daemon: {e}")),
@@ -647,20 +647,20 @@ fn fingerprint_mark(
             .await
             .map_err(|e| format!("cannot connect to daemon at {endpoint}: {e}"))?;
         let request = if success {
-            zccache::protocol::Request::FingerprintMarkSuccess {
+            crate::protocol::Request::FingerprintMarkSuccess {
                 cache_file: cache_file.into(),
             }
         } else {
-            zccache::protocol::Request::FingerprintMarkFailure {
+            crate::protocol::Request::FingerprintMarkFailure {
                 cache_file: cache_file.into(),
             }
         };
         conn.send(&request)
             .await
             .map_err(|e| format!("failed to send to daemon: {e}"))?;
-        match conn.recv::<zccache::protocol::Response>().await {
-            Ok(Some(zccache::protocol::Response::FingerprintAck)) => Ok(()),
-            Ok(Some(zccache::protocol::Response::Error { message })) => Err(message),
+        match conn.recv::<crate::protocol::Response>().await {
+            Ok(Some(crate::protocol::Response::FingerprintAck)) => Ok(()),
+            Ok(Some(crate::protocol::Response::Error { message })) => Err(message),
             Ok(None) => Err("lost connection to daemon (no response received)".to_string()),
             Ok(Some(other)) => Err(format!("unexpected response from daemon: {other:?}")),
             Err(e) => Err(format!("broken connection to daemon: {e}")),
@@ -676,14 +676,14 @@ pub fn fingerprint_invalidate(endpoint: Option<&str>, cache_file: &Path) -> Resu
         let mut conn = connect_client(&endpoint)
             .await
             .map_err(|e| format!("cannot connect to daemon at {endpoint}: {e}"))?;
-        conn.send(&zccache::protocol::Request::FingerprintInvalidate {
+        conn.send(&crate::protocol::Request::FingerprintInvalidate {
             cache_file: cache_file.into(),
         })
         .await
         .map_err(|e| format!("failed to send to daemon: {e}"))?;
-        match conn.recv::<zccache::protocol::Response>().await {
-            Ok(Some(zccache::protocol::Response::FingerprintAck)) => Ok(()),
-            Ok(Some(zccache::protocol::Response::Error { message })) => Err(message),
+        match conn.recv::<crate::protocol::Response>().await {
+            Ok(Some(crate::protocol::Response::FingerprintAck)) => Ok(()),
+            Ok(Some(crate::protocol::Response::Error { message })) => Err(message),
             Ok(None) => Err("lost connection to daemon (no response received)".to_string()),
             Ok(Some(other)) => Err(format!("unexpected response from daemon: {other:?}")),
             Err(e) => Err(format!("broken connection to daemon: {e}")),
@@ -831,7 +831,7 @@ mod tests {
     fn session_end_idempotent_swallows_vanished_daemon() {
         // Construct an endpoint that is guaranteed to have no listener —
         // a unique pipe / socket name with no server bound to it.
-        let endpoint = zccache::ipc::unique_test_endpoint();
+        let endpoint = crate::ipc::unique_test_endpoint();
         let session_id = "00000000-0000-0000-0000-000000000000";
 
         let result = session_end_idempotent(&endpoint, session_id);
@@ -852,7 +852,7 @@ mod tests {
     /// error".
     #[test]
     fn session_end_idempotent_treats_timeout_as_real_error() {
-        let err = zccache::ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::TimedOut));
+        let err = crate::ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::TimedOut));
         assert!(
             !is_daemon_unreachable_err(&err),
             "TimedOut must NOT be classified as daemon-unreachable; session_end_idempotent \
@@ -864,9 +864,9 @@ mod tests {
     /// connection mid-response) must NOT be classified as unreachable.
     #[test]
     fn session_end_idempotent_treats_protocol_errors_as_real() {
-        let err = zccache::ipc::IpcError::ConnectionClosed;
+        let err = crate::ipc::IpcError::ConnectionClosed;
         assert!(!is_daemon_unreachable_err(&err));
-        let err = zccache::ipc::IpcError::Endpoint("bogus".into());
+        let err = crate::ipc::IpcError::Endpoint("bogus".into());
         assert!(!is_daemon_unreachable_err(&err));
     }
 
@@ -878,20 +878,20 @@ mod tests {
     /// pipe / socket is missing or has no listener.
     #[test]
     fn is_daemon_unreachable_recognizes_not_found() {
-        let err = zccache::ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::NotFound));
+        let err = crate::ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::NotFound));
         assert!(is_daemon_unreachable_err(&err));
     }
 
     #[test]
     fn is_daemon_unreachable_recognizes_connection_refused() {
         let err =
-            zccache::ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::ConnectionRefused));
+            crate::ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::ConnectionRefused));
         assert!(is_daemon_unreachable_err(&err));
     }
 
     #[test]
     fn is_daemon_unreachable_recognizes_broken_pipe() {
-        let err = zccache::ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::BrokenPipe));
+        let err = crate::ipc::IpcError::Io(std::io::Error::from(std::io::ErrorKind::BrokenPipe));
         assert!(is_daemon_unreachable_err(&err));
     }
 
@@ -903,7 +903,7 @@ mod tests {
     /// would be silently swallowed and the user would never see it.
     #[test]
     fn is_daemon_unreachable_timeout_is_not_unreachable() {
-        let err = zccache::ipc::IpcError::Timeout(std::time::Duration::from_secs(5));
+        let err = crate::ipc::IpcError::Timeout(std::time::Duration::from_secs(5));
         assert!(
             !is_daemon_unreachable_err(&err),
             "Timeout must propagate as a real fault, not be swallowed as daemon-unreachable"
@@ -917,12 +917,12 @@ mod tests {
     #[test]
     fn is_daemon_unreachable_recognizes_raw_enoent() {
         // ENOENT == 2 on every Unix; on Windows ERROR_FILE_NOT_FOUND == 2 too.
-        let err = zccache::ipc::IpcError::Io(std::io::Error::from_raw_os_error(2));
+        let err = crate::ipc::IpcError::Io(std::io::Error::from_raw_os_error(2));
         assert!(
             is_daemon_unreachable_err(&err),
             "errno 2 must map to a kind in the unreachable set; got kind={:?}",
             match &err {
-                zccache::ipc::IpcError::Io(io) => io.kind(),
+                crate::ipc::IpcError::Io(io) => io.kind(),
                 _ => unreachable!(),
             }
         );
@@ -937,7 +937,7 @@ mod tests {
     /// Test failed teardown even after every workspace test passed.
     #[test]
     fn client_session_end_swallows_vanished_daemon() {
-        let endpoint = zccache::ipc::unique_test_endpoint();
+        let endpoint = crate::ipc::unique_test_endpoint();
         let session_id = "00000000-0000-0000-0000-000000000000";
 
         let result = client_session_end(Some(&endpoint), session_id);

--- a/crates/zccache/src/cli/runtime.rs
+++ b/crates/zccache/src/cli/runtime.rs
@@ -7,7 +7,7 @@
 //! threshold. Re-exported from `cli/mod.rs` so the public path is unchanged.
 
 use std::path::Path;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 pub fn run_async<T>(
     future: impl std::future::Future<Output = Result<T, String>>,
@@ -31,18 +31,18 @@ enum VersionCheck {
 #[cfg(unix)]
 pub async fn connect_client(
     endpoint: &str,
-) -> Result<zccache::ipc::IpcConnection, zccache::ipc::IpcError> {
-    let mut conn = zccache::ipc::connect(endpoint).await?;
-    conn.set_recv_timeout(zccache::ipc::DEFAULT_CLIENT_RECV_TIMEOUT);
+) -> Result<crate::ipc::IpcConnection, crate::ipc::IpcError> {
+    let mut conn = crate::ipc::connect(endpoint).await?;
+    conn.set_recv_timeout(crate::ipc::DEFAULT_CLIENT_RECV_TIMEOUT);
     Ok(conn)
 }
 
 #[cfg(windows)]
 pub async fn connect_client(
     endpoint: &str,
-) -> Result<zccache::ipc::IpcClientConnection, zccache::ipc::IpcError> {
-    let mut conn = zccache::ipc::connect(endpoint).await?;
-    conn.set_recv_timeout(zccache::ipc::DEFAULT_CLIENT_RECV_TIMEOUT);
+) -> Result<crate::ipc::IpcClientConnection, crate::ipc::IpcError> {
+    let mut conn = crate::ipc::connect(endpoint).await?;
+    conn.set_recv_timeout(crate::ipc::DEFAULT_CLIENT_RECV_TIMEOUT);
     Ok(conn)
 }
 
@@ -52,19 +52,19 @@ async fn check_daemon_version(endpoint: &str) -> VersionCheck {
         Err(_) => return VersionCheck::Unreachable,
     };
     if conn
-        .send(&zccache::protocol::Request::Status)
+        .send(&crate::protocol::Request::Status)
         .await
         .is_err()
     {
         return VersionCheck::CommError;
     }
-    match conn.recv::<zccache::protocol::Response>().await {
-        Ok(Some(zccache::protocol::Response::Status(s))) => {
-            if s.version == zccache::core::VERSION {
+    match conn.recv::<crate::protocol::Response>().await {
+        Ok(Some(crate::protocol::Response::Status(s))) => {
+            if s.version == crate::core::VERSION {
                 return VersionCheck::Ok;
             }
-            let client_ver = zccache::core::version::current();
-            match zccache::core::version::Version::parse(&s.version) {
+            let client_ver = crate::core::version::current();
+            match crate::core::version::Version::parse(&s.version) {
                 Some(daemon_ver) => match daemon_ver.cmp(&client_ver) {
                     std::cmp::Ordering::Equal => VersionCheck::Ok,
                     std::cmp::Ordering::Greater => VersionCheck::DaemonNewer,
@@ -90,8 +90,8 @@ async fn spawn_and_wait(endpoint: &str, reason: &str) -> Result<(), String> {
     // replaced-* variants. This is the diagnostic gap zccache#323
     // identified — knowing 5 daemons spawned without knowing why
     // makes the root cause undebuggable.
-    zccache::core::lifecycle::write_event(
-        zccache::core::lifecycle::EVENT_SPAWN_ATTEMPT,
+    crate::core::lifecycle::write_event(
+        crate::core::lifecycle::EVENT_SPAWN_ATTEMPT,
         serde_json::json!({
             "reason": reason,
             "endpoint": endpoint,
@@ -113,21 +113,21 @@ async fn spawn_and_wait(endpoint: &str, reason: &str) -> Result<(), String> {
 async fn stop_stale_daemon(endpoint: &str) {
     if let Ok(mut conn) = connect_client(endpoint).await {
         let _ = conn
-            .send(&zccache::protocol::Request::Shutdown)
+            .send(&crate::protocol::Request::Shutdown)
             .await;
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     }
 
-    if let Some(pid) = zccache::ipc::check_running_daemon() {
-        if zccache::ipc::force_kill_process(pid).is_ok() {
+    if let Some(pid) = crate::ipc::check_running_daemon() {
+        if crate::ipc::force_kill_process(pid).is_ok() {
             for _ in 0..50 {
-                if !zccache::ipc::is_process_alive(pid) {
+                if !crate::ipc::is_process_alive(pid) {
                     break;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }
         }
-        zccache::ipc::remove_lock_file();
+        crate::ipc::remove_lock_file();
     }
 
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
@@ -139,13 +139,13 @@ pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
         VersionCheck::DaemonOlder { daemon_ver } => {
             tracing::info!(
                 daemon_ver,
-                client_ver = zccache::core::VERSION,
+                client_ver = crate::core::VERSION,
                 "daemon is older than client, auto-recovering"
             );
             stop_stale_daemon(endpoint).await;
             return spawn_and_wait(
                 endpoint,
-                zccache::core::lifecycle::REASON_REPLACED_STALE_VERSION,
+                crate::core::lifecycle::REASON_REPLACED_STALE_VERSION,
             )
             .await;
         }
@@ -154,14 +154,14 @@ pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
             stop_stale_daemon(endpoint).await;
             return spawn_and_wait(
                 endpoint,
-                zccache::core::lifecycle::REASON_REPLACED_COMM_ERROR,
+                crate::core::lifecycle::REASON_REPLACED_COMM_ERROR,
             )
             .await;
         }
         VersionCheck::Unreachable => {}
     }
 
-    if let Some(pid) = zccache::ipc::check_running_daemon() {
+    if let Some(pid) = crate::ipc::check_running_daemon() {
         let mut backoff = std::time::Duration::from_millis(100);
         for _ in 0..20 {
             tokio::time::sleep(backoff).await;
@@ -171,13 +171,13 @@ pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
                 VersionCheck::DaemonOlder { daemon_ver } => {
                     tracing::info!(
                         daemon_ver,
-                        client_ver = zccache::core::VERSION,
+                        client_ver = crate::core::VERSION,
                         "daemon is older than client during startup, auto-recovering"
                     );
                     stop_stale_daemon(endpoint).await;
                     return spawn_and_wait(
                         endpoint,
-                        zccache::core::lifecycle::REASON_REPLACED_STALE_VERSION,
+                        crate::core::lifecycle::REASON_REPLACED_STALE_VERSION,
                     )
                     .await;
                 }
@@ -185,7 +185,7 @@ pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
                     stop_stale_daemon(endpoint).await;
                     return spawn_and_wait(
                         endpoint,
-                        zccache::core::lifecycle::REASON_REPLACED_COMM_ERROR,
+                        crate::core::lifecycle::REASON_REPLACED_COMM_ERROR,
                     )
                     .await;
                 }
@@ -199,7 +199,7 @@ pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
 
     spawn_and_wait(
         endpoint,
-        zccache::core::lifecycle::REASON_INITIAL_START,
+        crate::core::lifecycle::REASON_INITIAL_START,
     )
     .await
 }
@@ -304,7 +304,7 @@ const RUNTIME_BINARIES_SUBDIR: &str = "runtime-binaries";
 /// Returns `<global_cache_dir>/runtime-binaries`.
 #[must_use]
 pub fn runtime_binaries_dir() -> NormalizedPath {
-    zccache::core::config::default_cache_dir().join(RUNTIME_BINARIES_SUBDIR)
+    crate::core::config::default_cache_dir().join(RUNTIME_BINARIES_SUBDIR)
 }
 
 /// Copy `canonical` (the daemon binary at its install location) to a unique
@@ -379,7 +379,7 @@ const DAEMON_SPAWN_LOGS_SUBDIR: &str = "logs";
 /// path — the daemon's own opener will see the error and fall back to
 /// `Stdio::null` after warning.
 fn allocate_daemon_spawn_log_path() -> std::path::PathBuf {
-    let dir = zccache::core::config::default_cache_dir().join(DAEMON_SPAWN_LOGS_SUBDIR);
+    let dir = crate::core::config::default_cache_dir().join(DAEMON_SPAWN_LOGS_SUBDIR);
     let _ = std::fs::create_dir_all(dir.as_path());
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -416,7 +416,7 @@ const LOG_GC_CUTOFF: std::time::Duration = std::time::Duration::from_secs(60 * 6
 /// and deleting it mid-life would erase the very history that #323
 /// needed to diagnose the multi-spawn bug.
 pub fn gc_log_directory() {
-    let dir = zccache::core::config::default_cache_dir().join(DAEMON_SPAWN_LOGS_SUBDIR);
+    let dir = crate::core::config::default_cache_dir().join(DAEMON_SPAWN_LOGS_SUBDIR);
     gc_log_directory_in(dir.as_path(), LOG_GC_CUTOFF);
 }
 
@@ -437,7 +437,7 @@ pub fn gc_log_directory_in(dir: &Path, cutoff: std::time::Duration) {
         // untouched between a daemon's `spawn` and `died-*` events.
         // Every other file in `logs/` either rotates often or is a
         // historical artifact safe to discard once old.
-        if name == zccache::core::lifecycle::LIVE_LOG_FILENAME {
+        if name == crate::core::lifecycle::LIVE_LOG_FILENAME {
             continue;
         }
         let file_type = entry.file_type();

--- a/crates/zccache/src/cli/symbols.rs
+++ b/crates/zccache/src/cli/symbols.rs
@@ -332,7 +332,7 @@ fn archive_cache_path(version: &str, target: &str, kind: ArchiveKind) -> PathBuf
         "zccache-v{version}-{target}-debug.{ext}",
         ext = kind.file_extension(),
     );
-    zccache::core::config::symbols_cache_dir()
+    crate::core::config::symbols_cache_dir()
         .into_path_buf()
         .join(filename)
 }
@@ -735,7 +735,7 @@ mod tests {
             .and_then(|s| s.to_str());
         assert_eq!(parent, Some("symbols"));
 
-        let expected_root = zccache::core::config::default_cache_dir();
+        let expected_root = crate::core::config::default_cache_dir();
         assert!(
             path.starts_with(expected_root.as_path()),
             "cache path {} should be under default_cache_dir {}",

--- a/crates/zccache/src/compiler/arduino.rs
+++ b/crates/zccache/src/compiler/arduino.rs
@@ -13,7 +13,7 @@ use std::sync::{Mutex, OnceLock};
 
 use clang::{Clang, Entity, EntityKind, Index};
 use thiserror::Error;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Conversion settings for `.ino` parsing and `.ino.cpp` generation.
 #[derive(Debug, Clone)]
@@ -83,10 +83,10 @@ pub fn can_load_libclang() -> bool {
 }
 
 /// Return the discovered `libclang` binary path and hash it for cache keys.
-pub fn libclang_hash() -> Option<zccache::hash::ContentHash> {
+pub fn libclang_hash() -> Option<crate::hash::ContentHash> {
     libclang_path()
         .as_ref()
-        .and_then(|path| zccache::hash::hash_file(path).ok())
+        .and_then(|path| crate::hash::hash_file(path).ok())
 }
 
 /// Generate an Arduino-style `.ino.cpp` file from an `.ino` source.

--- a/crates/zccache/src/compiler/mod.rs
+++ b/crates/zccache/src/compiler/mod.rs
@@ -33,7 +33,7 @@ pub mod strict_paths;
 mod tests;
 
 use std::sync::Arc;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 pub use detect::detect_family;
 pub use parse::parse_invocation;

--- a/crates/zccache/src/compiler/parse.rs
+++ b/crates/zccache/src/compiler/parse.rs
@@ -4,7 +4,7 @@
 //! For rustc, see [`crate::parse_rustc`].
 
 use std::sync::Arc;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use super::detect::{detect_family, is_source_file, MODULE_EXTENSIONS};
 use super::{parse_msvc, CacheableCompilation, CompilerFamily, ParsedInvocation, SourceMode};

--- a/crates/zccache/src/compiler/parse_archiver.rs
+++ b/crates/zccache/src/compiler/parse_archiver.rs
@@ -3,7 +3,7 @@
 //! Handles parsing command-line arguments for `ar`, `llvm-ar`, and MSVC `lib.exe`
 //! to determine cacheability and extract cache-relevant information.
 
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Supported archiver tool families.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/zccache/src/compiler/parse_linker.rs
+++ b/crates/zccache/src/compiler/parse_linker.rs
@@ -4,7 +4,7 @@
 //! and compiler drivers (`gcc`, `clang`) to determine cacheability for
 //! linking (shared libraries, DLLs, and executables).
 
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Supported linker tool families.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/zccache/src/compiler/parse_msvc.rs
+++ b/crates/zccache/src/compiler/parse_msvc.rs
@@ -20,7 +20,7 @@
 
 use std::sync::Arc;
 
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use super::{CacheableCompilation, CompilerFamily, ParsedInvocation};
 

--- a/crates/zccache/src/compiler/parse_rustc.rs
+++ b/crates/zccache/src/compiler/parse_rustc.rs
@@ -4,7 +4,7 @@
 //! crate types, `--emit=` mixed types, host-side proc-macro dylibs, etc.
 
 use std::sync::Arc;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use super::{CacheableCompilation, CompilerFamily, ParsedInvocation};
 

--- a/crates/zccache/src/compiler/parse_rustfmt.rs
+++ b/crates/zccache/src/compiler/parse_rustfmt.rs
@@ -4,7 +4,7 @@
 //! mode flags, and configuration for cache key computation.
 
 use std::path::Path;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Parsed rustfmt invocation.
 #[derive(Debug, Clone)]

--- a/crates/zccache/src/compiler/response_file.rs
+++ b/crates/zccache/src/compiler/response_file.rs
@@ -7,7 +7,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Maximum nesting depth for response files to prevent stack overflow.
 const MAX_DEPTH: usize = 10;
@@ -569,9 +569,9 @@ mod tests {
         let path = f.path().to_str().unwrap();
         let args = s(&["-c", "foo.cpp", "-o", "foo.o", &format!("@{path}")]);
         let expanded = expand_response_files(&args).unwrap();
-        let result = super::parse_invocation("gcc", &expanded);
+        let result = super::super::parse_invocation("gcc", &expanded);
         match result {
-            super::ParsedInvocation::Cacheable(c) => {
+            super::super::ParsedInvocation::Cacheable(c) => {
                 assert_eq!(c.source_file, NormalizedPath::new("foo.cpp"));
                 assert_eq!(c.output_file, NormalizedPath::new("foo.o"));
                 assert!(c.original_args.contains(&"-O2".to_string()));

--- a/crates/zccache/src/compiler/tests/clang_cl.rs
+++ b/crates/zccache/src/compiler/tests/clang_cl.rs
@@ -2,7 +2,7 @@
 
 use super::args;
 use super::super::{detect_family, parse_invocation, CompilerFamily, ParsedInvocation};
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 #[test]
 fn detect_clang_cl_is_msvc() {

--- a/crates/zccache/src/compiler/tests/clippy_driver.rs
+++ b/crates/zccache/src/compiler/tests/clippy_driver.rs
@@ -2,7 +2,7 @@
 
 use super::args;
 use super::super::{detect_family, parse_invocation, CompilerFamily, ParsedInvocation};
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 #[test]
 fn detect_clippy_driver_family() {

--- a/crates/zccache/src/compiler/tests/cpp_output.rs
+++ b/crates/zccache/src/compiler/tests/cpp_output.rs
@@ -2,7 +2,7 @@
 
 use super::args;
 use super::super::{parse_invocation, ParsedInvocation};
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 // ─── PCH default output tests ─────────────────────────────────────────
 

--- a/crates/zccache/src/compiler/tests/cpp_parse.rs
+++ b/crates/zccache/src/compiler/tests/cpp_parse.rs
@@ -2,7 +2,7 @@
 
 use super::args;
 use super::super::{parse_invocation, CompilerFamily, ParsedInvocation};
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 #[test]
 fn basic_cacheable_compilation() {

--- a/crates/zccache/src/compiler/tests/modules.rs
+++ b/crates/zccache/src/compiler/tests/modules.rs
@@ -2,7 +2,7 @@
 
 use super::args;
 use super::super::{parse_invocation, ParsedInvocation};
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 // Group A: Source extension recognition (.cppm, .ixx)
 

--- a/crates/zccache/src/compiler/tests/rustc.rs
+++ b/crates/zccache/src/compiler/tests/rustc.rs
@@ -2,7 +2,7 @@
 
 use super::args;
 use super::super::{detect_family, parse_invocation, CompilerFamily, ParsedInvocation};
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 // ─── Rustc detection tests ────────────────────────────────────────────
 

--- a/crates/zccache/src/daemon/compile_journal/journal_thread.rs
+++ b/crates/zccache/src/daemon/compile_journal/journal_thread.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 use std::path::Path;
 
 use tokio::sync::mpsc;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use super::super::event_log::open_append;
 

--- a/crates/zccache/src/daemon/compile_journal/mod.rs
+++ b/crates/zccache/src/daemon/compile_journal/mod.rs
@@ -20,7 +20,7 @@ use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use super::event_log::{format_timestamp, open_append};
 

--- a/crates/zccache/src/daemon/compile_journal/outcome.rs
+++ b/crates/zccache/src/daemon/compile_journal/outcome.rs
@@ -1,6 +1,6 @@
-//! Map a [`zccache::protocol::Response`] to a journal-ready tuple.
+//! Map a [`crate::protocol::Response`] to a journal-ready tuple.
 
-use zccache::protocol::Response;
+use crate::protocol::Response;
 
 use super::miss_reason;
 

--- a/crates/zccache/src/daemon/compile_journal/tests/miss_reason.rs
+++ b/crates/zccache/src/daemon/compile_journal/tests/miss_reason.rs
@@ -4,7 +4,7 @@
 use std::fs;
 use std::sync::Arc;
 
-use zccache::protocol::Response;
+use crate::protocol::Response;
 
 use super::super::{
     extract_outcome, miss_reason, CompileJournal, JournalContext, JournalEntry, MissDiff,

--- a/crates/zccache/src/daemon/compile_journal/tests/outcome.rs
+++ b/crates/zccache/src/daemon/compile_journal/tests/outcome.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use zccache::protocol::Response;
+use crate::protocol::Response;
 
 use super::super::{extract_outcome, miss_reason};
 
@@ -122,8 +122,8 @@ fn test_extract_outcome_link_error() {
 
 #[test]
 fn test_extract_outcome_all_non_journalable() {
-    use zccache::core::NormalizedPath;
-    use zccache::protocol::{DaemonStatus, LookupResult as LR, SessionStats, StoreResult as SR};
+    use crate::core::NormalizedPath;
+    use crate::protocol::{DaemonStatus, LookupResult as LR, SessionStats, StoreResult as SR};
 
     let non_journalable: Vec<Response> = vec![
         Response::Pong,

--- a/crates/zccache/src/daemon/crash.rs
+++ b/crates/zccache/src/daemon/crash.rs
@@ -1,7 +1,7 @@
-//! Daemon-side façade over [`zccache::core::crash`].
+//! Daemon-side façade over [`crate::core::crash`].
 //!
 //! Historically this module owned the panic hook + signal handler
-//! implementation. Issue #313 moved that code into `zccache::core::crash`
+//! implementation. Issue #313 moved that code into `crate::core::crash`
 //! so the CLI can install the same coverage with one call. The
 //! daemon-only knobs that survived (`install_panic_hook`,
 //! `install_minidump_handler`, `check_previous_crashes`,
@@ -9,13 +9,13 @@
 //! delegate to the shared core implementation, and the daemon's
 //! `main.rs` still installs them in the same order it always has.
 //!
-//! New code should call `zccache::core::crash::install("zccache-daemon")`
+//! New code should call `crate::core::crash::install("zccache-daemon")`
 //! once at the top of `main` and rely on the returned `CrashGuard` to
 //! keep handlers registered.
 
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
-pub use zccache::core::crash::{
+pub use crate::core::crash::{
     check_previous_crashes, clear_crash_dumps, list_crash_dumps, CrashGuard,
 };
 
@@ -23,7 +23,7 @@ pub use zccache::core::crash::{
 /// Kept as a free function so the existing crash-trigger fixture (which
 /// is shared with the panic-only minidump test) keeps compiling.
 pub fn install_panic_hook() {
-    let _ = zccache::core::crash::install("zccache-daemon");
+    let _ = crate::core::crash::install("zccache-daemon");
 }
 
 /// Install OS-level signal/exception handlers. Returns a guard the
@@ -36,7 +36,7 @@ pub fn install_minidump_handler() -> Option<MinidumpHandle> {
     // so it's safe for the daemon to call install_panic_hook() first
     // and then install_minidump_handler() — they end up wired through
     // the same guard.
-    let guard = zccache::core::crash::install("zccache-daemon");
+    let guard = crate::core::crash::install("zccache-daemon");
     Some(MinidumpHandle { _guard: guard })
 }
 
@@ -52,7 +52,7 @@ pub struct MinidumpHandle {
 /// want to record a synthesised "crash report" (e.g. a graceful shutdown
 /// from a recoverable error that still warrants postmortem).
 pub fn write_crash_dump(panic_info: &str, backtrace: &str) -> Option<NormalizedPath> {
-    let crash_dir = zccache::core::config::crash_dump_dir();
+    let crash_dir = crate::core::config::crash_dump_dir();
     std::fs::create_dir_all(&crash_dir).ok()?;
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/crates/zccache/src/daemon/event_log.rs
+++ b/crates/zccache/src/daemon/event_log.rs
@@ -15,8 +15,8 @@ use std::path::Path;
 use std::time::{Duration, SystemTime};
 
 use tokio::sync::mpsc;
-use zccache::core::NormalizedPath;
-use zccache::depgraph::{SessionId, SessionManager};
+use crate::core::NormalizedPath;
+use crate::depgraph::{SessionId, SessionManager};
 
 /// Open a file in append mode with sharing flags that allow deletion on Windows.
 ///
@@ -573,7 +573,7 @@ mod tests {
         let logger = EventLogger::new(log_dir.clone().into(), 10 * 1024 * 1024, 5);
 
         let sessions = SessionManager::new(Duration::from_secs(300));
-        let sid = sessions.create(zccache::depgraph::SessionConfig {
+        let sid = sessions.create(crate::depgraph::SessionConfig {
             client_pid: 42,
             working_dir: "/test".into(),
             log_file: Some(session_log.to_path_buf().into()),

--- a/crates/zccache/src/daemon/eviction.rs
+++ b/crates/zccache/src/daemon/eviction.rs
@@ -12,9 +12,9 @@ use rayon::prelude::*;
 use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
-use zccache::core::NormalizedPath;
-use zccache::depgraph::{ContextKey, DepGraph};
-use zccache::fscache::CacheSystem;
+use crate::core::NormalizedPath;
+use crate::depgraph::{ContextKey, DepGraph};
+use crate::fscache::CacheSystem;
 
 use super::server::{trim_fast_hit_cache, CachedArtifact, FastHitEntry};
 
@@ -290,10 +290,10 @@ pub(crate) fn evict_disk_artifacts(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::server::CachedPayload;
+    use super::super::server::CachedPayload;
     use std::time::{Instant, SystemTime};
-    use zccache::depgraph::CompileContext;
-    use zccache::fscache::{Confidence, FileMetadata};
+    use crate::depgraph::CompileContext;
+    use crate::fscache::{Confidence, FileMetadata};
 
     fn empty_caches() -> (
         CacheSystem,
@@ -312,7 +312,7 @@ mod tests {
     fn make_ctx(source: &str) -> CompileContext {
         CompileContext {
             source_file: source.into(),
-            include_search: zccache::depgraph::IncludeSearchPaths::default(),
+            include_search: crate::depgraph::IncludeSearchPaths::default(),
             defines: Vec::new(),
             flags: Vec::new(),
             force_includes: Vec::new(),
@@ -342,7 +342,7 @@ mod tests {
         fh.insert(
             make_context_key("/tmp/snap.c"),
             FastHitEntry {
-                clock: zccache::fscache::Clock::ZERO,
+                clock: crate::fscache::Clock::ZERO,
                 artifact_key_hex: String::new(),
                 cached_at: Instant::now(),
             },
@@ -370,7 +370,7 @@ mod tests {
             fh.insert(
                 make_context_key(&format!("/tmp/fh{i}.c")),
                 FastHitEntry {
-                    clock: zccache::fscache::Clock::ZERO,
+                    clock: crate::fscache::Clock::ZERO,
                     artifact_key_hex: String::new(),
                     cached_at: Instant::now(),
                 },
@@ -463,7 +463,7 @@ mod tests {
             fh.insert(
                 make_context_key(&format!("/tmp/inflight{i}.c")),
                 FastHitEntry {
-                    clock: zccache::fscache::Clock::ZERO,
+                    clock: crate::fscache::Clock::ZERO,
                     artifact_key_hex: String::new(),
                     cached_at: Instant::now(),
                 },
@@ -493,7 +493,7 @@ mod tests {
     }
 
     fn make_artifact(payload_size: usize) -> CachedArtifact {
-        use zccache::artifact::ArtifactIndex;
+        use crate::artifact::ArtifactIndex;
         CachedArtifact {
             meta: ArtifactIndex::new(
                 vec!["test.o".to_string()],

--- a/crates/zccache/src/daemon/fingerprint.rs
+++ b/crates/zccache/src/daemon/fingerprint.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use dashmap::DashMap;
 
@@ -227,9 +227,9 @@ impl FingerprintManager {
         // Hash all files and build tracked state.
         let mut tracked = HashMap::new();
         for file in &files {
-            let mtime = zccache::fingerprint::persist::mtime_ns(&file.absolute).unwrap_or(0);
-            let size = zccache::fingerprint::persist::file_size(&file.absolute).unwrap_or(0);
-            let hash_hex = match zccache::hash::hash_file(&file.absolute) {
+            let mtime = crate::fingerprint::persist::mtime_ns(&file.absolute).unwrap_or(0);
+            let size = crate::fingerprint::persist::file_size(&file.absolute).unwrap_or(0);
+            let hash_hex = match crate::hash::hash_file(&file.absolute) {
                 Ok(h) => h.to_hex(),
                 Err(_) => String::new(),
             };
@@ -324,9 +324,9 @@ impl FingerprintManager {
                 if let Ok(rel) = path.strip_prefix(root) {
                     let rel_str = rel.to_string_lossy().replace('\\', "/");
                     // Re-hash the changed file.
-                    let mtime = zccache::fingerprint::persist::mtime_ns(&path).unwrap_or(0);
-                    let size = zccache::fingerprint::persist::file_size(&path).unwrap_or(0);
-                    let hash_hex = match zccache::hash::hash_file(&path) {
+                    let mtime = crate::fingerprint::persist::mtime_ns(&path).unwrap_or(0);
+                    let size = crate::fingerprint::persist::file_size(&path).unwrap_or(0);
+                    let hash_hex = match crate::hash::hash_file(&path) {
                         Ok(h) => h.to_hex(),
                         Err(_) => String::new(),
                     };
@@ -381,17 +381,17 @@ impl FingerprintManager {
         include_globs: &[String],
         exclude: &[String],
     ) -> std::result::Result<
-        Vec<zccache::fingerprint::ScannedFile>,
-        zccache::fingerprint::FingerprintError,
+        Vec<crate::fingerprint::ScannedFile>,
+        crate::fingerprint::FingerprintError,
     > {
         if !include_globs.is_empty() {
             let include_refs: Vec<&str> = include_globs.iter().map(|s| s.as_str()).collect();
             let exclude_refs: Vec<&str> = exclude.iter().map(|s| s.as_str()).collect();
-            zccache::fingerprint::walk_files_glob(root, &include_refs, &exclude_refs)
+            crate::fingerprint::walk_files_glob(root, &include_refs, &exclude_refs)
         } else {
             let ext_refs: Vec<&str> = extensions.iter().map(|s| s.as_str()).collect();
             let exclude_refs: Vec<&str> = exclude.iter().map(|s| s.as_str()).collect();
-            zccache::fingerprint::walk_files(root, &ext_refs, &exclude_refs)
+            crate::fingerprint::walk_files(root, &ext_refs, &exclude_refs)
         }
     }
 
@@ -402,13 +402,13 @@ impl FingerprintManager {
         let root = watch.root.clone();
         for (rel_path, tracked) in watch.files.iter_mut() {
             let abs = root.join(rel_path);
-            let mtime = zccache::fingerprint::persist::mtime_ns(&abs).unwrap_or(0);
-            let size = zccache::fingerprint::persist::file_size(&abs).unwrap_or(0);
+            let mtime = crate::fingerprint::persist::mtime_ns(&abs).unwrap_or(0);
+            let size = crate::fingerprint::persist::file_size(&abs).unwrap_or(0);
             if mtime == tracked.mtime_ns && size == tracked.size {
                 continue; // Layer 1: fast skip
             }
             // Layer 2: mtime/size changed — re-hash to confirm.
-            let hash_hex = match zccache::hash::hash_file(&abs) {
+            let hash_hex = match crate::hash::hash_file(&abs) {
                 Ok(h) => h.to_hex(),
                 Err(_) => {
                     changed.push(rel_path.clone());

--- a/crates/zccache/src/daemon/lifecycle.rs
+++ b/crates/zccache/src/daemon/lifecycle.rs
@@ -1,5 +1,5 @@
 //! Daemon lifecycle event log — thin re-export of
-//! [`zccache::core::lifecycle`].
+//! [`crate::core::lifecycle`].
 //!
 //! The writer was extracted to `zccache-core` so the CLI can also
 //! append lifecycle events (notably `spawn-attempt` records that
@@ -8,7 +8,7 @@
 //! continues to address this as `super::lifecycle::...` for
 //! readability; this module exists only to forward those references.
 
-pub use zccache::core::lifecycle::{
+pub use crate::core::lifecycle::{
     log_file_path, write_event, EVENT_DIED_IDLE, EVENT_DIED_SHUTDOWN, EVENT_SPAWN,
     EVENT_SPAWN_ATTEMPT, EVENT_VERSION_MISMATCH, LIVE_LOG_FILENAME, MAX_LOG_SIZE,
     REASON_GRACEFUL_SHUTDOWN, REASON_IDLE_TIMEOUT, REASON_INITIAL_START,

--- a/crates/zccache/src/daemon/server/compiler_hash.rs
+++ b/crates/zccache/src/daemon/server/compiler_hash.rs
@@ -30,7 +30,7 @@ impl CompilerHashCache {
     }
 
     pub(super) fn get_or_hash(&self, path: &Path) -> Option<ContentHash> {
-        self.get_or_hash_with(path, |path| zccache::hash::hash_file(path).ok())
+        self.get_or_hash_with(path, |path| crate::hash::hash_file(path).ok())
     }
 
     pub(super) fn get_or_hash_with<F>(&self, path: &Path, hasher: F) -> Option<ContentHash>

--- a/crates/zccache/src/daemon/server/connection.rs
+++ b/crates/zccache/src/daemon/server/connection.rs
@@ -6,12 +6,12 @@ use super::*;
 pub(super) async fn handle_connection(
     mut conn: IpcConnection,
     state: Arc<SharedState>,
-) -> Result<(), zccache::ipc::IpcError> {
+) -> Result<(), crate::ipc::IpcError> {
     loop {
         let request: Option<Request> = match conn.recv().await {
             Ok(req) => req,
-            Err(zccache::ipc::IpcError::Protocol(
-                zccache::protocol::ProtocolError::VersionMismatch { expected, received },
+            Err(crate::ipc::IpcError::Protocol(
+                crate::protocol::ProtocolError::VersionMismatch { expected, received },
             )) => {
                 // Don't drop the connection silently — without a reply the
                 // CLI surfaces the (correct) closure as the misleading
@@ -52,8 +52,8 @@ pub(super) async fn handle_connection(
                         message: msg.clone(),
                     })
                     .await;
-                return Err(zccache::ipc::IpcError::Protocol(
-                    zccache::protocol::ProtocolError::VersionMismatch { expected, received },
+                return Err(crate::ipc::IpcError::Protocol(
+                    crate::protocol::ProtocolError::VersionMismatch { expected, received },
                 ));
             }
             Err(e) => return Err(e),
@@ -100,8 +100,8 @@ pub(super) async fn handle_connection(
                     .sum();
                 let metadata_entries = state.cache_system.metadata().len() as u64;
                 (
-                    Response::Status(zccache::protocol::DaemonStatus {
-                        version: zccache::core::VERSION.to_string(),
+                    Response::Status(crate::protocol::DaemonStatus {
+                        version: crate::core::VERSION.to_string(),
                         artifact_count,
                         cache_size_bytes,
                         metadata_entries,
@@ -120,9 +120,9 @@ pub(super) async fn handle_connection(
                         dep_graph_files: dg.file_count as u64,
                         sessions_total: snap.sessions_total,
                         sessions_active: state.sessions.active_count() as u64,
-                        cache_dir: zccache::core::config::default_cache_dir(),
-                        dep_graph_version: zccache::depgraph::DEPGRAPH_VERSION,
-                        dep_graph_disk_size: zccache::depgraph::depgraph_file_path()
+                        cache_dir: crate::core::config::default_cache_dir(),
+                        dep_graph_version: crate::depgraph::DEPGRAPH_VERSION,
+                        dep_graph_disk_size: crate::depgraph::depgraph_file_path()
                             .metadata()
                             .map(|m| m.len())
                             .unwrap_or(0),
@@ -132,11 +132,11 @@ pub(super) async fn handle_connection(
                 )
             }
             Request::Lookup { .. } => (
-                Response::LookupResult(zccache::protocol::LookupResult::Miss),
+                Response::LookupResult(crate::protocol::LookupResult::Miss),
                 None,
             ),
             Request::Store { .. } => (
-                Response::StoreResult(zccache::protocol::StoreResult::Stored),
+                Response::StoreResult(crate::protocol::StoreResult::Stored),
                 None,
             ),
             Request::Clear => (handle_clear(&state).await, None),
@@ -225,7 +225,7 @@ pub(super) async fn handle_connection(
                         if let Some(session) = state.sessions.get(&sid) {
                             let stats = session.stats_tracker.as_ref().map(|tracker| {
                                 let f = tracker.finalize(session.created_at);
-                                zccache::protocol::SessionStats {
+                                crate::protocol::SessionStats {
                                     duration_ms: f.duration_ms,
                                     compilations: f.compilations,
                                     hits: f.hits,
@@ -266,7 +266,7 @@ pub(super) async fn handle_connection(
                             }
                             let stats = session.stats_tracker.map(|tracker| {
                                 let f = tracker.finalize(session.created_at);
-                                zccache::protocol::SessionStats {
+                                crate::protocol::SessionStats {
                                     duration_ms: f.duration_ms,
                                     compilations: f.compilations,
                                     hits: f.hits,
@@ -374,7 +374,7 @@ pub(super) async fn handle_connection(
                             || n.ends_with(".dll")
                     });
                     if is_rust {
-                        artifacts.push(zccache::protocol::RustArtifactInfo {
+                        artifacts.push(crate::protocol::RustArtifactInfo {
                             cache_key: key,
                             output_names: names.clone(),
                             payload_count: names.len(),

--- a/crates/zccache/src/daemon/server/handle_clear.rs
+++ b/crates/zccache/src/daemon/server/handle_clear.rs
@@ -69,7 +69,7 @@ pub(super) async fn handle_clear(state: &SharedState) -> Response {
     let _ = std::fs::remove_file(state.metadata_path.as_path());
 
     // Delete on-disk depgraph snapshot.
-    let _ = std::fs::remove_file(zccache::depgraph::depgraph_file_path());
+    let _ = std::fs::remove_file(crate::depgraph::depgraph_file_path());
 
     tracing::info!(
         artifacts_removed,

--- a/crates/zccache/src/daemon/server/handle_compile.rs
+++ b/crates/zccache/src/daemon/server/handle_compile.rs
@@ -43,7 +43,7 @@ pub(super) async fn handle_compile(
         Err(err) => return compile_failure_stderr(format!("zccache: {err}")),
     };
     if let Err(err) =
-        zccache::compiler::strict_paths::validate_args(&expanded_args, strict_paths_mode)
+        crate::compiler::strict_paths::validate_args(&expanded_args, strict_paths_mode)
     {
         let compiler = compiler_path.display().to_string();
         return compile_failure_stderr(err.diagnostic(&compiler, &expanded_args));
@@ -245,7 +245,7 @@ pub(super) async fn handle_compile(
         let lineage_for_probe = lineage.clone();
         cache
             .get_or_discover(&compiler, |c| {
-                let disc_args = zccache::depgraph::discovery_args();
+                let disc_args = crate::depgraph::discovery_args();
                 let output = {
                     let mut cmd = std::process::Command::new(c);
                     cmd.args(&disc_args);
@@ -255,7 +255,7 @@ pub(super) async fn handle_compile(
                 match output {
                     Ok(out) => {
                         let stderr = String::from_utf8_lossy(&out.stderr);
-                        zccache::depgraph::parse_system_include_output(&stderr)
+                        crate::depgraph::parse_system_include_output(&stderr)
                     }
                     Err(e) => {
                         tracing::warn!("failed to run compiler for include discovery: {e}");
@@ -277,10 +277,10 @@ pub(super) async fn handle_compile(
     // ── Phase: expand response files + parse args ─────────────────────
     let t0 = std::time::Instant::now();
     let compiler_str = compiler.to_str().unwrap_or("");
-    let parsed = zccache::compiler::parse_invocation(compiler_str, &effective_args);
+    let parsed = crate::compiler::parse_invocation(compiler_str, &effective_args);
     let compilation = match parsed {
-        zccache::compiler::ParsedInvocation::Cacheable(c) => c,
-        zccache::compiler::ParsedInvocation::NonCacheable { reason } => {
+        crate::compiler::ParsedInvocation::Cacheable(c) => c,
+        crate::compiler::ParsedInvocation::NonCacheable { reason } => {
             state.stats.record_non_cacheable();
             record_session_stat(&state.sessions, &sid, |t| t.record_non_cacheable());
             write_session_log(&state.sessions, &sid, &format!("non-cacheable: {reason}"));
@@ -297,7 +297,7 @@ pub(super) async fn handle_compile(
             )
             .await;
         }
-        zccache::compiler::ParsedInvocation::MultiFile {
+        crate::compiler::ParsedInvocation::MultiFile {
             compilations,
             original_args,
             source_indices,
@@ -584,7 +584,7 @@ pub(super) async fn handle_compile(
         // Cold context — skip hashing and depgraph check entirely.
         hash_headers_ns = 0;
         depgraph_check_ns = 0;
-        verdict = zccache::depgraph::CacheVerdict::Cold;
+        verdict = crate::depgraph::CacheVerdict::Cold;
         diag_reason = "cold_skip".to_string();
     } else {
         // Hash includes + force-includes in parallel (PCH-aware).
@@ -636,7 +636,7 @@ pub(super) async fn handle_compile(
             hash_map.get(&path).copied()
         }) {
             depgraph_check_ns = 0;
-            verdict = zccache::depgraph::CacheVerdict::Hit { artifact_key };
+            verdict = crate::depgraph::CacheVerdict::Hit { artifact_key };
             diag_reason = "fast_key_match".to_string();
         } else {
             let t4 = std::time::Instant::now();
@@ -671,18 +671,18 @@ pub(super) async fn handle_compile(
             output_path.display(),
             &context_key.hash().to_hex()[..8],
             match &verdict {
-                zccache::depgraph::CacheVerdict::Hit { .. } => "Hit",
-                zccache::depgraph::CacheVerdict::SourceChanged { .. } => "SourceChanged",
-                zccache::depgraph::CacheVerdict::HeadersChanged { .. } => "HeadersChanged",
-                zccache::depgraph::CacheVerdict::Cold => "Cold",
-                zccache::depgraph::CacheVerdict::NeedsPreprocessor => "NeedsPreprocessor",
+                crate::depgraph::CacheVerdict::Hit { .. } => "Hit",
+                crate::depgraph::CacheVerdict::SourceChanged { .. } => "SourceChanged",
+                crate::depgraph::CacheVerdict::HeadersChanged { .. } => "HeadersChanged",
+                crate::depgraph::CacheVerdict::Cold => "Cold",
+                crate::depgraph::CacheVerdict::NeedsPreprocessor => "NeedsPreprocessor",
             },
             diag_reason,
         ),
     );
     match verdict {
-        zccache::depgraph::CacheVerdict::Hit { artifact_key }
-        | zccache::depgraph::CacheVerdict::SourceChanged { artifact_key } => {
+        crate::depgraph::CacheVerdict::Hit { artifact_key }
+        | crate::depgraph::CacheVerdict::SourceChanged { artifact_key } => {
             // ── Phase: artifact lookup + write ─────────────────────────
             let t5 = std::time::Instant::now();
             let artifact_key_hex = artifact_key.hash().to_hex();
@@ -823,9 +823,9 @@ pub(super) async fn handle_compile(
                 &format!("[DIAG] artifact_not_found: key={artifact_key_hex}"),
             );
         }
-        zccache::depgraph::CacheVerdict::Cold
-        | zccache::depgraph::CacheVerdict::HeadersChanged { .. }
-        | zccache::depgraph::CacheVerdict::NeedsPreprocessor => {
+        crate::depgraph::CacheVerdict::Cold
+        | crate::depgraph::CacheVerdict::HeadersChanged { .. }
+        | crate::depgraph::CacheVerdict::NeedsPreprocessor => {
             // Need to compile and scan includes
         }
     }
@@ -848,7 +848,7 @@ pub(super) async fn handle_compile(
     let pre_exec_ns = compile_start.elapsed().as_nanos() as u64;
     let t_exec = std::time::Instant::now();
     let supports_depfile = compilation.family.supports_depfile();
-    let (mut extra_args, mut depfile_strategy) = zccache::depgraph::depfile::prepare_depfile(
+    let (mut extra_args, mut depfile_strategy) = crate::depgraph::depfile::prepare_depfile(
         supports_depfile,
         &dep_flags,
         &output_path,
@@ -858,7 +858,7 @@ pub(super) async fn handle_compile(
     // For MSVC, use /showIncludes to get complete dependency info
     // (equivalent to depfiles for gcc/clang). This enables cache hits
     // for files with computed includes like `#include MACRO`.
-    if compilation.family == zccache::compiler::CompilerFamily::Msvc
+    if compilation.family == crate::compiler::CompilerFamily::Msvc
         && depfile_strategy == DepfileStrategy::Unsupported
     {
         if !dep_flags.has_md {
@@ -877,7 +877,7 @@ pub(super) async fn handle_compile(
         &combined_args
     };
 
-    let _rsp_guard = match zccache::compiler::response_file::write_response_file_if_needed(
+    let _rsp_guard = match crate::compiler::response_file::write_response_file_if_needed(
         rsp_args,
         &state.depfile_tmpdir,
     ) {
@@ -949,7 +949,7 @@ pub(super) async fn handle_compile(
     // For MSVC /showIncludes: parse dependency info from stderr and
     // filter out the /showIncludes lines before returning to the client.
     let (show_includes_scan, stderr_bytes) = if depfile_strategy == DepfileStrategy::ShowIncludes {
-        let (scan, filtered) = zccache::depgraph::show_includes::parse_show_includes(
+        let (scan, filtered) = crate::depgraph::show_includes::parse_show_includes(
             &output.stderr,
             &source_path,
             &cwd_path,
@@ -1030,7 +1030,7 @@ pub(super) async fn handle_compile(
                 | DepfileStrategy::UserSpecified { path }
                 | DepfileStrategy::UserDefault { path } => {
                     let cwd_path: NormalizedPath = cwd.into();
-                    match zccache::depgraph::depfile::parse_depfile_path(
+                    match crate::depgraph::depfile::parse_depfile_path(
                         path,
                         &source_path,
                         &cwd_path,
@@ -1054,7 +1054,7 @@ pub(super) async fn handle_compile(
                             if matches!(depfile_strategy, DepfileStrategy::Injected { .. }) {
                                 let _ = std::fs::remove_file(path);
                             }
-                            zccache::depgraph::scanner::scan_recursive(
+                            crate::depgraph::scanner::scan_recursive(
                                 &source_path,
                                 &ctx.include_search,
                             )
@@ -1064,11 +1064,11 @@ pub(super) async fn handle_compile(
                 DepfileStrategy::ShowIncludes => {
                     // Already parsed from stderr above.
                     show_includes_scan.unwrap_or_else(|| {
-                        zccache::depgraph::scanner::scan_recursive(&source_path, &ctx.include_search)
+                        crate::depgraph::scanner::scan_recursive(&source_path, &ctx.include_search)
                     })
                 }
                 DepfileStrategy::Unsupported => {
-                    zccache::depgraph::scanner::scan_recursive(&source_path, &ctx.include_search)
+                    crate::depgraph::scanner::scan_recursive(&source_path, &ctx.include_search)
                 }
             }
         };

--- a/crates/zccache/src/daemon/server/handle_compile_ephemeral.rs
+++ b/crates/zccache/src/daemon/server/handle_compile_ephemeral.rs
@@ -67,7 +67,7 @@ pub(super) async fn run_compiler_direct(
     tmp_dir: &Path,
 ) -> Response {
     let _rsp_guard =
-        match zccache::compiler::response_file::write_response_file_if_needed(args, tmp_dir) {
+        match crate::compiler::response_file::write_response_file_if_needed(args, tmp_dir) {
             Ok(guard) => guard,
             Err(e) => {
                 return Response::Error {

--- a/crates/zccache/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache/src/daemon/server/handle_compile_multi.rs
@@ -35,7 +35,7 @@ pub(super) enum UnitCacheResult {
 /// compilations where all units share the same flags.
 pub(super) fn check_unit_cache(
     state: &SharedState,
-    compilation: &zccache::compiler::CacheableCompilation,
+    compilation: &crate::compiler::CacheableCompilation,
     cwd_path: &Path,
     key_root: &NormalizedPath,
     system_includes: &[NormalizedPath],
@@ -209,8 +209,8 @@ pub(super) fn check_unit_cache(
     let t_depgraph = t0.elapsed();
 
     // Try to serve from cache
-    if let zccache::depgraph::CacheVerdict::Hit { artifact_key }
-    | zccache::depgraph::CacheVerdict::SourceChanged { artifact_key } = verdict
+    if let crate::depgraph::CacheVerdict::Hit { artifact_key }
+    | crate::depgraph::CacheVerdict::SourceChanged { artifact_key } = verdict
     {
         let artifact_key_hex = artifact_key.hash().to_hex();
         if let Some(mut cached_ref) = lookup_artifact_with_disk_fallback(state, &artifact_key_hex) {
@@ -296,7 +296,7 @@ pub(super) async fn handle_compile_multi(
     state: Arc<SharedState>,
     sid: SessionId,
     compiler: NormalizedPath,
-    compilations: Vec<zccache::compiler::CacheableCompilation>,
+    compilations: Vec<crate::compiler::CacheableCompilation>,
     original_args: Arc<[String]>,
     source_indices: Vec<usize>,
     cwd_path: NormalizedPath,
@@ -317,10 +317,10 @@ pub(super) async fn handle_compile_multi(
     let shared_base: Arc<CompileContext> = {
         let first = &compilations[0];
         let parsed = match first.family {
-            zccache::compiler::CompilerFamily::Msvc => {
-                zccache::depgraph::msvc_args::parse_msvc_args(&first.original_args, &cwd_path)
+            crate::compiler::CompilerFamily::Msvc => {
+                crate::depgraph::msvc_args::parse_msvc_args(&first.original_args, &cwd_path)
             }
-            _ => zccache::depgraph::args::parse_gnu_args(&first.original_args, &cwd_path),
+            _ => crate::depgraph::args::parse_gnu_args(&first.original_args, &cwd_path),
         };
         let mut base = CompileContext::from_parsed_args(parsed);
         for path in &system_includes {
@@ -503,7 +503,7 @@ pub(super) async fn handle_compile_multi(
         compiler_args.push("-MD".to_string());
     }
 
-    let _rsp_guard = match zccache::compiler::response_file::write_response_file_if_needed(
+    let _rsp_guard = match crate::compiler::response_file::write_response_file_if_needed(
         &compiler_args,
         &state.depfile_tmpdir,
     ) {
@@ -635,7 +635,7 @@ pub(super) async fn handle_compile_multi(
                         .unwrap_or_else(|| std::ffi::OsStr::new("out"));
                     cwd_path_task.join(stem).with_extension("d").into()
                 };
-                match zccache::depgraph::depfile::parse_depfile_path(
+                match crate::depgraph::depfile::parse_depfile_path(
                     &depfile_path,
                     &source_path,
                     &cwd_path_task,
@@ -649,11 +649,11 @@ pub(super) async fn handle_compile_multi(
                             "multi-file depfile parse failed for {}: {e}",
                             source_path.display()
                         );
-                        zccache::depgraph::scanner::scan_recursive(&source_path, &ctx.include_search)
+                        crate::depgraph::scanner::scan_recursive(&source_path, &ctx.include_search)
                     }
                 }
             } else {
-                zccache::depgraph::scanner::scan_recursive(&source_path, &ctx.include_search)
+                crate::depgraph::scanner::scan_recursive(&source_path, &ctx.include_search)
             };
 
             let tracked_paths: Vec<NormalizedPath> = std::iter::once(source_path.clone())

--- a/crates/zccache/src/daemon/server/handle_link.rs
+++ b/crates/zccache/src/daemon/server/handle_link.rs
@@ -15,8 +15,8 @@ pub(super) async fn handle_link_ephemeral(
     env: Option<Vec<(String, String)>>,
 ) -> Response {
     let lineage = super::super::lineage::Lineage::current(Some(client_pid), None);
-    use zccache::compiler::parse_archiver::{parse_archive_invocation, ParsedArchiveInvocation};
-    use zccache::compiler::parse_linker::{parse_linker_invocation, ParsedLinkerInvocation};
+    use crate::compiler::parse_archiver::{parse_archive_invocation, ParsedArchiveInvocation};
+    use crate::compiler::parse_linker::{parse_linker_invocation, ParsedLinkerInvocation};
 
     state.stats.record_link();
     let worktree_root = resolve_worktree_root(cwd, env.as_deref());
@@ -39,7 +39,7 @@ pub(super) async fn handle_link_ephemeral(
     let parsed_tool = match parse_archive_invocation(tool.to_str().unwrap_or(""), args) {
         ParsedArchiveInvocation::Cacheable(c) => ParsedTool {
             non_determinism_hint: match c.family {
-                zccache::compiler::parse_archiver::ArchiverFamily::MsvcLib => "/BREPRO".to_string(),
+                crate::compiler::parse_archiver::ArchiverFamily::MsvcLib => "/BREPRO".to_string(),
                 _ => "D".to_string(),
             },
             input_files: c.input_files,
@@ -53,7 +53,7 @@ pub(super) async fn handle_link_ephemeral(
             match parse_linker_invocation(tool.to_str().unwrap_or(""), args.to_vec()) {
                 ParsedLinkerInvocation::Cacheable(c) => ParsedTool {
                     non_determinism_hint: match c.family {
-                        zccache::compiler::parse_linker::LinkerFamily::MsvcLink => {
+                        crate::compiler::parse_linker::LinkerFamily::MsvcLink => {
                             "/DETERMINISTIC".to_string()
                         }
                         _ => "--build-id=sha1 (avoid --build-id=uuid)".to_string(),
@@ -124,14 +124,14 @@ pub(super) async fn handle_link_ephemeral(
         cwd_path,
         link_path_remap_key_root,
     );
-    let mut key_builder = zccache::hash::link_cache_key::LinkCacheKeyBuilder::new().tool(tool_hash);
+    let mut key_builder = crate::hash::link_cache_key::LinkCacheKeyBuilder::new().tool(tool_hash);
 
     if link_path_remap_key_root.is_some() {
         key_builder = key_builder.flag(LINK_PATH_REMAP_AUTO_KEY_FLAG);
     }
     if link_key_plan.root_specific {
         let root_identity = link_path_remap_key_root
-            .map(zccache::core::path::normalize_for_key)
+            .map(crate::core::path::normalize_for_key)
             .unwrap_or_default();
         key_builder = key_builder.flag(format!(
             "{LINK_PATH_REMAP_ROOT_SPECIFIC_FLAG}:{root_identity}"
@@ -476,7 +476,7 @@ pub(super) async fn run_tool_passthrough(
     tmp_dir: &Path,
 ) -> Response {
     let _rsp_guard =
-        match zccache::compiler::response_file::write_response_file_if_needed(args, tmp_dir) {
+        match crate::compiler::response_file::write_response_file_if_needed(args, tmp_dir) {
             Ok(guard) => guard,
             Err(e) => {
                 return Response::Error {

--- a/crates/zccache/src/daemon/server/keys.rs
+++ b/crates/zccache/src/daemon/server/keys.rs
@@ -73,14 +73,14 @@ pub(super) fn compile_worktree_root(
 pub(super) fn normalize_path_for_request_key(path: &Path, key_root: Option<&Path>) -> String {
     if let Some(root) = key_root {
         if let Ok(relative) = path.strip_prefix(root) {
-            let relative = zccache::core::path::normalize_for_key(relative);
+            let relative = crate::core::path::normalize_for_key(relative);
             if relative.is_empty() {
                 return REQUEST_ROOT_MARKER.to_string();
             }
             return format!("{REQUEST_ROOT_MARKER}/{relative}");
         }
     }
-    zccache::core::path::normalize_for_key(path)
+    crate::core::path::normalize_for_key(path)
 }
 
 pub(super) fn normalize_request_path_value(value: &str, key_root: Option<&Path>) -> Option<String> {
@@ -132,7 +132,7 @@ pub(super) fn normalize_cc_prefix_map_arg_for_key(
 }
 
 pub(super) fn same_key_path(left: &Path, right: &Path) -> bool {
-    zccache::core::path::normalize_for_key(left) == zccache::core::path::normalize_for_key(right)
+    crate::core::path::normalize_for_key(left) == crate::core::path::normalize_for_key(right)
 }
 
 pub(super) fn has_ffile_prefix_map_for_old(args: &[String], old: &Path) -> bool {
@@ -146,8 +146,8 @@ pub(super) fn has_ffile_prefix_map_for_old(args: &[String], old: &Path) -> bool 
 
 pub(super) fn compiler_supports_ffile_prefix_map(compiler_path: &Path) -> bool {
     matches!(
-        zccache::compiler::detect_family(&compiler_path.to_string_lossy()),
-        zccache::compiler::CompilerFamily::Clang | zccache::compiler::CompilerFamily::Gcc
+        crate::compiler::detect_family(&compiler_path.to_string_lossy()),
+        crate::compiler::CompilerFamily::Clang | crate::compiler::CompilerFamily::Gcc
     )
 }
 
@@ -300,9 +300,9 @@ pub(super) fn request_fingerprint(
     key_root: Option<&Path>,
     client_env: Option<&[(String, String)]>,
 ) -> ContentHash {
-    let mut h = zccache::hash::StreamHasher::new();
+    let mut h = crate::hash::StreamHasher::new();
     h.update(b"zccache-request-v2\0");
-    let compiler = zccache::core::path::normalize_for_key(compiler);
+    let compiler = crate::core::path::normalize_for_key(compiler);
     h.update(compiler.as_bytes());
     h.update(&[0]);
     let mut i = 0;
@@ -423,7 +423,7 @@ pub(super) fn request_cache_resolved_inputs(
 }
 
 pub(super) fn request_cache_inputs_fresh_since(
-    journal: &zccache::fscache::ChangeJournal,
+    journal: &crate::fscache::ChangeJournal,
     paths: &[NormalizedPath],
     since: Clock,
 ) -> bool {
@@ -471,7 +471,7 @@ pub(super) fn request_cache_artifact_matches(
         file_hashes.push((path, hash));
     }
 
-    let artifact_key = zccache::depgraph::compute_artifact_key(
+    let artifact_key = crate::depgraph::compute_artifact_key(
         &entry.context_key,
         &mut file_hashes,
         Some(root.as_path()),
@@ -492,11 +492,11 @@ pub(super) fn request_cache_artifact_matches(
 
 pub(super) fn strict_paths_mode_from_client_env(
     client_env: Option<&[(String, String)]>,
-) -> Result<zccache::compiler::strict_paths::StrictPathsMode, String> {
+) -> Result<crate::compiler::strict_paths::StrictPathsMode, String> {
     let Some(env) = client_env else {
-        return Ok(zccache::compiler::strict_paths::StrictPathsMode::Off);
+        return Ok(crate::compiler::strict_paths::StrictPathsMode::Off);
     };
-    zccache::compiler::strict_paths::StrictPathsMode::from_env_vars(
+    crate::compiler::strict_paths::StrictPathsMode::from_env_vars(
         env.iter()
             .map(|(key, value)| (key.as_str(), value.as_str())),
     )

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -12,14 +12,14 @@ pub(super) static ARTIFACT_PERSIST_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 impl DaemonServer {
     /// Create a new daemon server bound to the given endpoint, using the
-    /// configured cache directory (resolved via [`zccache::core::config::default_cache_dir`]).
+    /// configured cache directory (resolved via [`crate::core::config::default_cache_dir`]).
     ///
     /// Production callers should use this. Tests that need to isolate their
     /// cache directory must use [`Self::bind_with_cache_dir`] instead — this
     /// reads `ZCCACHE_CACHE_DIR` from a process-global env, which races when
     /// multiple tests run in parallel.
-    pub fn bind(endpoint: &str) -> Result<Self, zccache::ipc::IpcError> {
-        Self::bind_with_cache_dir(endpoint, &zccache::core::config::default_cache_dir())
+    pub fn bind(endpoint: &str) -> Result<Self, crate::ipc::IpcError> {
+        Self::bind_with_cache_dir(endpoint, &crate::core::config::default_cache_dir())
     }
 
     /// Create a new daemon server bound to the given endpoint, rooted at an
@@ -27,13 +27,13 @@ impl DaemonServer {
     /// parallel tests can each operate in isolation.
     pub fn bind_with_cache_dir(
         endpoint: &str,
-        cache_dir: &zccache::core::NormalizedPath,
-    ) -> Result<Self, zccache::ipc::IpcError> {
+        cache_dir: &crate::core::NormalizedPath,
+    ) -> Result<Self, crate::ipc::IpcError> {
         let listener = IpcListener::bind(endpoint)?;
         let shutdown = Arc::new(Notify::new());
         let now = now_secs();
         let instance = SERVER_INSTANCE.fetch_add(1, Ordering::Relaxed);
-        let artifact_dir = zccache::core::config::artifacts_dir_from_cache_dir(cache_dir);
+        let artifact_dir = crate::core::config::artifacts_dir_from_cache_dir(cache_dir);
         std::fs::create_dir_all(&artifact_dir).ok();
 
         // Artifact loading is deferred to a background task in run() so the
@@ -41,9 +41,9 @@ impl DaemonServer {
         let artifacts: DashMap<String, CachedArtifact> = DashMap::new();
 
         // Open the bincode-backed artifact index for fast startup + persistence.
-        let index_path = zccache::core::config::index_path_from_cache_dir(cache_dir);
+        let index_path = crate::core::config::index_path_from_cache_dir(cache_dir);
         let artifact_store = ArtifactStore::open(&index_path).map_err(|e| {
-            zccache::ipc::IpcError::Io(std::io::Error::other(format!(
+            crate::ipc::IpcError::Io(std::io::Error::other(format!(
                 "failed to open artifact index at {}: {e}",
                 index_path.display()
             )))
@@ -58,9 +58,9 @@ impl DaemonServer {
         // corrupt snapshot falls back to an empty cache (the
         // `MetadataCache::lookup` stat-verify safety net still guards
         // correctness on every subsequent lookup).
-        let metadata_path = zccache::core::config::metadata_path_from_cache_dir(cache_dir);
+        let metadata_path = crate::core::config::metadata_path_from_cache_dir(cache_dir);
         let cache_system =
-            match zccache::fscache::MetadataCache::load_from_disk(metadata_path.as_path()) {
+            match crate::fscache::MetadataCache::load_from_disk(metadata_path.as_path()) {
                 Ok(metadata) => {
                     let loaded = metadata.len();
                     if loaded > 0 {
@@ -101,7 +101,7 @@ impl DaemonServer {
                 artifact_dir,
                 metadata_path,
                 depfile_tmpdir: {
-                    let dir = zccache::core::config::depfile_dir_from_cache_dir(cache_dir)
+                    let dir = crate::core::config::depfile_dir_from_cache_dir(cache_dir)
                         .join(format!("{}-{instance}", std::process::id()));
                     std::fs::create_dir_all(&dir).ok();
                     dir
@@ -115,7 +115,7 @@ impl DaemonServer {
                 compiler_hash_cache: CompilerHashCache::new(),
                 watched_raw_dirs: DashMap::new(),
                 pch_source_map: DashMap::new(),
-                journal: CompileJournal::new(zccache::core::config::log_dir_from_cache_dir(
+                journal: CompileJournal::new(crate::core::config::log_dir_from_cache_dir(
                     cache_dir,
                 )),
                 in_flight_bytes: AtomicUsize::new(0),
@@ -141,7 +141,7 @@ impl DaemonServer {
     ///
     /// Must be called before `run()` (while this is the only Arc holder).
     /// Marks the graph as persisted because it was restored from disk.
-    pub fn set_dep_graph(&mut self, graph: zccache::depgraph::DepGraph) {
+    pub fn set_dep_graph(&mut self, graph: crate::depgraph::DepGraph) {
         let state =
             Arc::get_mut(&mut self.state).expect("set_dep_graph must be called before run()");
         state.dep_graph = graph;
@@ -150,7 +150,7 @@ impl DaemonServer {
 
     /// Record a load-time depgraph warning to mirror into per-session logs.
     ///
-    /// Called by the daemon's startup path after [`zccache::depgraph::classify_load`]
+    /// Called by the daemon's startup path after [`crate::depgraph::classify_load`]
     /// returns a non-`Loaded` outcome that warrants surfacing (version
     /// mismatch, corruption, I/O error). The warning is appended to each
     /// session's log file at `SessionStart` so a cold fallback caused by a

--- a/crates/zccache/src/daemon/server/mod.rs
+++ b/crates/zccache/src/daemon/server/mod.rs
@@ -13,17 +13,17 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, Notify};
-use zccache::artifact::{ArtifactIndex, ArtifactStore};
-use zccache::core::NormalizedPath;
-use zccache::depgraph::{
+use crate::artifact::{ArtifactIndex, ArtifactStore};
+use crate::core::NormalizedPath;
+use crate::depgraph::{
     CompileContext, ContextKey, DepGraph, DepfileStrategy, SessionId, SessionManager,
     SystemIncludeCache, UserDepFlags,
 };
-use zccache::fscache::{CacheSystem, Clock};
-use zccache::hash::ContentHash;
-use zccache::ipc::{IpcConnection, IpcListener};
-use zccache::protocol::{ArtifactData, ArtifactOutput, ArtifactPayload, Request, Response};
-use zccache::watcher::{NotifyWatcher, SettleBuffer, SettledEvent};
+use crate::fscache::{CacheSystem, Clock};
+use crate::hash::ContentHash;
+use crate::ipc::{IpcConnection, IpcListener};
+use crate::protocol::{ArtifactData, ArtifactOutput, ArtifactPayload, Request, Response};
+use crate::watcher::{NotifyWatcher, SettleBuffer, SettledEvent};
 
 use super::compile_journal::{extract_outcome, CompileJournal, JournalContext, JournalEntry};
 use super::fingerprint::FingerprintManager;

--- a/crates/zccache/src/daemon/server/rsp_cache.rs
+++ b/crates/zccache/src/daemon/server/rsp_cache.rs
@@ -96,8 +96,8 @@ pub(super) fn expand_rsp_recursive(
     seen: &mut HashSet<NormalizedPath>,
     dependencies: &mut Vec<RspDependency>,
     depth: usize,
-) -> Result<Vec<String>, zccache::compiler::response_file::ResponseFileError> {
-    use zccache::compiler::response_file::{parse_response_file_content, ResponseFileError};
+) -> Result<Vec<String>, crate::compiler::response_file::ResponseFileError> {
+    use crate::compiler::response_file::{parse_response_file_content, ResponseFileError};
 
     const MAX_RSP_DEPTH: usize = 10;
 

--- a/crates/zccache/src/daemon/server/run.rs
+++ b/crates/zccache/src/daemon/server/run.rs
@@ -13,7 +13,7 @@ impl DaemonServer {
     ///
     /// `idle_timeout_secs`: if non-zero, the daemon shuts down after this many
     /// seconds with no client activity. Pass 0 to disable.
-    pub async fn run(&mut self, idle_timeout_secs: u64) -> Result<(), zccache::ipc::IpcError> {
+    pub async fn run(&mut self, idle_timeout_secs: u64) -> Result<(), crate::ipc::IpcError> {
         tracing::info!(
             persist_workers = self.state.persist_semaphore.available_permits(),
             "daemon server running"
@@ -28,7 +28,7 @@ impl DaemonServer {
             index_writer_handle = Some(tokio::spawn(run_index_writer(rx, store, shutdown)));
         }
 
-        let cache_dir = zccache::core::config::default_cache_dir();
+        let cache_dir = crate::core::config::default_cache_dir();
         let temp_root = std::env::temp_dir();
 
         // Clean up legacy log backup directory (Bug 7).
@@ -50,10 +50,10 @@ impl DaemonServer {
 
         // Remove legacy temp-root state from older builds before starting the daemon.
         {
-            let cleaned = zccache::core::config::cleanup_legacy_temp_root_state(
+            let cleaned = crate::core::config::cleanup_legacy_temp_root_state(
                 &temp_root,
                 &cache_dir,
-                zccache::ipc::is_process_alive,
+                crate::ipc::is_process_alive,
             );
             if cleaned > 0 {
                 tracing::info!(cleaned, "cleaned legacy temp-root zccache state");
@@ -63,7 +63,7 @@ impl DaemonServer {
         // Clean up stale depfile directories from dead daemon instances.
         {
             let cleaned =
-                zccache::core::config::cleanup_stale_depfile_dirs(zccache::ipc::is_process_alive);
+                crate::core::config::cleanup_stale_depfile_dirs(crate::ipc::is_process_alive);
             if cleaned > 0 {
                 tracing::info!(cleaned, "cleaned stale depfile directories");
             }
@@ -140,8 +140,8 @@ impl DaemonServer {
         // Start memory eviction background task.
         {
             let state = Arc::clone(&self.state);
-            let budget = zccache::core::config::Config::default().max_memory_bytes;
-            let interval_secs = zccache::core::config::Config::default().eviction_interval_secs;
+            let budget = crate::core::config::Config::default().max_memory_bytes;
+            let interval_secs = crate::core::config::Config::default().eviction_interval_secs;
             tokio::spawn(async move {
                 loop {
                     tokio::time::sleep(std::time::Duration::from_secs(interval_secs)).await;
@@ -182,8 +182,8 @@ impl DaemonServer {
         // Start disk artifact GC background task.
         {
             let state = Arc::clone(&self.state);
-            let max_cache_size = zccache::core::config::Config::default().max_cache_size;
-            let interval_secs = zccache::core::config::Config::default().disk_gc_interval_secs;
+            let max_cache_size = crate::core::config::Config::default().max_cache_size;
+            let interval_secs = crate::core::config::Config::default().disk_gc_interval_secs;
             tokio::spawn(async move {
                 // Run once immediately at startup to reclaim excess disk from Bug 5.
                 {
@@ -230,11 +230,11 @@ impl DaemonServer {
             tokio::spawn(async move {
                 loop {
                     tokio::time::sleep(std::time::Duration::from_secs(300)).await;
-                    let path = zccache::depgraph::depgraph_file_path();
+                    let path = crate::depgraph::depgraph_file_path();
                     if let Some(parent) = path.parent() {
                         std::fs::create_dir_all(parent).ok();
                     }
-                    match zccache::depgraph::save_to_file(&state.dep_graph, &path) {
+                    match crate::depgraph::save_to_file(&state.dep_graph, &path) {
                         Ok(()) => {
                             state.dep_graph_persisted.store(true, Ordering::Release);
                             tracing::debug!("periodic depgraph save");
@@ -320,14 +320,14 @@ impl DaemonServer {
 
                     // Save depgraph to disk before exiting.
                     let start = std::time::Instant::now();
-                    let path = zccache::depgraph::depgraph_file_path();
+                    let path = crate::depgraph::depgraph_file_path();
                     if let Some(parent) = path.parent() {
                         std::fs::create_dir_all(parent).ok();
                     }
                     let (cold_ctxs, warm_ctxs, stale_ctxs) =
                         self.state.dep_graph.state_breakdown();
                     let ctxs_with_key = self.state.dep_graph.contexts_with_artifact_key();
-                    match zccache::depgraph::save_to_file(&self.state.dep_graph, &path) {
+                    match crate::depgraph::save_to_file(&self.state.dep_graph, &path) {
                         Ok(()) => {
                             self.state
                                 .dep_graph_persisted
@@ -390,7 +390,7 @@ impl DaemonServer {
     /// Initialize the file watcher pipeline:
     /// `NotifyWatcher (OS thread) → SettleBuffer (tokio task) → CacheSystem consumer (tokio task)`
     async fn start_watcher_pipeline(&self) {
-        let ignore = Arc::new(zccache::watcher::IgnoreFilter::default());
+        let ignore = Arc::new(crate::watcher::IgnoreFilter::default());
         let (watcher, raw_rx) = match NotifyWatcher::new(ignore) {
             Ok(w) => w,
             Err(e) => {

--- a/crates/zccache/src/daemon/server/rustc.rs
+++ b/crates/zccache/src/daemon/server/rustc.rs
@@ -13,31 +13,31 @@ pub(super) enum BuildContextResult {
     /// Rustc compilation.
     Rustc {
         /// The Rustc-specific context (for context key computation).
-        rustc_ctx: Box<zccache::depgraph::RustcCompileContext>,
+        rustc_ctx: Box<crate::depgraph::RustcCompileContext>,
         /// A "compatible" CompileContext for dep_graph storage (has source_file).
         compat_ctx: CompileContext,
         /// Parsed args for extern crate info, output path derivation, etc.
-        rustc_args: Box<zccache::depgraph::RustcParsedArgs>,
+        rustc_args: Box<crate::depgraph::RustcParsedArgs>,
     },
 }
 
 pub(super) fn build_compile_context(
-    compilation: &zccache::compiler::CacheableCompilation,
+    compilation: &crate::compiler::CacheableCompilation,
     cwd: &Path,
     system_includes: &[NormalizedPath],
     client_env: &[(String, String)],
     compiler_hash_cache: &CompilerHashCache,
 ) -> BuildContextResult {
-    if compilation.family == zccache::compiler::CompilerFamily::Rustc {
+    if compilation.family == crate::compiler::CompilerFamily::Rustc {
         return build_rustc_compile_context(compilation, cwd, client_env, compiler_hash_cache);
     }
 
     // Dispatch to the correct parser based on compiler family.
     let parsed = match compilation.family {
-        zccache::compiler::CompilerFamily::Msvc => {
-            zccache::depgraph::msvc_args::parse_msvc_args(&compilation.original_args, cwd)
+        crate::compiler::CompilerFamily::Msvc => {
+            crate::depgraph::msvc_args::parse_msvc_args(&compilation.original_args, cwd)
         }
-        _ => zccache::depgraph::args::parse_gnu_args(&compilation.original_args, cwd),
+        _ => crate::depgraph::args::parse_gnu_args(&compilation.original_args, cwd),
     };
     let dep_flags = parsed.dep_flags.clone();
     let mut ctx = CompileContext::from_parsed_args(parsed);
@@ -64,18 +64,18 @@ pub(super) fn build_compile_context(
 
 /// Build compile context for a Rustc invocation.
 pub(super) fn build_rustc_compile_context(
-    compilation: &zccache::compiler::CacheableCompilation,
+    compilation: &crate::compiler::CacheableCompilation,
     cwd: &Path,
     client_env: &[(String, String)],
     compiler_hash_cache: &CompilerHashCache,
 ) -> BuildContextResult {
-    let rustc_args = zccache::depgraph::parse_rustc_args(&compilation.original_args, cwd);
+    let rustc_args = crate::depgraph::parse_rustc_args(&compilation.original_args, cwd);
 
     // Hash the rustc binary for compiler version identity.
     // Different rustc versions produce different output for the same source.
     let compiler_hash = compiler_hash_cache.get_or_hash(&compilation.compiler);
 
-    let rustc_ctx = zccache::depgraph::RustcCompileContext::from_parsed_args(
+    let rustc_ctx = crate::depgraph::RustcCompileContext::from_parsed_args(
         &rustc_args,
         client_env,
         compiler_hash,
@@ -104,10 +104,10 @@ pub(super) fn build_rustc_compile_context(
 /// Parses rustc's dep-info file which has multiple rules (one per output target),
 /// all sharing the same dependencies. Extracts the unique set of source file deps.
 pub(super) fn scan_rustc_deps(
-    rustc_args: &zccache::depgraph::RustcParsedArgs,
+    rustc_args: &crate::depgraph::RustcParsedArgs,
     source_path: &Path,
     cwd: &Path,
-) -> zccache::depgraph::ScanResult {
+) -> crate::depgraph::ScanResult {
     let mut result = if rustc_args.emit_types.iter().any(|t| t == "dep-info") {
         let name = rustc_args.crate_name.as_deref().unwrap_or("unknown");
         let ext_suffix = rustc_args.extra_filename.as_deref().unwrap_or("");
@@ -117,21 +117,21 @@ pub(super) fn scan_rustc_deps(
             if let Ok(content) = std::fs::read_to_string(&depfile_path) {
                 parse_rustc_depinfo(&content, source_path, cwd)
             } else {
-                zccache::depgraph::ScanResult {
+                crate::depgraph::ScanResult {
                     resolved: Vec::new(),
                     unresolved: Vec::new(),
                     has_computed: false,
                 }
             }
         } else {
-            zccache::depgraph::ScanResult {
+            crate::depgraph::ScanResult {
                 resolved: Vec::new(),
                 unresolved: Vec::new(),
                 has_computed: false,
             }
         }
     } else {
-        zccache::depgraph::ScanResult {
+        crate::depgraph::ScanResult {
             resolved: Vec::new(),
             unresolved: Vec::new(),
             has_computed: false,
@@ -167,7 +167,7 @@ pub(super) fn parse_rustc_depinfo(
     content: &str,
     source_path: &Path,
     cwd: &Path,
-) -> zccache::depgraph::ScanResult {
+) -> crate::depgraph::ScanResult {
     let mut deps = std::collections::HashSet::new();
 
     for line in content.lines() {
@@ -248,7 +248,7 @@ pub(super) fn parse_rustc_depinfo(
     }
     resolved.sort();
 
-    zccache::depgraph::ScanResult {
+    crate::depgraph::ScanResult {
         resolved,
         unresolved: Vec::new(),
         has_computed: false,
@@ -269,7 +269,7 @@ pub(super) struct RustcOutputFile {
 }
 
 pub(super) fn rustc_expected_output_paths(
-    rustc_args: &zccache::depgraph::RustcParsedArgs,
+    rustc_args: &crate::depgraph::RustcParsedArgs,
     primary_output_path: &Path,
     cwd: &Path,
 ) -> Vec<NormalizedPath> {
@@ -299,7 +299,7 @@ pub(super) fn rustc_expected_output_paths(
 
 /// Collect output file metadata from a rustc compilation without reading bytes.
 pub(super) fn collect_rustc_output_files(
-    rustc_args: &zccache::depgraph::RustcParsedArgs,
+    rustc_args: &crate::depgraph::RustcParsedArgs,
     primary_output_path: &Path,
     cwd: &Path,
 ) -> Vec<RustcOutputFile> {
@@ -418,8 +418,8 @@ pub(super) fn rust_args_have_remap_for_old(args: &[String], old: &Path) -> bool 
 }
 
 pub(super) fn compiler_is_rustc_like(compiler_path: &Path) -> bool {
-    zccache::compiler::detect_family(&compiler_path.to_string_lossy())
-        == zccache::compiler::CompilerFamily::Rustc
+    crate::compiler::detect_family(&compiler_path.to_string_lossy())
+        == crate::compiler::CompilerFamily::Rustc
 }
 
 pub(super) fn rustc_request_key_root(
@@ -464,7 +464,7 @@ pub(super) fn rust_remap_gate(
     let Some(root) = worktree_root else {
         return RustRemapGate::Missing;
     };
-    let root_key = zccache::core::path::normalize_for_key(root.as_path());
+    let root_key = crate::core::path::normalize_for_key(root.as_path());
     let root_child_prefix = format!("{root_key}/");
     let mut saw_malformed = false;
     let mut saw_external = false;
@@ -479,7 +479,7 @@ pub(super) fn rust_remap_gate(
             saw_malformed = true;
             continue;
         }
-        let old_key = zccache::core::path::normalize_for_key(old_path);
+        let old_key = crate::core::path::normalize_for_key(old_path);
         if old_key == root_key {
             return RustRemapGate::Ok;
         }

--- a/crates/zccache/src/daemon/server/session.rs
+++ b/crates/zccache/src/daemon/server/session.rs
@@ -13,7 +13,7 @@ pub(super) async fn handle_session_start(
     journal_path: Option<NormalizedPath>,
     profile: bool,
 ) -> Response {
-    let session_config = zccache::depgraph::SessionConfig {
+    let session_config = crate::depgraph::SessionConfig {
         client_pid,
         working_dir: working_dir.into(),
         log_file,
@@ -62,7 +62,7 @@ pub(super) async fn handle_session_start(
 pub(super) fn record_session_stat(
     sessions: &SessionManager,
     session_id: &SessionId,
-    f: impl FnOnce(&mut zccache::depgraph::SessionStatsTracker),
+    f: impl FnOnce(&mut crate::depgraph::SessionStatsTracker),
 ) {
     sessions.mutate(session_id, |session| {
         if let Some(ref mut tracker) = session.stats_tracker {

--- a/crates/zccache/src/daemon/server/state.rs
+++ b/crates/zccache/src/daemon/server/state.rs
@@ -42,7 +42,7 @@ pub(super) struct SharedState {
     /// Written on flush (`Clear`) and shutdown (`Shutdown`); read at
     /// daemon startup so warm-side daemons spawned after `soldr load`
     /// start with their fast path already populated instead of an
-    /// empty `DashMap`. See `zccache::fscache::persistence`.
+    /// empty `DashMap`. See `crate::fscache::persistence`.
     pub(super) metadata_path: NormalizedPath,
     /// Temporary directory for injected depfiles.
     pub(super) depfile_tmpdir: NormalizedPath,

--- a/crates/zccache/src/daemon/server/tests/cache_trim.rs
+++ b/crates/zccache/src/daemon/server/tests/cache_trim.rs
@@ -9,7 +9,7 @@ use super::super::*;
 fn test_context_key(source: &str) -> ContextKey {
     CompileContext {
         source_file: source.into(),
-        include_search: zccache::depgraph::IncludeSearchPaths::default(),
+        include_search: crate::depgraph::IncludeSearchPaths::default(),
         defines: Vec::new(),
         flags: Vec::new(),
         force_includes: Vec::new(),
@@ -180,7 +180,7 @@ fn request_cache_resolved_inputs_requires_cross_root_shareable_entry() {
 
 #[test]
 fn request_cache_inputs_fresh_since_uses_journal_tracking() {
-    let journal = zccache::fscache::ChangeJournal::new();
+    let journal = crate::fscache::ChangeJournal::new();
     let path: NormalizedPath = "/tmp/request-cache-input.cc".into();
     let clock = journal.current_clock();
 

--- a/crates/zccache/src/daemon/server/tests/compiler_hash.rs
+++ b/crates/zccache/src/daemon/server/tests/compiler_hash.rs
@@ -80,16 +80,16 @@ fn rustc_context_build_reuses_compiler_hash_cache() {
         "-o".into(),
         output.to_string_lossy().into_owned(),
     ];
-    let compilation = zccache::compiler::CacheableCompilation {
+    let compilation = crate::compiler::CacheableCompilation {
         compiler: compiler.clone().into(),
-        family: zccache::compiler::CompilerFamily::Rustc,
+        family: crate::compiler::CompilerFamily::Rustc,
         source_file: source.clone().into(),
         output_file: output.into(),
         original_args: std::sync::Arc::from(args),
         unknown_flags: Vec::new(),
     };
     let cache = CompilerHashCache::new();
-    let expected_hash = zccache::hash::hash_file(&compiler).ok();
+    let expected_hash = crate::hash::hash_file(&compiler).ok();
 
     let first = build_rustc_compile_context(&compilation, tmp.path(), &[], &cache);
     let second = build_rustc_compile_context(&compilation, tmp.path(), &[], &cache);

--- a/crates/zccache/src/daemon/server/tests/link_cache.rs
+++ b/crates/zccache/src/daemon/server/tests/link_cache.rs
@@ -69,7 +69,7 @@ async fn link_cache_hit_restores_sibling_side_effects() {
     std::fs::write(&input, b"fake object").unwrap();
 
     let _cache_dir = CacheDirEnvGuard::set(&tmp.path().join("zccache-cache"));
-    let server = DaemonServer::bind(&zccache::ipc::unique_test_endpoint()).unwrap();
+    let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
     let args = vec![
         "-o".to_string(),
         output.to_string_lossy().into_owned(),

--- a/crates/zccache/src/daemon/server/tests/mod.rs
+++ b/crates/zccache/src/daemon/server/tests/mod.rs
@@ -28,8 +28,8 @@ pub(super) struct CacheDirEnvGuard {
 
 impl CacheDirEnvGuard {
     pub(super) fn set(path: &Path) -> Self {
-        let previous = std::env::var_os(zccache::core::config::CACHE_DIR_ENV);
-        std::env::set_var(zccache::core::config::CACHE_DIR_ENV, path);
+        let previous = std::env::var_os(crate::core::config::CACHE_DIR_ENV);
+        std::env::set_var(crate::core::config::CACHE_DIR_ENV, path);
         Self { previous }
     }
 }
@@ -37,8 +37,8 @@ impl CacheDirEnvGuard {
 impl Drop for CacheDirEnvGuard {
     fn drop(&mut self) {
         match &self.previous {
-            Some(previous) => std::env::set_var(zccache::core::config::CACHE_DIR_ENV, previous),
-            None => std::env::remove_var(zccache::core::config::CACHE_DIR_ENV),
+            Some(previous) => std::env::set_var(crate::core::config::CACHE_DIR_ENV, previous),
+            None => std::env::remove_var(crate::core::config::CACHE_DIR_ENV),
         }
     }
 }

--- a/crates/zccache/src/daemon/server/tests/server_ipc.rs
+++ b/crates/zccache/src/daemon/server/tests/server_ipc.rs
@@ -8,7 +8,7 @@ use super::super::*;
 use super::CacheDirEnvGuard;
 
 async fn start_daemon() -> (String, tokio::task::JoinHandle<()>, Arc<Notify>) {
-    let endpoint = zccache::ipc::unique_test_endpoint();
+    let endpoint = crate::ipc::unique_test_endpoint();
     let mut server = DaemonServer::bind(&endpoint).unwrap();
     let shutdown = server.shutdown_handle();
     let handle = tokio::spawn(async move {
@@ -20,10 +20,10 @@ async fn start_daemon() -> (String, tokio::task::JoinHandle<()>, Arc<Notify>) {
 #[tokio::test]
 #[ignore] // integration-level: starts real daemon with IPC + file watcher
 async fn test_server_ping_pong() {
-    zccache::test_support::test_timeout(async {
+    crate::test_support::test_timeout(async {
         let (endpoint, server_task, shutdown) = start_daemon().await;
 
-        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
         client.send(&Request::Ping).await.unwrap();
         let resp: Option<Response> = client.recv().await.unwrap();
         assert_eq!(resp, Some(Response::Pong));
@@ -37,10 +37,10 @@ async fn test_server_ping_pong() {
 #[tokio::test]
 #[ignore] // integration-level: starts real daemon with IPC + file watcher
 async fn test_server_shutdown_request() {
-    zccache::test_support::test_timeout(async {
+    crate::test_support::test_timeout(async {
         let (endpoint, server_task, shutdown) = start_daemon().await;
 
-        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
         client.send(&Request::Shutdown).await.unwrap();
         let resp: Option<Response> = client.recv().await.unwrap();
         assert_eq!(resp, Some(Response::ShuttingDown));
@@ -54,10 +54,10 @@ async fn test_server_shutdown_request() {
 #[tokio::test]
 #[ignore] // integration-level: starts real daemon with IPC + file watcher
 async fn test_server_clear_empty() {
-    zccache::test_support::test_timeout(async {
+    crate::test_support::test_timeout(async {
         let (endpoint, server_task, shutdown) = start_daemon().await;
 
-        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
         client.send(&Request::Clear).await.unwrap();
         let resp: Option<Response> = client.recv().await.unwrap();
         match resp {
@@ -83,10 +83,10 @@ async fn test_server_clear_empty() {
 #[tokio::test]
 #[ignore] // integration-level: starts real daemon with IPC + file watcher
 async fn test_server_status() {
-    zccache::test_support::test_timeout(async {
+    crate::test_support::test_timeout(async {
         let (endpoint, server_task, shutdown) = start_daemon().await;
 
-        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
         client.send(&Request::Status).await.unwrap();
         let resp: Option<Response> = client.recv().await.unwrap();
         assert!(matches!(resp, Some(Response::Status(_))));
@@ -103,11 +103,11 @@ async fn test_server_status() {
 #[tokio::test]
 #[ignore] // integration-level: starts real daemon with IPC + compiler
 async fn cli_session_lifecycle() {
-    let clang = match zccache::test_support::find_clang() {
+    let clang = match crate::test_support::find_clang() {
         Some(p) => p,
         None => return,
     };
-    zccache::test_support::test_timeout(async move {
+    crate::test_support::test_timeout(async move {
         let tmp = tempfile::tempdir().unwrap();
         let src = tmp.path().join("hello.cpp");
         let obj = tmp.path().join("hello.o");
@@ -121,7 +121,7 @@ async fn cli_session_lifecycle() {
         .unwrap();
 
         let (endpoint, server_handle, shutdown) = start_daemon().await;
-        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
 
         // session-start
         client
@@ -257,9 +257,9 @@ async fn cli_session_lifecycle() {
 #[tokio::test]
 #[ignore] // integration-level: starts real daemon with IPC
 async fn cli_session_end_invalid_id() {
-    zccache::test_support::test_timeout(async {
+    crate::test_support::test_timeout(async {
         let (endpoint, server_handle, shutdown) = start_daemon().await;
-        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
 
         client
             .send(&Request::SessionEnd {
@@ -295,9 +295,9 @@ async fn cli_session_end_invalid_id() {
 #[tokio::test]
 #[ignore] // integration-level: starts real daemon with IPC
 async fn cli_session_end_unknown_uuid_is_idempotent() {
-    zccache::test_support::test_timeout(async {
+    crate::test_support::test_timeout(async {
         let (endpoint, server_handle, shutdown) = start_daemon().await;
-        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
 
         client
             .send(&Request::SessionEnd {
@@ -335,14 +335,14 @@ async fn cli_session_end_unknown_uuid_is_idempotent() {
 #[tokio::test]
 #[ignore] // integration-level: starts real daemon with IPC
 async fn cli_compile_unknown_uuid_is_idempotent() {
-    zccache::test_support::test_timeout(async {
+    crate::test_support::test_timeout(async {
         let tmp = tempfile::tempdir().unwrap();
         // Use an isolated cache dir so we don't clash with any
         // production daemon writing the global index blob.
         let _cache_dir = CacheDirEnvGuard::set(&tmp.path().join("zccache-cache"));
 
         let (endpoint, server_handle, shutdown) = start_daemon().await;
-        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
 
         let cwd = tmp.path().to_string_lossy().into_owned();
 
@@ -384,12 +384,12 @@ async fn cli_compile_unknown_uuid_is_idempotent() {
 #[tokio::test]
 #[ignore] // integration-level: starts real daemon with IPC + compiler
 async fn cli_clear_resets_cache() {
-    let clang = match zccache::test_support::find_clang() {
+    let clang = match crate::test_support::find_clang() {
         Some(p) => p,
         None => return,
     };
 
-    zccache::test_support::test_timeout(async move {
+    crate::test_support::test_timeout(async move {
         let tmp = tempfile::tempdir().unwrap();
         let src = tmp.path().join("clear_test.cpp");
         let obj = tmp.path().join("clear_test.o");
@@ -398,7 +398,7 @@ async fn cli_clear_resets_cache() {
         std::fs::write(&src, "int main() { return 0; }\n").unwrap();
 
         let (endpoint, server_handle, shutdown) = start_daemon().await;
-        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
 
         // Start session
         client
@@ -544,12 +544,12 @@ async fn cli_clear_resets_cache() {
 #[tokio::test]
 #[ignore] // integration-level: starts real daemon with IPC + compiler
 async fn cli_multi_file_compilation_runs_directly() {
-    let clang = match zccache::test_support::find_clang() {
+    let clang = match crate::test_support::find_clang() {
         Some(p) => p,
         None => return,
     };
 
-    zccache::test_support::test_timeout(async move {
+    crate::test_support::test_timeout(async move {
         let tmp = tempfile::tempdir().unwrap();
         let src_a = tmp.path().join("multi_a.cpp");
         let src_b = tmp.path().join("multi_b.cpp");
@@ -559,7 +559,7 @@ async fn cli_multi_file_compilation_runs_directly() {
         std::fs::write(&src_b, "int bar() { return 2; }\n").unwrap();
 
         let (endpoint, server_handle, shutdown) = start_daemon().await;
-        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
 
         // Start session
         client

--- a/crates/zccache/src/daemon/server/util.rs
+++ b/crates/zccache/src/daemon/server/util.rs
@@ -32,7 +32,7 @@ pub(super) fn hash_file_via_cache(state: &SharedState, path: &Path) -> Option<Co
         return Some(hash);
     }
     // Fall back to direct hash
-    zccache::hash::hash_file(path).ok()
+    crate::hash::hash_file(path).ok()
 }
 
 /// Hash a file using the CacheSystem's metadata cache.

--- a/crates/zccache/src/daemon/side_effect.rs
+++ b/crates/zccache/src/daemon/side_effect.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::path::Path;
 use std::time::SystemTime;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Maximum size (bytes) for a single side-effect file. Larger files are skipped.
 const MAX_SIDE_EFFECT_SIZE: u64 = 50 * 1024 * 1024; // 50 MB

--- a/crates/zccache/src/daemon/stats.rs
+++ b/crates/zccache/src/daemon/stats.rs
@@ -330,7 +330,7 @@ impl PhaseProfiler {
     /// Return a snapshot of raw phase-timing totals (not averaged).
     ///
     /// Used by [`super::server`]'s `SessionEnd` / `SessionStats` handlers
-    /// to populate [`zccache::protocol::SessionStats::phase_profile`]. The
+    /// to populate [`crate::protocol::SessionStats::phase_profile`]. The
     /// caller divides by `hit_count` / `miss_count` if it wants averages —
     /// the existing [`snapshot`] does that, but pre-averaged values can't
     /// be summed if a downstream tool ever wants to combine results from
@@ -425,7 +425,7 @@ pub struct MissPhases {
 
 /// Raw phase-timing totals — symmetric to [`ProfileSnapshot`] but without
 /// the per-compile averaging. The struct layout intentionally mirrors
-/// [`zccache::protocol::PhaseProfileSummary`] so the conversion is
+/// [`crate::protocol::PhaseProfileSummary`] so the conversion is
 /// field-for-field.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PhaseTotals {
@@ -449,7 +449,7 @@ pub struct PhaseTotals {
     pub total_miss_ns: u64,
 }
 
-impl From<PhaseTotals> for zccache::protocol::PhaseProfileSummary {
+impl From<PhaseTotals> for crate::protocol::PhaseProfileSummary {
     fn from(t: PhaseTotals) -> Self {
         Self {
             hit_count: t.hit_count,
@@ -691,7 +691,7 @@ mod tests {
         assert_eq!(totals.total_miss_ns, 10_000);
 
         // From-impl preserves every field for the protocol crate.
-        let summary: zccache::protocol::PhaseProfileSummary = totals.clone().into();
+        let summary: crate::protocol::PhaseProfileSummary = totals.clone().into();
         assert_eq!(summary.hit_count, totals.hit_count);
         assert_eq!(summary.miss_count, totals.miss_count);
         assert_eq!(summary.parse_args_ns, totals.parse_args_ns);

--- a/crates/zccache/src/daemon/trampoline.rs
+++ b/crates/zccache/src/daemon/trampoline.rs
@@ -377,7 +377,7 @@ fn detach_stdio_windows() {
 /// against the canonicalized cache dir to be robust to symlinks and
 /// short-name (8.3) tilde expansion on Windows.
 fn exe_is_under_runtime_binaries(exe: &Path) -> bool {
-    let runtime_dir = zccache::core::config::default_cache_dir().join("runtime-binaries");
+    let runtime_dir = crate::core::config::default_cache_dir().join("runtime-binaries");
     let runtime_canon = match fs::canonicalize(&runtime_dir) {
         Ok(p) => p,
         Err(_) => return false,

--- a/crates/zccache/src/depgraph/args.rs
+++ b/crates/zccache/src/depgraph/args.rs
@@ -6,7 +6,7 @@
 use std::path::Path;
 
 use super::search_paths::IncludeSearchPaths;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Dependency-generation flags already present in the user's compiler args.
 #[derive(Debug, Clone, Default)]

--- a/crates/zccache/src/depgraph/compile_commands.rs
+++ b/crates/zccache/src/depgraph/compile_commands.rs
@@ -3,7 +3,7 @@
 //! Supports both the `"command"` (string) and `"arguments"` (array)
 //! forms as defined by the clang compilation database specification.
 
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use serde::Deserialize;
 
@@ -91,7 +91,7 @@ pub fn parse_compile_commands_json(json: &str) -> Result<Vec<CompileCommand>, se
 #[cfg(test)]
 mod tests {
     use std::path::Path;
-    use zccache::core::NormalizedPath;
+    use crate::core::NormalizedPath;
 
     use super::*;
 

--- a/crates/zccache/src/depgraph/context.rs
+++ b/crates/zccache/src/depgraph/context.rs
@@ -6,9 +6,9 @@
 
 use std::path::Path;
 
-use zccache::core::path::normalize_for_key;
-use zccache::core::NormalizedPath;
-use zccache::hash::ContentHash;
+use crate::core::path::normalize_for_key;
+use crate::core::NormalizedPath;
+use crate::hash::ContentHash;
 
 use super::args::ParsedArgs;
 use super::rustc_args::RustcParsedArgs;
@@ -643,11 +643,11 @@ pub fn compute_rustc_artifact_key_with_root<P: AsRef<Path> + Ord>(
 
 #[cfg(test)]
 mod tests {
-    use zccache::core::NormalizedPath;
+    use crate::core::NormalizedPath;
 
     use super::*;
-    use super::args::UserDepFlags;
-    use super::rustc_args::ExternCrate;
+    use super::super::args::UserDepFlags;
+    use super::super::rustc_args::ExternCrate;
 
     fn make_context(source: &str, user_dirs: &[&str], defines: &[&str]) -> CompileContext {
         CompileContext {
@@ -751,21 +751,21 @@ mod tests {
         let mut file_hashes_a = vec![
             (
                 NormalizedPath::from(r"C:\work\include\foo.h"),
-                zccache::hash::hash_bytes(b"header"),
+                crate::hash::hash_bytes(b"header"),
             ),
             (
                 NormalizedPath::from(r"C:\work\src\main.cpp"),
-                zccache::hash::hash_bytes(b"source"),
+                crate::hash::hash_bytes(b"source"),
             ),
         ];
         let mut file_hashes_b = vec![
             (
                 NormalizedPath::from("c:/work/include/foo.h"),
-                zccache::hash::hash_bytes(b"header"),
+                crate::hash::hash_bytes(b"header"),
             ),
             (
                 NormalizedPath::from("c:/work/src/main.cpp"),
-                zccache::hash::hash_bytes(b"source"),
+                crate::hash::hash_bytes(b"source"),
             ),
         ];
 
@@ -809,8 +809,8 @@ mod tests {
         let ctx = make_context("/src/a.c", &[], &[]);
         let ck = ctx.context_key();
 
-        let hash_a = zccache::hash::hash_bytes(b"content A");
-        let hash_b = zccache::hash::hash_bytes(b"content B");
+        let hash_a = crate::hash::hash_bytes(b"content A");
+        let hash_b = crate::hash::hash_bytes(b"content B");
 
         let ak1 =
             compute_artifact_key(&ck, &mut [(NormalizedPath::from("/src/a.c"), hash_a)], None);
@@ -824,7 +824,7 @@ mod tests {
         let ctx = make_context("/src/a.c", &[], &[]);
         let ck = ctx.context_key();
 
-        let hash = zccache::hash::hash_bytes(b"content");
+        let hash = crate::hash::hash_bytes(b"content");
 
         let ak1 = compute_artifact_key(&ck, &mut [(NormalizedPath::from("/src/a.c"), hash)], None);
         let ak2 = compute_artifact_key(&ck, &mut [(NormalizedPath::from("/src/a.c"), hash)], None);
@@ -836,8 +836,8 @@ mod tests {
         let ctx = make_context("/src/a.c", &[], &[]);
         let ck = ctx.context_key();
 
-        let h1 = zccache::hash::hash_bytes(b"content 1");
-        let h2 = zccache::hash::hash_bytes(b"content 2");
+        let h1 = crate::hash::hash_bytes(b"content 1");
+        let h2 = crate::hash::hash_bytes(b"content 2");
 
         let ak1 = compute_artifact_key(
             &ck,
@@ -950,21 +950,21 @@ mod tests {
         let mut hashes_a = vec![
             (
                 NormalizedPath::from("/workspace-a/include/foo.h"),
-                zccache::hash::hash_bytes(b"header"),
+                crate::hash::hash_bytes(b"header"),
             ),
             (
                 NormalizedPath::from("/workspace-a/src/main.cpp"),
-                zccache::hash::hash_bytes(b"source"),
+                crate::hash::hash_bytes(b"source"),
             ),
         ];
         let mut hashes_b = vec![
             (
                 NormalizedPath::from("/workspace-b/include/foo.h"),
-                zccache::hash::hash_bytes(b"header"),
+                crate::hash::hash_bytes(b"header"),
             ),
             (
                 NormalizedPath::from("/workspace-b/src/main.cpp"),
-                zccache::hash::hash_bytes(b"source"),
+                crate::hash::hash_bytes(b"source"),
             ),
         ];
 
@@ -1270,7 +1270,7 @@ mod tests {
     fn rustc_compiler_hash_affects_key() {
         let ctx1 = make_rustc_context("/src/lib.rs", "2021");
         let mut ctx2 = make_rustc_context("/src/lib.rs", "2021");
-        ctx2.compiler_hash = Some(zccache::hash::hash_bytes(b"rustc-1.94.1"));
+        ctx2.compiler_hash = Some(crate::hash::hash_bytes(b"rustc-1.94.1"));
         assert_ne!(
             ctx1.context_key(),
             ctx2.context_key(),
@@ -1281,9 +1281,9 @@ mod tests {
     #[test]
     fn rustc_different_compiler_versions_different_key() {
         let mut ctx1 = make_rustc_context("/src/lib.rs", "2021");
-        ctx1.compiler_hash = Some(zccache::hash::hash_bytes(b"rustc-1.94.1"));
+        ctx1.compiler_hash = Some(crate::hash::hash_bytes(b"rustc-1.94.1"));
         let mut ctx2 = make_rustc_context("/src/lib.rs", "2021");
-        ctx2.compiler_hash = Some(zccache::hash::hash_bytes(b"rustc-1.94.2"));
+        ctx2.compiler_hash = Some(crate::hash::hash_bytes(b"rustc-1.94.2"));
         assert_ne!(ctx1.context_key(), ctx2.context_key());
     }
 
@@ -1364,9 +1364,9 @@ mod tests {
         let ctx = make_rustc_context("/src/lib.rs", "2021");
         let ck = ctx.context_key();
 
-        let src_hash = zccache::hash::hash_bytes(b"source");
-        let ext_hash_a = zccache::hash::hash_bytes(b"extern A");
-        let ext_hash_b = zccache::hash::hash_bytes(b"extern B");
+        let src_hash = crate::hash::hash_bytes(b"source");
+        let ext_hash_a = crate::hash::hash_bytes(b"extern A");
+        let ext_hash_b = crate::hash::hash_bytes(b"extern B");
 
         let ak1 = compute_rustc_artifact_key(
             &ck,
@@ -1497,8 +1497,8 @@ mod tests {
         let ctx = make_rustc_context("/src/lib.rs", "2021");
         let ck = ctx.context_key();
 
-        let src_hash = zccache::hash::hash_bytes(b"source");
-        let ext_hash = zccache::hash::hash_bytes(b"extern");
+        let src_hash = crate::hash::hash_bytes(b"source");
+        let ext_hash = crate::hash::hash_bytes(b"extern");
 
         let ak1 = compute_rustc_artifact_key(
             &ck,
@@ -1524,9 +1524,9 @@ mod tests {
         let ck_b = ctx_b.context_key_with_root(Some(root_b));
         assert_eq!(ck_a, ck_b);
 
-        let src_hash = zccache::hash::hash_bytes(b"source");
-        let dep_hash = zccache::hash::hash_bytes(b"dependency");
-        let ext_hash = zccache::hash::hash_bytes(b"extern");
+        let src_hash = crate::hash::hash_bytes(b"source");
+        let dep_hash = crate::hash::hash_bytes(b"dependency");
+        let ext_hash = crate::hash::hash_bytes(b"extern");
 
         let ak_a = compute_rustc_artifact_key_with_root(
             &ck_a,

--- a/crates/zccache/src/depgraph/depfile.rs
+++ b/crates/zccache/src/depgraph/depfile.rs
@@ -16,7 +16,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::args::UserDepFlags;
 use super::scanner::ScanResult;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Errors that can occur while parsing a `.d` file.
 #[derive(Debug)]
@@ -337,7 +337,7 @@ pub(crate) fn strip_win_prefix(path: NormalizedPath) -> NormalizedPath {
 
 #[cfg(test)]
 mod tests {
-    use zccache::core::NormalizedPath;
+    use crate::core::NormalizedPath;
 
     use super::*;
     use tempfile::TempDir;

--- a/crates/zccache/src/depgraph/graph.rs
+++ b/crates/zccache/src/depgraph/graph.rs
@@ -9,8 +9,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
-use zccache::core::NormalizedPath;
-use zccache::hash::ContentHash;
+use crate::core::NormalizedPath;
+use crate::hash::ContentHash;
 
 use super::context::{
     compute_artifact_key, compute_context_key, ArtifactKey, CompileContext, ContextKey,
@@ -858,7 +858,7 @@ impl DepGraph {
     /// Returns the context keys for all successfully registered entries.
     pub fn ingest_compile_commands(
         &self,
-        commands: &[crate::compile_commands::CompileCommand],
+        commands: &[super::compile_commands::CompileCommand],
         system_includes: &[NormalizedPath],
     ) -> Vec<ContextKey> {
         commands
@@ -892,9 +892,9 @@ impl Default for DepGraph {
 mod tests {
     use super::*;
     use std::path::Path;
-    use zccache::core::NormalizedPath;
+    use crate::core::NormalizedPath;
 
-    use super::search_paths::IncludeSearchPaths;
+    use super::super::search_paths::IncludeSearchPaths;
 
     fn make_ctx(source: &str) -> CompileContext {
         CompileContext {
@@ -916,7 +916,7 @@ mod tests {
     }
 
     fn dummy_hash(path: &Path) -> Option<ContentHash> {
-        Some(zccache::hash::hash_bytes(path.to_string_lossy().as_bytes()))
+        Some(crate::hash::hash_bytes(path.to_string_lossy().as_bytes()))
     }
 
     #[test]
@@ -980,7 +980,7 @@ mod tests {
         let is_fresh = |p: &Path| p != Path::new("/src/a.c");
         let changed_source_hash = |p: &Path| -> Option<ContentHash> {
             if p == Path::new("/src/a.c") {
-                Some(zccache::hash::hash_bytes(b"source-modified"))
+                Some(crate::hash::hash_bytes(b"source-modified"))
             } else {
                 dummy_hash(p)
             }
@@ -1009,7 +1009,7 @@ mod tests {
         let is_fresh = |p: &Path| p != Path::new("/inc/b.h");
         let changed_b_hash = |p: &Path| -> Option<ContentHash> {
             if p == Path::new("/inc/b.h") {
-                Some(zccache::hash::hash_bytes(b"b-modified"))
+                Some(crate::hash::hash_bytes(b"b-modified"))
             } else {
                 dummy_hash(p)
             }
@@ -1136,7 +1136,7 @@ mod tests {
         // HeadersChanged and the entry flips to Stale.
         let changed_h_hash = |p: &Path| -> Option<ContentHash> {
             if p == Path::new("/h.h") {
-                Some(zccache::hash::hash_bytes(b"h-modified"))
+                Some(crate::hash::hash_bytes(b"h-modified"))
             } else {
                 dummy_hash(p)
             }
@@ -1208,10 +1208,10 @@ mod tests {
             has_computed: false,
         };
 
-        let hash_v1 = |_: &Path| Some(zccache::hash::hash_bytes(b"v1"));
+        let hash_v1 = |_: &Path| Some(crate::hash::hash_bytes(b"v1"));
         let ak1 = graph.update(&key, scan.clone(), hash_v1).unwrap();
 
-        let hash_v2 = |_: &Path| Some(zccache::hash::hash_bytes(b"v2"));
+        let hash_v2 = |_: &Path| Some(crate::hash::hash_bytes(b"v2"));
         let ak2 = graph.update(&key, scan, hash_v2).unwrap();
 
         assert_ne!(ak1, ak2);
@@ -1221,8 +1221,8 @@ mod tests {
     fn store_and_get_file_includes() {
         let graph = DepGraph::new();
         let path = NormalizedPath::from("/src/foo.h");
-        let includes = vec![super::IncludeDirective {
-            kind: super::IncludeKind::Quoted,
+        let includes = vec![super::super::IncludeDirective {
+            kind: super::super::IncludeKind::Quoted,
             path: "bar.h".to_string(),
             line: 1,
         }];
@@ -1284,7 +1284,7 @@ mod tests {
             }
         ]"#;
 
-        let commands = super::compile_commands::parse_compile_commands_json(json).unwrap();
+        let commands = super::super::compile_commands::parse_compile_commands_json(json).unwrap();
         let graph = DepGraph::new();
         let system_includes = vec![NormalizedPath::from("/usr/include")];
         let keys = graph.ingest_compile_commands(&commands, &system_includes);
@@ -1308,7 +1308,7 @@ mod tests {
             }
         ]"#;
 
-        let commands = super::compile_commands::parse_compile_commands_json(json).unwrap();
+        let commands = super::super::compile_commands::parse_compile_commands_json(json).unwrap();
         let graph = DepGraph::new();
         let system_includes = vec![NormalizedPath::from("/usr/include")];
         let keys = graph.ingest_compile_commands(&commands, &system_includes);
@@ -1339,7 +1339,7 @@ mod tests {
             }
         ]"#;
 
-        let commands = super::compile_commands::parse_compile_commands_json(json).unwrap();
+        let commands = super::super::compile_commands::parse_compile_commands_json(json).unwrap();
         let graph = DepGraph::new();
         // /usr/include is already in -isystem, should not be added twice.
         let system_includes = vec![NormalizedPath::from("/usr/include")];
@@ -1431,7 +1431,7 @@ mod tests {
             if p == Path::new("/inc/b.h") {
                 None
             } else {
-                Some(zccache::hash::hash_bytes(p.to_string_lossy().as_bytes()))
+                Some(crate::hash::hash_bytes(p.to_string_lossy().as_bytes()))
             }
         };
         let result = graph.update(&key, scan, partial_hash);
@@ -1533,8 +1533,8 @@ mod tests {
         graph.update(&key, scan, dummy_hash);
 
         // Populate the files map for both the force-include and resolved include.
-        let empty_includes = vec![super::IncludeDirective {
-            kind: super::IncludeKind::Quoted,
+        let empty_includes = vec![super::super::IncludeDirective {
+            kind: super::super::IncludeKind::Quoted,
             path: "stdafx.h".to_string(),
             line: 1,
         }];
@@ -1547,8 +1547,8 @@ mod tests {
         // Also add an unreferenced file that should be evicted.
         graph.store_file_includes(
             NormalizedPath::from("/stale/old.h"),
-            vec![super::IncludeDirective {
-                kind: super::IncludeKind::Quoted,
+            vec![super::super::IncludeDirective {
+                kind: super::super::IncludeKind::Quoted,
                 path: "gone.h".to_string(),
                 line: 1,
             }],

--- a/crates/zccache/src/depgraph/msvc_args.rs
+++ b/crates/zccache/src/depgraph/msvc_args.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use super::args::{ParsedArgs, UserDepFlags};
 use super::search_paths::IncludeSearchPaths;

--- a/crates/zccache/src/depgraph/rustc_args.rs
+++ b/crates/zccache/src/depgraph/rustc_args.rs
@@ -6,7 +6,7 @@
 
 use std::path::Path;
 
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// A parsed `--extern name=path` declaration.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -385,7 +385,7 @@ fn resolve_path(path: &str, cwd: &Path) -> NormalizedPath {
 
 #[cfg(test)]
 mod tests {
-    use zccache::core::NormalizedPath;
+    use crate::core::NormalizedPath;
 
     use super::*;
 

--- a/crates/zccache/src/depgraph/scanner.rs
+++ b/crates/zccache/src/depgraph/scanner.rs
@@ -7,7 +7,7 @@
 use std::path::Path;
 
 use super::search_paths::IncludeSearchPaths;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// The kind of `#include` directive.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/zccache/src/depgraph/search_paths.rs
+++ b/crates/zccache/src/depgraph/search_paths.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Ordered include search paths, preserving -I/-isystem/-iquote/-idirafter.
 ///

--- a/crates/zccache/src/depgraph/session.rs
+++ b/crates/zccache/src/depgraph/session.rs
@@ -11,7 +11,7 @@ use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use super::context::ContextKey;
 
@@ -438,9 +438,9 @@ mod tests {
         let mgr = SessionManager::new(Duration::from_secs(900));
         let id = mgr.create(test_config());
 
-        let ctx = super::context::CompileContext {
+        let ctx = super::super::context::CompileContext {
             source_file: "/src/main.c".into(),
-            include_search: super::search_paths::IncludeSearchPaths::default(),
+            include_search: super::super::search_paths::IncludeSearchPaths::default(),
             defines: Vec::new(),
             flags: Vec::new(),
             force_includes: Vec::new(),
@@ -459,9 +459,9 @@ mod tests {
     #[test]
     fn add_context_nonexistent_session_returns_false() {
         let mgr = SessionManager::new(Duration::from_secs(900));
-        let ctx = super::context::CompileContext {
+        let ctx = super::super::context::CompileContext {
             source_file: "/src/main.c".into(),
-            include_search: super::search_paths::IncludeSearchPaths::default(),
+            include_search: super::super::search_paths::IncludeSearchPaths::default(),
             defines: Vec::new(),
             flags: Vec::new(),
             force_includes: Vec::new(),

--- a/crates/zccache/src/depgraph/show_includes.rs
+++ b/crates/zccache/src/depgraph/show_includes.rs
@@ -184,7 +184,7 @@ fn split_lines_preserving(data: &[u8]) -> Vec<(&[u8], &[u8])> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::depfile::strip_win_prefix;
+    use super::super::depfile::strip_win_prefix;
 
     #[test]
     fn parse_basic() {

--- a/crates/zccache/src/depgraph/snapshot/mod.rs
+++ b/crates/zccache/src/depgraph/snapshot/mod.rs
@@ -19,13 +19,13 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use dashmap::DashMap;
 use rayon::prelude::*;
 use rkyv::{Archive, Deserialize, Serialize};
-use zccache::core::NormalizedPath;
-use zccache::hash::ContentHash;
+use crate::core::NormalizedPath;
+use crate::hash::ContentHash;
 
-use super::super::context::{ArtifactKey, CompileContext, ContextKey};
-use super::super::graph::{ContextEntry, ContextState, DepGraph, FileEntry};
-use super::super::scanner::{IncludeDirective, IncludeKind};
-use super::super::search_paths::IncludeSearchPaths;
+use super::context::{ArtifactKey, CompileContext, ContextKey};
+use super::graph::{ContextEntry, ContextState, DepGraph, FileEntry};
+use super::scanner::{IncludeDirective, IncludeKind};
+use super::search_paths::IncludeSearchPaths;
 
 mod persistence;
 #[cfg(test)]

--- a/crates/zccache/src/depgraph/snapshot/persistence.rs
+++ b/crates/zccache/src/depgraph/snapshot/persistence.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use rkyv::Deserialize;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use super::super::graph::DepGraph;
 
@@ -20,7 +20,7 @@ const SERIALIZE_SCRATCH: usize = 4096;
 /// Returns the default path for the depgraph snapshot file.
 #[must_use]
 pub fn depgraph_file_path() -> NormalizedPath {
-    zccache::core::config::depgraph_dir().join("depgraph.bin")
+    crate::core::config::depgraph_dir().join("depgraph.bin")
 }
 
 /// Save the dependency graph to disk with atomic write.

--- a/crates/zccache/src/depgraph/snapshot/tests/behavioral.rs
+++ b/crates/zccache/src/depgraph/snapshot/tests/behavioral.rs
@@ -7,8 +7,8 @@
 use std::time::Duration;
 
 use tempfile::TempDir;
-use zccache::core::NormalizedPath;
-use zccache::hash::ContentHash;
+use crate::core::NormalizedPath;
+use crate::hash::ContentHash;
 
 use super::{always_fresh, dummy_hash, make_ctx, test_path};
 use super::super::super::context::CompileContext;
@@ -55,15 +55,15 @@ fn loaded_graph_serves_cache_hits() {
     let hashes: std::collections::HashMap<NormalizedPath, ContentHash> = [
         (
             NormalizedPath::from("/src/main.cpp"),
-            zccache::hash::hash_bytes(b"src"),
+            crate::hash::hash_bytes(b"src"),
         ),
         (
             NormalizedPath::from("/include/a.h"),
-            zccache::hash::hash_bytes(b"a"),
+            crate::hash::hash_bytes(b"a"),
         ),
         (
             NormalizedPath::from("/pch.h"),
-            zccache::hash::hash_bytes(b"pch"),
+            crate::hash::hash_bytes(b"pch"),
         ),
     ]
     .into_iter()
@@ -126,7 +126,7 @@ fn context_key_consistent_after_roundtrip() {
     let original_key = ctx.context_key();
     graph.register(ctx);
 
-    let hash = zccache::hash::hash_bytes(b"x");
+    let hash = crate::hash::hash_bytes(b"x");
     let hashes: std::collections::HashMap<NormalizedPath, ContentHash> = [
         (NormalizedPath::from("/src/main.cpp"), hash),
         (NormalizedPath::from("/fi/pch.h"), hash),
@@ -205,7 +205,7 @@ fn unicode_paths_roundtrip() {
         unknown_flags: Vec::new(),
     };
     let key = graph.register(ctx);
-    let hash = zccache::hash::hash_bytes(b"x");
+    let hash = crate::hash::hash_bytes(b"x");
     let hashes: std::collections::HashMap<NormalizedPath, ContentHash> =
         [(NormalizedPath::from(unicode_source), hash)]
             .into_iter()
@@ -372,13 +372,13 @@ fn overlapping_contexts_roundtrip() {
     let hashes: std::collections::HashMap<NormalizedPath, ContentHash> = [
         (
             NormalizedPath::from("/src/a.cpp"),
-            zccache::hash::hash_bytes(b"a"),
+            crate::hash::hash_bytes(b"a"),
         ),
         (
             NormalizedPath::from("/src/b.cpp"),
-            zccache::hash::hash_bytes(b"b"),
+            crate::hash::hash_bytes(b"b"),
         ),
-        (shared_header.clone(), zccache::hash::hash_bytes(b"shared")),
+        (shared_header.clone(), crate::hash::hash_bytes(b"shared")),
     ]
     .into_iter()
     .collect();

--- a/crates/zccache/src/depgraph/snapshot/tests/mod.rs
+++ b/crates/zccache/src/depgraph/snapshot/tests/mod.rs
@@ -4,11 +4,11 @@
 //! See the directory's `README.md` for the layout overview.
 
 use tempfile::TempDir;
-use zccache::core::NormalizedPath;
-use zccache::hash::ContentHash;
+use crate::core::NormalizedPath;
+use crate::hash::ContentHash;
 
-use super::super::super::context::CompileContext;
-use super::super::super::search_paths::IncludeSearchPaths;
+use super::super::context::CompileContext;
+use super::super::search_paths::IncludeSearchPaths;
 
 mod behavioral;
 mod persistence;
@@ -35,7 +35,7 @@ pub(super) fn make_ctx(source: &str) -> CompileContext {
 /// Hash a path's bytes — used by tests that don't care what the hash is,
 /// only that it is stable per-path.
 pub(super) fn dummy_hash(path: &std::path::Path) -> Option<ContentHash> {
-    Some(zccache::hash::hash_bytes(path.to_string_lossy().as_bytes()))
+    Some(crate::hash::hash_bytes(path.to_string_lossy().as_bytes()))
 }
 
 /// Freshness oracle that always reports "no change since last scan". Used

--- a/crates/zccache/src/depgraph/snapshot/tests/round_trip.rs
+++ b/crates/zccache/src/depgraph/snapshot/tests/round_trip.rs
@@ -6,8 +6,8 @@
 //! field. Cross-cutting behavior across save/load lives in `behavioral.rs`.
 
 use tempfile::TempDir;
-use zccache::core::NormalizedPath;
-use zccache::hash::ContentHash;
+use crate::core::NormalizedPath;
+use crate::hash::ContentHash;
 
 use super::{make_ctx, test_path};
 use super::super::super::context::CompileContext;
@@ -75,9 +75,9 @@ fn populated_graph_roundtrip() {
     let key = graph.register(ctx);
 
     // Update with resolved includes and file hashes.
-    let source_hash = zccache::hash::hash_bytes(b"source content");
-    let header_hash = zccache::hash::hash_bytes(b"header content");
-    let pch_hash = zccache::hash::hash_bytes(b"pch content");
+    let source_hash = crate::hash::hash_bytes(b"source content");
+    let header_hash = crate::hash::hash_bytes(b"header content");
+    let pch_hash = crate::hash::hash_bytes(b"pch content");
     let hashes: std::collections::HashMap<NormalizedPath, ContentHash> = [
         (NormalizedPath::from("/src/main.cpp"), source_hash),
         (NormalizedPath::from("/include/header.h"), header_hash),
@@ -126,8 +126,8 @@ fn last_file_hashes_roundtrip() {
     let graph = DepGraph::new();
 
     let key = graph.register(make_ctx("/src/a.cpp"));
-    let hash1 = zccache::hash::hash_bytes(b"content1");
-    let hash2 = zccache::hash::hash_bytes(b"content2");
+    let hash1 = crate::hash::hash_bytes(b"content1");
+    let hash2 = crate::hash::hash_bytes(b"content2");
     let hashes: std::collections::HashMap<NormalizedPath, ContentHash> = [
         (NormalizedPath::from("/src/a.cpp"), hash1),
         (NormalizedPath::from("/inc/b.h"), hash2),
@@ -164,7 +164,7 @@ fn artifact_key_some_roundtrip() {
     let graph = DepGraph::new();
 
     let key = graph.register(make_ctx("/src/c.cpp"));
-    let hash = zccache::hash::hash_bytes(b"source");
+    let hash = crate::hash::hash_bytes(b"source");
     let hashes: std::collections::HashMap<NormalizedPath, ContentHash> =
         [(NormalizedPath::from("/src/c.cpp"), hash)]
             .into_iter()
@@ -389,7 +389,7 @@ fn empty_strings_roundtrip() {
     let key = graph.register(ctx);
 
     // Empty path hash.
-    let hash = zccache::hash::hash_bytes(b"");
+    let hash = crate::hash::hash_bytes(b"");
     let hashes: std::collections::HashMap<NormalizedPath, ContentHash> =
         [(NormalizedPath::from(""), hash)].into_iter().collect();
     graph.update(
@@ -422,8 +422,8 @@ fn file_hash_bytes_exact_roundtrip() {
     let graph = DepGraph::new();
 
     let key = graph.register(make_ctx("/src/a.cpp"));
-    let source_hash = zccache::hash::hash_bytes(b"specific source content 12345");
-    let header_hash = zccache::hash::hash_bytes(b"specific header content 67890");
+    let source_hash = crate::hash::hash_bytes(b"specific source content 12345");
+    let header_hash = crate::hash::hash_bytes(b"specific header content 67890");
 
     let hashes: std::collections::HashMap<NormalizedPath, ContentHash> = [
         (NormalizedPath::from("/src/a.cpp"), source_hash),

--- a/crates/zccache/src/depgraph/system_includes.rs
+++ b/crates/zccache/src/depgraph/system_includes.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Parse compiler `-v -E` output to extract system include paths.
 ///

--- a/crates/zccache/src/depgraph/watcher_support.rs
+++ b/crates/zccache/src/depgraph/watcher_support.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 
 use super::context::ContextKey;
 use super::graph::DepGraph;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Set of directories that should be watched, with tracked filenames per directory.
 ///
@@ -144,7 +144,7 @@ impl WatchSet {
 fn is_higher_priority(
     dir_a: &Path,
     dir_b: &Path,
-    search: &crate::search_paths::IncludeSearchPaths,
+    search: &super::search_paths::IncludeSearchPaths,
 ) -> bool {
     let all_dirs: Vec<&Path> = search.all_search_dirs().collect();
 
@@ -278,15 +278,15 @@ impl DepGraph {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use zccache::core::NormalizedPath;
+    use crate::core::NormalizedPath;
 
-    use super::context::CompileContext;
-    use super::scanner::ScanResult;
-    use super::search_paths::IncludeSearchPaths;
-    use zccache::hash::ContentHash;
+    use super::super::context::CompileContext;
+    use super::super::scanner::ScanResult;
+    use super::super::search_paths::IncludeSearchPaths;
+    use crate::hash::ContentHash;
 
     fn dummy_hash(path: &Path) -> Option<ContentHash> {
-        Some(zccache::hash::hash_bytes(path.to_string_lossy().as_bytes()))
+        Some(crate::hash::hash_bytes(path.to_string_lossy().as_bytes()))
     }
 
     fn make_ctx_with_search(source: &str, search: IncludeSearchPaths) -> CompileContext {
@@ -653,13 +653,13 @@ mod tests {
         graph.update(&key, scan, dummy_hash);
         assert_eq!(
             graph.get_state(&key),
-            Some(super::graph::ContextState::Warm)
+            Some(super::super::graph::ContextState::Warm)
         );
 
         assert!(graph.mark_stale(&key));
         assert_eq!(
             graph.get_state(&key),
-            Some(super::graph::ContextState::Stale)
+            Some(super::super::graph::ContextState::Stale)
         );
     }
 

--- a/crates/zccache/src/download/mod.rs
+++ b/crates/zccache/src/download/mod.rs
@@ -11,7 +11,7 @@ use reqwest::header::{
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_util::sync::CancellationToken;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DownloadOptions {
@@ -130,7 +130,7 @@ pub async fn download_to_path(
     cancel_token: CancellationToken,
 ) -> Result<Option<u64>, DownloadError> {
     let client = reqwest::Client::builder()
-        .user_agent(format!("zccache-download/{}", zccache::core::VERSION))
+        .user_agent(format!("zccache-download/{}", crate::core::VERSION))
         .build()
         .map_err(|e| DownloadError::Http(e.to_string()))?;
 
@@ -467,7 +467,7 @@ async fn download_segment(request: SegmentDownload<'_>) -> Result<u64, DownloadE
 }
 
 pub fn stable_download_id(path: &Path) -> String {
-    let key = zccache::core::normalize_for_key(path);
+    let key = crate::core::normalize_for_key(path);
     blake3::hash(key.as_bytes()).to_hex().to_string()
 }
 

--- a/crates/zccache/src/download_client/artifact.rs
+++ b/crates/zccache/src/download_client/artifact.rs
@@ -6,7 +6,7 @@ use reqwest::header::ACCEPT_ENCODING;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::io::AsyncWriteExt;
-use zccache_download::{canonical_destination, stable_download_id, DownloadOptions, DownloadPhase};
+use crate::download::{canonical_destination, stable_download_id, DownloadOptions, DownloadPhase};
 
 use super::DownloadClient;
 
@@ -414,7 +414,7 @@ fn normalize_target(path: &Path, create_parent: bool) -> Result<PathBuf, String>
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
         std::fs::canonicalize(parent).map_err(|e| e.to_string())?
     } else {
-        zccache::core::NormalizedPath::new(parent).into_path_buf()
+        crate::core::NormalizedPath::new(parent).into_path_buf()
     };
     Ok(canonical_parent.join(file_name))
 }
@@ -572,7 +572,7 @@ fn download_explicit_parts(part_urls: &[String], destination: &Path) -> Result<(
         .map_err(|e| format!("failed to create tokio runtime: {e}"))?;
     runtime.block_on(async move {
         let client = reqwest::Client::builder()
-            .user_agent(format!("zccache-download/{}", zccache::core::VERSION))
+            .user_agent(format!("zccache-download/{}", crate::core::VERSION))
             .build()
             .map_err(|e| e.to_string())?;
 
@@ -678,13 +678,13 @@ fn acquire_fetch_lock(request: &ResolvedFetchRequest) -> Result<FetchLock, Strin
 }
 
 fn fetch_lock_path(request: &ResolvedFetchRequest) -> PathBuf {
-    let mut key = zccache::core::normalize_for_key(&request.cache_path);
+    let mut key = crate::core::normalize_for_key(&request.cache_path);
     if let Some(expanded_path) = &request.expanded_path {
         key.push('\n');
-        key.push_str(&zccache::core::normalize_for_key(expanded_path));
+        key.push_str(&crate::core::normalize_for_key(expanded_path));
     }
     let hash = stable_download_id(Path::new(&key));
-    zccache::core::config::default_cache_dir()
+    crate::core::config::default_cache_dir()
         .join("downloads")
         .join("locks")
         .join(format!("{hash}.lock"))
@@ -693,7 +693,7 @@ fn fetch_lock_path(request: &ResolvedFetchRequest) -> PathBuf {
 
 fn artifact_marker_path(cache_path: &Path) -> PathBuf {
     let hash = stable_download_id(cache_path);
-    zccache::core::config::default_cache_dir()
+    crate::core::config::default_cache_dir()
         .join("downloads")
         .join("artifact-state")
         .join(format!("{hash}.json"))
@@ -702,7 +702,7 @@ fn artifact_marker_path(cache_path: &Path) -> PathBuf {
 
 fn expanded_marker_path(expanded_path: &Path) -> PathBuf {
     let hash = stable_download_id(expanded_path);
-    zccache::core::config::default_cache_dir()
+    crate::core::config::default_cache_dir()
         .join("downloads")
         .join("expanded-state")
         .join(format!("{hash}.json"))
@@ -1013,7 +1013,7 @@ mod tests {
 
     use flate2::write::GzEncoder;
     use flate2::Compression;
-    use zccache_download_daemon::DownloadDaemon;
+    use crate::download_daemon::DownloadDaemon;
 
     #[derive(Clone)]
     struct TestHttpConfig {

--- a/crates/zccache/src/download_client/mod.rs
+++ b/crates/zccache/src/download_client/mod.rs
@@ -4,12 +4,12 @@ mod artifact;
 
 use std::path::Path;
 
-use zccache::core::NormalizedPath;
-use zccache_download::{
+use crate::core::NormalizedPath;
+use crate::download::{
     canonical_destination, DownloadAttachResult, DownloadDaemonStatus, DownloadOptions,
     DownloadStatus,
 };
-use zccache_download_protocol::{Request, Response};
+use crate::download_protocol::{Request, Response};
 
 pub use artifact::{
     ArchiveFormat, DownloadSource, FetchRequest, FetchResult, FetchState, FetchStateKind,
@@ -17,11 +17,11 @@ pub use artifact::{
 };
 
 #[cfg(unix)]
-type ClientConn = zccache::ipc::IpcConnection;
+type ClientConn = crate::ipc::IpcConnection;
 #[cfg(windows)]
-type ClientConn = zccache::ipc::IpcClientConnection;
+type ClientConn = crate::ipc::IpcClientConnection;
 
-pub use zccache_download_protocol::daemon_mgmt::{
+pub use crate::download_protocol::daemon_mgmt::{
     default_endpoint, lock_file_path, read_lock_file_pid, remove_lock_file, write_lock_file,
 };
 
@@ -30,7 +30,7 @@ pub fn check_running_daemon() -> Option<u32> {
     // Verify the PID actually points at the download daemon. A bare
     // is_process_alive check would falsely accept a recycled PID inherited
     // from a restored CI cache (see issue #132).
-    if zccache::ipc::verify_pid_exe_stem(pid, "zccache-download-daemon") {
+    if crate::ipc::verify_pid_exe_stem(pid, "zccache-download-daemon") {
         Some(pid)
     } else {
         remove_lock_file();
@@ -43,13 +43,13 @@ pub fn check_running_daemon() -> Option<u32> {
 }
 
 #[cfg(unix)]
-async fn connect_client(endpoint: &str) -> Result<ClientConn, zccache::ipc::IpcError> {
-    zccache::ipc::connect(endpoint).await
+async fn connect_client(endpoint: &str) -> Result<ClientConn, crate::ipc::IpcError> {
+    crate::ipc::connect(endpoint).await
 }
 
 #[cfg(windows)]
-async fn connect_client(endpoint: &str) -> Result<ClientConn, zccache::ipc::IpcError> {
-    zccache::ipc::connect(endpoint).await
+async fn connect_client(endpoint: &str) -> Result<ClientConn, crate::ipc::IpcError> {
+    crate::ipc::connect(endpoint).await
 }
 
 fn resolve_endpoint(explicit: Option<&str>) -> String {
@@ -332,9 +332,9 @@ impl DownloadHandle {
 pub fn is_terminal(status: &DownloadStatus) -> bool {
     matches!(
         status.phase,
-        zccache_download::DownloadPhase::Completed
-            | zccache_download::DownloadPhase::Cancelled
-            | zccache_download::DownloadPhase::Failed
+        crate::download::DownloadPhase::Completed
+            | crate::download::DownloadPhase::Cancelled
+            | crate::download::DownloadPhase::Failed
     )
 }
 

--- a/crates/zccache/src/download_daemon/mod.rs
+++ b/crates/zccache/src/download_daemon/mod.rs
@@ -9,12 +9,12 @@ use std::time::Instant;
 use dashmap::DashMap;
 use tokio::sync::{watch, Notify, RwLock};
 use tokio_util::sync::CancellationToken;
-use zccache::core::NormalizedPath;
-use zccache_download::{
+use crate::core::NormalizedPath;
+use crate::download::{
     percentage, stable_download_id, DownloadDaemonStatus, DownloadOptions, DownloadPhase,
     DownloadStatus,
 };
-use zccache_download_protocol::{Request, Response};
+use crate::download_protocol::{Request, Response};
 
 #[derive(Clone)]
 struct FileLogger {
@@ -66,16 +66,16 @@ struct SharedState {
 }
 
 pub struct DownloadDaemon {
-    listener: zccache::ipc::IpcListener,
+    listener: crate::ipc::IpcListener,
     state: Arc<SharedState>,
 }
 
 impl DownloadDaemon {
-    pub fn bind(endpoint: &str) -> Result<Self, zccache::ipc::IpcError> {
-        let listener = zccache::ipc::IpcListener::bind(endpoint)?;
-        let log_path = zccache::core::config::log_dir().join("download-daemon.log");
+    pub fn bind(endpoint: &str) -> Result<Self, crate::ipc::IpcError> {
+        let listener = crate::ipc::IpcListener::bind(endpoint)?;
+        let log_path = crate::core::config::log_dir().join("download-daemon.log");
         let logger = FileLogger::new(&log_path)
-            .map_err(|e| zccache::ipc::IpcError::Io(std::io::Error::other(e.to_string())))?;
+            .map_err(|e| crate::ipc::IpcError::Io(std::io::Error::other(e.to_string())))?;
         Ok(Self {
             listener,
             state: Arc::new(SharedState {
@@ -94,7 +94,7 @@ impl DownloadDaemon {
         Arc::clone(&self.state.shutdown)
     }
 
-    pub async fn run(&mut self) -> Result<(), zccache::ipc::IpcError> {
+    pub async fn run(&mut self) -> Result<(), crate::ipc::IpcError> {
         loop {
             tokio::select! {
                 _ = self.state.shutdown.notified() => {
@@ -118,7 +118,7 @@ impl DownloadDaemon {
 
 async fn handle_connection(
     state: Arc<SharedState>,
-    mut conn: zccache::ipc::IpcConnection,
+    mut conn: crate::ipc::IpcConnection,
 ) -> Result<(), String> {
     let client_id = state.next_client_id.fetch_add(1, Ordering::Relaxed);
     let mut attached_job_id: Option<String> = None;
@@ -291,7 +291,7 @@ async fn handle_connection(
 }
 
 async fn send_terminal(
-    conn: &mut zccache::ipc::IpcConnection,
+    conn: &mut crate::ipc::IpcConnection,
     status: DownloadStatus,
 ) -> Result<(), String> {
     match status.phase {
@@ -317,7 +317,7 @@ fn daemon_status(state: &SharedState) -> DownloadDaemonStatus {
         .map(|entry| entry.active_clients.load(Ordering::Relaxed) as u64)
         .sum();
     DownloadDaemonStatus {
-        version: zccache::core::VERSION.to_string(),
+        version: crate::core::VERSION.to_string(),
         active_downloads: state.jobs.len() as u64,
         connected_clients,
         uptime_secs: state.start_time.elapsed().as_secs(),
@@ -353,7 +353,7 @@ async fn attach_job(
         return Ok((existing, false));
     }
 
-    let metadata_dir = zccache::core::config::default_cache_dir()
+    let metadata_dir = crate::core::config::default_cache_dir()
         .join("downloads")
         .join(&download_id);
     let initial_status = if destination.exists() && !options.force {
@@ -443,7 +443,7 @@ fn spawn_download_worker(state: Arc<SharedState>, job: Arc<DownloadJob>, options
             },
         );
 
-        let result = zccache_download::download_to_path(
+        let result = crate::download::download_to_path(
             &url,
             &destination,
             &metadata_dir,
@@ -466,7 +466,7 @@ fn spawn_download_worker(state: Arc<SharedState>, job: Arc<DownloadJob>, options
                     .logger
                     .log(&format!("download completed id={} bytes={total}", job.id));
             }
-            Err(zccache_download::DownloadError::Cancelled) => {
+            Err(crate::download::DownloadError::Cancelled) => {
                 status.phase = DownloadPhase::Cancelled;
                 status.error = None;
                 state

--- a/crates/zccache/src/download_protocol/daemon_mgmt.rs
+++ b/crates/zccache/src/download_protocol/daemon_mgmt.rs
@@ -1,11 +1,11 @@
 //! Shared daemon-management utilities used by both the download client and
 //! the download daemon binary (lock-file helpers, default endpoint, etc.).
 
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Return the default IPC endpoint for the download daemon.
 pub fn default_endpoint() -> String {
-    if let Some(cache_dir) = zccache::core::config::cache_dir_override() {
+    if let Some(cache_dir) = crate::core::config::cache_dir_override() {
         return endpoint_for_cache_dir(&cache_dir);
     }
 
@@ -34,14 +34,14 @@ fn endpoint_for_cache_dir(cache_dir: &std::path::Path) -> String {
     }
     #[cfg(windows)]
     {
-        let suffix = zccache::core::stable_path_id(cache_dir);
+        let suffix = crate::core::stable_path_id(cache_dir);
         format!(r"\\.\pipe\zccache-download-{suffix}")
     }
 }
 
 /// Path to the daemon PID lock file.
 pub fn lock_file_path() -> NormalizedPath {
-    zccache::core::config::default_cache_dir().join("download-daemon.lock")
+    crate::core::config::default_cache_dir().join("download-daemon.lock")
 }
 
 /// Write the daemon PID to the lock file.
@@ -81,8 +81,8 @@ mod tests {
     impl EnvGuard {
         fn set_cache_dir(value: &std::path::Path) -> Self {
             let lock = ENV_LOCK.lock().unwrap();
-            let previous = std::env::var_os(zccache::core::config::CACHE_DIR_ENV);
-            std::env::set_var(zccache::core::config::CACHE_DIR_ENV, value);
+            let previous = std::env::var_os(crate::core::config::CACHE_DIR_ENV);
+            std::env::set_var(crate::core::config::CACHE_DIR_ENV, value);
             Self {
                 _lock: lock,
                 previous,
@@ -93,8 +93,8 @@ mod tests {
     impl Drop for EnvGuard {
         fn drop(&mut self) {
             match &self.previous {
-                Some(value) => std::env::set_var(zccache::core::config::CACHE_DIR_ENV, value),
-                None => std::env::remove_var(zccache::core::config::CACHE_DIR_ENV),
+                Some(value) => std::env::set_var(crate::core::config::CACHE_DIR_ENV, value),
+                None => std::env::remove_var(crate::core::config::CACHE_DIR_ENV),
             }
         }
     }
@@ -117,7 +117,7 @@ mod tests {
         #[cfg(windows)]
         {
             assert!(endpoint.starts_with(r"\\.\pipe\zccache-download-"));
-            assert!(endpoint.ends_with(&zccache::core::stable_path_id(&cache_dir)));
+            assert!(endpoint.ends_with(&crate::core::stable_path_id(&cache_dir)));
         }
 
         assert_eq!(lock_file_path(), cache_dir.join("download-daemon.lock"));

--- a/crates/zccache/src/download_protocol/mod.rs
+++ b/crates/zccache/src/download_protocol/mod.rs
@@ -3,8 +3,8 @@
 pub mod daemon_mgmt;
 
 use serde::{Deserialize, Serialize};
-use zccache::core::NormalizedPath;
-use zccache_download::{DownloadDaemonStatus, DownloadOptions, DownloadStatus};
+use crate::core::NormalizedPath;
+use crate::download::{DownloadDaemonStatus, DownloadOptions, DownloadStatus};
 
 pub const PROTOCOL_VERSION: u32 = 1;
 

--- a/crates/zccache/src/fingerprint/error.rs
+++ b/crates/zccache/src/fingerprint/error.rs
@@ -1,4 +1,4 @@
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Errors that can occur during fingerprint operations.
 #[derive(Debug, thiserror::Error)]

--- a/crates/zccache/src/fingerprint/file_lock.rs
+++ b/crates/zccache/src/fingerprint/file_lock.rs
@@ -2,7 +2,7 @@ use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::path::Path;
 use std::time::{Duration, Instant};
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 // fs2::FileExt trait methods are called via UFCS below to avoid
 // ambiguity with std::fs::File inherent methods added in Rust 1.89.

--- a/crates/zccache/src/fingerprint/hash_cache.rs
+++ b/crates/zccache/src/fingerprint/hash_cache.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use rayon::prelude::*;
 
@@ -22,7 +22,7 @@ pub fn compute_aggregate_hash(files: &[ScannedFile]) -> Result<String> {
     let contents = contents?;
 
     // Phase 2: Hash sequentially to preserve order-dependent aggregate hash.
-    let mut hasher = zccache::hash::StreamHasher::new();
+    let mut hasher = crate::hash::StreamHasher::new();
     // Domain separation.
     hasher.update(b"zccache-fingerprint-v1");
 
@@ -175,7 +175,7 @@ impl HashCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::scan;
+    use super::super::scan;
     use std::fs;
     use tempfile::TempDir;
 
@@ -414,7 +414,7 @@ mod tests {
         let cache = HashCache::new(cache_dir.path().join("fp.json"));
         let err = cache.mark_success().unwrap_err();
         assert!(
-            matches!(err, super::error::FingerprintError::NoPendingData { .. }),
+            matches!(err, super::super::error::FingerprintError::NoPendingData { .. }),
             "expected NoPendingData, got: {err}"
         );
     }

--- a/crates/zccache/src/fingerprint/persist.rs
+++ b/crates/zccache/src/fingerprint/persist.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::time::SystemTime;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/zccache/src/fingerprint/scan.rs
+++ b/crates/zccache/src/fingerprint/scan.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::path::Path;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use globset::{Glob, GlobSet, GlobSetBuilder};
 

--- a/crates/zccache/src/fingerprint/two_layer.rs
+++ b/crates/zccache/src/fingerprint/two_layer.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::Path;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use rayon::prelude::*;
 
@@ -73,7 +73,7 @@ impl TwoLayerCache {
                         Ok((file.relative.clone(), cached_entry.clone(), false))
                     } else {
                         // Layer 2: mtime or size differ → hash the file.
-                        let hash = zccache::hash::hash_file(&file.absolute)?;
+                        let hash = crate::hash::hash_file(&file.absolute)?;
                         let hash_hex = hash.to_hex();
                         let content_changed = hash_hex != cached_entry.hash;
                         Ok((
@@ -88,7 +88,7 @@ impl TwoLayerCache {
                     }
                 } else {
                     // New file not in cache.
-                    let hash = zccache::hash::hash_file(&file.absolute)?;
+                    let hash = crate::hash::hash_file(&file.absolute)?;
                     Ok((
                         file.relative.clone(),
                         FileEntry {
@@ -198,7 +198,7 @@ impl TwoLayerCache {
             .map(|file| {
                 let mtime = persist::mtime_ns(&file.absolute)?;
                 let size = persist::file_size(&file.absolute)?;
-                let hash = zccache::hash::hash_file(&file.absolute)?;
+                let hash = crate::hash::hash_file(&file.absolute)?;
                 Ok((
                     file.relative.clone(),
                     FileEntry {
@@ -216,7 +216,7 @@ impl TwoLayerCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::{persist, scan};
+    use super::super::{persist, scan};
     use std::fs;
     use tempfile::TempDir;
 
@@ -439,7 +439,7 @@ mod tests {
         let cache = TwoLayerCache::new(cache_dir.path().join("fp.json"));
         let err = cache.mark_success().unwrap_err();
         assert!(
-            matches!(err, super::error::FingerprintError::NoPendingData { .. }),
+            matches!(err, super::super::error::FingerprintError::NoPendingData { .. }),
             "expected NoPendingData, got: {err}"
         );
     }
@@ -450,7 +450,7 @@ mod tests {
         let cache = TwoLayerCache::new(cache_dir.path().join("fp.json"));
         let err = cache.mark_failure().unwrap_err();
         assert!(
-            matches!(err, super::error::FingerprintError::NoPendingData { .. }),
+            matches!(err, super::super::error::FingerprintError::NoPendingData { .. }),
             "expected NoPendingData, got: {err}"
         );
     }

--- a/crates/zccache/src/fscache/cache_system.rs
+++ b/crates/zccache/src/fscache/cache_system.rs
@@ -7,9 +7,9 @@
 
 use super::clock::{ChangeJournal, Clock};
 use super::metadata::MetadataCache;
-use zccache::core::NormalizedPath;
-use zccache::core::Result;
-use zccache::hash::ContentHash;
+use crate::core::NormalizedPath;
+use crate::core::Result;
+use crate::hash::ContentHash;
 
 /// Result of a clock-aware lookup.
 #[derive(Debug, Clone)]
@@ -218,7 +218,7 @@ impl Default for CacheSystem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::metadata::Confidence;
+    use super::super::metadata::Confidence;
     use std::fs;
     use std::thread;
     use std::time::Duration;
@@ -267,7 +267,7 @@ mod tests {
 
         // lookup_since with c1 → journal says no change, but no cached hash → slow path.
         let result = cache.lookup_since(&path, c1).unwrap();
-        let expected = zccache::hash::hash_bytes(b"data");
+        let expected = crate::hash::hash_bytes(b"data");
         assert_eq!(result.hash, expected);
     }
 
@@ -311,7 +311,7 @@ mod tests {
         let result = cache.lookup_since(&path, Clock::ZERO).unwrap();
 
         // Should have computed the hash.
-        let expected = zccache::hash::hash_bytes(b"hello");
+        let expected = crate::hash::hash_bytes(b"hello");
         assert_eq!(result.hash, expected);
     }
 
@@ -349,7 +349,7 @@ mod tests {
         // Lookup with old clock → journal says "changed" → full stat path.
         let r2 = cache.lookup_since(&path, Clock::ZERO).unwrap();
         assert_ne!(r1.hash, r2.hash);
-        assert_eq!(r2.hash, zccache::hash::hash_bytes(b"v2"));
+        assert_eq!(r2.hash, crate::hash::hash_bytes(b"v2"));
 
         // Lookup with new clock → journal says "not changed" → fast path.
         let r3 = cache.lookup_since(&path, c2).unwrap();
@@ -415,7 +415,7 @@ mod tests {
         // Now lookup_since should use fast path (journal says no change, hash cached).
         let r2 = cache.lookup_since(&path, clock).unwrap();
         assert_eq!(r1.hash, r2.hash);
-        assert_eq!(r2.hash, zccache::hash::hash_bytes(b"content"));
+        assert_eq!(r2.hash, crate::hash::hash_bytes(b"content"));
     }
 
     #[test]
@@ -448,7 +448,7 @@ mod tests {
             handles.push(std::thread::spawn(move || {
                 for path in &paths {
                     let result = cache.lookup_since(path, c1).unwrap();
-                    assert_eq!(result.hash, zccache::hash::hash_file(path).unwrap(),);
+                    assert_eq!(result.hash, crate::hash::hash_file(path).unwrap(),);
                 }
             }));
         }

--- a/crates/zccache/src/fscache/clock.rs
+++ b/crates/zccache/src/fscache/clock.rs
@@ -9,7 +9,7 @@ use dashmap::DashMap;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Monotonically increasing clock tick.
 ///

--- a/crates/zccache/src/fscache/metadata.rs
+++ b/crates/zccache/src/fscache/metadata.rs
@@ -3,7 +3,7 @@
 use dashmap::DashMap;
 use rayon::prelude::*;
 use std::time::{Duration, Instant, SystemTime};
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Confidence level for a cached metadata entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -167,13 +167,13 @@ impl MetadataCache {
     /// not applied. Returns `None` if the entry is missing, Low confidence,
     /// or has no cached hash.
     #[must_use]
-    pub fn get_cached_hash(&self, path: &NormalizedPath) -> Option<zccache::hash::ContentHash> {
+    pub fn get_cached_hash(&self, path: &NormalizedPath) -> Option<crate::hash::ContentHash> {
         self.entries
             .get(path)
             .and_then(|entry| match entry.confidence {
                 Confidence::High | Confidence::Medium => entry
                     .content_hash
-                    .map(zccache::hash::ContentHash::from_bytes),
+                    .map(crate::hash::ContentHash::from_bytes),
                 Confidence::Low => None,
             })
     }
@@ -191,7 +191,7 @@ impl MetadataCache {
     pub fn get_cached_hash_if_stat_valid(
         &self,
         path: &NormalizedPath,
-    ) -> Option<zccache::hash::ContentHash> {
+    ) -> Option<crate::hash::ContentHash> {
         let entry = self.entries.get(path)?;
         match entry.confidence {
             Confidence::High | Confidence::Medium => {}
@@ -199,7 +199,7 @@ impl MetadataCache {
         }
         let hash = entry
             .content_hash
-            .map(zccache::hash::ContentHash::from_bytes)?;
+            .map(crate::hash::ContentHash::from_bytes)?;
 
         // One stat syscall to verify mtime + size still match.
         let fs_meta = std::fs::metadata(path).ok()?;

--- a/crates/zccache/src/fscache/persistence.rs
+++ b/crates/zccache/src/fscache/persistence.rs
@@ -54,7 +54,7 @@ use serde::{Deserialize, Serialize};
 use std::io::Write;
 use std::path::Path;
 use std::time::{Instant, SystemTime};
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// On-disk format version for the persisted [`MetadataCache`] snapshot.
 ///
@@ -289,7 +289,7 @@ impl PersistIter for MetadataCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::metadata::Confidence;
+    use super::super::metadata::Confidence;
     use std::fs;
     use tempfile::TempDir;
 

--- a/crates/zccache/src/fscache/verify.rs
+++ b/crates/zccache/src/fscache/verify.rs
@@ -6,9 +6,9 @@
 use super::metadata::{Confidence, FileMetadata, MetadataCache};
 use std::path::Path;
 use std::time::Instant;
-use zccache::core::NormalizedPath;
-use zccache::core::Result;
-use zccache::hash::ContentHash;
+use crate::core::NormalizedPath;
+use crate::core::Result;
+use crate::hash::ContentHash;
 
 /// Result of verifying cached metadata against the current filesystem state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -54,13 +54,13 @@ impl MetadataCache {
         let normalized = NormalizedPath::from(path);
         let cached = self
             .get(&normalized)
-            .ok_or_else(|| zccache::core::Error::Cache {
+            .ok_or_else(|| crate::core::Error::Cache {
                 message: format!("path not in cache: {}", path.display()),
             })?;
 
         let fresh = match Self::stat_file(path) {
             Ok(m) => m,
-            Err(zccache::core::Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+            Err(crate::core::Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
                 return Ok(VerifyResult::Gone);
             }
             Err(e) => return Err(e),
@@ -100,9 +100,9 @@ impl MetadataCache {
         // "A wrong cache hit is catastrophic; an extra stat is cheap."
         let fresh = match Self::stat_file(path) {
             Ok(m) => m,
-            Err(zccache::core::Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+            Err(crate::core::Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
                 self.remove(&normalized);
-                return Err(zccache::core::Error::FileNotFound(path.into()));
+                return Err(crate::core::Error::FileNotFound(path.into()));
             }
             Err(e) => return Err(e),
         };
@@ -139,14 +139,14 @@ impl MetadataCache {
     /// Stat the file, hash it, insert at High confidence, return hash.
     fn hash_and_insert(&self, path: &Path) -> Result<ContentHash> {
         let pre_stat = Self::stat_file(path)?;
-        let hash = zccache::hash::hash_file(path)?;
+        let hash = crate::hash::hash_file(path)?;
         let post_stat = Self::stat_file(path)?;
 
         // TOCTOU check: if file changed during hashing, retry up to 3 times.
         if pre_stat.mtime != post_stat.mtime || pre_stat.size != post_stat.size {
             for _ in 0..3 {
                 let pre = Self::stat_file(path)?;
-                let h = zccache::hash::hash_file(path)?;
+                let h = crate::hash::hash_file(path)?;
                 let post = Self::stat_file(path)?;
                 if pre.mtime == post.mtime && pre.size == post.size {
                     self.insert(
@@ -191,7 +191,7 @@ mod tests {
     use std::thread;
     use std::time::Duration;
     use tempfile::TempDir;
-    use zccache::core::NormalizedPath;
+    use crate::core::NormalizedPath;
 
     /// Helper: create a file with given content, return its path.
     fn create_file(dir: &TempDir, name: &str, content: &str) -> NormalizedPath {
@@ -387,7 +387,7 @@ mod tests {
         assert_eq!(entry.confidence, Confidence::High);
         assert!(entry.content_hash.is_some());
 
-        let expected = zccache::hash::hash_file(&path).unwrap();
+        let expected = crate::hash::hash_file(&path).unwrap();
         assert_eq!(hash, expected);
     }
 
@@ -425,7 +425,7 @@ mod tests {
         let hash_v2 = cache.lookup(&path).unwrap();
         assert_ne!(hash_v1, hash_v2);
 
-        let expected = zccache::hash::hash_bytes(b"v2 with more content");
+        let expected = crate::hash::hash_bytes(b"v2 with more content");
         assert_eq!(hash_v2, expected);
     }
 
@@ -532,7 +532,7 @@ mod tests {
         fs::write(&path, "changed content").unwrap();
 
         let new_hash = cache.lookup(&path).unwrap();
-        let expected = zccache::hash::hash_bytes(b"changed content");
+        let expected = crate::hash::hash_bytes(b"changed content");
         assert_eq!(new_hash, expected);
     }
 
@@ -553,14 +553,14 @@ mod tests {
         // 2. Create the file
         fs::write(&path, "version 1").unwrap();
         let hash_v1 = cache.lookup(&path).unwrap();
-        assert_eq!(hash_v1, zccache::hash::hash_bytes(b"version 1"));
+        assert_eq!(hash_v1, crate::hash::hash_bytes(b"version 1"));
 
         // 3. First edit
         sleep_for_mtime();
         fs::write(&path, "version 2").unwrap();
         let hash_v2 = cache.lookup(&path).unwrap();
         assert_ne!(hash_v1, hash_v2);
-        assert_eq!(hash_v2, zccache::hash::hash_bytes(b"version 2"));
+        assert_eq!(hash_v2, crate::hash::hash_bytes(b"version 2"));
 
         // 4. Second edit
         sleep_for_mtime();
@@ -569,7 +569,7 @@ mod tests {
         assert_ne!(hash_v2, hash_v3);
         assert_eq!(
             hash_v3,
-            zccache::hash::hash_bytes(b"version 3 with extra stuff")
+            crate::hash::hash_bytes(b"version 3 with extra stuff")
         );
 
         // 5. Remove
@@ -634,7 +634,7 @@ mod tests {
 
         let cache = MetadataCache::new();
         let hash = cache.lookup(&path).unwrap();
-        assert_eq!(hash, zccache::hash::hash_bytes(b""));
+        assert_eq!(hash, crate::hash::hash_bytes(b""));
     }
 
     // ---------------------------------------------------------------

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -16,7 +16,7 @@ pub use transport::{
     connect, unique_test_endpoint, IpcConnection, IpcListener, DEFAULT_CLIENT_RECV_TIMEOUT,
 };
 
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Returns the platform-specific default IPC endpoint path.
 ///
@@ -28,7 +28,7 @@ use zccache::core::NormalizedPath;
 /// so independently managed cache roots get independent daemon instances.
 #[must_use]
 pub fn default_endpoint() -> String {
-    if let Some(cache_dir) = zccache::core::config::cache_dir_override() {
+    if let Some(cache_dir) = crate::core::config::cache_dir_override() {
         return endpoint_for_cache_dir(&cache_dir);
     }
 
@@ -54,7 +54,7 @@ fn endpoint_for_cache_dir(cache_dir: &std::path::Path) -> String {
     }
     #[cfg(windows)]
     {
-        let suffix = zccache::core::stable_path_id(cache_dir);
+        let suffix = crate::core::stable_path_id(cache_dir);
         format!(r"\\.\pipe\zccache-{suffix}")
     }
 }
@@ -62,7 +62,7 @@ fn endpoint_for_cache_dir(cache_dir: &std::path::Path) -> String {
 /// Returns the path for the daemon lock file.
 #[must_use]
 pub fn lock_file_path() -> NormalizedPath {
-    if let Some(cache_dir) = zccache::core::config::cache_dir_override() {
+    if let Some(cache_dir) = crate::core::config::cache_dir_override() {
         return cache_dir.join("daemon.lock");
     }
 
@@ -76,7 +76,7 @@ pub fn lock_file_path() -> NormalizedPath {
     }
     #[cfg(windows)]
     {
-        zccache::core::config::default_cache_dir().join("daemon.lock")
+        crate::core::config::default_cache_dir().join("daemon.lock")
     }
 }
 
@@ -332,8 +332,8 @@ mod tests {
     impl EnvGuard {
         fn set_cache_dir(value: &std::path::Path) -> Self {
             let lock = ENV_LOCK.lock().unwrap();
-            let previous = std::env::var_os(zccache::core::config::CACHE_DIR_ENV);
-            std::env::set_var(zccache::core::config::CACHE_DIR_ENV, value);
+            let previous = std::env::var_os(crate::core::config::CACHE_DIR_ENV);
+            std::env::set_var(crate::core::config::CACHE_DIR_ENV, value);
             Self {
                 _lock: lock,
                 previous,
@@ -344,8 +344,8 @@ mod tests {
     impl Drop for EnvGuard {
         fn drop(&mut self) {
             match &self.previous {
-                Some(value) => std::env::set_var(zccache::core::config::CACHE_DIR_ENV, value),
-                None => std::env::remove_var(zccache::core::config::CACHE_DIR_ENV),
+                Some(value) => std::env::set_var(crate::core::config::CACHE_DIR_ENV, value),
+                None => std::env::remove_var(crate::core::config::CACHE_DIR_ENV),
             }
         }
     }
@@ -365,7 +365,7 @@ mod tests {
         #[cfg(windows)]
         {
             assert!(endpoint.starts_with(r"\\.\pipe\zccache-"));
-            assert!(endpoint.ends_with(&zccache::core::stable_path_id(&cache_dir)));
+            assert!(endpoint.ends_with(&crate::core::stable_path_id(&cache_dir)));
         }
 
         assert_eq!(lock_file_path(), cache_dir.join("daemon.lock"));

--- a/crates/zccache/src/lib.rs
+++ b/crates/zccache/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Each `pub mod` below corresponds to a former workspace crate of the same
 //! name (`zccache-core` → [`core`], `zccache-hash` → [`hash`], etc.). New code
-//! should `use zccache::<module>::*` instead of the legacy
+//! should `use crate::<module>::*` instead of the legacy
 //! `zccache_<module>::*` paths, which are being deleted wave by wave.
 
 pub mod artifact;

--- a/crates/zccache/src/protocol/messages.rs
+++ b/crates/zccache/src/protocol/messages.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// A request from client to daemon.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -870,13 +870,13 @@ mod tests {
     }
 
     // Compile-time check: PROTOCOL_VERSION must be positive.
-    const _: () = assert!(super::PROTOCOL_VERSION > 0);
+    const _: () = assert!(super::super::PROTOCOL_VERSION > 0);
     // Compile-time check: PROTOCOL_VERSION == 9 after SessionStats gained
     // `phase_profile: Option<PhaseProfileSummary>` (perf observability for
     // per-session phase aggregates). v8 was the prior pin after
     // Compile/CompileEphemeral gained `stdin: Vec<u8>` and ArtifactPayload
     // replaced ArtifactOutput.data: Arc<Vec<u8>> (issue #296 Option B).
-    const _FINGERPRINT_VERSION: () = assert!(super::PROTOCOL_VERSION == 9);
+    const _FINGERPRINT_VERSION: () = assert!(super::super::PROTOCOL_VERSION == 9);
 
     #[test]
     fn fingerprint_check_roundtrip() {

--- a/crates/zccache/src/symbols/cache.rs
+++ b/crates/zccache/src/symbols/cache.rs
@@ -7,7 +7,7 @@
 //! or admin).
 
 use std::path::{Path, PathBuf};
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 /// Sentinel file written after a successful extract. Its presence
 /// declares the directory "complete and ready to consume." Absence

--- a/crates/zccache/src/test_support/mod.rs
+++ b/crates/zccache/src/test_support/mod.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 use std::time::{Duration, SystemTime};
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 // ─── Tool discovery ─────────────────────────────────────────────────────────
 

--- a/crates/zccache/src/watcher/mod.rs
+++ b/crates/zccache/src/watcher/mod.rs
@@ -17,7 +17,7 @@ pub mod polling_watcher;
 pub mod recovery;
 pub mod settle;
 
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 pub use ignore::IgnoreFilter;
 pub use notify_watcher::NotifyWatcher;

--- a/crates/zccache/src/watcher/notify_watcher.rs
+++ b/crates/zccache/src/watcher/notify_watcher.rs
@@ -40,7 +40,7 @@ impl NotifyWatcher {
     /// Returns an error if the OS file watcher cannot be initialized.
     pub fn new(
         ignore: Arc<IgnoreFilter>,
-    ) -> zccache::core::Result<(Self, mpsc::UnboundedReceiver<WatchEvent>)> {
+    ) -> crate::core::Result<(Self, mpsc::UnboundedReceiver<WatchEvent>)> {
         let (tx, rx) = mpsc::unbounded_channel();
 
         let watcher = notify::recommended_watcher(move |res: notify::Result<Event>| {
@@ -73,7 +73,7 @@ impl NotifyWatcher {
     /// # Errors
     ///
     /// Returns an error if the path cannot be watched.
-    pub fn watch(&mut self, path: &Path) -> zccache::core::Result<()> {
+    pub fn watch(&mut self, path: &Path) -> crate::core::Result<()> {
         self.watcher
             .watch(path, RecursiveMode::NonRecursive)
             .map_err(|e| std::io::Error::other(e.to_string()))?;
@@ -87,7 +87,7 @@ impl NotifyWatcher {
     /// # Errors
     ///
     /// Returns an error if the path cannot be watched.
-    pub fn watch_recursive(&mut self, path: &Path) -> zccache::core::Result<()> {
+    pub fn watch_recursive(&mut self, path: &Path) -> crate::core::Result<()> {
         self.watcher
             .watch(path, RecursiveMode::Recursive)
             .map_err(|e| std::io::Error::other(e.to_string()))?;
@@ -99,7 +99,7 @@ impl NotifyWatcher {
     /// # Errors
     ///
     /// Returns an error if the path was not being watched.
-    pub fn unwatch(&mut self, path: &Path) -> zccache::core::Result<()> {
+    pub fn unwatch(&mut self, path: &Path) -> crate::core::Result<()> {
         self.watcher
             .unwatch(path)
             .map_err(|e| std::io::Error::other(e.to_string()))?;

--- a/crates/zccache/src/watcher/polling_watcher.rs
+++ b/crates/zccache/src/watcher/polling_watcher.rs
@@ -5,7 +5,7 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use globset::{Glob, GlobSet, GlobSetBuilder};
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct FileState {

--- a/crates/zccache/src/watcher/recovery.rs
+++ b/crates/zccache/src/watcher/recovery.rs
@@ -12,7 +12,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::sync::Notify;
-use zccache_fscache::CacheSystem;
+use crate::fscache::CacheSystem;
 
 /// Deferred overflow recovery.
 ///
@@ -127,9 +127,9 @@ mod tests {
     use std::fs;
     use std::sync::Arc;
     use tempfile::TempDir;
-    use zccache::core::NormalizedPath;
-    use zccache_fscache::clock::Clock;
-    use zccache_fscache::Confidence;
+    use crate::core::NormalizedPath;
+    use crate::fscache::clock::Clock;
+    use crate::fscache::Confidence;
 
     fn create_file(dir: &TempDir, name: &str, content: &str) -> NormalizedPath {
         let path = dir.path().join(name);

--- a/crates/zccache/src/watcher/settle.rs
+++ b/crates/zccache/src/watcher/settle.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 use tokio::sync::mpsc;
-use zccache::core::NormalizedPath;
+use crate::core::NormalizedPath;
 
 use super::WatchEvent;
 

--- a/crates/zccache/tests/artifact_kv_stress.rs
+++ b/crates/zccache/tests/artifact_kv_stress.rs
@@ -6,8 +6,8 @@
 
 use std::sync::Arc;
 
-use zccache_artifact::kv::{is_valid_namespace, INLINE_THRESHOLD, MAX_VALUE_BYTES};
-use zccache_artifact::{Key, KvError, KvStore};
+use zccache::artifact::kv::{is_valid_namespace, INLINE_THRESHOLD, MAX_VALUE_BYTES};
+use zccache::artifact::{Key, KvError, KvStore};
 
 fn store_in_dir(dir: &std::path::Path) -> KvStore {
     KvStore::open(dir).unwrap()

--- a/crates/zccache/tests/artifact_perf_index_durability_test.rs
+++ b/crates/zccache/tests/artifact_perf_index_durability_test.rs
@@ -19,7 +19,7 @@
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use zccache_artifact::{ArtifactIndex, ArtifactStore};
+use zccache::artifact::{ArtifactIndex, ArtifactStore};
 
 fn sample_index(i: u32) -> ArtifactIndex {
     ArtifactIndex::new(

--- a/crates/zccache/tests/common/mod.rs
+++ b/crates/zccache/tests/common/mod.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 
-use zccache_fingerprint::ScannedFile;
+use zccache::fingerprint::ScannedFile;
 
 /// Create a file with content, creating parent dirs as needed.
 pub fn create_file(dir: &Path, rel: &str, content: &str) {

--- a/crates/zccache/tests/compiler_arduino_ino.rs
+++ b/crates/zccache/tests/compiler_arduino_ino.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 fn libclang_available() -> bool {
-    zccache_compiler::arduino::can_load_libclang()
+    zccache::compiler::arduino::can_load_libclang()
 }
 
 #[test]
@@ -32,9 +32,9 @@ static unsigned long tick(unsigned long now = 0) {
     )
     .unwrap();
 
-    let generated = zccache_compiler::arduino::generate_ino_cpp(
+    let generated = zccache::compiler::arduino::generate_ino_cpp(
         &ino,
-        &zccache_compiler::arduino::ArduinoConversionOptions::default(),
+        &zccache::compiler::arduino::ArduinoConversionOptions::default(),
     )
     .unwrap();
 
@@ -82,9 +82,9 @@ int helper(int value) {
     )
     .unwrap();
 
-    let generated = zccache_compiler::arduino::generate_ino_cpp(
+    let generated = zccache::compiler::arduino::generate_ino_cpp(
         &ino,
-        &zccache_compiler::arduino::ArduinoConversionOptions::default(),
+        &zccache::compiler::arduino::ArduinoConversionOptions::default(),
     )
     .unwrap();
 

--- a/crates/zccache/tests/compiler_clang_cl_classification.rs
+++ b/crates/zccache/tests/compiler_clang_cl_classification.rs
@@ -19,8 +19,8 @@
 
 use std::path::Path;
 
-use zccache_compiler::response_file::expand_response_files_in;
-use zccache_compiler::{parse_invocation, CompilerFamily, ParsedInvocation};
+use zccache::compiler::response_file::expand_response_files_in;
+use zccache::compiler::{parse_invocation, CompilerFamily, ParsedInvocation};
 use zccache::core::NormalizedPath;
 
 fn s(v: &[&str]) -> Vec<String> {

--- a/crates/zccache/tests/compiler_response_file_adversarial.rs
+++ b/crates/zccache/tests/compiler_response_file_adversarial.rs
@@ -14,13 +14,13 @@
 //! Run single: soldr cargo test -p zccache-compiler --test response_file_adversarial -- <test_name> --nocapture
 
 use std::path::Path;
-use zccache_compiler::response_file::{
+use zccache::compiler::response_file::{
     expand_response_files, parse_response_file_content, ResponseFileError,
 };
 use zccache::core::NormalizedPath;
 
 #[cfg(windows)]
-use zccache_compiler::response_file::write_response_file_if_needed;
+use zccache::compiler::response_file::write_response_file_if_needed;
 
 fn s(v: &[&str]) -> Vec<String> {
     v.iter().map(|x| x.to_string()).collect()
@@ -1059,8 +1059,8 @@ fn integration_all_args_from_response_file() {
 
     let args = s(&[&format!("@{}", path.display())]);
     let expanded = expand_response_files(&args).unwrap();
-    match zccache_compiler::parse_invocation("gcc", &expanded) {
-        zccache_compiler::ParsedInvocation::Cacheable(c) => {
+    match zccache::compiler::parse_invocation("gcc", &expanded) {
+        zccache::compiler::ParsedInvocation::Cacheable(c) => {
             assert_eq!(c.source_file, Path::new("foo.cpp"));
             assert_eq!(c.output_file, Path::new("foo.o"));
             assert!(c.original_args.contains(&"-O2".to_string()));
@@ -1079,8 +1079,8 @@ fn integration_c_flag_from_response_file() {
 
     let args = s(&["foo.cpp", &format!("@{}", path.display()), "-o", "foo.o"]);
     let expanded = expand_response_files(&args).unwrap();
-    match zccache_compiler::parse_invocation("clang", &expanded) {
-        zccache_compiler::ParsedInvocation::Cacheable(c) => {
+    match zccache::compiler::parse_invocation("clang", &expanded) {
+        zccache::compiler::ParsedInvocation::Cacheable(c) => {
             assert_eq!(c.source_file, Path::new("foo.cpp"));
             assert_eq!(c.output_file, Path::new("foo.o"));
         }
@@ -1097,8 +1097,8 @@ fn integration_noncacheable_flag_from_response_file() {
 
     let args = s(&["-c", "foo.cpp", &format!("@{}", path.display())]);
     let expanded = expand_response_files(&args).unwrap();
-    match zccache_compiler::parse_invocation("gcc", &expanded) {
-        zccache_compiler::ParsedInvocation::NonCacheable { .. } => { /* expected */ }
+    match zccache::compiler::parse_invocation("gcc", &expanded) {
+        zccache::compiler::ParsedInvocation::NonCacheable { .. } => { /* expected */ }
         other => panic!("expected cacheable, got: {other:?}"),
     }
 }
@@ -1112,8 +1112,8 @@ fn integration_quoted_source_path_from_response_file() {
 
     let args = s(&[&format!("@{}", path.display())]);
     let expanded = expand_response_files(&args).unwrap();
-    match zccache_compiler::parse_invocation("gcc", &expanded) {
-        zccache_compiler::ParsedInvocation::Cacheable(c) => {
+    match zccache::compiler::parse_invocation("gcc", &expanded) {
+        zccache::compiler::ParsedInvocation::Cacheable(c) => {
             assert_eq!(c.source_file, Path::new("path with spaces/main.cpp"));
             assert_eq!(c.output_file, Path::new("main.o"));
         }
@@ -1138,8 +1138,8 @@ fn integration_nested_response_files_cacheable() {
 
     let args = s(&[&format!("@{}", outer_file.display()), "-o", "main.o"]);
     let expanded = expand_response_files(&args).unwrap();
-    match zccache_compiler::parse_invocation("g++", &expanded) {
-        zccache_compiler::ParsedInvocation::Cacheable(c) => {
+    match zccache::compiler::parse_invocation("g++", &expanded) {
+        zccache::compiler::ParsedInvocation::Cacheable(c) => {
             assert_eq!(c.source_file, Path::new("main.cpp"));
             assert_eq!(c.output_file, Path::new("main.o"));
             assert!(c.original_args.contains(&"-O2".to_string()));
@@ -1159,8 +1159,8 @@ fn integration_multiple_sources_via_response_file() {
 
     let args = s(&["-c", "a.cpp", &format!("@{}", path.display())]);
     let expanded = expand_response_files(&args).unwrap();
-    match zccache_compiler::parse_invocation("gcc", &expanded) {
-        zccache_compiler::ParsedInvocation::MultiFile { compilations, .. } => {
+    match zccache::compiler::parse_invocation("gcc", &expanded) {
+        zccache::compiler::ParsedInvocation::MultiFile { compilations, .. } => {
             assert_eq!(compilations.len(), 2);
         }
         other => {
@@ -1182,8 +1182,8 @@ fn integration_define_with_quoted_value_in_cache_key() {
 
     let args = s(&["-c", "main.cpp", &format!("@{}", path.display())]);
     let expanded = expand_response_files(&args).unwrap();
-    match zccache_compiler::parse_invocation("clang++", &expanded) {
-        zccache_compiler::ParsedInvocation::Cacheable(c) => {
+    match zccache::compiler::parse_invocation("clang++", &expanded) {
+        zccache::compiler::ParsedInvocation::Cacheable(c) => {
             assert!(c.original_args.contains(&"-DVERSION=1.2.3".to_string()));
             assert!(c
                 .original_args

--- a/crates/zccache/tests/depgraph_depfile_integration_test.rs
+++ b/crates/zccache/tests/depgraph_depfile_integration_test.rs
@@ -76,7 +76,7 @@ fn depfile_basic() {
 
     // Parse depfile
     let source = cwd.join("main.c");
-    let result = zccache_depgraph::depfile::parse_depfile_path(&depfile, &source, cwd).unwrap();
+    let result = zccache::depgraph::depfile::parse_depfile_path(&depfile, &source, cwd).unwrap();
 
     // Should contain util.h (and possibly system headers)
     let util_h = std::fs::canonicalize(cwd.join("util.h")).unwrap();
@@ -138,7 +138,7 @@ int main() { return 0; }
     assert!(output.status.success());
 
     let source = cwd.join("main.c");
-    let result = zccache_depgraph::depfile::parse_depfile_path(&depfile, &source, cwd).unwrap();
+    let result = zccache::depgraph::depfile::parse_depfile_path(&depfile, &source, cwd).unwrap();
 
     // All three headers should be in the dependency list
     let a_h = std::fs::canonicalize(cwd.join("a.h")).unwrap();
@@ -206,7 +206,7 @@ fn depfile_computed_include() {
     );
 
     let source = cwd.join("main.c");
-    let result = zccache_depgraph::depfile::parse_depfile_path(&depfile, &source, cwd).unwrap();
+    let result = zccache::depgraph::depfile::parse_depfile_path(&depfile, &source, cwd).unwrap();
 
     // The compiler resolves computed includes — depfile should contain computed.h
     let computed_h = std::fs::canonicalize(cwd.join("computed.h")).unwrap();
@@ -252,7 +252,7 @@ fn depfile_system_headers_with_md() {
     assert!(output.status.success());
 
     let source = cwd.join("main.c");
-    let result = zccache_depgraph::depfile::parse_depfile_path(&depfile, &source, cwd).unwrap();
+    let result = zccache::depgraph::depfile::parse_depfile_path(&depfile, &source, cwd).unwrap();
 
     // Should contain at least one system header (stdio.h or its internal includes)
     assert!(
@@ -317,16 +317,16 @@ fn depfile_parity_with_scanner() {
 
     // Parse depfile
     let depfile_result =
-        zccache_depgraph::depfile::parse_depfile_path(&depfile_path, &source, cwd).unwrap();
+        zccache::depgraph::depfile::parse_depfile_path(&depfile_path, &source, cwd).unwrap();
 
     // Scan with scanner
-    let search_paths = zccache_depgraph::IncludeSearchPaths {
+    let search_paths = zccache::depgraph::IncludeSearchPaths {
         iquote: vec![],
         user: vec![cwd.to_path_buf().into()],
         system: vec![],
         after: vec![],
     };
-    let scan_result = zccache_depgraph::scanner::scan_recursive(&source, &search_paths);
+    let scan_result = zccache::depgraph::scanner::scan_recursive(&source, &search_paths);
 
     // All scanner-resolved paths should appear in depfile results
     for path in &scan_result.resolved {
@@ -367,12 +367,12 @@ fn depfile_strategy_injected_works_end_to_end() {
 
     let output_file = cwd.join("test.o");
 
-    let dep_flags = zccache_depgraph::UserDepFlags::default();
+    let dep_flags = zccache::depgraph::UserDepFlags::default();
     let (extra_args, strategy) =
-        zccache_depgraph::depfile::prepare_depfile(true, &dep_flags, &output_file, &tmpdir);
+        zccache::depgraph::depfile::prepare_depfile(true, &dep_flags, &output_file, &tmpdir);
 
     let depfile_path = match &strategy {
-        zccache_depgraph::DepfileStrategy::Injected { path } => path.clone(),
+        zccache::depgraph::DepfileStrategy::Injected { path } => path.clone(),
         other => panic!("expected Injected, got: {other:?}"),
     };
 
@@ -405,7 +405,7 @@ fn depfile_strategy_injected_works_end_to_end() {
     // Parse depfile
     let source = cwd.join("test.c");
     let result =
-        zccache_depgraph::depfile::parse_depfile_path(&depfile_path, &source, cwd).unwrap();
+        zccache::depgraph::depfile::parse_depfile_path(&depfile_path, &source, cwd).unwrap();
 
     let test_h = std::fs::canonicalize(cwd.join("test.h")).unwrap();
     assert!(

--- a/crates/zccache/tests/depgraph_stress_test.rs
+++ b/crates/zccache/tests/depgraph_stress_test.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
 use zccache::core::{normalize_for_key, NormalizedPath};
-use zccache_depgraph::*;
+use zccache::depgraph::*;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/crates/zccache/tests/fingerprint_concurrent.rs
+++ b/crates/zccache/tests/fingerprint_concurrent.rs
@@ -2,7 +2,7 @@ mod common;
 
 use std::sync::Arc;
 use tempfile::TempDir;
-use zccache_fingerprint::{walk_files, CacheDecision, HashCache, TwoLayerCache};
+use zccache::fingerprint::{walk_files, CacheDecision, HashCache, TwoLayerCache};
 
 // ── Independent caches in parallel (no locking needed) ───────────
 

--- a/crates/zccache/tests/fingerprint_edge_cases.rs
+++ b/crates/zccache/tests/fingerprint_edge_cases.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use tempfile::TempDir;
-use zccache_fingerprint::{
+use zccache::fingerprint::{
     walk_files, walk_files_glob, CacheDecision, HashCache, RunReason, TwoLayerCache,
 };
 

--- a/crates/zccache/tests/fingerprint_end_to_end.rs
+++ b/crates/zccache/tests/fingerprint_end_to_end.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use tempfile::TempDir;
-use zccache_fingerprint::{
+use zccache::fingerprint::{
     walk_files, walk_files_glob, CacheDecision, HashCache, RunReason, TwoLayerCache,
 };
 

--- a/crates/zccache/tests/fingerprint_glob_scan.rs
+++ b/crates/zccache/tests/fingerprint_glob_scan.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use tempfile::TempDir;
-use zccache_fingerprint::{walk_files, walk_files_glob};
+use zccache::fingerprint::{walk_files, walk_files_glob};
 
 // ── Basic patterns ───────────────────────────────────────────────
 

--- a/crates/zccache/tests/fingerprint_stress.rs
+++ b/crates/zccache/tests/fingerprint_stress.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use tempfile::TempDir;
-use zccache_fingerprint::{walk_files, walk_files_glob, CacheDecision, HashCache, TwoLayerCache};
+use zccache::fingerprint::{walk_files, walk_files_glob, CacheDecision, HashCache, TwoLayerCache};
 
 fn setup() -> (TempDir, TempDir) {
     (TempDir::new().unwrap(), TempDir::new().unwrap())

--- a/crates/zccache/tests/fscache_persistence_perf_test.rs
+++ b/crates/zccache/tests/fscache_persistence_perf_test.rs
@@ -26,7 +26,7 @@ use std::fs;
 use std::time::{Duration, Instant, SystemTime};
 use tempfile::TempDir;
 use zccache::core::NormalizedPath;
-use zccache_fscache::{Confidence, FileMetadata, MetadataCache};
+use zccache::fscache::{Confidence, FileMetadata, MetadataCache};
 
 /// Roughly the order of magnitude of headers a `medium` perf fixture
 /// touches; large enough to surface algorithmic regressions, small

--- a/crates/zccache/tests/symbols_stamp_roundtrip.rs
+++ b/crates/zccache/tests/symbols_stamp_roundtrip.rs
@@ -4,7 +4,7 @@
 //! `read_marker_from_path` in the daemon and CLI.
 
 use std::io::Write;
-use zccache_symbols::marker::{read_marker_from_path, MARKER_SIZE};
+use zccache::symbols::marker::{read_marker_from_path, MARKER_SIZE};
 
 #[test]
 fn stamp_then_read_returns_same_fields() {

--- a/crates/zccache/tests/watcher_stress_test.rs
+++ b/crates/zccache/tests/watcher_stress_test.rs
@@ -9,10 +9,10 @@ use std::thread;
 use std::time::Duration;
 use tempfile::TempDir;
 use zccache::core::NormalizedPath;
-use zccache_fscache::clock::Clock;
-use zccache_fscache::CacheSystem;
-use zccache_watcher::settle::{SettleBuffer, SettledEvent};
-use zccache_watcher::{IgnoreFilter, NotifyWatcher, WatchEvent};
+use zccache::fscache::clock::Clock;
+use zccache::fscache::CacheSystem;
+use zccache::watcher::settle::{SettleBuffer, SettledEvent};
+use zccache::watcher::{IgnoreFilter, NotifyWatcher, WatchEvent};
 
 /// Helper: create a file with content, return path.
 fn create_file(dir: &TempDir, name: &str, content: &str) -> NormalizedPath {
@@ -200,7 +200,7 @@ fn stress_journal_overflow_recovery() {
         let entry = cache.metadata().get(path).unwrap();
         assert_eq!(
             entry.confidence,
-            zccache_fscache::Confidence::Low,
+            zccache::fscache::Confidence::Low,
             "entry should be Low after overflow"
         );
     }
@@ -519,7 +519,7 @@ fn adversarial_many_apply_overflow_cycles() {
             let entry = cache.metadata().get(path).unwrap();
             assert_eq!(
                 entry.confidence,
-                zccache_fscache::Confidence::Low,
+                zccache::fscache::Confidence::Low,
                 "cycle {cycle}: should be Low after overflow"
             );
         }


### PR DESCRIPTION
## Summary

The 7-wave monocrate consolidation (issue #365, PRs #366–#372) merged with \`--admin --squash\` and no CI gating, leaving 826 build errors on \`main\`. This PR restores \`cargo check --workspace --all-targets\` to clean.

### Categories of fixes

1. **Internal `zccache::` → `crate::` in 128 files.** Wave 7's mass sed swept self-references in the monocrate's own source; Rust requires `crate::` for in-crate paths.
2. **Bins use `zccache::`, not `crate::`.** Each `[[bin]]` compiles as a separate crate; the 9 bins under `src/bin/` needed the inverse swap.
3. **Test-mod sibling refs at wrong depth.** Inside `#[cfg(test)] mod tests { ... }`, `super::` resolves to the file's module not the dir; sibling refs now use `super::super::sibling::*`. Affected: fscache, fingerprint, depgraph, compiler, daemon, protocol.
4. **depgraph/snapshot/tests/* depth corrections.** Wave 4's depth-flip overshot for nested tests; mod.rs at depth 2, sub-files at depth 3.
5. **`tests/common/mod.rs` convention restored** for fingerprint tests (Wave 4 had renamed to `fingerprint_common.rs`).
6. **py-binding crates gated `#![cfg(feature = "python")]`** so default `cargo check` doesn't choke on `use pyo3::*`.
7. **`Win32_System_JobObjects` feature** added to `windows-sys` for `daemon::process`.
8. **`zccache_download[_*]::` → `zccache::download[_*]::`** swept in test/bench/bin files.

## Verification

- \`soldr cargo check --workspace --all-targets\` → 0 errors
- Docker perf harness running locally (in progress at PR open time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)