### PR TITLE
fix(#955): daemon no longer wedges on large-crate full-codegen; client fails fast on detected wedge

### DIFF
--- a/crates/zccache/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache/src/cli/commands/wrap/ipc.rs
@@ -76,12 +76,21 @@ pub(super) async fn cmd_compile(
                     cmd_compile_ephemeral(endpoint, compiler.as_path(), args, cwd, client_env).await
                 }
                 WedgeAction::EscalateKill | WedgeAction::EscalateKillProbeError => {
+                    // The daemon is genuinely wedged: it missed the
+                    // per-request wedge budget AND failed the follow-up
+                    // responsiveness probe. Per the fail-fast policy (#955)
+                    // a *detected* wedge fails IMMEDIATELY — we do not mask
+                    // it with a slow uncached retry/fallback. Kill the
+                    // wedged daemon so the next invocation starts fresh,
+                    // then surface the failure now. (The root-cause daemon
+                    // fix keeps this path from triggering in normal builds.)
                     eprintln!(
-                        "zccache[warn][W]: daemon at {endpoint} appears wedged \
-                         (probe failed within budget); recovering — issue #666"
+                        "zccache[err][W]: daemon at {endpoint} is wedged \
+                         (missed wedge budget + failed probe); killing it and \
+                         failing immediately — issue #955"
                     );
                     stop_stale_daemon(endpoint).await;
-                    cmd_compile_ephemeral(endpoint, compiler.as_path(), args, cwd, client_env).await
+                    ExitCode::FAILURE
                 }
             }
         }

--- a/crates/zccache/src/daemon/process.rs
+++ b/crates/zccache/src/daemon/process.rs
@@ -67,6 +67,41 @@ fn is_truthy(value: &str) -> bool {
     )
 }
 
+/// Run a CPU/IO-heavy **synchronous** section without stalling the async
+/// runtime (issue #955 — daemon-side root cause).
+///
+/// The miss-store tail of a full-codegen compile does two size-scaling
+/// synchronous things on the tokio worker thread: a rayon parallel hash of
+/// the source + the whole extern set, and the artifact persist (a large
+/// `.rlib` copy when it can't be hardlinked cross-volume). For the
+/// consolidated `zccache` crate the extern set is the entire workspace, so
+/// each miss parks a worker for a long time. Under several concurrent
+/// `cargo test` invocations this can park *every* worker at once — the
+/// runtime then can't drive the reply I/O for any in-flight compile, so
+/// the daemon "never responds" (0 rustc alive, since rustc already exited)
+/// and the client wedges. That is the #955 wedge.
+///
+/// On the multi-thread daemon runtime, [`tokio::task::block_in_place`] tells
+/// tokio to spin up a replacement worker for the duration of `f`, so the
+/// runtime keeps servicing other compiles' I/O (including sending their
+/// replies) while this section runs. On a current-thread runtime (the
+/// embedded host path) `block_in_place` would panic, so `f` runs inline —
+/// the pre-#955 status quo, no worse than before.
+pub(crate) fn run_cpu_blocking<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let is_multi_thread = matches!(
+        tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()),
+        Ok(tokio::runtime::RuntimeFlavor::MultiThread)
+    );
+    if is_multi_thread {
+        tokio::task::block_in_place(f)
+    } else {
+        f()
+    }
+}
+
 /// Priority policy for compiler/linker child processes owned by the daemon.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) enum CompilePriority {
