### PR TITLE
fix(config): version-namespace the cache root (#761 Phase 0, closes #762)

### DIFF
--- a/crates/zccache/src/core/config.rs
+++ b/crates/zccache/src/core/config.rs
@@ -140,6 +140,27 @@ pub fn resolve_cache_root() -> (NormalizedPath, CacheRootSource) {
 }
 
 fn resolve_cache_root_from_env_value(value: Option<OsString>) -> (NormalizedPath, CacheRootSource) {
+    let (root, source) = resolve_cache_root_top_level_from_env_value(value);
+    (root.join(versioned_subdir()), source)
+}
+
+/// Issue #761 / meta #762 — Phase 0: shared cache state is now
+/// per-daemon-version. The top-level root (`~/.zccache/` or whatever
+/// `ZCCACHE_CACHE_DIR` points at) is reserved for advisory cross-version
+/// metadata only (e.g. a `last-version.txt` migration breadcrumb); every
+/// state file the daemon and CLI persistently read/write lives under
+/// `<root>/v<daemon-version>/`. Returns the *top-level* root prior to
+/// the version segment — callers that need to drop a cross-version
+/// marker file at the root use this, everyone else uses
+/// `resolve_cache_root` which appends the version automatically.
+#[must_use]
+pub fn resolve_cache_root_top_level() -> (NormalizedPath, CacheRootSource) {
+    resolve_cache_root_top_level_from_env_value(std::env::var_os(CACHE_DIR_ENV))
+}
+
+fn resolve_cache_root_top_level_from_env_value(
+    value: Option<OsString>,
+) -> (NormalizedPath, CacheRootSource) {
     if let Some(p) = cache_dir_from_env_value(value) {
         return (p, CacheRootSource::Env);
     }
@@ -150,6 +171,16 @@ fn resolve_cache_root_from_env_value(value: Option<OsString>) -> (NormalizedPath
         }
     }
     (home.join(".zccache"), CacheRootSource::Default)
+}
+
+/// The version-suffix path segment appended to every resolved cache
+/// root. Format: `v<VERSION>` (e.g. `v1.12.7`) — leading `v` is
+/// intentional so a future `zccache clear` that prunes `^v\d+\.\d+\.\d+$`
+/// subdirs (#761 Phase 0 follow-up) can match cleanly. Exposed for
+/// tooling that wants to enumerate sibling versions.
+#[must_use]
+pub fn versioned_subdir() -> String {
+    format!("v{}", super::VERSION)
 }
 
 /// True when `ZCCACHE_COLOCATE` is set to a non-empty, non-"0" value.
@@ -710,17 +741,38 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_cache_dir_ends_with_zccache() {
+    fn default_cache_dir_lives_under_versioned_subdir() {
+        // Issue #761 / #762 Phase 0: every state file is now per-daemon-version.
+        // The default cache dir must end with `<root>/.zccache/v<VERSION>`, not
+        // `<root>/.zccache` directly.
         let dir = default_cache_dir_from_env_value(None);
-        assert!(dir.ends_with(".zccache"));
+        let segs: Vec<String> = dir
+            .as_path()
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            segs.iter().rev().nth(1).map(String::as_str) == Some(".zccache"),
+            "expected `.zccache` directly above the version segment, got components {segs:?}"
+        );
+        let last = segs.last().expect("path has a last segment");
+        assert!(
+            last.starts_with('v'),
+            "version segment must be `v<VERSION>`, got `{last}`"
+        );
+        assert_eq!(last, &versioned_subdir());
     }
 
     #[test]
