### PR TITLE
perf(stats): expose lookup outcome counters

### DIFF
--- a/crates/zccache/proto/zccache_v1.proto
+++ b/crates/zccache/proto/zccache_v1.proto
@@ -281,6 +281,14 @@ message SessionStats {
   uint64 bytes_read = 10;
   uint64 bytes_written = 11;
   optional PhaseProfileSummary phase_profile = 12;
+  optional LookupOutcomes lookup_outcomes = 13;
+}
+
+message LookupOutcomes {
+  uint64 depgraph_hit_artifact_hit = 1;
+  uint64 depgraph_hit_artifact_miss = 2;
+  uint64 depgraph_cold_skip = 3;
+  map<string, uint64> depgraph_other_miss = 4;
 }
 
 message PhaseProfileSummary {

--- a/crates/zccache/src/cli/commands/session.rs
+++ b/crates/zccache/src/cli/commands/session.rs
@@ -428,6 +428,7 @@ pub(crate) fn session_stats_json(
         "bytes_read": stats.bytes_read,
         "bytes_written": stats.bytes_written,
         "hit_rate": hit_rate,
+        "lookup_outcomes": &stats.lookup_outcomes,
         "phase_profile": phase_profile,
     })
 }

--- a/crates/zccache/src/cli/commands/tests/analyze.rs
+++ b/crates/zccache/src/cli/commands/tests/analyze.rs
@@ -239,6 +239,7 @@ fn analyze_journal_rejects_session_stats_json() {
         unique_sources: 8,
         bytes_read: 1024,
         bytes_written: 2048,
+        lookup_outcomes: crate::protocol::LookupOutcomes::default(),
         phase_profile: None,
     };
     let stats_json = session_stats_json("session-123", &stats);

--- a/crates/zccache/src/cli/commands/tests/args_parsing.rs
+++ b/crates/zccache/src/cli/commands/tests/args_parsing.rs
@@ -134,6 +134,12 @@ fn rust_plan_session_stats_json_separates_compile_cache_stats() {
         unique_sources: 8,
         bytes_read: 1024,
         bytes_written: 2048,
+        lookup_outcomes: crate::protocol::LookupOutcomes {
+            depgraph_hit_artifact_hit: 7,
+            depgraph_hit_artifact_miss: 2,
+            depgraph_cold_skip: 3,
+            depgraph_other_miss: [("headers_changed".to_string(), 1)].into_iter().collect(),
+        },
         phase_profile: None,
     };
     let json = session_stats_json("session-123", &stats);
@@ -143,6 +149,13 @@ fn rust_plan_session_stats_json_separates_compile_cache_stats() {
     assert_eq!(json["hits"], 7);
     assert_eq!(json["misses"], 3);
     assert_eq!(json["hit_rate"].as_f64().unwrap(), 0.7);
+    assert_eq!(json["lookup_outcomes"]["depgraph_hit_artifact_hit"], 7);
+    assert_eq!(json["lookup_outcomes"]["depgraph_hit_artifact_miss"], 2);
+    assert_eq!(json["lookup_outcomes"]["depgraph_cold_skip"], 3);
+    assert_eq!(
+        json["lookup_outcomes"]["depgraph_other_miss"]["headers_changed"],
+        1
+    );
 }
 
 #[test]

--- a/crates/zccache/src/daemon/compile_journal/tests/outcome.rs
+++ b/crates/zccache/src/daemon/compile_journal/tests/outcome.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use crate::protocol::Response;
+use crate::protocol::{LookupOutcomes, Response};
 
 use super::super::{extract_outcome, miss_reason};
 
@@ -184,6 +184,7 @@ fn test_extract_outcome_all_non_journalable() {
                 unique_sources: 0,
                 bytes_read: 0,
                 bytes_written: 0,
+                lookup_outcomes: LookupOutcomes::default(),
                 phase_profile: None,
             }),
         },

