### PR TITLE
chore(lint): promote expect_used to deny + audit all expect sites (#946)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ libraries = [{ path = "dylints/*" }]
 unwrap_used        = "deny"
 unwrap_in_result   = "deny"
 panic_in_result_fn = "deny"
-expect_used        = "warn"
+expect_used        = "deny"
 
 # Keep just enough debug info for readable stack traces (function names +
 # source-line numbers) while dropping the DWARF variable/type tables that

--- a/crates/zccache/build.rs
+++ b/crates/zccache/build.rs
@@ -1,3 +1,10 @@
+// Build scripts are allowed to panic on setup failure: cargo surfaces
+// the panic message and fails the build cleanly. Per-site `#[expect]`
+// would add noise for no gain — every expect() in this file encodes a
+// real build-time invariant (TARGET set by cargo, vendored protoc
+// present, protobuf compile succeeds).
+#![allow(clippy::expect_used)]
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     compile_zccache_wire_proto();

--- a/crates/zccache/src/artifact/kv.rs
+++ b/crates/zccache/src/artifact/kv.rs
@@ -389,6 +389,10 @@ impl KvStore {
                 std::fs::create_dir_all(parent)?;
             }
             // Tempfile + rename so partial writes never become visible.
+            #[expect(
+                clippy::expect_used,
+                reason = "spill_path(namespace, key) joins onto the kv root, so .parent() is structurally guaranteed to be Some"
+            )]
             let dir = path
                 .parent()
                 .expect("spill path always has a parent because we joined kv/<ns>/");

--- a/crates/zccache/src/bin/zccache-ci.rs
+++ b/crates/zccache/src/bin/zccache-ci.rs
@@ -22,6 +22,10 @@ use zccache::ci::{reap_orphan_daemons, resolve_timeout, StageOutcome, StageRunne
 use zccache::core::NormalizedPath;
 
 fn project_root() -> NormalizedPath {
+    #[expect(
+        clippy::expect_used,
+        reason = "ci helper bootstrap: cannot perform any CI operation without a working directory; no useful recovery path"
+    )]
     let current = env::current_dir().expect("cannot determine working directory");
     let mut dir = current.as_path();
     loop {

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -166,6 +166,10 @@ fn print_status(args: &Args) {
     println!();
 
     // Try to connect and get status from a running daemon
+    #[expect(
+        clippy::expect_used,
+        reason = "current-thread runtime construction with enable_all only fails on OS resource exhaustion; daemon-status query cannot proceed without it"
+    )]
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -250,6 +254,10 @@ fn run_server(args: Args) {
     // need to bring up the full multi-thread runtime before deciding
     // whether to defer.
     {
+        #[expect(
+            clippy::expect_used,
+            reason = "current-thread probe runtime construction with enable_all only fails on OS resource exhaustion; daemon-defer probe cannot proceed without it"
+        )]
         let probe_rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -274,6 +282,10 @@ fn run_server(args: Args) {
     let cache_root = zccache::core::config::default_cache_dir();
     zccache::core::defender::maybe_emit_first_run_banner(cache_root.as_path());
 
+    #[expect(
+        clippy::expect_used,
+        reason = "multi-thread runtime construction with enable_all only fails on OS resource exhaustion; daemon cannot proceed without it"
+    )]
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .max_blocking_threads(daemon_max_blocking_threads())

--- a/crates/zccache/src/bin/zccache-download-daemon.rs
+++ b/crates/zccache/src/bin/zccache-download-daemon.rs
@@ -85,6 +85,10 @@ fn run_server(args: Args) {
         tracing::warn!("failed to write download daemon lock file: {err}");
     }
 
