### PR TITLE
feat(embedded): per-sub-phase compile trace gated by ZCCACHE_INNER_TRACE (#940)

### DIFF
--- a/crates/zccache/src/compile_trace.rs
+++ b/crates/zccache/src/compile_trace.rs
@@ -76,17 +76,11 @@ fn init() -> Option<Mutex<std::fs::File>> {
         Ok(file) => {
             // One-line startup confirmation so hosts can verify the
             // env var was picked up by THIS process.
-            eprintln!(
-                "zccache: {ENV_VAR} active, writing to {}",
-                path.display()
-            );
+            eprintln!("zccache: {ENV_VAR} active, writing to {}", path.display());
             Some(Mutex::new(file))
         }
         Err(e) => {
-            eprintln!(
-                "zccache: {ENV_VAR}={} but open failed: {e}",
-                path.display()
-            );
+            eprintln!("zccache: {ENV_VAR}={} but open failed: {e}", path.display());
             None
         }
     }

--- a/crates/zccache/src/compile_trace.rs
+++ b/crates/zccache/src/compile_trace.rs
@@ -1,0 +1,158 @@
+//! Per-sub-phase JSONL trace inside the embedded compile path.
+//!
+//! Diagnostic-only — written when the `ZCCACHE_INNER_TRACE` env var
+//! points at a writable file path. Off by default (one atomic `OnceLock`
+//! load per call, no allocation when disabled). Records elapsed micros
+//! per named sub-phase plus optional byte counters, one JSON object per
+//! line:
+//!
+//! ```jsonl
+//! {"ts_ns":<u128>, "phase":"<name>", "micros":<u64>, "compile_id":"<str>"}
+//! ```
+//!
+//! ## Why this exists
+//!
+//! The soldr-side per-phase JSONL trace
+//! (`crates/soldr-cli/src/daemon/compile_trace.rs` in zackees/soldr,
+//! soldr#985) revealed that **99.7% of cold-build dispatch time on a
+//! medium-fixture cargo build sits inside `ZccacheService::compile`**
+//! as a single opaque async call. The wire-side IPC framing (stdout
+//! chunk loop, stderr chunk loop, terminal frame) totals 0.04% of
+//! dispatch budget — under 40 ms across 146 compiles.
+//!
+//! That number falsified the prior "buffer-elimination" optimization
+//! plan in zccache#939 (two attempts moved cold by zero seconds). The
+//! actually-load-bearing work — input hashing, cache lookup, the rustc
+//! subprocess, pipe drains, the cache-miss store — all sit inside
+//! the embedded compile pipeline where soldr can't see them.
+//!
+//! This module is the diagnostic layer that lets us see them.
+//!
+//! ## Wire format and ABI compatibility with soldr's trace
+//!
+//! The JSONL shape is byte-for-byte the same as soldr's daemon trace.
+//! soldr's `bench/parse_compile_trace.py` reads either file with no
+//! changes — it buckets by the `phase` field. Hosts that point
+//! `ZCCACHE_INNER_TRACE` and `SOLDR_DAEMON_TRACE` at *the same path*
+//! get a unified per-compile timeline; pointing them at different
+//! paths keeps the two layers separate.
+//!
+//! ## Hot-path cost
+//!
+//! - **Off** (env var unset): one [`OnceLock::get_or_init`] miss
+//!   resolves to `None`; subsequent calls hit the `None` arm and
+//!   return immediately. Below noise.
+//! - **On**: one [`Instant::elapsed`], one [`format!`], one mutex-guarded
+//!   [`Write::write_all`]. The mutex contention is bounded by the
+//!   number of sub-phase records per compile (~6 today) times the
+//!   embedded daemon's compile concurrency — fine for diagnostic use,
+//!   not enabled in production.
+//!
+//! Errors during open + write are silently dropped. The trace site
+//! **must never** block, fail, or perturb the compile it's measuring.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static TRACE_FILE: OnceLock<Option<Mutex<std::fs::File>>> = OnceLock::new();
+
+/// Name of the env var that, when set to a writable file path, enables
+/// the JSONL trace. Unset = trace is off.
+pub const ENV_VAR: &str = "ZCCACHE_INNER_TRACE";
+
+fn init() -> Option<Mutex<std::fs::File>> {
+    let path = std::env::var_os(ENV_VAR)?;
+    let path = PathBuf::from(path);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        Ok(file) => {
+            // One-line startup confirmation so hosts can verify the
+            // env var was picked up by THIS process.
+            eprintln!(
+                "zccache: {ENV_VAR} active, writing to {}",
+                path.display()
+            );
+            Some(Mutex::new(file))
+        }
+        Err(e) => {
+            eprintln!(
+                "zccache: {ENV_VAR}={} but open failed: {e}",
+                path.display()
+            );
+            None
+        }
+    }
+}
+
+fn writer() -> Option<&'static Mutex<std::fs::File>> {
+    TRACE_FILE.get_or_init(init).as_ref()
+}
+
+/// Append a single phase-record line to the trace file. No-op when
+/// [`ENV_VAR`] is unset. Errors silently dropped — the trace file is
+/// diagnostic-only and must never block compile work.
+///
+/// `phase` is a short stable name (snake_case is conventional);
+/// `micros` is the elapsed wall time in microseconds; `compile_id` is
+/// the per-compile identifier the caller already tracks for audit
+/// correlation (the embedded API surfaces this through
+/// [`crate::audit::AuditId`] / `CompileResponse::compile_id`).
+pub fn record(phase: &str, micros: u64, compile_id: &str) {
+    let Some(file_mu) = writer() else { return };
+    let ts_ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let line = format!(
+        r#"{{"ts_ns":{ts_ns},"phase":"{}","micros":{micros},"compile_id":"{}"}}{nl}"#,
+        escape(phase),
+        escape(compile_id),
+        nl = "\n",
+    );
+    if let Ok(mut guard) = file_mu.lock() {
+        let _ = guard.write_all(line.as_bytes());
+    }
+}
+
+fn escape(s: &str) -> String {
+    s.replace('\\', r"\\").replace('"', r#"\""#)
+}
+
+/// RAII guard that records on drop. Use for scope-bounded sub-phases:
+///
+/// ```ignore
+/// {
+///     let _p = Phase::start("cache_lookup", &compile_id);
+///     // … work …
+/// } // recorded here
+/// ```
+pub struct Phase<'a> {
+    name: &'a str,
+    compile_id: &'a str,
+    start: std::time::Instant,
+}
+
+impl<'a> Phase<'a> {
+    pub fn start(name: &'a str, compile_id: &'a str) -> Self {
+        Self {
+            name,
+            compile_id,
+            start: std::time::Instant::now(),
+        }
+    }
+}
+
+impl Drop for Phase<'_> {
+    fn drop(&mut self) {
+        let micros = self.start.elapsed().as_micros() as u64;
+        record(self.name, micros, self.compile_id);
+    }
+}

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -9,6 +9,16 @@ use super::*;
 /// artifact and depfile directories, even within the same process.
 pub(super) static SERVER_INSTANCE: AtomicU64 = AtomicU64::new(0);
 pub(super) static ARTIFACT_PERSIST_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+/// zccache#940 — monotonic per-process compile counter for the inner