@@ -906,6 +941,30 @@ unsafe impl Sync for WindowsJob {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── run_cpu_blocking (#955) ──
+
+    #[test]
+    fn run_cpu_blocking_no_runtime_runs_inline() {
+        // Outside any tokio runtime the section runs inline and returns
+        // the closure's value.
+        assert_eq!(run_cpu_blocking(|| 40 + 2), 42);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_cpu_blocking_multi_thread_ok() {
+        // On the daemon's real (multi-thread) runtime this takes the
+        // block_in_place branch and must still return the value.
+        assert_eq!(run_cpu_blocking(|| "ok"), "ok");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_cpu_blocking_current_thread_does_not_panic() {
+        // Regression guard: block_in_place panics on a current-thread
+        // runtime (the embedded-host path), so run_cpu_blocking MUST fall
+        // back to running inline there rather than aborting the compile.
+        assert_eq!(run_cpu_blocking(|| 123), 123);
+    }
 
     #[test]
     fn parse_compile_priority_values() {

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -385,7 +385,11 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         None => pre_hashed.unwrap_or_default(),
     };
     let pre_hashed_count = hash_map.len();
-    {
+    // #955: run the parallel hash under block_in_place so a large extern
+    // set (the whole workspace, for a consolidated crate) doesn't park the
+    // tokio worker and stall the runtime under concurrent misses. See
+    // process::run_cpu_blocking.
+    crate::daemon::process::run_cpu_blocking(|| {
         use rayon::prelude::*;
         // Build the post-compile path list. When the pre-hash phase
         // populated `hash_map` (either rustc's `pre_hash_task` or the
@@ -441,7 +445,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
                 ),
             );
         }
-    }
+    });
     let hash_all_ns = t_hash.elapsed().as_nanos() as u64;
 
     let MissArtifactStoreStats {
@@ -459,7 +463,11 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         artifact_index_build_ns,
         artifact_index_persist_ns,
         artifact_memory_insert_ns,
-    } = store_miss_artifact(MissArtifactStoreRequest {
+    // #955: the miss persist (a large rustc `.rlib` copy when it can't be
+    // hardlinked cross-volume) is synchronous; run it under block_in_place
+    // so it doesn't park the tokio worker. See process::run_cpu_blocking.
+    } = crate::daemon::process::run_cpu_blocking(|| {
+        store_miss_artifact(MissArtifactStoreRequest {
         state_arc,
         sid,
         context_key,
@@ -474,6 +482,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         stderr: &stderr,
         exit_code,
         compile_start,
+        })
     });
 
     // Record miss phase profile


### PR DESCRIPTION
Closes #955. Part of meta #956 (Theme B).

## Root cause (daemon)
A full-codegen compile **miss** runs two size-scaling **synchronous** sections on the tokio worker thread: a rayon parallel hash of source + the whole extern set, and the artifact persist (large `.rlib` copy when it can't be hardlinked cross-volume). For the consolidated `zccache` crate the extern set is the entire workspace, so each miss parks a worker. Under several concurrent `cargo test` invocations this parks **every** worker at once — the runtime can't drive reply I/O for any in-flight compile, so the daemon 'never responds' (**0 rustc alive**, since rustc already exited) and clients wedge. That is the #955 symptom.

**Fix:** `process::run_cpu_blocking` — `block_in_place` on the multi-thread daemon runtime (tokio spins up a replacement worker so other compiles' replies keep flowing), inline on a current-thread runtime (embedded host, where `block_in_place` would panic). Wraps the rayon hash and the `store_miss_artifact` persist.

## Client: fail fast on a *detected* wedge
When the #753 probe confirms a genuinely wedged daemon (missed the wedge budget **and** failed the responsiveness probe), the wrapper now kills it and returns `FAILURE` **immediately** — it no longer masks the wedge with a slow uncached ephemeral retry. Fast, loud failure beats a silently degraded build; the root-cause fix keeps this path from triggering in normal builds. Burst-load (daemon answered the probe) still recovers via the ephemeral path, unchanged.

## Tests
- `cargo clippy -p zccache --all-targets -- -D warnings`: clean.
- `run_cpu_blocking` unit tests: no-runtime inline, multi-thread block_in_place, **current-thread no-panic** (embedded regression guard).
- `soldr --no-cache cargo test -p zccache --lib -- daemon::process::tests cli::commands::wrap daemon::server::tests::deferred_cold_path daemon::server::tests::artifact_store_deferred`: **76 passed / 0 failed**.

Note: per PERF.md the daemon-side change is normally perf-cluster-gated; validated locally at the maintainer's direction for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)