### PR TITLE
feat: scaffold prost daemon wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
 name = "protox"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3731,6 +3795,8 @@ dependencies = [
  "mimalloc",
  "notify",
  "prost",
+ "prost-build",
+ "protoc-bin-vendored",
  "rayon",
  "redb",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ rayon = "1"
 jwalk = "0.8"
 bytes = "1"
 prost = "0.14"
+prost-build = "0.14"
+protoc-bin-vendored = "3"
 futures = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "stream"] }
 tokio-util = "0.7"

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ See [`docs/FEATURE-MATRIX.md`](docs/FEATURE-MATRIX.md) for the long-form view wi
 | Feature | zccache | sccache |
 |---|:---:|:---:|
 | Persistent daemon with sub-ms IPC | yes | partial |
-| Single-roundtrip IPC (length-prefixed daemon frame) | yes | no |
+| Single-roundtrip IPC (length-prefixed bincode) | yes | no |
 | Hardlink delivery on hit | yes | no |
 | In-memory metadata cache (DashMap) | yes | no |
 | Filesystem watcher (notify-backed) | yes | no |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The difference comes from **architecture**, not better caching:
 
 - **Filesystem watcher** — a background `notify` watcher tracks file changes in real time, so the daemon already knows whether inputs are dirty before you even invoke a compile. No redundant stat/hash work on hit.
 - **In-memory metadata cache** — file sizes, mtimes, and content hashes live in a lock-free `DashMap`. Cache key computation is a memory lookup, not disk I/O.
-- **Single-roundtrip IPC** — each compile is one length-prefixed bincode message over a Unix socket (or named pipe on Windows). No subprocess spawning, no repeated handshakes.
+- **Single-roundtrip IPC** — each compile is one length-prefixed daemon message over a Unix socket (or named pipe on Windows). No subprocess spawning, no repeated handshakes. The active wire is v15 bincode; a v16 prost wire is staged behind the migration tracked by zackees/running-process#234.
 - **Hardlink delivery** — cache hits are served by hardlinking the cached artifact to the output path — a single syscall instead of reading + writing the file contents.
 - **Multi-file fast path** — when a build system passes N source files in one invocation, zccache checks all N against the cache in parallel, serves hits immediately, and batches only the misses into a single compiler process.
 
@@ -156,7 +156,7 @@ See [`docs/FEATURE-MATRIX.md`](docs/FEATURE-MATRIX.md) for the long-form view wi
 | Feature | zccache | sccache |
 |---|:---:|:---:|
 | Persistent daemon with sub-ms IPC | yes | partial |
-| Single-roundtrip IPC (length-prefixed bincode) | yes | no |
+| Single-roundtrip IPC (length-prefixed daemon frame) | yes | no |
 | Hardlink delivery on hit | yes | no |
 | In-memory metadata cache (DashMap) | yes | no |
 | Filesystem watcher (notify-backed) | yes | no |
@@ -436,6 +436,13 @@ soldr development, use `ZCCACHE_DAEMON_NAMESPACE=dev` or a more specific value
 such as `soldr-dev`. `zccache-daemon-dev` is not a separate shipped binary; it
 is represented by the documented namespace mode so the `zccache` CLI, wrapper
 mode, and direct daemon entrypoint all resolve the same daemon identity.
+
+### Daemon wire migration
+
+The active daemon wire remains v15 bincode while the v16 prost schema and
+dispatcher foundation land. `ZCCACHE_DAEMON_WIRE=prost` is reserved for the
+future prost default, and `ZCCACHE_DAEMON_WIRE=bincode` is the documented
+fallback spelling for keeping v15 behavior during the migration.
 
 ### Worktree cache sharing
 

--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -115,6 +115,10 @@ criterion = { version = "0.5", features = ["html_reports"] }
 # test_support module without needing a separate workspace member.
 zccache = { path = ".", features = ["test-support"] }
 
+[build-dependencies]
+prost-build = { workspace = true }
+protoc-bin-vendored = { workspace = true }
+
 [[bench]]
 name = "hashing"
 harness = false

--- a/crates/zccache/build.rs
+++ b/crates/zccache/build.rs
@@ -1,8 +1,22 @@
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    compile_zccache_wire_proto();
+
     // Expose the build's target triple at runtime so `zccache symbols install`
     // can construct the matching GitHub Release asset URL without asking the
     // user to type it. `TARGET` is set by cargo for build scripts.
     let target = std::env::var("TARGET").expect("cargo sets TARGET for build scripts");
     println!("cargo:rustc-env=ZCCACHE_BUILD_TARGET={target}");
