### PR TITLE
docs(target-cache): clarify legacy action snapshot ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,6 +758,11 @@ The action now treats the two cache layers differently:
 - Target snapshots are disabled by default because Cargo does not garbage collect `target/`. When enabled, the default `target-snapshot-mode: hot` saves Cargo freshness metadata plus target files read or modified during the job instead of archiving the whole tree. Use `target-snapshot-mode: full` only for tightly scoped jobs where the target directory is known to stay bounded.
 - Target snapshot saves prune `target/**/incremental` by default, can optionally prune `target/**/build/*/out`, and skip saving when the pruned snapshot exceeds `target-snapshot-max-size`.
 
+Target snapshots are legacy action-only behavior for `cache-target: true`
+workflows. soldr/setup-soldr integrations should use `zccache rust-plan` for
+target artifact restore/save behavior; see
+`docs/architecture/target-cache.md` for the ownership boundary.
+
 If you want the old fastest-possible behavior for developer CI, opt back in explicitly:
 
 ```yaml

--- a/action/README.md
+++ b/action/README.md
@@ -81,6 +81,11 @@ Target snapshots are disabled by default because Cargo does not garbage collect
 leave `cache-target: false`. Enable target snapshots only for jobs where skipping
 Cargo fingerprint work matters enough to spend extra cache and runner disk.
 
+Target snapshots are a legacy action-only compatibility layer. soldr and
+setup-soldr integrations should use `zccache rust-plan` for target artifact
+restore/save behavior; see `../docs/architecture/target-cache.md` for the
+ownership boundary.
+
 ### Restore policy
 
 - `compilation-restore-fallback: true` keeps the speed-first behavior for incremental CI.

--- a/action/cleanup/README.md
+++ b/action/cleanup/README.md
@@ -26,6 +26,11 @@ The default target snapshot mode is `hot`: cleanup saves Cargo metadata and
 files read or modified after setup using access and modification times. Set
 `target-snapshot-mode: full` in the main action to save the pruned target tree.
 
+This target snapshot path is legacy action-only behavior. It is kept for
+`cache-target: true` compatibility and should not receive new soldr/setup-soldr
+target artifact behavior. The soldr-facing owner is `zccache rust-plan`; see
+`../../docs/architecture/target-cache.md`.
+
 ## Target Snapshot Outputs
 
 When target snapshots are enabled, cleanup exposes:

--- a/action/cleanup/prepare-target-snapshot.sh
+++ b/action/cleanup/prepare-target-snapshot.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Legacy action-only target snapshot preparation.
+#
+# This script is intentionally kept for `cache-target: true` compatibility in
+# the zackees/zccache composite action. soldr/setup-soldr target artifact work
+# belongs in `zccache rust-plan`; see docs/architecture/target-cache.md. If a
+# future native `zccache target-cache prepare --json` replaces this script, it
+# must preserve the cleanup action outputs and skip reasons documented there.
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 parse_size_bytes() {

--- a/action/cleanup/select-hot-target.py
+++ b/action/cleanup/select-hot-target.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+# Legacy action-only hot target selector.
+#
+# This module supports `action/cleanup/prepare-target-snapshot.sh` for
+# `cache-target: true` workflows. New soldr/setup-soldr target artifact behavior
+# belongs in `zccache rust-plan`; see docs/architecture/target-cache.md.
+
 import argparse
 import json
 import os

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,6 +12,7 @@ This document is the index for zccache's architecture specification. Each subsys
 | [architecture/metadata-cache.md](architecture/metadata-cache.md) | ~130 | In-memory cache data model, confidence levels, watcher integration |
 | [architecture/artifact-store.md](architecture/artifact-store.md) | ~130 | Disk layout, redb index schema, LRU eviction, corruption detection |
 | [architecture/rust-artifact-plan.md](architecture/rust-artifact-plan.md) | ~120 | Rust plan ownership, thin/full semantics, restore hardening, backends, diagnostics, CLI contract |
+| [architecture/target-cache.md](architecture/target-cache.md) | ~70 | Legacy action target snapshot ownership, outputs, and rust-plan boundary |
 | [architecture/runtime.md](architecture/runtime.md) | ~130 | Concurrency model, correctness guarantees, failure modes, crash recovery |
 | [architecture/portability.md](architecture/portability.md) | ~110 | Platform differences, path handling, file identity, future extensions |
 
@@ -22,6 +23,8 @@ This document is the index for zccache's architecture specification. Each subsys
 - **CLI↔daemon communication** → [ipc.md](architecture/ipc.md)
 - **File change detection** → [metadata-cache.md](architecture/metadata-cache.md)
 - **Disk cache & eviction** → [artifact-store.md](architecture/artifact-store.md)
+- **soldr target artifact contract** → [rust-artifact-plan.md](architecture/rust-artifact-plan.md)
+- **Legacy action target snapshots** → [target-cache.md](architecture/target-cache.md)
 - **Thread safety & crash safety** → [runtime.md](architecture/runtime.md)
 - **Where zccache writes on disk (`ZCCACHE_CACHE_DIR` contract)** → [runtime.md § Cache root invariants](architecture/runtime.md#cache-root-invariants)
 - **Windows/macOS/Linux differences** → [portability.md](architecture/portability.md)

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -803,3 +803,25 @@ expected v8, received v7. Run zccache stop first.`
   (`crates/zccache-cli/src/main.rs`). Exceeding it truncates silently
   today; a future fix can either widen the cap or fall back to direct
   compile.
