### PR TITLE
fix: share rustc cache across target dir shapes

### DIFF
--- a/crates/zccache/src/daemon/server/handle_compile/hit_branches.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/hit_branches.rs
@@ -147,6 +147,13 @@ pub(super) fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
     if !state.watcher_active.load(Ordering::Acquire) {
         return None;
     }
+    if worktree_equivalent_context {
+        // Cross-worktree hits may be the first time this daemon has seen the
+        // current root's source paths. Until that root has gone through a
+        // miss path and installed directory watches, keep using the hashed
+        // depgraph path instead of the zero-hash fast-hit cache.
+        return None;
+    }
     let entry = state.fast_hit_cache.get(&context_key)?;
     if !cache_entry_fresh_at(compile_start, entry.cached_at, FAST_HIT_MAX_AGE)
         || !context_files_fresh(state, &context_key, source_path, entry.clock)
@@ -290,34 +297,36 @@ pub(super) fn try_depgraph_cached_hit(probe: DepgraphHitProbe<'_>) -> Option<Res
         },
     })?;
 
-    let input_paths = request_cache_input_paths(state, &context_key, source_path, ctx);
-    state.cache_system.register_tracked(&input_paths);
-    let current_clock = state.cache_system.current_clock();
-    state.fast_hit_cache.insert(
-        context_key,
-        FastHitEntry {
-            clock: current_clock,
-            artifact_key_hex: artifact_key_hex.to_string(),
-            cached_at: Instant::now(),
-        },
-    );
-
-    let rfp = request_fingerprint(
-        compiler_path,
-        effective_args,
-        cwd,
-        request_cache_key_root.as_deref(),
-        client_env,
-    );
-    state.request_cache.insert(
-        rfp,
-        request_cache_entry(
+    if !worktree_equivalent_context {
+        let input_paths = request_cache_input_paths(state, &context_key, source_path, ctx);
+        state.cache_system.register_tracked(&input_paths);
+        let current_clock = state.cache_system.current_clock();
+        state.fast_hit_cache.insert(
             context_key,
-            source_path,
-            output_path,
-            input_paths,
-            request_cache_key_root.as_ref(),
-        ),
-    );
+            FastHitEntry {
+                clock: current_clock,
+                artifact_key_hex: artifact_key_hex.to_string(),
+                cached_at: Instant::now(),
+            },
+        );
+
+        let rfp = request_fingerprint(
+            compiler_path,
+            effective_args,
+            cwd,
+            request_cache_key_root.as_deref(),
+            client_env,
+        );
+        state.request_cache.insert(
+            rfp,
+            request_cache_entry(
+                context_key,
+                source_path,
+                output_path,
+                input_paths,
+                request_cache_key_root.as_ref(),
+            ),
+        );
+    }
     Some(response)
 }

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
@@ -234,10 +234,16 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 let rustc_key_root =
                     rustc_context_key_root(&rustc_args.remap_path_prefixes, worktree_root.as_ref());
                 let key = rustc_ctx.context_key_with_root(rustc_key_root.as_deref());
-                let registration = state.dep_graph.register_with_key_and_root_result(
+                let rustc_externs = rustc_args
+                    .externs
+                    .iter()
+                    .map(|ext| (ext.name.clone(), ext.path.clone()))
+                    .collect();
+                let registration = state.dep_graph.register_rustc_with_key_and_root_result(
                     key,
                     compat_ctx.clone(),
                     rustc_key_root.clone(),
+                    rustc_externs,
                 );
                 (
                     compat_ctx,
@@ -249,6 +255,16 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             }
         };
     let is_rustc = rustc_args_opt.is_some();
+    let rustc_extern_paths: Vec<NormalizedPath> = rustc_args_opt
+        .as_ref()
+        .map(|rustc_args| {
+            rustc_args
+                .externs
+                .iter()
+                .map(|ext| ext.path.clone())
+                .collect()
+        })
+        .unwrap_or_default();
     let rust_profile_enabled = is_rustc && std::env::var_os(RUST_MISS_PROFILE_ENV).is_some();
     let rust_profile_mode = rustc_args_opt
         .as_ref()
@@ -348,7 +364,10 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 .force_includes
                 .iter()
                 .map(|h| (h, "force_include_hash_fail"));
