### PR TITLE
[DO NOT MERGE] e2e: verify setup-soldr#237 coarse build-cache key raises warm hit rate

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
-      uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
+      uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
       with:
         toolchain: 1.94.1
         cache: true

--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
-      uses: zackees/setup-soldr@a409991
+      uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
       with:
         toolchain: 1.94.1
         cache: true

--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
-      uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
+      uses: zackees/setup-soldr@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
       with:
         toolchain: 1.94.1
         cache: true

--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
-      uses: zackees/setup-soldr@v0.9.13
+      uses: zackees/setup-soldr@a409991
       with:
         toolchain: 1.94.1
         cache: true

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@a409991
+      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@a409991
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
+      - uses: zackees/setup-soldr@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
+      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
+      - uses: zackees/setup-soldr@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
+      - uses: zackees/setup-soldr@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --lib --bins --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@55d85af93815ee549bcf420d613f1f4f2f90433f
+        uses: zackees/setup-soldr/cleanup@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
       - name: Test
         shell: bash
         env:

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@a409991
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@a409991
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --lib --bins --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.13
+        uses: zackees/setup-soldr/cleanup@a409991
       - name: Test
         shell: bash
         env:

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
+      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
+      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --lib --bins --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@a4099910639a3ccdee38aa3f3af348ba054eac61
+        uses: zackees/setup-soldr/cleanup@55d85af93815ee549bcf420d613f1f4f2f90433f
       - name: Test
         shell: bash
         env:

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a409991
+      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a409991
+      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --lib --bins --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@a409991
+        uses: zackees/setup-soldr/cleanup@a4099910639a3ccdee38aa3f3af348ba054eac61
       - name: Test
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
+      - uses: zackees/setup-soldr@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: setup-soldr
-        uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
+        uses: zackees/setup-soldr@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
+      - uses: zackees/setup-soldr@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
         with:
           zccache-seed-strict: true
           cache: true
@@ -123,7 +123,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
+      - uses: zackees/setup-soldr@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a409991
+      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: setup-soldr
-        uses: zackees/setup-soldr@a409991
+        uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a409991
+      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
         with:
           zccache-seed-strict: true
           cache: true
@@ -123,7 +123,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a409991
+      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@a409991
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.13
+        uses: zackees/setup-soldr@a409991
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@a409991
         with:
           zccache-seed-strict: true
           cache: true
@@ -123,7 +123,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@a409991
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
+      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: setup-soldr
-        uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
+        uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
+      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
         with:
           zccache-seed-strict: true
           cache: true
@@ -123,7 +123,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
+      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a409991
+      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
+      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@a409991
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
+      - uses: zackees/setup-soldr@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
+      - uses: zackees/setup-soldr@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -38,7 +38,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Stop setup-soldr builder cache before coverage tests
-        uses: zackees/setup-soldr/cleanup@55d85af93815ee549bcf420d613f1f4f2f90433f
+        uses: zackees/setup-soldr/cleanup@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
       - name: Generate coverage
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@a409991
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -38,7 +38,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Stop setup-soldr builder cache before coverage tests
-        uses: zackees/setup-soldr/cleanup@v0.9.13
+        uses: zackees/setup-soldr/cleanup@a409991
       - name: Generate coverage
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a409991
+      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -38,7 +38,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Stop setup-soldr builder cache before coverage tests
-        uses: zackees/setup-soldr/cleanup@a409991
+        uses: zackees/setup-soldr/cleanup@a4099910639a3ccdee38aa3f3af348ba054eac61
       - name: Generate coverage
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
+      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -38,7 +38,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Stop setup-soldr builder cache before coverage tests
-        uses: zackees/setup-soldr/cleanup@a4099910639a3ccdee38aa3f3af348ba054eac61
+        uses: zackees/setup-soldr/cleanup@55d85af93815ee549bcf420d613f1f4f2f90433f
       - name: Generate coverage
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
+      - uses: zackees/setup-soldr@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -61,7 +61,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@55d85af93815ee549bcf420d613f1f4f2f90433f
+        uses: zackees/setup-soldr/cleanup@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
       - name: Test (full workspace)
         shell: bash
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@a409991
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -61,7 +61,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.13
+        uses: zackees/setup-soldr/cleanup@a409991
       - name: Test (full workspace)
         shell: bash
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
+      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -61,7 +61,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@a4099910639a3ccdee38aa3f3af348ba054eac61
+        uses: zackees/setup-soldr/cleanup@55d85af93815ee549bcf420d613f1f4f2f90433f
       - name: Test (full workspace)
         shell: bash
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@a409991
+      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -61,7 +61,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@a409991
+        uses: zackees/setup-soldr/cleanup@a4099910639a3ccdee38aa3f3af348ba054eac61
       - name: Test (full workspace)
         shell: bash
         env:

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
+      - uses: zackees/setup-soldr@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
         with:
           zccache-seed-strict: true
           cache: false
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
+      - uses: zackees/setup-soldr@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@a409991
+      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
         with:
           zccache-seed-strict: true
           cache: false
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@a409991
+      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
+      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
         with:
           zccache-seed-strict: true
           cache: false
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
+      - uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@a409991
         with:
           zccache-seed-strict: true
           cache: false
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@a409991
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@a409991
+        uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@a409991
+        uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
         with:
           zccache-seed-strict: true
           cache: true
