### PR TITLE
feat(broker): delete v1 broker imports — production code now v2-namespaced (slice 25 of #782)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "running-process"
 version = "4.5.6"
-source = "git+https://github.com/zackees/running-process?rev=d0299b3f4d18465fa36b80dab6939cc39bbff549#d0299b3f4d18465fa36b80dab6939cc39bbff549"
+source = "git+https://github.com/zackees/running-process?rev=eb49f1138e4a960f039f7bd5376211073e6dcd84#eb49f1138e4a960f039f7bd5376211073e6dcd84"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ notify = { path = "vendor/notify" }
 # (buried `details: Box<Refused>` instead of top-level `retry_after_ms`)
 # which `BrokerRefusal::from_brokerv2_error` no longer compiles against.
 # Revert to the published version line once running-process cuts 4.5.6+.
-running-process = { git = "https://github.com/zackees/running-process", rev = "d0299b3f4d18465fa36b80dab6939cc39bbff549" }
+running-process = { git = "https://github.com/zackees/running-process", rev = "eb49f1138e4a960f039f7bd5376211073e6dcd84" }
 
 [workspace.metadata.dylint]
 libraries = [{ path = "dylints/*" }]

--- a/crates/zccache/src/ipc/broker.rs
+++ b/crates/zccache/src/ipc/broker.rs
@@ -31,8 +31,15 @@
 //! TEST-ONLY fake-backend seam also stays resolve-and-drop: it dials a raw
 //! socket with no Hello negotiation, so there is no live session to adopt.
 
-use running_process::broker::adopt::{AdoptError, AsyncBrokerSession, OwnedConnectRequest};
-use running_process::broker::client::{BackendConnectionRoute, RefusalKind};
+// Slice 25 of zccache#782: migrated to the `protocol_v2::client_compat`
+// namespace (upstream PR #528). The underlying types remain identical
+// to v1's per the coexistence re-export design — no behaviour change.
+// When client_v2 + the v2 broker scaffold are production-ready the
+// implementation under this namespace flips to v2-native; the
+// consumer side stays unchanged.
+use running_process::broker::protocol_v2::client_compat::{
+    AdoptError, AsyncBrokerSession, BackendConnectionRoute, OwnedConnectRequest, RefusalKind,
+};
 // Slice 11 of zccache#782: the raw-socket reachability probe used by
 // the `RUNNING_PROCESS_FAKE_BACKEND` seam now lives in `ipc::broker_v2`
 // instead of being pulled from `running_process::broker::client`. This
@@ -224,9 +231,12 @@ async fn adopt_session_connection(
 }
 
 /// Wrap the adopted `OwnedFd` as a tokio-backed `IpcConnection`.
+///
+/// Slice 25 of zccache#782: migrated to the `protocol_v2::client_compat`
+/// namespace (upstream PR #529).
 #[cfg(unix)]
 fn unix_connection_from_backend_io(
-    io: running_process::broker::adopt::OwnedBackendIo,
+    io: running_process::broker::protocol_v2::client_compat::OwnedBackendIo,
 ) -> Result<IpcConnection, IpcError> {
     let fd = io.into_owned_fd();
     let std_stream = std::os::unix::net::UnixStream::from(fd);
@@ -387,7 +397,7 @@ impl BrokerRefusal {
 /// the function returns `None` regardless.
 #[must_use]
 pub fn classify_adopt_error(err: &AdoptError) -> Option<BrokerRefusal> {
-    use running_process::broker::client::BrokerClientError;
+    use running_process::broker::protocol_v2::client_compat::BrokerClientError;
     match err {
         AdoptError::Connect(connect_err) => connect_err.refusal_kind().map(|kind| {
             let retry_after_ms = match connect_err {
@@ -728,7 +738,7 @@ mod tests {
 
     #[test]
     fn classify_adopt_error_maps_typed_refusals() {
-        use running_process::broker::client::BrokerClientError;
+        use running_process::broker::protocol_v2::client_compat::BrokerClientError;
         use running_process::broker::protocol::ErrorCode;
 
         let refusal = |code: ErrorCode| {
@@ -849,7 +859,7 @@ mod tests {
     /// Catches the half-done fix where the typed surface drops the hint.
     #[test]
     fn classify_adopt_error_propagates_retry_after_ms_on_v1_rate_limited() {
-        use running_process::broker::client::BrokerClientError;
+        use running_process::broker::protocol_v2::client_compat::BrokerClientError;
         use running_process::broker::protocol::ErrorCode;
 
         let err = AdoptError::Connect(BrokerClientError::Refused {

--- a/crates/zccache/src/ipc/transport/mod.rs
+++ b/crates/zccache/src/ipc/transport/mod.rs
@@ -97,7 +97,7 @@ impl IpcConnection {
     /// `recv`/`recv_wire` call.
     pub async fn try_serve_backend_handle_probe(
         &mut self,
-        daemon: &running_process::broker::backend_handle::DaemonProcess,
+        daemon: &running_process::broker::protocol_v2::backend_handle::DaemonProcess,
     ) -> Result<bool, IpcError> {
         probe::try_serve_backend_handle_probe(
             &mut self.reader,

--- a/crates/zccache/src/ipc/transport/probe.rs
+++ b/crates/zccache/src/ipc/transport/probe.rs
@@ -32,7 +32,7 @@ pub(super) async fn try_serve_backend_handle_probe<R, W>(
     reader: &mut R,
     writer: &mut W,
     read_buf: &mut BytesMut,
-    daemon: &running_process::broker::backend_handle::DaemonProcess,
+    daemon: &running_process::broker::protocol_v2::backend_handle::DaemonProcess,
 ) -> Result<bool, IpcError>
 where
     R: AsyncRead + Unpin,
@@ -89,7 +89,7 @@ where
 }
 
 fn is_backend_handle_probe_request(frame: &running_process::broker::protocol::Frame) -> bool {
-    use running_process::broker::backend_lifecycle::probe::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL;
+    use running_process::broker::protocol_v2::backend_handle::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL;
     use running_process::broker::protocol::{FrameKind, PayloadEncoding};
 
     frame.envelope_version == 1
@@ -101,9 +101,9 @@ fn is_backend_handle_probe_request(frame: &running_process::broker::protocol::Fr
 
 fn backend_handle_probe_response(
     request: &running_process::broker::protocol::Frame,
-    daemon: &running_process::broker::backend_handle::DaemonProcess,
+    daemon: &running_process::broker::protocol_v2::backend_handle::DaemonProcess,
 ) -> Result<running_process::broker::protocol::Frame, IpcError> {
-    use running_process::broker::backend_lifecycle::probe::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL;
+    use running_process::broker::protocol_v2::backend_handle::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL;
     use running_process::broker::protocol::{Frame, FrameKind, PayloadEncoding};
 
     let mut payload = Vec::with_capacity(32 + 128);

--- a/crates/zccache/src/ipc/transport/tests.rs
+++ b/crates/zccache/src/ipc/transport/tests.rs
@@ -133,7 +133,7 @@ async fn backend_handle_probe_succeeds_on_direct_endpoint() {
     });
 
     let (service_name, handle_endpoint) = tokio::task::spawn_blocking(move || {
-        let handle = running_process::broker::backend_handle::BackendHandle::probe_with_service(
+        let handle = running_process::broker::protocol_v2::backend_handle::BackendHandle::probe_with_service(
             "zccache",
             crate::core::VERSION,
             &probe_endpoint,


### PR DESCRIPTION
## Summary

zccache#782 slice 25 — completes the v1→v2 import migration. **ZERO `running_process::broker::{adopt,client,backend_handle,backend_lifecycle}::*` import statements remain in zccache production source code.**

## What flipped

| file | what swapped |
|---|---|
| `ipc/broker.rs` | `adopt::*` + `client::*` imports + `OwnedBackendIo` |
| `ipc/transport/mod.rs` | `try_serve_backend_handle_probe` DaemonProcess parameter |
| `ipc/transport/probe.rs` | DaemonProcess parameters (2) + `BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL` constant (2 uses) |
| `ipc/transport/tests.rs` | `BackendHandle::probe_with_service` test call site |

All paths swap to `running_process::broker::protocol_v2::{client_compat, backend_handle}::*`. Per upstream PRs #527, #528, #529, #530, those v2 namespaces re-export the cross-version-stable v1 types at the same TypeId. The migration is pure-namespace; behaviour, wire bytes, and on-disk shapes are unchanged.

## What this enables

zccache's dependency graph now anchors on the v2 namespace for broker types. When client_v2 + the v2 broker scaffold are production-ready, this module's re-exports get swapped to `client_v2::*` equivalents — consumer-side stays unchanged.

## Remaining v1 references (doc comments only)

- `crates/zccache/src/ipc/README.md` — descriptive prose.
- `crates/zccache/src/ipc/transport/unix.rs:22` — doc comment on a helper.

These are informational; production code path has zero v1 broker imports.

## Pin bump bundled

`running-process` pin → `eb49f11` (post-#530 main; includes the last v1 holdout — `BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL` re-export under `backend_handle`).

## Test plan

- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean.
- The upstream TypeId-equality tests in #527 + #528 guarantee the swap is behaviour-preserving.

Closes zccache#782 slice 25 (the goal anchor — "delete v1 broker path").
