### PR TITLE
feat: add prost wire dispatcher hook

### DIFF
--- a/crates/zccache/src/protocol/README.md
+++ b/crates/zccache/src/protocol/README.md
@@ -16,6 +16,8 @@ Domain payloads live next to it:
 - `messages/compat.rs`: bincode roundtrip and variant-index guards.
 - `wire_prost.rs`: generated protobuf module, v16 frame helpers, and
   `ZCCACHE_DAEMON_WIRE` parsing.
+- `decode_wire_message`: migration dispatcher hook that peeks the frame
+  protocol-version header and selects v15 bincode or v16 prost decoding.
 
 New protocol payload structs should land in the closest domain module. New
 enum variants must still be appended in `messages/mod.rs` and require a
@@ -25,9 +27,11 @@ enum variants must still be appended in `messages/mod.rs` and require a
 
 `PROTOCOL_VERSION` remains `15` while the public `encode_message` and
 `decode_message` helpers emit and accept bincode bodies. `PROST_PROTOCOL_VERSION`
-is `16` for the planned prost path. `ZCCACHE_DAEMON_WIRE=prost` is reserved for
-the future v16 client default, and `ZCCACHE_DAEMON_WIRE=bincode` is the fallback
-spelling that will keep old v15 behavior available during the transition.
+is `16` for the planned prost path. `decode_wire_message` now models the daemon
+dispatcher that accepts both frame versions, but the live IPC transport has not
+switched to it yet. `ZCCACHE_DAEMON_WIRE` parsing models the intended client
+selection: unset or `auto` prefers prost, and `bincode` keeps the old v15
+fallback available during the transition.
 
 ## Request Variants
 

--- a/crates/zccache/src/protocol/mod.rs
+++ b/crates/zccache/src/protocol/mod.rs
@@ -53,6 +53,27 @@ pub const PROST_PROTOCOL_VERSION: u32 = 16;
 pub const PROTOCOL_VERSION: u32 = BINCODE_PROTOCOL_VERSION;
 
 use bytes::{Buf, BufMut, BytesMut};
+use prost::Message as ProstMessage;
+
+/// Message decoded from a version-dispatched daemon frame.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodedWireMessage<Bincode, Prost> {
+    /// v15 bincode payload, kept for old clients during the migration.
+    BincodeV15(Bincode),
+    /// v16 prost payload.
+    ProstV16(Prost),
+}
+
+impl<Bincode, Prost> DecodedWireMessage<Bincode, Prost> {
+    /// Wire family selected by the frame protocol-version header.
+    #[must_use]
+    pub const fn wire_format(&self) -> wire_prost::WireFormat {
+        match self {
+            Self::BincodeV15(_) => wire_prost::WireFormat::BincodeV15,
+            Self::ProstV16(_) => wire_prost::WireFormat::ProstV16,
+        }
+    }
+}
 
 /// Serialize a message to a length-prefixed byte buffer with protocol version.
 ///
@@ -64,6 +85,15 @@ use bytes::{Buf, BufMut, BytesMut};
 ///
 /// Returns an error if serialization fails.
 pub fn encode_message<T: serde::Serialize>(msg: &T) -> Result<BytesMut, ProtocolError> {
+    encode_bincode_message(msg)
+}
+
+/// Serialize a message to the v15 bincode compatibility frame.
+///
+/// # Errors
+///
+/// Returns an error if serialization fails.
+pub fn encode_bincode_message<T: serde::Serialize>(msg: &T) -> Result<BytesMut, ProtocolError> {
     let payload =
         bincode::serialize(msg).map_err(|e| ProtocolError::Serialization(e.to_string()))?;
     let frame_len: u32 = (4 + payload.len())
@@ -72,7 +102,7 @@ pub fn encode_message<T: serde::Serialize>(msg: &T) -> Result<BytesMut, Protocol
 
     let mut buf = BytesMut::with_capacity(4 + 4 + payload.len());
     buf.put_u32_le(frame_len);
-    buf.put_u32_le(PROTOCOL_VERSION);
+    buf.put_u32_le(BINCODE_PROTOCOL_VERSION);
     buf.extend_from_slice(&payload);
     Ok(buf)
 }
