### PR TITLE
feat(protocol): add ExecProbe/ExecStore for caller-owned exec caching (#838 slice 1)

### DIFF
--- a/crates/zccache/src/daemon/server/connection.rs
+++ b/crates/zccache/src/daemon/server/connection.rs
@@ -560,6 +560,28 @@ pub(super) async fn handle_connection(
             Request::ReleaseWorktreeHandles { path } => {
                 (handle_release_worktree_handles(&state, &path).await, None)
             }
+            Request::ExecProbe {
+                name,
+                input_files,
+                input_env,
+                input_extra,
+            } => (
+                super::handle_exec_probe::handle_exec_probe(
+                    &state,
+                    &name,
+                    &input_files,
+                    &input_env,
+                    &input_extra,
+                ),
+                None,
+            ),
+            Request::ExecStore {
+                cache_key_hex,
+                result_bytes,
+            } => (
+                super::handle_exec_probe::handle_exec_store(&state, &cache_key_hex, &result_bytes),
+                None,
+            ),
         };
 
         // Capture journal metadata BEFORE conn.send so the client unblocks

--- a/crates/zccache/src/daemon/server/handle_exec_probe.rs
+++ b/crates/zccache/src/daemon/server/handle_exec_probe.rs
@@ -1,0 +1,145 @@
+//! `Request::ExecProbe` / `Request::ExecStore` handlers (issue #838).
+//!
+//! Caller-owned tool caching: the *caller* runs the tool, the daemon only
+//! computes a stable cache key from declared inputs and stores opaque
+//! result bytes. This complements [`handle_generic_tool_exec`](super::handle_exec)
+//! (which spawns the tool inside the daemon) and powers the upcoming PyO3
+//! `zccache.exec` binding for Python build orchestrators that already own
+//! their subprocess lifecycle.
+//!
+//! Cache-key composition (domain tag `zccache-exec-probe-v1`):
+//!   - caller-supplied `name` (typically tool identity or AST schema id)
+//!   - sorted `(path, content-hash)` declared input file pairs
+//!   - sorted `(name, value)` declared env pairs
+//!   - opaque `input_extra` bytes
+//!
+//! Slice 1 holds the (key → bytes) map in an in-memory `DashMap` on
+//! `SharedState::exec_cache`. A follow-up slice swaps that to a
+//! [`KvStore`](crate::artifact::kv::KvStore)-backed table for persistence
+//! across daemon restarts.
+
+use std::sync::Arc;
+
+use super::util::hash_file_via_cache;
+use super::SharedState;
+use crate::core::NormalizedPath;
+use crate::protocol::Response;
+
+/// Domain separation tag for ExecProbe/ExecStore cache keys.
+const EXEC_PROBE_KEY_DOMAIN: &[u8] = b"zccache-exec-probe-v1";
+
+/// Compute the cache key for an ExecProbe / ExecStore call and look it up
+/// in the in-memory exec cache.
+pub(super) fn handle_exec_probe(
+    state: &Arc<SharedState>,
+    name: &str,
+    input_files: &[NormalizedPath],
+    input_env: &[(String, String)],
+    input_extra: &Arc<Vec<u8>>,
+) -> Response {
+    let cache_key_hex =
+        match compose_exec_probe_key(state, name, input_files, input_env, input_extra) {
+            Ok(hex) => hex,
+            Err(message) => return Response::Error { message },
+        };
+    let cached_bytes = state
+        .exec_cache
+        .get(&cache_key_hex)
+        .map(|entry| Arc::clone(entry.value()));
+    Response::ExecProbeResult {
+        cache_key_hex,
+        cached_bytes,
+    }
+}
+
+/// Write opaque result bytes under the caller-supplied cache key. Last-writer-wins.
+pub(super) fn handle_exec_store(
+    state: &Arc<SharedState>,
+    cache_key_hex: &str,
+    result_bytes: &Arc<Vec<u8>>,
+) -> Response {
+    if !is_valid_cache_key_hex(cache_key_hex) {
+        return Response::Error {
+            message: format!(
+                "invalid cache_key_hex: expected 64 lowercase hex chars, got {} chars",
+                cache_key_hex.len()
+            ),
+        };
+    }
+    state
+        .exec_cache
+        .insert(cache_key_hex.to_string(), Arc::clone(result_bytes));
+    Response::ExecStoreAck { stored: true }
+}
+
+/// Compose the deterministic blake3 cache key from declared inputs.
+fn compose_exec_probe_key(
+    state: &Arc<SharedState>,
+    name: &str,
+    input_files: &[NormalizedPath],
+    input_env: &[(String, String)],
+    input_extra: &Arc<Vec<u8>>,
+) -> Result<String, String> {
+    let mut input_pairs: Vec<(String, [u8; 32])> = Vec::with_capacity(input_files.len());
+    for input in input_files {
+        let hash = hash_file_via_cache(state, input.as_path())
+            .ok_or_else(|| format!("cannot hash input file {}", input.as_path().display()))?;
+        input_pairs.push((
+            input.as_path().to_string_lossy().into_owned(),
+            *hash.as_bytes(),
+        ));
+    }
+    input_pairs.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut env_pairs: Vec<(String, String)> = input_env.to_vec();
+    env_pairs.sort();
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(EXEC_PROBE_KEY_DOMAIN);
+
+    hasher.update(b"name=");
+    hasher.update(name.as_bytes());
+    hasher.update(b"\0");
+
+    hasher.update(b"input_files=");
+    hasher.update(&(input_pairs.len() as u64).to_le_bytes());
+    for (path, hash) in &input_pairs {
+        hasher.update(&(path.len() as u64).to_le_bytes());
+        hasher.update(path.as_bytes());
+        hasher.update(hash);
+    }
+
+    hasher.update(b"input_env=");
+    hasher.update(&(env_pairs.len() as u64).to_le_bytes());
+    for (k, v) in &env_pairs {
+        hasher.update(&(k.len() as u64).to_le_bytes());
+        hasher.update(k.as_bytes());
+        hasher.update(&(v.len() as u64).to_le_bytes());
+        hasher.update(v.as_bytes());
+    }
+
+    hasher.update(b"input_extra=");
+    hasher.update(&(input_extra.len() as u64).to_le_bytes());
+    hasher.update(input_extra.as_slice());
+
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn is_valid_cache_key_hex(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_cache_key_hex_is_rejected() {
+        assert!(!is_valid_cache_key_hex(""));
+        assert!(!is_valid_cache_key_hex("ABCDEF"));
+        assert!(!is_valid_cache_key_hex(&"g".repeat(64)));
+        assert!(!is_valid_cache_key_hex(&"A".repeat(64)));
+        assert!(is_valid_cache_key_hex(&"a".repeat(64)));
+        assert!(is_valid_cache_key_hex(&"0123456789abcdef".repeat(4)));
+    }
+}

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -206,6 +206,7 @@ impl DaemonServer {
                 depgraph_load_warning: Mutex::new(None),
                 in_flight_exec: DashMap::new(),
                 pending_cache_writes: DashMap::new(),
+                exec_cache: DashMap::new(),
             }),
         })
     }
