### PR TITLE
[codex] centralize async blocking bridges

### DIFF
--- a/crates/zccache/src/artifact/kv.rs
+++ b/crates/zccache/src/artifact/kv.rs
@@ -355,6 +355,17 @@ impl KvStore {
         }
     }
 
+    /// Async wrapper for [`Self::get`] that runs redb reads and spill-file I/O
+    /// on Tokio's blocking pool.
+    pub async fn get_async(&self, namespace: &str, key: &Key) -> KvResult<Option<Vec<u8>>> {
+        let store = self.clone();
+        let namespace = namespace.to_string();
+        let key = *key;
+        tokio::task::spawn_blocking(move || store.get(&namespace, &key))
+            .await
+            .map_err(|e| KvError::BlockingJoin(e.to_string()))?
+    }
+
     /// Last-writer-wins. Writes spill side files via tempfile + rename so a
     /// crash mid-write leaves no dangling state in the redb row.
     pub fn put(&self, namespace: &str, key: &Key, value: &[u8]) -> KvResult<usize> {
@@ -525,10 +536,30 @@ impl KvStore {
         Ok(out)
     }
 
+    /// Async wrapper for [`Self::list_namespace`] that keeps redb scans off
+    /// Tokio runtime threads.
+    pub async fn list_namespace_async(&self, namespace: &str) -> KvResult<Vec<(Key, u64)>> {
+        let store = self.clone();
+        let namespace = namespace.to_string();
+        tokio::task::spawn_blocking(move || store.list_namespace(&namespace))
+            .await
+            .map_err(|e| KvError::BlockingJoin(e.to_string()))?
+    }
+
     /// Sum of value lengths in `namespace`. Does not include redb overhead.
     pub fn namespace_bytes(&self, namespace: &str) -> KvResult<u64> {
         let entries = self.list_namespace(namespace)?;
         Ok(entries.iter().map(|(_, l)| *l).sum())
+    }
+
+    /// Async wrapper for [`Self::namespace_bytes`] that keeps redb scans off
+    /// Tokio runtime threads.
+    pub async fn namespace_bytes_async(&self, namespace: &str) -> KvResult<u64> {
+        let store = self.clone();
+        let namespace = namespace.to_string();
+        tokio::task::spawn_blocking(move || store.namespace_bytes(&namespace))
+            .await
+            .map_err(|e| KvError::BlockingJoin(e.to_string()))?
     }
 
     /// Sum of value lengths across every namespace.
@@ -546,6 +577,15 @@ impl KvStore {
             }
         }
         Ok(total)
+    }
+
+    /// Async wrapper for [`Self::total_bytes`] that keeps redb scans off Tokio
+    /// runtime threads.
+    pub async fn total_bytes_async(&self) -> KvResult<u64> {
+        let store = self.clone();
+        tokio::task::spawn_blocking(move || store.total_bytes())
+            .await
+            .map_err(|e| KvError::BlockingJoin(e.to_string()))?
     }
 
     /// Per-namespace statistics. Returned namespaces are sorted lexically.
@@ -569,6 +609,15 @@ impl KvStore {
             }
         }
         Ok(by_ns.into_iter().collect())
+    }
+
+    /// Async wrapper for [`Self::stats`] that keeps redb scans off Tokio
+    /// runtime threads.
+    pub async fn stats_async(&self) -> KvResult<Vec<(String, u64)>> {
+        let store = self.clone();
+        tokio::task::spawn_blocking(move || store.stats())
+            .await
+            .map_err(|e| KvError::BlockingJoin(e.to_string()))?
     }
 }
 

