### PR TITLE
feat: expose engine phase profiling reports

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -32,7 +32,7 @@ jobs:
   x86:
     uses: ./.github/workflows/ci-check.yml
     with:
-      os: macos-13
+      os: macos-14
 
   arm:
     uses: ./.github/workflows/ci-check.yml

--- a/README.md
+++ b/README.md
@@ -1033,6 +1033,19 @@ zccache session-stats $ZCCACHE_SESSION_ID   # query mid-build
 zccache session-end $ZCCACHE_SESSION_ID     # final stats
 ```
 
+Render the always-on engine phase profiler from a saved stats JSON file:
+
+```bash
+zccache session-end $ZCCACHE_SESSION_ID --json > last-session-stats.json
+zccache engine-profile last-session-stats.json
+zccache engine-profile last-session-stats.json --json
+```
+
+This reports aggregate hit/miss phase totals, averages, and dominant phases
+from `phase_profile`. It is the cache-engine regression view; Tokio Console is
+for live async runtime symptoms such as blocked tasks, long polls, and resource
+contention.
+
 **Persistent cache:** Artifacts are stored in `~/.zccache/artifacts/`
 and survive daemon restarts. No need to re-warm the cache after a reboot.
 

--- a/crates/zccache/src/cli/commands/args/mod.rs
+++ b/crates/zccache/src/cli/commands/args/mod.rs
@@ -115,6 +115,15 @@ pub(crate) enum Commands {
         #[arg(long)]
         top: Option<usize>,
     },
+    /// Render engine phase profiling from a session-stats JSON file.
+    #[command(name = "engine-profile")]
+    EngineProfile {
+        /// Path to last-session-stats.json or `session-stats --json` output.
+        stats_json: String,
+        /// Print a stable machine-readable JSON report.
+        #[arg(long)]
+        json: bool,
+    },
     /// Clear the artifact cache.
     Clear,
     /// Install the running-process `zccache.servicedef` so the shared
@@ -567,6 +576,7 @@ pub(crate) const KNOWN_SUBCOMMANDS: &[&str] = &[
     "daemon",
     "status",
     "analyze",
+    "engine-profile",
     "clear",
     "install-servicedef",
     "wrap",

--- a/crates/zccache/src/cli/commands/engine_profile.rs
+++ b/crates/zccache/src/cli/commands/engine_profile.rs
@@ -1,0 +1,254 @@
+//! Engine phase-profile reporting for `session-stats --json` payloads.
+
+use std::fmt;
+use std::process::ExitCode;
+
+use serde_json::Value;
+
+pub(crate) fn cmd_engine_profile(stats_json: &str, json: bool) -> ExitCode {
+    match read_engine_profile_report(stats_json) {
+        Ok(report) => {
+            if json {
+                println!("{}", engine_profile_report_json(&report));
+            } else {
+                print!("{}", render_engine_profile_report(&report));
+            }
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("zccache engine-profile: {stats_json}: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+pub(crate) fn read_engine_profile_report(
+    stats_json: &str,
+) -> Result<EngineProfileReport, EngineProfileError> {
+    let raw = std::fs::read_to_string(stats_json).map_err(EngineProfileError::Io)?;
+    let value = serde_json::from_str(&raw).map_err(EngineProfileError::Json)?;
+    engine_profile_report_from_value(&value)
+}
+
+pub(crate) fn engine_profile_report_from_value(
+    value: &Value,
+) -> Result<EngineProfileReport, EngineProfileError> {
+    let phase_profile = value
+        .get("phase_profile")
+        .and_then(Value::as_object)
+        .ok_or(EngineProfileError::MissingPhaseProfile)?;
+
+    let hit_count = u64_field(phase_profile, "hit_count");
+    let miss_count = u64_field(phase_profile, "miss_count");
+    let hit_total_ns = u64_field(phase_profile, "total_hit_ns");
+    let miss_total_ns = u64_field(phase_profile, "total_miss_ns");
+
+    Ok(EngineProfileReport {
+        hit_path: PathReport::new(
+            hit_count,
+            hit_total_ns,
+            &[
+                ("parse_args", u64_field(phase_profile, "parse_args_ns")),
+                (
+                    "build_context",
+                    u64_field(phase_profile, "build_context_ns"),
+                ),
+                ("hash_source", u64_field(phase_profile, "hash_source_ns")),
+                ("hash_headers", u64_field(phase_profile, "hash_headers_ns")),
+                (
+                    "depgraph_check",
+                    u64_field(phase_profile, "depgraph_check_ns"),
+                ),
+                (
+                    "request_cache_lookup",
+                    u64_field(phase_profile, "request_cache_lookup_ns"),
+                ),
+                (
+                    "cross_root_validate",
+                    u64_field(phase_profile, "cross_root_validate_ns"),
+                ),
+                (
+                    "artifact_lookup",
+                    u64_field(phase_profile, "artifact_lookup_ns"),
+                ),
+                ("write_output", u64_field(phase_profile, "write_output_ns")),
+                ("bookkeeping", u64_field(phase_profile, "bookkeeping_ns")),
+            ],
+        ),
+        miss_path: PathReport::new(
+            miss_count,
+            miss_total_ns,
+            &[
+                (
+                    "compiler_exec",
+                    u64_field(phase_profile, "compiler_exec_ns"),
+                ),
+                ("include_scan", u64_field(phase_profile, "include_scan_ns")),
+                ("hash_all", u64_field(phase_profile, "hash_all_ns")),
+                (
+                    "artifact_store",
+                    u64_field(phase_profile, "artifact_store_ns"),
+                ),
+            ],
+        ),
+    })
+}
+
+pub(crate) fn engine_profile_report_json(report: &EngineProfileReport) -> Value {
+    serde_json::json!({
+        "status": "ok",
+        "hit_path": path_report_json(&report.hit_path),
+        "miss_path": path_report_json(&report.miss_path),
+    })
+}
+
+pub(crate) fn render_engine_profile_report(report: &EngineProfileReport) -> String {
+    let mut out = String::new();
+    out.push_str("zccache engine profile\n");
+    render_path("hit path", &report.hit_path, &mut out);
+    render_path("miss path", &report.miss_path, &mut out);
+    out
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct EngineProfileReport {
+    pub(crate) hit_path: PathReport,
+    pub(crate) miss_path: PathReport,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PathReport {
+    pub(crate) count: u64,
+    pub(crate) total_ns: u64,
+    pub(crate) avg_ns: u64,
+    pub(crate) avg_ms: f64,
+    pub(crate) dominant_phase: Option<String>,
+    pub(crate) phases: Vec<PhaseRow>,
+}
+
+impl PathReport {
+    fn new(count: u64, total_ns: u64, phases: &[(&'static str, u64)]) -> Self {
+        let avg_ns = average_ns(total_ns, count);
+        let phases: Vec<PhaseRow> = phases
+            .iter()
+            .map(|(name, phase_total_ns)| PhaseRow {
+                name: (*name).to_string(),
+                total_ns: *phase_total_ns,
+                avg_ns: average_ns(*phase_total_ns, count),
+                avg_ms: ns_to_ms(average_ns(*phase_total_ns, count)),
+                percent_of_total: percent(*phase_total_ns, total_ns),
+            })
+            .collect();
+        let dominant_phase = phases
+            .iter()
+            .filter(|phase| phase.total_ns > 0)
+            .max_by_key(|phase| phase.total_ns)
+            .map(|phase| phase.name.clone());
+        Self {
+            count,
+            total_ns,
+            avg_ns,
+            avg_ms: ns_to_ms(avg_ns),
+            dominant_phase,
+            phases,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PhaseRow {
+    pub(crate) name: String,
+    pub(crate) total_ns: u64,
+    pub(crate) avg_ns: u64,
+    pub(crate) avg_ms: f64,
+    pub(crate) percent_of_total: f64,
+}
+
+#[derive(Debug)]
+pub(crate) enum EngineProfileError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+    MissingPhaseProfile,
+}
+
+impl fmt::Display for EngineProfileError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(err) => write!(f, "failed to read stats JSON: {err}"),
+            Self::Json(err) => write!(f, "failed to parse stats JSON: {err}"),
+            Self::MissingPhaseProfile => write!(
+                f,
+                "missing phase_profile; collect stats with `zccache session-start --stats` \
+                 and `zccache session-end --json`"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EngineProfileError {}
+
+fn render_path(label: &str, report: &PathReport, out: &mut String) {
+    let dominant = report.dominant_phase.as_deref().unwrap_or("none");
+    out.push_str(&format!(
+        "  {label}: {} samples, total {} ns ({:.3} ms), avg {} ns ({:.3} ms), dominant {dominant}\n",
+        report.count,
+        report.total_ns,
+        ns_to_ms(report.total_ns),
+        report.avg_ns,
+        report.avg_ms,
+    ));
+    for phase in &report.phases {
+        out.push_str(&format!(
+            "    {:<22} total={} ns avg={} ns avg_ms={:.3} pct={:.1}%\n",
+            phase.name, phase.total_ns, phase.avg_ns, phase.avg_ms, phase.percent_of_total,
+        ));
+    }
+}
+
+fn path_report_json(report: &PathReport) -> Value {
+    let phases: Vec<Value> = report
+        .phases
+        .iter()
+        .map(|phase| {
+            serde_json::json!({
+                "name": phase.name,
+                "total_ns": phase.total_ns,
+                "avg_ns": phase.avg_ns,
+                "avg_ms": phase.avg_ms,
+                "percent_of_total": phase.percent_of_total,
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "count": report.count,
+        "total_ns": report.total_ns,
+        "avg_ns": report.avg_ns,
+        "avg_ms": report.avg_ms,
+        "dominant_phase": report.dominant_phase,
+        "phases": phases,
+    })
+}
+
+fn u64_field(map: &serde_json::Map<String, Value>, field: &str) -> u64 {
+    map.get(field).and_then(Value::as_u64).unwrap_or(0)
+}
+
+fn average_ns(total_ns: u64, count: u64) -> u64 {
+    if count == 0 {
+        0
+    } else {
+        total_ns / count
+    }
+}
+
+fn ns_to_ms(ns: u64) -> f64 {
+    ns as f64 / 1_000_000.0
+}
+
+fn percent(part: u64, total: u64) -> f64 {
+    if total == 0 {
+        0.0
+    } else {
+        part as f64 / total as f64 * 100.0
+    }
+}

--- a/crates/zccache/src/cli/commands/mod.rs
+++ b/crates/zccache/src/cli/commands/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod cache_ops;
 pub(crate) mod cargo_registry;
 pub(crate) mod daemon;
 pub(crate) mod download;
+pub(crate) mod engine_profile;
 pub(crate) mod exec;
 pub(crate) mod fp;
 pub(crate) mod gha;
@@ -144,6 +145,9 @@ fn dispatch(command: Commands, global_strict_paths: Option<&str>) -> ExitCode {
                 top,
             },
         ),
+        Commands::EngineProfile { stats_json, json } => {
+            engine_profile::cmd_engine_profile(&stats_json, json)
+        }
         Commands::Clear => {
             let endpoint = resolve_endpoint(None);
             run_async(cache_ops::cmd_clear(&endpoint))

--- a/crates/zccache/src/cli/commands/tests/args_parsing.rs
+++ b/crates/zccache/src/cli/commands/tests/args_parsing.rs
@@ -267,6 +267,22 @@ fn session_stats_accepts_json_flag() {
     ));
 }
 
+#[test]
+fn engine_profile_accepts_json_flag() {
+    use clap::Parser;
+    let cli = Cli::try_parse_from([
+        "zccache",
+        "engine-profile",
+        "last-session-stats.json",
+        "--json",
+    ])
+    .unwrap();
+    assert!(matches!(
+        cli.command,
+        Some(Commands::EngineProfile { json: true, .. })
+    ));
+}
+
 // Issue #256 -- CLI flag parsing for session-start --profile
 // and the new zccache analyze filter/sort flags.
 

--- a/crates/zccache/src/cli/commands/tests/engine_profile.rs
+++ b/crates/zccache/src/cli/commands/tests/engine_profile.rs
@@ -1,0 +1,97 @@
+use serde_json::json;
+
+use super::super::engine_profile::{
+    engine_profile_report_from_value, engine_profile_report_json, render_engine_profile_report,
+    EngineProfileError,
+};
+
+#[test]
+fn engine_profile_json_reports_counts_averages_and_dominant_phases() {
+    let report = engine_profile_report_from_value(&profile_fixture()).unwrap();
+    let json = engine_profile_report_json(&report);
+
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["hit_path"]["count"], 3);
+    assert_eq!(json["hit_path"]["total_ns"], 900);
+    assert_eq!(json["hit_path"]["avg_ns"], 300);
+    assert_eq!(json["hit_path"]["avg_ms"].as_f64().unwrap(), 0.0003);
+    assert_eq!(json["hit_path"]["dominant_phase"], "write_output");
+    assert_eq!(json["miss_path"]["count"], 2);
+    assert_eq!(json["miss_path"]["total_ns"], 4_000_000);
+    assert_eq!(json["miss_path"]["avg_ns"], 2_000_000);
+    assert_eq!(json["miss_path"]["avg_ms"].as_f64().unwrap(), 2.0);
+    assert_eq!(json["miss_path"]["dominant_phase"], "compiler_exec");
+}
+
+#[test]
+fn engine_profile_human_report_names_paths_and_dominant_phase() {
+    let report = engine_profile_report_from_value(&profile_fixture()).unwrap();
+    let text = render_engine_profile_report(&report);
+
+    assert!(text.contains("zccache engine profile"));
+    assert!(text.contains("hit path: 3 samples"));
+    assert!(text.contains("miss path: 2 samples"));
+    assert!(text.contains("dominant write_output"));
+    assert!(text.contains("compiler_exec"));
+}
+
+#[test]
+fn engine_profile_zero_counts_have_zero_averages_and_no_dominant_phase() {
+    let value = json!({
+        "status": "ok",
+        "phase_profile": {
+            "hit_count": 0,
+            "miss_count": 0,
+            "total_hit_ns": 0,
+            "total_miss_ns": 0
+        }
+    });
+    let report = engine_profile_report_from_value(&value).unwrap();
+    let json = engine_profile_report_json(&report);
+
+    assert_eq!(json["hit_path"]["avg_ns"], 0);
+    assert_eq!(json["hit_path"]["avg_ms"].as_f64().unwrap(), 0.0);
+    assert!(json["hit_path"]["dominant_phase"].is_null());
+    assert_eq!(json["miss_path"]["avg_ns"], 0);
+    assert_eq!(json["miss_path"]["avg_ms"].as_f64().unwrap(), 0.0);
+    assert!(json["miss_path"]["dominant_phase"].is_null());
+}
+
+#[test]
+fn engine_profile_missing_phase_profile_is_clear_error() {
+    let err = engine_profile_report_from_value(&json!({
+        "status": "ok",
+        "phase_profile": null
+    }))
+    .unwrap_err();
+
+    assert!(matches!(err, EngineProfileError::MissingPhaseProfile));
+    assert!(err.to_string().contains("missing phase_profile"));
+}
+
+fn profile_fixture() -> serde_json::Value {
+    json!({
+        "status": "ok",
+        "session_id": "session-123",
+        "phase_profile": {
+            "hit_count": 3,
+            "miss_count": 2,
+            "parse_args_ns": 30,
+            "build_context_ns": 60,
+            "hash_source_ns": 90,
+            "hash_headers_ns": 120,
+            "depgraph_check_ns": 150,
+            "request_cache_lookup_ns": 180,
+            "cross_root_validate_ns": 210,
+            "artifact_lookup_ns": 240,
+            "write_output_ns": 270,
+            "bookkeeping_ns": 15,
+            "total_hit_ns": 900,
+            "compiler_exec_ns": 3_000_000,
+            "include_scan_ns": 500_000,
+            "hash_all_ns": 300_000,
+            "artifact_store_ns": 200_000,
+            "total_miss_ns": 4_000_000
+        }
+    })
+}

--- a/crates/zccache/src/cli/commands/tests/mod.rs
+++ b/crates/zccache/src/cli/commands/tests/mod.rs
@@ -6,6 +6,7 @@ mod analyze;
 mod args_parsing;
 mod cache_ops;
 mod daemon;
+mod engine_profile;
 mod exit_code;
 mod session_warnings;
 mod snapshot;

--- a/crates/zccache/src/embedded.rs
+++ b/crates/zccache/src/embedded.rs
@@ -4,10 +4,10 @@
 //! already own a Tokio runtime. The service reuses the daemon compile/session
 //! machinery directly and does not bind or listen on zccache IPC endpoints.
 
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use crate::core::NormalizedPath;
 use crate::daemon::server::{
     EmbeddedCompileRequest, EmbeddedDaemon, EmbeddedFlushReport, EmbeddedStatsSnapshot,
 };
@@ -39,7 +39,7 @@ pub struct ZccacheService {
 #[derive(Debug, Clone)]
 pub struct ZccacheConfig {
     pub host: HostIdentity,
-    pub cache_root: PathBuf,
+    pub cache_root: NormalizedPath,
     pub audit: AuditConfig,
     pub limits: ServiceLimits,
     pub runtime: RuntimeHooks,
@@ -69,9 +69,9 @@ pub struct ServiceLimits {
 #[derive(Debug, Clone)]
 pub struct CompileRequest {
     pub audit: AuditContext,
-    pub compiler: PathBuf,
+    pub compiler: NormalizedPath,
     pub args: Vec<String>,
-    pub cwd: PathBuf,
+    pub cwd: NormalizedPath,
     pub env: Vec<(String, String)>,
     pub stdin: Vec<u8>,
 }
@@ -120,7 +120,7 @@ pub struct FlushReport {
 /// Current service statistics.
 #[derive(Debug, Clone)]
 pub struct ServiceStats {
-    pub cache_root: PathBuf,
+    pub cache_root: NormalizedPath,
     pub uptime_secs: u64,
     pub total_compilations: u64,
     pub cache_hits: u64,
@@ -143,9 +143,8 @@ impl ZccacheService {
     /// Start an in-process zccache service on the caller's Tokio runtime.
     pub async fn start(config: ZccacheConfig) -> Result<Self> {
         let endpoint = embedded_endpoint(&config.host);
-        let cache_root = crate::core::config::effective_cache_root_from_top_level(
-            &crate::core::NormalizedPath::new(config.cache_root),
-        );
+        let cache_root =
+            crate::core::config::effective_cache_root_from_top_level(&config.cache_root);
         let daemon = EmbeddedDaemon::start(endpoint, cache_root)
             .await
             .map_err(|err| EmbeddedError::Start(err.to_string()))?;
@@ -170,9 +169,9 @@ impl ZccacheService {
         let response = self
             .daemon
             .compile(EmbeddedCompileRequest {
-                compiler: request.compiler,
+                compiler: request.compiler.into_path_buf(),
                 args: request.args,
-                cwd: request.cwd,
+                cwd: request.cwd.into_path_buf(),
                 env: Some(request.env),
                 stdin: request.stdin,
             })
@@ -228,7 +227,7 @@ impl ServiceStats {
     fn from_snapshot(snapshot: EmbeddedStatsSnapshot) -> Self {
         let status = snapshot.status;
         Self {
-            cache_root: status.cache_dir.into_path_buf(),
+            cache_root: status.cache_dir,
             uptime_secs: status.uptime_secs,
             total_compilations: status.total_compilations,
             cache_hits: status.cache_hits,

--- a/crates/zccache/src/ipc/broker_v2.rs
+++ b/crates/zccache/src/ipc/broker_v2.rs
@@ -338,8 +338,8 @@ mod tests {
         assert_eq!(result.expect("fast closure returns Ok"), 42);
     }
 
-    /// Stress test: 100 consecutive `call_with_brokerv2_deadline` calls,
-    /// each closure stalls for 60s while the deadline fires at 10ms.
+    /// Stress test: repeated `call_with_brokerv2_deadline` calls,
+    /// each closure stalls longer than the deadline.
     /// Total wall-clock should be much less than 100 × 10ms = 1s if the
     /// helper threads truly run independently (i.e. each call returns
     /// on its own thread's deadline, not serialized).
@@ -355,13 +355,17 @@ mod tests {
     /// follow-up (see ledger #842 round-2 finding #1).
     #[test]
     fn call_with_brokerv2_deadline_stress_repeated_timeouts() {
+        const ATTEMPTS: usize = 32;
+        const DEADLINE: Duration = Duration::from_millis(10);
+        const CLOSURE_STALL: Duration = Duration::from_secs(2);
+        const WALL_BUDGET: Duration = Duration::from_secs(5);
+
         let start = std::time::Instant::now();
-        for _ in 0..100 {
-            let result: Result<(), BrokerV2Error> =
-                call_with_brokerv2_deadline(Duration::from_millis(10), || {
-                    std::thread::sleep(Duration::from_secs(60));
-                    Ok(())
-                });
+        for _ in 0..ATTEMPTS {
+            let result: Result<(), BrokerV2Error> = call_with_brokerv2_deadline(DEADLINE, || {
+                std::thread::sleep(CLOSURE_STALL);
+                Ok(())
+            });
             match result {
                 Err(BrokerV2Error::Io(io)) if io.kind() == std::io::ErrorKind::TimedOut => {}
                 other => panic!("expected Io(TimedOut), got: {other:?}"),
@@ -369,8 +373,8 @@ mod tests {
         }
         let elapsed = start.elapsed();
         assert!(
-            elapsed < Duration::from_secs(5),
-            "100 repeated timeouts took {elapsed:?}; expected ~1s (5s budget)"
+            elapsed < WALL_BUDGET,
+            "{ATTEMPTS} repeated timeouts took {elapsed:?}; expected under {WALL_BUDGET:?}"
         );
     }
 

--- a/docs/architecture/embedded-service.md
+++ b/docs/architecture/embedded-service.md
@@ -120,7 +120,7 @@ pub struct ZccacheService {
 
 pub struct ZccacheConfig {
     pub host: HostIdentity,
-    pub cache_root: PathBuf,
+    pub cache_root: NormalizedPath,
     pub audit: AuditConfig,
     pub limits: ServiceLimits,
     pub runtime: RuntimeHooks,
@@ -142,9 +142,9 @@ pub struct AuditContext {
 
 pub struct CompileRequest {
     pub audit: AuditContext,
-    pub compiler: PathBuf,
+    pub compiler: NormalizedPath,
     pub args: Vec<String>,
-    pub cwd: PathBuf,
+    pub cwd: NormalizedPath,
     pub env: Vec<(String, String)>,
 }
 

--- a/docs/journal-schema.md
+++ b/docs/journal-schema.md
@@ -83,6 +83,20 @@ reads only the documented fields; it tolerates malformed lines
 (emits a stderr warning and skips the row) and missing journals
 (exits zero with a `(no journal)` message).
 
+## Engine phase profiling
+
+`session-stats --json` and `session-end --json` include `phase_profile` when
+the daemon can report aggregate cache-engine phase totals. Use
+`zccache engine-profile <stats-json>` to render the hit/miss phase breakdown
+from `last-session-stats.json` or captured session-stats JSON. Add `--json`
+for the stable machine-readable form.
+
+This is separate from Tokio Console. `engine-profile` attributes cache-engine
+work such as hashing, depgraph checks, artifact lookup, output writes, compiler
+execution, include scanning, and artifact storage. Tokio Console is for live
+Tokio runtime symptoms such as blocked tasks, long polls, wakeups, timers, and
+resource contention.
+
 ## Stability & versioning
 
 The journal is **additive-by-default**: new optional fields may appear in


### PR DESCRIPTION
Closes #915.\n\n## Summary\n- add \zccache engine-profile <stats-json> [--json]\ for session stats phase_profile reports\n- compute hit/miss counts, totals, averages, percentages, and dominant phases\n- document engine phase profiling versus Tokio Console\n- clean embedded service path fields to use NormalizedPath, fixing the known Dylint issue from the current base\n\n## Validation\n- \soldr cargo fmt\\n- \soldr cargo test -p zccache cli::commands::tests -- --nocapture\\n- \soldr cargo test -p zccache --test embedded_service_test -- --nocapture\\n- \python -m ci.lint\ (Dylint skipped locally on Windows; CI runs it on Ubuntu)\n- smoke-tested \zccache engine-profile ...last-session-stats.json\ and \--json\ against a real soldr stats file