### PR TITLE
feat: adopt BackendHandle for daemon probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +665,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
 name = "downcast-rs"
@@ -1249,6 +1276,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "interprocess"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
+dependencies = [
+ "doctest-file",
+ "libc",
+ "recvmsg",
+ "widestring",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +1723,12 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -2213,6 +2259,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
+
+[[package]]
 name = "redb"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,6 +2289,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2363,16 +2426,24 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64479526e50ccc2d842a78361bcf452e12e09329159e0beafd19d6e9d659d9e"
+version = "4.0.3"
+source = "git+https://github.com/zackees/running-process?rev=e49edf839706f42c655e83a2e8235a482abbc38e#e49edf839706f42c655e83a2e8235a482abbc38e"
 dependencies = [
+ "anyhow",
+ "blake3",
+ "clap",
+ "dirs",
+ "getrandom 0.4.2",
+ "interprocess",
  "libc",
  "portable-pty",
+ "prost",
  "prost-build",
+ "prost-types",
  "protox",
  "serde",
  "serde_json",
+ "sha2",
  "sysinfo 0.30.13",
  "thiserror 2.0.18",
  "winapi",
@@ -3423,6 +3494,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ sevenz-rust = "0.6"
 rkyv = { version = "0.7", features = ["validation"] }
 tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
 mimalloc = "0.1"
-running-process = { version = "4.0.0", default-features = false }
+running-process = { git = "https://github.com/zackees/running-process", rev = "e49edf839706f42c655e83a2e8235a482abbc38e", default-features = false, features = ["client"] }
 zccache = { path = "crates/zccache" }
 zccache-watcher = { path = "crates/zccache-watcher" }
 zccache-cli = { path = "crates/zccache-cli" }

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -304,6 +304,9 @@ fn run_server(args: Args) {
         if let Err(e) = zccache::ipc::write_lock_file(pid) {
             tracing::warn!("failed to write lock file: {e}");
         }
+        if let Err(e) = zccache::ipc::write_backend_identity(&server.backend_identity()) {
+            tracing::warn!("failed to write running-process backend identity: {e}");
+        }
 
         // Spawn the depgraph load. Holds a `DepGraphSetter` that survives
         // the spawn_blocking boundary; on completion atomically installs

--- a/crates/zccache/src/daemon/server/connection.rs
+++ b/crates/zccache/src/daemon/server/connection.rs
@@ -16,6 +16,14 @@ pub(super) async fn handle_connection(
     mut conn: IpcConnection,
     state: Arc<SharedState>,
 ) -> Result<(), crate::ipc::IpcError> {
+    if conn
+        .try_serve_backend_handle_probe(&state.backend_identity)
+        .await?
+    {
+        state.last_activity.store(now_secs(), Ordering::Relaxed);
+        return Ok(());
+    }
+
     loop {
         let request = match conn.recv_wire::<Request, pb::Request>().await {
             Ok(req) => req,

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -30,6 +30,8 @@ impl DaemonServer {
         cache_dir: &crate::core::NormalizedPath,
     ) -> Result<Self, crate::ipc::IpcError> {
         let listener = IpcListener::bind(endpoint)?;
+        let backend_identity = crate::ipc::current_backend_identity(endpoint)
+            .map_err(|err| crate::ipc::IpcError::Endpoint(err.to_string()))?;
         let shutdown = Arc::new(Notify::new());
         let now = now_secs();
         let instance = SERVER_INSTANCE.fetch_add(1, Ordering::Relaxed);
@@ -124,6 +126,7 @@ impl DaemonServer {
             index_writer_rx: Some(index_writer_rx),
             state: Arc::new(SharedState {
                 endpoint: endpoint.to_string(),
+                backend_identity,
                 daemon_namespace: crate::core::config::daemon_namespace_label(),
                 cache_dir: cache_dir.clone(),
                 private_daemon: PrivateDaemonLifecycle::new(),
@@ -180,6 +183,12 @@ impl DaemonServer {
     #[must_use]
     pub fn shutdown_handle(&self) -> Arc<Notify> {
         Arc::clone(&self.shutdown)
+    }
+
+    /// Clone the running-process identity served by this daemon.
+    #[must_use]
+    pub fn backend_identity(&self) -> running_process::broker::backend_handle::DaemonProcess {
+        self.state.backend_identity.clone()
     }
 
     /// Replace the dependency graph with a pre-loaded one.

--- a/crates/zccache/src/daemon/server/state.rs
+++ b/crates/zccache/src/daemon/server/state.rs
@@ -13,6 +13,9 @@ pub(super) struct SharedState {
     /// IPC endpoint this daemon bound. Reported through `zccache status` so
     /// wrappers can verify they reached the intended daemon identity.
     pub(super) endpoint: String,
+    /// running-process BackendHandle identity served on the same direct
+    /// daemon endpoint for the minimal broker-adoption path.
+    pub(super) backend_identity: running_process::broker::backend_handle::DaemonProcess,
     /// Active daemon/socket namespace label.
     pub(super) daemon_namespace: String,
     /// Cache root this daemon was created with.

--- a/crates/zccache/src/ipc/README.md
+++ b/crates/zccache/src/ipc/README.md
@@ -22,3 +22,14 @@ generic-tool, and download-daemon requests still use v15 bincode directly.
 compatibility harness: a v15-only daemon rejects the first v16 prost control
 frame, returns a v15 bincode mismatch response, and the public auto client
 retries the same control request as v15 bincode.
+
+Minimal running-process adoption is intentionally separate from the full broker
+rollout. The direct zccache daemon now records
+`daemon.running-process.json` beside its lock file and answers the reserved
+`BackendHandle` endpoint probe on the existing IPC endpoint. This lets callers
+verify the current daemon through `running_process::broker::BackendHandle`
+without requiring a `.servicedef`, broker-client routing, default-on rollout,
+or the remaining protobuf message-family conversions. The daemon pre-bind
+probe uses that BackendHandle identity when present and falls back to the
+legacy raw-connect probe for older daemons that have not written the identity
+file yet.

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -365,6 +365,92 @@ pub fn remove_lock_file() {
     let _ = std::fs::remove_file(lock_file_path());
 }
 
+/// Path where the daemon records the identity consumed by
+/// `running_process::broker::backend_handle::BackendHandle`.
+#[must_use]
+pub fn backend_identity_path() -> NormalizedPath {
+    let namespace = crate::core::config::daemon_namespace();
+    if let Some(cache_dir) = crate::core::config::cache_dir_override() {
+        return cache_dir.join(backend_identity_file_name(namespace.as_deref()));
+    }
+    crate::core::config::default_cache_dir().join(backend_identity_file_name(namespace.as_deref()))
+}
+
+fn backend_identity_file_name(namespace: Option<&str>) -> String {
+    match namespace {
+        Some(ns) => format!("daemon-{ns}.running-process.json"),
+        None => "daemon.running-process.json".to_string(),
+    }
+}
+
+/// Convert zccache's direct daemon endpoint to the running-process endpoint
+/// tuple used by `BackendHandle`.
+#[must_use]
+pub fn running_process_endpoint(endpoint: &str) -> running_process::broker::protocol::Endpoint {
+    running_process::broker::protocol::Endpoint {
+        namespace_id: crate::core::config::daemon_namespace_label(),
+        path: running_process_endpoint_path(endpoint),
+    }
+}
+
+#[cfg(windows)]
+fn running_process_endpoint_path(endpoint: &str) -> String {
+    endpoint
+        .strip_prefix(r"\\.\pipe\")
+        .unwrap_or(endpoint)
+        .to_string()
+}
+
+#[cfg(unix)]
+fn running_process_endpoint_path(endpoint: &str) -> String {
+    endpoint.to_string()
+}
+
+/// Build the current process identity that a zccache daemon exposes to
+/// `BackendHandle` probes.
+pub fn current_backend_identity(
+    endpoint: &str,
+) -> Result<
+    running_process::broker::backend_handle::DaemonProcess,
+    running_process::broker::backend_lifecycle::identity::IdentityError,
+> {
+    running_process::broker::backend_handle::DaemonProcess::current_process(
+        running_process_endpoint(endpoint),
+        None,
+    )
+}
+
+/// Persist the daemon identity used by future `BackendHandle` probes.
+pub fn write_backend_identity(
+    daemon: &running_process::broker::backend_handle::DaemonProcess,
+) -> Result<(), std::io::Error> {
+    let path = backend_identity_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_vec_pretty(daemon)
+        .map_err(|err| std::io::Error::other(format!("serialize backend identity: {err}")))?;
+    std::fs::write(path, json)
+}
+
+/// Load and actively verify the daemon identity through `BackendHandle`.
+#[must_use]
+pub fn probe_backend_handle(
+    endpoint: &str,
+) -> Option<running_process::broker::backend_handle::BackendHandle> {
+    let daemon = std::fs::read(backend_identity_path())
+        .ok()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok())?;
+    let endpoint = running_process_endpoint(endpoint);
+    running_process::broker::backend_handle::BackendHandle::probe_with_service(
+        "zccache",
+        crate::core::VERSION,
+        &endpoint,
+        &daemon,
+    )
+    .ok()
+}
+
 /// Forcefully terminate a process by PID.
 ///
 /// This is intended as a last-resort escape hatch when the daemon is no longer
@@ -497,6 +583,9 @@ pub async fn probe_existing_daemon(endpoint: &str, timeout: std::time::Duration)
     }
     if !verify_daemon_pid(pid) {
         return false;
+    }
+    if probe_backend_handle(endpoint).is_some() {
+        return true;
     }
     match tokio::time::timeout(timeout, crate::ipc::connect(endpoint)).await {
         Ok(Ok(_conn)) => true,

--- a/crates/zccache/src/ipc/transport.rs
+++ b/crates/zccache/src/ipc/transport.rs
@@ -8,7 +8,8 @@
 
 use std::time::Duration;
 
-use bytes::BytesMut;
+use bytes::{Buf, BytesMut};
+use prost::Message as _;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 
 use super::error::IpcError;
@@ -73,6 +74,25 @@ pub struct IpcClientConnection {
 // ── IpcConnection impl (server-side on Windows, both on Unix) ───────
 
 impl IpcConnection {
+    /// Serve a running-process `BackendHandle` endpoint identity probe.
+    ///
+    /// Returns `true` when this connection was a probe and has been answered.
+    /// Returns `false` after buffering enough bytes to prove the peer is using
+    /// zccache's normal daemon wire; those bytes remain queued for the next
+    /// `recv`/`recv_wire` call.
+    pub async fn try_serve_backend_handle_probe(
+        &mut self,
+        daemon: &running_process::broker::backend_handle::DaemonProcess,
+    ) -> Result<bool, IpcError> {
+        try_serve_backend_handle_probe(
+            &mut self.reader,
+            &mut self.writer,
+            &mut self.read_buf,
+            daemon,
+        )
+        .await
+    }
+
     /// Send a serializable message over the connection.
     pub async fn send<T: serde::Serialize>(&mut self, msg: &T) -> Result<(), IpcError> {
         let buf = crate::protocol::encode_message(msg)?;
@@ -353,6 +373,143 @@ where
     }
     read_buf.extend_from_slice(&tmp[..n]);
     Ok(true)
+}
+
+async fn try_serve_backend_handle_probe<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    read_buf: &mut BytesMut,
+    daemon: &running_process::broker::backend_handle::DaemonProcess,
+) -> Result<bool, IpcError>
+where
+    R: AsyncRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    ensure_buffered(reader, read_buf, 8).await?;
+    if read_buf.is_empty() {
+        return Ok(false);
+    }
+
+    let running_process_version = running_process::broker::protocol::ENVELOPE_VERSION;
+    if read_buf[0] != running_process_version {
+        return Ok(false);
+    }
+
+    let zccache_len = u32::from_le_bytes([read_buf[0], read_buf[1], read_buf[2], read_buf[3]]);
+    let zccache_version = u32::from_le_bytes([read_buf[4], read_buf[5], read_buf[6], read_buf[7]]);
+    if zccache_len >= 4
+        && matches!(
+            zccache_version,
+            crate::protocol::BINCODE_PROTOCOL_VERSION | crate::protocol::PROST_PROTOCOL_VERSION
+        )
+    {
+        return Ok(false);
+    }
+
+    let body_len =
+        u32::from_le_bytes([read_buf[1], read_buf[2], read_buf[3], read_buf[4]]) as usize;
+    if body_len > running_process::broker::protocol::MAX_FRAME_BYTES {
+        return Err(IpcError::Endpoint(format!(
+            "running-process BackendHandle probe frame too large: {body_len} bytes"
+        )));
+    }
+    ensure_buffered(reader, read_buf, 5 + body_len).await?;
+
+    read_buf.advance(5);
+    let body = read_buf.split_to(body_len);
+    let frame = running_process::broker::protocol::Frame::decode(body.as_ref())
+        .map_err(|err| IpcError::Endpoint(format!("BackendHandle probe decode failed: {err}")))?;
+    if !is_backend_handle_probe_request(&frame) {
+        return Err(IpcError::Endpoint(
+            "unexpected running-process frame on zccache daemon endpoint".to_string(),
+        ));
+    }
+
+    let response = backend_handle_probe_response(&frame, daemon)?;
+    write_running_process_frame(writer, &response).await?;
+    Ok(true)
+}
+
+async fn ensure_buffered<R>(
+    reader: &mut R,
+    read_buf: &mut BytesMut,
+    min_len: usize,
+) -> Result<(), IpcError>
+where
+    R: AsyncRead + Unpin,
+{
+    while read_buf.len() < min_len {
+        if !read_next_chunk(reader, read_buf).await? {
+            if read_buf.is_empty() {
+                return Ok(());
+            }
+            return Err(IpcError::ConnectionClosed);
+        }
+    }
+    Ok(())
+}
+
+fn is_backend_handle_probe_request(frame: &running_process::broker::protocol::Frame) -> bool {
+    use running_process::broker::backend_lifecycle::probe::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL;
+    use running_process::broker::protocol::{FrameKind, PayloadEncoding};
+
+    frame.envelope_version == 1
+        && FrameKind::try_from(frame.kind) == Ok(FrameKind::Request)
+        && frame.payload_protocol == BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL
+        && PayloadEncoding::try_from(frame.payload_encoding) == Ok(PayloadEncoding::None)
+        && frame.payload.len() == 32
+}
+
+fn backend_handle_probe_response(
+    request: &running_process::broker::protocol::Frame,
+    daemon: &running_process::broker::backend_handle::DaemonProcess,
+) -> Result<running_process::broker::protocol::Frame, IpcError> {
+    use running_process::broker::backend_lifecycle::probe::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL;
+    use running_process::broker::protocol::{Frame, FrameKind, PayloadEncoding};
+
+    let mut payload = Vec::with_capacity(32 + 128);
+    payload.extend_from_slice(&request.payload);
+    daemon.to_proto().encode(&mut payload).map_err(|err| {
+        IpcError::Endpoint(format!("BackendHandle identity encode failed: {err}"))
+    })?;
+
+    Ok(Frame {
+        envelope_version: 1,
+        kind: FrameKind::Response as i32,
+        payload_protocol: BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL,
+        payload,
+        request_id: request.request_id,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: request.traceparent.clone(),
+        tracestate: request.tracestate.clone(),
+    })
+}
+
+async fn write_running_process_frame<W>(
+    writer: &mut W,
+    frame: &running_process::broker::protocol::Frame,
+) -> Result<(), IpcError>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    let mut body = Vec::new();
+    frame.encode(&mut body).map_err(|err| {
+        IpcError::Endpoint(format!("BackendHandle response encode failed: {err}"))
+    })?;
+    if body.len() > running_process::broker::protocol::MAX_FRAME_BYTES {
+        return Err(IpcError::Endpoint(format!(
+            "BackendHandle response frame too large: {} bytes",
+            body.len()
+        )));
+    }
+    writer
+        .write_all(&[running_process::broker::protocol::ENVELOPE_VERSION])
+        .await?;
+    writer.write_all(&(body.len() as u32).to_le_bytes()).await?;
+    writer.write_all(&body).await?;
+    writer.flush().await?;
+    Ok(())
 }
 
 // ── IpcListener ─────────────────────────────────────────────────────
@@ -781,6 +938,66 @@ mod tests {
         let resp: Option<Response> = client.recv().await.unwrap();
         assert_eq!(resp, Some(Response::Pong));
 
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn backend_handle_probe_detector_preserves_zccache_requests() {
+        let endpoint = unique_test_endpoint();
+        let daemon = crate::ipc::current_backend_identity(&endpoint).unwrap();
+        let mut listener = IpcListener::bind(&endpoint).unwrap();
+
+        let server = tokio::spawn(async move {
+            let mut conn = listener.accept().await.unwrap();
+            assert!(!conn.try_serve_backend_handle_probe(&daemon).await.unwrap());
+            let msg: Option<Request> = conn.recv().await.unwrap();
+            assert_eq!(msg, Some(Request::Ping));
+            conn.send(&Response::Pong).await.unwrap();
+        });
+
+        let mut client = connect(&endpoint).await.unwrap();
+        client.send(&Request::Ping).await.unwrap();
+        let resp: Option<Response> = client.recv().await.unwrap();
+        assert_eq!(resp, Some(Response::Pong));
+
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn backend_handle_probe_succeeds_on_direct_endpoint() {
+        let endpoint = unique_test_endpoint();
+        let daemon = crate::ipc::current_backend_identity(&endpoint).unwrap();
+        let probe_endpoint = daemon.ipc_endpoint.clone();
+        let expected_daemon = daemon.clone();
+        let mut listener = IpcListener::bind(&endpoint).unwrap();
+
+        let server = tokio::spawn(async move {
+            let mut conn = listener.accept().await.unwrap();
+            assert!(conn.try_serve_backend_handle_probe(&daemon).await.unwrap());
+        });
+
+        let (service_name, handle_endpoint) = tokio::task::spawn_blocking(move || {
+            let handle =
+                running_process::broker::backend_handle::BackendHandle::probe_with_service(
+                    "zccache",
+                    crate::core::VERSION,
+                    &probe_endpoint,
+                    &expected_daemon,
+                )
+                .unwrap();
+            (
+                handle.service_name.clone(),
+                handle.daemon_process.ipc_endpoint.path.clone(),
+            )
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(service_name, "zccache");
+        assert_eq!(
+            handle_endpoint,
+            crate::ipc::running_process_endpoint(&endpoint).path
+        );
         server.await.unwrap();
     }
 


### PR DESCRIPTION
﻿## Summary

- Pin zccache to the running-process commit that contains the current broker BackendHandle API.
- Persist a `daemon.running-process.json` identity next to the zccache daemon lock file.
- Answer the reserved running-process BackendHandle endpoint probe on the existing direct zccache daemon IPC endpoint.
- Use BackendHandle in the existing pre-bind `probe_existing_daemon` path when the identity file is present, while preserving the legacy raw-connect fallback for old daemons.

## Stubbed / deferred

- Full zccache prost message-family conversion remains deferred.
- running-process `Frame` wrapping for normal zccache request/response traffic remains deferred.
- `.servicedef` packaging and broker-client `connect_to_backend` routing remain deferred.
- Default-on rollout, escape hatch removal, exhaustive perf, Linux/macOS matrix, lint, and dylint are deferred per the narrowed policy.
- Published-crate adoption is deferred until running-process releases the BackendHandle API; this PR pins the current upstream commit.

## Critical Windows-local checks

- `soldr cargo test -p zccache backend_handle_probe -- --nocapture`
- `soldr cargo check -p zccache --bin zccache-daemon`
- `soldr cargo fmt -- --check`
- `git diff --check`

Refs zackees/running-process#234
Refs zackees/running-process#242
Refs zackees/running-process#228
Refs zackees/zccache#698
