### PR TITLE
ci: adopt setup-soldr v0.9.16 (soldr 0.7.44 cook fix + verify-compile-cache + isolated cache seed)

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@v0.9.14
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.14
+      - uses: zackees/setup-soldr@v0.9.16
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.14
+      - uses: zackees/setup-soldr@v0.9.16
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.14
+      - uses: zackees/setup-soldr@v0.9.16
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --lib --bins --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.14
+        uses: zackees/setup-soldr/cleanup@v0.9.16
       - name: Test
         shell: bash
         env:

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@v0.9.14
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -26,6 +26,7 @@ jobs:
           linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
+          verify-compile-cache: warn
       - name: Check
         shell: bash
         run: |
@@ -41,7 +42,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@v0.9.14
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -50,6 +51,11 @@ jobs:
           linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
+          # #240: seed the isolated test SOLDR_CACHE_DIR (per-OS) from the
+          # restored build-cache so the daemon-isolated test phase starts warm
+          # across Linux/macOS/Windows.
+          seed-isolated-build-cache: ${{ runner.temp }}/zccache-self-tests/test-${{ inputs.os }}
+          verify-compile-cache: warn
       # Platform Test runs unit tests in libraries and binaries only — it
       # intentionally does NOT compile the integration test binaries under
       # `crates/*/tests/`. Most of those binaries' tests are #[ignore]'d, but
@@ -60,7 +66,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --lib --bins --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.13
+        uses: zackees/setup-soldr/cleanup@v0.9.14
       - name: Test
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,14 +111,11 @@ jobs:
           zccache-seed-strict: true
           cache: true
           toolchain: 1.94.1
-          # fresh suffix forces a clean cold->warm to verify the soldr 0.7.44
-          # cook fix lands first-party first-warm hits (zccache#448). Revert.
-          cache-key-suffix: msrv-v44
+          cache-key-suffix: msrv
           linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
           verify-compile-cache: warn
-          logging: true
       - name: Check MSRV
         run: soldr cargo check --workspace
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,9 @@ jobs:
           zccache-seed-strict: true
           cache: true
           toolchain: 1.94.1
-          cache-key-suffix: msrv
+          # diag suffix forces a fresh cold seed so the cold->first-warm
+          # convergence gap can be captured (setup-soldr#236). Revert to "msrv".
+          cache-key-suffix: msrv-diag
           linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
@@ -122,6 +124,16 @@ jobs:
           compile-cache-stats: detailed
       - name: Check MSRV
         run: soldr cargo check --workspace
+      - name: Upload zccache journal (diag)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zccache-journal-msrv
+          path: |
+            ${{ env.ZCCACHE_CACHE_DIR }}/private/*/logs/
+            ${{ env.ZCCACHE_CACHE_DIR }}/logs/
+          if-no-files-found: warn
+          include-hidden-files: true
 
   docs:
     name: Documentation
@@ -135,7 +147,8 @@ jobs:
           zccache-seed-strict: true
           toolchain: 1.94.1
           cache: true
-          cache-key-suffix: docs
+          # diag suffix forces a fresh cold seed (setup-soldr#236). Revert to "docs".
+          cache-key-suffix: docs-diag
           linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
@@ -146,3 +159,13 @@ jobs:
           compile-cache-stats: detailed
       - name: Build docs
         run: soldr cargo doc --workspace --no-deps
+      - name: Upload zccache journal (diag)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zccache-journal-docs
+          path: |
+            ${{ env.ZCCACHE_CACHE_DIR }}/private/*/logs/
+            ${{ env.ZCCACHE_CACHE_DIR }}/logs/
+          if-no-files-found: warn
+          include-hidden-files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.14
+      - uses: zackees/setup-soldr@v0.9.16
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.14
+        uses: zackees/setup-soldr@v0.9.16
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -106,16 +106,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.14
+      - uses: zackees/setup-soldr@v0.9.16
         with:
           zccache-seed-strict: true
           cache: true
           toolchain: 1.94.1
-          cache-key-suffix: msrv
+          # fresh suffix forces a clean cold->warm to verify the soldr 0.7.44
+          # cook fix lands first-party first-warm hits (zccache#448). Revert.
+          cache-key-suffix: msrv-v44
           linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
           verify-compile-cache: warn
+          logging: true
       - name: Check MSRV
         run: soldr cargo check --workspace
 
@@ -126,7 +129,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.14
+      - uses: zackees/setup-soldr@v0.9.16
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@v0.9.14
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.13
+        uses: zackees/setup-soldr@v0.9.14
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@v0.9.14
         with:
           zccache-seed-strict: true
           cache: true
@@ -115,6 +115,7 @@ jobs:
           linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
+          verify-compile-cache: warn
       - name: Check MSRV
         run: soldr cargo check --workspace
 
@@ -125,7 +126,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@v0.9.14
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -134,5 +135,6 @@ jobs:
           linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
