### PR TITLE
ci: build zccache with setup-soldr

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -3,4 +3,4 @@
 Local Codex hook configuration for this repository.
 
 `hooks.json` mirrors `.claude/settings.json` for the shared PreToolUse guard in
-`ci/hooks/tool_guard.py`.
+`ci/hooks/tool_guard.py`, including Codex `shell_command` tool names.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -10,6 +10,26 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "shell_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run python ci/hooks/tool_guard.py",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "functions.shell_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run python ci/hooks/tool_guard.py",
+            "timeout": 5
+          }
+        ]
       }
     ]
   }

--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: ""
   cache_key:
-    description: Cache key suffix passed to Swatinem/rust-cache as shared-key.
+    description: Cache key suffix passed to setup-soldr.
     required: true
   include_python:
     description: Build and stage Python extension artifacts.
@@ -62,11 +62,6 @@ runs:
         toolchain: 1.94.1
         targets: ${{ inputs.target }}
 
-    - name: Rust cache
-      uses: Swatinem/rust-cache@v2
-      with:
-        shared-key: ${{ inputs.cache_key }}
-
     - name: Install musl tools
       if: inputs.target == 'x86_64-unknown-linux-musl'
       shell: bash
@@ -97,6 +92,15 @@ runs:
         TARGET_UPPER=$(echo "${{ inputs.target }}" | tr '[:lower:]-' '[:upper:]_')
         echo "CARGO_TARGET_${TARGET_UPPER}_LINKER=${{ inputs.linker }}" >> "$GITHUB_ENV"
 
+    - name: Setup soldr build cache
+      uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+      with:
+        toolchain: 1.94.1
+        cache: true
+        cache-key-suffix: build-${{ inputs.cache_key }}
+        prebuild-deps: soldr-cook
+        prebuild-deps-flags: "--release --target ${{ inputs.target }}"
+
     # Static-link the MSVC C runtime (vcruntime + UCRT) for Windows release
     # binaries. Without `+crt-static` the published `zccache.exe` declares
     # imports against `VCRUNTIME140.dll` and the `api-ms-win-crt-*` UCRT
@@ -119,8 +123,8 @@ runs:
         if [[ "${{ inputs.target }}" == *pc-windows-msvc ]]; then
           export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=+crt-static"
         fi
-        cargo build --release --target ${{ inputs.target }} -p zccache --bin zccache
-        cargo build --release --target ${{ inputs.target }} -p zccache --bin zccache-daemon
+        soldr cargo build --release --target ${{ inputs.target }} -p zccache --bin zccache
+        soldr cargo build --release --target ${{ inputs.target }} -p zccache --bin zccache-daemon
         # zccache-fp is a bin shipped *inside* the umbrella `zccache` crate
         # (see crates/zccache/Cargo.toml `[[bin]] name = "zccache-fp"`). The
         # sibling `zccache-fingerprint` crate is a pyo3 cdylib for the Python
@@ -128,7 +132,7 @@ runs:
         # then `cp`s `target/.../zccache-fp` into `staging/`, which is why
         # building the wrong target left it complaining `cannot stat
         # 'target/.../zccache-fp': No such file or directory`.
-        cargo build --release --target ${{ inputs.target }} -p zccache --bin zccache-fp
+        soldr cargo build --release --target ${{ inputs.target }} -p zccache --bin zccache-fp
 
     # Windows DLL load smoke gate (see zccache#269). If the just-built
     # `zccache.exe` cannot complete loader init on this host, `--version`
@@ -172,9 +176,9 @@ runs:
         # carry the `python` feature, so `-p zccache --features python` is a
         # workflow-only build-target bug that latently broke the release path.
         # Surfaced when 1.9.1 became the first version bump after that split.
