### PR TITLE
perf(core): zero-copy OsString → String in normalize_for_key on Linux (refs #550)

### DIFF
--- a/crates/zccache/src/core/path.rs
+++ b/crates/zccache/src/core/path.rs
@@ -255,7 +255,16 @@ pub fn normalize_for_key(path: &Path) -> String {
 
     #[cfg(not(any(windows, target_os = "macos")))]
     {
-        normalized.to_string_lossy().into_owned()
+        // Issue #550: zero-copy `OsString::into_string()` when the path is
+        // valid UTF-8 (always true for the C/C++ headers in the hot
+        // `compute_artifact_key` loop). Falls back to lossy conversion if
+        // not — preserves prior `to_string_lossy().into_owned()` behavior.
+        // Saves one `String` allocation per call on Linux (~500 alloc/dealloc
+        // pairs per cpp-inline cold compile of `<iostream>`-bearing files).
+        normalized
+            .into_os_string()
+            .into_string()
+            .unwrap_or_else(|os| os.to_string_lossy().into_owned())
     }
 }
 


### PR DESCRIPTION
## Summary

A targeted 2-line fix on the Linux branch of \`normalize_for_key\`. Replaces \`to_string_lossy().into_owned()\` (which always allocates a new \`String\`, even when the path is valid UTF-8) with \`into_os_string().into_string()\` (which reuses the \`OsString\`'s buffer when the bytes are valid UTF-8 — the always-true case for system C/C++ headers).

Fallback to lossy conversion preserves the prior behavior bit-for-bit for non-UTF-8 paths.

## Why

#550 traced the cpp-inline Single-file Cold per-compile bottleneck to \`depgraph_update_ns = 7.47 ms\` (99% of artifact_store_ns). The hot phase is \`compute_artifact_key\`'s loop over 500+ resolved C++ include headers, each calling \`normalize_for_key\`. Saving one allocation per call × 500 calls = ~500 µs per compile.

This is a clean targeted win, not the silver bullet. The bigger architectural fix (caching normalized paths per (header, key_root) in \`DepGraph\`) stays queued on #550 — that needs careful design and lifetime threading.

## Test plan

- [x] \`soldr cargo test -p zccache --lib\` — all 1647 tests pass (existing \`core::path::tests\` cover the normalize behavior end-to-end).
- [x] \`soldr cargo clippy -p zccache --lib --tests -- -D warnings\` clean.
- [x] \`soldr cargo fmt --all -- --check\` clean.

## Expected benchmark effect

Next \`zccache_cc_miss_profile\` publish should show \`depgraph_update_ns\` drop from ~7.5 ms to ~7.0 ms on cpp-inline Single-file Cold per-compile. Modest but visible.

Refs #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)