### PR TITLE
fix(daemon): invalidate depgraph contexts on disk artifact eviction (closes #680)

### DIFF
--- a/crates/zccache/src/daemon/eviction.rs
+++ b/crates/zccache/src/daemon/eviction.rs
@@ -207,11 +207,21 @@ struct DiskArtifact {
 ///
 /// Also removes the corresponding in-memory `DashMap` entries.
 ///
+/// **Issue #680**: when `dep_graph` is `Some`, after the artifact eviction
+/// pass completes, every depgraph context whose `artifact_key` matches an
+/// evicted artifact gets its key cleared via
+/// [`DepGraph::invalidate_artifact_keys`]. Without this, the depgraph keeps
+/// pointing at the now-evicted artifact and the next compile reports
+/// `verdict=Hit` followed by `artifact_not_found` and a wasted recompile.
+/// Callers that don't have a depgraph reference (the legacy test fixtures
+/// in this module) pass `None`.
+///
 /// Returns `(bytes_freed, artifacts_removed)`.
 pub(crate) fn evict_disk_artifacts(
     artifact_dir: &Path,
     artifacts: &DashMap<String, CachedArtifact>,
     max_cache_size: u64,
+    dep_graph: Option<&DepGraph>,
 ) -> (u64, usize) {
     let entries = match std::fs::read_dir(artifact_dir) {
         Ok(e) => e,
@@ -296,6 +306,26 @@ pub(crate) fn evict_disk_artifacts(
     // Remove from in-memory DashMap.
     for artifact in &to_evict {
         artifacts.remove(&artifact.key);
+    }
+
+    // Issue #680: invalidate any depgraph contexts pointing at the
+    // artifacts we just evicted. Without this, the next compile through
+    // those contexts reports Hit, the artifact_store lookup misses, and
+    // the unit recompiles for no caching benefit. Build the set once and
+    // pass it; the depgraph walks its DashMap inside.
+    if let Some(dg) = dep_graph {
+        if !to_evict.is_empty() {
+            let evicted_keys: std::collections::HashSet<String> =
+                to_evict.iter().map(|a| a.key.clone()).collect();
+            let cleared = dg.invalidate_artifact_keys(&evicted_keys);
+            if cleared > 0 {
+                tracing::info!(
+                    contexts_cleared = cleared,
+                    artifacts_evicted = artifacts_removed,
+                    "invalidated depgraph contexts pointing at disk-evicted artifacts (issue #680)"
+                );
+            }
+        }
     }
 
     (bytes_freed, artifacts_removed)
@@ -631,7 +661,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let artifacts: DashMap<String, CachedArtifact> = DashMap::new();
         write_fake_artifact(dir.path(), "aaa", 100);
-        let (freed, removed) = evict_disk_artifacts(dir.path(), &artifacts, 1_000_000);
+        let (freed, removed) = evict_disk_artifacts(dir.path(), &artifacts, 1_000_000, None);
         assert_eq!(freed, 0);
         assert_eq!(removed, 0);
     }
@@ -651,7 +681,7 @@ mod tests {
 
         // Total: 3 * (5000 + 64) = 15192 bytes.
         // Budget: 10000 bytes → need to evict oldest.
-        let (freed, removed) = evict_disk_artifacts(dir.path(), &artifacts, 10_000);
+        let (freed, removed) = evict_disk_artifacts(dir.path(), &artifacts, 10_000, None);
         assert!(freed > 0);
         assert!(removed >= 1);
         // "new" should still exist.
@@ -669,10 +699,47 @@ mod tests {
         artifacts.insert("key1".to_string(), make_artifact(5000));
 
         // Budget: 0 → must evict everything.
-        let (freed, removed) = evict_disk_artifacts(dir.path(), &artifacts, 0);
+        let (freed, removed) = evict_disk_artifacts(dir.path(), &artifacts, 0, None);
         assert!(freed > 0);
         assert_eq!(removed, 1);
         assert!(artifacts.is_empty());
+    }
+
+    /// Regression test for <https://github.com/zackees/zccache/issues/680>.
+    ///
+    /// Pre-fix: `evict_disk_artifacts` removed the on-disk artifact and the
+    /// in-memory `DashMap` entry, but did NOT touch the depgraph contexts
+    /// that pointed at the now-evicted artifact key. The next compile
+    /// through those contexts surfaced `verdict=Hit` followed by
+    /// `artifact_not_found` and a wasted recompile (~15% real hit rate on
+    /// the dogfood reproducer instead of ~99%).
+    ///
+    /// Post-fix: passing `Some(&dep_graph)` invalidates the matching
+    /// context `artifact_key`s. Full integration coverage (registering a
+    /// depgraph context with a known artifact_key and asserting it gets
+    /// cleared) lives next to the `invalidate_artifact_keys` method in
+    /// `depgraph::graph::tests` — that's where the depgraph's internal
+    /// test seams already exist. This site-local test asserts only the
+    /// signature wiring: passing `None` is a no-op (back-compat with the
+    /// fixture callers above), passing `Some` reaches the depgraph.
+    #[test]
+    fn disk_eviction_signature_accepts_optional_depgraph() {
+        let dir = tempfile::tempdir().unwrap();
+        let artifacts: DashMap<String, CachedArtifact> = DashMap::new();
+        let dg = DepGraph::new();
+
+        write_fake_artifact(dir.path(), "k", 5000);
+
+        // Some(&dg) compiles and is a no-op when the depgraph has no
+        // matching contexts — the bridge is wired, the production
+        // invalidation path is covered by the depgraph-level unit test
+        // (`invalidate_artifact_keys_clears_only_matching` in
+        // `depgraph::graph::tests`).
+        let (freed, removed) = evict_disk_artifacts(dir.path(), &artifacts, 0, Some(&dg));
+        assert!(freed > 0);
+        assert_eq!(removed, 1);
+        // Empty depgraph → no contexts to invalidate, no panic.
+        assert_eq!(dg.stats().context_count, 0);
     }
 
     #[test]
@@ -688,7 +755,7 @@ mod tests {
 
         // Budget: 10000. 90% target = 9000. Need to free ~1640 bytes.
         // That's ~2 artifacts (each ~1064 bytes).
-        let (freed, removed) = evict_disk_artifacts(dir.path(), &artifacts, 10_000);
+        let (freed, removed) = evict_disk_artifacts(dir.path(), &artifacts, 10_000, None);
         assert!(freed > 0);
         // Should remove just enough, not all.
         assert!(removed >= 1);

--- a/crates/zccache/src/daemon/server/run.rs
+++ b/crates/zccache/src/daemon/server/run.rs
@@ -229,11 +229,17 @@ impl DaemonServer {
                 {
                     let dir = state.artifact_dir.clone();
                     let artifacts = state.artifacts.clone();
+                    // Issue #680: pass the current depgraph snapshot so
+                    // contexts pointing at evicted artifacts are invalidated
+                    // synchronously. Pre-fix the depgraph kept stale Hit
+                    // pointers and the next compile reported `artifact_not_found`.
+                    let dg = state.dep_graph.load_full();
                     let result = tokio::task::spawn_blocking(move || {
                         super::super::eviction::evict_disk_artifacts(
                             &dir,
                             &artifacts,
                             max_cache_size,
+                            Some(&dg),
                         )
                     })
                     .await;
@@ -251,11 +257,13 @@ impl DaemonServer {
                     tokio::time::sleep(std::time::Duration::from_secs(interval_secs)).await;
                     let dir = state.artifact_dir.clone();
                     let artifacts = state.artifacts.clone();
+                    let dg = state.dep_graph.load_full();
                     let result = tokio::task::spawn_blocking(move || {
                         super::super::eviction::evict_disk_artifacts(
                             &dir,
                             &artifacts,
                             max_cache_size,
+                            Some(&dg),
                         )
                     })
                     .await;

--- a/crates/zccache/src/depgraph/graph/mod.rs
+++ b/crates/zccache/src/depgraph/graph/mod.rs
@@ -1062,6 +1062,64 @@ impl DepGraph {
         Some(artifact_key)
     }
 
+    /// Clear `artifact_key` on every context whose currently-recorded
+    /// artifact key is in `evicted_hex`. Returns the number of contexts
+    /// whose key was cleared.
+    ///
+    /// **Issue #680 — eviction-divergence fix.** When the disk artifact
+    /// GC (`evict_disk_artifacts`) removes an artifact, the depgraph
+    /// contexts that point at the now-evicted key still report
+    /// `CacheVerdict::Hit { artifact_key }` on their next check, which
+    /// then surfaces in the daemon log as `artifact_not_found` and a
+    /// wasted recompile (the user observed a 15.7% real hit rate on a
+    /// soldr dogfood rebuild that should have been ~99%). Wiring the
+    /// disk GC to call this method after each eviction batch keeps the
+    /// two stores in agreement: the next check on an evicted context
+    /// returns `Cold` (forcing a clean miss + re-store) instead of a
+    /// stale `Hit`.
+    ///
+    /// Key comparison uses the hex form (`ArtifactKey::hash().to_hex()`)
+    /// so callers — which already have the evicted artifacts' string
+    /// keys from the disk eviction pass — do not have to round-trip
+    /// through `ArtifactKey` construction.
+    ///
+    /// `last_accessed` is intentionally NOT bumped — this is a passive
+    /// invalidation, and resetting access time would extend the
+    /// context's `trim()` lifetime past its disk-evicted artifact.
+    pub fn invalidate_artifact_keys(
+        &self,
+        evicted_hex: &std::collections::HashSet<String>,
+    ) -> usize {
+        if evicted_hex.is_empty() {
+            return 0;
+        }
+        // Two-phase to avoid holding DashMap shard locks across the
+        // `evicted_hex.contains(...)` allocation: read-only scan collects
+        // the context keys whose artifact_key needs clearing, then a
+        // bounded set of `get_mut` writes does the clear. Each `get_mut`
+        // takes only the matching shard's lock briefly. This pattern is
+        // what `trim()` and the existing artifact retention loops use to
+        // stay deadlock-free under concurrent compile traffic.
+        let mut to_clear: Vec<ContextKey> = Vec::new();
+        for entry in self.contexts.iter() {
+            if let Some(ref ak) = entry.value().artifact_key {
+                if evicted_hex.contains(ak.hash().to_hex().as_str()) {
+                    to_clear.push(*entry.key());
+                }
+            }
+        }
+        let mut cleared = 0;
+        for ctx_key in &to_clear {
+            if let Some(mut entry) = self.contexts.get_mut(ctx_key) {
+                if entry.artifact_key.is_some() {
+                    entry.artifact_key = None;
+                    cleared += 1;
+                }
+            }
+        }
+        cleared
+    }
+
     /// Trim entries not accessed within the given duration.
     /// Returns the number of entries removed.
     pub fn trim(&self, max_age: Duration) -> usize {

--- a/crates/zccache/src/depgraph/graph/tests.rs
+++ b/crates/zccache/src/depgraph/graph/tests.rs
@@ -73,6 +73,89 @@ fn warm_context_all_fresh_returns_hit() {
     assert!(matches!(verdict, CacheVerdict::Hit { .. }));
 }
 
+/// Regression test for <https://github.com/zackees/zccache/issues/680>.
+///
+/// `invalidate_artifact_keys` must clear `artifact_key` on every context whose
+/// currently-recorded key is in the evicted set, and leave every other
+/// context untouched. Without this, the disk-GC fix's bridge from eviction →
+/// depgraph has no payload — the symptom (depgraph `Hit` followed by
+/// artifact-store `not_found`) returns the moment the disk fills again.
+#[test]
+fn invalidate_artifact_keys_clears_only_matching() {
+    let graph = DepGraph::new();
+
+    // Two warm contexts with distinct artifact keys.
+    let key_a = graph.register(make_ctx("/src/a.c"));
+    let key_b = graph.register(make_ctx("/src/b.c"));
+    let scan_a = ScanResult {
+        resolved: vec![NormalizedPath::from("/inc/a.h")],
+        unresolved: Vec::new(),
+        has_computed: false,
+    };
+    let scan_b = ScanResult {
+        resolved: vec![NormalizedPath::from("/inc/b.h")],
+        unresolved: Vec::new(),
+        has_computed: false,
+    };
+    let art_a = graph
+        .update(&key_a, scan_a, dummy_hash)
+        .expect("a artifact");
+    let art_b = graph
+        .update(&key_b, scan_b, dummy_hash)
+        .expect("b artifact");
+    let hex_a = art_a.hash().to_hex().to_string();
+    let hex_b = art_b.hash().to_hex().to_string();
+
+    // Pre-condition: both contexts have artifact_key populated.
+    assert!(
+        graph.contexts.get(&key_a).unwrap().artifact_key.is_some(),
+        "fixture: A must start with artifact_key set"
+    );
+    assert!(
+        graph.contexts.get(&key_b).unwrap().artifact_key.is_some(),
+        "fixture: B must start with artifact_key set"
+    );
+
+    // Evict only artifact A.
+    let mut evicted = std::collections::HashSet::new();
+    evicted.insert(hex_a.clone());
+    let cleared = graph.invalidate_artifact_keys(&evicted);
+    assert_eq!(cleared, 1, "exactly one context should have been cleared");
+
+    // Post-condition: A's artifact_key is None; B's is intact (and still
+    // equals its original hex).
+    assert!(
+        graph.contexts.get(&key_a).unwrap().artifact_key.is_none(),
+        "issue #680: A's artifact_key must be cleared — pre-fix this stayed \
+         populated and surfaced as a wasted hit"
+    );
+    let surviving = graph.contexts.get(&key_b).unwrap();
+    assert_eq!(
+        surviving
+            .artifact_key
+            .as_ref()
+            .map(|k| k.hash().to_hex().to_string()),
+        Some(hex_b),
+        "B must keep its artifact_key — invalidation must be precise, \
+         not a blanket wipe"
+    );
+
+    // Empty-set call is a no-op.
+    assert_eq!(
+        graph.invalidate_artifact_keys(&std::collections::HashSet::new()),
+        0,
+        "empty evicted set must be a no-op (no spurious clears)"
+    );
+
+    // Calling again with the same key after it's already cleared is also
+    // a no-op (no double-counting).
+    assert_eq!(
+        graph.invalidate_artifact_keys(&evicted),
+        0,
+        "re-invalidating already-cleared contexts must report zero clears"
+    );
+}
+
 #[test]
 fn rustc_extern_artifact_key_ignores_target_dir_path_shape() {
     let graph = DepGraph::new();


### PR DESCRIPTION
## Summary

Closes #680. The daemon's session log on a soldr-cli rebuild showed a consistent wasted-hit pattern: depgraph returns `verdict=Hit`, immediately followed by `artifact_not_found` for that exact key, then a full recompile. Real hit rate 15.7% on a build that should have been ~99%.

**Root cause**: `evict_disk_artifacts` removed the on-disk artifact files and the in-memory `DashMap` entry, but left the depgraph contexts that pointed at the now-evicted artifact key untouched. The depgraph kept returning `CacheVerdict::Hit { artifact_key }` on the next check; the artifact-store lookup then missed; the unit recompiled for no caching benefit.

**Fix**:

- New `DepGraph::invalidate_artifact_keys(evicted_hex: &HashSet<String>) -> usize` clears `artifact_key` on every context whose recorded key is in the evicted set. Two-phase (read-only scan → bounded `get_mut`) to stay deadlock-free under concurrent compile traffic (the same pattern `trim()` already uses).
- `evict_disk_artifacts` gains an `Option<&DepGraph>` parameter. Production callers in `daemon/server/run.rs` pass `Some(&state.dep_graph.load_full())`; existing test fixtures pass `None` and remain unchanged.

`last_accessed` is intentionally NOT bumped on invalidation — passive clear, no lifetime extension past the artifact.

## Test plan

- [x] `invalidate_artifact_keys_clears_only_matching` (new depgraph unit test) — registers two warm contexts, evicts one's hex key, asserts only the matching context's `artifact_key` clears; empty-set and re-invocation are zero-clear no-ops.
- [x] `disk_eviction_signature_accepts_optional_depgraph` (new eviction test) — verifies the new `Option<&DepGraph>` parameter is wired through; legacy fixture tests cover the `None` path.
- [x] `soldr cargo test -p zccache --lib eviction` — 17 passed, 0 failed.
- [x] `soldr cargo test -p zccache --lib` — full lib suite green.
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` — clean.
- [ ] User-side validation (the maintainer): re-run the soldr-cli warm rebuild reproducer; expect the depgraph `Hit` + `artifact_not_found` pattern to be gone, and the second warm build to report ≥99% hit rate instead of the 15.7% in the issue body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)