### PR TITLE
fix(daemon): bound Status-probe recv to 2s in check_daemon_version (#554)

### DIFF
--- a/crates/zccache/src/cli/commands/daemon.rs
+++ b/crates/zccache/src/cli/commands/daemon.rs
@@ -3,6 +3,7 @@
 use crate::core::NormalizedPath;
 use std::process::ExitCode;
 
+use super::super::status_probe_timeout;
 use super::util::{connect, resolve_endpoint, run_async};
 
 pub(crate) enum VersionCheck {
@@ -22,6 +23,12 @@ pub(crate) enum VersionCheck {
 }
 
 /// Connect to the daemon and compare its version to ours.
+///
+/// The Status recv is bounded by [`status_probe_timeout`] so that a wedged
+/// daemon (alive socket, no response) surfaces as `CommError` in seconds
+/// rather than the 5-minute global default. The caller's recovery path
+/// (`ensure_daemon` → `stop_stale_daemon` → `spawn_and_wait`) then runs
+/// promptly. See issue #554.
 pub(crate) async fn check_daemon_version(endpoint: &str) -> VersionCheck {
     let mut conn = match connect(endpoint).await {
         Ok(c) => c,
@@ -30,7 +37,10 @@ pub(crate) async fn check_daemon_version(endpoint: &str) -> VersionCheck {
     if conn.send(&crate::protocol::Request::Status).await.is_err() {
         return VersionCheck::CommError;
     }
-    match conn.recv::<crate::protocol::Response>().await {
+    match conn
+        .recv_with_timeout::<crate::protocol::Response>(status_probe_timeout())
+        .await
+    {
         Ok(Some(crate::protocol::Response::Status(s))) => {
             if s.version == crate::core::VERSION {
                 return VersionCheck::Ok;

--- a/crates/zccache/src/cli/commands/tests/daemon.rs
+++ b/crates/zccache/src/cli/commands/tests/daemon.rs
@@ -1,8 +1,10 @@
 //! Daemon-bootstrap / teardown regression tests. These cover the
-//! protocol-mismatch auto-recovery path (issue #27) and the bounded wait
-//! after a clean stop.
+//! protocol-mismatch auto-recovery path (issue #27), the bounded wait
+//! after a clean stop, and the bounded Status-probe (issue #554).
 
-use super::super::daemon::{ensure_daemon, wait_for_daemon_teardown};
+use super::super::daemon::{
+    check_daemon_version, ensure_daemon, wait_for_daemon_teardown, VersionCheck,
+};
 
 // ── Protocol mismatch recovery (issue #27) ──────────────────
 
@@ -79,5 +81,83 @@ fn wait_for_daemon_teardown_returns_when_endpoint_unreachable() {
     assert!(
         elapsed < std::time::Duration::from_secs(2),
         "wait_for_daemon_teardown blocked for {elapsed:?} despite endpoint unreachable at t=0"
+    );
+}
+
+// ── Wedged-daemon Status probe (issue #554) ──────────────────────────
+
+/// Regression test for <https://github.com/zackees/zccache/issues/554>.
+///
+/// When the daemon's IPC accepts connections but never answers `Request::Status`,
+/// `check_daemon_version` must surface `CommError` within the configured probe
+/// timeout — not the 5-minute global recv default. Before the fix this took
+/// 300 s; with the fix it takes ≤ 2 s (or whatever
+/// `ZCCACHE_STATUS_PROBE_TIMEOUT_SECS` is set to).
+#[tokio::test]
+async fn check_daemon_version_is_bounded_when_daemon_never_answers() {
+    // Force a 1-second probe so the test stays fast.
+    std::env::set_var("ZCCACHE_STATUS_PROBE_TIMEOUT_SECS", "1");
+
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let ep = endpoint.clone();
+
+    // Fake wedged daemon: accept once, hold the connection open without
+    // responding so the client's recv hits the timeout (not ConnectionClosed).
+    let mut listener = crate::ipc::IpcListener::bind(&ep).expect("bind listener");
+    let server = tokio::spawn(async move {
+        let _conn = listener.accept().await;
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    });
+
+    // Give the listener a moment to be ready.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let started = std::time::Instant::now();
+    let verdict = check_daemon_version(&endpoint).await;
+    let elapsed = started.elapsed();
+
+    server.abort();
+    std::env::remove_var("ZCCACHE_STATUS_PROBE_TIMEOUT_SECS");
+
+    assert!(
+        matches!(verdict, VersionCheck::CommError),
+        "unresponsive Status probe should route to CommError recovery"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "check_daemon_version took {elapsed:?} against an unresponsive daemon — \
+         issue #554 expects bounded fail-fast (≤ probe timeout + epsilon)"
+    );
+}
+
+/// End-to-end guard for the `ensure_daemon` recovery branch behind the bounded
+/// Status probe. Ignored for the same reason as the issue #27 integration test:
+/// with a daemon binary available, this may spawn a real replacement daemon.
+#[tokio::test]
+#[ignore] // Integration test — may spawn the daemon binary. Run with `test --full`.
+async fn ensure_daemon_is_bounded_when_status_probe_never_answers() {
+    std::env::set_var("ZCCACHE_STATUS_PROBE_TIMEOUT_SECS", "1");
+
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let ep = endpoint.clone();
+
+    let mut listener = crate::ipc::IpcListener::bind(&ep).expect("bind listener");
+    let server = tokio::spawn(async move {
+        let _conn = listener.accept().await;
+        tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let started = std::time::Instant::now();
+    let result = ensure_daemon(&endpoint).await;
+    let elapsed = started.elapsed();
+
+    server.abort();
+    std::env::remove_var("ZCCACHE_STATUS_PROBE_TIMEOUT_SECS");
+
+    assert!(
+        elapsed < std::time::Duration::from_secs(10),
+        "ensure_daemon took {elapsed:?} against an unresponsive daemon; result={result:?}"
     );
 }

--- a/crates/zccache/src/cli/mod.rs
+++ b/crates/zccache/src/cli/mod.rs
@@ -9,6 +9,22 @@ mod runtime;
 pub mod snapshot_fp;
 pub mod symbols;
 
+/// Default per-call timeout for the `Status` probe used by daemon version
+/// checks. Two seconds keeps startup responsive when an existing daemon is
+/// alive but IPC-deaf, while still leaving normal Compile/Link roundtrips on
+/// the generous global client recv timeout.
+const STATUS_PROBE_DEFAULT_SECS: u64 = 2;
+
+/// Returns the per-call timeout for daemon version-probe Status recv calls,
+/// honoring `ZCCACHE_STATUS_PROBE_TIMEOUT_SECS` when it parses as `u64`.
+pub(crate) fn status_probe_timeout() -> std::time::Duration {
+    let secs = std::env::var("ZCCACHE_STATUS_PROBE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(STATUS_PROBE_DEFAULT_SECS);
+    std::time::Duration::from_secs(secs)
+}
+
 // Re-export daemon-lifecycle helpers moved to `runtime.rs` (issue #365 wave 6)
 // so the public API path is unchanged.
 #[allow(deprecated)]

--- a/crates/zccache/src/cli/runtime.rs
+++ b/crates/zccache/src/cli/runtime.rs
@@ -54,7 +54,10 @@ async fn check_daemon_version(endpoint: &str) -> VersionCheck {
     if conn.send(&crate::protocol::Request::Status).await.is_err() {
         return VersionCheck::CommError;
     }
-    match conn.recv::<crate::protocol::Response>().await {
+    match conn
+        .recv_with_timeout::<crate::protocol::Response>(super::status_probe_timeout())
+        .await
+    {
         Ok(Some(crate::protocol::Response::Status(s))) => {
             if s.version == crate::core::VERSION {
                 return VersionCheck::Ok;

--- a/crates/zccache/src/ipc/transport.rs
+++ b/crates/zccache/src/ipc/transport.rs
@@ -27,12 +27,12 @@ use super::error::IpcError;
 /// `IpcError::Io(_)` or `IpcError::ConnectionClosed` without involving
 /// this timeout.
 ///
-/// Five minutes is intentionally generous. If a real workload exceeds it,
-/// switch that single call site to `recv_with_timeout` with a longer
-/// budget rather than bumping the const — the const is also the upper
-/// bound on hung-daemon detection latency for `ensure_daemon`'s
-/// auto-recovery path, and shortening it is the easier fix once the
-/// daemon side is fast enough.
+/// Five minutes is intentionally generous for Compile/Link responses. Cheap
+/// daemon-health probes that need fast recovery, such as `ensure_daemon`'s
+/// version `Status` probe, must override this with `recv_with_timeout` and a
+/// short per-call budget. If a real workload exceeds this default, switch that
+/// specific call site to `recv_with_timeout` with a longer budget rather than
+/// bumping the const.
 pub const DEFAULT_CLIENT_RECV_TIMEOUT: Duration = Duration::from_secs(300);
 
 // ── Platform-specific connection inner ──────────────────────────────


### PR DESCRIPTION
## Summary

Closes #554. `zccache start` was blocking ~5 minutes whenever the existing daemon was alive but IPC-deaf because the startup Status probe inherited the 300 s `DEFAULT_CLIENT_RECV_TIMEOUT`. The recovery path (`stop_stale_daemon` -> `spawn_and_wait`) already existed, but it ran behind that long recv timeout, which forced downstream fbuild to add a 30 s wrapper-side cutoff (`FBUILD_ZCCACHE_START_TIMEOUT_SECS`). Reported as [FastLED/fbuild#346](https://github.com/FastLED/fbuild/issues/346) finding (2).

This routes daemon version Status probes through the existing `recv_with_timeout` helper with a 2 s default budget, overridable via `ZCCACHE_STATUS_PROBE_TIMEOUT_SECS`. Compile/Link IPC roundtrips continue to use the global 300 s default for legitimate long-running LTO/link workloads.

Worst-case wedged-daemon detection drops from ~300 s to the short probe budget, so startup recovery can happen inside fbuild's 30 s wrapper timeout.

## Diff scope

- `crates/zccache/src/cli/mod.rs` - shared `status_probe_timeout()` helper and `STATUS_PROBE_DEFAULT_SECS = 2`.
- `crates/zccache/src/cli/commands/daemon.rs` - `zccache start` Status recv now uses `recv_with_timeout(status_probe_timeout())`; the existing `_ => VersionCheck::CommError` arm still routes timeouts into recovery.
- `crates/zccache/src/cli/runtime.rs` - reusable library/client startup path uses the same bounded Status probe, so `client_start`/library callers do not retain the old 300 s startup hang.
- `crates/zccache/src/ipc/transport.rs` - updated `DEFAULT_CLIENT_RECV_TIMEOUT` docs to note that fast daemon-health probes override the global default.
- `crates/zccache/src/cli/commands/tests/daemon.rs` - wedged listener tests for the bounded Status probe and the `ensure_daemon` recovery branch.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `soldr cargo test -p zccache --lib check_daemon_version_is_bounded_when_daemon_never_answers` - passed in 1.22 s
- [x] `soldr cargo test -p zccache --lib ensure_daemon_is_bounded_when_status_probe_never_answers -- --ignored --nocapture` - passed in 2.49 s
- [x] `soldr cargo test -p zccache --lib` - 1648 passed, 0 failed, 15 ignored
- [x] `soldr cargo clippy -p zccache --lib --tests -- -D warnings` - clean
- [x] CI green on Linux + macOS + Windows

## Cross-references

- Closes zackees/zccache#554
- Unblocks FastLED/fbuild#352 (downstream cleanup of `FBUILD_ZCCACHE_START_TIMEOUT_SECS` after a tagged zccache release)
- Related: zackees/zccache#555 (sibling FastLED `_kill_zombie_zccache` workaround status)
- Origin report: [FastLED/fbuild#346](https://github.com/FastLED/fbuild/issues/346) finding (2)