### PR TITLE
chore(release): bump 1.11.19 -> 1.11.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.11.19"
+version = "1.11.20"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.11.19"
+version = "1.11.20"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Patch release shipping the feature comparison matrix from #684 (closed #682).

## What 1.11.20 includes vs 1.11.19

Just PR #684 — the auto-generated zccache vs sccache feature matrix:

- `docs/feature-matrix.yaml` (single source of truth, 54 rows × 8 categories)
- `ci/render_feature_matrix.py` (Python renderer, idempotent)
- README headline + `<details>` full-table sections
- `docs/FEATURE-MATRIX.md` canonical long-form view
- `.github/workflows/feature-matrix-check.yml` CI gate

## Verification

- Only touches `Cargo.toml` workspace version and the 4 matching `Cargo.lock` entries.
- main HEAD includes the #684 merge — the only commit since 1.11.19.

## Merge → release

`release-auto.yml` fires on push-to-main → `detect-bump` sees 1.11.19 → 1.11.20 → wheel build × 8 targets → PyPI + crates.io publish → GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)