### PR TITLE
feat(embedded): route ephemeral session log to ZCCACHE_EPHEMERAL_LOG for warm-miss diagnosis

### DIFF
--- a/crates/zccache/src/daemon/server/handle_compile_ephemeral.rs
+++ b/crates/zccache/src/daemon/server/handle_compile_ephemeral.rs
@@ -30,7 +30,12 @@ pub(super) async fn handle_compile_ephemeral(
         SessionStartArgs {
             client_pid,
             working_dir,
-            log_file: None,
+            // DIAG seam: when ZCCACHE_EPHEMERAL_LOG is set, route this
+            // ephemeral session's log (incl. [DIAG] depgraph_check lines)
+            // to that file so save/load warm-miss verdicts are observable.
+            log_file: std::env::var("ZCCACHE_EPHEMERAL_LOG")
+                .ok()
+                .map(|s| crate::core::NormalizedPath::from(std::path::PathBuf::from(s))),
             track_stats: false,
             journal_path: None,
             profile: false,


### PR DESCRIPTION
## What

The embedded compile path (`handle_compile_ephemeral`, used by soldr-daemon) hardcoded `log_file: None`, so every per-compile `[DIAG] depgraph_check ... verdict=... reason=...` line the pipeline emits for an embedded build was **discarded**. You could see an aggregate hit/miss count but not *which* unit missed or *why*.

When `ZCCACHE_EPHEMERAL_LOG` is set, this routes the ephemeral session's log to that file so the DIAG verdict/reason stream is captured. Opt-in, env-gated; unset behaviour is unchanged.

## Why

This is the exact observability seam needed to diagnose soldr save/load warm-build misses. With it, a residual warm-miss that looked like a depgraph problem was proven **not** to be: all 37 `depgraph_check` verdicts showed `Hit` (0 Cold, 0 `depgraph_load_pending`), localizing the residual to the artifact-store startup window instead of the depgraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)