+}
+
+fn compile_zccache_wire_proto() {
+    println!("cargo:rerun-if-changed=proto/zccache_v1.proto");
+
+    let protoc = protoc_bin_vendored::protoc_bin_path()
+        .expect("vendored protoc is available for zccache wire protobufs");
+    std::env::set_var("PROTOC", protoc);
+
+    prost_build::Config::new()
+        .compile_protos(&["proto/zccache_v1.proto"], &["proto"])
+        .expect("zccache wire protobufs compile");
 }

--- a/crates/zccache/proto/zccache_v1.proto
+++ b/crates/zccache/proto/zccache_v1.proto
@@ -1,0 +1,382 @@
+syntax = "proto3";
+
+package zccache.v1;
+
+message Frame {
+  uint32 protocol_version = 1;
+  bytes payload = 2;
+  string payload_type = 3;
+}
+
+message Empty {}
+
+message Path {
+  string value = 1;
+}
+
+message EnvVar {
+  string name = 1;
+  string value = 2;
+}
+
+message Request {
+  oneof body {
+    Empty ping = 1;
+    Empty shutdown = 2;
+    Empty status = 3;
+    Lookup lookup = 4;
+    Store store = 5;
+    SessionStart session_start = 6;
+    Compile compile = 7;
+    SessionEnd session_end = 8;
+    Empty clear = 9;
+    CompileEphemeral compile_ephemeral = 10;
+    LinkEphemeral link_ephemeral = 11;
+    SessionStatsRequest session_stats = 12;
+    FingerprintCheck fingerprint_check = 13;
+    FingerprintMarkSuccess fingerprint_mark_success = 14;
+    FingerprintMarkFailure fingerprint_mark_failure = 15;
+    FingerprintInvalidate fingerprint_invalidate = 16;
+    Empty list_rust_artifacts = 17;
+    GenericToolExec generic_tool_exec = 18;
+    ReleaseWorktreeHandles release_worktree_handles = 19;
+  }
+  string request_id = 100;
+}
+
+message Response {
+  oneof body {
+    Empty pong = 1;
+    Empty shutting_down = 2;
+    DaemonStatus status = 3;
+    LookupResult lookup_result = 4;
+    StoreResult store_result = 5;
+    SessionStarted session_started = 6;
+    CompileResult compile_result = 7;
+    SessionEnded session_ended = 8;
+    LinkResult link_result = 9;
+    Error error = 10;
+    Cleared cleared = 11;
+    SessionStatsResult session_stats_result = 12;
+    FingerprintCheckResult fingerprint_check_result = 13;
+    Empty fingerprint_ack = 14;
+    RustArtifactList rust_artifact_list = 15;
+    GenericToolExecResult generic_tool_exec_result = 16;
+    Backpressure backpressure = 17;
+    ReleaseWorktreeHandlesResult release_worktree_handles_result = 18;
+  }
+  string request_id = 100;
+}
+
+message Lookup {
+  string cache_key = 1;
+}
+
+message Store {
+  string cache_key = 1;
+  ArtifactData artifact = 2;
+}
+
+message SessionStart {
+  uint32 client_pid = 1;
+  Path working_dir = 2;
+  optional Path log_file = 3;
+  bool track_stats = 4;
+  optional Path journal_path = 5;
+  bool profile = 6;
+  optional PrivateDaemonSessionOptions private_daemon = 7;
+}
+
+message PrivateDaemonSessionOptions {
+  optional string daemon_name = 1;
+  optional string endpoint = 2;
+  optional Path cache_dir = 3;
+  repeated uint32 owner_pids = 4;
+  repeated EnvVar env = 5;
+}
+
+message Compile {
+  string session_id = 1;
+  repeated string args = 2;
+  Path cwd = 3;
+  Path compiler = 4;
+  repeated EnvVar env = 5;
+  bool env_is_set = 6;
+  bytes stdin = 7;
+}
+
+message SessionEnd {
+  string session_id = 1;
+}
+
+message CompileEphemeral {
+  uint32 client_pid = 1;
+  Path working_dir = 2;
+  Path compiler = 3;
+  repeated string args = 4;
+  Path cwd = 5;
+  repeated EnvVar env = 6;
+  bool env_is_set = 7;
+  bytes stdin = 8;
+}
+
+message LinkEphemeral {
+  uint32 client_pid = 1;
+  Path tool = 2;
+  repeated string args = 3;
+  Path cwd = 4;
+  repeated EnvVar env = 5;
+  bool env_is_set = 6;
+}
+
+message SessionStatsRequest {
+  string session_id = 1;
+}
+
+message FingerprintCheck {
+  Path cache_file = 1;
+  string cache_type = 2;
+  Path root = 3;
+  repeated string extensions = 4;
+  repeated string include_globs = 5;
+  repeated string exclude = 6;
+}
+
+message FingerprintMarkSuccess {
+  Path cache_file = 1;
+}
+
+message FingerprintMarkFailure {
+  Path cache_file = 1;
+}
+
+message FingerprintInvalidate {
+  Path cache_file = 1;
+}
+
+message GenericToolExec {
+  Path tool = 1;
+  repeated string args = 2;
+  Path cwd = 3;
+  repeated EnvVar env = 4;
+  repeated Path input_files = 5;
+  bytes input_extra = 6;
+  ExecOutputStreams output_streams = 7;
+  repeated Path output_files = 8;
+  optional bytes tool_hash = 9;
+  ExecCachePolicy cache_policy = 10;
+  bool cwd_in_key = 11;
+  repeated Path include_scan_files = 12;
+  repeated Path include_dirs = 13;
+  repeated Path system_include_dirs = 14;
+  repeated Path iquote_dirs = 15;
+  optional Path depfile = 16;
+  bool non_deterministic = 17;
+  repeated string key_args_filter = 18;
+}
+
+message ReleaseWorktreeHandles {
+  Path path = 1;
+}
+
+message ArtifactData {
+  repeated ArtifactOutput outputs = 1;
+  bytes stdout = 2;
+  bytes stderr = 3;
+  int32 exit_code = 4;
+}
+
+message ArtifactOutput {
+  string name = 1;
+  ArtifactPayload payload = 2;
+}
+
+message ArtifactPayload {
+  oneof body {
+    bytes bytes = 1;
+    Path path = 2;
+  }
+}
+
+message LookupResult {
+  oneof body {
+    ArtifactData hit = 1;
+    Empty miss = 2;
+  }
+}
+
+message StoreResult {
+  StoreResultKind kind = 1;
+}
+
+enum StoreResultKind {
+  STORE_RESULT_KIND_UNSPECIFIED = 0;
+  STORE_RESULT_KIND_STORED = 1;
+  STORE_RESULT_KIND_ALREADY_EXISTS = 2;
+}
+
+message ExecOutputStreams {
+  bool stdout = 1;
+  bool stderr = 2;
+}
+
+enum ExecCachePolicy {
+  EXEC_CACHE_POLICY_UNSPECIFIED = 0;
+  EXEC_CACHE_POLICY_NORMAL = 1;
+  EXEC_CACHE_POLICY_BYPASS = 2;
+  EXEC_CACHE_POLICY_READ_ONLY = 3;
+}
+
+message DaemonStatus {
+  string version = 1;
+  string daemon_namespace = 2;
+  string endpoint = 3;
+  PrivateDaemonStatus private_daemon = 4;
+  uint64 artifact_count = 5;
+  uint64 cache_size_bytes = 6;
+  uint64 metadata_entries = 7;
+  uint64 uptime_secs = 8;
+  uint64 cache_hits = 9;
+  uint64 cache_misses = 10;
+  uint64 total_compilations = 11;
+  uint64 non_cacheable = 12;
+  uint64 compile_errors = 13;
+  uint64 compile_errors_cached = 14;
+  uint64 time_saved_ms = 15;
+  uint64 total_links = 16;
+  uint64 link_hits = 17;
+  uint64 link_misses = 18;
+  uint64 link_non_cacheable = 19;
+  uint64 dep_graph_contexts = 20;
+  uint64 dep_graph_files = 21;
+  uint64 sessions_total = 22;
+  uint64 sessions_active = 23;
+  Path cache_dir = 24;
+  uint32 dep_graph_version = 25;
+  uint64 dep_graph_disk_size = 26;
+  bool dep_graph_persisted = 27;
+}
+
+message PrivateDaemonOwnerStatus {
+  uint32 pid = 1;
+  uint64 ref_count = 2;
+}
+
+message PrivateDaemonStatus {
+  bool enabled = 1;
+  repeated PrivateDaemonOwnerStatus owners = 2;
+  repeated string private_env_keys = 3;
+}
+
+message SessionStats {
+  uint64 duration_ms = 1;
+  uint64 compilations = 2;
+  uint64 hits = 3;
+  uint64 misses = 4;
+  uint64 non_cacheable = 5;
+  uint64 errors = 6;
+  uint64 errors_cached = 7;
+  uint64 time_saved_ms = 8;
+  uint64 unique_sources = 9;
+  uint64 bytes_read = 10;
+  uint64 bytes_written = 11;
+  optional PhaseProfileSummary phase_profile = 12;
+}
+
+message PhaseProfileSummary {
+  uint64 hit_count = 1;
+  uint64 miss_count = 2;
+  uint64 parse_args_ns = 3;
+  uint64 build_context_ns = 4;
+  uint64 hash_source_ns = 5;
+  uint64 hash_headers_ns = 6;
+  uint64 depgraph_check_ns = 7;
+  uint64 request_cache_lookup_ns = 8;
+  uint64 cross_root_validate_ns = 9;
+  uint64 artifact_lookup_ns = 10;
+  uint64 write_output_ns = 11;
+  uint64 bookkeeping_ns = 12;
+  uint64 total_hit_ns = 13;
+  uint64 compiler_exec_ns = 14;
+  uint64 include_scan_ns = 15;
+  uint64 hash_all_ns = 16;
+  uint64 artifact_store_ns = 17;
+  uint64 total_miss_ns = 18;
+}
+
+message SessionStarted {
+  string session_id = 1;
+  optional Path journal_path = 2;
+}
+
+message CompileResult {
+  int32 exit_code = 1;
+  bytes stdout = 2;
+  bytes stderr = 3;
+  bool cached = 4;
+}
+
+message SessionEnded {
+  optional SessionStats stats = 1;
+}
+
+message LinkResult {
+  int32 exit_code = 1;
+  bytes stdout = 2;
+  bytes stderr = 3;
+  bool cached = 4;
+  optional string warning = 5;
+}
+
+message Error {
+  string message = 1;
+}
+
+message Cleared {
+  uint64 artifacts_removed = 1;
+  uint64 metadata_cleared = 2;
+  uint64 dep_graph_contexts_cleared = 3;
+  uint64 on_disk_bytes_freed = 4;
+}
+
+message SessionStatsResult {
+  optional SessionStats stats = 1;
+}
+
+message FingerprintCheckResult {
+  string decision = 1;
+  optional string reason = 2;
+  repeated string changed_files = 3;
+}
+
+message RustArtifactInfo {
+  string cache_key = 1;
+  repeated string output_names = 2;
+  uint64 payload_count = 3;
+}
+
+message RustArtifactList {
+  repeated RustArtifactInfo artifacts = 1;
+}
+
+message GenericToolExecResult {
+  int32 exit_code = 1;
+  bytes stdout = 2;
+  bytes stderr = 3;
+  repeated ArtifactOutput output_files = 4;
+  bool cached = 5;
+  string cache_key_hex = 6;
+}
+
+message Backpressure {
+  uint32 queue_depth = 1;
+  uint32 retry_after_ms = 2;
+  string reason = 3;
+}
+
+message ReleaseWorktreeHandlesResult {
+  uint32 inspected = 1;
+  uint32 released = 2;
+  repeated string sessions_dropped = 3;
+  repeated Path unreleased = 4;
+}

