### PR TITLE
feat(config): version-namespace hygiene — last-version.txt + stale sibling pruning (#1005)

### DIFF
--- a/crates/zccache-core/src/config/mod.rs
+++ b/crates/zccache-core/src/config/mod.rs
@@ -102,8 +102,10 @@ pub use paths::{
     tmp_dir, tmp_dir_from_cache_dir,
 };
 pub use resolve::{
-    cache_dir_override, default_cache_dir, effective_cache_root_from_top_level, resolve_cache_root,
-    resolve_cache_root_top_level, versioned_subdir, CacheRootSource,
+    cache_dir_override, default_cache_dir, effective_cache_root_from_top_level, is_version_dir_name,
+    prune_stale_version_dirs, prune_stale_version_dirs_in, read_last_version_marker,
+    resolve_cache_root, resolve_cache_root_top_level, versioned_subdir, write_last_version_marker,
+    write_last_version_marker_in, CacheRootSource, PruneReport, LAST_VERSION_MARKER,
 };
 
 /// Top-level configuration for zccache.

--- a/crates/zccache-core/src/config/resolve.rs
+++ b/crates/zccache-core/src/config/resolve.rs
@@ -139,6 +139,101 @@ pub fn effective_cache_root_from_top_level(cache_root: &NormalizedPath) -> Norma
     cache_root.join(version)
 }
 
