### PR TITLE
[codex] add daemon tokio-console profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +142,55 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -404,6 +464,46 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "console-api"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8599749b6667e2f0c910c1d0dff6901163ff698a52d5a39720f61b5be4b20d3"
+dependencies = [
+ "futures-core",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4915b7d8dd960457a1b6c380114c2944f728e7c65294ab247ae6b6f1f37592"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -967,6 +1067,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1125,19 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
+]
 
 [[package]]
 name = "heck"
@@ -1059,6 +1191,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,9 +1212,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1096,12 +1242,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1543,6 +1702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +1769,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,6 +1818,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1780,6 +1967,26 @@ dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
  "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2364,7 +2571,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3096,6 +3303,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -3117,6 +3325,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -3175,6 +3394,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,11 +3441,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3351,7 +3614,7 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "log",
  "once_cell",
  "rustls",
@@ -3973,6 +4236,7 @@ dependencies = [
  "bytes",
  "clang",
  "clap",
+ "console-subscriber",
  "crash-handler",
  "criterion",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ homepage = "https://github.com/zackees/zccache"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }
+console-subscriber = "0.5"
 serde = { version = "1", features = ["derive", "rc"] }
 bincode = "1"
 blake3 = { version = "1", features = ["pure", "rayon"] }

--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -13,6 +13,10 @@ description = "Local-first compiler cache for C/C++/Rust/Emscripten"
 default = []
 # Enables zccache::test_support (dev-only helpers).
 test-support = []
+# Enables zccache-daemon Tokio Console instrumentation. Build with
+# `RUSTFLAGS="--cfg tokio_unstable"` so Tokio emits the runtime tracing
+# events consumed by console-subscriber.
+tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 
 [dependencies]
 # core
@@ -37,6 +41,7 @@ prost = { workspace = true }
 
 # ipc + test-support: needs full tokio
 tokio = { workspace = true }
+console-subscriber = { workspace = true, optional = true }
 
 # fscache
 dashmap = { workspace = true }

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -19,6 +19,12 @@ use clap::Parser;
 use zccache::core::NormalizedPath;
 
 const DAEMON_MAX_BLOCKING_THREADS: usize = 16;
+const DAEMON_PROFILE_ENV: &str = "ZCCACHE_DAEMON_PROFILE";
+const TOKIO_CONSOLE_PROFILE: &str = "tokio-console";
+#[cfg(feature = "tokio-console")]
+const TOKIO_CONSOLE_BIND_ENV: &str = "TOKIO_CONSOLE_BIND";
+#[cfg(feature = "tokio-console")]
+const TOKIO_CONSOLE_DEFAULT_BIND: &str = "127.0.0.1:6669";
 
 /// zccache daemon -- local compiler cache service.
 #[derive(Debug, Parser)]
@@ -489,7 +495,7 @@ fn run_server(args: Args) {
 }
 
 fn init_tracing(level: &str) {
-    use tracing_subscriber::EnvFilter;
+    use tracing_subscriber::{prelude::*, EnvFilter};
     let mut filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level));
     // When a parent process (notably soldr) launches us with a narrowed
     // `RUST_LOG=zccache_daemon=info`, the directive *only* matches the
@@ -518,9 +524,55 @@ fn init_tracing(level: &str) {
             filter = filter.add_directive(d);
         }
     }
-    tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_target(true)
-        .with_thread_ids(true)
+    let profile = std::env::var(DAEMON_PROFILE_ENV).ok();
+    let tokio_console_enabled = profile.as_deref() == Some(TOKIO_CONSOLE_PROFILE);
+
+    #[cfg(feature = "tokio-console")]
+    {
+        if tokio_console_enabled {
+            let bind = std::env::var(TOKIO_CONSOLE_BIND_ENV)
+                .unwrap_or_else(|_| TOKIO_CONSOLE_DEFAULT_BIND.to_string());
+            let console_layer = console_subscriber::spawn();
+            tracing_subscriber::registry()
+                .with(console_layer)
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .with_target(true)
+                        .with_thread_ids(true)
+                        .with_filter(filter),
+                )
+                .init();
+            tracing::info!(
+                bind,
+                "tokio-console daemon profile enabled; connect with `tokio-console {bind}`"
+            );
+            return;
+        }
+    }
+
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_target(true)
+                .with_thread_ids(true)
+                .with_filter(filter),
+        )
         .init();
