### PR TITLE
chore: bump zackees/setup-soldr to v0.9.17

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
-      uses: zackees/setup-soldr@v0.9.13
+      uses: zackees/setup-soldr@v0.9.17
       with:
         toolchain: 1.94.1
         cache: true

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.16
+      - uses: zackees/setup-soldr@v0.9.17
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.16
+      - uses: zackees/setup-soldr@v0.9.17
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.16
+      - uses: zackees/setup-soldr@v0.9.17
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.16
+      - uses: zackees/setup-soldr@v0.9.17
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.16
+        uses: zackees/setup-soldr@v0.9.17
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.16
+      - uses: zackees/setup-soldr@v0.9.17
         with:
           zccache-seed-strict: true
           cache: true
@@ -126,7 +126,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.16
+      - uses: zackees/setup-soldr@v0.9.17
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.16
+      - uses: zackees/setup-soldr@v0.9.17
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.16
+      - uses: zackees/setup-soldr@v0.9.17
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.16
+      - uses: zackees/setup-soldr@v0.9.17
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.16
+      - uses: zackees/setup-soldr@v0.9.17
         with:
           zccache-seed-strict: true
           cache: false
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.16
+      - uses: zackees/setup-soldr@v0.9.17
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@v0.9.16
+        uses: zackees/setup-soldr@v0.9.17
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@v0.9.16
+        uses: zackees/setup-soldr@v0.9.17
         with:
           zccache-seed-strict: true
           cache: true


### PR DESCRIPTION
Bumps all 15 `zackees/setup-soldr@…` pins in this repo to **v0.9.17** (the new release that ships the [`cache-preset` umbrella](https://github.com/zackees/setup-soldr/issues/251) + the `build-cache-mode: thin` resolved default when `target-cache` is opted in). The previous mix was 14 × `@v0.9.16` + 1 × `@v0.9.13` (in `.github/actions/build-target/action.yml`).

This is a strict-superset version bump:
- v0.9.16 → v0.9.17 adds two new opt-in features; the existing per-input config (`build-cache: true`, `prebuild-deps: soldr-cook`, etc.) is unchanged.
- v0.9.13 → v0.9.17 also picks up v0.9.14 (compile-cache verification + delta-aware save gating + isolated seed) and v0.9.15 (private-daemon journal path fix), already used by the rest of the repo's pins.

No workflow `with:` block is changed in this PR — pure pin bump. A separate cleanup could later replace `prebuild-deps: soldr-cook` with `cache-preset: foundation` where it would simplify configs, but holding that as out-of-scope for the version bump.

## Test plan

- [ ] Full CI matrix runs the same as on main with the new setup-soldr revision.
- [ ] Re-run warm — expect `cook-cache-base` HIT + `build-cache` HIT on the warm path (no behavior change from v0.9.16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)