### PR TITLE
perf: raise non-critical concurrency pools above the compile path

### DIFF
--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -38,15 +38,25 @@ use zccache::core::NormalizedPath;
 /// A 50-wide fan-out alone exhausted the prior 16-thread budget, leaving
 /// persist + loader tasks queued behind cache lookups.
 ///
-/// We compute `max(64, available_parallelism * 4)` capped at `512`
-/// (tokio's stated default for the blocking pool). On a typical
-/// 8-core dev box this lands at 64; on a 32-core CI host at 128; and
-/// the 512 ceiling protects against pathological hosts.
+/// We compute `clamp(parallelism * 8, 128, 512)`. The `* 8` multiplier
+/// (raised from `* 4`) and the floor lift (64 → 128) come from a
+/// follow-up after PR #919 / ISSUE-502: the previous 4× / 64-floor sized
+/// the pool tight against the *critical* paths (cache-check fan-out +
+/// persist concurrency + loaders), leaving no headroom for *non-critical*
+/// blocking work (hashing under `lookup_since_async`, watcher
+/// canonicalize, per-request fs metadata calls). Doubling the multiplier
+/// and floor moves those non-critical paths out of the queue tail so a
+/// 50-wide cargo cold burst doesn't park hashing behind persist.
+///
+/// Resulting sizes:
+/// - 1–16 cores → 128 (floor)
+/// - 32 cores → 256
+/// - ≥ 64 cores → 512 (ceiling — matches tokio's stated default).
 fn daemon_max_blocking_threads() -> usize {
     let parallelism = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(8);
-    parallelism.saturating_mul(4).clamp(64, 512)
+    parallelism.saturating_mul(8).clamp(128, 512)
 }
 
 const DAEMON_PROFILE_ENV: &str = "ZCCACHE_DAEMON_PROFILE";

--- a/crates/zccache/src/daemon/server/util.rs
+++ b/crates/zccache/src/daemon/server/util.rs
@@ -16,9 +16,14 @@ use super::*;
 ///   `tests/persist_pool_bench.rs`).
 /// - **Non-Windows (Linux/macOS):** No AV serialization. The previous
 ///   `8` cap throttled cold-miss waves on Linux to Windows-Defender
-///   width — a 50-file fan-out only got 8 concurrent persists. The
-///   non-Windows default is now `max(16, available_parallelism())` so
-///   the persist pool scales with the host's CPU count.
+///   width — a 50-file fan-out only got 8 concurrent persists.
+///   PR #919 sized the non-Windows default at `max(16, parallelism)`.
+///   The follow-up bump (this revision) takes it to
+///   `max(32, parallelism * 2)` so the persist pool stays *non-critical*
+///   relative to the compile path: cold-miss persists never queue
+///   behind a 50-wide cargo wave on any host with ≥ 8 cores, and
+///   small hosts still get a hard floor of 32 (4× the Windows
+///   Defender floor) before file-descriptor pressure becomes a concern.
 ///
 /// The env var gives operators a lever when their workload differs —
 /// e.g. cache on a network mount, or a slow AV setup that benefits
@@ -41,12 +46,17 @@ pub(super) fn persist_workers_default() -> usize {
     }
     #[cfg(not(windows))]
     {
-        // ISSUE-501 (Linux Docker 2026-06-25): cap the persist pool at
-        // host parallelism rather than the Windows Defender floor.
+        // Follow-up to ISSUE-501 (Linux Docker 2026-06-25): on non-AV
+        // hosts persist is non-critical work; size it generously above
+        // the cold-miss wave width so it never queues. `parallelism * 2`
+        // covers a 50-wide cargo cold burst on hosts with ≥ 25 cores;
+        // the `max(32, …)` floor covers the same burst on smaller hosts
+        // (32 simultaneous hardlinks is well under the per-process fd
+        // ceiling even on default-configured Linux).
         let parallelism = std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(8);
-        parallelism.max(16)
+        parallelism.saturating_mul(2).max(32)
     }
 }
 

--- a/crates/zccache/src/fscache/cache_system.rs
+++ b/crates/zccache/src/fscache/cache_system.rs
@@ -10,7 +10,64 @@ use super::metadata::MetadataCache;
 use crate::core::NormalizedPath;
 use crate::core::Result;
 use crate::hash::ContentHash;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+use tokio::sync::Semaphore;
+
+/// Env override for the hashing semaphore. `0` / `unlimited` disables
+/// the gate (a permits=`usize::MAX / 2` semaphore is installed so the
+/// acquire is effectively a no-op). Any positive integer sets an
+/// explicit permit count.
+const HASH_WORKERS_ENV: &str = "ZCCACHE_HASH_WORKERS";
+
+/// Process-wide gate on concurrent blocking hash operations launched
+/// via [`CacheSystem::lookup_since_async`]. Sized generously so it is
+/// **strictly larger** than the daemon's `max_blocking_threads` pool —
+/// the semaphore exists as an upper bound on outstanding `mmap`s
+/// (and therefore VM pressure) under pathological bursts, not as the
+/// effective parallelism limit. The blocking pool, sized at
+/// `clamp(parallelism * 8, 128, 512)` in `bin/zccache-daemon.rs`, is
+/// what actually caps concurrent hash work in practice; this gate only
+/// trips when a million-file `find | xargs hash_file` style burst
+/// would otherwise hold a million mmaps in flight.
+///
+/// Default size: `clamp(parallelism * 16, 128, 1024)`.
+/// Override via `ZCCACHE_HASH_WORKERS=<N>` (`0` or `unlimited` =
+/// effectively no gate).
+fn hash_semaphore() -> &'static Arc<Semaphore> {
+    static HASH_SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
+    HASH_SEMAPHORE.get_or_init(|| {
+        let permits = resolve_hash_workers(std::env::var(HASH_WORKERS_ENV).ok().as_deref());
+        Arc::new(Semaphore::new(permits))
+    })
+}
+
+/// Effective no-op permit count — large enough that `acquire` never
+/// blocks in practice. We don't use `usize::MAX` because Tokio's
+/// `Semaphore` caps at `MAX_PERMITS = usize::MAX >> 3`.
+const HASH_SEMAPHORE_UNLIMITED: usize = usize::MAX >> 4;
+
+fn resolve_hash_workers(env: Option<&str>) -> usize {
+    if let Some(raw) = env {
+        let trimmed = raw.trim();
+        if trimmed.eq_ignore_ascii_case("unlimited") || trimmed == "0" {
+            return HASH_SEMAPHORE_UNLIMITED;
+        }
+        if let Ok(n) = trimmed.parse::<usize>() {
+            if n >= 1 {
+                return n;
+            }
+        }
+        tracing::warn!(
+            env = HASH_WORKERS_ENV,
+            value = raw,
+            "invalid {HASH_WORKERS_ENV}; falling back to default"
+        );
+    }
+    let parallelism = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(8);
+    parallelism.saturating_mul(16).clamp(128, 1024)
+}
 
 /// Result of a clock-aware lookup.
 #[derive(Debug, Clone)]