--- a/crates/zccache/src/protocol/README.md
+++ b/crates/zccache/src/protocol/README.md
@@ -1,6 +1,9 @@
 # zccache-protocol
 
-Wire protocol: `Request`/`Response` enums, length-prefixed bincode framing.
+Wire protocol: `Request`/`Response` enums over a length-prefixed daemon frame.
+The active compatibility path is v15 bincode. The v16 prost schema is generated
+from `proto/zccache_v1.proto` and scaffolded in `wire_prost.rs` so the daemon can
+later dispatch both v15 bincode and v16 prost frames during migration.
 
 ## Module Layout
 
@@ -11,10 +14,20 @@ Domain payloads live next to it:
 - `messages/artifact.rs`: artifact cache payloads and Rust artifact listings.
 - `messages/exec.rs`: generic tool execution request options.
 - `messages/compat.rs`: bincode roundtrip and variant-index guards.
+- `wire_prost.rs`: generated protobuf module, v16 frame helpers, and
+  `ZCCACHE_DAEMON_WIRE` parsing.
 
 New protocol payload structs should land in the closest domain module. New
 enum variants must still be appended in `messages/mod.rs` and require a
 `PROTOCOL_VERSION` bump.
+
+## Wire Migration
+
+`PROTOCOL_VERSION` remains `15` while the public `encode_message` and
+`decode_message` helpers emit and accept bincode bodies. `PROST_PROTOCOL_VERSION`
+is `16` for the planned prost path. `ZCCACHE_DAEMON_WIRE=prost` is reserved for
+the future v16 client default, and `ZCCACHE_DAEMON_WIRE=bincode` is the fallback
+spelling that will keep old v15 behavior available during the transition.
 
 ## Request Variants
 

