### PR TITLE
fix(ipc): unstick zccache after taskkill /F on Windows daemon (#774)

### DIFF
--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -671,7 +671,23 @@ pub fn force_kill_process(pid: u32) -> Result<(), std::io::Error> {
     }
 }
 
-/// Check if a process with the given PID is alive.
+/// Check if a process with the given PID is actually running.
+///
+/// On Windows this is stricter than "the kernel still has a process object for
+/// this PID": the function returns `false` for a terminated process whose
+/// process object is being kept alive by some other handle holder (Task
+/// Manager, Process Explorer, a sibling tool that called `OpenProcess` for
+/// monitoring, etc.). Plain `OpenProcess` success is *not* sufficient because
+/// the object can outlive the actual process by an arbitrary amount of time;
+/// see issue #774 where this caused `taskkill /F` on `zccache-daemon` to leave
+/// the CLI looping against a dead PID until manual cleanup.
+///
+/// We disambiguate with `WaitForSingleObject(handle, 0)`: the process object
+/// becomes signaled at termination, so `WAIT_TIMEOUT` (still waiting) is the
+/// unambiguous "actually running" signal. Using `WaitForSingleObject` rather
+/// than `GetExitCodeProcess` also sidesteps the documented Windows wart where
+/// a process that genuinely exited with code 259 is indistinguishable from
+/// one that is still running.
 #[must_use]
 pub fn is_process_alive(pid: u32) -> bool {
     #[cfg(unix)]
@@ -690,16 +706,24 @@ pub fn is_process_alive(pid: u32) -> bool {
         extern "system" {
             fn OpenProcess(access: u32, inherit: i32, pid: u32) -> isize;
             fn CloseHandle(handle: isize) -> i32;
+            fn WaitForSingleObject(handle: isize, milliseconds: u32) -> u32;
         }
         const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
+        const SYNCHRONIZE: u32 = 0x0010_0000;
+        const WAIT_TIMEOUT: u32 = 0x0000_0102;
         unsafe {
-            let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
-            if handle != 0 {
-                CloseHandle(handle);
-                true
-            } else {
-                false
+            let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE, 0, pid);
+            if handle == 0 {
+                return false;
             }
+            // WAIT_TIMEOUT means the process object has not yet been signaled
+            // — i.e. the process really is still running. Any other return
+            // value (WAIT_OBJECT_0 = signaled = exited, WAIT_FAILED, WAIT_ABANDONED)
+            // means the process is not running, even if a zombie process
+            // object keeps the PID nominally addressable.
+            let status = WaitForSingleObject(handle, 0);
+            CloseHandle(handle);
+            status == WAIT_TIMEOUT
         }
     }
 }

--- a/crates/zccache/src/ipc/mod_tests.rs
+++ b/crates/zccache/src/ipc/mod_tests.rs
@@ -704,3 +704,57 @@ async fn probe_returns_false_when_lock_file_pid_is_not_a_daemon() {
              not waited for the connect timeout — elapsed {elapsed:?}"
     );
 }
