### PR TITLE
chore(release): bump 1.11.16 -> 1.11.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.11.16"
+version = "1.11.17"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.11.16"
+version = "1.11.17"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.11.16"
+version = "1.11.17"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.11.16"
+version = "1.11.17"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.11.16"
+version = "1.11.17"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Patch release shipping the CLI env-var discoverability fix from #676 (refs #672) so `zccache --help` surfaces `ZCCACHE_PATH_REMAP` and two other commonly-flipped env vars.

## What 1.11.17 includes vs 1.11.16

Just PR #676:

- New `after_help` block on the top-level `Cli` lists discoverable env vars: `ZCCACHE_PATH_REMAP`, `ZCCACHE_STRICT_PATHS`, `ZCCACHE_CACHE_DIR`. Each entry points at the README for full semantics — the goal is "discoverability from the CLI", not duplicating the README.
- New unit test `top_level_help_lists_discoverable_env_vars` locks the contract: a future refactor that drops the after_help block (or silently renames a var) breaks the build.

## Verification this is a clean release

- No code changes in this PR — only `Cargo.toml` workspace version (1.11.16 -> 1.11.17) and the 4 matching `Cargo.lock` entries.
- main HEAD includes the #676 merge — every commit since 1.11.16 is the #676 merge.
- `release-auto.yml` triggers off the `Cargo.toml` `[workspace.package].version` bump on push to main, so merging this PR auto-cuts the PyPI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)