### PR TITLE
diagnostics(persist): enrich "failed to persist artifact output" WARN with src/dst/errno/exists/size/gap_ms (#728)

### DIFF
--- a/crates/zccache/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/miss_store.rs
@@ -383,9 +383,21 @@ fn store_single_output(
         let _permit = sem.acquire().await.unwrap();
         let written = tokio::task::spawn_blocking(move || {
             let _guard = guard;
+            // Issue #728: `gap_ms` = wall-clock between
+            // "linker-success-recorded" (immediately before this spawn was
+            // scheduled) and "persist-attempt-started" (now, inside the
+            // blocking task). Captured *before* the persist call so the
+            // measurement excludes the persist work itself; useful for
+            // distinguishing "queue starvation under burst load" from
+            // "src vanished" / errno-N failure modes (the rest of the
+            // diagnostic — src=, dst=, errno=, src_exists_now=,
+            // src_size_now= — is baked into the error by
+            // `persist::enrich_persist_err`).
+            let gap_ms = t_persist_enqueue.elapsed().as_millis() as u64;
             if let Err(e) = persist_artifact_paths(&artifact_dir, &key_hex, &source_paths) {
                 tracing::warn!(
                     key = %key_hex,
+                    gap_ms,
                     "failed to persist artifact output: {e}"
                 );
             }

--- a/crates/zccache/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache/src/daemon/server/handle_compile_multi.rs
@@ -871,13 +871,20 @@ pub(super) async fn handle_compile_multi(
         };
         let sem = Arc::clone(&state.persist_semaphore);
         let state_ref = Arc::clone(&state);
+        // Issue #728: capture the per-job enqueue Instant so the WARN below
+        // can report `gap_ms` = "linker-success-recorded → persist-attempt-
+        // started" (distinguishes queue starvation under burst load from
+        // src/dst failures already enriched by `persist::enrich_persist_err`).
+        let t_persist_enqueue = std::time::Instant::now();
         tokio::spawn(async move {
             let _permit = sem.acquire().await.unwrap();
             let written = tokio::task::spawn_blocking(move || {
                 let _guard = guard;
+                let gap_ms = t_persist_enqueue.elapsed().as_millis() as u64;
                 if let Err(e) = persist_artifact_payloads(&artifact_dir, &key_hex, &payloads) {
                     tracing::warn!(
                         key = %key_hex,
+                        gap_ms,
                         "failed to persist artifact output: {e}"
                     );
                 }

--- a/crates/zccache/src/daemon/server/persist.rs
+++ b/crates/zccache/src/daemon/server/persist.rs
@@ -13,17 +13,63 @@ pub(super) fn artifact_persist_tmp_path(cache_path: &Path) -> PathBuf {
 
 pub(super) fn persist_artifact_output(cache_path: &Path, payload: &[u8]) -> std::io::Result<()> {
     if let Some(parent) = cache_path.parent() {
-        std::fs::create_dir_all(parent)?;
+        std::fs::create_dir_all(parent).map_err(|e| enrich_persist_err(e, None, cache_path))?;
     }
     let tmp_path = artifact_persist_tmp_path(cache_path);
     let result = (|| {
         std::fs::write(&tmp_path, payload)?;
         replace_artifact_cache_file(&tmp_path, cache_path)
     })();
-    if result.is_err() {
+    if let Err(e) = result {
         let _ = std::fs::remove_file(&tmp_path);
+        return Err(enrich_persist_err(e, None, cache_path));
     }
-    result
+    Ok(())
+}
+
+// Issue #728: failed cache writes used to surface as a bare io::Error with no
+// path context, leaving us unable to tell whether the source file vanished
+// mid-flight (TOCTOU against ninja), whether the destination dir was wrong,
+// or whether Defender quarantined the file. The error returned from
+// `persist_artifact_file` / `persist_artifact_output` now embeds:
+//   src=, dst=, errno=, src_exists_now=, src_size_now=
+// so the WARN at the call site can distinguish those cases without plumbing
+// extra fields through.
+//
+// Pass `src = None` for payload writes (the bytes came from RAM — there is
+// no source file to stat). The `src_exists_now=` / `src_size_now=` fields
+// are then omitted.
+pub(super) fn enrich_persist_err(
+    orig: std::io::Error,
+    src: Option<&Path>,
+    dst: &Path,
+) -> std::io::Error {
+    let errno = orig.raw_os_error();
+    let kind = orig.kind();
+    let mut msg = String::new();
+    if let Some(src) = src {
+        use std::fmt::Write as _;
+        let (exists_now, size_now) = match std::fs::metadata(src) {
+            Ok(meta) => (true, Some(meta.len())),
+            Err(_) => (false, None),
+        };
+        let _ = write!(msg, "src={}", src.display());
+        let _ = write!(msg, " src_exists_now={exists_now}");
+        match size_now {
+            Some(size) => {
+                let _ = write!(msg, " src_size_now={size}");
+            }
+            None => {
+                let _ = write!(msg, " src_size_now=?");
+            }
+        }
+        msg.push(' ');
+    }
+    use std::fmt::Write as _;
+    let _ = write!(msg, "dst={}", dst.display());
+    let _ = write!(msg, " errno={errno:?}");
+    let _ = write!(msg, ": {orig}");
+    std::io::Error::new(kind, msg)
 }
 
 // ─── Artifact-pack format (experimental, env-gated) ───────────────────────────
@@ -237,7 +283,8 @@ pub(super) fn persist_artifact_file(
     source_path: &Path,
 ) -> std::io::Result<PersistArtifactFileStats> {
     if let Some(parent) = cache_path.parent() {
-        std::fs::create_dir_all(parent)?;
+        std::fs::create_dir_all(parent)
+            .map_err(|e| enrich_persist_err(e, Some(source_path), cache_path))?;
     }
 
     let tmp_path = artifact_persist_tmp_path(cache_path);
@@ -259,10 +306,13 @@ pub(super) fn persist_artifact_file(
             })
         }
     })();
-    if result.is_err() {
-        let _ = std::fs::remove_file(&tmp_path);
+    match result {
+        Ok(stats) => Ok(stats),
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp_path);
+            Err(enrich_persist_err(e, Some(source_path), cache_path))
+        }
     }
-    result
 }
 
 #[cfg(not(windows))]

--- a/crates/zccache/src/daemon/server/tests/pack.rs
+++ b/crates/zccache/src/daemon/server/tests/pack.rs
@@ -110,3 +110,57 @@ fn persist_artifact_paths_falls_back_to_copy_when_source_missing() {
     // Caller's contract is "best effort; on err skip caching."
     assert!(persist_artifact_paths(dir.path(), key, &sources).is_err());
 }
+
+#[test]
+fn persist_artifact_paths_err_includes_diagnostics_for_missing_source() {
+    // Issue #728: WARN at the persist call site has historically been a bare
+    // "failed to persist artifact output: os error 2" with no path context —
+    // we could not tell whether ninja deleted the output mid-flight, whether
+    // the destination dir was wrong, or whether Defender quarantined the
+    // file. The error returned from `persist_artifact_paths` now embeds the
+    // full diagnostic so callers (the daemon WARN sites) surface it without
+    // any extra plumbing.
+    std::env::remove_var("ZCCACHE_PACK_ARTIFACTS");
+    let dir = tempfile::tempdir().unwrap();
+    let key = "diagkey";
+    let missing = dir.path().join("does-not-exist.rlib");
+    let sources = vec![NormalizedPath::from(missing.clone())];
+    let err = persist_artifact_paths(dir.path(), key, &sources).expect_err("expected err");
+    let msg = format!("{err}");
+    assert!(msg.contains("src="), "missing src= field in {msg}");
+    assert!(msg.contains("dst="), "missing dst= field in {msg}");
+    assert!(msg.contains("errno="), "missing errno= field in {msg}");
+    assert!(
+        msg.contains("src_exists_now=false"),
+        "expected src_exists_now=false in {msg}"
+    );
+    assert!(
+        msg.contains("src_size_now=?"),
+        "expected src_size_now=? for missing source in {msg}"
+    );
+}
+
+#[test]
+fn persist_artifact_output_err_includes_dst_diagnostics() {
+    // Counterpart for `persist_artifact_output` (payload writes): payloads
+    // come from RAM so there's no source-path question, but `dst=` and
+    // `errno=` must still be embedded so a write-failure WARN is debuggable.
+    std::env::remove_var("ZCCACHE_PACK_ARTIFACTS");
+    // Cache path under a *file* (not a dir) so create_dir_all fails:
+    // mkdir-ing a path whose parent is a regular file yields NotADirectory
+    // on Linux and InvalidInput on Windows — either way an error path we
+    // can exercise without root.
+    let dir = tempfile::tempdir().unwrap();
+    let blocker = dir.path().join("blocker");
+    std::fs::write(&blocker, b"not a directory").unwrap();
+    let cache_path = blocker.join("nested").join("artifact_0");
+    let err = persist_artifact_output(&cache_path, b"bytes").expect_err("expected err");
+    let msg = format!("{err}");
+    assert!(msg.contains("dst="), "missing dst= field in {msg}");
+    assert!(msg.contains("errno="), "missing errno= field in {msg}");
+    // No src= for payload writes — that field is gated on Some(src).
+    assert!(
+        !msg.contains("src="),
+        "payload writes have no source path; src= must not appear in {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

First half of #728: enriches the WARN at `handle_compile/miss_store.rs:387` and `handle_compile_multi.rs:879` so we can distinguish the failure modes that today are indistinguishable from a bare \"failed to persist artifact output: os error 2\". The second half (reproduce-under-FastLED+Defender and either fix-the-race or downgrade) belongs to a later iteration on a Windows runner — acceptance criteria #2-#3 of #728.

### Diagnostic shape now in the WARN

```
warn: key=<key_hex> gap_ms=<N> failed to persist artifact output: \
  src=<path> src_exists_now=<bool> src_size_now=<bytes|?> \
  dst=<cache_path> errno=Some(2): <orig io::Error>
```

For payload writes (RAM → cache, no source file) the `src=`/`src_exists_now=`/`src_size_now=` block is omitted; `dst=` + `errno=` + `gap_ms` still appear.

### Why these six fields

- **`src=` + `src_exists_now=` + `src_size_now=`** — disambiguates \"ninja deleted the output between linker-exit and persist-attempt\" (file gone, `src_exists_now=false`) from \"compute-the-path bug\" (file still there but wrong path) from \"Defender quarantine\" (file gone *now* but linker did emit it).
- **`dst=`** — confirms the cache destination zccache computed.
- **`errno=`** — separates ENOENT (file vanished) from EACCES (perms) from ERROR_SHARING_VIOLATION (AV scan window).
- **`gap_ms`** — distinguishes \"queue starvation under burst link load\" (large gap → DD-025 persist-semaphore is starved) from \"instant-vanish\" (small gap → real TOCTOU).

### Changes
- `crates/zccache/src/daemon/server/persist.rs`: new helper `enrich_persist_err(io::Error, Option<&Path> src, &Path dst)` wraps every error path in `persist_artifact_file` (has src) and `persist_artifact_output` (no src). One best-effort `fs::metadata(src)` runs only on the error path → zero cost on the happy path.
- `crates/zccache/src/daemon/server/handle_compile/miss_store.rs`: capture `gap_ms = t_persist_enqueue.elapsed()` inside the `spawn_blocking` *before* the persist call, so the measurement excludes persist execution time.
- `crates/zccache/src/daemon/server/handle_compile_multi.rs`: same pattern, per-job (multi-compile spawns one blocking task per `persist_job`).
- `crates/zccache/src/daemon/server/tests/pack.rs`: two new unit tests asserting the field shape for both error paths.

## Test plan

- [x] `soldr cargo test -p zccache --lib daemon::server::tests::pack` — 8/8 pass (incl. 2 new tests)
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` — clean
- [x] `soldr cargo check -p zccache --all-targets` — clean
- [x] `soldr cargo fmt --all --check` — clean
- [ ] CI on this PR (Linux + macOS + Windows)

Deferred to follow-up (criteria #2-#3 of #728):
- Reproduce under FastLED `all-with-examples` on a Defender-on Windows runner with the enriched logs.
- From the captured `gap_ms` + `src_exists_now=` distribution, decide whether to fix the race at source or downgrade the WARN.

Refs #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)