### PR TITLE
fix(watcher): wake the settled-event consumer on shutdown (#974)

### DIFF
--- a/crates/zccache/src/daemon/server/run.rs
+++ b/crates/zccache/src/daemon/server/run.rs
@@ -619,7 +619,15 @@ impl DaemonServer {
         let state = Arc::clone(&self.state);
         tokio::spawn(async move {
             while !state.shutdown_requested.load(Ordering::Acquire) {
-                let event = settled_rx.recv().await;
+                // Race the settled-event recv against the shutdown signal
+                // (issue #974). Without this the loop only re-checks
+                // `shutdown_requested` AFTER `recv()` returns, so if the settle
+                // task neither sends nor drops its sender the consumer parks
+                // forever and ignores shutdown — a shutdown-cleanliness gap.
+                let event = tokio::select! {
+                    e = settled_rx.recv() => e,
+                    () = state.shutdown.notified() => None,
+                };
                 let Some(event) = event else { break };
                 match event {
                     SettledEvent::Batch { changed, removed } => {


### PR DESCRIPTION
## Summary

Closes #974 (meta #968). The watcher's settled-event consumer loop checked
`shutdown_requested` only *after* `settled_rx.recv().await` returned. If the
settle task neither sent another event nor dropped its sender, the consumer
parked in `recv()` forever and ignored the shutdown request — a
shutdown-cleanliness gap found in the #968 deadlock sweep.

## Fix

Race the `recv()` against the shutdown signal:

```rust
let event = tokio::select! {
    e = settled_rx.recv() => e,
    () = state.shutdown.notified() => None,
};
let Some(event) = event else { break };
```

`shutdown_requested` remains the source of truth (the `while` guard still
short-circuits an already-requested shutdown); the added `state.shutdown`
`Notify` branch guarantees the loop also wakes when shutdown is signalled while
it is parked in `recv()`, then falls through the `let Some(event) else break`.

## Scope

Minimal, targeted change to one spawned loop; no behavior change on the normal
event path (a settled event still resolves the `recv()` branch). The spawned
watcher-consumer task isn't unit-testable in isolation without standing up the
full watcher pipeline; correctness rests on the standard `select!`-on-shutdown
pattern and is exercised by the existing watcher integration coverage.

Refs #968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
