### PR TITLE
feat: accept prost release-worktree requests

### DIFF
--- a/crates/zccache/src/daemon/server/connection.rs
+++ b/crates/zccache/src/daemon/server/connection.rs
@@ -724,6 +724,42 @@ mod live_ipc_prost_tests {
                 other => panic!("expected Cleared response, got {other:?}"),
             }
 
+            let release_path = temp.path().join("orphan-worktree");
+            client
+                .send_prost(&prost_request(
+                    "prost-release-worktree",
+                    pb::request::Body::ReleaseWorktreeHandles(pb::ReleaseWorktreeHandles {
+                        path: Some(pb::Path {
+                            value: release_path.to_string_lossy().into_owned(),
+                        }),
+                    }),
+                ))
+                .await
+                .unwrap();
+            let response: Option<DecodedWireMessage<Response, pb::Response>> =
+                client.recv_wire().await.unwrap();
+            match response {
+                Some(DecodedWireMessage::ProstV16(response)) => {
+                    assert_eq!(response.request_id, "prost-release-worktree");
+                    let response =
+                        wire_prost::supported_control_response_from_prost(response).unwrap();
+                    let Response::ReleaseWorktreeHandlesResult {
+                        inspected,
+                        released,
+                        sessions_dropped,
+                        unreleased,
+                    } = response
+                    else {
+                        panic!("expected ReleaseWorktreeHandlesResult response, got {response:?}");
+                    };
+                    assert_eq!(inspected, 0);
+                    assert_eq!(released, 0);
+                    assert!(sessions_dropped.is_empty());
+                    assert!(unreleased.is_empty());
+                }
+                other => panic!("expected ReleaseWorktreeHandlesResult response, got {other:?}"),
+            }
+
             client
                 .send_prost(&prost_request(
                     "prost-ping",

--- a/crates/zccache/src/ipc/README.md
+++ b/crates/zccache/src/ipc/README.md
@@ -12,6 +12,8 @@ bincode or v16 prost without breaking old clients.
 honors `ZCCACHE_DAEMON_WIRE` for `Ping`, `Status`, `Shutdown`, and cache
 `Clear`; unset/`auto` tries v16 prost first and retries v15 bincode when an
 older daemon rejects the frame. The v16 control path accepts either v16 prost
-control replies or v15 bincode replies from compatibility daemons. Compile,
-session, artifact lookup/store, fingerprint, and download-daemon requests still
-use v15 bincode directly.
+control replies or v15 bincode replies from compatibility daemons. The daemon
+also accepts direct v16 prost `ReleaseWorktreeHandles` requests and sends the
+matching v16 prost response, but there is no high-level client selector for
+that path yet. Compile, session, artifact lookup/store, fingerprint,
+generic-tool, and download-daemon requests still use v15 bincode directly.

--- a/crates/zccache/src/protocol/README.md
+++ b/crates/zccache/src/protocol/README.md
@@ -28,14 +28,18 @@ enum variants must still be appended in `messages/mod.rs` and require a
 `PROTOCOL_VERSION` remains `15` while the public `encode_message` and
 `decode_message` helpers emit and accept bincode bodies. `PROST_PROTOCOL_VERSION`
 is `16` for the prost path. The live daemon receive path dispatches both frame
-versions, but only the control-request slice (`Ping`, `Status`, `Shutdown`) is
-converted from prost today, and only the matching control-response slice
-(`Pong`, `Status`, `ShuttingDown`, `Error`) is converted back to prost replies.
+versions, but only the control/maintenance request slice (`Ping`, `Status`,
+`Shutdown`, `Clear`, `ReleaseWorktreeHandles`) is converted from prost today,
+and only the matching control/maintenance response slice (`Pong`, `Status`,
+`ShuttingDown`, `Cleared`, `ReleaseWorktreeHandlesResult`, `Error`) is converted
+back to prost replies.
 `ZCCACHE_DAEMON_WIRE` is honored for that client control slice: unset or `auto`
 tries prost first and falls back to v15 bincode on a clear old-daemon protocol
-rejection; `bincode` forces the old path. Compile, session, cache, fingerprint,
-and download-daemon requests remain v15 bincode until their full protobuf
-conversion lands.
+rejection; `bincode` forces the old path. The live daemon can accept a direct
+v16 prost `ReleaseWorktreeHandles` request, but the high-level client selector
+does not route it yet. Compile, session, artifact lookup/store, fingerprint,
+generic-tool, and download-daemon requests remain v15 bincode until their full
+protobuf conversion lands.
 
 ## Request Variants
 
@@ -52,6 +56,7 @@ conversion lands.
 | `LinkEphemeral` | Single-roundtrip link/archive |
 | `Lookup` / `Store` | Direct artifact cache access |
 | `Clear` | Wipe all caches |
+| `ReleaseWorktreeHandles` | Drop session-owned handles under a worktree path |
 
 ## Response Variants
 
@@ -67,3 +72,4 @@ conversion lands.
 | `LinkResult` | Same as `CompileResult` plus optional `warning` |
 | `Error { message }` | Error string |
 | `Cleared` | Counts of artifacts/metadata/contexts removed |
+| `ReleaseWorktreeHandlesResult` | Worktree-handle release counts and unreleased paths |

--- a/crates/zccache/src/protocol/wire_prost.rs
+++ b/crates/zccache/src/protocol/wire_prost.rs
@@ -137,8 +137,8 @@ pub fn client_wire_selection_from_env() -> Result<ClientWireSelection, String> {
     client_wire_selection_from_env_value(std::env::var(WIRE_FORMAT_ENV).ok().as_deref())
 }
 
-/// Convert the narrow set of v16 prost daemon-control requests that the live
-/// dispatcher can handle before the full enum conversion lands.
+/// Convert the narrow set of v16 prost daemon-control and maintenance requests
+/// that the live dispatcher can handle before the full enum conversion lands.
 ///
 /// # Errors
 ///
@@ -155,19 +155,28 @@ pub fn supported_control_request_from_prost(
         Some(Body::Status(_)) => Ok(super::Request::Status),
         Some(Body::Shutdown(_)) => Ok(super::Request::Shutdown),
         Some(Body::Clear(_)) => Ok(super::Request::Clear),
+        Some(Body::ReleaseWorktreeHandles(request)) => {
+            Ok(super::Request::ReleaseWorktreeHandles {
+                path: path_from_prost(required_prost_field(
+                    request.path,
+                    "ReleaseWorktreeHandles.path",
+                )?),
+            })
+        }
         Some(other) => Err(format!(
-            "unsupported v16 prost request body {other:?}; only Ping, Status, Shutdown, and Clear \
-             are supported before the full zccache prost conversion lands"
+            "unsupported v16 prost request body {other:?}; only Ping, Status, Shutdown, Clear, \
+             and ReleaseWorktreeHandles are supported before the full zccache prost conversion lands"
         )),
         None => Err(
-            "unsupported v16 prost request: missing request body; only Ping, Status, Shutdown, and Clear \
-             are supported before the full zccache prost conversion lands"
+            "unsupported v16 prost request: missing request body; only Ping, Status, Shutdown, \
+             Clear, and ReleaseWorktreeHandles are supported before the full zccache prost conversion lands"
                 .to_string(),
         ),
     }
 }
 
-/// Convert the narrow daemon-control request slice to the v16 prost schema.
+/// Convert the narrow daemon-control and maintenance request slice to the v16
+/// prost schema.
 ///
 /// # Errors
 ///
@@ -183,10 +192,17 @@ pub fn supported_control_request_to_prost(
         super::Request::Status => ("control-status", Body::Status(zccache_v1::Empty {})),
         super::Request::Shutdown => ("control-shutdown", Body::Shutdown(zccache_v1::Empty {})),
         super::Request::Clear => ("control-clear", Body::Clear(zccache_v1::Empty {})),
+        super::Request::ReleaseWorktreeHandles { path } => (
+            "control-release-worktree-handles",
+            Body::ReleaseWorktreeHandles(zccache_v1::ReleaseWorktreeHandles {
+                path: Some(path_to_prost(path)),
+            }),
+        ),
         other => {
             return Err(format!(
-                "unsupported v16 prost control request {other:?}; only Ping, Status, Shutdown, and Clear \
-                 may select {WIRE_FORMAT_ENV} before the full zccache prost conversion lands"
+                "unsupported v16 prost control request {other:?}; only Ping, Status, Shutdown, \
+                 Clear, and ReleaseWorktreeHandles may select {WIRE_FORMAT_ENV} before the full \
+                 zccache prost conversion lands"
             ));
         }
     };
@@ -197,8 +213,8 @@ pub fn supported_control_request_to_prost(
     })
 }
 
