### PR TITLE
fix(rustdoc): drop private intra-doc links to hash_semaphore

### DIFF
--- a/crates/zccache/src/fscache/cache_system.rs
+++ b/crates/zccache/src/fscache/cache_system.rs
@@ -171,10 +171,10 @@ impl CacheSystem {
     /// The slow path can stat and hash files, so async callers use this named
     /// edge instead of running filesystem work on Tokio runtime threads.
     ///
-    /// Acquires a permit from [`hash_semaphore`] before dispatching to
-    /// `spawn_blocking`. Sized so the gate is a memory-pressure backstop,
-    /// not the effective parallelism limit — see the module-level docs on
-    /// [`hash_semaphore`].
+    /// Acquires a permit from the module-private `hash_semaphore` before
+    /// dispatching to `spawn_blocking`. Sized so the gate is a
+    /// memory-pressure backstop, not the effective parallelism limit —
+    /// see the module-level docs.
     pub async fn lookup_since_async(
         &self,
         path: NormalizedPath,


### PR DESCRIPTION
Surfaced while gating PR #930. The Documentation CI lane runs `cargo doc -p zccache -- -D warnings` which refuses public-item rustdoc that links to private items. Two `[`hash_semaphore`]` links in `lookup_since_async`'s doc comment both target the module-private `fn hash_semaphore()` added in #920, so the workspace docs build has been broken on main since #920 landed.

Replaces the broken links with plain prose. Fixing the link target by promoting `hash_semaphore` to a public re-export would expose a private implementation detail — the plain prose is the right scope.

Refs #929.