### PR TITLE
fix: floor cache-hit outputs to input mtimes

### DIFF
--- a/.github/workflows/bench-action.yml
+++ b/.github/workflows/bench-action.yml
@@ -398,6 +398,11 @@ jobs:
           done
           echo ""
           CACHED=${{ needs.zccache-cached.outputs.restored }}
+          WARM_TARGET_LIMIT=$(( (BARE[warm_target] * 13 + 9) / 10 ))
+          if [ "${ZC[warm_target]}" -gt "$WARM_TARGET_LIMIT" ]; then
+            echo "::error::zccache warm-target-intact ${ZC[warm_target]}ms exceeds 1.3x bare ${BARE[warm_target]}ms (limit ${WARM_TARGET_LIMIT}ms)"
+            exit 1
+          fi
           printf "%-30s %8s   %8s   %8sms\n" "Cached target (2nd CI run)" "—" "—" "$CACHED"
           echo ""
           echo "| **Cached target (2nd CI run)** | — | — | **${CACHED}ms** | — | — |" >> "$GITHUB_STEP_SUMMARY"

--- a/crates/zccache/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/cached_hit.rs
@@ -38,6 +38,7 @@ pub(super) struct CachedHitMaterializeRequest<'a> {
     pub(super) cached_error_label: &'static str,
     pub(super) record_compilation: bool,
     pub(super) downgrade_output_metadata: bool,
+    pub(super) mtime_floor_paths: Vec<NormalizedPath>,
     pub(super) phases: CachedHitPhases,
 }
 
@@ -56,6 +57,7 @@ pub(super) fn materialize_cached_compile_hit(
         cached_error_label,
         record_compilation,
         downgrade_output_metadata,
+        mtime_floor_paths,
         phases,
     } = request;
 
@@ -91,7 +93,7 @@ pub(super) fn materialize_cached_compile_hit(
             (out, cache_file)
         })
         .collect();
-    if !write_payloads_par(&targets, &payloads) {
+    if !write_payloads_par_with_mtime_floor(&targets, &payloads, &mtime_floor_paths) {
         return None;
     }
     let t2 = Instant::now();
@@ -220,6 +222,7 @@ mod tests {
             cached_error_label: "CACHED_ERROR_TEST",
             record_compilation: true,
             downgrade_output_metadata: true,
+            mtime_floor_paths: Vec::new(),
             phases: CachedHitPhases::request_cache(0, 0),
         })
         .unwrap();
@@ -297,6 +300,7 @@ mod tests {
                 cached_error_label: "CACHED_ERROR_TEST",
                 record_compilation: true,
                 downgrade_output_metadata: false,
+                mtime_floor_paths: Vec::new(),
                 phases: CachedHitPhases::request_cache(0, 0),
             })
             .expect("materialize_cached_compile_hit must succeed");

--- a/crates/zccache/src/daemon/server/handle_compile/hit_branches.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/hit_branches.rs
@@ -55,6 +55,11 @@ pub(super) fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Option<R
     let output_path = req_entry
         .output_path
         .resolve(request_cache_key_root.as_deref());
+    let mtime_floor_paths: Vec<NormalizedPath> = req_entry
+        .input_paths
+        .iter()
+        .map(|path| path.resolve(request_cache_key_root.as_deref()))
+        .collect();
     let same_root = req_entry.root.as_ref() == request_cache_key_root.as_ref();
     let t_cross_root_validate = Instant::now();
     let inputs_match = if same_root {
@@ -99,6 +104,7 @@ pub(super) fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Option<R
         cached_error_label: "CACHED_ERROR_REQUEST",
         record_compilation: true,
         downgrade_output_metadata: false,
+        mtime_floor_paths,
         phases: CachedHitPhases::request_cache(request_cache_lookup_ns, cross_root_validate_ns),
     })
 }
@@ -173,6 +179,7 @@ pub(super) fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
     } else {
         "HIT_FAST"
     };
