### PR TITLE
chore(release): bump 1.12.2 -> 1.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.12.2"
+version = "1.12.3"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.12.2"
+version = "1.12.3"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.12.2"
+version = "1.12.3"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.12.2"
+version = "1.12.3"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.12.2"
+version = "1.12.3"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Ships four PRs that landed on top of 1.12.2:

| PR | What |
|----|------|
| #730 | test(wedge): deterministic `wedge_detection_returns_wedged_on_recv_timeout` (#717) |
| #731 | diagnostics(persist): enrich the `os error 2` WARN with src/dst/errno/exists/size/gap_ms (#728) |
| #732 | fix(meson): allowlist configure outputs, skip-persist on no-op, purge meson-configure on clear (#710) |
| #733 | test(daemon): synthetic burst-link reproducer for #726 (#729) |

Issues closed via this release line: #710, #717, #728 (criterion 1), #729.

Triggers `release-auto.yml` on merge → PyPI 1.12.3 + crates.io 1.12.3 + GitHub release with binary assets + SHA256SUMS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)