### PR TITLE
fix(release): build release artifacts without compile cache

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -12,6 +12,10 @@ inputs:
   cache_key:
     description: Cache key suffix passed to setup-soldr.
     required: true
+  use_soldr:
+    description: Use setup-soldr for setup and caching. Release builds set this false to avoid post-build cache uploads.
+    required: false
+    default: "true"
   prebuild_deps:
     description: setup-soldr prebuild dependency mode.
     required: false
@@ -68,11 +72,27 @@ runs:
       with:
         python-version: ${{ inputs.python_version }}
 
+    - name: Select Rust toolchain
+      shell: bash
+      run: |
+        echo "RELEASE_RUST_TOOLCHAIN=${{ contains(inputs.target, 'pc-windows-msvc') && '1.94.1-x86_64-pc-windows-msvc' || '1.94.1' }}" >> "$GITHUB_ENV"
+
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.94.1
+        toolchain: ${{ contains(inputs.target, 'pc-windows-msvc') && '1.94.1-x86_64-pc-windows-msvc' || '1.94.1' }}
         targets: ${{ inputs.target }}
+
+    - name: Verify Rust host toolchain
+      shell: bash
+      run: |
+        info="$(rustup run "$RELEASE_RUST_TOOLCHAIN" rustc -vV)"
+        printf '%s\n' "$info"
+        host="$(printf '%s\n' "$info" | awk '/^host: / { print $2 }')"
+        if [[ "${{ inputs.target }}" == *pc-windows-msvc && "$host" != "x86_64-pc-windows-msvc" ]]; then
+          echo "::error::Windows release builds must use the MSVC host toolchain, got: ${host:-<missing>}" >&2
+          exit 1
+        fi
 
     - name: Install musl tools
       if: inputs.target == 'x86_64-unknown-linux-musl'
@@ -107,6 +127,7 @@ runs:
         echo "CC_${TARGET_CC}=${{ inputs.linker }}" >> "$GITHUB_ENV"
 
     - name: Setup soldr build cache
+      if: inputs.use_soldr == 'true'
       uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
       with:
         toolchain: 1.94.1
@@ -153,11 +174,18 @@ runs:
       env:
         PYO3_PYTHON: python
       run: |
+        # Release artifacts are distribution outputs, so they must be compiled
+        # from source instead of being hydrated from a restored compile cache.
+        if [ "${{ inputs.use_soldr }}" = "true" ]; then
+          cargo_build=(soldr --no-cache cargo build)
+        else
+          cargo_build=(rustup run "$RELEASE_RUST_TOOLCHAIN" cargo build)
+        fi
         if [[ "${{ inputs.target }}" == *pc-windows-msvc ]]; then
           export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=+crt-static"
         fi
-        soldr cargo build --release --target ${{ inputs.target }} -p zccache --bin zccache
-        soldr cargo build --release --target ${{ inputs.target }} -p zccache --bin zccache-daemon
+        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache --bin zccache
+        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache --bin zccache-daemon
         # zccache-fp is a bin shipped *inside* the umbrella `zccache` crate
         # (see crates/zccache/Cargo.toml `[[bin]] name = "zccache-fp"`). The
         # sibling `zccache-fingerprint` crate is a pyo3 cdylib for the Python
@@ -165,7 +193,7 @@ runs:
         # then `cp`s `target/.../zccache-fp` into `staging/`, which is why
         # building the wrong target left it complaining `cannot stat
         # 'target/.../zccache-fp': No such file or directory`.
-        soldr cargo build --release --target ${{ inputs.target }} -p zccache --bin zccache-fp
+        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache --bin zccache-fp
 
     # Windows DLL load smoke gate (see zccache#269). If the just-built
     # `zccache.exe` cannot complete loader init on this host, `--version`
@@ -188,7 +216,12 @@ runs:
         esac
         BIN="target/${{ inputs.target }}/release/zccache${{ inputs.binary_ext }}"
         echo "Smoke test: $BIN --version"
-        "$BIN" --version
+        version="$("$BIN" --version)"
+        printf '%s\n' "$version"
+        if ! printf '%s\n' "$version" | grep -Eq '^zccache [0-9]'; then
+          echo "::error::Built zccache binary did not report a valid version: ${version:-<empty>}" >&2
+          exit 1
+        fi
 
     - name: Build Python extension artifacts
       if: inputs.include_python == 'true'
@@ -196,7 +229,7 @@ runs:
       env:
         PYO3_PYTHON: python
       run: |
-        HOST_TARGET=$(soldr rustc -vV | awk '/^host: / { print $2 }')
+        HOST_TARGET=$(rustup run "$RELEASE_RUST_TOOLCHAIN" rustc -vV | awk '/^host: / { print $2 }')
         if [ "$HOST_TARGET" != "${{ inputs.target }}" ]; then
           export PYO3_CROSS=1
           export PYO3_CROSS_PYTHON_VERSION="${{ inputs.python_version }}"
@@ -209,9 +242,14 @@ runs:
         # carry the `python` feature, so `-p zccache --features python` is a
         # workflow-only build-target bug that latently broke the release path.
         # Surfaced when 1.9.1 became the first version bump after that split.
