### PR TITLE
ci(release-auto): poll PyPI until all wheels visible before returning (closes #483)

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -442,6 +442,26 @@ jobs:
           print-hash: true
           skip-existing: true
 
+      # Issue #483: pypa/gh-action-pypi-publish uploads wheels
+      # sequentially, so downstream `uv sync` running mid-upload can
+      # cache a partial wheel set and refuse to install. Poll the PyPI
+      # JSON API until every wheel we just uploaded is visible before
+      # this job returns success.
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.preflight.outputs.checkout_ref }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Verify all wheels visible on PyPI
+        run: |
+          python -m ci.release_workflow verify-pypi \
+            --project zccache \
+            --version "${{ needs.preflight.outputs.version }}" \
+            --wheels-dir dist/wheels \
+            --timeout-s 300 \
+            --poll-interval-s 5
+
   publish-crates:
     name: Publish crates.io
     runs-on: ubuntu-latest

--- a/ci/release_workflow.py
+++ b/ci/release_workflow.py
@@ -630,6 +630,133 @@ def command_publish_crates(_: argparse.Namespace) -> None:
     publish_rust_crates(version, existing_crates)
 
 
+# ── Issue #483: post-publish PyPI verification ──────────────────────────────
+
+
+PYPI_JSON_URL_TEMPLATE = "https://pypi.org/pypi/{project}/{version}/json"
+
+
+def fetch_pypi_release_filenames(
+    project: str,
+    version: str,
+    *,
+    fetch=None,
+) -> set[str]:
+    """Return the set of file basenames PyPI currently lists for
+    ``<project>==<version>``. Returns an empty set on 404 (the release
+    isn't visible yet — caller treats that as "keep polling"). Re-raises
+    any other HTTP / network error so transient infra failures are loud,
+    not silently swallowed as missing-wheel false positives.
+
+    The ``fetch`` parameter exists so tests can inject a deterministic
+    in-memory response without touching the network. Default is a thin
+    `urllib.request.urlopen` wrapper.
+    """
+    if fetch is None:
+        def _default_fetch(url: str) -> bytes:
+            req = urllib.request.Request(url, headers={"Accept": "application/json"})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return resp.read()
+        fetch = _default_fetch
+
+    url = PYPI_JSON_URL_TEMPLATE.format(project=project, version=version)
+    try:
+        body = fetch(url)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return set()
+        raise
+    data = json.loads(body)
+    return {f["filename"] for f in data.get("urls", [])}
+
+
+def verify_pypi_publish(
+    project: str,
+    version: str,
+    expected_wheels: list[str],
+    *,
+    timeout_s: float = 300.0,
+    poll_interval_s: float = 5.0,
+    fetch=None,
+    clock=None,
+    sleep=None,
+) -> None:
+    """Poll PyPI's release JSON until every name in ``expected_wheels``
+    is visible — closing the upload-race window where downstream
+    `uv sync` would otherwise cache a partial wheel set
+    (issue #483).
+
+    Raises :class:`RuntimeError` after ``timeout_s`` if any wheel is
+    still missing. Polls every ``poll_interval_s``. The ``fetch``,
+    ``clock``, ``sleep`` parameters exist for tests; production uses
+    the stdlib defaults.
+
+    No-op when ``expected_wheels`` is empty — release_auto's wheel
+    pipeline always produces at least one wheel for a non-empty
+    release, so an empty list means caller misconfiguration and the
+    pre-check below surfaces it before we hit PyPI.
+    """
+    if not expected_wheels:
+        raise SystemExit("ERROR: verify-pypi called with no expected wheels")
+    if clock is None:
+        clock = time.monotonic
+    if sleep is None:
+        sleep = time.sleep
+
+    expected = set(expected_wheels)
+    deadline = clock() + timeout_s
+    last_seen: set[str] = set()
+    attempt = 0
+    while True:
+        attempt += 1
+        seen = fetch_pypi_release_filenames(project, version, fetch=fetch)
+        last_seen = seen
+        missing = expected - seen
+        if not missing:
+            log(
+                f"verify-pypi: all {len(expected)} wheels visible for "
+                f"{project}=={version} (attempt {attempt})"
+            )
+            return
+        # One-line progress: count of missing, plus the first few names
+        # so log readers can spot which one's lagging.
+        preview = ", ".join(sorted(missing)[:3])
+        if len(missing) > 3:
+            preview += f", … ({len(missing) - 3} more)"
+        log(
+            f"verify-pypi: attempt {attempt} — {len(seen)}/{len(expected)} "
+            f"wheels visible, waiting for: {preview}"
+        )
+        if clock() >= deadline:
+            raise RuntimeError(
+                f"verify-pypi: timed out after {timeout_s:.0f}s waiting for "
+                f"{project}=={version} on PyPI. "
+                f"Seen {len(last_seen)}/{len(expected)} wheels. "
+                f"Missing: {sorted(expected - last_seen)}"
+            )
+        sleep(poll_interval_s)
+
+
+def command_verify_pypi(args: argparse.Namespace) -> None:
+    wheels_dir = Path(args.wheels_dir).expanduser().resolve()
+    if not wheels_dir.is_dir():
+        raise SystemExit(f"ERROR: wheels directory does not exist: {wheels_dir}")
+    expected = sorted(p.name for p in wheels_dir.glob("*.whl"))
+    if not expected:
+        raise SystemExit(f"ERROR: no *.whl files found in {wheels_dir}")
+    log(
+        f"verify-pypi: checking PyPI for {len(expected)} wheel(s) of "
+        f"{args.project}=={args.version}"
+    )
+    verify_pypi_publish(
+        args.project,
+        args.version,
+        expected,
+        timeout_s=args.timeout_s,
+        poll_interval_s=args.poll_interval_s,
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Workflow-only release helpers for zccache."
@@ -658,6 +785,40 @@ def build_parser() -> argparse.ArgumentParser:
         help="Publish workspace crates in dependency order, skipping existing versions.",
     )
     crates_parser.set_defaults(func=command_publish_crates)
