### PR TITLE
feat(ipc): adopt FrameV1 transport with 0x7A63 payload protocol

### DIFF
--- a/crates/zccache/src/daemon/server/connection.rs
+++ b/crates/zccache/src/daemon/server/connection.rs
@@ -8,7 +8,16 @@ use crate::protocol::{
 
 enum ResponseWire {
     BincodeV15,
-    ProstV16 { request_id: String },
+    ProstV16 {
+        request_id: String,
+    },
+    /// running-process `Frame` envelope lane. `frame_request_id` is the
+    /// frame correlation id to echo; `request_id` is the inner zccache
+    /// prost request id echoed in the response body.
+    FrameV1 {
+        frame_request_id: u64,
+        request_id: String,
+    },
 }
 
 /// Handle a single client connection.
@@ -92,6 +101,34 @@ pub(super) async fn handle_connection(
                         send_response_for_wire(
                             &mut conn,
                             &ResponseWire::ProstV16 { request_id },
+                            &Response::Error { message },
+                        )
+                        .await?;
+                        continue;
+                    }
+                }
+            }
+            DecodedWireMessage::FrameV1 {
+                message: request,
+                request_id: frame_request_id,
+            } => {
+                let request_id = request.request_id.clone();
+                match wire_prost::request_from_prost(request) {
+                    Ok(request) => (
+                        request,
+                        ResponseWire::FrameV1 {
+                            frame_request_id,
+                            request_id,
+                        },
+                    ),
+                    Err(message) => {
+                        tracing::warn!("{message}");
+                        send_response_for_wire(
+                            &mut conn,
+                            &ResponseWire::FrameV1 {
+                                frame_request_id,
+                                request_id,
+                            },
                             &Response::Error { message },
                         )
                         .await?;
@@ -596,6 +633,14 @@ async fn send_response_for_wire(
         ResponseWire::ProstV16 { request_id } => {
             let response = wire_prost::response_to_prost(response, request_id);
             conn.send_prost(&response).await
+        }
+        ResponseWire::FrameV1 {
+            frame_request_id,
+            request_id,
+        } => {
+            let response = wire_prost::response_to_prost(response, request_id);
+            conn.send_frame_v1_response(&response, *frame_request_id)
+                .await
         }
     }
 }

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -84,6 +84,11 @@ async fn daemon_control_roundtrip_with_selection(
         wire_prost::WireFormat::BincodeV15 => {
             send_bincode_control(endpoint, request, recv_timeout).await
         }
+        // Forced-only lane (`ZCCACHE_DAEMON_WIRE=frame`): no bincode
+        // fallback, the caller asked for the Frame envelope explicitly.
+        wire_prost::WireFormat::FrameV1 => {
+            send_frame_control(endpoint, request, recv_timeout).await
+        }
         wire_prost::WireFormat::ProstV16 => {
             match send_prost_control(endpoint, request, recv_timeout).await {
                 Ok(Some(Response::Error { message }))
@@ -137,6 +142,19 @@ async fn send_prost_control(
     recv_control_wire_response(&mut conn, recv_timeout).await
 }
 
+async fn send_frame_control(
+    endpoint: &str,
+    request: DaemonControlRequest,
+    recv_timeout: Option<std::time::Duration>,
+) -> Result<Option<Response>, IpcError> {
+    let mut conn = connect_control_client(endpoint).await?;
+    let request = request.to_protocol_request();
+    let request =
+        wire_prost::supported_control_request_to_prost(&request).map_err(IpcError::Endpoint)?;
+    conn.send_frame_v1_request(&request).await?;
+    recv_control_wire_response(&mut conn, recv_timeout).await
+}
+
 async fn recv_control_response(
     conn: &mut ClientConnection,
     recv_timeout: Option<std::time::Duration>,
@@ -159,13 +177,16 @@ async fn recv_control_wire_response(
 
     match response {
         Some(protocol::DecodedWireMessage::BincodeV15(response)) => Ok(Some(response)),
-        Some(protocol::DecodedWireMessage::ProstV16(response)) => {
-            wire_prost::supported_control_response_from_prost(response)
-                .map(Some)
-                .map_err(|message| {
-                    IpcError::Protocol(protocol::ProtocolError::Deserialization(message))
-                })
-        }
+        Some(
+            protocol::DecodedWireMessage::ProstV16(response)
+            | protocol::DecodedWireMessage::FrameV1 {
+                message: response, ..
+            },
+        ) => wire_prost::supported_control_response_from_prost(response)
+            .map(Some)
+            .map_err(|message| {
+                IpcError::Protocol(protocol::ProtocolError::Deserialization(message))
+            }),
         None => Ok(None),
     }
 }

--- a/crates/zccache/src/ipc/transport.rs
+++ b/crates/zccache/src/ipc/transport.rs
@@ -5,6 +5,15 @@
 //! bincode via `zccache-protocol`. Explicit migration hooks can send v16 prost
 //! frames and receive either v15 bincode or v16 prost frames without changing
 //! the default v15 client/server path.
+//!
+//! A third lane carries zccache prost payloads inside running-process broker
+//! `Frame` envelopes (`[u8 envelope_version=1][u32 LE body_len][Frame]`,
+//! `payload_protocol` =
+//! [`ZCCACHE_FRAME_PAYLOAD_PROTOCOL`](crate::protocol::wire_frame::ZCCACHE_FRAME_PAYLOAD_PROTOCOL)).
+//! It is selected only by an explicit `ZCCACHE_DAEMON_WIRE=frame` and shares
+//! the running-process framing already used by the `BackendHandle` identity
+//! probe; `recv_wire` disambiguates it from v15/v16 the same way
+//! `try_serve_backend_handle_probe` does.
 
 use std::time::Duration;
 
@@ -59,6 +68,9 @@ pub struct IpcConnection {
     /// (today's historical behavior, kept for server-side and other
     /// idle-style readers). Set via `set_recv_timeout`.
     recv_timeout: Option<Duration>,
+    /// Monotonic correlation id for outgoing running-process `Frame`
+    /// envelopes on the FrameV1 lane.
+    next_frame_request_id: u64,
 }
 
 /// Client-side IPC connection (Windows uses a different type).
@@ -69,6 +81,8 @@ pub struct IpcClientConnection {
     read_buf: BytesMut,
     /// Optional default timeout for `recv`. See `IpcConnection::recv_timeout`.
     recv_timeout: Option<Duration>,
+    /// See `IpcConnection::next_frame_request_id`.
+    next_frame_request_id: u64,
 }
 
 // ── IpcConnection impl (server-side on Windows, both on Unix) ───────
@@ -108,6 +122,35 @@ impl IpcConnection {
     /// flips its live protocol policy.
     pub async fn send_prost<M: prost::Message>(&mut self, msg: &M) -> Result<(), IpcError> {
         let buf = crate::protocol::wire_prost::encode_prost_message(msg)?;
+        self.writer.write_all(&buf).await?;
+        self.writer.flush().await?;
+        Ok(())
+    }
+
+    /// Send a prost message as a running-process `Frame` request envelope.
+    ///
+    /// Returns the frame correlation id assigned to the request so the
+    /// caller can match the daemon's echoed `request_id`.
+    pub async fn send_frame_v1_request<M: prost::Message>(
+        &mut self,
+        msg: &M,
+    ) -> Result<u64, IpcError> {
+        let request_id = self.next_frame_request_id;
+        self.next_frame_request_id = self.next_frame_request_id.wrapping_add(1);
+        let buf = crate::protocol::wire_frame::encode_frame_v1_request(msg, request_id)?;
+        self.writer.write_all(&buf).await?;
+        self.writer.flush().await?;
+        Ok(request_id)
+    }
+
+    /// Send a prost message as a running-process `Frame` response envelope,
+    /// echoing the client's frame correlation id.
+    pub async fn send_frame_v1_response<M: prost::Message>(
+        &mut self,
+        msg: &M,
+        request_id: u64,
+    ) -> Result<(), IpcError> {
+        let buf = crate::protocol::wire_frame::encode_frame_v1_response(msg, request_id)?;
         self.writer.write_all(&buf).await?;
         self.writer.flush().await?;
         Ok(())
@@ -211,11 +254,16 @@ impl IpcConnection {
                 let request = crate::protocol::wire_prost::request_to_prost(request, request_id);
                 self.send_prost(&request).await
             }
+            crate::protocol::wire_prost::WireFormat::FrameV1 => {
+                let request_id = crate::protocol::wire_prost::default_request_id(request);
+                let request = crate::protocol::wire_prost::request_to_prost(request, request_id);
+                self.send_frame_v1_request(&request).await.map(|_| ())
+            }
         }
     }
 
     /// Receive a protocol [`Response`](crate::protocol::Response), accepting
-    /// both v15 bincode and v16 prost frames.
+    /// v15 bincode, v16 prost, and running-process `Frame` envelopes.
     pub async fn recv_response(&mut self) -> Result<Option<crate::protocol::Response>, IpcError> {
         let message = self
             .recv_wire::<crate::protocol::Response, crate::protocol::wire_prost::zccache_v1::Response>()
@@ -274,6 +322,19 @@ impl IpcClientConnection {
         self.writer.write_all(&buf).await?;
         self.writer.flush().await?;
         Ok(())
+    }
+
+    /// See [`IpcConnection::send_frame_v1_request`].
+    pub async fn send_frame_v1_request<M: prost::Message>(
+        &mut self,
+        msg: &M,
+    ) -> Result<u64, IpcError> {
+        let request_id = self.next_frame_request_id;
+        self.next_frame_request_id = self.next_frame_request_id.wrapping_add(1);
+        let buf = crate::protocol::wire_frame::encode_frame_v1_request(msg, request_id)?;
+        self.writer.write_all(&buf).await?;
+        self.writer.flush().await?;
+        Ok(request_id)
     }
 
     /// See [`IpcConnection::set_recv_timeout`].
@@ -361,6 +422,11 @@ impl IpcClientConnection {
                 let request_id = crate::protocol::wire_prost::default_request_id(request);
                 let request = crate::protocol::wire_prost::request_to_prost(request, request_id);
                 self.send_prost(&request).await
+            }
+            crate::protocol::wire_prost::WireFormat::FrameV1 => {
+                let request_id = crate::protocol::wire_prost::default_request_id(request);
+                let request = crate::protocol::wire_prost::request_to_prost(request, request_id);
+                self.send_frame_v1_request(&request).await.map(|_| ())
             }
         }
     }
@@ -510,15 +576,20 @@ where
     }
     ensure_buffered(reader, read_buf, 5 + body_len).await?;
 
-    read_buf.advance(5);
-    let body = read_buf.split_to(body_len);
-    let frame = running_process::broker::protocol::Frame::decode(body.as_ref())
+    // Decode from a peek so non-probe frames (e.g. the zccache FrameV1
+    // request lane, which shares this framing) stay buffered for the
+    // dispatching `recv_wire` decoder.
+    let frame = running_process::broker::protocol::Frame::decode(&read_buf[5..5 + body_len])
         .map_err(|err| IpcError::Endpoint(format!("BackendHandle probe decode failed: {err}")))?;
     if !is_backend_handle_probe_request(&frame) {
+        if frame.payload_protocol == crate::protocol::wire_frame::ZCCACHE_FRAME_PAYLOAD_PROTOCOL {
+            return Ok(false);
+        }
         return Err(IpcError::Endpoint(
             "unexpected running-process frame on zccache daemon endpoint".to_string(),
         ));
     }
+    read_buf.advance(5 + body_len);
 
     let response = backend_handle_probe_response(&frame, daemon)?;
     write_running_process_frame(writer, &response).await?;
@@ -698,6 +769,7 @@ impl IpcListener {
                 writer,
                 read_buf: BytesMut::with_capacity(4096),
                 recv_timeout: None,
+                next_frame_request_id: 1,
             })
         }
         #[cfg(windows)]
@@ -780,6 +852,7 @@ impl IpcListener {
                 writer,
                 read_buf: BytesMut::with_capacity(4096),
                 recv_timeout: None,
+                next_frame_request_id: 1,
             });
         }
     }
