### PR TITLE
fix(rsp): rustc-aware response-file dialect — closes #634

### DIFF
--- a/crates/zccache/src/compiler/response_file.rs
+++ b/crates/zccache/src/compiler/response_file.rs
@@ -264,9 +264,50 @@ fn format_rsp_argument(arg: &str) -> Option<String> {
     None
 }
 
+/// Format args for a response file that **rustc** will read.
+///
+/// Rustc's response-file parser at
+/// `compiler/rustc_driver_impl/src/args.rs` is simply
+/// `contents.lines().for_each(|arg| ...)` — every line becomes one argv
+/// element verbatim, with **no quote handling at all**. That means the
+/// GCC/Clang-style single-quote wrapping (`'arg'`) used by
+/// [`format_rsp_argument`] would leak the literal `'` characters into
+/// the argument value and break parsing of structured options like
+/// `--check-cfg "cfg(feature, values(\"...\", \"...\"))"` (issue #634:
+/// rustc reported "multiple input filenames provided" when zccache
+/// spilled a long web-sys cargo invocation through the GCC-style
+/// formatter and the cfg expression got mangled).
+///
+/// For rustc, the safe shape is: **one arg per line, no quoting, no
+/// escaping** — provided no argument contains a newline. Newline-bearing
+/// args cannot be represented in rustc's line-oriented format; we
+/// return `None` and the caller falls back to passing the args directly
+/// on the command line.
+#[cfg(any(windows, test))]
+fn format_rsp_content_rustc(args: &[String]) -> Option<String> {
+    let estimated_len: usize = args.iter().map(|a| a.len() + 1).sum();
+    let mut content = String::with_capacity(estimated_len);
+    for arg in args {
+        if arg.contains('\n') || arg.contains('\r') {
+            return None;
+        }
+        content.push_str(arg);
+        content.push('\n');
+    }
+    Some(content)
+}
+
 /// If the total length of `args` exceeds the Windows command-line limit, write
 /// them to a temporary `.rsp` file and return a single `@path` argument.
 /// Otherwise return `None` (caller should pass args directly).
+///
+/// `family_hint` selects the response-file dialect:
+///
+/// - [`CompilerFamily::Rustc`] uses rustc's line-oriented format (one arg
+///   per line, no quoting). Required because rustc does not unquote
+///   `'..."..."...'`-style values from response files; see #634.
+/// - All other families use the GCC/Clang/MSVC-compatible single- or
+///   double-quoted format produced by [`format_rsp_argument`].
 ///
 /// The returned [`TempResponseFile`] keeps the temporary file alive via RAII.
 /// Drop it after the compiler process finishes.
