### PR TITLE
fix: single-flight daemon spawn (#952) + expand @rsp before miss attribution (#951) - release 1.12.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.12.14"
+version = "1.12.15"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.12.14"
+version = "1.12.15"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4000,7 +4000,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.12.14"
+version = "1.12.15"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.12.14"
+version = "1.12.15"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.12.14"
+version = "1.12.15"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/crates/zccache/src/cli/commands/daemon.rs
+++ b/crates/zccache/src/cli/commands/daemon.rs
@@ -93,30 +93,51 @@ pub(crate) async fn spawn_and_wait(
 ) -> Result<(), String> {
     let daemon_bin = find_daemon_binary().ok_or("cannot find zccache-daemon binary")?;
     tracing::debug!(?daemon_bin, %endpoint, reason, "spawning daemon");
-    // Record *why* the CLI is about to spawn a daemon so an operator
-    // can correlate each CLI decision with the resulting daemon PID
-    // by parsing the single `daemon-lifecycle.log`. See zccache#323
-    // for the diagnostic gap that motivated this.
+    // Issue #952: single-flight the spawn — same arbiter as the
+    // runtime.rs spawn path. Exactly one client in a cold-start herd
+    // spawns; the rest park on the ready-wait.
+    let spawn_slot = crate::cli::runtime::acquire_spawn_slot();
     let meta = crate::core::lifecycle::client_meta(crate::core::VERSION);
-    crate::core::lifecycle::write_event(
-        crate::core::lifecycle::EVENT_SPAWN_ATTEMPT,
-        serde_json::json!({
-            "reason": reason,
-            "endpoint": endpoint,
-            "daemon_namespace": crate::core::config::daemon_namespace_label(),
-            "client_pid": std::process::id(),
-            // #755 acceptance #4: see runtime.rs for rationale.
-            "client_version": meta["client_version"],
-            "client_binary_path": meta["client_binary_path"],
-        }),
-    );
-    super::super::spawn_daemon(&daemon_bin, endpoint)?;
+    if spawn_slot.is_some() {
+        // Record *why* the CLI is about to spawn a daemon so an operator
+        // can correlate each CLI decision with the resulting daemon PID
+        // by parsing the single `daemon-lifecycle.log`. See zccache#323
+        // for the diagnostic gap that motivated this.
+        crate::core::lifecycle::write_event(
+            crate::core::lifecycle::EVENT_SPAWN_ATTEMPT,
+            serde_json::json!({
+                "reason": reason,
+                "endpoint": endpoint,
+                "daemon_namespace": crate::core::config::daemon_namespace_label(),
+                "client_pid": std::process::id(),
+                // #755 acceptance #4: see runtime.rs for rationale.
+                "client_version": meta["client_version"],
+                "client_binary_path": meta["client_binary_path"],
+            }),
+        );
+        super::super::spawn_daemon(&daemon_bin, endpoint)?;
+    } else {
+        crate::core::lifecycle::write_event(
+            crate::core::lifecycle::EVENT_SPAWN_PARKED,
+            serde_json::json!({
+                "reason": reason,
+                "endpoint": endpoint,
+                "daemon_namespace": crate::core::config::daemon_namespace_label(),
+                "client_pid": std::process::id(),
+                "client_version": meta["client_version"],
+            }),
+        );
+    }
 
     // Adaptive wait keyed on the daemon-lifecycle lockfile PID (issue #673):
     // the previous 100-iteration / 10 s loop expired under thundering-herd
     // builds while individual ERROR_PIPE_BUSY backoffs were still in flight.
     // The shared helper polls past 10 s as long as a daemon owns the lockfile.
-    super::super::wait_for_daemon_ready(endpoint).await?;
+    // The slot guard lives until READY so a late client can't win a
+    // second slot before the daemon binds (#952).
+    let wait_result = super::super::wait_for_daemon_ready(endpoint).await;
+    drop(spawn_slot);
+    wait_result?;
 
     // #755 acceptance #2: emit linked daemon-died + pipe-handover events
     // for the takeover case. Best-effort: if we can't read the new

--- a/crates/zccache/src/cli/runtime.rs
+++ b/crates/zccache/src/cli/runtime.rs
@@ -91,30 +91,55 @@ async fn spawn_and_wait(
     outbound_pid: Option<u32>,
 ) -> Result<(), String> {
     let daemon_bin = find_daemon_binary().ok_or("cannot find zccache-daemon binary")?;
-    // Record *why* the CLI is about to spawn a daemon. Pairs with the
-    // daemon-side "spawn" event so an operator can correlate each CLI
-    // decision with the resulting daemon PID by parsing the single
-    // `daemon-lifecycle.log`. Reasons: initial-start vs. one of the
-    // replaced-* variants. This is the diagnostic gap zccache#323
-    // identified — knowing 5 daemons spawned without knowing why
-    // makes the root cause undebuggable.
+    // Issue #952: single-flight the spawn across a client herd. A
+    // -j16 cold start used to produce 16+ spawn-attempts within
+    // milliseconds — each losing client paid a fork/exec plus lockfile
+    // contention that delayed the winner's bind by seconds. Exactly
+    // one client wins the slot and spawns; the rest park directly on
+    // the ready-wait below.
+    let spawn_slot = acquire_spawn_slot();
     let meta = crate::core::lifecycle::client_meta(crate::core::VERSION);
-    crate::core::lifecycle::write_event(
-        crate::core::lifecycle::EVENT_SPAWN_ATTEMPT,
-        serde_json::json!({
-            "reason": reason,
-            "endpoint": endpoint,
-            "daemon_namespace": crate::core::config::daemon_namespace_label(),
-            "client_pid": std::process::id(),
-            // #755 acceptance #4: distinguishes fbuild's bundled
-            // binary from a PyPI install when both share an endpoint.
-            "client_version": meta["client_version"],
-            "client_binary_path": meta["client_binary_path"],
-        }),
-    );
-    spawn_daemon(&daemon_bin, endpoint)?;
+    if spawn_slot.is_some() {
+        // Record *why* the CLI is about to spawn a daemon. Pairs with the
+        // daemon-side "spawn" event so an operator can correlate each CLI
+        // decision with the resulting daemon PID by parsing the single
+        // `daemon-lifecycle.log`. Reasons: initial-start vs. one of the
+        // replaced-* variants. This is the diagnostic gap zccache#323
+        // identified — knowing 5 daemons spawned without knowing why
+        // makes the root cause undebuggable.
+        crate::core::lifecycle::write_event(
+            crate::core::lifecycle::EVENT_SPAWN_ATTEMPT,
+            serde_json::json!({
+                "reason": reason,
+                "endpoint": endpoint,
+                "daemon_namespace": crate::core::config::daemon_namespace_label(),
+                "client_pid": std::process::id(),
+                // #755 acceptance #4: distinguishes fbuild's bundled
+                // binary from a PyPI install when both share an endpoint.
+                "client_version": meta["client_version"],
+                "client_binary_path": meta["client_binary_path"],
+            }),
+        );
+        spawn_daemon(&daemon_bin, endpoint)?;
+    } else {
+        crate::core::lifecycle::write_event(
+            crate::core::lifecycle::EVENT_SPAWN_PARKED,
+            serde_json::json!({
+                "reason": reason,
+                "endpoint": endpoint,
+                "daemon_namespace": crate::core::config::daemon_namespace_label(),
+                "client_pid": std::process::id(),
+                "client_version": meta["client_version"],
+            }),
+        );
+    }
 
-    wait_for_daemon_ready(endpoint).await?;
+    // The slot guard must survive until the daemon is READY: releasing
+    // right after spawn would let a late-arriving client win a second
+    // slot before the daemon binds its lockfile.
+    let wait_result = wait_for_daemon_ready(endpoint).await;
+    drop(spawn_slot);
+    wait_result?;
 
     // #755 acceptance #2: emit the linked daemon-died + pipe-handover
     // pair so the takeover lineage is reconstructable from a single
@@ -132,6 +157,85 @@ async fn spawn_and_wait(
         }
     }
     Ok(())
+}
+
+/// Issue #952: RAII guard for the single-flight spawn slot. Removes the
+/// slot file on drop so the next cold start can win a fresh slot.
+pub(crate) struct SpawnSlotGuard {
+    path: std::path::PathBuf,
+}
+
+impl Drop for SpawnSlotGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// How long a spawn slot may exist before another client treats it as
+/// abandoned (winner crashed between slot-create and daemon bind).
+/// Generous relative to a healthy spawn (~1-5s) but short enough that a
+/// crashed winner doesn't wedge the herd for long — the parked losers'
+/// ready-wait grace is 10s, so one stale window later a new winner
+/// spawns.
+const SPAWN_SLOT_STALE: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// Issue #952: try to become the one client that spawns the daemon.
+///
+/// Winner: atomically creates `<daemon-lock>.spawn` (`create_new`) and
+/// gets a guard that removes it once the daemon is ready (or the spawn
+/// failed). Losers get `None` and park on the ready-wait. A slot older
+/// than [`SPAWN_SLOT_STALE`] is treated as abandoned and reclaimed.
+/// Fail-open: if the filesystem refuses the arbitration entirely
+/// (permissions, exotic tmpfs), the caller behaves as the winner —
+/// worst case is the pre-#952 thundering herd, never a lost spawn.
+pub(crate) fn acquire_spawn_slot() -> Option<SpawnSlotGuard> {
+    let lock_path = crate::ipc::lock_file_path();
+    let slot_path = std::path::PathBuf::from(format!("{}.spawn", lock_path.display()));
+    acquire_spawn_slot_at(slot_path, SPAWN_SLOT_STALE)
+}
+
+/// Path-parameterized core of [`acquire_spawn_slot`], split out so the
+/// arbitration logic is unit-testable without touching the process-
+/// global endpoint/lockfile config.
+fn acquire_spawn_slot_at(
+    slot_path: std::path::PathBuf,
+    stale_after: std::time::Duration,
+) -> Option<SpawnSlotGuard> {
+    if let Some(parent) = slot_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    for attempt in 0..2 {
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&slot_path)
+        {
+            Ok(mut file) => {
+                use std::io::Write as _;
+                let _ = writeln!(file, "{}", std::process::id());
+                return Some(SpawnSlotGuard { path: slot_path });
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                let stale = std::fs::metadata(&slot_path)
+                    .and_then(|m| m.modified())
+                    .ok()
+                    .and_then(|modified| modified.elapsed().ok())
+                    .is_some_and(|age| age > stale_after);
+                if stale && attempt == 0 {
+                    let _ = std::fs::remove_file(&slot_path);
+                    continue;
+                }
+                return None;
+            }
+            // Unexpected fs error: fail open (spawn without a guard).
+            Err(_) => {
+                return Some(SpawnSlotGuard {
+                    path: std::path::PathBuf::new(),
+                });
+            }
+        }
+    }
+    None
 }
 
 /// Tunables for [`wait_for_daemon_ready_with`]. Defaults match the contract
