### PR TITLE
chore(release): bump 1.11.8 -> 1.11.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.11.8"
+version = "1.11.9"
 dependencies = [
  "bincode",
  "blake3",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.11.8"
+version = "1.11.9"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.11.8"
+version = "1.11.9"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.11.8"
+version = "1.11.9"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.11.8"
+version = "1.11.9"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Patch release bundling the fixes and CI hardening landed since 1.11.8.

### Fixes
- fix(persist): retry artifact rename through AV-scanner share lock on Windows (#509)
- fix(request-cache): scope worktree-bound entries to their originating root (#511)
- fix(cli): add `analyze` + `kv` to KNOWN_SUBCOMMANDS to stop wrap-mode misroute (#507)

### Perf
- perf(guard): gate rust-workspace-link Cold ratio (#519, issue #517)
- perf(bench): emit `zccache_rust_miss_profile` lines in benchmark-stats logs (#521)
- perf(ci): enable solo-toolchain-cache to skip warm rustup install (#508)

### CI / housekeeping
- ci(cache-cleanup): switch to count-based policy, broader per-commit families, on-demand trigger (#515, #516, #520)
- ci: setup-soldr pin bumps v0.9.21 → v0.9.38 (#485–#518)
- ci(release-auto): poll PyPI until all wheels visible before returning (#484)

## Test plan

- [ ] CI green on `chore/release-1.11.9`
- [ ] On merge to `main`, `release-auto.yml` detects the bump and ships
  - [ ] PyPI wheels published for all 6 targets
  - [ ] Rust crates published to crates.io
  - [ ] GitHub release `1.11.9` created
- [ ] Spot-check `pip install zccache==1.11.9` after release-auto completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)