### PR TITLE
Always compile Tokio Console support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ Thumbs.db
 .claude/settings.local.json
 
 # Project-local toolchain caches (managed by soldr)
-.cargo/
+**/.cargo/*
+!/.cargo/config.toml
 .rustup/
 
 # zccache cache directory

--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -13,10 +13,9 @@ description = "Local-first compiler cache for C/C++/Rust/Emscripten"
 default = []
 # Enables zccache::test_support (dev-only helpers).
 test-support = []
-# Enables zccache-daemon Tokio Console instrumentation. Build with
-# `RUSTFLAGS="--cfg tokio_unstable"` so Tokio emits the runtime tracing
-# events consumed by console-subscriber.
-tokio-console = ["dep:console-subscriber", "tokio/tracing"]
+# Compatibility no-op: Tokio Console support is always compiled in and
+# remains dormant unless the daemon is started with the tokio-console profile.
+tokio-console = []
 
 [dependencies]
 # core
@@ -39,9 +38,10 @@ bincode = { workspace = true }
 bytes = { workspace = true }
 prost = { workspace = true }
 
-# ipc + test-support: needs full tokio
-tokio = { workspace = true }
-console-subscriber = { workspace = true, optional = true }
+# ipc + test-support: needs full tokio. The tracing feature lets Tokio emit
+# runtime telemetry when the workspace is built with `--cfg tokio_unstable`.
+tokio = { workspace = true, features = ["tracing"] }
+console-subscriber = { workspace = true }
 
 # fscache
 dashmap = { workspace = true }

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -21,9 +21,7 @@ use zccache::core::NormalizedPath;
 const DAEMON_MAX_BLOCKING_THREADS: usize = 16;
 const DAEMON_PROFILE_ENV: &str = "ZCCACHE_DAEMON_PROFILE";
 const TOKIO_CONSOLE_PROFILE: &str = "tokio-console";
-#[cfg(feature = "tokio-console")]
 const TOKIO_CONSOLE_BIND_ENV: &str = "TOKIO_CONSOLE_BIND";
-#[cfg(feature = "tokio-console")]
 const TOKIO_CONSOLE_DEFAULT_BIND: &str = "127.0.0.1:6669";
 
 /// zccache daemon -- local compiler cache service.
@@ -527,27 +525,24 @@ fn init_tracing(level: &str) {
     let profile = std::env::var(DAEMON_PROFILE_ENV).ok();
     let tokio_console_enabled = profile.as_deref() == Some(TOKIO_CONSOLE_PROFILE);
 
-    #[cfg(feature = "tokio-console")]
-    {
-        if tokio_console_enabled {
-            let bind = std::env::var(TOKIO_CONSOLE_BIND_ENV)
-                .unwrap_or_else(|_| TOKIO_CONSOLE_DEFAULT_BIND.to_string());
-            let console_layer = console_subscriber::spawn();
-            tracing_subscriber::registry()
-                .with(console_layer)
-                .with(
-                    tracing_subscriber::fmt::layer()
-                        .with_target(true)
-                        .with_thread_ids(true)
-                        .with_filter(filter),
-                )
-                .init();
-            tracing::info!(
-                bind,
-                "tokio-console daemon profile enabled; connect with `tokio-console {bind}`"
-            );
-            return;
-        }
+    if tokio_console_enabled {
+        let bind = std::env::var(TOKIO_CONSOLE_BIND_ENV)
+            .unwrap_or_else(|_| TOKIO_CONSOLE_DEFAULT_BIND.to_string());
+        let console_layer = console_subscriber::spawn();
+        tracing_subscriber::registry()
+            .with(console_layer)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_target(true)
+                    .with_thread_ids(true)
+                    .with_filter(filter),
+            )
+            .init();
+        tracing::info!(
+            bind,
+            "tokio-console daemon profile enabled; connect with `tokio-console {bind}`"
+        );
+        return;
     }
 
     tracing_subscriber::registry()
@@ -558,14 +553,6 @@ fn init_tracing(level: &str) {
                 .with_filter(filter),
         )
         .init();
-
-    #[cfg(not(feature = "tokio-console"))]
-    if tokio_console_enabled {
-        tracing::warn!(
-            profile = TOKIO_CONSOLE_PROFILE,
-            "ZCCACHE_DAEMON_PROFILE requested tokio-console, but this binary was built without the `tokio-console` feature"
-        );
-    }
 
     if let Some(profile) = profile {
         if profile != TOKIO_CONSOLE_PROFILE {

--- a/crates/zccache/src/cli/commands/daemon.rs
+++ b/crates/zccache/src/cli/commands/daemon.rs
@@ -6,17 +6,11 @@ use std::process::ExitCode;
 use super::super::status_probe_timeout;
 use super::util::{connect, resolve_endpoint, run_async, LOST_CONNECTION_MSG};
 
-#[cfg(any(test, feature = "tokio-console"))]
 const DAEMON_PROFILE_ENV: &str = "ZCCACHE_DAEMON_PROFILE";
-#[cfg(any(test, feature = "tokio-console"))]
 const TOKIO_CONSOLE_PROFILE: &str = "tokio-console";
-#[cfg(any(test, feature = "tokio-console"))]
 const TOKIO_CONSOLE_BIND_ENV: &str = "TOKIO_CONSOLE_BIND";
-#[cfg(any(test, feature = "tokio-console"))]
 const TOKIO_CONSOLE_OPEN_ENV: &str = "ZCCACHE_TOKIO_CONSOLE_OPEN";
-#[cfg(any(test, feature = "tokio-console"))]
 const TOKIO_CONSOLE_DEFAULT_BIND: &str = "127.0.0.1:6669";
-#[cfg(feature = "tokio-console")]
 const PROFILE_START_REASON: &str = "tokio-console-profile-start";
 
 pub(crate) enum VersionCheck {
@@ -346,50 +340,34 @@ pub(crate) async fn cmd_start(endpoint: &str) -> ExitCode {
 }
 
 pub(crate) async fn cmd_profile_start(endpoint: &str, bind: Option<&str>, open: bool) -> ExitCode {
-    #[cfg(not(feature = "tokio-console"))]
-    {
-        let _ = (endpoint, bind, open);
-        eprintln!(
-            "tokio-console daemon profile is unavailable: this zccache binary was built without \
-             the `tokio-console` feature. Rebuild with \
-             `RUSTFLAGS=\"--cfg tokio_unstable\" cargo build --features tokio-console`."
-        );
-        ExitCode::FAILURE
+    let open = open || env_truthy(TOKIO_CONSOLE_OPEN_ENV);
+    let bind = tokio_console_bind(bind);
+    let env = profile_env_overrides(&bind, open);
+    let _guard = ScopedEnv::apply(&env);
+
+    let killed_pid = stop_stale_daemon(endpoint).await;
+    if let Err(e) = spawn_and_wait(endpoint, PROFILE_START_REASON, killed_pid).await {
+        eprintln!("failed to start tokio-console daemon profile: {e}");
+        return ExitCode::FAILURE;
     }
+    eprintln!("daemon running with tokio-console profile at {bind}");
 
-    #[cfg(feature = "tokio-console")]
-    {
-        let open = open || env_truthy(TOKIO_CONSOLE_OPEN_ENV);
-        let bind = tokio_console_bind(bind);
-        let env = profile_env_overrides(&bind, open);
-        let _guard = ScopedEnv::apply(&env);
-
-        let killed_pid = stop_stale_daemon(endpoint).await;
-        if let Err(e) = spawn_and_wait(endpoint, PROFILE_START_REASON, killed_pid).await {
-            eprintln!("failed to start tokio-console daemon profile: {e}");
+    if open {
+        if let Err(e) = launch_tokio_console(&bind) {
+            eprintln!("{e}");
             return ExitCode::FAILURE;
         }
-        eprintln!("daemon running with tokio-console profile at {bind}");
-
-        if open {
-            if let Err(e) = launch_tokio_console(&bind) {
-                eprintln!("{e}");
-                return ExitCode::FAILURE;
-            }
-        }
-
-        ExitCode::SUCCESS
     }
+
+    ExitCode::SUCCESS
 }
 
-#[cfg(any(test, feature = "tokio-console"))]
 pub(crate) fn tokio_console_bind(bind: Option<&str>) -> String {
     bind.map(str::to_string)
         .or_else(|| std::env::var(TOKIO_CONSOLE_BIND_ENV).ok())
         .unwrap_or_else(|| TOKIO_CONSOLE_DEFAULT_BIND.to_string())
 }
 
-#[cfg(any(test, feature = "tokio-console"))]
 pub(crate) fn profile_env_overrides(bind: &str, open: bool) -> Vec<(String, String)> {
     let mut env = vec![
         (
@@ -404,7 +382,6 @@ pub(crate) fn profile_env_overrides(bind: &str, open: bool) -> Vec<(String, Stri
     env
 }
 
-#[cfg(feature = "tokio-console")]
 fn launch_tokio_console(bind: &str) -> Result<(), String> {
     let mut cmd = std::process::Command::new("tokio-console");
     #[cfg(windows)]
@@ -422,7 +399,6 @@ fn launch_tokio_console(bind: &str) -> Result<(), String> {
         })
 }
 
-#[cfg(feature = "tokio-console")]
 fn env_truthy(name: &str) -> bool {
     std::env::var(name).is_ok_and(|value| {
         let value = value.trim();
@@ -434,12 +410,10 @@ fn env_truthy(name: &str) -> bool {
     })
 }
 
-#[cfg(feature = "tokio-console")]
 struct ScopedEnv {
     previous: Vec<(String, Option<String>)>,
 }
 
-#[cfg(feature = "tokio-console")]
 impl ScopedEnv {
     fn apply(overrides: &[(String, String)]) -> Self {
         let previous = overrides
@@ -454,7 +428,6 @@ impl ScopedEnv {
     }
 }
 
-#[cfg(feature = "tokio-console")]
 impl Drop for ScopedEnv {
     fn drop(&mut self) {
         for (key, value) in self.previous.iter().rev() {

--- a/crates/zccache/tests/daemon_tokio_console_test.rs
+++ b/crates/zccache/tests/daemon_tokio_console_test.rs
@@ -1,0 +1,205 @@
+//! Integration proof for Tokio Console's default-dormant behavior.
+//!
+//! The daemon always links the console subscriber, but it must only start the
+//! console server when explicitly launched with the tokio-console daemon
+//! profile. This test snapshots that process state with a real daemon process:
+//! no TCP listener in normal mode, TCP listener plus profile log in console
+//! mode.
+
+use serde_json::json;
+use std::io;
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+#[test]
+fn tokio_console_is_compiled_in_but_dormant_until_profile_start() {
+    let daemon_bin = env!("CARGO_BIN_EXE_zccache-daemon");
+    let tmp = tempfile::tempdir().expect("create tempdir");
+
+    let dormant_bind = free_console_bind();
+    let mut dormant = spawn_daemon(daemon_bin, tmp.path(), "dormant", None);
+    wait_for_log(
+        &dormant.log_file,
+        "listening for connections",
+        Duration::from_secs(10),
+    )
+    .expect("dormant daemon should reach listening state");
+
+    let dormant_tcp_listening = wait_for_tcp(&dormant_bind, Duration::from_millis(750));
+    let dormant_log = read_log(&dormant.log_file);
+    let dormant_snapshot = json!({
+        "mode": "dormant",
+        "daemon_pid": dormant.child.id(),
+        "tokio_console_bind": dormant_bind.to_string(),
+        "tokio_console_tcp_listening": dormant_tcp_listening,
+        "profile_log_present": dormant_log.contains("tokio-console daemon profile enabled"),
+    });
+    println!("tokio-console dormant snapshot: {dormant_snapshot}");
+
+    assert!(
+        !dormant_tcp_listening,
+        "normal daemon unexpectedly opened Tokio Console listener at {dormant_bind}; \
+         snapshot={dormant_snapshot}"
+    );
+    assert!(
+        !dormant_log.contains("tokio-console daemon profile enabled"),
+        "normal daemon unexpectedly logged tokio-console profile activation; \
+         snapshot={dormant_snapshot}"
+    );
+    dormant.stop();
+
+    let active_bind = free_console_bind();
+    let mut active = spawn_daemon(
+        daemon_bin,
+        tmp.path(),
+        "active",
+        Some(active_bind.to_string()),
+    );
+    wait_for_log(
+        &active.log_file,
+        "tokio-console daemon profile enabled",
+        Duration::from_secs(10),
+    )
+    .expect("profile daemon should log tokio-console activation");
+
+    let active_tcp_listening = wait_for_tcp(&active_bind, Duration::from_secs(10));
+    let active_log = read_log(&active.log_file);
+    let active_snapshot = json!({
+        "mode": "active",
+        "daemon_pid": active.child.id(),
+        "tokio_console_bind": active_bind.to_string(),
+        "tokio_console_tcp_listening": active_tcp_listening,
+        "profile_log_present": active_log.contains("tokio-console daemon profile enabled"),
+    });
+    println!("tokio-console active snapshot: {active_snapshot}");
+
+    active.stop();
+
+    assert!(
+        active_tcp_listening,
+        "tokio-console profile did not open listener at {active_bind}; \
+         snapshot={active_snapshot}"
+    );
+    assert!(
+        active_log.contains("tokio-console daemon profile enabled"),
+        "tokio-console profile did not log activation; snapshot={active_snapshot}"
+    );
+}
+
+struct DaemonProcess {
+    child: Child,
+    log_file: PathBuf,
+}
+
+impl DaemonProcess {
+    fn stop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for DaemonProcess {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn spawn_daemon(
+    daemon_bin: &str,
+    root: &Path,
+    mode: &str,
+    tokio_console_bind: Option<String>,
+) -> DaemonProcess {
+    let nonce = format!(
+        "{}-{mode}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    );
+    let cache_dir = root.join(format!("cache-{nonce}"));
+    let log_file = root.join(format!("daemon-{nonce}.log"));
+    std::fs::create_dir_all(&cache_dir).expect("create cache dir");
+
+    let endpoint = endpoint_for(&nonce, root);
+    let mut cmd = Command::new(daemon_bin);
+    cmd.args([
+        "--foreground",
+        "--endpoint",
+        &endpoint,
+        "--log-file",
+        &log_file.to_string_lossy(),
+        "--idle-timeout",
+        "30",
+    ])
+    .env("ZCCACHE_CACHE_DIR", &cache_dir)
+    .env("ZCCACHE_QUIET", "1")
+    .env("ZCCACHE_NO_UNLOCK", "1")
+    .stdin(Stdio::null())
+    .stdout(Stdio::null())
+    .stderr(Stdio::null());
+
+    if let Some(bind) = tokio_console_bind {
+        cmd.env("ZCCACHE_DAEMON_PROFILE", "tokio-console")
+            .env("TOKIO_CONSOLE_BIND", bind);
+    }
+
+    let child = cmd.spawn().expect("spawn zccache-daemon");
+    DaemonProcess { child, log_file }
+}
+
+#[cfg(windows)]
+fn endpoint_for(nonce: &str, _root: &Path) -> String {
+    format!(r"\\.\pipe\zccache-test-tokio-console-{nonce}")
+}
+
+#[cfg(unix)]
+fn endpoint_for(nonce: &str, root: &Path) -> String {
+    root.join(format!("zccache-test-tokio-console-{nonce}.sock"))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn free_console_bind() -> SocketAddr {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind free local port");
+    listener.local_addr().expect("read local addr")
+}
+
+fn wait_for_tcp(addr: &SocketAddr, timeout: Duration) -> bool {
+    wait_until(timeout, || {
+        TcpStream::connect_timeout(addr, Duration::from_millis(100)).is_ok()
+    })
+}
+
+fn wait_for_log(log_file: &Path, needle: &str, timeout: Duration) -> io::Result<()> {
+    let found = wait_until(timeout, || read_log(log_file).contains(needle));
+    if found {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!(
+                "timed out waiting for log line {needle:?}; current log: {}",
+                read_log(log_file)
+            ),
+        ))
+    }
+}
+
+fn read_log(log_file: &Path) -> String {
+    std::fs::read_to_string(log_file).unwrap_or_default()
+}
+
+fn wait_until(timeout: Duration, mut predicate: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if predicate() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    predicate()
+}


### PR DESCRIPTION
## Summary

- always compile `console-subscriber` and Tokio's `tracing` feature into zccache
- keep Tokio Console dormant until `ZCCACHE_DAEMON_PROFILE=tokio-console` / `zccache daemon top` starts the profile
- add an integration test that snapshots a real daemon's runtime state: normal mode has no Tokio Console TCP listener, profile mode does

## Proof

Local:

```text
ZCCACHE_DISABLE=1 soldr cargo test -p zccache --test daemon_tokio_console_test -- --nocapture
```

Snapshot output:

```json
{"mode":"dormant","profile_log_present":false,"tokio_console_tcp_listening":false}
{"mode":"active","profile_log_present":true,"tokio_console_tcp_listening":true}
```

Docker:

```text
docker run --rm -v <repo>:/src:ro -v zccache-tokio-console-target:/target -v zccache-tokio-console-cargo:/cargo-home -w /src --entrypoint /bin/bash zccache-perf-zccache-builder -lc 'export PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin; cargo test -p zccache --test daemon_tokio_console_test -- --nocapture'
```

Docker snapshot output:

```json
{"mode":"dormant","profile_log_present":false,"tokio_console_tcp_listening":false}
{"mode":"active","profile_log_present":true,"tokio_console_tcp_listening":true}
```

Closes #895
