### PR TITLE
feat(cli): add `zccache release-handles --path X` (#694 Phase 2)

### DIFF
--- a/crates/zccache/src/cli/commands/args.rs
+++ b/crates/zccache/src/cli/commands/args.rs
@@ -514,6 +514,25 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         command: CacheCommands,
     },
+    /// Ask the daemon to release every session handle under a path
+    /// (#694 Phase 2, builds on #690).
+    ///
+    /// Useful before `git worktree remove` / `rmdir` on Windows where the
+    /// daemon's per-session journal and log handles would otherwise block
+    /// deletion. The daemon refuses to release handles whose target
+    /// overlaps the cache root.
+    #[command(name = "release-handles")]
+    ReleaseHandles {
+        /// Path under which all daemon-held session handles should be released.
+        #[arg(long)]
+        path: PathBuf,
+        /// Emit a JSON summary instead of the plain text summary.
+        #[arg(long)]
+        json: bool,
+        /// IPC endpoint (default: platform-specific).
+        #[arg(long)]
+        endpoint: Option<String>,
+    },
 }
 
 /// `zccache cache` subcommands (#695).
@@ -958,6 +977,7 @@ pub(crate) const KNOWN_SUBCOMMANDS: &[&str] = &[
     "symbols",
     "cache",
     "cache-root",
+    "release-handles",
     "defender-exclusions",
     "exec",
     "cc",

--- a/crates/zccache/src/cli/commands/cache_ops.rs
+++ b/crates/zccache/src/cli/commands/cache_ops.rs
@@ -525,6 +525,90 @@ pub(crate) fn cmd_cache_root(json: bool) -> ExitCode {
     ExitCode::SUCCESS
 }
 
+/// `zccache release-handles --path X` (#694 Phase 2 / builds on #690).
+///
+/// Wraps the existing `Request::ReleaseWorktreeHandles` daemon-side handler
+/// in a standalone CLI surface so direct-zccache consumers (FastLED CI
+/// teardown, sysadmin scripts, anything that does `git worktree remove` or
+/// `rmdir` before tearing down a path) can break the daemon's session
+/// handles deterministically without going through a router or wrapper.
+///
+/// The daemon refuses to release handles whose target contains the cache
+/// root (`handle_release_worktree_handles` returns `Response::Error`); the
+/// CLI surfaces that as a non-zero exit and a stderr message.
+pub(crate) async fn cmd_release_handles(
+    endpoint: &str,
+    path: PathBuf,
+    json: bool,
+) -> ExitCode {
+    let recv_result = match crate::ipc::daemon_release_worktree_handles_roundtrip(
+        endpoint,
+        path.clone(),
+        None,
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(e) if crate::cli::client::is_daemon_unreachable_err(&e) => {
+            eprintln!(
+                "daemon not running at {endpoint} — nothing to release for {}",
+                path.display()
+            );
+            return ExitCode::SUCCESS;
+        }
+        Err(e) => {
+            eprintln!("zccache[err][R]: broken connection to daemon: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match recv_result {
+        Some(crate::protocol::Response::ReleaseWorktreeHandlesResult {
+            inspected,
+            released,
+            sessions_dropped,
+            unreleased,
+        }) => {
+            if json {
+                let payload = serde_json::json!({
+                    "inspected": inspected,
+                    "released": released,
+                    "sessions_dropped": sessions_dropped,
+                    "unreleased": unreleased.iter().map(|p| p.as_path()).collect::<Vec<_>>(),
+                });
+                println!("{}", serde_json::to_string(&payload).unwrap_or_default());
+            } else {
+                println!(
+                    "released {released} of {inspected} session handle(s) under {}",
+                    path.display()
+                );
+                if !sessions_dropped.is_empty() {
+                    println!("  sessions dropped: {}", sessions_dropped.join(", "));
+                }
+                if !unreleased.is_empty() {
+                    println!("  unreleased paths:");
+                    for p in &unreleased {
+                        println!("    {}", p.as_path().display());
+                    }
+                }
+            }
+            ExitCode::SUCCESS
+        }
+        Some(crate::protocol::Response::Error { message }) => {
+            eprintln!("zccache release-handles: {message}");
+            ExitCode::FAILURE
+        }
+        None => {
+            eprintln!("{LOST_CONNECTION_MSG}");
+            ExitCode::FAILURE
+        }
+        Some(other) => {
+            eprintln!("zccache[err][U]: unexpected response from daemon: {other:?}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
 /// `zccache cache size` (#695 Phase 1). Walks the resolved cache root and
 /// prints the total bytes of every regular file under it. Hardlinks are
 /// counted once via `snapshot_bytes_walk`'s `(dev, inode)` dedup.

--- a/crates/zccache/src/cli/commands/cache_ops.rs
+++ b/crates/zccache/src/cli/commands/cache_ops.rs
@@ -536,31 +536,24 @@ pub(crate) fn cmd_cache_root(json: bool) -> ExitCode {
 /// The daemon refuses to release handles whose target contains the cache
 /// root (`handle_release_worktree_handles` returns `Response::Error`); the
 /// CLI surfaces that as a non-zero exit and a stderr message.
-pub(crate) async fn cmd_release_handles(
-    endpoint: &str,
-    path: PathBuf,
-    json: bool,
-) -> ExitCode {
-    let recv_result = match crate::ipc::daemon_release_worktree_handles_roundtrip(
-        endpoint,
-        path.clone(),
-        None,
-    )
-    .await
-    {
-        Ok(response) => response,
-        Err(e) if crate::cli::client::is_daemon_unreachable_err(&e) => {
-            eprintln!(
-                "daemon not running at {endpoint} — nothing to release for {}",
-                path.display()
-            );
-            return ExitCode::SUCCESS;
-        }
-        Err(e) => {
-            eprintln!("zccache[err][R]: broken connection to daemon: {e}");
-            return ExitCode::FAILURE;
-        }
-    };
+pub(crate) async fn cmd_release_handles(endpoint: &str, path: PathBuf, json: bool) -> ExitCode {
+    let recv_result =
+        match crate::ipc::daemon_release_worktree_handles_roundtrip(endpoint, path.clone(), None)
+            .await
+        {
+            Ok(response) => response,
+            Err(e) if crate::cli::client::is_daemon_unreachable_err(&e) => {
+                eprintln!(
+                    "daemon not running at {endpoint} — nothing to release for {}",
+                    path.display()
+                );
+                return ExitCode::SUCCESS;
+            }
+            Err(e) => {
+                eprintln!("zccache[err][R]: broken connection to daemon: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
 
     match recv_result {
         Some(crate::protocol::Response::ReleaseWorktreeHandlesResult {

--- a/crates/zccache/src/cli/commands/mod.rs
+++ b/crates/zccache/src/cli/commands/mod.rs
@@ -391,6 +391,14 @@ fn dispatch(command: Commands, global_strict_paths: Option<&str>) -> ExitCode {
         Commands::Cache { command } => match command {
             args::CacheCommands::Size { json } => cache_ops::cmd_cache_size(json),
         },
+        Commands::ReleaseHandles {
+            path,
+            json,
+            endpoint,
+        } => {
+            let endpoint = resolve_endpoint(endpoint.as_deref());
+            run_async(cache_ops::cmd_release_handles(&endpoint, path, json))
+        }
         Commands::Meson { command } => match command {
             args::MesonCommands::Configure {
                 source_dir,

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -59,6 +59,103 @@ impl DaemonControlRequest {
     }
 }
 
+/// Send a `ReleaseWorktreeHandles` request to the daemon and receive its
+/// response. Wraps the wire dispatch the same way [`daemon_control_roundtrip`]
+/// does for the four parameterless control requests, but plumbs the
+/// path-carrying request directly since it cannot be a `Copy` enum variant.
+///
+/// This is the `zccache release-handles --path X` plumbing (#694 Phase 2 — the
+/// standalone CLI surface that ships value to direct-zccache consumers
+/// independently of the router architecture).
+///
+/// # Errors
+///
+/// Returns the IPC error from the selected send/receive path, or an endpoint
+/// error when `ZCCACHE_DAEMON_WIRE` is invalid.
+pub async fn daemon_release_worktree_handles_roundtrip(
+    endpoint: &str,
+    path: std::path::PathBuf,
+    recv_timeout: Option<std::time::Duration>,
+) -> Result<Option<Response>, IpcError> {
+    let selection = wire_prost::client_wire_selection_from_env().map_err(IpcError::Endpoint)?;
+    let request = protocol::Request::ReleaseWorktreeHandles {
+        path: crate::core::NormalizedPath::new(path),
+    };
+
+    if broker::broker_lane_active() {
+        let (mut conn, route) = connect_control_client_with_route(endpoint).await?;
+        if matches!(route, DaemonConnectRoute::Broker { .. }) {
+            let request = wire_prost::supported_control_request_to_prost(&request)
+                .map_err(IpcError::Endpoint)?;
+            conn.send_frame_v1_request(&request).await?;
+            return recv_control_wire_response(&mut conn, recv_timeout).await;
+        }
+        drop(conn);
+    }
+
+    // Mirror the `daemon_control_roundtrip_with_selection` dispatch pattern,
+    // inlined here because `Request::ReleaseWorktreeHandles` carries a path
+    // (and so cannot route through the `Copy` `DaemonControlRequest` enum).
+    match selection.preferred_format() {
+        wire_prost::WireFormat::BincodeV15 => send_bincode(endpoint, &request, recv_timeout).await,
+        wire_prost::WireFormat::FrameV1 => send_frame(endpoint, &request, recv_timeout).await,
+        wire_prost::WireFormat::ProstV16 => {
+            match send_prost(endpoint, &request, recv_timeout).await {
+                Ok(Some(Response::Error { message }))
+                    if selection.allows_bincode_fallback()
+                        && control_wire_mismatch_message(&message) =>
+                {
+                    send_bincode(endpoint, &request, recv_timeout).await
+                }
+                Ok(None) if selection.allows_bincode_fallback() => {
+                    send_bincode(endpoint, &request, recv_timeout).await
+                }
+                Ok(response) => Ok(response),
+                Err(err)
+                    if selection.allows_bincode_fallback() && control_wire_mismatch_error(&err) =>
+                {
+                    send_bincode(endpoint, &request, recv_timeout).await
+                }
+                Err(err) => Err(err),
+            }
+        }
+    }
+}
+
+async fn send_bincode(
+    endpoint: &str,
+    request: &protocol::Request,
+    recv_timeout: Option<std::time::Duration>,
+) -> Result<Option<Response>, IpcError> {
+    let mut conn = connect_control_client(endpoint).await?;
+    conn.send(request).await?;
+    recv_control_response(&mut conn, recv_timeout).await
+}
+
+async fn send_prost(
+    endpoint: &str,
+    request: &protocol::Request,
+    recv_timeout: Option<std::time::Duration>,
+) -> Result<Option<Response>, IpcError> {
+    let mut conn = connect_control_client(endpoint).await?;
+    let prost_req =
+        wire_prost::supported_control_request_to_prost(request).map_err(IpcError::Endpoint)?;
+    conn.send_prost(&prost_req).await?;
+    recv_control_wire_response(&mut conn, recv_timeout).await
+}
+
+async fn send_frame(
+    endpoint: &str,
+    request: &protocol::Request,
+    recv_timeout: Option<std::time::Duration>,
+) -> Result<Option<Response>, IpcError> {
+    let mut conn = connect_control_client(endpoint).await?;
+    let prost_req =
+        wire_prost::supported_control_request_to_prost(request).map_err(IpcError::Endpoint)?;
+    conn.send_frame_v1_request(&prost_req).await?;
+    recv_control_wire_response(&mut conn, recv_timeout).await
+}
+
 /// Send a daemon control request and receive its response.
 ///
 /// Only `Ping`, `Status`, `Shutdown`, and `Clear` are eligible for the v16


### PR DESCRIPTION
Phase 2 of #694 — the standalone CLI surface for the daemon-side `Request::ReleaseWorktreeHandles` handler that already exists from #690. Useful for direct-zccache consumers (FastLED CI teardown, sysadmin scripts, anything doing `git worktree remove` / `rmdir` on Windows) that need to break the daemon's per-session journal + log handles deterministically before tearing down a path.

## What ships

- `zccache release-handles --path <X> [--json] [--endpoint <X>]` CLI subcommand: sends `Request::ReleaseWorktreeHandles { path }` to the daemon and prints the typed result. The daemon's existing safety guard — refuse if the target contains the cache root — surfaces as a non-zero exit + stderr message.
- `ipc::daemon_release_worktree_handles_roundtrip(endpoint, path, recv_timeout)` — companion to `daemon_control_roundtrip` for the one path-carrying request that cannot route through the existing `Copy` `DaemonControlRequest` enum. Mirrors the same wire-selection dispatch (`Auto` / `Bincode` / `Prost` / `Frame` + the `broker_lane_active()` override) so the new path inherits the same wire semantics as `Clear`, `Status`, etc.

Net diff: 4 files changed, 209 insertions(+), 0 deletions. Pure additive surface — no existing callers changed behavior.

## Sample output

```
$ zccache release-handles --path C:\dev\some-worktree
released 3 of 12 session handle(s) under C:\dev\some-worktree
  sessions dropped: s-abc..., s-def..., s-ghi...

$ zccache release-handles --path C:\dev\some-worktree --json
{"inspected":12,"released":3,"sessions_dropped":["s-abc...","s-def...","s-ghi..."],"unreleased":[]}
```

## What is staged for follow-ups in #694

- Phase 3 — `zccache router serve` control-plane skeleton + `Hello`/`HelloReply` plumbing.
- Phase 4 — backend management (spawn, recovery, idle timeout, spawn budget; consolidates #691's coordination at the router).
- Phase 5 — `DuplicateHandle` (Windows) / `SCM_RIGHTS` (Unix) FD handoff.
- Phase 6 — router-aware client mode behind `ZCCACHE_USE_ROUTER=1`.

## Test plan

- [x] `cargo check -p zccache --bin zccache` clean
- [x] `cargo build -p zccache --bin zccache` clean
- [x] `zccache release-handles --help` renders correctly
- [x] Manual smoke against a live local daemon — sends the request, daemon returns `Response::ReleaseWorktreeHandlesResult` with the expected zeros for a path with no matching sessions
- [x] `release-handles` added to `KNOWN_SUBCOMMANDS` so the binary distinguishes the subcommand from a compiler-wrap invocation

Refs zackees/zccache#694, zackees/zccache#735
