### PR TITLE
chore(release): bump 1.11.6 -> 1.11.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.11.6"
+version = "1.11.7"
 dependencies = [
  "bincode",
  "blake3",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.11.6"
+version = "1.11.7"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.11.6"
+version = "1.11.7"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.11.6"
+version = "1.11.7"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.11.6"
+version = "1.11.7"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Ships #450 (closes #449): stale `.obj` regression for unity-build TUs after a transitive `.cpp.hpp` change.
- `release-auto.yml` detects the `[workspace.package].version` change on push-to-main and triggers PyPI + crates.io publish.

## Test plan
- [x] `soldr cargo check --workspace` — clean, lockfile regenerated to 1.11.7.
- [x] CI on #450 was green across all 26 checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)