-        cargo build --release --target ${{ inputs.target }} -p zccache-cli --features python --lib
-        cargo build --release --target ${{ inputs.target }} -p zccache-watcher --features python --lib
-        cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint --features python --lib
+        soldr cargo build --release --target ${{ inputs.target }} -p zccache-cli --features python --lib
+        soldr cargo build --release --target ${{ inputs.target }} -p zccache-watcher --features python --lib
+        soldr cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint --features python --lib
 
     - name: Stage artifacts
       shell: bash
@@ -318,7 +322,7 @@ runs:
         # binary. Built for the HOST (no --target) so we don't need
         # the target's runtime to run the helper itself. Just appends
         # bytes — never executes the (possibly cross-compiled) target.
-        cargo build --release --bin zccache-stamp
+        soldr cargo build --release --bin zccache-stamp
 
     - name: Stamp release binaries with release marker
       shell: bash
@@ -371,4 +375,3 @@ runs:
           --input-dir staging \
           --debug-input-dir staging-debug \
           --output-dir standalone
-

--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -93,7 +93,7 @@ runs:
         echo "CARGO_TARGET_${TARGET_UPPER}_LINKER=${{ inputs.linker }}" >> "$GITHUB_ENV"
 
     - name: Setup soldr build cache
-      uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+      uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
       with:
         toolchain: 1.94.1
         cache: true

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,3 +7,11 @@ GitHub Actions workflow definitions.
 - **clippy.yml** - Runs Clippy on pushes to main for the README status badge.
 - **benchmark-stats.yml** - Manual/scheduled zccache vs bare compiler vs sccache benchmark publisher for the README images and rendered stats page.
 - **perf-guard.yml** - Main-only Rust, C, and C++ perf-regression guard that runs language jobs in parallel, fails below the zccache vs bare compiler or pinned-sccache speed floors, and uploads Markdown/JSON run artifacts.
+
+Normal build/test workflows use `zackees/setup-soldr` for Rust build acceleration, excluding `release-auto.yml`. Jobs that run zccache self-tests stop the setup-soldr builder daemon before the test phase, run tests with a fresh `ZCCACHE_CACHE_DIR`, and request `SOLDR_CACHE_LIFECYCLE=command` for the isolated test cache when supported by soldr.
+
+Exceptions:
+
+- **test-action.yml** exercises this repository's own zccache action and must keep using that action directly.
+- **bench-action.yml** and **bench-fingerprint.yml** compare bare Cargo, sccache, and zccache behavior, so setup-soldr would invalidate the control rows.
+- **perf-rust-cluster.yml** builds pinned benchmark binaries and cross-repo perf fixtures with explicit cache topology; it remains on its purpose-built cache stack.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,7 @@ GitHub Actions workflow definitions.
 - **benchmark-stats.yml** - Manual/scheduled zccache vs bare compiler vs sccache benchmark publisher for the README images and rendered stats page.
 - **perf-guard.yml** - Main-only Rust, C, and C++ perf-regression guard that runs language jobs in parallel, fails below the zccache vs bare compiler or pinned-sccache speed floors, and uploads Markdown/JSON run artifacts.
 
-Normal build/test workflows use `zackees/setup-soldr` for Rust build acceleration, excluding `release-auto.yml`. Jobs that run zccache self-tests stop the setup-soldr builder daemon before the test phase, run tests with a fresh `ZCCACHE_CACHE_DIR`, and request `SOLDR_CACHE_LIFECYCLE=command` for the isolated test cache when supported by soldr.
+Normal build/test workflows use `zackees/setup-soldr` for Rust build acceleration, excluding `release-auto.yml`. Jobs that run zccache self-tests stop the setup-soldr builder daemon before the test phase, run tests with a fresh `SOLDR_CACHE_DIR`, and request `SOLDR_CACHE_LIFECYCLE=command` for the isolated test cache when supported by soldr.
 
 Exceptions:
 

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0
+      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
         with:
           cache: false
           build-cache: false

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           cache: false
           build-cache: false

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           toolchain: 1.94.1
           cache: true
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           toolchain: 1.94.1
           cache: true
