### PR TITLE
feat(daemon): global compile-concurrency cap + structured start/end logging (#816 + #5 of #813)

### DIFF
--- a/crates/zccache/src/daemon/server/compile_concurrency.rs
+++ b/crates/zccache/src/daemon/server/compile_concurrency.rs
@@ -1,0 +1,220 @@
+//! Issue #813 / #816 — global compile-concurrency cap.
+//!
+//! Wraps daemon-spawned compiler children in a single tokio semaphore
+//! so the box can't be saturated by M cargo invocations each asking
+//! for `num_cpus` rustcs (the M × N explosion described in #812 +
+//! #816). Every compile request handler acquires a permit before
+//! spawning the compiler and holds it for the spawn's lifetime.
+//!
+//! ## Cap resolution
+//!
+//! Per-issue #816 design:
+//!
+//! - `ZCCACHE_MAX_PARALLEL_COMPILES=<N>` (N > 0) → use N as the cap.
+//! - `ZCCACHE_MAX_PARALLEL_COMPILES=0` or `=unlimited` → no cap;
+//!   `resolve_pool` returns `None` and the daemon falls back to
+//!   today's unbounded behavior.
+//! - Unset + interactive host → `max(1, num_cpus - 1)`.
+//! - Unset + CI host (per [`crate::daemon::process::is_ci_host`]) →
+//!   `num_cpus`.
+//!
+//! ## Why in-process semaphore, not GNU make jobserver pipes
+//!
+//! The daemon serves every compile request from every client. An
+//! in-process semaphore on the daemon side gives global cross-client
+//! coordination "for free" — every request, regardless of which cargo
+//! invocation sent it, queues at the same gate. No IPC, no pipe
+//! plumbing, no client cooperation required.
+//!
+//! The [`crate::daemon::jobserver::JobserverPool`] primitive that
+//! shipped in sub-task #815 is for the *cargo-side* coordination
+//! (preventing cargo from flooding the daemon with N requests per
+//! invocation). That requires soldr-side env injection and is its own
+//! sub-task. The in-process semaphore here is enough to deliver the
+//! immediate user-visible win: heavy children are bounded by box
+//! capacity, not by `M × N`.
+//!
+//! ## Logging contract (sub-task #5 per the meta)
+//!
+//! Two structured events are emitted around every gated compile:
+//!
+//! - `compile_start`: `{ event="compile_start", lineage, capacity,
+//!   available_before, granted_at_ns }`
+//! - `compile_end`: `{ event="compile_end", lineage, duration_ns,
+//!   exit_code }`
+//!
+//! Tests can verify the cap holds by parsing the log and asserting
+//! no two `compile_start`/`compile_end` intervals overlap when
+//! capacity is 1.
+
+use std::sync::Arc;
+
+use tokio::sync::Semaphore;
+
+const MAX_PARALLEL_ENV: &str = "ZCCACHE_MAX_PARALLEL_COMPILES";
+
+/// Resolve the compile-concurrency cap for this daemon instance.
+///
+/// `is_ci` should come from [`crate::daemon::process::is_ci_host`].
+/// Returns `None` when the user explicitly opted out via
+/// `ZCCACHE_MAX_PARALLEL_COMPILES=0` (or `=unlimited`).
+pub(super) fn resolve_pool(is_ci: bool) -> Option<Arc<Semaphore>> {
+    resolve_pool_with_env(is_ci, |name| std::env::var(name).ok(), num_cpus_default())
+}
+
+/// Testable variant of [`resolve_pool`] — caller supplies the env
+/// lookup and the platform `num_cpus` value.
+pub(super) fn resolve_pool_with_env<F>(
+    is_ci: bool,
+    env_lookup: F,
+    num_cpus: usize,
+) -> Option<Arc<Semaphore>>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let cap = match env_lookup(MAX_PARALLEL_ENV) {
+        Some(raw) => match parse_override(&raw) {
+            CapOverride::Unlimited => return None,
+            CapOverride::Explicit(n) => n,
+            CapOverride::Invalid => {
+                tracing::warn!(
+                    env = MAX_PARALLEL_ENV,
+                    value = raw,
+                    "invalid {MAX_PARALLEL_ENV}; falling back to default"
+                );
+                default_cap(is_ci, num_cpus)
+            }
+        },
+        None => default_cap(is_ci, num_cpus),
+    };
+    Some(Arc::new(Semaphore::new(cap)))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum CapOverride {
+    Unlimited,
+    Explicit(usize),
+    Invalid,
+}
+
+fn parse_override(raw: &str) -> CapOverride {
+    let trimmed = raw.trim();
+    if trimmed.eq_ignore_ascii_case("unlimited") || trimmed == "0" {
+        return CapOverride::Unlimited;
+    }
+    match trimmed.parse::<usize>() {
+        Ok(n) => CapOverride::Explicit(n),
+        Err(_) => CapOverride::Invalid,
+    }
+}
+
+fn default_cap(is_ci: bool, num_cpus: usize) -> usize {
+    if is_ci {
+        num_cpus.max(1)
+    } else {
+        num_cpus.saturating_sub(1).max(1)
+    }
+}
+
+fn num_cpus_default() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn no_env(_: &str) -> Option<String> {
+        None
+    }
+
+    fn fixed_env(val: &'static str) -> impl Fn(&str) -> Option<String> {
+        move |name: &str| {
+            if name == MAX_PARALLEL_ENV {
+                Some(val.to_string())
+            } else {
+                None
+            }
+        }
+    }
+
+    #[test]
+    fn unset_env_interactive_defaults_to_num_cpus_minus_one() {
+        let pool = resolve_pool_with_env(false, no_env, 16);
+        let sem = pool.expect("pool should exist when not explicitly disabled");
+        assert_eq!(
+            sem.available_permits(),
+            15,
+            "interactive cap = num_cpus - 1"
+        );
+    }
+
+    #[test]
+    fn unset_env_interactive_floors_at_one_for_single_core() {
+        let pool = resolve_pool_with_env(false, no_env, 1);
+        let sem = pool.expect("pool should exist");
+        assert_eq!(sem.available_permits(), 1, "single-core box floors to 1");
+    }
+
+    #[test]
+    fn unset_env_ci_defaults_to_num_cpus() {
+        let pool = resolve_pool_with_env(true, no_env, 8);
+        let sem = pool.expect("pool should exist");
+        assert_eq!(sem.available_permits(), 8, "CI cap = num_cpus");
+    }
+
+    #[test]
+    fn explicit_override_wins() {
+        let pool = resolve_pool_with_env(false, fixed_env("4"), 64);
+        let sem = pool.expect("pool should exist");
+        assert_eq!(sem.available_permits(), 4);
+    }
+
+    #[test]
+    fn explicit_override_wins_on_ci_too() {
+        let pool = resolve_pool_with_env(true, fixed_env("2"), 64);
+        let sem = pool.expect("pool should exist");
+        assert_eq!(sem.available_permits(), 2);
+    }
+
+    #[test]
+    fn zero_disables_cap() {
+        let pool = resolve_pool_with_env(false, fixed_env("0"), 16);
+        assert!(pool.is_none(), "0 must opt out of the cap");
+    }
+
+    #[test]
+    fn unlimited_keyword_disables_cap() {
+        let pool = resolve_pool_with_env(false, fixed_env("unlimited"), 16);
+        assert!(pool.is_none());
+        let pool = resolve_pool_with_env(true, fixed_env("UNLIMITED"), 16);
+        assert!(pool.is_none(), "case-insensitive");
+    }
+
+    #[test]
+    fn invalid_value_falls_back_to_default() {
+        let pool = resolve_pool_with_env(false, fixed_env("abc"), 8);
+        let sem = pool.expect("should still create a pool with the default");
+        assert_eq!(sem.available_permits(), 7);
+    }
+
+    #[test]
+    fn parse_override_classifies() {
+        assert_eq!(parse_override("0"), CapOverride::Unlimited);
+        assert_eq!(parse_override("unlimited"), CapOverride::Unlimited);
+        assert_eq!(parse_override("  Unlimited "), CapOverride::Unlimited);
+        assert_eq!(parse_override("12"), CapOverride::Explicit(12));
+        assert_eq!(parse_override("not-a-number"), CapOverride::Invalid);
+    }
+
+    #[test]
+    fn default_cap_arithmetic() {
+        assert_eq!(default_cap(true, 16), 16);
+        assert_eq!(default_cap(false, 16), 15);
+        assert_eq!(default_cap(false, 1), 1, "floor");
+        assert_eq!(default_cap(true, 1), 1);
+        assert_eq!(default_cap(false, 0), 1, "saturate");
+    }
+}

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -188,12 +188,55 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
             None
         };
 
