### PR TITLE
perf(depgraph): invalidate missing artifact hits

### DIFF
--- a/crates/zccache/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -453,6 +453,9 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             record_session_stat(&state.sessions, &sid, |t| {
                 t.record_depgraph_hit_artifact_miss();
             });
+            let evicted: std::collections::HashSet<String> =
+                std::iter::once(artifact_key_hex.clone()).collect();
+            state.dep_graph.load().invalidate_artifact_keys(&evicted);
             write_session_log(
                 &state.sessions,
                 &sid,

--- a/crates/zccache/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache/src/daemon/server/handle_compile_multi.rs
@@ -235,6 +235,7 @@ pub(super) fn check_unit_cache(
     let t_depgraph = t0.elapsed();
 
     // Try to serve from cache
+    let depgraph_claimed_hit = matches!(verdict, crate::depgraph::CacheVerdict::Hit { .. });
     if let crate::depgraph::CacheVerdict::Hit { artifact_key }
     | crate::depgraph::CacheVerdict::SourceChanged { artifact_key } = verdict
     {
@@ -304,6 +305,11 @@ pub(super) fn check_unit_cache(
                     pending_writes: Vec::new(),
                 };
             }
+        }
+        if depgraph_claimed_hit {
+            let evicted: std::collections::HashSet<String> =
+                std::iter::once(artifact_key_hex).collect();
+            state.dep_graph.load().invalidate_artifact_keys(&evicted);
         }
     }
 

--- a/crates/zccache/src/depgraph/graph/check.rs
+++ b/crates/zccache/src/depgraph/graph/check.rs
@@ -186,12 +186,13 @@ impl DepGraph {
                 return CacheVerdict::HeadersChanged { changed: drifted };
             }
 
-            // No drift detected (e.g., first check after a warm context
-            // with no stored artifact_key, or last_file_hashes empty):
-            // record the new key and hit.
-            entry.artifact_key = Some(artifact_key);
-            self.hits.fetch_add(1, Ordering::Relaxed);
-            CacheVerdict::Hit { artifact_key }
+            // No drift detected, but the stored artifact key did not match.
+            // If the key was cleared because the artifact store could not
+            // serve the payload (#799), do not recreate a depgraph-only hit.
+            // The miss path must recompile and publish a real artifact before
+            // this context can hit again.
+            self.misses.fetch_add(1, Ordering::Relaxed);
+            CacheVerdict::Cold
         } else {
             // Fast path: only source changed, headers all fresh.
             entry.artifact_key = Some(artifact_key);
@@ -405,18 +406,16 @@ impl DepGraph {
                 );
             }
 
-            // No drift detected (e.g., warm context with no previously
-            // stored artifact_key, or `last_file_hashes` empty). Adopt
-            // the new artifact_key and return Hit so a subsequent check
-            // takes the ultra-fast path.
-            entry.artifact_key = Some(artifact_key);
-            self.hits.fetch_add(1, Ordering::Relaxed);
-            let hex = &artifact_key.hash().to_hex()[..8];
-            entry.last_file_hashes = file_hashes;
+            // No drift detected, but the stored artifact key did not match.
+            // If the key was cleared because the artifact store could not
+            // serve the payload (#799), do not recreate a depgraph-only hit.
+            // The miss path must recompile and publish a real artifact before
+            // this context can hit again.
+            self.misses.fetch_add(1, Ordering::Relaxed);
             (
-                CacheVerdict::Hit { artifact_key },
+                CacheVerdict::Cold,
                 format!(
-                    "hit: artifact_key={hex} (first check after update, was={old_hex}, files={file_count})",
+                    "artifact key missing or stale (was={old_hex}, files={file_count}); recompile forced",
                 ),
             )
         } else {

--- a/crates/zccache/src/depgraph/graph/tests.rs
+++ b/crates/zccache/src/depgraph/graph/tests.rs
@@ -159,6 +159,45 @@ fn invalidate_artifact_keys_clears_only_matching() {
 }
 
 #[test]
+fn invalidated_artifact_key_does_not_recreate_hit() {
+    let graph = DepGraph::new();
+    let key = graph.register(make_ctx("/src/stale.c"));
+    let scan = ScanResult {
+        resolved: vec![NormalizedPath::from("/inc/stale.h")],
+        unresolved: Vec::new(),
+        has_computed: false,
+    };
+    let artifact = graph
+        .update(&key, scan.clone(), dummy_hash)
+        .expect("artifact key");
+
+    let first = graph.check(&key, always_fresh, dummy_hash);
+    assert!(
+        matches!(first, CacheVerdict::Hit { .. }),
+        "fixture must start warm"
+    );
+
+    let evicted = [artifact.hash().to_hex().to_string()].into_iter().collect();
+    assert_eq!(graph.invalidate_artifact_keys(&evicted), 1);
+
+    let after_invalidate = graph.check(&key, always_fresh, dummy_hash);
+    assert!(
+        !matches!(after_invalidate, CacheVerdict::Hit { .. }),
+        "issue #799: invalidated depgraph entries must not recreate a hit \
+         without a newly-published artifact"
+    );
+
+    graph
+        .update(&key, scan, dummy_hash)
+        .expect("restored artifact");
+    let after_update = graph.check(&key, always_fresh, dummy_hash);
+    assert!(
+        matches!(after_update, CacheVerdict::Hit { .. }),
+        "a real update should restore normal hit behavior"
+    );
+}
+
+#[test]
 fn rustc_extern_artifact_key_ignores_target_dir_path_shape() {
     let graph = DepGraph::new();
     let ctx = make_ctx("/src/app.rs");
@@ -754,14 +793,12 @@ fn warm_context_with_no_artifact_returns_cold_on_check() {
     );
 
     // check_diagnostic should still produce a valid verdict (not panic).
-    // With all fresh, it should compute an artifact key and return Hit.
-    let (verdict, _reason) = graph.check_diagnostic(&key, always_fresh, dummy_hash);
+    // Missing artifact metadata must not be promoted back into a hit; the
+    // caller needs a real compile to repopulate the artifact store.
+    let (verdict, reason) = graph.check_diagnostic(&key, always_fresh, dummy_hash);
     assert!(
-        matches!(
-            verdict,
-            CacheVerdict::Hit { .. } | CacheVerdict::SourceChanged { .. }
-        ),
-        "warm context with all hashes available should hit, got {verdict:?}"
+        matches!(verdict, CacheVerdict::Cold),
+        "warm context without artifact metadata should be cold, got {verdict:?}: {reason}"
     );
 }
 


### PR DESCRIPTION
## Summary
- treat warm depgraph entries with missing or stale artifact metadata as cold instead of recreating depgraph-only hits
- invalidate depgraph artifact keys when artifact lookup fails after a depgraph hit in both single and multi-file compile paths
- add a regression test proving invalidated artifact keys do not recreate hits before a real update repopulates metadata

## Tests
- soldr --no-cache cargo fmt
- soldr --no-cache cargo test -p zccache invalidated_artifact_key_does_not_recreate_hit --lib
- soldr --no-cache cargo test -p zccache depgraph::graph::tests --lib
- soldr --no-cache cargo check -p zccache

Closes #799