### PR TITLE
test(wedge): make wedge_detection_returns_wedged_on_recv_timeout deterministic (#717)

### DIFF
--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -118,6 +118,10 @@ interprocess = "2.4.2"
 # Self-dep so zccache's own integration tests can pull in the gated
 # test_support module without needing a separate workspace member.
 zccache = { path = ".", features = ["test-support"] }
+# Enables `#[tokio::test(start_paused = true)]` for deterministic
+# time-dependent unit tests (issue #717). test-util is a dev-only feature
+# so it does not bloat production builds.
+tokio = { workspace = true, features = ["test-util"] }
 
 [build-dependencies]
 prost-build = { workspace = true }

--- a/crates/zccache/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache/src/cli/commands/wrap/ipc.rs
@@ -417,24 +417,36 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn wedge_detection_returns_wedged_on_recv_timeout() {
         // Force a 1 s budget so a wedged daemon surfaces within the test
         // window. Pre-#666 this path inherited the 300 s global default and
         // the whole build paid that wall × N workers.
+        //
+        // Issue #717: `start_paused = true` + `tokio::time::Instant` make the
+        // elapsed measurement deterministic against the configured budget
+        // instead of wall-clock-dependent. Under tokio's paused clock the
+        // fake's `sleep(budget)` auto-advances virtual time the moment no
+        // other tasks are ready, so this test no longer races CI scheduler
+        // jitter on loaded runners.
         std::env::set_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS", "1");
         let mut conn = FakeConn {
             behavior: FakeBehavior::TimesOut,
         };
-        let started = std::time::Instant::now();
+        let started = tokio::time::Instant::now();
         let outcome = compile_recv_with_wedge_detection(&mut conn).await;
         let elapsed = started.elapsed();
         std::env::remove_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS");
         assert!(matches!(outcome, CompileRecvOutcome::Wedged));
+        // Lower bound: the wedge budget was actually respected (no early
+        // false-positive). Upper bound: fail-fast at the configured budget
+        // with a tight margin for the post-timeout return path. Both bounds
+        // measure tokio-virtual time, not wall clock.
         assert!(
-            elapsed < std::time::Duration::from_secs(3),
-            "wedge detection took {elapsed:?} against a never-responding fake — \
-             issue #666 expects bounded fail-fast at the configured budget"
+            elapsed >= std::time::Duration::from_secs(1)
+                && elapsed < std::time::Duration::from_millis(1100),
+            "wedge detection took {elapsed:?} against a never-responding fake; \
+             issue #666 expects fail-fast at the configured budget"
         );
     }
 


### PR DESCRIPTION
## Summary

The flaky test (#717) measured `std::time::Instant::elapsed()` against a 3 s wall-clock bound after a 1 s wedge budget. On loaded CI runners the post-timeout return path crossed the 2 s margin and tripped the assert (observed three times on PRs #713 and #716, passing on rerun each time).

Switch to `#[tokio::test(start_paused = true)]` + `tokio::time::Instant` so the fake's `sleep(budget)` auto-advances tokio-virtual time the moment no other tasks are ready. Elapsed is now deterministic — exactly the configured budget regardless of host load — so the assertion can test fail-fast behaviour with both lower and upper bounds (`1 s ≤ elapsed < 1.1 s`).

`tokio/test-util` is added as a dev-dependency feature on the `zccache` crate (dev-only — does not bloat production builds).

### Changes
- `crates/zccache/src/cli/commands/wrap/ipc.rs`: pause tokio time in the wedge-timeout test; measure with `tokio::time::Instant`; tighten elapsed bound to `[1 s, 1.1 s)`.
- `crates/zccache/Cargo.toml`: add `tokio = { workspace = true, features = ["test-util"] }` to `[dev-dependencies]`.

## Test plan

- [x] `soldr cargo test -p zccache --lib cli::commands::wrap::ipc::tests::wedge` — 4/4 pass locally (Windows)
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` — clean
- [x] `soldr cargo fmt --all --check` — clean
- [ ] CI on this PR (Linux + macOS + Windows)

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)