### PR TITLE
refactor(cache-root): centralize soldr-facing cache paths

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -255,6 +255,18 @@ runs:
         # Verify install
         which zccache || { echo "ERROR: zccache not found on PATH"; echo "PATH=$PATH"; exit 1; }
 
+    - name: Resolve zccache cache paths
+      id: zccache-paths
+      shell: bash
+      run: |
+        CACHE_ROOT="$(zccache cache-root)"
+        {
+          echo "cache-root=$CACHE_ROOT"
+          echo "cargo-registry-cache=$CACHE_ROOT/cargo-registry"
+          echo "target-meta-dir=$HOME/.zccache-target-meta"
+          echo "action-state-dir=$HOME/.zccache-action-state"
+        } >> "$GITHUB_OUTPUT"
+
     # --- Layer 1: Restore zccache compilation cache ---
     - name: Restore zccache compilation cache
       id: restore-zccache-native
@@ -264,7 +276,7 @@ runs:
         set +e
         OUTPUT="$(zccache gha-cache restore \
           --key "${{ steps.keys.outputs.compilation-key }}" \
-          --path "$HOME/.zccache" 2>&1)"
+          --path "${{ steps.zccache-paths.outputs.cache-root }}" 2>&1)"
         STATUS=$?
         set -e
         printf '%s\n' "$OUTPUT"
@@ -283,7 +295,7 @@ runs:
       if: steps.cache-backend.outputs.backend == 'native' && inputs.cache-compilation == 'true' && inputs.compilation-restore-fallback == 'true' && steps.restore-zccache-native.outputs.cache-hit != 'true'
       uses: actions/cache/restore@v4
       with:
-        path: ~/.zccache
+        path: ${{ steps.zccache-paths.outputs.cache-root }}
         key: ${{ steps.keys.outputs.compilation-key }}
         restore-keys: ${{ steps.keys.outputs.compilation-restore }}
 
@@ -292,7 +304,7 @@ runs:
       if: steps.cache-backend.outputs.backend != 'native' && inputs.cache-compilation == 'true'
       uses: actions/cache/restore@v4
       with:
-        path: ~/.zccache
+        path: ${{ steps.zccache-paths.outputs.cache-root }}
         key: ${{ steps.keys.outputs.compilation-key }}
         restore-keys: ${{ steps.keys.outputs.compilation-restore }}
 
@@ -305,7 +317,7 @@ runs:
         set +e
         OUTPUT="$(zccache gha-cache restore \
           --key "${{ steps.keys.outputs.registry-key }}" \
-          --path "$HOME/.zccache/cargo-registry" 2>&1)"
+          --path "${{ steps.zccache-paths.outputs.cargo-registry-cache }}" 2>&1)"
         STATUS=$?
         set -e
         printf '%s\n' "$OUTPUT"
@@ -346,7 +358,7 @@ runs:
         set +e
         OUTPUT="$(zccache gha-cache restore \
           --key "${{ steps.keys.outputs.target-key }}" \
-          --path "$HOME/.zccache-target-meta" 2>&1)"
+          --path "${{ steps.zccache-paths.outputs.target-meta-dir }}" 2>&1)"
         STATUS=$?
         set -e
         printf '%s\n' "$OUTPUT"
@@ -365,7 +377,7 @@ runs:
       if: steps.cache-backend.outputs.backend == 'native' && inputs.cache-target == 'true' && inputs.target-restore-fallback == 'true' && steps.restore-target-native.outputs.cache-hit != 'true'
       uses: actions/cache/restore@v4
       with:
-        path: ~/.zccache-target-meta
+        path: ${{ steps.zccache-paths.outputs.target-meta-dir }}
         key: ${{ steps.keys.outputs.target-key }}
         restore-keys: ${{ steps.keys.outputs.target-restore }}
 
@@ -374,7 +386,7 @@ runs:
       if: steps.cache-backend.outputs.backend != 'native' && inputs.cache-target == 'true'
       uses: actions/cache/restore@v4
       with:
-        path: ~/.zccache-target-meta
+        path: ${{ steps.zccache-paths.outputs.target-meta-dir }}
         key: ${{ steps.keys.outputs.target-key }}
         restore-keys: ${{ steps.keys.outputs.target-restore }}
 
@@ -383,7 +395,7 @@ runs:
       shell: bash
       run: |
         TARGET="${{ inputs.target-dir }}"
