### PR TITLE
fix(release): make release reruns restartable

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -402,7 +402,14 @@ runs:
     - name: Validate staged release binaries
       shell: bash
       run: |
-        min_size=1048576
+        case "${{ inputs.target }}" in
+          *pc-windows-msvc)
+            min_size=1048576
+            ;;
+          *)
+            min_size=262144
+            ;;
+        esac
         for bin in zccache zccache-daemon zccache-fp; do
           path="staging/${bin}${{ inputs.binary_ext }}"
           if [ ! -f "$path" ]; then
@@ -411,7 +418,7 @@ runs:
           fi
           size=$(wc -c < "$path" | tr -d '[:space:]')
           if [ "$size" -lt "$min_size" ]; then
-            echo "::error::Staged binary is suspiciously small: $path ($size bytes)" >&2
+            echo "::error::Staged binary is suspiciously small for ${{ inputs.target }}: $path ($size bytes, minimum $min_size)" >&2
             exit 1
           fi
         done

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -40,6 +40,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           REF_TYPE: ${{ github.ref_type }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         shell: bash
         run: |
           set -euo pipefail
@@ -77,8 +78,15 @@ jobs:
 
           # Skip if a GitHub release already exists for this version. Prevents
           # double-runs when publish-release creates the tag and re-triggers us.
+          # Rerun attempts are allowed through so an operator can restart after
+          # the GitHub Release checkpoint exists and resume PyPI/crates.io.
           for CANDIDATE in "$NEW_VERSION" "v$NEW_VERSION"; do
             if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$CANDIDATE" >/dev/null 2>&1; then
+              if [ "${RUN_ATTEMPT:-1}" != "1" ]; then
+                echo "release $CANDIDATE already exists, but run attempt $RUN_ATTEMPT is a restart - proceeding"
+                echo "should_release=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
               echo "release $CANDIDATE already exists — skipping"
               echo "should_release=false" >> "$GITHUB_OUTPUT"
               exit 0
@@ -239,6 +247,7 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             binary_ext: ""
+            clear_target_after_setup: "true"
             include_python: "true"
             upload_binaries: "true"
             upload_release: "false"
@@ -257,6 +266,7 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-14
             binary_ext: ""
+            clear_target_after_setup: "true"
             include_python: "true"
             upload_binaries: "true"
             upload_release: "true"
@@ -273,6 +283,7 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             binary_ext: ".exe"
+            clear_target_after_setup: "true"
             include_python: "true"
             upload_binaries: "true"
             upload_release: "true"

--- a/ci/README.md
+++ b/ci/README.md
@@ -14,9 +14,9 @@ Python scripts for development tooling. Rust commands go through `soldr <tool>` 
 
 - **Canonical workflow** - `.github/workflows/release-auto.yml` is the only supported release entrypoint
 - **Workflow helper** - `ci/release_workflow.py` provides preflight checks, wheel assembly, and crates publish helpers for the release workflow only
-- **Fast fail** - preflight checks PyPI and crates.io before any build fan-out and stops if the current version is already published
+- **Fast fail** - preflight checks PyPI and crates.io before any build fan-out and skips registry jobs that are already complete
 - **Trigger** - push a tag matching the workspace version (`1.3.6` or `v1.3.6`)
-- **Manual runs** - `Run workflow` can leave `tag` empty; the workflow derives the current workspace version from the selected branch and fails if that version already has a published GitHub release
+- **Manual runs and restarts** - `Run workflow` can leave `tag` empty; the workflow derives the current workspace version from the selected branch. Existing GitHub Releases are updated, and rerun attempts proceed so PyPI/crates.io can resume from the GitHub Release checkpoint.
 - **PyPI** - use Trusted Publishing with GitHub environment `pypi` and workflow `.github/workflows/release-auto.yml`
 - **crates.io** - add repository secret `CARGO_REGISTRY_TOKEN`
 - **GitHub Release** - created automatically with standalone archives, installer scripts, and `SHA256SUMS`

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -209,6 +209,15 @@ def test_build_target_can_treat_debug_sidecars_as_optional() -> None:
     assert "::warning::Missing debug sidecars for $TARGET: ${missing[*]}" in action
 
 
+def test_build_target_uses_target_specific_binary_size_floor() -> None:
+    action = _repo_text(".github/actions/build-target/action.yml")
+
+    assert "*pc-windows-msvc)" in action
+    assert "min_size=1048576" in action
+    assert "min_size=262144" in action
+    assert "minimum $min_size" in action
+
+
 def test_release_and_build_workflows_disable_cook_cache_for_cross_targets() -> None:
     cross_targets = {
         "x86_64-unknown-linux-musl",
@@ -223,11 +232,10 @@ def test_release_and_build_workflows_disable_cook_cache_for_cross_targets() -> N
         "x86_64-pc-windows-msvc",
     }
 
-    for workflow_path in (
-        ".github/workflows/build.yml",
-        ".github/workflows/release-auto.yml",
-    ):
-        workflow = _repo_text(workflow_path)
+    build_workflow = _repo_text(".github/workflows/build.yml")
+    release_workflow = _repo_text(".github/workflows/release-auto.yml")
+
+    for workflow in (build_workflow, release_workflow):
         assert "prebuild_deps: ${{ matrix.prebuild_deps || 'soldr-cook' }}" in workflow
         assert (
             "clear_target_after_setup: "
@@ -243,13 +251,26 @@ def test_release_and_build_workflows_disable_cook_cache_for_cross_targets() -> N
             assert "prebuild_deps: none" in block
             assert 'clear_target_after_setup: "true"' in block
 
-        for target in native_targets:
-            block = _matrix_entry(workflow, target)
-            assert "prebuild_deps: none" not in block
-            assert "clear_target_after_setup:" not in block
-
         windows_arm_block = _matrix_entry(workflow, "aarch64-pc-windows-msvc")
         assert 'require_debug_sidecars: "false"' in windows_arm_block
+
+    for target in native_targets:
+        block = _matrix_entry(build_workflow, target)
+        assert "prebuild_deps: none" not in block
+        assert "clear_target_after_setup:" not in block
+
+        release_block = _matrix_entry(release_workflow, target)
+        assert "prebuild_deps: none" not in release_block
+        assert 'clear_target_after_setup: "true"' in release_block
+
+
+def test_release_workflow_restart_attempts_resume_existing_github_release() -> None:
+    workflow = _repo_text(".github/workflows/release-auto.yml")
+
+    assert "RUN_ATTEMPT: ${{ github.run_attempt }}" in workflow
+    assert 'if [ "${RUN_ATTEMPT:-1}" != "1" ]; then' in workflow
+    assert "GitHub Release checkpoint" in workflow
+    assert "overwrite_files: true" in workflow
 
 
 def test_stamp_release_marker_layout_and_append(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- clear restored target artifacts for every `release-auto` target so release packaging cannot reuse stale/stub target outputs
- make the staged binary size gate target-aware: Windows MSVC keeps the 1 MiB floor that catches the bad 219 KiB stubs, while stripped Unix artifacts use a lower floor and still run version/wrapper smoke checks on executable host targets
- allow GitHub Actions rerun attempts to proceed when a GitHub Release already exists, so a failed release can resume from the GH Release checkpoint while PyPI/crates.io remain gated behind `publish-release`

## Context

Refs #434. The first 1.11.6 release run failed before publishing anything. Linux GNU hit an overstrict 1 MiB post-strip size floor, and Windows x64 still ran with `clear_target_after_setup: false`, packaging the restored 219 KiB stub. Windows ARM64 already had target clearing enabled and passed.

## Test Plan

- [x] `python -m pytest ci/tests/test_package_release.py ci/tests/test_release_workflow.py -q`
- [x] YAML parse for `.github/actions/build-target/action.yml`, `.github/workflows/release-auto.yml`, `.github/workflows/build.yml`
- [x] `git diff --check`