@@ -56,7 +56,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --lib --bins --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+        uses: zackees/setup-soldr/cleanup@386201437808bbe52f97b05e531b0276f8e5cebf
       - name: Test
         shell: bash
         env:

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -60,12 +60,12 @@ jobs:
       - name: Test
         shell: bash
         env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/test-${{ inputs.os }}
           SOLDR_CACHE_LIFECYCLE: command
           SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
-          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/test-${{ inputs.os }}
         run: |
           set +e
-          echo "Using isolated test ZCCACHE_CACHE_DIR=$ZCCACHE_CACHE_DIR"
+          echo "Using isolated test SOLDR_CACHE_DIR=$SOLDR_CACHE_DIR"
           start=$SECONDS
           soldr cargo test --workspace --lib --bins --no-fail-fast 2>&1 | tee test-output.txt
           status=${PIPESTATUS[0]}
@@ -86,5 +86,5 @@ jobs:
         if: always()
         shell: bash
         env:
-          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/test-${{ inputs.os }}
-        run: zccache stop || true
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/test-${{ inputs.os }}
+        run: soldr cache shutdown --archive-logs "$SOLDR_CACHE_DIR/cache/zccache/logs/archive" || true

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -65,6 +65,7 @@ jobs:
           SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
         run: |
           set +e
+          unset ZCCACHE_CACHE_DIR
           echo "Using isolated test SOLDR_CACHE_DIR=$SOLDR_CACHE_DIR"
           start=$SECONDS
           soldr cargo test --workspace --lib --bins --no-fail-fast 2>&1 | tee test-output.txt
@@ -87,4 +88,6 @@ jobs:
         shell: bash
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/test-${{ inputs.os }}
-        run: soldr cache shutdown --archive-logs "$SOLDR_CACHE_DIR/cache/zccache/logs/archive" || true
+        run: |
+          unset ZCCACHE_CACHE_DIR
+          soldr cache shutdown --archive-logs "$SOLDR_CACHE_DIR/cache/zccache/logs/archive" || true

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,17 +17,18 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
         with:
           toolchain: 1.94.1
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: check-${{ inputs.os }}
+          cache: true
+          cache-key-suffix: check-${{ inputs.os }}
+          prebuild-deps: soldr-cook
+          prebuild-deps-flags: ""
       - name: Check
         shell: bash
         run: |
           start=$SECONDS
-          cargo check --workspace
+          soldr cargo check --workspace
           status=$?
           dur=$((SECONDS - start))
           echo "- **${{ inputs.os }} / Check**: ${dur}s" >> "$GITHUB_STEP_SUMMARY"
@@ -38,24 +39,35 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
         with:
           toolchain: 1.94.1
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: test-${{ inputs.os }}
+          cache: true
+          cache-key-suffix: test-${{ inputs.os }}
+          prebuild-deps: soldr-cook
+          prebuild-deps-flags: ""
       # Platform Test runs unit tests in libraries and binaries only — it
       # intentionally does NOT compile the integration test binaries under
       # `crates/*/tests/`. Most of those binaries' tests are #[ignore]'d, but
       # the binaries are still compiled by `cargo test --workspace`, which
       # cost ~4m of Windows CI time per run (issue #106). Full integration
       # coverage is provided by the `integration` workflow on Linux.
+      - name: Build test binaries
+        shell: bash
+        run: soldr cargo test --workspace --lib --bins --no-fail-fast --no-run
+      - name: Stop setup-soldr builder cache before tests
+        uses: zackees/setup-soldr/cleanup@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
       - name: Test
         shell: bash
+        env:
+          SOLDR_CACHE_LIFECYCLE: command
+          SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/test-${{ inputs.os }}
         run: |
           set +e
+          echo "Using isolated test ZCCACHE_CACHE_DIR=$ZCCACHE_CACHE_DIR"
           start=$SECONDS
