### PR TITLE
fix: persist rustc externs in depgraph snapshots

### DIFF
--- a/.github/workflows/bench-action.yml
+++ b/.github/workflows/bench-action.yml
@@ -179,6 +179,7 @@ jobs:
         with:
           shared-key: bench
           cache-target: "true"
+          zccache-version: source
 
       - name: "Cold build"
         id: cold
@@ -249,6 +250,7 @@ jobs:
         with:
           shared-key: bench
           cache-target: "true"
+          zccache-version: source
 
       - name: "Diagnostics: target restore status"
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,8 @@ inputs:
   zccache-version:
     description: >
       Version of zccache to install.
-      Use "latest" for the newest release, or a specific version like "1.2.5".
+      Use "latest" for the newest release, a specific version like "1.2.5",
+      or "source" to build the checked-out repository version.
     required: false
     default: "latest"
   save-cache:
@@ -213,8 +214,32 @@ runs:
           return 0
         }
 
+        if [ "$VERSION" = "source" ] || [ "$VERSION" = "local" ]; then
+          INSTALL_DIR="$HOME/.local/bin"
+          BUILD_DIR="${RUNNER_TEMP:-/tmp}/zccache-action-source-build"
+          mkdir -p "$INSTALL_DIR"
+          rm -rf "$BUILD_DIR"
+
+          cargo build --release --target-dir "$BUILD_DIR" \
+            -p zccache \
+            --bin zccache \
+            --bin zccache-daemon \
+            --bin zccache-fp
+
+          BIN_EXT=""
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            BIN_EXT=".exe"
+          fi
+          cp "$BUILD_DIR/release/zccache${BIN_EXT}" "$INSTALL_DIR/"
+          cp "$BUILD_DIR/release/zccache-daemon${BIN_EXT}" "$INSTALL_DIR/"
+          cp "$BUILD_DIR/release/zccache-fp${BIN_EXT}" "$INSTALL_DIR/"
+          chmod +x "$INSTALL_DIR/zccache"* 2>/dev/null || true
+          add_install_dir_to_path "$INSTALL_DIR"
+          INSTALLED=true
+        fi
+
         # Try binary install on Linux/macOS (requires GitHub Releases to exist)
-        if [ "${{ runner.os }}" != "Windows" ]; then
+        if [ "$INSTALLED" = "false" ] && [ "${{ runner.os }}" != "Windows" ]; then
           INSTALL_DIR="$HOME/.local/bin"
           mkdir -p "$INSTALL_DIR"
 

--- a/action/README.md
+++ b/action/README.md
@@ -41,7 +41,7 @@ steps:
 | `target-restore-fallback` | `false` | Allow prefix fallback for target snapshot restores |
 | `target-dir` | `target` | Path to the cargo target directory |
 | `shared-key` | `""` | Extra cache key for matrix isolation |
-| `zccache-version` | `latest` | PyPI version to install |
+| `zccache-version` | `latest` | Version to install; use `source` to build the checked-out repo |
 | `save-cache` | `true` | Set `false` for PR builds (restore-only) |
 
 ## Outputs

--- a/crates/zccache/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/cached_hit.rs
@@ -174,7 +174,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn target_paths_keep_cache_mtime_through_shared_materializer() {
+    async fn target_paths_get_fresh_mtime_through_shared_materializer() {
         let dir = tempfile::tempdir().unwrap();
         let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
         let state = server.state.as_ref();
@@ -236,9 +236,11 @@ mod tests {
             }
         ));
         assert_eq!(std::fs::read(&output_path).unwrap(), payload.as_slice());
-        assert_eq!(
-            file_time(&output_path).unix_seconds(),
-            old_time.unix_seconds()
+        let output_time = file_time(&output_path);
+        assert!(
+            output_time.unix_seconds() > old_time.unix_seconds(),
+            "compile-hit output must be fresher than stale cache artifact; \
+             output={output_time:?}, cache={old_time:?}",
         );
         assert_eq!(state.stats.snapshot().compilations, 1);
         assert_eq!(state.stats.snapshot().hits, 1);

--- a/crates/zccache/src/daemon/server/persist.rs
+++ b/crates/zccache/src/daemon/server/persist.rs
@@ -428,9 +428,11 @@ where
     if !write_payloads_par(targets, payloads) {
         return false;
     }
+    let batch_floor = std::time::SystemTime::now();
     floor_materialized_outputs_to_input_max(
         targets.iter().map(|(out, _)| out.as_ref()),
         floor_paths.iter().map(|path| path.as_ref()),
+        batch_floor,
     );
     true
 }
