### PR TITLE
lint(dylint): ban hardcoded /tmp path literals (#828)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
         run: soldr cargo fmt --manifest-path dylints/ban_std_pathbuf/Cargo.toml --all -- --check
       - name: Check Dylint Library Formatting (ban_unrooted_tempdir)
         run: soldr cargo fmt --manifest-path dylints/ban_unrooted_tempdir/Cargo.toml --all -- --check
+      - name: Check Dylint Library Formatting (ban_tmp_literal)
+        run: soldr cargo fmt --manifest-path dylints/ban_tmp_literal/Cargo.toml --all -- --check
       - name: Test Dylint Library (ban_std_pathbuf)
         run: |
           export PATH="${CARGO_HOME}/bin:${PATH}"
@@ -100,6 +102,10 @@ jobs:
         run: |
           export PATH="${CARGO_HOME}/bin:${PATH}"
           soldr rustup run nightly-2026-03-26 cargo test --manifest-path dylints/ban_unrooted_tempdir/Cargo.toml
+      - name: Test Dylint Library (ban_tmp_literal)
+        run: |
+          export PATH="${CARGO_HOME}/bin:${PATH}"
+          soldr rustup run nightly-2026-03-26 cargo test --manifest-path dylints/ban_tmp_literal/Cargo.toml
       - name: Run Dylint
         run: |
           export PATH="${CARGO_HOME}/bin:${PATH}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ exclude = [
     "dylints/ban_std_pathbuf",
     "dylints/ban_unrooted_tempdir",
     "dylints/ban_raw_subprocess_in_daemon",
+    "dylints/ban_tmp_literal",
 ]
 
 [workspace.package]

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -247,6 +247,7 @@ def lint_workspace():
         for dylint_manifest in (
             "dylints/ban_std_pathbuf/Cargo.toml",
             "dylints/ban_unrooted_tempdir/Cargo.toml",
+            "dylints/ban_tmp_literal/Cargo.toml",
         ):
             result = run_cmd(cargo_command(
                 "fmt",

--- a/dylints/README.md
+++ b/dylints/README.md
@@ -3,6 +3,9 @@
 Custom Rust lints used by this workspace.
 
 - `ban_std_pathbuf`: bans new uses of `std::path::PathBuf` outside the explicit legacy allowlist.
+- `ban_unrooted_tempdir`: bans tempdir/temp-file creation under `$TMPDIR` instead of `zccache_core::config::default_cache_dir()`.
+- `ban_raw_subprocess_in_daemon`: bans raw subprocess spawns in daemon code paths.
+- `ban_tmp_literal`: bans hardcoded `/tmp` path string literals — they only exist on POSIX (#828).
 
 Note:
 

--- a/dylints/ban_tmp_literal/Cargo.toml
+++ b/dylints/ban_tmp_literal/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "ban_tmp_literal"
+version = "0.1.0"
+description = "Ban hardcoded /tmp path string literals; they only exist on POSIX"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# Match the dylint_linting pin used by ban_std_pathbuf — same toolchain, same
+# upstream commit until a crates.io release ships the post-2026-03-18
+# rustc_session fix.
+dylint_linting = { git = "https://github.com/trailofbits/dylint", rev = "4bd91ce7729b74c7ee5664bbb588f7baf30b4a09" }
+
+[dev-dependencies]
+dylint_testing = { git = "https://github.com/trailofbits/dylint", rev = "4bd91ce7729b74c7ee5664bbb588f7baf30b4a09" }
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/dylints/ban_tmp_literal/README.md
+++ b/dylints/ban_tmp_literal/README.md
@@ -1,0 +1,63 @@
+# ban_tmp_literal
+
+Dylint library that bans hardcoded `/tmp` path string literals (`"/tmp"` or
+`"/tmp/..."`) in workspace Rust code. Tracked by issue
+[#828](https://github.com/zackees/zccache/issues/828).
+
+## Why
+
+zccache ships on Linux, macOS, and Windows. A literal `/tmp/...` path only
+exists on POSIX: Windows callers either silently write to `C:\tmp\` (if it
+exists, polluting the filesystem) or fail. CI on macOS/Linux passes; Windows
+runners or dev boxes break. The fix is mechanical, but discovery requires a
+scan — and future regressions require this lint.
+
+## What to use instead
+
+- **Runtime scratch state**: `zccache_core::config::tmp_dir()` — rooted under
+  the ground-truth cache dir, visible to `zccache clear`, same volume as the
+  destination (preserves the atomic-rename invariant). See
+  `ban_unrooted_tempdir` for the companion rule that keeps scratch state out
+  of `$TMPDIR` entirely.
+- **Tests that need a real directory**: `tempfile::tempdir_in(...)` rooted
+  under the cache dir per `ban_unrooted_tempdir`'s guidance.
+- **Fixture path strings that never touch the filesystem** (map keys, parser
+  inputs): any platform-neutral fake path that does not imply a real POSIX
+  location, e.g. `/fixture/foo.c`.
+
+## Allowlist
+
+Legacy files are exempted via `src/allowlist.txt` (path-tail matching, same
+mechanism as `ban_unrooted_tempdir`). The entries fall into three groups,
+documented inline in that file:
+
+1. **Deliberate `cfg(unix)` socket endpoints** — `/tmp/zccache-{user}/...`
+   is the versioned daemon-discovery convention when `XDG_RUNTIME_DIR` is
+   unset. Changing these would break endpoint compatibility between zccache
+   versions; they are intentionally permanent exemptions.
+2. **Wire-format compat pins** — fixture literals that feed pinned bincode
+   fingerprints; changing the bytes breaks golden values by design.
+3. **fs-inert legacy test fixtures** — map keys and parser inputs that never
+   touch the filesystem. Migrate to neutral fake paths as you touch each
+   file; do not add new entries in this group.
+
+## Scope note
+
+The workspace dylint runner (`cargo dylint --all --workspace`, via
+`python3 -m ci.lint --dylint-only`) checks production targets; `#[cfg(test)]`
+modules and integration tests are compiled only under `--all-targets`, which
+the runner does not currently pass (a pre-existing property shared by all
+dylints in this repo). The allowlist nevertheless carries the test-side legacy
+files so the lint stays clean if the runner ever gains `--all-targets`.
+
+## Running
+
+From the repository root:
+
+```bash
+cargo dylint --lib ban_tmp_literal --workspace
+```
+
+The UI test is `#[ignore]`d until `.stderr` snapshots are captured, matching
+`ban_unrooted_tempdir`; the lint is exercised end-to-end by the workspace
+dylint run in CI.

--- a/dylints/ban_tmp_literal/rust-toolchain.toml
+++ b/dylints/ban_tmp_literal/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2026-03-26"
+components = ["llvm-tools-preview", "rust-src", "rustc-dev"]

--- a/dylints/ban_tmp_literal/src/README.md
+++ b/dylints/ban_tmp_literal/src/README.md
@@ -1,0 +1,8 @@
+# ban_tmp_literal/src
+
+- `lib.rs` — the late lint pass: flags `"/tmp"` / `"/tmp/..."` string
+  literals, checks the allowlist by path tail, and carries the ignored UI
+  test scaffolding shared with `ban_unrooted_tempdir`.
+- `allowlist.txt` — legacy exemptions, grouped and justified inline. New
+  entries require an inline comment explaining why the site cannot use
+  `zccache_core::config::tmp_dir()` or a neutral fixture path.

--- a/dylints/ban_tmp_literal/src/allowlist.txt
+++ b/dylints/ban_tmp_literal/src/allowlist.txt
@@ -1,0 +1,63 @@
+# Each non-empty, non-comment line is matched against the tail of each
+# source file path (slashes normalized). See ban_unrooted_tempdir for the
+# same mechanism.
+#
+# DO NOT add new entries without an inline comment explaining why the site
+# cannot use `zccache_core::config::tmp_dir()` (runtime scratch), a
+# `tempfile::tempdir_in(...)` (fs-touching tests), or a neutral fake path
+# like `/fixture/...` (fs-inert fixtures).
+
+# ── Group 1: deliberate cfg(unix) socket-endpoint conventions ──────────────
+# `/tmp/zccache-{user}/...` (and the download daemon's equivalent) is the
+# daemon-discovery fallback when XDG_RUNTIME_DIR is unset. These paths are
+# part of the endpoint contract between zccache versions — rewriting them
+# would strand running daemons and split caches. Permanent exemptions.
+crates/zccache-ipc/src/lib.rs
+crates/zccache-download-protocol/src/daemon_mgmt.rs
+
+# ── Group 2: wire-format compat pins ────────────────────────────────────────
+# Fixture literals in these files feed pinned bincode fingerprints and
+# variant-index golden values. Changing the bytes is a wire-format change by
+# definition; the literals stay verbatim. Permanent exemptions.
+crates/zccache-protocol/src/messages/compat/variant_indices.rs
+crates/zccache-protocol/src/messages/compat/fingerprint.rs
+crates/zccache-protocol/src/messages/compat/session_lifecycle.rs
+crates/zccache-protocol/src/messages/compat/ephemeral.rs
+crates/zccache-protocol/src/messages/compat/artifact_payload.rs
+crates/zccache-protocol/src/messages/compat/mod.rs
+
+# ── Group 3: fs-inert legacy test fixtures ──────────────────────────────────
+# Map keys, parser inputs, and Unix-only test socket names that never touch
+# the filesystem on Windows. Migrate to neutral fake paths (`/fixture/...`)
+# as you touch each file; do not add new entries in this group. See #828.
+crates/zccache/src/cli/commands/tests/analyze.rs
+crates/zccache/src/cli/runtime.rs
+crates/zccache/src/cli/snapshot_fp.rs
+crates/zccache/src/daemon/compile_journal/tests/entry.rs
+crates/zccache/src/daemon/compile_journal/tests/journal_file.rs
+crates/zccache/src/daemon/compile_journal/tests/miss_reason.rs
+crates/zccache/src/daemon/event_log.rs
+crates/zccache/src/daemon/eviction.rs
+crates/zccache/src/daemon/server/session.rs
+crates/zccache/src/daemon/server/tests/cache_trim.rs
+crates/zccache/src/daemon/server/tests/client_env.rs
+crates/zccache/tests/daemon_wire_prost_roundtrip.rs
+crates/zccache/tests/v2_probe_local_socket_test.rs
+crates/zccache/tests/v2_stress_adversarial_test.rs
+crates/zccache-compiler/src/response_file.rs
+crates/zccache-compiler/src/tests/rustc.rs
+crates/zccache-core/src/config/tests.rs
+crates/zccache-core/src/defender.rs
+crates/zccache-core/src/lifecycle.rs
+crates/zccache-depgraph/src/context/tests/rustc.rs
+crates/zccache-depgraph/src/depfile/tests.rs
+crates/zccache-depgraph/src/rustc_args.rs
+crates/zccache-depgraph/src/scanner.rs
+crates/zccache-fingerprint/src/persist.rs
+crates/zccache-fscache/src/metadata.rs
+crates/zccache-fscache/src/persistence.rs
+crates/zccache-ipc/src/broker_v2.rs
+crates/zccache-ipc/src/manifest.rs
+crates/zccache-ipc/src/mod_tests.rs
+crates/zccache-ipc/src/transport/mod.rs
+crates/zccache-symbols/src/cache.rs

--- a/dylints/ban_tmp_literal/src/lib.rs
+++ b/dylints/ban_tmp_literal/src/lib.rs
@@ -1,0 +1,204 @@
+#![feature(rustc_private)]
+
+extern crate rustc_ast;
+extern crate rustc_errors;
+extern crate rustc_hir;
+extern crate rustc_span;
+
+use rustc_ast::LitKind;
+use rustc_errors::DiagDecorator;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_span::{FileName, RemapPathScopeComponents};
+
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// Bans string literals that hardcode the POSIX temp directory:
+    /// `"/tmp"` or anything starting with `"/tmp/"`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// zccache ships on Linux, macOS, and Windows. A literal `/tmp/...`
+    /// path only exists on POSIX: Windows callers either silently write to
+    /// `C:\tmp\` (if it exists, polluting the filesystem) or fail. CI on
+    /// macOS/Linux passes; Windows runners or dev boxes break.
+    ///
+    /// ### Known problems
+    ///
+    /// Legacy call sites are exempted via `src/allowlist.txt`. The
+    /// `cfg(unix)` daemon-socket endpoints are permanent exemptions (the
+    /// `/tmp/zccache-{user}` convention is part of the daemon-discovery
+    /// contract); fs-inert test fixtures should migrate to neutral fake
+    /// paths as each file is touched.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// let log = std::path::Path::new("/tmp/zc.log");
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```rust
+    /// let root = zccache_core::config::tmp_dir();
+    /// let log = root.join("zc.log");
+    /// ```
+    pub BAN_TMP_LITERAL,
+    Deny,
+    "ban hardcoded /tmp path literals; they only exist on POSIX"
+}
+
+const ALLOWLIST: &str = include_str!("allowlist.txt");
+
+impl<'tcx> LateLintPass<'tcx> for BanTmpLiteral {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        let ExprKind::Lit(lit) = expr.kind else {
+            return;
+        };
+        let LitKind::Str(symbol, _) = lit.node else {
+            return;
+        };
+        let value = symbol.as_str();
+        if value != "/tmp" && !value.starts_with("/tmp/") {
+            return;
+        }
+        if is_allowlisted(cx, expr.span) {
+            return;
+        }
+        emit_lint(cx, expr.span);
+    }
+}
+
+fn emit_lint(cx: &LateContext<'_>, span: rustc_span::Span) {
+    cx.opt_span_lint(
+        BAN_TMP_LITERAL,
+        Some(span),
+        DiagDecorator(move |diag| {
+            diag.primary_message(
+                "hardcoded `/tmp` path only exists on POSIX; use \
+                 zccache_core::config::tmp_dir() for runtime scratch state, \
+                 tempfile::tempdir_in(...) for tests that touch the \
+                 filesystem, or a neutral fake path (e.g. `/fixture/...`) \
+                 for fs-inert fixtures",
+            );
+        }),
+    );
+}
+
+fn is_allowlisted(cx: &LateContext<'_>, span: rustc_span::Span) -> bool {
+    let filename = match cx.sess().source_map().span_to_filename(span) {
+        FileName::Real(real_filename) => real_filename
+            .local_path()
+            .map(|path| path.to_string_lossy().into_owned())
+            .unwrap_or_else(|| {
+                real_filename
+                    .path(RemapPathScopeComponents::DIAGNOSTICS)
+                    .to_string_lossy()
+                    .into_owned()
+            }),
+        filename => filename
+            .display(RemapPathScopeComponents::DIAGNOSTICS)
+            .to_string(),
+    };
+    let normalized = normalize_slashes(&filename);
+
+    ALLOWLIST
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .any(|allowed| normalized.ends_with(allowed))
+}
+
+fn normalize_slashes(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+#[cfg(test)]
+struct CurrentDirGuard(std::path::PathBuf);
+
+#[cfg(test)]
+impl CurrentDirGuard {
+    fn set(path: &std::path::Path) -> Self {
+        let previous = std::env::current_dir().expect("current dir should be readable");
+        std::env::set_current_dir(path).expect("current dir should switch to manifest dir");
+        Self(previous)
+    }
+}
+
+#[cfg(test)]
+fn prepare_dylint_library() {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let status = std::process::Command::new("cargo")
+        .arg("build")
+        .current_dir(manifest_dir)
+        .status()
+        .expect("cargo build should start");
+    assert!(status.success(), "cargo build should succeed");
+
+    let toolchain = std::env::var("RUSTUP_TOOLCHAIN").expect("RUSTUP_TOOLCHAIN should be set");
+    let library_name = env!("CARGO_PKG_NAME").replace('-', "_");
+    let target_debug = manifest_dir.join("target").join("debug");
+    let expected = target_debug.join(format!(
+        "{}{}@{}{}",
+        std::env::consts::DLL_PREFIX,
+        library_name,
+        toolchain,
+        std::env::consts::DLL_SUFFIX
+    ));
+    if expected.exists() {
+        return;
+    }
+
+    let plain = target_debug.join(format!(
+        "{}{}{}",
+        std::env::consts::DLL_PREFIX,
+        library_name,
+        std::env::consts::DLL_SUFFIX
+    ));
+    if plain.exists() {
+        std::fs::copy(&plain, &expected)
+            .expect("toolchain-suffixed dylint library should be copied");
+        return;
+    }
+
+    let deps_dir = target_debug.join("deps");
+    for entry in std::fs::read_dir(&deps_dir).expect("deps dir should be readable") {
+        let path = entry.expect("deps entry should be readable").path();
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if name.starts_with(&format!("{}{}", std::env::consts::DLL_PREFIX, library_name))
+            && name.ends_with(std::env::consts::DLL_SUFFIX)
+        {
+            std::fs::copy(&path, &expected)
+                .expect("hashed dylint library should be copied to the expected filename");
+            return;
+        }
+    }
+
+    panic!(
+        "could not find a built dylint library to copy into {}",
+        expected.display()
+    );
+}
+
+#[cfg(test)]
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.0).expect("current dir should be restored");
+    }
+}
+
+// UI test ignored until matching `.stderr` snapshots are captured locally.
+// The lint behavior is exercised end-to-end by `cargo dylint --all
+// --workspace` against the real workspace tree (the allowlist covers the
+// legacy sites, and any new violation lights up the workspace lint). Same
+// arrangement as ban_unrooted_tempdir.
+#[test]
+#[ignore = "no .stderr snapshots yet — verify via `cargo dylint --all --workspace`"]
+fn ui() {
+    let _guard = CurrentDirGuard::set(std::path::Path::new(env!("CARGO_MANIFEST_DIR")));
+    prepare_dylint_library();
+    dylint_testing::ui_test(env!("CARGO_PKG_NAME"), "ui");
+}

