### PR TITLE
chore(release): bump 1.12.7 -> 1.12.8 + rustdoc fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.12.7"
+version = "1.12.8"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.12.7"
+version = "1.12.8"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.12.7"
+version = "1.12.8"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.12.7"
+version = "1.12.8"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.12.7"
+version = "1.12.8"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/crates/zccache/src/cli/commands/args/mod.rs
+++ b/crates/zccache/src/cli/commands/args/mod.rs
@@ -12,9 +12,8 @@ use std::path::PathBuf;
 mod subcommands;
 
 pub(crate) use subcommands::{
-    CacheCommands, CargoRegistryCommands, DefenderExclusionsCommands, FpCommands,
-    GhaCacheCommands, KvCommands, MesonCommands, RustPlanBackendArg, RustPlanCommands,
-    SymbolsCommands,
+    CacheCommands, CargoRegistryCommands, DefenderExclusionsCommands, FpCommands, GhaCacheCommands,
+    KvCommands, MesonCommands, RustPlanBackendArg, RustPlanCommands, SymbolsCommands,
 };
 
 /// Environment-variable reference appended to the top-level `--help` output.

--- a/crates/zccache/src/compiler/parse_linker/compiler_driver.rs
+++ b/crates/zccache/src/compiler/parse_linker/compiler_driver.rs
@@ -24,10 +24,7 @@ fn is_linker_input(path: &str) -> bool {
 /// The compiler driver passes flags through to the linker internally,
 /// so we treat the full invocation as a link operation. `-shared` is kept as a
 /// cache-relevant flag since it affects output type.
-pub(super) fn parse_compiler_driver_link(
-    tool: &str,
-    args: Vec<String>,
-) -> ParsedLinkerInvocation {
+pub(super) fn parse_compiler_driver_link(tool: &str, args: Vec<String>) -> ParsedLinkerInvocation {
     if args.is_empty() {
         return ParsedLinkerInvocation::NonCacheable {
             reason: "no arguments".to_string(),

--- a/crates/zccache/src/compiler/parse_linker/mod.rs
+++ b/crates/zccache/src/compiler/parse_linker/mod.rs
@@ -17,8 +17,8 @@
 //! [`ParsedLinkerInvocation`], [`CacheableLink`], [`is_linker`],
 //! [`is_link_invocation`], [`parse_linker_invocation`].
 
-pub(crate) mod detect;
 mod compiler_driver;
+pub(crate) mod detect;
 mod gnu_ld;
 mod msvc_link;
 mod types;

--- a/crates/zccache/src/compiler/parse_linker/mod.rs
+++ b/crates/zccache/src/compiler/parse_linker/mod.rs
@@ -6,12 +6,12 @@
 //!
 //! The implementation is split across focused submodules:
 //!
-//! - [`types`] (private) — public types ([`LinkerFamily`],
+//! - `types` (private) — public types ([`LinkerFamily`],
 //!   [`ParsedLinkerInvocation`], [`CacheableLink`]).
-//! - [`detect`] (private) — tool-name detection and [`is_link_invocation`].
-//! - [`gnu_ld`] (private) — GNU `ld` / LLVM `lld` argument parser.
-//! - [`msvc_link`] (private) — MSVC `link.exe` argument parser.
-//! - [`compiler_driver`] (private) — `gcc` / `clang` as-linker parser.
+//! - `detect` (private) — tool-name detection and [`is_link_invocation`].
+//! - `gnu_ld` (private) — GNU `ld` / LLVM `lld` argument parser.
+//! - `msvc_link` (private) — MSVC `link.exe` argument parser.
+//! - `compiler_driver` (private) — `gcc` / `clang` as-linker parser.
 //!
 //! Public surface (re-exported here): [`LinkerFamily`],
 //! [`ParsedLinkerInvocation`], [`CacheableLink`], [`is_linker`],

--- a/crates/zccache/src/compiler/parse_linker/tests/compiler_driver.rs
+++ b/crates/zccache/src/compiler/parse_linker/tests/compiler_driver.rs
@@ -1,7 +1,7 @@
 //! Compiler-driver-as-linker tests (`gcc`, `clang`, `emcc`, ...).
 
-use super::args;
 use super::super::{parse_linker_invocation, LinkerFamily, ParsedLinkerInvocation};
+use super::args;
 use crate::core::NormalizedPath;
 
 #[test]
@@ -92,8 +92,7 @@ fn gcc_shared_wl_build_id_uuid_non_deterministic() {
 #[test]
 fn gcc_with_compile_flag_non_cacheable() {
     // gcc -c -shared means compile only (not link), should not be cached as link
-    let result =
-        parse_linker_invocation("gcc", args(&["-c", "-shared", "-o", "foo.o", "foo.c"]));
+    let result = parse_linker_invocation("gcc", args(&["-c", "-shared", "-o", "foo.o", "foo.c"]));
     assert!(matches!(
         result,
         ParsedLinkerInvocation::NonCacheable { .. }

--- a/crates/zccache/src/compiler/parse_linker/tests/detection.rs
+++ b/crates/zccache/src/compiler/parse_linker/tests/detection.rs
@@ -1,8 +1,8 @@
 //! Detection tests: `detect_family`, `is_linker`, `is_compiler_driver`.
 
-use super::args;
 use super::super::detect::{detect_family, is_compiler_driver};
 use super::super::{is_link_invocation, is_linker, LinkerFamily};
+use super::args;
 
 #[test]
 fn detect_gnu_ld() {

--- a/crates/zccache/src/compiler/parse_linker/tests/gnu_ld.rs
+++ b/crates/zccache/src/compiler/parse_linker/tests/gnu_ld.rs
@@ -1,15 +1,14 @@
 //! GNU ld / LLD argument-parsing tests.
 
-use super::args;
 use super::super::{parse_linker_invocation, LinkerFamily, ParsedLinkerInvocation};
+use super::args;
 use crate::core::NormalizedPath;
 
 // ─── GNU ld shared library parsing ───────────────────────────────
 
 #[test]
 fn basic_shared_lib() {
-    let result =
-        parse_linker_invocation("ld", args(&["-shared", "-o", "libfoo.so", "a.o", "b.o"]));
+    let result = parse_linker_invocation("ld", args(&["-shared", "-o", "libfoo.so", "a.o", "b.o"]));
     match result {
         ParsedLinkerInvocation::Cacheable(c) => {
             assert_eq!(c.family, LinkerFamily::Ld);
@@ -451,8 +450,7 @@ fn redundant_shared_flags() {
 #[test]
 fn wl_shared_inside_pass_through() {
     // -Wl,-shared inside a -Wl, pass-through should detect shared mode
-    let result =
-        parse_linker_invocation("ld", args(&["-Wl,-shared", "-o", "libfoo.so", "a.o"]));
+    let result = parse_linker_invocation("ld", args(&["-Wl,-shared", "-o", "libfoo.so", "a.o"]));
     match result {
         ParsedLinkerInvocation::Cacheable(c) => {
             assert_eq!(c.output_file, NormalizedPath::new("libfoo.so"));

--- a/crates/zccache/src/compiler/parse_linker/tests/implib.rs
+++ b/crates/zccache/src/compiler/parse_linker/tests/implib.rs
@@ -1,7 +1,7 @@
 //! GNU/LLD `--out-implib` secondary-output tests.
 
-use super::args;
 use super::super::{parse_linker_invocation, LinkerFamily, ParsedLinkerInvocation};
+use super::args;
 use crate::core::NormalizedPath;
 
 #[test]

--- a/crates/zccache/src/compiler/parse_linker/tests/is_link.rs
+++ b/crates/zccache/src/compiler/parse_linker/tests/is_link.rs
@@ -1,7 +1,7 @@
 //! `is_link_invocation` classification tests.
 
-use super::args;
 use super::super::is_link_invocation;
+use super::args;
 
 #[test]
 fn is_link_invocation_direct_linker() {

--- a/crates/zccache/src/compiler/parse_linker/tests/msvc_link.rs
+++ b/crates/zccache/src/compiler/parse_linker/tests/msvc_link.rs
@@ -1,7 +1,7 @@
 //! MSVC `link.exe` argument-parsing tests.
 
-use super::args;
 use super::super::{parse_linker_invocation, LinkerFamily, ParsedLinkerInvocation};
+use super::args;
 use crate::core::NormalizedPath;
 
 #[test]

--- a/crates/zccache/src/compiler/response_file.rs
+++ b/crates/zccache/src/compiler/response_file.rs
@@ -303,11 +303,11 @@ fn format_rsp_content_rustc(args: &[String]) -> Option<String> {
 ///
 /// `family_hint` selects the response-file dialect:
 ///
-/// - [`CompilerFamily::Rustc`] uses rustc's line-oriented format (one arg
+/// - `CompilerFamily::Rustc` uses rustc's line-oriented format (one arg
 ///   per line, no quoting). Required because rustc does not unquote
 ///   `'..."..."...'`-style values from response files; see #634.
 /// - All other families use the GCC/Clang/MSVC-compatible single- or
-///   double-quoted format produced by [`format_rsp_argument`].
+///   double-quoted format produced by `format_rsp_argument`.
 ///
 /// The returned [`TempResponseFile`] keeps the temporary file alive via RAII.
 /// Drop it after the compiler process finishes.

--- a/crates/zccache/src/core/config/tests.rs
+++ b/crates/zccache/src/core/config/tests.rs
@@ -61,8 +61,7 @@ fn resolve_cache_root_env_branch_still_versioned() {
     // override root (the soldr/perf-cluster shape) don't trample each other.
     let root = tempfile::tempdir().unwrap();
     let env_value = root.path().join("zc");
-    let (dir, src) =
-        resolve_cache_root_from_env_value(Some(env_value.clone().into_os_string()));
+    let (dir, src) = resolve_cache_root_from_env_value(Some(env_value.clone().into_os_string()));
     assert_eq!(dir, env_value.join(versioned_subdir()));
     assert_eq!(src, CacheRootSource::Env);
     assert_eq!(src.as_str(), "env:ZCCACHE_CACHE_DIR");
@@ -177,8 +176,7 @@ fn cache_root_invariant_all_subpaths_rooted() {
 fn cache_dir_override_uses_non_empty_env_value() {
     let root = tempfile::tempdir().unwrap();
     let override_dir = root.path().join("zc");
-    let cache_dir =
-        default_cache_dir_from_env_value(Some(override_dir.clone().into_os_string()));
+    let cache_dir = default_cache_dir_from_env_value(Some(override_dir.clone().into_os_string()));
 
     // Issue #761 / #762 Phase 0: the env-overridden root is the *top-level*
     // unversioned path; the actual cache_dir lives one segment below it
@@ -396,8 +394,7 @@ fn cleanup_legacy_temp_root_state_skips_current_cache_dir() {
     std::fs::create_dir_all(&current_cache_dir).unwrap();
     std::fs::write(current_cache_dir.join("sentinel"), "keep").unwrap();
 
-    let cleaned =
-        cleanup_legacy_temp_root_state(temp_root.path(), &current_cache_dir, |_| false);
+    let cleaned = cleanup_legacy_temp_root_state(temp_root.path(), &current_cache_dir, |_| false);
 
     assert_eq!(cleaned, 0);
     assert!(current_cache_dir.exists());
@@ -414,8 +411,7 @@ fn cleanup_legacy_temp_root_state_skips_parent_of_current_cache_dir() {
     std::fs::create_dir_all(&current_cache_dir).unwrap();
     std::fs::write(current_cache_dir.join("sentinel"), "keep").unwrap();
 
-    let cleaned =
-        cleanup_legacy_temp_root_state(temp_root.path(), &current_cache_dir, |_| false);
+    let cleaned = cleanup_legacy_temp_root_state(temp_root.path(), &current_cache_dir, |_| false);
 
     assert_eq!(cleaned, 0);
     assert!(current_cache_dir.exists());
@@ -559,12 +555,10 @@ fn daemon_namespace_sanitizes_for_paths_and_pipes() {
 
 #[test]
 fn daemon_namespace_keeps_long_values_distinct() {
-    let a =
-        daemon_namespace_from_env_value(Some(OsString::from(format!("{}a", "x".repeat(40)))))
-            .unwrap();
-    let b =
-        daemon_namespace_from_env_value(Some(OsString::from(format!("{}b", "x".repeat(40)))))
-            .unwrap();
+    let a = daemon_namespace_from_env_value(Some(OsString::from(format!("{}a", "x".repeat(40)))))
+        .unwrap();
+    let b = daemon_namespace_from_env_value(Some(OsString::from(format!("{}b", "x".repeat(40)))))
+        .unwrap();
     assert_ne!(a, b);
     assert!(a.starts_with(&"x".repeat(32)));
     assert_eq!(a.len(), 41);

--- a/crates/zccache/src/daemon/server/persist/artifact_io.rs
+++ b/crates/zccache/src/daemon/server/persist/artifact_io.rs
@@ -12,7 +12,10 @@ pub(in crate::daemon::server) fn artifact_persist_tmp_path(cache_path: &Path) ->
     cache_path.with_file_name(format!(".{name}.tmp-{}-{counter}", std::process::id()))
 }
 
-pub(in crate::daemon::server) fn persist_artifact_output(cache_path: &Path, payload: &[u8]) -> std::io::Result<()> {
+pub(in crate::daemon::server) fn persist_artifact_output(
+    cache_path: &Path,
+    payload: &[u8],
+) -> std::io::Result<()> {
     if let Some(parent) = cache_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| enrich_persist_err(e, None, cache_path))?;
     }

--- a/crates/zccache/src/daemon/server/persist/pack.rs
+++ b/crates/zccache/src/daemon/server/persist/pack.rs
@@ -51,7 +51,9 @@ pub(in crate::daemon::server) fn build_pack(payloads: &[Arc<Vec<u8>>]) -> Vec<u8
     buf
 }
 
-pub(in crate::daemon::server) fn parse_pack_header(data: &[u8]) -> std::io::Result<Vec<(u64, u64)>> {
+pub(in crate::daemon::server) fn parse_pack_header(
+    data: &[u8],
+) -> std::io::Result<Vec<(u64, u64)>> {
     if data.len() < 8 || &data[..4] != PACK_MAGIC {
         return Err(std::io::Error::other("not a zccache pack file"));
     }

--- a/crates/zccache/src/depgraph/depfile/parse.rs
+++ b/crates/zccache/src/depgraph/depfile/parse.rs
@@ -4,9 +4,9 @@
 use std::collections::HashSet;
 use std::path::Path;
 
+use super::super::scanner::ScanResult;
 use super::canonicalize::canonicalize_path;
 use super::error::DepfileError;
-use super::super::scanner::ScanResult;
 
 /// Parse `.d` file content into a [`ScanResult`].
 ///

--- a/crates/zccache/src/depgraph/depfile/tests.rs
+++ b/crates/zccache/src/depgraph/depfile/tests.rs
@@ -4,13 +4,13 @@ use std::path::Path;
 
 use tempfile::TempDir;
 
+use super::super::args::UserDepFlags;
 use super::canonicalize::{canonicalize_cache_len_for_test, canonicalize_path, strip_win_prefix};
 use super::error::DepfileError;
 use super::parse::{
     find_separator_colon, join_continuations, parse_depfile, parse_depfile_path, split_and_unescape,
 };
 use super::strategy::{prepare_depfile, user_depfile_destination, DepfileStrategy};
-use super::super::args::UserDepFlags;
 use crate::core::NormalizedPath;
 
 /// Helper: create a file with empty content inside a temp dir.
@@ -444,8 +444,7 @@ fn strategy_user_mf() {
         has_md: true,
         mf_path: Some(NormalizedPath::from("/build/deps.d")),
     };
-    let (args, strategy) =
-        prepare_depfile(true, &dep_flags, Path::new("foo.o"), Path::new("/tmp"));
+    let (args, strategy) = prepare_depfile(true, &dep_flags, Path::new("foo.o"), Path::new("/tmp"));
     assert!(args.is_empty());
     assert_eq!(
         strategy,
@@ -461,8 +460,7 @@ fn strategy_user_md_no_mf() {
         has_md: true,
         mf_path: None,
     };
-    let (args, strategy) =
-        prepare_depfile(true, &dep_flags, Path::new("foo.o"), Path::new("/tmp"));
+    let (args, strategy) = prepare_depfile(true, &dep_flags, Path::new("foo.o"), Path::new("/tmp"));
     assert!(args.is_empty());
     assert_eq!(
         strategy,
@@ -513,8 +511,7 @@ fn user_depfile_destination_none_when_user_has_no_dep_flags() {
 #[test]
 fn strategy_injected() {
     let dep_flags = UserDepFlags::default();
-    let (args, strategy) =
-        prepare_depfile(true, &dep_flags, Path::new("foo.o"), Path::new("/tmp"));
+    let (args, strategy) = prepare_depfile(true, &dep_flags, Path::new("foo.o"), Path::new("/tmp"));
 
     assert_eq!(args.len(), 3);
     assert_eq!(args[0], "-MD");

--- a/crates/zccache/src/depgraph/graph/mod.rs
+++ b/crates/zccache/src/depgraph/graph/mod.rs
@@ -5,10 +5,10 @@
 //! - `contexts`: per-compilation-context entries with resolved include lists
 //!
 //! The implementation is split across several files for the LOC guard:
-//! - [`register`] — context registration (`register*`, `register_context_entry`, `is_cold`).
-//! - [`check`] — verdict computation (`check`, `check_diagnostic`, `try_fast_hit`).
-//! - [`update`] — post-compile include-list + artifact-key recording.
-//! - [`maintenance`] — `trim`, `clear`, stats, accessors, `ingest_compile_commands`.
+//! - `register` — context registration (`register*`, `register_context_entry`, `is_cold`).
+//! - `check` — verdict computation (`check`, `check_diagnostic`, `try_fast_hit`).
+//! - `update` — post-compile include-list + artifact-key recording.
+//! - `maintenance` — `trim`, `clear`, stats, accessors, `ingest_compile_commands`.
 
 mod check;
 mod maintenance;

--- a/crates/zccache/src/depgraph/graph/update.rs
+++ b/crates/zccache/src/depgraph/graph/update.rs
@@ -4,13 +4,9 @@
 
 use std::time::Instant;
 
-use super::super::context::{
-    compute_rustc_artifact_key_with_root_with, ArtifactKey, ContextKey,
-};
+use super::super::context::{compute_rustc_artifact_key_with_root_with, ArtifactKey, ContextKey};
 use super::super::scanner::ScanResult;
-use super::{
-    collect_rustc_extern_hashes, depgraph_update_profile_enabled, ContextState, DepGraph,
-};
+use super::{collect_rustc_extern_hashes, depgraph_update_profile_enabled, ContextState, DepGraph};
 use crate::hash::ContentHash;
 
 impl DepGraph {

--- a/crates/zccache/src/download_client/artifact/mod.rs
+++ b/crates/zccache/src/download_client/artifact/mod.rs
@@ -26,7 +26,9 @@ mod tests;
 
 use archive::{extract_archive, remove_path_if_exists};
 use lock::acquire_fetch_lock;
-use marker::{expanded_marker_matches, expanded_marker_path, write_artifact_marker, write_expanded_marker};
+use marker::{
+    expanded_marker_matches, expanded_marker_path, write_artifact_marker, write_expanded_marker,
+};
 use parts::download_explicit_parts;
 use resolve::{resolve_request, resolve_request_no_create};
 use state::{cleanup_invalid_fetch_state, exists_resolved, validate_artifact};

--- a/crates/zccache/src/download_client/artifact/tests/fetch.rs
+++ b/crates/zccache/src/download_client/artifact/tests/fetch.rs
@@ -504,8 +504,7 @@ fn force_is_rejected_for_existing_artifact_state() {
     let dir = tempfile::tempdir().unwrap();
     let destination = dir.path().join("immutable.bin");
 
-    let _ =
-        fetch_with_retry(&client, FetchRequest::new(server.url.clone(), &destination)).unwrap();
+    let _ = fetch_with_retry(&client, FetchRequest::new(server.url.clone(), &destination)).unwrap();
 
     let mut force = FetchRequest::new(server.url.clone(), &destination);
     force.force = true;

--- a/crates/zccache/src/ipc/transport/tests.rs
+++ b/crates/zccache/src/ipc/transport/tests.rs
@@ -54,8 +54,7 @@ async fn recv_wire_accepts_bincode_request_on_live_ipc() {
 
     let server = tokio::spawn(async move {
         let mut conn = listener.accept().await.unwrap();
-        let msg: Option<DecodedWireMessage<Request, pb::Request>> =
-            conn.recv_wire().await.unwrap();
+        let msg: Option<DecodedWireMessage<Request, pb::Request>> = conn.recv_wire().await.unwrap();
         assert_eq!(msg, Some(DecodedWireMessage::BincodeV15(Request::Ping)));
         conn.send(&Response::Pong).await.unwrap();
     });
@@ -75,8 +74,7 @@ async fn recv_wire_accepts_prost_request_on_live_ipc() {
 
     let server = tokio::spawn(async move {
         let mut conn = listener.accept().await.unwrap();
-        let msg: Option<DecodedWireMessage<Request, pb::Request>> =
-            conn.recv_wire().await.unwrap();
+        let msg: Option<DecodedWireMessage<Request, pb::Request>> = conn.recv_wire().await.unwrap();
         match msg {
             Some(DecodedWireMessage::ProstV16(request)) => {
                 assert_eq!(request.request_id, "live-prost");

--- a/crates/zccache/src/protocol/messages/compat/mod.rs
+++ b/crates/zccache/src/protocol/messages/compat/mod.rs
@@ -22,7 +22,9 @@ mod session_stats;
 mod variant_indices;
 
 /// Helper: roundtrip a value through bincode.
-pub(super) fn roundtrip<T: Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug>(
+pub(super) fn roundtrip<
+    T: Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug,
+>(
     val: &T,
 ) {
     let bytes = bincode::serialize(val).unwrap();

--- a/crates/zccache/src/protocol/wire_prost/convert.rs
+++ b/crates/zccache/src/protocol/wire_prost/convert.rs
@@ -186,7 +186,9 @@ pub(super) fn store_result_kind_to_prost(
     }
 }
 
-pub(super) fn store_result_kind_from_prost(kind: i32) -> Result<crate::protocol::StoreResult, String> {
+pub(super) fn store_result_kind_from_prost(
+    kind: i32,
+) -> Result<crate::protocol::StoreResult, String> {
     match zccache_v1::StoreResultKind::try_from(kind) {
         Ok(zccache_v1::StoreResultKind::Stored) => Ok(crate::protocol::StoreResult::Stored),
         Ok(zccache_v1::StoreResultKind::AlreadyExists) => {

--- a/crates/zccache/src/protocol/wire_prost/response.rs
+++ b/crates/zccache/src/protocol/wire_prost/response.rs
@@ -25,9 +25,11 @@ pub fn response_to_prost(
         crate::protocol::Response::LookupResult(result) => {
             Body::LookupResult(lookup_result_to_prost(result))
         }
-        crate::protocol::Response::StoreResult(result) => Body::StoreResult(zccache_v1::StoreResult {
-            kind: store_result_kind_to_prost(result).into(),
-        }),
+        crate::protocol::Response::StoreResult(result) => {
+            Body::StoreResult(zccache_v1::StoreResult {
+                kind: store_result_kind_to_prost(result).into(),
+            })
+        }
         crate::protocol::Response::SessionStarted {
             session_id,
             journal_path,

--- a/crates/zccache/tests/compiler_response_file_integration_test.rs
+++ b/crates/zccache/tests/compiler_response_file_integration_test.rs
@@ -12,7 +12,9 @@ use std::path::Path;
 use zccache::compiler::response_file::{expand_response_files, ResponseFileError};
 
 #[cfg(windows)]
-use zccache::compiler::response_file::{parse_response_file_content, write_response_file_if_needed};
+use zccache::compiler::response_file::{
+    parse_response_file_content, write_response_file_if_needed,
+};
 
 fn s(v: &[&str]) -> Vec<String> {
     v.iter().map(|x| x.to_string()).collect()


### PR DESCRIPTION
## Summary

- **fix(docs):** unbreak `Documentation / Build docs` CI by demoting intra-doc links to private submodules in `parse_linker/mod.rs`, `depgraph/graph/mod.rs`, and `response_file.rs` (fallout from #769 LOC split + a pair of pre-existing references). Verified locally with `RUSTDOCFLAGS="-D warnings" soldr cargo doc --workspace --no-deps`.
- **chore(release):** bump workspace `1.12.7 -> 1.12.8`. No behavioural changes, no protocol bump.

## Test plan

- [x] `RUSTDOCFLAGS="-D warnings" soldr cargo doc --workspace --no-deps` (passes locally on Windows)
- [x] `soldr cargo check --workspace` (refreshes Cargo.lock cleanly)
- [ ] CI on this PR

## Notes — pre-existing failures NOT addressed here

The following CI workflows are red on `main` for reasons **unrelated** to this PR. They do not block `release-auto.yml`, so 1.12.8 will ship over them, but each deserves its own follow-up:

- `Integration`, `Coverage`, `Wrapper end-to-end`, `Test zccache-action` — fail because `cli_cache_root`, `cargo-registry`, and crash-dump tests assert the **top-level** path (`$HOME/.zccache/...`) but `resolve_cache_root()` now returns the **effective** path (`$HOME/.zccache/v<VERSION>/...`) after the #761/#762/#763 version-namespacing chain. PR #772 added `effective_cache_root_from_top_level` for the daemon side, but the CLI surface (`cmd_cache_root`, `cargo_registry_cache_dir`, `crash_dump_dir`) still routes user-facing paths through the versioned root. This is a multi-subsystem design call — should user-facing paths be top-level or effective? — and deserves a dedicated PR.
- `Perf Guard` — the `C speed floor` aggregator job has been failing since #769; root cause not investigated here.
