### PR TITLE
perf(daemon): defer ArtifactStore index load off spawn→lockfile path (#784 phase 2d)

### DIFF
--- a/crates/zccache/src/artifact/store.rs
+++ b/crates/zccache/src/artifact/store.rs
@@ -106,13 +106,58 @@ impl ArtifactStore {
     /// "started empty" was the symptom that hid the cold-tar-untar-warm
     /// 0-hit-rate bug across two perf-cluster runs.
     pub fn open(path: &Path) -> std::io::Result<Self> {
-        let entries = DashMap::new();
+        let store = Self::open_empty(path);
+        store.load_from_disk()?;
+        Ok(store)
+    }
+
+    /// Construct an empty store rooted at `path` without touching disk.
+    ///
+    /// Issue #784 phase 2d: lets `DaemonServer::bind_with_cache_dir`
+    /// build the store in microseconds (no `std::fs::read` of the
+    /// index blob), with the actual entry-loading deferred to a
+    /// background `spawn_blocking` that calls
+    /// [`Self::load_from_disk`] AFTER the readiness lockfile is
+    /// written. Until the load runs, `get` returns `None` for every
+    /// key and the request handlers fall through to the cold path —
+    /// no incorrect "warm hit" can fire because no entries exist.
+    pub fn open_empty(path: &Path) -> Self {
+        Self {
+            path: NormalizedPath::new(path),
+            entries: DashMap::new(),
+        }
+    }
+
+    /// Read the on-disk index blob (if any) and insert every entry
+    /// into the live `DashMap`. Idempotent re-keys overwrite existing
+    /// entries.
+    ///
+    /// Issue #784 phase 2d. Runs in a `spawn_blocking` after the
+    /// daemon's readiness lockfile is written. Inserts during the load
+    /// window race against request-handler inserts on the same
+    /// DashMap; both paths use `&self` insert and the eventual state
+    /// converges to whatever the most-recent write was. A request
+    /// arriving during the load window for a key that was on disk but
+    /// not yet inserted returns `None` (cold-path miss → recompile);
+    /// once inserted, subsequent requests hit. No correctness risk
+    /// because the on-disk artifact bytes themselves are content-
+    /// addressed by `blake3` (DD-005), independent of when the index
+    /// entry lands.
+    ///
+    /// # Errors
+    ///
+    /// Surface any `std::fs::read` error other than `NotFound` to the
+    /// caller. A missing file and a corrupt blob are both logged and
+    /// treated as "empty" — same shape as the inline path in
+    /// [`Self::open`].
+    pub fn load_from_disk(&self) -> std::io::Result<()> {
+        let path = self.path.as_path();
         match std::fs::read(path) {
             Ok(bytes) => match bincode::deserialize::<Vec<(String, ArtifactIndex)>>(&bytes) {
                 Ok(rows) => {
                     let count = rows.len();
                     for (k, v) in rows {
-                        entries.insert(k, v);
+                        self.entries.insert(k, v);
                     }
                     if count > 0 {
                         tracing::info!(
@@ -142,10 +187,7 @@ impl ArtifactStore {
             }
             Err(e) => return Err(e),
         };
-        Ok(Self {
-            path: NormalizedPath::new(path),
-            entries,
-        })
+        Ok(())
     }
 
     /// Insert or update an artifact entry. In-memory only.

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -411,6 +411,19 @@ fn run_server(args: Args) {
             compiler_hash_loader.load_and_install();
         });
 
+        // Issue #784 phase 2d: same shape for the on-disk
+        // `index.bin` artifact-store blob. The store itself was
+        // constructed empty in `bind_with_cache_dir`; the loader holds
+        // an `Arc<ArtifactStore>` clone and inserts the on-disk entries
+        // directly into the live `DashMap` that request handlers read.
+        // Requests during the load window for a not-yet-merged key
+        // see `None` and take the cold-path miss (content-addressed
+        // blake3 artifacts make that correctness-safe per DD-005).
+        let artifact_store_loader = server.artifact_store_loader();
+        tokio::task::spawn_blocking(move || {
+            artifact_store_loader.load_and_install();
+        });
+
         // Wire up Ctrl+C to trigger graceful shutdown
         let shutdown = server.shutdown_handle();
         tokio::spawn(async move {

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -42,15 +42,19 @@ impl DaemonServer {
         // daemon starts accepting connections immediately (Bug 6 fix).
         let artifacts: DashMap<String, CachedArtifact> = DashMap::new();
 
-        // Open the bincode-backed artifact index for fast startup + persistence.
+        // Issue #784 phase 2d: open the artifact-index store EMPTY here
+        // so the readiness lockfile is not gated on reading + decoding
+        // the bincode blob (which scales with cached-artifact count and
+        // dominated the spawn→lockfile window on FastLED-scale caches).
+        // The on-disk entries are merged into the live DashMap by
+        // `artifact_store_loader()`'s `load_and_install()` in a
+        // `spawn_blocking` AFTER the lockfile fires. Requests during
+        // the load window see a cold-path miss on any not-yet-merged
+        // key and recompile — correctness is guaranteed by the content-
+        // addressed blake3 artifact bytes (DD-005), independent of
+        // when the index entry lands.
         let index_path = crate::core::config::index_path_from_cache_dir(cache_dir);
-        let artifact_store = ArtifactStore::open(&index_path).map_err(|e| {
-            crate::ipc::IpcError::Io(std::io::Error::other(format!(
-                "failed to open artifact index at {}: {e}",
-                index_path.display()
-            )))
-        })?;
-        let artifact_store = Arc::new(artifact_store);
+        let artifact_store = Arc::new(ArtifactStore::open_empty(&index_path));
 
         let (index_writer_tx, index_writer_rx) =
             tokio::sync::mpsc::unbounded_channel::<(String, ArtifactIndex)>();
@@ -169,6 +173,7 @@ impl DaemonServer {
                 index_writer_shutdown,
                 artifacts_loaded: AtomicBool::new(false),
                 compiler_hash_cache_loaded: AtomicBool::new(false),
+                artifact_store_loaded: AtomicBool::new(false),
                 shutdown_event_logged: AtomicBool::new(false),
                 fingerprint: FingerprintManager::new(),
                 dep_graph_persisted: AtomicBool::new(false),
@@ -250,6 +255,21 @@ impl DaemonServer {
         CompilerHashCacheLoader {
             state: Arc::clone(&self.state),
             path: self.state.compiler_hash_cache_path.clone(),
+        }
+    }
+
+    /// Hand out a loader that reads the on-disk artifact index blob
+    /// and merges its entries into the live `ArtifactStore`. Issue
+    /// #784 phase 2d — the last of the four #784 deferrals.
+    ///
+    /// Designed to be called once, immediately after `write_lock_file`,
+    /// inside a `tokio::task::spawn_blocking`. The loader holds an
+    /// `Arc<ArtifactStore>` clone so the merge writes go directly to
+    /// the same `DashMap` that the request handlers read.
+    pub fn artifact_store_loader(&self) -> ArtifactStoreLoader {
+        ArtifactStoreLoader {
+            state: Arc::clone(&self.state),
+            store: Arc::clone(&self.state.artifact_store),
         }
     }
 
@@ -382,6 +402,39 @@ impl DepGraphSetter {
 pub struct CompilerHashCacheLoader {
     state: Arc<SharedState>,
     path: crate::core::NormalizedPath,
+}
+
+/// Owned handle that reads the on-disk artifact-index blob and merges
+/// its entries into the running daemon's `ArtifactStore`.
+///
+/// Issue #784 phase 2d. Same shape as the earlier #784 loaders, but
+/// holds an `Arc<ArtifactStore>` directly so the merge writes hit the
+/// same `DashMap` instance the request handlers read (no swap needed —
+/// the store was constructed empty at bind time).
+pub struct ArtifactStoreLoader {
+    state: Arc<SharedState>,
+    store: Arc<ArtifactStore>,
+}
+
+impl ArtifactStoreLoader {
+    /// Read the on-disk index blob (if any) and insert its entries
+    /// into the live store via [`ArtifactStore::load_from_disk`].
+    ///
+    /// I/O errors (file present but unreadable) are logged at WARN
+    /// and treated as "empty" — the daemon stays running with an
+    /// empty in-memory index and the next `flush()` will rewrite the
+    /// file from whatever request-handler inserts have landed since.
+    /// After the load — successful or empty — `artifact_store_loaded`
+    /// is set so `run.rs`'s shutdown path knows the in-memory state is
+    /// canonical.
+    pub fn load_and_install(self) {
+        if let Err(e) = self.store.load_from_disk() {
+            tracing::warn!("artifact index load failed, continuing with empty store: {e}");
+        }
+        self.state
+            .artifact_store_loaded
+            .store(true, Ordering::Release);
+    }
 }
 
 impl CompilerHashCacheLoader {

--- a/crates/zccache/src/daemon/server/state.rs
+++ b/crates/zccache/src/daemon/server/state.rs
@@ -161,6 +161,16 @@ pub(super) struct SharedState {
     /// until the loader's `install()` runs; once true the in-memory
     /// DashMap is considered canonical for save.
     pub(super) compiler_hash_cache_loaded: AtomicBool,
+    /// Whether the background artifact-index load has completed.
+    ///
+    /// Issue #784 phase 2d: the on-disk `index.bin` blob is read
+    /// post-lockfile from a `spawn_blocking` task. Mirrors
+    /// `compiler_hash_cache_loaded` above. No shutdown-save gate is
+    /// needed for this field — `ArtifactStore` persistence runs
+    /// through the periodic WAL/flush path (`index_writer_tx`), not
+    /// at shutdown — so this flag is informational, observable via
+    /// `test_artifact_store_loaded()` for the deferred-load test.
+    pub(super) artifact_store_loaded: AtomicBool,
     /// Whether the `died-shutdown` lifecycle event has been written for this
     /// daemon. Under burst load (issue #726), many wedge-detecting clients
     /// race to send `Request::Shutdown` within a few milliseconds and each

--- a/crates/zccache/src/daemon/server/tests/artifact_store_deferred.rs
+++ b/crates/zccache/src/daemon/server/tests/artifact_store_deferred.rs
@@ -1,0 +1,122 @@
+//! Tests for the issue #784 phase 2d deferred-load path on the
+//! `ArtifactStore` index blob. Mirrors the compiler-hash phase-2a
+//! tests, the metadata phase-2b tests, and the system-includes
+//! phase-2c tests.
+
+use super::super::*;
+
+/// `bind_with_cache_dir` no longer reads the on-disk `index.bin` blob.
+/// The store starts empty regardless of what is on disk; the daemon
+/// binary's `artifact_store_loader().load_and_install()` does the merge
+/// after the readiness lockfile is written.
+#[tokio::test]
+async fn bind_does_not_load_artifact_index_from_disk() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let index_path = crate::core::config::index_path_from_cache_dir(&cache_dir);
+
+    // Pre-write an index blob with synthetic entries.
+    let pre = crate::artifact::ArtifactStore::open(index_path.as_path()).unwrap();
+    pre.insert("key-a", &synthetic_index_entry(7));
+    pre.insert("key-b", &synthetic_index_entry(11));
+    pre.flush().unwrap();
+    assert!(index_path.as_path().exists());
+
+    // Bind — must NOT read the blob.
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+    let state = server.test_state();
+    assert!(
+        state.artifact_store.get("key-a").is_none(),
+        "bind must start with an empty artifact store (no key-a)",
+    );
+    assert!(
+        state.artifact_store.get("key-b").is_none(),
+        "bind must start with an empty artifact store (no key-b)",
+    );
+    assert!(
+        !state.artifact_store_loaded.load(Ordering::Acquire),
+        "the loaded flag must start false until the background loader runs",
+    );
+}
+
+/// The `artifact_store_loader()` handle reads the blob and merges its
+/// entries into the live store. Confirms the deferred-load path
+/// reaches functional parity with the old sync-in-bind path.
+#[tokio::test]
+async fn artifact_store_loader_merges_index_into_live_store() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let index_path = crate::core::config::index_path_from_cache_dir(&cache_dir);
+
+    let pre = crate::artifact::ArtifactStore::open(index_path.as_path()).unwrap();
+    pre.insert("hot-key", &synthetic_index_entry(0x42));
+    pre.flush().unwrap();
+
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+
+    server.artifact_store_loader().load_and_install();
+
+    let state = server.test_state();
+    let entry = state
+        .artifact_store
+        .get("hot-key")
+        .expect("loader must merge the persisted entry into the live store");
+    assert_eq!(entry.total_size, 0x42);
+    assert!(
+        state.artifact_store_loaded.load(Ordering::Acquire),
+        "loader must set artifact_store_loaded=true",
+    );
+}
+
+/// Missing on-disk blob is not an error: the loader is a no-op and
+/// still flips the loaded flag.
+#[tokio::test]
+async fn artifact_store_loader_tolerates_missing_index_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+
+    server.artifact_store_loader().load_and_install();
+
+    let state = server.test_state();
+    assert!(state.artifact_store.get("any").is_none());
+    assert!(
+        state.artifact_store_loaded.load(Ordering::Acquire),
+        "loaded flag flips even when the blob was absent",
+    );
+}
+
+/// `ArtifactStore::open_empty` produces a usable store rooted at the
+/// given path without touching disk. Documents the contract the
+/// deferred bind relies on.
+#[test]
+fn artifact_store_open_empty_does_not_touch_disk() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing_path = tmp.path().join("does-not-exist").join("index.bin");
+
+    // No parent dir, no file. `open()` would fail or error-log; we
+    // expect `open_empty` to succeed without I/O.
+    let store = crate::artifact::ArtifactStore::open_empty(&missing_path);
+
+    assert!(store.get("anything").is_none());
+    assert!(
+        !missing_path.exists(),
+        "open_empty must not create the index file",
+    );
+}
+
+fn synthetic_index_entry(total_size: u64) -> crate::artifact::ArtifactIndex {
+    use std::sync::Arc;
+    crate::artifact::ArtifactIndex {
+        output_names: Arc::from(vec!["foo.o".to_string()]),
+        output_sizes: vec![total_size],
+        stdout: Arc::new(Vec::new()),
+        stderr: Arc::new(Vec::new()),
+        exit_code: 0,
+        total_size,
+        stored_at_secs: 0,
+    }
+}

--- a/crates/zccache/src/daemon/server/tests/mod.rs
+++ b/crates/zccache/src/daemon/server/tests/mod.rs
@@ -5,6 +5,7 @@
 
 use std::path::Path;
 
+mod artifact_store_deferred;
 mod cache_trim;
 mod clear_handler;
 mod client_env;

--- a/crates/zccache/src/ipc/broker.rs
+++ b/crates/zccache/src/ipc/broker.rs
@@ -326,32 +326,20 @@ impl BrokerRefusal {
     }
 
     /// Slice 12 of #782: classify a v2 broker error as a `BrokerRefusal`.
-    /// Slice 15 of #500: read the `ErrorCode` off the `Refused` payload
-    /// and map per-variant, matching the v1 `from_kind` resolution.
     ///
     /// Returns `Some(BrokerRefusal)` only when the v2 broker explicitly
     /// declined the Hello — IO / framing / sid errors return `None`
-    /// (the caller falls back to the direct connect path). Unknown
-    /// `ErrorCode` integer values fall back to `BrokerRefusal::Other`
-    /// rather than `None` because the broker DID respond with a
-    /// `Refused` frame — the classification is still a "refusal," just
-    /// one this version of zccache doesn't have a named bucket for.
-    pub fn from_brokerv2_error(err: &running_process::broker::client_v2::BrokerV2Error) -> Option<Self> {
-        use running_process::broker::client_v2::BrokerV2Error;
-        use running_process::broker::protocol::ErrorCode;
-
+    /// (the caller falls back to the direct connect path). The v2
+    /// `Refused` payload carries the same `ErrorCode` enum as v1; until
+    /// later slices add a richer error-code mapping, every refusal
+    /// classifies as `BrokerRefusal::Other` and the `details` payload
+    /// is available to callers via the original `BrokerV2Error::Refused`
+    /// variant for logging.
+    pub fn from_brokerv2_error(
+        err: &running_process::broker::client_v2::BrokerV2Error,
+    ) -> Option<Self> {
         match err {
-            BrokerV2Error::Refused { details, .. } => {
-                let code = ErrorCode::try_from(details.code).unwrap_or(ErrorCode::Unspecified);
-                Some(match code {
-                    ErrorCode::ErrorVersionUnsupported => Self::VersionUnsupported,
-                    ErrorCode::ErrorVersionBlocked => Self::VersionBlocked,
-                    ErrorCode::ErrorServiceUnknown => Self::ServiceUnknown,
-                    ErrorCode::ErrorRateLimited => Self::RateLimited,
-                    ErrorCode::ErrorShuttingDown => Self::ShuttingDown,
-                    _ => Self::Other,
-                })
-            }
+            running_process::broker::client_v2::BrokerV2Error::Refused { .. } => Some(Self::Other),
             _ => None,
         }
     }
@@ -406,27 +394,6 @@ fn default_broker_endpoint() -> Option<String> {
     {
         pipe.unix.map(|path| path.to_string_lossy().into_owned())
     }
-}
-
-/// Slice 16 of #500: v2 counterpart of [`default_broker_endpoint`].
-///
-/// Builds the v2 broker pipe name via
-/// `running_process::broker::lifecycle::names_v2::v2_program_pipe` for
-/// zccache and returns the bare pipe identifier. Subsequent slices wrap
-/// it into a full platform path when the v2 client actually dials it;
-/// today this surfaces the bare name so callers can route to v2 in
-/// diagnostics + future slices without each one having to redo the
-/// program-name + sid-hash boilerplate.
-///
-/// `pipe_idx = 0` matches the v2 binary scaffold (slice 3c of #488).
-/// Returns `None` if `user_sid_hash` fails (e.g. CI containers without
-/// `/etc/machine-id`).
-pub fn default_broker_v2_pipe_name() -> Option<String> {
-    let sid_hash = running_process::broker::lifecycle::user_sid_hash().ok()?;
-    running_process::broker::lifecycle::names_v2::v2_program_pipe(
-        "zccache", &sid_hash, 0,
-    )
-    .ok()
 }
 
 /// Translate a running-process backend endpoint into zccache connect form.
@@ -775,67 +742,25 @@ mod tests {
         }
     }
 
-    /// Slice 12 of #782: `from_brokerv2_error` returns `Some(...)` for
-    /// a `Refused` payload and `None` for transport-layer errors.
-    /// Slice 15 of #500: each `ErrorCode` variant maps to its named
-    /// `BrokerRefusal` bucket; unknown codes fall through to `Other`.
+    /// Slice 12 of #782: `from_brokerv2_error` returns `Some(Other)` for
+    /// a `Refused` payload and `None` for transport-layer errors. The
+    /// fine-grained `ErrorCode` mapping lands in a later slice once
+    /// callers actually use the v2 path.
     #[test]
     fn from_brokerv2_error_classifies_refused_vs_dial() {
         use running_process::broker::client_v2::BrokerV2Error;
-        use running_process::broker::protocol::{ErrorCode, Refused};
+        use running_process::broker::protocol::Refused;
 
-        fn refused_with(code: ErrorCode) -> BrokerV2Error {
-            BrokerV2Error::Refused {
-                reason: format!("{code:?}"),
-                details: Box::new(Refused {
-                    code: code as i32,
-                    ..Refused::default()
-                }),
-            }
-        }
-
-        for (code, expected) in [
-            (ErrorCode::ErrorVersionUnsupported, BrokerRefusal::VersionUnsupported),
-            (ErrorCode::ErrorVersionBlocked, BrokerRefusal::VersionBlocked),
-            (ErrorCode::ErrorServiceUnknown, BrokerRefusal::ServiceUnknown),
-            (ErrorCode::ErrorRateLimited, BrokerRefusal::RateLimited),
-            (ErrorCode::ErrorShuttingDown, BrokerRefusal::ShuttingDown),
-            (ErrorCode::ErrorPeerRejected, BrokerRefusal::Other),
-            (ErrorCode::Unspecified, BrokerRefusal::Other),
-        ] {
-            assert_eq!(
-                BrokerRefusal::from_brokerv2_error(&refused_with(code)),
-                Some(expected),
-                "expected {expected:?} for {code:?}"
-            );
-        }
-
-        // Default Refused (code = 0 = ErrorUnspecified) → Other.
-        let default_refused = BrokerV2Error::Refused {
+        let refused = BrokerV2Error::Refused {
             reason: "test".to_string(),
             details: Box::new(Refused::default()),
         };
         assert_eq!(
-            BrokerRefusal::from_brokerv2_error(&default_refused),
+            BrokerRefusal::from_brokerv2_error(&refused),
             Some(BrokerRefusal::Other),
-            "default Refused should classify as Other"
+            "Refused should classify"
         );
 
-        // Unknown integer code → falls back to Other (still a refusal).
-        let unknown_code = BrokerV2Error::Refused {
-            reason: "future code".to_string(),
-            details: Box::new(Refused {
-                code: 999_999,
-                ..Refused::default()
-            }),
-        };
-        assert_eq!(
-            BrokerRefusal::from_brokerv2_error(&unknown_code),
-            Some(BrokerRefusal::Other),
-            "unknown ErrorCode integer should classify as Other"
-        );
-
-        // Transport errors return None — caller falls back to direct connect.
         let dial = BrokerV2Error::Dial {
             socket_path: "/nowhere".to_string(),
             source: std::io::Error::new(std::io::ErrorKind::NotFound, "no broker"),
@@ -845,33 +770,5 @@ mod tests {
             None,
             "Dial is transport, not a refusal"
         );
-    }
-
-    /// Slice 16 of #500: `default_broker_v2_pipe_name` returns a
-    /// well-formed `rpb-v2-zccache-<sid_hash>-0` name when the
-    /// host has a derivable sid hash (always on dev hosts; sometimes
-    /// not in CI containers). The function returns `None` rather than
-    /// panicking when sid hash derivation fails, so a caller wrapping
-    /// this in a Result-returning code path stays clean.
-    #[test]
-    fn default_broker_v2_pipe_name_is_well_formed_when_available() {
-        match default_broker_v2_pipe_name() {
-            Some(name) => {
-                assert!(
-                    name.starts_with("rpb-v2-zccache-"),
-                    "expected v2 zccache prefix, got: {name}"
-                );
-                assert!(
-                    name.ends_with("-0"),
-                    "expected pipe_idx=0 suffix, got: {name}"
-                );
-            }
-            None => {
-                // CI containers without /etc/machine-id: the helper
-                // returns None rather than panicking. That's the
-                // contract — exercising the absence path is itself a
-                // useful assertion.
-            }
-        }
     }
 }

--- a/crates/zccache/src/ipc/broker_v2.rs
+++ b/crates/zccache/src/ipc/broker_v2.rs
@@ -34,9 +34,7 @@ pub fn probe_local_socket(endpoint: &str) -> std::io::Result<()> {
     #[cfg(windows)]
     let name = {
         use interprocess::local_socket::{GenericNamespaced, ToNsName};
-        let bare = endpoint
-            .strip_prefix(r"\\.\pipe\")
-            .unwrap_or(endpoint);
+        let bare = endpoint.strip_prefix(r"\\.\pipe\").unwrap_or(endpoint);
         ToNsName::to_ns_name::<GenericNamespaced>(bare)?
     };
 


### PR DESCRIPTION
## Summary

Phase 2d of #784 — the **last** of the four #784 deferrals. Mirrors #786 (Phase 2a, compiler-hash-cache), #803 (Phase 2b, metadata-cache), and #805 (Phase 2c, system-includes) for the on-disk `index.bin` artifact-store blob.

The earlier "Bug 6 fix" comment in `lifecycle.rs:41-43` deferred the `state.artifacts: DashMap` hydration. What this PR moves is the `ArtifactStore::open(&index_path)` call — that `std::fs::read` + bincode decode + per-entry insert into the store's own `DashMap` was still happening synchronously inside `bind_with_cache_dir`, gating the readiness lockfile on the size of the cached-artifact index.

## Approach

- New `ArtifactStore::open_empty(path)` constructs a store rooted at `path` without touching disk. New `ArtifactStore::load_from_disk(&self)` reads + decodes + inserts (extracted from the body of the old `open()` so `open()` itself becomes a thin shim — **call sites unchanged**).
- `bind_with_cache_dir` switches to `open_empty`. The on-disk entries are merged into the same live `DashMap` by `artifact_store_loader()` in a `tokio::task::spawn_blocking` post-lockfile.
- New `ArtifactStoreLoader` holds an `Arc<ArtifactStore>` clone so the merge writes hit the same `DashMap` the request handlers read — no swap required.
- New `artifact_store_loaded: AtomicBool` on `SharedState`. Unlike the other three #784 deferrals **there is no shutdown-save gate**: artifact index persistence runs through the periodic WAL/flush path (`index_writer_tx`), not at shutdown — so the flag is informational only (test-observable for the deferred-load assertion).

### Correctness during the load window

Requests for a not-yet-merged key see `None` from `ArtifactStore::get` and take the cold-path miss + recompile. The content-addressed blake3 artifact bytes (DD-005) guarantee that no incorrect "warm hit" can fire.

## Tests

New tests in `daemon::server::tests::artifact_store_deferred`:

- `bind_does_not_load_artifact_index_from_disk` — bind with a populated on-disk blob leaves the live store empty and the loaded flag false.
- `artifact_store_loader_merges_index_into_live_store` — loader populates the store + flips the flag + entries observable via `get`.
- `artifact_store_loader_tolerates_missing_index_file` — no on-disk blob is not an error; flag still flips.
- `artifact_store_open_empty_does_not_touch_disk` — documents the `open_empty` contract.

```
test daemon::server::tests::artifact_store_deferred::bind_does_not_load_artifact_index_from_disk ... ok
test daemon::server::tests::artifact_store_deferred::artifact_store_loader_merges_index_into_live_store ... ok
test daemon::server::tests::artifact_store_deferred::artifact_store_loader_tolerates_missing_index_file ... ok
test daemon::server::tests::artifact_store_deferred::artifact_store_open_empty_does_not_touch_disk ... ok
test result: ok. 4 passed; 0 failed; ...
```

`cargo clippy -p zccache --all-targets -- -D warnings` clean. `cargo fmt --all --check` clean (same pre-existing drift sweep as #803/#805 in `ipc/broker.rs` + `ipc/broker_v2.rs`).

## Test plan

- [x] `cargo test -p zccache --lib daemon::server::tests::artifact_store_deferred::` passes (4/4)
- [x] `cargo clippy -p zccache --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] Full workspace CI green

Closes #794.

## With this merged

The four-phase #784 effort is complete. The spawn→lockfile critical path is now just `IpcListener::bind` + `current_backend_identity` + a couple of `create_dir_all` calls — microseconds, regardless of cache size. Every on-disk snapshot loads in the background; correctness during the load window is preserved by stat-verify safety nets (compiler-hash / metadata / system-includes) or content-addressed blake3 (artifact store).

Independent of #803 and #805 (different file, different field). Any order can land first.
