### PR TITLE
ci(cache-cleanup): switch to count-based policy, drop age filter (#320)

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -22,10 +22,16 @@ jobs:
     permissions:
       actions: write
     steps:
-      - name: Prune cook-delta entries (keep newest 3, prune >24h old)
+      - name: Prune cook-delta entries (keep newest 5, prune the rest)
         uses: actions/github-script@v7
         with:
           script: |
+            // First iteration used a 24h age filter, but real data
+            // (21 entries accumulated in < 24h) showed cook-deltas
+            // arrive faster than the age filter prunes. Switch to a
+            // count-based policy: keep the 5 most recent, prune all
+            // older regardless of age. The 5-entry window covers
+            // recent push + retry + ~3 in-flight PRs.
             const repo = context.repo;
             const caches = await github.paginate(
               github.rest.actions.getActionsCacheList,
@@ -35,11 +41,7 @@ jobs:
               c.key && c.key.startsWith("cook-delta-v2-")
             );
             console.log(`Found ${cookDeltas.length} cook-delta entries`);
-            const candidates = cookDeltas.slice(3);
-            const cutoffMs = Date.now() - 24 * 3600 * 1000;
-            const stale = candidates.filter(c =>
-              new Date(c.created_at).getTime() < cutoffMs
-            );
+            const stale = cookDeltas.slice(5);
             let prunedBytes = 0;
             for (const c of stale) {
               await github.rest.actions.deleteActionsCacheById({


### PR DESCRIPTION
First iteration of #514 used a 24h age filter, but real data showed 21 cook-deltas accumulated in <24h — none pruned. Switch to: keep newest 5, prune the rest unconditionally. Expected ~3 GB recovered per 6h cleanup cycle. 🤖 Generated with [Claude Code](https://claude.com/claude-code)