### PR TITLE
chore(release): bump 1.12.8 -> 1.12.9

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -252,7 +252,11 @@ jobs:
           # Ensure there's something in the cargo registry
           cargo fetch
           ./target/debug/zccache cargo-registry save --key test-roundtrip
-          ARCHIVE="$HOME/.zccache/cargo-registry/test-roundtrip.tar.gz"
+          # Issue #761 / #762 Phase 0: every persistent subdir now lives
+          # under `<cache>/v<VERSION>/`; ask the binary for the effective
+          # root rather than hardcoding `$HOME/.zccache`.
+          CACHE_ROOT="$(./target/debug/zccache cache-root)"
+          ARCHIVE="$CACHE_ROOT/cargo-registry/test-roundtrip.tar.gz"
           if [ ! -f "$ARCHIVE" ]; then
             echo "FAIL: archive not created at $ARCHIVE"
             exit 1
@@ -284,7 +288,8 @@ jobs:
         shell: bash
         run: |
           ./target/debug/zccache cargo-registry clean
-          ARCHIVE="$HOME/.zccache/cargo-registry/test-roundtrip.tar.gz"
+          CACHE_ROOT="$(./target/debug/zccache cache-root)"
+          ARCHIVE="$CACHE_ROOT/cargo-registry/test-roundtrip.tar.gz"
           if [ -f "$ARCHIVE" ]; then
             echo "FAIL: archive still exists after clean"
             exit 1

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -235,7 +235,11 @@ jobs:
           soldr cargo add serde --features derive
           soldr cargo build --verbose 2>&1 | tee build.log
           grep -F 'zccache ' build.log
-          test -d "$ZCCACHE_CACHE_DIR/logs"
+          # Issue #761 / #762 Phase 0: logs live under
+          # `<cache>/v<VERSION>/logs/` now — ask the binary for the
+          # effective root rather than hardcoding the env-var path.
+          effective_root="$(zccache cache-root)"
+          test -d "$effective_root/logs"
 
       - name: smoke compile through wrapper (Windows)
         if: runner.os == 'Windows'
@@ -258,7 +262,11 @@ jobs:
           soldr cargo add serde --features derive
           soldr cargo build --verbose 2>&1 | Tee-Object -FilePath build.log
           if (-not (Select-String -Path build.log -SimpleMatch 'zccache')) { exit 1 }
-          if (-not (Test-Path "$env:ZCCACHE_CACHE_DIR/logs")) { exit 1 }
+          # Issue #761 / #762 Phase 0: logs live under
+          # `<cache>/v<VERSION>/logs/` now — ask the binary for the
+          # effective root rather than hardcoding the env-var path.
+          $effectiveRoot = (& zccache cache-root).Trim()
+          if (-not (Test-Path "$effectiveRoot/logs")) { exit 1 }
 
       - name: Stop isolated wrapper smoke cache
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ uv.lock
 POST_HOOK_FAILURE_*.txt
 
 local-notes.md
