### PR TITLE
[codex] fix hook uv run project sync

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run python ci/hooks/tool_guard.py",
+            "command": "uv run --no-project python ci/hooks/tool_guard.py",
             "timeout": 5
           }
         ]
@@ -18,12 +18,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run python ci/hooks/readme_guard.py",
+            "command": "uv run --no-project python ci/hooks/readme_guard.py",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "uv run python ci/hooks/loc_guard.py",
+            "command": "uv run --no-project python ci/hooks/loc_guard.py",
             "timeout": 5
           }
         ]
@@ -34,7 +34,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run python ci/hooks/check-on-start.py",
+            "command": "uv run --no-project python ci/hooks/check-on-start.py",
             "timeout": 15
           }
         ]

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run python ci/hooks/tool_guard.py",
+            "command": "uv run --no-project python ci/hooks/tool_guard.py",
             "timeout": 5
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run python ci/hooks/tool_guard.py",
+            "command": "uv run --no-project python ci/hooks/tool_guard.py",
             "timeout": 5
           }
         ]
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run python ci/hooks/tool_guard.py",
+            "command": "uv run --no-project python ci/hooks/tool_guard.py",
             "timeout": 5
           }
         ]
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run python ci/hooks/tool_guard.py",
+            "command": "uv run --no-project python ci/hooks/tool_guard.py",
             "timeout": 5
           }
         ]
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run python ci/hooks/tool_guard.py",
+            "command": "uv run --no-project python ci/hooks/tool_guard.py",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Summary

Updates agent hook invocations to run Python through `uv run --no-project` so hook execution does not discover the repository project and trigger a maturin-backed project sync/rebuild.

## Impact

This keeps Claude and Codex hook startup paths lightweight and avoids slow or timeout-prone hook execution in the Python+Rust repo.

## Validation

- Parsed `.claude/settings.json` and `.codex/hooks.json` with PowerShell `ConvertFrom-Json`
- Verified hook `uv` commands now include `--no-project` with `rg uv .claude .codex -n`