### PR TITLE
fix(depgraph): invalidate stale entries on artifact miss

### DIFF
--- a/crates/zccache/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -458,6 +458,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 &sid,
                 &format!("[DIAG] artifact_not_found: key={artifact_key_hex}"),
             );
+            invalidate_missing_depgraph_artifact(state, &sid, &artifact_key_hex);
         }
         crate::depgraph::CacheVerdict::SourceChanged { artifact_key } => {
             let artifact_key_hex = artifact_key.hash().to_hex();
@@ -651,6 +652,21 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         stderr,
         cached: false,
     }
+}
+
+fn invalidate_missing_depgraph_artifact(
+    state: &SharedState,
+    sid: &SessionId,
+    artifact_key_hex: &str,
+) {
+    let mut stale_keys = std::collections::HashSet::with_capacity(1);
+    stale_keys.insert(artifact_key_hex.to_string());
+    let cleared = state.dep_graph.load().invalidate_artifact_keys(&stale_keys);
+    write_session_log(
+        &state.sessions,
+        sid,
+        &format!("[DIAG] depgraph_invalidate_artifact: key={artifact_key_hex} cleared={cleared}"),
+    );
 }
 
 async fn wait_for_startup_depgraph_load(state: &SharedState, sid: &SessionId) {

--- a/crates/zccache/tests/daemon_rustc_restore_test.rs
+++ b/crates/zccache/tests/daemon_rustc_restore_test.rs
@@ -13,7 +13,7 @@ use tokio::task::JoinHandle;
 use zccache::core::NormalizedPath;
 use zccache::daemon::DaemonServer;
 use zccache::depgraph::{classify_load, depgraph_file_path, DepGraphLoadOutcome};
-use zccache::protocol::{DaemonStatus, Request, Response};
+use zccache::protocol::{DaemonStatus, Request, Response, SessionStats};
 
 #[cfg(unix)]
 type ClientConn = zccache::ipc::IpcConnection;
@@ -112,7 +112,7 @@ async fn connect(endpoint: &str) -> ClientConn {
 }
 
 async fn start_session(client: &mut ClientConn, working_dir: &Path) -> String {
-    start_session_with_log(client, working_dir, None).await
+    start_session_with_options(client, working_dir, None, false).await
 }
 
 async fn start_session_with_log(
@@ -120,12 +120,21 @@ async fn start_session_with_log(
     working_dir: &Path,
     log_file: Option<NormalizedPath>,
 ) -> String {
+    start_session_with_options(client, working_dir, log_file, false).await
+}
+
+async fn start_session_with_options(
+    client: &mut ClientConn,
+    working_dir: &Path,
+    log_file: Option<NormalizedPath>,
+    track_stats: bool,
+) -> String {
     client
         .send(&Request::SessionStart {
             client_pid: std::process::id(),
             working_dir: NormalizedPath::from(working_dir),
             log_file,
-            track_stats: false,
+            track_stats,
             journal_path: None,
             profile: false,
             private_daemon: None,
@@ -136,6 +145,20 @@ async fn start_session_with_log(
     match client.recv().await.expect("recv SessionStarted") {
         Some(Response::SessionStarted { session_id, .. }) => session_id,
         other => panic!("expected SessionStarted, got {other:?}"),
+    }
+}
+
+async fn query_session_stats(client: &mut ClientConn, session_id: &str) -> Option<SessionStats> {
+    client
+        .send(&Request::SessionStats {
+            session_id: session_id.to_string(),
+        })
+        .await
+        .expect("send SessionStats");
+
+    match client.recv().await.expect("recv SessionStatsResult") {
+        Some(Response::SessionStatsResult { stats }) => stats,
+        other => panic!("expected SessionStatsResult, got {other:?}"),
     }
 }
 
@@ -268,6 +291,55 @@ fn assert_outputs_exist(outputs: &[PathBuf], context: &str) {
     }
 }
 
+fn single_artifact_key_in(cache_dir: &Path) -> String {
+    let cache_dir = zccache::core::config::effective_cache_root_from_top_level(
+        &NormalizedPath::from(cache_dir),
+    );
+    let artifact_dir = zccache::core::config::artifacts_dir_from_cache_dir(&cache_dir);
+    let mut keys = std::collections::BTreeSet::new();
+    for entry in std::fs::read_dir(&artifact_dir).expect("read artifact dir") {
+        let entry = entry.expect("artifact dir entry");
+        if !entry.file_type().expect("artifact file type").is_file() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if let Some(key) = name.strip_suffix(".pack") {
+            keys.insert(key.to_string());
+        } else if let Some((key, _index)) = name.split_once('_') {
+            keys.insert(key.to_string());
+        }
+    }
+    assert_eq!(
+        keys.len(),
+        1,
+        "expected one artifact key in isolated cache, found {keys:?}"
+    );
+    keys.into_iter().next().expect("one artifact key")
+}
+
+fn remove_artifact_payloads(cache_dir: &Path, artifact_key_hex: &str) {
+    let cache_dir = zccache::core::config::effective_cache_root_from_top_level(
+        &NormalizedPath::from(cache_dir),
+    );
+    let artifact_dir = zccache::core::config::artifacts_dir_from_cache_dir(&cache_dir);
+    let mut removed = 0;
+    for entry in std::fs::read_dir(&artifact_dir).expect("read artifact dir") {
+        let entry = entry.expect("artifact dir entry");
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name == format!("{artifact_key_hex}.pack")
+            || name.starts_with(&format!("{artifact_key_hex}_"))
+        {
+            std::fs::remove_file(path).expect("remove artifact payload");
+            removed += 1;
+        }
+    }
+    assert!(
+        removed > 0,
+        "expected to remove artifact payloads for {artifact_key_hex}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn rustc_multi_output_hit_survives_cache_restore_without_target_dir() {
     let rustc = match zccache::test_support::find_rustc() {
@@ -374,6 +446,139 @@ async fn rustc_multi_output_hit_survives_cache_restore_without_target_dir() {
             "second compile should be restored from the cache after target/ deletion",
         );
         assert_outputs_exist(&outputs, "cached restore");
+        end_session(&mut client2, session2).await;
+        shutdown_daemon(client2, handle2).await;
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn depgraph_hit_artifact_not_found_invalidates_stale_entry() {
+    let rustc = match zccache::test_support::find_rustc() {
+        Some(path) => path,
+        None => {
+            eprintln!("skipping test: rustc not found");
+            return;
+        }
+    };
+
+    zccache::test_support::test_timeout(async move {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cache_dir = tmp.path().join("zccache-cache");
+        let project_dir = tmp.path().join("workspace");
+        std::fs::create_dir_all(&cache_dir).expect("create cache dir");
+        create_tiny_project(&project_dir);
+        let _cache_env = CacheEnvGuard::new(&cache_dir);
+
+        let args = rustc_multi_output_args();
+        let outputs = expected_outputs(&project_dir);
+
+        let (endpoint1, handle1) = start_daemon_like_zccache_daemon().await;
+        let mut client1 = connect(&endpoint1).await;
+        let session1 = start_session(&mut client1, &project_dir).await;
+        let first = compile_rustc(
+            &mut client1,
+            &session1,
+            rustc.as_path(),
+            &args,
+            &project_dir,
+        )
+        .await;
+        assert_eq!(
+            first.exit_code,
+            0,
+            "first rustc compile failed: {}",
+            String::from_utf8_lossy(&first.stderr),
+        );
+        assert!(!first.cached, "first compile should populate the cache");
+        assert_outputs_exist(&outputs, "first compile");
+        end_session(&mut client1, session1).await;
+        shutdown_daemon(client1, handle1).await;
+
+        let artifact_key_hex = single_artifact_key_in(&cache_dir);
+        remove_artifact_payloads(&cache_dir, &artifact_key_hex);
+        for output in &outputs {
+            let _ = std::fs::remove_file(output);
+        }
+
+        let (endpoint2, handle2) = start_daemon_like_zccache_daemon().await;
+        let mut client2 = connect(&endpoint2).await;
+        let log_path = tmp.path().join("artifact-miss-session.log");
+        let session2 = start_session_with_options(
+            &mut client2,
+            &project_dir,
+            Some(NormalizedPath::from(log_path.as_path())),
+            true,
+        )
+        .await;
+        let second = compile_rustc(
+            &mut client2,
+            &session2,
+            rustc.as_path(),
+            &args,
+            &project_dir,
+        )
+        .await;
+        assert_eq!(
+            second.exit_code,
+            0,
+            "second rustc compile failed: {}\nsession log:\n{}",
+            String::from_utf8_lossy(&second.stderr),
+            std::fs::read_to_string(&log_path).unwrap_or_default(),
+        );
+        assert!(
+            !second.cached,
+            "missing artifact payload should force a miss and repopulate"
+        );
+        let stats = query_session_stats(&mut client2, &session2)
+            .await
+            .expect("stats tracking enabled");
+        assert_eq!(stats.lookup_outcomes.depgraph_hit_artifact_miss, 1);
+        assert_eq!(stats.lookup_outcomes.depgraph_hit_artifact_hit, 0);
+        let session_log = std::fs::read_to_string(&log_path).unwrap_or_default();
+        assert!(
+            session_log.contains(&format!(
+                "[DIAG] artifact_not_found: key={artifact_key_hex}"
+            )),
+            "expected artifact_not_found diagnostic; session log:\n{session_log}",
+        );
+        assert!(
+            session_log.contains(&format!(
+                "[DIAG] depgraph_invalidate_artifact: key={artifact_key_hex} cleared=1"
+            )),
+            "expected stale depgraph artifact invalidation; session log:\n{session_log}",
+        );
+        assert_outputs_exist(&outputs, "miss repopulates outputs");
+
+        for output in &outputs {
+            let _ = std::fs::remove_file(output);
+        }
+        let third = compile_rustc(
+            &mut client2,
+            &session2,
+            rustc.as_path(),
+            &args,
+            &project_dir,
+        )
+        .await;
+        assert_eq!(
+            third.exit_code,
+            0,
+            "third rustc compile failed: {}\nsession log:\n{}",
+            String::from_utf8_lossy(&third.stderr),
+            std::fs::read_to_string(&log_path).unwrap_or_default(),
+        );
+        assert!(
+            third.cached,
+            "repopulated artifact should be restorable after stale entry invalidation"
+        );
+        let stats = query_session_stats(&mut client2, &session2)
+            .await
+            .expect("stats tracking enabled");
+        assert_eq!(stats.lookup_outcomes.depgraph_hit_artifact_miss, 1);
+        assert_eq!(stats.lookup_outcomes.depgraph_hit_artifact_hit, 1);
+        assert_outputs_exist(&outputs, "third compile restores outputs");
+
         end_session(&mut client2, session2).await;
         shutdown_daemon(client2, handle2).await;
     })


### PR DESCRIPTION
﻿## Summary
- invalidate depgraph entries when a depgraph hit points at a missing artifact payload
- log the invalidation result beside the existing `artifact_not_found` diagnostic
- add a daemon restore regression that deletes the cached artifact, checks `depgraph_hit_artifact_miss`, and verifies the repopulated artifact is hit afterward

Fixes #799.
Part of #796 and #787. Builds on #821 / #798.

## Validation
- `soldr --no-cache cargo fmt --all --check`
- `soldr --no-cache cargo test -p zccache --test daemon_rustc_restore_test -- --nocapture --test-threads=1`
- `soldr --no-cache cargo test -p zccache depgraph --lib`
- `soldr --no-cache cargo test -p zccache lookup_outcomes --lib`
- Docker/Linux from `git archive` of this commit: `soldr --no-cache cargo test -p zccache --test daemon_rustc_restore_test depgraph_hit_artifact_not_found_invalidates_stale_entry -- --nocapture`
