### PR TITLE
ci: bump setup-soldr v0.9.56 -> v0.9.57

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
-      uses: zackees/setup-soldr@v0.9.56
+      uses: zackees/setup-soldr@v0.9.57
       with:
         toolchain: 1.94.1
         cache: true

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -73,7 +73,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --lib --bins --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.56
+        uses: zackees/setup-soldr/cleanup@v0.9.57
       - name: Test
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.56
+        uses: zackees/setup-soldr@v0.9.57
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -119,7 +119,7 @@ jobs:
       actions: write
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         with:
           zccache-seed-strict: true
           cache: true
@@ -148,7 +148,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -44,7 +44,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Stop setup-soldr builder cache before coverage tests
-        uses: zackees/setup-soldr/cleanup@v0.9.56
+        uses: zackees/setup-soldr/cleanup@v0.9.57
       - name: Generate coverage
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -69,7 +69,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.56
+        uses: zackees/setup-soldr/cleanup@v0.9.57
       - name: Test (full workspace)
         shell: bash
         env:

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         with:
           zccache-seed-strict: true
           cache: false
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@v0.9.56
+        uses: zackees/setup-soldr@v0.9.57
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@v0.9.56
+        uses: zackees/setup-soldr@v0.9.57
         with:
           zccache-seed-strict: true
           cache: true


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.56` to `v0.9.57`.

## What's in v0.9.57 — major perf win
Adds `cook-base-v2-` to `FOUNDATION_PREFIXES` so setup-soldr's controlled eviction skips cook-cache-base entries. Closes setup-soldr#368.

Production evidence on zccache:
- 08:17 UTC: cook-cache-base HIT (key `cook-base-v2-linux-x64-glibc-rustc1.94.1-fnone-l92559307b22cc1be-soldrv0.7.51`)
- 08:38 UTC: same lockfile hash on child commit — base **MISS** (evicted in 21 minutes by our own graduated age floor)

Cost of MISS: ~200s of cold cargo cook per affected job. With this change, the same base survives across commits and CI cycles.

GitHub's own LRU continues evicting truly-stale cook-base entries (~7 days unused), so unbounded growth is bounded. Worst case ~7 platforms × 300 MB = ~2.1 GB foundation footprint.

## Test plan
- [ ] CI green
- [ ] Cook-cache-base HIT rate climbs to >50% on consecutive commits with same lockfile
- [ ] Post-step eviction log shows cook-base entries protected from self-eviction
