### PR TITLE
refactor(state): wrap state.dep_graph in ArcSwap — foundation for #640

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3700,6 +3709,7 @@ dependencies = [
 name = "zccache"
 version = "1.11.10"
 dependencies = [
+ "arc-swap",
  "bincode",
  "blake3",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 clap = { version = "4", features = ["derive", "env"] }
 dashmap = "6"
+arc-swap = "1"
 redb = "2"
 clang = { version = "2", features = ["runtime"] }
 notify = "7"

--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -40,6 +40,13 @@ tokio = { workspace = true }
 
 # fscache
 dashmap = { workspace = true }
+# arc-swap: atomic pointer swap used by `daemon::server::state::SharedState`
+# to swap `dep_graph: ArcSwap<Arc<DepGraph>>` from the empty-default to the
+# disk-loaded graph after `DaemonServer::bind` returns. Removes the prior
+# `Arc::get_mut` constraint on `DaemonServer::set_dep_graph`, which is
+# the foundation for the deferred-depgraph-load that closes the #637 /
+# #640 first-wave herd window.
+arc-swap = { workspace = true }
 rayon = { workspace = true }
 
 # artifact

--- a/crates/zccache/src/daemon/server/connection.rs
+++ b/crates/zccache/src/daemon/server/connection.rs
@@ -107,7 +107,7 @@ pub(super) async fn handle_connection(
             }
             Request::Status => {
                 let snap = state.stats.snapshot();
-                let dg = state.dep_graph.stats();
+                let dg = state.dep_graph.load().stats();
                 let artifact_count = state.artifacts.len() as u64;
                 let cache_size_bytes: u64 = state
                     .artifacts

--- a/crates/zccache/src/daemon/server/handle_clear.rs
+++ b/crates/zccache/src/daemon/server/handle_clear.rs
@@ -12,7 +12,7 @@ pub(super) async fn handle_clear(state: &SharedState) -> Response {
         count
     };
     let metadata_cleared = state.cache_system.metadata().len() as u64;
-    let dep_graph_contexts_cleared = state.dep_graph.stats().context_count as u64;
+    let dep_graph_contexts_cleared = state.dep_graph.load().stats().context_count as u64;
 
     // Calculate on-disk artifact size before deleting.
     let on_disk_bytes_freed = match std::fs::read_dir(&state.artifact_dir) {
@@ -34,7 +34,7 @@ pub(super) async fn handle_clear(state: &SharedState) -> Response {
     // built artifacts. The on-disk persistence (issues #517 and #541)
     // exists specifically to survive across daemon lifecycle — Clear
     // is not a stronger lifecycle event than restart.
-    state.dep_graph.clear();
+    state.dep_graph.load().clear();
     state.cache_system.clear();
     state.fast_hit_cache.clear();
     state.request_cache.clear();

--- a/crates/zccache/src/daemon/server/handle_compile/error_cache.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/error_cache.rs
@@ -69,7 +69,10 @@ pub(super) fn maybe_store_rustc_error_artifact(
         let path = NormalizedPath::new(p);
         hash_map.get(&path).copied()
     };
-    let artifact_key = state.dep_graph.update(context_key, scan_result, get_hash)?;
+    let artifact_key = state
+        .dep_graph
+        .load()
+        .update(context_key, scan_result, get_hash)?;
     let artifact_key_hex = artifact_key.hash().to_hex();
     let meta = ArtifactIndex::new(
         Vec::new(),

--- a/crates/zccache/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/miss_store.rs
@@ -60,7 +60,10 @@ pub(super) fn store_miss_artifact(request: MissArtifactStoreRequest<'_>) -> Miss
     };
     let include_count = scan_result.resolved.len();
     let t_depgraph_update = Instant::now();
-    let artifact_key_result = state.dep_graph.update(context_key, scan_result, get_hash);
+    let artifact_key_result = state
+        .dep_graph
+        .load()
+        .update(context_key, scan_result, get_hash);
     let mut stats = MissArtifactStoreStats {
         depgraph_update_ns: t_depgraph_update.elapsed().as_nanos() as u64,
         ..MissArtifactStoreStats::default()

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline.rs
@@ -306,7 +306,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     let (ctx, dep_flags, rustc_args_opt, context_key, worktree_equivalent_context) =
         match build_result {
             BuildContextResult::Cc { ctx, dep_flags } => {
-                let registration = state.dep_graph.register_with_root_and_salt_result(
+                let registration = state.dep_graph.load().register_with_root_and_salt_result(
                     ctx.clone(),
                     Some(default_key_root.clone()),
                     worktree_salt,
@@ -339,12 +339,15 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                     .iter()
                     .map(|ext| (ext.name.clone(), ext.path.clone()))
                     .collect();
-                let registration = state.dep_graph.register_rustc_with_key_and_root_result(
-                    key,
-                    compat_ctx.clone(),
-                    rustc_key_root.clone(),
-                    rustc_externs,
-                );
+                let registration = state
+                    .dep_graph
+                    .load()
+                    .register_rustc_with_key_and_root_result(
+                        key,
+                        compat_ctx.clone(),
+                        rustc_key_root.clone(),
+                        rustc_externs,
+                    );
                 (
                     compat_ctx,
                     UserDepFlags::default(),
@@ -408,7 +411,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     // Skip pre-compile hashing for cold contexts — the depgraph would
     // return Cold without examining any hashes, so the work is wasted.
     // Jump straight to compiler exec.
-    let context_is_cold = state.dep_graph.is_cold(&context_key);
+    let context_is_cold = state.dep_graph.load().is_cold(&context_key);
 
     // ── Phase: hash source ───────────────────────────────────────────
     // Issue #468: env-gated sub-phase trace. When ZCCACHE_HIT_TRACE=1, the
@@ -463,7 +466,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         let headers_count: usize;
         {
             use rayon::prelude::*;
-            let includes = state.dep_graph.get_includes(&context_key);
+            let includes = state.dep_graph.load().get_includes(&context_key);
             let include_iter = includes
                 .iter()
                 .flat_map(|v| v.iter().map(|h| (h, "header_hash_fail")));
@@ -528,7 +531,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         // Fast path: recompute artifact key from fresh hashes and compare
         // with the stored key.  Skips redundant journal freshness checks
         // and path clones that check_diagnostic performs.
-        if let Some(artifact_key) = state.dep_graph.try_fast_hit(&context_key, |p| {
+        if let Some(artifact_key) = state.dep_graph.load().try_fast_hit(&context_key, |p| {
             let path = NormalizedPath::new(p);
             hash_map.get(&path).copied()
         }) {
@@ -551,6 +554,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 };
                 state
                     .dep_graph
+                    .load()
                     .check_diagnostic(&context_key, is_fresh, get_hash)
             };
             depgraph_check_ns = t4.elapsed().as_nanos() as u64;

--- a/crates/zccache/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache/src/daemon/server/handle_compile_multi.rs
@@ -101,7 +101,7 @@ pub(super) fn check_unit_cache(
     } else {
         None
     };
-    let context_key = state.dep_graph.register_with_root_and_salt(
+    let context_key = state.dep_graph.load().register_with_root_and_salt(
         ctx.clone(),
         Some(key_root.clone()),
         worktree_salt,
@@ -196,7 +196,7 @@ pub(super) fn check_unit_cache(
     hash_map.insert(source_path.clone(), source_hash);
     {
         use rayon::prelude::*;
-        let includes = state.dep_graph.get_includes(&context_key);
+        let includes = state.dep_graph.load().get_includes(&context_key);
         let include_iter = includes.iter().flat_map(|v| v.iter());
         let all_paths: Vec<&NormalizedPath> =
             include_iter.chain(ctx.force_includes.iter()).collect();
@@ -227,7 +227,10 @@ pub(super) fn check_unit_cache(
             let path = NormalizedPath::new(p);
             hash_map.get(&path).copied()
         };
-        state.dep_graph.check(&context_key, is_fresh, get_hash)
+        state
+            .dep_graph
+            .load()
+            .check(&context_key, is_fresh, get_hash)
     };
     let t_depgraph = t0.elapsed();
 
@@ -722,9 +725,11 @@ pub(super) async fn handle_compile_multi(
                 let path = NormalizedPath::new(p);
                 hash_map.get(&path).copied()
             };
-            let update_result = state_task
-                .dep_graph
-                .update(&context_key, scan_result, get_hash);
+            let update_result =
+                state_task
+                    .dep_graph
+                    .load()
+                    .update(&context_key, scan_result, get_hash);
 
             if let Some(artifact_key) = update_result {
                 let output_name = output_path

--- a/crates/zccache/src/daemon/server/keys.rs
+++ b/crates/zccache/src/daemon/server/keys.rs
@@ -442,10 +442,10 @@ pub(super) fn request_cache_input_paths(
 ) -> Vec<NormalizedPath> {
     let mut paths = Vec::new();
     paths.push(source_path.clone());
-    if let Some(includes) = state.dep_graph.get_includes(context_key) {
+    if let Some(includes) = state.dep_graph.load().get_includes(context_key) {
         paths.extend(includes.iter().cloned());
     }
-    if let Some(externs) = state.dep_graph.get_rustc_externs(context_key) {
+    if let Some(externs) = state.dep_graph.load().get_rustc_externs(context_key) {
         paths.extend(externs.into_iter().map(|(_, path)| path));
     }
     paths.extend(ctx.force_includes.iter().cloned());

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -130,7 +130,7 @@ impl DaemonServer {
                 sessions: SessionManager::new(std::time::Duration::from_secs(300)),
                 system_includes: Mutex::new(system_includes_loaded),
                 system_includes_cache_path,
-                dep_graph: DepGraph::new(),
+                dep_graph: arc_swap::ArcSwap::from_pointee(DepGraph::new()),
                 artifacts,
                 cache_system,
                 watcher: Mutex::new(None),
@@ -183,13 +183,19 @@ impl DaemonServer {
 
     /// Replace the dependency graph with a pre-loaded one.
     ///
-    /// Must be called before `run()` (while this is the only Arc holder).
+    /// **Pre-#640**: this required `&mut self` and `Arc::get_mut` —
+    /// constraints that locked the call to BEFORE `run()` and prevented
+    /// post-bind injection from a background task. The field is now
+    /// `ArcSwap<Arc<DepGraph>>` so atomic replacement is safe at any
+    /// time, including from a `tokio::task::spawn_blocking` started
+    /// after `run()`.
+    ///
     /// Marks the graph as persisted because it was restored from disk.
-    pub fn set_dep_graph(&mut self, graph: crate::depgraph::DepGraph) {
-        let state =
-            Arc::get_mut(&mut self.state).expect("set_dep_graph must be called before run()");
-        state.dep_graph = graph;
-        state.dep_graph_persisted.store(true, Ordering::Release);
+    pub fn set_dep_graph(&self, graph: crate::depgraph::DepGraph) {
+        self.state.dep_graph.store(std::sync::Arc::new(graph));
+        self.state
+            .dep_graph_persisted
+            .store(true, Ordering::Release);
     }
 
     /// Record a load-time depgraph warning to mirror into per-session logs.

--- a/crates/zccache/src/daemon/server/run.rs
+++ b/crates/zccache/src/daemon/server/run.rs
@@ -198,14 +198,16 @@ impl DaemonServer {
                             "trimmed ephemeral daemon caches"
                         );
                     }
+                    let dep_graph_guard = state.dep_graph.load();
                     let (freed, items) = super::super::eviction::evict_to_budget(
                         budget,
                         &state.cache_system,
-                        &state.dep_graph,
+                        &dep_graph_guard,
                         &state.fast_hit_cache,
                         &state.artifacts,
                         state.in_flight_bytes.load(Ordering::Relaxed),
                     );
+                    drop(dep_graph_guard);
                     if items > 0 {
                         tracing::info!(
                             freed_bytes = freed,
@@ -280,7 +282,8 @@ impl DaemonServer {
                     if let Some(parent) = path.parent() {
                         std::fs::create_dir_all(parent).ok();
                     }
-                    match crate::depgraph::save_to_file(&state.dep_graph, &path) {
+                    let dg = state.dep_graph.load();
+                    match crate::depgraph::save_to_file(&dg, &path) {
                         Ok(()) => {
                             state.dep_graph_persisted.store(true, Ordering::Release);
                             tracing::debug!("periodic depgraph save");
@@ -370,10 +373,10 @@ impl DaemonServer {
                     if let Some(parent) = path.parent() {
                         std::fs::create_dir_all(parent).ok();
                     }
-                    let (cold_ctxs, warm_ctxs, stale_ctxs) =
-                        self.state.dep_graph.state_breakdown();
-                    let ctxs_with_key = self.state.dep_graph.contexts_with_artifact_key();
-                    match crate::depgraph::save_to_file(&self.state.dep_graph, &path) {
+                    let dg = self.state.dep_graph.load();
+                    let (cold_ctxs, warm_ctxs, stale_ctxs) = dg.state_breakdown();
+                    let ctxs_with_key = dg.contexts_with_artifact_key();
+                    match crate::depgraph::save_to_file(&dg, &path) {
                         Ok(()) => {
                             self.state
                                 .dep_graph_persisted

--- a/crates/zccache/src/daemon/server/state.rs
+++ b/crates/zccache/src/daemon/server/state.rs
@@ -22,7 +22,23 @@ pub(super) struct SharedState {
     pub(super) sessions: SessionManager,
     pub(super) system_includes: Mutex<SystemIncludeCache>,
     /// Dependency graph: tracks include relationships and cache verdicts.
-    pub(super) dep_graph: DepGraph,
+    ///
+    /// **Wrapped in `ArcSwap` per #640** so that the on-disk-loaded graph
+    /// can be installed *after* `DaemonServer::bind` has handed out
+    /// `Arc<SharedState>` clones to spawned tasks — a constraint the prior
+    /// `Arc::get_mut`-based `set_dep_graph` could not satisfy. The initial
+    /// value is `Arc::new(DepGraph::default())`; the first
+    /// [`DaemonServer::set_dep_graph`] call atomically swaps in the loaded
+    /// graph. Subsequent calls also swap (no one-shot constraint).
+    ///
+    /// All reader access is `state.dep_graph.load().method(...)`. The
+    /// `Guard<Arc<DepGraph>>` returned by `.load()` derefs to `&DepGraph`,
+    /// so existing method calls work unchanged once the `.load()` is
+    /// inserted. Cache that guard in a local when multiple methods on the
+    /// same graph snapshot are needed in one logical operation, so a
+    /// concurrent swap can't split the operation across two graph
+    /// generations.
+    pub(super) dep_graph: arc_swap::ArcSwap<crate::depgraph::DepGraph>,
     /// In-memory artifact cache: artifact_key_hex → artifact data.
     pub(super) artifacts: DashMap<String, CachedArtifact>,
     /// Metadata cache + change journal. The watcher feeds file-change events

--- a/crates/zccache/src/daemon/server/util.rs
+++ b/crates/zccache/src/daemon/server/util.rs
@@ -73,14 +73,14 @@ pub(super) fn context_files_fresh(
     if journal.changed_since(&source_path.into(), since) {
         return false;
     }
-    if let Some(includes) = state.dep_graph.get_includes(context_key) {
+    if let Some(includes) = state.dep_graph.load().get_includes(context_key) {
         for header in &includes {
             if journal.changed_since(header, since) {
                 return false;
             }
         }
     }
-    if let Some(externs) = state.dep_graph.get_rustc_externs(context_key) {
+    if let Some(externs) = state.dep_graph.load().get_rustc_externs(context_key) {
         for (_, path) in &externs {
             if journal.changed_since(path, since) {
                 return false;


### PR DESCRIPTION
## Summary

Pure refactor; **no behaviour change**. Lifts the `Arc::get_mut`-based write-once constraint on `DaemonServer::set_dep_graph` so the follow-up PR can actually defer the depgraph load to a background task. That deferred load is what closes the #637 first-wave herd window, but it depends on this type plumbing landing first.

## What changed

`SharedState::dep_graph: DepGraph` → `arc_swap::ArcSwap<DepGraph>`.

| Site | Before | After |
|---|---|---|
| `SharedState::dep_graph` field | `DepGraph` | `ArcSwap<DepGraph>` |
| Init (`lifecycle.rs:133`) | `DepGraph::new()` | `ArcSwap::from_pointee(DepGraph::new())` |
| `set_dep_graph` | `&mut self`, `Arc::get_mut(...).expect(...)`, panics post-run | `&self`, atomic `store(Arc::new(graph))`, callable from any thread |
| 26 reader sites | `state.dep_graph.method(...)` | `state.dep_graph.load().method(...)` |
| Multi-call sites in `run.rs` (eviction at :201, periodic save at :285, final save at :376) | `&state.dep_graph` passed by reference | bind guard to local, reuse — single graph generation per logical operation |

## Why this is safe

`DepGraph` is already internally concurrent — all mutable state lives behind `DashMap` (lock-free) or `AtomicU64`. Every method takes `&self`, not `&mut self`. The ArcSwap wrap doesn't change per-entry mutation semantics; it adds atomic replacement of the WHOLE graph at the `SharedState` level.

## What this does NOT do

This PR is just the type plumbing. It does NOT yet:
- Defer the depgraph load to a background task
- Move the named-pipe bind ahead of the load

Those are the actual herd-collapse changes; they land in a follow-up PR on top of this foundation. The split keeps each PR small and individually testable — the prior monolithic attempt (v1 of #639) broke the `wrapper-e2e (windows-latest)` smoke lane.

## Test plan

- [x] `soldr cargo check -p zccache --tests` clean
- [x] `soldr cargo clippy -p zccache --tests -- -D warnings` clean
- [x] `soldr cargo fmt --all -- --check` clean
- [x] `soldr cargo test -p zccache --lib` — 1688 / 1688 pass
- [ ] PR CI green — particularly `wrapper-e2e (windows-latest)` (no run_server reorder yet, so this should be a no-op behaviour-wise)

Refs: #640 (foundation; deferred-load follow-up tracks the actual herd-collapse fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)