### PR TITLE
test(wedge): plumb wedge budget as parameter to eliminate env-var race (#745)

### DIFF
--- a/crates/zccache/src/cli/commands/cache_ops.rs
+++ b/crates/zccache/src/cli/commands/cache_ops.rs
@@ -677,8 +677,8 @@ pub(crate) fn cmd_cache_list(json: bool) -> ExitCode {
         .map(|d| d.as_secs())
         .unwrap_or(0);
     println!(
-        "{:<24}  {:<10}  {:>12}  {:<18}  {}",
-        "version", "status", "size", "last-active", "path"
+        "{:<24}  {:<10}  {:>12}  {:<18}  path",
+        "version", "status", "size", "last-active"
     );
     for r in &rows {
         let last_active = match r.last_active_unix {

--- a/crates/zccache/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache/src/cli/commands/wrap/ipc.rs
@@ -40,7 +40,7 @@ pub(super) async fn cmd_compile(
         return ExitCode::FAILURE;
     }
 
-    match compile_recv_with_wedge_detection(&mut conn).await {
+    match compile_recv_with_wedge_detection(&mut conn, wedge_recv_timeout()).await {
         CompileRecvOutcome::Done(recv_result) => {
             relay_compile_response(recv_result, &mut std::io::stdout(), &mut std::io::stderr())
         }
@@ -81,15 +81,23 @@ enum CompileRecvOutcome {
     Failed(String),
 }
 
-/// Wrap a compile-response recv with the [`wedge_recv_timeout`] budget.
+/// Wrap a compile-response recv with an optional wedge budget.
+///
+/// `budget = Some(d)` enables wedge detection; `budget = None` falls
+/// through to an unbounded recv. Production callers pass
+/// [`wedge_recv_timeout`] so the env knob still works; tests pass an
+/// explicit value so they don't race the process-global env var (#745).
 ///
 /// Returns [`CompileRecvOutcome::Wedged`] only for the specific
 /// `IpcError::Timeout` signal — everything else (graceful close, broken
 /// pipe, protocol error) maps to [`CompileRecvOutcome::Failed`] so the
 /// caller does not respawn the daemon on errors that have nothing to do
 /// with a wedge.
-async fn compile_recv_with_wedge_detection<C: ConnRecv>(conn: &mut C) -> CompileRecvOutcome {
-    match wedge_recv_timeout() {
+async fn compile_recv_with_wedge_detection<C: ConnRecv>(
+    conn: &mut C,
+    budget: Option<std::time::Duration>,
+) -> CompileRecvOutcome {
+    match budget {
         Some(budget) => match conn.recv_with_timeout(budget).await {
             Ok(opt) => CompileRecvOutcome::Done(opt),
             Err(crate::ipc::IpcError::Timeout(_)) => CompileRecvOutcome::Wedged,
@@ -181,7 +189,7 @@ pub(super) async fn cmd_compile_ephemeral(
     // fresh-daemon path (ensure_daemon ran above); if the daemon wedges
     // mid-recv we surface a fast failure (~90 s instead of 300 s) so the
     // build framework's per-job retry budget isn't blown.
-    match compile_recv_with_wedge_detection(&mut conn).await {
+    match compile_recv_with_wedge_detection(&mut conn, wedge_recv_timeout()).await {
         CompileRecvOutcome::Done(recv_result) => {
             relay_compile_response(recv_result, &mut std::io::stdout(), &mut std::io::stderr())
         }
@@ -235,7 +243,7 @@ pub(super) async fn cmd_link_ephemeral(
     }
 
     // Wedge detection only — see `cmd_compile_ephemeral` for the rationale.
-    match compile_recv_with_wedge_detection(&mut conn).await {
+    match compile_recv_with_wedge_detection(&mut conn, wedge_recv_timeout()).await {
         CompileRecvOutcome::Done(recv_result) => {
             relay_link_response(recv_result, &mut std::io::stdout(), &mut std::io::stderr())
         }
@@ -402,15 +410,18 @@ mod tests {
         }
     }
 
+    // Test-only budget: 1 s mirrors the prior env-var convention but is
+    // injected directly so parallel tests can't race the process-global env
+    // (#745). The matching test for the env-var parser lives in
+    // `crate::cli` next to `wedge_recv_timeout`.
+    const TEST_BUDGET: Option<std::time::Duration> = Some(std::time::Duration::from_secs(1));
+
     #[tokio::test]
     async fn wedge_detection_returns_done_on_normal_response() {
-        // Use a short budget so the test stays snappy even if the fake regresses.
-        std::env::set_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS", "1");
         let mut conn = FakeConn {
             behavior: FakeBehavior::Ok(crate::protocol::Response::Pong),
         };
-        let outcome = compile_recv_with_wedge_detection(&mut conn).await;
-        std::env::remove_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS");
+        let outcome = compile_recv_with_wedge_detection(&mut conn, TEST_BUDGET).await;
         assert!(matches!(
             outcome,
             CompileRecvOutcome::Done(Some(crate::protocol::Response::Pong))
@@ -419,24 +430,23 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn wedge_detection_returns_wedged_on_recv_timeout() {
-        // Force a 1 s budget so a wedged daemon surfaces within the test
-        // window. Pre-#666 this path inherited the 300 s global default and
-        // the whole build paid that wall × N workers.
+        // Pre-#666 this path inherited the 300 s global default and the
+        // whole build paid that wall × N workers.
         //
-        // Issue #717: `start_paused = true` + `tokio::time::Instant` make the
-        // elapsed measurement deterministic against the configured budget
-        // instead of wall-clock-dependent. Under tokio's paused clock the
-        // fake's `sleep(budget)` auto-advances virtual time the moment no
-        // other tasks are ready, so this test no longer races CI scheduler
-        // jitter on loaded runners.
-        std::env::set_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS", "1");
+        // Issue #717: `start_paused = true` + `tokio::time::Instant` make
+        // the elapsed measurement deterministic against the configured
+        // budget instead of wall-clock-dependent.
+        //
+        // Issue #745: the budget is now an explicit parameter, so parallel
+        // tests can't race the `ZCCACHE_WEDGE_RECV_TIMEOUT_SECS` env var
+        // out from under each other and accidentally surface the 180 s
+        // default mid-recv.
         let mut conn = FakeConn {
             behavior: FakeBehavior::TimesOut,
         };
         let started = tokio::time::Instant::now();
-        let outcome = compile_recv_with_wedge_detection(&mut conn).await;
+        let outcome = compile_recv_with_wedge_detection(&mut conn, TEST_BUDGET).await;
         let elapsed = started.elapsed();
-        std::env::remove_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS");
         assert!(matches!(outcome, CompileRecvOutcome::Wedged));
         // Lower bound: the wedge budget was actually respected (no early
         // false-positive). Upper bound: fail-fast at the configured budget
@@ -455,27 +465,23 @@ mod tests {
         // A non-timeout transport error must NOT trigger the recovery path
         // (force-killing the daemon on every protocol mismatch would be a
         // worse cure than the disease).
-        std::env::set_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS", "1");
         let mut conn = FakeConn {
             behavior: FakeBehavior::BrokenPipe,
         };
-        let outcome = compile_recv_with_wedge_detection(&mut conn).await;
-        std::env::remove_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS");
+        let outcome = compile_recv_with_wedge_detection(&mut conn, TEST_BUDGET).await;
         assert!(matches!(outcome, CompileRecvOutcome::Failed(_)));
     }
 
     #[tokio::test]
-    async fn wedge_detection_disabled_when_env_is_zero() {
-        // `ZCCACHE_WEDGE_RECV_TIMEOUT_SECS=0` opts back into the pre-#666
-        // unbounded recv (useful for huge LTO links that legitimately
-        // exceed the default budget). The fake's BrokenPipe path returns
-        // immediately so the test doesn't hang.
-        std::env::set_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS", "0");
+    async fn wedge_detection_disabled_when_budget_is_none() {
+        // `budget = None` opts back into the pre-#666 unbounded recv
+        // (used in production when `ZCCACHE_WEDGE_RECV_TIMEOUT_SECS=0`).
+        // The fake's BrokenPipe path returns immediately so the test
+        // doesn't hang.
         let mut conn = FakeConn {
             behavior: FakeBehavior::BrokenPipe,
         };
-        let outcome = compile_recv_with_wedge_detection(&mut conn).await;
-        std::env::remove_var("ZCCACHE_WEDGE_RECV_TIMEOUT_SECS");
+        let outcome = compile_recv_with_wedge_detection(&mut conn, None).await;
         // Disabled → falls through to `conn.recv()` unbounded, which the
         // fake reports as a broken pipe. Crucially: not classified as Wedged.
         assert!(matches!(outcome, CompileRecvOutcome::Failed(_)));


### PR DESCRIPTION
Closes #745.

## Root cause

The four `wedge_detection_*` unit tests in `wrap::ipc::tests` each mutated the process-global `ZCCACHE_WEDGE_RECV_TIMEOUT_SECS` env var to inject a 1 s or 0 s budget. `cargo test` runs them in parallel, so when one test called `remove_var` between another test's `set_var` and the recv, `wedge_recv_timeout()` fell through to its **180 s** default. Under `#[tokio::test(start_paused = true)]` virtual time then advanced 180 s during the fake's `sleep(budget)` and the assertion's upper bound (`elapsed < 1.1 s`) tripped — exact symptom from PR #744's Windows runner ("wedge detection took 180s against a never-responding fake").

PR #730 made the elapsed measurement deterministic against the configured budget. But it did not address the env-var race that made the *configured budget itself* non-deterministic.

## Fix

Refactor `compile_recv_with_wedge_detection` to take an explicit `Option<Duration>` budget parameter:

- **Production callers** (`cmd_compile`, `cmd_compile_ephemeral`, `cmd_link_ephemeral`) pass `wedge_recv_timeout()` so the `ZCCACHE_WEDGE_RECV_TIMEOUT_SECS` knob still works for users and integration tests.
- **Unit tests** pass a constant `Some(Duration::from_secs(1))` (or `None` for the disabled path) directly — no env mutation, no race.

Renamed `wedge_detection_disabled_when_env_is_zero` → `wedge_detection_disabled_when_budget_is_none` since it no longer exercises the env var.

## Drive-by

Second commit (`style(cache_ops): inline format literal in cache list header`) is a clippy `print_literal` fix in the new `cache list` header (PR #742) that was blocking CI on this branch — pure mechanical refactor, no behavior change.

## Test plan

- [x] `soldr cargo test -p zccache cli::commands::wrap::ipc::tests` — 6/6 pass in 0.00s
- [x] `soldr cargo fmt --all -- --check`
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings`
- [ ] CI green across Linux / macOS / Windows

## Refs

- #717 — original flake report (1 s vs 3 s wall-clock margin)
- #730 — virtual-time hardening that solved part of the problem
- #666 — original wedge-detection feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)