### PR TITLE
chore(release): bump 1.12.3 -> 1.12.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.12.3"
+version = "1.12.4"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.12.3"
+version = "1.12.4"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump workspace version 1.12.3 -> 1.12.4 (patch).

Triggers `release-auto.yml` on merge to main to publish wheels (PyPI) and crates (crates.io), then a GitHub release.

## Changes since 1.12.3

- 97ef7d0 feat(daemon): auto-install ServiceDefinition at startup (#720 Phase 2) (#743)
- 6968375 feat(cli): add `zccache cache list` subcommand (#695 Phase 1) (#742)
- 2e933c1 feat(cli): add `zccache release-handles --path X` (#694 Phase 2) (#741)
- 1197de4 test(daemon): synthetic spawn-storm reproducer for #691 (#738)
- 72bcecb feat(cli): add `zccache cache size` subcommand (#695 Phase 1 starter) (#739)
- 8d5b5d4 docs(wire): add wire-stability commitment + CI guard (refs #693 Phase 1) (#737)
- 838082b refactor(wire_frame): port FrameV1 encode/decode onto running-process backend_sdk codecs (refs #718) (#736)

No wire-breaking changes — patch bump is appropriate.

## Test plan

- [x] `soldr cargo check --workspace` clean
- [ ] CI green
- [ ] `release-auto.yml` runs on push-to-main with matching `[workspace.package].version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)