### PR TITLE
feat(ipc): version-aware endpoint naming so multi-version installs stop colliding (#1004)

### DIFF
--- a/crates/zccache-ipc/src/lib.rs
+++ b/crates/zccache-ipc/src/lib.rs
@@ -470,19 +470,34 @@ pub fn lock_file_path() -> NormalizedPath {
     }
 }
 
+/// The `v<VERSION>` tag folded into every endpoint + lock name (#1004 / #694
+/// Phase 1). Without it, two installed zccache versions contend for one
+/// socket/pipe/lock and "resolve" the conflict by kill-and-replace ping-pong
+/// (the #755 lifecycle-log herds). With it, each version gets a distinct
+/// front door, so coexisting versions never fight — kill-and-replace becomes a
+/// same-version-only rare path.
+///
+/// Standalone-only: embedded hosts (soldr/fbuild) use synthetic `embedded:`
+/// endpoints and never bind IPC, so they are unaffected.
+fn version_tag() -> String {
+    zccache_core::config::versioned_subdir()
+}
+
 #[cfg(unix)]
 fn socket_name(namespace: Option<&str>) -> String {
+    let v = version_tag();
     match namespace {
-        Some(ns) => format!("sock-{ns}"),
-        None => "sock".to_string(),
+        Some(ns) => format!("sock-{ns}-{v}"),
+        None => format!("sock-{v}"),
     }
 }
 
 #[cfg(unix)]
 fn daemon_socket_name(namespace: Option<&str>) -> String {
+    let v = version_tag();
     match namespace {
-        Some(ns) => format!("daemon-{ns}.sock"),
-        None => "daemon.sock".to_string(),
+        Some(ns) => format!("daemon-{ns}-{v}.sock"),
+        None => format!("daemon-{v}.sock"),
     }
 }
 
