### PR TITLE
fix(ci): restore format and dylint gates

### DIFF
--- a/crates/zccache/src/bin/zccache-download.rs
+++ b/crates/zccache/src/bin/zccache-download.rs
@@ -175,7 +175,7 @@ fn main() -> std::process::ExitCode {
                 }
             };
             let mut request = FetchRequest::new(source, destination);
-            request.destination_path_expanded = expanded;
+            request.destination_path_expanded = expanded.map(Into::into);
             request.expected_sha256 = expected_sha256;
             request.archive_format = parse_archive_format(&archive_format);
             request.wait_mode = if no_wait {
@@ -217,7 +217,7 @@ fn main() -> std::process::ExitCode {
                 }
             };
             let mut request = FetchRequest::new(source, destination);
-            request.destination_path_expanded = expanded;
+            request.destination_path_expanded = expanded.map(Into::into);
             request.expected_sha256 = expected_sha256;
             request.archive_format = parse_archive_format(&archive_format);
             match client.exists(&request) {

--- a/crates/zccache/src/cli/commands/service_definition.rs
+++ b/crates/zccache/src/cli/commands/service_definition.rs
@@ -73,20 +73,18 @@ fn zccache_service_definition_v2(
         )
     })?;
 
-    Ok(
-        protocol_v2::ServiceDefinitionBuilder::shared_broker(
-            ZCCACHE_SERVICE_NAME,
-            binary.display().to_string(),
-        )
-        .per_version_binary_dir(binary_dir.display().to_string())
-        .min_version(crate::core::VERSION)
-        .version_allow_list([crate::core::VERSION])
-        .label("vendor", "zackees")
-        .label("package", "zccache")
-        .label("consumer", "zccache")
-        .label("running-process-tracker", "zackees/running-process#435")
-        .build(),
+    Ok(protocol_v2::ServiceDefinitionBuilder::shared_broker(
+        ZCCACHE_SERVICE_NAME,
+        binary.display().to_string(),
     )
+    .per_version_binary_dir(binary_dir.display().to_string())
+    .min_version(crate::core::VERSION)
+    .version_allow_list([crate::core::VERSION])
+    .label("vendor", "zackees")
+    .label("package", "zccache")
+    .label("consumer", "zccache")
+    .label("running-process-tracker", "zackees/running-process#435")
+    .build())
 }
 
 /// Build the zccache daemon service definition for the given daemon binary.