-/// Convert the narrow daemon-control response slice from the v16 prost schema
-/// back to the local protocol enum.
+/// Convert the narrow daemon-control and maintenance response slice from the
+/// v16 prost schema back to the local protocol enum.
 ///
 /// # Errors
 ///
@@ -222,19 +238,30 @@ pub fn supported_control_response_from_prost(
         Some(Body::Error(error)) => Ok(super::Response::Error {
             message: error.message,
         }),
+        Some(Body::ReleaseWorktreeHandlesResult(result)) => {
+            Ok(super::Response::ReleaseWorktreeHandlesResult {
+                inspected: result.inspected,
+                released: result.released,
+                sessions_dropped: result.sessions_dropped,
+                unreleased: result.unreleased.into_iter().map(path_from_prost).collect(),
+            })
+        }
         Some(other) => Err(format!(
             "unsupported v16 prost response body {other:?}; only Pong, Status, ShuttingDown, \
-             Cleared, and Error are supported before the full zccache prost conversion lands"
+             Cleared, Error, and ReleaseWorktreeHandlesResult are supported before the full \
+             zccache prost conversion lands"
         )),
         None => Err(
             "unsupported v16 prost response: missing response body; only Pong, Status, \
-             ShuttingDown, Cleared, and Error are supported before the full zccache prost conversion lands"
+             ShuttingDown, Cleared, Error, and ReleaseWorktreeHandlesResult are supported before the full \
+             zccache prost conversion lands"
                 .to_string(),
         ),
     }
 }
 