--- a/dylints/ban_tmp_literal/ui/README.md
+++ b/dylints/ban_tmp_literal/ui/README.md
@@ -1,0 +1,11 @@
+# UI tests
+
+`*.rs` here are minimal programs that exercise specific lint behavior. For
+each, `dylint_testing::ui_test` compiles the file and asserts the resulting
+diagnostics match the adjacent `*.stderr` snapshot (snapshots not yet
+captured — the `ui` test is `#[ignore]`d, same as `ban_unrooted_tempdir`).
+
+- `disallowed.rs` — must trigger the lint on `"/tmp"`, `"/tmp/..."`, and a
+  `format!` template starting with `/tmp/`.
+- `allowed.rs` — neutral fixture paths, `/var/tmp`, and relative `tmp/`
+  segments must NOT trigger the lint.

--- a/dylints/ban_tmp_literal/ui/allowed.rs
+++ b/dylints/ban_tmp_literal/ui/allowed.rs
@@ -1,0 +1,9 @@
+fn main() {
+    // Neutral fake paths for fs-inert fixtures do not trigger the lint.
+    let _key = "/fixture/persist0.c";
+    // Paths that merely contain "tmp" elsewhere are fine.
+    let _other = "/var/tmp/x";
+    let _name = "tmp/relative";
+    // Building on the sanctioned scratch root is the runtime replacement.
+    let _joined = std::path::Path::new("/some/configured/dir").join("scratch");
+}

