### PR TITLE
chore(release): bump 1.11.11 -> 1.11.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.11.11"
+version = "1.11.12"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.11.11"
+version = "1.11.12"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.11.11"
+version = "1.11.12"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.11.11"
+version = "1.11.12"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.11.11"
+version = "1.11.12"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Ships #649 (zccache meson configure wrapper, closes #627), #650 (perf: single-pass output-meta build), #651 (test: cross-key contention), #648 (closes #640).

Headline payload is #649 - the wrapper was merged 2026-06-04 but the 1.11.11 release was tagged 2026-06-03, so downstream pyproject pins on >=1.11.11 do not currently see it. This release closes that gap.

Validated end-to-end against FastLED on Windows: 'zccache meson configure --source-dir . --build-dir .build/X --meson-bin meson.exe -- ...' correctly captures + restores.