@@ -210,7 +210,7 @@ jobs:
           Add-Content $env:GITHUB_PATH $installDir
 
       - name: Stop setup-soldr builder cache before wrapper smoke test
-        uses: zackees/setup-soldr/cleanup@a409991
+        uses: zackees/setup-soldr/cleanup@a4099910639a3ccdee38aa3f3af348ba054eac61
 
       - name: smoke compile through wrapper (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@v0.9.13
+        uses: zackees/setup-soldr@a409991
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@v0.9.13
+        uses: zackees/setup-soldr@a409991
         with:
           zccache-seed-strict: true
           cache: true
@@ -210,7 +210,7 @@ jobs:
           Add-Content $env:GITHUB_PATH $installDir
 
       - name: Stop setup-soldr builder cache before wrapper smoke test
-        uses: zackees/setup-soldr/cleanup@v0.9.13
+        uses: zackees/setup-soldr/cleanup@a409991
 
       - name: smoke compile through wrapper (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
+        uses: zackees/setup-soldr@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
+        uses: zackees/setup-soldr@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
         with:
           zccache-seed-strict: true
           cache: true
@@ -210,7 +210,7 @@ jobs:
           Add-Content $env:GITHUB_PATH $installDir
 
       - name: Stop setup-soldr builder cache before wrapper smoke test
-        uses: zackees/setup-soldr/cleanup@55d85af93815ee549bcf420d613f1f4f2f90433f
+        uses: zackees/setup-soldr/cleanup@9b1b9ce70106b793fe8000a2a31a0dfd3f22488a
 
       - name: smoke compile through wrapper (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
+        uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@a4099910639a3ccdee38aa3f3af348ba054eac61
+        uses: zackees/setup-soldr@55d85af93815ee549bcf420d613f1f4f2f90433f
         with:
           zccache-seed-strict: true
           cache: true
@@ -210,7 +210,7 @@ jobs:
           Add-Content $env:GITHUB_PATH $installDir
 
       - name: Stop setup-soldr builder cache before wrapper smoke test
-        uses: zackees/setup-soldr/cleanup@a4099910639a3ccdee38aa3f3af348ba054eac61
+        uses: zackees/setup-soldr/cleanup@55d85af93815ee549bcf420d613f1f4f2f90433f
 
       - name: smoke compile through wrapper (Unix)
         if: runner.os != 'Windows'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3889,3 +3889,4 @@ dependencies = [
  "log",
  "simd-adler32",
 ]
+


### PR DESCRIPTION
Throwaway verification PR. Pins setup-soldr to the #237 fix commit `a409991` to confirm the coarse build-cache key (no commit-SHA, no per-job suffix) raises the warm zccache build-cache hit rate from ~0%. Will be closed after measuring. See zackees/setup-soldr#237 / #243.