### PR TITLE
fix(ipc): shorten long private daemon socket paths

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -125,6 +125,15 @@ runs:
           rm -rf "$TARGET_DIR"
         fi
 
+    - name: Remove stale release binaries
+      shell: bash
+      run: |
+        TARGET_DIR="target/${{ inputs.target }}/release"
+        rm -f \
+          "$TARGET_DIR/zccache${{ inputs.binary_ext }}" \
+          "$TARGET_DIR/zccache-daemon${{ inputs.binary_ext }}" \
+          "$TARGET_DIR/zccache-fp${{ inputs.binary_ext }}"
+
     # Static-link the MSVC C runtime (vcruntime + UCRT) for Windows release
     # binaries. Without `+crt-static` the published `zccache.exe` declares
     # imports against `VCRUNTIME140.dll` and the `api-ms-win-crt-*` UCRT
@@ -237,28 +246,35 @@ runs:
         # ships without embedded debug info on Linux/macOS, so this is mostly
         # belt-and-suspenders. Fall back to plain `strip` when the
         # cross-tool doesn't support the flag.
-        STRIP="${{ inputs.strip }}"
-        if [ -z "$STRIP" ]; then
-          STRIP="strip"
-        fi
-        do_strip() {
-          if "$STRIP" --strip-debug "$1" 2>/dev/null; then
-            return 0
-          fi
-          "$STRIP" "$1" 2>/dev/null || true
-        }
-        if command -v "$STRIP" &> /dev/null; then
-          do_strip staging/zccache${{ inputs.binary_ext }}
-          do_strip staging/zccache-daemon${{ inputs.binary_ext }}
-          do_strip staging/zccache-fp${{ inputs.binary_ext }}
-          if [ "${{ inputs.include_python }}" = "true" ]; then
-            for native in staging/python/zccache/_native.* \
-                          staging/python/zccache/fingerprint/_native.* \
-                          staging/python/zccache/watcher/_native.*; do
-              [ -e "$native" ] && do_strip "$native"
-            done
-          fi
-        fi
+        case "${{ inputs.target }}" in
+          *pc-windows-msvc)
+            echo "Skipping strip for Windows MSVC artifacts"
+            ;;
+          *)
+            STRIP="${{ inputs.strip }}"
+            if [ -z "$STRIP" ]; then
+              STRIP="strip"
+            fi
+            do_strip() {
+              if "$STRIP" --strip-debug "$1" 2>/dev/null; then
+                return 0
+              fi
+              "$STRIP" "$1" 2>/dev/null || true
+            }
+            if command -v "$STRIP" &> /dev/null; then
+              do_strip staging/zccache${{ inputs.binary_ext }}
+              do_strip staging/zccache-daemon${{ inputs.binary_ext }}
+              do_strip staging/zccache-fp${{ inputs.binary_ext }}
+              if [ "${{ inputs.include_python }}" = "true" ]; then
+                for native in staging/python/zccache/_native.* \
+                              staging/python/zccache/fingerprint/_native.* \
+                              staging/python/zccache/watcher/_native.*; do
+                  [ -e "$native" ] && do_strip "$native"
+                done
+              fi
+            fi
+            ;;
+        esac
 
     - name: Stage debug-symbol sidecars
       shell: bash
@@ -382,6 +398,61 @@ runs:
             --triple "${{ inputs.target }}" \
             --timestamp "$NOW"
         done
