### PR TITLE
perf(m e s o n): minimal skip-list expansion + --no-walk for explicit input control (closes #659)

### DIFF
--- a/crates/zccache/src/cli/commands/args.rs
+++ b/crates/zccache/src/cli/commands/args.rs
@@ -523,6 +523,17 @@ pub(crate) enum MesonCommands {
         /// entirely. See issue #654.
         #[arg(long = "input-file", value_name = "PATH")]
         input_file: Vec<String>,
+        /// Skip the implicit recursive walk of `--source-dir` for
+        /// `meson.build` / `meson.options` / `meson_options.txt`. The
+        /// caller takes full responsibility for naming every input file
+        /// via `--input-file` instead. Use this when you know your
+        /// project's input set exactly and the implicit walk is paying
+        /// for itself in directory-traversal cost on large monorepos
+        /// (e.g. trees with `.venv`, `.cached`, `.fbuild`, `.pio`, or
+        /// other large scratch dirs not on the default skip list). See
+        /// issue #659.
+        #[arg(long = "no-walk", default_value_t = false)]
+        no_walk: bool,
         /// Extra `meson setup` arguments passed verbatim on a miss. They
         /// also enter the cache key so different option sets produce
         /// distinct cache entries.

--- a/crates/zccache/src/cli/commands/meson_cache.rs
+++ b/crates/zccache/src/cli/commands/meson_cache.rs
@@ -19,6 +19,10 @@
 //! - The `[meson.build, meson.options, meson_options.txt]` file set
 //!   discovered recursively under the source dir, each file's content
 //!   hashed and the (relative-path, content-hash) pairs sorted.
+//!   Pass `--no-walk` to skip this implicit discovery — the caller then
+//!   takes full responsibility for naming every input file via
+//!   `--input-file` (intended for monorepos whose default skip list
+//!   doesn't cover their scratch dirs; see issue #659).
 //! - The meson executable's `--version` output (cheap, stable).
 //! - The build-directory **absolute path** (same-build-dir restriction).
 //! - The source-directory **absolute path** (so a renamed source tree
@@ -71,6 +75,7 @@ pub(crate) fn cmd_configure(
     meson_bin: Option<PathBuf>,
     extra_input_env: Vec<String>,
     extra_input_file: Vec<String>,
+    no_walk: bool,
     meson_args: Vec<String>,
 ) -> ExitCode {
     if !source_dir.exists() {
@@ -107,18 +112,37 @@ pub(crate) fn cmd_configure(
         .map(|name| ((*name).to_string(), std::env::var(name).unwrap_or_default()))
         .collect();
 
-    let input_files = match discover_meson_inputs(&source_abs) {
-        Ok(set) => set,
-        Err(e) => {
-            eprintln!("[zccache-meson] error: scanning source dir failed: {e}");
-            return ExitCode::FAILURE;
+    // With `--no-walk` the caller takes full responsibility for naming
+    // every input file via `--input-file`. The implicit walk of the
+    // source directory is skipped entirely (no traversal, no read), and
+    // the empty discovery set is the documented signal — distinct from
+    // the "walked but found nothing" error path below.
+    let input_files = if no_walk {
+        BTreeMap::new()
+    } else {
+        match discover_meson_inputs(&source_abs) {
+            Ok(set) => set,
+            Err(e) => {
+                eprintln!("[zccache-meson] error: scanning source dir failed: {e}");
+                return ExitCode::FAILURE;
+            }
         }
     };
 
-    if input_files.is_empty() {
+    if !no_walk && input_files.is_empty() {
         eprintln!(
             "[zccache-meson] error: no meson input files found under {}",
             source_abs.display()
+        );
+        return ExitCode::FAILURE;
+    }
+
+    // With `--no-walk` the caller must supply at least one `--input-file`
+    // — otherwise the cache key only sees the (source, build, version,
+    // env, args) tuple, which is rarely what anyone wants.
+    if no_walk && extra_input_file.is_empty() {
+        eprintln!(
+            "[zccache-meson] error: --no-walk requires at least one --input-file (otherwise the cache key has no source-content contribution)"
         );
         return ExitCode::FAILURE;
     }
@@ -263,13 +287,28 @@ fn walk_meson_dir(
         let entry = entry?;
         let path = entry.path();
         if path.is_dir() {
-            // Skip common scratch dirs that meson doesn't read but might
-            // contain copies of meson.build inside vendored sources.
-            // Keep the list short and conservative.
+            // Skip common scratch / dependency / VCS directories. These
+            // are the dirs every real project has in tree that meson
+            // would never legitimately read configure inputs from. The
+            // list is intentionally conservative — only directories
+            // whose ENTIRE canonical purpose is "out of source-control
+            // build/cache state". Callers that need exact control over
+            // which dirs are walked (or want to skip the walk entirely)
+            // should use `--no-walk` plus explicit `--input-file`
+            // entries — see issue #659.
             if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                 if matches!(
                     name,
-                    "build" | ".build" | "target" | "node_modules" | ".git"
+                    ".git"
+                        | ".hg"
+                        | ".svn"
+                        | "build"
+                        | ".build"
+                        | "target"
+                        | "node_modules"
+                        | ".venv"
+                        | "venv"
+                        | ".cargo"
                 ) {
                     continue;
                 }

--- a/crates/zccache/src/cli/commands/mod.rs
+++ b/crates/zccache/src/cli/commands/mod.rs
@@ -391,9 +391,10 @@ fn dispatch(command: Commands, global_strict_paths: Option<&str>) -> ExitCode {
                 meson_bin,
                 input_env,
                 input_file,
+                no_walk,
                 meson_args,
             } => meson_cache::cmd_configure(
-                source_dir, build_dir, meson_bin, input_env, input_file, meson_args,
+                source_dir, build_dir, meson_bin, input_env, input_file, no_walk, meson_args,
             ),
         },
         Commands::Exec {

--- a/crates/zccache/tests/cli_meson_configure_cache.rs
+++ b/crates/zccache/tests/cli_meson_configure_cache.rs
@@ -350,3 +350,133 @@ fn input_file_order_does_not_affect_key() {
         "reordering --input-file flags must NOT change the key; got: {stderr_b}",
     );
 }
+
+// ============================================================================
+// `--no-walk` — issue #659.
+// ============================================================================
+// Callers who know their meson.build set exactly and want to avoid the
+// implicit recursive walk of `--source-dir` (e.g. monorepos whose
+// scratch dirs aren't on the default skip list) can pass `--no-walk`
+// plus per-file `--input-file` flags. The wrapper then skips the source
+// walk entirely and keys only on the supplied inputs + (source, build,
+// env, args, meson-version) tuple.
+
+fn run_zccache_meson_configure_no_walk(
+    cache_dir: &Path,
+    source_dir: &Path,
+    build_dir: &Path,
+    extra_input_files: &[&Path],
+) -> std::process::Output {
+    let bin = zccache_bin();
+    let mut cmd = Command::new(bin.as_path());
+    cmd.env("ZCCACHE_CACHE_DIR", cache_dir);
+    cmd.env_remove("ZCCACHE_SESSION_ID");
+    cmd.arg("meson").arg("configure");
+    cmd.arg("--source-dir").arg(source_dir);
+    cmd.arg("--build-dir").arg(build_dir);
+    cmd.arg("--no-walk");
+    for f in extra_input_files {
+        cmd.arg("--input-file").arg(f);
+    }
+    cmd.output()
+        .expect("spawn zccache meson configure --no-walk")
+}
+
+#[test]
+fn no_walk_requires_at_least_one_input_file() {
+    if !meson_available() {
+        eprintln!("SKIP: meson not on PATH");
+        return;
+    }
+    let cache = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let source = project.path().join("src");
+    std::fs::create_dir_all(&source).unwrap();
+    write_tiny_meson_project(&source);
+
+    let build = project.path().join("build");
+    // No --input-file supplied — wrapper must refuse rather than emit a
+    // surprisingly-broad cache hit later.
+    let out = run_zccache_meson_configure_no_walk(cache.path(), &source, &build, &[]);
+    assert!(
+        !out.status.success(),
+        "--no-walk without --input-file must fail"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--no-walk requires at least one --input-file"),
+        "stderr must explain the constraint; got: {stderr}",
+    );
+}
+
+#[test]
+fn no_walk_hits_on_unchanged_input_files() {
+    if !meson_available() {
+        eprintln!("SKIP: meson not on PATH");
+        return;
+    }
+    let cache = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let source = project.path().join("src");
+    std::fs::create_dir_all(&source).unwrap();
+    write_tiny_meson_project(&source);
+
+    let inputs = source.join("meson.build");
+    let build = project.path().join("build");
+
+    let out_a = run_zccache_meson_configure_no_walk(cache.path(), &source, &build, &[&inputs]);
+    assert!(
+        out_a.status.success(),
+        "cold --no-walk run must succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out_a.stdout),
+        String::from_utf8_lossy(&out_a.stderr),
+    );
+    let stderr_a = String::from_utf8_lossy(&out_a.stderr);
+    assert!(stderr_a.contains("[zccache-meson] miss"));
+
+    std::fs::remove_dir_all(&build).unwrap();
+
+    let out_b = run_zccache_meson_configure_no_walk(cache.path(), &source, &build, &[&inputs]);
+    assert!(out_b.status.success());
+    let stderr_b = String::from_utf8_lossy(&out_b.stderr);
+    assert!(
+        stderr_b.contains("[zccache-meson] hit"),
+        "second --no-walk run with unchanged --input-file must hit; got: {stderr_b}",
+    );
+}
+
+#[test]
+fn no_walk_is_keyed_distinctly_from_walked() {
+    if !meson_available() {
+        eprintln!("SKIP: meson not on PATH");
+        return;
+    }
+    // A run with --no-walk and a run without --no-walk produce different
+    // cache keys even when the explicitly-named input is the same file
+    // the implicit walk would have found. This is by design: the walked
+    // case hashes every meson.build under source-dir; the no-walk case
+    // hashes only what's listed. Cross-pollution between them would be a
+    // foot-gun.
+    let cache = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let source = project.path().join("src");
+    std::fs::create_dir_all(&source).unwrap();
+    write_tiny_meson_project(&source);
+
+    let inputs = source.join("meson.build");
+    let build = project.path().join("build");
+
+    // Walked-mode populates the cache.
+    let out_a = run_zccache_meson_configure(cache.path(), &source, &build);
+    assert!(out_a.status.success());
+    std::fs::remove_dir_all(&build).unwrap();
+
+    // No-walk-mode with the same input — must NOT hit the walked entry.
+    let out_b = run_zccache_meson_configure_no_walk(cache.path(), &source, &build, &[&inputs]);
+    assert!(out_b.status.success());
+    let stderr_b = String::from_utf8_lossy(&out_b.stderr);
+    assert!(
+        stderr_b.contains("[zccache-meson] miss"),
+        "--no-walk run must NOT reuse a walked-mode cache entry; got: {stderr_b}",
+    );
+}


### PR DESCRIPTION
Closes #659. Two complementary changes to discover_meson_inputs:

1. Add .venv, venv, .cargo to the default skip list alongside existing entries (universally never-meson; on FastLED these were the dominant ~5s cost walking ~100k site-packages files).

2. Add --no-walk flag. When set, the wrapper skips the implicit walk entirely and keys only on the explicitly-named --input-file set. Whitelisting at the caller's choice. Failed if no --input-file supplied (foot-gun prevention).

Deliberately refused to ship an exhaustive blacklist (.pio, .cached, .fbuild, .clang-tool-chain, .claude, .idea, .vscode, ...) because every entry is a heuristic and the list grows forever. Whitelisting via --no-walk is the cleaner long-term API.

Three new integration tests: no_walk_requires_at_least_one_input_file; no_walk_hits_on_unchanged_input_files; no_walk_is_keyed_distinctly_from_walked. All 9 tests pass on Windows.

Generated with Claude Code.