@@ -425,6 +426,16 @@ impl DaemonServer {
     #[must_use]
     pub(super) fn test_state(&self) -> &SharedState {
         &self.state
+    }
+
+    /// Test-only seam: clone the `Arc<SharedState>` so tests can call
+    /// handlers whose signatures want an owned arc (e.g. `handle_exec_probe`).
+    /// Issue #838.
+    #[doc(hidden)]
+    #[cfg(test)]
+    #[must_use]
+    pub(super) fn test_state_arc(&self) -> Arc<SharedState> {
+        Arc::clone(&self.state)
     }
 }
 

--- a/crates/zccache/src/daemon/server/mod.rs
+++ b/crates/zccache/src/daemon/server/mod.rs
@@ -87,6 +87,7 @@ mod handle_compile;
 mod handle_compile_ephemeral;
 mod handle_compile_multi;
 mod handle_exec;
+mod handle_exec_probe;
 mod handle_link;
 mod handle_release_worktree_handles;
 mod in_flight;

--- a/crates/zccache/src/daemon/server/state.rs
+++ b/crates/zccache/src/daemon/server/state.rs
@@ -265,4 +265,10 @@ pub(super) struct SharedState {
     /// `daemon/server/tests/deferred_cold_path.rs` (PR #618).
     ///
     pub(super) pending_cache_writes: DashMap<String, Arc<Notify>>,
+    /// In-memory exec-probe/store cache for caller-owned tool caching
+    /// (issue #838 slice 1). Keyed by hex-encoded blake3 cache key,
+    /// values are the opaque result bytes the caller supplied via
+    /// `Request::ExecStore`. Slice 1 keeps this in-memory only; a
+    /// follow-up slice swaps to `KvStore` for persistence.
+    pub(super) exec_cache: DashMap<String, Arc<Vec<u8>>>,
 }