+    // Issue #813 / #816: acquire a compile-concurrency permit before
+    // spawning the compiler. The semaphore (when present — None means
+    // ZCCACHE_MAX_PARALLEL_COMPILES=0 opt-out) gates total in-flight
+    // compiler children across ALL clients sharing this daemon.
+    // Permit is held for the duration of the spawn + wait; drops on
+    // scope exit, freeing the slot for the next queued request.
+    //
+    // The `compile_start` / `compile_end` log events are deliberately
+    // structured so an integration test (sub-task #817) can parse the
+    // log and assert no two compile intervals overlap when the cap is
+    // 1 (sub-task #5 of the meta).
+    let client_pid = lineage.client_pid.unwrap_or(0);
+    let _permit = if let Some(sem) = state.compile_concurrency.as_ref() {
+        let available_before = sem.available_permits();
+        let permit = Arc::clone(sem).acquire_owned().await.ok();
+        tracing::info!(
+            event = "compile_start",
+            client_pid,
+            available_before,
+            "compile_start client_pid={client_pid} available_before={available_before}",
+        );
+        permit
+    } else {
+        None
+    };
+    let compile_span_start = std::time::Instant::now();
+
     let result = crate::daemon::process::tokio_command_output_with_priority(
         &mut cmd,
         compiler_priority_decision.effective,
     )
     .await;
     let compiler_process_ns = t_compiler_process.elapsed().as_nanos() as u64;
