### PR TITLE
chore(release): bump 1.12.4 -> 1.12.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.12.4"
+version = "1.12.5"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.12.4"
+version = "1.12.5"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.12.4"
+version = "1.12.5"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.12.4"
+version = "1.12.5"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.12.4"
+version = "1.12.5"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump workspace version 1.12.4 -> 1.12.5 (patch).

Triggers `release-auto.yml` on merge to main to publish wheels (PyPI) and crates (crates.io), then a GitHub release.

## Changes since 1.12.4

- fix(meson_cache): restore via extract-then-swap; preserve user files outside allowlist ([#750](https://github.com/zackees/zccache/pull/750), closes #749, cross-ref [FastLED/FastLED#3048](https://github.com/FastLED/FastLED/issues/3048))

## Test plan

- [x] `soldr cargo check --workspace` clean
- [ ] CI green
- [ ] `release-auto.yml` runs on push-to-main with matching workspace version

🤖 Generated with [Claude Code](https://claude.com/claude-code)