### PR TITLE
feat: send prost control responses

### DIFF
--- a/crates/zccache/src/daemon/server/connection.rs
+++ b/crates/zccache/src/daemon/server/connection.rs
@@ -6,6 +6,11 @@ use crate::protocol::{
     DecodedWireMessage,
 };
 
+enum ResponseWire {
+    BincodeV15,
+    ProstV16 { request_id: String },
+}
+
 /// Handle a single client connection.
 pub(super) async fn handle_connection(
     mut conn: IpcConnection,
@@ -68,14 +73,20 @@ pub(super) async fn handle_connection(
         };
         state.last_activity.store(now_secs(), Ordering::Relaxed);
 
-        let request = match request {
-            DecodedWireMessage::BincodeV15(request) => request,
+        let (request, response_wire) = match request {
+            DecodedWireMessage::BincodeV15(request) => (request, ResponseWire::BincodeV15),
             DecodedWireMessage::ProstV16(request) => {
+                let request_id = request.request_id.clone();
                 match wire_prost::supported_control_request_from_prost(request) {
-                    Ok(request) => request,
+                    Ok(request) => (request, ResponseWire::ProstV16 { request_id }),
                     Err(message) => {
                         tracing::warn!("{message}");
-                        conn.send(&Response::Error { message }).await?;
+                        send_response_for_wire(
+                            &mut conn,
+                            &ResponseWire::ProstV16 { request_id },
+                            &Response::Error { message },
+                        )
+                        .await?;
                         continue;
                     }
                 }
@@ -107,7 +118,7 @@ pub(super) async fn handle_connection(
         let (response, journal_ctx): (Response, Option<JournalContext>) = match request {
             Request::Ping => (Response::Pong, None),
             Request::Shutdown => {
-                conn.send(&Response::ShuttingDown).await?;
+                send_response_for_wire(&mut conn, &response_wire, &Response::ShuttingDown).await?;
                 // Record graceful exit alongside the existing "spawn"
                 // event so a single parse of `daemon-lifecycle.log`
                 // reconstructs the daemon's full lifetime. Pairs with
@@ -528,7 +539,7 @@ pub(super) async fn handle_connection(
         // Send the response BEFORE logging the journal entry. Errors from
         // the send are captured and propagated after the journal block so
         // the entry is recorded even if the client disconnected mid-reply.
-        let send_result = conn.send(&response).await;
+        let send_result = send_response_for_wire(&mut conn, &response_wire, &response).await;
 
         if let Some((
             ctx,
@@ -564,6 +575,21 @@ pub(super) async fn handle_connection(
         }
 
         send_result?;
+    }
+}
+
+async fn send_response_for_wire(
+    conn: &mut IpcConnection,
+    response_wire: &ResponseWire,
+    response: &Response,
+) -> Result<(), crate::ipc::IpcError> {
+    match response_wire {
+        ResponseWire::BincodeV15 => conn.send(response).await,
+        ResponseWire::ProstV16 { request_id } => {
+            let response = wire_prost::supported_control_response_to_prost(response, request_id)
+                .map_err(|message| crate::protocol::ProtocolError::Serialization(message))?;
+            conn.send_prost(&response).await
+        }
     }
 }
 
@@ -648,8 +674,12 @@ mod live_ipc_prost_tests {
             let mut client = crate::ipc::connect(&endpoint).await.unwrap();
 
             client.send(&Request::Ping).await.unwrap();
-            let response: Option<Response> = client.recv().await.unwrap();
-            assert_eq!(response, Some(Response::Pong));
+            let response: Option<DecodedWireMessage<Response, pb::Response>> =
+                client.recv_wire().await.unwrap();
+            assert_eq!(
+                response,
+                Some(DecodedWireMessage::BincodeV15(Response::Pong))
+            );
 
             client
                 .send_prost(&prost_request(
@@ -658,9 +688,16 @@ mod live_ipc_prost_tests {
                 ))
                 .await
                 .unwrap();
-            let response: Option<Response> = client.recv().await.unwrap();
+            let response: Option<DecodedWireMessage<Response, pb::Response>> =
+                client.recv_wire().await.unwrap();
             match response {
-                Some(Response::Status(status)) => {
+                Some(DecodedWireMessage::ProstV16(response)) => {
+                    assert_eq!(response.request_id, "prost-status");
+                    let response =
+                        wire_prost::supported_control_response_from_prost(response).unwrap();
+                    let Response::Status(status) = response else {
+                        panic!("expected Status response, got {response:?}");
+                    };
                     assert_eq!(status.endpoint, endpoint);
                 }
                 other => panic!("expected Status response, got {other:?}"),
@@ -673,9 +710,16 @@ mod live_ipc_prost_tests {
                 ))
                 .await
                 .unwrap();
-            let response: Option<Response> = client.recv().await.unwrap();
+            let response: Option<DecodedWireMessage<Response, pb::Response>> =
+                client.recv_wire().await.unwrap();
             match response {
-                Some(Response::Error { message }) => {
+                Some(DecodedWireMessage::ProstV16(response)) => {
+                    assert_eq!(response.request_id, "prost-clear");
+                    let response =
+                        wire_prost::supported_control_response_from_prost(response).unwrap();
+                    let Response::Error { message } = response else {
+                        panic!("expected Error response, got {response:?}");
+                    };
                     assert!(
                         message.contains("unsupported v16 prost request"),
                         "unexpected error message: {message}"
@@ -695,8 +739,17 @@ mod live_ipc_prost_tests {
                 ))
                 .await
                 .unwrap();
-            let response: Option<Response> = client.recv().await.unwrap();
-            assert_eq!(response, Some(Response::Pong));
+            let response: Option<DecodedWireMessage<Response, pb::Response>> =
+                client.recv_wire().await.unwrap();
+            match response {
+                Some(DecodedWireMessage::ProstV16(response)) => {
+                    assert_eq!(response.request_id, "prost-ping");
+                    let response =
+                        wire_prost::supported_control_response_from_prost(response).unwrap();
+                    assert_eq!(response, Response::Pong);
+                }
+                other => panic!("expected prost Pong response, got {other:?}"),
+            }
 
             client
                 .send_prost(&prost_request(
@@ -705,8 +758,17 @@ mod live_ipc_prost_tests {
                 ))
                 .await
                 .unwrap();
-            let response: Option<Response> = client.recv().await.unwrap();
-            assert_eq!(response, Some(Response::ShuttingDown));
+            let response: Option<DecodedWireMessage<Response, pb::Response>> =
+                client.recv_wire().await.unwrap();
+            match response {
+                Some(DecodedWireMessage::ProstV16(response)) => {
+                    assert_eq!(response.request_id, "prost-shutdown");
+                    let response =
+                        wire_prost::supported_control_response_from_prost(response).unwrap();
+                    assert_eq!(response, Response::ShuttingDown);
+                }
+                other => panic!("expected prost ShuttingDown response, got {other:?}"),
+            }
 
             server_task.await.unwrap();
         })

--- a/crates/zccache/src/ipc/README.md
+++ b/crates/zccache/src/ipc/README.md
@@ -11,4 +11,6 @@ bincode or v16 prost without breaking old clients.
 `daemon_control_roundtrip` is the only live client-side selector today. It
 honors `ZCCACHE_DAEMON_WIRE` for `Ping`, `Status`, and `Shutdown`; unset/`auto`
 tries v16 prost first and retries v15 bincode when an older daemon rejects the
-frame. All non-control zccache daemon requests still use v15 bincode directly.
+frame. The v16 control path accepts either v16 prost control replies or v15
+bincode replies from compatibility daemons. All non-control zccache daemon
+requests still use v15 bincode directly.

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -49,7 +49,7 @@ impl DaemonControlRequest {
     }
 }
 
-/// Send a daemon control request and receive the bincode response.
+/// Send a daemon control request and receive its response.
 ///
 /// Only `Ping`, `Status`, and `Shutdown` are eligible for the v16 prost client
 /// path. Unset/`auto` `ZCCACHE_DAEMON_WIRE` prefers prost, then retries the
@@ -131,7 +131,7 @@ async fn send_prost_control(
     let request =
         wire_prost::supported_control_request_to_prost(&request).map_err(IpcError::Endpoint)?;
     conn.send_prost(&request).await?;
-    recv_control_response(&mut conn, recv_timeout).await
+    recv_control_wire_response(&mut conn, recv_timeout).await
 }
 
 async fn recv_control_response(
@@ -141,6 +141,29 @@ async fn recv_control_response(
     match recv_timeout {
         Some(timeout) => conn.recv_with_timeout(timeout).await,
         None => conn.recv().await,
+    }
+}
+
+async fn recv_control_wire_response(
+    conn: &mut ClientConnection,
+    recv_timeout: Option<std::time::Duration>,
+) -> Result<Option<Response>, IpcError> {
+    let response: Option<protocol::DecodedWireMessage<Response, wire_prost::zccache_v1::Response>> =
+        match recv_timeout {
+            Some(timeout) => conn.recv_wire_with_timeout(timeout).await?,
+            None => conn.recv_wire().await?,
+        };
+
+    match response {
+        Some(protocol::DecodedWireMessage::BincodeV15(response)) => Ok(Some(response)),
+        Some(protocol::DecodedWireMessage::ProstV16(response)) => {
+            wire_prost::supported_control_response_from_prost(response)
+                .map(Some)
+                .map_err(|message| {
+                    IpcError::Protocol(protocol::ProtocolError::Deserialization(message))
+                })
+        }
+        None => Ok(None),
     }
 }
 
@@ -722,12 +745,16 @@ mod tests {
                         request.body,
                         Some(crate::protocol::wire_prost::zccache_v1::request::Body::Status(_))
                     ));
+                    let response = Response::Status(test_daemon_status(&expected_endpoint));
+                    let response = wire_prost::supported_control_response_to_prost(
+                        &response,
+                        &request.request_id,
+                    )
+                    .unwrap();
+                    conn.send_prost(&response).await.unwrap();
                 }
                 other => panic!("expected prost status request, got {other:?}"),
             }
-            conn.send(&Response::Status(test_daemon_status(&expected_endpoint)))
-                .await
-                .unwrap();
         });
 
         let response = daemon_control_roundtrip_with_selection(
@@ -742,6 +769,38 @@ mod tests {
         match response {
             Some(Response::Status(status)) => assert_eq!(status.endpoint, endpoint),
             other => panic!("expected Status response, got {other:?}"),
+        }
+
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn daemon_control_roundtrip_bincode_selection_stays_v15_for_status() {
+        let endpoint = unique_test_endpoint();
+        let mut listener = IpcListener::bind(&endpoint).unwrap();
+        let expected_endpoint = endpoint.clone();
+
+        let server = tokio::spawn(async move {
+            let mut conn = listener.accept().await.unwrap();
+            let request: Option<crate::protocol::Request> = conn.recv().await.unwrap();
+            assert_eq!(request, Some(crate::protocol::Request::Status));
+            conn.send(&Response::Status(test_daemon_status(&expected_endpoint)))
+                .await
+                .unwrap();
+        });
+
+        let response = daemon_control_roundtrip_with_selection(
+            &endpoint,
+            DaemonControlRequest::Status,
+            None,
+            wire_prost::ClientWireSelection::BincodeV15,
+        )
+        .await
+        .unwrap();
+
+        match response {
+            Some(Response::Status(status)) => assert_eq!(status.endpoint, endpoint),
+            other => panic!("expected bincode Status response, got {other:?}"),
         }
 
         server.await.unwrap();

--- a/crates/zccache/src/protocol/README.md
+++ b/crates/zccache/src/protocol/README.md
@@ -29,11 +29,13 @@ enum variants must still be appended in `messages/mod.rs` and require a
 `decode_message` helpers emit and accept bincode bodies. `PROST_PROTOCOL_VERSION`
 is `16` for the prost path. The live daemon receive path dispatches both frame
 versions, but only the control-request slice (`Ping`, `Status`, `Shutdown`) is
-converted from prost today. `ZCCACHE_DAEMON_WIRE` is honored for that client
-control slice: unset or `auto` tries prost first and falls back to v15 bincode
-on a clear old-daemon protocol rejection; `bincode` forces the old path.
-Compile, session, cache, fingerprint, and download-daemon requests remain v15
-bincode until their full protobuf conversion lands.
+converted from prost today, and only the matching control-response slice
+(`Pong`, `Status`, `ShuttingDown`, `Error`) is converted back to prost replies.
+`ZCCACHE_DAEMON_WIRE` is honored for that client control slice: unset or `auto`
+tries prost first and falls back to v15 bincode on a clear old-daemon protocol
+rejection; `bincode` forces the old path. Compile, session, cache, fingerprint,
+and download-daemon requests remain v15 bincode until their full protobuf
+conversion lands.
 
 ## Request Variants
 

--- a/crates/zccache/src/protocol/wire_prost.rs
+++ b/crates/zccache/src/protocol/wire_prost.rs
@@ -195,6 +195,191 @@ pub fn supported_control_request_to_prost(
     })
 }
 
+/// Convert the narrow daemon-control response slice from the v16 prost schema
+/// back to the local protocol enum.
+///
+/// # Errors
+///
+/// Returns a clear diagnostic for unsupported response bodies or missing nested
+/// fields in the supported `Status` response body.
+pub fn supported_control_response_from_prost(
+    response: zccache_v1::Response,
+) -> Result<super::Response, String> {
+    use zccache_v1::response::Body;
+
+    match response.body {
+        Some(Body::Pong(_)) => Ok(super::Response::Pong),
+        Some(Body::ShuttingDown(_)) => Ok(super::Response::ShuttingDown),
+        Some(Body::Status(status)) => daemon_status_from_prost(status).map(super::Response::Status),
+        Some(Body::Error(error)) => Ok(super::Response::Error {
+            message: error.message,
+        }),
+        Some(other) => Err(format!(
+            "unsupported v16 prost response body {other:?}; only Pong, Status, ShuttingDown, and \
+             Error are supported before the full zccache prost conversion lands"
+        )),
+        None => Err(
+            "unsupported v16 prost response: missing response body; only Pong, Status, \
+             ShuttingDown, and Error are supported before the full zccache prost conversion lands"
+                .to_string(),
+        ),
+    }
+}
+
+/// Convert the narrow daemon-control response slice to the v16 prost schema.
+///
+/// # Errors
+///
+/// Returns a clear diagnostic when a caller tries to route an unsupported
+/// response through the prost control path.
+pub fn supported_control_response_to_prost(
+    response: &super::Response,
+    request_id: &str,
+) -> Result<zccache_v1::Response, String> {
+    use zccache_v1::response::Body;
+
+    let body = match response {
+        super::Response::Pong => Body::Pong(zccache_v1::Empty {}),
+        super::Response::ShuttingDown => Body::ShuttingDown(zccache_v1::Empty {}),
+        super::Response::Status(status) => Body::Status(daemon_status_to_prost(status)),
+        super::Response::Error { message } => Body::Error(zccache_v1::Error {
+            message: message.clone(),
+        }),
+        other => {
+            return Err(format!(
+                "unsupported v16 prost control response {other:?}; only Pong, Status, \
+                 ShuttingDown, and Error may use the prost control response path before the full \
+                 zccache prost conversion lands"
+            ));
+        }
+    };
+
+    Ok(zccache_v1::Response {
+        body: Some(body),
+        request_id: request_id.to_string(),
+    })
+}
+
+fn daemon_status_to_prost(status: &super::DaemonStatus) -> zccache_v1::DaemonStatus {
+    zccache_v1::DaemonStatus {
+        version: status.version.clone(),
+        daemon_namespace: status.daemon_namespace.clone(),
+        endpoint: status.endpoint.clone(),
+        private_daemon: Some(private_daemon_status_to_prost(&status.private_daemon)),
+        artifact_count: status.artifact_count,
+        cache_size_bytes: status.cache_size_bytes,
+        metadata_entries: status.metadata_entries,
+        uptime_secs: status.uptime_secs,
+        cache_hits: status.cache_hits,
+        cache_misses: status.cache_misses,
+        total_compilations: status.total_compilations,
+        non_cacheable: status.non_cacheable,
+        compile_errors: status.compile_errors,
+        compile_errors_cached: status.compile_errors_cached,
+        time_saved_ms: status.time_saved_ms,
+        total_links: status.total_links,
+        link_hits: status.link_hits,
+        link_misses: status.link_misses,
+        link_non_cacheable: status.link_non_cacheable,
+        dep_graph_contexts: status.dep_graph_contexts,
+        dep_graph_files: status.dep_graph_files,
+        sessions_total: status.sessions_total,
+        sessions_active: status.sessions_active,
+        cache_dir: Some(path_to_prost(&status.cache_dir)),
+        dep_graph_version: status.dep_graph_version,
+        dep_graph_disk_size: status.dep_graph_disk_size,
+        dep_graph_persisted: status.dep_graph_persisted,
+    }
+}
+
+fn daemon_status_from_prost(
+    status: zccache_v1::DaemonStatus,
+) -> Result<super::DaemonStatus, String> {
+    Ok(super::DaemonStatus {
+        version: status.version,
+        daemon_namespace: status.daemon_namespace,
+        endpoint: status.endpoint,
+        private_daemon: private_daemon_status_from_prost(required_prost_field(
+            status.private_daemon,
+            "DaemonStatus.private_daemon",
+        )?),
+        artifact_count: status.artifact_count,
+        cache_size_bytes: status.cache_size_bytes,
+        metadata_entries: status.metadata_entries,
+        uptime_secs: status.uptime_secs,
+        cache_hits: status.cache_hits,
+        cache_misses: status.cache_misses,
+        total_compilations: status.total_compilations,
+        non_cacheable: status.non_cacheable,
+        compile_errors: status.compile_errors,
+        compile_errors_cached: status.compile_errors_cached,
+        time_saved_ms: status.time_saved_ms,
+        total_links: status.total_links,
+        link_hits: status.link_hits,
+        link_misses: status.link_misses,
+        link_non_cacheable: status.link_non_cacheable,
+        dep_graph_contexts: status.dep_graph_contexts,
+        dep_graph_files: status.dep_graph_files,
+        sessions_total: status.sessions_total,
+        sessions_active: status.sessions_active,
+        cache_dir: path_from_prost(required_prost_field(
+            status.cache_dir,
+            "DaemonStatus.cache_dir",
+        )?),
+        dep_graph_version: status.dep_graph_version,
+        dep_graph_disk_size: status.dep_graph_disk_size,
+        dep_graph_persisted: status.dep_graph_persisted,
+    })
+}
+
+fn private_daemon_status_to_prost(
+    status: &super::PrivateDaemonStatus,
+) -> zccache_v1::PrivateDaemonStatus {
+    zccache_v1::PrivateDaemonStatus {
+        enabled: status.enabled,
+        owners: status
+            .owners
+            .iter()
+            .map(|owner| zccache_v1::PrivateDaemonOwnerStatus {
+                pid: owner.pid,
+                ref_count: owner.ref_count,
+            })
+            .collect(),
+        private_env_keys: status.private_env_keys.clone(),
+    }
+}
+
+fn private_daemon_status_from_prost(
+    status: zccache_v1::PrivateDaemonStatus,
+) -> super::PrivateDaemonStatus {
+    super::PrivateDaemonStatus {
+        enabled: status.enabled,
+        owners: status
+            .owners
+            .into_iter()
+            .map(|owner| super::PrivateDaemonOwnerStatus {
+                pid: owner.pid,
+                ref_count: owner.ref_count,
+            })
+            .collect(),
+        private_env_keys: status.private_env_keys,
+    }
+}
+
+fn path_to_prost(path: &crate::core::NormalizedPath) -> zccache_v1::Path {
+    zccache_v1::Path {
+        value: path.as_path().to_string_lossy().into_owned(),
+    }
+}
+
+fn path_from_prost(path: zccache_v1::Path) -> crate::core::NormalizedPath {
+    crate::core::NormalizedPath::from(path.value)
+}
+
+fn required_prost_field<T>(value: Option<T>, field: &str) -> Result<T, String> {
+    value.ok_or_else(|| format!("missing required v16 prost control response field {field}"))
+}
+
 /// Serialize a prost message to the planned v16 length-prefixed frame.
 ///
 /// Format: `[4-byte LE length][4-byte LE protocol version][prost payload]`.


### PR DESCRIPTION
Refs zackees/running-process#234
Refs zackees/running-process#242

## Summary
- add narrow prost Response conversion helpers for Pong, Status, ShuttingDown, and Error, including DaemonStatus/private-daemon status fields
- let prost-selected daemon control roundtrips receive either v16 prost responses or v15 bincode compatibility responses
- reply to live v16 prost Ping/Status/Shutdown/Error control requests with v16 prost responses while preserving v15 bincode replies for v15 requests
- keep compile, session, cache, fingerprint, and download-daemon request families on the existing v15 bincode path

## Compatibility
- unset/auto ZCCACHE_DAEMON_WIRE still tries prost first and falls back to v15 bincode on old-daemon protocol rejection or clean close
- forced prost does not retry as bincode; it only uses the mixed receive decoder for the selected prost control attempt
- forced bincode continues to send and receive v15 bincode

## Tests
- soldr cargo test -p zccache daemon_control_roundtrip -- --nocapture
- soldr cargo test -p zccache recv_wire -- --nocapture
- soldr cargo test -p zccache handle_connection_accepts_v15_and_v16_control_requests -- --nocapture
- soldr cargo test -p zccache --test daemon_wire_protocol_version -- --nocapture
- soldr cargo test -p zccache --test daemon_wire_prost_roundtrip -- --nocapture
- soldr cargo test -p zccache --test daemon_wire_dispatcher -- --nocapture
- soldr cargo fmt --all -- --check
- git diff --check