### PR TITLE
chore(release): bump 1.12.10 -> 1.12.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.12.10"
+version = "1.12.11"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release **1.12.11** — ships PRs #919 and #920 (perf-only; no API breaks).

## Changes since 1.12.10

### #919 — perf: cut daemon hot paths surfaced by Linux Docker profiler
- Cache `current_backend_identity` via `LazyLock<DashMap>` (was 43% of on-CPU; daemon binary is immutable per process).
- Journal writer: `std::sync::mpsc` + try_recv drain + `BufWriter` (14-frame parking_lot chain → 3-frame std mpsc).
- Adaptive `Auto` priority via in-flight compile counter (`InFlightCompileTicket`, race-free fetch_add).
- `persist_semaphore` Linux floor raised; Windows Defender floor preserved.
- `DAEMON_MAX_BLOCKING_THREADS` now scales with `parallelism`.
- Forward `hash_map` from `hash_verify` → `store_outcome` (cc/cpp no longer double-hashes on cold miss).
- Persist system-include cache write-through on insert.
- Batch watcher mutex acquisition.
- New Linux Docker profiler harness at `ci/docker/profile/`.

### #920 — perf: raise non-critical concurrency pools above the compile path
- Blocking pool: `(parallelism × 4).clamp(64, 512)` → `(parallelism × 8).clamp(128, 512)`.
- Linux persist semaphore: `max(16, parallelism)` → `max(32, parallelism × 2)`.
- New `HASH_SEMAPHORE` in `CacheSystem` with `ZCCACHE_HASH_WORKERS` env override; default `clamp(parallelism × 16, 128, 1024)`.

## Measured impact (Linux Docker, 99 Hz)

- `current_backend_identity` share of on-CPU: **43.1% → 33.0%** (-10.1 pp cumulative)
- `zccache-journal` unique off-CPU stack shapes: **13 → 2**
- Check warm: **28× → 34× faster than bare rustc**
- DD-025 ordering preserved (5/5 `issue_210_*` integration tests pass)

## Test plan

- [x] `soldr cargo check -p zccache --tests`
- [x] `soldr cargo clippy -p zccache --tests -- -D warnings`
- [x] `soldr cargo fmt -p zccache --check`
- [x] `soldr cargo test -p zccache --lib` (1876 / 1876)
- [x] `daemon_rustc_issue_210_async_populate_test --ignored` (5 / 5)
- [ ] `release-auto.yml` workflow publishes wheel + Rust crates + GitHub release after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)