### PR TITLE
fix(bench): report cache columns for all published perf tables

### DIFF
--- a/crates/zccache/tests/perf_bench/sibling_remap.rs
+++ b/crates/zccache/tests/perf_bench/sibling_remap.rs
@@ -13,8 +13,8 @@ use std::path::Path;
 use std::time::Duration;
 
 use super::common::{
-    end_zccache_session, find_sccache, print_trials_per, start_daemon, start_zccache_session,
-    NUM_FILES, WARM_TRIALS,
+    dir_size_bytes, end_zccache_session, find_sccache, print_trials_per, start_daemon,
+    start_zccache_session, NUM_FILES, WARM_TRIALS,
 };
 use super::cpp_project::{
     absolute_cpp_source_names, baseline_single, generate_project, generate_project_with_file_tags,
@@ -44,6 +44,8 @@ pub struct CppSiblingRemapResult {
     pub bare_warm: Duration,
     pub sccache_warm: Option<Vec<Duration>>,
     pub zccache_warm: Vec<Duration>,
+    pub sccache_cache_bytes: Option<u64>,
+    pub zccache_cache_bytes: u64,
 }
 
 pub async fn measure_cpp_sibling_remap_mode(
@@ -91,6 +93,7 @@ pub async fn measure_cpp_sibling_remap_mode(
     print_trials_per("warm:", &bl_warm, Some(NUM_FILES));
     eprintln!();
 
+    let mut sccache_cache_bytes = None;
     let sccache_warm = if let Some(sccache_bin) = find_sccache() {
         let sc_cache_dir = zccache::test_support::temp_cache_dir().unwrap();
         let sc_cache_str = sc_cache_dir.path().to_string_lossy().into_owned();
@@ -125,6 +128,7 @@ pub async fn measure_cpp_sibling_remap_mode(
             ));
         }
         print_trials_per("warm:", &warm, Some(NUM_FILES));
+        sccache_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
         let _ = std::process::Command::new(&sccache_bin)
             .arg("--stop-server")
             .stdout(std::process::Stdio::null())
@@ -139,7 +143,7 @@ pub async fn measure_cpp_sibling_remap_mode(
     };
 
     eprintln!("  [3/3] zccache (prime: workspace A, warm: workspace B, remap=auto)");
-    let (_zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
+    let (zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
 
     let workspace_a_str = workspace_a.to_string_lossy().into_owned();
@@ -174,6 +178,7 @@ pub async fn measure_cpp_sibling_remap_mode(
         );
     }
     print_trials_per("warm:", &zc_warm, Some(NUM_FILES));
+    let zccache_cache_bytes = dir_size_bytes(zccache_cache_dir.path());
 
     end_zccache_session(&mut client, session_b).await;
     shutdown.notify_one();
@@ -185,5 +190,7 @@ pub async fn measure_cpp_sibling_remap_mode(
         bare_warm: super::common::median(&bl_warm),
         sccache_warm,
         zccache_warm: zc_warm,
+        sccache_cache_bytes,
+        zccache_cache_bytes,
     }
 }

--- a/crates/zccache/tests/perf_bench/tests_cpp.rs
+++ b/crates/zccache/tests/perf_bench/tests_cpp.rs
@@ -4,7 +4,8 @@ use std::path::Path;
 use zccache::protocol::{Request, Response};
 
 use super::common::{
-    find_sccache, fmt_dur, fmt_ratio, median, print_trials, start_daemon, NUM_FILES, WARM_TRIALS,
+    dir_size_bytes, find_sccache, fmt_bytes, fmt_dur, fmt_ratio, median, print_trials,
+    start_daemon, NUM_FILES, WARM_TRIALS,
 };
 use super::cpp_project::{
     baseline_multi, baseline_single, generate_project, nuke_and_regenerate, sccache_compile_multi,
@@ -63,6 +64,7 @@ async fn perf_warm_cache_zccache_vs_sccache() {
     let sccache_cold_multi;
     let sccache_single_times;
     let sccache_multi_times;
+    let mut sccache_cache_bytes = None;
 
     if let Some(sccache_bin) = find_sccache() {
         let sc_dir = zccache::test_support::temp_cache_dir().unwrap();
@@ -143,6 +145,7 @@ async fn perf_warm_cache_zccache_vs_sccache() {
         }
         print_trials("multi warm:", &times);
         sccache_multi_times = Some(times);
+        sccache_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
 
         let _ = std::process::Command::new(&sccache_bin)
             .arg("--stop-server")
@@ -170,7 +173,7 @@ async fn perf_warm_cache_zccache_vs_sccache() {
 
     eprintln!("  [3/3] zccache (in-process daemon)");
 
-    let (_zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
+    let (zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
 
     // Start session
@@ -223,6 +226,7 @@ async fn perf_warm_cache_zccache_vs_sccache() {
         );
     }
     print_trials("multi warm:", &zc_multi_times);
+    let zccache_cache_bytes = dir_size_bytes(zccache_cache_dir.path());
 
     // End session
     client
@@ -244,6 +248,8 @@ async fn perf_warm_cache_zccache_vs_sccache() {
     let scc_multi_str = sccache_multi_times.as_ref().map(|t| fmt_dur(median(t)));
     let scc_cold_s_str = sccache_cold_single.map(fmt_dur);
     let scc_cold_m_str = sccache_cold_multi.map(fmt_dur);
+    let sccache_cache_str = sccache_cache_bytes.map(fmt_bytes);
+    let zccache_cache_str = fmt_bytes(zccache_cache_bytes);
     let dash = "\u{2014}";
 
     eprintln!();
@@ -253,18 +259,21 @@ async fn perf_warm_cache_zccache_vs_sccache() {
     eprintln!();
     eprintln!("## Benchmark: {NUM_FILES} C++ files, {WARM_TRIALS} warm trials");
     eprintln!();
-    eprintln!("| Scenario | Bare Clang | sccache | zccache | vs sccache | vs bare clang |");
-    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|");
+    eprintln!("| Scenario | Bare Clang | sccache | zccache | bare cache | sccache cache | zccache cache | vs sccache | vs bare clang |");
+    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|--------------:|-----------:|--------------:|");
 
     // Single-file, Cold
     let scc_cs = scc_cold_s_str.as_deref().unwrap_or(dash);
     let vs_scc_cold_s = sccache_cold_single.map(|t| fmt_ratio(t, zc_cold_single, false));
     let vs_bare_cold_s = fmt_ratio(bl_cold_single, zc_cold_single, false);
     eprintln!(
-        "| Single-file, Cold | {} | {} | {} | {} | {} |",
+        "| Single-file, Cold | {} | {} | {} | {} | {} | {} | {} | {} |",
         fmt_dur(bl_cold_single),
         scc_cs,
         fmt_dur(zc_cold_single),
+        fmt_bytes(0),
+        sccache_cache_str.as_deref().unwrap_or(dash),
+        zccache_cache_str,
         vs_scc_cold_s.as_deref().unwrap_or(dash),
         vs_bare_cold_s,
     );
@@ -276,10 +285,13 @@ async fn perf_warm_cache_zccache_vs_sccache() {
         .map(|t| fmt_ratio(median(t), zc_single_med, true));
     let vs_bare_warm_s = fmt_ratio(bl_warm_single, zc_single_med, true);
     eprintln!(
-        "| Single-file, Warm | {} | {} | **{}** | {} | {} |",
+        "| Single-file, Warm | {} | {} | **{}** | {} | {} | {} | {} | {} |",
         fmt_dur(bl_warm_single),
         scc_ws,
         fmt_dur(zc_single_med),
+        fmt_bytes(0),
+        sccache_cache_str.as_deref().unwrap_or(dash),
+        zccache_cache_str,
         vs_scc_warm_s.as_deref().unwrap_or(dash),
         vs_bare_warm_s,
     );
@@ -289,10 +301,13 @@ async fn perf_warm_cache_zccache_vs_sccache() {
     let vs_scc_cold_m = sccache_cold_multi.map(|t| fmt_ratio(t, zc_cold_multi, false));
     let vs_bare_cold_m = fmt_ratio(bl_cold_multi, zc_cold_multi, false);
     eprintln!(
-        "| Multi-file, Cold | {} | {} | {} | {} | {} |",
+        "| Multi-file, Cold | {} | {} | {} | {} | {} | {} | {} | {} |",
         fmt_dur(bl_cold_multi),
         scc_cm,
         fmt_dur(zc_cold_multi),
+        fmt_bytes(0),
+        sccache_cache_str.as_deref().unwrap_or(dash),
+        zccache_cache_str,
         vs_scc_cold_m.as_deref().unwrap_or(dash),
         vs_bare_cold_m,
     );
@@ -304,10 +319,13 @@ async fn perf_warm_cache_zccache_vs_sccache() {
         .map(|t| fmt_ratio(median(t), zc_multi_med, true));
     let vs_bare_warm_m = fmt_ratio(bl_warm_multi, zc_multi_med, true);
     eprintln!(
-        "| Multi-file, Warm | {} | {} | **{}** | {} | {} |",
+        "| Multi-file, Warm | {} | {} | **{}** | {} | {} | {} | {} | {} |",
         fmt_dur(bl_warm_multi),
         scc_wm,
         fmt_dur(zc_multi_med),
+        fmt_bytes(0),
+        sccache_cache_str.as_deref().unwrap_or(dash),
+        zccache_cache_str,
         vs_scc_warm_m.as_deref().unwrap_or(dash),
         vs_bare_warm_m,
     );

--- a/crates/zccache/tests/perf_bench/tests_emcc.rs
+++ b/crates/zccache/tests/perf_bench/tests_emcc.rs
@@ -10,8 +10,9 @@ use std::path::Path;
 use zccache::protocol::{Request, Response};
 
 use super::common::{
-    end_zccache_session, find_empp, find_sccache, fmt_dur, fmt_ratio, median, print_trials,
-    print_trials_per, start_daemon, start_zccache_session, NUM_FILES, WARM_TRIALS,
+    dir_size_bytes, end_zccache_session, find_empp, find_sccache, fmt_bytes, fmt_dur, fmt_ratio,
+    median, print_trials, print_trials_per, start_daemon, start_zccache_session, NUM_FILES,
+    WARM_TRIALS,
 };
 use super::cpp_project::{
     baseline_multi, baseline_single, generate_project, nuke_and_regenerate, sccache_compile_multi,
@@ -69,6 +70,7 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
     let sccache_warm_single;
     let sccache_cold_multi;
     let sccache_warm_multi;
+    let mut sccache_cache_bytes = None;
     if let Some(sccache_bin) = find_sccache() {
         let sc_dir = zccache::test_support::temp_cache_dir().unwrap();
         generate_project(sc_dir.path());
@@ -132,6 +134,7 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
         }
         print_trials("multi warm:", &warm);
         sccache_warm_multi = Some(warm);
+        sccache_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
 
         let _ = std::process::Command::new(&sccache_bin)
             .arg("--stop-server")
@@ -154,7 +157,7 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
     let zc_cwd = zc_dir.path().to_string_lossy().into_owned();
 
     eprintln!("  [3/3] zccache em++");
-    let (_zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
+    let (zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
     let session_id = start_zccache_session(&mut client, &zc_cwd).await;
 
@@ -191,6 +194,7 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
         );
     }
     print_trials("multi warm:", &zc_warm_multi);
+    let zccache_cache_bytes = dir_size_bytes(zccache_cache_dir.path());
 
     end_zccache_session(&mut client, session_id).await;
     shutdown.notify_one();
@@ -204,6 +208,8 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
     let sc_warm_multi_str = sccache_warm_multi.as_ref().map(|t| fmt_dur(median(t)));
     let sc_cold_single_str = sccache_cold_single.map(fmt_dur);
     let sc_cold_multi_str = sccache_cold_multi.map(fmt_dur);
+    let sccache_cache_str = sccache_cache_bytes.map(fmt_bytes);
+    let zccache_cache_str = fmt_bytes(zccache_cache_bytes);
     let vs_sccache_cold_single = sccache_cold_single.map(|d| fmt_ratio(d, zc_cold_single, false));
     let vs_sccache_cold_multi = sccache_cold_multi.map(|d| fmt_ratio(d, zc_cold_multi, false));
     let vs_sccache_warm_single = sccache_warm_single
@@ -216,37 +222,49 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
     eprintln!();
     eprintln!("## Emscripten Benchmark: {NUM_FILES} .cpp files, {WARM_TRIALS} warm trials");
     eprintln!();
-    eprintln!("| Scenario | Bare em++ | sccache | zccache | vs sccache | vs bare em++ |");
-    eprintln!("|:---------|---------:|--------:|--------:|-----------:|-------------:|");
+    eprintln!("| Scenario | Bare em++ | sccache | zccache | bare cache | sccache cache | zccache cache | vs sccache | vs bare em++ |");
+    eprintln!("|:---------|---------:|--------:|--------:|-----------:|--------------:|--------------:|-----------:|-------------:|");
     eprintln!(
-        "| Single-file, Cold | {} | {} | {} | {} | {} |",
+        "| Single-file, Cold | {} | {} | {} | {} | {} | {} | {} | {} |",
         fmt_dur(bl_cold_single),
         sc_cold_single_str.as_deref().unwrap_or(dash),
         fmt_dur(zc_cold_single),
+        fmt_bytes(0),
+        sccache_cache_str.as_deref().unwrap_or(dash),
+        zccache_cache_str,
         vs_sccache_cold_single.as_deref().unwrap_or(dash),
         fmt_ratio(bl_cold_single, zc_cold_single, false),
     );
     eprintln!(
-        "| Single-file, Warm | {} | {} | **{}** | {} | {} |",
+        "| Single-file, Warm | {} | {} | **{}** | {} | {} | {} | {} | {} |",
         fmt_dur(bl_warm_single),
         sc_warm_single_str.as_deref().unwrap_or(dash),
         fmt_dur(zc_single_med),
+        fmt_bytes(0),
+        sccache_cache_str.as_deref().unwrap_or(dash),
+        zccache_cache_str,
         vs_sccache_warm_single.as_deref().unwrap_or(dash),
         fmt_ratio(bl_warm_single, zc_single_med, true),
     );
     eprintln!(
-        "| Multi-file, Cold | {} | {} | {} | {} | {} |",
+        "| Multi-file, Cold | {} | {} | {} | {} | {} | {} | {} | {} |",
         fmt_dur(bl_cold_multi),
         sc_cold_multi_str.as_deref().unwrap_or(dash),
         fmt_dur(zc_cold_multi),
+        fmt_bytes(0),
+        sccache_cache_str.as_deref().unwrap_or(dash),
+        zccache_cache_str,
         vs_sccache_cold_multi.as_deref().unwrap_or(dash),
         fmt_ratio(bl_cold_multi, zc_cold_multi, false),
     );
     eprintln!(
-        "| Multi-file, Warm | {} | {} | **{}** | {} | {} |",
+        "| Multi-file, Warm | {} | {} | **{}** | {} | {} | {} | {} | {} |",
         fmt_dur(bl_warm_multi),
         sc_warm_multi_str.as_deref().unwrap_or(dash),
         fmt_dur(zc_multi_med),
+        fmt_bytes(0),
+        sccache_cache_str.as_deref().unwrap_or(dash),
+        zccache_cache_str,
         vs_sccache_warm_multi.as_deref().unwrap_or(dash),
         fmt_ratio(bl_warm_multi, zc_multi_med, true),
     );
@@ -301,6 +319,7 @@ async fn perf_emcc_sibling_remap_warm() {
     eprintln!();
 
     // ── sccache em++ warm in workspace B ──────────────────────────────
+    let mut sccache_cache_bytes = None;
     let sccache_warm = if let Some(sccache_bin) = find_sccache() {
         let sc_cache_dir = zccache::test_support::temp_cache_dir().unwrap();
         let sc_cache_str = sc_cache_dir.path().to_string_lossy().into_owned();
@@ -329,6 +348,7 @@ async fn perf_emcc_sibling_remap_warm() {
             ));
         }
         print_trials_per("warm:", &warm, Some(NUM_FILES));
+        sccache_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
         let _ = std::process::Command::new(&sccache_bin)
             .arg("--stop-server")
             .stdout(std::process::Stdio::null())
@@ -344,7 +364,7 @@ async fn perf_emcc_sibling_remap_warm() {
 
     // ── zccache primed from workspace A, warm in workspace B ──────────
     eprintln!("  [3/3] zccache em++ (prime: workspace A, warm: workspace B, remap=auto)");
-    let (_zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
+    let (zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
 
     let workspace_a_str = workspace_a.to_string_lossy().into_owned();
@@ -387,6 +407,7 @@ async fn perf_emcc_sibling_remap_warm() {
         );
     }
     print_trials_per("warm:", &zc_warm, Some(NUM_FILES));
+    let zccache_cache_bytes = dir_size_bytes(zccache_cache_dir.path());
 
     end_zccache_session(&mut client, session_b).await;
     shutdown.notify_one();
@@ -397,6 +418,8 @@ async fn perf_emcc_sibling_remap_warm() {
     let bl_warm_med = median(&bl_warm);
     let zc_warm_med = median(&zc_warm);
     let sccache_warm_str = sccache_warm.as_ref().map(|t| fmt_dur(median(t)));
+    let sccache_cache_str = sccache_cache_bytes.map(fmt_bytes);
+    let zccache_cache_str = fmt_bytes(zccache_cache_bytes);
     let vs_sccache = sccache_warm
         .as_ref()
         .map(|t| fmt_ratio(median(t), zc_warm_med, true));
@@ -407,13 +430,16 @@ async fn perf_emcc_sibling_remap_warm() {
         "## Emscripten Sibling-Workspace Remap Benchmark: {NUM_FILES} .cpp files, {WARM_TRIALS} warm trials"
     );
     eprintln!();
-    eprintln!("| Scenario | Bare em++ | sccache | zccache | vs sccache | vs bare em++ |");
-    eprintln!("|:---------|---------:|--------:|--------:|-----------:|-------------:|");
+    eprintln!("| Scenario | Bare em++ | sccache | zccache | bare cache | sccache cache | zccache cache | vs sccache | vs bare em++ |");
+    eprintln!("|:---------|---------:|--------:|--------:|-----------:|--------------:|--------------:|-----------:|-------------:|");
     eprintln!(
-        "| Sibling-workspace, Warm | {} | {} | **{}** | {} | {} |",
+        "| Sibling-workspace, Warm | {} | {} | **{}** | {} | {} | {} | {} | {} |",
         fmt_dur(bl_warm_med),
         sccache_warm_str.as_deref().unwrap_or(dash),
         fmt_dur(zc_warm_med),
+        fmt_bytes(0),
+        sccache_cache_str.as_deref().unwrap_or(dash),
+        zccache_cache_str,
         vs_sccache.as_deref().unwrap_or(dash),
         vs_bare,
     );

--- a/crates/zccache/tests/perf_bench/tests_response_file.rs
+++ b/crates/zccache/tests/perf_bench/tests_response_file.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use zccache::protocol::{Request, Response};
 
 use super::common::{
-    find_sccache, fmt_dur, fmt_ratio, median, print_trials, start_daemon, NUM_FILES,
-    RSP_NUM_DEFINES, RSP_NUM_INCLUDES, WARM_TRIALS,
+    dir_size_bytes, find_sccache, fmt_bytes, fmt_dur, fmt_ratio, median, print_trials,
+    start_daemon, NUM_FILES, RSP_NUM_DEFINES, RSP_NUM_INCLUDES, WARM_TRIALS,
 };
 use super::cpp_project::{
     generate_project, nuke_and_regenerate_with_rsp, source_names, warmup_compiler,
@@ -69,6 +69,7 @@ async fn perf_response_file() {
     let sccache_cold_multi;
     let sccache_single_times;
     let sccache_multi_times;
+    let mut sccache_cache_bytes = None;
 
     if let Some(sccache_bin) = find_sccache() {
         let sc_dir = zccache::test_support::temp_cache_dir().unwrap();
@@ -140,6 +141,7 @@ async fn perf_response_file() {
         }
         print_trials("multi warm:", &times);
         sccache_multi_times = Some(times);
+        sccache_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
 
         let _ = std::process::Command::new(&sccache_bin)
             .arg("--stop-server")
@@ -168,7 +170,7 @@ async fn perf_response_file() {
 
     eprintln!("  [3/3] zccache (in-process daemon)");
 
-    let (_zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
+    let (zccache_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
 
     client
@@ -220,6 +222,7 @@ async fn perf_response_file() {
             .push(zccache_compile_multi_rsp(&mut client, &session_id, &compiler, &zc_cwd).await);
     }
     print_trials("multi warm:", &zc_multi_times);
+    let zccache_cache_bytes = dir_size_bytes(zccache_cache_dir.path());
 
     // End session
     client
@@ -241,6 +244,8 @@ async fn perf_response_file() {
     let scc_multi_str = sccache_multi_times.as_ref().map(|t| fmt_dur(median(t)));
     let scc_cold_s_str = sccache_cold_single.map(fmt_dur);
     let scc_cold_m_str = sccache_cold_multi.map(fmt_dur);
+    let sccache_cache_str = sccache_cache_bytes.map(fmt_bytes);
+    let zccache_cache_str = fmt_bytes(zccache_cache_bytes);
     let dash = "\u{2014}";
 
     eprintln!();
@@ -253,18 +258,21 @@ async fn perf_response_file() {
         RSP_NUM_DEFINES + RSP_NUM_INCLUDES + 30 + 3,
     );
     eprintln!();
-    eprintln!("| Scenario | Bare Clang | sccache | zccache | vs sccache | vs bare clang |");
-    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|");
+    eprintln!("| Scenario | Bare Clang | sccache | zccache | bare cache | sccache cache | zccache cache | vs sccache | vs bare clang |");
+    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|--------------:|-----------:|--------------:|");
 
     // Single-file RSP, Cold
     let scc_cs = scc_cold_s_str.as_deref().unwrap_or(dash);
     let vs_scc_cold_s = sccache_cold_single.map(|t| fmt_ratio(t, zc_cold_single, false));
     let vs_bare_cold_s = fmt_ratio(bl_cold_single, zc_cold_single, false);
     eprintln!(
-        "| Single-file RSP, Cold | {} | {} | {} | {} | {} |",
+        "| Single-file RSP, Cold | {} | {} | {} | {} | {} | {} | {} | {} |",
         fmt_dur(bl_cold_single),
         scc_cs,
         fmt_dur(zc_cold_single),
+        fmt_bytes(0),
+        sccache_cache_str.as_deref().unwrap_or(dash),
+        zccache_cache_str,
         vs_scc_cold_s.as_deref().unwrap_or(dash),
         vs_bare_cold_s,
     );
@@ -276,10 +284,13 @@ async fn perf_response_file() {
         .map(|t| fmt_ratio(median(t), zc_single_med, true));
     let vs_bare_warm_s = fmt_ratio(bl_warm_single, zc_single_med, true);
     eprintln!(
-        "| Single-file RSP, Warm | {} | {} | **{}** | {} | {} |",
+        "| Single-file RSP, Warm | {} | {} | **{}** | {} | {} | {} | {} | {} |",
         fmt_dur(bl_warm_single),
         scc_ws,
         fmt_dur(zc_single_med),
+        fmt_bytes(0),
+        sccache_cache_str.as_deref().unwrap_or(dash),
+        zccache_cache_str,
         vs_scc_warm_s.as_deref().unwrap_or(dash),
         vs_bare_warm_s,
     );
@@ -289,10 +300,13 @@ async fn perf_response_file() {
     let vs_scc_cold_m = sccache_cold_multi.map(|t| fmt_ratio(t, zc_cold_multi, false));
     let vs_bare_cold_m = fmt_ratio(bl_cold_multi, zc_cold_multi, false);
     eprintln!(
-        "| Multi-file RSP, Cold | {} | {} | {} | {} | {} |",
+        "| Multi-file RSP, Cold | {} | {} | {} | {} | {} | {} | {} | {} |",
         fmt_dur(bl_cold_multi),
         scc_cm,
         fmt_dur(zc_cold_multi),
+        fmt_bytes(0),
+        sccache_cache_str.as_deref().unwrap_or(dash),
+        zccache_cache_str,
         vs_scc_cold_m.as_deref().unwrap_or(dash),
         vs_bare_cold_m,
     );
@@ -304,10 +318,13 @@ async fn perf_response_file() {
         .map(|t| fmt_ratio(median(t), zc_multi_med, true));
     let vs_bare_warm_m = fmt_ratio(bl_warm_multi, zc_multi_med, true);
     eprintln!(
-        "| Multi-file RSP, Warm | {} | {} | **{}** | {} | {} |",
+        "| Multi-file RSP, Warm | {} | {} | **{}** | {} | {} | {} | {} | {} |",
         fmt_dur(bl_warm_multi),
         scc_wm,
         fmt_dur(zc_multi_med),
+        fmt_bytes(0),
+        sccache_cache_str.as_deref().unwrap_or(dash),
+        zccache_cache_str,
         vs_scc_warm_m.as_deref().unwrap_or(dash),
         vs_bare_warm_m,
     );

--- a/crates/zccache/tests/perf_bench/tests_rust.rs
+++ b/crates/zccache/tests/perf_bench/tests_rust.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use zccache::protocol::{Request, Response};
 
 use super::common::{
-    find_sccache, fmt_dur, fmt_ratio, median, print_trials, start_daemon, RUSTC_NUM_FILES,
-    RUSTC_WARM_TRIALS,
+    dir_size_bytes, find_sccache, fmt_bytes, fmt_dur, fmt_ratio, median, print_trials,
+    start_daemon, RUSTC_NUM_FILES, RUSTC_WARM_TRIALS,
 };
 use super::rust_project::{
     generate_rust_project, run_rustc_batch, run_sccache_rustc_batch, run_zccache_rustc_batch,
@@ -54,6 +54,7 @@ async fn perf_rustc_zccache_vs_sccache() {
 
     let build_sc_cold;
     let build_sc_warm;
+    let mut build_sccache_cache_bytes = None;
     if let Some(ref scc_bin) = find_sccache() {
         let sd = zccache::test_support::temp_cache_dir().unwrap();
         generate_rust_project(sd.path());
@@ -92,6 +93,7 @@ async fn perf_rustc_zccache_vs_sccache() {
         }
         print_trials("warm:", &t);
         build_sc_warm = Some(t);
+        build_sccache_cache_bytes = Some(dir_size_bytes(scd.path()));
         let _ = std::process::Command::new(scc_bin)
             .arg("--stop-server")
             .stdout(std::process::Stdio::null())
@@ -109,7 +111,7 @@ async fn perf_rustc_zccache_vs_sccache() {
     generate_rust_project(zd.path());
     let zc = zd.path().to_string_lossy().into_owned();
     eprintln!("  [3/3] zccache");
-    let (_zccache_cache_dir, ep, sh, sd) = start_daemon().await;
+    let (zccache_cache_dir, ep, sh, sd) = start_daemon().await;
     let mut cl = zccache::ipc::connect(&ep).await.unwrap();
     cl.send(&Request::SessionStart {
         client_pid: std::process::id(),
@@ -136,6 +138,7 @@ async fn perf_rustc_zccache_vs_sccache() {
             .push(run_zccache_rustc_batch(&mut cl, &sid, &rc, &zc, &srcs, rustc_args_for).await);
     }
     print_trials("warm:", &build_zc_warm);
+    let build_zccache_cache_bytes = dir_size_bytes(zccache_cache_dir.path());
     eprintln!();
 
     // ─── Check mode (--emit=dep-info,metadata) ──────────────────────────
@@ -155,6 +158,7 @@ async fn perf_rustc_zccache_vs_sccache() {
 
     let check_sc_cold;
     let check_sc_warm;
+    let mut check_sccache_cache_bytes = None;
     if let Some(ref scc_bin) = find_sccache() {
         let sd = zccache::test_support::temp_cache_dir().unwrap();
         generate_rust_project(sd.path());
@@ -193,6 +197,7 @@ async fn perf_rustc_zccache_vs_sccache() {
         }
         print_trials("warm:", &t);
         check_sc_warm = Some(t);
+        check_sccache_cache_bytes = Some(dir_size_bytes(scd.path()));
         let _ = std::process::Command::new(scc_bin)
             .arg("--stop-server")
             .stdout(std::process::Stdio::null())
@@ -222,6 +227,7 @@ async fn perf_rustc_zccache_vs_sccache() {
         );
     }
     print_trials("warm:", &check_zc_warm);
+    let check_zccache_cache_bytes = dir_size_bytes(zccache_cache_dir.path());
 
     cl.send(&Request::SessionEnd { session_id: sid })
         .await
@@ -242,13 +248,22 @@ async fn perf_rustc_zccache_vs_sccache() {
     eprintln!();
     eprintln!("## Rust Benchmark: {RUSTC_NUM_FILES} .rs files, {RUSTC_WARM_TRIALS} warm trials");
     eprintln!();
-    eprintln!("| Scenario | Bare rustc | sccache | zccache | vs sccache | vs bare rustc |");
-    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|");
+    eprintln!("| Scenario | Bare rustc | sccache | zccache | bare cache | sccache cache | zccache cache | vs sccache | vs bare rustc |");
+    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|--------------:|-----------:|--------------:|");
 
     // Helper closure for table rows
-    let row = |label: &str, bl: Duration, sc: Option<Duration>, zc: Duration, bold: bool| {
+    let row = |label: &str,
+               bl: Duration,
+               sc: Option<Duration>,
+               zc: Duration,
+               sccache_cache_bytes: Option<u64>,
+               zccache_cache_bytes: u64,
+               bold: bool| {
         let sc_s = sc.map(fmt_dur);
         let sc_str = sc_s.as_deref().unwrap_or(dash);
+        let sc_cache_s = sccache_cache_bytes.map(fmt_bytes);
+        let sc_cache_str = sc_cache_s.as_deref().unwrap_or(dash);
+        let zc_cache_str = fmt_bytes(zccache_cache_bytes);
         let vs_sc = sc.map(|s| fmt_ratio(s, zc, bold));
         let vs_bl = fmt_ratio(bl, zc, bold);
         let zc_fmt = if bold {
@@ -257,11 +272,14 @@ async fn perf_rustc_zccache_vs_sccache() {
             fmt_dur(zc)
         };
         eprintln!(
-            "| {} | {} | {} | {} | {} | {} |",
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} |",
             label,
             fmt_dur(bl),
             sc_str,
             zc_fmt,
+            fmt_bytes(0),
+            sc_cache_str,
+            zc_cache_str,
             vs_sc.as_deref().unwrap_or(dash),
             vs_bl
         );
@@ -272,6 +290,8 @@ async fn perf_rustc_zccache_vs_sccache() {
         build_bl_cold,
         build_sc_cold,
         build_zc_cold,
+        build_sccache_cache_bytes,
+        build_zccache_cache_bytes,
         false,
     );
     row(
@@ -279,6 +299,8 @@ async fn perf_rustc_zccache_vs_sccache() {
         build_bl_warm,
         build_sc_warm.as_ref().map(|t| median(t)),
         build_zm,
+        build_sccache_cache_bytes,
+        build_zccache_cache_bytes,
         true,
     );
     row(
@@ -286,6 +308,8 @@ async fn perf_rustc_zccache_vs_sccache() {
         check_bl_cold,
         check_sc_cold,
         check_zc_cold,
+        check_sccache_cache_bytes,
+        check_zccache_cache_bytes,
         false,
     );
     row(
@@ -293,6 +317,8 @@ async fn perf_rustc_zccache_vs_sccache() {
         check_bl_warm,
         check_sc_warm.as_ref().map(|t| median(t)),
         check_zm,
+        check_sccache_cache_bytes,
+        check_zccache_cache_bytes,
         true,
     );
 

--- a/crates/zccache/tests/perf_bench/tests_sibling_remap.rs
+++ b/crates/zccache/tests/perf_bench/tests_sibling_remap.rs
@@ -1,8 +1,9 @@
 //! Sibling-workspace `ZCCACHE_PATH_REMAP=auto` benchmarks (C++ and Rust).
 
 use super::common::{
-    end_zccache_session, find_sccache, fmt_dur, fmt_ratio, median, print_trials_per, start_daemon,
-    start_zccache_session, NUM_FILES, RUSTC_NUM_FILES, RUSTC_WARM_TRIALS, WARM_TRIALS,
+    dir_size_bytes, end_zccache_session, find_sccache, fmt_bytes, fmt_dur, fmt_ratio, median,
+    print_trials_per, start_daemon, start_zccache_session, NUM_FILES, RUSTC_NUM_FILES,
+    RUSTC_WARM_TRIALS, WARM_TRIALS,
 };
 use super::rust_project::{
     generate_rust_project, run_rustc_batch, run_sccache_rustc_batch,
@@ -57,22 +58,27 @@ async fn perf_cpp_sibling_remap_warm() {
         "## C++ Sibling-Workspace Remap Benchmark: {NUM_FILES} .cpp files, {WARM_TRIALS} warm trials"
     );
     eprintln!();
-    eprintln!("| Scenario | Bare clang | sccache | zccache | vs sccache | vs bare clang |");
-    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|");
+    eprintln!("| Scenario | Bare clang | sccache | zccache | bare cache | sccache cache | zccache cache | vs sccache | vs bare clang |");
+    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|--------------:|-----------:|--------------:|");
     for result in &results {
         let zc_warm_med = median(&result.zccache_warm);
         let sccache_warm_str = result.sccache_warm.as_ref().map(|t| fmt_dur(median(t)));
+        let sccache_cache_str = result.sccache_cache_bytes.map(fmt_bytes);
+        let zccache_cache_str = fmt_bytes(result.zccache_cache_bytes);
         let vs_sccache = result
             .sccache_warm
             .as_ref()
             .map(|t| fmt_ratio(median(t), zc_warm_med, true));
         let vs_bare = fmt_ratio(result.bare_warm, zc_warm_med, true);
         eprintln!(
-            "| {} | {} | {} | **{}** | {} | {} |",
+            "| {} | {} | {} | **{}** | {} | {} | {} | {} | {} |",
             result.scenario,
             fmt_dur(result.bare_warm),
             sccache_warm_str.as_deref().unwrap_or(dash),
             fmt_dur(zc_warm_med),
+            fmt_bytes(0),
+            sccache_cache_str.as_deref().unwrap_or(dash),
+            zccache_cache_str,
             vs_sccache.as_deref().unwrap_or(dash),
             vs_bare,
         );
@@ -132,6 +138,7 @@ async fn perf_rustc_sibling_remap_warm() {
     eprintln!();
 
     // ── sccache warm in workspace B ────────────────────────────────────
+    let mut sccache_cache_bytes = None;
     let sccache_warm = if let Some(scc_bin) = find_sccache() {
         let scd = zccache::test_support::temp_cache_dir().unwrap();
         let scd_s = scd.path().to_string_lossy().into_owned();
@@ -161,6 +168,7 @@ async fn perf_rustc_sibling_remap_warm() {
             ));
         }
         print_trials_per("warm:", &warm, Some(RUSTC_NUM_FILES));
+        sccache_cache_bytes = Some(dir_size_bytes(scd.path()));
         let _ = std::process::Command::new(&scc_bin)
             .arg("--stop-server")
             .stdout(std::process::Stdio::null())
@@ -176,7 +184,7 @@ async fn perf_rustc_sibling_remap_warm() {
 
     // ── zccache primed from workspace A, warm in workspace B ───────────
     eprintln!("  [3/3] zccache (prime: workspace A, warm: workspace B, remap=auto)");
-    let (_zccache_cache_dir, ep, sh, sd) = start_daemon().await;
+    let (zccache_cache_dir, ep, sh, sd) = start_daemon().await;
     let mut cl = zccache::ipc::connect(&ep).await.unwrap();
     let workspace_a_str = workspace_a.to_string_lossy().into_owned();
     let workspace_b_str = workspace_b.to_string_lossy().into_owned();
@@ -223,6 +231,7 @@ async fn perf_rustc_sibling_remap_warm() {
         );
     }
     print_trials_per("warm:", &zc_warm, Some(RUSTC_NUM_FILES));
+    let zccache_cache_bytes = dir_size_bytes(zccache_cache_dir.path());
 
     end_zccache_session(&mut cl, session_b).await;
     sd.notify_one();
@@ -233,6 +242,8 @@ async fn perf_rustc_sibling_remap_warm() {
     let bl_med = median(&bl_warm);
     let zc_med = median(&zc_warm);
     let sccache_warm_str = sccache_warm.as_ref().map(|t| fmt_dur(median(t)));
+    let sccache_cache_str = sccache_cache_bytes.map(fmt_bytes);
+    let zccache_cache_str = fmt_bytes(zccache_cache_bytes);
     let vs_sccache = sccache_warm
         .as_ref()
         .map(|t| fmt_ratio(median(t), zc_med, true));
@@ -243,13 +254,16 @@ async fn perf_rustc_sibling_remap_warm() {
         "## Rust Sibling-Workspace Remap Benchmark: {RUSTC_NUM_FILES} .rs files, {RUSTC_WARM_TRIALS} warm trials"
     );
     eprintln!();
-    eprintln!("| Scenario | Bare rustc | sccache | zccache | vs sccache | vs bare rustc |");
-    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|");
+    eprintln!("| Scenario | Bare rustc | sccache | zccache | bare cache | sccache cache | zccache cache | vs sccache | vs bare rustc |");
+    eprintln!("|:---------|----------:|--------:|--------:|-----------:|--------------:|--------------:|-----------:|--------------:|");
     eprintln!(
-        "| Sibling-workspace, Warm | {} | {} | **{}** | {} | {} |",
+        "| Sibling-workspace, Warm | {} | {} | **{}** | {} | {} | {} | {} | {} |",
         fmt_dur(bl_med),
         sccache_warm_str.as_deref().unwrap_or(dash),
         fmt_dur(zc_med),
+        fmt_bytes(0),
+        sccache_cache_str.as_deref().unwrap_or(dash),
+        zccache_cache_str,
         vs_sccache.as_deref().unwrap_or(dash),
         vs_bare,
     );


### PR DESCRIPTION
## Summary
- add cache-byte columns to the remaining benchmark-stats perf table emitters: C++, response-file, Rust, Emscripten, and sibling-remap
- carry measured isolated sccache/zccache cache-root sizes into those rows; bare remains `0 B`
- leaves only the non-published probe-storm table on the old shape

Follow-up to #802 and #788.

## Tests
- `soldr rustfmt --check crates/zccache/tests/perf_bench/tests_cpp.rs crates/zccache/tests/perf_bench/tests_response_file.rs crates/zccache/tests/perf_bench/tests_rust.rs crates/zccache/tests/perf_bench/tests_emcc.rs crates/zccache/tests/perf_bench/sibling_remap.rs crates/zccache/tests/perf_bench/tests_sibling_remap.rs`
- `soldr cargo test -p zccache --test perf_bench_test --no-run`
- `$env:PYTHONPATH=(Get-Location).Path; uv run --no-project --with pytest --with pillow python -m pytest ci/tests/test_benchmark_stats.py`