### PR TITLE
Gate zccache dependency surfaces

### DIFF
--- a/.github/workflows/ci-check-cross.yml
+++ b/.github/workflows/ci-check-cross.yml
@@ -63,7 +63,10 @@ jobs:
         # `/home/runner/.rustup` instead, which soldr ignores —
         # producing the "can't find crate for `core`" failure that
         # blocked main pre-fix.
-        run: soldr rustup target add ${{ inputs.target }}
+        shell: bash
+        run: |
+          soldr rustup target remove ${{ inputs.target }} || true
+          soldr rustup target add ${{ inputs.target }}
       - name: Check
         shell: bash
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,6 +42,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
+  ZCCACHE_INTEGRATION_FEATURES: "zccache/zccache-bin,zccache/daemon-bin,zccache/download-bin,zccache/download-daemon-bin,zccache/fingerprint-bin,zccache/stamp-bin,zccache/ci-bin,zccache/crash-tools,zccache/tokio-console,zccache/test-support"
 
 jobs:
   integration:
@@ -67,7 +68,7 @@ jobs:
           solo-toolchain-cache: true
       - name: Build integration test binaries
         shell: bash
-        run: soldr cargo test --workspace --no-fail-fast --no-run
+        run: soldr cargo test --workspace --features "$ZCCACHE_INTEGRATION_FEATURES" --no-fail-fast --no-run
       - name: Stop setup-soldr builder cache before tests
         uses: zackees/setup-soldr/cleanup@v0.9.62
       - name: Test (full workspace)
@@ -82,7 +83,7 @@ jobs:
           unset ZCCACHE_CACHE_DIR
           echo "Using isolated test SOLDR_CACHE_DIR=$SOLDR_CACHE_DIR"
           start=$SECONDS
-          soldr cargo test --workspace --no-fail-fast 2>&1 | tee test-output.txt
+          soldr cargo test --workspace --features "$ZCCACHE_INTEGRATION_FEATURES" --no-fail-fast 2>&1 | tee test-output.txt
           status=${PIPESTATUS[0]}
           dur=$((SECONDS - start))
           echo "- **Integration (Linux)**: ${dur}s" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/perf-rust-cluster.yml
+++ b/.github/workflows/perf-rust-cluster.yml
@@ -260,6 +260,7 @@ jobs:
           repository: zackees/soldr
           ref: main
           path: soldr-src
+          submodules: recursive
 
       - name: Install Rust toolchain
         if: steps.gate.outputs.selected == 'true'
@@ -318,7 +319,7 @@ jobs:
         env:
           RUSTFLAGS: -C link-arg=-fuse-ld=mold
         run: |
-          cargo build --release --bin zccache --bin zccache-daemon --bin zccache-fp
+          cargo build --release --features zccache-bin,daemon-bin,fingerprint-bin --bin zccache --bin zccache-daemon --bin zccache-fp
 
       - name: Stage zccache binaries
         if: steps.gate.outputs.selected == 'true' && steps.cache_zccache.outputs.cache-hit != 'true'

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -212,7 +212,7 @@ jobs:
 
       - name: Build zccache CLI
         shell: bash
-        run: cargo build -p zccache --bin zccache
+        run: cargo build -p zccache --features zccache-bin --bin zccache
 
       # --- Test cargo-registry hash ---
       - name: "cargo-registry hash: produces 16-char hex"
@@ -310,12 +310,12 @@ jobs:
 
       - name: Build zccache CLI
         shell: bash
-        run: cargo build -p zccache --bin zccache
+        run: cargo build -p zccache --features zccache-bin --bin zccache
 
       # --- Unit tests always run ---
       - name: "zccache unit tests"
         shell: bash
-        run: cargo test -p zccache
+        run: cargo test -p zccache --features zccache-bin,daemon-bin,download-bin,download-daemon-bin,fingerprint-bin,stamp-bin,ci-bin,crash-tools,tokio-console,test-support
 
       # --- Test gha-cache status (works without cache API) ---
       - name: "gha-cache status: runs without error"

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -135,7 +135,7 @@ jobs:
           # reintroduce cargo-chef placeholder executables after cleanup.
           SOLDR_TARGET_CACHE_MODE: off
         run: |
-          soldr cargo build --release --target-dir target -p zccache --bin zccache -p zccache --bin zccache-daemon
+          soldr cargo build --release --target-dir target -p zccache --features zccache-bin,daemon-bin --bin zccache --bin zccache-daemon
 
       - name: install binaries on PATH (Unix)
         if: runner.os != 'Windows'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,7 +117,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -241,18 +230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake3"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,24 +271,25 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.12"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
