### PR TITLE
feat(ipc): add broker_v2 module — first v2 surface (slice 10 of #488)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "running-process"
 version = "4.4.0"
-source = "git+https://github.com/zackees/running-process?rev=49a356473ef64cbd524f60c718078d61a206eae2#49a356473ef64cbd524f60c718078d61a206eae2"
+source = "git+https://github.com/zackees/running-process?rev=e64f6ff5de860499dc66f2e6fbf3536859ff4d1a#e64f6ff5de860499dc66f2e6fbf3536859ff4d1a"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ notify = { path = "vendor/notify" }
 # no local path required and no dependency on a published crates.io
 # release of that revision. Remove this patch once running-process
 # publishes a version that exposes `broker::protocol_v2`.
-running-process = { git = "https://github.com/zackees/running-process", rev = "49a356473ef64cbd524f60c718078d61a206eae2" }
+running-process = { git = "https://github.com/zackees/running-process", rev = "e64f6ff5de860499dc66f2e6fbf3536859ff4d1a" }
 
 [workspace.metadata.dylint]
 libraries = [{ path = "dylints/*" }]

--- a/crates/zccache/src/ipc/broker_v2.rs
+++ b/crates/zccache/src/ipc/broker_v2.rs
@@ -1,0 +1,51 @@
+//! v2 broker client wiring for zccache (slice 10 of upstream #488).
+//!
+//! First zccache surface that calls the v2 broker API. Wraps
+//! [`running_process::broker::client_v2::connect`] with a zccache-typed
+//! result that fits this crate's existing error idioms. Each subsequent
+//! slice of the migration replaces one more v1 surface with a v2 path,
+//! per the burndown queue in
+//! [zackees/running-process#488](https://github.com/zackees/running-process/issues/488)
+//! and the consumer-side tracker
+//! [zackees/zccache#777](https://github.com/zackees/zccache/issues/777).
+//!
+//! This slice does **not** remove any v1 caller. v2 ships alongside v1
+//! per the coexistence table in upstream #470; the migration is per-
+//! surface and opt-in until every reference is replaced.
+
+use running_process::broker::client_v2::{self, BrokerV2Error, ClientSession};
+
+/// Dial the v2 broker for zccache and return the negotiated session.
+///
+/// `wanted_version` is the daemon version zccache wants — the upstream
+/// Hello carries it as `wanted_version`. The stub v2 broker (slices 3c/3d
+/// of #488) currently accepts any well-formed Hello and replies with a
+/// `Negotiated` carrying the broker binary's own package version as
+/// `daemon_version`, so this entry point gives zccache observable
+/// evidence that the v2 path is wired without depending on a fully-built
+/// production broker.
+pub fn connect_v2_broker(wanted_version: &str) -> Result<ClientSession, BrokerV2Error> {
+    client_v2::connect("zccache", wanted_version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smoke test: with no v2 broker running, `connect_v2_broker` returns
+    /// the typed `BrokerV2Error::Dial` path. This is the same shape the
+    /// rest of zccache will pattern-match on as more surfaces migrate.
+    #[test]
+    fn connect_v2_broker_no_broker_returns_dial_error() {
+        let err = connect_v2_broker("0.0.0").expect_err("no broker => Dial error");
+        match err {
+            BrokerV2Error::Dial { socket_path, .. } => {
+                assert!(
+                    socket_path.contains("rpb-v2-zccache-"),
+                    "Dial socket_path should reference the v2 zccache pipe, got: {socket_path}"
+                );
+            }
+            other => panic!("expected BrokerV2Error::Dial, got: {other:?}"),
+        }
+    }
+}

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::missing_errors_doc)]
 
 pub mod broker;
+pub mod broker_v2;
 pub mod error;
 pub mod manifest;
 pub mod transport;


### PR DESCRIPTION
Slice 10. First v2 surface in zccache: new ipc::broker_v2 module + bumps running-process patch to e64f6ff (picks up slices 5-8). 1 unit test passes. Refs #777.