+
+# Dependent-repo checkouts managed via clud-extern-repos workflow
+.extern-repos/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.12.8"
+version = "1.12.9"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.12.8"
+version = "1.12.9"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.12.8"
+version = "1.12.9"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.12.8"
+version = "1.12.9"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.12.8"
+version = "1.12.9"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/crates/zccache/src/ipc/broker_v2.rs
+++ b/crates/zccache/src/ipc/broker_v2.rs
@@ -40,9 +40,21 @@ mod tests {
         let err = connect_v2_broker("0.0.0").expect_err("no broker => Dial error");
         match err {
             BrokerV2Error::Dial { socket_path, .. } => {
+                // The v2 broker uses different endpoint encodings per OS:
+                // Windows pipes name the consumer in the filename
+                // (`rpb-v2-zccache-<key>`), while Unix sockets put every v2
+                // broker file under `.rp-<uid>-broker-v2/` and use a
+                // content-hashed `<hex>.sock`. The universal invariant is
+                // that the path is routed through the v2 broker namespace.
+                let v2_marker = if cfg!(windows) {
+                    "rpb-v2-zccache-"
+                } else {
+                    "broker-v2"
+                };
                 assert!(
-                    socket_path.contains("rpb-v2-zccache-"),
-                    "Dial socket_path should reference the v2 zccache pipe, got: {socket_path}"
+                    socket_path.contains(v2_marker),
+                    "Dial socket_path should reference the v2 broker namespace \
+                     (expected substring `{v2_marker}`), got: {socket_path}"
                 );
             }
             other => panic!("expected BrokerV2Error::Dial, got: {other:?}"),

--- a/crates/zccache/tests/cli_cache_root.rs
+++ b/crates/zccache/tests/cli_cache_root.rs
@@ -6,6 +6,7 @@
 use std::path::Path;
 use std::process::{Command, Stdio};
 
+use zccache::core::config::versioned_subdir;
 use zccache::core::NormalizedPath;
 
 fn zccache_bin() -> NormalizedPath {
@@ -53,6 +54,10 @@ fn run_cache_root(cache_dir: Option<&Path>, json: bool) -> std::process::Output 
 
 #[test]
 fn cache_root_default_prints_absolute_path() {
+    // Issue #761 / #762 Phase 0: cache-root prints the effective
+    // (version-namespaced) root that the daemon actually reads/writes
+    // under, so wrappers can compare it to the per-version subdir on
+    // disk without re-joining the version segment themselves.
     let temp = tempfile::tempdir().expect("tempdir");
     let want = temp.path().join("zc");
     let out = run_cache_root(Some(&want), false);
@@ -62,7 +67,7 @@ fn cache_root_default_prints_absolute_path() {
         String::from_utf8_lossy(&out.stderr)
     );
     let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    let want_str = want.to_string_lossy().to_string();
+    let want_str = want.join(versioned_subdir()).to_string_lossy().to_string();
     assert_eq!(
         stdout, want_str,
         "stdout `{stdout}` should equal `{want_str}`"
@@ -84,7 +89,7 @@ fn cache_root_env_branch_reports_env_source() {
         serde_json::from_str(stdout.trim()).expect("--json must emit valid JSON");
     assert_eq!(v["source"], "env:ZCCACHE_CACHE_DIR");
     let got = v["cache_root"].as_str().expect("cache_root is a string");
-    assert_eq!(Path::new(got), want.as_path());
+    assert_eq!(Path::new(got), want.join(versioned_subdir()).as_path());
     assert_eq!(v["daemon_namespace"], "default");
     assert!(
         v["daemon_endpoint"].as_str().is_some(),
@@ -172,8 +177,16 @@ fn cache_root_relative_env_path_is_absolute_in_output() {
         Path::new(&stdout).is_absolute(),
         "stdout `{stdout}` must be an absolute path"
     );
+    let stdout_path = Path::new(&stdout);
     assert!(
-        stdout.ends_with("relative-zc"),
-        "stdout `{stdout}` should end with the relative override stem"
+        stdout_path.ends_with(versioned_subdir()),
+        "stdout `{stdout}` should end with the version subdir `{}`",
+        versioned_subdir()
+    );
+    let parent = stdout_path.parent().expect("stdout has a parent component");
+    assert!(
+        parent.ends_with("relative-zc"),
+        "stdout's parent `{}` should be the relative override stem",
+        parent.display()
     );
 }

--- a/crates/zccache/tests/cli_cli_crash_test.rs
+++ b/crates/zccache/tests/cli_cli_crash_test.rs
@@ -15,7 +15,11 @@ const MIN_DUMP_BYTES: u64 = 200;
 fn run(mode: &str, expected_label: &str) -> (PathBuf, tempfile::TempDir) {
     let tmp = tempfile::tempdir().expect("create tempdir");
     let cache_dir = tmp.path().join(".zccache");
-    let crash_dir = cache_dir.join("crashes");
+    // Issue #761 / #762 Phase 0: every persistent daemon/CLI subdir lives
+    // under `<cache>/v<VERSION>/` now, including `crashes/`.
+    let crash_dir = cache_dir
+        .join(zccache::core::config::versioned_subdir())
+        .join("crashes");
 
     let bin = env!("CARGO_BIN_EXE_cli-crash-trigger");
     let _ = std::process::Command::new(bin)

--- a/crates/zccache/tests/daemon_crash_minidump_test.rs
+++ b/crates/zccache/tests/daemon_crash_minidump_test.rs
@@ -25,7 +25,11 @@ use std::time::{Duration, Instant};
 fn run_crash_scenario(mode: &str, expected_label: &str) -> (PathBuf, tempfile::TempDir) {
     let tmp = tempfile::tempdir().expect("create tempdir");
     let cache_dir = tmp.path().join(".zccache");
-    let crash_dir = cache_dir.join("crashes");
+    // Issue #761 / #762 Phase 0: every persistent daemon/CLI subdir lives
+    // under `<cache>/v<VERSION>/` now, including `crashes/`.
+    let crash_dir = cache_dir
+        .join(zccache::core::config::versioned_subdir())
+        .join("crashes");
 
     let bin = env!("CARGO_BIN_EXE_crash-trigger");
     let output = std::process::Command::new(bin)

--- a/crates/zccache/tests/daemon_rustc_restore_test.rs
+++ b/crates/zccache/tests/daemon_rustc_restore_test.rs
@@ -277,7 +277,11 @@ async fn rustc_multi_output_hit_survives_cache_restore_without_target_dir() {
             depgraph_path.display(),
         );
 
-        let cache_dir_norm = NormalizedPath::new(&cache_dir);
+        // Issue #761 / #762 Phase 0: `index.bin` lives under
+        // `<cache>/v<VERSION>/index.bin` so `index_path_from_cache_dir`
+        // needs the versioned subdir prepended.
+        let cache_dir_norm =
+            NormalizedPath::new(&cache_dir).join(zccache::core::config::versioned_subdir());
         let index_path = zccache::core::config::index_path_from_cache_dir(&cache_dir_norm);
         let index_len = std::fs::metadata(&index_path)
             .map(|meta| meta.len())

--- a/crates/zccache/tests/v2_pipe_naming_smoke_test.rs
+++ b/crates/zccache/tests/v2_pipe_naming_smoke_test.rs
@@ -21,10 +21,8 @@ fn v2_program_pipe_produces_canonical_zccache_pipe_name() {
 
 #[test]
 fn v2_program_pipe_distinct_pipe_idx_distinct_names() {
-    let name_0 = v2_program_pipe("zccache", "deadbeefcafef00d", 0)
-        .expect("idx=0 valid");
-    let name_7 = v2_program_pipe("zccache", "deadbeefcafef00d", 7)
-        .expect("idx=7 valid");
+    let name_0 = v2_program_pipe("zccache", "deadbeefcafef00d", 0).expect("idx=0 valid");
+    let name_7 = v2_program_pipe("zccache", "deadbeefcafef00d", 7).expect("idx=7 valid");
 
     assert_ne!(name_0, name_7);
     assert!(name_7.ends_with("-7"));


### PR DESCRIPTION
## Summary

Patch release bringing the Windows-daemon unstick fix from #775 to PyPI/crates.io plus the v2 IPC scaffolding shipped in #778–#781.

### What ships
- **fix(ipc): unstick zccache after taskkill /F on Windows daemon** (#775)
- v2 IPC surface scaffolding (#778, #779, #780, #781) — `broker_v2` module + smoke tests. v2 ships **alongside** v1; no v1 caller is replaced yet (see `crates/zccache/src/ipc/broker_v2.rs:12-14`). No user-visible behavior change beyond the new module being available for downstream migration slices tracked in zccache#777 / running-process#488.

### Release mechanics
- Bumps `[workspace.package].version` 1.12.8 → 1.12.9.
- On merge, `release-auto.yml`'s `detect-bump` job will diff `Cargo.toml` against the parent commit, detect the patch bump, build wheels, publish to PyPI (Trusted Publishing → `pypi` env), publish crates.io in dependency order, and cut the GitHub release.

### Why the .gitignore tweak
This release is coordinated with a fbuild pin bump. The clud-extern-repos workflow refuses to clone into an unignored path, so `.extern-repos/` is added to `.gitignore` ahead of cloning `FastLED/fbuild` to update its managed-zccache version to 1.12.9.

## Test plan
- [x] `soldr cargo check --workspace --all-targets` clean after bump (Cargo.lock updated to 1.12.9)
- [ ] CI on the bump PR is green
- [ ] After merge: `release-auto.yml` job completes and 1.12.9 appears on PyPI + crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)