### PR TITLE
feat(strict-paths): ZCCACHE_WINDOWS_PCH_GUARD opt-in (#619)

### DIFF
--- a/crates/zccache/src/cli/commands/wrap/env.rs
+++ b/crates/zccache/src/cli/commands/wrap/env.rs
@@ -40,10 +40,33 @@ pub(super) fn effective_strict_paths_mode(
 
     match std::env::var("ZCCACHE_STRICT_PATHS") {
         Ok(value) => StrictPathsMode::parse(&value).map_err(|err| err.to_string()),
-        Err(std::env::VarError::NotPresent) => Ok(StrictPathsMode::Off),
+        Err(std::env::VarError::NotPresent) => Ok(windows_pch_guard_default()),
         Err(std::env::VarError::NotUnicode(_)) => {
             Err("ZCCACHE_STRICT_PATHS is not valid Unicode".to_string())
         }
+    }
+}
+
+/// Issue #619: Windows-only opt-in. When `ZCCACHE_WINDOWS_PCH_GUARD=1` and
+/// `ZCCACHE_STRICT_PATHS` is unset, default to `Consistent` mode so the
+/// mixed-separator `-I` / `-include` patterns that defeat clang's
+/// `#pragma once` dedup across PCH boundaries get rejected at the
+/// compile-command level. Off-by-default on Windows for backward compat;
+/// the env var is the safe opt-in path until consistent-on-Windows
+/// proves out in the field.
+fn windows_pch_guard_default() -> StrictPathsMode {
+    let guard_value = std::env::var("ZCCACHE_WINDOWS_PCH_GUARD").ok();
+    windows_pch_guard_default_for(cfg!(target_os = "windows"), guard_value.as_deref())
+}
+
+/// Pure helper for `windows_pch_guard_default` — separated so unit tests
+/// don't have to mutate process env (which races under cargo's
+/// parallel-test default).
+fn windows_pch_guard_default_for(is_windows: bool, guard_value: Option<&str>) -> StrictPathsMode {
+    if is_windows && matches!(guard_value, Some("1" | "true" | "yes" | "on")) {
+        StrictPathsMode::Consistent
+    } else {
+        StrictPathsMode::Off
     }
 }
 
@@ -101,5 +124,49 @@ mod tests {
                 .map(|(_, value)| value.as_str()),
             Some("absolute")
         );
+    }
+
+    #[test]
+    fn windows_pch_guard_default_off_when_not_windows() {
+        // Linux/macOS never auto-enable the guard, regardless of env value.
+        assert_eq!(
+            windows_pch_guard_default_for(false, Some("1")),
+            StrictPathsMode::Off
+        );
+        assert_eq!(
+            windows_pch_guard_default_for(false, None),
+            StrictPathsMode::Off
+        );
+    }
+
+    #[test]
+    fn windows_pch_guard_default_off_when_env_unset_or_falsy() {
+        assert_eq!(
+            windows_pch_guard_default_for(true, None),
+            StrictPathsMode::Off
+        );
+        assert_eq!(
+            windows_pch_guard_default_for(true, Some("0")),
+            StrictPathsMode::Off
+        );
+        assert_eq!(
+            windows_pch_guard_default_for(true, Some("")),
+            StrictPathsMode::Off
+        );
+        assert_eq!(
+            windows_pch_guard_default_for(true, Some("garbage")),
+            StrictPathsMode::Off
+        );
+    }
+
+    #[test]
+    fn windows_pch_guard_default_consistent_when_windows_and_opt_in() {
+        for truthy in ["1", "true", "yes", "on"] {
+            assert_eq!(
+                windows_pch_guard_default_for(true, Some(truthy)),
+                StrictPathsMode::Consistent,
+                "ZCCACHE_WINDOWS_PCH_GUARD={truthy} on Windows should enable Consistent"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds the safer of the two paths #619 proposed: a Windows-only opt-in env var that enables \`StrictPathsMode::Consistent\` when \`ZCCACHE_STRICT_PATHS\` is not explicitly set. **Off by default** for backward compat.

When set to \`1\`/\`true\`/\`yes\`/\`on\` AND the target is Windows AND \`ZCCACHE_STRICT_PATHS\` is unset, the wrapper's \`effective_strict_paths_mode\` returns \`Consistent\` — so the mixed-separator \`-I\` / \`-include\` patterns that defeat clang's \`#pragma once\` dedup across PCH boundaries get rejected at the compile-command level (instead of surfacing as a baffling \`error: redefinition of X\` inside clang).

## Priority order (explicit > implicit)

1. \`--strict-paths=<mode>\` (or the per-\`Wrap\` flag) → explicit override.
2. \`ZCCACHE_STRICT_PATHS=<mode>\` → explicit env setting.
3. \`ZCCACHE_WINDOWS_PCH_GUARD=1\` on Windows → auto-Consistent.
4. Otherwise → \`Off\` (the existing default).

Non-Windows platforms never auto-enable the guard, regardless of env value.

## What does NOT change

- Default behavior on every platform: \`Off\` unless the user opts in. No build that worked before breaks.
- The full default-on-Windows option from #619 is left for a future iteration once the opt-in proves out in the field.

## Tests

Three new unit tests cover the matrix via a pure helper that doesn't touch process env (race-free under cargo's parallel-test default):
- \`windows_pch_guard_default_off_when_not_windows\` — Linux/macOS always Off.
- \`windows_pch_guard_default_off_when_env_unset_or_falsy\` — Windows respects opt-out.
- \`windows_pch_guard_default_consistent_when_windows_and_opt_in\` — all truthy spellings work.

## Refs

- #619 — the underlying issue
- #621 (merged) — help-text discoverability landed first

🤖 Generated with [Claude Code](https://claude.com/claude-code)