### PR TITLE
fix: accept private daemon top-level cache roots

### DIFF
--- a/crates/zccache/src/core/config/mod.rs
+++ b/crates/zccache/src/core/config/mod.rs
@@ -67,8 +67,8 @@ pub use paths::{
     tmp_dir, tmp_dir_from_cache_dir,
 };
 pub use resolve::{
-    cache_dir_override, default_cache_dir, resolve_cache_root, resolve_cache_root_top_level,
-    versioned_subdir, CacheRootSource,
+    cache_dir_override, default_cache_dir, effective_cache_root_from_top_level, resolve_cache_root,
+    resolve_cache_root_top_level, versioned_subdir, CacheRootSource,
 };
 
 /// Top-level configuration for zccache.

--- a/crates/zccache/src/core/config/resolve.rs
+++ b/crates/zccache/src/core/config/resolve.rs
@@ -77,7 +77,7 @@ pub(super) fn resolve_cache_root_from_env_value(
     value: Option<OsString>,
 ) -> (NormalizedPath, CacheRootSource) {
     let (root, source) = resolve_cache_root_top_level_from_env_value(value);
-    (root.join(versioned_subdir()), source)
+    (effective_cache_root_from_top_level(&root), source)
 }
 
 /// Issue #761 / meta #762 — Phase 0: shared cache state is now
@@ -117,6 +117,26 @@ pub(super) fn resolve_cache_root_top_level_from_env_value(
 #[must_use]
 pub fn versioned_subdir() -> String {
     format!("v{}", crate::core::VERSION)
+}
+
+/// Convert a user-facing cache root into the effective daemon cache root.
+///
+/// `ZCCACHE_CACHE_DIR` and `--cache-dir` name the top-level root owned by the
+/// caller. The daemon's persistent state lives one segment below that root in
+/// `v<VERSION>`. If the caller already supplied the effective root, leave it
+/// alone so diagnostics, broker manifests, and compatibility paths do not
+/// double-append the version segment.
+#[must_use]
+pub fn effective_cache_root_from_top_level(cache_root: &NormalizedPath) -> NormalizedPath {
+    let version = versioned_subdir();
+    if cache_root
+        .file_name()
+        .and_then(|segment| segment.to_str())
+        .is_some_and(|segment| segment == version)
+    {
+        return cache_root.clone();
+    }
+    cache_root.join(version)
 }
 
 /// True when `ZCCACHE_COLOCATE` is set to a non-empty, non-"0" value.
@@ -241,4 +261,3 @@ fn normalize_cache_dir_override(path: &std::path::Path) -> NormalizedPath {
             .into()
     }
 }
-

--- a/crates/zccache/src/core/config/tests.rs
+++ b/crates/zccache/src/core/config/tests.rs
@@ -19,8 +19,9 @@ use super::paths::{
 };
 use super::resolve::{
     cache_dir_from_env_value, colocate_enabled, default_cache_dir_from_env_value,
-    resolve_cache_root_from_env_value, resolve_cache_root_top_level_from_env_value,
-    same_volume_root, sanitize_path_component, versioned_subdir, CacheRootSource,
+    effective_cache_root_from_top_level, resolve_cache_root_from_env_value,
+    resolve_cache_root_top_level_from_env_value, same_volume_root, sanitize_path_component,
+    versioned_subdir, CacheRootSource,
 };
 use super::{Config, COLOCATE_ENV};
 use crate::core::NormalizedPath;
@@ -117,6 +118,14 @@ fn top_level_root_still_unversioned_for_advisory_writes() {
 fn versioned_subdir_matches_crate_version() {
     assert_eq!(versioned_subdir(), format!("v{}", crate::core::VERSION));
     assert!(versioned_subdir().starts_with('v'));
+}
+
+#[test]
+fn effective_cache_root_appends_version_once() {
+    let root = NormalizedPath::from("/tmp/zccache-private-root");
+    let effective = effective_cache_root_from_top_level(&root);
+    assert_eq!(effective, root.join(versioned_subdir()));
+    assert_eq!(effective_cache_root_from_top_level(&effective), effective);
 }
 
 #[test]

--- a/crates/zccache/src/daemon/server/session.rs
+++ b/crates/zccache/src/daemon/server/session.rs
@@ -31,12 +31,15 @@ pub(super) async fn handle_session_start(
                 }
             }
             if let Some(cache_dir) = options.cache_dir.as_ref() {
-                if cache_dir != &state.cache_dir {
+                let requested_effective =
+                    crate::core::config::effective_cache_root_from_top_level(cache_dir);
+                if requested_effective != state.cache_dir {
                     return Response::Error {
                         message: format!(
-                            "private daemon cache dir mismatch: connected to {}, requested {}",
+                            "private daemon cache dir mismatch: connected effective root {}, requested root {} (effective {})",
                             state.cache_dir.display(),
-                            cache_dir.display()
+                            cache_dir.display(),
+                            requested_effective.display()
                         ),
                     };
                 }

--- a/crates/zccache/src/daemon/server/tests/server_ipc.rs
+++ b/crates/zccache/src/daemon/server/tests/server_ipc.rs
@@ -205,6 +205,45 @@ async fn private_session_start_registers_redacted_status_and_owner_refs() {
 }
 
 #[tokio::test]
+#[ignore] // integration-level: starts real daemon with IPC + file watcher
+async fn private_session_start_accepts_top_level_cache_root() {
+    crate::test_support::test_timeout(async {
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = CacheDirEnvGuard::set_with_namespace(tmp.path(), "soldr-dev-parent-root");
+        let (endpoint, server_task, shutdown) = start_daemon().await;
+
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
+        client
+            .send(&Request::SessionStart {
+                client_pid: std::process::id(),
+                working_dir: tmp.path().into(),
+                log_file: None,
+                track_stats: false,
+                journal_path: None,
+                profile: false,
+                private_daemon: Some(crate::protocol::PrivateDaemonSessionOptions {
+                    daemon_name: Some("soldr-dev-parent-root".to_string()),
+                    endpoint: Some(endpoint.clone()),
+                    cache_dir: Some(tmp.path().into()),
+                    owner_pids: vec![std::process::id()],
+                    env: Vec::new(),
+                }),
+            })
+            .await
+            .unwrap();
+
+        match client.recv().await.unwrap() {
+            Some(Response::SessionStarted { .. }) => {}
+            other => panic!("expected SessionStarted for top-level cache root, got: {other:?}"),
+        }
+
+        shutdown.notify_one();
+        server_task.await.unwrap();
+    })
+    .await;
+}
+
+#[tokio::test]
 #[ignore] // integration-level: starts real daemon with IPC + compiler
 async fn cli_session_lifecycle() {
     let clang = match crate::test_support::find_clang() {


### PR DESCRIPTION
## Summary

- normalize private-session `--cache-dir` requests to the effective versioned cache root before comparing with the running daemon
- keep endpoint naming based on the caller-provided top-level root, so this stays a compatibility fix rather than expanding private-daemon semantics
- add a regression IPC test for `session-start --private-daemon --cache-dir <top-level-root>` joining a daemon serving from `<top-level-root>/v<version>`

Closes #770.
Related follow-up: #771.

## Tests

- `git diff --check`
- attempted focused `cargo test -p zccache ...`; stopped because local compilation was too slow for this turn, per maintainer direction