### PR TITLE
perf(daemon): persist CompilerHashCache across daemon restarts (refs #517)

### DIFF
--- a/crates/zccache/src/core/config.rs
+++ b/crates/zccache/src/core/config.rs
@@ -611,6 +611,19 @@ pub fn metadata_path_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPat
     cache_dir.join("metadata.bin")
 }
 
+/// Returns the on-disk path for the persisted compiler-binary hash cache.
+///
+/// Issue #517: hashing a 150 MB rustc binary on the cold path costs
+/// ~50-60 ms per first-after-restart compile, the dominant phase of the
+/// `rust-workspace-link Cold` overhead. This snapshot survives daemon
+/// restart so subsequent daemons start with the rustc hash already
+/// cached. Sibling of `metadata.bin` / `index.bin` so the soldr save /
+/// load pipeline already bundles it.
+#[must_use]
+pub fn compiler_hash_cache_path_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
+    cache_dir.join("compiler_hash.bin")
+}
+
 fn crash_dump_dir_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
     cache_dir.join("crashes")
 }

--- a/crates/zccache/src/daemon/server/compiler_hash.rs
+++ b/crates/zccache/src/daemon/server/compiler_hash.rs
@@ -2,14 +2,41 @@
 //!
 //! Caches `(mtime, size) -> ContentHash` for compiler binaries to skip
 //! the per-request blake3 over multi-MB executables.
+//!
+//! ## On-disk persistence (issue #517)
+//!
+//! Hashing a 150 MB rustc binary on the cold path costs ~50-60 ms (Linux,
+//! blake3 ~3 GB/s), dominating the `rust-workspace-link Cold` overhead
+//! measured in `benchmark-stats/latest.json`. The cache is persisted to
+//! disk alongside `metadata.bin` so a daemon restart (CI runner restart,
+//! Stop hook tear-down, soldr-driven daemon recycle) does not refill it
+//! from zero. The stored `(path, mtime, size, hash)` quad is exactly the
+//! in-memory shape; correctness on load relies on the same stat-verify
+//! that the in-memory `get_or_hash` already enforces — a (mtime, size)
+//! mismatch silently downgrades the loaded entry to a re-hash, so a stale
+//! snapshot cannot poison the cache key.
 
 use super::*;
+use serde::{Deserialize, Serialize};
+use std::io::Write as _;
 