@@ -728,6 +832,40 @@ mod tests {
         } else {
             "/tmp/zccache-test-issue-673-dead.sock"
         }
+    }
+
+    // -- acquire_spawn_slot_at (issue #952 single-flight arbiter) ----------
+
+    #[test]
+    fn spawn_slot_first_caller_wins_second_parks() {
+        let dir = tempfile::tempdir().unwrap();
+        let slot = dir.path().join("daemon.lock.spawn");
+        let winner = acquire_spawn_slot_at(slot.clone(), Duration::from_secs(20));
+        assert!(winner.is_some(), "first caller must win the slot");
+        assert!(
+            acquire_spawn_slot_at(slot.clone(), Duration::from_secs(20)).is_none(),
+            "second caller must park while the slot is held"
+        );
+        drop(winner);
+        assert!(
+            acquire_spawn_slot_at(slot, Duration::from_secs(20)).is_some(),
+            "slot must be reusable after the winner's guard drops"
+        );
+    }
+
+    #[test]
+    fn spawn_slot_stale_holder_is_reclaimed() {
+        let dir = tempfile::tempdir().unwrap();
+        let slot = dir.path().join("daemon.lock.spawn");
+        std::fs::write(&slot, "12345\n").unwrap();
+        // A zero staleness window means any existing slot is abandoned;
+        // sleep a few ms so the file's mtime age is strictly positive.
+        std::thread::sleep(Duration::from_millis(20));
+        let reclaimed = acquire_spawn_slot_at(slot, Duration::from_millis(0));
+        assert!(
+            reclaimed.is_some(),
+            "an abandoned slot older than the staleness window must be reclaimed"
+        );
     }
 
     // -- classify_wait_tick (pure decision function) -----------------------