-        META_TAR="$HOME/.zccache-target-meta/target-meta.tar"
+        META_TAR="${{ steps.zccache-paths.outputs.target-meta-dir }}/target-meta.tar"
         if [ -f "$META_TAR" ]; then
           MAX_BYTES="$(bash "${{ github.action_path }}/action/cleanup/prepare-target-snapshot.sh" --parse-size "${{ inputs.target-snapshot-max-size }}")"
           TAR_BYTES="$(wc -c < "$META_TAR" | tr -d '[:space:]')"
@@ -454,22 +466,23 @@ runs:
       shell: bash
       run: |
         # Write cache keys to a file so the cleanup action can read them
-        mkdir -p ~/.zccache-action-state
-        echo "${{ steps.keys.outputs.compilation-key }}" > ~/.zccache-action-state/compilation-key
-        echo "${{ steps.keys.outputs.registry-key }}" > ~/.zccache-action-state/registry-key
-        echo "${{ steps.keys.outputs.target-key }}" > ~/.zccache-action-state/target-key
-        echo "${{ inputs.save-cache }}" > ~/.zccache-action-state/save-cache
-        echo "${{ inputs.cache-compilation }}" > ~/.zccache-action-state/cache-compilation
-        echo "${{ inputs.cache-cargo-registry }}" > ~/.zccache-action-state/cache-registry
-        echo "${{ inputs.cache-target }}" > ~/.zccache-action-state/cache-target
-        echo "${{ inputs.target-dir }}" > ~/.zccache-action-state/target-dir
-        echo "${{ inputs.target-snapshot-max-size }}" > ~/.zccache-action-state/target-snapshot-max-size
-        echo "${{ inputs.target-snapshot-mode }}" > ~/.zccache-action-state/target-snapshot-mode
-        echo "${{ inputs.target-snapshot-too-large }}" > ~/.zccache-action-state/target-snapshot-too-large
-        echo "${{ inputs.target-prune-incremental }}" > ~/.zccache-action-state/target-prune-incremental
-        echo "${{ inputs.target-prune-build-script-out }}" > ~/.zccache-action-state/target-prune-build-script-out
-        echo "${{ steps.cache-backend.outputs.backend }}" > ~/.zccache-action-state/cache-backend
-        date +%s > ~/.zccache-action-state/target-cache-marker-epoch
+        STATE_DIR="${{ steps.zccache-paths.outputs.action-state-dir }}"
+        mkdir -p "$STATE_DIR"
+        echo "${{ steps.keys.outputs.compilation-key }}" > "$STATE_DIR/compilation-key"
+        echo "${{ steps.keys.outputs.registry-key }}" > "$STATE_DIR/registry-key"
+        echo "${{ steps.keys.outputs.target-key }}" > "$STATE_DIR/target-key"
+        echo "${{ inputs.save-cache }}" > "$STATE_DIR/save-cache"
+        echo "${{ inputs.cache-compilation }}" > "$STATE_DIR/cache-compilation"
+        echo "${{ inputs.cache-cargo-registry }}" > "$STATE_DIR/cache-registry"
+        echo "${{ inputs.cache-target }}" > "$STATE_DIR/cache-target"
+        echo "${{ inputs.target-dir }}" > "$STATE_DIR/target-dir"
+        echo "${{ inputs.target-snapshot-max-size }}" > "$STATE_DIR/target-snapshot-max-size"
+        echo "${{ inputs.target-snapshot-mode }}" > "$STATE_DIR/target-snapshot-mode"
+        echo "${{ inputs.target-snapshot-too-large }}" > "$STATE_DIR/target-snapshot-too-large"
+        echo "${{ inputs.target-prune-incremental }}" > "$STATE_DIR/target-prune-incremental"
+        echo "${{ inputs.target-prune-build-script-out }}" > "$STATE_DIR/target-prune-build-script-out"
+        echo "${{ steps.cache-backend.outputs.backend }}" > "$STATE_DIR/cache-backend"
+        date +%s > "$STATE_DIR/target-cache-marker-epoch"
 
 branding:
   icon: "zap"

--- a/action/cleanup/action.yml
+++ b/action/cleanup/action.yml
@@ -37,12 +37,31 @@ runs:
       shell: bash
       run: zccache stop 2>/dev/null || true
 
+    - name: Resolve zccache cache paths
+      if: always()
+      id: zccache-paths
+      shell: bash
+      run: |
+        CACHE_ROOT=""
+        if command -v zccache >/dev/null 2>&1; then
+          CACHE_ROOT="$(zccache cache-root 2>/dev/null || true)"
+        fi
+        if [ -z "$CACHE_ROOT" ]; then
+          CACHE_ROOT="${ZCCACHE_CACHE_DIR:-$HOME/.zccache}"
+        fi
+        {
+          echo "cache-root=$CACHE_ROOT"
+          echo "cargo-registry-cache=$CACHE_ROOT/cargo-registry"
+          echo "target-meta-dir=$HOME/.zccache-target-meta"
+          echo "action-state-dir=$HOME/.zccache-action-state"
+        } >> "$GITHUB_OUTPUT"
+
     - name: Read state from setup
       if: always()
       id: state
       shell: bash
       run: |
