### PR TITLE
Fix post-876 shutdown validation fallout

### DIFF
--- a/ci/lint.py
+++ b/ci/lint.py
@@ -136,6 +136,13 @@ def ensure_dylint_components():
 
 def lint_dylint_only():
     """Run workspace dylint, retrying after alias repair if cargo-dylint misses it."""
+    if os.name == "nt":
+        print(
+            "Skipping workspace dylint on Windows; the dedicated Dylint CI job runs on Ubuntu.",
+            file=sys.stderr,
+        )
+        return 0
+
     if which("cargo-dylint") is None:
         print(
             "cargo-dylint is required for workspace linting. Install with "

--- a/crates/zccache/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache/src/cli/commands/wrap/ipc.rs
@@ -151,7 +151,6 @@ async fn compile_recv_with_wedge_detection<C: ConnRecv>(
 /// pipe/socket. Two impls live below — one for Unix `IpcConnection`, one
 /// for the Windows client-side `IpcClientConnection`.
 trait ConnRecv {
-    async fn recv(&mut self) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError>;
     async fn recv_with_timeout(
         &mut self,
         timeout: std::time::Duration,
@@ -301,9 +300,6 @@ pub(super) fn wedge_probe_budget() -> Option<std::time::Duration> {
 
 #[cfg(unix)]
 impl ConnRecv for crate::ipc::IpcConnection {
-    async fn recv(&mut self) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError> {
-        crate::ipc::IpcConnection::recv_response(self).await
-    }
     async fn recv_with_timeout(
         &mut self,
         timeout: std::time::Duration,
@@ -314,9 +310,6 @@ impl ConnRecv for crate::ipc::IpcConnection {
 
 #[cfg(windows)]
 impl ConnRecv for crate::ipc::IpcClientConnection {
-    async fn recv(&mut self) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError> {
-        crate::ipc::IpcClientConnection::recv_response(self).await
-    }
     async fn recv_with_timeout(
         &mut self,
         timeout: std::time::Duration,
@@ -632,19 +625,6 @@ mod tests {
     }
 
     impl ConnRecv for FakeConn {
-        async fn recv(
-            &mut self,
-        ) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError> {
-            match &self.behavior {
-                FakeBehavior::Ok(r) => Ok(Some(r.clone())),
-                FakeBehavior::TimesOut => {
-                    // Sleep forever; the outer timeout wrapper handles it.
-                    futures::future::pending::<()>().await;
-                    unreachable!()
-                }
-                FakeBehavior::BrokenPipe => Err(crate::ipc::IpcError::ConnectionClosed),
-            }
-        }
         async fn recv_with_timeout(
             &mut self,
             timeout: std::time::Duration,

--- a/crates/zccache/src/daemon/eviction.rs
+++ b/crates/zccache/src/daemon/eviction.rs
@@ -199,7 +199,7 @@ fn trim_fast_hit_cache_two_pass(
         .iter()
         .filter_map(|entry| {
             if now.saturating_duration_since(entry.value().cached_at) > max_age {
-                Some(entry.key().clone())
+                Some(*entry.key())
             } else {
                 None
             }

--- a/crates/zccache/src/daemon/process.rs
+++ b/crates/zccache/src/daemon/process.rs
@@ -457,18 +457,20 @@ fn child_wait_with_output_timeout(
 
     let stdout = child.stdout.take();
     let stderr = child.stderr.take();
-    let stdout_reader =
-        stdout.map(|mut pipe| std::thread::spawn(move || -> io::Result<Vec<u8>> {
+    let stdout_reader = stdout.map(|mut pipe| {
+        std::thread::spawn(move || -> io::Result<Vec<u8>> {
             let mut bytes = Vec::new();
             pipe.read_to_end(&mut bytes)?;
             Ok(bytes)
-        }));
-    let stderr_reader =
-        stderr.map(|mut pipe| std::thread::spawn(move || -> io::Result<Vec<u8>> {
+        })
+    });
+    let stderr_reader = stderr.map(|mut pipe| {
+        std::thread::spawn(move || -> io::Result<Vec<u8>> {
             let mut bytes = Vec::new();
             pipe.read_to_end(&mut bytes)?;
             Ok(bytes)
-        }));
+        })
+    });
 
     let Some(status) = child.wait_timeout(timeout)? else {
         let _ = child.kill();

--- a/crates/zccache/src/daemon/server/cache_trim.rs
+++ b/crates/zccache/src/daemon/server/cache_trim.rs
@@ -6,14 +6,6 @@
 
 use super::*;
 
-/// Remove fast-hit cache entries older than `max_age`. Returns entries removed.
-pub(crate) fn trim_fast_hit_cache(
-    cache: &DashMap<ContextKey, FastHitEntry>,
-    max_age: Duration,
-) -> usize {
-    trim_fast_hit_cache_at(cache, max_age, Instant::now())
-}
-
 pub(super) fn cache_age_at(now: Instant, cached_at: Instant) -> Duration {
     now.saturating_duration_since(cached_at)
 }
@@ -26,6 +18,7 @@ pub(super) fn cache_entry_fresh_at(now: Instant, cached_at: Instant, max_age: Du
     cache_age_at(now, cached_at) < max_age
 }
 
+#[cfg(test)]
 pub(super) fn trim_fast_hit_cache_at(
     cache: &DashMap<ContextKey, FastHitEntry>,
     max_age: Duration,

--- a/crates/zccache/src/daemon/server/connection.rs
+++ b/crates/zccache/src/daemon/server/connection.rs
@@ -198,6 +198,7 @@ pub(super) async fn handle_connection(
                         }),
                     );
                 }
+                state.shutdown_requested.store(true, Ordering::Release);
                 state.shutdown.notify_waiters();
                 return Ok(());
             }

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline/system_includes.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline/system_includes.rs
@@ -57,12 +57,8 @@ pub(super) async fn discover_system_includes(
         if let Some(paths) = cached {
             paths
         } else {
-            let discovered = discover_system_include_paths(
-                compiler,
-                lineage,
-                compiler_priority,
-                use_fast,
-            );
+            let discovered =
+                discover_system_include_paths(compiler, lineage, compiler_priority, use_fast);
             let mut cache = state.system_includes.lock().await;
             if let Some(paths) = cache.get(compiler) {
                 paths.to_vec()

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -199,6 +199,7 @@ impl DaemonServer {
                 system_includes_loaded: AtomicBool::new(false),
                 artifact_store_loaded: AtomicBool::new(false),
                 shutdown_event_logged: AtomicBool::new(false),
+                shutdown_requested: AtomicBool::new(false),
                 fingerprint: FingerprintManager::new(),
                 dep_graph_persisted: AtomicBool::new(false),
                 dep_graph_load_complete: AtomicBool::new(true),

--- a/crates/zccache/src/daemon/server/mod.rs
+++ b/crates/zccache/src/daemon/server/mod.rs
@@ -108,7 +108,6 @@ mod util;
 mod wal;
 mod watch;
 
-pub(crate) use cache_trim::trim_fast_hit_cache;
 use cache_trim::*;
 use cached_artifact::*;
 pub(crate) use cached_artifact::{CachedArtifact, CachedPayload};

--- a/crates/zccache/src/daemon/server/run.rs
+++ b/crates/zccache/src/daemon/server/run.rs
@@ -96,6 +96,7 @@ impl DaemonServer {
                                 "idle_timeout_secs": timeout,
                             }),
                         );
+                        state.shutdown_requested.store(true, Ordering::Release);
                         state.shutdown.notify_waiters();
                         break;
                     }
@@ -134,6 +135,7 @@ impl DaemonServer {
                                 "removed_pids": prune.removed_pids,
                             }),
                         );
+                        state.shutdown_requested.store(true, Ordering::Release);
                         state.shutdown.notify_waiters();
                         break;
                     }
@@ -230,12 +232,14 @@ impl DaemonServer {
                 // Run once immediately at startup to reclaim excess disk from Bug 5.
                 run_disk_gc_pass(Arc::clone(&state), max_cache_size, "initial").await;
                 loop {
-                    tokio::select! {
-                        () = state.shutdown.notified() => break,
-                        () = tokio::time::sleep(std::time::Duration::from_secs(interval_secs)) => {
-                            run_disk_gc_pass(Arc::clone(&state), max_cache_size, "periodic").await;
-                        }
+                    if state.shutdown_requested.load(Ordering::Acquire) {
+                        break;
                     }
+                    tokio::time::sleep(std::time::Duration::from_secs(interval_secs)).await;
+                    if state.shutdown_requested.load(Ordering::Acquire) {
+                        break;
+                    }
+                    run_disk_gc_pass(Arc::clone(&state), max_cache_size, "periodic").await;
                 }
             });
         }
@@ -286,6 +290,7 @@ impl DaemonServer {
                     );
                 }
                 () = self.shutdown.notified() => {
+                    self.state.shutdown_requested.store(true, Ordering::Release);
                     tracing::info!("daemon server shutting down");
                     // Drop the watcher to stop the OS thread and close channels.
                     // The settle buffer and consumer tasks will exit when their
@@ -608,11 +613,8 @@ impl DaemonServer {
         // Consumer: feeds settled events into CacheSystem for metadata invalidation.
         let state = Arc::clone(&self.state);
         tokio::spawn(async move {
-            loop {
-                let event = tokio::select! {
-                    event = settled_rx.recv() => event,
-                    () = state.shutdown.notified() => break,
-                };
+            while !state.shutdown_requested.load(Ordering::Acquire) {
+                let event = settled_rx.recv().await;
                 let Some(event) = event else { break };
                 match event {
                     SettledEvent::Batch { changed, removed } => {

--- a/crates/zccache/src/daemon/server/state.rs
+++ b/crates/zccache/src/daemon/server/state.rs
@@ -207,6 +207,10 @@ pub(super) struct SharedState {
     /// rows for a single death observed. Guard the write with a compare-and-swap
     /// so only the first Shutdown handler logs.
     pub(super) shutdown_event_logged: AtomicBool,
+    /// Latched once any shutdown source fires. Background tasks use this
+    /// instead of consuming the public shutdown Notify, so legacy
+    /// `shutdown_handle().notify_one()` callers still wake the accept loop.
+    pub(super) shutdown_requested: AtomicBool,
     /// Fingerprint manager: tracks per-watch dirty state for `zccache fp` commands.
     pub(super) fingerprint: FingerprintManager,
     /// Whether the in-memory dep graph is backed by a persisted snapshot.

--- a/crates/zccache/src/depgraph/graph/maintenance.rs
+++ b/crates/zccache/src/depgraph/graph/maintenance.rs
@@ -119,11 +119,8 @@ impl DepGraph {
         // Also trim file entries not referenced by any context.
         let referenced: std::collections::HashSet<NormalizedPath> = self.contexts.iter().fold(
             std::collections::HashSet::new(),
-            |mut paths, entry: dashmap::mapref::multiple::RefMulti<
-                '_,
-                ContextKey,
-                ContextEntry,
-            >| {
+            |mut paths,
+             entry: dashmap::mapref::multiple::RefMulti<'_, ContextKey, ContextEntry>| {
                 let entry = entry.value();
                 paths.extend(entry.resolved_includes.iter().cloned());
                 paths.insert(entry.context.source_file.clone());


### PR DESCRIPTION
## Summary
- latch daemon shutdown state so background tasks do not consume the public shutdown Notify ahead of the accept loop
- preserve existing shutdown_handle().notify_one() behavior used across tests and direct daemon handles
- apply rustfmt/clippy cleanup from post-merge validation
- make `python -m ci.lint --dylint-only` skip on Windows, matching workspace lint behavior

## Validation
- `soldr cargo check --workspace`
- `soldr cargo test --workspace`
- `python -m ci.lint`
- `python -m ci.lint --dylint-only` (skips on Windows)

Refs #876