--- a/crates/zccache/src/daemon/server/tests/exec_probe.rs
+++ b/crates/zccache/src/daemon/server/tests/exec_probe.rs
@@ -1,0 +1,113 @@
+//! Tests for `handle_exec_probe` / `handle_exec_store` (issue #838 slice 1).
+//!
+//! Drives the handlers in-process via `DaemonServer::test_state()` — the
+//! same seam `release_worktree_handles` uses. Verifies the
+//! probe-miss → store → probe-hit round trip and that the cache key is a
+//! stable function of declared inputs.
+
+use std::sync::Arc;
+
+use super::super::*;
+use super::CacheDirEnvGuard;
+use crate::core::NormalizedPath;
+use crate::protocol::Response;
+
+fn probe(
+    state: &Arc<super::super::SharedState>,
+    name: &str,
+    input_files: &[NormalizedPath],
+    input_env: &[(String, String)],
+    input_extra: &Arc<Vec<u8>>,
+) -> (String, Option<Arc<Vec<u8>>>) {
+    let resp = super::super::handle_exec_probe::handle_exec_probe(
+        state,
+        name,
+        input_files,
+        input_env,
+        input_extra,
+    );
+    match resp {
+        Response::ExecProbeResult {
+            cache_key_hex,
+            cached_bytes,
+        } => (cache_key_hex, cached_bytes),
+        other => panic!("expected ExecProbeResult, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore] // integration-level: instantiates a real DaemonServer
+async fn probe_miss_then_store_then_probe_hit() {
+    crate::test_support::test_timeout(async {
+        let cache_tmp = tempfile::tempdir().unwrap();
+        let _env = CacheDirEnvGuard::set(cache_tmp.path());
+        let endpoint = crate::ipc::unique_test_endpoint();
+        let cache_dir = NormalizedPath::new(cache_tmp.path());
+        let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+        let state = server.test_state_arc();
+
+        let name = "fastled-parse-ast";
+        let env: Vec<(String, String)> = vec![("LINT_VERSION".into(), "1.2.3".into())];
+        let extra = Arc::new(b"schema-v1".to_vec());
+
+        // First probe: miss. cache_key_hex returned regardless.
+        let (key_miss, cached_miss) = probe(&state, name, &[], &env, &extra);
+        assert!(cached_miss.is_none(), "fresh daemon must miss");
+        assert_eq!(key_miss.len(), 64, "cache key must be 64-char hex");
+        assert!(
+            key_miss
+                .bytes()
+                .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f')),
+            "cache key must be lowercase hex: {key_miss}"
+        );
+
+        // Store the caller's result bytes under that key.
+        let payload = Arc::new(b"opaque-ast-bytes".to_vec());
+        let store_resp =
+            super::super::handle_exec_probe::handle_exec_store(&state, &key_miss, &payload);
+        match store_resp {
+            Response::ExecStoreAck { stored } => assert!(stored, "store must ack"),
+            other => panic!("expected ExecStoreAck, got: {other:?}"),
+        }
+
+        // Second probe with the same declared inputs: hit, same key, same bytes.
+        let (key_hit, cached_hit) = probe(&state, name, &[], &env, &extra);
+        assert_eq!(key_miss, key_hit, "key must be stable across probes");
+        let cached = cached_hit.expect("post-store probe must hit");
+        assert_eq!(
+            cached.as_slice(),
+            payload.as_slice(),
+            "cached bytes must match what was stored"
+        );
+
+        // Different declared input → different key → still a miss.
+        let extra2 = Arc::new(b"schema-v2".to_vec());
+        let (key_other, cached_other) = probe(&state, name, &[], &env, &extra2);
+        assert_ne!(key_miss, key_other, "changing input_extra must change key");
+        assert!(
+            cached_other.is_none(),
+            "different key must not surface the prior store"
+        );
+    })
+    .await;
+}
+
+#[test]
+fn malformed_cache_key_fails_validation_shape() {
+    // The handler's `is_valid_cache_key_hex` is the source of truth and is
+    // unit-tested where it lives; this test mirrors the contract so a
+    // future loosening (e.g. uppercase hex) doesn't silently regress the
+    // integration story.
+    let invalid_keys: Vec<String> = vec![
+        String::new(),
+        "abc".to_string(),
+        "G".repeat(64),
+        "0".repeat(63),
+    ];
+    for k in &invalid_keys {
+        assert!(
+            !(k.len() == 64 && k.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))),
+            "key {k:?} should not pass lowercase-hex-64 validation"
+        );
+    }
+}

--- a/crates/zccache/src/daemon/server/tests/mod.rs
+++ b/crates/zccache/src/daemon/server/tests/mod.rs
@@ -11,6 +11,7 @@ mod clear_handler;
 mod client_env;
 mod compiler_hash;
 mod deferred_cold_path;
+mod exec_probe;
 mod fingerprint;
 mod link_cache;
 mod metadata_deferred;

--- a/crates/zccache/src/protocol/messages/compat/exec_probe.rs
+++ b/crates/zccache/src/protocol/messages/compat/exec_probe.rs
@@ -1,0 +1,61 @@
+//! `ExecProbe` / `ExecStore` (issue #838 slice 1) bincode roundtrip tests.
+//!
+//! These are the caller-owned-tool variants: the Python (or other foreign)
+//! orchestrator runs the tool itself, calls `ExecProbe` to ask the daemon
+//! whether the (name + inputs + env + extra) tuple already has a cached
+//! result, and posts the bytes via `ExecStore` on a miss.
+
+use super::*;
+
+#[test]
+fn exec_probe_request_roundtrip() {
+    let req = Request::ExecProbe {
+        name: "fastled-parse-ast".to_string(),
+        input_files: vec!["src/foo.cpp".into(), "ci/lint_cpp_rs/rules.json".into()],
+        input_env: vec![
+            ("LINT_VERSION".to_string(), "1.2.3".to_string()),
+            ("PATH".to_string(), "/usr/bin".to_string()),
+        ],
+        input_extra: Arc::new(b"schema-v1".to_vec()),
+    };
+    roundtrip(&req);
+
+    // Empty-inputs path used by tools that hash only their name + extra.
+    let req_empty = Request::ExecProbe {
+        name: "rustc-fingerprint".to_string(),
+        input_files: vec![],
+        input_env: vec![],
+        input_extra: Arc::new(Vec::new()),
+    };
+    roundtrip(&req_empty);
+}
+
+#[test]
+fn exec_store_request_roundtrip() {
+    let req = Request::ExecStore {
+        cache_key_hex: "0123456789abcdef".repeat(4),
+        result_bytes: Arc::new(b"opaque-result-bytes".to_vec()),
+    };
+    roundtrip(&req);
+}
+
+#[test]
+fn exec_probe_result_roundtrip_miss_and_hit() {
+    let miss = Response::ExecProbeResult {
+        cache_key_hex: "0".repeat(64),
+        cached_bytes: None,
+    };
+    roundtrip(&miss);
+
+    let hit = Response::ExecProbeResult {
+        cache_key_hex: "f".repeat(64),
+        cached_bytes: Some(Arc::new(b"cached-ast-bytes".to_vec())),
+    };
+    roundtrip(&hit);
+}
+
+#[test]
+fn exec_store_ack_roundtrip() {
+    let ack = Response::ExecStoreAck { stored: true };
+    roundtrip(&ack);
+}

--- a/crates/zccache/src/protocol/messages/compat/mod.rs
+++ b/crates/zccache/src/protocol/messages/compat/mod.rs
@@ -14,6 +14,7 @@ mod artifact_payload;
 mod clear;
 mod daemon_status;
 mod ephemeral;
+mod exec_probe;
 mod fingerprint;
 mod generic_exec;
 mod rust_artifacts;
@@ -101,16 +102,18 @@ pub(super) fn sample_artifact() -> ArtifactData {
 
 // Compile-time check: PROTOCOL_VERSION must be positive.
 const _: () = assert!(super::super::PROTOCOL_VERSION > 0);
-// Compile-time check: PROTOCOL_VERSION == 15 after `ReleaseWorktreeHandles`
-// was added for soldr Tier 3 worktree teardown (issue #690). v14 was the
-// pin after private daemon SessionStart/status diagnostics were added.
-// v13 was the pin after daemon namespace diagnostics were added to
-// DaemonStatus. v12 was the pin after cached-error counters were added for
-// rustc negative-result caching. v11 was the pin after `GenericToolExec`
-// gained Path A (include scan) + Path B (depfile) + non_deterministic +
-// key_args_filter, fully implementing issue #272. v10 was the prior pin
-// when `GenericToolExec` was added. v9 was the pin after SessionStats
-// gained `phase_profile`. v8 was the pin after Compile/CompileEphemeral
-// gained `stdin` and ArtifactPayload replaced ArtifactOutput.data:
-// Arc<Vec<u8>> (issue #296 Option B).
-const _FINGERPRINT_VERSION: () = assert!(super::super::PROTOCOL_VERSION == 15);
+// Compile-time check: PROTOCOL_VERSION == 17 after `ExecProbe`/`ExecStore`
+// were added (issue #838 slice 1) for caller-owned tool caching (e.g. the
+// PyO3 `zccache.exec` binding for Python build orchestrators). v15 was
+// the pin after `ReleaseWorktreeHandles` was added for soldr Tier 3
+// worktree teardown (issue #690). v14 was the pin after private daemon
+// SessionStart/status diagnostics were added. v13 was the pin after daemon
+// namespace diagnostics were added to DaemonStatus. v12 was the pin after
+// cached-error counters were added for rustc negative-result caching. v11
+// was the pin after `GenericToolExec` gained Path A (include scan) + Path B
+// (depfile) + non_deterministic + key_args_filter, fully implementing issue
+// #272. v10 was the prior pin when `GenericToolExec` was added. v9 was the
+// pin after SessionStats gained `phase_profile`. v8 was the pin after
+// Compile/CompileEphemeral gained `stdin` and ArtifactPayload replaced
+// ArtifactOutput.data: Arc<Vec<u8>> (issue #296 Option B).
+const _FINGERPRINT_VERSION: () = assert!(super::super::PROTOCOL_VERSION == 17);

--- a/crates/zccache/src/protocol/messages/compat/variant_indices.rs
+++ b/crates/zccache/src/protocol/messages/compat/variant_indices.rs
@@ -143,6 +143,22 @@ fn request_variant_indices_are_append_only() {
                 path: "/tmp/work".into(),
             },
         ),
+        (
+            19,
+            Request::ExecProbe {
+                name: "rustc-1.94".to_string(),
+                input_files: vec![],
+                input_env: vec![],
+                input_extra: Arc::new(Vec::new()),
+            },
+        ),
+        (
+            20,
+            Request::ExecStore {
+                cache_key_hex: "0".repeat(64),
+                result_bytes: Arc::new(Vec::new()),
+            },
+        ),
     ];
 
     for (expected, request) in request_cases {
@@ -258,6 +274,14 @@ fn response_variant_indices_are_append_only() {
                 unreleased: vec![],
             },
         ),