--- a/crates/zccache/src/core/lifecycle.rs
+++ b/crates/zccache/src/core/lifecycle.rs
@@ -33,7 +33,8 @@
 //!
 //! | event | who writes it | meaning | key fields |
 //! |---|---|---|---|
-//! | `spawn-attempt` | CLI | about to spawn a daemon (or was about to, and lost the race) | `reason`, `endpoint`, `client_pid`, `client_version`, `client_binary_path` |
+//! | `spawn-attempt` | CLI | won the single-flight spawn slot and is spawning a daemon (#952) | `reason`, `endpoint`, `client_pid`, `client_version`, `client_binary_path` |
+//! | `spawn-parked` | CLI | wanted a daemon but another client holds the spawn slot; parking on ready-wait (#952) | `reason`, `endpoint`, `client_pid`, `client_version` |
 //! | `spawn` | daemon | bound the endpoint, server up | `endpoint`, `version`, `idle_timeout`, `client_version`, `client_binary_path` |
 //! | `died-idle` | daemon | exiting after idle timeout | `reason`, `idle_secs`, `idle_timeout_secs` |
 //! | `died-shutdown` | daemon | got a `Shutdown` request | `reason`, `uptime_secs` |
@@ -75,6 +76,11 @@ use super::NormalizedPath;
 /// constants exist for the call sites we ship today.
 pub const EVENT_SPAWN: &str = "spawn";
 pub const EVENT_SPAWN_ATTEMPT: &str = "spawn-attempt";
