### PR TITLE
[codex] fix Docker Linux validation

### DIFF
--- a/ci/docker/zccache-builder.Dockerfile
+++ b/ci/docker/zccache-builder.Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update \
         pkg-config \
         libssl-dev \
         ca-certificates \
+        curl \
         git \
  && rm -rf /var/lib/apt/lists/*
 

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -19,6 +19,9 @@ from ci.soldr import cargo_command, rust_tool_command, self_build_env
 SCRIPT_DIR = Path(__file__).parent.parent.resolve()
 DYLINT_TOOLCHAIN = "nightly-2026-03-26"
 DYLINT_COMPONENTS = ["llvm-tools-preview", "rust-src", "rustc-dev"]
+DYLINT_WINDOWS_SKIP = (
+    "Skipping Dylint on Windows; the dedicated Dylint CI job runs on Ubuntu."
+)
 
 
 def is_soldr_cargo_command(cmd):
@@ -134,13 +137,16 @@ def ensure_dylint_components():
     return result.returncode
 
 
+def skip_dylint_on_windows():
+    if os.name != "nt":
+        return False
+    print(DYLINT_WINDOWS_SKIP, file=sys.stderr)
+    return True
+
+
 def lint_dylint_only():
     """Run workspace dylint, retrying after alias repair if cargo-dylint misses it."""
-    if os.name == "nt":
-        print(
-            "Skipping workspace dylint on Windows; the dedicated Dylint CI job runs on Ubuntu.",
-            file=sys.stderr,
-        )
+    if skip_dylint_on_windows():
         return 0
 
     if which("cargo-dylint") is None:
@@ -236,21 +242,23 @@ def lint_workspace():
         print("Formatting issues found. Run './lint --fix' to auto-fix.", file=sys.stderr)
         return result.returncode
 
-    for dylint_manifest in (
-        "dylints/ban_std_pathbuf/Cargo.toml",
-        "dylints/ban_unrooted_tempdir/Cargo.toml",
-    ):
-        result = run_cmd(cargo_command(
-            "fmt",
-            "--manifest-path", dylint_manifest,
-            "--all", "--check",
-        ))
-        if result.returncode != 0:
-            print(
-                f"Dylint library formatting issues found in {dylint_manifest}.",
-                file=sys.stderr,
-            )
-            return result.returncode
+    skip_dylint = skip_dylint_on_windows()
+    if not skip_dylint:
+        for dylint_manifest in (
+            "dylints/ban_std_pathbuf/Cargo.toml",
+            "dylints/ban_unrooted_tempdir/Cargo.toml",
+        ):
+            result = run_cmd(cargo_command(
+                "fmt",
+                "--manifest-path", dylint_manifest,
+                "--all", "--check",
+            ))
+            if result.returncode != 0:
+                print(
+                    f"Dylint library formatting issues found in {dylint_manifest}.",
+                    file=sys.stderr,
+                )
+                return result.returncode
 
     result = run_cmd(cargo_command(
         "clippy", "--workspace", "--all-targets",
@@ -259,12 +267,7 @@ def lint_workspace():
     if result.returncode != 0:
         return result.returncode
 
-    if os.name == "nt":
-        print(
-            "Skipping workspace dylint on Windows; the dedicated Dylint CI job runs on Ubuntu.",
-            file=sys.stderr,
-        )
-    else:
+    if not skip_dylint:
         result = lint_dylint_only()
         if result != 0:
             return result

--- a/crates/zccache/src/daemon/server/watch.rs
+++ b/crates/zccache/src/daemon/server/watch.rs
@@ -107,13 +107,25 @@ async fn watch_one_directory(
     state: &SharedState,
     dir: NormalizedPath,
 ) -> crate::core::Result<bool> {
-    tokio::task::block_in_place(|| {
-        let mut watcher_guard = state.watcher.blocking_lock();
-        if let Some(ref mut w) = *watcher_guard {
-            w.watch(&dir)?;
-            Ok(true)
-        } else {
-            Ok(false)
-        }
-    })
+    if tokio::runtime::Handle::current().runtime_flavor()
+        == tokio::runtime::RuntimeFlavor::MultiThread
+    {
+        return tokio::task::block_in_place(|| {
+            let mut watcher_guard = state.watcher.blocking_lock();
+            if let Some(ref mut w) = *watcher_guard {
+                w.watch(&dir)?;
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        });
+    }
+
+    let mut watcher_guard = state.watcher.lock().await;
+    if let Some(ref mut w) = *watcher_guard {
+        w.watch(&dir)?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
 }

--- a/crates/zccache/tests/artifact_kv_stress.rs
+++ b/crates/zccache/tests/artifact_kv_stress.rs
@@ -312,6 +312,11 @@ fn p4_symlinked_store_dir() {
 #[test]
 fn p5_readonly_dir_put_fails_io() {
     use std::os::unix::fs::PermissionsExt;
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping readonly permission test while running as root");
+        return;
+    }
+
     let dir = tempfile::tempdir().unwrap();
     let s = KvStore::open(dir.path()).unwrap();
     // Make `kv/` un-writable so the spill write path fails.


### PR DESCRIPTION
## Summary

- Skip Dylint-specific work on Windows lint runs, including Dylint crate formatting.
- Avoid `tokio::task::block_in_place` when watcher registration runs under a current-thread Tokio runtime.
- Make the readonly KV stress test skip when running as root in Docker, where Unix mode bits do not enforce the expected failure.
- Add `curl` to the local Docker zccache builder image so Unix installer tests can exercise `install.sh`.

## Validation

- `python ci/perf_local.py cargo test --workspace --no-fail-fast`
- `python ci/perf_local.py --skip-soldr-build`
  - `cold-tar-untar-warm x medium`: PASS, `31.19x` speedup, warm `2.39s`, hit rate `99.4%`
- `python ci/perf_local.py cargo fmt --all -- --check`
- Docker clippy after installing component: `cargo clippy --workspace --all-targets -- -D warnings`
- `python -m ci.lint --dylint-only` on Windows skips successfully
- `python -m py_compile ci\lint.py`