### PR TITLE
fix: wait for startup depgraph before first compile

### DIFF
--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -251,12 +251,9 @@ fn run_server(args: Args) {
         // With #642's `ArcSwap<DepGraph>` foundation, `set_dep_graph` is
         // now `&self` + atomic-swap-safe, so the load can fire from a
         // `spawn_blocking` AFTER `server.run()` has started the accept
-        // loop. Compile requests arriving during the load window see
-        // the empty default graph and take the cold-path miss
-        // (correct — the cache_system's stat-verify safety net catches
-        // any stale-hit risk; sub-optimal speed for ~3 s and then the
-        // post-load `set_dep_graph` atomically publishes the warm graph
-        // for every subsequent `state.dep_graph.load()`).
+        // loop. Compile requests arriving during the load window wait
+        // until the persisted graph has been classified and published,
+        // avoiding the fresh-daemon `cold_skip` race fixed in zccache#798.
         //
         // The pre-bind probe (#641) and bind-error race discrimination
         // (#639) both still fire in their original order — only the
@@ -339,6 +336,7 @@ fn run_server(args: Args) {
         // Spawn the depgraph load. Holds a `DepGraphSetter` that survives
         // the spawn_blocking boundary; on completion atomically installs
         // the graph + warning via #642's ArcSwap.
+        server.mark_dep_graph_load_pending();
         let setter = server.dep_graph_setter();
         let depgraph_path = zccache::depgraph::depgraph_file_path();
         let load_handle = tokio::task::spawn_blocking(move || {

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -30,6 +30,8 @@ use hash_verify::{hash_and_verify, HashSourceOutcome, HashVerifyInput, HashVerif
 use store_outcome::{store_successful_compile, StoreOutcomeRequest};
 use system_includes::{discover_system_includes, SystemIncludesOutcome};
 
+const DEPGRAPH_STARTUP_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 /// Handle a Compile request: parse args, check depgraph, run compiler or return cached.
 pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response {
     let CompileRequest {
@@ -173,6 +175,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             original_args,
             source_indices,
         } => {
+            wait_for_startup_depgraph_load(state, &sid).await;
             return handle_compile_multi(
                 Arc::clone(state_arc),
                 sid,
@@ -204,6 +207,8 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     };
 
     // ── Phase: build context + register ──────────────────────────────
+    wait_for_startup_depgraph_load(state, &sid).await;
+
     let t1 = std::time::Instant::now();
     let env_slice = client_env.as_deref().unwrap_or(&[]);
     let build_result = build_compile_context(
@@ -645,5 +650,41 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         stdout,
         stderr,
         cached: false,
+    }
+}
+
+async fn wait_for_startup_depgraph_load(state: &SharedState, sid: &SessionId) {
+    if state.dep_graph_load_complete.load(Ordering::Acquire) {
+        return;
+    }
+
+    write_session_log(
+        &state.sessions,
+        sid,
+        "[DIAG] depgraph_load_pending: waiting before compile context registration",
+    );
+
+    let deadline = tokio::time::sleep(DEPGRAPH_STARTUP_WAIT_TIMEOUT);
+    tokio::pin!(deadline);
+    loop {
+        let notified = state.dep_graph_load_notify.notified();
+        if state.dep_graph_load_complete.load(Ordering::Acquire) {
+            return;
+        }
+        tokio::select! {
+            () = notified => {
+                if state.dep_graph_load_complete.load(Ordering::Acquire) {
+                    return;
+                }
+            }
+            () = &mut deadline => {
+                write_session_log(
+                    &state.sessions,
+                    sid,
+                    "[WARN] depgraph_load_pending: timed out; continuing with current graph",
+                );
+                return;
+            }
+        }
     }
 }

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -181,6 +181,8 @@ impl DaemonServer {
                 shutdown_event_logged: AtomicBool::new(false),
                 fingerprint: FingerprintManager::new(),
                 dep_graph_persisted: AtomicBool::new(false),
+                dep_graph_load_complete: AtomicBool::new(true),
+                dep_graph_load_notify: Arc::new(Notify::new()),
                 depgraph_load_warning: Mutex::new(None),
                 in_flight_exec: DashMap::new(),
                 pending_cache_writes: DashMap::new(),
@@ -215,6 +217,22 @@ impl DaemonServer {
         self.state
             .dep_graph_persisted
             .store(true, Ordering::Release);
+        self.state
+            .dep_graph_load_complete
+            .store(true, Ordering::Release);
+        self.state.dep_graph_load_notify.notify_waiters();
+    }
+
+    /// Mark startup depgraph classification as pending.
+    ///
+    /// The daemon binary calls this before it offloads `depgraph.bin` loading
+    /// to `spawn_blocking`. Compile handlers use the paired notify to avoid
+    /// making the first warm compile race against the empty default graph.
+    #[doc(hidden)]
+    pub fn mark_dep_graph_load_pending(&self) {
+        self.state
+            .dep_graph_load_complete
+            .store(false, Ordering::Release);
     }
 
     /// Record a load-time depgraph warning to mirror into per-session logs.
@@ -428,6 +446,10 @@ impl DepGraphSetter {
             let mut guard = self.state.depgraph_load_warning.blocking_lock();
             *guard = Some(warning);
         }
+        self.state
+            .dep_graph_load_complete
+            .store(true, Ordering::Release);
+        self.state.dep_graph_load_notify.notify_waiters();
     }
 }
 

--- a/crates/zccache/src/daemon/server/pending_writes.rs
+++ b/crates/zccache/src/daemon/server/pending_writes.rs
@@ -140,6 +140,25 @@ pub(super) async fn await_pending(
     true
 }
 
+/// Wait until all currently pending cache writes have completed, bounded by
+/// `timeout`. Used during graceful shutdown before draining the artifact-index
+/// WAL so deferred persist tasks can publish their `(key, ArtifactIndex)` rows.
+pub(super) async fn await_all(pending: &DashMap<String, Arc<Notify>>, timeout: Duration) -> bool {
+    let deadline = tokio::time::sleep(timeout);
+    tokio::pin!(deadline);
+    loop {
+        if pending.is_empty() {
+            return true;
+        }
+        tokio::select! {
+            () = tokio::time::sleep(Duration::from_millis(10)) => {}
+            () = &mut deadline => {
+                return pending.is_empty();
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/zccache/src/daemon/server/run.rs
+++ b/crates/zccache/src/daemon/server/run.rs
@@ -326,6 +326,23 @@ impl DaemonServer {
                     // input channels close.
                     *self.state.watcher.lock().await = None;
 
+                    // Deferred rustc/C++ persist tasks publish their durable
+                    // `ArtifactIndex` rows only after the cache files land on
+                    // disk. Wait for those tasks before draining the WAL;
+                    // otherwise shutdown can save a warm depgraph whose
+                    // artifact keys have not reached index.bin yet (#799).
+                    let pending_drained = pending_writes::await_all(
+                        &self.state.pending_cache_writes,
+                        std::time::Duration::from_secs(30),
+                    )
+                    .await;
+                    if !pending_drained {
+                        tracing::warn!(
+                            pending = self.state.pending_cache_writes.len(),
+                            "timed out waiting for pending artifact writes before WAL drain"
+                        );
+                    }
+
                     // Signal the index-writer to drain its WAL to disk, then
                     // wait briefly for it. Without this, unflushed entries are
                     // lost if the runtime aborts before the next interval tick.

--- a/crates/zccache/src/daemon/server/state.rs
+++ b/crates/zccache/src/daemon/server/state.rs
@@ -206,6 +206,16 @@ pub(super) struct SharedState {
     /// CLI can distinguish "persisted graph" from "first-run, not yet flushed"
     /// without inferring it from the on-disk file size.
     pub(super) dep_graph_persisted: AtomicBool,
+    /// Whether startup has finished classifying the persisted depgraph.
+    ///
+    /// `zccache-daemon` marks this false before it moves the disk load onto a
+    /// background thread. Compile requests must not register/check contexts
+    /// against the empty default graph while this is false, otherwise the
+    /// first warm lookup races into the `cold_skip` path even though a valid
+    /// persisted graph is about to be installed. Issue #798.
+    pub(super) dep_graph_load_complete: AtomicBool,
+    /// Wakes compile requests waiting for startup depgraph classification.
+    pub(super) dep_graph_load_notify: Arc<Notify>,
     /// Optional load-time warning to mirror into every session log.
     ///
     /// Populated by `set_depgraph_load_warning` when the daemon's startup load

--- a/crates/zccache/tests/daemon_rustc_restore_test.rs
+++ b/crates/zccache/tests/daemon_rustc_restore_test.rs
@@ -72,6 +72,39 @@ async fn start_daemon_like_zccache_daemon() -> (String, JoinHandle<()>) {
     (endpoint, handle)
 }
 
+async fn start_daemon_with_delayed_background_depgraph_load(
+    delay: std::time::Duration,
+) -> (String, JoinHandle<()>, JoinHandle<()>) {
+    let endpoint = zccache::ipc::unique_test_endpoint();
+    let depgraph_path = depgraph_file_path();
+    let mut server = DaemonServer::bind(&endpoint).expect("bind daemon");
+    server.mark_dep_graph_load_pending();
+    let setter = server.dep_graph_setter();
+
+    let load_handle = tokio::spawn(async move {
+        tokio::time::sleep(delay).await;
+        let depgraph_load = classify_load(&depgraph_path);
+        let depgraph_warning = depgraph_load.warning(&depgraph_path);
+        match depgraph_load {
+            DepGraphLoadOutcome::Loaded { graph } => {
+                setter.install(Some(graph), depgraph_warning);
+            }
+            DepGraphLoadOutcome::Missing
+            | DepGraphLoadOutcome::VersionMismatch { .. }
+            | DepGraphLoadOutcome::Corrupt { .. }
+            | DepGraphLoadOutcome::IoError { .. } => {
+                setter.install(None, depgraph_warning);
+            }
+        }
+    });
+
+    let handle = tokio::spawn(async move {
+        server.run(0).await.expect("daemon run");
+    });
+
+    (endpoint, handle, load_handle)
+}
+
 async fn connect(endpoint: &str) -> ClientConn {
     zccache::ipc::connect(endpoint)
         .await
@@ -79,11 +112,19 @@ async fn connect(endpoint: &str) -> ClientConn {
 }
 
 async fn start_session(client: &mut ClientConn, working_dir: &Path) -> String {
+    start_session_with_log(client, working_dir, None).await
+}
+
+async fn start_session_with_log(
+    client: &mut ClientConn,
+    working_dir: &Path,
+    log_file: Option<NormalizedPath>,
+) -> String {
     client
         .send(&Request::SessionStart {
             client_pid: std::process::id(),
             working_dir: NormalizedPath::from(working_dir),
-            log_file: None,
+            log_file,
             track_stats: false,
             journal_path: None,
             profile: false,
@@ -333,6 +374,104 @@ async fn rustc_multi_output_hit_survives_cache_restore_without_target_dir() {
             "second compile should be restored from the cache after target/ deletion",
         );
         assert_outputs_exist(&outputs, "cached restore");
+        end_session(&mut client2, session2).await;
+        shutdown_daemon(client2, handle2).await;
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn first_compile_waits_for_background_depgraph_load_before_cold_skip() {
+    let rustc = match zccache::test_support::find_rustc() {
+        Some(path) => path,
+        None => {
+            eprintln!("skipping test: rustc not found");
+            return;
+        }
+    };
+
+    zccache::test_support::test_timeout(async move {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cache_dir = tmp.path().join("zccache-cache");
+        let project_dir = tmp.path().join("workspace");
+        std::fs::create_dir_all(&cache_dir).expect("create cache dir");
+        create_tiny_project(&project_dir);
+        let _cache_env = CacheEnvGuard::new(&cache_dir);
+
+        let args = rustc_multi_output_args();
+        let outputs = expected_outputs(&project_dir);
+
+        let (endpoint1, handle1) = start_daemon_like_zccache_daemon().await;
+        let mut client1 = connect(&endpoint1).await;
+        let session1 = start_session(&mut client1, &project_dir).await;
+        let first = compile_rustc(
+            &mut client1,
+            &session1,
+            rustc.as_path(),
+            &args,
+            &project_dir,
+        )
+        .await;
+        assert_eq!(
+            first.exit_code,
+            0,
+            "first rustc compile failed: {}",
+            String::from_utf8_lossy(&first.stderr),
+        );
+        assert!(!first.cached, "first compile should populate the cache");
+        assert_outputs_exist(&outputs, "first compile");
+        end_session(&mut client1, session1).await;
+        shutdown_daemon(client1, handle1).await;
+
+        let depgraph_path = depgraph_file_path();
+        assert!(
+            depgraph_path.is_file(),
+            "graceful shutdown should flush depgraph to {}",
+            depgraph_path.display(),
+        );
+
+        let (endpoint2, handle2, load_handle) =
+            start_daemon_with_delayed_background_depgraph_load(std::time::Duration::from_secs(3))
+                .await;
+        let mut client2 = connect(&endpoint2).await;
+        let log_path = tmp.path().join("delayed-load-session.log");
+        let session2 =
+            start_session_with_log(
+                &mut client2,
+                &project_dir,
+                Some(NormalizedPath::from(log_path.as_path())),
+            )
+            .await;
+        let second = compile_rustc(
+            &mut client2,
+            &session2,
+            rustc.as_path(),
+            &args,
+            &project_dir,
+        )
+        .await;
+        assert_eq!(
+            second.exit_code,
+            0,
+            "second rustc compile failed: {}\nsession log:\n{}",
+            String::from_utf8_lossy(&second.stderr),
+            std::fs::read_to_string(&log_path).unwrap_or_default(),
+        );
+        let session_log = std::fs::read_to_string(&log_path).unwrap_or_default();
+        assert!(
+            session_log.contains("depgraph_load_pending: waiting"),
+            "first compile should observe the pending startup depgraph load; session log:\n{session_log}",
+        );
+        assert!(
+            !session_log.contains("reason=cold_skip"),
+            "first compile after daemon readiness must wait for the persisted depgraph instead of racing into cold_skip; session log:\n{session_log}",
+        );
+        assert!(
+            session_log.contains("verdict=Hit") || session_log.contains("verdict=SourceChanged"),
+            "first compile should consult the loaded depgraph after the wait; session log:\n{session_log}",
+        );
+        assert_outputs_exist(&outputs, "cached restore");
+        load_handle.await.expect("depgraph load task join");
         end_session(&mut client2, session2).await;
         shutdown_daemon(client2, handle2).await;
     })

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -169,6 +169,13 @@ On startup, the daemon attempts to load the snapshot:
 
 The `dep_graph_persisted` flag is also flipped to `true` when a periodic or shutdown save completes successfully, so a daemon that started cold but has since flushed reports itself as persisted. `zccache status` surfaces this as either `vN, persisted, X.YZ MB on disk` or `vN, not persisted`.
 
+The daemon writes its readiness lock file before the potentially expensive disk
+load completes, but compile requests do not register or classify contexts until
+startup depgraph classification has finished. This keeps daemon startup
+observable quickly while preventing the first warm compile from racing against
+the empty default graph and reporting `cold_skip` when a valid persisted graph
+is about to be installed (issue #798).
+
 ### Crash Dumper (shared with CLI)
 
 Both `zccache-cli` and `zccache-daemon` call `zccache_core::crash::install(<bin-stem>)` at the top of `main`. That call wires up:


### PR DESCRIPTION
## Summary

- wait for startup depgraph classification before compile context registration so fresh-daemon warm lookups do not race the empty default graph into `cold_skip`
- add a regression test that delays background depgraph load and asserts the first warm compile waits and avoids `reason=cold_skip`
- drain pending artifact writes before WAL shutdown drain so the warm depgraph is not saved before artifact index rows land
- document the daemon-readiness/depgraph-load behavior

Fixes #798.
Related #799: this prevents the shutdown-ordering source of stale depgraph/artifact-index mismatch that the #798 repro exposed, but #799's runtime invalidation/counter acceptance remains separate.

## Validation

- `soldr cargo fmt --all --check`
- `git diff --check`
- `soldr cargo test -p zccache --test daemon_rustc_restore_test first_compile_waits_for_background_depgraph_load_before_cold_skip -- --nocapture`
- `soldr cargo test -p zccache --test daemon_rustc_restore_test -- --nocapture --test-threads=1`
- `soldr cargo test -p zccache depgraph --lib`
- `soldr cargo test -p zccache pending_writes --lib`
- Docker/Linux: `rust:latest` + soldr v0.7.56 release tarball + `soldr cargo test -p zccache --test daemon_rustc_restore_test -- --nocapture --test-threads=1` exited 0. A follow-up capture-only rerun was stopped because compiling through the Windows bind mount was too slow; the first run's container used `--rm`, so only the exit code was retained.