### PR TITLE
feat(bench): publish cache sizes and history

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -61,6 +61,11 @@ jobs:
           ZCCACHE_BENCHMARK_RAW_BASE_URL: https://raw.githubusercontent.com/zackees/zccache/benchmark-stats
         run: |
           set -euo pipefail
+          mkdir -p benchmark-stats
+          curl --fail --silent --location --max-time 30 \
+            -o benchmark-stats/history.jsonl \
+            https://raw.githubusercontent.com/zackees/zccache/benchmark-stats/history.jsonl \
+            || : > benchmark-stats/history.jsonl
           python3 -m ci.benchmark_stats --run-benchmarks --output-dir benchmark-stats --log-path benchmark-output/benchmark.log
 
       - name: Upload benchmark stats artifact

--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -30,6 +30,7 @@ DEFAULT_OUTPUT_DIR = REPO_ROOT / "benchmark-stats"
 DEFAULT_PAGES_URL = "https://zackees.github.io/zccache/"
 DEFAULT_RAW_IMAGE_BASE_URL = "https://raw.githubusercontent.com/zackees/zccache/benchmark-stats"
 BENCHMARK_STATS_BRANCH_URL = "https://github.com/zackees/zccache/tree/benchmark-stats"
+HISTORY_MAX_LINES = 1000
 LANGUAGES = ("c", "c++", "emscripten", "rust")
 LANGUAGE_LABELS = {
     "c": "C",
@@ -350,6 +351,27 @@ def _duration_seconds(value: str) -> float | None:
     return round(number, 6)
 
 
+def _bytes_from_text(value: str) -> int | None:
+    text = _clean_cell(value)
+    if not text or text in {"-", "\u2014", "n/a", "N/A"}:
+        return None
+    match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)\s*(B|KiB|MiB|GiB|KB|MB|GB)", text)
+    if match is None:
+        return None
+    number = float(match.group(1))
+    unit = match.group(2)
+    factors = {
+        "B": 1,
+        "KiB": 1024,
+        "MiB": 1024**2,
+        "GiB": 1024**3,
+        "KB": 1000,
+        "MB": 1000**2,
+        "GB": 1000**3,
+    }
+    return int(round(number * factors[unit]))
+
+
 def _ratio_from_text(value: str) -> float | None:
     text = _clean_cell(value)
     if text == "~same":
@@ -420,6 +442,19 @@ def parse_benchmark_log(text: str) -> list[dict[str, Any]]:
             bare_seconds = _duration_seconds(cells[1])
             sccache_seconds = _duration_seconds(cells[2])
             zccache_seconds = _duration_seconds(cells[3])
+            if len(cells) >= 9:
+                bare_cache_bytes = _bytes_from_text(cells[4])
+                sccache_cache_bytes = _bytes_from_text(cells[5])
+                zccache_cache_bytes = _bytes_from_text(cells[6])
+                vs_sccache_cell = cells[7]
+                vs_bare_cell = cells[8]
+            else:
+                bare_cache_bytes = 0
+                sccache_cache_bytes = 0
+                zccache_cache_bytes = 0
+                vs_sccache_cell = cells[4]
+                vs_bare_cell = cells[5]
+            cache_bytes_reported = len(cells) >= 9
             scenario = cells[0]
             mode = "warm" if "warm" in scenario.lower() else "cold"
             zccache_rounded_to_zero = zccache_seconds is None and _is_display_rounded_zero(
@@ -429,14 +464,14 @@ def parse_benchmark_log(text: str) -> list[dict[str, Any]]:
                 zccache_seconds = _duration_from_display_rounded_zero(
                     mode,
                     cells[3],
-                    ((sccache_seconds, cells[4]), (bare_seconds, cells[5])),
+                    ((sccache_seconds, vs_sccache_cell), (bare_seconds, vs_bare_cell)),
                 )
 
             sccache_ratio = _ratio(sccache_seconds, zccache_seconds)
             bare_ratio = _ratio(bare_seconds, zccache_seconds)
             if zccache_seconds is not None and zccache_rounded_to_zero:
-                sccache_ratio = _ratio_from_text(cells[4]) or sccache_ratio
-                bare_ratio = _ratio_from_text(cells[5]) or bare_ratio
+                sccache_ratio = _ratio_from_text(vs_sccache_cell) or sccache_ratio
+                bare_ratio = _ratio_from_text(vs_bare_cell) or bare_ratio
             result = {
                 "benchmark": current["id"],
                 "benchmark_label": current["label"],
@@ -447,10 +482,14 @@ def parse_benchmark_log(text: str) -> list[dict[str, Any]]:
                 "bare_seconds": bare_seconds,
                 "sccache_seconds": sccache_seconds,
                 "zccache_seconds": zccache_seconds,
+                "bare_cache_bytes": bare_cache_bytes if bare_cache_bytes is not None else 0,
+                "sccache_cache_bytes": sccache_cache_bytes if sccache_cache_bytes is not None else 0,
+                "zccache_cache_bytes": zccache_cache_bytes if zccache_cache_bytes is not None else 0,
+                "cache_bytes_reported": cache_bytes_reported,
                 "zccache_vs_sccache_ratio": sccache_ratio,
                 "zccache_vs_bare_ratio": bare_ratio,
-                "vs_sccache_text": cells[4],
-                "vs_bare_text": cells[5],
+                "vs_sccache_text": vs_sccache_cell,
+                "vs_bare_text": vs_bare_cell,
             }
             results.append(result)
 
@@ -459,6 +498,23 @@ def parse_benchmark_log(text: str) -> list[dict[str, Any]]:
 
 def _format_seconds(value: float | None) -> str:
     return "n/a" if value is None else f"{value:.3f}s"
+
+
+def _format_bytes(value: int | float | None) -> str:
+    if not isinstance(value, (int, float)) or value < 0:
+        return "n/a"
+    units = ("B", "KiB", "MiB", "GiB")
+    amount = float(value)
+    unit = units[0]
+    for unit in units:
+        if amount < 1024 or unit == units[-1]:
+            break
+        amount /= 1024
+    if unit == "B":
+        return f"{int(amount)} B"
+    if amount < 10:
+        return f"{amount:.1f} {unit}"
+    return f"{amount:.0f} {unit}"
 
 
 def _format_ratio(value: float | None) -> str:
@@ -515,11 +571,50 @@ def build_summary(results: list[dict[str, Any]]) -> dict[str, Any]:
 
 def build_payload(results: list[dict[str, Any]], metadata: dict[str, Any]) -> dict[str, Any]:
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "metadata": metadata,
         "summary": build_summary(results),
         "results": results,
     }