+ "rancor",
  "simdutf8",
 ]
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.12"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -339,8 +317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -349,12 +325,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -450,7 +420,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -723,7 +693,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -765,7 +735,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -773,12 +743,6 @@ name = "doctest-file"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
-
-[[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
@@ -807,17 +771,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "filedescriptor"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
-dependencies = [
- "libc",
- "thiserror 1.0.69",
- "winapi",
-]
 
 [[package]]
 name = "filetime"
@@ -904,12 +857,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,7 +912,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1098,15 +1045,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1125,6 +1063,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hdrhistogram"
@@ -1498,16 +1442,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,7 +1580,7 @@ dependencies = [
  "quote",
  "regex-syntax",
  "rustc_version",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1756,7 +1690,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1809,15 +1743,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
-name = "nix"
-version = "0.28.0"
+name = "munge"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
 dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases 0.1.1",
- "libc",
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1986,7 +1928,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1994,12 +1936,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -2042,27 +1978,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
-name = "portable-pty"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
-dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "downcast-rs",
- "filedescriptor",
- "lazy_static",
- "libc",
- "log",
- "nix",
- "serial2",
- "shared_library",
- "shell-words",
- "winapi",
- "winreg",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,7 +2008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2130,7 +2045,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.117",
+ "syn",
  "tempfile",
 ]
 
@@ -2144,7 +2059,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2244,7 +2159,7 @@ dependencies = [
  "prost-reflect",
  "prost-types",
  "protox-parse",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2256,27 +2171,27 @@ dependencies = [
  "logos",
  "miette",
  "prost-types",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "ptr_meta"
-version = "0.1.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
 dependencies = [
  "ptr_meta_derive",
 ]
 
 [[package]]
 name = "ptr_meta_derive"
-version = "0.1.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2327,7 +2242,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2340,7 +2255,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2359,14 +2274,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -2387,7 +2302,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2399,7 +2314,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
@@ -2429,10 +2344,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "radium"
-version = "0.7.0"
+name = "rancor"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+checksum = "daff8b7b3ccf5f7ba270b3e7a0a4d4c701c5797e38dec27c7e2c3dbb830fed1c"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -2491,9 +2409,9 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redb"
-version = "2.6.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
 dependencies = [
  "libc",
 ]
@@ -2524,7 +2442,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2558,9 +2476,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rend"
-version = "0.4.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
 dependencies = [
  "bytecheck",
 ]
@@ -2622,38 +2540,39 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.46"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
- "bitvec",
  "bytecheck",
  "bytes",
- "hashbrown 0.12.3",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "munge",
  "ptr_meta",
+ "rancor",
  "rend",
  "rkyv_derive",
- "seahash",
  "tinyvec",
  "uuid",
 ]
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.46"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "running-process"
-version = "4.5.8"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cfb64bf8432bcd3f842ba48536bb7218d83ac7fe24fd50f62f07a5e01618472"
+checksum = "7be0eb94932636a97372ec049442550886de8870f15a76b037e75262f8b9c8ff"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2662,7 +2581,6 @@ dependencies = [
  "getrandom 0.4.2",
  "interprocess",
  "libc",
- "portable-pty",
  "prost",
  "prost-build",
  "prost-types",
@@ -2670,15 +2588,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "sysinfo 0.30.13",
- "tar",
- "thiserror 2.0.18",
+ "sysinfo",
+ "thiserror",
  "tokio",
  "toml",
- "ureq",
  "winapi",
  "windows-sys 0.59.0",
- "zstd",
 ]
 
 [[package]]
@@ -2715,7 +2630,6 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2812,12 +2726,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2873,7 +2781,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2908,17 +2816,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serial2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
-dependencies = [
- "cfg-if",
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2957,22 +2854,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shared_library"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
-dependencies = [
- "lazy_static",
- "libc",
-]
-
-[[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -3050,17 +2931,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -3087,7 +2957,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3102,28 +2972,8 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "windows 0.52.0",
+ "windows",
 ]
-
-[[package]]
-name = "sysinfo"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
-dependencies = [
- "core-foundation-sys",
- "libc",
- "memchr",
- "ntapi",
- "rayon",
- "windows 0.57.0",
-]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -3157,31 +3007,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -3192,7 +3022,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3295,7 +3125,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3481,7 +3311,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3587,21 +3417,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
-]
 
 [[package]]
 name = "url"
@@ -3748,7 +3563,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3829,24 +3644,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.8",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3889,17 +3686,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core 0.52.0",
- "windows-targets",
-]
-
-[[package]]
-name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
+ "windows-core",
  "windows-targets",
 ]
 
@@ -3913,53 +3700,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-targets",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -4062,15 +3806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4100,7 +3835,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4116,7 +3851,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4165,15 +3900,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4202,7 +3928,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4248,10 +3974,10 @@ dependencies = [
  "serde_json",
  "sevenz-rust",
  "sha2",
- "sysinfo 0.33.1",
+ "sysinfo",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4307,7 +4033,7 @@ checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4327,7 +4053,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4367,7 +4093,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4383,7 +4109,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror 2.0.18",
+ "thiserror",
  "zopfli",
 ]
 
@@ -4403,32 +4129,4 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 clap = { version = "4", features = ["derive", "env"] }
 dashmap = "6"
 arc-swap = "1"
-redb = "2"
+redb = "4.1.0"
 clang = { version = "2", features = ["runtime"] }
 notify = "7"
 memmap2 = "0.9"
@@ -57,9 +57,9 @@ flate2 = "1"
 ruzstd = "0.7"
 lzma-rs = "0.3"
 sevenz-rust = "0.6"
-rkyv = { version = "0.7", features = ["validation"] }
+rkyv = "0.8"
 mimalloc = "0.1"
-running-process = { version = "4.5.8", default-features = false, features = ["client-async"] }
+running-process = { version = "4.5.9", default-features = false, features = ["client-async"] }
 zccache = { path = "crates/zccache" }
 zccache-watcher = { path = "crates/zccache-watcher" }
 zccache-cli = { path = "crates/zccache-cli" }

--- a/ci/docker/zccache-builder.Dockerfile
+++ b/ci/docker/zccache-builder.Dockerfile
@@ -58,6 +58,7 @@ if [ ! -f /src/Cargo.toml ]; then
 fi
 mkdir -p /out
 cargo build --release \
+    --features zccache-bin,daemon-bin,fingerprint-bin \
     --bin zccache \
     --bin zccache-daemon \
     --bin zccache-fp

--- a/crates/zccache-cli/Cargo.toml
+++ b/crates/zccache-cli/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["rlib", "cdylib"]
 
 [features]
 default = []
-python = ["dep:pyo3"]
+python = ["dep:pyo3", "zccache/cli"]
 
 [dependencies]
 zccache = { workspace = true }

--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -12,10 +12,37 @@ description = "Local-first compiler cache for C/C++/Rust/Emscripten"
 [features]
 default = []
 # Enables zccache::test_support (dev-only helpers).
-test-support = []
-# Compatibility no-op: Tokio Console support is always compiled in and
-# remains dormant unless the daemon is started with the tokio-console profile.
-tokio-console = []
+test-support = ["dep:tracing-subscriber"]
+ci = ["dep:wait-timeout"]
+cli = ["dep:clap", "dep:tracing-subscriber", "download-client", "gha", "symbols"]
+download = ["dep:futures", "dep:reqwest"]
+download-client = [
+    "download",
+    "download-protocol",
+    "dep:lzma-rs",
+    "dep:ruzstd",
+    "dep:sevenz-rust",
+    "dep:sha2",
+    "dep:zip",
+]
+download-daemon = ["download", "download-protocol"]
+download-protocol = ["download"]
+gha = ["dep:reqwest", "dep:sha2"]
+symbols = []
+tokio-console = ["dep:console-subscriber"]
+zccache-bin = ["cli", "dep:mimalloc"]
+daemon-bin = ["dep:clap", "dep:mimalloc", "dep:tracing-subscriber"]
+download-bin = ["dep:clap", "dep:mimalloc", "download-client"]
+download-daemon-bin = [
+    "dep:clap",
+    "dep:mimalloc",
+    "dep:tracing-subscriber",
+    "download-daemon",
+]
+fingerprint-bin = ["dep:clap", "dep:mimalloc"]
+stamp-bin = ["symbols"]
+ci-bin = ["ci", "dep:md5"]
+crash-tools = ["dep:sadness-generator"]
 
 [dependencies]
 # core
@@ -30,8 +57,8 @@ blake3 = { workspace = true }
 memmap2 = { workspace = true }
 
 # gha
-reqwest = { workspace = true, features = ["json"] }
-sha2 = { workspace = true }
+reqwest = { workspace = true, features = ["json"], optional = true }
+sha2 = { workspace = true, optional = true }
 
 # protocol
 bincode = { workspace = true }
@@ -41,7 +68,7 @@ prost = { workspace = true }
 # ipc + test-support: needs full tokio. The tracing feature lets Tokio emit
 # runtime telemetry when the workspace is built with `--cfg tokio_unstable`.
 tokio = { workspace = true, features = ["tracing"] }
-console-subscriber = { workspace = true }
+console-subscriber = { workspace = true, optional = true }
 
 # fscache
 dashmap = { workspace = true }
@@ -71,21 +98,21 @@ rkyv = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
 
 # fingerprint
-clap = { workspace = true }
+clap = { workspace = true, optional = true }
 fs2 = { workspace = true }
 
 # exec (issue #272): regex compiles `--key-args-filter` patterns
 regex = { workspace = true }
 
 # download stack
-futures = { workspace = true }
+futures = { workspace = true, optional = true }
 tokio-util = { workspace = true }
-zip = { workspace = true }
+zip = { workspace = true, optional = true }
 tar = { workspace = true }
 flate2 = { workspace = true }
-ruzstd = { workspace = true }
-lzma-rs = { workspace = true }
-sevenz-rust = { workspace = true }
+ruzstd = { workspace = true, optional = true }
+lzma-rs = { workspace = true, optional = true }
+sevenz-rust = { workspace = true, optional = true }
 
 # daemon
 running-process = { workspace = true }
@@ -97,15 +124,15 @@ running-process = { workspace = true }
 # it explicit in [dependencies] does not add a new resolved crate.
 interprocess = "2.4.2"
 filetime = { workspace = true }
-sysinfo = "0.33"
-sadness-generator = "0.6"
+sysinfo = "0.30.13"
+sadness-generator = { version = "0.6", optional = true }
 
 # ci
-md5 = "0.7"
-wait-timeout = "0.2"
+md5 = { version = "0.7", optional = true }
+wait-timeout = { version = "0.2", optional = true }
 
 # shared: used by test_support, download-daemon bin, etc.
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, optional = true }
 
 # Global allocator on every target. mimalloc is pure C with no autotools
 # step, so it cross-compiles cleanly in every direction. tikv-jemalloc
