### PR TITLE
feat(broker): adopt running-process v1 broker via AsyncBrokerSession

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.1.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b463aaf22bc2a27eb0b7bf347c4aa315075796908f859fbd8bcd469041cfc940"
+checksum = "a216d9a8561599e3aeb48477d7fb404fd852f938808e75e8fad3ad9df2d993e5"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2447,6 +2447,7 @@ dependencies = [
  "sha2",
  "sysinfo 0.30.13",
  "thiserror 2.0.18",
+ "tokio",
  "winapi",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ sevenz-rust = "0.6"
 rkyv = { version = "0.7", features = ["validation"] }
 tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
 mimalloc = "0.1"
-running-process = { version = "4.1.0", default-features = false, features = ["client"] }
+running-process = { version = "4.3.0", default-features = false, features = ["client-async"] }
 zccache = { path = "crates/zccache" }
 zccache-watcher = { path = "crates/zccache-watcher" }
 zccache-cli = { path = "crates/zccache-cli" }

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -237,6 +237,9 @@ fn run_server(args: Args) {
         .expect("failed to create tokio runtime");
 
     let no_depgraph_cache = args.no_depgraph_cache;
+    // Cache root for the v1 CacheManifest published after a successful bind
+    // (zackees/running-process#435); cloned so it survives the async move.
+    let manifest_cache_root = cache_root.clone();
     rt.block_on(async move {
         // ── Issue #640: bind FIRST, then load depgraph in background ─────
         //
@@ -306,6 +309,13 @@ fn run_server(args: Args) {
         }
         if let Err(e) = zccache::ipc::write_backend_identity(&server.backend_identity()) {
             tracing::warn!("failed to write running-process backend identity: {e}");
+        }
+        // Publish the v1 CacheManifest so broker peers can discover this
+        // daemon's cache roots (zackees/running-process#435). Best-effort:
+        // a registry write failure is logged inside publish_manifest and
+        // never blocks startup. Skipped under RUNNING_PROCESS_DISABLE=1.
+        if let Some(path) = zccache::ipc::publish_manifest(&manifest_cache_root) {
+            tracing::debug!(manifest = %path.display(), "published running-process cache manifest");
         }
 
         // Spawn the depgraph load. Holds a `DepGraphSetter` that survives

--- a/crates/zccache/src/cli/commands/service_definition.rs
+++ b/crates/zccache/src/cli/commands/service_definition.rs
@@ -8,13 +8,9 @@
 //! clients connect — the broker connect lane stays opt-in
 //! (`ZCCACHE_BROKER_CONNECT=1`, see `crate::ipc::broker`).
 
-use prost::Message as _;
-use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
-use running_process::broker::server::{
-    ensure_service_definition_dir, service_definition_dir, service_definition_path,
-    validate_service_definition_for_service,
-};
-use std::collections::HashMap;
+use running_process::broker::builders::ServiceDefinitionBuilder;
+use running_process::broker::protocol::ServiceDefinition;
+use running_process::broker::server::service_definition_dir;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -31,6 +27,11 @@ pub(crate) struct InstalledServiceDefinition {
 }
 
 /// Build the zccache daemon service definition for the given daemon binary.
+///
+/// Uses the frozen `ServiceDefinitionBuilder` (zackees/running-process#433):
+/// it defaults the broker-owned boilerplate, validates the absolute binary
+/// path, and produces the same `SHARED_BROKER` definition the daemon answers
+/// `BackendHandle` probes for.
 pub(crate) fn zccache_service_definition(daemon_binary: &Path) -> io::Result<ServiceDefinition> {
     let binary = std::fs::canonicalize(daemon_binary)?;
     let binary_dir = binary.parent().ok_or_else(|| {
@@ -40,27 +41,16 @@ pub(crate) fn zccache_service_definition(daemon_binary: &Path) -> io::Result<Ser
         )
     })?;
 
-    let mut labels = HashMap::new();
-    labels.insert("vendor".to_string(), "zackees".to_string());
-    labels.insert("package".to_string(), "zccache".to_string());
-    labels.insert(
-        "running-process-tracker".to_string(),
-        "zackees/running-process#383".to_string(),
-    );
-
-    let definition = ServiceDefinition {
-        service_name: ZCCACHE_SERVICE_NAME.to_string(),
-        binary_path: binary.display().to_string(),
-        isolation: BrokerIsolation::SharedBroker as i32,
-        explicit_instance: String::new(),
-        per_version_binary_dir: binary_dir.display().to_string(),
-        min_version: crate::core::VERSION.to_string(),
-        version_allow_list: vec![crate::core::VERSION.to_string()],
-        labels,
-    };
-    validate_service_definition_for_service(&definition, ZCCACHE_SERVICE_NAME)
-        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
-    Ok(definition)
+    ServiceDefinitionBuilder::shared_broker(ZCCACHE_SERVICE_NAME, binary.display().to_string())
+        .per_version_binary_dir(binary_dir.display().to_string())
+        .min_version(crate::core::VERSION)
+        .allow_version(crate::core::VERSION)
+        .label("vendor", "zackees")
+        .label("package", "zccache")
+        .label("consumer", "zccache")
+        .label("running-process-tracker", "zackees/running-process#435")
+        .build()
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))
 }
 
 /// Install the service definition into the default running-process
@@ -78,12 +68,30 @@ pub(crate) fn install_service_definition_to_dir(
     daemon_binary: &Path,
 ) -> io::Result<InstalledServiceDefinition> {
     let service_root = service_root.as_ref();
-    ensure_service_definition_dir(service_root).map_err(|err| io::Error::other(err.to_string()))?;
-    let definition = zccache_service_definition(daemon_binary)?;
-    let path = service_definition_path(service_root, ZCCACHE_SERVICE_NAME)
-        .map_err(|err| io::Error::other(err.to_string()))?;
+    let binary = std::fs::canonicalize(daemon_binary)?;
+    let binary_dir = binary.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "zccache-daemon binary path has no parent directory",
+        )
+    })?;
 
