### PR TITLE
ci: bump setup-soldr v0.9.49 -> v0.9.50

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
-      uses: zackees/setup-soldr@v0.9.49
+      uses: zackees/setup-soldr@v0.9.50
       with:
         toolchain: 1.94.1
         cache: true

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -73,7 +73,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --lib --bins --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.49
+        uses: zackees/setup-soldr/cleanup@v0.9.50
       - name: Test
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.49
+        uses: zackees/setup-soldr@v0.9.50
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -119,7 +119,7 @@ jobs:
       actions: write
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         with:
           zccache-seed-strict: true
           cache: true
@@ -148,7 +148,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -44,7 +44,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Stop setup-soldr builder cache before coverage tests
-        uses: zackees/setup-soldr/cleanup@v0.9.49
+        uses: zackees/setup-soldr/cleanup@v0.9.50
       - name: Generate coverage
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -69,7 +69,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.49
+        uses: zackees/setup-soldr/cleanup@v0.9.50
       - name: Test (full workspace)
         shell: bash
         env:

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         with:
           zccache-seed-strict: true
           cache: false
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@v0.9.49
+        uses: zackees/setup-soldr@v0.9.50
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@v0.9.49
+        uses: zackees/setup-soldr@v0.9.50
         with:
           zccache-seed-strict: true
           cache: true


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.49` to `v0.9.50`.

## What's in v0.9.50
Graduated age floor for `cache-eviction-policy` (closes setup-soldr#356).

v0.9.48's fixed 6h age floor became a no-op under heavy CI load. Observed on zccache MSRV at 13.63 GB usage where ALL 171 evictable entries were < 6h old — eviction deleted zero, leaving GitHub's non-deterministic LRU in charge of foundation entries.

New tier table:

| Overshoot (usage − trigger) | Floor (protect-foundations) | Floor (aggressive) |
|---|---|---|
| ≤ 1 GB        | 6h (baseline, #352 fix preserved)   | 2h |
| 1–3 GB        | 2h                                  | 2h |
| > 3 GB        | 0.5h (danger zone)                  | 0.5h |

Post-step log now emits `graduated age floor active — overshoot=X GB, floor=Y h` when the tier kicks in. No action-input changes; pure logic improvement that takes effect for repos already using `cache-eviction-policy: protect-foundations`.

## Test plan
- [ ] CI green
- [ ] Post-step log shows `deleted N entries` (N ≥ 1) when usage > +3 GB over trigger