--- a/crates/zccache/src/daemon/server/connection.rs
+++ b/crates/zccache/src/daemon/server/connection.rs
@@ -357,6 +357,7 @@ pub(super) async fn handle_connection(
                                     unique_sources: f.unique_sources,
                                     bytes_read: f.bytes_read,
                                     bytes_written: f.bytes_written,
+                                    lookup_outcomes: f.lookup_outcomes.into(),
                                     // Daemon-wide phase totals — see
                                     // PhaseProfileSummary doc for the
                                     // single-vs-multi-session caveat.
@@ -405,6 +406,7 @@ pub(super) async fn handle_connection(
                                     unique_sources: f.unique_sources,
                                     bytes_read: f.bytes_read,
                                     bytes_written: f.bytes_written,
+                                    lookup_outcomes: f.lookup_outcomes.into(),
                                     phase_profile: Some(state.profiler.totals_snapshot().into()),
                                 }
                             });

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -410,8 +410,51 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         ),
     );
     match verdict {
-        crate::depgraph::CacheVerdict::Hit { artifact_key }
-        | crate::depgraph::CacheVerdict::SourceChanged { artifact_key } => {
+        crate::depgraph::CacheVerdict::Hit { artifact_key } => {
+            let artifact_key_hex = artifact_key.hash().to_hex();
+            if let Some(response) = try_depgraph_cached_hit(DepgraphHitProbe {
+                state,
+                sid: &sid,
+                context_key,
+                artifact_key_hex: &artifact_key_hex,
+                source_path: &source_path,
+                output_path: &output_path,
+                cwd_path: &cwd_path,
+                ctx: &ctx,
+                compiler_path,
+                effective_args: &effective_args,
+                cwd,
+                request_cache_key_root: &request_cache_key_root,
+                client_env: client_env.as_deref(),
+                // Issue #643: see `FastHitProbe` site above for rationale.
+                dep_flags: if is_rustc { None } else { Some(&dep_flags) },
+                is_rustc,
+                worktree_equivalent_context,
+                worktree_bound,
+                compile_start,
+                parse_args_ns,
+                build_context_ns,
+                hash_source_ns,
+                hash_headers_ns,
+                depgraph_check_ns,
+            }) {
+                record_session_stat(&state.sessions, &sid, |t| {
+                    t.record_depgraph_hit_artifact_hit();
+                });
+                return response;
+            }
+            // Artifact key computed but no artifact stored yet, or payload delivery
+            // failed. Fall through to compile.
+            record_session_stat(&state.sessions, &sid, |t| {
+                t.record_depgraph_hit_artifact_miss();
+            });
+            write_session_log(
+                &state.sessions,
+                &sid,
+                &format!("[DIAG] artifact_not_found: key={artifact_key_hex}"),
+            );
+        }
+        crate::depgraph::CacheVerdict::SourceChanged { artifact_key } => {
             let artifact_key_hex = artifact_key.hash().to_hex();
             if let Some(response) = try_depgraph_cached_hit(DepgraphHitProbe {
                 state,
@@ -441,17 +484,30 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             }) {
                 return response;
             }
-            // Artifact key computed but no artifact stored yet, or payload delivery
-            // failed. Fall through to compile.
+            record_session_stat(&state.sessions, &sid, |t| {
+                t.record_depgraph_other_miss(&diag_reason);
+            });
             write_session_log(
                 &state.sessions,
                 &sid,
                 &format!("[DIAG] artifact_not_found: key={artifact_key_hex}"),
             );
         }
-        crate::depgraph::CacheVerdict::Cold
-        | crate::depgraph::CacheVerdict::HeadersChanged { .. }
+        crate::depgraph::CacheVerdict::Cold => {
+            record_session_stat(&state.sessions, &sid, |t| {
+                if diag_reason == "cold_skip" {
+                    t.record_depgraph_cold_skip();
+                } else {
+                    t.record_depgraph_other_miss(&diag_reason);
+                }
+            });
+            // Need to compile and scan includes
+        }
+        crate::depgraph::CacheVerdict::HeadersChanged { .. }
         | crate::depgraph::CacheVerdict::NeedsPreprocessor => {
+            record_session_stat(&state.sessions, &sid, |t| {
+                t.record_depgraph_other_miss(&diag_reason);
+            });
             // Need to compile and scan includes
         }
     }

--- a/crates/zccache/src/depgraph/mod.rs
+++ b/crates/zccache/src/depgraph/mod.rs
@@ -31,7 +31,8 @@ pub use rustc_args::{parse_rustc_args, ExternCrate, RustcParsedArgs};
 pub use scanner::{IncludeDirective, IncludeKind, ScanResult};
 pub use search_paths::IncludeSearchPaths;
 pub use session::{
-    FinalizedSessionStats, Session, SessionConfig, SessionId, SessionManager, SessionStatsTracker,
+    FinalizedSessionStats, LookupOutcomes, Session, SessionConfig, SessionId, SessionManager,
+    SessionStatsTracker,
 };
 pub use snapshot::{
     classify_load, depgraph_file_path, load_from_file, save_to_file, DepGraphLoadOutcome,

--- a/crates/zccache/src/depgraph/session.rs
+++ b/crates/zccache/src/depgraph/session.rs
@@ -7,13 +7,70 @@
 //! The graph itself survives across sessions â€” sessions are ephemeral
 //! metadata about who is using the graph.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::time::{Duration, Instant};
 
 use crate::core::NormalizedPath;
 use dashmap::DashMap;
 
 use super::context::ContextKey;
+
+/// Per-session depgraph/artifact lookup outcome counters.
+///
+/// These counters intentionally separate the #787 failure shapes that the
+/// top-level hit/miss counters collapse together: real depgraph-backed hits,
+/// depgraph hits whose artifact payload is missing, blanket `cold_skip`
+/// misses, and all other diagnostic miss reasons.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LookupOutcomes {
+    pub depgraph_hit_artifact_hit: u64,
+    pub depgraph_hit_artifact_miss: u64,
+    pub depgraph_cold_skip: u64,
+    pub depgraph_other_miss: BTreeMap<String, u64>,
+}
+
+impl LookupOutcomes {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            depgraph_hit_artifact_hit: 0,
+            depgraph_hit_artifact_miss: 0,
+            depgraph_cold_skip: 0,
+            depgraph_other_miss: BTreeMap::new(),
+        }
+    }
+
+    fn record_other_miss(&mut self, reason: &str) {
+        let key = normalize_lookup_miss_reason(reason);
+        *self.depgraph_other_miss.entry(key).or_insert(0) += 1;
+    }
+}
+
+impl Default for LookupOutcomes {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn normalize_lookup_miss_reason(reason: &str) -> String {
+    let mut out = String::with_capacity(reason.len());
+    let mut last_was_sep = false;
+    for ch in reason.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            last_was_sep = false;
+        } else if !last_was_sep {
+            out.push('_');
+            last_was_sep = true;
+        }
+    }
+    let normalized = out.trim_matches('_').to_string();
+    if normalized.is_empty() {
+        "unknown".to_string()
+    } else {
+        normalized
+    }
+}
 
 /// Per-session statistics tracker. Only allocated when the session opts in.
 #[derive(Debug, Clone)]