@@ -861,6 +934,7 @@ pub async fn connect(endpoint: &str) -> Result<IpcConnection, IpcError> {
         writer,
         read_buf: BytesMut::with_capacity(4096),
         recv_timeout: None,
+        next_frame_request_id: 1,
     })
 }
 
@@ -915,6 +989,7 @@ pub async fn connect(endpoint: &str) -> Result<IpcClientConnection, IpcError> {
         writer,
         read_buf: BytesMut::with_capacity(4096),
         recv_timeout: None,
+        next_frame_request_id: 1,
     })
 }
 

--- a/crates/zccache/src/protocol/mod.rs
+++ b/crates/zccache/src/protocol/mod.rs
@@ -4,6 +4,7 @@
 //! and provides serialization/deserialization using the active daemon wire.
 
 pub mod messages;
+pub mod wire_frame;
 pub mod wire_prost;
 
 pub use messages::*;
@@ -62,15 +63,26 @@ pub enum DecodedWireMessage<Bincode, Prost> {
     BincodeV15(Bincode),
     /// v16 prost payload.
     ProstV16(Prost),
+    /// Prost payload carried inside a running-process broker `Frame`
+    /// envelope. `request_id` is the frame correlation id the responder
+    /// must echo back.
+    FrameV1 {
+        /// The zccache prost message decoded from `Frame.payload`.
+        message: Prost,
+        /// The `Frame.request_id` to echo in the response frame.
+        request_id: u64,
+    },
 }
 
 impl<Bincode, Prost> DecodedWireMessage<Bincode, Prost> {
-    /// Wire family selected by the frame protocol-version header.
+    /// Wire family selected by the frame protocol-version header (or the
+    /// running-process envelope byte for the `Frame` lane).
     #[must_use]
     pub const fn wire_format(&self) -> wire_prost::WireFormat {
         match self {
             Self::BincodeV15(_) => wire_prost::WireFormat::BincodeV15,
             Self::ProstV16(_) => wire_prost::WireFormat::ProstV16,
+            Self::FrameV1 { .. } => wire_prost::WireFormat::FrameV1,
         }
     }
 }
