### PR TITLE
perf(depgraph): wire path_key_cache into compute_context_key (fixes #561)

### DIFF
--- a/crates/zccache/src/depgraph/context/mod.rs
+++ b/crates/zccache/src/depgraph/context/mod.rs
@@ -215,6 +215,32 @@ pub fn compute_context_key(
     key_root: Option<&Path>,
     worktree_salt: Option<&Path>,
 ) -> ContextKey {
+    compute_context_key_with(ctx, key_root, worktree_salt, |path, root| {
+        normalize_key_path(path, root).into()
+    })
+}
+
+/// Sibling of [`compute_context_key`] that accepts an injectable path
+/// normalizer. Issue #561 — lets `DepGraph::register_context` thread its
+/// `path_key_cache` (added by #553) through every `normalize_key_path`
+/// call, amortizing the per-compile ~50 String allocations across
+/// sequential compiles that share the same include / force-include set
+/// (the cpp-inline Single-file Cold benchmark's 50 sequential
+/// invocations are the dominant beneficiary).
+///
+/// The default `compute_context_key` delegates with
+/// `|p, r| normalize_key_path(p, r).into()` so callers without a
+/// `DepGraph` are unaffected.
+#[must_use]
+pub fn compute_context_key_with<F>(
+    ctx: &CompileContext,
+    key_root: Option<&Path>,
+    worktree_salt: Option<&Path>,
+    mut normalize: F,
+) -> ContextKey
+where
+    F: FnMut(&Path, Option<&Path>) -> Arc<str>,
+{
     let mut hasher = blake3::Hasher::new();
 
     hasher.update(b"zccache-context-key-v1\0");
@@ -229,30 +255,30 @@ pub fn compute_context_key(
         hasher.update(b"\0");
     }
 
-    hasher.update(normalize_key_path(&ctx.source_file, key_root).as_bytes());
+    hasher.update(normalize(ctx.source_file.as_ref(), key_root).as_bytes());
     hasher.update(b"\0");
 
     hasher.update(b"iquote\0");
     for dir in &ctx.include_search.iquote {
-        hasher.update(normalize_key_path(dir, key_root).as_bytes());
+        hasher.update(normalize(dir.as_ref(), key_root).as_bytes());
         hasher.update(b"\0");
     }
 
     hasher.update(b"user\0");
     for dir in &ctx.include_search.user {
-        hasher.update(normalize_key_path(dir, key_root).as_bytes());
+        hasher.update(normalize(dir.as_ref(), key_root).as_bytes());
         hasher.update(b"\0");
     }
 
     hasher.update(b"system\0");
     for dir in &ctx.include_search.system {
-        hasher.update(normalize_key_path(dir, key_root).as_bytes());
+        hasher.update(normalize(dir.as_ref(), key_root).as_bytes());
         hasher.update(b"\0");
     }
 
     hasher.update(b"after\0");
     for dir in &ctx.include_search.after {
-        hasher.update(normalize_key_path(dir, key_root).as_bytes());
+        hasher.update(normalize(dir.as_ref(), key_root).as_bytes());
         hasher.update(b"\0");
     }
 
@@ -271,7 +297,7 @@ pub fn compute_context_key(
 
     hasher.update(b"force-include\0");
     for fi in &ctx.force_includes {
-        hasher.update(normalize_key_path(fi, key_root).as_bytes());
+        hasher.update(normalize(fi.as_ref(), key_root).as_bytes());
         hasher.update(b"\0");
     }
 

--- a/crates/zccache/src/depgraph/graph/mod.rs
+++ b/crates/zccache/src/depgraph/graph/mod.rs
@@ -14,7 +14,7 @@ use crate::hash::ContentHash;
 use dashmap::DashMap;
 
 use super::context::{
-    compute_artifact_key_with, compute_context_key, compute_rustc_artifact_key_with_root_with,
+    compute_artifact_key_with, compute_context_key_with, compute_rustc_artifact_key_with_root_with,
     ArtifactKey, CompileContext, ContextKey,
 };
 use super::scanner::{IncludeDirective, ScanResult};
@@ -343,7 +343,10 @@ impl DepGraph {
         key_root: Option<NormalizedPath>,
         worktree_salt: Option<&Path>,
     ) -> ContextRegistration {
-        let key = compute_context_key(&ctx, key_root.as_deref(), worktree_salt);
+        let key =
+            compute_context_key_with(&ctx, key_root.as_deref(), worktree_salt, |path, root| {
+                self.cached_normalize_key_path(path, root)
+            });
         self.register_with_key_and_root_result(key, ctx, key_root)
     }
 

--- a/crates/zccache/src/depgraph/graph/tests.rs
+++ b/crates/zccache/src/depgraph/graph/tests.rs
@@ -804,3 +804,95 @@ fn cached_normalize_key_path_cache_clears_with_depgraph() {
         "DepGraph::clear must wipe the path key cache (issue #550 invalidation contract)",
     );
 }
+
+// ── Issue #561: context-key path normalization goes through cache ───
+
+/// `compute_context_key` invoked through DepGraph::register_with_root_and_salt_result
+/// must populate `path_key_cache` for the source + every include dir +
+/// every force-include. Calling register again with the same CompileContext
+/// must NOT add new cache entries — every path-normalization hits the cache.
+#[test]
+fn register_context_populates_and_reuses_path_key_cache() {
+    let graph = DepGraph::new();
+
+    let mut include_search = IncludeSearchPaths::default();
+    include_search
+        .user
+        .push(NormalizedPath::from("/proj/include"));
+    include_search
+        .system
+        .push(NormalizedPath::from("/usr/include"));
+    include_search
+        .system
+        .push(NormalizedPath::from("/usr/include/c++/13"));
+
+    let ctx = CompileContext {
+        source_file: NormalizedPath::from("/proj/src/unit.cpp"),
+        include_search,
+        defines: vec!["-DFOO=1".to_string()],
+        flags: vec!["-O2".to_string()],
+        force_includes: vec![NormalizedPath::from("/proj/include/prefix.h")],
+        unknown_flags: Vec::new(),
+    };
+
+    assert_eq!(graph.path_key_cache_len(), 0);
+    let first = graph.register_with_root_and_salt_result(ctx.clone(), None, None);
+
+    // 1 source + 1 user dir + 2 system dirs + 1 force-include = 5
+    // distinct paths normalized through the cache.
+    let after_first = graph.path_key_cache_len();
+    assert!(
+        after_first >= 5,
+        "first register must populate cache (got len={after_first}, expected >= 5)",
+    );
+
+    let second = graph.register_with_root_and_salt_result(ctx, None, None);
+    assert_eq!(
+        graph.path_key_cache_len(),
+        after_first,
+        "second register with identical context must hit the cache, not grow it",
+    );
+
+    assert_eq!(
+        first.key, second.key,
+        "context_key must be deterministic across cached and uncached normalize paths",
+    );
+}
+
+/// Regression: the cached normalizer must produce the same ContextKey
+/// as the uncached `compute_context_key` free function. Different
+/// allocator behavior or Arc<str> vs String paths must not perturb the
+/// blake3 input bytes.
+#[test]
+fn cached_context_key_matches_uncached_for_identical_inputs() {
+    use crate::depgraph::context::compute_context_key;
+
+    let mut include_search = IncludeSearchPaths::default();
+    include_search
+        .user
+        .push(NormalizedPath::from("/proj/include"));
+    include_search
+        .system
+        .push(NormalizedPath::from("/usr/include"));
+
+    let ctx = CompileContext {
+        source_file: NormalizedPath::from("/proj/src/unit.cpp"),
+        include_search,
+        defines: vec!["-DFOO=1".to_string()],
+        flags: vec!["-O2".to_string()],
+        force_includes: vec![NormalizedPath::from("/proj/include/prefix.h")],
+        unknown_flags: Vec::new(),
+    };
+
+    let uncached = compute_context_key(&ctx, None, None);
+    let graph = DepGraph::new();
+    let cached = graph
+        .register_with_root_and_salt_result(ctx, None, None)
+        .key;
+
+    assert_eq!(
+        uncached, cached,
+        "cached normalizer must produce byte-identical context_key bytes \
+         — divergence would invalidate every existing cache entry",
+    );
+}


### PR DESCRIPTION
## Summary

`compute_context_key` re-normalizes the source path + every include search dir + every force-include on EVERY compile. For the `cpp-inline Single-file Cold` benchmark (50 sequential compiles, identical context), that's ~50 `String` allocations × 50 invocations = ~2,500 redundant allocations across the cold phase.

#553 added `DepGraph::path_key_cache` and threaded it through `compute_artifact_key` via a `_with` sibling that takes an injectable normalizer. The same pattern was not applied to `compute_context_key` — its call sites still hit the bare `normalize_key_path` free function and bypassed the cache.

## Changes

- Add `compute_context_key_with<F: FnMut(&Path, Option<&Path>) -> Arc<str>>` sibling.
- Have existing `compute_context_key` delegate with the default `normalize_key_path(p, r).into()` normalizer (unchanged behavior for non-DepGraph callers, including `CompileContext::context_key()` and the test fixtures).
- Update `DepGraph::register_with_root_and_salt_result` to use the new sibling with `self.cached_normalize_key_path` so daemon-side compiles share the cache.

## Test plan (TDD RED→GREEN verified)

- [x] `register_context_populates_and_reuses_path_key_cache` — asserts the cache gets populated on first register and zero new entries on the second register with identical context. **Confirmed to FAIL** with the wiring reverted (cache len 0 after both calls), **PASSES** with the wiring in place.
- [x] `cached_context_key_matches_uncached_for_identical_inputs` — byte-equality of cached vs. uncached `ContextKey` for the same inputs (any divergence would silently invalidate every existing cache entry).
- [x] All 1655 lib tests pass.
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean.
- [x] `soldr cargo fmt --all -- --check` clean.
- [ ] Confirm `cpp-inline Single-file Cold` overhead drops by ~10–20 ms on next `bench (linux / medium)` publish.

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)