### PR TITLE
feat(daemon): CPU/output progress watchdog for alive-hung children (#891)

### DIFF
--- a/crates/zccache/src/daemon/child_watchdog.rs
+++ b/crates/zccache/src/daemon/child_watchdog.rs
@@ -61,6 +61,136 @@ fn post_exit_grace() -> Duration {
     }
 }
 
+/// Default alive-hung stall window (Mode B, issue #891). While the child is
+/// still running, the watchdog kills it only after this long with BOTH no
+/// stdout/stderr output AND no CPU progress. Deliberately generous: a silent
+/// but CPU-bound compile (rustc mid-codegen prints nothing) keeps advancing CPU
+/// and is never touched; only a process that is genuinely stuck — no output and
+/// no CPU for five minutes — is reaped. This is the "progress-based, not a dumb
+/// wall-clock timeout" contract: a legitimately long link runs for minutes
+/// while burning CPU / emitting output and is left alone.
+const DEFAULT_STALL_WINDOW: Duration = Duration::from_secs(300);
+
+/// How often the alive-hung watchdog samples progress (output bytes + child CPU
+/// time) while the child is running. Cheap: one `GetProcessTimes` /
+/// `/proc/<pid>/stat` read per tick.
+const STALL_TICK: Duration = Duration::from_secs(5);
+
+/// Env override for [`DEFAULT_STALL_WINDOW`], in milliseconds. `0` disables the
+/// alive-hung (Mode B) watchdog, leaving only the post-exit orphan-pipe (Mode A)
+/// watchdog active.
+const STALL_WINDOW_ENV: &str = "ZCCACHE_STALL_WINDOW_MS";
+
+/// Resolve the alive-hung stall window from the environment.
+fn stall_window() -> Duration {
+    match std::env::var(STALL_WINDOW_ENV) {
+        Ok(v) => match v.trim().parse::<u64>() {
+            Ok(ms) => Duration::from_millis(ms),
+            Err(_) => DEFAULT_STALL_WINDOW,
+        },
+        Err(_) => DEFAULT_STALL_WINDOW,
+    }
+}
+
+/// The Mode B kill decision: a still-running child is "wedged" only when it has
+/// produced no output for at least `stall_window` AND its CPU time has not
+/// advanced across the last sample. Requiring BOTH conditions is what keeps a
+/// silent-but-CPU-bound compile (advancing CPU) and a chatty-but-slow compile
+/// (advancing output) alive. Pure so it is trivially unit-testable.
+fn should_kill_stalled(
+    since_progress: Duration,
+    stall_window: Duration,
+    cpu_advanced: bool,
+) -> bool {
+    since_progress >= stall_window && !cpu_advanced
+}
+
+/// Total CPU time (user+kernel) consumed by `child` so far, in an opaque
+/// monotonically-increasing unit. Used ONLY for delta comparison ("did the
+/// process burn any CPU since the last sample?"), never for absolute timing.
+///
+/// Returns `None` where per-process CPU accounting is unavailable (an
+/// unsupported platform, or the handle/pid is already gone). Callers treat
+/// `None` as "assume progress" so Mode B can never false-kill on a platform it
+/// cannot measure — it simply falls back to the output-only signal there.
+#[cfg(windows)]
+fn child_cpu_ticks(child: &Child) -> Option<u64> {
+    use windows_sys::Win32::Foundation::FILETIME;
+    use windows_sys::Win32::System::Threading::GetProcessTimes;
+
+    let handle = child.raw_handle()?;
+    let mut creation = FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    };
+    let mut exit = creation;
+    let mut kernel = creation;
+    let mut user = creation;
+    // SAFETY: `handle` is a live process handle owned by `child` (the child has
+    // not been dropped); the four FILETIME out-params are valid stack storage.
+    let ok = unsafe {
+        GetProcessTimes(
+            handle.cast::<std::ffi::c_void>(),
+            &mut creation,
+            &mut exit,
+            &mut kernel,
+            &mut user,
+        )
+    };
+    if ok == 0 {
+        return None;
+    }
+    let filetime_to_u64 =
+        |ft: FILETIME| ((ft.dwHighDateTime as u64) << 32) | ft.dwLowDateTime as u64;
+    Some(filetime_to_u64(kernel).wrapping_add(filetime_to_u64(user)))
+}
+
+#[cfg(target_os = "linux")]
+fn child_cpu_ticks(child: &Child) -> Option<u64> {
+    // /proc/<pid>/stat: `pid (comm) state ...`. `comm` can contain spaces and
+    // parens, so split after the LAST ')' before tokenizing. utime is field 14
+    // and stime is field 15 (1-based) overall → indices 11 and 12 of the
+    // post-')' tokens (which start at field 3, `state`).
+    let pid = child.id()?;
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let after_comm = stat.rsplit_once(')')?.1;
+    let fields: Vec<&str> = after_comm.split_whitespace().collect();
+    let utime: u64 = fields.get(11)?.parse().ok()?;
+    let stime: u64 = fields.get(12)?.parse().ok()?;
+    Some(utime.wrapping_add(stime))
+}
+
+#[cfg(target_os = "macos")]
+fn child_cpu_ticks(child: &Child) -> Option<u64> {
+    // macOS: `proc_pid_rusage(RUSAGE_INFO_V2)` reports the process's cumulative
+    // user + system CPU time (nanoseconds, monotonic). Sufficient for the
+    // delta-only "did it burn CPU?" check.
+    let pid = child.id()? as libc::c_int;
+    // SAFETY: zeroed POD struct; `proc_pid_rusage` fills it and returns 0 on
+    // success. We pass a valid `&mut` and the matching V2 flavor.
+    let mut info: libc::rusage_info_v2 = unsafe { std::mem::zeroed() };
+    let rc = unsafe {
+        libc::proc_pid_rusage(
+            pid,
+            libc::RUSAGE_INFO_V2,
+            &mut info as *mut libc::rusage_info_v2 as *mut _,
+        )
+    };
+    if rc != 0 {
+        return None;
+    }
+    Some(info.ri_user_time.wrapping_add(info.ri_system_time))
+}
+
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
+fn child_cpu_ticks(_child: &Child) -> Option<u64> {
+    // Exotic non-CI targets (e.g. the BSDs) with no wired-up per-process CPU
+    // accounting. Mode B relies on the output-progress signal alone here (the
+    // `None` == "assume progress" rule), so it never false-kills; Mode A
+    // (orphan-pipe) still applies.
+    None
+}
+
 /// Await a spawned child, draining stdout/stderr concurrently, with a
 /// post-exit orphan-pipe watchdog (issue #962).
 ///
