### PR TITLE
ci: bump setup-soldr v0.9.55 -> v0.9.56

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
-      uses: zackees/setup-soldr@v0.9.55
+      uses: zackees/setup-soldr@v0.9.56
       with:
         toolchain: 1.94.1
         cache: true

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -73,7 +73,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --lib --bins --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.55
+        uses: zackees/setup-soldr/cleanup@v0.9.56
       - name: Test
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -119,7 +119,7 @@ jobs:
       actions: write
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         with:
           zccache-seed-strict: true
           cache: true
@@ -148,7 +148,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -44,7 +44,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Stop setup-soldr builder cache before coverage tests
-        uses: zackees/setup-soldr/cleanup@v0.9.55
+        uses: zackees/setup-soldr/cleanup@v0.9.56
       - name: Generate coverage
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -69,7 +69,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.55
+        uses: zackees/setup-soldr/cleanup@v0.9.56
       - name: Test (full workspace)
         shell: bash
         env:

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         with:
           zccache-seed-strict: true
           cache: false
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           zccache-seed-strict: true
           cache: true


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.55` to `v0.9.56`.

## What's in v0.9.56
Fixes v0.9.55's parentSha derivation on shallow checkouts (the default `actions/checkout` config with `fetch-depth: 1`). Production observation on zccache MSRV (run 26799669322):
```
parent-sha: unexpected git output "\n"; leaving empty
cook: layered keys ... (no parent-fallback — parentSha unavailable, #365)
cook-cache-delta MISS
```

`git log -1 --format=%P HEAD` returns empty for grafted root commits on shallow clones. v0.9.56 adds a `git cat-file -p HEAD` fallback that parses the raw commit object — its `parent` header line is preserved even when the parent commit isn't fetched. This finally activates the cook-cache-delta / target-cache / cargo-registry parent-SHA fallback restore keys.

## Test plan
- [ ] CI green
- [ ] Log shows `parent-sha: derived <sha> from cat-file (#365, shallow-safe)`
- [ ] `cook: layered keys ... delta-fallback=cook-delta-v2-...-g<parent-sha>` appears
- [ ] Second commit after this lands: cook-cache-delta should HIT against this commit's saved entry
