### PR TITLE
docs(cli): surface ZCCACHE_PATH_REMAP in `zccache --help` (refs #672)

### DIFF
--- a/crates/zccache/src/cli/commands/args.rs
+++ b/crates/zccache/src/cli/commands/args.rs
@@ -4,9 +4,24 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
+/// Environment-variable reference appended to the top-level `--help` output.
+/// Surfaced here so settings that are only readable from `std::env` (i.e. not
+/// modeled as clap flags) are discoverable without grepping the README.
+/// Issue #672 called out `ZCCACHE_PATH_REMAP` as the specific offender; the
+/// other entries are the smaller set users actually flip in practice.
+const ENV_VARS_HELP: &str = "\
+Environment variables:
+  ZCCACHE_PATH_REMAP=auto       Inject compiler path-prefix maps so cached
+                                artifacts are sharable across sibling clones /
+                                worktrees. Opt-in; default is off. See README
+                                'Path remapping' for guarantees and pitfalls.
+  ZCCACHE_STRICT_PATHS=MODE     Same as --strict-paths (off | consistent | absolute).
+  ZCCACHE_CACHE_DIR=PATH        Override the per-user cache root.
+";
+
 /// zccache -- fast local compiler cache.
 #[derive(Debug, Parser)]
-#[command(name = "zccache", version, about)]
+#[command(name = "zccache", version, about, after_help = ENV_VARS_HELP)]
 pub(crate) struct Cli {
     /// Clear the entire artifact cache (same as `zccache clear`).
     #[arg(long)]

--- a/crates/zccache/src/cli/commands/tests/args_parsing.rs
+++ b/crates/zccache/src/cli/commands/tests/args_parsing.rs
@@ -377,3 +377,26 @@ fn known_subcommands_matches_clap_enum() {
         stale,
     );
 }
+
+/// Lock in that the top-level `--help` output mentions the env vars users
+/// most often need to discover from the CLI. Issue #672 surfaced the gap
+/// for `ZCCACHE_PATH_REMAP` specifically — it has no clap flag, so without
+/// the `after_help` block there is no way to learn about it short of
+/// reading the README.
+#[test]
+fn top_level_help_lists_discoverable_env_vars() {
+    use clap::CommandFactory;
+    let help = Cli::command().render_help().to_string();
+    for var in [
+        "ZCCACHE_PATH_REMAP",
+        "ZCCACHE_STRICT_PATHS",
+        "ZCCACHE_CACHE_DIR",
+    ] {
+        assert!(
+            help.contains(var),
+            "`zccache --help` no longer mentions {var}. \
+             If the env var was renamed or removed, update args.rs::ENV_VARS_HELP; \
+             do not silently drop it (issue #672)."
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Refs #672. The issue's first ask:

> **Is `path_remap` opt-in?** If yes, what is the env var / CLI flag / config knob to turn it on (no `path_remap` mention in `zccache --help` / `zccache wrap --help`)?

Today there is genuinely no on-CLI breadcrumb to `ZCCACHE_PATH_REMAP`, even though that single env var is what decides whether cross-clone / cross-worktree compiles share cache entries. Users who see foreign-clone paths in their session-log diagnostics have to grep the README to find out it's a tunable.

This PR adds a `clap` `after_help` block to the top-level `Cli` that surfaces the small set of env vars users actually flip in practice:

- `ZCCACHE_PATH_REMAP=auto` — opt-in path remapping
- `ZCCACHE_STRICT_PATHS=MODE` — same as `--strict-paths` (off / consistent / absolute)
- `ZCCACHE_CACHE_DIR=PATH` — override the per-user cache root

Each entry is one or two lines and points at the README for full semantics; the goal is **discoverability from the CLI**, not duplicating the README.

## Test plan

- [x] New unit test `top_level_help_lists_discoverable_env_vars` renders `Cli::command().render_help()` and asserts each env var name appears. A future refactor that drops the `after_help` (or silently renames a var) breaks the build.
- [x] `soldr cargo test -p zccache --lib args_parsing::top_level_help_lists_discoverable_env_vars` → pass.
- [x] `soldr cargo clippy -p zccache --lib --tests -- -D warnings` clean.
- [x] `soldr cargo fmt --all -- --check` clean.

## Scope note

This addresses only the first triage ask in #672. The other two questions — whether pre-fix cache entries are auto-invalidated on upgrade, and whether prefix-map flags scrub diagnostic stderr at hit time — still need the issue author's decision on which experiment to run, and are intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)