### PR TITLE
perf(daemon): defer depgraph load to spawn_blocking — closes #640 herd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.11.10"
+version = "1.11.11"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.11.10"
+version = "1.11.11"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.11.10"
+version = "1.11.11"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.11.10"
+version = "1.11.11"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -230,128 +230,39 @@ fn run_server(args: Args) {
     let cache_root = zccache::core::config::default_cache_dir();
     zccache::core::defender::maybe_emit_first_run_banner(cache_root.as_path());
 
-    // Persist a "spawn" lifecycle event to disk. tracing logs go to
-    // stderr which is detached to NUL, so this file-based sink is the
-    // only way an operator (or CI) can correlate daemon lifetime with
-    // surrounding events after the fact.
-    //
-    // Per #637, the spawn record is still written before bind — losers
-    // of the parallel-spawn race exit cleanly at bind time without an
-    // ERROR log, but their spawn-attempt is still recorded here. A
-    // future PR moving the bind earlier (deferred-depgraph-load) would
-    // let us scope this to winners only.
-    zccache::daemon::lifecycle::write_event(
-        zccache::daemon::lifecycle::EVENT_SPAWN,
-        serde_json::json!({
-            "endpoint": &endpoint,
-            "daemon_namespace": zccache::core::config::daemon_namespace_label(),
-            "idle_timeout": idle_timeout,
-            "version": env!("CARGO_PKG_VERSION"),
-        }),
-    );
-
-    // Write lock file so CLI can detect us
-    let pid = std::process::id();
-    if let Err(e) = zccache::ipc::write_lock_file(pid) {
-        tracing::warn!("failed to write lock file: {e}");
-    }
-
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .max_blocking_threads(DAEMON_MAX_BLOCKING_THREADS)
         .build()
         .expect("failed to create tokio runtime");
 
-    // Load dep graph from disk (before entering async block).
-    //
-    // Issue #320: a fresh daemon pointed at a populated cache dir is auto-
-    // classified as warm by loading the persisted graph here. On version
-    // mismatch or corruption the outcome carries a warning that we surface
-    // both on stderr (for operators) and via the daemon server (which forwards
-    // it into per-session logs) so the cold fallback is never silent.
-    //
-    // Future work (#637 follow-up): defer this load to a background task
-    // so the bind can land first without delaying accept-loop start.
-    let path = zccache::depgraph::depgraph_file_path();
-    let (dep_graph, depgraph_load_warning) = if args.no_depgraph_cache {
-        let _ = std::fs::remove_file(&path);
-        tracing::info!("depgraph cache disabled — starting with empty graph");
-        (None, None)
-    } else {
-        let start = std::time::Instant::now();
-        let outcome = zccache::depgraph::classify_load(&path);
-        let warning = outcome.warning(&path);
-        match outcome {
-            zccache::depgraph::DepGraphLoadOutcome::Loaded { graph } => {
-                let stats = graph.stats();
-                let (cold_ctxs, warm_ctxs, stale_ctxs) = graph.state_breakdown();
-                let ctxs_with_key = graph.contexts_with_artifact_key();
-                // State breakdown explains why cold_skip fires after load:
-                // an `is_cold` check only returns false for Warm contexts,
-                // so cold/stale contexts will take the cold_skip branch on
-                // the first warm-side compile and miss regardless of what
-                // the artifact_store knows.
-                tracing::info!(
-                    contexts = stats.context_count,
-                    files = stats.file_count,
-                    cold = cold_ctxs,
-                    warm = warm_ctxs,
-                    stale = stale_ctxs,
-                    with_artifact_key = ctxs_with_key,
-                    elapsed_ms = start.elapsed().as_millis() as u64,
-                    "loaded depgraph from disk"
-                );
-                (Some(graph), None)
-            }
-            zccache::depgraph::DepGraphLoadOutcome::Missing => (None, None),
-            zccache::depgraph::DepGraphLoadOutcome::VersionMismatch {
-                file_version,
-                expected_version,
-            } => {
-                tracing::warn!(
-                    file_version,
-                    expected_version,
-                    "depgraph version mismatch — starting with empty graph"
-                );
-                if let Some(ref w) = warning {
-                    eprintln!("{w}");
-                }
-                (None, warning)
-            }
-            zccache::depgraph::DepGraphLoadOutcome::Corrupt { ref message }
-            | zccache::depgraph::DepGraphLoadOutcome::IoError { ref message } => {
-                tracing::warn!("depgraph load failed: {message} — starting with empty graph");
-                if let Some(ref w) = warning {
-                    eprintln!("{w}");
-                }
-                (None, warning)
-            }
-        }
-    };
+    let no_depgraph_cache = args.no_depgraph_cache;
+    rt.block_on(async move {
+        // ── Issue #640: bind FIRST, then load depgraph in background ─────
+        //
+        // The prior flow loaded the depgraph (3+ s on a populated cache)
+        // BEFORE the bind, so for the entire load window every parallel
+        // `ninja -jN` client whose connect failed ALSO spawned a daemon.
+        // 277 redundant spawns per FastLED build per #637.
+        //
+        // With #642's `ArcSwap<DepGraph>` foundation, `set_dep_graph` is
+        // now `&self` + atomic-swap-safe, so the load can fire from a
+        // `spawn_blocking` AFTER `server.run()` has started the accept
+        // loop. Compile requests arriving during the load window see
+        // the empty default graph and take the cold-path miss
+        // (correct — the cache_system's stat-verify safety net catches
+        // any stale-hit risk; sub-optimal speed for ~3 s and then the
+        // post-load `set_dep_graph` atomically publishes the warm graph
+        // for every subsequent `state.dep_graph.load()`).
+        //
+        // The pre-bind probe (#641) and bind-error race discrimination
+        // (#639) both still fire in their original order — only the
+        // depgraph load itself moves.
 
-    rt.block_on(async {
-        // ── Issue #637: discriminate loser-of-race from real bind failure ──
-        //
-        // Parallel `ninja -jN` builds on Windows produce a spawn race:
-        // multiple newly-launched daemons reach this bind at once, and
-        // only one wins the named pipe. The losers previously logged at
-        // ERROR level ("failed to bind ... Access is denied") and
-        // exited 1, even though "another daemon owns this endpoint" is
-        // a clean, expected outcome — not an error.
-        //
-        // Field measurement from the issue: 277 redundant daemon spawns
-        // produced 276 ERROR entries in `daemon-lifecycle.log`. Now
-        // the losers log at INFO level and exit 0 cleanly, so the
-        // lifecycle log only carries the genuinely-failing daemons (if
-        // any). The 277-daemon herd cause itself needs a follow-up
-        // (deferred-depgraph-load so the bind can land before the slow
-        // init starts; this PR is the safe minimum-blast-radius slice).
-        let mut server = match zccache::daemon::DaemonServer::bind(&endpoint) {
+        // ── Issue #637/#639: discriminate loser-of-race from real bind failure ──
+        let server = match zccache::daemon::DaemonServer::bind(&endpoint) {
             Ok(s) => s,
             Err(e) => {
-                // Windows named-pipe collision surfaces as PermissionDenied
-                // (ERROR_ACCESS_DENIED, the user's repro) or AlreadyExists.
-                // Unix-domain-socket equivalent is AddrInUse.
                 let is_pipe_in_use = matches!(
                     &e,
                     zccache::ipc::IpcError::Io(io_err) if matches!(
@@ -377,18 +288,82 @@ fn run_server(args: Args) {
             }
         };
 
-        // Inject pre-loaded dep graph if we have one.
-        if let Some(graph) = dep_graph {
-            server.set_dep_graph(graph);
+        // Bind won — we are THE daemon. NOW write the spawn event and
+        // lock file (loser-of-race exits at bind above without
+        // polluting either).
+        zccache::daemon::lifecycle::write_event(
+            zccache::daemon::lifecycle::EVENT_SPAWN,
+            serde_json::json!({
+                "endpoint": &endpoint,
+                "daemon_namespace": zccache::core::config::daemon_namespace_label(),
+                "idle_timeout": idle_timeout,
+                "version": env!("CARGO_PKG_VERSION"),
+            }),
+        );
+        let pid = std::process::id();
+        if let Err(e) = zccache::ipc::write_lock_file(pid) {
+            tracing::warn!("failed to write lock file: {e}");
         }
 
-        // Forward any depgraph load warning so SessionStart can mirror it
-        // into the per-session log (`last-session.log`). Without this the
-        // cold fallback after a version-mismatch / corrupt file would be
-        // invisible to operators looking at per-build logs.
-        if let Some(warning) = depgraph_load_warning {
-            server.set_depgraph_load_warning(warning);
-        }
+        // Spawn the depgraph load. Holds a `DepGraphSetter` that survives
+        // the spawn_blocking boundary; on completion atomically installs
+        // the graph + warning via #642's ArcSwap.
+        let setter = server.dep_graph_setter();
+        let depgraph_path = zccache::depgraph::depgraph_file_path();
+        let load_handle = tokio::task::spawn_blocking(move || {
+            if no_depgraph_cache {
+                let _ = std::fs::remove_file(&depgraph_path);
+                tracing::info!("depgraph cache disabled — starting with empty graph");
+                setter.install(None, None);
+                return;
+            }
+            let start = std::time::Instant::now();
+            let outcome = zccache::depgraph::classify_load(&depgraph_path);
+            let warning = outcome.warning(&depgraph_path);
+            match outcome {
+                zccache::depgraph::DepGraphLoadOutcome::Loaded { graph } => {
+                    let stats = graph.stats();
+                    let (cold_ctxs, warm_ctxs, stale_ctxs) = graph.state_breakdown();
+                    let ctxs_with_key = graph.contexts_with_artifact_key();
+                    tracing::info!(
+                        contexts = stats.context_count,
+                        files = stats.file_count,
+                        cold = cold_ctxs,
+                        warm = warm_ctxs,
+                        stale = stale_ctxs,
+                        with_artifact_key = ctxs_with_key,
+                        elapsed_ms = start.elapsed().as_millis() as u64,
+                        "loaded depgraph from disk (background)"
+                    );
+                    setter.install(Some(graph), None);
+                }
+                zccache::depgraph::DepGraphLoadOutcome::Missing => {
+                    setter.install(None, None);
+                }
+                zccache::depgraph::DepGraphLoadOutcome::VersionMismatch {
+                    file_version,
+                    expected_version,
+                } => {
+                    tracing::warn!(
+                        file_version,
+                        expected_version,
+                        "depgraph version mismatch — starting with empty graph"
+                    );
+                    if let Some(ref w) = warning {
+                        eprintln!("{w}");
+                    }
+                    setter.install(None, warning);
+                }
+                zccache::depgraph::DepGraphLoadOutcome::Corrupt { ref message }
+                | zccache::depgraph::DepGraphLoadOutcome::IoError { ref message } => {
+                    tracing::warn!("depgraph load failed: {message} — starting with empty graph");
+                    if let Some(ref w) = warning {
+                        eprintln!("{w}");
+                    }
+                    setter.install(None, warning);
+                }
+            }
+        });
 
         // Wire up Ctrl+C to trigger graceful shutdown
         let shutdown = server.shutdown_handle();
@@ -401,14 +376,22 @@ fn run_server(args: Args) {
 
         tracing::info!(%endpoint, "listening for connections");
 
+        // Take `mut server` here so `server.run(&mut self)` can borrow.
+        let mut server = server;
         if let Err(e) = server.run(idle_timeout).await {
             tracing::error!("server error: {e}");
             zccache::ipc::remove_lock_file();
+            // Best-effort: abort the background load if it hasn't
+            // landed yet. If it has, the swap is harmless.
+            load_handle.abort();
             std::process::exit(1);
         }
 
         tracing::info!("daemon exiting cleanly");
         zccache::ipc::remove_lock_file();
+        // The load may still be running if shutdown came in <3 s after
+        // start; abort is safe (nothing for the swap to corrupt).
+        load_handle.abort();
     });
 }
 

--- a/crates/zccache/src/daemon/mod.rs
+++ b/crates/zccache/src/daemon/mod.rs
@@ -19,5 +19,5 @@ pub mod stats;
 pub mod trampoline;
 
 pub use event_log::EventLogger;
-pub use server::DaemonServer;
+pub use server::{DaemonServer, DepGraphSetter};
 pub use stats::{PhaseProfiler, ProfileSnapshot, StatsCollector};

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -206,11 +206,25 @@ impl DaemonServer {
     /// session's log file at `SessionStart` so a cold fallback caused by a
     /// stale or corrupt `depgraph.bin` is visible to operators. Issue #320.
     ///
-    /// Must be called before `run()` (while this is the only `Arc` holder).
-    pub fn set_depgraph_load_warning(&mut self, warning: String) {
-        let state = Arc::get_mut(&mut self.state)
-            .expect("set_depgraph_load_warning must be called before run()");
-        *state.depgraph_load_warning.get_mut() = Some(warning);
+    /// **Post-#640**: takes `&self` and uses the field's existing
+    /// `tokio::sync::Mutex` via `blocking_lock` — safe to call from a
+    /// `tokio::task::spawn_blocking` after `run()` has started so the
+    /// daemon can move the depgraph load off the bind critical path.
+    pub fn set_depgraph_load_warning(&self, warning: String) {
+        let mut guard = self.state.depgraph_load_warning.blocking_lock();
+        *guard = Some(warning);
+    }
+
+    /// Hand out an owned handle that can install a loaded depgraph (and
+    /// optional warning) from any thread, at any time during the daemon's
+    /// lifetime. This is the #640 seam for the deferred-depgraph-load —
+    /// the background `spawn_blocking` loader holds a `DepGraphSetter` and
+    /// calls `install()` when the disk load completes; meanwhile
+    /// `server.run()` has been accepting connections from t ≈ 0.
+    pub fn dep_graph_setter(&self) -> DepGraphSetter {
+        DepGraphSetter {
+            state: Arc::clone(&self.state),
+        }
     }
 
     /// Get a snapshot of the phase profiler (for benchmarks).
@@ -286,5 +300,46 @@ impl DaemonServer {
     #[must_use]
     pub(super) fn test_state(&self) -> &SharedState {
         &self.state
+    }
+}
+
+/// Owned handle to install a loaded depgraph on a running [`DaemonServer`].
+///
+/// Holds a clone of the daemon's `Arc<SharedState>`. The setter survives
+/// across `tokio::task::spawn_blocking` boundaries (it is `Send + Sync`),
+/// so `bin/zccache-daemon::run_server` can hand one off to the background
+/// loader BEFORE calling `server.run()`. When the disk load finishes, the
+/// loader calls [`Self::install`] and the daemon's hot-path readers
+/// (`state.dep_graph.load()` at every compile request) atomically pick up
+/// the new graph on their next `.load()`.
+///
+/// Issue #640.
+pub struct DepGraphSetter {
+    state: Arc<SharedState>,
+}
+
+impl DepGraphSetter {
+    /// Atomically install a loaded depgraph (and optional warning).
+    ///
+    /// - `graph = Some(g)` swaps the daemon's empty default with the
+    ///   loaded graph and marks the on-disk snapshot as persisted (so
+    ///   the next clean shutdown doesn't re-save the empty default
+    ///   over the real graph).
+    /// - `graph = None` leaves the empty default in place. Use this
+    ///   for the `Missing` / corrupt-load fallback so the warning
+    ///   still routes into the per-session log via `warning`.
+    /// - `warning` is mirrored into `SessionStart`'s per-session log
+    ///   if `Some` (issue #320).
+    pub fn install(self, graph: Option<crate::depgraph::DepGraph>, warning: Option<String>) {
+        if let Some(graph) = graph {
+            self.state.dep_graph.store(Arc::new(graph));
+            self.state
+                .dep_graph_persisted
+                .store(true, Ordering::Release);
+        }
+        if let Some(warning) = warning {
+            let mut guard = self.state.depgraph_load_warning.blocking_lock();
+            *guard = Some(warning);
+        }
     }
 }

--- a/crates/zccache/src/daemon/server/mod.rs
+++ b/crates/zccache/src/daemon/server/mod.rs
@@ -65,6 +65,8 @@ const REQUEST_ROOT_MARKER: &str = "$ZCCACHE_WORKTREE_ROOT";
 const LINK_PATH_REMAP_AUTO_KEY_FLAG: &str = "zccache:path-remap=auto";
 const LINK_PATH_REMAP_ROOT_SPECIFIC_FLAG: &str = "zccache:path-remap=root-specific";
 
+pub use lifecycle::DepGraphSetter;
+
 /// The daemon server that listens for IPC connections.
 pub struct DaemonServer {
     listener: IpcListener,


### PR DESCRIPTION
## Summary

The first-wave daemon herd from #637 / #640 finally collapses. With #642's `ArcSwap<DepGraph>` foundation in place, `set_dep_graph` is `&self` + atomic-swap-safe, so the on-disk depgraph load can fire from `tokio::task::spawn_blocking` AFTER `server.run()` has started the accept loop.

## Order of operations on the winning daemon

| Step | Before | After this PR |
|---|---|---|
| 1 | crash guard, "starting" log | crash guard, "starting" log |
| 2 | Pre-bind probe (#641) | Pre-bind probe (#641) |
| 3 | defender banner | defender banner |
| 4 | **load depgraph (3+ s)** | tokio runtime built |
| 5a | tokio runtime built | **`DaemonServer::bind(endpoint)` — pipe claimed at t ≈ 0** |
| 5b | (still in rt.block_on) bind | On bind error: #639 path |
| 5c | inject graph, run accept | **write spawn event + lock file** (winner-only) |
| 5d | | **spawn_blocking(load_depgraph_and_install)** — parallel with accept |
| 5e | | server.run() — accept loop runs immediately |
| 5f | | (background) load completes, `DepGraphSetter::install` swaps in |

Compile requests arriving during step (5e) before (5f) see the empty default `DepGraph` and take the cold-path miss. That is correct — the `cache_system`'s stat-verify safety net catches any stale-hit risk; we lose ~3 s of cache hits per cold start, which is exactly what the user was paying anyway under the old broken-herd flow.

## Order of operations on redundant daemons

The 277-daemon herd shape collapses to ~2 across both waves:

- **First wave** (initial cohort, no lock file written yet): N daemons all race at step 5a. One wins; the other N-1 hit #639's PermissionDenied path at step 5b **in microseconds** (no depgraph load paid) and exit 0.
- **Second wave** (spawned by clients whose connect failed mid-load on the winner): caught at step 2 by #641's pre-bind probe.

## Why this didn't ship in v1 of #639

The first attempt at bind-before-load broke `wrapper-e2e (windows-latest)`: the pipe was bound but the accept loop hadn't started, so clients connected fast, sent a message, then timed out after 10 s waiting for a response that no one was reading.

**This PR keeps the bind + accept on the same timeline.** Both happen inside `rt.block_on`; only the depgraph load moves to a background task. Accept starts at the same instant it always did relative to bind. The v1 #639 regression shape doesn't recur.

The reason this couldn't be done before #642: `set_dep_graph` used `Arc::get_mut`, which only works pre-`run()`. ArcSwap removed that constraint. This PR is exactly the follow-up #642's commit message promised.

## New types / API

- **`daemon::DepGraphSetter`** — owned handle that survives `spawn_blocking` boundaries. Holds a clone of the daemon's `Arc<SharedState>`; calls `state.dep_graph.store(...)` + `state.depgraph_load_warning.blocking_lock()` on `install()`.
- **`DaemonServer::dep_graph_setter() -> DepGraphSetter`** — public method to hand out the setter before calling `run()`.
- **`DaemonServer::set_depgraph_load_warning`** is now `&self` + uses `tokio::sync::Mutex::blocking_lock` (matching the field's existing type). Same change shape as `set_dep_graph` in #642.

## Test plan

- [x] `soldr cargo check -p zccache --tests` clean
- [x] `soldr cargo clippy -p zccache --tests -- -D warnings` clean
- [x] `soldr cargo fmt --all -- --check` clean
- [x] `soldr cargo test -p zccache --lib` — 1693 / 1693 pass
- [ ] PR CI green — **particularly `wrapper-e2e (windows-latest)`**. The v1 #639 regression was "bound pipe, no accept" for 3+ s. This PR keeps bind and accept on the same timeline (both inside `rt.block_on`), so the regression shape should not recur.

A live-spawn-race repro is intrinsically flaky as a unit test (depends on real Windows pipe scheduling), so coverage is the structural one: "is there any blocking I/O between `rt.block_on(async)` entry and `DaemonServer::bind`?" — answer after this PR: no.

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)