### PR TITLE
feat(exec): --input-file-list / --input-file-stdin bulk inputs (#837)

### DIFF
--- a/crates/zccache/src/cli/commands/args/mod.rs
+++ b/crates/zccache/src/cli/commands/args/mod.rs
@@ -443,6 +443,18 @@ pub(crate) enum Commands {
         /// Repeatable: declare a file whose content feeds the cache key.
         #[arg(long = "input-file", value_name = "PATH")]
         input_file: Vec<String>,
+        /// Issue #837: read a newline-delimited list of input-file paths from
+        /// this file. Each entry is treated exactly as a separate
+        /// `--input-file`; blank lines are ignored. Lets high-fanout callers
+        /// (e.g. every file under `src/**`) sidestep the OS argv limit.
+        #[arg(long = "input-file-list", value_name = "PATH")]
+        input_file_list: Option<String>,
+        /// Issue #837: read newline-delimited input-file paths from stdin.
+        /// Same semantics as `--input-file-list` but from the pipe. The
+        /// wrapped tool does not receive stdin (exec runs it with a null
+        /// stdin), so this does not compete with it.
+        #[arg(long = "input-file-stdin")]
+        input_file_stdin: bool,
         /// Repeatable: env var name whose *value* feeds the cache key.
         /// The current process env is queried for the value at request time.
         #[arg(long = "input-env", value_name = "NAME")]

--- a/crates/zccache/src/cli/commands/exec.rs
+++ b/crates/zccache/src/cli/commands/exec.rs
@@ -18,6 +18,10 @@ use super::util::{absolute_path, connect, exit_code_from_i32, resolve_endpoint};
 /// daemon.
 pub(crate) struct ExecParams {
     pub(crate) input_files: Vec<String>,
+    /// Issue #837: newline-delimited file of additional input-file paths.
+    pub(crate) input_file_list: Option<String>,
+    /// Issue #837: read additional input-file paths from stdin.
+    pub(crate) input_file_stdin: bool,
     pub(crate) input_env: Vec<String>,
     pub(crate) input_extra: Option<String>,
     pub(crate) output_stdout: bool,
@@ -48,6 +52,8 @@ pub(crate) struct ExecParams {
 pub(crate) fn cmd_exec(params: ExecParams) -> ExitCode {
     let ExecParams {
         input_files,
+        input_file_list,
+        input_file_stdin,
         input_env,
         input_extra,
         output_stdout,
@@ -98,6 +104,30 @@ pub(crate) fn cmd_exec(params: ExecParams) -> ExitCode {
     }
 
     let cwd_norm: NormalizedPath = std::env::current_dir().unwrap_or_default().into();
+
+    // Issue #837: expand `--input-file-list` / `--input-file-stdin` into the
+    // same path set as repeated `--input-file`. This is purely a delivery
+    // mechanism — the paths join `input_files` before absolutization, so the
+    // cache key is byte-identical to spelling every path on the command line.
+    let mut input_files = input_files;
+    if let Some(list_path) = input_file_list.as_deref() {
+        match std::fs::read_to_string(list_path) {
+            Ok(contents) => input_files.extend(parse_input_path_lines(&contents)),
+            Err(e) => {
+                eprintln!("zccache exec: failed to read --input-file-list {list_path}: {e}");
+                return ExitCode::from(2);
+            }
+        }
+    }
+    if input_file_stdin {
+        use std::io::Read as _;
+        let mut buf = String::new();
+        if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
+            eprintln!("zccache exec: failed to read --input-file-stdin: {e}");
+            return ExitCode::from(2);
+        }
+        input_files.extend(parse_input_path_lines(&buf));
+    }
 
     let input_file_paths: Vec<NormalizedPath> =
         input_files.iter().map(|p| absolute_path(p)).collect();
@@ -258,6 +288,21 @@ fn parse_hex_32(s: &str) -> Option<[u8; 32]> {
     Some(out)
 }
 
+/// Issue #837: split a newline-delimited path list (from `--input-file-list`
+/// or `--input-file-stdin`) into individual paths. Trailing whitespace and
+/// `\r` (Windows CRLF) are trimmed and blank lines dropped so a trailing
+/// newline or a hand-edited list doesn't inject empty paths. Every surviving
+/// line is treated exactly as one `--input-file` value — no comment syntax,
+/// so a literal `#foo` path is preserved.
+fn parse_input_path_lines(contents: &str) -> Vec<String> {
+    contents
+        .lines()
+        .map(|line| line.trim_end_matches(['\r', '\n']).trim_end())
+        .filter(|line| !line.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -280,5 +325,27 @@ mod tests {
         let mut bad = "0".repeat(64);
         bad.replace_range(0..1, "z");
         assert!(parse_hex_32(&bad).is_none());
+    }
+
+    #[test]
+    fn parse_input_path_lines_splits_and_trims() {
+        let listing = "src/a.h\nsrc/b.h\r\n  src/c.h  \n\n\tsrc/d.h\n";
+        assert_eq!(
+            parse_input_path_lines(listing),
+            vec!["src/a.h", "src/b.h", "  src/c.h", "\tsrc/d.h"],
+        );
+    }
+
+    #[test]
+    fn parse_input_path_lines_drops_blanks_and_keeps_hash_paths() {
+        // Trailing newline / blank lines must not inject empty entries, and a
+        // leading '#' is a real path segment, not a comment.
+        assert!(parse_input_path_lines("\n\n   \n").is_empty());
+        assert_eq!(parse_input_path_lines("#notacomment.h\n"), vec!["#notacomment.h"]);
+    }
+
+    #[test]
+    fn parse_input_path_lines_empty_input_is_empty() {
+        assert!(parse_input_path_lines("").is_empty());
     }
 }

--- a/crates/zccache/src/cli/commands/mod.rs
+++ b/crates/zccache/src/cli/commands/mod.rs
@@ -447,6 +447,8 @@ fn dispatch(command: Commands, global_strict_paths: Option<&str>) -> ExitCode {
         },
         Commands::Exec {
             input_file,
+            input_file_list,
+            input_file_stdin,
             input_env,
             input_extra,
             output_stdout,
@@ -466,6 +468,8 @@ fn dispatch(command: Commands, global_strict_paths: Option<&str>) -> ExitCode {
             tool_command,
         } => exec::cmd_exec(exec::ExecParams {
             input_files: input_file,
+            input_file_list,
+            input_file_stdin,
             input_env,
             input_extra,
             output_stdout,

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -197,7 +197,7 @@ Cache-key composition has two layers, both domain-separated:
 - args in argv order, after `--key-args-filter` regex drops (filtered args still reach the tool's argv)
 - sorted (name=value) env subset declared via `--input-env`
 - cwd (when `cwd_in_key=true`; suppressible via `--no-cwd-in-key`)
-- sorted (path, content-hash) input file pairs (content via the two-layer fingerprint)
+- sorted (path, content-hash) input file pairs (content via the two-layer fingerprint), declared via repeated `--input-file` and/or the bulk forms below
 - sorted (path, content-hash) **Path A** transitive headers — every file reached from `--include-scan` seeds resolved against `--include-dir` / `--system-include` / `--iquote-dir` using the existing `depgraph::scanner`
 - declared output_file names (so changing the capture set invalidates)
 - `input_extra` opaque bytes
@@ -205,6 +205,12 @@ Cache-key composition has two layers, both domain-separated:
 **Full key** (domain tag `zccache-exec-full-key-v2`) — extends the primary with Path B depfile-derived deps:
 - **First invocation**: full = primary; tool runs, the emitted `--depfile` is parsed, each listed file's content-hash is recorded in a `<primary>.deps` sidecar alongside the artifact.
 - **Subsequent invocations**: the sidecar is read before lookup, dep contents are re-hashed (via two-layer), and the full key is composed; lookup happens under the full key. Stale sidecars (referencing vanished files) force a fresh miss; a non-zero tool exit skips writing the sidecar so the next call cleanly bootstraps.
+
+**Bulk input declaration** (issue #837) — for high-fanout callers (e.g. every file under `src/**`, ~1500–2000 paths) that would blow the OS argv limit spelling out `--input-file` per path:
+- `--input-file-list <PATH>` — read newline-delimited paths from a file.
+- `--input-file-stdin` — read newline-delimited paths from this process's stdin. Safe alongside the wrapped tool, which exec runs with a null stdin.
+
+Both are pure delivery mechanisms: `cli/commands/exec.rs::parse_input_path_lines` trims trailing whitespace/`\r` and drops blank lines (no comment syntax — a literal `#path` is preserved), then the entries join the `--input-file` set before absolutization. The cache key is byte-identical to spelling every path on the command line. `--input-glob` (daemon-side walking) was deferred as a design question; see #837.
 
 Cache policies (`ExecCachePolicy`):
 - `Normal` (default) — look up + store


### PR DESCRIPTION
## Summary

`zccache exec` currently requires one `--input-file` per declared input. High-fanout callers (FastLED's C++ lint scopes ~1500–2000 files under `src/**`) blow the Windows `CreateProcess` 32K argv limit and pay 100–200 KB of process-launch bookkeeping per invocation. This adds two by-reference delivery modes:

- `--input-file-list <PATH>` — newline-delimited paths from a file.
- `--input-file-stdin` — same, from stdin. The wrapped tool runs with a null stdin (confirmed in `handle_exec.rs` → `process.rs`), so consuming the CLI's stdin doesn't compete with it.

## No cache-key change

Both modes expand into the same `input_files` vector **before** absolutization, so the daemon composes a byte-identical cache key to spelling every path on the command line (the daemon content-hashes + sorts the pairs regardless of delivery order). The daemon, protocol, and wire layers are untouched — all new logic is CLI-side in `exec.rs`.

`parse_input_path_lines` trims trailing whitespace/`\r` (CRLF) and drops blank lines so a trailing newline or hand-edited list doesn't inject empty paths; there is no comment syntax, so a literal `#path` is preserved (faithful to "treated exactly as a separate `--input-file`").

`--input-glob` (daemon-side walking) is **deferred** — it changes the "explicit inputs" model and needs a design decision, so it stays in #837's parent scope.

## Tests

`cli::commands::exec::tests` (run with `--features cli`):
- `parse_input_path_lines_splits_and_trims` — CRLF, trailing space, leading whitespace preserved.
- `parse_input_path_lines_drops_blanks_and_keeps_hash_paths` — blank-line drop + `#path` is not a comment.
- `parse_input_path_lines_empty_input_is_empty`.

All 3 pass locally; clippy clean (`-p zccache --lib --features cli`).

Closes #837. Part of the #991 low-risk burn-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)