### PR TITLE
feat(ipc): application-layer back-pressure groundwork (Phase 1+2 partial)

### DIFF
--- a/crates/zccache/src/ipc/transport.rs
+++ b/crates/zccache/src/ipc/transport.rs
@@ -259,10 +259,24 @@ impl IpcListener {
             use std::collections::VecDeque;
             use tokio::net::windows::named_pipe::ServerOptions;
 
-            let pool_size = std::thread::available_parallelism()
-                .map(|n| n.get())
-                .unwrap_or(4)
-                .min(16);
+            // Pool sizing rationale (issue #666 follow-up, application-layer
+            // back-pressure precondition): the pre-existing `.min(16)` cap
+            // made the named-pipe accept queue the dominant bottleneck under
+            // a ninja burst of ~670 parallel TUs. The OS layer would return
+            // `ERROR_PIPE_BUSY` to clients before the daemon ever saw the
+            // request, which aliased "daemon overloaded" with "daemon dead"
+            // at the client. Raising the cap moves the bottleneck inside
+            // the daemon where it can be expressed as an in-band
+            // `Response::Backpressure` reply.
+            let pool_size = std::env::var("ZCCACHE_PIPE_POOL_SIZE")
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap_or_else(|| {
+                    std::thread::available_parallelism()
+                        .map(|n| n.get().saturating_mul(4))
+                        .unwrap_or(64)
+                        .clamp(16, 128)
+                });
 
             let mut pool = VecDeque::with_capacity(pool_size);
             for i in 0..pool_size {

--- a/crates/zccache/src/protocol/messages/mod.rs
+++ b/crates/zccache/src/protocol/messages/mod.rs
@@ -356,4 +356,28 @@ pub enum Response {
         /// Cache key, hex-encoded. Useful for diagnostics.
         cache_key_hex: String,
     },
+    /// Daemon is healthy but under sufficient internal pressure (queue depth,
+    /// lock contention, etc.) that it has chosen not to dispatch this request
+    /// right now. The client should sleep `retry_after_ms` and retry against
+    /// the same daemon — this is **not** a wedge signal, and the existing
+    /// Layer A/B/C wedge-recovery path should not fire on this response.
+    ///
+    /// Lets the daemon express overload in-band rather than letting the
+    /// transport layer alias overload with "daemon dead" via
+    /// `ERROR_PIPE_BUSY` or recv-timeout. See issue tracker for the
+    /// back-pressure design doc.
+    ///
+    /// NOTE: Appended at end to preserve bincode variant indices.
+    Backpressure {
+        /// Daemon's current queue depth at the moment of decision.
+        /// Diagnostic — the client treats this as advisory only.
+        queue_depth: u32,
+        /// How long the client should sleep before retrying, in milliseconds.
+        /// Includes server-side jitter; client may add its own.
+        retry_after_ms: u32,
+        /// Why the daemon back-pressured. Diagnostic — known reasons:
+        /// `"compile_queue_full"`, `"fp_lock_contention"`,
+        /// `"depgraph_lock_contention"`, `"resident_memory_high"`.
+        reason: String,
+    },
 }


### PR DESCRIPTION
**Draft — opening for design feedback, not ready to merge.** Phases 3-4 (daemon emission, client retry loop) are TODO; this PR holds Phase 1 (pool sizing) + Phase 2 protocol surface only.

## Problem

Under a parallel-build burst of ~670 TUs, the Windows named-pipe pool capped at `.min(16)` becomes the dominant bottleneck. Clients hit OS-level `ERROR_PIPE_BUSY` before the daemon ever sees the request, so "daemon overloaded" gets aliased with "daemon dead" at the client — every natural overload looks like a wedge and triggers the Layer A 90 s recv-timeout + force-kill recovery path from #669.

#669's recovery is the right safety net for **actual** wedges. This series prevents it from firing on **healthy-but-overloaded** daemons by moving the bottleneck inside the daemon where it can be expressed in-band.

## Design

- ACCEPT layer (this PR, Phase 1) — pool sized for expected burst (default cpu*4, clamp 16..=128, env override); goal: never reject at the OS layer
- DISPATCH layer (next PR, Phase 3) — daemon reads request, evaluates real pressure metric (queue depth, lock waits), emits Response::Backpressure with retry_after_ms hint on overload
- CLIENT layer (next PR, Phase 4) — honors retry_after_ms with jittered backoff and a budget; falls through to ephemeral compile on budget exhaustion

Properties this gives that the current design doesn't:

- Failure mode separates from load mode. "Daemon dead" = ECONNREFUSED from accept; "daemon busy" = explicit BACKPRESSURE response. The two errors stop being aliased.
- Adaptive client behavior. Retry budget moves from blind 50 retries / 12 s to honor what the daemon told the client.
- Smart throttling. The daemon's pressure metric can be the actual narrow resource (queue depth, fingerprint-cache lock wait), not an OS-layer proxy.

## This PR (Phase 1 + Phase 2 partial)

Phase 1 (transport.rs): `.min(16)` -> `clamp(cpu*4, 16..=128)` with `ZCCACHE_PIPE_POOL_SIZE` env override. cargo check clean.

Phase 2 (protocol/messages/mod.rs): New `Response::Backpressure { queue_depth, retry_after_ms, reason }` appended at end of the enum, following the existing convention (`FingerprintCheckResult`, `RustArtifactList`, `GenericToolExecResult`) so bincode variant indices stay stable for older clients.

## TODO (separate commits)

- Phase 3: Daemon dispatch reads queue depth, computes `retry_after_ms = ((depth - threshold) * 50).min(5000) + jitter(50)`, emits Backpressure when `depth > ZCCACHE_QUEUE_PRESSURE_THRESHOLD` (default 256).
- Phase 4: Client wrap path (`cli/commands/wrap/ipc.rs`) handles Backpressure: sleeps retry_after_ms, retries up to `ZCCACHE_BACKPRESSURE_MAX_RETRIES` (default 8), falls through to existing ephemeral path on budget exhaustion.
- Tests: serialization, retry-then-success, budget-exhaustion-fallback, daemon-emits-on-threshold, regression: does-not-misclassify-wedge.
- Version: 1.11.14 -> 1.12.0 once Phases 3-4 land.

## Co-existence with #669

Backpressure and wedge-recovery don't collide: Backpressure is an in-band response (instant), wedge requires 90 s of silence. A healthy-but-overloaded daemon sends Backpressure within the wedge window so Layer A never fires; a truly hung daemon sends nothing so Layer A fires as designed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
