### PR TITLE
chore(ci): set setup-soldr linker explicitly

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -133,6 +133,7 @@ runs:
         toolchain: 1.94.1
         cache: true
         cache-key-suffix: build-${{ inputs.cache_key }}
+        linker: fast
         prebuild-deps: ${{ inputs.prebuild_deps }}
         prebuild-deps-flags: "--release --target ${{ inputs.target }}"
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,7 @@ GitHub Actions workflow definitions.
 - **benchmark-stats.yml** - Manual/scheduled zccache vs bare compiler vs sccache benchmark publisher for the README images and rendered stats page.
 - **perf-guard.yml** - Main-only Rust, C, and C++ perf-regression guard that runs language jobs in parallel, fails below the zccache vs bare compiler or pinned-sccache speed floors, and uploads Markdown/JSON run artifacts.
 
-Normal build/test workflows use `zackees/setup-soldr` for Rust build acceleration, excluding `release-auto.yml`. These setup-soldr steps enable strict zccache seeding so missing managed zccache releases fail immediately instead of falling back to `cargo install`. Jobs that run zccache self-tests stop the setup-soldr builder daemon before the test phase, run tests with a fresh `SOLDR_CACHE_DIR`, and request `SOLDR_CACHE_LIFECYCLE=command` for the isolated test cache when supported by soldr.
+Normal build/test workflows use `zackees/setup-soldr` for Rust build acceleration, excluding `release-auto.yml`. These setup-soldr steps enable strict zccache seeding so missing managed zccache releases fail immediately instead of falling back to `cargo install`, and they set `linker: fast` explicitly to keep the intended fast-linker behavior without warning noise. Jobs that run zccache self-tests stop the setup-soldr builder daemon before the test phase, run tests with a fresh `SOLDR_CACHE_DIR`, and request `SOLDR_CACHE_LIFECYCLE=command` for the isolated test cache when supported by soldr.
 
 Exceptions:
 

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -29,6 +29,7 @@ jobs:
           cache: false
           build-cache: false
           target-cache: false
+          linker: fast
 
       - uses: mozilla-actions/sccache-action@v0.0.10
 

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -23,6 +23,7 @@ jobs:
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: check-${{ inputs.os }}
+          linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
       - name: Check
@@ -46,6 +47,7 @@ jobs:
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: test-${{ inputs.os }}
+          linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
       # Platform Test runs unit tests in libraries and binaries only — it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           cache: true
           build-cache: false
           target-cache: false
+          linker: fast
           prebuild-deps: none
       - name: Install Rust components
         run: soldr rustup component add rustfmt
@@ -64,6 +65,7 @@ jobs:
           cache: true
           cargo-registry-cache: false
           cache-key-suffix: dylint
+          linker: fast
       - name: Install Dylint nightly toolchain
         run: soldr rustup toolchain install nightly-2026-03-26 --component llvm-tools-preview --component rust-src --component rustc-dev --profile minimal
       - name: Install stable Rust components
@@ -102,6 +104,7 @@ jobs:
           cache: true
           toolchain: 1.94.1
           cache-key-suffix: msrv
+          linker: fast
       - name: Check MSRV
         run: soldr cargo check --workspace
 
@@ -118,5 +121,6 @@ jobs:
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: docs
+          linker: fast
       - name: Build docs
         run: soldr cargo doc --workspace --no-deps

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -31,6 +31,7 @@ jobs:
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: clippy
+          linker: fast
       - name: Install Clippy
         run: soldr rustup component add clippy
       - name: Run Clippy

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,6 +30,7 @@ jobs:
           toolchain: 1.94.1
           cache: true
           cache-key-suffix: coverage
+          linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
       - name: Install Rust coverage component

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,6 +54,7 @@ jobs:
           zccache-seed-strict: true
           toolchain: 1.94.1
           cache: true
+          linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
       - name: Build integration test binaries

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -36,6 +36,7 @@ jobs:
           cache: false
           build-cache: false
           target-cache: false
+          linker: fast
 
       - name: Build perf benchmark binary
         shell: bash
@@ -94,6 +95,7 @@ jobs:
           cache: false
           build-cache: false
           target-cache: false
+          linker: fast
 
       - uses: mozilla-actions/sccache-action@v0.0.10
         with:

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -64,6 +64,7 @@ jobs:
           zccache-seed-strict: true
           cache: true
           cache-key-suffix: wrapper-e2e-${{ matrix.os }}
+          linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: "--release"
 
@@ -74,6 +75,7 @@ jobs:
           zccache-seed-strict: true
           cache: true
           cache-key-suffix: wrapper-e2e-${{ matrix.os }}
+          linker: fast
 
       - name: restore source tree after dependency cook
         shell: bash


### PR DESCRIPTION
## Summary
- set \\linker: fast\\ on every zccache \\zackees/setup-soldr\\ invocation to preserve current fast-link behavior without default-linker warning noise
- document the explicit linker policy in the workflow README

Closes #438
Part of zackees/setup-soldr#224

## Test plan
- \\git diff --check\\
- verified all \\zackees/setup-soldr@...\\ invocations under \\.github\\ have an explicit \\linker:\\ input