### PR TITLE
ci(cache-cleanup): workflow_dispatch only, invoked from cascade process

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -6,19 +6,21 @@ name: Cache Cleanup
 # dominated by per-commit cook-delta + zccache-test entries,
 # nullifying the warm-run wins from setup-soldr#305 / #310 / #313.
 #
-# Triggered periodically — keeps the per-CI workflow surface
-# untouched. The schedule runs every 6 hours; the high-water-mark
-# gate makes runs no-ops when cache usage is already healthy.
+# Triggered ONLY by workflow_dispatch — invoked manually as part of
+# the setup-soldr release-and-cascade process. No scheduled or
+# per-CI-workflow trigger. Aim: avoid surprise cleanup runs that
+# can race with a workflow's save phase, and keep the CI surface
+# clean from unrelated lifecycle hooks.
 #
 # Strategy: for each per-commit key family, keep the newest 3,
 # prune the rest unconditionally. After count-based prune, a
 # hard-cap step deletes oldest entries until under 8 GB.
+#
+# Recommended invocation:
+#   gh workflow run cache-cleanup.yml --repo zackees/zccache
 
 on:
   workflow_dispatch:
-  schedule:
-    # Every 6 hours at :17 (off-peak vs :00).
-    - cron: "17 */6 * * *"
 
 jobs:
   prune-per-commit-caches:


### PR DESCRIPTION
Per user direction: stop running cleanup on a cadence or per-CI. Invoke manually as part of the setup-soldr release process. Keeps the 8 GB gate. 🤖 Generated with [Claude Code](https://claude.com/claude-code)