### PR TITLE
refactor(wire_frame): port FrameV1 onto backend_sdk codecs (partial #718)

### DIFF
--- a/crates/zccache/src/protocol/wire_frame.rs
+++ b/crates/zccache/src/protocol/wire_frame.rs
@@ -7,37 +7,32 @@
 //! [`ZCCACHE_FRAME_PAYLOAD_PROTOCOL`] and `Frame.request_id` correlates a
 //! response to its request. This lane is selected only by an explicit
 //! `ZCCACHE_DAEMON_WIRE=frame`; `auto` never prefers it.
+//!
+//! The outer envelope construction and the buffer-level codec come from
+//! running-process's `backend_sdk` family (`Frame::request`/`response_to`
+//! and `frame_ext::encode_framed`/`try_decode_framed`); this module is the
+//! thin zccache-side wrapper that pins the payload protocol id and binds
+//! the codecs to typed prost messages. See zackees/zccache#718.
 
-use bytes::{Buf, BufMut, BytesMut};
+use bytes::BytesMut;
 use prost::Message;
+use running_process::broker::protocol::frame_ext::{encode_framed, try_decode_framed};
+use running_process::register_payload_protocol;
 
 use super::{ProtocolError, BINCODE_PROTOCOL_VERSION, PROST_PROTOCOL_VERSION};
 
-/// `payload_protocol` registry value for zccache requests/responses carried
-/// inside running-process broker `Frame` envelopes.
-///
-/// `0x7A63` is ASCII `"zc"` (`0x7A` = 'z', `0x63` = 'c'). Collision check
-/// against the frozen running-process broker payload-protocol registry:
-///
-/// - `0x0000` — broker control (`Hello`/`HelloReply`)
-/// - `0xAD01` — broker admin verbs
-/// - `0xB232` — `BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL`
-///   (`running_process::broker::backend_lifecycle::probe`)
-/// - `0xD0FF` — broker handoff
-///
-/// `0x7A63` collides with none of these; a compile-time assertion below pins
-/// the probe-constant check so a future running-process bump cannot silently
-/// introduce a collision.
-pub const ZCCACHE_FRAME_PAYLOAD_PROTOCOL: u32 = 0x7A63;
-
-const _: () = assert!(
-    ZCCACHE_FRAME_PAYLOAD_PROTOCOL
-        != running_process::broker::backend_lifecycle::probe::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL,
-    "zccache Frame payload protocol must not collide with the BackendHandle probe"
-);
-const _: () = assert!(ZCCACHE_FRAME_PAYLOAD_PROTOCOL != 0x0000);
-const _: () = assert!(ZCCACHE_FRAME_PAYLOAD_PROTOCOL != 0xAD01);
-const _: () = assert!(ZCCACHE_FRAME_PAYLOAD_PROTOCOL != 0xD0FF);
+register_payload_protocol! {
+    /// `payload_protocol` registry value for zccache requests/responses carried
+    /// inside running-process broker `Frame` envelopes.
+    ///
+    /// `0x7A63` is ASCII `"zc"` (`0x7A` = 'z', `0x63` = 'c'). The
+    /// [`register_payload_protocol!`] macro emits compile-time asserts that
+    /// this value does not collide with any first-party running-process
+    /// payload protocol and lies inside the registered-consumer range
+    /// (`0x7000..=0x7EFF`). The authoritative registration mirrors
+    /// `running_process::broker::protocol::registry::ZCCACHE_PAYLOAD_PROTOCOL`.
+    pub const ZCCACHE_FRAME_PAYLOAD_PROTOCOL: u32 = 0x7A63;
+}
 
 /// Decoded zccache message extracted from a running-process `Frame`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -58,14 +53,17 @@ pub fn encode_frame_v1_request<M: Message>(
     msg: &M,
     request_id: u64,
 ) -> Result<BytesMut, ProtocolError> {
-    encode_frame_v1_message(
-        msg,
-        running_process::broker::protocol::FrameKind::Request,
-        request_id,
-    )
+    use running_process::broker::protocol::Frame;
+
+    let payload = encode_payload(msg)?;
+    let frame = Frame::request(ZCCACHE_FRAME_PAYLOAD_PROTOCOL, payload).with_request_id(request_id);
+    encode_framed_bytes(&frame)
 }
 
 /// Serialize a zccache prost response into a running-process `Frame` envelope.
+///
+/// The response echoes the request's `request_id` and `payload_protocol`
+/// (always [`ZCCACHE_FRAME_PAYLOAD_PROTOCOL`] on this lane).
 ///
 /// # Errors
 ///