+/// Advisory top-level marker file recording the last daemon version that
+/// bound. Lives at `<top-level>/last-version.txt` — NEVER authoritative for
+/// identity (that is the versioned subdir); diagnostics + a warm-start hint
+/// only. Issue #1005 / #761 Phase-0 follow-up.
+pub const LAST_VERSION_MARKER: &str = "last-version.txt";
+
+/// Write `crate::VERSION` to the advisory `<top-level>/last-version.txt`.
+/// Best-effort — the error is returned for the caller to log, never fatal.
+pub fn write_last_version_marker() -> std::io::Result<()> {
+    write_last_version_marker_in(resolve_cache_root_top_level().0.as_path())
+}
+
+/// Test seam for [`write_last_version_marker`]: write the marker under an
+/// explicit top-level dir.
+pub fn write_last_version_marker_in(top_level: &std::path::Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(top_level)?;
+    std::fs::write(
+        top_level.join(LAST_VERSION_MARKER),
+        format!("{}\n", crate::VERSION),
+    )
+}
+
+/// Read the advisory last-version marker, if present and non-empty.
+#[must_use]
+pub fn read_last_version_marker() -> Option<String> {
+    let (top, _) = resolve_cache_root_top_level();
+    std::fs::read_to_string(top.join(LAST_VERSION_MARKER).as_path())
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// True if `name` is a versioned cache subdir (`v<major>.<minor>.<patch>`),
+/// the shape [`versioned_subdir`] produces. Used to identify prunable siblings
+/// without pulling in a regex dependency.
+#[must_use]
+pub fn is_version_dir_name(name: &str) -> bool {
+    let Some(rest) = name.strip_prefix('v') else {
+        return false;
+    };
+    let parts: Vec<&str> = rest.split('.').collect();
+    parts.len() == 3
+        && parts
+            .iter()
+            .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+}
+
+/// Outcome of [`prune_stale_version_dirs`].
+#[derive(Debug, Default, Clone)]
+pub struct PruneReport {
+    /// Version dirs successfully removed.
+    pub removed: Vec<String>,
+    /// Version dirs left in place (removal failed — most often a live daemon
+    /// on Windows holds its `zccache-daemon.exe` open; retried next prune).
+    pub skipped: Vec<String>,
+}
+
+/// Prune stale sibling `v<VERSION>` cache dirs under the top-level root,
+/// keeping the CURRENT version's dir.
+///
+/// Conservative + best-effort (issue #1005): a dir whose removal fails — the
+/// signal that a live daemon of that version still holds its
+/// `zccache-daemon.exe` open (Windows) — is **skipped**, not force-displaced,
+/// so `zccache clear` never nukes a running daemon's state and never fails.
+/// The skipped dir is reclaimed on a later prune once that daemon exits.
+pub fn prune_stale_version_dirs() -> PruneReport {
+    prune_stale_version_dirs_in(
+        resolve_cache_root_top_level().0.as_path(),
+        &versioned_subdir(),
+    )
+}
+
+/// Test seam for [`prune_stale_version_dirs`].
+pub fn prune_stale_version_dirs_in(top_level: &std::path::Path, keep: &str) -> PruneReport {
+    let mut report = PruneReport::default();
+    let entries = match std::fs::read_dir(top_level) {
+        Ok(e) => e,
+        Err(_) => return report,
+    };
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name == keep || !is_version_dir_name(&name) {
+            continue;
+        }
+        match std::fs::remove_dir_all(entry.path()) {
+            Ok(()) => report.removed.push(name),
+            Err(_) => report.skipped.push(name),
+        }
+    }
+    report
+}
+
 /// True when `ZCCACHE_COLOCATE` is set to a non-empty, non-"0" value.
 pub(super) fn colocate_enabled() -> bool {
     std::env::var(COLOCATE_ENV)
@@ -259,5 +354,69 @@ fn normalize_cache_dir_override(path: &std::path::Path) -> NormalizedPath {
             .unwrap_or_default()
             .join(path)
             .into()
+    }
+}
+
+#[cfg(test)]
+mod version_hygiene_tests {
+    use super::*;
+
+    #[test]
+    fn is_version_dir_name_accepts_semver_dirs() {
+        assert!(is_version_dir_name("v1.12.15"));
+        assert!(is_version_dir_name("v0.0.0"));
+        assert!(is_version_dir_name("v10.200.3000"));
+    }
+
+    #[test]
+    fn is_version_dir_name_rejects_non_version_dirs() {
+        assert!(!is_version_dir_name("v1.12")); // only 2 parts
+        assert!(!is_version_dir_name("v1.12.15.1")); // 4 parts
+        assert!(!is_version_dir_name("1.12.15")); // no leading v
+        assert!(!is_version_dir_name("vX.Y.Z")); // non-numeric
+        assert!(!is_version_dir_name("v1.12.")); // empty part
+        assert!(!is_version_dir_name("logs"));
+        assert!(!is_version_dir_name("runtime-binaries"));
+        assert!(!is_version_dir_name("v"));
+    }
+
+    #[test]
+    fn prune_removes_stale_siblings_keeps_current_and_non_version_dirs() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let top = tmp.path();
+        for name in ["v1.12.13", "v1.12.14", "v1.12.15", "logs", "crashes"] {
+            std::fs::create_dir_all(top.join(name)).unwrap();
+            std::fs::write(top.join(name).join("marker"), b"x").unwrap();
+        }
+        // Keep v1.12.15 (the "current" version); prune the two older siblings.
+        let report = prune_stale_version_dirs_in(top, "v1.12.15");
+
+        let mut removed = report.removed.clone();
+        removed.sort();
+        assert_eq!(removed, vec!["v1.12.13", "v1.12.14"]);
+        assert!(report.skipped.is_empty());
+
+        assert!(top.join("v1.12.15").is_dir(), "current version kept");
+        assert!(top.join("logs").is_dir(), "non-version dir kept");
+        assert!(top.join("crashes").is_dir(), "non-version dir kept");
+        assert!(!top.join("v1.12.13").exists());
+        assert!(!top.join("v1.12.14").exists());
+    }
+
+    #[test]
+    fn write_last_version_marker_writes_current_version() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let top = tmp.path().join("nested-top");
+        write_last_version_marker_in(&top).expect("marker write");
+        let contents = std::fs::read_to_string(top.join(LAST_VERSION_MARKER)).expect("read marker");
+        assert_eq!(contents.trim(), crate::VERSION);
+    }
+
+    #[test]
+    fn prune_is_noop_on_missing_top_level() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let missing = tmp.path().join("does-not-exist");
+        let report = prune_stale_version_dirs_in(&missing, "v1.12.15");
+        assert!(report.removed.is_empty() && report.skipped.is_empty());
     }
 }

--- a/crates/zccache/src/cli/commands/cache_ops.rs
+++ b/crates/zccache/src/cli/commands/cache_ops.rs
@@ -6,6 +6,26 @@ use std::process::ExitCode;
 use super::super::snapshot_fp;
 use super::util::{format_bytes, LOST_CONNECTION_MSG};
 
