### PR TITLE
fix(daemon): chdir to ~/.zccache/ in release_cwd to harden against TEMP override (#747)

### DIFF
--- a/crates/zccache/src/daemon/trampoline.rs
+++ b/crates/zccache/src/daemon/trampoline.rs
@@ -96,12 +96,49 @@ pub fn unlock_exe() {
     std::thread::spawn(move || gc_old_files(&parent, &stem));
 }
 
-/// Release the launch-cwd handle by chdir-ing to the OS temp dir. On
-/// Windows a running process holds an implicit kernel handle on its
-/// cwd, so launching the daemon from a project dir blocks deletion of
-/// that dir until the daemon exits. Cheap one-liner, runs on every OS.
+/// Release the launch-cwd handle by chdir-ing to a stable global
+/// directory the daemon owns. On Windows a running process holds an
+/// implicit kernel handle on its cwd, so launching the daemon from a
+/// project dir blocks deletion of that dir until the daemon exits.
+/// Runs on every OS.
+///
+/// Target order:
+///   1. `~/.zccache/` — sibling of the daemon's runtime-binaries and
+///      logs, stable across reboots and outside any user workspace.
+///      Preferred per #747: a path the daemon owns can never be
+///      reconfigured via a stray `TMP` / `TEMP` env override.
+///   2. `std::env::temp_dir()` — fallback when the home directory is
+///      not discoverable (`$HOME` / `%USERPROFILE%` unset) or
+///      chdir into `~/.zccache/` fails for any reason. Best-effort and
+///      safe on every supported platform.
+///
+/// Best-effort; no panic on failure. A failure here is strictly better
+/// than the pre-fix behavior (no chdir at all): the daemon will still
+/// hold the inherited workspace handle, but anything that worked before
+/// still works.
 pub fn release_cwd() {
+    if let Some(stable) = zccache_home_dir() {
+        let _ = std::fs::create_dir_all(&stable);
+        if std::env::set_current_dir(&stable).is_ok() {
+            return;
+        }
+    }
     let _ = std::env::set_current_dir(std::env::temp_dir());
+}
+
+/// `~/.zccache/` resolved from `$HOME` (Unix) or `%USERPROFILE%`
+/// (Windows). Returns `None` if neither env var is set.
+///
+/// Intentionally does NOT consult `ZCCACHE_CACHE_DIR`: that override
+/// can legitimately point into a workspace (perf scenarios use a
+/// project-local cache), and the whole point of [`release_cwd`] is to
+/// chdir OUT of any workspace so its directory handle is released.
+fn zccache_home_dir() -> Option<std::path::PathBuf> {
+    let home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))?;
+    if home.is_empty() {
+        return None;
+    }
+    Some(std::path::Path::new(&home).join(".zccache"))
 }
 
 /// Detach inherited stdio (stdin/stdout/stderr) by re-opening them to the
@@ -457,5 +494,16 @@ mod tests {
         assert_ne!(std::env::current_dir().unwrap(), tmp_canon);
 
         let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn zccache_home_dir_resolves_to_dot_zccache_under_home_or_userprofile() {
+        // Ignores `ZCCACHE_CACHE_DIR` deliberately — see the doc comment
+        // on `zccache_home_dir`. Reads `HOME` / `USERPROFILE` directly.
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .expect("test host must have HOME or USERPROFILE set");
+        let resolved = zccache_home_dir().expect("home discoverable");
+        assert_eq!(resolved, Path::new(&home).join(".zccache"));
     }
 }

