### PR TITLE
feat(manifest): v2 cache-manifest dual-write alongside v1 (slice 23 of #782)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,8 +2444,8 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.5.5"
-source = "git+https://github.com/zackees/running-process?rev=7b08279eb74cedae0d376fc41866f3ea7fbeeb63#7b08279eb74cedae0d376fc41866f3ea7fbeeb63"
+version = "4.5.6"
+source = "git+https://github.com/zackees/running-process?rev=2ee3c586fc3518498c78ea8ea4b839cc84613ce6#2ee3c586fc3518498c78ea8ea4b839cc84613ce6"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ notify = { path = "vendor/notify" }
 # (buried `details: Box<Refused>` instead of top-level `retry_after_ms`)
 # which `BrokerRefusal::from_brokerv2_error` no longer compiles against.
 # Revert to the published version line once running-process cuts 4.5.6+.
-running-process = { git = "https://github.com/zackees/running-process", rev = "7b08279eb74cedae0d376fc41866f3ea7fbeeb63" }
+running-process = { git = "https://github.com/zackees/running-process", rev = "2ee3c586fc3518498c78ea8ea4b839cc84613ce6" }
 
 [workspace.metadata.dylint]
 libraries = [{ path = "dylints/*" }]

--- a/crates/zccache/src/ipc/manifest.rs
+++ b/crates/zccache/src/ipc/manifest.rs
@@ -24,11 +24,26 @@
 //! failure is logged and ignored, exactly like the `BackendHandle` identity
 //! write. `RUNNING_PROCESS_DISABLE=1` skips publishing entirely so the direct
 //! bincode path stays byte-for-byte the pre-adoption behavior.
+//!
+//! ## v2 dual-write (slice 23 of zccache#782)
+//!
+//! As of running-process PR #525 + #526 a v2 `CacheManifestBuilder` +
+//! `write_to_central_v2` surface exists upstream
+//! (`broker::protocol_v2::manifest_io`) with wire values that mirror
+//! v1's `CacheRootKind` exactly. To stay reachable from both v1 and v2
+//! brokers during the rollout, [`publish_manifest`] now writes BOTH
+//! `zccache-<ver>.pb` and `zccache-<ver>.v2.pb` into the central
+//! registry. Each carries the same service identity + cache-root list;
+//! the v2 file is read by the v2 broker scaffold (loader still in
+//! flight). v2 failures are logged but do NOT abort the v1 write —
+//! v1 stays primary during rollout. zccache#782 slice 25 collapses
+//! this to v2-only once v1 retires.
 
 use std::path::{Path, PathBuf};
 
 use running_process::broker::builders::CacheManifestBuilder;
 use running_process::broker::protocol::CacheRootKind;
+use running_process::broker::protocol_v2;
 
 use crate::core::NormalizedPath;
 
@@ -66,27 +81,79 @@ pub fn build_manifest_builder(cache_dir: &NormalizedPath) -> CacheManifestBuilde
 /// Seal and write the zccache cache manifest into the running-process central
 /// registry. Best-effort: returns the written path on success.
 ///
+/// Slice 23 of zccache#782: also dual-writes a v2 manifest
+/// (`zccache-<ver>.v2.pb`) into the same registry. The v2 write is
+/// best-effort and never blocks the v1 path — a v2 failure is logged
+/// and ignored.
+///
 /// Honors `RUNNING_PROCESS_DISABLE=1` (returns `None` without writing).
 pub fn publish_manifest(cache_dir: &NormalizedPath) -> Option<PathBuf> {
     if super::running_process_disabled() {
         return None;
     }
-    match build_manifest_builder(cache_dir).publish() {
+    let v1_path = match build_manifest_builder(cache_dir).publish() {
         Ok(path) => Some(path),
         Err(err) => {
             tracing::warn!(error = %err, "failed to publish running-process cache manifest");
             None
         }
+    };
+
+    // Dual-write v2 alongside v1. The v2 write reuses v1's
+    // `central_registry_dir()` (mirrored upstream as
+    // `central_registry_dir_v2()`), so a single directory carries
+    // both. v2 failures are logged + ignored.
+    if let Err(err) = build_manifest_builder_v2(cache_dir).publish() {
+        tracing::warn!(
+            error = %err,
+            "v2 manifest dual-write failed (non-fatal during rollout)"
+        );
     }
+
+    v1_path
 }
 
 /// Seal and write the manifest into an explicit registry dir (tests, custom
 /// layouts). Bypasses the disable hatch so tests stay deterministic.
+///
+/// Returns the v1 path; the v2 file is written alongside as a side
+/// effect (callers that need both can locate the v2 file at
+/// `<v1_path.with_extension("v2.pb")>`).
 pub fn publish_manifest_in(
     registry_dir: &Path,
     cache_dir: &NormalizedPath,
 ) -> Result<PathBuf, running_process::broker::manifest::ManifestError> {
-    build_manifest_builder(cache_dir).publish_in(registry_dir)
+    let v1_path = build_manifest_builder(cache_dir).publish_in(registry_dir)?;
+    // v2 dual-write — surface the v2 error here so tests can pin
+    // both write paths. Production [`publish_manifest`] swallows the
+    // v2 error; tests want the louder failure mode.
+    let _v2_path = build_manifest_builder_v2(cache_dir).publish_in(registry_dir)?;
+    Ok(v1_path)
+}
+
+/// Slice 23 of zccache#782: build a v2 CacheManifest mirroring the v1
+/// shape from [`build_manifest_builder`]. Shares service identity,
+/// version, broker_instance, and the full cache-root list — every
+/// `CacheRootKind` value is identical to v1 (the upstream `as i32`
+/// cast is wire-compatible per #526).
+#[must_use]
+pub fn build_manifest_builder_v2(cache_dir: &NormalizedPath) -> protocol_v2::CacheManifestBuilder {
+    use running_process::broker::protocol_v2::CacheRootKind as V2;
+    let index_dir = cache_dir.join("depgraph");
+    let log_dir = cache_dir.join("logs");
+    protocol_v2::CacheManifestBuilder::new(ZCCACHE_SERVICE_NAME, crate::core::VERSION)
+        .broker_instance(SHARED_BROKER_INSTANCE)
+        .root(
+            V2::CacheData,
+            path_string(&crate::core::config::artifacts_dir_from_cache_dir(cache_dir)),
+        )
+        .root(V2::CacheIndex, path_string(&index_dir))
+        .root(V2::CacheLogs, path_string(&log_dir))
+        .root(V2::CacheLocks, path_string(cache_dir))
+        .root(
+            V2::CacheTmp,
+            path_string(&crate::core::config::tmp_dir_from_cache_dir(cache_dir)),
+        )
 }
 
 /// Install the zccache `ServiceDefinition` into the running-process service-
@@ -212,5 +279,68 @@ mod tests {
                 .roots,
         );
         assert_eq!(roots_by_kind(&loaded.roots), original);
+    }
+
+    /// Slice 23 of zccache#782: dual-write also produces a v2
+    /// `zccache-<ver>.v2.pb` file alongside the v1 file, carrying the
+    /// same identity + cache-root list. Pins that a v2 broker would
+    /// discover the same zccache cache layout once it has a loader.
+    #[test]
+    fn publish_also_writes_v2_manifest() {
+        use prost::Message;
+
+        let registry = tempfile::tempdir().expect("tempdir");
+        let cache_dir = NormalizedPath::from("/tmp/zccache-manifest-v2-roundtrip");
+
+        publish_manifest_in(registry.path(), &cache_dir).expect("publish manifest");
+
+        // The v2 file lives at the same stem but with .v2.pb extension.
+        let v2_path = registry
+            .path()
+            .join(format!("zccache-{}.v2.pb", crate::core::VERSION));
+        assert!(
+            v2_path.exists(),
+            "v2 manifest must exist at {}",
+            v2_path.display()
+        );
+
+        let bytes = std::fs::read(&v2_path).expect("read v2 file");
+        let decoded = protocol_v2::CacheManifest::decode(bytes.as_slice())
+            .expect("v2 CacheManifest decodes");
+
+        assert_eq!(decoded.service_name, "zccache");
+        assert_eq!(decoded.service_version, crate::core::VERSION);
+        assert_eq!(decoded.broker_envelope_version, "v2");
+        assert_eq!(decoded.broker_instance, "shared");
+        assert_eq!(decoded.roots.len(), 5, "all 5 cache roots present in v2");
+
+        // v2 wire values mirror v1's per upstream PR #526, so an
+        // `as i32` cast from the v1 enum equals the v2 enum value.
+        use running_process::broker::protocol_v2::CacheRootKind as V2;
+        let v2_kinds: Vec<i32> = decoded.roots.iter().map(|r| r.kind).collect();
+        assert!(v2_kinds.contains(&(V2::CacheData as i32)));
+        assert!(v2_kinds.contains(&(V2::CacheIndex as i32)));
+        assert!(v2_kinds.contains(&(V2::CacheLogs as i32)));
+        assert!(v2_kinds.contains(&(V2::CacheLocks as i32)));
+        assert!(v2_kinds.contains(&(V2::CacheTmp as i32)));
+    }
+
+    /// v1↔v2 wire alignment: each cache root in the v2 manifest must
+    /// match the corresponding root in the v1 manifest at the same
+    /// `kind as i32` value (per upstream PR #526). Pins that the two
+    /// generations agree on the role classification for every root
+    /// zccache writes.
+    #[test]
+    fn v1_and_v2_manifest_roots_agree_on_wire_values() {
+        let cache_dir = NormalizedPath::from("/tmp/zccache-manifest-alignment");
+        let v1 = build_manifest_builder(&cache_dir)
+            .build()
+            .expect("seal v1");
+        let v2 = build_manifest_builder_v2(&cache_dir).build();
+        assert_eq!(v1.roots.len(), v2.roots.len(), "same root count");
+        for (a, b) in v1.roots.iter().zip(v2.roots.iter()) {
+            assert_eq!(a.kind, b.kind, "kind mismatch for path={}", a.path);
+            assert_eq!(a.path, b.path, "path mismatch for kind={}", a.kind);
+        }
     }
 }


