### PR TITLE
feat(cargo-registry): --output PATH bypasses SOLDR_SKIP_CARGO_REGISTRY_SAVE

### DIFF
--- a/crates/zccache/src/cli/commands/args/subcommands.rs
+++ b/crates/zccache/src/cli/commands/args/subcommands.rs
@@ -165,12 +165,21 @@ pub(crate) enum DefenderExclusionsCommands {
 pub(crate) enum CargoRegistryCommands {
     /// Save cargo registry to a compressed archive.
     Save {
-        /// Cache key (used as filename).
+        /// Cache key (used as filename when `--output` is not set).
         #[arg(long)]
         key: String,
         /// Cargo home directory (default: ~/.cargo or $CARGO_HOME).
         #[arg(long)]
         cargo_home: Option<String>,
+        /// Explicit output archive path. When supplied, the archive is
+        /// written exactly here instead of the default
+        /// `<cache-root>/cargo-registry/<key>.tar.gz`, AND the
+        /// `SOLDR_SKIP_CARGO_REGISTRY_SAVE=1` no-op is bypassed —
+        /// the caller has chosen a non-standard destination, so the
+        /// setup-soldr coordination flag (which exists to avoid
+        /// double-saving the standard location) does not apply.
+        #[arg(long)]
+        output: Option<String>,
     },
     /// Restore cargo registry from a compressed archive.
     Restore {

--- a/crates/zccache/src/cli/commands/cargo_registry.rs
+++ b/crates/zccache/src/cli/commands/cargo_registry.rs
@@ -31,14 +31,27 @@ pub(crate) fn cargo_registry_cache_dir() -> NormalizedPath {
     crate::core::config::cargo_registry_cache_dir()
 }
 
-pub(crate) fn cmd_cargo_registry_save(key: &str, cargo_home: Option<&str>) -> ExitCode {
+pub(crate) fn cmd_cargo_registry_save(
+    key: &str,
+    cargo_home: Option<&str>,
+    output: Option<&str>,
+) -> ExitCode {
     // setup-soldr#70's payload C migration: when setup-soldr owns
-    // `~/.cargo/registry` caching with fast-zstd, double-saving here just
-    // burns CPU on the same bytes. Caller signals takeover via env var.
-    if env_flag_truthy("SOLDR_SKIP_CARGO_REGISTRY_SAVE") {
+    // `~/.cargo/registry` caching with fast-zstd, double-saving to the
+    // default location burns CPU on bytes setup-soldr already owns.
+    // Caller signals takeover via `SOLDR_SKIP_CARGO_REGISTRY_SAVE=1`.
+    //
+    // BUT: when the caller passes `--output PATH`, they are explicitly
+    // directing the archive to a non-standard location — the
+    // setup-soldr coordination flag does not apply, so we bypass the
+    // skip and run the save. (Without this carve-out, a CI smoke test
+    // or any other explicit consumer that runs inside a setup-soldr
+    // context would have to `unset` the env var to make `save` do
+    // anything, which is brittle and easy to miss.)
+    if output.is_none() && env_flag_truthy("SOLDR_SKIP_CARGO_REGISTRY_SAVE") {
         println!(
             "cargo-registry save: skipping (SOLDR_SKIP_CARGO_REGISTRY_SAVE=1) \
-             — caller owns the cache layer"
+             — caller owns the cache layer (pass --output to override)"
         );
         return ExitCode::SUCCESS;
     }
@@ -49,15 +62,37 @@ pub(crate) fn cmd_cargo_registry_save(key: &str, cargo_home: Option<&str>) -> Ex
             return ExitCode::FAILURE;
         }
     };
-    let cache_dir = cargo_registry_cache_dir();
-    if let Err(e) = std::fs::create_dir_all(&cache_dir) {
-        eprintln!(
-            "zccache cargo-registry save: failed to create {}: {e}",
-            cache_dir.display()
-        );
-        return ExitCode::FAILURE;
+    // Resolve the archive destination. `--output` takes the full path
+    // (including filename); without it we fall back to the derived
+    // `<cache-root>/cargo-registry/<key>.tar.gz`.
+    let archive_path: std::path::PathBuf = match output {
+        Some(p) => std::path::PathBuf::from(p),
+        None => {
+            let cache_dir = cargo_registry_cache_dir();
+            if let Err(e) = std::fs::create_dir_all(&cache_dir) {
+                eprintln!(
+                    "zccache cargo-registry save: failed to create {}: {e}",
+                    cache_dir.display()
+                );
+                return ExitCode::FAILURE;
+            }
+            cache_dir.join(format!("{key}.tar.gz")).into_path_buf()
+        }
+    };
+    // For `--output`, the caller may have given us a path whose parent
+    // directory does not exist yet. Create it on their behalf so we
+    // match the default-path branch's create-on-demand behavior.
+    if let Some(parent) = archive_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                eprintln!(
+                    "zccache cargo-registry save: failed to create {}: {e}",
+                    parent.display()
+                );
+                return ExitCode::FAILURE;
+            }
+        }
     }
-    let archive_path = cache_dir.join(format!("{key}.tar.gz"));
 
     // Collect paths to archive.
     let subdirs: &[&str] = &["registry/index", "registry/cache", "git/db"];
@@ -206,5 +241,110 @@ mod tests {
             cargo_registry_cache_dir(),
             crate::core::config::cargo_registry_cache_dir()
         );
+    }
+
+    /// Process-shared env-var helper. The save fn reads
+    /// `SOLDR_SKIP_CARGO_REGISTRY_SAVE` from process env; the tests
+    /// below toggle it and must not race each other.
+    fn with_skip_env<F: FnOnce()>(set: bool, f: F) {
+        let var = "SOLDR_SKIP_CARGO_REGISTRY_SAVE";
+        let prev = std::env::var_os(var);
+        // SAFETY: documented in test-local guard; restored below.
+        unsafe {
+            if set {
+                std::env::set_var(var, "1");
+            } else {
+                std::env::remove_var(var);
+            }
+        }
+        f();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(var, v),
+                None => std::env::remove_var(var),
+            }
+        }
+    }
+
+    /// `--output` suppresses the `SOLDR_SKIP_CARGO_REGISTRY_SAVE` skip:
+    /// the caller has explicitly chosen a non-standard destination, so
+    /// the env var's coordination intent does not apply. The
+    /// observable contract is the archive file appearing at the
+    /// explicit path; without the bypass, the save would short-circuit
+    /// and the file would not exist.
+    #[test]
+    fn output_path_bypasses_soldr_skip_env() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let archive = tmp.path().join("explicit.tar.gz");
+        let archive_str = archive.to_string_lossy().into_owned();
+
+        with_skip_env(true, || {
+            // Use a small fake cargo home so the save has *something*
+            // to archive instead of erroring out on an empty registry.
+            let fake_cargo = tmp.path().join("cargo");
+            let reg = fake_cargo.join("registry").join("index");
+            std::fs::create_dir_all(&reg).unwrap();
+            std::fs::write(reg.join("marker"), b"x").unwrap();
+            let _ = cmd_cargo_registry_save(
+                "ignored-when-output-set",
+                Some(&fake_cargo.to_string_lossy()),
+                Some(&archive_str),
+            );
+            assert!(
+                archive.is_file(),
+                "archive must be written at the explicit --output path \
+                 (env var should not have skipped this): {}",
+                archive.display()
+            );
+        });
+    }
+
+    /// Without `--output`, `SOLDR_SKIP_CARGO_REGISTRY_SAVE=1` keeps the
+    /// pre-existing short-circuit behavior — the setup-soldr
+    /// coordination flag continues to apply when the caller is using
+    /// the default derived path.
+    #[test]
+    fn default_path_still_respects_soldr_skip_env() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Redirect zccache's cache root into the tempdir so the test
+        // does not touch the real home directory if the save WERE to
+        // run (it should not, per the env var).
+        let prev_cache_dir = std::env::var_os("ZCCACHE_CACHE_DIR");
+        unsafe { std::env::set_var("ZCCACHE_CACHE_DIR", tmp.path()) };
+
+        with_skip_env(true, || {
+            let _ = cmd_cargo_registry_save("noop-key", None, None);
+            // The skip path returns before touching the disk, so no
+            // archive should appear anywhere under the redirected root.
+            let mut stray = Vec::new();
+            walk_collect_gz(tmp.path(), &mut stray);
+            assert!(
+                stray.is_empty(),
+                "skip path must not write any .gz archive; found: {stray:?}"
+            );
+        });
+
+        unsafe {
+            match prev_cache_dir {
+                Some(v) => std::env::set_var("ZCCACHE_CACHE_DIR", v),
+                None => std::env::remove_var("ZCCACHE_CACHE_DIR"),
+            }
+        }
+    }
+
+    /// Shallow recursive walk for tests — avoid adding a `walkdir` dep
+    /// just for this one assertion.
+    fn walk_collect_gz(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                walk_collect_gz(&p, out);
+            } else if p.extension().is_some_and(|e| e == "gz") {
+                out.push(p);
+            }
+        }
     }
 }