-            let all_paths: Vec<_> = include_iter.chain(force_iter).collect();
+            let extern_iter = rustc_extern_paths
+                .iter()
+                .map(|h| (h, "rustc_extern_hash_fail"));
+            let all_paths: Vec<_> = include_iter.chain(force_iter).chain(extern_iter).collect();
 
             let results: Vec<_> = all_paths
                 .par_iter()
@@ -753,6 +772,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         let tracked_paths: Vec<NormalizedPath> = std::iter::once(source_path.clone())
             .chain(scan_result.resolved.iter().cloned())
             .chain(ctx.force_includes.iter().cloned())
+            .chain(rustc_extern_paths.iter().cloned())
             .collect();
         let t_register_tracked = std::time::Instant::now();
         state.cache_system.register_tracked(&tracked_paths);
@@ -778,6 +798,11 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                     dirs.insert(parent.into());
                 }
             }
+            for ext in &rustc_extern_paths {
+                if let Some(parent) = ext.parent() {
+                    dirs.insert(parent.into());
+                }
+            }
             dirs.into_iter().collect()
         };
         let dep_dirs_ns = t_dep_dirs.elapsed().as_nanos() as u64;
@@ -789,7 +814,11 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         let mut hash_map: HashMap<NormalizedPath, ContentHash> = HashMap::new();
         {
             use rayon::prelude::*;
-            let header_iter = scan_result.resolved.iter().chain(ctx.force_includes.iter());
+            let header_iter = scan_result
+                .resolved
+                .iter()
+                .chain(ctx.force_includes.iter())
+                .chain(rustc_extern_paths.iter());
             let all_paths: Vec<&NormalizedPath> =
                 std::iter::once(&source_path).chain(header_iter).collect();
 
@@ -821,7 +850,9 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                     &format!(
                         "[DIAG] hash_failures: {} of {} files failed to hash for {}",
                         hash_failures,
-                        1 + scan_result.resolved.len() + ctx.force_includes.len(),
+                        1 + scan_result.resolved.len()
+                            + ctx.force_includes.len()
+                            + rustc_extern_paths.len(),
                         source_path.display(),
                     ),
                 );