@@ -274,6 +315,7 @@ fn format_rsp_argument(arg: &str) -> Option<String> {
 pub fn write_response_file_if_needed(
     args: &[String],
     tmp_dir: &Path,
+    family_hint: crate::compiler::CompilerFamily,
 ) -> std::io::Result<Option<TempResponseFile>> {
     let estimated_len: usize = args.iter().map(|a| a.len() + 3).sum();
     if estimated_len < MAX_CMDLINE_LEN {
@@ -283,7 +325,11 @@ pub fn write_response_file_if_needed(
     let id = RSP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let rsp_path =
         NormalizedPath::new(tmp_dir.join(format!("zccache_{}_{}.rsp", std::process::id(), id)));
-    let Some(content) = format_rsp_content_if_safe(args) else {
+    let content = match family_hint {
+        crate::compiler::CompilerFamily::Rustc => format_rsp_content_rustc(args),
+        _ => format_rsp_content_if_safe(args),
+    };
+    let Some(content) = content else {
         return Ok(None);
     };
     std::fs::write(&rsp_path, content)?;
@@ -296,6 +342,7 @@ pub fn write_response_file_if_needed(
 pub fn write_response_file_if_needed(
     _args: &[String],
     _tmp_dir: &Path,
+    _family_hint: crate::compiler::CompilerFamily,
 ) -> std::io::Result<Option<TempResponseFile>> {
     Ok(None)
 }
@@ -833,6 +880,69 @@ mod tests {
             "'-DVALUE=\"C:\\Program Files\\SDK\\include\"'\n'C:\\work tree\\main.c'\n"
         );
         assert_eq!(parse_response_file_content(&content), args);
+    }
+
+    // ── #634: rustc response-file dialect ─────────────────────────────
+
+    /// rustc's response-file parser is `file.lines().for_each(|arg|...)`
+    /// — every line is one argv element, no quote handling. The rustc
+    /// format function must therefore write each arg literally, on its
+    /// own line.
+    #[test]
+    fn format_rsp_content_rustc_writes_args_literally() {
+        let args = s(&["--crate-name", "web_sys", "--edition=2021"]);
+        let content = format_rsp_content_rustc(&args).unwrap();
+        assert_eq!(content, "--crate-name\nweb_sys\n--edition=2021\n");
+    }
+
+    /// Regression guard for #634: the cargo `--check-cfg` value for
+    /// web-sys is a structured expression containing whitespace, commas,
+    /// parens, and embedded double quotes. The GCC-style formatter
+    /// wraps it in single quotes (`'cfg(feature, values(\"a\", ...))'`)
+    /// which rustc reads literally and chokes on. The rustc formatter
+    /// must NOT add quoting characters.
+    #[test]
+    fn format_rsp_content_rustc_preserves_check_cfg_with_embedded_quotes() {
+        let check_cfg = r#"cfg(feature, values("AbortController", "AbortSignal"))"#;
+        let args = s(&["--check-cfg", check_cfg]);
+        let content = format_rsp_content_rustc(&args).unwrap();
+        // No leading/trailing quote characters were added to either line.
+        assert_eq!(
+            content,
+            "--check-cfg\ncfg(feature, values(\"AbortController\", \"AbortSignal\"))\n"
+        );
+        // Round-trip: rustc's `lines()` parse recovers exactly the
+        // original argv. We model rustc's parser as `lines()` here.
+        let recovered: Vec<String> = content.lines().map(str::to_string).collect();
+        assert_eq!(recovered, args);
+    }
+
+    /// Newlines cannot be represented in rustc's line-oriented format;
+    /// the formatter must refuse so the caller can fall back to
+    /// passing args directly on the command line.
+    #[test]
+    fn format_rsp_content_rustc_refuses_args_with_newline() {
+        let args = s(&["--foo", "value-with-\n-newline"]);
+        assert!(format_rsp_content_rustc(&args).is_none());
+
+        let args_cr = s(&["--foo", "value-with-\r-cr"]);
+        assert!(format_rsp_content_rustc(&args_cr).is_none());
+    }
+
+    /// Contrast with the GCC-style formatter: the same `--check-cfg`
+    /// arg gets wrapped in single quotes, which is exactly the bug
+    /// shape from #634 when fed to rustc.
+    #[test]
+    fn format_rsp_content_gcc_style_wraps_in_single_quotes() {
+        let check_cfg = r#"cfg(feature, values("AbortController"))"#;
+        let args = s(&["--check-cfg", check_cfg]);
+        let content = format_rsp_content_if_safe(&args).unwrap();
+        // GCC-style: the value got wrapped in single quotes. rustc would
+        // see the leading `'` as part of the value and choke.
+        assert!(
+            content.contains("'cfg(feature, values(\"AbortController\"))'"),
+            "GCC-style format wraps in single quotes; got: {content:?}"
+        );
     }
 
     #[test]

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
@@ -679,6 +679,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     let _rsp_guard = match crate::compiler::response_file::write_response_file_if_needed(
         rsp_args,
         &state.depfile_tmpdir,
+        compilation.family,
     ) {
         Ok(guard) => guard,
         Err(e) => {

--- a/crates/zccache/src/daemon/server/handle_compile_ephemeral.rs
+++ b/crates/zccache/src/daemon/server/handle_compile_ephemeral.rs
@@ -77,15 +77,25 @@ pub(super) async fn run_compiler_direct(
     stdin_bytes: &[u8],
     tmp_dir: &Path,
 ) -> Response {
-    let _rsp_guard =
-        match crate::compiler::response_file::write_response_file_if_needed(args, tmp_dir) {
-            Ok(guard) => guard,
-            Err(e) => {
-                return Response::Error {
-                    message: format!("failed to write response file: {e}"),
-                };
-            }
-        };
+    // Family hint controls response-file dialect (#634): rustc reads
+    // response files line-by-line with no quote handling, so the
+    // GCC-style single-quote wrapping mangles structured args like
+    // `--check-cfg cfg(feature, values("a","b"))`. Detect from the
+    // compiler path; `detect_family` falls back to Gcc for unknown
+    // names, which matches the historical behaviour.
+    let family_hint = crate::compiler::detect_family(&compiler.to_string_lossy());
+    let _rsp_guard = match crate::compiler::response_file::write_response_file_if_needed(
+        args,
+        tmp_dir,
+        family_hint,
+    ) {
+        Ok(guard) => guard,
+        Err(e) => {
+            return Response::Error {
+                message: format!("failed to write response file: {e}"),
+            };
+        }
+    };
 
     let lineage = super::super::lineage::Lineage::current(
         sessions.get(sid).map(|s| s.client_pid),

--- a/crates/zccache/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache/src/daemon/server/handle_compile_multi.rs
@@ -529,6 +529,7 @@ pub(super) async fn handle_compile_multi(
     let _rsp_guard = match crate::compiler::response_file::write_response_file_if_needed(
         &compiler_args,
         &state.depfile_tmpdir,
+        compilations[0].family,
     ) {
         Ok(guard) => guard,
         Err(e) => {

--- a/crates/zccache/src/daemon/server/handle_link.rs
+++ b/crates/zccache/src/daemon/server/handle_link.rs
@@ -576,15 +576,24 @@ pub(super) async fn run_tool_passthrough(
     lineage: &super::super::lineage::Lineage,
     tmp_dir: &Path,
 ) -> Response {
-    let _rsp_guard =
-        match crate::compiler::response_file::write_response_file_if_needed(args, tmp_dir) {
-            Ok(guard) => guard,
-            Err(e) => {
-                return Response::Error {
-                    message: format!("failed to write response file for {}: {e}", tool.display()),
-                };
-            }
-        };
+    // Family hint controls response-file dialect (#634); detect from
+    // the tool path. Rustc driver linking can land here too (cargo's
+    // `--crate-type bin` link step shells out to rustc, which uses
+    // file.lines() to parse @rsp). `detect_family` falls back to Gcc
+    // for unknown names, which matches the historical behaviour.
+    let family_hint = crate::compiler::detect_family(&tool.to_string_lossy());
+    let _rsp_guard = match crate::compiler::response_file::write_response_file_if_needed(
+        args,
+        tmp_dir,
+        family_hint,
+    ) {
+        Ok(guard) => guard,
+        Err(e) => {
+            return Response::Error {
+                message: format!("failed to write response file for {}: {e}", tool.display()),
+            };
+        }
+    };
 
     let mut cmd = std::process::Command::new(tool);
     if let Some(ref rsp) = _rsp_guard {

--- a/crates/zccache/tests/compiler_response_file_adversarial.rs
+++ b/crates/zccache/tests/compiler_response_file_adversarial.rs
@@ -1410,9 +1410,10 @@ fn windows_fbuild_shape_roundtrips_through_spill_rsp() {
         format!("@{}", includes.display()),
     ]);
 
-    let rsp = write_response_file_if_needed(&args, dir.path())
-        .unwrap()
-        .expect("spill rsp should be written");
+    let rsp =
+        write_response_file_if_needed(&args, dir.path(), zccache::compiler::CompilerFamily::Clang)
+            .unwrap()
+            .expect("spill rsp should be written");
     let written = std::fs::read_to_string(&rsp.path).unwrap();
     let reparsed = parse_response_file_content(&written);
 
@@ -1435,9 +1436,10 @@ fn windows_fbuild_shape_preserves_expanded_argv_semantics() {
 
     let dir = tempfile::tempdir().unwrap();
     let args = force_spill_args_owned(original.clone());
-    let rsp = write_response_file_if_needed(&args, dir.path())
-        .unwrap()
-        .expect("spill rsp should be written");
+    let rsp =
+        write_response_file_if_needed(&args, dir.path(), zccache::compiler::CompilerFamily::Clang)
+            .unwrap()
+            .expect("spill rsp should be written");
     let written = std::fs::read_to_string(&rsp.path).unwrap();
     let reparsed = parse_response_file_content(&written);
 


### PR DESCRIPTION
## Summary

Fixes #634. zccache's response-file spill (used when the command line exceeds Windows' `MAX_CMDLINE_LEN ≈ 30 KB`) wrote args using GCC-style single-quote wrapping. **Rustc's response-file parser is `file.lines()` with zero quote handling** (source: `rustc_driver_impl/src/args.rs:26`), so the single quotes leak into the value and break structured args like `--check-cfg "cfg(feature, values(\"AbortController\", \"AbortSignal\", ...))"` — the exact arg shape web-sys uses.

## Repro chain

`cargo build` on a project depending on `web-sys 0.3.99` with zccache as `RUSTC_WRAPPER`:

```
error: multiple input filenames provided
  (first two filenames are `...\web-sys-0.3.99\src\lib.rs` and `values(AbortController,`)
```

Locally reproduced via a minimal `@rsp` file → `soldr rustc @probe.rsp`:

```
error[E0762]: unterminated character literal
  = note: this occurred on the command line:
    `--check-cfg='cfg(foo, values("a", "b", "c"))'`
```

The leading `'` from zccache's GCC-style quoting is what poisons everything downstream.

## Fix

Add `format_rsp_content_rustc` — one arg per line, no quoting, no escaping. Refuses to spill when an arg contains a newline (unrepresentable in a line-oriented format), letting the caller fall back to direct argv passing.

Plumb a `family_hint: CompilerFamily` through `write_response_file_if_needed`:

- `CompilerFamily::Rustc` → line-oriented format
- All others → existing GCC/Clang/MSVC format (unchanged)

Four call sites updated:

- `handle_compile_multi.rs` — `compilation.family` in scope.
- `handle_compile/pipeline.rs` — same.
- `handle_compile_ephemeral.rs` — `detect_family(compiler)`.
- `handle_link.rs` — `detect_family(tool)` (rustc driver links land here on `--crate-type bin`).

`detect_family` falls back to `Gcc` for unknown names → no behaviour change for any non-rustc caller.

## Tests

Four new tests in `compiler::response_file::tests`:

| Test | What it pins |
|---|---|
| `format_rsp_content_rustc_writes_args_literally` | basic shape |
| `format_rsp_content_rustc_preserves_check_cfg_with_embedded_quotes` | **the #634 regression guard** — round-trips through a `lines()` model of rustc's parser |
| `format_rsp_content_rustc_refuses_args_with_newline` | unrepresentable input refuses cleanly |
| `format_rsp_content_gcc_style_wraps_in_single_quotes` | documents the dialect difference in code so future readers see why the split exists |

All 53 `response_file` tests pass (including the existing `format_rsp_prefers_single_quotes_for_windows_gcc_shapes` — GCC path unchanged).

## Test plan

- [x] `soldr cargo check -p zccache --tests` clean
- [x] `soldr cargo clippy -p zccache --tests -- -D warnings` clean
- [x] `soldr cargo fmt --all -- --check` clean
- [x] `soldr cargo test -p zccache --lib response_file` — 53/53 pass
- [x] Local repro from the issue confirmed fixed
- [ ] PR CI green
- [ ] Confirm with reporter (@goddnsgit) that their `cargo build` now succeeds

Fixes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)