### PR TITLE
fix(cli): make resolve_endpoint pub so zccache-cli pyo3 layer compiles

### DIFF
--- a/crates/zccache/src/cli/mod.rs
+++ b/crates/zccache/src/cli/mod.rs
@@ -161,7 +161,12 @@ fn write_file_atomically(path: &Path, data: &[u8]) -> Result<(), std::io::Error>
     }
 }
 
-fn resolve_endpoint(explicit: Option<&str>) -> String {
+/// Expose the daemon endpoint resolver as `pub` so the thin `zccache-cli`
+/// pyo3 crate (which lives in a sibling workspace member) can hand it
+/// to Python callers without round-tripping through a CLI subcommand.
+/// Marked `pub` rather than `pub(crate)` because `zccache-cli` is a
+/// separate crate per the Wave 7 monocrate split.
+pub fn resolve_endpoint(explicit: Option<&str>) -> String {
     if let Some(ep) = explicit {
         return ep.to_string();
     }


### PR DESCRIPTION
## Summary
- `zccache-cli/src/lib.rs:757` calls `zccache::cli::resolve_endpoint(None)` — a cross-crate use after the Wave 7 monocrate split.
- `resolve_endpoint` is currently `fn` (private to its defining module), so the python build of `zccache-cli` fails with `E0603: function resolve_endpoint is private`.
- Fix: bump it to `pub` with a doc-comment explaining why a sibling crate needs it.

## Why this is urgent
This is the second of two bugs blocking the zccache 1.9.1 release. The first (release workflow building from the wrong package) was fixed in #379 and exposed this one. Both are blocking soldr#476 (the soldr-side fix for soldr#461 — 1.5 GB target-cache bundle).

## Local verification
```
soldr cargo build --release -p zccache-cli --features python --lib
```
compiles cleanly after the change.

## Test plan
- [ ] CI clears on the eight-target Auto-Release build matrix once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)