### PR TITLE
fix(daemon): pipe-pool depletion + compile-path wedge recovery (refs #666)

### DIFF
--- a/crates/zccache/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache/src/cli/commands/wrap/ipc.rs
@@ -5,7 +5,8 @@ use std::io::Write;
 use std::path::Path;
 use std::process::ExitCode;
 
-use super::super::daemon::ensure_daemon;
+use super::super::super::wedge_recv_timeout;
+use super::super::daemon::{ensure_daemon, stop_stale_daemon};
 use super::super::util::{connect, exit_code_from_i32, slurp_stdin_if_piped};
 
 pub(super) async fn cmd_compile(
@@ -28,11 +29,11 @@ pub(super) async fn cmd_compile(
     if let Err(e) = conn
         .send(&crate::protocol::Request::Compile {
             session_id: session_id.to_string(),
-            args,
-            cwd,
-            compiler,
-            env: Some(client_env),
-            stdin: stdin_bytes,
+            args: args.clone(),
+            cwd: cwd.clone(),
+            compiler: compiler.clone(),
+            env: Some(client_env.clone()),
+            stdin: stdin_bytes.clone(),
         })
         .await
     {
@@ -40,14 +41,108 @@ pub(super) async fn cmd_compile(
         return ExitCode::FAILURE;
     }
 
-    let recv_result = match conn.recv().await {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("zccache[err][R]: broken connection to daemon: {e}");
-            return ExitCode::FAILURE;
+    match compile_recv_with_wedge_detection(&mut conn).await {
+        CompileRecvOutcome::Done(recv_result) => {
+            relay_compile_response(recv_result, &mut std::io::stdout(), &mut std::io::stderr())
         }
-    };
-    relay_compile_response(recv_result, &mut std::io::stdout(), &mut std::io::stderr())
+        CompileRecvOutcome::Wedged => {
+            // Daemon wedged mid-compile (issue #666). Recovery: force-kill
+            // the wedged daemon (releases the IPC endpoint and frees other
+            // workers waiting on `pipe.connect()`), spawn a fresh one, and
+            // retry the compile in ephemeral mode (the new daemon doesn't
+            // have the old session). The fall-through to ephemeral loses
+            // session-stats accounting for this single compile but keeps
+            // the build alive — a much better trade than the pre-#666
+            // 300 s wall × N workers behaviour.
+            eprintln!(
+                "zccache[warn][W]: daemon at {endpoint} appears wedged \
+                 (no response within wedge budget); recovering — issue #666"
+            );
+            drop(conn);
+            stop_stale_daemon(endpoint).await;
+            cmd_compile_ephemeral(endpoint, compiler.as_path(), args, cwd, client_env).await
+        }
+        CompileRecvOutcome::Failed(msg) => {
+            eprintln!("zccache[err][R]: {msg}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[allow(clippy::large_enum_variant)]
+enum CompileRecvOutcome {
+    // `Response` is large (cached compile result holds 2× Arc<Vec<u8>>),
+    // but `CompileRecvOutcome` is only ever stack-local for one match arm
+    // before being dropped — the extra indirection of Box would add an
+    // allocation per request on the hot wrapper path for no real gain.
+    Done(Option<crate::protocol::Response>),
+    /// Daemon stopped responding within the configured wedge budget.
+    Wedged,
+    /// Non-timeout recv failure (broken pipe, deserialization error, etc.).
+    Failed(String),
+}
+
+/// Wrap a compile-response recv with the [`wedge_recv_timeout`] budget.
+///
+/// Returns [`CompileRecvOutcome::Wedged`] only for the specific
+/// `IpcError::Timeout` signal — everything else (graceful close, broken
+/// pipe, protocol error) maps to [`CompileRecvOutcome::Failed`] so the
+/// caller does not respawn the daemon on errors that have nothing to do
+/// with a wedge.
+async fn compile_recv_with_wedge_detection<C: ConnRecv>(conn: &mut C) -> CompileRecvOutcome {
+    match wedge_recv_timeout() {
+        Some(budget) => match conn.recv_with_timeout(budget).await {
+            Ok(opt) => CompileRecvOutcome::Done(opt),
+            Err(crate::ipc::IpcError::Timeout(_)) => CompileRecvOutcome::Wedged,
+            Err(e) => CompileRecvOutcome::Failed(format!("broken connection to daemon: {e}")),
+        },
+        None => match conn.recv().await {
+            Ok(opt) => CompileRecvOutcome::Done(opt),
+            Err(e) => CompileRecvOutcome::Failed(format!("broken connection to daemon: {e}")),
+        },
+    }
+}
+
+/// Tiny seam over the platform-specific IPC connection types so the
+/// wedge-detection helper can be unit-tested without spinning up a real
+/// pipe/socket. Two impls live below — one for Unix `IpcConnection`, one
+/// for the Windows client-side `IpcClientConnection`.
+trait ConnRecv {
+    async fn recv(&mut self) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError>;
+    async fn recv_with_timeout(
+        &mut self,
+        timeout: std::time::Duration,
+    ) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError>;
+}
+
+#[cfg(unix)]
+impl ConnRecv for crate::ipc::IpcConnection {
+    async fn recv(&mut self) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError> {
+        crate::ipc::IpcConnection::recv::<crate::protocol::Response>(self).await
+    }
+    async fn recv_with_timeout(
+        &mut self,
+        timeout: std::time::Duration,
+    ) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError> {
+        crate::ipc::IpcConnection::recv_with_timeout::<crate::protocol::Response>(self, timeout)
+            .await
+    }
+}
+
+#[cfg(windows)]
+impl ConnRecv for crate::ipc::IpcClientConnection {
+    async fn recv(&mut self) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError> {
+        crate::ipc::IpcClientConnection::recv::<crate::protocol::Response>(self).await
+    }
+    async fn recv_with_timeout(
+        &mut self,
+        timeout: std::time::Duration,
+    ) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError> {
+        crate::ipc::IpcClientConnection::recv_with_timeout::<crate::protocol::Response>(
+            self, timeout,
+        )
+        .await
+    }
 }
 
 /// Ephemeral session: single-roundtrip compile (session start + compile +
@@ -88,14 +183,28 @@ pub(super) async fn cmd_compile_ephemeral(
         return ExitCode::FAILURE;
     }
 
-    let recv_result = match conn.recv().await {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("zccache[err][R]: broken connection to daemon: {e}");
-            return ExitCode::FAILURE;
+    // Wedge detection only — no retry. CompileEphemeral is already on a
+    // fresh-daemon path (ensure_daemon ran above); if the daemon wedges
+    // mid-recv we surface a fast failure (~90 s instead of 300 s) so the
+    // build framework's per-job retry budget isn't blown.
+    match compile_recv_with_wedge_detection(&mut conn).await {
+        CompileRecvOutcome::Done(recv_result) => {
+            relay_compile_response(recv_result, &mut std::io::stdout(), &mut std::io::stderr())
         }
-    };
-    relay_compile_response(recv_result, &mut std::io::stdout(), &mut std::io::stderr())
+        CompileRecvOutcome::Wedged => {
+            eprintln!(
+                "zccache[err][W]: daemon at {endpoint} stopped responding within \
+                 the wedge budget; killing it so the next compile starts fresh — issue #666"
+            );
+            drop(conn);
+            stop_stale_daemon(endpoint).await;
+            ExitCode::FAILURE
+        }
+        CompileRecvOutcome::Failed(msg) => {
+            eprintln!("zccache[err][R]: {msg}");
+            ExitCode::FAILURE
+        }
+    }
 }
 
 /// Ephemeral link/archive: single-roundtrip for `zccache ar ...` etc.
@@ -132,14 +241,26 @@ pub(super) async fn cmd_link_ephemeral(
         return ExitCode::FAILURE;
     }
 
-    let recv_result = match conn.recv().await {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("zccache[err][R]: broken connection to daemon: {e}");
-            return ExitCode::FAILURE;
+    // Wedge detection only — see `cmd_compile_ephemeral` for the rationale.
+    match compile_recv_with_wedge_detection(&mut conn).await {
+        CompileRecvOutcome::Done(recv_result) => {
+            relay_link_response(recv_result, &mut std::io::stdout(), &mut std::io::stderr())
         }
-    };
-    relay_link_response(recv_result, &mut std::io::stdout(), &mut std::io::stderr())
+        CompileRecvOutcome::Wedged => {
+            eprintln!(
+                "zccache[err][W]: daemon at {endpoint} stopped responding within \
+                 the wedge budget on a Link; killing it so the next request starts \
+                 fresh — issue #666"
+            );
+            drop(conn);
+            stop_stale_daemon(endpoint).await;
+            ExitCode::FAILURE
+        }
+        CompileRecvOutcome::Failed(msg) => {
+            eprintln!("zccache[err][R]: {msg}");
+            ExitCode::FAILURE
+        }
+    }
 }
 
 fn relay_compile_response<W: Write, E: Write>(
@@ -244,6 +365,121 @@ mod tests {
         assert_eq!(exit, ExitCode::from(7));
         assert_eq!(stdout, b"compiler-out");
         assert_eq!(stderr, b"compiler-err");
+    }
+
+    // ── Issue #666: wedge-detection helper ──────────────────────────────
+    //
+    // Verifies that `compile_recv_with_wedge_detection`:
+    //   • returns `Done` on a normal response,
+    //   • returns `Wedged` only when the underlying recv times out,
+    //   • returns `Failed` (not `Wedged`) on a non-timeout transport error,
+    //   • respects the disabled (`secs == 0`) configuration.
+
+    struct FakeConn {
+        behavior: FakeBehavior,
+    }
+
+    #[allow(clippy::large_enum_variant)]
+    enum FakeBehavior {
+        Ok(crate::protocol::Response),
+        TimesOut,
+        BrokenPipe,
+    }
+
+    impl ConnRecv for FakeConn {
+        async fn recv(
+            &mut self,
+        ) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError> {
+            match &self.behavior {
+                FakeBehavior::Ok(r) => Ok(Some(r.clone())),
+                FakeBehavior::TimesOut => {
+                    // Sleep forever; the outer timeout wrapper handles it.
+                    futures::future::pending::<()>().await;
+                    unreachable!()
+                }
+                FakeBehavior::BrokenPipe => Err(crate::ipc::IpcError::ConnectionClosed),
+            }
+        }
+        async fn recv_with_timeout(
+            &mut self,
+            timeout: std::time::Duration,
+        ) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError> {
+            match &self.behavior {
+                FakeBehavior::Ok(r) => Ok(Some(r.clone())),
+                FakeBehavior::TimesOut => {
+                    tokio::time::sleep(timeout).await;
+                    Err(crate::ipc::IpcError::Timeout(timeout))
+                }
+                FakeBehavior::BrokenPipe => Err(crate::ipc::IpcError::ConnectionClosed),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn wedge_detection_returns_done_on_normal_response() {
+        // Use a short budget so the test stays snappy even if the fake regresses.
+        std::env::set_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS", "1");
+        let mut conn = FakeConn {
+            behavior: FakeBehavior::Ok(crate::protocol::Response::Pong),
+        };
+        let outcome = compile_recv_with_wedge_detection(&mut conn).await;
+        std::env::remove_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS");
+        assert!(matches!(
+            outcome,
+            CompileRecvOutcome::Done(Some(crate::protocol::Response::Pong))
+        ));
+    }
+
+    #[tokio::test]
+    async fn wedge_detection_returns_wedged_on_recv_timeout() {
+        // Force a 1 s budget so a wedged daemon surfaces within the test
+        // window. Pre-#666 this path inherited the 300 s global default and
+        // the whole build paid that wall × N workers.
+        std::env::set_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS", "1");
+        let mut conn = FakeConn {
+            behavior: FakeBehavior::TimesOut,
+        };
+        let started = std::time::Instant::now();
+        let outcome = compile_recv_with_wedge_detection(&mut conn).await;
+        let elapsed = started.elapsed();
+        std::env::remove_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS");
+        assert!(matches!(outcome, CompileRecvOutcome::Wedged));
+        assert!(
+            elapsed < std::time::Duration::from_secs(3),
+            "wedge detection took {elapsed:?} against a never-responding fake — \
+             issue #666 expects bounded fail-fast at the configured budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn wedge_detection_does_not_misclassify_broken_pipe_as_wedge() {
+        // A non-timeout transport error must NOT trigger the recovery path
+        // (force-killing the daemon on every protocol mismatch would be a
+        // worse cure than the disease).
+        std::env::set_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS", "1");
+        let mut conn = FakeConn {
+            behavior: FakeBehavior::BrokenPipe,
+        };
+        let outcome = compile_recv_with_wedge_detection(&mut conn).await;
+        std::env::remove_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS");
+        assert!(matches!(outcome, CompileRecvOutcome::Failed(_)));
+    }
+
+    #[tokio::test]
+    async fn wedge_detection_disabled_when_env_is_zero() {
+        // `ZCCACHE_WEDGE_RECV_TIMEOUT_SECS=0` opts back into the pre-#666
+        // unbounded recv (useful for huge LTO links that legitimately
+        // exceed the default budget). The fake's BrokenPipe path returns
+        // immediately so the test doesn't hang.
+        std::env::set_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS", "0");
+        let mut conn = FakeConn {
+            behavior: FakeBehavior::BrokenPipe,
+        };
+        let outcome = compile_recv_with_wedge_detection(&mut conn).await;
+        std::env::remove_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS");
+        // Disabled → falls through to `conn.recv()` unbounded, which the
+        // fake reports as a broken pipe. Crucially: not classified as Wedged.
+        assert!(matches!(outcome, CompileRecvOutcome::Failed(_)));
     }
 
     #[test]

--- a/crates/zccache/src/cli/mod.rs
+++ b/crates/zccache/src/cli/mod.rs
@@ -25,6 +25,39 @@ pub(crate) fn status_probe_timeout() -> std::time::Duration {
     std::time::Duration::from_secs(secs)
 }
 
+/// Default per-call timeout for Compile/Link recv before treating the daemon
+/// as wedged and triggering recovery (issue #666). Ninety seconds covers any
+/// reasonable single-TU compile (FastLED's heaviest unity-ish TU finishes
+/// well under 60 s on the slowest supported Windows runner) while bounding
+/// the per-worker wait when the daemon stops servicing the IPC. The pre-#666
+/// behavior was the 300 s global `DEFAULT_CLIENT_RECV_TIMEOUT`; under a wedge,
+/// every parallel ninja job paid the full window.
+///
+/// On timeout the wrapper force-kills the wedged daemon via
+/// `stop_stale_daemon`, ensures a fresh one is spawned, and retries the
+/// request exactly once on the fresh daemon. Subsequent ninja workers that
+/// queue up while the kill is in flight see no daemon at connect time and
+/// take the normal spawn path — so only one worker pays the recovery cost,
+/// not all 673.
+///
+/// Overridable via `ZCCACHE_WEDGE_RECV_TIMEOUT_SECS`; set to `0` to disable
+/// the wedge detection entirely and keep the historical 300 s behavior.
+const WEDGE_RECV_DEFAULT_SECS: u64 = 90;
+
+/// Returns the wedge-detection recv timeout for Compile/Link calls. `None`
+/// means "disabled" (the env var was set to `0`). See [`WEDGE_RECV_DEFAULT_SECS`].
+pub(crate) fn wedge_recv_timeout() -> Option<std::time::Duration> {
+    let secs = std::env::var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(WEDGE_RECV_DEFAULT_SECS);
+    if secs == 0 {
+        None
+    } else {
+        Some(std::time::Duration::from_secs(secs))
+    }
+}
+
 // Re-export daemon-lifecycle helpers moved to `runtime.rs` (issue #365 wave 6)
 // so the public API path is unchanged.
 #[allow(deprecated)]

--- a/crates/zccache/src/ipc/transport.rs
+++ b/crates/zccache/src/ipc/transport.rs
@@ -299,31 +299,148 @@ impl IpcListener {
         }
         #[cfg(windows)]
         {
-            use tokio::net::windows::named_pipe::ServerOptions;
+            self.accept_windows().await
+        }
+    }
 
-            // Pop the front pipe and wait for a client to connect.
-            let pipe = self
-                .inner
-                .pool
-                .pop_front()
-                .expect("pipe pool must not be empty");
-            pipe.connect().await?;
+    /// Windows named-pipe accept with pool-depletion recovery (issue #666).
+    ///
+    /// The pre-#666 implementation had two depletion paths:
+    /// 1. `pool.pop_front().expect(...)` panicked if the pool ever emptied.
+    /// 2. `ServerOptions::create(...)?` on the replacement leaked the popped
+    ///    pipe slot on every failure, silently shrinking the pool.
+    ///
+    /// Combined, a sustained period of transient `create` errors (handle
+    /// exhaustion under a 673-TU ninja burst, antivirus reentrancy, etc.)
+    /// would shrink the pool toward zero and eventually wedge the daemon
+    /// without crashing — every new client would queue on the dwindling
+    /// number of remaining `pipe.connect().await` calls and see the
+    /// CLI-side 300 s recv timeout.
+    ///
+    /// This implementation:
+    /// - Replaces the `pop_front().expect()` panic with an emergency create.
+    /// - Retries replacement creation with bounded backoff so a transient
+    ///   OS hiccup does not consume a pool slot.
+    /// - Treats a `connect()` failure as a normal accept retry rather than
+    ///   propagating it to the daemon's main loop (which would drop the
+    ///   slot the same way the old code did).
+    #[cfg(windows)]
+    async fn accept_windows(&mut self) -> Result<IpcConnection, IpcError> {
+        loop {
+            let pipe = match self.inner.pool.pop_front() {
+                Some(p) => p,
+                None => {
+                    // Pool depleted — every prior `create` retry failed and
+                    // the popped slot was never replaced. Try once more
+                    // synchronously; failure here is a real OS problem and
+                    // is propagated to the caller.
+                    tracing::warn!(
+                        endpoint = %self.inner.endpoint,
+                        "named-pipe pool exhausted — attempting emergency create (issue #666)"
+                    );
+                    create_replacement_pipe(&self.inner.endpoint)?
+                }
+            };
 
-            // Create a replacement instance and push to the back.
-            let replacement = ServerOptions::new()
-                .first_pipe_instance(false)
-                .create(&self.inner.endpoint)?;
-            self.inner.pool.push_back(replacement);
+            if let Err(e) = pipe.connect().await {
+                // The popped pipe is now dropped. Replenish the pool with a
+                // fresh instance (best-effort) and retry the accept so the
+                // daemon's main loop never sees a transient connect glitch.
+                tracing::warn!(
+                    endpoint = %self.inner.endpoint,
+                    error = %e,
+                    "named-pipe connect failed — replenishing and retrying"
+                );
+                if let Ok(replacement) = create_replacement_pipe(&self.inner.endpoint) {
+                    self.inner.pool.push_back(replacement);
+                }
+                continue;
+            }
+
+            // Connect succeeded. Try hard to create a replacement before we
+            // return so the pool stays full. If replacement creation fails
+            // even after retries, log loudly and proceed anyway — the next
+            // accept will hit the pool-depleted branch above instead of
+            // panicking.
+            match create_replacement_pipe_with_retry(&self.inner.endpoint).await {
+                Some(replacement) => self.inner.pool.push_back(replacement),
+                None => tracing::error!(
+                    endpoint = %self.inner.endpoint,
+                    "named-pipe replacement create failed after retries — \
+                     pool slot temporarily unfilled; next accept will recreate (issue #666)"
+                ),
+            }
 
             let (reader, writer) = tokio::io::split(pipe);
-            Ok(IpcConnection {
+            return Ok(IpcConnection {
                 reader,
                 writer,
                 read_buf: BytesMut::with_capacity(4096),
                 recv_timeout: None,
-            })
+            });
         }
     }
+
+    /// Test-only: pop every pipe out of the pool to simulate a deeply
+    /// depleted state. Used by `pool_recovers_from_full_depletion` to
+    /// exercise the issue #666 emergency-create path.
+    #[cfg(all(windows, test))]
+    pub(crate) fn test_drain_pool(&mut self) -> usize {
+        let drained = self.inner.pool.len();
+        self.inner.pool.clear();
+        drained
+    }
+}
+
+/// Issue #666: synchronous replacement pipe creation. Used by the emergency
+/// path when the pool is fully depleted.
+#[cfg(windows)]
+fn create_replacement_pipe(
+    endpoint: &str,
+) -> Result<tokio::net::windows::named_pipe::NamedPipeServer, IpcError> {
+    use tokio::net::windows::named_pipe::ServerOptions;
+    Ok(ServerOptions::new()
+        .first_pipe_instance(false)
+        .create(endpoint)?)
+}
+
+/// Issue #666: bounded-backoff retry around replacement creation. Returns
+/// `None` only after the full retry budget is exhausted; in that case the
+/// caller logs and proceeds without push-back so the pool slot is filled
+/// lazily on the next accept.
+///
+/// The backoff is deliberately short (5 ms → 80 ms over 5 attempts, ~155 ms
+/// total worst case) because we are blocking the daemon's accept loop while
+/// retrying — long enough to ride out a brief OS handle spike, short enough
+/// that the daemon doesn't appear wedged.
+#[cfg(windows)]
+async fn create_replacement_pipe_with_retry(
+    endpoint: &str,
+) -> Option<tokio::net::windows::named_pipe::NamedPipeServer> {
+    const ATTEMPTS: u32 = 5;
+    const INITIAL_DELAY_MS: u64 = 5;
+    const MAX_DELAY_MS: u64 = 80;
+
+    let mut delay_ms = INITIAL_DELAY_MS;
+    for attempt in 0..ATTEMPTS {
+        match create_replacement_pipe(endpoint) {
+            Ok(p) => return Some(p),
+            Err(e) => {
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    max_attempts = ATTEMPTS,
+                    error = %e,
+                    endpoint = %endpoint,
+                    "named-pipe replacement create retry"
+                );
+                if attempt + 1 < ATTEMPTS {
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                    delay_ms = (delay_ms * 2).min(MAX_DELAY_MS);
+                }
+            }
+        }
+    }
+    None
 }
 
 // ── Client connect ──────────────────────────────────────────────────
@@ -487,6 +604,42 @@ mod tests {
             Err(IpcError::Io(_)) => {}
             other => panic!("unexpected result: {other:?}"),
         }
+
+        server.await.unwrap();
+    }
+
+    /// Regression test for <https://github.com/zackees/zccache/issues/666>.
+    ///
+    /// The pre-#666 Windows accept path would `pop_front().expect(...)`-panic
+    /// the moment the pool ever depleted. After the fix, a fully drained pool
+    /// must recover via the emergency-create path on the next accept.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn pool_recovers_from_full_depletion() {
+        let endpoint = unique_test_endpoint();
+        let mut listener = IpcListener::bind(&endpoint).unwrap();
+
+        // Simulate the issue #666 wedge: pool is fully drained by repeated
+        // replacement-create failures (modelled here by an explicit drain).
+        let drained = listener.test_drain_pool();
+        assert!(drained > 0, "fresh listener should have pre-created pipes");
+
+        let server = tokio::spawn(async move {
+            // accept() on a drained pool must NOT panic — it must take the
+            // emergency-create path and serve the client.
+            let mut conn = listener.accept().await.expect("accept after drain");
+            let msg: Option<Request> = conn.recv().await.unwrap();
+            assert_eq!(msg, Some(Request::Ping));
+            conn.send(&Response::Pong).await.unwrap();
+        });
+
+        // The emergency create + connect handshake adds a few ms — give the
+        // server room to set up before the client connects.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let mut client = connect(&endpoint).await.unwrap();
+        client.send(&Request::Ping).await.unwrap();
+        let resp: Option<Response> = client.recv().await.unwrap();
+        assert_eq!(resp, Some(Response::Pong));
 
         server.await.unwrap();
     }


### PR DESCRIPTION
## Summary

Fixes the wedge from #666: a long-lived Windows daemon stopped responding mid-build and every parallel ninja worker paid the full 300 s `DEFAULT_CLIENT_RECV_TIMEOUT` wall before reporting `[FAILED]`. Recovery required manual `taskkill /F`.

Three layers:

- **Layer C — root cause**: `IpcListener::accept()` on Windows silently shrank the pre-created named-pipe pool whenever the replacement `ServerOptions::create(...)` returned `Err`. Sustained transient OS hiccups eventually depleted the pool, and `pool.pop_front().expect(...)` would panic. Replaced with a bounded-backoff retry around replacement creation, a `connect()`-failure retry loop, and an emergency-create fallback when the pool ever empties.
- **Layer A — recovery**: `cmd_compile` wraps the response recv in a configurable `wedge_recv_timeout` (default 90 s, env `ZCCACHE_WEDGE_RECV_TIMEOUT_SECS`, `0` disables). On timeout: force-kill the wedged daemon via the existing `stop_stale_daemon` helper (releases the pipe endpoint, unblocks other workers queued on `pipe.connect()`) and fall back to `cmd_compile_ephemeral` so the user's compile still succeeds. Only the first worker to hit the wedge pays the recovery cost.
- **Layer B — defense-in-depth**: `cmd_compile_ephemeral` and `cmd_link_ephemeral` get the same wedge detection (no retry — they're already on a fresh-daemon path).

Full hypothesis writeup: https://github.com/zackees/zccache/issues/666#issuecomment-4628443896

## Test plan

- [x] `soldr cargo test -p zccache --lib` — 1708 passed, 0 failed
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` — clean
- [x] `soldr cargo fmt --all` — clean
- [x] `pool_recovers_from_full_depletion` (new regression test): drains the pool fully and asserts accept still serves a client (would have panicked pre-fix)
- [x] `wedge_detection_*` × 4 (new regression tests): exhaustive table for the recv classifier — broken pipe MUST NOT trigger the recovery path
- [ ] Manual: reproduce the FastLED ninja-burst scenario under the new daemon and confirm the wedge no longer occurs (user-side validation — I cannot replicate the 1-hour-uptime timing locally on this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)