### PR TITLE
chore(release): bump 1.11.14 -> 1.11.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.11.14"
+version = "1.11.15"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.11.14"
+version = "1.11.15"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.11.14"
+version = "1.11.15"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.11.14"
+version = "1.11.15"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.11.14"
+version = "1.11.15"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Patch release from current main so the wedge-recovery fix from #669 reaches PyPI.

## Context

- 1.11.14 was published 2026-06-04 23:24 UTC
- #669 (`fix(daemon): pipe-pool depletion + compile-path wedge recovery`) merged 2026-06-05 07:02 UTC — about 8 hours after 1.11.14 shipped
- Every 1.11.14 user is still seeing the steady-state daemon wedge described in #666 under heavy parallel-build load (~670 TUs), because the recovery layers from #669 ship in this release for the first time

## Verification this is a clean release

- No code changes in this PR — only `Cargo.toml` workspace version (1.11.14 -> 1.11.15) and the 4 matching `Cargo.lock` entries
- main HEAD includes the #669 merge — every commit since the 1.11.14 release is the merge of #669
- release-auto.yml triggers off the Cargo.toml `workspace.package.version` bump on push to main, so merging this PR auto-cuts the PyPI release

## What 1.11.15 includes vs 1.11.14

Just PR #669:
- Layer A (recovery): wrap path detects daemon wedge via configurable `wedge_recv_timeout` (default 90 s), force-kills the wedged daemon, falls back to ephemeral compile so the user's build completes
- Layer B (defense): same wedge detection on ephemeral paths but fast-fail (already on fresh-daemon path via ensure_daemon)
- Layer C (root-cause): `IpcListener::accept()` on Windows no longer silently shrinks the pre-created named-pipe pool on transient `ServerOptions::create()` failures. Bounded-backoff retry + emergency-create fallback when the pool ever empties. Replaces a panic with graceful recovery.

The back-pressure refactor proposed in #670 is intentionally not in 1.11.15 - that work is incomplete (Phase 1+2 partial; Phases 3-4 TODO) and warrants its own release cycle once Phases 3-4 land.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>