### PR TITLE
[codex] fix release binary feature flags

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -185,8 +185,8 @@ runs:
         if [[ "${{ inputs.target }}" == *pc-windows-msvc ]]; then
           export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=+crt-static"
         fi
-        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache --bin zccache
-        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache --bin zccache-daemon
+        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache --features zccache-bin --bin zccache
+        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache --features daemon-bin --bin zccache-daemon
         # zccache-fp is a bin shipped *inside* the umbrella `zccache` crate
         # (see crates/zccache/Cargo.toml `[[bin]] name = "zccache-fp"`). The
         # sibling `zccache-fingerprint` crate is a pyo3 cdylib for the Python
@@ -194,7 +194,7 @@ runs:
         # then `cp`s `target/.../zccache-fp` into `staging/`, which is why
         # building the wrong target left it complaining `cannot stat
         # 'target/.../zccache-fp': No such file or directory`.
-        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache --bin zccache-fp
+        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache --features fingerprint-bin --bin zccache-fp
 
     # Windows DLL load smoke gate (see zccache#269). If the just-built
     # `zccache.exe` cannot complete loader init on this host, `--version`


### PR DESCRIPTION
﻿## Summary
- pass each release binary's required feature to the build-target composite action
- fixes the 1.12.15 release build failure where `cargo build -p zccache --bin zccache` was invoked without `zccache-bin`

## Root Cause
The split facade crate keeps binary targets behind `required-features`, but the release action still built `zccache`, `zccache-daemon`, and `zccache-fp` without enabling `zccache-bin`, `daemon-bin`, or `fingerprint-bin`.

## Validation
- `ZCCACHE_DISABLE=1 soldr --no-cache cargo check -p zccache --features zccache-bin,daemon-bin,fingerprint-bin --bin zccache --bin zccache-daemon --bin zccache-fp`
- `git diff --check`

Release evidence:
- failed manual release run: https://github.com/zackees/zccache/actions/runs/28995602000
- failing job error: `target zccache in package zccache requires the features: zccache-bin`
