### PR TITLE
[codex] fix clippy and dylint CI failures

### DIFF
--- a/crates/zccache/src/cli/commands/daemon.rs
+++ b/crates/zccache/src/cli/commands/daemon.rs
@@ -354,7 +354,7 @@ pub(crate) async fn cmd_profile_start(endpoint: &str, bind: Option<&str>, open: 
              the `tokio-console` feature. Rebuild with \
              `RUSTFLAGS=\"--cfg tokio_unstable\" cargo build --features tokio-console`."
         );
-        return ExitCode::FAILURE;
+        ExitCode::FAILURE
     }
 
     #[cfg(feature = "tokio-console")]

--- a/crates/zccache/src/cli/commands/gha.rs
+++ b/crates/zccache/src/cli/commands/gha.rs
@@ -1,5 +1,6 @@
 //! `zccache gha-cache` subcommands: status / save / restore.
 
+use crate::core::NormalizedPath;
 use crate::gha::{GhaCache, GhaError};
 use std::path::Path;
 use std::process::ExitCode;
@@ -37,7 +38,7 @@ pub(crate) async fn cmd_gha_save(key: &str, path: &str) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    let data = match tar_gz_encode_async(src.to_path_buf()).await {
+    let data = match tar_gz_encode_async(NormalizedPath::new(src)).await {
         Ok(d) => d,
         Err(e) => {
             eprintln!("zccache gha-cache save: failed to create archive: {e}");
@@ -94,7 +95,7 @@ pub(crate) async fn cmd_gha_restore(key: &str, path: &str) -> ExitCode {
     }
 
     let restored_bytes = data.len();
-    match tar_gz_decode_async(data, dest.to_path_buf()).await {
+    match tar_gz_decode_async(data, NormalizedPath::new(dest)).await {
         Ok(()) => {
             eprintln!(
                 "zccache gha-cache restore: restored {} bytes for key '{key}' to {path}",

--- a/crates/zccache/src/cli/commands/rust_plan.rs
+++ b/crates/zccache/src/cli/commands/rust_plan.rs
@@ -7,7 +7,7 @@ use crate::artifact::{
 };
 use crate::core::NormalizedPath;
 use crate::gha::{GhaCache, GhaError};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::ExitCode;
 
 use super::args::{RustPlanBackendArg, RustPlanCommands};
@@ -145,8 +145,8 @@ pub(crate) async fn cmd_rust_plan(action: RustPlanCommands) -> ExitCode {
             };
             match restore_rust_plan_layered_local_async(
                 plan.clone(),
-                PathBuf::from(&base_cache_dir),
-                PathBuf::from(&delta_cache_dir),
+                NormalizedPath::from(&base_cache_dir),
+                NormalizedPath::from(&delta_cache_dir),
             )
             .await
             {
@@ -222,8 +222,8 @@ pub(crate) async fn cmd_rust_plan(action: RustPlanCommands) -> ExitCode {
             };
             match save_rust_plan_delta_local_async(
                 plan.clone(),
-                PathBuf::from(&base_cache_dir),
-                PathBuf::from(&delta_cache_dir),
+                NormalizedPath::from(&base_cache_dir),
+                NormalizedPath::from(&delta_cache_dir),
             )
             .await
             {
@@ -281,36 +281,36 @@ where
 
 async fn restore_rust_plan_local_async(
     plan: RustArtifactPlanV1,
-    cache_dir: PathBuf,
+    cache_dir: NormalizedPath,
 ) -> Result<RustPlanSummary, RustPlanError> {
-    run_rust_plan_local_blocking(move || restore_rust_plan_local(&plan, &cache_dir)).await
+    run_rust_plan_local_blocking(move || restore_rust_plan_local(&plan, cache_dir.as_path())).await
 }
 
 async fn save_rust_plan_local_async(
     plan: RustArtifactPlanV1,
-    cache_dir: PathBuf,
+    cache_dir: NormalizedPath,
 ) -> Result<RustPlanSummary, RustPlanError> {
-    run_rust_plan_local_blocking(move || save_rust_plan_local(&plan, &cache_dir)).await
+    run_rust_plan_local_blocking(move || save_rust_plan_local(&plan, cache_dir.as_path())).await
 }
 
 async fn restore_rust_plan_layered_local_async(
     plan: RustArtifactPlanV1,
-    base_cache_dir: PathBuf,
-    delta_cache_dir: PathBuf,
+    base_cache_dir: NormalizedPath,
+    delta_cache_dir: NormalizedPath,
 ) -> Result<RustPlanSummary, RustPlanError> {
     run_rust_plan_local_blocking(move || {
-        restore_rust_plan_layered_local(&plan, &base_cache_dir, &delta_cache_dir)
+        restore_rust_plan_layered_local(&plan, base_cache_dir.as_path(), delta_cache_dir.as_path())
     })
     .await
 }
 
 async fn save_rust_plan_delta_local_async(
     plan: RustArtifactPlanV1,
-    base_cache_dir: PathBuf,
-    delta_cache_dir: PathBuf,
+    base_cache_dir: NormalizedPath,
+    delta_cache_dir: NormalizedPath,
 ) -> Result<RustPlanSummary, RustPlanError> {
     run_rust_plan_local_blocking(move || {
-        save_rust_plan_delta_local(&plan, &base_cache_dir, &delta_cache_dir)
+        save_rust_plan_delta_local(&plan, base_cache_dir.as_path(), delta_cache_dir.as_path())
     })
     .await
 }
@@ -338,7 +338,7 @@ async fn run_rust_plan_restore(
 ) -> Result<RustPlanSummary, RustPlanRuntimeError> {
     match backend {
         RustPlanBackendArg::Local => {
-            restore_rust_plan_local_async(plan.clone(), cache_dir.to_path_buf())
+            restore_rust_plan_local_async(plan.clone(), NormalizedPath::new(cache_dir))
                 .await
                 .map_err(|err| rust_plan_backend_failure(backend, err.to_string()))
         }
@@ -354,7 +354,7 @@ async fn run_rust_plan_save(
 ) -> Result<RustPlanSummary, RustPlanRuntimeError> {
     match backend {
         RustPlanBackendArg::Local => {
-            save_rust_plan_local_async(plan.clone(), cache_dir.to_path_buf())
+            save_rust_plan_local_async(plan.clone(), NormalizedPath::new(cache_dir))
                 .await
                 .map_err(|err| rust_plan_backend_failure(backend, err.to_string()))
         }
@@ -387,9 +387,12 @@ async fn restore_rust_plan_gha(
         .await
         .map_err(rust_plan_gha_error)?
     else {
-        let mut summary = restore_rust_plan_local_async(plan.clone(), cache_dir.to_path_buf())
-            .await
-            .map_err(|err| rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()))?;
+        let mut summary =
+            restore_rust_plan_local_async(plan.clone(), NormalizedPath::new(cache_dir))
+                .await
+                .map_err(|err| {
+                    rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string())
+                })?;
         summary.set_backend("gha", Some(cache_key), Some(version));
         summary.record_skip("<gha-cache>", "backend_cache_miss");
         return Ok(summary);

--- a/crates/zccache/src/cli/commands/targz.rs
+++ b/crates/zccache/src/cli/commands/targz.rs
@@ -1,7 +1,7 @@
 //! Shared tar+gzip helpers used by `gha-cache` and `rust-plan` backends.
 
+use crate::core::NormalizedPath;
 use std::path::Path;
-use std::path::PathBuf;
 
 async fn join_io<T>(
     handle: tokio::task::JoinHandle<Result<T, std::io::Error>>,
@@ -31,8 +31,11 @@ pub(crate) fn tar_gz_encode(src: &Path) -> Result<Vec<u8>, std::io::Error> {
 }
 
 /// Create a tar.gz archive from a directory path on Tokio's blocking pool.
-pub(crate) async fn tar_gz_encode_async(src: PathBuf) -> Result<Vec<u8>, std::io::Error> {
-    join_io(tokio::task::spawn_blocking(move || tar_gz_encode(&src))).await
+pub(crate) async fn tar_gz_encode_async(src: NormalizedPath) -> Result<Vec<u8>, std::io::Error> {
+    join_io(tokio::task::spawn_blocking(move || {
+        tar_gz_encode(src.as_path())
+    }))
+    .await
 }
 
 /// Extract a tar.gz archive into a destination directory.
@@ -47,10 +50,10 @@ pub(crate) fn tar_gz_decode(data: &[u8], dest: &Path) -> Result<(), std::io::Err
 /// Extract a tar.gz archive into a destination directory on Tokio's blocking pool.
 pub(crate) async fn tar_gz_decode_async(
     data: Vec<u8>,
-    dest: PathBuf,
+    dest: NormalizedPath,
 ) -> Result<(), std::io::Error> {
     join_io(tokio::task::spawn_blocking(move || {
-        tar_gz_decode(&data, &dest)
+        tar_gz_decode(&data, dest.as_path())
     }))
     .await
 }

--- a/crates/zccache/src/daemon/server/watch.rs
+++ b/crates/zccache/src/daemon/server/watch.rs
@@ -123,7 +123,7 @@ async fn register_notify_watch(
 ) -> crate::core::Result<bool> {
     let mut watcher_guard = state.watcher.lock().await;
     if let Some(ref mut w) = *watcher_guard {
-        w.watch(&dir)?;
+        w.watch(dir)?;
         Ok(true)
     } else {
         Ok(false)


### PR DESCRIPTION
## Summary

Fixes the remaining post-merge CI failures on `main` after the Tokio Console profiling merge.

## Root cause

- Clippy failed on a needless return in the daemon profiling path and a needless borrow in watcher registration.
- Dylint failed on CLI blocking wrappers that used `PathBuf` where the repo lint expects `NormalizedPath`.

## Changes

- removes the needless return and needless borrow
- changes async tar.gz and rust-plan blocking wrappers to carry `NormalizedPath`
- updates `gha-cache` and rust-plan call sites to pass normalized paths

## Validation

- `soldr cargo fmt`
- `RUSTFLAGS=''-D warnings'' soldr cargo check -p zccache`
- `soldr cargo clippy --workspace --all-targets -- -D warnings`
- `soldr cargo test -p zccache --test cli_rust_plan_lifecycle`