+
+    verify_parser = subparsers.add_parser(
+        "verify-pypi",
+        help=(
+            "Poll PyPI until every wheel in --wheels-dir is visible for "
+            "the given project/version. Closes the sequential-upload "
+            "race window where downstream `uv sync` would otherwise "
+            "cache a partial wheel set (issue #483)."
+        ),
+    )
+    verify_parser.add_argument("--project", required=True, help="PyPI project name, e.g. zccache.")
+    verify_parser.add_argument(
+        "--version",
+        required=True,
+        help="Version string that was just published, e.g. 1.11.7.",
+    )
+    verify_parser.add_argument(
+        "--wheels-dir",
+        required=True,
+        help="Local directory whose *.whl filenames define the expected set on PyPI.",
+    )
+    verify_parser.add_argument(
+        "--timeout-s",
+        type=float,
+        default=300.0,
+        help="Maximum total wait in seconds (default: 300).",
+    )
+    verify_parser.add_argument(
+        "--poll-interval-s",
+        type=float,
+        default=5.0,
+        help="Sleep between poll attempts in seconds (default: 5).",
+    )
+    verify_parser.set_defaults(func=command_verify_pypi)
 
     return parser
 

--- a/ci/tests/test_verify_pypi_publish.py
+++ b/ci/tests/test_verify_pypi_publish.py
@@ -1,0 +1,242 @@
+"""Tests for `ci.release_workflow.verify_pypi_publish` (issue #483).
+
+The function polls PyPI's release JSON until every expected wheel is
+visible, closing the upload-race window where downstream `uv sync` would
+otherwise cache a partial wheel set.
+
+These tests inject fake `fetch` / `clock` / `sleep` callables so:
+- No network is touched.
+- The clock advances deterministically without real sleeping.
+- The polling/timeout/HTTP-404-tolerance branches each get a dedicated
+  scenario.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_release_workflow():
+    # Import via a fresh module spec so a parent `from ci.release_workflow
+    # import ...` elsewhere can't shadow the version under test.
+    spec = importlib.util.spec_from_file_location(
+        "ci.release_workflow",
+        REPO_ROOT / "ci" / "release_workflow.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["ci.release_workflow"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def rw():
+    return _load_release_workflow()
+
+
+def _json_body(filenames: list[str]) -> bytes:
+    return json.dumps({"urls": [{"filename": f} for f in filenames]}).encode()
+
+
+# ── fetch_pypi_release_filenames ──────────────────────────────────────────
+
+
+def test_fetch_returns_filenames_from_json(rw) -> None:
+    expected = ["zccache-1.0-cp310-cp310-manylinux_2_17_x86_64.whl",
+                "zccache-1.0-cp310-cp310-win_amd64.whl"]
+    captured: list[str] = []
+
+    def fake_fetch(url: str) -> bytes:
+        captured.append(url)
+        return _json_body(expected)
+
+    result = rw.fetch_pypi_release_filenames("zccache", "1.0", fetch=fake_fetch)
+
+    assert result == set(expected)
+    assert captured == ["https://pypi.org/pypi/zccache/1.0/json"]
+
+
+def test_fetch_treats_404_as_empty_release(rw) -> None:
+    def fake_fetch(_url: str) -> bytes:
+        raise urllib.error.HTTPError(
+            url=_url, code=404, msg="Not Found", hdrs=None, fp=None  # type: ignore[arg-type]
+        )
+
+    result = rw.fetch_pypi_release_filenames("zccache", "9.9.9", fetch=fake_fetch)
+    assert result == set(), "404 must surface as empty so callers keep polling"
+
+
+def test_fetch_propagates_non_404_http_errors(rw) -> None:
+    def fake_fetch(_url: str) -> bytes:
+        raise urllib.error.HTTPError(
+            url=_url, code=503, msg="Service Unavailable", hdrs=None, fp=None  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(urllib.error.HTTPError):
+        rw.fetch_pypi_release_filenames("zccache", "1.0", fetch=fake_fetch)
+
+
+# ── verify_pypi_publish ────────────────────────────────────────────────────
+
+
+def test_verify_returns_immediately_when_all_wheels_visible(rw) -> None:
+    expected = ["a.whl", "b.whl", "c.whl"]
+    fetches: list[str] = []
+
+    def fake_fetch(url: str) -> bytes:
+        fetches.append(url)
+        return _json_body(expected)
+
+    sleeps: list[float] = []
+    rw.verify_pypi_publish(
+        "zccache",
+        "1.0",
+        expected,
+        timeout_s=60.0,
+        poll_interval_s=5.0,
+        fetch=fake_fetch,
+        clock=lambda: 0.0,
+        sleep=lambda s: sleeps.append(s),
+    )
+
+    assert len(fetches) == 1, "should not poll twice when everything visible on first try"
+    assert sleeps == [], "should not sleep when first poll succeeds"
+
+
+def test_verify_polls_until_all_wheels_appear(rw) -> None:
+    expected = ["a.whl", "b.whl", "c.whl"]
+    # Sequential uploads visible to us: first poll sees 1/3, second 2/3,
+    # third 3/3. Mirrors the actual `pypa/gh-action-pypi-publish` upload
+    # pattern that this fix closes the race for.
+    visibility = [["a.whl"], ["a.whl", "b.whl"], expected]
+    poll_idx = [0]
+
+    def fake_fetch(_url: str) -> bytes:
+        body = _json_body(visibility[min(poll_idx[0], len(visibility) - 1)])
+        poll_idx[0] += 1
+        return body
+
+    sleeps: list[float] = []
+    now = [0.0]
+
+    rw.verify_pypi_publish(
+        "zccache",
+        "1.0",
+        expected,
+        timeout_s=600.0,
+        poll_interval_s=5.0,
+        fetch=fake_fetch,
+        clock=lambda: now[0],
+        sleep=lambda s: (sleeps.append(s), now.__setitem__(0, now[0] + s))[1],
+    )
+
+    # Three poll attempts (1/3 → 2/3 → 3/3); two sleeps between them.
+    assert poll_idx[0] == 3
+    assert sleeps == [5.0, 5.0]
+
+
+def test_verify_raises_runtime_error_on_timeout(rw) -> None:
+    expected = ["a.whl", "b.whl"]
+
+    def fake_fetch(_url: str) -> bytes:
+        # Always partial — only one wheel ever appears.
+        return _json_body(["a.whl"])
+
+    now = [0.0]
+
+    def fake_clock() -> float:
+        return now[0]
+
+    def fake_sleep(s: float) -> None:
+        now[0] += s
+
+    with pytest.raises(RuntimeError, match=r"timed out after 30s"):
+        rw.verify_pypi_publish(
+            "zccache",
+            "1.0",
+            expected,
+            timeout_s=30.0,
+            poll_interval_s=10.0,
+            fetch=fake_fetch,
+            clock=fake_clock,
+            sleep=fake_sleep,
+        )
+
+
+def test_verify_timeout_message_lists_missing_wheels(rw) -> None:
+    expected = ["a.whl", "b.whl", "c.whl"]
+
+    def fake_fetch(_url: str) -> bytes:
+        return _json_body(["a.whl"])
+
+    now = [0.0]
+
+    def fake_clock() -> float:
+        return now[0]
+
+    def fake_sleep(s: float) -> None:
+        now[0] += s
+
+    with pytest.raises(RuntimeError) as excinfo:
+        rw.verify_pypi_publish(
+            "zccache",
+            "1.0",
+            expected,
+            timeout_s=10.0,
+            poll_interval_s=20.0,
+            fetch=fake_fetch,
+            clock=fake_clock,
+            sleep=fake_sleep,
+        )
+
+    msg = str(excinfo.value)
+    assert "b.whl" in msg
+    assert "c.whl" in msg
+    assert "a.whl" not in msg, "the seen wheel should not appear in the missing list"
+
+
+def test_verify_rejects_empty_expected_list(rw) -> None:
+    # Empty list = caller bug (e.g. wheels-dir was empty). Surface it
+    # before we hit PyPI; the workflow should fail loudly, not poll
+    # forever / accept whatever happens to be there.
+    with pytest.raises(SystemExit, match="no expected wheels"):
+        rw.verify_pypi_publish("zccache", "1.0", [], fetch=lambda _u: _json_body([]))
+
+
+def test_verify_tolerates_initial_404(rw) -> None:
+    # Realistic timing: PyPI's release JSON is 404 for a brief window
+    # after the first wheel uploads (cache propagation). The fix must
+    # poll through that, not bail.
+    expected = ["a.whl"]
+    state = {"calls": 0}
+
+    def fake_fetch(_url: str) -> bytes:
+        state["calls"] += 1
+        if state["calls"] == 1:
+            raise urllib.error.HTTPError(
+                url=_url, code=404, msg="Not Found", hdrs=None, fp=None  # type: ignore[arg-type]
+            )
+        return _json_body(expected)
+
+    now = [0.0]
+    rw.verify_pypi_publish(
+        "zccache",
+        "1.0",
+        expected,
+        timeout_s=60.0,
+        poll_interval_s=1.0,
+        fetch=fake_fetch,
+        clock=lambda: now[0],
+        sleep=lambda s: now.__setitem__(0, now[0] + s),
+    )
+
+    assert state["calls"] == 2


### PR DESCRIPTION
Closes #483.

`pypa/gh-action-pypi-publish` uploads wheels sequentially. With 6 wheels per zccache release this opens a ~12-18 s window where the PyPI JSON API returns a partial wheel set. Downstream consumers (`uv sync`, pip wheel cache, etc.) resolving during that window can cache a "no wheel for this platform" failure that survives until the consumer manually clears their cache. `fbuild 2.2.10` hit this on Windows last night — receipts in the issue body.

## Fix

After `pypa/gh-action-pypi-publish` returns, poll PyPI's release JSON until every locally-built wheel filename is visible. 300 s timeout (default), 5 s poll interval. The job fails loudly if any wheel is still missing at deadline, instead of returning success while the registry's view is inconsistent.

## Shape

New `verify-pypi` subcommand on `ci/release_workflow.py`:

```
python -m ci.release_workflow verify-pypi   --project zccache   --version "$VERSION"   --wheels-dir dist/wheels   --timeout-s 300   --poll-interval-s 5
```

Two helpers split for testability:

- `fetch_pypi_release_filenames(project, version, fetch=...)` — one GET; 404 → empty (keep polling); 5xx → propagate (loud transient).
- `verify_pypi_publish(project, version, expected, fetch=, clock=, sleep=)` — the polling loop with injectable time/network so tests are deterministic and offline.

## Test plan

9 pytest tests in `ci/tests/test_verify_pypi_publish.py`:

- ✅ `uv run pytest ci/tests/test_verify_pypi_publish.py` — 9/9 pass

Scenarios covered: filename extraction; 404 tolerance; non-404 propagation; immediate-success no-poll; sequential 1/N → 2/N → N/N polling; timeout RuntimeError; timeout-message content; empty-list rejection; initial-404 then success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)