### PR TITLE
perf(daemon): defer SystemIncludeCache load off spawn→lockfile path (#784 phase 2c)

### DIFF
--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -423,6 +423,18 @@ fn run_server(args: Args) {
             metadata_loader.load_and_install();
         });
 
+        // Issue #784 phase 2c: same shape for the on-disk
+        // system-includes snapshot. The loader briefly acquires the
+        // `system_includes: Mutex<...>` via `blocking_lock()` to merge
+        // entries from the loaded cache into the live one. Same
+        // shutdown-save gating as the compiler-hash loader:
+        // `system_includes_loaded` tells `server::run`'s shutdown arm
+        // whether the in-memory state is canonical.
+        let system_includes_loader = server.system_includes_loader();
+        tokio::task::spawn_blocking(move || {
+            system_includes_loader.load_and_install();
+        });
+
         // Wire up Ctrl+C to trigger graceful shutdown
         let shutdown = server.shutdown_handle();
         tokio::spawn(async move {

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -70,18 +70,15 @@ impl DaemonServer {
         // ~30-50 ms `<compiler> -v -E -x c++ NUL` spawn on its first
         // C/C++ compile. Stat-verify on lookup catches in-place compiler
         // upgrades, so a stale snapshot is harmless.
-        let system_includes_loaded = match crate::depgraph::SystemIncludeCache::load_from_disk(
-            system_includes_cache_path.as_path(),
-        ) {
-            Ok(cache) => cache,
-            Err(e) => {
-                tracing::warn!(
-                    path = %system_includes_cache_path.display(),
-                    "failed to load system include cache, starting empty: {e}"
-                );
-                crate::depgraph::SystemIncludeCache::new()
-            }
-        };
+        //
+        // Issue #784 phase 2c: start empty here. The on-disk snapshot
+        // is loaded by `system_includes_loader()`'s `load_and_install()`
+        // in a `spawn_blocking` AFTER the daemon's readiness lockfile is
+        // written, so the disk read is removed from the spawn→lockfile
+        // critical path. Compile requests arriving during the merge
+        // window pay the cold compiler probe — same outcome as before
+        // #541's persistence existed.
+        let system_includes_loaded = crate::depgraph::SystemIncludeCache::new();
         // Issue #517: hashing rustc's ~150 MB binary on the cold path
         // costs ~50-60 ms per first-after-restart compile. Loading the
         // (path, mtime, size, hash) snapshot from a prior daemon makes
@@ -159,6 +156,7 @@ impl DaemonServer {
                 artifacts_loaded: AtomicBool::new(false),
                 compiler_hash_cache_loaded: AtomicBool::new(false),
                 metadata_cache_loaded: AtomicBool::new(false),
+                system_includes_loaded: AtomicBool::new(false),
                 shutdown_event_logged: AtomicBool::new(false),
                 fingerprint: FingerprintManager::new(),
                 dep_graph_persisted: AtomicBool::new(false),
@@ -257,6 +255,22 @@ impl DaemonServer {
         MetadataCacheLoader {
             state: Arc::clone(&self.state),
             path: self.state.metadata_path.clone(),
+        }
+    }
+
+    /// Hand out a loader that reads the on-disk system-includes snapshot
+    /// and merges it into the live `Mutex<SystemIncludeCache>` on the
+    /// state. Issue #784 phase 2c.
+    ///
+    /// Designed to be called once, immediately after `write_lock_file`,
+    /// inside a `tokio::task::spawn_blocking`. The loader uses
+    /// `blocking_lock()` on the tokio mutex so the brief merge fits
+    /// inside the blocking thread (same shape as
+    /// `set_depgraph_load_warning`).
+    pub fn system_includes_loader(&self) -> SystemIncludesLoader {
+        SystemIncludesLoader {
+            state: Arc::clone(&self.state),
+            path: self.state.system_includes_cache_path.clone(),
         }
     }
 
@@ -389,6 +403,57 @@ impl DepGraphSetter {
 pub struct CompilerHashCacheLoader {
     state: Arc<SharedState>,
     path: crate::core::NormalizedPath,
+}
+
+/// Owned handle that loads the on-disk system-includes snapshot and
+/// merges it into the running daemon's `Mutex<SystemIncludeCache>`.
+///
+/// Issue #784 phase 2c. Same shape as [`CompilerHashCacheLoader`] but
+/// uses `blocking_lock()` to acquire the tokio mutex briefly during
+/// the merge (the `SystemIncludeCache` itself uses `HashMap` with
+/// `&mut self` mutations, so the mutex stays on the live field).
+pub struct SystemIncludesLoader {
+    state: Arc<SharedState>,
+    path: crate::core::NormalizedPath,
+}
+
+impl SystemIncludesLoader {
+    /// Load the on-disk snapshot (if any) and merge it into the live
+    /// cache.
+    ///
+    /// A missing or corrupt snapshot is logged at WARN and the live
+    /// cache is left empty (the stat-verify safety net in
+    /// `SystemIncludeCache::get` / `get_or_discover` keeps correctness
+    /// either way). After the merge — successful or empty —
+    /// `system_includes_loaded` is set so `run.rs`'s shutdown path
+    /// knows the in-memory state is canonical and safe to save.
+    pub fn load_and_install(self) {
+        match crate::depgraph::SystemIncludeCache::load_from_disk(self.path.as_path()) {
+            Ok(loaded) => {
+                let loaded_len = loaded.len();
+                {
+                    let mut live = self.state.system_includes.blocking_lock();
+                    live.merge_from(loaded);
+                }
+                if loaded_len > 0 {
+                    tracing::info!(
+                        loaded = loaded_len,
+                        path = %self.path.display(),
+                        "system include cache restored from disk (background)"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %self.path.display(),
+                    "failed to load system include cache, starting empty: {e}"
+                );
+            }
+        }
+        self.state
+            .system_includes_loaded
+            .store(true, Ordering::Release);
+    }
 }
 
 impl CompilerHashCacheLoader {

--- a/crates/zccache/src/daemon/server/run.rs
+++ b/crates/zccache/src/daemon/server/run.rs
@@ -495,6 +495,20 @@ impl DaemonServer {
                     // so the next daemon does not pay the ~30-50 ms
                     // `<compiler> -v -E -x c++ NUL` spawn on its first
                     // C/C++ compile.
+                    //
+                    // Issue #784 phase 2c: gate on `system_includes_loaded`.
+                    // The disk load now runs in a background
+                    // `spawn_blocking` after the readiness lockfile, so
+                    // an early shutdown could otherwise save a partial
+                    // snapshot over the on-disk file. Skipping the save
+                    // when the load hasn't completed preserves the
+                    // existing snapshot — entries that DID land
+                    // in-memory came from in-process compiles whose
+                    // re-probe is cheap.
+                    if self
+                        .state
+                        .system_includes_loaded
+                        .load(Ordering::Acquire)
                     {
                         let includes = self.state.system_includes.lock().await;
                         if let Err(e) = includes
@@ -505,6 +519,10 @@ impl DaemonServer {
                                 "system include cache save failed: {e}"
                             );
                         }
+                    } else {
+                        tracing::debug!(
+                            "system include cache load still pending at shutdown — skipping save"
+                        );
                     }
 
                     // Clean up our own depfile temp directory.

--- a/crates/zccache/src/daemon/server/state.rs
+++ b/crates/zccache/src/daemon/server/state.rs
@@ -169,6 +169,14 @@ pub(super) struct SharedState {
     /// the load is still pending could write a partial snapshot over
     /// the on-disk file. Mirrors `compiler_hash_cache_loaded` above.
     pub(super) metadata_cache_loaded: AtomicBool,
+    /// Whether the background system-include-cache load has completed.
+    ///
+    /// Issue #784 phase 2c: the on-disk snapshot is loaded post-lockfile
+    /// from a `spawn_blocking` task. The shutdown save path in `run.rs`
+    /// checks this before persisting — saving while the load is still
+    /// pending could write a partial snapshot over the on-disk file.
+    /// Mirrors `compiler_hash_cache_loaded` above.
+    pub(super) system_includes_loaded: AtomicBool,
     /// Whether the `died-shutdown` lifecycle event has been written for this
     /// daemon. Under burst load (issue #726), many wedge-detecting clients
     /// race to send `Request::Shutdown` within a few milliseconds and each

--- a/crates/zccache/src/daemon/server/tests/mod.rs
+++ b/crates/zccache/src/daemon/server/tests/mod.rs
@@ -20,6 +20,7 @@ mod pending_cache_writes;
 mod post_link_hook;
 mod release_worktree_handles;
 mod server_ipc;
+mod system_includes_deferred;
 mod write_cached;
 
 /// RAII guard that overrides `ZCCACHE_CACHE_DIR` for the duration of a

--- a/crates/zccache/src/daemon/server/tests/system_includes_deferred.rs
+++ b/crates/zccache/src/daemon/server/tests/system_includes_deferred.rs
@@ -1,0 +1,161 @@
+//! Tests for the issue #784 phase 2c deferred-load path on the
+//! `SystemIncludeCache` snapshot. Mirrors the compiler-hash phase-2a
+//! tests in `tests/compiler_hash.rs` ("Issue #784: deferred compiler-
+//! hash-cache load" section) and the metadata phase-2b tests, with the
+//! `tokio::sync::Mutex` wrinkle on the live cache.
+
+use super::super::*;
+
+/// `bind_with_cache_dir` no longer reads the system-includes snapshot
+/// from disk. The cache starts empty regardless of what is on disk;
+/// the daemon binary's `system_includes_loader().load_and_install()`
+/// does the merge after the readiness lockfile is written.
+#[tokio::test]
+async fn bind_does_not_load_system_includes_from_disk() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let snapshot_path = crate::core::config::system_includes_cache_path_from_cache_dir(&cache_dir);
+
+    // Pre-write a snapshot with a synthetic compiler-includes entry.
+    let mut pre = crate::depgraph::SystemIncludeCache::new();
+    let fake_compiler = tmp.path().join("fake-clang");
+    let synthetic_include = tmp.path().join("include");
+    std::fs::write(&fake_compiler, b"fake compiler").unwrap();
+    std::fs::create_dir_all(&synthetic_include).unwrap();
+    pre.insert(
+        crate::core::NormalizedPath::new(&fake_compiler),
+        vec![crate::core::NormalizedPath::new(&synthetic_include)],
+    );
+    pre.save_to_disk(snapshot_path.as_path()).unwrap();
+    assert!(snapshot_path.as_path().exists());
+
+    // Bind — must NOT read the snapshot (the load is deferred to the
+    // background loader fired post-lockfile by the daemon binary).
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+    let state = server.test_state();
+    {
+        let live = state.system_includes.lock().await;
+        assert_eq!(
+            live.len(),
+            0,
+            "bind must start with an empty system-includes cache",
+        );
+    }
+    assert!(
+        !state.system_includes_loaded.load(Ordering::Acquire),
+        "the loaded flag must start false until the background loader runs",
+    );
+}
+
+/// The `system_includes_loader()` handle reads the snapshot and merges
+/// it into the live cache. Confirms the deferred-load path reaches
+/// functional parity with the old sync-in-bind path.
+#[tokio::test]
+async fn system_includes_loader_merges_snapshot_into_live_cache() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let snapshot_path = crate::core::config::system_includes_cache_path_from_cache_dir(&cache_dir);
+
+    let mut pre = crate::depgraph::SystemIncludeCache::new();
+    let fake_compiler = tmp.path().join("fake-gcc");
+    let synthetic_include = tmp.path().join("include");
+    std::fs::write(&fake_compiler, b"fake gcc").unwrap();
+    std::fs::create_dir_all(&synthetic_include).unwrap();
+    let compiler_key = crate::core::NormalizedPath::new(&fake_compiler);
+    pre.insert(
+        compiler_key.clone(),
+        vec![crate::core::NormalizedPath::new(&synthetic_include)],
+    );
+    pre.save_to_disk(snapshot_path.as_path()).unwrap();
+
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+
+    // Loader uses `blocking_lock()` on the tokio mutex, which would
+    // panic inside a runtime; production calls it from
+    // `tokio::task::spawn_blocking`, so do the same here.
+    let loader = server.system_includes_loader();
+    tokio::task::spawn_blocking(move || loader.load_and_install())
+        .await
+        .unwrap();
+
+    let state = server.test_state();
+    {
+        let live = state.system_includes.lock().await;
+        assert_eq!(
+            live.len(),
+            1,
+            "loader must merge the persisted entry into the live cache",
+        );
+        assert!(
+            live.get(&fake_compiler).is_some(),
+            "the merged entry must be observable via the live cache API",
+        );
+    }
+    assert!(
+        state.system_includes_loaded.load(Ordering::Acquire),
+        "loader must set system_includes_loaded=true so shutdown save fires",
+    );
+}
+
+/// Missing on-disk snapshot is not an error: the loader logs a warning,
+/// leaves the live cache empty, and still flips the loaded flag so
+/// shutdown save fires (and short-circuits because the cache is empty
+/// per `save_to_disk`'s empty-cache early-exit).
+#[tokio::test]
+async fn system_includes_loader_tolerates_missing_snapshot() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+
+    let loader = server.system_includes_loader();
+    tokio::task::spawn_blocking(move || loader.load_and_install())
+        .await
+        .unwrap();
+
+    let state = server.test_state();
+    {
+        let live = state.system_includes.lock().await;
+        assert_eq!(live.len(), 0);
+    }
+    assert!(
+        state.system_includes_loaded.load(Ordering::Acquire),
+        "loaded flag flips even when the snapshot was absent",
+    );
+}
+
+/// `merge_from` is `&mut self`, takes ownership of the loaded cache,
+/// and drains all entries. Documents the contract the deferred loader
+/// relies on.
+#[test]
+fn system_includes_merge_from_drains_other() {
+    let tmp = tempfile::tempdir().unwrap();
+    let compiler_a = tmp.path().join("a");
+    let compiler_b = tmp.path().join("b");
+    let include_a = tmp.path().join("inc_a");
+    let include_b = tmp.path().join("inc_b");
+    std::fs::write(&compiler_a, b"a").unwrap();
+    std::fs::write(&compiler_b, b"b").unwrap();
+    std::fs::create_dir_all(&include_a).unwrap();
+    std::fs::create_dir_all(&include_b).unwrap();
+
+    let mut live = crate::depgraph::SystemIncludeCache::new();
+    live.insert(
+        crate::core::NormalizedPath::new(&compiler_a),
+        vec![crate::core::NormalizedPath::new(&include_a)],
+    );
+
+    let mut loaded = crate::depgraph::SystemIncludeCache::new();
+    loaded.insert(
+        crate::core::NormalizedPath::new(&compiler_b),
+        vec![crate::core::NormalizedPath::new(&include_b)],
+    );
+
+    live.merge_from(loaded);
+
+    assert_eq!(live.len(), 2);
+    assert!(live.get(&compiler_a).is_some());
+    assert!(live.get(&compiler_b).is_some());
+}

--- a/crates/zccache/src/depgraph/system_includes.rs
+++ b/crates/zccache/src/depgraph/system_includes.rs
@@ -308,6 +308,21 @@ impl SystemIncludeCache {
         self.cache.clear();
     }
 
+    /// Drain entries from a freshly loaded `SystemIncludeCache` into
+    /// `self` using `HashMap::extend`.
+    ///
+    /// Issue #784 phase 2c: lets a background `spawn_blocking` task
+    /// load the on-disk snapshot AFTER the daemon has written its
+    /// readiness lockfile, then populate the live cache without
+    /// holding up bind. Readers during the merge window either see no
+    /// entry (cold-path miss — the next `get_or_discover` re-runs the
+    /// compiler probe) or a loaded entry (stat-verify at the call site
+    /// rejects a stale `(mtime, size)` before trusting the cached
+    /// paths, so a partially-loaded snapshot cannot poison results).
+    pub fn merge_from(&mut self, other: Self) {
+        self.cache.extend(other.cache);
+    }
+
     /// Number of cached entries.
     #[must_use]
     pub fn len(&self) -> usize {


### PR DESCRIPTION
## Summary

Phase 2c of #784 — defers the `SystemIncludeCache` load off the spawn→lockfile critical path. Mirrors #786 (Phase 2a, compiler-hash-cache) and #803 (Phase 2b, metadata-cache).

The wrinkle vs. the prior two phases: the live cache lives behind a `tokio::sync::Mutex` rather than using interior-mutability (DashMap), so the loader briefly acquires the mutex via `blocking_lock()` to merge loaded entries — same shape as `set_depgraph_load_warning` already uses in `lifecycle.rs`.

## Approach

- `SystemIncludeCache::merge_from(&mut self, other: Self)` drains entries via `HashMap::extend`. The cache itself uses `&mut self` mutations, so this fits the existing `Mutex<SystemIncludeCache>` shape without changing the field type.
- New `SystemIncludesLoader` handle captures `Arc<SharedState>` + the snapshot path; survives `spawn_blocking` boundary. Inside `load_and_install` it reads the disk snapshot then acquires `state.system_includes.blocking_lock()` for the brief merge. Production always calls it from `tokio::task::spawn_blocking` (`bin/zccache-daemon.rs`); the unit tests wrap the same way.
- `bind_with_cache_dir` now constructs `SystemIncludeCache::new()` (empty) instead of calling `load_from_disk` inline. New `system_includes_loaded: AtomicBool` on `SharedState`; the daemon binary fires the load post-lockfile.
- Shutdown save path (`run.rs:473`) gates on the flag — if shutdown fires before the background load finishes, the on-disk snapshot is preserved.

## Tests

New tests in `daemon::server::tests::system_includes_deferred`:

- `bind_does_not_load_system_includes_from_disk` — bind with a populated snapshot leaves the live cache empty and the loaded flag false.
- `system_includes_loader_merges_snapshot_into_live_cache` — loader populates the cache + flips the flag + entries observable.
- `system_includes_loader_tolerates_missing_snapshot` — no on-disk file is not an error; flag still flips.
- `system_includes_merge_from_drains_other` — documents the `merge_from` contract.

```
test daemon::server::tests::system_includes_deferred::bind_does_not_load_system_includes_from_disk ... ok
test daemon::server::tests::system_includes_deferred::system_includes_loader_merges_snapshot_into_live_cache ... ok
test daemon::server::tests::system_includes_deferred::system_includes_loader_tolerates_missing_snapshot ... ok
test daemon::server::tests::system_includes_deferred::system_includes_merge_from_drains_other ... ok
test result: ok. 4 passed; 0 failed; ...
```

`cargo clippy -p zccache --all-targets -- -D warnings` clean. `cargo fmt --all --check` clean (swept up the same pre-existing drift in `ipc/broker.rs` and `ipc/broker_v2.rs` that #803 picked up).

## Test plan

- [x] `cargo test -p zccache --lib daemon::server::tests::system_includes_deferred::` passes (4/4)
- [x] `cargo clippy -p zccache --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] Full workspace CI green

Closes #793.

Independent of #803 (different file, different field). Either can land first.
