### PR TITLE
fix(wedge): widen wedge budget + dedupe shutdown log under burst link load (#726)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.12.1"
+version = "1.12.2"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/crates/zccache/src/cli/mod.rs
+++ b/crates/zccache/src/cli/mod.rs
@@ -26,12 +26,19 @@ pub(crate) fn status_probe_timeout() -> std::time::Duration {
 }
 
 /// Default per-call timeout for Compile/Link recv before treating the daemon
-/// as wedged and triggering recovery (issue #666). Ninety seconds covers any
-/// reasonable single-TU compile (FastLED's heaviest unity-ish TU finishes
-/// well under 60 s on the slowest supported Windows runner) while bounding
-/// the per-worker wait when the daemon stops servicing the IPC. The pre-#666
-/// behavior was the 300 s global `DEFAULT_CLIENT_RECV_TIMEOUT`; under a wedge,
-/// every parallel ninja job paid the full window.
+/// as wedged and triggering recovery (issue #666). The pre-#666 behavior was
+/// the 300 s global `DEFAULT_CLIENT_RECV_TIMEOUT`; under a wedge, every
+/// parallel ninja job paid the full window.
+///
+/// Budget was widened from 90 s → 180 s in issue #726. Under FastLED's
+/// `all-with-examples` ninja target (~341 link TUs over a ~150 s wall window),
+/// the 90 s ceiling tripped for *healthy* daemons that were simply bottlenecked
+/// behind the burst — the client then sent `Request::Shutdown`, killed the
+/// daemon mid-work, and triggered a thundering-herd respawn. 180 s preserves
+/// wedge detection (real wedges show up as recv stalls measured in minutes,
+/// not seconds) while leaving headroom for legitimate burst link loads on a
+/// busy daemon. The 300 s pre-#666 behavior is still recoverable via the env
+/// var override.
 ///
 /// On timeout the wrapper force-kills the wedged daemon via
 /// `stop_stale_daemon`, ensures a fresh one is spawned, and retries the
@@ -42,7 +49,7 @@ pub(crate) fn status_probe_timeout() -> std::time::Duration {
 ///
 /// Overridable via `ZCCACHE_WEDGE_RECV_TIMEOUT_SECS`; set to `0` to disable
 /// the wedge detection entirely and keep the historical 300 s behavior.
-const WEDGE_RECV_DEFAULT_SECS: u64 = 90;
+const WEDGE_RECV_DEFAULT_SECS: u64 = 180;
 
 /// Returns the wedge-detection recv timeout for Compile/Link calls. `None`
 /// means "disabled" (the env var was set to `0`). See [`WEDGE_RECV_DEFAULT_SECS`].

--- a/crates/zccache/src/daemon/server/connection.rs
+++ b/crates/zccache/src/daemon/server/connection.rs
@@ -169,13 +169,23 @@ pub(super) async fn handle_connection(
                 // reconstructs the daemon's full lifetime. Pairs with
                 // EVENT_DIED_IDLE for unattended exits and the CLI's
                 // EVENT_SPAWN_ATTEMPT for the matching start side.
-                super::super::lifecycle::write_event(
-                    super::super::lifecycle::EVENT_DIED_SHUTDOWN,
-                    serde_json::json!({
-                        "reason": super::super::lifecycle::REASON_GRACEFUL_SHUTDOWN,
-                        "uptime_secs": now_secs().saturating_sub(state.start_time),
-                    }),
-                );
+                //
+                // Under burst load (issue #726) many wedge-detecting clients
+                // race to send Shutdown within a few ms; gate the write with
+                // a CAS so only the first writes — without this, we observed
+                // 25+ duplicate rows for a single death in production logs.
+                if !state
+                    .shutdown_event_logged
+                    .swap(true, std::sync::atomic::Ordering::AcqRel)
+                {
+                    super::super::lifecycle::write_event(
+                        super::super::lifecycle::EVENT_DIED_SHUTDOWN,
+                        serde_json::json!({
+                            "reason": super::super::lifecycle::REASON_GRACEFUL_SHUTDOWN,
+                            "uptime_secs": now_secs().saturating_sub(state.start_time),
+                        }),
+                    );
+                }
                 state.shutdown.notify_one();
                 return Ok(());
             }

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -170,6 +170,7 @@ impl DaemonServer {
                 index_writer_tx,
                 index_writer_shutdown,
                 artifacts_loaded: AtomicBool::new(false),
+                shutdown_event_logged: AtomicBool::new(false),
                 fingerprint: FingerprintManager::new(),
                 dep_graph_persisted: AtomicBool::new(false),
                 depgraph_load_warning: Mutex::new(None),

--- a/crates/zccache/src/daemon/server/state.rs
+++ b/crates/zccache/src/daemon/server/state.rs
@@ -152,6 +152,13 @@ pub(super) struct SharedState {
     pub(super) index_writer_shutdown: Arc<Notify>,
     /// Whether the background artifact loading has completed.
     pub(super) artifacts_loaded: AtomicBool,
+    /// Whether the `died-shutdown` lifecycle event has been written for this
+    /// daemon. Under burst load (issue #726), many wedge-detecting clients
+    /// race to send `Request::Shutdown` within a few milliseconds and each
+    /// connection handler would otherwise write the same event — 25+ duplicate
+    /// rows for a single death observed. Guard the write with a compare-and-swap
+    /// so only the first Shutdown handler logs.
+    pub(super) shutdown_event_logged: AtomicBool,
     /// Fingerprint manager: tracks per-watch dirty state for `zccache fp` commands.
     pub(super) fingerprint: FingerprintManager,
     /// Whether the in-memory dep graph is backed by a persisted snapshot.


### PR DESCRIPTION
## Summary

Two related fixes for the FastLED `all-with-examples` burst-link scenario surfaced in #726:

### 1. `WEDGE_RECV_DEFAULT_SECS` 90s -> 180s

The 90s ceiling tripped for *healthy* daemons that were simply bottlenecked behind a burst of concurrent link TUs. Daemon log evidence in #726: `died-shutdown reason=graceful-shutdown uptime_secs=120` fired in the middle of active compile/link work, killed by the client wedge guard via `Request::Shutdown` — not a true wedge, just a slow recv on a busy daemon. 180s preserves wedge detection for real failures (#666/#724 patterns show stalls measured in minutes) while leaving headroom for legitimate burst link loads.

`ZCCACHE_WEDGE_RECV_TIMEOUT_SECS` override still works; setting it to `0` still restores the pre-#666 300s behavior.

### 2. Dedupe `died-shutdown` lifecycle writes

Under the same burst, many wedge-detecting clients raced to send `Request::Shutdown` within ~15 ms. Each connection handler wrote the same `died-shutdown` row, producing **25+ duplicate entries** for a single daemon death in production logs. Now gated by CAS on a new `shutdown_event_logged: AtomicBool` on `SharedState` so only the first Shutdown handler writes.

Bumps workspace to **1.12.2** so `release-auto.yml` ships the fix on merge.

## What's deliberately not in this PR

- **Persist semaphore CPU-auto sizing** (`persist_workers_default()` currently hardcoded to 8). User asked about `-j auto`; this is the right answer but the existing comment cites a measured wall-clock regression on raising it without other changes (`tests/persist_pool_bench.rs`). PERF.md requires perf changes to go through `perf-rust-cluster` — deferring to a follow-up.
- **`failed to persist artifact output: os error 2` investigation** (#726 proposal item 2). Needs a separate diagnostic-path PR with source-path + stat-retry on the WARN.

## Test plan

- [x] `soldr cargo fmt --all`
- [x] `soldr cargo clippy -p zccache --lib --tests -- -D warnings` — clean
- [x] `soldr cargo test -p zccache --lib wedge` — all 4 wedge tests pass (`wedge_detection_*`)
- [x] Builds clean (`soldr cargo build -p zccache --bins`)
- [x] CAS-gated write logic is a standard AcqRel `swap` pattern — first caller observes `false`, all subsequent observe `true`

Refs #726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)