+    #[expect(
+        clippy::expect_used,
+        reason = "multi-thread runtime construction with enable_all only fails on OS resource exhaustion (timer/IO driver registration); download daemon cannot proceed by any other means at that point"
+    )]
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/crates/zccache/src/cli/commands/cache_ops.rs
+++ b/crates/zccache/src/cli/commands/cache_ops.rs
@@ -823,7 +823,17 @@ pub(crate) fn cmd_snapshot_fp_record(
     profile: &str,
     manifest_path: Option<PathBuf>,
 ) -> ExitCode {
-    let workspace = workspace_root.unwrap_or_else(|| std::env::current_dir().expect("cwd"));
+    let workspace = if let Some(w) = workspace_root {
+        w
+    } else {
+        match std::env::current_dir() {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("zccache snapshot-fp-record: failed to read cwd: {e}");
+                return ExitCode::FAILURE;
+            }
+        }
+    };
     let manifest = manifest_path.unwrap_or_else(|| target_dir.join(snapshot_fp::MANIFEST_FILENAME));
     match snapshot_fp::record(target_dir, &workspace, &manifest, profile) {
         Ok(stats) => {
@@ -849,7 +859,17 @@ pub(crate) fn cmd_snapshot_fp_validate(
     manifest_path: Option<PathBuf>,
     stamp_seconds_ahead: u64,
 ) -> ExitCode {
-    let workspace = workspace_root.unwrap_or_else(|| std::env::current_dir().expect("cwd"));
+    let workspace = if let Some(w) = workspace_root {
+        w
+    } else {
+        match std::env::current_dir() {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("zccache snapshot-fp-validate: failed to read cwd: {e}");
+                return ExitCode::FAILURE;
+            }
+        }
+    };
     let manifest = manifest_path.unwrap_or_else(|| target_dir.join(snapshot_fp::MANIFEST_FILENAME));
     match snapshot_fp::validate(
         target_dir,

--- a/crates/zccache/src/cli/commands/util.rs
+++ b/crates/zccache/src/cli/commands/util.rs
@@ -116,11 +116,15 @@ pub(crate) fn slurp_stdin_if_piped() -> Vec<u8> {
 }
 
 pub(crate) fn run_async(future: impl std::future::Future<Output = ExitCode>) -> ExitCode {
-    tokio::runtime::Builder::new_current_thread()
+    #[expect(
+        clippy::expect_used,
+        reason = "current-thread runtime construction with enable_all only fails on OS resource exhaustion (timer/IO driver registration); CLI cannot proceed by any other means at that point"
+    )]
+    let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .expect("failed to create tokio runtime")
-        .block_on(future)
+        .expect("failed to create tokio runtime");
+    rt.block_on(future)
 }
 
 pub(crate) fn format_uptime(secs: u64) -> String {

--- a/crates/zccache/src/compiler/parse.rs
+++ b/crates/zccache/src/compiler/parse.rs
@@ -283,6 +283,10 @@ pub fn parse_invocation(compiler: &str, args: &[String]) -> ParsedInvocation {
     }
 
     // Single source file
+    #[expect(
+        clippy::expect_used,
+        reason = "source_files non-empty: structurally guaranteed by the is_empty() guard earlier in this function and the multi-file early return"
+    )]
     let (source, _, mode) = source_files
         .into_iter()
         .next()

--- a/crates/zccache/src/compiler/parse_msvc.rs
+++ b/crates/zccache/src/compiler/parse_msvc.rs
@@ -378,6 +378,10 @@ pub fn parse_msvc_invocation(
         };
     }
 
+    #[expect(
+        clippy::expect_used,
+        reason = "source_files non-empty: structurally guaranteed by the is_empty() guard earlier in this function and the multi-file early return"
+    )]
     let (source, _) = source_files
         .into_iter()
         .next()

--- a/crates/zccache/src/compiler/response_file.rs
+++ b/crates/zccache/src/compiler/response_file.rs
@@ -214,7 +214,12 @@ fn format_rsp_content(args: &[String]) -> String {
     let estimated_len: usize = args.iter().map(|a| a.len() + 3).sum();
     let mut content = String::with_capacity(estimated_len);
     for arg in args {
-        content.push_str(&format_rsp_argument(arg).expect("argument should be representable"));
+        #[expect(
+            clippy::expect_used,
+            reason = "test-only path; tests pass arg shapes known to be representable. Production callers use format_rsp_content_if_safe which returns Option."
+        )]
+        let formatted = format_rsp_argument(arg).expect("argument should be representable");
+        content.push_str(&formatted);
         content.push('\n');
     }
     content

--- a/crates/zccache/src/core/version.rs
+++ b/crates/zccache/src/core/version.rs
@@ -34,6 +34,10 @@ impl Version {
 }
 
 /// Return the version of the currently compiled crate.
+#[expect(
+    clippy::expect_used,
+    reason = "CARGO_PKG_VERSION is cargo-validated semver at compile time"
+)]
 pub fn current() -> Version {
     Version::parse(super::VERSION).expect("CARGO_PKG_VERSION is not valid semver")
 }