+
+---
+
+## DD-024: Rust-Plan Owns soldr Target Artifacts; Action Target Snapshots Are Legacy
+
+**Context:** zccache has two target artifact paths. The newer `zccache
+rust-plan` path is structured around a versioned Rust build plan from soldr.
+The older composite-action target snapshot path saves a tarball of selected
+`target/` state for workflows that opt into `cache-target: true`.
+
+**Decision:** `zccache rust-plan` is the soldr/setup-soldr target artifact
+interface. The action target snapshot path is legacy action-only behavior kept
+for compatibility. It remains documented and tested, but new soldr-facing
+restore/save behavior must land in rust-plan unless a follow-up issue replaces
+the legacy shell/Python path with a native `zccache target-cache` command.
+
+**Consequences:**
+- soldr and setup-soldr have a single target artifact owner: rust-plan.
+- Action target snapshots keep their existing outputs, skip reasons, size
+  gates, and hot/full modes for compatibility.
+- Bugs in `cache-target: true` remain valid fixes for the legacy action path,
+  but they should not expand that path into a second soldr integration API.

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -279,7 +279,9 @@ excludes these separately if Defender scanning ever becomes an issue:
 - **Composite-action target snapshot metadata:** `$HOME/.zccache-target-meta`
   stores `target-meta.tar` for the optional target snapshot cache layer. This
   is action-owned rather than daemon/CLI-owned zccache cache state, and the
-  path is kept stable so existing action/cache entries remain compatible.
+  path is kept stable so existing action/cache entries remain compatible. This
+  is legacy action-only behavior, not the soldr target artifact interface; see
+  [target-cache.md](target-cache.md).
 - **Composite-action cleanup handoff state:** `$HOME/.zccache-action-state`
   stores the setup action's cache keys and options until
   `action/cleanup/action.yml` runs. It is ephemeral action state, removed by

--- a/docs/architecture/rust-artifact-plan.md
+++ b/docs/architecture/rust-artifact-plan.md
@@ -33,6 +33,15 @@ The important boundary is that zccache consumes a structured plan. It validates
 the plan, executes it, and reports what happened. It does not infer the full
 Cargo workspace model by itself.
 
+### Relationship to target snapshots
+
+`zccache rust-plan` is the supported soldr/setup-soldr target artifact
+interface. The optional composite-action target snapshot cache is legacy
+action-only behavior for `cache-target: true` workflows and is documented in
+[target-cache.md](target-cache.md). New soldr-facing target artifact behavior
+belongs in rust-plan unless a follow-up issue explicitly replaces the legacy
+target snapshot action path with a native `zccache target-cache` command.
+
 ### zccache module map
 
 The Rust plan implementation is split by ownership under

