### PR TITLE
fix(ci): re-download wheels after checkout so verify-pypi finds them (closes #657)

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -453,6 +453,17 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+      # Issue #657: `actions/checkout@v6` above wipes the workspace,
+      # including `dist/wheels/` populated by the earlier download-
+      # artifact step. Re-download the artifact post-checkout so the
+      # verify step's `--wheels-dir dist/wheels` lookup succeeds.
+      # Without this, the verify step fails with "wheels directory does
+      # not exist" even though the actual publish step already ran
+      # successfully — release-auto reports failure on a green release.
+      - uses: actions/download-artifact@v8
+        with:
+          name: pypi-wheels
+          path: dist/wheels
       - name: Verify all wheels visible on PyPI
         run: |
           python -m ci.release_workflow verify-pypi \


### PR DESCRIPTION
Closes #657.

actions/checkout@v6 between publish-wheels and verify-wheels wipes the workspace including dist/wheels/. So the verify step fails with 'wheels directory does not exist' even though the upload itself succeeded -- release-auto reports failure on an otherwise-green release.

Fix: add a second download-artifact step post-checkout to restore dist/wheels before verify runs. Verified against 1.11.13's failing run that PyPI itself had all 6 wheels at the time the verify step ran; the failure was purely a path issue.