@@ -114,7 +141,7 @@ tracing-subscriber = { workspace = true }
 # `--sysroot` flag — broke Linux->*-apple-darwin (and would equally
 # break Windows->Linux); see tikv/jemallocator#170. Using one allocator
 # everywhere also removes a per-platform variable from perf analysis.
-mimalloc = { workspace = true }
+mimalloc = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -130,6 +157,7 @@ windows-sys = { version = "0.59", features = [
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+futures = { workspace = true }
 # Spike-only (broker_into_backend_io_spike_test): bind a running-process broker
 # listener directly. Pinned to the version already locked transitively via
 # running-process so no new resolution occurs.
@@ -175,39 +203,48 @@ required-features = ["test-support"]
 [[bin]]
 name = "zccache-fp"
 path = "src/bin/zccache-fp.rs"
+required-features = ["fingerprint-bin"]
 
 [[bin]]
 name = "zccache-stamp"
 path = "src/bin/zccache-stamp.rs"
+required-features = ["stamp-bin"]
 
 [[bin]]
 name = "zccache-download-daemon"
 path = "src/bin/zccache-download-daemon.rs"
+required-features = ["download-daemon-bin"]
 
 [[bin]]
 name = "zccache-download"
 path = "src/bin/zccache-download.rs"
 doc = false
+required-features = ["download-bin"]
 
 [[bin]]
 name = "zccache-daemon"
 path = "src/bin/zccache-daemon.rs"
+required-features = ["daemon-bin"]
 
 [[bin]]
 name = "crash-trigger"
 path = "src/bin/crash-trigger.rs"
+required-features = ["crash-tools"]
 
 [[bin]]
 name = "zccache"
 path = "src/bin/zccache.rs"
+required-features = ["zccache-bin"]
 
 [[bin]]
 name = "cli-crash-trigger"
 path = "src/bin/cli-crash-trigger.rs"
+required-features = ["crash-tools"]
 
 [[bin]]
 name = "zccache-ci"
 path = "src/bin/zccache-ci.rs"
+required-features = ["ci-bin"]
 
 [[bench]]
 name = "write_payloads"

--- a/crates/zccache/src/artifact/kv.rs
+++ b/crates/zccache/src/artifact/kv.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::core::NormalizedPath;
-use redb::{Database, ReadableTable, TableDefinition};
+use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
 use serde::{Deserialize, Serialize};
 
 /// Windows long-path (`\\?\`) helpers. On non-Windows platforms every entry

--- a/crates/zccache/src/artifact/mod.rs
+++ b/crates/zccache/src/artifact/mod.rs
@@ -13,6 +13,7 @@ mod store;
 pub use kv::{
     is_valid_namespace, Key, KvError, KvResult, KvStore, INLINE_THRESHOLD, MAX_VALUE_BYTES,
 };
+#[cfg(feature = "gha")]
 pub use rust_plan::{
     restore_rust_plan_gha, restore_rust_plan_layered_local, restore_rust_plan_local,
     rust_plan_bundle_dir, rust_plan_cache_key, rust_plan_gha_version, save_rust_plan_delta_local,
@@ -23,6 +24,17 @@ pub use rust_plan::{
     RustPlanSummary, RustToolchainIdentity, RUST_ARTIFACT_CACHE_SCHEMA_VERSION,
     RUST_ARTIFACT_PLAN_SCHEMA_VERSION,
 };
+#[cfg(not(feature = "gha"))]
+pub use rust_plan::{
+    restore_rust_plan_layered_local, restore_rust_plan_local, rust_plan_bundle_dir,
+    rust_plan_cache_key, save_rust_plan_delta_local, save_rust_plan_local,
+    RustArtifactBundleLayerKind, RustArtifactBundleManifest, RustArtifactClass, RustArtifactPlanV1,
+    RustBundledArtifact, RustPlanArtifactEffectiveness, RustPlanCompatibility, RustPlanError,
+    RustPlanInputs, RustPlanMode, RustPlanOperation, RustPlanPackages, RustPlanSkippedSample,
+    RustPlanSummary, RustToolchainIdentity, RUST_ARTIFACT_CACHE_SCHEMA_VERSION,
+    RUST_ARTIFACT_PLAN_SCHEMA_VERSION,
+};
+#[cfg(feature = "cli")]
 pub(crate) use rust_plan::{tar_gz_decode, tar_gz_encode};
 pub use store::{ArtifactIndex, ArtifactStore};
 

--- a/crates/zccache/src/artifact/rust_plan.rs
+++ b/crates/zccache/src/artifact/rust_plan.rs
@@ -1,5 +1,6 @@
 //! Plan-driven Rust target artifact save/restore.
 
+#[cfg(feature = "gha")]
 mod gha;
 mod local;
 mod manifest;
@@ -7,12 +8,14 @@ mod proto;
 mod schema;
 mod selection;
 mod summary;
+#[cfg(any(feature = "cli", feature = "gha"))]
 mod targz;
 mod threads;
 
 #[cfg(test)]
 mod tests;
 
+#[cfg(feature = "gha")]
 pub use gha::{restore_rust_plan_gha, rust_plan_gha_version, save_rust_plan_gha, RustPlanGhaError};
 pub use local::{
     restore_rust_plan_layered_local, restore_rust_plan_local, rust_plan_bundle_dir,
@@ -28,6 +31,7 @@ pub use summary::{
     RustPlanArtifactEffectiveness, RustPlanCompatibility, RustPlanOperation, RustPlanSkippedSample,
     RustPlanSummary,
 };
+#[cfg(feature = "cli")]
 pub(crate) use targz::{tar_gz_decode, tar_gz_encode};
 
 #[cfg(test)]

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -540,7 +540,7 @@ fn run_server(args: Args) {
 }
 
 fn init_tracing(level: &str) {
-    use tracing_subscriber::{prelude::*, EnvFilter};
+    use tracing_subscriber::EnvFilter;
     let mut filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level));
     // When a parent process (notably soldr) launches us with a narrowed
     // `RUST_LOG=zccache_daemon=info`, the directive *only* matches the
@@ -575,50 +575,11 @@ fn init_tracing(level: &str) {
     if tokio_console_enabled {
         let bind = std::env::var(TOKIO_CONSOLE_BIND_ENV)
             .unwrap_or_else(|_| TOKIO_CONSOLE_DEFAULT_BIND.to_string());
-        let console_layer = std::panic::catch_unwind(console_subscriber::spawn);
-        match console_layer {
-            Ok(console_layer) => {
-                tracing_subscriber::registry()
-                    .with(console_layer)
-                    .with(
-                        tracing_subscriber::fmt::layer()
-                            .with_target(true)
-                            .with_thread_ids(true)
-                            .with_filter(filter),
-                    )
-                    .init();
-                tracing::info!(
-                    bind,
-                    "tokio-console daemon profile enabled; connect with `tokio-console {bind}`"
-                );
-            }
-            Err(_) => {
-                tracing_subscriber::registry()
-                    .with(
-                        tracing_subscriber::fmt::layer()
-                            .with_target(true)
-                            .with_thread_ids(true)
-                            .with_filter(filter),
-                    )
-                    .init();
-                tracing::warn!(
-                    bind,
-                    "tokio-console daemon profile requested but unavailable; \
-                     rebuild with RUSTFLAGS=\"--cfg tokio_unstable\""
-                );
-            }
-        }
+        init_tokio_console_tracing(filter, &bind);
         return;
     }
 
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_target(true)
-                .with_thread_ids(true)
-                .with_filter(filter),
-        )
-        .init();
+    init_fmt_tracing(filter);
 
     if let Some(profile) = profile {
         if profile != TOKIO_CONSOLE_PROFILE {
@@ -628,4 +589,59 @@ fn init_tracing(level: &str) {
             );
         }
     }
+}
+
+fn init_fmt_tracing(filter: tracing_subscriber::EnvFilter) {
+    use tracing_subscriber::prelude::*;
+
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_target(true)
+                .with_thread_ids(true)
+                .with_filter(filter),
+        )
+        .init();
+}
+
+#[cfg(feature = "tokio-console")]
+fn init_tokio_console_tracing(filter: tracing_subscriber::EnvFilter, bind: &str) {
+    use tracing_subscriber::prelude::*;
+
+    let console_layer = std::panic::catch_unwind(console_subscriber::spawn);
+    match console_layer {
+        Ok(console_layer) => {
+            tracing_subscriber::registry()
+                .with(console_layer)
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .with_target(true)
+                        .with_thread_ids(true)
+                        .with_filter(filter),
+                )
+                .init();
+            tracing::info!(
+                bind,
+                "tokio-console daemon profile enabled; connect with `tokio-console {bind}`"
+            );
+        }
+        Err(_) => {
+            init_fmt_tracing(filter);
+            tracing::warn!(
+                bind,
+                "tokio-console daemon profile requested but unavailable; \
+                 rebuild with RUSTFLAGS=\"--cfg tokio_unstable\""
+            );
+        }
+    }
+}
+
+#[cfg(not(feature = "tokio-console"))]
+fn init_tokio_console_tracing(filter: tracing_subscriber::EnvFilter, bind: &str) {
+    init_fmt_tracing(filter);
+    tracing::warn!(
+        bind,
+        "tokio-console daemon profile requested but zccache was built without \
+         the `tokio-console` feature"
+    );
 }