### PR DESCRIPTION
## Summary

zccache#782 slice 23 — extends the v1→v2 broker migration to the cache manifest. `ipc/manifest.rs` now writes BOTH `zccache-<ver>.pb` (v1, primary) and `zccache-<ver>.v2.pb` (v2, secondary) into the central registry. Same identity, same 5-root cache layout.

## v1↔v2 wire alignment

The v2 `CacheRootKind` wire values were originally misnumbered in upstream PR #525; PR #526 re-aligned them to match v1 EXACTLY. As a result, this consumer-side migration is mechanical — every root's `kind as i32` is identical between the two manifests.

`v1_and_v2_manifest_roots_agree_on_wire_values` is a new test that pins this contract from the consumer side, complementing the `cache_root_kind_wire_values_mirror_v1` test that ships upstream.

## Failure semantics

`publish_manifest` (production) treats the v2 write as best-effort: failure → logged + ignored. v1 is the only mandatory write during rollout. `publish_manifest_in` (test) surfaces both errors so tests pin both code paths.

## Pin bump

Bumped `running-process` pin to `2ee3c58` (post-#525-#526 main).

## Tests

- 2 unchanged v1 tests still pass.
- `publish_also_writes_v2_manifest` (new) — decodes the v2 file, asserts `broker_envelope_version="v2"`, 5 cache roots present.
- `v1_and_v2_manifest_roots_agree_on_wire_values` (new) — iterates both root lists in parallel, asserts every (kind, path) tuple matches.

## Test plan

- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean.

Closes zccache#782 slice 23 (Phase C — service-definition + manifest surfaces).
