### PR TITLE
perf(daemon): use `clang -###` for fast C/C++ system-include discovery (refs #541)

### DIFF
--- a/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
@@ -123,16 +123,29 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     // to an empty include list — `watch_directories(&[])` is a fast no-op.
     let t_system_includes = want_rust_miss_profile.then(std::time::Instant::now);
     let compiler_priority = CompilePriority::from_client_env(client_env.as_deref());
-    let needs_discovery = crate::compiler::detect_family(&compiler.to_string_lossy())
-        .needs_system_include_discovery();
+    let compiler_family = crate::compiler::detect_family(&compiler.to_string_lossy());
+    let needs_discovery = compiler_family.needs_system_include_discovery();
     let system_includes = if !needs_discovery {
         Vec::new()
     } else {
+        // Issue #541 option B: for the clang family the daemon prefers
+        // `clang -###` discovery (~3-5 ms) over the slower `-v -E`
+        // (~30-50 ms). Clang's `-###` prints the cc1 command line with
+        // every `-internal-isystem` / `-internal-externc-isystem`
+        // argument WITHOUT spawning the real preprocessor, so the
+        // parser can pull include paths straight out of the printed
+        // argv. Gcc / Msvc don't emit this format; they keep using
+        // the slow path.
+        let use_fast = matches!(compiler_family, crate::compiler::CompilerFamily::Clang);
         let mut cache = state.system_includes.lock().await;
         let lineage_for_probe = lineage.clone();
         cache
             .get_or_discover(&compiler, |c| {
-                let disc_args = crate::depgraph::discovery_args();
+                let disc_args = if use_fast {
+                    crate::depgraph::discovery_args_fast()
+                } else {
+                    crate::depgraph::discovery_args()
+                };
                 let output = {
                     let mut cmd = std::process::Command::new(c);
                     cmd.args(&disc_args);
@@ -145,7 +158,32 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 match output {
                     Ok(out) => {
                         let stderr = String::from_utf8_lossy(&out.stderr);
-                        crate::depgraph::parse_system_include_output(&stderr)
+                        let mut paths = if use_fast {
+                            crate::depgraph::parse_cc1_system_include_output(&stderr)
+                        } else {
+                            crate::depgraph::parse_system_include_output(&stderr)
+                        };
+                        // Defensive fall-through: if the fast probe
+                        // returned no paths (e.g. an older clang that
+                        // doesn't emit `-internal-isystem` flags, or
+                        // the binary detected as Clang turned out to
+                        // be gcc behind a clang symlink), retry with
+                        // the slow `-v -E` discovery. The cache
+                        // memoizes the result either way.
+                        if use_fast && paths.is_empty() {
+                            let slow_args = crate::depgraph::discovery_args();
+                            let mut cmd = std::process::Command::new(c);
+                            cmd.args(&slow_args);
+                            lineage_for_probe.apply_to_sync(&mut cmd, None);
+                            if let Ok(out) = crate::daemon::process::command_output_with_priority(
+                                &mut cmd,
+                                compiler_priority,
+                            ) {
+                                let stderr = String::from_utf8_lossy(&out.stderr);
+                                paths = crate::depgraph::parse_system_include_output(&stderr);
+                            }
+                        }
+                        paths
                     }
                     Err(e) => {
                         tracing::warn!("failed to run compiler for include discovery: {e}");

--- a/crates/zccache/src/depgraph/mod.rs
+++ b/crates/zccache/src/depgraph/mod.rs
@@ -37,5 +37,8 @@ pub use snapshot::{
     classify_load, depgraph_file_path, load_from_file, save_to_file, DepGraphLoadOutcome,
     SnapshotError, DEPGRAPH_VERSION,
 };
-pub use system_includes::{discovery_args, parse_system_include_output, SystemIncludeCache};
+pub use system_includes::{
+    discovery_args, discovery_args_fast, parse_cc1_system_include_output,
+    parse_system_include_output, SystemIncludeCache,
+};
 pub use watcher_support::WatchSet;

--- a/crates/zccache/src/depgraph/system_includes.rs
+++ b/crates/zccache/src/depgraph/system_includes.rs
@@ -87,6 +87,89 @@ pub fn discovery_args() -> Vec<&'static str> {
     }
 }
 
+/// Build the **fast** clang-family discovery command arguments.
+///
+/// Issue #541 option (B): `clang -###` makes clang print the `-cc1`
+/// command-line it WOULD execute, then exit without spawning cc1. The
+/// printed line includes `-internal-isystem` / `-internal-externc-isystem`
+/// flags pointing at every system include path the driver would have
+/// passed to the real preprocessor. Wall-clock: ~3-5 ms vs the ~30-50 ms
+/// of the full `-v -E` discovery.
+///
+/// Only safe for clang-family compilers (clang, clang++, em++,
+/// clang-cl). Gcc accepts `-###` but emits a different format that
+/// doesn't include the per-path `-internal-isystem` flags this parser
+/// expects. Use [`discovery_args`] (the slow path) for gcc/MSVC.
+#[must_use]
+pub fn discovery_args_fast() -> Vec<&'static str> {
+    if cfg!(windows) {
+        vec!["-###", "-E", "-x", "c++", "NUL"]
+    } else {
+        vec!["-###", "-E", "-x", "c++", "/dev/null"]
+    }
+}
+
+/// Parse the `-cc1` line from clang's `-###` output and extract every
+/// `-internal-isystem` / `-internal-externc-isystem` path.
+///
+/// The driver prints exactly one line per invocation that looks like:
+///
+/// ```text
+///  "/usr/lib/llvm-18/bin/clang-18" "-cc1" "-triple" "x86_64-pc-linux-gnu" "-E" \
+///    "-internal-isystem" "/usr/lib/llvm-18/lib/clang/18/include" \
+///    "-internal-isystem" "/usr/local/include" \
+///    "-internal-externc-isystem" "/usr/include/x86_64-linux-gnu" \
+///    "-internal-externc-isystem" "/usr/include" ...
+/// ```
+///
+/// Tokens are double-quoted; spaces inside paths are preserved by the
+/// quoting. The tokenizer splits on `"` and reads odd-indexed segments
+/// (the actual argument values, alternating with single-space gaps).
+///
+/// Returns the include paths in driver-emitted order (which matches
+/// clang's actual `#include <...>` search order — the first `-cc1`
+/// invocation's order is canonical).
+#[must_use]
+pub fn parse_cc1_system_include_output(output: &str) -> Vec<NormalizedPath> {
+    let mut paths = Vec::new();
+    for line in output.lines() {
+        // Cheap shape probe — the cc1 line always contains "-cc1" as a
+        // quoted token. Skip everything else (version banner, "Found
+        // candidate GCC" notes, etc.).
+        if !line.contains("\"-cc1\"") {
+            continue;
+        }
+        let tokens = tokenize_quoted(line);
+        let mut iter = tokens.iter();
+        while let Some(token) = iter.next() {
+            if *token == "-internal-isystem" || *token == "-internal-externc-isystem" {
+                if let Some(path) = iter.next() {
+                    if !path.is_empty() {
+                        paths.push(NormalizedPath::new(*path));
+                    }
+                }
+            }
+        }
+        // Only the first cc1 line — multi-arch / multi-tu drivers may
+        // emit several but the include search order is identical.
+        if !paths.is_empty() {
+            break;
+        }
+    }
+    paths
+}
+
+/// Split a `-###`-style quoted command line on `"` and return the
+/// odd-indexed segments (the actual argument values). Empty even-index
+/// segments are the inter-quote whitespace; even-index non-empty
+/// segments would indicate malformed quoting and are dropped.
+fn tokenize_quoted(line: &str) -> Vec<&str> {
+    line.split('"')
+        .enumerate()
+        .filter_map(|(i, s)| if i % 2 == 1 { Some(s) } else { None })
+        .collect()
+}
+
 /// On-disk format version for the persisted `SystemIncludeCache` snapshot.
 ///
 /// Bump on any layout change so the loader rejects older / newer snapshots
@@ -525,5 +608,78 @@ End of search list.
     #[test]
     fn discovery_args_returns_nonempty() {
         assert!(!discovery_args().is_empty());
+    }
+
+    #[test]
+    fn discovery_args_fast_contains_triple_hash() {
+        // Sanity: the fast path uses `-###` so clang prints the cc1
+        // command without spawning the real preprocessor.
+        assert!(discovery_args_fast().contains(&"-###"));
+        assert!(discovery_args_fast().contains(&"-E"));
+        assert!(discovery_args_fast().contains(&"-x"));
+        assert!(discovery_args_fast().contains(&"c++"));
+    }
+
+    #[test]
+    fn parse_cc1_output_extracts_internal_isystem_paths() {
+        // Realistic clang 18 -### output on Ubuntu 24.04. The cc1 line
+        // is at the bottom, all args quoted with double quotes.
+        let output = r#"clang version 18.1.3 (1ubuntu1)
+Target: x86_64-pc-linux-gnu
+Thread model: posix
+InstalledDir: /usr/bin
+Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/13
+Selected GCC installation: /usr/lib/gcc/x86_64-linux-gnu/13
+Candidate multilib: .;@m64
+Selected multilib: .;@m64
+ "/usr/lib/llvm-18/bin/clang-18" "-cc1" "-triple" "x86_64-pc-linux-gnu" "-E" "-disable-free" "-disable-llvm-verifier" "-main-file-name" "null" "-mrelocation-model" "pic" "-pic-level" "2" "-mframe-pointer=all" "-fmath-errno" "-ffp-contract=on" "-fno-rounding-math" "-mconstructor-aliases" "-funwind-tables=2" "-target-cpu" "x86-64" "-debugger-tuning=gdb" "-fcoverage-compilation-dir=/tmp" "-resource-dir" "/usr/lib/llvm-18/lib/clang/18" "-internal-isystem" "/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13" "-internal-isystem" "/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/x86_64-linux-gnu/c++/13" "-internal-isystem" "/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/backward" "-internal-isystem" "/usr/lib/llvm-18/lib/clang/18/include" "-internal-isystem" "/usr/local/include" "-internal-externc-isystem" "/usr/include/x86_64-linux-gnu" "-internal-externc-isystem" "/include" "-internal-externc-isystem" "/usr/include" "-fdeprecated-macro" "-ferror-limit" "19" "-fgnuc-version=4.2.1" "-fcxx-exceptions" "-fexceptions" "-fcolor-diagnostics" "-target-feature" "+cx8" "-target-feature" "+fxsr" "-target-feature" "+mmx" "-target-feature" "+sse" "-target-feature" "+sse2" "-target-feature" "+x87" "-faddrsig" "-D__GCC_HAVE_DWARF2_CFI_ASM=1" "-o" "-" "-x" "c++" "/dev/null"
+"#;
+
+        let paths = parse_cc1_system_include_output(output);
+        assert_eq!(
+            paths.len(),
+            8,
+            "expected 5 isystem + 3 externc-isystem entries, got {paths:?}",
+        );
+        // First captures must include the GCC C++ headers (driver
+        // canonical-order):
+        assert_eq!(
+            paths[0],
+            NormalizedPath::new(
+                "/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13"
+            ),
+        );
+        // Last must be /usr/include (the catch-all):
+        assert_eq!(paths[7], NormalizedPath::new("/usr/include"));
+    }
+
+    #[test]
+    fn parse_cc1_output_empty_when_no_cc1_line() {
+        // Output without a cc1 line (e.g. gcc -### or a compiler that
+        // doesn't support `-###`) must yield an empty path list so the
+        // caller can fall back to the slow `-v -E` discovery.
+        let output = "gcc version 13.2.0 (Ubuntu 13.2.0-23ubuntu4)\nCOLLECT_GCC_OPTIONS='-### -E -x c++' '-mtune=generic' '-march=x86-64'\n";
+        let paths = parse_cc1_system_include_output(output);
+        assert!(paths.is_empty(), "expected empty, got {paths:?}");
+    }
+
+    #[test]
+    fn parse_cc1_output_handles_paths_with_spaces() {
+        // Driver quoting preserves spaces inside paths — the tokenizer
+        // must read the whole quoted segment as one token.
+        let output =
+            "\"/usr/bin/clang\" \"-cc1\" \"-E\" \"-internal-isystem\" \"/opt/Custom Include Path/v1\" \"-x\" \"c++\" \"/dev/null\"\n";
+        let paths = parse_cc1_system_include_output(output);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], NormalizedPath::new("/opt/Custom Include Path/v1"));
+    }
+
+    #[test]
+    fn parse_cc1_output_skips_isystem_when_value_missing() {
+        // Truncated cc1 line — the -internal-isystem flag with no value
+        // following must not panic and must not produce an entry.
+        let output = "\"/usr/bin/clang\" \"-cc1\" \"-internal-isystem\"\n";
+        let paths = parse_cc1_system_include_output(output);
+        assert!(paths.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Option B from #541 — the bench-visible companion to #542 (persistence). Replaces the ~30-50 ms \`<compiler> -v -E -x c++ /dev/null\` discovery spawn with clang's \`-###\` form that prints the cc1 command line WITHOUT actually invoking the preprocessor. Wall-clock: ~3-5 ms vs ~30-50 ms.

- \`discovery_args_fast()\` returns \`-### -E -x c++ /dev/null\` (or \`NUL\` on Windows).
- \`parse_cc1_system_include_output\` tokenizes the cc1 line by splitting on \`\"\` and reading odd-indexed segments — robust against paths containing spaces.
- \`pipeline.rs\` gates the fast path on \`CompilerFamily::Clang\` ONLY. Gcc / Msvc keep the slow path since their \`-###\` output doesn't include the \`-internal-isystem\` flags this parser expects.
- Defensive fall-through: if the fast probe yields zero paths, the closure retries with the slow \`-v -E\` discovery. The cache memoizes either result.

## Why now

#536's data showed cpp-inline Single-file Cold's \`system_includes_ns = 44.7 ms\` (98 % of pre_exec). #542 just merged and persists discovery across restarts — production win. This PR is the COMPLEMENT: a faster method that helps even the very-first-ever daemon, which is what the bench measures.

## TDD coverage

5 new parser tests:
- Real clang 18 \`-###\` output → 8 paths extracted in driver-canonical order.
- Gcc-style output (no cc1 line) → empty, triggers caller fall-through.
- Paths containing spaces → preserved as single tokens (quoting respected).
- Truncated cc1 line (-internal-isystem with no value) → no panic, no spurious entry.
- \`discovery_args_fast\` sanity check.

## Test plan

- [x] \`soldr cargo test -p zccache --lib -- depgraph::system_includes\` — all 15 pass (10 from #542 + 5 new).
- [x] \`soldr cargo test -p zccache --lib -- daemon::server::tests\` — all 93 pass.
- [x] \`soldr cargo clippy -p zccache --lib --tests -- -D warnings\` clean.
- [x] \`soldr cargo fmt --all -- --check\` clean.

## Expected benchmark effect

For clang-driven cold benches (cpp-inline / c-inline Single-file Cold, cpp-driver-link Cold, emscripten Cold via em++):

| Bench | Cold today | Cold projected |
|---|---:|---:|
| cpp-inline Single-file Cold | 89 ms | ~50 ms (−39 ms ≈ first-call system_includes saved) |
| c-inline Single-file Cold | 2.1 s | ~2.06 s (−40 ms first compile, amortized across 50 source files) |
| cpp-driver-link Cold | 75 ms | unchanged (link path skips system_includes entirely) |

The actual delta will be in the next benchmark publish.

## Note on em++ family

\`detect_family\` classifies \`em++\` as Clang. \`em++\` is a Python wrapper around clang and DOES support \`-###\` in passthrough mode. If it doesn't, the defensive fall-through hits the slow path with no net cost (one extra spawn on first-ever discovery, cached forever after).

Refs #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)