### PR TITLE
chore(build): build fingerprint+watcher wheels via soldr PEP 517 backend

### DIFF
--- a/crates/zccache-fingerprint/pyproject.toml
+++ b/crates/zccache-fingerprint/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["maturin>=1.7"]
-build-backend = "maturin"
+requires = ["soldr>=0.7.98"]
+build-backend = "soldr"
 
 [project]
 name = "zccache-fingerprint"

--- a/crates/zccache-watcher/pyproject.toml
+++ b/crates/zccache-watcher/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["maturin>=1.7"]
-build-backend = "maturin"
+requires = ["soldr>=0.7.98"]
+build-backend = "soldr"
 
 [project]
 name = "zccache-watcher"


### PR DESCRIPTION
Migrates the TWO maturin-built crate packages (crates/zccache-fingerprint, crates/zccache-watcher) to soldr's PEP 517 backend (`requires = ["soldr>=0.7.98"]` / `build-backend = "soldr"`); each `[tool.maturin]` is byte-identical. The root pyproject (setuptools umbrella) is deliberately untouched. Ref zackees/soldr#1264; docs: https://github.com/zackees/soldr#use-soldr-as-your-pep-517-build-backend-instead-of-maturin. Validated: isolated `uv pip install .` with the PyPI soldr 0.7.98 backend builds cleanly on a toolchain-poisoned box (sibling repo run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)