@@ -89,6 +119,82 @@ pub fn encode_message<T: serde::Serialize>(msg: &T) -> Result<BytesMut, Protocol
 pub fn decode_message<T: serde::de::DeserializeOwned>(
     buf: &mut BytesMut,
 ) -> Result<Option<T>, ProtocolError> {
+    decode_bincode_message(buf)
+}
+
+/// Try to decode a v15 bincode compatibility frame from a byte buffer.
+///
+/// Returns `None` if the buffer does not contain a complete message.
+/// Advances the buffer past the consumed message on success.
+///
+/// # Errors
+///
+/// Returns `VersionMismatch` if the sender is not using v15 bincode.
+/// Returns a deserialization error if the payload is malformed.
+pub fn decode_bincode_message<T: serde::de::DeserializeOwned>(
+    buf: &mut BytesMut,
+) -> Result<Option<T>, ProtocolError> {
+    let Some((remote_ver, payload)) = take_complete_frame(buf)? else {
+        return Ok(None);
+    };
+
+    if remote_ver != BINCODE_PROTOCOL_VERSION {
+        return Err(ProtocolError::VersionMismatch {
+            expected: BINCODE_PROTOCOL_VERSION,
+            received: remote_ver,
+        });
+    }
+
+    let msg = bincode::deserialize(&payload[..])
+        .map_err(|e| ProtocolError::Deserialization(e.to_string()))?;
+    Ok(Some(msg))
+}
+
+/// Try to decode either a v15 bincode or v16 prost frame from a byte buffer.
+///
+/// The live transport still calls [`decode_message`], which keeps today's v15
+/// behavior. This helper is the migration hook for the daemon dispatcher: it
+/// peeks the existing protocol-version header and routes to the compatible
+/// decoder without consuming incomplete or unsupported frames.
+///
+/// # Errors
+///
+/// Returns a protocol error if the frame version is unsupported, too large, or
+/// if the selected decoder cannot deserialize the payload.
+pub fn decode_wire_message<Bincode, Prost>(
+    buf: &mut BytesMut,
+) -> Result<Option<DecodedWireMessage<Bincode, Prost>>, ProtocolError>
+where
+    Bincode: serde::de::DeserializeOwned,
+    Prost: ProstMessage + Default,
+{
+    let Some(version) = peek_frame_protocol_version(buf)? else {
+        return Ok(None);
+    };
+
+    match wire_prost::wire_format_for_protocol_version(version) {
+        Some(wire_prost::WireFormat::BincodeV15) => {
+            decode_bincode_message(buf).map(|msg| msg.map(DecodedWireMessage::BincodeV15))
+        }
+        Some(wire_prost::WireFormat::ProstV16) => {
+            wire_prost::decode_prost_message(buf).map(|msg| msg.map(DecodedWireMessage::ProstV16))
+        }
+        None => Err(ProtocolError::VersionMismatch {
+            expected: PROST_PROTOCOL_VERSION,
+            received: version,
+        }),
+    }
+}
+
+/// Read the protocol-version header without consuming the buffer.
+///
+/// Returns `None` until a complete frame is buffered.
+///
+/// # Errors
+///
+/// Returns an error when the announced frame length is impossible or exceeds
+/// the maximum message size.
+pub fn peek_frame_protocol_version(buf: &BytesMut) -> Result<Option<u32>, ProtocolError> {
     if buf.len() < 4 {
         return Ok(None);
     }
@@ -99,8 +205,28 @@ pub fn decode_message<T: serde::de::DeserializeOwned>(
         return Err(ProtocolError::MessageTooLarge(len));
     }
 
+    if len < 4 {
+        return Err(ProtocolError::Deserialization(
+            "frame too small for protocol version".into(),
+        ));
+    }
+
     if buf.len() < 4 + len {
         return Ok(None);
+    }
+
+    Ok(Some(u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]])))
+}
+
+fn take_complete_frame(buf: &mut BytesMut) -> Result<Option<(u32, BytesMut)>, ProtocolError> {
+    if buf.len() < 4 {
+        return Ok(None);
+    }
+
+    let len = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+
+    if len > MAX_MESSAGE_SIZE {
+        return Err(ProtocolError::MessageTooLarge(len));
     }
 
     if len < 4 {
@@ -109,20 +235,14 @@ pub fn decode_message<T: serde::de::DeserializeOwned>(
         ));
     }
 