@@ -79,21 +209,51 @@ pub(crate) async fn wait_with_output_watchdog(
     child: Child,
     cmd_desc: &str,
 ) -> std::io::Result<Output> {
-    wait_with_output_watchdog_with_grace(child, cmd_desc, post_exit_grace()).await
+    watchdog_inner(
+        child,
+        cmd_desc,
+        post_exit_grace(),
+        stall_window(),
+        STALL_TICK,
+    )
+    .await
 }
 
-/// [`wait_with_output_watchdog`] with an explicit drain grace, so tests can pin
-/// the grace without mutating the process-global environment (which would race
-/// across parallel tests). A `grace` of zero disables the watchdog and falls
-/// back to the historical unbounded `wait_with_output`.
-pub(crate) async fn wait_with_output_watchdog_with_grace(
-    mut child: Child,
+/// [`wait_with_output_watchdog`] with an explicit post-exit drain grace and
+/// Mode B (alive-hung) disabled, so tests can pin the grace without mutating
+/// the process-global environment (which would race across parallel tests). A
+/// `grace` of zero disables the watchdog and falls back to the historical
+/// unbounded `wait_with_output`. Test-only: production callers use
+/// [`wait_with_output_watchdog`] (both modes, env-configured).
+#[cfg(test)]
+async fn wait_with_output_watchdog_with_grace(
+    child: Child,
     cmd_desc: &str,
     grace: Duration,
 ) -> std::io::Result<Output> {
-    // Grace of zero == watchdog disabled: fall back to the historical behavior
-    // so a host can opt out if some exotic pipeline needs strict EOF semantics.
-    if grace.is_zero() {
+    watchdog_inner(child, cmd_desc, grace, Duration::ZERO, STALL_TICK).await
+}
+
+/// Core watchdog loop.
+///
+/// - `grace` > 0 enables Mode A (issue #962): after the child exits, bound the
+///   stdout/stderr EOF drain, abandoning it if an orphaned grandchild holds the
+///   pipe.
+/// - `stall_window` > 0 enables Mode B (issue #891): while the child is still
+///   running, kill it if it makes no progress — no output AND no CPU — for that
+///   long. See [`should_kill_stalled`].
+///
+/// With both zero this is a plain `wait_with_output`.
+async fn watchdog_inner(
+    mut child: Child,
+    cmd_desc: &str,
+    grace: Duration,
+    stall_window: Duration,
+    stall_tick: Duration,
+) -> std::io::Result<Output> {
+    // Both modes disabled: historical behavior (host opt-out for exotic
+    // pipelines needing strict EOF semantics).
+    if grace.is_zero() && stall_window.is_zero() {
         return child.wait_with_output().await;
     }
 
@@ -115,6 +275,16 @@ pub(crate) async fn wait_with_output_watchdog_with_grace(
     // Exit status + the instant the child exited, captured together so the
     // grace deadline never needs an `unwrap`.
     let mut exited: Option<(ExitStatus, Instant)> = None;
+    // Mode B (alive-hung, issue #891) progress tracking. `last_progress` is
+    // reset on every non-empty read; `last_cpu` is the previous CPU sample so a
+    // tick can tell whether the child burned CPU since the last check.
+    let mode_b = !stall_window.is_zero();
+    let mut last_progress = Instant::now();
+    let mut last_cpu = if mode_b {
+        child_cpu_ticks(&child)
+    } else {
+        None
+    };
 
     loop {
         // Clean completion: process exited AND both pipes reached EOF.
@@ -140,6 +310,19 @@ pub(crate) async fn wait_with_output_watchdog_with_grace(
             }
         };
 
+        // Mode B tick: armed only while the child is still running and Mode B
+        // is enabled. Fires every `STALL_TICK` to sample progress; `pending()`
+        // otherwise so it never competes once the child has exited (Mode A
+        // takes over then).
+        let stall_armed = mode_b && exited.is_none();
+        let stall_tick_fut = async move {
+            if stall_armed {
+                tokio::time::sleep(stall_tick).await;
+            } else {
+                std::future::pending::<()>().await;
+            }
+        };
+
         tokio::select! {
             // Concurrent drain of both pipes prevents the classic
             // fill-the-pipe-then-block deadlock; the child-exit wait runs
@@ -150,12 +333,18 @@ pub(crate) async fn wait_with_output_watchdog_with_grace(
             }
             r = read_opt(stdout.as_mut(), &mut sbuf), if !stdout_done => match r {
                 Ok(0) => stdout_done = true,
-                Ok(n) => out.extend_from_slice(&sbuf[..n]),
+                Ok(n) => {
+                    out.extend_from_slice(&sbuf[..n]);
+                    last_progress = Instant::now();
+                }
                 Err(_) => stdout_done = true,
             },
             r = read_opt(stderr.as_mut(), &mut ebuf), if !stderr_done => match r {
                 Ok(0) => stderr_done = true,
-                Ok(n) => err.extend_from_slice(&ebuf[..n]),
+                Ok(n) => {
+                    err.extend_from_slice(&ebuf[..n]);
+                    last_progress = Instant::now();
+                }
                 Err(_) => stderr_done = true,
             },
             () = grace_deadline, if exited.is_some() => {
@@ -179,6 +368,43 @@ pub(crate) async fn wait_with_output_watchdog_with_grace(
                         stdout: out,
                         stderr: err,
                     });
+                }
+            }
+            () = stall_tick_fut, if stall_armed => {
+                // Mode B (issue #891): the child is still running. Sample CPU
+                // and decide whether it is wedged — no output for the whole
+                // stall window AND no CPU burned since the last sample. Either
+                // signal advancing (fresh output, or CPU delta) resets/spares
+                // it, so a silent-but-CPU-bound compile and a chatty-but-slow
+                // one are both left alone.
+                let now_cpu = child_cpu_ticks(&child);
+                let cpu_advanced = match (last_cpu, now_cpu) {
+                    (Some(prev), Some(cur)) => cur > prev,
+                    // Unknown on this platform / handle gone → assume progress
+                    // so Mode B never false-kills something it cannot measure.
+                    _ => true,
+                };
+                last_cpu = now_cpu;
+                if should_kill_stalled(last_progress.elapsed(), stall_window, cpu_advanced) {
+                    emit_stall_diagnostics(
+                        cmd_desc,
+                        stall_window,
+                        last_progress.elapsed(),
+                        out.len(),
+                        err.len(),
+                    );
+                    // Kill the wedged child and reap it to recover the real
+                    // (killed) exit status; the compile-concurrency permit the
+                    // caller holds is freed as soon as we return.
+                    let _ = child.start_kill();
+                    return match child.wait().await {
+                        Ok(status) => Ok(Output {
+                            status,
+                            stdout: out,
+                            stderr: err,
+                        }),
+                        Err(e) => Err(e),
+                    };
                 }
             }
         }
@@ -238,6 +464,45 @@ fn emit_orphan_pipe_diagnostics(
             "stdout_eof": stdout_done,
             "stderr_eof": stderr_done,
             "reason": "orphaned grandchild inherited the pipe write handle; drain abandoned to free the compile-concurrency permit",
+        }),
+    );
+}
+
+/// Loud + durable diagnostics for a fired alive-hung (Mode B) watchdog, per the
+/// forensics rule. Emitted only when the child made no progress — no output AND
+/// no CPU — for the whole stall window, so it is a genuine wedge, not a slow
+/// build.
+fn emit_stall_diagnostics(
+    cmd_desc: &str,
+    stall_window: Duration,
+    since_progress: Duration,
+    stdout_bytes: usize,
+    stderr_bytes: usize,
+) {
+    tracing::warn!(
+        event = "child_wait_watchdog_fired",
+        stage = "alive_hung_no_progress",
+        cmd = %cmd_desc,
+        stall_window_ms = stall_window.as_millis() as u64,
+        since_progress_ms = since_progress.as_millis() as u64,
+        stdout_bytes,
+        stderr_bytes,
+        "child is still running but produced no output AND burned no CPU for the \
+         stall window — treating it as wedged; killing it so the daemon does not \
+         park forever and leak a compile-concurrency permit (issue #891). This is \
+         progress-based, not a wall-clock cap: a compile emitting output or burning \
+         CPU is never affected."
+    );
+    crate::core::lifecycle::write_event(
+        "child_wait_watchdog_fired",
+        serde_json::json!({
+            "stage": "alive_hung_no_progress",
+            "cmd": cmd_desc,
+            "stall_window_ms": stall_window.as_millis() as u64,
+            "since_progress_ms": since_progress.as_millis() as u64,
+            "stdout_bytes": stdout_bytes,
+            "stderr_bytes": stderr_bytes,
+            "reason": "no output and no CPU progress for the stall window; killed as wedged",
         }),
     );
 }
