### PR TITLE
chore: bump zackees/setup-soldr to v0.9.19

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
-      uses: zackees/setup-soldr@v0.9.17
+      uses: zackees/setup-soldr@v0.9.19
       with:
         toolchain: 1.94.1
         cache: true

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.17
+      - uses: zackees/setup-soldr@v0.9.19
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.17
+      - uses: zackees/setup-soldr@v0.9.19
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.17
+      - uses: zackees/setup-soldr@v0.9.19
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.17
+      - uses: zackees/setup-soldr@v0.9.19
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.17
+        uses: zackees/setup-soldr@v0.9.19
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.17
+      - uses: zackees/setup-soldr@v0.9.19
         with:
           zccache-seed-strict: true
           cache: true
@@ -126,7 +126,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.17
+      - uses: zackees/setup-soldr@v0.9.19
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.17
+      - uses: zackees/setup-soldr@v0.9.19
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.17
+      - uses: zackees/setup-soldr@v0.9.19
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.17
+      - uses: zackees/setup-soldr@v0.9.19
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.17
+      - uses: zackees/setup-soldr@v0.9.19
         with:
           zccache-seed-strict: true
           cache: false
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.17
+      - uses: zackees/setup-soldr@v0.9.19
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@v0.9.17
+        uses: zackees/setup-soldr@v0.9.19
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@v0.9.17
+        uses: zackees/setup-soldr@v0.9.19
         with:
           zccache-seed-strict: true
           cache: true


### PR DESCRIPTION
Bumps all 15 `zackees/setup-soldr@` pins from v0.9.17 → v0.9.19 (the latest release).

Picks up:
- **v0.9.18** ([#251](https://github.com/zackees/setup-soldr/pull/256)): `target-cache-save-min-compiles` (delta-aware save gate for target-cache, mirror of `build-cache-save-min-compiles`). No effect on zccache CI today (target-cache is off across the matrix), but available if any workflow ever opts into target-cache.
- **v0.9.19** ([#258](https://github.com/zackees/setup-soldr/pull/258)): default Soldr bumped 0.7.44 → 0.7.45, which bundles **zccache 1.11.7** carrying the depgraph drift-detection fix ([zackees/zccache#449](https://github.com/zackees/zccache/issues/449) → [PR #450](https://github.com/zackees/zccache/pull/450)). Prevents stale-artifact link errors when transitive .cpp.hpp headers are modified in C++ unity builds.

Strict superset of v0.9.17. No `with:` block touched in this PR — pure pin bump.

## Test plan

- [ ] Full CI matrix runs the same as on main with the new setup-soldr revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)