### PR TITLE
perf(ci): enable solo-toolchain-cache on hot jobs (setup-soldr#305, ~8s warm-run win × 5 jobs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
           build-cache: false
           linker: fast
           prebuild-deps: none
+          # setup-soldr#305: enable solo-toolchain-cache so warm runs
+          # restore the rustup-installed toolchain from a tiny long-lived
+          # cache instead of paying ~8s for `rustup toolchain install`
+          # every time. Cache key is (rustc release × components × targets
+          # × soldr version) — invalidates only on real toolchain bumps.
+          solo-toolchain-cache: true
       - name: Install Rust components
         run: soldr rustup component add rustfmt
       - name: Check formatting
@@ -116,6 +122,8 @@ jobs:
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
           verify-compile-cache: warn
+          # setup-soldr#305: see Formatting job comment above.
+          solo-toolchain-cache: true
       - name: Check MSRV
         run: soldr cargo check --workspace
 
@@ -136,5 +144,7 @@ jobs:
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
           verify-compile-cache: warn
+          # setup-soldr#305: see Formatting job comment above.
+          solo-toolchain-cache: true
       - name: Build docs
         run: soldr cargo doc --workspace --no-deps

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -35,6 +35,8 @@ jobs:
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
           verify-compile-cache: warn
+          # setup-soldr#305: see Formatting job comment in ci.yml.
+          solo-toolchain-cache: true
       - name: Install Clippy
         run: soldr rustup component add clippy
       - name: Run Clippy

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,12 +37,14 @@ jobs:
           # build-cache so the daemon-isolated llvm-cov phase starts warm.
           seed-isolated-build-cache: ${{ runner.temp }}/zccache-self-tests/coverage
           verify-compile-cache: warn
+          # setup-soldr#305: see Formatting job comment in ci.yml.
+          solo-toolchain-cache: true
       - name: Install Rust coverage component
         run: soldr rustup component add llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Stop setup-soldr builder cache before coverage tests
-        uses: zackees/setup-soldr/cleanup@v0.9.33
+        uses: zackees/setup-soldr/cleanup@v0.9.35
       - name: Generate coverage
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,11 +61,15 @@ jobs:
           # restored build-cache so the daemon-isolated test phase starts warm.
           seed-isolated-build-cache: ${{ runner.temp }}/zccache-self-tests/integration
           verify-compile-cache: warn
+          # setup-soldr#305: skip the ~8s `rustup toolchain install` on
+          # warm runs by restoring the toolchain delta from a tiny
+          # long-lived cache.
+          solo-toolchain-cache: true
       - name: Build integration test binaries
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.33
+        uses: zackees/setup-soldr/cleanup@v0.9.35
       - name: Test (full workspace)
         shell: bash
         env:


### PR DESCRIPTION
## Summary
Sets \`solo-toolchain-cache: true\` on the Linux jobs that pin toolchain 1.94.1: Formatting, MSRV, Documentation, Clippy, Coverage, Integration. Same key across them — one tiny shared slot.

## Motivation
setup-soldr#302 sub-phase data on v0.9.35 (real numbers from CI runs on \`28a242b\`):

\`\`\`
linux/Test:  resolve=0.0s  toolchain=8.0s {rustup_install=8.0s ...}  cook=2.7s  total=14.8s
linux/Check: resolve=0.0s  toolchain=8.0s {rustup_install=8.0s ...}  cook=4.5s  total=16.3s
\`\`\`

After the v0.9.35 cascade (#304/#308) eliminated \`resolve\` entirely (down from 7.1s), \`toolchain=8.0s {rustup_install=8.0s}\` is now the dominant warm-run cost. The cache that would skip that install — solo-toolchain-cache — is off by default in setup-soldr because it was marked experimental during validation. This PR opts in on zccache and lets us measure the win.

## Expected validation
After the cold-save cycle, the warm \`toolchain\` phase should drop:
\`\`\`
toolchain=8.0s {rustup_install=8.0s ...}
\`\`\`
to
\`\`\`
toolchain=~0.5s {rustup_install=~0.0s solo_restore=~0.3s ...}
\`\`\`

Per-job win ~7.5s × 5 jobs = ~37.5s of CI wall clock saved per push.

## Followup
If the win materializes, file a setup-soldr PR to flip the default to \`true\` in action.yml so all consumers get it without opt-in.

## Bonus
Also bumps stale \`zackees/setup-soldr/cleanup\` subaction pin from v0.9.33 → v0.9.35 in integration.yml + coverage.yml (was missed in the v0.9.34/v0.9.35 cascades).

🤖 Generated with [Claude Code](https://claude.com/claude-code)