### PR TITLE
perf(daemon): split REQUEST_VALIDATION_CACHE_MAX_ENTRIES from request cache (#453)

### DIFF
--- a/crates/zccache/src/daemon/server/cache_trim.rs
+++ b/crates/zccache/src/daemon/server/cache_trim.rs
@@ -93,7 +93,7 @@ pub(super) fn trim_request_validation_cache_at(
             true
         }
     });
-    if cache.len() > REQUEST_CACHE_MAX_ENTRIES {
+    if cache.len() > REQUEST_VALIDATION_CACHE_MAX_ENTRIES {
         let remaining = cache.len();
         cache.clear();
         removed += remaining;

--- a/crates/zccache/src/daemon/server/mod.rs
+++ b/crates/zccache/src/daemon/server/mod.rs
@@ -50,6 +50,12 @@ pub(crate) struct FastHitEntry {
 const FAST_HIT_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(60);
 const EPHEMERAL_CACHE_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(300);
 const REQUEST_CACHE_MAX_ENTRIES: usize = 4096;
+/// Validation-cache entries are lightweight (~200 bytes: ContentHash + root +
+/// artifact_key hex + clock) vs request_cache's parsed invocation metadata
+/// (multiple KiB per entry). Sized 2× the request cache so sibling-build /
+/// multi-root scenarios don't evict good validation entries while the request
+/// cache is still sparse. Memory cost at the cap: ~1.6 MiB. (#453)
+const REQUEST_VALIDATION_CACHE_MAX_ENTRIES: usize = 8192;
 const RSP_CACHE_MAX_ENTRIES: usize = 1024;
 const RUST_MISS_PROFILE_ENV: &str = "ZCCACHE_PROFILE_RUST_MISS";
 const WORKTREE_ROOT_ENV: &str = "ZCCACHE_WORKTREE_ROOT";

--- a/crates/zccache/src/daemon/server/tests/cache_trim.rs
+++ b/crates/zccache/src/daemon/server/tests/cache_trim.rs
@@ -152,6 +152,50 @@ fn trim_request_validation_cache_removes_old_entries() {
 }
 
 #[test]
+fn trim_request_validation_cache_uses_its_own_larger_hard_cap_not_request_cache_max() {
+    // #453: validation cache should have its own bound separate from the
+    // request cache, sized larger (lighter per-entry → can hold more).
+    // Filling it with REQUEST_CACHE_MAX_ENTRIES + 100 entries (4196) must
+    // NOT trigger the hard-cap clear, because the validation cap is 8192.
+    let cache = DashMap::new();
+    let tmp = tempfile::tempdir().unwrap();
+    let now = std::time::Instant::now();
+    for i in 0..(REQUEST_CACHE_MAX_ENTRIES + 100) {
+        cache.insert(
+            test_request_validation_key(i, &tmp.path().join(format!("root-{i}"))),
+            test_request_validation_entry(now),
+        );
+    }
+
+    let removed = trim_request_validation_cache_at(&cache, EPHEMERAL_CACHE_MAX_AGE, now);
+
+    assert_eq!(removed, 0, "validation cap is 8192, holding 4196 must not evict");
+    assert_eq!(cache.len(), REQUEST_CACHE_MAX_ENTRIES + 100);
+    // Sanity: the new cap really is larger than the old shared one.
+    assert!(REQUEST_VALIDATION_CACHE_MAX_ENTRIES > REQUEST_CACHE_MAX_ENTRIES);
+}
+
+#[test]
+fn trim_request_validation_cache_clears_when_over_validation_hard_cap() {
+    // #453: when filled past the validation-specific cap (8192), the cache
+    // is wiped just like request_cache is past its own cap.
+    let cache = DashMap::new();
+    let tmp = tempfile::tempdir().unwrap();
+    let now = std::time::Instant::now();
+    for i in 0..=REQUEST_VALIDATION_CACHE_MAX_ENTRIES {
+        cache.insert(
+            test_request_validation_key(i, &tmp.path().join(format!("root-{i}"))),
+            test_request_validation_entry(now),
+        );
+    }
+
+    let removed = trim_request_validation_cache_at(&cache, EPHEMERAL_CACHE_MAX_AGE, now);
+
+    assert_eq!(removed, REQUEST_VALIDATION_CACHE_MAX_ENTRIES + 1);
+    assert!(cache.is_empty());
+}
+
+#[test]
 fn request_cache_resolved_inputs_requires_cross_root_shareable_entry() {
     let tmp = tempfile::tempdir().unwrap();
     let root_a = tmp.path().join("workspace-a");

--- a/crates/zccache/src/daemon/server/tests/cache_trim.rs
+++ b/crates/zccache/src/daemon/server/tests/cache_trim.rs
@@ -169,7 +169,10 @@ fn trim_request_validation_cache_uses_its_own_larger_hard_cap_not_request_cache_
 
     let removed = trim_request_validation_cache_at(&cache, EPHEMERAL_CACHE_MAX_AGE, now);
 
-    assert_eq!(removed, 0, "validation cap is 8192, holding 4196 must not evict");
+    assert_eq!(
+        removed, 0,
+        "validation cap is 8192, holding 4196 must not evict"
+    );
     assert_eq!(cache.len(), REQUEST_CACHE_MAX_ENTRIES + 100);
     // Sanity: the new cap really is larger than the old shared one.
     assert!(REQUEST_VALIDATION_CACHE_MAX_ENTRIES > REQUEST_CACHE_MAX_ENTRIES);


### PR DESCRIPTION
Closes #453.

The `request_validation` cache (added in e7336f7) shared `REQUEST_CACHE_MAX_ENTRIES` (4096) with the `request_cache` via the shared trim helper. Validation entries are about 5× lighter (~200 B: ContentHash + root + artifact_key hex + clock; vs the request_cache's parsed invocation metadata at multiple KiB per entry), so they can hold more without memory pressure. In sibling-build / multi-root scenarios the validation cache fills faster, and sharing the bound caused premature wipes of good validation entries while the heavier request_cache was still sparse.

## Change

- Introduce `REQUEST_VALIDATION_CACHE_MAX_ENTRIES: usize = 8192` (conservative 2× the existing 4096; memory ceiling ~1.6 MiB at the cap, well within budget).
- Update `trim_request_validation_cache_at` to use the new constant instead of `REQUEST_CACHE_MAX_ENTRIES`.
- Add two tests covering the bound semantics:
  - `trim_request_validation_cache_uses_its_own_larger_hard_cap_not_request_cache_max` — fills with `REQUEST_CACHE_MAX_ENTRIES + 100 = 4196` entries; asserts 0 removed (the larger cap covers it). Also asserts the sanity invariant `REQUEST_VALIDATION_CACHE_MAX_ENTRIES > REQUEST_CACHE_MAX_ENTRIES`.
  - `trim_request_validation_cache_clears_when_over_validation_hard_cap` — fills past 8192, asserts the full wipe behavior matches what request_cache does at its own cap.

If 16384 is preferred (the issue mentioned both as candidates), it's a one-line tweak on the constant.

## Test plan

- [x] `cargo test -p zccache --lib daemon::server::tests::cache_trim` — 14/14 pass (12 existing + 2 new).
- [ ] Full CI matrix runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)