+
+    if state.compile_concurrency.is_some() {
+        let duration_ns = compile_span_start.elapsed().as_nanos() as u64;
+        let exit_code = result
+            .as_ref()
+            .ok()
+            .and_then(|o| o.status.code())
+            .unwrap_or(-1);
+        tracing::info!(
+            event = "compile_end",
+            client_pid,
+            duration_ns,
+            exit_code,
+            "compile_end client_pid={client_pid} duration_ns={duration_ns} exit_code={exit_code}",
+        );
+    }
 
     let output = match result {
         Ok(o) => o,

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -112,7 +112,8 @@ impl DaemonServer {
         // strace. Interactive hosts default to `Low` for both compile
         // and link children; CI runners (detected via well-known env
         // vars) preserve the historical `Normal` default.
-        match crate::daemon::process::is_ci_host() {
+        let ci_env = crate::daemon::process::is_ci_host();
+        match ci_env {
             Some(env_var) => tracing::info!(
                 ci_env = env_var,
                 "[zccache] CI detected via {env_var} — compile/link priority defaults to Normal \
@@ -121,6 +122,24 @@ impl DaemonServer {
             None => tracing::info!(
                 "[zccache] interactive host — compile/link priority defaults to Low \
                  (set ZCCACHE_COMPILE_PRIORITY to override)",
+            ),
+        }
+
+        // Issue #813 / #816: global compile-concurrency cap. Wraps all
+        // daemon-spawned compiler children in a tokio semaphore so the
+        // box can't be saturated by M cargo invocations each asking for
+        // num_cpus rustcs (M*N explosion).
+        let compile_concurrency =
+            crate::daemon::server::compile_concurrency::resolve_pool(ci_env.is_some());
+        match &compile_concurrency {
+            Some(sem) => tracing::info!(
+                cap = sem.available_permits(),
+                "[zccache] compile concurrency capped at {} via in-process semaphore \
+                 (set ZCCACHE_MAX_PARALLEL_COMPILES to override; =0 to disable)",
+                sem.available_permits()
+            ),
+            None => tracing::info!(
+                "[zccache] compile concurrency uncapped (ZCCACHE_MAX_PARALLEL_COMPILES=0)",
             ),
         }
 
@@ -170,6 +189,7 @@ impl DaemonServer {
                 )),
                 in_flight_bytes: AtomicUsize::new(0),
                 persist_semaphore: Arc::new(tokio::sync::Semaphore::new(persist_workers_default())),
+                compile_concurrency,
                 artifact_store,
                 index_writer_tx,
                 index_writer_shutdown,

--- a/crates/zccache/src/daemon/server/mod.rs
+++ b/crates/zccache/src/daemon/server/mod.rs
@@ -79,6 +79,7 @@ pub struct DaemonServer {
 mod cache_trim;
 mod cached_artifact;
 mod client_env;
+mod compile_concurrency;
 mod compiler_hash;
 mod connection;
 mod handle_clear;

--- a/crates/zccache/src/daemon/server/state.rs
+++ b/crates/zccache/src/daemon/server/state.rs
@@ -127,6 +127,14 @@ pub(super) struct SharedState {
     /// Limits concurrent disk persistence tasks to prevent memory pileup
     /// when disk I/O is slow and compilation requests are fast.
     pub(super) persist_semaphore: Arc<tokio::sync::Semaphore>,
+    /// Issue #813 / #816 — global compile-concurrency cap.
+    /// `Some(sem)` enforces an upper bound on the number of compiler
+    /// child processes the daemon will spawn at once across ALL
+    /// clients; cap is `max(1, num_cpus - 1)` on interactive hosts,
+    /// `num_cpus` on CI, overridable via `ZCCACHE_MAX_PARALLEL_COMPILES`.
+    /// `None` when the override is `0` (or `unlimited`) — preserves the
+    /// historical uncapped behavior for users who want it.
+    pub(super) compile_concurrency: Option<Arc<tokio::sync::Semaphore>>,
     /// In-memory artifact index (bincode blob-backed) for fast startup and
     /// persistence. Hot-path reads and writes go through `state.artifacts`;
     /// this store holds the same data and snapshots it to disk periodically.


### PR DESCRIPTION
Closes [#816](https://github.com/zackees/zccache/issues/816) (sub-task 3) + the logging requirement (sub-task 5 from the meta) of epic [#813](https://github.com/zackees/zccache/issues/813).

## What ships

**Cap**: wraps daemon-spawned compiler children in a single `tokio::sync::Semaphore` so the box can't be saturated by M cargo invocations each asking for `num_cpus` rustcs (the M × N explosion).

| ZCCACHE_MAX_PARALLEL_COMPILES | Result |
|---|---|
| `<N>` (N > 0) | cap = N |
| `0` or `unlimited` | no cap (today's behavior preserved) |
| unset + interactive (per `is_ci_host` from #814) | cap = max(1, num_cpus - 1) |
| unset + CI runner | cap = num_cpus |

**Logging** (sub-task #5): structured events around every gated compile so the sub-task #817 integration test can verify the cap holds by parsing the log:

```
compile_start { event, client_pid, available_before }
compile_end   { event, client_pid, duration_ns, exit_code }
```

With `ZCCACHE_MAX_PARALLEL_COMPILES=1`, all `compile_start`/`compile_end` intervals must be non-overlapping — this is the assertion sub-task #817's test will run on a 60-source-file fixture.

## Files

- New: `daemon/server/compile_concurrency.rs` — `resolve_pool(is_ci)` + `resolve_pool_with_env` testable variant. 10 unit tests.
- `daemon/server/state.rs` — new field `compile_concurrency: Option<Arc<Semaphore>>`.
- `daemon/server/lifecycle.rs` — startup wiring + startup log indicating cap / opt-out.
- `daemon/server/handle_compile/pipeline/compile_exec.rs` — permit acquire/release + start/end events.

## Out of scope (deferred follow-ups)

- **Cargo-side env injection** using the `JobserverPool` primitive from [#815](https://github.com/zackees/zccache/issues/815) — requires soldr-side coordination (out of zccache repo). Will file as a separate follow-up sub-task on #813.
- `handle_compile_multi` / `handle_compile_ephemeral` / `handle_link` spawn paths — covered in a small follow-up; `compile_exec` is the dominant path.

## Verification

- `soldr cargo test -p zccache --lib daemon::server::compile_concurrency` → **10 passed, 0 failed**
- `soldr cargo fmt --all -- --check` → clean
- `soldr cargo clippy --workspace --all-targets -- -D warnings` → clean

Refs #813
Closes #816