### PR TITLE
ci: bump setup-soldr v0.9.57 -> v0.9.59

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
-      uses: zackees/setup-soldr@v0.9.57
+      uses: zackees/setup-soldr@v0.9.59
       with:
         toolchain: 1.94.1
         cache: true

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.57
+      - uses: zackees/setup-soldr@v0.9.59
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.57
+      - uses: zackees/setup-soldr@v0.9.59
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.57
+      - uses: zackees/setup-soldr@v0.9.59
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -73,7 +73,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --lib --bins --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.57
+        uses: zackees/setup-soldr/cleanup@v0.9.59
       - name: Test
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.57
+      - uses: zackees/setup-soldr@v0.9.59
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -119,7 +119,7 @@ jobs:
       actions: write
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.57
+      - uses: zackees/setup-soldr@v0.9.59
         with:
           zccache-seed-strict: true
           cache: true
@@ -148,7 +148,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.57
+      - uses: zackees/setup-soldr@v0.9.59
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.57
+      - uses: zackees/setup-soldr@v0.9.59
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.57
+      - uses: zackees/setup-soldr@v0.9.59
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -44,7 +44,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Stop setup-soldr builder cache before coverage tests
-        uses: zackees/setup-soldr/cleanup@v0.9.57
+        uses: zackees/setup-soldr/cleanup@v0.9.59
       - name: Generate coverage
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.57
+      - uses: zackees/setup-soldr@v0.9.59
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -69,7 +69,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.57
+        uses: zackees/setup-soldr/cleanup@v0.9.59
       - name: Test (full workspace)
         shell: bash
         env:

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.57
+      - uses: zackees/setup-soldr@v0.9.59
         with:
           zccache-seed-strict: true
           cache: false
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.57
+      - uses: zackees/setup-soldr@v0.9.59
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           zccache-seed-strict: true
           cache: true


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.57` to `v0.9.59`.

## What's in v0.9.58–v0.9.59
- **v0.9.58** — Eviction log splits foundation-protected vs age-floor-protected counts (diagnostic).
- **v0.9.59** — **PERF**: drops git SHA from cargo-registry cache key (closes setup-soldr#371). Same anti-pattern fix as #237 did for build-cache. Production-observed: every commit's cargo-registry exact-key probe missed (only matched same-SHA retries), and the action burned ~56 MB upload bandwidth saving a new entry that no future probe could hit. After this fix, exact-key hit rate climbs to ~100% per (lockHash, digest) generation, save status flips to `skipped-race` for subsequent matrix jobs, and per-CI-cycle redundant uploads drop by ~50 MB × matrix-job-count.

## Test plan
- [ ] CI green
- [ ] cargo-registry log shows `HIT` instead of `FALLBACK` on subsequent commits with same lockHash
- [ ] Per-layer save table shows cargo-registry status flipping to `skipped-race` for jobs after the first save
