### PR TITLE
feat(rust-plan): lift GHA save/restore into the library + release 1.12.14 (#960)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.12.13"
+version = "1.12.14"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4265,7 +4265,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.12.13"
+version = "1.12.14"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4274,7 +4274,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.12.13"
+version = "1.12.14"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.12.13"
+version = "1.12.14"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.12.13"
+version = "1.12.14"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/crates/zccache/src/artifact/mod.rs
+++ b/crates/zccache/src/artifact/mod.rs
@@ -14,14 +14,16 @@ pub use kv::{
     is_valid_namespace, Key, KvError, KvResult, KvStore, INLINE_THRESHOLD, MAX_VALUE_BYTES,
 };
 pub use rust_plan::{
-    restore_rust_plan_layered_local, restore_rust_plan_local, rust_plan_bundle_dir,
-    rust_plan_cache_key, save_rust_plan_delta_local, save_rust_plan_local,
-    RustArtifactBundleLayerKind, RustArtifactBundleManifest, RustArtifactClass, RustArtifactPlanV1,
-    RustBundledArtifact, RustPlanArtifactEffectiveness, RustPlanCompatibility, RustPlanError,
+    restore_rust_plan_gha, restore_rust_plan_layered_local, restore_rust_plan_local,
+    rust_plan_bundle_dir, rust_plan_cache_key, rust_plan_gha_version, save_rust_plan_delta_local,
+    save_rust_plan_gha, save_rust_plan_local, RustArtifactBundleLayerKind,
+    RustArtifactBundleManifest, RustArtifactClass, RustArtifactPlanV1, RustBundledArtifact,
+    RustPlanArtifactEffectiveness, RustPlanCompatibility, RustPlanError, RustPlanGhaError,
     RustPlanInputs, RustPlanMode, RustPlanOperation, RustPlanPackages, RustPlanSkippedSample,
     RustPlanSummary, RustToolchainIdentity, RUST_ARTIFACT_CACHE_SCHEMA_VERSION,
     RUST_ARTIFACT_PLAN_SCHEMA_VERSION,
 };
+pub(crate) use rust_plan::{tar_gz_decode, tar_gz_encode};
 pub use store::{ArtifactIndex, ArtifactStore};
 
 use crate::core::NormalizedPath;

--- a/crates/zccache/src/artifact/rust_plan.rs
+++ b/crates/zccache/src/artifact/rust_plan.rs
@@ -1,16 +1,19 @@
 //! Plan-driven Rust target artifact save/restore.
 
+mod gha;
 mod local;
 mod manifest;
 mod proto;
 mod schema;
 mod selection;
 mod summary;
+mod targz;
 mod threads;
 
 #[cfg(test)]
 mod tests;
 
+pub use gha::{restore_rust_plan_gha, rust_plan_gha_version, save_rust_plan_gha, RustPlanGhaError};
 pub use local::{
     restore_rust_plan_layered_local, restore_rust_plan_local, rust_plan_bundle_dir,
     rust_plan_cache_key, save_rust_plan_delta_local, save_rust_plan_local,
@@ -25,6 +28,7 @@ pub use summary::{
     RustPlanArtifactEffectiveness, RustPlanCompatibility, RustPlanOperation, RustPlanSkippedSample,
     RustPlanSummary,
 };
+pub(crate) use targz::{tar_gz_decode, tar_gz_encode};
 
 #[cfg(test)]
 use local::{

--- a/crates/zccache/src/artifact/rust_plan/README.md
+++ b/crates/zccache/src/artifact/rust_plan/README.md
@@ -1,0 +1,27 @@
+# rust_plan
+
+Plan-driven Rust target artifact save/restore for `zccache-artifact`.
+
+A `RustArtifactPlanV1` describes a Cargo target directory (workspace root, target
+dir, toolchain, inputs, packages). This module bundles the selected artifacts,
+computes a stable cache key, and saves/restores them against a backend.
+
+## Modules
+
+- `schema` — `RustArtifactPlanV1` and related plan/config types; schema versions.
+- `selection` — classify and select which target-dir files belong in a bundle.
+- `manifest` — bundle manifest (`RustArtifactBundleManifest`) read/write + safe join.
+- `local` — local, delta, and layered save/restore execution + cache-key/identity hashing.
+- `summary` — `RustPlanSummary` operation result (counts, backend identity, skips).
+- `threads` — tar thread-count resolution for bundling.
+- `targz` — synchronous tar+gzip codec used by the GHA backend (single home; the
+  CLI's async `targz` wrappers re-export these).
+- `gha` — in-process GitHub Actions cache save/restore (`save_rust_plan_gha` /
+  `restore_rust_plan_gha`) and `RustPlanGhaError`. Consumed by soldr#1368.
+
+## Public entry points
+
+Re-exported from `crate::artifact`: `save_rust_plan_local`, `restore_rust_plan_local`,
+`save_rust_plan_delta_local`, `restore_rust_plan_layered_local`, `rust_plan_cache_key`,
+`rust_plan_bundle_dir`, `save_rust_plan_gha`, `restore_rust_plan_gha`,
+`rust_plan_gha_version`, plus the schema/manifest/summary types.

--- a/crates/zccache/src/artifact/rust_plan/gha.rs
+++ b/crates/zccache/src/artifact/rust_plan/gha.rs
@@ -1,0 +1,172 @@
+//! In-process Rust-plan save/restore against the GitHub Actions cache backend.
+//!
+//! This is the CLI-independent library API lifted out of
+//! `cli/commands/rust_plan.rs` (issue #960). It is callable in-process so that
+//! soldr (soldr#1368) can drive GHA rust-plan save/restore without shelling out
+//! to the `zccache rust-plan --backend gha` subcommand.
+//!
+//! The public surface is `save_rust_plan_gha`, `restore_rust_plan_gha`, and
+//! `rust_plan_gha_version`, all re-exported from `crate::artifact`.
+
+use std::path::Path;
+
+use crate::gha::{GhaCache, GhaError};
+
+use super::local::{
+    restore_rust_plan_local, rust_plan_bundle_dir, rust_plan_cache_key, save_rust_plan_local,
+};
+use super::schema::RustArtifactPlanV1;
+use super::summary::RustPlanSummary;
+use super::targz::{tar_gz_decode, tar_gz_encode};
+
+/// Library-native error for the Rust-plan GHA backend.
+///
+/// Distinguishes a not-configured backend (`GhaError::NotAvailable`) from a
+/// genuine save/restore failure so callers can decide whether to fall back to
+/// the local backend. Intentionally free of any CLI types.
+#[derive(Debug)]
+pub enum RustPlanGhaError {
+    /// The GHA cache backend is not available (not running inside GitHub
+    /// Actions, or the cache environment variables are unset).
+    Unavailable(String),
+    /// The GHA save/restore operation failed.
+    Failure(String),
+}
+
+impl RustPlanGhaError {
+    /// The human-readable message describing the failure.
+    #[must_use]
+    pub fn message(&self) -> &str {
+        match self {
+            Self::Unavailable(message) | Self::Failure(message) => message,
+        }
+    }
+
+    /// Whether this error means the backend is unavailable (vs. a hard failure).
+    #[must_use]
+    pub fn is_unavailable(&self) -> bool {
+        matches!(self, Self::Unavailable(_))
+    }
+}
+
+impl std::fmt::Display for RustPlanGhaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unavailable(message) => write!(f, "GHA cache backend unavailable: {message}"),
+            Self::Failure(message) => write!(f, "GHA cache backend failure: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for RustPlanGhaError {}
+
+fn gha_error(err: GhaError) -> RustPlanGhaError {
+    let message = err.to_string();
+    if matches!(err, GhaError::NotAvailable) {
+        RustPlanGhaError::Unavailable(message)
+    } else {
+        RustPlanGhaError::Failure(message)
+    }
+}
+
+/// Run blocking Rust-plan work on Tokio's blocking pool, surfacing failures as
+/// `RustPlanGhaError::Failure`.
+async fn run_rust_plan_backend_blocking<F, T>(work: F) -> Result<T, RustPlanGhaError>
+where
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(work)
+        .await
+        .map_err(|err| RustPlanGhaError::Failure(format!("blocking rust-plan task failed: {err}")))?
+        .map_err(RustPlanGhaError::Failure)
+}
+
+/// GHA cache version string for a Rust-plan cache key.
+#[must_use]
+pub fn rust_plan_gha_version(cache_key: &str) -> String {
+    GhaCache::version_hash(&["zccache-rust-plan-v2-protobuf", cache_key])
+}
+
+/// Restore a Rust-plan bundle from the GitHub Actions cache into `cache_dir`.
+///
+/// On a cache miss, falls back to a local restore and records the miss in the
+/// returned summary. Returns `RustPlanGhaError::Unavailable` when the GHA
+/// backend is not configured.
+///
+/// Consumed in-process by soldr (soldr#1368).
+pub async fn restore_rust_plan_gha(
+    plan: &RustArtifactPlanV1,
+    cache_dir: &Path,
+) -> Result<RustPlanSummary, RustPlanGhaError> {
+    let cache_key = rust_plan_cache_key(plan);
+    let version = rust_plan_gha_version(&cache_key);
+    let cache = GhaCache::from_env().map_err(gha_error)?;
+    let Some(data) = cache
+        .restore(&cache_key, &version)
+        .await
+        .map_err(gha_error)?
+    else {
+        let plan = plan.clone();
+        let cache_dir = cache_dir.to_path_buf();
+        let mut summary = run_rust_plan_backend_blocking(move || {
+            restore_rust_plan_local(&plan, &cache_dir).map_err(|err| err.to_string())
+        })
+        .await?;
+        summary.set_backend("gha", Some(cache_key), Some(version));
+        summary.record_skip("<gha-cache>", "backend_cache_miss");
+        return Ok(summary);
+    };
+
+    let plan = plan.clone();
+    let cache_dir = cache_dir.to_path_buf();
+    run_rust_plan_backend_blocking(move || {
+        let bundle_dir = rust_plan_bundle_dir(&cache_dir, &cache_key);
+        if bundle_dir.exists() {
+            std::fs::remove_dir_all(&bundle_dir).map_err(|err| err.to_string())?;
+        }
+        let bundle_parent = bundle_dir
+            .parent()
+            .ok_or_else(|| "invalid rust-plan bundle path".to_string())?;
+        std::fs::create_dir_all(bundle_parent).map_err(|err| err.to_string())?;
+        tar_gz_decode(&data, bundle_parent).map_err(|err| err.to_string())?;
+        let mut summary =
+            restore_rust_plan_local(&plan, &cache_dir).map_err(|err| err.to_string())?;
+        summary.set_backend("gha", Some(cache_key), Some(version));
+        Ok(summary)
+    })
+    .await
+}
+
+/// Save a Rust-plan bundle from `cache_dir` into the GitHub Actions cache.
+///
+/// Runs a local save first (to produce the bundle), then uploads the tar.gz to
+/// the GHA cache. Returns `RustPlanGhaError::Unavailable` when the GHA backend
+/// is not configured.
+///
+/// Consumed in-process by soldr (soldr#1368).
+pub async fn save_rust_plan_gha(
+    plan: &RustArtifactPlanV1,
+    cache_dir: &Path,
+) -> Result<RustPlanSummary, RustPlanGhaError> {
+    let plan = plan.clone();
+    let cache_dir = cache_dir.to_path_buf();
+    let (summary, data) = run_rust_plan_backend_blocking(move || {
+        let summary = save_rust_plan_local(&plan, &cache_dir).map_err(|err| err.to_string())?;
+        let cache_key = summary.cache_key.clone();
+        let bundle_dir = rust_plan_bundle_dir(&cache_dir, &cache_key);
+        let data = tar_gz_encode(&bundle_dir).map_err(|err| err.to_string())?;
+        Ok((summary, data))
+    })
+    .await?;
+    let cache_key = summary.cache_key.clone();
+    let version = rust_plan_gha_version(&cache_key);
+    let cache = GhaCache::from_env().map_err(gha_error)?;
+    cache
+        .save(&cache_key, &version, &data)
+        .await
+        .map_err(gha_error)?;
+    let mut summary = summary;
+    summary.set_backend("gha", Some(cache_key), Some(version));
+    Ok(summary)
+}

--- a/crates/zccache/src/artifact/rust_plan/targz.rs
+++ b/crates/zccache/src/artifact/rust_plan/targz.rs
@@ -1,0 +1,35 @@
+//! Synchronous tar+gzip helpers for Rust-plan GHA bundle transport.
+//!
+//! These are the single home for the blocking tar/gzip codec used by the
+//! Rust-plan GHA backend. The CLI's async `targz` wrappers re-export these so
+//! there is exactly one implementation.
+
+use std::path::Path;
+
+/// Create a tar.gz archive from a directory path.
+pub(crate) fn tar_gz_encode(src: &Path) -> Result<Vec<u8>, std::io::Error> {
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+
+    let buf = Vec::new();
+    let enc = GzEncoder::new(buf, Compression::fast());
+    let mut tar = tar::Builder::new(enc);
+    // Use the last component of the path as the archive prefix so that
+    // extraction recreates the directory structure relative to the target.
+    let prefix = src
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| ".".to_string());
+    tar.append_dir_all(&prefix, src)?;
+    let enc = tar.into_inner()?;
+    enc.finish()
+}
+
+/// Extract a tar.gz archive into a destination directory.
+pub(crate) fn tar_gz_decode(data: &[u8], dest: &Path) -> Result<(), std::io::Error> {
+    use flate2::read::GzDecoder;
+
+    let dec = GzDecoder::new(data);
+    let mut archive = tar::Archive::new(dec);
+    archive.unpack(dest)
+}

--- a/crates/zccache/src/cli/commands/rust_plan.rs
+++ b/crates/zccache/src/cli/commands/rust_plan.rs
@@ -1,18 +1,17 @@
 //! `zccache rust-plan` subcommands and helpers.
 
 use crate::artifact::{
-    restore_rust_plan_layered_local, restore_rust_plan_local, rust_plan_bundle_dir,
-    rust_plan_cache_key, save_rust_plan_delta_local, save_rust_plan_local, RustArtifactPlanV1,
-    RustPlanError, RustPlanOperation, RustPlanSummary,
+    restore_rust_plan_gha, restore_rust_plan_layered_local, restore_rust_plan_local,
+    rust_plan_gha_version, save_rust_plan_delta_local, save_rust_plan_gha, save_rust_plan_local,
+    RustArtifactPlanV1, RustPlanError, RustPlanGhaError, RustPlanOperation, RustPlanSummary,
 };
 use crate::core::NormalizedPath;
-use crate::gha::{GhaCache, GhaError};
+use crate::gha::GhaCache;
 use std::path::Path;
 use std::process::ExitCode;
 
 use super::args::{RustPlanBackendArg, RustPlanCommands};
 use super::session::query_session_stats_json;
-use super::targz::{tar_gz_decode, tar_gz_encode};
 use super::util::{absolute_path, format_bytes, resolve_endpoint};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,18 +45,6 @@ impl RustPlanRuntimeError {
     pub(crate) fn message(&self) -> &str {
         match self {
             Self::Backend { message, .. } => message,
-        }
-    }
-
-    pub(crate) fn with_kind(self, kind: RustPlanRuntimeErrorKind) -> Self {
-        match self {
-            Self::Backend {
-                backend, message, ..
-            } => Self::Backend {
-                backend,
-                kind,
-                message,
-            },
         }
     }
 }
@@ -315,22 +302,6 @@ async fn save_rust_plan_delta_local_async(
     .await
 }
 
-async fn run_rust_plan_backend_blocking<F, T>(
-    backend: RustPlanBackendArg,
-    work: F,
-) -> Result<T, RustPlanRuntimeError>
-where
-    F: FnOnce() -> Result<T, String> + Send + 'static,
-    T: Send + 'static,
-{
-    tokio::task::spawn_blocking(work)
-        .await
-        .map_err(|err| {
-            rust_plan_backend_failure(backend, format!("blocking rust-plan task failed: {err}"))
-        })?
-        .map_err(|err| rust_plan_backend_failure(backend, err))
-}
-
 async fn run_rust_plan_restore(
     plan: &RustArtifactPlanV1,
     cache_dir: &Path,
@@ -342,7 +313,9 @@ async fn run_rust_plan_restore(
                 .await
                 .map_err(|err| rust_plan_backend_failure(backend, err.to_string()))
         }
-        RustPlanBackendArg::Gha => restore_rust_plan_gha(plan, cache_dir).await,
+        RustPlanBackendArg::Gha => restore_rust_plan_gha(plan, cache_dir)
+            .await
+            .map_err(map_rust_plan_gha_error),
         RustPlanBackendArg::Auto => unreachable!("auto backend is resolved before execution"),
     }
 }
@@ -358,7 +331,9 @@ async fn run_rust_plan_save(
                 .await
                 .map_err(|err| rust_plan_backend_failure(backend, err.to_string()))
         }
-        RustPlanBackendArg::Gha => save_rust_plan_gha(plan, cache_dir).await,
+        RustPlanBackendArg::Gha => save_rust_plan_gha(plan, cache_dir)
+            .await
+            .map_err(map_rust_plan_gha_error),
         RustPlanBackendArg::Auto => unreachable!("auto backend is resolved before execution"),
     }
 }