--- a/crates/zccache/src/cli/mod.rs
+++ b/crates/zccache/src/cli/mod.rs
@@ -277,7 +277,7 @@ pub fn build_download_request(params: DownloadParams) -> FetchRequest {
         .archive_path
         .unwrap_or_else(|| infer_download_archive_path(&params.source, params.archive_format));
     let mut request = FetchRequest::new(params.source, archive_path);
-    request.destination_path_expanded = params.unarchive_path;
+    request.destination_path_expanded = params.unarchive_path.map(Into::into);
     request.expected_sha256 = params.expected_sha256;
     request.archive_format = params.archive_format;
     request.wait_mode = params.wait_mode;

--- a/crates/zccache/src/download_client/artifact/mod.rs
+++ b/crates/zccache/src/download_client/artifact/mod.rs
@@ -5,10 +5,9 @@
 //! orchestration that ties them together. All `pub` items are re-exported
 //! here so the public path remains `download_client::artifact::<Name>`.
 
-use std::path::PathBuf;
-
 use serde::{Deserialize, Serialize};
 
+use crate::core::NormalizedPath;
 use crate::download::{DownloadOptions, DownloadPhase};
 
 use super::DownloadClient;
@@ -108,8 +107,8 @@ impl From<Vec<String>> for DownloadSource {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FetchRequest {
     pub source: DownloadSource,
-    pub destination_path: PathBuf,
-    pub destination_path_expanded: Option<PathBuf>,
+    pub destination_path: NormalizedPath,
+    pub destination_path_expanded: Option<NormalizedPath>,
     pub expected_sha256: Option<String>,
     pub archive_format: ArchiveFormat,
     pub wait_mode: WaitMode,
@@ -120,7 +119,10 @@ pub struct FetchRequest {
 
 impl FetchRequest {
     #[must_use]
-    pub fn new(source: impl Into<DownloadSource>, destination_path: impl Into<PathBuf>) -> Self {
+    pub fn new(
+        source: impl Into<DownloadSource>,
+        destination_path: impl Into<NormalizedPath>,
+    ) -> Self {
         Self {
             source: source.into(),
             destination_path: destination_path.into(),
@@ -138,8 +140,8 @@ impl FetchRequest {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FetchResult {
     pub status: FetchStatus,
-    pub cache_path: PathBuf,
-    pub expanded_path: Option<PathBuf>,
+    pub cache_path: NormalizedPath,
+    pub expanded_path: Option<NormalizedPath>,
     pub bytes: Option<u64>,
     pub sha256: String,
 }
@@ -147,8 +149,8 @@ pub struct FetchResult {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FetchState {
     pub kind: FetchStateKind,
-    pub cache_path: PathBuf,
-    pub expanded_path: Option<PathBuf>,
+    pub cache_path: NormalizedPath,
+    pub expanded_path: Option<NormalizedPath>,
     pub bytes: Option<u64>,
     pub sha256: Option<String>,
     pub reason: Option<String>,

--- a/crates/zccache/src/download_client/artifact/resolve.rs
+++ b/crates/zccache/src/download_client/artifact/resolve.rs
@@ -1,5 +1,6 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
+use crate::core::NormalizedPath;
 use crate::download::{canonical_destination, DownloadOptions};
 
 use super::{ArchiveFormat, DownloadSource, FetchRequest, WaitMode};
@@ -7,8 +8,8 @@ use super::{ArchiveFormat, DownloadSource, FetchRequest, WaitMode};
 #[derive(Debug, Clone)]
 pub(super) struct ResolvedFetchRequest {
     pub(super) source: DownloadSource,
-    pub(super) cache_path: PathBuf,
-    pub(super) expanded_path: Option<PathBuf>,
+    pub(super) cache_path: NormalizedPath,
+    pub(super) expanded_path: Option<NormalizedPath>,
     pub(super) expected_sha256: Option<String>,
     pub(super) archive_format: ArchiveFormat,
     pub(super) wait_mode: WaitMode,
@@ -20,9 +21,7 @@ pub(super) struct ResolvedFetchRequest {
 pub(super) fn resolve_request(request: &FetchRequest) -> Result<ResolvedFetchRequest, String> {
     Ok(ResolvedFetchRequest {
         source: normalize_source(request.source.clone())?,
-        cache_path: canonical_destination(&request.destination_path)
-            .map_err(|e| e.to_string())?
-            .into_path_buf(),
+        cache_path: canonical_destination(&request.destination_path).map_err(|e| e.to_string())?,
         expanded_path: request
             .destination_path_expanded
             .as_ref()
@@ -57,7 +56,7 @@ pub(super) fn resolve_request_no_create(
     })
 }
 
-fn normalize_target(path: &Path, create_parent: bool) -> Result<PathBuf, String> {
+fn normalize_target(path: &Path, create_parent: bool) -> Result<NormalizedPath, String> {
     let absolute = if path.is_absolute() {
         path.to_path_buf()
     } else {
@@ -76,9 +75,9 @@ fn normalize_target(path: &Path, create_parent: bool) -> Result<PathBuf, String>
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
         std::fs::canonicalize(parent).map_err(|e| e.to_string())?
     } else {
-        crate::core::NormalizedPath::new(parent).into_path_buf()
+        NormalizedPath::new(parent).into_path_buf()
     };
-    Ok(canonical_parent.join(file_name))
+    Ok(NormalizedPath::new(canonical_parent.join(file_name)))
 }
 
 fn normalize_sha256(value: String) -> String {

--- a/crates/zccache/src/download_client/artifact/tests/fetch.rs
+++ b/crates/zccache/src/download_client/artifact/tests/fetch.rs
@@ -382,7 +382,7 @@ fn fetch_expands_7z_and_exists_reports_expanded_ready() {
     let cache_path = dir.path().join("cache").join("toolchain.7z");
     let expanded_path = dir.path().join("expanded");
     let mut request = FetchRequest::new(server.url.clone(), &cache_path);
-    request.destination_path_expanded = Some(expanded_path.clone());
+    request.destination_path_expanded = Some(expanded_path.clone().into());
     request.expected_sha256 = Some(sha256_hex(&archive_bytes));
 
     let first = fetch_with_retry(&client, request.clone()).unwrap();
@@ -470,12 +470,12 @@ fn expanded_state_remains_valid_when_expected_sha_is_added_later() {
     let expanded_path = dir.path().join("expanded");
 
     let mut initial = FetchRequest::new(server.url.clone(), &cache_path);
-    initial.destination_path_expanded = Some(expanded_path.clone());
+    initial.destination_path_expanded = Some(expanded_path.clone().into());
     let first = fetch_with_retry(&client, initial).unwrap();
     assert_eq!(first.status, FetchStatus::Expanded);
 
     let mut later = FetchRequest::new(server.url.clone(), &cache_path);
-    later.destination_path_expanded = Some(expanded_path.clone());
+    later.destination_path_expanded = Some(expanded_path.clone().into());
     later.expected_sha256 = Some(first.sha256.clone());
     let second = fetch_with_retry(&client, later.clone()).unwrap();
     assert_eq!(second.status, FetchStatus::AlreadyExpanded);
@@ -540,7 +540,7 @@ fn fetch_rejects_unsafe_zip_entries_end_to_end() {
     let cache_path = dir.path().join("cache").join("unsafe.zip");
     let expanded_path = dir.path().join("expanded");
     let mut request = FetchRequest::new(server.url.clone(), &cache_path);
-    request.destination_path_expanded = Some(expanded_path.clone());
+    request.destination_path_expanded = Some(expanded_path.clone().into());
 
     let err = fetch_with_retry(&client, request).unwrap_err();
     assert!(err.contains("unsafe zip entry"));

--- a/crates/zccache/src/ipc/broker.rs
+++ b/crates/zccache/src/ipc/broker.rs
@@ -739,8 +739,8 @@ mod tests {
 
     #[test]
     fn classify_adopt_error_maps_typed_refusals() {
-        use running_process::broker::protocol_v2::client_compat::BrokerClientError;
         use running_process::broker::protocol::ErrorCode;
+        use running_process::broker::protocol_v2::client_compat::BrokerClientError;
 
         let refusal = |code: ErrorCode| {
             AdoptError::Connect(BrokerClientError::Refused {
@@ -860,8 +860,8 @@ mod tests {
     /// Catches the half-done fix where the typed surface drops the hint.
     #[test]
     fn classify_adopt_error_propagates_retry_after_ms_on_v1_rate_limited() {
-        use running_process::broker::protocol_v2::client_compat::BrokerClientError;
         use running_process::broker::protocol::ErrorCode;
+        use running_process::broker::protocol_v2::client_compat::BrokerClientError;
 
         let err = AdoptError::Connect(BrokerClientError::Refused {
             code: ErrorCode::ErrorRateLimited,

--- a/crates/zccache/src/ipc/manifest.rs
+++ b/crates/zccache/src/ipc/manifest.rs
@@ -145,7 +145,9 @@ pub fn build_manifest_builder_v2(cache_dir: &NormalizedPath) -> protocol_v2::Cac
         .broker_instance(SHARED_BROKER_INSTANCE)
         .root(
             V2::CacheData,
-            path_string(&crate::core::config::artifacts_dir_from_cache_dir(cache_dir)),
+            path_string(&crate::core::config::artifacts_dir_from_cache_dir(
+                cache_dir,
+            )),
         )
         .root(V2::CacheIndex, path_string(&index_dir))
         .root(V2::CacheLogs, path_string(&log_dir))
@@ -305,8 +307,8 @@ mod tests {
         );
 
         let bytes = std::fs::read(&v2_path).expect("read v2 file");
-        let decoded = protocol_v2::CacheManifest::decode(bytes.as_slice())
-            .expect("v2 CacheManifest decodes");
+        let decoded =
+            protocol_v2::CacheManifest::decode(bytes.as_slice()).expect("v2 CacheManifest decodes");
 
         assert_eq!(decoded.service_name, "zccache");
         assert_eq!(decoded.service_version, crate::core::VERSION);
@@ -333,9 +335,7 @@ mod tests {
     #[test]
     fn v1_and_v2_manifest_roots_agree_on_wire_values() {
         let cache_dir = NormalizedPath::from("/tmp/zccache-manifest-alignment");
-        let v1 = build_manifest_builder(&cache_dir)
-            .build()
-            .expect("seal v1");
+        let v1 = build_manifest_builder(&cache_dir).build().expect("seal v1");
         let v2 = build_manifest_builder_v2(&cache_dir).build();
         assert_eq!(v1.roots.len(), v2.roots.len(), "same root count");
         for (a, b) in v1.roots.iter().zip(v2.roots.iter()) {

--- a/crates/zccache/src/ipc/transport/probe.rs
+++ b/crates/zccache/src/ipc/transport/probe.rs
@@ -89,8 +89,8 @@ where
 }
 
 fn is_backend_handle_probe_request(frame: &running_process::broker::protocol::Frame) -> bool {
-    use running_process::broker::protocol_v2::backend_handle::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL;
     use running_process::broker::protocol::{FrameKind, PayloadEncoding};
+    use running_process::broker::protocol_v2::backend_handle::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL;
 
     frame.envelope_version == 1
         && FrameKind::try_from(frame.kind) == Ok(FrameKind::Request)
@@ -103,8 +103,8 @@ fn backend_handle_probe_response(
     request: &running_process::broker::protocol::Frame,
     daemon: &running_process::broker::protocol_v2::backend_handle::DaemonProcess,
 ) -> Result<running_process::broker::protocol::Frame, IpcError> {
-    use running_process::broker::protocol_v2::backend_handle::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL;
     use running_process::broker::protocol::{Frame, FrameKind, PayloadEncoding};
+    use running_process::broker::protocol_v2::backend_handle::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL;
 
     let mut payload = Vec::with_capacity(32 + 128);
     payload.extend_from_slice(&request.payload);

--- a/crates/zccache/tests/v2_stress_adversarial_test.rs
+++ b/crates/zccache/tests/v2_stress_adversarial_test.rs
@@ -20,8 +20,8 @@ use running_process::broker::protocol_v2::{
     self, BrokerIsolation, CacheManifestBuilder, CacheRootKind, HttpServerCapability,
     ServiceDefinition, ServiceDefinitionBuilder,
 };
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::Instant;
 
@@ -54,15 +54,13 @@ fn service_definition_install_64x32_concurrent_writes() {
                     // distinct sub-prefix so no cross-thread collision can
                     // mask an actual concurrency bug.
                     let name = format!("zccache-stress-t{tid:02}n{i:02}");
-                    let path = ServiceDefinitionBuilder::shared_broker(
-                        &name,
-                        format!("/usr/bin/{name}"),
-                    )
-                    .min_version("1.0.0")
-                    .label("env", "stress")
-                    .label("thread", format!("{tid}"))
-                    .install_in(dir.path())
-                    .expect("install_in must succeed under concurrency");
+                    let path =
+                        ServiceDefinitionBuilder::shared_broker(&name, format!("/usr/bin/{name}"))
+                            .min_version("1.0.0")
+                            .label("env", "stress")
+                            .label("thread", format!("{tid}"))
+                            .install_in(dir.path())
+                            .expect("install_in must succeed under concurrency");
                     assert!(path.exists(), "install path must materialize");
                     success.fetch_add(1, Ordering::Relaxed);
                 }
@@ -264,9 +262,7 @@ fn probe_local_socket_rejects_full_adversarial_input_set() {
         "x".repeat(8192),
     ];
     for ep in &bad {
-        let err = probe_local_socket(ep).expect_err(
-            "garbage endpoint must Err",
-        );
+        let err = probe_local_socket(ep).expect_err("garbage endpoint must Err");
         let _ = err;
     }
 }
@@ -283,11 +279,11 @@ fn v2_program_pipe_rejects_every_malformed_sid() {
     let bad_sids = [
         "",
         "x",
-        "deadbeef",                          // 8 chars (too short)
-        "deadbeefcafef00d00",                // 18 chars
-        "deadbeefcafef00g",                  // non-hex 'g'
-        "DEADBEEFCAFEF00D",                  // uppercase (rejected per slice 16 tests)
-        "deadbeefcafef00\0",                 // embedded NUL
+        "deadbeef",           // 8 chars (too short)
+        "deadbeefcafef00d00", // 18 chars
+        "deadbeefcafef00g",   // non-hex 'g'
+        "DEADBEEFCAFEF00D",   // uppercase (rejected per slice 16 tests)
+        "deadbeefcafef00\0",  // embedded NUL
     ];
     for sid in bad_sids {
         for idx in [0u32, 1, 0xDEAD_BEEF, u32::MAX] {
@@ -359,13 +355,11 @@ fn dual_write_servicedef_and_manifest_16x_concurrent() {
                 let dir = tempfile::tempdir().expect("tempdir");
                 let svc = format!("zccache-dual-t{tid:02}");
                 // ServiceDefinition v2 write.
-                let sd_path = ServiceDefinitionBuilder::shared_broker(
-                    &svc,
-                    format!("/usr/bin/{svc}"),
-                )
-                .min_version("1.0.0")
-                .install_in(dir.path())
-                .expect("servicedef install");
+                let sd_path =
+                    ServiceDefinitionBuilder::shared_broker(&svc, format!("/usr/bin/{svc}"))
+                        .min_version("1.0.0")
+                        .install_in(dir.path())
+                        .expect("servicedef install");
                 // CacheManifest v2 write into the SAME dir.
                 let mf_path = CacheManifestBuilder::new(&svc, "1.0.0")
                     .root(CacheRootKind::CacheData, format!("/data/{svc}"))


### PR DESCRIPTION
## Summary
- apply rustfmt changes required by the current main formatting gate
- replace artifact download PathBuf surfaces with NormalizedPath so the ban_std_pathbuf Dylint gate no longer flags them
- adapt CLI/test call sites for normalized expanded paths

## Verification
- soldr cargo fmt --all -- --check
- soldr cargo check --workspace
- python -m ci.lint --dylint-only exited 0 locally, but emitted nested-worktree workspace discovery warnings and did not find dylint libraries; GitHub clean checkout should be authoritative for this gate.

Prerequisite for continuing #876 because main currently has a failed CI run.