### PR TITLE
ci: bump setup-soldr pin

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+      - uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           cache: false
           build-cache: false

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+      - uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           toolchain: 1.94.1
           cache: true
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+      - uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           toolchain: 1.94.1
           cache: true
@@ -56,7 +56,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --lib --bins --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@386201437808bbe52f97b05e531b0276f8e5cebf
+        uses: zackees/setup-soldr/cleanup@0425f54e37b65c5c36be1fb73628019b3e1aabed
       - name: Test
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+      - uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           toolchain: 1.94.1
           cache: true
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+      - uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           toolchain: 1.94.1
           cache: true
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+      - uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           cache: true
           toolchain: 1.94.1
@@ -106,7 +106,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+      - uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           toolchain: 1.94.1
           cache: true

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+      - uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           toolchain: 1.94.1
           cache: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+      - uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           toolchain: 1.94.1
           cache: true
@@ -36,7 +36,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Stop setup-soldr builder cache before coverage tests
-        uses: zackees/setup-soldr/cleanup@386201437808bbe52f97b05e531b0276f8e5cebf
+        uses: zackees/setup-soldr/cleanup@0425f54e37b65c5c36be1fb73628019b3e1aabed
       - name: Generate coverage
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+      - uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           toolchain: 1.94.1
           cache: true
@@ -59,7 +59,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@386201437808bbe52f97b05e531b0276f8e5cebf
+        uses: zackees/setup-soldr/cleanup@0425f54e37b65c5c36be1fb73628019b3e1aabed
       - name: Test (full workspace)
         shell: bash
         env:

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+      - uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           cache: false
           build-cache: false
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+      - uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           cache: false
           build-cache: false

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+      - uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           cache: true
           cache-key-suffix: wrapper-e2e-${{ matrix.os }}
@@ -121,7 +121,7 @@ jobs:
           Add-Content $env:GITHUB_PATH $installDir
 
       - name: Stop setup-soldr builder cache before wrapper smoke test
-        uses: zackees/setup-soldr/cleanup@386201437808bbe52f97b05e531b0276f8e5cebf
+        uses: zackees/setup-soldr/cleanup@0425f54e37b65c5c36be1fb73628019b3e1aabed
 
       - name: smoke compile through wrapper (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary

- bump all non-release setup-soldr and setup-soldr/cleanup workflow pins from `386201437808bbe52f97b05e531b0276f8e5cebf` to `0425f54e37b65c5c36be1fb73628019b3e1aabed`
- picks up setup-soldr#211 so isolated `SOLDR_CACHE_DIR` test roots use the pinned zccache seed instead of rebuilding zccache from source

Part of #405 and #407.

## Validation

- `actionlint .github/workflows/*.yml`
- `git diff --check`