### PR TITLE
perf(daemon): hash rustc identity via `-vV` output instead of binary blake3 (refs #517)

### DIFF
--- a/crates/zccache/src/daemon/server/compiler_hash.rs
+++ b/crates/zccache/src/daemon/server/compiler_hash.rs
@@ -12,7 +12,7 @@
 //! Stop hook tear-down, soldr-driven daemon recycle) does not refill it
 //! from zero. The stored `(path, mtime, size, hash)` quad is exactly the
 //! in-memory shape; correctness on load relies on the same stat-verify
-//! that the in-memory `get_or_hash` already enforces — a (mtime, size)
+//! that the in-memory `get_or_hash_with` already enforces — a (mtime, size)
 //! mismatch silently downgrades the loaded entry to a re-hash, so a stale
 //! snapshot cannot poison the cache key.
 
@@ -56,10 +56,6 @@ impl CompilerHashCache {
         self.entries.len()
     }
 
-    pub(super) fn get_or_hash(&self, path: &Path) -> Option<ContentHash> {
-        self.get_or_hash_with(path, |path| crate::hash::hash_file(path).ok())
-    }
-
     pub(super) fn get_or_hash_with<F>(&self, path: &Path, hasher: F) -> Option<ContentHash>
     where
         F: FnOnce(&Path) -> Option<ContentHash>,
@@ -92,7 +88,7 @@ impl CompilerHashCache {
     ///
     /// Atomic on success: writes to `<path>.tmp-<pid>`, then renames over
     /// `path`. Empty snapshots short-circuit without touching disk. Stale
-    /// entries on disk are harmless: `get_or_hash` re-stats every key
+    /// entries on disk are harmless: `get_or_hash_with` re-stats every key
     /// before trusting the hash, so a mismatch silently downgrades to a
     /// re-hash. See module-level doc.
     ///
@@ -152,7 +148,7 @@ impl CompilerHashCache {
     /// Returns an empty cache when the file is absent (first run). Any
     /// other I/O error, bincode decode failure, or version mismatch is
     /// surfaced as `Err`; the daemon caller is expected to log and start
-    /// empty. Stat-verification at the `get_or_hash` call site re-checks
+    /// empty. Stat-verification at the `get_or_hash_with` call site re-checks
     /// every loaded entry before use, so a stale on-disk snapshot cannot
     /// produce an incorrect cache key.
     ///
@@ -209,4 +205,26 @@ fn write_atomic_durable(tmp: &Path, target: &Path, bytes: &[u8]) -> std::io::Res
         }
     }
     Ok(())
+}
+
+/// Compute a content hash that uniquely identifies a rustc /
+/// clippy-driver / rustfmt build, preferring `<compiler> -vV` output
+/// over a full blake3 over the binary. `-vV` prints the toolchain
+/// version + commit hash + LLVM version + host triple — all the bits
+/// the cache key must vary on — and runs in ~10 ms vs ~50-60 ms for
+/// the ~150 MB binary blake3 (issue #517).
+///
+/// Falls back to the file-content hash on spawn failure, non-zero
+/// exit, or empty stdout so cache keys are still well-defined for
+/// stubbed binaries (unit tests) or broken toolchains.
+pub(super) fn hash_rustc_identity(path: &Path) -> Option<ContentHash> {
+    match std::process::Command::new(path).arg("-vV").output() {
+        Ok(output) if output.status.success() && !output.stdout.is_empty() => {
+            Some(crate::hash::hash_bytes(&output.stdout))
+        }
+        // Spawn error, non-zero exit, or empty stdout — fall through to
+        // the file-content hash so cache keys stay well-defined for
+        // stubbed binaries (unit tests) and broken toolchains.
+        _ => crate::hash::hash_file(path).ok(),
+    }
 }

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -65,7 +65,7 @@ impl DaemonServer {
         // costs ~50-60 ms per first-after-restart compile. Loading the
         // (path, mtime, size, hash) snapshot from a prior daemon makes
         // that first compile near-instant — the stat-verify in
-        // `get_or_hash` keeps correctness if the binary changed since.
+        // `get_or_hash_with` keeps correctness if the binary changed since.
         let compiler_hash_cache =
             match CompilerHashCache::load_from_disk(compiler_hash_cache_path.as_path()) {
                 Ok(cache) => cache,

--- a/crates/zccache/src/daemon/server/rustc.rs
+++ b/crates/zccache/src/daemon/server/rustc.rs
@@ -71,9 +71,18 @@ pub(super) fn build_rustc_compile_context(
 ) -> BuildContextResult {
     let rustc_args = crate::depgraph::parse_rustc_args(&compilation.original_args, cwd);
 
-    // Hash the rustc binary for compiler version identity.
-    // Different rustc versions produce different output for the same source.
-    let compiler_hash = compiler_hash_cache.get_or_hash(&compilation.compiler);
+    // Compiler identity for the cache key. Different rustc versions
+    // produce different output for the same source, so the identity
+    // hash must vary with the toolchain build.
+    //
+    // Issue #517: prefer `rustc -vV` output (~10 ms spawn) over a full
+    // blake3 over the ~150 MB binary (~50-60 ms on Linux). The cache
+    // is still keyed by the binary's (path, mtime, size); only the
+    // identity bytes that get hashed change. Failure falls through to
+    // the binary hash so cache keys stay well-defined for stub
+    // binaries (unit tests) and broken toolchains.
+    let compiler_hash =
+        compiler_hash_cache.get_or_hash_with(&compilation.compiler, hash_rustc_identity);
 
     let rustc_ctx = crate::depgraph::RustcCompileContext::from_parsed_args(
         &rustc_args,

--- a/crates/zccache/src/daemon/server/tests/compiler_hash.rs
+++ b/crates/zccache/src/daemon/server/tests/compiler_hash.rs
@@ -107,6 +107,51 @@ fn rustc_context_build_reuses_compiler_hash_cache() {
     assert_eq!(cache.len(), 1);
 }
 
+// ── Issue #517 Option 3: rustc -vV identity instead of binary hash ─────
+
+/// `hash_rustc_identity` against a real rustc on PATH. Skips on hosts
+/// without rustc (e.g. minimal CI containers); the assertion only
+/// fires when we can compare against a known-good `-vV` output.
+#[test]
+fn hash_rustc_identity_matches_rustc_vv_output_when_rustc_available() {
+    let Some(rustc) = crate::test_support::find_rustc() else {
+        eprintln!("SKIP: rustc not found on PATH");
+        return;
+    };
+
+    let identity = hash_rustc_identity(rustc.as_path()).expect("rustc -vV must produce a hash");
+
+    // Recompute the expected hash from rustc's own -vV output. If
+    // production code matches, identity == expected.
+    let output = std::process::Command::new(rustc.as_path())
+        .arg("-vV")
+        .output()
+        .expect("rustc -vV must spawn");
+    assert!(output.status.success());
+    let expected = crate::hash::hash_bytes(&output.stdout);
+
+    assert_eq!(identity, expected);
+    // And it must NOT match the full-binary hash — that's the whole
+    // point: the version-string hash is the cheaper alternative.
+    let binary_hash = crate::hash::hash_file(rustc.as_path()).ok();
+    assert_ne!(Some(identity), binary_hash);
+}
+
+/// Stubbed binary that can't be spawned falls back to the file-content
+/// hash so cache keys remain well-defined for tests and broken
+/// toolchains.
+#[test]
+fn hash_rustc_identity_falls_back_to_file_hash_when_spawn_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fake_rustc = tmp.path().join("not-actually-rustc");
+    std::fs::write(&fake_rustc, b"").unwrap();
+
+    let identity = hash_rustc_identity(&fake_rustc);
+    let file_hash = crate::hash::hash_file(&fake_rustc).ok();
+
+    assert_eq!(identity, file_hash);
+}
+
 // ── Issue #517: persisted compiler hash cache ───────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

For the rust toolchain only, swap \`hash_file(rustc_binary)\` for \`hash_bytes(rustc -vV stdout)\` as the compiler-identity input. Same correctness model, ~5x faster on the cold path.

- New \`hash_rustc_identity(path)\` runs \`<rustc> -vV\` and hashes the stdout. Falls back to \`hash_file\` on spawn error / non-zero exit / empty stdout so stub binaries and broken toolchains still produce well-defined cache keys.
- \`build_rustc_compile_context\` calls it via \`get_or_hash_with\` — the existing (path, mtime, size) gate amortizes the spawn across every compile that doesn't change the toolchain.
- Two new tests + drive-by cleanup (dead \`get_or_hash\` wrapper removed).

## Why this is Option 3 from #517

| Option | First-daemon win | Repeat-daemon win | CPU contention |
|---|---:|---:|---:|
| #525 (persist) | 0 | ~63 ms | none |
| #526 (background prehash) | claimed ~63 ms | ~63 ms | **+48 ms hash_all** ✗ (reverted in #528) |
| **This PR (-vV identity)** | **~40-50 ms** | **~40-50 ms** | **none** |

\`rustc -vV\` runs in ~10 ms and prints the toolchain version + commit hash + LLVM version + host triple — the exact bits that must vary in the cache key. Wall-clock comparison: ~10 ms spawn vs ~50-60 ms for the 150 MB blake3, a 40-50 ms saving per first-after-restart compile.

Critically, the spawn happens INLINE on the request critical path. Unlike #526, there's no concurrent background work for the request to compete with — so no \`hash_all\` regression.

## Why this is safe

- \`-vV\` output uniquely identifies a rustc build (this is what sccache uses). Two rustc binaries with identical \`-vV\` output produce identical compile output for the same source.
- The cache is still keyed by the binary's \`(path, mtime, size)\`. If the user updates rustc (rustup), mtime/size change → re-spawn → fresh identity.
- The fallback path preserves stat-verify semantics: a broken / stubbed rustc produces a binary-content-hash, never a stale or zero hash.
- Existing cache artifacts written under the old (binary-blake3) identity remain valid for the unchanged rustc that wrote them. New compiles use the new identity for any new rustc binary.

## Test plan

- [x] \`soldr cargo test -p zccache --lib daemon::server::tests::compiler_hash\` — all 9 pass (7 existing + 2 new).
- [x] \`soldr cargo test -p zccache --lib -- daemon::server::tests\` — all 93 pass.
- [x] \`soldr cargo clippy -p zccache --lib --tests -- -D warnings\` clean.
- [x] \`soldr cargo fmt --all -- --check\` clean.

## Expected benchmark effect

\`rust-workspace-link Cold\` \`build_context_ns\` drops from ~37 ms (#525 baseline) to ~10 ms. Combined with #519 + #521 + #522 + #525 already in main, total cold time should approach bare (~35 ms + ~15 ms overhead = ~50 ms vs current 125 ms). The perf_guard floor from #519 gates regressions.

Refs #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)