### PR TITLE
diag(daemon): expose key_root + path_remap state in depgraph_check log (#353)

### DIFF
--- a/crates/zccache/src/daemon/server/handle_compile.rs
+++ b/crates/zccache/src/daemon/server/handle_compile.rs
@@ -664,11 +664,16 @@ pub(super) async fn handle_compile(
         }
     }
 
+    // Issue #353: include `key_root` and `path_remap` state in the diag line so
+    // cross-runner cache-miss bisection (two GHA runners hit the same cache via
+    // actions/cache@v4 but see 0% hit rate) can diff the per-runner resolution.
+    // `path_remap=auto_no_git` exposes the silent-fallback case where
+    // `ZCCACHE_PATH_REMAP=auto` was requested but `find_git_root` returned None.
     write_session_log(
         &state.sessions,
         &sid,
         &format!(
-            "[DIAG] depgraph_check: {} -> {} ctx={} verdict={} reason={}",
+            "[DIAG] depgraph_check: {} -> {} ctx={} verdict={} reason={} key_root={} path_remap={}",
             source_path.display(),
             output_path.display(),
             &context_key.hash().to_hex()[..8],
@@ -680,6 +685,8 @@ pub(super) async fn handle_compile(
                 crate::depgraph::CacheVerdict::NeedsPreprocessor => "NeedsPreprocessor",
             },
             diag_reason,
+            default_key_root.display(),
+            diag_path_remap_state(client_env.as_deref(), worktree_root.is_some()),
         ),
     );
     match verdict {

--- a/crates/zccache/src/daemon/server/keys.rs
+++ b/crates/zccache/src/daemon/server/keys.rs
@@ -17,6 +17,26 @@ pub(super) fn path_remap_auto_enabled(client_env: Option<&[(String, String)]>) -
         .is_some_and(|value| value.eq_ignore_ascii_case("auto"))
 }
 
+/// Stringly tag of path-remap state for the depgraph-check diag line.
+/// Issue #353: exposes the silent fallback case where `ZCCACHE_PATH_REMAP=auto`
+/// was requested but `find_git_root` returned None — distinguishing it from
+/// "remap disabled" (off) and "remap firing" (auto) lets cross-runner bisection
+/// catch the case where two runners disagree on whether remap is active.
+pub(super) fn diag_path_remap_state(
+    client_env: Option<&[(String, String)]>,
+    worktree_root_resolved: bool,
+) -> &'static str {
+    if path_remap_auto_enabled(client_env) {
+        if worktree_root_resolved {
+            "auto"
+        } else {
+            "auto_no_git"
+        }
+    } else {
+        "off"
+    }
+}
+
 pub(super) fn resolve_worktree_root(
     cwd: &Path,
     client_env: Option<&[(String, String)]>,


### PR DESCRIPTION
## Summary

Investigative diagnostic for [issue #353](https://github.com/zackees/zccache/issues/353) — cross-runner cache misses despite #337's load-classifier fix.

**This PR does NOT speculatively change cache-key logic.** It adds two new tags to the existing \`[DIAG] depgraph_check\` log line so the next experiment in soldr's \`cache-delta-experiment.yml\` can bisect the failure empirically rather than by guess.

### New log fields

\`\`\`
[DIAG] depgraph_check: <src> -> <out> ctx=<8hex> verdict=<v> reason=<r> key_root=<path> path_remap=<state>
\`\`\`

- \`key_root=\` — the resolved worktree root used to normalize paths in \`compute_context_key\`. Two runners with divergent \`key_root\` produce divergent \`context_key\` hashes and the persisted depgraph won't match any of them.
- \`path_remap=\` — one of:
  - \`auto\` — \`ZCCACHE_PATH_REMAP=auto\` set AND \`find_git_root\` resolved a \`.git/\` ancestor.
  - \`auto_no_git\` — env var requested but \`find_git_root\` returned None. **This exposes the silent-fallback case** the issue's ask #2 documents.
  - \`off\` — env var not set.

## Investigation summary (posted as issue comment)

- Rustc absolute path is **not** in cache keys (only content hash; verified in \`daemon/server/rustc.rs:76\` + \`depgraph/context.rs:428\`). Rules out issue ask #4.
- \`env_vars\` filters to \`CARGO_*\` and excludes volatile-path variants (\`CARGO_MANIFEST_DIR\`, \`CARGO_MANIFEST_PATH\`, \`CARGO_MAKEFLAGS\`, \`CARGO_INCREMENTAL\`).
- The depgraph load classifier from #337 is fully visible — \`Loaded\` / \`VersionMismatch\` / \`Corrupt\` / \`IoError\` / \`Missing\` all surface a warning into \`last-session.log\`.
- The most plausible un-ruled-out failure mode is **silent path-remap fallback** when \`.git/\` isn't detected by \`find_git_root\`. \`effective_compile_args\` bails out at \`let Some(root) = worktree_root else { return expanded_args.to_vec(); }\` without adding \`--remap-path-prefix\`. The new \`path_remap=auto_no_git\` tag exposes this.

\`miss_reason\` (acceptance criterion #3) is already shipped in 1.9.0 in \`compile_journal\` JSON entries (\`context_not_found\`, \`input_fingerprint_mismatch\`, \`no_artifact_for_key\`, \`version_skew\`, \`uncacheable_input\`, \`unknown\`).

## How to use this for bisection

Re-run \`cache-delta-experiment.yml\` once this lands. Diff the two runners' \`last-session.log\`:

\`\`\`bash
diff <(grep '\[DIAG\] depgraph_check' runner-a/last-session.log) \
     <(grep '\[DIAG] depgraph_check' runner-b/last-session.log)
\`\`\`

If \`key_root=\` matches and \`path_remap=\` matches but \`ctx=\` differs → cache-key derivation has a hidden runner-specific input (escalate to a focused unit test).
If \`key_root=\` differs → silent path-remap failure on one runner (likely \`.git/\` not detected); fix is to surface the failure as a hard error or have \`find_git_root\` walk more aggressively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)