### PR TITLE
[codex] reuse build metadata for cargo check

### DIFF
--- a/ci/perf_local.py
+++ b/ci/perf_local.py
@@ -106,6 +106,7 @@ VOLUME_CARGO_HOME_ZCCACHE = "zccache-perf-cargo-home-zccache"
 VOLUME_RUST_STATE = "zccache-perf-rust-state"
 
 VALID_SCENARIOS = (
+    "build-then-check",
     "cold-tar-untar-warm",
     "worktree-share",
     "touch-no-change",

--- a/crates/zccache/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/cached_hit.rs
@@ -49,6 +49,7 @@ pub(super) struct CachedHitMaterializeRequest<'a> {
     pub(super) record_compilation: bool,
     pub(super) downgrade_output_metadata: bool,
     pub(super) mtime_floor_paths: Vec<NormalizedPath>,
+    pub(super) rustc_metadata_compat_outputs: Option<Vec<NormalizedPath>>,
     pub(super) phases: CachedHitPhases,
 }
 
@@ -69,6 +70,7 @@ pub(super) fn materialize_cached_compile_hit(
         record_compilation,
         downgrade_output_metadata,
         mtime_floor_paths,
+        rustc_metadata_compat_outputs,
         phases,
     } = request;
 
@@ -104,22 +106,46 @@ pub(super) fn materialize_cached_compile_hit(
     // build tool is looking for, leaving the user's `-MF` target absent
     // and reproducing the exact stale-incremental-build bug this fix
     // closes.
-    let targets: Vec<(NormalizedPath, NormalizedPath)> = (0..payloads.len())
-        .map(|i| {
-            let out: NormalizedPath = if i == 0 {
-                output_path.clone()
-            } else if i == 1 && payloads.len() == 2 {
-                current_depfile_dest
-                    .clone()
-                    .unwrap_or_else(|| secondary_output_dir.join(&names[i]))
-            } else {
-                secondary_output_dir.join(&names[i])
-            };
-            let cache_file = state.artifact_dir.join(format!("{artifact_key_hex}_{i}"));
-            (out, cache_file)
-        })
-        .collect();
-    if !write_payloads_par_with_mtime_floor(&targets, &payloads, &mtime_floor_paths) {
+    let (targets, payloads_to_write): (Vec<(NormalizedPath, NormalizedPath)>, Vec<CachedPayload>) =
+        if let Some(requested_outputs) = rustc_metadata_compat_outputs {
+            let mut targets = Vec::with_capacity(requested_outputs.len());
+            let mut selected_payloads = Vec::with_capacity(requested_outputs.len());
+            for requested in requested_outputs {
+                let Some(i) = rustc_compat_payload_index_for(&names, &requested) else {
+                    write_session_log(
+                        &state.sessions,
+                        sid,
+                        &format!(
+                            "[DIAG] rustc_emit_compat_missing_output: {}",
+                            requested.display()
+                        ),
+                    );
+                    return None;
+                };
+                let cache_file = state.artifact_dir.join(format!("{artifact_key_hex}_{i}"));
+                targets.push((requested, cache_file));
+                selected_payloads.push(payloads[i].clone());
+            }
+            (targets, selected_payloads)
+        } else {
+            let targets = (0..payloads.len())
+                .map(|i| {
+                    let out: NormalizedPath = if i == 0 {
+                        output_path.clone()
+                    } else if i == 1 && payloads.len() == 2 {
+                        current_depfile_dest
+                            .clone()
+                            .unwrap_or_else(|| secondary_output_dir.join(&names[i]))
+                    } else {
+                        secondary_output_dir.join(&names[i])
+                    };
+                    let cache_file = state.artifact_dir.join(format!("{artifact_key_hex}_{i}"));
+                    (out, cache_file)
+                })
+                .collect();
+            (targets, payloads.iter().cloned().collect())
+        };
+    if !write_payloads_par_with_mtime_floor(&targets, &payloads_to_write, &mtime_floor_paths) {
         return None;
     }
     let t2 = Instant::now();
@@ -191,6 +217,21 @@ pub(super) fn materialize_cached_compile_hit(
     })
 }
 
+fn rustc_compat_payload_index_for(names: &[String], requested: &NormalizedPath) -> Option<usize> {
+    let requested_ext = requested.extension().and_then(|ext| ext.to_str())?;
+    let wanted = match requested_ext {
+        "rmeta" => "rmeta",
+        "d" => "d",
+        _ => return None,
+    };
+    names.iter().position(|name| {
+        std::path::Path::new(name)
+            .extension()
+            .and_then(|ext| ext.to_str())
+            == Some(wanted)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -250,6 +291,7 @@ mod tests {
             record_compilation: true,
             downgrade_output_metadata: true,
             mtime_floor_paths: Vec::new(),
+            rustc_metadata_compat_outputs: None,
             phases: CachedHitPhases::request_cache(0, 0),
         })
         .unwrap();
@@ -353,6 +395,7 @@ mod tests {
             record_compilation: true,
             downgrade_output_metadata: true,
             mtime_floor_paths: Vec::new(),
+            rustc_metadata_compat_outputs: None,
             phases: CachedHitPhases::request_cache(0, 0),
         })
         .expect("materialize_cached_compile_hit must succeed");
@@ -441,6 +484,7 @@ mod tests {
             record_compilation: true,
             downgrade_output_metadata: false,
             mtime_floor_paths: Vec::new(),
+            rustc_metadata_compat_outputs: None,
             phases: CachedHitPhases::request_cache(0, 0),
         })
         .expect("legacy single-output hit must still succeed");
@@ -517,6 +561,7 @@ mod tests {
                 record_compilation: true,
                 downgrade_output_metadata: false,
                 mtime_floor_paths: Vec::new(),
+                rustc_metadata_compat_outputs: None,
                 phases: CachedHitPhases::request_cache(0, 0),
             })
             .expect("materialize_cached_compile_hit must succeed");

