### PR TITLE
chore(release): bump workspace version 1.10.0 -> 1.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.10.0"
+version = "1.11.0"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Minor bump for the new `zccache cc` subcommand (#391/#392) — a public CLI surface addition that downstream consumers (notably soldr's default-on `CC` / `CXX` injection from soldr#310, now on soldr main) depend on. Also picks up the loc_guard hook message tweak in #393 (non-functional).

```
[workspace.package]
-version = "1.10.0"
+version = "1.11.0"
```

Required before `release.yml` will publish — the workflow fails fast when `[workspace.package].version` equals the most recent published release.

## What ships in 1.11.0

- **`zccache cc` subcommand** (#391 / PR #392) — explicit cc-rs build-script wrapper entrypoint that soldr#310 wires into the cargo front door.
- **loc_guard hook copy fix** (#393) — error message now tells devs to refactor below the 1K warn threshold rather than just below the 1.5K block, so future edits don't re-trip the guard.

## Test plan

- [x] `soldr cargo check --workspace` — clean.
- [x] `Cargo.lock` regenerated; the four in-tree crates (`zccache`, `zccache-cli`, `zccache-fingerprint`, `zccache-watcher`) now show `version = "1.11.0"`.
- [ ] CI on this PR.
- [ ] After merge: trigger `release.yml` (push tag `v1.11.0` or workflow_dispatch with empty tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)