+/// Issue #952: the client wanted a daemon but another client already
+/// holds the single-flight spawn slot; this one parks on the
+/// ready-wait instead of spawning. Pairs with exactly one
+/// `spawn-attempt` per cold start.
+pub const EVENT_SPAWN_PARKED: &str = "spawn-parked";
 pub const EVENT_DIED_IDLE: &str = "died-idle";
 pub const EVENT_DIED_SHUTDOWN: &str = "died-shutdown";
 pub const EVENT_VERSION_MISMATCH: &str = "version_mismatch";

--- a/crates/zccache/src/daemon/server/connection.rs
+++ b/crates/zccache/src/daemon/server/connection.rs
@@ -754,7 +754,22 @@ pub(super) fn compile_miss_reason(
     if outcome != "miss" || default_reason != Some(miss_reason::UNKNOWN) {
         return default_reason;
     }
-    match crate::compiler::parse_invocation(&ctx.compiler, &ctx.args) {
+    // Issue #951: expand `@response-file` args before parsing. The
+    // compile pipeline expands them (`expand_args_cached`) and caches
+    // through them, but this attribution path used to parse the RAW
+    // argv — for fbuild-style invocations (`g++ @args.rsp`) the parser
+    // then saw no `-c`/no source and stamped every such miss
+    // `uncacheable_input`, hiding the real reason (observed: 117/117
+    // mislabeled on a dev machine while the second pass served hits).
+    // If the response file is already gone by journal time, keep the
+    // honest `unknown` default instead of guessing uncacheable.
+    let base_dir = std::path::Path::new(&ctx.cwd);
+    let expanded =
+        match crate::compiler::response_file::expand_response_files_in(&ctx.args, base_dir) {
+            Ok(expanded) => expanded,
+            Err(_) => return default_reason,
+        };
+    match crate::compiler::parse_invocation(&ctx.compiler, &expanded) {
         crate::compiler::ParsedInvocation::NonCacheable { .. } => {
             Some(miss_reason::UNCACHEABLE_INPUT)
         }
@@ -983,6 +998,55 @@ mod self_profile_tests {
     #[test]
     fn cacheable_miss_keeps_default_reason() {
         let ctx = test_journal_ctx("rustc", &["--crate-name", "demo", "src/lib.rs"]);
+        assert_eq!(
+            compile_miss_reason(&ctx, "miss", Some(miss_reason::UNKNOWN)),
+            Some(miss_reason::UNKNOWN)
+        );
+    }
+
+    // Issue #951: fbuild-style invocations pass the whole cacheable
+    // argv through `@file.rsp`. Attribution must expand the response
+    // file before parsing — parsing the raw `@arg` mislabels every
+    // such miss as `uncacheable_input`.
+    #[test]
+    fn rsp_cacheable_miss_keeps_default_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("file1.cpp");
+        std::fs::write(&src, "int f() { return 1; }\n").unwrap();
+        let rsp = dir.path().join("compile_1.rsp");
+        std::fs::write(&rsp, format!("-c\n{}\n-o\nfile1.o\n-O2\n", src.display())).unwrap();
+        let arg = format!("@{}", rsp.display());
+        let mut ctx = test_journal_ctx("/usr/bin/g++", &[arg.as_str()]);
+        ctx.cwd = dir.path().to_string_lossy().into_owned();
+        assert_eq!(
+            compile_miss_reason(&ctx, "miss", Some(miss_reason::UNKNOWN)),
+            Some(miss_reason::UNKNOWN),
+            "a cacheable compile behind @rsp must not be stamped uncacheable_input"
+        );
+    }
+
+    // Issue #951: a genuinely uncacheable invocation stays attributed
+    // even when it arrives through a response file.
+    #[test]
+    fn rsp_preprocess_only_miss_is_attributed_uncacheable() {
+        let dir = tempfile::tempdir().unwrap();
+        let rsp = dir.path().join("preprocess.rsp");
+        std::fs::write(&rsp, "-E\nfile1.cpp\n").unwrap();
+        let arg = format!("@{}", rsp.display());
+        let mut ctx = test_journal_ctx("/usr/bin/g++", &[arg.as_str()]);
+        ctx.cwd = dir.path().to_string_lossy().into_owned();
+        assert_eq!(
+            compile_miss_reason(&ctx, "miss", Some(miss_reason::UNKNOWN)),
+            Some(miss_reason::UNCACHEABLE_INPUT)
+        );
+    }
+
+    // Issue #951: fbuild deletes the rsp right after the compile; if it
+    // is already gone at journal time, keep the honest `unknown`
+    // default rather than guessing uncacheable.
+    #[test]
+    fn rsp_missing_at_journal_time_keeps_default_reason() {
+        let ctx = test_journal_ctx("/usr/bin/g++", &["@/nonexistent/gone.rsp"]);
         assert_eq!(
             compile_miss_reason(&ctx, "miss", Some(miss_reason::UNKNOWN)),
             Some(miss_reason::UNKNOWN)


### PR DESCRIPTION
Closes #951. Closes #952. Part of the reopened [soldr#1286](https://github.com/zackees/soldr/issues/1286) follow-up scope.

## #951 — @rsp misses mislabeled `uncacheable_input`

`compile_miss_reason` parsed the RAW argv, so fbuild-style invocations (`g++ @args.rsp`) always looked like 'no -c / no source' → every such miss stamped `uncacheable_input` (117/117 mislabeled on the reporting dev machine) even though the compile pipeline expands the rsp and caches fine. Attribution now expands response files first; a deleted-by-journal-time rsp keeps the honest `unknown` default.

**Before/after (docker linux, 8 C++ files compiled via fbuild-shape @rsp, two passes):**

| | pass 1 (cold) | pass 2 (warm) | pass-1 miss_reason |
|---|---|---|---|
| before (main) | 12.8s, 8 miss | 0.19s, **8 hit** | 8× `uncacheable_input` (false) |
| after (fix) | 23.8s*, 8 miss | 0.56s, **8 hit** | 8× `unknown` (honest) |

\*debug-build container timing noise; the caching behavior (all-hit warm pass) is identical — the fix is attribution correctness, which is what made the original 117-compile mystery undiagnosable.

New tests: `rsp_cacheable_miss_keeps_default_reason`, `rsp_preprocess_only_miss_is_attributed_uncacheable`, `rsp_missing_at_journal_time_keeps_default_reason`.

## #952 — spawn thundering-herd

A `-j16` cold start produced 16 `spawn-attempt`s within milliseconds and forked 4–6 daemon processes per burst (losers died on the bind). The spawn is now single-flighted via an O_EXCL `<daemon-lock>.spawn` slot: one winner spawns, the rest emit the new `spawn-parked` lifecycle event and park on the ready-wait. Slot guard lives until READY; slots older than 20s are reclaimed; fs errors fail open (worst case = the old herd, never a lost spawn). Wired into both spawn paths (`cli/runtime.rs` + `cli/commands/daemon.rs`).

**Before/after (docker linux, 16-way cold burst, same-container A/B ×2):**

| round | spawn-attempts | daemons forked | burst wall |
|---|---|---|---|
| before r1 | 16 | 4 | 18.2s |
| before r2 | 16 | 6 | 36.8s |
| **after r1** | **1** (+15 parked) | **1** | **13.9s** |
| **after r2** | **1** (+15 parked) | **1** | **13.8s** |

New tests: `spawn_slot_first_caller_wins_second_parks`, `spawn_slot_stale_holder_is_reclaimed`.

## Validation

Docker-linux harness: full lib suite **1895 passed / 0 failed**, `cargo fmt --check` + `cargo clippy --lib -- -D warnings` green. Version bumped 1.12.14 -> 1.12.15 (+ lockfile) so the merge auto-releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)