+
+    #[cfg(not(feature = "tokio-console"))]
+    if tokio_console_enabled {
+        tracing::warn!(
+            profile = TOKIO_CONSOLE_PROFILE,
+            "ZCCACHE_DAEMON_PROFILE requested tokio-console, but this binary was built without the `tokio-console` feature"
+        );
+    }
+
+    if let Some(profile) = profile {
+        if profile != TOKIO_CONSOLE_PROFILE {
+            tracing::warn!(
+                profile,
+                "unknown daemon profile requested; running without extra profiling"
+            );
+        }
+    }
 }

--- a/crates/zccache/src/cli/commands/args/mod.rs
+++ b/crates/zccache/src/cli/commands/args/mod.rs
@@ -12,8 +12,9 @@ use std::path::PathBuf;
 mod subcommands;
 
 pub(crate) use subcommands::{
-    CacheCommands, CargoRegistryCommands, DefenderExclusionsCommands, FpCommands, GhaCacheCommands,
-    KvCommands, MesonCommands, RustPlanBackendArg, RustPlanCommands, SymbolsCommands,
+    CacheCommands, CargoRegistryCommands, DaemonCommands, DaemonProfileCommands,
+    DefenderExclusionsCommands, FpCommands, GhaCacheCommands, KvCommands, MesonCommands,
+    RustPlanBackendArg, RustPlanCommands, SymbolsCommands,
 };
 
 /// Environment-variable reference appended to the top-level `--help` output.