--- a/docs/architecture/target-cache.md
+++ b/docs/architecture/target-cache.md
@@ -1,0 +1,76 @@
+# Target Cache and Action Snapshot Ownership
+
+This document defines the ownership boundary for the optional target snapshot
+cache layer used by the composite GitHub Action.
+
+## Strategic Owner
+
+For soldr and setup-soldr integration, `zccache rust-plan` is the strategic
+target artifact interface. It consumes a structured Rust build plan, restores
+or saves artifacts through local or GitHub Actions backends, and emits
+machine-readable summaries for setup-soldr.
+
+Target snapshots are not the soldr integration interface. They are a legacy,
+action-only compatibility layer for workflows that set the `cache-target` input
+to `true` on the zackees/zccache action.
+
+## Legacy Action Path
+
+The legacy path is intentionally scoped to the composite action:
+
+- `action.yml` restores the optional target snapshot and runs `zccache warm`.
+- `action/cleanup/action.yml` records the fingerprint sidecar, invokes
+  `prepare-target-snapshot.sh`, and saves the resulting `target-meta.tar`.
+- `action/cleanup/prepare-target-snapshot.sh` owns snapshot mode selection,
+  pruning, size parsing, size limits, tar creation, GitHub output fields, and
+  step-summary text.
+- `action/cleanup/select-hot-target.py` owns hot-file selection for the legacy
+  hot snapshot mode.
+- `zccache snapshot-bytes`, `snapshot-fp-record`, and `snapshot-fp-validate`
+  are support commands for this legacy action flow.
+
+This code exists to preserve action compatibility. New soldr/setup-soldr work
+should not add target artifact behavior here unless the goal is explicitly to
+replace the legacy action path.
+
+## Output Contract
+
+The cleanup action continues to expose these target snapshot outputs:
+
+- `target-snapshot-saved`
+- `target-snapshot-skipped-reason`
+- `target-snapshot-bytes`
+- `target-snapshot-candidate-bytes`
+- `target-pruned-dirs`
+- `target-pruned-bytes`
+
+If a future native `zccache target-cache prepare --json` command replaces the
+shell/Python path, it must preserve those fields and the current skip reasons:
+
+- `missing-target-dir`
+- `target-too-large`
+- `no-hot-target-files`
+- `tar-failed`
+
+It must also preserve the current target snapshot modes:
+
+- `hot`: save Cargo metadata plus files read or modified after setup.
+- `full`: save the pruned target tree.
+
+## Rust-Plan Relationship
+
+The rust-plan path and the target snapshot path should remain separate:
+
+- rust-plan is plan-driven and safe for soldr/setup-soldr ownership.
+- target snapshots are action-input-driven and cache `target/` freshness state
+  as a unit.
+- rust-plan summaries are the vocabulary for soldr-facing reporting.
+- target snapshot summaries are GitHub Action compatibility output.
+
+When fixing a target artifact bug, use this rule:
+
+- If the bug affects soldr/setup-soldr restore/save behavior, fix rust-plan.
+- If the bug affects `cache-target: true` in the zackees/zccache action, fix
+  the legacy target snapshot path.
+- If both are affected, file separate issues unless the fix is strictly shared
+  helper code.


### PR DESCRIPTION
## Summary
- Documented the #420 decision that `zccache rust-plan` is the soldr/setup-soldr target artifact owner.
- Added `docs/architecture/target-cache.md` to mark composite-action target snapshots as legacy action-only behavior and preserve their output/skip-reason contract.
- Cross-linked the boundary from action docs, runtime docs, rust-plan docs, and design decisions; added script headers so future changes do not expand the legacy path into another soldr API.

## Validation
- bash action/cleanup/tests/test_prepare_target_snapshot.sh
- git diff --check

Closes #420