### PR TITLE
lint(dylint): allowlist remaining temp_dir + subprocess sites

### DIFF
--- a/dylints/ban_raw_subprocess_in_daemon/Cargo.toml
+++ b/dylints/ban_raw_subprocess_in_daemon/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "ban_raw_subprocess_in_daemon"
-version = "0.1.0"
+# 2026-06-15: bumped to bust the dylint .so cache when allowlist.txt
+# changes — see ban_std_pathbuf for the same workaround rationale.
+version = "0.2.0"
 description = "Ban raw std/tokio Command spawn/output/status in zccache-daemon production code"
 edition = "2021"
 publish = false

--- a/dylints/ban_raw_subprocess_in_daemon/src/allowlist.txt
+++ b/dylints/ban_raw_subprocess_in_daemon/src/allowlist.txt
@@ -15,3 +15,10 @@ crates/zccache/src/daemon/process.rs
 # lineage.rs has `#[cfg(test)]` modules that spawn `echo` to validate
 # env-var application. Test-only fixtures.
 crates/zccache/src/daemon/lineage.rs
+
+# compiler_hash.rs probes `rustc -vV` to derive a stable identity hash
+# for cache-key purposes. The discovered output is immediately consumed
+# and the child exits; no caching, output redirection, or job-object
+# semantics from `command_output_with_priority` are required for this
+# one-shot capability probe.
+crates/zccache/src/daemon/server/compiler_hash.rs

--- a/dylints/ban_unrooted_tempdir/Cargo.toml
+++ b/dylints/ban_unrooted_tempdir/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "ban_unrooted_tempdir"
-version = "0.1.0"
+# 2026-06-15: bumped to bust the dylint .so cache when allowlist.txt
+# changes — see ban_std_pathbuf for the same workaround rationale.
+version = "0.2.0"
 description = "Ban tempdir/temp_dir calls that aren't rooted under zccache's cache dir"
 edition = "2021"
 publish = false

--- a/dylints/ban_unrooted_tempdir/src/allowlist.txt
+++ b/dylints/ban_unrooted_tempdir/src/allowlist.txt
@@ -33,3 +33,15 @@ crates/zccache-test-support/src/lib.rs
 # by the compiler subprocess and which deliberately don't live under the
 # user-visible `~/.zccache/` tree. Migrating those is a follow-up.
 crates/zccache/src/daemon/server/run.rs
+
+# diag.rs reads `std::env::temp_dir()` purely to display its value in a
+# diagnostic dump (`zccache wrap --diag`). Nothing is created at the
+# path; if the operator's TMPDIR is misconfigured we want to surface
+# the value as observed, not a normalized rewrite.
+crates/zccache/src/cli/commands/wrap/diag.rs
+
+# Same release_cwd pattern as wrap.rs (which is allowlisted above) —
+# passthrough.rs chdirs to $TMPDIR before invoking the underlying tool
+# so the wrapper's own working directory handle is released. The path
+# is the chdir destination, not a scratch location.
+crates/zccache/src/cli/commands/wrap/passthrough.rs


### PR DESCRIPTION
Wraps up the pre-existing dylint failure on main (3 of 8 violators remained after #764 / #765 because they belong to two sibling lints, not ban_std_pathbuf). Plugin versions bumped on both affected plugins to force a fresh .so build with the updated allowlists.