### PR TITLE
test+docs: standalone daemon identity/lifecycle hardening + architecture doc (#1006)

### DIFF
--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -1,6 +1,9 @@
 # Crates Architecture
 
-21 crates split into two product surfaces: the **compile cache** (`zccache-daemon` + `zccache-cli`, plus their library subsystems) and a separate **download cache** (`zccache-download-daemon` + `zccache-download-cli`, plus their library subsystems). A few utility binaries (`zccache-fp`, `zccache-stamp`) and one CI lib (`zccache-ci`) round out the workspace.
+21 crates split into two product surfaces: the **compile cache** and a separate **download cache**, plus utility binaries (`zccache-fp`, `zccache-stamp`) and one CI lib (`zccache-ci`).
+
+> [!NOTE]
+> **Binary layout (post-consolidation, #997–#999).** The compile-cache binaries all live as `[[bin]]` targets in the single `crates/zccache` crate — `zccache` (CLI), `zccache-daemon` (the standalone daemon; its `main` is the library `daemon::entry`), and `zccache-fp`. As of #998 the `zccache` binary is a **multi-call binary**: it dispatches on `argv[0]` and runs the daemon when invoked as `zccache-daemon`, so the CLI **self-deploys** the daemon by copying itself to `~/.zccache/v<VERSION>/zccache-daemon` (#999) rather than shipping a separate daemon executable. `crates/zccache-cli` is **not** the CLI — it is the PyO3 `cdylib` hosting `zccache._native`. See [docs/architecture/runtime.md § Standalone daemon identity, deployment & lifecycle](../docs/architecture/runtime.md#standalone-daemon-identity-deployment--lifecycle).
 
 ## Dependency Graph
 

--- a/crates/zccache/src/cli/mod.rs
+++ b/crates/zccache/src/cli/mod.rs
@@ -526,6 +526,39 @@ mod tests {
         );
     }
 
+    #[test]
+    fn concurrent_materialize_converges_on_one_daemon_binary() {
+        // #1006 adversarial: N threads racing to deploy the daemon (the
+        // thundering-herd first-invocation case) must converge on exactly one
+        // dest file, atomically (never a torn exe), with no leftover temps.
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("zccache");
+        std::fs::write(&src, vec![0xABu8; 4096]).expect("write source");
+        let dest = std::sync::Arc::new(tmp.path().join("v1.2.3").join("zccache-daemon"));
+        let src = std::sync::Arc::new(src);
+
+        let mut handles = Vec::new();
+        for _ in 0..16 {
+            let (src, dest) = (std::sync::Arc::clone(&src), std::sync::Arc::clone(&dest));
+            handles.push(std::thread::spawn(move || {
+                materialize_daemon_exe_to(&src, &dest).map(|p| std::fs::read(p).unwrap())
+            }));
+        }
+        for h in handles {
+            let bytes = h.join().expect("thread panicked").expect("materialize ok");
+            assert_eq!(bytes.len(), 4096, "every racer sees a complete (non-torn) exe");
+            assert_eq!(bytes, vec![0xABu8; 4096]);
+        }
+        // Exactly the dest survives — no `.tmp.` leftovers from the losers.
+        let leftovers: Vec<_> = std::fs::read_dir(dest.parent().unwrap())
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp."))
+            .collect();
+        assert!(leftovers.is_empty(), "no temp files left: {leftovers:?}");
+    }
+
     /// Issue #159: `session_end_idempotent` is the shared library entry
     /// point for ending a session — used by the CLI `session-end` command
     /// AND by tools like soldr that call into the library directly. When

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,6 +31,7 @@ This document is the index for zccache's architecture specification. Each subsys
 - **Async/process bridge — watchdogs, cancellation & timeouts (deadlock hardening)** → [runtime.md § Async / process bridge](architecture/runtime.md#async--process-bridge-watchdogs-cancellation--timeouts)
 - **Where zccache writes on disk (`ZCCACHE_CACHE_DIR` contract)** → [runtime.md § Cache root invariants](architecture/runtime.md#cache-root-invariants)
 - **Host no-spawn guard (`ZCCACHE_NO_SPAWN`, embedding hosts)** → [runtime.md § Host no-spawn guard](architecture/runtime.md#host-no-spawn-guard-zccache_no_spawn)
+- **Standalone daemon identity, deployment & lifecycle (argv[0] single binary, version-rooted deploy, versioned endpoints)** → [runtime.md § Standalone daemon identity, deployment & lifecycle](architecture/runtime.md#standalone-daemon-identity-deployment--lifecycle)
 - **Windows/macOS/Linux differences** → [portability.md](architecture/portability.md)
 - **Compile journal fields & `miss_reason` enum** → [journal-schema.md](journal-schema.md)
 

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -132,6 +132,103 @@ daemon stderr is redirected. A silent timeout is forbidden.
 
 ---
 
+## Standalone daemon identity, deployment & lifecycle
+
+This section is the single source of truth for how a **standalone** zccache
+daemon is named, deployed, discovered, and torn down. It is the end state of
+the #1007 burn-down (#997–#1005). **Embedded mode is out of scope**: soldr and
+fbuild run the daemon in-process via `ZccacheService` on synthetic `embedded:`
+endpoints, never bind IPC, and are fenced off from standalone spawning by
+`ZCCACHE_NO_SPAWN` (#982/#987). Everything below applies only when the `zccache`
+CLI lazily spawns a real per-user daemon.
+
+### One binary, dispatched by `argv[0]` (#998)
+
+Only the `zccache` CLI is deployed. It is a **multi-call binary**: it reads its
+own `argv[0]` file stem and, if invoked as `zccache-daemon`, runs the daemon
+(`daemon::entry::run`); any other or empty name falls through to the CLI. The
+daemon `main` lives in the library (`daemon::entry`, #997) so both the CLI and
+the transitional `zccache-daemon` bin can host it. A hidden
+`zccache daemon-run <flags…>` subcommand is the `argv[0]`-independent escape
+hatch (debugging, `noexec` cache dirs, unreliable `argv[0]`). The name check is
+`cli::multicall::stem_matches`: Windows is case-insensitive and drops `.exe`;
+Unix is exact; a teardown orphan `zccache-daemon.old.<rand>.exe` does **not**
+dispatch as the daemon (`file_stem` strips only the final extension).
+
+### Version-rooted self-materialization (#999, fixes #760)
+
+When the daemon is needed, the CLI **copies itself** (`current_exe()`) to a
+stable, version-rooted path using the daemon's own name:
+
+```
+~/.zccache/v<VERSION>/zccache-daemon[.exe]
+```
+
+`materialize_daemon_exe` is **idempotent** (an existing dest whose size matches
+the source is reused — N concurrent same-version CLIs converge on one file, no
+repeated multi-MB copies) and **atomic** (temp-in-same-dir + `rename`; a
+concurrent winner is tolerated). Because each installed version owns its own
+`v<VERSION>/` directory, a stale copy can never masquerade as a newer one — the
+structural fix for the #760 "soft-shadow" downgrade the old random-name
+`runtime-binaries/` copies allowed. The own-name `zccache-daemon` satisfies
+`verify_pid_exe_stem(pid, "zccache-daemon")`.
+
+**Windows locked-exe teardown.** Windows locks a running executable's file, so
+`rm -rf` of a version dir (during `zccache clear`, a stale-sibling prune, or an
+upgrade) cannot delete a live daemon's `zccache-daemon.exe` — but it *can*
+rename it. `trampoline::unlock_exe` renames the locked exe to
+`zccache-daemon.old.<rand>.exe` to free the path; the orphan is swept once the
+daemon exits. The hash/random suffix is a **teardown displacement device only**,
+never the daemon's deployed identity.
+
+### Version-aware endpoint, lock & identity (#1004, #1003)
+
+Every front-door name carries the version tag (`v<VERSION>`), folded into the
+leaf helpers `socket_name` / `daemon_socket_name` / `pipe_name` /
+`lock_file_name`. Two installed versions therefore get **distinct** endpoints,
+locks, and backend-identity files and never contend — kill-and-replace becomes a
+same-version-only rare path (previously the #755 lifecycle-log herds). There is
+**no** unversioned compat alias: binding a shared alias would reintroduce the
+collision; the one-time transient extra daemon on the first upgrade (old daemon
+idles out) is the accepted trade-off.
+
+When a cache dir is pinned (`ZCCACHE_CACHE_DIR` / `--cache-dir`), the override is
+normalized through `effective_cache_root_from_top_level` (`normalized_override_root`,
+#1003) before the endpoint/lock/backend-identity are derived, so `--cache-dir
+/foo` and `--cache-dir /foo/v<version>` resolve to the **same** daemon — the
+endpoint, lock, backend identity, and daemon state all live coherently under
+`/foo/v<version>`.
+
+### Conflict prevention & the retired broker (#1002)
+
+Standalone conflict prevention is the version-aware endpoint scheme above, not a
+control-plane broker. The opt-in `ZCCACHE_BROKER_CONNECT` broker-negotiation
+connect lane was **retired** (#1002) — it was never enabled in production. The
+daemon still **publishes** its manifest + BackendHandle identity for discovery
+tooling; only the client-side broker *connect* path is gone. Clients use the
+direct connect.
+
+### Version-namespace hygiene (#1005)
+
+The daemon writes an advisory `<top-level>/last-version.txt` on bind
+(diagnostics / warm-start hint, never authoritative). `zccache clear` prunes
+stale sibling `v<MAJOR.MINOR.PATCH>` dirs, **skipping** the current version and
+any version whose daemon still holds its files (a live-daemon dir's removal
+fails on Windows and is retried next prune — `clear` never nukes a running
+daemon's state).
+
+### Spawn single-flight & takeover
+
+Discovery + spawn preserve the existing thundering-herd protections: the #952
+`.spawn` slot (materialization runs inside it — one arbiter copies + spawns,
+losers park on the ready-wait), the #640/#641 pre-bind probe, the #639 bind-race
+loser-defer, the #132 recycled-PID `verify_pid_exe_stem` defense, and the
+#666/#726 wedge single-payer. `ensure_daemon` kills+replaces only a
+same-version *stale* daemon (`DaemonOlder`). All spawn/park/takeover decisions
+land as JSONL lifecycle events (#755) for post-mortem correlation.
+
+---
+
 ## Correctness Model
 
 ### Layered Invalidation


### PR DESCRIPTION
## Summary

Capstone of the #1007 burn-down.

- **Adversarial concurrency test**: 16 threads racing `materialize_daemon_exe_to` (the thundering-herd first-invocation case) converge on exactly one dest file, atomically — every racer reads a complete 4096-byte exe (never torn), with no `.tmp.` leftovers.
- **New architecture section** `Standalone daemon identity, deployment & lifecycle` in `docs/architecture/runtime.md` — the single source of truth for the end state: argv[0] multi-call dispatch (#998), version-rooted self-materialization + Windows unlock teardown (#999, fixes #760), version-aware endpoint/lock/identity (#1004) + override normalization (#1003), retired broker + direct connect (#1002), version-namespace hygiene (#1005), spawn single-flight / takeover, and the embedded-vs-standalone boundary (`ZCCACHE_NO_SPAWN`). Plus an `ARCHITECTURE.md` breadcrumb.
- **Fixed the stale `crates/CLAUDE.md`** binary layout: the daemon is a `[[bin]]` in `crates/zccache` (main in `daemon::entry`, argv[0]-dispatched + self-deployed), not a separate crate; `zccache-cli` is the PyO3 cdylib.

## Validation

Windows: clippy clean, concurrent-materialize + materialize tests pass. **Linux docker**: same tests green, `VALIDATE-EXIT=0`.

Closes #1006. Completes the #1007 burn-down (modulo #1000, deferred — see the meta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)