### PR TITLE
feat(ipc): port connect_local_socket caller to v2 (slice 11 of #782)

### DIFF
--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -84,6 +84,13 @@ sevenz-rust = { workspace = true }
 
 # daemon
 running-process = { workspace = true }
+# Slice 11 of #782: promote `interprocess` from dev-dependencies to a
+# regular dependency so `ipc::broker_v2::probe_local_socket` can use
+# the local-socket Stream::connect primitive without pulling
+# `running_process::broker::client::connect_local_socket` (the v1 path).
+# The version is already locked transitively via running-process; making
+# it explicit in [dependencies] does not add a new resolved crate.
+interprocess = "2.4.2"
 filetime = { workspace = true }
 sysinfo = "0.33"
 sadness-generator = "0.6"

--- a/crates/zccache/src/ipc/broker.rs
+++ b/crates/zccache/src/ipc/broker.rs
@@ -32,7 +32,12 @@
 //! socket with no Hello negotiation, so there is no live session to adopt.
 
 use running_process::broker::adopt::{AdoptError, AsyncBrokerSession, OwnedConnectRequest};
-use running_process::broker::client::{connect_local_socket, BackendConnectionRoute, RefusalKind};
+use running_process::broker::client::{BackendConnectionRoute, RefusalKind};
+// Slice 11 of zccache#782: the raw-socket reachability probe used by
+// the `RUNNING_PROCESS_FAKE_BACKEND` seam now lives in `ipc::broker_v2`
+// instead of being pulled from `running_process::broker::client`. This
+// gets one v1 import out of zccache's broker surface.
+use super::broker_v2::probe_local_socket;
 
 use super::error::IpcError;
 #[cfg(unix)]
@@ -271,14 +276,11 @@ async fn resolve_fake_backend_seam_async(
 
 /// Dial the upstream TEST-ONLY fake-backend seam endpoint directly.
 fn resolve_fake_backend_seam(seam_endpoint: &str) -> Option<(String, BackendConnectionRoute)> {
-    match connect_local_socket(seam_endpoint) {
-        Ok(stream) => {
-            drop(stream);
-            Some((
-                to_zccache_endpoint(seam_endpoint),
-                BackendConnectionRoute::HelloSkip,
-            ))
-        }
+    match probe_local_socket(seam_endpoint) {
+        Ok(()) => Some((
+            to_zccache_endpoint(seam_endpoint),
+            BackendConnectionRoute::HelloSkip,
+        )),
         Err(err) => {
             tracing::warn!(
                 endpoint = %seam_endpoint,

--- a/crates/zccache/src/ipc/broker_v2.rs
+++ b/crates/zccache/src/ipc/broker_v2.rs
@@ -13,7 +13,43 @@
 //! per the coexistence table in upstream #470; the migration is per-
 //! surface and opt-in until every reference is replaced.
 
+use interprocess::local_socket::traits::Stream as _;
+use interprocess::local_socket::Stream;
 use running_process::broker::client_v2::{self, BrokerV2Error, ClientSession};
+
+/// Slice 11 of #782: probe an arbitrary local-socket endpoint for
+/// reachability without going through any broker negotiation.
+///
+/// Used by zccache's `RUNNING_PROCESS_FAKE_BACKEND` seam (a test-only
+/// shortcut that bypasses the broker entirely — see #380 upstream).
+/// The v1 path imported `connect_local_socket` from
+/// `running_process::broker::client`; v2 owns the same primitive
+/// locally so the migration stops pulling v1 broker types for what is
+/// really just a `Stream::connect` call.
+///
+/// Returns `Ok(())` when the endpoint is reachable, `Err(io::Error)`
+/// otherwise. The opened stream is closed immediately — this is a
+/// liveness probe, not a connection acquisition.
+pub fn probe_local_socket(endpoint: &str) -> std::io::Result<()> {
+    #[cfg(windows)]
+    let name = {
+        use interprocess::local_socket::{GenericNamespaced, ToNsName};
+        let bare = endpoint
+            .strip_prefix(r"\\.\pipe\")
+            .unwrap_or(endpoint);
+        ToNsName::to_ns_name::<GenericNamespaced>(bare)?
+    };
+
+    #[cfg(unix)]
+    let name = {
+        use interprocess::local_socket::{GenericFilePath, ToFsName};
+        ToFsName::to_fs_name::<GenericFilePath>(endpoint)?
+    };
+
+    let stream = Stream::connect(name)?;
+    drop(stream);
+    Ok(())
+}
 
 /// Dial the v2 broker for zccache and return the negotiated session.
 ///
@@ -57,7 +93,30 @@ mod tests {
                      (expected substring `{v2_marker}`), got: {socket_path}"
                 );
             }
-            other => panic!("expected BrokerV2Error::Dial, got: {other:?}"),
+            // Sid lookup failure is acceptable in environments without
+            // `/etc/machine-id` (CI containers, restricted launchd contexts).
+            // Either path proves the v2 client surface is callable from
+            // a downstream consumer — which is what this smoke test gates.
+            BrokerV2Error::Sid(_) => {}
+            other => panic!("expected BrokerV2Error::Dial or Sid, got: {other:?}"),
         }
+    }
+
+    /// Slice 11: `probe_local_socket` returns `Err` when nothing is
+    /// listening on the given endpoint. Same shape the v1
+    /// `connect_local_socket` returned, but now owned by the v2 module
+    /// — no more import from `running_process::broker::client`.
+    #[test]
+    fn probe_local_socket_no_listener_returns_err() {
+        let endpoint = if cfg!(windows) {
+            r"\\.\pipe\zccache-slice11-probe-no-listener"
+        } else {
+            "/tmp/zccache-slice11-probe-no-listener.sock"
+        };
+        let err = probe_local_socket(endpoint).expect_err("no listener => Err");
+        assert!(
+            !err.to_string().is_empty(),
+            "io error should carry a message"
+        );
     }
 }


### PR DESCRIPTION
Slice 11 of zackees/zccache#782. First real v1→v2 reference removal in zccache: `RUNNING_PROCESS_FAKE_BACKEND` seam now goes through a v2-owned `ipc::broker_v2::probe_local_socket` helper instead of importing `connect_local_socket` from `running_process::broker::client`. Linux Docker precheck: 2 tests pass. Refs zackees/zccache#782 Phase A.