### PR TITLE
chore(deps): bump running-process pin to 82615fa (post-slice-22-merge)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "running-process"
 version = "4.5.5"
-source = "git+https://github.com/zackees/running-process?rev=502040adb1ce8366d3042edd80c48caac9ff7968#502040adb1ce8366d3042edd80c48caac9ff7968"
+source = "git+https://github.com/zackees/running-process?rev=82615fa08b1db2b24d598fbcece40f869435ecf6#82615fa08b1db2b24d598fbcece40f869435ecf6"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ notify = { path = "vendor/notify" }
 # (buried `details: Box<Refused>` instead of top-level `retry_after_ms`)
 # which `BrokerRefusal::from_brokerv2_error` no longer compiles against.
 # Revert to the published version line once running-process cuts 4.5.6+.
-running-process = { git = "https://github.com/zackees/running-process", rev = "502040adb1ce8366d3042edd80c48caac9ff7968" }
+running-process = { git = "https://github.com/zackees/running-process", rev = "82615fa08b1db2b24d598fbcece40f869435ecf6" }
 
 [workspace.metadata.dylint]
 libraries = [{ path = "dylints/*" }]

--- a/crates/zccache/tests/protocol_v2_roundtrip_test.rs
+++ b/crates/zccache/tests/protocol_v2_roundtrip_test.rs
@@ -36,6 +36,7 @@ fn protocol_v2_service_definition_round_trips_without_http() {
     let original = ServiceDefinition {
         service_name: "zccache".to_owned(),
         http_server: None,
+        ..Default::default()
     };
 
     let bytes = original.encode_to_vec();
@@ -55,6 +56,7 @@ fn protocol_v2_service_definition_round_trips_with_http_capability() {
             health_path: "/health".to_owned(),
             display_name: "zccache status".to_owned(),
         }),
+        ..Default::default()
     };
 
     let bytes = original.encode_to_vec();
@@ -86,6 +88,7 @@ fn service_definition_decode_tolerates_unknown_future_field() {
     let mut bytes = ServiceDefinition {
         service_name: "zccache".to_owned(),
         http_server: None,
+        ..Default::default()
     }
     .encode_to_vec();
     bytes.extend_from_slice(&[0x9A, 0x06, 10]);
@@ -111,6 +114,7 @@ fn service_definition_decode_rejects_truncated_input() {
             health_path: "/health".to_owned(),
             display_name: "zccache status".to_owned(),
         }),
+        ..Default::default()
     }
     .encode_to_vec();
     bytes.truncate(6);


### PR DESCRIPTION
## Summary

Picks up zackees/running-process PR #521 (slice 22 of zccache#782), which extends `protocol_v2::ServiceDefinition` with the v1 launcher / isolation fields zccache needs to migrate `cli/commands/service_definition.rs` over to v2 in the upcoming slice 21 PR.

## What's new in the upstream commit

The v2 envelope now carries all v1 launcher/isolation fields (numbers 2–8 mirror v1's for diff legibility):

- `binary_path` (2)
- `isolation` + `BrokerIsolation` enum (3)
- `explicit_instance` (4)
- `per_version_binary_dir` (5)
- `min_version` (6)
- `version_allow_list` (7)
- `labels` (8)

The `http_server` field stays at 10. New v2-only fields grow upward from there.

## zccache-side compile fix

zccache's pre-#850 `protocol_v2_roundtrip_test` struct literals only named `service_name` + `http_server`. With the wider schema those become E0063 misses. Added `..Default::default()` to the 4 literal sites — keeps each test focused on the fields it actually asserts on while letting the new fields default to zero values.

## Test plan

- [x] `soldr cargo update -p running-process` → resolves to `82615fa`.
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` clean.
- [ ] CI confirms the test suite still passes (local sandbox daemon hosed; CI is ground truth).

## What unblocks

zccache#782 slice 21 (`service_definition.rs` migration) now has the upstream schema it needs. The remaining gates are upstream v2 `ServiceDefinitionBuilder` + `service_definition_dir` + `Loader` helpers (separate slice — zccache can implement its own thin local helpers in the meantime).
