### PR TITLE
chore(hooks): loc_guard error points at the < 1k refactor target

### DIFF
--- a/ci/hooks/loc_guard.py
+++ b/ci/hooks/loc_guard.py
@@ -57,7 +57,12 @@ def main():
     if loc > ERROR_THRESHOLD:
         print(
             f"LOC guard: {file_path} is {loc} lines (>{ERROR_THRESHOLD}). "
-            f"Split it into focused submodules before continuing.",
+            f"Split it into focused submodules before continuing. "
+            f"Refactor target: < {WARN_THRESHOLD} lines so the file has "
+            f"headroom and future edits don't re-trip this guard or the warn "
+            f"threshold. Convention: `foo.rs` → `foo/mod.rs` + per-domain "
+            f"submodules, with `pub use` re-exports in `mod.rs` so the public "
+            f"path is unchanged.",
             file=sys.stderr,
         )
         return 2
@@ -65,7 +70,10 @@ def main():
     if loc > WARN_THRESHOLD:
         print(
             f"LOC guard warning: {file_path} is {loc} lines (>{WARN_THRESHOLD}). "
-            f"Consider splitting it before it crosses {ERROR_THRESHOLD}.",
+            f"Refactor down to < {WARN_THRESHOLD} so future edits can land "
+            f"without nudging the file past {ERROR_THRESHOLD} and hard-blocking. "
+            f"Convention: `foo.rs` → `foo/mod.rs` + per-domain submodules, with "
+            f"`pub use` re-exports in `mod.rs` so the public path is unchanged.",
             file=sys.stderr,
         )
 


### PR DESCRIPTION
## Summary

The hard-block message previously said "split into focused submodules" without telling the dev what size to target. The result is a partial split: a 1600-line file becomes a 1450-line file and a 150-line file, and the very next edit trips the WARN threshold.

Update both the error and warn messages to explicitly tell the dev:

- refactor target is **< 1000 LOC**, not just < 1500
- the convention is `foo.rs` → `foo/mod.rs` + per-domain submodules with `pub use` re-exports, matching the precedent set by PRs #355–#363

So the next edit lands without tripping either threshold.

## Test plan

- [x] `python ci/hooks/loc_guard.py` syntax check (no functional flow change, just message text).
- [x] Hook still returns exit codes 0 / 2 in the existing cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)