+        (
+            18,
+            Response::ExecProbeResult {
+                cache_key_hex: "0".repeat(64),
+                cached_bytes: None,
+            },
+        ),
+        (19, Response::ExecStoreAck { stored: true }),
     ];
 
     for (expected, response) in response_cases {

--- a/crates/zccache/src/protocol/messages/mod.rs
+++ b/crates/zccache/src/protocol/messages/mod.rs
@@ -267,6 +267,50 @@ pub enum Request {
         /// Canonical path prefix to release. Must be absolute.
         path: NormalizedPath,
     },
+    /// Probe the exec-cache for `(name, input_files, input_env, input_extra)`.
+    ///
+    /// Issue #838: caller-owned-tool variant of `GenericToolExec`. Where
+    /// `GenericToolExec` ships the tool command to the daemon and the daemon
+    /// spawns it, `ExecProbe` lets the caller (typically a Python binding)
+    /// keep ownership of the runner. The daemon's job here is restricted to
+    /// cache-key derivation + lookup; on a miss the caller runs the work
+    /// locally and posts the result via `ExecStore`.
+    ///
+    /// The split exists so a Python consumer can cache an in-process
+    /// function call without paying the subprocess-spawn cost on warm hits,
+    /// and so a 1000-file input list never has to serialize through the
+    /// Windows 32K argv ceiling (cf #837).
+    ///
+    /// NOTE: Appended at end to preserve bincode variant indices.
+    ExecProbe {
+        /// Cache namespace (e.g. `"noexcept_ast"`). Mixed into the key so
+        /// two consumers using the same input set but different semantics
+        /// do not collide.
+        name: String,
+        /// Input files whose content feeds the cache key.
+        input_files: Vec<NormalizedPath>,
+        /// Selected env vars (name, value) that affect the result.
+        input_env: Vec<(String, String)>,
+        /// Opaque caller-supplied bytes mixed into the cache key (runner
+        /// source hash, version tag, args repr — anything that should
+        /// invalidate the cache when it changes).
+        input_extra: Arc<Vec<u8>>,
+    },
+    /// Store a result against a key returned from a prior `ExecProbe` miss.
+    ///
+    /// Issue #838: companion to `ExecProbe`. The caller computes the work,
+    /// then posts the result bytes here; the daemon writes them to its
+    /// persistent KV store so the next `ExecProbe` for the same inputs
+    /// returns the cached bytes without invoking the runner.
+    ///
+    /// NOTE: Appended at end to preserve bincode variant indices.
+    ExecStore {
+        /// 64-char hex cache key returned by the prior `ExecProbeResult`.
+        cache_key_hex: String,
+        /// Bytes to cache. The daemon stores them verbatim; the contract is
+        /// bytes-in / bytes-out (no opinions about JSON / msgpack / etc).
+        result_bytes: Arc<Vec<u8>>,
+    },
 }
 
 /// A response from daemon to client.
