### PR TITLE
perf(daemon): defer compiler-hash-cache load off spawn→lockfile path (#784 phase 2a)

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -252,7 +252,11 @@ jobs:
           # Ensure there's something in the cargo registry
           cargo fetch
           ./target/debug/zccache cargo-registry save --key test-roundtrip
-          ARCHIVE="$HOME/.zccache/cargo-registry/test-roundtrip.tar.gz"
+          # Issue #761 / #762 Phase 0: every persistent subdir now lives
+          # under `<cache>/v<VERSION>/`; ask the binary for the effective
+          # root rather than hardcoding `$HOME/.zccache`.
+          CACHE_ROOT="$(./target/debug/zccache cache-root)"
+          ARCHIVE="$CACHE_ROOT/cargo-registry/test-roundtrip.tar.gz"
           if [ ! -f "$ARCHIVE" ]; then
             echo "FAIL: archive not created at $ARCHIVE"
             exit 1
@@ -284,7 +288,8 @@ jobs:
         shell: bash
         run: |
           ./target/debug/zccache cargo-registry clean
-          ARCHIVE="$HOME/.zccache/cargo-registry/test-roundtrip.tar.gz"
+          CACHE_ROOT="$(./target/debug/zccache cache-root)"
+          ARCHIVE="$CACHE_ROOT/cargo-registry/test-roundtrip.tar.gz"
           if [ -f "$ARCHIVE" ]; then
             echo "FAIL: archive still exists after clean"
             exit 1

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -235,7 +235,11 @@ jobs:
           soldr cargo add serde --features derive
           soldr cargo build --verbose 2>&1 | tee build.log
           grep -F 'zccache ' build.log
-          test -d "$ZCCACHE_CACHE_DIR/logs"
+          # Issue #761 / #762 Phase 0: logs live under
+          # `<cache>/v<VERSION>/logs/` now — ask the binary for the
+          # effective root rather than hardcoding the env-var path.
+          effective_root="$(zccache cache-root)"
+          test -d "$effective_root/logs"
 
       - name: smoke compile through wrapper (Windows)
         if: runner.os == 'Windows'
@@ -258,7 +262,11 @@ jobs:
           soldr cargo add serde --features derive
           soldr cargo build --verbose 2>&1 | Tee-Object -FilePath build.log
           if (-not (Select-String -Path build.log -SimpleMatch 'zccache')) { exit 1 }
-          if (-not (Test-Path "$env:ZCCACHE_CACHE_DIR/logs")) { exit 1 }
+          # Issue #761 / #762 Phase 0: logs live under
+          # `<cache>/v<VERSION>/logs/` now — ask the binary for the
+          # effective root rather than hardcoding the env-var path.
+          $effectiveRoot = (& zccache cache-root).Trim()
+          if (-not (Test-Path "$effectiveRoot/logs")) { exit 1 }
 
       - name: Stop isolated wrapper smoke cache
         if: always()

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -396,6 +396,21 @@ fn run_server(args: Args) {
             }
         });
 
