### PR TITLE
perf(daemon): defer ArtifactStore index load + sync fallback (#784 phase 2d, take 2)

### DIFF
--- a/crates/zccache/src/artifact/store.rs
+++ b/crates/zccache/src/artifact/store.rs
@@ -106,13 +106,59 @@ impl ArtifactStore {
     /// "started empty" was the symptom that hid the cold-tar-untar-warm
     /// 0-hit-rate bug across two perf-cluster runs.
     pub fn open(path: &Path) -> std::io::Result<Self> {
-        let entries = DashMap::new();
+        let store = Self::open_empty(path);
+        store.load_from_disk()?;
+        Ok(store)
+    }
+
+    /// Construct an empty store rooted at `path` without touching disk.
+    ///
+    /// Issue #784 phase 2d: lets `DaemonServer::bind_with_cache_dir`
+    /// build the store in microseconds (no `std::fs::read` of the
+    /// index blob), with the actual entry-loading deferred to a
+    /// background `spawn_blocking` that calls [`Self::load_from_disk`]
+    /// after the readiness lockfile is written. Until the load runs,
+    /// `get` returns `None` for every key — `lookup_artifact_with_disk_fallback`
+    /// (see `daemon::server::util`) triggers a synchronous
+    /// `load_from_disk` on the first cache-miss in that window so the
+    /// disk-fallback contract (perf test
+    /// `perf_artifact_lookup_hits_before_background_load_completes`)
+    /// is preserved.
+    pub fn open_empty(path: &Path) -> Self {
+        Self {
+            path: NormalizedPath::new(path),
+            entries: DashMap::new(),
+        }
+    }
+
+    /// Read the on-disk index blob (if any) and insert every entry
+    /// into the live `DashMap`. Idempotent: re-keys overwrite. Safe
+    /// to call concurrently with request-handler inserts (DashMap
+    /// `insert` is `&self`); safe to call multiple times (a redundant
+    /// second call just re-inserts the same entries with the same
+    /// values).
+    ///
+    /// Issue #784 phase 2d. Called once from `tokio::task::spawn_blocking`
+    /// in the daemon binary after the readiness lockfile is written.
+    /// Also called synchronously by
+    /// `lookup_artifact_with_disk_fallback` on the first cache-miss
+    /// during the load window — the synchronous path makes the
+    /// existing on-disk-fallback test pass without paying the load
+    /// cost at bind time.
+    ///
+    /// # Errors
+    ///
+    /// Returns any `std::fs::read` error other than `NotFound`. A
+    /// missing file and a corrupt blob are both logged and treated
+    /// as "empty" — same shape as the inline path in [`Self::open`].
+    pub fn load_from_disk(&self) -> std::io::Result<()> {
+        let path = self.path.as_path();
         match std::fs::read(path) {
             Ok(bytes) => match bincode::deserialize::<Vec<(String, ArtifactIndex)>>(&bytes) {
                 Ok(rows) => {
                     let count = rows.len();
                     for (k, v) in rows {
-                        entries.insert(k, v);
+                        self.entries.insert(k, v);
                     }
                     if count > 0 {
                         tracing::info!(
@@ -142,10 +188,7 @@ impl ArtifactStore {
             }
             Err(e) => return Err(e),
         };
-        Ok(Self {
-            path: NormalizedPath::new(path),
-            entries,
-        })
+        Ok(())
     }
 
     /// Insert or update an artifact entry. In-memory only.

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -435,6 +435,21 @@ fn run_server(args: Args) {
             system_includes_loader.load_and_install();
         });
 
+        // Issue #784 phase 2d: same shape for the on-disk artifact
+        // index blob. The store was constructed empty in
+        // `bind_with_cache_dir`; the loader holds an
+        // `Arc<ArtifactStore>` clone and inserts the on-disk entries
+        // directly into the live `DashMap` request handlers read.
+        // Coexists with the synchronous on-demand load in
+        // `util::lookup_artifact_with_disk_fallback`: both paths do
+        // identical `DashMap::insert` operations, so racing them
+        // produces converged state. The `artifact_store_loaded` flag
+        // prevents redundant disk reads.
+        let artifact_store_loader = server.artifact_store_loader();
+        tokio::task::spawn_blocking(move || {
+            artifact_store_loader.load_and_install();
+        });
+
         // Wire up Ctrl+C to trigger graceful shutdown
         let shutdown = server.shutdown_handle();
         tokio::spawn(async move {

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -42,15 +42,18 @@ impl DaemonServer {
         // daemon starts accepting connections immediately (Bug 6 fix).
         let artifacts: DashMap<String, CachedArtifact> = DashMap::new();
 
-        // Open the bincode-backed artifact index for fast startup + persistence.
+        // Issue #784 phase 2d: open the artifact-index store EMPTY
+        // here so the readiness lockfile fires before reading +
+        // decoding the bincode blob. The on-disk entries are merged
+        // into the live `DashMap` by `artifact_store_loader()` in a
+        // `tokio::task::spawn_blocking` after the lockfile. The
+        // existing on-disk-fallback contract in
+        // `util::lookup_artifact_with_disk_fallback` is preserved: if
+        // a DashMap-miss request races ahead of the background load,
+        // it calls `load_from_disk` synchronously on the spot so the
+        // fallback still hits.
         let index_path = crate::core::config::index_path_from_cache_dir(cache_dir);
-        let artifact_store = ArtifactStore::open(&index_path).map_err(|e| {
-            crate::ipc::IpcError::Io(std::io::Error::other(format!(
-                "failed to open artifact index at {}: {e}",
-                index_path.display()
-            )))
-        })?;
-        let artifact_store = Arc::new(artifact_store);
+        let artifact_store = Arc::new(ArtifactStore::open_empty(&index_path));
 
         let (index_writer_tx, index_writer_rx) =
             tokio::sync::mpsc::unbounded_channel::<(String, ArtifactIndex)>();
@@ -157,6 +160,7 @@ impl DaemonServer {
                 compiler_hash_cache_loaded: AtomicBool::new(false),
                 metadata_cache_loaded: AtomicBool::new(false),
                 system_includes_loaded: AtomicBool::new(false),
+                artifact_store_loaded: AtomicBool::new(false),
                 shutdown_event_logged: AtomicBool::new(false),
                 fingerprint: FingerprintManager::new(),
                 dep_graph_persisted: AtomicBool::new(false),
@@ -271,6 +275,25 @@ impl DaemonServer {
         SystemIncludesLoader {
             state: Arc::clone(&self.state),
             path: self.state.system_includes_cache_path.clone(),
+        }
+    }
+
+    /// Hand out a loader that reads the on-disk `index.bin` blob and
+    /// merges its entries into the live `ArtifactStore`. Issue #784
+    /// phase 2d — last of the four #784 deferrals.
+    ///
+    /// Designed to be called once, immediately after `write_lock_file`,
+    /// inside a `tokio::task::spawn_blocking`. The handle holds an
+    /// `Arc<ArtifactStore>` clone so the merge writes hit the same
+    /// `DashMap` request handlers read. If a lookup races ahead of
+    /// this background load,
+    /// `util::lookup_artifact_with_disk_fallback` invokes
+    /// [`ArtifactStore::load_from_disk`] synchronously on the spot —
+    /// idempotent because both call sites do equivalent inserts.
+    pub fn artifact_store_loader(&self) -> ArtifactStoreLoader {
+        ArtifactStoreLoader {
+            state: Arc::clone(&self.state),
+            store: Arc::clone(&self.state.artifact_store),
         }
     }
 
@@ -415,6 +438,44 @@ pub struct CompilerHashCacheLoader {
 pub struct SystemIncludesLoader {
     state: Arc<SharedState>,
     path: crate::core::NormalizedPath,
+}
+
+/// Owned handle that reads the on-disk artifact-index blob and merges
+/// its entries into the running daemon's `ArtifactStore`.
+///
+/// Issue #784 phase 2d. Holds an `Arc<ArtifactStore>` directly so the
+/// merge writes hit the same `DashMap` the request handlers read — no
+/// swap needed (the store was constructed empty at bind time).
+///
+/// Coexists safely with the on-demand `load_from_disk` invocation
+/// inside `util::lookup_artifact_with_disk_fallback`: both call sites
+/// perform identical `DashMap::insert` operations, so a race between
+/// them produces the same converged state. The `artifact_store_loaded`
+/// flag merely prevents redundant disk reads — it is not a load-once
+/// gate.
+pub struct ArtifactStoreLoader {
+    state: Arc<SharedState>,
+    store: Arc<ArtifactStore>,
+}
+
+impl ArtifactStoreLoader {
+    /// Read the on-disk index blob (if any) and insert its entries
+    /// into the live store via [`ArtifactStore::load_from_disk`].
+    ///
+    /// I/O errors are logged at WARN and treated as "empty" — the
+    /// daemon stays running with an empty in-memory index, and the
+    /// next periodic flush will rewrite the file from whatever
+    /// request-handler inserts have landed since. After the load,
+    /// `artifact_store_loaded` is set so subsequent on-demand calls
+    /// from `lookup_artifact_with_disk_fallback` short-circuit.
+    pub fn load_and_install(self) {
+        if let Err(e) = self.store.load_from_disk() {
+            tracing::warn!("artifact index load failed, continuing with empty store: {e}");
+        }
+        self.state
+            .artifact_store_loaded
+            .store(true, Ordering::Release);
+    }
 }
 
 impl SystemIncludesLoader {

--- a/crates/zccache/src/daemon/server/state.rs
+++ b/crates/zccache/src/daemon/server/state.rs
@@ -177,6 +177,18 @@ pub(super) struct SharedState {
     /// pending could write a partial snapshot over the on-disk file.
     /// Mirrors `compiler_hash_cache_loaded` above.
     pub(super) system_includes_loaded: AtomicBool,
+    /// Whether the on-disk artifact-index blob has been merged into
+    /// the live `artifact_store`.
+    ///
+    /// Issue #784 phase 2d: `bind_with_cache_dir` constructs the store
+    /// empty; a background `spawn_blocking` calls `load_from_disk`
+    /// after the readiness lockfile. `lookup_artifact_with_disk_fallback`
+    /// (in `util.rs`) also triggers a synchronous `load_from_disk` on
+    /// the first cache-miss in the load window so the existing
+    /// disk-fallback contract holds. Either call site flips this to
+    /// `true` on completion; subsequent misses short-circuit instead
+    /// of re-reading the blob.
+    pub(super) artifact_store_loaded: AtomicBool,
     /// Whether the `died-shutdown` lifecycle event has been written for this
     /// daemon. Under burst load (issue #726), many wedge-detecting clients
     /// race to send `Request::Shutdown` within a few milliseconds and each

--- a/crates/zccache/src/daemon/server/tests/artifact_store_deferred.rs
+++ b/crates/zccache/src/daemon/server/tests/artifact_store_deferred.rs
@@ -1,0 +1,180 @@
+//! Tests for the issue #784 phase 2d deferred-load path on the
+//! `ArtifactStore` index blob. Companion to the on-disk-fallback test
+//! at `tests/daemon_perf_artifact_fallback_test.rs` — these cover the
+//! deferred-load invariants, the perf test covers the in-process
+//! disk-fallback contract.
+
+use super::super::*;
+
+/// `bind_with_cache_dir` no longer reads the on-disk `index.bin` blob.
+/// The store starts empty regardless of what is on disk.
+#[tokio::test]
+async fn bind_does_not_load_artifact_index_from_disk() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let index_path = crate::core::config::index_path_from_cache_dir(&cache_dir);
+
+    // Pre-write an index blob with synthetic entries.
+    let pre = crate::artifact::ArtifactStore::open(index_path.as_path()).unwrap();
+    pre.insert("key-a", &synthetic_index_entry(7));
+    pre.insert("key-b", &synthetic_index_entry(11));
+    pre.flush().unwrap();
+    assert!(index_path.as_path().exists());
+
+    // Bind — must NOT read the blob.
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+    let state = server.test_state();
+    assert!(
+        state.artifact_store.get("key-a").is_none(),
+        "bind must start with an empty artifact store (no key-a)",
+    );
+    assert!(
+        state.artifact_store.get("key-b").is_none(),
+        "bind must start with an empty artifact store (no key-b)",
+    );
+    assert!(
+        !state.artifact_store_loaded.load(Ordering::Acquire),
+        "the loaded flag must start false until the background loader runs",
+    );
+}
+
+/// The background loader reads the blob and merges its entries into
+/// the live store, then flips the loaded flag.
+#[tokio::test]
+async fn artifact_store_loader_merges_index_into_live_store() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let index_path = crate::core::config::index_path_from_cache_dir(&cache_dir);
+
+    let pre = crate::artifact::ArtifactStore::open(index_path.as_path()).unwrap();
+    pre.insert("hot-key", &synthetic_index_entry(0x42));
+    pre.flush().unwrap();
+
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+
+    server.artifact_store_loader().load_and_install();
+
+    let state = server.test_state();
+    let entry = state
+        .artifact_store
+        .get("hot-key")
+        .expect("loader must merge the persisted entry into the live store");
+    assert_eq!(entry.total_size, 0x42);
+    assert!(
+        state.artifact_store_loaded.load(Ordering::Acquire),
+        "loader must set artifact_store_loaded=true",
+    );
+}
+
+/// Missing on-disk blob is not an error: the loader is a no-op and
+/// still flips the loaded flag.
+#[tokio::test]
+async fn artifact_store_loader_tolerates_missing_index_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+
+    server.artifact_store_loader().load_and_install();
+
+    let state = server.test_state();
+    assert!(state.artifact_store.get("any").is_none());
+    assert!(
+        state.artifact_store_loaded.load(Ordering::Acquire),
+        "loaded flag flips even when the blob was absent",
+    );
+}
+
+/// `ArtifactStore::open_empty` produces a usable store rooted at the
+/// given path without touching disk.
+#[test]
+fn artifact_store_open_empty_does_not_touch_disk() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing_path = tmp.path().join("does-not-exist").join("index.bin");
+
+    let store = crate::artifact::ArtifactStore::open_empty(&missing_path);
+
+    assert!(store.get("anything").is_none());
+    assert!(
+        !missing_path.exists(),
+        "open_empty must not create the index file",
+    );
+}
+
+/// **Key correctness property for #794-v2**: if a lookup races ahead
+/// of the background loader, it triggers a synchronous `load_from_disk`
+/// on the spot. Mirrors the property the existing perf test
+/// `perf_artifact_lookup_hits_before_background_load_completes` locks
+/// in, but at the unit-test level so a future refactor of
+/// `lookup_artifact_with_disk_fallback` can't drop it silently.
+#[tokio::test]
+async fn lookup_triggers_synchronous_load_when_background_load_pending() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let index_path = crate::core::config::index_path_from_cache_dir(&cache_dir);
+
+    // Seed a payload + index entry on disk (so the daemon would have
+    // hit if it had loaded; the test asserts it hits even WITHOUT the
+    // background loader running).
+    let artifact_dir = crate::core::config::artifacts_dir_from_cache_dir(&cache_dir);
+    std::fs::create_dir_all(artifact_dir.as_path()).unwrap();
+    let key_hex = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    let payload: &[u8] = b"abcd";
+    let payload_path = artifact_dir.join(format!("{key_hex}_0"));
+    std::fs::write(payload_path.as_path(), payload).unwrap();
+
+    let pre = crate::artifact::ArtifactStore::open(index_path.as_path()).unwrap();
+    pre.insert(
+        key_hex,
+        &crate::artifact::ArtifactIndex::new(
+            vec!["foo.o".to_string()],
+            vec![payload.len() as u64],
+            b"".to_vec(),
+            b"".to_vec(),
+            0,
+        ),
+    );
+    pre.flush().unwrap();
+    drop(pre);
+
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+    let state = server.test_state();
+
+    // Confirm preconditions: empty store, loaded flag false (background
+    // loader has NOT been called).
+    assert!(state.artifact_store.get(key_hex).is_none());
+    assert!(!state.artifact_store_loaded.load(Ordering::Acquire));
+
+    // The test seam. Internally calls
+    // `lookup_artifact_with_disk_fallback`, which should detect the
+    // loaded flag is false and call `load_from_disk` synchronously.
+    let found = server.test_lookup_artifact(key_hex);
+    assert!(
+        found,
+        "lookup must hit even when background loader hasn't run yet \
+         — the helper itself triggers load_from_disk on the spot",
+    );
+
+    // Postcondition: the synchronous load flipped the flag, so a
+    // subsequent miss on a different key won't redundantly hit disk.
+    assert!(
+        state.artifact_store_loaded.load(Ordering::Acquire),
+        "synchronous fallback load must flip the loaded flag",
+    );
+}
+
+fn synthetic_index_entry(total_size: u64) -> crate::artifact::ArtifactIndex {
+    use std::sync::Arc;
+    crate::artifact::ArtifactIndex {
+        output_names: Arc::from(vec!["foo.o".to_string()]),
+        output_sizes: vec![total_size],
+        stdout: Arc::new(Vec::new()),
+        stderr: Arc::new(Vec::new()),
+        exit_code: 0,
+        total_size,
+        stored_at_secs: 0,
+    }
+}

--- a/crates/zccache/src/daemon/server/tests/mod.rs
+++ b/crates/zccache/src/daemon/server/tests/mod.rs
@@ -5,6 +5,7 @@
 
 use std::path::Path;
 
+mod artifact_store_deferred;
 mod cache_trim;
 mod clear_handler;
 mod client_env;

--- a/crates/zccache/src/daemon/server/util.rs
+++ b/crates/zccache/src/daemon/server/util.rs
@@ -131,6 +131,26 @@ pub(super) fn lookup_artifact_with_disk_fallback<'a>(
     if let Some(entry) = state.artifacts.get_mut(key_hex) {
         return Some(entry);
     }
+    // Issue #784 phase 2d: the artifact-index blob is no longer read at
+    // bind time — `bind_with_cache_dir` constructs an empty store and a
+    // background `spawn_blocking` calls `load_from_disk`. If a lookup
+    // races ahead of that load, fall through to the disk read on the
+    // spot so this helper's contract ("DashMap miss → on-disk fallback
+    // hit") still holds. Idempotent: the background loader and this
+    // synchronous path can both insert the same entries; DashMap
+    // inserts are last-writer-wins of equivalent values, so the live
+    // store converges. We swap `artifact_store_loaded` to `true`
+    // afterwards so subsequent misses (including from other request
+    // handlers) skip the disk read.
+    if !state
+        .artifact_store_loaded
+        .load(std::sync::atomic::Ordering::Acquire)
+    {
+        let _ = state.artifact_store.load_from_disk();
+        state
+            .artifact_store_loaded
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
     let meta = state.artifact_store.get(key_hex)?;
     state
         .artifacts


### PR DESCRIPTION
## Summary

Phase 2d of #784, take 2 (replaces the closed #809).

The first attempt (#809) deferred `ArtifactStore::open` by splitting it into `open_empty` + `load_from_disk` and using a `spawn_blocking` post-lockfile loader. **That broke the existing on-disk-fallback contract** — the test `perf_artifact_lookup_hits_before_background_load_completes` specifically locks in that a DashMap-cold lookup must still hit through the `artifact_store` secondary tier, which #809 made also-empty during the load window.

This take preserves the contract by making `lookup_artifact_with_disk_fallback` itself trigger a synchronous `load_from_disk` if it sees `artifact_store_loaded == false` on a miss.

## Approach

- New `ArtifactStore::open_empty(path)` constructs a store without touching disk. New `ArtifactStore::load_from_disk(&self)` reads + decodes + inserts (extracted from `open()`'s body — `open()` is now a thin shim, every existing caller still works).
- `bind_with_cache_dir` switches to `open_empty`. Blocking-load gone from the spawn → lockfile critical path.
- `util::lookup_artifact_with_disk_fallback` — between the DashMap-miss and the `artifact_store.get()`, check `artifact_store_loaded`. If false, call `load_from_disk` synchronously and set the flag.
- New `ArtifactStoreLoader` handle holds an `Arc<ArtifactStore>` and flips the flag after loading. Wired into the daemon binary's `spawn_blocking` sequence next to the #786 / #803 / #805 loaders.

## Net effect

- Spawn → lockfile path stays microseconds-fast.
- Background loader typically wins the race and merges entries before any lookup arrives.
- If a request arrives first, the fallback path pays the disk load once on that lookup. Subsequent requests skip the disk read.
- Coexistence: both loaders call `load_from_disk` via DashMap inserts. Last-writer-wins of equivalent values converges to the same state. The `artifact_store_loaded` flag is a redundancy optimization, **not** a load-once gate.

## Tests

New tests in `daemon::server::tests::artifact_store_deferred`:

- `bind_does_not_load_artifact_index_from_disk`
- `artifact_store_loader_merges_index_into_live_store`
- `artifact_store_loader_tolerates_missing_index_file`
- `artifact_store_open_empty_does_not_touch_disk`
- **`lookup_triggers_synchronous_load_when_background_load_pending`** — pins the disk-fallback property at unit-test level so a future refactor of `lookup_artifact_with_disk_fallback` can't drop it silently. Complement to the existing perf-level test.

Pre-existing tests verified passing locally:
- `perf_artifact_lookup_hits_before_background_load_completes` (the test #809 broke; passes here)
- `cache_restore_with_normalized_mtimes_still_hits`
- `exec_cache_survives_daemon_restart`

```
test daemon::server::tests::artifact_store_deferred::bind_does_not_load_artifact_index_from_disk ... ok
test daemon::server::tests::artifact_store_deferred::artifact_store_loader_merges_index_into_live_store ... ok
test daemon::server::tests::artifact_store_deferred::artifact_store_loader_tolerates_missing_index_file ... ok
test daemon::server::tests::artifact_store_deferred::artifact_store_open_empty_does_not_touch_disk ... ok
test daemon::server::tests::artifact_store_deferred::lookup_triggers_synchronous_load_when_background_load_pending ... ok
test result: ok. 5 passed; 0 failed; ...

test perf_artifact_lookup_hits_before_background_load_completes ... ok
test cache_restore_with_normalized_mtimes_still_hits ... ok
test exec_cache_survives_daemon_restart ... ok
```

`cargo clippy -p zccache --all-targets -- -D warnings` clean. `cargo fmt --all --check` clean.

## Test plan

- [x] All 5 new unit tests pass
- [x] The pre-existing tests that #809 broke now pass
- [x] `cargo clippy -p zccache --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] Full workspace CI green

Closes #794. With this merged, **all four #784 phases ship** — the spawn → lockfile critical path is now just `IpcListener::bind` + `current_backend_identity` + `create_dir_all`.
