### PR TITLE
perf(daemon): parallelize input-file hashing in handle_link_ephemeral (fixes #563)

### DIFF
--- a/crates/zccache/src/daemon/server/handle_link.rs
+++ b/crates/zccache/src/daemon/server/handle_link.rs
@@ -158,35 +158,47 @@ pub(super) async fn handle_link_ephemeral(
         key_builder = key_builder.flag(flag);
     }
 
-    for input in parsed_tool
+    // Issue #563: hash all input files in parallel via rayon. The serial
+    // loop was the dominant cold-side cost for `rust-workspace-link Cold`
+    // (50 .rlib files at 5–50 MB each, each requiring a fresh mmap +
+    // blake3 after a `Request::Clear`). `par_iter().collect()` preserves
+    // iteration order, so the cache key bytes are identical to the prior
+    // serial computation. Failure (any input not hashable) routes through
+    // the same `run_tool_passthrough` fallback the serial loop used.
+    let inputs: Vec<&NormalizedPath> = parsed_tool
         .input_files
         .iter()
         .chain(link_key_plan.extra_input_files.iter())
-    {
-        let input_path = if input.is_absolute() {
-            input.clone()
-        } else {
-            cwd_path.join(input).into()
+        .collect();
+    let hash_results: Vec<(NormalizedPath, Option<ContentHash>)> = {
+        use rayon::prelude::*;
+        inputs
+            .par_iter()
+            .map(|input| {
+                let input_path: NormalizedPath = if input.is_absolute() {
+                    (*input).clone()
+                } else {
+                    cwd_path.join(input).into()
+                };
+                let hash = hash_file_via_cache(state, &input_path);
+                (input_path, hash)
+            })
+            .collect()
+    };
+    for (path, hash) in &hash_results {
+        let Some(input_hash) = hash else {
+            tracing::warn!("cannot hash input file {}: skipping cache", path.display());
+            return run_tool_passthrough(
+                tool,
+                args,
+                cwd,
+                env,
+                &lineage,
+                state.depfile_tmpdir.as_path(),
+            )
+            .await;
         };
-        let input_hash = match hash_file_via_cache(state, &input_path) {
-            Some(h) => h,
-            None => {
-                tracing::warn!(
-                    "cannot hash input file {}: skipping cache",
-                    input_path.display()
-                );
-                return run_tool_passthrough(
-                    tool,
-                    args,
-                    cwd,
-                    env,
-                    &lineage,
-                    state.depfile_tmpdir.as_path(),
-                )
-                .await;
-            }
-        };
-        key_builder = key_builder.input(input_hash);
+        key_builder = key_builder.input(*input_hash);
     }
 
     let input_hash_ns = t_input_hash

--- a/crates/zccache/src/daemon/server/tests/link_cache.rs
+++ b/crates/zccache/src/daemon/server/tests/link_cache.rs
@@ -133,3 +133,108 @@ async fn link_cache_hit_restores_sibling_side_effects() {
         "cache hit should restore the wasm map sidecar"
     );
 }
+
+/// Issue #563: the input-hash loop is parallelized via rayon. `par_iter`
+/// preserves iteration order, so the cache key bytes are identical to
+/// the serial computation. This test asserts:
+///
+/// 1. With 12 unique input files, the first link populates the cache
+///    and the second link with the SAME input order hits.
+/// 2. With the same 12 inputs in REVERSED order, the second link
+///    MISSES — order is part of the cache key, so a reordering must
+///    produce a different key.
+///
+/// If rayon's collect ever stopped preserving order (or my change
+/// inadvertently moved to a Set / unordered structure), case (2) would
+/// degrade to a hit and this test would fail.
+#[tokio::test]
+async fn link_cache_key_preserves_input_order_under_parallel_hashing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fake_linker = write_fake_linker(tmp.path());
+    let output = tmp.path().join("app.exe");
+
+    // 12 inputs — enough to exercise rayon's work-stealing across
+    // multiple threads on the 4-core CI runner.
+    let mut input_paths: Vec<std::path::PathBuf> = Vec::with_capacity(12);
+    for i in 0..12 {
+        let p = tmp.path().join(format!("input-{i}.o"));
+        std::fs::write(&p, format!("payload-bytes-{i}-{}", "x".repeat(64))).unwrap();
+        input_paths.push(p);
+    }
+
+    let _cache_dir = CacheDirEnvGuard::set(&tmp.path().join("zccache-cache"));
+    let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
+
+    let make_args = |inputs: &[std::path::PathBuf]| -> Vec<String> {
+        let mut a = vec!["-o".to_string(), output.to_string_lossy().into_owned()];
+        for p in inputs {
+            a.push(p.to_string_lossy().into_owned());
+        }
+        a
+    };
+
+    // (1) First link with inputs in natural order — populates cache.
+    let first_args = make_args(&input_paths);
+    let first = handle_link_ephemeral(
+        &server.state,
+        std::process::id(),
+        &fake_linker,
+        &first_args,
+        tmp.path(),
+        None,
+    )
+    .await;
+    assert!(
+        matches!(
+            first,
+            Response::LinkResult {
+                cached: false,
+                exit_code: 0,
+                ..
+            }
+        ),
+        "first link must be a miss + 0 exit, got: {first:?}"
+    );
+
+    // (2) Repeat with same order — must hit.
+    let second = handle_link_ephemeral(
+        &server.state,
+        std::process::id(),
+        &fake_linker,
+        &first_args,
+        tmp.path(),
+        None,
+    )
+    .await;
+    assert!(
+        matches!(second, Response::LinkResult { cached: true, exit_code: 0, .. }),
+        "same-order repeat must HIT (parallel hash must preserve input order in cache key), got: {second:?}"
+    );
+
+    // (3) Same inputs, REVERSED order — must miss. If parallel hashing
+    // ever lost order, this would falsely report a hit and corrupt
+    // the cache key invariant.
+    let mut reversed = input_paths.clone();
+    reversed.reverse();
+    let reversed_args = make_args(&reversed);
+    let third = handle_link_ephemeral(
+        &server.state,
+        std::process::id(),
+        &fake_linker,
+        &reversed_args,
+        tmp.path(),
+        None,
+    )
+    .await;
+    assert!(
+        matches!(
+            third,
+            Response::LinkResult {
+                cached: false,
+                exit_code: 0,
+                ..
+            }
+        ),
+        "reversed-order link must MISS (input order is part of the cache key), got: {third:?}"
+    );
+}


### PR DESCRIPTION
## Summary

The cold-link input-hash loop was the dominant remaining cold-side overhead in `rust-workspace-link Cold` (48 ms above bare, the worst cold ratio in `benchmark-stats/latest.json` at 0.455). After a `Request::Clear` the metadata cache is empty for the 50 .rlib inputs, so each iteration of the previous serial loop hits `hash_file` (mmap + blake3). At ~5–50 MB per .rlib × ~700 MB/s single-threaded blake3, that's 20–50 ms of wall clock scaling linearly with input count.

Replaces the serial `for input in ... { hash_file_via_cache(...) }` loop with a rayon `par_iter().map().collect::<Vec<_>>()`. `par_iter` preserves iteration order, so the cache key bytes are identical to the serial computation — `key_builder.input(...)` still receives the same hashes in the same order.

The two parallelization layers compose: #557's per-file rayon dispatch (blake3 ≥ 128 KB) parallelizes *within* a single hash; this PR parallelizes *across* hashes. rayon's work-stealing scheduler balances load even if some .rlibs are much larger than others.

## Test plan

- [x] `link_cache_key_preserves_input_order_under_parallel_hashing` — runs 12 unique inputs through `handle_link_ephemeral` three times: natural order (miss), same order again (hit), reversed order (miss). If `par_iter` ever stops preserving order, case 3 would falsely report a hit and this test would fail.
- [x] Existing `link_cache_hit_restores_sibling_side_effects` still passes — the cache key is deterministic across the two same-order calls.
- [x] All 1656 lib tests pass.
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean.
- [x] `soldr cargo fmt --all -- --check` clean.
- [ ] Confirm `rust-workspace-link Cold` overhead drops from ~48 ms to ~15–25 ms on next `bench (linux / medium)` publish.

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)