### PR TITLE
fix(dylint): remove std::path::PathBuf usages flagged by ban_std_pathbuf

### DIFF
--- a/crates/zccache/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/cached_hit.rs
@@ -32,7 +32,7 @@ pub(super) struct CachedHitMaterializeRequest<'a> {
     pub(super) artifact_key_hex: &'a str,
     pub(super) source_path: &'a NormalizedPath,
     pub(super) output_path: &'a NormalizedPath,
-    pub(super) secondary_output_dir: PathBuf,
+    pub(super) secondary_output_dir: NormalizedPath,
     pub(super) compile_start: Instant,
     pub(super) hit_label: &'static str,
     pub(super) cached_error_label: &'static str,
@@ -85,7 +85,7 @@ pub(super) fn materialize_cached_compile_hit(
             let out: NormalizedPath = if i == 0 {
                 output_path.clone()
             } else {
-                secondary_output_dir.join(&names[i]).into()
+                secondary_output_dir.join(&names[i])
             };
             let cache_file = state.artifact_dir.join(format!("{artifact_key_hex}_{i}"));
             (out, cache_file)
@@ -214,7 +214,7 @@ mod tests {
             artifact_key_hex: "artifact-key",
             source_path: &source_path,
             output_path: &output_path,
-            secondary_output_dir: dir.path().to_path_buf(),
+            secondary_output_dir: dir.path().into(),
             compile_start: Instant::now(),
             hit_label: "HIT_TEST",
             cached_error_label: "CACHED_ERROR_TEST",
@@ -291,7 +291,7 @@ mod tests {
                 artifact_key_hex: "budget-key",
                 source_path: &source_path,
                 output_path: &output_path,
-                secondary_output_dir: dir.path().to_path_buf(),
+                secondary_output_dir: dir.path().into(),
                 compile_start: Instant::now(),
                 hit_label: "HIT_TEST",
                 cached_error_label: "CACHED_ERROR_TEST",

--- a/crates/zccache/src/daemon/server/handle_compile/hit_branches.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/hit_branches.rs
@@ -93,7 +93,7 @@ pub(super) fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Option<R
         artifact_key_hex,
         source_path: &source_path,
         output_path: &output_path,
-        secondary_output_dir: output_path.parent().unwrap_or(cwd).to_path_buf(),
+        secondary_output_dir: output_path.parent().unwrap_or(cwd).into(),
         compile_start,
         hit_label,
         cached_error_label: "CACHED_ERROR_REQUEST",
@@ -162,9 +162,9 @@ pub(super) fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
     }
 
     let secondary_output_dir = if is_rustc {
-        output_path.parent().unwrap_or(cwd_path).to_path_buf()
+        output_path.parent().unwrap_or(cwd_path).into()
     } else {
-        cwd_path.clone().to_path_buf()
+        cwd_path.clone()
     };
     let hit_label = if worktree_equivalent_context {
         "HIT_WORKTREE_FAST"
@@ -265,9 +265,9 @@ pub(super) fn try_depgraph_cached_hit(probe: DepgraphHitProbe<'_>) -> Option<Res
     } = probe;
 
     let secondary_output_dir = if is_rustc {
-        output_path.parent().unwrap_or(cwd_path).to_path_buf()
+        output_path.parent().unwrap_or(cwd_path).into()
     } else {
-        cwd_path.clone().to_path_buf()
+        cwd_path.clone()
     };
     let hit_label = if worktree_equivalent_context {
         "HIT_WORKTREE"

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -67,8 +67,6 @@ pub fn endpoint_for_cache_dir(cache_dir: &std::path::Path, namespace: Option<&st
         }
 
         compact_cache_dir_endpoint(cache_dir, namespace)
-            .to_string_lossy()
-            .into_owned()
     }
     #[cfg(windows)]
     {
@@ -78,15 +76,13 @@ pub fn endpoint_for_cache_dir(cache_dir: &std::path::Path, namespace: Option<&st
 }
 
 #[cfg(unix)]
-fn compact_cache_dir_endpoint(
-    cache_dir: &std::path::Path,
-    namespace: Option<&str>,
-) -> std::path::PathBuf {
+fn compact_cache_dir_endpoint(cache_dir: &std::path::Path, namespace: Option<&str>) -> String {
+    // Endpoint is a Unix socket path; return it as a `String` directly so
+    // we don't round-trip through `PathBuf` only to immediately convert
+    // back via `to_string_lossy`. The previous shape was the only
+    // `ban_std_pathbuf` lint hit in this file.
     let cache_id = crate::core::stable_path_id(cache_dir);
-    std::path::PathBuf::from(format!(
-        "/tmp/zccache-{cache_id}-{}",
-        daemon_socket_name(namespace)
-    ))
+    format!("/tmp/zccache-{cache_id}-{}", daemon_socket_name(namespace))
 }
 
 /// Derive a platform IPC endpoint for a portable private daemon name.


### PR DESCRIPTION
Dylint job on main has been failing with three `ban_std_pathbuf` findings:

- `crates/zccache/src/daemon/server/handle_compile/cached_hit.rs:35` — `secondary_output_dir: PathBuf` field
- `crates/zccache/src/ipc/mod.rs:84` — function returns `std::path::PathBuf`
- `crates/zccache/src/ipc/mod.rs:86` — `std::path::PathBuf::from(format!(...))`

This PR replaces all three with the workspace's `NormalizedPath` (or, in the ipc case, drops the PathBuf round-trip entirely since the caller immediately converted to `String`).

## Test plan

All in Docker via `ci/perf_local.py` (#477's CLI) — host zccache daemon never invoked:

- [x] `cargo check -p zccache --lib --tests` clean
- [x] `cargo clippy -p zccache --lib --tests -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --lib daemon::server::handle_compile::cached_hit` — 2 passed

CI's Dylint job will run on push-to-main; expected to go from FAIL → PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)