### PR TITLE
chore(broker-v2): polish — update v1 doc-comment references to v2 namespace (#782)

### DIFF
--- a/crates/zccache/src/ipc/README.md
+++ b/crates/zccache/src/ipc/README.md
@@ -36,8 +36,10 @@ file yet. `RUNNING_PROCESS_DISABLE=1` skips the BackendHandle probe and uses
 that same legacy raw-connect fallback.
 
 `broker.rs` wires the frozen
-`running_process::broker::adopt::AsyncBrokerSession::adopt` one-call recipe
-(zackees/running-process#435) in front of the daemon client connect
+`AsyncBrokerSession::adopt` one-call recipe (re-exported through
+`running_process::broker::protocol_v2::client_compat` per zccache#782
+slice 25; underlying impl per zackees/running-process#435) in front of
+the daemon client connect
 (`connect_daemon`). `adopt` runs the Hello negotiation (service_name
 `"zccache"`, protocol min/max = 1, client_lib_name `"running-process"`,
 wanted_version = the zccache daemon version) on a blocking worker and returns

--- a/crates/zccache/src/ipc/broker.rs
+++ b/crates/zccache/src/ipc/broker.rs
@@ -1,8 +1,9 @@
 //! Broker-mediated connect lane for the daemon client path.
 //!
-//! Wires the frozen `running_process::broker::adopt::AsyncBrokerSession::adopt`
-//! one-call recipe (zackees/running-process#433/#435) in front of zccache's
-//! direct IPC connect. `adopt` runs the Hello negotiation (service_name
+//! Wires the frozen [`AsyncBrokerSession::adopt`] one-call recipe
+//! (re-exported through `protocol_v2::client_compat` per zccache#782
+//! slices 25-A/25; underlying impl from running-process#433/#435)
+//! in front of zccache's direct IPC connect. `adopt` runs the Hello negotiation (service_name
 //! `"zccache"`, protocol min/max = 1, client_lib_name `"running-process"`,
 //! wanted_version = the zccache daemon version) on a blocking worker and hands
 //! back the broker-selected backend endpoint. Lane selection precedence:
@@ -42,8 +43,8 @@ use running_process::broker::protocol_v2::client_compat::{
 };
 // Slice 11 of zccache#782: the raw-socket reachability probe used by
 // the `RUNNING_PROCESS_FAKE_BACKEND` seam now lives in `ipc::broker_v2`
-// instead of being pulled from `running_process::broker::client`. This
-// gets one v1 import out of zccache's broker surface.
+// instead of being pulled from the upstream v1 client module. This
+// gets one upstream import out of zccache's broker surface.
 use super::broker_v2::probe_local_socket;
 
 use super::error::IpcError;
@@ -54,9 +55,9 @@ use super::{connect, running_process_disabled, ClientConnection};
 /// Upstream TEST-ONLY seam: a non-empty value short-circuits the broker
 /// negotiation and dials the given running-process endpoint directly.
 ///
-/// Mirrors the `running_process::broker::client` seam contract (the
-/// constant ships upstream after 4.1.0; replace this local copy with the
-/// upstream re-export on the next running-process bump). The canonical
+/// Mirrors the upstream v1-client seam contract (the constant ships
+/// upstream after 4.1.0; replace this local copy with the upstream
+/// re-export on the next running-process bump). The canonical
 /// `RUNNING_PROCESS_DISABLE=1` hatch takes precedence: a disabled broker
 /// ignores the fake seam too. Never set this in production.
 pub const RUNNING_PROCESS_FAKE_BACKEND_ENV: &str = "RUNNING_PROCESS_FAKE_BACKEND";

--- a/crates/zccache/src/ipc/mod.rs
+++ b/crates/zccache/src/ipc/mod.rs
@@ -524,7 +524,7 @@ pub fn remove_lock_file() {
 }
 
 /// Path where the daemon records the identity consumed by
-/// `running_process::broker::backend_handle::BackendHandle`.
+/// [`running_process::broker::protocol_v2::backend_handle::BackendHandle`].
 #[must_use]
 pub fn backend_identity_path() -> NormalizedPath {
     let namespace = crate::core::config::daemon_namespace();

--- a/crates/zccache/src/ipc/transport/unix.rs
+++ b/crates/zccache/src/ipc/transport/unix.rs
@@ -19,9 +19,12 @@ impl IpcConnection {
     /// Wrap an already-connected `UnixStream` as an `IpcConnection`.
     ///
     /// The broker lane uses this to adopt the live socket handed back by
-    /// `running_process::broker::adopt::AsyncBrokerSession::into_backend_io`
-    /// instead of re-dialing the endpoint, so the negotiated connection is
-    /// reused as the data connection.
+    /// [`AsyncBrokerSession::into_backend_io`] (re-exported through
+    /// `protocol_v2::client_compat` per zccache#782 slice 25) instead of
+    /// re-dialing the endpoint, so the negotiated connection is reused
+    /// as the data connection.
+    ///
+    /// [`AsyncBrokerSession::into_backend_io`]: running_process::broker::protocol_v2::client_compat::AsyncBrokerSession
     pub fn from_unix_stream(stream: tokio::net::UnixStream) -> Self {
         let (reader, writer) = tokio::io::split(stream);
         IpcConnection {


### PR DESCRIPTION
After slice 25 (PR #859) removed every v1 `running_process::broker::{adopt,client,backend_handle,backend_lifecycle}::*` import, 4 doc-comments + README still mentioned v1 paths descriptively. Updates those to `protocol_v2::{client_compat,backend_handle}`. Pure docs cleanup, zero functional change. After this PR: `grep` for v1 broker paths in zccache source returns ZERO matches.