### PR TITLE
fix(daemon): cwd fallback for PATH_REMAP=auto when .git/ missing (closes #353)

### DIFF
--- a/crates/zccache/src/daemon/server/keys.rs
+++ b/crates/zccache/src/daemon/server/keys.rs
@@ -76,18 +76,44 @@ pub(super) fn compile_worktree_root(
         return resolve_worktree_root(cwd, client_env);
     }
 
-    let cwd: NormalizedPath = cwd.into();
+    let cwd_normalized: NormalizedPath = cwd.into();
     if let Some(cached) = state.session_worktree_roots.get(sid) {
         if let Some(root) = cached.root.as_ref() {
-            if cwd.starts_with(root.as_path()) {
+            if cwd_normalized.starts_with(root.as_path()) {
                 return Some(root.clone());
             }
-        } else if cwd.starts_with(cached.working_dir.as_path()) {
+        } else if cwd_normalized.starts_with(cached.working_dir.as_path())
+            && !path_remap_auto_enabled(client_env)
+        {
+            // Cached "no worktree" applies only when PATH_REMAP isn't requested.
+            // Issue #353: when the user explicitly opts into auto-remap, prefer
+            // the cwd fallback (below) over the sticky None so the compiler
+            // still gets a `--remap-path-prefix=<cwd>=.` flag and embedded
+            // paths in debug info / macros become path-independent.
             return None;
         }
     }
 
-    resolve_worktree_root(&cwd, client_env)
+    if let Some(root) = resolve_worktree_root(cwd, client_env) {
+        return Some(root);
+    }
+
+    // Issue #353: `ZCCACHE_PATH_REMAP=auto` was requested but no `.git/`
+    // ancestor was found. Previously this silently fell through, so the
+    // compiler ran with absolute paths in its output even though the user
+    // asked for path normalization. Two GHA runners with byte-identical
+    // checkouts but no `.git/` (e.g., shallow / git-archive workflows) would
+    // produce divergent .rlib bytes and miss every cache lookup.
+    //
+    // Fall back to using the cwd itself as the worktree root: the remap flag
+    // gets added (`--remap-path-prefix=<cwd>=.`) and the depgraph context_key
+    // normalizes paths relative to a deterministic root. Behavior when the env
+    // var isn't set is unchanged.
+    if path_remap_auto_enabled(client_env) {
+        return Some(cwd_normalized);
+    }
+
+    None
 }
 
 pub(super) fn normalize_path_for_request_key(path: &Path, key_root: Option<&Path>) -> String {

--- a/crates/zccache/src/daemon/server/tests/fingerprint.rs
+++ b/crates/zccache/src/daemon/server/tests/fingerprint.rs
@@ -39,6 +39,31 @@ fn find_git_root_detects_git_directory() {
 }
 
 #[test]
+fn path_remap_auto_enabled_recognizes_auto_case_insensitive() {
+    // Issue #353 prerequisite: confirm the auto-detection helper recognizes
+    // the env value the cwd-fallback branch keys on.
+    let env = vec![("ZCCACHE_PATH_REMAP".to_string(), "auto".to_string())];
+    assert!(path_remap_auto_enabled(Some(&env)));
+    let env = vec![("ZCCACHE_PATH_REMAP".to_string(), "AUTO".to_string())];
+    assert!(path_remap_auto_enabled(Some(&env)));
+    let env = vec![("ZCCACHE_PATH_REMAP".to_string(), "off".to_string())];
+    assert!(!path_remap_auto_enabled(Some(&env)));
+    assert!(!path_remap_auto_enabled(None));
+}
+
+#[test]
+fn diag_path_remap_state_tags() {
+    // Issue #353: the `auto_no_git` tag is the one observers grep for to
+    // distinguish "remap fired with cwd fallback" from "remap silently
+    // skipped because no env var".
+    let auto = vec![("ZCCACHE_PATH_REMAP".to_string(), "auto".to_string())];
+    assert_eq!(diag_path_remap_state(Some(&auto), true), "auto");
+    assert_eq!(diag_path_remap_state(Some(&auto), false), "auto_no_git");
+    assert_eq!(diag_path_remap_state(None, true), "off");
+    assert_eq!(diag_path_remap_state(None, false), "off");
+}
+
+#[test]
 fn resolve_worktree_root_prefers_client_env_override() {
     let tmp = tempfile::tempdir().unwrap();
     let cwd = tmp.path().join("repo/subdir");


### PR DESCRIPTION
## Summary

Closes #353.

When \`ZCCACHE_PATH_REMAP=auto\` is requested but \`find_git_root\` returns None (e.g., shallow checkout, git-archive workflow, GHA runner with unusual init order), the old code silently no-ops the remap: compiler output embeds absolute paths in debuginfo + macro outputs → artifact bytes differ across runners even when context_keys match → cross-runner cache misses.

This PR makes the cwd itself the fallback worktree root in that case. The compiler gets \`--remap-path-prefix=<cwd>=.\`, output becomes path-independent, and the GHA cross-runner scenario from soldr's \`cache-delta-experiment.yml\` should produce hits.

The depgraph context_key already used \`default_key_root = worktree_root.unwrap_or(cwd)\` (handle_compile.rs:347), so this doesn't shift cache keys — it just stops dropping the \`--remap-path-prefix\` flag on the floor.

## Behavior table

| PATH_REMAP | .git/ present | Before | After |
|---|---|---|---|
| unset | no | no remap | no remap (unchanged) |
| unset | yes | no remap | no remap (unchanged) |
| auto | yes | remap with git root | remap with git root (unchanged) |
| **auto** | **no** | **no remap (silent)** | **remap with cwd as root** |

## Diagnostic from #375 still applies

The \`path_remap=auto_no_git\` tag in \`[DIAG] depgraph_check\` now means "compiler got --remap-path-prefix=<cwd>=. via the cwd-fallback branch" rather than "remap silently skipped."

## Tests

- \`path_remap_auto_enabled_recognizes_auto_case_insensitive\`
- \`diag_path_remap_state_tags\`

Both pass locally. Full \`cargo check --workspace --all-targets\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)