### PR TITLE
deps: bump tikv-jemallocator 0.6 -> 0.7 (jemalloc 5.3.0 -> 5.3.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,9 +3206,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -3216,9 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ ruzstd = "0.7"
 lzma-rs = "0.3"
 sevenz-rust = "0.6"
 rkyv = { version = "0.7", features = ["validation"] }
-tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
+tikv-jemallocator = { version = "0.7", features = ["unprefixed_malloc_on_supported_platforms"] }
 mimalloc = "0.1"
 running-process = { version = "4.5.7", default-features = false, features = ["client-async"] }
 zccache = { path = "crates/zccache" }


### PR DESCRIPTION
Picks up upstream jemalloc 5.3.1 ([tikv-jemallocator#161](https://github.com/tikv/jemallocator/pull/161)). Verifies the aarch64-unknown-linux-musl cross-compile failure observed on soldr's CI matrix (`atomic.h:22:4: error: "Don't have atomics implemented on this platform."`) is resolved by the bundled-source bump rather than needing a soldr-side cfg-gate. No API changes — same global-allocator init pattern in the four bin entry points. Lib + soldr-side embedded integration both build clean.