--- a/crates/zccache/src/protocol/mod.rs
+++ b/crates/zccache/src/protocol/mod.rs
@@ -1,17 +1,34 @@
 //! IPC protocol types and serialization for zccache.
 //!
 //! Defines the message types exchanged between CLI/wrapper and daemon,
-//! and provides serialization/deserialization using bincode.
+//! and provides serialization/deserialization using the active daemon wire.
 
 pub mod messages;
+pub mod wire_prost;
 
 pub use messages::*;
+
+/// Current bincode daemon wire version.
+///
+/// This remains the active compatibility version until the v16 prost dispatcher
+/// is wired through the IPC transport. Do not change `PROTOCOL_VERSION` to v16
+/// while `encode_message` and `decode_message` still serialize bincode bodies.
+pub const BINCODE_PROTOCOL_VERSION: u32 = 15;
+
+/// Planned prost daemon wire version.
+///
+/// The prost schema and frame helpers use this value. A future change will make
+/// the daemon dispatch v15 bincode and v16 prost frames concurrently.
+pub const PROST_PROTOCOL_VERSION: u32 = 16;
 
 /// Protocol version number. Bump this when the wire format changes:
 /// new/removed/reordered enum variants or struct field changes.
 /// Patch releases that don't change the protocol keep the same version.
 ///
