### PR TITLE
chore(release): bump 1.11.18 -> 1.11.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.11.18"
+version = "1.11.19"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.11.18"
+version = "1.11.19"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.11.18"
+version = "1.11.19"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.11.18"
+version = "1.11.19"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.11.18"
+version = "1.11.19"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Refs #687 (release-prep meta).

## What 1.11.19 includes vs 1.11.18

The four merged-to-main commits since 1.11.18 was tagged:

- **fix(cli): drop misleading \"protocol version mismatch\" hint from lost-connection message** (#678) — the hint was wrong in most cases and sent users down `zccache stop` rabbit holes that didn't help.
- **fix(daemon): invalidate depgraph contexts on disk artifact eviction** (#681, closes #680) — root-causes the wasted-hit pattern where the depgraph reported `verdict=Hit` followed by `artifact_not_found` and a full recompile. Dogfood reproducer's real hit rate: 15.7 % → ~99 %.
- **docs(readme): explain cached-stderr cross-worktree leak** (#679, closes #672) — README now spells out the cached-stderr replay surface and the two workarounds (`ZCCACHE_PATH_REMAP=auto` or `zccache clear` after upgrading past 1.11.9).
- **feat(cli): `ZCCACHE_DIAG_CWD` env-gated wrapper CWD/argv diagnostic** (#686, closes #683) — opt-in `eprintln!` at `zccache.exe` entry; zero cost when unset.

## Verification this is a clean release

- No code changes in this PR — only `Cargo.toml` workspace version (1.11.18 → 1.11.19) and the 4 matching `Cargo.lock` entries (`zccache`, `zccache-cli`, `zccache-fingerprint`, `zccache-watcher`).
- `soldr cargo check --workspace` passes against the bumped manifest.
- main HEAD is `ce99ae2`; every commit since 1.11.18 was tagged is one of the four listed above.

## What ships next

Merging this triggers `release-auto.yml`'s `detect-bump` job on push-to-main → wheel build → PyPI publish → crates.io publish (in dependency order via `ci/release_workflow.py`) → GitHub Release creation.

Once 1.11.19 is live, #687 closes with `#682` / PR #684 still as a separate decision (recommend merge-into-1.11.20 if not bundled here pre-merge).

## Test plan

- [x] `Cargo.toml` workspace version updated.
- [x] All 4 `Cargo.lock` entries updated to 1.11.19.
- [x] `soldr cargo check --workspace` green against bumped manifest.
- [ ] CI green on this PR.
- [ ] `release-auto.yml` runs end-to-end on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)