### PR TITLE
perf(daemon): env-gated ZCCACHE_HIT_TRACE dump for hit-path sub-phase data

### DIFF
--- a/ci/perf_local.py
+++ b/ci/perf_local.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -219,6 +220,15 @@ def run_scenario(layout: dict[str, Path], scenario: str, fixture: str) -> Path:
 
     print(f"[perf-local] running scenario {scenario} x {fixture} -> {results_dir}")
     start = time.monotonic()
+    # Pass any ZCCACHE_* env through to the container so the daemon's
+    # env-gated instrumentation (e.g. ZCCACHE_HIT_TRACE=1 for the sub-phase
+    # dump from issue #468) reaches the in-container daemon process.
+    pass_through_env = [
+        (k, v) for k, v in os.environ.items() if k.startswith("ZCCACHE_")
+    ]
+    env_flags: list[str] = []
+    for k, v in pass_through_env:
+        env_flags.extend(["-e", f"{k}={v}"])
     run([
         "docker", "run", "--rm",
         "-v", host_volume(soldr_bin,              "/usr/local/bin/soldr", "ro"),
@@ -227,6 +237,7 @@ def run_scenario(layout: dict[str, Path], scenario: str, fixture: str) -> Path:
         "-v", host_volume(results_dir,            "/results"),
         "-e", f"SCENARIO={scenario}",
         "-e", f"FIXTURE={fixture}",
+        *env_flags,
         IMAGE_RUNNER,
     ])
     elapsed = time.monotonic() - start

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
@@ -327,6 +327,11 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     let context_is_cold = state.dep_graph.is_cold(&context_key);
 
     // ── Phase: hash source ───────────────────────────────────────────
+    // Issue #468: env-gated sub-phase trace. When ZCCACHE_HIT_TRACE=1, the
+    // daemon dumps per-compile sub-phase counts to stderr so the perf
+    // harness can break down the dominant "metadata cache (source+hdrs)"
+    // phase into source vs headers vs metadata-hit-rate components.
+    let hit_trace = std::env::var_os("ZCCACHE_HIT_TRACE").is_some();
     let t2 = std::time::Instant::now();
     let mut hash_map: HashMap<NormalizedPath, ContentHash> = HashMap::new();
     if !context_is_cold {
@@ -363,6 +368,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     let verdict;
     let diag_reason;
 
+    let mut hit_trace_headers_count: usize = 0;
     if context_is_cold {
         // Cold context — skip hashing and depgraph check entirely.
         hash_headers_ns = 0;
@@ -385,6 +391,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 .iter()
                 .map(|h| (h, "rustc_extern_hash_fail"));
             let all_paths: Vec<_> = include_iter.chain(force_iter).chain(extern_iter).collect();
+            hit_trace_headers_count = all_paths.len();
 
             let results: Vec<_> = all_paths
                 .par_iter()
@@ -412,6 +419,23 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             }
         }
         hash_headers_ns = t3.elapsed().as_nanos() as u64;
+
+        // Issue #468: ZCCACHE_HIT_TRACE=1 dumps per-compile sub-phase breakdown
+        // so the perf harness can decompose the dominant metadata-cache phase.
+        // Format is a single line per compile, easy to grep/awk over a session.
+        if hit_trace {
+            let hdr_avg_us =
+                if hit_trace_headers_count > 0 { hash_headers_ns / hit_trace_headers_count as u64 / 1_000 } else { 0 };
+            eprintln!(
+                "ZCCACHE_HIT_TRACE source_us={} headers_count={} headers_us={} hdr_avg_us={} \
+                 source_path={}",
+                hash_source_ns / 1_000,
+                hit_trace_headers_count,
+                hash_headers_ns / 1_000,
+                hdr_avg_us,
+                source_path.display()
+            );
+        }
 
         // ── Phase: depgraph check ────────────────────────────────────
         // Fast path: recompute artifact key from fresh hashes and compare

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
@@ -368,7 +368,6 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     let verdict;
     let diag_reason;
 
-    let mut hit_trace_headers_count: usize = 0;
     if context_is_cold {
         // Cold context — skip hashing and depgraph check entirely.
         hash_headers_ns = 0;
@@ -377,6 +376,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         diag_reason = "cold_skip".to_string();
     } else {
         // Hash includes + force-includes in parallel (PCH-aware).
+        let headers_count: usize;
         {
             use rayon::prelude::*;
             let includes = state.dep_graph.get_includes(&context_key);
@@ -391,7 +391,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 .iter()
                 .map(|h| (h, "rustc_extern_hash_fail"));
             let all_paths: Vec<_> = include_iter.chain(force_iter).chain(extern_iter).collect();
-            hit_trace_headers_count = all_paths.len();
+            headers_count = all_paths.len();
 
             let results: Vec<_> = all_paths
                 .par_iter()
@@ -424,13 +424,16 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         // so the perf harness can decompose the dominant metadata-cache phase.
         // Format is a single line per compile, easy to grep/awk over a session.
         if hit_trace {
-            let hdr_avg_us =
-                if hit_trace_headers_count > 0 { hash_headers_ns / hit_trace_headers_count as u64 / 1_000 } else { 0 };
+            let hdr_avg_us = if headers_count > 0 {
+                hash_headers_ns / headers_count as u64 / 1_000
+            } else {
+                0
+            };
             eprintln!(
                 "ZCCACHE_HIT_TRACE source_us={} headers_count={} headers_us={} hdr_avg_us={} \
                  source_path={}",
                 hash_source_ns / 1_000,
-                hit_trace_headers_count,
+                headers_count,
                 hash_headers_ns / 1_000,
                 hdr_avg_us,
                 source_path.display()


### PR DESCRIPTION
## Summary

Adds `ZCCACHE_HIT_TRACE=1` env-gated stderr dump in `pipeline.rs` that emits one line per warm hit through the hash-headers slow path with `source_us`, `headers_count`, `headers_us`, `hdr_avg_us`, and the source path. Lets the perf harness decompose the dominant 995µs `metadata cache (source+hdrs)` phase into actionable sub-components.

`ci/perf_local.py` now propagates any `ZCCACHE_*` env var to the in-container daemon, so:

\`\`\`
ZCCACHE_HIT_TRACE=1 uv run python ci/perf_local.py --scenario cold-tar-untar-warm --fixture medium
\`\`\`

…produces per-hit lines you can pipe through awk/grep to histogram which compiles are paying the most for header re-hashing.

## Why

The `metadata cache (source+hdrs)` phase (= `hash_source_ns + hash_headers_ns`) dominates the warm hit budget at 5.6× the next phase. Without sub-phase data we can't tell if the cost is:

- One pathological source file with many headers
- Many small files each adding rayon dispatch overhead
- Metadata-cache stat-verify routinely failing → forced re-hash

The dump gives us the per-call shape directly. Findings feed into follow-up issues (#469 already filed: the slow-path is dominating because mtime-precision asymmetry causes stat-verify to fail post-tar/untar).

## Cost

One `std::env::var_os` call per warm hit (~50ns) when the env is unset — negligible. When set, one `eprintln!` per non-fast-hit compile.

## Test plan

- [x] `soldr cargo check -p zccache`
- [x] Docker run with `ZCCACHE_HIT_TRACE=1` confirms the env var propagates into the container

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)