### PR TITLE
feat(ipc): cover full message family in prost v16 lane

### DIFF
--- a/crates/zccache/src/cli/client.rs
+++ b/crates/zccache/src/cli/client.rs
@@ -80,7 +80,8 @@ pub fn client_session_start(
         let mut conn = connect_client(&endpoint)
             .await
             .map_err(|e| format!("cannot connect to daemon at {endpoint}: {e}"))?;
-        conn.send(&crate::protocol::Request::SessionStart {
+        let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+        let request = crate::protocol::Request::SessionStart {
             client_pid: std::process::id(),
             working_dir: cwd.into(),
             log_file,
@@ -88,11 +89,12 @@ pub fn client_session_start(
             journal_path,
             profile: false,
             private_daemon: None,
-        })
-        .await
-        .map_err(|e| format!("failed to send to daemon: {e}"))?;
+        };
+        conn.send_request(&request, wire)
+            .await
+            .map_err(|e| format!("failed to send to daemon: {e}"))?;
 
-        match conn.recv::<crate::protocol::Response>().await {
+        match conn.recv_response().await {
             Ok(Some(crate::protocol::Response::SessionStarted {
                 session_id,
                 journal_path,
@@ -218,12 +220,13 @@ pub fn session_end_idempotent(
             }
         };
 
-        conn.send(&crate::protocol::Request::SessionEnd {
+        let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+        let request = crate::protocol::Request::SessionEnd {
             session_id: session_id.clone(),
-        })
-        .await?;
+        };
+        conn.send_request(&request, wire).await?;
 
-        match conn.recv::<crate::protocol::Response>().await? {
+        match conn.recv_response().await? {
             Some(crate::protocol::Response::SessionEnded { stats }) => Ok(stats),
             Some(crate::protocol::Response::Error { message }) => Err(
                 crate::ipc::IpcError::Endpoint(format!("session-end failed: {message}")),
@@ -246,13 +249,15 @@ pub fn client_session_stats(
         let mut conn = connect_client(&endpoint)
             .await
             .map_err(|e| format!("cannot connect to daemon at {endpoint}: {e}"))?;
-        conn.send(&crate::protocol::Request::SessionStats {
+        let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+        let request = crate::protocol::Request::SessionStats {
             session_id: session_id.clone(),
-        })
-        .await
-        .map_err(|e| format!("failed to send to daemon: {e}"))?;
+        };
+        conn.send_request(&request, wire)
+            .await
+            .map_err(|e| format!("failed to send to daemon: {e}"))?;
 
-        match conn.recv::<crate::protocol::Response>().await {
+        match conn.recv_response().await {
             Ok(Some(crate::protocol::Response::SessionStatsResult { stats })) => Ok(stats),
             Ok(Some(crate::protocol::Response::Error { message })) => Err(message),
             Ok(None) => Err("lost connection to daemon (no response received)".to_string()),
@@ -292,18 +297,20 @@ pub fn fingerprint_check(
             .await
             .map_err(|e| format!("cannot connect to daemon at {endpoint}: {e}"))?;
 
-        conn.send(&crate::protocol::Request::FingerprintCheck {
+        let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+        let request = crate::protocol::Request::FingerprintCheck {
             cache_file: cache_file.into(),
             cache_type,
             root: root.into(),
             extensions,
             include_globs,
             exclude,
-        })
-        .await
-        .map_err(|e| format!("failed to send to daemon: {e}"))?;
+        };
+        conn.send_request(&request, wire)
+            .await
+            .map_err(|e| format!("failed to send to daemon: {e}"))?;
 
-        match conn.recv::<crate::protocol::Response>().await {
+        match conn.recv_response().await {
             Ok(Some(crate::protocol::Response::FingerprintCheckResult {
                 decision,
                 reason,
@@ -350,10 +357,11 @@ fn fingerprint_mark(
                 cache_file: cache_file.into(),
             }
         };
-        conn.send(&request)
+        let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+        conn.send_request(&request, wire)
             .await
             .map_err(|e| format!("failed to send to daemon: {e}"))?;
-        match conn.recv::<crate::protocol::Response>().await {
+        match conn.recv_response().await {
             Ok(Some(crate::protocol::Response::FingerprintAck)) => Ok(()),
             Ok(Some(crate::protocol::Response::Error { message })) => Err(message),
             Ok(None) => Err("lost connection to daemon (no response received)".to_string()),
@@ -371,12 +379,14 @@ pub fn fingerprint_invalidate(endpoint: Option<&str>, cache_file: &Path) -> Resu
         let mut conn = connect_client(&endpoint)
             .await
             .map_err(|e| format!("cannot connect to daemon at {endpoint}: {e}"))?;
-        conn.send(&crate::protocol::Request::FingerprintInvalidate {
+        let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+        let request = crate::protocol::Request::FingerprintInvalidate {
             cache_file: cache_file.into(),
-        })
-        .await
-        .map_err(|e| format!("failed to send to daemon: {e}"))?;
-        match conn.recv::<crate::protocol::Response>().await {
+        };
+        conn.send_request(&request, wire)
+            .await
+            .map_err(|e| format!("failed to send to daemon: {e}"))?;
+        match conn.recv_response().await {
             Ok(Some(crate::protocol::Response::FingerprintAck)) => Ok(()),
             Ok(Some(crate::protocol::Response::Error { message })) => Err(message),
             Ok(None) => Err("lost connection to daemon (no response received)".to_string()),

--- a/crates/zccache/src/cli/commands/exec.rs
+++ b/crates/zccache/src/cli/commands/exec.rs
@@ -176,12 +176,13 @@ pub(crate) fn cmd_exec(params: ExecParams) -> ExitCode {
             }
         };
 
-        if let Err(e) = conn.send(&request).await {
+        let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+        if let Err(e) = conn.send_request(&request, wire).await {
             eprintln!("zccache exec: send error: {e}");
             return ExitCode::from(2);
         }
 
-        match conn.recv::<Response>().await {
+        match conn.recv_response().await {
             Ok(Some(Response::GenericToolExecResult {
                 exit_code,
                 stdout,

--- a/crates/zccache/src/cli/commands/fp.rs
+++ b/crates/zccache/src/cli/commands/fp.rs
@@ -37,12 +37,13 @@ pub(crate) async fn cmd_fp_check(
         exclude: exclude.to_vec(),
     };
 
-    if let Err(e) = conn.send(&request).await {
+    let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+    if let Err(e) = conn.send_request(&request, wire).await {
         eprintln!("zccache fp: send error: {e}");
         return ExitCode::from(2);
     }
 
-    match conn.recv::<crate::protocol::Response>().await {
+    match conn.recv_response().await {
         Ok(Some(crate::protocol::Response::FingerprintCheckResult {
             decision,
             reason,
@@ -103,12 +104,13 @@ pub(crate) async fn cmd_fp_mark(endpoint: &str, cache_file: &Path, success: bool
         }
     };
 
-    if let Err(e) = conn.send(&request).await {
+    let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+    if let Err(e) = conn.send_request(&request, wire).await {
         eprintln!("zccache fp: send error: {e}");
         return ExitCode::from(2);
     }
 
-    match conn.recv::<crate::protocol::Response>().await {
+    match conn.recv_response().await {
         Ok(Some(crate::protocol::Response::FingerprintAck)) => {
             let label = if success {
                 "mark-success"
@@ -151,12 +153,13 @@ pub(crate) async fn cmd_fp_invalidate(endpoint: &str, cache_file: &Path) -> Exit
         cache_file: cache_file.into(),
     };
 
-    if let Err(e) = conn.send(&request).await {
+    let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+    if let Err(e) = conn.send_request(&request, wire).await {
         eprintln!("zccache fp: send error: {e}");
         return ExitCode::from(2);
     }
 
-    match conn.recv::<crate::protocol::Response>().await {
+    match conn.recv_response().await {
         Ok(Some(crate::protocol::Response::FingerprintAck)) => {
             eprintln!("zccache fp: invalidated");
             ExitCode::SUCCESS

--- a/crates/zccache/src/cli/commands/session.rs
+++ b/crates/zccache/src/cli/commands/session.rs
@@ -140,34 +140,33 @@ pub(crate) async fn cmd_session_start(
         }
     };
 
-    if let Err(e) = conn
-        .send(&crate::protocol::Request::SessionStart {
-            client_pid: std::process::id(),
-            working_dir: cwd.into(),
-            log_file: log.map(NormalizedPath::from),
-            track_stats,
-            journal_path: journal,
-            profile,
-            private_daemon: private_options.enabled().then(|| {
-                crate::protocol::PrivateDaemonSessionOptions {
-                    daemon_name: private_options
-                        .daemon_name
-                        .as_deref()
-                        .and_then(crate::core::config::sanitize_daemon_namespace),
-                    endpoint: Some(endpoint.to_string()),
-                    cache_dir: private_options.cache_dir.clone(),
-                    owner_pids: private_options.owner_pids.clone(),
-                    env: private_options.private_env.clone(),
-                }
-            }),
-        })
-        .await
-    {
+    let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+    let request = crate::protocol::Request::SessionStart {
+        client_pid: std::process::id(),
+        working_dir: cwd.into(),
+        log_file: log.map(NormalizedPath::from),
+        track_stats,
+        journal_path: journal,
+        profile,
+        private_daemon: private_options.enabled().then(|| {
+            crate::protocol::PrivateDaemonSessionOptions {
+                daemon_name: private_options
+                    .daemon_name
+                    .as_deref()
+                    .and_then(crate::core::config::sanitize_daemon_namespace),
+                endpoint: Some(endpoint.to_string()),
+                cache_dir: private_options.cache_dir.clone(),
+                owner_pids: private_options.owner_pids.clone(),
+                env: private_options.private_env.clone(),
+            }
+        }),
+    };
+    if let Err(e) = conn.send_request(&request, wire).await {
         eprintln!("zccache[err][S]: failed to send to daemon: {e}");
         return ExitCode::FAILURE;
     }
 
-    let recv_result = match conn.recv().await {
+    let recv_result = match conn.recv_response().await {
         Ok(r) => r,
         Err(e) => {
             eprintln!("zccache[err][R]: broken connection to daemon: {e}");
@@ -264,12 +263,11 @@ pub(crate) async fn cmd_session_stats(endpoint: &str, session_id: String, json: 
         }
     };
 
-    if let Err(e) = conn
-        .send(&crate::protocol::Request::SessionStats {
-            session_id: session_id.clone(),
-        })
-        .await
-    {
+    let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+    let request = crate::protocol::Request::SessionStats {
+        session_id: session_id.clone(),
+    };
+    if let Err(e) = conn.send_request(&request, wire).await {
         let message = format!("zccache: failed to send to daemon: {e}");
         if json {
             print_session_stats_error_json(&session_id, &message);
@@ -279,7 +277,7 @@ pub(crate) async fn cmd_session_stats(endpoint: &str, session_id: String, json: 
         return ExitCode::FAILURE;
     }
 
-    let recv_result = match conn.recv().await {
+    let recv_result = match conn.recv_response().await {
         Ok(r) => r,
         Err(e) => {
             let message = format!("zccache: broken connection to daemon: {e}");
@@ -486,14 +484,16 @@ pub(crate) async fn query_session_stats(
         .await
         .map_err(|err| format!("cannot connect to daemon at {endpoint}: {err}"))?;
 
-    conn.send(&crate::protocol::Request::SessionStats {
+    let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+    let request = crate::protocol::Request::SessionStats {
         session_id: session_id.to_string(),
-    })
-    .await
-    .map_err(|err| format!("failed to send session stats request: {err}"))?;
+    };
+    conn.send_request(&request, wire)
+        .await
+        .map_err(|err| format!("failed to send session stats request: {err}"))?;
 
     let recv_result = conn
-        .recv()
+        .recv_response()
         .await
         .map_err(|err| format!("broken daemon connection: {err}"))?;
     match recv_result {

--- a/crates/zccache/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache/src/cli/commands/wrap/ipc.rs
@@ -26,17 +26,16 @@ pub(super) async fn cmd_compile(
         }
     };
 
-    if let Err(e) = conn
-        .send(&crate::protocol::Request::Compile {
-            session_id: session_id.to_string(),
-            args: args.clone(),
-            cwd: cwd.clone(),
-            compiler: compiler.clone(),
-            env: Some(client_env.clone()),
-            stdin: stdin_bytes.clone(),
-        })
-        .await
-    {
+    let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+    let request = crate::protocol::Request::Compile {
+        session_id: session_id.to_string(),
+        args: args.clone(),
+        cwd: cwd.clone(),
+        compiler: compiler.clone(),
+        env: Some(client_env.clone()),
+        stdin: stdin_bytes.clone(),
+    };
+    if let Err(e) = conn.send_request(&request, wire).await {
         eprintln!("zccache[err][S]: failed to send to daemon: {e}");
         return ExitCode::FAILURE;
     }
@@ -118,30 +117,26 @@ trait ConnRecv {
 #[cfg(unix)]
 impl ConnRecv for crate::ipc::IpcConnection {
     async fn recv(&mut self) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError> {
-        crate::ipc::IpcConnection::recv::<crate::protocol::Response>(self).await
+        crate::ipc::IpcConnection::recv_response(self).await
     }
     async fn recv_with_timeout(
         &mut self,
         timeout: std::time::Duration,
     ) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError> {
-        crate::ipc::IpcConnection::recv_with_timeout::<crate::protocol::Response>(self, timeout)
-            .await
+        crate::ipc::IpcConnection::recv_response_with_timeout(self, timeout).await
     }
 }
 
 #[cfg(windows)]
 impl ConnRecv for crate::ipc::IpcClientConnection {
     async fn recv(&mut self) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError> {
-        crate::ipc::IpcClientConnection::recv::<crate::protocol::Response>(self).await
+        crate::ipc::IpcClientConnection::recv_response(self).await
     }
     async fn recv_with_timeout(
         &mut self,
         timeout: std::time::Duration,
     ) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError> {
-        crate::ipc::IpcClientConnection::recv_with_timeout::<crate::protocol::Response>(
-            self, timeout,
-        )
-        .await
+        crate::ipc::IpcClientConnection::recv_response_with_timeout(self, timeout).await
     }
 }
 
@@ -167,18 +162,17 @@ pub(super) async fn cmd_compile_ephemeral(
     };
 
     let stdin_bytes = slurp_stdin_if_piped();
-    if let Err(e) = conn
-        .send(&crate::protocol::Request::CompileEphemeral {
-            client_pid: std::process::id(),
-            working_dir: cwd.clone(),
-            compiler: compiler.into(),
-            args,
-            cwd,
-            env: Some(client_env),
-            stdin: stdin_bytes,
-        })
-        .await
-    {
+    let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+    let request = crate::protocol::Request::CompileEphemeral {
+        client_pid: std::process::id(),
+        working_dir: cwd.clone(),
+        compiler: compiler.into(),
+        args,
+        cwd,
+        env: Some(client_env),
+        stdin: stdin_bytes,
+    };
+    if let Err(e) = conn.send_request(&request, wire).await {
         eprintln!("zccache[err][S]: failed to send to daemon: {e}");
         return ExitCode::FAILURE;
     }
@@ -227,16 +221,15 @@ pub(super) async fn cmd_link_ephemeral(
         }
     };
 
-    if let Err(e) = conn
-        .send(&crate::protocol::Request::LinkEphemeral {
-            client_pid: std::process::id(),
-            tool: tool.into(),
-            args,
-            cwd,
-            env: Some(client_env),
-        })
-        .await
-    {
+    let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+    let request = crate::protocol::Request::LinkEphemeral {
+        client_pid: std::process::id(),
+        tool: tool.into(),
+        args,
+        cwd,
+        env: Some(client_env),
+    };
+    if let Err(e) = conn.send_request(&request, wire).await {
         eprintln!("zccache[err][S]: failed to send to daemon: {e}");
         return ExitCode::FAILURE;
     }

--- a/crates/zccache/src/daemon/server/connection.rs
+++ b/crates/zccache/src/daemon/server/connection.rs
@@ -85,7 +85,7 @@ pub(super) async fn handle_connection(
             DecodedWireMessage::BincodeV15(request) => (request, ResponseWire::BincodeV15),
             DecodedWireMessage::ProstV16(request) => {
                 let request_id = request.request_id.clone();
-                match wire_prost::supported_control_request_from_prost(request) {
+                match wire_prost::request_from_prost(request) {
                     Ok(request) => (request, ResponseWire::ProstV16 { request_id }),
                     Err(message) => {
                         tracing::warn!("{message}");
@@ -594,8 +594,7 @@ async fn send_response_for_wire(
     match response_wire {
         ResponseWire::BincodeV15 => conn.send(response).await,
         ResponseWire::ProstV16 { request_id } => {
-            let response = wire_prost::supported_control_response_to_prost(response, request_id)
-                .map_err(crate::protocol::ProtocolError::Serialization)?;
+            let response = wire_prost::response_to_prost(response, request_id);
             conn.send_prost(&response).await
         }
     }

--- a/crates/zccache/src/ipc/transport.rs
+++ b/crates/zccache/src/ipc/transport.rs
@@ -192,6 +192,48 @@ impl IpcConnection {
         }
     }
 
+    /// Send a protocol [`Request`](crate::protocol::Request) on the selected wire.
+    ///
+    /// `BincodeV15` keeps the legacy [`Self::send`] frame; `ProstV16`
+    /// converts via [`wire_prost::request_to_prost`] using the canonical
+    /// per-family request id and sends a v16 prost frame.
+    ///
+    /// [`wire_prost::request_to_prost`]: crate::protocol::wire_prost::request_to_prost
+    pub async fn send_request(
+        &mut self,
+        request: &crate::protocol::Request,
+        wire: crate::protocol::wire_prost::WireFormat,
+    ) -> Result<(), IpcError> {
+        match wire {
+            crate::protocol::wire_prost::WireFormat::BincodeV15 => self.send(request).await,
+            crate::protocol::wire_prost::WireFormat::ProstV16 => {
+                let request_id = crate::protocol::wire_prost::default_request_id(request);
+                let request = crate::protocol::wire_prost::request_to_prost(request, request_id);
+                self.send_prost(&request).await
+            }
+        }
+    }
+
+    /// Receive a protocol [`Response`](crate::protocol::Response), accepting
+    /// both v15 bincode and v16 prost frames.
+    pub async fn recv_response(&mut self) -> Result<Option<crate::protocol::Response>, IpcError> {
+        let message = self
+            .recv_wire::<crate::protocol::Response, crate::protocol::wire_prost::zccache_v1::Response>()
+            .await?;
+        decode_response_wire(message)
+    }
+
+    /// Like [`Self::recv_response`] but with a per-call timeout override.
+    pub async fn recv_response_with_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<Option<crate::protocol::Response>, IpcError> {
+        let message = self
+            .recv_wire_with_timeout::<crate::protocol::Response, crate::protocol::wire_prost::zccache_v1::Response>(timeout)
+            .await?;
+        decode_response_wire(message)
+    }
+
     /// The recv read loop, factored out so both `recv` and
     /// `recv_with_timeout` share the same implementation. Always
     /// unbounded — the wrapping methods add the deadline.
@@ -307,6 +349,41 @@ impl IpcClientConnection {
         }
     }
 
+    /// See [`IpcConnection::send_request`].
+    pub async fn send_request(
+        &mut self,
+        request: &crate::protocol::Request,
+        wire: crate::protocol::wire_prost::WireFormat,
+    ) -> Result<(), IpcError> {
+        match wire {
+            crate::protocol::wire_prost::WireFormat::BincodeV15 => self.send(request).await,
+            crate::protocol::wire_prost::WireFormat::ProstV16 => {
+                let request_id = crate::protocol::wire_prost::default_request_id(request);
+                let request = crate::protocol::wire_prost::request_to_prost(request, request_id);
+                self.send_prost(&request).await
+            }
+        }
+    }
+
+    /// See [`IpcConnection::recv_response`].
+    pub async fn recv_response(&mut self) -> Result<Option<crate::protocol::Response>, IpcError> {
+        let message = self
+            .recv_wire::<crate::protocol::Response, crate::protocol::wire_prost::zccache_v1::Response>()
+            .await?;
+        decode_response_wire(message)
+    }
+
+    /// See [`IpcConnection::recv_response_with_timeout`].
+    pub async fn recv_response_with_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<Option<crate::protocol::Response>, IpcError> {
+        let message = self
+            .recv_wire_with_timeout::<crate::protocol::Response, crate::protocol::wire_prost::zccache_v1::Response>(timeout)
+            .await?;
+        decode_response_wire(message)
+    }
+
     async fn recv_loop<T: serde::de::DeserializeOwned>(&mut self) -> Result<Option<T>, IpcError> {
         recv_bincode_loop(&mut self.reader, &mut self.read_buf).await
     }
@@ -320,6 +397,24 @@ impl IpcClientConnection {
     {
         recv_wire_loop(&mut self.reader, &mut self.read_buf).await
     }
+}
+
+/// Decode a dual-wire response message into the internal [`Response`]
+/// type, mapping prost conversion failures into [`IpcError::Protocol`].
+///
+/// [`Response`]: crate::protocol::Response
+fn decode_response_wire(
+    message: Option<
+        crate::protocol::DecodedWireMessage<
+            crate::protocol::Response,
+            crate::protocol::wire_prost::zccache_v1::Response,
+        >,
+    >,
+) -> Result<Option<crate::protocol::Response>, IpcError> {
+    message
+        .map(crate::protocol::wire_prost::response_from_decoded_wire)
+        .transpose()
+        .map_err(IpcError::Protocol)
 }
 
 async fn recv_bincode_loop<R, T>(

--- a/crates/zccache/src/protocol/wire_prost.rs
+++ b/crates/zccache/src/protocol/wire_prost.rs
@@ -137,39 +137,34 @@ pub fn client_wire_selection_from_env() -> Result<ClientWireSelection, String> {
     client_wire_selection_from_env_value(std::env::var(WIRE_FORMAT_ENV).ok().as_deref())
 }
 
-/// Convert the narrow set of v16 prost daemon-control and maintenance requests
-/// that the live dispatcher can handle before the full enum conversion lands.
+/// Convert v16 prost daemon-control and maintenance requests, rejecting
+/// non-control bodies so the control roundtrip helper keeps its narrow scope.
 ///
 /// # Errors
 ///
-/// Returns a clear diagnostic for missing or unsupported request bodies. The
-/// caller should surface this as a daemon response instead of dropping the
-/// connection.
+/// Returns a clear diagnostic for missing, malformed, or non-control request
+/// bodies. The caller should surface this as a daemon response instead of
+/// dropping the connection.
 pub fn supported_control_request_from_prost(
     request: zccache_v1::Request,
 ) -> Result<super::Request, String> {
     use zccache_v1::request::Body;
 
-    match request.body {
-        Some(Body::Ping(_)) => Ok(super::Request::Ping),
-        Some(Body::Status(_)) => Ok(super::Request::Status),
-        Some(Body::Shutdown(_)) => Ok(super::Request::Shutdown),
-        Some(Body::Clear(_)) => Ok(super::Request::Clear),
-        Some(Body::ReleaseWorktreeHandles(request)) => {
-            Ok(super::Request::ReleaseWorktreeHandles {
-                path: path_from_prost(required_prost_field(
-                    request.path,
-                    "ReleaseWorktreeHandles.path",
-                )?),
-            })
-        }
+    match &request.body {
+        Some(
+            Body::Ping(_)
+            | Body::Status(_)
+            | Body::Shutdown(_)
+            | Body::Clear(_)
+            | Body::ReleaseWorktreeHandles(_),
+        ) => request_from_prost(request),
         Some(other) => Err(format!(
-            "unsupported v16 prost request body {other:?}; only Ping, Status, Shutdown, Clear, \
-             and ReleaseWorktreeHandles are supported before the full zccache prost conversion lands"
+            "unsupported v16 prost control request body {other:?}; only Ping, Status, Shutdown, \
+             Clear, and ReleaseWorktreeHandles may use the prost control request path"
         )),
         None => Err(
             "unsupported v16 prost request: missing request body; only Ping, Status, Shutdown, \
-             Clear, and ReleaseWorktreeHandles are supported before the full zccache prost conversion lands"
+             Clear, and ReleaseWorktreeHandles may use the prost control request path"
                 .to_string(),
         ),
     }
@@ -185,76 +180,52 @@ pub fn supported_control_request_from_prost(
 pub fn supported_control_request_to_prost(
     request: &super::Request,
 ) -> Result<zccache_v1::Request, String> {
-    use zccache_v1::request::Body;
-
-    let (request_id, body) = match request {
-        super::Request::Ping => ("control-ping", Body::Ping(zccache_v1::Empty {})),
-        super::Request::Status => ("control-status", Body::Status(zccache_v1::Empty {})),
-        super::Request::Shutdown => ("control-shutdown", Body::Shutdown(zccache_v1::Empty {})),
-        super::Request::Clear => ("control-clear", Body::Clear(zccache_v1::Empty {})),
-        super::Request::ReleaseWorktreeHandles { path } => (
-            "control-release-worktree-handles",
-            Body::ReleaseWorktreeHandles(zccache_v1::ReleaseWorktreeHandles {
-                path: Some(path_to_prost(path)),
-            }),
-        ),
-        other => {
-            return Err(format!(
-                "unsupported v16 prost control request {other:?}; only Ping, Status, Shutdown, \
-                 Clear, and ReleaseWorktreeHandles may select {WIRE_FORMAT_ENV} before the full \
-                 zccache prost conversion lands"
-            ));
+    match request {
+        super::Request::Ping
+        | super::Request::Status
+        | super::Request::Shutdown
+        | super::Request::Clear
+        | super::Request::ReleaseWorktreeHandles { .. } => {
+            Ok(request_to_prost(request, default_request_id(request)))
         }
-    };
-
-    Ok(zccache_v1::Request {
-        body: Some(body),
-        request_id: request_id.to_string(),
-    })
+        other => Err(format!(
+            "unsupported v16 prost control request {other:?}; only Ping, Status, Shutdown, \
+             Clear, and ReleaseWorktreeHandles may select {WIRE_FORMAT_ENV} through the prost \
+             control request path"
+        )),
+    }
 }
 
-/// Convert the narrow daemon-control and maintenance response slice from the
-/// v16 prost schema back to the local protocol enum.
+/// Convert v16 prost daemon-control and maintenance responses, rejecting
+/// non-control bodies so the control roundtrip helper keeps its narrow scope.
 ///
 /// # Errors
 ///
-/// Returns a clear diagnostic for unsupported response bodies or missing nested
-/// fields in the supported `Status` response body.
+/// Returns a clear diagnostic for non-control response bodies or missing
+/// nested fields in the supported `Status` response body.
 pub fn supported_control_response_from_prost(
     response: zccache_v1::Response,
 ) -> Result<super::Response, String> {
     use zccache_v1::response::Body;
 
-    match response.body {
-        Some(Body::Pong(_)) => Ok(super::Response::Pong),
-        Some(Body::ShuttingDown(_)) => Ok(super::Response::ShuttingDown),
-        Some(Body::Status(status)) => daemon_status_from_prost(status).map(super::Response::Status),
-        Some(Body::Cleared(cleared)) => Ok(super::Response::Cleared {
-            artifacts_removed: cleared.artifacts_removed,
-            metadata_cleared: cleared.metadata_cleared,
-            dep_graph_contexts_cleared: cleared.dep_graph_contexts_cleared,
-            on_disk_bytes_freed: cleared.on_disk_bytes_freed,
-        }),
-        Some(Body::Error(error)) => Ok(super::Response::Error {
-            message: error.message,
-        }),
-        Some(Body::ReleaseWorktreeHandlesResult(result)) => {
-            Ok(super::Response::ReleaseWorktreeHandlesResult {
-                inspected: result.inspected,
-                released: result.released,
-                sessions_dropped: result.sessions_dropped,
-                unreleased: result.unreleased.into_iter().map(path_from_prost).collect(),
-            })
-        }
+    match &response.body {
+        Some(
+            Body::Pong(_)
+            | Body::ShuttingDown(_)
+            | Body::Status(_)
+            | Body::Cleared(_)
+            | Body::Error(_)
+            | Body::ReleaseWorktreeHandlesResult(_),
+        ) => response_from_prost(response),
         Some(other) => Err(format!(
-            "unsupported v16 prost response body {other:?}; only Pong, Status, ShuttingDown, \
-             Cleared, Error, and ReleaseWorktreeHandlesResult are supported before the full \
-             zccache prost conversion lands"
+            "unsupported v16 prost control response body {other:?}; only Pong, Status, \
+             ShuttingDown, Cleared, Error, and ReleaseWorktreeHandlesResult may use the prost \
+             control response path"
         )),
         None => Err(
             "unsupported v16 prost response: missing response body; only Pong, Status, \
-             ShuttingDown, Cleared, Error, and ReleaseWorktreeHandlesResult are supported before the full \
-             zccache prost conversion lands"
+             ShuttingDown, Cleared, Error, and ReleaseWorktreeHandlesResult may use the prost \
+             control response path"
                 .to_string(),
         ),
     }
@@ -271,12 +242,472 @@ pub fn supported_control_response_to_prost(
     response: &super::Response,
     request_id: &str,
 ) -> Result<zccache_v1::Response, String> {
+    match response {
+        super::Response::Pong
+        | super::Response::ShuttingDown
+        | super::Response::Status(_)
+        | super::Response::Cleared { .. }
+        | super::Response::Error { .. }
+        | super::Response::ReleaseWorktreeHandlesResult { .. } => {
+            Ok(response_to_prost(response, request_id))
+        }
+        other => Err(format!(
+            "unsupported v16 prost control response {other:?}; only Pong, Status, \
+             ShuttingDown, Cleared, Error, and ReleaseWorktreeHandlesResult may use the prost \
+             control response path"
+        )),
+    }
+}
+
+/// Canonical request id used when a request is routed over the v16 prost lane
+/// without a caller-supplied id.
+#[must_use]
+pub const fn default_request_id(request: &super::Request) -> &'static str {
+    match request {
+        super::Request::Ping => "control-ping",
+        super::Request::Status => "control-status",
+        super::Request::Shutdown => "control-shutdown",
+        super::Request::Clear => "control-clear",
+        super::Request::ReleaseWorktreeHandles { .. } => "control-release-worktree-handles",
+        super::Request::Lookup { .. } => "lookup",
+        super::Request::Store { .. } => "store",
+        super::Request::SessionStart { .. } => "session-start",
+        super::Request::Compile { .. } => "compile",
+        super::Request::SessionEnd { .. } => "session-end",
+        super::Request::CompileEphemeral { .. } => "compile-ephemeral",
+        super::Request::LinkEphemeral { .. } => "link-ephemeral",
+        super::Request::SessionStats { .. } => "session-stats",
+        super::Request::FingerprintCheck { .. } => "fingerprint-check",
+        super::Request::FingerprintMarkSuccess { .. } => "fingerprint-mark-success",
+        super::Request::FingerprintMarkFailure { .. } => "fingerprint-mark-failure",
+        super::Request::FingerprintInvalidate { .. } => "fingerprint-invalidate",
+        super::Request::ListRustArtifacts => "list-rust-artifacts",
+        super::Request::GenericToolExec { .. } => "generic-tool-exec",
+    }
+}
+
+/// Wire family for full-message-family (non-control) client requests.
+///
+/// The hot wrapper, session, fingerprint, and exec client paths keep their
+/// current v15 bincode default: only an explicit `ZCCACHE_DAEMON_WIRE=prost`
+/// opts them into the v16 prost lane. `auto`/unset intentionally stays
+/// bincode here (even though the control slice prefers prost under auto) so
+/// the staged migration does not change default wire selection. Invalid
+/// values also fall back to bincode instead of failing a build.
+#[must_use]
+pub fn full_family_wire_format_from_env() -> WireFormat {
+    match client_wire_selection_from_env() {
+        Ok(ClientWireSelection::ProstV16) => WireFormat::ProstV16,
+        Ok(ClientWireSelection::Auto | ClientWireSelection::BincodeV15) | Err(_) => {
+            WireFormat::BincodeV15
+        }
+    }
+}
+
+/// Convert a dual-wire decoded daemon response into the internal enum.
+///
+/// v15 bincode responses pass through unchanged; v16 prost responses are
+/// converted via [`response_from_prost`].
+///
+/// # Errors
+///
+/// Returns a deserialization error when a v16 prost response body is missing
+/// or carries malformed required fields.
+pub fn response_from_decoded_wire(
+    message: super::DecodedWireMessage<super::Response, zccache_v1::Response>,
+) -> Result<super::Response, super::ProtocolError> {
+    match message {
+        super::DecodedWireMessage::BincodeV15(response) => Ok(response),
+        super::DecodedWireMessage::ProstV16(response) => {
+            response_from_prost(response).map_err(super::ProtocolError::Deserialization)
+        }
+    }
+}
+
+/// Convert any internal daemon request to the v16 prost schema.
+#[must_use]
+pub fn request_to_prost(request: &super::Request, request_id: &str) -> zccache_v1::Request {
+    use zccache_v1::request::Body;
+
+    let body = match request {
+        super::Request::Ping => Body::Ping(zccache_v1::Empty {}),
+        super::Request::Shutdown => Body::Shutdown(zccache_v1::Empty {}),
+        super::Request::Status => Body::Status(zccache_v1::Empty {}),
+        super::Request::Clear => Body::Clear(zccache_v1::Empty {}),
+        super::Request::Lookup { cache_key } => Body::Lookup(zccache_v1::Lookup {
+            cache_key: cache_key.clone(),
+        }),
+        super::Request::Store {
+            cache_key,
+            artifact,
+        } => Body::Store(zccache_v1::Store {
+            cache_key: cache_key.clone(),
+            artifact: Some(artifact_data_to_prost(artifact)),
+        }),
+        super::Request::SessionStart {
+            client_pid,
+            working_dir,
+            log_file,
+            track_stats,
+            journal_path,
+            profile,
+            private_daemon,
+        } => Body::SessionStart(zccache_v1::SessionStart {
+            client_pid: *client_pid,
+            working_dir: Some(path_to_prost(working_dir)),
+            log_file: log_file.as_ref().map(path_to_prost),
+            track_stats: *track_stats,
+            journal_path: journal_path.as_ref().map(path_to_prost),
+            profile: *profile,
+            private_daemon: private_daemon
+                .as_ref()
+                .map(private_daemon_session_options_to_prost),
+        }),
+        super::Request::Compile {
+            session_id,
+            args,
+            cwd,
+            compiler,
+            env,
+            stdin,
+        } => {
+            let (env, env_is_set) = optional_env_to_prost(env.as_deref());
+            Body::Compile(zccache_v1::Compile {
+                session_id: session_id.clone(),
+                args: args.clone(),
+                cwd: Some(path_to_prost(cwd)),
+                compiler: Some(path_to_prost(compiler)),
+                env,
+                env_is_set,
+                stdin: stdin.clone(),
+            })
+        }
+        super::Request::SessionEnd { session_id } => Body::SessionEnd(zccache_v1::SessionEnd {
+            session_id: session_id.clone(),
+        }),
+        super::Request::CompileEphemeral {
+            client_pid,
+            working_dir,
+            compiler,
+            args,
+            cwd,
+            env,
+            stdin,
+        } => {
+            let (env, env_is_set) = optional_env_to_prost(env.as_deref());
+            Body::CompileEphemeral(zccache_v1::CompileEphemeral {
+                client_pid: *client_pid,
+                working_dir: Some(path_to_prost(working_dir)),
+                compiler: Some(path_to_prost(compiler)),
+                args: args.clone(),
+                cwd: Some(path_to_prost(cwd)),
+                env,
+                env_is_set,
+                stdin: stdin.clone(),
+            })
+        }
+        super::Request::LinkEphemeral {
+            client_pid,
+            tool,
+            args,
+            cwd,
+            env,
+        } => {
+            let (env, env_is_set) = optional_env_to_prost(env.as_deref());
+            Body::LinkEphemeral(zccache_v1::LinkEphemeral {
+                client_pid: *client_pid,
+                tool: Some(path_to_prost(tool)),
+                args: args.clone(),
+                cwd: Some(path_to_prost(cwd)),
+                env,
+                env_is_set,
+            })
+        }
+        super::Request::SessionStats { session_id } => {
+            Body::SessionStats(zccache_v1::SessionStatsRequest {
+                session_id: session_id.clone(),
+            })
+        }
+        super::Request::FingerprintCheck {
+            cache_file,
+            cache_type,
+            root,
+            extensions,
+            include_globs,
+            exclude,
+        } => Body::FingerprintCheck(zccache_v1::FingerprintCheck {
+            cache_file: Some(path_to_prost(cache_file)),
+            cache_type: cache_type.clone(),
+            root: Some(path_to_prost(root)),
+            extensions: extensions.clone(),
+            include_globs: include_globs.clone(),
+            exclude: exclude.clone(),
+        }),
+        super::Request::FingerprintMarkSuccess { cache_file } => {
+            Body::FingerprintMarkSuccess(zccache_v1::FingerprintMarkSuccess {
+                cache_file: Some(path_to_prost(cache_file)),
+            })
+        }
+        super::Request::FingerprintMarkFailure { cache_file } => {
+            Body::FingerprintMarkFailure(zccache_v1::FingerprintMarkFailure {
+                cache_file: Some(path_to_prost(cache_file)),
+            })
+        }
+        super::Request::FingerprintInvalidate { cache_file } => {
+            Body::FingerprintInvalidate(zccache_v1::FingerprintInvalidate {
+                cache_file: Some(path_to_prost(cache_file)),
+            })
+        }
+        super::Request::ListRustArtifacts => Body::ListRustArtifacts(zccache_v1::Empty {}),
+        super::Request::GenericToolExec {
+            tool,
+            args,
+            cwd,
+            env,
+            input_files,
+            input_extra,
+            output_streams,
+            output_files,
+            tool_hash,
+            cache_policy,
+            cwd_in_key,
+            include_scan_files,
+            include_dirs,
+            system_include_dirs,
+            iquote_dirs,
+            depfile,
+            non_deterministic,
+            key_args_filter,
+        } => Body::GenericToolExec(zccache_v1::GenericToolExec {
+            tool: Some(path_to_prost(tool)),
+            args: args.clone(),
+            cwd: Some(path_to_prost(cwd)),
+            env: env_pairs_to_prost(env),
+            input_files: paths_to_prost(input_files),
+            input_extra: input_extra.as_ref().clone(),
+            output_streams: Some(exec_output_streams_to_prost(*output_streams)),
+            output_files: paths_to_prost(output_files),
+            tool_hash: tool_hash.map(|hash| hash.to_vec()),
+            cache_policy: exec_cache_policy_to_prost(*cache_policy).into(),
+            cwd_in_key: *cwd_in_key,
+            include_scan_files: paths_to_prost(include_scan_files),
+            include_dirs: paths_to_prost(include_dirs),
+            system_include_dirs: paths_to_prost(system_include_dirs),
+            iquote_dirs: paths_to_prost(iquote_dirs),
+            depfile: depfile.as_ref().map(path_to_prost),
+            non_deterministic: *non_deterministic,
+            key_args_filter: key_args_filter.clone(),
+        }),
+        super::Request::ReleaseWorktreeHandles { path } => {
+            Body::ReleaseWorktreeHandles(zccache_v1::ReleaseWorktreeHandles {
+                path: Some(path_to_prost(path)),
+            })
+        }
+    };
+
+    zccache_v1::Request {
+        body: Some(body),
+        request_id: request_id.to_string(),
+    }
+}
+
+/// Convert any v16 prost request to the internal daemon request enum.
+///
+/// # Errors
+///
+/// Returns a clear diagnostic for a missing request body, missing required
+/// nested fields, or out-of-range enum values. The daemon dispatcher surfaces
+/// this as a `Response::Error` instead of dropping the connection.
+pub fn request_from_prost(request: zccache_v1::Request) -> Result<super::Request, String> {
+    use zccache_v1::request::Body;
+
+    match request.body {
+        Some(Body::Ping(_)) => Ok(super::Request::Ping),
+        Some(Body::Shutdown(_)) => Ok(super::Request::Shutdown),
+        Some(Body::Status(_)) => Ok(super::Request::Status),
+        Some(Body::Clear(_)) => Ok(super::Request::Clear),
+        Some(Body::Lookup(lookup)) => Ok(super::Request::Lookup {
+            cache_key: lookup.cache_key,
+        }),
+        Some(Body::Store(store)) => Ok(super::Request::Store {
+            cache_key: store.cache_key,
+            artifact: artifact_data_from_prost(required_prost_field(
+                store.artifact,
+                "Store.artifact",
+            )?)?,
+        }),
+        Some(Body::SessionStart(start)) => Ok(super::Request::SessionStart {
+            client_pid: start.client_pid,
+            working_dir: path_from_prost(required_prost_field(
+                start.working_dir,
+                "SessionStart.working_dir",
+            )?),
+            log_file: start.log_file.map(path_from_prost),
+            track_stats: start.track_stats,
+            journal_path: start.journal_path.map(path_from_prost),
+            profile: start.profile,
+            private_daemon: start
+                .private_daemon
+                .map(private_daemon_session_options_from_prost),
+        }),
+        Some(Body::Compile(compile)) => Ok(super::Request::Compile {
+            session_id: compile.session_id,
+            args: compile.args,
+            cwd: path_from_prost(required_prost_field(compile.cwd, "Compile.cwd")?),
+            compiler: path_from_prost(required_prost_field(
+                compile.compiler,
+                "Compile.compiler",
+            )?),
+            env: optional_env_from_prost(compile.env, compile.env_is_set),
+            stdin: compile.stdin,
+        }),
+        Some(Body::SessionEnd(end)) => Ok(super::Request::SessionEnd {
+            session_id: end.session_id,
+        }),
+        Some(Body::CompileEphemeral(compile)) => Ok(super::Request::CompileEphemeral {
+            client_pid: compile.client_pid,
+            working_dir: path_from_prost(required_prost_field(
+                compile.working_dir,
+                "CompileEphemeral.working_dir",
+            )?),
+            compiler: path_from_prost(required_prost_field(
+                compile.compiler,
+                "CompileEphemeral.compiler",
+            )?),
+            args: compile.args,
+            cwd: path_from_prost(required_prost_field(compile.cwd, "CompileEphemeral.cwd")?),
+            env: optional_env_from_prost(compile.env, compile.env_is_set),
+            stdin: compile.stdin,
+        }),
+        Some(Body::LinkEphemeral(link)) => Ok(super::Request::LinkEphemeral {
+            client_pid: link.client_pid,
+            tool: path_from_prost(required_prost_field(link.tool, "LinkEphemeral.tool")?),
+            args: link.args,
+            cwd: path_from_prost(required_prost_field(link.cwd, "LinkEphemeral.cwd")?),
+            env: optional_env_from_prost(link.env, link.env_is_set),
+        }),
+        Some(Body::SessionStats(stats)) => Ok(super::Request::SessionStats {
+            session_id: stats.session_id,
+        }),
+        Some(Body::FingerprintCheck(check)) => Ok(super::Request::FingerprintCheck {
+            cache_file: path_from_prost(required_prost_field(
+                check.cache_file,
+                "FingerprintCheck.cache_file",
+            )?),
+            cache_type: check.cache_type,
+            root: path_from_prost(required_prost_field(check.root, "FingerprintCheck.root")?),
+            extensions: check.extensions,
+            include_globs: check.include_globs,
+            exclude: check.exclude,
+        }),
+        Some(Body::FingerprintMarkSuccess(mark)) => Ok(super::Request::FingerprintMarkSuccess {
+            cache_file: path_from_prost(required_prost_field(
+                mark.cache_file,
+                "FingerprintMarkSuccess.cache_file",
+            )?),
+        }),
+        Some(Body::FingerprintMarkFailure(mark)) => Ok(super::Request::FingerprintMarkFailure {
+            cache_file: path_from_prost(required_prost_field(
+                mark.cache_file,
+                "FingerprintMarkFailure.cache_file",
+            )?),
+        }),
+        Some(Body::FingerprintInvalidate(invalidate)) => {
+            Ok(super::Request::FingerprintInvalidate {
+                cache_file: path_from_prost(required_prost_field(
+                    invalidate.cache_file,
+                    "FingerprintInvalidate.cache_file",
+                )?),
+            })
+        }
+        Some(Body::ListRustArtifacts(_)) => Ok(super::Request::ListRustArtifacts),
+        Some(Body::GenericToolExec(exec)) => Ok(super::Request::GenericToolExec {
+            tool: path_from_prost(required_prost_field(exec.tool, "GenericToolExec.tool")?),
+            args: exec.args,
+            cwd: path_from_prost(required_prost_field(exec.cwd, "GenericToolExec.cwd")?),
+            env: env_pairs_from_prost(exec.env),
+            input_files: paths_from_prost(exec.input_files),
+            input_extra: std::sync::Arc::new(exec.input_extra),
+            output_streams: exec_output_streams_from_prost(required_prost_field(
+                exec.output_streams,
+                "GenericToolExec.output_streams",
+            )?),
+            output_files: paths_from_prost(exec.output_files),
+            tool_hash: tool_hash_from_prost(exec.tool_hash)?,
+            cache_policy: exec_cache_policy_from_prost(exec.cache_policy)?,
+            cwd_in_key: exec.cwd_in_key,
+            include_scan_files: paths_from_prost(exec.include_scan_files),
+            include_dirs: paths_from_prost(exec.include_dirs),
+            system_include_dirs: paths_from_prost(exec.system_include_dirs),
+            iquote_dirs: paths_from_prost(exec.iquote_dirs),
+            depfile: exec.depfile.map(path_from_prost),
+            non_deterministic: exec.non_deterministic,
+            key_args_filter: exec.key_args_filter,
+        }),
+        Some(Body::ReleaseWorktreeHandles(release)) => {
+            Ok(super::Request::ReleaseWorktreeHandles {
+                path: path_from_prost(required_prost_field(
+                    release.path,
+                    "ReleaseWorktreeHandles.path",
+                )?),
+            })
+        }
+        None => Err("v16 prost request is missing its request body".to_string()),
+    }
+}
+
+/// Convert any internal daemon response to the v16 prost schema.
+#[must_use]
+pub fn response_to_prost(response: &super::Response, request_id: &str) -> zccache_v1::Response {
     use zccache_v1::response::Body;
 
     let body = match response {
         super::Response::Pong => Body::Pong(zccache_v1::Empty {}),
         super::Response::ShuttingDown => Body::ShuttingDown(zccache_v1::Empty {}),
         super::Response::Status(status) => Body::Status(daemon_status_to_prost(status)),
+        super::Response::LookupResult(result) => {
+            Body::LookupResult(lookup_result_to_prost(result))
+        }
+        super::Response::StoreResult(result) => Body::StoreResult(zccache_v1::StoreResult {
+            kind: store_result_kind_to_prost(result).into(),
+        }),
+        super::Response::SessionStarted {
+            session_id,
+            journal_path,
+        } => Body::SessionStarted(zccache_v1::SessionStarted {
+            session_id: session_id.clone(),
+            journal_path: journal_path.as_ref().map(path_to_prost),
+        }),
+        super::Response::CompileResult {
+            exit_code,
+            stdout,
+            stderr,
+            cached,
+        } => Body::CompileResult(zccache_v1::CompileResult {
+            exit_code: *exit_code,
+            stdout: stdout.as_ref().clone(),
+            stderr: stderr.as_ref().clone(),
+            cached: *cached,
+        }),
+        super::Response::SessionEnded { stats } => Body::SessionEnded(zccache_v1::SessionEnded {
+            stats: stats.as_ref().map(session_stats_to_prost),
+        }),
+        super::Response::LinkResult {
+            exit_code,
+            stdout,
+            stderr,
+            cached,
+            warning,
+        } => Body::LinkResult(zccache_v1::LinkResult {
+            exit_code: *exit_code,
+            stdout: stdout.as_ref().clone(),
+            stderr: stderr.as_ref().clone(),
+            cached: *cached,
+            warning: warning.clone(),
+        }),
+        super::Response::Error { message } => Body::Error(zccache_v1::Error {
+            message: message.clone(),
+        }),
         super::Response::Cleared {
             artifacts_removed,
             metadata_cleared,
@@ -288,8 +719,49 @@ pub fn supported_control_response_to_prost(
             dep_graph_contexts_cleared: *dep_graph_contexts_cleared,
             on_disk_bytes_freed: *on_disk_bytes_freed,
         }),
-        super::Response::Error { message } => Body::Error(zccache_v1::Error {
-            message: message.clone(),
+        super::Response::SessionStatsResult { stats } => {
+            Body::SessionStatsResult(zccache_v1::SessionStatsResult {
+                stats: stats.as_ref().map(session_stats_to_prost),
+            })
+        }
+        super::Response::FingerprintCheckResult {
+            decision,
+            reason,
+            changed_files,
+        } => Body::FingerprintCheckResult(zccache_v1::FingerprintCheckResult {
+            decision: decision.clone(),
+            reason: reason.clone(),
+            changed_files: changed_files.clone(),
+        }),
+        super::Response::FingerprintAck => Body::FingerprintAck(zccache_v1::Empty {}),
+        super::Response::RustArtifactList { artifacts } => {
+            Body::RustArtifactList(zccache_v1::RustArtifactList {
+                artifacts: artifacts.iter().map(rust_artifact_info_to_prost).collect(),
+            })
+        }
+        super::Response::GenericToolExecResult {
+            exit_code,
+            stdout,
+            stderr,
+            output_files,
+            cached,
+            cache_key_hex,
+        } => Body::GenericToolExecResult(zccache_v1::GenericToolExecResult {
+            exit_code: *exit_code,
+            stdout: stdout.as_ref().clone(),
+            stderr: stderr.as_ref().clone(),
+            output_files: output_files.iter().map(artifact_output_to_prost).collect(),
+            cached: *cached,
+            cache_key_hex: cache_key_hex.clone(),
+        }),
+        super::Response::Backpressure {
+            queue_depth,
+            retry_after_ms,
+            reason,
+        } => Body::Backpressure(zccache_v1::Backpressure {
+            queue_depth: *queue_depth,
+            retry_after_ms: *retry_after_ms,
+            reason: reason.clone(),
         }),
         super::Response::ReleaseWorktreeHandlesResult {
             inspected,
@@ -302,19 +774,429 @@ pub fn supported_control_response_to_prost(
             sessions_dropped: sessions_dropped.clone(),
             unreleased: unreleased.iter().map(path_to_prost).collect(),
         }),
-        other => {
-            return Err(format!(
-                "unsupported v16 prost control response {other:?}; only Pong, Status, \
-                 ShuttingDown, Cleared, Error, and ReleaseWorktreeHandlesResult may use the prost \
-                 control response path before the full zccache prost conversion lands"
-            ));
-        }
     };
 
-    Ok(zccache_v1::Response {
+    zccache_v1::Response {
         body: Some(body),
         request_id: request_id.to_string(),
+    }
+}
+
+/// Convert any v16 prost response to the internal daemon response enum.
+///
+/// # Errors
+///
+/// Returns a clear diagnostic for a missing response body, missing required
+/// nested fields, or out-of-range enum values.
+pub fn response_from_prost(response: zccache_v1::Response) -> Result<super::Response, String> {
+    use zccache_v1::response::Body;
+
+    match response.body {
+        Some(Body::Pong(_)) => Ok(super::Response::Pong),
+        Some(Body::ShuttingDown(_)) => Ok(super::Response::ShuttingDown),
+        Some(Body::Status(status)) => daemon_status_from_prost(status).map(super::Response::Status),
+        Some(Body::LookupResult(result)) => {
+            lookup_result_from_prost(result).map(super::Response::LookupResult)
+        }
+        Some(Body::StoreResult(result)) => {
+            store_result_kind_from_prost(result.kind).map(super::Response::StoreResult)
+        }
+        Some(Body::SessionStarted(started)) => Ok(super::Response::SessionStarted {
+            session_id: started.session_id,
+            journal_path: started.journal_path.map(path_from_prost),
+        }),
+        Some(Body::CompileResult(result)) => Ok(super::Response::CompileResult {
+            exit_code: result.exit_code,
+            stdout: std::sync::Arc::new(result.stdout),
+            stderr: std::sync::Arc::new(result.stderr),
+            cached: result.cached,
+        }),
+        Some(Body::SessionEnded(ended)) => Ok(super::Response::SessionEnded {
+            stats: ended.stats.map(session_stats_from_prost),
+        }),
+        Some(Body::LinkResult(result)) => Ok(super::Response::LinkResult {
+            exit_code: result.exit_code,
+            stdout: std::sync::Arc::new(result.stdout),
+            stderr: std::sync::Arc::new(result.stderr),
+            cached: result.cached,
+            warning: result.warning,
+        }),
+        Some(Body::Error(error)) => Ok(super::Response::Error {
+            message: error.message,
+        }),
+        Some(Body::Cleared(cleared)) => Ok(super::Response::Cleared {
+            artifacts_removed: cleared.artifacts_removed,
+            metadata_cleared: cleared.metadata_cleared,
+            dep_graph_contexts_cleared: cleared.dep_graph_contexts_cleared,
+            on_disk_bytes_freed: cleared.on_disk_bytes_freed,
+        }),
+        Some(Body::SessionStatsResult(result)) => Ok(super::Response::SessionStatsResult {
+            stats: result.stats.map(session_stats_from_prost),
+        }),
+        Some(Body::FingerprintCheckResult(result)) => Ok(super::Response::FingerprintCheckResult {
+            decision: result.decision,
+            reason: result.reason,
+            changed_files: result.changed_files,
+        }),
+        Some(Body::FingerprintAck(_)) => Ok(super::Response::FingerprintAck),
+        Some(Body::RustArtifactList(list)) => Ok(super::Response::RustArtifactList {
+            artifacts: list
+                .artifacts
+                .into_iter()
+                .map(rust_artifact_info_from_prost)
+                .collect::<Result<Vec<_>, _>>()?,
+        }),
+        Some(Body::GenericToolExecResult(result)) => Ok(super::Response::GenericToolExecResult {
+            exit_code: result.exit_code,
+            stdout: std::sync::Arc::new(result.stdout),
+            stderr: std::sync::Arc::new(result.stderr),
+            output_files: result
+                .output_files
+                .into_iter()
+                .map(artifact_output_from_prost)
+                .collect::<Result<Vec<_>, _>>()?,
+            cached: result.cached,
+            cache_key_hex: result.cache_key_hex,
+        }),
+        Some(Body::Backpressure(backpressure)) => Ok(super::Response::Backpressure {
+            queue_depth: backpressure.queue_depth,
+            retry_after_ms: backpressure.retry_after_ms,
+            reason: backpressure.reason,
+        }),
+        Some(Body::ReleaseWorktreeHandlesResult(result)) => {
+            Ok(super::Response::ReleaseWorktreeHandlesResult {
+                inspected: result.inspected,
+                released: result.released,
+                sessions_dropped: result.sessions_dropped,
+                unreleased: result.unreleased.into_iter().map(path_from_prost).collect(),
+            })
+        }
+        None => Err("v16 prost response is missing its response body".to_string()),
+    }
+}
+
+fn env_pairs_to_prost(env: &[(String, String)]) -> Vec<zccache_v1::EnvVar> {
+    env.iter()
+        .map(|(name, value)| zccache_v1::EnvVar {
+            name: name.clone(),
+            value: value.clone(),
+        })
+        .collect()
+}
+
+fn env_pairs_from_prost(env: Vec<zccache_v1::EnvVar>) -> Vec<(String, String)> {
+    env.into_iter().map(|var| (var.name, var.value)).collect()
+}
+
+fn optional_env_to_prost(
+    env: Option<&[(String, String)]>,
+) -> (Vec<zccache_v1::EnvVar>, bool) {
+    match env {
+        Some(env) => (env_pairs_to_prost(env), true),
+        None => (Vec::new(), false),
+    }
+}
+
+fn optional_env_from_prost(
+    env: Vec<zccache_v1::EnvVar>,
+    env_is_set: bool,
+) -> Option<Vec<(String, String)>> {
+    env_is_set.then(|| env_pairs_from_prost(env))
+}
+
+fn paths_to_prost(paths: &[crate::core::NormalizedPath]) -> Vec<zccache_v1::Path> {
+    paths.iter().map(path_to_prost).collect()
+}
+
+fn paths_from_prost(paths: Vec<zccache_v1::Path>) -> Vec<crate::core::NormalizedPath> {
+    paths.into_iter().map(path_from_prost).collect()
+}
+
+fn private_daemon_session_options_to_prost(
+    options: &super::PrivateDaemonSessionOptions,
+) -> zccache_v1::PrivateDaemonSessionOptions {
+    zccache_v1::PrivateDaemonSessionOptions {
+        daemon_name: options.daemon_name.clone(),
+        endpoint: options.endpoint.clone(),
+        cache_dir: options.cache_dir.as_ref().map(path_to_prost),
+        owner_pids: options.owner_pids.clone(),
+        env: env_pairs_to_prost(&options.env),
+    }
+}
+
+fn private_daemon_session_options_from_prost(
+    options: zccache_v1::PrivateDaemonSessionOptions,
+) -> super::PrivateDaemonSessionOptions {
+    super::PrivateDaemonSessionOptions {
+        daemon_name: options.daemon_name,
+        endpoint: options.endpoint,
+        cache_dir: options.cache_dir.map(path_from_prost),
+        owner_pids: options.owner_pids,
+        env: env_pairs_from_prost(options.env),
+    }
+}
+
+fn artifact_data_to_prost(artifact: &super::ArtifactData) -> zccache_v1::ArtifactData {
+    zccache_v1::ArtifactData {
+        outputs: artifact.outputs.iter().map(artifact_output_to_prost).collect(),
+        stdout: artifact.stdout.as_ref().clone(),
+        stderr: artifact.stderr.as_ref().clone(),
+        exit_code: artifact.exit_code,
+    }
+}
+
+fn artifact_data_from_prost(
+    artifact: zccache_v1::ArtifactData,
+) -> Result<super::ArtifactData, String> {
+    Ok(super::ArtifactData {
+        outputs: artifact
+            .outputs
+            .into_iter()
+            .map(artifact_output_from_prost)
+            .collect::<Result<Vec<_>, _>>()?,
+        stdout: std::sync::Arc::new(artifact.stdout),
+        stderr: std::sync::Arc::new(artifact.stderr),
+        exit_code: artifact.exit_code,
     })
+}
+
+fn artifact_output_to_prost(output: &super::ArtifactOutput) -> zccache_v1::ArtifactOutput {
+    zccache_v1::ArtifactOutput {
+        name: output.name.clone(),
+        payload: Some(artifact_payload_to_prost(&output.payload)),
+    }
+}
+
+fn artifact_output_from_prost(
+    output: zccache_v1::ArtifactOutput,
+) -> Result<super::ArtifactOutput, String> {
+    Ok(super::ArtifactOutput {
+        payload: artifact_payload_from_prost(required_prost_field(
+            output.payload,
+            "ArtifactOutput.payload",
+        )?)?,
+        name: output.name,
+    })
+}
+
+fn artifact_payload_to_prost(payload: &super::ArtifactPayload) -> zccache_v1::ArtifactPayload {
+    use zccache_v1::artifact_payload::Body;
+
+    zccache_v1::ArtifactPayload {
+        body: Some(match payload {
+            super::ArtifactPayload::Bytes(bytes) => Body::Bytes(bytes.as_ref().clone()),
+            super::ArtifactPayload::Path(path) => Body::Path(path_to_prost(path)),
+        }),
+    }
+}
+
+fn artifact_payload_from_prost(
+    payload: zccache_v1::ArtifactPayload,
+) -> Result<super::ArtifactPayload, String> {
+    use zccache_v1::artifact_payload::Body;
+
+    match payload.body {
+        Some(Body::Bytes(bytes)) => Ok(super::ArtifactPayload::Bytes(std::sync::Arc::new(bytes))),
+        Some(Body::Path(path)) => Ok(super::ArtifactPayload::Path(path_from_prost(path))),
+        None => Err("missing required v16 prost field ArtifactPayload.body".to_string()),
+    }
+}
+
+fn lookup_result_to_prost(result: &super::LookupResult) -> zccache_v1::LookupResult {
+    use zccache_v1::lookup_result::Body;
+
+    zccache_v1::LookupResult {
+        body: Some(match result {
+            super::LookupResult::Hit { artifact } => Body::Hit(artifact_data_to_prost(artifact)),
+            super::LookupResult::Miss => Body::Miss(zccache_v1::Empty {}),
+        }),
+    }
+}
+
+fn lookup_result_from_prost(
+    result: zccache_v1::LookupResult,
+) -> Result<super::LookupResult, String> {
+    use zccache_v1::lookup_result::Body;
+
+    match result.body {
+        Some(Body::Hit(artifact)) => Ok(super::LookupResult::Hit {
+            artifact: artifact_data_from_prost(artifact)?,
+        }),
+        Some(Body::Miss(_)) => Ok(super::LookupResult::Miss),
+        None => Err("missing required v16 prost field LookupResult.body".to_string()),
+    }
+}
+
+fn store_result_kind_to_prost(result: &super::StoreResult) -> zccache_v1::StoreResultKind {
+    match result {
+        super::StoreResult::Stored => zccache_v1::StoreResultKind::Stored,
+        super::StoreResult::AlreadyExists => zccache_v1::StoreResultKind::AlreadyExists,
+    }
+}
+
+fn store_result_kind_from_prost(kind: i32) -> Result<super::StoreResult, String> {
+    match zccache_v1::StoreResultKind::try_from(kind) {
+        Ok(zccache_v1::StoreResultKind::Stored) => Ok(super::StoreResult::Stored),
+        Ok(zccache_v1::StoreResultKind::AlreadyExists) => Ok(super::StoreResult::AlreadyExists),
+        Ok(zccache_v1::StoreResultKind::Unspecified) | Err(_) => Err(format!(
+            "invalid v16 prost StoreResult.kind value {kind}; expected Stored or AlreadyExists"
+        )),
+    }
+}
+
+fn exec_output_streams_to_prost(streams: super::ExecOutputStreams) -> zccache_v1::ExecOutputStreams {
+    zccache_v1::ExecOutputStreams {
+        stdout: streams.stdout,
+        stderr: streams.stderr,
+    }
+}
+
+fn exec_output_streams_from_prost(
+    streams: zccache_v1::ExecOutputStreams,
+) -> super::ExecOutputStreams {
+    super::ExecOutputStreams {
+        stdout: streams.stdout,
+        stderr: streams.stderr,
+    }
+}
+
+fn exec_cache_policy_to_prost(policy: super::ExecCachePolicy) -> zccache_v1::ExecCachePolicy {
+    match policy {
+        super::ExecCachePolicy::Normal => zccache_v1::ExecCachePolicy::Normal,
+        super::ExecCachePolicy::Bypass => zccache_v1::ExecCachePolicy::Bypass,
+        super::ExecCachePolicy::ReadOnly => zccache_v1::ExecCachePolicy::ReadOnly,
+    }
+}
+
+fn exec_cache_policy_from_prost(policy: i32) -> Result<super::ExecCachePolicy, String> {
+    match zccache_v1::ExecCachePolicy::try_from(policy) {
+        Ok(zccache_v1::ExecCachePolicy::Normal) => Ok(super::ExecCachePolicy::Normal),
+        Ok(zccache_v1::ExecCachePolicy::Bypass) => Ok(super::ExecCachePolicy::Bypass),
+        Ok(zccache_v1::ExecCachePolicy::ReadOnly) => Ok(super::ExecCachePolicy::ReadOnly),
+        Ok(zccache_v1::ExecCachePolicy::Unspecified) | Err(_) => Err(format!(
+            "invalid v16 prost GenericToolExec.cache_policy value {policy}; \
+             expected Normal, Bypass, or ReadOnly"
+        )),
+    }
+}
+
+fn tool_hash_from_prost(hash: Option<Vec<u8>>) -> Result<Option<[u8; 32]>, String> {
+    match hash {
+        None => Ok(None),
+        Some(bytes) => <[u8; 32]>::try_from(bytes.as_slice()).map(Some).map_err(|_| {
+            format!(
+                "invalid v16 prost GenericToolExec.tool_hash length {}; expected 32 bytes",
+                bytes.len()
+            )
+        }),
+    }
+}
+
+fn rust_artifact_info_to_prost(info: &super::RustArtifactInfo) -> zccache_v1::RustArtifactInfo {
+    zccache_v1::RustArtifactInfo {
+        cache_key: info.cache_key.clone(),
+        output_names: info.output_names.clone(),
+        payload_count: info.payload_count as u64,
+    }
+}
+
+fn rust_artifact_info_from_prost(
+    info: zccache_v1::RustArtifactInfo,
+) -> Result<super::RustArtifactInfo, String> {
+    Ok(super::RustArtifactInfo {
+        payload_count: usize::try_from(info.payload_count).map_err(|_| {
+            format!(
+                "invalid v16 prost RustArtifactInfo.payload_count value {}; exceeds usize",
+                info.payload_count
+            )
+        })?,
+        cache_key: info.cache_key,
+        output_names: info.output_names,
+    })
+}
+
+fn session_stats_to_prost(stats: &super::SessionStats) -> zccache_v1::SessionStats {
+    zccache_v1::SessionStats {
+        duration_ms: stats.duration_ms,
+        compilations: stats.compilations,
+        hits: stats.hits,
+        misses: stats.misses,
+        non_cacheable: stats.non_cacheable,
+        errors: stats.errors,
+        errors_cached: stats.errors_cached,
+        time_saved_ms: stats.time_saved_ms,
+        unique_sources: stats.unique_sources,
+        bytes_read: stats.bytes_read,
+        bytes_written: stats.bytes_written,
+        phase_profile: stats.phase_profile.as_ref().map(phase_profile_to_prost),
+    }
+}
+
+fn session_stats_from_prost(stats: zccache_v1::SessionStats) -> super::SessionStats {
+    super::SessionStats {
+        duration_ms: stats.duration_ms,
+        compilations: stats.compilations,
+        hits: stats.hits,
+        misses: stats.misses,
+        non_cacheable: stats.non_cacheable,
+        errors: stats.errors,
+        errors_cached: stats.errors_cached,
+        time_saved_ms: stats.time_saved_ms,
+        unique_sources: stats.unique_sources,
+        bytes_read: stats.bytes_read,
+        bytes_written: stats.bytes_written,
+        phase_profile: stats.phase_profile.map(phase_profile_from_prost),
+    }
+}
+
+fn phase_profile_to_prost(
+    profile: &super::PhaseProfileSummary,
+) -> zccache_v1::PhaseProfileSummary {
+    zccache_v1::PhaseProfileSummary {
+        hit_count: profile.hit_count,
+        miss_count: profile.miss_count,
+        parse_args_ns: profile.parse_args_ns,
+        build_context_ns: profile.build_context_ns,
+        hash_source_ns: profile.hash_source_ns,
+        hash_headers_ns: profile.hash_headers_ns,
+        depgraph_check_ns: profile.depgraph_check_ns,
+        request_cache_lookup_ns: profile.request_cache_lookup_ns,
+        cross_root_validate_ns: profile.cross_root_validate_ns,
+        artifact_lookup_ns: profile.artifact_lookup_ns,
+        write_output_ns: profile.write_output_ns,
+        bookkeeping_ns: profile.bookkeeping_ns,
+        total_hit_ns: profile.total_hit_ns,
+        compiler_exec_ns: profile.compiler_exec_ns,
+        include_scan_ns: profile.include_scan_ns,
+        hash_all_ns: profile.hash_all_ns,
+        artifact_store_ns: profile.artifact_store_ns,
+        total_miss_ns: profile.total_miss_ns,
+    }
+}
+
+fn phase_profile_from_prost(
+    profile: zccache_v1::PhaseProfileSummary,
+) -> super::PhaseProfileSummary {
+    super::PhaseProfileSummary {
+        hit_count: profile.hit_count,
+        miss_count: profile.miss_count,
+        parse_args_ns: profile.parse_args_ns,
+        build_context_ns: profile.build_context_ns,
+        hash_source_ns: profile.hash_source_ns,
+        hash_headers_ns: profile.hash_headers_ns,
+        depgraph_check_ns: profile.depgraph_check_ns,
+        request_cache_lookup_ns: profile.request_cache_lookup_ns,
+        cross_root_validate_ns: profile.cross_root_validate_ns,
+        artifact_lookup_ns: profile.artifact_lookup_ns,
+        write_output_ns: profile.write_output_ns,
+        bookkeeping_ns: profile.bookkeeping_ns,
+        total_hit_ns: profile.total_hit_ns,
+        compiler_exec_ns: profile.compiler_exec_ns,
+        include_scan_ns: profile.include_scan_ns,
+        hash_all_ns: profile.hash_all_ns,
+        artifact_store_ns: profile.artifact_store_ns,
+        total_miss_ns: profile.total_miss_ns,
+    }
 }
 
 fn daemon_status_to_prost(status: &super::DaemonStatus) -> zccache_v1::DaemonStatus {
@@ -434,7 +1316,7 @@ fn path_from_prost(path: zccache_v1::Path) -> crate::core::NormalizedPath {
 }
 
 fn required_prost_field<T>(value: Option<T>, field: &str) -> Result<T, String> {
-    value.ok_or_else(|| format!("missing required v16 prost control response field {field}"))
+    value.ok_or_else(|| format!("missing required v16 prost field {field}"))
 }
 
 /// Serialize a prost message to the planned v16 length-prefixed frame.

--- a/crates/zccache/src/protocol/wire_prost.rs
+++ b/crates/zccache/src/protocol/wire_prost.rs
@@ -554,10 +554,7 @@ pub fn request_from_prost(request: zccache_v1::Request) -> Result<super::Request
             session_id: compile.session_id,
             args: compile.args,
             cwd: path_from_prost(required_prost_field(compile.cwd, "Compile.cwd")?),
-            compiler: path_from_prost(required_prost_field(
-                compile.compiler,
-                "Compile.compiler",
-            )?),
+            compiler: path_from_prost(required_prost_field(compile.compiler, "Compile.compiler")?),
             env: optional_env_from_prost(compile.env, compile.env_is_set),
             stdin: compile.stdin,
         }),
@@ -644,14 +641,12 @@ pub fn request_from_prost(request: zccache_v1::Request) -> Result<super::Request
             non_deterministic: exec.non_deterministic,
             key_args_filter: exec.key_args_filter,
         }),
-        Some(Body::ReleaseWorktreeHandles(release)) => {
-            Ok(super::Request::ReleaseWorktreeHandles {
-                path: path_from_prost(required_prost_field(
-                    release.path,
-                    "ReleaseWorktreeHandles.path",
-                )?),
-            })
-        }
+        Some(Body::ReleaseWorktreeHandles(release)) => Ok(super::Request::ReleaseWorktreeHandles {
+            path: path_from_prost(required_prost_field(
+                release.path,
+                "ReleaseWorktreeHandles.path",
+            )?),
+        }),
         None => Err("v16 prost request is missing its request body".to_string()),
     }
 }
@@ -665,9 +660,7 @@ pub fn response_to_prost(response: &super::Response, request_id: &str) -> zccach
         super::Response::Pong => Body::Pong(zccache_v1::Empty {}),
         super::Response::ShuttingDown => Body::ShuttingDown(zccache_v1::Empty {}),
         super::Response::Status(status) => Body::Status(daemon_status_to_prost(status)),
-        super::Response::LookupResult(result) => {
-            Body::LookupResult(lookup_result_to_prost(result))
-        }
+        super::Response::LookupResult(result) => Body::LookupResult(lookup_result_to_prost(result)),
         super::Response::StoreResult(result) => Body::StoreResult(zccache_v1::StoreResult {
             kind: store_result_kind_to_prost(result).into(),
         }),
@@ -888,9 +881,7 @@ fn env_pairs_from_prost(env: Vec<zccache_v1::EnvVar>) -> Vec<(String, String)> {
     env.into_iter().map(|var| (var.name, var.value)).collect()
 }
 
-fn optional_env_to_prost(
-    env: Option<&[(String, String)]>,
-) -> (Vec<zccache_v1::EnvVar>, bool) {
+fn optional_env_to_prost(env: Option<&[(String, String)]>) -> (Vec<zccache_v1::EnvVar>, bool) {
     match env {
         Some(env) => (env_pairs_to_prost(env), true),
         None => (Vec::new(), false),
@@ -938,7 +929,11 @@ fn private_daemon_session_options_from_prost(
 
 fn artifact_data_to_prost(artifact: &super::ArtifactData) -> zccache_v1::ArtifactData {
     zccache_v1::ArtifactData {
-        outputs: artifact.outputs.iter().map(artifact_output_to_prost).collect(),
+        outputs: artifact
+            .outputs
+            .iter()
+            .map(artifact_output_to_prost)
+            .collect(),
         stdout: artifact.stdout.as_ref().clone(),
         stderr: artifact.stderr.as_ref().clone(),
         exit_code: artifact.exit_code,
@@ -1044,7 +1039,9 @@ fn store_result_kind_from_prost(kind: i32) -> Result<super::StoreResult, String>
     }
 }
 
-fn exec_output_streams_to_prost(streams: super::ExecOutputStreams) -> zccache_v1::ExecOutputStreams {
+fn exec_output_streams_to_prost(
+    streams: super::ExecOutputStreams,
+) -> zccache_v1::ExecOutputStreams {
     zccache_v1::ExecOutputStreams {
         stdout: streams.stdout,
         stderr: streams.stderr,
@@ -1083,12 +1080,14 @@ fn exec_cache_policy_from_prost(policy: i32) -> Result<super::ExecCachePolicy, S
 fn tool_hash_from_prost(hash: Option<Vec<u8>>) -> Result<Option<[u8; 32]>, String> {
     match hash {
         None => Ok(None),
-        Some(bytes) => <[u8; 32]>::try_from(bytes.as_slice()).map(Some).map_err(|_| {
-            format!(
-                "invalid v16 prost GenericToolExec.tool_hash length {}; expected 32 bytes",
-                bytes.len()
-            )
-        }),
+        Some(bytes) => <[u8; 32]>::try_from(bytes.as_slice())
+            .map(Some)
+            .map_err(|_| {
+                format!(
+                    "invalid v16 prost GenericToolExec.tool_hash length {}; expected 32 bytes",
+                    bytes.len()
+                )
+            }),
     }
 }
 
@@ -1149,9 +1148,7 @@ fn session_stats_from_prost(stats: zccache_v1::SessionStats) -> super::SessionSt
     }
 }
 
-fn phase_profile_to_prost(
-    profile: &super::PhaseProfileSummary,
-) -> zccache_v1::PhaseProfileSummary {
+fn phase_profile_to_prost(profile: &super::PhaseProfileSummary) -> zccache_v1::PhaseProfileSummary {
     zccache_v1::PhaseProfileSummary {
         hit_count: profile.hit_count,
         miss_count: profile.miss_count,

--- a/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
+++ b/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
@@ -175,3 +175,408 @@ fn protocol_version_dispatch_models_v15_and_v16() {
     );
     assert_eq!(wire_format_for_protocol_version(99), None);
 }
+
+// ── Full message-family round-trips (issue rp#383, staged PR 2) ─────────
+//
+// Every non-control request/response family must survive a
+// prost-conversion round trip exactly, so the v16 lane can carry the
+// full protocol when `ZCCACHE_DAEMON_WIRE=prost` is selected.
+
+mod full_family {
+    use std::sync::Arc;
+    use zccache::protocol::wire_prost::{
+        default_request_id, request_from_prost, request_to_prost, response_from_prost,
+        response_to_prost,
+    };
+    use zccache::protocol::{
+        ArtifactData, ArtifactOutput, ArtifactPayload, ExecCachePolicy, ExecOutputStreams,
+        LookupResult, PhaseProfileSummary, PrivateDaemonSessionOptions, Request, Response,
+        RustArtifactInfo, SessionStats, StoreResult,
+    };
+
+    fn roundtrip_request(request: Request) {
+        let request_id = default_request_id(&request);
+        let prost = request_to_prost(&request, request_id);
+        assert_eq!(prost.request_id, request_id);
+        assert_eq!(request_from_prost(prost).unwrap(), request);
+    }
+
+    fn roundtrip_response(response: Response) {
+        let prost = response_to_prost(&response, "resp-1");
+        assert_eq!(prost.request_id, "resp-1");
+        assert_eq!(response_from_prost(prost).unwrap(), response);
+    }
+
+    fn sample_artifact() -> ArtifactData {
+        ArtifactData {
+            outputs: vec![
+                ArtifactOutput {
+                    name: "foo.o".to_string(),
+                    payload: ArtifactPayload::Bytes(Arc::new(vec![1, 2, 3])),
+                },
+                ArtifactOutput {
+                    name: "foo.d".to_string(),
+                    payload: ArtifactPayload::Path("/tmp/foo.d".into()),
+                },
+            ],
+            stdout: Arc::new(b"out".to_vec()),
+            stderr: Arc::new(b"err".to_vec()),
+            exit_code: 0,
+        }
+    }
+
+    fn sample_stats() -> SessionStats {
+        SessionStats {
+            duration_ms: 1,
+            compilations: 2,
+            hits: 3,
+            misses: 4,
+            non_cacheable: 5,
+            errors: 6,
+            errors_cached: 7,
+            time_saved_ms: 8,
+            unique_sources: 9,
+            bytes_read: 10,
+            bytes_written: 11,
+            phase_profile: Some(PhaseProfileSummary {
+                hit_count: 1,
+                miss_count: 2,
+                parse_args_ns: 3,
+                build_context_ns: 4,
+                hash_source_ns: 5,
+                hash_headers_ns: 6,
+                depgraph_check_ns: 7,
+                request_cache_lookup_ns: 8,
+                cross_root_validate_ns: 9,
+                artifact_lookup_ns: 10,
+                write_output_ns: 11,
+                bookkeeping_ns: 12,
+                total_hit_ns: 13,
+                compiler_exec_ns: 14,
+                include_scan_ns: 15,
+                hash_all_ns: 16,
+                artifact_store_ns: 17,
+                total_miss_ns: 18,
+            }),
+        }
+    }
+
+    #[test]
+    fn compile_request_roundtrips() {
+        roundtrip_request(Request::Compile {
+            session_id: "sess-1".to_string(),
+            args: vec!["-c".to_string(), "hello.cpp".to_string()],
+            cwd: "/src".into(),
+            compiler: "/usr/bin/g++".into(),
+            env: Some(vec![("PATH".to_string(), "/usr/bin".to_string())]),
+            stdin: b"stdin-bytes".to_vec(),
+        });
+        // env: None must be distinguishable from Some(vec![]).
+        roundtrip_request(Request::Compile {
+            session_id: "sess-2".to_string(),
+            args: vec![],
+            cwd: "/src".into(),
+            compiler: "/usr/bin/cc".into(),
+            env: None,
+            stdin: Vec::new(),
+        });
+        roundtrip_request(Request::Compile {
+            session_id: "sess-3".to_string(),
+            args: vec![],
+            cwd: "/src".into(),
+            compiler: "/usr/bin/cc".into(),
+            env: Some(Vec::new()),
+            stdin: Vec::new(),
+        });
+    }
+
+    #[test]
+    fn compile_ephemeral_request_roundtrips() {
+        roundtrip_request(Request::CompileEphemeral {
+            client_pid: 42,
+            working_dir: "/work".into(),
+            compiler: "/usr/bin/clang".into(),
+            args: vec!["-c".to_string(), "a.c".to_string()],
+            cwd: "/work/sub".into(),
+            env: Some(vec![("CC".to_string(), "clang".to_string())]),
+            stdin: vec![9, 8, 7],
+        });
+    }
+
+    #[test]
+    fn link_ephemeral_request_roundtrips() {
+        roundtrip_request(Request::LinkEphemeral {
+            client_pid: 7,
+            tool: "/usr/bin/ar".into(),
+            args: vec!["rcs".to_string(), "libfoo.a".to_string()],
+            cwd: "/work".into(),
+            env: None,
+        });
+    }
+
+    #[test]
+    fn session_request_family_roundtrips() {
+        roundtrip_request(Request::SessionStart {
+            client_pid: 1234,
+            working_dir: "/proj".into(),
+            log_file: Some("/proj/log.txt".into()),
+            track_stats: true,
+            journal_path: Some("/proj/journal.jsonl".into()),
+            profile: true,
+            private_daemon: Some(PrivateDaemonSessionOptions {
+                daemon_name: Some("soldr-dev".to_string()),
+                endpoint: Some("endpoint-1".to_string()),
+                cache_dir: Some("/cache".into()),
+                owner_pids: vec![1, 2, 3],
+                env: vec![("SECRET".to_string(), "value".to_string())],
+            }),
+        });
+        roundtrip_request(Request::SessionStart {
+            client_pid: 1,
+            working_dir: "/proj".into(),
+            log_file: None,
+            track_stats: false,
+            journal_path: None,
+            profile: false,
+            private_daemon: None,
+        });
+        roundtrip_request(Request::SessionEnd {
+            session_id: "sess-1".to_string(),
+        });
+        roundtrip_request(Request::SessionStats {
+            session_id: "sess-1".to_string(),
+        });
+    }
+
+    #[test]
+    fn lookup_and_store_request_roundtrips() {
+        roundtrip_request(Request::Lookup {
+            cache_key: "abc123".to_string(),
+        });
+        roundtrip_request(Request::Store {
+            cache_key: "abc123".to_string(),
+            artifact: sample_artifact(),
+        });
+    }
+
+    #[test]
+    fn fingerprint_request_family_roundtrips() {
+        roundtrip_request(Request::FingerprintCheck {
+            cache_file: "/proj/.cache/lint.json".into(),
+            cache_type: "two-layer".to_string(),
+            root: "/proj".into(),
+            extensions: vec!["rs".to_string()],
+            include_globs: vec!["**/*.rs".to_string()],
+            exclude: vec!["target".to_string()],
+        });
+        roundtrip_request(Request::FingerprintMarkSuccess {
+            cache_file: "/proj/.cache/lint.json".into(),
+        });
+        roundtrip_request(Request::FingerprintMarkFailure {
+            cache_file: "/proj/.cache/lint.json".into(),
+        });
+        roundtrip_request(Request::FingerprintInvalidate {
+            cache_file: "/proj/.cache/lint.json".into(),
+        });
+    }
+
+    #[test]
+    fn list_rust_artifacts_request_roundtrips() {
+        roundtrip_request(Request::ListRustArtifacts);
+    }
+
+    #[test]
+    fn generic_tool_exec_request_roundtrips() {
+        roundtrip_request(Request::GenericToolExec {
+            tool: "/usr/bin/protoc".into(),
+            args: vec!["--version".to_string()],
+            cwd: "/work".into(),
+            env: vec![("LANG".to_string(), "C".to_string())],
+            input_files: vec!["/work/a.proto".into()],
+            input_extra: Arc::new(vec![1, 2, 3, 4]),
+            output_streams: ExecOutputStreams {
+                stdout: true,
+                stderr: false,
+            },
+            output_files: vec!["/work/a.pb.rs".into()],
+            tool_hash: Some([7u8; 32]),
+            cache_policy: ExecCachePolicy::ReadOnly,
+            cwd_in_key: true,
+            include_scan_files: vec!["/work/a.c".into()],
+            include_dirs: vec!["/work/include".into()],
+            system_include_dirs: vec!["/usr/include".into()],
+            iquote_dirs: vec!["/work/quoted".into()],
+            depfile: Some("/work/a.d".into()),
+            non_deterministic: false,
+            key_args_filter: vec!["--verbose".to_string()],
+        });
+        // No tool hash, bypass policy, empty collections.
+        roundtrip_request(Request::GenericToolExec {
+            tool: "/usr/bin/true".into(),
+            args: vec![],
+            cwd: "/".into(),
+            env: vec![],
+            input_files: vec![],
+            input_extra: Arc::new(Vec::new()),
+            output_streams: ExecOutputStreams::default(),
+            output_files: vec![],
+            tool_hash: None,
+            cache_policy: ExecCachePolicy::Bypass,
+            cwd_in_key: false,
+            include_scan_files: vec![],
+            include_dirs: vec![],
+            system_include_dirs: vec![],
+            iquote_dirs: vec![],
+            depfile: None,
+            non_deterministic: true,
+            key_args_filter: vec![],
+        });
+    }
+
+    #[test]
+    fn generic_tool_exec_rejects_bad_tool_hash_length() {
+        let request = Request::GenericToolExec {
+            tool: "/usr/bin/true".into(),
+            args: vec![],
+            cwd: "/".into(),
+            env: vec![],
+            input_files: vec![],
+            input_extra: Arc::new(Vec::new()),
+            output_streams: ExecOutputStreams::default(),
+            output_files: vec![],
+            tool_hash: None,
+            cache_policy: ExecCachePolicy::Normal,
+            cwd_in_key: false,
+            include_scan_files: vec![],
+            include_dirs: vec![],
+            system_include_dirs: vec![],
+            iquote_dirs: vec![],
+            depfile: None,
+            non_deterministic: false,
+            key_args_filter: vec![],
+        };
+        let mut prost = request_to_prost(&request, "generic-tool-exec");
+        match prost.body {
+            Some(zccache::protocol::wire_prost::zccache_v1::request::Body::GenericToolExec(
+                ref mut exec,
+            )) => exec.tool_hash = Some(vec![1, 2, 3]),
+            _ => panic!("expected generic-tool-exec body"),
+        }
+        let err = request_from_prost(prost).unwrap_err();
+        assert!(err.contains("tool_hash"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn compile_result_response_roundtrips() {
+        roundtrip_response(Response::CompileResult {
+            exit_code: 1,
+            stdout: Arc::new(b"warning".to_vec()),
+            stderr: Arc::new(b"error".to_vec()),
+            cached: true,
+        });
+    }
+
+    #[test]
+    fn link_result_response_roundtrips() {
+        roundtrip_response(Response::LinkResult {
+            exit_code: 0,
+            stdout: Arc::new(Vec::new()),
+            stderr: Arc::new(b"link-err".to_vec()),
+            cached: false,
+            warning: Some("non-deterministic archive flags".to_string()),
+        });
+        roundtrip_response(Response::LinkResult {
+            exit_code: 0,
+            stdout: Arc::new(Vec::new()),
+            stderr: Arc::new(Vec::new()),
+            cached: true,
+            warning: None,
+        });
+    }
+
+    #[test]
+    fn session_response_family_roundtrips() {
+        roundtrip_response(Response::SessionStarted {
+            session_id: "sess-1".to_string(),
+            journal_path: Some("/proj/journal.jsonl".into()),
+        });
+        roundtrip_response(Response::SessionEnded {
+            stats: Some(sample_stats()),
+        });
+        roundtrip_response(Response::SessionEnded { stats: None });
+        roundtrip_response(Response::SessionStatsResult {
+            stats: Some(sample_stats()),
+        });
+    }
+
+    #[test]
+    fn lookup_and_store_response_roundtrips() {
+        roundtrip_response(Response::LookupResult(LookupResult::Hit {
+            artifact: sample_artifact(),
+        }));
+        roundtrip_response(Response::LookupResult(LookupResult::Miss));
+        roundtrip_response(Response::StoreResult(StoreResult::Stored));
+        roundtrip_response(Response::StoreResult(StoreResult::AlreadyExists));
+    }
+
+    #[test]
+    fn fingerprint_response_family_roundtrips() {
+        roundtrip_response(Response::FingerprintCheckResult {
+            decision: "run".to_string(),
+            reason: Some("content changed".to_string()),
+            changed_files: vec!["src/main.rs".to_string()],
+        });
+        roundtrip_response(Response::FingerprintAck);
+    }
+
+    #[test]
+    fn rust_artifact_list_response_roundtrips() {
+        roundtrip_response(Response::RustArtifactList {
+            artifacts: vec![RustArtifactInfo {
+                cache_key: "abc".to_string(),
+                output_names: vec!["libfoo.rlib".to_string()],
+                payload_count: 2,
+            }],
+        });
+    }
+
+    #[test]
+    fn generic_tool_exec_response_roundtrips() {
+        roundtrip_response(Response::GenericToolExecResult {
+            exit_code: 0,
+            stdout: Arc::new(b"tool-out".to_vec()),
+            stderr: Arc::new(Vec::new()),
+            output_files: vec![ArtifactOutput {
+                name: "gen.rs".to_string(),
+                payload: ArtifactPayload::Bytes(Arc::new(vec![5, 6])),
+            }],
+            cached: true,
+            cache_key_hex: "deadbeef".to_string(),
+        });
+    }
+
+    #[test]
+    fn backpressure_response_roundtrips() {
+        roundtrip_response(Response::Backpressure {
+            queue_depth: 12,
+            retry_after_ms: 250,
+            reason: "compile_queue_full".to_string(),
+        });
+    }
+
+    #[test]
+    fn control_converters_reject_non_control_families() {
+        use zccache::protocol::wire_prost::{
+            supported_control_request_from_prost, supported_control_response_from_prost,
+        };
+        let request = Request::SessionEnd {
+            session_id: "sess-1".to_string(),
+        };
+        let prost = request_to_prost(&request, "session-end");
+        assert!(supported_control_request_from_prost(prost).is_err());
+
+        let response = Response::FingerprintAck;
+        let prost = response_to_prost(&response, "resp-1");
+        assert!(supported_control_response_from_prost(prost).is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- Extends the prost v16 converter set in `protocol/wire_prost.rs` from the minimal/control slice to the full daemon message family.
- Teaches the IPC dispatcher in `daemon/server/connection.rs` (and CLI client wiring) to route the new message types over the prost lane.
- Adds full round-trip coverage in `tests/daemon_wire_prost_roundtrip.rs`.

Second PR in the stacked sequence; FrameV1 transport follows.

Refs zackees/running-process#383

## Test plan
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings`
- [x] `soldr cargo nextest run --workspace` (all tests pass; `daemon_rustc_restore_test::rustc_multi_output_hit_survives_cache_restore_without_target_dir` is a pre-existing local Windows flake — also fails on main, unrelated to this change)