### PR TITLE
fix(persist): retry artifact rename through AV-scanner share lock on Windows

### DIFF
--- a/crates/zccache/src/daemon/server/persist.rs
+++ b/crates/zccache/src/daemon/server/persist.rs
@@ -250,14 +250,52 @@ pub(super) fn replace_artifact_cache_file(
     tmp_path: &Path,
     cache_path: &Path,
 ) -> std::io::Result<()> {
-    match std::fs::rename(tmp_path, cache_path) {
+    av_scan_retry(|| match std::fs::rename(tmp_path, cache_path) {
         Ok(()) => Ok(()),
         Err(_) if cache_path.exists() => {
             std::fs::remove_file(cache_path)?;
             std::fs::rename(tmp_path, cache_path)
         }
         Err(err) => Err(err),
+    })
+}
+
+// ── Windows AV-scanner retry (issue #490) ──────────────────────────────────
+//
+// Defender / EDR tools open just-written files for an inline scan with a
+// restrictive share mode and no `FILE_SHARE_DELETE`, so any `MoveFileExW` /
+// `DeleteFileW` against the target during the scan window fails with
+// `ERROR_ACCESS_DENIED` (5) or `ERROR_SHARING_VIOLATION` (32). The scan window
+// is short — typically tens to a few hundred milliseconds — so a bounded
+// back-off retry absorbs the race without papering over real ACL failures
+// (those persist past the budget and surface to the caller unchanged).
+
+#[cfg(windows)]
+const AV_SCAN_RETRY_DELAYS_MS: &[u64] = &[50, 100, 250, 500];
+
+#[cfg(windows)]
+fn is_av_scan_transient(err: &std::io::Error) -> bool {
+    if matches!(err.kind(), std::io::ErrorKind::PermissionDenied) {
+        return true;
     }
+    matches!(err.raw_os_error(), Some(5) | Some(32))
+}
+
+#[cfg(windows)]
+fn av_scan_retry<T, F>(mut op: F) -> std::io::Result<T>
+where
+    F: FnMut() -> std::io::Result<T>,
+{
+    for &delay in AV_SCAN_RETRY_DELAYS_MS {
+        match op() {
+            Ok(value) => return Ok(value),
+            Err(err) if is_av_scan_transient(&err) => {
+                std::thread::sleep(std::time::Duration::from_millis(delay));
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    op()
 }
 
 /// Write cached output to disk. Optimized syscall sequence:

--- a/crates/zccache/src/daemon/server/tests/write_cached.rs
+++ b/crates/zccache/src/daemon/server/tests/write_cached.rs
@@ -274,3 +274,87 @@ fn write_cached_output_fallback_has_fresh_mtime() {
         "fallback path should produce fresh mtime — {diff}s old"
     );
 }
+
+// ── Issue #490: AV-scanner rename race ─────────────────────────────
+//
+// On Windows, Defender (MsMpEng) opens just-written files for an inline scan
+// with `FILE_SHARE_READ` only — no `FILE_SHARE_DELETE`. While that handle is
+// live, `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` and `DeleteFileW` against the
+// target file return `ERROR_ACCESS_DENIED` (raw OS error 5) or
+// `ERROR_SHARING_VIOLATION` (32). The scan window is short — typically tens to
+// hundreds of milliseconds — so a bounded retry absorbs it.
+//
+// This test simulates the scanner by holding the rename destination open with
+// the same restrictive share mode from a separate thread that releases the
+// handle shortly. The pre-fix code path fails immediately at the first
+// `remove_file` call inside `replace_artifact_cache_file`; the retry must
+// outlive the held handle.
+
+#[cfg(windows)]
+#[test]
+fn replace_artifact_cache_file_retries_through_av_scanner_lock() {
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("output.obj");
+    let tmp = dir.path().join("output.obj.tmp");
+
+    std::fs::write(&target, b"OLD").unwrap();
+    std::fs::write(&tmp, b"NEW").unwrap();
+
+    // FILE_SHARE_READ (0x1) only — no SHARE_WRITE, no SHARE_DELETE.
+    // This is the exact share mode Defender uses during real-time inline
+    // scans, which is why ninja's subsequent remove fails in the wild.
+    let handle = std::fs::OpenOptions::new()
+        .read(true)
+        .share_mode(0x1)
+        .open(&target)
+        .expect("open lock handle");
+
+    let released = Arc::new(AtomicBool::new(false));
+    let released_clone = Arc::clone(&released);
+    let worker = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(150));
+        drop(handle);
+        released_clone.store(true, Ordering::SeqCst);
+    });
+
+    // Without the retry, this fails immediately at the inner remove_file with
+    // ERROR_ACCESS_DENIED. With the retry, the closure retries past the
+    // 150 ms hold and succeeds.
+    replace_artifact_cache_file(&tmp, &target).expect("replace must absorb the simulated AV lock");
+
+    worker.join().unwrap();
+    assert!(
+        released.load(Ordering::SeqCst),
+        "worker must have released the lock before the call returned",
+    );
+    assert_eq!(std::fs::read(&target).unwrap(), b"NEW");
+}
+
+// Negative guard: a NotFound (or any other non-transient) error must surface
+// immediately rather than burning the retry budget. Without this assertion,
+// a misclassified `ErrorKind` could silently inflate every cache-store
+// failure path by ~1 s.
+#[cfg(windows)]
+#[test]
+fn replace_artifact_cache_file_does_not_retry_non_transient_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("output.obj");
+    let tmp = dir.path().join("missing.obj.tmp"); // tmp does NOT exist
+
+    // Neither file exists; rename returns ENOENT/NotFound — not a share
+    // violation. The call must fail promptly, not after the full budget.
+    let start = std::time::Instant::now();
+    let err = replace_artifact_cache_file(&tmp, &target).expect_err("must propagate NotFound");
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < std::time::Duration::from_millis(45),
+        "non-transient errors must not enter the retry sleep — took {elapsed:?}"
+    );
+    assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+}


### PR DESCRIPTION
## Summary

- Wrap the Windows variant of `replace_artifact_cache_file` in a bounded retry (50 / 100 / 250 / 500 ms, ~900 ms total) that absorbs the `ERROR_ACCESS_DENIED` (5) / `ERROR_SHARING_VIOLATION` (32) race against Defender's inline scan of just-written files.
- Retry only on `PermissionDenied` and raw OS error 5/32 — `NotFound` and other real failures propagate immediately, so this does not slow real errors.
- No behavior change on Unix; the helpers (`av_scan_retry`, `is_av_scan_transient`) and the test are `#[cfg(windows)]` only.

## Test plan

- [x] RED test in `tests/write_cached.rs::replace_artifact_cache_file_retries_through_av_scanner_lock` — pre-fix fails immediately with `Os { code: 32, ... "being used by another process" }`, the exact failure mode reported in #490. Post-fix: succeeds.
- [x] Negative guard `replace_artifact_cache_file_does_not_retry_non_transient_errors` — `NotFound` returns in <45 ms, well under the 900 ms budget.
- [x] All 12 `write_cached` tests pass.
- [x] `soldr cargo clippy -p zccache --lib --tests -- -D warnings` clean.
- [x] `soldr cargo fmt --all -- --check` clean.

Fixes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)