### PR TITLE
perf(daemon): skip system-include discovery probe for the rust toolchain (refs #517)

### DIFF
--- a/crates/zccache/src/compiler/mod.rs
+++ b/crates/zccache/src/compiler/mod.rs
@@ -77,6 +77,23 @@ impl CompilerFamily {
     pub fn is_formatter(&self) -> bool {
         matches!(self, CompilerFamily::Rustfmt)
     }
+
+    /// Whether the daemon should probe this compiler for system include
+    /// paths on first use (via `depgraph::discovery_args()`).
+    ///
+    /// True for C/C++ family compilers (Gcc, Clang, Msvc) — the discovery
+    /// args (`-v -E -x c++ NUL`) are C/C++-preprocessor flags. False for
+    /// the rust toolchain (Rustc, Rustfmt) because (a) rust has no concept
+    /// of system include paths and (b) rustc rejects the C/C++ flags and
+    /// the spawn cost is wasted ~30-50 ms on every first-after-clear
+    /// invocation. See issue #517.
+    #[must_use]
+    pub fn needs_system_include_discovery(&self) -> bool {
+        matches!(
+            self,
+            CompilerFamily::Gcc | CompilerFamily::Clang | CompilerFamily::Msvc,
+        )
+    }
 }
 
 /// The result of parsing a compiler invocation.

--- a/crates/zccache/src/compiler/tests/rustc.rs
+++ b/crates/zccache/src/compiler/tests/rustc.rs
@@ -28,6 +28,19 @@ fn rustc_no_pch_extension() {
     assert_eq!(CompilerFamily::Rustc.pch_extension(), None);
 }
 
+// Issue #517: the system-include discovery probe spawns the compiler with
+// C/C++ preprocessor flags (`-v -E -x c++ NUL`). Doing that for rustc on
+// the cold path adds ~30-50 ms per first-after-clear compile while
+// returning no useful data — rust has no concept of system includes.
+#[test]
+fn needs_system_include_discovery_truth_table() {
+    assert!(CompilerFamily::Gcc.needs_system_include_discovery());
+    assert!(CompilerFamily::Clang.needs_system_include_discovery());
+    assert!(CompilerFamily::Msvc.needs_system_include_discovery());
+    assert!(!CompilerFamily::Rustc.needs_system_include_discovery());
+    assert!(!CompilerFamily::Rustfmt.needs_system_include_discovery());
+}
+
 // ─── Rustc cacheability tests ─────────────────────────────────────────
 
 #[test]

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
@@ -109,10 +109,23 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     // diagnostic path.
     let want_rust_miss_profile = std::env::var_os(RUST_MISS_PROFILE_ENV).is_some();
 
-    // Discover system includes for this compiler (cached per compiler path)
+    // Discover system includes for this compiler (cached per compiler path).
+    //
+    // Issue #517: skip discovery entirely for the rust toolchain. The
+    // discovery args (`-v -E -x c++ NUL`) are C/C++-preprocessor flags;
+    // rustc / clippy-driver / rustfmt do not understand them and do not have
+    // a notion of system includes anyway. Spawning rustc just to capture an
+    // error contributes ~30-50 ms (Linux) on every first-after-clear rust
+    // compile, which is the dominant share of the 91 ms `rust-workspace-link
+    // Cold` overhead measured in `benchmark-stats/latest.json`. Short-circuit
+    // to an empty include list — `watch_directories(&[])` is a fast no-op.
     let t_system_includes = want_rust_miss_profile.then(std::time::Instant::now);
     let compiler_priority = CompilePriority::from_client_env(client_env.as_deref());
-    let system_includes = {
+    let needs_discovery = crate::compiler::detect_family(&compiler.to_string_lossy())
+        .needs_system_include_discovery();
+    let system_includes = if !needs_discovery {
+        Vec::new()
+    } else {
         let mut cache = state.system_includes.lock().await;
         let lineage_for_probe = lineage.clone();
         cache


### PR DESCRIPTION
## Summary

- Add `CompilerFamily::needs_system_include_discovery()` — false for Rustc/Rustfmt, true for Gcc/Clang/Msvc.
- In `handle_compile::pipeline`, skip the `SystemIncludeCache::get_or_discover` call (and its child process spawn) when the predicate is false.
- TDD coverage: `compiler::tests::rustc::needs_system_include_discovery_truth_table`.

## Why this is the dominant phase in `rust-workspace-link Cold`

The daemon's cold-path system-include probe runs the compiler with `-v -E -x c++ NUL`. Those are C/C++ preprocessor flags — rustc / clippy-driver / rustfmt do not understand them. The spawn is wasted work on every first-after-clear rust compile, costing ~30-50 ms on Linux.

`benchmark-stats/latest.json` (issue #517) shows `rust-workspace-link Cold` at 127 ms zccache vs 36 ms bare — 91 ms of daemon-side overhead. The bench layout (`crates/zccache/tests/perf_bench/tests_link.rs:402-417`) calls `clear_zccache(&mut client).await` right before the cold measurement, which empties the `SystemIncludeCache` (see `handle_clear.rs:34`), forcing a fresh discovery probe on the next compile. The probe is the largest single phase in that overhead window.

Code-level confirmation that this lands on rust today:
- `pipeline.rs:115-142` calls `cache.get_or_discover(&compiler, |c| { ... spawn ... })` unconditionally
- `discovery_args()` in `depgraph/system_includes.rs:68` always returns the C/C++ form
- nothing branches on `CompilerFamily` before the spawn

The skip is safe: rust has no `#include <...>` semantics, so passing an empty include list to `watch_directories` (which then iterates an empty Vec) preserves observable behavior. The first warm-trial rust compile already short-circuited this path because the discovery output was cached.

## Test plan

- [x] `soldr cargo test -p zccache --lib needs_system_include_discovery_truth_table` passes.
- [x] `soldr cargo test -p zccache --lib -- daemon::server::tests` — all 87 pass.
- [x] `soldr cargo clippy -p zccache --lib --tests -- -D warnings` clean.
- [x] `soldr cargo fmt --all -- --check` clean.

The 91 ms → real-number speedup will be reported by the next Benchmark Stats run (triggered post-merge). The perf_guard floor from #519 (0.20 bare) catches any regression that drives the ratio worse instead of better.

Refs #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)