### PR TITLE
fix(perf-guard): pin rustup default toolchain from rust-toolchain.toml (fixes #596)

### DIFF
--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -114,6 +114,25 @@ jobs:
         shell: bash
         run: chmod +x perf-guard-bin/perf_bench_test
 
+      # Issue #596: the perf benchmark binary spawns rustc from worker
+      # tempdirs that have no rust-toolchain.toml — without a configured
+      # default in setup-soldr's managed RUSTUP_HOME, rustup's shim
+      # fails with "could not choose a version of rustc to run". Pin
+      # the default to the same toolchain the rest of CI builds with
+      # (sourced from rust-toolchain.toml at repo root) so every rustc
+      # subprocess resolves regardless of CWD.
+      - name: Pin rustup default toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          toolchain="$(awk -F'[="]+' '/^channel/ {print $2; exit}' rust-toolchain.toml)"
+          if [[ -z "$toolchain" ]]; then
+            echo "could not read channel from rust-toolchain.toml" >&2
+            exit 1
+          fi
+          rustup default "$toolchain"
+          rustc --version
+
       # --- Per-test perf guard steps -----------------------------------
       # Each benchmark test gets its own step so the GitHub Actions UI shows
       # per-test timing and failure status. Each step writes its results to


### PR DESCRIPTION
## Summary

Perf Guard's "Rust speed floor" and "C speed floor" jobs have been failing all 3 retry attempts with:

```
error: rustup could not choose a version of rustc to run, because one wasn't specified explicitly, and no default is configured.
```

`setup-soldr` provisions the 1.94.1 toolchain into its managed `RUSTUP_HOME` but does not set a default. The perf bench binary spawns rustc from worker tempdirs that have no `rust-toolchain.toml` of their own — without a default in `RUSTUP_HOME`'s `settings.toml`, the rustup shim has nothing to resolve, and the benchmark fails for environment reasons (not perf reasons).

**Net effect: Perf Guard has been failing on every push to main, so the regression-detection safety net is offline.**

## Fix

Add a step after `setup-soldr` that reads the channel from `rust-toolchain.toml` and runs `rustup default <channel>` so the managed `RUSTUP_HOME` has a resolved default. Subsequent rustc subprocess invocations (from any CWD) work.

## Why dynamic vs hardcoded "1.94.1"

The value moves on MSRV bumps. Sourcing from `rust-toolchain.toml` keeps the perf guard locked to the same toolchain the rest of CI uses without needing two-place updates.

## Test plan (TDD RED→GREEN)

- [x] **RED** — confirmed by prior failing run on main 2026-06-01 19:45 UTC ([job 78934504853](https://github.com/zackees/zccache/actions/runs/26777842412/job/78934504853)).
- [ ] **GREEN** — to be confirmed by post-merge Perf Guard run.

YAML-only change; no Rust test possible (the failure is in the CI environment, not in code).

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)