@@ -361,6 +626,94 @@ mod tests {
                 .expect("watchdog wait");
             assert!(out.status.success());
             assert!(String::from_utf8_lossy(&out.stdout).contains("ok"));
+        })
+        .await;
+    }
+
+    // ── Mode B: alive-hung / CPU-progress watchdog (issue #891) ──────────
+
+    /// A process that sleeps: no output, ~0 CPU — the canonical wedge Mode B
+    /// must catch. `>nul` keeps `ping` from writing to our captured stdout.
+    fn sleeper_cmd() -> tokio::process::Command {
+        #[cfg(windows)]
+        {
+            let mut c = tokio::process::Command::new("cmd");
+            c.args(["/c", "ping -n 31 127.0.0.1 >nul"]);
+            c
+        }
+        #[cfg(unix)]
+        {
+            let mut c = tokio::process::Command::new("sh");
+            c.args(["-c", "sleep 30"]);
+            c
+        }
+    }
+
+    #[test]
+    fn should_kill_stalled_only_when_silent_and_cpu_flat() {
+        let w = Duration::from_secs(300);
+        assert!(
+            should_kill_stalled(Duration::from_secs(301), w, false),
+            "no output past the window AND cpu flat → wedged"
+        );
+        assert!(
+            !should_kill_stalled(Duration::from_secs(301), w, true),
+            "cpu still advancing → never killed, even past the window"
+        );
+        assert!(
+            !should_kill_stalled(Duration::from_secs(10), w, false),
+            "within the window → never killed"
+        );
+        assert!(
+            !should_kill_stalled(Duration::from_secs(10), w, true),
+            "recent progress + cpu → never killed"
+        );
+    }
+
+    /// Per-platform integration: per-process CPU sampling must actually work on
+    /// every CI platform (Windows / Linux / macOS), not silently no-op.
+    #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
+    async fn child_cpu_ticks_reports_for_live_process() {
+        crate::test_support::test_timeout(async {
+            let mut child = piped(sleeper_cmd()).spawn().expect("spawn");
+            let ticks = super::child_cpu_ticks(&child);
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            assert!(
+                ticks.is_some(),
+                "per-process CPU sampling must be wired up on this platform (#891)"
+            );
+        })
+        .await;
+    }
+
+    /// End-to-end Mode B: a still-running child with no output and no CPU is
+    /// killed within the (tiny, for the test) stall window instead of hanging.
+    #[tokio::test]
+    async fn alive_hung_no_progress_child_is_killed() {
+        crate::test_support::test_timeout(async {
+            let child = piped(sleeper_cmd()).spawn().expect("spawn");
+            let start = Instant::now();
+            // Mode A off (grace 0); Mode B on with a tiny window + tick.
+            let out = watchdog_inner(
+                child,
+                "sleeper",
+                Duration::ZERO,
+                Duration::from_millis(150),
+                Duration::from_millis(50),
+            )
+            .await
+            .expect("watchdog wait");
+            assert!(
+                start.elapsed() < Duration::from_secs(15),
+                "Mode B must kill the wedged child promptly (took {:?})",
+                start.elapsed()
+            );
+            assert!(
+                !out.status.success(),
+                "a killed wedged child must not report success"
+            );
         })
         .await;
     }