@@ -599,6 +601,7 @@ pub(super) fn touch_mtime(path: &Path) {
 fn floor_materialized_outputs_to_input_max<'a>(
     output_paths: impl IntoIterator<Item = &'a Path>,
     input_paths: impl IntoIterator<Item = &'a Path>,
+    minimum_mtime: std::time::SystemTime,
 ) {
     if mtime_floor_disabled() {
         return;
@@ -609,19 +612,16 @@ fn floor_materialized_outputs_to_input_max<'a>(
         return;
     }
 
-    let mut max_mtime: Option<std::time::SystemTime> = None;
+    let mut max_mtime = minimum_mtime;
     for path in outputs.iter().copied().chain(input_paths) {
         let Ok(mtime) = std::fs::metadata(path).and_then(|metadata| metadata.modified()) else {
             continue;
         };
-        if max_mtime.is_none_or(|current| mtime > current) {
-            max_mtime = Some(mtime);
+        if mtime > max_mtime {
+            max_mtime = mtime;
         }
     }
 
-    let Some(max_mtime) = max_mtime else {
-        return;
-    };
     let ft = filetime::FileTime::from_system_time(max_mtime);
     for path in outputs {
         let Ok(current) = std::fs::metadata(path).and_then(|metadata| metadata.modified()) else {
@@ -900,10 +900,44 @@ mod tests {
             &floor_paths,
         ));
 
-        assert_eq!(
-            mtime_of(&output),
-            dep_mtime,
-            "extensionless build-script output must be floored to extern dependency mtime",
+        let output_mtime = mtime_of(&output);
+        assert!(
+            output_mtime >= dep_mtime,
+            "extensionless build-script output must be at least as new as extern dependency; \
+             output={output_mtime:?}, dep={dep_mtime:?}",
+        );
+    }
+
+    #[test]
+    fn batch_floor_freshens_materialized_outputs_without_floor_paths() {
+        // Issue #599: a compile cache hit is still a rustc invocation from
+        // Cargo's perspective. If zccache hardlinks an old cache artifact and
+        // preserves that old mtime, Cargo records stale output mtimes and the
+        // next no-op build recompiles the graph. The batch materializer uses
+        // one fresh floor for all outputs from that hit.
+        let dir = tempfile::tempdir().unwrap();
+        let cache = dir.path().join("cache/libcrate-cache.rlib");
+        std::fs::create_dir_all(cache.parent().unwrap()).unwrap();
+        std::fs::write(&cache, b"rlib").unwrap();
+        let old_mtime = epoch_plus(1_000_000);
+        filetime::set_file_mtime(&cache, filetime::FileTime::from_system_time(old_mtime)).unwrap();
+
+        let output = dir.path().join("target/debug/deps/libcrate.rlib");
+        let targets = vec![(output.clone(), cache.clone())];
+        let payloads = vec![CachedPayload::File(cache.clone().into())];
+        let floor_paths: Vec<PathBuf> = Vec::new();
+
+        assert!(write_payloads_par_with_mtime_floor(
+            &targets,
+            &payloads,
+            &floor_paths,
+        ));
+
+        let output_mtime = mtime_of(&output);
+        assert!(
+            output_mtime > old_mtime,
+            "compile-hit output must not inherit the stale cache mtime; \
+             output={output_mtime:?}, old_cache={old_mtime:?}",
         );
     }
 }

--- a/crates/zccache/src/depgraph/graph/mod.rs
+++ b/crates/zccache/src/depgraph/graph/mod.rs
@@ -1205,15 +1205,16 @@ impl DepGraph {
         self.files.iter()
     }
 
-    /// Construct a `DepGraph` from pre-built maps (for deserialization).
-    pub(crate) fn from_maps(
+    /// Construct a `DepGraph` from pre-built maps, including rustc extern inputs.
+    pub(crate) fn from_maps_with_rustc_externs(
         files: DashMap<NormalizedPath, FileEntry>,
         contexts: DashMap<ContextKey, ContextEntry>,
+        rustc_externs: DashMap<ContextKey, Vec<(String, NormalizedPath)>>,
     ) -> Self {
         Self {
             files,
             contexts,
-            rustc_externs: DashMap::new(),
+            rustc_externs,
             path_key_cache: DashMap::new(),
             checks: AtomicU64::new(0),
             hits: AtomicU64::new(0),

--- a/crates/zccache/src/depgraph/snapshot/mod.rs
+++ b/crates/zccache/src/depgraph/snapshot/mod.rs
@@ -36,7 +36,7 @@ pub use persistence::{
 };
 
 /// On-disk format version. Bump when snapshot layout changes.
-pub const DEPGRAPH_VERSION: u32 = 4;
+pub const DEPGRAPH_VERSION: u32 = 5;
 
 /// Magic bytes identifying a depgraph snapshot file ("ZCDG").
 pub const DEPGRAPH_MAGIC: [u8; 4] = [0x5A, 0x43, 0x44, 0x47];
@@ -91,8 +91,16 @@ pub struct ContextEntrySnapshot {
     pub has_computed_includes: bool,
     pub artifact_key: Option<[u8; 32]>,
     pub last_file_hashes: Vec<(String, [u8; 32])>,
+    pub rustc_externs: Vec<RustcExternSnapshot>,
     /// 0=Cold, 1=Warm, 2=Stale
     pub state: u8,
+}
+
+#[derive(Archive, Serialize, Deserialize)]
+#[archive(check_bytes)]
+pub struct RustcExternSnapshot {
+    pub name: String,
+    pub path: String,
 }
 
 #[derive(Archive, Serialize, Deserialize)]
@@ -156,6 +164,15 @@ impl DepGraph {
             .map(|entry| {
                 let key = entry.key();
                 let ctx = entry.value();
+                let rustc_externs = self
+                    .get_rustc_externs(key)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|(name, path)| RustcExternSnapshot {
+                        name,
+                        path: path.to_string_lossy().into_owned(),
+                    })
+                    .collect();
                 ContextEntrySnapshot {
                     context_key: *key.hash().as_bytes(),
                     key_root: ctx
@@ -180,6 +197,7 @@ impl DepGraph {
                         .iter()
                         .map(|(p, h)| (p.to_string_lossy().into_owned(), *h.as_bytes()))
                         .collect(),
+                    rustc_externs,
                     state: match ctx.state {
                         ContextState::Cold => 0,
                         ContextState::Warm => 1,
@@ -234,8 +252,14 @@ impl DepGraph {
         });
 
         let contexts: DashMap<ContextKey, ContextEntry> = DashMap::new();
+        let rustc_externs: DashMap<ContextKey, Vec<(String, NormalizedPath)>> = DashMap::new();
         snap.contexts.into_par_iter().for_each(|c| {
             let key = ContextKey::from_raw(c.context_key);
+            let externs: Vec<(String, NormalizedPath)> = c
+                .rustc_externs
+                .into_iter()
+                .map(|entry| (entry.name, NormalizedPath::from(entry.path.as_str())))
+                .collect();
             let context = CompileContext {
                 source_file: NormalizedPath::from(c.source_file.as_str()),
                 include_search: IncludeSearchPaths {
@@ -269,9 +293,12 @@ impl DepGraph {
                 },
             };
             contexts.insert(key, entry);
+            if !externs.is_empty() {
+                rustc_externs.insert(key, externs);
+            }
         });
 
-        DepGraph::from_maps(files, contexts)
+        DepGraph::from_maps_with_rustc_externs(files, contexts, rustc_externs)
     }
 }
 

--- a/crates/zccache/src/depgraph/snapshot/tests/round_trip.rs
+++ b/crates/zccache/src/depgraph/snapshot/tests/round_trip.rs
@@ -190,6 +190,42 @@ fn artifact_key_some_roundtrip() {
     );
 }
 
+#[test]
+fn rustc_externs_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let path = test_path(&dir);
+    let graph = DepGraph::new();
+
+    let ctx = make_ctx("/src/app.rs");
+    let key = ctx.context_key();
+    let externs = vec![
+        (
+            "dep".to_string(),
+            NormalizedPath::from("/target/debug/deps/libdep.rlib"),
+        ),
+        (
+            "cc".to_string(),
+            NormalizedPath::from("/target/debug/deps/libcc.rlib"),
+        ),
+    ];
+
+    graph.register_rustc_with_key_and_root_result(key, ctx, None, externs.clone());
+    graph.update(
+        &key,
+        ScanResult {
+            resolved: Vec::new(),
+            unresolved: Vec::new(),
+            has_computed: false,
+        },
+        super::dummy_hash,
+    );
+
+    save_to_file(&graph, &path).unwrap();
+    let loaded = load_from_file(&path).unwrap();
+
+    assert_eq!(loaded.get_rustc_externs(&key), Some(externs));
+}
+
 /// Artifact key=None (Cold context) must roundtrip as None.
 #[test]
 fn artifact_key_none_roundtrip() {


### PR DESCRIPTION
Follow-up to #600 for #599.\n\nThe stricter benchmark guard exposed that zccache still recompiles after a restored target because the persisted depgraph drops rustc extern input paths. Cache-hit materialization then cannot floor build-script outputs to newer dependency artifact mtimes after a daemon restart.\n\nThis PR persists rustc extern paths in depgraph snapshot v5 and adds a roundtrip regression test.\n\nVerification run locally:\n- cargo test -p zccache depgraph::snapshot::tests --lib -- --nocapture\n\nI will run the benchmark workflow on this branch before merge.