### PR TITLE
chore(ci): revert logging:true on Integration job (#282 closed)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,13 +61,6 @@ jobs:
           # restored build-cache so the daemon-isolated test phase starts warm.
           seed-isolated-build-cache: ${{ runner.temp }}/zccache-self-tests/integration
           verify-compile-cache: warn
-          # zackees/setup-soldr#282: this job restored 5,454 cook artifacts
-          # but produced hit_rate=0.0% on the subsequent compile. logging:true
-          # emits the [compile_journal] block in the post step (miss_reasons
-          # histogram + slowest_misses with per-record miss_diff). Confirmed
-          # zero key-impact (setup-soldr#247), so enabling it does NOT cold
-          # any cache layer. Remove once #282 is root-caused.
-          logging: true
       - name: Build integration test binaries
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run


### PR DESCRIPTION
#282 is closed (build-cache cap raise unblocked the save → 100% hit rate on follow-up). Reverting logging:true so per-run logs don't carry unnecessary [compile_journal] payload.