-        STATE_DIR="$HOME/.zccache-action-state"
+        STATE_DIR="${{ steps.zccache-paths.outputs.action-state-dir }}"
         if [ -d "$STATE_DIR" ]; then
           echo "compilation-key=$(cat "$STATE_DIR/compilation-key" 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
           echo "registry-key=$(cat "$STATE_DIR/registry-key" 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
@@ -73,13 +92,13 @@ runs:
       run: |
         zccache gha-cache save \
           --key "${{ steps.state.outputs.compilation-key }}" \
-          --path "$HOME/.zccache"
+          --path "${{ steps.zccache-paths.outputs.cache-root }}"
 
     - name: Save zccache compilation cache
       if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-backend != 'native' && steps.state.outputs.cache-compilation == 'true'
       uses: actions/cache/save@v4
       with:
-        path: ~/.zccache
+        path: ${{ steps.zccache-paths.outputs.cache-root }}
         key: ${{ steps.state.outputs.compilation-key }}
 
     - name: Save cargo registry archive
@@ -89,10 +108,10 @@ runs:
         zccache cargo-registry save \
           --key "${{ steps.state.outputs.registry-key }}" \
           --cargo-home "$HOME/.cargo"
-        if [ -f "$HOME/.zccache/cargo-registry/${{ steps.state.outputs.registry-key }}.tar.gz" ]; then
+        if [ -f "${{ steps.zccache-paths.outputs.cargo-registry-cache }}/${{ steps.state.outputs.registry-key }}.tar.gz" ]; then
           zccache gha-cache save \
             --key "${{ steps.state.outputs.registry-key }}" \
-            --path "$HOME/.zccache/cargo-registry"
+            --path "${{ steps.zccache-paths.outputs.cargo-registry-cache }}"
         fi
 
     - name: Save cargo registry cache
@@ -142,16 +161,16 @@ runs:
       run: |
         zccache gha-cache save \
           --key "${{ steps.state.outputs.target-key }}" \
-          --path "$HOME/.zccache-target-meta"
+          --path "${{ steps.zccache-paths.outputs.target-meta-dir }}"
 
     - name: Save cargo target snapshot
       if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-backend != 'native' && steps.state.outputs.cache-target == 'true' && steps.target-snapshot.outputs.snapshot-saved == 'true'
       uses: actions/cache/save@v4
       with:
-        path: ~/.zccache-target-meta
+        path: ${{ steps.zccache-paths.outputs.target-meta-dir }}
         key: ${{ steps.state.outputs.target-key }}
 
     - name: Clean up state
       if: always()
       shell: bash
-      run: rm -rf ~/.zccache-action-state
+      run: rm -rf "${{ steps.zccache-paths.outputs.action-state-dir }}"

--- a/crates/zccache/src/cli/commands/cargo_registry.rs
+++ b/crates/zccache/src/cli/commands/cargo_registry.rs
@@ -23,13 +23,12 @@ pub(crate) fn resolve_cargo_home(explicit: Option<&str>) -> Result<NormalizedPat
 }
 
 /// Directory where cargo-registry archives are stored.
-pub(crate) fn cargo_registry_cache_dir() -> Result<NormalizedPath, String> {
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .map_err(|_| "cannot determine home directory (set HOME)".to_string())?;
-    Ok(NormalizedPath::from(home)
-        .join(".zccache")
-        .join("cargo-registry"))
+///
+/// This is rooted at the same cache root reported by `zccache cache-root` so
+/// soldr/setup-soldr can redirect the full zccache-owned cache surface with
+/// `ZCCACHE_CACHE_DIR`.
+pub(crate) fn cargo_registry_cache_dir() -> NormalizedPath {
+    crate::core::config::cargo_registry_cache_dir()
 }
 
 pub(crate) fn cmd_cargo_registry_save(key: &str, cargo_home: Option<&str>) -> ExitCode {
@@ -50,13 +49,7 @@ pub(crate) fn cmd_cargo_registry_save(key: &str, cargo_home: Option<&str>) -> Ex
             return ExitCode::FAILURE;
         }
     };
