### PR TITLE
feat(cli): add `zccache release-handles --path X` subcommand (#694 Phase 2)

### DIFF
--- a/crates/zccache/src/cli/commands/args.rs
+++ b/crates/zccache/src/cli/commands/args.rs
@@ -502,6 +502,24 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         command: MesonCommands,
     },
+    /// Ask the daemon to release any handles it owns under `--path`.
+    ///
+    /// Wraps `Request::ReleaseWorktreeHandles` (issue #690) so callers who
+    /// don't go through soldr — FastLED CI cleanup, sysadmin scripts,
+    /// manual debugging — can break daemon-held file handles before
+    /// `rm -rf` / `git worktree remove` on Windows. The daemon refuses
+    /// to release handles whose target path contains the cache root.
+    /// See zccache#694 Phase 2.
+    #[command(name = "release-handles")]
+    ReleaseHandles {
+        /// Path prefix under which daemon-held handles should be released.
+        /// Resolved to an absolute path before the request is sent.
+        #[arg(long, value_name = "PATH")]
+        path: String,
+        /// Emit a machine-readable JSON document on stdout.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// `zccache meson` subcommands.
@@ -930,6 +948,7 @@ pub(crate) const KNOWN_SUBCOMMANDS: &[&str] = &[
     "defender-exclusions",
     "exec",
     "cc",
+    "release-handles",
     "help",
     "--help",
     "-h",

--- a/crates/zccache/src/cli/commands/mod.rs
+++ b/crates/zccache/src/cli/commands/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod exec;
 pub(crate) mod fp;
 pub(crate) mod gha;
 pub(crate) mod meson_cache;
+pub(crate) mod release_handles;
 pub(crate) mod rust_plan;
 pub(crate) mod service_definition;
 pub(crate) mod session;
@@ -387,6 +388,10 @@ fn dispatch(command: Commands, global_strict_paths: Option<&str>) -> ExitCode {
                 }
             };
             wrap::run_wrap(&wrap_args, strict_paths)
+        }
+        Commands::ReleaseHandles { path, json } => {
+            let endpoint = resolve_endpoint(None);
+            run_async(release_handles::cmd_release_handles(&endpoint, &path, json))
         }
         Commands::Meson { command } => match command {
             args::MesonCommands::Configure {

--- a/crates/zccache/src/cli/commands/release_handles.rs
+++ b/crates/zccache/src/cli/commands/release_handles.rs
@@ -1,0 +1,128 @@
+//! `zccache release-handles --path <PATH>` — standalone handle-release
+//! subcommand. Sends `Request::ReleaseWorktreeHandles` to the daemon so
+//! the caller can break daemon-owned file handles before `rm -rf` /
+//! `git worktree remove` on Windows.
+//!
+//! Companions the existing daemon-side handler (`handle_release_worktree_handles`,
+//! issue #690) and the soldr Tier 3 worktree-teardown call site. This
+//! subcommand exposes the same wire request to anyone who is using
+//! zccache without soldr — FastLED CI cleanup, sysadmin scripts, manual
+//! debugging — so the Windows file-lock-on-teardown class (soldr#710) is
+//! solvable from the zccache binary alone. See zccache#694 Phase 2.
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use super::daemon::ensure_daemon;
+use super::util::{absolute_path, connect, print_json_value};
+
+/// Exit codes:
+/// - 0: request succeeded (whether or not any handles were released).
+///   `released` and `unreleased` in the output describe the actual work.
+/// - 2: daemon unreachable, send/recv error, or daemon refused (e.g. path
+///   overlaps the cache root).
+pub(crate) async fn cmd_release_handles(endpoint: &str, path: &str, json: bool) -> ExitCode {
+    // Resolve to an absolute path before sending — the daemon-side handler
+    // (handle_release_worktree_handles.rs:28) canonicalizes against the
+    // active sessions' `working_dir`, and a relative path here would
+    // resolve against the daemon's CWD instead of the caller's. The
+    // protocol docstring on `Request::ReleaseWorktreeHandles` also
+    // requires absolute paths.
+    let abs = absolute_path(path);
+    let abs_path: &Path = abs.as_path();
+
+    if let Err(e) = ensure_daemon(endpoint).await {
+        let message = format!("failed to start daemon: {e}");
+        report_error(&message, json, endpoint, path);
+        return ExitCode::from(2);
+    }
+
+    let mut conn = match connect(endpoint).await {
+        Ok(c) => c,
+        Err(e) => {
+            let message = format!("cannot connect to daemon: {e}");
+            report_error(&message, json, endpoint, path);
+            return ExitCode::from(2);
+        }
+    };
+
+    let request = crate::protocol::Request::ReleaseWorktreeHandles {
+        path: abs_path.into(),
+    };
+
+    let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
+    if let Err(e) = conn.send_request(&request, wire).await {
+        let message = format!("send error: {e}");
+        report_error(&message, json, endpoint, path);
+        return ExitCode::from(2);
+    }
+
+    match conn.recv_response().await {
+        Ok(Some(crate::protocol::Response::ReleaseWorktreeHandlesResult {
+            inspected,
+            released,
+            sessions_dropped,
+            unreleased,
+        })) => {
+            if json {
+                let value = serde_json::json!({
+                    "status": "ok",
+                    "path": abs_path.display().to_string(),
+                    "inspected": inspected,
+                    "released": released,
+                    "sessions_dropped": sessions_dropped,
+                    "unreleased": unreleased
+                        .iter()
+                        .map(|p| p.as_path().display().to_string())
+                        .collect::<Vec<_>>(),
+                });
+                print_json_value(&value);
+            } else {
+                println!(
+                    "zccache release-handles: inspected {inspected} session(s), released {released}"
+                );
+                if !sessions_dropped.is_empty() {
+                    println!("  sessions dropped: {}", sessions_dropped.join(", "));
+                }
+                if !unreleased.is_empty() {
+                    println!("  unreleased paths ({}):", unreleased.len());
+                    for p in &unreleased {
+                        println!("    {}", p.as_path().display());
+                    }
+                }
+            }
+            ExitCode::SUCCESS
+        }
+        Ok(Some(crate::protocol::Response::Error { message })) => {
+            report_error(&format!("daemon error: {message}"), json, endpoint, path);
+            ExitCode::from(2)
+        }
+        Ok(other) => {
+            report_error(
+                &format!("unexpected response: {other:?}"),
+                json,
+                endpoint,
+                path,
+            );
+            ExitCode::from(2)
+        }
+        Err(e) => {
+            report_error(&format!("recv error: {e}"), json, endpoint, path);
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn report_error(message: &str, json: bool, endpoint: &str, path: &str) {
+    if json {
+        let value = serde_json::json!({
+            "status": "error",
+            "endpoint": endpoint,
+            "path": path,
+            "error": message,
+        });
+        print_json_value(&value);
+    } else {
+        eprintln!("zccache release-handles: {message}");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `zccache release-handles --path <PATH>` (with optional `--json`) as a thin CLI wrapper over the existing `Request::ReleaseWorktreeHandles` IPC request (daemon-side handler `handle_release_worktree_handles` is already in tree from issue #690).
- Standalone — does not require soldr, the router, or any new wire format. Direct-zccache consumers (FastLED CI cleanup, sysadmin scripts, manual debugging) can now drop daemon-held file handles before `rm -rf` / `git worktree remove` on Windows without going through soldr's Tier 3 path.
- Mirrors `cli/commands/fp.rs` end-to-end — connect → send_request → recv_response → format result — so it inherits the same tracing, error-mapping, and wire-format-selection infrastructure as the fingerprint subcommands.

Refs zccache#694 Phase 2 (the standalone-first slice). Tracked under meta #735 Wave 2.

## Behavior

| Outcome | Exit | What's printed |
|---|---|---|
| Daemon roundtrip succeeded | 0 | `inspected N session(s), released M` (text) or `{\"status\":\"ok\", ...}` (json). `released == 0` with no `unreleased` paths means no daemon-owned handles were under `--path` — caller can proceed with rmdir. |
| Daemon refused (path overlaps cache root) | 2 | `daemon error: refusing to release handles under ...` |
| Daemon unreachable / send / recv error | 2 | `cannot connect to daemon: ...` / `send error: ...` / `recv error: ...` |
| Unexpected response variant | 2 | `unexpected response: ...` |

`--path` is canonicalized to an absolute path via `absolute_path` before the request leaves the CLI — the protocol field requires an absolute `NormalizedPath`, and a relative path would otherwise resolve against the daemon's CWD instead of the caller's.

## Scope explicitly NOT in this PR

- `zccache router serve` and friends from #694 (Phase 3+) — those need the router lifecycle work which is several PRs out.
- A new `MaintenanceRequest` wrapper proposed in #693 (#4) — `ReleaseWorktreeHandles` is already a top-level `Request` variant; wrapping it in `MaintenanceRequest` would be a wire change and is orthogonal.
- Per-version pipe-name convention (#694 Phase 1) — promoting that to the public stability contract belongs in the same PR that lands the convention, which is gated on #737 (`#693` Phase 1) merging.

## Test plan

- [ ] CI green: `known_subcommands_matches_clap_enum` enforces that the `release-handles` name in the clap `Commands` enum matches the `KNOWN_SUBCOMMANDS` constant; if either side drifts the unit suite fails. Daemon-side `release_worktree_handles` tests (already in tree) cover the protocol shape on the receiving end.
- [ ] Manual smoke (post-merge, on Windows): start a session under a worktree, run `zccache release-handles --path <worktree>` from another shell, confirm `released >= 1` and that the worktree can subsequently be `rmdir`'d without a sharing violation.

> Note: I could not run `soldr cargo check -p zccache --bin zccache` locally in this iteration — the managed zccache 1.11.20 named pipe is saturated by concurrent agents working on adjacent PRs (#695 / #736 / #737 / #738), and every dep crate's rustc invocation fails with `lost connection to daemon`. `soldr cargo fmt --check` is green. The new code mirrors `fp.rs` very closely; the only public surface change is the new clap variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)