### PR TITLE
feat(release): publish manifest.json release asset (#858)

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -363,6 +363,19 @@ jobs:
           cd release-assets
           find . -maxdepth 1 -type f -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
 
+      - name: Generate manifest.json
+        shell: bash
+        # Issue #858: publish a static manifest so soldr resolves binaries via
+        # the release-asset CDN instead of the rate-limited GitHub releases API.
+        # Runs after checksums so it enumerates the final archive set; the
+        # manifest lands in release-assets/ and is swept up by the upload glob.
+        run: |
+          uv run --no-project ci/build_release_manifest.py \
+            --assets-dir release-assets \
+            --version "${{ needs.preflight.outputs.version }}" \
+            --tag "${{ needs.preflight.outputs.release_tag }}" \
+            --repo "${{ github.repository }}"
+
       - name: Publish or update release
         uses: softprops/action-gh-release@v3
         with:

--- a/ci/build_release_manifest.py
+++ b/ci/build_release_manifest.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Build a `manifest.json` release asset enumerating the published binaries.
+
+Issue #858: soldr's binary-fetch path currently lists a repo's releases via the
+unauthenticated GitHub API (`GET /repos/.../releases`), which is rate-limited
+per IP (shared across every CI job on a runner-pool IP) and 403s on busy macOS
+pools — forcing a 4-6 min `cargo install` fallback. Publishing a static
+`manifest.json` alongside each release lets soldr resolve the exact binary via
+the release-asset CDN (no API call, no rate limit).
+
+The manifest is generated in the `publish-release` job after the archives are
+downloaded into one directory, so it enumerates whatever archives are actually
+present (robust to matrix changes). It is written into that same directory and
+swept up by the workflow's `files: release-assets/*` upload glob.
+
+Schema (the contract soldr reads):
+
+    {
+      "version": "1.12.15",
+      "tag": "v1.12.15",
+      "binaries": [
+        {
+          "target": "x86_64-unknown-linux-musl",
+          "asset": "zccache-v1.12.15-x86_64-unknown-linux-musl.tar.gz",
+          "url": "https://github.com/<repo>/releases/download/<tag>/<asset>",
+          "sha256": "<hex>"
+        },
+        ...
+      ]
+    }
+
+Only the primary per-target binary archives are listed; `-debug` symbol
+archives are intentionally excluded (soldr wants the runnable binary, and a
+`-debug` entry would collide on the `target` key).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+# Primary binary archive extensions, longest first so `.tar.gz` is matched
+# before a hypothetical `.gz`.
+ARCHIVE_EXTS = (".tar.gz", ".zip")
+DEBUG_MARKER = "-debug"
+
+
+def normalize_version(version: str) -> str:
+    """Force the `v` prefix used in asset filenames (mirrors package_release)."""
+    return version if version.startswith("v") else f"v{version}"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_target(filename: str, version_tag: str) -> str | None:
+    """Extract the target triple from a primary binary archive filename.
+
+    Returns None for anything that is not a primary `zccache-<vtag>-<target>`
+    archive (installers, checksums, `-debug` archives, unrelated files).
+    """
+    prefix = f"zccache-{version_tag}-"
+    if not filename.startswith(prefix):
+        return None
+    for ext in ARCHIVE_EXTS:
+        if filename.endswith(ext):
+            middle = filename[len(prefix) : -len(ext)]
+            if not middle or DEBUG_MARKER in middle:
+                return None
+            return middle
+    return None
+
+
+def build_manifest(assets_dir: Path, version: str, tag: str, repo: str) -> dict:
+    version_tag = normalize_version(version)
+    binaries = []
+    for path in sorted(assets_dir.iterdir()):
+        if not path.is_file():
+            continue
+        target = parse_target(path.name, version_tag)
+        if target is None:
+            continue
+        binaries.append(
+            {
+                "target": target,
+                "asset": path.name,
+                "url": f"https://github.com/{repo}/releases/download/{tag}/{path.name}",
+                "sha256": sha256_file(path),
+            }
+        )
+    # Deterministic order regardless of filesystem iteration.
+    binaries.sort(key=lambda entry: entry["target"])
+    return {
+        "version": version.lstrip("v"),
+        "tag": tag,
+        "binaries": binaries,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--assets-dir", type=Path, required=True, help="Directory of downloaded release archives")
+    parser.add_argument("--version", required=True, help="Release version, e.g. 1.12.15 or v1.12.15")
+    parser.add_argument("--tag", required=True, help="Actual release tag used in the download URL (may be bare or v-prefixed)")
+    parser.add_argument("--repo", default="zackees/zccache", help="owner/repo for the download URL")
+    parser.add_argument("--output", type=Path, default=None, help="Manifest output path (default: <assets-dir>/manifest.json)")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    manifest = build_manifest(args.assets_dir, args.version, args.tag, args.repo)
+    output = args.output or (args.assets_dir / "manifest.json")
+    output.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {output} with {len(manifest['binaries'])} binaries")
+    for entry in manifest["binaries"]:
+        print(f"  {entry['target']} -> {entry['asset']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tests/test_build_release_manifest.py
+++ b/ci/tests/test_build_release_manifest.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_build_release_manifest():
+    module_path = Path(__file__).resolve().parents[1] / "build_release_manifest.py"
+    spec = importlib.util.spec_from_file_location("build_release_manifest", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+build_release_manifest = _load_build_release_manifest()
+
+
+def _repo_text(*parts: str) -> str:
+    return (Path(__file__).resolve().parents[2] / Path(*parts)).read_text(encoding="utf-8")
+
+
+# The six targets that produce release assets (upload_release: "true").
+RELEASE_TARGETS = (
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "aarch64-pc-windows-msvc",
+)
+
+
+def _seed_release_assets(assets_dir: Path, version: str = "1.12.15") -> None:
+    assets_dir.mkdir(parents=True, exist_ok=True)
+    for target in RELEASE_TARGETS:
+        ext = ".zip" if "windows" in target else ".tar.gz"
+        (assets_dir / f"zccache-v{version}-{target}{ext}").write_bytes(
+            f"binary-{target}".encode()
+        )
+        # A debug sidecar archive that must NOT appear in the manifest.
+        (assets_dir / f"zccache-v{version}-{target}-debug{ext}").write_bytes(b"debug")
+    # Non-archive assets that must be ignored.
+    (assets_dir / "install.sh").write_text("#!/bin/sh\n")
+    (assets_dir / "install.ps1").write_text("# ps\n")
+    (assets_dir / "SHA256SUMS").write_text("deadbeef  x\n")
+
+
+def test_manifest_lists_every_release_target(tmp_path: Path) -> None:
+    assets = tmp_path / "release-assets"
+    _seed_release_assets(assets)
+
+    manifest = build_release_manifest.build_manifest(
+        assets, version="1.12.15", tag="v1.12.15", repo="zackees/zccache"
+    )
+
+    assert manifest["version"] == "1.12.15"
+    assert manifest["tag"] == "v1.12.15"
+    targets = [b["target"] for b in manifest["binaries"]]
+    assert sorted(targets) == sorted(RELEASE_TARGETS)
+
+
+def test_manifest_excludes_debug_installers_and_checksums(tmp_path: Path) -> None:
+    assets = tmp_path / "release-assets"
+    _seed_release_assets(assets)
+
+    manifest = build_release_manifest.build_manifest(
+        assets, version="1.12.15", tag="v1.12.15", repo="zackees/zccache"
+    )
+
+    assets_named = [b["asset"] for b in manifest["binaries"]]
+    assert not any("-debug" in name for name in assets_named)
+    assert not any(name in ("install.sh", "install.ps1", "SHA256SUMS") for name in assets_named)
+    assert len(manifest["binaries"]) == len(RELEASE_TARGETS)
+
+
+def test_manifest_url_uses_actual_tag_and_correct_sha256(tmp_path: Path) -> None:
+    assets = tmp_path / "release-assets"
+    _seed_release_assets(assets)
+
+    # A bare (non-v) release tag must be preserved verbatim in the URL path,
+    # while the asset filename keeps its v-prefix.
+    manifest = build_release_manifest.build_manifest(
+        assets, version="1.12.15", tag="1.12.15", repo="zackees/zccache"
+    )
+
+    entry = next(b for b in manifest["binaries"] if b["target"] == "x86_64-apple-darwin")
+    asset = "zccache-v1.12.15-x86_64-apple-darwin.tar.gz"
+    assert entry["asset"] == asset
+    assert entry["url"] == (
+        f"https://github.com/zackees/zccache/releases/download/1.12.15/{asset}"
+    )
+    expected_sha = hashlib.sha256((assets / asset).read_bytes()).hexdigest()
+    assert entry["sha256"] == expected_sha
+
+
+def test_manifest_is_deterministically_ordered(tmp_path: Path) -> None:
+    assets = tmp_path / "release-assets"
+    _seed_release_assets(assets)
+
+    manifest = build_release_manifest.build_manifest(
+        assets, version="1.12.15", tag="v1.12.15", repo="zackees/zccache"
+    )
+    targets = [b["target"] for b in manifest["binaries"]]
+    assert targets == sorted(targets)
+
+
+def test_manifest_targets_match_workflow_upload_release_true() -> None:
+    # Guard: the manifest test's target set stays in sync with the workflow's
+    # `upload_release: "true"` matrix rows.
+    workflow = _repo_text(".github", "workflows", "release-auto.yml")
+    blocks = workflow.split("- target: ")
+    releasing = set()
+    for block in blocks[1:]:
+        target = block.splitlines()[0].strip()
+        head = block[: block.find("- target: ") if "- target: " in block else len(block)]
+        if 'upload_release: "true"' in head:
+            releasing.add(target)
+    assert releasing == set(RELEASE_TARGETS)


### PR DESCRIPTION
## Summary

soldr's binary-fetch path lists a repo's releases via the unauthenticated GitHub releases API (`GET /repos/.../releases`), which is rate-limited per IP (shared across every CI job on a runner-pool IP) and 403s on busy macOS pools — forcing a 4–6 min `cargo install` fallback (observed in FastLED PR #3335). This publishes a static `manifest.json` alongside each release so soldr resolves the exact binary via the release-asset CDN, with no API call.

## Implementation

`ci/build_release_manifest.py` runs in the `publish-release` job **after** the checksums step (so it enumerates the final archive set) and **before** the release upload. It walks `release-assets/`, matches the primary per-target archives (`zccache-v<version>-<target>.{tar.gz,zip}`), and emits:

```json
{
  "version": "1.12.15",
  "tag": "v1.12.15",
  "binaries": [
    { "target": "...", "asset": "...", "url": "https://github.com/<repo>/releases/download/<tag>/<asset>", "sha256": "..." }
  ]
}
```

Key decisions:
- **Enumerates what's on disk**, not a hardcoded target list — robust to matrix changes.
- **`-debug` archives, `install.sh`/`install.ps1`, and `SHA256SUMS` excluded** (a `-debug` entry would collide on the `target` key; soldr wants the runnable binary).
- **URL uses the actual `release_tag`** (which may be bare `1.2.3` or `v1.2.3`) while asset filenames always keep the `v` prefix — mirrors `install.sh`'s tag/asset split.
- The manifest lands in `release-assets/` and is swept up by the existing `files: release-assets/*` glob — **no upload-step change**.

## Tests

`ci/tests/test_build_release_manifest.py` (run: `uv run pytest ci/tests`), all 5 pass locally:
- every release target listed;
- debug archives / installers / checksums excluded;
- bare-tag URL preserved + sha256 matches the file;
- deterministic ordering;
- a guard asserting the test's target set stays in sync with the workflow's `upload_release: "true"` matrix rows.

Also smoke-tested end-to-end against a fake asset dir; `release-auto.yml` re-validated as parseable YAML.

Closes #858. Completes the #991 low-risk burn-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)