### PR TITLE
fix(release): build Python extension from zccache-cli, not zccache

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -159,7 +159,13 @@ runs:
           export PYO3_CROSS_PYTHON_IMPLEMENTATION=CPython
         fi
 
-        cargo build --release --target ${{ inputs.target }} -p zccache --bin zccache --features python --lib
+        # The Python extension cdylibs live in their own thin pyo3 crates
+        # (zccache-cli / zccache-watcher / zccache-fingerprint) per the Wave 7
+        # monocrate split. The umbrella `zccache` rlib intentionally does NOT
+        # carry the `python` feature, so `-p zccache --features python` is a
+        # workflow-only build-target bug that latently broke the release path.
+        # Surfaced when 1.9.1 became the first version bump after that split.
+        cargo build --release --target ${{ inputs.target }} -p zccache-cli --features python --lib
         cargo build --release --target ${{ inputs.target }} -p zccache-watcher --features python --lib
         cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint --features python --lib
 

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ build/
 uv.lock
 .pytest_cache/
 POST_HOOK_FAILURE_*.txt
+
+local-notes.md


### PR DESCRIPTION
## Summary
- Wave 7 monocrate split moved the `python` feature + cdylib out of the renamed `zccache` rlib into `zccache-cli`.
- The release build-target step never followed; it still says `cargo build -p zccache --bin zccache --features python --lib`, which cargo rejects with `error: the package 'zccache' does not contain this feature: python`.
- This bug stayed latent because Auto-Release only enters the build path on a workspace version bump, and the previous bumps predated the split. It surfaced as the **1.9.1** release attempt (run [26351678030](https://github.com/zackees/zccache/actions/runs/26351678030)) which was the first version bump after Wave 7.
- Fix: switch the python build to `-p zccache-cli --features python --lib`. This matches the existing staging step that already copies `libzccache_cli.{dylib,so}` / `zccache_cli.dll` into `staging/python/zccache/_native.*`.
- Also gitignores `local-notes.md` (a scratchpad file that surfaces only in stale clones).

## Why this is urgent
This is blocking the 1.9.1 release, which is in turn blocking soldr#476 (the soldr-side fix for the bundle-size issue soldr#461).

## Test plan
- [x] Workflow file syntax sanity-check (no other refs to change).
- [ ] Auto-Release re-runs on merge; the build matrix should clear and 1.9.1 publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)