### PR TITLE
fix(cli): unblock zccache analyze and kv (wrap-mode misroute)

### DIFF
--- a/crates/zccache/src/cli/commands/args.rs
+++ b/crates/zccache/src/cli/commands/args.rs
@@ -779,10 +779,18 @@ pub(crate) enum RustPlanBackendArg {
 }
 
 /// Known subcommand names for auto-detect.
+///
+/// MUST stay in sync with the `Commands` enum below — any name added to
+/// the enum without being listed here gets routed into wrap mode (the
+/// `mod.rs` auto-detect path) and surfaces as "daemon error: failed to
+/// run compiler: program not found" instead of dispatching normally. The
+/// `known_subcommands_matches_clap_enum` test in
+/// `cli/commands/tests/args_parsing.rs` enforces this contract.
 pub(crate) const KNOWN_SUBCOMMANDS: &[&str] = &[
     "start",
     "stop",
     "status",
+    "analyze",
     "clear",
     "wrap",
     "inspect",
@@ -796,6 +804,7 @@ pub(crate) const KNOWN_SUBCOMMANDS: &[&str] = &[
     "cargo-registry",
     "gha-cache",
     "rust-plan",
+    "kv",
     "warm",
     "snapshot-bytes",
     "snapshot-fp-record",

--- a/crates/zccache/src/cli/commands/tests/args_parsing.rs
+++ b/crates/zccache/src/cli/commands/tests/args_parsing.rs
@@ -4,7 +4,7 @@
 //! — adding/renaming a flag should require touching one of the assertions
 //! here.
 
-use super::super::args::{Cli, Commands, RustPlanBackendArg, RustPlanCommands};
+use super::super::args::{Cli, Commands, RustPlanBackendArg, RustPlanCommands, KNOWN_SUBCOMMANDS};
 use super::super::rust_plan::rust_plan_gha_version;
 use super::super::session::{
     session_stats_error_json, session_stats_json, session_stats_unavailable_json,
@@ -331,4 +331,49 @@ fn rust_plan_gha_version_is_stable_for_backend_diagnostics() {
     let key = "rust-plan-v1-test";
     assert_eq!(rust_plan_gha_version(key), rust_plan_gha_version(key));
     assert_ne!(rust_plan_gha_version(key), rust_plan_gha_version("other"));
+}
+
+/// Locks the auto-detect contract: every name in the `Commands` clap enum
+/// MUST be listed in `KNOWN_SUBCOMMANDS`, otherwise `mod.rs::run` treats
+/// the subcommand as a compiler invocation and surfaces "daemon error:
+/// failed to run compiler: program not found" instead of dispatching. This
+/// drift previously hid `zccache analyze` and `zccache kv` for users.
+#[test]
+fn known_subcommands_matches_clap_enum() {
+    use clap::CommandFactory;
+    let cmd = Cli::command();
+    let clap_subs: std::collections::BTreeSet<String> = cmd
+        .get_subcommands()
+        .map(|s| s.get_name().to_string())
+        .collect();
+    let known: std::collections::BTreeSet<String> = KNOWN_SUBCOMMANDS
+        .iter()
+        .filter(|s| !s.starts_with('-'))
+        // `help` is a clap-managed meta-subcommand that doesn't appear in the
+        // `Commands` enum but is still a valid invocation we want auto-detect
+        // to recognize, so keep it in KNOWN_SUBCOMMANDS without requiring it
+        // in the enum.
+        .filter(|s| **s != "help")
+        .map(|s| s.to_string())
+        .collect();
+
+    let missing: Vec<&String> = clap_subs.difference(&known).collect();
+    assert!(
+        missing.is_empty(),
+        "KNOWN_SUBCOMMANDS is missing {} clap subcommand(s): {:?}. \
+         Without these entries, `zccache <name>` falls through to wrap mode \
+         and fails with 'failed to run compiler: program not found'. Add them \
+         to KNOWN_SUBCOMMANDS in args.rs.",
+        missing.len(),
+        missing,
+    );
+
+    let stale: Vec<&String> = known.difference(&clap_subs).collect();
+    assert!(
+        stale.is_empty(),
+        "KNOWN_SUBCOMMANDS lists {} name(s) not in the clap Commands enum: {:?}. \
+         Either re-add the subcommand or drop the stale entry.",
+        stale.len(),
+        stale,
+    );
 }


### PR DESCRIPTION
## Summary

- `zccache analyze` and `zccache kv` both failed with `daemon error: failed to run compiler: program not found` because `KNOWN_SUBCOMMANDS` (hand-maintained list in `cli/commands/args.rs`) had drifted from the clap `Commands` enum and was missing both names.
- The auto-detect dispatcher in `cli/commands/mod.rs:50-58` treats any first arg not in the list as a compiler invocation and routes it through the wrap path, which then tried to exec `analyze` / `kv` as compilers.
- Fix adds both names. Also adds a regression test that uses `CommandFactory` to diff the clap enum against `KNOWN_SUBCOMMANDS` so the next subcommand added to the enum can't silently fall through to wrap mode.

This unblocks `soldr cache report`, which shells out to `zccache analyze` — so perf-diagnosis workflows are usable again. Fixes #506.

## Test plan

- [x] `soldr cargo test -p zccache --lib known_subcommands_matches_clap_enum` passes
- [x] Built binary `zccache analyze --help` prints subcommand usage (no more daemon error)
- [x] Built binary `zccache kv --help` prints subcommand usage (no more daemon error)
- [x] `soldr cargo clippy -p zccache --lib --tests -- -D warnings` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)