### PR TITLE
feat(meson): zccache meson configure — cache meson setup, 6.2x speedup on fastled (#627)

### DIFF
--- a/crates/zccache/src/cli/commands/args.rs
+++ b/crates/zccache/src/cli/commands/args.rs
@@ -469,6 +469,53 @@ pub(crate) enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Meson build-system caching helpers. Issue #627.
+    Meson {
+        #[command(subcommand)]
+        command: MesonCommands,
+    },
+}
+
+/// `zccache meson` subcommands.
+#[derive(Debug, Subcommand)]
+pub(crate) enum MesonCommands {
+    /// Cache-aware `meson setup`. On first invocation runs real meson and
+    /// captures the resulting build directory into the zccache cache; on
+    /// subsequent invocations with the same `meson.build` set, environment,
+    /// and meson version, restores the cached build directory and skips
+    /// invoking meson entirely.
+    ///
+    /// **Same-build-dir restriction** — the build directory path is part of
+    /// the cache key. Build-dir-portable caching would require rewriting
+    /// the absolute paths meson scatters through `meson-info/` and
+    /// `meson-private/` on materialisation; for the common dev-loop case
+    /// (one developer, stable build dir) this is unnecessary. The
+    /// substantially larger fastled-style CI matrix that uses different
+    /// build dirs per platform still benefits because each (source, build,
+    /// host, env) tuple converges to a per-tuple cache entry on its second
+    /// invocation.
+    Configure {
+        /// Project source directory containing the root `meson.build`.
+        #[arg(long = "source-dir", value_name = "DIR")]
+        source_dir: PathBuf,
+        /// Build directory meson will populate.
+        #[arg(long = "build-dir", value_name = "DIR")]
+        build_dir: PathBuf,
+        /// Path to the meson executable. Defaults to `meson` on PATH.
+        #[arg(long = "meson-bin", value_name = "PATH")]
+        meson_bin: Option<PathBuf>,
+        /// Extra environment variable names whose values feed the cache
+        /// key. The current process env is queried at request time.
+        /// Repeatable. Common defaults (CC, CXX, CFLAGS, CXXFLAGS,
+        /// LDFLAGS, PKG_CONFIG_PATH) are always included.
+        #[arg(long = "input-env", value_name = "NAME")]
+        input_env: Vec<String>,
+        /// Extra `meson setup` arguments passed verbatim on a miss. They
+        /// also enter the cache key so different option sets produce
+        /// distinct cache entries.
+        #[arg(trailing_var_arg = true)]
+        meson_args: Vec<String>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -820,6 +867,7 @@ pub(crate) const KNOWN_SUBCOMMANDS: &[&str] = &[
     "gha-cache",
     "rust-plan",
     "kv",
+    "meson",
     "warm",
     "snapshot-bytes",
     "snapshot-fp-record",

--- a/crates/zccache/src/cli/commands/meson_cache.rs
+++ b/crates/zccache/src/cli/commands/meson_cache.rs
@@ -1,0 +1,451 @@
+//! `zccache meson configure` — cache-aware `meson setup` wrapper.
+//!
+//! Issue #627. Implements the configure-cache sketch from the issue body:
+//! on a cold invocation we shell out to real `meson setup`, capture the
+//! resulting build directory contents into a zccache-rooted artifact
+//! tree, and on subsequent invocations with identical inputs we restore
+//! the cached contents and skip meson entirely.
+//!
+//! The user-facing argument here is the build directory PATH, not its
+//! content. Build-dir-portable caching would require rewriting the
+//! absolute paths meson scatters through `meson-info/` and
+//! `meson-private/` on materialisation (see #627 open question 2). For
+//! the common dev-loop case (stable build dir per developer) this is
+//! unnecessary, and a CI matrix that uses distinct build dirs per
+//! platform still benefits as soon as each tuple has run once.
+//!
+//! **Cache key inputs** (blake3, domain-separated):
+//!
+//! - The `[meson.build, meson.options, meson_options.txt]` file set
+//!   discovered recursively under the source dir, each file's content
+//!   hashed and the (relative-path, content-hash) pairs sorted.
+//! - The meson executable's `--version` output (cheap, stable).
+//! - The build-directory **absolute path** (same-build-dir restriction).
+//! - The source-directory **absolute path** (so a renamed source tree
+//!   gets a fresh entry — meson embeds the source path in `build.ninja`).
+//! - Selected environment variables: `CC`, `CXX`, `CFLAGS`, `CXXFLAGS`,
+//!   `LDFLAGS`, `PKG_CONFIG_PATH` always; plus any extras supplied via
+//!   `--input-env`. Each as `NAME=VALUE` with absent vars contributing
+//!   `NAME=` (so set-vs-unset distinguishes).
+//! - The verbatim `meson_args` trailing argv (so different `-Dopt=…`
+//!   combinations produce distinct entries).
+//! - A version tag (`"zccache-meson-cache-v1"`) for forward-compat key
+//!   rotation when the capture/restore scheme evolves.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+use crate::core::config;
+
+const KEY_DOMAIN_TAG: &str = "zccache-meson-cache-v1";
+
+/// Environment variables whose values always feed the cache key. Set
+/// regardless of `--input-env` so a forgotten extra never silently
+/// publishes a stale cache hit.
+const DEFAULT_INPUT_ENV: &[&str] = &[
+    "CC",
+    "CXX",
+    "CFLAGS",
+    "CXXFLAGS",
+    "LDFLAGS",
+    "PKG_CONFIG_PATH",
+];
+
+/// Filenames meson reads as configure inputs. Recursively discovered
+/// under the source dir; each matching file's content enters the key.
+const MESON_INPUT_FILENAMES: &[&str] = &["meson.build", "meson.options", "meson_options.txt"];
+
+pub(crate) fn cmd_configure(
+    source_dir: PathBuf,
+    build_dir: PathBuf,
+    meson_bin: Option<PathBuf>,
+    extra_input_env: Vec<String>,
+    meson_args: Vec<String>,
+) -> ExitCode {
+    if !source_dir.exists() {
+        eprintln!(
+            "[zccache-meson] error: source dir {} does not exist",
+            source_dir.display()
+        );
+        return ExitCode::FAILURE;
+    }
+    // Absolutise without `canonicalize` — on Windows canonicalize injects
+    // the `\\?\` UNC prefix that subprocesses generally don't like.
+    let source_abs = absolutise(&source_dir);
+    let build_abs = absolutise(&build_dir);
+    let meson_bin = meson_bin.unwrap_or_else(|| PathBuf::from("meson"));
+
+    let meson_version = match capture_meson_version(&meson_bin) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[zccache-meson] error: cannot read `meson --version`: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let mut env_inputs: Vec<&str> = DEFAULT_INPUT_ENV.to_vec();
+    for extra in &extra_input_env {
+        if !env_inputs.iter().any(|s| s == extra) {
+            env_inputs.push(extra.as_str());
+        }
+    }
+    env_inputs.sort_unstable();
+
+    let env_pairs: Vec<(String, String)> = env_inputs
+        .iter()
+        .map(|name| ((*name).to_string(), std::env::var(name).unwrap_or_default()))
+        .collect();
+
+    let input_files = match discover_meson_inputs(&source_abs) {
+        Ok(set) => set,
+        Err(e) => {
+            eprintln!("[zccache-meson] error: scanning source dir failed: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if input_files.is_empty() {
+        eprintln!(
+            "[zccache-meson] error: no meson input files found under {}",
+            source_abs.display()
+        );
+        return ExitCode::FAILURE;
+    }
+
+    let key_hex = match compute_cache_key(
+        &input_files,
+        &source_abs,
+        &build_abs,
+        &meson_version,
+        &env_pairs,
+        &meson_args,
+    ) {
+        Ok(hex) => hex,
+        Err(e) => {
+            eprintln!("[zccache-meson] error: hashing inputs failed: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let cache_root = config::default_cache_dir();
+    let entry_dir = Path::new(cache_root.as_path())
+        .join("meson-configure")
+        .join(&key_hex);
+    let payload_path = entry_dir.join("build-dir.tar");
+    let stdout_path = entry_dir.join("stdout.bin");
+    let stderr_path = entry_dir.join("stderr.bin");
+
+    if payload_path.exists() {
+        match restore_from_cache(&payload_path, &stdout_path, &stderr_path, &build_abs) {
+            Ok(()) => {
+                eprintln!(
+                    "[zccache-meson] hit key={} build_dir={}",
+                    &key_hex[..16],
+                    build_abs.display()
+                );
+                return ExitCode::SUCCESS;
+            }
+            Err(e) => {
+                eprintln!(
+                    "[zccache-meson] warning: cache restore failed ({e}); falling back to fresh meson setup"
+                );
+                // Fall through to miss path.
+            }
+        }
+    }
+
+    eprintln!(
+        "[zccache-meson] miss key={} build_dir={}",
+        &key_hex[..16],
+        build_abs.display()
+    );
+
+    // Miss: run real meson. The build dir is created by meson itself.
+    let _ = std::fs::create_dir_all(&build_abs);
+    let mut cmd = Command::new(&meson_bin);
+    cmd.arg("setup").arg(&build_abs).arg(&source_abs);
+    for arg in &meson_args {
+        cmd.arg(arg);
+    }
+    let output = match cmd.output() {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!(
+                "[zccache-meson] error: failed to run `{} setup`: {e}",
+                meson_bin.display()
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // Replay meson's output to the caller's streams regardless of hit/miss.
+    let _ = std::io::Write::write_all(&mut std::io::stdout(), &output.stdout);
+    let _ = std::io::Write::write_all(&mut std::io::stderr(), &output.stderr);
+
+    if !output.status.success() {
+        // meson failed — DO NOT cache. The user sees meson's exit code
+        // unchanged and can re-run after fixing the issue. Caching the
+        // failed config would defeat the whole point: a re-run would
+        // restore the failure instead of giving meson a fresh chance.
+        return crate::cli::commands::util::exit_code_from_i32(output.status.code().unwrap_or(1));
+    }
+
+    if let Err(e) = persist_to_cache(
+        &entry_dir,
+        &payload_path,
+        &stdout_path,
+        &stderr_path,
+        &output.stdout,
+        &output.stderr,
+        &build_abs,
+    ) {
+        // Persist failure on a successful meson is non-fatal — the
+        // user got a valid build dir; they just don't get the cache
+        // win for next time. Surface the warning so it's diagnosable.
+        eprintln!("[zccache-meson] warning: failed to persist cache entry: {e}");
+    }
+
+    ExitCode::SUCCESS
+}
+
+fn absolutise(p: &Path) -> PathBuf {
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        std::env::current_dir().unwrap_or_default().join(p)
+    }
+}
+
+fn capture_meson_version(meson_bin: &Path) -> std::io::Result<String> {
+    let out = Command::new(meson_bin).arg("--version").output()?;
+    if !out.status.success() {
+        return Err(std::io::Error::other(format!(
+            "`{} --version` exit={}",
+            meson_bin.display(),
+            out.status
+        )));
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    Ok(s)
+}
+
+/// Discover every meson input file recursively under `root`. Returns a
+/// map keyed by the path *relative to root* (forward-slash normalised)
+/// so the resulting cache key is portable across path-separator
+/// quirks. The file content itself is read in
+/// [`compute_cache_key`] — keeping discovery and hashing separate so
+/// the discovery list can also drive the "is this list stable?" debug
+/// output if added later.
+fn discover_meson_inputs(root: &Path) -> std::io::Result<BTreeMap<String, PathBuf>> {
+    let mut out = BTreeMap::new();
+    walk_meson_dir(root, root, &mut out)?;
+    Ok(out)
+}
+
+fn walk_meson_dir(
+    root: &Path,
+    dir: &Path,
+    acc: &mut BTreeMap<String, PathBuf>,
+) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            // Skip common scratch dirs that meson doesn't read but might
+            // contain copies of meson.build inside vendored sources.
+            // Keep the list short and conservative.
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                if matches!(
+                    name,
+                    "build" | ".build" | "target" | "node_modules" | ".git"
+                ) {
+                    continue;
+                }
+            }
+            walk_meson_dir(root, &path, acc)?;
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !MESON_INPUT_FILENAMES.contains(&name) {
+            continue;
+        }
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        acc.insert(rel, path);
+    }
+    Ok(())
+}
+
+fn compute_cache_key(
+    inputs: &BTreeMap<String, PathBuf>,
+    source_abs: &Path,
+    build_abs: &Path,
+    meson_version: &str,
+    env_pairs: &[(String, String)],
+    meson_args: &[String],
+) -> std::io::Result<String> {
+    let mut hasher = blake3::Hasher::new_derive_key(KEY_DOMAIN_TAG);
+    // Source and build dir absolute paths — same-build-dir restriction.
+    hash_str_with_tag(&mut hasher, "source", &source_abs.to_string_lossy());
+    hash_str_with_tag(&mut hasher, "build", &build_abs.to_string_lossy());
+    // meson version string (e.g. "1.5.1").
+    hash_str_with_tag(&mut hasher, "meson-version", meson_version);
+    // Sorted env pairs (set-vs-unset captured by the empty-string convention).
+    hasher.update(b"env\0");
+    for (k, v) in env_pairs {
+        hasher.update(k.as_bytes());
+        hasher.update(b"=");
+        hasher.update(v.as_bytes());
+        hasher.update(b"\0");
+    }
+    // Trailing meson_args verbatim.
+    hasher.update(b"args\0");
+    for a in meson_args {
+        hasher.update(a.as_bytes());
+        hasher.update(b"\0");
+    }
+    // meson.build et al. content. Ordered by relative path (BTreeMap).
+    hasher.update(b"inputs\0");
+    for (rel, abs) in inputs {
+        let bytes = std::fs::read(abs)?;
+        hasher.update(rel.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(&bytes);
+        hasher.update(b"\0");
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn hash_str_with_tag(hasher: &mut blake3::Hasher, tag: &str, value: &str) {
+    hasher.update(tag.as_bytes());
+    hasher.update(b"=");
+    hasher.update(value.as_bytes());
+    hasher.update(b"\0");
+}
+
+/// Persist a freshly-produced build dir into the cache. The build dir
+/// contents are walked, each file written as a record in a simple
+/// length-prefixed tarball format: `[u32 path_len][path bytes][u64
+/// content_len][content bytes]` repeated until EOF.
+///
+/// Why hand-roll a format instead of using `tar`: the `tar` crate brings
+/// in its own modtime / uid / gid handling that's a poor fit for a
+/// content-only cache where mtimes are explicitly NOT preserved (the
+/// restore writes everything with `now()` so meson's regen-trigger logic
+/// re-validates inputs but doesn't think the cache files were
+/// pre-existing). The format is tiny, well-defined, and trivial to
+/// extend.
+fn persist_to_cache(
+    entry_dir: &Path,
+    payload_path: &Path,
+    stdout_path: &Path,
+    stderr_path: &Path,
+    stdout_bytes: &[u8],
+    stderr_bytes: &[u8],
+    build_abs: &Path,
+) -> std::io::Result<()> {
+    std::fs::create_dir_all(entry_dir)?;
+    let tmp = payload_path.with_extension("tar.tmp");
+    {
+        let f = std::fs::File::create(&tmp)?;
+        let mut writer = std::io::BufWriter::new(f);
+        archive_dir(build_abs, build_abs, &mut writer)?;
+        std::io::Write::flush(&mut writer)?;
+    }
+    std::fs::rename(&tmp, payload_path)?;
+    std::fs::write(stdout_path, stdout_bytes)?;
+    std::fs::write(stderr_path, stderr_bytes)?;
+    Ok(())
+}
+
+fn archive_dir(
+    root: &Path,
+    dir: &Path,
+    writer: &mut std::io::BufWriter<std::fs::File>,
+) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            archive_dir(root, &path, writer)?;
+            continue;
+        }
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        let rel_bytes = rel.as_bytes();
+        let content = std::fs::read(&path)?;
+        use std::io::Write;
+        writer.write_all(&(rel_bytes.len() as u32).to_le_bytes())?;
+        writer.write_all(rel_bytes)?;
+        writer.write_all(&(content.len() as u64).to_le_bytes())?;
+        writer.write_all(&content)?;
+    }
+    Ok(())
+}
+
+fn restore_from_cache(
+    payload_path: &Path,
+    stdout_path: &Path,
+    stderr_path: &Path,
+    build_abs: &Path,
+) -> std::io::Result<()> {
+    // Ensure a clean restore destination. If the build dir already has
+    // partial contents (e.g. a previous interrupted miss), wipe so the
+    // restore is bit-identical to the cold-run snapshot.
+    if build_abs.exists() {
+        std::fs::remove_dir_all(build_abs)?;
+    }
+    std::fs::create_dir_all(build_abs)?;
+
+    let f = std::fs::File::open(payload_path)?;
+    let mut reader = std::io::BufReader::new(f);
+    loop {
+        use std::io::Read;
+        let mut len_buf = [0u8; 4];
+        match reader.read_exact(&mut len_buf) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(e) => return Err(e),
+        }
+        let path_len = u32::from_le_bytes(len_buf) as usize;
+        let mut path_bytes = vec![0u8; path_len];
+        reader.read_exact(&mut path_bytes)?;
+        let rel = String::from_utf8(path_bytes).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("non-UTF8 path in archive: {e}"),
+            )
+        })?;
+
+        let mut content_len_buf = [0u8; 8];
+        reader.read_exact(&mut content_len_buf)?;
+        let content_len = u64::from_le_bytes(content_len_buf) as usize;
+        let mut content = vec![0u8; content_len];
+        reader.read_exact(&mut content)?;
+
+        let dest = build_abs.join(rel.replace('/', std::path::MAIN_SEPARATOR_STR));
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&dest, &content)?;
+    }
+
+    // Replay the cached stdout/stderr so the caller sees the same
+    // operator-facing output a cold run would have produced.
+    if let Ok(bytes) = std::fs::read(stdout_path) {
+        let _ = std::io::Write::write_all(&mut std::io::stdout(), &bytes);
+    }
+    if let Ok(bytes) = std::fs::read(stderr_path) {
+        let _ = std::io::Write::write_all(&mut std::io::stderr(), &bytes);
+    }
+    Ok(())
+}

--- a/crates/zccache/src/cli/commands/mod.rs
+++ b/crates/zccache/src/cli/commands/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod download;
 pub(crate) mod exec;
 pub(crate) mod fp;
 pub(crate) mod gha;
+pub(crate) mod meson_cache;
 pub(crate) mod rust_plan;
 pub(crate) mod session;
 pub(crate) mod status;
@@ -383,6 +384,17 @@ fn dispatch(command: Commands, global_strict_paths: Option<&str>) -> ExitCode {
             };
             wrap::run_wrap(&wrap_args, strict_paths)
         }
+        Commands::Meson { command } => match command {
+            args::MesonCommands::Configure {
+                source_dir,
+                build_dir,
+                meson_bin,
+                input_env,
+                meson_args,
+            } => {
+                meson_cache::cmd_configure(source_dir, build_dir, meson_bin, input_env, meson_args)
+            }
+        },
         Commands::Exec {
             input_file,
             input_env,

--- a/crates/zccache/tests/cli_meson_configure_cache.rs
+++ b/crates/zccache/tests/cli_meson_configure_cache.rs
@@ -1,0 +1,195 @@
+//! Integration tests for `zccache meson configure` — issue #627.
+//!
+//! TDD pins for the configure-cache wrapper. The contract:
+//!
+//! - First invocation with given (source-dir + meson.build set + meson
+//!   version + selected env vars) is a MISS: shells out to real `meson
+//!   setup`, captures the resulting build dir, exits with meson's exit
+//!   code.
+//! - Subsequent invocations with the same inputs are HITs: the captured
+//!   build dir is restored from cache; meson is not invoked.
+//! - On HIT, `build.ninja` content matches the original run exactly.
+//! - On HIT, the cached run completes substantially faster than the cold
+//!   run.
+
+use std::path::Path;
+use std::process::Command;
+use std::time::Instant;
+
+use zccache::core::NormalizedPath;
+
+fn zccache_bin() -> NormalizedPath {
+    let mut path = std::env::current_exe()
+        .expect("current_exe")
+        .parent()
+        .expect("parent of test binary")
+        .parent()
+        .expect("target dir")
+        .to_path_buf();
+    if cfg!(windows) {
+        path.push("zccache.exe");
+    } else {
+        path.push("zccache");
+    }
+    assert!(
+        path.exists(),
+        "zccache binary not found at {path:?}. Run `cargo build -p zccache --bin zccache` first."
+    );
+    NormalizedPath::new(path)
+}
+
+fn meson_available() -> bool {
+    Command::new("meson")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn write_tiny_meson_project(source_dir: &Path) {
+    std::fs::write(
+        source_dir.join("meson.build"),
+        "project('zccache-mc-test', 'c')\nexecutable('hello', 'main.c')\n",
+    )
+    .unwrap();
+    std::fs::write(source_dir.join("main.c"), "int main(void) { return 0; }\n").unwrap();
+}
+
+fn run_zccache_meson_configure(
+    cache_dir: &Path,
+    source_dir: &Path,
+    build_dir: &Path,
+) -> std::process::Output {
+    let bin = zccache_bin();
+    let mut cmd = Command::new(bin.as_path());
+    cmd.env("ZCCACHE_CACHE_DIR", cache_dir);
+    // Soldr sets ZCCACHE_SESSION_ID on the parent test process; the
+    // child would otherwise inherit and try to talk to a daemon at the
+    // session's endpoint instead of running the self-contained meson
+    // configure cache.
+    cmd.env_remove("ZCCACHE_SESSION_ID");
+    cmd.arg("meson").arg("configure");
+    cmd.arg("--source-dir").arg(source_dir);
+    cmd.arg("--build-dir").arg(build_dir);
+    cmd.output().expect("spawn zccache meson configure")
+}
+
+#[test]
+fn first_invocation_misses_and_runs_real_meson() {
+    if !meson_available() {
+        eprintln!("SKIP: meson not on PATH");
+        return;
+    }
+    let cache = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let source = project.path().join("src");
+    let build = project.path().join("build");
+    std::fs::create_dir_all(&source).unwrap();
+    write_tiny_meson_project(&source);
+
+    let output = run_zccache_meson_configure(cache.path(), &source, &build);
+    assert!(
+        output.status.success(),
+        "first invocation must succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    // meson must have populated the build dir
+    assert!(
+        build.join("build.ninja").exists(),
+        "first invocation should produce build.ninja"
+    );
+    // stderr should report a MISS so an operator can see it in CI logs
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("[zccache-meson] miss"),
+        "stderr must mark the miss path; got: {stderr}",
+    );
+}
+
+#[test]
+fn second_invocation_hits_cache_and_restores_build_dir() {
+    if !meson_available() {
+        eprintln!("SKIP: meson not on PATH");
+        return;
+    }
+    let cache = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let source = project.path().join("src");
+    std::fs::create_dir_all(&source).unwrap();
+    write_tiny_meson_project(&source);
+
+    let build_a = project.path().join("build-a");
+    let cold = Instant::now();
+    let out_a = run_zccache_meson_configure(cache.path(), &source, &build_a);
+    let cold_elapsed = cold.elapsed();
+    assert!(out_a.status.success(), "cold run must succeed");
+    let ninja_a = std::fs::read(build_a.join("build.ninja")).unwrap();
+
+    // Wipe the build dir to prove the cache is restoring, not just
+    // hitting a no-op "build dir already good" check.
+    std::fs::remove_dir_all(&build_a).unwrap();
+
+    let warm = Instant::now();
+    let out_b = run_zccache_meson_configure(cache.path(), &source, &build_a);
+    let warm_elapsed = warm.elapsed();
+    assert!(
+        out_b.status.success(),
+        "warm run must succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out_b.stdout),
+        String::from_utf8_lossy(&out_b.stderr),
+    );
+
+    let stderr_b = String::from_utf8_lossy(&out_b.stderr);
+    assert!(
+        stderr_b.contains("[zccache-meson] hit"),
+        "stderr must mark the hit path; got: {stderr_b}",
+    );
+
+    let ninja_b = std::fs::read(build_a.join("build.ninja")).unwrap();
+    assert_eq!(
+        ninja_a, ninja_b,
+        "restored build.ninja must match the cold-run build.ninja byte-for-byte"
+    );
+
+    // Warm run must be substantially faster than the cold run. Allow a
+    // generous 4× headroom — cold runs typically take 1–5 s on this
+    // tiny project; warm should be under 200 ms.
+    assert!(
+        warm_elapsed.as_millis() * 4 < cold_elapsed.as_millis(),
+        "warm run should be much faster than cold: cold={cold_elapsed:?}, warm={warm_elapsed:?}"
+    );
+}
+
+#[test]
+fn changing_meson_build_busts_the_cache() {
+    if !meson_available() {
+        eprintln!("SKIP: meson not on PATH");
+        return;
+    }
+    let cache = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let source = project.path().join("src");
+    std::fs::create_dir_all(&source).unwrap();
+    write_tiny_meson_project(&source);
+
+    let build = project.path().join("build");
+    let out_a = run_zccache_meson_configure(cache.path(), &source, &build);
+    assert!(out_a.status.success());
+    std::fs::remove_dir_all(&build).unwrap();
+
+    // Mutate meson.build — must invalidate the cache.
+    std::fs::write(
+        source.join("meson.build"),
+        "project('zccache-mc-test-v2', 'c')\nexecutable('hello', 'main.c')\n",
+    )
+    .unwrap();
+
+    let out_b = run_zccache_meson_configure(cache.path(), &source, &build);
+    assert!(out_b.status.success());
+    let stderr_b = String::from_utf8_lossy(&out_b.stderr);
+    assert!(
+        stderr_b.contains("[zccache-meson] miss"),
+        "changing meson.build must produce a fresh miss; got: {stderr_b}",
+    );
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -314,6 +314,38 @@ This document describes the phased implementation plan for **zccache**, a high-p
 
 ---
 
+## Phase 5.5: Build System Configure Cache (`zccache meson configure`)
+
+**Goal:** Skip the meson `setup` (configure) phase on identical inputs. The compile cache (Phase 5) already handles the per-TU step; this addresses the once-per-build-cycle configure cost that the compile cache cannot reach.
+
+**Motivation:** Issue #627. Field measurement on a large FastLED checkout: the configure phase alone is 50 s on a cold run (683 build targets, 1434 ninja rules). The same checkout on a warm cache restores in 8 s — a 6.2× speedup, 42 s saved per build cycle. Multiply by N rebuilds per day × M developers.
+
+**Deliverable (shipped):** `zccache meson configure --source-dir SRC --build-dir BUILD [-- meson-args...]`. Implemented in `crates/zccache/src/cli/commands/meson_cache.rs`.
+
+**Cache key (blake3 with domain tag `"zccache-meson-cache-v1"`):**
+- `[meson.build, meson.options, meson_options.txt]` discovered recursively under source dir, each (relative-path, content) pair sorted
+- `meson --version` output
+- Source-dir + build-dir absolute paths (same-build-dir restriction)
+- Selected env vars (`CC`, `CXX`, `CFLAGS`, `CXXFLAGS`, `LDFLAGS`, `PKG_CONFIG_PATH` always; extras via `--input-env`)
+- Trailing `meson_args` verbatim
+
+**Storage:** flat hand-rolled archive (`[u32 path_len][path][u64 content_len][content]` repeated) at `~/.cache/zccache/meson-configure/<key>/build-dir.tar` plus cached stdout/stderr sidecars.
+
+**Same-build-dir restriction.** Build-dir-portable caching would require rewriting absolute paths meson scatters through `meson-info/` and `meson-private/` — see issue #627 open question 2. The current scope solves the common dev-loop case (stable build dir per developer) and the CI matrix case (each tuple converges to a per-tuple cache entry on its second invocation per platform).
+
+**Failure modes:**
+- Meson exit code != 0 → do NOT cache. A re-run after the fix gives meson a fresh chance.
+- Cache restore I/O error → log warning, fall through to a fresh meson setup. Self-healing.
+
+**Tests:** `crates/zccache/tests/cli_meson_configure_cache.rs` — TDD-pinned MISS → HIT → invalidate-on-meson.build-change.
+
+**Future work (not in v1):**
+- CMake / Bazel equivalents (same shape, different file set)
+- `--reconfigure` interaction — currently we always serve a cache hit if the key matches; meson's own `--reconfigure` decision happens *after* our hit check by definition. If a user relies on meson's reconfigure heuristics outside the meson.build content (e.g. environment-only changes), they should add those vars to `--input-env`.
+- Build-dir-portable mode via on-restore path rewriting
+
+---
+
 ## Phase 6: Correctness Hardening and Benchmarks
 
 **Goals:** Ensure the system is correct under stress, measure performance, and make the system observable and debuggable. This phase turns the MVP into production-quality software.


### PR DESCRIPTION
## Summary

Closes #627. Field-validated against `~/dev/fastled3`: cold meson setup on a 683-target / 1434-ninja-rule project takes **50.7 s**; the same project on the warm cache restores in **8.2 s** (**6.2× speedup, 42 s saved per build cycle**). The 20-30 s configure phase the user reported as "primary slowdown" collapses to single-digit seconds.

## What ships

A new top-level subcommand `zccache meson configure`:

```
zccache meson configure --source-dir <SRC> --build-dir <BUILD> [-- meson-setup-args...]
```

On a cold invocation shells out to real `meson setup` and captures the resulting build directory; on subsequent invocations with identical inputs restores the cached directory and skips meson entirely.

Self-contained CLI implementation in `crates/zccache/src/cli/commands/meson_cache.rs` — no daemon, no IPC, no protocol changes. Storage lives under `~/.cache/zccache/meson-configure/<key>/`.

## TDD pattern (RED → GREEN)

`crates/zccache/tests/cli_meson_configure_cache.rs` lands the failing test first; each test pins a contract:

| Test | Contract |
|---|---|
| `first_invocation_misses_and_runs_real_meson` | MISS shells out, produces build.ninja, stderr marks `[zccache-meson] miss` |
| `second_invocation_hits_cache_and_restores_build_dir` | HIT restores byte-identical build.ninja, ≥ 4× faster than cold |
| `changing_meson_build_busts_the_cache` | Mutating meson.build forces a fresh MISS — cache cannot publish stale content |

All three were RED before the impl and GREEN after.

## Field validation against fastled3

```
COLD: real    0m50.690s   ← real meson setup, 683 targets, 1434 ninja rules
WARM: real    0m8.166s    ← cache hit, build dir restored from
                            ~/.cache/zccache/meson-configure/<key>/
```

stderr on the warm run: `[zccache-meson] hit key=33ef1dd2946d8c96 build_dir=...`.

The warm wall-time is dominated by writing the cached build dir contents back to disk (~50 MB on fastled-scale projects); it is NOT dominated by meson, which doesn't run on hit.

## Cache key (blake3, domain-tagged `\"zccache-meson-cache-v1\"`)

- `[meson.build, meson.options, meson_options.txt]` files discovered recursively under source dir
- `meson --version` output
- Source-dir + build-dir absolute paths (same-build-dir restriction)
- Selected env vars: `CC`, `CXX`, `CFLAGS`, `CXXFLAGS`, `LDFLAGS`, `PKG_CONFIG_PATH` always; extras via `--input-env`
- Trailing `meson_args` verbatim

## What this PR does NOT do (deliberate v1 scope)

- **Build-dir-portable mode.** Per #627 open question 2 — portable mode requires rewriting absolute paths meson scatters through `meson-info/` and `meson-private/`. Out of v1 scope; current scope solves dev-loop + per-platform CI matrix cases.
- **cmake / bazel** — orthogonal, ROADMAP entry calls out the shape.
- **`--reconfigure` integration.** Meson's reconfigure heuristics fire *after* our hit check; users who rely on env-only triggers should add them to `--input-env`.
- **Daemon integration.** Configure-cache is CWD-rooted + per-user; no daemon coordination needed for v1.

## Test plan

- [x] `soldr cargo check -p zccache --tests` clean
- [x] `soldr cargo clippy -p zccache --tests -- -D warnings` clean
- [x] `soldr cargo fmt --all -- --check` clean
- [x] `soldr cargo test -p zccache --lib` — 1693 / 1693 pass
- [x] `soldr cargo test -p zccache --test cli_meson_configure_cache` — 3 / 3 pass
- [x] Real-world validation: ~/dev/fastled3 cold 50.7 s → warm 8.2 s
- [ ] PR CI green

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)