### PR TITLE
perf: pre-size hot Vec/HashSet allocations in DepGraph + parse_depfile (fixes #578)

### DIFF
--- a/crates/zccache/src/depgraph/depfile.rs
+++ b/crates/zccache/src/depgraph/depfile.rs
@@ -99,8 +99,11 @@ pub fn parse_depfile(content: &str, source: &Path, cwd: &Path) -> Result<ScanRes
     // Step 5-7: Resolve paths, filter source, deduplicate.
     let source_canonical = canonicalize_path(source, cwd);
 
-    let mut seen = HashSet::new();
-    let mut resolved = Vec::new();
+    // Issue #578: pre-size both collections to the (over-)bound `tokens.len()`.
+    // After dedup + source filter, actual `resolved.len()` ≤ tokens.len();
+    // pre-sizing eliminates the grow-from-zero reallocations.
+    let mut seen = HashSet::with_capacity(tokens.len());
+    let mut resolved = Vec::with_capacity(tokens.len());
 
     for token in tokens {
         if token.is_empty() {

--- a/crates/zccache/src/depgraph/graph/mod.rs
+++ b/crates/zccache/src/depgraph/graph/mod.rs
@@ -546,7 +546,11 @@ impl DepGraph {
         }
 
         // All headers fresh. Compute artifact key (using &Path to avoid NormalizedPath clones).
-        let mut file_hashes: Vec<(&Path, ContentHash)> = Vec::new();
+        // Issue #578: pre-size to avoid the ~10 reallocations that grow-from-zero
+        // triggers for a typical 600-header cpp compile.
+        let mut file_hashes: Vec<(&Path, ContentHash)> = Vec::with_capacity(
+            1 + entry.resolved_includes.len() + entry.context.force_includes.len(),
+        );
 
         if let Some(h) = get_hash(&entry.context.source_file) {
             file_hashes.push((&entry.context.source_file, h));
@@ -735,7 +739,10 @@ impl DepGraph {
         }
 
         // All headers fresh. Compute artifact key.
-        let mut file_hashes = Vec::new();
+        // Issue #578: pre-size to avoid grow-from-zero reallocations.
+        let mut file_hashes = Vec::with_capacity(
+            1 + entry.resolved_includes.len() + entry.context.force_includes.len(),
+        );
 
         if let Some(h) = get_hash(&entry.context.source_file) {
             file_hashes.push((entry.context.source_file.clone(), h));
@@ -959,7 +966,12 @@ impl DepGraph {
         // Compute artifact key â€” if any file is missing a hash, leave state
         // unchanged (Cold stays Cold) so check() doesn't see a Warm context
         // with no artifact key.
-        let mut file_hashes = Vec::new();
+        //
+        // Issue #578: pre-size to avoid the grow-from-zero reallocations
+        // (~10 for a typical 600-header cpp compile).
+        let mut file_hashes = Vec::with_capacity(
+            1 + entry.resolved_includes.len() + entry.context.force_includes.len(),
+        );
         let source_hash = get_hash(&entry.context.source_file)?;
         file_hashes.push((entry.context.source_file.clone(), source_hash));
 


### PR DESCRIPTION
## Summary

Post-#576 the dominant remaining cc-miss sub-phase is `depgraph_update_ns` at 792 ms / 2.28 ms mean / 4.04 ms p90 across 348 cc miss profiles. Tracing what's left after the #576 NormalizedPath cached-key fix: much of the residual time is per-element `Vec::push` against Vecs that start at capacity 0 and grow via doubling.

For a typical cpp compile with ~600 transitive headers, grow-from-zero triggers ~10 reallocations (1→2→4→8→...→1024), each copying all prior entries — ~50–100 µs of avoidable copy work per call.

## Sites pre-sized

- `DepGraph::update` `file_hashes` — bound `1 + resolved_includes.len() + force_includes.len()`.
- `DepGraph::check` (Hit branch) `file_hashes` — same bound.
- `DepGraph::check_diagnostic` (Hit branch) `file_hashes` — same bound.
- `parse_depfile` `resolved` + `seen` HashSet — bound `tokens.len()` (after-dedup count ≤ tokens.len()).

Pure capacity hints — no behavior change. `Vec::with_capacity(n)` followed by `< n` pushes is correct; followed by `> n` pushes silently triggers the same realloc as today.

## Test plan

- [x] All 1664 lib tests pass.
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean.
- [x] `soldr cargo fmt --all -- --check` clean.
- [ ] Confirm `depgraph_update_ns` mean drops by ~50 µs (~30 ms aggregate across bench).

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)