### PR TITLE
fix(ipc): sanitize Windows pipe usernames

### DIFF
--- a/crates/zccache/src/core/config.rs
+++ b/crates/zccache/src/core/config.rs
@@ -294,6 +294,38 @@ fn namespace_short_hash(value: &str) -> String {
     fnv_short_hash(value.as_bytes())
 }
 
+/// Sanitize a user-controlled IPC name component for endpoints such as Windows
+/// named pipes. Already-safe ASCII components are returned unchanged so
+/// historical endpoint names remain stable. If any character must be replaced,
+/// append a short hash of the original value so distinct unsafe names do not
+/// collapse to the same pipe name.
+#[must_use]
+pub fn sanitize_ipc_component(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let sanitized: String = trimmed
+        .chars()
+        .map(|c| {
+            if is_safe_ipc_component_char(c) {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitized == trimmed {
+        return Some(sanitized);
+    }
+    let prefix: String = sanitized.chars().take(32).collect();
+    Some(format!("{prefix}-{}", fnv_short_hash(trimmed.as_bytes())))
+}
+
+fn is_safe_ipc_component_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.'
+}
+
 /// Stable 8-hex-char identifier derived from the home dir's canonical
 /// path. FNV-1a (64-bit) — small, deterministic, no extra dep.
 fn home_dir_short_hash(home: &Path) -> String {
@@ -1147,6 +1179,36 @@ mod tests {
         assert_ne!(a, b);
         assert!(a.starts_with(&"x".repeat(32)));
         assert_eq!(a.len(), 41);
+    }
+
+    #[test]
+    fn sanitize_ipc_component_keeps_safe_values_unchanged() {
+        assert_eq!(
+            sanitize_ipc_component("zackees-dev_1.2").as_deref(),
+            Some("zackees-dev_1.2")
+        );
+    }
+
+    #[test]
+    fn sanitize_ipc_component_replaces_spaces_and_adds_hash() {
+        let component = sanitize_ipc_component("Zach Vorhies").unwrap();
+        assert!(component.starts_with("Zach_Vorhies-"));
+        assert_eq!(component.len(), "Zach_Vorhies-".len() + 8);
+        assert!(component.chars().all(is_safe_ipc_component_char));
+    }
+
+    #[test]
+    fn sanitize_ipc_component_keeps_unsafe_names_distinct() {
+        let spaced = sanitize_ipc_component("Zach Vorhies").unwrap();
+        let slashed = sanitize_ipc_component("Zach/Vorhies").unwrap();
+        assert_ne!(spaced, slashed);
+        assert!(spaced.starts_with("Zach_Vorhies-"));
+        assert!(slashed.starts_with("Zach_Vorhies-"));
+    }
+
+    #[test]
+    fn sanitize_ipc_component_ignores_empty_values() {
+        assert_eq!(sanitize_ipc_component("   "), None);
     }
 
     #[test]

--- a/crates/zccache/src/download_protocol/daemon_mgmt.rs
+++ b/crates/zccache/src/download_protocol/daemon_mgmt.rs
@@ -20,6 +20,8 @@ pub fn default_endpoint() -> String {
     #[cfg(windows)]
     {
         let username = std::env::var("USERNAME").unwrap_or_else(|_| String::from("unknown"));
+        let username = crate::core::config::sanitize_ipc_component(&username)
+            .unwrap_or_else(|| String::from("unknown"));
         format!(r"\\.\pipe\zccache-download-{username}")
     }
 }

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -156,6 +156,8 @@ fn daemon_socket_name(namespace: Option<&str>) -> String {
 
 #[cfg(windows)]
 fn pipe_name(base: &str, namespace: Option<&str>) -> String {
+    let base = crate::core::config::sanitize_ipc_component(base)
+        .unwrap_or_else(|| String::from("unknown"));
     match namespace {
         Some(ns) => format!(r"\\.\pipe\zccache-{base}-{ns}"),
         None => format!(r"\\.\pipe\zccache-{base}"),
@@ -617,6 +619,20 @@ mod tests {
             assert!(endpoint.ends_with("-soldr_dev"));
             assert!(endpoint.contains(&crate::core::stable_path_id(&cache_dir)));
         }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn pipe_name_keeps_safe_username_endpoint_unchanged() {
+        assert_eq!(pipe_name("zackees", None), r"\\.\pipe\zccache-zackees");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn pipe_name_sanitizes_username_spaces() {
+        let endpoint = pipe_name("Zach Vorhies", None);
+        assert!(endpoint.starts_with(r"\\.\pipe\zccache-Zach_Vorhies-"));
+        assert!(!endpoint.contains(' '));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- sanitize Windows IPC pipe components derived from `%USERNAME%`
- keep already-safe usernames on their historical pipe names
- append a deterministic short hash when sanitization changes a component to avoid collisions
- apply the same protection to the download daemon pipe endpoint

Closes #696

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p zccache sanitize_ipc_component`
- `cargo test -p zccache pipe_name`
- `cargo check -p zccache --all-targets`
- `rustup run 1.94.1-x86_64-pc-windows-gnu cargo clippy -p zccache --all-targets -- -D warnings`

Note: plain `cargo clippy` hit a local toolchain mismatch because PATH resolves `cargo`/`rustc` from Chocolatey GNU while `clippy-driver` resolves from rustup's active MSVC toolchain; the aligned rustup GNU clippy invocation passed.