### PR TITLE
lint(dylint): bump ban_std_pathbuf version to bust cached plugin

### DIFF
--- a/dylints/ban_std_pathbuf/Cargo.toml
+++ b/dylints/ban_std_pathbuf/Cargo.toml
@@ -1,6 +1,11 @@
 [package]
 name = "ban_std_pathbuf"
-version = "0.1.0"
+# 2026-06-15: bumped to bust the dylint .so cache when allowlist.txt
+# changes. setup-soldr's dylint-cache key hashes the manifest but not
+# src/allowlist.txt, so a content-only change to the allowlist does
+# not invalidate the cached compiled plugin and the OLD allowlist
+# stays in effect.
+version = "0.2.0"
 description = "Ban std::path::PathBuf outside the legacy allowlist"
 edition = "2021"
 publish = false


### PR DESCRIPTION
Follow-up to #764. setup-soldr's dylint-cache hashes Cargo.toml but not src/allowlist.txt, so the new allowlist entries were ignored by the cached .so. Bumping the plugin version forces a fresh compile.