@@ -371,86 +346,19 @@ fn resolve_rust_plan_backend(backend: RustPlanBackendArg) -> RustPlanBackendArg 
     }
 }
 
-pub(crate) fn rust_plan_gha_version(cache_key: &str) -> String {
-    GhaCache::version_hash(&["zccache-rust-plan-v2-protobuf", cache_key])
-}
-
-async fn restore_rust_plan_gha(
-    plan: &RustArtifactPlanV1,
-    cache_dir: &Path,
-) -> Result<RustPlanSummary, RustPlanRuntimeError> {
-    let cache_key = rust_plan_cache_key(plan);
-    let version = rust_plan_gha_version(&cache_key);
-    let cache = GhaCache::from_env().map_err(rust_plan_gha_error)?;
-    let Some(data) = cache
-        .restore(&cache_key, &version)
-        .await
-        .map_err(rust_plan_gha_error)?
-    else {
-        let mut summary =
-            restore_rust_plan_local_async(plan.clone(), NormalizedPath::new(cache_dir))
-                .await
-                .map_err(|err| {
-                    rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string())
-                })?;
-        summary.set_backend("gha", Some(cache_key), Some(version));
-        summary.record_skip("<gha-cache>", "backend_cache_miss");
-        return Ok(summary);
-    };
-
-    let plan = plan.clone();
-    let cache_dir = cache_dir.to_path_buf();
-    run_rust_plan_backend_blocking(RustPlanBackendArg::Gha, move || {
-        let bundle_dir = rust_plan_bundle_dir(&cache_dir, &cache_key);
-        if bundle_dir.exists() {
-            std::fs::remove_dir_all(&bundle_dir).map_err(|err| err.to_string())?;
-        }
-        let bundle_parent = bundle_dir
-            .parent()
-            .ok_or_else(|| "invalid rust-plan bundle path".to_string())?;
-        std::fs::create_dir_all(bundle_parent).map_err(|err| err.to_string())?;
-        tar_gz_decode(&data, bundle_parent).map_err(|err| err.to_string())?;
-        let mut summary =
-            restore_rust_plan_local(&plan, &cache_dir).map_err(|err| err.to_string())?;
-        summary.set_backend("gha", Some(cache_key), Some(version));
-        Ok(summary)
-    })
-    .await
-}
-
-async fn save_rust_plan_gha(
-    plan: &RustArtifactPlanV1,
-    cache_dir: &Path,
-) -> Result<RustPlanSummary, RustPlanRuntimeError> {
-    let plan = plan.clone();
-    let cache_dir = cache_dir.to_path_buf();
-    let (summary, data) = run_rust_plan_backend_blocking(RustPlanBackendArg::Gha, move || {
-        let summary = save_rust_plan_local(&plan, &cache_dir).map_err(|err| err.to_string())?;
-        let cache_key = summary.cache_key.clone();
-        let bundle_dir = rust_plan_bundle_dir(&cache_dir, &cache_key);
-        let data = tar_gz_encode(&bundle_dir).map_err(|err| err.to_string())?;
-        Ok((summary, data))
-    })
-    .await?;
-    let cache_key = summary.cache_key.clone();
-    let version = rust_plan_gha_version(&cache_key);
-    let cache = GhaCache::from_env().map_err(rust_plan_gha_error)?;
-    cache
-        .save(&cache_key, &version, &data)
-        .await
-        .map_err(rust_plan_gha_error)?;
-    let mut summary = summary;
-    summary.set_backend("gha", Some(cache_key), Some(version));
-    Ok(summary)
-}
-
-fn rust_plan_gha_error(err: GhaError) -> RustPlanRuntimeError {
-    let kind = if matches!(&err, GhaError::NotAvailable) {
+/// Map the library-native `RustPlanGhaError` onto the CLI's runtime-error type
+/// at the boundary, preserving the unavailable-vs-failure distinction.
+fn map_rust_plan_gha_error(err: RustPlanGhaError) -> RustPlanRuntimeError {
+    let kind = if err.is_unavailable() {
         RustPlanRuntimeErrorKind::Unavailable
     } else {
         RustPlanRuntimeErrorKind::Failure
     };
-    rust_plan_backend_failure(RustPlanBackendArg::Gha, err.to_string()).with_kind(kind)
+    RustPlanRuntimeError::Backend {
+        backend: RustPlanBackendArg::Gha,
+        kind,
+        message: err.message().to_string(),
+    }
 }
 
 fn rust_plan_backend_failure(backend: RustPlanBackendArg, message: String) -> RustPlanRuntimeError {

--- a/crates/zccache/src/cli/commands/targz.rs
+++ b/crates/zccache/src/cli/commands/targz.rs
@@ -1,7 +1,11 @@
 //! Shared tar+gzip helpers used by `gha-cache` and `rust-plan` backends.
+//!
+//! The synchronous codec lives in the library at
+//! `crate::artifact::rust_plan::{tar_gz_encode, tar_gz_decode}` (single home);
+//! these async wrappers run it on Tokio's blocking pool.
 
+use crate::artifact::{tar_gz_decode, tar_gz_encode};
 use crate::core::NormalizedPath;
-use std::path::Path;
 
 async fn join_io<T>(
     handle: tokio::task::JoinHandle<Result<T, std::io::Error>>,
@@ -11,40 +15,12 @@ async fn join_io<T>(
         .map_err(|err| std::io::Error::other(format!("blocking archive task failed: {err}")))?
 }
 
-/// Create a tar.gz archive from a directory path.
-pub(crate) fn tar_gz_encode(src: &Path) -> Result<Vec<u8>, std::io::Error> {
-    use flate2::write::GzEncoder;
-    use flate2::Compression;
-
-    let buf = Vec::new();
-    let enc = GzEncoder::new(buf, Compression::fast());
-    let mut tar = tar::Builder::new(enc);
-    // Use the last component of the path as the archive prefix so that
-    // extraction recreates the directory structure relative to the target.
-    let prefix = src
-        .file_name()
-        .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_else(|| ".".to_string());
-    tar.append_dir_all(&prefix, src)?;
-    let enc = tar.into_inner()?;
-    enc.finish()
-}
-
 /// Create a tar.gz archive from a directory path on Tokio's blocking pool.
 pub(crate) async fn tar_gz_encode_async(src: NormalizedPath) -> Result<Vec<u8>, std::io::Error> {
     join_io(tokio::task::spawn_blocking(move || {
         tar_gz_encode(src.as_path())
     }))
     .await
-}
-
-/// Extract a tar.gz archive into a destination directory.
-pub(crate) fn tar_gz_decode(data: &[u8], dest: &Path) -> Result<(), std::io::Error> {
-    use flate2::read::GzDecoder;
-
-    let dec = GzDecoder::new(data);
-    let mut archive = tar::Archive::new(dec);
-    archive.unpack(dest)
 }
 
 /// Extract a tar.gz archive into a destination directory on Tokio's blocking pool.

--- a/crates/zccache/src/cli/commands/tests/args_parsing.rs
+++ b/crates/zccache/src/cli/commands/tests/args_parsing.rs
@@ -8,11 +8,11 @@ use super::super::args::{
     Cli, Commands, DaemonCommands, DaemonProfileCommands, RustPlanBackendArg, RustPlanCommands,
     KNOWN_SUBCOMMANDS,
 };
-use super::super::rust_plan::rust_plan_gha_version;
 use super::super::session::{
     session_stats_error_json, session_stats_json, session_stats_unavailable_json,
     session_summary_warnings, SessionStartPrivateOptions,
 };
+use crate::artifact::rust_plan_gha_version;
 
 #[test]
 fn rust_plan_cli_parses_validate_restore_save() {

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -463,25 +463,25 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         artifact_index_build_ns,
         artifact_index_persist_ns,
         artifact_memory_insert_ns,
-    // #955: the miss persist (a large rustc `.rlib` copy when it can't be
-    // hardlinked cross-volume) is synchronous; run it under block_in_place
-    // so it doesn't park the tokio worker. See process::run_cpu_blocking.
+        // #955: the miss persist (a large rustc `.rlib` copy when it can't be
+        // hardlinked cross-volume) is synchronous; run it under block_in_place
+        // so it doesn't park the tokio worker. See process::run_cpu_blocking.
     } = crate::daemon::process::run_cpu_blocking(|| {
         store_miss_artifact(MissArtifactStoreRequest {
-        state_arc,
-        sid,
-        context_key,
-        source_path,
-        output_path,
-        scan_result,
-        hash_map: &hash_map,
-        output_data,
-        user_depfile: user_depfile_capture,
-        rustc_all_outputs: rustc_all_outputs.as_deref(),
-        stdout: &stdout,
-        stderr: &stderr,
-        exit_code,
-        compile_start,
+            state_arc,
+            sid,
+            context_key,
+            source_path,
+            output_path,
+            scan_result,
+            hash_map: &hash_map,
+            output_data,
+            user_depfile: user_depfile_capture,
+            rustc_all_outputs: rustc_all_outputs.as_deref(),
+            stdout: &stdout,
+            stderr: &stderr,
+            exit_code,
+            compile_start,
         })
     });
 

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -228,7 +228,6 @@ pub(super) fn new_shared_state(
     )
 }
 
-
 impl DaemonServer {
     /// Get a handle to signal shutdown.
     #[must_use]
@@ -300,7 +299,6 @@ impl DaemonServer {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         *guard = Some(warning);
     }
-
 
     /// Get a snapshot of the phase profiler (for benchmarks).
     #[must_use]
@@ -387,7 +385,6 @@ impl DaemonServer {
         Arc::clone(&self.state)
     }
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Closes #960. Unblocks full no-regression for soldr#1368.

Exposes `zccache::artifact::{save_rust_plan_gha, restore_rust_plan_gha, rust_plan_gha_version}` + `RustPlanGhaError` as a CLI-independent, in-process API (tar + blocking helpers moved into the library). soldr can now do GHA rust-plan warm save/restore in-process instead of shelling out to the removed managed zccache binary. The CLI calls the lifted library fns (behavior unchanged). Also rustfmt's the latent store_outcome/lifecycle formatting from #958.

Tests: 38 rust_plan lib tests pass; clippy --all-targets clean; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)