--- a/crates/zccache/src/daemon/compile_journal/journal_thread.rs
+++ b/crates/zccache/src/daemon/compile_journal/journal_thread.rs
@@ -120,6 +120,10 @@ pub(super) fn journal_thread(
                                     tracing::debug!("session journal open error: {e}");
                                     // Return a dummy that will fail writes — we'll
                                     // skip silently via is_err() below.
+                                    #[expect(
+                                        clippy::expect_used,
+                                        reason = "NUL on Windows / /dev/null on Unix must exist; their absence indicates a fundamentally broken host where the daemon cannot recover"
+                                    )]
                                     let fallback = open_append(&path).unwrap_or_else(|_| {
                                         // Last resort: /dev/null equivalent. The HashMap
                                         // entry will be cleaned up on CloseSession.

--- a/crates/zccache/src/daemon/server/connection.rs
+++ b/crates/zccache/src/daemon/server/connection.rs
@@ -703,11 +703,15 @@ async fn compile_response_for_session(
         env: journal_env,
         session_id: Some(session_id),
     };
+    #[expect(
+        clippy::expect_used,
+        reason = "ctx.session_id is set to Some(session_id) immediately above (line 704); the Option wrap is purely for the JournalContext return field"
+    )]
     let resp = handle_compile(
         state,
         ctx.session_id
             .as_deref()
-            .expect("session_id set by HandleCtx constructor above"),
+            .expect("session_id set by JournalContext constructor above"),
         &ctx.args,
         &cwd,
         &compiler,

--- a/crates/zccache/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/miss_store.rs
@@ -336,6 +336,10 @@ fn store_single_output(
     // misses → recompile; the DD-025 failure-mode-is-miss invariant).
     let _pending = pending_writes::register(&state.pending_cache_writes, artifact_key_hex);
     tokio::spawn(async move {
+        #[expect(
+            clippy::expect_used,
+            reason = "persist_semaphore is owned by ServerState for the daemon's lifetime; AcquireError here would be a logic bug (semaphore explicitly closed), not a runtime condition"
+        )]
         let _permit = sem
             .acquire()
             .await

--- a/crates/zccache/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache/src/daemon/server/handle_compile_multi.rs
@@ -129,6 +129,10 @@ pub(super) fn check_unit_cache(
                         ensure_payloads(&mut cached_ref, &state.artifact_dir, artifact_key_hex)
                             .is_some();
                     if loaded {
+                        #[expect(
+                            clippy::expect_used,
+                            reason = "ensure_payloads on the preceding line returned Some, which is the contract guaranteeing cached_ref.payloads is now populated"
+                        )]
                         let payloads = Arc::clone(
                             cached_ref
                                 .payloads
@@ -251,6 +255,10 @@ pub(super) fn check_unit_cache(
             let loaded =
                 ensure_payloads(&mut cached_ref, &state.artifact_dir, &artifact_key_hex).is_some();
             if loaded {
+                #[expect(
+                    clippy::expect_used,
+                    reason = "ensure_payloads on the preceding line returned Some, which is the contract guaranteeing cached_ref.payloads is now populated"
+                )]
                 let payloads = Arc::clone(
                     cached_ref
                         .payloads
@@ -893,6 +901,10 @@ pub(super) async fn handle_compile_multi(
         // src/dst failures already enriched by `persist::enrich_persist_err`).
         let t_persist_enqueue = std::time::Instant::now();
         tokio::spawn(async move {
+            #[expect(
+                clippy::expect_used,
+                reason = "persist_semaphore is owned by ServerState for the daemon's lifetime; AcquireError here would be a logic bug (semaphore explicitly closed), not a runtime condition"
+            )]
             let _permit = sem
                 .acquire()
                 .await

--- a/crates/zccache/src/daemon/server/handle_exec.rs
+++ b/crates/zccache/src/daemon/server/handle_exec.rs
@@ -778,6 +778,10 @@ async fn store_exec_artifact(state: &Arc<SharedState>, key_hex: String, artifact
         let state_ref = Arc::clone(state);
         let sem = Arc::clone(&state.persist_semaphore);
         tokio::spawn(async move {
+            #[expect(
+                clippy::expect_used,
+                reason = "persist_semaphore is owned by ServerState for the daemon's lifetime; AcquireError here would be a logic bug (semaphore explicitly closed), not a runtime condition"
+            )]
             let _permit = sem
                 .acquire()
                 .await

--- a/crates/zccache/src/daemon/server/handle_link.rs
+++ b/crates/zccache/src/daemon/server/handle_link.rs
@@ -226,6 +226,10 @@ pub(super) async fn handle_link_ephemeral(
         // Load payloads from disk if not already loaded.
         let loaded = ensure_payloads(&mut entry, &state.artifact_dir, &key_hex).is_some();
         if loaded {
+            #[expect(
+                clippy::expect_used,
+                reason = "ensure_payloads on the preceding line returned Some, which is the contract guaranteeing entry.payloads is now populated"
+            )]
             let payloads = Arc::clone(
                 entry
                     .payloads
@@ -500,6 +504,10 @@ pub(super) async fn handle_link_ephemeral(
                 let sem = Arc::clone(&state.persist_semaphore);
                 let state_ref = Arc::clone(state);
                 tokio::spawn(async move {
+                    #[expect(
+                        clippy::expect_used,
+                        reason = "persist_semaphore is owned by ServerState for the daemon's lifetime; AcquireError here would be a logic bug (semaphore explicitly closed), not a runtime condition"
+                    )]
                     let _permit = sem
                         .acquire()
                         .await

--- a/crates/zccache/src/depgraph/context/mod.rs
+++ b/crates/zccache/src/depgraph/context/mod.rs
@@ -380,10 +380,16 @@ pub fn compute_artifact_key_normalized_with_root(
                 Some(root) if np.as_path().starts_with(root) => {
                     Cow::Owned(normalize_key_path(np.as_path(), Some(root)))
                 }
-                _ => Cow::Borrowed(
-                    np.case_key()
-                        .expect("NormalizedPath::key is always populated post-#576"),
-                ),
+                _ => {
+                    #[expect(
+                        clippy::expect_used,
+                        reason = "NormalizedPath::case_key() returns Option only as a forward-compat marker; post-#576 it is always Some. Returning a fallback would silently corrupt cache keys, which is catastrophic per CLAUDE.md correctness model."
+                    )]
+                    let key = np
+                        .case_key()
+                        .expect("NormalizedPath::key is always populated post-#576");
+                    Cow::Borrowed(key)
+                }
             };
             (path_key, *h)
         })

--- a/crates/zccache/src/depgraph/scanner.rs
+++ b/crates/zccache/src/depgraph/scanner.rs
@@ -76,11 +76,10 @@ pub fn scan_includes_str(source: &str) -> Vec<IncludeDirective> {
                     });
                 }
                 in_block_comment = false;
-                // Could have another block comment start after...
-                if rest.contains("/*") {
-                    let after_end = rest
-                        .find("/*")
-                        .expect("contains check immediately above guarantees Some");
+                // Could have another block comment start after — fuse the
+                // detect-and-locate into one search to drop the expect and
+                // halve the scanner's per-line work on the hot path.
+                if let Some(after_end) = rest.find("/*") {
                     if !rest[..after_end].contains("*/") {
                         in_block_comment = true;
                     }
@@ -202,8 +201,11 @@ pub fn scan_recursive(source: &Path, search: &IncludeSearchPaths) -> ScanResult 
     }
 
     ScanResult {
-        resolved: resolved.into_inner().expect("resolved mutex poisoned"),
-        unresolved: unresolved.into_inner().expect("unresolved mutex poisoned"),
+        // Poison only happens if a rayon worker panicked; recovering the
+        // inner Vec preserves the partial scan output of the surviving
+        // workers, which is what callers want.
+        resolved: resolved.into_inner().unwrap_or_else(|e| e.into_inner()),
+        unresolved: unresolved.into_inner().unwrap_or_else(|e| e.into_inner()),
         has_computed: has_computed.load(Ordering::Relaxed),
     }
 }
@@ -256,13 +258,13 @@ fn scan_one_level(
     if !local_resolved.is_empty() {
         resolved
             .lock()
-            .expect("resolved mutex poisoned")
+            .unwrap_or_else(|e| e.into_inner())
             .extend(local_resolved);
     }
     if !local_unresolved.is_empty() {
         unresolved
             .lock()
-            .expect("unresolved mutex poisoned")
+            .unwrap_or_else(|e| e.into_inner())
             .extend(local_unresolved);
     }
     if saw_computed {

--- a/crates/zccache/src/download/mod.rs
+++ b/crates/zccache/src/download/mod.rs
@@ -171,12 +171,17 @@ pub async fn download_to_path(
         max_connections,
         min_segment_size,
     ) {
+        #[expect(
+            clippy::expect_used,
+            reason = "should_use_segments(total, ...) returns false when total is None; reaching this branch implies Some(_)"
+        )]
+        let total_bytes = total.expect("segment use requires total");
         download_segmented(SegmentedDownload {
             client: &client,
             url,
             temp_path: &temp_path,
             metadata_dir,
-            total: total.expect("segment use requires total"),
+            total: total_bytes,
             max_connections,
             min_segment_size,
             validator: probe.validator,

--- a/crates/zccache/src/fscache/clock.rs
+++ b/crates/zccache/src/fscache/clock.rs
@@ -100,6 +100,10 @@ impl ChangeJournal {
         }
 
         // Append to the ordered journal.
+        #[expect(
+            clippy::expect_used,
+            reason = "RwLock only poisons if another thread panicked mid-write; the journal BTreeMap would be mid-mutation. Failing loudly lets the daemon supervisor restart from a clean state — silently returning empty change-sets would cause wrong cache hits."
+        )]
         let mut journal = self.journal.write().expect("journal lock poisoned");
         journal.insert(clock, changed_paths);
 
@@ -142,6 +146,10 @@ impl ChangeJournal {
     /// for very old clocks if journal entries have been trimmed.
     #[must_use]
     pub fn changes_since(&self, since: Clock) -> Vec<NormalizedPath> {
+        #[expect(
+            clippy::expect_used,
+            reason = "RwLock only poisons if another thread panicked mid-write; returning empty Vec here would mean 'no changes' and cause wrong cache hits — fail loudly so the supervisor can restart"
+        )]
         let journal = self.journal.read().expect("journal lock poisoned");
         let mut result = Vec::new();
         for (_clock, paths) in
@@ -169,7 +177,13 @@ impl ChangeJournal {
     /// Returns the new overflow clock.
     pub fn clear(&self) -> Clock {
         self.last_change.clear();
-        self.journal.write().expect("journal lock poisoned").clear();
+        #[expect(
+            clippy::expect_used,
+            reason = "RwLock only poisons if another thread panicked mid-write; skipping the clear would leave stale entries the new overflow clock cannot compensate for"
+        )]
+        let mut journal = self.journal.write().expect("journal lock poisoned");
+        journal.clear();
+        drop(journal);
         self.mark_overflow()
     }
 

--- a/crates/zccache/src/hash/cache_key.rs
+++ b/crates/zccache/src/hash/cache_key.rs
@@ -74,6 +74,10 @@ impl CacheKeyBuilder {
         hasher.update(b"zccache-cache-key-v1");
 
         // Compiler identity
+        #[expect(
+            clippy::expect_used,
+            reason = "builder precondition: caller must call .compiler() before .build() — documented in `# Panics`"
+        )]
         let compiler = self.compiler_id.expect("compiler hash is required");
         hasher.update(compiler.as_bytes());
 
@@ -93,6 +97,10 @@ impl CacheKeyBuilder {
         }
 
         // Source hash
+        #[expect(
+            clippy::expect_used,
+            reason = "builder precondition: caller must call .source() before .build() — documented in `# Panics`"
+        )]
         let source = self.source_hash.expect("source hash is required");
         hasher.update(source.as_bytes());
 

