### PR TITLE
fix: unblock main on 4 broken builds (macOS pipe2 + clippy + depgraph test + proto)

### DIFF
--- a/ci/check_wire_stability.py
+++ b/ci/check_wire_stability.py
@@ -57,7 +57,15 @@ ONEOF_OPEN_RE = re.compile(r"^\s*oneof\s+([A-Za-z_]\w*)\s*\{\s*$")
 FIELD_RE = re.compile(
     r"""^\s*
         (?:(?P<label>optional|repeated)\s+)?
-        (?P<type>[A-Za-z_][\w.]*)\s+
+        # `map<K, V>` must come first so the identifier branch does
+        # not eat the bare keyword. Both K and V are restricted to the
+        # protobuf scalar types we use today (uint{32,64}, int{32,64},
+        # string, bool); extend if a future proto needs more.
+        (?P<type>
+            map<\s*[A-Za-z_]\w*\s*,\s*[A-Za-z_][\w.]*\s*>
+            |
+            [A-Za-z_][\w.]*
+        )\s+
         (?P<name>[A-Za-z_]\w*)\s*=\s*
         (?P<number>\d+)
         \s*(?:\[[^]]*\])?

--- a/crates/zccache/src/daemon/jobserver.rs
+++ b/crates/zccache/src/daemon/jobserver.rs
@@ -129,12 +129,24 @@ struct PosixPipe {
 #[cfg(unix)]
 impl PosixPipe {
     fn create(capacity: usize) -> std::io::Result<Self> {
-        // `pipe2(O_CLOEXEC)` keeps these FDs out of unrelated forks.
-        // The daemon explicitly clears CLOEXEC at spawn time for the
-        // children that should inherit (sub-task #816's responsibility);
-        // by default, descendants are isolated.
+        // Create a pipe with both ends marked CLOEXEC so the FDs do not
+        // leak into unrelated forks. The daemon explicitly clears
+        // CLOEXEC at spawn time for children that should inherit
+        // (sub-task #816's responsibility); by default, descendants are
+        // isolated.
+        //
+        // On Linux/BSD/Solarish we use `pipe2(O_CLOEXEC)` — atomic.
+        // On macOS the libc crate exposes no `pipe2`, so we fall back
+        // to the two-call `pipe()` + per-FD `fcntl(F_SETFD, FD_CLOEXEC)`
+        // dance. There is a tiny race between the `pipe()` return and
+        // the two `fcntl` calls during which a concurrent `fork()`
+        // could inherit either FD; the daemon's process model does not
+        // spawn worker forks before this pool is constructed, so the
+        // race is closed in practice. If that invariant changes,
+        // switch to a guarded spawn lock or use the `nix` crate's
+        // `pipe2` wrapper.
         let mut fds = [0_i32; 2];
-        let rc = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };
+        let rc = unsafe { Self::sys_pipe(&mut fds) };
         if rc != 0 {
             return Err(std::io::Error::last_os_error());
         }
@@ -154,17 +166,58 @@ impl PosixPipe {
             return Err(std::io::Error::last_os_error());
         }
         if (written as usize) != bytes.len() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!(
-                    "jobserver pipe priming wrote {} of {} bytes",
-                    written,
-                    bytes.len()
-                ),
-            ));
+            return Err(std::io::Error::other(format!(
+                "jobserver pipe priming wrote {} of {} bytes",
+                written,
+                bytes.len()
+            )));
         }
 
         Ok(Self { read, write })
+    }
+
+    /// Platform-shimmed pipe creation. Returns 0 on success and -1 on
+    /// failure (setting errno via the underlying syscalls).
+    ///
+    /// SAFETY: `fds` must point at a writable `[i32; 2]`.
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly",
+        target_os = "illumos",
+        target_os = "solaris",
+        target_os = "redox",
+        target_os = "emscripten",
+    ))]
+    unsafe fn sys_pipe(fds: &mut [i32; 2]) -> libc::c_int {
+        libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC)
+    }
+
+    /// macOS + iOS fallback: `pipe()` + per-FD `fcntl(F_SETFD, FD_CLOEXEC)`.
+    /// See the doc comment on `create` for the race-window rationale.
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    unsafe fn sys_pipe(fds: &mut [i32; 2]) -> libc::c_int {
+        let rc = libc::pipe(fds.as_mut_ptr());
+        if rc != 0 {
+            return rc;
+        }
+        for &fd in fds.iter() {
+            let flags = libc::fcntl(fd, libc::F_GETFD);
+            if flags == -1 {
+                libc::close(fds[0]);
+                libc::close(fds[1]);
+                return -1;
+            }
+            if libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) == -1 {
+                libc::close(fds[0]);
+                libc::close(fds[1]);
+                return -1;
+            }
+        }
+        0
     }
 
     fn read_fd(&self) -> RawFd {

--- a/crates/zccache/src/daemon/jobserver.rs
+++ b/crates/zccache/src/daemon/jobserver.rs
@@ -32,7 +32,7 @@
 //!   a follow-up sub-task. The Windows form of the protocol is
 //!   `--jobserver-auth=fifo:<name>` per GNU make 4.4+; the
 //!   implementation requires a server-side message loop that's its own
-//!   focused review. Until that lands, [`JobserverPool::create`]
+//!   focused review. Until that lands, `JobserverPool::create`
 //!   returns an error on Windows; callers fall back to today's
 //!   uncapped behavior.
 

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -453,14 +453,19 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             record_session_stat(&state.sessions, &sid, |t| {
                 t.record_depgraph_hit_artifact_miss();
             });
-            let evicted: std::collections::HashSet<String> =
-                std::iter::once(artifact_key_hex.clone()).collect();
-            state.dep_graph.load().invalidate_artifact_keys(&evicted);
             write_session_log(
                 &state.sessions,
                 &sid,
                 &format!("[DIAG] artifact_not_found: key={artifact_key_hex}"),
             );
+            // Drop the stale depgraph entry pointing at the missing
+            // payload so the next lookup for this source does not
+            // re-fire the same wasted-hit dance. `invalidate_missing_
+            // depgraph_artifact` logs `cleared=N` so the
+            // regression test in `daemon_rustc_restore_test.rs` can
+            // assert the expected cleared count of 1; an earlier
+            // version of this branch invalidated inline too, racing
+            // the helper to `cleared=0` and breaking the test.
             invalidate_missing_depgraph_artifact(state, &sid, &artifact_key_hex);
         }
         crate::depgraph::CacheVerdict::SourceChanged { artifact_key } => {


### PR DESCRIPTION
## Summary

Main has been red on every PR for the last several hours because of four independent regressions that landed across the #813 / #825 sub-task series. This PR unblocks all four in one place; each fix is independent and reviewable in isolation.

| # | Fix | Where | Workflows it unblocks |
|---|---|---|---|
| 1 | macOS `pipe2` shim | `crates/zccache/src/daemon/jobserver.rs` | `macOS / Check`, `macOS / Test`, `Wrapper end-to-end (macos-14)` |
| 2 | `Error::other` (was: `clippy::io_other_error`) | `crates/zccache/src/daemon/jobserver.rs` | `Clippy` |
| 3 | Drop double-invalidation in `CacheVerdict::Hit` arm | `crates/zccache/src/daemon/server/handle_compile/pipeline/mod.rs` | `Integration (Linux)`, `Coverage` |
| 4 | `map<K, V>` proto field shape | `ci/check_wire_stability.py` | `Wire stability` |

## (1) `pipe2` shim for macOS

`libc::pipe2` is Linux-only. The original sub-task #815 commit used it directly inside `#[cfg(unix)]`, which compiles on Linux but errors `E0425: cannot find function pipe2 in crate libc` on macOS.

Replaced the direct call with a `sys_pipe(fds)` shim:
- `pipe2(O_CLOEXEC)` on Linux/Android/BSD/Solarish/Redox/Emscripten — atomic.
- `pipe()` + per-fd `fcntl(F_SETFD, FD_CLOEXEC)` on macOS/iOS.

The two-call dance has a tiny race between `pipe()` return and the two `fcntl` calls if a concurrent `fork()` happens, but the daemon does not spawn worker forks before this pool is constructed; the race is closed in practice. Documented in the doc comment so a future change to the daemon process model surfaces it.

## (2) `Error::other` vs `Error::new(ErrorKind::Other, ...)`

`clippy::io_other_error` (warn-by-default, promoted to error by `-D warnings`) rejects the legacy form. Replace with `Error::other(msg)` (stable since Rust 1.74). Pre-existing main breakage; the same fix landed on PR #832 but never reached main.

## (3) Double invalidation in `CacheVerdict::Hit`

The SI-3 fix from #825 invalidates the stale depgraph entry TWICE in the `CacheVerdict::Hit` arm: once inline at the top of the arm, once via the `invalidate_missing_depgraph_artifact` helper at the bottom. By the time the helper runs the entry is already gone, so it logs `cleared=0`. The regression test `depgraph_hit_artifact_not_found_invalidates_stale_entry` (`daemon_rustc_restore_test.rs:545`) asserts `cleared=1` and panics in `Integration` + `Coverage`.

Drop the inline invalidation and let the helper own the work — it logs the auditable diagnostic the test expects.

## (4) `map<K, V>` in the wire-stability guard

`zccache_v1.proto:291` added `map<string, uint64> depgraph_other_miss = 4;` for the `LookupOutcomes` message. The wire-stability guard's `FIELD_RE` only modelled bare identifiers, so it failed with `unparseable line` on every PR.

Extended `FIELD_RE` to recognise `map<K, V>` as a valid field type (both K and V restricted to scalar identifiers; extend further if a future proto uses nested maps). Verified locally:
```
$ uv run python ci/check_wire_stability.py
wire stability OK: 264 fields across 54 message/enum types
```

## Not addressed

The **Perf Guard** failure (C++ driver link cold path: 0.843× vs 0.85× floor, gap = 0.007×) is left for a separate look. 0.8% miss on a single observation is well within flake territory; the perf cluster's median-of-N machinery should reject as flake on rerun.

## Test plan

- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `soldr cargo test -p zccache --test daemon_rustc_restore_test depgraph_hit_artifact_not_found_invalidates_stale_entry` → ok in 5.13s
- [x] `uv run python ci/check_wire_stability.py` → wire stability OK
- [ ] CI on this PR (macOS, Integration, Wire stability, Clippy all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)