### PR TITLE
chore(release): bump 1.11.22 -> 1.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.11.22"
+version = "1.12.0"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.11.22"
+version = "1.12.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.11.22"
+version = "1.12.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.11.22"
+version = "1.12.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.11.22"
+version = "1.12.0"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump `[workspace.package].version` from 1.11.22 -> **1.12.0** (minor).
- Regenerate `Cargo.lock` for the four workspace crates that carry the workspace version.

Merging this to `main` triggers `release-auto.yml` (`detect-bump` sees the version change) and publishes:
- PyPI wheel (Trusted Publishing)
- crates.io crates
- GitHub release

This is the first leg of the broker-adoption rollout: cut 1.12.0 so `fbuild` and `soldr` can bump their zccache dependency and be exercised in parallel against a single shared daemon through the running-process broker.

## Test plan
- [x] `cargo update -p zccache --precise 1.12.0` produced a clean lockfile (only version strings changed)
- [x] Diff limited to `Cargo.toml` + `Cargo.lock`
- [ ] CI green