-/// Convert the narrow daemon-control response slice to the v16 prost schema.
+/// Convert the narrow daemon-control and maintenance response slice to the v16
+/// prost schema.
 ///
 /// # Errors
 ///
@@ -264,11 +291,22 @@ pub fn supported_control_response_to_prost(
         super::Response::Error { message } => Body::Error(zccache_v1::Error {
             message: message.clone(),
         }),
+        super::Response::ReleaseWorktreeHandlesResult {
+            inspected,
+            released,
+            sessions_dropped,
+            unreleased,
+        } => Body::ReleaseWorktreeHandlesResult(zccache_v1::ReleaseWorktreeHandlesResult {
+            inspected: *inspected,
+            released: *released,
+            sessions_dropped: sessions_dropped.clone(),
+            unreleased: unreleased.iter().map(path_to_prost).collect(),
+        }),
         other => {
             return Err(format!(
                 "unsupported v16 prost control response {other:?}; only Pong, Status, \
-                 ShuttingDown, Cleared, and Error may use the prost control response path before the full \
-                 zccache prost conversion lands"
+                 ShuttingDown, Cleared, Error, and ReleaseWorktreeHandlesResult may use the prost \
+                 control response path before the full zccache prost conversion lands"
             ));
         }
     };

--- a/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
+++ b/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
@@ -94,6 +94,40 @@ fn prost_clear_request_and_response_convert_to_protocol_enums() {
 }
 
 #[test]
+fn prost_release_worktree_handles_request_and_response_convert_to_protocol_enums() {
+    let request = zccache::protocol::Request::ReleaseWorktreeHandles {
+        path: "/tmp/worktree".into(),
+    };
+    let prost_request = supported_control_request_to_prost(&request).unwrap();
+    assert_eq!(prost_request.request_id, "control-release-worktree-handles");
+    assert!(matches!(
+        prost_request.body,
+        Some(pb::request::Body::ReleaseWorktreeHandles(_))
+    ));
+    assert_eq!(
+        supported_control_request_from_prost(prost_request).unwrap(),
+        request
+    );
+
+    let response = zccache::protocol::Response::ReleaseWorktreeHandlesResult {
+        inspected: 2,
+        released: 1,
+        sessions_dropped: vec!["session-a".to_string()],
+        unreleased: vec!["/tmp/worktree/locked.obj".into()],
+    };
+    let prost_response = supported_control_response_to_prost(&response, "release-1").unwrap();
+    assert_eq!(prost_response.request_id, "release-1");
+    assert!(matches!(
+        prost_response.body,
+        Some(pb::response::Body::ReleaseWorktreeHandlesResult(_))
+    ));
+    assert_eq!(
+        supported_control_response_from_prost(prost_response).unwrap(),
+        response
+    );
+}
+
+#[test]
 fn generated_frame_envelope_can_carry_opaque_payload() {
     let request = pb::Request {
         body: Some(pb::request::Body::Status(pb::Empty {})),


### PR DESCRIPTION
Advances zackees/running-process#234 with the next bounded prost wire slice.

Summary:
- Adds v16 prost conversion for `Request::ReleaseWorktreeHandles` and `Response::ReleaseWorktreeHandlesResult`.
- Lets the live daemon accept direct v16 prost release-worktree requests and reply with v16 prost results.
- Updates zccache protocol/IPC migration docs to name the new supported slice and remaining bincode-only paths.

#234 remains open: compile/session/artifact/fingerprint/generic-tool families, full enum conversion, previous-release compatibility, p50/p99 perf evidence, and running-process Frame integration are still outstanding.

Local Windows checks:
- `soldr rustfmt --check crates/zccache/src/protocol/wire_prost.rs crates/zccache/src/daemon/server/connection.rs crates/zccache/tests/daemon_wire_prost_roundtrip.rs`
- `git diff --check`
- `soldr cargo test -p zccache --test daemon_wire_prost_roundtrip`
- `soldr cargo test -p zccache handle_connection_accepts_v15_and_v16_control_requests --lib -- --nocapture`
- `soldr cargo test -p zccache daemon_control_roundtrip --lib -- --nocapture`
- `soldr cargo test -p zccache --test daemon_wire_dispatcher --test daemon_wire_protocol_version --test daemon_wire_perf_scaffold`
- `soldr cargo clippy -p zccache --all-targets -- -D warnings`