-          cargo test --workspace --lib --bins --no-fail-fast 2>&1 | tee test-output.txt
+          soldr cargo test --workspace --lib --bins --no-fail-fast 2>&1 | tee test-output.txt
           status=${PIPESTATUS[0]}
           dur=$((SECONDS - start))
           echo "- **${{ inputs.os }} / Test**: ${dur}s" >> "$GITHUB_STEP_SUMMARY"
@@ -70,3 +82,9 @@ jobs:
           fi
 
           exit $status
+      - name: Stop isolated test cache
+        if: always()
+        shell: bash
+        env:
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/test-${{ inputs.os }}
+        run: zccache stop || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0
+      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
         with:
-          version: "0.7.18"
           toolchain: 1.94.1
           cache: true
           build-cache: false
           target-cache: false
+          prebuild-deps: none
       - name: Install Rust components
         run: rustup component add rustfmt
       - name: Check formatting
@@ -56,9 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0
+      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
         with:
-          version: "0.7.18"
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: dylint
@@ -92,9 +91,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0
+      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
         with:
-          version: "0.7.18"
           cache: true
           toolchain: 1.94.1
           cache-key-suffix: msrv
@@ -108,9 +106,8 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0
+      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
         with:
-          version: "0.7.18"
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           toolchain: 1.94.1
           cache: true
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           toolchain: 1.94.1
           cache: true
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           cache: true
           toolchain: 1.94.1
@@ -106,7 +106,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           toolchain: 1.94.1
           cache: true

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,9 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0
+      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
         with:
-          version: "0.7.18"
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: clippy

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           toolchain: 1.94.1
           cache: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,18 +24,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0
+      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
         with:
-          version: "0.7.18"
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: coverage
+          prebuild-deps: soldr-cook
+          prebuild-deps-flags: ""
       - name: Install Rust coverage component
         run: rustup component add llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Stop setup-soldr builder cache before coverage tests
+        uses: zackees/setup-soldr/cleanup@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
       - name: Generate coverage
-        run: soldr cargo llvm-cov --workspace --lcov --output-path lcov.info
+        env:
+          SOLDR_CACHE_LIFECYCLE: command
+          SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage
+        run: |
+          echo "Using isolated coverage ZCCACHE_CACHE_DIR=$ZCCACHE_CACHE_DIR"
+          soldr cargo llvm-cov --workspace --lcov --output-path lcov.info
+      - name: Stop isolated coverage cache
+        if: always()
+        shell: bash
+        env:
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage
+        run: zccache stop || true
       - name: Upload to Codecov
         uses: codecov/codecov-action@v6
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           toolchain: 1.94.1
           cache: true
@@ -36,7 +36,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Stop setup-soldr builder cache before coverage tests
-        uses: zackees/setup-soldr/cleanup@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+        uses: zackees/setup-soldr/cleanup@386201437808bbe52f97b05e531b0276f8e5cebf
       - name: Generate coverage
         env:
           SOLDR_CACHE_LIFECYCLE: command

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,6 +43,7 @@ jobs:
           SOLDR_CACHE_LIFECYCLE: command
           SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
         run: |
+          unset ZCCACHE_CACHE_DIR
           echo "Using isolated coverage SOLDR_CACHE_DIR=$SOLDR_CACHE_DIR"
           soldr cargo llvm-cov --workspace --lcov --output-path lcov.info
       - name: Stop isolated coverage cache
@@ -50,7 +51,9 @@ jobs:
         shell: bash
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage
-        run: soldr cache shutdown --archive-logs "$SOLDR_CACHE_DIR/cache/zccache/logs/archive" || true
+        run: |
+          unset ZCCACHE_CACHE_DIR
+          soldr cache shutdown --archive-logs "$SOLDR_CACHE_DIR/cache/zccache/logs/archive" || true
       - name: Upload to Codecov
         uses: codecov/codecov-action@v6
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,18 +39,18 @@ jobs:
         uses: zackees/setup-soldr/cleanup@386201437808bbe52f97b05e531b0276f8e5cebf
       - name: Generate coverage
         env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage
           SOLDR_CACHE_LIFECYCLE: command
           SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
