### PR TITLE
feat(broker-v2): migrate backend_identity to protocol_v2 namespace (slice 24 of #782)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "running-process"
 version = "4.5.6"
-source = "git+https://github.com/zackees/running-process?rev=2ee3c586fc3518498c78ea8ea4b839cc84613ce6#2ee3c586fc3518498c78ea8ea4b839cc84613ce6"
+source = "git+https://github.com/zackees/running-process?rev=d0299b3f4d18465fa36b80dab6939cc39bbff549#d0299b3f4d18465fa36b80dab6939cc39bbff549"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ notify = { path = "vendor/notify" }
 # (buried `details: Box<Refused>` instead of top-level `retry_after_ms`)
 # which `BrokerRefusal::from_brokerv2_error` no longer compiles against.
 # Revert to the published version line once running-process cuts 4.5.6+.
-running-process = { git = "https://github.com/zackees/running-process", rev = "2ee3c586fc3518498c78ea8ea4b839cc84613ce6" }
+running-process = { git = "https://github.com/zackees/running-process", rev = "d0299b3f4d18465fa36b80dab6939cc39bbff549" }
 
 [workspace.metadata.dylint]
 libraries = [{ path = "dylints/*" }]

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -218,8 +218,13 @@ impl DaemonServer {
     }
 
     /// Clone the running-process identity served by this daemon.
+    ///
+    /// Slice 24 of zccache#782: migrated to the `protocol_v2::backend_handle`
+    /// namespace.
     #[must_use]
-    pub fn backend_identity(&self) -> running_process::broker::backend_handle::DaemonProcess {
+    pub fn backend_identity(
+        &self,
+    ) -> running_process::broker::protocol_v2::backend_handle::DaemonProcess {
         self.state.backend_identity.clone()
     }
 

--- a/crates/zccache/src/daemon/server/state.rs
+++ b/crates/zccache/src/daemon/server/state.rs
@@ -14,8 +14,11 @@ pub(super) struct SharedState {
     /// wrappers can verify they reached the intended daemon identity.
     pub(super) endpoint: String,
     /// running-process BackendHandle identity served on the same direct
-    /// daemon endpoint for the minimal broker-adoption path.
-    pub(super) backend_identity: running_process::broker::backend_handle::DaemonProcess,
+    /// daemon endpoint for the minimal broker-adoption path. Slice 24
+    /// of zccache#782: migrated to the `protocol_v2::backend_handle`
+    /// namespace (upstream re-export of the cross-version-stable type).
+    pub(super) backend_identity:
+        running_process::broker::protocol_v2::backend_handle::DaemonProcess,
     /// Active daemon/socket namespace label.
     pub(super) daemon_namespace: String,
     /// Cache root this daemon was created with.

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -543,9 +543,15 @@ fn backend_identity_file_name(namespace: Option<&str>) -> String {
 
 /// Convert zccache's direct daemon endpoint to the running-process endpoint
 /// tuple used by `BackendHandle`.
+///
+/// Slice 24 of zccache#782: migrated to the `protocol_v2::backend_handle`
+/// namespace (upstream PR #527). The underlying type is identical to v1's
+/// per the coexistence re-export design — no behaviour change.
 #[must_use]
-pub fn running_process_endpoint(endpoint: &str) -> running_process::broker::protocol::Endpoint {
-    running_process::broker::protocol::Endpoint {
+pub fn running_process_endpoint(
+    endpoint: &str,
+) -> running_process::broker::protocol_v2::backend_handle::Endpoint {
+    running_process::broker::protocol_v2::backend_handle::Endpoint {
         namespace_id: crate::core::config::daemon_namespace_label(),
         path: running_process_endpoint_path(endpoint),
     }
@@ -566,21 +572,27 @@ fn running_process_endpoint_path(endpoint: &str) -> String {
 
 /// Build the current process identity that a zccache daemon exposes to
 /// `BackendHandle` probes.
+///
+/// Slice 24 of zccache#782: migrated to the `protocol_v2::backend_handle`
+/// namespace.
 pub fn current_backend_identity(
     endpoint: &str,
 ) -> Result<
-    running_process::broker::backend_handle::DaemonProcess,
-    running_process::broker::backend_lifecycle::identity::IdentityError,
+    running_process::broker::protocol_v2::backend_handle::DaemonProcess,
+    running_process::broker::protocol_v2::backend_handle::IdentityError,
 > {
-    running_process::broker::backend_handle::DaemonProcess::current_process(
+    running_process::broker::protocol_v2::backend_handle::DaemonProcess::current_process(
         running_process_endpoint(endpoint),
         None,
     )
 }
 
 /// Persist the daemon identity used by future `BackendHandle` probes.
+///
+/// Slice 24 of zccache#782: migrated to the `protocol_v2::backend_handle`
+/// namespace.
 pub fn write_backend_identity(
-    daemon: &running_process::broker::backend_handle::DaemonProcess,
+    daemon: &running_process::broker::protocol_v2::backend_handle::DaemonProcess,
 ) -> Result<(), std::io::Error> {
     let path = backend_identity_path();
     if let Some(parent) = path.parent() {
@@ -592,15 +604,18 @@ pub fn write_backend_identity(
 }
 
 /// Load and actively verify the daemon identity through `BackendHandle`.
+///
+/// Slice 24 of zccache#782: migrated to the `protocol_v2::backend_handle`
+/// namespace.
 #[must_use]
 pub fn probe_backend_handle(
     endpoint: &str,
-) -> Option<running_process::broker::backend_handle::BackendHandle> {
+) -> Option<running_process::broker::protocol_v2::backend_handle::BackendHandle> {
     let daemon = std::fs::read(backend_identity_path())
         .ok()
         .and_then(|bytes| serde_json::from_slice(&bytes).ok())?;
     let endpoint = running_process_endpoint(endpoint);
-    running_process::broker::backend_handle::BackendHandle::probe_with_service(
+    running_process::broker::protocol_v2::backend_handle::BackendHandle::probe_with_service(
         "zccache",
         crate::core::VERSION,
         &endpoint,


### PR DESCRIPTION
## Summary

zccache#782 slice 24 — completes the v1→v2 import migration for broker-side process identity. 5 call sites swap their import path from `running_process::broker::backend_handle::*` to `running_process::broker::protocol_v2::backend_handle::*`.

## Files touched

- `ipc/mod.rs` — 4 fn signatures: `running_process_endpoint`, `current_backend_identity`, `write_backend_identity`, `probe_backend_handle`
- `daemon/server/state.rs` — 1 field: `backend_identity: DaemonProcess`
- `daemon/server/lifecycle.rs` — 1 getter: `backend_identity()`

## Behaviour

ZERO change. Per upstream PR #527 (slice 23-B), the v2 namespace types are TypeId-identical to v1's. These symbols are intentionally cross-version-stable per the broker-v2 coexistence design (#470). Pure import swap.

The upstream `v1_and_v2_backend_handle_types_are_the_same` test guarantees the swap is behaviour-preserving — if upstream ever forks the types, zccache's test suite would catch it on the next build.

## Pin bump

Bumped `running-process` pin to `d0299b3` (post-#527 main).

## Remaining v1 imports

Slice 24 removes `broker::backend_handle::*` from production paths. The remaining v1 imports in `broker.rs` (adopt / client / BrokerClientError) require actual v2 broker scaffold functionality (accept loop, hello router consuming v2 servicedef files) that's still in flight upstream — those land in slice 25.

## Test plan

- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean.