@@ -38,6 +95,8 @@ pub struct SessionStatsTracker {
     pub bytes_read: u64,
     /// Artifact bytes stored into cache.
     pub bytes_written: u64,
+    /// Depgraph/artifact lookup outcome breakdown.
+    pub lookup_outcomes: LookupOutcomes,
 }
 
 /// Finalized session statistics (plain data, no sets).
@@ -54,6 +113,7 @@ pub struct FinalizedSessionStats {
     pub unique_sources: u64,
     pub bytes_read: u64,
     pub bytes_written: u64,
+    pub lookup_outcomes: LookupOutcomes,
 }
 
 impl SessionStatsTracker {
@@ -71,6 +131,7 @@ impl SessionStatsTracker {
             sources: HashSet::new(),
             bytes_read: 0,
             bytes_written: 0,
+            lookup_outcomes: LookupOutcomes::new(),
         }
     }
 
@@ -108,6 +169,26 @@ impl SessionStatsTracker {
         self.errors_cached += 1;
     }
 
+    /// Record a depgraph hit that successfully materialized an artifact.
+    pub fn record_depgraph_hit_artifact_hit(&mut self) {
+        self.lookup_outcomes.depgraph_hit_artifact_hit += 1;
+    }
+
+    /// Record a depgraph hit whose artifact payload was absent.
+    pub fn record_depgraph_hit_artifact_miss(&mut self) {
+        self.lookup_outcomes.depgraph_hit_artifact_miss += 1;
+    }
+
+    /// Record a depgraph cold-skip classifier miss.
+    pub fn record_depgraph_cold_skip(&mut self) {
+        self.lookup_outcomes.depgraph_cold_skip += 1;
+    }
+
+    /// Record any other depgraph miss reason.
+    pub fn record_depgraph_other_miss(&mut self, reason: &str) {
+        self.lookup_outcomes.record_other_miss(reason);
+    }
+
     /// Finalize into a plain stats struct given the session's creation time.
     #[must_use]
     pub fn finalize(&self, created_at: Instant) -> FinalizedSessionStats {
@@ -123,6 +204,7 @@ impl SessionStatsTracker {
             unique_sources: self.sources.len() as u64,
             bytes_read: self.bytes_read,
             bytes_written: self.bytes_written,
+            lookup_outcomes: self.lookup_outcomes.clone(),
         }
     }
 }
