### PR TITLE
perf(miss): single-pass output-meta build in store_rustc_outputs

### DIFF
--- a/crates/zccache/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/miss_store.rs
@@ -161,13 +161,25 @@ fn store_rustc_outputs(
 ) {
     let state = state_arc.as_ref();
     let t_artifact_meta_build = Instant::now();
-    let artifact_bytes: u64 = all_outputs.iter().map(|o| o.size).sum();
-    let output_names: Vec<String> = all_outputs.iter().map(|o| o.name.clone()).collect();
-    let output_sizes: Vec<u64> = all_outputs.iter().map(|o| o.size).collect();
-    let source_paths: Vec<NormalizedPath> = all_outputs
-        .iter()
-        .map(|output| output.path.clone())
-        .collect();
+    // Issue #629: the prior four-pass shape (`.iter().map().sum()`
+    // + three `.iter().map().collect()`s) walks `all_outputs` four
+    // times and allocates three Vecs whose capacity wasn't hinted.
+    // For the typical rustc miss (2 outputs: `.rmeta` + `.rlib`) the
+    // savings are micro, but every µs on the daemon's
+    // response-return critical path stacks against the same-job-seed
+    // warm gap soldr is chasing in #629. Single pass with
+    // `with_capacity` hint and a `saturating_add` accumulator.
+    let n = all_outputs.len();
+    let mut output_names: Vec<String> = Vec::with_capacity(n);
+    let mut output_sizes: Vec<u64> = Vec::with_capacity(n);
+    let mut source_paths: Vec<NormalizedPath> = Vec::with_capacity(n);
+    let mut artifact_bytes: u64 = 0;
+    for output in all_outputs {
+        output_names.push(output.name.clone());
+        output_sizes.push(output.size);
+        source_paths.push(output.path.clone());
+        artifact_bytes = artifact_bytes.saturating_add(output.size);
+    }
     stats.artifact_meta_build_ns = t_artifact_meta_build.elapsed().as_nanos() as u64;
 
     // Issue #632: move the rust miss persist OFF the daemon's


### PR DESCRIPTION
## Summary

Four-pass over `all_outputs` in `store_rustc_outputs` collapsed to one. Each output Vec preallocates via `with_capacity`, the size accumulator uses `saturating_add`, and the loop builds `output_names` / `output_sizes` / `source_paths` / `artifact_bytes` in a single iteration.

## Why this matters here

PR #635 already deferred the rustc miss persist itself off the daemon's response-return critical path. What remains synchronous between rustc-done and the daemon-response write is the artifact metadata build, the depgraph update, and the in-memory artifact insert.

Every µs shaved off this path compounds against the same-job-seed warm-MISS gap soldr is chasing in **#629** (`zccache warm 2-5% behind no-wrapper baseline on incremental release`).

## Honest framing of impact

This alone won't close #629. For 2-output rustc misses (typical: `.rmeta` + `.rlib`) the savings are sub-µs. The dominant remaining post-compile chunks on the critical path are:

- `hash_all_ns` (~64ms on 4-core CI for a workspace link per the #532 comment)
- `include_scan` (dep-info parse)
- `depgraph_update` inside `store_miss_artifact`

Those are the next levers. This PR is a compounding micro-opt while the bigger ones get scoped.

## Tests

No isolated perf unit test here — the metadata-build phase is sub-µs on typical rustc misses and falls below the perf-rust-cluster.yml signal floor. The existing rust-link cold cells in that workflow remain the regression catcher per PERF.md, and the `artifact_meta_build_ns` field on `RustMissProfile` (miss_profile.rs:80) makes any regression directly observable in the published phase breakdown.

## Branch name

`perf/linux-asyncpersist-rustcoutput-single-pass` per PERF.md's scope-table convention. The bench cells exercised here are the linux-x86_64 rust-link cold scenarios.

Refs: #629
Coordinated with `zackees/soldr` (no soldr-side changes required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)