### PR TITLE
ci: bump setup-soldr pin in internal build-target action v0.9.33 → v0.9.38

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
-      uses: zackees/setup-soldr@v0.9.33
+      uses: zackees/setup-soldr@v0.9.38
       with:
         toolchain: 1.94.1
         cache: true


### PR DESCRIPTION
Composite action was stuck at v0.9.33. Bringing it inline with the main workflow pin so consumers of build-target.yml also get the post-step optimization series (#310/#313/#314/#317/#319/#316/#320). 🤖 Generated with [Claude Code](https://claude.com/claude-code)