### PR TITLE
perf(depgraph): skip allocation for paths NOT under key_root (fixes #591)

### DIFF
--- a/crates/zccache/src/depgraph/context/mod.rs
+++ b/crates/zccache/src/depgraph/context/mod.rs
@@ -351,22 +351,52 @@ pub fn compute_artifact_key_normalized_inplace(
     context_key: &ContextKey,
     file_hashes: &mut [(crate::core::NormalizedPath, ContentHash)],
 ) -> ArtifactKey {
-    // Sort by NormalizedPath::cmp — which since #576 is a byte compare
-    // on the cached `key` field, no per-comparison normalize_for_key calls.
-    file_hashes.sort_by(|a, b| a.0.cmp(&b.0));
+    compute_artifact_key_normalized_with_root(context_key, file_hashes, None)
+}
+
+/// Issue #591: extension of [`compute_artifact_key_normalized_inplace`]
+/// that also handles `key_root: Some`. For paths NOT under `key_root`
+/// (the common case for system headers), the path-key bytes are just
+/// `NormalizedPath::case_key()` — no allocation. For paths under
+/// `key_root`, we fall back to `normalize_key_path(path, Some(root))`.
+///
+/// Replaces the closure-based slow path through
+/// `compute_artifact_key_with` + `cached_normalize_key_path` which
+/// allocated 1 String per entry even after #590's cache bypass.
+#[must_use]
+pub fn compute_artifact_key_normalized_with_root(
+    context_key: &ContextKey,
+    file_hashes: &[(crate::core::NormalizedPath, ContentHash)],
+    key_root: Option<&Path>,
+) -> ArtifactKey {
+    use std::borrow::Cow;
+
+    // Materialize path-keys: borrow from NormalizedPath::key for paths
+    // not under key_root (zero alloc); compute fresh for project-local.
+    let mut indexed: Vec<(Cow<'_, str>, ContentHash)> = file_hashes
+        .iter()
+        .map(|(np, h)| {
+            let path_key: Cow<'_, str> = match key_root {
+                Some(root) if np.as_path().starts_with(root) => {
+                    Cow::Owned(normalize_key_path(np.as_path(), Some(root)))
+                }
+                _ => Cow::Borrowed(
+                    np.case_key()
+                        .expect("NormalizedPath::key is always populated post-#576"),
+                ),
+            };
+            (path_key, *h)
+        })
+        .collect();
+    indexed.sort_by(|a, b| a.0.cmp(&b.0));
 
     let mut hasher = blake3::Hasher::new();
     hasher.update(b"zccache-artifact-key-v1\0");
     hasher.update(context_key.0.as_bytes());
     hasher.update(b"\0");
 
-    for (path, hash) in file_hashes.iter() {
-        // Use the cached normalize_for_key bytes directly. Bit-identical
-        // to going through the closure in compute_artifact_key_with.
-        let key = path
-            .case_key()
-            .expect("NormalizedPath::key is always populated post-#576");
-        hasher.update(key.as_bytes());
+    for (path_key, hash) in &indexed {
+        hasher.update(path_key.as_bytes());
         hasher.update(b"\0");
         hasher.update(hash.as_bytes());
         hasher.update(b"\0");

--- a/crates/zccache/src/depgraph/context/tests/cc.rs
+++ b/crates/zccache/src/depgraph/context/tests/cc.rs
@@ -8,8 +8,9 @@ use crate::depgraph::args::{ParsedArgs, UserDepFlags};
 use crate::depgraph::search_paths::IncludeSearchPaths;
 
 use super::super::{
-    compute_artifact_key, compute_artifact_key_normalized_inplace, compute_artifact_key_with,
-    compute_context_key, CompileContext,
+    compute_artifact_key, compute_artifact_key_normalized_inplace,
+    compute_artifact_key_normalized_with_root, compute_artifact_key_with, compute_context_key,
+    CompileContext,
 };
 use super::make_context;
 
@@ -523,5 +524,63 @@ fn compute_artifact_key_normalized_inplace_matches_closure_path() {
         "fast-path and slow-path must produce bit-identical ArtifactKey \
          — any divergence invalidates every cache entry written by the \
          cc/cpp pipeline post-#585",
+    );
+}
+
+/// Issue #591: `compute_artifact_key_normalized_with_root` must produce
+/// the byte-identical ArtifactKey to the closure-based slow path
+/// (`compute_artifact_key_with` with `cached_normalize_key_path`) for
+/// both `key_root: None` AND `key_root: Some`. For paths NOT under
+/// `key_root` (system headers like `/usr/include/...`), the closure
+/// returns `normalize_for_key(path)` — which equals `NormalizedPath::key`
+/// by construction post-#576. The new shape borrows from `np.key`
+/// directly (zero allocation) for those entries and only allocates for
+/// paths actually under the root.
+#[test]
+fn compute_artifact_key_normalized_with_root_matches_closure() {
+    let ctx = make_context("/proj/src/main.cpp", &["/inc"], &[]);
+    let ck = ctx.context_key();
+    let inputs: Vec<(NormalizedPath, crate::hash::ContentHash)> = vec![
+        (
+            NormalizedPath::from("/usr/include/c++/13/iostream"),
+            crate::hash::hash_bytes(b"iostream-content"),
+        ),
+        (
+            NormalizedPath::from("/proj/src/main.cpp"),
+            crate::hash::hash_bytes(b"main-content"),
+        ),
+        (
+            NormalizedPath::from("/proj/include/local.h"),
+            crate::hash::hash_bytes(b"local-content"),
+        ),
+        (
+            NormalizedPath::from("/usr/include/stdio.h"),
+            crate::hash::hash_bytes(b"stdio-content"),
+        ),
+    ];
+
+    // key_root: None — both shapes must produce equal keys.
+    let mut slow1 = inputs.clone();
+    let slow_key_none = compute_artifact_key(&ck, &mut slow1, None);
+    let fast_key_none = compute_artifact_key_normalized_with_root(&ck, &inputs, None);
+    assert_eq!(
+        slow_key_none, fast_key_none,
+        "key_root: None — fast-path must match closure path",
+    );
+
+    // key_root: Some("/proj") — paths under /proj get relative form;
+    // paths under /usr/include use cached key directly. Both shapes
+    // must agree.
+    let mut slow2 = inputs.clone();
+    let slow_key_root = compute_artifact_key(&ck, &mut slow2, Some(std::path::Path::new("/proj")));
+    let fast_key_root = compute_artifact_key_normalized_with_root(
+        &ck,
+        &inputs,
+        Some(std::path::Path::new("/proj")),
+    );
+    assert_eq!(
+        slow_key_root, fast_key_root,
+        "key_root: Some — fast-path must match closure path for mixed \
+         project-local + system-header inputs",
     );
 }

--- a/crates/zccache/src/depgraph/graph/mod.rs
+++ b/crates/zccache/src/depgraph/graph/mod.rs
@@ -1016,19 +1016,18 @@ impl DepGraph {
                 entry.key_root.as_deref(),
                 |path, key_root| self.cached_normalize_key_path(path, key_root),
             )
-        } else if entry.key_root.is_none() {
-            // Issue #585: fast path — when there's no key_root, the
-            // path-key bytes ARE NormalizedPath::key (populated since #576).
-            // Skip the cached_normalize_key_path indirection (which
-            // allocates 4 owned objects per lookup just to build the
-            // DashMap key) and use the in-struct cache directly.
-            crate::depgraph::context::compute_artifact_key_normalized_inplace(key, &mut file_hashes)
         } else {
-            compute_artifact_key_with(
+            // Issue #591: closure-free path for cc/cpp. For paths NOT
+            // under `key_root` (system headers — the common case),
+            // `NormalizedPath::case_key()` is the answer with zero
+            // allocation. For paths under `key_root` we compute fresh
+            // via `normalize_key_path(path, Some(root))`. Handles both
+            // `key_root: None` (was #585's compute_artifact_key_normalized_inplace)
+            // and `key_root: Some` in one shape.
+            crate::depgraph::context::compute_artifact_key_normalized_with_root(
                 key,
-                &mut file_hashes,
+                &file_hashes,
                 entry.key_root.as_deref(),
-                |path, key_root| self.cached_normalize_key_path(path, key_root),
             )
         };
         let artifact_key_compute_ns = t_artifact_key


### PR DESCRIPTION
## Summary

#584's diagnostic showed `artifact_key_compute_ns` scales linearly with `resolved_count` at ~20 µs/element (3.93 ms mean for 150+ headers post-#590). Tracing into the closure path: each entry calls `normalize_key_path(path, Some(root))` which:

1. Attempts `path.strip_prefix(root)` — fails for system headers (`/usr/include/...` is never under the project root).
2. Falls through to `normalize_for_key(path)`, allocating a fresh `String`.

But every `NormalizedPath` already caches its `normalize_for_key(self.path)` result in `self.key` (since #576). For the system-header case, the result of step 2 is **identical** to `np.case_key()` — we're recomputing what we already have.

## Fix

Add `compute_artifact_key_normalized_with_root` (extension of #587's `compute_artifact_key_normalized_inplace` that also handles `key_root: Some`). For each entry:
- Path under `key_root` → `Cow::Owned(normalize_key_path(...))` (alloc).
- Path NOT under (system headers, the common case) → `Cow::Borrowed(np.case_key())` (zero alloc).

Sorts on the materialized `Cow<str>` keys, then hashes — bit-identical output to the closure-based path.

`DepGraph::update`'s cc branch dispatches here directly (no closure, no `cached_normalize_key_path` indirection). Rustc still uses the closure form (needs it for extern-hash interaction with key_root).

## Test plan (TDD verified)

- [x] `compute_artifact_key_normalized_with_root_matches_closure` — byte-equality of fast-path vs `compute_artifact_key` (closure path) for mixed project-local + system-header inputs under both `key_root: None` AND `key_root: Some`.
- [x] All 1666 lib tests pass with `RUSTFLAGS=-D warnings`.
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean.
- [x] `soldr cargo fmt --all -- --check` clean.
- [ ] Confirm `artifact_key_compute_ns` mean drops from ~1.6 ms toward ~1.0 ms on next bench publish.

Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)