### PR TITLE
feat(alloc): make mimalloc the sole global allocator (drop jemalloc)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,6 @@ ruzstd = "0.7"
 lzma-rs = "0.3"
 sevenz-rust = "0.6"
 rkyv = { version = "0.7", features = ["validation"] }
-tikv-jemallocator = { version = "0.7", features = ["unprefixed_malloc_on_supported_platforms"] }
 mimalloc = "0.1"
 running-process = { version = "4.5.7", default-features = false, features = ["client-async"] }
 zccache = { path = "crates/zccache" }

--- a/ci/docker/zccache-builder.Dockerfile
+++ b/ci/docker/zccache-builder.Dockerfile
@@ -23,18 +23,14 @@ FROM rust:1.94.1-slim-bookworm
 
 # Build deps for any cc-rs / pkg-config / C-FFI crates that show up in
 # zccache's transitive graph. Notable consumers:
-#   - tikv-jemalloc-sys: invokes its bundled autogen.sh + make to build
-#     libjemalloc.a from C source (needs build-essential + autoconf;
-#     without them the build.rs panics with "No such file or directory"
-#     when it tries to exec `make`)
 #   - libssl-dev: openssl-sys
 #   - pkg-config: every -sys crate that uses it for system-lib discovery
-# Pin to a specific apt snapshot would be nice but slim-bookworm doesn't
-# expose snapshot pins out-of-box.
+#   - build-essential: cc-rs link step for mimalloc and other -sys crates
+# (autoconf was here for tikv-jemalloc-sys' autogen.sh; dropped now that
+# mimalloc — pure C, no autotools — is the sole allocator.)
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         build-essential \
-        autoconf \
         pkg-config \
         libssl-dev \
         ca-certificates \

--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -107,19 +107,16 @@ wait-timeout = "0.2"
 # shared: used by test_support, download-daemon bin, etc.
 tracing-subscriber = { workspace = true }
 
+# Global allocator on every target. mimalloc is pure C with no autotools
+# step, so it cross-compiles cleanly from Linux to Windows MSVC and
+# *-apple-darwin (where `tikv-jemalloc-sys`' hidden `$(CC) -MM` autoconf
+# dep-tracking pass drops the `--sysroot` and aborts; see
+# tikv/jemallocator#170). Single allocator across all platforms also
+# simplifies perf analysis — no per-target allocator-behavior delta.
+mimalloc = { workspace = true }
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-
-# jemalloc is only viable on non-macOS unix today. tikv-jemalloc-sys' bundled
-# autoconf invokes a hidden `$(CC) -MM $(CPPFLAGS)` dep-tracking pass that
-# drops the Apple `--sysroot` during Linux -> *-apple-darwin cross builds,
-# breaking on `os/lock.h`. macOS falls back to mimalloc below (matches the
-# Windows MSVC story). Tracked upstream as tikv/jemallocator#170.
-[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
-tikv-jemallocator = { workspace = true }
-
-[target.'cfg(any(windows, target_os = "macos"))'.dependencies]
-mimalloc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = [

--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -109,10 +109,19 @@ tracing-subscriber = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+# jemalloc is only viable on non-macOS unix today. tikv-jemalloc-sys' bundled
+# autoconf invokes a hidden `$(CC) -MM $(CPPFLAGS)` dep-tracking pass that
+# drops the Apple `--sysroot` during Linux -> *-apple-darwin cross builds,
+# breaking on `os/lock.h`. macOS falls back to mimalloc below (matches the
+# Windows MSVC story). Tracked upstream as tikv/jemallocator#170.
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 tikv-jemallocator = { workspace = true }
 
-[target.'cfg(windows)'.dependencies]
+[target.'cfg(any(windows, target_os = "macos"))'.dependencies]
 mimalloc = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_Security",

--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -108,11 +108,12 @@ wait-timeout = "0.2"
 tracing-subscriber = { workspace = true }
 
 # Global allocator on every target. mimalloc is pure C with no autotools
-# step, so it cross-compiles cleanly from Linux to Windows MSVC and
-# *-apple-darwin (where `tikv-jemalloc-sys`' hidden `$(CC) -MM` autoconf
-# dep-tracking pass drops the `--sysroot` and aborts; see
-# tikv/jemallocator#170). Single allocator across all platforms also
-# simplifies perf analysis — no per-target allocator-behavior delta.
+# step, so it cross-compiles cleanly in every direction. tikv-jemalloc
+# was the previous choice on unix but its bundled autoconf invokes a
+# hidden `$(CC) -MM` dep-tracking pass that silently drops the
+# `--sysroot` flag — broke Linux->*-apple-darwin (and would equally
+# break Windows->Linux); see tikv/jemallocator#170. Using one allocator
+# everywhere also removes a per-platform variable from perf analysis.
 mimalloc = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -7,11 +7,11 @@
 //! handles (exe file lock on Windows, implicit cwd handle on all OSes)
 //! via [`zccache::daemon::trampoline`] before entering [`run_server`].
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "macos"))]
 #[global_allocator]
 static GLOBAL_WIN: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -7,13 +7,8 @@
 //! handles (exe file lock on Windows, implicit cwd handle on all OSes)
 //! via [`zccache::daemon::trampoline`] before entering [`run_server`].
 