### PR DESCRIPTION
## Summary

Implements #891 (meta #889 → #968): the **alive-hung / CPU-progress watchdog**
("Mode B"). Complements the #962 orphan-pipe watchdog ("Mode A", already in
`daemon/child_watchdog.rs`): Mode A bounds the drain *after* a child exits; Mode
B catches a child that never exits and makes no progress.

## Design — progress-based, never a wall-clock cap

While a daemon-owned child is still running, the watchdog samples progress every
`STALL_TICK` (5 s) and kills it only when it has, for the whole stall window
(`ZCCACHE_STALL_WINDOW_MS`, default 300 s):

1. produced **no** stdout/stderr output, **and**
2. burned **no** CPU (its total user+kernel CPU time did not advance).

Requiring *both* is the point: a silent-but-CPU-bound compile (rustc mid-codegen
prints nothing) keeps advancing CPU and is never touched; a chatty-but-slow
compile keeps advancing output and is never touched. Only a genuinely wedged
process — silent *and* idle for 5 minutes — is reaped. This honors the "no dumb
wall-clock timeout; large links run for minutes" contract: a live link burning
CPU / writing output is never affected. The kill decision is the pure,
unit-tested `should_kill_stalled(since_progress, window, cpu_advanced)`.

## Per-process CPU sampling — all platforms

