### PR TITLE
chore(release): bump 1.12.5 -> 1.12.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.12.5"
+version = "1.12.6"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.12.5"
+version = "1.12.6"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.12.5"
+version = "1.12.6"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.12.5"
+version = "1.12.6"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.12.5"
+version = "1.12.6"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Patch release shipping three changes that landed after 1.12.5:

- **fix(wrap)** — auto-retry link / compile-ephemeral on lost-connection (#754, fixes #752)
- **feat(observability)** — daemon-died / pipe-handover / client-disconnected lifecycle events (#756, refs #755)
- **fix(wedge)** — probe daemon with `Ping` before sending `Shutdown` (#757, fixes #753)

All three are reliability / diagnostics improvements with no breaking surface changes — patch bump.

## Release pipeline

Merging this PR triggers `release-auto.yml` (`detect-bump` sees `1.12.5 -> 1.12.6` in `Cargo.toml` and runs the publish jobs):

- Build wheel + native artifacts (8 targets)
- Publish PyPI wheels via Trusted Publishing
- Publish Rust crates (`CARGO_REGISTRY_TOKEN`)
- Create GitHub release `1.12.6`

## Test plan

- [x] `soldr cargo check --workspace` clean on the bumped lockfile
- [ ] CI green on this PR
- [ ] `release-auto.yml` succeeds on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)