+          verify-compile-cache: warn
       - name: Build docs
         run: soldr cargo doc --workspace --no-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,10 @@ jobs:
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
           verify-compile-cache: warn
+          # Diagnostics: enumerate which compile units miss on warm runs
+          # (setup-soldr#236 warm-path follow-up). Not part of any cache key.
+          logging: true
+          compile-cache-stats: detailed
       - name: Check MSRV
         run: soldr cargo check --workspace
 
@@ -136,5 +140,9 @@ jobs:
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
           verify-compile-cache: warn
+          # Diagnostics: enumerate which compile units miss on warm runs
+          # (setup-soldr#236 warm-path follow-up). Not part of any cache key.
+          logging: true
+          compile-cache-stats: detailed
       - name: Build docs
         run: soldr cargo doc --workspace --no-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,10 +116,6 @@ jobs:
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
           verify-compile-cache: warn
-          # Diagnostics: enumerate which compile units miss on warm runs
-          # (setup-soldr#236 warm-path follow-up). Not part of any cache key.
-          logging: true
-          compile-cache-stats: detailed
       - name: Check MSRV
         run: soldr cargo check --workspace
 
@@ -140,9 +136,5 @@ jobs:
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
           verify-compile-cache: warn
-          # Diagnostics: enumerate which compile units miss on warm runs
-          # (setup-soldr#236 warm-path follow-up). Not part of any cache key.
-          logging: true
-          compile-cache-stats: detailed
       - name: Build docs
         run: soldr cargo doc --workspace --no-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,30 +106,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.15
+      - uses: zackees/setup-soldr@v0.9.14
         with:
           zccache-seed-strict: true
           cache: true
           toolchain: 1.94.1
-          # ctx suffix forces fresh cold so we can capture cold-vs-warm ctx
-          # for the first-party units (zccache#448). Revert to "msrv".
-          cache-key-suffix: msrv-ctx
+          cache-key-suffix: msrv
           linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
           verify-compile-cache: warn
-          logging: true
       - name: Check MSRV
         run: soldr cargo check --workspace
-      - name: Upload zccache session log (diag)
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: zccache-ctx-msrv
-          path: |
-            ${{ env.ZCCACHE_CACHE_DIR }}/private/*/logs/
-          if-no-files-found: warn
-          include-hidden-files: true
 
   docs:
     name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,18 +106,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.14
+      - uses: zackees/setup-soldr@v0.9.15
         with:
           zccache-seed-strict: true
           cache: true
           toolchain: 1.94.1
-          cache-key-suffix: msrv
+          # ctx suffix forces fresh cold so we can capture cold-vs-warm ctx
+          # for the first-party units (zccache#448). Revert to "msrv".
+          cache-key-suffix: msrv-ctx
           linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
           verify-compile-cache: warn
+          logging: true
       - name: Check MSRV
         run: soldr cargo check --workspace
+      - name: Upload zccache session log (diag)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zccache-ctx-msrv
+          path: |
+            ${{ env.ZCCACHE_CACHE_DIR }}/private/*/logs/
+          if-no-files-found: warn
+          include-hidden-files: true
 
   docs:
     name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,7 @@ jobs:
           zccache-seed-strict: true
           cache: true
           toolchain: 1.94.1
-          # diag suffix forces a fresh cold seed so the cold->first-warm
-          # convergence gap can be captured (setup-soldr#236). Revert to "msrv".
-          cache-key-suffix: msrv-diag
+          cache-key-suffix: msrv
           linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
@@ -124,16 +122,6 @@ jobs:
           compile-cache-stats: detailed
       - name: Check MSRV
         run: soldr cargo check --workspace
-      - name: Upload zccache journal (diag)
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: zccache-journal-msrv
-          path: |
-            ${{ env.ZCCACHE_CACHE_DIR }}/private/*/logs/
-            ${{ env.ZCCACHE_CACHE_DIR }}/logs/
-          if-no-files-found: warn
-          include-hidden-files: true
 
   docs:
     name: Documentation
@@ -147,8 +135,7 @@ jobs:
           zccache-seed-strict: true
           toolchain: 1.94.1
           cache: true
-          # diag suffix forces a fresh cold seed (setup-soldr#236). Revert to "docs".
-          cache-key-suffix: docs-diag
+          cache-key-suffix: docs
           linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
@@ -159,13 +146,3 @@ jobs:
           compile-cache-stats: detailed
       - name: Build docs
         run: soldr cargo doc --workspace --no-deps
-      - name: Upload zccache journal (diag)
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: zccache-journal-docs
-          path: |
-            ${{ env.ZCCACHE_CACHE_DIR }}/private/*/logs/
-            ${{ env.ZCCACHE_CACHE_DIR }}/logs/
-          if-no-files-found: warn
-          include-hidden-files: true

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@v0.9.14
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -34,6 +34,7 @@ jobs:
           linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
