### PR TITLE
fix(embedded): arm depgraph-load gate so first warm compile doesn't race the snapshot

### DIFF
--- a/crates/zccache/src/daemon/server/embedded.rs
+++ b/crates/zccache/src/daemon/server/embedded.rs
@@ -27,6 +27,19 @@ impl EmbeddedDaemon {
         let backend_identity = crate::ipc::current_backend_identity(&endpoint)
             .map_err(|err| crate::ipc::IpcError::Endpoint(err.to_string()))?;
         let (state, index_writer_rx) = new_shared_state(&endpoint, &cache_dir, backend_identity);
+        // Arm the startup depgraph-load gate as early as possible — before
+        // this state can serve any compile. The shared `dep_graph_load_complete`
+        // flag inits `true` ("assume loaded"); the standalone daemon flips it
+        // to `false` via `mark_dep_graph_load_pending()` before offloading the
+        // `depgraph.bin` load, but the embedded service never did. So
+        // `wait_for_startup_depgraph_load` in the compile pipeline was a no-op
+        // and the first warm compiles after a `soldr load` raced the empty
+        // default graph, taking a `CacheVerdict::Cold` (miss) until the
+        // background load swapped the restored graph in. The depgraph load in
+        // `start_background_tasks` flips this back to `true` + notifies waiters.
+        state
+            .dep_graph_load_complete
+            .store(false, std::sync::atomic::Ordering::Release);
 
         let mut daemon = Self {
             state,


### PR DESCRIPTION
## Problem

The embedded daemon service (soldr-daemon) starts with an empty default depgraph and loads the on-disk snapshot in a background task (#784, for fast bind). `SharedState::dep_graph_load_complete` inits to `true`; the **standalone** daemon flips it to `false` via `mark_dep_graph_load_pending()` before offloading the load, so `wait_for_startup_depgraph_load` actually waits — but the **embedded** service never did. So the gate was a no-op, and the first warm compiles after a `soldr load` (fresh daemon, restored cache) raced the empty graph and took a `CacheVerdict::Cold` (miss) until the background swap.

**Symptom**: after `soldr save`/`soldr load`, the first warm build missed a non-deterministic 5-25% of crates (worse under host load, gone once the daemon was warm), which also destabilized soldr's `cold-tar-untar-warm` Perf Matrix cell (`cold/warm ≥ 3×`) into flaky failures.

## Fix

Set `dep_graph_load_complete = false` immediately after `new_shared_state` in `EmbeddedDaemon::start`, before the state can serve any compile — mirroring the standalone daemon's `mark_dep_graph_load_pending()`. The existing depgraph load in `start_background_tasks` flips it back to `true` + `notify_waiters()`, so the gate always releases (no hang for a missing/empty snapshot).

## Validation

In the soldr Docker harness, first-build-after-load misses drop from a variable **2-8/35** to a deterministic **1/35**, and all subsequent builds stay 100%.

Follow-up: the residual 1/35 deterministic miss (a single crate that hits same-dir but misses after save/load) is a separate, smaller issue tracked outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)