### PR TITLE
fix(release): add version= alongside path= for intra-workspace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,10 +55,16 @@ rkyv = { version = "0.7", features = ["validation"] }
 tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
 mimalloc = "0.1"
 running-process-core = "3.3"
-zccache = { path = "crates/zccache" }
-zccache-watcher = { path = "crates/zccache-watcher" }
-zccache-cli = { path = "crates/zccache-cli" }
-zccache-fingerprint = { path = "crates/zccache-fingerprint" }
+# `version` is required alongside `path` for crates.io publishing:
+# `cargo publish` rejects path-only intra-workspace deps with
+# "all dependencies must have a version requirement specified".
+# Local builds keep using `path` (cargo prefers it when both are set);
+# the version is what gets baked into the published Cargo.toml.
+# Must track [workspace.package].version above.
+zccache = { path = "crates/zccache", version = "1.9.1" }
+zccache-watcher = { path = "crates/zccache-watcher", version = "1.9.1" }
+zccache-cli = { path = "crates/zccache-cli", version = "1.9.1" }
+zccache-fingerprint = { path = "crates/zccache-fingerprint", version = "1.9.1" }
 
 # Vendored notify with fixes for Windows ReadDirectoryChangesW:
 # 1. Detect buffer overflow (bytes_written == 0) and report as error


### PR DESCRIPTION
## Summary
- `cargo publish` rejects path-only intra-workspace deps:
  > error: failed to verify manifest at crates/zccache-cli/Cargo.toml
  > Caused by: all dependencies must have a version requirement specified when publishing.
  > dependency \`zccache\` does not specify a version
- Fix: add `version = "1.9.1"` alongside `path =` for the four `zccache*` workspace deps. Cargo prefers `path` locally; `version` is what's baked into the published Cargo.toml.

## Progress on the release path
This is the 5th and (hopefully) final release-blocking bug exposed by the 1.9.0 → 1.9.1 version bump (the first non-skipped Auto-Release build since Wave 7 monocrate rename):

1. zccache#379 — workflow built `--features python` against wrong package.
2. zccache#382 — `resolve_endpoint` private across new crate boundary.
3. zccache#383 — `zccache-cli` missing `build.rs` for pyo3 link args.
4. zccache#384 — workflow built `zccache-fingerprint` (cdylib) but staging expected `zccache-fp` binary.
5. **This PR** — workspace deps had no `version` for `cargo publish`.

On the 5th Auto-Release attempt, all 8 platform builds + PyPI publish succeeded; only crates.io publish failed for this reason.

## Why urgent
Still blocking zccache 1.9.1 → blocking soldr#476 (soldr#461 1.5 GB bundle fix).

## Test plan
- [x] `soldr cargo check --workspace` passes locally.
- [ ] Auto-Release reaches "Publish GitHub Release" successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)