-    buf.advance(4);
-    let frame = buf.split_to(len);
-
-    let remote_ver = u32::from_le_bytes([frame[0], frame[1], frame[2], frame[3]]);
-    if remote_ver != PROTOCOL_VERSION {
-        return Err(ProtocolError::VersionMismatch {
-            expected: PROTOCOL_VERSION,
-            received: remote_ver,
-        });
+    if buf.len() < 4 + len {
+        return Ok(None);
     }
 
-    let msg = bincode::deserialize(&frame[4..])
-        .map_err(|e| ProtocolError::Deserialization(e.to_string()))?;
-    Ok(Some(msg))
+    buf.advance(4);
+    let mut frame = buf.split_to(len);
+    let remote_ver = frame.get_u32_le();
+    Ok(Some((remote_ver, frame)))
 }
 
 /// Maximum message size (16 MB).

--- a/crates/zccache/src/protocol/wire_prost.rs
+++ b/crates/zccache/src/protocol/wire_prost.rs
@@ -38,6 +38,9 @@ impl WireFormat {
     }
 }
 
+/// Planned default for new clients once the live transport uses the dispatcher.
+pub const DEFAULT_CLIENT_WIRE_FORMAT: WireFormat = WireFormat::ProstV16;
+
 /// Return the wire family for a protocol-version header.
 #[must_use]
 pub const fn wire_format_for_protocol_version(version: u32) -> Option<WireFormat> {
@@ -50,20 +53,21 @@ pub const fn wire_format_for_protocol_version(version: u32) -> Option<WireFormat
 
 /// Parse a `ZCCACHE_DAEMON_WIRE` value.
 ///
-/// `None` keeps the current v15 bincode path active. The value is modeled now
-/// so callers and docs can agree on accepted spellings before the live
-/// dispatcher flips the default to prost.
+/// `None` and `auto` model the migration target: new clients prefer v16 prost,
+/// while `bincode` remains the explicit v15 fallback spelling. The live
+/// transport still calls the bincode helpers directly until the daemon
+/// dispatcher is wired into IPC.
 ///
 /// # Errors
 ///
 /// Returns a message suitable for diagnostics when the value is not recognized.
 pub fn wire_format_from_env_value(value: Option<&str>) -> Result<WireFormat, String> {
     let Some(value) = value else {
-        return Ok(WireFormat::BincodeV15);
+        return Ok(DEFAULT_CLIENT_WIRE_FORMAT);
     };
 
     match value.trim().to_ascii_lowercase().as_str() {
-        "" | "auto" => Ok(WireFormat::BincodeV15),
+        "" | "auto" => Ok(DEFAULT_CLIENT_WIRE_FORMAT),
         "bincode" | "bincode-v15" | "v15" => Ok(WireFormat::BincodeV15),
         "prost" | "prost-v16" | "v16" => Ok(WireFormat::ProstV16),
         other => Err(format!(

--- a/crates/zccache/tests/daemon_wire_dispatcher.rs
+++ b/crates/zccache/tests/daemon_wire_dispatcher.rs
@@ -1,0 +1,86 @@
+use bytes::{BufMut, BytesMut};
+use zccache::protocol::wire_prost::{encode_prost_message, zccache_v1 as pb, WireFormat};
+use zccache::protocol::{
+    decode_wire_message, encode_message, peek_frame_protocol_version, DecodedWireMessage,
+    ProtocolError, Request, BINCODE_PROTOCOL_VERSION, PROST_PROTOCOL_VERSION,
+};
+
+#[test]
+fn dispatcher_decodes_v15_bincode_request() {
+    let encoded = encode_message(&Request::Ping).unwrap();
+    let mut buf = BytesMut::from(&encoded[..]);
+
+    assert_eq!(
+        peek_frame_protocol_version(&buf).unwrap(),
+        Some(BINCODE_PROTOCOL_VERSION)
+    );
+
+    let decoded = decode_wire_message::<Request, pb::Request>(&mut buf)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(decoded.wire_format(), WireFormat::BincodeV15);
+    assert_eq!(decoded, DecodedWireMessage::BincodeV15(Request::Ping));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn dispatcher_decodes_v16_prost_request() {
+    let request = pb::Request {
+        body: Some(pb::request::Body::Ping(pb::Empty {})),
+        request_id: "prost-dispatch".to_string(),
+    };
+    let encoded = encode_prost_message(&request).unwrap();
+    let mut buf = BytesMut::from(&encoded[..]);
+
+    assert_eq!(
+        peek_frame_protocol_version(&buf).unwrap(),
+        Some(PROST_PROTOCOL_VERSION)
+    );
+
+    let decoded = decode_wire_message::<Request, pb::Request>(&mut buf)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(decoded.wire_format(), WireFormat::ProstV16);
+    match decoded {
+        DecodedWireMessage::ProstV16(decoded) => {
+            assert_eq!(decoded.request_id, "prost-dispatch");
+            assert!(matches!(decoded.body, Some(pb::request::Body::Ping(_))));
+        }
+        DecodedWireMessage::BincodeV15(_) => panic!("expected prost request"),
+    }
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn dispatcher_waits_for_complete_frame_before_consuming() {
+    let encoded = encode_message(&Request::Ping).unwrap();
+    let mut buf = BytesMut::from(&encoded[..encoded.len() - 1]);
+    let before = buf.clone();
+
+    assert_eq!(peek_frame_protocol_version(&buf).unwrap(), None);
+    let decoded = decode_wire_message::<Request, pb::Request>(&mut buf).unwrap();
+
+    assert!(decoded.is_none());
+    assert_eq!(buf, before);
+}
+
+#[test]
+fn dispatcher_rejects_unknown_version_without_consuming() {
+    let mut buf = BytesMut::new();
+    buf.put_u32_le(4);
+    buf.put_u32_le(99);
+    let before = buf.clone();
+
+    let result = decode_wire_message::<Request, pb::Request>(&mut buf);
+
+    assert!(matches!(
+        result,
+        Err(ProtocolError::VersionMismatch {
+            expected: PROST_PROTOCOL_VERSION,
+            received: 99
+        })
+    ));
+    assert_eq!(buf, before);
+}

--- a/crates/zccache/tests/daemon_wire_protocol_version.rs
+++ b/crates/zccache/tests/daemon_wire_protocol_version.rs
@@ -11,11 +11,11 @@ fn current_protocol_version_remains_v15_bincode() {
 fn wire_env_accepts_current_and_planned_modes() {
     assert_eq!(
         wire_format_from_env_value(None).unwrap(),
-        WireFormat::BincodeV15
+        WireFormat::ProstV16
     );
     assert_eq!(
         wire_format_from_env_value(Some("auto")).unwrap(),
-        WireFormat::BincodeV15
+        WireFormat::ProstV16
     );
     assert_eq!(
         wire_format_from_env_value(Some("bincode")).unwrap(),


### PR DESCRIPTION
Coordinated with zackees/running-process#234 and zackees/running-process#242.
Refs #698.

## Summary

- add a `decode_wire_message` dispatcher hook that peeks the daemon frame protocol version and routes v15 bincode or v16 prost frames
- keep the live `encode_message` / `decode_message` IPC helpers on v15 bincode compatibility
- model the intended `ZCCACHE_DAEMON_WIRE` client selection: unset/auto prefers prost, explicit `bincode` keeps the v15 fallback
- document that the dispatcher exists but is not wired into the live IPC transport yet

## Tests

- `soldr cargo fmt --all`
- `soldr cargo test -p zccache --test daemon_wire_dispatcher --test daemon_wire_protocol_version --test daemon_wire_prost_roundtrip --test daemon_wire_perf_scaffold`
- `soldr cargo test -p zccache protocol`
- `soldr cargo check -p zccache --all-targets`
- `soldr cargo fmt --all --check`
- `git diff --check`

## Remaining running-process#234 gaps

- live daemon/client IPC still calls the v15 bincode helpers instead of the dispatcher
- v16 prost is not yet the active default on actual daemon requests
- generated protobuf messages still do not cover every Rust `Request` / `Response` variant with full typed conversions
- mixed live bincode/prost daemon-client compatibility tests are still pending
- previous-release-client cross-version coverage is still pending
- hot-path prost-vs-bincode p50/p99 budget enforcement is still scaffold-only
- running-process `Frame` wrapping and broker integration remain blocked on the finalized upstream API