### PR TITLE
ci(bench): upload benchmark.log artifact for phase-profile data (fixes #569)

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -71,6 +71,19 @@ jobs:
           path: benchmark-stats
           if-no-files-found: error
 
+      # Issue #569: ship the merged stdout+stderr log so future perf
+      # iterations can read the per-phase `zccache_*_miss_profile` lines
+      # the daemon already emits (env enabled in `ci/benchmark_stats`).
+      # Without this upload the only published data is `latest.json`'s
+      # totals — sub-phase data is GC'd with the runner.
+      - name: Upload bench log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-log
+          path: benchmark-output/benchmark.log
+          if-no-files-found: warn
+
       - name: Publish benchmark-stats branch
         if: ${{ success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
         shell: bash


### PR DESCRIPTION
## Summary

The benchmark workflow already enables `ZCCACHE_PROFILE_RUST_MISS=1` and `ZCCACHE_PROFILE_CC_MISS=1` (see `ci/benchmark_stats.benchmark_env`), so the daemon emits `zccache_rust_miss_profile`, `zccache_cc_miss_profile`, and `zccache_link_miss_profile` lines on every cold miss. The runner captures all of that into `benchmark-output/benchmark.log` via `--log-path` but never uploaded that directory.

Adds an `actions/upload-artifact@v7` step (matching the existing benchmark-stats upload) that publishes the log as `benchmark-log`. `if: always()` so failed runs still ship the log, and `if-no-files-found: warn` so a runner crashing before the log writes doesn't fail the workflow.

## Why this matters

After 7 perf PRs merged this session (#553, #557, #560, #562, #564, #567, #568), the published `latest.json` totals only show that *some* overhead remains in e.g. `rust-workspace-link Cold` (0.443 ratio) and `emscripten Single-file Cold` (+1073 ms). Picking the next target without sub-phase data is speculative. With this PR landed, the next iteration can `gh run download <id> --name benchmark-log` and read the per-phase `tool_hash_ns`, `input_hash_ns`, `artifact_store_ns`, `system_includes_ns` numbers directly.

## Test plan

- [x] YAML syntax verified locally.
- [ ] Confirm a `benchmark-log` artifact appears in the next Benchmark Stats run.
- [ ] `gh run download <id> --name benchmark-log --dir /tmp` and grep `/tmp/benchmark.log` for `zccache_cc_miss_profile`, `zccache_rust_miss_profile`, `zccache_link_miss_profile` lines.

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)