+
+    - name: Validate staged release binaries
+      shell: bash
+      run: |
+        min_size=1048576
+        for bin in zccache zccache-daemon zccache-fp; do
+          path="staging/${bin}${{ inputs.binary_ext }}"
+          if [ ! -f "$path" ]; then
+            echo "::error::Missing staged binary: $path" >&2
+            exit 1
+          fi
+          size=$(wc -c < "$path" | tr -d '[:space:]')
+          if [ "$size" -lt "$min_size" ]; then
+            echo "::error::Staged binary is suspiciously small: $path ($size bytes)" >&2
+            exit 1
+          fi
+        done
+
+        case "${{ inputs.target }}" in
+          aarch64-pc-windows-msvc|aarch64-unknown-linux-musl|aarch64-unknown-linux-gnu)
+            echo "Skipping staged binary execution check for cross-compiled target ${{ inputs.target }}"
+            exit 0
+            ;;
+        esac
+
+        for bin in zccache zccache-daemon zccache-fp; do
+          path="staging/${bin}${{ inputs.binary_ext }}"
+          version="$("$path" --version)"
+          printf '%s\n' "$version"
+          if ! printf '%s\n' "$version" | grep -Eq "^${bin} [0-9]"; then
+            echo "::error::Staged binary did not report a valid version: $path" >&2
+            exit 1
+          fi
+        done
+
+        smoke_root="${RUNNER_TEMP:-/tmp}/zccache-release-smoke-${{ inputs.target }}"
+        rm -rf "$smoke_root"
+        mkdir -p "$smoke_root"
+        export ZCCACHE_CACHE_DIR="$smoke_root/cache"
+        cleanup() {
+          staging/zccache${{ inputs.binary_ext }} stop >/dev/null 2>&1 || true
+          rm -rf "$smoke_root"
+        }
+        trap cleanup EXIT
+
+        rustc_bin="$(rustup which rustc)"
+        probe="$(staging/zccache${{ inputs.binary_ext }} "$rustc_bin" -vV)"
+        printf '%s\n' "$probe"
+        if ! printf '%s\n' "$probe" | grep -q '^host: '; then
+          echo "::error::zccache RUSTC_WRAPPER smoke did not print rustc host metadata" >&2
+          exit 1
+        fi
+
+        staging/zccache${{ inputs.binary_ext }} start
+        staging/zccache${{ inputs.binary_ext }} status
 
     - name: Package standalone archive
       shell: bash

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -98,6 +98,7 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       pypi_complete: ${{ steps.registries.outputs.pypi_complete }}
       crates_complete: ${{ steps.registries.outputs.crates_complete }}
+      github_release_exists: ${{ steps.meta.outputs.github_release_exists }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -119,7 +120,7 @@ jobs:
           validate_release_metadata()
           PY
 
-      - name: Resolve release version and fail on already-published release
+      - name: Resolve release version and existing release
         id: meta
         shell: bash
         env:
@@ -167,6 +168,7 @@ jobs:
           fi
 
           SEEN=""
+          GITHUB_RELEASE_EXISTS=false
           for CANDIDATE in "$TAG" "$NORMALIZED_TAG" "v$NORMALIZED_TAG"; do
             if [ -z "$CANDIDATE" ]; then
               continue
@@ -190,14 +192,16 @@ jobs:
           PY
             )"
             if [ -n "$PUBLISHED_AT" ]; then
-              echo "Release $CANDIDATE is already published at $PUBLISHED_AT" >&2
-              exit 1
+              GITHUB_RELEASE_EXISTS=true
+              echo "Release $CANDIDATE is already published at $PUBLISHED_AT; release job will update it"
+              break
             fi
           done
 
           echo "checkout_ref=$CHECKOUT_REF" >> "$GITHUB_OUTPUT"
           echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "github_release_exists=$GITHUB_RELEASE_EXISTS" >> "$GITHUB_OUTPUT"
 
       - name: Check registry publish status
         id: registries
@@ -316,10 +320,64 @@ jobs:
           path: ${{ format('{0}/*{1}', steps.build_target.outputs.standalone_dir, matrix.binary_ext == '.exe' && '.zip' || '.tar.gz') }}
           if-no-files-found: error
 