--- a/crates/zccache/src/artifact/store.rs
+++ b/crates/zccache/src/artifact/store.rs
@@ -302,10 +302,15 @@ impl ArtifactStore {
 
     /// Async wrapper for [`Self::flush`] that keeps the durable atomic write
     /// path off Tokio runtime threads.
-    pub async fn flush_blocking(self: Arc<Self>) -> std::io::Result<()> {
+    pub async fn flush_async(self: Arc<Self>) -> std::io::Result<()> {
         tokio::task::spawn_blocking(move || self.flush())
             .await
             .map_err(|e| std::io::Error::other(format!("artifact store flush task join: {e}")))?
+    }
+
+    /// Backwards-compatible alias for callers not yet renamed.
+    pub async fn flush_blocking(self: Arc<Self>) -> std::io::Result<()> {
+        self.flush_async().await
     }
 }
 

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -260,9 +260,14 @@ fn run_server(args: Args) {
         // depgraph load itself moves.
 
         // ── Issue #637/#639: discriminate loser-of-race from real bind failure ──
-        let server = match zccache::daemon::DaemonServer::bind(&endpoint) {
-            Ok(s) => s,
-            Err(e) => {
+        let bind_endpoint = endpoint.clone();
+        let bind_result = tokio::task::spawn_blocking(move || {
+            zccache::daemon::DaemonServer::bind(&bind_endpoint)
+        })
+        .await;
+        let server = match bind_result {
+            Ok(Ok(s)) => s,
+            Ok(Err(e)) => {
                 let is_pipe_in_use = matches!(
                     &e,
                     zccache::ipc::IpcError::Io(io_err) if matches!(
@@ -283,6 +288,11 @@ fn run_server(args: Args) {
                     std::process::exit(0);
                 }
                 tracing::error!("failed to bind {endpoint}: {e}");
+                zccache::ipc::remove_lock_file();
+                std::process::exit(1);
+            }
+            Err(e) => {
+                tracing::error!("failed to join daemon bind worker for {endpoint}: {e}");
                 zccache::ipc::remove_lock_file();
                 std::process::exit(1);
             }

--- a/crates/zccache/src/bin/zccache-download-daemon.rs
+++ b/crates/zccache/src/bin/zccache-download-daemon.rs
@@ -90,10 +90,20 @@ fn run_server(args: Args) {
         .build()
         .expect("failed to create runtime");
     rt.block_on(async move {
-        let mut server = match zccache::download_daemon::DownloadDaemon::bind(&endpoint) {
-            Ok(server) => server,
-            Err(err) => {
+        let bind_endpoint = endpoint.clone();
+        let bind_result = tokio::task::spawn_blocking(move || {
+            zccache::download_daemon::DownloadDaemon::bind(&bind_endpoint)
+        })
+        .await;
+        let mut server = match bind_result {
+            Ok(Ok(server)) => server,
+            Ok(Err(err)) => {
                 eprintln!("failed to bind download daemon at {endpoint}: {err}");
+                daemon_mgmt::remove_lock_file();
+                std::process::exit(1);
+            }
+            Err(err) => {
+                eprintln!("failed to join download daemon bind worker for {endpoint}: {err}");
                 daemon_mgmt::remove_lock_file();
                 std::process::exit(1);
             }

--- a/crates/zccache/src/cli/commands/gha.rs
+++ b/crates/zccache/src/cli/commands/gha.rs
@@ -4,7 +4,7 @@ use crate::gha::{GhaCache, GhaError};
 use std::path::Path;
 use std::process::ExitCode;
 
-use super::targz::{tar_gz_decode, tar_gz_encode};
+use super::targz::{tar_gz_decode_async, tar_gz_encode_async};
 
 pub(crate) fn cmd_gha_status() -> ExitCode {
     if GhaCache::is_available() {
@@ -37,8 +37,7 @@ pub(crate) async fn cmd_gha_save(key: &str, path: &str) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    // Create a tar.gz archive in memory.
-    let data = match tar_gz_encode(src) {
+    let data = match tar_gz_encode_async(src.to_path_buf()).await {
         Ok(d) => d,
         Err(e) => {
             eprintln!("zccache gha-cache save: failed to create archive: {e}");
@@ -89,16 +88,17 @@ pub(crate) async fn cmd_gha_restore(key: &str, path: &str) -> ExitCode {
     };
 
     let dest = Path::new(path);
-    if let Err(e) = std::fs::create_dir_all(dest) {
+    if let Err(e) = tokio::fs::create_dir_all(dest).await {
         eprintln!("zccache gha-cache restore: failed to create directory: {e}");
         return ExitCode::FAILURE;
     }
 
-    match tar_gz_decode(&data, dest) {
+    let restored_bytes = data.len();
+    match tar_gz_decode_async(data, dest.to_path_buf()).await {
         Ok(()) => {
             eprintln!(
                 "zccache gha-cache restore: restored {} bytes for key '{key}' to {path}",
-                data.len()
+                restored_bytes
             );
             ExitCode::SUCCESS
         }

--- a/crates/zccache/src/cli/commands/rust_plan.rs
+++ b/crates/zccache/src/cli/commands/rust_plan.rs
@@ -7,7 +7,7 @@ use crate::artifact::{
 };
 use crate::core::NormalizedPath;
 use crate::gha::{GhaCache, GhaError};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use super::args::{RustPlanBackendArg, RustPlanCommands};
@@ -143,11 +143,13 @@ pub(crate) async fn cmd_rust_plan(action: RustPlanCommands) -> ExitCode {
                 Ok(plan) => plan,
                 Err(code) => return code,
             };
-            match restore_rust_plan_layered_local(
-                &plan,
-                Path::new(&base_cache_dir),
-                Path::new(&delta_cache_dir),
-            ) {
+            match restore_rust_plan_layered_local_async(
+                plan.clone(),
+                PathBuf::from(&base_cache_dir),
+                PathBuf::from(&delta_cache_dir),
+            )
+            .await
+            {
                 Ok(mut summary) => {
                     enrich_rust_plan_summary(
                         &mut summary,
@@ -218,11 +220,13 @@ pub(crate) async fn cmd_rust_plan(action: RustPlanCommands) -> ExitCode {
                 Ok(plan) => plan,
                 Err(code) => return code,
             };
-            match save_rust_plan_delta_local(
-                &plan,
-                Path::new(&base_cache_dir),
-                Path::new(&delta_cache_dir),
-            ) {
+            match save_rust_plan_delta_local_async(
+                plan.clone(),
+                PathBuf::from(&base_cache_dir),
+                PathBuf::from(&delta_cache_dir),
+            )
+            .await
+            {
                 Ok(mut summary) => {
                     enrich_rust_plan_summary(
                         &mut summary,
@@ -263,14 +267,81 @@ fn load_rust_plan_for_cli(
     }
 }
 
+async fn run_rust_plan_local_blocking<F, T>(work: F) -> Result<T, RustPlanError>
+where
+    F: FnOnce() -> Result<T, RustPlanError> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(work).await.map_err(|err| {
+        RustPlanError::Io(std::io::Error::other(format!(
+            "blocking rust-plan task failed: {err}"
+        )))
+    })?
+}
+
+async fn restore_rust_plan_local_async(
+    plan: RustArtifactPlanV1,
+    cache_dir: PathBuf,
+) -> Result<RustPlanSummary, RustPlanError> {
+    run_rust_plan_local_blocking(move || restore_rust_plan_local(&plan, &cache_dir)).await
+}
+
+async fn save_rust_plan_local_async(
+    plan: RustArtifactPlanV1,
+    cache_dir: PathBuf,
+) -> Result<RustPlanSummary, RustPlanError> {
+    run_rust_plan_local_blocking(move || save_rust_plan_local(&plan, &cache_dir)).await
+}
+
+async fn restore_rust_plan_layered_local_async(
+    plan: RustArtifactPlanV1,
+    base_cache_dir: PathBuf,
+    delta_cache_dir: PathBuf,
+) -> Result<RustPlanSummary, RustPlanError> {
+    run_rust_plan_local_blocking(move || {
+        restore_rust_plan_layered_local(&plan, &base_cache_dir, &delta_cache_dir)
+    })
+    .await
+}
+
+async fn save_rust_plan_delta_local_async(
+    plan: RustArtifactPlanV1,
+    base_cache_dir: PathBuf,
+    delta_cache_dir: PathBuf,
+) -> Result<RustPlanSummary, RustPlanError> {
+    run_rust_plan_local_blocking(move || {
+        save_rust_plan_delta_local(&plan, &base_cache_dir, &delta_cache_dir)
+    })
+    .await
+}
+
+async fn run_rust_plan_backend_blocking<F, T>(
+    backend: RustPlanBackendArg,
+    work: F,
+) -> Result<T, RustPlanRuntimeError>
+where
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(work)
+        .await
+        .map_err(|err| {
+            rust_plan_backend_failure(backend, format!("blocking rust-plan task failed: {err}"))
+        })?
+        .map_err(|err| rust_plan_backend_failure(backend, err))
+}
+
 async fn run_rust_plan_restore(
     plan: &RustArtifactPlanV1,
     cache_dir: &Path,
     backend: RustPlanBackendArg,
 ) -> Result<RustPlanSummary, RustPlanRuntimeError> {
     match backend {
-        RustPlanBackendArg::Local => restore_rust_plan_local(plan, cache_dir)
-            .map_err(|err| rust_plan_backend_failure(backend, err.to_string())),
+        RustPlanBackendArg::Local => {
+            restore_rust_plan_local_async(plan.clone(), cache_dir.to_path_buf())
+                .await
+                .map_err(|err| rust_plan_backend_failure(backend, err.to_string()))
+        }
         RustPlanBackendArg::Gha => restore_rust_plan_gha(plan, cache_dir).await,
         RustPlanBackendArg::Auto => unreachable!("auto backend is resolved before execution"),
     }
@@ -282,8 +353,11 @@ async fn run_rust_plan_save(
     backend: RustPlanBackendArg,
 ) -> Result<RustPlanSummary, RustPlanRuntimeError> {
     match backend {
-        RustPlanBackendArg::Local => save_rust_plan_local(plan, cache_dir)
-            .map_err(|err| rust_plan_backend_failure(backend, err.to_string())),
+        RustPlanBackendArg::Local => {
+            save_rust_plan_local_async(plan.clone(), cache_dir.to_path_buf())
+                .await
+                .map_err(|err| rust_plan_backend_failure(backend, err.to_string()))
+        }
         RustPlanBackendArg::Gha => save_rust_plan_gha(plan, cache_dir).await,
         RustPlanBackendArg::Auto => unreachable!("auto backend is resolved before execution"),
     }
@@ -313,44 +387,49 @@ async fn restore_rust_plan_gha(
         .await
         .map_err(rust_plan_gha_error)?
     else {
-        let mut summary = restore_rust_plan_local(plan, cache_dir)
+        let mut summary = restore_rust_plan_local_async(plan.clone(), cache_dir.to_path_buf())
+            .await
             .map_err(|err| rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()))?;
         summary.set_backend("gha", Some(cache_key), Some(version));
         summary.record_skip("<gha-cache>", "backend_cache_miss");
         return Ok(summary);
     };
 
-    let bundle_dir = rust_plan_bundle_dir(cache_dir, &cache_key);
-    if bundle_dir.exists() {
-        std::fs::remove_dir_all(&bundle_dir)
-            .map_err(|err| rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()))?;
-    }
-    let bundle_parent = bundle_dir.parent().ok_or_else(|| {
-        rust_plan_backend_failure(
-            RustPlanBackendArg::Gha,
-            "invalid rust-plan bundle path".to_string(),
-        )
-    })?;
-    std::fs::create_dir_all(bundle_parent)
-        .map_err(|err| rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()))?;
-    tar_gz_decode(&data, bundle_parent)
-        .map_err(|err| rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()))?;
-    let mut summary = restore_rust_plan_local(plan, cache_dir)
-        .map_err(|err| rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()))?;
-    summary.set_backend("gha", Some(cache_key), Some(version));
-    Ok(summary)
+    let plan = plan.clone();
+    let cache_dir = cache_dir.to_path_buf();
+    run_rust_plan_backend_blocking(RustPlanBackendArg::Gha, move || {
+        let bundle_dir = rust_plan_bundle_dir(&cache_dir, &cache_key);
+        if bundle_dir.exists() {
+            std::fs::remove_dir_all(&bundle_dir).map_err(|err| err.to_string())?;
+        }
+        let bundle_parent = bundle_dir
+            .parent()
+            .ok_or_else(|| "invalid rust-plan bundle path".to_string())?;
+        std::fs::create_dir_all(bundle_parent).map_err(|err| err.to_string())?;
+        tar_gz_decode(&data, bundle_parent).map_err(|err| err.to_string())?;
+        let mut summary =
+            restore_rust_plan_local(&plan, &cache_dir).map_err(|err| err.to_string())?;
+        summary.set_backend("gha", Some(cache_key), Some(version));
+        Ok(summary)
+    })
+    .await
 }
 
 async fn save_rust_plan_gha(
     plan: &RustArtifactPlanV1,
     cache_dir: &Path,
 ) -> Result<RustPlanSummary, RustPlanRuntimeError> {
-    let summary = save_rust_plan_local(plan, cache_dir)
-        .map_err(|err| rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()))?;
+    let plan = plan.clone();
+    let cache_dir = cache_dir.to_path_buf();
+    let (summary, data) = run_rust_plan_backend_blocking(RustPlanBackendArg::Gha, move || {
+        let summary = save_rust_plan_local(&plan, &cache_dir).map_err(|err| err.to_string())?;
+        let cache_key = summary.cache_key.clone();
+        let bundle_dir = rust_plan_bundle_dir(&cache_dir, &cache_key);
+        let data = tar_gz_encode(&bundle_dir).map_err(|err| err.to_string())?;
+        Ok((summary, data))
+    })
+    .await?;
     let cache_key = summary.cache_key.clone();
-    let bundle_dir = rust_plan_bundle_dir(cache_dir, &cache_key);
-    let data = tar_gz_encode(&bundle_dir)
-        .map_err(|err| rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()))?;
     let version = rust_plan_gha_version(&cache_key);
     let cache = GhaCache::from_env().map_err(rust_plan_gha_error)?;
     cache

--- a/crates/zccache/src/cli/commands/targz.rs
+++ b/crates/zccache/src/cli/commands/targz.rs
@@ -1,6 +1,15 @@
 //! Shared tar+gzip helpers used by `gha-cache` and `rust-plan` backends.
 
 use std::path::Path;
+use std::path::PathBuf;
+
+async fn join_io<T>(
+    handle: tokio::task::JoinHandle<Result<T, std::io::Error>>,
+) -> Result<T, std::io::Error> {
+    handle
+        .await
+        .map_err(|err| std::io::Error::other(format!("blocking archive task failed: {err}")))?
+}
 
 /// Create a tar.gz archive from a directory path.
 pub(crate) fn tar_gz_encode(src: &Path) -> Result<Vec<u8>, std::io::Error> {
@@ -21,6 +30,11 @@ pub(crate) fn tar_gz_encode(src: &Path) -> Result<Vec<u8>, std::io::Error> {
     enc.finish()
 }
 
+/// Create a tar.gz archive from a directory path on Tokio's blocking pool.
+pub(crate) async fn tar_gz_encode_async(src: PathBuf) -> Result<Vec<u8>, std::io::Error> {
+    join_io(tokio::task::spawn_blocking(move || tar_gz_encode(&src))).await
+}
+
 /// Extract a tar.gz archive into a destination directory.
 pub(crate) fn tar_gz_decode(data: &[u8], dest: &Path) -> Result<(), std::io::Error> {
     use flate2::read::GzDecoder;
@@ -28,4 +42,15 @@ pub(crate) fn tar_gz_decode(data: &[u8], dest: &Path) -> Result<(), std::io::Err
     let dec = GzDecoder::new(data);
     let mut archive = tar::Archive::new(dec);
     archive.unpack(dest)
+}
+
+/// Extract a tar.gz archive into a destination directory on Tokio's blocking pool.
+pub(crate) async fn tar_gz_decode_async(
+    data: Vec<u8>,
+    dest: PathBuf,
+) -> Result<(), std::io::Error> {
+    join_io(tokio::task::spawn_blocking(move || {
+        tar_gz_decode(&data, &dest)
+    }))
+    .await
 }

--- a/crates/zccache/src/daemon/process.rs
+++ b/crates/zccache/src/daemon/process.rs
@@ -393,118 +393,6 @@ pub(crate) fn command_output_with_priority(
     command_output_with_priority_stdin(cmd, priority, None)
 }
 
-/// Wait for a synchronous command after applying compiler child priority,
-/// killing the child and returning `TimedOut` when `timeout` elapses.
-pub(crate) fn command_output_with_priority_timeout(
-    cmd: &mut std::process::Command,
-    priority: CompilePriority,
-    timeout: std::time::Duration,
-) -> io::Result<Output> {
-    let decision = priority.resolve_for_current_load();
-    let priority = decision.effective;
-
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        use std::process::Stdio;
-
-        cmd.stdin(Stdio::null());
-        cmd.stdout(Stdio::piped());
-        cmd.stderr(Stdio::piped());
-        cmd.creation_flags(child_creation_flags(priority));
-        let child = cmd.spawn()?;
-        assign_child_to_daemon_job(child.as_raw_handle());
-        apply_priority_to_child_windows(child.as_raw_handle(), priority);
-        child_wait_with_output_timeout(child, timeout)
-    }
-
-    #[cfg(unix)]
-    {
-        use std::process::Stdio;
-
-        cmd.stdin(Stdio::null());
-        cmd.stdout(Stdio::piped());
-        cmd.stderr(Stdio::piped());
-        let child = cmd.spawn()?;
-        apply_priority_to_child_unix(child.id(), priority);
-        child_wait_with_output_timeout(child, timeout)
-    }
-
-    #[cfg(not(any(unix, windows)))]
-    {
-        use std::process::Stdio;
-
-        if priority != CompilePriority::Normal {
-            tracing::debug!(
-                ?priority,
-                "compiler child priority is unsupported on this platform"
-            );
-        }
-        cmd.stdin(Stdio::null());
-        cmd.stdout(Stdio::piped());
-        cmd.stderr(Stdio::piped());
-        let child = cmd.spawn()?;
-        child_wait_with_output_timeout(child, timeout)
-    }
-}
-
-fn child_wait_with_output_timeout(
-    mut child: std::process::Child,
-    timeout: std::time::Duration,
-) -> io::Result<Output> {
-    use std::io::Read;
-    use wait_timeout::ChildExt;
-
-    let stdout = child.stdout.take();
-    let stderr = child.stderr.take();
-    let stdout_reader = stdout.map(|mut pipe| {
-        std::thread::spawn(move || -> io::Result<Vec<u8>> {
-            let mut bytes = Vec::new();
-            pipe.read_to_end(&mut bytes)?;
-            Ok(bytes)
-        })
-    });
-    let stderr_reader = stderr.map(|mut pipe| {
-        std::thread::spawn(move || -> io::Result<Vec<u8>> {
-            let mut bytes = Vec::new();
-            pipe.read_to_end(&mut bytes)?;
-            Ok(bytes)
-        })
-    });
-
-    let Some(status) = child.wait_timeout(timeout)? else {
-        let _ = child.kill();
-        let _ = child.wait();
-        // Do not join output reader threads on timeout: descendants may still
-        // hold inherited pipe handles open after the parent is killed.
-        let _ = stdout_reader;
-        let _ = stderr_reader;
-        return Err(io::Error::new(
-            io::ErrorKind::TimedOut,
-            format!("child process timed out after {timeout:?}"),
-        ));
-    };
-
-    let stdout = join_output_reader(stdout_reader)?;
-    let stderr = join_output_reader(stderr_reader)?;
-    Ok(Output {
-        status,
-        stdout,
-        stderr,
-    })
-}
-
-fn join_output_reader(
-    reader: Option<std::thread::JoinHandle<io::Result<Vec<u8>>>>,
-) -> io::Result<Vec<u8>> {
-    match reader {
-        Some(handle) => handle
-            .join()
-            .map_err(|_| io::Error::other("child output reader thread panicked"))?,
-        None => Ok(Vec::new()),
-    }
-}
-
 /// Sync variant that pipes `stdin_bytes` into the child's stdin when the
 /// slice is `Some` and non-empty. `None` or empty = `Stdio::null()` (the
 /// previous behaviour). Use this in the non-cacheable / direct-run path
@@ -593,6 +481,23 @@ pub(crate) async fn tokio_command_output_with_priority(
     tokio_command_output_with_priority_stdin(cmd, priority, None).await
 }
 
+/// Wait for an async command after applying compiler child priority, killing
+/// the child and returning `TimedOut` when `timeout` elapses.
+pub(crate) async fn tokio_command_output_with_priority_timeout(
+    cmd: &mut tokio::process::Command,
+    priority: CompilePriority,
+    timeout: std::time::Duration,
+) -> io::Result<Output> {
+    let wait = tokio_command_output_with_priority_stdin(cmd, priority, None);
+    match tokio::time::timeout(timeout, wait).await {
+        Ok(result) => result,
+        Err(_) => Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("child process timed out after {timeout:?}"),
+        )),
+    }
+}
+
 /// Async variant that pipes `stdin_bytes` into the child's stdin when the
 /// slice is `Some` and non-empty. See [`command_output_with_priority_stdin`].
 pub(crate) async fn tokio_command_output_with_priority_stdin(
@@ -616,6 +521,7 @@ pub(crate) async fn tokio_command_output_with_priority_stdin(
         }
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
+        cmd.kill_on_drop(true);
         cmd.creation_flags(child_creation_flags(priority));
         let mut child = cmd.spawn()?;
         if let Some(handle) = child.raw_handle() {
@@ -643,6 +549,7 @@ pub(crate) async fn tokio_command_output_with_priority_stdin(
         }
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
+        cmd.kill_on_drop(true);
         let mut child = cmd.spawn()?;
         if let Some(pid) = child.id() {
             apply_priority_to_child_unix(pid, priority);

--- a/crates/zccache/src/daemon/server/compiler_hash.rs
+++ b/crates/zccache/src/daemon/server/compiler_hash.rs
@@ -100,6 +100,39 @@ impl CompilerHashCache {
         Some(hash)
     }
 
+    pub(super) async fn get_or_hash_with_async<F, Fut>(
+        &self,
+        path: &Path,
+        hasher: F,
+    ) -> Option<ContentHash>
+    where
+        F: FnOnce(std::path::PathBuf) -> Fut,
+        Fut: std::future::Future<Output = Option<ContentHash>>,
+    {
+        let metadata = std::fs::metadata(path).ok()?;
+        let mtime = metadata.modified().ok()?;
+        let size = metadata.len();
+        let key = NormalizedPath::new(path);
+
+        if let Some(entry) = self.entries.get(&key) {
+            if entry.mtime == mtime && entry.size == size {
+                return Some(entry.hash);
+            }
+        }
+
+        let hash = hasher(path.to_path_buf()).await?;
+        let post_metadata = std::fs::metadata(path).ok()?;
+        let post_mtime = post_metadata.modified().ok()?;
+        let post_size = post_metadata.len();
+        if post_mtime != mtime || post_size != size {
+            return Some(hash);
+        }
+
+        self.entries
+            .insert(key, CompilerHashEntry { mtime, size, hash });
+        Some(hash)
+    }
+
     /// Persist the cache to `path` as a versioned bincode snapshot.
     ///
     /// Atomic on success: writes to `<path>.tmp-<pid>`, then renames over
@@ -238,9 +271,25 @@ pub(super) fn hash_rustc_identity(path: &Path) -> Option<ContentHash> {
         Ok(output) if output.status.success() && !output.stdout.is_empty() => {
             Some(crate::hash::hash_bytes(&output.stdout))
         }
-        // Spawn error, non-zero exit, or empty stdout — fall through to
+        // Spawn error, non-zero exit, or empty stdout - fall through to
         // the file-content hash so cache keys stay well-defined for
         // stubbed binaries (unit tests) and broken toolchains.
         _ => crate::hash::hash_file(path).ok(),
+    }
+}
+
+pub(super) async fn hash_rustc_identity_async(path: std::path::PathBuf) -> Option<ContentHash> {
+    match tokio::process::Command::new(&path)
+        .arg("-vV")
+        .output()
+        .await
+    {
+        Ok(output) if output.status.success() && !output.stdout.is_empty() => {
+            Some(crate::hash::hash_bytes(&output.stdout))
+        }
+        // Spawn error, non-zero exit, or empty stdout - fall through to
+        // the file-content hash so cache keys stay well-defined for
+        // stubbed binaries (unit tests) and broken toolchains.
+        _ => crate::hash::hash_file(&path).ok(),
     }
 }

--- a/crates/zccache/src/daemon/server/handle_clear.rs
+++ b/crates/zccache/src/daemon/server/handle_clear.rs
@@ -58,7 +58,7 @@ pub(super) async fn handle_clear(state: &SharedState) -> Response {
 
     // Clear the in-memory artifact index and persist the empty state.
     state.artifact_store.clear();
-    let _ = state.artifact_store.flush();
+    let _ = Arc::clone(&state.artifact_store).flush_async().await;
 
     // Persist the (now empty) metadata cache so the prior on-disk
     // snapshot stays consistent with the live state. Empty snapshots

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -214,13 +214,14 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
 
     let t1 = std::time::Instant::now();
     let env_slice = client_env.as_deref().unwrap_or(&[]);
-    let build_result = build_compile_context(
+    let build_result = build_compile_context_async(
         &compilation,
         &cwd_path,
         &system_includes,
         env_slice,
         &state.compiler_hash_cache,
-    );
+    )
+    .await;
     let default_key_root = worktree_root.clone().unwrap_or_else(|| cwd_path.clone());
     // Issue #474: PCH (output ends in .pch / .gch) and MSVC compiles must
     // get a per-worktree cache key — the compiler embeds absolute paths in
@@ -761,7 +762,6 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             context_key: &context_key,
             source_path: &source_path,
             output_path: &output_path,
-            cwd,
             cwd_path: &cwd_path,
             ctx: &ctx,
             compilation: &compilation,

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -18,7 +18,6 @@ pub(super) struct StoreOutcomeRequest<'a> {
     pub(super) context_key: &'a ContextKey,
     pub(super) source_path: &'a NormalizedPath,
     pub(super) output_path: &'a NormalizedPath,
-    pub(super) cwd: &'a Path,
     pub(super) cwd_path: &'a NormalizedPath,
     pub(super) ctx: &'a CompileContext,
     pub(super) compilation: &'a crate::compiler::CacheableCompilation,
@@ -52,6 +51,144 @@ pub(super) struct StoreOutcomeRequest<'a> {
     pub(super) break_outputs_ns: u64,
 }
 
+enum CompileOutputCollection {
+    Rustc(Vec<RustcOutputFile>),
+    Bytes(Vec<u8>),
+}
+
+async fn collect_compile_outputs_blocking(
+    is_rustc: bool,
+    rustc_args: Option<crate::depgraph::RustcParsedArgs>,
+    output_path: NormalizedPath,
+    cwd_path: NormalizedPath,
+) -> std::io::Result<CompileOutputCollection> {
+    tokio::task::spawn_blocking(move || {
+        if is_rustc {
+            let Some(rustc_args) = rustc_args else {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "missing parsed rustc args for rustc output collection",
+                ));
+            };
+            let outputs = collect_rustc_output_files(&rustc_args, &output_path, &cwd_path);
+            if outputs.is_empty() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "rustc primary output was not found",
+                ));
+            }
+            Ok(CompileOutputCollection::Rustc(outputs))
+        } else {
+            std::fs::read(&output_path).map(CompileOutputCollection::Bytes)
+        }
+    })
+    .await
+    .map_err(|e| std::io::Error::other(format!("compile output worker failed: {e}")))?
+}
+
+struct CompileScanRequest {
+    is_rustc: bool,
+    rustc_args: Option<crate::depgraph::RustcParsedArgs>,
+    source_path: NormalizedPath,
+    cwd_path: NormalizedPath,
+    depfile_strategy: DepfileStrategy,
+    show_includes_scan: Option<crate::depgraph::ScanResult>,
+    include_search: crate::depgraph::IncludeSearchPaths,
+}
+
+struct CompileScanCollection {
+    scan_result: crate::depgraph::ScanResult,
+    user_depfile_capture: Option<(NormalizedPath, Vec<u8>)>,
+    depfile_parse_warning: Option<String>,
+}
+
+async fn collect_compile_scan_blocking(req: CompileScanRequest) -> CompileScanCollection {
+    tokio::task::spawn_blocking(move || collect_compile_scan(req))
+        .await
+        .unwrap_or_else(|e| CompileScanCollection {
+            scan_result: crate::depgraph::ScanResult {
+                resolved: Vec::new(),
+                unresolved: vec![format!("compile dependency scan worker failed: {e}")],
+                has_computed: false,
+            },
+            user_depfile_capture: None,
+            depfile_parse_warning: None,
+        })
+}
+
+fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
+    let CompileScanRequest {
+        is_rustc,
+        rustc_args,
+        source_path,
+        cwd_path,
+        depfile_strategy,
+        show_includes_scan,
+        include_search,
+    } = req;
+
+    if is_rustc {
+        let scan_result = rustc_args.as_ref().map_or_else(
+            || crate::depgraph::ScanResult {
+                resolved: Vec::new(),
+                unresolved: vec!["missing parsed rustc args for rustc dependency scan".into()],
+                has_computed: false,
+            },
+            |args| scan_rustc_deps(args, &source_path, &cwd_path),
+        );
+        return CompileScanCollection {
+            scan_result,
+            user_depfile_capture: None,
+            depfile_parse_warning: None,
+        };
+    }
+
+    let mut user_depfile_capture = None;
+    let mut depfile_parse_warning = None;
+    let scan_result = match &depfile_strategy {
+        DepfileStrategy::Injected { path }
+        | DepfileStrategy::UserSpecified { path }
+        | DepfileStrategy::UserDefault { path } => {
+            let want_capture = matches!(
+                depfile_strategy,
+                DepfileStrategy::UserSpecified { .. } | DepfileStrategy::UserDefault { .. }
+            );
+            match crate::depgraph::depfile::parse_depfile_path(path, &source_path, &cwd_path) {
+                Ok(result) => {
+                    if want_capture {
+                        if let Ok(bytes) = std::fs::read(path) {
+                            user_depfile_capture = Some((path.clone(), bytes));
+                        }
+                    }
+                    if matches!(depfile_strategy, DepfileStrategy::Injected { .. }) {
+                        let _ = std::fs::remove_file(path);
+                    }
+                    result
+                }
+                Err(e) => {
+                    depfile_parse_warning = Some(format!("path={} error={e}", path.display()));
+                    if matches!(depfile_strategy, DepfileStrategy::Injected { .. }) {
+                        let _ = std::fs::remove_file(path);
+                    }
+                    crate::depgraph::scanner::scan_recursive(&source_path, &include_search)
+                }
+            }
+        }
+        DepfileStrategy::ShowIncludes => show_includes_scan.unwrap_or_else(|| {
+            crate::depgraph::scanner::scan_recursive(&source_path, &include_search)
+        }),
+        DepfileStrategy::Unsupported => {
+            crate::depgraph::scanner::scan_recursive(&source_path, &include_search)
+        }
+    };
+
+    CompileScanCollection {
+        scan_result,
+        user_depfile_capture,
+        depfile_parse_warning,
+    }
+}
+
 /// Drive the post-compile success path. Returns `Some(Response)` only when an
 /// output-collection failure forces an uncached `CompileResult`; otherwise
 /// returns `None` to signal the orchestrator should respond with the standard
@@ -64,7 +201,6 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         context_key,
         source_path,
         output_path,
-        cwd,
         cwd_path,
         ctx,
         compilation,
@@ -111,10 +247,22 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
     // cache files after the artifact key is known, avoiding foreground
     // reads of .rlib/.rmeta/.d on cold misses.
     let t_collect_outputs = std::time::Instant::now();
-    let (output_data, rustc_all_outputs) = if is_rustc {
-        let all = collect_rustc_output_files(rustc_args_opt.unwrap(), output_path, cwd_path);
-        if all.is_empty() {
-            tracing::warn!("failed to stat output file {}", output_path.display());
+    let rustc_args_owned = rustc_args_opt.cloned();
+    let output_collection = match collect_compile_outputs_blocking(
+        is_rustc,
+        rustc_args_owned.clone(),
+        output_path.clone(),
+        cwd_path.clone(),
+    )
+    .await
+    {
+        Ok(output_collection) => output_collection,
+        Err(e) => {
+            if is_rustc {
+                tracing::warn!("failed to stat output file {}: {e}", output_path.display());
+            } else {
+                tracing::warn!("failed to read output file {}: {e}", output_path.display());
+            }
             return Some(Response::CompileResult {
                 exit_code,
                 stdout: Arc::clone(&stdout),
@@ -122,20 +270,10 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
                 cached: false,
             });
         }
-        (Vec::new(), Some(all))
-    } else {
-        match std::fs::read(output_path) {
-            Ok(data) => (data, None),
-            Err(e) => {
-                tracing::warn!("failed to read output file {}: {e}", output_path.display());
-                return Some(Response::CompileResult {
-                    exit_code,
-                    stdout: Arc::clone(&stdout),
-                    stderr: Arc::clone(&stderr),
-                    cached: false,
-                });
-            }
-        }
+    };
+    let (output_data, rustc_all_outputs) = match output_collection {
+        CompileOutputCollection::Rustc(outputs) => (Vec::new(), Some(outputs)),
+        CompileOutputCollection::Bytes(data) => (data, None),
     };
     let collect_outputs_ns = t_collect_outputs.elapsed().as_nanos() as u64;
     let rust_output_count = rustc_all_outputs.as_ref().map_or(1, Vec::len);
@@ -155,61 +293,29 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
     // *current* build's `-MF` target, even after `git clean` or
     // worktree-rename — closing the stale-incremental-build bug.
     let t_scan = std::time::Instant::now();
-    let mut user_depfile_capture: Option<(NormalizedPath, Vec<u8>)> = None;
-    let scan_result = if is_rustc {
-        // Rustc: try to parse the dep-info file if --emit included dep-info.
-        // The dep-info file is in --out-dir with crate name and extra-filename.
-        scan_rustc_deps(rustc_args_opt.unwrap(), source_path, cwd_path)
-    } else {
-        match &depfile_strategy {
-            DepfileStrategy::Injected { path }
-            | DepfileStrategy::UserSpecified { path }
-            | DepfileStrategy::UserDefault { path } => {
-                let want_capture = matches!(
-                    depfile_strategy,
-                    DepfileStrategy::UserSpecified { .. } | DepfileStrategy::UserDefault { .. }
-                );
-                let scan_cwd: NormalizedPath = cwd.into();
-                match crate::depgraph::depfile::parse_depfile_path(path, source_path, &scan_cwd) {
-                    Ok(result) => {
-                        if want_capture {
-                            if let Ok(bytes) = std::fs::read(path) {
-                                user_depfile_capture = Some((path.clone(), bytes));
-                            }
-                        }
-                        if matches!(depfile_strategy, DepfileStrategy::Injected { .. }) {
-                            let _ = std::fs::remove_file(path);
-                        }
-                        result
-                    }
-                    Err(e) => {
-                        tracing::warn!("depfile parse failed, falling back to scanner: {e}");
-                        write_session_log(
-                            &state.sessions,
-                            sid,
-                            &format!(
-                                "[DIAG] depfile_parse_fail: path={} error={e}",
-                                path.display()
-                            ),
-                        );
-                        if matches!(depfile_strategy, DepfileStrategy::Injected { .. }) {
-                            let _ = std::fs::remove_file(path);
-                        }
-                        crate::depgraph::scanner::scan_recursive(source_path, &ctx.include_search)
-                    }
-                }
-            }
-            DepfileStrategy::ShowIncludes => {
-                // Already parsed from stderr above.
-                show_includes_scan.unwrap_or_else(|| {
-                    crate::depgraph::scanner::scan_recursive(source_path, &ctx.include_search)
-                })
-            }
-            DepfileStrategy::Unsupported => {
-                crate::depgraph::scanner::scan_recursive(source_path, &ctx.include_search)
-            }
-        }
+    let scan_collection = collect_compile_scan_blocking(CompileScanRequest {
+        is_rustc,
+        rustc_args: rustc_args_owned,
+        source_path: source_path.clone(),
+        cwd_path: cwd_path.clone(),
+        depfile_strategy,
+        show_includes_scan,
+        include_search: ctx.include_search.clone(),
+    })
+    .await;
+    if let Some(warning) = &scan_collection.depfile_parse_warning {
+        tracing::warn!("depfile parse failed, falling back to scanner: {warning}");
+        write_session_log(
+            &state.sessions,
+            sid,
+            &format!("[DIAG] depfile_parse_fail: {warning}"),
+        );
     };
+    let CompileScanCollection {
+        scan_result,
+        user_depfile_capture,
+        ..
+    } = scan_collection;
     let include_scan_ns = t_scan.elapsed().as_nanos() as u64;
 
     // Register scanned paths for zero-syscall fast path on future hits.

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline/system_includes.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline/system_includes.rs
@@ -58,7 +58,7 @@ pub(super) async fn discover_system_includes(
             paths
         } else {
             let discovered =
-                discover_system_include_paths(compiler, lineage, compiler_priority, use_fast);
+                discover_system_include_paths(compiler, lineage, compiler_priority, use_fast).await;
             let mut cache = state.system_includes.lock().await;
             if let Some(paths) = cache.get(compiler) {
                 paths.to_vec()
@@ -91,7 +91,7 @@ pub(super) async fn discover_system_includes(
     }
 }
 
-fn discover_system_include_paths(
+async fn discover_system_include_paths(
     compiler: &NormalizedPath,
     lineage: &crate::daemon::lineage::Lineage,
     compiler_priority: CompilePriority,
@@ -102,7 +102,7 @@ fn discover_system_include_paths(
     } else {
         crate::depgraph::discovery_args()
     };
-    let output = run_discovery_command(compiler, &disc_args, lineage, compiler_priority);
+    let output = run_discovery_command(compiler, &disc_args, lineage, compiler_priority).await;
     match output {
         Ok(out) => {
             let stderr = String::from_utf8_lossy(&out.stderr);
@@ -118,7 +118,8 @@ fn discover_system_include_paths(
             // discovery. The cache memoizes the result either way.
             if use_fast && paths.is_empty() {
                 let slow_args = crate::depgraph::discovery_args();
-                match run_discovery_command(compiler, &slow_args, lineage, compiler_priority) {
+                match run_discovery_command(compiler, &slow_args, lineage, compiler_priority).await
+                {
                     Ok(out) => {
                         let stderr = String::from_utf8_lossy(&out.stderr);
                         paths = crate::depgraph::parse_system_include_output(&stderr);
@@ -139,18 +140,19 @@ fn discover_system_include_paths(
     }
 }
 
-fn run_discovery_command(
+async fn run_discovery_command(
     compiler: &NormalizedPath,
     args: &[&str],
     lineage: &crate::daemon::lineage::Lineage,
     compiler_priority: CompilePriority,
 ) -> std::io::Result<std::process::Output> {
-    let mut cmd = std::process::Command::new(compiler);
+    let mut cmd = tokio::process::Command::new(compiler);
     cmd.args(args);
-    lineage.apply_to_sync(&mut cmd, None);
-    crate::daemon::process::command_output_with_priority_timeout(
+    lineage.apply_to_tokio(&mut cmd, None);
+    crate::daemon::process::tokio_command_output_with_priority_timeout(
         &mut cmd,
         compiler_priority,
         SYSTEM_INCLUDE_DISCOVERY_TIMEOUT,
     )
+    .await
 }

--- a/crates/zccache/src/daemon/server/handle_link.rs
+++ b/crates/zccache/src/daemon/server/handle_link.rs
@@ -595,7 +595,7 @@ pub(super) async fn run_tool_passthrough(
         }
     };
 
-    let mut cmd = std::process::Command::new(tool);
+    let mut cmd = tokio::process::Command::new(tool);
     if let Some(ref rsp) = _rsp_guard {
         cmd.arg(rsp.at_arg());
     } else {
@@ -603,10 +603,10 @@ pub(super) async fn run_tool_passthrough(
     }
     cmd.current_dir(cwd);
 
-    apply_client_env_sync(&mut cmd, env.as_deref(), lineage);
+    apply_client_env(&mut cmd, &env, lineage);
 
     let priority = CompilePriority::from_client_env(env.as_deref());
-    match super::super::process::command_output_with_priority(&mut cmd, priority) {
+    match super::super::process::tokio_command_output_with_priority(&mut cmd, priority).await {
         Ok(output) => Response::LinkResult {
             exit_code: output.status.code().unwrap_or(1),
             stdout: Arc::new(output.stdout),
@@ -666,7 +666,7 @@ pub(super) async fn run_post_link_deploy_hook(
     };
     let extra_args: Vec<&str> = parts.collect();
 
-    let mut cmd = std::process::Command::new(program);
+    let mut cmd = tokio::process::Command::new(program);
     cmd.args(&extra_args);
     cmd.arg(output_path);
 
@@ -680,7 +680,15 @@ pub(super) async fn run_post_link_deploy_hook(
     // language-specific vars (CLANG_TOOL_CHAIN_*), etc. Spawn-lineage env
     // vars are layered on top so the hook (and anything it spawns) can be
     // attributed back to the daemon.
-    apply_client_env_sync(&mut cmd, env, lineage);
+    if let Some(vars) = env {
+        cmd.env_clear();
+        for (key, val) in vars {
+            if client_env_var_is_safe_to_replay(key) {
+                cmd.env(key, val);
+            }
+        }
+    }
+    lineage.apply_to_tokio(&mut cmd, env);
 
     tracing::debug!(
         program = %program,
@@ -689,7 +697,7 @@ pub(super) async fn run_post_link_deploy_hook(
     );
 
     let priority = CompilePriority::from_client_env(env);
-    match super::super::process::command_output_with_priority(&mut cmd, priority) {
+    match super::super::process::tokio_command_output_with_priority(&mut cmd, priority).await {
         Ok(out) if out.status.success() => {
             tracing::debug!(
                 program = %program,

--- a/crates/zccache/src/daemon/server/run.rs
+++ b/crates/zccache/src/daemon/server/run.rs
@@ -361,7 +361,7 @@ impl DaemonServer {
                     let store = Arc::clone(&self.state.artifact_store);
                     let entries = store.len();
                     let flush_start = std::time::Instant::now();
-                    let res = store.flush_blocking().await;
+                    let res = store.flush_async().await;
                     match res {
                         Ok(()) => tracing::info!(
                             entries,

--- a/crates/zccache/src/daemon/server/rustc.rs
+++ b/crates/zccache/src/daemon/server/rustc.rs
@@ -62,6 +62,32 @@ pub(super) fn build_compile_context(
     BuildContextResult::Cc { ctx, dep_flags }
 }
 
+pub(super) async fn build_compile_context_async(
+    compilation: &crate::compiler::CacheableCompilation,
+    cwd: &Path,
+    system_includes: &[NormalizedPath],
+    client_env: &[(String, String)],
+    compiler_hash_cache: &CompilerHashCache,
+) -> BuildContextResult {
+    if compilation.family == crate::compiler::CompilerFamily::Rustc {
+        return build_rustc_compile_context_async(
+            compilation,
+            cwd,
+            client_env,
+            compiler_hash_cache,
+        )
+        .await;
+    }
+
+    build_compile_context(
+        compilation,
+        cwd,
+        system_includes,
+        client_env,
+        compiler_hash_cache,
+    )
+}
+
 /// Build compile context for a Rustc invocation.
 pub(super) fn build_rustc_compile_context(
     compilation: &crate::compiler::CacheableCompilation,
@@ -92,6 +118,40 @@ pub(super) fn build_rustc_compile_context(
 
     // Create a "compatible" CompileContext for dep_graph storage.
     // Only source_file is used by the dep_graph for freshness checks.
+    let compat_ctx = CompileContext {
+        source_file: rustc_args.source_file.clone(),
+        include_search: Default::default(),
+        defines: Vec::new(),
+        flags: Vec::new(),
+        force_includes: Vec::new(),
+        unknown_flags: Vec::new(),
+    };
+
+    BuildContextResult::Rustc {
+        rustc_ctx: Box::new(rustc_ctx),
+        compat_ctx,
+        rustc_args: Box::new(rustc_args),
+    }
+}
+
+pub(super) async fn build_rustc_compile_context_async(
+    compilation: &crate::compiler::CacheableCompilation,
+    cwd: &Path,
+    client_env: &[(String, String)],
+    compiler_hash_cache: &CompilerHashCache,
+) -> BuildContextResult {
+    let rustc_args = crate::depgraph::parse_rustc_args(&compilation.original_args, cwd);
+
+    let compiler_hash = compiler_hash_cache
+        .get_or_hash_with_async(&compilation.compiler, hash_rustc_identity_async)
+        .await;
+
+    let rustc_ctx = crate::depgraph::RustcCompileContext::from_parsed_args(
+        &rustc_args,
+        client_env,
+        compiler_hash,
+    );
+
     let compat_ctx = CompileContext {
         source_file: rustc_args.source_file.clone(),
         include_search: Default::default(),

--- a/crates/zccache/src/daemon/server/wal.rs
+++ b/crates/zccache/src/daemon/server/wal.rs
@@ -130,11 +130,9 @@ pub(super) async fn flush_wal_to_disk(
     // do the disk write off the runtime thread so the flush doesn't block
     // request handlers.
     store.insert_many(drained);
-    let store = Arc::clone(store);
-    let res = tokio::task::spawn_blocking(move || store.flush()).await;
+    let res = Arc::clone(store).flush_async().await;
     match res {
-        Ok(Ok(())) => tracing::info!(committed = count, "WAL flushed to disk"),
-        Ok(Err(e)) => tracing::warn!(count, "WAL flush to disk failed: {e}"),
-        Err(e) => tracing::warn!(count, "WAL flush task join error: {e}"),
+        Ok(()) => tracing::info!(committed = count, "WAL flushed to disk"),
+        Err(e) => tracing::warn!(count, "WAL flush to disk failed: {e}"),
     }
 }

--- a/crates/zccache/src/daemon/server/watch.rs
+++ b/crates/zccache/src/daemon/server/watch.rs
@@ -12,6 +12,39 @@ pub(super) async fn watch_directory(state: &SharedState, dir: &Path) {
     watch_directories(state, &[dir.into()]).await;
 }
 
+async fn canonicalize_watch_registration_batch(dirs: Vec<NormalizedPath>) -> Vec<NormalizedPath> {
+    tokio::task::spawn_blocking(move || {
+        dirs.into_iter()
+            .filter_map(|dir| match dir.canonicalize() {
+                Ok(p) => {
+                    #[cfg(windows)]
+                    {
+                        let s = p.to_string_lossy();
+                        if let Some(stripped) = s.strip_prefix(r"\\?\") {
+                            Some(stripped.into())
+                        } else {
+                            Some(p.into())
+                        }
+                    }
+                    #[cfg(not(windows))]
+                    {
+                        Some(p.into())
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!("cannot canonicalize {}: {e}", dir.display());
+                    None
+                }
+            })
+            .collect()
+    })
+    .await
+    .unwrap_or_else(|err| {
+        tracing::warn!("watch canonicalization worker failed: {err}");
+        Vec::new()
+    })
+}
+
 /// Watch multiple directories in a single batch.
 ///
 /// Canonicalizes all paths up front, reserves unwatched paths under
@@ -24,47 +57,21 @@ pub(super) async fn watch_directories(state: &SharedState, dirs: &[NormalizedPat
     // Pre-filter: skip dirs we've already processed (by raw path).
     // This avoids expensive canonicalize() syscalls (~1-5ms each on Windows)
     // for directories that are already being watched.
-    let new_raw: Vec<&NormalizedPath> = dirs
+    let new_raw: Vec<NormalizedPath> = dirs
         .iter()
         .filter(|d| !state.watched_raw_dirs.contains_key(*d))
+        .cloned()
         .collect();
     if new_raw.is_empty() {
         return;
     }
 
-    // Canonicalize only new paths (filesystem work, no lock needed).
-    // On Windows, canonicalize() produces \\?\ extended-length paths which
-    // don't match the paths reported by notify's ReadDirectoryChangesW.
-    // Strip the prefix so watched paths match event paths.
-    let canonical: Vec<NormalizedPath> = new_raw
-        .iter()
-        .filter_map(|dir| match dir.canonicalize() {
-            Ok(p) => {
-                #[cfg(windows)]
-                {
-                    let s = p.to_string_lossy();
-                    if let Some(stripped) = s.strip_prefix(r"\\?\") {
-                        Some(stripped.into())
-                    } else {
-                        Some(p.into())
-                    }
-                }
-                #[cfg(not(windows))]
-                {
-                    Some(p.into())
-                }
-            }
-            Err(e) => {
-                tracing::debug!("cannot canonicalize {}: {e}", dir.display());
-                None
-            }
-        })
-        .collect();
+    let canonical = canonicalize_watch_registration_batch(new_raw.clone()).await;
 
     // Mark raw paths as processed (even if canonicalize failed) so we don't
     // retry them on every subsequent call.
     for d in &new_raw {
-        state.watched_raw_dirs.insert((*d).clone(), ());
+        state.watched_raw_dirs.insert(d.clone(), ());
     }
 
     if canonical.is_empty() {
@@ -107,20 +114,13 @@ async fn watch_one_directory(
     state: &SharedState,
     dir: NormalizedPath,
 ) -> crate::core::Result<bool> {
-    if tokio::runtime::Handle::current().runtime_flavor()
-        == tokio::runtime::RuntimeFlavor::MultiThread
-    {
-        return tokio::task::block_in_place(|| {
-            let mut watcher_guard = state.watcher.blocking_lock();
-            if let Some(ref mut w) = *watcher_guard {
-                w.watch(&dir)?;
-                Ok(true)
-            } else {
-                Ok(false)
-            }
-        });
-    }
+    register_notify_watch(state, &dir).await
+}
 
+async fn register_notify_watch(
+    state: &SharedState,
+    dir: &NormalizedPath,
+) -> crate::core::Result<bool> {
     let mut watcher_guard = state.watcher.lock().await;
     if let Some(ref mut w) = *watcher_guard {
         w.watch(&dir)?;

--- a/crates/zccache/src/download_client/mod.rs
+++ b/crates/zccache/src/download_client/mod.rs
@@ -147,6 +147,7 @@ async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
     Err("download daemon started but did not accept connections after 10s".to_string())
 }
 
+#[derive(Clone)]
 pub struct DownloadClient {
     endpoint: Option<String>,
 }
@@ -163,47 +164,58 @@ impl DownloadClient {
     }
 
     pub fn start_daemon(&self) -> Result<(), String> {
-        let endpoint = self.resolved_endpoint();
-        run_async(async move { ensure_daemon(&endpoint).await })
+        let client = self.clone();
+        run_async(async move { client.start_daemon_async().await })
     }
 
     pub fn stop_daemon(&self) -> Result<bool, String> {
-        let endpoint = self.resolved_endpoint();
-        run_async(async move {
-            let mut conn = match connect_client(&endpoint).await {
-                Ok(conn) => conn,
-                Err(_) => return Ok(false),
-            };
-            conn.send(&Request::Shutdown)
-                .await
-                .map_err(|e| format!("failed to send shutdown to download daemon: {e}"))?;
-            match conn.recv::<Response>().await {
-                Ok(Some(Response::ShuttingDown)) => Ok(true),
-                Ok(Some(Response::Error { message })) => Err(message),
-                Ok(Some(other)) => Err(format!("unexpected response: {other:?}")),
-                Ok(None) => Err("download daemon closed connection unexpectedly".to_string()),
-                Err(e) => Err(format!("broken connection to download daemon: {e}")),
-            }
-        })
+        let client = self.clone();
+        run_async(async move { client.stop_daemon_async().await })
     }
 
     pub fn daemon_status(&self) -> Result<DownloadDaemonStatus, String> {
+        let client = self.clone();
+        run_async(async move { client.daemon_status_async().await })
+    }
+
+    pub async fn start_daemon_async(&self) -> Result<(), String> {
         let endpoint = self.resolved_endpoint();
-        run_async(async move {
-            let mut conn = connect_client(&endpoint)
-                .await
-                .map_err(|e| format!("download daemon not running at {endpoint}: {e}"))?;
-            conn.send(&Request::Status)
-                .await
-                .map_err(|e| format!("failed to query download daemon: {e}"))?;
-            match conn.recv::<Response>().await {
-                Ok(Some(Response::Status(status))) => Ok(status),
-                Ok(Some(Response::Error { message })) => Err(message),
-                Ok(Some(other)) => Err(format!("unexpected response: {other:?}")),
-                Ok(None) => Err("download daemon closed connection unexpectedly".to_string()),
-                Err(e) => Err(format!("broken connection to download daemon: {e}")),
-            }
-        })
+        ensure_daemon(&endpoint).await
+    }
+
+    pub async fn stop_daemon_async(&self) -> Result<bool, String> {
+        let endpoint = self.resolved_endpoint();
+        let mut conn = match connect_client(&endpoint).await {
+            Ok(conn) => conn,
+            Err(_) => return Ok(false),
+        };
+        conn.send(&Request::Shutdown)
+            .await
+            .map_err(|e| format!("failed to send shutdown to download daemon: {e}"))?;
+        match conn.recv::<Response>().await {
+            Ok(Some(Response::ShuttingDown)) => Ok(true),
+            Ok(Some(Response::Error { message })) => Err(message),
+            Ok(Some(other)) => Err(format!("unexpected response: {other:?}")),
+            Ok(None) => Err("download daemon closed connection unexpectedly".to_string()),
+            Err(e) => Err(format!("broken connection to download daemon: {e}")),
+        }
+    }
+
+    pub async fn daemon_status_async(&self) -> Result<DownloadDaemonStatus, String> {
+        let endpoint = self.resolved_endpoint();
+        let mut conn = connect_client(&endpoint)
+            .await
+            .map_err(|e| format!("download daemon not running at {endpoint}: {e}"))?;
+        conn.send(&Request::Status)
+            .await
+            .map_err(|e| format!("failed to query download daemon: {e}"))?;
+        match conn.recv::<Response>().await {
+            Ok(Some(Response::Status(status))) => Ok(status),
+            Ok(Some(Response::Error { message })) => Err(message),
+            Ok(Some(other)) => Err(format!("unexpected response: {other:?}")),
+            Ok(None) => Err("download daemon closed connection unexpectedly".to_string()),
+            Err(e) => Err(format!("broken connection to download daemon: {e}")),
+        }
     }
 
     pub fn download(
@@ -212,43 +224,88 @@ impl DownloadClient {
         destination: &Path,
         options: DownloadOptions,
     ) -> Result<DownloadHandle, String> {
-        let endpoint = self.resolved_endpoint();
-        let url = url.to_string();
-        let destination = canonical_destination(destination).map_err(|e| e.to_string())?;
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .map_err(|e| format!("failed to create runtime: {e}"))?;
-        let (conn, initiator, download_id) = runtime.block_on(async move {
-            ensure_daemon(&endpoint).await?;
-            let mut conn = connect_client(&endpoint)
-                .await
-                .map_err(|e| format!("cannot connect to download daemon at {endpoint}: {e}"))?;
-            conn.send(&Request::DownloadAttach {
-                url: url.clone(),
-                destination,
-                options,
-            })
-            .await
-            .map_err(|e| format!("failed to send attach request: {e}"))?;
-            match conn.recv::<Response>().await {
-                Ok(Some(Response::DownloadAttached {
-                    download_id,
-                    initiator,
-                    status: _,
-                })) => Ok((conn, initiator, download_id)),
-                Ok(Some(Response::Error { message })) => Err(message),
-                Ok(Some(other)) => Err(format!("unexpected response: {other:?}")),
-                Ok(None) => Err("download daemon closed connection unexpectedly".to_string()),
-                Err(e) => Err(format!("broken connection to download daemon: {e}")),
-            }
-        })?;
+        let async_handle = runtime.block_on(self.download_async(url, destination, options))?;
         Ok(DownloadHandle {
             runtime,
-            conn,
-            initiator,
-            download_id,
+            conn: async_handle.conn,
+            initiator: async_handle.initiator,
+            download_id: async_handle.download_id,
         })
+    }
+
+    pub async fn download_async(
+        &self,
+        url: &str,
+        destination: &Path,
+        options: DownloadOptions,
+    ) -> Result<AsyncDownloadHandle, String> {
+        let endpoint = self.resolved_endpoint();
+        let url = url.to_string();
+        let destination = canonical_destination(destination).map_err(|e| e.to_string())?;
+        ensure_daemon(&endpoint).await?;
+        let mut conn = connect_client(&endpoint)
+            .await
+            .map_err(|e| format!("cannot connect to download daemon at {endpoint}: {e}"))?;
+        conn.send(&Request::DownloadAttach {
+            url: url.clone(),
+            destination,
+            options,
+        })
+        .await
+        .map_err(|e| format!("failed to send attach request: {e}"))?;
+        match conn.recv::<Response>().await {
+            Ok(Some(Response::DownloadAttached {
+                download_id,
+                initiator,
+                status: _,
+            })) => Ok(AsyncDownloadHandle {
+                conn,
+                initiator,
+                download_id,
+            }),
+            Ok(Some(Response::Error { message })) => Err(message),
+            Ok(Some(other)) => Err(format!("unexpected response: {other:?}")),
+            Ok(None) => Err("download daemon closed connection unexpectedly".to_string()),
+            Err(e) => Err(format!("broken connection to download daemon: {e}")),
+        }
+    }
+}
+
+pub struct AsyncDownloadHandle {
+    conn: ClientConn,
+    initiator: bool,
+    download_id: String,
+}
+
+impl AsyncDownloadHandle {
+    #[must_use]
+    pub fn initiator(&self) -> bool {
+        self.initiator
+    }
+
+    #[must_use]
+    pub fn download_id(&self) -> &str {
+        &self.download_id
+    }
+
+    pub async fn status(&mut self) -> Result<DownloadStatus, String> {
+        send_download_command(&mut self.conn, Request::DownloadStatus).await
+    }
+
+    pub async fn wait(&mut self, timeout_ms: Option<u64>) -> Result<DownloadStatus, String> {
+        send_download_command(&mut self.conn, Request::DownloadWait { timeout_ms }).await
+    }
+
+    pub async fn cancel(&mut self) -> Result<DownloadStatus, String> {
+        send_download_command(&mut self.conn, Request::DownloadCancel).await
+    }
+
+    pub fn close(self) -> Result<(), String> {
+        Ok(())
     }
 }
 
@@ -271,61 +328,52 @@ impl DownloadHandle {
     }
 
     pub fn status(&mut self) -> Result<DownloadStatus, String> {
-        self.runtime.block_on(async {
-            self.conn
-                .send(&Request::DownloadStatus)
-                .await
-                .map_err(|e| format!("failed to send status request: {e}"))?;
-            match self.conn.recv::<Response>().await {
-                Ok(Some(Response::DownloadStatusResult { status })) => Ok(status),
-                Ok(Some(Response::DownloadFinished { status })) => Ok(status),
-                Ok(Some(Response::DownloadCancelled { status })) => Ok(status),
-                Ok(Some(Response::Error { message })) => Err(message),
-                Ok(Some(other)) => Err(format!("unexpected response: {other:?}")),
-                Ok(None) => Err("download daemon closed connection unexpectedly".to_string()),
-                Err(e) => Err(format!("broken connection to download daemon: {e}")),
-            }
-        })
+        self.runtime.block_on(send_download_command(
+            &mut self.conn,
+            Request::DownloadStatus,
+        ))
     }
 
     pub fn wait(&mut self, timeout_ms: Option<u64>) -> Result<DownloadStatus, String> {
-        self.runtime.block_on(async {
-            self.conn
-                .send(&Request::DownloadWait { timeout_ms })
-                .await
-                .map_err(|e| format!("failed to send wait request: {e}"))?;
-            match self.conn.recv::<Response>().await {
-                Ok(Some(Response::DownloadStatusResult { status })) => Ok(status),
-                Ok(Some(Response::DownloadFinished { status })) => Ok(status),
-                Ok(Some(Response::DownloadCancelled { status })) => Ok(status),
-                Ok(Some(Response::Error { message })) => Err(message),
-                Ok(Some(other)) => Err(format!("unexpected response: {other:?}")),
-                Ok(None) => Err("download daemon closed connection unexpectedly".to_string()),
-                Err(e) => Err(format!("broken connection to download daemon: {e}")),
-            }
-        })
+        self.runtime.block_on(send_download_command(
+            &mut self.conn,
+            Request::DownloadWait { timeout_ms },
+        ))
     }
 
     pub fn cancel(&mut self) -> Result<DownloadStatus, String> {
-        self.runtime.block_on(async {
-            self.conn
-                .send(&Request::DownloadCancel)
-                .await
-                .map_err(|e| format!("failed to send cancel request: {e}"))?;
-            match self.conn.recv::<Response>().await {
-                Ok(Some(Response::DownloadCancelled { status })) => Ok(status),
-                Ok(Some(Response::DownloadFinished { status })) => Ok(status),
-                Ok(Some(Response::DownloadStatusResult { status })) => Ok(status),
-                Ok(Some(Response::Error { message })) => Err(message),
-                Ok(Some(other)) => Err(format!("unexpected response: {other:?}")),
-                Ok(None) => Err("download daemon closed connection unexpectedly".to_string()),
-                Err(e) => Err(format!("broken connection to download daemon: {e}")),
-            }
-        })
+        self.runtime.block_on(send_download_command(
+            &mut self.conn,
+            Request::DownloadCancel,
+        ))
     }
 
     pub fn close(self) -> Result<(), String> {
         Ok(())
+    }
+}
+
+async fn send_download_command(
+    conn: &mut ClientConn,
+    request: Request,
+) -> Result<DownloadStatus, String> {
+    let action = match &request {
+        Request::DownloadStatus => "status",
+        Request::DownloadWait { .. } => "wait",
+        Request::DownloadCancel => "cancel",
+        _ => "download",
+    };
+    conn.send(&request)
+        .await
+        .map_err(|e| format!("failed to send {action} request: {e}"))?;
+    match conn.recv::<Response>().await {
+        Ok(Some(Response::DownloadStatusResult { status })) => Ok(status),
+        Ok(Some(Response::DownloadFinished { status })) => Ok(status),
+        Ok(Some(Response::DownloadCancelled { status })) => Ok(status),
+        Ok(Some(Response::Error { message })) => Err(message),
+        Ok(Some(other)) => Err(format!("unexpected response: {other:?}")),
+        Ok(None) => Err("download daemon closed connection unexpectedly".to_string()),
+        Err(e) => Err(format!("broken connection to download daemon: {e}")),
     }
 }
 

--- a/crates/zccache/src/fscache/cache_system.rs
+++ b/crates/zccache/src/fscache/cache_system.rs
@@ -10,6 +10,7 @@ use super::metadata::MetadataCache;
 use crate::core::NormalizedPath;
 use crate::core::Result;
 use crate::hash::ContentHash;
+use std::sync::Arc;
 
 /// Result of a clock-aware lookup.
 #[derive(Debug, Clone)]
@@ -26,10 +27,10 @@ pub struct ClockLookup {
 /// the same headers. Without the clock, each one would stat-verify
 /// independently. With the clock, the daemon verifies once per batch
 /// and all concurrent clients share that answer.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CacheSystem {
-    metadata: MetadataCache,
-    journal: ChangeJournal,
+    metadata: Arc<MetadataCache>,
+    journal: Arc<ChangeJournal>,
 }
 
 impl CacheSystem {
@@ -37,8 +38,8 @@ impl CacheSystem {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            metadata: MetadataCache::new(),
-            journal: ChangeJournal::new(),
+            metadata: Arc::new(MetadataCache::new()),
+            journal: Arc::new(ChangeJournal::new()),
         }
     }
 
@@ -54,8 +55,8 @@ impl CacheSystem {
     #[must_use]
     pub fn with_metadata(metadata: MetadataCache) -> Self {
         Self {
-            metadata,
-            journal: ChangeJournal::new(),
+            metadata: Arc::new(metadata),
+            journal: Arc::new(ChangeJournal::new()),
         }
     }
 
@@ -106,6 +107,23 @@ impl CacheSystem {
             hash,
             clock: self.journal.current_clock(),
         })
+    }
+
+    /// Async bridge for [`Self::lookup_since`].
+    ///
+    /// The slow path can stat and hash files, so async callers use this named
+    /// edge instead of running filesystem work on Tokio runtime threads.
+    pub async fn lookup_since_async(
+        &self,
+        path: NormalizedPath,
+        since_clock: Clock,
+    ) -> Result<ClockLookup> {
+        let cache = self.clone();
+        tokio::task::spawn_blocking(move || cache.lookup_since(&path, since_clock))
+            .await
+            .map_err(|err| crate::core::Error::Cache {
+                message: format!("cache lookup worker failed: {err}"),
+            })?
     }
 
     /// Apply a settled batch of file changes from the watcher.
@@ -163,6 +181,16 @@ impl CacheSystem {
     /// Returns the number of entries promoted.
     pub fn rescan_entries(&self) -> usize {
         self.metadata.rescan_all()
+    }
+
+    /// Async bridge for [`Self::rescan_entries`].
+    pub async fn rescan_entries_async(&self) -> Result<usize> {
+        let cache = self.clone();
+        tokio::task::spawn_blocking(move || cache.rescan_entries())
+            .await
+            .map_err(|err| crate::core::Error::Cache {
+                message: format!("cache rescan worker failed: {err}"),
+            })
     }
 
     /// Clear all cached metadata and journal state.

--- a/crates/zccache/src/fscache/verify.rs
+++ b/crates/zccache/src/fscache/verify.rs
@@ -7,7 +7,7 @@ use super::metadata::{Confidence, FileMetadata, MetadataCache};
 use crate::core::NormalizedPath;
 use crate::core::Result;
 use crate::hash::ContentHash;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::Instant;
 
 /// Result of verifying cached metadata against the current filesystem state.
@@ -184,28 +184,7 @@ impl MetadataCache {
 }
 
 fn hash_file_off_runtime(path: &Path) -> Result<ContentHash> {
-    let path = PathBuf::from(path);
-    let Ok(handle) = tokio::runtime::Handle::try_current() else {
-        return Ok(crate::hash::hash_file(&path)?);
-    };
-
-    if matches!(
-        handle.runtime_flavor(),
-        tokio::runtime::RuntimeFlavor::MultiThread
-    ) {
-        tokio::task::block_in_place(|| {
-            handle
-                .block_on(tokio::task::spawn_blocking(move || {
-                    crate::hash::hash_file(&path)
-                }))
-                .map_err(|err| crate::core::Error::Cache {
-                    message: format!("blocking hash task failed: {err}"),
-                })?
-                .map_err(crate::core::Error::Io)
-        })
-    } else {
-        Ok(crate::hash::hash_file(&path)?)
-    }
+    Ok(crate::hash::hash_file(path)?)
 }
 
 #[cfg(test)]

--- a/crates/zccache/src/ipc/broker_v2.rs
+++ b/crates/zccache/src/ipc/broker_v2.rs
@@ -103,6 +103,26 @@ pub fn probe_local_socket_with_deadline(endpoint: &str, deadline: Duration) -> s
     })
 }
 
+/// Async bridge for [`probe_local_socket`].
+///
+/// The underlying local-socket dial is synchronous and can block at the OS
+/// layer. Async production callers should use this wrapper so that work is
+/// charged to Tokio's blocking pool instead of an executor worker.
+pub async fn probe_local_socket_async(endpoint: &str) -> std::io::Result<()> {
+    probe_local_socket_with_deadline_async(endpoint, DEFAULT_PROBE_TIMEOUT).await
+}
+
+/// Async bridge for [`probe_local_socket_with_deadline`].
+pub async fn probe_local_socket_with_deadline_async(
+    endpoint: &str,
+    deadline: Duration,
+) -> std::io::Result<()> {
+    let endpoint = endpoint.to_owned();
+    tokio::task::spawn_blocking(move || probe_local_socket_with_deadline(&endpoint, deadline))
+        .await
+        .map_err(join_error_to_io)?
+}
+
 /// Run a blocking `io::Result<T>`-returning closure on a helper thread,
 /// bounded by `deadline`. On deadline the helper thread is leaked
 /// (there is no portable way to cancel a `Stream::connect` mid-call)
@@ -186,6 +206,18 @@ pub fn connect_v2_broker(wanted_version: &str) -> Result<ClientSession, BrokerV2
     })
 }
 
+/// Async bridge for [`connect_v2_broker`].
+///
+/// This keeps the v2 broker's synchronous Hello round-trip out of async
+/// callers while preserving the existing typed `BrokerV2Error` surface.
+#[doc(hidden)]
+pub async fn connect_v2_broker_async(wanted_version: &str) -> Result<ClientSession, BrokerV2Error> {
+    let wanted = wanted_version.to_owned();
+    tokio::task::spawn_blocking(move || connect_v2_broker(&wanted))
+        .await
+        .map_err(join_error_to_brokerv2)?
+}
+
 /// Slice 13 of #782: v2 adopt path counterpart of v1's
 /// `AsyncBrokerSession::adopt` / `OwnedBackendIo`.
 ///
@@ -223,6 +255,23 @@ pub fn adopt_v2_session(
     Ok(session.into_inner())
 }
 
+/// Async bridge for [`adopt_v2_session`].
+#[doc(hidden)]
+pub async fn adopt_v2_session_async(
+    wanted_version: &str,
+) -> Result<
+    (
+        interprocess::local_socket::Stream,
+        running_process::broker::protocol::Negotiated,
+    ),
+    BrokerV2Error,
+> {
+    let wanted = wanted_version.to_owned();
+    tokio::task::spawn_blocking(move || adopt_v2_session(&wanted))
+        .await
+        .map_err(join_error_to_brokerv2)?
+}
+
 /// Slice 14 of #782: v2 counterpart of v1's
 /// `AsyncBrokerSession::into_backend_io`.
 ///
@@ -242,6 +291,25 @@ pub fn into_backend_io_v2(
 ) -> Result<interprocess::local_socket::Stream, BrokerV2Error> {
     let (stream, _negotiated) = adopt_v2_session(wanted_version)?;
     Ok(stream)
+}
+
+/// Async bridge for [`into_backend_io_v2`].
+#[doc(hidden)]
+pub async fn into_backend_io_v2_async(
+    wanted_version: &str,
+) -> Result<interprocess::local_socket::Stream, BrokerV2Error> {
+    let wanted = wanted_version.to_owned();
+    tokio::task::spawn_blocking(move || into_backend_io_v2(&wanted))
+        .await
+        .map_err(join_error_to_brokerv2)?
+}
+
+fn join_error_to_io(err: tokio::task::JoinError) -> std::io::Error {
+    std::io::Error::other(format!("broker-v2 async bridge worker failed: {err}"))
+}
+
+fn join_error_to_brokerv2(err: tokio::task::JoinError) -> BrokerV2Error {
+    BrokerV2Error::Io(join_error_to_io(err))
 }
 
 #[cfg(test)]

--- a/crates/zccache/src/ipc/transport/mod.rs
+++ b/crates/zccache/src/ipc/transport/mod.rs
@@ -421,6 +421,25 @@ impl IpcListener {
         }
     }
 
+    /// Bind to the given endpoint from an async context.
+    ///
+    /// The synchronous [`Self::bind`] API remains available for tests and
+    /// true sync callers. Async production paths should use this bridge so
+    /// filesystem and named-pipe setup do not run on an executor worker.
+    pub async fn bind_async(endpoint: &str) -> Result<Self, IpcError> {
+        #[cfg(unix)]
+        {
+            let endpoint = endpoint.to_owned();
+            tokio::task::spawn_blocking(move || Self::bind(&endpoint))
+                .await
+                .map_err(join_error_to_ipc)?
+        }
+        #[cfg(windows)]
+        {
+            windows::bind_listener_async(endpoint).await
+        }
+    }
+
     /// Accept a new connection.
     ///
     /// On Unix, returns an `IpcConnection` wrapping a `UnixStream`.
@@ -443,6 +462,13 @@ impl IpcListener {
             self.accept_windows().await
         }
     }
+}
+
+#[cfg(unix)]
+fn join_error_to_ipc(err: tokio::task::JoinError) -> IpcError {
+    IpcError::Io(std::io::Error::other(format!(
+        "async IPC bind worker failed: {err}"
+    )))
 }
 
 /// Generate a unique test endpoint name.

--- a/crates/zccache/src/ipc/transport/windows.rs
+++ b/crates/zccache/src/ipc/transport/windows.rs
@@ -6,14 +6,70 @@ use std::time::Duration;
 
 use bytes::BytesMut;
 use tokio::io::{AsyncWriteExt, ReadHalf, WriteHalf};
-use tokio::net::windows::named_pipe::{NamedPipeClient, NamedPipeServer};
+use tokio::net::windows::named_pipe::{NamedPipeClient, NamedPipeServer, ServerOptions};
 
 use crate::ipc::error::IpcError;
 
 use super::framing::{decode_response_wire, recv_bincode_loop, recv_wire_loop};
-use super::{IpcConnection, IpcListener};
+use super::{IpcConnection, IpcListener, ListenerInner};
 
 const WINDOWS_PIPE_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub(super) async fn bind_listener_async(endpoint: &str) -> Result<IpcListener, IpcError> {
+    use std::collections::VecDeque;
+
+    let pool_size = std::env::var("ZCCACHE_PIPE_POOL_SIZE")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or_else(|| {
+            std::thread::available_parallelism()
+                .map(|n| n.get().saturating_mul(4))
+                .unwrap_or(64)
+                .clamp(16, 128)
+        });
+
+    const FIRST_BIND_ATTEMPTS: u32 = 8;
+    const FIRST_BIND_INITIAL_DELAY_MS: u64 = 20;
+    const FIRST_BIND_MAX_DELAY_MS: u64 = 160;
+
+    let mut pool = VecDeque::with_capacity(pool_size);
+    let first_pipe = {
+        let mut attempt = 0u32;
+        let mut delay_ms = FIRST_BIND_INITIAL_DELAY_MS;
+        loop {
+            match create_pipe_server_async(endpoint, true).await {
+                Ok(p) => break p,
+                Err(e) => {
+                    attempt += 1;
+                    if attempt >= FIRST_BIND_ATTEMPTS {
+                        return Err(e);
+                    }
+                    tracing::warn!(
+                        attempt,
+                        max_attempts = FIRST_BIND_ATTEMPTS,
+                        error = %e,
+                        endpoint = %endpoint,
+                        "first pipe instance bind failed; retrying after async backoff (issue #774)"
+                    );
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                    delay_ms = (delay_ms * 2).min(FIRST_BIND_MAX_DELAY_MS);
+                }
+            }
+        }
+    };
+    pool.push_back(first_pipe);
+
+    for _ in 1..pool_size {
+        pool.push_back(create_pipe_server_async(endpoint, false).await?);
+    }
+
+    Ok(IpcListener {
+        inner: ListenerInner {
+            endpoint: endpoint.to_string(),
+            pool,
+        },
+    })
+}
 
 /// Client-side IPC connection (Windows uses a different type).
 pub struct IpcClientConnection {
@@ -225,7 +281,7 @@ impl IpcListener {
                         endpoint = %self.inner.endpoint,
                         "named-pipe pool exhausted — attempting emergency create (issue #666)"
                     );
-                    create_replacement_pipe(&self.inner.endpoint)?
+                    create_replacement_pipe_async(&self.inner.endpoint).await?
                 }
             };
 
@@ -240,7 +296,9 @@ impl IpcListener {
                         error = %e,
                         "named-pipe connect failed - replenishing and retrying"
                     );
-                    if let Ok(replacement) = create_replacement_pipe(&self.inner.endpoint) {
+                    if let Ok(replacement) =
+                        create_replacement_pipe_async(&self.inner.endpoint).await
+                    {
                         self.inner.pool.push_back(replacement);
                     }
                     continue;
@@ -253,7 +311,9 @@ impl IpcListener {
                         timeout = ?WINDOWS_PIPE_CONNECT_TIMEOUT,
                         "named-pipe connect timed out - dropping pipe and retrying"
                     );
-                    if let Ok(replacement) = create_replacement_pipe(&self.inner.endpoint) {
+                    if let Ok(replacement) =
+                        create_replacement_pipe_async(&self.inner.endpoint).await
+                    {
                         self.inner.pool.push_back(replacement);
                     }
                     continue;
@@ -296,13 +356,22 @@ impl IpcListener {
     }
 }
 
-/// Issue #666: synchronous replacement pipe creation. Used by the emergency
-/// path when the pool is fully depleted.
-pub(super) fn create_replacement_pipe(endpoint: &str) -> Result<NamedPipeServer, IpcError> {
-    use tokio::net::windows::named_pipe::ServerOptions;
-    Ok(ServerOptions::new()
-        .first_pipe_instance(false)
-        .create(endpoint)?)
+async fn create_replacement_pipe_async(endpoint: &str) -> Result<NamedPipeServer, IpcError> {
+    create_pipe_server_async(endpoint, false).await
+}
+
+async fn create_pipe_server_async(
+    endpoint: &str,
+    first_pipe_instance: bool,
+) -> Result<NamedPipeServer, IpcError> {
+    let endpoint = endpoint.to_owned();
+    tokio::task::spawn_blocking(move || {
+        Ok(ServerOptions::new()
+            .first_pipe_instance(first_pipe_instance)
+            .create(&endpoint)?)
+    })
+    .await
+    .map_err(join_error_to_ipc)?
 }
 
 /// Issue #666: bounded-backoff retry around replacement creation. Returns
@@ -321,7 +390,7 @@ async fn create_replacement_pipe_with_retry(endpoint: &str) -> Option<NamedPipeS
 
     let mut delay_ms = INITIAL_DELAY_MS;
     for attempt in 0..ATTEMPTS {
-        match create_replacement_pipe(endpoint) {
+        match create_replacement_pipe_async(endpoint).await {
             Ok(p) => return Some(p),
             Err(e) => {
                 tracing::warn!(
@@ -348,8 +417,6 @@ async fn create_replacement_pipe_with_retry(endpoint: &str) -> Option<NamedPipeS
 /// about 5 seconds before giving up. This handles bursts from parallel build
 /// systems that spawn hundreds of concurrent compilations.
 pub async fn connect(endpoint: &str) -> Result<IpcClientConnection, IpcError> {
-    use tokio::net::windows::named_pipe::ClientOptions;
-
     const MAX_PIPE_BUSY_RETRIES: u32 = 50;
     const INITIAL_BACKOFF_MS: u64 = 10;
     const MAX_BACKOFF_MS: u64 = 500;
@@ -358,7 +425,7 @@ pub async fn connect(endpoint: &str) -> Result<IpcClientConnection, IpcError> {
         let mut attempts = 0u32;
         let mut backoff_ms = INITIAL_BACKOFF_MS;
         let client = loop {
-            match ClientOptions::new().open(endpoint) {
+            match open_pipe_client_async(endpoint).await {
                 Ok(client) => break client,
                 Err(e) if e.raw_os_error() == Some(231) => {
                     // ERROR_PIPE_BUSY = 231: all pipe instances are in use.
@@ -406,4 +473,21 @@ pub async fn connect(endpoint: &str) -> Result<IpcClientConnection, IpcError> {
         recv_timeout: None,
         next_frame_request_id: 1,
     })
+}
+
+async fn open_pipe_client_async(endpoint: &str) -> Result<NamedPipeClient, std::io::Error> {
+    use tokio::net::windows::named_pipe::ClientOptions;
+
+    let endpoint = endpoint.to_owned();
+    tokio::task::spawn_blocking(move || ClientOptions::new().open(&endpoint))
+        .await
+        .map_err(|err| {
+            std::io::Error::other(format!("named-pipe client open worker failed: {err}"))
+        })?
+}
+
+fn join_error_to_ipc(err: tokio::task::JoinError) -> IpcError {
+    IpcError::Io(std::io::Error::other(format!(
+        "named-pipe setup worker failed: {err}"
+    )))
 }

--- a/crates/zccache/src/watcher/recovery.rs
+++ b/crates/zccache/src/watcher/recovery.rs
@@ -110,7 +110,13 @@ impl OverflowRecovery {
                 }
             }
 
-            let promoted = cache.rescan_entries();
+            let promoted = match cache.rescan_entries_async().await {
+                Ok(promoted) => promoted,
+                Err(e) => {
+                    tracing::warn!("overflow recovery: rescan failed: {e}");
+                    0
+                }
+            };
             self.pending.store(false, Ordering::Release);
 
             tracing::info!(

--- a/crates/zccache/tests/daemon_spawn_lockfile_budget_test.rs
+++ b/crates/zccache/tests/daemon_spawn_lockfile_budget_test.rs
@@ -138,8 +138,12 @@ fn lockfile_window_has_no_synchronous_persisted_state_loads() {
     let daemon = source_file("src/bin/zccache-daemon.rs");
     let startup_window = slice_between(
         &daemon,
-        "let server = match zccache::daemon::DaemonServer::bind(&endpoint)",
+        "let bind_result = tokio::task::spawn_blocking(move || {",
         "zccache::ipc::write_lock_file(pid)",
+    );
+    assert!(
+        startup_window.contains("zccache::daemon::DaemonServer::bind(&bind_endpoint)"),
+        "daemon bind-to-lockfile window must include endpoint bind"
     );
     assert_no_sync_loads("daemon bind-to-lockfile", startup_window);
 }


### PR DESCRIPTION
﻿## Summary

Implements #881 by moving the major sync/blocking categories behind named async bridge APIs:

- watcher/fscache registration, recovery, and cache lookup/rescan bridges
- daemon process execution and rustc/compiler identity async-facing paths
- IPC transport, broker-v2, and download-client async wrappers
- post-compile output collection, depfile capture/cleanup, and scanner fallback bridges
- CLI archive/rust-plan phase-level blocking bridges
- KV/redb and artifact-store async facades

Also updates the lockfile-window source sentinel test for the daemon bind bridge shape.

## Validation

- `soldr cargo fmt`
- `soldr cargo check -p zccache`
- `soldr cargo test -p zccache --test daemon_spawn_lockfile_budget_test`
- `soldr cargo test -p zccache ipc::tests::daemon_control_roundtrip_auto_falls_back_to_bincode_for_old_daemon -- --exact`
- `soldr cargo test -p zccache -- --test-threads=1`
- `uv run --no-sync python ci/perf_local.py test`

Notes:

- I intentionally did not run lint or dylint.
- One parallel Windows IPC test run hit a transient `BrokenPipe`; the exact test passed immediately afterward, and the full serial package test passed.
