### PR TITLE
fix(request-cache): scope worktree-bound entries to their originating root

### DIFF
--- a/crates/zccache/src/daemon/server/handle_compile/hit_branches.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/hit_branches.rs
@@ -118,6 +118,7 @@ pub(super) struct FastHitProbe<'a> {
     pub(super) client_env: Option<&'a [(String, String)]>,
     pub(super) is_rustc: bool,
     pub(super) worktree_equivalent_context: bool,
+    pub(super) worktree_bound: bool,
     pub(super) compile_start: Instant,
     pub(super) parse_args_ns: u64,
     pub(super) build_context_ns: u64,
@@ -139,6 +140,7 @@ pub(super) fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
         client_env,
         is_rustc,
         worktree_equivalent_context,
+        worktree_bound,
         compile_start,
         parse_args_ns,
         build_context_ns,
@@ -210,6 +212,7 @@ pub(super) fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
             output_path,
             input_paths,
             request_cache_key_root.as_ref(),
+            worktree_bound,
         ),
     );
     Some(response)
@@ -231,6 +234,7 @@ pub(super) struct DepgraphHitProbe<'a> {
     pub(super) client_env: Option<&'a [(String, String)]>,
     pub(super) is_rustc: bool,
     pub(super) worktree_equivalent_context: bool,
+    pub(super) worktree_bound: bool,
     pub(super) compile_start: Instant,
     pub(super) parse_args_ns: u64,
     pub(super) build_context_ns: u64,
@@ -256,6 +260,7 @@ pub(super) fn try_depgraph_cached_hit(probe: DepgraphHitProbe<'_>) -> Option<Res
         client_env,
         is_rustc,
         worktree_equivalent_context,
+        worktree_bound,
         compile_start,
         parse_args_ns,
         build_context_ns,
@@ -325,6 +330,7 @@ pub(super) fn try_depgraph_cached_hit(probe: DepgraphHitProbe<'_>) -> Option<Res
                 output_path,
                 input_paths,
                 request_cache_key_root.as_ref(),
+                worktree_bound,
             ),
         );
     }

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
@@ -238,9 +238,14 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     } else {
         crate::compiler::SourceMode::Normal
     };
