### PR TITLE
fix(cli): adaptive daemon-spawn wait keyed on lockfile PID (closes #673)

### DIFF
--- a/crates/zccache/src/cli/commands/daemon.rs
+++ b/crates/zccache/src/cli/commands/daemon.rs
@@ -85,13 +85,11 @@ pub(crate) async fn spawn_and_wait(endpoint: &str, reason: &str) -> Result<(), S
     );
     super::super::spawn_daemon(&daemon_bin, endpoint)?;
 
-    for _ in 0..100 {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        if connect(endpoint).await.is_ok() {
-            return Ok(());
-        }
-    }
-    Err("daemon started but not accepting connections after 10s".to_string())
+    // Adaptive wait keyed on the daemon-lifecycle lockfile PID (issue #673):
+    // the previous 100-iteration / 10 s loop expired under thundering-herd
+    // builds while individual ERROR_PIPE_BUSY backoffs were still in flight.
+    // The shared helper polls past 10 s as long as a daemon owns the lockfile.
+    super::super::wait_for_daemon_ready(endpoint).await
 }
 
 /// Stop a stale daemon that is unreachable or version-incompatible.

--- a/crates/zccache/src/cli/mod.rs
+++ b/crates/zccache/src/cli/mod.rs
@@ -65,7 +65,7 @@ pub(crate) fn wedge_recv_timeout() -> Option<std::time::Duration> {
 pub use runtime::{
     connect_client, ensure_daemon, gc_daemon_spawn_logs, gc_log_directory, gc_log_directory_in,
     gc_runtime_binaries, gc_runtime_binaries_in, prepare_daemon_exe, prepare_daemon_exe_in,
-    run_async, runtime_binaries_dir, spawn_daemon,
+    run_async, runtime_binaries_dir, spawn_daemon, wait_for_daemon_ready,
 };
 
 pub use crate::download_client::{

--- a/crates/zccache/src/cli/runtime.rs
+++ b/crates/zccache/src/cli/runtime.rs
@@ -100,13 +100,142 @@ async fn spawn_and_wait(endpoint: &str, reason: &str) -> Result<(), String> {
     );
     spawn_daemon(&daemon_bin, endpoint)?;
 
-    for _ in 0..100 {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    wait_for_daemon_ready(endpoint).await
+}
+
+/// Tunables for [`wait_for_daemon_ready_with`]. Defaults match the contract
+/// described in issue #673: keep waiting as long as a daemon process owns
+/// the lockfile, treat absence-of-lockfile as a spawn failure after a short
+/// grace period, and refuse to wait beyond a hard ceiling even with a live
+/// daemon (the daemon may be wedged).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AdaptiveWaitConfig {
+    pub poll_interval: std::time::Duration,
+    pub no_daemon_grace: std::time::Duration,
+    pub hard_ceiling: std::time::Duration,
+}
+
+impl Default for AdaptiveWaitConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: std::time::Duration::from_millis(100),
+            // Matches the pre-#673 10s budget for the cold-start case where
+            // the spawn itself fails before the daemon ever binds.
+            no_daemon_grace: std::time::Duration::from_secs(10),
+            // Safety net once a daemon has been observed alive. Issue #673
+            // reports individual ERROR_PIPE_BUSY backoffs taking 5+ seconds
+            // on Windows under a 32-deep thundering herd; 60 s gives the
+            // accept queue room to drain before declaring the daemon wedged.
+            hard_ceiling: std::time::Duration::from_secs(60),
+        }
+    }
+}
+
+/// Outcome of one poll of the adaptive ready-wait loop. Factored out so the
+/// timing decisions can be unit-tested without touching the real clock,
+/// filesystem lockfile, or IPC stack.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum WaitTick {
+    /// Daemon is still coming up; sleep another `poll_interval` and try again.
+    Pending,
+    /// A daemon was alive but a hard wall-clock ceiling was hit — declare
+    /// the daemon wedged so the caller can recover.
+    HardCeilingHit { observed_pid: Option<u32> },
+    /// Grace period elapsed without ever observing a daemon lockfile — the
+    /// `spawn_daemon` call most likely failed silently.
+    NoDaemonGracePassed,
+    /// A daemon previously owned the lockfile but it has since vanished —
+    /// the daemon crashed before draining its accept queue.
+    DaemonExited { pid: u32 },
+}
+
+/// Pure decision function: given the wall-clock state and the current /
+/// last-observed daemon lockfile PID, return what the wait loop should do
+/// next. Unit-tested in `mod tests` below; production callers go through
+/// [`wait_for_daemon_ready_with`].
+pub(crate) fn classify_wait_tick(
+    elapsed: std::time::Duration,
+    daemon_pid: Option<u32>,
+    last_observed_pid: Option<u32>,
+    cfg: &AdaptiveWaitConfig,
+) -> WaitTick {
+    if let Some(pid) = daemon_pid {
+        if elapsed >= cfg.hard_ceiling {
+            return WaitTick::HardCeilingHit {
+                observed_pid: Some(pid),
+            };
+        }
+        return WaitTick::Pending;
+    }
+    if let Some(pid) = last_observed_pid {
+        return WaitTick::DaemonExited { pid };
+    }
+    if elapsed >= cfg.no_daemon_grace {
+        return WaitTick::NoDaemonGracePassed;
+    }
+    WaitTick::Pending
+}
+
+/// Poll the daemon endpoint until either the connect succeeds or one of the
+/// failure modes from [`classify_wait_tick`] fires. Used by both
+/// `spawn_and_wait` call sites so they share a single timing contract.
+///
+/// Issue #673: replaces a flat 10 s, 100-iteration loop that expired under
+/// thundering-herd builds even when the daemon was alive and just slow to
+/// drain its Windows named-pipe accept queue.
+pub async fn wait_for_daemon_ready(endpoint: &str) -> Result<(), String> {
+    wait_for_daemon_ready_with(
+        endpoint,
+        crate::ipc::check_running_daemon,
+        AdaptiveWaitConfig::default(),
+    )
+    .await
+}
+
+/// Test seam for [`wait_for_daemon_ready`]: caller injects the lockfile
+/// check and timing config so unit tests can drive the loop without
+/// touching the real daemon-lock file or sleeping for real seconds.
+pub(crate) async fn wait_for_daemon_ready_with(
+    endpoint: &str,
+    daemon_alive_check: impl Fn() -> Option<u32>,
+    cfg: AdaptiveWaitConfig,
+) -> Result<(), String> {
+    let start = std::time::Instant::now();
+    let mut last_observed_pid: Option<u32> = None;
+    loop {
+        tokio::time::sleep(cfg.poll_interval).await;
         if connect_client(endpoint).await.is_ok() {
             return Ok(());
         }
+        let elapsed = start.elapsed();
+        let daemon_pid = daemon_alive_check();
+        if daemon_pid.is_some() {
+            last_observed_pid = daemon_pid;
+        }
+        match classify_wait_tick(elapsed, daemon_pid, last_observed_pid, &cfg) {
+            WaitTick::Pending => continue,
+            WaitTick::HardCeilingHit { observed_pid } => {
+                let pid_str = observed_pid
+                    .map(|p| p.to_string())
+                    .unwrap_or_else(|| "<unknown>".to_string());
+                return Err(format!(
+                    "daemon process {pid_str} still not accepting connections after {}s (hard cap)",
+                    cfg.hard_ceiling.as_secs()
+                ));
+            }
+            WaitTick::NoDaemonGracePassed => {
+                return Err(format!(
+                    "no daemon lockfile observed within {}s of spawn (spawn likely failed)",
+                    cfg.no_daemon_grace.as_secs()
+                ));
+            }
+            WaitTick::DaemonExited { pid } => {
+                return Err(format!(
+                    "daemon process {pid} exited before accepting connections"
+                ));
+            }
+        }
     }
-    Err("daemon started but not accepting connections after 10s".to_string())
 }
 
 /// Stop a stale daemon that is unreachable or version-incompatible.
