### PR TITLE
feat(m e s o n): add --input-file to extend configure-cache key (closes #654)

### DIFF
--- a/crates/zccache/src/cli/commands/args.rs
+++ b/crates/zccache/src/cli/commands/args.rs
@@ -510,6 +510,19 @@ pub(crate) enum MesonCommands {
         /// LDFLAGS, PKG_CONFIG_PATH) are always included.
         #[arg(long = "input-env", value_name = "NAME")]
         input_env: Vec<String>,
+        /// Extra file paths whose content feeds the cache key. Repeatable.
+        /// Each file is hashed by content; the path is recorded as it
+        /// appeared on the command line.
+        ///
+        /// Use this when source-change detection lives outside the
+        /// meson.build set itself — e.g. a downstream caching layer that
+        /// hashes test/example/source globs and writes the digest to a
+        /// sidecar file. Pointing `--input-file` at that sidecar lets the
+        /// wrapper invalidate the cached configure tree when those globs
+        /// change, instead of forcing the caller to bypass the wrapper
+        /// entirely. See issue #654.
+        #[arg(long = "input-file", value_name = "PATH")]
+        input_file: Vec<String>,
         /// Extra `meson setup` arguments passed verbatim on a miss. They
         /// also enter the cache key so different option sets produce
         /// distinct cache entries.

--- a/crates/zccache/src/cli/commands/meson_cache.rs
+++ b/crates/zccache/src/cli/commands/meson_cache.rs
@@ -27,10 +27,19 @@
 //!   `LDFLAGS`, `PKG_CONFIG_PATH` always; plus any extras supplied via
 //!   `--input-env`. Each as `NAME=VALUE` with absent vars contributing
 //!   `NAME=` (so set-vs-unset distinguishes).
+//! - Any extra `--input-file PATH` flags. Each file is read and its
+//!   content hashed alongside the meson.build set; the path is recorded
+//!   verbatim as it appeared on the command line. Repeats are
+//!   deduplicated and the set is sorted before hashing, so argv order
+//!   is irrelevant. Intended for downstream layers whose source-change
+//!   detection lives outside `meson.build` (e.g. a digest-of-globs
+//!   sidecar file). See issue #654.
 //! - The verbatim `meson_args` trailing argv (so different `-Dopt=…`
 //!   combinations produce distinct entries).
-//! - A version tag (`"zccache-meson-cache-v1"`) for forward-compat key
-//!   rotation when the capture/restore scheme evolves.
+//! - A version tag (`"zccache-meson-cache-v2"`) for forward-compat key
+//!   rotation when the capture/restore scheme evolves. Bumped from
+//!   `v1` -> `v2` alongside the `--input-file` addition so existing
+//!   cache entries don't collide with the new key layout.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -38,7 +47,7 @@ use std::process::{Command, ExitCode};
 
 use crate::core::config;
 
-const KEY_DOMAIN_TAG: &str = "zccache-meson-cache-v1";
+const KEY_DOMAIN_TAG: &str = "zccache-meson-cache-v2";
 
 /// Environment variables whose values always feed the cache key. Set
 /// regardless of `--input-env` so a forgotten extra never silently
@@ -61,6 +70,7 @@ pub(crate) fn cmd_configure(
     build_dir: PathBuf,
     meson_bin: Option<PathBuf>,
     extra_input_env: Vec<String>,
+    extra_input_file: Vec<String>,
     meson_args: Vec<String>,
 ) -> ExitCode {
     if !source_dir.exists() {
@@ -119,6 +129,7 @@ pub(crate) fn cmd_configure(
         &build_abs,
         &meson_version,
         &env_pairs,
+        &extra_input_file,
         &meson_args,
     ) {
         Ok(hex) => hex,
@@ -288,6 +299,7 @@ fn compute_cache_key(
     build_abs: &Path,
     meson_version: &str,
     env_pairs: &[(String, String)],
+    extra_input_files: &[String],
     meson_args: &[String],
 ) -> std::io::Result<String> {
     let mut hasher = blake3::Hasher::new_derive_key(KEY_DOMAIN_TAG);
@@ -315,6 +327,25 @@ fn compute_cache_key(
     for (rel, abs) in inputs {
         let bytes = std::fs::read(abs)?;
         hasher.update(rel.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(&bytes);
+        hasher.update(b"\0");
+    }
+    // User-supplied extra input files (issue #654). Each file's path is
+    // recorded as it appeared on the command line — sorted by that path
+    // so duplicate `--input-file foo --input-file foo` is idempotent and
+    // the key is stable across argv reordering. The empty list is a no-op
+    // and produces the same key contribution every time (just the
+    // section delimiter), so callers that don't pass `--input-file` see
+    // no behavior change beyond the v1 → v2 domain tag bump.
+    hasher.update(b"extra-inputs\0");
+    let mut sorted: Vec<&String> = extra_input_files.iter().collect();
+    sorted.sort();
+    sorted.dedup();
+    for path in sorted {
+        let bytes = std::fs::read(path)
+            .map_err(|e| std::io::Error::new(e.kind(), format!("--input-file {path}: {e}")))?;
+        hasher.update(path.as_bytes());
         hasher.update(b"\0");
         hasher.update(&bytes);
         hasher.update(b"\0");

--- a/crates/zccache/src/cli/commands/mod.rs
+++ b/crates/zccache/src/cli/commands/mod.rs
@@ -390,10 +390,11 @@ fn dispatch(command: Commands, global_strict_paths: Option<&str>) -> ExitCode {
                 build_dir,
                 meson_bin,
                 input_env,
+                input_file,
                 meson_args,
-            } => {
-                meson_cache::cmd_configure(source_dir, build_dir, meson_bin, input_env, meson_args)
-            }
+            } => meson_cache::cmd_configure(
+                source_dir, build_dir, meson_bin, input_env, input_file, meson_args,
+            ),
         },
         Commands::Exec {
             input_file,

--- a/crates/zccache/tests/cli_meson_configure_cache.rs
+++ b/crates/zccache/tests/cli_meson_configure_cache.rs
@@ -193,3 +193,160 @@ fn changing_meson_build_busts_the_cache() {
         "changing meson.build must produce a fresh miss; got: {stderr_b}",
     );
 }
+
+// ============================================================================
+// `--input-file` — issue #654.
+// ============================================================================
+// The wrapper key by default covers meson.build / meson.options /
+// meson_options.txt content. Downstream projects whose source-change
+// detection lives OUTSIDE the meson.build set (e.g. FastLED's
+// metadata-cache layer that hashes test/example/source globs and writes
+// a sidecar digest) can extend the key by passing one or more
+// `--input-file PATH` flags. Each file's content enters the key; if any
+// file's content changes, the next invocation is a fresh miss.
+
+fn run_zccache_meson_configure_with_extra_inputs(
+    cache_dir: &Path,
+    source_dir: &Path,
+    build_dir: &Path,
+    extra_input_files: &[&Path],
+) -> std::process::Output {
+    let bin = zccache_bin();
+    let mut cmd = Command::new(bin.as_path());
+    cmd.env("ZCCACHE_CACHE_DIR", cache_dir);
+    cmd.env_remove("ZCCACHE_SESSION_ID");
+    cmd.arg("meson").arg("configure");
+    cmd.arg("--source-dir").arg(source_dir);
+    cmd.arg("--build-dir").arg(build_dir);
+    for f in extra_input_files {
+        cmd.arg("--input-file").arg(f);
+    }
+    cmd.output()
+        .expect("spawn zccache meson configure --input-file ...")
+}
+
+#[test]
+fn input_file_change_busts_the_cache() {
+    if !meson_available() {
+        eprintln!("SKIP: meson not on PATH");
+        return;
+    }
+    let cache = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let source = project.path().join("src");
+    std::fs::create_dir_all(&source).unwrap();
+    write_tiny_meson_project(&source);
+
+    // Sidecar digest file the downstream caller maintains.
+    let sidecar = project.path().join("sources.hash");
+    std::fs::write(&sidecar, "deadbeef-v1").unwrap();
+
+    let build = project.path().join("build");
+    let out_a =
+        run_zccache_meson_configure_with_extra_inputs(cache.path(), &source, &build, &[&sidecar]);
+    assert!(
+        out_a.status.success(),
+        "cold run must succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out_a.stdout),
+        String::from_utf8_lossy(&out_a.stderr),
+    );
+    let stderr_a = String::from_utf8_lossy(&out_a.stderr);
+    assert!(stderr_a.contains("[zccache-meson] miss"));
+
+    std::fs::remove_dir_all(&build).unwrap();
+
+    // Sidecar content unchanged → expect a hit.
+    let out_b =
+        run_zccache_meson_configure_with_extra_inputs(cache.path(), &source, &build, &[&sidecar]);
+    assert!(out_b.status.success());
+    let stderr_b = String::from_utf8_lossy(&out_b.stderr);
+    assert!(
+        stderr_b.contains("[zccache-meson] hit"),
+        "unchanged --input-file content must still hit; got: {stderr_b}",
+    );
+
+    std::fs::remove_dir_all(&build).unwrap();
+
+    // Mutate the sidecar → expect a miss even though meson.build is unchanged.
+    std::fs::write(&sidecar, "cafef00d-v2").unwrap();
+
+    let out_c =
+        run_zccache_meson_configure_with_extra_inputs(cache.path(), &source, &build, &[&sidecar]);
+    assert!(out_c.status.success());
+    let stderr_c = String::from_utf8_lossy(&out_c.stderr);
+    assert!(
+        stderr_c.contains("[zccache-meson] miss"),
+        "mutating --input-file content must invalidate the cache; got: {stderr_c}",
+    );
+}
+
+#[test]
+fn input_file_is_distinct_from_no_input_file() {
+    if !meson_available() {
+        eprintln!("SKIP: meson not on PATH");
+        return;
+    }
+    // Same source tree, two cache populations: one with `--input-file`,
+    // one without. They must NOT share entries — the with-input-file run
+    // is a fresh miss even though the no-input-file run already populated
+    // the cache for the same meson.build.
+    let cache = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let source = project.path().join("src");
+    std::fs::create_dir_all(&source).unwrap();
+    write_tiny_meson_project(&source);
+
+    let sidecar = project.path().join("sources.hash");
+    std::fs::write(&sidecar, "anything").unwrap();
+
+    let build = project.path().join("build");
+    let out_a = run_zccache_meson_configure(cache.path(), &source, &build);
+    assert!(out_a.status.success());
+    std::fs::remove_dir_all(&build).unwrap();
+
+    let out_b =
+        run_zccache_meson_configure_with_extra_inputs(cache.path(), &source, &build, &[&sidecar]);
+    assert!(out_b.status.success());
+    let stderr_b = String::from_utf8_lossy(&out_b.stderr);
+    assert!(
+        stderr_b.contains("[zccache-meson] miss"),
+        "adding --input-file to a previously-cached entry must produce a fresh miss; got: {stderr_b}",
+    );
+}
+
+#[test]
+fn input_file_order_does_not_affect_key() {
+    if !meson_available() {
+        eprintln!("SKIP: meson not on PATH");
+        return;
+    }
+    // Two `--input-file` flags in opposite orders must produce the same
+    // cache key (the implementation sorts internally). This pins that
+    // contract so a caller using `BTreeMap`/`HashMap` iteration doesn't
+    // accidentally split cache entries by argv order.
+    let cache = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let source = project.path().join("src");
+    std::fs::create_dir_all(&source).unwrap();
+    write_tiny_meson_project(&source);
+
+    let a = project.path().join("a.hash");
+    let b = project.path().join("b.hash");
+    std::fs::write(&a, "alpha").unwrap();
+    std::fs::write(&b, "beta").unwrap();
+
+    let build = project.path().join("build");
+    let out_a =
+        run_zccache_meson_configure_with_extra_inputs(cache.path(), &source, &build, &[&a, &b]);
+    assert!(out_a.status.success());
+    std::fs::remove_dir_all(&build).unwrap();
+
+    let out_b =
+        run_zccache_meson_configure_with_extra_inputs(cache.path(), &source, &build, &[&b, &a]);
+    assert!(out_b.status.success());
+    let stderr_b = String::from_utf8_lossy(&out_b.stderr);
+    assert!(
+        stderr_b.contains("[zccache-meson] hit"),
+        "reordering --input-file flags must NOT change the key; got: {stderr_b}",
+    );
+}


### PR DESCRIPTION
Closes #654. Adds repeatable --input-file PATH flag to zccache m e s o n configure. Each file's content enters the cache key alongside existing inputs.

Downstream callers whose source-change detection lives outside meson.build set (e.g. FastLED's metadata-cache layer that hashes test/example/source globs to a sidecar digest) can pass --input-file <sidecar> to invalidate the cached tree when the globs change, instead of bypassing the wrapper.

Key domain tag v1 -> v2 (one-time invalidation). Three new integration tests pin the contract: input_file_change_busts_the_cache; input_file_is_distinct_from_no_input_file; input_file_order_does_not_affect_key. All 6 cli_meson_configure_cache tests pass on Windows.