@@ -594,6 +676,7 @@ mod tests {
         assert_eq!(t.errors_cached, 0);
         assert_eq!(t.bytes_read, 0);
         assert_eq!(t.bytes_written, 0);
+        assert_eq!(t.lookup_outcomes, LookupOutcomes::new());
         assert!(t.sources.is_empty());
     }
 
@@ -651,6 +734,44 @@ mod tests {
         assert_eq!(f.unique_sources, 2);
         assert_eq!(f.bytes_read, 1024);
         assert_eq!(f.bytes_written, 2048);
+    }
+
+    #[test]
+    fn tracker_records_lookup_outcomes_reproducer_mix() {
+        let mut t = SessionStatsTracker::new();
+
+        t.record_depgraph_hit_artifact_hit();
+        t.record_depgraph_hit_artifact_miss();
+        t.record_depgraph_hit_artifact_miss();
+        t.record_depgraph_cold_skip();
+        t.record_depgraph_cold_skip();
+        t.record_depgraph_cold_skip();
+        t.record_depgraph_other_miss("headers changed");
+        t.record_depgraph_other_miss("headers changed");
+        t.record_depgraph_other_miss("source content changed");
+        t.record_depgraph_other_miss("hit: artifact_key=abc (first check after update)");
+
+        let f = t.finalize(Instant::now());
+
+        assert_eq!(f.lookup_outcomes.depgraph_hit_artifact_hit, 1);
+        assert_eq!(f.lookup_outcomes.depgraph_hit_artifact_miss, 2);
+        assert_eq!(f.lookup_outcomes.depgraph_cold_skip, 3);
+        assert_eq!(
+            f.lookup_outcomes.depgraph_other_miss.get("headers_changed"),
+            Some(&2)
+        );
+        assert_eq!(
+            f.lookup_outcomes
+                .depgraph_other_miss
+                .get("source_content_changed"),
+            Some(&1)
+        );
+        assert_eq!(
+            f.lookup_outcomes
+                .depgraph_other_miss
+                .get("hit_artifact_key_abc_first_check_after_update"),
+            Some(&1)
+        );
     }
 
     #[test]

--- a/crates/zccache/src/protocol/messages/compat/mod.rs
+++ b/crates/zccache/src/protocol/messages/compat/mod.rs
@@ -50,6 +50,7 @@ pub(super) fn sample_session_stats() -> SessionStats {
         unique_sources: 9,
         bytes_read: 10,
         bytes_written: 11,
+        lookup_outcomes: LookupOutcomes::default(),
         phase_profile: None,
     }
 }

--- a/crates/zccache/src/protocol/messages/compat/session_lifecycle.rs
+++ b/crates/zccache/src/protocol/messages/compat/session_lifecycle.rs
@@ -102,6 +102,7 @@ fn session_ended_with_stats_roundtrip() {
         unique_sources: 30,
         bytes_read: 2_000_000,
         bytes_written: 500_000,
+        lookup_outcomes: LookupOutcomes::default(),
         phase_profile: None,
     };
     let resp = Response::SessionEnded { stats: Some(stats) };
@@ -132,6 +133,7 @@ fn session_stats_result_roundtrip() {
         unique_sources: 9,
         bytes_read: 50_000,
         bytes_written: 20_000,
+        lookup_outcomes: LookupOutcomes::default(),
         phase_profile: None,
     };
     roundtrip(&Response::SessionStatsResult { stats: Some(stats) });

--- a/crates/zccache/src/protocol/messages/compat/session_stats.rs
+++ b/crates/zccache/src/protocol/messages/compat/session_stats.rs
@@ -17,6 +17,7 @@ fn session_stats_roundtrip() {
         unique_sources: 42,
         bytes_read: 1024 * 1024,
         bytes_written: 512 * 1024,
+        lookup_outcomes: LookupOutcomes::default(),
         phase_profile: None,
     };
     roundtrip(&stats);
@@ -36,6 +37,7 @@ fn session_stats_default_zeros() {
         unique_sources: 0,
         bytes_read: 0,
         bytes_written: 0,
+        lookup_outcomes: LookupOutcomes::default(),
         phase_profile: None,
     };
     roundtrip(&stats);