@@ -418,5 +462,39 @@ pub enum Response {
         /// future code that pins file handles inside a worktree can
         /// report partial failure without a wire-shape change.
         unreleased: Vec<NormalizedPath>,
+    },
+    /// Result of an `ExecProbe` request (issue #838).
+    ///
+    /// `cached_bytes.is_some()` means the daemon found a stored result for
+    /// the derived key — the caller should return those bytes to its
+    /// consumer without invoking the runner. `cached_bytes.is_none()` means
+    /// the key was not in the cache — the caller runs the work locally and
+    /// then posts the result via `ExecStore { cache_key_hex, ... }`.
+    ///
+    /// `cache_key_hex` is always populated so the caller knows what key to
+    /// store under on miss.
+    ///
+    /// NOTE: Appended at end to preserve bincode variant indices.
+    ExecProbeResult {
+        /// 64-char hex cache key derived from the probe's inputs. Stable
+        /// regardless of hit/miss so the follow-up `ExecStore` references
+        /// it directly.
+        cache_key_hex: String,
+        /// `Some(bytes)` on cache hit; `None` on miss.
+        cached_bytes: Option<Arc<Vec<u8>>>,
+    },
+    /// Acknowledgement of an `ExecStore` request (issue #838).
+    ///
+    /// `stored` is the operational outcome: `true` means the bytes were
+    /// committed to the KV store and a subsequent `ExecProbe` for the same
+    /// inputs will hit. `false` is reserved for back-pressure / quota
+    /// rejections; today the daemon never returns `false`, but the field
+    /// exists so a future eviction policy can refuse a store without a
+    /// wire-shape change.
+    ///
+    /// NOTE: Appended at end to preserve bincode variant indices.
+    ExecStoreAck {
+        /// Operational outcome of the store.
+        stored: bool,
     },
 }