-        soldr cargo build --release --target ${{ inputs.target }} -p zccache-cli --features python --lib
-        soldr cargo build --release --target ${{ inputs.target }} -p zccache-watcher --features python --lib
-        soldr cargo build --release --target ${{ inputs.target }} -p zccache-fingerprint --features python --lib
+        if [ "${{ inputs.use_soldr }}" = "true" ]; then
+          cargo_build=(soldr --no-cache cargo build)
+        else
+          cargo_build=(rustup run "$RELEASE_RUST_TOOLCHAIN" cargo build)
+        fi
+        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache-cli --features python --lib
+        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache-watcher --features python --lib
+        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache-fingerprint --features python --lib
 
     - name: Stage artifacts
       shell: bash
@@ -450,7 +488,7 @@ runs:
         }
         trap cleanup EXIT
 
-        rustc_bin="$(rustup which rustc)"
+        rustc_bin="$(rustup which --toolchain "$RELEASE_RUST_TOOLCHAIN" rustc)"
         probe="$(staging/zccache${{ inputs.binary_ext }} "$rustc_bin" -vV)"
         printf '%s\n' "$probe"
         if ! printf '%s\n' "$probe" | grep -q '^host: '; then

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -309,6 +309,7 @@ jobs:
           target: ${{ matrix.target }}
           binary_ext: ${{ matrix.binary_ext }}
           cache_key: release-${{ matrix.target }}
+          use_soldr: "false"
           prebuild_deps: ${{ matrix.prebuild_deps || 'soldr-cook' }}
           clear_target_after_setup: ${{ matrix.clear_target_after_setup || 'false' }}
           require_debug_sidecars: ${{ matrix.require_debug_sidecars || 'true' }}

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -171,10 +171,47 @@ def test_build_target_stamps_release_binaries_with_python_footer() -> None:
     assert 'soldr cargo build --release --target "$HOST_TARGET"' not in action
 
 
+def test_build_target_compiles_release_artifacts_without_compile_cache() -> None:
+    action = _repo_text(".github/actions/build-target/action.yml")
+
+    assert "cargo_build=(soldr --no-cache cargo build)" in action
+    assert 'cargo_build=(rustup run "$RELEASE_RUST_TOOLCHAIN" cargo build)' in action
+    assert "Release artifacts are distribution outputs" in action
+    assert '"${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache --bin zccache' in action
+    assert '"${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache-cli --features python --lib' in action
+
+
+def test_release_workflow_disables_soldr_for_artifact_builds() -> None:
+    release_workflow = _repo_text(".github/workflows/release-auto.yml")
+    action = _repo_text(".github/actions/build-target/action.yml")
+
+    assert 'use_soldr: "false"' in release_workflow
+    assert "if: inputs.use_soldr == 'true'" in action
+    assert "Use setup-soldr for setup and caching" in action
+
+
+def test_build_target_forces_msvc_host_toolchain_for_windows() -> None:
+    action = _repo_text(".github/actions/build-target/action.yml")
+
+    assert "1.94.1-x86_64-pc-windows-msvc" in action
+    assert 'rustup run "$RELEASE_RUST_TOOLCHAIN" rustc -vV' in action
+    assert "Windows release builds must use the MSVC host toolchain" in action
+    assert 'rustup which --toolchain "$RELEASE_RUST_TOOLCHAIN" rustc' in action
+
+
+def test_build_target_smoke_requires_valid_version_output() -> None:
+    action = _repo_text(".github/actions/build-target/action.yml")
+
+    assert 'version="$("$BIN" --version)"' in action
+    assert "Built zccache binary did not report a valid version" in action
+    assert "grep -Eq '^zccache [0-9]'" in action
+
+
 def test_build_target_exposes_cross_cache_controls() -> None:
     action = _repo_text(".github/actions/build-target/action.yml")
 
     assert "prebuild_deps:" in action
+    assert "use_soldr:" in action
     assert "clear_target_after_setup:" in action
     assert "require_debug_sidecars:" in action
     assert "prebuild-deps: ${{ inputs.prebuild_deps }}" in action


### PR DESCRIPTION
## Summary

- disable setup-soldr entirely for `release-auto` artifact builds (`use_soldr: false`), removing the post-action cache upload path
- build shipped release binaries and Python native extension artifacts with direct `rustup run <toolchain> cargo build`
- force Windows release builds onto the MSVC host toolchain (`1.94.1-x86_64-pc-windows-msvc`) and fail if `rustc -vV` reports anything else
- keep the built/staged binary validation gates, including rejection of empty `--version` output

## Context

Refs #434 and follows #435. The 1.11.6 dispatch run after #435 cleared restored target artifacts, but `Build (x86_64-unknown-linux-gnu)` still produced a `zccache` binary with empty `--version`. The job log showed setup-soldr compile-cache hits and then setup-soldr spent time uploading caches in the post step. Release artifacts are distribution outputs; this PR removes soldr from the release artifact build path entirely.

## Test Plan

- [x] `python -m pytest ci/tests/test_package_release.py ci/tests/test_release_workflow.py -q`
- [x] YAML parse for `.github/actions/build-target/action.yml`, `.github/workflows/release-auto.yml`, `.github/workflows/build.yml`
- [x] `git diff --check`