### PR TITLE
ci(cache-cleanup): hourly + broader per-commit families (#320)

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,62 +1,78 @@
 name: Cache Cleanup
 
-# setup-soldr#320 / setup-soldr#316: prune stale cook-delta cache entries to
-# prevent LRU eviction of small long-lived caches (solo-toolchain,
-# cargo-registry). Cook-delta is keyed per-commit (~200MB each); with N
-# recent commits the entries push the small caches out of the 10GB
-# repo cache budget, nullifying the warm-run wins from setup-soldr#305
-# / #310 / #313.
+# setup-soldr#320 / setup-soldr#316: prune per-commit caches to prevent
+# LRU eviction of small long-lived caches (solo-toolchain,
+# cargo-registry). Without this the repo cache budget (10 GB) gets
+# dominated by per-commit cook-delta + zccache-test entries,
+# nullifying the warm-run wins from setup-soldr#305 / #310 / #313.
 #
-# Strategy: keep the newest 3 cook-delta entries (covers recent push +
-# retry + in-flight PR), prune anything older than 24h.
+# Observed regrowth rate: 11 cook-delta entries in < 1 h (every push
+# creates a new ~200-300 MB entry). 6h cadence wasn't fast enough.
+# Switched to hourly.
+#
+# Strategy: for each per-commit key family, keep the newest 5,
+# prune the rest unconditionally.
 
 on:
   schedule:
-    - cron: "23 */6 * * *" # every 6 hours at :23
+    - cron: "27 * * * *" # every hour at :27
   workflow_dispatch:
 
 jobs:
-  prune-cook-deltas:
-    name: Prune stale cook-delta cache entries
+  prune-per-commit-caches:
+    name: Prune stale per-commit cache entries
     runs-on: ubuntu-latest
     permissions:
       actions: write
     steps:
-      - name: Prune cook-delta entries (keep newest 5, prune the rest)
+      - name: Prune cook-delta + zccache-test + cargo-target entries (keep newest 5 per family)
         uses: actions/github-script@v7
         with:
           script: |
-            // First iteration used a 24h age filter, but real data
-            // (21 entries accumulated in < 24h) showed cook-deltas
-            // arrive faster than the age filter prunes. Switch to a
-            // count-based policy: keep the 5 most recent, prune all
-            // older regardless of age. The 5-entry window covers
-            // recent push + retry + ~3 in-flight PRs.
+            // Per-commit cache families that accumulate one entry per
+            // push and dominate the 10 GB budget. Each family keeps
+            // its 5 newest entries (covers recent push + retry +
+            // ~3 in-flight PRs); the rest are pruned unconditionally.
+            const PREFIXES = [
+              "cook-delta-v2-",
+              "zccache-Linux-X64-test-",
+              "zccache-Linux-ARM64-test-",
+              "zccache-Windows-X64-test-",
+              "zccache-macos-arm64-test-",
+              "cargo-target-Linux-X64-bench-",
+              "cargo-target-Windows-X64-bench-",
+              "zccache-Linux-X64-bench-",
+              "zccache-Windows-X64-bench-",
+            ];
+            const KEEP = 5;
             const repo = context.repo;
             const caches = await github.paginate(
               github.rest.actions.getActionsCacheList,
               { ...repo, per_page: 100, sort: "created_at", direction: "desc" }
             );
-            const cookDeltas = caches.filter(c =>
-              c.key && c.key.startsWith("cook-delta-v2-")
-            );
-            console.log(`Found ${cookDeltas.length} cook-delta entries`);
-            const stale = cookDeltas.slice(5);
-            let prunedBytes = 0;
-            for (const c of stale) {
-              await github.rest.actions.deleteActionsCacheById({
-                ...repo,
-                cache_id: c.id,
-              });
-              prunedBytes += c.size_in_bytes;
-              console.log(
-                `Deleted ${c.key} (${(c.size_in_bytes / 1024 / 1024).toFixed(0)} MB, age ` +
-                `${((Date.now() - new Date(c.created_at).getTime()) / 3600000).toFixed(1)}h)`
-              );
+
+            let totalPruned = 0;
+            let totalBytes = 0;
+            for (const prefix of PREFIXES) {
+              const matching = caches.filter(c => c.key && c.key.startsWith(prefix));
+              const stale = matching.slice(KEEP);
+              if (matching.length === 0) continue;
+              console.log(`${prefix}: ${matching.length} entries, will prune ${stale.length}`);
+              for (const c of stale) {
+                await github.rest.actions.deleteActionsCacheById({
+                  ...repo,
+                  cache_id: c.id,
+                });
+                totalBytes += c.size_in_bytes;
+                totalPruned += 1;
+                console.log(
+                  `  Deleted ${c.key} (${(c.size_in_bytes / 1024 / 1024).toFixed(0)} MB, age ` +
+                  `${((Date.now() - new Date(c.created_at).getTime()) / 3600000).toFixed(1)}h)`
+                );
+              }
             }
             console.log(
-              `Pruned ${stale.length} stale cook-delta entries ` +
-              `(${(prunedBytes / 1024 / 1024 / 1024).toFixed(2)} GB recovered)`
+              `Pruned ${totalPruned} per-commit entries (${(totalBytes / 1024 / 1024 / 1024).toFixed(2)} GB recovered)`
             );
 
       - name: Report repo cache usage


### PR DESCRIPTION
Cleanup needs to run more often and cover more per-commit cache families. Observed: cook-deltas regrew from 0 → 11 entries / 3.2 GB within 1h post-cleanup. zccache-test caches add another 1.4 GB on top. Hourly cleanup + 6 additional per-commit families pruned. 🤖 Generated with [Claude Code](https://claude.com/claude-code)