### PR TITLE
[codex] fix dead code warning in CI

### DIFF
--- a/crates/zccache/src/daemon/server/client_env.rs
+++ b/crates/zccache/src/daemon/server/client_env.rs
@@ -38,6 +38,7 @@ pub(super) fn client_env_var_is_safe_to_replay(key: &str) -> bool {
 }
 
 /// Sync-command counterpart of [`apply_client_env`].
+#[cfg(test)]
 pub(super) fn apply_client_env_sync(
     cmd: &mut std::process::Command,
     client_env: Option<&[(String, String)]>,


### PR DESCRIPTION
## Summary

Fixes the Linux CI failure after PR #896 by keeping the sync client-env helper test-only.

## Root cause

CI runs with `RUSTFLAGS=-D warnings`, so the production library check failed on `apply_client_env_sync` being unused. That helper is only used by unit tests and comments.

## Changes

- gates `apply_client_env_sync` behind `#[cfg(test)]`
- keeps the existing unit test coverage for the sync helper

## Validation

- `soldr cargo fmt`
- `RUSTFLAGS=''-D warnings'' soldr cargo check -p zccache`
- `soldr cargo test -p zccache apply_client_env_sync_filters_stale_jobserver_vars_for_tool_spawns`