### PR TITLE
perf(depgraph): skip path_key_cache when key_root is None (fixes #585)

### DIFF
--- a/crates/zccache/src/depgraph/context/mod.rs
+++ b/crates/zccache/src/depgraph/context/mod.rs
@@ -332,6 +332,49 @@ pub fn compute_artifact_key<P: AsRef<Path> + Ord>(
 /// per-compile allocations amortize across the daemon's lifetime
 /// (issue #550). The closure is `FnMut` only because the impl forwards
 /// it through the iterator; in practice it's a `Fn`-shaped lookup.
+/// Fast-path variant of [`compute_artifact_key_with`] for the common case
+/// where the caller already holds owned [`NormalizedPath`] values and has
+/// no `key_root` (the cc/cpp compile path without `-ffile-prefix-map`).
+///
+/// Issue #585: post-#576 each [`NormalizedPath`] caches its
+/// `normalize_for_key` result in the struct's `key` field. With no
+/// `key_root`, that cached key IS the bytes we want to hash — no
+/// allocation, no DashMap lookup, no closure call. The previous shape
+/// went through `cached_normalize_key_path` which allocated 4 owned
+/// objects per lookup just to construct the `DashMap` key.
+///
+/// Output is bit-identical to `compute_artifact_key_with` when called
+/// with `key_root: None` and a closure that returns
+/// `normalize_for_key(path).into()`.
+#[must_use]
+pub fn compute_artifact_key_normalized_inplace(
+    context_key: &ContextKey,
+    file_hashes: &mut [(crate::core::NormalizedPath, ContentHash)],
+) -> ArtifactKey {
+    // Sort by NormalizedPath::cmp — which since #576 is a byte compare
+    // on the cached `key` field, no per-comparison normalize_for_key calls.
+    file_hashes.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"zccache-artifact-key-v1\0");
+    hasher.update(context_key.0.as_bytes());
+    hasher.update(b"\0");
+
+    for (path, hash) in file_hashes.iter() {
+        // Use the cached normalize_for_key bytes directly. Bit-identical
+        // to going through the closure in compute_artifact_key_with.
+        let key = path
+            .case_key()
+            .expect("NormalizedPath::key is always populated post-#576");
+        hasher.update(key.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(hash.as_bytes());
+        hasher.update(b"\0");
+    }
+
+    ArtifactKey(ContentHash::from_bytes(*hasher.finalize().as_bytes()))
+}
+
 pub fn compute_artifact_key_with<P, F>(
     context_key: &ContextKey,
     file_hashes: &mut [(P, ContentHash)],

--- a/crates/zccache/src/depgraph/context/tests/cc.rs
+++ b/crates/zccache/src/depgraph/context/tests/cc.rs
@@ -8,7 +8,8 @@ use crate::depgraph::args::{ParsedArgs, UserDepFlags};
 use crate::depgraph::search_paths::IncludeSearchPaths;
 
 use super::super::{
-    compute_artifact_key, compute_artifact_key_with, compute_context_key, CompileContext,
+    compute_artifact_key, compute_artifact_key_normalized_inplace, compute_artifact_key_with,
+    compute_context_key, CompileContext,
 };
 use super::make_context;
 
@@ -477,5 +478,50 @@ fn compute_artifact_key_with_byte_identical_to_prior_shape() {
     assert_eq!(
         key1, key2,
         "input order must not perturb the artifact key (sort is the determinizer)"
+    );
+}
+
+/// Issue #585: the fast-path
+/// `compute_artifact_key_normalized_inplace` must produce the
+/// byte-identical ArtifactKey to the closure-based slow path for the
+/// same inputs when `key_root` is None. A divergence would silently
+/// invalidate every cache entry written by the cc/cpp pipeline.
+#[test]
+fn compute_artifact_key_normalized_inplace_matches_closure_path() {
+    let ctx = make_context("/src/main.cpp", &["/inc"], &["DEBUG"]);
+    let ck = ctx.context_key();
+    let inputs: Vec<(NormalizedPath, crate::hash::ContentHash)> = vec![
+        (
+            NormalizedPath::from("/inc/zlast.h"),
+            crate::hash::hash_bytes(b"zlast content"),
+        ),
+        (
+            NormalizedPath::from("/inc/amid.h"),
+            crate::hash::hash_bytes(b"amid content"),
+        ),
+        (
+            NormalizedPath::from("/inc/mfirst.h"),
+            crate::hash::hash_bytes(b"mfirst content"),
+        ),
+        (
+            NormalizedPath::from("/src/main.cpp"),
+            crate::hash::hash_bytes(b"source"),
+        ),
+    ];
+
+    // Slow path via compute_artifact_key_with (which goes through a
+    // closure). This is what the previous code path produced.
+    let mut slow_inputs = inputs.clone();
+    let slow_key = compute_artifact_key(&ck, &mut slow_inputs, None);
+
+    // Fast path: in-place sort + hash with NormalizedPath::key bytes.
+    let mut fast_inputs = inputs;
+    let fast_key = compute_artifact_key_normalized_inplace(&ck, &mut fast_inputs);
+
+    assert_eq!(
+        slow_key, fast_key,
+        "fast-path and slow-path must produce bit-identical ArtifactKey \
+         — any divergence invalidates every cache entry written by the \
+         cc/cpp pipeline post-#585",
     );
 }

--- a/crates/zccache/src/depgraph/graph/mod.rs
+++ b/crates/zccache/src/depgraph/graph/mod.rs
@@ -1021,6 +1021,13 @@ impl DepGraph {
                 entry.key_root.as_deref(),
                 |path, key_root| self.cached_normalize_key_path(path, key_root),
             )
+        } else if entry.key_root.is_none() {
+            // Issue #585: fast path — when there's no key_root, the
+            // path-key bytes ARE NormalizedPath::key (populated since #576).
+            // Skip the cached_normalize_key_path indirection (which
+            // allocates 4 owned objects per lookup just to build the
+            // DashMap key) and use the in-struct cache directly.
+            crate::depgraph::context::compute_artifact_key_normalized_inplace(key, &mut file_hashes)
         } else {
             compute_artifact_key_with(
                 key,


### PR DESCRIPTION
## Summary

#584's sub-phase diagnostic revealed `artifact_key_compute_ns` is **79% of `depgraph_update_ns`** (1.95 ms mean / 1262 ms aggregate over 647 calls). Tracing into the closure path: `cached_normalize_key_path` allocates **4 owned objects** per lookup just to construct the `PathKeyCacheKey { path: NormalizedPath::new(...), key_root: ... }` — even on a cache hit.

For the common cc/cpp compile (no `-ffile-prefix-map` → `key_root: None`), the cached value IS just `normalize_for_key(path)`, which post-#576 lives in `NormalizedPath::key`. The cache lookup is redundant — we already have the bytes.

## Fix

Add `compute_artifact_key_normalized_inplace(context_key, file_hashes)` that:
- Sorts `&mut [(NormalizedPath, ContentHash)]` via `NormalizedPath::cmp` (post-#576: byte compare on cached `key`, zero allocations).
- Hashes each `NormalizedPath::case_key().as_bytes()` directly — no closure, no DashMap lookup, no allocation per entry.

`DepGraph::update` dispatches to the fast path when `entry.key_root` is None and the context is non-rustc (the common cc case). Rustc and the `-ffile-prefix-map` path continue to use the closure-based `compute_artifact_key_with`.

## Correctness

Output is bit-identical:
- Same sort order (`NormalizedPath::cmp` == `case_key.cmp`)
- Same blake3 input bytes (`case_key().as_bytes()` == `normalize_for_key(path).as_bytes()` by construction post-#576)

Verified by the new `compute_artifact_key_normalized_inplace_matches_closure_path` test.

## Test plan

- [x] **New** `compute_artifact_key_normalized_inplace_matches_closure_path` — passes the same inputs to both shapes and asserts ArtifactKey equality.
- [x] All 1665 lib tests pass.
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean.
- [x] `soldr cargo fmt --all -- --check` clean.
- [ ] Confirm `artifact_key_compute_ns` mean drops from 1.95 ms toward ~500 µs on next Benchmark Stats publish.

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)