### PR TITLE
fix(cli): drop misleading 'protocol version mismatch' hint from lost-connection message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.11.17"
+version = "1.11.18"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.11.17"
+version = "1.11.18"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.11.17"
+version = "1.11.18"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.11.17"
+version = "1.11.18"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.11.17"
+version = "1.11.18"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/crates/zccache/src/cli/commands/cache_ops.rs
+++ b/crates/zccache/src/cli/commands/cache_ops.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use super::super::snapshot_fp;
-use super::util::{connect, format_bytes};
+use super::util::{connect, format_bytes, LOST_CONNECTION_MSG};
 
 pub(crate) async fn cmd_clear(endpoint: &str) -> ExitCode {
     let mut conn = match connect(endpoint).await {
@@ -46,7 +46,7 @@ pub(crate) async fn cmd_clear(endpoint: &str) -> ExitCode {
             ExitCode::SUCCESS
         }
         None => {
-            eprintln!("zccache[err][R]: lost connection to daemon (no response). Often a daemon-CLI protocol version mismatch — try `zccache stop`");
+            eprintln!("{LOST_CONNECTION_MSG}");
             ExitCode::FAILURE
         }
         Some(other) => {

--- a/crates/zccache/src/cli/commands/daemon.rs
+++ b/crates/zccache/src/cli/commands/daemon.rs
@@ -4,7 +4,7 @@ use crate::core::NormalizedPath;
 use std::process::ExitCode;
 
 use super::super::status_probe_timeout;
-use super::util::{connect, resolve_endpoint, run_async};
+use super::util::{connect, resolve_endpoint, run_async, LOST_CONNECTION_MSG};
 
 pub(crate) enum VersionCheck {
     Ok,
@@ -339,7 +339,7 @@ pub(crate) async fn cmd_stop(endpoint: &str) -> ExitCode {
             ExitCode::SUCCESS
         }
         None => {
-            eprintln!("zccache[err][R]: lost connection to daemon (no response). Often a daemon-CLI protocol version mismatch — try `zccache stop`");
+            eprintln!("{LOST_CONNECTION_MSG}");
             ExitCode::FAILURE
         }
         Some(other) => {

--- a/crates/zccache/src/cli/commands/session.rs
+++ b/crates/zccache/src/cli/commands/session.rs
@@ -7,7 +7,9 @@ use std::process::ExitCode;
 
 use super::super::session_end_idempotent;
 use super::daemon::ensure_daemon;
-use super::util::{connect, format_duration_ms, print_json_value, resolve_endpoint};
+use super::util::{
+    connect, format_duration_ms, print_json_value, resolve_endpoint, LOST_CONNECTION_MSG,
+};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SessionStartPrivateOptions {
@@ -203,7 +205,7 @@ pub(crate) async fn cmd_session_start(
             ExitCode::FAILURE
         }
         None => {
-            eprintln!("zccache[err][R]: lost connection to daemon (no response). Often a daemon-CLI protocol version mismatch — try `zccache stop`");
+            eprintln!("{LOST_CONNECTION_MSG}");
             ExitCode::FAILURE
         }
         Some(other) => {
@@ -313,7 +315,7 @@ pub(crate) async fn cmd_session_stats(endpoint: &str, session_id: String, json: 
             ExitCode::FAILURE
         }
         None => {
-            let message = "zccache[err][R]: lost connection to daemon (no response). Often a daemon-CLI protocol version mismatch — try `zccache stop`";
+            let message = LOST_CONNECTION_MSG;
             if json {
                 print_session_stats_error_json(&session_id, message);
             } else {
@@ -498,6 +500,6 @@ pub(crate) async fn query_session_stats(
         Some(crate::protocol::Response::SessionStatsResult { stats }) => Ok(stats),
         Some(crate::protocol::Response::Error { message }) => Err(message),
         Some(other) => Err(format!("unexpected daemon response: {other:?}")),
-        None => Err("lost connection to daemon (no response). Often a daemon-CLI protocol version mismatch — try `zccache stop`".to_string()),
+        None => Err(LOST_CONNECTION_MSG.to_string()),
     }
 }

--- a/crates/zccache/src/cli/commands/status.rs
+++ b/crates/zccache/src/cli/commands/status.rs
@@ -2,7 +2,9 @@
 
 use std::process::ExitCode;
 
-use super::util::{connect, format_bytes, format_duration_ms, format_uptime, print_json_value};
+use super::util::{
+    connect, format_bytes, format_duration_ms, format_uptime, print_json_value, LOST_CONNECTION_MSG,
+};
 
 pub(crate) async fn cmd_status(endpoint: &str, json: bool) -> ExitCode {
     let mut conn = match connect(endpoint).await {
@@ -151,7 +153,7 @@ pub(crate) async fn cmd_status(endpoint: &str, json: bool) -> ExitCode {
             ExitCode::SUCCESS
         }
         None => {
-            let message = "zccache[err][R]: lost connection to daemon (no response). Often a daemon-CLI protocol version mismatch — try `zccache stop`";
+            let message = LOST_CONNECTION_MSG;
             if json {
                 print_status_error_json(endpoint, message);
             } else {

--- a/crates/zccache/src/cli/commands/util.rs
+++ b/crates/zccache/src/cli/commands/util.rs
@@ -169,6 +169,17 @@ pub(crate) fn init_tracing() {
         .init();
 }
 
+/// User-facing message for the `Ok(None)` recv path — daemon closed the
+/// pipe cleanly without sending a Response frame.
+///
+/// The legacy text led with "daemon-CLI protocol version mismatch", which
+/// was misleading: the thundering-herd window that produced this symptom
+/// for FastLED's `clud-pr` parallel builds was fixed in 1.11.16 (#674)
+/// and the pipe-pool wedge in 1.11.15 (#669). With those gone, the
+/// remaining causes are an external `zccache stop`/kill mid-request or a
+/// genuine daemon crash — point users at `zccache status` first.
+pub(crate) const LOST_CONNECTION_MSG: &str = "zccache[err][R]: lost connection to daemon (no response). The daemon may have crashed or been killed mid-request — run `zccache status` to check, or `zccache stop` then retry to restart it.";
+
 pub(crate) fn print_json_value(value: &serde_json::Value) {
     match serde_json::to_string_pretty(value) {
         Ok(s) => println!("{s}"),

--- a/crates/zccache/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache/src/cli/commands/wrap/ipc.rs
@@ -7,7 +7,7 @@ use std::process::ExitCode;
 
 use super::super::super::wedge_recv_timeout;
 use super::super::daemon::{ensure_daemon, stop_stale_daemon};
-use super::super::util::{connect, exit_code_from_i32, slurp_stdin_if_piped};
+use super::super::util::{connect, exit_code_from_i32, slurp_stdin_if_piped, LOST_CONNECTION_MSG};
 
 pub(super) async fn cmd_compile(
     endpoint: &str,
@@ -284,10 +284,7 @@ fn relay_compile_response<W: Write, E: Write>(
             ExitCode::FAILURE
         }
         None => {
-            let _ = writeln!(
-                stderr,
-                "zccache[err][R]: lost connection to daemon (no response). Often a daemon-CLI protocol version mismatch - try `zccache stop`"
-            );
+            let _ = writeln!(stderr, "{LOST_CONNECTION_MSG}");
             ExitCode::FAILURE
         }
         Some(other) => {
@@ -325,10 +322,7 @@ fn relay_link_response<W: Write, E: Write>(
             ExitCode::FAILURE
         }
         None => {
-            let _ = writeln!(
-                stderr,
-                "zccache[err][R]: lost connection to daemon (no response). Often a daemon-CLI protocol version mismatch - try `zccache stop`"
-            );
+            let _ = writeln!(stderr, "{LOST_CONNECTION_MSG}");
             ExitCode::FAILURE
         }
         Some(other) => {


### PR DESCRIPTION
fix(cli): drop misleading "protocol version mismatch" hint from lost-connection message

The user-facing daemon hangup message historically read:

  zccache[err][R]: lost connection to daemon (no response). Often
  a daemon-CLI protocol version mismatch — try `zccache stop`

That hint was misleading. The actual cause of `Ok(None) => Err(...)`
on the CLI's recv path is the daemon closing its side of the pipe
without sending a Response frame. The two real-world triggers that
produced this signal in FastLED's `clud-pr` parallel builds were:

  - thundering-herd "daemon started but not accepting connections
    after 10s" wedge — fixed in 1.11.16 (#674, closes #673)
  - pipe-pool depletion / compile-path wedge after ~1h uptime on
    Windows — fixed in 1.11.15 (#669, refs #666)

With both fixes shipped, the remaining real causes are an external
`zccache stop` or kill mid-request, or a genuine daemon crash —
neither of which is "protocol version mismatch".

Centralize the user-facing copy in `util::LOST_CONNECTION_MSG` and
update all 7 call sites (`cache_ops`, `daemon`, `session` ×3,
`status`, `wrap/ipc` ×2) to use it. The new copy points users at
`zccache status` first, then a stop+retry recovery.

The lower-level `Ok(None) => Err("lost connection to daemon (no
response received)")` strings inside `client.rs` are left alone —
they don't carry the misleading hint, and they're internal Result
strings consumed by other layers, not user-facing.

Refs FastLED#2889, zccache#666, zccache#673.
