### PR TITLE
test(cold-path): crash-mid-flight recovery test for #610

### DIFF
--- a/crates/zccache/src/daemon/server/tests/deferred_cold_path.rs
+++ b/crates/zccache/src/daemon/server/tests/deferred_cold_path.rs
@@ -465,3 +465,103 @@ cat "$src" >> "$out"
         "v1 and v2 bytes must differ — source edit between compiles must invalidate the cache key"
     );
 }
+
+/// Daemon crash mid-flight must never surface wrong content to a post-restart
+/// lookup. The lookup either hits with correct content (artifact + index were
+/// already durable before the crash) or misses and recompiles to the same
+/// deterministic bytes (artifact and/or index were lost). It never returns
+/// content from a different cache key.
+///
+/// This is the canonical crash-recovery invariant from #610: under the
+/// deferred-write path, the response leaves the daemon BEFORE the in-memory
+/// cache becomes visible and BEFORE the WAL flush. If a crash lands inside
+/// that window, the next daemon's `load_all()` from the on-disk index plus
+/// content-addressed artifact directory must recover any committed entry,
+/// and reject any uncommitted one without surfacing wrong content.
+///
+/// The test simulates the crash by **dropping** the `DaemonServer` (no
+/// graceful shutdown — no shutdown notify, no final WAL flush, no in-flight
+/// task drain) and binding a fresh server to the same cache root. Both
+/// daemons share the cache root via `ZCCACHE_CACHE_DIR` (set by
+/// `CacheDirEnvGuard`), so the second daemon reads whatever the first
+/// daemon managed to persist before the abrupt drop.
+#[tokio::test]
+async fn crash_mid_flight_recovery_never_surfaces_wrong_content() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_root = tmp.path().join("zccache-cache");
+    let _guard = CacheDirEnvGuard::set(&cache_root);
+
+    let cc = write_fake_cc(tmp.path());
+    let src = tmp.path().join("crashy.c");
+    std::fs::write(&src, b"int crashy(void) { return 9; }\n").unwrap();
+    let out = tmp.path().join("crashy.o");
+    let args = vec![
+        "-c".to_string(),
+        src.to_string_lossy().into_owned(),
+        "-o".to_string(),
+        out.to_string_lossy().into_owned(),
+    ];
+
+    // First daemon: do the cold-miss compile and capture the canonical bytes
+    // for `crashy.c`. The fake cc shim derives bytes from the source path —
+    // so any post-restart lookup that returns different bytes would be
+    // surfacing content from a different cache key, the wrong-hit we must
+    // never see.
+    let expected = {
+        let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
+        let resp = handle_compile_ephemeral(
+            &server.state,
+            std::process::id(),
+            tmp.path(),
+            &cc,
+            &args,
+            tmp.path(),
+            None,
+            Vec::new(),
+        )
+        .await;
+        match resp {
+            Response::CompileResult { exit_code, .. } => assert_eq!(exit_code, 0),
+            other => panic!("expected CompileResult on cold path, got {other:?}"),
+        }
+        std::fs::read(&out).expect("cold output present")
+        // `server` drops here — no graceful shutdown, no final WAL flush.
+        // Any uncommitted entries are lost on purpose. This is the "crash".
+    };
+
+    // Drop the cold-miss output file so any post-restart compile must
+    // materialize fresh bytes (either from cache or by recompiling).
+    std::fs::remove_file(&out).ok();
+
+    // Second daemon: same cache root, fresh process state. `load_all()` may
+    // or may not have seen the first daemon's writes depending on whether
+    // the artifact persist + WAL flush completed before the drop.
+    let server2 = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
+    let resp = handle_compile_ephemeral(
+        &server2.state,
+        std::process::id(),
+        tmp.path(),
+        &cc,
+        &args,
+        tmp.path(),
+        None,
+        Vec::new(),
+    )
+    .await;
+    match resp {
+        Response::CompileResult { exit_code, .. } => assert_eq!(exit_code, 0),
+        other => panic!("expected CompileResult on post-crash path, got {other:?}"),
+    }
+    let got = std::fs::read(&out).expect("post-crash output present");
+
+    // Core invariant: the post-restart compile, whether it hit recovered
+    // cache state or recompiled from scratch, must produce content that
+    // matches the original cold-miss bytes. A wrong-hit returning content
+    // from a different cache key fails here.
+    assert_eq!(
+        got, expected,
+        "post-restart content must match the original cold-miss bytes — \
+         whether the cache was recovered or rebuilt is implementation \
+         detail; the only invariant is correctness"
+    );
+}


### PR DESCRIPTION
## Summary

Fourth installment of #610's adversarial test track.

`crash_mid_flight_recovery_never_surfaces_wrong_content` simulates a daemon crash mid-flight by **dropping** the `DaemonServer` (no graceful shutdown — no `shutdown.notify()`, no final WAL flush, no in-flight task drain) and binding a fresh server to the same cache root.

## Invariant under test

The post-restart compile lookup either:

- **Hits with content matching the original cold-miss bytes** (artifact + index were already durable before the crash), or
- **Misses and recompiles to the same deterministic bytes** (artifact and/or index were lost).

It **never** surfaces content from a different cache key. That is the wrong-hit window DD-015 forbids and DD-025 condition 2 (\"failure mode is a miss, never a wrong hit\") explicitly preserves under deferred-write semantics.

## Why this matters for #610

Under #610's deferred-write path, the response leaves the daemon **before** the in-memory cache becomes visible and **before** the WAL flush. A crash that lands inside that window must not leave any future lookup with corrupt or cross-key content. The test asserts that today (the sync-store path already meets the bar via DD-008/DD-010/DD-017 — atomic writes + ACID redb + persistent artifacts) and will continue to assert it once the defer lands.

## Test mechanics

- `CacheDirEnvGuard` pins `ZCCACHE_CACHE_DIR` to a `tempfile::tempdir` for both daemon instances → they share the same cache root.
- First `DaemonServer::bind` does the cold-miss compile.
- First server is dropped (no graceful path). Any uncommitted in-flight WAL entries are lost intentionally.
- Second `DaemonServer::bind` loads from on-disk state and handles a fresh compile request for the same source.
- Assertion: bytes match.

## Refs

- #605 — cold-path-optimization ledger
- #610 — implementation issue
- #611, #612, #613 (all merged) — prior installments of the adversarial test track
- DD-008 / DD-010 / DD-017 — the foundations the recovery invariant rests on
- DD-025 condition 2 — \"failure mode is a miss, never a wrong hit\"
- DD-025 condition 4 — adversarial tests land before the optimization

## Test plan

- [ ] CI green
- [ ] No production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)