-/// v15 (current): added `Request::ReleaseWorktreeHandles` /
+/// v16 (planned): prost-encoded protobuf body. The v16 schema lives in
+///                  `proto/zccache_v1.proto`; v15 bincode remains accepted
+///                  during the transition.
+/// v15 (current bincode): added `Request::ReleaseWorktreeHandles` /
 ///                  `Response::ReleaseWorktreeHandlesResult` so callers
 ///                  (soldr Tier 3 worktree teardown, issue #690) can ask
 ///                  the daemon to drop sessions and close per-session
@@ -33,7 +50,7 @@ pub use messages::*;
 ///     so per-session aggregate phase timing reaches clients.
 /// v8: `Compile` / `CompileEphemeral` gained `stdin: Vec<u8>` and
 ///     `ArtifactPayload` replaced `ArtifactOutput.data: Arc<Vec<u8>>`.
-pub const PROTOCOL_VERSION: u32 = 15;
+pub const PROTOCOL_VERSION: u32 = BINCODE_PROTOCOL_VERSION;
 
 use bytes::{Buf, BufMut, BytesMut};
 

--- a/crates/zccache/src/protocol/wire_prost.rs
+++ b/crates/zccache/src/protocol/wire_prost.rs
@@ -1,0 +1,154 @@
+//! Prost wire helpers and v16 dispatcher scaffolding.
+//!
+//! The live daemon wire remains v15 bincode today. This module intentionally
+//! models the v16 prost path without changing `encode_message` /
+//! `decode_message`, so old clients keep working while the generated protobuf
+//! types and compatibility tests land first.
+
+use bytes::{Buf, BufMut, BytesMut};
+use prost::Message;
+
+use super::{ProtocolError, BINCODE_PROTOCOL_VERSION, MAX_MESSAGE_SIZE, PROST_PROTOCOL_VERSION};
+
+/// Generated protobuf schema for the planned zccache v1 wire.
+pub mod zccache_v1 {
+    include!(concat!(env!("OUT_DIR"), "/zccache.v1.rs"));
+}
+
+/// Environment variable reserved for the daemon wire migration fallback.
+pub const WIRE_FORMAT_ENV: &str = "ZCCACHE_DAEMON_WIRE";
+
+/// Supported daemon wire families.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WireFormat {
+    /// Current v15 bincode body.
+    BincodeV15,
+    /// Planned v16 prost body.
+    ProstV16,
+}
+
+impl WireFormat {
+    /// Protocol version carried in the existing frame header.
+    #[must_use]
+    pub const fn protocol_version(self) -> u32 {
+        match self {
+            Self::BincodeV15 => BINCODE_PROTOCOL_VERSION,
+            Self::ProstV16 => PROST_PROTOCOL_VERSION,
+        }
+    }
+}
+
+/// Return the wire family for a protocol-version header.
+#[must_use]
+pub const fn wire_format_for_protocol_version(version: u32) -> Option<WireFormat> {
+    match version {
+        BINCODE_PROTOCOL_VERSION => Some(WireFormat::BincodeV15),
+        PROST_PROTOCOL_VERSION => Some(WireFormat::ProstV16),
+        _ => None,
+    }
+}
+
+/// Parse a `ZCCACHE_DAEMON_WIRE` value.
+///
+/// `None` keeps the current v15 bincode path active. The value is modeled now
+/// so callers and docs can agree on accepted spellings before the live
+/// dispatcher flips the default to prost.
+///
+/// # Errors
+///
+/// Returns a message suitable for diagnostics when the value is not recognized.
+pub fn wire_format_from_env_value(value: Option<&str>) -> Result<WireFormat, String> {
+    let Some(value) = value else {
+        return Ok(WireFormat::BincodeV15);
+    };
+
+    match value.trim().to_ascii_lowercase().as_str() {
+        "" | "auto" => Ok(WireFormat::BincodeV15),
+        "bincode" | "bincode-v15" | "v15" => Ok(WireFormat::BincodeV15),
+        "prost" | "prost-v16" | "v16" => Ok(WireFormat::ProstV16),
+        other => Err(format!(
+            "invalid {WIRE_FORMAT_ENV}={other:?}; expected auto, bincode, or prost"
+        )),
+    }
+}
+
+/// Read `ZCCACHE_DAEMON_WIRE` from the process environment.
+///
+/// # Errors
+///
+/// Returns a message suitable for diagnostics when the value is not recognized.
+pub fn wire_format_from_env() -> Result<WireFormat, String> {
+    wire_format_from_env_value(std::env::var(WIRE_FORMAT_ENV).ok().as_deref())
+}
+
+/// Serialize a prost message to the planned v16 length-prefixed frame.
+///
+/// Format: `[4-byte LE length][4-byte LE protocol version][prost payload]`.
+/// The length field covers the protocol version plus payload bytes, matching
+/// the existing bincode frame envelope.
+///
+/// # Errors
+///
+/// Returns an error if prost encoding fails or the payload exceeds the frame
+/// size budget.
+pub fn encode_prost_message<M: Message>(msg: &M) -> Result<BytesMut, ProtocolError> {
+    let mut payload = Vec::with_capacity(msg.encoded_len());
+    msg.encode(&mut payload)
+        .map_err(|e| ProtocolError::Serialization(e.to_string()))?;
+
+    let frame_len: u32 = (4 + payload.len())
+        .try_into()
+        .map_err(|_| ProtocolError::MessageTooLarge(payload.len()))?;
+
+    let mut buf = BytesMut::with_capacity(4 + 4 + payload.len());
+    buf.put_u32_le(frame_len);
+    buf.put_u32_le(PROST_PROTOCOL_VERSION);
+    buf.extend_from_slice(&payload);
+    Ok(buf)
+}
+
+/// Try to decode a v16 prost message from a byte buffer.
+///
+/// Returns `None` when the buffer does not contain a complete frame.
+///
+/// # Errors
+///
+/// Returns a version mismatch for non-v16 frames and a deserialization error
+/// for malformed prost payloads.
+pub fn decode_prost_message<M: Message + Default>(
+    buf: &mut BytesMut,
+) -> Result<Option<M>, ProtocolError> {
+    if buf.len() < 4 {
+        return Ok(None);
+    }
+
+    let len = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+    if len > MAX_MESSAGE_SIZE {
+        return Err(ProtocolError::MessageTooLarge(len));
+    }
+
+    if buf.len() < 4 + len {
+        return Ok(None);
+    }
+
+    if len < 4 {
+        return Err(ProtocolError::Deserialization(
+            "frame too small for protocol version".into(),
+        ));
+    }
+
+    buf.advance(4);
+    let frame = buf.split_to(len);
+
+    let remote_ver = u32::from_le_bytes([frame[0], frame[1], frame[2], frame[3]]);
+    if remote_ver != PROST_PROTOCOL_VERSION {
+        return Err(ProtocolError::VersionMismatch {
+            expected: PROST_PROTOCOL_VERSION,
+            received: remote_ver,
+        });
+    }
+
+    M::decode(&frame[4..])
+        .map(Some)
+        .map_err(|e| ProtocolError::Deserialization(e.to_string()))
+}