+  publish-release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    needs: [preflight, build]
+    if: |
+      always()
+      && needs.preflight.result == 'success'
+      && needs.build.result == 'success'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.preflight.outputs.checkout_ref }}
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: release-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Add installer scripts
+        run: |
+          cp install.sh release-assets/install.sh
+          cp install.ps1 release-assets/install.ps1
+          chmod 755 release-assets/install.sh
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          cd release-assets
+          find . -maxdepth 1 -type f -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+
+      - name: Publish or update release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ needs.preflight.outputs.release_tag }}
+          name: zccache ${{ needs.preflight.outputs.version }}
+          body: |
+            ## Install
+
+            ```bash
+            curl -LsSf https://github.com/zackees/zccache/releases/latest/download/install.sh | sh
+            ```
+
+            ```powershell
+            powershell -ExecutionPolicy Bypass -c "irm https://github.com/zackees/zccache/releases/latest/download/install.ps1 | iex"
+            ```
+
+            GitHub Marketplace publication remains a manual GitHub UI step:
+            open the generated release, select `Publish this action to the GitHub Marketplace`,
+            choose categories, and publish.
+          files: release-assets/*
+          fail_on_unmatched_files: true
+          overwrite_files: true
+
   build-wheels:
     name: Build PyPI Wheels
     runs-on: ubuntu-latest
-    needs: [preflight, build]
+    needs: [preflight, build, publish-release]
     if: needs.preflight.outputs.pypi_complete != 'true'
     steps:
       - uses: actions/checkout@v6
@@ -347,8 +405,13 @@ jobs:
   publish-pypi:
     name: Publish PyPI
     runs-on: ubuntu-latest
-    needs: [preflight, build-wheels]
-    if: needs.preflight.outputs.pypi_complete != 'true'
+    needs: [preflight, publish-release, build-wheels]
+    if: |
+      always()
+      && needs.preflight.result == 'success'
+      && needs.publish-release.result == 'success'
+      && needs.preflight.outputs.pypi_complete != 'true'
+      && needs.build-wheels.result == 'success'
     environment: pypi
     permissions:
       actions: read
@@ -370,10 +433,11 @@ jobs:
   publish-crates:
     name: Publish crates.io
     runs-on: ubuntu-latest
-    needs: [preflight, publish-pypi]
+    needs: [preflight, publish-release, publish-pypi]
     if: |
       always()
       && needs.preflight.result == 'success'
+      && needs.publish-release.result == 'success'
       && needs.preflight.outputs.crates_complete != 'true'
       && (needs.preflight.outputs.pypi_complete == 'true' || needs.publish-pypi.result == 'success')
     steps:
@@ -393,59 +457,3 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: python -m ci.release_workflow publish-crates
-
-  publish-release:
-    name: Publish GitHub Release
-    runs-on: ubuntu-latest
-    needs: [preflight, build, build-wheels, publish-pypi, publish-crates]
-    if: |
-      always()
-      && needs.preflight.result == 'success'
-      && needs.build.result == 'success'
-      && (needs.build-wheels.result == 'success' || needs.build-wheels.result == 'skipped')
-      && (needs.publish-pypi.result == 'success' || needs.publish-pypi.result == 'skipped')
-      && (needs.publish-crates.result == 'success' || needs.publish-crates.result == 'skipped')
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.preflight.outputs.checkout_ref }}
-
-      - uses: actions/download-artifact@v8
-        with:
-          pattern: release-*
-          path: release-assets
-          merge-multiple: true
-
-      - name: Add installer scripts
-        run: |
-          cp install.sh release-assets/install.sh
-          cp install.ps1 release-assets/install.ps1
-          chmod 755 release-assets/install.sh
-
-      - name: Generate checksums
-        shell: bash
-        run: |
-          cd release-assets
-          find . -maxdepth 1 -type f -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
-
-      - name: Publish release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ needs.preflight.outputs.release_tag }}
-          name: zccache ${{ needs.preflight.outputs.version }}
-          body: |
-            ## Install
-
-            ```bash
-            curl -LsSf https://github.com/zackees/zccache/releases/latest/download/install.sh | sh
-            ```
-
-            ```powershell
-            powershell -ExecutionPolicy Bypass -c "irm https://github.com/zackees/zccache/releases/latest/download/install.ps1 | iex"
-            ```
-
-            GitHub Marketplace publication remains a manual GitHub UI step:
-            open the generated release, select `Publish this action to the GitHub Marketplace`,
-            choose categories, and publish.
-          files: release-assets/*
-          fail_on_unmatched_files: true

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -76,6 +76,11 @@ jobs:
         uses: ./
         with:
           shared-key: test-${{ matrix.target }}
+          # Bootstrap this repair PR from the last known-good GitHub binary
+          # release. The production action still defaults to latest, and the
+          # release workflow now blocks malformed latest assets before PyPI or
+          # crates.io publish.
+          zccache-version: "1.11.4"
 
       - name: Verify RUSTC_WRAPPER is set
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.11.5"
+version = "1.11.6"
 dependencies = [
  "bincode",
  "blake3",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.11.5"
+version = "1.11.6"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.11.5"
+version = "1.11.6"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.11.5"
+version = "1.11.6"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.11.5"
+version = "1.11.6"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/action.yml
+++ b/action.yml
@@ -176,6 +176,43 @@ runs:
         VERSION="${{ inputs.zccache-version }}"
         INSTALLED=false
 
+        path_for_runner() {
+          local dir="$1"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            cygpath -w "$dir" 2>/dev/null || printf '%s\n' "$dir"
+          else
+            printf '%s\n' "$dir"
+          fi
+        }
+
+        add_install_dir_to_path() {
+          local dir="$1"
+          echo "$(path_for_runner "$dir")" >> "$GITHUB_PATH"
+          export PATH="$dir:$PATH"
+        }
+
+        validate_zccache_install() {
+          local version_out
+          if ! version_out="$(zccache --version 2>&1)" || ! printf '%s\n' "$version_out" | grep -Eq '^zccache [0-9]'; then
+            echo "::warning::Installed zccache did not report a valid version: ${version_out:-<empty>}"
+            return 1
+          fi
+
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            local rustc_bin probe_out
+            rustc_bin="$(rustup which rustc 2>/dev/null || command -v rustc || true)"
+            if [ -n "$rustc_bin" ]; then
+              if ! probe_out="$(zccache "$rustc_bin" -vV 2>&1)" || ! printf '%s\n' "$probe_out" | grep -q '^host: '; then
+                echo "::warning::Installed zccache failed the Windows RUSTC_WRAPPER probe."
+                printf '%s\n' "$probe_out"
+                zccache stop >/dev/null 2>&1 || true
+                return 1
+              fi
+            fi
+          fi
+          return 0
+        }
+
         # Try binary install on Linux/macOS (requires GitHub Releases to exist)
         if [ "${{ runner.os }}" != "Windows" ]; then
           INSTALL_DIR="$HOME/.local/bin"
@@ -192,12 +229,40 @@ runs:
             if ZCCACHE_INSTALL_VERSION="$VERSION" \
                ZCCACHE_INSTALL_DIR="$INSTALL_DIR" \
                ZCCACHE_NO_MODIFY_PATH=1 \
-                 sh "$INSTALL_SCRIPT" 2>/dev/null; then
-              echo "$INSTALL_DIR" >> "$GITHUB_PATH"
-              export PATH="$INSTALL_DIR:$PATH"
+                  sh "$INSTALL_SCRIPT" 2>/dev/null; then
+              add_install_dir_to_path "$INSTALL_DIR"
               INSTALLED=true
             fi
           fi
+        fi
+
+        # On Windows, prefer the native release zip over the PyPI console
+        # script wrapper. The native exe is required for RUSTC_WRAPPER.
+        if [ "$INSTALLED" = "false" ] && [ "${{ runner.os }}" = "Windows" ]; then
+          INSTALL_DIR="$HOME/.local/bin"
+          export INSTALL_DIR
+          mkdir -p "$INSTALL_DIR"
+          WIN_INSTALL_DIR="$(cygpath -w "$INSTALL_DIR" 2>/dev/null || python -c 'import os; print(os.path.abspath(os.environ["INSTALL_DIR"]))')"
+
+          if [ -f "${{ github.action_path }}/install.ps1" ]; then
+            INSTALL_SCRIPT="${{ github.action_path }}/install.ps1"
+          else
+            INSTALL_SCRIPT="$(mktemp --suffix=.ps1)"
+            curl -fsSL https://raw.githubusercontent.com/zackees/zccache/main/install.ps1 -o "$INSTALL_SCRIPT" 2>/dev/null || true
+          fi
+
+          if [ -f "$INSTALL_SCRIPT" ] && [ -s "$INSTALL_SCRIPT" ]; then
+            if ZCCACHE_INSTALL_VERSION="$VERSION" ZCCACHE_NO_MODIFY_PATH=1 \
+              pwsh -NoProfile -ExecutionPolicy Bypass -File "$INSTALL_SCRIPT" -BinDir "$WIN_INSTALL_DIR"; then
+              add_install_dir_to_path "$INSTALL_DIR"
+              INSTALLED=true
+            fi
+          fi
+        fi
+
+        if [ "$INSTALLED" = "true" ] && ! validate_zccache_install; then
+          echo "::error::Downloaded zccache release binary is not usable"
+          exit 1
         fi
 
         # Try cargo-binstall (downloads pre-built binary, no Python needed)
@@ -209,9 +274,13 @@ runs:
             cargo-binstall "zccache-cli@${VERSION}" --no-confirm --install-path "$INSTALL_DIR" 2>/dev/null && INSTALLED=true
           fi
           if [ "$INSTALLED" = "true" ]; then
-            echo "$INSTALL_DIR" >> "$GITHUB_PATH"
-            export PATH="$INSTALL_DIR:$PATH"
+            add_install_dir_to_path "$INSTALL_DIR"
           fi
+        fi
+
+        if [ "$INSTALLED" = "true" ] && ! validate_zccache_install; then
+          echo "::error::Installed zccache binary is not usable"
+          exit 1
         fi
 
         # Fall back to pip install (works on all platforms)
@@ -243,8 +312,7 @@ runs:
           fi
 
           if [ -n "$FOUND_DIR" ]; then
-            export PATH="$FOUND_DIR:$PATH"
-            echo "$FOUND_DIR" >> "$GITHUB_PATH"
+            add_install_dir_to_path "$FOUND_DIR"
             # Fix executable permissions (macOS PyPI bundles may lose +x)
             if [ "${{ runner.os }}" != "Windows" ]; then
               chmod +x "$FOUND_DIR/zccache" "$FOUND_DIR/zccache-daemon" 2>/dev/null || true
@@ -254,12 +322,19 @@ runs:
 
         # Verify install
         which zccache || { echo "ERROR: zccache not found on PATH"; echo "PATH=$PATH"; exit 1; }
+        if ! validate_zccache_install; then
+          echo "::error::Unable to install a working zccache binary"
+          exit 1
+        fi
 
     - name: Resolve zccache cache paths
       id: zccache-paths
       shell: bash
       run: |
-        CACHE_ROOT="$(zccache cache-root)"
+        CACHE_ROOT="$(zccache cache-root 2>/dev/null || true)"
+        if [ -z "$CACHE_ROOT" ]; then
+          CACHE_ROOT="${ZCCACHE_CACHE_DIR:-$HOME/.zccache}"
+        fi
         {
           echo "cache-root=$CACHE_ROOT"
           echo "cargo-registry-cache=$CACHE_ROOT/cargo-registry"

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -18,6 +18,9 @@ pub use transport::{
 
 use crate::core::NormalizedPath;
 
+#[cfg(unix)]
+const MAX_PORTABLE_UNIX_SOCKET_PATH_BYTES: usize = 100;
+
 /// Returns the platform-specific default IPC endpoint path.
 ///
 /// - Linux: `$XDG_RUNTIME_DIR/zccache/sock` or `/tmp/zccache-$USER/sock`
@@ -57,8 +60,13 @@ pub fn default_endpoint() -> String {
 pub fn endpoint_for_cache_dir(cache_dir: &std::path::Path, namespace: Option<&str>) -> String {
     #[cfg(unix)]
     {
-        cache_dir
-            .join(daemon_socket_name(namespace))
+        let direct = cache_dir.join(daemon_socket_name(namespace));
+        let direct = direct.to_string_lossy();
+        if direct.as_bytes().len() <= MAX_PORTABLE_UNIX_SOCKET_PATH_BYTES {
+            return direct.into_owned();
+        }
+
+        compact_cache_dir_endpoint(cache_dir, namespace)
             .to_string_lossy()
             .into_owned()
     }
@@ -67,6 +75,18 @@ pub fn endpoint_for_cache_dir(cache_dir: &std::path::Path, namespace: Option<&st
         let suffix = crate::core::stable_path_id(cache_dir);
         pipe_name(&suffix, namespace)
     }
+}
+
+#[cfg(unix)]
+fn compact_cache_dir_endpoint(
+    cache_dir: &std::path::Path,
+    namespace: Option<&str>,
+) -> std::path::PathBuf {
+    let cache_id = crate::core::stable_path_id(cache_dir);
+    std::path::PathBuf::from(format!(
+        "/tmp/zccache-{cache_id}-{}",
+        daemon_socket_name(namespace)
+    ))
 }
 
 /// Derive a platform IPC endpoint for a portable private daemon name.
@@ -548,6 +568,38 @@ mod tests {
             assert!(endpoint.ends_with("-soldr_dev"));
             assert!(endpoint.contains(&crate::core::stable_path_id(&cache_dir)));
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_dir_endpoint_falls_back_to_short_unix_socket_path() {
+        let root = tempfile::tempdir().unwrap();
+        let cache_dir = root
+            .path()
+            .join("this")
+            .join("is")
+            .join("a")
+            .join("deep")
+            .join("private")
+            .join("zccache")
+            .join("cache")
+            .join("directory")
+            .join("that")
+            .join("would")
+            .join("exceed")
+            .join("sockaddr_un")
+            .join("path")
+            .join("limits");
+
+        let endpoint = endpoint_for_cache_dir(&cache_dir, Some("soldr-dev"));
+
+        assert!(
+            endpoint.as_bytes().len() <= MAX_PORTABLE_UNIX_SOCKET_PATH_BYTES,
+            "endpoint too long: {endpoint}"
+        );
+        assert!(endpoint.starts_with("/tmp/zccache-"));
+        assert!(endpoint.contains(&crate::core::stable_path_id(&cache_dir)));
+        assert!(endpoint.ends_with("-daemon-soldr-dev.sock"));
     }
 
     /// On macOS, `daemon_exe_for_pid` must reject a PID whose


### PR DESCRIPTION
## Summary
- Fall back to a compact `/tmp/zccache-<cache-id>-...sock` endpoint on Unix when a cache-dir-derived daemon socket path would exceed portable Unix socket path limits.
- Preserve the existing in-cache socket path for short cache roots and the existing Windows named pipe behavior.
- Harden the GitHub Action install/path resolver so Windows gets the native GitHub release exe on `PATH` and validates it before setting `RUSTC_WRAPPER`.
- Add release-build gates for #434: remove stale release binaries, skip stripping MSVC artifacts, validate the exact post-stamp staged binaries, run `zccache <rustc> -vV`, and smoke `start/status` before packaging.
- Reorder release publishing so the validated GitHub Release is published/updated before PyPI wheels and crates.io, with `overwrite_files: true` so release reruns can repair existing assets.
- Pin the action self-test matrix to the last known-good GitHub release (`1.11.4`) to avoid the known-bad `latest` 1.11.5 bootstrap deadlock while this repair release is being produced.
- Bump zccache to 1.11.6 so soldr can consume a released fix for private daemon CI paths.

This fixes the soldr private-daemon rollout failure seen in zackees/soldr#557, where deep CI temp paths plus `private/<daemon-name>/daemon-<daemon-name>.sock` exceeded `sockaddr_un` limits.

Part of #430. Fixes #434.

## Verification
- MSVC: `cargo fmt -- --check`
- MSVC: `cargo check -p zccache --all-targets`
- MSVC: `cargo-clippy.exe clippy -p zccache --all-targets -- -D warnings`
- MSVC: `cargo test -p zccache --lib ipc::tests`
- MSVC: `cargo build -p zccache --bins`
- MSVC release-smoke against stamped staged binaries: size/version checks for `zccache.exe`, `zccache-daemon.exe`, `zccache-fp.exe`; `zccache <msvc rustc> -vV`; `zccache start`; `zccache status`; `zccache stop`
- MSVC private-daemon smoke: `zccache start`, `zccache status --json`, `zccache session-start --private-daemon ...`, `zccache stop`
- YAML parse: `action.yml`, `.github/actions/build-target/action.yml`, `.github/workflows/release-auto.yml`, `.github/workflows/test-action.yml`
- `git diff --check`