### PR TITLE
chore(release): bump 1.11.10 -> 1.11.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.11.10"
+version = "1.11.11"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Patch release shipping the depfile-on-cache-hit fix.

- **Fix**: #643 / PR #644 — `materialize_cached_compile_hit` now restores the user-requested `-MF <path>` depfile alongside the `.obj` on cache hits. Without this, ninja+gcc/clang builds with `deps = gcc` silently produce stale objects (every `.obj` ends up with `#deps 0` recorded in ninja's deps database, so transitive header changes never trigger rebuilds).
- Detected downstream by FastLED master incremental builds throwing `undefined symbol: ...` link errors hours after a header change landed.

## Release-note bullet

- fix(daemon): restore depfile on cache hit so ninja's `deps = gcc` mode reliably tracks transitive includes after warm-cache rebuilds (closes #643)

## Test plan

- [x] PR #644 already merged with green CI across the full 26-job matrix
- [x] `[workspace.package].version` bumped to `1.11.11`
- [x] `bump` script run via `uv run --script ci/bump.py 1.11.11` — touches `Cargo.toml` only
- [ ] `release-auto.yml` `detect-bump` will pick this up on merge-to-main and ship the wheel/crates/release