### PR TITLE
perf(daemon): preserve system_includes cache across Request::Clear (fixes #558)

### DIFF
--- a/crates/zccache/src/daemon/server/handle_clear.rs
+++ b/crates/zccache/src/daemon/server/handle_clear.rs
@@ -24,6 +24,16 @@ pub(super) async fn handle_clear(state: &SharedState) -> Response {
     };
 
     // Clear all subsystems.
+    //
+    // Issue #558: `system_includes` and `compiler_hash_cache` are NOT
+    // cleared — they're compiler-environment data keyed by
+    // `(compiler_path, mtime, size)` and self-correcting via stat-verify
+    // on access. Wiping them costs ~44 ms (re-probe via `<compiler> -v
+    // -E`) / ~50–60 ms (re-blake3 the compiler binary) on the next
+    // compile, paying nothing toward the user's intent of clearing
+    // built artifacts. The on-disk persistence (issues #517 and #541)
+    // exists specifically to survive across daemon lifecycle — Clear
+    // is not a stronger lifecycle event than restart.
     state.dep_graph.clear();
     state.cache_system.clear();
     state.fast_hit_cache.clear();
@@ -31,7 +41,6 @@ pub(super) async fn handle_clear(state: &SharedState) -> Response {
     state.request_validation_cache.clear();
     state.rsp_cache.clear();
     state.watched_raw_dirs.clear();
-    state.system_includes.lock().await.clear();
     state.watched_dirs.lock().await.clear();
 
     // Reset stats and profiler.

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -247,4 +247,38 @@ impl DaemonServer {
     pub fn test_artifacts_len(&self) -> usize {
         self.state.artifacts.len()
     }
+
+    /// Test-only seam: insert a synthetic system-includes entry for the
+    /// given compiler path. Issue #558 — lets the `handle_clear` test
+    /// pre-populate the cache before sending Clear so the test can
+    /// verify the entry survives.
+    #[doc(hidden)]
+    pub async fn test_insert_system_includes(
+        &self,
+        compiler: crate::core::NormalizedPath,
+        paths: Vec<crate::core::NormalizedPath>,
+    ) {
+        let mut cache = self.state.system_includes.lock().await;
+        cache.insert(compiler, paths);
+    }
+
+    /// Test-only seam: report the number of entries currently in the
+    /// in-memory `state.system_includes` cache. Issue #558 — used to
+    /// assert `handle_clear` preserves compiler-environment data
+    /// (consistent with `compiler_hash_cache` which is also preserved).
+    #[doc(hidden)]
+    #[must_use]
+    pub async fn test_system_includes_len(&self) -> usize {
+        self.state.system_includes.lock().await.len()
+    }
+
+    /// Test-only seam: borrow the `SharedState` so tests can invoke
+    /// the request handlers directly (e.g. `handle_clear`) without
+    /// standing up the full IPC machinery. Issue #558.
+    #[doc(hidden)]
+    #[cfg(test)]
+    #[must_use]
+    pub(super) fn test_state(&self) -> &SharedState {
+        &self.state
+    }
 }

--- a/crates/zccache/src/daemon/server/tests/clear_handler.rs
+++ b/crates/zccache/src/daemon/server/tests/clear_handler.rs
@@ -1,0 +1,110 @@
+//! Tests for `handle_clear` — Request::Clear's preservation invariants.
+//!
+//! Issue #558: `system_includes` (and the sibling `compiler_hash_cache`)
+//! store compiler-environment data keyed by `(compiler_path, mtime, size)`.
+//! They are self-correcting via stat-verify on every access, so wiping
+//! them across Clear pays the ~44 ms re-probe / ~50–60 ms re-hash penalty
+//! on the next compile while contributing nothing to the user's intent
+//! of clearing built artifacts.
+
+use super::super::*;
+
+/// Unit-level invariant: an entry stored in `SystemIncludeCache` survives
+/// being "skipped by Clear" cleanly. The follow-up `get` stat-verifies the
+/// compiler binary; an unchanged binary returns the cached entry, and any
+/// post-Clear change to the compiler (the only correctness concern with
+/// preservation) is detected on the next access and rejected.
+///
+/// This is the safety net that makes [`handle_clear`] safe to skip
+/// `system_includes.clear()` (and the symmetric `compiler_hash_cache`
+/// already gets this treatment — see issue #517).
+#[test]
+fn system_include_cache_entry_self_verifies_after_clear_skip() {
+    use crate::depgraph::SystemIncludeCache;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let compiler = tmp.path().join("clang");
+    std::fs::write(&compiler, b"compiler binary").unwrap();
+    let include_dir = tmp.path().join("usr-include");
+    std::fs::create_dir_all(&include_dir).unwrap();
+
+    let mut cache = SystemIncludeCache::new();
+    cache.insert(
+        crate::core::NormalizedPath::new(&compiler),
+        vec![crate::core::NormalizedPath::new(&include_dir)],
+    );
+    assert_eq!(cache.len(), 1);
+
+    // "Clear ran but system_includes was NOT wiped" — the entry must
+    // still stat-verify against the unchanged compiler.
+    let hit = cache.get(&compiler);
+    assert!(
+        hit.is_some(),
+        "preserved entry must still stat-verify against an unchanged compiler"
+    );
+    assert_eq!(hit.unwrap().len(), 1);
+
+    // After a compiler change, stat-verify must reject the entry —
+    // this is the safety net that makes preservation across Clear safe.
+    filetime::set_file_mtime(
+        &compiler,
+        filetime::FileTime::from_unix_time(2_000_000_000, 0),
+    )
+    .unwrap();
+    std::fs::write(&compiler, b"different compiler bytes after upgrade").unwrap();
+    let post_change = cache.get(&compiler);
+    assert!(
+        post_change.is_none(),
+        "stat-verify must reject the entry once the compiler binary changes"
+    );
+}
+
+/// Integration-level check: after Clear, the in-memory
+/// `system_includes` cache is NOT empty if it was non-empty before.
+/// Uses the `#[cfg(test)]` `test_insert_system_includes` /
+/// `test_system_includes_len` seams to pre-populate and observe
+/// without standing up a full compile pipeline (which would require
+/// clang on PATH and would couple the test to the chosen toolchain).
+#[tokio::test]
+#[ignore] // integration-level: instantiates a real DaemonServer
+async fn handle_clear_preserves_system_includes() {
+    crate::test_support::test_timeout(async {
+        let endpoint = crate::ipc::unique_test_endpoint();
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+        let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+
+        let fake_compiler = tmp.path().join("fake-clang");
+        std::fs::write(&fake_compiler, b"fake compiler bytes").unwrap();
+        let synthetic_include_dir = tmp.path().join("include");
+        std::fs::create_dir_all(&synthetic_include_dir).unwrap();
+        server
+            .test_insert_system_includes(
+                crate::core::NormalizedPath::new(&fake_compiler),
+                vec![crate::core::NormalizedPath::new(&synthetic_include_dir)],
+            )
+            .await;
+        assert_eq!(
+            server.test_system_includes_len().await,
+            1,
+            "test setup: synthetic entry must be installed"
+        );
+
+        // Drive handle_clear via the same internal call site that the
+        // request handler uses. This bypasses IPC so we retain access
+        // to the server to observe state after Clear.
+        let response = super::super::handle_clear::handle_clear(server.test_state()).await;
+        assert!(
+            matches!(response, Response::Cleared { .. }),
+            "expected Cleared response, got: {response:?}"
+        );
+
+        assert_eq!(
+            server.test_system_includes_len().await,
+            1,
+            "issue #558: handle_clear must preserve system_includes entries — \
+             they self-verify via stat-verify and re-discovery is expensive"
+        );
+    })
+    .await;
+}

--- a/crates/zccache/src/daemon/server/tests/mod.rs
+++ b/crates/zccache/src/daemon/server/tests/mod.rs
@@ -6,6 +6,7 @@
 use std::path::Path;
 
 mod cache_trim;
+mod clear_handler;
 mod client_env;
 mod compiler_hash;
 mod fingerprint;


### PR DESCRIPTION
## Summary

`handle_clear` previously wiped the in-memory system-includes cache, forcing the next C/C++ compile to re-run `<compiler> -v -E -x c++ NUL` (~44 ms — the very cost issue #541 was designed to eliminate via on-disk persistence). Meanwhile the sibling `compiler_hash_cache` (issue #517) was already preserved across Clear. The asymmetric treatment of two semantically identical caches was an oversight.

Both caches are keyed by `(compiler_path, mtime, size)` and stat-verify on access, so preservation is safe: an in-place compiler upgrade is detected on next lookup and the entry is re-discovered. The on-disk persistence layer (issues #517/#541) exists specifically to survive across daemon lifecycle events — Clear is not a stronger event than restart.

## Test plan

- [x] **Unit test** `system_include_cache_entry_self_verifies_after_clear_skip` — invariant on `SystemIncludeCache`: a preserved entry stat-verifies cleanly when the compiler is unchanged, and is rejected once the compiler's `(mtime, size)` shifts.
- [x] **Integration test** `handle_clear_preserves_system_includes` — calls `handle_clear` directly through new `#[cfg(test)]` seams on `DaemonServer` and asserts the entry survives. Verified to **fail** with the prior `state.system_includes.lock().await.clear()` line in place; **passes** after removal.
- [x] Pre-existing `test_server_clear_empty` integration test still passes — the Cleared response contract is unchanged.
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean.
- [x] `soldr cargo fmt --all -- --check` clean.
- [ ] Confirm single-file Cold overhead drops by ~30–44 ms on next `bench (linux / medium)` publish.

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)