### PR TITLE
chore(release): bump 1.11.7 -> 1.11.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.11.7"
+version = "1.11.8"
 dependencies = [
  "bincode",
  "blake3",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.11.7"
+version = "1.11.8"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.11.7"
+version = "1.11.8"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.11.7"
+version = "1.11.8"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.11.7"
+version = "1.11.8"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Ships the path-remap fix for #474 (PR #478): per-worktree key for PCH + MSVC and explicit triple prefix-map (`-ffile-prefix-map`, `-fmacro-prefix-map`, `-fdebug-prefix-map`) for clang/gcc — kills cross-clone cache pollution where `.obj` artifacts produced in worktree A leaked into worktree B with original-clone absolute paths embedded.
- Includes accumulated hit-path / mtime / clock-read perf wins (#466, #467, #469, #464, #461) and CI tooling cleanup (#475, #477, #479).
- On merge, `release-auto.yml` `detect-bump` will see 1.11.7 → 1.11.8 and ship PyPI + crates.io + GitHub release automatically.

## Test plan
- [x] Workspace cargo check clean
- [ ] PR CI green (Linux/macOS/Windows/Integration/Wrapper E2E/Clippy/Perf Cluster Rust)

🤖 Generated with [Claude Code](https://claude.com/claude-code)