### PR TITLE
perf(session): warn on degraded cache summaries

### DIFF
--- a/crates/zccache/src/cli/commands/session.rs
+++ b/crates/zccache/src/cli/commands/session.rs
@@ -2,6 +2,7 @@
 
 use crate::core::NormalizedPath;
 use std::ffi::OsString;
+use std::io::IsTerminal;
 use std::path::Path;
 use std::process::ExitCode;
 
@@ -364,6 +365,13 @@ pub(crate) fn print_session_stats_human(
     if stats.time_saved_ms > 0 {
         eprintln!("  Time saved: ~{}", format_duration_ms(stats.time_saved_ms));
     }
+    if !crate::core::defender::is_quiet_env() {
+        let depgraph_exists = crate::depgraph::depgraph_file_path().exists();
+        let verbose = summary_verbose_env();
+        for warning in session_summary_warnings(stats, depgraph_exists, verbose) {
+            eprintln!("  {}", warning.render(std::io::stderr().is_terminal()));
+        }
+    }
 }
 
 pub(crate) fn print_session_stats_json(session_id: &str, stats: &crate::protocol::SessionStats) {
@@ -431,6 +439,95 @@ pub(crate) fn session_stats_json(
         "lookup_outcomes": &stats.lookup_outcomes,
         "phase_profile": phase_profile,
     })