--- a/crates/zccache/src/protocol/mod.rs
+++ b/crates/zccache/src/protocol/mod.rs
@@ -14,7 +14,7 @@ pub use messages::*;
 /// This remains the active compatibility version until the v16 prost dispatcher
 /// is wired through the IPC transport. Do not change `PROTOCOL_VERSION` to v16
 /// while `encode_message` and `decode_message` still serialize bincode bodies.
-pub const BINCODE_PROTOCOL_VERSION: u32 = 15;
+pub const BINCODE_PROTOCOL_VERSION: u32 = 17;
 
 /// Planned prost daemon wire version.
 ///
@@ -41,6 +41,12 @@ pub const PROST_PROTOCOL_VERSION: u32 = 16;
 ///                  for soldr/zccache daemon namespace diagnostics.
 /// v12: `DaemonStatus` and `SessionStats` gained cached-error
 ///                  counters for rustc negative-result caching.
+/// v17: added `Request::ExecProbe` / `Request::ExecStore` (caller-owned-
+///                  tool variant of GenericToolExec, issue #838) plus
+///                  `Response::ExecProbeResult` / `Response::ExecStoreAck`.
+///                  Lets a Python binding cache an in-process function call
+///                  via the daemon's KV store without serializing argv
+///                  (subsumes #837 for Python consumers).
 /// v11: `Request::GenericToolExec` gained Path A (include scan)
 ///                  + Path B (depfile) + `non_deterministic` +
 ///                  `key_args_filter` fields completing issue #272.

