### PR TITLE
chore(release): bump workspace 1.9.1 -> 1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.9.1"
+version = "1.10.0"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Minor bump preparing the next release after [#389](https://github.com/zackees/zccache/pull/389) (`zccache exec` generic tool caching, closing #272).

- New public CLI subcommand `zccache exec` → minor bump per semver
- `PROTOCOL_VERSION` 9 → 11 (issue #272 wave); CLI already surfaces a clear "Run `zccache stop`" message on mismatch

Required before `.github/workflows/release.yml` will publish — the workflow fails fast when `[workspace.package].version` matches the already-published latest release.

## Test plan

- [x] `soldr cargo check --workspace` — Cargo.lock refreshed cleanly with all four workspace crates moving to 1.10.0
- [ ] CI green
- [ ] After merge: tag `1.10.0` to trigger `release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)