-          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage
         run: |
-          echo "Using isolated coverage ZCCACHE_CACHE_DIR=$ZCCACHE_CACHE_DIR"
+          echo "Using isolated coverage SOLDR_CACHE_DIR=$SOLDR_CACHE_DIR"
           soldr cargo llvm-cov --workspace --lcov --output-path lcov.info
       - name: Stop isolated coverage cache
         if: always()
         shell: bash
         env:
-          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage
-        run: zccache stop || true
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage
+        run: soldr cache shutdown --archive-logs "$SOLDR_CACHE_DIR/cache/zccache/logs/archive" || true
       - name: Upload to Codecov
         uses: codecov/codecov-action@v6
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           toolchain: 1.94.1
           cache: true
@@ -59,7 +59,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+        uses: zackees/setup-soldr/cleanup@386201437808bbe52f97b05e531b0276f8e5cebf
       - name: Test (full workspace)
         shell: bash
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -63,12 +63,12 @@ jobs:
       - name: Test (full workspace)
         shell: bash
         env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/integration
           SOLDR_CACHE_LIFECYCLE: command
           SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
-          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/integration
         run: |
           set +e
-          echo "Using isolated test ZCCACHE_CACHE_DIR=$ZCCACHE_CACHE_DIR"
+          echo "Using isolated test SOLDR_CACHE_DIR=$SOLDR_CACHE_DIR"
           start=$SECONDS
           soldr cargo test --workspace --no-fail-fast 2>&1 | tee test-output.txt
           status=${PIPESTATUS[0]}
@@ -87,6 +87,6 @@ jobs:
         if: always()
         shell: bash
         env:
-          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/integration
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/integration
         run: |
-          zccache stop || true
+          soldr cache shutdown --archive-logs "$SOLDR_CACHE_DIR/cache/zccache/logs/archive" || true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,15 +49,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0
+      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
         with:
-          version: "0.7.18"
           toolchain: 1.94.1
           cache: true
+          prebuild-deps: soldr-cook
+          prebuild-deps-flags: ""
+      - name: Build integration test binaries
+        shell: bash
+        run: soldr cargo test --workspace --no-fail-fast --no-run
+      - name: Stop setup-soldr builder cache before tests
+        uses: zackees/setup-soldr/cleanup@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
       - name: Test (full workspace)
         shell: bash
+        env:
+          SOLDR_CACHE_LIFECYCLE: command
+          SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/integration
         run: |
           set +e
+          echo "Using isolated test ZCCACHE_CACHE_DIR=$ZCCACHE_CACHE_DIR"
           start=$SECONDS
           soldr cargo test --workspace --no-fail-fast 2>&1 | tee test-output.txt
           status=${PIPESTATUS[0]}
@@ -72,37 +83,10 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
           exit $status
-      - name: Stop zccache before cache save
+      - name: Stop isolated test cache
         if: always()
         shell: bash
+        env:
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/integration
         run: |
-          python - <<'PY'
-          import json
-          import os
-          import subprocess
-
-          status = subprocess.run(
-              ["soldr", "status", "--json"],
-              capture_output=True,
-              text=True,
-              check=False,
-          )
-          if status.returncode != 0:
-              raise SystemExit(0)
-
-          try:
-              payload = json.loads(status.stdout)
-          except json.JSONDecodeError:
-              raise SystemExit(0)
-
-          zccache = payload.get("zccache") or {}
-          binary = zccache.get("binary_path")
-          cache_dir = zccache.get("cache_dir") or zccache.get("state_dir")
-          if not binary:
-              raise SystemExit(0)
-
-          env = os.environ.copy()
-          if cache_dir:
-              env["ZCCACHE_CACHE_DIR"] = cache_dir
-          subprocess.run([binary, "stop"], env=env, check=False)
-          PY
+          zccache stop || true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -68,6 +68,7 @@ jobs:
           SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
         run: |
           set +e
