### PR TITLE
test: prove v15 daemon fallback

### DIFF
--- a/crates/zccache/src/ipc/README.md
+++ b/crates/zccache/src/ipc/README.md
@@ -17,3 +17,8 @@ also accepts direct v16 prost `ReleaseWorktreeHandles` requests and sends the
 matching v16 prost response, but there is no high-level client selector for
 that path yet. Compile, session, artifact lookup/store, fingerprint,
 generic-tool, and download-daemon requests still use v15 bincode directly.
+
+`tests/daemon_wire_protocol_version.rs` includes the explicit previous-release
+compatibility harness: a v15-only daemon rejects the first v16 prost control
+frame, returns a v15 bincode mismatch response, and the public auto client
+retries the same control request as v15 bincode.

--- a/crates/zccache/tests/daemon_wire_protocol_version.rs
+++ b/crates/zccache/tests/daemon_wire_protocol_version.rs
@@ -1,5 +1,34 @@
+use std::ffi::OsString;
+
+use zccache::ipc::{
+    daemon_control_roundtrip, unique_test_endpoint, DaemonControlRequest, IpcError, IpcListener,
+};
 use zccache::protocol::wire_prost::{wire_format_from_env_value, WireFormat, WIRE_FORMAT_ENV};
-use zccache::protocol::{BINCODE_PROTOCOL_VERSION, PROST_PROTOCOL_VERSION, PROTOCOL_VERSION};
+use zccache::protocol::{
+    ProtocolError, Request, Response, BINCODE_PROTOCOL_VERSION, PROST_PROTOCOL_VERSION,
+    PROTOCOL_VERSION,
+};
+
+struct WireEnvGuard {
+    previous: Option<OsString>,
+}
+
+impl WireEnvGuard {
+    fn unset_for_auto() -> Self {
+        let previous = std::env::var_os(WIRE_FORMAT_ENV);
+        std::env::remove_var(WIRE_FORMAT_ENV);
+        Self { previous }
+    }
+}
+
+impl Drop for WireEnvGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => std::env::set_var(WIRE_FORMAT_ENV, value),
+            None => std::env::remove_var(WIRE_FORMAT_ENV),
+        }
+    }
+}
 
 #[test]
 fn current_protocol_version_remains_v15_bincode() {
@@ -37,4 +66,47 @@ fn wire_env_rejects_unknown_values() {
     assert!(err.contains(WIRE_FORMAT_ENV));
     assert!(err.contains("bincode"));
     assert!(err.contains("prost"));
+}
+
+#[tokio::test]
+async fn auto_client_falls_back_against_previous_release_v15_daemon() {
+    let _env = WireEnvGuard::unset_for_auto();
+    let endpoint = unique_test_endpoint();
+    let mut listener = IpcListener::bind(&endpoint).unwrap();
+
+    let server = tokio::spawn(async move {
+        let mut first = listener.accept().await.unwrap();
+        let err = first
+            .recv::<Request>()
+            .await
+            .expect_err("previous-release v15 daemon must reject the first v16 prost frame");
+        assert!(matches!(
+            err,
+            IpcError::Protocol(ProtocolError::VersionMismatch {
+                expected: BINCODE_PROTOCOL_VERSION,
+                received: PROST_PROTOCOL_VERSION,
+            })
+        ));
+        first
+            .send(&Response::Error {
+                message: format!(
+                    "protocol version mismatch: expected v{BINCODE_PROTOCOL_VERSION}, received \
+                     v{PROST_PROTOCOL_VERSION}"
+                ),
+            })
+            .await
+            .unwrap();
+
+        let mut second = listener.accept().await.unwrap();
+        let request: Option<Request> = second.recv().await.unwrap();
+        assert_eq!(request, Some(Request::Ping));
+        second.send(&Response::Pong).await.unwrap();
+    });
+
+    let response = daemon_control_roundtrip(&endpoint, DaemonControlRequest::Ping, None)
+        .await
+        .unwrap();
+    assert_eq!(response, Some(Response::Pong));
+
+    server.await.unwrap();
 }


### PR DESCRIPTION
## Summary
- Add an integration-style previous-release compatibility harness for the running-process#234 zccache wire migration.
- Prove the public auto client retries a daemon control request as v15 bincode after a v15-only daemon rejects the first v16 prost frame.
- Document the harness in the IPC migration notes.

Refs zackees/running-process#234
Refs zackees/running-process#228

## Tests
- soldr rustfmt --check crates/zccache/tests/daemon_wire_protocol_version.rs
- git diff --check
- soldr cargo test -p zccache --test daemon_wire_protocol_version auto_client_falls_back_against_previous_release_v15_daemon -- --nocapture
- soldr cargo test -p zccache --test daemon_wire_protocol_version -- --nocapture
- soldr cargo test -p zccache --test daemon_wire_dispatcher --test daemon_wire_prost_roundtrip --test daemon_wire_perf_scaffold
- soldr cargo test -p zccache daemon_control_roundtrip_auto_falls_back_to_bincode_for_old_daemon --lib -- --nocapture
- soldr cargo clippy -p zccache --test daemon_wire_protocol_version -- -D warnings
- soldr cargo clippy -p zccache --all-targets -- -D warnings