### PR TITLE
feat(cli): ZCCACHE_NO_SPAWN host guard — refuse standalone daemon spawns

### DIFF
--- a/crates/zccache/src/cli/commands/daemon.rs
+++ b/crates/zccache/src/cli/commands/daemon.rs
@@ -91,6 +91,12 @@ pub(crate) async fn spawn_and_wait(
     reason: &str,
     outbound_pid: Option<u32>,
 ) -> Result<(), String> {
+    // Issue #982: embedding hosts forbid standalone daemon spawns.
+    // Checked before binary resolution so the refusal message is the
+    // guard's, not a misleading "cannot find zccache-daemon binary".
+    if crate::core::config::daemon_spawn_disabled() {
+        return Err(crate::core::config::no_spawn_error("zccache-daemon"));
+    }
     let daemon_bin = find_daemon_binary().ok_or("cannot find zccache-daemon binary")?;
     tracing::debug!(?daemon_bin, %endpoint, reason, "spawning daemon");
     // Issue #952: single-flight the spawn — same arbiter as the
@@ -210,6 +216,17 @@ pub(crate) async fn stop_stale_daemon(endpoint: &str) -> Option<u32> {
 /// the daemon, only one wins the bind. The losers detect this and connect to
 /// the winning daemon instead of failing.
 pub(crate) async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
+    // Issue #982: under the host no-spawn guard a reachable,
+    // version-compatible daemon may still be used, but every other
+    // outcome — including the stale-daemon replace paths, which would
+    // stop the old daemon before respawning — fails here, BEFORE
+    // anything is stopped or killed.
+    if crate::core::config::daemon_spawn_disabled() {
+        return match check_daemon_version(endpoint).await {
+            VersionCheck::Ok | VersionCheck::DaemonNewer { .. } => Ok(()),
+            _ => Err(crate::core::config::no_spawn_error("zccache-daemon")),
+        };
+    }
     // Fast path: connect + version check
     match check_daemon_version(endpoint).await {
         VersionCheck::Ok => return Ok(()),

--- a/crates/zccache/src/cli/runtime.rs
+++ b/crates/zccache/src/cli/runtime.rs
@@ -90,6 +90,12 @@ async fn spawn_and_wait(
     reason: &str,
     outbound_pid: Option<u32>,
 ) -> Result<(), String> {
+    // Issue #982: embedding hosts forbid standalone daemon spawns.
+    // Checked before binary resolution so the refusal message is the
+    // guard's, not a misleading "cannot find zccache-daemon binary".
+    if crate::core::config::daemon_spawn_disabled() {
+        return Err(crate::core::config::no_spawn_error("zccache-daemon"));
+    }
     let daemon_bin = find_daemon_binary().ok_or("cannot find zccache-daemon binary")?;
     // Issue #952: single-flight the spawn across a client herd. A
     // -j16 cold start used to produce 16+ spawn-attempts within
@@ -405,6 +411,17 @@ async fn stop_stale_daemon(endpoint: &str) -> Option<u32> {
 }
 
 pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
+    // Issue #982: under the host no-spawn guard a reachable,
+    // version-compatible daemon may still be used, but every other
+    // outcome — including the stale-daemon replace paths, which would
+    // stop the old daemon before respawning — fails here, BEFORE
+    // anything is stopped or killed.
+    if crate::core::config::daemon_spawn_disabled() {
+        return match check_daemon_version(endpoint).await {
+            VersionCheck::Ok | VersionCheck::DaemonNewer => Ok(()),
+            _ => Err(crate::core::config::no_spawn_error("zccache-daemon")),
+        };
+    }
     match check_daemon_version(endpoint).await {
         VersionCheck::Ok | VersionCheck::DaemonNewer => return Ok(()),
         VersionCheck::DaemonOlder { daemon_ver } => {
@@ -742,6 +759,12 @@ pub fn gc_daemon_spawn_logs() {
 }
 
 pub fn spawn_daemon(bin: &Path, endpoint: &str) -> Result<(), String> {
+    // Issue #982: backstop for the host no-spawn guard — refuse before
+    // `prepare_daemon_exe` materializes a runtime-binaries copy, so a
+    // guarded run leaves zero daemon artifacts on disk.
+    if crate::core::config::daemon_spawn_disabled() {
+        return Err(crate::core::config::no_spawn_error("zccache-daemon"));
+    }
     // GC before the new spawn so neither dir grows unbounded across
     // crash-loop scenarios. Live daemons keep their open log file FDs;
     // GC only touches files older than the 24h cutoff and preserves

--- a/crates/zccache/src/core/config/mod.rs
+++ b/crates/zccache/src/core/config/mod.rs
@@ -48,6 +48,41 @@ pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 3600;
 /// without falling back to byte-copy. Unset → behaviour unchanged.
 pub const COLOCATE_ENV: &str = "ZCCACHE_COLOCATE";
 
+/// Environment variable set by embedding hosts (e.g. soldr's compiled-in
+/// `zccache` trampoline, which serves compiles through an embedded
+/// in-process zccache service) to forbid the CLI from ever spawning a
+/// standalone `zccache-daemon` / `zccache-download-daemon` process
+/// (issue #982). Value grammar matches `ZCCACHE_DISABLE`: `1` or
+/// case-insensitive `true`. Connecting to an already-running,
+/// version-compatible daemon remains allowed — the guard forbids
+/// spawning, not talking.
+pub const NO_SPAWN_ENV: &str = "ZCCACHE_NO_SPAWN";
+
+/// True when the host forbids standalone daemon spawns via [`NO_SPAWN_ENV`].
+#[must_use]
+pub fn daemon_spawn_disabled() -> bool {
+    no_spawn_from_env_value(std::env::var_os(NO_SPAWN_ENV).as_deref())
+}
+
+/// Testable core of [`daemon_spawn_disabled`] — no environment access.
+#[must_use]
+pub(crate) fn no_spawn_from_env_value(value: Option<&std::ffi::OsStr>) -> bool {
+    value
+        .map(|v| v.to_string_lossy())
+        .is_some_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+}
+
+/// Standard error for a refused spawn. Names [`NO_SPAWN_ENV`] so operators
+/// can find the knob, and points at the embedded service so the failure is
+/// self-explaining in host contexts.
+#[must_use]
+pub fn no_spawn_error(daemon_name: &str) -> String {
+    format!(
+        "{daemon_name} spawn disabled by host ({NO_SPAWN_ENV}=1); \
+         this host serves compiles through an embedded zccache service"
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Re-exports — every public symbol the old single-file module exposed.
 // External callers use `crate::core::config::<Name>`, so we keep that path

--- a/crates/zccache/src/core/config/tests.rs
+++ b/crates/zccache/src/core/config/tests.rs
@@ -635,3 +635,25 @@ fn colocate_basename_appears_in_path() {
     assert!(expected_suffix.starts_with(".zccache-myuser-"));
     assert!(expected_suffix.len() == ".zccache-myuser-".len() + 8);
 }
+
+#[test]
+fn no_spawn_value_grammar_matches_zccache_disable() {
+    use super::no_spawn_from_env_value;
+    use std::ffi::OsStr;
+
+    assert!(no_spawn_from_env_value(Some(OsStr::new("1"))));
+    assert!(no_spawn_from_env_value(Some(OsStr::new("true"))));
+    assert!(no_spawn_from_env_value(Some(OsStr::new("TRUE"))));
+    assert!(no_spawn_from_env_value(Some(OsStr::new("True"))));
+    assert!(!no_spawn_from_env_value(Some(OsStr::new("0"))));
+    assert!(!no_spawn_from_env_value(Some(OsStr::new(""))));
+    assert!(!no_spawn_from_env_value(Some(OsStr::new("yes"))));
+    assert!(!no_spawn_from_env_value(None));
+}
+
+#[test]
+fn no_spawn_error_names_the_env_var() {
+    let message = super::no_spawn_error("zccache-daemon");
+    assert!(message.contains("ZCCACHE_NO_SPAWN"));
+    assert!(message.contains("zccache-daemon"));
+}

--- a/crates/zccache/src/core/lifecycle.rs
+++ b/crates/zccache/src/core/lifecycle.rs
@@ -442,16 +442,34 @@ mod tests {
 
         let log_path = log_file_path().as_path().to_path_buf();
         let contents = std::fs::read_to_string(&log_path).expect("log file written");
-        let lines: Vec<&str> = contents.lines().collect();
-        assert_eq!(lines.len(), 2, "expected two events, got: {contents:?}");
+        // Concurrent tests elsewhere in the crate legitimately emit their
+        // own lifecycle events while this test's cache-dir override is
+        // active: `write_event` reads the env at call time, and async
+        // tests (e.g. the child-watchdog kill paths) cannot hold ENV_LOCK
+        // across their awaits. Filter to the two events this test wrote
+        // instead of asserting an exact line count (arm-lane flake seen
+        // on zccache#987).
+        let mine: Vec<serde_json::Value> = contents
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("line parses"))
+            .filter(|value| {
+                (value["event"] == EVENT_SPAWN && value["endpoint"] == "test://nowhere")
+                    || (value["event"] == EVENT_DIED_IDLE && value["idle_secs"] == 3600)
+            })
+            .collect();
+        assert_eq!(
+            mine.len(),
+            2,
+            "expected this test's two events, got: {contents:?}"
+        );
 
-        let first: serde_json::Value = serde_json::from_str(lines[0]).expect("line 0 parses");
+        let first = &mine[0];
         assert_eq!(first["event"], EVENT_SPAWN);
         assert!(first["ts_ms"].is_number());
         assert!(first["pid"].is_number());
         assert_eq!(first["endpoint"], "test://nowhere");
 
-        let second: serde_json::Value = serde_json::from_str(lines[1]).expect("line 1 parses");
+        let second = &mine[1];
         assert_eq!(second["event"], EVENT_DIED_IDLE);
         assert_eq!(second["idle_secs"], 3600);
         assert_eq!(second["uptime_secs"], 7200);

--- a/crates/zccache/src/download_client/mod.rs
+++ b/crates/zccache/src/download_client/mod.rs
@@ -105,6 +105,14 @@ fn which_on_path(name: &str) -> Option<NormalizedPath> {
 }
 
 fn spawn_daemon(bin: &Path, endpoint: &str) -> Result<(), String> {
+    // Issue #982: backstop for the host no-spawn guard (see
+    // `core::config::NO_SPAWN_ENV`) — the download daemon is covered
+    // by the same contract as the compile daemon.
+    if crate::core::config::daemon_spawn_disabled() {
+        return Err(crate::core::config::no_spawn_error(
+            "zccache-download-daemon",
+        ));
+    }
     let mut cmd = std::process::Command::new(bin);
     cmd.args(["--foreground", "--endpoint", endpoint]);
     cmd.stdin(std::process::Stdio::null());
@@ -134,6 +142,13 @@ async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
         }
         return Err(format!(
             "download daemon process {pid} exists but is not accepting connections"
+        ));
+    }
+    // Issue #982: refuse before binary resolution so the guard's message
+    // wins over "cannot find zccache-download-daemon binary".
+    if crate::core::config::daemon_spawn_disabled() {
+        return Err(crate::core::config::no_spawn_error(
+            "zccache-download-daemon",
         ));
     }
     let bin = find_daemon_binary().ok_or("cannot find zccache-download-daemon binary")?;

--- a/crates/zccache/tests/ci_timeout_and_progress.rs
+++ b/crates/zccache/tests/ci_timeout_and_progress.rs
@@ -2,6 +2,10 @@
 //! markers exposed by `zccache-ci`. Uses parameterized timeouts of a few
 //! hundred milliseconds so the suite runs in well under a second.
 
+// `zccache::ci` is gated behind the `ci` feature (c615a17e "gate zccache
+// dependency surfaces"). Without this gate a default-features
+// `clippy/check --all-targets` fails to compile the target.
+#![cfg(feature = "ci")]
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,

--- a/crates/zccache/tests/cli_ino_convert.rs
+++ b/crates/zccache/tests/cli_ino_convert.rs
@@ -1,3 +1,9 @@
+// The whole file tests `zccache::cli::run_ino_convert_cached`, which is
+// gated behind the `cli` feature (c615a17e "gate zccache dependency
+// surfaces"). Without this gate a default-features `clippy/check
+// --all-targets` fails to compile the target (broke the clippy lane on
+// main).
+#![cfg(feature = "cli")]
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,

--- a/crates/zccache/tests/cli_installers.rs
+++ b/crates/zccache/tests/cli_installers.rs
@@ -1,3 +1,8 @@
+// Uses the optional `zip` dep (and exercises installer download flows),
+// both gated behind `download-client` since c615a17e "gate zccache
+// dependency surfaces". Without this gate a default-features
+// `clippy/check --all-targets` fails to compile the target.
+#![cfg(feature = "download-client")]
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,

--- a/crates/zccache/tests/cli_no_spawn_guard.rs
+++ b/crates/zccache/tests/cli_no_spawn_guard.rs
@@ -1,0 +1,168 @@
+//! Integration tests for the `ZCCACHE_NO_SPAWN` host guard (issue #982).
+//!
+//! Embedding hosts (e.g. soldr's compiled-in `zccache` trampoline, which
+//! serves compiles through an embedded in-process zccache service) set
+//! `ZCCACHE_NO_SPAWN=1` to forbid the CLI from ever spawning a standalone
+//! `zccache-daemon` / `zccache-download-daemon` process.
+//!
+//! Contract under test: a subcommand that would spawn a daemon must
+//! - exit non-zero,
+//! - name `ZCCACHE_NO_SPAWN` in its error output,
+//! - spawn no daemon process, and
+//! - leave no `zccache-daemon.*` runtime-binaries copy behind.
+//!
+//! The tests run the real `zccache` binary as a subprocess with an isolated
+//! `ZCCACHE_CACHE_DIR` + `ZCCACHE_DAEMON_NAMESPACE`, so env handling is
+//! race-free and an accidental spawn (the RED state of this test) cannot
+//! touch the developer's real daemon.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// Path to the zccache binary built by cargo for this integration test.
+///
+/// Using `CARGO_BIN_EXE_zccache` makes cargo build the binary automatically
+/// before running the test (requires the `zccache-bin` feature, which the
+/// integration lane enables via `ZCCACHE_INTEGRATION_FEATURES`).
+fn zccache_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_zccache"))
+}
+
+/// Isolated environment for one guard test: unique cache root + daemon
+/// namespace so nothing here can collide with the developer's real daemon.
+struct GuardEnv {
+    bin: PathBuf,
+    cache_dir: tempfile::TempDir,
+    namespace: String,
+}
+
+impl GuardEnv {
+    fn new(tag: &str) -> Self {
+        Self {
+            bin: zccache_bin(),
+            cache_dir: tempfile::tempdir().expect("create temp cache dir"),
+            namespace: format!("no-spawn-{tag}-{}", std::process::id()),
+        }
+    }
+
+    /// Run `zccache <args>` with the guard env var set to `no_spawn_value`.
+    fn run_guarded(&self, args: &[&str], no_spawn_value: &str) -> Output {
+        Command::new(&self.bin)
+            .args(args)
+            .env("ZCCACHE_CACHE_DIR", self.cache_dir.path())
+            .env("ZCCACHE_DAEMON_NAMESPACE", &self.namespace)
+            .env("ZCCACHE_NO_SPAWN", no_spawn_value)
+            .output()
+            .expect("run zccache subcommand")
+    }
+
+    fn assert_refused(&self, args: &[&str], no_spawn_value: &str) {
+        let output = self.run_guarded(args, no_spawn_value);
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !output.status.success(),
+            "`zccache {}` must fail under ZCCACHE_NO_SPAWN={no_spawn_value}, got success.\noutput: {combined}",
+            args.join(" ")
+        );
+        assert!(
+            combined.contains("ZCCACHE_NO_SPAWN"),
+            "error output must name ZCCACHE_NO_SPAWN so operators can find the knob.\noutput: {combined}"
+        );
+        assert_no_daemon_artifacts(self.cache_dir.path());
+    }
+}
+
+impl Drop for GuardEnv {
+    /// Best-effort cleanup: in the RED state (guard not implemented) the
+    /// subcommand really spawns an isolated daemon — stop it so a failing
+    /// test run cannot leak a process.
+    fn drop(&mut self) {
+        let _ = Command::new(&self.bin)
+            .arg("stop")
+            .env("ZCCACHE_CACHE_DIR", self.cache_dir.path())
+            .env("ZCCACHE_DAEMON_NAMESPACE", &self.namespace)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+}
+
+/// No `zccache-daemon.*` per-launch copy may exist anywhere under the
+/// isolated cache root (see `prepare_daemon_exe` — the copy is the last
+/// step before the actual process spawn).
+fn assert_no_daemon_artifacts(root: &Path) {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().to_string();
+            assert!(
+                !name.starts_with("zccache-daemon"),
+                "found daemon runtime copy {path:?} — the guard must refuse before prepare_daemon_exe"
+            );
+        }
+    }
+}
+
+/// `zccache start` is the most direct spawn path (`cmd_start` →
+/// `spawn_and_wait`). Under the guard it must refuse.
+#[test]
+fn start_refuses_to_spawn_under_no_spawn() {
+    GuardEnv::new("start").assert_refused(&["start"], "1");
+}
+
+/// `zccache session-start` reaches the client-side lazy-spawn path
+/// (`cmd_session_start` → `ensure_daemon`). Under the guard it must refuse
+/// rather than kill/replace/spawn anything.
+#[test]
+fn session_start_refuses_to_spawn_under_no_spawn() {
+    GuardEnv::new("session").assert_refused(&["session-start"], "1");
+}
+
+/// The guard accepts the same value grammar as `ZCCACHE_DISABLE`:
+/// `1` or case-insensitive `true`.
+#[test]
+fn guard_accepts_true_value_variant() {
+    GuardEnv::new("truevar").assert_refused(&["start"], "true");
+}
+
+/// `ZCCACHE_NO_SPAWN=0` must NOT trip the guard: `zccache cache-root` (a
+/// daemon-free subcommand) succeeds and the error message machinery stays
+/// out of the way.
+#[test]
+fn zero_value_does_not_trip_guard() {
+    let env = GuardEnv::new("zero");
+    let output = env.run_guarded(&["cache-root"], "0");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.status.success(),
+        "`zccache cache-root` must succeed with ZCCACHE_NO_SPAWN=0.\noutput: {combined}"
+    );
+    assert!(
+        !combined.contains("ZCCACHE_NO_SPAWN"),
+        "no guard error may appear when the guard is off.\noutput: {combined}"
+    );
+}

--- a/crates/zccache/tests/symbols_stamp_roundtrip.rs
+++ b/crates/zccache/tests/symbols_stamp_roundtrip.rs
@@ -3,6 +3,11 @@
 //! CI workflow relies on — produced by the stamp binary, consumed by
 //! `read_marker_from_path` in the daemon and CLI.
 
+// `zccache::symbols` is gated behind the `symbols` feature (c615a17e
+// "gate zccache dependency surfaces"). Without this gate a
+// default-features `clippy/check --all-targets` fails to compile the
+// target. The integration lane enables it via `stamp-bin` → `symbols`.
+#![cfg(feature = "symbols")]
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,6 +30,7 @@ This document is the index for zccache's architecture specification. Each subsys
 - **Thread safety & crash safety** → [runtime.md](architecture/runtime.md)
 - **Async/process bridge — watchdogs, cancellation & timeouts (deadlock hardening)** → [runtime.md § Async / process bridge](architecture/runtime.md#async--process-bridge-watchdogs-cancellation--timeouts)
 - **Where zccache writes on disk (`ZCCACHE_CACHE_DIR` contract)** → [runtime.md § Cache root invariants](architecture/runtime.md#cache-root-invariants)
+- **Host no-spawn guard (`ZCCACHE_NO_SPAWN`, embedding hosts)** → [runtime.md § Host no-spawn guard](architecture/runtime.md#host-no-spawn-guard-zccache_no_spawn)
 - **Windows/macOS/Linux differences** → [portability.md](architecture/portability.md)
 - **Compile journal fields & `miss_reason` enum** → [journal-schema.md](journal-schema.md)
 

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -332,6 +332,32 @@ shipped binary; callers should set `ZCCACHE_DAEMON_NAMESPACE=dev` (or a more
 specific soldr namespace) and then use the normal `zccache` / `zccache-daemon`
 entrypoints.
 
+### Host no-spawn guard (`ZCCACHE_NO_SPAWN`)
+
+Embedding hosts that serve compiles through the in-process embedded service
+(see [embedded-service.md](embedded-service.md)) set `ZCCACHE_NO_SPAWN=1`
+(or case-insensitive `true`) to forbid the CLI from ever spawning a
+standalone `zccache-daemon` or `zccache-download-daemon` process
+(issue #982). soldr's compiled-in `zccache` trampoline is the canonical
+setter.
+
+Semantics:
+
+- Connecting to an **already-running, version-compatible** daemon is still
+  allowed — the guard forbids spawning, not talking.
+- Any path that would spawn — including the stale-daemon **replace** paths,
+  which would otherwise stop the old daemon first — fails *before* any
+  daemon is stopped, killed, or copied, with an error that names
+  `ZCCACHE_NO_SPAWN`.
+- Enforced at the `ensure_daemon` / `spawn_and_wait` chokepoints in
+  `cli/runtime.rs` and `cli/commands/daemon.rs`, as a backstop inside
+  `runtime::spawn_daemon` (before `prepare_daemon_exe` materializes a
+  runtime-binaries copy), and on the `download_client` spawn path.
+- This is different from `ZCCACHE_DISABLE=1`, which puts the compiler
+  wrapper into passthrough (run the compiler, skip the cache): the no-spawn
+  guard keeps every subcommand's cache semantics but turns lazy daemon
+  spawns into hard errors.
+
 ### Persistent writes — exhaustive table
 
 Every persistent write the daemon and CLI perform lands under the resolved


### PR DESCRIPTION
## Summary

Closes #982.

Adds the host no-spawn guard: embedding hosts (soldr's compiled-in `zccache` trampoline, zackees/soldr#1467) set `ZCCACHE_NO_SPAWN=1` (or case-insensitive `true` — same value grammar as `ZCCACHE_DISABLE`) to forbid the CLI from ever spawning a standalone `zccache-daemon` / `zccache-download-daemon` process.

### Semantics
- Connecting to an already-running, **version-compatible** daemon stays allowed — the guard forbids spawning, not talking.
- The stale-daemon **replace** paths fail *before* `stop_stale_daemon`, so a guarded run never kills a daemon it cannot replace.
- Refusal error names `ZCCACHE_NO_SPAWN` and points at the embedded service.

### Enforcement points
- `cli/runtime.rs`: `ensure_daemon`, `spawn_and_wait`, and a backstop in `spawn_daemon` **before** `prepare_daemon_exe` materializes a runtime-binaries copy (guarded runs leave zero daemon artifacts on disk).
- `cli/commands/daemon.rs`: its duplicate `ensure_daemon` / `spawn_and_wait` chain.
- `download_client`: `ensure_daemon` + `spawn_daemon`.

### RED→GREEN
`tests/cli_no_spawn_guard.rs` (subprocess-based, race-free env handling, isolated cache dir + daemon namespace): RED run demonstrated `zccache start` / `session-start` really spawned daemons under the env var; GREEN asserts refusal + error text + zero `zccache-daemon.*` artifacts + `=0` does not trip the guard. Value grammar unit-tested in `core::config::tests`.

### Also: unbreak the clippy lane on main
First commit gates four integration-test targets (`cli_ino_convert`, `cli_installers`, `ci_timeout_and_progress`, `symbols_stamp_roundtrip`) behind the features they consume — c615a17e ("gate zccache dependency surfaces") left them referencing gated modules unconditionally, so every default-features `clippy/check --all-targets` on main has been red since dc199a16. The integration lane still compiles + runs them via `ZCCACHE_INTEGRATION_FEATURES`.

### Docs
`docs/architecture/runtime.md` § "Host no-spawn guard" + ARCHITECTURE.md breadcrumb.

### Verification
- `cargo test -p zccache --features zccache-bin --test cli_no_spawn_guard` — 4/4 green (0.08s; nothing spawns).
- `cargo test -p zccache --lib no_spawn` — 2/2 green.
- `cargo clippy -p zccache --all-targets -- -D warnings` — clean (was failing on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)