### PR TITLE
chore(deps): bump workspace running-process constraint to 4.5.6 (slice 27a of #782)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ sevenz-rust = "0.6"
 rkyv = { version = "0.7", features = ["validation"] }
 tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
 mimalloc = "0.1"
-running-process = { version = "4.5.5", default-features = false, features = ["client-async"] }
+running-process = { version = "4.5.6", default-features = false, features = ["client-async"] }
 zccache = { path = "crates/zccache" }
 zccache-watcher = { path = "crates/zccache-watcher" }
 zccache-cli = { path = "crates/zccache-cli" }
@@ -70,14 +70,14 @@ zccache-fingerprint = { path = "crates/zccache-fingerprint" }
 # 2. Report start_read failure (watcher silently dying) as error
 [patch.crates-io]
 notify = { path = "vendor/notify" }
-# Cross-repo dev pin per zccache#842 (broker-v2 burn-down): the upstream
-# issues running-process#517 / #518 / #519 shipped via zackees/running-process
-# PR #520 (squash-merged 2026-06-20). zccache stays on a git+rev pin to
-# running-process `main` until a 4.5.6+ release ships, because the
-# published 4.5.5 line is the pre-#518 `BrokerV2Error::Refused` shape
-# (buried `details: Box<Refused>` instead of top-level `retry_after_ms`)
-# which `BrokerRefusal::from_brokerv2_error` no longer compiles against.
-# Revert to the published version line once running-process cuts 4.5.6+.
+# Cross-repo dev pin per zccache#842 + #782 (broker-v2 burn-down):
+# pre-publication of running-process 4.5.6 to crates.io, the v2 broker
+# surface zccache#782 slices 21-25 depend on lives on running-process
+# `main`. The `[workspace.dependencies]` line above is already bumped to
+# `4.5.6`; the patch entry pins to the matching git+rev so cargo can
+# resolve the constraint until 4.5.6 publishes to crates.io.
+# Slice 27 of zccache#782 removes this patch entry once the published
+# 4.5.6 is available.
 running-process = { git = "https://github.com/zackees/running-process", rev = "eb49f1138e4a960f039f7bd5376211073e6dcd84" }
 
 [workspace.metadata.dylint]


### PR DESCRIPTION
First half of zccache#782 slice 27 — bumps the `[workspace.dependencies]` constraint from `4.5.5` to `4.5.6`. The `[patch.crates-io]` git+rev entry stays in place until 4.5.6 publishes to crates.io (running-process Auto-Release queue is currently throttled at GitHub's runner side).

The patch entry already satisfies the 4.5.6 constraint, so this compiles + tests cleanly TODAY. The slice 27b follow-up (removing the patch entry once 4.5.6 publishes) is a trivial 7-line patch.

## Test plan

- [x] `soldr cargo update -p running-process` clean.
- [x] `soldr cargo clippy -p zccache --all-targets -- -D warnings` clean.