-    std::fs::write(&path, definition.encode_to_vec())?;
+    // The builder validates and writes the `.servicedef` atomically into the
+    // service-definition root. Build the definition once for the return value
+    // and once through `install_in` so the persisted bytes are loader-compatible.
+    let definition = zccache_service_definition(daemon_binary)?;
+    let path =
+        ServiceDefinitionBuilder::shared_broker(ZCCACHE_SERVICE_NAME, binary.display().to_string())
+            .per_version_binary_dir(binary_dir.display().to_string())
+            .min_version(crate::core::VERSION)
+            .allow_version(crate::core::VERSION)
+            .label("vendor", "zackees")
+            .label("package", "zccache")
+            .label("consumer", "zccache")
+            .label("running-process-tracker", "zackees/running-process#435")
+            .install_in(service_root)
+            .map_err(|err| io::Error::other(err.to_string()))?;
+
     Ok(InstalledServiceDefinition { path, definition })
 }
 
@@ -129,6 +137,7 @@ pub(crate) fn run_install_servicedef(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use running_process::broker::protocol::BrokerIsolation;
     use running_process::broker::server::ServiceDefinitionLoader;
     use tempfile::TempDir;
 
@@ -158,7 +167,11 @@ mod tests {
                 .labels
                 .get("running-process-tracker")
                 .map(String::as_str),
-            Some("zackees/running-process#383"),
+            Some("zackees/running-process#435"),
+        );
+        assert_eq!(
+            definition.labels.get("consumer").map(String::as_str),
+            Some("zccache"),
         );
     }
 

--- a/crates/zccache/src/ipc/README.md
+++ b/crates/zccache/src/ipc/README.md
@@ -35,10 +35,27 @@ legacy raw-connect probe for older daemons that have not written the identity
 file yet. `RUNNING_PROCESS_DISABLE=1` skips the BackendHandle probe and uses
 that same legacy raw-connect fallback.
 
