### PR TITLE
docs(readme): explain cached-stderr cross-worktree leak (closes #672)

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,26 @@ A few things worth knowing:
   benchmarks (introduced in #238) confirm warm-state hits across sibling
   worktrees run an order of magnitude faster than bare compiles and sccache
   even though sccache cannot share across sibling roots at all.
+- Cached diagnostics follow the same toggle. zccache caches the compiler's
+  stdout and stderr alongside the object payload and replays them verbatim on
+  every hit. With `ZCCACHE_PATH_REMAP=auto`, the original compile sees the
+  injected `-ffile-prefix-map` flags, so the cached diagnostics are already
+  worktree-neutral and survive being served to a sibling clone cleanly. With
+  `ZCCACHE_PATH_REMAP=off` (the default), the compiler emits absolute paths
+  into stderr — for example, a warning whose include trace points at
+  `C:\Users\me\dev\fastled5\src\...` — and those bytes are what every
+  cross-worktree hit replays into the new build. The `.obj` machine code
+  itself is still scrubbed by the #474/#489 fixes for the non-`auto` case
+  (per-worktree salting for PCH/MSVC; absolute paths in C/C++ debug info
+  only land when their flags are missing), so the contamination is cosmetic:
+  confusing diagnostics, never wrong code generation. Set
+  `ZCCACHE_PATH_REMAP=auto` to clean diagnostics at the source, or run
+  `zccache clear` after upgrading past 1.11.9 to drop pre-fix entries that
+  were captured before the per-worktree salting (#474, shipped in 1.11.8)
+  and request-cache scoping (#489, shipped in 1.11.9) landed — those entries
+  are still served as cross-worktree hits and carry their original-clone
+  paths in both the diagnostic stream and (for PCH/MSVC) the artifact bytes
+  themselves.
 
 ### Strict path validation
 


### PR DESCRIPTION
## Summary

Closes #672 — the open follow-up to #474 / #489. The user reported that even after both PRs shipped in 1.11.15, foreign-clone paths still surfaced in compiler diagnostic output on a sibling-checkout Windows build. They posed three questions: (1) is `path_remap` opt-in?, (2) does the fix invalidate pre-fix cache entries on upgrade?, (3) is the diagnostic-output path surface covered by the same prefix-map fix as the `.obj` machine code?

PR #676 already documented (1) by surfacing `ZCCACHE_PATH_REMAP=auto` in `zccache --help`. This PR closes the loop on (2) and (3) in the README's existing "Worktree cache sharing" section.

The answer to (3) is: **no, it's a separate code path — by design.** zccache caches stdout/stderr alongside the artifact bytes and replays them verbatim on every hit. The `-ffile-prefix-map` injection only fires on the original compile under `ZCCACHE_PATH_REMAP=auto`; with the default `off`, the compiler emits absolute paths into stderr, and those bytes are what every cross-worktree hit replays. The artifact bytes themselves are already scrubbed by #474 (per-worktree salt for PCH/MSVC) so the leak is **cosmetic** — confusing diagnostics, never wrong code generation.

The answer to (2) is captured in the same bullet: `zccache clear` after upgrading past 1.11.9 evicts any pre-#478 / pre-#511 entries that were captured before the salting and request-cache scoping landed.

## Test plan

- [x] No code changes — README only.
- [x] `git diff` reviewed: single new bullet appended to the "A few things worth knowing" list under "Worktree cache sharing"; no other surface touched.
- [ ] User-side validation by the maintainer (the issue reporter): re-read the bullet, confirm it accurately reflects their understanding of the surface. The doc text is reversible — happy to iterate on the wording if the framing is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)