### PR TITLE
Route clear over prost daemon wire

### DIFF
--- a/crates/zccache/src/cli/commands/cache_ops.rs
+++ b/crates/zccache/src/cli/commands/cache_ops.rs
@@ -4,28 +4,27 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use super::super::snapshot_fp;
-use super::util::{connect, format_bytes, LOST_CONNECTION_MSG};
+use super::util::{format_bytes, LOST_CONNECTION_MSG};
 
 pub(crate) async fn cmd_clear(endpoint: &str) -> ExitCode {
-    let mut conn = match connect(endpoint).await {
-        Ok(c) => c,
-        Err(_) => {
+    let recv_result = match crate::ipc::daemon_control_roundtrip(
+        endpoint,
+        crate::ipc::DaemonControlRequest::Clear,
+        None,
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(e) if crate::cli::client::is_daemon_unreachable_err(&e) => {
             eprintln!("daemon not running at {endpoint} — nothing to clear");
             return ExitCode::SUCCESS;
         }
-    };
-
-    if let Err(e) = conn.send(&crate::protocol::Request::Clear).await {
-        eprintln!("zccache[err][S]: failed to send to daemon: {e}");
-        return ExitCode::FAILURE;
-    }
-    let recv_result = match conn.recv().await {
-        Ok(r) => r,
         Err(e) => {
             eprintln!("zccache[err][R]: broken connection to daemon: {e}");
             return ExitCode::FAILURE;
         }
     };
+
     match recv_result {
         Some(crate::protocol::Response::Cleared {
             artifacts_removed,

--- a/crates/zccache/src/daemon/server/connection.rs
+++ b/crates/zccache/src/daemon/server/connection.rs
@@ -587,7 +587,7 @@ async fn send_response_for_wire(
         ResponseWire::BincodeV15 => conn.send(response).await,
         ResponseWire::ProstV16 { request_id } => {
             let response = wire_prost::supported_control_response_to_prost(response, request_id)
-                .map_err(|message| crate::protocol::ProtocolError::Serialization(message))?;
+                .map_err(crate::protocol::ProtocolError::Serialization)?;
             conn.send_prost(&response).await
         }
     }
@@ -717,19 +717,11 @@ mod live_ipc_prost_tests {
                     assert_eq!(response.request_id, "prost-clear");
                     let response =
                         wire_prost::supported_control_response_from_prost(response).unwrap();
-                    let Response::Error { message } = response else {
-                        panic!("expected Error response, got {response:?}");
+                    let Response::Cleared { .. } = response else {
+                        panic!("expected Cleared response, got {response:?}");
                     };
-                    assert!(
-                        message.contains("unsupported v16 prost request"),
-                        "unexpected error message: {message}"
-                    );
-                    assert!(
-                        message.contains("Ping, Status, and Shutdown"),
-                        "unsupported diagnostic should name the supported slice: {message}"
-                    );
                 }
-                other => panic!("expected Error response, got {other:?}"),
+                other => panic!("expected Cleared response, got {other:?}"),
             }
 
             client

--- a/crates/zccache/src/ipc/README.md
+++ b/crates/zccache/src/ipc/README.md
@@ -9,8 +9,9 @@ incoming frames by protocol-version header so a server can accept either v15
 bincode or v16 prost without breaking old clients.
 
 `daemon_control_roundtrip` is the only live client-side selector today. It
-honors `ZCCACHE_DAEMON_WIRE` for `Ping`, `Status`, and `Shutdown`; unset/`auto`
-tries v16 prost first and retries v15 bincode when an older daemon rejects the
-frame. The v16 control path accepts either v16 prost control replies or v15
-bincode replies from compatibility daemons. All non-control zccache daemon
-requests still use v15 bincode directly.
+honors `ZCCACHE_DAEMON_WIRE` for `Ping`, `Status`, `Shutdown`, and cache
+`Clear`; unset/`auto` tries v16 prost first and retries v15 bincode when an
+older daemon rejects the frame. The v16 control path accepts either v16 prost
+control replies or v15 bincode replies from compatibility daemons. Compile,
+session, artifact lookup/store, fingerprint, and download-daemon requests still
+use v15 bincode directly.

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -36,6 +36,8 @@ pub enum DaemonControlRequest {
     Status,
     /// Request daemon shutdown.
     Shutdown,
+    /// Clear all caches.
+    Clear,
 }
 
 impl DaemonControlRequest {
@@ -45,18 +47,19 @@ impl DaemonControlRequest {
             Self::Ping => protocol::Request::Ping,
             Self::Status => protocol::Request::Status,
             Self::Shutdown => protocol::Request::Shutdown,
+            Self::Clear => protocol::Request::Clear,
         }
     }
 }
 
 /// Send a daemon control request and receive its response.
 ///
-/// Only `Ping`, `Status`, and `Shutdown` are eligible for the v16 prost client
-/// path. Unset/`auto` `ZCCACHE_DAEMON_WIRE` prefers prost, then retries the
-/// same control request as v15 bincode if an older daemon clearly rejects the
-/// v16 frame or closes the connection after the mismatch. Compile, session,
-/// cache, fingerprint, and download-daemon requests do not route through this
-/// helper and remain v15 bincode.
+/// Only `Ping`, `Status`, `Shutdown`, and `Clear` are eligible for the v16
+/// prost client path. Unset/`auto` `ZCCACHE_DAEMON_WIRE` prefers prost, then
+/// retries the same control request as v15 bincode if an older daemon clearly
+/// rejects the v16 frame or closes the connection after the mismatch. Compile,
+/// session, artifact lookup/store, fingerprint, and download-daemon requests do
+/// not route through this helper and remain v15 bincode.
 ///
 /// # Errors
 ///
@@ -769,6 +772,70 @@ mod tests {
         match response {
             Some(Response::Status(status)) => assert_eq!(status.endpoint, endpoint),
             other => panic!("expected Status response, got {other:?}"),
+        }
+
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn daemon_control_roundtrip_auto_prefers_prost_for_clear() {
+        let endpoint = unique_test_endpoint();
+        let mut listener = IpcListener::bind(&endpoint).unwrap();
+
+        let server = tokio::spawn(async move {
+            let mut conn = listener.accept().await.unwrap();
+            let msg: Option<
+                crate::protocol::DecodedWireMessage<
+                    crate::protocol::Request,
+                    crate::protocol::wire_prost::zccache_v1::Request,
+                >,
+            > = conn.recv_wire().await.unwrap();
+            match msg {
+                Some(crate::protocol::DecodedWireMessage::ProstV16(request)) => {
+                    assert_eq!(request.request_id, "control-clear");
+                    assert!(matches!(
+                        request.body,
+                        Some(crate::protocol::wire_prost::zccache_v1::request::Body::Clear(_))
+                    ));
+                    let response = Response::Cleared {
+                        artifacts_removed: 1,
+                        metadata_cleared: 2,
+                        dep_graph_contexts_cleared: 3,
+                        on_disk_bytes_freed: 4,
+                    };
+                    let response = wire_prost::supported_control_response_to_prost(
+                        &response,
+                        &request.request_id,
+                    )
+                    .unwrap();
+                    conn.send_prost(&response).await.unwrap();
+                }
+                other => panic!("expected prost clear request, got {other:?}"),
+            }
+        });
+
+        let response = daemon_control_roundtrip_with_selection(
+            &endpoint,
+            DaemonControlRequest::Clear,
+            None,
+            wire_prost::ClientWireSelection::Auto,
+        )
+        .await
+        .unwrap();
+
+        match response {
+            Some(Response::Cleared {
+                artifacts_removed,
+                metadata_cleared,
+                dep_graph_contexts_cleared,
+                on_disk_bytes_freed,
+            }) => {
+                assert_eq!(artifacts_removed, 1);
+                assert_eq!(metadata_cleared, 2);
+                assert_eq!(dep_graph_contexts_cleared, 3);
+                assert_eq!(on_disk_bytes_freed, 4);
+            }
+            other => panic!("expected Cleared response, got {other:?}"),
         }
 
         server.await.unwrap();

--- a/crates/zccache/src/protocol/wire_prost.rs
+++ b/crates/zccache/src/protocol/wire_prost.rs
@@ -154,12 +154,13 @@ pub fn supported_control_request_from_prost(
         Some(Body::Ping(_)) => Ok(super::Request::Ping),
         Some(Body::Status(_)) => Ok(super::Request::Status),
         Some(Body::Shutdown(_)) => Ok(super::Request::Shutdown),
+        Some(Body::Clear(_)) => Ok(super::Request::Clear),
         Some(other) => Err(format!(
-            "unsupported v16 prost request body {other:?}; only Ping, Status, and Shutdown are \
-             supported before the full zccache prost conversion lands"
+            "unsupported v16 prost request body {other:?}; only Ping, Status, Shutdown, and Clear \
+             are supported before the full zccache prost conversion lands"
         )),
         None => Err(
-            "unsupported v16 prost request: missing request body; only Ping, Status, and Shutdown \
+            "unsupported v16 prost request: missing request body; only Ping, Status, Shutdown, and Clear \
              are supported before the full zccache prost conversion lands"
                 .to_string(),
         ),
@@ -181,9 +182,10 @@ pub fn supported_control_request_to_prost(
         super::Request::Ping => ("control-ping", Body::Ping(zccache_v1::Empty {})),
         super::Request::Status => ("control-status", Body::Status(zccache_v1::Empty {})),
         super::Request::Shutdown => ("control-shutdown", Body::Shutdown(zccache_v1::Empty {})),
+        super::Request::Clear => ("control-clear", Body::Clear(zccache_v1::Empty {})),
         other => {
             return Err(format!(
-                "unsupported v16 prost control request {other:?}; only Ping, Status, and Shutdown \
+                "unsupported v16 prost control request {other:?}; only Ping, Status, Shutdown, and Clear \
                  may select {WIRE_FORMAT_ENV} before the full zccache prost conversion lands"
             ));
         }
@@ -211,16 +213,22 @@ pub fn supported_control_response_from_prost(
         Some(Body::Pong(_)) => Ok(super::Response::Pong),
         Some(Body::ShuttingDown(_)) => Ok(super::Response::ShuttingDown),
         Some(Body::Status(status)) => daemon_status_from_prost(status).map(super::Response::Status),
+        Some(Body::Cleared(cleared)) => Ok(super::Response::Cleared {
+            artifacts_removed: cleared.artifacts_removed,
+            metadata_cleared: cleared.metadata_cleared,
+            dep_graph_contexts_cleared: cleared.dep_graph_contexts_cleared,
+            on_disk_bytes_freed: cleared.on_disk_bytes_freed,
+        }),
         Some(Body::Error(error)) => Ok(super::Response::Error {
             message: error.message,
         }),
         Some(other) => Err(format!(
-            "unsupported v16 prost response body {other:?}; only Pong, Status, ShuttingDown, and \
-             Error are supported before the full zccache prost conversion lands"
+            "unsupported v16 prost response body {other:?}; only Pong, Status, ShuttingDown, \
+             Cleared, and Error are supported before the full zccache prost conversion lands"
         )),
         None => Err(
             "unsupported v16 prost response: missing response body; only Pong, Status, \
-             ShuttingDown, and Error are supported before the full zccache prost conversion lands"
+             ShuttingDown, Cleared, and Error are supported before the full zccache prost conversion lands"
                 .to_string(),
         ),
     }
@@ -242,13 +250,24 @@ pub fn supported_control_response_to_prost(
         super::Response::Pong => Body::Pong(zccache_v1::Empty {}),
         super::Response::ShuttingDown => Body::ShuttingDown(zccache_v1::Empty {}),
         super::Response::Status(status) => Body::Status(daemon_status_to_prost(status)),
+        super::Response::Cleared {
+            artifacts_removed,
+            metadata_cleared,
+            dep_graph_contexts_cleared,
+            on_disk_bytes_freed,
+        } => Body::Cleared(zccache_v1::Cleared {
+            artifacts_removed: *artifacts_removed,
+            metadata_cleared: *metadata_cleared,
+            dep_graph_contexts_cleared: *dep_graph_contexts_cleared,
+            on_disk_bytes_freed: *on_disk_bytes_freed,
+        }),
         super::Response::Error { message } => Body::Error(zccache_v1::Error {
             message: message.clone(),
         }),
         other => {
             return Err(format!(
                 "unsupported v16 prost control response {other:?}; only Pong, Status, \
-                 ShuttingDown, and Error may use the prost control response path before the full \
+                 ShuttingDown, Cleared, and Error may use the prost control response path before the full \
                  zccache prost conversion lands"
             ));
         }

--- a/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
+++ b/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
@@ -1,7 +1,9 @@
 use bytes::BytesMut;
 use prost::Message;
 use zccache::protocol::wire_prost::{
-    decode_prost_message, encode_prost_message, wire_format_for_protocol_version, zccache_v1 as pb,
+    decode_prost_message, encode_prost_message, supported_control_request_from_prost,
+    supported_control_request_to_prost, supported_control_response_from_prost,
+    supported_control_response_to_prost, wire_format_for_protocol_version, zccache_v1 as pb,
     WireFormat,
 };
 use zccache::protocol::{decode_message, encode_message, PROST_PROTOCOL_VERSION};
@@ -57,6 +59,38 @@ fn prost_response_frame_roundtrips_release_worktree_result() {
         }
         _ => panic!("expected release-worktree response"),
     }
+}
+
+#[test]
+fn prost_clear_request_and_response_convert_to_protocol_enums() {
+    let request = zccache::protocol::Request::Clear;
+    let prost_request = supported_control_request_to_prost(&request).unwrap();
+    assert_eq!(prost_request.request_id, "control-clear");
+    assert!(matches!(
+        prost_request.body,
+        Some(pb::request::Body::Clear(_))
+    ));
+    assert_eq!(
+        supported_control_request_from_prost(prost_request).unwrap(),
+        request
+    );
+
+    let response = zccache::protocol::Response::Cleared {
+        artifacts_removed: 1,
+        metadata_cleared: 2,
+        dep_graph_contexts_cleared: 3,
+        on_disk_bytes_freed: 4,
+    };
+    let prost_response = supported_control_response_to_prost(&response, "clear-1").unwrap();
+    assert_eq!(prost_response.request_id, "clear-1");
+    assert!(matches!(
+        prost_response.body,
+        Some(pb::response::Body::Cleared(_))
+    ));
+    assert_eq!(
+        supported_control_response_from_prost(prost_response).unwrap(),
+        response
+    );
 }
 
 #[test]


### PR DESCRIPTION
Coordinated with zackees/running-process#234.

This is a bounded next slice of the zccache prost wire migration after #704. It adds the cache-maintenance `Clear`/`Cleared` request-response family to the live v16 prost path while preserving the v15 bincode fallback for older daemons.

Summary:
- Convert v16 prost `Clear` requests to `Request::Clear` and `Cleared` responses back to `Response::Cleared`.
- Route `zccache clear` through `daemon_control_roundtrip`, so unset/auto `ZCCACHE_DAEMON_WIRE` tries prost first and falls back to bincode on old daemons.
- Add focused conversion, selector, and live daemon IPC coverage.

Still intentionally out of scope for running-process#234:
- Compile/session/artifact/fingerprint/generic-tool request families.
- Full enum conversion and default global prost transport.
- Previous-release compatibility harness and p50/p99 perf evidence.
- running-process Frame integration.

Tests:
- `soldr cargo test -p zccache --test daemon_wire_prost_roundtrip`
- `soldr cargo test -p zccache daemon_control_roundtrip_auto_prefers_prost_for_clear`
- `soldr cargo test -p zccache handle_connection_accepts_v15_and_v16_control_requests --lib`
- `soldr cargo clippy -p zccache --all-targets -- -D warnings`
- `soldr rustfmt --check crates/zccache/src/protocol/wire_prost.rs crates/zccache/src/ipc/mod.rs crates/zccache/src/cli/commands/cache_ops.rs crates/zccache/src/daemon/server/connection.rs crates/zccache/tests/daemon_wire_prost_roundtrip.rs`
- `git diff --check`