--- a/crates/zccache/src/hash/link_cache_key.rs
+++ b/crates/zccache/src/hash/link_cache_key.rs
@@ -68,6 +68,10 @@ impl LinkCacheKeyBuilder {
         hasher.update(b"zccache-link-key-v1");
 
         // Tool identity
+        #[expect(
+            clippy::expect_used,
+            reason = "builder precondition: caller must call .tool() before .build() — documented in `# Panics`"
+        )]
         let tool = self.tool_id.expect("tool hash is required");
         hasher.update(tool.as_bytes());
 


### PR DESCRIPTION
Promotes `expect_used = "warn"` → `"deny"` per #946, completing the four-lint strictness target. Workflow per the user's `/goal` directive: four parallel read-only sub-agents audited every site by subsystem, main agent applied edits, local clippy verified (no remote multi-platform run).

## What changed in Cargo.toml

```toml
[workspace.lints.clippy]
unwrap_used        = "deny"
unwrap_in_result   = "deny"
panic_in_result_fn = "deny"
expect_used        = "deny"    # ← was "warn"
```

## Per-site dispositions (39 sites)

Three categories matching the issue spec:

### KEEP with `#[expect(clippy::expect_used, reason = "…")]` — real invariants

The `reason` text describes **why the value can't be the failure case**, not the failure mode.

