### PR TITLE
feat(rust-plan): add protobuf delta bundles

### DIFF
--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -74,13 +74,33 @@ jobs:
       # soldr otherwise picks its own CARGO_TARGET_DIR under
       # `$HOME/.soldr/...`. The `--target-dir` is per-invocation; nothing
       # else in CI relies on it.
-      - name: build zccache release binaries
+      - name: clean zccache release package
         run: |
           # `soldr-cook` uses cargo-chef, whose recipe build can leave
           # placeholder local-package binaries in target/release on cold
           # caches. Clean this package before installing the wrapper that
           # this workflow is specifically testing.
           soldr cargo clean -p zccache --target-dir target
+
+      - name: remove stale release binaries (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          find target -path '*/release/zccache' -type f -not -path '*/deps/*' -delete || true
+          find target -path '*/release/zccache-daemon' -type f -not -path '*/deps/*' -delete || true
+
+      - name: remove stale release binaries (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Get-ChildItem -Recurse target -Filter zccache.exe -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match '\\release\\' -and $_.FullName -notmatch '\\deps\\' } |
+            Remove-Item -Force
+          Get-ChildItem -Recurse target -Filter zccache-daemon.exe -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match '\\release\\' -and $_.FullName -notmatch '\\deps\\' } |
+            Remove-Item -Force
+
+      - name: build zccache release binaries
+        run: |
           soldr cargo build --release --target-dir target -p zccache --bin zccache -p zccache --bin zccache-daemon
 
       - name: install binaries on PATH (Unix)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3719,6 +3719,7 @@ dependencies = [
  "memmap2",
  "mimalloc",
  "notify",
+ "prost",
  "rayon",
  "redb",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tempfile = "3"
 rayon = "1"
 jwalk = "0.8"
 bytes = "1"
+prost = "0.14"
 futures = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "stream"] }
 tokio-util = "0.7"

--- a/ci/hooks/tool_guard.py
+++ b/ci/hooks/tool_guard.py
@@ -216,6 +216,8 @@ def main():
     if result:
         _, reason = result
         deny(reason)
+        print(reason, file=sys.stderr)
+        sys.exit(2)
 
     sys.exit(0)
 

--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -33,6 +33,7 @@ sha2 = { workspace = true }
 # protocol
 bincode = { workspace = true }
 bytes = { workspace = true }
+prost = { workspace = true }
 
 # ipc + test-support: needs full tokio
 tokio = { workspace = true }
@@ -190,4 +191,3 @@ harness = false
 name = "exec"
 harness = false
 required-features = ["test-support"]
-

--- a/crates/zccache/src/artifact/mod.rs
+++ b/crates/zccache/src/artifact/mod.rs
@@ -14,11 +14,13 @@ pub use kv::{
     is_valid_namespace, Key, KvError, KvResult, KvStore, INLINE_THRESHOLD, MAX_VALUE_BYTES,
 };
 pub use rust_plan::{
-    restore_rust_plan_local, rust_plan_bundle_dir, rust_plan_cache_key, save_rust_plan_local,
-    RustArtifactBundleManifest, RustArtifactClass, RustArtifactPlanV1, RustBundledArtifact,
-    RustPlanArtifactEffectiveness, RustPlanCompatibility, RustPlanError, RustPlanInputs,
-    RustPlanMode, RustPlanOperation, RustPlanPackages, RustPlanSkippedSample, RustPlanSummary,
-    RustToolchainIdentity, RUST_ARTIFACT_CACHE_SCHEMA_VERSION, RUST_ARTIFACT_PLAN_SCHEMA_VERSION,
+    restore_rust_plan_layered_local, restore_rust_plan_local, rust_plan_bundle_dir,
+    rust_plan_cache_key, save_rust_plan_delta_local, save_rust_plan_local,
+    RustArtifactBundleLayerKind, RustArtifactBundleManifest, RustArtifactClass, RustArtifactPlanV1,
+    RustBundledArtifact, RustPlanArtifactEffectiveness, RustPlanCompatibility, RustPlanError,
+    RustPlanInputs, RustPlanMode, RustPlanOperation, RustPlanPackages, RustPlanSkippedSample,
+    RustPlanSummary, RustToolchainIdentity, RUST_ARTIFACT_CACHE_SCHEMA_VERSION,
+    RUST_ARTIFACT_PLAN_SCHEMA_VERSION,
 };
 pub use store::{ArtifactIndex, ArtifactStore};
 

--- a/crates/zccache/src/artifact/rust_plan.rs
+++ b/crates/zccache/src/artifact/rust_plan.rs
@@ -6,6 +6,7 @@ use std::path::{Component, Path};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::core::{normalize_for_key, NormalizedPath};
+use prost::Message;
 use rayon::prelude::*;
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
@@ -33,7 +34,8 @@ pub const SUPPORTED_RUST_ARTIFACT_CACHE_SCHEMA_VERSIONS: &[u32] = &[1, 2];
 /// outputs in the manifest itself.
 pub const RUST_ARTIFACT_CACHE_SCHEMA_VERSION: u32 = 1;
 
-const BUNDLE_MANIFEST_NAME: &str = "manifest.json";
+const BUNDLE_MANIFEST_NAME: &str = "manifest.pb";
+const LEGACY_BUNDLE_MANIFEST_NAME: &str = "manifest.json";
 const BUNDLE_FILES_DIR: &str = "files";
 
 /// Errors returned by plan loading and execution.
@@ -43,6 +45,10 @@ pub enum RustPlanError {
     Io(#[from] std::io::Error),
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
+    #[error("protobuf encode error: {0}")]
+    ProtobufEncode(#[from] prost::EncodeError),
+    #[error("protobuf decode error: {0}")]
+    ProtobufDecode(#[from] prost::DecodeError),
     #[error(
         "unsupported Rust artifact plan schema version {found}; supported version is {supported}"
     )]
@@ -202,16 +208,35 @@ pub struct RustArtifactPlanV1 {
 }
 
 impl RustArtifactPlanV1 {
-    /// Load, version-check, and validate a plan from a JSON file.
+    /// Load, version-check, and validate a plan from a protobuf or legacy JSON file.
     pub fn load(path: &Path) -> Result<Self, RustPlanError> {
-        let raw = std::fs::read_to_string(path)?;
-        Self::from_json_str(&raw)
+        let raw = std::fs::read(path)?;
+        if is_probably_json_plan(&raw) {
+            let raw = std::str::from_utf8(&raw).map_err(|err| {
+                RustPlanError::InvalidPlan(format!("JSON plan is not valid UTF-8: {err}"))
+            })?;
+            return Self::from_json_str(raw);
+        }
+        Self::from_proto_bytes(&raw)
     }
 
     /// Load, version-check, and validate a plan from a JSON string.
     pub fn from_json_str(raw: &str) -> Result<Self, RustPlanError> {
         let value: serde_json::Value = serde_json::from_str(raw.trim_start_matches('\u{feff}'))?;
         Self::from_json_value(value)
+    }
+
+    /// Load, version-check, and validate a plan from protobuf bytes.
+    pub fn from_proto_bytes(raw: &[u8]) -> Result<Self, RustPlanError> {
+        let proto = rust_plan_proto::RustArtifactPlanV1::decode(raw)?;
+        plan_from_proto(proto)
+    }
+
+    /// Encode this plan as compact protobuf bytes.
+    pub fn to_proto_bytes(&self) -> Result<Vec<u8>, RustPlanError> {
+        let mut bytes = Vec::new();
+        plan_to_proto(self).encode(&mut bytes)?;
+        Ok(bytes)
     }
 
     /// Load, version-check, and validate a plan from a JSON value.
@@ -275,6 +300,15 @@ impl RustArtifactPlanV1 {
             self.allowed_artifact_classes.iter().copied().collect()
         }
     }
+}
+
+fn is_probably_json_plan(raw: &[u8]) -> bool {
+    let without_bom = raw.strip_prefix(b"\xEF\xBB\xBF").unwrap_or(raw);
+    without_bom
+        .iter()
+        .copied()
+        .find(|byte| !byte.is_ascii_whitespace())
+        .is_some_and(|byte| byte == b'{')
 }
 
 /// Backend operation represented in summaries.
@@ -615,6 +649,17 @@ pub struct RustBundledArtifact {
     pub class: RustArtifactClass,
     pub size: u64,
     pub content_hash: String,
+    #[serde(default)]
+    pub mtime_unix_nanos: u64,
+}
+
+/// Layer kind for a Rust artifact bundle manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RustArtifactBundleLayerKind {
+    Complete,
+    Base,
+    Delta,
 }
 
 /// Manifest for zccache-owned Rust artifact bundles.
