### PR TITLE
feat(ipc): normalized cache-identity contract for standalone daemon ownership (#1003)

### DIFF
--- a/crates/zccache-ipc/src/lib.rs
+++ b/crates/zccache-ipc/src/lib.rs
@@ -363,8 +363,8 @@ fn control_wire_mismatch_message(message: &str) -> bool {
 #[must_use]
 pub fn default_endpoint() -> String {
     let namespace = zccache_core::config::daemon_namespace();
-    if let Some(cache_dir) = zccache_core::config::cache_dir_override() {
-        return endpoint_for_cache_dir(&cache_dir, namespace.as_deref());
+    if let Some(cache_dir) = normalized_override_root() {
+        return endpoint_for_cache_dir(cache_dir.as_path(), namespace.as_deref());
     }
 
     #[cfg(unix)]
@@ -448,7 +448,7 @@ pub fn endpoint_for_private_daemon_name(
 #[must_use]
 pub fn lock_file_path() -> NormalizedPath {
     let namespace = zccache_core::config::daemon_namespace();
-    if let Some(cache_dir) = zccache_core::config::cache_dir_override() {
+    if let Some(cache_dir) = normalized_override_root() {
         return cache_dir.join(lock_file_name(namespace.as_deref()));
     }
 
@@ -549,10 +549,25 @@ pub fn remove_lock_file() {
 #[must_use]
 pub fn backend_identity_path() -> NormalizedPath {
     let namespace = zccache_core::config::daemon_namespace();
-    if let Some(cache_dir) = zccache_core::config::cache_dir_override() {
+    if let Some(cache_dir) = normalized_override_root() {
         return cache_dir.join(backend_identity_file_name(namespace.as_deref()));
     }
     zccache_core::config::default_cache_dir().join(backend_identity_file_name(namespace.as_deref()))
+}
+
+/// #1003 — the single normalized cache identity for daemon ownership.
+///
+/// When the user pins a cache dir, `--cache-dir /foo` and
+/// `--cache-dir /foo/v<version>` must resolve to the SAME daemon (same
+/// endpoint, lock, and backend identity), or a second client is rejected as a
+/// cache-dir mismatch (#770 / #771). Route the override through
+/// `effective_cache_root_from_top_level` (idempotent — it won't double-append
+/// the version) so both forms converge on one effective versioned root, and
+/// derive the endpoint, lock, and backend-identity from THAT. Returns `None`
+/// when no override is set (the default runtime/tmp/pipe location is used).
+fn normalized_override_root() -> Option<NormalizedPath> {
+    zccache_core::config::cache_dir_override()
+        .map(|top| zccache_core::config::effective_cache_root_from_top_level(&top))
 }
 
 fn backend_identity_file_name(namespace: Option<&str>) -> String {

--- a/crates/zccache-ipc/src/mod_tests.rs
+++ b/crates/zccache-ipc/src/mod_tests.rs
@@ -431,24 +431,26 @@ fn cache_dir_override_moves_endpoint_and_lock_file() {
 
     let endpoint = default_endpoint();
     let v = zccache_core::config::versioned_subdir();
+    // #1003: the override is normalized to the effective (versioned) root, so
+    // the endpoint/lock live under <cache_dir>/v<VERSION>.
+    let eff = zccache_core::config::effective_cache_root_from_top_level(&NormalizedPath::from(
+        cache_dir.clone(),
+    ));
     #[cfg(unix)]
     assert_eq!(
         endpoint,
-        cache_dir
-            .join(format!("daemon-{v}.sock"))
+        eff.join(format!("daemon-{v}.sock"))
             .to_string_lossy()
             .into_owned()
     );
     #[cfg(windows)]
     {
         assert!(endpoint.starts_with(r"\\.\pipe\zccache-"));
-        // #1004: endpoint now carries the version tag; the cache id is no
-        // longer the trailing component.
-        assert!(endpoint.contains(&zccache_core::stable_path_id(&cache_dir)));
+        assert!(endpoint.contains(&zccache_core::stable_path_id(eff.as_path())));
         assert!(endpoint.ends_with(&v));
     }
 
-    assert_eq!(lock_file_path(), cache_dir.join(format!("daemon-{v}.lock")));
+    assert_eq!(lock_file_path(), eff.join(format!("daemon-{v}.lock")));
 }
 
 #[test]
@@ -485,6 +487,32 @@ fn endpoint_and_lock_carry_the_version_tag() {
 }
 
 #[test]
+fn parent_and_versioned_cache_dir_resolve_to_the_same_identity() {
+    // #1003 / #771: `--cache-dir /foo` and `--cache-dir /foo/v<version>` must
+    // name the SAME daemon — same endpoint, lock, and backend identity — or a
+    // second client using the parent form is rejected as a cache-dir mismatch.
+    let root = tempfile::tempdir().unwrap();
+    let parent = root.path().join("foo");
+    let versioned = parent.join(zccache_core::config::versioned_subdir());
+
+    let (ep_parent, lock_parent, id_parent) = {
+        let _env = EnvGuard::set_cache_dir(&parent);
+        (default_endpoint(), lock_file_path(), backend_identity_path())
+    };
+    let (ep_versioned, lock_versioned, id_versioned) = {
+        let _env = EnvGuard::set_cache_dir(&versioned);
+        (default_endpoint(), lock_file_path(), backend_identity_path())
+    };
+
+    assert_eq!(ep_parent, ep_versioned, "endpoints must converge");
+    assert_eq!(lock_parent, lock_versioned, "lock paths must converge");
+    assert_eq!(
+        id_parent, id_versioned,
+        "backend identity paths must converge"
+    );
+}
+
+#[test]
 fn daemon_namespace_moves_endpoint_and_lock_file() {
     let root = tempfile::tempdir().unwrap();
     let cache_dir = root.path().join("zc");
@@ -492,11 +520,13 @@ fn daemon_namespace_moves_endpoint_and_lock_file() {
 
     let endpoint = default_endpoint();
     let v = zccache_core::config::versioned_subdir();
+    let eff = zccache_core::config::effective_cache_root_from_top_level(&NormalizedPath::from(
+        cache_dir.clone(),
+    ));
     #[cfg(unix)]
     assert_eq!(
         endpoint,
-        cache_dir
-            .join(format!("daemon-soldr-dev-{v}.sock"))
+        eff.join(format!("daemon-soldr-dev-{v}.sock"))
             .to_string_lossy()
             .into_owned()
     );
@@ -505,12 +535,12 @@ fn daemon_namespace_moves_endpoint_and_lock_file() {
         assert!(endpoint.starts_with(r"\\.\pipe\zccache-"));
         assert!(endpoint.contains("-soldr-dev-"));
         assert!(endpoint.ends_with(&v));
-        assert!(endpoint.contains(&zccache_core::stable_path_id(&cache_dir)));
+        assert!(endpoint.contains(&zccache_core::stable_path_id(eff.as_path())));
     }
 
     assert_eq!(
         lock_file_path(),
-        cache_dir.join(format!("daemon-soldr-dev-{v}.lock"))
+        eff.join(format!("daemon-soldr-dev-{v}.lock"))
     );
 }
 


### PR DESCRIPTION
## Summary

Revives #771. A private daemon started with `--cache-dir /foo` (serving from `/foo/v<version>`) was rejected when a second client reconnected with the same `--cache-dir /foo`, because the endpoint/lock/backend-identity derivations keyed off the **raw requested root** while the daemon's state used the **effective versioned root** — `/foo` and `/foo/v<version>` resolved to *different* endpoints.

**Fix**: `normalized_override_root()` routes `cache_dir_override` through `effective_cache_root_from_top_level` (idempotent — it won't double-append the version) in `default_endpoint`, `lock_file_path`, and `backend_identity_path`. Both `--cache-dir /foo` and `--cache-dir /foo/v<version>` now converge on one effective versioned root, so the endpoint, lock, backend identity, and daemon state are all coherent under `/foo/v<version>`. (Session-join rejoin was already handled by #770.)

This completes the endpoint/lock/identity coherence that #1004 began: #1004 versioned the *names*; #1003 normalizes the *root* the override resolves to.

## Validation

- Windows: 48 ipc unit tests pass — including the new `parent_and_versioned_cache_dir_resolve_to_the_same_identity`, which asserts the endpoint, lock, and backend-identity paths are byte-identical for the two `--cache-dir` forms. Clippy clean.
- **Linux docker**: 44 unit tests pass; end-to-end, a daemon started with the parent `--cache-dir` form is reached by a client using the versioned form (same normalized identity). *(Note: an intermittent pre-existing `status`-path abort — unrelated to this path-string change, confirmed by 4/4 successful parent-form status calls against a stable daemon — is retried in the harness.)*

Closes #1003 and #771. Part of the #1007 burn-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)