+}
+
+const WASTED_DEPGRAPH_HIT_WARN_PCT: f64 = 10.0;
+const COLD_SKIP_WARN_PCT: f64 = 50.0;
+const CATASTROPHIC_HIT_RATE_WARN_PCT: f64 = 5.0;
+const CATASTROPHIC_MIN_COMPILATIONS: u64 = 50;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionSummaryWarning {
+    message: String,
+}
+
+impl SessionSummaryWarning {
+    fn new(message: String) -> Self {
+        Self { message }
+    }
+
+    pub(crate) fn render(&self, color: bool) -> String {
+        if color {
+            format!("\x1b[33mWARNING: {}\x1b[0m", self.message)
+        } else {
+            format!("WARNING: {}", self.message)
+        }
+    }
+}
+
+pub(crate) fn session_summary_warnings(
+    stats: &crate::protocol::SessionStats,
+    depgraph_exists: bool,
+    verbose: bool,
+) -> Vec<SessionSummaryWarning> {
+    let outcomes = &stats.lookup_outcomes;
+    let total_lookups = outcomes
+        .depgraph_hit_artifact_hit
+        .saturating_add(outcomes.depgraph_hit_artifact_miss)
+        .saturating_add(outcomes.depgraph_cold_skip)
+        .saturating_add(outcomes.depgraph_other_miss.values().copied().sum::<u64>());
+    let mut warnings = Vec::new();
+
+    if let Some(pct) = percentage(outcomes.depgraph_hit_artifact_miss, total_lookups) {
+        if pct > WASTED_DEPGRAPH_HIT_WARN_PCT {
+            warnings.push(SessionSummaryWarning::new(format!(
+                "{pct:.1}% of depgraph hits did not produce an artifact fetch; \
+                 the cache is degraded (see #680 / #796 SI-3)"
+            )));
+        }
+    }
+
+    if depgraph_exists {
+        if let Some(pct) = percentage(outcomes.depgraph_cold_skip, total_lookups) {
+            if pct > COLD_SKIP_WARN_PCT {
+                warnings.push(SessionSummaryWarning::new(format!(
+                    "{pct:.1}% of lookups returned cold_skip despite a populated depgraph \
+                     on disk; the warm-cache classifier may be regressed (see #320 / #796 SI-2)"
+                )));
+            }
+        }
+
+        let cacheable = stats.hits.saturating_add(stats.misses);
+        if verbose && stats.compilations > CATASTROPHIC_MIN_COMPILATIONS && cacheable > 0 {
+            let hit_rate = stats.hits as f64 / cacheable as f64 * 100.0;
+            if hit_rate < CATASTROPHIC_HIT_RATE_WARN_PCT {
+                warnings.push(SessionSummaryWarning::new(format!(
+                    "catastrophic hit rate ({hit_rate:.1}%) over {} compilations; \
+                     cache may be silently dead; capture last-session.log and file a bug",
+                    stats.compilations
+                )));
+            }
+        }
+    }
+
+    warnings
+}
+
+fn percentage(part: u64, total: u64) -> Option<f64> {
+    (total > 0).then(|| part as f64 / total as f64 * 100.0)
+}
+
+fn summary_verbose_env() -> bool {
+    std::env::var("ZCCACHE_SUMMARY_VERBOSE")
+        .ok()
+        .as_deref()
+        .is_some_and(|value| {
+            let value = value.trim();
+            !value.is_empty()
+                && value != "0"
+                && !value.eq_ignore_ascii_case("false")
+                && !value.eq_ignore_ascii_case("no")
+        })
 }
 
 pub(crate) fn phase_profile_summary_json(

--- a/crates/zccache/src/cli/commands/tests/args_parsing.rs
+++ b/crates/zccache/src/cli/commands/tests/args_parsing.rs
@@ -8,7 +8,7 @@ use super::super::args::{Cli, Commands, RustPlanBackendArg, RustPlanCommands, KN
 use super::super::rust_plan::rust_plan_gha_version;
 use super::super::session::{
     session_stats_error_json, session_stats_json, session_stats_unavailable_json,
-    SessionStartPrivateOptions,
+    session_summary_warnings, SessionStartPrivateOptions,
 };
 
 #[test]
@@ -156,6 +156,92 @@ fn rust_plan_session_stats_json_separates_compile_cache_stats() {
         json["lookup_outcomes"]["depgraph_other_miss"]["headers_changed"],
         1
     );
+}
+
+#[test]
+fn session_summary_warning_thresholds_detect_degraded_cache() {
+    let mut stats = session_stats_fixture();
+    stats.lookup_outcomes.depgraph_hit_artifact_hit = 80;
+    stats.lookup_outcomes.depgraph_hit_artifact_miss = 20;
+
+    let warnings = session_summary_warnings(&stats, false, false);
+    assert_eq!(warnings.len(), 1);
+    let rendered = warnings[0].render(false);
+    assert!(rendered.starts_with("WARNING: 20.0% of depgraph hits"));
+    assert!(rendered.contains("#680 / #796 SI-3"));
+    assert_eq!(
+        warnings[0].render(true),
+        format!("\x1b[33m{rendered}\x1b[0m")
+    );
+}
+
+#[test]
+fn session_summary_warning_thresholds_detect_cold_skip_with_depgraph() {
+    let mut stats = session_stats_fixture();
+    stats.lookup_outcomes.depgraph_hit_artifact_hit = 10;
+    stats.lookup_outcomes.depgraph_cold_skip = 60;
+    stats.lookup_outcomes.depgraph_other_miss =
+        [("headers_changed".to_string(), 10)].into_iter().collect();
+
+    let warnings = session_summary_warnings(&stats, true, false);
+    assert_eq!(warnings.len(), 1);
+    let rendered = warnings[0].render(false);
+    assert!(rendered.starts_with("WARNING: 75.0% of lookups returned cold_skip"));
+    assert!(rendered.contains("#320 / #796 SI-2"));
+
+    assert!(
+        session_summary_warnings(&stats, false, false).is_empty(),
+        "cold_skip warning requires a populated depgraph on disk"
+    );
+}
+
+#[test]
+fn session_summary_warning_thresholds_gate_catastrophic_hit_rate_on_verbose() {
+    let mut stats = session_stats_fixture();
+    stats.compilations = 80;
+    stats.hits = 2;
+    stats.misses = 78;
+
+    assert!(session_summary_warnings(&stats, true, false).is_empty());
+
+    let warnings = session_summary_warnings(&stats, true, true);
+    assert_eq!(warnings.len(), 1);
+    let rendered = warnings[0].render(false);
+    assert!(rendered.starts_with("WARNING: catastrophic hit rate (2.5%)"));
+    assert!(rendered.contains("over 80 compilations"));
+}
+
+#[test]
+fn session_summary_warning_thresholds_stay_quiet_for_healthy_session() {
+    let mut stats = session_stats_fixture();
+    stats.compilations = 100;
+    stats.hits = 90;
+    stats.misses = 10;
+    stats.lookup_outcomes.depgraph_hit_artifact_hit = 90;
+    stats.lookup_outcomes.depgraph_hit_artifact_miss = 1;
+    stats.lookup_outcomes.depgraph_cold_skip = 2;
+    stats.lookup_outcomes.depgraph_other_miss =
+        [("headers_changed".to_string(), 7)].into_iter().collect();
+
+    assert!(session_summary_warnings(&stats, true, true).is_empty());
+}
+
+fn session_stats_fixture() -> crate::protocol::SessionStats {
+    crate::protocol::SessionStats {
+        duration_ms: 1000,
+        compilations: 10,
+        hits: 7,
+        misses: 3,
+        non_cacheable: 0,
+        errors: 0,
+        errors_cached: 0,
+        time_saved_ms: 0,
+        unique_sources: 8,
+        bytes_read: 0,
+        bytes_written: 0,
+        lookup_outcomes: crate::protocol::LookupOutcomes::default(),
+        phase_profile: None,
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- emit stderr WARNING lines when wasted depgraph hits or cold_skip dominate session lookup outcomes
- gate the catastrophic hit-rate warning behind `ZCCACHE_SUMMARY_VERBOSE=1`
- respect existing `ZCCACHE_QUIET` suppression and color warnings yellow on TTY stderr
- add unit coverage for threshold math and healthy-session suppression

## Tests
- soldr --no-cache cargo fmt
- soldr --no-cache cargo test -p zccache session_summary_warning_thresholds --lib
- soldr --no-cache cargo test -p zccache rust_plan_session_stats_json_separates_compile_cache_stats --lib
- soldr --no-cache cargo check -p zccache

Closes #801
Refs #796, #787, #704