-    let worktree_salt = if worktree_root.is_some()
-        && requires_worktree_in_key(compilation.family, source_mode_for_key)
-    {
+    // Issue #489: PCH/MSVC artifacts embed absolute paths the path-remap
+    // family can't scrub, so the request-level cache must refuse to share
+    // their entries across worktrees regardless of how root-relative the
+    // captured paths look. `requires_worktree_in_key` is the single source
+    // of truth — we mirror it here into both the context-key salt and the
+    // request-cache `worktree_bound` flag so the two cache layers agree.
+    let worktree_bound = requires_worktree_in_key(compilation.family, source_mode_for_key);
+    let worktree_salt = if worktree_root.is_some() && worktree_bound {
         Some(default_key_root.as_path())
     } else {
         None
@@ -337,6 +342,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         client_env: client_env.as_deref(),
         is_rustc,
         worktree_equivalent_context,
+        worktree_bound,
         compile_start,
         parse_args_ns,
         build_context_ns,
@@ -545,6 +551,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 client_env: client_env.as_deref(),
                 is_rustc,
                 worktree_equivalent_context,
+                worktree_bound,
                 compile_start,
                 parse_args_ns,
                 build_context_ns,

--- a/crates/zccache/src/daemon/server/keys.rs
+++ b/crates/zccache/src/daemon/server/keys.rs
@@ -454,12 +454,22 @@ pub(super) fn request_cache_input_paths(
     paths
 }
 
+/// Build a request-cache entry.
+///
+/// `worktree_bound` must be `true` for any artifact whose bytes embed
+/// absolute paths that no remap pass scrubs — PCH/GCH (`-include`-baked
+/// header AST) and MSVC compiles (PDB/`/Fp`/`/Fd` paths). Setting it forces
+/// `cross_root_shareable = false`, so the entry only matches lookups from
+/// its originating worktree even when every captured path is technically
+/// root-relative. See [`requires_worktree_in_key`] for the truth table and
+/// issue #489 for the diagnostic / DLL-load failure that motivated this.
 pub(super) fn request_cache_entry(
     context_key: ContextKey,
     source_path: &NormalizedPath,
     output_path: &NormalizedPath,
     input_paths: Vec<NormalizedPath>,
     key_root: Option<&NormalizedPath>,
+    worktree_bound: bool,
 ) -> RequestCacheEntry {
     let root = key_root.cloned();
     let root_path = key_root.map(|root| root.as_path());
@@ -469,7 +479,8 @@ pub(super) fn request_cache_entry(
         .iter()
         .map(|path| CachedRequestPath::capture(path, root_path))
         .collect();
-    let cross_root_shareable = root.is_some()
+    let cross_root_shareable = !worktree_bound
+        && root.is_some()
         && source_path.is_root_relative()
         && output_path.is_root_relative()
         && input_paths.iter().all(CachedRequestPath::is_root_relative);

--- a/crates/zccache/src/daemon/server/tests/cache_trim.rs
+++ b/crates/zccache/src/daemon/server/tests/cache_trim.rs
@@ -212,6 +212,7 @@ fn request_cache_resolved_inputs_requires_cross_root_shareable_entry() {
         &output_a,
         vec![source_a.clone(), header_a],
         Some(&NormalizedPath::new(&root_a)),
+        false,
     );
 
     let resolved = request_cache_resolved_inputs(&entry, &NormalizedPath::new(&root_b)).unwrap();
@@ -223,6 +224,69 @@ fn request_cache_resolved_inputs_requires_cross_root_shareable_entry() {
             NormalizedPath::new(root_b.join("include/common.h")),
         ]
     );
+}
+
+// Issue #489: PCH (and MSVC) artifacts bake absolute include paths into the
+// compiled output. `path_remap=off` does not change that — there is no
+// `-ffile-prefix-map` family of scrubbers that touches the PCH AST table. So
+// even when every captured path looks root-relative, a request-level cache
+// entry tagged `worktree_bound` must NEVER be served across worktrees, or the
+// HIT serves a PCH whose embedded paths reference the original worktree.
+//
+// Before the fix, `cross_root_shareable` was derived solely from "are all
+// paths root-relative?" — which is `true` for PCH (the `.h` lives inside the
+// worktree), so a stale fastled10 PCH leaked into a fastled7 build and
+// produced compiler diagnostics referencing `fastled10` paths + downstream
+// DLL load failures (Windows error 126).
+#[test]
+fn request_cache_entry_worktree_bound_rejects_cross_worktree_match() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root_a = NormalizedPath::new(tmp.path().join("fastled10"));
+    let root_b = NormalizedPath::new(tmp.path().join("fastled7"));
+    let source_a: NormalizedPath = root_a.as_path().join("src/FastLED.h").into();
+    let output_a: NormalizedPath = root_a
+        .as_path()
+        .join(".build/meson-quick/ci/meson/native/FastLED.h.pch")
+        .into();
+
+    let pch_entry = request_cache_entry(
+        test_context_key("src/FastLED.h"),
+        &source_a,
+        &output_a,
+        vec![source_a.clone()],
+        Some(&root_a),
+        true,
+    );
+
+    // Same-root lookup: still HITs (sanity).
+    assert!(request_cache_entry_matches_root(&pch_entry, Some(&root_a)));
+
+    // Cross-root lookup: MUST NOT hit, even though every captured path was
+    // root-relative when the entry was built.
+    assert!(
+        !request_cache_entry_matches_root(&pch_entry, Some(&root_b)),
+        "PCH entries are worktree-bound and must not match across worktrees",
+    );
+    assert!(
+        !pch_entry.cross_root_shareable,
+        "worktree-bound entries must opt out of cross-root sharing entirely",
+    );
+
+    // Sanity contrast: an otherwise-identical NON-PCH entry (`worktree_bound = false`)
+    // remains cross-root-shareable. The flag is the single discriminator.
+    let object_entry = request_cache_entry(
+        test_context_key("src/main.cc"),
+        &source_a,
+        &output_a,
+        vec![source_a.clone()],
+        Some(&root_a),
+        false,
+    );
+    assert!(request_cache_entry_matches_root(
+        &object_entry,
+        Some(&root_b)
+    ));
+    assert!(object_entry.cross_root_shareable);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add `worktree_bound: bool` to `request_cache_entry`. When `true`, force `cross_root_shareable = false` regardless of path layout — so PCH / GCH / MSVC entries can never be served as cross-worktree HITs even when every captured path is technically root-relative.
- Derive the flag in `pipeline.rs` from the same `requires_worktree_in_key(family, source_mode)` predicate that already gates the depgraph context-key salt. Both cache layers now agree by construction.
- Plumb through `FastHitProbe` / `DepgraphHitProbe`.

## Why

A build in worktree `fastled10` populated a `FastLED.h.pch` request-cache entry whose fingerprint then matched a `--clean` rebuild in sibling worktree `fastled7`. The HIT replayed a PCH carrying baked `fastled10` paths into the `fastled7` build, surfacing as compiler diagnostics referencing the wrong worktree + a deterministic set of nine DLLs failing to load with Windows `ERROR_MOD_NOT_FOUND` (126). The depgraph context-key already handled this via the worktree salt, but the request-level fast path skipped the same gate.

## Test plan

- [x] TDD RED → GREEN with `request_cache_entry_worktree_bound_rejects_cross_worktree_match` in `tests/cache_trim.rs`:
  - Pre-fix: doesn't compile (signature mismatch — wired into the call).
  - Post-fix: PCH entry (`worktree_bound=true`) does NOT match a different root; otherwise-identical non-PCH entry (`worktree_bound=false`) still matches. The flag is the single discriminator.
- [x] All 15 `cache_trim` tests green.
- [x] All 85 `daemon::server::tests` green.
- [x] `soldr cargo clippy -p zccache --lib --tests -- -D warnings` clean.
- [x] `soldr cargo fmt --all -- --check` clean.

Fixes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)