### PR TITLE
fix(release): build zccache-fp binary from the umbrella zccache crate

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -121,7 +121,14 @@ runs:
         fi
         cargo build --release --target ${{ inputs.target }} -p zccache --bin zccache
         cargo build --release --target ${{ inputs.target }} -p zccache --bin zccache-daemon
-        cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint
+        # zccache-fp is a bin shipped *inside* the umbrella `zccache` crate
+        # (see crates/zccache/Cargo.toml `[[bin]] name = "zccache-fp"`). The
+        # sibling `zccache-fingerprint` crate is a pyo3 cdylib for the Python
+        # extension and produces no native executable. The staging step below
+        # then `cp`s `target/.../zccache-fp` into `staging/`, which is why
+        # building the wrong target left it complaining `cannot stat
+        # 'target/.../zccache-fp': No such file or directory`.
+        cargo build --release --target ${{ inputs.target }} -p zccache --bin zccache-fp
 
     # Windows DLL load smoke gate (see zccache#269). If the just-built
     # `zccache.exe` cannot complete loader init on this host, `--version`


### PR DESCRIPTION
## Summary
- Release matrix staging step crashed: `cp: cannot stat 'target/$TARGET/release/zccache-fp': No such file or directory`.
- Root cause: build command was `cargo build -p zccache-fingerprint`, but that crate is a pyo3 cdylib (Python extension) — it doesn't produce a `zccache-fp` executable. The `zccache-fp` binary actually lives in the umbrella `zccache` crate per its Cargo.toml `[[bin]] name = "zccache-fp"`.
- Fix: switch to `-p zccache --bin zccache-fp`.

## Why this kept surfacing
Fourth bug in a row exposed by the release path after the 1.9.0 → 1.9.1 bump triggered the first non-skipped Auto-Release build since the Wave 7 monocrate rename. Predecessors:

1. zccache#379 — workflow pointed `--features python` at wrong package.
2. zccache#382 — `resolve_endpoint` was private across the new crate boundary.
3. zccache#383 — `zccache-cli` was missing `build.rs` so pyo3 couldn't emit `-undefined dynamic_lookup`.
4. **This PR** — staging expected `zccache-fp` binary but workflow was building `zccache-fingerprint` (cdylib only).

## Local verification
```
soldr cargo build --release -p zccache --bin zccache-fp
```
produces `target/.../release/zccache-fp.exe`.

## Why urgent
Still blocking the zccache 1.9.1 release → blocking soldr#476 (soldr#461 1.5 GB bundle fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)