### PR TITLE
feat(ipc): protocol_v2 round-trip smoke test (#777 spike)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1337,6 +1339,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,6 +1787,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -2427,8 +2445,7 @@ dependencies = [
 [[package]]
 name = "running-process"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0fed77f3564a9728493f29f3c48ef8a85d76508de94fc2bcb2baaea05b58c23"
+source = "git+https://github.com/zackees/running-process?rev=cb57d382791d9a64ad0c35d3d617df60600ad6c0#cb57d382791d9a64ad0c35d3d617df60600ad6c0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2446,10 +2463,14 @@ dependencies = [
  "serde_json",
  "sha2",
  "sysinfo 0.30.13",
+ "tar",
  "thiserror 2.0.18",
  "tokio",
+ "toml",
+ "ureq",
  "winapi",
  "windows-sys 0.59.0",
+ "zstd",
 ]
 
 [[package]]
@@ -2486,6 +2507,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2657,6 +2679,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3102,6 +3133,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3271,6 +3343,21 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -3498,6 +3585,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3702,6 +3807,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"
@@ -4045,4 +4159,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,13 @@ zccache-fingerprint = { path = "crates/zccache-fingerprint" }
 # 2. Report start_read failure (watcher silently dying) as error
 [patch.crates-io]
 notify = { path = "vendor/notify" }
+# Spike for #777: pin to the running-process commit that landed the
+# broker-v2 proto types (zackees/running-process PR #484, slice 1 of
+# zackees/running-process#483). Reproducible for any contributor —
+# no local path required and no dependency on a published crates.io
+# release of that revision. Remove this patch once running-process
+# publishes a version that exposes `broker::protocol_v2`.
+running-process = { git = "https://github.com/zackees/running-process", rev = "cb57d382791d9a64ad0c35d3d617df60600ad6c0" }
 
 [workspace.metadata.dylint]
 libraries = [{ path = "dylints/*" }]

--- a/crates/zccache/tests/protocol_v2_roundtrip_test.rs
+++ b/crates/zccache/tests/protocol_v2_roundtrip_test.rs
@@ -1,0 +1,58 @@
+//! Downstream-consumer smoke test for `running_process::broker::protocol_v2`.
+//!
+//! Coordinates with [zackees/zccache#777](https://github.com/zackees/zccache/issues/777)
+//! and [zackees/running-process#483](https://github.com/zackees/running-process/issues/483).
+//! Slice 1 of the broker-v2 work (running-process PR #484) added the
+//! `protocol_v2::ServiceDefinition` envelope + `HttpServerCapability`
+//! optional sub-message. This test:
+//!
+//! 1. Proves the new v2 types are importable from a downstream consumer.
+//! 2. Exercises a prost encode/decode round-trip end-to-end so the path-dep
+//!    swap (zccache workspace `[patch.crates-io]` → local running-process)
+//!    surfaces immediately if the proto shape regresses upstream.
+//!
+//! The "real" v2 migration (running-process broker binary, v2 client, v2
+//! Frame streaming) is tracked in #777 — those slices land once the
+//! upstream v2 baseline ships.
+
+use prost::Message;
+use running_process::broker::protocol_v2::{HttpServerCapability, ServiceDefinition};
+
+#[test]
+fn protocol_v2_service_definition_round_trips_without_http() {
+    let original = ServiceDefinition {
+        service_name: "zccache".to_owned(),
+        http_server: None,
+    };
+
+    let bytes = original.encode_to_vec();
+    let decoded =
+        ServiceDefinition::decode(bytes.as_slice()).expect("encoded ServiceDefinition decodes");
+
+    assert_eq!(decoded.service_name, "zccache");
+    assert!(decoded.http_server.is_none());
+}
+
+#[test]
+fn protocol_v2_service_definition_round_trips_with_http_capability() {
+    let original = ServiceDefinition {
+        service_name: "zccache".to_owned(),
+        http_server: Some(HttpServerCapability {
+            bind_addr: "127.0.0.1".to_owned(),
+            health_path: "/health".to_owned(),
+            display_name: "zccache status".to_owned(),
+        }),
+    };
+
+    let bytes = original.encode_to_vec();
+    let decoded =
+        ServiceDefinition::decode(bytes.as_slice()).expect("encoded ServiceDefinition decodes");
+
+    let cap = decoded
+        .http_server
+        .expect("http_server survives round-trip");
+    assert_eq!(decoded.service_name, "zccache");
+    assert_eq!(cap.bind_addr, "127.0.0.1");
+    assert_eq!(cap.health_path, "/health");
+    assert_eq!(cap.display_name, "zccache status");
+}


### PR DESCRIPTION
## Summary

Short-form spike from #777 — the running-process v2 broker API integration plan. Validates that:

1. **PR #484** on upstream running-process (broker-v2 proto types) does not regress zccache's v1 broker consumers.
2. The new `running_process::broker::protocol_v2::ServiceDefinition` + `HttpServerCapability` types are importable from a downstream consumer and round-trip cleanly.

## Changes

- **`Cargo.toml`** — adds `[patch.crates-io] running-process = { git = "...", rev = "cb57d38..." }`. Pins to the running-process commit that landed slice 1 of zackees/running-process#483 so any contributor builds reproducibly without a local checkout. **Remove this patch** once running-process publishes a version that exposes `broker::protocol_v2` on crates.io.
- **`Cargo.lock`** — regenerated for the new git+rev dep.
- **`crates/zccache/tests/protocol_v2_roundtrip_test.rs`** — two `#[test]`s constructing a `ServiceDefinition` (with and without `HttpServerCapability`), encoding via prost, decoding, asserting field-for-field equality.

## Test plan

```
$ soldr cargo test -p zccache --test protocol_v2_roundtrip_test
running 2 tests
test protocol_v2_service_definition_round_trips_without_http ... ok
test protocol_v2_service_definition_round_trips_with_http_capability ... ok
test result: ok. 2 passed; 0 failed
```

Also validated `soldr cargo check --workspace` clean against the pinned tip — confirms the proto-only upstream change does not break zccache's v1 broker consumer paths.

## Scope

This is the **short-form acceptance criteria** from #777. The long-form (full v2 broker migration — v2 client, v2 frame streaming, v2 backend identity, etc.) is gated on the upstream v2 baseline shipping (zackees/running-process Phase 1, closed via #474, routed to /clud-pr against the not-yet-created `shmem` branch).

## Coordinated with

- zackees/running-process#483 (parent feature design)
- zackees/running-process/pull/484 (slice 1 — merged proto types)
- zackees/zccache#777 (this integration tracker)

Refs #777. Does **not** use `Closes` — #777 stays open until the full migration lands.