### PR TITLE
chore(release): bump 1.11.9 -> 1.11.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3698,7 +3698,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.11.9"
+version = "1.11.10"
 dependencies = [
  "bincode",
  "blake3",
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.11.9"
+version = "1.11.10"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3760,7 +3760,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.11.9"
+version = "1.11.10"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.11.9"
+version = "1.11.10"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.11.9"
+version = "1.11.10"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Bump workspace version from `1.11.9` to `1.11.10` so the merged start-hang fix from #559 can ship in a released zccache version.

This release is needed to unblock FastLED/fbuild#352, which intentionally waits for a tagged zccache release before removing its wrapper-side `FBUILD_ZCCACHE_START_TIMEOUT_SECS` workaround.

## Includes since 1.11.9

- fix(daemon): bound Status-probe recv to 2s in `check_daemon_version` (#559, closes #554)
- recent depgraph/cache cleanup and setup-soldr CI follow-ups already on main

## Test plan

- [x] `cargo check -p zccache --lib`