### PR TITLE
ci: bump setup-soldr v0.9.60 -> v0.9.61

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
-      uses: zackees/setup-soldr@v0.9.60
+      uses: zackees/setup-soldr@v0.9.61
       with:
         toolchain: 1.94.1
         cache: true

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.60
+      - uses: zackees/setup-soldr@v0.9.61
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.60
+      - uses: zackees/setup-soldr@v0.9.61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.60
+      - uses: zackees/setup-soldr@v0.9.61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -73,7 +73,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --lib --bins --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.60
+        uses: zackees/setup-soldr/cleanup@v0.9.61
       - name: Test
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.60
+      - uses: zackees/setup-soldr@v0.9.61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.60
+        uses: zackees/setup-soldr@v0.9.61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -119,7 +119,7 @@ jobs:
       actions: write
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.60
+      - uses: zackees/setup-soldr@v0.9.61
         with:
           zccache-seed-strict: true
           cache: true
@@ -148,7 +148,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.60
+      - uses: zackees/setup-soldr@v0.9.61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.60
+      - uses: zackees/setup-soldr@v0.9.61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.60
+      - uses: zackees/setup-soldr@v0.9.61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -44,7 +44,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Stop setup-soldr builder cache before coverage tests
-        uses: zackees/setup-soldr/cleanup@v0.9.60
+        uses: zackees/setup-soldr/cleanup@v0.9.61
       - name: Generate coverage
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: zackees/setup-soldr@v0.9.60
+      - uses: zackees/setup-soldr@v0.9.61
         with:
           zccache-seed-strict: true
           toolchain: 1.94.1
@@ -69,7 +69,7 @@ jobs:
         shell: bash
         run: soldr cargo test --workspace --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@v0.9.60
+        uses: zackees/setup-soldr/cleanup@v0.9.61
       - name: Test (full workspace)
         shell: bash
         env:

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.60
+      - uses: zackees/setup-soldr@v0.9.61
         with:
           zccache-seed-strict: true
           cache: false
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: zackees/setup-soldr@v0.9.60
+      - uses: zackees/setup-soldr@v0.9.61
         with:
           zccache-seed-strict: true
           cache: false

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: setup soldr with cook prebuild (Unix)
         if: runner.os != 'Windows'
-        uses: zackees/setup-soldr@v0.9.60
+        uses: zackees/setup-soldr@v0.9.61
         with:
           zccache-seed-strict: true
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: setup soldr without cook prebuild (Windows)
         if: runner.os == 'Windows'
-        uses: zackees/setup-soldr@v0.9.60
+        uses: zackees/setup-soldr@v0.9.61
         with:
           zccache-seed-strict: true
           cache: true


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.60` to `v0.9.61`.

## What's in v0.9.61 — perf win
Cache-eviction now sorts evictable entries by size descending (biggest first) instead of age ascending. Same byte-target reached with ~10× fewer API calls.

Production observation on zccache (v0.9.60 cascade run):
- 304 entries deleted to free 1.33 GB
- 70% were <1 MB sccache shards (~100 MB total)
- 3% were >100 MB entries (~1 GB total)

Combined with v0.9.60's parallel deletes, cache-eviction wall-clock should drop from ~12s to ~1-2s per CI cycle.

## Test plan
- [ ] CI green
- [ ] Post-step eviction log shows ~10 deletions (instead of ~300) when over-budget
