### PR TITLE
feat(session): warn on degraded cache summaries

### DIFF
--- a/crates/zccache/src/cli/commands/tests/mod.rs
+++ b/crates/zccache/src/cli/commands/tests/mod.rs
@@ -7,6 +7,7 @@ mod args_parsing;
 mod cache_ops;
 mod daemon;
 mod exit_code;
+mod session_warnings;
 mod snapshot;
 mod util;
 mod warm_lockfile;

--- a/crates/zccache/src/cli/commands/tests/session_warnings.rs
+++ b/crates/zccache/src/cli/commands/tests/session_warnings.rs
@@ -1,0 +1,94 @@
+use crate::cli::commands::session::session_summary_warnings;
+use crate::protocol::{LookupOutcomes, SessionStats};
+
+fn stats_with(outcomes: LookupOutcomes) -> SessionStats {
+    SessionStats {
+        duration_ms: 1000,
+        compilations: 10,
+        hits: 5,
+        misses: 5,
+        non_cacheable: 0,
+        errors: 0,
+        errors_cached: 0,
+        time_saved_ms: 0,
+        unique_sources: 5,
+        bytes_read: 0,
+        bytes_written: 0,
+        lookup_outcomes: outcomes,
+        phase_profile: None,
+    }
+}
+
+#[test]
+fn summary_warning_fires_for_wasted_depgraph_hits_over_threshold() {
+    let warnings = session_summary_warnings(
+        &stats_with(LookupOutcomes {
+            depgraph_hit_artifact_hit: 80,
+            depgraph_hit_artifact_miss: 12,
+            depgraph_cold_skip: 8,
+            depgraph_other_miss: Default::default(),
+        }),
+        true,
+        false,
+    );
+
+    assert_eq!(warnings.len(), 1);
+    let rendered = warnings[0].render(false);
+    assert!(rendered.contains("12.0% of depgraph hits"));
+    assert!(rendered.contains("#680 / #796 SI-3"));
+}
+
+#[test]
+fn summary_warning_fires_for_cold_skip_dominating_with_depgraph_activity() {
+    let warnings = session_summary_warnings(
+        &stats_with(LookupOutcomes {
+            depgraph_hit_artifact_hit: 10,
+            depgraph_hit_artifact_miss: 0,
+            depgraph_cold_skip: 90,
+            depgraph_other_miss: Default::default(),
+        }),
+        true,
+        false,
+    );
+
+    assert_eq!(warnings.len(), 1);
+    let rendered = warnings[0].render(false);
+    assert!(rendered.contains("90.0% of lookups returned cold_skip"));
+    assert!(rendered.contains("#320 / #796 SI-2"));
+}
+
+#[test]
+fn summary_warning_does_not_fire_for_cold_skip_when_depgraph_missing() {
+    let warnings = session_summary_warnings(
+        &stats_with(LookupOutcomes {
+            depgraph_hit_artifact_hit: 0,
+            depgraph_hit_artifact_miss: 0,
+            depgraph_cold_skip: 100,
+            depgraph_other_miss: Default::default(),
+        }),
+        false,
+        false,
+    );
+
+    assert!(warnings.is_empty());
+}
+
+#[test]
+fn summary_warning_verbose_controls_catastrophic_hit_rate() {
+    let mut stats = stats_with(LookupOutcomes {
+        depgraph_hit_artifact_hit: 1,
+        depgraph_hit_artifact_miss: 0,
+        depgraph_cold_skip: 0,
+        depgraph_other_miss: Default::default(),
+    });
+    stats.compilations = 80;
+    stats.hits = 1;
+    stats.misses = 79;
+
+    assert!(session_summary_warnings(&stats, true, false).is_empty());
+    let warnings = session_summary_warnings(&stats, true, true);
+    assert_eq!(warnings.len(), 1);
+    let rendered = warnings[0].render(false);
+    assert!(rendered.contains("catastrophic hit rate (1.2%)"));
+    assert!(rendered.contains("80 compilations"));
+}


### PR DESCRIPTION
﻿## Summary
- add thresholded session-summary warnings for degraded depgraph behavior
- warn when artifact-miss depgraph hits exceed 10% of lookup outcomes
- warn when cold_skip dominates a session that also shows depgraph activity
- add `ZCCACHE_SUMMARY_VERBOSE=1` catastrophic-hit-rate warning for large sessions
- keep warnings on stderr, with yellow TTY color and plain output when piped/NO_COLOR

Fixes #801.
Part of #796 and #787.

## Validation
- `soldr --no-cache cargo test -p zccache session_warning --lib`
- `soldr --no-cache cargo fmt --all --check`
- `soldr --no-cache cargo test -p zccache session_stats --lib`
- `git diff --check`

## Docker/Linux note
I attempted the same focused `soldr --no-cache cargo test -p zccache session_warning --lib` from a `git archive` inside `rust:latest`, but Docker Desktop stopped responding during the run and subsequent `docker ps` calls timed out / returned Docker API 500. No Rust test failure was observed before the Docker daemon failure.
