### PR TITLE
feat(ipc): bump running-process patch + add v2 pipe-naming smoke test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "running-process"
 version = "4.4.0"
-source = "git+https://github.com/zackees/running-process?rev=cb57d382791d9a64ad0c35d3d617df60600ad6c0#cb57d382791d9a64ad0c35d3d617df60600ad6c0"
+source = "git+https://github.com/zackees/running-process?rev=975e87ee8ebf65829b65781cde0f94a736163642#975e87ee8ebf65829b65781cde0f94a736163642"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ notify = { path = "vendor/notify" }
 # no local path required and no dependency on a published crates.io
 # release of that revision. Remove this patch once running-process
 # publishes a version that exposes `broker::protocol_v2`.
-running-process = { git = "https://github.com/zackees/running-process", rev = "cb57d382791d9a64ad0c35d3d617df60600ad6c0" }
+running-process = { git = "https://github.com/zackees/running-process", rev = "975e87ee8ebf65829b65781cde0f94a736163642" }
 
 [workspace.metadata.dylint]
 libraries = [{ path = "dylints/*" }]

--- a/crates/zccache/tests/v2_pipe_naming_smoke_test.rs
+++ b/crates/zccache/tests/v2_pipe_naming_smoke_test.rs
@@ -1,0 +1,36 @@
+//! Downstream-consumer smoke test for `running_process::broker::lifecycle::names_v2`.
+//!
+//! Tracks the long-form migration in #777. Slice 3b of upstream #483
+//! (running-process PR #487) added a v2 pipe-naming utility that
+//! constructs `rpb-v2-<program>-<sid_hash>-<pipe_idx>` names — the
+//! namespace a v2 broker will bind on once the binary slices land.
+//!
+//! Asserting on the exact string shape here pins the name format from
+//! a downstream consumer so that any future drift upstream surfaces
+//! immediately, before zccache's runtime broker integration starts
+//! depending on the bytes.
+
+use running_process::broker::lifecycle::names_v2::v2_program_pipe;
+
+#[test]
+fn v2_program_pipe_produces_canonical_zccache_pipe_name() {
+    let name = v2_program_pipe("zccache", "deadbeefcafef00d", 0)
+        .expect("zccache + 16-hex sid + idx 0 are valid inputs");
+    assert_eq!(name, "rpb-v2-zccache-deadbeefcafef00d-0");
+}
+
+#[test]
+fn v2_program_pipe_distinct_pipe_idx_distinct_names() {
+    let name_0 = v2_program_pipe("zccache", "deadbeefcafef00d", 0)
+        .expect("idx=0 valid");
+    let name_7 = v2_program_pipe("zccache", "deadbeefcafef00d", 7)
+        .expect("idx=7 valid");
+
+    assert_ne!(name_0, name_7);
+    assert!(name_7.ends_with("-7"));
+}
+
+#[test]
+fn v2_program_pipe_rejects_invalid_program() {
+    assert!(v2_program_pipe("ZCCACHE", "deadbeefcafef00d", 0).is_err());
+}


### PR DESCRIPTION
## Summary

Bumps the `[patch.crates-io] running-process` pin from `cb57d38` (slice 1 of upstream #483) to `975e87e` — picks up running-process slices 2, 3a, 3b that landed after #778. Adds a second downstream-consumer smoke test that exercises `running_process::broker::lifecycle::names_v2::v2_program_pipe`.

## Changes

- **`Cargo.toml`** — updates the running-process git+rev pin to `975e87e`.
- **`Cargo.lock`** — regenerated.
- **`crates/zccache/tests/v2_pipe_naming_smoke_test.rs`** — three `#[test]`s asserting:
  1. \`v2_program_pipe(\"zccache\", \"deadbeefcafef00d\", 0)\` produces \`rpb-v2-zccache-deadbeefcafef00d-0\` (canonical shape pinned from a consumer).
  2. Different \`pipe_idx\` values produce different names.
  3. Invalid program names (uppercase) are rejected.

The pre-existing \`protocol_v2_roundtrip_test.rs\` (from PR #778) continues to pass against the new tip — no regression on the ServiceDefinition + HttpServerCapability path.

## Why pin the format here

The v2 broker isn't running yet, but zccache will eventually dial the pipe namespace defined by `names_v2::v2_program_pipe`. Asserting on the exact string shape from a downstream test pins the format so any future drift upstream surfaces immediately — well before zccache's runtime broker integration depends on the bytes.

## Test plan

\`\`\`
\$ soldr cargo test -p zccache --test v2_pipe_naming_smoke_test
test result: ok. 3 passed; 0 failed
\`\`\`

## Refs

#777 (integration tracker, stays open until the full v2 migration lands).