@@ -628,6 +673,434 @@ pub struct RustArtifactBundleManifest {
     pub created_at_secs: u64,
     pub plan_identity_hash: String,
     pub artifacts: Vec<RustBundledArtifact>,
+    #[serde(default = "default_bundle_layer_kind")]
+    pub layer_kind: RustArtifactBundleLayerKind,
+    #[serde(default)]
+    pub base_cache_key: Option<String>,
+    #[serde(default)]
+    pub deleted_paths: Vec<String>,
+}
+
+fn default_bundle_layer_kind() -> RustArtifactBundleLayerKind {
+    RustArtifactBundleLayerKind::Complete
+}
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+mod rust_plan_proto {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct RustArtifactPlanV1 {
+        #[prost(uint32, tag = "1")]
+        pub schema_version: u32,
+        #[prost(uint32, tag = "2")]
+        pub mode: u32,
+        #[prost(string, tag = "3")]
+        pub workspace_root: String,
+        #[prost(string, tag = "4")]
+        pub target_dir: String,
+        #[prost(message, optional, tag = "5")]
+        pub toolchain: Option<RustToolchainIdentity>,
+        #[prost(string, tag = "6")]
+        pub target_triple: String,
+        #[prost(string, tag = "7")]
+        pub profile: String,
+        #[prost(message, optional, tag = "8")]
+        pub inputs: Option<RustPlanInputs>,
+        #[prost(message, optional, tag = "9")]
+        pub packages: Option<RustPlanPackages>,
+        #[prost(uint32, repeated, tag = "10")]
+        pub allowed_artifact_classes: Vec<u32>,
+        #[prost(uint32, tag = "11")]
+        pub cache_schema_version: u32,
+        #[prost(string, tag = "12")]
+        pub journal_log_path: String,
+        #[prost(string, tag = "13")]
+        pub cache_profile: String,
+        #[prost(uint32, repeated, tag = "14")]
+        pub dropped_artifact_classes: Vec<u32>,
+    }
+
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct RustToolchainIdentity {
+        #[prost(string, tag = "1")]
+        pub rustc: String,
+        #[prost(string, tag = "2")]
+        pub cargo: String,
+        #[prost(string, tag = "3")]
+        pub channel: String,
+        #[prost(string, tag = "4")]
+        pub host: String,
+    }
+
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct RustPlanInputs {
+        #[prost(string, tag = "1")]
+        pub features_hash: String,
+        #[prost(string, tag = "2")]
+        pub rustflags_hash: String,
+        #[prost(string, tag = "3")]
+        pub env_hash: String,
+        #[prost(string, tag = "4")]
+        pub lockfile_hash: String,
+        #[prost(string, tag = "5")]
+        pub cargo_config_hash: String,
+        #[prost(string, repeated, tag = "6")]
+        pub manifest_hashes: Vec<String>,
+    }
+
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct RustPlanPackages {
+        #[prost(string, repeated, tag = "1")]
+        pub selected_package_ids: Vec<String>,
+        #[prost(string, repeated, tag = "2")]
+        pub workspace_package_ids: Vec<String>,
+        #[prost(string, repeated, tag = "3")]
+        pub excluded_path_package_ids: Vec<String>,
+    }
+
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct RustArtifactBundleManifest {
+        #[prost(uint32, tag = "1")]
+        pub manifest_schema_version: u32,
+        #[prost(uint32, tag = "2")]
+        pub plan_schema_version: u32,
+        #[prost(uint32, tag = "3")]
+        pub cache_schema_version: u32,
+        #[prost(uint32, tag = "4")]
+        pub mode: u32,
+        #[prost(string, tag = "5")]
+        pub cache_key: String,
+        #[prost(uint64, tag = "6")]
+        pub created_at_secs: u64,
+        #[prost(string, tag = "7")]
+        pub plan_identity_hash: String,
+        #[prost(message, repeated, tag = "8")]
+        pub artifacts: Vec<RustBundledArtifact>,
+        #[prost(uint32, tag = "9")]
+        pub layer_kind: u32,
+        #[prost(string, tag = "10")]
+        pub base_cache_key: String,
+        #[prost(string, repeated, tag = "11")]
+        pub deleted_paths: Vec<String>,
+    }
+
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct RustBundledArtifact {
+        #[prost(string, tag = "1")]
+        pub relative_path: String,
+        #[prost(uint32, tag = "2")]
+        pub class: u32,
+        #[prost(uint64, tag = "3")]
+        pub size: u64,
+        #[prost(string, tag = "4")]
+        pub content_hash: String,
+        #[prost(uint64, tag = "5")]
+        pub mtime_unix_nanos: u64,
+    }
+}
+
+fn plan_mode_to_proto(mode: RustPlanMode) -> u32 {
+    match mode {
+        RustPlanMode::Thin => 1,
+        RustPlanMode::Full => 2,
+    }
+}
+
+fn plan_mode_from_proto(value: u32) -> Result<RustPlanMode, RustPlanError> {
+    match value {
+        1 => Ok(RustPlanMode::Thin),
+        2 => Ok(RustPlanMode::Full),
+        other => Err(RustPlanError::InvalidManifest(format!(
+            "unknown plan mode code {other}"
+        ))),
+    }
+}
+
+fn artifact_class_to_proto(class: RustArtifactClass) -> u32 {
+    match class {
+        RustArtifactClass::Rlib => 1,
+        RustArtifactClass::Rmeta => 2,
+        RustArtifactClass::DepInfo => 3,
+        RustArtifactClass::ProcMacro => 4,
+        RustArtifactClass::SharedLib => 5,
+        RustArtifactClass::CargoFingerprint => 6,
+        RustArtifactClass::CargoFingerprintMeta => 7,
+        RustArtifactClass::CargoFingerprintOutputs => 8,
+        RustArtifactClass::BuildScriptMetadata => 9,
+        RustArtifactClass::BuildScriptOutput => 10,
+        RustArtifactClass::BuildScriptBuild => 11,
+        RustArtifactClass::Incremental => 12,
+        RustArtifactClass::Dwo => 13,
+        RustArtifactClass::Pdb => 14,
+        RustArtifactClass::Dsym => 15,
+        RustArtifactClass::FullTarget => 16,
+    }
+}
+
+fn artifact_class_from_proto(value: u32) -> Result<RustArtifactClass, RustPlanError> {
+    match value {
+        1 => Ok(RustArtifactClass::Rlib),
+        2 => Ok(RustArtifactClass::Rmeta),
+        3 => Ok(RustArtifactClass::DepInfo),
+        4 => Ok(RustArtifactClass::ProcMacro),
+        5 => Ok(RustArtifactClass::SharedLib),
+        6 => Ok(RustArtifactClass::CargoFingerprint),
+        7 => Ok(RustArtifactClass::CargoFingerprintMeta),
+        8 => Ok(RustArtifactClass::CargoFingerprintOutputs),
+        9 => Ok(RustArtifactClass::BuildScriptMetadata),
+        10 => Ok(RustArtifactClass::BuildScriptOutput),
+        11 => Ok(RustArtifactClass::BuildScriptBuild),
+        12 => Ok(RustArtifactClass::Incremental),
+        13 => Ok(RustArtifactClass::Dwo),
+        14 => Ok(RustArtifactClass::Pdb),
+        15 => Ok(RustArtifactClass::Dsym),
+        16 => Ok(RustArtifactClass::FullTarget),
+        other => Err(RustPlanError::InvalidManifest(format!(
+            "unknown artifact class code {other}"
+        ))),
+    }
+}
+
+fn layer_kind_to_proto(kind: RustArtifactBundleLayerKind) -> u32 {
+    match kind {
+        RustArtifactBundleLayerKind::Complete => 0,
+        RustArtifactBundleLayerKind::Base => 1,
+        RustArtifactBundleLayerKind::Delta => 2,
+    }
+}
+
+fn layer_kind_from_proto(value: u32) -> Result<RustArtifactBundleLayerKind, RustPlanError> {
+    match value {
+        0 => Ok(RustArtifactBundleLayerKind::Complete),
+        1 => Ok(RustArtifactBundleLayerKind::Base),
+        2 => Ok(RustArtifactBundleLayerKind::Delta),
+        other => Err(RustPlanError::InvalidManifest(format!(
+            "unknown layer kind code {other}"
+        ))),
+    }
+}
+
+fn normalized_path_to_proto(path: &NormalizedPath) -> String {
+    path.as_path().to_string_lossy().into_owned()
+}
+
+fn optional_normalized_path_to_proto(path: &Option<NormalizedPath>) -> String {
+    path.as_ref()
+        .map(normalized_path_to_proto)
+        .unwrap_or_default()
+}
+
+fn optional_normalized_path_from_proto(raw: String) -> Option<NormalizedPath> {
+    if raw.is_empty() {
+        None
+    } else {
+        Some(NormalizedPath::new(raw))
+    }
+}
+
+fn optional_string_from_proto(raw: String) -> Option<String> {
+    if raw.is_empty() {
+        None
+    } else {
+        Some(raw)
+    }
+}
+
+fn plan_to_proto(plan: &RustArtifactPlanV1) -> rust_plan_proto::RustArtifactPlanV1 {
+    rust_plan_proto::RustArtifactPlanV1 {
+        schema_version: plan.schema_version,
+        mode: plan_mode_to_proto(plan.mode),
+        workspace_root: normalized_path_to_proto(&plan.workspace_root),
+        target_dir: normalized_path_to_proto(&plan.target_dir),
+        toolchain: Some(rust_plan_proto::RustToolchainIdentity {
+            rustc: plan.toolchain.rustc.clone(),
+            cargo: plan.toolchain.cargo.clone(),
+            channel: plan.toolchain.channel.clone(),
+            host: plan.toolchain.host.clone(),
+        }),
+        target_triple: plan.target_triple.clone(),
+        profile: plan.profile.clone(),
+        inputs: Some(rust_plan_proto::RustPlanInputs {
+            features_hash: plan.inputs.features_hash.clone(),
+            rustflags_hash: plan.inputs.rustflags_hash.clone(),
+            env_hash: plan.inputs.env_hash.clone(),
+            lockfile_hash: plan.inputs.lockfile_hash.clone(),
+            cargo_config_hash: plan.inputs.cargo_config_hash.clone(),
+            manifest_hashes: plan.inputs.manifest_hashes.clone(),
+        }),
+        packages: Some(rust_plan_proto::RustPlanPackages {
+            selected_package_ids: plan.packages.selected_package_ids.clone(),
+            workspace_package_ids: plan.packages.workspace_package_ids.clone(),
+            excluded_path_package_ids: plan.packages.excluded_path_package_ids.clone(),
+        }),
+        allowed_artifact_classes: plan
+            .allowed_artifact_classes
+            .iter()
+            .copied()
+            .map(artifact_class_to_proto)
+            .collect(),
+        cache_schema_version: plan.cache_schema_version,
+        journal_log_path: optional_normalized_path_to_proto(&plan.journal_log_path),
+        cache_profile: plan.cache_profile.clone().unwrap_or_default(),
+        dropped_artifact_classes: plan
+            .dropped_artifact_classes
+            .iter()
+            .copied()
+            .map(artifact_class_to_proto)
+            .collect(),
+    }
+}
+
+fn plan_from_proto(
+    proto: rust_plan_proto::RustArtifactPlanV1,
+) -> Result<RustArtifactPlanV1, RustPlanError> {
+    if proto.schema_version != RUST_ARTIFACT_PLAN_SCHEMA_VERSION {
+        return Err(RustPlanError::UnsupportedSchemaVersion {
+            found: proto.schema_version,
+            supported: RUST_ARTIFACT_PLAN_SCHEMA_VERSION,
+        });
+    }
+    ensure_supported_cache_schema_version(proto.cache_schema_version)?;
+
+    let toolchain = proto
+        .toolchain
+        .ok_or_else(|| RustPlanError::InvalidPlan("toolchain is required".to_string()))?;
+    let inputs = proto
+        .inputs
+        .ok_or_else(|| RustPlanError::InvalidPlan("inputs are required".to_string()))?;
+    let packages = proto.packages.unwrap_or_default();
+    let plan = RustArtifactPlanV1 {
+        schema_version: proto.schema_version,
+        mode: plan_mode_from_proto(proto.mode)?,
+        workspace_root: NormalizedPath::new(proto.workspace_root),
+        target_dir: NormalizedPath::new(proto.target_dir),
+        toolchain: RustToolchainIdentity {
+            rustc: toolchain.rustc,
+            cargo: toolchain.cargo,
+            channel: toolchain.channel,
+            host: toolchain.host,
+        },
+        target_triple: proto.target_triple,
+        profile: proto.profile,
+        inputs: RustPlanInputs {
+            features_hash: inputs.features_hash,
+            rustflags_hash: inputs.rustflags_hash,
+            env_hash: inputs.env_hash,
+            lockfile_hash: inputs.lockfile_hash,
+            cargo_config_hash: inputs.cargo_config_hash,
+            manifest_hashes: inputs.manifest_hashes,
+        },
+        packages: RustPlanPackages {
+            selected_package_ids: packages.selected_package_ids,
+            workspace_package_ids: packages.workspace_package_ids,
+            excluded_path_package_ids: packages.excluded_path_package_ids,
+        },
+        allowed_artifact_classes: proto
+            .allowed_artifact_classes
+            .into_iter()
+            .map(artifact_class_from_proto)
+            .collect::<Result<Vec<_>, RustPlanError>>()?,
+        cache_schema_version: proto.cache_schema_version,
+        journal_log_path: optional_normalized_path_from_proto(proto.journal_log_path),
+        cache_profile: optional_string_from_proto(proto.cache_profile),
+        dropped_artifact_classes: proto
+            .dropped_artifact_classes
+            .into_iter()
+            .map(artifact_class_from_proto)
+            .collect::<Result<Vec<_>, RustPlanError>>()?,
+    };
+    plan.validate()?;
+    Ok(plan)
+}
+
+fn manifest_to_proto(
+    manifest: &RustArtifactBundleManifest,
+) -> rust_plan_proto::RustArtifactBundleManifest {
+    rust_plan_proto::RustArtifactBundleManifest {
+        manifest_schema_version: manifest.manifest_schema_version,
+        plan_schema_version: manifest.plan_schema_version,
+        cache_schema_version: manifest.cache_schema_version,
+        mode: plan_mode_to_proto(manifest.mode),
+        cache_key: manifest.cache_key.clone(),
+        created_at_secs: manifest.created_at_secs,
+        plan_identity_hash: manifest.plan_identity_hash.clone(),
+        artifacts: manifest
+            .artifacts
+            .iter()
+            .map(|artifact| rust_plan_proto::RustBundledArtifact {
+                relative_path: artifact.relative_path.clone(),
+                class: artifact_class_to_proto(artifact.class),
+                size: artifact.size,
+                content_hash: artifact.content_hash.clone(),
+                mtime_unix_nanos: artifact.mtime_unix_nanos,
+            })
+            .collect(),
+        layer_kind: layer_kind_to_proto(manifest.layer_kind),
+        base_cache_key: manifest.base_cache_key.clone().unwrap_or_default(),
+        deleted_paths: manifest.deleted_paths.clone(),
+    }
+}
+
+fn manifest_from_proto(
+    proto: rust_plan_proto::RustArtifactBundleManifest,
+) -> Result<RustArtifactBundleManifest, RustPlanError> {
+    Ok(RustArtifactBundleManifest {
+        manifest_schema_version: proto.manifest_schema_version,
+        plan_schema_version: proto.plan_schema_version,
+        cache_schema_version: proto.cache_schema_version,
+        mode: plan_mode_from_proto(proto.mode)?,
+        cache_key: proto.cache_key,
+        created_at_secs: proto.created_at_secs,
+        plan_identity_hash: proto.plan_identity_hash,
+        artifacts: proto
+            .artifacts
+            .into_iter()
+            .map(|artifact| {
+                Ok(RustBundledArtifact {
+                    relative_path: artifact.relative_path,
+                    class: artifact_class_from_proto(artifact.class)?,
+                    size: artifact.size,
+                    content_hash: artifact.content_hash,
+                    mtime_unix_nanos: artifact.mtime_unix_nanos,
+                })
+            })
+            .collect::<Result<Vec<_>, RustPlanError>>()?,
+        layer_kind: layer_kind_from_proto(proto.layer_kind)?,
+        base_cache_key: if proto.base_cache_key.is_empty() {
+            None
+        } else {
+            Some(proto.base_cache_key)
+        },
+        deleted_paths: proto.deleted_paths,
+    })
+}
+
+fn write_bundle_manifest(
+    bundle_dir: &Path,
+    manifest: &RustArtifactBundleManifest,
+) -> Result<(), RustPlanError> {
+    let mut bytes = Vec::new();
+    manifest_to_proto(manifest).encode(&mut bytes)?;
+    std::fs::write(bundle_dir.join(BUNDLE_MANIFEST_NAME), bytes)?;
+    let legacy_manifest = bundle_dir.join(LEGACY_BUNDLE_MANIFEST_NAME);
+    if legacy_manifest.exists() {
+        std::fs::remove_file(legacy_manifest)?;
+    }
+    Ok(())
+}
+
+fn read_bundle_manifest(bundle_dir: &Path) -> Result<RustArtifactBundleManifest, RustPlanError> {
+    let manifest_path = bundle_dir.join(BUNDLE_MANIFEST_NAME);
+    if manifest_path.exists() {
+        let proto = rust_plan_proto::RustArtifactBundleManifest::decode(
+            std::fs::read(manifest_path)?.as_slice(),
+        )?;
+        return manifest_from_proto(proto);
+    }
+
+    let legacy_manifest_path = bundle_dir.join(LEGACY_BUNDLE_MANIFEST_NAME);
+    let manifest: RustArtifactBundleManifest =
+        serde_json::from_slice(&std::fs::read(legacy_manifest_path)?)?;
+    Ok(manifest)
 }
 
 /// Compute the stable cache key for a plan.
