### PR TITLE
feat(servicedef): v2 dual-write alongside v1 (slice 21 of #782)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "running-process"
 version = "4.5.5"
-source = "git+https://github.com/zackees/running-process?rev=82615fa08b1db2b24d598fbcece40f869435ecf6#82615fa08b1db2b24d598fbcece40f869435ecf6"
+source = "git+https://github.com/zackees/running-process?rev=7b08279eb74cedae0d376fc41866f3ea7fbeeb63#7b08279eb74cedae0d376fc41866f3ea7fbeeb63"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ notify = { path = "vendor/notify" }
 # (buried `details: Box<Refused>` instead of top-level `retry_after_ms`)
 # which `BrokerRefusal::from_brokerv2_error` no longer compiles against.
 # Revert to the published version line once running-process cuts 4.5.6+.
-running-process = { git = "https://github.com/zackees/running-process", rev = "82615fa08b1db2b24d598fbcece40f869435ecf6" }
+running-process = { git = "https://github.com/zackees/running-process", rev = "7b08279eb74cedae0d376fc41866f3ea7fbeeb63" }
 
 [workspace.metadata.dylint]
 libraries = [{ path = "dylints/*" }]

--- a/crates/zccache/src/cli/commands/service_definition.rs
+++ b/crates/zccache/src/cli/commands/service_definition.rs
@@ -7,9 +7,30 @@
 //! zccache daemon. This does not change how the daemon is spawned or how
 //! clients connect — the broker connect lane stays opt-in
 //! (`ZCCACHE_BROKER_CONNECT=1`, see `crate::ipc::broker`).
+//!
+//! ## v2 dual-write (slice 21 of zccache#782)
+//!
+//! As of running-process PR #522 a v2 `.servicedef.v2` write path
+//! exists upstream (`broker::protocol_v2::ServiceDefinitionBuilder` +
+//! `write_service_definition_v2`). To stay reachable from *both* v1
+//! and v2 brokers during the rollout, this module now writes BOTH:
+//!
+//! - `zccache.servicedef` — v1 protobuf, primary, read by today's
+//!   v1 broker. STAYS until v2 broker has a loader (separate
+//!   running-process slice) AND zccache's `ipc/broker.rs` migrates
+//!   off v1's `client::*` surface (zccache#782 slice 25).
+//! - `zccache.servicedef.v2` — v2 protobuf, secondary, read by the
+//!   v2 broker scaffold (loader still in flight). Carries the same
+//!   semantic identity (\"shared broker, pinned to this binary +
+//!   version range\") so a v2 broker finds zccache at the same
+//!   identity v1 brokers know.
+//!
+//! When zccache flips slice 25 (delete v1 broker surface) the v1
+//! write goes away with it.
 
 use running_process::broker::builders::ServiceDefinitionBuilder;
 use running_process::broker::protocol::ServiceDefinition;
+use running_process::broker::protocol_v2;
 use running_process::broker::server::service_definition_dir;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -20,10 +41,52 @@ use std::process::ExitCode;
 pub(crate) const ZCCACHE_SERVICE_NAME: &str = "zccache";
 
 /// An installed service definition: where it was written and what it says.
+///
+/// `path` is the v1 file location (primary during the v1→v2 rollout).
+/// `v2_path` is the v2 file location (written alongside via dual-write
+/// per the module docstring); `None` indicates the v2 write was
+/// skipped or failed without aborting the v1 install — the rollout
+/// keeps v1 primary so a v2 write failure does not block daemon
+/// startup. zccache#782 slice 25 will collapse this back to a single
+/// path once v1 goes away.
 #[derive(Debug, Clone)]
 pub(crate) struct InstalledServiceDefinition {
     pub(crate) path: PathBuf,
     pub(crate) definition: ServiceDefinition,
+    pub(crate) v2_path: Option<PathBuf>,
+}
+
+/// Build the zccache daemon's v2 ServiceDefinition counterpart.
+///
+/// Mirrors [`zccache_service_definition`]'s v1 shape using the v2
+/// `protocol_v2::ServiceDefinitionBuilder`. The two share an identity
+/// (service_name + binary_path + isolation + version pin + labels) so
+/// a v2 broker discovers the same zccache daemon a v1 broker would.
+fn zccache_service_definition_v2(
+    daemon_binary: &Path,
+) -> io::Result<protocol_v2::ServiceDefinition> {
+    let binary = std::fs::canonicalize(daemon_binary)?;
+    let binary_dir = binary.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "zccache-daemon binary path has no parent directory",
+        )
+    })?;
+
+    Ok(
+        protocol_v2::ServiceDefinitionBuilder::shared_broker(
+            ZCCACHE_SERVICE_NAME,
+            binary.display().to_string(),
+        )
+        .per_version_binary_dir(binary_dir.display().to_string())
+        .min_version(crate::core::VERSION)
+        .version_allow_list([crate::core::VERSION])
+        .label("vendor", "zackees")
+        .label("package", "zccache")
+        .label("consumer", "zccache")
+        .label("running-process-tracker", "zackees/running-process#435")
+        .build(),
+    )
 }
 
 /// Build the zccache daemon service definition for the given daemon binary.
