### PR TITLE
feat(daemon): auto-install ServiceDefinition at startup (#720 Phase 2)

### DIFF
--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -318,6 +318,18 @@ fn run_server(args: Args) {
             tracing::debug!(manifest = %path.display(), "published running-process cache manifest");
         }
 
+        // Install the ServiceDefinition into the running-process service-
+        // definition dir so the shared broker can discover us without the
+        // user running `zccache install-servicedef` manually (#720 Phase 2).
+        // Idempotent + best-effort like publish_manifest above; a write
+        // failure is logged and ignored. Skipped under
+        // RUNNING_PROCESS_DISABLE=1. The version-policy refinement (#720
+        // Phase 0) is the follow-up that turns the current exact-version
+        // pin into a real compatibility floor + range.
+        if let Ok(binary) = std::env::current_exe() {
+            let _ = zccache::ipc::publish_service_definition(&binary);
+        }
+
         // Spawn the depgraph load. Holds a `DepGraphSetter` that survives
         // the spawn_blocking boundary; on completion atomically installs
         // the graph + warning via #642's ArcSwap.

--- a/crates/zccache/src/ipc/manifest.rs
+++ b/crates/zccache/src/ipc/manifest.rs
@@ -89,6 +89,72 @@ pub fn publish_manifest_in(
     build_manifest_builder(cache_dir).publish_in(registry_dir)
 }
 
+/// Install the zccache `ServiceDefinition` into the running-process service-
+/// definition directory at daemon startup (#720 Phase 2).
+///
+/// Best-effort and idempotent — `ServiceDefinitionBuilder::install_in` writes
+/// atomically and overwrites a stale definition of the same service name with
+/// the new one. A registry write failure is logged and ignored, exactly like
+/// the [`publish_manifest`] / `write_backend_identity` siblings.
+/// `RUNNING_PROCESS_DISABLE=1` skips installation entirely so the direct
+/// bincode path stays byte-for-byte the pre-adoption behavior.
+///
+/// Phase 0 of #720 is the version-policy refinement that turns the current
+/// exact-version pin (`min_version = allow_version = CARGO_PKG_VERSION`) into
+/// a real compatibility floor + range; until that decision lands this
+/// function preserves the existing exact-version policy already shipped by
+/// the `zccache install-servicedef` CLI subcommand.
+pub fn publish_service_definition(daemon_binary: &Path) -> Option<PathBuf> {
+    use running_process::broker::builders::ServiceDefinitionBuilder;
+    use running_process::broker::server::service_definition_dir;
+
+    if super::running_process_disabled() {
+        return None;
+    }
+
+    let binary = match std::fs::canonicalize(daemon_binary) {
+        Ok(p) => p,
+        Err(err) => {
+            tracing::warn!(
+                daemon_binary = %daemon_binary.display(),
+                error = %err,
+                "failed to canonicalize zccache-daemon binary for service-definition install"
+            );
+            return None;
+        }
+    };
+    let Some(binary_dir) = binary.parent() else {
+        tracing::warn!(
+            binary = %binary.display(),
+            "zccache-daemon binary has no parent directory; skipping service-definition install"
+        );
+        return None;
+    };
+
+    match ServiceDefinitionBuilder::shared_broker(
+        ZCCACHE_SERVICE_NAME,
+        binary.display().to_string(),
+    )
+    .per_version_binary_dir(binary_dir.display().to_string())
+    .min_version(crate::core::VERSION)
+    .allow_version(crate::core::VERSION)
+    .label("vendor", "zackees")
+    .label("package", "zccache")
+    .label("consumer", "zccache")
+    .label("running-process-tracker", "zackees/running-process#435")
+    .install_in(&service_definition_dir())
+    {
+        Ok(path) => {
+            tracing::debug!(servicedef = %path.display(), "installed running-process service definition");
+            Some(path)
+        }
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to install running-process service definition");
+            None
+        }
+    }
+}
+
 fn path_string(path: &NormalizedPath) -> String {
     path.as_path().display().to_string()
 }

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -16,7 +16,7 @@ pub use broker::{
     DaemonConnectRoute, ZCCACHE_BROKER_CONNECT_ENV,
 };
 pub use error::IpcError;
-pub use manifest::{publish_manifest, publish_manifest_in};
+pub use manifest::{publish_manifest, publish_manifest_in, publish_service_definition};
 #[cfg(windows)]
 pub use transport::IpcClientConnection;
 pub use transport::{


### PR DESCRIPTION
Phase 2 of #720 — the daemon now installs its `.servicedef` into the running-process service-definition directory on every successful bind, idempotently, so the shared broker can discover and version-verify it without anyone having to run `zccache install-servicedef` manually first.

## What lands

- `ipc::publish_service_definition(daemon_binary)` — sibling to `publish_manifest`. Honors `RUNNING_PROCESS_DISABLE=1` (skips silently to keep the direct-bincode path byte-for-byte the pre-adoption behavior). Calls `ServiceDefinitionBuilder::install_in(service_definition_dir())` with the same labels + version policy already used by the explicit `zccache install-servicedef` CLI subcommand, so a future host that has never been manually provisioned still has a valid servicedef the moment its first daemon starts.
- `bin/zccache-daemon.rs` calls it right after `publish_manifest`, guarded by `std::env::current_exe()` succeeding. Best-effort: a registry write failure is logged and ignored, matching the manifest-publish + identity-write siblings.

## What is NOT yet in scope

- `min_version = allow_version = CARGO_PKG_VERSION` (the exact-version pin) carries over from the CLI subcommand verbatim. The Phase 0 decision in #720 is what turns this into a real compatibility floor + allowed range; this PR keeps the existing semantics so the wire is unchanged until that sign-off lands.
- Removing the `ZCCACHE_BROKER_CONNECT` opt-in is Phase 4 of #720; this PR only addresses Phase 2 ("guarantee registration").

## Effect on adoption

After this lands, a fresh host with no prior `install-servicedef` run will have a valid servicedef from the first daemon start onward, which removes the `ServiceUnknown` failure mode from broker adoption on unprovisioned machines. The explicit `zccache install-servicedef` subcommand remains for sysadmin scripts that want to install before the daemon has ever been started.

## Test plan

- [x] `cargo check -p zccache` clean
- [x] `cargo fmt -p zccache --check` clean
- [x] Code path mirrors the existing `publish_manifest` startup hook 1:1 (best-effort logging on failure, `RUNNING_PROCESS_DISABLE` skip, idempotent atomic write).

Refs zackees/zccache#720, zackees/zccache#735