--- a/crates/zccache/src/daemon/server/keys.rs
+++ b/crates/zccache/src/daemon/server/keys.rs
@@ -401,6 +401,9 @@ pub(super) fn request_cache_input_paths(
     if let Some(includes) = state.dep_graph.get_includes(context_key) {
         paths.extend(includes.iter().cloned());
     }
+    if let Some(externs) = state.dep_graph.get_rustc_externs(context_key) {
+        paths.extend(externs.into_iter().map(|(_, path)| path));
+    }
     paths.extend(ctx.force_includes.iter().cloned());
     paths.sort();
     paths.dedup();

--- a/crates/zccache/src/daemon/server/rustc.rs
+++ b/crates/zccache/src/daemon/server/rustc.rs
@@ -103,12 +103,14 @@ pub(super) fn build_rustc_compile_context(
 ///
 /// Parses rustc's dep-info file which has multiple rules (one per output target),
 /// all sharing the same dependencies. Extracts the unique set of source file deps.
+/// `--extern` crate files are tracked separately by the dependency graph so
+/// their content, but not target-dir path prefix, participates in artifact keys.
 pub(super) fn scan_rustc_deps(
     rustc_args: &crate::depgraph::RustcParsedArgs,
     source_path: &Path,
     cwd: &Path,
 ) -> crate::depgraph::ScanResult {
-    let mut result = if rustc_args.emit_types.iter().any(|t| t == "dep-info") {
+    let result = if rustc_args.emit_types.iter().any(|t| t == "dep-info") {
         let name = rustc_args.crate_name.as_deref().unwrap_or("unknown");
         let ext_suffix = rustc_args.extra_filename.as_deref().unwrap_or("");
         let dir = rustc_args.out_dir.as_deref().unwrap_or(cwd);
@@ -137,16 +139,6 @@ pub(super) fn scan_rustc_deps(
             has_computed: false,
         }
     };
-
-    // Add extern crate files as resolved dependencies.
-    // Their content hashes will be part of the artifact key,
-    // so changing an extern crate causes a cache miss.
-    for ext in &rustc_args.externs {
-        let dep_path: NormalizedPath = ext.path.clone().into_path_buf().into();
-        if ext.path.exists() && !result.resolved.contains(&dep_path) {
-            result.resolved.push(dep_path);
-        }
-    }
 
     result
 }

--- a/crates/zccache/src/daemon/server/tests/fingerprint.rs
+++ b/crates/zccache/src/daemon/server/tests/fingerprint.rs
@@ -531,3 +531,56 @@ fn request_fingerprint_ignores_cargo_target_dir() {
          should share the request-level fast path (issue #396)"
     );
 }
+
+#[test]
+fn request_fingerprint_keeps_external_out_dirs_distinct() {
+    let args_a = vec![
+        "--crate-name".to_string(),
+        "dep".to_string(),
+        "--out-dir".to_string(),
+        "/external/agent-a-target".to_string(),
+        "src/dep.rs".to_string(),
+    ];
+    let args_b = vec![
+        "--crate-name".to_string(),
+        "dep".to_string(),
+        "--out-dir".to_string(),
+        "/external/agent-b-target".to_string(),
+        "src/dep.rs".to_string(),
+    ];
+    let env_a = vec![
+        ("CARGO_PKG_VERSION".to_string(), "1.0.0".to_string()),
+        (
+            "CARGO_TARGET_DIR".to_string(),
+            "/external/agent-a-target".to_string(),
+        ),
+    ];
+    let env_b = vec![
+        ("CARGO_PKG_VERSION".to_string(), "1.0.0".to_string()),
+        (
+            "CARGO_TARGET_DIR".to_string(),
+            "/external/agent-b-target".to_string(),
+        ),
+    ];
+
+    let a = request_fingerprint(
+        Path::new("/usr/bin/rustc"),
+        &args_a,
+        Path::new("/workspace"),
+        Some(Path::new("/workspace")),
+        Some(&env_a),
+    );
+    let b = request_fingerprint(
+        Path::new("/usr/bin/rustc"),
+        &args_b,
+        Path::new("/workspace"),
+        Some(Path::new("/workspace")),
+        Some(&env_b),
+    );
+
+    assert_ne!(
+        a, b,
+        "target dirs outside ZCCACHE_WORKTREE_ROOT remain request-key distinct \
+         because their --out-dir paths are not root-relative"
+    );
+}

--- a/crates/zccache/src/daemon/server/util.rs
+++ b/crates/zccache/src/daemon/server/util.rs
@@ -80,6 +80,13 @@ pub(super) fn context_files_fresh(
             }
         }
     }
+    if let Some(externs) = state.dep_graph.get_rustc_externs(context_key) {
+        for (_, path) in &externs {
+            if journal.changed_since(path, since) {
+                return false;
+            }
+        }
+    }
     true
 }
 

--- a/crates/zccache/src/depgraph/graph.rs
+++ b/crates/zccache/src/depgraph/graph.rs
@@ -13,7 +13,8 @@ use crate::hash::ContentHash;
 use dashmap::DashMap;
 
 use super::context::{
-    compute_artifact_key, compute_context_key, ArtifactKey, CompileContext, ContextKey,
+    compute_artifact_key, compute_context_key, compute_rustc_artifact_key_with_root, ArtifactKey,
+    CompileContext, ContextKey,
 };
 use super::scanner::{IncludeDirective, ScanResult};
 
@@ -105,6 +106,12 @@ pub struct DepGraph {
     files: DashMap<NormalizedPath, FileEntry>,
     /// Per-context entries: context key â†’ include list + state.
     contexts: DashMap<ContextKey, ContextEntry>,
+    /// Rustc-only extern inputs keyed by context.
+    ///
+    /// These are tracked outside `ContextEntry::resolved_includes` because
+    /// their paths are output-placement state. Their content hashes affect the
+    /// rustc artifact key by crate name, but target-dir path prefixes must not.
+    rustc_externs: DashMap<ContextKey, Vec<(String, NormalizedPath)>>,
     /// Stats counters.
     checks: AtomicU64,
     hits: AtomicU64,
@@ -131,6 +138,20 @@ fn rebase_project_path(
     }
 }
 
