### PR TITLE
perf(bench): emit zccache_rust_miss_profile lines in benchmark-stats logs (refs #517)

### DIFF
--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -268,11 +268,25 @@ def collect_metadata() -> dict[str, Any]:
     }
 
 
-def run_benchmarks(log_path: Path) -> str:
-    cache_dir = Path(tempfile.mkdtemp(prefix="zccache-benchmark-cache-"))
+def benchmark_env(cache_dir: Path) -> dict[str, str]:
+    """Env used by `run_benchmarks` to invoke the bench binary.
+
+    Mirrors `ci.perf_guard._benchmark_env` for the rust-relevant bits so the
+    nightly benchmark-stats run captures the same per-phase
+    `zccache_rust_miss_profile` lines perf_guard already emits — issue #517
+    needs that breakdown in the published bench log to identify which phase
+    of the rust-workspace-link Cold path owns the 91 ms of overhead.
+    """
     env = os.environ.copy()
     env["ZCCACHE_CACHE_DIR"] = str(cache_dir)
+    env["ZCCACHE_PROFILE_RUST_MISS"] = "1"
     env.pop("RUSTC_WRAPPER", None)
+    return env
+
+
+def run_benchmarks(log_path: Path) -> str:
+    cache_dir = Path(tempfile.mkdtemp(prefix="zccache-benchmark-cache-"))
+    env = benchmark_env(cache_dir)
 
     try:
         result = subprocess.run(

--- a/ci/tests/test_benchmark_stats.py
+++ b/ci/tests/test_benchmark_stats.py
@@ -191,6 +191,24 @@ def test_parse_benchmark_log_extracts_all_tables():
     assert rust_link[1]["scenario"] == "Workspace staticlib link, Warm"
 
 
+def test_benchmark_env_enables_rust_miss_profile(tmp_path, monkeypatch):
+    # Issue #517: benchmark-stats publishes one log per run to the
+    # `benchmark-stats` branch. The log must include `zccache_rust_miss_profile`
+    # lines so future perf investigations can read the cold-path phase
+    # breakdown directly from the published artifact, without having to
+    # re-run the bench manually. `ZCCACHE_PROFILE_RUST_MISS` is the env knob
+    # the daemon already keys on (see `RUST_MISS_PROFILE_ENV` in
+    # `handle_compile/pipeline.rs`). Mirrors what `perf_guard._benchmark_env`
+    # has been doing all along.
+    monkeypatch.setenv("RUSTC_WRAPPER", "sccache")
+
+    env = benchmark_stats.benchmark_env(tmp_path)
+
+    assert env["ZCCACHE_CACHE_DIR"] == str(tmp_path)
+    assert env["ZCCACHE_PROFILE_RUST_MISS"] == "1"
+    assert "RUSTC_WRAPPER" not in env
+
+
 def test_benchmark_command_targets_existing_workspace_package():
     assert benchmark_stats.BENCHMARK_BASE_COMMAND == [
         "soldr",


### PR DESCRIPTION
## Summary

- Set `ZCCACHE_PROFILE_RUST_MISS=1` in `ci/benchmark_stats.py::run_benchmarks`, mirroring `ci.perf_guard._benchmark_env`.
- Extract env construction into a `benchmark_env(cache_dir)` factory so it's testable in isolation.
- Add a unit test asserting the env carries the profile knob and scrubs `RUSTC_WRAPPER`.

## Why

`latest.json` on the [`benchmark-stats`](https://github.com/zackees/zccache/tree/benchmark-stats) branch shows rust-workspace-link Cold at 127 ms zccache vs 36 ms bare — the worst cold-side ratio in the matrix. Issue #517 owns that investigation; this PR is the unblock for it.

The daemon already emits a comprehensive per-phase breakdown via `zccache_rust_miss_profile mode=… total_ns=… pre_exec_ns=… parse_args_ns=… build_context_ns=… hash_source_ns=… hash_headers_ns=… …` when `ZCCACHE_PROFILE_RUST_MISS=1` is set (see `crates/zccache/src/daemon/server/handle_compile/miss_profile.rs`). `perf_guard.py` already sets that env for rust runs. The nightly **Benchmark Stats** workflow does not — so the per-phase data never reaches the published log, and every future investigation has to spend a separate cycle re-running the bench under profile mode.

Setting the env in the bench wrapper means every nightly captures the breakdown going forward, at zero extra runtime cost (the daemon emits one extra line per compile to stderr, captured in the same log).

## Test plan

- [x] `PYTHONPATH=. uv run pytest ci/tests/test_benchmark_stats.py ci/tests/test_perf_guard.py` — 38/38 pass.
- [x] New `test_benchmark_env_enables_rust_miss_profile` asserts the env factory sets the knob and scrubs `RUSTC_WRAPPER`.
- [x] No runtime cost — `ZCCACHE_PROFILE_RUST_MISS` is a stderr-only diagnostic, captured in the same log already piped to the workflow artifact.

Refs #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)