### PR TITLE
[codex] add publish-time zccache amalgamation

### DIFF
--- a/ci/publish_amalgamate.py
+++ b/ci/publish_amalgamate.py
@@ -1,0 +1,390 @@
+"""Build the crates.io `zccache` package as a self-contained crate."""
+
+from __future__ import annotations
+
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+@dataclass(frozen=True)
+class AmalgamatedModule:
+    crate: str
+    module: str
+    declaration: str
+    drop_python_bindings: bool = False
+
+
+INTERNAL_MODULES: tuple[AmalgamatedModule, ...] = (
+    AmalgamatedModule("zccache-artifact", "artifact", "pub mod artifact;"),
+    AmalgamatedModule("zccache-audit", "audit", "pub mod audit;"),
+    AmalgamatedModule(
+        "zccache-compile-trace",
+        "compile_trace",
+        "pub mod compile_trace;",
+    ),
+    AmalgamatedModule("zccache-compiler", "compiler", "pub mod compiler;"),
+    AmalgamatedModule("zccache-core", "core", "pub mod core;"),
+    AmalgamatedModule("zccache-depgraph", "depgraph", "pub mod depgraph;"),
+    AmalgamatedModule(
+        "zccache-download",
+        "download",
+        '#[cfg(feature = "download")]\npub mod download;',
+    ),
+    AmalgamatedModule(
+        "zccache-download-protocol",
+        "download_protocol",
+        '#[cfg(feature = "download-protocol")]\npub mod download_protocol;',
+    ),
+    AmalgamatedModule(
+        "zccache-fingerprint",
+        "fingerprint",
+        "pub mod fingerprint;",
+        drop_python_bindings=True,
+    ),
+    AmalgamatedModule("zccache-fscache", "fscache", "pub mod fscache;"),
+    AmalgamatedModule(
+        "zccache-gha",
+        "gha",
+        '#[cfg(feature = "gha")]\npub mod gha;',
+    ),
+    AmalgamatedModule("zccache-hash", "hash", "pub mod hash;"),
+    AmalgamatedModule("zccache-ipc", "ipc", "pub mod ipc;"),
+    AmalgamatedModule("zccache-protocol", "protocol", "pub mod protocol;"),
+    AmalgamatedModule(
+        "zccache-symbols",
+        "symbols",
+        '#[cfg(feature = "symbols")]\npub mod symbols;',
+    ),
+    AmalgamatedModule(
+        "zccache-watcher",
+        "watcher",
+        "pub mod watcher;",
+        drop_python_bindings=True,
+    ),
+)
+
+INTERNAL_FEATURE_REMOVALS: dict[str, set[str]] = {
+    "cli": {"zccache-artifact/cli"},
+    "download": {"dep:zccache-download"},
+    "download-protocol": {"dep:zccache-download-protocol"},
+    "gha": {"dep:zccache-gha", "zccache-artifact/gha"},
+    "symbols": {"dep:zccache-symbols"},
+}
+INTERNAL_FEATURE_ADDITIONS: dict[str, tuple[str, ...]] = {
+    "gha": ("dep:reqwest", "dep:sha2"),
+}
+
+
+def prepare_zccache_crate_for_publish(
+    root: Path = ROOT,
+    modules: Sequence[AmalgamatedModule] = INTERNAL_MODULES,
+) -> None:
+    """Rewrite `crates/zccache` into the single crate uploaded to crates.io."""
+
+    root = root.resolve()
+    zccache_dir = root / "crates" / "zccache"
+    zccache_src = zccache_dir / "src"
+    module_map = {module.crate: module.module for module in modules}
+
+    for module in modules:
+        source_src = root / "crates" / module.crate / "src"
+        target_src = zccache_src / module.module
+        if not source_src.is_dir():
+            raise FileNotFoundError(f"missing internal crate source: {source_src}")
+        if target_src.exists():
+            shutil.rmtree(target_src)
+        shutil.copytree(
+            source_src,
+            target_src,
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+        )
+
+        copied_lib = target_src / "lib.rs"
+        if copied_lib.exists():
+            copied_lib.rename(target_src / "mod.rs")
+
+        if module.drop_python_bindings:
+            python_file = target_src / "python.rs"
+            if python_file.exists():
+                python_file.unlink()
+
+        rewrite_copied_module_sources(target_src, module, module_map)
+
+    copy_protocol_schema(root)
+    write_publish_lib_rs(zccache_src, modules)
+    write_publish_build_rs(zccache_dir)
+    rewrite_zccache_manifest(zccache_dir / "Cargo.toml", module_map)
+    assert_publish_crate_is_self_contained(zccache_dir, module_map)
+
+
+def copy_protocol_schema(root: Path) -> None:
+    source_proto = root / "crates" / "zccache-protocol" / "proto"
+    target_proto = root / "crates" / "zccache" / "proto"
+    if target_proto.exists():
+        shutil.rmtree(target_proto)
+    shutil.copytree(source_proto, target_proto)
+
+
+def write_publish_lib_rs(
+    zccache_src: Path,
+    modules: Sequence[AmalgamatedModule],
+) -> None:
+    internal_declarations = "\n".join(module.declaration for module in modules)
+    text = f"""//! Public zccache crate.
+//!
+//! Release packaging rewrites this facade into a self-contained crate so
+//! crates.io consumers only depend on `zccache`, while git and path consumers
+//! still get parallel compilation from the internal workspace crates.
+
+{internal_declarations}
+/// Issue zccache#926 - durable audit JSONL writer for the embedded service.
+pub mod audit_writer;
+#[cfg(feature = "ci")]
+pub mod ci;
+#[cfg(feature = "cli")]
+pub mod cli;
+pub mod daemon;
+#[cfg(feature = "download-client")]
+pub mod download_client;
+#[cfg(feature = "download-daemon")]
+pub mod download_daemon;
+pub mod embedded;
+
+#[cfg(feature = "test-support")]
+pub mod test_support;
+"""
+    (zccache_src / "lib.rs").write_text(text, encoding="utf-8")
+
+
+def write_publish_build_rs(zccache_dir: Path) -> None:
+    text = """// Build scripts are allowed to panic on setup failure: cargo surfaces
+// the panic message and fails the build cleanly.
+#![allow(clippy::expect_used)]
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let target = std::env::var("TARGET").expect("cargo sets TARGET for build scripts");
+    println!("cargo:rustc-env=ZCCACHE_BUILD_TARGET={target}");
+
+    println!("cargo:rerun-if-changed=proto/zccache_v1.proto");
+    let protoc = protoc_bin_vendored::protoc_bin_path()
+        .expect("vendored protoc is available for zccache wire protobufs");
+    std::env::set_var("PROTOC", protoc);
+
+    prost_build::Config::new()
+        .compile_protos(&["proto/zccache_v1.proto"], &["proto"])
+        .expect("zccache wire protobufs compile");
+}
+"""
+    (zccache_dir / "build.rs").write_text(text, encoding="utf-8")
+
+
+def rewrite_copied_module_sources(
+    target_src: Path,
+    module: AmalgamatedModule,
+    module_map: dict[str, str],
+) -> None:
+    for source in sorted(target_src.rglob("*.rs")):
+        text = source.read_text(encoding="utf-8")
+        text = rewrite_rust_source_for_amalgamation(
+            text,
+            module=module.module,
+            module_map=module_map,
+        )
+        if module.drop_python_bindings:
+            text = drop_python_extension_bindings(text)
+        source.write_text(text, encoding="utf-8")
+
+
+def rewrite_rust_source_for_amalgamation(
+    text: str,
+    *,
+    module: str,
+    module_map: dict[str, str],
+) -> str:
+    text = re.sub(r"\bcrate::", f"crate::{module}::", text)
+    for crate_name, module_name in sorted(
+        module_map.items(),
+        key=lambda item: len(rust_crate_ident(item[0])),
+        reverse=True,
+    ):
+        ident = rust_crate_ident(crate_name)
+        text = re.sub(rf"\b{re.escape(ident)}::", f"crate::{module_name}::", text)
+        text = re.sub(rf"\b{re.escape(ident)}\b", f"crate::{module_name}", text)
+    return text
+
+
+def drop_python_extension_bindings(text: str) -> str:
+    lines = text.splitlines(keepends=True)
+    out: list[str] = []
+    skip_next_python_item = False
+    for line in lines:
+        if line.strip() == '#[cfg(feature = "python")]':
+            skip_next_python_item = True
+            continue
+        if skip_next_python_item:
+            stripped = line.strip()
+            if stripped == "mod python;" or stripped.startswith("pub use python::"):
+                skip_next_python_item = False
+                continue
+            out.append('#[cfg(feature = "python")]\n')
+            skip_next_python_item = False
+        out.append(line)
+    if skip_next_python_item:
+        out.append('#[cfg(feature = "python")]\n')
+    return "".join(out)
+
+
+def rust_crate_ident(crate_name: str) -> str:
+    return crate_name.replace("-", "_")
+
+
+def rewrite_zccache_manifest(manifest_path: Path, module_map: dict[str, str]) -> None:
+    text = manifest_path.read_text(encoding="utf-8")
+    text = strip_internal_dependency_lines(text, module_map.keys())
+    for feature, removals in INTERNAL_FEATURE_REMOVALS.items():
+        additions = INTERNAL_FEATURE_ADDITIONS.get(feature, ())
+        text = rewrite_feature_items(text, feature, remove=removals, add=additions)
+    text = ensure_build_dependency(text, "prost-build = { workspace = true }")
+    text = ensure_build_dependency(text, "protoc-bin-vendored = { workspace = true }")
+    manifest_path.write_text(text, encoding="utf-8")
+
+
+def strip_internal_dependency_lines(text: str, internal_crates: Iterable[str]) -> str:
+    internal = set(internal_crates)
+    output: list[str] = []
+    section = ""
+    for line in text.splitlines(keepends=True):
+        stripped = line.strip()
+        match = re.match(r"^\[([^\]]+)\]$", stripped)
+        if match:
+            section = match.group(1)
+
+        if section == "dependencies" and stripped == "# internal facade crates":
+            continue
+        if section == "dependencies" and dependency_line_name(line) in internal:
+            continue
+        if section == "dev-dependencies" and dependency_line_name(line) == "zccache":
+            continue
+        output.append(line)
+    return "".join(output)
+
+
+def dependency_line_name(line: str) -> str | None:
+    match = re.match(r"^([A-Za-z0-9_-]+)\s*=", line)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def rewrite_feature_items(
+    text: str,
+    feature: str,
+    *,
+    remove: set[str],
+    add: Sequence[str] = (),
+) -> str:
+    pattern = re.compile(rf"(?ms)^{re.escape(feature)}\s*=\s*\[(.*?)\]")
+    match = pattern.search(text)
+    if not match:
+        return text
+
+    existing = re.findall(r'"([^"]+)"', match.group(1))
+    items: list[str] = []
+    for item in existing:
+        if item in remove or item in items:
+            continue
+        items.append(item)
+    for item in add:
+        if item not in items:
+            items.append(item)
+
+    return text[: match.start()] + format_feature(feature, items) + text[match.end() :]
+
+
+def format_feature(feature: str, items: Sequence[str]) -> str:
+    if not items:
+        return f"{feature} = []"
+    if len(items) <= 3:
+        rendered = ", ".join(f'"{item}"' for item in items)
+        return f"{feature} = [{rendered}]"
+    lines = [f"{feature} = [\n"]
+    lines.extend(f'    "{item}",\n' for item in items)
+    lines.append("]")
+    return "".join(lines)
+
+
+def ensure_build_dependency(text: str, dependency_line: str) -> str:
+    if dependency_line in text:
+        return text
+    section_header = "[build-dependencies]"
+    if section_header in text:
+        return insert_into_section(text, section_header, dependency_line)
+
+    insert_at = len(text)
+    for marker in ("\n[target.", "\n[dev-dependencies]", "\n[[bench]]", "\n[lints]"):
+        index = text.find(marker)
+        if index != -1:
+            insert_at = index
+            break
+    block = f"\n{section_header}\n{dependency_line}\n"
+    return text[:insert_at].rstrip() + "\n" + block + text[insert_at:]
+
+
+def insert_into_section(text: str, section_header: str, dependency_line: str) -> str:
+    start = text.index(section_header) + len(section_header)
+    next_section = re.search(r"(?m)^\[", text[start:])
+    end = len(text) if next_section is None else start + next_section.start()
+    section = text[start:end].rstrip()
+    updated = f"{section}\n{dependency_line}\n"
+    return text[:start] + updated + text[end:]
+
+
+def assert_publish_crate_is_self_contained(
+    zccache_dir: Path,
+    module_map: dict[str, str],
+) -> None:
+    manifest = (zccache_dir / "Cargo.toml").read_text(encoding="utf-8")
+    source_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted((zccache_dir / "src").rglob("*.rs"))
+    )
+
+    manifest_errors = [
+        crate
+        for crate in sorted(module_map)
+        if re.search(rf"^{re.escape(crate)}\s*=", manifest, re.M)
+    ]
+    source_errors = [
+        rust_crate_ident(crate)
+        for crate in sorted(module_map)
+        if re.search(
+            rf"\b(?:use\s+|extern\s+crate\s+)?{re.escape(rust_crate_ident(crate))}::",
+            source_text,
+        )
+        or re.search(
+            rf"\bextern\s+crate\s+{re.escape(rust_crate_ident(crate))}\b",
+            source_text,
+        )
+    ]
+    if manifest_errors or source_errors:
+        details = []
+        if manifest_errors:
+            details.append("manifest dependencies: " + ", ".join(manifest_errors))
+        if source_errors:
+            details.append("source references: " + ", ".join(source_errors))
+        raise RuntimeError("amalgamated crate is not self-contained: " + "; ".join(details))
+
+
+def main() -> None:
+    prepare_zccache_crate_for_publish()
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/release_checks.py
+++ b/ci/release_checks.py
@@ -12,7 +12,6 @@ from typing import Any
 ROOT = Path(__file__).parent.parent.resolve()
 RUST_PUBLISH_ORDER = [
     "zccache",
-    "zccache-cli",
 ]
 DYNAMIC_VERSION_PYPROJECTS = (
     ROOT / "pyproject.toml",
@@ -27,7 +26,8 @@ DYNAMIC_VERSION_PYPROJECTS = (
 # rejected the resulting path-only dep with
 # "all dependencies must have a version requirement specified". The set is
 # sourced from RUST_PUBLISH_ORDER so it only includes crates that are still
-# published to crates.io; split-out engine crates remain publish=false.
+# published to crates.io; split-out engine crates and PyPI extension crates
+# remain publish=false.
 INTERNAL_CRATE_NAMES = frozenset(RUST_PUBLISH_ORDER)
 # Matches `<name> = { <body> }` where `<name>` is the umbrella `zccache`
 # *or* any `zccache-<suffix>` workspace member. Same rationale as the set

--- a/ci/release_workflow.py
+++ b/ci/release_workflow.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from ci.env import clean_env
+from ci.publish_amalgamate import prepare_zccache_crate_for_publish
 from ci.release_checks import (
     RUST_PUBLISH_ORDER,
     ReleaseCheckError,
@@ -557,8 +558,11 @@ def verify_rust_crates_locally() -> None:
             + ", ".join(stamped)
         )
 
+    prepare_zccache_crate_for_publish(ROOT)
+    log("  Prepared crates/zccache as a self-contained crates.io package")
+
     for crate in RUST_PUBLISH_ORDER:
-        run(["cargo", "package", "--allow-dirty", "--no-verify", "-p", crate, "--list"], cwd=ROOT)
+        run(["cargo", "package", "--allow-dirty", "-p", crate], cwd=ROOT)
 
 
 def verify_crate_visible(crate: str, version: str) -> None:
@@ -588,7 +592,7 @@ def publish_rust_crates(version: str, existing_crates: set[str] | None = None) -
         if crate in existing_crates:
             log(f"  Skipping {crate} {version}; already published")
             continue
-        run(["cargo", "publish", "--allow-dirty", "--no-verify", "-p", crate], cwd=ROOT)
+        run(["cargo", "publish", "--allow-dirty", "-p", crate], cwd=ROOT)
         verify_crate_visible(crate, version)
 
 

--- a/ci/tests/test_publish_amalgamate.py
+++ b/ci/tests/test_publish_amalgamate.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ci import release_checks
+from ci.publish_amalgamate import (
+    AmalgamatedModule,
+    drop_python_extension_bindings,
+    prepare_zccache_crate_for_publish,
+    rewrite_rust_source_for_amalgamation,
+    rewrite_zccache_manifest,
+)
+
+
+def test_rewrite_rust_source_rebases_crate_root_and_internal_crate_paths() -> None:
+    module_map = {
+        "zccache-core": "core",
+        "zccache-hash": "hash",
+        "zccache-protocol": "protocol",
+    }
+    source = """
+use crate::{ProtocolError, Request};
+use zccache_core::NormalizedPath;
+
+fn hash(path: &zccache_core::NormalizedPath) -> zccache_hash::ContentHash {
+    zccache_hash::hash_file(path).unwrap()
+}
+"""
+
+    rewritten = rewrite_rust_source_for_amalgamation(
+        source,
+        module="protocol",
+        module_map=module_map,
+    )
+
+    assert "use crate::protocol::{ProtocolError, Request};" in rewritten
+    assert "use crate::core::NormalizedPath;" in rewritten
+    assert "path: &crate::core::NormalizedPath" in rewritten
+    assert "-> crate::hash::ContentHash" in rewritten
+    assert "crate::hash::hash_file(path)" in rewritten
+    assert "zccache_core" not in rewritten
+    assert "zccache_hash" not in rewritten
+
+
+def test_drop_python_extension_bindings_removes_extension_only_exports() -> None:
+    source = """
+pub mod scan;
+#[cfg(feature = "python")]
+mod python;
+pub use scan::walk_files;
+#[cfg(feature = "python")]
+pub use python::{NativeWatcher, WatchBatch};
+"""
+
+    rewritten = drop_python_extension_bindings(source)
+
+    assert "pub mod scan;" in rewritten
+    assert "pub use scan::walk_files;" in rewritten
+    assert "python" not in rewritten
+
+
+def test_rewrite_zccache_manifest_removes_facade_deps_and_retargets_features(
+    tmp_path: Path,
+) -> None:
+    manifest = tmp_path / "Cargo.toml"
+    manifest.write_text(
+        """
+[package]
+name = "zccache"
+
+[features]
+cli = ["download-client", "gha", "zccache-artifact/cli"]
+download = ["dep:zccache-download", "dep:futures", "dep:reqwest"]
+download-protocol = ["download", "dep:zccache-download-protocol"]
+gha = ["dep:zccache-gha", "zccache-artifact/gha"]
+symbols = ["dep:zccache-symbols"]
+
+[dependencies]
+# internal facade crates
+zccache-artifact = { workspace = true }
+zccache-core = { workspace = true }
+zccache-download = { workspace = true, optional = true }
+zccache-gha = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
+
+[dev-dependencies]
+zccache = { path = ".", features = ["test-support"] }
+tokio = { workspace = true }
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    rewrite_zccache_manifest(
+        manifest,
+        {
+            "zccache-artifact": "artifact",
+            "zccache-core": "core",
+            "zccache-download": "download",
+            "zccache-download-protocol": "download_protocol",
+            "zccache-gha": "gha",
+            "zccache-symbols": "symbols",
+        },
+    )
+
+    text = manifest.read_text(encoding="utf-8")
+    assert "zccache-artifact =" not in text
+    assert "zccache-core =" not in text
+    assert "zccache-download =" not in text
+    assert 'cli = ["download-client", "gha"]' in text
+    assert 'download = ["dep:futures", "dep:reqwest"]' in text
+    assert 'download-protocol = ["download"]' in text
+    assert 'gha = ["dep:reqwest", "dep:sha2"]' in text
+    assert "symbols = []" in text
+    assert 'zccache = { path = "."' not in text
+    assert "prost-build = { workspace = true }" in text
+    assert "protoc-bin-vendored = { workspace = true }" in text
+
+
+def test_prepare_zccache_crate_for_publish_copies_and_rewrites_sources(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path
+    zccache = root / "crates" / "zccache"
+    (zccache / "src").mkdir(parents=True)
+    (zccache / "src" / "lib.rs").write_text(
+        "pub use zccache_core as core;\n",
+        encoding="utf-8",
+    )
+    (zccache / "Cargo.toml").write_text(
+        """
+[package]
+name = "zccache"
+
+[features]
+gha = ["dep:zccache-gha", "zccache-artifact/gha"]
+
+[dependencies]
+zccache-core = { workspace = true }
+zccache-hash = { workspace = true }
+reqwest = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (zccache / "build.rs").write_text("fn main() {}\n", encoding="utf-8")
+
+    core_src = root / "crates" / "zccache-core" / "src"
+    core_src.mkdir(parents=True)
+    (core_src / "lib.rs").write_text(
+        "pub mod config;\nuse zccache_hash::ContentHash;\n",
+        encoding="utf-8",
+    )
+    (core_src / "config.rs").write_text(
+        "pub fn version() -> &'static str { crate::VERSION }\n",
+        encoding="utf-8",
+    )
+    hash_src = root / "crates" / "zccache-hash" / "src"
+    hash_src.mkdir(parents=True)
+    (hash_src / "lib.rs").write_text(
+        "pub struct ContentHash;\n",
+        encoding="utf-8",
+    )
+    proto_dir = root / "crates" / "zccache-protocol" / "proto"
+    proto_dir.mkdir(parents=True)
+    (proto_dir / "zccache_v1.proto").write_text(
+        'syntax = "proto3";\n',
+        encoding="utf-8",
+    )
+
+    prepare_zccache_crate_for_publish(
+        root,
+        modules=(
+            AmalgamatedModule("zccache-core", "core", "pub mod core;"),
+            AmalgamatedModule("zccache-hash", "hash", "pub mod hash;"),
+        ),
+    )
+
+    assert (zccache / "src" / "core" / "mod.rs").is_file()
+    assert (zccache / "src" / "hash" / "mod.rs").is_file()
+    assert (zccache / "proto" / "zccache_v1.proto").is_file()
+    assert "crate::hash::ContentHash" in (
+        zccache / "src" / "core" / "mod.rs"
+    ).read_text(encoding="utf-8")
+    assert "crate::core::VERSION" in (
+        zccache / "src" / "core" / "config.rs"
+    ).read_text(encoding="utf-8")
+    assert "pub mod core;" in (zccache / "src" / "lib.rs").read_text(
+        encoding="utf-8"
+    )
+    assert "zccache-core =" not in (zccache / "Cargo.toml").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_release_metadata_allows_only_public_zccache_crate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert release_checks.RUST_PUBLISH_ORDER == ["zccache"]
+
+    monkeypatch.setattr(
+        release_checks,
+        "read_workspace_metadata",
+        lambda: {
+            "packages": [
+                {"name": "zccache", "dependencies": []},
+                {"name": "zccache-core", "dependencies": []},
+            ]
+        },
+    )
+
+    with pytest.raises(release_checks.ReleaseCheckError, match="zccache-core"):
+        release_checks.validate_rust_publish_order()

--- a/crates/zccache-cli/Cargo.toml
+++ b/crates/zccache-cli/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 readme = "README.md"
 description = "PyO3 cdylib hosting the `zccache._native` extension module"
+publish = false
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/crates/zccache/src/daemon/trampoline.rs
+++ b/crates/zccache/src/daemon/trampoline.rs
@@ -239,6 +239,7 @@ fn redirect_stdio_to_log_windows(log_path: &Path) -> bool {
     use std::os::windows::ffi::OsStrExt;
     use std::ptr;
 
+    #[allow(clashing_extern_declarations)]
     extern "system" {
         fn CreateFileW(
             lp_file_name: *const u16,
@@ -348,6 +349,7 @@ fn detach_stdio_windows() {
     use std::os::windows::ffi::OsStrExt;
     use std::ptr;
 
+    #[allow(clashing_extern_declarations)]
     extern "system" {
         fn CreateFileW(
             lp_file_name: *const u16,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -98,3 +98,9 @@ Wave 5 status:
 Next wave:
 - Add publish-time single-crate amalgamation and CI guards so only the public `zccache` crate can be published.
 - Do release/soldr validation and hardening after the split PR lands.
+
+Wave 6 status:
+- Added release-time `zccache` crate amalgamation for crates.io packaging while keeping the checked-in workspace split for git/path consumers.
+- Marked internal and PyPI extension crates `publish = false`; crates.io publish order is now only the public `zccache` crate.
+- Release publish now performs a real `cargo package` verification on the transformed crate before upload.
+- Verified on 2026-07-09: focused release Python tests, full `ci/tests`, `bash ./test`, workspace clippy all-target/all-feature, and transformed `zccache` package verification with `RUSTFLAGS=-D warnings`.


### PR DESCRIPTION
﻿## Summary
- add release-time amalgamation that rewrites `crates/zccache` into a self-contained crates.io package while keeping the checked-in workspace split for git/path consumers
- make `zccache` the only crates.io-published crate and mark the PyPI extension crate `zccache-cli` as `publish = false`
- replace no-verify crates publish checks with real package/publish verification and cover the transform with CI-script tests
- suppress the Windows `CloseHandle` extern clash that only appears once internal modules are packaged into one crate

Closes #975.

## Validation
- `uv run --frozen pytest ci/tests/test_publish_amalgamate.py ci/tests/test_release_workflow.py`
- `soldr --no-cache cargo fmt --all`
- `ZCCACHE_DISABLE=1 soldr cargo clippy -p zccache --lib -- -D warnings`
- `uv run --frozen pytest ci/tests`
- `bash ./test`
- `ZCCACHE_DISABLE=1 soldr cargo clippy --workspace --all-targets --all-features -- -D warnings`
- temp transformed package: `ZCCACHE_DISABLE=1 RUSTFLAGS="-D warnings" soldr cargo package --allow-dirty -p zccache`
