### PR TITLE
[codex] bump version to 1.12.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.12.9"
+version = "1.12.10"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4286,7 +4286,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.12.9"
+version = "1.12.10"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.12.9"
+version = "1.12.10"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4304,7 +4304,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.12.9"
+version = "1.12.10"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.12.9"
+version = "1.12.10"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump workspace version from `1.12.9` to `1.12.10`.
- Refresh workspace crate versions in `Cargo.lock`.

## Validation
- `python -c "from ci.release_checks import validate_release_metadata; validate_release_metadata()"`
- `$env:RUSTFLAGS='-D warnings'; soldr cargo check -p zccache`