### PR TITLE
fix(perf-guard): extract toolchain from rust-toolchain.toml correctly

### DIFF
--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -125,8 +125,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          toolchain="$(awk -F'[="]+' '/^channel/ {print $2; exit}' rust-toolchain.toml)"
-          if [[ -z "$toolchain" ]]; then
+          # Parse `channel = "1.94.1"` from rust-toolchain.toml.
+          # Previous awk-with-multi-char-FS extracted the space
+          # between `=` and the opening quote into $2 instead of the
+          # actual value into $3, so `rustup default ' '` errored
+          # with "toolchain ' ' is not installed". Use sed with a
+          # capture group for unambiguous extraction.
+          toolchain="$(sed -nE 's/^channel[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' rust-toolchain.toml | head -n1)"
+          if [[ -z "$toolchain" || "$toolchain" =~ ^[[:space:]]*$ ]]; then
             echo "could not read channel from rust-toolchain.toml" >&2
             exit 1
           fi


### PR DESCRIPTION
## Summary
PR #597 added a \`Pin rustup default toolchain\` step that uses awk with multi-char FS (\`[=\"]+\`) to extract the channel from \`rust-toolchain.toml\`. The expression treats \`=\` and \`\"\` as field separators but \`$2\` then becomes the space between \`=\` and the opening quote — not the value. Result: \`rustup default ' '\` fails with \"toolchain ' ' is not installed\" on every Perf Guard run.

Replace with \`sed\` + a capture group for unambiguous extraction.

## Test plan
- [x] Locally: \`sed -nE 's/^channel[[:space:]]*=[[:space:]]*\"([^\"]+)\".*/\1/p' rust-toolchain.toml\` → \`1.94.1\`
- [ ] Perf Guard \`Rust speed floor\` / \`C speed floor\` / \`C++ speed floor\` jobs go green on this PR