--- a/crates/zccache/src/cli/commands/mod.rs
+++ b/crates/zccache/src/cli/commands/mod.rs
@@ -310,9 +310,15 @@ fn dispatch(command: Commands, global_strict_paths: Option<&str>) -> ExitCode {
             }
         }
         Commands::CargoRegistry { action } => match action {
-            CargoRegistryCommands::Save { key, cargo_home } => {
-                cargo_registry::cmd_cargo_registry_save(&key, cargo_home.as_deref())
-            }
+            CargoRegistryCommands::Save {
+                key,
+                cargo_home,
+                output,
+            } => cargo_registry::cmd_cargo_registry_save(
+                &key,
+                cargo_home.as_deref(),
+                output.as_deref(),
+            ),
             CargoRegistryCommands::Restore { key, cargo_home } => {
                 cargo_registry::cmd_cargo_registry_restore(&key, cargo_home.as_deref())
             }


### PR DESCRIPTION
## Summary

Adds `--output <PATH>` to `zccache cargo-registry save`. When supplied:

1. The archive is written to **exactly** `<PATH>` (not the derived `<cache-root>/cargo-registry/<key>.tar.gz`).
2. The `SOLDR_SKIP_CARGO_REGISTRY_SAVE=1` skip is **bypassed** — the caller has explicitly chosen a non-standard destination, so the setup-soldr coordination flag (which exists to avoid double-saving the *standard* location) does not apply.

Without `--output` the existing semantics are preserved exactly.

## Motivation

`zccache cargo-registry save` short-circuits to a no-op when `SOLDR_SKIP_CARGO_REGISTRY_SAVE=1`. setup-soldr sets that env var in its warm-path CI setup because it owns the cargo-registry cache layer itself; double-saving to the default location would burn CPU on bytes setup-soldr already manages.

But an explicit caller (a smoke test, a manual archive of a non-standard cache, a CI step that wants to materialize the archive for inspection) had two unappealing escape hatches:

1. `unset SOLDR_SKIP_CARGO_REGISTRY_SAVE` before the call — brittle, easy to forget, and silently no-ops the next invocation if you forget to unset.
2. Re-export the env var from a wrapper script — fragile across shell hosts.

`--output` is the discoverable, self-documenting replacement. The next consumer reading `--help` finds the flag instead of grepping setup-soldr's source for the env var name.

## Test plan

Two new unit tests in `crates/zccache/src/cli/commands/cargo_registry.rs::tests`:

- [x] `output_path_bypasses_soldr_skip_env` — with the env var set AND `--output` provided, the file appears at the explicit path.
- [x] `default_path_still_respects_soldr_skip_env` — with the env var set AND no `--output`, no .tar.gz is written anywhere under the redirected cache root.

```
running 3 tests
test cli::commands::cargo_registry::tests::cargo_registry_command_uses_core_cache_layout ... ok
test cli::commands::cargo_registry::tests::default_path_still_respects_soldr_skip_env ... ok
test cli::commands::cargo_registry::tests::output_path_bypasses_soldr_skip_env ... ok

test result: ok. 3 passed; 0 failed; 0 ignored
```

- [ ] CI on this PR
- [ ] Follow-up: update ci-unified.yml in #832 to use `--output <runner.temp>/cargo-registry-smoke.tar.gz` and drop the `unset SOLDR_SKIP_CARGO_REGISTRY_SAVE` workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)