--- a/crates/zccache/tests/daemon_workspace_pin_747.rs
+++ b/crates/zccache/tests/daemon_workspace_pin_747.rs
@@ -1,0 +1,124 @@
+//! Integration regression for #747: a live daemon process must not pin
+//! the directory from which it was spawned on Windows.
+//!
+//! Repro shape (same as the issue's repro):
+//!   1. Spawn the real `zccache-daemon --foreground` binary with its
+//!      child-process cwd set to a fresh temp directory.
+//!   2. Wait long enough for the daemon's startup path to run through
+//!      `trampoline::release_cwd()` and bind its IPC endpoint.
+//!   3. While the daemon is still alive, try to delete the temp dir.
+//!
+//! On Windows pre-fix, step 3 fails with `os error 32` ("process cannot
+//! access the file") because the daemon holds an implicit kernel
+//! `FILE_OBJECT` on its inherited cwd.
+
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+#[test]
+#[cfg_attr(
+    not(windows),
+    ignore = "CWD-handle pinning is a Windows-only failure mode"
+)]
+fn spawned_daemon_does_not_pin_its_launch_cwd() {
+    let daemon_bin = env!("CARGO_BIN_EXE_zccache-daemon");
+
+    let workspace = tempfile::tempdir().expect("create workspace tempdir");
+    let workspace_path = workspace
+        .path()
+        .canonicalize()
+        .expect("canonicalize workspace tempdir");
+
+    // Per-test isolated state so we don't collide with the user's running
+    // daemon or with another test running in parallel.
+    let nonce = format!(
+        "{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    );
+    let endpoint = endpoint_for(&nonce);
+    let cache_dir = std::env::temp_dir().join(format!("zccache-747-cache-{nonce}"));
+    let log_file = std::env::temp_dir().join(format!("zccache-747-log-{nonce}.log"));
+    std::fs::create_dir_all(&cache_dir).expect("create per-test cache dir");
+
+    let mut cmd = Command::new(daemon_bin);
+    cmd.current_dir(&workspace_path)
+        .env("ZCCACHE_CACHE_DIR", &cache_dir)
+        .env("ZCCACHE_QUIET", "1")
+        .args([
+            "--foreground",
+            "--endpoint",
+            &endpoint,
+            "--log-file",
+            &log_file.to_string_lossy(),
+            // Short idle timeout so a wedged daemon eventually exits even
+            // if the test panics before its own kill arm.
+            "--idle-timeout",
+            "30",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    let mut child = cmd.spawn().expect("spawn zccache-daemon");
+
+    // Give the daemon time to:
+    //   * detach stdio
+    //   * init tracing
+    //   * call release_cwd()
+    //   * enter run_server() and bind the IPC endpoint
+    // 3 s is generous — startup on a cold cache is ~hundreds of ms.
+    std::thread::sleep(Duration::from_secs(3));
+
+    // Sanity: a daemon that crashed before reaching release_cwd would
+    // make the test pass for the wrong reason. Skip with a clear note if
+    // the binary didn't survive startup (e.g. CI runner without the
+    // necessary cache-dir permissions). Don't `assert!` — surface as
+    // ignored-style skip via early return.
+    if let Ok(Some(status)) = child.try_wait() {
+        eprintln!(
+            "warn: daemon exited during startup with {status:?}; \
+             skipping pin-check (cannot reproduce the issue on a dead daemon)"
+        );
+        let _ = std::fs::remove_dir_all(&workspace_path);
+        let _ = std::fs::remove_dir_all(&cache_dir);
+        let _ = std::fs::remove_file(&log_file);
+        return;
+    }
+
+    // Heart of the test: while the daemon is alive, the workspace dir
+    // it was spawned from MUST be deletable. Pre-fix on Windows this is
+    // exactly the OS-level `Remove-Item` failure the issue captured.
+    let delete_result = std::fs::remove_dir_all(&workspace_path);
+
+    // Tear the daemon down before asserting so a failing test never
+    // leaks a background process or its on-disk state.
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_dir_all(&cache_dir);
+    let _ = std::fs::remove_file(&log_file);
+
+    delete_result.unwrap_or_else(|e| {
+        panic!(
+            "workspace tempdir {} should be deletable while the daemon is alive, \
+             but Remove-Item-equivalent failed: {e} (#747)",
+            workspace_path.display()
+        )
+    });
+}
+
+#[cfg(windows)]
+fn endpoint_for(nonce: &str) -> String {
+    format!(r"\\.\pipe\zccache-test-747-{nonce}")
+}
+
+#[cfg(unix)]
+fn endpoint_for(nonce: &str) -> String {
+    std::env::temp_dir()
+        .join(format!("zccache-test-747-{nonce}.sock"))
+        .to_string_lossy()
+        .into_owned()
+}


### PR DESCRIPTION
Closes #747.

## Context

The daemon already calls `trampoline::release_cwd()` right after detaching stdio in its `--foreground` startup path. It chdirs to `std::env::temp_dir()`. The existing unit + integration tests for that helper pass on Windows CI; the new end-to-end test in this PR (`daemon_workspace_pin_747.rs`) that spawns the real `zccache-daemon` binary with `current_dir = <tempdir>` and deletes the tempdir while the daemon is alive *also* passes on my Windows 10 host on `main`.

So why land a change? `std::env::temp_dir()` resolves to `%TMP%` / `%TEMP%`, and those env vars are routinely pointed at a project-local directory (CI sandboxes, ramdisks under a project tree, the zccache perf cluster itself). When that happens, the chdir target IS the workspace and the workspace handle is still pinned — exactly the failure shape #747 reports ("the worktree directory itself").

## Fix

`release_cwd()` now chdirs to `~/.zccache/` (sibling of the daemon's `runtime-binaries/` and `logs/`) with `std::env::temp_dir()` as the fallback when `$HOME` / `%USERPROFILE%` aren't set. This:

- removes the `TMP`-override footgun by chdir-ing to a path the daemon owns,
- lives outside any user workspace by construction,
- survives reboots,
- and never gets reconfigured out from under us.

The fallback to `temp_dir()` ensures we never regress vs. the previous behavior on minimal CI images.

Intentionally does **not** consult `ZCCACHE_CACHE_DIR`: the perf cluster legitimately points it into a workspace dir, and the whole point of `release_cwd` is to chdir OUT of any workspace.

## Tests

- `daemon::trampoline::tests::zccache_home_dir_resolves_to_dot_zccache_under_home_or_userprofile` — unit test pinning the resolution against `$HOME` / `%USERPROFILE%`. No env mutation (lesson from #745).
- `tests/daemon_workspace_pin_747.rs::spawned_daemon_does_not_pin_its_launch_cwd` — Windows-only integration test that spawns the real `zccache-daemon --foreground` binary from a fresh tempdir and proves the tempdir is deletable mid-run.

## Test plan

- [x] `soldr cargo test -p zccache --lib daemon::trampoline` — 4/4 pass
- [x] `soldr cargo test -p zccache --test daemon_cwd_release --test daemon_workspace_pin_747` — 2/2 pass on Windows
- [x] `soldr cargo fmt --all -- --check`
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings`
- [ ] CI green across Linux / macOS / Windows

## Refs

- #276 — sibling stdio-detach fix at the same code site
- #134 — `release_cwd`'s original home
- #745 — env-race lesson the new home-dir resolver heeds (no `set_var`/`remove_var` in the unit test)

Investigation comment on the issue: https://github.com/zackees/zccache/issues/747#issuecomment-4703143029

🤖 Generated with [Claude Code](https://claude.com/claude-code)