| File:line | Invariant |
|---|---|
| `daemon/server/handle_compile/miss_store.rs:339` | `persist_semaphore` owned by ServerState; never closed |
| `daemon/server/handle_compile_multi.rs:136, 258` | `ensure_payloads.is_some()` gate on prior line guarantees `Some` |
| `daemon/server/handle_compile_multi.rs:899` | `persist_semaphore` invariant (same as miss_store) |
| `daemon/server/handle_exec.rs:784` | `persist_semaphore` invariant |
| `daemon/server/handle_link.rs:233` | `ensure_payloads.is_some()` gate |
| `daemon/server/handle_link.rs:506` | `persist_semaphore` invariant |
| `daemon/server/connection.rs:710` | `ctx.session_id = Some(session_id)` six lines above |
| `daemon/compile_journal/journal_thread.rs:131` | NUL on Windows / `/dev/null` on Unix must exist |
| `compiler/parse.rs:286, parse_msvc.rs:381` | `source_files` non-empty: `is_empty()` guard above |
| `compiler/response_file.rs:217` | Test-only path; tests pass representable args |
| `depgraph/context/mod.rs:384` | `NormalizedPath::case_key()` is always `Some` post-#576 |
| `artifact/kv.rs:392` | `spill_path` joins onto kv root; `.parent()` structurally Some |
| `cli/commands/util.rs:119` | Tokio current-thread runtime only fails on OS resource exhaustion |
| `core/version.rs:38` | `CARGO_PKG_VERSION` is cargo-validated semver at compile time |
| `download/mod.rs:179` | `should_use_segments` returns false when `total` is None |
| `fscache/clock.rs:103, 145, 172` | RwLock poison-only; failing loudly beats silent empty-result cache corruption |
| `hash/cache_key.rs:77, 96; link_cache_key.rs:71` | Builder preconditions documented in `# Panics` |
| `bin/zccache-ci.rs:25` | CI tool can't operate without cwd |
| `bin/zccache-daemon.rs:172, 256, 281` | Tokio runtime construction (current-thread/probe/multi-thread) |
| `bin/zccache-download-daemon.rs:88` | Tokio multi-thread runtime |

