### PR TITLE
perf(daemon): gate debug-only clock reads on ZCCACHE_PROFILE_RUST_MISS

### DIFF
--- a/crates/zccache/src/daemon/server/handle_compile/README.md
+++ b/crates/zccache/src/daemon/server/handle_compile/README.md
@@ -1,0 +1,17 @@
+# `handle_compile` — compile-request pipeline
+
+Split-out modules from the original `handle_compile.rs`. The compile pipeline is the per-request flow that decides hit vs miss, materializes cached outputs on hit, or runs the compiler on miss.
+
+## File map
+
+| File | Role |
+|---|---|
+| `pipeline.rs` | `handle_compile_request` — the top-level dispatch (system include discovery, arg parse, context build, hash, depgraph check, hit branches, fallback to compiler exec, store) |
+| `hit_branches.rs` | Request-cache / fast-hit / depgraph-hit probes — early returns into `cached_hit` |
+| `cached_hit.rs` | Shared materialization of a cached artifact onto the output path (hardlink + mtime preservation), stats bookkeeping |
+| `request.rs` | Decoded request shape consumed by `pipeline` |
+| `error_cache.rs` | Caching + materialization of cached compiler errors |
+| `miss_profile.rs` | Opt-in detailed per-phase profile of a miss (gated by `ZCCACHE_PROFILE_RUST_MISS`) |
+| `miss_store.rs` | Post-exec artifact store path |
+
+Tests live in `cached_hit.rs::tests` (mtime preservation, materialization shape) and in `pipeline.rs::tests` (phase wiring).

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
@@ -96,8 +96,21 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         Some(session_id.into()),
     );
 
+    // Issue #461: the timed phases below feed only `RustMissProfile`, which is
+    // emitted only when `ZCCACHE_PROFILE_RUST_MISS` is set. Decide once here
+    // whether to capture phase boundaries — otherwise we pay 4 unconditional
+    // clock reads (~50ns Linux / ~500ns Windows each) on EVERY request,
+    // including warm hits that never reach the miss emitter. Cheap env var
+    // probe is ~50ns; tied here for amortization across the rest of the
+    // function. Note this is broader than `rust_profile_enabled` at line 268
+    // (which also requires `is_rustc`); allowing the env-only check to gate
+    // these early phases costs at most a handful of bytes when a non-rustc
+    // compile happens with the env set — acceptable since that's the rare
+    // diagnostic path.
+    let want_rust_miss_profile = std::env::var_os(RUST_MISS_PROFILE_ENV).is_some();
+
     // Discover system includes for this compiler (cached per compiler path)
-    let t_system_includes = std::time::Instant::now();
+    let t_system_includes = want_rust_miss_profile.then(std::time::Instant::now);
     let compiler_priority = CompilePriority::from_client_env(client_env.as_deref());
     let system_includes = {
         let mut cache = state.system_includes.lock().await;
@@ -127,12 +140,16 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             })
             .to_vec()
     };
-    let system_includes_ns = t_system_includes.elapsed().as_nanos() as u64;
+    let system_includes_ns = t_system_includes
+        .map(|t| t.elapsed().as_nanos() as u64)
+        .unwrap_or(0);
 
     // Watch system include directories
-    let t_system_watch = std::time::Instant::now();
+    let t_system_watch = want_rust_miss_profile.then(std::time::Instant::now);
     watch_directories(state, &system_includes).await;
-    let system_watch_ns = t_system_watch.elapsed().as_nanos() as u64;
+    let system_watch_ns = t_system_watch
+        .map(|t| t.elapsed().as_nanos() as u64)
+        .unwrap_or(0);
 
     state.sessions.touch(&sid);
 


### PR DESCRIPTION
## Summary

`system_includes_ns` and `system_watch_ns` in `pipeline.rs` feed only `RustMissProfile`, which is emitted only when `ZCCACHE_PROFILE_RUST_MISS` is set. Today they run unconditionally on EVERY request — including warm fast-hits that never reach the miss emitter.

This PR:
- Captures the env-var probe once at the top (`want_rust_miss_profile`, ~50ns)
- Converts the 2 `Instant::now()` + `.elapsed()` pairs to an `Option<Instant>` pattern
- When the env is unset (default), the phase boundaries are not measured

## Per-request savings (warm hits)

| Platform | Per read | Reduction | Per request |
|---|---|---|---|
| Linux | ~50 ns | 4 reads | ~200 ns |
| Windows | ~500 ns | 4 reads | ~2 µs |

## Scope

Limited to the 2 warm-path-impacting phases. The other 6 debug-only phases in this function (break_outputs, post_exec, apply_changes, collect_outputs, register_tracked, dep_dirs) are on the miss path only and can follow the same pattern in a fast-follow PR. Keeping the diff focused.

## Measurement

Linux Docker `cold-tar-untar-warm/medium`: expected delta ~34 µs over 171 hits, below ~600ms inter-run variance. Fix is correct by inspection; pattern is clean (`Option<Instant>` via `bool::then`).

## Caveats

- `perf-rust-cluster.yml` is currently broken (`soldr update-zccache` missing on crates.io). Cluster gate will not validate this PR.

## Test plan

- [x] `soldr cargo check -p zccache`
- [x] `soldr cargo clippy -p zccache --lib -- -D warnings`

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)