### PR TITLE
fix(perf-bench): clear cache before emcc multi-file cold scenario (#445)

### DIFF
--- a/crates/zccache/tests/perf_bench/tests_emcc.rs
+++ b/crates/zccache/tests/perf_bench/tests_emcc.rs
@@ -7,6 +7,8 @@
 
 use std::path::Path;
 
+use zccache::protocol::{Request, Response};
+
 use super::common::{
     end_zccache_session, find_empp, find_sccache, fmt_dur, fmt_ratio, median, print_trials,
     print_trials_per, start_daemon, start_zccache_session, NUM_FILES, WARM_TRIALS,
@@ -169,6 +171,14 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
     }
     print_trials("single warm:", &zc_warm_single);
 
+    // #445: reset the cache before the multi-cold measurement. Without
+    // this, `nuke_and_regenerate` only rewrites the (deterministic)
+    // sources, so the content-addressed entries from the single-file
+    // phase still hit and the "cold" measurement reports an impossible
+    // warm-hit time. The C++ benchmark (`tests_cpp.rs`) does this
+    // correctly; this brings emcc in line.
+    client.send(&Request::Clear).await.unwrap();
+    let _ = client.recv::<Response>().await;
     nuke_and_regenerate(zc_dir.path());
     warmup_compiler(&compiler, zc_dir.path());
     let zc_cold_multi =


### PR DESCRIPTION
Closes #445.

`perf_emcc_warm_cache_zccache_vs_sccache` measured "multi cold" right after "single warm" without resetting the cache. `nuke_and_regenerate` only rewrites the deterministic source files; the content-addressed entries from the single-file phase still hit, so the "cold" row reported an impossible **0.025 s** warm-hit time (163× faster than bare).

Mirror what `tests_cpp.rs` already does at lines 209-210: `Request::Clear` + `recv` before the multi-cold measurement, so it's genuinely cold. Same fix shape (and same author rationale) as the link-timer cleanup in #443.

## Change

- Add `use zccache::protocol::{Request, Response};` (already present in tests_cpp.rs).
- Insert the two-line clear-then-recv pair between `print_trials("single warm:", ...)` and the `nuke_and_regenerate` / cold-multi block.

## Verification

The perf-bench test is `#[ignore]` (only runs with `--ignored`), so unit-test CI doesn't execute it; `cargo check --tests -p zccache` confirms the file compiles cleanly. The actual proof point will be the next Benchmark Stats run, where the emcc "Multi-file Cold" row should land near bare (~3.96 s) instead of the spurious 0.025 s warm-hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)