+/// diagnostic trace. Resets across process restarts by design (the
+/// trace file is process-scoped). Hosts that need durable ids should
+/// cross-correlate by `ts_ns` against their own audit log.
+static INNER_COMPILE_SEQ: AtomicU64 = AtomicU64::new(0);
+
+fn next_inner_compile_id() -> String {
+    let n = INNER_COMPILE_SEQ.fetch_add(1, Ordering::Relaxed);
+    format!("z{n:08x}")
+}
 
 impl DaemonServer {
     /// Create a new daemon server bound to the given endpoint, using the
@@ -368,6 +378,14 @@ impl EmbeddedDaemon {
         self.state
             .last_activity
             .store(now_secs(), Ordering::Relaxed);
+        // zccache#940: per-compile id for the diagnostic trace. The
+        // embedded daemon does not yet surface an audit id through
+        // EmbeddedCompileRequest, so we generate a monotonic per-process
+        // counter here. Hosts that already track their own per-compile
+        // id (soldr's `c<N>` scheme) get a parallel namespace; the two
+        // sides can be cross-correlated by timestamp.
+        let compile_id = next_inner_compile_id();
+        let total = std::time::Instant::now();
         let response = handle_compile_ephemeral(
             &self.state,
             std::process::id(),
@@ -379,19 +397,38 @@ impl EmbeddedDaemon {
             request.stdin,
         )
         .await;
+        crate::compile_trace::record(
+            "embedded_daemon_compile",
+            total.elapsed().as_micros() as u64,
+            &compile_id,
+        );
         match response {
             Response::CompileResult {
                 exit_code,
                 stdout,
                 stderr,
                 cached,
-            } => Ok(EmbeddedCompileResult {
-                exit_code,
-                stdout,
-                stderr,
-                cached,
-            }),
-            Response::Error { message } => Err(message),
+            } => {
+                crate::compile_trace::record(
+                    if cached {
+                        "embedded_outcome_cached"
+                    } else {
+                        "embedded_outcome_miss"
+                    },
+                    0,
+                    &compile_id,
+                );
+                Ok(EmbeddedCompileResult {
+                    exit_code,
+                    stdout,
+                    stderr,
+                    cached,
+                })
+            }
+            Response::Error { message } => {
+                crate::compile_trace::record("embedded_outcome_error", 0, &compile_id);
+                Err(message)
+            }
             other => Err(format!("unexpected embedded compile response: {other:?}")),
         }
     }

--- a/crates/zccache/src/lib.rs
+++ b/crates/zccache/src/lib.rs
@@ -14,6 +14,10 @@ pub mod audit_writer;
 pub mod ci;
 pub mod cli;
 pub mod compiler;
+/// zccache#940 — per-sub-phase JSONL trace for the embedded compile
+/// path. Diagnostic-only, gated by the `ZCCACHE_INNER_TRACE` env var.
+/// See module doc for the wire format and why it exists.
+pub mod compile_trace;
 pub mod core;
 pub mod daemon;
 pub mod depgraph;

--- a/crates/zccache/src/lib.rs
+++ b/crates/zccache/src/lib.rs
@@ -13,11 +13,11 @@ pub mod audit;
 pub mod audit_writer;
 pub mod ci;
 pub mod cli;
-pub mod compiler;
 /// zccache#940 — per-sub-phase JSONL trace for the embedded compile
 /// path. Diagnostic-only, gated by the `ZCCACHE_INNER_TRACE` env var.
 /// See module doc for the wire format and why it exists.
 pub mod compile_trace;
+pub mod compiler;
 pub mod core;
 pub mod daemon;
 pub mod depgraph;


### PR DESCRIPTION
## Summary

- Adds a thin diagnostic trace module (`compile_trace.rs`) and wires its first record site into `EmbeddedDaemon::compile`. Gated by `ZCCACHE_INNER_TRACE=<path>`; off by default with zero hot-path cost when unset.
- Wire format is byte-identical to soldr's per-phase trace (soldr#985), so a single `bench/parse_compile_trace.py` reads both layers and either env var can point at the same file for a unified per-compile timeline.
- Implements [zccache#940](https://github.com/zackees/zccache/issues/940).

## Why

Soldr-side instrumentation (soldr#985 PR) revealed that **99.7% of cold-build dispatch time on a medium-fixture cargo build sits inside `ZccacheService::compile`** as a single opaque async call from soldr's perspective. All IPC wire framing combined totals 0.04% of dispatch. The prior buffer-elimination plan (#939) attacked that 0.04% slice and moved cold by zero seconds across two iterations.

The real time lives in this crate — input hash, cache lookup, rustc spawn + wait, output capture, cache store. This module is the diagnostic layer needed to identify which sub-phase dominates the cold gap.

## What this PR ships

- `crates/zccache/src/compile_trace.rs` — same shape as soldr's, intentionally:
  - `record(phase, micros, compile_id)` — fire-and-forget JSONL append
  - `Phase::start(name, compile_id)` — RAII guard for scope-bounded sub-phases
  - Errors during open/write are silently dropped; the trace site cannot block a compile
- Instrumentation in `EmbeddedDaemon::compile` (`daemon/server/lifecycle.rs`):
  - `embedded_daemon_compile` — total elapsed for the `handle_compile_ephemeral` call
  - `embedded_outcome_{cached,miss,error}` — zero-micros marker for outcome classification
- `INNER_COMPILE_SEQ` monotonic per-process counter; IDs are `z<8-hex>` so they're visually distinct from soldr's `c<8-hex>` when both layers write to the same file.

## What this PR does NOT do

- Does NOT instrument `handle_compile_ephemeral`'s internal sub-phases (input_hash, cache_lookup, rustc_spawn, rustc_wait, cache_store) — that's the follow-up. This PR lands the infrastructure + the outer timer so the pipeline is wired end-to-end. The inner markers are purely additive on top.
- Does NOT change any public API. `ZccacheService::compile` / `compile_streaming` shapes are unchanged.
- Does NOT affect any hot path when `ZCCACHE_INNER_TRACE` is unset.

## Hot-path cost when enabled

One `Instant::elapsed`, one `format!`, one mutex-guarded `write_all` per record. ~6 records per compile (planned full breakdown) through one mutex — fine for diagnostic use, not for production.

## Test plan

- [x] `cargo build -p zccache` — clean
- [ ] Set `ZCCACHE_INNER_TRACE=/tmp/zinner.jsonl` on a soldr cold docker run, parse with soldr's `bench/parse_compile_trace.py`, confirm `embedded_daemon_compile` records show up
- [ ] Confirm off-state cost is ≤ 50 ns per call (one atomic load) — micro-bench in the follow-up PR

## Related

- zccache#940 — issue this implements
- zccache#937 — parent (streaming compile pipeline)
- zccache#939 — the falsified buffer-elimination plan
- soldr#981 — the cold-build regression this is the next debugging step toward closing
- soldr#985 — soldr-side per-phase trace (the parallel layer that proved the bottleneck wasn't in IPC framing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)