### PR TITLE
fix(release): stamper must pin the umbrella zccache crate too

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,16 +55,10 @@ rkyv = { version = "0.7", features = ["validation"] }
 tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
 mimalloc = "0.1"
 running-process-core = "3.3"
-# `version` is required alongside `path` for crates.io publishing:
-# `cargo publish` rejects path-only intra-workspace deps with
-# "all dependencies must have a version requirement specified".
-# Local builds keep using `path` (cargo prefers it when both are set);
-# the version is what gets baked into the published Cargo.toml.
-# Must track [workspace.package].version above.
-zccache = { path = "crates/zccache", version = "1.9.1" }
-zccache-watcher = { path = "crates/zccache-watcher", version = "1.9.1" }
-zccache-cli = { path = "crates/zccache-cli", version = "1.9.1" }
-zccache-fingerprint = { path = "crates/zccache-fingerprint", version = "1.9.1" }
+zccache = { path = "crates/zccache" }
+zccache-watcher = { path = "crates/zccache-watcher" }
+zccache-cli = { path = "crates/zccache-cli" }
+zccache-fingerprint = { path = "crates/zccache-fingerprint" }
 
 # Vendored notify with fixes for Windows ReadDirectoryChangesW:
 # 1. Detect buffer overflow (bytes_written == 0) and report as error

--- a/ci/release_checks.py
+++ b/ci/release_checks.py
@@ -21,9 +21,22 @@ DYNAMIC_VERSION_PYPROJECTS = (
     ROOT / "crates" / "zccache-watcher" / "pyproject.toml",
     ROOT / "crates" / "zccache-fingerprint" / "pyproject.toml",
 )
-INTERNAL_CRATE_PREFIX = "zccache-"
+# Names whose workspace dep entries the release flow stamps with the
+# exact `=<workspace.package.version>` pin before `cargo publish`. After
+# the Wave 7 monocrate rename (`zccache-monocrate` -> `zccache`) the umbrella
+# crate name no longer matches the previous `startswith("zccache-")` filter,
+# so the publish flow silently skipped stamping `zccache` and crates.io
+# rejected the resulting path-only dep with
+# "all dependencies must have a version requirement specified". The set
+# is sourced from RUST_PUBLISH_ORDER so any new internal crate flows in
+# automatically.
+INTERNAL_CRATE_NAMES = frozenset(RUST_PUBLISH_ORDER)
+# Matches `<name> = { <body> }` where `<name>` is the umbrella `zccache`
+# *or* any `zccache-<suffix>` workspace member. Same rationale as the set
+# above: the umbrella crate is no longer hyphen-suffixed and was being
+# excluded by the previous regex.
 WORKSPACE_DEPENDENCY_RE = re.compile(
-    r"^(?P<name>zccache-[A-Za-z0-9_-]+)\s*=\s*\{\s*(?P<body>[^{}\n]*)\s*\}\s*$",
+    r"^(?P<name>zccache(?:-[A-Za-z0-9_-]+)?)\s*=\s*\{\s*(?P<body>[^{}\n]*)\s*\}\s*$",
     re.MULTILINE,
 )
 
@@ -60,7 +73,7 @@ def _internal_workspace_dependencies(
     return {
         name: spec
         for name, spec in workspace_deps.items()
-        if name.startswith(INTERNAL_CRATE_PREFIX)
+        if name in INTERNAL_CRATE_NAMES
         and isinstance(spec, dict)
         and "path" in spec
     }


### PR DESCRIPTION
## Summary
- Sixth (and hopefully last) bug in the release path exposed by the 1.9.0 → 1.9.1 bump.
- Root cause: after the Wave 7 monocrate rename (`zccache-monocrate` → `zccache`), the publish-time version-stamper silently stopped stamping the umbrella crate's workspace dep because both filters (`INTERNAL_CRATE_PREFIX = "zccache-"`, regex `zccache-X`) were prefix-based on `zccache-` with a trailing hyphen. Only the three sibling pyo3 cdylibs still matched.
- Net result: on the 5th Auto-Release attempt, 8/8 platform builds + PyPI publish succeeded; `cargo publish -p zccache-cli` then failed with `dependency zccache does not specify a version`.

## Fix
- `INTERNAL_CRATE_PREFIX` → `INTERNAL_CRATE_NAMES = frozenset(RUST_PUBLISH_ORDER)`. Any new internal crate added to `RUST_PUBLISH_ORDER` now flows through the stamper automatically.
- `WORKSPACE_DEPENDENCY_RE` widened from `zccache-X` to `zccache(-X)?` so it captures the umbrella line.

This supersedes #385 (which tried to hardcode `version =` in the workspace deps directly — but the preflight check correctly forbids that). #385's Cargo.toml change is reverted in the same commit.

## Local verification
- `stamp_internal_dependency_versions` on a fresh `Cargo.toml` now produces exact `version = "=1.9.1"` pins on **all four** intra-workspace deps (including the umbrella).
- Existing `ci/tests/test_release_workflow.py` suite passes (6 passed, 1 skipped).

## Why urgent
Still blocking zccache 1.9.1 → blocking soldr#476 (soldr#461 1.5 GB bundle fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)