### PR TITLE
ci: clean cargo-chef wrapper placeholders

### DIFF
--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -75,7 +75,13 @@ jobs:
       # `$HOME/.soldr/...`. The `--target-dir` is per-invocation; nothing
       # else in CI relies on it.
       - name: build zccache release binaries
-        run: soldr cargo build --release --target-dir target -p zccache --bin zccache -p zccache --bin zccache-daemon
+        run: |
+          # `soldr-cook` uses cargo-chef, whose recipe build can leave
+          # placeholder local-package binaries in target/release on cold
+          # caches. Clean this package before installing the wrapper that
+          # this workflow is specifically testing.
+          soldr cargo clean -p zccache --target-dir target
+          soldr cargo build --release --target-dir target -p zccache --bin zccache -p zccache --bin zccache-daemon
 
       - name: install binaries on PATH (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
Follow-up to #408 / #405.

The post-merge cold-cache wrapper-e2e run on main installed a cargo-chef placeholder local-package binary (`zccache v0.0.1`) from `target/release`, then failed the smoke build with an empty `rustc -vV` wrapper response.

This keeps `soldr-cook` enabled but runs `soldr cargo clean -p zccache --target-dir target` immediately before the release binary build, forcing the real wrapper binaries to replace any cargo-chef placeholders before the install step.

Validation:
- `actionlint .github/workflows/wrapper-e2e.yml`
- `git diff --check`
