### PR TITLE
feat(ipc): bump running-process patch + add v2 client smoke test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "running-process"
 version = "4.4.0"
-source = "git+https://github.com/zackees/running-process?rev=975e87ee8ebf65829b65781cde0f94a736163642#975e87ee8ebf65829b65781cde0f94a736163642"
+source = "git+https://github.com/zackees/running-process?rev=49a356473ef64cbd524f60c718078d61a206eae2#49a356473ef64cbd524f60c718078d61a206eae2"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ notify = { path = "vendor/notify" }
 # no local path required and no dependency on a published crates.io
 # release of that revision. Remove this patch once running-process
 # publishes a version that exposes `broker::protocol_v2`.
-running-process = { git = "https://github.com/zackees/running-process", rev = "975e87ee8ebf65829b65781cde0f94a736163642" }
+running-process = { git = "https://github.com/zackees/running-process", rev = "49a356473ef64cbd524f60c718078d61a206eae2" }
 
 [workspace.metadata.dylint]
 libraries = [{ path = "dylints/*" }]

--- a/crates/zccache/tests/v2_client_smoke_test.rs
+++ b/crates/zccache/tests/v2_client_smoke_test.rs
@@ -1,0 +1,27 @@
+//! Downstream-consumer smoke test for `running_process::broker::client_v2`.
+//!
+//! Tracks #777. Slice 4 of upstream #488 added a typed v2 broker client
+//! (`client_v2::connect`) returning `Result<ClientSession, BrokerV2Error>`.
+//! Asserting on the typed-error path here proves the v2 client API is
+//! importable from a downstream consumer and that the `BrokerV2Error::Dial`
+//! variant fires when no broker is listening — the exact behavior zccache's
+//! eventual v1 → v2 migration will pattern-match on.
+
+use running_process::broker::client_v2::{connect, BrokerV2Error};
+
+#[test]
+fn client_v2_returns_dial_error_when_no_broker_running() {
+    // Use a unique program name so a parallel test never accidentally
+    // satisfies the connect.
+    let err = connect("zccache-v2-smoke-no-broker-12345", "0.0.0")
+        .expect_err("no broker running => Dial error");
+    match err {
+        BrokerV2Error::Dial { socket_path, .. } => {
+            assert!(
+                socket_path.contains("rpb-v2-zccache-v2-smoke-no-broker-12345-"),
+                "Dial socket_path should reference the v2 pipe namespace, got: {socket_path}"
+            );
+        }
+        other => panic!("expected BrokerV2Error::Dial, got: {other:?}"),
+    }
+}


### PR DESCRIPTION
Bumps running-process patch pin from 975e87e to 49a3564 (picks up slices 3c/3d/4). Adds v2_client_smoke_test.rs exercising client_v2::connect typed-error path. Refs #777.