### PR TITLE
perf(fscache): per-worktree key for PCH + MSVC, triple prefix-map for clang/gcc (closes #474)

### DIFF
--- a/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
@@ -222,12 +222,37 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         &state.compiler_hash_cache,
     );
     let default_key_root = worktree_root.clone().unwrap_or_else(|| cwd_path.clone());
+    // Issue #474: PCH (output ends in .pch / .gch) and MSVC compiles must
+    // get a per-worktree cache key — the compiler embeds absolute paths in
+    // the artifact in a form the `-ffile-prefix-map` family can't scrub.
+    // See `keys::requires_worktree_in_key` for the truth table.
+    let source_mode_for_key = if matches!(
+        compilation
+            .output_file
+            .as_path()
+            .extension()
+            .and_then(|e| e.to_str()),
+        Some("pch") | Some("gch")
+    ) {
+        crate::compiler::SourceMode::Header
+    } else {
+        crate::compiler::SourceMode::Normal
+    };
+    let worktree_salt = if worktree_root.is_some()
+        && requires_worktree_in_key(compilation.family, source_mode_for_key)
+    {
+        Some(default_key_root.as_path())
+    } else {
+        None
+    };
     let (ctx, dep_flags, rustc_args_opt, context_key, worktree_equivalent_context) =
         match build_result {
             BuildContextResult::Cc { ctx, dep_flags } => {
-                let registration = state
-                    .dep_graph
-                    .register_with_root_result(ctx.clone(), Some(default_key_root.clone()));
+                let registration = state.dep_graph.register_with_root_and_salt_result(
+                    ctx.clone(),
+                    Some(default_key_root.clone()),
+                    worktree_salt,
+                );
                 (
                     ctx,
                     dep_flags,

--- a/crates/zccache/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache/src/daemon/server/handle_compile_multi.rs
@@ -80,9 +80,32 @@ pub(super) fn check_unit_cache(
         }
     };
     let t_ctx = t0.elapsed();
-    let context_key = state
-        .dep_graph
-        .register_with_root(ctx.clone(), Some(key_root.clone()));
+    // Issue #474: PCH / MSVC compiles take a per-worktree salt so the
+    // resulting cache entry can't be cross-served between sibling
+    // worktrees. Mirror of the single-file gate in
+    // `pipeline.rs::handle_compile_request`.
+    let source_mode_for_key = if matches!(
+        compilation
+            .output_file
+            .as_path()
+            .extension()
+            .and_then(|e| e.to_str()),
+        Some("pch") | Some("gch")
+    ) {
+        crate::compiler::SourceMode::Header
+    } else {
+        crate::compiler::SourceMode::Normal
+    };
+    let worktree_salt = if requires_worktree_in_key(compilation.family, source_mode_for_key) {
+        Some(key_root.as_path())
+    } else {
+        None
+    };
+    let context_key = state.dep_graph.register_with_root_and_salt(
+        ctx.clone(),
+        Some(key_root.clone()),
+        worktree_salt,
+    );
     let t_register = t0.elapsed();
 
     // ── Ultra-fast path: per-file freshness skip ────────────────────

--- a/crates/zccache/src/daemon/server/keys.rs
+++ b/crates/zccache/src/daemon/server/keys.rs
@@ -181,12 +181,17 @@ pub(super) fn same_key_path(left: &Path, right: &Path) -> bool {
     crate::core::path::normalize_for_key(left) == crate::core::path::normalize_for_key(right)
 }
 
-pub(super) fn has_ffile_prefix_map_for_old(args: &[String], old: &Path) -> bool {
+/// Does `args` contain a `<target_flag>=<old>=...` mapping (case- and
+/// path-normalisation aware on the `old` side)? Used by the auto-injection
+/// branch in [`effective_compile_args`] to skip adding redundant
+/// `-ffile-prefix-map` / `-fmacro-prefix-map` / `-fdebug-prefix-map` flags
+/// when the caller already passed one for the same `old` root (issue #474).
+pub(super) fn has_cc_prefix_map_for_old(args: &[String], target_flag: &str, old: &Path) -> bool {
     args.iter().any(|arg| {
         let Some((flag, existing_old, _)) = split_cc_prefix_map_arg(arg) else {
             return false;
         };
-        flag == "-ffile-prefix-map" && same_key_path(Path::new(existing_old), old)
+        flag == target_flag && same_key_path(Path::new(existing_old), old)
     })
 }
 
@@ -195,6 +200,35 @@ pub(super) fn compiler_supports_ffile_prefix_map(compiler_path: &Path) -> bool {
         crate::compiler::detect_family(&compiler_path.to_string_lossy()),
         crate::compiler::CompilerFamily::Clang | crate::compiler::CompilerFamily::Gcc
     )
+}
+
+/// Does this (family, source_mode) pair require the worktree-root to be
+/// folded into the artifact cache key?
+///
+/// Returns `true` for compile invocations whose ARTIFACTS the compiler
+/// embeds absolute paths inside, in a form the `-ffile-prefix-map` family
+/// of flags can't scrub:
+///
+/// * **PCH builds** (`SourceMode::Header` with clang or gcc) — the `.pch` /
+///   `.gch` binary serialises the AST's header-path table; even with
+///   `-ffile-prefix-map` and friends, restoring a fastled9-built PCH into
+///   fastled10 leaves fastled9 paths inside the AST (issue #474).
+/// * **MSVC** (`CompilerFamily::Msvc`) — cl.exe has no `-fmacro-prefix-map`
+///   equivalent. Object files emit absolute paths in debug info and the
+///   `$$PDB` reference, with no compiler-side scrub available.
+///
+/// When this returns `true`, the cache key for the artifact must include
+/// the `worktree_root` (or another stable per-worktree salt) so the cache
+/// entry stays scoped to the worktree that built it. The trade-off is one
+/// cold compile per worktree for the affected unit; everything else
+/// continues to share across worktrees (issue #474 plan, Piece B).
+#[must_use]
+pub fn requires_worktree_in_key(
+    family: crate::compiler::CompilerFamily,
+    source_mode: crate::compiler::SourceMode,
+) -> bool {
+    use crate::compiler::{CompilerFamily, SourceMode};
+    matches!(family, CompilerFamily::Msvc) || matches!(source_mode, SourceMode::Header)
 }
 
 pub(super) fn request_key_root(
@@ -241,21 +275,31 @@ pub(super) fn effective_compile_args(
         return expanded_args.to_vec();
     }
 
-    let mut auto_args = Vec::with_capacity(2);
-    if !has_ffile_prefix_map_for_old(expanded_args, root_path) {
-        auto_args.push(format!(
-            "-ffile-prefix-map={}={}",
-            root_path.to_string_lossy(),
-            "."
-        ));
+    // Inject the three siblings together. Modern clang treats
+    // `-ffile-prefix-map` as the umbrella, but older clang (< 10) and
+    // some gcc versions need `-fmacro-prefix-map` and `-fdebug-prefix-map`
+    // explicitly. Issue #474: without the explicit macro form, `__FILE__`
+    // strings in `.rodata` leak the original-clone path into artifacts
+    // restored to a sibling worktree.
+    const AUTO_PREFIX_MAP_FLAGS: &[&str] = &[
+        "-ffile-prefix-map",
+        "-fmacro-prefix-map",
+        "-fdebug-prefix-map",
+    ];
+
+    let mut auto_args = Vec::with_capacity(AUTO_PREFIX_MAP_FLAGS.len() * 2);
+    for flag in AUTO_PREFIX_MAP_FLAGS {
+        if !has_cc_prefix_map_for_old(expanded_args, flag, root_path) {
+            auto_args.push(format!("{}={}=.", flag, root_path.to_string_lossy()));
+        }
     }
 
-    if !same_key_path(root_path, cwd) && !has_ffile_prefix_map_for_old(expanded_args, cwd) {
-        auto_args.push(format!(
-            "-ffile-prefix-map={}={}",
-            cwd.to_string_lossy(),
-            "."
-        ));
+    if !same_key_path(root_path, cwd) {
+        for flag in AUTO_PREFIX_MAP_FLAGS {
+            if !has_cc_prefix_map_for_old(expanded_args, flag, cwd) {
+                auto_args.push(format!("{}={}=.", flag, cwd.to_string_lossy()));
+            }
+        }
     }
 
     if auto_args.is_empty() {

--- a/crates/zccache/src/daemon/server/tests/cache_trim.rs
+++ b/crates/zccache/src/daemon/server/tests/cache_trim.rs
@@ -175,7 +175,7 @@ fn trim_request_validation_cache_uses_its_own_larger_hard_cap_not_request_cache_
     );
     assert_eq!(cache.len(), REQUEST_CACHE_MAX_ENTRIES + 100);
     // Sanity: the new cap really is larger than the old shared one.
-    assert!(REQUEST_VALIDATION_CACHE_MAX_ENTRIES > REQUEST_CACHE_MAX_ENTRIES);
+    const _: () = assert!(REQUEST_VALIDATION_CACHE_MAX_ENTRIES > REQUEST_CACHE_MAX_ENTRIES);
 }
 
 #[test]

--- a/crates/zccache/src/daemon/server/tests/fingerprint.rs
+++ b/crates/zccache/src/daemon/server/tests/fingerprint.rs
@@ -248,6 +248,12 @@ fn request_fingerprint_keeps_malformed_rust_remap_detached_values_distinct() {
 
 #[test]
 fn effective_compile_args_auto_adds_root_and_cwd_maps() {
+    // Issue #474: alongside `-ffile-prefix-map`, the auto-inject now
+    // also emits `-fmacro-prefix-map` and `-fdebug-prefix-map` for both
+    // the worktree root and the cwd. Older clang (< 10) and some gcc
+    // versions don't treat `-ffile-prefix-map` as the umbrella; the
+    // explicit triplet ensures `__FILE__` strings and DWARF debug info
+    // are both scrubbed on every supported toolchain.
     let tmp = tempfile::tempdir().unwrap();
     let root_path = tmp.path().join("workspace");
     let cwd = root_path.join("build");
@@ -264,16 +270,32 @@ fn effective_compile_args_auto_adds_root_and_cwd_maps() {
     );
 
     assert!(effective.contains(&"-c".to_string()));
-    assert!(effective.contains(&format!("-ffile-prefix-map={}=.", root_path.display())));
-    assert!(effective.contains(&format!("-ffile-prefix-map={}=.", cwd.display())));
-    assert_eq!(
-        effective[0],
-        format!("-ffile-prefix-map={}=.", root_path.display())
-    );
-    assert_eq!(
-        effective[1],
-        format!("-ffile-prefix-map={}=.", cwd.display())
-    );
+    for flag in &[
+        "-ffile-prefix-map",
+        "-fmacro-prefix-map",
+        "-fdebug-prefix-map",
+    ] {
+        let root_arg = format!("{flag}={}=.", root_path.display());
+        let cwd_arg = format!("{flag}={}=.", cwd.display());
+        assert!(
+            effective.contains(&root_arg),
+            "expected {root_arg:?} in {effective:?}"
+        );
+        assert!(
+            effective.contains(&cwd_arg),
+            "expected {cwd_arg:?} in {effective:?}"
+        );
+    }
+    // Order invariant: root-mapped flags precede cwd-mapped flags.
+    let root_file_pos = effective
+        .iter()
+        .position(|a| a == &format!("-ffile-prefix-map={}=.", root_path.display()))
+        .unwrap();
+    let cwd_file_pos = effective
+        .iter()
+        .position(|a| a == &format!("-ffile-prefix-map={}=.", cwd.display()))
+        .unwrap();
+    assert!(root_file_pos < cwd_file_pos);
 }
 
 #[test]

--- a/crates/zccache/src/daemon/server/tests/mod.rs
+++ b/crates/zccache/src/daemon/server/tests/mod.rs
@@ -11,6 +11,7 @@ mod compiler_hash;
 mod fingerprint;
 mod link_cache;
 mod pack;
+mod path_remap;
 mod pch;
 mod post_link_hook;
 mod server_ipc;

--- a/crates/zccache/src/daemon/server/tests/path_remap.rs
+++ b/crates/zccache/src/daemon/server/tests/path_remap.rs
@@ -1,0 +1,364 @@
+//! Tests for path-remap behaviour (issue #474).
+//!
+//! Covers the two halves of the fix:
+//!
+//! 1. **Flag injection** — `effective_compile_args` should inject
+//!    `-fmacro-prefix-map=<root>=.` and `-fdebug-prefix-map=<root>=.` for
+//!    clang / gcc (alongside the existing `-ffile-prefix-map`). Modern clang
+//!    treats `-ffile-prefix-map` as an umbrella, but older clang (< 10) and
+//!    some gcc versions need the explicit pair; we inject both for
+//!    portability. MSVC has no equivalent flag and must skip.
+//!
+//! 2. **Worktree-keyed cache** — `requires_worktree_in_key` is true for the
+//!    cases where the compiler embeds absolute paths the remap flags can't
+//!    scrub (PCH `.pch`/`.gch` binaries; all of MSVC because it has no
+//!    flag). When true, `compute_artifact_key` hashes the `worktree_salt`
+//!    into the key so two sibling worktrees of the same commit get
+//!    distinct cache entries for these artifacts — preventing the
+//!    cross-clone path-leak from #474.
+//!
+//! All tests are fixture-based; none invoke a real compiler. They are fast
+//! enough (< 10 ms each) to keep in the unit-test tier.
+
+use super::super::*;
+use crate::compiler::{CompilerFamily, SourceMode};
+
+// ── Piece A: flag injection ────────────────────────────────────────────────
+
+#[test]
+fn injects_macro_prefix_map_for_clang() {
+    // Older clang doesn't honour `-ffile-prefix-map` as an umbrella over
+    // `__FILE__` expansions; the explicit `-fmacro-prefix-map` is required
+    // to stop fastled9 paths from leaking into the .rodata of artifacts
+    // shipped to fastled10.
+    let tmp = tempfile::tempdir().unwrap();
+    let root_path = tmp.path().join("workspace");
+    let root = NormalizedPath::new(&root_path);
+    let env = vec![(PATH_REMAP_ENV.to_string(), "auto".to_string())];
+    let args = vec!["-c".to_string(), "src/main.cc".to_string()];
+
+    let effective = effective_compile_args(
+        &args,
+        Path::new("/usr/bin/clang++"),
+        &root_path,
+        Some(&root),
+        Some(&env),
+    );
+
+    assert!(
+        effective.contains(&format!("-fmacro-prefix-map={}=.", root_path.display())),
+        "expected -fmacro-prefix-map=<root>=. in {:?}",
+        effective
+    );
+}
+
+#[test]
+fn injects_debug_prefix_map_for_clang() {
+    // DWARF debug info embeds compilation-directory + source paths. Without
+    // an explicit `-fdebug-prefix-map`, gdb/lldb on a sibling worktree show
+    // the original clone's paths.
+    let tmp = tempfile::tempdir().unwrap();
+    let root_path = tmp.path().join("workspace");
+    let root = NormalizedPath::new(&root_path);
+    let env = vec![(PATH_REMAP_ENV.to_string(), "auto".to_string())];
+    let args = vec!["-c".to_string(), "src/main.cc".to_string()];
+
+    let effective = effective_compile_args(
+        &args,
+        Path::new("/usr/bin/clang++"),
+        &root_path,
+        Some(&root),
+        Some(&env),
+    );
+
+    assert!(
+        effective.contains(&format!("-fdebug-prefix-map={}=.", root_path.display())),
+        "expected -fdebug-prefix-map=<root>=. in {:?}",
+        effective
+    );
+}
+
+#[test]
+fn injects_macro_prefix_map_for_gcc() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root_path = tmp.path().join("workspace");
+    let root = NormalizedPath::new(&root_path);
+    let env = vec![(PATH_REMAP_ENV.to_string(), "auto".to_string())];
+    let args = vec!["-c".to_string(), "src/main.cc".to_string()];
+
+    let effective = effective_compile_args(
+        &args,
+        Path::new("/usr/bin/g++"),
+        &root_path,
+        Some(&root),
+        Some(&env),
+    );
+
+    assert!(
+        effective.contains(&format!("-fmacro-prefix-map={}=.", root_path.display())),
+        "expected -fmacro-prefix-map=<root>=. for gcc in {:?}",
+        effective
+    );
+}
+
+#[test]
+fn does_not_inject_redundant_macro_prefix_map_for_clang() {
+    // User-supplied narrower `-fmacro-prefix-map` for the same root must
+    // suppress the auto-injection — otherwise we'd ship two conflicting
+    // remaps for the same FROM and the second-wins behaviour silently
+    // changes which one is active.
+    let tmp = tempfile::tempdir().unwrap();
+    let root_path = tmp.path().join("workspace");
+    let root = NormalizedPath::new(&root_path);
+    let env = vec![(PATH_REMAP_ENV.to_string(), "auto".to_string())];
+    let user_map = format!("-fmacro-prefix-map={}=/source", root_path.display());
+    let args = vec![
+        user_map.clone(),
+        "-c".to_string(),
+        "src/main.cc".to_string(),
+    ];
+
+    let effective = effective_compile_args(
+        &args,
+        Path::new("/usr/bin/clang++"),
+        &root_path,
+        Some(&root),
+        Some(&env),
+    );
+
+    let macro_maps: Vec<&String> = effective
+        .iter()
+        .filter(|a| a.starts_with("-fmacro-prefix-map="))
+        .collect();
+    assert_eq!(
+        macro_maps.len(),
+        1,
+        "expected one -fmacro-prefix-map (the user's), got {:?}",
+        macro_maps
+    );
+    assert_eq!(macro_maps[0], &user_map);
+}
+
+#[test]
+fn does_not_inject_for_msvc() {
+    // cl.exe doesn't support `-fmacro-prefix-map` / `-ffile-prefix-map` /
+    // `-fdebug-prefix-map`. Auto-injecting any of them would make MSVC
+    // reject the command line.
+    let tmp = tempfile::tempdir().unwrap();
+    let root_path = tmp.path().join("workspace");
+    let root = NormalizedPath::new(&root_path);
+    let env = vec![(PATH_REMAP_ENV.to_string(), "auto".to_string())];
+    let args = vec!["/c".to_string(), "src\\main.cpp".to_string()];
+
+    let effective = effective_compile_args(
+        &args,
+        Path::new("cl.exe"),
+        &root_path,
+        Some(&root),
+        Some(&env),
+    );
+
+    for arg in &effective {
+        assert!(
+            !arg.starts_with("-fmacro-prefix-map=")
+                && !arg.starts_with("-fdebug-prefix-map=")
+                && !arg.starts_with("-ffile-prefix-map="),
+            "MSVC argv must not contain prefix-map flags, found {:?} in {:?}",
+            arg,
+            effective
+        );
+    }
+}
+
+#[test]
+fn injects_remap_path_prefix_for_rustc() {
+    // Pre-existing behaviour pinned: rustc gets `--remap-path-prefix=<root>=.`
+    // when `ZCCACHE_PATH_REMAP=auto`. The new C++ flag injection must not
+    // break this code path.
+    let tmp = tempfile::tempdir().unwrap();
+    let root_path = tmp.path().join("workspace");
+    let root = NormalizedPath::new(&root_path);
+    let env = vec![(PATH_REMAP_ENV.to_string(), "auto".to_string())];
+    let args = vec![
+        "--crate-type".to_string(),
+        "lib".to_string(),
+        "src/lib.rs".to_string(),
+    ];
+
+    let effective = effective_compile_args(
+        &args,
+        Path::new("rustc"),
+        &root_path,
+        Some(&root),
+        Some(&env),
+    );
+
+    assert_eq!(
+        &effective[..2],
+        &[
+            "--remap-path-prefix".to_string(),
+            format!("{}=.", root_path.display())
+        ],
+        "rustc should still get --remap-path-prefix=<root>=. as its first arg pair"
+    );
+}
+
+// ── Piece B: `requires_worktree_in_key` truth table ────────────────────────
+
+#[test]
+fn requires_worktree_in_key_for_pch_clang() {
+    // PCH binary stores absolute header paths in its serialised AST table.
+    // Flag-based remap can't scrub them; the cache entry must be per-
+    // worktree to prevent fastled9's PCH from being served to fastled10.
+    assert!(requires_worktree_in_key(
+        CompilerFamily::Clang,
+        SourceMode::Header
+    ));
+}
+
+#[test]
+fn requires_worktree_in_key_for_pch_gcc() {
+    assert!(requires_worktree_in_key(
+        CompilerFamily::Gcc,
+        SourceMode::Header
+    ));
+}
+
+#[test]
+fn requires_worktree_in_key_for_msvc_regardless_of_mode() {
+    // cl.exe has no `-fmacro-prefix-map` equivalent — every MSVC compile
+    // potentially embeds absolute paths in debug info + `$$PDB` refs.
+    // Worktree-key is the only robust answer.
+    assert!(requires_worktree_in_key(
+        CompilerFamily::Msvc,
+        SourceMode::Normal
+    ));
+    assert!(requires_worktree_in_key(
+        CompilerFamily::Msvc,
+        SourceMode::Header
+    ));
+}
+
+#[test]
+fn requires_worktree_in_key_false_for_normal_clang() {
+    // Cross-worktree sharing must stay intact for the common case
+    // (clang non-PCH .cpp compile with auto-remap). Returning true here
+    // would tank the cache hit rate for FastLED-class workflows.
+    assert!(!requires_worktree_in_key(
+        CompilerFamily::Clang,
+        SourceMode::Normal
+    ));
+}
+
+#[test]
+fn requires_worktree_in_key_false_for_normal_gcc() {
+    assert!(!requires_worktree_in_key(
+        CompilerFamily::Gcc,
+        SourceMode::Normal
+    ));
+}
+
+#[test]
+fn requires_worktree_in_key_false_for_rustc() {
+    // rustc's `--remap-path-prefix` is enough to scrub paths from .rlib /
+    // .rmeta artifacts; rustc artifacts must share across worktrees.
+    assert!(!requires_worktree_in_key(
+        CompilerFamily::Rustc,
+        SourceMode::Normal
+    ));
+}
+
+// ── Piece B: `compute_context_key` worktree-salt behaviour ─────────────────
+//
+// The salt lives on the context key (not the artifact key) so all artifact
+// keys derived from a salted context are automatically per-worktree without
+// the eight downstream `compute_artifact_key` callers needing to know about
+// the salt. Tests pin that compute_context_key's optional salt parameter
+// (a) yields distinct keys when present and different, (b) yields identical
+// keys when absent (the cross-worktree-share-preserving default), and
+// (c) is deterministic.
+
+mod context_key_salt {
+    use crate::core::NormalizedPath;
+    use crate::depgraph::context::{compute_context_key, CompileContext};
+    use crate::depgraph::search_paths::IncludeSearchPaths;
+
+    fn minimal_context() -> CompileContext {
+        CompileContext {
+            source_file: NormalizedPath::from("src/main.cpp"),
+            include_search: IncludeSearchPaths::default(),
+            defines: Vec::new(),
+            flags: Vec::new(),
+            force_includes: Vec::new(),
+            unknown_flags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn context_key_differs_across_worktrees_when_salt_supplied() {
+        // The whole point of the salt: same context in two different
+        // worktrees → distinct context keys → distinct downstream
+        // artifact keys, even though every other input is identical.
+        let tmp = tempfile::tempdir().unwrap();
+        let root_a = tmp.path().join("worktree-a");
+        let root_b = tmp.path().join("worktree-b");
+        let ctx = minimal_context();
+
+        let key_a = compute_context_key(&ctx, None, Some(&root_a));
+        let key_b = compute_context_key(&ctx, None, Some(&root_b));
+
+        assert_ne!(
+            key_a, key_b,
+            "PCH / MSVC: per-worktree salt must yield distinct context keys"
+        );
+    }
+
+    #[test]
+    fn context_key_matches_across_worktrees_when_no_salt() {
+        // Cross-worktree sharing for the common case: clang non-PCH .cpp,
+        // rustc, etc. Salt is None → same content → same key, regardless
+        // of which worktree the build happens in.
+        let ctx = minimal_context();
+
+        let key_a = compute_context_key(&ctx, None, None);
+        let key_b = compute_context_key(&ctx, None, None);
+
+        assert_eq!(
+            key_a, key_b,
+            "no salt → identical keys; cross-worktree sharing must work"
+        );
+    }
+
+    #[test]
+    fn context_key_stable_for_same_worktree_salt() {
+        // Sanity: the salt is deterministic. Same context + same salt →
+        // same key on repeat invocation. Otherwise the first build in a
+        // worktree would store a key the second build couldn't match.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("worktree-a");
+        let ctx = minimal_context();
+
+        let key_1 = compute_context_key(&ctx, None, Some(&root));
+        let key_2 = compute_context_key(&ctx, None, Some(&root));
+
+        assert_eq!(key_1, key_2, "salt must be deterministic across calls");
+    }
+
+    #[test]
+    fn context_key_with_salt_differs_from_no_salt() {
+        // Sanity: Some(x) and None must be distinguishable, otherwise the
+        // salt branch is dead code and #474 stays broken.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("worktree");
+        let ctx = minimal_context();
+
+        let key_with_salt = compute_context_key(&ctx, None, Some(&root));
+        let key_no_salt = compute_context_key(&ctx, None, None);
+
+        assert_ne!(
+            key_with_salt, key_no_salt,
+            "Some(salt) must produce a different key from None — \
+             otherwise the salt branch is a no-op"
+        );
+    }
+}

--- a/crates/zccache/src/depgraph/context/mod.rs
+++ b/crates/zccache/src/depgraph/context/mod.rs
@@ -115,10 +115,12 @@ impl CompileContext {
     /// Compute the context key.
     ///
     /// Includes: source file path, include dirs (in order), sorted defines,
-    /// sorted flags, unknown flags, force includes.
+    /// sorted flags, unknown flags, force includes. Passes `None` for both
+    /// `key_root` and `worktree_salt` — callers that need either should call
+    /// [`compute_context_key`] directly.
     #[must_use]
     pub fn context_key(&self) -> ContextKey {
-        compute_context_key(self, None)
+        compute_context_key(self, None, None)
     }
 }
 
@@ -191,11 +193,40 @@ fn normalize_cxx_prefix_map_flag_for_key(flag: &str, key_root: Option<&Path>) ->
 ///
 /// When `key_root` is provided, paths under that root are hashed relative to it
 /// so equivalent workspaces can share cache keys across root-directory renames.
+///
+/// When `worktree_salt` is provided, its byte representation is folded into the
+/// hash so the resulting key is unique to that worktree. This is the
+/// correctness escape hatch for compile modes whose artifacts the compiler
+/// embeds absolute paths inside in a form the `-ffile-prefix-map` family of
+/// flags can't scrub:
+///
+/// * PCH builds (`-x c++-header` / `-x c-header`) — the `.pch`/`.gch` binary
+///   serialises the AST's header-path table.
+/// * MSVC compiles — `cl.exe` has no `-fmacro-prefix-map` equivalent.
+///
+/// See `crate::daemon::server::keys::requires_worktree_in_key` for the
+/// truth table and issue #474 for the cross-clone leak this guards against.
+/// All other callers (rustc, clang/gcc non-PCH) pass `None` and continue to
+/// share cache entries across worktrees of the same commit.
 #[must_use]
-pub fn compute_context_key(ctx: &CompileContext, key_root: Option<&Path>) -> ContextKey {
+pub fn compute_context_key(
+    ctx: &CompileContext,
+    key_root: Option<&Path>,
+    worktree_salt: Option<&Path>,
+) -> ContextKey {
     let mut hasher = blake3::Hasher::new();
 
     hasher.update(b"zccache-context-key-v1\0");
+
+    if let Some(salt) = worktree_salt {
+        // Domain-tagged so the salt can't collide with any future hash
+        // input that happens to start with the same bytes. `None` is the
+        // common case and writes no bytes — keys produced with no salt
+        // are byte-identical to pre-#474 keys.
+        hasher.update(b"worktree-salt\0");
+        hasher.update(crate::core::path::normalize_for_key(salt).as_bytes());
+        hasher.update(b"\0");
+    }
 
     hasher.update(normalize_key_path(&ctx.source_file, key_root).as_bytes());
     hasher.update(b"\0");

--- a/crates/zccache/src/depgraph/context/tests/cc.rs
+++ b/crates/zccache/src/depgraph/context/tests/cc.rs
@@ -180,8 +180,8 @@ fn context_key_ignores_workspace_root_when_key_root_is_stable() {
         &["DEBUG"],
     );
 
-    let key_a = compute_context_key(&ctx_a, Some(Path::new("/workspace-a")));
-    let key_b = compute_context_key(&ctx_b, Some(Path::new("/workspace-b")));
+    let key_a = compute_context_key(&ctx_a, Some(Path::new("/workspace-a")), None);
+    let key_b = compute_context_key(&ctx_b, Some(Path::new("/workspace-b")), None);
 
     assert_eq!(key_a, key_b);
 }
@@ -194,8 +194,8 @@ fn cxx_context_key_with_root_normalizes_file_prefix_map_roots() {
     ctx_b.flags = vec!["-ffile-prefix-map=/workspace-b=.".to_string()];
 
     assert_eq!(
-        compute_context_key(&ctx_a, Some(Path::new("/workspace-a"))),
-        compute_context_key(&ctx_b, Some(Path::new("/workspace-b"))),
+        compute_context_key(&ctx_a, Some(Path::new("/workspace-a")), None),
+        compute_context_key(&ctx_b, Some(Path::new("/workspace-b")), None),
         "equivalent file-prefix-map old prefixes under the key root should match"
     );
 }
@@ -208,8 +208,8 @@ fn cxx_context_key_with_root_preserves_file_prefix_map_new_prefixes() {
     ctx_b.flags = vec!["-ffile-prefix-map=/workspace-b=/src".to_string()];
 
     assert_ne!(
-        compute_context_key(&ctx_a, Some(Path::new("/workspace-a"))),
-        compute_context_key(&ctx_b, Some(Path::new("/workspace-b"))),
+        compute_context_key(&ctx_a, Some(Path::new("/workspace-a")), None),
+        compute_context_key(&ctx_b, Some(Path::new("/workspace-b")), None),
         "different file-prefix-map new prefixes should remain key-significant"
     );
 }
@@ -222,8 +222,8 @@ fn cxx_context_key_with_root_keeps_external_file_prefix_map_old_prefixes_distinc
     ctx_b.flags = vec!["-ffile-prefix-map=/external-b=.".to_string()];
 
     assert_ne!(
-        compute_context_key(&ctx_a, Some(Path::new("/workspace-a"))),
-        compute_context_key(&ctx_b, Some(Path::new("/workspace-b"))),
+        compute_context_key(&ctx_a, Some(Path::new("/workspace-a")), None),
+        compute_context_key(&ctx_b, Some(Path::new("/workspace-b")), None),
         "file-prefix-map old prefixes outside the key root should keep absolute identity"
     );
 }
@@ -246,8 +246,8 @@ fn cxx_context_key_with_root_normalizes_prefix_maps_in_unknown_flags() {
     ];
 
     assert_eq!(
-        compute_context_key(&ctx_a, Some(Path::new("/workspace-a"))),
-        compute_context_key(&ctx_b, Some(Path::new("/workspace-b"))),
+        compute_context_key(&ctx_a, Some(Path::new("/workspace-a")), None),
+        compute_context_key(&ctx_b, Some(Path::new("/workspace-b")), None),
         "C/C++ prefix-map flags should normalize under unknown_flags"
     );
 }
@@ -255,7 +255,7 @@ fn cxx_context_key_with_root_normalizes_prefix_maps_in_unknown_flags() {
 #[test]
 fn artifact_key_ignores_workspace_root_when_key_root_is_stable() {
     let ctx = make_context("/workspace-a/src/main.cpp", &["/workspace-a/include"], &[]);
-    let key = compute_context_key(&ctx, Some(Path::new("/workspace-a")));
+    let key = compute_context_key(&ctx, Some(Path::new("/workspace-a")), None);
     let mut hashes_a = vec![
         (
             NormalizedPath::from("/workspace-a/include/foo.h"),

--- a/crates/zccache/src/depgraph/graph/mod.rs
+++ b/crates/zccache/src/depgraph/graph/mod.rs
@@ -244,6 +244,20 @@ impl DepGraph {
 
     /// Register a compilation context with an optional key root used to
     /// normalize project-local paths across workspace renames.
+    /// Variant of [`Self::register_with_root`] that folds an optional
+    /// `worktree_salt` into the context key (issue #474). Used by the
+    /// multi-file compile path when `keys::requires_worktree_in_key` is
+    /// true for the unit. Returns only the resulting [`ContextKey`].
+    pub fn register_with_root_and_salt(
+        &self,
+        ctx: CompileContext,
+        key_root: Option<NormalizedPath>,
+        worktree_salt: Option<&Path>,
+    ) -> ContextKey {
+        self.register_with_root_and_salt_result(ctx, key_root, worktree_salt)
+            .key
+    }
+
     pub fn register_with_root(
         &self,
         ctx: CompileContext,
@@ -257,7 +271,22 @@ impl DepGraph {
         ctx: CompileContext,
         key_root: Option<NormalizedPath>,
     ) -> ContextRegistration {
-        let key = compute_context_key(&ctx, key_root.as_deref());
+        self.register_with_root_and_salt_result(ctx, key_root, None)
+    }
+
+    /// Issue #474: variant of [`Self::register_with_root_result`] that folds an
+    /// optional `worktree_salt` into the context key. Used by the C/C++
+    /// compile pipeline when `keys::requires_worktree_in_key` returns true
+    /// (PCH builds + MSVC), so the resulting cache entry is scoped to one
+    /// worktree and can't be served to a sibling clone whose embedded
+    /// paths would diverge from the artifact's.
+    pub fn register_with_root_and_salt_result(
+        &self,
+        ctx: CompileContext,
+        key_root: Option<NormalizedPath>,
+        worktree_salt: Option<&Path>,
+    ) -> ContextRegistration {
+        let key = compute_context_key(&ctx, key_root.as_deref(), worktree_salt);
         self.register_with_key_and_root_result(key, ctx, key_root)
     }
 

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -62,7 +62,7 @@ pub fn endpoint_for_cache_dir(cache_dir: &std::path::Path, namespace: Option<&st
     {
         let direct = cache_dir.join(daemon_socket_name(namespace));
         let direct = direct.to_string_lossy();
-        if direct.as_bytes().len() <= MAX_PORTABLE_UNIX_SOCKET_PATH_BYTES {
+        if direct.len() <= MAX_PORTABLE_UNIX_SOCKET_PATH_BYTES {
             return direct.into_owned();
         }
 
@@ -594,7 +594,7 @@ mod tests {
         let endpoint = endpoint_for_cache_dir(&cache_dir, Some("soldr-dev"));
 
         assert!(
-            endpoint.as_bytes().len() <= MAX_PORTABLE_UNIX_SOCKET_PATH_BYTES,
+            endpoint.len() <= MAX_PORTABLE_UNIX_SOCKET_PATH_BYTES,
             "endpoint too long: {endpoint}"
         );
         assert!(endpoint.starts_with("/tmp/zccache-"));


### PR DESCRIPTION
## Summary

Issue #474 — cross-clone cache pollution. Cached `.obj` artifacts produced in worktree A (`fastled9`) were being returned to worktree B (`fastled10`) by zccache's hit path, with the original-clone absolute paths still embedded inside. Downstream builds then failed with header-redefinition errors because the PCH-baked header path differed from the live source-tree path.

Two complementary fixes, both Docker-validated, neither disturbs the host's running zccache daemon.

### Piece A — explicit triple prefix-map for clang/gcc

`effective_compile_args` previously only injected `-ffile-prefix-map=<root>=.`. Modern clang treats that as an umbrella but older clang (< 10) and some gcc versions need `-fmacro-prefix-map` and `-fdebug-prefix-map` injected explicitly. The new code injects all three siblings together for both the worktree root and the cwd, with the existing skip-if-user-supplied guard generalised via `has_cc_prefix_map_for_old(args, flag, old)`.

Net effect: `__FILE__` strings in `.rodata` and DWARF debug info are both scrubbed on every supported toolchain, not just the modern ones.

### Piece B — per-worktree salt for PCH + MSVC

For PCH builds (`.pch` / `.gch` output) the compiler serialises absolute header paths into the AST binary; no command-line flag scrubs them. For MSVC compiles, there's no `-fmacro-prefix-map` equivalent at all. Both classes need to be cached per-worktree to prevent cross-clone leakage.

New helper in `daemon/server/keys.rs`:

```rust
pub fn requires_worktree_in_key(family, source_mode) -> bool
```

True for `(_, SourceMode::Header)` and `(CompilerFamily::Msvc, _)`.

New `compute_context_key` parameter `worktree_salt: Option<&Path>`: when `Some`, hashes a `worktree-salt\0<path>\0` domain-tagged block alongside the existing inputs. `None` (the default for clang/gcc non-PCH and all rustc compiles) is byte-identical to pre-#474 keys — so cross-worktree sharing remains intact for the common case.

`DepGraph::register_with_root_and_salt_result` (single-file) and `register_with_root_and_salt` (multi-file) thread the salt through. Pipeline + `handle_compile_multi` detect PCH-by-output-extension (`.pch`/`.gch`) and MSVC via `compilation.family`, only passing `Some(worktree_root)` for those classes.

## Test coverage (per user's "lock it in with unit tests, both cpp and rust" directive)

16 new unit tests in `daemon/server/tests/path_remap.rs`:

| Group | Coverage |
|---|---|
| Injection | macro/debug/file prefix-map flags emitted for clang, gcc; not for msvc; redundant-user-flag suppression; rustc still gets `--remap-path-prefix` |
| `requires_worktree_in_key` truth table | true for PCH-clang, PCH-gcc, MSVC-any-mode; false for clang-normal, gcc-normal, rustc |
| `compute_context_key` salt behaviour | distinct salts → distinct keys, no salt → cross-worktree-shareable keys, salt is deterministic, salt is observable (Some vs None differ) |

One existing fingerprint test updated to reflect the new triple-flag injection. Pre-existing clippy warnings (`needless_as_bytes` ×2, `assertions_on_constants` ×1) cleaned up while in the area so the clippy gate stays green.

## Validation — Docker-only

All testing via `ci/perf_local.py cargo …` (PR #475's Docker pipeline). The host's zccache daemon was never invoked. Confirmed in Docker:

- [x] 16/16 path_remap tests pass (RED-failed pre-Piece-B with 14 compile errors as predicted)
- [x] 86/86 `daemon::server::tests` pass
- [x] 50/50 `depgraph::context::tests` pass
- [x] `cargo fmt --all -- --check` is clean
- [x] `cargo clippy -p zccache --lib --tests -- -D warnings` is clean

## Trade-off

C++ PCH and MSVC compiles now do one cold rebuild per worktree (was: one broken-but-shared rebuild). Everything else (Rust + clang/gcc non-PCH) continues to share cache entries across worktrees of the same commit — the typical FastLED-class workflow is unaffected.

Follow-up filed as #477 to streamline the ad-hoc Docker invocations this PR needed.

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)
