### PR TITLE
ci: bump setup-soldr to v0.9.35 (FS-first rustup probe, ~7s warm-run win)

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.34
+      - uses: zackees/setup-soldr@v0.9.35
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.34
+      - uses: zackees/setup-soldr@v0.9.35
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.34
+      - uses: zackees/setup-soldr@v0.9.35
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.34
+      - uses: zackees/setup-soldr@v0.9.35
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.34
+        uses: zackees/setup-soldr@v0.9.35
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.34
+      - uses: zackees/setup-soldr@v0.9.35
         with:
           zccache-seed-strict: true
           cache: true
@@ -126,7 +126,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.34
+      - uses: zackees/setup-soldr@v0.9.35
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.34
+      - uses: zackees/setup-soldr@v0.9.35
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.34
+      - uses: zackees/setup-soldr@v0.9.35
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.34
+      - uses: zackees/setup-soldr@v0.9.35
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.34
+      - uses: zackees/setup-soldr@v0.9.35
         with:
           zccache-seed-strict: true
           cache: false
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.34
+      - uses: zackees/setup-soldr@v0.9.35
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@v0.9.34
+        uses: zackees/setup-soldr@v0.9.35
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@v0.9.34
+        uses: zackees/setup-soldr@v0.9.35
         with:
           zccache-seed-strict: true
           cache: true


### PR DESCRIPTION
Picks up setup-soldr#304 / #308 — the warm-run resolve phase that was ~7s on v0.9.34 (\`rustup toolchain list\` subprocess spawn) should now drop to ~0s (\`readdirSync(\$RUSTUP_HOME/toolchains)\`).

## Expected validation
The post-merge CI run should show on each warm Linux job:

\`\`\`
setup phase totals: resolve=0.1s {rustup_probe=0.0s ...} toolchain=Ys ...
\`\`\`

instead of the prior \`resolve=7.1s {rustup_probe=7.0s ...}\`.

If validation passes, that's a clean ~7s cut from every warm CI run on this repo.

## Restore branch
After merge, the original branch must be deleted (and \`main\` updated locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)