### PR TITLE
docs(strict-paths): document Windows PCH #pragma-once failure mode (#619)

### DIFF
--- a/crates/zccache/src/cli/commands/args.rs
+++ b/crates/zccache/src/cli/commands/args.rs
@@ -17,6 +17,17 @@ pub(crate) struct Cli {
     pub show_stats: bool,
 
     /// Validate compiler path flag spelling: off, consistent, or absolute.
+    ///
+    /// On Windows, header paths reaching the compiler through both a PCH
+    /// and a direct `#include` can be spelled with mixed separators
+    /// (e.g. `src\fl/stl/cstdio.h`) — clang then sees one physical file
+    /// as two paths and `#pragma once` fails to dedupe across the PCH
+    /// boundary. Symptom: `error: redefinition of 'X'` with an
+    /// "included multiple times" note that quotes the SAME path on both
+    /// sides. Set `--strict-paths=consistent` (or
+    /// `ZCCACHE_STRICT_PATHS=consistent`) to catch the spelling drift at
+    /// the compile-command level before it reaches clang internals. See
+    /// #619 for the worked example.
     #[arg(
         long,
         value_name = "MODE",
@@ -142,6 +153,10 @@ pub(crate) enum Commands {
     /// Wrap a compiler invocation (explicit mode).
     Wrap {
         /// Validate compiler path flag spelling: off, consistent, or absolute.
+        ///
+        /// On Windows, mixed-separator include paths can defeat clang's
+        /// `#pragma once` dedup across PCH/consumer-TU boundaries — see
+        /// #619 and the global `--strict-paths` help above.
         #[arg(
             long,
             value_name = "MODE",

--- a/crates/zccache/src/compiler/strict_paths.rs
+++ b/crates/zccache/src/compiler/strict_paths.rs
@@ -2,6 +2,24 @@
 //!
 //! This catches include/force-include path spellings that can make compilers
 //! see one physical header through multiple raw path strings.
+//!
+//! ## Canonical failure this guards against (Windows / clang / PCH)
+//!
+//! On Windows, a header reached both via a PCH and via a direct `#include`
+//! can be passed to clang under two mixed-separator spellings —
+//! `src\fl/stl/cstdio.h` from one site, `src/fl/stl/cstdio.h` from another.
+//! Clang treats those as distinct paths inside its dedup map, so
+//! `#pragma once` no longer dedupes across the PCH boundary and the user
+//! sees `error: redefinition of …` with an "included multiple times" note
+//! that quotes the SAME-looking path on both sides. See issue #619 for the
+//! worked example on FastLED.
+//!
+//! Enabling `StrictPathsMode::Consistent` (set
+//! `ZCCACHE_STRICT_PATHS=consistent` or pass `--strict-paths=consistent`)
+//! makes zccache reject mixed-separator `-I` / `-include` flags at the
+//! compile-command level — before the spelling drift reaches clang
+//! internals where the symptom is much harder to diagnose. The mode is
+//! OFF by default so existing builds don't fail without warning.
 
 use std::fmt;
 


### PR DESCRIPTION
## Summary

#619 reports that on Windows, mixed-separator include paths (\`src\fl/stl/cstdio.h\` from one site, \`src/fl/stl/cstdio.h\` from another) can defeat clang's \`#pragma once\` dedup when the same physical header is reached both via a PCH and via a direct \`#include\`. The user-visible symptom is \`error: redefinition of X\` with an "included multiple times" note that quotes the SAME-looking path on both sides — substantially harder to diagnose at the clang level than at the compile-command level.

\`StrictPathsMode::Consistent\` already catches this class of bug; it was simply **not discoverable** from the CLI help text. This PR fixes that.

## Changes

- **Global `--strict-paths` clap help** in `cli/commands/args.rs`: expanded to name the Windows PCH `#pragma once` symptom and point at #619.
- **`Wrap` subcommand `--strict-paths` help**: cross-references the global help.
- **Module docstring** in `compiler/strict_paths.rs`: adds a "Canonical failure this guards against (Windows / clang / PCH)" section so future readers find the connection without re-debugging.

## What does NOT change

- No behavior change. Off-by-default still holds for backward compat (the issue's "if consistent-on-Windows default is too aggressive" hedge).
- The actual behavioral fix — default `StrictPathsMode::Consistent` on Windows, or auto-enable via a `ZCCACHE_WINDOWS_PCH_GUARD=1` env var, or hint-injection on the clang stderr — is left to a follow-up so this PR can land quickly without surfacing new errors on existing Windows builds.

## Refs

- #619 — the worked example on FastLED that prompted this

## Test plan

- [ ] CI green (docs-only)
- [ ] `zccache --help` shows the new strict-paths help text
- [ ] `zccache wrap --help` cross-references it

🤖 Generated with [Claude Code](https://claude.com/claude-code)