+    let input_paths = request_cache_input_paths(state, &context_key, source_path, ctx);
     let response = materialize_cached_compile_hit(CachedHitMaterializeRequest {
         state,
         sid,
@@ -185,6 +192,7 @@ pub(super) fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
         cached_error_label: "CACHED_ERROR_FAST",
         record_compilation: false,
         downgrade_output_metadata: true,
+        mtime_floor_paths: input_paths.clone(),
         phases: CachedHitPhases {
             parse_args_ns,
             build_context_ns,
@@ -203,7 +211,6 @@ pub(super) fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
         request_cache_key_root.as_deref(),
         client_env,
     );
-    let input_paths = request_cache_input_paths(state, &context_key, source_path, ctx);
     state.request_cache.insert(
         rfp,
         request_cache_entry(
@@ -279,6 +286,7 @@ pub(super) fn try_depgraph_cached_hit(probe: DepgraphHitProbe<'_>) -> Option<Res
     } else {
         "HIT"
     };
+    let input_paths = request_cache_input_paths(state, &context_key, source_path, ctx);
     let response = materialize_cached_compile_hit(CachedHitMaterializeRequest {
         state,
         sid,
@@ -291,6 +299,7 @@ pub(super) fn try_depgraph_cached_hit(probe: DepgraphHitProbe<'_>) -> Option<Res
         cached_error_label: "CACHED_ERROR",
         record_compilation: false,
         downgrade_output_metadata: true,
+        mtime_floor_paths: input_paths.clone(),
         phases: CachedHitPhases {
             parse_args_ns,
             build_context_ns,
@@ -303,7 +312,6 @@ pub(super) fn try_depgraph_cached_hit(probe: DepgraphHitProbe<'_>) -> Option<Res
     })?;
 
     if !worktree_equivalent_context {
-        let input_paths = request_cache_input_paths(state, &context_key, source_path, ctx);
         state.cache_system.register_tracked(&input_paths);
         let current_clock = state.cache_system.current_clock();
         state.fast_hit_cache.insert(

--- a/crates/zccache/src/daemon/server/persist.rs
+++ b/crates/zccache/src/daemon/server/persist.rs
@@ -415,6 +415,26 @@ where
         .all(|((out, cache), payload)| write_one(out.as_ref(), cache.as_ref(), payload))
 }
 
+pub(super) fn write_payloads_par_with_mtime_floor<P, Q, R>(
+    targets: &[(P, Q)],
+    payloads: &[CachedPayload],
+    floor_paths: &[R],
+) -> bool
+where
+    P: AsRef<Path> + Sync,
+    Q: AsRef<Path> + Sync,
+    R: AsRef<Path>,
+{
+    if !write_payloads_par(targets, payloads) {
+        return false;
+    }
+    floor_materialized_outputs_to_input_max(
+        targets.iter().map(|(out, _)| out.as_ref()),
+        floor_paths.iter().map(|path| path.as_ref()),
+    );
+    true
+}
+
 pub(super) fn break_output_hardlink_before_compile(path: &Path) -> std::io::Result<()> {
     match std::fs::metadata(path) {
         Ok(meta) if meta.is_file() => {}
@@ -574,6 +594,43 @@ pub(super) fn touch_mtime(path: &Path) {
         return;
     }
     let _ = floor_artifact_mtime_to_sibling_max(path);
+}
+
+fn floor_materialized_outputs_to_input_max<'a>(
+    output_paths: impl IntoIterator<Item = &'a Path>,
+    input_paths: impl IntoIterator<Item = &'a Path>,
+) {
+    if mtime_floor_disabled() {
+        return;
+    }
+
+    let outputs: Vec<&Path> = output_paths.into_iter().collect();
+    if outputs.is_empty() {
+        return;
+    }
+
+    let mut max_mtime: Option<std::time::SystemTime> = None;
+    for path in outputs.iter().copied().chain(input_paths) {
+        let Ok(mtime) = std::fs::metadata(path).and_then(|metadata| metadata.modified()) else {
+            continue;
+        };
+        if max_mtime.is_none_or(|current| mtime > current) {
+            max_mtime = Some(mtime);
+        }
+    }
+
+    let Some(max_mtime) = max_mtime else {
+        return;
+    };
+    let ft = filetime::FileTime::from_system_time(max_mtime);
+    for path in outputs {
+        let Ok(current) = std::fs::metadata(path).and_then(|metadata| metadata.modified()) else {
+            continue;
+        };
+        if current < max_mtime {
+            let _ = filetime::set_file_mtime(path, ft);
+        }
+    }
 }
 
 fn mtime_floor_disabled() -> bool {
@@ -805,5 +862,48 @@ mod tests {
         assert_eq!(first, epoch_plus(2_000_000));
         assert_eq!(second, first);
         assert_eq!(third, first);
+    }
+
+    #[test]
+    fn batch_floor_bumps_build_script_output_to_extern_mtime() {
+        // Issue #599: build-script binaries live in target/debug/build/*,
+        // while their rustc extern dependencies live in target/debug/deps.
+        // The same-directory floor never saw those extern artifacts.
+        let dir = tempfile::tempdir().unwrap();
+        let build_dir = dir.path().join("target/debug/build/blake3-abc");
+        let deps_dir = dir.path().join("target/debug/deps");
+        std::fs::create_dir_all(&build_dir).unwrap();
+        std::fs::create_dir_all(&deps_dir).unwrap();
+
+        let cache = dir.path().join("cache/build-script-cache");
+        std::fs::create_dir_all(cache.parent().unwrap()).unwrap();
+        std::fs::write(&cache, b"build script exe").unwrap();
+        let old_time = filetime::FileTime::from_unix_time(1_000_000, 0);
+        filetime::set_file_mtime(&cache, old_time).unwrap();
+
+        let extern_dep = deps_dir.join("libcc-new.rlib");
+        write_with_mtime(
+            &extern_dep,
+            b"cc rlib",
+            SystemTime::UNIX_EPOCH + Duration::new(2_000_000, 123_456_700),
+        );
+        let dep_mtime = mtime_of(&extern_dep);
+
+        let output = build_dir.join("build-script-build");
+        let targets = vec![(output.clone(), cache.clone())];
+        let payloads = vec![CachedPayload::File(cache.clone().into())];
+        let floor_paths = vec![extern_dep.clone()];
+
+        assert!(write_payloads_par_with_mtime_floor(
+            &targets,
+            &payloads,
+            &floor_paths,
+        ));
+
+        assert_eq!(
+            mtime_of(&output),
+            dep_mtime,
+            "extensionless build-script output must be floored to extern dependency mtime",
+        );
     }
 }


### PR DESCRIPTION
## Summary

- floor cache-hit materialized outputs to the max mtime of the context inputs, not just same-directory siblings
- covers Rust build-script outputs under `target/debug/build/*`, whose extern deps live under `target/debug/deps/*`
- add a benchmark guard that fails when zccache warm-target-intact exceeds 1.3x bare

Closes #599

## Local verification

- `cargo fmt --all`
- `cargo test -p zccache batch_floor_bumps_build_script_output_to_extern_mtime --lib -- --nocapture`
- `cargo test -p zccache daemon::server::persist::tests --lib`
- `cargo test -p zccache write_cached --lib`
- `cargo test -p zccache cached_hit --lib`
- `cargo test -p zccache fetch_no_wait_returns_locked_while_other_client_is_downloading --lib -- --nocapture`