### PR TITLE
fix(ci): unblock main — fmt, doc, test, musl target

### DIFF
--- a/.github/workflows/ci-check-cross.yml
+++ b/.github/workflows/ci-check-cross.yml
@@ -57,7 +57,13 @@ jobs:
       - name: Install musl-tools
         run: sudo apt-get update && sudo apt-get install -y musl-tools
       - name: Add rust target
-        run: rustup target add ${{ inputs.target }}
+        # Route through `soldr rustup` so the target lands in the
+        # setup-soldr-managed RUSTUP_HOME (the same one `soldr cargo`
+        # below uses). Bare `rustup target add` installs into
+        # `/home/runner/.rustup` instead, which soldr ignores —
+        # producing the "can't find crate for `core`" failure that
+        # blocked main pre-fix.
+        run: soldr rustup target add ${{ inputs.target }}
       - name: Check
         shell: bash
         run: |

--- a/crates/zccache/benches/exec.rs
+++ b/crates/zccache/benches/exec.rs
@@ -14,7 +14,13 @@
 //! The daemon and IPC client are constructed once and reused; criterion
 //! drives the inner request loop only.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;

--- a/crates/zccache/benches/fingerprint.rs
+++ b/crates/zccache/benches/fingerprint.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 

--- a/crates/zccache/benches/hashing.rs
+++ b/crates/zccache/benches/hashing.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 

--- a/crates/zccache/benches/persist_payloads.rs
+++ b/crates/zccache/benches/persist_payloads.rs
@@ -12,7 +12,13 @@
 //! (`fs::write` to tmp, `fs::rename` to final, on a per-payload basis)
 //! and compares serial vs `rayon::par_iter` for `N ∈ {1, 3, 5, 10}`.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/crates/zccache/benches/read_outputs.rs
+++ b/crates/zccache/benches/read_outputs.rs
@@ -12,7 +12,13 @@
 //! - N = 5: link with a couple of side-effect DLLs
 //! - N = 10: link saturated with side-effects
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::PathBuf;
 

--- a/crates/zccache/benches/scan_metadata.rs
+++ b/crates/zccache/benches/scan_metadata.rs
@@ -11,7 +11,13 @@
 //!
 //! Counts: 100, 1000, 5000 — covers tiny / typical / large repos.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/crates/zccache/benches/scan_recursive.rs
+++ b/crates/zccache/benches/scan_recursive.rs
@@ -16,7 +16,13 @@
 //! Save a baseline on the pre-change commit with `-- --save-baseline pre`,
 //! then re-run after the impl change with `-- --baseline pre`.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::{Path, PathBuf};
 

--- a/crates/zccache/benches/warm_restore.rs
+++ b/crates/zccache/benches/warm_restore.rs
@@ -9,7 +9,13 @@
 //! This bench mirrors that syscall sequence and compares a serial loop
 //! against `rayon::par_iter`. Counts: 100 / 1000 / 5000.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::PathBuf;
 use std::time::SystemTime;

--- a/crates/zccache/benches/write_payloads.rs
+++ b/crates/zccache/benches/write_payloads.rs
@@ -15,7 +15,13 @@
 //! hardlink/copy fast path without dominating measurement noise from
 //! filesystem flushing.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::PathBuf;
 

--- a/crates/zccache/src/audit_writer.rs
+++ b/crates/zccache/src/audit_writer.rs
@@ -10,17 +10,17 @@
 //!
 //! ## What this module ships
 //!
-//! - [`AuditSink::start`] — spawn the writer task for a configured
+//! - [`crate::audit_writer::AuditSink::start`] — spawn the writer task for a configured
 //!   [`crate::audit::AuditConfig`]; returns a `AuditSink` handle the
 //!   embedded service holds for its lifetime.
-//! - [`AuditSink::emit`] — non-blocking enqueue of a single event.
+//! - [`crate::audit_writer::AuditSink::emit`] — non-blocking enqueue of a single event.
 //!   Honors [`crate::audit::AuditSinkPolicy`] when the channel is at
 //!   capacity (drop / block / degrade / fail-lossless).
-//! - [`AuditSink::flush`] — drain the queue and `fsync` the file.
+//! - [`crate::audit_writer::AuditSink::flush`] — drain the queue and `fsync` the file.
 //!   Called from [`crate::embedded::ZccacheService::flush`].
-//! - [`AuditSink::shutdown`] — flush, close, await the writer task.
+//! - [`crate::audit_writer::AuditSink::shutdown`] — flush, close, await the writer task.
 //!   Called from [`crate::embedded::ZccacheService::shutdown`].
-//! - [`AuditSink::lost_events`] — diagnostic counter of events dropped
+//! - [`crate::audit_writer::AuditSink::lost_events`] — diagnostic counter of events dropped
 //!   under `DropLowPriority` policy. Surfaced by stats so host
 //!   operators can detect backpressure incidents.
 //!
@@ -32,7 +32,7 @@
 //!   the writer can land + soak under host control before the upstream
 //!   hot-path commits to using it. The audit-schema.md doc enumerates
 //!   the milestone list when that work lands.
-//! - **Summary mode.** [`AuditMode::Summary`] currently degrades to a
+//! - **Summary mode.** [`crate::audit::AuditMode::Summary`] currently degrades to a
 //!   `Normal` writer (no separate accumulator). The summary writer is
 //!   tracked under #910 (operator API) since the consumer is the same.
 //! - **Multi-file rollover.** The writer opens one file for the
