### PR TITLE
ci: calibrate C archive cold perf floor

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,6 +76,7 @@ jobs:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/integration
           SOLDR_CACHE_LIFECYCLE: command
           SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
+          SOLDR_TARGET_BLOCK_FREE_GB: "2"
         run: |
           set +e
           unset ZCCACHE_CACHE_DIR

--- a/ci/perf_guard.py
+++ b/ci/perf_guard.py
@@ -36,6 +36,10 @@ CPP_SIBLING_REMAP_NO_FILE_SCENARIO = "Sibling-workspace no __FILE__, Warm"
 CPP_SIBLING_REMAP_WITH_FILE_SCENARIO = "Sibling-workspace with __FILE__, Warm"
 CPP_SIBLING_REMAP_NO_FILE_SCCACHE_THRESHOLD = 1.0
 CPP_COLD_SCCACHE_THRESHOLD = 0.9
+C_STATIC_LIBRARY_LINK_BENCHMARK = "c-static-library-link"
+C_STATIC_LIBRARY_LINK_COLD_SCENARIO = "Static archive, Cold"
+C_STATIC_LIBRARY_LINK_COLD_BARE_THRESHOLD = 0.75
+C_STATIC_LIBRARY_LINK_COLD_SCCACHE_THRESHOLD = 0.75
 RUST_BUILD_COLD_SCENARIO = "Build, Cold"
 RUST_BUILD_COLD_BARE_THRESHOLD = 0.4
 RUST_BUILD_COLD_SCCACHE_THRESHOLD = 0.6
@@ -257,6 +261,15 @@ def _comparison_threshold(
         if baseline == "bare":
             return RUST_WORKSPACE_LINK_COLD_BARE_THRESHOLD
         return RUST_WORKSPACE_LINK_COLD_SCCACHE_THRESHOLD
+    if (
+        row.get("language") == "c"
+        and row.get("benchmark") == C_STATIC_LIBRARY_LINK_BENCHMARK
+        and row.get("scenario") == C_STATIC_LIBRARY_LINK_COLD_SCENARIO
+        and row.get("mode") == "cold"
+    ):
+        if baseline == "bare":
+            return C_STATIC_LIBRARY_LINK_COLD_BARE_THRESHOLD
+        return C_STATIC_LIBRARY_LINK_COLD_SCCACHE_THRESHOLD
     if baseline == "bare":
         return bare_floor
     if (

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -119,6 +119,59 @@ def test_default_cold_thresholds_allow_near_bare_misses():
     ]
 
 
+C_STATIC_LIBRARY_LINK_LOG = """
+## C Static-Library Link Benchmark: 50 .o inputs, 5 warm trials
+
+| Scenario | Bare ar | sccache | zccache | bare cache | sccache cache | zccache cache | vs sccache | vs Bare ar |
+|:---------|----------:|--------:|--------:|-----------:|--------------:|--------------:|-----------:|--------------:|
+| Static archive, Cold | 0.058s | 0.055s | 0.070s | 0 B | 0 B | 189.5 KiB | 1.3x slower | 1.2x slower |
+| Static archive, Warm | 0.056s | 0.056s | **0.001s** | 0 B | 0 B | 193.7 KiB | **56x faster** | **56x faster** |
+"""
+
+
+def test_c_static_library_link_cold_uses_dedicated_threshold_and_passes_baseline():
+    # The cold archive path is dominated by fixed daemon/hash overhead on a
+    # tiny ~60 ms `ar` run. Guard warm-cache speedups tightly, but use a
+    # scenario floor for cold mode so routine runner noise does not fail main.
+    report = perf_guard.evaluate_attempts(
+        [rows(C_STATIC_LIBRARY_LINK_LOG)],
+        languages=("c",),
+        require_coverage=False,
+    )
+
+    cold_statuses = [
+        status for status in report.statuses if status.scenario == "Static archive, Cold"
+    ]
+    assert {
+        (status.baseline, status.best_ratio, status.threshold) for status in cold_statuses
+    } == {
+        ("bare", 0.829, perf_guard.C_STATIC_LIBRARY_LINK_COLD_BARE_THRESHOLD),
+        ("sccache", 0.786, perf_guard.C_STATIC_LIBRARY_LINK_COLD_SCCACHE_THRESHOLD),
+    }
+    assert all(status.passed for status in cold_statuses), [
+        (s.baseline, s.best_ratio, s.threshold) for s in cold_statuses
+    ]
+
+
+def test_c_static_library_link_cold_regression_below_threshold_fails():
+    regressed = C_STATIC_LIBRARY_LINK_LOG.replace(
+        "| Static archive, Cold | 0.058s | 0.055s | 0.070s | 0 B | 0 B | 189.5 KiB | 1.3x slower | 1.2x slower |",
+        "| Static archive, Cold | 0.058s | 0.055s | 0.090s | 0 B | 0 B | 189.5 KiB | 1.6x slower | 1.6x slower |",
+    )
+    report = perf_guard.evaluate_attempts(
+        [rows(regressed)],
+        languages=("c",),
+        require_coverage=False,
+    )
+
+    failing_baselines = {
+        status.baseline
+        for status in report.statuses
+        if status.scenario == "Static archive, Cold" and not status.passed
+    }
+    assert failing_baselines == {"bare", "sccache"}
+
+
 def test_cold_floor_overrides_are_targeted():
     cpp_log = PASSING_LOG.replace(
         "| Single-file, Cold | 6.000s | 7.000s | 4.000s | 1.8x faster | 1.5x faster |",


### PR DESCRIPTION
Closes #917.

Summary:
- add a dedicated cold threshold for c-static-library-link / Static archive, Cold
- keep generic C cold thresholds unchanged for normal compile benchmarks
- add regression coverage for the calibrated pass case and a real backslide

Validation:
- python -m pytest ci/tests/test_perf_guard.py
- python -m ci.lint
- git diff --check