`child_cpu_ticks(&Child) -> Option<u64>` returns cumulative user+kernel CPU in an
opaque monotonic unit (delta-comparison only):

- **Windows:** `GetProcessTimes` (kernel+user FILETIME).
- **Linux:** `/proc/<pid>/stat` utime+stime (robust parse after the last `)`).
- **macOS:** `libc::proc_pid_rusage(RUSAGE_INFO_V2)` ri_user_time+ri_system_time.
- other (non-CI BSDs): `None` → treated as "assume progress", so Mode B never
  false-kills a platform it cannot measure (Mode A still applies).

Validated on all three CI platforms via `soldr cargo check --target` cross-compile
plus a per-platform integration test.

On fire: loud `warn! event="child_wait_watchdog_fired" stage="alive_hung_no_progress"`
+ a durable lifecycle event with the window, elapsed-since-progress, and byte
counts (forensics rule).

## Wiring

`wait_with_output_watchdog` (used by every compile/link/exec spawn via
`process::tokio_command_output_with_priority_stdin`) now runs both modes. The
stall tick is `pending()` once the child exits, so it never competes with Mode
A. `ZCCACHE_STALL_WINDOW_MS=0` disables Mode B (Mode A stays on).

## Tests

`daemon::child_watchdog::tests`:
- `should_kill_stalled_only_when_silent_and_cpu_flat` — the decision matrix.
- `child_cpu_ticks_reports_for_live_process` — per-platform CPU sampling actually
  works (Windows/Linux/macOS), not a silent no-op.
- `alive_hung_no_progress_child_is_killed` — a sleeper (no output, ~0 CPU) is
  killed within a tiny test window instead of hanging.
- Existing Mode A tests still pass.

Refs #889 #968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