### CONVERT to recovery / restructure

| Site | Change |
|---|---|
| `depgraph/scanner.rs:81` | Fused `contains` + `find` into single `if let Some(after_end) = rest.find("/*")` — drops the expect AND speeds the scanner hot path |
| `depgraph/scanner.rs:205, 206` | `into_inner().unwrap_or_else(\|e\| e.into_inner())` — preserve partial scan output if a rayon worker poisons the mutex |
| `depgraph/scanner.rs:259, 265` | Same `unwrap_or_else(\|e\| e.into_inner())` pattern for the per-file extend |
| `cli/commands/cache_ops.rs:826, 852` | Replace `unwrap_or_else(\|\| current_dir().expect("cwd"))` with `if let Some/else match` that emits `eprintln! + ExitCode::FAILURE` on cwd read failure — matches the established CLI error-reporting pattern |

### File-level `#![allow(clippy::expect_used)]`

| Site | Justification |
|---|---|
| `crates/zccache/build.rs` | All three `.expect()` sites encode true build-time invariants; cargo surfaces panic messages cleanly. Per-site `#[expect]` would add noise. |

## Verification

`soldr cargo clippy --workspace --all-targets` (post-promotion, all 39 sites resolved):

```
0 errors, 0 warnings
```

**Per the user's `/goal` directive: no remote multi-platform CI run before merge** — would bottleneck. Lint promotion is a quality-of-life change; the only behavior changes are (a) cwd error printout instead of panic in two CLI subcommands and (b) mutex poison-recovery in the depgraph scanner. Both fail-safer than the original code.

## Process notes

- Sub-agents partitioned by subsystem: daemon/server+journal (Agent A), compiler+depgraph (Agent B), cli+core+build+artifact+download (Agent C), fscache+hash (Agent D). Each returned per-site disposition + exact attribute/code text.
- Agents missed 5 `.expect()` sites in `src/bin/*` (zccache-ci, zccache-daemon, zccache-download-daemon) because the partition didn't include `bin/`. Main agent caught these in the local clippy verify loop and applied the same `tokio runtime` / `cwd` patterns.
- Agent B flagged two sites where the structural fix is clearer than `#[expect]`: scanner.rs:81 (fuse contains+find) and scanner.rs poison sites (recover via `into_inner`). Both adopted.

## Closes

Closes #946.