-    fn resolve_cache_root_env_branch() {
+    fn resolve_cache_root_env_branch_still_versioned() {
+        // Even when the user pins a custom root via ZCCACHE_CACHE_DIR, the
+        // version segment is still appended so two daemon versions sharing one
+        // override root (the soldr/perf-cluster shape) don't trample each other.
         let root = tempfile::tempdir().unwrap();
-        let want = root.path().join("zc");
-        let (dir, src) = resolve_cache_root_from_env_value(Some(want.clone().into_os_string()));
-        assert_eq!(dir, want);
+        let env_value = root.path().join("zc");
+        let (dir, src) =
+            resolve_cache_root_from_env_value(Some(env_value.clone().into_os_string()));
+        assert_eq!(dir, env_value.join(versioned_subdir()));
         assert_eq!(src, CacheRootSource::Env);
         assert_eq!(src.as_str(), "env:ZCCACHE_CACHE_DIR");
     }
@@ -729,7 +781,15 @@ mod tests {
     fn resolve_cache_root_default_branch_when_env_unset() {
         std::env::remove_var(COLOCATE_ENV);
         let (dir, src) = resolve_cache_root_from_env_value(None);
-        assert!(dir.ends_with(".zccache"));
+        // Default path now ends with `v<VERSION>` (see #761 Phase 0); the
+        // `.zccache` segment is now the SECOND-from-last component.
+        assert_eq!(
+            dir.as_path()
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(""),
+            &versioned_subdir(),
+        );
         assert_eq!(src, CacheRootSource::Default);
         assert_eq!(src.as_str(), "default:platform_dirs");
     }
@@ -739,6 +799,34 @@ mod tests {
         std::env::remove_var(COLOCATE_ENV);
         let (_dir, src) = resolve_cache_root_from_env_value(Some(OsString::new()));
         assert_eq!(src, CacheRootSource::Default);
+    }
+
+    #[test]
+    fn top_level_root_still_unversioned_for_advisory_writes() {
+        // The Phase 0 design reserves the TOP-LEVEL `~/.zccache/` for
+        // cross-version markers (last-version.txt, migration log) — daemons
+        // need a way to address it without picking up their own version
+        // segment. Confirm the new helper hands back the pre-versioning path.
+        let root = tempfile::tempdir().unwrap();
+        let env_value = root.path().join("zc");
+        let (top, _src) =
+            resolve_cache_root_top_level_from_env_value(Some(env_value.clone().into_os_string()));
+        assert_eq!(top, env_value);
+        let (default_top, _) = resolve_cache_root_top_level_from_env_value(None);
+        assert_eq!(
+            default_top
+                .as_path()
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(""),
+            ".zccache",
+        );
+    }
+
+    #[test]
+    fn versioned_subdir_matches_crate_version() {
+        assert_eq!(versioned_subdir(), format!("v{}", crate::core::VERSION));
+        assert!(versioned_subdir().starts_with('v'));
     }
 
     #[test]
@@ -793,32 +881,34 @@ mod tests {
         let cache_dir =
             default_cache_dir_from_env_value(Some(override_dir.clone().into_os_string()));
 
-        assert_eq!(cache_dir, override_dir);
+        // Issue #761 / #762 Phase 0: the env-overridden root is the *top-level*
+        // unversioned path; the actual cache_dir lives one segment below it
+        // under `v<VERSION>` so a single env-pinned root can host multiple
+        // sibling daemon versions without one overwriting the other's state.
+        let versioned = override_dir.join(versioned_subdir());
+        assert_eq!(cache_dir, versioned);
         assert_eq!(
             artifacts_dir_from_cache_dir(&cache_dir),
-            override_dir.join("artifacts")
+            versioned.join("artifacts")
         );
-        assert_eq!(tmp_dir_from_cache_dir(&cache_dir), override_dir.join("tmp"));
+        assert_eq!(tmp_dir_from_cache_dir(&cache_dir), versioned.join("tmp"));
         assert_eq!(
             depgraph_dir_from_cache_dir(&cache_dir),
-            override_dir.join("depgraph")
+            versioned.join("depgraph")
         );
         assert_eq!(
             index_path_from_cache_dir(&cache_dir),
-            override_dir.join("index.bin")
+            versioned.join("index.bin")
         );
         assert_eq!(
             metadata_path_from_cache_dir(&cache_dir),
-            override_dir.join("metadata.bin")
+            versioned.join("metadata.bin")
         );
         assert_eq!(
             crash_dump_dir_from_cache_dir(&cache_dir),
-            override_dir.join("crashes")
+            versioned.join("crashes")
         );
-        assert_eq!(
-            log_dir_from_cache_dir(&cache_dir),
-            override_dir.join("logs")
-        );
+        assert_eq!(log_dir_from_cache_dir(&cache_dir), versioned.join("logs"));
     }
 
     #[test]
@@ -1219,9 +1309,18 @@ mod tests {
         std::env::remove_var(COLOCATE_ENV);
         assert!(!colocate_enabled());
         let result = default_cache_dir_from_env_value(None);
-        assert!(
-            result.to_string_lossy().ends_with(".zccache"),
-            "got {}",
+        // Issue #761 / #762 Phase 0: the active cache_dir is one segment
+        // below `.zccache` — assert on the parent component instead.
+        let parent_name = result
+            .as_path()
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .unwrap_or("");
+        assert_eq!(
+            parent_name,
+            ".zccache",
+            "expected parent component `.zccache`, got path {}",
             result.display()
         );
     }

--- a/crates/zccache/src/core/lifecycle.rs
+++ b/crates/zccache/src/core/lifecycle.rs
@@ -434,7 +434,7 @@ mod tests {
             serde_json::json!({"idle_secs": 3600u64, "uptime_secs": 7200u64}),
         );
 
-        let log_path = tmp.path().join("logs").join("daemon-lifecycle.log");
+        let log_path = log_file_path().as_path().to_path_buf();
         let contents = std::fs::read_to_string(&log_path).expect("log file written");
         let lines: Vec<&str> = contents.lines().collect();
         assert_eq!(lines.len(), 2, "expected two events, got: {contents:?}");
@@ -457,9 +457,12 @@ mod tests {
         let _env = EnvGuard::set_cache_dir_and_namespace(tmp.path(), "soldr-dev");
 
         assert_eq!(live_log_filename(), "daemon-lifecycle-soldr-dev.log");
+        // Issue #761 / #762 Phase 0: cache state lives under
+        // `<root>/v<VERSION>/logs/...`, not `<root>/logs/...`.
         assert_eq!(
             log_file_path(),
             tmp.path()
+                .join(crate::core::config::versioned_subdir())
                 .join("logs")
                 .join("daemon-lifecycle-soldr-dev.log")
         );
@@ -489,8 +492,8 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let _env = EnvGuard::set_cache_dir(tmp.path());
 
-        let log_path = tmp.path().join("logs").join("daemon-lifecycle.log");
-        let archive = tmp.path().join("logs").join("daemon-lifecycle.log.1");
+        let log_path = log_file_path().as_path().to_path_buf();
+        let archive = log_file_path().as_path().with_extension("log.1");
         std::fs::create_dir_all(log_path.parent().unwrap()).unwrap();
 
         let padding = vec![b'x'; (MAX_LOG_SIZE + 1024) as usize];
@@ -511,10 +514,7 @@ mod tests {
 
         assert!(archive.exists(), "archive still present");
         assert!(
-            !tmp.path()
-                .join("logs")
-                .join("daemon-lifecycle.log.2")
-                .exists(),
+            !log_file_path().as_path().with_extension("log.2").exists(),
             "no .2 archive — single-rotation policy"
         );
     }
@@ -586,7 +586,7 @@ mod tests {
             }),
         );
 
-        let log_path = tmp.path().join("logs").join("daemon-lifecycle.log");
+        let log_path = log_file_path().as_path().to_path_buf();
         let contents = std::fs::read_to_string(&log_path).expect("log file written");
         let v: serde_json::Value =
             serde_json::from_str(contents.trim()).expect("jsonl line parses");
@@ -617,7 +617,7 @@ mod tests {
 
         emit_takeover_lifecycle_events(1111, 2222, "9.9.9", "\\\\.\\pipe\\test");
 
-        let log_path = tmp.path().join("logs").join("daemon-lifecycle.log");
+        let log_path = log_file_path().as_path().to_path_buf();
         let contents = std::fs::read_to_string(&log_path).expect("log file written");
         let lines: Vec<&str> = contents.lines().collect();
         assert_eq!(lines.len(), 2, "expected daemon-died + pipe-handover");
@@ -656,8 +656,8 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let _env = EnvGuard::set_cache_dir(tmp.path());
 
-        let log_path = tmp.path().join("logs").join("daemon-lifecycle.log");
-        let archive = tmp.path().join("logs").join("daemon-lifecycle.log.1");
+        let log_path = log_file_path().as_path().to_path_buf();
+        let archive = log_file_path().as_path().with_extension("log.1");
 
         write_event(EVENT_SPAWN, serde_json::json!({"only": "event"}));
         write_event(EVENT_SPAWN, serde_json::json!({"another": "event"}));

--- a/crates/zccache/src/download_protocol/daemon_mgmt.rs
+++ b/crates/zccache/src/download_protocol/daemon_mgmt.rs
@@ -5,8 +5,13 @@ use crate::core::NormalizedPath;
 
 /// Return the default IPC endpoint for the download daemon.
 pub fn default_endpoint() -> String {
-    if let Some(cache_dir) = crate::core::config::cache_dir_override() {
-        return endpoint_for_cache_dir(&cache_dir);
+    if let Some(top_root) = crate::core::config::cache_dir_override() {
+        // Issue #761 / #762 Phase 0: append `v<VERSION>` so two sibling
+        // daemon versions sharing one env-pinned root don't collide on
+        // the IPC endpoint name. The override returns the unversioned
+        // top-level; the endpoint resolver applies the version segment.
+        let versioned = top_root.join(crate::core::config::versioned_subdir());
+        return endpoint_for_cache_dir(versioned.as_path());
     }
 
     #[cfg(unix)]
@@ -107,11 +112,16 @@ mod tests {
         let cache_dir = root.path().join("zc");
         let _env = EnvGuard::set_cache_dir(&cache_dir);
 
+        // Issue #761 / #762 Phase 0: the env var pins the *top-level* root;
+        // every state file (including this lock file) lives under
+        // `<top-level>/v<VERSION>/`.
+        let versioned = cache_dir.join(crate::core::config::versioned_subdir());
+
         let endpoint = default_endpoint();
         #[cfg(unix)]
         assert_eq!(
             endpoint,
-            cache_dir
+            versioned
                 .join("download-daemon.sock")
                 .to_string_lossy()
                 .into_owned()
@@ -119,9 +129,9 @@ mod tests {
         #[cfg(windows)]
         {
             assert!(endpoint.starts_with(r"\\.\pipe\zccache-download-"));
-            assert!(endpoint.ends_with(&crate::core::stable_path_id(&cache_dir)));
+            assert!(endpoint.ends_with(&crate::core::stable_path_id(&versioned)));
         }
 
-        assert_eq!(lock_file_path(), cache_dir.join("download-daemon.lock"));
+        assert_eq!(lock_file_path(), versioned.join("download-daemon.lock"));
     }
 }


### PR DESCRIPTION
Closes #762. Addresses #761 Phase 0. Should dissolve #760 and #759 as a side effect.

## Why

Pre-fix, every state file (artifacts, depgraph, logs, metadata, crash dumps, runtime-binaries, broker JSON, IPC lock files, named-pipe endpoint suffix) lived directly under `~/.zccache/` — a single flat namespace shared by every installed daemon version. Side-by-side installs (the #755 fbuild 1.12.4 + PyPI 1.12.5 collision, or 1.12.6 + 1.12.7 across an upgrade) trampled each other's state: broker JSON pointed at a stale binary, self-hash failed on spawn (#760), the daemon that won the bind silently ran older code (#759 silent mid-build death).

## What

Every resolved cache root now lives one segment below the user-visible `~/.zccache/`, namespaced by daemon version:

```
~/.zccache/v<VERSION>/artifacts/
~/.zccache/v<VERSION>/depgraph/
~/.zccache/v<VERSION>/logs/
~/.zccache/v<VERSION>/runtime-binaries/
~/.zccache/v<VERSION>/download-daemon.lock
... etc.
```

The top-level `~/.zccache/` is reserved for cross-version advisory metadata (planned `last-version.txt` + migration log). Daemons refuse to touch sibling versions' state. Cost: cache miss across upgrade — accepted per the issue body.

## How (localized change)

Two function additions in `crates/zccache/src/core/config.rs`:

- `resolve_cache_root_from_env_value` now appends `versioned_subdir()` to whatever path the existing `Env / Colocated / Default` resolver picked. Every downstream `*_from_cache_dir(cache_dir)` helper (artifacts, logs, depgraph, runtime-binaries, …) inherits the version segment for free without per-helper edits.
- `resolve_cache_root_top_level` (new `pub fn`) exposes the pre-version path for callers that need to drop a cross-version breadcrumb at the root.
- `versioned_subdir` (new `pub fn`) returns `format!("v{VERSION}")` — leading `v` so a future `zccache clear` pruning sibling versions can match `^v\d+\.\d+\.\d+$` cleanly.

Incidental fix: `download_protocol::daemon_mgmt::default_endpoint` now also versions the IPC endpoint suffix on Windows so two sibling daemon versions sharing one env-pinned root don't collide on the named pipe.

## Tests

8 RED→GREEN unit tests in `core::config::tests`:

- `default_cache_dir_lives_under_versioned_subdir`
- `resolve_cache_root_env_branch_still_versioned`
- `resolve_cache_root_default_branch_when_env_unset` (updated)
- `top_level_root_still_unversioned_for_advisory_writes`
- `versioned_subdir_matches_crate_version`
- `cache_dir_override_uses_non_empty_env_value` (updated)
- `colocate_disabled_returns_home_path` (updated)
- `download_protocol::daemon_mgmt::tests::cache_dir_override_*` (updated)

Lifecycle tests updated to call `log_file_path()` directly instead of reconstructing paths — path-construction-agnostic for future layout changes.

Full lib sweep with `--test-threads=1`: **1786/1786 pass**. The parallel run flakes one ipc test on the known `ZCCACHE_CACHE_DIR` env-mutation race (the #745 pattern); pre-existing test-isolation noise, not a regression.

## Test plan

- [x] `soldr cargo test -p zccache --lib -- --test-threads=1` — 1786/1786 pass
- [x] `soldr cargo fmt --all -- --check`
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings`
- [ ] CI green across Linux / macOS / Windows
- [ ] Validate per #762: spawn a 1.12.7 daemon next to a 1.12.6 leftover, confirm each lives under its own `v<VERSION>` subdir and they don't fight on the endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)