@@ -75,6 +76,11 @@ pub(crate) enum Commands {
     /// Stop the daemon.
     #[command(visible_alias = "kill")]
     Stop,
+    /// Daemon lifecycle and profiling helpers.
+    Daemon {
+        #[command(subcommand)]
+        command: DaemonCommands,
+    },
     /// Show daemon and cache status.
     Status {
         /// Print the daemon status as a JSON document to stdout.
@@ -558,6 +564,7 @@ pub(crate) enum Commands {
 pub(crate) const KNOWN_SUBCOMMANDS: &[&str] = &[
     "start",
     "stop",
+    "daemon",
     "status",
     "analyze",
     "clear",

--- a/crates/zccache/src/cli/commands/args/subcommands.rs
+++ b/crates/zccache/src/cli/commands/args/subcommands.rs
@@ -8,6 +8,48 @@
 use clap::{Subcommand, ValueEnum};
 use std::path::PathBuf;
 
+/// `zccache daemon` subcommands.
+#[derive(Debug, Subcommand)]
+pub(crate) enum DaemonCommands {
+    /// Restart the daemon with Tokio Console instrumentation enabled.
+    Top {
+        /// Tokio Console bind address, e.g. localhost:1234.
+        bind: Option<String>,
+        /// Tokio Console bind address, e.g. localhost:1234.
+        #[arg(long = "bind")]
+        bind_addr: Option<String>,
+        /// Do not launch the `tokio-console` terminal UI after the daemon is ready.
+        #[arg(long)]
+        no_open: bool,
+        /// IPC endpoint for the zccache daemon itself (default: platform-specific).
+        #[arg(long)]
+        endpoint: Option<String>,
+    },
+    /// Compatibility alias for `zccache daemon top`.
+    #[command(hide = true)]
+    Profile {
+        #[command(subcommand)]
+        command: DaemonProfileCommands,
+    },
+}
+
+/// `zccache daemon profile` subcommands.
+#[derive(Debug, Subcommand)]
+pub(crate) enum DaemonProfileCommands {
+    /// Compatibility alias for `zccache daemon top`.
+    Start {
+        /// Tokio Console bind address, e.g. localhost:1234.
+        #[arg(long)]
+        bind: Option<String>,
+        /// Launch the `tokio-console` terminal UI after the daemon is ready.
+        #[arg(long)]
+        open: bool,
+        /// IPC endpoint for the zccache daemon itself (default: platform-specific).
+        #[arg(long)]
+        endpoint: Option<String>,
+    },
+}
+
 /// `zccache cache` subcommands (#695).
 #[derive(Debug, Subcommand)]
 pub(crate) enum CacheCommands {

--- a/crates/zccache/src/cli/commands/daemon.rs
+++ b/crates/zccache/src/cli/commands/daemon.rs
@@ -6,6 +6,19 @@ use std::process::ExitCode;
 use super::super::status_probe_timeout;
 use super::util::{connect, resolve_endpoint, run_async, LOST_CONNECTION_MSG};
 
+#[cfg(any(test, feature = "tokio-console"))]
+const DAEMON_PROFILE_ENV: &str = "ZCCACHE_DAEMON_PROFILE";
+#[cfg(any(test, feature = "tokio-console"))]
+const TOKIO_CONSOLE_PROFILE: &str = "tokio-console";
+#[cfg(any(test, feature = "tokio-console"))]
+const TOKIO_CONSOLE_BIND_ENV: &str = "TOKIO_CONSOLE_BIND";
+#[cfg(any(test, feature = "tokio-console"))]
+const TOKIO_CONSOLE_OPEN_ENV: &str = "ZCCACHE_TOKIO_CONSOLE_OPEN";
+#[cfg(any(test, feature = "tokio-console"))]
+const TOKIO_CONSOLE_DEFAULT_BIND: &str = "127.0.0.1:6669";
+#[cfg(feature = "tokio-console")]
+const PROFILE_START_REASON: &str = "tokio-console-profile-start";
+
 pub(crate) enum VersionCheck {
     Ok,
     /// Daemon is newer than client — safe to proceed.
@@ -328,6 +341,127 @@ pub(crate) async fn cmd_start(endpoint: &str) -> ExitCode {
         Err(e) => {
             eprintln!("failed to start daemon: {e}");
             ExitCode::FAILURE
+        }
+    }
+}
+
+pub(crate) async fn cmd_profile_start(endpoint: &str, bind: Option<&str>, open: bool) -> ExitCode {
+    #[cfg(not(feature = "tokio-console"))]
+    {
+        let _ = (endpoint, bind, open);
+        eprintln!(
+            "tokio-console daemon profile is unavailable: this zccache binary was built without \
+             the `tokio-console` feature. Rebuild with \
+             `RUSTFLAGS=\"--cfg tokio_unstable\" cargo build --features tokio-console`."
+        );
+        return ExitCode::FAILURE;
+    }
+
+    #[cfg(feature = "tokio-console")]
+    {
+        let open = open || env_truthy(TOKIO_CONSOLE_OPEN_ENV);
+        let bind = tokio_console_bind(bind);
+        let env = profile_env_overrides(&bind, open);
+        let _guard = ScopedEnv::apply(&env);
+
+        let killed_pid = stop_stale_daemon(endpoint).await;
+        if let Err(e) = spawn_and_wait(endpoint, PROFILE_START_REASON, killed_pid).await {
+            eprintln!("failed to start tokio-console daemon profile: {e}");
+            return ExitCode::FAILURE;
+        }
+        eprintln!("daemon running with tokio-console profile at {bind}");
+
+        if open {
+            if let Err(e) = launch_tokio_console(&bind) {
+                eprintln!("{e}");
+                return ExitCode::FAILURE;
+            }
+        }
+
+        ExitCode::SUCCESS
+    }
+}
+
+#[cfg(any(test, feature = "tokio-console"))]
+pub(crate) fn tokio_console_bind(bind: Option<&str>) -> String {
+    bind.map(str::to_string)
+        .or_else(|| std::env::var(TOKIO_CONSOLE_BIND_ENV).ok())
+        .unwrap_or_else(|| TOKIO_CONSOLE_DEFAULT_BIND.to_string())
+}
+
+#[cfg(any(test, feature = "tokio-console"))]
+pub(crate) fn profile_env_overrides(bind: &str, open: bool) -> Vec<(String, String)> {
+    let mut env = vec![
+        (
+            DAEMON_PROFILE_ENV.to_string(),
+            TOKIO_CONSOLE_PROFILE.to_string(),
+        ),
+        (TOKIO_CONSOLE_BIND_ENV.to_string(), bind.to_string()),
+    ];
+    if open {
+        env.push((TOKIO_CONSOLE_OPEN_ENV.to_string(), "1".to_string()));
+    }
+    env
+}
+
+#[cfg(feature = "tokio-console")]
+fn launch_tokio_console(bind: &str) -> Result<(), String> {
+    let mut cmd = std::process::Command::new("tokio-console");
+    #[cfg(windows)]
+    cmd.args(["--lang", "en_US.UTF-8"]);
+    cmd.arg(bind);
+    cmd.spawn()
+        .map(|_| {
+            eprintln!("launched tokio-console {bind}");
+        })
+        .map_err(|e| {
+            format!(
+                "daemon profile is running at {bind}, but failed to launch `tokio-console`: {e}. \
+                 Install it with `cargo install --locked tokio-console` and run `tokio-console {bind}`."
+            )
+        })
+}
+
+#[cfg(feature = "tokio-console")]
+fn env_truthy(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|value| {
+        let value = value.trim();
+        !value.is_empty()
+            && !matches!(
+                value.to_ascii_lowercase().as_str(),
+                "0" | "false" | "no" | "off" | "n"
+            )
+    })
+}
+
+#[cfg(feature = "tokio-console")]
+struct ScopedEnv {
+    previous: Vec<(String, Option<String>)>,
+}
+
+#[cfg(feature = "tokio-console")]
+impl ScopedEnv {
+    fn apply(overrides: &[(String, String)]) -> Self {
+        let previous = overrides
+            .iter()
+            .map(|(key, value)| {
+                let old = std::env::var(key).ok();
+                std::env::set_var(key, value);
+                (key.clone(), old)
+            })
+            .collect();
+        Self { previous }
+    }
+}
+
+#[cfg(feature = "tokio-console")]
+impl Drop for ScopedEnv {
+    fn drop(&mut self) {
+        for (key, value) in self.previous.iter().rev() {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
         }
     }
 }

--- a/crates/zccache/src/cli/commands/mod.rs
+++ b/crates/zccache/src/cli/commands/mod.rs
@@ -33,8 +33,8 @@ use super::{run_ino_convert_cached, InoConvertOptions};
 use super::{ArchiveFormat, DownloadParams, WaitMode};
 
 use args::{
-    CargoRegistryCommands, Cli, Commands, DefenderExclusionsCommands, FpCommands, GhaCacheCommands,
-    SymbolsCommands, KNOWN_SUBCOMMANDS,
+    CargoRegistryCommands, Cli, Commands, DaemonCommands, DaemonProfileCommands,
+    DefenderExclusionsCommands, FpCommands, GhaCacheCommands, SymbolsCommands, KNOWN_SUBCOMMANDS,
 };
 use util::{absolute_path, init_tracing, resolve_endpoint, run_async};
 
@@ -99,6 +99,28 @@ fn dispatch(command: Commands, global_strict_paths: Option<&str>) -> ExitCode {
     match command {
         Commands::Start => daemon::run_start(),
         Commands::Stop => daemon::run_stop(),
+        Commands::Daemon { command } => match command {
+            DaemonCommands::Top {
+                bind,
+                bind_addr,
+                no_open,
+                endpoint,
+            } => {
+                let endpoint = resolve_endpoint(endpoint.as_deref());
+                let bind = bind_addr.as_deref().or(bind.as_deref());
+                run_async(daemon::cmd_profile_start(&endpoint, bind, !no_open))
+            }
+            DaemonCommands::Profile { command } => match command {
+                DaemonProfileCommands::Start {
+                    bind,
+                    open,
+                    endpoint,
+                } => {
+                    let endpoint = resolve_endpoint(endpoint.as_deref());
+                    run_async(daemon::cmd_profile_start(&endpoint, bind.as_deref(), open))
+                }
+            },
+        },
         Commands::Status { json } => {
             let endpoint = resolve_endpoint(None);
             run_async(status::cmd_status(&endpoint, json))

--- a/crates/zccache/src/cli/commands/tests/args_parsing.rs
+++ b/crates/zccache/src/cli/commands/tests/args_parsing.rs
@@ -4,7 +4,10 @@
 //! — adding/renaming a flag should require touching one of the assertions
 //! here.
 
-use super::super::args::{Cli, Commands, RustPlanBackendArg, RustPlanCommands, KNOWN_SUBCOMMANDS};
+use super::super::args::{
+    Cli, Commands, DaemonCommands, DaemonProfileCommands, RustPlanBackendArg, RustPlanCommands,
+    KNOWN_SUBCOMMANDS,
+};
 use super::super::rust_plan::rust_plan_gha_version;
 use super::super::session::{
     session_stats_error_json, session_stats_json, session_stats_unavailable_json,
@@ -284,6 +287,118 @@ fn session_start_profile_flag_parses_when_set() {
     match cli.command {
         Some(Commands::SessionStart { profile, .. }) => assert!(profile),
         other => panic!("expected SessionStart, got {other:?}"),
+    }
+}
+
+#[test]
+fn daemon_top_parses_bind_open_and_endpoint() {
+    use clap::Parser;
+    let cli = Cli::try_parse_from([
+        "zccache",
+        "daemon",
+        "top",
+        "localhost:1234",
+        "--endpoint",
+        "tcp:127.0.0.1:9",
+    ])
+    .unwrap();
+
+    match cli.command {
+        Some(Commands::Daemon {
+            command:
+                DaemonCommands::Top {
+                    bind,
+                    bind_addr,
+                    no_open,
+                    endpoint,
+                },
+        }) => {
+            assert_eq!(bind.as_deref(), Some("localhost:1234"));
+            assert!(bind_addr.is_none());
+            assert!(!no_open);
+            assert_eq!(endpoint.as_deref(), Some("tcp:127.0.0.1:9"));
+        }
+        other => panic!("expected Daemon profile start, got {other:?}"),
+    }
+}
+
+#[test]
+fn daemon_top_parses_no_open_and_long_bind_aliases() {
+    use clap::Parser;
+    let cli =
+        Cli::try_parse_from(["zccache", "daemon", "top", "--bind", "localhost:1234"]).unwrap();
+
+    match cli.command {
+        Some(Commands::Daemon {
+            command:
+                DaemonCommands::Top {
+                    bind,
+                    bind_addr,
+                    no_open,
+                    endpoint,
+                },
+        }) => {
+            assert!(bind.is_none());
+            assert_eq!(bind_addr.as_deref(), Some("localhost:1234"));
+            assert!(!no_open);
+            assert!(endpoint.is_none());
+        }
+        other => panic!("expected Daemon top, got {other:?}"),
+    }
+
+    let cli =
+        Cli::try_parse_from(["zccache", "daemon", "top", "localhost:1234", "--no-open"]).unwrap();
+
+    match cli.command {
+        Some(Commands::Daemon {
+            command:
+                DaemonCommands::Top {
+                    bind,
+                    bind_addr,
+                    no_open,
+                    endpoint,
+                },
+        }) => {
+            assert_eq!(bind.as_deref(), Some("localhost:1234"));
+            assert!(bind_addr.is_none());
+            assert!(no_open);
+            assert!(endpoint.is_none());
+        }
+        other => panic!("expected Daemon top, got {other:?}"),
+    }
+}
+
+#[test]
+fn daemon_profile_start_parses_as_compatibility_alias() {
+    use clap::Parser;
+    let cli = Cli::try_parse_from([
+        "zccache",
+        "daemon",
+        "profile",
+        "start",
+        "--bind",
+        "localhost:1234",
+        "--open",
+    ])
+    .unwrap();
+
+    match cli.command {
+        Some(Commands::Daemon {
+            command:
+                DaemonCommands::Profile {
+                    command:
+                        DaemonProfileCommands::Start {
+                            bind,
+                            open,
+                            endpoint,
+                        },
+                },
+        }) => {
+            assert_eq!(bind.as_deref(), Some("localhost:1234"));
+            assert!(open);
+            assert!(endpoint.is_none());
+        }
+        other => panic!("expected Daemon profile start alias, got {other:?}"),
     }
 }
 

--- a/crates/zccache/src/cli/commands/tests/daemon.rs
+++ b/crates/zccache/src/cli/commands/tests/daemon.rs
@@ -3,7 +3,8 @@
 //! after a clean stop, and the bounded Status-probe (issue #554).
 
 use super::super::daemon::{
-    check_daemon_version, ensure_daemon, wait_for_daemon_teardown, VersionCheck,
+    check_daemon_version, ensure_daemon, profile_env_overrides, tokio_console_bind,
+    wait_for_daemon_teardown, VersionCheck,
 };
 
 // ── Protocol mismatch recovery (issue #27) ──────────────────
@@ -51,6 +52,36 @@ async fn ensure_daemon_auto_recovers_on_comm_error() {
              auto-recovering on protocol mismatch: {msg}"
         );
     }
+}
+
+#[test]
+fn tokio_console_bind_prefers_cli_over_env_over_default() {
+    let old = std::env::var("TOKIO_CONSOLE_BIND").ok();
+    std::env::set_var("TOKIO_CONSOLE_BIND", "localhost:5555");
+
+    assert_eq!(tokio_console_bind(Some("localhost:1234")), "localhost:1234");
+    assert_eq!(tokio_console_bind(None), "localhost:5555");
+
+    match old {
+        Some(value) => std::env::set_var("TOKIO_CONSOLE_BIND", value),
+        None => std::env::remove_var("TOKIO_CONSOLE_BIND"),
+    }
+    assert_eq!(tokio_console_bind(None), "127.0.0.1:6669");
+}
+
+#[test]
+fn profile_env_overrides_enable_tokio_console_profile() {
+    let env = profile_env_overrides("localhost:1234", true);
+
+    assert!(env.contains(&(
+        "ZCCACHE_DAEMON_PROFILE".to_string(),
+        "tokio-console".to_string()
+    )));
+    assert!(env.contains(&(
+        "TOKIO_CONSOLE_BIND".to_string(),
+        "localhost:1234".to_string()
+    )));
+    assert!(env.contains(&("ZCCACHE_TOKIO_CONSOLE_OPEN".to_string(), "1".to_string())));
 }
 
 /// The bounded wait loop must return promptly when the IPC endpoint is


### PR DESCRIPTION
## Summary

Adds an optional Tokio Console profiling mode for the zccache daemon and exposes it through the CLI.

## Changes

- adds a `tokio-console` feature that wires `console-subscriber` into daemon tracing
- adds `zccache daemon top` as the primary profiling command
- supports `zccache daemon top localhost:1234`, `--bind`, and `--no-open`
- keeps `zccache daemon profile start --bind ... --open` as a hidden compatibility alias
- adds parser/helper tests for the profiling CLI behavior

## Validation

- `soldr cargo fmt`
- `soldr cargo test -p zccache daemon_top_parses_bind_open_and_endpoint`
- `soldr cargo test -p zccache daemon_top_parses_no_open_and_long_bind_aliases`
- `soldr cargo test -p zccache daemon_profile_start_parses_as_compatibility_alias`
- `soldr cargo check -p zccache`
- `RUSTFLAGS=''--cfg tokio_unstable'' soldr cargo check -p zccache --features tokio-console`