--- a/crates/zccache/src/daemon/server/handle_compile/hit_branches.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/hit_branches.rs
@@ -117,6 +117,7 @@ pub(super) fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Option<R
         record_compilation: true,
         downgrade_output_metadata: false,
         mtime_floor_paths,
+        rustc_metadata_compat_outputs: None,
         phases: CachedHitPhases::request_cache(request_cache_lookup_ns, cross_root_validate_ns),
     })
 }
@@ -235,6 +236,7 @@ pub(super) async fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
         record_compilation: false,
         downgrade_output_metadata: true,
         mtime_floor_paths: input_paths.clone(),
+        rustc_metadata_compat_outputs: None,
         phases: CachedHitPhases {
             parse_args_ns,
             build_context_ns,
@@ -352,6 +354,7 @@ pub(super) fn try_depgraph_cached_hit(probe: DepgraphHitProbe<'_>) -> Option<Res
         record_compilation: false,
         downgrade_output_metadata: true,
         mtime_floor_paths: input_paths.clone(),
+        rustc_metadata_compat_outputs: None,
         phases: CachedHitPhases {
             parse_args_ns,
             build_context_ns,

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -18,6 +18,9 @@ mod store_outcome;
 mod system_includes;
 
 use super::super::*;
+use super::cached_hit::{
+    materialize_cached_compile_hit, CachedHitMaterializeRequest, CachedHitPhases,
+};
 use super::error_cache::{compile_failure_stderr, maybe_store_rustc_error_artifact};
 use super::hit_branches::{
     try_depgraph_cached_hit, try_fast_hit, try_request_cache_hit, DepgraphHitProbe, FastHitProbe,
@@ -247,60 +250,77 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     } else {
         None
     };
-    let (ctx, dep_flags, rustc_args_opt, context_key, worktree_equivalent_context) =
-        match build_result {
-            BuildContextResult::Cc { ctx, dep_flags } => {
-                let registration = state.dep_graph.load().register_with_root_and_salt_result(
-                    ctx.clone(),
-                    Some(default_key_root.clone()),
-                    worktree_salt,
+    let (
+        ctx,
+        dep_flags,
+        rustc_args_opt,
+        context_key,
+        rustc_metadata_compat_key,
+        worktree_equivalent_context,
+    ) = match build_result {
+        BuildContextResult::Cc { ctx, dep_flags } => {
+            let registration = state.dep_graph.load().register_with_root_and_salt_result(
+                ctx.clone(),
+                Some(default_key_root.clone()),
+                worktree_salt,
+            );
+            (
+                ctx,
+                dep_flags,
+                None,
+                registration.key,
+                None,
+                registration.rebased_from_equivalent_root,
+            )
+        }
+        BuildContextResult::Rustc {
+            rustc_ctx,
+            compat_ctx,
+            rustc_args,
+        } => {
+            let remap_gate =
+                rust_remap_gate(&rustc_args.remap_path_prefixes, worktree_root.as_ref());
+            write_session_log(
+                &state.sessions,
+                &sid,
+                &format!("[DIAG] {}", remap_gate.as_str()),
+            );
+            let rustc_key_root =
+                rustc_context_key_root(&rustc_args.remap_path_prefixes, worktree_root.as_ref());
+            let key = rustc_ctx.context_key_with_root(rustc_key_root.as_deref());
+            let compat_key =
+                rustc_ctx.check_metadata_compat_key_with_root(rustc_key_root.as_deref());
+            let published_compat_key = rustc_args
+                .emit_types
+                .iter()
+                .any(|emit| emit == "link")
+                .then_some(compat_key)
+                .flatten();
+            let rustc_externs = rustc_args
+                .externs
+                .iter()
+                .map(|ext| (ext.name.clone(), ext.path.clone()))
+                .collect();
+            let registration = state
+                .dep_graph
+                .load()
+                .register_rustc_with_key_and_root_result(
+                    key,
+                    compat_ctx.clone(),
+                    rustc_key_root.clone(),
+                    rustc_externs,
+                    published_compat_key,
                 );
-                (
-                    ctx,
-                    dep_flags,
-                    None,
-                    registration.key,
-                    registration.rebased_from_equivalent_root,
-                )
-            }
-            BuildContextResult::Rustc {
-                rustc_ctx,
+            (
                 compat_ctx,
-                rustc_args,
-            } => {
-                let remap_gate =
-                    rust_remap_gate(&rustc_args.remap_path_prefixes, worktree_root.as_ref());
-                write_session_log(
-                    &state.sessions,
-                    &sid,
-                    &format!("[DIAG] {}", remap_gate.as_str()),
-                );
-                let rustc_key_root =
-                    rustc_context_key_root(&rustc_args.remap_path_prefixes, worktree_root.as_ref());
-                let key = rustc_ctx.context_key_with_root(rustc_key_root.as_deref());
-                let rustc_externs = rustc_args
-                    .externs
-                    .iter()
-                    .map(|ext| (ext.name.clone(), ext.path.clone()))
-                    .collect();
-                let registration = state
-                    .dep_graph
-                    .load()
-                    .register_rustc_with_key_and_root_result(
-                        key,
-                        compat_ctx.clone(),
-                        rustc_key_root.clone(),
-                        rustc_externs,
-                    );
-                (
-                    compat_ctx,
-                    UserDepFlags::default(),
-                    Some(rustc_args),
-                    registration.key,
-                    registration.rebased_from_equivalent_root,
-                )
-            }
-        };
+                UserDepFlags::default(),
+                Some(rustc_args),
+                registration.key,
+                compat_key,
+                registration.rebased_from_equivalent_root,
+            )
+        }
+    };
     let is_rustc = rustc_args_opt.is_some();
     let rustc_extern_paths: Vec<NormalizedPath> = rustc_args_opt
         .as_ref()
@@ -309,6 +329,16 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 .externs
                 .iter()
                 .map(|ext| ext.path.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+    let rustc_current_externs: Vec<(String, NormalizedPath)> = rustc_args_opt
+        .as_ref()
+        .map(|rustc_args| {
+            rustc_args
+                .externs
+                .iter()
+                .map(|ext| (ext.name.clone(), ext.path.clone()))
                 .collect()
         })
         .unwrap_or_default();
@@ -358,7 +388,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
 
     // ── Slow path: hash + depgraph verify ────────────────────────────
     let HashVerifyOutcome {
-        hash_map: _hash_map,
+        hash_map,
         hash_source_ns,
         hash_headers_ns,
         depgraph_check_ns,
@@ -527,6 +557,121 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     }
 
     // Cache miss — invalidate fast-hit cache for this context
+    if is_rustc {
+        if let (Some(compat_key), Some(rustc_args)) =
+            (rustc_metadata_compat_key, rustc_args_opt.as_deref())
+        {
+            let check_style_request = !rustc_args.emit_types.iter().any(|emit| emit == "link");
+            if check_style_request {
+                let compat_hash_map = std::cell::RefCell::new(hash_map);
+                let get_hash = |p: &Path| {
+                    let path = NormalizedPath::new(p);
+                    if let Some(hash) = compat_hash_map.borrow().get(&path).copied() {
+                        return Some(hash);
+                    }
+                    let hash = hash_file(&state.cache_system, &path, snap_clock).ok()?;
+                    compat_hash_map.borrow_mut().insert(path, hash);
+                    Some(hash)
+                };
+                let is_fresh = |p: &Path| {
+                    let path = NormalizedPath::new(p);
+                    !state
+                        .cache_system
+                        .journal()
+                        .changed_since(&path, snap_clock)
+                };
+                let (compat_verdict, compat_reason, actual_context_key) = state
+                    .dep_graph
+                    .load()
+                    .check_rustc_metadata_compat_diagnostic(
+                        &compat_key,
+                        &rustc_current_externs,
+                        is_fresh,
+                        get_hash,
+                    );
+                write_session_log(
+                    &state.sessions,
+                    &sid,
+                    &format!(
+                        "[DIAG] rustc_emit_compat_check: {} -> {} compat_ctx={} verdict={} reason={}",
+                        source_path.display(),
+                        output_path.display(),
+                        &compat_key.hash().to_hex()[..8],
+                        match &compat_verdict {
+                            crate::depgraph::CacheVerdict::Hit { .. } => "Hit",
+                            crate::depgraph::CacheVerdict::SourceChanged { .. } => "SourceChanged",
+                            crate::depgraph::CacheVerdict::HeadersChanged { .. } => "HeadersChanged",
+                            crate::depgraph::CacheVerdict::Cold => "Cold",
+                            crate::depgraph::CacheVerdict::NeedsPreprocessor => "NeedsPreprocessor",
+                        },
+                        compat_reason,
+                    ),
+                );
+                if let crate::depgraph::CacheVerdict::Hit { artifact_key } = compat_verdict {
+                    let artifact_key_hex = artifact_key.hash().to_hex();
+                    pending_writes::await_pending(
+                        &state.pending_cache_writes,
+                        &artifact_key_hex,
+                        pending_writes::PENDING_WAIT_TIMEOUT,
+                    )
+                    .await;
+                    let requested_outputs =
+                        rustc_expected_output_paths(rustc_args, output_path.as_path(), cwd);
+                    if let Some(response) =
+                        materialize_cached_compile_hit(CachedHitMaterializeRequest {
+                            state,
+                            sid: &sid,
+                            artifact_key_hex: &artifact_key_hex,
+                            source_path: &source_path,
+                            output_path: &output_path,
+                            secondary_output_dir: output_path
+                                .parent()
+                                .unwrap_or(cwd_path.as_path())
+                                .into(),
+                            current_depfile_dest: None,
+                            compile_start,
+                            hit_label: "HIT_RUSTC_EMIT_COMPAT",
+                            cached_error_label: "CACHED_ERROR_RUSTC_EMIT_COMPAT",
+                            record_compilation: false,
+                            downgrade_output_metadata: true,
+                            mtime_floor_paths: request_cache_input_paths(
+                                state,
+                                actual_context_key.as_ref().unwrap_or(&context_key),
+                                &source_path,
+                                &ctx,
+                            ),
+                            rustc_metadata_compat_outputs: Some(requested_outputs),
+                            phases: CachedHitPhases {
+                                parse_args_ns,
+                                build_context_ns,
+                                hash_source_ns,
+                                hash_headers_ns,
+                                depgraph_check_ns,
+                                request_cache_lookup_ns: 0,
+                                cross_root_validate_ns: 0,
+                            },
+                        })
+                    {
+                        record_session_stat(&state.sessions, &sid, |t| {
+                            t.record_depgraph_hit_artifact_hit();
+                        });
+                        return response;
+                    }
+                    record_session_stat(&state.sessions, &sid, |t| {
+                        t.record_depgraph_hit_artifact_miss();
+                    });
+                    write_session_log(
+                        &state.sessions,
+                        &sid,
+                        &format!(
+                            "[DIAG] rustc_emit_compat_artifact_not_found: key={artifact_key_hex}"
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
     state.fast_hit_cache.remove(&context_key);
 
     // Cache miss — run the compiler

--- a/crates/zccache/src/depgraph/context/mod.rs
+++ b/crates/zccache/src/depgraph/context/mod.rs
@@ -772,6 +772,170 @@ impl RustcCompileContext {
 
         ContextKey(ContentHash::from_bytes(*hasher.finalize().as_bytes()))
     }
+
+    /// Compatibility key for reusing build-mode rustc metadata during check.
+    ///
+    /// This is deliberately narrower than the normal rustc context key. It is
+    /// only produced for Cargo's check-style metadata emits and the matching
+    /// build-style metadata+link emits:
+    ///
+    /// - `metadata` <-> `metadata,link`
+    /// - `dep-info,metadata` <-> `dep-info,metadata,link`
+    ///
+    /// Cargo gives check and build units different `-C metadata` /
+    /// `-C extra-filename` values, so those output-placement fields are not
+    /// part of this alias. Correctness is guarded later by source/dependency
+    /// content hashes and by comparing current extern content hashes with the
+    /// candidate build entry's extern content hashes.
+    #[must_use]
+    pub fn check_metadata_compat_key_with_root(
+        &self,
+        key_root: Option<&Path>,
+    ) -> Option<ContextKey> {
+        let normalized_emit = normalized_check_metadata_emit(&self.emit_types)?;
+        if self.crate_types.iter().any(|ct| {
+            matches!(
+                ct.as_str(),
+                "bin" | "proc-macro" | "staticlib" | "dylib" | "cdylib"
+            )
+        }) {
+            return None;
+        }
+
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"zccache-rustc-check-metadata-compat-key-v1\0");
+
+        if let Some(ref ch) = self.compiler_hash {
+            hasher.update(b"compiler\0");
+            hasher.update(ch.as_bytes());
+            hasher.update(b"\0");
+        }
+
+        let source_file = normalize_key_path(&self.source_file, key_root);
+        hasher.update(source_file.as_bytes());
+        hasher.update(b"\0");
+
+        if let Some(ref name) = self.crate_name {
+            hasher.update(b"crate-name\0");
+            hasher.update(name.as_bytes());
+            hasher.update(b"\0");
+        }
+
+        hasher.update(b"crate-types\0");
+        for ct in &self.crate_types {
+            hasher.update(ct.as_bytes());
+            hasher.update(b"\0");
+        }
+
+        if let Some(ref edition) = self.edition {
+            hasher.update(b"edition\0");
+            hasher.update(edition.as_bytes());
+            hasher.update(b"\0");
+        }
+
+        hasher.update(b"emit\0");
+        for et in normalized_emit {
+            hasher.update(et.as_bytes());
+            hasher.update(b"\0");
+        }
+
+        hasher.update(b"cfg\0");
+        for cfg in &self.cfgs {
+            hasher.update(cfg.as_bytes());
+            hasher.update(b"\0");
+        }
+
+        hasher.update(b"check-cfg\0");
+        for cfg in &self.check_cfgs {
+            hasher.update(cfg.as_bytes());
+            hasher.update(b"\0");
+        }
+
+        hasher.update(b"codegen\0");
+        for flag in &self.codegen_flags {
+            hasher.update(flag.as_bytes());
+            hasher.update(b"\0");
+        }
+
+        if let Some(ref target) = self.target {
+            hasher.update(b"target\0");
+            hasher.update(target.as_bytes());
+            hasher.update(b"\0");
+        }
+
+        if let Some(ref cap) = self.cap_lints {
+            hasher.update(b"cap-lints\0");
+            hasher.update(cap.as_bytes());
+            hasher.update(b"\0");
+        }
+
+        // Extern paths carry Cargo's check/build-specific filename suffixes.
+        // The compatibility lookup compares extern content hashes by crate
+        // name, so the alias key only needs the names to preserve dependency
+        // shape without baking in the output suffix.
+        hasher.update(b"externs\0");
+        for (name, _) in &self.extern_crates {
+            hasher.update(name.as_bytes());
+            hasher.update(b"\0");
+        }
+
+        hasher.update(b"lints\0");
+        for flag in &self.lint_flags {
+            hasher.update(flag.as_bytes());
+            hasher.update(b"\0");
+        }
+
+        hasher.update(b"unknown\0");
+        for flag in &self.unknown_flags {
+            hasher.update(flag.as_bytes());
+            hasher.update(b"\0");
+        }
+
+        hasher.update(b"remap\0");
+        if key_root.is_some() {
+            let mut remap_path_prefixes: Vec<String> = self
+                .remap_path_prefixes
+                .iter()
+                .map(|remap| normalize_remap_path_prefix_for_key(remap, key_root))
+                .collect();
+            remap_path_prefixes.sort();
+            for remap in &remap_path_prefixes {
+                hasher.update(remap.as_bytes());
+                hasher.update(b"\0");
+            }
+        } else {
+            for remap in &self.remap_path_prefixes {
+                hasher.update(remap.as_bytes());
+                hasher.update(b"\0");
+            }
+        }
+
+        hasher.update(b"env\0");
+        for (key, val) in &self.env_vars {
+            if VOLATILE_CARGO_ENV_VARS.contains(&key.as_str()) {
+                continue;
+            }
+            hasher.update(key.as_bytes());
+            hasher.update(b"=");
+            hasher.update(val.as_bytes());
+            hasher.update(b"\0");
+        }
+
+        Some(ContextKey(ContentHash::from_bytes(
+            *hasher.finalize().as_bytes(),
+        )))
+    }
+}
+
+fn normalized_check_metadata_emit(emit_types: &[String]) -> Option<&'static [&'static str]> {
+    let has = |needle: &str| emit_types.iter().any(|emit| emit == needle);
+    match emit_types.len() {
+        1 if has("metadata") => Some(&["metadata"]),
+        2 if has("metadata") && has("link") => Some(&["metadata"]),
+        2 if has("dep-info") && has("metadata") => Some(&["dep-info", "metadata"]),
+        3 if has("dep-info") && has("metadata") && has("link") => Some(&["dep-info", "metadata"]),
+        _ => None,
+    }
 }
 
 /// Compute the artifact key for a rustc compilation.

--- a/crates/zccache/src/depgraph/context/tests/rustc.rs
+++ b/crates/zccache/src/depgraph/context/tests/rustc.rs
@@ -221,6 +221,46 @@ fn rustc_extra_filename_affects_key() {
 }
 
 #[test]
+fn rustc_check_metadata_compat_key_matches_build_emit_superset() {
+    let mut check = make_rustc_context("/src/lib.rs", "2021");
+    check.emit_types = vec!["dep-info".to_string(), "metadata".to_string()];
+    check.cargo_metadata = Some("check-metadata".to_string());
+    check.extra_filename = Some("-check".to_string());
+    check.extern_crates = vec![("dep".into(), "/target/check/libdep-check.rmeta".into())];
+
+    let mut build = check.clone();
+    build.emit_types = vec![
+        "dep-info".to_string(),
+        "metadata".to_string(),
+        "link".to_string(),
+    ];
+    build.cargo_metadata = Some("build-metadata".to_string());
+    build.extra_filename = Some("-build".to_string());
+    build.extern_crates = vec![("dep".into(), "/target/build/libdep-build.rmeta".into())];
+
+    assert_ne!(check.context_key(), build.context_key());
+    assert_eq!(
+        check.check_metadata_compat_key_with_root(None),
+        build.check_metadata_compat_key_with_root(None),
+        "check metadata should be able to probe build metadata+link via a separate alias"
+    );
+}
+
+#[test]
+fn rustc_check_metadata_compat_key_rejects_non_metadata_shapes() {
+    let mut ctx = make_rustc_context("/src/lib.rs", "2021");
+    ctx.emit_types = vec!["dep-info".to_string(), "link".to_string()];
+    assert!(ctx.check_metadata_compat_key_with_root(None).is_none());
+
+    ctx.emit_types = vec!["llvm-ir".to_string()];
+    assert!(ctx.check_metadata_compat_key_with_root(None).is_none());
+
+    ctx.emit_types = vec!["dep-info".to_string(), "metadata".to_string()];
+    ctx.crate_types = vec!["proc-macro".to_string()];
+    assert!(ctx.check_metadata_compat_key_with_root(None).is_none());
+}
+
+#[test]
 fn rustc_context_key_differs_from_cc() {
     // The domain separation tags differ, so even identical-looking contexts
     // produce different keys.

--- a/crates/zccache/src/depgraph/graph/check.rs
+++ b/crates/zccache/src/depgraph/graph/check.rs
@@ -18,6 +18,156 @@ use super::{
 };
 
 impl DepGraph {
+    pub fn check_rustc_metadata_compat_diagnostic<F, G>(
+        &self,
+        compat_key: &ContextKey,
+        current_externs: &[(String, NormalizedPath)],
+        is_fresh: F,
+        get_hash: G,
+    ) -> (CacheVerdict, String, Option<ContextKey>)
+    where
+        F: Fn(&Path) -> bool,
+        G: Fn(&Path) -> Option<ContentHash>,
+    {
+        let Some(actual_key) = self
+            .rustc_check_metadata_compat
+            .get(compat_key)
+            .map(|entry| *entry)
+        else {
+            return (
+                CacheVerdict::Cold,
+                "rustc metadata compatibility alias not registered".to_string(),
+                None,
+            );
+        };
+
+        let Some(candidate_externs) = self.rustc_extern_inputs(&actual_key) else {
+            return (
+                CacheVerdict::Cold,
+                "rustc metadata compatibility candidate has no extern inputs".to_string(),
+                Some(actual_key),
+            );
+        };
+
+        let entry = match self.contexts.get(&actual_key) {
+            Some(e) => e,
+            None => {
+                return (
+                    CacheVerdict::Cold,
+                    "rustc metadata compatibility candidate context missing".to_string(),
+                    Some(actual_key),
+                );
+            }
+        };
+
+        if entry.state == ContextState::Cold {
+            return (
+                CacheVerdict::Cold,
+                "rustc metadata compatibility candidate is cold".to_string(),
+                Some(actual_key),
+            );
+        }
+        if entry.has_computed_includes {
+            return (
+                CacheVerdict::NeedsPreprocessor,
+                "rustc metadata compatibility candidate needs preprocessor".to_string(),
+                Some(actual_key),
+            );
+        }
+        let Some(artifact_key) = entry.artifact_key else {
+            return (
+                CacheVerdict::Cold,
+                "rustc metadata compatibility candidate has no artifact key".to_string(),
+                Some(actual_key),
+            );
+        };
+
+        let fresh_or_hash_match = |path: &NormalizedPath| -> bool {
+            if is_fresh(path) {
+                return true;
+            }
+            let current = match get_hash(path) {
+                Some(h) => h,
+                None => return false,
+            };
+            entry
+                .last_file_hashes
+                .iter()
+                .any(|(p, h)| p == path && *h == current)
+        };
+
+        if !fresh_or_hash_match(&entry.context.source_file) {
+            return (
+                CacheVerdict::HeadersChanged {
+                    changed: vec![entry.context.source_file.clone()],
+                },
+                "rustc metadata compatibility source changed".to_string(),
+                Some(actual_key),
+            );
+        }
+        for header in &entry.resolved_includes {
+            if !fresh_or_hash_match(header) {
+                return (
+                    CacheVerdict::HeadersChanged {
+                        changed: vec![header.clone()],
+                    },
+                    format!(
+                        "rustc metadata compatibility header changed: {}",
+                        header.display()
+                    ),
+                    Some(actual_key),
+                );
+            }
+        }
+        for fi in &entry.context.force_includes {
+            if !fresh_or_hash_match(fi) {
+                return (
+                    CacheVerdict::HeadersChanged {
+                        changed: vec![fi.clone()],
+                    },
+                    format!(
+                        "rustc metadata compatibility force-include changed: {}",
+                        fi.display()
+                    ),
+                    Some(actual_key),
+                );
+            }
+        }
+
+        let Some(mut current_hashes) = collect_rustc_extern_hashes(current_externs, &get_hash)
+        else {
+            return (
+                CacheVerdict::Cold,
+                "rustc metadata compatibility current extern hash missing".to_string(),
+                Some(actual_key),
+            );
+        };
+        let Some(mut candidate_hashes) = collect_rustc_extern_hashes(&candidate_externs, &get_hash)
+        else {
+            return (
+                CacheVerdict::Cold,
+                "rustc metadata compatibility candidate extern hash missing".to_string(),
+                Some(actual_key),
+            );
+        };
+        current_hashes.sort_by(|a, b| a.0.cmp(&b.0));
+        candidate_hashes.sort_by(|a, b| a.0.cmp(&b.0));
+        if current_hashes != candidate_hashes {
+            return (
+                CacheVerdict::Cold,
+                "rustc metadata compatibility extern content differs".to_string(),
+                Some(actual_key),
+            );
+        }
+
+        self.hits.fetch_add(1, Ordering::Relaxed);
+        (
+            CacheVerdict::Hit { artifact_key },
+            "rustc metadata compatibility hit".to_string(),
+            Some(actual_key),
+        )
+    }
+
     /// Check if a compilation can use cached output.
     ///
     /// `is_fresh` is called for each file path. It should query Layer 1

--- a/crates/zccache/src/depgraph/graph/mod.rs
+++ b/crates/zccache/src/depgraph/graph/mod.rs
@@ -121,6 +121,12 @@ pub struct DepGraph {
     /// their paths are output-placement state. Their content hashes affect the
     /// rustc artifact key by crate name, but target-dir path prefixes must not.
     pub(super) rustc_externs: DashMap<ContextKey, Vec<(String, NormalizedPath)>>,
+    /// Rustc check/build metadata compatibility alias.
+    ///
+    /// Keyed by `RustcCompileContext::check_metadata_compat_key_with_root`.
+    /// Values are exact build-style context keys that can supply `.rmeta`
+    /// and dep-info outputs to a check-style request.
+    pub(super) rustc_check_metadata_compat: DashMap<ContextKey, ContextKey>,
     /// Issue #550: cached normalize_key_path results, keyed by
     /// (path, key_root_identity). The `update()` hot loop calls
     /// `normalize_key_path` once per resolved include header (typically
@@ -266,6 +272,7 @@ impl DepGraph {
             files: DashMap::new(),
             contexts: DashMap::new(),
             rustc_externs: DashMap::new(),
+            rustc_check_metadata_compat: DashMap::new(),
             path_key_cache: DashMap::new(),
             checks: AtomicU64::new(0),
             hits: AtomicU64::new(0),
@@ -322,6 +329,7 @@ impl DepGraph {
             files,
             contexts,
             rustc_externs,
+            rustc_check_metadata_compat: DashMap::new(),
             path_key_cache: DashMap::new(),
             checks: AtomicU64::new(0),
             hits: AtomicU64::new(0),

--- a/crates/zccache/src/depgraph/graph/register.rs
+++ b/crates/zccache/src/depgraph/graph/register.rs
@@ -109,9 +109,14 @@ impl DepGraph {
         ctx: CompileContext,
         key_root: Option<NormalizedPath>,
         externs: Vec<(String, NormalizedPath)>,
+        check_metadata_compat_key: Option<ContextKey>,
     ) -> ContextRegistration {
         let registration = self.register_context_entry(key, ctx, key_root);
         self.rustc_externs.insert(registration.key, externs);
+        if let Some(compat_key) = check_metadata_compat_key {
+            self.rustc_check_metadata_compat
+                .insert(compat_key, registration.key);
+        }
         registration
     }
 

--- a/crates/zccache/src/depgraph/graph/tests.rs
+++ b/crates/zccache/src/depgraph/graph/tests.rs
@@ -212,6 +212,7 @@ fn rustc_extern_artifact_key_ignores_target_dir_path_shape() {
         ctx.clone(),
         None,
         vec![("dep".to_string(), extern_a.clone())],
+        None,
     );
     let first_key = graph
         .update(
@@ -238,6 +239,7 @@ fn rustc_extern_artifact_key_ignores_target_dir_path_shape() {
         ctx,
         None,
         vec![("dep".to_string(), extern_b.clone())],
+        None,
     );
     let verdict = graph.check(&key, always_fresh, |path| {
         if path == Path::new("/src/app.rs") {

--- a/crates/zccache/src/depgraph/snapshot/tests/round_trip.rs
+++ b/crates/zccache/src/depgraph/snapshot/tests/round_trip.rs
@@ -209,7 +209,7 @@ fn rustc_externs_roundtrip() {
         ),
     ];
 
-    graph.register_rustc_with_key_and_root_result(key, ctx, None, externs.clone());
+    graph.register_rustc_with_key_and_root_result(key, ctx, None, externs.clone(), None);
     graph.update(
         &key,
         ScanResult {

--- a/crates/zccache/tests/daemon_rustc_cache_basic_test.rs
+++ b/crates/zccache/tests/daemon_rustc_cache_basic_test.rs
@@ -422,6 +422,109 @@ async fn test_rustc_multi_output_cached() {
     .await;
 }
 
+/// Test check-style metadata can reuse a prior build-style metadata+link artifact.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore] // integration-level: starts real daemon with IPC + rustc
+async fn test_rustc_check_metadata_hits_build_metadata_link() {
+    let rustc = match zccache::test_support::find_rustc() {
+        Some(p) => p,
+        None => return,
+    };
+
+    zccache::test_support::test_timeout(async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("lib.rs");
+        let out_dir = tmp.path().join("deps");
+        std::fs::create_dir_all(&out_dir).unwrap();
+        std::fs::write(&src, "pub fn add(a: i32, b: i32) -> i32 { a + b }\n").unwrap();
+
+        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let session_id = start_session(&mut client).await;
+
+        let rustc_str = rustc.to_string_lossy().to_string();
+        let src_str = src.to_string_lossy().to_string();
+        let out_dir_str = out_dir.to_string_lossy().to_string();
+
+        let build_args = &[
+            "--edition",
+            "2021",
+            "--crate-type",
+            "lib",
+            "--crate-name",
+            "hello",
+            "--emit=dep-info,metadata,link",
+            "-C",
+            "embed-bitcode=no",
+            "-C",
+            "metadata=build123",
+            "-C",
+            "extra-filename=-build123",
+            "--out-dir",
+            &out_dir_str,
+            &src_str,
+        ];
+        let check_args = &[
+            "--edition",
+            "2021",
+            "--crate-type",
+            "lib",
+            "--crate-name",
+            "hello",
+            "--emit=dep-info,metadata",
+            "-C",
+            "embed-bitcode=no",
+            "-C",
+            "metadata=check456",
+            "-C",
+            "extra-filename=-check456",
+            "--out-dir",
+            &out_dir_str,
+            &src_str,
+        ];
+
+        let (exit_code, cached) =
+            compile(&mut client, &session_id, &rustc_str, build_args, tmp.path()).await;
+        assert_eq!(exit_code, 0, "build-style compile should succeed");
+        assert!(!cached, "build-style compile should be a miss");
+
+        let build_rlib = out_dir.join("libhello-build123.rlib");
+        let build_rmeta = out_dir.join("libhello-build123.rmeta");
+        let build_depinfo = out_dir.join("hello-build123.d");
+        assert!(build_rlib.exists());
+        assert!(build_rmeta.exists());
+        assert!(build_depinfo.exists());
+
+        let check_rlib = out_dir.join("libhello-check456.rlib");
+        let check_rmeta = out_dir.join("libhello-check456.rmeta");
+        let check_depinfo = out_dir.join("hello-check456.d");
+        let _ = std::fs::remove_file(&check_rlib);
+        let _ = std::fs::remove_file(&check_rmeta);
+        let _ = std::fs::remove_file(&check_depinfo);
+
+        let (exit_code, cached) =
+            compile(&mut client, &session_id, &rustc_str, check_args, tmp.path()).await;
+        assert_eq!(exit_code, 0, "check-style compile should succeed");
+        assert!(
+            cached,
+            "check-style compile should hit build-style artifact"
+        );
+        assert!(check_rmeta.exists(), "check .rmeta should be materialized");
+        assert!(
+            check_depinfo.exists(),
+            "check dep-info should be materialized"
+        );
+        assert!(
+            !check_rlib.exists(),
+            "compatibility hit must not materialize link output for check"
+        );
+
+        shutdown.notify_one();
+        server_handle.await.unwrap();
+    })
+    .await;
+}
+
 /// Test that changing an extern crate invalidates the cache.
 ///
 /// 1. Compile crate A → libA.rlib

--- a/perf/README.md
+++ b/perf/README.md
@@ -22,8 +22,9 @@ matrix cell in this cluster pins a single failure mode:
 
 | Scenario              | What breaks when this cell turns red                |
 | --------------------- | --------------------------------------------------- |
-| `cold-tar-untar-warm` | cache archive fidelity (tar/untar round-trip)       |
-| `worktree-share`      | `ZCCACHE_PATH_REMAP=auto` injection (issue #352)    |
+| `build-then-check`    | cross-verb build/check cache reuse (soldr#758)       |
+| `cold-tar-untar-warm` | cache archive fidelity (tar/untar round-trip)        |
+| `worktree-share`      | `ZCCACHE_PATH_REMAP=auto` injection (issue #352)     |
 | `touch-no-change`     | mtime/content-hash robustness (soldr save/load #377) |
 
 ## How a worker measures
@@ -78,6 +79,7 @@ perf/
 │   ├── common.sh           # measure::* helpers (rss poller, du, summary)
 │   └── extract.sh          # untar a fixture into $WORKDIR
 ├── scenarios/
+│   ├── build-then-check/run.sh
 │   ├── cold-tar-untar-warm/run.sh
 │   ├── worktree-share/run.sh
 │   └── touch-no-change/run.sh

--- a/perf/scenarios/build-then-check/run.sh
+++ b/perf/scenarios/build-then-check/run.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Scenario: cold `cargo build --release`, then immediate `cargo check
+# --release` against an unchanged source tree.
+#
+# Reproduces soldr#758 for zccache: after build fills the cache with
+# metadata+link artifacts, check should be able to reuse the metadata
+# subset. Today zccache keys split on rustc's `--emit`, so check misses.
+#
+# Usage: run.sh <fixture-workdir>
+set -euo pipefail
+
+if (( $# != 1 )); then
+    echo "usage: run.sh <fixture-workdir>" >&2
+    exit 2
+fi
+
+FIXTURE_DIR="$1"
+SCENARIO="build-then-check"
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../lib/common.sh
+. "${HERE}/../../lib/common.sh"
+
+WORKDIR="$(cd -- "${FIXTURE_DIR}/.." && pwd)"
+CACHE="${WORKDIR}/cache-build-then-check"
+RSS_CSV="${WORKDIR}/rss-${SCENARIO}.csv"
+
+mkdir -p "${CACHE}"
+
+measure::start_rss_poller "${RSS_CSV}"
+trap 'measure::stop_rss_poller' EXIT
+
+# --- Cold build (populates zccache for the release profile) --------
+
+cold_start_ms="$(measure::now_ms)"
+(
+    cd "${FIXTURE_DIR}"
+    SOLDR_CACHE_DIR="${CACHE}" soldr cargo build --release
+)
+cold_elapsed_ms="$(measure::elapsed_ms "${cold_start_ms}")"
+
+# Flush so the depgraph snapshot is durable before the cross-verb pass.
+SOLDR_CACHE_DIR="${CACHE}" soldr cache flush --json >/dev/null 2>&1 || true
+
+# Cargo can sometimes accept build's rmeta as fresh enough and skip rustc
+# entirely. Touch metadata without changing contents so cargo asks rustc for
+# each unit while zccache still sees identical source bytes.
+find "${FIXTURE_DIR}" -name '*.rs' -exec touch {} +
+find "${FIXTURE_DIR}" -name 'Cargo.toml' -exec touch {} +
+find "${FIXTURE_DIR}" -name 'Cargo.lock' -exec touch {} +
+
+# --- Cross-verb check pass -----------------------------------------
+
+warm_start_ms="$(measure::now_ms)"
+(
+    cd "${FIXTURE_DIR}"
+    SOLDR_CACHE_DIR="${CACHE}" soldr cargo check --release
+)
+warm_elapsed_ms="$(measure::elapsed_ms "${warm_start_ms}")"
+
+SOLDR_CACHE_DIR="${CACHE}" soldr cache report --json \
+    > "${WORKDIR}/warm-cache-report.json" 2>/dev/null || true
+cp -R "${CACHE}/cache/zccache/logs" "${WORKDIR}/warm-zccache-logs" 2>/dev/null || true
+
+WARM_STATS_FILE="${CACHE}/cache/zccache/logs/last-session-stats.json"
+if [[ -s "${WARM_STATS_FILE}" ]]; then
+    warm_hits="$(jq -r '.stats.hits // .hits // 0' "${WARM_STATS_FILE}")"
+    warm_misses="$(jq -r '.stats.misses // .misses // 0' "${WARM_STATS_FILE}")"
+    warm_hit_rate="$(jq -r '.stats.hit_rate // .hit_rate // 0' "${WARM_STATS_FILE}")"
+    warm_stats_source="file"
+else
+    warm_stats="$(SOLDR_CACHE_DIR="${CACHE}" measure::session_end_json)"
+    warm_hits="$(echo "${warm_stats}" | jq -r '.stats.hits // 0')"
+    warm_misses="$(echo "${warm_stats}" | jq -r '.stats.misses // 0')"
+    warm_hit_rate="$(echo "${warm_stats}" | jq -r '.stats.hit_rate // 0')"
+    warm_stats_source="session-end"
+fi
+
+SOLDR_CACHE_DIR="${CACHE}" soldr cache shutdown \
+    --shutdown-timeout-seconds 30 --json >"${WORKDIR}/build-then-check-shutdown.json" || true
+
+cache_bytes="$(measure::cache_bytes "${CACHE}")"
+
+# --- Measurement teardown ------------------------------------------
+
+measure::stop_rss_poller
+trap - EXIT
+
+peak_daemon_rss="$(measure::peak_daemon_rss_bytes "${RSS_CSV}")"
+peak_compile_rss="$(measure::peak_compile_rss_bytes "${RSS_CSV}")"
+
+if (( warm_elapsed_ms > 0 )); then
+    speedup="$(awk -v c="${cold_elapsed_ms}" -v w="${warm_elapsed_ms}" 'BEGIN { printf "%.2f", c / w }')"
+else
+    speedup="0.00"
+fi
+
+measure::emit_summary_json "${SCENARIO}" \
+    "cold_ms=${cold_elapsed_ms}" \
+    "warm_ms=${warm_elapsed_ms}" \
+    "speedup=${speedup}" \
+    "warm_hits=${warm_hits}" \
+    "warm_misses=${warm_misses}" \
+    "warm_hit_rate=${warm_hit_rate}" \
+    "warm_stats_source=${warm_stats_source}" \
+    "cache_bytes=${cache_bytes}" \
+    "peak_daemon_rss_bytes=${peak_daemon_rss}" \
+    "peak_compile_rss_bytes=${peak_compile_rss}"
+
+measure::append_summary_md "| ${SCENARIO} | ${cold_elapsed_ms} ms | ${warm_elapsed_ms} ms | ${speedup}x | ${warm_hits}/${warm_misses} | ${warm_hit_rate} | $(( peak_daemon_rss / 1024 / 1024 )) MiB |"


### PR DESCRIPTION
## Summary

- Add a narrow rustc metadata compatibility path so check-style `--emit=metadata` / `--emit=dep-info,metadata` requests can reuse build-style `metadata,link` artifacts.
- Materialize only the outputs requested by `cargo check` so link outputs are not restored for check hits.
- Add focused unit/integration coverage and a Docker perf scenario for the soldr#758 build-then-check repro.

## Root Cause

`cargo build --release` stores rustc artifacts under build-style emits such as `dep-info,metadata,link`, while `cargo check --release` requests `dep-info,metadata`. zccache keyed these as fully distinct rustc contexts, so check missed after build even when the needed metadata output was already present.

## Validation

- `soldr cargo check -p zccache`
- `soldr cargo test -p zccache rustc_check_metadata_compat_key --lib`
- `soldr cargo test -p zccache --test daemon_rustc_cache_basic_test test_rustc_check_metadata_hits_build_metadata_link -- --ignored --nocapture`
- `uv run --no-project python ci/perf_local.py --scenario build-then-check --skip-soldr-build`

Docker repro result: 103 hits / 1 miss, 99.0% hit rate, warm check 1.657s, 50.61x speedup.