### PR TITLE
fix(deps): swap file:// running-process pin to https git+rev — unblocks CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "running-process"
 version = "4.5.5"
-source = "git+file:///C:/Users/niteris/dev/zccache/.extern-repos/running-process#baf2d60b73a14e375771231d73a5d9584c7d8b0d"
+source = "git+https://github.com/zackees/running-process?rev=ca0a7ad219b16af0b01f1055c2970acc1dca3e2c#ca0a7ad219b16af0b01f1055c2970acc1dca3e2c"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,15 +72,15 @@ zccache-fingerprint = { path = "crates/zccache-fingerprint" }
 notify = { path = "vendor/notify" }
 # Cross-repo dev pin per zccache#842 (broker-v2 burn-down): the
 # upstream issues running-process#517 / #518 / #519 are being fixed
-# locally in `.extern-repos/running-process` so zccache can compile +
-# test against the patched copy before upstream cuts a new release.
-# Uses a file:// git URL so running-process keeps its own workspace
-# context (a path-dep would collapse it into zccache's workspace and
-# miss inherited deps like `rusqlite`). Iteration cycle: edit in
-# `.extern-repos/running-process`, commit there, then
-# `soldr cargo update -p running-process` in zccache. Revert to the
-# published version (4.5.6+) once the fixes ship upstream.
-running-process = { git = "file:///C:/Users/niteris/dev/zccache/.extern-repos/running-process" }
+# on the `fix/broker-v2-hardening-rp517-518-519` branch tracked in
+# zackees/running-process PR #520. Pin to a public git+rev on that
+# branch so CI runners (which don't have the maintainer's
+# `.extern-repos/` clone) can fetch the same source. Iteration cycle:
+# edit in `.extern-repos/running-process`, push to the PR branch,
+# bump this `rev` to the new tip, `soldr cargo update -p running-process`
+# in zccache. Revert to the published version (4.5.6+) once
+# running-process PR #520 merges and the next release ships.
+running-process = { git = "https://github.com/zackees/running-process", rev = "ca0a7ad219b16af0b01f1055c2970acc1dca3e2c" }
 
 [workspace.metadata.dylint]
 libraries = [{ path = "dylints/*" }]


### PR DESCRIPTION
## Summary

Unblocks main CI. Since the cross-repo dev pin in #842 landed a `file:///C:/Users/niteris/dev/zccache/.extern-repos/running-process` patch into `[patch.crates-io]`, every CI runner that doesn't have the maintainer's local clone has failed at \"Build integration test binaries\" with:

```
Updating git repository \`file:///C:/Users/niteris/dev/zccache/.extern-repos/running-process\`
Unable to update file:///C:/Users/niteris/dev/zccache/.extern-repos/running-process#baf2d60b
##[error]Process completed with exit code 101.
```

Visible on the latest main push (PR #850's merge run [27879118164](https://github.com/zackees/zccache/actions/runs/27879118164)): Integration / Perf Guard / Linux / macOS / Windows all red at that exact step.

## Fix

Swap the file:// pin for the equivalent public git+rev on running-process's `fix/broker-v2-hardening-rp517-518-519` branch (zackees/running-process#520).

```diff
-running-process = { git = \"file:///C:/Users/niteris/dev/zccache/.extern-repos/running-process\" }
+running-process = { git = \"https://github.com/zackees/running-process\", rev = \"ca0a7ad219b16af0b01f1055c2970acc1dca3e2c\" }
```

The pinned commit `ca0a7ad2` is the tip after the trivial clippy `manual_flatten` fix on the PR branch (so running-process PR #520 itself is also unblocked on the lint front).

## Iteration cycle is unchanged for local dev

The maintainer's `.extern-repos/running-process` checkout still works — bump the `rev` to the new branch tip after pushing each upstream commit. The only difference is that CI now fetches from github instead of the local path.

## Reverts cleanly

Once upstream PR #520 merges and a 4.5.6+ running-process release ships, this patch entry can be deleted entirely (the published 4.5.5 line in `[workspace.dependencies]` takes over).

## Test plan

- [x] `soldr cargo update -p running-process` — resolves to `ca0a7ad2` from github.
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` clean.