-    let cache_dir = match cargo_registry_cache_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("zccache cargo-registry save: {e}");
-            return ExitCode::FAILURE;
-        }
-    };
+    let cache_dir = cargo_registry_cache_dir();
     if let Err(e) = std::fs::create_dir_all(&cache_dir) {
         eprintln!(
             "zccache cargo-registry save: failed to create {}: {e}",
@@ -128,13 +121,7 @@ pub(crate) fn cmd_cargo_registry_restore(key: &str, cargo_home: Option<&str>) ->
             return ExitCode::FAILURE;
         }
     };
-    let cache_dir = match cargo_registry_cache_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("zccache cargo-registry restore: {e}");
-            return ExitCode::FAILURE;
-        }
-    };
+    let cache_dir = cargo_registry_cache_dir();
     let archive_path = cache_dir.join(format!("{key}.tar.gz"));
 
     if !archive_path.exists() {
@@ -183,13 +170,7 @@ pub(crate) fn cmd_cargo_registry_hash(lockfile: &str) -> ExitCode {
 }
 
 pub(crate) fn cmd_cargo_registry_clean() -> ExitCode {
-    let cache_dir = match cargo_registry_cache_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("zccache cargo-registry clean: {e}");
-            return ExitCode::FAILURE;
-        }
-    };
+    let cache_dir = cargo_registry_cache_dir();
     if cache_dir.exists() {
         let count = match std::fs::read_dir(&cache_dir) {
             Ok(entries) => entries.count(),
@@ -213,4 +194,17 @@ pub(crate) fn cmd_cargo_registry_clean() -> ExitCode {
         println!("no cached archives to clean");
     }
     ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cargo_registry_command_uses_core_cache_layout() {
+        assert_eq!(
+            cargo_registry_cache_dir(),
+            crate::core::config::cargo_registry_cache_dir()
+        );
+    }
 }

--- a/crates/zccache/src/core/config.rs
+++ b/crates/zccache/src/core/config.rs
@@ -344,6 +344,12 @@ pub fn depfile_dir() -> NormalizedPath {
     depfile_dir_from_cache_dir(&default_cache_dir())
 }
 
+/// Returns the directory for compressed cargo registry archives.
+#[must_use]
+pub fn cargo_registry_cache_dir() -> NormalizedPath {
+    cargo_registry_cache_dir_from_cache_dir(&default_cache_dir())
+}
+
 /// Remove legacy zccache state left directly under the OS temp directory.
 ///
 /// Older builds stored the full cache root at `%TEMP%/.zccache` and created
@@ -532,6 +538,12 @@ pub fn symbols_cache_dir_from_cache_dir(cache_dir: &NormalizedPath) -> Normalize
     cache_dir.join("symbols")
 }
 
