### PR TITLE
perf(classifier): gate first compile on depgraph load

### DIFF
--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -634,3 +634,63 @@ impl MetadataCacheLoader {
             .store(true, Ordering::Release);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_ctx(source: &str) -> crate::depgraph::CompileContext {
+        crate::depgraph::CompileContext {
+            source_file: source.into(),
+            include_search: crate::depgraph::IncludeSearchPaths::default(),
+            defines: Vec::new(),
+            flags: Vec::new(),
+            force_includes: Vec::new(),
+            unknown_flags: Vec::new(),
+        }
+    }
+
+    fn dummy_hash(path: &std::path::Path) -> Option<crate::hash::ContentHash> {
+        Some(crate::hash::hash_bytes(path.to_string_lossy().as_bytes()))
+    }
+
+    #[tokio::test]
+    async fn depgraph_load_gate_waits_until_loaded_graph_is_visible() {
+        let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
+        let state = Arc::clone(&server.state);
+        let setter = server.dep_graph_setter();
+
+        let graph = crate::depgraph::DepGraph::new();
+        let ctx = make_ctx("/src/warm.cc");
+        let key = graph.register(ctx);
+        graph.update(
+            &key,
+            crate::depgraph::ScanResult {
+                resolved: Vec::new(),
+                unresolved: Vec::new(),
+                has_computed: false,
+            },
+            dummy_hash,
+        );
+
+        server.mark_dep_graph_load_pending();
+        let handle = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(25));
+            setter.install(Some(graph), None);
+        });
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            state.dep_graph_load_notify.notified(),
+        )
+        .await
+        .expect("depgraph load notify should fire");
+        handle.join().unwrap();
+
+        assert!(
+            !state.dep_graph.load().is_cold(&key),
+            "first compile must see the loaded warm graph instead of the empty default"
+        );
+        assert!(state.dep_graph_persisted.load(Ordering::Acquire));
+    }
+}

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -167,6 +167,8 @@ On startup, the daemon attempts to load the snapshot:
 - **Success:** the in-memory graph is populated from the file and `DaemonStatus.dep_graph_persisted` reports `true`. CI runs that restore `<cache_dir>` from a cache store skip the cold-seed compile entirely.
 - **Missing file / `VersionMismatch` / corrupt bytes:** a warning is logged and the daemon starts with an empty graph (the pre-fix behavior).
 
+The snapshot load runs in a background blocking task after the IPC endpoint and readiness lockfile are available, so daemon startup stays fast. Compile handlers gate their first depgraph registration/check on that background task completing; otherwise a warm daemon can race the empty default graph and classify the first lookup as `cold_skip` before the persisted graph is installed.
+
 The `dep_graph_persisted` flag is also flipped to `true` when a periodic or shutdown save completes successfully, so a daemon that started cold but has since flushed reports itself as persisted. `zccache status` surfaces this as either `vN, persisted, X.YZ MB on disk` or `vN, not persisted`.
 
 The daemon writes its readiness lock file before the potentially expensive disk


### PR DESCRIPTION
## Summary

- Keep daemon readiness fast, but mark startup depgraph load as pending while the background loader classifies the persisted snapshot.
- Gate single-file and multi-file compile depgraph registration/checks until that load completes, avoiding first-lookup `cold_skip` against the empty default graph.
- Add a regression test proving the gate waits until a loaded warm graph is visible, plus runtime docs for the contract.

Closes #798

## Tests

- `soldr --no-cache cargo test -p zccache depgraph_load_gate_waits_until_loaded_graph_is_visible --lib`
- `soldr --no-cache cargo check -p zccache`