@@ -525,4 +654,124 @@ pub fn spawn_daemon(bin: &Path, endpoint: &str) -> Result<(), String> {
     running_process::spawn_daemon(&mut cmd)
         .map(|_child| ())
         .map_err(|e| format!("failed to spawn daemon (sanitized): {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    fn cfg(grace_ms: u64, ceiling_ms: u64, poll_ms: u64) -> AdaptiveWaitConfig {
+        AdaptiveWaitConfig {
+            poll_interval: Duration::from_millis(poll_ms),
+            no_daemon_grace: Duration::from_millis(grace_ms),
+            hard_ceiling: Duration::from_millis(ceiling_ms),
+        }
+    }
+
+    // Bogus endpoint that connect_client cannot bind to on either platform.
+    // Unix: a nonexistent socket path. Windows: a nonexistent named pipe.
+    fn dead_endpoint() -> &'static str {
+        if cfg!(windows) {
+            r"\\.\pipe\zccache-test-issue-673-dead"
+        } else {
+            "/tmp/zccache-test-issue-673-dead.sock"
+        }
+    }
+
+    // -- classify_wait_tick (pure decision function) -----------------------
+
+    #[test]
+    fn pending_when_daemon_visible_and_below_hard_ceiling() {
+        let c = cfg(1_000, 5_000, 100);
+        let tick = classify_wait_tick(Duration::from_millis(500), Some(42), Some(42), &c);
+        assert_eq!(tick, WaitTick::Pending);
+    }
+
+    #[test]
+    fn hard_ceiling_hit_only_when_daemon_visible() {
+        let c = cfg(1_000, 5_000, 100);
+        let tick = classify_wait_tick(Duration::from_millis(5_000), Some(42), Some(42), &c);
+        assert_eq!(
+            tick,
+            WaitTick::HardCeilingHit {
+                observed_pid: Some(42)
+            }
+        );
+    }
+
+    #[test]
+    fn daemon_exited_when_previously_observed_then_gone() {
+        let c = cfg(1_000, 5_000, 100);
+        let tick = classify_wait_tick(Duration::from_millis(200), None, Some(42), &c);
+        assert_eq!(tick, WaitTick::DaemonExited { pid: 42 });
+    }
+
+    #[test]
+    fn no_daemon_grace_passed_when_never_observed_and_grace_elapsed() {
+        let c = cfg(1_000, 5_000, 100);
+        let tick = classify_wait_tick(Duration::from_millis(1_000), None, None, &c);
+        assert_eq!(tick, WaitTick::NoDaemonGracePassed);
+    }
+
+    #[test]
+    fn pending_when_never_observed_but_grace_still_running() {
+        let c = cfg(1_000, 5_000, 100);
+        let tick = classify_wait_tick(Duration::from_millis(500), None, None, &c);
+        assert_eq!(tick, WaitTick::Pending);
+    }
+
+    // -- wait_for_daemon_ready_with (drives the loop with mock predicate) --
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn returns_grace_error_when_no_lockfile_ever_observed() {
+        // Tight grace + ceiling so the test resolves in well under a second.
+        let c = cfg(150, 5_000, 25);
+        let err = wait_for_daemon_ready_with(dead_endpoint(), || None, c)
+            .await
+            .expect_err("no-daemon path must fail, not hang");
+        assert!(
+            err.contains("no daemon lockfile observed"),
+            "wrong error: {err}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn returns_hard_ceiling_error_when_daemon_visible_but_unreachable() {
+        // Daemon always-alive (mock returns Some), but no real socket → IPC
+        // connect keeps failing → we hit the hard ceiling.
+        let c = cfg(5_000, 200, 25);
+        let err = wait_for_daemon_ready_with(dead_endpoint(), || Some(12_345), c)
+            .await
+            .expect_err("hard ceiling path must fail, not hang");
+        assert!(err.contains("hard cap"), "wrong error: {err}");
+        assert!(err.contains("12345"), "PID should appear: {err}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn returns_daemon_exited_error_when_lockfile_disappears() {
+        // First poll observes the daemon, every subsequent poll says None.
+        // The loop must exit with DaemonExited, not hit the grace timeout.
+        let polls = Arc::new(AtomicU32::new(0));
+        let c = cfg(10_000, 10_000, 25);
+        let polls_for_check = Arc::clone(&polls);
+        let err = wait_for_daemon_ready_with(
+            dead_endpoint(),
+            move || {
+                let n = polls_for_check.fetch_add(1, Ordering::SeqCst);
+                if n == 0 {
+                    Some(99_999)
+                } else {
+                    None
+                }
+            },
+            c,
+        )
+        .await
+        .expect_err("daemon-exit path must fail, not hang");
+        assert!(err.contains("exited"), "wrong error: {err}");
+        assert!(err.contains("99999"), "PID should appear: {err}");
+    }
 }

--- a/crates/zccache/src/cli/runtime.rs
+++ b/crates/zccache/src/cli/runtime.rs
@@ -177,7 +177,8 @@ pub(crate) fn classify_wait_tick(
 }
 
 /// Poll the daemon endpoint until either the connect succeeds or one of the
-/// failure modes from [`classify_wait_tick`] fires. Used by both
+/// adaptive failure modes (no-lockfile grace expired, observed daemon
+/// exited, or hard wall-clock ceiling reached) fires. Used by both
 /// `spawn_and_wait` call sites so they share a single timing contract.
 ///
 /// Issue #673: replaces a flat 10 s, 100-iteration loop that expired under


### PR DESCRIPTION
## Summary

Fixes #673. Under fbuild's parallel compile (esp32s3 Blink, ~600 TUs), 32 zccache CLI processes simultaneously raced `ensure_daemon`. Most deferred gracefully via the #637/#639 discriminator, but the survivor polled the endpoint for a flat 10 s — short enough that individual `ERROR_PIPE_BUSY` backoffs (5+ s under herd conditions on Windows) consumed the entire budget before a single probe succeeded. The CLI then surfaced `daemon started but not accepting connections after 10s` even though the daemon was live and just slow to drain its accept queue, and the whole build aborted.

The fix replaces the flat 100-iteration / 10 s loop in both `spawn_and_wait` call sites with a single shared helper that keys the wait on the daemon-lifecycle lockfile PID, matching the [first ask in the issue](https://github.com/zackees/zccache/issues/673):

> Bump `spawn_and_wait` budget OR make it adaptive. 10 s is fine for steady state; under the observed thundering herd, individual probes can take 5+ s on their own. Suggested: poll until either the connect succeeds or the daemon-lifecycle lockfile PID exits — whichever comes first — with no hard wall-clock cap as long as the lockfile PID is alive.

## What changed

- New `wait_for_daemon_ready` helper in `cli/runtime.rs` that polls the endpoint while a daemon owns the lockfile, up to a 60 s hard ceiling that catches a daemon that bound but wedged before draining its accept pool.
- If the lockfile never appears within a 10 s grace window, fail fast (preserves the previous "spawn likely failed" semantics for the cold-start case).
- If a daemon was observed alive but the lockfile then vanishes, fail with a distinct error (`daemon process <pid> exited before accepting connections`) so callers can distinguish "raced and lost" from "genuinely broken".
- Both `spawn_and_wait` call sites (`cli/runtime.rs` and `cli/commands/daemon.rs`) now route through the shared helper.
- Pure decision logic lives in `classify_wait_tick(elapsed, daemon_pid, last_observed_pid, &cfg) -> WaitTick` so the timing contract is unit-testable without touching the real clock, lockfile, or IPC stack.

## Out of scope

The other asks in #673 are intentionally separate fixes:
- **CLI-side spawn-race coordination** (`#673 ask 2`) — needs a CLI-side mutex/lockfile design pass before 32 processes decide to spawn simultaneously.
- **Typed retry-vs-fatal error** (`#673 ask 3`) — needs a public error-type addition for downstream consumers like fbuild.
- **Orphan-process cleanup** (`#673 ask 4`) — needs separate investigation of the 16 `zccache.exe` workers that survived the failed run.

## Test plan

- [x] 8 new unit tests in `cli::runtime::tests` covering the full state machine:
  - `pending_when_daemon_visible_and_below_hard_ceiling`
  - `hard_ceiling_hit_only_when_daemon_visible`
  - `daemon_exited_when_previously_observed_then_gone`
  - `no_daemon_grace_passed_when_never_observed_and_grace_elapsed`
  - `pending_when_never_observed_but_grace_still_running`
  - `returns_grace_error_when_no_lockfile_ever_observed` (drives the real loop)
  - `returns_hard_ceiling_error_when_daemon_visible_but_unreachable`
  - `returns_daemon_exited_error_when_lockfile_disappears`
- [x] `soldr cargo test -p zccache --lib cli::` → 141 passed, 0 failed.
- [x] `soldr cargo clippy -p zccache --lib --tests -- -D warnings` clean.
- [x] `soldr cargo fmt --all -- --check` clean.
- [x] `soldr cargo check --workspace --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)