### PR TITLE
fix(embedded): drain artifact index writer on flush

### DIFF
--- a/crates/zccache/src/daemon/server/embedded.rs
+++ b/crates/zccache/src/daemon/server/embedded.rs
@@ -271,7 +271,6 @@ impl EmbeddedDaemon {
 
     pub(crate) async fn shutdown(&self) -> EmbeddedFlushReport {
         self.state.shutdown_requested.store(true, Ordering::Release);
-        self.state.index_writer_shutdown.notify_waiters();
         let mut index_writer_handle = self.index_writer_handle.lock().await;
         let report = flush_embedded_state(&self.state, &mut index_writer_handle, true).await;
         let _ = std::fs::remove_dir_all(&self.state.depfile_tmpdir);
@@ -334,6 +333,12 @@ async fn flush_embedded_state(
         std::time::Duration::from_secs(30),
     )
     .await;
+
+    let index_writer_drained =
+        flush_index_writer(&state.index_writer_tx, std::time::Duration::from_secs(30)).await;
+    if !index_writer_drained {
+        tracing::warn!("timed out waiting for artifact index writer flush");
+    }
 
     if shutdown_writer {
         state.index_writer_shutdown.notify_waiters();

--- a/crates/zccache/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/miss_store.rs
@@ -205,9 +205,10 @@ fn store_rustc_outputs(
             stats.rust_snapshot_hardlink_count = snapshot_stats.hardlink_count;
             stats.rust_snapshot_copy_count = snapshot_stats.copy_count;
             stats.rust_snapshot_copy_bytes = snapshot_stats.copy_bytes;
-            let _ = state
-                .index_writer_tx
-                .send((artifact_key_hex.to_string(), meta.clone()));
+            let _ = state.index_writer_tx.send(IndexWriterCommand::Insert(
+                artifact_key_hex.to_string(),
+                meta.clone(),
+            ));
             true
         }
         Err(e) => {
@@ -368,7 +369,9 @@ fn store_single_output(
         })
         .await;
         if let Ok((key_hex, meta)) = written {
-            let _ = state_ref.index_writer_tx.send((key_hex, meta));
+            let _ = state_ref
+                .index_writer_tx
+                .send(IndexWriterCommand::Insert(key_hex, meta));
         }
         // Always complete the pending entry, even on JoinError, so
         // waiters cannot hang past the spawn's lifetime.

--- a/crates/zccache/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache/src/daemon/server/handle_compile_multi.rs
@@ -841,7 +841,9 @@ pub(super) async fn handle_compile_multi(
                 // Files are already on disk via the hardlink above. The
                 // remaining work is the redb index entry, which goes through
                 // the same background WAL the byte-write path used.
-                let _ = state_task.index_writer_tx.send((artifact_key_hex, meta));
+                let _ = state_task
+                    .index_writer_tx
+                    .send(IndexWriterCommand::Insert(artifact_key_hex, meta));
             }
             // No PersistTaskParams: persistence is complete synchronously.
             let persist: Option<PersistTaskParams> = None;
@@ -923,7 +925,9 @@ pub(super) async fn handle_compile_multi(
             })
             .await;
             if let Ok((key_hex, meta)) = written {
-                let _ = state_ref.index_writer_tx.send((key_hex, meta));
+                let _ = state_ref
+                    .index_writer_tx
+                    .send(IndexWriterCommand::Insert(key_hex, meta));
             }
         });
     }

--- a/crates/zccache/src/daemon/server/handle_exec.rs
+++ b/crates/zccache/src/daemon/server/handle_exec.rs
@@ -792,7 +792,9 @@ async fn store_exec_artifact(state: &Arc<SharedState>, key_hex: String, artifact
             })
             .await;
             if let Ok((kh, meta)) = written {
-                let _ = state_ref.index_writer_tx.send((kh, meta));
+                let _ = state_ref
+                    .index_writer_tx
+                    .send(IndexWriterCommand::Insert(kh, meta));
             }
         });
     }

--- a/crates/zccache/src/daemon/server/handle_link.rs
+++ b/crates/zccache/src/daemon/server/handle_link.rs
@@ -519,7 +519,9 @@ pub(super) async fn handle_link_ephemeral(
                     })
                     .await;
                     if let Ok((kh, meta)) = written {
-                        let _ = state_ref.index_writer_tx.send((kh, meta));
+                        let _ = state_ref
+                            .index_writer_tx
+                            .send(IndexWriterCommand::Insert(kh, meta));
                     }
                 });
             }