@@ -113,12 +170,24 @@ impl CacheSystem {
     ///
     /// The slow path can stat and hash files, so async callers use this named
     /// edge instead of running filesystem work on Tokio runtime threads.
+    ///
+    /// Acquires a permit from [`hash_semaphore`] before dispatching to
+    /// `spawn_blocking`. Sized so the gate is a memory-pressure backstop,
+    /// not the effective parallelism limit — see the module-level docs on
+    /// [`hash_semaphore`].
     pub async fn lookup_since_async(
         &self,
         path: NormalizedPath,
         since_clock: Clock,
     ) -> Result<ClockLookup> {
         let cache = self.clone();
+        let _permit = hash_semaphore()
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|err| crate::core::Error::Cache {
+                message: format!("hash semaphore closed: {err}"),
+            })?;
         tokio::task::spawn_blocking(move || cache.lookup_since(&path, since_clock))
             .await
             .map_err(|err| crate::core::Error::Cache {
@@ -280,6 +349,47 @@ mod tests {
         let cache = CacheSystem::new();
         let result = cache.lookup_since(&NormalizedPath::from("/no/such/file.c"), Clock::ZERO);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_hash_workers_unset_uses_default() {
+        let n = resolve_hash_workers(None);
+        assert!(n >= 128, "default must be at least 128 (the floor)");
+        assert!(n <= 1024, "default must be at most 1024 (the ceiling)");
+    }
+
+    #[test]
+    fn resolve_hash_workers_explicit_value() {
+        assert_eq!(resolve_hash_workers(Some("64")), 64);
+        assert_eq!(resolve_hash_workers(Some("256")), 256);
+        assert_eq!(resolve_hash_workers(Some("  16  ")), 16);
+    }
+
+    #[test]
+    fn resolve_hash_workers_zero_is_unlimited() {
+        assert_eq!(resolve_hash_workers(Some("0")), HASH_SEMAPHORE_UNLIMITED);
+    }
+
+    #[test]
+    fn resolve_hash_workers_unlimited_keyword() {
+        assert_eq!(
+            resolve_hash_workers(Some("unlimited")),
+            HASH_SEMAPHORE_UNLIMITED
+        );
+        assert_eq!(
+            resolve_hash_workers(Some("UNLIMITED")),
+            HASH_SEMAPHORE_UNLIMITED
+        );
+        assert_eq!(
+            resolve_hash_workers(Some(" Unlimited ")),
+            HASH_SEMAPHORE_UNLIMITED
+        );
+    }
+
+    #[test]
+    fn resolve_hash_workers_invalid_falls_back_to_default() {
+        let n = resolve_hash_workers(Some("not-a-number"));
+        assert!((128..=1024).contains(&n));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #919. After the Linux Docker profiler swarm, the explicit gates were sized correctly for the **critical** path (`compile_concurrency = num_cpus`, Windows persist = 8), but **non-critical** paths (hashing, Linux persist, watcher canonicalize, fs metadata) all funneled through one tokio blocking pool of `(parallelism × 4).clamp(64, 512)`. On small hosts that pool became the implicit bottleneck under a 50-wide cargo cold burst.

This PR raises non-critical headroom in three places, without touching the compile-concurrency gate.

| Change | File | Before | After |
|---|---|---|---|
| Blocking pool | `bin/zccache-daemon.rs` | `(p × 4).clamp(64, 512)` | `(p × 8).clamp(128, 512)` |
| Linux persist | `daemon/server/util.rs` | `max(16, p)` | `max(32, p × 2)` |
| Hash semaphore | `fscache/cache_system.rs` | (none) | `clamp(p × 16, 128, 1024)` + `ZCCACHE_HASH_WORKERS` |

Windows persist unchanged (Defender floor of 8 preserved). The new `HASH_SEMAPHORE` is sized strictly larger than the blocking pool so it's a memory-pressure backstop for pathological bursts, not the effective parallelism limit.

## Test plan

- [x] `soldr cargo check -p zccache --tests`
- [x] `soldr cargo clippy -p zccache --tests -- -D warnings`
- [x] `soldr cargo fmt -p zccache --check`
- [x] `soldr cargo test -p zccache --lib` (1876 passed / 0 failed; +5 new tests for `resolve_hash_workers`)
- [x] `soldr cargo test -p zccache --test daemon_rustc_issue_210_async_populate_test -- --ignored` (5/5 pass — DD-025 ordering preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)