### PR TITLE
chore(deps): bump running-process to 4.1.0 from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2426,8 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.0.3"
-source = "git+https://github.com/zackees/running-process?rev=e49edf839706f42c655e83a2e8235a482abbc38e#e49edf839706f42c655e83a2e8235a482abbc38e"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b463aaf22bc2a27eb0b7bf347c4aa315075796908f859fbd8bcd469041cfc940"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ sevenz-rust = "0.6"
 rkyv = { version = "0.7", features = ["validation"] }
 tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
 mimalloc = "0.1"
-running-process = { git = "https://github.com/zackees/running-process", rev = "e49edf839706f42c655e83a2e8235a482abbc38e", default-features = false, features = ["client"] }
+running-process = { version = "4.1.0", default-features = false, features = ["client"] }
 zccache = { path = "crates/zccache" }
 zccache-watcher = { path = "crates/zccache-watcher" }
 zccache-cli = { path = "crates/zccache-cli" }


### PR DESCRIPTION
## Summary
- Replaces the `running-process` git pin (`rev = e49edf8…`) with the published `4.1.0` release from crates.io.
- No code changes; client feature set unchanged (`default-features = false, features = ["client"]`).

This is the first PR in a stacked sequence (full prost message family + FrameV1 transport follow).

Refs zackees/running-process#383

## Test plan
- [x] `soldr cargo check --workspace --all-targets`
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings`
- [x] `soldr cargo nextest run --workspace` (2006 passed, 246 skipped)