@@ -58,6 +60,17 @@ fn session_stats_with_phase_profile_roundtrip() {
         unique_sources: 115,
         bytes_read: 143_812_577,
         bytes_written: 62_500_000,
+        lookup_outcomes: LookupOutcomes {
+            depgraph_hit_artifact_hit: 103,
+            depgraph_hit_artifact_miss: 2,
+            depgraph_cold_skip: 7,
+            depgraph_other_miss: [
+                ("headers_changed".to_string(), 3),
+                ("source_content_changed".to_string(), 1),
+            ]
+            .into_iter()
+            .collect(),
+        },
         phase_profile: Some(PhaseProfileSummary {
             hit_count: 103,
             miss_count: 12,
@@ -87,6 +100,9 @@ fn session_stats_with_phase_profile_roundtrip() {
     let json = serde_json::to_string(&stats).expect("serialize");
     let decoded: SessionStats = serde_json::from_str(&json).expect("deserialize");
     assert_eq!(stats, decoded);
+    assert_eq!(decoded.lookup_outcomes.depgraph_hit_artifact_hit, 103);
+    assert_eq!(decoded.lookup_outcomes.depgraph_hit_artifact_miss, 2);
+    assert_eq!(decoded.lookup_outcomes.depgraph_cold_skip, 7);
 
     // An old-daemon-style JSON that omits phase_profile must decode to
     // None (back-compat with PROTOCOL_VERSION 8 consumers that haven't
@@ -98,5 +114,6 @@ fn session_stats_with_phase_profile_roundtrip() {
     }"#;
     let decoded: SessionStats = serde_json::from_str(legacy).expect("legacy decode");
     assert!(decoded.phase_profile.is_none());
+    assert_eq!(decoded.lookup_outcomes, LookupOutcomes::default());
     assert_eq!(decoded.errors_cached, 0);
 }

--- a/crates/zccache/src/protocol/messages/mod.rs
+++ b/crates/zccache/src/protocol/messages/mod.rs
@@ -21,7 +21,8 @@ pub use artifact::{
 };
 pub use exec::{ExecCachePolicy, ExecOutputStreams};
 pub use status::{
-    DaemonStatus, PhaseProfileSummary, PrivateDaemonOwnerStatus, PrivateDaemonStatus, SessionStats,
+    DaemonStatus, LookupOutcomes, PhaseProfileSummary, PrivateDaemonOwnerStatus,
+    PrivateDaemonStatus, SessionStats,
 };
 
 /// Private daemon options carried by `SessionStart`.

--- a/crates/zccache/src/protocol/messages/status.rs
+++ b/crates/zccache/src/protocol/messages/status.rs
@@ -2,6 +2,7 @@
 
 use crate::core::NormalizedPath;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// One owner PID currently keeping a private daemon alive.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -125,6 +126,9 @@ pub struct SessionStats {
     pub bytes_read: u64,
     /// Total artifact bytes stored into cache.
     pub bytes_written: u64,
+    /// Depgraph/artifact lookup outcome breakdown.
+    #[serde(default)]
+    pub lookup_outcomes: LookupOutcomes,
     /// Daemon-wide phase-timing aggregate. `None` from older daemons that
     /// don't populate the field; `Some` from PROTOCOL_VERSION >= 9 daemons.
     ///
@@ -135,6 +139,27 @@ pub struct SessionStats {
     /// totals cross-contaminate — that's acceptable for v1 and revisited if
     /// a real consumer needs per-session isolation.
     pub phase_profile: Option<PhaseProfileSummary>,
+}
+
+/// Per-session depgraph/artifact lookup outcome counters.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct LookupOutcomes {
+    pub depgraph_hit_artifact_hit: u64,
+    pub depgraph_hit_artifact_miss: u64,
+    pub depgraph_cold_skip: u64,
+    #[serde(default)]
+    pub depgraph_other_miss: BTreeMap<String, u64>,
+}
+
+impl From<crate::depgraph::LookupOutcomes> for LookupOutcomes {
+    fn from(outcomes: crate::depgraph::LookupOutcomes) -> Self {
+        Self {
+            depgraph_hit_artifact_hit: outcomes.depgraph_hit_artifact_hit,
+            depgraph_hit_artifact_miss: outcomes.depgraph_hit_artifact_miss,
+            depgraph_cold_skip: outcomes.depgraph_cold_skip,
+            depgraph_other_miss: outcomes.depgraph_other_miss,
+        }
+    }
 }
 
 /// Aggregate phase-timing totals from the daemon's PhaseProfiler.

--- a/crates/zccache/src/protocol/wire_prost/convert.rs
+++ b/crates/zccache/src/protocol/wire_prost/convert.rs
@@ -297,6 +297,7 @@ pub(super) fn session_stats_to_prost(
         bytes_read: stats.bytes_read,
         bytes_written: stats.bytes_written,
         phase_profile: stats.phase_profile.as_ref().map(phase_profile_to_prost),
+        lookup_outcomes: Some(lookup_outcomes_to_prost(&stats.lookup_outcomes)),
     }
 }
 
@@ -316,6 +317,32 @@ pub(super) fn session_stats_from_prost(
         bytes_read: stats.bytes_read,
         bytes_written: stats.bytes_written,
         phase_profile: stats.phase_profile.map(phase_profile_from_prost),
+        lookup_outcomes: stats
+            .lookup_outcomes
+            .map(lookup_outcomes_from_prost)
+            .unwrap_or_default(),
+    }
+}
+
+fn lookup_outcomes_to_prost(
+    outcomes: &crate::protocol::LookupOutcomes,
+) -> zccache_v1::LookupOutcomes {
+    zccache_v1::LookupOutcomes {
+        depgraph_hit_artifact_hit: outcomes.depgraph_hit_artifact_hit,
+        depgraph_hit_artifact_miss: outcomes.depgraph_hit_artifact_miss,
+        depgraph_cold_skip: outcomes.depgraph_cold_skip,
+        depgraph_other_miss: outcomes.depgraph_other_miss.clone().into_iter().collect(),
+    }
+}
+
+fn lookup_outcomes_from_prost(
+    outcomes: zccache_v1::LookupOutcomes,
+) -> crate::protocol::LookupOutcomes {
+    crate::protocol::LookupOutcomes {
+        depgraph_hit_artifact_hit: outcomes.depgraph_hit_artifact_hit,
+        depgraph_hit_artifact_miss: outcomes.depgraph_hit_artifact_miss,
+        depgraph_cold_skip: outcomes.depgraph_cold_skip,
+        depgraph_other_miss: outcomes.depgraph_other_miss.into_iter().collect(),
     }
 }
 

