### PR TITLE
build: collapse the 3x zccache lib rebuild in release builds (#1017 Lever 1)

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -185,16 +185,18 @@ runs:
         if [[ "${{ inputs.target }}" == *pc-windows-msvc ]]; then
           export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=+crt-static"
         fi
-        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache --features zccache-bin --bin zccache
-        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache --features daemon-bin --bin zccache-daemon
-        # zccache-fp is a bin shipped *inside* the umbrella `zccache` crate
-        # (see crates/zccache/Cargo.toml `[[bin]] name = "zccache-fp"`). The
-        # sibling `zccache-fingerprint` crate is a pyo3 cdylib for the Python
-        # extension and produces no native executable. The staging step below
-        # then `cp`s `target/.../zccache-fp` into `staging/`, which is why
-        # building the wrong target left it complaining `cannot stat
-        # 'target/.../zccache-fp': No such file or directory`.
-        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache --features fingerprint-bin --bin zccache-fp
+        # #1017 Lever 1: build all three shipped binaries in ONE cargo
+        # invocation with unified features. Building them separately (one
+        # invocation per feature set) re-resolved features and recompiled the
+        # whole `zccache` lib THREE times per platform. One invocation compiles
+        # the lib once and links the three bins — matching perf-rust-cluster.yml.
+        # zccache-fp is a bin shipped *inside* the umbrella `zccache` crate (the
+        # sibling `zccache-fingerprint` crate is a pyo3 cdylib and produces no
+        # native executable); the staging step below `cp`s `target/.../zccache-fp`
+        # into `staging/`.
+        "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache \
+          --features zccache-bin,daemon-bin,fingerprint-bin \
+          --bin zccache --bin zccache-daemon --bin zccache-fp
 
     # Windows DLL load smoke gate (see zccache#269). If the just-built
     # `zccache.exe` cannot complete loader init on this host, `--version`


### PR DESCRIPTION
## Summary

`build-target/action.yml` built the three shipped binaries (`zccache`, `zccache-daemon`, `zccache-fp`) as **three separate cargo invocations with three different feature sets** (`zccache-bin` / `daemon-bin` / `fingerprint-bin`). Because the features differ per invocation, cargo re-resolves features and **recompiles the whole `zccache` lib three times** per platform, per release (worst under `--release` LTO).

Collapse them into **one** invocation with unified features — the lib compiles once and the three bins link off it, matching what `perf-rust-cluster.yml` already does. The downstream strip/stamp/debug-sidecar/package steps are unchanged (same three artifacts).

## Validation

- YAML parses.
- **Linux docker** (forced-cold): the combined invocation compiles the `zccache` lib **exactly once** (vs 3×) and emits all three binaries; `zccache` runs. `VALIDATE-EXIT=0`.

Refs #1017 (Lever 1). Lever 2 (argv[0] fold-and-drop of `zccache-daemon` / `zccache-fp`) stays bundled with the deferred #1000. The incremental-recompile sub-issue #1018 (daemon crate split) is merged (PR #1019).

🤖 Generated with [Claude Code](https://claude.com/claude-code)