### PR TITLE
fix(daemon): pre-bind probe — short-circuit second-wave spawn herd (#640 partial)

### DIFF
--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -185,6 +185,45 @@ fn run_server(args: Args) {
 
     tracing::info!(%endpoint, idle_timeout, "zccache-daemon starting");
 
+    // ── Issue #640: pre-bind probe to cut second-wave spawn herd ─────────
+    //
+    // Before paying the 3+ s depgraph-load cost, check whether another
+    // daemon is already serving at this endpoint. A short async probe
+    // (timeout: 500 ms) is enough — if it succeeds we know a live
+    // daemon owns the pipe and we can exit cleanly without writing a
+    // spawn event, lock file, or doing any heavy init.
+    //
+    // This DOES NOT help the initial cohort racing for the bind from a
+    // cold start (none of them have written a lock file yet); those
+    // are still caught by the post-bind PermissionDenied → INFO+exit 0
+    // path landed in #639. What it DOES catch is the second wave:
+    // every daemon spawn that fires AFTER one daemon has already
+    // registered its lock file. In the user's #637 repro (277 spawns
+    // over 3 hours, spaced anywhere from 11 ms to ~10 s apart) this
+    // is most of the herd.
+    //
+    // A short-lived tokio runtime hosts the async probe so we don't
+    // need to bring up the full multi-thread runtime before deciding
+    // whether to defer.
+    {
+        let probe_rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to create probe runtime");
+        let existing_daemon = probe_rt.block_on(zccache::ipc::probe_existing_daemon(
+            &endpoint,
+            std::time::Duration::from_millis(500),
+        ));
+        if existing_daemon {
+            tracing::info!(
+                %endpoint,
+                "active daemon already serving — deferring"
+            );
+            // Do NOT remove the lock file — it belongs to the live daemon.
+            std::process::exit(0);
+        }
+    }
+
     // Issue #273: on Windows, warn once on stderr if the cache dir is
     // not on Defender's exclusion list. Non-fatal; no-ops off Windows
     // and when `ZCCACHE_QUIET` is set.

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -281,6 +281,59 @@ pub fn is_process_alive(pid: u32) -> bool {
     }
 }
 
+/// Probe whether a daemon is **already serving** at `endpoint`. Returns
+/// `true` iff **all** of the following hold:
+///
+/// 1. The lock file records a PID.
+/// 2. That PID is alive AND its executable is `zccache-daemon` (defends
+///    against recycled PIDs — see [`verify_daemon_pid`]).
+/// 3. We can complete an IPC connect to `endpoint` within `timeout`.
+///
+/// **Why this exists** (issue #640): on Windows, parallel `ninja -jN`
+/// builds create a thundering-herd race where every newly-spawned
+/// daemon pays the 3+ s depgraph-load cost BEFORE attempting to bind
+/// the named pipe. Second-wave daemons (those spawned after a
+/// previous daemon has already won the bind and registered its lock
+/// file) can short-circuit here without paying the load cost — they
+/// see the live PID + working endpoint and exit 0 cleanly. First-wave
+/// daemons (the initial cohort racing for the bind before anyone has
+/// registered) still go through the existing bind error-discrimination
+/// path landed in #639.
+///
+/// The connection returned by `connect` is dropped immediately on a
+/// successful probe — we are only verifying that the other end is
+/// accepting, not exchanging any application-level message. Returning
+/// the connection would make this function harder to use (callers
+/// can't drop it without an explicit shutdown handshake) and the
+/// extra round-trip is wasted work for the common case where the
+/// caller is the daemon itself and is about to exit.
+///
+/// `timeout` caps the worst case. Pick a value that's small relative
+/// to the cost we're avoiding (3+ s depgraph load) but large enough
+/// to absorb normal connect latency under load (typically <50 ms on
+/// a local pipe).
+pub async fn probe_existing_daemon(endpoint: &str, timeout: std::time::Duration) -> bool {
+    let Some(pid) = read_lock_file_pid() else {
+        return false;
+    };
+    // Don't probe ourselves — the post-fork daemon's own PID could be
+    // recorded in the lock file by a sibling racing-init thread under
+    // pathological conditions; treating self as "another daemon" would
+    // be a deadlock.
+    if pid == std::process::id() {
+        return false;
+    }
+    if !verify_daemon_pid(pid) {
+        return false;
+    }
+    match tokio::time::timeout(timeout, crate::ipc::connect(endpoint)).await {
+        Ok(Ok(_conn)) => true,
+        // Connection refused, pipe not yet listening, or any other IPC error:
+        // treat as "no live daemon" and let the caller proceed with full init.
+        Ok(Err(_)) | Err(_) => false,
+    }
+}
+
 /// Returns true if `pid` exists **and** its executable looks like a zccache
 /// daemon. Defends against stale `daemon.lock` files where the recorded PID has
 /// been recycled by an unrelated process — typical when a CI runner restores a
@@ -700,5 +753,54 @@ mod tests {
             assert!(check_running_daemon().is_none());
             assert!(!lock.exists(), "stale lock file should have been removed");
         }
+    }
+
+    // ─── #640 probe_existing_daemon ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn probe_returns_false_when_no_lock_file() {
+        let cache = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set_cache_dir(cache.path());
+        // No lock file written.
+        assert!(!probe_existing_daemon("anything", std::time::Duration::from_millis(50)).await);
+    }
+
+    #[tokio::test]
+    async fn probe_returns_false_when_lock_file_records_self_pid() {
+        let cache = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set_cache_dir(cache.path());
+        // Self-PID early-out: we must NEVER probe our own process —
+        // otherwise a sibling racing-init thread that wrote our PID
+        // into the lock file would cause us to deadlock waiting for
+        // ourselves to accept.
+        write_lock_file(std::process::id()).unwrap();
+        assert!(!probe_existing_daemon("anything", std::time::Duration::from_millis(50)).await);
+    }
+
+    #[tokio::test]
+    async fn probe_returns_false_when_lock_file_pid_is_not_a_daemon() {
+        let cache = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set_cache_dir(cache.path());
+        // PID 1 exists everywhere (init / System) but is definitely not
+        // zccache-daemon, so verify_daemon_pid rejects it. The probe
+        // must short-circuit at the PID-verification step BEFORE
+        // attempting any IPC connect — otherwise we'd waste the
+        // timeout budget on a doomed handshake against init.
+        write_lock_file(1).unwrap();
+        let start = std::time::Instant::now();
+        let result = probe_existing_daemon(
+            "garbage-endpoint-that-could-never-exist",
+            std::time::Duration::from_millis(500),
+        )
+        .await;
+        let elapsed = start.elapsed();
+        assert!(!result);
+        // Short-circuit means we returned faster than the connect
+        // timeout — proves we never attempted the connect.
+        assert!(
+            elapsed < std::time::Duration::from_millis(250),
+            "probe should have short-circuited via verify_daemon_pid, \
+             not waited for the connect timeout — elapsed {elapsed:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Catches the redundant-daemon herd cause from #637 / #640 without requiring the full ArcSwap refactor sketched in #640.

Before paying the 3+ s depgraph-load cost, the daemon checks whether another daemon is already serving at the endpoint. If yes, exit 0 cleanly without writing a spawn event, lock file, or doing any heavy init.

## What this catches

#637 measured 277 redundant daemon spawns over a 3-hour parallel FastLED build. Spawn intervals ranged from 11 ms to ~10 s — most of those are **second-wave** spawns, fired by clients that connected to a busy/loading daemon, gave up, and spawned their own. With this PR each second-wave daemon detects the existing daemon in ~50-500 ms (timeout-bounded probe) and exits cleanly.

## What this does NOT catch

The **first-wave** cohort racing for the bind from a cold start. No lock file exists yet, so `read_lock_file_pid()` returns `None` and the probe short-circuits as "no existing daemon". Those first-wave losers are still caught by the post-bind PermissionDenied → INFO + exit 0 path landed in #639. The first-wave collapse needs the deferred-depgraph-load refactor tracked in #640 (an `ArcSwap<DepGraph>` in `state.dep_graph` + every reader migrating to `.load()` is ~200-400 LOC; this PR is the safe wedge that doesn't require server-side changes).

## How it works

`ipc::probe_existing_daemon(endpoint, timeout)` returns `true` iff:
1. The lock file records a PID.
2. The PID is alive AND its executable is `zccache-daemon` (`verify_daemon_pid`, which already defended against recycled PIDs per #132).
3. An IPC connect to `endpoint` completes within `timeout` (500 ms in `run_server`).

The connection from a successful probe is dropped immediately — we only verify that the other end is accepting, not exchange any application-level message.

`run_server` spins up a short-lived single-thread tokio runtime just for the probe (~ms), then drops it. The full multi-thread runtime is still built later, only for the daemon that won the race.

`pid == std::process::id()` short-circuits early so a sibling racing-init thread that wrote our own PID into the lock file under pathological conditions cannot deadlock us into waiting for ourselves to accept.

## Tests

Three unit tests in `crates/zccache/src/ipc/mod.rs::tests`:

| Test | What it pins |
|---|---|
| `probe_returns_false_when_no_lock_file` | empty state — fast no-op |
| `probe_returns_false_when_lock_file_records_self_pid` | self short-circuit prevents self-deadlock |
| `probe_returns_false_when_lock_file_pid_is_not_a_daemon` | PID 1 (init / System) — verify_daemon_pid short-circuits BEFORE connect timeout (asserted via elapsed < 250 ms vs 500 ms timeout) |

End-to-end "live daemon + probe defers" needs a real serving daemon, same shape as the existing integration tests; the spawn-herd repro is intrinsically flaky as a unit test.

## Test plan

- [x] `soldr cargo check -p zccache --tests` clean
- [x] `soldr cargo clippy -p zccache --tests -- -D warnings` clean
- [x] `soldr cargo fmt --all -- --check` clean
- [x] 3 new probe tests pass locally
- [ ] PR CI green — especially `wrapper-e2e (windows-latest)` (the lane that caught v1 of #639). This PR's `run_server` restructure must not introduce the same "pipe bound but no accept" problem v1 of #639 did. It shouldn't, because the probe runs BEFORE the bind and exits if the bind would lose — the winning daemon's bind+accept happens on the same timeline as before.

Refs: #640 (partial — covers second wave), follows-up #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)