### PR TITLE
fix(daemon): pipe-in-use bind error → INFO + exit 0 (partial #637)

### DIFF
--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -185,66 +185,6 @@ fn run_server(args: Args) {
 
     tracing::info!(%endpoint, idle_timeout, "zccache-daemon starting");
 
-    // ── Issue #637: bind FIRST, before any slow initialization ─────────
-    //
-    // The named-pipe (Windows) / unix-socket (Linux/macOS) bind is the
-    // ownership-establishing operation. Until we've called it, *no other
-    // daemon knows we exist*; until they've called it, *we don't know
-    // they exist*. So if we waste 3+ seconds loading the depgraph (or
-    // any other slow init) before binding, we create a window in which
-    // every parallel `ninja -jN` client whose connect fails ALSO spawns
-    // a daemon — every one of which then races us for the bind, loses,
-    // and the cycle continues for the build's lifetime.
-    //
-    // Field measurement from the issue: 277 redundant daemon spawns and
-    // 126 `replaced-comm-error` retries during a single 3-hour parallel
-    // FastLED build. With bind-before-load, the redundant spawns lose
-    // the pipe-bind race in microseconds rather than after a 3-second
-    // depgraph load, and the herd collapses to ~2.
-    //
-    // `DaemonServer::bind_with_cache_dir` itself does cheap work
-    // beyond the pipe bind (artifact-store open, metadata-cache load),
-    // but the pipe bind is unconditionally the FIRST operation inside
-    // it — see `daemon::server::lifecycle::bind_with_cache_dir`. So
-    // calling `DaemonServer::bind` early IS the bind-first claim.
-    let mut server = match zccache::daemon::DaemonServer::bind(&endpoint) {
-        Ok(s) => s,
-        Err(e) => {
-            // Discriminate "another daemon owns this endpoint" (clean,
-            // expected race outcome) from "real bind failure" (operator
-            // alert). The Windows named-pipe collision surfaces as
-            // PermissionDenied (ERROR_ACCESS_DENIED, the user's repro)
-            // or AlreadyExists. Unix-domain-socket equivalent is
-            // AddrInUse.
-            let is_pipe_in_use = matches!(
-                &e,
-                zccache::ipc::IpcError::Io(io_err) if matches!(
-                    io_err.kind(),
-                    std::io::ErrorKind::PermissionDenied
-                        | std::io::ErrorKind::AddrInUse
-                        | std::io::ErrorKind::AlreadyExists
-                )
-            );
-            if is_pipe_in_use {
-                // Clean "deferring to existing daemon" outcome — do NOT
-                // write a spawn event or lock file (we never claimed
-                // ownership) and do NOT log at ERROR level (the
-                // operator would otherwise see N-1 spurious "ERROR
-                // failed to bind" entries on every parallel build).
-                tracing::info!(
-                    %endpoint,
-                    error = %e,
-                    "another daemon already owns endpoint — deferring"
-                );
-                std::process::exit(0);
-            }
-            tracing::error!("failed to bind {endpoint}: {e}");
-            std::process::exit(1);
-        }
-    };
-
-    // ── Bind won — we are THE daemon. Continue with the slow init. ────
-
     // Issue #273: on Windows, warn once on stderr if the cache dir is
     // not on Defender's exclusion list. Non-fatal; no-ops off Windows
     // and when `ZCCACHE_QUIET` is set.
@@ -254,9 +194,13 @@ fn run_server(args: Args) {
     // Persist a "spawn" lifecycle event to disk. tracing logs go to
     // stderr which is detached to NUL, so this file-based sink is the
     // only way an operator (or CI) can correlate daemon lifetime with
-    // surrounding events after the fact. Per #637, this only fires
-    // for the daemon that actually won the bind — losers exit silently
-    // above so the lifecycle log isn't polluted by the herd.
+    // surrounding events after the fact.
+    //
+    // Per #637, the spawn record is still written before bind — losers
+    // of the parallel-spawn race exit cleanly at bind time without an
+    // ERROR log, but their spawn-attempt is still recorded here. A
+    // future PR moving the bind earlier (deferred-depgraph-load) would
+    // let us scope this to winners only.
     zccache::daemon::lifecycle::write_event(
         zccache::daemon::lifecycle::EVENT_SPAWN,
         serde_json::json!({
@@ -287,8 +231,8 @@ fn run_server(args: Args) {
     // both on stderr (for operators) and via the daemon server (which forwards
     // it into per-session logs) so the cold fallback is never silent.
     //
-    // Per #637, this load is now on the winning-daemon-only path — losers
-    // already exited above without paying the 3+ s cost.
+    // Future work (#637 follow-up): defer this load to a background task
+    // so the bind can land first without delaying accept-loop start.
     let path = zccache::depgraph::depgraph_file_path();
     let (dep_graph, depgraph_load_warning) = if args.no_depgraph_cache {
         let _ = std::fs::remove_file(&path);
@@ -346,20 +290,67 @@ fn run_server(args: Args) {
         }
     };
 
-    // Inject pre-loaded dep graph if we have one.
-    if let Some(graph) = dep_graph {
-        server.set_dep_graph(graph);
-    }
-
-    // Forward any depgraph load warning so SessionStart can mirror it
-    // into the per-session log (`last-session.log`). Without this the
-    // cold fallback after a version-mismatch / corrupt file would be
-    // invisible to operators looking at per-build logs.
-    if let Some(warning) = depgraph_load_warning {
-        server.set_depgraph_load_warning(warning);
-    }
-
     rt.block_on(async {
+        // ── Issue #637: discriminate loser-of-race from real bind failure ──
+        //
+        // Parallel `ninja -jN` builds on Windows produce a spawn race:
+        // multiple newly-launched daemons reach this bind at once, and
+        // only one wins the named pipe. The losers previously logged at
+        // ERROR level ("failed to bind ... Access is denied") and
+        // exited 1, even though "another daemon owns this endpoint" is
+        // a clean, expected outcome — not an error.
+        //
+        // Field measurement from the issue: 277 redundant daemon spawns
+        // produced 276 ERROR entries in `daemon-lifecycle.log`. Now
+        // the losers log at INFO level and exit 0 cleanly, so the
+        // lifecycle log only carries the genuinely-failing daemons (if
+        // any). The 277-daemon herd cause itself needs a follow-up
+        // (deferred-depgraph-load so the bind can land before the slow
+        // init starts; this PR is the safe minimum-blast-radius slice).
+        let mut server = match zccache::daemon::DaemonServer::bind(&endpoint) {
+            Ok(s) => s,
+            Err(e) => {
+                // Windows named-pipe collision surfaces as PermissionDenied
+                // (ERROR_ACCESS_DENIED, the user's repro) or AlreadyExists.
+                // Unix-domain-socket equivalent is AddrInUse.
+                let is_pipe_in_use = matches!(
+                    &e,
+                    zccache::ipc::IpcError::Io(io_err) if matches!(
+                        io_err.kind(),
+                        std::io::ErrorKind::PermissionDenied
+                            | std::io::ErrorKind::AddrInUse
+                            | std::io::ErrorKind::AlreadyExists
+                    )
+                );
+                if is_pipe_in_use {
+                    tracing::info!(
+                        %endpoint,
+                        error = %e,
+                        "another daemon already owns endpoint — deferring"
+                    );
+                    // Do NOT remove the lock file — it belongs to the
+                    // winning daemon, not us.
+                    std::process::exit(0);
+                }
+                tracing::error!("failed to bind {endpoint}: {e}");
+                zccache::ipc::remove_lock_file();
+                std::process::exit(1);
+            }
+        };
+
+        // Inject pre-loaded dep graph if we have one.
+        if let Some(graph) = dep_graph {
+            server.set_dep_graph(graph);
+        }
+
+        // Forward any depgraph load warning so SessionStart can mirror it
+        // into the per-session log (`last-session.log`). Without this the
+        // cold fallback after a version-mismatch / corrupt file would be
+        // invisible to operators looking at per-build logs.
+        if let Some(warning) = depgraph_load_warning {
+            server.set_depgraph_load_warning(warning);
+        }
+
         // Wire up Ctrl+C to trigger graceful shutdown
         let shutdown = server.shutdown_handle();
         tokio::spawn(async move {

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -185,6 +185,66 @@ fn run_server(args: Args) {
 
     tracing::info!(%endpoint, idle_timeout, "zccache-daemon starting");
 
+    // ── Issue #637: bind FIRST, before any slow initialization ─────────
+    //
+    // The named-pipe (Windows) / unix-socket (Linux/macOS) bind is the
+    // ownership-establishing operation. Until we've called it, *no other
+    // daemon knows we exist*; until they've called it, *we don't know
+    // they exist*. So if we waste 3+ seconds loading the depgraph (or
+    // any other slow init) before binding, we create a window in which
+    // every parallel `ninja -jN` client whose connect fails ALSO spawns
+    // a daemon — every one of which then races us for the bind, loses,
+    // and the cycle continues for the build's lifetime.
+    //
+    // Field measurement from the issue: 277 redundant daemon spawns and
+    // 126 `replaced-comm-error` retries during a single 3-hour parallel
+    // FastLED build. With bind-before-load, the redundant spawns lose
+    // the pipe-bind race in microseconds rather than after a 3-second
+    // depgraph load, and the herd collapses to ~2.
+    //
+    // `DaemonServer::bind_with_cache_dir` itself does cheap work
+    // beyond the pipe bind (artifact-store open, metadata-cache load),
+    // but the pipe bind is unconditionally the FIRST operation inside
+    // it — see `daemon::server::lifecycle::bind_with_cache_dir`. So
+    // calling `DaemonServer::bind` early IS the bind-first claim.
+    let mut server = match zccache::daemon::DaemonServer::bind(&endpoint) {
+        Ok(s) => s,
+        Err(e) => {
+            // Discriminate "another daemon owns this endpoint" (clean,
+            // expected race outcome) from "real bind failure" (operator
+            // alert). The Windows named-pipe collision surfaces as
+            // PermissionDenied (ERROR_ACCESS_DENIED, the user's repro)
+            // or AlreadyExists. Unix-domain-socket equivalent is
+            // AddrInUse.
+            let is_pipe_in_use = matches!(
+                &e,
+                zccache::ipc::IpcError::Io(io_err) if matches!(
+                    io_err.kind(),
+                    std::io::ErrorKind::PermissionDenied
+                        | std::io::ErrorKind::AddrInUse
+                        | std::io::ErrorKind::AlreadyExists
+                )
+            );
+            if is_pipe_in_use {
+                // Clean "deferring to existing daemon" outcome — do NOT
+                // write a spawn event or lock file (we never claimed
+                // ownership) and do NOT log at ERROR level (the
+                // operator would otherwise see N-1 spurious "ERROR
+                // failed to bind" entries on every parallel build).
+                tracing::info!(
+                    %endpoint,
+                    error = %e,
+                    "another daemon already owns endpoint — deferring"
+                );
+                std::process::exit(0);
+            }
+            tracing::error!("failed to bind {endpoint}: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    // ── Bind won — we are THE daemon. Continue with the slow init. ────
+
     // Issue #273: on Windows, warn once on stderr if the cache dir is
     // not on Defender's exclusion list. Non-fatal; no-ops off Windows
     // and when `ZCCACHE_QUIET` is set.
@@ -194,7 +254,9 @@ fn run_server(args: Args) {
     // Persist a "spawn" lifecycle event to disk. tracing logs go to
     // stderr which is detached to NUL, so this file-based sink is the
     // only way an operator (or CI) can correlate daemon lifetime with
-    // surrounding events after the fact.
+    // surrounding events after the fact. Per #637, this only fires
+    // for the daemon that actually won the bind — losers exit silently
+    // above so the lifecycle log isn't polluted by the herd.
     zccache::daemon::lifecycle::write_event(
         zccache::daemon::lifecycle::EVENT_SPAWN,
         serde_json::json!({
@@ -224,6 +286,9 @@ fn run_server(args: Args) {
     // mismatch or corruption the outcome carries a warning that we surface
     // both on stderr (for operators) and via the daemon server (which forwards
     // it into per-session logs) so the cold fallback is never silent.
+    //
+    // Per #637, this load is now on the winning-daemon-only path — losers
+    // already exited above without paying the 3+ s cost.
     let path = zccache::depgraph::depgraph_file_path();
     let (dep_graph, depgraph_load_warning) = if args.no_depgraph_cache {
         let _ = std::fs::remove_file(&path);
@@ -281,29 +346,20 @@ fn run_server(args: Args) {
         }
     };
 
+    // Inject pre-loaded dep graph if we have one.
+    if let Some(graph) = dep_graph {
+        server.set_dep_graph(graph);
+    }
+
+    // Forward any depgraph load warning so SessionStart can mirror it
+    // into the per-session log (`last-session.log`). Without this the
+    // cold fallback after a version-mismatch / corrupt file would be
+    // invisible to operators looking at per-build logs.
+    if let Some(warning) = depgraph_load_warning {
+        server.set_depgraph_load_warning(warning);
+    }
+
     rt.block_on(async {
-        let mut server = match zccache::daemon::DaemonServer::bind(&endpoint) {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::error!("failed to bind {endpoint}: {e}");
-                zccache::ipc::remove_lock_file();
-                std::process::exit(1);
-            }
-        };
-
-        // Inject pre-loaded dep graph if we have one.
-        if let Some(graph) = dep_graph {
-            server.set_dep_graph(graph);
-        }
-
-        // Forward any depgraph load warning so SessionStart can mirror it
-        // into the per-session log (`last-session.log`). Without this the
-        // cold fallback after a version-mismatch / corrupt file would be
-        // invisible to operators looking at per-build logs.
-        if let Some(warning) = depgraph_load_warning {
-            server.set_depgraph_load_warning(warning);
-        }
-
         // Wire up Ctrl+C to trigger graceful shutdown
         let shutdown = server.shutdown_handle();
         tokio::spawn(async move {


### PR DESCRIPTION
## Status: scaled back from the original reorder

The first version (commit 1033c14) moved `DaemonServer::bind` BEFORE the depgraph load, per the user's analysis. **CI smoke (`wrapper-e2e (windows-latest)`) caught a regression**:

```
zccache[err][D]: cannot start daemon at \.\pipe\zccache-...
  : daemon started but not accepting connections after 10s
```

Why: the pipe-bind alone doesn't make the daemon serve. The accept loop runs inside `server.run()`, which only starts AFTER the 3+ s depgraph load. Moving the bind up made the pipe appear immediately — so clients connected fast, sent their first message, and then waited for a response that never came (no accept) until the 10 s CLI timeout fired.

In the old flow this worked **by accident**: clients retried `CreateFile` until the pipe appeared (which was AFTER depgraph load), and by then accept was milliseconds away. With bind-first the pipe appears but accept lags by 3+ s.

The full fix requires deferring depgraph load to a background task so accept can start immediately while the graph loads asynchronously. That's a meaningful refactor (server has to inject the graph post-bind, requests-during-load have to fall through to cold-path lookup) and out of scope for a same-iteration follow-up. Filed as a TODO comment + this PR description.

## What this PR keeps (narrow, safe slice)

The error-handler discrimination that does NOT depend on the reorder:

- `IpcError::Io(e)` with `e.kind() ∈ {PermissionDenied, AddrInUse, AlreadyExists}` → **INFO** "another daemon already owns endpoint — deferring", exit **0**, preserve the winner's lock file.
- Any other bind error: ERROR + exit 1, unchanged.

**Effect even without the reorder:** the user's 277-daemon herd still produces ~276 redundant spawns, but those spawns now log at INFO level (clean "deferring to existing daemon") instead of ERROR, so `daemon-lifecycle.log` is no longer polluted with spurious failures. The operator can see which daemons actually crashed vs which lost a benign race.

The 277-spawn herd cause itself is unchanged by this PR — the depgraph load still happens before bind, so redundant daemons still pay the 3+ s startup cost before discovering they lost the race. The full collapse (277 → ~2) needs the deferred-load follow-up.

## What this PR reverts vs the first commit

- `DaemonServer::bind` moved back inside `rt.block_on(async {...})` (restores original timing, so accept-loop starts immediately after bind).
- Spawn event + lock file write order restored (before bind, as before).
- Comments updated to make clear that herd collapse needs the follow-up.

## Test plan

- [x] `soldr cargo check -p zccache --bin zccache-daemon` clean
- [x] `soldr cargo clippy -p zccache --tests -- -D warnings` clean
- [x] `soldr cargo fmt --all -- --check` clean
- [x] `soldr cargo test -p zccache --test daemon_cli_flow_test --test daemon_stdio_detach --test cli_daemon_start` — all pass
- [ ] PR CI green (specifically the `wrapper-e2e (windows-latest)` lane that caught v1's regression)

## Follow-up planned

Once this lands, a separate PR can do the deferred-depgraph-load refactor that:
1. Binds the pipe (claims ownership)
2. Spawns the depgraph load in `spawn_blocking`
3. Starts `server.run()` immediately so accept is responsive
4. Injects the graph via thread-safe set when load completes
5. Compile requests during the load window fall through to the cold-path (no graph) lookup — correct, just temporarily sub-optimal

That's the actual herd-collapse fix from the original analysis; this PR is the safe minimum that lands now.

Refs: #637 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)