+          verify-compile-cache: warn
       - name: Install Clippy
         run: soldr rustup component add clippy
       - name: Run Clippy

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.14
+      - uses: zackees/setup-soldr@v0.9.16
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@v0.9.14
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -33,12 +33,16 @@ jobs:
           linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
+          # #240: seed the isolated coverage SOLDR_CACHE_DIR from the restored
+          # build-cache so the daemon-isolated llvm-cov phase starts warm.
+          seed-isolated-build-cache: ${{ runner.temp }}/zccache-self-tests/coverage
+          verify-compile-cache: warn
       - name: Install Rust coverage component
         run: soldr rustup component add llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Stop setup-soldr builder cache before coverage tests
-        uses: zackees/setup-soldr/cleanup@v0.9.13
+        uses: zackees/setup-soldr/cleanup@v0.9.14
       - name: Generate coverage
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.14
+      - uses: zackees/setup-soldr@v0.9.16
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -42,7 +42,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Stop setup-soldr builder cache before coverage tests
-        uses: zackees/setup-soldr/cleanup@v0.9.14
+        uses: zackees/setup-soldr/cleanup@v0.9.16
       - name: Generate coverage
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@v0.9.14
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -57,11 +57,15 @@ jobs:
           linker: fast
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
+          # #240: seed the isolated integration SOLDR_CACHE_DIR from the
+          # restored build-cache so the daemon-isolated test phase starts warm.
+          seed-isolated-build-cache: ${{ runner.temp }}/zccache-self-tests/integration
+          verify-compile-cache: warn
       - name: Build integration test binaries
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.13
+        uses: zackees/setup-soldr/cleanup@v0.9.14
       - name: Test (full workspace)
         shell: bash
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.14
+      - uses: zackees/setup-soldr@v0.9.16
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -65,7 +65,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.14
+        uses: zackees/setup-soldr/cleanup@v0.9.16
       - name: Test (full workspace)
         shell: bash
         env:

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.14
+      - uses: zackees/setup-soldr@v0.9.16
         with:
           zccache-seed-strict: true
           cache: false
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.14
+      - uses: zackees/setup-soldr@v0.9.16
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@v0.9.14
         with:
           zccache-seed-strict: true
           cache: false
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.13
+      - uses: zackees/setup-soldr@v0.9.14
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@v0.9.14
+        uses: zackees/setup-soldr@v0.9.16
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@v0.9.14
+        uses: zackees/setup-soldr@v0.9.16
         with:
           zccache-seed-strict: true
           cache: true
@@ -210,7 +210,7 @@ jobs:
           Add-Content $env:GITHUB_PATH $installDir
 
       - name: Stop setup-soldr builder cache before wrapper smoke test
-        uses: zackees/setup-soldr/cleanup@v0.9.14
+        uses: zackees/setup-soldr/cleanup@v0.9.16
 
       - name: smoke compile through wrapper (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@v0.9.13
+        uses: zackees/setup-soldr@v0.9.14
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@v0.9.13
+        uses: zackees/setup-soldr@v0.9.14
         with:
           zccache-seed-strict: true
           cache: true
@@ -210,7 +210,7 @@ jobs:
           Add-Content $env:GITHUB_PATH $installDir
 
       - name: Stop setup-soldr builder cache before wrapper smoke test
-        uses: zackees/setup-soldr/cleanup@v0.9.13
+        uses: zackees/setup-soldr/cleanup@v0.9.14
 
       - name: smoke compile through wrapper (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
Adopts [setup-soldr v0.9.14](https://github.com/zackees/setup-soldr/releases/tag/v0.9.14) to gather the real-CI evidence the setup-soldr #236 perf meta needs, and to put the two new guards to work.

## Changes
- Bump all `setup-soldr` / `setup-soldr/cleanup` pins `v0.9.13` → `v0.9.14`.
- `verify-compile-cache: warn` on the compile jobs (clippy, msrv, docs, ci-check check/test, coverage, integration) — surfaces any zccache bypass / `hits+misses==0` measurement as a warning (non-fatal) and sets the `compile-cache-verification` output.
- `seed-isolated-build-cache` on the daemon-isolated self-test phases (coverage, integration, ci-check `test` per-OS) — pre-seeds the isolated `SOLDR_CACHE_DIR` from the restored build-cache so those phases start warm instead of cold (setup-soldr#240).

## Why
Provides the evidence for setup-soldr **#226** (footprint), **#231** (cross-platform target/registry timings via the per-OS ci-check matrix), **#235** (clippy/msrv/docs warm timings), **#240** (isolated warm-hit rate), feeding the **#188/#189** build-cache/registry keep-or-gate decisions.

## What to watch in this run
- coverage/integration/test `compile-cache-verification` + warm hit rate (should be nonzero now that the isolated dir is seeded).
- Whether any compile job emits the `verify-compile-cache` 0-hit warning (would pinpoint a remaining bypass).
- Post-step per-phase save timing (compress vs upload), especially on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)