--- a/crates/zccache/tests/daemon_wire_perf_scaffold.rs
+++ b/crates/zccache/tests/daemon_wire_perf_scaffold.rs
@@ -1,0 +1,53 @@
+use bytes::BytesMut;
+use std::time::Instant;
+use zccache::protocol::wire_prost::{decode_prost_message, encode_prost_message, zccache_v1 as pb};
+
+#[test]
+fn prost_roundtrip_perf_scaffold_records_nonzero_samples() {
+    let request = pb::Request {
+        body: Some(pb::request::Body::CompileEphemeral(pb::CompileEphemeral {
+            client_pid: 123,
+            working_dir: Some(pb::Path {
+                value: "/work/project".to_string(),
+            }),
+            compiler: Some(pb::Path {
+                value: "/usr/bin/clang++".to_string(),
+            }),
+            args: vec![
+                "-c".to_string(),
+                "main.cc".to_string(),
+                "-o".to_string(),
+                "main.o".to_string(),
+            ],
+            cwd: Some(pb::Path {
+                value: "/work/project".to_string(),
+            }),
+            env: vec![pb::EnvVar {
+                name: "PATH".to_string(),
+                value: "/usr/bin".to_string(),
+            }],
+            env_is_set: true,
+            stdin: Vec::new(),
+        })),
+        request_id: "perf-sample".to_string(),
+    };
+
+    let start = Instant::now();
+    let mut bytes = 0usize;
+    for _ in 0..128 {
+        let encoded = encode_prost_message(&request).unwrap();
+        bytes += encoded.len();
+        let mut buf = BytesMut::from(&encoded[..]);
+        let decoded = decode_prost_message::<pb::Request>(&mut buf)
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            decoded.body,
+            Some(pb::request::Body::CompileEphemeral(_))
+        ));
+    }
+
+    let elapsed = start.elapsed();
+    assert!(bytes > 0);
+    assert!(elapsed.as_nanos() > 0);
+}