--- a/crates/zccache/src/ci/mod.rs
+++ b/crates/zccache/src/ci/mod.rs
@@ -26,7 +26,9 @@
 //!    its daemon could be reaped.
 
 use crate::core::NormalizedPath;
+use std::borrow::Cow;
 use std::env;
+use std::ffi::OsStr;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
@@ -34,6 +36,26 @@ use std::process::{Child, Command};
 use std::time::{Duration, Instant};
 
 use wait_timeout::ChildExt;
+
+trait ProcessNameExt {
+    fn to_lossy_name(&self) -> Cow<'_, str>;
+}
+
+impl ProcessNameExt for str {
+    fn to_lossy_name(&self) -> Cow<'_, str> {
+        Cow::Borrowed(self)
+    }
+}
+
+impl ProcessNameExt for OsStr {
+    fn to_lossy_name(&self) -> Cow<'_, str> {
+        self.to_string_lossy()
+    }
+}
+
+fn process_name_lossy<N: ProcessNameExt + ?Sized>(name: &N) -> Cow<'_, str> {
+    name.to_lossy_name()
+}
 
 /// Default wall-clock timeout for the entire stop hook run, in seconds.
 ///
@@ -319,12 +341,11 @@ pub fn capture_diagnostics() {
 }
 
 fn dump_relevant_processes() {
-    let mut sys = sysinfo::System::new();
-    sys.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+    let sys = sysinfo::System::new_all();
     eprintln!("processes (zccache/cargo/rustc/soldr):");
     let mut count = 0usize;
     for (pid, p) in sys.processes() {
-        let name = p.name().to_string_lossy();
+        let name = process_name_lossy(p.name());
         let lower = name.to_ascii_lowercase();
         if lower.contains("zccache")
             || lower.contains("cargo")
@@ -333,7 +354,7 @@ fn dump_relevant_processes() {
         {
             eprintln!(
                 "  PID={pid} name={} status={:?} cpu={:.1}% mem={}KB",
-                name,
+                name.as_ref(),
                 p.status(),
                 p.cpu_usage(),
                 p.memory() / 1024,
@@ -432,15 +453,13 @@ pub const KILL_DAEMON_WAIT: Duration = Duration::from_secs(2);
 
 /// Find every running `zccache-daemon[.exe]` PID by walking the process table.
 fn find_daemon_pids() -> Vec<u32> {
-    use sysinfo::ProcessesToUpdate;
-
-    let mut sys = sysinfo::System::new();
-    sys.refresh_processes(ProcessesToUpdate::All, true);
+    let sys = sysinfo::System::new_all();
     sys.processes()
         .iter()
         .filter_map(|(pid, process)| {
-            let name = process.name().to_string_lossy();
-            (name == "zccache-daemon" || name == "zccache-daemon.exe").then_some(pid.as_u32())
+            let name = process_name_lossy(process.name());
+            (name.as_ref() == "zccache-daemon" || name.as_ref() == "zccache-daemon.exe")
+                .then_some(pid.as_u32())
         })
         .collect()
 }
@@ -528,17 +547,16 @@ pub fn kill_daemon() {
 /// This is conservative: we only reap when we can confirm the parent is
 /// gone. Daemons spawned by a still-running supervisor are left alone.
 pub fn reap_orphan_daemons() -> Vec<u32> {
-    use sysinfo::{Pid, ProcessesToUpdate};
+    use sysinfo::Pid;
 
-    let mut sys = sysinfo::System::new();
-    sys.refresh_processes(ProcessesToUpdate::All, true);
+    let sys = sysinfo::System::new_all();
 
     let alive: std::collections::HashSet<Pid> = sys.processes().keys().copied().collect();
 
     let mut killed = Vec::new();
     for (pid, process) in sys.processes() {
-        let name = process.name().to_string_lossy();
-        if name != "zccache-daemon" && name != "zccache-daemon.exe" {
+        let name = process_name_lossy(process.name());
+        if name.as_ref() != "zccache-daemon" && name.as_ref() != "zccache-daemon.exe" {
             continue;
         }
         let parent = process.parent();

--- a/crates/zccache/src/daemon/process.rs
+++ b/crates/zccache/src/daemon/process.rs
@@ -425,11 +425,19 @@ impl CpuUsageMonitor {
         loop {
             std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
             system.refresh_cpu_usage();
-            let usage = system.global_cpu_usage().clamp(0.0, 100.0);
+            let usage = average_cpu_usage_percent(&system).clamp(0.0, 100.0);
             self.last_usage_percent_bits
                 .store(usage.to_bits(), Ordering::Relaxed);
         }
     }
+}
+
+fn average_cpu_usage_percent(system: &sysinfo::System) -> f32 {
+    let cpus = system.cpus();
+    if cpus.is_empty() {
+        return 0.0;
+    }
+    cpus.iter().map(|cpu| cpu.cpu_usage()).sum::<f32>() / cpus.len() as f32
 }
 
 fn current_cpu_usage_percent() -> Option<f32> {

--- a/crates/zccache/src/depgraph/snapshot/mod.rs
+++ b/crates/zccache/src/depgraph/snapshot/mod.rs
@@ -49,7 +49,6 @@ pub(crate) const HEADER_SIZE: usize = 16;
 // ---------------------------------------------------------------------------
 
 #[derive(Archive, Serialize, Deserialize)]
-#[archive(check_bytes)]
 pub struct DepGraphSnapshot {
     pub files: Vec<FileEntrySnapshot>,
     pub contexts: Vec<ContextEntrySnapshot>,
@@ -57,14 +56,12 @@ pub struct DepGraphSnapshot {
 }
 
 #[derive(Archive, Serialize, Deserialize)]
-#[archive(check_bytes)]
 pub struct FileEntrySnapshot {
     pub path: String,
     pub includes: Vec<IncludeDirectiveSnapshot>,
 }
 
 #[derive(Archive, Serialize, Deserialize)]
-#[archive(check_bytes)]
 pub struct IncludeDirectiveSnapshot {
     /// 0=Quoted, 1=AngleBracket, 2=Computed
     pub kind: u8,
@@ -73,7 +70,6 @@ pub struct IncludeDirectiveSnapshot {
 }
 
 #[derive(Archive, Serialize, Deserialize)]
-#[archive(check_bytes)]
 pub struct ContextEntrySnapshot {
     pub context_key: [u8; 32],
     pub key_root: Option<String>,
@@ -97,14 +93,12 @@ pub struct ContextEntrySnapshot {
 }
 
 #[derive(Archive, Serialize, Deserialize)]
-#[archive(check_bytes)]
 pub struct RustcExternSnapshot {
     pub name: String,
     pub path: String,
 }
 
 #[derive(Archive, Serialize, Deserialize)]
-#[archive(check_bytes)]
 pub struct SnapshotStats {
     pub saved_at_epoch_secs: u64,
     pub file_count: u64,

--- a/crates/zccache/src/depgraph/snapshot/persistence.rs
+++ b/crates/zccache/src/depgraph/snapshot/persistence.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use crate::core::NormalizedPath;
-use rkyv::Deserialize;
+use rkyv::rancor::Error as RkyvError;
 
 use super::super::graph::DepGraph;
 
@@ -13,9 +13,6 @@ use super::{DepGraphSnapshot, SnapshotError, DEPGRAPH_MAGIC, DEPGRAPH_VERSION, H
 
 /// Entries older than this are trimmed before persisting the snapshot.
 const GC_TTL: Duration = Duration::from_secs(86_400); // 1 day
-
-/// Initial scratch-space size for rkyv serialization.
-const SERIALIZE_SCRATCH: usize = 4096;
 
 /// Returns the default path for the depgraph snapshot file.
 #[must_use]
@@ -32,7 +29,7 @@ pub fn save_to_file(graph: &DepGraph, path: &Path) -> Result<(), SnapshotError> 
 
     let snapshot = graph.to_snapshot();
 
-    let payload = rkyv::to_bytes::<_, SERIALIZE_SCRATCH>(&snapshot)
+    let payload = rkyv::to_bytes::<RkyvError>(&snapshot)
         .map_err(|e| SnapshotError::Corrupt(format!("serialize: {e}")))?;
 
     // Build header: magic + version (LE u32) + payload len (LE u64)
@@ -201,12 +198,8 @@ pub fn load_from_file(path: &Path) -> Result<DepGraph, SnapshotError> {
     let payload = &data[HEADER_SIZE..HEADER_SIZE + payload_len];
 
     // Validate and deserialize.
-    let archived = rkyv::check_archived_root::<DepGraphSnapshot>(payload)
+    let snapshot: DepGraphSnapshot = rkyv::from_bytes::<DepGraphSnapshot, RkyvError>(payload)
         .map_err(|e| SnapshotError::Corrupt(format!("validation: {e}")))?;
-
-    let snapshot: DepGraphSnapshot = archived
-        .deserialize(&mut rkyv::Infallible)
-        .map_err(|e| SnapshotError::Corrupt(format!("deserialize: {e:?}")))?;
 
     Ok(DepGraph::from_snapshot(snapshot))
 }

--- a/crates/zccache/src/download_client/artifact/mod.rs
+++ b/crates/zccache/src/download_client/artifact/mod.rs
@@ -20,7 +20,7 @@ mod parts;
 mod resolve;
 mod state;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "download-daemon"))]
 mod tests;
 
 use archive::{extract_archive, remove_path_if_exists};

--- a/crates/zccache/src/lib.rs
+++ b/crates/zccache/src/lib.rs
@@ -11,7 +11,9 @@ pub mod audit;
 /// service. Spawned by [`embedded::ZccacheService::start`] when
 /// [`audit::AuditConfig::mode`] > `Off`.
 pub mod audit_writer;
+#[cfg(feature = "ci")]
 pub mod ci;
+#[cfg(feature = "cli")]
 pub mod cli;
 /// zccache#940 — per-sub-phase JSONL trace for the embedded compile
 /// path. Diagnostic-only, gated by the `ZCCACHE_INNER_TRACE` env var.
@@ -21,17 +23,23 @@ pub mod compiler;
 pub mod core;
 pub mod daemon;
 pub mod depgraph;
+#[cfg(feature = "download")]
 pub mod download;
+#[cfg(feature = "download-client")]
 pub mod download_client;
+#[cfg(feature = "download-daemon")]
 pub mod download_daemon;
+#[cfg(feature = "download-protocol")]
 pub mod download_protocol;
 pub mod embedded;
 pub mod fingerprint;
 pub mod fscache;
+#[cfg(feature = "gha")]
 pub mod gha;
 pub mod hash;
 pub mod ipc;
 pub mod protocol;
+#[cfg(feature = "symbols")]
 pub mod symbols;
 pub mod watcher;
 


### PR DESCRIPTION
## Summary
- gate zccache's CLI/download/GHA/CI/symbols/tokio-console surfaces behind opt-in features
- make CLI/download/daemon/crash bins require the features that compile their dependencies
- migrate rkyv 0.7 -> 0.8 and redb 2 -> 4.1, align sysinfo with running-process, and consume running-process 4.5.9

Coordinated with zackees/soldr#1356.
Depends on zackees/running-process#589, released as running-process 4.5.9.

## Validation
- `soldr --no-cache cargo check -p zccache --no-default-features --lib`
- `soldr --no-cache cargo check -p zccache --no-default-features --features gha --lib`
- `soldr --no-cache cargo check -p zccache --no-default-features --features zccache-bin,daemon-bin,download-bin,download-daemon-bin,fingerprint-bin,stamp-bin,ci-bin,crash-tools,tokio-console --bins`
- `soldr --no-cache cargo test -p zccache --no-default-features --lib` (1668 passed, 19 ignored)
- `soldr --no-cache cargo test -p zccache --no-default-features --features gha --lib` (1674 passed, 19 ignored)
- `soldr --no-cache cargo clippy -p zccache --no-default-features --lib -- -D warnings`
- `soldr --no-cache cargo clippy -p zccache --no-default-features --features gha --lib -- -D warnings`
- `soldr --no-cache cargo fmt --check`
- `soldr --no-cache cargo tree -p zccache -i ureq` and `... -i portable-pty` both fail to match packages on the default zccache graph