### PR TITLE
chore(deps): drop running-process git+rev patch — 4.5.7 published (slice 27b of #782)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,8 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.5.6"
-source = "git+https://github.com/zackees/running-process?rev=eb49f1138e4a960f039f7bd5376211073e6dcd84#eb49f1138e4a960f039f7bd5376211073e6dcd84"
+version = "4.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc9c5f443f6e2af5fa401ab865b862902b769820da1e3b2b2b9bdab658982f9"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ sevenz-rust = "0.6"
 rkyv = { version = "0.7", features = ["validation"] }
 tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
 mimalloc = "0.1"
-running-process = { version = "4.5.6", default-features = false, features = ["client-async"] }
+running-process = { version = "4.5.7", default-features = false, features = ["client-async"] }
 zccache = { path = "crates/zccache" }
 zccache-watcher = { path = "crates/zccache-watcher" }
 zccache-cli = { path = "crates/zccache-cli" }
@@ -70,15 +70,6 @@ zccache-fingerprint = { path = "crates/zccache-fingerprint" }
 # 2. Report start_read failure (watcher silently dying) as error
 [patch.crates-io]
 notify = { path = "vendor/notify" }
-# Cross-repo dev pin per zccache#842 + #782 (broker-v2 burn-down):
-# pre-publication of running-process 4.5.6 to crates.io, the v2 broker
-# surface zccache#782 slices 21-25 depend on lives on running-process
-# `main`. The `[workspace.dependencies]` line above is already bumped to
-# `4.5.6`; the patch entry pins to the matching git+rev so cargo can
-# resolve the constraint until 4.5.6 publishes to crates.io.
-# Slice 27 of zccache#782 removes this patch entry once the published
-# 4.5.6 is available.
-running-process = { git = "https://github.com/zackees/running-process", rev = "eb49f1138e4a960f039f7bd5376211073e6dcd84" }
 
 [workspace.metadata.dylint]
 libraries = [{ path = "dylints/*" }]

--- a/crates/zccache/tests/v2_stress_adversarial_test.rs
+++ b/crates/zccache/tests/v2_stress_adversarial_test.rs
@@ -2,10 +2,10 @@
 //!
 //! Sweeps every consumer-facing slice that landed in zccache#782's
 //! v1→v2 migration (slices 21, 23, 24, 25) — the ServiceDefinition
-//! + CacheManifest dual-write paths, the `protocol_v2::backend_handle`
-//! namespace, the `probe_local_socket` reachability seam, and the
-//! v2 pipe namer — and pounds on each one concurrently with
-//! adversarial inputs.
+//! and CacheManifest dual-write paths, the `protocol_v2::backend_handle`
+//! namespace, the `probe_local_socket` reachability seam, and the v2
+//! pipe namer — and pounds on each one concurrently with adversarial
+//! inputs.
 //!
 //! Why this exists: criterion #3 of zccache#782's goal demands
 //! "rock stable through stress and adversarial tests with the v2


### PR DESCRIPTION
running-process 4.5.7 just published to crates.io with the full v2 broker surface (PRs #520-#535 plus the just-shipped 4.5.7 bump). This PR drops the `[patch.crates-io]` entry zccache has been carrying since the cross-repo burn-down started.

Bumps `[workspace.dependencies]` running-process 4.5.6 → 4.5.7 and deletes the git+rev patch pin. After this, zccache consumes running-process from crates.io like any other downstream — the cross-repo dev-pin chapter of #782 closes.

Bundled cosmetic: rewords a docstring line that started with `+` so clippy's new `doc_list_item_without_indentation` lint stops false-firing.

Test plan: clippy clean, cargo update resolves to 4.5.7.
