### PR TITLE
perf(daemon): pre-hash known compilers in background on startup (refs #517)

### DIFF
--- a/crates/zccache/src/daemon/server/compiler_hash.rs
+++ b/crates/zccache/src/daemon/server/compiler_hash.rs
@@ -210,3 +210,49 @@ fn write_atomic_durable(tmp: &Path, target: &Path, bytes: &[u8]) -> std::io::Res
     }
     Ok(())
 }
+
+/// Env vars that name compiler executables. Issue #517 Option 2: warm the
+/// hash cache for these on daemon startup so the very first compile
+/// request — even on a fresh-checkout runner with no `compiler_hash.bin`
+/// from a prior daemon — does NOT pay the ~50-60 ms cold blake3.
+///
+/// The list is intentionally minimal. We don't probe `$PATH` or scan for
+/// rustup toolchains because:
+/// - false positives (e.g. hashing `/usr/bin/cc` on a runner that only
+///   uses `clang++`) cost wall-clock with no later benefit.
+/// - the daemon may not have permission to stat arbitrary `PATH` entries.
+///
+/// If the user's invocations use a compiler whose path is not in any of
+/// these env vars, the regular synchronous hash path in `get_or_hash`
+/// still works — pre-hashing is purely an optimization, never a
+/// correctness gate.
+pub(super) const PREHASH_ENV_VARS: &[&str] = &["RUSTC", "CC", "CXX"];
+
+/// Pre-hash the given paths into `cache` in the background. Failures
+/// (path missing, stat error, hash error) are silently ignored — each
+/// per-path failure just means the next real request for that compiler
+/// pays the normal hash cost, the same as before this optimisation.
+///
+/// Caller is expected to wrap this in `tokio::task::spawn_blocking` so
+/// the blake3 over multi-MB binaries does not block the async runtime.
+pub(super) fn prehash_paths(cache: &CompilerHashCache, paths: &[std::path::PathBuf]) -> usize {
+    let mut hashed = 0;
+    for path in paths {
+        if cache.get_or_hash(path).is_some() {
+            hashed += 1;
+        }
+    }
+    hashed
+}
+
+/// Read [`PREHASH_ENV_VARS`] from the process environment and return any
+/// non-empty values as paths. Order is preserved so callers can rely on
+/// `RUSTC` being warmed before `CC` etc. when iterated.
+pub(super) fn prehash_candidates_from_env() -> Vec<std::path::PathBuf> {
+    PREHASH_ENV_VARS
+        .iter()
+        .filter_map(std::env::var_os)
+        .filter(|val| !val.is_empty())
+        .map(std::path::PathBuf::from)
+        .collect()
+}