+
+/// Issue #774 regression. On Windows the kernel keeps a process object
+/// alive as long as **any** handle references it — Task Manager, Process
+/// Explorer, a sibling tool monitoring the daemon, the running-process
+/// broker, etc. Plain `OpenProcess` on the dead PID still returns a
+/// valid handle in that state, so the previous `is_process_alive`
+/// implementation reported the dead daemon as alive and the CLI looped
+/// against an orphaned pipe until the user rebooted.
+///
+/// This test spawns a short-lived process, waits for it to exit, then
+/// pins the kernel process object open via `OpenProcess` and asserts
+/// that `is_process_alive` correctly returns `false` — the
+/// `WaitForSingleObject(handle, 0) == WAIT_TIMEOUT` check added in the
+/// fix is what makes that work.
+#[cfg(windows)]
+#[test]
+fn is_process_alive_returns_false_for_terminated_referenced_process() {
+    use std::process::{Command, Stdio};
+
+    let mut child = Command::new("cmd")
+        .args(["/c", "exit", "0"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn cmd /c exit 0");
+    let pid = child.id();
+    let status = child.wait().expect("wait child");
+    assert!(status.success(), "child should have exited cleanly");
+
+    // Pin the kernel process object alive by holding our own OpenProcess
+    // handle — this is exactly what an external monitor (Task Manager,
+    // a parent shell's job table, fbuild's process tracker) does.
+    #[allow(clashing_extern_declarations)]
+    extern "system" {
+        fn OpenProcess(access: u32, inherit: i32, pid: u32) -> isize;
+        fn CloseHandle(handle: isize) -> i32;
+    }
+    const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
+    let pin = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    assert_ne!(
+        pin, 0,
+        "expected to pin the kernel process object open — without this the OS \
+         may have already reaped the PID and the test would be trivially passing"
+    );
+
+    assert!(
+        !is_process_alive(pid),
+        "PID {pid} terminated cleanly but is_process_alive returned true \
+         (Windows process-object zombie — issue #774)"
+    );
+
+    unsafe { CloseHandle(pin) };
+}

--- a/crates/zccache/src/ipc/transport/mod.rs
+++ b/crates/zccache/src/ipc/transport/mod.rs
@@ -361,10 +361,53 @@ impl IpcListener {
                         .clamp(16, 128)
                 });
 
+            // Issue #774: the first pipe instance asserts namespace ownership
+            // via `first_pipe_instance(true)`. After a hard-killed daemon
+            // (`taskkill /F`), the pipe name can linger briefly in the OS
+            // namespace while the kernel reaps the dead process's handles.
+            // Retry the first bind with backoff to ride out that GC window
+            // before declaring the namespace contested — the alternative is
+            // the daemon failing to start and forcing a reboot. The
+            // companion fix in `is_process_alive` (also #774) stops the CLI
+            // from spinning against a still-referenced-but-terminated PID,
+            // which is what allowed the orphan pipe to outlive the daemon
+            // long enough to matter here.
+            const FIRST_BIND_ATTEMPTS: u32 = 8;
+            const FIRST_BIND_INITIAL_DELAY_MS: u64 = 20;
+            const FIRST_BIND_MAX_DELAY_MS: u64 = 160;
+
             let mut pool = VecDeque::with_capacity(pool_size);
-            for i in 0..pool_size {
+            let first_pipe = {
+                let mut attempt = 0u32;
+                let mut delay_ms = FIRST_BIND_INITIAL_DELAY_MS;
+                loop {
+                    match ServerOptions::new()
+                        .first_pipe_instance(true)
+                        .create(endpoint)
+                    {
+                        Ok(p) => break p,
+                        Err(e) => {
+                            attempt += 1;
+                            if attempt >= FIRST_BIND_ATTEMPTS {
+                                return Err(e.into());
+                            }
+                            tracing::warn!(
+                                attempt,
+                                max_attempts = FIRST_BIND_ATTEMPTS,
+                                error = %e,
+                                endpoint = %endpoint,
+                                "first pipe instance bind failed; retrying after backoff (issue #774)"
+                            );
+                            std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                            delay_ms = (delay_ms * 2).min(FIRST_BIND_MAX_DELAY_MS);
+                        }
+                    }
+                }
+            };
+            pool.push_back(first_pipe);
+            for _ in 1..pool_size {
                 let pipe = ServerOptions::new()
-                    .first_pipe_instance(i == 0)
+                    .first_pipe_instance(false)
                     .create(endpoint)?;
                 pool.push_back(pipe);
             }


### PR DESCRIPTION
Closes #774.

## Summary

Two coupled Windows-only changes that together kill the failure mode where, after `taskkill /F /PID <zccache-daemon>`, the CLI loops against an orphaned pipe with:

```
zccache[err][D]: cannot start daemon at \\.\pipe\zccache-<user>-<hash>:
                 daemon process <pid> exists but not accepting connections
```

The root cause is a **Windows process-object zombie**, not a literal stuck pipe.

### Change 1 — `is_process_alive` correctly detects Windows zombies

`crates/zccache/src/ipc/mod.rs` — the Windows arm of `is_process_alive` used plain `OpenProcess` to decide "alive." But the kernel keeps a process object addressable as long as **any** handle references it: Task Manager, Process Explorer, fbuild's process tracker, the running-process broker, or a parent shell's job table all open a process for monitoring incidentally. After `taskkill /F`, `OpenProcess` still returns a valid handle, so the old code reported the dead daemon as alive → `check_running_daemon()` returned `Some(pid)` → `ensure_daemon()` looped 20×500 ms against a daemon that would never respond.

Fix: add `WaitForSingleObject(handle, 0) == WAIT_TIMEOUT` (with `SYNCHRONIZE` in the access mask) as the unambiguous "actually running" probe. `WaitForSingleObject` is preferred over `GetExitCodeProcess` to sidestep the documented Windows wart where exit code 259 is indistinguishable from `STILL_ACTIVE`.

### Change 2 — bind-retry on first pipe instance

`crates/zccache/src/ipc/transport/mod.rs` — once change 1 lets the CLI correctly identify the dead daemon and spawn a fresh one, the new daemon's `first_pipe_instance(true)` create can still race the OS GC window where the kernel hasn't yet reaped the dead daemon's handle table. Add a short backoff (~510 ms total budget across 8 attempts, 20→160 ms exponential) so the daemon binds cleanly instead of failing startup and forcing a reboot.

## Test plan

- [x] `soldr cargo test -p zccache --lib ipc::tests::is_process_alive_returns_false_for_terminated_referenced_process` (passes on Windows; gated `#[cfg(windows)]`)
- [x] `soldr cargo test -p zccache --lib ipc::` — full ipc suite: 54 passed, 0 failed (includes `pool_recovers_from_full_depletion` which exercises the modified bind path)
- [x] `soldr cargo fmt --all -- --check` clean
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean
- [ ] CI on this PR

## Why two coupled changes, not just the bind-retry?

The bind-retry alone wouldn't help, because the CLI never *gets* to the spawn step — `is_process_alive` says the daemon is alive, so `ensure_daemon` enters the retry loop instead of falling through to `spawn_and_wait(REASON_INITIAL_START)`. Conversely, `is_process_alive` alone would mostly work but leaves a thin race where the freshly-spawned daemon hits a not-yet-GC'd pipe name. Both changes together close the loop end-to-end.

## Out of scope

Per-spawn unique pipe naming (e.g. `\\.\pipe\zccache-<user>-<pid>`) would eliminate the orphan-pipe collision class entirely, but it changes the lockfile format and the endpoint-discovery contract — bigger surface, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