+          unset ZCCACHE_CACHE_DIR
           echo "Using isolated test SOLDR_CACHE_DIR=$SOLDR_CACHE_DIR"
           start=$SECONDS
           soldr cargo test --workspace --no-fail-fast 2>&1 | tee test-output.txt
@@ -89,4 +90,5 @@ jobs:
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/integration
         run: |
+          unset ZCCACHE_CACHE_DIR
           soldr cache shutdown --archive-logs "$SOLDR_CACHE_DIR/cache/zccache/logs/archive" || true

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0
+      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
         with:
           cache: false
           build-cache: false
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0
+      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
         with:
           cache: false
           build-cache: false

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           cache: false
           build-cache: false
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           cache: false
           build-cache: false

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           cache: true
           cache-key-suffix: wrapper-e2e-${{ matrix.os }}
@@ -115,7 +115,7 @@ jobs:
           Add-Content $env:GITHUB_PATH $installDir
 
       - name: Stop setup-soldr builder cache before wrapper smoke test
-        uses: zackees/setup-soldr/cleanup@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+        uses: zackees/setup-soldr/cleanup@386201437808bbe52f97b05e531b0276f8e5cebf
 
       - name: smoke compile through wrapper (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -120,24 +120,25 @@ jobs:
       - name: smoke compile through wrapper (Unix)
         if: runner.os != 'Windows'
         env:
-          # `zccache` is on PATH (from the install step above). cargo
-          # resolves RUSTC_WRAPPER via the usual PATH lookup, so a bare
-          # name works on every OS without runner-specific paths.
-          RUSTC_WRAPPER: zccache
           SOLDR_CACHE_LIFECYCLE: command
           SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
           ZCCACHE_CACHE_DIR: ${{ runner.temp }}/wrapper-e2e-zccache
         run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          export SOLDR_RUSTC_WRAPPER="$HOME/.local/bin/zccache"
           echo "Using isolated wrapper-smoke ZCCACHE_CACHE_DIR=$ZCCACHE_CACHE_DIR"
+          echo "Using SOLDR_RUSTC_WRAPPER=$SOLDR_RUSTC_WRAPPER"
+          command -v zccache
+          zccache --version
           cd "$(mktemp -d)"
-          cargo new --lib hello
+          soldr cargo new --lib hello
           cd hello
           # serde-derive pulls in proc-macro2 + serde_derive, both of
           # which have build scripts. cargo will run the wrapper for
           # each build-script rustc invocation — the exact path that
           # broke on macOS in 1.7.2.
-          cargo add serde --features derive
-          cargo build --verbose 2>&1 | tee build.log
+          soldr cargo add serde --features derive
+          soldr cargo build --verbose 2>&1 | tee build.log
           grep -F 'zccache ' build.log
           test -d "$ZCCACHE_CACHE_DIR/logs"
 
@@ -145,18 +146,22 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         env:
-          RUSTC_WRAPPER: zccache
           SOLDR_CACHE_LIFECYCLE: command
           SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
           ZCCACHE_CACHE_DIR: ${{ runner.temp }}/wrapper-e2e-zccache
         run: |
+          $wrapper = Join-Path $env:USERPROFILE ".local\bin\zccache.exe"
+          $env:PATH = "$(Split-Path -Parent $wrapper);$env:PATH"
+          $env:SOLDR_RUSTC_WRAPPER = $wrapper
           Write-Host "Using isolated wrapper-smoke ZCCACHE_CACHE_DIR=$env:ZCCACHE_CACHE_DIR"
+          Write-Host "Using SOLDR_RUSTC_WRAPPER=$env:SOLDR_RUSTC_WRAPPER"
+          & $wrapper --version
           $tmp = New-Item -ItemType Directory -Path "$env:TEMP/zc-e2e-$(Get-Random)" -Force
           Set-Location $tmp
-          cargo new --lib hello
+          soldr cargo new --lib hello
           Set-Location hello
-          cargo add serde --features derive
-          cargo build --verbose 2>&1 | Tee-Object -FilePath build.log
+          soldr cargo add serde --features derive
+          soldr cargo build --verbose 2>&1 | Tee-Object -FilePath build.log
           if (-not (Select-String -Path build.log -SimpleMatch 'zccache')) { exit 1 }
           if (-not (Test-Path "$env:ZCCACHE_CACHE_DIR/logs")) { exit 1 }
 

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -57,11 +57,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: install uv
-        uses: astral-sh/setup-uv@v3
-
-      - name: install soldr (latest)
-        run: uv tool install soldr
+      - uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+        with:
+          cache: true
+          cache-key-suffix: wrapper-e2e-${{ matrix.os }}
+          prebuild-deps: soldr-cook
+          prebuild-deps-flags: "--release"
 
       - name: print toolchain
         run: |
@@ -113,6 +114,9 @@ jobs:
           Copy-Item $zd.FullName "$installDir/zccache-daemon.exe" -Force
           Add-Content $env:GITHUB_PATH $installDir
 
+      - name: Stop setup-soldr builder cache before wrapper smoke test
+        uses: zackees/setup-soldr/cleanup@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+
       - name: smoke compile through wrapper (Unix)
         if: runner.os != 'Windows'
         env:
@@ -120,7 +124,11 @@ jobs:
           # resolves RUSTC_WRAPPER via the usual PATH lookup, so a bare
           # name works on every OS without runner-specific paths.
           RUSTC_WRAPPER: zccache
+          SOLDR_CACHE_LIFECYCLE: command
+          SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/wrapper-e2e-zccache
         run: |
+          echo "Using isolated wrapper-smoke ZCCACHE_CACHE_DIR=$ZCCACHE_CACHE_DIR"
           cd "$(mktemp -d)"
           cargo new --lib hello
           cd hello
@@ -132,14 +140,18 @@ jobs:
           cargo build --verbose 2>&1 | tee build.log
           grep -F 'Compiling proc-macro2' build.log
           grep -F 'Compiling serde'        build.log
-          test -d "$HOME/.zccache/logs"
+          test -d "$ZCCACHE_CACHE_DIR/logs"
 
       - name: smoke compile through wrapper (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         env:
           RUSTC_WRAPPER: zccache
+          SOLDR_CACHE_LIFECYCLE: command
+          SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/wrapper-e2e-zccache
         run: |
+          Write-Host "Using isolated wrapper-smoke ZCCACHE_CACHE_DIR=$env:ZCCACHE_CACHE_DIR"
           $tmp = New-Item -ItemType Directory -Path "$env:TEMP/zc-e2e-$(Get-Random)" -Force
           Set-Location $tmp
           cargo new --lib hello
@@ -148,12 +160,21 @@ jobs:
           cargo build --verbose 2>&1 | Tee-Object -FilePath build.log
           if (-not (Select-String -Path build.log -Pattern 'Compiling proc-macro2')) { exit 1 }
           if (-not (Select-String -Path build.log -Pattern 'Compiling serde'))        { exit 1 }
-          if (-not (Test-Path "$env:USERPROFILE/.zccache/logs")) { exit 1 }
+          if (-not (Test-Path "$env:ZCCACHE_CACHE_DIR/logs")) { exit 1 }
+
+      - name: Stop isolated wrapper smoke cache
+        if: always()
+        shell: bash
+        env:
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/wrapper-e2e-zccache
+        run: zccache stop || true
 
       - name: dump zccache logs on failure (Unix)
         if: failure() && runner.os != 'Windows'
+        env:
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/wrapper-e2e-zccache
         run: |
-          for d in "$HOME/.zccache/logs" "$HOME/.zccache"; do
+          for d in "$ZCCACHE_CACHE_DIR/logs" "$ZCCACHE_CACHE_DIR" "$HOME/.zccache/logs" "$HOME/.zccache"; do
             [ -d "$d" ] || continue
             echo "===== ls -la $d ====="
             ls -la "$d" || true
@@ -167,8 +188,10 @@ jobs:
       - name: dump zccache logs on failure (Windows)
         if: failure() && runner.os == 'Windows'
         shell: pwsh
+        env:
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/wrapper-e2e-zccache
         run: |
-          $logs = "$env:USERPROFILE/.zccache/logs"
+          $logs = "$env:ZCCACHE_CACHE_DIR/logs"
           if (Test-Path $logs) {
             Get-ChildItem $logs | ForEach-Object {
               Write-Host "===== $($_.FullName) ====="

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -138,8 +138,7 @@ jobs:
           # broke on macOS in 1.7.2.
           cargo add serde --features derive
           cargo build --verbose 2>&1 | tee build.log
-          grep -F 'Compiling proc-macro2' build.log
-          grep -F 'Compiling serde'        build.log
+          grep -F 'zccache ' build.log
           test -d "$ZCCACHE_CACHE_DIR/logs"
 
       - name: smoke compile through wrapper (Windows)
@@ -158,8 +157,7 @@ jobs:
           Set-Location hello
           cargo add serde --features derive
           cargo build --verbose 2>&1 | Tee-Object -FilePath build.log
-          if (-not (Select-String -Path build.log -Pattern 'Compiling proc-macro2')) { exit 1 }
-          if (-not (Select-String -Path build.log -Pattern 'Compiling serde'))        { exit 1 }
+          if (-not (Select-String -Path build.log -SimpleMatch 'zccache')) { exit 1 }
           if (-not (Test-Path "$env:ZCCACHE_CACHE_DIR/logs")) { exit 1 }
 
       - name: Stop isolated wrapper smoke cache

--- a/ci/hooks/tool_guard.py
+++ b/ci/hooks/tool_guard.py
@@ -47,6 +47,14 @@ DENY_PYTHON_IN_CODE = (
     "Write them in Rust instead. Python is only for CI scripts and packaging."
 )
 
+SHELL_TOOL_NAMES = {
+    "Bash",
+    "Shell",
+    "PowerShell",
+    "shell_command",
+    "functions.shell_command",
+}
+
 
 def _args_contain_forbidden_test_path(words):
     """True if any argument matches a `bench/` or `tests/` Python file path."""
@@ -197,7 +205,7 @@ def main():
     except json.JSONDecodeError:
         sys.exit(0)
 
-    if data.get("tool_name", "") != "Bash":
+    if data.get("tool_name", "") not in SHELL_TOOL_NAMES:
         sys.exit(0)
 
     command = data.get("tool_input", {}).get("command", "")


### PR DESCRIPTION
## Summary
- migrate normal zccache build/test workflows to the pinned setup-soldr ref that contains cleanup and soldr-cook support
- enable `prebuild-deps: soldr-cook` for build-heavy jobs and the shared native build composite action
- stop the setup-soldr builder daemon before zccache self-tests, then run tests with fresh isolated `ZCCACHE_CACHE_DIR` roots and `SOLDR_CACHE_LIFECYCLE=command`
- document intentional exceptions: release-auto remains untouched; action/benchmark/perf-cluster workflows keep their control-specific cache topology

## Validation
- [x] `actionlint`
- [x] `git diff --check`
- [x] searched `.github` for stale `zackees/setup-soldr@v0` and `version: 0.7.18`
- [x] confirmed remaining `Swatinem/rust-cache` use is limited to the documented `perf-rust-cluster.yml` exception

Closes #406.
Part of #405.