### PR TITLE
chore: release zccache 1.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "bincode",
  "blake3",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.11.1"
+version = "1.11.2"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- bump workspace version to 1.11.2
- release current main, including `fix: persist stdout-only exec artifacts before shutdown`

## Release sequencing
This schedules a new zccache release so soldr can pin a release that includes the latest stdout artifact persistence fix.

## Validation
- cargo fmt --check
- release metadata validation