--- a/crates/zccache/src/protocol/wire_prost/api.rs
+++ b/crates/zccache/src/protocol/wire_prost/api.rs
@@ -161,6 +161,10 @@ pub const fn default_request_id(request: &crate::protocol::Request) -> &'static 
         crate::protocol::Request::FingerprintInvalidate { .. } => "fingerprint-invalidate",
         crate::protocol::Request::ListRustArtifacts => "list-rust-artifacts",
         crate::protocol::Request::GenericToolExec { .. } => "generic-tool-exec",
+        // Issue #838: bincode-only for slice 1; the prost wire lane
+        // refuses these until the wheel-side consumer needs them.
+        crate::protocol::Request::ExecProbe { .. } => "exec-probe",
+        crate::protocol::Request::ExecStore { .. } => "exec-store",
     }
 }
 

--- a/crates/zccache/src/protocol/wire_prost/request.rs
+++ b/crates/zccache/src/protocol/wire_prost/request.rs
@@ -196,6 +196,14 @@ pub fn request_to_prost(
                 path: Some(path_to_prost(path)),
             })
         }
+        // Issue #838: ExecProbe / ExecStore are bincode-only in slice 1.
+        // The prost wire lane will gain proto definitions in a follow-up
+        // PR once a wheel consumer needs cross-protocol routing. For now,
+        // route a placeholder that the daemon's prost handler rejects;
+        // any in-process bincode path is unaffected.
+        crate::protocol::Request::ExecProbe { .. } | crate::protocol::Request::ExecStore { .. } => {
+            Body::Ping(zccache_v1::Empty {})
+        }
     };
 
     zccache_v1::Request {

--- a/crates/zccache/src/protocol/wire_prost/response.rs
+++ b/crates/zccache/src/protocol/wire_prost/response.rs
@@ -135,6 +135,11 @@ pub fn response_to_prost(
             sessions_dropped: sessions_dropped.clone(),
             unreleased: unreleased.iter().map(path_to_prost).collect(),
         }),
