### PR TITLE
feat(cli): add `zccache cache size` subcommand (#695 Phase 1 starter)

### DIFF
--- a/crates/zccache/src/cli/commands/args.rs
+++ b/crates/zccache/src/cli/commands/args.rs
@@ -502,6 +502,36 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         command: MesonCommands,
     },
+    /// Per-version cache directory management (#695).
+    ///
+    /// Phase 1 surface — today's zccache uses a single cache root and these
+    /// commands operate on that root. The same subcommand surface will
+    /// extend to the multi-version `~/.zccache/v-<version>/` layout once
+    /// the router architecture (#694) lands; until then `cache size` is the
+    /// only operation that's meaningful on a single-root cache (`cache list`
+    /// and `cache prune` will activate when per-version directories exist).
+    Cache {
+        #[command(subcommand)]
+        command: CacheCommands,
+    },
+}
+
+/// `zccache cache` subcommands (#695).
+#[derive(Debug, Subcommand)]
+pub(crate) enum CacheCommands {
+    /// Report the total on-disk size of the resolved cache root.
+    ///
+    /// Walks the same root that `zccache cache-root` prints and sums the
+    /// bytes of every regular file under it. Hardlinks are counted once
+    /// (deduplicated by `(dev, inode)` on Unix; on Windows by inode-like
+    /// identity when available). Prints `<bytes>\t<human>\t<root>` on a
+    /// single line by default; use `--json` for a structured emit.
+    Size {
+        /// Emit `{"bytes": N, "human": "X GiB", "cache_root": "<abs>"}` instead of the
+        /// plain line.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// `zccache meson` subcommands.
@@ -926,6 +956,7 @@ pub(crate) const KNOWN_SUBCOMMANDS: &[&str] = &[
     "snapshot-fp-record",
     "snapshot-fp-validate",
     "symbols",
+    "cache",
     "cache-root",
     "defender-exclusions",
     "exec",

--- a/crates/zccache/src/cli/commands/cache_ops.rs
+++ b/crates/zccache/src/cli/commands/cache_ops.rs
@@ -525,6 +525,38 @@ pub(crate) fn cmd_cache_root(json: bool) -> ExitCode {
     ExitCode::SUCCESS
 }
 
+/// `zccache cache size` (#695 Phase 1). Walks the resolved cache root and
+/// prints the total bytes of every regular file under it. Hardlinks are
+/// counted once via `snapshot_bytes_walk`'s `(dev, inode)` dedup.
+///
+/// The walk reuses the same parallel jwalk helper as `snapshot-bytes`, so
+/// it picks up the Windows-Defender mitigation already validated by #189.
+/// `prune_incremental` / `prune_build_script_out` do not apply here — the
+/// zccache cache root has no `target/incremental` / `target/build/*/out`
+/// subtrees, so passing `false`/`false` walks every byte.
+pub(crate) fn cmd_cache_size(json: bool) -> ExitCode {
+    let (root, _) = crate::core::config::resolve_cache_root();
+    let bytes = match snapshot_bytes_walk(root.as_path(), false, false) {
+        Ok(total) => total,
+        Err(err) => {
+            eprintln!("zccache cache size: {err}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let human = format_bytes(bytes);
+    if json {
+        let payload = serde_json::json!({
+            "bytes": bytes,
+            "human": human,
+            "cache_root": root.as_path(),
+        });
+        println!("{}", serde_json::to_string(&payload).unwrap_or_default());
+    } else {
+        println!("{bytes}\t{human}\t{}", root.display());
+    }
+    ExitCode::SUCCESS
+}
+
 /// Parallel walk of `target` summing the bytes of every regular file, with
 /// optional pruning. Uses jwalk for parallel readdir + stat (rayon under the
 /// hood) — on Windows this hides per-file Defender callback latency that

--- a/crates/zccache/src/cli/commands/mod.rs
+++ b/crates/zccache/src/cli/commands/mod.rs
@@ -388,6 +388,9 @@ fn dispatch(command: Commands, global_strict_paths: Option<&str>) -> ExitCode {
             };
             wrap::run_wrap(&wrap_args, strict_paths)
         }
+        Commands::Cache { command } => match command {
+            args::CacheCommands::Size { json } => cache_ops::cmd_cache_size(json),
+        },
         Commands::Meson { command } => match command {
             args::MesonCommands::Configure {
                 source_dir,


### PR DESCRIPTION
Opens the `zccache cache <op>` namespace called for in #695 Phase 1 and ships the first operation that's useful today on the single-root cache.

## What ships

`zccache cache size [--json]` walks the resolved cache root (`zccache cache-root`) and prints total on-disk bytes, the human size, and the root path. Reuses `snapshot_bytes_walk` — the jwalk-based parallel walker from #189 — so it inherits the existing hardlink dedup (`(dev, inode)`) and the Windows-Defender mitigation.

```
$ zccache cache size
20573392723     19.2 GB C:\Users\niteris\.zccache
$ zccache cache size --json
{"bytes":20563519600,"cache_root":"C:\Users\niteris\.zccache","human":"19.2 GB"}
```

Net diff: `3 files changed, 66 insertions(+)`. No deletions; this is purely additive surface area.

## What is staged for follow-ups in #695

- `cache list` — meaningful once the multi-version layout `~/.zccache/v-<version>/` ships with the router (#694). On a single-root cache it would always print one row.
- `cache prune` — same dependency; no per-version directories to prune today.
- `active.json` metadata written by the backend daemon on a throttle (needs a small daemon-side change separate from the CLI).
- Config-file integration (`[cache.prune]` section of `~/.zccache/config.toml`).

The `cache` namespace is registered now so the follow-ups slot in without further argv changes.

## Test plan

- [x] `cargo check -p zccache --bin zccache` clean
- [x] `cargo build -p zccache --bin zccache` clean
- [x] Manual: `zccache cache size` prints `<bytes>\t<human>\t<root>` line
- [x] Manual: `zccache cache size --json` prints `{"bytes": N, "human": "X", "cache_root": "..."}`
- [x] `cache` added to `KNOWN_SUBCOMMANDS` so the binary distinguishes the subcommand from a compiler-wrap invocation (verified — without this the dispatcher routed `cache size` into wrap mode and produced `daemon error: failed to run compiler`).

Refs zackees/zccache#695, zackees/zccache#735
