### PR TITLE
feat(ipc): ReleaseWorktreeHandles for soldr Tier 3 worktree teardown

### DIFF
--- a/crates/zccache/src/daemon/server/connection.rs
+++ b/crates/zccache/src/daemon/server/connection.rs
@@ -471,6 +471,9 @@ pub(super) async fn handle_connection(
                 }
                 (Response::RustArtifactList { artifacts }, None)
             }
+            Request::ReleaseWorktreeHandles { path } => {
+                (handle_release_worktree_handles(&state, &path).await, None)
+            }
         };
 
         // Capture journal metadata BEFORE conn.send so the client unblocks

--- a/crates/zccache/src/daemon/server/handle_release_worktree_handles.rs
+++ b/crates/zccache/src/daemon/server/handle_release_worktree_handles.rs
@@ -1,0 +1,135 @@
+//! `Request::ReleaseWorktreeHandles` handler (issue #690).
+//!
+//! soldr's Tier 3 worktree-teardown fallback calls this to deterministically
+//! break Windows file locks before `git worktree remove` / `rmdir`. The
+//! daemon's only long-lived handles inside a client-owned directory are the
+//! per-session JSONL journal files and per-session log files; mmap'd cache
+//! artifacts are short-lived (`hash_file` maps-and-drops). So "release
+//! handles under `path`" reduces to: find every session whose `working_dir`
+//! is under `path`, end the session, and close its journal sink.
+//!
+//! Safety: the handler refuses to release `state.cache_dir` (or any ancestor
+//! of it). The cache root is shared across every concurrent session — letting
+//! a single soldr caller close those handles would corrupt unrelated work.
+//! soldr's worktree paths are always disjoint from the cache root, so this
+//! refusal never blocks a legitimate Tier 3 call.
+
+use super::*;
+use std::path::{Path, PathBuf};
+
+/// Handle a `ReleaseWorktreeHandles` request.
+///
+/// Returns either `Response::ReleaseWorktreeHandlesResult` on success or
+/// `Response::Error` if the requested path overlaps the daemon's cache root.
+pub(super) async fn handle_release_worktree_handles(
+    state: &SharedState,
+    path: &NormalizedPath,
+) -> Response {
+    let target = match canonicalize_for_match(path.as_path()) {
+        Some(p) => p,
+        None => path.as_path().to_path_buf(),
+    };
+
+    // Refuse if the caller asked us to release our own cache root, or any
+    // ancestor of it. The cache root is owned by the daemon, not by any
+    // worktree, and closing those handles would corrupt unrelated sessions.
+    let cache_root = match canonicalize_for_match(state.cache_dir.as_path()) {
+        Some(p) => p,
+        None => state.cache_dir.as_path().to_path_buf(),
+    };
+    if cache_root.starts_with(&target) {
+        return Response::Error {
+            message: format!(
+                "refusing to release handles under {} — that path contains the daemon \
+                 cache root {}",
+                target.display(),
+                cache_root.display(),
+            ),
+        };
+    }
+
+    let session_ids = state.sessions.active_ids();
+    let inspected = session_ids.len() as u32;
+    let mut released: u32 = 0;
+    let mut sessions_dropped: Vec<String> = Vec::new();
+
+    for sid in session_ids {
+        let Some(session) = state.sessions.get(&sid) else {
+            continue;
+        };
+
+        if !path_is_under(&session.working_dir, &target) {
+            continue;
+        }
+
+        // Mirror the cleanup `Request::SessionEnd` performs so the daemon
+        // state is consistent regardless of which path tore the session
+        // down. Order matches connection.rs:295 to keep the two sites
+        // visually comparable.
+        state.session_worktree_roots.remove(&sid);
+        if let Some(ended) = state.sessions.end(&sid) {
+            if !ended.owner_pids.is_empty() {
+                state
+                    .private_daemon
+                    .release_session(&ended.owner_pids)
+                    .await;
+            }
+            if let Some(ref journal_path) = ended.journal_path {
+                state.journal.close_session(journal_path);
+            }
+            released += 1;
+            sessions_dropped.push(sid.to_string());
+        }
+    }
+
+    tracing::info!(
+        path = %target.display(),
+        inspected,
+        released,
+        "released worktree handles"
+    );
+
+    Response::ReleaseWorktreeHandlesResult {
+        inspected,
+        released,
+        sessions_dropped,
+        // Empty today: no long-lived mmaps to fail-to-release. The field
+        // exists so future code that pins file handles inside a worktree
+        // can report partial failure without a wire-shape change.
+        unreleased: Vec::new(),
+    }
+}
+
+/// Canonicalize a path for prefix matching. Returns `None` if the path
+/// cannot be canonicalized (deleted, permission error, etc.) — callers
+/// fall back to the as-supplied path so a soldr teardown of a partially
+/// deleted worktree still sweeps sessions whose working_dir is gone.
+fn canonicalize_for_match(p: &Path) -> Option<PathBuf> {
+    std::fs::canonicalize(p).ok()
+}
+
+/// True iff `candidate` resolves to a path under `target`. Both sides are
+/// canonicalized when possible so a `\\?\C:\...` verbatim target matches
+/// a non-verbatim session working_dir (and vice versa).
+fn path_is_under(candidate: &NormalizedPath, target: &Path) -> bool {
+    let resolved = canonicalize_for_match(candidate.as_path())
+        .unwrap_or_else(|| candidate.as_path().to_path_buf());
+    resolved.starts_with(target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_path_is_canonicalized_for_match() {
+        // Verifies the helper accepts canonicalize failures gracefully —
+        // a path that does not exist must not panic, just return None.
+        let bogus = std::path::Path::new(if cfg!(windows) {
+            r"C:\zccache-nonexistent-test-path-690"
+        } else {
+            "/zccache-nonexistent-test-path-690"
+        });
+        assert!(canonicalize_for_match(bogus).is_none());
+    }
+}

--- a/crates/zccache/src/daemon/server/mod.rs
+++ b/crates/zccache/src/daemon/server/mod.rs
@@ -87,6 +87,7 @@ mod handle_compile_ephemeral;
 mod handle_compile_multi;
 mod handle_exec;
 mod handle_link;
+mod handle_release_worktree_handles;
 mod in_flight;
 mod keys;
 mod lifecycle;
@@ -120,6 +121,7 @@ use handle_exec::handle_generic_tool_exec;
 use handle_link::handle_link_ephemeral;
 #[cfg(test)]
 use handle_link::run_post_link_deploy_hook;
+use handle_release_worktree_handles::handle_release_worktree_handles;
 use in_flight::*;
 use keys::*;
 use lifecycle::*;

--- a/crates/zccache/src/daemon/server/tests/mod.rs
+++ b/crates/zccache/src/daemon/server/tests/mod.rs
@@ -17,6 +17,7 @@ mod path_remap;
 mod pch;
 mod pending_cache_writes;
 mod post_link_hook;
+mod release_worktree_handles;
 mod server_ipc;
 mod write_cached;
 

--- a/crates/zccache/src/daemon/server/tests/release_worktree_handles.rs
+++ b/crates/zccache/src/daemon/server/tests/release_worktree_handles.rs
@@ -1,0 +1,171 @@
+//! Tests for `handle_release_worktree_handles` (issue #690).
+//!
+//! Drives the handler in-process via `DaemonServer::test_state()` — the same
+//! seam `handle_clear`'s integration test uses. Avoids the IPC roundtrip so
+//! we can observe `SessionManager` state directly after the call.
+
+use super::super::*;
+use super::CacheDirEnvGuard;
+use crate::depgraph::SessionConfig;
+
+fn session_under(worktree: &std::path::Path, journal: Option<&std::path::Path>) -> SessionConfig {
+    SessionConfig {
+        client_pid: std::process::id(),
+        working_dir: NormalizedPath::from(worktree),
+        log_file: None,
+        track_stats: false,
+        journal_path: journal.map(NormalizedPath::from),
+        profile: false,
+        private_env: Vec::new(),
+        owner_pids: Vec::new(),
+    }
+}
+
+/// Happy path: a session whose `working_dir` is under the released path is
+/// dropped; a session under a *different* worktree is preserved. The dropped
+/// session ID appears in the response, and counts match.
+#[tokio::test]
+#[ignore] // integration-level: instantiates a real DaemonServer
+async fn release_drops_sessions_under_path_and_leaves_siblings() {
+    crate::test_support::test_timeout(async {
+        let cache_tmp = tempfile::tempdir().unwrap();
+        let _env = CacheDirEnvGuard::set(cache_tmp.path());
+        let endpoint = crate::ipc::unique_test_endpoint();
+        let cache_dir = NormalizedPath::new(cache_tmp.path());
+        let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+
+        let worktree_a = tempfile::tempdir().unwrap();
+        let worktree_b = tempfile::tempdir().unwrap();
+        let inside_a = worktree_a.path().join("target/debug");
+        std::fs::create_dir_all(&inside_a).unwrap();
+
+        let state = server.test_state();
+        let sid_root_a = state
+            .sessions
+            .create(session_under(worktree_a.path(), None));
+        let sid_inside_a = state.sessions.create(session_under(&inside_a, None));
+        let sid_b = state
+            .sessions
+            .create(session_under(worktree_b.path(), None));
+        assert_eq!(state.sessions.active_count(), 3);
+
+        let target = NormalizedPath::new(worktree_a.path());
+        let resp = super::super::handle_release_worktree_handles::handle_release_worktree_handles(
+            state, &target,
+        )
+        .await;
+
+        let Response::ReleaseWorktreeHandlesResult {
+            inspected,
+            released,
+            sessions_dropped,
+            unreleased,
+        } = resp
+        else {
+            panic!("expected ReleaseWorktreeHandlesResult, got: {resp:?}");
+        };
+
+        assert_eq!(inspected, 3, "should have looked at every active session");
+        assert_eq!(released, 2, "both sessions under worktree_a must drop");
+        assert!(
+            unreleased.is_empty(),
+            "no long-lived mmaps means nothing should fail to release; got {unreleased:?}"
+        );
+        assert_eq!(state.sessions.active_count(), 1, "sibling session survives");
+        assert!(
+            state.sessions.get(&sid_b).is_some(),
+            "session under worktree_b must still exist"
+        );
+        assert!(
+            state.sessions.get(&sid_root_a).is_none()
+                && state.sessions.get(&sid_inside_a).is_none(),
+            "sessions under worktree_a must be gone"
+        );
+
+        let dropped: std::collections::HashSet<String> = sessions_dropped.into_iter().collect();
+        assert!(dropped.contains(&sid_root_a.to_string()));
+        assert!(dropped.contains(&sid_inside_a.to_string()));
+    })
+    .await;
+}
+
+/// Safety guard: the daemon must refuse to release its own cache root.
+/// soldr's worktree paths are always disjoint from the cache root, so a
+/// well-behaved caller never hits this — but a buggy caller passing the
+/// cache root would corrupt every concurrent session if we honored it.
+#[tokio::test]
+#[ignore] // integration-level: instantiates a real DaemonServer
+async fn release_refuses_to_release_cache_root() {
+    crate::test_support::test_timeout(async {
+        let cache_tmp = tempfile::tempdir().unwrap();
+        let _env = CacheDirEnvGuard::set(cache_tmp.path());
+        let endpoint = crate::ipc::unique_test_endpoint();
+        let cache_dir = NormalizedPath::new(cache_tmp.path());
+        let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+        let state = server.test_state();
+
+        // Seed a session so the handler has something to potentially touch.
+        let unrelated = tempfile::tempdir().unwrap();
+        let sid = state.sessions.create(session_under(unrelated.path(), None));
+        assert!(state.sessions.get(&sid).is_some());
+
+        let resp = super::super::handle_release_worktree_handles::handle_release_worktree_handles(
+            state, &cache_dir,
+        )
+        .await;
+
+        assert!(
+            matches!(resp, Response::Error { ref message } if message.contains("cache root")),
+            "expected refusal naming the cache root, got: {resp:?}"
+        );
+        assert!(
+            state.sessions.get(&sid).is_some(),
+            "refusal must not have torn down any sessions"
+        );
+    })
+    .await;
+}
+
+/// Empty case: the daemon has no sessions under the requested path. The
+/// response counts are zero and no session state is disturbed.
+#[tokio::test]
+#[ignore] // integration-level: instantiates a real DaemonServer
+async fn release_with_no_matches_returns_zero_counts() {
+    crate::test_support::test_timeout(async {
+        let cache_tmp = tempfile::tempdir().unwrap();
+        let _env = CacheDirEnvGuard::set(cache_tmp.path());
+        let endpoint = crate::ipc::unique_test_endpoint();
+        let cache_dir = NormalizedPath::new(cache_tmp.path());
+        let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+        let state = server.test_state();
+
+        let other_worktree = tempfile::tempdir().unwrap();
+        let sid = state
+            .sessions
+            .create(session_under(other_worktree.path(), None));
+
+        // Target a fresh, unrelated tmp dir with no sessions under it.
+        let target_tmp = tempfile::tempdir().unwrap();
+        let target = NormalizedPath::new(target_tmp.path());
+        let resp = super::super::handle_release_worktree_handles::handle_release_worktree_handles(
+            state, &target,
+        )
+        .await;
+
+        let Response::ReleaseWorktreeHandlesResult {
+            inspected,
+            released,
+            sessions_dropped,
+            unreleased,
+        } = resp
+        else {
+            panic!("expected ReleaseWorktreeHandlesResult, got: {resp:?}");
+        };
+        assert_eq!(inspected, 1);
+        assert_eq!(released, 0);
+        assert!(sessions_dropped.is_empty());
+        assert!(unreleased.is_empty());
+        assert!(state.sessions.get(&sid).is_some());
+    })
+    .await;
+}

--- a/crates/zccache/src/protocol/messages/README.md
+++ b/crates/zccache/src/protocol/messages/README.md
@@ -1,0 +1,17 @@
+# protocol/messages
+
+Wire enums and per-domain payload structs.
+
+`mod.rs` owns the append-only `Request` and `Response` enums — bincode encodes
+variants by declaration order, so new variants must be appended at the end and
+require a `PROTOCOL_VERSION` bump (see `../mod.rs`). Domain payload structs
+live in sibling files so new fields land next to related types instead of
+interleaving every helper in one monolithic file.
+
+| File | Owns |
+|---|---|
+| `mod.rs` | `Request`, `Response`, `PrivateDaemonSessionOptions` |
+| `status.rs` | `DaemonStatus`, `SessionStats`, `PhaseProfileSummary`, private-daemon diagnostics |
+| `artifact.rs` | `ArtifactData`, `ArtifactOutput`, `ArtifactPayload`, `LookupResult`, `RustArtifactInfo`, `StoreResult` |
+| `exec.rs` | `ExecCachePolicy`, `ExecOutputStreams` (for `Request::GenericToolExec`) |
+| `compat.rs` | Bincode roundtrip + variant-index regression tests (`cfg(test)` only) |

--- a/crates/zccache/src/protocol/messages/compat.rs
+++ b/crates/zccache/src/protocol/messages/compat.rs
@@ -208,6 +208,12 @@ fn request_variant_indices_are_append_only() {
                 key_args_filter: vec![],
             },
         ),