-`broker.rs` wires `running_process::broker::client::connect_to_backend` in
-front of the daemon client connect (`connect_daemon`). The lane is opt-in
+`broker.rs` wires the frozen
+`running_process::broker::adopt::AsyncBrokerSession::adopt` one-call recipe
+(zackees/running-process#435) in front of the daemon client connect
+(`connect_daemon`). `adopt` runs the Hello negotiation (service_name
+`"zccache"`, protocol min/max = 1, client_lib_name `"running-process"`,
+wanted_version = the zccache daemon version) on a blocking worker and returns
+the broker-selected backend endpoint. The lane is opt-in
 (`ZCCACHE_BROKER_CONNECT=1`, or the upstream TEST-ONLY
-`RUNNING_PROCESS_FAKE_BACKEND` seam); `RUNNING_PROCESS_DISABLE=1` bypasses it
-entirely, and any broker-side failure falls back silently to the direct
-connect. The negotiated connection resolves the endpoint only — the data
-connection still uses zccache's tokio transport and wire lanes unchanged.
+`RUNNING_PROCESS_FAKE_BACKEND` seam, which still dials directly via
+`connect_local_socket`); `RUNNING_PROCESS_DISABLE=1` bypasses it entirely, and
+any broker-side failure falls back silently to the direct connect. Typed
+broker refusals are classified through `RefusalKind` into the local
+`BrokerRefusal` enum (`classify_adopt_error`). The negotiated connection
+resolves the endpoint only — the data connection still uses zccache's tokio
+transport and wire lanes unchanged.
+
+`manifest.rs` publishes the zccache `CacheManifest` into the running-process
+central registry at daemon startup via the frozen `CacheManifestBuilder`
+(zackees/running-process#433), mapping the five zccache cache roots onto the
+v1 `CacheRootKind` taxonomy (artifact→`CacheData`, index→`CacheIndex`,
+log→`CacheLogs`, lock→`CacheLocks`, temp→`CacheTmp`). Publishing is
+best-effort and honors `RUNNING_PROCESS_DISABLE=1`. The companion
+`cli/commands/service_definition.rs` registers the `SHARED_BROKER`
+`ServiceDefinition` through `ServiceDefinitionBuilder::shared_broker`.

--- a/crates/zccache/src/ipc/broker.rs
+++ b/crates/zccache/src/ipc/broker.rs
@@ -1,8 +1,11 @@
 //! Broker-mediated connect lane for the daemon client path.
 //!
-//! Wires `running_process::broker::client::connect_to_backend` in front of
-//! zccache's direct IPC connect (upstream tracking:
-//! zackees/running-process#383). Lane selection precedence:
+//! Wires the frozen `running_process::broker::adopt::AsyncBrokerSession::adopt`
+//! one-call recipe (zackees/running-process#433/#435) in front of zccache's
+//! direct IPC connect. `adopt` runs the Hello negotiation (service_name
+//! `"zccache"`, protocol min/max = 1, client_lib_name `"running-process"`,
+//! wanted_version = the zccache daemon version) on a blocking worker and hands
+//! back the broker-selected backend endpoint. Lane selection precedence:
 //!
 //! 1. `RUNNING_PROCESS_DISABLE=1` — the canonical upstream escape hatch.
 //!    The broker lane (including the fake-backend test seam) is bypassed
@@ -24,9 +27,8 @@
 //! Adopting the negotiated `interprocess` stream as the data connection is
 //! deferred until the broker lane becomes the default.
 
-use running_process::broker::client::{
-    connect_local_socket, connect_to_backend, BackendConnectionRoute, ConnectBackendRequest,
-};
+use running_process::broker::adopt::{AdoptError, AsyncBrokerSession, OwnedConnectRequest};
+use running_process::broker::client::{connect_local_socket, BackendConnectionRoute, RefusalKind};
 
 use super::error::IpcError;
 use super::{connect, running_process_disabled, ClientConnection};
@@ -122,62 +124,138 @@ fn broker_lane_requested() -> bool {
     std::env::var(ZCCACHE_BROKER_CONNECT_ENV).is_ok_and(|value| value == "1")
 }
 
-/// Run broker resolution (blocking, on a worker thread) and return the
-/// resolved endpoint in zccache connect form plus the broker route.
+/// Run broker resolution and return the resolved endpoint in zccache connect
+/// form plus the broker route.
 ///
 /// Returns `None` on any broker-side failure; the caller falls back to the
-/// direct connect. The negotiated stream is dropped here — see the module
-/// docs for why endpoint resolution and the data connection are separate.
+/// direct connect. The negotiated session is dropped here (endpoint resolution
+/// only) — see the module docs for why resolution and the data connection are
+/// separate.
 async fn resolve_backend_endpoint() -> Option<(String, BackendConnectionRoute)> {
-    match tokio::task::spawn_blocking(resolve_backend_endpoint_blocking).await {
-        Ok(resolved) => resolved,
+    // The fake-backend seam dials the endpoint directly, skipping broker
+    // discovery, Hello negotiation, and version checks entirely — matching the
+    // upstream connect_to_backend seam semantics. Kept on a worker thread
+    // because `connect_local_socket` is a blocking dial.
+    if let Some(seam_endpoint) = fake_backend_endpoint_from_env() {
+        return tokio::task::spawn_blocking(move || resolve_fake_backend_seam(&seam_endpoint))
+            .await
+            .unwrap_or_else(|err| {
+                tracing::debug!(error = %err, "fake-backend seam task failed; using direct connect");
+                None
+            });
+    }
+
+    let broker_endpoint = default_broker_endpoint()?;
+    // `AsyncBrokerSession::adopt` is the frozen #433 one-call recipe: it honors
+    // RUNNING_PROCESS_DISABLE=1, runs the Hello negotiation on spawn_blocking,
+    // and hands back the negotiated endpoint + route. We adopt for endpoint
+    // resolution only and drop the session; the data connection is opened with
+    // zccache's own transport (see module docs).
+    let request = OwnedConnectRequest::new(
+        broker_endpoint,
+        "zccache",
+        crate::core::VERSION,
+        crate::core::VERSION,
+    );
+    match AsyncBrokerSession::adopt(request).await {
+        Ok(session) => {
+            let resolved = to_zccache_endpoint(session.endpoint());
+            let route = session.route();
+            // Drop the negotiated frame client; we only needed the endpoint.
+            drop(session);
+            Some((resolved, route))
+        }
+        Err(AdoptError::BrokerDisabled) => {
+            // Belt-and-suspenders: connect_daemon_with_route already checks the
+            // disable hatch before calling us, but adopt re-checks it too.
+            None
+        }
         Err(err) => {
-            tracing::debug!(error = %err, "broker negotiation task failed; using direct connect");
+            log_adopt_failure(&err);
             None
         }
     }
 }
 
-fn resolve_backend_endpoint_blocking() -> Option<(String, BackendConnectionRoute)> {
-    // The fake-backend seam dials the endpoint directly, skipping broker
-    // discovery, Hello negotiation, and version checks entirely — matching
-    // the upstream connect_to_backend seam semantics.
-    if let Some(seam_endpoint) = fake_backend_endpoint_from_env() {
-        return match connect_local_socket(&seam_endpoint) {
-            Ok(stream) => {
-                drop(stream);
-                Some((
-                    to_zccache_endpoint(&seam_endpoint),
-                    BackendConnectionRoute::HelloSkip,
-                ))
-            }
-            Err(err) => {
-                tracing::warn!(
-                    endpoint = %seam_endpoint,
-                    error = %err,
-                    "RUNNING_PROCESS_FAKE_BACKEND endpoint unreachable; using direct connect"
-                );
-                None
-            }
-        };
-    }
-
-    let broker_endpoint = default_broker_endpoint()?;
-    let request = ConnectBackendRequest::new(
-        &broker_endpoint,
-        "zccache",
-        crate::core::VERSION,
-        crate::core::VERSION,
-    );
-    match connect_to_backend(request) {
-        Ok(connection) => Some((to_zccache_endpoint(&connection.endpoint), connection.route)),
+/// Dial the upstream TEST-ONLY fake-backend seam endpoint directly.
+fn resolve_fake_backend_seam(seam_endpoint: &str) -> Option<(String, BackendConnectionRoute)> {
+    match connect_local_socket(seam_endpoint) {
+        Ok(stream) => {
+            drop(stream);
+            Some((
+                to_zccache_endpoint(seam_endpoint),
+                BackendConnectionRoute::HelloSkip,
+            ))
+        }
         Err(err) => {
-            tracing::debug!(
+            tracing::warn!(
+                endpoint = %seam_endpoint,
                 error = %err,
-                "running-process broker negotiation failed; using direct connect"
+                "RUNNING_PROCESS_FAKE_BACKEND endpoint unreachable; using direct connect"
             );
             None
         }
+    }
+}
+
+/// Typed classification of a broker refusal, surfaced for diagnostics and for
+/// callers that want to branch on *why* the broker declined rather than always
+/// falling back silently. zccache always falls back to the direct connect on a
+/// refusal (the broker lane must never make a working build fail), but the
+/// classification is logged and exposed for the diagnostics command.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BrokerRefusal {
+    /// The requested daemon version is below the registered `min_version`.
+    VersionUnsupported,
+    /// The requested daemon version is explicitly blocked (e.g. yanked).
+    VersionBlocked,
+    /// No `zccache.servicedef` is installed for this broker.
+    ServiceUnknown,
+    /// The broker is rate-limiting this peer.
+    RateLimited,
+    /// The broker is shutting down.
+    ShuttingDown,
+    /// Any other refusal code the broker reported.
+    Other,
+}
+
+impl BrokerRefusal {
+    fn from_kind(kind: RefusalKind) -> Self {
+        match kind {
+            RefusalKind::VersionUnsupported => Self::VersionUnsupported,
+            RefusalKind::VersionBlocked => Self::VersionBlocked,
+            RefusalKind::ServiceUnknown => Self::ServiceUnknown,
+            RefusalKind::RateLimited => Self::RateLimited,
+            RefusalKind::ShuttingDown => Self::ShuttingDown,
+            RefusalKind::Other(_) => Self::Other,
+        }
+    }
+}
+
+/// Classify an `AdoptError`, returning the typed refusal when the broker spoke
+/// and declined, or `None` for a dial/IO failure (broker unreachable).
+#[must_use]
+pub fn classify_adopt_error(err: &AdoptError) -> Option<BrokerRefusal> {
+    match err {
+        AdoptError::Connect(connect_err) => {
+            connect_err.refusal_kind().map(BrokerRefusal::from_kind)
+        }
+        _ => None,
+    }
+}
+
+/// Log a broker adoption failure with its typed refusal classification.
+fn log_adopt_failure(err: &AdoptError) {
+    match classify_adopt_error(err) {
+        Some(refusal) => tracing::debug!(
+            ?refusal,
+            error = %err,
+            "running-process broker refused negotiation; using direct connect"
+        ),
+        None => tracing::debug!(
+            error = %err,
+            "running-process broker negotiation failed (unreachable/dial error); using direct connect"
+        ),
     }
 }
 
@@ -490,6 +568,51 @@ mod tests {
             broker_p99 < 1000.0,
             "broker lane p99 {broker_p99:.3}ms exceeded 1000ms budget"
         );
+    }
+
+    #[test]
+    fn classify_adopt_error_maps_typed_refusals() {
+        use running_process::broker::client::BrokerClientError;
+        use running_process::broker::protocol::ErrorCode;
+
+        let refusal = |code: ErrorCode| {
+            AdoptError::Connect(BrokerClientError::Refused {
+                code,
+                reason: "test".to_string(),
+                retry_after_ms: 0,
+            })
+        };
+
+        assert_eq!(
+            classify_adopt_error(&refusal(ErrorCode::ErrorVersionUnsupported)),
+            Some(BrokerRefusal::VersionUnsupported)
+        );
+        assert_eq!(
+            classify_adopt_error(&refusal(ErrorCode::ErrorVersionBlocked)),
+            Some(BrokerRefusal::VersionBlocked)
+        );
+        assert_eq!(
+            classify_adopt_error(&refusal(ErrorCode::ErrorServiceUnknown)),
+            Some(BrokerRefusal::ServiceUnknown)
+        );
+        assert_eq!(
+            classify_adopt_error(&refusal(ErrorCode::ErrorRateLimited)),
+            Some(BrokerRefusal::RateLimited)
+        );
+        assert_eq!(
+            classify_adopt_error(&refusal(ErrorCode::ErrorShuttingDown)),
+            Some(BrokerRefusal::ShuttingDown)
+        );
+        assert_eq!(
+            classify_adopt_error(&refusal(ErrorCode::ErrorPeerRejected)),
+            Some(BrokerRefusal::Other)
+        );
+    }
+
+    #[test]
+    fn classify_adopt_error_returns_none_for_disabled() {
+        // BrokerDisabled is the escape hatch, not a refusal — no classification.
+        assert_eq!(classify_adopt_error(&AdoptError::BrokerDisabled), None);
     }
 
     #[test]

--- a/crates/zccache/src/ipc/manifest.rs
+++ b/crates/zccache/src/ipc/manifest.rs
@@ -1,0 +1,150 @@
+//! Publish the zccache `CacheManifest` into the running-process central
+//! registry (zackees/running-process#435).
+//!
+//! The manifest lets broker peers discover this daemon's cache roots without
+//! probing the daemon. It is built with the frozen `CacheManifestBuilder`
+//! (#433), which stamps the broker-owned boilerplate (media type, schema
+//! version, host identity, timestamps) and seals the `self_sha256` digest on
+//! `publish`. The daemon records the manifest at startup, beside writing its
+//! `BackendHandle` identity (see [`crate::ipc::write_backend_identity`]).
+//!
+//! The manifest records the five cache roots named in the zccache adoption
+//! guide — artifact, index, log, lock, and temp — mapped onto the v1
+//! `CacheRootKind` taxonomy:
+//!
+//! | zccache root | `CacheRootKind` | path source |
+//! |---|---|---|
+//! | artifact | `CacheData` | [`crate::core::config::artifacts_dir_from_cache_dir`] |
+//! | index | `CacheIndex` | depgraph dir under the cache root |
+//! | log | `CacheLogs` | log dir under the cache root |
+//! | lock | `CacheLocks` | the cache root itself (lock/socket/identity live here) |
+//! | temp | `CacheTmp` | [`crate::core::config::tmp_dir_from_cache_dir`] |
+//!
+//! Publishing is best-effort and never blocks daemon startup: a registry write
+//! failure is logged and ignored, exactly like the `BackendHandle` identity
+//! write. `RUNNING_PROCESS_DISABLE=1` skips publishing entirely so the direct
+//! bincode path stays byte-for-byte the pre-adoption behavior.
+
+use std::path::{Path, PathBuf};
+
+use running_process::broker::builders::CacheManifestBuilder;
+use running_process::broker::protocol::CacheRootKind;
+
+use crate::core::NormalizedPath;
+
+/// Service name advertised by the manifest — must match the `ServiceDefinition`
+/// and the `BackendHandle` probe (`crate::ipc::probe_backend_handle`).
+pub const ZCCACHE_SERVICE_NAME: &str = "zccache";
+
+/// Broker instance label for the per-user shared broker.
+const SHARED_BROKER_INSTANCE: &str = "shared";
+
+/// Build the zccache `CacheManifest` for `cache_dir` without persisting it.
+///
+/// Exposed for tests; production code calls [`publish_manifest`].
+#[must_use]
+pub fn build_manifest_builder(cache_dir: &NormalizedPath) -> CacheManifestBuilder {
+    let index_dir = cache_dir.join("depgraph");
+    let log_dir = cache_dir.join("logs");
+    CacheManifestBuilder::new(ZCCACHE_SERVICE_NAME, crate::core::VERSION)
+        .broker_instance(SHARED_BROKER_INSTANCE)
+        .root(
+            CacheRootKind::CacheData,
+            path_string(&crate::core::config::artifacts_dir_from_cache_dir(cache_dir)),
+        )
+        .root(CacheRootKind::CacheIndex, path_string(&index_dir))
+        .root(CacheRootKind::CacheLogs, path_string(&log_dir))
+        // Lock files, the daemon socket, and the running-process identity JSON
+        // all live directly under the cache root.
+        .root(CacheRootKind::CacheLocks, path_string(cache_dir))
+        .root(
+            CacheRootKind::CacheTmp,
+            path_string(&crate::core::config::tmp_dir_from_cache_dir(cache_dir)),
+        )
+}
+
+/// Seal and write the zccache cache manifest into the running-process central
+/// registry. Best-effort: returns the written path on success.
+///
+/// Honors `RUNNING_PROCESS_DISABLE=1` (returns `None` without writing).
+pub fn publish_manifest(cache_dir: &NormalizedPath) -> Option<PathBuf> {
+    if super::running_process_disabled() {
+        return None;
+    }
+    match build_manifest_builder(cache_dir).publish() {
+        Ok(path) => Some(path),
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to publish running-process cache manifest");
+            None
+        }
+    }
+}
+
+/// Seal and write the manifest into an explicit registry dir (tests, custom
+/// layouts). Bypasses the disable hatch so tests stay deterministic.
+pub fn publish_manifest_in(
+    registry_dir: &Path,
+    cache_dir: &NormalizedPath,
+) -> Result<PathBuf, running_process::broker::manifest::ManifestError> {
+    build_manifest_builder(cache_dir).publish_in(registry_dir)
+}
+
+fn path_string(path: &NormalizedPath) -> String {
+    path.as_path().display().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use running_process::broker::manifest::read_manifest;
+    use running_process::broker::protocol::CacheRoot;
+
+    fn roots_by_kind(roots: &[CacheRoot]) -> Vec<(i32, String)> {
+        roots.iter().map(|r| (r.kind, r.path.clone())).collect()
+    }
+
+    #[test]
+    fn manifest_records_all_five_cache_roots() {
+        let cache_dir = NormalizedPath::from("/tmp/zccache-manifest-test");
+        let manifest = build_manifest_builder(&cache_dir)
+            .build()
+            .expect("seal manifest");
+
+        assert_eq!(manifest.service_name, "zccache");
+        assert_eq!(manifest.service_version, crate::core::VERSION);
+        assert_eq!(manifest.broker_instance, "shared");
+
+        let kinds: Vec<i32> = manifest.roots.iter().map(|r| r.kind).collect();
+        assert!(
+            kinds.contains(&(CacheRootKind::CacheData as i32)),
+            "artifact"
+        );
+        assert!(kinds.contains(&(CacheRootKind::CacheIndex as i32)), "index");
+        assert!(kinds.contains(&(CacheRootKind::CacheLogs as i32)), "log");
+        assert!(kinds.contains(&(CacheRootKind::CacheLocks as i32)), "lock");
+        assert!(kinds.contains(&(CacheRootKind::CacheTmp as i32)), "temp");
+        assert_eq!(manifest.roots.len(), 5);
+    }
+
+    #[test]
+    fn publish_round_trips_through_central_registry() {
+        let registry = tempfile::tempdir().expect("tempdir");
+        let cache_dir = NormalizedPath::from("/tmp/zccache-manifest-roundtrip");
+
+        let written = publish_manifest_in(registry.path(), &cache_dir).expect("publish manifest");
+        assert!(written.exists(), "manifest file should exist on disk");
+
+        // read_manifest recomputes the self_sha256 digest, so a successful
+        // load proves the CacheManifestBuilder sealed the manifest correctly.
+        let loaded = read_manifest(&written).expect("read + verify sealed manifest");
+        assert_eq!(loaded.service_name, "zccache");
+
+        let original = roots_by_kind(
+            &build_manifest_builder(&cache_dir)
+                .build()
+                .expect("seal manifest")
+                .roots,
+        );
+        assert_eq!(roots_by_kind(&loaded.roots), original);
+    }
+}

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -8,13 +8,15 @@
 
 pub mod broker;
 pub mod error;
+pub mod manifest;
 pub mod transport;
 
 pub use broker::{
-    connect_daemon, connect_daemon_with_route, to_running_process_endpoint, DaemonConnectRoute,
-    ZCCACHE_BROKER_CONNECT_ENV,
+    connect_daemon, connect_daemon_with_route, to_running_process_endpoint, BrokerRefusal,
+    DaemonConnectRoute, ZCCACHE_BROKER_CONNECT_ENV,
 };
 pub use error::IpcError;
+pub use manifest::{publish_manifest, publish_manifest_in};
 #[cfg(windows)]
 pub use transport::IpcClientConnection;
 pub use transport::{

--- a/crates/zccache/src/protocol/wire_frame.rs
+++ b/crates/zccache/src/protocol/wire_frame.rs
@@ -223,3 +223,112 @@ pub fn decode_frame_v1_message<M: Message + Default>(
         request_id: frame.request_id,
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::wire_prost::zccache_v1;
+
+    /// Build a fixed, deterministic zccache `Lookup` request used as the
+    /// golden-bytes fixture. The contents must never change — if a field is
+    /// added/reordered in `zccache_v1`, the frozen bytes below catch it.
+    fn golden_request() -> zccache_v1::Request {
+        zccache_v1::Request {
+            body: Some(zccache_v1::request::Body::Lookup(zccache_v1::Lookup {
+                cache_key: "golden-cache-key".to_string(),
+            })),
+            request_id: "golden-request-id".to_string(),
+        }
+    }
+
+    /// Golden-bytes freeze for the `0x7A63` Frame lane (zackees/running-process#435).
+    ///
+    /// Encodes a fixed request and asserts the EXACT outer envelope bytes
+    /// (`[u8 envelope_version][u32 LE body_len][prost Frame]`). Any change to
+    /// the running-process `Frame` field layout, the zccache payload protocol
+    /// id, or the `zccache_v1` request encoding will break this — which is the
+    /// point: the wire is a frozen contract once consumers depend on it.
+    #[test]
+    fn frame_v1_request_golden_bytes_are_frozen() {
+        let encoded = encode_frame_v1_request(&golden_request(), 0x0102_0304_0506_0708)
+            .expect("encode golden frame");
+
+        // FROZEN: regenerate ONLY with an intentional, documented wire bump.
+        // These bytes were captured from the running-process v1 `Frame` + the
+        // `zccache_v1::Request` encoder; they are the canonical contract.
+        let expected: &[u8] = &[
+            0x01, // outer envelope_version
+            0x3A, 0x00, 0x00, 0x00, // u32 LE body_len = 58
+            // ── prost Frame body ──
+            0x08, 0x01, // field 1 (envelope_version) = 1
+            // field 2 (kind) = Request (0) is the default and is not serialized
+            0x18, 0xE3, 0xF4, 0x01, // field 3 (payload_protocol) = 0x7A63 (31331)
+            0x22, 0x28, // field 4 (payload), len 40
+            // ── inner zccache_v1::Request prost payload ──
+            0x22, 0x12, // field 4 (Lookup body), len 18
+            0x0A, 0x10, // Lookup.cache_key (field 1), len 16
+            b'g', b'o', b'l', b'd', b'e', b'n', b'-', b'c', b'a', b'c', b'h', b'e', b'-', b'k',
+            b'e', b'y', // "golden-cache-key"
+            0xA2, 0x06, 0x11, // Request.request_id (field 100), len 17
+            b'g', b'o', b'l', b'd', b'e', b'n', b'-', b'r', b'e', b'q', b'u', b'e', b's', b't',
+            b'-', b'i', b'd', // "golden-request-id"
+            0x28, 0x88, 0x8E, 0x98, 0xA8, 0xC0, 0xE0, 0x80, 0x81,
+            0x01, // field 5 (Frame.request_id) u64 = 0x0102030405060708
+        ];
+
+        assert_eq!(
+            encoded.as_ref(),
+            expected,
+            "0x7A63 Frame lane golden bytes changed — wire is frozen; \
+             see zackees/running-process#435"
+        );
+    }
+
+    /// The golden bytes must round-trip back to the original request.
+    #[test]
+    fn frame_v1_golden_round_trips() {
+        let request_id = 0x0102_0304_0506_0708;
+        let mut buf =
+            encode_frame_v1_request(&golden_request(), request_id).expect("encode golden frame");
+
+        assert_eq!(buffer_starts_running_process_frame(&buf), Some(true));
+
+        let decoded: FrameV1Decoded<zccache_v1::Request> = decode_frame_v1_message(&mut buf)
+            .expect("decode")
+            .expect("complete frame");
+        assert_eq!(decoded.request_id, request_id);
+        assert_eq!(decoded.message, golden_request());
+    }
+
+    /// A frame whose payload_protocol is not `0x7A63` is rejected before the
+    /// payload is decoded.
+    #[test]
+    fn frame_v1_rejects_foreign_payload_protocol() {
+        use prost::Message as _;
+        use running_process::broker::protocol::{Frame, FrameKind, PayloadEncoding};
+
+        let frame = Frame {
+            envelope_version: 1,
+            kind: FrameKind::Request as i32,
+            payload_protocol: 0x7001, // not the zccache lane
+            payload: golden_request().encode_to_vec(),
+            request_id: 7,
+            payload_encoding: PayloadEncoding::None as i32,
+            deadline_unix_ms: 0,
+            traceparent: String::new(),
+            tracestate: String::new(),
+        };
+        let body = frame.encode_to_vec();
+        let mut buf = BytesMut::new();
+        buf.put_u8(running_process::broker::protocol::ENVELOPE_VERSION);
+        buf.put_u32_le(u32::try_from(body.len()).unwrap());
+        buf.extend_from_slice(&body);
+
+        let err = decode_frame_v1_message::<zccache_v1::Request>(&mut buf)
+            .expect_err("foreign payload protocol must be rejected");
+        assert!(
+            matches!(err, ProtocolError::Deserialization(msg) if msg.contains("payload_protocol")),
+            "expected a payload_protocol rejection"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Full v1 broker adoption for zccache, tracking zackees/running-process#435.

- **Bump** `running-process` to `4.3.0` (`features = [client-async]`) and replace the raw `connect_to_backend` lane with the frozen `AsyncBrokerSession::adopt` one-call recipe. Hello negotiates `service_name=zccache`, protocol min/max=1, `client_lib_name=running-process`, `wanted_version` = the zccache daemon version; the negotiated endpoint feeds the existing tokio data connection unchanged.
- **ServiceDefinition** is now built through `ServiceDefinitionBuilder::shared_broker` (SHARED_BROKER) instead of the hand-built struct.
- **CacheManifest** (`ipc/manifest.rs`) is published into the running-process central registry at daemon startup via `CacheManifestBuilder`, mapping the five zccache cache roots onto the v1 `CacheRootKind` taxonomy (artifact→`CacheData`, index→`CacheIndex`, log→`CacheLogs`, lock→`CacheLocks`, temp→`CacheTmp`).
- **Typed refusals**: broker `RefusalKind` is classified into a local `BrokerRefusal` enum (`classify_adopt_error`).
- **Wire freeze**: golden-bytes freeze test for the `0x7A63` Frame lane, plus round-trip and foreign-payload-protocol rejection coverage.
- All broker/manifest/servicedef paths are best-effort and honor `RUNNING_PROCESS_DISABLE=1`, which keeps the direct bincode fallback byte-for-byte.

## Test plan

- [x] `soldr cargo test -p zccache --lib -- --test-threads=1` — 1757 passed, 0 failed, 19 ignored
- [x] New golden-bytes / round-trip / foreign-protocol tests green (`protocol::wire_frame::tests::*`)
- [x] New `classify_adopt_error_*` and manifest round-trip tests green
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean
- [x] `soldr cargo fmt --all` applied
- [x] Builds against published `running-process` 4.3.0 from crates.io (no local patch in the committed diff)

Tracks zackees/running-process#435.