### PR TITLE
feat(trace): emit ZCCACHE_INNER_TRACE inner sub-phase markers (#940)

### DIFF
--- a/crates/zccache-compile-trace/README.md
+++ b/crates/zccache-compile-trace/README.md
@@ -3,5 +3,53 @@
 Diagnostic JSONL trace support for embedded compile phases.
 
 This unpublished internal crate owns the `ZCCACHE_INNER_TRACE` writer and
-phase guard. The `zccache` facade is expected to re-export this crate as
+phase guard. The `zccache` facade re-exports this crate as
 `zccache::compile_trace` so existing compile-trace paths keep working.
+
+## Enabling
+
+Set `ZCCACHE_INNER_TRACE=<path>` before starting the process that hosts the
+embedded compile (soldr / fbuild). Each recorded sub-phase appends one JSONL
+line; the shape is byte-for-byte identical to soldr's daemon trace, so
+soldr's `bench/parse_compile_trace.py` reads either file unchanged:
+
+```jsonl
+{"ts_ns":<u128>,"phase":"<name>","micros":<u64>,"compile_id":"<str>"}
+```
+
+Off by default: one `OnceLock` load resolves to `None` and every `record`
+call returns immediately when the env var is unset.
+
+## Sub-phase markers (issue #940)
+
+`record`/`Phase` are the low-level API. The `zccache` daemon wires the
+per-compile id and the sub-phase seams through
+`crate::daemon::server::inner_trace` (a `tokio::task_local` scoped around
+`EmbeddedDaemon::compile`). The markers emitted for an embedded compile:
+
+| phase | path | emitted from |
+|---|---|---|
+| `embedded_daemon_compile` | always | outer span in `embedded.rs` |
+| `input_hash` | miss | `pipeline/store_outcome.rs` (`hash_source_ns + hash_headers_ns`) |
+| `cache_lookup` | miss | `pipeline/store_outcome.rs` (`depgraph_check_ns`) |
+| `cache_load` | hit | `handle_compile/cached_hit.rs` (artifact index lookup + payload read) |
+| `rustc_spawn` | miss | `pipeline/store_outcome.rs` (`compiler_prep_ns`) |
+| `rustc_wait` | miss | `pipeline/store_outcome.rs` (`compiler_process_ns`) |
+| `output_read` | miss | `pipeline/store_outcome.rs` (`collect_outputs_ns`) |
+| `cache_store` | miss | `pipeline/store_outcome.rs` (`artifact_store_ns`) |
+
+`rustc_spawn` and `rustc_wait` reuse the fused prep/process timings — the
+subprocess spawn+wait+pipe-drain is one measured region (`compiler_process_ns`)
+in `daemon/process.rs`. Splitting it into distinct spawn / wait / read markers
+would need a process-layer refactor the diagnostic does not warrant; the two
+markers approximate the split from the already-measured seams.
+
+Only embedded compiles emit sub-phase markers: the IPC wrapper path does not
+open an `inner_trace::scope`, so the shared pipeline seams stay silent there.
+
+## Tests
+
+- `crate::daemon::server::inner_trace` unit tests cover the task-local
+  gating (no-op outside a scope, id visible inside).
+- `crates/zccache/tests/inner_trace_file_test.rs` covers the JSONL writer
+  wire shape end-to-end in its own test binary (fresh `OnceLock`).

--- a/crates/zccache/src/daemon/server/embedded.rs
+++ b/crates/zccache/src/daemon/server/embedded.rs
@@ -204,15 +204,23 @@ impl EmbeddedDaemon {
             env: request.env.clone(),
             session_id: None,
         };
-        let response = handle_compile_ephemeral(
-            &self.state,
-            std::process::id(),
-            &request.cwd,
-            &request.compiler,
-            &request.args,
-            &request.cwd,
-            request.env,
-            request.stdin,
+        // zccache#940: open the inner-trace scope so the deep pipeline seams
+        // (input_hash, cache_lookup, cache_load, rustc_spawn/wait, output_read,
+        // cache_store) attribute their sub-phase records to this compile_id.
+        // No-op unless ZCCACHE_INNER_TRACE is set; the IPC wrapper path does
+        // not open a scope, so only embedded compiles emit sub-phase records.
+        let response = super::inner_trace::scope(
+            compile_id.clone(),
+            handle_compile_ephemeral(
+                &self.state,
+                std::process::id(),
+                &request.cwd,
+                &request.compiler,
+                &request.args,
+                &request.cwd,
+                request.env,
+                request.stdin,
+            ),
         )
         .await;
         crate::compile_trace::record(

--- a/crates/zccache/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/cached_hit.rs
@@ -87,6 +87,12 @@ pub(super) fn materialize_cached_compile_hit(
     let t1 = Instant::now();
     let artifact_lookup_ns = (t1 - t0).as_nanos() as u64;
 
+    // zccache#940: cache-hit "cache_load" sub-phase — the artifact index
+    // lookup + payload read that materializes a cached hit. No-op unless this
+    // compile runs inside an embedded `inner_trace::scope` with the trace env
+    // set.
+    crate::daemon::server::inner_trace::record_ns("cache_load", artifact_lookup_ns);
+
     let payloads = Arc::clone(cached_ref.payloads.as_ref()?);
     let names = Arc::clone(&cached_ref.meta.output_names);
     let exit_code = cached_ref.meta.exit_code;

--- a/crates/zccache/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -495,6 +495,22 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         total_ns,
     });
 
+    // zccache#940: emit the cache-miss sub-phase markers for the inner trace.
+    // Every value here is already measured for the miss profile above; we just
+    // forward the ones the issue enumerates. No-op unless this compile runs
+    // inside an embedded `inner_trace::scope` with ZCCACHE_INNER_TRACE set.
+    // `rustc_spawn`/`rustc_wait` reuse the fused prep/process timings — the
+    // subprocess spawn+wait+drain is one measured region (`compiler_process_ns`)
+    // in `process.rs`; splitting it would need a process-layer refactor the
+    // diagnostic doesn't warrant.
+    use crate::daemon::server::inner_trace::record_ns;
+    record_ns("input_hash", hash_source_ns.saturating_add(hash_headers_ns));
+    record_ns("cache_lookup", depgraph_check_ns);
+    record_ns("rustc_spawn", compiler_prep_ns);
+    record_ns("rustc_wait", compiler_process_ns);
+    record_ns("output_read", collect_outputs_ns);
+    record_ns("cache_store", artifact_store_ns);
+
     // Defer expensive watch_directories to background — canonicalize()
     // on Windows costs ~1-5ms per directory. This doesn't affect cache
     // correctness; it only delays watcher-based invalidation setup.

--- a/crates/zccache/src/daemon/server/inner_trace.rs
+++ b/crates/zccache/src/daemon/server/inner_trace.rs
@@ -1,0 +1,88 @@
+//! Task-scoped compile-id plumbing for the `ZCCACHE_INNER_TRACE` sub-phase
+//! trace (issue #940).
+//!
+//! `EmbeddedDaemon::compile` (the `ZccacheService::compile` entry) generates
+//! a per-compile id and calls the pipeline through [`scope`]. Deep inside the
+//! pipeline — at the hash/verify seam, the miss-path store, and the cached-hit
+//! materialize — the timing seams call [`record_ns`] with a named sub-phase.
+//! `record_ns` reads the current task's compile-id via the task-local and
+//! forwards to [`crate::compile_trace::record`], which is itself a no-op unless
+//! `ZCCACHE_INNER_TRACE` points at a writable file.
+//!
+//! ## Why a task-local instead of threading a `compile_id` argument
+//!
+//! The sub-phase seams live 3–4 calls deep (`handle_compile_ephemeral` →
+//! `handle_compile` → `handle_compile_request` → `store_outcome`/`cached_hit`)
+//! and are shared by both the embedded path and the IPC wrapper path. Threading
+//! a `compile_id: &str` through every signature would churn ~12 test call sites
+//! and both production callers for a diagnostic-only feature. A task-local
+//! scopes the id to exactly the embedded compile future without touching any
+//! signature: the seams read it when present and emit nothing otherwise, so the
+//! IPC path (which does not open a scope) stays silent by construction.
+//!
+//! The foreground seams all run in the same task as the [`scope`] wrapper — the
+//! only `tokio::spawn` in the compile path is the *background* artifact persist,
+//! which is enqueued after `cache_store` timing is already recorded — so the
+//! task-local is always in scope where [`record_ns`] is called.
+
+tokio::task_local! {
+    /// The current embedded compile's trace id. Present only inside a
+    /// [`scope`] future; absent (and every [`record_ns`] a no-op) otherwise.
+    pub(crate) static INNER_COMPILE_ID: String;
+}
+
+/// Record a sub-phase duration (in **nanoseconds**, converted to the trace's
+/// microsecond unit) against the current embedded compile's trace id.
+///
+/// No-op when called outside a [`scope`] future (e.g. the IPC wrapper path) or
+/// when `ZCCACHE_INNER_TRACE` is unset. Never blocks, allocates on the disabled
+/// path, or perturbs the compile it measures.
+pub(crate) fn record_ns(phase: &str, elapsed_ns: u64) {
+    let _ = INNER_COMPILE_ID.try_with(|id| {
+        crate::compile_trace::record(phase, elapsed_ns / 1_000, id);
+    });
+}
+
+/// Run `fut` with `id` installed as the current embedded compile's trace id so
+/// sub-phase [`record_ns`] calls emitted within it attribute to `id`.
+pub(crate) async fn scope<F>(id: String, fut: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    INNER_COMPILE_ID.scope(id, fut).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn try_with_is_err_outside_scope() {
+        // The gating contract: with no scope open, the task-local read fails
+        // and `record_ns` therefore emits nothing (and must not panic).
+        assert!(INNER_COMPILE_ID.try_with(|_| ()).is_err());
+        record_ns("input_hash", 5_000);
+    }
+
+    #[tokio::test]
+    async fn scope_installs_current_id() {
+        let seen = scope("zbeef".to_owned(), async {
+            INNER_COMPILE_ID.with(|id| id.clone())
+        })
+        .await;
+        assert_eq!(seen, "zbeef");
+    }
+
+    #[tokio::test]
+    async fn record_ns_is_reachable_inside_scope() {
+        // Inside a scope the read succeeds, so `record_ns` reaches
+        // `compile_trace::record` (which is itself a no-op unless the env var
+        // is set). We assert the task-local is visible; the file-format wire
+        // shape is covered by tests/inner_trace_file_test.rs.
+        scope("z00000001".to_owned(), async {
+            assert_eq!(INNER_COMPILE_ID.with(|id| id.clone()), "z00000001");
+            record_ns("cache_store", 12_000);
+        })
+        .await;
+    }
+}

--- a/crates/zccache/src/daemon/server/mod.rs
+++ b/crates/zccache/src/daemon/server/mod.rs
@@ -128,6 +128,7 @@ mod handle_exec_probe;
 mod handle_link;
 mod handle_release_worktree_handles;
 mod in_flight;
+mod inner_trace;
 mod keys;
 mod lifecycle;
 mod link_helpers;

--- a/crates/zccache/tests/inner_trace_file_test.rs
+++ b/crates/zccache/tests/inner_trace_file_test.rs
@@ -1,0 +1,80 @@
+//! Wire-shape regression test for the `ZCCACHE_INNER_TRACE` sub-phase trace
+//! (issue #940). Lives in its own integration-test binary so the trace
+//! module's one-shot `OnceLock` env read is guaranteed fresh — a shared unit
+//! test could lose the race if another test triggered the writer first.
+//!
+//! This exercises the exact `compile_trace::record` writer the deep pipeline
+//! seams call through `inner_trace::record_ns`; it asserts the JSONL line shape
+//! that soldr's `bench/parse_compile_trace.py` parses.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::io::Read;
+
+#[test]
+fn inner_trace_writes_jsonl_line_per_subphase() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let trace_path = dir.path().join("inner_trace.jsonl");
+
+    // Must be set before the first `record` call so the module's OnceLock
+    // picks it up. This is the only test in this binary.
+    std::env::set_var("ZCCACHE_INNER_TRACE", &trace_path);
+
+    // Emit one record per sub-phase #940 enumerates, mirroring what the
+    // pipeline seams forward.
+    for phase in [
+        "input_hash",
+        "cache_lookup",
+        "cache_load",
+        "rustc_spawn",
+        "rustc_wait",
+        "output_read",
+        "cache_store",
+    ] {
+        zccache::compile_trace::record(phase, 1_234, "z0000002a");
+    }
+
+    let mut contents = String::new();
+    std::fs::File::open(&trace_path)
+        .expect("trace file was created")
+        .read_to_string(&mut contents)
+        .expect("trace file is readable");
+
+    let lines: Vec<&str> = contents.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 7, "one JSONL line per sub-phase record");
+
+    // First line carries the exact field order/shape soldr's parser depends on.
+    let first = lines[0];
+    assert!(
+        first.starts_with(r#"{"ts_ns":"#),
+        "line starts with ts_ns: {first}"
+    );
+    assert!(
+        first.contains(r#""phase":"input_hash""#),
+        "phase field present: {first}"
+    );
+    assert!(
+        first.contains(r#""micros":1234"#),
+        "micros field present: {first}"
+    );
+    assert!(
+        first.contains(r#""compile_id":"z0000002a""#),
+        "compile_id field present: {first}"
+    );
+
+    // Every enumerated sub-phase name made it to disk.
+    for phase in [
+        "input_hash",
+        "cache_lookup",
+        "cache_load",
+        "rustc_spawn",
+        "rustc_wait",
+        "output_read",
+        "cache_store",
+    ] {
+        assert!(
+            contents.contains(&format!(r#""phase":"{phase}""#)),
+            "sub-phase {phase} recorded"
+        );
+    }
+}

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -40,3 +40,15 @@ locally — they're cheap and catch exactly what `cargo check` misses:
 If admin-merging past CI for speed, at minimum run fmt --check + doc first. The
 perf-rust-cluster jobs (`arm / Test`, `x86 / Test`, `arm-musl / Check`) are
 known-broken at the pin step and are NOT merge-blocking — don't chase them.
+
+## soldr is the bootstrapper even inside the docker Linux build container
+
+When validating in the `clud-docker-build` soldr container, go through
+`soldr cargo ...` / `soldr rustup ...`, NOT bare `cargo install` / `rustup`.
+soldr is baked into the image (`/usr/local/bin/soldr`) and owns toolchain
+discovery. Bare `cargo install cargo-dylint` failed with "rustup is not
+installed at '/cargo-home'" because CARGO_HOME points at a named volume whose
+proxies weren't seeded; `soldr cargo install` resolves the right toolchain
+front-door. The host PreToolUse hook enforces this, but `docker exec` bypasses
+the hook, so the discipline has to be applied manually in container scripts.
+**Rule:** any container-side build/lint script uses `soldr <tool>`.


### PR DESCRIPTION
## Summary

PR #941 shipped the `compile_trace` JSONL writer plus the *outer* per-compile markers (`embedded_daemon_compile`, `embedded_outcome_*`) but none of the **seven inner sub-phases** #940 enumerates. This wires them in so the cold-build gap that lives inside `ZccacheService::compile` becomes visible per sub-phase.

## Approach

A `tokio::task_local` compile-id (new `crates/zccache/src/daemon/server/inner_trace.rs`) is scoped around `EmbeddedDaemon::compile`. The deep pipeline seams call `inner_trace::record_ns(phase, ns)`, which reads the current task's id and forwards to `compile_trace::record` — a no-op outside the scope or when `ZCCACHE_INNER_TRACE` is unset.

**Why task-local instead of threading a `compile_id` argument:** the seams sit 3–4 calls deep and are shared by the embedded and IPC wrapper paths. Threading a `compile_id: &str` through every signature would churn ~12 test call sites and both production callers for a diagnostic-only feature. The task-local scopes the id to exactly the embedded compile future with zero signature changes, and the IPC path (which opens no scope) stays silent by construction. All foreground seams run in the same task as the scope — the only `tokio::spawn` is the *background* persist, enqueued after `cache_store` timing is recorded.

## Markers

Emitted from where each value is already measured:

| phase | path | file |
|---|---|---|
| `input_hash` / `cache_lookup` / `rustc_spawn` / `rustc_wait` / `output_read` / `cache_store` | miss | `pipeline/store_outcome.rs` |
| `cache_load` | hit | `handle_compile/cached_hit.rs` |

`rustc_spawn`/`rustc_wait` reuse the fused prep/process timings — the subprocess spawn+wait+pipe-drain is one measured region (`compiler_process_ns`) in `process.rs`; splitting it would need a process-layer refactor the diagnostic doesn't warrant (documented in the crate README).

## Tests

- `inner_trace` unit tests — task-local gating (no-op outside scope, id visible inside).
- `crates/zccache/tests/inner_trace_file_test.rs` — JSONL writer wire shape end-to-end in its own binary (fresh `OnceLock`); covers the writer #941 shipped untested.

Local (Windows): `cargo test -p zccache --lib inner_trace` (3 pass) + `--test inner_trace_file_test` (1 pass), clippy clean.

Closes #940. Part of the #991 low-risk burn-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)