+        (
+            18,
+            Request::ReleaseWorktreeHandles {
+                path: "/tmp/work".into(),
+            },
+        ),
     ];
 
     for (expected, request) in request_cases {
@@ -304,6 +310,23 @@ fn response_variant_indices_are_append_only() {
                 output_files: vec![],
                 cached: false,
                 cache_key_hex: "abc".to_string(),
+            },
+        ),
+        (
+            16,
+            Response::Backpressure {
+                queue_depth: 0,
+                retry_after_ms: 0,
+                reason: "compile_queue_full".to_string(),
+            },
+        ),
+        (
+            17,
+            Response::ReleaseWorktreeHandlesResult {
+                inspected: 0,
+                released: 0,
+                sessions_dropped: vec![],
+                unreleased: vec![],
             },
         ),
     ];
@@ -732,18 +755,19 @@ fn daemon_status_version_field_roundtrips() {
 
 // Compile-time check: PROTOCOL_VERSION must be positive.
 const _: () = assert!(super::super::PROTOCOL_VERSION > 0);
-// Compile-time check: PROTOCOL_VERSION == 14 after private daemon
-// SessionStart/status diagnostics were added. v13 was the pin after daemon
-// namespace diagnostics were added to DaemonStatus. v12 was the pin after
-// cached-error counters were added for rustc negative-result caching.
-// v11 was the pin after
-// `GenericToolExec` gained Path A (include scan) + Path B (depfile) +
-// non_deterministic + key_args_filter, fully implementing issue #272.
-// v10 was the prior pin when `GenericToolExec` was added. v9 was the pin
-// after SessionStats gained `phase_profile`. v8 was the pin after
-// Compile/CompileEphemeral gained `stdin` and ArtifactPayload replaced
-// ArtifactOutput.data: Arc<Vec<u8>> (issue #296 Option B).
-const _FINGERPRINT_VERSION: () = assert!(super::super::PROTOCOL_VERSION == 14);
+// Compile-time check: PROTOCOL_VERSION == 15 after `ReleaseWorktreeHandles`
+// was added for soldr Tier 3 worktree teardown (issue #690). v14 was the
+// pin after private daemon SessionStart/status diagnostics were added.
+// v13 was the pin after daemon namespace diagnostics were added to
+// DaemonStatus. v12 was the pin after cached-error counters were added for
+// rustc negative-result caching. v11 was the pin after `GenericToolExec`
+// gained Path A (include scan) + Path B (depfile) + non_deterministic +
+// key_args_filter, fully implementing issue #272. v10 was the prior pin
+// when `GenericToolExec` was added. v9 was the pin after SessionStats
+// gained `phase_profile`. v8 was the pin after Compile/CompileEphemeral
+// gained `stdin` and ArtifactPayload replaced ArtifactOutput.data:
+// Arc<Vec<u8>> (issue #296 Option B).
+const _FINGERPRINT_VERSION: () = assert!(super::super::PROTOCOL_VERSION == 15);
 
 #[test]
 fn fingerprint_check_roundtrip() {

--- a/crates/zccache/src/protocol/messages/mod.rs
+++ b/crates/zccache/src/protocol/messages/mod.rs
@@ -251,6 +251,21 @@ pub enum Request {
         /// runtime flags like `--verbose` or `--no-color` from the key.
         key_args_filter: Vec<String>,
     },
+    /// Release every daemon-owned handle whose canonical path is under
+    /// `path`, and drop session contexts whose `working_dir` resolves
+    /// there. Issue #690: gives soldr's Tier 3 worktree-teardown fallback
+    /// a deterministic way to break Windows file locks before
+    /// `git worktree remove` / `rmdir`.
+    ///
+    /// The daemon refuses to release its own cache root (`ZCCACHE_CACHE_DIR`)
+    /// or any ancestor of it — that path is shared by every concurrent
+    /// session and is never owned by a worktree.
+    ///
+    /// NOTE: Appended at end to preserve bincode variant indices.
+    ReleaseWorktreeHandles {
+        /// Canonical path prefix to release. Must be absolute.
+        path: NormalizedPath,
+    },
 }
 
 /// A response from daemon to client.
@@ -379,5 +394,28 @@ pub enum Response {
         /// `"compile_queue_full"`, `"fp_lock_contention"`,
         /// `"depgraph_lock_contention"`, `"resident_memory_high"`.
         reason: String,
+    },
+    /// Result of a `ReleaseWorktreeHandles` request (issue #690).
+    ///
+    /// `released == 0` with `unreleased.is_empty()` means the path had no
+    /// daemon-owned handles to release — soldr can proceed with its rmdir.
+    /// A non-empty `unreleased` list signals the daemon could not break a
+    /// specific handle; soldr's caller decides whether to fall back to
+    /// Tier 2 (move-to-trash) or surface a diagnostic.
+    ///
+    /// NOTE: Appended at end to preserve bincode variant indices.
+    ReleaseWorktreeHandlesResult {
+        /// Active sessions inspected against the path prefix.
+        inspected: u32,
+        /// Sessions whose journal handle was closed and state was dropped.
+        released: u32,
+        /// Session IDs that were dropped because their `working_dir`
+        /// resolved under the requested path.
+        sessions_dropped: Vec<String>,
+        /// Paths the daemon could not release. Empty today because the
+        /// daemon holds no long-lived mmap handles; the field exists so
+        /// future code that pins file handles inside a worktree can
+        /// report partial failure without a wire-shape change.
+        unreleased: Vec<NormalizedPath>,
     },
 }