-#[derive(Clone)]
+/// On-disk format version for the persisted compiler-hash cache.
+///
+/// Bump on any layout change to the `Persisted*` types so the loader
+/// rejects older / newer snapshots instead of mis-decoding them.
+pub(super) const FORMAT_VERSION: u32 = 1;
+
+#[derive(Clone, Serialize, Deserialize)]
 pub(super) struct CompilerHashEntry {
     pub(super) mtime: std::time::SystemTime,
     pub(super) size: u64,
     pub(super) hash: ContentHash,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PersistedCompilerHashes {
+    version: u32,
+    entries: Vec<(NormalizedPath, CompilerHashEntry)>,
 }
 
 #[derive(Default)]
@@ -60,4 +87,126 @@ impl CompilerHashCache {
             .insert(key, CompilerHashEntry { mtime, size, hash });
         Some(hash)
     }
+
+    /// Persist the cache to `path` as a versioned bincode snapshot.
+    ///
+    /// Atomic on success: writes to `<path>.tmp-<pid>`, then renames over
+    /// `path`. Empty snapshots short-circuit without touching disk. Stale
+    /// entries on disk are harmless: `get_or_hash` re-stats every key
+    /// before trusting the hash, so a mismatch silently downgrades to a
+    /// re-hash. See module-level doc.
+    ///
+    /// # Errors
+    ///
+    /// Returns I/O errors from `create_dir_all`, `write`, `rename`, or
+    /// bincode serialization.
+    pub(super) fn save_to_disk(&self, path: &Path) -> std::io::Result<()> {
+        let entries: Vec<(NormalizedPath, CompilerHashEntry)> = self
+            .entries
+            .iter()
+            .map(|e| (e.key().clone(), e.value().clone()))
+            .collect();
+
+        if entries.is_empty() {
+            tracing::debug!(
+                path = %path.display(),
+                "compiler hash cache flush: 0 entries, skipping write"
+            );
+            return Ok(());
+        }
+
+        let entry_count = entries.len();
+        let snapshot = PersistedCompilerHashes {
+            version: FORMAT_VERSION,
+            entries,
+        };
+        let bytes = bincode::serialize(&snapshot)
+            .map_err(|e| std::io::Error::other(format!("bincode serialize: {e}")))?;
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "compiler_hash.bin".into());
+        let tmp = path.with_file_name(format!(".{name}.tmp-{}", std::process::id()));
+
+        let result = write_atomic_durable(&tmp, path, &bytes);
+        if result.is_err() {
+            let _ = std::fs::remove_file(&tmp);
+        }
+        if result.is_ok() {
+            tracing::info!(
+                path = %path.display(),
+                entries = entry_count,
+                bytes = bytes.len(),
+                "compiler hash cache flushed to disk"
+            );
+        }
+        result
+    }
+
+    /// Load a previously persisted snapshot from `path`.
+    ///
+    /// Returns an empty cache when the file is absent (first run). Any
+    /// other I/O error, bincode decode failure, or version mismatch is
+    /// surfaced as `Err`; the daemon caller is expected to log and start
+    /// empty. Stat-verification at the `get_or_hash` call site re-checks
+    /// every loaded entry before use, so a stale on-disk snapshot cannot
+    /// produce an incorrect cache key.
+    ///
+    /// # Errors
+    ///
+    /// Any I/O error other than `NotFound`, any bincode decode failure,
+    /// or any version mismatch.
+    pub(super) fn load_from_disk(path: &Path) -> std::io::Result<Self> {
+        let bytes = match std::fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                tracing::debug!(
+                    path = %path.display(),
+                    "compiler hash cache file not found, starting empty"
+                );
+                return Ok(Self::new());
+            }
+            Err(e) => return Err(e),
+        };
+
+        let snapshot: PersistedCompilerHashes = bincode::deserialize(&bytes)
+            .map_err(|e| std::io::Error::other(format!("bincode deserialize: {e}")))?;
+        if snapshot.version != FORMAT_VERSION {
+            return Err(std::io::Error::other(format!(
+                "compiler hash cache version mismatch: file={}, expected={}",
+                snapshot.version, FORMAT_VERSION
+            )));
+        }
+
+        let entries = DashMap::with_capacity(snapshot.entries.len());
+        let entry_count = snapshot.entries.len();
+        for (key, value) in snapshot.entries {
+            entries.insert(key, value);
+        }
+        tracing::info!(
+            path = %path.display(),
+            entries = entry_count,
+            "compiler hash cache restored from disk"
+        );
+        Ok(Self { entries })
+    }
+}
+
+fn write_atomic_durable(tmp: &Path, target: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    {
+        let mut f = std::fs::File::create(tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+    }
+    std::fs::rename(tmp, target)?;
+    if let Some(parent) = target.parent() {
+        if let Ok(dir) = std::fs::File::open(parent) {
+            let _ = dir.sync_all();
+        }
+    }
+    Ok(())
 }

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -59,6 +59,24 @@ impl DaemonServer {
         // `MetadataCache::lookup` stat-verify safety net still guards
         // correctness on every subsequent lookup).
         let metadata_path = crate::core::config::metadata_path_from_cache_dir(cache_dir);
+        let compiler_hash_cache_path =
+            crate::core::config::compiler_hash_cache_path_from_cache_dir(cache_dir);
+        // Issue #517: hashing rustc's ~150 MB binary on the cold path
+        // costs ~50-60 ms per first-after-restart compile. Loading the
+        // (path, mtime, size, hash) snapshot from a prior daemon makes
+        // that first compile near-instant — the stat-verify in
+        // `get_or_hash` keeps correctness if the binary changed since.
+        let compiler_hash_cache =
+            match CompilerHashCache::load_from_disk(compiler_hash_cache_path.as_path()) {
+                Ok(cache) => cache,
+                Err(e) => {
+                    tracing::warn!(
+                        path = %compiler_hash_cache_path.display(),
+                        "failed to load compiler hash cache, starting empty: {e}"
+                    );
+                    CompilerHashCache::new()
+                }
+            };
         let cache_system =
             match crate::fscache::MetadataCache::load_from_disk(metadata_path.as_path()) {
                 Ok(metadata) => {
@@ -104,6 +122,7 @@ impl DaemonServer {
                 profiler: PhaseProfiler::new(),
                 artifact_dir,
                 metadata_path,
+                compiler_hash_cache_path,
                 depfile_tmpdir: {
                     let dir = crate::core::config::depfile_dir_from_cache_dir(cache_dir)
                         .join(format!("{}-{instance}", std::process::id()));
@@ -116,7 +135,7 @@ impl DaemonServer {
                 request_cache: DashMap::new(),
                 session_worktree_roots: DashMap::new(),
                 request_validation_cache: DashMap::new(),
-                compiler_hash_cache: CompilerHashCache::new(),
+                compiler_hash_cache,
                 watched_raw_dirs: DashMap::new(),
                 pch_source_map: DashMap::new(),
                 journal: CompileJournal::new(crate::core::config::log_dir_from_cache_dir(

--- a/crates/zccache/src/daemon/server/run.rs
+++ b/crates/zccache/src/daemon/server/run.rs
@@ -424,6 +424,20 @@ impl DaemonServer {
                         ),
                     }
 
+                    // Issue #517: persist the compiler-binary hash cache
+                    // so the next daemon does not pay the ~50-60 ms cold
+                    // blake3 over rustc on its first compile.
+                    if let Err(e) = self
+                        .state
+                        .compiler_hash_cache
+                        .save_to_disk(self.state.compiler_hash_cache_path.as_path())
+                    {
+                        tracing::warn!(
+                            path = %self.state.compiler_hash_cache_path.display(),
+                            "compiler hash cache save failed: {e}"
+                        );
+                    }
+
                     // Clean up our own depfile temp directory.
                     let _ = std::fs::remove_dir_all(&self.state.depfile_tmpdir);
 

--- a/crates/zccache/src/daemon/server/state.rs
+++ b/crates/zccache/src/daemon/server/state.rs
@@ -53,6 +53,12 @@ pub(super) struct SharedState {
     /// start with their fast path already populated instead of an
     /// empty `DashMap`. See `crate::fscache::persistence`.
     pub(super) metadata_path: NormalizedPath,
+    /// Path used by [`CompilerHashCache`] for persistent (path, mtime, size,
+    /// hash) snapshots. Issue #517 — eliminates the ~50-60 ms cold-path
+    /// blake3 of the rustc binary on every first-after-restart compile.
+    /// Loaded by `Lifecycle::new`, written on shutdown alongside
+    /// `metadata.bin`.
+    pub(super) compiler_hash_cache_path: NormalizedPath,
     /// Temporary directory for injected depfiles.
     pub(super) depfile_tmpdir: NormalizedPath,
     /// Ultra-fast hit cache: context_key → (clock, artifact_key_hex, timestamp).

--- a/crates/zccache/src/daemon/server/tests/compiler_hash.rs
+++ b/crates/zccache/src/daemon/server/tests/compiler_hash.rs
@@ -106,3 +106,96 @@ fn rustc_context_build_reuses_compiler_hash_cache() {
     assert_eq!(second_hash, expected_hash);
     assert_eq!(cache.len(), 1);
 }
+
+// ── Issue #517: persisted compiler hash cache ───────────────────────────
+
+#[test]
+fn compiler_hash_cache_save_then_load_roundtrip_preserves_entries() {
+    let tmp = tempfile::tempdir().unwrap();
+    let compiler = tmp.path().join("rustc.exe");
+    let snapshot = tmp.path().join("compiler_hash.bin");
+    std::fs::write(&compiler, b"fake rustc").unwrap();
+
+    let cache = CompilerHashCache::new();
+    let primed = cache.get_or_hash_with(&compiler, |_| Some(ContentHash::from_bytes([42; 32])));
+    assert_eq!(primed, Some(ContentHash::from_bytes([42; 32])));
+    cache.save_to_disk(&snapshot).unwrap();
+    assert!(snapshot.exists(), "save_to_disk must produce a file");
+
+    let restored = CompilerHashCache::load_from_disk(&snapshot).unwrap();
+    let hash_calls = AtomicUsize::new(0);
+    let from_restored = restored.get_or_hash_with(&compiler, |_| {
+        hash_calls.fetch_add(1, Ordering::Relaxed);
+        Some(ContentHash::from_bytes([99; 32]))
+    });
+    assert_eq!(from_restored, Some(ContentHash::from_bytes([42; 32])));
+    assert_eq!(
+        hash_calls.load(Ordering::Relaxed),
+        0,
+        "loaded snapshot must short-circuit the hasher when stat is unchanged",
+    );
+}
+
+#[test]
+fn compiler_hash_cache_load_missing_file_returns_empty() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("does-not-exist.bin");
+
+    let cache = CompilerHashCache::load_from_disk(&missing).unwrap();
+    assert_eq!(cache.len(), 0);
+}
+
+#[test]
+fn compiler_hash_cache_save_empty_cache_does_not_create_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let snapshot = tmp.path().join("compiler_hash.bin");
+
+    let cache = CompilerHashCache::new();
+    cache.save_to_disk(&snapshot).unwrap();
+
+    assert!(
+        !snapshot.exists(),
+        "empty cache must not write a zero-entry file",
+    );
+}
+
+#[test]
+fn compiler_hash_cache_load_rehashes_when_binary_changes_after_save() {
+    // Safety net: a stale snapshot must NEVER substitute for a real hash
+    // of a changed binary. `get_or_hash_with` already enforces this via
+    // its (mtime, size) stat-verify; this test pins it down so future
+    // refactors of the persist code can't drop the guard.
+    let tmp = tempfile::tempdir().unwrap();
+    let compiler = tmp.path().join("rustc.exe");
+    let snapshot = tmp.path().join("compiler_hash.bin");
+    std::fs::write(&compiler, b"original rustc").unwrap();
+    filetime::set_file_mtime(
+        &compiler,
+        filetime::FileTime::from_unix_time(1_000_000_000, 0),
+    )
+    .unwrap();
+
+    let cache = CompilerHashCache::new();
+    cache.get_or_hash_with(&compiler, |_| Some(ContentHash::from_bytes([1; 32])));
+    cache.save_to_disk(&snapshot).unwrap();
+
+    std::fs::write(&compiler, b"changed rustc binary").unwrap();
+    filetime::set_file_mtime(
+        &compiler,
+        filetime::FileTime::from_unix_time(1_000_000_500, 0),
+    )
+    .unwrap();
+
+    let restored = CompilerHashCache::load_from_disk(&snapshot).unwrap();
+    let hash_calls = AtomicUsize::new(0);
+    let observed = restored.get_or_hash_with(&compiler, |_| {
+        hash_calls.fetch_add(1, Ordering::Relaxed);
+        Some(ContentHash::from_bytes([7; 32]))
+    });
+    assert_eq!(
+        observed,
+        Some(ContentHash::from_bytes([7; 32])),
+        "stale snapshot must not survive a binary change",
+    );
+    assert_eq!(hash_calls.load(Ordering::Relaxed), 1);
+}


### PR DESCRIPTION
## Summary

- New `CompilerHashCache::save_to_disk` / `load_from_disk` writing a bincode snapshot of `(path, mtime, size, hash)` entries.
- `Lifecycle::new` loads the snapshot from `<cache_dir>/compiler_hash.bin` on startup; the run-loop's shutdown branch writes on graceful exit, beside the existing `metadata.bin` flush.
- `core::config::compiler_hash_cache_path_from_cache_dir` mirrors the metadata path helper so soldr save/load already bundles it.
- Four new tests in `tests/compiler_hash.rs` (round-trip, missing-file, empty-cache, stale-snapshot-rehash).

## Why

[Issue #517 — profile breakdown](https://github.com/zackees/zccache/issues/517#issuecomment-4587703887) showed `build_context_ns = 63.6 ms` is **60% of `rust-workspace-link Cold` total**. The phase is dominated by `compiler_hash_cache.get_or_hash(rustc_binary)` — a blake3 over ~150 MB of rustc executable. On warm trials of the same daemon the phase drops to ~110 µs (in-memory cache); on every daemon restart the cost reappears.

Persisting the cache to disk lets the next daemon (same machine, post `soldr load`, post-CI-restart, post-Stop-hook recycle) start with the rustc hash already populated. The bench's first-after-fresh-checkout call still hashes once, but every restart after that is fast.

## Safety

`get_or_hash` already re-stats the file before trusting the cached hash — a (mtime, size) mismatch silently downgrades to a fresh hash. The new `…_load_rehashes_when_binary_changes_after_save` test pins this invariant: rotate the binary, save, load on the new binary, observe a fresh hash.

A version-mismatched / corrupt snapshot is surfaced as `Err` and the daemon logs + treats as empty — no risk of mis-decoding bytes.

## Test plan

- [x] `soldr cargo test -p zccache --lib daemon::server::tests::compiler_hash` — all 7 pass (3 existing + 4 new).
- [x] `soldr cargo test -p zccache --lib -- daemon::server::tests` — all 91 pass.
- [x] `soldr cargo clippy -p zccache --lib --tests -- -D warnings` clean.
- [x] `soldr cargo fmt --all -- --check` clean.

## Expected benchmark effect

`rust-workspace-link Cold` drops from ~127 ms to ~67 ms after `compiler_hash.bin` is populated, leaving `compiler_process_ns` (the irreducible ~33 ms of bare rustc) as the dominant phase. The perf_guard floor from #519 will detect any regression.

Refs #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)