@@ -490,16 +505,18 @@ fn daemon_socket_name(namespace: Option<&str>) -> String {
 fn pipe_name(base: &str, namespace: Option<&str>) -> String {
     let base = zccache_core::config::sanitize_ipc_component(base)
         .unwrap_or_else(|| String::from("unknown"));
+    let v = version_tag();
     match namespace {
-        Some(ns) => format!(r"\\.\pipe\zccache-{base}-{ns}"),
-        None => format!(r"\\.\pipe\zccache-{base}"),
+        Some(ns) => format!(r"\\.\pipe\zccache-{base}-{ns}-{v}"),
+        None => format!(r"\\.\pipe\zccache-{base}-{v}"),
     }
 }
 
 fn lock_file_name(namespace: Option<&str>) -> String {
+    let v = version_tag();
     match namespace {
-        Some(ns) => format!("daemon-{ns}.lock"),
-        None => "daemon.lock".to_string(),
+        Some(ns) => format!("daemon-{ns}-{v}.lock"),
+        None => format!("daemon-{v}.lock"),
     }
 }
 

--- a/crates/zccache-ipc/src/mod_tests.rs
+++ b/crates/zccache-ipc/src/mod_tests.rs
@@ -435,18 +435,25 @@ fn cache_dir_override_moves_endpoint_and_lock_file() {
     let _env = EnvGuard::set_cache_dir(&cache_dir);
 
     let endpoint = default_endpoint();
+    let v = zccache_core::config::versioned_subdir();
     #[cfg(unix)]
     assert_eq!(
         endpoint,
-        cache_dir.join("daemon.sock").to_string_lossy().into_owned()
+        cache_dir
+            .join(format!("daemon-{v}.sock"))
+            .to_string_lossy()
+            .into_owned()
     );
     #[cfg(windows)]
     {
         assert!(endpoint.starts_with(r"\\.\pipe\zccache-"));
-        assert!(endpoint.ends_with(&zccache_core::stable_path_id(&cache_dir)));
+        // #1004: endpoint now carries the version tag; the cache id is no
+        // longer the trailing component.
+        assert!(endpoint.contains(&zccache_core::stable_path_id(&cache_dir)));
+        assert!(endpoint.ends_with(&v));
     }
 
-    assert_eq!(lock_file_path(), cache_dir.join("daemon.lock"));
+    assert_eq!(lock_file_path(), cache_dir.join(format!("daemon-{v}.lock")));
 }
 
 #[test]
@@ -460,28 +467,56 @@ fn different_cache_roots_get_different_endpoints() {
 }
 
 #[test]
+fn endpoint_and_lock_carry_the_version_tag() {
+    // #1004: the version segment must appear in both the endpoint and the
+    // lock name so two installed versions never contend for one socket/pipe.
+    let root = tempfile::tempdir().unwrap();
+    let cache_dir = root.path().join("zc");
+    let _env = EnvGuard::set_cache_dir(&cache_dir);
+
+    let v = zccache_core::config::versioned_subdir();
+    assert!(
+        default_endpoint().contains(&v),
+        "endpoint {} must contain {v}",
+        default_endpoint()
+    );
+    assert!(
+        lock_file_path().to_string_lossy().contains(&v),
+        "lock path {} must contain {v}",
+        lock_file_path().display()
+    );
+    // A cache-dir-derived endpoint is versioned too.
+    assert!(endpoint_for_cache_dir(cache_dir.as_path(), None).contains(&v));
+}
+
+#[test]
 fn daemon_namespace_moves_endpoint_and_lock_file() {
     let root = tempfile::tempdir().unwrap();
     let cache_dir = root.path().join("zc");
     let _env = EnvGuard::set_cache_dir_and_namespace(&cache_dir, "soldr-dev");
 
     let endpoint = default_endpoint();
+    let v = zccache_core::config::versioned_subdir();
     #[cfg(unix)]
     assert_eq!(
         endpoint,
         cache_dir
-            .join("daemon-soldr-dev.sock")
+            .join(format!("daemon-soldr-dev-{v}.sock"))
             .to_string_lossy()
             .into_owned()
     );
     #[cfg(windows)]
     {
         assert!(endpoint.starts_with(r"\\.\pipe\zccache-"));
-        assert!(endpoint.ends_with("-soldr-dev"));
+        assert!(endpoint.contains("-soldr-dev-"));
+        assert!(endpoint.ends_with(&v));
         assert!(endpoint.contains(&zccache_core::stable_path_id(&cache_dir)));
     }
 
-    assert_eq!(lock_file_path(), cache_dir.join("daemon-soldr-dev.lock"));
+    assert_eq!(
+        lock_file_path(),
+        cache_dir.join(format!("daemon-soldr-dev-{v}.lock"))
+    );
 }
 
 #[test]
@@ -521,18 +556,20 @@ fn private_daemon_name_derives_endpoint_from_cache_root() {
     let cache_dir = root.path().join("zc");
     let endpoint = endpoint_for_private_daemon_name(Some(&cache_dir), "soldr dev");
 
+    let v = zccache_core::config::versioned_subdir();
     #[cfg(unix)]
     assert_eq!(
         endpoint,
         cache_dir
-            .join("daemon-soldr_dev.sock")
+            .join(format!("daemon-soldr_dev-{v}.sock"))
             .to_string_lossy()
             .into_owned()
     );
     #[cfg(windows)]
     {
         assert!(endpoint.starts_with(r"\\.\pipe\zccache-"));
-        assert!(endpoint.ends_with("-soldr_dev"));
+        assert!(endpoint.contains("-soldr_dev-"));
+        assert!(endpoint.ends_with(&v));
         assert!(endpoint.contains(&zccache_core::stable_path_id(&cache_dir)));
     }
 }
@@ -540,7 +577,11 @@ fn private_daemon_name_derives_endpoint_from_cache_root() {
 #[cfg(windows)]
 #[test]
 fn pipe_name_keeps_safe_username_endpoint_unchanged() {
-    assert_eq!(pipe_name("zackees", None), r"\\.\pipe\zccache-zackees");
+    let v = zccache_core::config::versioned_subdir();
+    assert_eq!(
+        pipe_name("zackees", None),
+        format!(r"\\.\pipe\zccache-zackees-{v}")
+    );
 }
 
 #[cfg(windows)]
@@ -580,7 +621,8 @@ fn cache_dir_endpoint_falls_back_to_short_unix_socket_path() {
     );
     assert!(endpoint.starts_with("/tmp/zccache-"));
     assert!(endpoint.contains(&zccache_core::stable_path_id(&cache_dir)));
-    assert!(endpoint.ends_with("-daemon-soldr-dev.sock"));
+    let v = zccache_core::config::versioned_subdir();
+    assert!(endpoint.ends_with(&format!("-daemon-soldr-dev-{v}.sock")));
 }
 
 /// On macOS, `daemon_exe_for_pid` must reject a PID whose


### PR DESCRIPTION
## Summary

Implements the never-shipped **Phase 1 of #694**. `default_endpoint()` and every sibling derivation had **no version component**, so two installed zccache versions contended for one socket/pipe/lock and "resolved" the conflict by kill-and-replace ping-pong (the #755 lifecycle-log herds). This is the core unsolved multi-version conflict — state dirs were already versioned (#761), but the front door was not.

Fold `v<VERSION>` into the leaf name helpers — `socket_name`, `daemon_socket_name`, `pipe_name`, `lock_file_name` — so every endpoint **and** lock derivation is versioned consistently. Each installed version now gets a distinct front door; coexisting versions never fight, and kill-and-replace becomes a same-version-only rare path. The endpoint and lock now **agree** on the version (also advancing #1003's endpoint/lock coherence goal).

- **No compat alias**: binding a shared unversioned alias would reintroduce the very collision we remove. The one-time transient extra daemon on the first upgrade to a versioned-endpoint build (old daemon idles out) is the accepted trade-off.
- **Embedded hosts unaffected**: soldr/fbuild use synthetic `embedded:` endpoints and never bind IPC.

## Validation

- Windows: `zccache-ipc` clippy clean; the mod_tests exact-name assertions updated to the versioned form + a new `endpoint_and_lock_carry_the_version_tag` test.
- **Linux docker**: 43 unit tests pass (incl. the cfg(unix) socket-path fallback test, corrected for the version suffix). End-to-end: `zccache start` binds `daemon-v1.12.15.sock` + writes `daemon-v1.12.15.lock`, `status` reports running, `stop` finds and stops it — versioning the front door did not break discovery. `VALIDATE-EXIT=0`.

Closes #1004. Part of the #1007 burn-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)