+/// Returns the cargo registry archive cache under an explicit cache root.
+#[must_use]
+pub fn cargo_registry_cache_dir_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
+    cache_dir.join("cargo-registry")
+}
+
 /// Returns the path to the artifact index database.
 #[must_use]
 pub fn index_path() -> NormalizedPath {
@@ -691,7 +703,7 @@ mod tests {
     #[test]
     fn cache_root_invariant_all_subpaths_rooted() {
         let (_temp, cache) = temp_cache_dir();
-        let subs: [(NormalizedPath, &str); 8] = [
+        let subs: [(NormalizedPath, &str); 10] = [
             (artifacts_dir_from_cache_dir(&cache), "artifacts/"),
             (tmp_dir_from_cache_dir(&cache), "tmp/"),
             (depfile_dir_from_cache_dir(&cache), "tmp/depfiles/"),
@@ -699,7 +711,12 @@ mod tests {
             (log_dir_from_cache_dir(&cache), "logs/"),
             (crash_dump_dir_from_cache_dir(&cache), "crashes/"),
             (symbols_cache_dir_from_cache_dir(&cache), "symbols/"),
+            (
+                cargo_registry_cache_dir_from_cache_dir(&cache),
+                "cargo-registry/",
+            ),
             (index_path_from_cache_dir(&cache), "index.bin"),
+            (metadata_path_from_cache_dir(&cache), "metadata.bin"),
         ];
         for (p, label) in &subs {
             assert!(
@@ -808,6 +825,14 @@ mod tests {
         let (_temp, cache) = temp_cache_dir();
         let logs = log_dir_from_cache_dir(&cache);
         assert!(logs.starts_with(&cache));
+    }
+
+    #[test]
+    fn cargo_registry_cache_dir_is_under_cache_dir() {
+        let (_temp, cache) = temp_cache_dir();
+        let dir = cargo_registry_cache_dir_from_cache_dir(&cache);
+        assert!(dir.ends_with("cargo-registry"));
+        assert!(dir.starts_with(&cache));
     }
 
     #[test]

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -246,7 +246,7 @@ entrypoints.
 ### Persistent writes — exhaustive table
 
 Every persistent write the daemon and CLI perform lands under the resolved
-cache root via one of the helpers in `zccache_core::config`:
+cache root via one of the helpers in `zccache::core::config`:
 
 | Subpath | Owner | Resolver |
 |---|---|---|
@@ -259,7 +259,9 @@ cache root via one of the helpers in `zccache_core::config`:
 | `logs/compile_journal.jsonl` + per-session `*.jsonl` | daemon — compile decisions | derives from `log_dir_from_cache_dir` |
 | `crashes/crash-*.{txt,dmp}` + `.reported` | daemon — panic & signal dumps | `crash_dump_dir_from_cache_dir` |
 | `symbols/<version>-<triple>/` + `.symref` sidecars next to dumps | CLI — `zccache symbols install` + `symbolicate` | `symbols_cache_dir_from_cache_dir` |
+| `cargo-registry/<key>.tar.gz` | CLI + composite action - compressed cargo registry archive cache used by `zccache cargo-registry` and native GHA cache upload/download | `cargo_registry_cache_dir_from_cache_dir` |
 | `index.bin` (+ sibling tmp) | daemon — bincode artifact index, atomic-rename writes | `index_path_from_cache_dir` |
+| `metadata.bin` (+ sibling tmp) | daemon - persisted metadata cache snapshot | `metadata_path_from_cache_dir` |
 | `ino/<key>.ino.cpp` | CLI — Arduino preprocessor cache | `default_cache_dir().join("ino")` |
 | `kv/<namespace>/<hex>.bin` | CLI — namespaced key/value store | derives from `default_cache_dir` |
 | `daemon[--namespace].lock` | CLI + daemon — PID lock | `lock_file_path` |
@@ -267,13 +269,21 @@ cache root via one of the helpers in `zccache_core::config`:
 
 The cache-root-rooted invariant for the well-known subpaths is asserted in
 the unit test `cache_root_invariant_all_subpaths_rooted` in
-`crates/zccache-core/src/config.rs`.
+`crates/zccache/src/core/config.rs`.
 
 ### Legitimate exceptions (documented and stable)
 
 A small set of writes is intentionally *outside* the cache root. soldr
 excludes these separately if Defender scanning ever becomes an issue:
 
+- **Composite-action target snapshot metadata:** `$HOME/.zccache-target-meta`
+  stores `target-meta.tar` for the optional target snapshot cache layer. This
+  is action-owned rather than daemon/CLI-owned zccache cache state, and the
+  path is kept stable so existing action/cache entries remain compatible.
+- **Composite-action cleanup handoff state:** `$HOME/.zccache-action-state`
+  stores the setup action's cache keys and options until
+  `action/cleanup/action.yml` runs. It is ephemeral action state, removed by
+  cleanup, and not part of the cache root contract.
 - **IPC socket (Unix, no env override):** `$XDG_RUNTIME_DIR/zccache/sock`
   or `/tmp/zccache-$USER/sock`. The socket inode lives in `tmpfs` on Linux
   so it is not a real on-disk write. When `ZCCACHE_CACHE_DIR` is set, the


### PR DESCRIPTION
## Summary
- centralize the cargo registry archive cache under the same cache root reported by `zccache cache-root`
- update setup/cleanup composite actions to resolve zccache-owned cache paths once and reuse those outputs
- document cache-root-owned paths and the action-owned exceptions that intentionally remain outside the cache root

## Validation
- `cargo fmt --all`
- `rustup run 1.94.1-x86_64-pc-windows-gnu cargo check -p zccache --all-targets`
- `rustup run 1.94.1-x86_64-pc-windows-gnu cargo test -p zccache cache_root -- --test-threads=1 --nocapture`
- `rustup run 1.94.1-x86_64-pc-windows-gnu cargo test -p zccache cargo_registry_cache_dir_is_under_cache_dir -- --test-threads=1 --nocapture`
- `rustup run 1.94.1-x86_64-pc-windows-gnu cargo test -p zccache cargo_registry_command_uses_core_cache_layout -- --test-threads=1 --nocapture`
- YAML parse for `action.yml` and `action/cleanup/action.yml`
- `rustup run 1.94.1-x86_64-pc-windows-gnu cargo clippy -p zccache --all-targets -- -D warnings`
- `git diff --check` (passes; reports existing CRLF normalization warning for `docs/architecture/runtime.md`)

Closes #417