--- a/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
+++ b/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
@@ -193,8 +193,8 @@ mod full_family {
     };
     use zccache::protocol::{
         ArtifactData, ArtifactOutput, ArtifactPayload, ExecCachePolicy, ExecOutputStreams,
-        LookupResult, PhaseProfileSummary, PrivateDaemonSessionOptions, Request, Response,
-        RustArtifactInfo, SessionStats, StoreResult,
+        LookupOutcomes, LookupResult, PhaseProfileSummary, PrivateDaemonSessionOptions, Request,
+        Response, RustArtifactInfo, SessionStats, StoreResult,
     };
 
     fn roundtrip_request(request: Request) {
@@ -241,6 +241,12 @@ mod full_family {
             unique_sources: 9,
             bytes_read: 10,
             bytes_written: 11,
+            lookup_outcomes: LookupOutcomes {
+                depgraph_hit_artifact_hit: 12,
+                depgraph_hit_artifact_miss: 13,
+                depgraph_cold_skip: 14,
+                depgraph_other_miss: [("headers_changed".to_string(), 15)].into_iter().collect(),
+            },
             phase_profile: Some(PhaseProfileSummary {
                 hit_count: 1,
                 miss_count: 2,


### PR DESCRIPTION
## Summary

- Add `lookup_outcomes` to session stats JSON/protocol payloads.
- Track depgraph-backed artifact hits, depgraph-hit artifact misses, cold_skip misses, and other depgraph miss reasons.
- Add a synthetic #787-style unit test plus JSON/prost round-trip coverage.

Closes #797

## Tests

- `soldr --no-cache cargo test -p zccache tracker_records_lookup_outcomes_reproducer_mix --lib`
- `soldr --no-cache cargo test -p zccache session_stats --lib`
- `soldr --no-cache cargo test -p zccache --test daemon_wire_prost_roundtrip`
- `soldr --no-cache cargo check -p zccache`

Note: bare `soldr cargo ...` hit the known daemon startup failure (`no daemon lockfile observed within 10s`), so validation used `--no-cache`.