--- a/crates/zccache/src/protocol/mod.rs
+++ b/crates/zccache/src/protocol/mod.rs
@@ -11,7 +11,13 @@ pub use messages::*;
 /// new/removed/reordered enum variants or struct field changes.
 /// Patch releases that don't change the protocol keep the same version.
 ///
-/// v14 (current): `SessionStart` gained private daemon options, and
+/// v15 (current): added `Request::ReleaseWorktreeHandles` /
+///                  `Response::ReleaseWorktreeHandlesResult` so callers
+///                  (soldr Tier 3 worktree teardown, issue #690) can ask
+///                  the daemon to drop sessions and close per-session
+///                  journal handles under a path prefix before the
+///                  worktree is deleted.
+/// v14: `SessionStart` gained private daemon options, and
 ///                  `DaemonStatus` gained redacted private daemon diagnostics.
 /// v13: `DaemonStatus` gained `daemon_namespace` and `endpoint`
 ///                  for soldr/zccache daemon namespace diagnostics.
@@ -27,7 +33,7 @@ pub use messages::*;
 ///     so per-session aggregate phase timing reaches clients.
 /// v8: `Compile` / `CompileEphemeral` gained `stdin: Vec<u8>` and
 ///     `ArtifactPayload` replaced `ArtifactOutput.data: Arc<Vec<u8>>`.
