### PR TITLE
chore(ci): update setup-soldr to v0.9.13

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
-      uses: zackees/setup-soldr@v0.9.12
+      uses: zackees/setup-soldr@v0.9.13
       with:
         toolchain: 1.94.1
         cache: true

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.12
+      - uses: zackees/setup-soldr@v0.9.13
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.12
+      - uses: zackees/setup-soldr@v0.9.13
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.12
+      - uses: zackees/setup-soldr@v0.9.13
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --lib --bins --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.12
+        uses: zackees/setup-soldr/cleanup@v0.9.13
       - name: Test
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.12
+      - uses: zackees/setup-soldr@v0.9.13
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -58,7 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.12
+      - id: setup-soldr
+        uses: zackees/setup-soldr@v0.9.13
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -66,15 +67,22 @@ jobs:
           cargo-registry-cache: false
           cache-key-suffix: dylint
           linker: fast
+          dylint-cache: true
+          dylint-toolchain: nightly-2026-03-26
+          dylint-driver-rev: 4bd91ce7729b74c7ee5664bbb588f7baf30b4a09
+          cargo-dylint-version: 5.0.0
+          dylint-link-version: 5.0.0
       - name: Install Dylint nightly toolchain
         run: soldr rustup toolchain install nightly-2026-03-26 --component llvm-tools-preview --component rust-src --component rustc-dev --profile minimal
       - name: Install stable Rust components
         run: soldr rustup component add rustfmt
       - name: Install Dylint
+        if: steps.setup-soldr.outputs.dylint-cache-hit != 'true'
         run: |
           soldr cargo install cargo-dylint --version 5.0.0 --locked
           soldr cargo install dylint-link --version 5.0.0 --locked
       - name: Build compatible Dylint driver
+        if: steps.setup-soldr.outputs.dylint-cache-hit != 'true'
         run: python3 ci/build_dylint_driver.py
       - name: Check Dylint Library Formatting (ban_std_pathbuf)
         run: soldr cargo fmt --manifest-path dylints/ban_std_pathbuf/Cargo.toml --all -- --check
@@ -98,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.12
+      - uses: zackees/setup-soldr@v0.9.13
         with:
           zccache-seed-strict: true
           cache: true
@@ -115,7 +123,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.12
+      - uses: zackees/setup-soldr@v0.9.13
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.12
+      - uses: zackees/setup-soldr@v0.9.13
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.12
+      - uses: zackees/setup-soldr@v0.9.13
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -38,7 +38,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Stop setup-soldr builder cache before coverage tests
-        uses: zackees/setup-soldr/cleanup@v0.9.12
+        uses: zackees/setup-soldr/cleanup@v0.9.13
       - name: Generate coverage
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.12
+      - uses: zackees/setup-soldr@v0.9.13
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -61,7 +61,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.12
+        uses: zackees/setup-soldr/cleanup@v0.9.13
       - name: Test (full workspace)
         shell: bash
         env:

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.12
+      - uses: zackees/setup-soldr@v0.9.13
         with:
           zccache-seed-strict: true
           cache: false
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.12
+      - uses: zackees/setup-soldr@v0.9.13
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -55,11 +55,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@v0.9.12
+        uses: zackees/setup-soldr@v0.9.13
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@v0.9.12
+        uses: zackees/setup-soldr@v0.9.13
         with:
           zccache-seed-strict: true
           cache: true
@@ -210,7 +210,7 @@ jobs:
           Add-Content $env:GITHUB_PATH $installDir
 
       - name: Stop setup-soldr builder cache before wrapper smoke test
-        uses: zackees/setup-soldr/cleanup@v0.9.12
+        uses: zackees/setup-soldr/cleanup@v0.9.13
 
       - name: smoke compile through wrapper (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary
- pin all zccache setup-soldr and cleanup action uses to `v0.9.13`
- enable setup-soldr's opt-in Dylint tool/driver cache in the Dylint job and skip reinstall/rebuild steps on exact cache hits
- update the remaining workflow checkout from `actions/checkout@v4` to `v6` so Node 20 action warnings do not come from wrapper E2E

Part of zackees/setup-soldr#224.

## Verification
- [x] `python -m pytest ci/tests/test_package_release.py` (21 passed)
- [x] workflow/action YAML parsed with PyYAML
- [x] `git diff --check`
- [x] no live `.github` references remain for `setup-soldr@v0.9.12`, `setup-soldr/cleanup@v0.9.12`, `actions/checkout@v4`, or Node 20 setup-soldr metadata