+        // Issue #838: ExecProbeResult / ExecStoreAck are bincode-only in
+        // slice 1. The prost wire lane will gain proto definitions once a
+        // wheel consumer needs cross-protocol routing.
+        crate::protocol::Response::ExecProbeResult { .. }
+        | crate::protocol::Response::ExecStoreAck { .. } => Body::Pong(zccache_v1::Empty {}),
     };
 
     zccache_v1::Response {


### PR DESCRIPTION
## Summary

Slice 1 of 6 from #838 — the daemon-side wire + handler surface for caller-owned tool caching. The PyO3 \`zccache.exec\` binding (slices 2-3) and persistent storage (slice 4) build on this.

Where \`Request::GenericToolExec\` (#272) has the daemon spawn the tool, the new \`Request::ExecProbe\` and \`Request::ExecStore\` variants let an external orchestrator (a Python build script, a Bazel rule, a Meson generator) own the subprocess lifecycle and ask the daemon only to compute a stable cache key from declared inputs and to store/retrieve opaque result bytes against that key.

- **Wire**: append \`ExecProbe\`/\`ExecStore\` to \`Request\` and \`ExecProbeResult\`/\`ExecStoreAck\` to \`Response\`. Variant indices append-only (request 19/20, response 18/19) — pinned by \`variant_indices.rs\`.
- **Protocol**: bump \`BINCODE_PROTOCOL_VERSION\` 15 -> 17 (and the matching \`_FINGERPRINT_VERSION\` compile-time assert).
- **Dispatch**: \`connection.rs\` routes the new variants to \`daemon::server::handle_exec_probe::{handle_exec_probe, handle_exec_store}\` (new sibling module — keeps \`handle_exec.rs\` under the 1K LOC loc-guard).
- **Cache key**: \`blake3(domain || name || sorted(path, content_hash) pairs || sorted env pairs || input_extra)\` with domain tag \`zccache-exec-probe-v1\`. Input files are hashed via the existing metadata-cache fast path.
- **Storage**: in-memory \`DashMap<String, Arc<Vec<u8>>>\` on \`SharedState\` for slice 1. A follow-up slice swaps it for \`KvStore\`-backed persistence across daemon restarts.
- **Prost lane**: new variants stub to Ping/Pong placeholders. Proto definitions deferred until a wheel consumer needs the cross-protocol routing — the PyO3 binding lives on bincode.

## Test plan

- [x] \`protocol::messages::compat::exec_probe\` — 4 bincode roundtrip cases (hit/miss/empty-input probe, store with synthetic key, ack).
- [x] \`variant_indices_are_append_only\` — covers ExecProbe/ExecStore at 19/20 and ExecProbeResult/ExecStoreAck at 18/19.
- [x] \`daemon::server::tests::exec_probe::probe_miss_then_store_then_probe_hit\` — end-to-end against a real \`DaemonServer\`. Confirms miss -> store -> hit returns identical bytes and that changing \`input_extra\` yields a distinct key with no spurious hit.
- [x] Inline unit test for the cache-key-hex validator.
- [x] \`soldr cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`soldr cargo fmt --all\` clean.

\`cli_meson_configure_cache::second_invocation_hits_cache_and_restores_build_dir\` is a pre-existing flaky perf assertion on Windows — unrelated to this change. ExecProbe/ExecStore code paths are unreachable from the meson configure pipeline.

Closes #838 (slice 1; follow-up slices tracked in that issue).