-pub const PROTOCOL_VERSION: u32 = 14;
+pub const PROTOCOL_VERSION: u32 = 15;
 
 use bytes::{Buf, BufMut, BytesMut};
 


### PR DESCRIPTION
Closes #690. Companion to `zackees/soldr#710` (Tier 3 fallback for the Windows worktree-removal race).

## Summary

- New `Request::ReleaseWorktreeHandles { path }` and `Response::ReleaseWorktreeHandlesResult { inspected, released, sessions_dropped, unreleased }`, appended at the end of both wire enums (variant indices 18 / 17). `PROTOCOL_VERSION` 14 → 15.
- New `handle_release_worktree_handles.rs` mirrors the cleanup `Request::SessionEnd` does, scoped to every active session whose canonicalized `working_dir` resolves under the requested path. For each match: `session_worktree_roots.remove`, `sessions.end`, `journal.close_session`, and `private_daemon.release_session` if owner PIDs were registered.
- The handler refuses to release the daemon's own `cache_dir` (or any ancestor of it) — that path is shared by every concurrent session and is never owned by a worktree. soldr's Tier 3 paths are always disjoint from the cache root, so this refusal never blocks a legitimate call.
- Integration tests under `daemon::server::tests::release_worktree_handles`:
  - **happy path** — two sessions under worktree A drop, a sibling session under worktree B survives, dropped session IDs appear in the response.
  - **safety guard** — releasing the cache root returns `Response::Error` and leaves session state untouched.
  - **no-op** — releasing a path with no matching sessions returns zero counts.

