### PR TITLE
perf(daemon): overlap tool_hash and input_hash via rayon::join (fixes #566)

### DIFF
--- a/crates/zccache/src/daemon/server/handle_link.rs
+++ b/crates/zccache/src/daemon/server/handle_link.rs
@@ -110,10 +110,56 @@ pub(super) async fn handle_link_ephemeral(
         0
     };
 
-    // 3. Hash the tool binary
+    // 3+4. Hash tool binary and input files concurrently via rayon::join
+    // (issue #566). Both phases are CPU-bound blake3 work over mmap'd
+    // files. Before this overlap, they ran strictly sequentially —
+    // `tool_hash` (~150 MB rustc binary, 10–20 ms) blocked the start of
+    // input hashing (50 .rlibs in parallel via #564, also 5–15 ms wall).
+    // `rayon::join` reduces the combined wall-clock to ~max(tool_hash,
+    // input_hashes) instead of the prior sum.
     let tool_path = std::path::Path::new(tool);
-    let t_tool_hash = profile_enabled.then(std::time::Instant::now);
-    let tool_hash = match hash_file_via_cache(state, tool_path) {
+    let cwd_path = std::path::Path::new(cwd);
+
+    let link_key_plan = build_link_path_remap_key_plan(
+        &parsed_tool.cache_relevant_flags,
+        cwd_path,
+        link_path_remap_key_root,
+    );
+
+    let inputs: Vec<&NormalizedPath> = parsed_tool
+        .input_files
+        .iter()
+        .chain(link_key_plan.extra_input_files.iter())
+        .collect();
+
+    let t_hash = profile_enabled.then(std::time::Instant::now);
+    let (tool_hash_opt, hash_results) = rayon::join(
+        || hash_file_via_cache(state, tool_path),
+        || -> Vec<(NormalizedPath, Option<ContentHash>)> {
+            use rayon::prelude::*;
+            inputs
+                .par_iter()
+                .map(|input| {
+                    let input_path: NormalizedPath = if input.is_absolute() {
+                        (*input).clone()
+                    } else {
+                        cwd_path.join(input).into()
+                    };
+                    let hash = hash_file_via_cache(state, &input_path);
+                    (input_path, hash)
+                })
+                .collect()
+        },
+    );
+    // Combined wall-clock budget for the overlapped phases. Reported as
+    // both tool_hash_ns and input_hash_ns in the LinkMissProfile for now
+    // — they're indistinguishable post-overlap. A future diagnostic
+    // change can split them via per-closure timers if needed.
+    let combined_hash_ns = t_hash.map(|t| t.elapsed().as_nanos() as u64).unwrap_or(0);
+    let tool_hash_ns = combined_hash_ns;
+    let input_hash_ns = combined_hash_ns;
+
+    let tool_hash = match tool_hash_opt {
         Some(h) => h,
         None => {
             tracing::warn!("cannot hash tool {}", tool.display());
@@ -129,18 +175,6 @@ pub(super) async fn handle_link_ephemeral(
         }
     };
 
-    let tool_hash_ns = t_tool_hash
-        .map(|t| t.elapsed().as_nanos() as u64)
-        .unwrap_or(0);
-
-    // 4. Hash all input files
-    let cwd_path = std::path::Path::new(cwd);
-    let t_input_hash = profile_enabled.then(std::time::Instant::now);
-    let link_key_plan = build_link_path_remap_key_plan(
-        &parsed_tool.cache_relevant_flags,
-        cwd_path,
-        link_path_remap_key_root,
-    );
     let mut key_builder = crate::hash::link_cache_key::LinkCacheKeyBuilder::new().tool(tool_hash);
 
     if link_path_remap_key_root.is_some() {
@@ -158,33 +192,6 @@ pub(super) async fn handle_link_ephemeral(
         key_builder = key_builder.flag(flag);
     }
 
-    // Issue #563: hash all input files in parallel via rayon. The serial
-    // loop was the dominant cold-side cost for `rust-workspace-link Cold`
-    // (50 .rlib files at 5–50 MB each, each requiring a fresh mmap +
-    // blake3 after a `Request::Clear`). `par_iter().collect()` preserves
-    // iteration order, so the cache key bytes are identical to the prior
-    // serial computation. Failure (any input not hashable) routes through
-    // the same `run_tool_passthrough` fallback the serial loop used.
-    let inputs: Vec<&NormalizedPath> = parsed_tool
-        .input_files
-        .iter()
-        .chain(link_key_plan.extra_input_files.iter())
-        .collect();
-    let hash_results: Vec<(NormalizedPath, Option<ContentHash>)> = {
-        use rayon::prelude::*;
-        inputs
-            .par_iter()
-            .map(|input| {
-                let input_path: NormalizedPath = if input.is_absolute() {
-                    (*input).clone()
-                } else {
-                    cwd_path.join(input).into()
-                };
-                let hash = hash_file_via_cache(state, &input_path);
-                (input_path, hash)
-            })
-            .collect()
-    };
     for (path, hash) in &hash_results {
         let Some(input_hash) = hash else {
             tracing::warn!("cannot hash input file {}: skipping cache", path.display());
@@ -200,10 +207,6 @@ pub(super) async fn handle_link_ephemeral(
         };
         key_builder = key_builder.input(*input_hash);
     }
-
-    let input_hash_ns = t_input_hash
-        .map(|t| t.elapsed().as_nanos() as u64)
-        .unwrap_or(0);
     let input_count = parsed_tool.input_files.len() + link_key_plan.extra_input_files.len();
     let cache_key = key_builder.build();
     let key_hex = cache_key.to_hex();


### PR DESCRIPTION
## Summary

After #557 (blake3 rayon for ≥128 KB) and #564 (parallel input-file hashing), the two largest sub-phases of the cold link in `handle_link_ephemeral` are:

1. `tool_hash_ns` — single ~150 MB rustc-binary blake3, 10–20 ms.
2. `input_hash_ns` — 50 .rlibs hashed in parallel via rayon, 5–15 ms wall.

These ran **strictly sequentially**: tool_hash blocked the start of input hashing. `rayon::join` runs both closures on the existing rayon pool concurrently, reducing combined wall-clock to ~max(tool, inputs) instead of the prior sum.

## Approach

- Compute `link_key_plan` + `inputs` list (cheap, main thread).
- `rayon::join(|| hash_tool, || par_iter inputs)` overlap.
- Drain results into `key_builder` in the same order as before — cache key bytes are unchanged (verified by the #564 invariant test `link_cache_key_preserves_input_order_under_parallel_hashing`).

The `LinkMissProfile` `tool_hash_ns` and `input_hash_ns` fields each carry the combined wall-clock budget for the overlapped phases post-merge; they're indistinguishable post-overlap. A future diagnostic change can split them via per-closure timers if needed.

## Test plan

- [x] **No new test required** — #564's `link_cache_key_preserves_input_order_under_parallel_hashing` already exercises the cache-key-determinism invariant via miss → hit → reversed-miss sequence. If the overlap broke order, case 3 would falsely report a hit and that test would fail. **Verified to still pass after this PR.**
- [x] All 12 `tests::link_cache::*` tests pass.
- [x] Full lib test suite (1656 passing) clean.
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean.
- [x] `soldr cargo fmt --all -- --check` clean.
- [ ] Confirm `rust-workspace-link Cold` overhead drops from ~38 ms toward ~25–30 ms on next `bench (linux / medium)` publish.

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)