+        // Issue #784: move the compiler-hash cache load off the
+        // spawn→lockfile critical path, using the same `spawn_blocking`
+        // shape as the depgraph load above. The loader logs at WARN on
+        // disk failure and leaves the in-memory cache empty; the
+        // stat-verify in `get_or_hash_with` keeps cache-key correctness
+        // either way. Fire-and-forget — the JoinHandle is dropped; if
+        // shutdown fires mid-load, the shutdown save path checks the
+        // `compiler_hash_cache_loaded` flag and skips the write so the
+        // on-disk snapshot is preserved (see `server::run`'s shutdown
+        // arm).
+        let compiler_hash_loader = server.compiler_hash_cache_loader();
+        tokio::task::spawn_blocking(move || {
+            compiler_hash_loader.load_and_install();
+        });
+
         // Wire up Ctrl+C to trigger graceful shutdown
         let shutdown = server.shutdown_handle();
         tokio::spawn(async move {

--- a/crates/zccache/src/daemon/server/compiler_hash.rs
+++ b/crates/zccache/src/daemon/server/compiler_hash.rs
@@ -56,6 +56,22 @@ impl CompilerHashCache {
         self.entries.len()
     }
 
+    /// Drain entries from a freshly loaded `CompilerHashCache` into `self`
+    /// using `DashMap::insert` (which is `&self`).
+    ///
+    /// Issue #784: lets a background `spawn_blocking` task load the on-disk
+    /// snapshot AFTER the daemon has written its readiness lockfile, then
+    /// populate the live cache without holding up bind. Readers during the
+    /// merge window either see no entry (cold-path miss — safe; the next
+    /// call to `get_or_hash_with` re-hashes) or a loaded entry (stat-verify
+    /// at the call site rejects stale (mtime, size) before trusting the
+    /// hash, so a partially-loaded snapshot cannot poison cache keys).
+    pub(super) fn merge_from(&self, other: Self) {
+        for (k, v) in other.entries {
+            self.entries.insert(k, v);
+        }
+    }
+
     pub(super) fn get_or_hash_with<F>(&self, path: &Path, hasher: F) -> Option<ContentHash>
     where
         F: FnOnce(&Path) -> Option<ContentHash>,

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -87,17 +87,15 @@ impl DaemonServer {
         // (path, mtime, size, hash) snapshot from a prior daemon makes
         // that first compile near-instant — the stat-verify in
         // `get_or_hash_with` keeps correctness if the binary changed since.
-        let compiler_hash_cache =
-            match CompilerHashCache::load_from_disk(compiler_hash_cache_path.as_path()) {
-                Ok(cache) => cache,
-                Err(e) => {
-                    tracing::warn!(
-                        path = %compiler_hash_cache_path.display(),
-                        "failed to load compiler hash cache, starting empty: {e}"
-                    );
-                    CompilerHashCache::new()
-                }
-            };
+        //
+        // Issue #784: start empty here. The on-disk snapshot is loaded
+        // by `compiler_hash_cache_loader()`'s `install()` in a
+        // `spawn_blocking` AFTER the daemon's readiness lockfile is
+        // written, so the disk read is removed from the spawn→lockfile
+        // critical path. Compile requests arriving during the merge
+        // window take the cold blake3 path — same outcome as before
+        // #517's persistence existed.
+        let compiler_hash_cache = CompilerHashCache::new();
         let cache_system =
             match crate::fscache::MetadataCache::load_from_disk(metadata_path.as_path()) {
                 Ok(metadata) => {
@@ -170,6 +168,7 @@ impl DaemonServer {
                 index_writer_tx,
                 index_writer_shutdown,
                 artifacts_loaded: AtomicBool::new(false),
+                compiler_hash_cache_loaded: AtomicBool::new(false),
                 shutdown_event_logged: AtomicBool::new(false),
                 fingerprint: FingerprintManager::new(),
                 dep_graph_persisted: AtomicBool::new(false),
@@ -235,6 +234,22 @@ impl DaemonServer {
     pub fn dep_graph_setter(&self) -> DepGraphSetter {
         DepGraphSetter {
             state: Arc::clone(&self.state),
+        }
+    }
+
+    /// Hand out a loader that reads the compiler-hash cache from disk and
+    /// installs it into the running state. Issue #784 — moves the load
+    /// out of `bind_with_cache_dir`'s critical path so the readiness
+    /// lockfile fires before any disk I/O.
+    ///
+    /// Designed to be called once, immediately after `write_lock_file`,
+    /// inside a `tokio::task::spawn_blocking`. The handle captures the
+    /// on-disk snapshot path so the daemon binary doesn't need access
+    /// to the (private) `compiler_hash_cache_path` field.
+    pub fn compiler_hash_cache_loader(&self) -> CompilerHashCacheLoader {
+        CompilerHashCacheLoader {
+            state: Arc::clone(&self.state),
+            path: self.state.compiler_hash_cache_path.clone(),
         }
     }
 
@@ -352,5 +367,47 @@ impl DepGraphSetter {
             let mut guard = self.state.depgraph_load_warning.blocking_lock();
             *guard = Some(warning);
         }
+    }
+}
+
+/// Owned handle that loads the on-disk compiler-hash-cache snapshot and
+/// merges it into the running daemon's state.
+///
+/// Issue #784. Mirrors [`DepGraphSetter`]'s role for the depgraph: the
+/// daemon binary holds one across a `spawn_blocking` boundary and calls
+/// [`Self::load_and_install`] once after the readiness lockfile is
+/// written. The merge uses [`CompilerHashCache::merge_from`], which is
+/// `&self`, so concurrent `get_or_hash_with` readers either see no entry
+/// (cold-hash path) or a loaded entry (stat-verify guards correctness).
+pub struct CompilerHashCacheLoader {
+    state: Arc<SharedState>,
+    path: crate::core::NormalizedPath,
+}
+
+impl CompilerHashCacheLoader {
+    /// Load the on-disk compiler-hash-cache snapshot (if any) and merge
+    /// it into the live state.
+    ///
+    /// A missing or corrupt snapshot is logged at WARN and the live
+    /// cache is left empty (the stat-verify safety net in
+    /// `get_or_hash_with` keeps correctness either way). After the
+    /// merge — successful or empty — `compiler_hash_cache_loaded` is
+    /// set so `run.rs`'s shutdown path knows the in-memory state is
+    /// canonical and safe to save.
+    pub fn load_and_install(self) {
+        match CompilerHashCache::load_from_disk(self.path.as_path()) {
+            Ok(loaded) => {
+                self.state.compiler_hash_cache.merge_from(loaded);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %self.path.display(),
+                    "failed to load compiler hash cache, starting empty: {e}"
+                );
+            }
+        }
+        self.state
+            .compiler_hash_cache_loaded
+            .store(true, Ordering::Release);
     }
 }

--- a/crates/zccache/src/daemon/server/run.rs
+++ b/crates/zccache/src/daemon/server/run.rs
@@ -438,14 +438,35 @@ impl DaemonServer {
                     // Issue #517: persist the compiler-binary hash cache
                     // so the next daemon does not pay the ~50-60 ms cold
                     // blake3 over rustc on its first compile.
-                    if let Err(e) = self
+                    //
+                    // Issue #784: gate on `compiler_hash_cache_loaded`.
+                    // The disk load now runs in a background
+                    // `spawn_blocking` after the readiness lockfile, so
+                    // an early shutdown (Ctrl+C before the loader
+                    // finishes) could otherwise save a partial snapshot
+                    // over the on-disk file. Skipping the save when the
+                    // load hasn't completed preserves the existing
+                    // snapshot — the in-memory DashMap is still warm
+                    // enough for the in-process compiles that already
+                    // happened.
+                    if self
                         .state
-                        .compiler_hash_cache
-                        .save_to_disk(self.state.compiler_hash_cache_path.as_path())
+                        .compiler_hash_cache_loaded
+                        .load(Ordering::Acquire)
                     {
-                        tracing::warn!(
-                            path = %self.state.compiler_hash_cache_path.display(),
-                            "compiler hash cache save failed: {e}"
+                        if let Err(e) = self
+                            .state
+                            .compiler_hash_cache
+                            .save_to_disk(self.state.compiler_hash_cache_path.as_path())
+                        {
+                            tracing::warn!(
+                                path = %self.state.compiler_hash_cache_path.display(),
+                                "compiler hash cache save failed: {e}"
+                            );
+                        }
+                    } else {
+                        tracing::debug!(
+                            "compiler hash cache load still pending at shutdown — skipping save"
                         );
                     }
 

--- a/crates/zccache/src/daemon/server/state.rs
+++ b/crates/zccache/src/daemon/server/state.rs
@@ -152,6 +152,15 @@ pub(super) struct SharedState {
     pub(super) index_writer_shutdown: Arc<Notify>,
     /// Whether the background artifact loading has completed.
     pub(super) artifacts_loaded: AtomicBool,
+    /// Whether the background compiler-hash-cache load has completed.
+    ///
+    /// Issue #784: the on-disk snapshot is loaded post-lockfile from a
+    /// `spawn_blocking` task. The shutdown save path checks this before
+    /// calling `save_to_disk` — saving while the load is still pending
+    /// could write a partial snapshot over the persisted file. False
+    /// until the loader's `install()` runs; once true the in-memory
+    /// DashMap is considered canonical for save.
+    pub(super) compiler_hash_cache_loaded: AtomicBool,
     /// Whether the `died-shutdown` lifecycle event has been written for this
     /// daemon. Under burst load (issue #726), many wedge-detecting clients
     /// race to send `Request::Shutdown` within a few milliseconds and each

--- a/crates/zccache/src/daemon/server/tests/compiler_hash.rs
+++ b/crates/zccache/src/daemon/server/tests/compiler_hash.rs
@@ -3,6 +3,7 @@
 //! avoids re-hashing the compiler binary on every request.
 
 use super::super::*;
+use std::time::SystemTime;
 
 #[test]
 fn compiler_hash_cache_reuses_hash_for_unchanged_compiler() {
@@ -243,4 +244,156 @@ fn compiler_hash_cache_load_rehashes_when_binary_changes_after_save() {
         "stale snapshot must not survive a binary change",
     );
     assert_eq!(hash_calls.load(Ordering::Relaxed), 1);
+}
+
+// ── Issue #784: deferred compiler-hash-cache load ─────────────────────────
+
+/// `bind_with_cache_dir` no longer reads the compiler-hash-cache snapshot
+/// from disk. The cache starts empty regardless of what is on disk; the
+/// daemon binary's `compiler_hash_cache_loader().load_and_install()` does
+/// the merge after the readiness lockfile is written.
+#[tokio::test]
+async fn bind_does_not_load_compiler_hash_cache_from_disk() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let snapshot_path = crate::core::config::compiler_hash_cache_path_from_cache_dir(&cache_dir);
+
+    // Pre-write a snapshot with two entries.
+    let pre = CompilerHashCache::new();
+    let compiler_a = tmp.path().join("rustc-a.exe");
+    let compiler_b = tmp.path().join("rustc-b.exe");
+    std::fs::write(&compiler_a, b"fake rustc a").unwrap();
+    std::fs::write(&compiler_b, b"fake rustc b").unwrap();
+    pre.get_or_hash_with(&compiler_a, |_| Some(ContentHash::from_bytes([0xAA; 32])));
+    pre.get_or_hash_with(&compiler_b, |_| Some(ContentHash::from_bytes([0xBB; 32])));
+    pre.save_to_disk(snapshot_path.as_path()).unwrap();
+    assert!(snapshot_path.as_path().exists());
+
+    // Bind — must NOT read the snapshot (the load is deferred to the
+    // background loader fired post-lockfile by the daemon binary).
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+    let state = server.test_state();
+    assert_eq!(
+        state.compiler_hash_cache.len(),
+        0,
+        "bind must start with an empty compiler-hash cache",
+    );
+    assert!(
+        !state.compiler_hash_cache_loaded.load(Ordering::Acquire),
+        "the loaded flag must start false until the background loader runs",
+    );
+}
+
+/// The `compiler_hash_cache_loader()` handle reads the snapshot and
+/// merges it into the live cache. Confirms the deferred-load path
+/// reaches functional parity with the old sync-in-bind path.
+#[tokio::test]
+async fn compiler_hash_cache_loader_merges_snapshot_into_live_cache() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let snapshot_path = crate::core::config::compiler_hash_cache_path_from_cache_dir(&cache_dir);
+
+    let pre = CompilerHashCache::new();
+    let compiler = tmp.path().join("rustc.exe");
+    std::fs::write(&compiler, b"fake rustc").unwrap();
+    pre.get_or_hash_with(&compiler, |_| Some(ContentHash::from_bytes([0x42; 32])));
+    pre.save_to_disk(snapshot_path.as_path()).unwrap();
+
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+
+    // Run the loader synchronously (it's `spawn_blocking`-safe but
+    // calling it inline in the test is equivalent for observability).
+    server.compiler_hash_cache_loader().load_and_install();
+
+    let state = server.test_state();
+    assert_eq!(
+        state.compiler_hash_cache.len(),
+        1,
+        "loader must merge the persisted entry into the live cache",
+    );
+    assert!(
+        state.compiler_hash_cache_loaded.load(Ordering::Acquire),
+        "loader must set compiler_hash_cache_loaded=true so shutdown save fires",
+    );
+
+    // The loaded entry must short-circuit the hasher on next lookup —
+    // proving the (path, mtime, size) -> hash mapping survived the
+    // bind → loader hop.
+    let hash_calls = AtomicUsize::new(0);
+    let observed = state.compiler_hash_cache.get_or_hash_with(&compiler, |_| {
+        hash_calls.fetch_add(1, Ordering::Relaxed);
+        Some(ContentHash::from_bytes([0x99; 32]))
+    });
+    assert_eq!(observed, Some(ContentHash::from_bytes([0x42; 32])));
+    assert_eq!(
+        hash_calls.load(Ordering::Relaxed),
+        0,
+        "loaded entry must hit, not re-hash",
+    );
+}
+
+/// Missing on-disk snapshot is not an error: the loader logs a warning,
+/// leaves the live cache empty, and still flips the loaded flag so
+/// shutdown save fires (and short-circuits because the cache is empty
+/// per `save_to_disk`'s empty-cache early-exit).
+#[tokio::test]
+async fn compiler_hash_cache_loader_tolerates_missing_snapshot() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+
+    server.compiler_hash_cache_loader().load_and_install();
+
+    let state = server.test_state();
+    assert_eq!(state.compiler_hash_cache.len(), 0);
+    assert!(
+        state.compiler_hash_cache_loaded.load(Ordering::Acquire),
+        "loaded flag flips even when the snapshot was absent",
+    );
+}
+
+/// `merge_from` is `&self`, takes ownership of the loaded cache, and
+/// drains all entries. Documents the contract the deferred loader
+/// relies on.
+#[test]
+fn compiler_hash_cache_merge_from_drains_other() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("a");
+    let b = tmp.path().join("b");
+    std::fs::write(&a, b"a").unwrap();
+    std::fs::write(&b, b"b").unwrap();
+
+    let live = CompilerHashCache::new();
+    let mtime = SystemTime::now();
+    live.entries.insert(
+        crate::core::NormalizedPath::new(&a),
+        CompilerHashEntry {
+            mtime,
+            size: 1,
+            hash: ContentHash::from_bytes([1; 32]),
+        },
+    );
+
+    let loaded = CompilerHashCache::new();
+    loaded.entries.insert(
+        crate::core::NormalizedPath::new(&b),
+        CompilerHashEntry {
+            mtime,
+            size: 1,
+            hash: ContentHash::from_bytes([2; 32]),
+        },
+    );
+
+    live.merge_from(loaded);
+
+    assert_eq!(live.entries.len(), 2);
+    assert!(live
+        .entries
+        .contains_key(&crate::core::NormalizedPath::new(&a)));
+    assert!(live
+        .entries
+        .contains_key(&crate::core::NormalizedPath::new(&b)));
 }

--- a/crates/zccache/src/ipc/broker_v2.rs
+++ b/crates/zccache/src/ipc/broker_v2.rs
@@ -40,9 +40,21 @@ mod tests {
         let err = connect_v2_broker("0.0.0").expect_err("no broker => Dial error");
         match err {
             BrokerV2Error::Dial { socket_path, .. } => {
+                // The v2 broker uses different endpoint encodings per OS:
+                // Windows pipes name the consumer in the filename
+                // (`rpb-v2-zccache-<key>`), while Unix sockets put every v2
+                // broker file under `.rp-<uid>-broker-v2/` and use a
+                // content-hashed `<hex>.sock`. The universal invariant is
+                // that the path is routed through the v2 broker namespace.
+                let v2_marker = if cfg!(windows) {
+                    "rpb-v2-zccache-"
+                } else {
+                    "broker-v2"
+                };
                 assert!(
-                    socket_path.contains("rpb-v2-zccache-"),
-                    "Dial socket_path should reference the v2 zccache pipe, got: {socket_path}"
+                    socket_path.contains(v2_marker),
+                    "Dial socket_path should reference the v2 broker namespace \
+                     (expected substring `{v2_marker}`), got: {socket_path}"
                 );
             }
             other => panic!("expected BrokerV2Error::Dial, got: {other:?}"),

--- a/crates/zccache/tests/cli_cache_root.rs
+++ b/crates/zccache/tests/cli_cache_root.rs
@@ -6,6 +6,7 @@
 use std::path::Path;
 use std::process::{Command, Stdio};
 
+use zccache::core::config::versioned_subdir;
 use zccache::core::NormalizedPath;
 
 fn zccache_bin() -> NormalizedPath {
@@ -53,6 +54,10 @@ fn run_cache_root(cache_dir: Option<&Path>, json: bool) -> std::process::Output 
 
 #[test]
 fn cache_root_default_prints_absolute_path() {
+    // Issue #761 / #762 Phase 0: cache-root prints the effective
+    // (version-namespaced) root that the daemon actually reads/writes
+    // under, so wrappers can compare it to the per-version subdir on
+    // disk without re-joining the version segment themselves.
     let temp = tempfile::tempdir().expect("tempdir");
     let want = temp.path().join("zc");
     let out = run_cache_root(Some(&want), false);
@@ -62,7 +67,7 @@ fn cache_root_default_prints_absolute_path() {
         String::from_utf8_lossy(&out.stderr)
     );
     let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    let want_str = want.to_string_lossy().to_string();
+    let want_str = want.join(versioned_subdir()).to_string_lossy().to_string();
     assert_eq!(
         stdout, want_str,
         "stdout `{stdout}` should equal `{want_str}`"
@@ -84,7 +89,7 @@ fn cache_root_env_branch_reports_env_source() {
         serde_json::from_str(stdout.trim()).expect("--json must emit valid JSON");
     assert_eq!(v["source"], "env:ZCCACHE_CACHE_DIR");
     let got = v["cache_root"].as_str().expect("cache_root is a string");
-    assert_eq!(Path::new(got), want.as_path());
+    assert_eq!(Path::new(got), want.join(versioned_subdir()).as_path());
     assert_eq!(v["daemon_namespace"], "default");
     assert!(
         v["daemon_endpoint"].as_str().is_some(),
@@ -172,8 +177,16 @@ fn cache_root_relative_env_path_is_absolute_in_output() {
         Path::new(&stdout).is_absolute(),
         "stdout `{stdout}` must be an absolute path"
     );
+    let stdout_path = Path::new(&stdout);
     assert!(
-        stdout.ends_with("relative-zc"),
-        "stdout `{stdout}` should end with the relative override stem"
+        stdout_path.ends_with(versioned_subdir()),
+        "stdout `{stdout}` should end with the version subdir `{}`",
+        versioned_subdir()
+    );
+    let parent = stdout_path.parent().expect("stdout has a parent component");
+    assert!(
+        parent.ends_with("relative-zc"),
+        "stdout's parent `{}` should be the relative override stem",
+        parent.display()
     );
 }

--- a/crates/zccache/tests/cli_cli_crash_test.rs
+++ b/crates/zccache/tests/cli_cli_crash_test.rs
@@ -15,7 +15,11 @@ const MIN_DUMP_BYTES: u64 = 200;
 fn run(mode: &str, expected_label: &str) -> (PathBuf, tempfile::TempDir) {
     let tmp = tempfile::tempdir().expect("create tempdir");
     let cache_dir = tmp.path().join(".zccache");
-    let crash_dir = cache_dir.join("crashes");
+    // Issue #761 / #762 Phase 0: every persistent daemon/CLI subdir lives
+    // under `<cache>/v<VERSION>/` now, including `crashes/`.
+    let crash_dir = cache_dir
+        .join(zccache::core::config::versioned_subdir())
+        .join("crashes");
 
     let bin = env!("CARGO_BIN_EXE_cli-crash-trigger");
     let _ = std::process::Command::new(bin)

--- a/crates/zccache/tests/daemon_crash_minidump_test.rs
+++ b/crates/zccache/tests/daemon_crash_minidump_test.rs
@@ -25,7 +25,11 @@ use std::time::{Duration, Instant};
 fn run_crash_scenario(mode: &str, expected_label: &str) -> (PathBuf, tempfile::TempDir) {
     let tmp = tempfile::tempdir().expect("create tempdir");
     let cache_dir = tmp.path().join(".zccache");
-    let crash_dir = cache_dir.join("crashes");
+    // Issue #761 / #762 Phase 0: every persistent daemon/CLI subdir lives
+    // under `<cache>/v<VERSION>/` now, including `crashes/`.
+    let crash_dir = cache_dir
+        .join(zccache::core::config::versioned_subdir())
+        .join("crashes");
 
     let bin = env!("CARGO_BIN_EXE_crash-trigger");
     let output = std::process::Command::new(bin)

--- a/crates/zccache/tests/daemon_rustc_restore_test.rs
+++ b/crates/zccache/tests/daemon_rustc_restore_test.rs
@@ -277,7 +277,11 @@ async fn rustc_multi_output_hit_survives_cache_restore_without_target_dir() {
             depgraph_path.display(),
         );
 
-        let cache_dir_norm = NormalizedPath::new(&cache_dir);
+        // Issue #761 / #762 Phase 0: `index.bin` lives under
+        // `<cache>/v<VERSION>/index.bin` so `index_path_from_cache_dir`
+        // needs the versioned subdir prepended.
+        let cache_dir_norm =
+            NormalizedPath::new(&cache_dir).join(zccache::core::config::versioned_subdir());
         let index_path = zccache::core::config::index_path_from_cache_dir(&cache_dir_norm);
         let index_len = std::fs::metadata(&index_path)
             .map(|meta| meta.len())

--- a/crates/zccache/tests/v2_pipe_naming_smoke_test.rs
+++ b/crates/zccache/tests/v2_pipe_naming_smoke_test.rs
@@ -21,10 +21,8 @@ fn v2_program_pipe_produces_canonical_zccache_pipe_name() {
 
 #[test]
 fn v2_program_pipe_distinct_pipe_idx_distinct_names() {
-    let name_0 = v2_program_pipe("zccache", "deadbeefcafef00d", 0)
-        .expect("idx=0 valid");
-    let name_7 = v2_program_pipe("zccache", "deadbeefcafef00d", 7)
-        .expect("idx=7 valid");
+    let name_0 = v2_program_pipe("zccache", "deadbeefcafef00d", 0).expect("idx=0 valid");
+    let name_7 = v2_program_pipe("zccache", "deadbeefcafef00d", 7).expect("idx=7 valid");
 
     assert_ne!(name_0, name_7);
     assert!(name_7.ends_with("-7"));


### PR DESCRIPTION
## Summary

Phase 2a of #784: defer the compiler-hash-cache load off the spawn→lockfile critical path using the `spawn_blocking` + atomic-merge pattern that #640 established for the depgraph load.

Of the four sync loads inside `DaemonServer::bind_with_cache_dir` that #784 wants moved (metadata, compiler-hash, system-includes, artifact-index), this PR ships the smallest, lowest-blast-radius one. The pattern is now in place for the remaining three to follow in sibling PRs without further design work.

## Approach

Mirrors #640's deferral of the depgraph load:

- `CompilerHashCache::merge_from(&self, other)` drains a freshly-loaded cache into the live one via `DashMap::insert` (`&self`), so **no `SharedState` field type changes are needed** — call sites stay untouched.
- New `CompilerHashCacheLoader` handle captures `Arc<SharedState>` + the snapshot path, survives the `spawn_blocking` boundary, and on disk failure logs at WARN + leaves the cache empty (stat-verify in `get_or_hash_with` keeps cache-key correctness either way).
- `bind_with_cache_dir` now constructs an empty `CompilerHashCache` instead of calling `load_from_disk` inline. New `compiler_hash_cache_loaded: AtomicBool` on `SharedState`; the daemon binary fires the load post-lockfile and the loader sets the flag on completion.
- Shutdown save path (`run.rs`) gates on the flag — if shutdown fires before the background load finishes, the on-disk snapshot is preserved (the in-memory cache would be partial). `save_to_disk` already short-circuits on empty caches, so the flag is belt + suspenders.

## Tests

New tests in `daemon::server::tests::compiler_hash`:

- `bind_does_not_load_compiler_hash_cache_from_disk` — bind with a pre-populated snapshot leaves the live cache empty and the loaded flag false. **Locks in the property that bind doesn't read disk for this cache.**
- `compiler_hash_cache_loader_merges_snapshot_into_live_cache` — loader populates the cache, flips the flag, and entries are usable (cache-hit on next lookup, no re-hash).
- `compiler_hash_cache_loader_tolerates_missing_snapshot` — no on-disk file is not an error; flag still flips.
- `compiler_hash_cache_merge_from_drains_other` — documents the `merge_from` contract the loader relies on.

```
test daemon::server::tests::compiler_hash::bind_does_not_load_compiler_hash_cache_from_disk ... ok
test daemon::server::tests::compiler_hash::compiler_hash_cache_loader_merges_snapshot_into_live_cache ... ok
test daemon::server::tests::compiler_hash::compiler_hash_cache_loader_tolerates_missing_snapshot ... ok
test daemon::server::tests::compiler_hash::compiler_hash_cache_merge_from_drains_other ... ok
test result: ok. 13 passed; 0 failed; ...
```

`cargo clippy -p zccache --all-targets -- -D warnings` clean. `cargo fmt --all --check` clean.

## Why phase split

The full #784 scope wants all four caches deferred. Doing them as one PR would touch `cache_system` (`>30` call sites containing `MetadataCache`) and `system_includes` (`Mutex` nesting) — substantial blast radius. Phase 2a establishes the pattern + the test scaffold here so the remaining three phases (each one cache) can land independently with minimal review surface and minimal CI risk.

Follow-up issues (each one cache) will be filed referencing this PR as the precedent.

## Test plan

- [x] `cargo test -p zccache --lib daemon::server::tests::compiler_hash::` passes (13/13 incl. 4 new)
- [x] `cargo clippy -p zccache --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] Full workspace CI green (this PR)

## Drift

`v2_pipe_naming_smoke_test.rs` had pre-existing `cargo fmt` drift (unrelated to this PR — surfaced by my running `cargo fmt --all`). Sweeping it in so `cargo fmt --all --check` stays green in CI.

Refs #784.