--- a/dylints/ban_tmp_literal/ui/disallowed.rs
+++ b/dylints/ban_tmp_literal/ui/disallowed.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let _bare = "/tmp";
+    let _file = "/tmp/zc.log";
+    let _path = std::path::Path::new("/tmp/scratch");
+    let _fmt = format!("/tmp/zccache-{}/sock", "user");
+}


### PR DESCRIPTION
## Summary

New dylint library `ban_tmp_literal` flagging `"/tmp"` / `"/tmp/..."` string literals — they only exist on POSIX, so any fs-touching use is a latent Windows-only regression (silently writes to `C:\tmp\` or fails; CI on Linux/macOS stays green). Follows the exact shape of the existing `ban_unrooted_tempdir` (path-tail allowlist, ignored UI test, same `dylint_linting` git pin).

Wired into: workspace `exclude` list, `ci/lint.py` fmt loop, the `.github/workflows/ci.yml` dylint job (fmt-check + `cargo test` + `Run Dylint`), and the `dylints/README.md`.

## Allowlist (3 documented groups)

I grepped every `/tmp` literal in `crates/` and categorized all 39 files:

1. **Permanent `cfg(unix)` socket-endpoint conventions** — `/tmp/zccache-{user}/...` is the daemon-discovery fallback when `XDG_RUNTIME_DIR` is unset; part of the cross-version endpoint contract (`zccache-ipc/src/lib.rs`, `zccache-download-protocol/src/daemon_mgmt.rs`).
2. **Wire-format compat pins** — fixture literals feeding pinned bincode fingerprints / variant-index golden values (`protocol/messages/compat/*`); the bytes must stay verbatim.
3. **fs-inert legacy test fixtures** — map keys and parser inputs that never touch the filesystem; migrate to neutral fake paths as touched.

New entries require an inline justification comment.

## Decision: no new `temp_path()` helper

#828 suggested a `temp_path(name)` factory, but `zccache_core::config::tmp_dir()` (rooted under the cache dir) already exists and is what `ban_unrooted_tempdir` steers callers to. The lint points there rather than introducing a parallel helper.

## Validation

- **Code-level (green):** `ban_tmp_literal` compiles; `cargo fmt --check` clean; the crate's `cargo test` passes under `nightly-2026-03-26` (Linux container). Structurally identical to the two CI-passing dylints.
- **End-to-end firing (blocked locally, by design elsewhere):** I attempted a RED/GREEN `cargo dylint --lib ban_tmp_literal --workspace` in a Linux container. It — **and the known-good `ban_unrooted_tempdir` run identically** — fails to build `dylint_linting` (rev `4bd91ce`) against a rustup-fresh `nightly-2026-03-26` (`early_error`/`parse_sess`/`local_crate_source_file` `rustc_session` API drift). This is the exact toolchain-pin fragility the `dylints/README.md` documents, and it breaks **every** repo dylint in a fresh container — not a defect in this lint. The authoritative gate is the repo's CI **Dylint** job (push-to-main only, `if: github.event_name == 'push'`), which uses setup-soldr's frozen toolchain + cached driver.

Because the Dylint job is push-only, it validates on `main` post-merge; the allowlist is comprehensive (all production `/tmp` sites covered) so GREEN should be clean there.

Closes #828. Part of the #991 low-risk burn-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)