### PR TITLE
feat: select daemon control wire format

### DIFF
--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -160,12 +160,12 @@ fn print_status(args: &Args) {
 async fn query_daemon_status(
     endpoint: &str,
 ) -> Result<zccache::protocol::DaemonStatus, Box<dyn std::error::Error>> {
-    let mut conn = zccache::ipc::connect(endpoint).await?;
-    // Client-style round trip: opt into the 5-minute default so a hung
-    // daemon surfaces as a Timeout rather than blocking forever.
-    conn.set_recv_timeout(zccache::ipc::DEFAULT_CLIENT_RECV_TIMEOUT);
-    conn.send(&zccache::protocol::Request::Status).await?;
-    let resp: Option<zccache::protocol::Response> = conn.recv().await?;
+    let resp = zccache::ipc::daemon_control_roundtrip(
+        endpoint,
+        zccache::ipc::DaemonControlRequest::Status,
+        None,
+    )
+    .await?;
     match resp {
         Some(zccache::protocol::Response::Status(s)) => Ok(s),
         Some(other) => Err(format!("unexpected response: {other:?}").into()),

--- a/crates/zccache/src/cli/client.rs
+++ b/crates/zccache/src/cli/client.rs
@@ -24,18 +24,18 @@ pub fn client_start(endpoint: Option<&str>) -> Result<(), String> {
 pub fn client_stop(endpoint: Option<&str>) -> Result<bool, String> {
     let endpoint = resolve_endpoint(endpoint);
     run_async(async move {
-        let mut conn = match connect_client(&endpoint).await {
-            Ok(c) => c,
-            Err(_) => return Ok(false),
-        };
-        conn.send(&crate::protocol::Request::Shutdown)
-            .await
-            .map_err(|e| format!("failed to send to daemon: {e}"))?;
-        match conn.recv::<crate::protocol::Response>().await {
+        match crate::ipc::daemon_control_roundtrip(
+            &endpoint,
+            crate::ipc::DaemonControlRequest::Shutdown,
+            None,
+        )
+        .await
+        {
             Ok(Some(crate::protocol::Response::ShuttingDown)) => Ok(true),
             Ok(Some(crate::protocol::Response::Error { message })) => Err(message),
             Ok(None) => Err("lost connection to daemon (no response received)".to_string()),
             Ok(Some(other)) => Err(format!("unexpected response from daemon: {other:?}")),
+            Err(e) if is_daemon_unreachable_err(&e) => Ok(false),
             Err(e) => Err(format!("broken connection to daemon: {e}")),
         }
     })
@@ -44,17 +44,20 @@ pub fn client_stop(endpoint: Option<&str>) -> Result<bool, String> {
 pub fn client_status(endpoint: Option<&str>) -> Result<crate::protocol::DaemonStatus, String> {
     let endpoint = resolve_endpoint(endpoint);
     run_async(async move {
-        let mut conn = connect_client(&endpoint)
-            .await
-            .map_err(|e| format!("daemon not running at {endpoint}: {e}"))?;
-        conn.send(&crate::protocol::Request::Status)
-            .await
-            .map_err(|e| format!("failed to send to daemon: {e}"))?;
-        match conn.recv::<crate::protocol::Response>().await {
+        match crate::ipc::daemon_control_roundtrip(
+            &endpoint,
+            crate::ipc::DaemonControlRequest::Status,
+            None,
+        )
+        .await
+        {
             Ok(Some(crate::protocol::Response::Status(status))) => Ok(status),
             Ok(Some(crate::protocol::Response::Error { message })) => Err(message),
             Ok(None) => Err("lost connection to daemon (no response received)".to_string()),
             Ok(Some(other)) => Err(format!("unexpected response from daemon: {other:?}")),
+            Err(e) if is_daemon_unreachable_err(&e) => {
+                Err(format!("daemon not running at {endpoint}: {e}"))
+            }
             Err(e) => Err(format!("broken connection to daemon: {e}")),
         }
     })

--- a/crates/zccache/src/cli/commands/daemon.rs
+++ b/crates/zccache/src/cli/commands/daemon.rs
@@ -20,6 +20,8 @@ pub(crate) enum VersionCheck {
     Unreachable,
     /// Connected but could not complete the version exchange (protocol mismatch, etc.).
     CommError,
+    /// Client-side daemon wire configuration is invalid.
+    ClientConfigError(String),
 }
 
 /// Connect to the daemon and compare its version to ours.
@@ -30,16 +32,12 @@ pub(crate) enum VersionCheck {
 /// (`ensure_daemon` → `stop_stale_daemon` → `spawn_and_wait`) then runs
 /// promptly. See issue #554.
 pub(crate) async fn check_daemon_version(endpoint: &str) -> VersionCheck {
-    let mut conn = match connect(endpoint).await {
-        Ok(c) => c,
-        Err(_) => return VersionCheck::Unreachable,
-    };
-    if conn.send(&crate::protocol::Request::Status).await.is_err() {
-        return VersionCheck::CommError;
-    }
-    match conn
-        .recv_with_timeout::<crate::protocol::Response>(status_probe_timeout())
-        .await
+    match crate::ipc::daemon_control_roundtrip(
+        endpoint,
+        crate::ipc::DaemonControlRequest::Status,
+        Some(status_probe_timeout()),
+    )
+    .await
     {
         Ok(Some(crate::protocol::Response::Status(s))) => {
             if s.version == crate::core::VERSION {
@@ -61,6 +59,14 @@ pub(crate) async fn check_daemon_version(endpoint: &str) -> VersionCheck {
                     daemon_ver: s.version,
                 },
             }
+        }
+        Err(crate::ipc::IpcError::Endpoint(message))
+            if message.contains(crate::protocol::wire_prost::WIRE_FORMAT_ENV) =>
+        {
+            VersionCheck::ClientConfigError(message)
+        }
+        Err(err) if crate::cli::client::is_daemon_unreachable_err(&err) => {
+            VersionCheck::Unreachable
         }
         _ => VersionCheck::CommError,
     }
@@ -97,12 +103,14 @@ pub(crate) async fn spawn_and_wait(endpoint: &str, reason: &str) -> Result<(), S
 /// Attempts graceful shutdown via IPC first, then falls back to force-killing
 /// the process via the lock file PID. Waits for the endpoint to be released.
 pub(crate) async fn stop_stale_daemon(endpoint: &str) {
-    // Try graceful shutdown via IPC
-    if let Ok(mut conn) = connect(endpoint).await {
-        let _ = conn.send(&crate::protocol::Request::Shutdown).await;
-        // Give it a moment to process the shutdown
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-    }
+    // Try graceful shutdown via IPC.
+    let _ = crate::ipc::daemon_control_roundtrip(
+        endpoint,
+        crate::ipc::DaemonControlRequest::Shutdown,
+        None,
+    )
+    .await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
     // Force-kill via lock file PID if the daemon is still alive
     if let Some(pid) = crate::ipc::check_running_daemon() {
@@ -162,6 +170,7 @@ pub(crate) async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
             return spawn_and_wait(endpoint, crate::core::lifecycle::REASON_REPLACED_COMM_ERROR)
                 .await;
         }
+        VersionCheck::ClientConfigError(message) => return Err(message),
         VersionCheck::Unreachable => {
             // Fall through to lock-file check / spawn
         }
@@ -205,6 +214,7 @@ pub(crate) async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
                     )
                     .await;
                 }
+                VersionCheck::ClientConfigError(message) => return Err(message),
                 VersionCheck::Unreachable => continue,
             }
         }
@@ -274,9 +284,15 @@ pub(crate) async fn cmd_start(endpoint: &str) -> ExitCode {
 }
 
 pub(crate) async fn cmd_stop(endpoint: &str) -> ExitCode {
-    let mut conn = match connect(endpoint).await {
-        Ok(c) => c,
-        Err(_) => {
+    let recv_result = match crate::ipc::daemon_control_roundtrip(
+        endpoint,
+        crate::ipc::DaemonControlRequest::Shutdown,
+        None,
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(e) if crate::cli::client::is_daemon_unreachable_err(&e) => {
             let Some(pid) = crate::ipc::check_running_daemon() else {
                 eprintln!("daemon not running at {endpoint}");
                 // No daemon — but the index file might still be there from a
@@ -313,14 +329,6 @@ pub(crate) async fn cmd_stop(endpoint: &str) -> ExitCode {
                 }
             }
         }
-    };
-
-    if let Err(e) = conn.send(&crate::protocol::Request::Shutdown).await {
-        eprintln!("zccache[err][S]: failed to send to daemon: {e}");
-        return ExitCode::FAILURE;
-    }
-    let recv_result = match conn.recv().await {
-        Ok(r) => r,
         Err(e) => {
             eprintln!("zccache[err][R]: broken connection to daemon: {e}");
             return ExitCode::FAILURE;

--- a/crates/zccache/src/cli/commands/status.rs
+++ b/crates/zccache/src/cli/commands/status.rs
@@ -3,13 +3,19 @@
 use std::process::ExitCode;
 
 use super::util::{
-    connect, format_bytes, format_duration_ms, format_uptime, print_json_value, LOST_CONNECTION_MSG,
+    format_bytes, format_duration_ms, format_uptime, print_json_value, LOST_CONNECTION_MSG,
 };
 
 pub(crate) async fn cmd_status(endpoint: &str, json: bool) -> ExitCode {
-    let mut conn = match connect(endpoint).await {
-        Ok(c) => c,
-        Err(e) => {
+    let recv_result = match crate::ipc::daemon_control_roundtrip(
+        endpoint,
+        crate::ipc::DaemonControlRequest::Status,
+        None,
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(e) if crate::cli::client::is_daemon_unreachable_err(&e) => {
             let message = format!("daemon not running at {endpoint}: {e}");
             if json {
                 print_status_error_json(endpoint, &message);
@@ -18,19 +24,6 @@ pub(crate) async fn cmd_status(endpoint: &str, json: bool) -> ExitCode {
             }
             return ExitCode::FAILURE;
         }
-    };
-
-    if let Err(e) = conn.send(&crate::protocol::Request::Status).await {
-        let message = format!("zccache: failed to send to daemon: {e}");
-        if json {
-            print_status_error_json(endpoint, &message);
-        } else {
-            eprintln!("{message}");
-        }
-        return ExitCode::FAILURE;
-    }
-    let recv_result = match conn.recv().await {
-        Ok(r) => r,
         Err(e) => {
             let message = format!("zccache: broken connection to daemon: {e}");
             if json {

--- a/crates/zccache/src/cli/runtime.rs
+++ b/crates/zccache/src/cli/runtime.rs
@@ -26,6 +26,7 @@ enum VersionCheck {
     DaemonOlder { daemon_ver: String },
     DaemonNewer,
     CommError,
+    ClientConfigError(String),
 }
 
 #[cfg(unix)]
@@ -47,16 +48,12 @@ pub async fn connect_client(
 }
 
 async fn check_daemon_version(endpoint: &str) -> VersionCheck {
-    let mut conn = match connect_client(endpoint).await {
-        Ok(c) => c,
-        Err(_) => return VersionCheck::Unreachable,
-    };
-    if conn.send(&crate::protocol::Request::Status).await.is_err() {
-        return VersionCheck::CommError;
-    }
-    match conn
-        .recv_with_timeout::<crate::protocol::Response>(super::status_probe_timeout())
-        .await
+    match crate::ipc::daemon_control_roundtrip(
+        endpoint,
+        crate::ipc::DaemonControlRequest::Status,
+        Some(super::status_probe_timeout()),
+    )
+    .await
     {
         Ok(Some(crate::protocol::Response::Status(s))) => {
             if s.version == crate::core::VERSION {
@@ -75,6 +72,14 @@ async fn check_daemon_version(endpoint: &str) -> VersionCheck {
                     daemon_ver: s.version,
                 },
             }
+        }
+        Err(crate::ipc::IpcError::Endpoint(message))
+            if message.contains(crate::protocol::wire_prost::WIRE_FORMAT_ENV) =>
+        {
+            VersionCheck::ClientConfigError(message)
+        }
+        Err(err) if crate::cli::client::is_daemon_unreachable_err(&err) => {
+            VersionCheck::Unreachable
         }
         _ => VersionCheck::CommError,
     }
@@ -241,10 +246,13 @@ pub(crate) async fn wait_for_daemon_ready_with(
 
 /// Stop a stale daemon that is unreachable or version-incompatible.
 async fn stop_stale_daemon(endpoint: &str) {
-    if let Ok(mut conn) = connect_client(endpoint).await {
-        let _ = conn.send(&crate::protocol::Request::Shutdown).await;
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-    }
+    let _ = crate::ipc::daemon_control_roundtrip(
+        endpoint,
+        crate::ipc::DaemonControlRequest::Shutdown,
+        None,
+    )
+    .await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
     if let Some(pid) = crate::ipc::check_running_daemon() {
         if crate::ipc::force_kill_process(pid).is_ok() {
@@ -283,6 +291,7 @@ pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
             return spawn_and_wait(endpoint, crate::core::lifecycle::REASON_REPLACED_COMM_ERROR)
                 .await;
         }
+        VersionCheck::ClientConfigError(message) => return Err(message),
         VersionCheck::Unreachable => {}
     }
 
@@ -314,6 +323,7 @@ pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
                     )
                     .await;
                 }
+                VersionCheck::ClientConfigError(message) => return Err(message),
                 VersionCheck::Unreachable => continue,
             }
         }

--- a/crates/zccache/src/ipc/README.md
+++ b/crates/zccache/src/ipc/README.md
@@ -7,3 +7,8 @@ wire. The running-process#234 migration hook lives beside it:
 `send_prost` writes an explicit v16 prost frame, and `recv_wire` dispatches
 incoming frames by protocol-version header so a server can accept either v15
 bincode or v16 prost without breaking old clients.
+
+`daemon_control_roundtrip` is the only live client-side selector today. It
+honors `ZCCACHE_DAEMON_WIRE` for `Ping`, `Status`, and `Shutdown`; unset/`auto`
+tries v16 prost first and retries v15 bincode when an older daemon rejects the
+frame. All non-control zccache daemon requests still use v15 bincode directly.

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -17,9 +17,153 @@ pub use transport::{
 };
 
 use crate::core::NormalizedPath;
+use crate::protocol::{self, wire_prost, Response};
 
 #[cfg(unix)]
 const MAX_PORTABLE_UNIX_SOCKET_PATH_BYTES: usize = 100;
+
+#[cfg(unix)]
+type ClientConnection = IpcConnection;
+#[cfg(windows)]
+type ClientConnection = IpcClientConnection;
+
+/// Daemon control requests that may opt into the v16 prost migration slice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DaemonControlRequest {
+    /// Health check.
+    Ping,
+    /// Request daemon status/statistics.
+    Status,
+    /// Request daemon shutdown.
+    Shutdown,
+}
+
+impl DaemonControlRequest {
+    #[must_use]
+    fn to_protocol_request(self) -> protocol::Request {
+        match self {
+            Self::Ping => protocol::Request::Ping,
+            Self::Status => protocol::Request::Status,
+            Self::Shutdown => protocol::Request::Shutdown,
+        }
+    }
+}
+
+/// Send a daemon control request and receive the bincode response.
+///
+/// Only `Ping`, `Status`, and `Shutdown` are eligible for the v16 prost client
+/// path. Unset/`auto` `ZCCACHE_DAEMON_WIRE` prefers prost, then retries the
+/// same control request as v15 bincode if an older daemon clearly rejects the
+/// v16 frame or closes the connection after the mismatch. Compile, session,
+/// cache, fingerprint, and download-daemon requests do not route through this
+/// helper and remain v15 bincode.
+///
+/// # Errors
+///
+/// Returns the IPC error from the selected send/receive path, or an endpoint
+/// error when `ZCCACHE_DAEMON_WIRE` is invalid.
+pub async fn daemon_control_roundtrip(
+    endpoint: &str,
+    request: DaemonControlRequest,
+    recv_timeout: Option<std::time::Duration>,
+) -> Result<Option<Response>, IpcError> {
+    let selection = wire_prost::client_wire_selection_from_env().map_err(IpcError::Endpoint)?;
+    daemon_control_roundtrip_with_selection(endpoint, request, recv_timeout, selection).await
+}
+
+async fn daemon_control_roundtrip_with_selection(
+    endpoint: &str,
+    request: DaemonControlRequest,
+    recv_timeout: Option<std::time::Duration>,
+    selection: wire_prost::ClientWireSelection,
+) -> Result<Option<Response>, IpcError> {
+    match selection.preferred_format() {
+        wire_prost::WireFormat::BincodeV15 => {
+            send_bincode_control(endpoint, request, recv_timeout).await
+        }
+        wire_prost::WireFormat::ProstV16 => {
+            match send_prost_control(endpoint, request, recv_timeout).await {
+                Ok(Some(Response::Error { message }))
+                    if selection.allows_bincode_fallback()
+                        && control_wire_mismatch_message(&message) =>
+                {
+                    send_bincode_control(endpoint, request, recv_timeout).await
+                }
+                Ok(None) if selection.allows_bincode_fallback() => {
+                    send_bincode_control(endpoint, request, recv_timeout).await
+                }
+                Ok(response) => Ok(response),
+                Err(err)
+                    if selection.allows_bincode_fallback() && control_wire_mismatch_error(&err) =>
+                {
+                    send_bincode_control(endpoint, request, recv_timeout).await
+                }
+                Err(err) => Err(err),
+            }
+        }
+    }
+}
+
+async fn connect_control_client(endpoint: &str) -> Result<ClientConnection, IpcError> {
+    let mut conn = connect(endpoint).await?;
+    conn.set_recv_timeout(DEFAULT_CLIENT_RECV_TIMEOUT);
+    Ok(conn)
+}
+
+async fn send_bincode_control(
+    endpoint: &str,
+    request: DaemonControlRequest,
+    recv_timeout: Option<std::time::Duration>,
+) -> Result<Option<Response>, IpcError> {
+    let mut conn = connect_control_client(endpoint).await?;
+    let request = request.to_protocol_request();
+    conn.send(&request).await?;
+    recv_control_response(&mut conn, recv_timeout).await
+}
+
+async fn send_prost_control(
+    endpoint: &str,
+    request: DaemonControlRequest,
+    recv_timeout: Option<std::time::Duration>,
+) -> Result<Option<Response>, IpcError> {
+    let mut conn = connect_control_client(endpoint).await?;
+    let request = request.to_protocol_request();
+    let request =
+        wire_prost::supported_control_request_to_prost(&request).map_err(IpcError::Endpoint)?;
+    conn.send_prost(&request).await?;
+    recv_control_response(&mut conn, recv_timeout).await
+}
+
+async fn recv_control_response(
+    conn: &mut ClientConnection,
+    recv_timeout: Option<std::time::Duration>,
+) -> Result<Option<Response>, IpcError> {
+    match recv_timeout {
+        Some(timeout) => conn.recv_with_timeout(timeout).await,
+        None => conn.recv().await,
+    }
+}
+
+fn control_wire_mismatch_error(err: &IpcError) -> bool {
+    match err {
+        IpcError::Protocol(protocol::ProtocolError::VersionMismatch { .. })
+        | IpcError::ConnectionClosed => true,
+        IpcError::Io(io) => matches!(
+            io.kind(),
+            std::io::ErrorKind::BrokenPipe
+                | std::io::ErrorKind::ConnectionReset
+                | std::io::ErrorKind::UnexpectedEof
+        ),
+        IpcError::Protocol(_) | IpcError::Endpoint(_) | IpcError::Timeout(_) => false,
+    }
+}
+
+fn control_wire_mismatch_message(message: &str) -> bool {
+    let message = message.to_ascii_lowercase();
+    message.contains("protocol version mismatch")
+        || message.contains("protocol_version")
+        || (message.contains("expected v15") && message.contains("received v16"))
+}
 
 /// Returns the platform-specific default IPC endpoint path.
 ///
@@ -523,6 +667,136 @@ mod tests {
                 None => std::env::remove_var(crate::core::config::DAEMON_NAMESPACE_ENV),
             }
         }
+    }
+
+    fn test_daemon_status(endpoint: &str) -> crate::protocol::DaemonStatus {
+        crate::protocol::DaemonStatus {
+            version: crate::core::VERSION.to_string(),
+            daemon_namespace: "test".to_string(),
+            endpoint: endpoint.to_string(),
+            private_daemon: crate::protocol::PrivateDaemonStatus::shared(),
+            artifact_count: 0,
+            cache_size_bytes: 0,
+            metadata_entries: 0,
+            uptime_secs: 1,
+            cache_hits: 0,
+            cache_misses: 0,
+            total_compilations: 0,
+            non_cacheable: 0,
+            compile_errors: 0,
+            compile_errors_cached: 0,
+            time_saved_ms: 0,
+            total_links: 0,
+            link_hits: 0,
+            link_misses: 0,
+            link_non_cacheable: 0,
+            dep_graph_contexts: 0,
+            dep_graph_files: 0,
+            sessions_total: 0,
+            sessions_active: 0,
+            cache_dir: std::env::temp_dir().into(),
+            dep_graph_version: crate::depgraph::DEPGRAPH_VERSION,
+            dep_graph_disk_size: 0,
+            dep_graph_persisted: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn daemon_control_roundtrip_auto_prefers_prost_for_status() {
+        let endpoint = unique_test_endpoint();
+        let mut listener = IpcListener::bind(&endpoint).unwrap();
+        let expected_endpoint = endpoint.clone();
+
+        let server = tokio::spawn(async move {
+            let mut conn = listener.accept().await.unwrap();
+            let msg: Option<
+                crate::protocol::DecodedWireMessage<
+                    crate::protocol::Request,
+                    crate::protocol::wire_prost::zccache_v1::Request,
+                >,
+            > = conn.recv_wire().await.unwrap();
+            match msg {
+                Some(crate::protocol::DecodedWireMessage::ProstV16(request)) => {
+                    assert_eq!(request.request_id, "control-status");
+                    assert!(matches!(
+                        request.body,
+                        Some(crate::protocol::wire_prost::zccache_v1::request::Body::Status(_))
+                    ));
+                }
+                other => panic!("expected prost status request, got {other:?}"),
+            }
+            conn.send(&Response::Status(test_daemon_status(&expected_endpoint)))
+                .await
+                .unwrap();
+        });
+
+        let response = daemon_control_roundtrip_with_selection(
+            &endpoint,
+            DaemonControlRequest::Status,
+            None,
+            wire_prost::ClientWireSelection::Auto,
+        )
+        .await
+        .unwrap();
+
+        match response {
+            Some(Response::Status(status)) => assert_eq!(status.endpoint, endpoint),
+            other => panic!("expected Status response, got {other:?}"),
+        }
+
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn daemon_control_roundtrip_auto_falls_back_to_bincode_for_old_daemon() {
+        let endpoint = unique_test_endpoint();
+        let mut listener = IpcListener::bind(&endpoint).unwrap();
+        let expected_endpoint = endpoint.clone();
+
+        let server = tokio::spawn(async move {
+            let mut first = listener.accept().await.unwrap();
+            let err = first
+                .recv::<crate::protocol::Request>()
+                .await
+                .expect_err("v16 prost request must not decode as v15 bincode");
+            assert!(matches!(
+                err,
+                IpcError::Protocol(crate::protocol::ProtocolError::VersionMismatch {
+                    expected: crate::protocol::BINCODE_PROTOCOL_VERSION,
+                    received: crate::protocol::PROST_PROTOCOL_VERSION,
+                })
+            ));
+            first
+                .send(&Response::Error {
+                    message: "protocol version mismatch: expected v15, received v16".to_string(),
+                })
+                .await
+                .unwrap();
+
+            let mut second = listener.accept().await.unwrap();
+            let request: Option<crate::protocol::Request> = second.recv().await.unwrap();
+            assert_eq!(request, Some(crate::protocol::Request::Status));
+            second
+                .send(&Response::Status(test_daemon_status(&expected_endpoint)))
+                .await
+                .unwrap();
+        });
+
+        let response = daemon_control_roundtrip_with_selection(
+            &endpoint,
+            DaemonControlRequest::Status,
+            None,
+            wire_prost::ClientWireSelection::Auto,
+        )
+        .await
+        .unwrap();
+
+        match response {
+            Some(Response::Status(status)) => assert_eq!(status.endpoint, endpoint),
+            other => panic!("expected fallback Status response, got {other:?}"),
+        }
+
+        server.await.unwrap();
     }
 
     #[test]

--- a/crates/zccache/src/protocol/README.md
+++ b/crates/zccache/src/protocol/README.md
@@ -27,11 +27,13 @@ enum variants must still be appended in `messages/mod.rs` and require a
 
 `PROTOCOL_VERSION` remains `15` while the public `encode_message` and
 `decode_message` helpers emit and accept bincode bodies. `PROST_PROTOCOL_VERSION`
-is `16` for the planned prost path. `decode_wire_message` now models the daemon
-dispatcher that accepts both frame versions, but the live IPC transport has not
-switched to it yet. `ZCCACHE_DAEMON_WIRE` parsing models the intended client
-selection: unset or `auto` prefers prost, and `bincode` keeps the old v15
-fallback available during the transition.
+is `16` for the prost path. The live daemon receive path dispatches both frame
+versions, but only the control-request slice (`Ping`, `Status`, `Shutdown`) is
+converted from prost today. `ZCCACHE_DAEMON_WIRE` is honored for that client
+control slice: unset or `auto` tries prost first and falls back to v15 bincode
+on a clear old-daemon protocol rejection; `bincode` forces the old path.
+Compile, session, cache, fingerprint, and download-daemon requests remain v15
+bincode until their full protobuf conversion lands.
 
 ## Request Variants
 

--- a/crates/zccache/src/protocol/wire_prost.rs
+++ b/crates/zccache/src/protocol/wire_prost.rs
@@ -1,9 +1,9 @@
 //! Prost wire helpers and v16 dispatcher scaffolding.
 //!
-//! The live daemon wire remains v15 bincode today. This module intentionally
-//! models the v16 prost path without changing `encode_message` /
-//! `decode_message`, so old clients keep working while the generated protobuf
-//! types and compatibility tests land first.
+//! The public `encode_message` / `decode_message` helpers remain v15 bincode
+//! so hot-path requests keep their old wire shape. The live daemon dispatcher
+//! can accept v16 prost control requests through the explicit helpers in this
+//! module while the full enum conversion lands incrementally.
 
 use bytes::{Buf, BufMut, BytesMut};
 use prost::Message;
@@ -41,6 +41,37 @@ impl WireFormat {
 /// Planned default for new clients once the live transport uses the dispatcher.
 pub const DEFAULT_CLIENT_WIRE_FORMAT: WireFormat = WireFormat::ProstV16;
 
+/// Client-side wire selection policy from `ZCCACHE_DAEMON_WIRE`.
+///
+/// `Auto` preserves the user's unset/auto intent so control-request callers
+/// can prefer prost while still retrying v15 bincode against older daemons.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClientWireSelection {
+    /// Prefer prost and allow a bincode retry on a clear protocol mismatch.
+    Auto,
+    /// Force the v15 bincode compatibility path.
+    BincodeV15,
+    /// Force the v16 prost path.
+    ProstV16,
+}
+
+impl ClientWireSelection {
+    /// Wire family to try first for this selection.
+    #[must_use]
+    pub const fn preferred_format(self) -> WireFormat {
+        match self {
+            Self::Auto | Self::ProstV16 => WireFormat::ProstV16,
+            Self::BincodeV15 => WireFormat::BincodeV15,
+        }
+    }
+
+    /// Whether a failed prost control request may be retried as bincode.
+    #[must_use]
+    pub const fn allows_bincode_fallback(self) -> bool {
+        matches!(self, Self::Auto)
+    }
+}
+
 /// Return the wire family for a protocol-version header.
 #[must_use]
 pub const fn wire_format_for_protocol_version(version: u32) -> Option<WireFormat> {
@@ -54,26 +85,15 @@ pub const fn wire_format_for_protocol_version(version: u32) -> Option<WireFormat
 /// Parse a `ZCCACHE_DAEMON_WIRE` value.
 ///
 /// `None` and `auto` model the migration target: new clients prefer v16 prost,
-/// while `bincode` remains the explicit v15 fallback spelling. The live
-/// transport still calls the bincode helpers directly until the daemon
-/// dispatcher is wired into IPC.
+/// while `bincode` remains the explicit v15 fallback spelling. Use
+/// [`client_wire_selection_from_env_value`] when callers need to distinguish
+/// auto from forced prost.
 ///
 /// # Errors
 ///
 /// Returns a message suitable for diagnostics when the value is not recognized.
 pub fn wire_format_from_env_value(value: Option<&str>) -> Result<WireFormat, String> {
-    let Some(value) = value else {
-        return Ok(DEFAULT_CLIENT_WIRE_FORMAT);
-    };
-
-    match value.trim().to_ascii_lowercase().as_str() {
-        "" | "auto" => Ok(DEFAULT_CLIENT_WIRE_FORMAT),
-        "bincode" | "bincode-v15" | "v15" => Ok(WireFormat::BincodeV15),
-        "prost" | "prost-v16" | "v16" => Ok(WireFormat::ProstV16),
-        other => Err(format!(
-            "invalid {WIRE_FORMAT_ENV}={other:?}; expected auto, bincode, or prost"
-        )),
-    }
+    client_wire_selection_from_env_value(value).map(ClientWireSelection::preferred_format)
 }
 
 /// Read `ZCCACHE_DAEMON_WIRE` from the process environment.
@@ -83,6 +103,38 @@ pub fn wire_format_from_env_value(value: Option<&str>) -> Result<WireFormat, Str
 /// Returns a message suitable for diagnostics when the value is not recognized.
 pub fn wire_format_from_env() -> Result<WireFormat, String> {
     wire_format_from_env_value(std::env::var(WIRE_FORMAT_ENV).ok().as_deref())
+}
+
+/// Parse `ZCCACHE_DAEMON_WIRE` while preserving unset/auto as a distinct
+/// selection for compatibility fallbacks.
+///
+/// # Errors
+///
+/// Returns a message suitable for diagnostics when the value is not recognized.
+pub fn client_wire_selection_from_env_value(
+    value: Option<&str>,
+) -> Result<ClientWireSelection, String> {
+    let Some(value) = value else {
+        return Ok(ClientWireSelection::Auto);
+    };
+
+    match value.trim().to_ascii_lowercase().as_str() {
+        "" | "auto" => Ok(ClientWireSelection::Auto),
+        "bincode" | "bincode-v15" | "v15" => Ok(ClientWireSelection::BincodeV15),
+        "prost" | "prost-v16" | "v16" => Ok(ClientWireSelection::ProstV16),
+        other => Err(format!(
+            "invalid {WIRE_FORMAT_ENV}={other:?}; expected auto, bincode, or prost"
+        )),
+    }
+}
+
+/// Read `ZCCACHE_DAEMON_WIRE` as a client selection policy.
+///
+/// # Errors
+///
+/// Returns a message suitable for diagnostics when the value is not recognized.
+pub fn client_wire_selection_from_env() -> Result<ClientWireSelection, String> {
+    client_wire_selection_from_env_value(std::env::var(WIRE_FORMAT_ENV).ok().as_deref())
 }
 
 /// Convert the narrow set of v16 prost daemon-control requests that the live
@@ -112,6 +164,35 @@ pub fn supported_control_request_from_prost(
                 .to_string(),
         ),
     }
+}
+
+/// Convert the narrow daemon-control request slice to the v16 prost schema.
+///
+/// # Errors
+///
+/// Returns a clear diagnostic when a caller tries to route an unsupported
+/// request through the prost control path.
+pub fn supported_control_request_to_prost(
+    request: &super::Request,
+) -> Result<zccache_v1::Request, String> {
+    use zccache_v1::request::Body;
+
+    let (request_id, body) = match request {
+        super::Request::Ping => ("control-ping", Body::Ping(zccache_v1::Empty {})),
+        super::Request::Status => ("control-status", Body::Status(zccache_v1::Empty {})),
+        super::Request::Shutdown => ("control-shutdown", Body::Shutdown(zccache_v1::Empty {})),
+        other => {
+            return Err(format!(
+                "unsupported v16 prost control request {other:?}; only Ping, Status, and Shutdown \
+                 may select {WIRE_FORMAT_ENV} before the full zccache prost conversion lands"
+            ));
+        }
+    };
+
+    Ok(zccache_v1::Request {
+        body: Some(body),
+        request_id: request_id.to_string(),
+    })
 }
 
 /// Serialize a prost message to the planned v16 length-prefixed frame.


### PR DESCRIPTION
Refs zackees/running-process#234
Refs zackees/running-process#242
Refs #698

## Summary
- Add a daemon control-request wire selector for Ping, Status, and Shutdown that honors ZCCACHE_DAEMON_WIRE.
- Keep compile/session/cache/fingerprint requests on the v15 bincode path while the full prost conversion remains incomplete.
- In unset/auto mode, try v16 prost first and retry v15 bincode when an older daemon clearly rejects or closes after the v16 control frame.
- Route CLI/library Status and Shutdown control flows through the selector, and update protocol/IPC docs for the partial migration state.

## Tests
- soldr cargo test -p zccache daemon_control_roundtrip -- --nocapture
- soldr cargo test -p zccache recv_wire -- --nocapture
- soldr cargo test -p zccache --test daemon_wire_protocol_version -- --nocapture
- soldr cargo fmt --all -- --check
- git diff --check