### PR TITLE
fix(perf-guard): handle rounded zero warm hits

### DIFF
--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -48,6 +48,10 @@ RATIO_COLORS = {
     "slower": "#f85149",
     "neutral": "#8b949e",
 }
+# Display-rounded zeroes above this speedup are still suspicious enough to
+# treat as missing data. This preserves the #443 guard against broken timing
+# while allowing legitimate sub-millisecond warm cache hits such as 87x-96x.
+MAX_DISPLAY_ROUNDED_ZERO_RATIO = 1000.0
 BENCHMARK_BASE_COMMAND = [
     "soldr",
     "--no-cache",
@@ -346,6 +350,50 @@ def _duration_seconds(value: str) -> float | None:
     return round(number, 6)
 
 
+def _ratio_from_text(value: str) -> float | None:
+    text = _clean_cell(value)
+    if text == "~same":
+        return 1.0
+    match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)x\s+(faster|slower)", text)
+    if match is None:
+        return None
+    number = float(match.group(1))
+    if number <= 0:
+        return None
+    if match.group(2) == "slower":
+        return round(1.0 / number, 3)
+    return round(number, 3)
+
+
+def _is_display_rounded_zero(value: str) -> bool:
+    text = _clean_cell(value)
+    match = re.fullmatch(r"0+(?:\.0+)?\s*(ms|s)", text)
+    return match is not None
+
+
+def _duration_from_display_rounded_zero(
+    mode: str,
+    zccache_cell: str,
+    comparisons: tuple[tuple[float | None, str], ...],
+) -> float | None:
+    if mode != "warm" or not _is_display_rounded_zero(zccache_cell):
+        return None
+
+    candidates: list[float] = []
+    for baseline_seconds, ratio_text in comparisons:
+        ratio = _ratio_from_text(ratio_text)
+        if ratio is None or ratio <= 1.0:
+            continue
+        if ratio > MAX_DISPLAY_ROUNDED_ZERO_RATIO:
+            return None
+        if baseline_seconds is not None:
+            candidates.append(baseline_seconds / ratio)
+
+    if not candidates:
+        return None
+    return round(sum(candidates) / len(candidates), 6)
+
+
 def _ratio(baseline: float | None, candidate: float | None) -> float | None:
     if baseline is None or candidate is None or candidate <= 0:
         return None
@@ -374,6 +422,21 @@ def parse_benchmark_log(text: str) -> list[dict[str, Any]]:
             zccache_seconds = _duration_seconds(cells[3])
             scenario = cells[0]
             mode = "warm" if "warm" in scenario.lower() else "cold"
+            zccache_rounded_to_zero = zccache_seconds is None and _is_display_rounded_zero(
+                cells[3]
+            )
+            if zccache_rounded_to_zero:
+                zccache_seconds = _duration_from_display_rounded_zero(
+                    mode,
+                    cells[3],
+                    ((sccache_seconds, cells[4]), (bare_seconds, cells[5])),
+                )
+
+            sccache_ratio = _ratio(sccache_seconds, zccache_seconds)
+            bare_ratio = _ratio(bare_seconds, zccache_seconds)
+            if zccache_seconds is not None and zccache_rounded_to_zero:
+                sccache_ratio = _ratio_from_text(cells[4]) or sccache_ratio
+                bare_ratio = _ratio_from_text(cells[5]) or bare_ratio
             result = {
                 "benchmark": current["id"],
                 "benchmark_label": current["label"],
@@ -384,8 +447,8 @@ def parse_benchmark_log(text: str) -> list[dict[str, Any]]:
                 "bare_seconds": bare_seconds,
                 "sccache_seconds": sccache_seconds,
                 "zccache_seconds": zccache_seconds,
-                "zccache_vs_sccache_ratio": _ratio(sccache_seconds, zccache_seconds),
-                "zccache_vs_bare_ratio": _ratio(bare_seconds, zccache_seconds),
+                "zccache_vs_sccache_ratio": sccache_ratio,
+                "zccache_vs_bare_ratio": bare_ratio,
                 "vs_sccache_text": cells[4],
                 "vs_bare_text": cells[5],
             }

