### PR TITLE
perf(diag): emit zccache_link_miss_profile from handle_link_ephemeral (refs #535)

### DIFF
--- a/crates/zccache/src/daemon/server/handle_compile.rs
+++ b/crates/zccache/src/daemon/server/handle_compile.rs
@@ -15,6 +15,12 @@ mod request;
 use super::*;
 use request::CompileRequest;
 
+// Re-export the link miss profile so `handle_link` can emit phase data
+// without owning a copy of the struct. Issue #535 — the ephemeral link
+// path needs the same per-phase counters the compile path already
+// emits, gated on the same `ZCCACHE_PROFILE_CC_MISS` env.
+pub(super) use miss_profile::{emit_link_miss_profile, LinkMissProfile};
+
 pub(super) async fn handle_compile(
     state_arc: &Arc<SharedState>,
     session_id: &str,

--- a/crates/zccache/src/daemon/server/handle_compile/miss_profile.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/miss_profile.rs
@@ -209,6 +209,74 @@ pub(super) struct CcMissProfile<'a> {
     pub(super) artifact_store_ns: u64,
 }
 
+/// Cold-miss phase profile for `Request::LinkEphemeral` paths
+/// (`handle_link_ephemeral` — ar / clang++ link / driver-link).
+///
+/// Distinct from `CcMissProfile` because link/archive operations don't
+/// have system-include discovery, dep-info scanning, or a
+/// CompileContext — the dominant phases are tool-hash, input-hash,
+/// the tool spawn, and the output read for cache storage. Issue #535
+/// needs this to confirm whether `c-static-library-link Cold` /
+/// `cpp-driver-link Cold` overhead lives in input hashing (the #533
+/// overlap target) or somewhere else.
+pub(in crate::daemon::server) struct LinkMissProfile<'a> {
+    pub(in crate::daemon::server) family: &'a str,
+    pub(in crate::daemon::server) input_count: usize,
+    pub(in crate::daemon::server) total_ns: u64,
+    pub(in crate::daemon::server) parse_args_ns: u64,
+    pub(in crate::daemon::server) tool_hash_ns: u64,
+    pub(in crate::daemon::server) input_hash_ns: u64,
+    pub(in crate::daemon::server) cache_lookup_ns: u64,
+    pub(in crate::daemon::server) compiler_process_ns: u64,
+    pub(in crate::daemon::server) output_read_ns: u64,
+    pub(in crate::daemon::server) artifact_store_ns: u64,
+}
+
+pub(in crate::daemon::server) fn emit_link_miss_profile(profile: LinkMissProfile<'_>) {
+    let LinkMissProfile {
+        family,
+        input_count,
+        total_ns,
+        parse_args_ns,
+        tool_hash_ns,
+        input_hash_ns,
+        cache_lookup_ns,
+        compiler_process_ns,
+        output_read_ns,
+        artifact_store_ns,
+    } = profile;
+
+    let accounted_ns = parse_args_ns
+        .saturating_add(tool_hash_ns)
+        .saturating_add(input_hash_ns)
+        .saturating_add(cache_lookup_ns)
+        .saturating_add(compiler_process_ns)
+        .saturating_add(output_read_ns)
+        .saturating_add(artifact_store_ns);
+    let unaccounted_ns = total_ns.saturating_sub(accounted_ns);
+
+    eprintln!(
+        concat!(
+            "zccache_link_miss_profile ",
+            "family={} input_count={} total_ns={} parse_args_ns={} ",
+            "tool_hash_ns={} input_hash_ns={} cache_lookup_ns={} ",
+            "compiler_process_ns={} output_read_ns={} ",
+            "artifact_store_ns={} unaccounted_ns={}",
+        ),
+        family,
+        input_count,
+        total_ns,
+        parse_args_ns,
+        tool_hash_ns,
+        input_hash_ns,
+        cache_lookup_ns,
+        compiler_process_ns,
+        output_read_ns,
+        artifact_store_ns,
+        unaccounted_ns,
+    );
+}
+
 pub(super) fn emit_cc_miss_profile(profile: CcMissProfile<'_>) {
     let CcMissProfile {
         family,

--- a/crates/zccache/src/daemon/server/handle_link.rs
+++ b/crates/zccache/src/daemon/server/handle_link.rs
@@ -14,6 +14,11 @@ pub(super) async fn handle_link_ephemeral(
     cwd: &Path,
     env: Option<Vec<(String, String)>>,
 ) -> Response {
+    // Issue #535: collect phase counters when `ZCCACHE_PROFILE_CC_MISS` is set
+    // so the bench / perf-guard logs carry breakdown data for cold link/
+    // archive operations (c-static-library-link, cpp-driver-link).
+    let profile_enabled = std::env::var_os(CC_MISS_PROFILE_ENV).is_some();
+    let link_start = std::time::Instant::now();
     let lineage = super::super::lineage::Lineage::current(Some(client_pid), None);
     use crate::compiler::parse_archiver::{parse_archive_invocation, ParsedArchiveInvocation};
     use crate::compiler::parse_linker::{parse_linker_invocation, ParsedLinkerInvocation};
@@ -99,8 +104,15 @@ pub(super) async fn handle_link_ephemeral(
         None
     };
 
+    let parse_args_ns = if profile_enabled {
+        link_start.elapsed().as_nanos() as u64
+    } else {
+        0
+    };
+
     // 3. Hash the tool binary
     let tool_path = std::path::Path::new(tool);
+    let t_tool_hash = profile_enabled.then(std::time::Instant::now);
     let tool_hash = match hash_file_via_cache(state, tool_path) {
         Some(h) => h,
         None => {
@@ -117,8 +129,13 @@ pub(super) async fn handle_link_ephemeral(
         }
     };
 
+    let tool_hash_ns = t_tool_hash
+        .map(|t| t.elapsed().as_nanos() as u64)
+        .unwrap_or(0);
+
     // 4. Hash all input files
     let cwd_path = std::path::Path::new(cwd);
+    let t_input_hash = profile_enabled.then(std::time::Instant::now);
     let link_key_plan = build_link_path_remap_key_plan(
         &parsed_tool.cache_relevant_flags,
         cwd_path,
@@ -172,10 +189,15 @@ pub(super) async fn handle_link_ephemeral(
         key_builder = key_builder.input(input_hash);
     }
 
+    let input_hash_ns = t_input_hash
+        .map(|t| t.elapsed().as_nanos() as u64)
+        .unwrap_or(0);
+    let input_count = parsed_tool.input_files.len() + link_key_plan.extra_input_files.len();
     let cache_key = key_builder.build();
     let key_hex = cache_key.to_hex();
 
     // 5. Cache lookup
+    let t_cache_lookup = profile_enabled.then(std::time::Instant::now);
     if let Some(mut entry) = lookup_artifact_with_disk_fallback(state, &key_hex) {
         entry.last_used = std::time::Instant::now();
         // Load payloads from disk if not already loaded.
@@ -236,6 +258,10 @@ pub(super) async fn handle_link_ephemeral(
         // Payloads missing — treat as cache miss, fall through
     }
 
+    let cache_lookup_ns = t_cache_lookup
+        .map(|t| t.elapsed().as_nanos() as u64)
+        .unwrap_or(0);
+
     // 6. Cache miss — run the real tool
     tracing::debug!(%key_hex, "link cache miss");
     state.stats.record_link_miss();
@@ -265,6 +291,7 @@ pub(super) async fn handle_link_ephemeral(
     // Clone env for the hook (we need to re-use it; passthrough consumes env).
     let env_for_hook = env.clone();
 
+    let t_compiler_process = profile_enabled.then(std::time::Instant::now);
     let result = run_tool_passthrough(
         tool,
         args,
@@ -274,6 +301,10 @@ pub(super) async fn handle_link_ephemeral(
         state.depfile_tmpdir.as_path(),
     )
     .await;
+
+    let compiler_process_ns = t_compiler_process
+        .map(|t| t.elapsed().as_nanos() as u64)
+        .unwrap_or(0);
 
     // 6b. Invoke optional post-link deploy command on successful link.
     // This handles the case where the compiler driver does NOT auto-deploy
@@ -444,7 +475,7 @@ pub(super) async fn handle_link_ephemeral(
         }
     }
 
-    match (result, nd_warning) {
+    let final_response = match (result, nd_warning) {
         (
             Response::LinkResult {
                 exit_code,
@@ -462,7 +493,36 @@ pub(super) async fn handle_link_ephemeral(
             warning,
         },
         (result, _) => result,
+    };
+
+    if profile_enabled {
+        let total_ns = link_start.elapsed().as_nanos() as u64;
+        // Tool-family label derived from the original parse — keep it
+        // short for grep/awk friendliness in published bench logs.
+        let family = tool
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("link")
+            .to_string();
+        super::handle_compile::emit_link_miss_profile(super::handle_compile::LinkMissProfile {
+            family: family.as_str(),
+            input_count,
+            total_ns,
+            parse_args_ns,
+            tool_hash_ns,
+            input_hash_ns,
+            cache_lookup_ns,
+            compiler_process_ns,
+            // output_read_ns + artifact_store_ns are not measured today —
+            // the cache populate runs in a background spawn after we
+            // return. Tracked as zero here so the published line stays
+            // parseable; a follow-up can plumb them through if needed.
+            output_read_ns: 0,
+            artifact_store_ns: 0,
+        });
     }
+
+    final_response
 }
 /// Run a tool directly (passthrough) and return a LinkResult response.
 ///


### PR DESCRIPTION
## Summary

Follow-up to #536. That PR added cc_miss_profile emission for \`Request::Compile\` cold misses, but the published log revealed all the profile lines came from the single-file compile benches — the link/archive benches (c-static-library-link, cpp-driver-link, the cells #535 originally targeted) send \`Request::LinkEphemeral\` which routes through \`handle_link_ephemeral\`, a separate handler with no phase instrumentation.

This PR adds the link-path profile so the next perf iteration can target the right phase.

- New \`LinkMissProfile\` struct + \`emit_link_miss_profile\` in \`handle_compile/miss_profile.rs\`. Distinct from \`CcMissProfile\` because link/archive operations have no system-include discovery, no dep-info scan, no CompileContext — the dominant phases are tool-hash, input-hash, the spawn, and the post-spawn cache populate.
- \`handle_link_ephemeral\` instrumentation: \`Instant::now\` markers around parse_args, tool_hash, input_hash, cache_lookup, then the tool spawn. All gated behind \`ZCCACHE_PROFILE_CC_MISS\` (the same env #536 added) so one flag now unlocks per-phase data for BOTH compile and link miss paths.

## Visibility

\`LinkMissProfile\` is \`pub(in crate::daemon::server)\` so handle_link can reach it via \`super::handle_compile::LinkMissProfile\`. Existing \`CcMissProfile\` and the rust profile stay private to handle_compile — they need internal context (CompileContext, system include cache state) that handle_link doesn't touch.

## Two phases intentionally zeroed

- \`output_read_ns\` — the post-link output read into \`ArtifactData\`.
- \`artifact_store_ns\` — the cache populate.

Both run in spawn_blocking after the LinkResult response is built and sent, so wall-clock attribution to the client request is muddled. A follow-up can plumb them through if/when those phases turn out to matter.

## Test plan

- [x] \`soldr cargo test -p zccache --lib -- daemon::server::tests\` — all 93 pass.
- [x] \`soldr cargo clippy -p zccache --lib --tests -- -D warnings\` clean.
- [x] \`soldr cargo fmt --all -- --check\` clean.

## What this unblocks

Post-merge, the next benchmark publish will carry \`zccache_link_miss_profile family=ar/clang++ ...\` lines for the c-static-library-link / cpp-driver-link cold rows. If \`input_hash_ns\` dominates, the #535 fix is a direct port of #533's overlap pattern to handle_link. If it's somewhere else (artifact_store, IPC, etc.), we target that instead.

Refs #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)