### PR TITLE
chore(release): bump 1.11.15 -> 1.11.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.11.15"
+version = "1.11.16"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.11.15"
+version = "1.11.16"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.11.15"
+version = "1.11.16"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.11.15"
+version = "1.11.16"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.11.15"
+version = "1.11.16"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Patch release shipping the thundering-herd daemon-spawn fix from #674 (closes #673) so fbuild's parallel esp32s3 builds stop failing on `daemon started but not accepting connections after 10s`.

## What 1.11.16 includes vs 1.11.15

Just PR #674:

- `cli/runtime::spawn_and_wait` and `cli/commands/daemon::spawn_and_wait` no longer poll on a flat 10 s / 100-iteration loop. They now route through a shared `wait_for_daemon_ready` helper that keys the wait on the daemon-lifecycle lockfile PID:
  - keep polling up to a 60 s hard ceiling while a daemon owns the lockfile (handles the Windows `ERROR_PIPE_BUSY` backoff that consumes 5+ s under a 32-deep herd in fbuild esp32s3 Blink);
  - fail fast (preserved 10 s grace) if no lockfile ever appears (spawn most likely failed);
  - fail with a distinct error if a daemon was observed alive but the lockfile then vanishes (daemon crashed mid-startup).
- Eight new unit tests in `cli::runtime::tests` cover the pure decision function `classify_wait_tick` and the full end-to-end loop with a mock lockfile predicate.

The other asks in #673 (CLI-side spawn-race coordination, typed retry-vs-fatal errors, orphan-process cleanup) are tracked for follow-up PRs and not in this release.

## Verification this is a clean release

- No code changes in this PR — only `Cargo.toml` workspace version (1.11.15 -> 1.11.16) and the 4 matching `Cargo.lock` entries.
- main HEAD includes the #674 merge — every commit since 1.11.15 is the #674 merge.
- `release-auto.yml` triggers off the `Cargo.toml` `[workspace.package].version` bump on push to main, so merging this PR auto-cuts the PyPI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)