+/// #1005: prune stale sibling `v<VERSION>` cache dirs and print a summary.
+/// Operates on the filesystem (independent of the daemon), so it runs even
+/// when the daemon isn't reachable. Conservative: a version whose daemon still
+/// holds its files is skipped and reclaimed on a later prune.
+fn prune_and_report_stale_versions() {
+    let report = crate::core::config::prune_stale_version_dirs();
+    if !report.removed.is_empty() {
+        println!(
+            "  Stale versions:     pruned {}",
+            report.removed.join(", ")
+        );
+    }
+    if !report.skipped.is_empty() {
+        println!(
+            "  Stale versions:     skipped (in use) {}",
+            report.skipped.join(", ")
+        );
+    }
+}
+
 pub(crate) async fn cmd_clear(endpoint: &str) -> ExitCode {
     let recv_result = match crate::ipc::daemon_control_roundtrip(
         endpoint,
@@ -17,6 +37,8 @@ pub(crate) async fn cmd_clear(endpoint: &str) -> ExitCode {
         Ok(response) => response,
         Err(e) if crate::cli::client::is_daemon_unreachable_err(&e) => {
             eprintln!("daemon not running at {endpoint} — nothing to clear");
+            // #1005: still prune stale sibling version caches from disk.
+            prune_and_report_stale_versions();
             return ExitCode::SUCCESS;
         }
         Err(e) => {
@@ -42,6 +64,9 @@ pub(crate) async fn cmd_clear(endpoint: &str) -> ExitCode {
                     format_bytes(on_disk_bytes_freed)
                 );
             }
+            // #1005: prune stale sibling version caches (skips the running
+            // version and any version whose daemon still holds its files).
+            prune_and_report_stale_versions();
             ExitCode::SUCCESS
         }
         None => {

--- a/crates/zccache/src/daemon/entry.rs
+++ b/crates/zccache/src/daemon/entry.rs
@@ -396,6 +396,11 @@ fn run_server(args: Args) {
         if let Err(e) = crate::ipc::write_lock_file(pid) {
             tracing::warn!("failed to write lock file: {e}");
         }
+        // #1005: advisory top-level marker of the last version that bound.
+        // Diagnostics / warm-start hint only, never authoritative for identity.
+        if let Err(e) = crate::core::config::write_last_version_marker() {
+            tracing::debug!("failed to write last-version marker: {e}");
+        }
         if let Err(e) = crate::ipc::write_backend_identity(&server.backend_identity()) {
             tracing::warn!("failed to write running-process backend identity: {e}");
         }


### PR DESCRIPTION
## Summary

Implements the unbuilt tail of #761 (Phase 0 landed the per-version subdir; the advisory marker and pruning never did). With #999 now placing each version's daemon binary under its own `v<VERSION>/` dir, this adds the cross-version hygiene around it.

- **`write_last_version_marker()`** — the daemon writes its own `VERSION` to an advisory `<top-level>/last-version.txt` on successful bind. Diagnostics / warm-start hint only, **never authoritative** for identity (the versioned subdir is).
- **`prune_stale_version_dirs()`** — `zccache clear` now prunes stale sibling `v<MAJOR.MINOR.PATCH>` dirs, keeping the current version. **Conservative + best-effort**: a dir whose removal fails — the signal that a live daemon of that version still holds its `zccache-daemon.exe` open on Windows — is *skipped*, not force-displaced, so `clear` never nukes a running daemon's state and never fails. Skipped dirs are reclaimed on a later prune. (This is the safe reading of the Windows-locked-exe case: don't force-remove a live daemon's dir.)
- **`is_version_dir_name()`** identifies prunable siblings without a regex dependency.

Wired: marker at daemon bind (`entry.rs`); prune into `cmd_clear` (both the cleared and daemon-not-running paths). Test seams (`_in` variants) give deterministic unit tests.

## Validation

- Windows: `zccache-core` clippy clean; 5 unit tests pass (`is_version_dir_name` accept/reject, prune removes-stale/keeps-current/noop-on-missing, marker write).
- **Linux docker**: directly confirmed the daemon writes `/tmp/st/last-version.txt`=`1.12.15` at bind (cold container binds ~5 s after spawn), and `zccache clear` prunes a seeded stale `v0.0.1` sibling while keeping the current `v1.12.15`.

Closes #1005. Part of the #1007 burn-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)