@@ -718,9 +1191,11 @@ pub fn save_rust_plan_local(
         created_at_secs: now_secs(),
         plan_identity_hash: rust_plan_identity_hash(plan),
         artifacts,
+        layer_kind: RustArtifactBundleLayerKind::Complete,
+        base_cache_key: None,
+        deleted_paths: Vec::new(),
     };
-    let manifest_bytes = serde_json::to_vec_pretty(&manifest)?;
-    std::fs::write(bundle_dir.join(BUNDLE_MANIFEST_NAME), manifest_bytes)?;
+    write_bundle_manifest(&bundle_dir, &manifest)?;
     Ok(summary)
 }
 
@@ -776,13 +1251,25 @@ fn bundle_one_artifact(
         std::fs::create_dir_all(parent)?;
     }
     std::fs::copy(&sel.source_path, &dst)?;
-    let size = std::fs::metadata(&sel.source_path)?.len();
+    snapshot_selected_artifact(sel)
+}
+
+fn snapshot_selected_artifact(
+    sel: &SelectedArtifact,
+) -> Result<RustBundledArtifact, RustPlanError> {
+    let metadata = std::fs::metadata(&sel.source_path)?;
+    let size = metadata.len();
     let content_hash = crate::hash::hash_file(&sel.source_path)?.to_hex();
     Ok(RustBundledArtifact {
         relative_path: sel.relative_path.clone(),
         class: sel.class,
         size,
         content_hash,
+        mtime_unix_nanos: metadata
+            .modified()
+            .ok()
+            .map(system_time_to_unix_nanos)
+            .unwrap_or(0),
     })
 }
 
