### PR TITLE
fix(release): add build.rs to zccache-cli for pyo3 extension-module link args

### DIFF
--- a/crates/zccache-cli/build.rs
+++ b/crates/zccache-cli/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_PYTHON");
+
+    if std::env::var_os("CARGO_FEATURE_PYTHON").is_some() {
+        pyo3_build_config::add_extension_module_link_args();
+    }
+}


### PR DESCRIPTION
## Summary
- The pyo3 release build of `zccache-cli` fails with hundreds of "Undefined symbols `_PyBaseObject_Type` / `_PyBool_Type` / ..." link errors on macOS (and would fail on ELF targets with strict undefined-symbol checking too).
- Root cause: `pyo3 + extension-module` asks the linker to leave Python symbols unresolved — they're satisfied by `libpython` at import time. On macOS this requires `-undefined dynamic_lookup`. `pyo3_build_config::add_extension_module_link_args()` emits the right flag, but only when invoked from a `build.rs`.
- Sibling crates `zccache-watcher` and `zccache-fingerprint` both have a `build.rs` that does this. `zccache-cli` did not.
- Fix: add `crates/zccache-cli/build.rs` that mirrors `crates/zccache-watcher/build.rs` verbatim.

## Why this kept surfacing one at a time
The release workflow's python build step had three latent bugs stacked:
1. `-p zccache --features python` (the wrong package). Fixed in #379.
2. `zccache::cli::resolve_endpoint` private. Fixed in #382.
3. Missing `build.rs` link-arg emission. **This PR.**

Each fix exposed the next; this is the last one between us and a clean 1.9.1 release.

## Local verification
```
soldr cargo build --release -p zccache-cli --features python --lib
```
links cleanly.

## Why this is urgent
Blocking the zccache 1.9.1 release → blocking soldr#476 (the soldr-side fix for soldr#461 — 1.5 GB target-cache bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)