### PR TITLE
ci: bump setup-soldr to v0.9.34 (sub-phase timing)

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.33
+      - uses: zackees/setup-soldr@v0.9.34
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.33
+      - uses: zackees/setup-soldr@v0.9.34
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.33
+      - uses: zackees/setup-soldr@v0.9.34
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.33
+      - uses: zackees/setup-soldr@v0.9.34
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.33
+        uses: zackees/setup-soldr@v0.9.34
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.33
+      - uses: zackees/setup-soldr@v0.9.34
         with:
           zccache-seed-strict: true
           cache: true
@@ -126,7 +126,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.33
+      - uses: zackees/setup-soldr@v0.9.34
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.33
+      - uses: zackees/setup-soldr@v0.9.34
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.33
+      - uses: zackees/setup-soldr@v0.9.34
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.33
+      - uses: zackees/setup-soldr@v0.9.34
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.33
+      - uses: zackees/setup-soldr@v0.9.34
         with:
           zccache-seed-strict: true
           cache: false
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.33
+      - uses: zackees/setup-soldr@v0.9.34
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@v0.9.33
+        uses: zackees/setup-soldr@v0.9.34
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@v0.9.33
+        uses: zackees/setup-soldr@v0.9.34
         with:
           zccache-seed-strict: true
           cache: true


### PR DESCRIPTION
Picks up sub-phase timing observability (setup-soldr#302). The next warm CI run on this branch should print:

\`\`\`
setup phase totals: resolve=Xs {rustup_probe=Xs toolchain_spec=Xs ws_hash=Xs lock_hash=Xs}
  toolchain=Ys {rustup_install=Ys solo_restore=Ys snapshot_pre/base/post=Ys} ...
\`\`\`

Validates end-to-end on a real consumer workload (not just the setup-soldr demo) and supplies the data for the next perf-target decision (setup-soldr#304 — rustup-probe caching; #305 — solo-toolchain-cache short-circuit on exact-hit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)