@@ -832,7 +1319,6 @@ pub fn restore_rust_plan_local(
     ensure_supported_cache_schema_version(plan.cache_schema_version)?;
     let cache_key = rust_plan_cache_key(plan);
     let bundle_dir = rust_plan_bundle_dir(cache_dir, &cache_key);
-    let files_dir = bundle_dir.join(BUNDLE_FILES_DIR);
     let mut summary = RustPlanSummary::new(
         RustPlanOperation::Restore,
         plan.mode,
@@ -849,19 +1335,39 @@ pub fn restore_rust_plan_local(
         return Ok(summary);
     }
 
-    let manifest_path = bundle_dir.join(BUNDLE_MANIFEST_NAME);
-    let manifest: RustArtifactBundleManifest =
-        serde_json::from_slice(&std::fs::read(&manifest_path)?)?;
+    let manifest = read_bundle_manifest(&bundle_dir)?;
     if !validate_manifest(plan, &cache_key, &manifest, &mut summary)? {
         summary.refresh_effectiveness(0);
         return Ok(summary);
     }
 
-    let now = SystemTime::now();
-    let file_times = std::fs::FileTimes::new()
-        .set_accessed(now)
-        .set_modified(now);
     let eligible = manifest.artifacts.len() as u64;
+    restore_manifest_artifacts(plan, &bundle_dir, &manifest, &mut summary)?;
+
+    summary.refresh_effectiveness(eligible);
+    Ok(summary)
+}
+
+fn restore_manifest_artifacts(
+    plan: &RustArtifactPlanV1,
+    bundle_dir: &Path,
+    manifest: &RustArtifactBundleManifest,
+    summary: &mut RustPlanSummary,
+) -> Result<(), RustPlanError> {
+    let files_dir = bundle_dir.join(BUNDLE_FILES_DIR);
+    for deleted_path in &manifest.deleted_paths {
+        let dst = match safe_join(plan.target_dir.as_path(), deleted_path) {
+            Ok(path) => path,
+            Err(err) => {
+                summary.skip(deleted_path, "path_traversal");
+                summary.compatibility.errors.push(err.to_string());
+                continue;
+            }
+        };
+        if dst.exists() {
+            std::fs::remove_file(&dst)?;
+        }
+    }
 
     for artifact in &manifest.artifacts {
         let src = match safe_join(&files_dir, &artifact.relative_path) {
@@ -918,14 +1424,21 @@ pub fn restore_rust_plan_local(
             std::fs::copy(&src, &dst)?;
         }
         if let Ok(file) = std::fs::File::open(&dst) {
+            let modified = if artifact.mtime_unix_nanos == 0 {
+                SystemTime::now()
+            } else {
+                unix_nanos_to_system_time(artifact.mtime_unix_nanos)
+            };
+            let file_times = std::fs::FileTimes::new()
+                .set_accessed(modified)
+                .set_modified(modified);
             let _ = file.set_times(file_times);
         }
         summary.restored_file_count += 1;
         summary.restored_bytes += artifact.size;
     }
 
-    summary.refresh_effectiveness(eligible);
-    Ok(summary)
+    Ok(())
 }
 
 fn validate_manifest(
@@ -960,6 +1473,17 @@ fn validate_manifest(
             .push("bundle input hash does not match requested plan".to_string());
         compatible = false;
     }
+    if manifest.layer_kind == RustArtifactBundleLayerKind::Delta
+        && manifest
+            .base_cache_key
+            .as_deref()
+            .is_some_and(|base_cache_key| base_cache_key != cache_key)
+    {
+        summary
+            .key_input_mismatches
+            .push("delta base cache key does not match requested plan".to_string());
+        compatible = false;
+    }
     if compatible {
         Ok(true)
     } else {
@@ -974,6 +1498,156 @@ struct SelectedArtifact {
     source_path: NormalizedPath,
     relative_path: String,
     class: RustArtifactClass,
+}
+
+/// Save only artifacts that differ from an already-restored base bundle.
+pub fn save_rust_plan_delta_local(
+    plan: &RustArtifactPlanV1,
+    base_cache_dir: &Path,
+    delta_cache_dir: &Path,
+) -> Result<RustPlanSummary, RustPlanError> {
+    plan.validate()?;
+    ensure_supported_cache_schema_version(plan.cache_schema_version)?;
+    let cache_key = rust_plan_cache_key(plan);
+    let base_bundle_dir = rust_plan_bundle_dir(base_cache_dir, &cache_key);
+    let delta_bundle_dir = rust_plan_bundle_dir(delta_cache_dir, &cache_key);
+    let delta_files_dir = delta_bundle_dir.join(BUNDLE_FILES_DIR);
+    let mut summary = RustPlanSummary::new(
+        RustPlanOperation::Save,
+        plan.mode,
+        plan.schema_version,
+        plan.cache_schema_version,
+        cache_key.clone(),
+        Some(delta_bundle_dir.clone()),
+        plan.journal_log_path.clone(),
+    );
+
+    let base_manifest = if base_bundle_dir.exists() {
+        let manifest = read_bundle_manifest(&base_bundle_dir)?;
+        if validate_manifest(plan, &cache_key, &manifest, &mut summary)? {
+            Some(manifest)
+        } else {
+            None
+        }
+    } else {
+        summary.record_skip("<base-bundle>", "base_bundle_missing_for_delta");
+        None
+    };
+    let base_artifacts: BTreeMap<String, RustBundledArtifact> = base_manifest
+        .as_ref()
+        .map(|manifest| {
+            manifest
+                .artifacts
+                .iter()
+                .map(|artifact| (artifact.relative_path.clone(), artifact.clone()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut candidates = Vec::new();
+    collect_files(plan.target_dir.as_path(), &mut candidates)?;
+    candidates.sort();
+    let selected = select_artifacts(plan, candidates, &mut summary);
+
+    if delta_bundle_dir.exists() {
+        std::fs::remove_dir_all(&delta_bundle_dir)?;
+    }
+    std::fs::create_dir_all(&delta_files_dir)?;
+
+    let mut current_paths = BTreeSet::new();
+    let mut artifacts = Vec::new();
+    for sel in &selected {
+        current_paths.insert(sel.relative_path.clone());
+        let snapshot = snapshot_selected_artifact(sel)?;
+        let unchanged = base_artifacts
+            .get(&sel.relative_path)
+            .map(|base| {
+                base.size == snapshot.size
+                    && base.content_hash == snapshot.content_hash
+                    && base.mtime_unix_nanos == snapshot.mtime_unix_nanos
+            })
+            .unwrap_or(false);
+        if unchanged {
+            continue;
+        }
+        let dst = safe_join(&delta_files_dir, &sel.relative_path)?;
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::copy(&sel.source_path, dst)?;
+        artifacts.push(snapshot);
+    }
+
+    let deleted_paths = base_artifacts
+        .keys()
+        .filter(|path| !current_paths.contains(*path))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    summary.saved_file_count += artifacts.len() as u64;
+    summary.saved_bytes += artifacts.iter().map(|artifact| artifact.size).sum::<u64>();
+
+    let manifest = RustArtifactBundleManifest {
+        manifest_schema_version: RUST_ARTIFACT_CACHE_SCHEMA_VERSION,
+        plan_schema_version: plan.schema_version,
+        cache_schema_version: plan.cache_schema_version,
+        mode: plan.mode,
+        cache_key: cache_key.clone(),
+        created_at_secs: now_secs(),
+        plan_identity_hash: rust_plan_identity_hash(plan),
+        artifacts,
+        layer_kind: RustArtifactBundleLayerKind::Delta,
+        base_cache_key: Some(cache_key),
+        deleted_paths,
+    };
+    write_bundle_manifest(&delta_bundle_dir, &manifest)?;
+    Ok(summary)
+}
+
+/// Restore a base bundle and then overlay a delta bundle.
+pub fn restore_rust_plan_layered_local(
+    plan: &RustArtifactPlanV1,
+    base_cache_dir: &Path,
+    delta_cache_dir: &Path,
+) -> Result<RustPlanSummary, RustPlanError> {
+    plan.validate()?;
+    ensure_supported_cache_schema_version(plan.cache_schema_version)?;
+    let cache_key = rust_plan_cache_key(plan);
+    let base_bundle_dir = rust_plan_bundle_dir(base_cache_dir, &cache_key);
+    let delta_bundle_dir = rust_plan_bundle_dir(delta_cache_dir, &cache_key);
+    let mut summary = RustPlanSummary::new(
+        RustPlanOperation::Restore,
+        plan.mode,
+        plan.schema_version,
+        plan.cache_schema_version,
+        cache_key.clone(),
+        Some(delta_bundle_dir.clone()),
+        plan.journal_log_path.clone(),
+    );
+
+    let mut eligible = 0_u64;
+    if base_bundle_dir.exists() {
+        let manifest = read_bundle_manifest(&base_bundle_dir)?;
+        if validate_manifest(plan, &cache_key, &manifest, &mut summary)? {
+            eligible += manifest.artifacts.len() as u64;
+            restore_manifest_artifacts(plan, &base_bundle_dir, &manifest, &mut summary)?;
+        }
+    } else {
+        summary.record_skip("<base-bundle>", "base_bundle_missing_for_layered_restore");
+    }
+
+    if delta_bundle_dir.exists() {
+        let manifest = read_bundle_manifest(&delta_bundle_dir)?;
+        if validate_manifest(plan, &cache_key, &manifest, &mut summary)? {
+            eligible += manifest.artifacts.len() as u64;
+            restore_manifest_artifacts(plan, &delta_bundle_dir, &manifest, &mut summary)?;
+        }
+    } else {
+        summary.record_skip("<delta-bundle>", "delta_bundle_missing_for_layered_restore");
+    }
+
+    summary.refresh_effectiveness(eligible);
+    Ok(summary)
 }
 
 fn select_artifacts(
@@ -1312,6 +1986,20 @@ fn now_secs() -> u64 {
         .as_secs()
 }
 
+fn system_time_to_unix_nanos(time: SystemTime) -> u64 {
+    let Ok(duration) = time.duration_since(UNIX_EPOCH) else {
+        return 0;
+    };
+    duration
+        .as_secs()
+        .saturating_mul(1_000_000_000)
+        .saturating_add(u64::from(duration.subsec_nanos()))
+}
+
+fn unix_nanos_to_system_time(nanos: u64) -> SystemTime {
+    UNIX_EPOCH + std::time::Duration::new(nanos / 1_000_000_000, (nanos % 1_000_000_000) as u32)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1363,15 +2051,29 @@ mod tests {
         std::fs::write(path, bytes).unwrap();
     }
 
+    fn set_mtime_nanos(path: &Path, nanos: u64) {
+        let time = unix_nanos_to_system_time(nanos);
+        let file_times = std::fs::FileTimes::new()
+            .set_accessed(time)
+            .set_modified(time);
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap();
+        file.set_times(file_times).unwrap();
+    }
+
+    fn file_mtime_nanos(path: &Path) -> u64 {
+        system_time_to_unix_nanos(std::fs::metadata(path).unwrap().modified().unwrap())
+    }
+
     fn load_manifest(bundle_dir: &Path) -> RustArtifactBundleManifest {
-        let manifest_path = bundle_dir.join(BUNDLE_MANIFEST_NAME);
-        serde_json::from_slice(&std::fs::read(manifest_path).unwrap()).unwrap()
+        read_bundle_manifest(bundle_dir).unwrap()
     }
 
     fn write_manifest(bundle_dir: &Path, manifest: &RustArtifactBundleManifest) {
-        let manifest_path = bundle_dir.join(BUNDLE_MANIFEST_NAME);
-        let bytes = serde_json::to_vec_pretty(manifest).unwrap();
-        std::fs::write(manifest_path, bytes).unwrap();
+        write_bundle_manifest(bundle_dir, manifest).unwrap();
     }
 
     fn synthetic_target(root: &Path) {
@@ -1590,6 +2292,26 @@ mod tests {
         let empty = RustArtifactPlanV1::from_json_value(plan_value).unwrap();
         assert_eq!(empty.effective_allowed_classes(), default_thin_classes());
     }
+
+    #[test]
+    fn rust_plan_load_accepts_protobuf_plan() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut plan = sample_plan(dir.path(), RustPlanMode::Thin);
+        plan.cache_schema_version = 2;
+        plan.cache_profile = Some("thin-v2".to_string());
+        plan.dropped_artifact_classes = vec![
+            RustArtifactClass::CargoFingerprintOutputs,
+            RustArtifactClass::BuildScriptBuild,
+            RustArtifactClass::Dwo,
+        ];
+        let plan_path = dir.path().join("plan.pb");
+
+        std::fs::write(&plan_path, plan.to_proto_bytes().unwrap()).unwrap();
+        let loaded = RustArtifactPlanV1::load(&plan_path).unwrap();
+
+        assert_eq!(loaded, plan);
+    }
+
     #[test]
     fn thin_save_restore_selects_dependency_artifacts_and_metadata() {
         let dir = tempfile::tempdir().unwrap();
@@ -1620,6 +2342,106 @@ mod tests {
             .exists());
         assert!(!plan.target_dir.join("debug/deps/libapp-abc.rlib").exists());
         assert!(!plan.target_dir.join("debug/incremental/state.bin").exists());
+    }
+
+    #[test]
+    fn save_writes_protobuf_manifest_and_restore_preserves_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        synthetic_target(dir.path());
+        let plan = sample_plan(dir.path(), RustPlanMode::Thin);
+        let cache = dir.path().join("cache");
+        let selected_file = plan.target_dir.join("debug/deps/libserde-abc.rlib");
+        let expected_mtime = 1_700_000_000_000_000_000;
+        set_mtime_nanos(&selected_file, expected_mtime);
+
+        save_rust_plan_local(&plan, &cache).unwrap();
+        let bundle_dir = rust_plan_bundle_dir(&cache, &rust_plan_cache_key(&plan));
+        assert!(bundle_dir.join(BUNDLE_MANIFEST_NAME).exists());
+        assert!(!bundle_dir.join(LEGACY_BUNDLE_MANIFEST_NAME).exists());
+        let manifest = load_manifest(&bundle_dir);
+        let artifact = manifest
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.relative_path == "debug/deps/libserde-abc.rlib")
+            .unwrap();
+        assert_eq!(artifact.mtime_unix_nanos, expected_mtime);
+
+        std::fs::remove_dir_all(plan.target_dir.as_path()).unwrap();
+        restore_rust_plan_local(&plan, &cache).unwrap();
+        assert_eq!(file_mtime_nanos(&selected_file), expected_mtime);
+    }
+
+    #[test]
+    fn delta_save_and_layered_restore_overlay_base_with_changes_and_tombstones() {
+        let dir = tempfile::tempdir().unwrap();
+        synthetic_target(dir.path());
+        let plan = sample_plan(dir.path(), RustPlanMode::Thin);
+        let base_cache = dir.path().join("base-cache");
+        let delta_cache = dir.path().join("delta-cache");
+
+        save_rust_plan_local(&plan, &base_cache).unwrap();
+
+        let unchanged_large = plan.target_dir.join("debug/deps/libserde-abc.rlib");
+        let changed = plan.target_dir.join("debug/deps/libserde-abc.rmeta");
+        let deleted = plan.target_dir.join("debug/deps/serde-abc.d");
+        write(&changed, b"serde rmeta changed");
+        let changed_mtime = 1_700_000_100_000_000_000;
+        set_mtime_nanos(&changed, changed_mtime);
+        std::fs::remove_file(&deleted).unwrap();
+
+        let saved_delta = save_rust_plan_delta_local(&plan, &base_cache, &delta_cache).unwrap();
+        assert_eq!(saved_delta.saved_file_count, 1);
+        let delta_bundle = rust_plan_bundle_dir(&delta_cache, &rust_plan_cache_key(&plan));
+        let delta_manifest = load_manifest(&delta_bundle);
+        assert_eq!(
+            delta_manifest.layer_kind,
+            RustArtifactBundleLayerKind::Delta
+        );
+        assert_eq!(delta_manifest.artifacts.len(), 1);
+        assert_eq!(
+            delta_manifest.artifacts[0].relative_path,
+            "debug/deps/libserde-abc.rmeta"
+        );
+        assert_eq!(delta_manifest.artifacts[0].mtime_unix_nanos, changed_mtime);
+        assert!(delta_manifest
+            .deleted_paths
+            .contains(&"debug/deps/serde-abc.d".to_string()));
+        assert!(!delta_bundle
+            .join(BUNDLE_FILES_DIR)
+            .join("debug/deps/libserde-abc.rlib")
+            .exists());
+
+        std::fs::remove_dir_all(plan.target_dir.as_path()).unwrap();
+        let restored = restore_rust_plan_layered_local(&plan, &base_cache, &delta_cache).unwrap();
+        assert_eq!(restored.restored_file_count, 7);
+        assert_eq!(std::fs::read(&changed).unwrap(), b"serde rmeta changed");
+        assert_eq!(file_mtime_nanos(&changed), changed_mtime);
+        assert_eq!(std::fs::read(&unchanged_large).unwrap(), b"serde rlib");
+        assert!(!deleted.exists());
+    }
+
+    #[test]
+    fn delta_save_treats_mtime_only_changes_as_different() {
+        let dir = tempfile::tempdir().unwrap();
+        synthetic_target(dir.path());
+        let plan = sample_plan(dir.path(), RustPlanMode::Thin);
+        let base_cache = dir.path().join("base-cache");
+        let delta_cache = dir.path().join("delta-cache");
+        let changed = plan.target_dir.join("debug/deps/libserde-abc.rlib");
+
+        save_rust_plan_local(&plan, &base_cache).unwrap();
+        let changed_mtime = 1_700_000_200_000_000_000;
+        set_mtime_nanos(&changed, changed_mtime);
+
+        let saved_delta = save_rust_plan_delta_local(&plan, &base_cache, &delta_cache).unwrap();
+        assert_eq!(saved_delta.saved_file_count, 1);
+        let delta_bundle = rust_plan_bundle_dir(&delta_cache, &rust_plan_cache_key(&plan));
+        let delta_manifest = load_manifest(&delta_bundle);
+        assert_eq!(
+            delta_manifest.artifacts[0].relative_path,
+            "debug/deps/libserde-abc.rlib"
+        );
+        assert_eq!(delta_manifest.artifacts[0].mtime_unix_nanos, changed_mtime);
     }
 
     #[test]

--- a/crates/zccache/src/artifact/rust_plan_manifest.proto
+++ b/crates/zccache/src/artifact/rust_plan_manifest.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+package zccache.rust_plan.v1;
+
+message RustArtifactPlanV1 {
+  uint32 schema_version = 1;
+  uint32 mode = 2;
+  string workspace_root = 3;
+  string target_dir = 4;
+  RustToolchainIdentity toolchain = 5;
+  string target_triple = 6;
+  string profile = 7;
+  RustPlanInputs inputs = 8;
+  RustPlanPackages packages = 9;
+  repeated uint32 allowed_artifact_classes = 10;
+  uint32 cache_schema_version = 11;
+  string journal_log_path = 12;
+  string cache_profile = 13;
+  repeated uint32 dropped_artifact_classes = 14;
+}
+
+message RustToolchainIdentity {
+  string rustc = 1;
+  string cargo = 2;
+  string channel = 3;
+  string host = 4;
+}
+
+message RustPlanInputs {
+  string features_hash = 1;
+  string rustflags_hash = 2;
+  string env_hash = 3;
+  string lockfile_hash = 4;
+  string cargo_config_hash = 5;
+  repeated string manifest_hashes = 6;
+}
+
+message RustPlanPackages {
+  repeated string selected_package_ids = 1;
+  repeated string workspace_package_ids = 2;
+  repeated string excluded_path_package_ids = 3;
+}
+
+message RustArtifactBundleManifest {
+  uint32 manifest_schema_version = 1;
+  uint32 plan_schema_version = 2;
+  uint32 cache_schema_version = 3;
+  uint32 mode = 4;
+  string cache_key = 5;
+  uint64 created_at_secs = 6;
+  string plan_identity_hash = 7;
+  repeated RustBundledArtifact artifacts = 8;
+  uint32 layer_kind = 9;
+  string base_cache_key = 10;
+  repeated string deleted_paths = 11;
+}
+
+message RustBundledArtifact {
+  string relative_path = 1;
+  uint32 class = 2;
+  uint64 size = 3;
+  string content_hash = 4;
+  uint64 mtime_unix_nanos = 5;
+}

--- a/crates/zccache/src/bin/zccache.rs
+++ b/crates/zccache/src/bin/zccache.rs
@@ -18,13 +18,32 @@
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-#[cfg(windows)]
-#[global_allocator]
-static GLOBAL_WIN: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 use std::process::ExitCode;
 
+#[cfg(windows)]
 fn main() -> ExitCode {
+    match std::thread::Builder::new()
+        .name("zccache-cli".to_string())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(run_main)
+    {
+        Ok(handle) => match handle.join() {
+            Ok(code) => code,
+            Err(_) => ExitCode::FAILURE,
+        },
+        Err(err) => {
+            eprintln!("zccache: failed to start CLI thread: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(not(windows))]
+fn main() -> ExitCode {
+    run_main()
+}
+
+fn run_main() -> ExitCode {
     // Crash coverage first thing: panic hook + native signal/SEH
     // handler so a fault inside arg parsing or symbol install still
     // leaves a dump under `~/.zccache/crashes/`. Guard stays alive

--- a/crates/zccache/src/cli/commands/args.rs
+++ b/crates/zccache/src/cli/commands/args.rs
@@ -638,7 +638,7 @@ pub(crate) enum GhaCacheCommands {
 pub(crate) enum RustPlanCommands {
     /// Validate a soldr-generated Rust artifact plan.
     Validate {
-        /// Path to the plan JSON file.
+        /// Path to the protobuf plan file, or a legacy JSON plan.
         #[arg(long)]
         plan: String,
         /// Print a machine-readable JSON summary.
@@ -659,7 +659,7 @@ pub(crate) enum RustPlanCommands {
     },
     /// Restore Rust target artifacts from a saved plan bundle.
     Restore {
-        /// Path to the plan JSON file.
+        /// Path to the protobuf plan file, or a legacy JSON plan.
         #[arg(long)]
         plan: String,
         /// Print a machine-readable JSON summary.
@@ -681,9 +681,33 @@ pub(crate) enum RustPlanCommands {
         #[arg(long = "cache-dir")]
         cache_dir: Option<String>,
     },
+    /// Restore Rust target artifacts from base and delta plan bundles.
+    RestoreLayered {
+        /// Path to the protobuf plan file, or a legacy JSON plan.
+        #[arg(long)]
+        plan: String,
+        /// Print a machine-readable JSON summary.
+        #[arg(long)]
+        json: bool,
+        /// Active zccache session ID whose compile-cache stats should be included.
+        #[arg(long = "session-id")]
+        session_id: Option<String>,
+        /// IPC endpoint for session stats lookup.
+        #[arg(long)]
+        endpoint: Option<String>,
+        /// Journal/log path to report in the summary, overriding the plan path.
+        #[arg(long)]
+        journal: Option<String>,
+        /// Local cache directory containing the base bundle.
+        #[arg(long = "base-cache-dir")]
+        base_cache_dir: String,
+        /// Local cache directory containing the delta bundle.
+        #[arg(long = "delta-cache-dir")]
+        delta_cache_dir: String,
+    },
     /// Save Rust target artifacts selected by a plan.
     Save {
-        /// Path to the plan JSON file.
+        /// Path to the protobuf plan file, or a legacy JSON plan.
         #[arg(long)]
         plan: String,
         /// Print a machine-readable JSON summary.
@@ -704,6 +728,30 @@ pub(crate) enum RustPlanCommands {
         /// Local cache directory used for bundle storage.
         #[arg(long = "cache-dir")]
         cache_dir: Option<String>,
+    },
+    /// Save only Rust target artifacts that differ from a base plan bundle.
+    SaveDelta {
+        /// Path to the protobuf plan file, or a legacy JSON plan.
+        #[arg(long)]
+        plan: String,
+        /// Print a machine-readable JSON summary.
+        #[arg(long)]
+        json: bool,
+        /// Active zccache session ID whose compile-cache stats should be included.
+        #[arg(long = "session-id")]
+        session_id: Option<String>,
+        /// IPC endpoint for session stats lookup.
+        #[arg(long)]
+        endpoint: Option<String>,
+        /// Journal/log path to report in the summary, overriding the plan path.
+        #[arg(long)]
+        journal: Option<String>,
+        /// Local cache directory containing the base bundle.
+        #[arg(long = "base-cache-dir")]
+        base_cache_dir: String,
+        /// Local cache directory that will receive the delta bundle.
+        #[arg(long = "delta-cache-dir")]
+        delta_cache_dir: String,
     },
 }
 

--- a/crates/zccache/src/cli/commands/rust_plan.rs
+++ b/crates/zccache/src/cli/commands/rust_plan.rs
@@ -1,8 +1,9 @@
 //! `zccache rust-plan` subcommands and helpers.
 
 use crate::artifact::{
-    restore_rust_plan_local, rust_plan_bundle_dir, rust_plan_cache_key, save_rust_plan_local,
-    RustArtifactPlanV1, RustPlanError, RustPlanOperation, RustPlanSummary,
+    restore_rust_plan_layered_local, restore_rust_plan_local, rust_plan_bundle_dir,
+    rust_plan_cache_key, save_rust_plan_delta_local, save_rust_plan_local, RustArtifactPlanV1,
+    RustPlanError, RustPlanOperation, RustPlanSummary,
 };
 use crate::core::NormalizedPath;
 use crate::gha::{GhaCache, GhaError};
@@ -129,6 +130,41 @@ pub(crate) async fn cmd_rust_plan(action: RustPlanCommands) -> ExitCode {
                 }
             }
         }
+        RustPlanCommands::RestoreLayered {
+            plan,
+            json,
+            session_id,
+            endpoint,
+            journal,
+            base_cache_dir,
+            delta_cache_dir,
+        } => {
+            let plan = match load_rust_plan_for_cli(&plan, RustPlanOperation::Restore, json) {
+                Ok(plan) => plan,
+                Err(code) => return code,
+            };
+            match restore_rust_plan_layered_local(
+                &plan,
+                Path::new(&base_cache_dir),
+                Path::new(&delta_cache_dir),
+            ) {
+                Ok(mut summary) => {
+                    enrich_rust_plan_summary(
+                        &mut summary,
+                        session_id.as_deref(),
+                        endpoint.as_deref(),
+                        journal.as_deref(),
+                    )
+                    .await;
+                    print_rust_plan_summary(&summary, json);
+                    ExitCode::SUCCESS
+                }
+                Err(err) => {
+                    print_rust_plan_error(RustPlanOperation::Restore, &err, json);
+                    ExitCode::FAILURE
+                }
+            }
+        }
         RustPlanCommands::Save {
             plan,
             json,
@@ -165,6 +201,41 @@ pub(crate) async fn cmd_rust_plan(action: RustPlanCommands) -> ExitCode {
                         &err,
                         json,
                     );
+                    ExitCode::FAILURE
+                }
+            }
+        }
+        RustPlanCommands::SaveDelta {
+            plan,
+            json,
+            session_id,
+            endpoint,
+            journal,
+            base_cache_dir,
+            delta_cache_dir,
+        } => {
+            let plan = match load_rust_plan_for_cli(&plan, RustPlanOperation::Save, json) {
+                Ok(plan) => plan,
+                Err(code) => return code,
+            };
+            match save_rust_plan_delta_local(
+                &plan,
+                Path::new(&base_cache_dir),
+                Path::new(&delta_cache_dir),
+            ) {
+                Ok(mut summary) => {
+                    enrich_rust_plan_summary(
+                        &mut summary,
+                        session_id.as_deref(),
+                        endpoint.as_deref(),
+                        journal.as_deref(),
+                    )
+                    .await;
+                    print_rust_plan_summary(&summary, json);
+                    ExitCode::SUCCESS
+                }
+                Err(err) => {
+                    print_rust_plan_error(RustPlanOperation::Save, &err, json);
                     ExitCode::FAILURE
                 }
             }
@@ -227,7 +298,7 @@ fn resolve_rust_plan_backend(backend: RustPlanBackendArg) -> RustPlanBackendArg 
 }
 
 pub(crate) fn rust_plan_gha_version(cache_key: &str) -> String {
-    GhaCache::version_hash(&["zccache-rust-plan-v1", cache_key])
+    GhaCache::version_hash(&["zccache-rust-plan-v2-protobuf", cache_key])
 }
 
 async fn restore_rust_plan_gha(

--- a/crates/zccache/src/cli/commands/tests/args_parsing.rs
+++ b/crates/zccache/src/cli/commands/tests/args_parsing.rs
@@ -79,6 +79,44 @@ fn rust_plan_cli_parses_validate_restore_save() {
             }
         })
     ));
+
+    let restore_layered = Cli::try_parse_from([
+        "zccache",
+        "rust-plan",
+        "restore-layered",
+        "--plan",
+        "plan.json",
+        "--base-cache-dir",
+        ".cache/base",
+        "--delta-cache-dir",
+        ".cache/delta",
+    ])
+    .unwrap();
+    assert!(matches!(
+        restore_layered.command,
+        Some(Commands::RustPlan {
+            action: RustPlanCommands::RestoreLayered { .. }
+        })
+    ));
+
+    let save_delta = Cli::try_parse_from([
+        "zccache",
+        "rust-plan",
+        "save-delta",
+        "--plan",
+        "plan.json",
+        "--base-cache-dir",
+        ".cache/base",
+        "--delta-cache-dir",
+        ".cache/delta",
+    ])
+    .unwrap();
+    assert!(matches!(
+        save_delta.command,
+        Some(Commands::RustPlan {
+            action: RustPlanCommands::SaveDelta { .. }
+        })
+    ));
 }
 
 #[test]

--- a/crates/zccache/tests/cli_rust_plan_lifecycle.rs
+++ b/crates/zccache/tests/cli_rust_plan_lifecycle.rs
@@ -417,11 +417,12 @@ fn rust_plan_auto_backend_without_gha_env_uses_local_backend() {
     write_synthetic_full_target(&target_dir);
 
     let plan = synthetic_full_plan(root, &target_dir);
-    let plan_path = root.join("auto-plan.json");
-    write_file(
+    let plan_path = root.join("auto-plan.pb");
+    fs::write(
         &plan_path,
-        &serde_json::to_string_pretty(&plan).expect("serialize plan"),
-    );
+        plan.to_proto_bytes().expect("serialize protobuf rust plan"),
+    )
+    .expect("write protobuf rust plan");
 
     let plan_path_str = plan_path.to_string_lossy().to_string();
     let cache_dir_str = cache_dir.to_string_lossy().to_string();

--- a/docs/architecture/rust-artifact-plan.md
+++ b/docs/architecture/rust-artifact-plan.md
@@ -37,8 +37,9 @@ Cargo workspace model by itself.
 
 ## Plan Inputs
 
-The v1 JSON plan carries the minimum information needed for deterministic
-restore/save decisions:
+The v1 plan carries the minimum information needed for deterministic
+restore/save decisions. zccache accepts compact protobuf plans and legacy JSON
+plans during migration:
 
 - selected mode: `thin` or `full`
 - workspace root
@@ -151,9 +152,9 @@ beyond the inputs it is given.
 The stable CLI surface for `soldr` and `setup-soldr` is:
 
 ```text
-zccache rust-plan validate --plan <plan.json> [--json] [--cache-dir <dir>] [--session-id <id>] [--endpoint <ipc>] [--journal <path.jsonl>]
-zccache rust-plan restore  --plan <plan.json> [--json] [--backend auto|local|gha] [--cache-dir <dir>] [--session-id <id>] [--endpoint <ipc>] [--journal <path.jsonl>]
-zccache rust-plan save     --plan <plan.json> [--json] [--backend auto|local|gha] [--cache-dir <dir>] [--session-id <id>] [--endpoint <ipc>] [--journal <path.jsonl>]
+zccache rust-plan validate --plan <plan.pb> [--json] [--cache-dir <dir>] [--session-id <id>] [--endpoint <ipc>] [--journal <path.jsonl>]
+zccache rust-plan restore  --plan <plan.pb> [--json] [--backend auto|local|gha] [--cache-dir <dir>] [--session-id <id>] [--endpoint <ipc>] [--journal <path.jsonl>]
+zccache rust-plan save     --plan <plan.pb> [--json] [--backend auto|local|gha] [--cache-dir <dir>] [--session-id <id>] [--endpoint <ipc>] [--journal <path.jsonl>]
 ```
 
 Command behavior:
@@ -188,18 +189,51 @@ The local backend is the reference backend. It writes a zccache-owned bundle at:
 
 ```text
 <cache-dir>/rust-plan/<cache_key>/
-  manifest.json
+  manifest.pb
   files/<normalized target-relative artifact paths>
 ```
 
-`manifest.json` records the manifest schema version, plan schema version, cache
-schema version, mode, cache key, creation time, plan identity hash, and artifact
-entries. Each artifact entry records the normalized target-relative path, class,
-size, and content hash.
+`manifest.pb` is a compact protobuf manifest. It records the manifest schema
+version, plan schema version, cache schema version, mode, cache key, creation
+time, plan identity hash, bundle layer kind, optional base cache key, optional
+deleted paths, and artifact entries. Each artifact entry records the normalized
+target-relative path, class, size, content hash, and mtime in Unix nanoseconds.
+
+Restore-critical metadata and soldr-to-zccache interop files use protobuf.
+JSON plan files are still accepted for migration, but new plan files, bundle
+manifests, and layer metadata are not JSON.
 
 Restore validates manifest compatibility, prevents path traversal, verifies
-payload size and content hash, recreates parent directories, and refreshes file
-times so Cargo sees a coherent restored tree.
+payload size and content hash, recreates parent directories, and restores file
+mtimes from manifest metadata so Cargo sees a coherent restored tree. zccache
+still accepts legacy local `manifest.json` bundles for migration, but new
+bundles write `manifest.pb`.
+
+### Layered local restore
+
+The local backend also supports a base-plus-delta workflow for soldr cook
+caches:
+
+```text
+zccache rust-plan save-delta \
+  --plan <plan.pb> \
+  --base-cache-dir <base-cache-dir> \
+  --delta-cache-dir <delta-cache-dir>
+
+zccache rust-plan restore-layered \
+  --plan <plan.pb> \
+  --base-cache-dir <base-cache-dir> \
+  --delta-cache-dir <delta-cache-dir>
+```
+
+`save-delta` compares selected target artifacts against the base manifest by
+path, size, content hash, and mtime. Only changed or new artifacts are copied
+into the delta bundle. Paths present in the base but absent from the current
+selected set are recorded as protobuf tombstones.
+
+`restore-layered` restores the base bundle first, then overlays the delta
+bundle. Delta artifacts win, missing artifacts fall back to the base bundle,
+and tombstones remove stale base artifacts.
 
 ### GitHub Actions backend
 
@@ -278,6 +312,10 @@ Expected CI flow:
 4. Cargo builds through the zccache session/wrapper.
 5. `soldr` runs `zccache rust-plan save --plan <plan> --json --backend auto`.
 6. `setup-soldr` presents the zccache JSON summaries in CI output.
+
+For cook-cache delta mode, soldr/setup-soldr provide separate base and delta
+local cache directories and use `restore-layered` before the build and
+`save-delta` after the build.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #411.

- add protobuf rust-plan files for soldr-to-zccache plan input and zccache bundle manifests
- write new bundles as `manifest.pb` while still reading legacy local `manifest.json` bundles during migration
- store per-artifact mtime, size, hash, class, and relative path, then restore mtimes from metadata
- add local `rust-plan save-delta` and `rust-plan restore-layered` for base-plus-delta cook cache workflows
- record protobuf tombstones so deleted base artifacts are removed during delta overlay
- add tests for protobuf plan loading, protobuf manifests, mtime restore, delta omission of unchanged files, and tombstones
- make the Windows CLI binary run on an 8 MiB thread stack to avoid MSVC stack overflow during Clap startup
- update the tool guard to deny Codex-style bare Rust tool invocations with exit code 2

## Verification

- `soldr cargo fmt --all -- --check`
- `soldr cargo clippy -p zccache --all-targets -- -D warnings`
- `soldr cargo test -p zccache artifact::rust_plan --lib`
- `soldr cargo test -p zccache --test cli_rust_plan_lifecycle`
- `soldr cargo test -p zccache --lib`
- `soldr cargo build -p zccache --bin zccache`
- `./target/x86_64-pc-windows-msvc/debug/zccache.exe --version`
- hook smoke: bare `cargo test` payload exits 2, `soldr cargo test` payload exits 0