--- a/crates/zccache/src/daemon/server/run.rs
+++ b/crates/zccache/src/daemon/server/run.rs
@@ -71,6 +71,33 @@ impl DaemonServer {
 
         self.start_watcher_pipeline().await;
 
+        // Issue #517 Option 2: warm the CompilerHashCache for paths named
+        // by `RUSTC` / `CC` / `CXX` in the daemon environment, in the
+        // background, on a blocking thread. On a fresh-checkout runner the
+        // persisted `compiler_hash.bin` (#525) doesn't exist yet — without
+        // this, the very first compile pays the ~50-60 ms cold blake3 of
+        // the rustc binary on the request critical path. By racing the
+        // hash against the first request, that cost is usually paid
+        // off-thread before any compile arrives. Failures are silent: a
+        // missing path or stat error just leaves the cache empty for that
+        // entry and the regular synchronous hash kicks in on first use.
+        {
+            let state = Arc::clone(&self.state);
+            let candidates = prehash_candidates_from_env();
+            if !candidates.is_empty() {
+                tokio::task::spawn_blocking(move || {
+                    let start = std::time::Instant::now();
+                    let hashed = prehash_paths(&state.compiler_hash_cache, &candidates);
+                    tracing::info!(
+                        elapsed_ms = start.elapsed().as_millis() as u64,
+                        candidates = candidates.len(),
+                        hashed,
+                        "compiler hash cache warmed from env"
+                    );
+                });
+            }
+        }
+
         // Start idle watchdog if timeout is configured.
         if idle_timeout_secs > 0 {
             let state = Arc::clone(&self.state);

--- a/crates/zccache/src/daemon/server/tests/compiler_hash.rs
+++ b/crates/zccache/src/daemon/server/tests/compiler_hash.rs
@@ -160,6 +160,82 @@ fn compiler_hash_cache_save_empty_cache_does_not_create_file() {
 }
 
 #[test]
+fn prehash_paths_populates_cache_and_short_circuits_subsequent_lookups() {
+    // Issue #517 Option 2: the daemon startup task warms the cache for
+    // known compiler paths. After warmup, a real request that calls
+    // `get_or_hash` on the same path MUST not re-hash — that's the whole
+    // point of the warmup.
+    let tmp = tempfile::tempdir().unwrap();
+    let rustc = tmp.path().join("rustc");
+    let cc = tmp.path().join("cc");
+    let cxx = tmp.path().join("does-not-exist");
+    std::fs::write(&rustc, b"fake rustc").unwrap();
+    std::fs::write(&cc, b"fake cc").unwrap();
+
+    let cache = CompilerHashCache::new();
+    let hashed = prehash_paths(&cache, &[rustc.clone(), cc.clone(), cxx.clone()]);
+
+    assert_eq!(
+        hashed, 2,
+        "the two existing paths should hash; missing one silently skipped"
+    );
+    assert_eq!(cache.len(), 2);
+
+    // Re-hashing the same paths must hit the cache (no fresh blake3).
+    let hash_calls = AtomicUsize::new(0);
+    cache.get_or_hash_with(&rustc, |_| {
+        hash_calls.fetch_add(1, Ordering::Relaxed);
+        Some(ContentHash::from_bytes([0xff; 32]))
+    });
+    cache.get_or_hash_with(&cc, |_| {
+        hash_calls.fetch_add(1, Ordering::Relaxed);
+        Some(ContentHash::from_bytes([0xff; 32]))
+    });
+    assert_eq!(
+        hash_calls.load(Ordering::Relaxed),
+        0,
+        "warmed entries must short-circuit the hasher",
+    );
+}
+
+#[test]
+fn prehash_candidates_from_env_filters_unset_and_empty() {
+    use std::sync::Mutex;
+    // serde_test uses lazy_static; we don't need that — just guard
+    // against the parallel-test env-var race.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    let _guard = ENV_LOCK.lock().unwrap();
+
+    // Stash + clear the three keys we manipulate so a prior test (or the
+    // surrounding shell) does not bias the assertion.
+    let saved: Vec<(&str, Option<std::ffi::OsString>)> = PREHASH_ENV_VARS
+        .iter()
+        .map(|k| (*k, std::env::var_os(k)))
+        .collect();
+    for (k, _) in &saved {
+        std::env::remove_var(k);
+    }
+
+    std::env::set_var("RUSTC", "/opt/rustup/bin/rustc");
+    std::env::set_var("CC", ""); // empty must be filtered
+                                 // CXX intentionally unset
+
+    let candidates = prehash_candidates_from_env();
+    assert_eq!(
+        candidates,
+        vec![std::path::PathBuf::from("/opt/rustup/bin/rustc")]
+    );
+
+    // Restore prior state so we don't leak into other tests.
+    for (k, v) in saved {
+        match v {
+            Some(value) => std::env::set_var(k, value),
+            None => std::env::remove_var(k),
+        }
+    }
+}
+
+#[test]
 fn compiler_hash_cache_load_rehashes_when_binary_changes_after_save() {
     // Safety net: a stale snapshot must NEVER substitute for a real hash
     // of a changed binary. `get_or_hash_with` already enforces this via


### PR DESCRIPTION
## Summary

- Spawn a `tokio::task::spawn_blocking` task on daemon startup that pre-populates `CompilerHashCache` for paths named in the daemon environment (`RUSTC`, `CC`, `CXX`).
- Conservative candidate set — no \`\$PATH\` enumeration, no rustup-toolchain guessing. Failures are silent; the synchronous hash path still kicks in if the warmup misses.
- Logs once on completion with `elapsed_ms` + `candidates` + `hashed`.
- Two new tests in `tests/compiler_hash.rs`.

## Why

#525 made `compiler_hash.bin` survive daemon restarts, so the second-onward daemon-restart compile is fast. But a fresh-checkout CI runner — or any first-ever daemon start under a new cache root — still pays the ~50-60 ms cold blake3 of the rustc binary on its very first compile, the dominant phase of \`rust-workspace-link Cold\` per the [#517 profile breakdown](https://github.com/zackees/zccache/issues/517#issuecomment-4587703887). 

Racing that hash off-thread on startup lets the first real compile request find the cache already warm. The blocking thread is the right placement: blake3 over a 150 MB executable is CPU work, not I/O — a normal \`tokio::spawn\` would stall the async runtime.

## Test plan

- [x] \`soldr cargo test -p zccache --lib daemon::server::tests::compiler_hash\` — all 9 pass (7 existing + 2 new).
- [x] \`soldr cargo test -p zccache --lib -- daemon::server::tests\` — all 93 pass.
- [x] \`soldr cargo clippy -p zccache --lib --tests -- -D warnings\` clean.
- [x] \`soldr cargo fmt --all -- --check\` clean.

## Expected benchmark effect

For the `rust-workspace-link Cold` row: when the daemon harness env carries `RUSTC` (which the cargo-test runner does — \`rustc\` is on `PATH` and cargo exports its toolchain), the warmup completes before the bench's `clear_zccache(&mut client)` + cold-measurement sequence runs, so the cold compile finds the hash already cached. Net target: drop the \`build_context_ns = 63.6 ms\` phase to ~110 µs even on the first compile, the same as warm trials. Combined with #525, this should close the gap to bare for runners where `RUSTC` is set.

If `RUSTC` is NOT set in the daemon env, this is a no-op (silent skip) and the synchronous hash + #525 persistence still apply.

Refs #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)