### PR TITLE
feat(ipc): adopt the live broker socket via into_backend_io on Unix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a216d9a8561599e3aeb48477d7fb404fd852f938808e75e8fad3ad9df2d993e5"
+checksum = "e0fed77f3564a9728493f29f3c48ef8a85d76508de94fc2bcb2baaea05b58c23"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3866,6 +3866,7 @@ dependencies = [
  "fs2",
  "futures",
  "globset",
+ "interprocess",
  "jwalk",
  "libc",
  "lzma-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ sevenz-rust = "0.6"
 rkyv = { version = "0.7", features = ["validation"] }
 tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
 mimalloc = "0.1"
-running-process = { version = "4.3.0", default-features = false, features = ["client-async"] }
+running-process = { version = "4.4.0", default-features = false, features = ["client-async"] }
 zccache = { path = "crates/zccache" }
 zccache-watcher = { path = "crates/zccache-watcher" }
 zccache-cli = { path = "crates/zccache-cli" }

--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -111,6 +111,10 @@ windows-sys = { version = "0.59", features = [
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+# Spike-only (broker_into_backend_io_spike_test): bind a running-process broker
+# listener directly. Pinned to the version already locked transitively via
+# running-process so no new resolution occurs.
+interprocess = "2.4.2"
 # Self-dep so zccache's own integration tests can pull in the gated
 # test_support module without needing a separate workspace member.
 zccache = { path = ".", features = ["test-support"] }

--- a/crates/zccache/src/ipc/broker.rs
+++ b/crates/zccache/src/ipc/broker.rs
@@ -20,17 +20,23 @@
 //!    previously-working build fail.
 //! 4. Default — direct connect, byte-for-byte the pre-adoption behavior.
 //!
-//! The negotiated (or seam) connection is consumed for **endpoint
-//! resolution only**; the data connection is then opened with zccache's
-//! own tokio transport so recv timeouts, the Windows named-pipe client
-//! backoff, and the v15/v16/FrameV1 wire lanes keep working unchanged.
-//! Adopting the negotiated `interprocess` stream as the data connection is
-//! deferred until the broker lane becomes the default.
+//! On the production broker lane (Unix), the live negotiated socket handed
+//! back by [`AsyncBrokerSession::into_backend_io`] is **adopted directly** as
+//! the data connection — no re-dial. The adopted socket is byte-identical to a
+//! fresh `connect()` stream (the broker hands back a `backend_pipe` the client
+//! dials itself), so recv timeouts and the v15/v16/FrameV1 wire lanes keep
+//! working unchanged. On Windows `into_backend_io` is unsupported (the
+//! `OwnedHandle` handoff is deferred, running-process #720), so the resolved
+//! endpoint is re-dialed with zccache's own transport (resolve-and-drop). The
+//! TEST-ONLY fake-backend seam also stays resolve-and-drop: it dials a raw
+//! socket with no Hello negotiation, so there is no live session to adopt.
 
 use running_process::broker::adopt::{AdoptError, AsyncBrokerSession, OwnedConnectRequest};
 use running_process::broker::client::{connect_local_socket, BackendConnectionRoute, RefusalKind};
 
 use super::error::IpcError;
+#[cfg(unix)]
+use super::IpcConnection;
 use super::{connect, running_process_disabled, ClientConnection};
 
 /// Upstream TEST-ONLY seam: a non-empty value short-circuits the broker
@@ -87,25 +93,22 @@ pub async fn connect_daemon_with_route(
         return Ok((conn, DaemonConnectRoute::Direct));
     }
 
-    if let Some((resolved, route)) = resolve_backend_endpoint().await {
-        match connect(&resolved).await {
-            Ok(conn) => {
-                return Ok((
-                    conn,
-                    DaemonConnectRoute::Broker {
-                        route,
-                        endpoint: resolved,
-                    },
-                ));
-            }
-            Err(err) => {
-                tracing::debug!(
-                    resolved_endpoint = %resolved,
-                    error = %err,
-                    "broker-resolved endpoint unreachable; falling back to direct connect"
-                );
+    // Fake-backend test seam keeps resolve-and-drop + re-dial: it dials a raw
+    // socket with no Hello negotiation, so there is no live session to adopt.
+    if let Some(seam_endpoint) = fake_backend_endpoint_from_env() {
+        if let Some((resolved, route)) = resolve_fake_backend_seam_async(seam_endpoint).await {
+            if let Some(result) = redial_resolved(route, resolved).await {
+                return Ok(result);
             }
         }
+        let conn = connect(endpoint).await?;
+        return Ok((conn, DaemonConnectRoute::Direct));
+    }
+
+    // Production broker lane: adopt the live negotiated socket as the data
+    // connection (Unix) instead of resolve-and-drop. See the module docs.
+    if let Some(result) = connect_via_broker().await {
+        return Ok(result);
     }
 
     let conn = connect(endpoint).await?;
@@ -124,57 +127,135 @@ fn broker_lane_requested() -> bool {
     std::env::var(ZCCACHE_BROKER_CONNECT_ENV).is_ok_and(|value| value == "1")
 }
 
-/// Run broker resolution and return the resolved endpoint in zccache connect
-/// form plus the broker route.
+/// Negotiate with the shared broker and return a ready data connection.
+///
+/// `AsyncBrokerSession::adopt` is the frozen one-call recipe: it honors
+/// RUNNING_PROCESS_DISABLE=1, runs the Hello negotiation on spawn_blocking,
+/// and hands back the negotiated session. On Unix the live socket is adopted
+/// directly via [`AsyncBrokerSession::into_backend_io`]; on Windows (no
+/// `into_backend_io` yet) the resolved endpoint is re-dialed.
 ///
 /// Returns `None` on any broker-side failure; the caller falls back to the
-/// direct connect. The negotiated session is dropped here (endpoint resolution
-/// only) — see the module docs for why resolution and the data connection are
-/// separate.
-async fn resolve_backend_endpoint() -> Option<(String, BackendConnectionRoute)> {
-    // The fake-backend seam dials the endpoint directly, skipping broker
-    // discovery, Hello negotiation, and version checks entirely — matching the
-    // upstream connect_to_backend seam semantics. Kept on a worker thread
-    // because `connect_local_socket` is a blocking dial.
-    if let Some(seam_endpoint) = fake_backend_endpoint_from_env() {
-        return tokio::task::spawn_blocking(move || resolve_fake_backend_seam(&seam_endpoint))
-            .await
-            .unwrap_or_else(|err| {
-                tracing::debug!(error = %err, "fake-backend seam task failed; using direct connect");
-                None
-            });
-    }
-
+/// direct connect.
+async fn connect_via_broker() -> Option<(ClientConnection, DaemonConnectRoute)> {
     let broker_endpoint = default_broker_endpoint()?;
-    // `AsyncBrokerSession::adopt` is the frozen #433 one-call recipe: it honors
-    // RUNNING_PROCESS_DISABLE=1, runs the Hello negotiation on spawn_blocking,
-    // and hands back the negotiated endpoint + route. We adopt for endpoint
-    // resolution only and drop the session; the data connection is opened with
-    // zccache's own transport (see module docs).
     let request = OwnedConnectRequest::new(
         broker_endpoint,
         "zccache",
         crate::core::VERSION,
         crate::core::VERSION,
     );
-    match AsyncBrokerSession::adopt(request).await {
-        Ok(session) => {
-            let resolved = to_zccache_endpoint(session.endpoint());
-            let route = session.route();
-            // Drop the negotiated frame client; we only needed the endpoint.
-            drop(session);
-            Some((resolved, route))
-        }
-        Err(AdoptError::BrokerDisabled) => {
-            // Belt-and-suspenders: connect_daemon_with_route already checks the
-            // disable hatch before calling us, but adopt re-checks it too.
-            None
-        }
+    let session = match AsyncBrokerSession::adopt(request).await {
+        Ok(session) => session,
+        // Belt-and-suspenders: connect_daemon_with_route already checks the
+        // disable hatch before calling us, but adopt re-checks it too.
+        Err(AdoptError::BrokerDisabled) => return None,
         Err(err) => {
             log_adopt_failure(&err);
+            return None;
+        }
+    };
+
+    let route = session.route();
+    let resolved = to_zccache_endpoint(session.endpoint());
+    adopt_session_connection(session, route, resolved).await
+}
+
+/// Adopt the negotiated session's live socket as the data connection.
+#[cfg(unix)]
+async fn adopt_session_connection(
+    session: AsyncBrokerSession,
+    route: BackendConnectionRoute,
+    resolved: String,
+) -> Option<(ClientConnection, DaemonConnectRoute)> {
+    match session.into_backend_io() {
+        Ok(io) => match unix_connection_from_backend_io(io) {
+            Ok(conn) => Some((
+                conn,
+                DaemonConnectRoute::Broker {
+                    route,
+                    endpoint: resolved,
+                },
+            )),
+            Err(err) => {
+                tracing::debug!(
+                    error = %err,
+                    "adopting broker backend socket failed; re-dialing resolved endpoint"
+                );
+                redial_resolved(route, resolved).await
+            }
+        },
+        Err(err) => {
+            tracing::debug!(
+                error = %err,
+                "into_backend_io declined the live socket; re-dialing resolved endpoint"
+            );
+            redial_resolved(route, resolved).await
+        }
+    }
+}
+
+/// Windows has no `into_backend_io` yet (OwnedHandle handoff deferred,
+/// running-process #720), so keep resolve-and-drop + re-dial.
+#[cfg(windows)]
+async fn adopt_session_connection(
+    session: AsyncBrokerSession,
+    route: BackendConnectionRoute,
+    resolved: String,
+) -> Option<(ClientConnection, DaemonConnectRoute)> {
+    drop(session);
+    redial_resolved(route, resolved).await
+}
+
+/// Wrap the adopted `OwnedFd` as a tokio-backed `IpcConnection`.
+#[cfg(unix)]
+fn unix_connection_from_backend_io(
+    io: running_process::broker::adopt::OwnedBackendIo,
+) -> Result<IpcConnection, IpcError> {
+    let fd = io.into_owned_fd();
+    let std_stream = std::os::unix::net::UnixStream::from(fd);
+    std_stream.set_nonblocking(true)?;
+    let stream = tokio::net::UnixStream::from_std(std_stream)?;
+    Ok(IpcConnection::from_unix_stream(stream))
+}
+
+/// Re-dial a broker-resolved endpoint with zccache's own transport, reporting
+/// the broker route on success. Returns `None` if the endpoint is unreachable.
+async fn redial_resolved(
+    route: BackendConnectionRoute,
+    resolved: String,
+) -> Option<(ClientConnection, DaemonConnectRoute)> {
+    match connect(&resolved).await {
+        Ok(conn) => Some((
+            conn,
+            DaemonConnectRoute::Broker {
+                route,
+                endpoint: resolved,
+            },
+        )),
+        Err(err) => {
+            tracing::debug!(
+                resolved_endpoint = %resolved,
+                error = %err,
+                "broker-resolved endpoint unreachable; falling back to direct connect"
+            );
             None
         }
     }
+}
+
+/// Dial the upstream TEST-ONLY fake-backend seam on a worker thread.
+///
+/// `connect_local_socket` is a blocking dial, so it runs on `spawn_blocking`.
+async fn resolve_fake_backend_seam_async(
+    seam_endpoint: String,
+) -> Option<(String, BackendConnectionRoute)> {
+    tokio::task::spawn_blocking(move || resolve_fake_backend_seam(&seam_endpoint))
+        .await
+        .unwrap_or_else(|err| {
+            tracing::debug!(error = %err, "fake-backend seam task failed; using direct connect");
+            None
+        })
 }
 
 /// Dial the upstream TEST-ONLY fake-backend seam endpoint directly.

--- a/crates/zccache/src/ipc/transport.rs
+++ b/crates/zccache/src/ipc/transport.rs
@@ -928,14 +928,27 @@ async fn create_replacement_pipe_with_retry(
 #[cfg(unix)]
 pub async fn connect(endpoint: &str) -> Result<IpcConnection, IpcError> {
     let stream = tokio::net::UnixStream::connect(endpoint).await?;
-    let (reader, writer) = tokio::io::split(stream);
-    Ok(IpcConnection {
-        reader,
-        writer,
-        read_buf: BytesMut::with_capacity(4096),
-        recv_timeout: None,
-        next_frame_request_id: 1,
-    })
+    Ok(IpcConnection::from_unix_stream(stream))
+}
+
+#[cfg(unix)]
+impl IpcConnection {
+    /// Wrap an already-connected `UnixStream` as an `IpcConnection`.
+    ///
+    /// The broker lane uses this to adopt the live socket handed back by
+    /// `running_process::broker::adopt::AsyncBrokerSession::into_backend_io`
+    /// instead of re-dialing the endpoint, so the negotiated connection is
+    /// reused as the data connection.
+    pub fn from_unix_stream(stream: tokio::net::UnixStream) -> Self {
+        let (reader, writer) = tokio::io::split(stream);
+        IpcConnection {
+            reader,
+            writer,
+            read_buf: BytesMut::with_capacity(4096),
+            recv_timeout: None,
+            next_frame_request_id: 1,
+        }
+    }
 }
 
 /// Connect to an IPC endpoint as a client.

--- a/crates/zccache/tests/broker_into_backend_io_spike_test.rs
+++ b/crates/zccache/tests/broker_into_backend_io_spike_test.rs
@@ -1,0 +1,251 @@
+//! BOUNDED EMPIRICAL SPIKE (Unix-only): does the live socket handed back by
+//! `running_process::broker::adopt::AsyncBrokerSession::into_backend_io()`
+//! carry zccache's FrameV1 application protocol through to a real zccache
+//! `DaemonServer`, so a `Ping` gets a `Pong`?
+//!
+//! Arrangement (closest faithful to a real broker fronting the real daemon):
+//!   * A real zccache `DaemonServer` binds its own Unix socket and serves the
+//!     normal daemon wire (FrameV1 included), exactly as in production.
+//!   * A real running-process broker (`HelloHandler` + `handle_hello_connection`,
+//!     copied verbatim from running-process 4.4.0
+//!     `tests/broker/into_backend_io.rs`) registers that daemon socket as the
+//!     negotiated `backend_pipe`. This is the `BrokerNegotiated` route: the
+//!     broker tells the client the backend endpoint, the client dials it, and
+//!     `into_backend_io()` hands back THAT live socket. The broker never itself
+//!     connects to the daemon, so the adopted connection is the client's first
+//!     and only connection to the daemon.
+//!   * Client: `AsyncBrokerSession::adopt(...)` -> `into_backend_io()` ->
+//!     `OwnedFd` -> `tokio::net::UnixStream` -> `IpcConnection::from_unix_stream`
+//!     -> FrameV1 `Ping` -> assert `Pong`.
+//!
+//! We do NOT use the lower-level `serve_registered_backend(BrokerServeConfig)`
+//! serve loop because it requires an on-disk `<service>.servicedef` file and
+//! probes the backend identity first. `HelloHandler::with_backend` carries the
+//! `ServiceDefinition` inline and skips the probe, which is the minimal faithful
+//! broker that fronts an external backend socket.
+
+#![cfg(unix)]
+
+use std::io;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use interprocess::local_socket::traits::Listener as _;
+use interprocess::local_socket::ListenerOptions;
+use running_process::broker::adopt::{AsyncBrokerSession, OwnedConnectRequest};
+use running_process::broker::client::BackendConnectionRoute;
+use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
+use running_process::broker::server::{
+    handle_hello_connection, local_socket_name, HelloHandler, PeerIdentity, RegisteredBackend,
+};
+
+use zccache::daemon::DaemonServer;
+use zccache::protocol::wire_prost::WireFormat;
+use zccache::protocol::{Request, Response};
+
+const SPIKE_SERVICE: &str = "zccache";
+
+// ── socket_common helpers, copied from running-process 4.4.0 tests ──────────
+
+fn unique_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+}
+
+/// Build a short unique Unix socket path (must fit in `sun_path`, ~104 bytes).
+fn unique_socket_name(label: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    label.hash(&mut hasher);
+    let label_hash = hasher.finish() as u32;
+    let short_suffix = unique_suffix() % 1_000_000_000;
+    std::env::temp_dir()
+        .join(format!(
+            "zcb-{label_hash:08x}-{}-{short_suffix}.sock",
+            std::process::id()
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn prepare_test_socket(socket_name: &str) {
+    let path = std::path::Path::new(socket_name);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::remove_file(path);
+}
+
+fn bind_ready_test_socket(
+    socket_name: &str,
+    ready_tx: &mpsc::Sender<Result<(), String>>,
+) -> io::Result<interprocess::local_socket::Listener> {
+    prepare_test_socket(socket_name);
+    let name = match local_socket_name(socket_name) {
+        Ok(name) => name,
+        Err(err) => {
+            let _ = ready_tx.send(Err(err.to_string()));
+            return Err(err);
+        }
+    };
+    match ListenerOptions::new().name(name).create_sync() {
+        Ok(listener) => {
+            ready_tx.send(Ok(())).unwrap();
+            Ok(listener)
+        }
+        Err(err) => {
+            let _ = ready_tx.send(Err(err.to_string()));
+            Err(err)
+        }
+    }
+}
+
+fn await_test_socket_ready(ready_rx: &mpsc::Receiver<Result<(), String>>, display_path: &str) {
+    match ready_rx.recv_timeout(Duration::from_secs(3)) {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => panic!("failed to bind test socket {display_path}: {err}"),
+        Err(err) => panic!("timed out waiting for test socket {display_path}: {err}"),
+    }
+}
+
+// ── Broker: negotiate one Hello, point client at the zccache daemon socket ──
+
+fn zccache_service_definition(version: &str) -> ServiceDefinition {
+    ServiceDefinition {
+        service_name: SPIKE_SERVICE.into(),
+        binary_path: "/usr/local/bin/zccache".into(),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: String::new(),
+        min_version: version.into(),
+        version_allow_list: vec![version.into()],
+        labels: Default::default(),
+    }
+}
+
+/// Spawn a real running-process broker that negotiates one Hello and returns
+/// `daemon_socket` as the negotiated backend endpoint. Copied from
+/// running-process 4.4.0 `tests/broker/into_backend_io.rs::spawn_broker`.
+fn spawn_broker(
+    broker_socket: String,
+    daemon_socket: String,
+    version: String,
+) -> thread::JoinHandle<io::Result<()>> {
+    let display = broker_socket.clone();
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let listener = bind_ready_test_socket(&broker_socket, &ready_tx)?;
+        let handler = HelloHandler::new()
+            .with_backend(RegisteredBackend {
+                service_definition: zccache_service_definition(&version),
+                daemon_version: version.clone(),
+                backend_pipe: daemon_socket.clone(),
+                server_capabilities: 0x01,
+            })
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        let mut stream = listener.accept()?;
+        let peer = PeerIdentity {
+            pid: std::process::id(),
+            uid_or_sid: "zccache-peer".into(),
+        };
+        handle_hello_connection(&mut stream, &handler, peer)
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        let _ = std::fs::remove_file(&broker_socket);
+        Ok(())
+    });
+    await_test_socket_ready(&ready_rx, &display);
+    handle
+}
+
+/// Start an isolated real zccache daemon, returning its endpoint + shutdown.
+fn start_daemon(
+    temp: &tempfile::TempDir,
+) -> (
+    String,
+    tokio::task::JoinHandle<()>,
+    std::sync::Arc<tokio::sync::Notify>,
+) {
+    let endpoint = zccache::ipc::unique_test_endpoint();
+    let cache_dir: zccache::core::NormalizedPath = temp.path().into();
+    let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+    let shutdown = server.shutdown_handle();
+    let handle = tokio::spawn(async move {
+        server.run(0).await.unwrap();
+    });
+    (endpoint, handle, shutdown)
+}
+
+#[tokio::test]
+async fn into_backend_io_socket_pings_real_zccache_daemon() {
+    let version = zccache::core::VERSION.to_string();
+
+    // 1) Real zccache daemon on its own socket.
+    let temp = tempfile::tempdir().unwrap();
+    let (daemon_endpoint, server_handle, shutdown) = start_daemon(&temp);
+
+    // 2) Real running-process broker registering that socket as the backend.
+    let broker_socket = unique_socket_name("zc-broker");
+    let broker = spawn_broker(
+        broker_socket.clone(),
+        daemon_endpoint.clone(),
+        version.clone(),
+    );
+
+    // 3) Adopt through the broker -> take the live negotiated socket.
+    let request = OwnedConnectRequest::new(
+        broker_socket.clone(),
+        SPIKE_SERVICE,
+        version.as_str(),
+        version.as_str(),
+    );
+    let session = AsyncBrokerSession::adopt(request)
+        .await
+        .expect("broker session adopt");
+    assert_eq!(
+        session.route(),
+        BackendConnectionRoute::BrokerNegotiated,
+        "expected the broker-negotiated route (client dials the registered backend)"
+    );
+    assert_eq!(
+        session.endpoint(),
+        daemon_endpoint,
+        "negotiated endpoint must be the zccache daemon socket"
+    );
+
+    // OwnedFd -> std UnixStream -> nonblocking -> tokio UnixStream ->
+    // IpcConnection::from_unix_stream.
+    let fd = session
+        .into_backend_io()
+        .expect("into_backend_io on unix")
+        .into_owned_fd();
+    let std_stream = std::os::unix::net::UnixStream::from(fd);
+    std_stream
+        .set_nonblocking(true)
+        .expect("set nonblocking on adopted socket");
+    let tokio_stream =
+        tokio::net::UnixStream::from_std(std_stream).expect("tokio UnixStream from adopted socket");
+    let mut client = zccache::ipc::IpcConnection::from_unix_stream(tokio_stream);
+
+    // 4) Speak zccache's FrameV1 wire over the adopted socket and expect Pong.
+    client
+        .send_request(&Request::Ping, WireFormat::FrameV1)
+        .await
+        .expect("send FrameV1 Ping over adopted socket");
+    let response = client
+        .recv_response_with_timeout(Duration::from_secs(5))
+        .await
+        .expect("recv response over adopted socket");
+    assert_eq!(
+        response,
+        Some(Response::Pong),
+        "adopted broker socket must carry zccache FrameV1 Ping->Pong to the real daemon"
+    );
+
+    drop(client);
+    shutdown.notify_one();
+    server_handle.await.unwrap();
+    broker.join().unwrap().unwrap();
+}


### PR DESCRIPTION
## Summary
- The opt-in broker lane now **adopts the live negotiated socket** handed back by `running_process::broker::adopt::AsyncBrokerSession::into_backend_io()` (new in running-process 4.4.0) instead of the old resolve-and-drop + re-dial. On Unix the adopted `OwnedFd` is wrapped through a new `IpcConnection::from_unix_stream` seam.
- The adopted socket is byte-identical to a fresh `connect()` stream (the broker returns a `backend_pipe` the client dials itself), so recv timeouts and the v15/v16/FrameV1 wire lanes are unchanged and **the daemon needs no changes** — this is a CLI-only migration.
- Windows keeps resolve-and-drop until `into_backend_io` grows an `OwnedHandle` path (running-process #720). The TEST-ONLY fake-backend seam also stays resolve-and-drop (it dials a raw socket with no live session to adopt).
- Bumps the workspace `running-process` dependency `4.3.0 -> 4.4.0`.

## Spike / empirical gate
Adds a Unix-only integration test `crates/zccache/tests/broker_into_backend_io_spike_test.rs` that stands up a **real** running-process broker (`HelloHandler` + `handle_hello_connection`) fronting a **real** zccache `DaemonServer`, adopts the live socket through `into_backend_io()`, and asserts a FrameV1 `Ping -> Pong`. This is the empirical proof that the adopted socket carries zccache's application protocol end-to-end. It runs on the Linux/macOS CI lanes (no-op on Windows, where `into_backend_io` returns `WindowsUnsupported`).

## Test plan
- [x] `soldr cargo check -p zccache --lib` (Windows) — clean
- [x] `soldr cargo test -p zccache --lib ipc::broker` (Windows) — 8/8 pass (existing broker lane unit tests, incl. fake-seam + fallback paths)
- [x] `soldr cargo clippy -p zccache --lib --tests -- -D warnings` (Windows) — clean
- [x] `soldr cargo fmt --all -- --check` — clean
- [ ] CI Linux/macOS: `broker_into_backend_io_spike_test::into_backend_io_socket_pings_real_zccache_daemon` (the live-adoption empirical gate; cannot run on the Windows dev host)

Refs #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)