+fn collect_rustc_extern_hashes<G>(
+    rustc_externs: &[(String, NormalizedPath)],
+    get_hash: &G,
+) -> Option<Vec<(String, ContentHash)>>
+where
+    G: Fn(&Path) -> Option<ContentHash>,
+{
+    let mut extern_hashes = Vec::with_capacity(rustc_externs.len());
+    for (name, path) in rustc_externs {
+        extern_hashes.push((name.clone(), get_hash(path)?));
+    }
+    Some(extern_hashes)
+}
+
 impl DepGraph {
     /// Create a new empty dependency graph.
     #[must_use]
@@ -138,6 +159,7 @@ impl DepGraph {
         Self {
             files: DashMap::new(),
             contexts: DashMap::new(),
+            rustc_externs: DashMap::new(),
             checks: AtomicU64::new(0),
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
@@ -194,6 +216,34 @@ impl DepGraph {
         ctx: CompileContext,
         key_root: Option<NormalizedPath>,
     ) -> ContextRegistration {
+        let registration = self.register_context_entry(key, ctx, key_root);
+        self.rustc_externs.remove(&registration.key);
+        registration
+    }
+
+    /// Register a rustc context with its current `--extern` file inputs.
+    ///
+    /// Rustc context keys already reduce extern path prefixes to filename
+    /// identity. The dependency graph keeps the actual extern paths here only
+    /// for hashing/freshness; artifact keys incorporate them by crate name.
+    pub fn register_rustc_with_key_and_root_result(
+        &self,
+        key: ContextKey,
+        ctx: CompileContext,
+        key_root: Option<NormalizedPath>,
+        externs: Vec<(String, NormalizedPath)>,
+    ) -> ContextRegistration {
+        let registration = self.register_context_entry(key, ctx, key_root);
+        self.rustc_externs.insert(registration.key, externs);
+        registration
+    }
+
+    fn register_context_entry(
+        &self,
+        key: ContextKey,
+        ctx: CompileContext,
+        key_root: Option<NormalizedPath>,
+    ) -> ContextRegistration {
         let mut rebased_from_equivalent_root = false;
         self.contexts
             .entry(key)
@@ -240,6 +290,10 @@ impl DepGraph {
         }
     }
 
+    fn rustc_extern_inputs(&self, key: &ContextKey) -> Option<Vec<(String, NormalizedPath)>> {
+        self.rustc_externs.get(key).map(|externs| externs.clone())
+    }
+
     /// Returns `true` if the context has never been updated (no artifact key).
     /// Used by the server to skip pre-compile hashing on cold contexts where
     /// `check_diagnostic` would return `Cold` without examining any hashes.
@@ -265,6 +319,7 @@ impl DepGraph {
     {
         self.checks.fetch_add(1, Ordering::Relaxed);
 
+        let rustc_externs = self.rustc_extern_inputs(key);
         let mut entry = match self.contexts.get_mut(key) {
             Some(e) => e,
             None => {
@@ -359,7 +414,20 @@ impl DepGraph {
             }
         }
 
-        let artifact_key = compute_artifact_key(key, &mut file_hashes, entry.key_root.as_deref());
+        let artifact_key = if let Some(externs) = rustc_externs.as_deref() {
+            let Some(mut extern_hashes) = collect_rustc_extern_hashes(externs, &get_hash) else {
+                self.misses.fetch_add(1, Ordering::Relaxed);
+                return CacheVerdict::Cold;
+            };
+            compute_rustc_artifact_key_with_root(
+                key,
+                &mut file_hashes,
+                &mut extern_hashes,
+                entry.key_root.as_deref(),
+            )
+        } else {
+            compute_artifact_key(key, &mut file_hashes, entry.key_root.as_deref())
+        };
 
         if source_fresh {
             // Ultra-fast path: nothing changed at all.
@@ -396,6 +464,7 @@ impl DepGraph {
     {
         self.checks.fetch_add(1, Ordering::Relaxed);
 
+        let rustc_externs = self.rustc_extern_inputs(key);
         let mut entry = match self.contexts.get_mut(key) {
             Some(e) => e,
             None => {
@@ -511,7 +580,20 @@ impl DepGraph {
             }
         }
 
-        let artifact_key = compute_artifact_key(key, &mut file_hashes, entry.key_root.as_deref());
+        let artifact_key = if let Some(externs) = rustc_externs.as_deref() {
+            let Some(mut extern_hashes) = collect_rustc_extern_hashes(externs, &get_hash) else {
+                self.misses.fetch_add(1, Ordering::Relaxed);
+                return (CacheVerdict::Cold, "rustc extern hash missing".to_string());
+            };
+            compute_rustc_artifact_key_with_root(
+                key,
+                &mut file_hashes,
+                &mut extern_hashes,
+                entry.key_root.as_deref(),
+            )
+        } else {
+            compute_artifact_key(key, &mut file_hashes, entry.key_root.as_deref())
+        };
 
         if source_fresh {
             if entry.artifact_key == Some(artifact_key) {
@@ -608,6 +690,7 @@ impl DepGraph {
     where
         G: Fn(&Path) -> Option<ContentHash>,
     {
+        let rustc_externs = self.rustc_extern_inputs(key);
         let entry = self.contexts.get(key)?;
 
         if entry.state == ContextState::Cold || entry.has_computed_includes {
@@ -631,7 +714,17 @@ impl DepGraph {
             file_hashes.push((fi.as_path(), get_hash(fi)?));
         }
 
-        let computed = compute_artifact_key(key, &mut file_hashes, entry.key_root.as_deref());
+        let computed = if let Some(externs) = rustc_externs.as_deref() {
+            let mut extern_hashes = collect_rustc_extern_hashes(externs, &get_hash)?;
+            compute_rustc_artifact_key_with_root(
+                key,
+                &mut file_hashes,
+                &mut extern_hashes,
+                entry.key_root.as_deref(),
+            )
+        } else {
+            compute_artifact_key(key, &mut file_hashes, entry.key_root.as_deref())
+        };
 
         if computed == *stored_key {
             self.hits.fetch_add(1, Ordering::Relaxed);
@@ -653,6 +746,7 @@ impl DepGraph {
     where
         G: Fn(&Path) -> Option<ContentHash>,
     {
+        let rustc_externs = self.rustc_extern_inputs(key);
         let mut entry = self.contexts.get_mut(key)?;
 
         // Always update include lists (useful for diagnostics even if hashing fails).
@@ -683,7 +777,17 @@ impl DepGraph {
             }
         }
 
-        let artifact_key = compute_artifact_key(key, &mut file_hashes, entry.key_root.as_deref());
+        let artifact_key = if let Some(externs) = rustc_externs.as_deref() {
+            let mut extern_hashes = collect_rustc_extern_hashes(externs, &get_hash)?;
+            compute_rustc_artifact_key_with_root(
+                key,
+                &mut file_hashes,
+                &mut extern_hashes,
+                entry.key_root.as_deref(),
+            )
+        } else {
+            compute_artifact_key(key, &mut file_hashes, entry.key_root.as_deref())
+        };
 
         // SUCCESS: all hashes computed â€” transition to Warm atomically with artifact key.
         entry.state = ContextState::Warm;
@@ -709,6 +813,8 @@ impl DepGraph {
                 true
             }
         });
+        self.rustc_externs
+            .retain(|key, _| self.contexts.contains_key(key));
 
         // Also trim file entries not referenced by any context.
         let referenced: std::collections::HashSet<NormalizedPath> = self
@@ -735,6 +841,7 @@ impl DepGraph {
     pub fn clear(&self) {
         self.files.clear();
         self.contexts.clear();
+        self.rustc_externs.clear();
         self.checks.store(0, Ordering::Relaxed);
         self.hits.store(0, Ordering::Relaxed);
         self.misses.store(0, Ordering::Relaxed);
@@ -799,6 +906,12 @@ impl DepGraph {
         self.contexts.get(key).map(|e| e.resolved_includes.clone())
     }
 
+    /// Get rustc extern input paths for a context.
+    #[must_use]
+    pub fn get_rustc_externs(&self, key: &ContextKey) -> Option<Vec<(String, NormalizedPath)>> {
+        self.rustc_extern_inputs(key)
+    }
+
     /// Store scanned includes for a file (shared file node).
     pub fn store_file_includes(&self, path: NormalizedPath, includes: Vec<IncludeDirective>) {
         self.files.insert(
@@ -834,6 +947,7 @@ impl DepGraph {
         Self {
             files,
             contexts,
+            rustc_externs: DashMap::new(),
             checks: AtomicU64::new(0),
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
@@ -959,6 +1073,64 @@ mod tests {
 
         let verdict = graph.check(&key, always_fresh, dummy_hash);
         assert!(matches!(verdict, CacheVerdict::Hit { .. }));
+    }
+
+    #[test]
+    fn rustc_extern_artifact_key_ignores_target_dir_path_shape() {
+        let graph = DepGraph::new();
+        let ctx = make_ctx("/src/app.rs");
+        let key = ctx.context_key();
+        let source_hash = crate::hash::hash_bytes(b"app");
+        let extern_hash = crate::hash::hash_bytes(b"dep-v1");
+        let extern_a = NormalizedPath::from("/target-main/libdep.rlib");
+        let extern_b = NormalizedPath::from("/target-subagent/libdep.rlib");
+
+        graph.register_rustc_with_key_and_root_result(
+            key,
+            ctx.clone(),
+            None,
+            vec![("dep".to_string(), extern_a.clone())],
+        );
+        let first_key = graph
+            .update(
+                &key,
+                ScanResult {
+                    resolved: Vec::new(),
+                    unresolved: Vec::new(),
+                    has_computed: false,
+                },
+                |path| {
+                    if path == Path::new("/src/app.rs") {
+                        Some(source_hash)
+                    } else if path == extern_a.as_path() {
+                        Some(extern_hash)
+                    } else {
+                        None
+                    }
+                },
+            )
+            .expect("rustc artifact key should be computed");
+
+        graph.register_rustc_with_key_and_root_result(
+            key,
+            ctx,
+            None,
+            vec![("dep".to_string(), extern_b.clone())],
+        );
+        let verdict = graph.check(&key, always_fresh, |path| {
+            if path == Path::new("/src/app.rs") {
+                Some(source_hash)
+            } else if path == extern_b.as_path() {
+                Some(extern_hash)
+            } else {
+                None
+            }
+        });
+
+        match verdict {
+            CacheVerdict::Hit { artifact_key } => assert_eq!(artifact_key, first_key),
+            other => panic!("expected rustc extern path-shape hit, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/zccache/tests/daemon_rustc_cache_test.rs
+++ b/crates/zccache/tests/daemon_rustc_cache_test.rs
@@ -110,6 +110,23 @@ fn path_remap_auto_env() -> Vec<(String, String)> {
     vec![("ZCCACHE_PATH_REMAP".to_string(), "auto".to_string())]
 }
 
+fn path_remap_auto_env_for_root(
+    root: &std::path::Path,
+    cargo_target_dir: &std::path::Path,
+) -> Vec<(String, String)> {
+    vec![
+        ("ZCCACHE_PATH_REMAP".to_string(), "auto".to_string()),
+        (
+            "ZCCACHE_WORKTREE_ROOT".to_string(),
+            root.to_string_lossy().into_owned(),
+        ),
+        (
+            "CARGO_TARGET_DIR".to_string(),
+            cargo_target_dir.to_string_lossy().into_owned(),
+        ),
+    ]
+}
+
 fn init_git_root(root: &std::path::Path) -> bool {
     std::fs::create_dir_all(root).unwrap();
     match std::process::Command::new("git")
@@ -129,6 +146,50 @@ fn init_git_root(root: &std::path::Path) -> bool {
         }
         Err(err) => panic!("failed to run git init: {err}"),
     }
+}
+
+fn run_git(root: &std::path::Path, args: &[&str]) -> bool {
+    match std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .status()
+    {
+        Ok(status) if status.success() => true,
+        Ok(status) => {
+            eprintln!(
+                "skipping test: git -C {} {} failed with status {status}",
+                root.display(),
+                args.join(" ")
+            );
+            false
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!("skipping test: git not found");
+            false
+        }
+        Err(err) => panic!("failed to run git: {err}"),
+    }
+}
+
+fn init_git_worktree_pair(
+    root_a: &std::path::Path,
+    root_b: &std::path::Path,
+) -> Option<(std::path::PathBuf, std::path::PathBuf)> {
+    if !init_git_root(root_a) {
+        return None;
+    }
+    let (dep_src, app_src) = write_worktree_project(root_a, 7, 1);
+    let root_b_arg = root_b.to_string_lossy().into_owned();
+    if !run_git(root_a, &["config", "user.email", "zccache@example.invalid"])
+        || !run_git(root_a, &["config", "user.name", "zccache test"])
+        || !run_git(root_a, &["add", "src/dep.rs", "src/lib.rs"])
+        || !run_git(root_a, &["commit", "--quiet", "-m", "initial test project"])
+        || !run_git(root_a, &["worktree", "add", "--quiet", &root_b_arg, "HEAD"])
+    {
+        return None;
+    }
+    Some((dep_src, app_src))
 }
 
 fn write_worktree_project(
@@ -266,6 +327,73 @@ async fn compile_worktree_app_with_env(
             "src/lib.rs",
             "-o",
             "target/libapp.rlib",
+        ],
+        root,
+        env,
+    )
+    .await
+}
+
+async fn compile_worktree_dep_to_target_with_env(
+    client: &mut ClientConn,
+    session_id: &str,
+    compiler: &str,
+    root: &std::path::Path,
+    target_dir: &std::path::Path,
+    env: Option<Vec<(String, String)>>,
+) -> (i32, bool) {
+    std::fs::create_dir_all(target_dir).unwrap();
+    let target_dir_arg = target_dir.to_string_lossy().to_string();
+    compile_with_env(
+        client,
+        session_id,
+        compiler,
+        &[
+            "--edition",
+            "2021",
+            "--crate-type",
+            "lib",
+            "--crate-name",
+            "dep",
+            "--emit=link",
+            "--out-dir",
+            &target_dir_arg,
+            "src/dep.rs",
+        ],
+        root,
+        env,
+    )
+    .await
+}
+
+async fn compile_worktree_app_to_target_with_env(
+    client: &mut ClientConn,
+    session_id: &str,
+    compiler: &str,
+    root: &std::path::Path,
+    target_dir: &std::path::Path,
+    env: Option<Vec<(String, String)>>,
+) -> (i32, bool) {
+    std::fs::create_dir_all(target_dir).unwrap();
+    let target_dir_arg = target_dir.to_string_lossy().to_string();
+    let dep_arg = format!("dep={}", target_dir.join("libdep.rlib").display());
+    compile_with_env(
+        client,
+        session_id,
+        compiler,
+        &[
+            "--edition",
+            "2021",
+            "--crate-type",
+            "lib",
+            "--crate-name",
+            "app",
+            "--emit=link",
+            "--out-dir",
+            &target_dir_arg,
+            "--extern",
+            &dep_arg,
+            "src/lib.rs",
         ],
         root,
         env,
@@ -921,6 +1049,114 @@ async fn test_rustc_sibling_git_worktree_equivalent_cache_sharing() {
             std::fs::read(&app_a).unwrap(),
             app_a_original,
             "A cached output should remain byte-identical after B misses"
+        );
+
+        shutdown.notify_one();
+        server_handle.await.unwrap();
+    })
+    .await;
+}
+
+/// Issue #396: a real `git worktree` pair should share rustc artifacts even
+/// when each worktree uses a different relative `CARGO_TARGET_DIR` leaf name.
+///
+/// The explicit `ZCCACHE_WORKTREE_ROOT` entries mirror soldr's managed-build
+/// contract. Before filtering `CARGO_TARGET_DIR`, these equivalent compiles
+/// missed because the target-dir shape leaked into rustc cache identity.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore] // integration-level: starts real daemon with IPC + rustc + git worktree
+async fn test_rustc_git_worktrees_share_with_different_cargo_target_dir_shapes() {
+    let rustc = match zccache::test_support::find_rustc() {
+        Some(p) => p,
+        None => {
+            eprintln!("skipping test: rustc not found");
+            return;
+        }
+    };
+
+    zccache::test_support::test_timeout(async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_a = tmp.path().join("repo-main");
+        let root_b = tmp.path().join("repo-subagent");
+
+        let Some((_dep_src, _app_src)) = init_git_worktree_pair(&root_a, &root_b) else {
+            return;
+        };
+
+        let target_a = root_a.join(".claude/worktrees/parent-cache-main-target");
+        let target_b = root_b.join(".claude/worktrees/parent-cache-sub-target");
+
+        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let mut client_a = zccache::ipc::connect(&endpoint).await.unwrap();
+        let mut client_b = zccache::ipc::connect(&endpoint).await.unwrap();
+        let session_a = start_session_in(&mut client_a, &root_a).await;
+        let session_b = start_session_in(&mut client_b, &root_b).await;
+        let rustc_str = rustc.to_string_lossy().to_string();
+
+        let env_a = path_remap_auto_env_for_root(&root_a, &target_a);
+        let env_b = path_remap_auto_env_for_root(&root_b, &target_b);
+
+        let (exit_code, cached) = compile_worktree_dep_to_target_with_env(
+            &mut client_a,
+            &session_a,
+            &rustc_str,
+            &root_a,
+            &target_a,
+            Some(env_a.clone()),
+        )
+        .await;
+        assert_eq!(exit_code, 0, "A dependency compile should succeed");
+        assert!(!cached, "A dependency compile should be a cold miss");
+
+        let (exit_code, cached) = compile_worktree_app_to_target_with_env(
+            &mut client_a,
+            &session_a,
+            &rustc_str,
+            &root_a,
+            &target_a,
+            Some(env_a),
+        )
+        .await;
+        assert_eq!(exit_code, 0, "A app compile should succeed");
+        assert!(!cached, "A app compile should be a cold miss");
+
+        let (exit_code, dep_cached) = compile_worktree_dep_to_target_with_env(
+            &mut client_b,
+            &session_b,
+            &rustc_str,
+            &root_b,
+            &target_b,
+            Some(env_b.clone()),
+        )
+        .await;
+        assert_eq!(exit_code, 0, "B dependency compile should succeed");
+
+        let (exit_code, app_cached) = compile_worktree_app_to_target_with_env(
+            &mut client_b,
+            &session_b,
+            &rustc_str,
+            &root_b,
+            &target_b,
+            Some(env_b),
+        )
+        .await;
+        assert_eq!(exit_code, 0, "B app compile should succeed");
+
+        let warm_hits = usize::from(dep_cached) + usize::from(app_cached);
+        let warm_cacheable = 2usize;
+        assert!(
+            warm_hits * 100 >= warm_cacheable * 95,
+            "expected >=95% warm hit rate across target-dir shapes, got \
+             {warm_hits}/{warm_cacheable}; dep_cached={dep_cached}, \
+             app_cached={app_cached}"
+        );
+        assert!(
+            target_b.join("libdep.rlib").exists(),
+            "B dependency output should be restored into B's target dir"
+        );
+        assert!(
+            target_b.join("libapp.rlib").exists(),
+            "B app output should be restored into B's target dir"
         );
 
         shutdown.notify_one();

--- a/docs/architecture/portability.md
+++ b/docs/architecture/portability.md
@@ -66,6 +66,10 @@ cache key. The constant of record is `VOLATILE_CARGO_ENV_VARS` in
 fast-path miss/hit decision does not diverge from the slow-path key
 computation (issue #396). Cargo `--out-dir`, `-L`, and `--extern` directory
 prefixes derived from `CARGO_TARGET_DIR` are already non-cache-key state.
+Target directories outside `ZCCACHE_WORKTREE_ROOT` are intentionally not
+rewritten into root-relative request-key paths; they remain distinct at the
+request-fingerprint layer unless a later depgraph validation proves the
+artifact is safe to reuse.
 
 ## File Identity
 


### PR DESCRIPTION
Closes #396.

## Summary

- Tracks rustc `--extern` files separately from generic depgraph includes so their content hashes affect rustc artifact keys by crate name, while target-dir path prefixes stay output-placement state.
- Keeps worktree-equivalent hits off the zero-hash fast/request cache path so source edits in newly seen worktrees still take the hashed depgraph validation path.
- Adds the requested git-worktree regression for different `CARGO_TARGET_DIR` shapes, keeps the existing same-shape regression green, covers outside-root target dirs, and updates the portability contract docs.

## Test plan

- [x] `rustup run 1.94.1-x86_64-pc-windows-gnu cargo fmt --all`
- [x] `rustup run 1.94.1-x86_64-pc-windows-gnu cargo test -p zccache rustc_extern_artifact_key_ignores_target_dir_path_shape -- --test-threads=1 --nocapture`
- [x] `rustup run 1.94.1-x86_64-pc-windows-gnu cargo test -p zccache external_out_dirs -- --test-threads=1 --nocapture`
- [x] `rustup run 1.94.1-x86_64-pc-windows-gnu cargo test -p zccache cargo_target_dir -- --test-threads=1 --nocapture`
- [x] `rustup run 1.94.1-x86_64-pc-windows-gnu cargo test -p zccache --test daemon_rustc_cache_test test_rustc_git_worktrees_share_with_different_cargo_target_dir_shapes -- --ignored --test-threads=1 --nocapture`
- [x] `rustup run 1.94.1-x86_64-pc-windows-gnu cargo test -p zccache --test daemon_rustc_cache_test test_rustc_sibling_git_worktree_equivalent_cache_sharing -- --ignored --test-threads=1 --nocapture`
- [x] `rustup run 1.94.1-x86_64-pc-windows-gnu cargo check -p zccache --all-targets`
- [x] `rustup run 1.94.1-x86_64-pc-windows-gnu cargo clippy -p zccache --all-targets -- -D warnings`
- [x] `rustup run 1.94.1-x86_64-pc-windows-gnu cargo test -p zccache --lib -- --test-threads=1`
- [x] `git diff --check`