### PR TITLE
feat(cli): argv[0] multi-call dispatch + hidden daemon-run subcommand (#998)

### DIFF
--- a/crates/zccache/src/bin/zccache.rs
+++ b/crates/zccache/src/bin/zccache.rs
@@ -43,6 +43,16 @@ fn main() -> ExitCode {
 }
 
 fn run_main() -> ExitCode {
+    // #998: argv[0] multi-call dispatch. When this binary is invoked under the
+    // daemon's name (the CLI self-copies to `…/v<VERSION>/zccache-daemon[.exe]`
+    // and runs it — #999), run the daemon and exit. Any other/unknown argv[0]
+    // falls through to the standard CLI below. The daemon installs its own
+    // crash guard, so this runs before the CLI's.
+    if zccache::cli::multicall::invoked_as_daemon() {
+        zccache::daemon::entry::run();
+        return ExitCode::SUCCESS;
+    }
+
     // Crash coverage first thing: panic hook + native signal/SEH
     // handler so a fault inside arg parsing or symbol install still
     // leaves a dump under `~/.zccache/crashes/`. Guard stays alive

--- a/crates/zccache/src/cli/commands/mod.rs
+++ b/crates/zccache/src/cli/commands/mod.rs
@@ -44,6 +44,18 @@ use util::{absolute_path, init_tracing, resolve_endpoint, run_async};
 pub fn run() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
 
+    // #998: hidden argv[0]-independent escape hatch into the daemon.
+    // `zccache daemon-run <daemon-flags…>` forwards to the daemon entry with a
+    // synthesized `zccache-daemon` program name. Handled before any CLI/wrap
+    // machinery so it works even where argv[0] multi-call dispatch can't (a
+    // `noexec` cache dir, debugging, or a platform with an unreliable argv[0]).
+    if args.get(1).map(String::as_str) == Some("daemon-run") {
+        let daemon_argv = std::iter::once(crate::cli::multicall::DAEMON_STEM.to_string())
+            .chain(args.iter().skip(2).cloned());
+        crate::daemon::entry::run_from(daemon_argv);
+        return ExitCode::SUCCESS;
+    }
+
     // Best-effort: if the user opted in via env, fetch matching debug
     // sidecars before doing anything else so the very first command's
     // failure (if any) lands with resolvable symbols. Idempotent — skips

--- a/crates/zccache/src/cli/mod.rs
+++ b/crates/zccache/src/cli/mod.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 pub mod client;
 pub mod commands;
 pub mod defender;
+pub mod multicall;
 mod runtime;
 pub mod snapshot_fp;
 pub mod symbols;

--- a/crates/zccache/src/cli/multicall.rs
+++ b/crates/zccache/src/cli/multicall.rs
@@ -1,0 +1,113 @@
+//! argv[0] multi-call dispatch (issue #998).
+//!
+//! The `zccache` binary is deployed as the only executable; when it needs the
+//! daemon it copies itself to `…/v<VERSION>/zccache-daemon[.exe]` (issue #999)
+//! and runs that copy. The copy — seeing its own `argv[0]` is the daemon name —
+//! must run the daemon instead of the CLI. This module is the name check.
+//!
+//! Any other or unrecognized `argv[0]` (including an empty/mangled one) falls
+//! through to the standard CLI. That unknown-name → CLI fallback is the safety
+//! net: argv[0] is not guaranteed meaningful on every platform, so the CLI is
+//! always the default and the daemon is only ever entered on an exact name
+//! match (or the explicit `zccache daemon-run` escape hatch).
+
+use std::ffi::OsStr;
+use std::path::Path;
+
+/// The file stem the self-copied daemon binary is deployed under. Must match
+/// `verify_pid_exe_stem(pid, "zccache-daemon")` in `zccache-ipc` and the
+/// deployment path in #999.
+pub const DAEMON_STEM: &str = "zccache-daemon";
+
+/// True when this process was invoked under the daemon's name.
+///
+/// Reads `std::env::args_os().next()` (argv[0]); returns `false` when it is
+/// absent so the caller falls through to the CLI.
+pub fn invoked_as_daemon() -> bool {
+    std::env::args_os()
+        .next()
+        .is_some_and(|arg0| stem_matches(&arg0, DAEMON_STEM))
+}
+
+/// Core, testable name check: does `arg0`'s file stem equal `target`?
+///
+/// - The directory portion of a path is ignored (`/a/b/zccache-daemon` → yes).
+/// - On Windows the comparison is case-insensitive and the `.exe` suffix is
+///   dropped by `file_stem`; on Unix it is exact.
+/// - `file_stem` strips only the final extension, so a teardown orphan named
+///   `zccache-daemon.old.<rand>.exe` (issue #999 Windows unlock rename) does
+///   NOT match — a dead relocated binary must never dispatch as the daemon.
+fn stem_matches(arg0: &OsStr, target: &str) -> bool {
+    let Some(stem) = Path::new(arg0).file_stem() else {
+        return false;
+    };
+    let Some(stem) = stem.to_str() else {
+        return false;
+    };
+    if cfg!(windows) {
+        stem.eq_ignore_ascii_case(target)
+    } else {
+        stem == target
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    fn matches(s: &str) -> bool {
+        stem_matches(&OsString::from(s), DAEMON_STEM)
+    }
+
+    #[test]
+    fn bare_daemon_name_matches() {
+        assert!(matches("zccache-daemon"));
+    }
+
+    #[test]
+    fn full_path_matches() {
+        assert!(matches("/home/u/.zccache/v1.12.15/zccache-daemon"));
+        assert!(matches(r"C:\Users\u\.zccache\v1.12.15\zccache-daemon.exe"));
+    }
+
+    #[test]
+    fn exe_suffix_stripped() {
+        assert!(matches("zccache-daemon.exe"));
+    }
+
+    #[test]
+    fn cli_name_does_not_match() {
+        assert!(!matches("zccache"));
+        assert!(!matches("zccache.exe"));
+        assert!(!matches("/usr/bin/zccache"));
+    }
+
+    #[test]
+    fn teardown_orphan_does_not_match() {
+        // #999 renames a locked exe to `<stem>.old.<rand>.exe` to free it for
+        // rm -rf; that orphan must never dispatch as the daemon.
+        assert!(!matches("zccache-daemon.old.9271.exe"));
+        assert!(!matches("zccache-daemon.old.9271"));
+    }
+
+    #[test]
+    fn empty_or_unrelated_does_not_match() {
+        assert!(!matches(""));
+        assert!(!matches("some-other-tool"));
+        assert!(!matches("zccache-download-daemon"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_is_case_insensitive() {
+        assert!(matches("ZCCACHE-DAEMON.EXE"));
+        assert!(matches("Zccache-Daemon"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn unix_is_case_sensitive() {
+        assert!(!matches("Zccache-Daemon"));
+    }
+}

--- a/crates/zccache/src/daemon/entry.rs
+++ b/crates/zccache/src/daemon/entry.rs
@@ -122,6 +122,20 @@ pub fn run() {
     run_with(args);
 }
 
+/// Parse the daemon [`Args`] from an explicit argv and run. Used by the
+/// hidden `zccache daemon-run …` escape hatch (#998): an argv[0]-independent
+/// way to enter the daemon (debugging, `noexec` cache dirs, or platforms where
+/// argv[0] is unreliable). The caller synthesizes a leading `zccache-daemon`
+/// program-name token followed by the daemon flags.
+pub fn run_from<I, T>(argv: I)
+where
+    I: IntoIterator<Item = T>,
+    T: Into<std::ffi::OsString> + Clone,
+{
+    let args = Args::parse_from(argv);
+    run_with(args);
+}
+
 /// Run the daemon from already-parsed [`Args`]. Split out so `argv[0]`
 /// dispatch (#998) and tests can drive the daemon without going through
 /// `Args::parse()` on the real process argv.


### PR DESCRIPTION
## Summary

The routing half of the single-binary self-deploying strategy (#1007 workstream B). The `zccache` binary now dispatches on `argv[0]`: invoked under the daemon name (`zccache-daemon[.exe]`, which the CLI self-copies to per #999) it runs the daemon; any other or unknown/empty `argv[0]` falls through to the CLI.

- **New `cli/multicall.rs`**: `invoked_as_daemon()` + a testable `stem_matches()` core. The path directory is ignored; on Windows the match is case-insensitive and drops `.exe`; on Unix it's exact. `file_stem` strips only the final extension, so a teardown orphan named `zccache-daemon.old.<rand>.exe` (the #999 Windows unlock rename) does **not** dispatch as the daemon. 7 unit tests cover bare name, full paths, `.exe`, case rules, the orphan, and empty/unrelated names.
- **Dispatch** in `run_main` before the CLI crash guard (the daemon installs its own).
- **Hidden `zccache daemon-run <flags>` escape hatch** — handled before any CLI/wrap machinery, forwarding to `entry::run_from` with a synthesized program name. An `argv[0]`-independent way into the daemon for debugging, `noexec` cache dirs, or platforms with an unreliable `argv[0]`.

## Validation

- Windows: `cargo check`/clippy clean; `cli::multicall::tests` (7) pass.
- **Linux docker** (the sanctioned gate) — built the single binary, copied it under several names, and asserted behavior:
  1. invoked as `zccache-daemon` → `zccache-daemon v1.12.15` (daemon) ✓
  2. `zccache daemon-run` → `zccache-daemon v1.12.15` (escape hatch) ✓
  3. `zccache --version` → `zccache 1.12.15` (CLI, not daemon) ✓
  4. `zccache-daemon.old.9999 --version` → `zccache 1.12.15` (orphan falls through to CLI) ✓

Depends on #997. Prereq for #999. Closes #998. Part of the #1007 burn-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