+
+
+def build_history_row(payload: dict[str, Any]) -> dict[str, Any]:
+    metadata = payload["metadata"]
+    return {
+        "ts": metadata.get("generated_at"),
+        "sha": metadata.get("git_sha"),
+        "summary": payload.get("summary"),
+        "results": [
+            {
+                "benchmark": row.get("benchmark"),
+                "language": row.get("language"),
+                "scenario": row.get("scenario"),
+                "mode": row.get("mode"),
+                "bare_seconds": row.get("bare_seconds"),
+                "sccache_seconds": row.get("sccache_seconds"),
+                "zccache_seconds": row.get("zccache_seconds"),
+                "bare_cache_bytes": row.get("bare_cache_bytes"),
+                "sccache_cache_bytes": row.get("sccache_cache_bytes"),
+                "zccache_cache_bytes": row.get("zccache_cache_bytes"),
+                "cache_bytes_reported": row.get("cache_bytes_reported"),
+            }
+            for row in payload.get("results", [])
+        ],
+    }
+
+
+def write_history_jsonl(payload: dict[str, Any], output_dir: Path) -> None:
+    history_path = output_dir / "history.jsonl"
+    rows: list[str] = []
+    if history_path.exists():
+        rows = [
+            line
+            for line in history_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    rows = rows[-(HISTORY_MAX_LINES - 1) :]
+    rows.append(json.dumps(build_history_row(payload), separators=(",", ":")))
+    history_path.write_text("\n".join(rows) + "\n", encoding="utf-8")
 
 
 def _grouped_results(results: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
@@ -541,7 +636,7 @@ def render_html(payload: dict[str, Any]) -> str:
     rows_html: list[str] = []
     for group, rows in _grouped_results(payload["results"]).items():
         rows_html.append(
-            "<tr class=\"group\"><th colspan=\"6\">" + escape(group) + "</th></tr>"
+            "<tr class=\"group\"><th colspan=\"9\">" + escape(group) + "</th></tr>"
         )
         for row in rows:
             rows_html.append(
@@ -550,6 +645,9 @@ def render_html(payload: dict[str, Any]) -> str:
                 f"<td>{escape(_format_seconds(row['bare_seconds']))}</td>"
                 f"<td>{escape(_format_seconds(row['sccache_seconds']))}</td>"
                 f"<td class=\"strong\">{escape(_format_seconds(row['zccache_seconds']))}</td>"
+                f"<td>{escape(_format_bytes(row.get('bare_cache_bytes')))}</td>"
+                f"<td>{escape(_format_bytes(row.get('sccache_cache_bytes')))}</td>"
+                f"<td>{escape(_format_bytes(row.get('zccache_cache_bytes')))}</td>"
                 f"<td>{escape(_format_ratio(row['zccache_vs_sccache_ratio']))}</td>"
                 f"<td>{escape(_format_ratio(row['zccache_vs_bare_ratio']))}</td>"
                 "</tr>"
@@ -670,7 +768,8 @@ def render_html(payload: dict[str, Any]) -> str:
         sha {escape((metadata.get('git_sha') or 'n/a')[:12])}{run_link}
       </p>
       <p class="note">
-        Raw machine-readable data: <a href="latest.json">latest.json</a>.
+        Raw machine-readable data: <a href="latest.json">latest.json</a> and
+        <a href="history.jsonl">history.jsonl</a>.
         Per-language README images:
       </p>
       <ul>
@@ -687,6 +786,9 @@ def render_html(payload: dict[str, Any]) -> str:
               <th>Bare compiler</th>
               <th>sccache</th>
               <th>zccache</th>
+              <th>bare cache</th>
+              <th>sccache cache</th>
+              <th>zccache cache</th>
               <th>zccache vs sccache</th>
               <th>zccache vs bare</th>
             </tr>
@@ -876,6 +978,7 @@ def build_combined_image_rows(results: list[dict[str, Any]]) -> list[dict[str, A
                 "compact_scenario": _compact_scenario(scenario_root),
                 "cold": {series: None for series in SERIES_ORDER},
                 "warm": {series: None for series in SERIES_ORDER},
+                "cache_bytes": {series: None for series in SERIES_ORDER},
             }
             groups[key] = combined
             order.append(key)
@@ -886,6 +989,9 @@ def build_combined_image_rows(results: list[dict[str, Any]]) -> list[dict[str, A
             value = row.get(f"{series}_seconds")
             if isinstance(value, (int, float)) and value > 0:
                 combined[mode][series] = float(value)
+            cache_value = row.get(f"{series}_cache_bytes")
+            if isinstance(cache_value, (int, float)) and cache_value >= 0:
+                combined["cache_bytes"][series] = int(cache_value)
     return [groups[key] for key in order]
 
 
@@ -969,7 +1075,7 @@ def render_language_jpg(payload: dict[str, Any], language: str, path: Path) -> N
     footer_h = 56
     legend_h = 40
 
-    bar_row_h = 44
+    bar_row_h = 54
     scenario_label_h = 36
     scenario_gap = 16
     scenario_padding_top = 10
@@ -1169,6 +1275,7 @@ def render_language_jpg(payload: dict[str, Any], language: str, path: Path) -> N
 
             cold_seconds = combined_row["cold"].get(series)
             warm_seconds = combined_row["warm"].get(series)
+            cache_bytes = combined_row["cache_bytes"].get(series)
             pair = SERIES_COLOR_PAIRS[series]
 
             # Series label (use bare_label for the "bare" row)
@@ -1218,7 +1325,7 @@ def render_language_jpg(payload: dict[str, Any], language: str, path: Path) -> N
                         fill=pair["warm"],
                     )
 
-            # Value labels: two compact lines (cold / warm)
+            # Value labels: compact cold / warm / cache stack.
             value_x = bar_area_x1 + 12
             draw_fit(
                 value_x,
@@ -1237,6 +1344,14 @@ def render_language_jpg(payload: dict[str, Any], language: str, path: Path) -> N
                 f"warm {_format_seconds_label(warm_seconds)}",
                 value_font,
                 warm_color,
+                value_label_w - 12,
+            )
+            draw_fit(
+                value_x,
+                row_top + bar_row_h - 15,
+                f"cache {_format_bytes(cache_bytes)}",
+                small_font,
+                "#8b949e",
                 value_label_w - 12,
             )
 
@@ -1301,6 +1416,7 @@ def render_language_jpg(payload: dict[str, Any], language: str, path: Path) -> N
 def write_outputs(payload: dict[str, Any], output_dir: Path) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     (output_dir / "latest.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    write_history_jsonl(payload, output_dir)
     (output_dir / "index.html").write_text(render_html(payload), encoding="utf-8")
     (output_dir / ".nojekyll").write_text("", encoding="utf-8")
     allowed_images = set(LANGUAGE_IMAGE_FILES.values())

--- a/ci/tests/test_benchmark_stats.py
+++ b/ci/tests/test_benchmark_stats.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 import pytest
@@ -189,6 +190,47 @@ def test_parse_benchmark_log_extracts_all_tables():
     rust_link = [row for row in rows if row["benchmark"] == "rust-workspace-link"]
     assert [row["mode"] for row in rust_link] == ["cold", "warm"]
     assert rust_link[1]["scenario"] == "Workspace staticlib link, Warm"
+    assert all(isinstance(row["bare_cache_bytes"], int) for row in rows)
+    assert all(isinstance(row["sccache_cache_bytes"], int) for row in rows)
+    assert all(isinstance(row["zccache_cache_bytes"], int) for row in rows)
+    assert all(row["cache_bytes_reported"] is False for row in rows)
+
+
+def test_parse_benchmark_log_extracts_cache_bytes_from_new_table_shape():
+    log = """
+## C Benchmark: 50 .c files, 5 warm trials
+
+| Scenario | Bare clang | sccache | zccache | bare cache | sccache cache | zccache cache | vs sccache | vs bare clang |
+|:---------|----------:|--------:|--------:|-----------:|--------------:|--------------:|-----------:|--------------:|
+| Single-file, Cold | 3.000s | 3.200s | 2.000s | 0 B | 12.5 KiB | 2.0 MiB | 1.6x faster | 1.5x faster |
+"""
+
+    row = benchmark_stats.parse_benchmark_log(log)[0]
+
+    assert row["bare_cache_bytes"] == 0
+    assert row["sccache_cache_bytes"] == 12800
+    assert row["zccache_cache_bytes"] == 2 * 1024 * 1024
+    assert row["cache_bytes_reported"] is True
+    assert row["zccache_vs_sccache_ratio"] == 1.6
+    assert row["zccache_vs_bare_ratio"] == 1.5
+
+
+def test_write_outputs_appends_history_with_cache_fields(tmp_path):
+    payload = sample_payload()
+    payload["results"][0]["sccache_cache_bytes"] = 123
+    payload["results"][0]["zccache_cache_bytes"] = 456
+
+    benchmark_stats.write_outputs(payload, tmp_path)
+
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "history.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(rows) == 1
+    assert rows[0]["sha"] == "abcdef1234567890"
+    assert rows[0]["results"][0]["bare_cache_bytes"] == 0
+    assert rows[0]["results"][0]["sccache_cache_bytes"] == 123
+    assert rows[0]["results"][0]["zccache_cache_bytes"] == 456
 
 
 def test_benchmark_env_enables_cc_miss_profile(tmp_path, monkeypatch):

--- a/crates/zccache/tests/perf_bench/common.rs
+++ b/crates/zccache/tests/perf_bench/common.rs
@@ -313,6 +313,44 @@ pub fn fmt_dur(d: Duration) -> String {
     format!("{:.3}s", d.as_secs_f64())
 }
 
+pub fn dir_size_bytes(path: &Path) -> u64 {
+    fn walk(path: &Path) -> u64 {
+        let Ok(metadata) = std::fs::symlink_metadata(path) else {
+            return 0;
+        };
+        if metadata.is_file() {
+            return metadata.len();
+        }
+        if !metadata.is_dir() {
+            return 0;
+        }
+        let Ok(entries) = std::fs::read_dir(path) else {
+            return 0;
+        };
+        entries
+            .filter_map(Result::ok)
+            .map(|entry| walk(&entry.path()))
+            .sum()
+    }
+    walk(path)
+}
+
+pub fn fmt_bytes(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+    let bytes_f = bytes as f64;
+    if bytes < 1024 {
+        format!("{bytes} B")
+    } else if bytes_f < MIB {
+        format!("{:.1} KiB", bytes_f / KIB)
+    } else if bytes_f < GIB {
+        format!("{:.1} MiB", bytes_f / MIB)
+    } else {
+        format!("{:.1} GiB", bytes_f / GIB)
+    }
+}
+
 pub fn print_trials(label: &str, times: &[Duration]) {
     print_trials_per(label, times, None);
 }

--- a/crates/zccache/tests/perf_bench/link.rs
+++ b/crates/zccache/tests/perf_bench/link.rs
@@ -7,9 +7,10 @@ use std::time::{Duration, Instant};
 use zccache::protocol::{Request, Response};
 
 use super::common::{
-    clean_link_outputs, clear_dir_contents, clear_zccache, find_sccache, fmt_dur, fmt_ratio,
-    median, print_trials, run_tool_timed, start_daemon, start_fresh_sccache, stop_sccache,
-    try_run_sccache_tool_timed, try_run_tool, ClientConn, NUM_FILES, RUSTC_NUM_FILES, WARM_TRIALS,
+    clean_link_outputs, clear_dir_contents, clear_zccache, dir_size_bytes, find_sccache, fmt_bytes,
+    fmt_dur, fmt_ratio, median, print_trials, run_tool_timed, start_daemon, start_fresh_sccache,
+    stop_sccache, try_run_sccache_tool_timed, try_run_tool, ClientConn, NUM_FILES, RUSTC_NUM_FILES,
+    WARM_TRIALS,
 };
 use super::cpp_project::{generate_project, source_names};
 use super::rust_project::{
@@ -73,6 +74,10 @@ pub struct LinkBenchResult {
     pub sccache_warm: Option<Vec<Duration>>,
     pub zccache_cold: Duration,
     pub zccache_warm: Vec<Duration>,
+    pub sccache_cold_cache_bytes: Option<u64>,
+    pub sccache_warm_cache_bytes: Option<u64>,
+    pub zccache_cold_cache_bytes: u64,
+    pub zccache_warm_cache_bytes: u64,
 }
 
 pub async fn measure_ephemeral_link_scenario(
@@ -101,69 +106,77 @@ pub async fn measure_ephemeral_link_scenario(
     print_trials("warm:", &bare_warm);
     eprintln!();
 
-    let (sccache_cold, sccache_warm) = if let Some(sccache_bin) = find_sccache() {
-        let sc_cache_dir = zccache::test_support::temp_cache_dir().unwrap();
-        let _cache_dir = start_fresh_sccache(&sccache_bin, sc_cache_dir.path());
-        eprintln!("  [2/3] sccache ({})", sccache_bin.display());
+    let (sccache_cold, sccache_warm, sccache_cold_cache_bytes, sccache_warm_cache_bytes) =
+        if let Some(sccache_bin) = find_sccache() {
+            let sc_cache_dir = zccache::test_support::temp_cache_dir().unwrap();
+            let _cache_dir = start_fresh_sccache(&sccache_bin, sc_cache_dir.path());
+            eprintln!("  [2/3] sccache ({})", sccache_bin.display());
 
-        clean_link_outputs(sccache_dir, outputs);
-        let cold = match try_run_sccache_tool_timed(
-            &sccache_bin,
-            tool,
-            args,
-            sccache_dir,
-            "sccache cold link",
-        ) {
-            Ok(duration) => duration,
-            Err(error) => {
-                eprintln!(
+            clean_link_outputs(sccache_dir, outputs);
+            let cold = match try_run_sccache_tool_timed(
+                &sccache_bin,
+                tool,
+                args,
+                sccache_dir,
+                "sccache cold link",
+            ) {
+                Ok(duration) => duration,
+                Err(error) => {
+                    eprintln!(
                     "        sccache link passthrough failed; using direct tool as no-cache baseline\n        {}",
                     error.lines().next().unwrap_or("unknown failure")
                 );
-                run_tool_timed(tool, args, sccache_dir, "direct no-cache cold link")
-            }
-        };
-        eprintln!("        cold: {}", fmt_dur(cold));
-
-        let mut passthrough_supported = true;
-        let mut warm = Vec::with_capacity(WARM_TRIALS);
-        for _ in 0..WARM_TRIALS {
-            clean_link_outputs(sccache_dir, outputs);
-            let duration = if passthrough_supported {
-                match try_run_sccache_tool_timed(
-                    &sccache_bin,
-                    tool,
-                    args,
-                    sccache_dir,
-                    "sccache warm link",
-                ) {
-                    Ok(duration) => duration,
-                    Err(_) => {
-                        passthrough_supported = false;
-                        run_tool_timed(tool, args, sccache_dir, "direct no-cache warm link")
-                    }
+                    run_tool_timed(tool, args, sccache_dir, "direct no-cache cold link")
                 }
-            } else {
-                run_tool_timed(tool, args, sccache_dir, "direct no-cache warm link")
             };
-            warm.push(duration);
-        }
-        print_trials("warm:", &warm);
-        stop_sccache(&sccache_bin);
-        eprintln!();
-        (Some(cold), Some(warm))
-    } else {
-        eprintln!("  [2/3] sccache: not found, skipping");
-        eprintln!();
-        (None, None)
-    };
+            eprintln!("        cold: {}", fmt_dur(cold));
+            let cold_cache_bytes = dir_size_bytes(sc_cache_dir.path());
+
+            let mut passthrough_supported = true;
+            let mut warm = Vec::with_capacity(WARM_TRIALS);
+            for _ in 0..WARM_TRIALS {
+                clean_link_outputs(sccache_dir, outputs);
+                let duration = if passthrough_supported {
+                    match try_run_sccache_tool_timed(
+                        &sccache_bin,
+                        tool,
+                        args,
+                        sccache_dir,
+                        "sccache warm link",
+                    ) {
+                        Ok(duration) => duration,
+                        Err(_) => {
+                            passthrough_supported = false;
+                            run_tool_timed(tool, args, sccache_dir, "direct no-cache warm link")
+                        }
+                    }
+                } else {
+                    run_tool_timed(tool, args, sccache_dir, "direct no-cache warm link")
+                };
+                warm.push(duration);
+            }
+            print_trials("warm:", &warm);
+            let warm_cache_bytes = dir_size_bytes(sc_cache_dir.path());
+            stop_sccache(&sccache_bin);
+            eprintln!();
+            (
+                Some(cold),
+                Some(warm),
+                Some(cold_cache_bytes),
+                Some(warm_cache_bytes),
+            )
+        } else {
+            eprintln!("  [2/3] sccache: not found, skipping");
+            eprintln!();
+            (None, None, None, None)
+        };
 
     eprintln!("  [3/3] zccache");
     clean_link_outputs(zccache_dir, outputs);
     let _ = run_tool_timed(tool, args, zccache_dir, "zccache linker warmup");
     clean_link_outputs(zccache_dir, outputs);
 
-    let (_zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
+    let (zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
     clear_zccache(&mut client).await;
 
@@ -177,6 +190,7 @@ pub async fn measure_ephemeral_link_scenario(
     )
     .await;
     eprintln!("        cold: {}", fmt_dur(zccache_cold));
+    let zccache_cold_cache_bytes = dir_size_bytes(zccache_cache_dir.path());
     let mut zccache_warm = Vec::with_capacity(WARM_TRIALS);
     for _ in 0..WARM_TRIALS {
         clean_link_outputs(zccache_dir, outputs);
@@ -193,6 +207,7 @@ pub async fn measure_ephemeral_link_scenario(
         );
     }
     print_trials("warm:", &zccache_warm);
+    let zccache_warm_cache_bytes = dir_size_bytes(zccache_cache_dir.path());
     shutdown.notify_one();
     server_handle.await.unwrap();
     eprintln!();
@@ -205,6 +220,10 @@ pub async fn measure_ephemeral_link_scenario(
         sccache_warm,
         zccache_cold,
         zccache_warm,
+        sccache_cold_cache_bytes,
+        sccache_warm_cache_bytes,
+        zccache_cold_cache_bytes,
+        zccache_warm_cache_bytes,
     }
 }
 
@@ -213,20 +232,24 @@ pub fn print_link_benchmark_table(title: &str, bare_label: &str, results: &[Link
     eprintln!();
     eprintln!("{title}");
     eprintln!();
-    eprintln!("| Scenario | {bare_label} | sccache | zccache | vs sccache | vs {bare_label} |");
-    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|");
+    eprintln!("| Scenario | {bare_label} | sccache | zccache | bare cache | sccache cache | zccache cache | vs sccache | vs {bare_label} |");
+    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|--------------:|-----------:|--------------:|");
     for result in results {
         let cold_sccache = result.sccache_cold.map(fmt_dur);
+        let cold_sccache_cache = result.sccache_cold_cache_bytes.map(fmt_bytes);
         let cold_vs_sccache = result
             .sccache_cold
             .map(|duration| fmt_ratio(duration, result.zccache_cold, false));
         let cold_vs_bare = fmt_ratio(result.bare_cold, result.zccache_cold, false);
         eprintln!(
-            "| {}, Cold | {} | {} | {} | {} | {} |",
+            "| {}, Cold | {} | {} | {} | {} | {} | {} | {} | {} |",
             result.scenario,
             fmt_dur(result.bare_cold),
             cold_sccache.as_deref().unwrap_or(dash),
             fmt_dur(result.zccache_cold),
+            fmt_bytes(0),
+            cold_sccache_cache.as_deref().unwrap_or(dash),
+            fmt_bytes(result.zccache_cold_cache_bytes),
             cold_vs_sccache.as_deref().unwrap_or(dash),
             cold_vs_bare,
         );
@@ -236,17 +259,21 @@ pub fn print_link_benchmark_table(title: &str, bare_label: &str, results: &[Link
             .sccache_warm
             .as_ref()
             .map(|times| fmt_dur(median(times)));
+        let warm_sccache_cache = result.sccache_warm_cache_bytes.map(fmt_bytes);
         let warm_vs_sccache = result
             .sccache_warm
             .as_ref()
             .map(|times| fmt_ratio(median(times), zccache_warm, true));
         let warm_vs_bare = fmt_ratio(result.bare_warm, zccache_warm, true);
         eprintln!(
-            "| {}, Warm | {} | {} | **{}** | {} | {} |",
+            "| {}, Warm | {} | {} | **{}** | {} | {} | {} | {} | {} |",
             result.scenario,
             fmt_dur(result.bare_warm),
             warm_sccache.as_deref().unwrap_or(dash),
             fmt_dur(zccache_warm),
+            fmt_bytes(0),
+            warm_sccache_cache.as_deref().unwrap_or(dash),
+            fmt_bytes(result.zccache_warm_cache_bytes),
             warm_vs_sccache.as_deref().unwrap_or(dash),
             warm_vs_bare,
         );

--- a/crates/zccache/tests/perf_bench/tests_c.rs
+++ b/crates/zccache/tests/perf_bench/tests_c.rs
@@ -7,7 +7,8 @@ use super::c_project::{
     sccache_compile_c_single, warmup_c_compiler, zccache_compile_c_single,
 };
 use super::common::{
-    find_sccache, fmt_dur, fmt_ratio, median, print_trials, start_daemon, NUM_FILES, WARM_TRIALS,
+    dir_size_bytes, find_sccache, fmt_bytes, fmt_dur, fmt_ratio, median, print_trials,
+    start_daemon, NUM_FILES, WARM_TRIALS,
 };
 
 #[tokio::test]
@@ -48,6 +49,8 @@ async fn perf_c_zccache_vs_bare() {
 
     let sccache_cold;
     let sccache_warm;
+    let mut sccache_cold_cache_bytes = None;
+    let mut sccache_warm_cache_bytes = None;
     if let Some(sccache_bin) = find_sccache() {
         let sc_dir = zccache::test_support::temp_cache_dir().unwrap();
         generate_c_project(sc_dir.path());
@@ -78,6 +81,7 @@ async fn perf_c_zccache_vs_bare() {
         let cold = sccache_compile_c_single(&sccache_bin, &compiler, sc_dir.path(), &sources);
         eprintln!("        cold:  {}", fmt_dur(cold));
         sccache_cold = Some(cold);
+        sccache_cold_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
 
         let mut times = Vec::with_capacity(WARM_TRIALS);
         for _ in 0..WARM_TRIALS {
@@ -90,6 +94,7 @@ async fn perf_c_zccache_vs_bare() {
         }
         print_trials("warm:", &times);
         sccache_warm = Some(times);
+        sccache_warm_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
 
         let _ = std::process::Command::new(&sccache_bin)
             .arg("--stop-server")
@@ -110,7 +115,7 @@ async fn perf_c_zccache_vs_bare() {
     let zc_cwd = zc_dir.path().to_string_lossy().into_owned();
 
     eprintln!("  [3/3] zccache");
-    let (_zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
+    let (zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
 
     client
@@ -135,6 +140,7 @@ async fn perf_c_zccache_vs_bare() {
     let zc_cold =
         zccache_compile_c_single(&mut client, &session_id, &compiler, &zc_cwd, &sources).await;
     eprintln!("        cold:  {}", fmt_dur(zc_cold));
+    let zc_cold_cache_bytes = dir_size_bytes(zccache_cache_dir.path());
 
     let mut zc_warm = Vec::with_capacity(WARM_TRIALS);
     for _ in 0..WARM_TRIALS {
@@ -143,6 +149,7 @@ async fn perf_c_zccache_vs_bare() {
         );
     }
     print_trials("warm:", &zc_warm);
+    let zc_warm_cache_bytes = dir_size_bytes(zccache_cache_dir.path());
 
     client
         .send(&Request::SessionEnd {
@@ -161,6 +168,8 @@ async fn perf_c_zccache_vs_bare() {
     let dash = "\u{2014}";
     let sccache_cold_str = sccache_cold.map(fmt_dur);
     let sccache_warm_str = sccache_warm.as_ref().map(|times| fmt_dur(median(times)));
+    let sccache_cold_cache_str = sccache_cold_cache_bytes.map(fmt_bytes);
+    let sccache_warm_cache_str = sccache_warm_cache_bytes.map(fmt_bytes);
     let vs_sccache_cold = sccache_cold.map(|duration| fmt_ratio(duration, zc_cold, false));
     let vs_sccache_warm = sccache_warm
         .as_ref()
@@ -169,21 +178,27 @@ async fn perf_c_zccache_vs_bare() {
     eprintln!();
     eprintln!("## C Benchmark: {NUM_FILES} .c files, {WARM_TRIALS} warm trials");
     eprintln!();
-    eprintln!("| Scenario | Bare clang | sccache | zccache | vs sccache | vs bare clang |");
-    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|");
+    eprintln!("| Scenario | Bare clang | sccache | zccache | bare cache | sccache cache | zccache cache | vs sccache | vs bare clang |");
+    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|--------------:|-----------:|--------------:|");
     eprintln!(
-        "| Single-file, Cold | {} | {} | {} | {} | {} |",
+        "| Single-file, Cold | {} | {} | {} | {} | {} | {} | {} | {} |",
         fmt_dur(bl_cold),
         sccache_cold_str.as_deref().unwrap_or(dash),
         fmt_dur(zc_cold),
+        fmt_bytes(0),
+        sccache_cold_cache_str.as_deref().unwrap_or(dash),
+        fmt_bytes(zc_cold_cache_bytes),
         vs_sccache_cold.as_deref().unwrap_or(dash),
         vs_bare_cold,
     );
     eprintln!(
-        "| Single-file, Warm | {} | {} | **{}** | {} | {} |",
+        "| Single-file, Warm | {} | {} | **{}** | {} | {} | {} | {} | {} |",
         fmt_dur(bl_warm),
         sccache_warm_str.as_deref().unwrap_or(dash),
         fmt_dur(zc_warm_med),
+        fmt_bytes(0),
+        sccache_warm_cache_str.as_deref().unwrap_or(dash),
+        fmt_bytes(zc_warm_cache_bytes),
         vs_sccache_warm.as_deref().unwrap_or(dash),
         vs_bare_warm,
     );

--- a/crates/zccache/tests/perf_bench/tests_link.rs
+++ b/crates/zccache/tests/perf_bench/tests_link.rs
@@ -4,9 +4,10 @@
 use std::path::Path;
 
 use super::common::{
-    bench_exe_name, clear_zccache, end_zccache_session, find_archiver, find_empp, find_sccache,
-    fmt_dur, median, print_trials, start_daemon, start_fresh_sccache, start_zccache_session,
-    stop_sccache, try_run_tool, NUM_FILES, RUSTC_NUM_FILES, RUSTC_WARM_TRIALS, WARM_TRIALS,
+    bench_exe_name, clear_zccache, dir_size_bytes, end_zccache_session, find_archiver, find_empp,
+    find_sccache, fmt_dur, median, print_trials, start_daemon, start_fresh_sccache,
+    start_zccache_session, stop_sccache, try_run_tool, NUM_FILES, RUSTC_NUM_FILES,
+    RUSTC_WARM_TRIALS, WARM_TRIALS,
 };
 use super::link::{
     archive_link_args, clean_rust_final_output, driver_link_args, measure_ephemeral_link_scenario,
@@ -318,78 +319,86 @@ async fn perf_rust_workspace_link() {
     print_trials("warm:", &bare_warm);
     eprintln!();
 
-    let (sccache_cold, sccache_warm) = if let Some(sccache_bin) = find_sccache() {
-        let sc_cache_dir = zccache::test_support::temp_cache_dir().unwrap();
-        let _cache_dir = start_fresh_sccache(&sccache_bin, sc_cache_dir.path());
-        eprintln!("  [2/3] sccache ({})", sccache_bin.display());
-        let cold = match try_run_sccache_rust_final_link_timed(
-            &sccache_bin,
-            Path::new(&rustc),
-            &args,
-            sccache_dir.path(),
-            &output,
-            "sccache Rust cold link",
-        ) {
-            Ok(duration) => duration,
-            Err(error) => {
-                eprintln!(
+    let (sccache_cold, sccache_warm, sccache_cold_cache_bytes, sccache_warm_cache_bytes) =
+        if let Some(sccache_bin) = find_sccache() {
+            let sc_cache_dir = zccache::test_support::temp_cache_dir().unwrap();
+            let _cache_dir = start_fresh_sccache(&sccache_bin, sc_cache_dir.path());
+            eprintln!("  [2/3] sccache ({})", sccache_bin.display());
+            let cold = match try_run_sccache_rust_final_link_timed(
+                &sccache_bin,
+                Path::new(&rustc),
+                &args,
+                sccache_dir.path(),
+                &output,
+                "sccache Rust cold link",
+            ) {
+                Ok(duration) => duration,
+                Err(error) => {
+                    eprintln!(
                     "        sccache Rust link passthrough failed; using direct rustc as no-cache baseline\n        {}",
                     error.lines().next().unwrap_or("unknown failure")
                 );
-                run_rust_final_link_timed(
-                    Path::new(&rustc),
-                    &args,
-                    sccache_dir.path(),
-                    &output,
-                    "direct Rust no-cache cold link",
-                )
-            }
-        };
-        eprintln!("        cold: {}", fmt_dur(cold));
-        let mut passthrough_supported = true;
-        let mut warm = Vec::with_capacity(RUSTC_WARM_TRIALS);
-        for _ in 0..RUSTC_WARM_TRIALS {
-            let duration = if passthrough_supported {
-                match try_run_sccache_rust_final_link_timed(
-                    &sccache_bin,
-                    Path::new(&rustc),
-                    &args,
-                    sccache_dir.path(),
-                    &output,
-                    "sccache Rust warm link",
-                ) {
-                    Ok(duration) => duration,
-                    Err(_) => {
-                        passthrough_supported = false;
-                        run_rust_final_link_timed(
-                            Path::new(&rustc),
-                            &args,
-                            sccache_dir.path(),
-                            &output,
-                            "direct Rust no-cache warm link",
-                        )
-                    }
+                    run_rust_final_link_timed(
+                        Path::new(&rustc),
+                        &args,
+                        sccache_dir.path(),
+                        &output,
+                        "direct Rust no-cache cold link",
+                    )
                 }
-            } else {
-                run_rust_final_link_timed(
-                    Path::new(&rustc),
-                    &args,
-                    sccache_dir.path(),
-                    &output,
-                    "direct Rust no-cache warm link",
-                )
             };
-            warm.push(duration);
-        }
-        print_trials("warm:", &warm);
-        stop_sccache(&sccache_bin);
-        eprintln!();
-        (Some(cold), Some(warm))
-    } else {
-        eprintln!("  [2/3] sccache: not found, skipping");
-        eprintln!();
-        (None, None)
-    };
+            eprintln!("        cold: {}", fmt_dur(cold));
+            let cold_cache_bytes = dir_size_bytes(sc_cache_dir.path());
+            let mut passthrough_supported = true;
+            let mut warm = Vec::with_capacity(RUSTC_WARM_TRIALS);
+            for _ in 0..RUSTC_WARM_TRIALS {
+                let duration = if passthrough_supported {
+                    match try_run_sccache_rust_final_link_timed(
+                        &sccache_bin,
+                        Path::new(&rustc),
+                        &args,
+                        sccache_dir.path(),
+                        &output,
+                        "sccache Rust warm link",
+                    ) {
+                        Ok(duration) => duration,
+                        Err(_) => {
+                            passthrough_supported = false;
+                            run_rust_final_link_timed(
+                                Path::new(&rustc),
+                                &args,
+                                sccache_dir.path(),
+                                &output,
+                                "direct Rust no-cache warm link",
+                            )
+                        }
+                    }
+                } else {
+                    run_rust_final_link_timed(
+                        Path::new(&rustc),
+                        &args,
+                        sccache_dir.path(),
+                        &output,
+                        "direct Rust no-cache warm link",
+                    )
+                };
+                warm.push(duration);
+            }
+            print_trials("warm:", &warm);
+            let warm_cache_bytes = dir_size_bytes(sc_cache_dir.path());
+            stop_sccache(&sccache_bin);
+            eprintln!();
+            (
+                Some(cold),
+                Some(warm),
+                Some(cold_cache_bytes),
+                Some(warm_cache_bytes),
+            )
+        } else {
+            eprintln!("  [2/3] sccache: not found, skipping");
+            eprintln!();
+            (None, None, None, None)
+        };
 
     eprintln!("  [3/3] zccache");
     let _ = run_rust_final_link_timed(
@@ -399,7 +408,7 @@ async fn perf_rust_workspace_link() {
         &output,
         "zccache Rust linker warmup",
     );
-    let (_zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
+    let (zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
     clear_zccache(&mut client).await;
     let zccache_cwd = zccache_dir.path().to_string_lossy().into_owned();
@@ -415,6 +424,7 @@ async fn perf_rust_workspace_link() {
     )
     .await;
     eprintln!("        cold: {}", fmt_dur(zccache_cold));
+    let zccache_cold_cache_bytes = dir_size_bytes(zccache_cache_dir.path());
     let mut zccache_warm = Vec::with_capacity(RUSTC_WARM_TRIALS);
     for _ in 0..RUSTC_WARM_TRIALS {
         zccache_warm.push(
@@ -431,6 +441,7 @@ async fn perf_rust_workspace_link() {
         );
     }
     print_trials("warm:", &zccache_warm);
+    let zccache_warm_cache_bytes = dir_size_bytes(zccache_cache_dir.path());
     end_zccache_session(&mut client, session_id).await;
     shutdown.notify_one();
     server_handle.await.unwrap();
@@ -443,6 +454,10 @@ async fn perf_rust_workspace_link() {
         sccache_warm,
         zccache_cold,
         zccache_warm,
+        sccache_cold_cache_bytes,
+        sccache_warm_cache_bytes,
+        zccache_cold_cache_bytes,
+        zccache_warm_cache_bytes,
     };
     print_link_benchmark_table(
         &format!(


### PR DESCRIPTION
## Summary
- parse and publish cache-byte fields in benchmark stats, with a `cache_bytes_reported` flag for legacy table rows
- add rolling `history.jsonl` output and preserve prior history before force-publishing benchmark-stats
- display cache sizes in Pages tables and per-language README JPG value stacks
- add measured cache columns for the C benchmark and shared link/archive benchmark tables

Closes #788.
Coordinated with zackees/soldr#803.

## Tests
- `$env:PYTHONPATH=(Get-Location).Path; uv run --no-project --with pytest --with pillow python -m pytest ci/tests/test_benchmark_stats.py`
- `soldr rustfmt --check crates/zccache/tests/perf_bench/common.rs crates/zccache/tests/perf_bench/tests_c.rs crates/zccache/tests/perf_bench/link.rs crates/zccache/tests/perf_bench/tests_link.rs`
- `soldr cargo test -p zccache --test perf_bench_test --no-run`