--- a/crates/zccache/src/daemon/server/lifecycle.rs
+++ b/crates/zccache/src/daemon/server/lifecycle.rs
@@ -49,7 +49,7 @@ pub(super) fn new_shared_state(
     backend_identity: running_process::broker::protocol_v2::backend_handle::DaemonProcess,
 ) -> (
     Arc<SharedState>,
-    tokio::sync::mpsc::UnboundedReceiver<(String, ArtifactIndex)>,
+    tokio::sync::mpsc::UnboundedReceiver<IndexWriterCommand>,
 ) {
     let shutdown = Arc::new(Notify::new());
     let now = now_secs();
@@ -75,7 +75,7 @@ pub(super) fn new_shared_state(
     let artifact_store = Arc::new(ArtifactStore::open_empty(&index_path));
 
     let (index_writer_tx, index_writer_rx) =
-        tokio::sync::mpsc::unbounded_channel::<(String, ArtifactIndex)>();
+        tokio::sync::mpsc::unbounded_channel::<IndexWriterCommand>();
     let index_writer_shutdown = Arc::new(Notify::new());
 
     // Try to restore the metadata cache from disk. A wrong-version /

--- a/crates/zccache/src/daemon/server/mod.rs
+++ b/crates/zccache/src/daemon/server/mod.rs
@@ -73,7 +73,7 @@ pub struct DaemonServer {
     shutdown: Arc<Notify>,
     state: Arc<SharedState>,
     /// Receiver for the background index-writer task. Taken in `run()`.
-    index_writer_rx: Option<tokio::sync::mpsc::UnboundedReceiver<(String, ArtifactIndex)>>,
+    index_writer_rx: Option<tokio::sync::mpsc::UnboundedReceiver<IndexWriterCommand>>,
 }
 
 /// In-process daemon engine used by the public embedded API.
@@ -82,7 +82,7 @@ pub struct DaemonServer {
 /// accepting an [`IpcListener`].
 pub(crate) struct EmbeddedDaemon {
     state: Arc<SharedState>,
-    index_writer_rx: Option<tokio::sync::mpsc::UnboundedReceiver<(String, ArtifactIndex)>>,
+    index_writer_rx: Option<tokio::sync::mpsc::UnboundedReceiver<IndexWriterCommand>>,
     index_writer_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 

--- a/crates/zccache/src/daemon/server/state.rs
+++ b/crates/zccache/src/daemon/server/state.rs
@@ -161,7 +161,7 @@ pub(super) struct SharedState {
     /// writes) from the periodic index snapshot, so a slow flush no longer
     /// holds a persist permit while other artifacts wait. See
     /// `tests/persist_pool_bench.rs` for the data motivating this split.
-    pub(super) index_writer_tx: tokio::sync::mpsc::UnboundedSender<(String, ArtifactIndex)>,
+    pub(super) index_writer_tx: tokio::sync::mpsc::UnboundedSender<IndexWriterCommand>,
     /// Notify the index-writer to drain its WAL and exit on graceful shutdown.
     /// Without this, the writer would only see the channel close after every
     /// `Arc<SharedState>` ref (including those held by spawned persist tasks)

--- a/crates/zccache/src/daemon/server/tests/embedded_flush.rs
+++ b/crates/zccache/src/daemon/server/tests/embedded_flush.rs
@@ -1,0 +1,47 @@
+//! Regression tests for embedded-service flush durability.
+
+use super::super::*;
+
+#[tokio::test(start_paused = true)]
+async fn embedded_flush_persists_queued_index_rows_before_returning() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let daemon = EmbeddedDaemon::start(endpoint, cache_dir.clone(), None)
+        .await
+        .unwrap();
+    let state = Arc::clone(&daemon.state);
+
+    let expected = 37usize;
+    for i in 0..expected {
+        let key = format!("{i:064x}");
+        let meta = synthetic_index_entry(i as u64 + 1);
+        state
+            .index_writer_tx
+            .send(IndexWriterCommand::Insert(key, meta))
+            .unwrap();
+    }
+
+    let report = daemon.flush().await;
+
+    assert!(report.pending_writes_drained);
+    assert_eq!(report.artifact_entries, expected as u64);
+    assert_eq!(state.artifact_store.len(), expected);
+
+    let index_path = crate::core::config::index_path_from_cache_dir(&cache_dir);
+    let reopened = crate::artifact::ArtifactStore::open(index_path.as_path()).unwrap();
+    assert_eq!(reopened.len(), state.artifact_store.len());
+    assert_eq!(reopened.len(), expected);
+
+    let _ = daemon.shutdown().await;
+}
+
+fn synthetic_index_entry(total_size: u64) -> crate::artifact::ArtifactIndex {
+    crate::artifact::ArtifactIndex::new(
+        vec!["foo.o".to_string()],
+        vec![total_size],
+        Vec::new(),
+        Vec::new(),
+        0,
+    )
+}

--- a/crates/zccache/src/daemon/server/tests/mod.rs
+++ b/crates/zccache/src/daemon/server/tests/mod.rs
@@ -11,6 +11,7 @@ mod clear_handler;
 mod client_env;
 mod compiler_hash;
 mod deferred_cold_path;
+mod embedded_flush;
 mod exec_probe;
 mod fingerprint;
 mod link_cache;

--- a/crates/zccache/src/daemon/server/wal.rs
+++ b/crates/zccache/src/daemon/server/wal.rs
@@ -2,6 +2,11 @@
 
 use super::*;
 
+pub(super) enum IndexWriterCommand {
+    Insert(String, ArtifactIndex),
+    Flush(tokio::sync::oneshot::Sender<()>),
+}
+
 /// Default WAL flush interval. Persist tasks return immediately after sending
 /// to the WAL; the WAL is flushed to the on-disk bincode blob on this cadence
 /// (or earlier if it exceeds the size budget).
@@ -61,7 +66,7 @@ pub(super) fn wal_max_pending() -> usize {
 /// an abrupt crash (where the files-on-disk are durable but the next
 /// session's `load_all()` won't see them, forcing a one-time re-miss).
 pub(super) async fn run_index_writer(
-    mut rx: tokio::sync::mpsc::UnboundedReceiver<(String, ArtifactIndex)>,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<IndexWriterCommand>,
     store: Arc<ArtifactStore>,
     shutdown: Arc<Notify>,
 ) {
@@ -78,14 +83,17 @@ pub(super) async fn run_index_writer(
         tokio::select! {
             msg = rx.recv() => {
                 match msg {
-                    Some((k, v)) => {
-                        wal.insert(k, v);
+                    Some(command) => {
+                        process_index_writer_command(command, &store, &mut wal, max_pending).await;
                         // Drain whatever else is already queued in this tick.
-                        while let Ok((k, v)) = rx.try_recv() {
-                            wal.insert(k, v);
-                        }
-                        if wal.len() >= max_pending {
-                            flush_wal_to_disk(&store, &mut wal).await;
+                        while let Ok(command) = rx.try_recv() {
+                            process_index_writer_command(
+                                command,
+                                &store,
+                                &mut wal,
+                                max_pending,
+                            )
+                            .await;
                         }
                     }
                     None => {
@@ -103,8 +111,8 @@ pub(super) async fn run_index_writer(
             _ = shutdown.notified() => {
                 // Daemon-initiated graceful shutdown. Drain anything still
                 // queued and flush before the runtime aborts us.
-                while let Ok((k, v)) = rx.try_recv() {
-                    wal.insert(k, v);
+                while let Ok(command) = rx.try_recv() {
+                    process_index_writer_command(command, &store, &mut wal, max_pending).await;
                 }
                 tracing::info!(
                     pending = wal.len(),
@@ -115,6 +123,37 @@ pub(super) async fn run_index_writer(
             }
         }
     }
+}
+
+async fn process_index_writer_command(
+    command: IndexWriterCommand,
+    store: &Arc<ArtifactStore>,
+    wal: &mut std::collections::HashMap<String, ArtifactIndex>,
+    max_pending: usize,
+) {
+    match command {
+        IndexWriterCommand::Insert(k, v) => {
+            wal.insert(k, v);
+            if wal.len() >= max_pending {
+                flush_wal_to_disk(store, wal).await;
+            }
+        }
+        IndexWriterCommand::Flush(ack) => {
+            flush_wal_to_disk(store, wal).await;
+            let _ = ack.send(());
+        }
+    }
+}
+
+pub(super) async fn flush_index_writer(
+    tx: &tokio::sync::mpsc::UnboundedSender<IndexWriterCommand>,
+    timeout: std::time::Duration,
+) -> bool {
+    let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+    if tx.send(IndexWriterCommand::Flush(ack_tx)).is_err() {
+        return false;
+    }
+    matches!(tokio::time::timeout(timeout, ack_rx).await, Ok(Ok(())))
 }
 
 pub(super) async fn flush_wal_to_disk(


### PR DESCRIPTION
Summary:
- add an explicit artifact-index WAL flush barrier with an ack
- make embedded flush wait for queued index rows before snapshotting index.bin
- avoid notifying embedded index-writer shutdown before pending cache writes drain
- add a regression that verifies persisted index count matches live count after flush

Tests:
- soldr cargo test -p zccache embedded_flush_persists_queued_index_rows_before_returning

Coordinated with zackees/soldr#1390.
Unblocks zackees/soldr#1389.