-#[cfg(all(unix, not(target_os = "macos")))]
 #[global_allocator]
-static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
-#[cfg(any(windows, target_os = "macos"))]
-#[global_allocator]
-static GLOBAL_WIN: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use clap::Parser;
 use zccache::core::NormalizedPath;

--- a/crates/zccache/src/bin/zccache-download-daemon.rs
+++ b/crates/zccache/src/bin/zccache-download-daemon.rs
@@ -1,10 +1,5 @@
-#[cfg(all(unix, not(target_os = "macos")))]
 #[global_allocator]
-static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
-#[cfg(any(windows, target_os = "macos"))]
-#[global_allocator]
-static GLOBAL_WIN: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use clap::Parser;
 use zccache::download_protocol::daemon_mgmt;

--- a/crates/zccache/src/bin/zccache-download-daemon.rs
+++ b/crates/zccache/src/bin/zccache-download-daemon.rs
@@ -1,8 +1,8 @@
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "macos"))]
 #[global_allocator]
 static GLOBAL_WIN: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/crates/zccache/src/bin/zccache-fp.rs
+++ b/crates/zccache/src/bin/zccache-fp.rs
@@ -1,10 +1,5 @@
-#[cfg(all(unix, not(target_os = "macos")))]
 #[global_allocator]
-static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
-#[cfg(any(windows, target_os = "macos"))]
-#[global_allocator]
-static GLOBAL_WIN: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use std::path::Path;
 use std::process::ExitCode;

--- a/crates/zccache/src/bin/zccache-fp.rs
+++ b/crates/zccache/src/bin/zccache-fp.rs
@@ -1,8 +1,8 @@
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "macos"))]
 #[global_allocator]
 static GLOBAL_WIN: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/crates/zccache/src/bin/zccache.rs
+++ b/crates/zccache/src/bin/zccache.rs
@@ -14,9 +14,13 @@
 //!    the entire command line as a compiler invocation and forwards
 //!    it to the daemon via the session from ZCCACHE_SESSION_ID.
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+#[cfg(any(windows, target_os = "macos"))]
+#[global_allocator]
+static GLOBAL_WIN: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use std::process::ExitCode;
 

--- a/crates/zccache/src/bin/zccache.rs
+++ b/crates/zccache/src/bin/zccache.rs
@@ -14,13 +14,8 @@
 //!    the entire command line as a compiler invocation and forwards
 //!    it to the daemon via the session from ZCCACHE_SESSION_ID.
 
-#[cfg(all(unix, not(target_os = "macos")))]
 #[global_allocator]
-static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
-#[cfg(any(windows, target_os = "macos"))]
-#[global_allocator]
-static GLOBAL_WIN: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use std::process::ExitCode;
 


### PR DESCRIPTION
## Summary

- Drop `tikv-jemallocator` entirely from the workspace.
- Make `mimalloc` the unconditional global allocator across linux/macos/windows.
- Simplify all four bin files (zccache-daemon, zccache-download-daemon, zccache-fp, zccache) to a single ungated `static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;`.
- Drop `autoconf` from the docker builder image (was only there for jemalloc's autogen.sh).

## Why

`tikv-jemalloc-sys`' bundled autoconf invokes a hidden `\$(CC) -MM \$(CPPFLAGS)` dep-tracking pass that silently drops the `--sysroot` flag. This breaks Linux → `*-apple-darwin` (the soldr release-pipeline darwin lanes hit it every build) and would equally break Windows → Linux for the same structural reason. Filed as [tikv/jemallocator#170](https://github.com/tikv/jemallocator/issues/170).

The first cut of this PR gated jemalloc to non-darwin and routed macOS through mimalloc. Review feedback (soldr PR #1112) pointed out that gating one cross-pair at a time just defers the same bug to the next pair. mimalloc is pure C with no autotools step, cross-compiles cleanly in every direction, and was already the Windows MSVC choice. A single allocator across all platforms also removes a per-target variable from perf analysis.

## Changes

- workspace `Cargo.toml`: drop `tikv-jemallocator` dep entirely.
- `crates/zccache/Cargo.toml`: move `mimalloc` to unconditional `[dependencies]` (no cfg gate).
- 4 bin files: collapse the cfg-gated two-allocator declarations into one unconditional `mimalloc::MiMalloc`.
- `ci/docker/zccache-builder.Dockerfile`: drop `autoconf` apt install + update comment.
- `Cargo.lock`: regenerates on next `cargo build`; the `tikv-jemalloc-*` entries fall out.

## Test plan

- [ ] CI green on linux/macos/windows
- [ ] No allocator-symbol regression on linux release tarballs (now mimalloc instead of jemalloc — different allocator, same C library shape)
- [ ] mimalloc symbols present in all daemon binaries (currently jemalloc on linux, expected to switch)
- [ ] downstream soldr darwin cross-build lanes complete past the previous `os/lock.h` failure (validated in soldr PR #1112)

🤖 Generated with [Claude Code](https://claude.com/claude-code)