### PR TITLE
feat(observability): emit empty miss_diff on profile misses (closes #340)

### DIFF
--- a/crates/zccache/src/daemon/compile_journal/mod.rs
+++ b/crates/zccache/src/daemon/compile_journal/mod.rs
@@ -206,6 +206,14 @@ impl JournalEntry {
     /// `session-start --profile`. Pure transformation - no I/O.
     /// `spans` is owned by the compile handler; passing `None`
     /// emits a record without `self_profile_ns`.
+    ///
+    /// Issue #340: emits an empty `MissDiff` for every miss outcome under
+    /// `--profile` so consumers see the field consistently. Populating the
+    /// `changed_files` / `changed_flags` / `changed_deps` arrays requires a
+    /// `(crate_name, crate_type) -> prior_context` index that doesn't exist
+    /// in the depgraph today — tracked as a follow-up. The presence of an
+    /// empty `MissDiff` is the distinguishing signal from
+    /// `--profile`-off entries (where the field is omitted entirely).
     #[must_use]
     pub fn with_profile_fields(mut self, spans: Option<SelfProfileSpans>) -> Self {
         let derived_name = derive_crate_name(&self.args);
@@ -214,6 +222,9 @@ impl JournalEntry {
         self.crate_type = derived_type.map(str::to_string);
         self.crate_name = derived_name;
         self.self_profile_ns = spans.map(SelfProfileSpans::finish);
+        if matches!(self.outcome, "miss" | "link_miss") {
+            self.miss_diff = Some(MissDiff::default());
+        }
         self
     }
 }

--- a/crates/zccache/src/daemon/compile_journal/tests/entry.rs
+++ b/crates/zccache/src/daemon/compile_journal/tests/entry.rs
@@ -393,6 +393,38 @@ fn with_profile_fields_threads_self_profile_spans() {
 }
 
 #[test]
+fn with_profile_fields_emits_empty_miss_diff_on_miss() {
+    // Issue #340 acceptance criterion: a `--profile` miss must always include
+    // a `miss_diff` object, even when no prior context is available to diff
+    // against (first-seen miss). The empty-arrays form is the distinguishing
+    // signal between "diff was computed but nothing changed" and "diff was
+    // not computed because --profile is off" (the latter omits the field).
+    let ctx = make_ctx(vec!["--crate-name", "x", "--crate-type", "lib"]);
+    let entry = JournalEntry::new(ctx, "miss", 0, 1_234, Some(miss_reason::UNKNOWN))
+        .with_profile_fields(None);
+    let diff = entry.miss_diff.as_ref().expect("miss_diff must be Some");
+    assert!(diff.changed_files.is_empty());
+    assert!(diff.changed_flags.is_empty());
+    assert!(diff.changed_deps.is_empty());
+}
+
+#[test]
+fn with_profile_fields_emits_empty_miss_diff_on_link_miss() {
+    let ctx = make_ctx(vec!["--crate-name", "x", "--crate-type", "lib"]);
+    let entry = JournalEntry::new(ctx, "link_miss", 0, 1_234, Some(miss_reason::UNKNOWN))
+        .with_profile_fields(None);
+    assert!(entry.miss_diff.is_some());
+}
+
+#[test]
+fn with_profile_fields_omits_miss_diff_on_hit() {
+    // Hits never carry miss_diff regardless of --profile state.
+    let ctx = make_ctx(vec!["--crate-name", "x", "--crate-type", "lib"]);
+    let entry = JournalEntry::new(ctx, "hit", 0, 1_234, None).with_profile_fields(None);
+    assert!(entry.miss_diff.is_none());
+}
+
+#[test]
 fn legacy_entry_without_with_profile_fields_omits_all_new_fields() {
     // Issue #256 acceptance criterion: when --profile is OFF the
     // journal record must serialize without crate_name, crate_type,


### PR DESCRIPTION
## Summary

Closes #340.

Minimal viable population for \`miss_diff\`: emit \`Some(MissDiff::default())\` on every \`--profile\` miss so the field is **present** consistently. Lets consumers distinguish "diff computed (nothing to report yet)" from "diff not computed (--profile off, field omitted)".

| --profile | outcome | miss_diff |
|---|---|---|
| on | miss / link_miss | \`{}\` (present, empty arrays) |
| on | hit / link_hit / error | omitted |
| off | any | omitted |

## What doesn't populate (follow-up)

\`changed_files\` / \`changed_flags\` / \`changed_deps\` need a \`(crate_name, crate_type) → prior_context\` index that doesn't exist today. Contexts are keyed solely by their content hash, so a flag change produces a new \`context_key\` with no way to find the prior crate's last good context. Building that index touches the depgraph snapshot format + registration path; that's larger than #340's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)