### PR TITLE
chore(release): bump 1.12.6 -> 1.12.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.12.6"
+version = "1.12.7"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.12.6"
+version = "1.12.7"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.12.6"
+version = "1.12.7"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.12.6"
+version = "1.12.7"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.12.6"
+version = "1.12.7"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Ships:

- [#763](https://github.com/zackees/zccache/pull/763) — fix(config): version-namespace the cache root (#761 Phase 0, closes #762, supersedes #760 / #759)
- [#764](https://github.com/zackees/zccache/pull/764) / [#765](https://github.com/zackees/zccache/pull/765) / [#766](https://github.com/zackees/zccache/pull/766) — lint(dylint): allowlist updates + cache-bust to unbreak the Dylint CI job that had been failing on every recent main commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)