## Notes from the investigation

The issue body called out "Windows mmap-close logic" as the non-trivial part. Tracing the daemon showed it holds **no long-lived mmaps** into client-owned directories — `zccache_hash::hash_file` maps-and-drops per lookup, and artifact payloads are stored as `Arc<Vec<u8>>` or lazy `Path` references. The only long-lived handles inside a worktree are per-session JSONL journal files, which `CompileJournal::close_session` already knows how to release on its background thread. The handler is therefore much smaller than the original design suggested.

The `unreleased: Vec<NormalizedPath>` slot is kept on the wire so future code that does pin file handles inside a worktree can report partial failure without a wire-shape change.

## Test plan

- [x] `soldr cargo check -p zccache --all-targets` clean
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean
- [x] `soldr cargo fmt --all -- --check` clean
- [x] `soldr cargo test -p zccache --lib protocol::messages::compat` (39 passed — covers the new `request_variant_indices_are_append_only` / `response_variant_indices_are_append_only` entries and the `PROTOCOL_VERSION == 15` compile-time pin)
- [x] `soldr cargo test -p zccache --lib daemon::server::tests::release_worktree_handles -- --include-ignored` (3 passed — covers happy path, cache-root refusal, empty match)
- [x] Full lib unit suite: 1725 passed, 0 failed
- [ ] CI: Linux + macOS + Windows green
- [ ] Follow-up: soldr-side Tier 3 PR can now call the IPC

🤖 Generated with [Claude Code](https://claude.com/claude-code)