### PR TITLE
fix(daemon): release wrapper CWD in passthrough paths (fixes #555 candidate 1)

### DIFF
--- a/crates/zccache/src/cli/commands/wrap/README.md
+++ b/crates/zccache/src/cli/commands/wrap/README.md
@@ -1,0 +1,23 @@
+# `wrap` — compiler/linker/archiver wrapper
+
+Implements `zccache <compiler> <args...>` and `zccache wrap`. The facade in
+[`../wrap.rs`](../wrap.rs) routes each invocation to one of the submodules
+here based on tool family and environment.
+
+## Files
+
+- **`env.rs`** — environment policy: `ZCCACHE_DISABLE`, `ZCCACHE_STRICT_PATHS`,
+  client-env filtering applied to every IPC request.
+- **`ipc.rs`** — request builders and response handling for `Compile` and
+  `LinkEphemeral`. Owns the per-request retry policy.
+- **`passthrough.rs`** — direct-exec paths used when the cache is disabled or
+  the tool is unsupported. Captures + releases the wrapper's CWD on Windows
+  so the build dir is not pinned by a kernel handle (issue #555 / #134).
+- **`routing.rs`** — classifies an argv into `Formatter | LinkOrArchive |
+  Compile` without doing the full parse.
+- **`rustfmt.rs`** — format-cache wrapper for rustfmt: skip files whose
+  content hash is already cached (avoids mtime churn that triggers downstream
+  rebuilds).
+- **`tool_resolution.rs`** — resolves bare tool names (`clang++`, `ar`, ...)
+  to absolute paths via `PATH`, with the policy decision about when to leave
+  the original spelling alone for the daemon to error on.

--- a/crates/zccache/src/cli/commands/wrap/passthrough.rs
+++ b/crates/zccache/src/cli/commands/wrap/passthrough.rs
@@ -6,16 +6,38 @@ use std::process::ExitCode;
 use super::super::util::exit_code_from_i32;
 use super::tool_resolution::resolve_compiler_path;
 
+/// Release the wrapper's own CWD handle on the build dir before spawning
+/// a child, while keeping the child's CWD pointing at the original
+/// directory so relative paths in argv still resolve.
+///
+/// Issue #555: in the `ZCCACHE_DISABLE` / unsupported-tool early-exit
+/// paths the wrapper bypasses the chdir-to-temp at `wrap.rs:59`. On
+/// Windows the parent's CWD holds an implicit kernel handle on the
+/// build directory, blocking `shutil.rmtree` until the wrapper exits.
+/// This helper restores parity with the cached-path behavior.
+fn run_with_released_cwd(
+    cmd: &mut std::process::Command,
+) -> std::io::Result<std::process::ExitStatus> {
+    if let Ok(cwd) = std::env::current_dir() {
+        cmd.current_dir(&cwd);
+        // Release the wrapper's own CWD handle before spawning. The
+        // child inherits `cmd.current_dir(...)` regardless of where the
+        // parent ends up, so argv-relative paths still resolve from
+        // the build dir.
+        let _ = std::env::set_current_dir(std::env::temp_dir());
+    }
+    cmd.status()
+}
+
 /// Run the compiler/tool directly without caching (`ZCCACHE_DISABLE` mode).
 pub(super) fn run_passthrough(args: &[String]) -> ExitCode {
     let tool = &args[0];
     let tool_args = args.get(1..).unwrap_or(&[]);
     let resolved = resolve_compiler_path(tool);
 
-    match std::process::Command::new(&resolved)
-        .args(tool_args)
-        .status()
-    {
+    let mut cmd = std::process::Command::new(&resolved);
+    cmd.args(tool_args);
+    match run_with_released_cwd(&mut cmd) {
         Ok(status) => exit_code_from_i32(status.code().unwrap_or(1)),
         Err(e) => {
             eprintln!("zccache: failed to run {}: {e}", resolved.display());
@@ -26,11 +48,101 @@ pub(super) fn run_passthrough(args: &[String]) -> ExitCode {
 
 /// Run a tool directly and return its exit code.
 pub(super) fn run_tool_direct(tool: &Path, args: &[String]) -> ExitCode {
-    match std::process::Command::new(tool).args(args).status() {
+    let mut cmd = std::process::Command::new(tool);
+    cmd.args(args);
+    match run_with_released_cwd(&mut cmd) {
         Ok(status) => exit_code_from_i32(status.code().unwrap_or(1)),
         Err(e) => {
             eprintln!("zccache: failed to run {}: {e}", tool.display());
             ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Process-global lock so the two CWD-mutating tests don't race.
+    /// `env::set_current_dir` is process-wide; running these in parallel
+    /// would produce nondeterministic results.
+    static CWD_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn noop_tool() -> std::path::PathBuf {
+        if cfg!(windows) {
+            std::path::PathBuf::from("cmd.exe")
+        } else {
+            std::path::PathBuf::from("true")
+        }
+    }
+
+    fn noop_args() -> Vec<String> {
+        if cfg!(windows) {
+            vec!["/c".to_string(), "exit".to_string(), "0".to_string()]
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Issue #555: `run_passthrough` must release the wrapper's CWD
+    /// before/while spawning the child, so the build dir is not held
+    /// by the wrapper's kernel CWD handle on Windows. Verified by
+    /// asserting `env::current_dir()` no longer points at the build
+    /// dir after the helper returns.
+    #[test]
+    fn run_passthrough_releases_wrapper_cwd() {
+        let _guard = CWD_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let original_cwd = std::env::current_dir().ok();
+        let build_dir = tempfile::tempdir().unwrap();
+        let canonical_build_dir = std::fs::canonicalize(build_dir.path()).unwrap();
+        std::env::set_current_dir(&canonical_build_dir).unwrap();
+
+        let mut args = vec![noop_tool().to_string_lossy().into_owned()];
+        args.extend(noop_args());
+        let _ = run_passthrough(&args);
+
+        let after = std::env::current_dir().unwrap();
+        // `tempfile`'s tempdir under `%TEMP%` would itself canonicalize
+        // to the same path as `canonical_build_dir` on weird CI
+        // configurations, so compare canonicalized forms.
+        let after_canonical = std::fs::canonicalize(&after).unwrap_or(after);
+        assert_ne!(
+            after_canonical, canonical_build_dir,
+            "issue #555: run_passthrough must release the wrapper's CWD \
+             before returning so the build dir is not pinned by the wrapper's \
+             kernel handle on Windows",
+        );
+
+        // Restore CWD so the rest of the test process is unaffected.
+        if let Some(cwd) = original_cwd {
+            let _ = std::env::set_current_dir(cwd);
+        }
+    }
+
+    /// `run_tool_direct` (used by the rustfmt help/version/stdin early
+    /// exit) must also release the wrapper's CWD — same correctness
+    /// rationale as `run_passthrough`.
+    #[test]
+    fn run_tool_direct_releases_wrapper_cwd() {
+        let _guard = CWD_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let original_cwd = std::env::current_dir().ok();
+        let build_dir = tempfile::tempdir().unwrap();
+        let canonical_build_dir = std::fs::canonicalize(build_dir.path()).unwrap();
+        std::env::set_current_dir(&canonical_build_dir).unwrap();
+
+        let tool = noop_tool();
+        let args: Vec<String> = noop_args();
+        let _ = run_tool_direct(&tool, &args);
+
+        let after = std::env::current_dir().unwrap();
+        let after_canonical = std::fs::canonicalize(&after).unwrap_or(after);
+        assert_ne!(
+            after_canonical, canonical_build_dir,
+            "issue #555: run_tool_direct must release the wrapper's CWD",
+        );
+
+        if let Some(cwd) = original_cwd {
+            let _ = std::env::set_current_dir(cwd);
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #555 candidate 1: `run_passthrough` (the `ZCCACHE_DISABLE` path) and `run_tool_direct` (the rustfmt help/version/stdin early exit) bypassed the chdir-to-temp at `wrap.rs:59`, leaving the wrapper's CWD pointing at the build directory for the entire child-process lifetime.

On Windows the parent's CWD holds an implicit kernel handle that blocks `shutil.rmtree(build_dir)` until the wrapper exits — exactly the leak that FastLED's `_kill_zombie_zccache` workaround (linked from #555) was forced to address. The main wrapper path already chdir's to `%TEMP%` before dispatching to route handlers, but both early-exit paths skipped it.

## Approach

New helper `run_with_released_cwd(cmd)` that:

1. Captures the current CWD.
2. Forwards it explicitly to `cmd.current_dir(...)` so argv-relative paths in the child still resolve from the build dir.
3. Chdir's the wrapper itself to `std::env::temp_dir()` before spawning, releasing the parent's handle on the build dir.
4. Spawns the child.

Both `run_passthrough` and `run_tool_direct` now route through this helper. Behavior is unchanged for the child process — only the wrapper's own handle is released.

## Test plan (TDD RED→GREEN verified)

- [x] `run_passthrough_releases_wrapper_cwd` — set wrapper CWD to a tempdir, invoke `run_passthrough`, assert `env::current_dir()` diverged from the build dir.
- [x] `run_tool_direct_releases_wrapper_cwd` — same invariant for the rustfmt early-exit path.
- [x] **Confirmed to FAIL** with the helper reverted to a bare `cmd.status()`, **PASS** with the chdir reinstated.
- [x] Tests serialize via a process-global `Mutex<()>` because `env::set_current_dir` is process-global and the two CWD-mutating tests would race in parallel.
- [x] All 1673 lib tests pass.
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean.
- [x] `soldr cargo fmt --all -- --check` clean.

## Follow-up for #555

Candidates 2-4 in the issue (early-exit paths before line 59, daemon-spawned child compilers inheriting daemon's CWD, subprocesses between wrap.rs:52 and wrap.rs:59) remain untested. With this PR's fix in place, FastLED can re-evaluate whether `_kill_zombie_zccache` still finds kills. If `killed == 0` consistently, the workaround can be removed downstream.

Closes #555 (partially — candidate 1 only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)