### PR TITLE
fix(ci): lint feature-gated targets so the Clippy job is green

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,6 +17,13 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Feature set that makes `--all-targets` compile the feature-gated
+  # integration tests (`zccache::ci`, `zccache::cli`, `zccache::symbols`,
+  # the `zip`/download installer test, …). Kept in sync with
+  # `integration.yml`'s ZCCACHE_INTEGRATION_FEATURES — without it,
+  # `clippy --workspace --all-targets` fails to compile those tests with
+  # `unresolved import` (the long-standing red Clippy job).
+  ZCCACHE_CLIPPY_FEATURES: "zccache/zccache-bin,zccache/daemon-bin,zccache/download-bin,zccache/download-daemon-bin,zccache/fingerprint-bin,zccache/stamp-bin,zccache/ci-bin,zccache/crash-tools,zccache/tokio-console,zccache/test-support"
   # NOTE: -D warnings deliberately omitted (#944). The workspace
   # [lints.clippy] block in Cargo.toml uses `deny` for the panic-class
   # lints (unwrap_used / unwrap_in_result / panic_in_result_fn) which
@@ -45,4 +52,4 @@ jobs:
       - name: Install Clippy
         run: soldr rustup component add clippy
       - name: Run Clippy
-        run: soldr cargo clippy --workspace --all-targets
+        run: soldr cargo clippy --workspace --all-targets --features "$ZCCACHE_CLIPPY_FEATURES"

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,42 @@
+# Lessons
+
+## Stopping a `soldr cargo` task can orphan its cargo child and wedge the build lock (2026-07-08)
+
+`TaskStop` on a background `soldr cargo test/check` kills the bash wrapper but
+the `cargo.exe` grandchild can survive as an orphan, keep holding the
+`target/debug/.cargo-lock`, and make every *subsequent* build print
+"Blocking waiting for file lock on build directory" — which looked like builds
+"dying" (they were actually blocked forever, and my monitors' racy
+no-process check misread it). The monolithic `zccache` crate's multi-minute
+single-rustc compile (see #975) amplified the confusion.
+
+**Rule:** don't launch overlapping `soldr cargo` builds, and don't `TaskStop`
+one mid-compile and immediately start another. If a build wedges, run
+`taskkill /F /IM cargo.exe //T; taskkill /F /IM rustc.exe //T` to clear orphans
+before retrying, and confirm `tasklist | grep -c cargo` is 0. Prefer the lighter
+`cargo check` locally and let CI run the heavy test build.
+
+## Admin-merge only after the fast lint gates are green (2026-07-08)
+
+**Mistake:** admin-merged #967 (PR #969) without waiting for CI. It carried two
+lint regressions that turned main red:
+- rustdoc `-D warnings`: a public item's doc (`wait_for_disconnect`) linked to a
+  private item (`framing::read_next_chunk`). Public→private intra-doc links are a
+  hard rustdoc error under `-D warnings`.
+- rustfmt: an edited file was not `cargo fmt`-clean.
+
+Local `cargo check -p <crate> --lib` and unit tests were green, so the code was
+correct — but neither runs rustdoc or rustfmt. The Documentation and Formatting
+CI jobs (in the Clippy workflow) caught it only after merge.
+
+**Rule for the future:** before pushing/merging any PR, run the fast gates
+locally — they're cheap and catch exactly what `cargo check` misses:
+- `soldr cargo fmt --all --check`  (instant)
+- `RUSTDOCFLAGS="-D warnings" soldr cargo doc -p <crate> --no-deps --lib`  (~1 min)
+- `soldr cargo clippy -p <crate> --lib` (feature-gated integration tests need the
+  right `--features`; use `--workspace --all-targets` to match CI's feature
+  unification, or scope with the needed feature).
+
+If admin-merging past CI for speed, at minimum run fmt --check + doc first. The
+perf-rust-cluster jobs (`arm / Test`, `x86 / Test`, `arm-musl / Check`) are
+known-broken at the pin step and are NOT merge-blocking — don't chase them.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,87 +1,38 @@
-# Static Library (.a) Caching — Phase 1
+# #968 wedge/timeout burn-down — near complete
 
-Cache compiled static libraries (.a, .lib) the same way we cache .o files.
-Shared libraries (.so, .dylib, .dll) and executables are Phase 2.
+Meta: https://github.com/zackees/zccache/issues/968
 
-## Design Decisions
+## Merged to main ✅
+- #967 (PR #969) client-disconnect cancellation
+- #962 (PR #970) orphan-pipe post-exit watchdog (Mode A)
+- #971 (PR #976) in_flight_exec lost-wakeup + bounded waiter + exec-spawn watchdog
+- #972 (PR #978) `-vV` identity probe timeout
+- #973 (PR #977) embedded flush disk-save bounds
+- #891 (PR #980) CPU/output progress watchdog (Mode B) — all-platform CPU sampling
+- #890 (PR #981) async/process bridge design doc (runtime.md)
 
-| Decision | Choice |
-|----------|--------|
-| Priority | Static libs first (.a via ar/llvm-ar/lib.exe) |
-| Interception | Explicit prefix wrapper (`zccache ar ...`) + compiler driver interception |
-| Non-determinism | Detect, warn, pass through — never cache non-deterministic links |
-| Incremental invalidation | Full cache miss if any input changes |
-| Scope | Libraries and executables (executables in Phase 2) |
-| Windows | Day one — lib.exe alongside GNU/LLVM |
-| Cache pool | Single shared pool, existing 10GB default |
-| Tool coverage | ar, llvm-ar, lib.exe (Phase 1); ld, lld, mold, ld64, link.exe (Phase 2) |
-| Input verification | Metadata cache + watcher for .o files (same model as source files) |
-| Implicit inputs | Track linker scripts, .def files, resolved -lfoo |
-| Build systems | Agnostic — intercept tool invocation |
+## In CI (merge when green) 🔁
+- #974 (PR #979) watcher consumer wakes on shutdown
+- #893 (PR #983) child pid in watchdog diagnostics
+- #892 (PR #984) pipe-saturation / concurrent-drain regression test
 
-## Plan
+## Remaining 📋
+- #894 concurrency-not-reduced test (child_watchdog tests) — DO AFTER #892 merges
+  (same tests-module region → conflict otherwise). N concurrent watchdog waits on
+  ~1s sleepers → assert total < serial (not serialized).
+- Then close #889 (all children #890/#891/#892/#893/#894 done) + close #968.
 
-- [x] Step 1: Archiver argument parser (`crates/zccache-compiler/src/parse_archiver.rs`)
-  - ArchiverFamily: Ar, LlvmAr, MsvcLib (30 tests)
-  - Parse GNU ar (`ar rcs libfoo.a a.o b.o`), MSVC lib.exe (`lib /OUT:foo.lib a.obj`)
-  - Non-cacheable detection: extract, list, delete, print, stdin
-  - Non-determinism detection: missing 'D' flag (ar) or /BREPRO (lib.exe)
-- [x] Step 2: Link cache key builder (`crates/zccache-hash/src/link_cache_key.rs`)
-  - Domain tag: "zccache-link-key-v1" (7 tests)
-  - Ordered input hashes (NOT sorted — order matters)
-  - Tool hash + flags + env vars
-  - Domain separation verified vs compile keys
-- [x] Step 3: Protocol extensions (`crates/zccache-protocol/src/messages.rs`)
-  - Request::LinkEphemeral, Response::LinkResult (with warning field)
-  - Updated DaemonStatus with link stats (total_links, link_hits, link_misses, link_non_cacheable)
-  - Roundtrip tests for all new variants
-- [x] Step 4: CLI routing (`crates/zccache-cli/src/main.rs`)
-  - Detect archiver tools via is_archiver() in wrap mode
-  - Route to LinkEphemeral request via cmd_link_ephemeral()
-  - Status display shows link stats when total_links > 0
-  - Added zccache-compiler dependency to CLI
-- [x] Step 5: Daemon link handler (`crates/zccache-daemon/src/server.rs`)
-  - handle_link_ephemeral: full cache hit/miss/passthrough flow
-  - Hash tool + input files via metadata cache + watcher
-  - Cache key computation via LinkCacheKeyBuilder
-  - Non-determinism: warn and pass through (never cache)
-  - Stats tracking via StatsCollector methods
-  - Artifact persistence via .meta sidecars (survives daemon restarts)
-- [x] Step 6: Integration tests (`crates/zccache-daemon/tests/link_cache_test.rs`)
-  - 5 tests (all #[ignore], run with `test --full`)
-  - test_ar_cache_miss_then_hit: compile miss → delete → cache hit, byte-identical
-  - test_ar_cache_invalidated_on_input_change: modify .o → cache miss
-  - test_ar_non_deterministic_warning: rcs without D → warning + passthrough
-  - test_ar_non_cacheable_passthrough: ar t → passthrough with output
-  - test_link_stats_in_status: verify DaemonStatus.total_links increments
-  - Also fixed: daemon_start tests now #[ignore] (were causing flaky failures)
+## Extra issues filed (user requests)
+- #975 internal multi-crate split for parallel compiles (single published crate)
+- soldr#1465 soldr build wedge (embedded zccache cache) — silent death; ZCCACHE_DISABLE=1 recovery
 
----
+## Key techniques learned (memory)
+- ZCCACHE_DISABLE=1 to bypass wedge-prone build cache locally
+- soldr cargo check --target <triple> to validate cfg(linux)/cfg(macos) arms locally
+- Always `cargo fmt --all` (auto-fix) + real exit check (no pipe mask) before commit
+- Kill orphan cargo.exe holding target/debug/.cargo-lock if builds "block"
 
-# Sibling Git Workspace + Path Remap Auto Benchmarks
-
-Add benchmark scenarios that exercise `ZCCACHE_PATH_REMAP=auto` across sibling
-git workspaces. Compare warm-state performance against bare compiler and
-sccache. Cold rows are intentionally omitted — the new feature only changes
-warm-state cache identity.
-
-## Scope
-
-- C++ (clang++, 50 files): single-file warm.
-- Rust (rustc, build emit-link, 50 files): warm only.
-- Each benchmark sets up two sibling git roots (`workspace-a` / `workspace-b`),
-  primes zccache from workspace A, then measures warm trials in workspace B.
-- Bare and sccache run warm trials in workspace B using their normal
-  same-workspace warm semantics (they cannot share across sibling roots).
-
-## Plan
-
-- [x] Step 1: Add `perf_cpp_sibling_remap_warm` test
-      (`crates/zccache-daemon/tests/perf_bench_test.rs`). Verified locally:
-      zccache 0.695s vs bare 11.353s (16x) vs sccache 1.420s (2x).
-- [x] Step 2: Add `perf_rustc_sibling_remap_warm` test. Verified locally:
-      zccache 0.195s vs bare 5.909s (30x) vs sccache 7.447s (38x).
-- [x] Step 3: Update `ci/benchmark_stats.py` TABLES dict and
-      `BENCHMARK_TESTS_BY_LANGUAGE`. Updated `ci/tests/test_perf_guard.py`
-      and `ci/tests/test_benchmark_stats.py` fixtures/assertions.
-- [x] Step 4: Verified pytest passes (37/37 + 1 skipped) and clippy clean.
+## Design rules honored
+- Progress/CPU-based watchdogs, never dumb wall-clock (links run minutes)
+- Every timeout/watchdog fire: loud warn! + durable lifecycle event (forensics)
+- Constants at top of file


### PR DESCRIPTION
Fixes main's **long-standing red Clippy job** (failing since before this burn-down, unrelated to it).

**Cause:** `clippy --workspace --all-targets` builds zccache with `default = []`, so every feature-gated integration test (`zccache::ci`, `zccache::cli`, `zccache::symbols`, the `zip`/download installer test) fails to compile with `unresolved import`.

**Fix:** give clippy the same feature set the Integration workflow already uses (`ZCCACHE_CLIPPY_FEATURES`, mirroring `integration.yml`'s `ZCCACHE_INTEGRATION_FEATURES`), so `--all-targets` compiles **and lints** those targets.

Validated locally: `clippy --workspace --all-targets --features <set>` → 0 warnings, exit 0. No `-D warnings` change (kept omitted per #944).

Also carries leftover working-tree housekeeping (tasks/todo.md burn-down notes + tasks/lessons.md).

⚠️ CI-config change — surfaced during the #968 burn-down; the Clippy job on this PR is the proof it works.