### PR TITLE
perf(ci): match soldr cook profile to debug jobs (verify setup-soldr#235/#236)

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -27,8 +27,6 @@ jobs:
         with:
           zccache-seed-strict: true
           cache: false
-          build-cache: false
-          target-cache: false
           linker: fast
 
       - uses: mozilla-actions/sccache-action@v0.0.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
           toolchain: 1.94.1
           cache: true
           build-cache: false
-          target-cache: false
           linker: fast
           prebuild-deps: none
       - name: Install Rust components
@@ -67,6 +66,7 @@ jobs:
           cargo-registry-cache: false
           cache-key-suffix: dylint
           linker: fast
+          prebuild-deps: soldr-cook
           dylint-cache: true
           dylint-toolchain: nightly-2026-03-26
           dylint-driver-rev: 4bd91ce7729b74c7ee5664bbb588f7baf30b4a09
@@ -113,6 +113,8 @@ jobs:
           toolchain: 1.94.1
           cache-key-suffix: msrv
           linker: fast
+          prebuild-deps: soldr-cook
+          prebuild-deps-flags: ""
       - name: Check MSRV
         run: soldr cargo check --workspace
 
@@ -130,5 +132,7 @@ jobs:
           cache: true
           cache-key-suffix: docs
           linker: fast
+          prebuild-deps: soldr-cook
+          prebuild-deps-flags: ""
       - name: Build docs
         run: soldr cargo doc --workspace --no-deps

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -32,6 +32,8 @@ jobs:
           cache: true
           cache-key-suffix: clippy
           linker: fast
+          prebuild-deps: soldr-cook
+          prebuild-deps-flags: ""
       - name: Install Clippy
         run: soldr rustup component add clippy
       - name: Run Clippy

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -34,8 +34,6 @@ jobs:
         with:
           zccache-seed-strict: true
           cache: false
-          build-cache: false
-          target-cache: false
           linker: fast
 
       - name: Build perf benchmark binary
@@ -93,8 +91,6 @@ jobs:
         with:
           zccache-seed-strict: true
           cache: false
-          build-cache: false
-          target-cache: false
           linker: fast
 
       - uses: mozilla-actions/sccache-action@v0.0.10


### PR DESCRIPTION
## Summary

Applies setup-soldr#235 / #236 to zccache CI: match `soldr cook`'s profile to what each job actually compiles.

- `clippy`, `msrv`, `docs` now set `prebuild-deps-flags: ""` (debug cook) instead of inheriting setup-soldr's `--release` default. These jobs compile in the dev (debug) profile, so release-cooked deps were never reused and bloated the build cache — the same `""` pattern `ci-check`/`integration`/`coverage` already use.
- `dylint` keeps the release-default cook (its heavy stable-toolchain compiles are `cargo install`; its dominant workspace lint runs under a nightly driver that cook can't warm regardless of profile).
- Drops the deprecated `target-cache` input and the redundant `build-cache: false` under the `cache: false` umbrella in `fmt` / `perf-guard` / `benchmark-stats`.

## Why this PR also exists: measurement

Local Docker A/B (ubuntu-24.04, isolated from the host daemon) showed the cook-profile effect is **more nuanced** than #235 assumed: cook's within-run benefit was largely *profile-independent* (downloads + build-script compiles), `cook → job` produced **0 zccache hits**, and for a single cold run `NONE` was fastest. Those local runs can't replicate CI's cross-run, setup-soldr-restored build-cache — so this PR runs the actual workflows to get the definitive warm timings and confirm or revise the per-workflow goals.

## Test plan

- [ ] CI green: `fmt`, `msrv`, `docs`, check/test matrix (linux/macos/windows), `integration`
- [ ] Record `msrv` / `docs` / check warm timings; compare against `main` (release-cook baseline)
- [ ] Confirm no setup-soldr deprecated-input warnings in `fmt` / `perf-guard` / `benchmark-stats` logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