--- a/ci/tests/test_benchmark_stats.py
+++ b/ci/tests/test_benchmark_stats.py
@@ -256,6 +256,39 @@ def test_zero_duration_cells_are_invalid_not_inflated():
     assert benchmark_stats._duration_seconds("0.000s") is None
 
 
+def test_warm_display_rounded_zero_duration_uses_reported_ratios():
+    log = """
+## C++ Driver-Link Benchmark: 50 .cpp objects, 5 warm trials
+
+| Scenario | Bare clang++ | sccache | zccache | vs sccache | vs Bare clang++ |
+|:---------|----------:|--------:|--------:|-----------:|--------------:|
+| Driver link, Warm | 0.042s | 0.046s | **0.000s** | **94x faster** | **87x faster** |
+"""
+
+    row = benchmark_stats.parse_benchmark_log(log)[0]
+
+    expected_duration = round(((0.046 / 94.0) + (0.042 / 87.0)) / 2.0, 6)
+    assert row["zccache_seconds"] == pytest.approx(expected_duration)
+    assert row["zccache_vs_sccache_ratio"] == 94.0
+    assert row["zccache_vs_bare_ratio"] == 87.0
+
+
+def test_absurd_warm_display_rounded_zero_stays_invalid():
+    log = """
+## C Static-Library Link Benchmark: 50 .o inputs, 5 warm trials
+
+| Scenario | Bare ar | sccache | zccache | vs sccache | vs Bare ar |
+|:---------|----------:|--------:|--------:|-----------:|--------------:|
+| Static archive, Warm | 0.057s | 0.057s | 0.000s | 1797x faster | 1797x faster |
+"""
+
+    row = benchmark_stats.parse_benchmark_log(log)[0]
+
+    assert row["zccache_seconds"] is None
+    assert row["zccache_vs_bare_ratio"] is None
+    assert row["zccache_vs_sccache_ratio"] is None
+
+
 def test_group_results_by_language_returns_expected_buckets():
     rows = benchmark_stats.parse_benchmark_log(SAMPLE_LOG)
 

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -334,6 +334,33 @@ def test_report_marks_failed_rows():
     assert "#### Passed checks" in markdown
 
 
+def test_report_passes_warm_row_that_display_rounded_to_zero():
+    log = """
+## C++ Driver-Link Benchmark: 50 .cpp objects, 5 warm trials
+
+| Scenario | Bare clang++ | sccache | zccache | vs sccache | vs Bare clang++ |
+|:---------|----------:|--------:|--------:|-----------:|--------------:|
+| Driver link, Warm | 0.042s | 0.046s | **0.000s** | **94x faster** | **87x faster** |
+"""
+    report = perf_guard.evaluate_attempts(
+        [rows(log)],
+        languages=("c++",),
+        require_coverage=False,
+    )
+    markdown = perf_guard.format_report(report, 1.5, 1.5)
+
+    assert report.passed
+    assert "n/a" not in markdown
+    assert (
+        "| PASS | c++ | C++ driver link | Driver link, Warm | Bare clang++ | "
+        "0.5ms | 42.0ms | 87.000x | 1.50x | 1 | 1 |"
+    ) in markdown
+    assert (
+        "| PASS | c++ | C++ driver link | Driver link, Warm | sccache | "
+        "0.5ms | 46.0ms | 94.000x | 1.50x | 1 | 1 |"
+    ) in markdown
+
+
 def test_benchmark_summary_lists_passes_and_failures():
     report = perf_guard.evaluate_attempts([rows(FAILING_SCCACHE_LOG)], threshold=1.5)
 


### PR DESCRIPTION
## Summary

- keep standalone `0.000s` benchmark cells invalid by default
- allow warm zccache rows that display-round to `0.000s` to recover a small positive duration from sane reported speedup ratios
- cover the issue #620 regression in parser and perf-guard report tests while preserving the #443 invalid-zero guard

## Validation

- `python -m pytest ci/tests`
- Re-parsed the downloaded failing `perf_cpp_driver_link/attempt-3.log` from run `26835069437`; the warm rows now pass with concrete `87.0x` and `94.0x` ratios instead of `n/a`.

Closes #620