@@ -150,12 +162,15 @@ pub fn decode_bincode_message<T: serde::de::DeserializeOwned>(
     Ok(Some(msg))
 }
 
-/// Try to decode either a v15 bincode or v16 prost frame from a byte buffer.
+/// Try to decode a v15 bincode frame, a v16 prost frame, or a zccache prost
+/// message carried in a running-process broker `Frame` envelope.
 ///
 /// The live transport still calls [`decode_message`], which keeps today's v15
 /// behavior. This helper is the migration hook for the daemon dispatcher: it
-/// peeks the existing protocol-version header and routes to the compatible
-/// decoder without consuming incomplete or unsupported frames.
+/// peeks the existing protocol-version header (or the running-process
+/// envelope byte, disambiguated exactly like the daemon's BackendHandle probe
+/// detector) and routes to the compatible decoder without consuming
+/// incomplete or unsupported frames.
 ///
 /// # Errors
 ///
@@ -168,6 +183,20 @@ where
     Bincode: serde::de::DeserializeOwned,
     Prost: ProstMessage + Default,
 {
+    match wire_frame::buffer_starts_running_process_frame(buf) {
+        // Empty or ambiguous prefix: wait for more bytes.
+        None => return Ok(None),
+        Some(true) => {
+            return wire_frame::decode_frame_v1_message(buf).map(|decoded| {
+                decoded.map(|frame| DecodedWireMessage::FrameV1 {
+                    message: frame.message,
+                    request_id: frame.request_id,
+                })
+            });
+        }
+        Some(false) => {}
+    }
+
     let Some(version) = peek_frame_protocol_version(buf)? else {
         return Ok(None);
     };
@@ -179,7 +208,9 @@ where
         Some(wire_prost::WireFormat::ProstV16) => {
             wire_prost::decode_prost_message(buf).map(|msg| msg.map(DecodedWireMessage::ProstV16))
         }
-        None => Err(ProtocolError::VersionMismatch {
+        // The Frame lane has no zccache protocol-version header; it is
+        // routed above via the running-process envelope byte.
+        Some(wire_prost::WireFormat::FrameV1) | None => Err(ProtocolError::VersionMismatch {
             expected: PROST_PROTOCOL_VERSION,
             received: version,
         }),

--- a/crates/zccache/src/protocol/wire_frame.rs
+++ b/crates/zccache/src/protocol/wire_frame.rs
@@ -1,0 +1,225 @@
+//! running-process `Frame` envelope lane for the daemon wire.
+//!
+//! Outer framing is running-process broker framing:
+//! `[u8 envelope_version=1][u32 LE body_len][prost broker_v1 Frame]`. The
+//! `Frame.payload` carries the raw prost-encoded `zccache_v1` message (no
+//! inner `[len][version]` header); `Frame.payload_protocol` is
+//! [`ZCCACHE_FRAME_PAYLOAD_PROTOCOL`] and `Frame.request_id` correlates a
+//! response to its request. This lane is selected only by an explicit
+//! `ZCCACHE_DAEMON_WIRE=frame`; `auto` never prefers it.
+
+use bytes::{Buf, BufMut, BytesMut};
+use prost::Message;
+
+use super::{ProtocolError, BINCODE_PROTOCOL_VERSION, PROST_PROTOCOL_VERSION};
+
+/// `payload_protocol` registry value for zccache requests/responses carried
+/// inside running-process broker `Frame` envelopes.
+///
+/// `0x7A63` is ASCII `"zc"` (`0x7A` = 'z', `0x63` = 'c'). Collision check
+/// against the frozen running-process broker payload-protocol registry:
+///
+/// - `0x0000` — broker control (`Hello`/`HelloReply`)
+/// - `0xAD01` — broker admin verbs
+/// - `0xB232` — `BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL`
+///   (`running_process::broker::backend_lifecycle::probe`)
+/// - `0xD0FF` — broker handoff
+///
+/// `0x7A63` collides with none of these; a compile-time assertion below pins
+/// the probe-constant check so a future running-process bump cannot silently
+/// introduce a collision.
+pub const ZCCACHE_FRAME_PAYLOAD_PROTOCOL: u32 = 0x7A63;
+
+const _: () = assert!(
+    ZCCACHE_FRAME_PAYLOAD_PROTOCOL
+        != running_process::broker::backend_lifecycle::probe::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL,
+    "zccache Frame payload protocol must not collide with the BackendHandle probe"
+);
+const _: () = assert!(ZCCACHE_FRAME_PAYLOAD_PROTOCOL != 0x0000);
+const _: () = assert!(ZCCACHE_FRAME_PAYLOAD_PROTOCOL != 0xAD01);
+const _: () = assert!(ZCCACHE_FRAME_PAYLOAD_PROTOCOL != 0xD0FF);
+
+/// Decoded zccache message extracted from a running-process `Frame`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FrameV1Decoded<M> {
+    /// The zccache prost message decoded from `Frame.payload`.
+    pub message: M,
+    /// The `Frame.request_id` (echoed verbatim in the response frame).
+    pub request_id: u64,
+}
+
+/// Serialize a zccache prost request into a running-process `Frame` envelope.
+///
+/// # Errors
+///
+/// Returns an error if prost encoding fails or the frame exceeds the
+/// running-process frame size cap.
+pub fn encode_frame_v1_request<M: Message>(
+    msg: &M,
+    request_id: u64,
+) -> Result<BytesMut, ProtocolError> {
+    encode_frame_v1_message(
+        msg,
+        running_process::broker::protocol::FrameKind::Request,
+        request_id,
+    )
+}
+
+/// Serialize a zccache prost response into a running-process `Frame` envelope.
+///
+/// # Errors
+///
+/// Returns an error if prost encoding fails or the frame exceeds the
+/// running-process frame size cap.
+pub fn encode_frame_v1_response<M: Message>(
+    msg: &M,
+    request_id: u64,
+) -> Result<BytesMut, ProtocolError> {
+    encode_frame_v1_message(
+        msg,
+        running_process::broker::protocol::FrameKind::Response,
+        request_id,
+    )
+}
+
+fn encode_frame_v1_message<M: Message>(
+    msg: &M,
+    kind: running_process::broker::protocol::FrameKind,
+    request_id: u64,
+) -> Result<BytesMut, ProtocolError> {
+    use running_process::broker::protocol::{Frame, PayloadEncoding};
+
+    let mut payload = Vec::with_capacity(msg.encoded_len());
+    msg.encode(&mut payload)
+        .map_err(|e| ProtocolError::Serialization(e.to_string()))?;
+
+    let frame = Frame {
+        envelope_version: 1,
+        kind: kind as i32,
+        payload_protocol: ZCCACHE_FRAME_PAYLOAD_PROTOCOL,
+        payload,
+        request_id,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    };
+
+    let mut body = Vec::with_capacity(frame.encoded_len());
+    frame
+        .encode(&mut body)
+        .map_err(|e| ProtocolError::Serialization(e.to_string()))?;
+    if body.len() > running_process::broker::protocol::MAX_FRAME_BYTES {
+        return Err(ProtocolError::MessageTooLarge(body.len()));
+    }
+
+    let mut buf = BytesMut::with_capacity(1 + 4 + body.len());
+    buf.put_u8(running_process::broker::protocol::ENVELOPE_VERSION);
+    buf.put_u32_le(u32::try_from(body.len()).expect("frame body under 16 MiB cap fits in u32"));
+    buf.extend_from_slice(&body);
+    Ok(buf)
+}
+
+/// Whether the buffered bytes begin a running-process `Frame` envelope
+/// rather than a zccache `[len][version]` frame.
+///
+/// Returns `None` until 8 bytes are buffered (the minimum needed to
+/// disambiguate). The disambiguation matches the daemon's BackendHandle
+/// probe detector exactly: a first byte equal to the running-process
+/// `ENVELOPE_VERSION` (1) is still treated as a zccache frame when bytes
+/// 0..4 form a plausible zccache length and bytes 4..8 carry a known
+/// zccache protocol version (v15/v16).
+#[must_use]
+pub fn buffer_starts_running_process_frame(buf: &[u8]) -> Option<bool> {
+    if buf.is_empty() {
+        return None;
+    }
+    if buf[0] != running_process::broker::protocol::ENVELOPE_VERSION {
+        return Some(false);
+    }
+    if buf.len() < 8 {
+        return None;
+    }
+    let zccache_len = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
+    let zccache_version = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
+    Some(
+        !(zccache_len >= 4
+            && matches!(
+                zccache_version,
+                BINCODE_PROTOCOL_VERSION | PROST_PROTOCOL_VERSION
+            )),
+    )
+}
+
+/// Try to decode a zccache message carried in a running-process `Frame`
+/// envelope from a byte buffer.
+///
+/// Returns `None` when the buffer does not yet contain a complete frame.
+/// The caller must have already established (via
+/// [`buffer_starts_running_process_frame`]) that the buffer starts a
+/// running-process frame.
+///
+/// # Errors
+///
+/// Returns an error for oversized frames, malformed `Frame` envelopes,
+/// frames whose `payload_protocol` is not [`ZCCACHE_FRAME_PAYLOAD_PROTOCOL`],
+/// or payloads that fail to decode as the expected zccache message.
+pub fn decode_frame_v1_message<M: Message + Default>(
+    buf: &mut BytesMut,
+) -> Result<Option<FrameV1Decoded<M>>, ProtocolError> {
+    use running_process::broker::protocol::{Frame, FrameKind, PayloadEncoding};
+
+    if buf.len() < 5 {
+        return Ok(None);
+    }
+    debug_assert_eq!(buf[0], running_process::broker::protocol::ENVELOPE_VERSION);
+
+    let body_len = u32::from_le_bytes([buf[1], buf[2], buf[3], buf[4]]) as usize;
+    if body_len > running_process::broker::protocol::MAX_FRAME_BYTES {
+        return Err(ProtocolError::MessageTooLarge(body_len));
+    }
+    if buf.len() < 5 + body_len {
+        return Ok(None);
+    }
+
+    buf.advance(5);
+    let body = buf.split_to(body_len);
+    let frame = Frame::decode(body.as_ref())
+        .map_err(|e| ProtocolError::Deserialization(format!("running-process Frame: {e}")))?;
+
+    if frame.envelope_version != 1 {
+        return Err(ProtocolError::Deserialization(format!(
+            "unsupported running-process Frame envelope_version {}",
+            frame.envelope_version
+        )));
+    }
+    if frame.payload_protocol != ZCCACHE_FRAME_PAYLOAD_PROTOCOL {
+        return Err(ProtocolError::Deserialization(format!(
+            "running-process Frame payload_protocol {:#06X} is not the zccache payload protocol \
+             {ZCCACHE_FRAME_PAYLOAD_PROTOCOL:#06X}",
+            frame.payload_protocol
+        )));
+    }
+    if !matches!(
+        FrameKind::try_from(frame.kind),
+        Ok(FrameKind::Request | FrameKind::Response)
+    ) {
+        return Err(ProtocolError::Deserialization(format!(
+            "unsupported running-process Frame kind {} on the zccache lane",
+            frame.kind
+        )));
+    }
+    if PayloadEncoding::try_from(frame.payload_encoding) != Ok(PayloadEncoding::None) {
+        return Err(ProtocolError::Deserialization(format!(
+            "unsupported running-process Frame payload_encoding {} on the zccache lane",
+            frame.payload_encoding
+        )));
+    }
+
+    let message = M::decode(frame.payload.as_slice())
+        .map_err(|e| ProtocolError::Deserialization(e.to_string()))?;
+    Ok(Some(FrameV1Decoded {
+        message,
+        request_id: frame.request_id,
+    }))
+}

--- a/crates/zccache/src/protocol/wire_prost.rs
+++ b/crates/zccache/src/protocol/wire_prost.rs
@@ -4,6 +4,12 @@
 //! so hot-path requests keep their old wire shape. The live daemon dispatcher
 //! can accept v16 prost control requests through the explicit helpers in this
 //! module while the full enum conversion lands incrementally.
+//!
+//! A third wire lane carries zccache prost payloads inside running-process
+//! broker `Frame` envelopes (`[u8 envelope_version=1][u32 LE body_len][Frame]`,
+//! see [`encode_frame_v1_request`] / [`decode_frame_v1_message`]). It is
+//! selected only by an explicit `ZCCACHE_DAEMON_WIRE=frame`; `auto` never
+//! prefers it.
 
 use bytes::{Buf, BufMut, BytesMut};
 use prost::Message;
@@ -15,6 +21,13 @@ pub mod zccache_v1 {
     include!(concat!(env!("OUT_DIR"), "/zccache.v1.rs"));
 }
 
+// Re-export the running-process Frame envelope lane so callers can keep
+// addressing the whole daemon-wire surface through `wire_prost`.
+pub use super::wire_frame::{
+    buffer_starts_running_process_frame, decode_frame_v1_message, encode_frame_v1_request,
+    encode_frame_v1_response, FrameV1Decoded, ZCCACHE_FRAME_PAYLOAD_PROTOCOL,
+};
+
 /// Environment variable reserved for the daemon wire migration fallback.
 pub const WIRE_FORMAT_ENV: &str = "ZCCACHE_DAEMON_WIRE";
 
@@ -25,15 +38,26 @@ pub enum WireFormat {
     BincodeV15,
     /// Planned v16 prost body.
     ProstV16,
+    /// zccache prost payloads inside running-process broker `Frame`
+    /// envelopes: `[u8 envelope_version=1][u32 LE body_len][Frame]` with
+    /// `payload_protocol` = [`ZCCACHE_FRAME_PAYLOAD_PROTOCOL`] and the raw
+    /// prost-encoded `zccache_v1` message as the opaque payload (no inner
+    /// `[len][version]` header).
+    FrameV1,
 }
 
 impl WireFormat {
-    /// Protocol version carried in the existing frame header.
+    /// Protocol version carried in the zccache `[len][version]` frame header.
+    ///
+    /// Returns `None` for [`Self::FrameV1`], which has no inner zccache
+    /// header — it is identified by the running-process envelope byte plus
+    /// the `Frame.payload_protocol` field instead.
     #[must_use]
-    pub const fn protocol_version(self) -> u32 {
+    pub const fn protocol_version(self) -> Option<u32> {
         match self {
-            Self::BincodeV15 => BINCODE_PROTOCOL_VERSION,
-            Self::ProstV16 => PROST_PROTOCOL_VERSION,
+            Self::BincodeV15 => Some(BINCODE_PROTOCOL_VERSION),
+            Self::ProstV16 => Some(PROST_PROTOCOL_VERSION),
+            Self::FrameV1 => None,
         }
     }
 }
@@ -53,6 +77,9 @@ pub enum ClientWireSelection {
     BincodeV15,
     /// Force the v16 prost path.
     ProstV16,
+    /// Force the running-process `Frame` envelope path. Forced-only:
+    /// `Auto` never prefers this lane.
+    FrameV1,
 }
 
 impl ClientWireSelection {
@@ -62,6 +89,7 @@ impl ClientWireSelection {
         match self {
             Self::Auto | Self::ProstV16 => WireFormat::ProstV16,
             Self::BincodeV15 => WireFormat::BincodeV15,
+            Self::FrameV1 => WireFormat::FrameV1,
         }
     }
 
@@ -122,8 +150,9 @@ pub fn client_wire_selection_from_env_value(
         "" | "auto" => Ok(ClientWireSelection::Auto),
         "bincode" | "bincode-v15" | "v15" => Ok(ClientWireSelection::BincodeV15),
         "prost" | "prost-v16" | "v16" => Ok(ClientWireSelection::ProstV16),
+        "frame" | "frame-v1" => Ok(ClientWireSelection::FrameV1),
         other => Err(format!(
-            "invalid {WIRE_FORMAT_ENV}={other:?}; expected auto, bincode, or prost"
+            "invalid {WIRE_FORMAT_ENV}={other:?}; expected auto, bincode, prost, or frame"
         )),
     }
 }
@@ -290,7 +319,8 @@ pub const fn default_request_id(request: &super::Request) -> &'static str {
 ///
 /// The hot wrapper, session, fingerprint, and exec client paths keep their
 /// current v15 bincode default: only an explicit `ZCCACHE_DAEMON_WIRE=prost`
-/// opts them into the v16 prost lane. `auto`/unset intentionally stays
+/// (or `=frame` for the running-process `Frame` envelope lane) opts them out
+/// of bincode. `auto`/unset intentionally stays
 /// bincode here (even though the control slice prefers prost under auto) so
 /// the staged migration does not change default wire selection. Invalid
 /// values also fall back to bincode instead of failing a build.
@@ -298,6 +328,7 @@ pub const fn default_request_id(request: &super::Request) -> &'static str {
 pub fn full_family_wire_format_from_env() -> WireFormat {
     match client_wire_selection_from_env() {
         Ok(ClientWireSelection::ProstV16) => WireFormat::ProstV16,
+        Ok(ClientWireSelection::FrameV1) => WireFormat::FrameV1,
         Ok(ClientWireSelection::Auto | ClientWireSelection::BincodeV15) | Err(_) => {
             WireFormat::BincodeV15
         }
@@ -318,9 +349,10 @@ pub fn response_from_decoded_wire(
 ) -> Result<super::Response, super::ProtocolError> {
     match message {
         super::DecodedWireMessage::BincodeV15(response) => Ok(response),
-        super::DecodedWireMessage::ProstV16(response) => {
-            response_from_prost(response).map_err(super::ProtocolError::Deserialization)
-        }
+        super::DecodedWireMessage::ProstV16(response)
+        | super::DecodedWireMessage::FrameV1 {
+            message: response, ..
+        } => response_from_prost(response).map_err(super::ProtocolError::Deserialization),
     }
 }
 

--- a/crates/zccache/tests/daemon_wire_dispatcher.rs
+++ b/crates/zccache/tests/daemon_wire_dispatcher.rs
@@ -48,7 +48,7 @@ fn dispatcher_decodes_v16_prost_request() {
             assert_eq!(decoded.request_id, "prost-dispatch");
             assert!(matches!(decoded.body, Some(pb::request::Body::Ping(_))));
         }
-        DecodedWireMessage::BincodeV15(_) => panic!("expected prost request"),
+        other => panic!("expected prost request, got {other:?}"),
     }
     assert!(buf.is_empty());
 }

--- a/crates/zccache/tests/daemon_wire_frame_v1_test.rs
+++ b/crates/zccache/tests/daemon_wire_frame_v1_test.rs
@@ -1,0 +1,378 @@
+//! FrameV1 daemon-wire lane tests (running-process `Frame` envelopes).
+//!
+//! Covers, for zackees/running-process#383:
+//! 1. Golden-bytes pinning of the exact on-wire layout of one request and
+//!    one response frame (modeled on running-process's
+//!    `tests/broker/golden_bytes.rs`). The expected byte arrays were derived
+//!    ONCE (by encoding the sample values and pasting the output) and are
+//!    now frozen; the tests never re-derive expectations from the encoder
+//!    under test. Any diff is a wire-format break.
+//! 2. A live IPC round-trip against a real daemon with
+//!    `WireFormat::FrameV1`, including multiple sequential requests on one
+//!    connection.
+//! 3. Mixed-wire coexistence: sequential connections speaking v15 bincode,
+//!    v16 prost, FrameV1, and a running-process `BackendHandle` identity
+//!    probe against the same daemon endpoint.
+
+use bytes::BytesMut;
+use zccache::daemon::DaemonServer;
+use zccache::protocol::wire_frame::{
+    buffer_starts_running_process_frame, decode_frame_v1_message, encode_frame_v1_request,
+    encode_frame_v1_response, ZCCACHE_FRAME_PAYLOAD_PROTOCOL,
+};
+use zccache::protocol::wire_prost::{zccache_v1 as pb, WireFormat};
+use zccache::protocol::{Request, Response};
+
+// ---------------------------------------------------------------------------
+// Sample values. Small, deterministic, every relevant field populated.
+// ---------------------------------------------------------------------------
+
+fn sample_ping_request() -> pb::Request {
+    pb::Request {
+        body: Some(pb::request::Body::Ping(pb::Empty {})),
+        request_id: "frame-ping".to_string(),
+    }
+}
+
+fn sample_pong_response() -> pb::Response {
+    pb::Response {
+        body: Some(pb::response::Body::Pong(pb::Empty {})),
+        request_id: "frame-ping".to_string(),
+    }
+}
+
+const SAMPLE_FRAME_REQUEST_ID: u64 = 7;
+
+// ---------------------------------------------------------------------------
+// FROZEN golden bytes. Derived once from the samples above; never
+// regenerate these from the encoder. A mismatch is a wire-format break.
+//
+// Outer layout (running-process broker framing):
+//   [u8 envelope_version = 1][u32 LE body_len][prost broker_v1 Frame]
+//
+// Frame body (prost, ascending field numbers — deterministic):
+//   field 1 envelope_version  = 1
+//   field 2 kind              = FRAME_KIND_REQUEST (0, omitted) /
+//                               FRAME_KIND_RESPONSE (1)
+//   field 3 payload_protocol  = ZCCACHE_FRAME_PAYLOAD_PROTOCOL (0x7A63 =
+//                               31331, varint 0xE3 0xF4 0x01)
+//   field 4 payload           = raw prost zccache_v1.Request / .Response
+//                               (no inner [len][version] header)
+//   field 5 request_id        = 7
+//   fields 6..9 (payload_encoding NONE, deadline 0, empty trace strings)
+//                               omitted as proto3 defaults
+//
+// Inner zccache_v1 payload:
+//   field 1   ping/pong oneof arm = Empty {}   (tag 0x0A, len 0)
+//   field 100 request_id = "frame-ping"        (tag 0xA2 0x06)
+// ---------------------------------------------------------------------------
+
+#[rustfmt::skip]
+const GOLDEN_REQUEST_FRAME: &[u8] = &[
+    // -- running-process outer framing --
+    0x01,                                       // envelope_version byte = 1
+    0x19, 0x00, 0x00, 0x00,                     // body_len = 25 (u32 LE)
+    // -- broker_v1 Frame --
+    0x08, 0x01,                                 // field 1: envelope_version = 1
+                                                // field 2: kind = REQUEST (0) omitted
+    0x18, 0xE3, 0xF4, 0x01,                     // field 3: payload_protocol = 0x7A63
+    0x22, 0x0F,                                 // field 4: payload, 15 bytes
+        // -- zccache_v1.Request payload --
+        0x0A, 0x00,                             //   field 1: ping = Empty {}
+        0xA2, 0x06, 0x0A,                       //   field 100: request_id, 10 bytes
+        0x66, 0x72, 0x61, 0x6D, 0x65, 0x2D,     //   "frame-"
+        0x70, 0x69, 0x6E, 0x67,                 //   "ping"
+    0x28, 0x07,                                 // field 5: request_id = 7
+];
+
+#[rustfmt::skip]
+const GOLDEN_RESPONSE_FRAME: &[u8] = &[
+    // -- running-process outer framing --
+    0x01,                                       // envelope_version byte = 1
+    0x1B, 0x00, 0x00, 0x00,                     // body_len = 27 (u32 LE)
+    // -- broker_v1 Frame --
+    0x08, 0x01,                                 // field 1: envelope_version = 1
+    0x10, 0x01,                                 // field 2: kind = RESPONSE (1)
+    0x18, 0xE3, 0xF4, 0x01,                     // field 3: payload_protocol = 0x7A63
+    0x22, 0x0F,                                 // field 4: payload, 15 bytes
+        // -- zccache_v1.Response payload --
+        0x0A, 0x00,                             //   field 1: pong = Empty {}
+        0xA2, 0x06, 0x0A,                       //   field 100: request_id, 10 bytes
+        0x66, 0x72, 0x61, 0x6D, 0x65, 0x2D,     //   "frame-"
+        0x70, 0x69, 0x6E, 0x67,                 //   "ping"
+    0x28, 0x07,                                 // field 5: request_id = 7 (echoed)
+];
+
+#[test]
+fn payload_protocol_value_is_frozen_and_collision_free() {
+    use running_process::broker::backend_lifecycle::probe::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL;
+
+    assert_eq!(ZCCACHE_FRAME_PAYLOAD_PROTOCOL, 0x7A63, "ASCII \"zc\"");
+    // The frozen running-process broker registry: 0x00 control (Hello),
+    // 0xAD01 admin, 0xB232 probe, 0xD0FF handoff.
+    assert_ne!(ZCCACHE_FRAME_PAYLOAD_PROTOCOL, 0x0000);
+    assert_ne!(ZCCACHE_FRAME_PAYLOAD_PROTOCOL, 0xAD01);
+    assert_ne!(
+        ZCCACHE_FRAME_PAYLOAD_PROTOCOL,
+        BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL
+    );
+    assert_ne!(ZCCACHE_FRAME_PAYLOAD_PROTOCOL, 0xD0FF);
+}
+
+#[test]
+fn request_frame_encodes_to_golden_bytes() {
+    let wire = encode_frame_v1_request(&sample_ping_request(), SAMPLE_FRAME_REQUEST_ID).unwrap();
+    assert_eq!(&wire[..], GOLDEN_REQUEST_FRAME);
+}
+
+#[test]
+fn response_frame_encodes_to_golden_bytes() {
+    let wire = encode_frame_v1_response(&sample_pong_response(), SAMPLE_FRAME_REQUEST_ID).unwrap();
+    assert_eq!(&wire[..], GOLDEN_RESPONSE_FRAME);
+}
+
+#[test]
+fn golden_request_frame_decodes_to_sample() {
+    let mut buf = BytesMut::from(GOLDEN_REQUEST_FRAME);
+    assert_eq!(buffer_starts_running_process_frame(&buf), Some(true));
+    let decoded = decode_frame_v1_message::<pb::Request>(&mut buf)
+        .unwrap()
+        .unwrap();
+    assert_eq!(decoded.request_id, SAMPLE_FRAME_REQUEST_ID);
+    assert_eq!(decoded.message, sample_ping_request());
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn golden_response_frame_decodes_to_sample() {
+    let mut buf = BytesMut::from(GOLDEN_RESPONSE_FRAME);
+    assert_eq!(buffer_starts_running_process_frame(&buf), Some(true));
+    let decoded = decode_frame_v1_message::<pb::Response>(&mut buf)
+        .unwrap()
+        .unwrap();
+    assert_eq!(decoded.request_id, SAMPLE_FRAME_REQUEST_ID);
+    assert_eq!(decoded.message, sample_pong_response());
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn zccache_v15_and_v16_headers_are_not_mistaken_for_frames() {
+    // v15 bincode and v16 prost frames start with a u32 LE length whose low
+    // byte may be 1 — the disambiguator must still classify them as zccache.
+    let v15 = zccache::protocol::encode_message(&Request::Ping).unwrap();
+    assert_eq!(buffer_starts_running_process_frame(&v15), Some(false));
+
+    let v16 = zccache::protocol::wire_prost::encode_prost_message(&sample_ping_request()).unwrap();
+    assert_eq!(buffer_starts_running_process_frame(&v16), Some(false));
+
+    // A zccache header whose length low byte is exactly the running-process
+    // envelope version (1) — len = 257 ≡ 1 (mod 256) — must stay zccache.
+    let mut ambiguous = vec![0x01, 0x01, 0x00, 0x00];
+    ambiguous.extend_from_slice(&zccache::protocol::PROST_PROTOCOL_VERSION.to_le_bytes());
+    assert_eq!(buffer_starts_running_process_frame(&ambiguous), Some(false));
+
+    // Fewer than 8 buffered bytes starting with 0x01 is still ambiguous.
+    assert_eq!(buffer_starts_running_process_frame(&[0x01, 0x02]), None);
+}
+
+// ---------------------------------------------------------------------------
+// Live IPC round-trips against a real daemon.
+// ---------------------------------------------------------------------------
+
+/// Start an isolated daemon (private cache dir) and return the endpoint,
+/// server task handle, and shutdown notifier.
+fn start_daemon(
+    temp: &tempfile::TempDir,
+) -> (
+    String,
+    tokio::task::JoinHandle<()>,
+    std::sync::Arc<tokio::sync::Notify>,
+) {
+    let endpoint = zccache::ipc::unique_test_endpoint();
+    let cache_dir: zccache::core::NormalizedPath = temp.path().into();
+    let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+    let shutdown = server.shutdown_handle();
+    let handle = tokio::spawn(async move {
+        server.run(0).await.unwrap();
+    });
+    (endpoint, handle, shutdown)
+}
+
+#[tokio::test]
+async fn frame_v1_client_round_trips_control_requests_on_live_daemon() {
+    zccache::test_support::test_timeout(async {
+        let temp = tempfile::tempdir().unwrap();
+        let (endpoint, server_handle, shutdown) = start_daemon(&temp);
+
+        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+
+        // Multiple sequential requests on the same FrameV1 connection.
+        client
+            .send_request(&Request::Ping, WireFormat::FrameV1)
+            .await
+            .unwrap();
+        let response = client.recv_response().await.unwrap();
+        assert_eq!(response, Some(Response::Pong));
+
+        client
+            .send_request(&Request::Status, WireFormat::FrameV1)
+            .await
+            .unwrap();
+        let response = client.recv_response().await.unwrap();
+        let Some(Response::Status(status)) = response else {
+            panic!("expected Status response, got {response:?}");
+        };
+        assert_eq!(status.endpoint, endpoint);
+
+        client
+            .send_request(&Request::Ping, WireFormat::FrameV1)
+            .await
+            .unwrap();
+        let response = client.recv_response().await.unwrap();
+        assert_eq!(response, Some(Response::Pong));
+
+        shutdown.notify_one();
+        server_handle.await.unwrap();
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn frame_v1_response_echoes_client_frame_request_id() {
+    zccache::test_support::test_timeout(async {
+        let temp = tempfile::tempdir().unwrap();
+        let (endpoint, server_handle, shutdown) = start_daemon(&temp);
+
+        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+
+        // Drive the frame correlation id forward, then assert the daemon
+        // echoes the exact id of each request frame.
+        for _ in 0..3 {
+            let frame_request_id = client
+                .send_frame_v1_request(&sample_ping_request())
+                .await
+                .unwrap();
+            // Read the raw frame back so the echoed id is observable.
+            let response: Option<zccache::protocol::DecodedWireMessage<Response, pb::Response>> =
+                client.recv_wire().await.unwrap();
+            match response {
+                Some(zccache::protocol::DecodedWireMessage::FrameV1 {
+                    message,
+                    request_id,
+                }) => {
+                    assert_eq!(request_id, frame_request_id);
+                    assert_eq!(message.request_id, "frame-ping");
+                    assert!(matches!(message.body, Some(pb::response::Body::Pong(_))));
+                }
+                other => panic!("expected FrameV1 Pong response, got {other:?}"),
+            }
+        }
+
+        shutdown.notify_one();
+        server_handle.await.unwrap();
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn mixed_wires_and_backend_probe_coexist_on_one_endpoint() {
+    zccache::test_support::test_timeout(async {
+        let temp = tempfile::tempdir().unwrap();
+        let (endpoint, server_handle, shutdown) = start_daemon(&temp);
+
+        // 1) v15 bincode connection.
+        {
+            let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+            client.send(&Request::Ping).await.unwrap();
+            let response: Option<Response> = client.recv().await.unwrap();
+            assert_eq!(response, Some(Response::Pong));
+        }
+
+        // 2) v16 prost connection.
+        {
+            let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+            client
+                .send_request(&Request::Ping, WireFormat::ProstV16)
+                .await
+                .unwrap();
+            let response = client.recv_response().await.unwrap();
+            assert_eq!(response, Some(Response::Pong));
+        }
+
+        // 3) FrameV1 connection.
+        {
+            let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+            client
+                .send_request(&Request::Ping, WireFormat::FrameV1)
+                .await
+                .unwrap();
+            let response = client.recv_response().await.unwrap();
+            assert_eq!(response, Some(Response::Pong));
+        }
+
+        // 4) running-process BackendHandle identity probe.
+        {
+            let expected = zccache::ipc::current_backend_identity(&endpoint).unwrap();
+            let probe_endpoint = expected.ipc_endpoint.clone();
+            let service_name = tokio::task::spawn_blocking(move || {
+                let handle =
+                    running_process::broker::backend_handle::BackendHandle::probe_with_service(
+                        "zccache",
+                        zccache::core::VERSION,
+                        &probe_endpoint,
+                        &expected,
+                    )
+                    .unwrap();
+                handle.service_name.clone()
+            })
+            .await
+            .unwrap();
+            assert_eq!(service_name, "zccache");
+        }
+
+        // 5) The daemon is still healthy afterwards.
+        {
+            let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+            client
+                .send_request(&Request::Ping, WireFormat::FrameV1)
+                .await
+                .unwrap();
+            let response = client.recv_response().await.unwrap();
+            assert_eq!(response, Some(Response::Pong));
+        }
+
+        shutdown.notify_one();
+        server_handle.await.unwrap();
+    })
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Env selection: `frame` is forced-only.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn frame_env_spelling_is_forced_only() {
+    use zccache::protocol::wire_prost::{
+        client_wire_selection_from_env_value, ClientWireSelection,
+    };
+
+    assert_eq!(
+        client_wire_selection_from_env_value(Some("frame")).unwrap(),
+        ClientWireSelection::FrameV1
+    );
+    assert_eq!(
+        client_wire_selection_from_env_value(Some("frame-v1")).unwrap(),
+        ClientWireSelection::FrameV1
+    );
+    assert_eq!(
+        ClientWireSelection::FrameV1.preferred_format(),
+        WireFormat::FrameV1
+    );
+    assert!(!ClientWireSelection::FrameV1.allows_bincode_fallback());
+    // Auto must NOT prefer the Frame lane.
+    assert_ne!(
+        ClientWireSelection::Auto.preferred_format(),
+        WireFormat::FrameV1
+    );
+}

--- a/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
+++ b/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
@@ -166,13 +166,16 @@ fn bincode_v15_frame_still_roundtrips_on_current_api() {
 #[test]
 fn protocol_version_dispatch_models_v15_and_v16() {
     assert_eq!(
-        wire_format_for_protocol_version(WireFormat::BincodeV15.protocol_version()),
+        wire_format_for_protocol_version(WireFormat::BincodeV15.protocol_version().unwrap()),
         Some(WireFormat::BincodeV15)
     );
     assert_eq!(
-        wire_format_for_protocol_version(WireFormat::ProstV16.protocol_version()),
+        wire_format_for_protocol_version(WireFormat::ProstV16.protocol_version().unwrap()),
         Some(WireFormat::ProstV16)
     );
+    // The Frame lane has no inner zccache protocol-version header; it is
+    // identified by the running-process envelope byte instead.
+    assert_eq!(WireFormat::FrameV1.protocol_version(), None);
     assert_eq!(wire_format_for_protocol_version(99), None);
 }
 


### PR DESCRIPTION
## Summary
- Adds a FrameV1 wire lane registering zccache's `0x7A63` payload protocol via the running-process 4.1.0 backend SDK
- Transports and dispatches zccache requests over FrameV1 end-to-end
- Pins FrameV1 golden bytes and covers mixed-wire daemon scenarios (legacy + FrameV1 coexistence)

Final PR of the staged 4.1.0 adoption stack (after #711, #712). Part of zackees/running-process#383.

## Test plan
- [x] Golden-bytes tests pin the 0x7A63 frame encoding
- [x] Mixed-wire daemon tests cover legacy/FrameV1 coexistence
- [ ] CI green across platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)