@@ -147,12 +147,7 @@ impl AuditSink {
             .ok_or(AuditSinkError::MissingOutputRoot)?;
         let output_root = PathBuf::from(output_root);
         std::fs::create_dir_all(&output_root)?;
-        let path = output_root.join(
-            config
-                .event_log
-                .as_deref()
-                .unwrap_or("audit.jsonl"),
-        );
+        let path = output_root.join(config.event_log.as_deref().unwrap_or("audit.jsonl"));
 
         let file = std::fs::OpenOptions::new()
             .create(true)
@@ -353,8 +348,10 @@ mod tests {
         let sink = AuditSink::start(&config, None)
             .expect("start ok")
             .expect("sink present in Normal mode");
-        sink.emit(fixture_event(AuditLevel::Info, 1)).expect("emit ok");
-        sink.emit(fixture_event(AuditLevel::Info, 2)).expect("emit ok");
+        sink.emit(fixture_event(AuditLevel::Info, 1))
+            .expect("emit ok");
+        sink.emit(fixture_event(AuditLevel::Info, 2))
+            .expect("emit ok");
         sink.flush().await.expect("flush ok");
         sink.shutdown().await.expect("shutdown ok");
 
@@ -363,7 +360,8 @@ mod tests {
         let lines: Vec<_> = contents.lines().collect();
         assert_eq!(lines.len(), 2, "two events should produce two JSONL rows");
         for line in lines {
-            let parsed: AuditEvent = serde_json::from_str(line).expect("each line is valid AuditEvent");
+            let parsed: AuditEvent =
+                serde_json::from_str(line).expect("each line is valid AuditEvent");
             assert_eq!(parsed.schema, crate::audit::AUDIT_SCHEMA);
             assert_eq!(parsed.schema_version, crate::audit::AUDIT_SCHEMA_VERSION);
         }

--- a/crates/zccache/src/compile_trace.rs
+++ b/crates/zccache/src/compile_trace.rs
@@ -39,11 +39,11 @@
 //!
 //! ## Hot-path cost
 //!
-//! - **Off** (env var unset): one [`OnceLock::get_or_init`] miss
+//! - **Off** (env var unset): one [`std::sync::OnceLock::get_or_init`] miss
 //!   resolves to `None`; subsequent calls hit the `None` arm and
 //!   return immediately. Below noise.
-//! - **On**: one [`Instant::elapsed`], one [`format!`], one mutex-guarded
-//!   [`Write::write_all`]. The mutex contention is bounded by the
+//! - **On**: one [`std::time::Instant::elapsed`], one [`format!`], one mutex-guarded
+//!   [`std::io::Write::write_all`]. The mutex contention is bounded by the
 //!   number of sub-phase records per compile (~6 today) times the
 //!   embedded daemon's compile concurrency — fine for diagnostic use,
 //!   not enabled in production.

--- a/crates/zccache/src/embedded.rs
+++ b/crates/zccache/src/embedded.rs
@@ -679,6 +679,14 @@ mod cancellation_tests {
         token: Option<CancellationToken>,
         instance_id: &str,
     ) -> Result<ZccacheService> {
+        // These tests exercise cancellation/runtime plumbing, not the
+        // audit sink, so disable audit (`AuditMode::Off`) to avoid the
+        // production `output_root` validation introduced after the
+        // tests were written. The audit sink is exercised in
+        // `audit_writer.rs` tests with a proper tempdir-backed
+        // `output_root`.
+        let mut audit = AuditConfig::default();
+        audit.mode = crate::audit::AuditMode::Off;
         ZccacheService::start(ZccacheConfig {
             host: HostIdentity {
                 product: "zccache-test".into(),
@@ -686,7 +694,7 @@ mod cancellation_tests {
                 workspace_id: instance_id.into(),
             },
             cache_root: temp.path().join("zccache").into(),
-            audit: AuditConfig::default(),
+            audit,
             limits: ServiceLimits::default(),
             runtime: RuntimeHooks::default(),
             cancellation: token,
@@ -903,6 +911,11 @@ mod runtime_hooks_tests {
         let landed_clone = Arc::clone(&landed_on_host);
         let host_handle_clone = host_handle.clone();
         let service = host_rt.block_on(async move {
+            // Disable audit (`AuditMode::Off`) so the production
+            // `output_root` validation does not reject this fixture; the
+            // test exercises runtime hooks, not the audit sink.
+            let mut audit = AuditConfig::default();
+            audit.mode = crate::audit::AuditMode::Off;
             ZccacheService::start(ZccacheConfig {
                 host: HostIdentity {
                     product: "zccache-test".into(),
@@ -910,7 +923,7 @@ mod runtime_hooks_tests {
                     workspace_id: "runtime-hooks".into(),
                 },
                 cache_root,
-                audit: AuditConfig::default(),
+                audit,
                 limits: ServiceLimits::default(),
                 runtime: RuntimeHooks {
                     service_name: Some("runtime-hooks-test".into()),

--- a/crates/zccache/tests/artifact_kv_stress.rs
+++ b/crates/zccache/tests/artifact_kv_stress.rs
@@ -4,7 +4,13 @@
 //! reader/writer races) are marked `#[ignore]` so they only run under
 //! `./test --full`. Default `./test` and the Stop hook stay fast.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::sync::Arc;
 

--- a/crates/zccache/tests/artifact_perf_index_durability_test.rs
+++ b/crates/zccache/tests/artifact_perf_index_durability_test.rs
@@ -17,7 +17,13 @@
 //! the budget assertion below guards against the fsync regressing latency
 //! past the point where it would be slower than re-populating from scratch.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/crates/zccache/tests/broker_into_backend_io_spike_test.rs
+++ b/crates/zccache/tests/broker_into_backend_io_spike_test.rs
@@ -24,8 +24,13 @@
 //! `ServiceDefinition` inline and skips the probe, which is the minimal faithful
 //! broker that fronts an external backend socket.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
-
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 #![cfg(unix)]
 
 use std::io;

--- a/crates/zccache/tests/ci_timeout_and_progress.rs
+++ b/crates/zccache/tests/ci_timeout_and_progress.rs
@@ -2,7 +2,13 @@
 //! markers exposed by `zccache-ci`. Uses parameterized timeouts of a few
 //! hundred milliseconds so the suite runs in well under a second.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::process::{Command, Stdio};
 use std::time::Duration;

--- a/crates/zccache/tests/cli_cache_root.rs
+++ b/crates/zccache/tests/cli_cache_root.rs
@@ -3,7 +3,13 @@
 //! this to verify at runtime that its `ZCCACHE_CACHE_DIR` redirect was
 //! honored by the binary on PATH.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use std::process::{Command, Stdio};

--- a/crates/zccache/tests/cli_cli_crash_test.rs
+++ b/crates/zccache/tests/cli_cli_crash_test.rs
@@ -7,7 +7,13 @@
 //! that the dump path under `<cache>/crashes/` matches the new
 //! `crash-<ts>-zccache-<kind>.txt` naming. See issue #313.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};

--- a/crates/zccache/tests/cli_daemon_start.rs
+++ b/crates/zccache/tests/cli_daemon_start.rs
@@ -13,7 +13,13 @@
 //! The fix: mark stdout/stderr as non-inheritable before spawning the
 //! daemon process on Windows.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::process::Command;
 use std::time::{Duration, Instant};

--- a/crates/zccache/tests/cli_defender_exclusions.rs
+++ b/crates/zccache/tests/cli_defender_exclusions.rs
@@ -6,7 +6,13 @@
 //! verbs touch real machine state and need an admin shell, so we stay
 //! out of them in CI.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::process::Command;
 

--- a/crates/zccache/tests/cli_ino_convert.rs
+++ b/crates/zccache/tests/cli_ino_convert.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::fs;
 use std::thread;

--- a/crates/zccache/tests/cli_installers.rs
+++ b/crates/zccache/tests/cli_installers.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::fs;
 use std::io::{Read, Write};

--- a/crates/zccache/tests/cli_kv.rs
+++ b/crates/zccache/tests/cli_kv.rs
@@ -3,7 +3,13 @@
 //! Each test uses an isolated `ZCCACHE_CACHE_DIR` so it never touches the
 //! user's real cache directory and never collides with other tests.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::io::Write;
 use std::path::Path;

--- a/crates/zccache/tests/cli_meson_configure_cache.rs
+++ b/crates/zccache/tests/cli_meson_configure_cache.rs
@@ -12,7 +12,13 @@
 //! - On HIT, the cached run completes substantially faster than the cold
 //!   run.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use std::process::Command;

--- a/crates/zccache/tests/cli_rust_plan_lifecycle.rs
+++ b/crates/zccache/tests/cli_rust_plan_lifecycle.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/zccache/tests/cli_session_end.rs
+++ b/crates/zccache/tests/cli_session_end.rs
@@ -8,7 +8,13 @@
 //! a daemon-unreachable error must yield exit 0 with a one-line warning
 //! to stderr.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::PathBuf;
 use std::process::Command;

--- a/crates/zccache/tests/cli_single_daemon_per_session.rs
+++ b/crates/zccache/tests/cli_single_daemon_per_session.rs
@@ -23,7 +23,13 @@
 //! Marked `#[ignore]` so the unit-test pass stays sub-second; runs
 //! under `./test --integration` and `./test --full`.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::io::Write;
 use std::process::{Command, Stdio};

--- a/crates/zccache/tests/cli_wrapper_passthrough.rs
+++ b/crates/zccache/tests/cli_wrapper_passthrough.rs
@@ -19,7 +19,13 @@
 //! Marked `#[ignore]` so the unit-test pass stays sub-second; the
 //! `./test --integration` and `./test --full` runners pick this up.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::io::Write;
 use std::process::{Command, Stdio};

--- a/crates/zccache/tests/common/mod.rs
+++ b/crates/zccache/tests/common/mod.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::fs;
 use std::path::Path;

--- a/crates/zccache/tests/compile_concurrency_gating.rs
+++ b/crates/zccache/tests/compile_concurrency_gating.rs
@@ -25,7 +25,13 @@
 //! parsing the daemon log file in the `ZCCACHE_MAX_PARALLEL_COMPILES=1`
 //! "60 source files" scenario.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/crates/zccache/tests/compiler_arduino_ino.rs
+++ b/crates/zccache/tests/compiler_arduino_ino.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::fs;
 

--- a/crates/zccache/tests/compiler_clang_cl_classification.rs
+++ b/crates/zccache/tests/compiler_clang_cl_classification.rs
@@ -17,7 +17,13 @@
 //!      generate must classify correctly — including response files,
 //!      mixed `-`/`/` prefixes, and the `/Tc`/`/Tp` source-language flags.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 

--- a/crates/zccache/tests/compiler_response_file_expansion_test.rs
+++ b/crates/zccache/tests/compiler_response_file_expansion_test.rs
@@ -9,7 +9,13 @@
 //! Run all:    soldr cargo test -p zccache --test compiler_response_file_expansion_test -- --nocapture
 //! Run single: soldr cargo test -p zccache --test compiler_response_file_expansion_test -- <test_name> --nocapture
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use zccache::compiler::response_file::{

--- a/crates/zccache/tests/compiler_response_file_integration_test.rs
+++ b/crates/zccache/tests/compiler_response_file_integration_test.rs
@@ -8,7 +8,13 @@
 //! Run all:    soldr cargo test -p zccache --test compiler_response_file_integration_test -- --nocapture
 //! Run single: soldr cargo test -p zccache --test compiler_response_file_integration_test -- <test_name> --nocapture
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use zccache::compiler::response_file::{expand_response_files, ResponseFileError};

--- a/crates/zccache/tests/compiler_response_file_parser_test.rs
+++ b/crates/zccache/tests/compiler_response_file_parser_test.rs
@@ -10,7 +10,13 @@
 //! Run all:    soldr cargo test -p zccache --test compiler_response_file_parser_test -- --nocapture
 //! Run single: soldr cargo test -p zccache --test compiler_response_file_parser_test -- <test_name> --nocapture
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::compiler::response_file::parse_response_file_content;
 

--- a/crates/zccache/tests/daemon_adversarial_corner_cases.rs
+++ b/crates/zccache/tests/daemon_adversarial_corner_cases.rs
@@ -8,7 +8,13 @@
 //! Run all:    soldr cargo test -p zccache-daemon --test adversarial_corner_cases -- --nocapture
 //! Run single: soldr cargo test -p zccache-daemon --test adversarial_corner_cases -- <test_name> --nocapture
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use std::sync::Arc;

--- a/crates/zccache/tests/daemon_adversarial_mutations.rs
+++ b/crates/zccache/tests/daemon_adversarial_mutations.rs
@@ -9,7 +9,13 @@
 //! Run all:    soldr cargo test -p zccache-daemon --test adversarial_mutations -- --nocapture
 //! Run single: soldr cargo test -p zccache-daemon --test adversarial_mutations -- <test_name> --nocapture
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use zccache::core::NormalizedPath;

--- a/crates/zccache/tests/daemon_burst_link_test.rs
+++ b/crates/zccache/tests/daemon_burst_link_test.rs
@@ -33,7 +33,13 @@
 //! issue's `N` parameter). The test no-ops when clang is not on PATH so
 //! it can stay in the default integration set.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::time::{Duration, Instant};
 

--- a/crates/zccache/tests/daemon_cli_flow_test.rs
+++ b/crates/zccache/tests/daemon_cli_flow_test.rs
@@ -5,7 +5,13 @@
 //!
 //! IPC-based session flow tests live in `server.rs` unit tests.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::sync::Once;
 

--- a/crates/zccache/tests/daemon_cold_path_profile_test.rs
+++ b/crates/zccache/tests/daemon_cold_path_profile_test.rs
@@ -10,7 +10,13 @@
 //!
 //! Run with: soldr cargo test -p zccache-daemon --test cold_path_profile_test -- --nocapture --ignored
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use std::sync::Arc;

--- a/crates/zccache/tests/daemon_crash_minidump_test.rs
+++ b/crates/zccache/tests/daemon_crash_minidump_test.rs
@@ -13,7 +13,13 @@
 //! discriminate by extension; they match on the substring inside the
 //! filename.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};

--- a/crates/zccache/tests/daemon_cwd_release.rs
+++ b/crates/zccache/tests/daemon_cwd_release.rs
@@ -11,7 +11,13 @@
 //! binary must serialize. Guarded by a local static `Mutex` to avoid
 //! pulling in `serial_test` as a dependency.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::sync::Mutex;
 

--- a/crates/zccache/tests/daemon_depgraph_persistence_test.rs
+++ b/crates/zccache/tests/daemon_depgraph_persistence_test.rs
@@ -8,7 +8,13 @@
 //!
 //! Run: soldr cargo test -p zccache-daemon --test depgraph_persistence_test -- --ignored --nocapture
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::sync::{Arc, Mutex};
 use tokio::sync::Notify;

--- a/crates/zccache/tests/daemon_depgraph_warm_classify_test.rs
+++ b/crates/zccache/tests/daemon_depgraph_warm_classify_test.rs
@@ -5,7 +5,13 @@
 //! session. Version-mismatch and corrupt files must fall back to cold AND
 //! emit a clear warning visible in the per-session `last-session.log`.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};

--- a/crates/zccache/tests/daemon_dll_cache_test.rs
+++ b/crates/zccache/tests/daemon_dll_cache_test.rs
@@ -2,7 +2,13 @@
 //!
 //! Tests the full flow: compile .o files → `gcc -shared` → cache hit/miss.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::daemon::DaemonServer;
 use zccache::protocol::{Request, Response};

--- a/crates/zccache/tests/daemon_exe_overwrite.rs
+++ b/crates/zccache/tests/daemon_exe_overwrite.rs
@@ -16,8 +16,13 @@
 //!
 //! See issue #134 / PR #135.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
-
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 #![cfg(windows)]
 
 use std::process::{Command, Stdio};

--- a/crates/zccache/tests/daemon_fingerprint_test.rs
+++ b/crates/zccache/tests/daemon_fingerprint_test.rs
@@ -3,7 +3,13 @@
 //! Tests the full CLI → daemon fingerprint pipeline:
 //! check, mark-success, mark-failure, invalidate, and watcher-based change detection.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::daemon::DaemonServer;
 use zccache::protocol::{Request, Response};

--- a/crates/zccache/tests/daemon_generic_exec_advanced_test.rs
+++ b/crates/zccache/tests/daemon_generic_exec_advanced_test.rs
@@ -6,7 +6,13 @@
 //! tool-binary-change/touch checklist items, missing-input diagnostics,
 //! and the cache-restore (normalized-mtime) scenario.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;

--- a/crates/zccache/tests/daemon_generic_exec_test.rs
+++ b/crates/zccache/tests/daemon_generic_exec_test.rs
@@ -6,7 +6,13 @@
 //! a deterministic Rust binary whose stdout/stderr/output-file are fully
 //! determined by its argv + the content of its declared input file.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;

--- a/crates/zccache/tests/daemon_integration_test.rs
+++ b/crates/zccache/tests/daemon_integration_test.rs
@@ -2,7 +2,13 @@
 //!
 //! Tests the full client → daemon → clang toolchain discovery pipeline.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::daemon::DaemonServer;
 use zccache::protocol::{Request, Response};

--- a/crates/zccache/tests/daemon_lineage_propagation.rs
+++ b/crates/zccache/tests/daemon_lineage_propagation.rs
@@ -11,8 +11,13 @@
 //! invariants of which env vars get set; this file verifies the full
 //! spawn-and-receive round trip on the host that supports it.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
-
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 #![cfg(unix)]
 
 use zccache::daemon::lineage::{

--- a/crates/zccache/tests/daemon_link_cache_test.rs
+++ b/crates/zccache/tests/daemon_link_cache_test.rs
@@ -2,7 +2,13 @@
 //!
 //! Tests the full flow: compile .o files → `ar rcsD` → cache hit/miss.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::daemon::DaemonServer;
 use zccache::protocol::{Request, Response};

--- a/crates/zccache/tests/daemon_ninja_rebuild_direct_test.rs
+++ b/crates/zccache/tests/daemon_ninja_rebuild_direct_test.rs
@@ -19,7 +19,13 @@
 //! Run all:    soldr cargo test -p zccache-daemon --test daemon_ninja_rebuild_direct_test -- --nocapture
 //! Run stress: soldr cargo test -p zccache-daemon --test daemon_ninja_rebuild_direct_test -- --ignored --nocapture
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/crates/zccache/tests/daemon_ninja_rebuild_meson_test.rs
+++ b/crates/zccache/tests/daemon_ninja_rebuild_meson_test.rs
@@ -7,7 +7,13 @@
 //!
 //! Run:    soldr cargo test -p zccache-daemon --test daemon_ninja_rebuild_meson_test -- --ignored --nocapture
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::sync::{Arc, Once};
 use tokio::sync::Notify;

--- a/crates/zccache/tests/daemon_pch_cache_basic_test.rs
+++ b/crates/zccache/tests/daemon_pch_cache_basic_test.rs
@@ -8,7 +8,13 @@
 //! Adversarial sub-header / chained / build-dir-separation / spurious-output
 //! scenarios live in `daemon_pch_cache_invalidation_test.rs`.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::daemon::DaemonServer;
 use zccache::protocol::{Request, Response};

--- a/crates/zccache/tests/daemon_pch_cache_invalidation_test.rs
+++ b/crates/zccache/tests/daemon_pch_cache_invalidation_test.rs
@@ -12,7 +12,13 @@
 //! Basic PCH usage / generation cacheability lives in
 //! `daemon_pch_cache_basic_test.rs`.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::daemon::DaemonServer;
 use zccache::protocol::{Request, Response};

--- a/crates/zccache/tests/daemon_perf_artifact_fallback_test.rs
+++ b/crates/zccache/tests/daemon_perf_artifact_fallback_test.rs
@@ -37,7 +37,13 @@
 //!   catches accidentally re-introducing a disk read or a blocking
 //!   syscall on the lookup hot path.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/crates/zccache/tests/daemon_perf_test.rs
+++ b/crates/zccache/tests/daemon_perf_test.rs
@@ -3,7 +3,13 @@
 //! Three-way benchmark measuring compile latency across cache-miss and cache-hit scenarios.
 //! Run with: soldr cargo test -p zccache-daemon --test perf_test -- --nocapture --ignored
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::time::Instant;
 use zccache::core::NormalizedPath;

--- a/crates/zccache/tests/daemon_persist_pool_bench.rs
+++ b/crates/zccache/tests/daemon_persist_pool_bench.rs
@@ -29,7 +29,13 @@
 //!   PERSIST_BENCH_TRIALS       (default 1)
 //!   PERSIST_BENCH_JSON         (set to write results JSON to that path)
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;

--- a/crates/zccache/tests/daemon_profile_multi_test.rs
+++ b/crates/zccache/tests/daemon_profile_multi_test.rs
@@ -2,7 +2,13 @@
 //!
 //! Run: soldr cargo test -p zccache-daemon --test profile_multi_test -- --nocapture --ignored
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::sync::Arc;
 use std::time::Instant;

--- a/crates/zccache/tests/daemon_profile_test.rs
+++ b/crates/zccache/tests/daemon_profile_test.rs
@@ -2,7 +2,13 @@
 //!
 //! Run with: soldr cargo test -p zccache-daemon --test profile_test -- --nocapture --ignored
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::daemon::DaemonServer;
 use zccache::protocol::{Request, Response};

--- a/crates/zccache/tests/daemon_response_file_cache.rs
+++ b/crates/zccache/tests/daemon_response_file_cache.rs
@@ -6,7 +6,13 @@
 //! Run all:    soldr cargo test -p zccache-daemon --test response_file_cache -- --ignored --nocapture
 //! Run single: soldr cargo test -p zccache-daemon --test response_file_cache -- <test_name> --ignored --nocapture
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};

--- a/crates/zccache/tests/daemon_rustc_adversarial_concurrency_test.rs
+++ b/crates/zccache/tests/daemon_rustc_adversarial_concurrency_test.rs
@@ -13,7 +13,13 @@
 //! Run all:    soldr cargo test -p zccache --test daemon_rustc_adversarial_concurrency_test -- --nocapture --ignored --test-threads=1
 //! Run single: soldr cargo test -p zccache --test daemon_rustc_adversarial_concurrency_test -- <test_name> --nocapture --ignored
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::core::NormalizedPath;
 use zccache::daemon::DaemonServer;

--- a/crates/zccache/tests/daemon_rustc_adversarial_corner_cases_test.rs
+++ b/crates/zccache/tests/daemon_rustc_adversarial_corner_cases_test.rs
@@ -15,7 +15,13 @@
 //! Run all:    soldr cargo test -p zccache --test daemon_rustc_adversarial_corner_cases_test -- --nocapture --ignored --test-threads=1
 //! Run single: soldr cargo test -p zccache --test daemon_rustc_adversarial_corner_cases_test -- <test_name> --nocapture --ignored
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::core::NormalizedPath;
 use zccache::daemon::DaemonServer;

--- a/crates/zccache/tests/daemon_rustc_adversarial_mutations_test.rs
+++ b/crates/zccache/tests/daemon_rustc_adversarial_mutations_test.rs
@@ -12,7 +12,13 @@
 //! Run all:    soldr cargo test -p zccache --test daemon_rustc_adversarial_mutations_test -- --nocapture --ignored --test-threads=1
 //! Run single: soldr cargo test -p zccache --test daemon_rustc_adversarial_mutations_test -- <test_name> --nocapture --ignored
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::core::NormalizedPath;
 use zccache::daemon::DaemonServer;

--- a/crates/zccache/tests/daemon_rustc_cache_basic_test.rs
+++ b/crates/zccache/tests/daemon_rustc_cache_basic_test.rs
@@ -5,7 +5,13 @@
 //! and extern-crate invalidation. Split out from
 //! `daemon_rustc_cache_test.rs` so each integration-test binary stays small.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::core::NormalizedPath;
 use zccache::daemon::DaemonServer;

--- a/crates/zccache/tests/daemon_rustc_cache_path_remap_test.rs
+++ b/crates/zccache/tests/daemon_rustc_cache_path_remap_test.rs
@@ -7,7 +7,13 @@
 //! Split out from `daemon_rustc_cache_test.rs` so each integration-test
 //! binary stays small.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::core::NormalizedPath;
 use zccache::daemon::DaemonServer;

--- a/crates/zccache/tests/daemon_rustc_cache_worktree_test.rs
+++ b/crates/zccache/tests/daemon_rustc_cache_worktree_test.rs
@@ -6,7 +6,13 @@
 //! Split out from `daemon_rustc_cache_test.rs` so each integration-test
 //! binary stays small.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::core::NormalizedPath;
 use zccache::daemon::DaemonServer;

--- a/crates/zccache/tests/daemon_rustc_issue_210_async_populate_test.rs
+++ b/crates/zccache/tests/daemon_rustc_issue_210_async_populate_test.rs
@@ -4,7 +4,13 @@
 //! Run all:
 //!   cargo test -p zccache-daemon --test rustc_issue_210_async_populate_test -- --ignored --nocapture
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};

--- a/crates/zccache/tests/daemon_rustc_restore_test.rs
+++ b/crates/zccache/tests/daemon_rustc_restore_test.rs
@@ -5,7 +5,13 @@
 //! persisted depgraph so unchanged rustc multi-output args are served from
 //! cache and recreate the missing output tree.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};

--- a/crates/zccache/tests/daemon_session_stats_test.rs
+++ b/crates/zccache/tests/daemon_session_stats_test.rs
@@ -13,7 +13,13 @@
 //!   5. Query session-stats → verify hits accumulated
 //!   6. session-end → verify final stats match mid-session snapshot
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::daemon::DaemonServer;
 use zccache::protocol::{Request, Response, SessionStats};

--- a/crates/zccache/tests/daemon_spawn_lockfile_budget_test.rs
+++ b/crates/zccache/tests/daemon_spawn_lockfile_budget_test.rs
@@ -6,7 +6,13 @@
 //! Defender plus concurrent builds can push clients into
 //! `no daemon lockfile observed within 10s`.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};

--- a/crates/zccache/tests/daemon_spawn_storm_test.rs
+++ b/crates/zccache/tests/daemon_spawn_storm_test.rs
@@ -55,7 +55,13 @@
 //! test should pass and the env-var gate can be dropped so it joins
 //! the standard integration suite as a permanent regression test.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::io::Write;
 use std::path::{Path, PathBuf};

--- a/crates/zccache/tests/daemon_stdio_detach.rs
+++ b/crates/zccache/tests/daemon_stdio_detach.rs
@@ -15,7 +15,13 @@
 //!
 //! See issue #276.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::io::Read;
 use std::process::{Command, Stdio};

--- a/crates/zccache/tests/daemon_stress_compiler_test.rs
+++ b/crates/zccache/tests/daemon_stress_compiler_test.rs
@@ -7,7 +7,13 @@
 //! See `daemon_stress_correctness_test.rs` for correctness + concurrency tests
 //! and `daemon_stress_edges_test.rs` for path/output/empty-source edge cases.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::daemon::DaemonServer;
 use zccache::protocol::{Request, Response};

--- a/crates/zccache/tests/daemon_stress_correctness_test.rs
+++ b/crates/zccache/tests/daemon_stress_correctness_test.rs
@@ -9,7 +9,13 @@
 //! See `daemon_stress_edges_test.rs` for path/output/empty-source edge cases and
 //! `daemon_stress_compiler_test.rs` for compiler-override coverage.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::daemon::DaemonServer;
 use zccache::protocol::{Request, Response};

--- a/crates/zccache/tests/daemon_stress_edges_test.rs
+++ b/crates/zccache/tests/daemon_stress_edges_test.rs
@@ -10,7 +10,13 @@
 //! See `daemon_stress_correctness_test.rs` for correctness + concurrency tests
 //! and `daemon_stress_compiler_test.rs` for compiler-override coverage.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::daemon::DaemonServer;
 use zccache::protocol::{Request, Response};

--- a/crates/zccache/tests/daemon_tokio_console_test.rs
+++ b/crates/zccache/tests/daemon_tokio_console_test.rs
@@ -7,7 +7,13 @@
 //! in console mode or a clean unavailable warning when the binary was not built
 //! with Tokio's `tokio_unstable` cfg.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use serde_json::json;
 use std::io;

--- a/crates/zccache/tests/daemon_watcher_adversarial.rs
+++ b/crates/zccache/tests/daemon_watcher_adversarial.rs
@@ -9,7 +9,13 @@
 //! Run all:    soldr cargo test -p zccache-daemon --test watcher_adversarial -- --nocapture
 //! Run single: soldr cargo test -p zccache-daemon --test watcher_adversarial -- <test_name> --nocapture
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use std::sync::Arc;

--- a/crates/zccache/tests/daemon_wire_dispatcher.rs
+++ b/crates/zccache/tests/daemon_wire_dispatcher.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use bytes::{BufMut, BytesMut};
 use zccache::protocol::wire_prost::{encode_prost_message, zccache_v1 as pb, WireFormat};

--- a/crates/zccache/tests/daemon_wire_frame_v1_test.rs
+++ b/crates/zccache/tests/daemon_wire_frame_v1_test.rs
@@ -14,7 +14,13 @@
 //!    v16 prost, FrameV1, and a running-process `BackendHandle` identity
 //!    probe against the same daemon endpoint.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use bytes::BytesMut;
 use zccache::daemon::DaemonServer;

--- a/crates/zccache/tests/daemon_wire_perf_scaffold.rs
+++ b/crates/zccache/tests/daemon_wire_perf_scaffold.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use bytes::BytesMut;
 use std::time::Instant;

--- a/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
+++ b/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use bytes::BytesMut;
 use prost::Message;

--- a/crates/zccache/tests/daemon_wire_protocol_version.rs
+++ b/crates/zccache/tests/daemon_wire_protocol_version.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::ffi::OsString;
 

--- a/crates/zccache/tests/daemon_workspace_pin_747.rs
+++ b/crates/zccache/tests/daemon_workspace_pin_747.rs
@@ -12,7 +12,13 @@
 //! access the file") because the daemon holds an implicit kernel
 //! `FILE_OBJECT` on its inherited cwd.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::process::{Command, Stdio};
 use std::time::Duration;

--- a/crates/zccache/tests/depgraph_depfile_integration_test.rs
+++ b/crates/zccache/tests/depgraph_depfile_integration_test.rs
@@ -3,7 +3,13 @@
 //! These tests require GCC or Clang to be installed. Run with:
 //! `soldr cargo test -p zccache-depgraph --test depfile_integration_test -- --ignored`
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::process::Command;
 use tempfile::TempDir;

--- a/crates/zccache/tests/depgraph_drift_detection_test.rs
+++ b/crates/zccache/tests/depgraph_drift_detection_test.rs
@@ -18,7 +18,13 @@
 //! set. The next read against an unchanged state then ultra-fast-hits the
 //! write-side key (single source of truth).
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 

--- a/crates/zccache/tests/depgraph_stress_adversarial_test.rs
+++ b/crates/zccache/tests/depgraph_stress_adversarial_test.rs
@@ -3,7 +3,13 @@
 //! All tests are `#[ignore]` — run with `uv run test --full` or
 //! `soldr cargo test -p zccache-depgraph --test stress_test -- --ignored`.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::collections::HashSet;
 use std::path::Path;

--- a/crates/zccache/tests/depgraph_stress_concurrent_test.rs
+++ b/crates/zccache/tests/depgraph_stress_concurrent_test.rs
@@ -3,7 +3,13 @@
 //! All tests are `#[ignore]` — run with `uv run test --full` or
 //! `soldr cargo test -p zccache-depgraph --test stress_test -- --ignored`.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use std::sync::Arc;

--- a/crates/zccache/tests/depgraph_stress_integration_test.rs
+++ b/crates/zccache/tests/depgraph_stress_integration_test.rs
@@ -3,7 +3,13 @@
 //! All tests are `#[ignore]` — run with `uv run test --full` or
 //! `soldr cargo test -p zccache-depgraph --test stress_test -- --ignored`.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::collections::HashSet;
 use std::path::Path;

--- a/crates/zccache/tests/embedded_service_test.rs
+++ b/crates/zccache/tests/embedded_service_test.rs
@@ -3,7 +3,13 @@
 //! The service-shape test below stays behind `cfg(any())` until the MVP API is
 //! fully wired into durable audit emission and limit enforcement.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 #[test]
 #[ignore = "documentation guard only; embedded public API is not exported yet"]

--- a/crates/zccache/tests/fingerprint_concurrent.rs
+++ b/crates/zccache/tests/fingerprint_concurrent.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 mod common;
 

--- a/crates/zccache/tests/fingerprint_edge_cases.rs
+++ b/crates/zccache/tests/fingerprint_edge_cases.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 mod common;
 

--- a/crates/zccache/tests/fingerprint_end_to_end.rs
+++ b/crates/zccache/tests/fingerprint_end_to_end.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 mod common;
 

--- a/crates/zccache/tests/fingerprint_glob_scan.rs
+++ b/crates/zccache/tests/fingerprint_glob_scan.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 mod common;
 

--- a/crates/zccache/tests/fingerprint_stress.rs
+++ b/crates/zccache/tests/fingerprint_stress.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 mod common;
 

--- a/crates/zccache/tests/fscache_persistence_perf_test.rs
+++ b/crates/zccache/tests/fscache_persistence_perf_test.rs
@@ -22,7 +22,13 @@
 //!    restored entry, this fails — that would silently revert the
 //!    warm-side perf win.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::fs;
 use std::time::{Duration, Instant, SystemTime};

--- a/crates/zccache/tests/ipc_timeout.rs
+++ b/crates/zccache/tests/ipc_timeout.rs
@@ -12,7 +12,13 @@
 //!    the timeout is reserved for the rare "alive but stuck" failure
 //!    mode.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::time::{Duration, Instant};
 

--- a/crates/zccache/tests/perf_bench/c_project.rs
+++ b/crates/zccache/tests/perf_bench/c_project.rs
@@ -1,6 +1,12 @@
 //! Synthetic C project generation + bare/sccache/zccache C compile helpers.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use std::time::{Duration, Instant};

--- a/crates/zccache/tests/perf_bench/common.rs
+++ b/crates/zccache/tests/perf_bench/common.rs
@@ -10,7 +10,13 @@
 //!   `clear_zccache`, `start_fresh_sccache`, `stop_sccache`.
 //! - Reporting helpers: `median`, `fmt_dur`, `print_trials*`, `fmt_ratio`.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use std::time::{Duration, Instant};

--- a/crates/zccache/tests/perf_bench/cpp_project.rs
+++ b/crates/zccache/tests/perf_bench/cpp_project.rs
@@ -2,7 +2,13 @@
 //! across bare clang, sccache, and zccache (including a `with_env` variant
 //! used by the sibling-remap benchmarks).
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use std::time::{Duration, Instant};

--- a/crates/zccache/tests/perf_bench/link.rs
+++ b/crates/zccache/tests/perf_bench/link.rs
@@ -2,7 +2,13 @@
 //! sccache / zccache, plus the input-preparation helpers used by the
 //! archive, driver-link, emcc-link, and rust-staticlib-link tests.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use std::time::{Duration, Instant};

--- a/crates/zccache/tests/perf_bench/mod.rs
+++ b/crates/zccache/tests/perf_bench/mod.rs
@@ -8,7 +8,13 @@
 //! Run with: soldr cargo test -p zccache-daemon --test perf_bench_test -- --nocapture --ignored
 
 // Shared helpers (constants, timing, daemon boot, tool finders, etc.)
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 mod common;
 

--- a/crates/zccache/tests/perf_bench/response_file.rs
+++ b/crates/zccache/tests/perf_bench/response_file.rs
@@ -1,7 +1,13 @@
 //! Response-file generation and `_rsp` variants of the single/multi compile
 //! helpers (bare clang, sccache, zccache).
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use std::time::{Duration, Instant};

--- a/crates/zccache/tests/perf_bench/rust_project.rs
+++ b/crates/zccache/tests/perf_bench/rust_project.rs
@@ -1,7 +1,13 @@
 //! Synthetic Rust project generation + rustc / sccache-rustc / zccache-rustc
 //! batch runners (with and without an explicit env vec).
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use std::time::{Duration, Instant};

--- a/crates/zccache/tests/perf_bench/sibling_remap.rs
+++ b/crates/zccache/tests/perf_bench/sibling_remap.rs
@@ -9,7 +9,13 @@
 //! share across sibling roots). zccache is primed from workspace A, then warm
 //! trials measure compiles in workspace B that should hit the sibling cache.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use std::time::Duration;

--- a/crates/zccache/tests/perf_bench/tests_c.rs
+++ b/crates/zccache/tests/perf_bench/tests_c.rs
@@ -1,6 +1,12 @@
 //! C compilation perf benchmark + the always-on C11 regression guard.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use zccache::protocol::{Request, Response};
 

--- a/crates/zccache/tests/perf_bench/tests_cpp.rs
+++ b/crates/zccache/tests/perf_bench/tests_cpp.rs
@@ -1,6 +1,12 @@
 //! C++ warm-cache benchmark: zccache vs sccache vs bare clang++.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use zccache::protocol::{Request, Response};

--- a/crates/zccache/tests/perf_bench/tests_emcc.rs
+++ b/crates/zccache/tests/perf_bench/tests_emcc.rs
@@ -5,7 +5,13 @@
 //! (single-file + multi-file warm-cache compile) and verify path-remap auto
 //! works across sibling git worktrees.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 

--- a/crates/zccache/tests/perf_bench/tests_link.rs
+++ b/crates/zccache/tests/perf_bench/tests_link.rs
@@ -1,7 +1,13 @@
 //! Link/archive benchmarks: bare / sccache / zccache across C archive,
 //! C++ driver-link, Emscripten link, and Rust workspace staticlib link.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 

--- a/crates/zccache/tests/perf_bench/tests_probe_storm.rs
+++ b/crates/zccache/tests/perf_bench/tests_probe_storm.rs
@@ -15,7 +15,13 @@
 //! lands with a perf unit test", no perf-cluster row is added yet —
 //! that comes with the fix.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::time::{Duration, Instant};
 

--- a/crates/zccache/tests/perf_bench/tests_probe_storm_wrapper.rs
+++ b/crates/zccache/tests/perf_bench/tests_probe_storm_wrapper.rs
@@ -22,7 +22,13 @@
 //! over the cached path). The bench also prints per-probe wall-time for
 //! the perf-cluster operator to inspect.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/crates/zccache/tests/perf_bench/tests_response_file.rs
+++ b/crates/zccache/tests/perf_bench/tests_response_file.rs
@@ -1,6 +1,12 @@
 //! Response-file C++ warm-cache benchmark.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::path::Path;
 use zccache::protocol::{Request, Response};

--- a/crates/zccache/tests/perf_bench/tests_rust.rs
+++ b/crates/zccache/tests/perf_bench/tests_rust.rs
@@ -1,6 +1,12 @@
 //! Rust (rustc) warm-cache benchmark: zccache vs sccache vs bare rustc.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::time::Duration;
 use zccache::protocol::{Request, Response};

--- a/crates/zccache/tests/perf_bench/tests_sibling_remap.rs
+++ b/crates/zccache/tests/perf_bench/tests_sibling_remap.rs
@@ -1,6 +1,12 @@
 //! Sibling-workspace `ZCCACHE_PATH_REMAP=auto` benchmarks (C++ and Rust).
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use super::common::{
     dir_size_bytes, end_zccache_session, find_sccache, fmt_bytes, fmt_dur, fmt_ratio, median,

--- a/crates/zccache/tests/perf_bench_test.rs
+++ b/crates/zccache/tests/perf_bench_test.rs
@@ -9,7 +9,13 @@
 //!
 //! Run with: soldr cargo test -p zccache-daemon --test perf_bench_test -- --nocapture --ignored
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 #[path = "perf_bench/mod.rs"]
 mod perf_bench;

--- a/crates/zccache/tests/protocol_v2_roundtrip_test.rs
+++ b/crates/zccache/tests/protocol_v2_roundtrip_test.rs
@@ -25,7 +25,13 @@
 //! (`[patch.crates-io]` → local running-process) surfaces breakage at
 //! `cargo check` time rather than at first runtime decode.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use prost::Message;
 use running_process::broker::protocol_v2::{

--- a/crates/zccache/tests/symbols_stamp_roundtrip.rs
+++ b/crates/zccache/tests/symbols_stamp_roundtrip.rs
@@ -3,7 +3,13 @@
 //! CI workflow relies on — produced by the stamp binary, consumed by
 //! `read_marker_from_path` in the daemon and CLI.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::io::Write;
 use zccache::symbols::marker::{read_marker_from_path, MARKER_SIZE};

--- a/crates/zccache/tests/v2_client_smoke_test.rs
+++ b/crates/zccache/tests/v2_client_smoke_test.rs
@@ -7,7 +7,13 @@
 //! variant fires when no broker is listening — the exact behavior zccache's
 //! eventual v1 → v2 migration will pattern-match on.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use running_process::broker::client_v2::{connect, BrokerV2Error};
 

--- a/crates/zccache/tests/v2_pipe_naming_smoke_test.rs
+++ b/crates/zccache/tests/v2_pipe_naming_smoke_test.rs
@@ -10,7 +10,13 @@
 //! immediately, before zccache's runtime broker integration starts
 //! depending on the bytes.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use running_process::broker::lifecycle::names_v2::v2_program_pipe;
 

--- a/crates/zccache/tests/v2_probe_local_socket_test.rs
+++ b/crates/zccache/tests/v2_probe_local_socket_test.rs
@@ -13,7 +13,13 @@
 //! against the OS. Without (3) a user-supplied env-var value could
 //! crash the daemon's seam-resolution.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use interprocess::local_socket::traits::Listener as _;
 use interprocess::local_socket::ListenerOptions;

--- a/crates/zccache/tests/v2_stress_adversarial_test.rs
+++ b/crates/zccache/tests/v2_stress_adversarial_test.rs
@@ -13,7 +13,13 @@
 //! this file pins the *system* contract under concurrency + bad
 //! inputs that a real production load would actually generate.
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use prost::Message;
 use running_process::broker::lifecycle::names_v2::v2_program_pipe;

--- a/crates/zccache/tests/watcher_stress_test.rs
+++ b/crates/zccache/tests/watcher_stress_test.rs
@@ -3,7 +3,13 @@
 //! These tests are `#[ignore]`d so they don't run during normal `cargo test`.
 //! Run with: `soldr cargo test -p zccache-watcher --test stress_test -- --ignored`
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
 
 use std::fs;
 use std::sync::Arc;


### PR DESCRIPTION
## Summary

Four pre-existing CI failures on main HEAD (`bb0346a`):

1. **rustfmt drift** — 121 files reformatted. Long single-line `#![allow(clippy::..., ...)]` attribute split across multiple lines per rustfmt's preferred shape.
2. **`cargo doc` broken-intra-doc-links** — module docs in `audit_writer.rs` and `compile_trace.rs` referenced `AuditSink::*`, `AuditMode::Summary`, and the std types `OnceLock` / `Instant` / `Write` without enough path context for rustdoc. Rewrote with fully-qualified paths (`crate::audit_writer::AuditSink::*`, `crate::audit::AuditMode::Summary`, `std::{sync::OnceLock, time::Instant, io::Write}`).
3. **embedded.rs tests** — 5 tests panicked with `audit sink requires output_root when mode > Off` because `AuditConfig::default()` is `AuditMode::Normal`. These tests exercise cancellation / runtime-hooks plumbing, not the audit sink, so they now override `audit.mode = AuditMode::Off`. The audit-sink contract itself stays covered by `audit_writer.rs` unit tests with a proper tempdir-backed `output_root`. Production validation is left strict.
4. **arm-musl / x86-musl Check** — `.github/workflows/ci-check-cross.yml` ran bare `rustup target add ${target}`, landing it in the system rustup home. `soldr cargo check` uses the setup-soldr-managed RUSTUP_HOME, so the target was missing at compile time (`error[E0463]: can't find crate for \`core\``). Routed through `soldr rustup target add` so both commands see the same toolchain.

Allocator / mimalloc work is reviewed separately in #948 and is **not** touched here.

## Test plan

- [x] `soldr cargo fmt --all -- --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" soldr cargo doc -p zccache --no-deps` clean
- [x] `soldr cargo test -p zccache --lib embedded` — 12/12 pass (including all 5 previously failing tests)
- [x] `soldr cargo clippy -p zccache --tests --lib -- -D warnings` clean
- [ ] CI green on this PR (esp. Formatting, Documentation, Linux arm-musl + x86-musl Check, and the embedded test surface)