--- a/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
+++ b/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
@@ -1,0 +1,109 @@
+use bytes::BytesMut;
+use prost::Message;
+use zccache::protocol::wire_prost::{
+    decode_prost_message, encode_prost_message, wire_format_for_protocol_version, zccache_v1 as pb,
+    WireFormat,
+};
+use zccache::protocol::{decode_message, encode_message, PROST_PROTOCOL_VERSION};
+
+#[test]
+fn prost_request_frame_roundtrips_with_v16_header() {
+    let request = pb::Request {
+        body: Some(pb::request::Body::Ping(pb::Empty {})),
+        request_id: "req-1".to_string(),
+    };
+
+    let encoded = encode_prost_message(&request).unwrap();
+    let version = u32::from_le_bytes([encoded[4], encoded[5], encoded[6], encoded[7]]);
+    assert_eq!(version, PROST_PROTOCOL_VERSION);
+
+    let mut buf = BytesMut::from(&encoded[..]);
+    let decoded = decode_prost_message::<pb::Request>(&mut buf)
+        .unwrap()
+        .unwrap();
+    assert_eq!(decoded.request_id, "req-1");
+    assert!(matches!(decoded.body, Some(pb::request::Body::Ping(_))));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn prost_response_frame_roundtrips_release_worktree_result() {
+    let response = pb::Response {
+        body: Some(pb::response::Body::ReleaseWorktreeHandlesResult(
+            pb::ReleaseWorktreeHandlesResult {
+                inspected: 2,
+                released: 1,
+                sessions_dropped: vec!["session-a".to_string()],
+                unreleased: vec![pb::Path {
+                    value: "/tmp/worktree/locked.obj".to_string(),
+                }],
+            },
+        )),
+        request_id: "req-release".to_string(),
+    };
+
+    let encoded = encode_prost_message(&response).unwrap();
+    let mut buf = BytesMut::from(&encoded[..]);
+    let decoded = decode_prost_message::<pb::Response>(&mut buf)
+        .unwrap()
+        .unwrap();
+
+    match decoded.body {
+        Some(pb::response::Body::ReleaseWorktreeHandlesResult(result)) => {
+            assert_eq!(result.inspected, 2);
+            assert_eq!(result.released, 1);
+            assert_eq!(result.sessions_dropped, ["session-a"]);
+            assert_eq!(result.unreleased[0].value, "/tmp/worktree/locked.obj");
+        }
+        _ => panic!("expected release-worktree response"),
+    }
+}
+
+#[test]
+fn generated_frame_envelope_can_carry_opaque_payload() {
+    let request = pb::Request {
+        body: Some(pb::request::Body::Status(pb::Empty {})),
+        request_id: "req-status".to_string(),
+    };
+    let payload = request.encode_to_vec();
+    let frame = pb::Frame {
+        protocol_version: PROST_PROTOCOL_VERSION,
+        payload,
+        payload_type: "zccache.v1.Request".to_string(),
+    };
+
+    let encoded = encode_prost_message(&frame).unwrap();
+    let mut buf = BytesMut::from(&encoded[..]);
+    let decoded = decode_prost_message::<pb::Frame>(&mut buf)
+        .unwrap()
+        .unwrap();
+    let request = pb::Request::decode(&decoded.payload[..]).unwrap();
+
+    assert_eq!(decoded.protocol_version, PROST_PROTOCOL_VERSION);
+    assert_eq!(decoded.payload_type, "zccache.v1.Request");
+    assert!(matches!(request.body, Some(pb::request::Body::Status(_))));
+}
+
+#[test]
+fn bincode_v15_frame_still_roundtrips_on_current_api() {
+    let encoded = encode_message(&zccache::protocol::Request::Ping).unwrap();
+    let mut buf = BytesMut::from(&encoded[..]);
+    let decoded = decode_message::<zccache::protocol::Request>(&mut buf)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(decoded, zccache::protocol::Request::Ping);
+}
+
+#[test]
+fn protocol_version_dispatch_models_v15_and_v16() {
+    assert_eq!(
+        wire_format_for_protocol_version(WireFormat::BincodeV15.protocol_version()),
+        Some(WireFormat::BincodeV15)
+    );
+    assert_eq!(
+        wire_format_for_protocol_version(WireFormat::ProstV16.protocol_version()),
+        Some(WireFormat::ProstV16)
+    );
+    assert_eq!(wire_format_for_protocol_version(99), None);
+}

--- a/crates/zccache/tests/daemon_wire_protocol_version.rs
+++ b/crates/zccache/tests/daemon_wire_protocol_version.rs
@@ -1,0 +1,40 @@
+use zccache::protocol::wire_prost::{wire_format_from_env_value, WireFormat, WIRE_FORMAT_ENV};
+use zccache::protocol::{BINCODE_PROTOCOL_VERSION, PROST_PROTOCOL_VERSION, PROTOCOL_VERSION};
+
+#[test]
+fn current_protocol_version_remains_v15_bincode() {
+    assert_eq!(PROTOCOL_VERSION, BINCODE_PROTOCOL_VERSION);
+    assert_ne!(PROTOCOL_VERSION, PROST_PROTOCOL_VERSION);
+}
+
+#[test]
+fn wire_env_accepts_current_and_planned_modes() {
+    assert_eq!(
+        wire_format_from_env_value(None).unwrap(),
+        WireFormat::BincodeV15
+    );
+    assert_eq!(
+        wire_format_from_env_value(Some("auto")).unwrap(),
+        WireFormat::BincodeV15
+    );
+    assert_eq!(
+        wire_format_from_env_value(Some("bincode")).unwrap(),
+        WireFormat::BincodeV15
+    );
+    assert_eq!(
+        wire_format_from_env_value(Some("prost")).unwrap(),
+        WireFormat::ProstV16
+    );
+    assert_eq!(
+        wire_format_from_env_value(Some("v16")).unwrap(),
+        WireFormat::ProstV16
+    );
+}
+
+#[test]
+fn wire_env_rejects_unknown_values() {
+    let err = wire_format_from_env_value(Some("json")).unwrap_err();
+    assert!(err.contains(WIRE_FORMAT_ENV));
+    assert!(err.contains("bincode"));
+    assert!(err.contains("prost"));
+}


### PR DESCRIPTION
## Summary

- add `crates/zccache/proto/zccache_v1.proto` covering the current daemon request/response surface and a prost `Frame` envelope
- wire `prost-build` with vendored `protoc` in `crates/zccache/build.rs`
- add v16 prost frame encode/decode helpers plus `ZCCACHE_DAEMON_WIRE` parsing while keeping the active v15 bincode `PROTOCOL_VERSION` unchanged
- document the staged daemon wire migration and fallback spelling
- add prost roundtrip, protocol-version, v15 compatibility, and perf-scaffold tests

## Remaining acceptance gaps

This is a foundation PR, not the full bincode-to-prost migration.

- live IPC transport still calls the v15 bincode `encode_message` / `decode_message` path
- daemon does not yet dispatch both v15 bincode and v16 prost frames concurrently
- client does not yet default to prost or apply `ZCCACHE_DAEMON_WIRE` at send time
- generated protobuf types are not yet converted to/from every existing Rust `Request` / `Response` variant
- previous-release-client cross-version test is not implemented yet
- no hot-path p50/p99 prost-vs-bincode regression budget is enforced yet

Coordinated with zackees/running-process#234.
Refs zackees/running-process#234
Refs #698