@@ -92,7 +155,32 @@ pub(crate) fn install_service_definition_to_dir(
             .install_in(service_root)
             .map_err(|err| io::Error::other(err.to_string()))?;
 
-    Ok(InstalledServiceDefinition { path, definition })
+    // Dual-write: also install the v2 ServiceDefinition counterpart so a
+    // v2 broker (with loader) finds zccache at the same identity. v2
+    // failures are reported but do NOT abort the v1 install — v1 is
+    // primary during the rollout. zccache#782 slice 25 collapses this
+    // to v2-only.
+    let v2_path = match zccache_service_definition_v2(daemon_binary) {
+        Ok(def_v2) => match protocol_v2::write_service_definition_v2(service_root, &def_v2) {
+            Ok(path) => Some(path),
+            Err(err) => {
+                tracing::warn!(
+                    "v2 ServiceDefinition install failed (non-fatal during rollout): {err}"
+                );
+                None
+            }
+        },
+        Err(err) => {
+            tracing::warn!("v2 ServiceDefinition build failed (non-fatal during rollout): {err}");
+            None
+        }
+    };
+
+    Ok(InstalledServiceDefinition {
+        path,
+        definition,
+        v2_path,
+    })
 }
 
 /// `zccache install-servicedef [--daemon-binary <path>] [--dir <path>]`
@@ -125,6 +213,14 @@ pub(crate) fn run_install_servicedef(
                 installed.definition.service_name,
                 installed.definition.binary_path,
             );
+            match &installed.v2_path {
+                Some(v2_path) => {
+                    println!("dual-write v2: {}", v2_path.display());
+                }
+                None => {
+                    println!("dual-write v2: skipped (see daemon log for cause)");
+                }
+            }
             ExitCode::SUCCESS
         }
         Err(err) => {
@@ -189,6 +285,51 @@ mod tests {
             .load("zccache")
             .expect("load service definition");
         assert_eq!(loaded, installed.definition);
+    }
+
+    /// Slice 21 of zccache#782: dual-write also produces a v2
+    /// `zccache.servicedef.v2` file alongside the v1 file, carrying
+    /// the same service_name + binary_path + isolation + version pin.
+    /// Pins that a v2 broker would discover the same zccache identity
+    /// once it has a loader.
+    #[test]
+    fn install_also_writes_v2_servicedef() {
+        use prost::Message;
+
+        let temp = TempDir::new().expect("tempdir");
+        let service_root = temp.path().join("services");
+        let daemon = fake_daemon_binary(temp.path());
+
+        let installed = install_service_definition_to_dir(&service_root, &daemon)
+            .expect("install service definition");
+
+        let v2_path = installed.v2_path.expect("v2 path must be present");
+        assert_eq!(v2_path, service_root.join("zccache.servicedef.v2"));
+
+        let bytes = std::fs::read(&v2_path).expect("read v2 file");
+        let decoded = protocol_v2::ServiceDefinition::decode(bytes.as_slice())
+            .expect("v2 ServiceDefinition decodes");
+
+        assert_eq!(decoded.service_name, "zccache");
+        assert_eq!(decoded.binary_path, installed.definition.binary_path);
+        assert_eq!(
+            decoded.isolation,
+            protocol_v2::BrokerIsolation::SharedBroker as i32,
+            "v2 must mirror v1's shared_broker isolation"
+        );
+        assert_eq!(decoded.min_version, crate::core::VERSION);
+        assert_eq!(decoded.version_allow_list, vec![crate::core::VERSION]);
+        assert_eq!(
+            decoded.labels.get("consumer").map(String::as_str),
+            Some("zccache")
+        );
+        assert_eq!(
+            decoded
+                .labels
+                .get("running-process-tracker")
+                .map(String::as_str),
+            Some("zackees/running-process#435")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

zccache#782 slice 21 — kicks off the v1 → v2 ServiceDefinition migration without breaking v1 brokers.

`cli/commands/service_definition.rs` now writes BOTH:

- **`zccache.servicedef`** (v1 protobuf, primary) — today's broker reads this; stays until zccache#782 slice 25 deletes v1.
- **`zccache.servicedef.v2`** (v2 protobuf, secondary) — a v2 broker with a loader reads this once that loader lands upstream.

Both files carry the same identity: `service_name`, `binary_path`, `shared_broker` isolation, `per_version_binary_dir`, `min_version`, `version_allow_list`, and the standard label set.

## Failure semantics

v2 failures are warned via tracing, not fatal. v1 is the only mandatory write during rollout, so a v2 build/write error never blocks daemon startup or `zccache install-servicedef`. `InstalledServiceDefinition` gained a `v2_path: Option<PathBuf>` field so callers can observe whether the secondary write actually happened.

`zccache install-servicedef` now prints both paths on success:

```
installed /path/to/zccache.servicedef (service `zccache`, daemon `/usr/bin/zccache-daemon`)
dual-write v2: /path/to/zccache.servicedef.v2
```

## Pin bump bundled

`82615fa` → `7b08279` picks up zackees/running-process PR #522 which shipped the v2 `protocol_v2::io` surface (`ServiceDefinitionBuilder`, `write_service_definition_v2`, `service_definition_dir_v2`). Without it, this PR wouldn't compile.

## Tests

- **`install_writes_loader_compatible_protobuf`** — unchanged; v1 round-trip via the v1 loader.
- **`install_also_writes_v2_servicedef`** (new) — reads `zccache.servicedef.v2` from disk, decodes it with prost, asserts every identity-shared field matches the v1 install (`service_name`, `binary_path`, `isolation`, `min_version`, `version_allow_list`, `consumer` label, `running-process-tracker` label).

## Forward-compat

Brokers that only know v1 keep working — they ignore unfamiliar `.servicedef.v2` files. Brokers that know v2 (once their loader lands) start finding zccache at the same logical identity v1 brokers already see.

## What this does NOT do

Does not delete any v1 reference yet. The deletion happens in zccache#782 slice 25 (delete v1 broker path) after the v2 broker has a loader AND zccache's `ipc/broker.rs` migrates off v1's `client::*` surface. This PR is the safe additive prerequisite for that.

## Test plan

- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean.

Closes zccache#782 slice 21 (line-by-line under Phase C — service-definition + manifest surfaces).
