### PR TITLE
fix(perf-bench): link benchmarks timed only the IPC send → 0.000s cold/warm (#443)

### DIFF
--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -315,7 +315,12 @@ def _duration_seconds(value: str) -> float | None:
     number = float(match.group(1))
     unit = match.group(2)
     if number == 0.0:
-        return 0.000001 if unit == "ms" else 0.001
+        # #443: a reading that rounds to 0 is not a real measurement — a cold
+        # (or even warm cache-hit) compile/link is never instant; only a broken
+        # measurement (e.g. timing the IPC send instead of the daemon
+        # round-trip) reads 0.000s. Return None instead of silently inflating
+        # it to a tiny value, so it can't feed an absurd speedup ratio.
+        return None
     if unit == "ms":
         return round(number / 1000.0, 6)
     return round(number, 6)

--- a/ci/tests/test_benchmark_stats.py
+++ b/ci/tests/test_benchmark_stats.py
@@ -204,7 +204,11 @@ def test_benchmark_command_targets_existing_workspace_package():
     ]
 
 
-def test_parse_benchmark_log_clamps_zero_duration_cells_for_ratios():
+def test_zero_duration_cells_are_invalid_not_inflated():
+    # #443: a 0.000s reading is a broken measurement — a cold (or even a warm
+    # cache-hit) compile/link is never instant. It must be treated as invalid
+    # (None), not silently inflated into a tiny value that yields an absurd
+    # speedup ratio like the bogus "1797x faster" below.
     log = """
 ## C Static-Library Link Benchmark: 50 .o inputs, 5 warm trials
 
@@ -215,10 +219,11 @@ def test_parse_benchmark_log_clamps_zero_duration_cells_for_ratios():
 
     row = benchmark_stats.parse_benchmark_log(log)[0]
 
-    assert row["zccache_seconds"] == 0.001
-    assert row["zccache_vs_bare_ratio"] == 57.0
-    assert row["zccache_vs_sccache_ratio"] == 57.0
-    assert benchmark_stats._duration_seconds("0.0ms") == 0.000001
+    assert row["zccache_seconds"] is None
+    assert row["zccache_vs_bare_ratio"] is None
+    assert row["zccache_vs_sccache_ratio"] is None
+    assert benchmark_stats._duration_seconds("0.0ms") is None
+    assert benchmark_stats._duration_seconds("0.000s") is None
 
 
 def test_group_results_by_language_returns_expected_buckets():

--- a/crates/zccache/tests/perf_bench/link.rs
+++ b/crates/zccache/tests/perf_bench/link.rs
@@ -35,8 +35,13 @@ pub async fn run_zccache_link_timed(
         })
         .await
         .unwrap();
+    // #443: capture elapsed AFTER recv() — the daemon performs the actual
+    // link/compile during recv(), so stopping the clock before it timed only
+    // the IPC send (~0.000s) and made every link benchmark report a bogus
+    // 0.000s cold/warm with absurd speedup ratios.
+    let response = client.recv().await.unwrap();
     let elapsed = start.elapsed();
-    match client.recv().await.unwrap() {
+    match response {
         Some(Response::LinkResult {
             exit_code,
             stderr,
@@ -436,8 +441,13 @@ pub async fn run_zccache_rust_final_link_timed(
         })
         .await
         .unwrap();
+    // #443: capture elapsed AFTER recv() — the daemon performs the actual
+    // link/compile during recv(), so stopping the clock before it timed only
+    // the IPC send (~0.000s) and made every link benchmark report a bogus
+    // 0.000s cold/warm with absurd speedup ratios.
+    let response = client.recv().await.unwrap();
     let elapsed = start.elapsed();
-    match client.recv().await.unwrap() {
+    match response {
         Some(Response::CompileResult {
             exit_code,
             stderr,


### PR DESCRIPTION
## Summary

Fixes #443. The two zccache **link** timers stopped the clock right after the IPC `send()`, **before** `recv()` — but the daemon performs the actual link/compile during `recv()`. So they timed only request serialization (~0.000s), making every link benchmark publish a bogus `0.000s` cold *and* warm with absurd "12936x faster" ratios on the public stats page.

- `crates/zccache/tests/perf_bench/link.rs` — move `let elapsed = start.elapsed();` to **after** `client.recv().await` in `run_zccache_link_timed` and `run_zccache_rust_final_link_timed` (covers C archive, C++ driver-link, emcc HTML/Wasm link, Rust workspace staticlib link).
- `ci/benchmark_stats.py` — `_duration_seconds` no longer inflates a `0.000s` cell into a tiny sentinel that feeds a ratio; a reading that rounds to 0 is a broken measurement (a cold/warm-hit compile is never instant) → returns `None`, so invalid readings can't publish a speedup.
- Rewrote the regression test that previously locked in the buggy clamp.

## Verification (isolated Docker, no host daemon)

`perf_c_archive_link` on this branch:

| | bare ar | zccache | vs bare |
|---|---|---|---|
| **Cold** | 0.066s | **0.061s** | 1.1x faster |
| **Warm** | 0.042s | **0.001s** | 33x faster |

zccache cold link is now ≈ the bare cold link (was `0.000s` / "872x faster"); warm is a plausible 33x (was `0.000s` / "1846x faster").

## Test plan
- [x] `pytest ci/tests/test_benchmark_stats.py` — 10 pass (incl. new 0.000s-is-invalid guard)
- [x] `cargo test -p zccache --test perf_bench_test -- perf_c_archive_link --ignored` in Docker — cold/warm now realistic
- [ ] re-run `benchmark-stats` after merge to regenerate the README/stats with correct link rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
