### PR TITLE
perf(persist): rustc miss path uses persist_artifact_paths_with_stats

### DIFF
--- a/crates/zccache/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/miss_store.rs
@@ -155,25 +155,30 @@ fn store_rustc_outputs(
         .collect();
     stats.artifact_meta_build_ns = t_artifact_meta_build.elapsed().as_nanos() as u64;
 
+    // Delegate to the shared `persist_artifact_paths_with_stats` helper so
+    // multi-output rustc misses (rlib + rmeta + dep-info + ...) pick up the
+    // same rayon-vs-serial threshold the C/C++ async persist path already
+    // uses, instead of an inline serial loop here. The helper hardlinks
+    // each `output.path` (which rustc just wrote into `target/...`) into
+    // the cache dir as `{key_hex}_{i}`; the source-vs-cache file ordering
+    // is preserved by giving it `output.path`s in the same order as
+    // `payload_paths`.
+    let source_paths: Vec<NormalizedPath> = all_outputs
+        .iter()
+        .map(|output| output.path.clone())
+        .collect();
     let mut snapshot_ok = true;
     let t_rust_snapshot = Instant::now();
-    for (output, cache_path) in all_outputs.iter().zip(payload_paths.iter()) {
-        match persist_artifact_file(cache_path, &output.path) {
-            Ok(snapshot_stats) => {
-                stats.rust_snapshot_hardlink_count += snapshot_stats.hardlink_count;
-                stats.rust_snapshot_copy_count += snapshot_stats.copy_count;
-                stats.rust_snapshot_copy_bytes += snapshot_stats.copy_bytes;
-            }
-            Err(e) => {
-                stats.rust_snapshot_error_count += 1;
-                snapshot_ok = false;
-                tracing::warn!(
-                    source = %output.path.display(),
-                    cache = %cache_path.display(),
-                    "failed to snapshot rustc output: {e}"
-                );
-                break;
-            }
+    match persist_artifact_paths_with_stats(&state.artifact_dir, artifact_key_hex, &source_paths) {
+        Ok(snapshot_stats) => {
+            stats.rust_snapshot_hardlink_count = snapshot_stats.hardlink_count;
+            stats.rust_snapshot_copy_count = snapshot_stats.copy_count;
+            stats.rust_snapshot_copy_bytes = snapshot_stats.copy_bytes;
+        }
+        Err(e) => {
+            stats.rust_snapshot_error_count = all_outputs.len() as u64;
+            snapshot_ok = false;
+            tracing::warn!("failed to snapshot rustc outputs for {artifact_key_hex}: {e}");
         }
     }
     stats.rust_snapshot_ns = t_rust_snapshot.elapsed().as_nanos() as u64;

--- a/crates/zccache/src/daemon/server/persist.rs
+++ b/crates/zccache/src/daemon/server/persist.rs
@@ -171,20 +171,38 @@ pub(super) fn persist_artifact_paths(
     key_hex: &str,
     sources: &[NormalizedPath],
 ) -> std::io::Result<()> {
+    persist_artifact_paths_with_stats(artifact_dir, key_hex, sources).map(|_| ())
+}
+
+/// Same as `persist_artifact_paths`, plus aggregate hardlink/copy/copy-bytes
+/// stats summed across every source. Lets the rustc miss path use the same
+/// serial-vs-rayon threshold without re-implementing the loop. Pack mode
+/// returns default stats — its single packed write doesn't yield per-source
+/// hardlink/copy attribution.
+pub(super) fn persist_artifact_paths_with_stats(
+    artifact_dir: &Path,
+    key_hex: &str,
+    sources: &[NormalizedPath],
+) -> std::io::Result<PersistArtifactFileStats> {
     if pack_mode_enabled() {
         let bytes: Vec<Arc<Vec<u8>>> = sources
             .iter()
             .map(|p| std::fs::read(p.as_path()).map(Arc::new))
             .collect::<std::io::Result<_>>()?;
         let pack = build_pack(&bytes);
-        return persist_artifact_output(&pack_path_for(artifact_dir, key_hex), &pack);
+        persist_artifact_output(&pack_path_for(artifact_dir, key_hex), &pack)?;
+        return Ok(PersistArtifactFileStats::default());
     }
     if sources.len() < PAR_WRITE_THRESHOLD {
+        let mut stats = PersistArtifactFileStats::default();
         for (i, source) in sources.iter().enumerate() {
             let cache_path = artifact_dir.join(format!("{key_hex}_{i}"));
-            persist_artifact_file(&cache_path, source.as_path())?;
+            let one = persist_artifact_file(&cache_path, source.as_path())?;
+            stats.hardlink_count += one.hardlink_count;
+            stats.copy_count += one.copy_count;
+            stats.copy_bytes += one.copy_bytes;
         }
-        return Ok(());
+        return Ok(stats);
     }
     use rayon::prelude::*;
     sources
@@ -192,9 +210,19 @@ pub(super) fn persist_artifact_paths(
         .enumerate()
         .map(|(i, source)| {
             let cache_path = artifact_dir.join(format!("{key_hex}_{i}"));
-            persist_artifact_file(&cache_path, source.as_path()).map(|_| ())
+            persist_artifact_file(&cache_path, source.as_path())
         })
-        .reduce(|| Ok(()), |a, b| a.and(b))
+        .reduce(
+            || Ok(PersistArtifactFileStats::default()),
+            |a, b| match (a, b) {
+                (Ok(x), Ok(y)) => Ok(PersistArtifactFileStats {
+                    hardlink_count: x.hardlink_count + y.hardlink_count,
+                    copy_count: x.copy_count + y.copy_count,
+                    copy_bytes: x.copy_bytes + y.copy_bytes,
+                }),
+                (Err(e), _) | (_, Err(e)) => Err(e),
+            },
+        )
 }
 
 #[derive(Clone, Copy, Debug, Default)]


### PR DESCRIPTION
## Summary

The rustc cold-miss persist path in `daemon/server/handle_compile/miss_store.rs::store_rustc_outputs` inlined a serial `for` loop over `persist_artifact_file`, while every other artifact persist site (`store_single_output`, `handle_compile_multi`, `handle_link`) already delegated to `persist_artifact_paths` and picked up the rayon-vs-serial threshold (`PAR_WRITE_THRESHOLD = 4`) for free.

This PR aligns the rustc path with the rest of the codebase.

## Change

- New `persist_artifact_paths_with_stats(artifact_dir, key_hex, sources) -> std::io::Result<PersistArtifactFileStats>` in `persist.rs` — same logic as `persist_artifact_paths` plus aggregate hardlink_count/copy_count/copy_bytes stats summed across every source.
- `persist_artifact_paths` becomes a thin `.map(|_| ())` wrapper. Existing C/C++ + link + multi-compile callers don't change.
- `store_rustc_outputs` builds `Vec<NormalizedPath>` of source paths from `all_outputs` and calls the new helper, replacing the inline serial loop.

## Effect

- For 4+ outputs (proc-macro crates emitting rlib + rmeta + dep-info + .so, or release rust binaries with multiple `--emit` kinds), the hardlink + atomic-rename now runs on rayon instead of serially.
- Below 4 outputs the serial loop is preserved (rayon dispatch cost would dominate, per the existing `PAR_WRITE_THRESHOLD` comment).
- Same atomic semantics throughout: tmp-then-rename, AV-scan retry on Windows, hardlink-then-copy fallback for cross-volume.

This is intentionally a small, mechanical alignment — not the full fix for #629. The dominant per-MISS gap measured in zackees/soldr#633 is still expected to lie in the input-hashing phase (rmeta/source content hashing) and/or the synchronous on-critical-path nature of the artifact persist itself. Moving artifact persist off the daemon's response-return critical path (mirroring `store_single_output`'s `tokio::spawn` pattern) requires a separate design pass because the rust path uses on-disk source files (`from_file_payloads`) rather than in-memory bytes, and a hit lookup needs the cache files materialised. That work belongs in a follow-up — this PR keeps the change reviewable.

## Issue + cross-link

- Tracks zackees/zccache#629.
- Coordinated with zackees/soldr#633.

## Test plan

- [ ] CI compiles + existing `pack.rs` / `write_cached.rs` tests pass without modification (no signature change on the public callers).
- [ ] `cargo test -p zccache --lib persist` runs.
- [ ] Per the `defer re-testing to next loop` workflow agreed with the parent project, perf-cluster re-measurement is deferred to the next iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)