### PR TITLE
ci(cache-cleanup): periodic schedule (every 6h), drop workflow_run trigger

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -6,21 +6,19 @@ name: Cache Cleanup
 # dominated by per-commit cook-delta + zccache-test entries,
 # nullifying the warm-run wins from setup-soldr#305 / #310 / #313.
 #
-# Triggered on-demand:
-# - workflow_dispatch: manual trigger
-# - workflow_run: after CI / Integration / Coverage complete (those
-#   are the workflows that ADD large per-commit cache entries). The
-#   first step gates on actual cache size so cleanup is a no-op
-#   unless usage is over the high-water mark (8 GB).
+# Triggered periodically — keeps the per-CI workflow surface
+# untouched. The schedule runs every 6 hours; the high-water-mark
+# gate makes runs no-ops when cache usage is already healthy.
 #
-# Strategy: for each per-commit key family, keep the newest 5,
-# prune the rest unconditionally.
+# Strategy: for each per-commit key family, keep the newest 3,
+# prune the rest unconditionally. After count-based prune, a
+# hard-cap step deletes oldest entries until under 8 GB.
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["CI", "Integration", "Coverage", "Benchmark Stats", "Perf Cluster Rust"]
-    types: [completed]
+  schedule:
+    # Every 6 hours at :17 (off-peak vs :00).
+    - cron: "17 */6 * * *"
 
 jobs:
   prune-per-commit-caches:


### PR DESCRIPTION
Per user request: prefer periodic purge over per-CI-workflow fixups. Switches from workflow_run trigger to cron (every 6h). Keeps the 8 GB high-water gate so most scheduled runs are no-ops. 🤖 Generated with [Claude Code](https://claude.com/claude-code)