### PR TITLE
feat(cli): ZCCACHE_DIAG_CWD env-gated wrapper CWD/argv diagnostic

### DIFF
--- a/crates/zccache/src/cli/commands/wrap.rs
+++ b/crates/zccache/src/cli/commands/wrap.rs
@@ -4,6 +4,7 @@
 //! resolution, rustfmt caching, and IPC request/response handling live in
 //! focused submodules so soldr-facing wrapper changes do not touch every layer.
 
+mod diag;
 mod env;
 mod ipc;
 mod passthrough;
@@ -30,6 +31,8 @@ pub(crate) fn run_wrap(
     args: &[String],
     strict_paths_override: Option<StrictPathsMode>,
 ) -> ExitCode {
+    diag::emit(args);
+
     if args.is_empty() {
         eprintln!("usage: zccache <compiler|tool> <args...>");
         return ExitCode::FAILURE;

--- a/crates/zccache/src/cli/commands/wrap/README.md
+++ b/crates/zccache/src/cli/commands/wrap/README.md
@@ -6,6 +6,12 @@ here based on tool family and environment.
 
 ## Files
 
+- **`diag.rs`** — opt-in CWD/argv diagnostic. When `ZCCACHE_DIAG_CWD` is set
+  to any non-empty, non-`0` value, each wrapper invocation emits one
+  tab-separated `ZCCACHE_DIAG_CWD` line to stderr before any CWD mutation,
+  carrying `pid`, `cwd`, `tmp`, `argv0`, and the raw `args`. Used to
+  diagnose cases (issue #683) where the request reaching the daemon carries
+  an unexpected CWD — typically because an outer shim chdir'd before exec.
 - **`env.rs`** — environment policy: `ZCCACHE_DISABLE`, `ZCCACHE_STRICT_PATHS`,
   client-env filtering applied to every IPC request.
 - **`ipc.rs`** — request builders and response handling for `Compile` and

--- a/crates/zccache/src/cli/commands/wrap/diag.rs
+++ b/crates/zccache/src/cli/commands/wrap/diag.rs
@@ -1,0 +1,105 @@
+//! Optional CWD/argv diagnostic for wrapper invocations.
+//!
+//! Gated behind `ZCCACHE_DIAG_CWD=1` so it costs nothing in normal operation.
+//! Emits a single tab-separated line to stderr at the very start of every
+//! wrapper invocation, before any CWD mutation. Used to diagnose cases
+//! (issue #683) where the wrapper appears to capture an unexpected CWD before
+//! sending the compile request to the daemon — typically because an outer
+//! shim/build system has chdir'd before exec'ing `zccache.exe`.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+const ENV_VAR: &str = "ZCCACHE_DIAG_CWD";
+const LINE_TAG: &str = "ZCCACHE_DIAG_CWD";
+
+/// Emit the diagnostic to stderr if `ZCCACHE_DIAG_CWD=1` (or any non-empty,
+/// non-`0` value). No-op otherwise. Errors writing to stderr are intentionally
+/// ignored — diagnostics must never affect the wrapper's exit status.
+pub(super) fn emit(args: &[String]) {
+    if !enabled_for(std::env::var_os(ENV_VAR).as_deref()) {
+        return;
+    }
+    let _ = emit_to(&mut std::io::stderr().lock(), args);
+}
+
+fn enabled_for(value: Option<&std::ffi::OsStr>) -> bool {
+    match value {
+        Some(v) if v.is_empty() => false,
+        Some(v) if v == "0" => false,
+        Some(_) => true,
+        None => false,
+    }
+}
+
+fn emit_to(writer: &mut dyn Write, args: &[String]) -> std::io::Result<()> {
+    let pid = std::process::id();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("<unavailable>"));
+    let tmp = std::env::temp_dir();
+    let argv0 = std::env::args_os().next().unwrap_or_default();
+    let argv0_display = std::path::Path::new(&argv0).display().to_string();
+
+    writeln!(
+        writer,
+        "{LINE_TAG}\tpid={pid}\tcwd={cwd}\ttmp={tmp}\targv0={argv0}\targs={args:?}",
+        cwd = cwd.display(),
+        tmp = tmp.display(),
+        argv0 = argv0_display,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn enabled_when_value_is_1() {
+        assert!(enabled_for(Some(OsStr::new("1"))));
+    }
+
+    #[test]
+    fn enabled_when_value_is_arbitrary_truthy_string() {
+        assert!(enabled_for(Some(OsStr::new("yes"))));
+        assert!(enabled_for(Some(OsStr::new("true"))));
+        assert!(enabled_for(Some(OsStr::new("verbose"))));
+    }
+
+    #[test]
+    fn disabled_when_unset_or_empty_or_zero() {
+        assert!(!enabled_for(None));
+        assert!(!enabled_for(Some(OsStr::new(""))));
+        assert!(!enabled_for(Some(OsStr::new("0"))));
+    }
+
+    #[test]
+    fn emits_single_tagged_line() {
+        let mut buf = Vec::new();
+        let args = vec!["clang++".to_string(), "-c".to_string(), "a.cpp".to_string()];
+        emit_to(&mut buf, &args).unwrap();
+        let line = String::from_utf8(buf).unwrap();
+
+        assert!(line.starts_with(LINE_TAG), "should start with tag: {line}");
+        assert_eq!(line.matches('\n').count(), 1, "should be one line: {line}");
+        assert!(line.contains("\tpid="));
+        assert!(line.contains("\tcwd="));
+        assert!(line.contains("\ttmp="));
+        assert!(line.contains("\targv0="));
+        assert!(line.contains("\targs="));
+    }
+
+    #[test]
+    fn args_round_trip_through_line() {
+        let mut buf = Vec::new();
+        let args = vec![
+            "clang++".to_string(),
+            "-c".to_string(),
+            "weird path/foo.cpp".to_string(),
+        ];
+        emit_to(&mut buf, &args).unwrap();
+        let line = String::from_utf8(buf).unwrap();
+
+        assert!(line.contains("clang++"));
+        assert!(line.contains("weird path/foo.cpp"));
+    }
+}

--- a/docs/architecture/portability.md
+++ b/docs/architecture/portability.md
@@ -79,6 +79,31 @@ artifact is safe to reuse.
 
 If obtaining the file ID fails (e.g., permission denied, network filesystem that doesn't support it), `file_id` is set to `None` and the entry falls back to `(path, mtime, size)` identity only.
 
+## Diagnosing wrapper-CWD anomalies (`ZCCACHE_DIAG_CWD`)
+
+Set `ZCCACHE_DIAG_CWD=1` to make every `zccache` wrapper invocation print one
+tab-separated diagnostic line to stderr **before** the wrapper releases its CWD
+handle to `temp_dir()`. The line is tagged `ZCCACHE_DIAG_CWD` and carries:
+
+- `pid` — the wrapper process ID
+- `cwd` — the result of `std::env::current_dir()` at process entry (this is the
+  value the wrapper will send to the daemon as `Request::Compile.cwd`)
+- `tmp` — `std::env::temp_dir()` (the directory the wrapper will chdir to)
+- `argv0` — the wrapper's own argv[0] path
+- `args` — the wrapped tool + tool args, as the wrapper received them
+
+Useful when the journal shows a cache miss recording a `cwd` that doesn't match
+the directory the build system thinks it invoked the compiler from (issue
+#683). Because the daemon writes the journal `cwd` field straight from
+`Request::Compile.cwd`, this diagnostic captures the truth at the source — if
+the diagnostic line shows the wrong directory, an outer shim/build system has
+already chdir'd before exec'ing `zccache.exe`. If the line shows the *right*
+directory but the journal still shows the wrong one, that points at a daemon
+bug.
+
+The diagnostic is gated, single-line, and writes to stderr — it adds no
+roundtrips and does not affect exit status.
+
 ## Watcher Behavior Differences
 
 - **inotify (Linux):** Per-directory watches. Recursive watching requires registering each subdirectory. The `notify` crate handles this. Watch limit: `/proc/sys/fs/inotify/max_user_watches` (default 8192 or 65536 depending on distro). If exhausted, fall back to polling.


### PR DESCRIPTION
## Summary

Adds an opt-in stderr diagnostic to the `zccache` wrapper, gated behind `ZCCACHE_DIAG_CWD`. Emits one tab-separated `ZCCACHE_DIAG_CWD` line per invocation carrying `pid`, `cwd`, `tmp`, `argv0`, and the raw `args` — captured at process entry, **before** the wrapper releases its CWD handle to `temp_dir()`.

## Motivation

Tracks item 2 of meta #685 — diagnostic patch for #683.

Issue #683 reports that a Meson+Ninja cold compile on Windows ends up with the daemon recording `cwd = source_dir` in compile-journal entry 1, even though Ninja invokes the compiler from `build_dir`. A full audit of every spawn site in the daemon (see [#683 comment](https://github.com/zackees/zccache/issues/683#issuecomment-4643460289)) showed the daemon already does `.current_dir(cwd)` everywhere and writes the journal `cwd` field straight from `Request::Compile.cwd` — meaning a wrong-cwd journal entry proves the *request* carried the wrong value.

Until now we had no way to tell whether:
1. The wrapper itself captured a bad CWD (e.g. an outer `clang-tool-chain` shim chdir'd before exec'ing `zccache.exe`), or
2. Something downstream mangled a good one.

This diagnostic lets the reporter `ZCCACHE_DIAG_CWD=1 ninja ...` and post the resulting stderr lines, which will pin the bug to the right layer.

## Behavior

- Gated: no-op unless `ZCCACHE_DIAG_CWD` is set to a non-empty, non-`"0"` value.
- Single line, tab-separated, prefixed with `ZCCACHE_DIAG_CWD`.
- Writes to stderr; write errors are ignored — diagnostic must never affect exit status.
- Fires before any CWD mutation in `run_wrap`, so the captured `cwd` is exactly what `Request::Compile.cwd` will carry.

Example:

```
ZCCACHE_DIAG_CWD	pid=12345	cwd=C:\proj\.build\meson-quick	tmp=C:\Users\...\Temp	argv0=C:\Users\...\zccache.exe	args=["clang++", "-c", "tests/foo.cpp", "-o", "ci/meson/native/foo.obj"]
```

## Test plan

5 new unit tests in `crates/zccache/src/cli/commands/wrap/diag.rs`:

- [x] `enabled_when_value_is_1`
- [x] `enabled_when_value_is_arbitrary_truthy_string`
- [x] `disabled_when_unset_or_empty_or_zero`
- [x] `emits_single_tagged_line` (verifies tag, single newline, all 5 fields)
- [x] `args_round_trip_through_line`

All pass locally:

```
test cli::commands::wrap::diag::tests::disabled_when_unset_or_empty_or_zero ... ok
test cli::commands::wrap::diag::tests::enabled_when_value_is_1 ... ok
test cli::commands::wrap::diag::tests::enabled_when_value_is_arbitrary_truthy_string ... ok
test cli::commands::wrap::diag::tests::args_round_trip_through_line ... ok
test cli::commands::wrap::diag::tests::emits_single_tagged_line ... ok

test result: ok. 5 passed; 0 failed
```

`soldr cargo clippy -p zccache --all-targets -- -D warnings` clean.

## Files

- `crates/zccache/src/cli/commands/wrap/diag.rs` — new module, ~90 lines incl. tests.
- `crates/zccache/src/cli/commands/wrap.rs` — wire `diag::emit(args)` as the first call in `run_wrap`.
- `crates/zccache/src/cli/commands/wrap/README.md` — document the new submodule.
- `docs/architecture/portability.md` — new section "Diagnosing wrapper-CWD anomalies (`ZCCACHE_DIAG_CWD`)" so anyone hitting a similar journal-cwd mystery on any platform knows the env var exists.

## Follow-up

Once the #683 reporter posts diag output, either fix the upstream cause (likely a wrapper shim) or close #683 as not-a-daemon-bug with the diagnostic line linked from the comment.