@@ -75,49 +73,37 @@ pub fn encode_frame_v1_response<M: Message>(
     msg: &M,
     request_id: u64,
 ) -> Result<BytesMut, ProtocolError> {
-    encode_frame_v1_message(
-        msg,
-        running_process::broker::protocol::FrameKind::Response,
-        request_id,
-    )
+    use running_process::broker::protocol::Frame;
+
+    // Use a one-shot request as the template so `response_to` can echo the
+    // request_id + payload_protocol exactly the way the SDK builds it on the
+    // server side. `Frame::request` is a pure constructor (no I/O), and the
+    // golden-bytes test pins the resulting wire.
+    let template =
+        Frame::request(ZCCACHE_FRAME_PAYLOAD_PROTOCOL, Vec::new()).with_request_id(request_id);
+    let payload = encode_payload(msg)?;
+    let frame = Frame::response_to(&template, payload);
+    encode_framed_bytes(&frame)
 }
 
-fn encode_frame_v1_message<M: Message>(
-    msg: &M,
-    kind: running_process::broker::protocol::FrameKind,
-    request_id: u64,
-) -> Result<BytesMut, ProtocolError> {
-    use running_process::broker::protocol::{Frame, PayloadEncoding};
-
+fn encode_payload<M: Message>(msg: &M) -> Result<Vec<u8>, ProtocolError> {
     let mut payload = Vec::with_capacity(msg.encoded_len());
     msg.encode(&mut payload)
         .map_err(|e| ProtocolError::Serialization(e.to_string()))?;
+    Ok(payload)
+}
 
-    let frame = Frame {
-        envelope_version: 1,
-        kind: kind as i32,
-        payload_protocol: ZCCACHE_FRAME_PAYLOAD_PROTOCOL,
-        payload,
-        request_id,
-        payload_encoding: PayloadEncoding::None as i32,
-        deadline_unix_ms: 0,
-        traceparent: String::new(),
-        tracestate: String::new(),
-    };
-
-    let mut body = Vec::with_capacity(frame.encoded_len());
-    frame
-        .encode(&mut body)
-        .map_err(|e| ProtocolError::Serialization(e.to_string()))?;
-    if body.len() > running_process::broker::protocol::MAX_FRAME_BYTES {
-        return Err(ProtocolError::MessageTooLarge(body.len()));
-    }
-
-    let mut buf = BytesMut::with_capacity(1 + 4 + body.len());
-    buf.put_u8(running_process::broker::protocol::ENVELOPE_VERSION);
-    buf.put_u32_le(u32::try_from(body.len()).expect("frame body under 16 MiB cap fits in u32"));
-    buf.extend_from_slice(&body);
-    Ok(buf)
+fn encode_framed_bytes(
+    frame: &running_process::broker::protocol::Frame,
+) -> Result<BytesMut, ProtocolError> {
+    use running_process::broker::protocol::FramingError;
+    let bytes = encode_framed(frame).map_err(|e| match e {
+        FramingError::FrameTooLarge { body_length, .. } => {
+            ProtocolError::MessageTooLarge(body_length)
+        }
+        other => ProtocolError::Serialization(other.to_string()),
+    })?;
+    Ok(BytesMut::from(bytes.as_slice()))
 }
 
 /// Whether the buffered bytes begin a running-process `Frame` envelope
@@ -167,26 +153,23 @@ pub fn buffer_starts_running_process_frame(buf: &[u8]) -> Option<bool> {
 pub fn decode_frame_v1_message<M: Message + Default>(
     buf: &mut BytesMut,
 ) -> Result<Option<FrameV1Decoded<M>>, ProtocolError> {
-    use running_process::broker::protocol::{Frame, FrameKind, PayloadEncoding};
+    use bytes::Buf;
+    use running_process::broker::protocol::{FrameKind, FramingError, PayloadEncoding};
 
-    if buf.len() < 5 {
-        return Ok(None);
-    }
-    debug_assert_eq!(buf[0], running_process::broker::protocol::ENVELOPE_VERSION);
+    let decoded = match try_decode_framed(buf.as_ref()) {
+        Ok(Some(d)) => d,
+        Ok(None) => return Ok(None),
+        Err(FramingError::FrameTooLarge { body_length, .. }) => {
+            return Err(ProtocolError::MessageTooLarge(body_length))
+        }
+        Err(other) => {
+            return Err(ProtocolError::Deserialization(format!(
+                "running-process Frame: {other}"
+            )))
+        }
+    };
 
-    let body_len = u32::from_le_bytes([buf[1], buf[2], buf[3], buf[4]]) as usize;
-    if body_len > running_process::broker::protocol::MAX_FRAME_BYTES {
-        return Err(ProtocolError::MessageTooLarge(body_len));
-    }
-    if buf.len() < 5 + body_len {
-        return Ok(None);
-    }
-
-    buf.advance(5);
-    let body = buf.split_to(body_len);
-    let frame = Frame::decode(body.as_ref())
-        .map_err(|e| ProtocolError::Deserialization(format!("running-process Frame: {e}")))?;
-
+    let frame = decoded.frame;
     if frame.envelope_version != 1 {
         return Err(ProtocolError::Deserialization(format!(
             "unsupported running-process Frame envelope_version {}",
@@ -218,6 +201,7 @@ pub fn decode_frame_v1_message<M: Message + Default>(
 
     let message = M::decode(frame.payload.as_slice())
         .map_err(|e| ProtocolError::Deserialization(e.to_string()))?;
+    buf.advance(decoded.consumed);
     Ok(Some(FrameV1Decoded {
         message,
         request_id: frame.request_id,
@@ -228,6 +212,7 @@ pub fn decode_frame_v1_message<M: Message + Default>(
 mod tests {
     use super::*;
     use crate::protocol::wire_prost::zccache_v1;
+    use bytes::BufMut;
 
     /// Build a fixed, deterministic zccache `Lookup` request used as the
     /// golden-bytes fixture. The contents must never change — if a field is


### PR DESCRIPTION
Closes part of #718 (the `crates/zccache/src/protocol/wire_frame.rs` slice). The transport.rs / connection.rs work in the issue body has a much larger blast radius and will land as a follow-up.

## What changed

`crates/zccache/src/protocol/wire_frame.rs` now delegates outer-envelope construction and decoding to running-process `backend_sdk` codecs:

- **Encode**: `Frame::request(ZCCACHE_FRAME_PAYLOAD_PROTOCOL, payload).with_request_id(id)` + `frame_ext::encode_framed` (and `Frame::response_to(&template, payload)` on the response path). Replaces hand-rolled `Frame { … }` literal + `[1][LE len][prost]` byte assembly in `encode_frame_v1_message`.
- **Decode**: `frame_ext::try_decode_framed` + buffer advance, replacing hand-rolled body-length parsing + `Frame::decode`.
- **Payload protocol id**: bare `pub const ZCCACHE_FRAME_PAYLOAD_PROTOCOL: u32 = 0x7A63;` + four hand-rolled collision asserts collapse into one `running_process::register_payload_protocol!` invocation, which inherits the SDK's compile-time first-party-collision and registered-consumer-range checks (tracks `running_process::broker::protocol::registry::ZCCACHE_PAYLOAD_PROTOCOL`).

The public API surface — `encode_frame_v1_request`, `encode_frame_v1_response`, `decode_frame_v1_message`, `FrameV1Decoded`, `buffer_starts_running_process_frame`, `ZCCACHE_FRAME_PAYLOAD_PROTOCOL` — is unchanged, so `transport.rs`, `connection.rs`, and `tests/daemon_wire_frame_v1_test.rs` need no edits.

## Acceptance

- **Golden bytes identical.** All 3 unit tests in `protocol::wire_frame::tests` pass; all 10 integration tests in `tests/daemon_wire_frame_v1_test.rs` pass (including live daemon round-trip and mixed-wire/backend-probe coexistence).
- **Net-negative LOC**: 1 file changed, 71 insertions(+), 86 deletions(-) — net -15 lines.

## What is left in #718 (follow-up)

- `transport.rs`: delete `try_serve_backend_handle_probe`, probe-side `ensure_buffered`, `is_backend_handle_probe_request`, `backend_handle_probe_response`, `write_running_process_frame`; replace the accept-path call with `BackendEndpointMux` (legacy detector = existing v15/v16 header check); drop `next_frame_request_id` + `send_frame_v1_request/response` once `FrameClient` owns correlation on the client side.
- `daemon/server/connection.rs`: replace `ResponseWire::FrameV1` plumbing with the mux payload-handler closure.
- `tests/daemon_wire_frame_v1_test.rs`: keep the golden-bytes constants verbatim; replace the bespoke live/mixed-wire harness with the conformance kit.

These are non-trivial restructures of the daemon's accept loop and wire dispatch; splitting them out keeps this PR small and verifiable.

## Test plan

- [x] Build the lib (warm-cache via soldr)
- [x] `soldr` test on `protocol::wire_frame` unit tests (3/3 pass)
- [x] `soldr` test on `daemon_wire_frame_v1_test` integration tests (10/10 pass)
- [x] Clippy clean with `-D warnings`

Refs zackees/zccache#718, zackees/zccache#735
