### PR TITLE
fix(rustc): close the env-dep cache-key soundness gap (#1021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,9 +380,23 @@ ZCCACHE_CACHE_DIR = { value = "/tmp/.zccache", force = false }
 ```
 
 Supports `--emit=metadata` (`cargo check`), `--emit=dep-info,metadata,link` (`cargo build`),
-extern crate content hashing, and cacheable crate types such as `lib`, `rlib`,
-and `staticlib`. Proc-macro and binary crates are passed through without caching,
-matching the usual `sccache` behavior.
+extern crate content hashing, and env-var dependency tracking: the `# env-dep:`
+names rustc records in dep-info (every `env!()` / `option_env!()` read, including
+build-script `cargo:rustc-env=` values like vergen's `GIT_SHA`) are folded into
+hit validation, so a changed value forces a recompile instead of serving a stale
+artifact.
+
+**Cacheable crate types**: `lib`, `rlib`, `staticlib`, `proc-macro`, and `bin`.
+`dylib` / `cdylib` invocations are deliberately passed through without caching —
+final shared-library artifacts (e.g. PyO3/maturin `cdylib` targets) recompile
+every time, while their rlib dependencies still hit.
+
+**Known blind spot (sccache parity)**: native libraries linked via `-L`/`-l`
+into `bin`/`staticlib` units are not content-hashed into the cache key — a
+system-upgraded `libssl.so` with an otherwise-identical invocation can serve a
+stale binary. This matches sccache's behavior; hashing `-L`-resolved libraries
+on every link was judged not worth the syscall cost. Run `zccache clear` after
+system-library upgrades if this matters to your workflow.
 
 Useful Rust workflow commands:
 

--- a/crates/zccache-cli-core/src/cli/commands/cache_ops.rs
+++ b/crates/zccache-cli-core/src/cli/commands/cache_ops.rs
@@ -13,10 +13,7 @@ use super::util::{format_bytes, LOST_CONNECTION_MSG};
 fn prune_and_report_stale_versions() {
     let report = crate::core::config::prune_stale_version_dirs();
     if !report.removed.is_empty() {
-        println!(
-            "  Stale versions:     pruned {}",
-            report.removed.join(", ")
-        );
+        println!("  Stale versions:     pruned {}", report.removed.join(", "));
     }
     if !report.skipped.is_empty() {
         println!(

--- a/crates/zccache-cli-core/src/cli/commands/exec.rs
+++ b/crates/zccache-cli-core/src/cli/commands/exec.rs
@@ -341,7 +341,10 @@ mod tests {
         // Trailing newline / blank lines must not inject empty entries, and a
         // leading '#' is a real path segment, not a comment.
         assert!(parse_input_path_lines("\n\n   \n").is_empty());
-        assert_eq!(parse_input_path_lines("#notacomment.h\n"), vec!["#notacomment.h"]);
+        assert_eq!(
+            parse_input_path_lines("#notacomment.h\n"),
+            vec!["#notacomment.h"]
+        );
     }
 
     #[test]

--- a/crates/zccache-cli-core/src/cli/mod.rs
+++ b/crates/zccache-cli-core/src/cli/mod.rs
@@ -93,8 +93,8 @@ pub(crate) fn link_retry_budget() -> u32 {
 // gc_daemon_spawn_logs is deprecated but still re-exported for the public API.
 pub use runtime::{
     connect_client, deployed_daemon_path, ensure_daemon, gc_daemon_spawn_logs, gc_log_directory,
-    gc_log_directory_in, materialize_daemon_exe, materialize_daemon_exe_to, run_async, spawn_daemon,
-    wait_for_daemon_ready,
+    gc_log_directory_in, materialize_daemon_exe, materialize_daemon_exe_to, run_async,
+    spawn_daemon, wait_for_daemon_ready,
 };
 
 pub use crate::download_client::{
@@ -546,7 +546,11 @@ mod tests {
         }
         for h in handles {
             let bytes = h.join().expect("thread panicked").expect("materialize ok");
-            assert_eq!(bytes.len(), 4096, "every racer sees a complete (non-torn) exe");
+            assert_eq!(
+                bytes.len(),
+                4096,
+                "every racer sees a complete (non-torn) exe"
+            );
             assert_eq!(bytes, vec![0xABu8; 4096]);
         }
         // Exactly the dest survives — no `.tmp.` leftovers from the losers.

--- a/crates/zccache-compiler/src/parse_rustc.rs
+++ b/crates/zccache-compiler/src/parse_rustc.rs
@@ -212,10 +212,16 @@ pub(crate) fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedI
         }
     };
 
-    // Note: -C incremental is ignored for caching purposes.
-    // The incremental dir is excluded from the cache key, and we let rustc
-    // use it on a miss (doesn't affect output determinism for rlib/rmeta).
-    // sccache also allows incremental — cargo always passes it.
+    // Note: -C incremental is ignored for caching purposes (issue #1021).
+    // zccache's position: the incremental dir is excluded from the cache key,
+    // and rustc may still use it on a miss. sccache takes the OPPOSITE
+    // position — it refuses to cache incremental compiles and the standard
+    // guidance there is CARGO_INCREMENTAL=0. Caveat we accept: incremental
+    // can change CGU partitioning and therefore internal symbol names in the
+    // artifact, so two byte-different artifacts can be "the same compile";
+    // artifacts are still correct for linking, and content-addressed lookup
+    // means we only ever serve bytes produced by a real compile of the same
+    // keyed inputs.
 
     // Default crate type is bin if not specified
     if crate_types.is_empty() {

--- a/crates/zccache-core/src/config/mod.rs
+++ b/crates/zccache-core/src/config/mod.rs
@@ -102,10 +102,11 @@ pub use paths::{
     tmp_dir, tmp_dir_from_cache_dir,
 };
 pub use resolve::{
-    cache_dir_override, default_cache_dir, effective_cache_root_from_top_level, is_version_dir_name,
-    prune_stale_version_dirs, prune_stale_version_dirs_in, read_last_version_marker,
-    resolve_cache_root, resolve_cache_root_top_level, versioned_subdir, write_last_version_marker,
-    write_last_version_marker_in, CacheRootSource, PruneReport, LAST_VERSION_MARKER,
+    cache_dir_override, default_cache_dir, effective_cache_root_from_top_level,
+    is_version_dir_name, prune_stale_version_dirs, prune_stale_version_dirs_in,
+    read_last_version_marker, resolve_cache_root, resolve_cache_root_top_level, versioned_subdir,
+    write_last_version_marker, write_last_version_marker_in, CacheRootSource, PruneReport,
+    LAST_VERSION_MARKER,
 };
 
 /// Top-level configuration for zccache.

--- a/crates/zccache-daemon-core/src/daemon/entry.rs
+++ b/crates/zccache-daemon-core/src/daemon/entry.rs
@@ -337,10 +337,9 @@ fn run_server(args: Args) {
 
         // ── Issue #637/#639: discriminate loser-of-race from real bind failure ──
         let bind_endpoint = endpoint.clone();
-        let bind_result = tokio::task::spawn_blocking(move || {
-            crate::daemon::DaemonServer::bind(&bind_endpoint)
-        })
-        .await;
+        let bind_result =
+            tokio::task::spawn_blocking(move || crate::daemon::DaemonServer::bind(&bind_endpoint))
+                .await;
         let server = match bind_result {
             Ok(Ok(s)) => s,
             Ok(Err(e)) => {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/error_cache.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/error_cache.rs
@@ -41,6 +41,7 @@ pub(super) fn maybe_store_rustc_error_artifact(
     cwd_path: &NormalizedPath,
     ctx: &CompileContext,
     rustc_args: &crate::depgraph::RustcParsedArgs,
+    client_env: Option<&[(String, String)]>,
     stdout: &Arc<Vec<u8>>,
     stderr: &Arc<Vec<u8>>,
     exit_code: i32,
@@ -50,7 +51,8 @@ pub(super) fn maybe_store_rustc_error_artifact(
         return None;
     }
 
-    let scan_result = scan_rustc_deps(rustc_args, source_path, cwd_path);
+    let dep_scan = scan_rustc_deps(rustc_args, source_path, cwd_path);
+    let scan_result = dep_scan.scan;
     let tracked_paths: Vec<NormalizedPath> = std::iter::once(source_path.clone())
         .chain(scan_result.resolved.iter().cloned())
         .chain(ctx.force_includes.iter().cloned())
@@ -73,6 +75,13 @@ pub(super) fn maybe_store_rustc_error_artifact(
         .dep_graph
         .load()
         .update(context_key, scan_result, get_hash)?;
+    // Record env-dep names AFTER update so a concurrent reader in the window
+    // sees the old fingerprint and safely recompiles (issue #1021).
+    let env_dep_fp = crate::depgraph::env_dep_fingerprint(&dep_scan.env_deps, client_env);
+    state
+        .dep_graph
+        .load()
+        .record_env_deps(context_key, dep_scan.env_deps, env_dep_fp);
     let artifact_key_hex = artifact_key.hash().to_hex();
     let meta = ArtifactIndex::new(
         Vec::new(),

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
@@ -49,6 +49,16 @@ pub(super) fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Option<R
     if !request_cache_entry_matches_root(&req_entry, request_cache_key_root.as_ref()) {
         return None;
     }
+    // Issue #1021: the request fingerprint only covers CARGO_* env, so a
+    // changed `# env-dep:` value (vergen-style rustc-env) is invisible to
+    // this zero-hash path. Gate on the context's recorded env-dep values.
+    if !state
+        .dep_graph
+        .load()
+        .env_deps_match(&req_entry.context_key, client_env)
+    {
+        return None;
+    }
     let fh_entry = state.fast_hit_cache.get(&req_entry.context_key)?;
     let artifact_key_hex = &fh_entry.artifact_key_hex;
     let source_path = req_entry
@@ -191,6 +201,15 @@ pub(super) async fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
     };
     if !cache_entry_fresh_at(compile_start, entry_cached_at, FAST_HIT_MAX_AGE)
         || !context_files_fresh(state, &context_key, source_path, entry_clock)
+    {
+        return None;
+    }
+    // Issue #1021: the context key only covers CARGO_* env, so a changed
+    // `# env-dep:` value is invisible to this zero-hash path too.
+    if !state
+        .dep_graph
+        .load()
+        .env_deps_match(&context_key, client_env)
     {
         return None;
     }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/hash_verify.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/hash_verify.rs
@@ -28,6 +28,9 @@ pub(super) struct HashVerifyInput<'a> {
     pub(super) source_path: &'a NormalizedPath,
     pub(super) ctx: &'a CompileContext,
     pub(super) rustc_extern_paths: &'a [NormalizedPath],
+    /// Current request env — gated against the context's recorded env-dep
+    /// values before any hit verdict (issue #1021).
+    pub(super) client_env: Option<&'a [(String, String)]>,
     pub(super) snap_clock: Clock,
 }
 
@@ -45,6 +48,7 @@ pub(super) fn hash_and_verify(input: HashVerifyInput<'_>) -> HashSourceOutcome {
         source_path,
         ctx,
         rustc_extern_paths,
+        client_env,
         snap_clock,
     } = input;
 
@@ -52,6 +56,27 @@ pub(super) fn hash_and_verify(input: HashVerifyInput<'_>) -> HashSourceOutcome {
     // return Cold without examining any hashes, so the work is wasted.
     // Jump straight to compiler exec.
     let context_is_cold = state.dep_graph.load().is_cold(&context_key);
+
+    // Issue #1021: env-dep gate. When the context's recorded `# env-dep:`
+    // values (e.g. vergen's `cargo:rustc-env=GIT_SHA`) don't match the
+    // current request env, every stored artifact for this context embeds
+    // stale values — skip hashing and force a recompile, which re-records
+    // the names and fingerprint.
+    if !context_is_cold
+        && !state
+            .dep_graph
+            .load()
+            .env_deps_match(&context_key, client_env)
+    {
+        return HashSourceOutcome::Ready(HashVerifyOutcome {
+            hash_map: HashMap::new(),
+            hash_source_ns: 0,
+            hash_headers_ns: 0,
+            depgraph_check_ns: 0,
+            verdict: crate::depgraph::CacheVerdict::Cold,
+            diag_reason: "env_deps_changed".to_string(),
+        });
+    }
 
     // ── Phase: hash source ───────────────────────────────────────────
     // Issue #468: env-gated sub-phase trace. When ZCCACHE_HIT_TRACE=1, the

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -410,6 +410,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         source_path: &source_path,
         ctx: &ctx,
         rustc_extern_paths: &rustc_extern_paths,
+        client_env: client_env.as_deref(),
         snap_clock,
     }) {
         HashSourceOutcome::Ready(outcome) => outcome,
@@ -625,7 +626,18 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                         compat_reason,
                     ),
                 );
-                if let crate::depgraph::CacheVerdict::Hit { artifact_key } = compat_verdict {
+                // Issue #1021: the compat candidate's artifact embeds the env
+                // values of the compile that stored it — gate on them before
+                // serving it under this check-style request.
+                let compat_env_ok = actual_context_key.as_ref().is_none_or(|key| {
+                    state
+                        .dep_graph
+                        .load()
+                        .env_deps_match(key, client_env.as_deref())
+                });
+                if let (crate::depgraph::CacheVerdict::Hit { artifact_key }, true) =
+                    (compat_verdict, compat_env_ok)
+                {
                     let artifact_key_hex = artifact_key.hash().to_hex();
                     pending_writes::await_pending(
                         &state.pending_cache_writes,
@@ -753,6 +765,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 &cwd_path,
                 &ctx,
                 rustc_args,
+                client_env.as_deref(),
                 &stdout,
                 &stderr,
                 exit_code,
@@ -784,6 +797,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             compilation: &compilation,
             rustc_args_opt: rustc_args_opt.as_deref(),
             rustc_extern_paths: &rustc_extern_paths,
+            client_env: client_env.as_deref(),
             is_rustc,
             rust_profile_enabled,
             rust_profile_mode,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -23,6 +23,9 @@ pub(super) struct StoreOutcomeRequest<'a> {
     pub(super) compilation: &'a crate::compiler::CacheableCompilation,
     pub(super) rustc_args_opt: Option<&'a crate::depgraph::RustcParsedArgs>,
     pub(super) rustc_extern_paths: &'a [NormalizedPath],
+    /// Client env of this request — env-dep values are fingerprinted from it
+    /// after the dep-info scan (issue #1021).
+    pub(super) client_env: Option<&'a [(String, String)]>,
     pub(super) is_rustc: bool,
     pub(super) rust_profile_enabled: bool,
     pub(super) rust_profile_mode: &'a str,
@@ -106,6 +109,9 @@ struct CompileScanRequest {
 
 struct CompileScanCollection {
     scan_result: crate::depgraph::ScanResult,
+    /// Env-var names from rustc dep-info `# env-dep:` lines (issue #1021).
+    /// Always empty for C/C++.
+    rustc_env_deps: Vec<String>,
     user_depfile_capture: Option<(NormalizedPath, Vec<u8>)>,
     depfile_parse_warning: Option<String>,
 }
@@ -119,6 +125,7 @@ async fn collect_compile_scan_blocking(req: CompileScanRequest) -> CompileScanCo
                 unresolved: vec![format!("compile dependency scan worker failed: {e}")],
                 has_computed: false,
             },
+            rustc_env_deps: Vec::new(),
             user_depfile_capture: None,
             depfile_parse_warning: None,
         })
@@ -136,16 +143,27 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
     } = req;
 
     if is_rustc {
-        let scan_result = rustc_args.as_ref().map_or_else(
-            || crate::depgraph::ScanResult {
-                resolved: Vec::new(),
-                unresolved: vec!["missing parsed rustc args for rustc dependency scan".into()],
-                has_computed: false,
+        let (scan_result, rustc_env_deps) = rustc_args.as_ref().map_or_else(
+            || {
+                (
+                    crate::depgraph::ScanResult {
+                        resolved: Vec::new(),
+                        unresolved: vec![
+                            "missing parsed rustc args for rustc dependency scan".into()
+                        ],
+                        has_computed: false,
+                    },
+                    Vec::new(),
+                )
             },
-            |args| scan_rustc_deps(args, &source_path, &cwd_path),
+            |args| {
+                let dep_scan = scan_rustc_deps(args, &source_path, &cwd_path);
+                (dep_scan.scan, dep_scan.env_deps)
+            },
         );
         return CompileScanCollection {
             scan_result,
+            rustc_env_deps,
             user_depfile_capture: None,
             depfile_parse_warning: None,
         };
@@ -153,6 +171,7 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
 
     let mut user_depfile_capture = None;
     let mut depfile_parse_warning = None;
+    let rustc_env_deps = Vec::new();
     let scan_result = match &depfile_strategy {
         DepfileStrategy::Injected { path }
         | DepfileStrategy::UserSpecified { path }
@@ -192,6 +211,7 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
 
     CompileScanCollection {
         scan_result,
+        rustc_env_deps,
         user_depfile_capture,
         depfile_parse_warning,
     }
@@ -214,6 +234,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         compilation,
         rustc_args_opt,
         rustc_extern_paths,
+        client_env,
         is_rustc,
         rust_profile_enabled,
         rust_profile_mode,
@@ -322,6 +343,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
     };
     let CompileScanCollection {
         scan_result,
+        rustc_env_deps,
         user_depfile_capture,
         ..
     } = scan_collection;
@@ -484,6 +506,18 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
             compile_start,
         })
     });
+
+    // Record env-dep names + value fingerprint AFTER the depgraph update
+    // inside `store_miss_artifact`: a concurrent reader in the window sees
+    // the old fingerprint and fails the gate toward a safe recompile rather
+    // than a stale hit (issue #1021).
+    if is_rustc {
+        let env_dep_fp = crate::depgraph::env_dep_fingerprint(&rustc_env_deps, client_env);
+        state
+            .dep_graph
+            .load()
+            .record_env_deps(context_key, rustc_env_deps, env_dep_fp);
+    }
 
     // Record miss phase profile
     let total_ns = compile_start.elapsed().as_nanos() as u64;

--- a/crates/zccache-daemon-core/src/daemon/server/rustc.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/rustc.rs
@@ -168,48 +168,52 @@ pub(super) async fn build_rustc_compile_context_async(
     }
 }
 
+/// Result of scanning rustc dep-info: file deps plus env-var deps.
+pub(super) struct RustcDepScan {
+    /// File dependencies (feeds `DepGraph::update`, same as before).
+    pub(super) scan: crate::depgraph::ScanResult,
+    /// Env-var names from `# env-dep:` lines — sorted, deduplicated, with
+    /// volatile path-valued names filtered out (issue #1021).
+    pub(super) env_deps: Vec<String>,
+}
+
+impl RustcDepScan {
+    fn empty() -> Self {
+        Self {
+            scan: crate::depgraph::ScanResult {
+                resolved: Vec::new(),
+                unresolved: Vec::new(),
+                has_computed: false,
+            },
+            env_deps: Vec::new(),
+        }
+    }
+}
+
 /// Scan rustc dependencies after compilation.
 ///
 /// Parses rustc's dep-info file which has multiple rules (one per output target),
-/// all sharing the same dependencies. Extracts the unique set of source file deps.
+/// all sharing the same dependencies. Extracts the unique set of source file deps
+/// plus the `# env-dep:` env-var names rustc records for `env!()` reads.
 /// `--extern` crate files are tracked separately by the dependency graph so
 /// their content, but not target-dir path prefix, participates in artifact keys.
 pub(super) fn scan_rustc_deps(
     rustc_args: &crate::depgraph::RustcParsedArgs,
     source_path: &Path,
     cwd: &Path,
-) -> crate::depgraph::ScanResult {
-    let result = if rustc_args.emit_types.iter().any(|t| t == "dep-info") {
+) -> RustcDepScan {
+    if rustc_args.emit_types.iter().any(|t| t == "dep-info") {
         let name = rustc_args.crate_name.as_deref().unwrap_or("unknown");
         let ext_suffix = rustc_args.extra_filename.as_deref().unwrap_or("");
         let dir = rustc_args.out_dir.as_deref().unwrap_or(cwd);
         let depfile_path = dir.join(format!("{name}{ext_suffix}.d"));
         if depfile_path.exists() {
             if let Ok(content) = std::fs::read_to_string(&depfile_path) {
-                parse_rustc_depinfo(&content, source_path, cwd)
-            } else {
-                crate::depgraph::ScanResult {
-                    resolved: Vec::new(),
-                    unresolved: Vec::new(),
-                    has_computed: false,
-                }
-            }
-        } else {
-            crate::depgraph::ScanResult {
-                resolved: Vec::new(),
-                unresolved: Vec::new(),
-                has_computed: false,
+                return parse_rustc_depinfo(&content, source_path, cwd);
             }
         }
-    } else {
-        crate::depgraph::ScanResult {
-            resolved: Vec::new(),
-            unresolved: Vec::new(),
-            has_computed: false,
-        }
-    };
-
-    result
+    }
+    RustcDepScan::empty()
 }
 
 /// Parse rustc's multi-rule dep-info format.
@@ -224,17 +228,35 @@ pub(super) fn scan_rustc_deps(
 /// ```
 ///
 /// We extract deps from ALL rules and deduplicate, excluding the source file.
-pub(super) fn parse_rustc_depinfo(
-    content: &str,
-    source_path: &Path,
-    cwd: &Path,
-) -> crate::depgraph::ScanResult {
+///
+/// `# env-dep:NAME[=VALUE]` comment lines record every env var the crate read
+/// via `env!()` / `option_env!()`. Only the NAME is kept — values are
+/// fingerprinted against the request's client env, not the dep-info bytes
+/// (issue #1021). Other `#` comment lines are skipped entirely so they can
+/// never be misparsed as dependency rules.
+pub(super) fn parse_rustc_depinfo(content: &str, source_path: &Path, cwd: &Path) -> RustcDepScan {
     let mut deps = std::collections::HashSet::new();
+    let mut env_dep_names = std::collections::BTreeSet::new();
 
     for line in content.lines() {
         // Join continuation lines (backslash-newline)
         let line = line.trim();
         if line.is_empty() {
+            continue;
+        }
+
+        if let Some(rest) = line.strip_prefix('#') {
+            if let Some(dep) = rest.trim_start().strip_prefix("env-dep:") {
+                // `NAME=VALUE` when set, bare `NAME` when option_env!() saw
+                // unset. rustc escapes spaces in the name as `\ `.
+                let name_raw = dep.split_once('=').map_or(dep, |(name, _)| name);
+                let name = name_raw.replace("\\ ", " ");
+                if !name.is_empty()
+                    && !crate::depgraph::VOLATILE_ENV_DEP_NAMES.contains(&name.as_str())
+                {
+                    env_dep_names.insert(name);
+                }
+            }
             continue;
         }
 
@@ -309,10 +331,13 @@ pub(super) fn parse_rustc_depinfo(
     }
     resolved.sort();
 
-    crate::depgraph::ScanResult {
-        resolved,
-        unresolved: Vec::new(),
-        has_computed: false,
+    RustcDepScan {
+        scan: crate::depgraph::ScanResult {
+            resolved,
+            unresolved: Vec::new(),
+            has_computed: false,
+        },
+        env_deps: env_dep_names.into_iter().collect(),
     }
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/tests/env_deps.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/env_deps.rs
@@ -1,0 +1,94 @@
+//! Tests for `# env-dep:` extraction from rustc dep-info (issue #1021).
+//!
+//! rustc records every `env!()` / `option_env!()` read as a comment line in
+//! dep-info; `parse_rustc_depinfo` must surface the names (sorted, deduped,
+//! volatile path-valued names filtered) and must never misparse comment
+//! lines as file dependencies.
+
+use super::super::*;
+
+fn parse(content: &str) -> RustcDepScan {
+    let cwd = std::env::temp_dir();
+    parse_rustc_depinfo(content, Path::new("src/lib.rs"), &cwd)
+}
+
+#[test]
+fn env_dep_lines_extract_names_only() {
+    let scan = parse(
+        "libfoo.rlib: src/lib.rs\n\
+         src/lib.rs:\n\
+         # env-dep:STAMP=one\n\
+         # env-dep:GIT_SHA=abc123\n",
+    );
+    assert_eq!(
+        scan.env_deps,
+        vec!["GIT_SHA".to_string(), "STAMP".to_string()]
+    );
+}
+
+#[test]
+fn env_dep_without_value_records_name() {
+    // option_env!() on an unset var emits a bare name.
+    let scan = parse("# env-dep:MAYBE_SET\n");
+    assert_eq!(scan.env_deps, vec!["MAYBE_SET".to_string()]);
+}
+
+#[test]
+fn env_dep_names_are_deduped_and_sorted() {
+    let scan = parse(
+        "# env-dep:B=2\n\
+         # env-dep:A=1\n\
+         # env-dep:B=2\n",
+    );
+    assert_eq!(scan.env_deps, vec!["A".to_string(), "B".to_string()]);
+}
+
+#[test]
+fn volatile_env_dep_names_are_filtered() {
+    let scan = parse(
+        "# env-dep:OUT_DIR=/target/debug/build/foo-abc/out\n\
+         # env-dep:CARGO_MANIFEST_DIR=/workspace/foo\n\
+         # env-dep:STAMP=x\n",
+    );
+    assert_eq!(scan.env_deps, vec!["STAMP".to_string()]);
+}
+
+#[test]
+fn env_dep_value_containing_equals_keeps_full_name_split_at_first() {
+    let scan = parse("# env-dep:FLAGS=-C opt-level=3\n");
+    assert_eq!(scan.env_deps, vec!["FLAGS".to_string()]);
+}
+
+#[test]
+fn comment_lines_are_never_file_deps() {
+    // An env-dep value that looks like an existing path must not leak into
+    // the resolved file-dependency set.
+    let tmp = tempfile::tempdir().unwrap();
+    let real = tmp.path().join("real.h");
+    std::fs::write(&real, "x").unwrap();
+    let content = format!(
+        "libfoo.rlib: src/lib.rs\n# env-dep:CONF={}\n# some other comment\n",
+        real.display()
+    );
+    let scan = parse_rustc_depinfo(&content, Path::new("src/lib.rs"), tmp.path());
+    assert!(
+        scan.scan.resolved.is_empty(),
+        "comment lines must not contribute file deps, got {:?}",
+        scan.scan.resolved
+    );
+    assert_eq!(scan.env_deps, vec!["CONF".to_string()]);
+}
+
+#[test]
+fn file_deps_still_parse_alongside_env_deps() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dep = tmp.path().join("other.rs");
+    std::fs::write(&dep, "x").unwrap();
+    let content = format!(
+        "libfoo.rlib: src/lib.rs {}\n# env-dep:STAMP=one\n",
+        dep.display()
+    );
+    let scan = parse_rustc_depinfo(&content, Path::new("src/lib.rs"), tmp.path());
+    assert_eq!(scan.scan.resolved.len(), 1);
+    assert_eq!(scan.env_deps, vec!["STAMP".to_string()]);
+}

--- a/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
@@ -12,6 +12,7 @@ mod client_env;
 mod compiler_hash;
 mod deferred_cold_path;
 mod embedded_flush;
+mod env_deps;
 mod exec_probe;
 mod fingerprint;
 mod link_cache;

--- a/crates/zccache-depgraph/src/env_deps.rs
+++ b/crates/zccache-depgraph/src/env_deps.rs
@@ -1,0 +1,131 @@
+//! Env-var dependency fingerprinting for rustc compiles (issue #1021).
+//!
+//! rustc records every `env!()` / `option_env!()` the crate reads as a
+//! `# env-dep:NAME[=VALUE]` line in its dep-info output. Cargo consumes those
+//! lines to re-invoke rustc when a value changes; zccache must do the same or
+//! it serves a stale artifact with the old value baked in (the vergen /
+//! shadow-rs / built `cargo:rustc-env=` failure shape).
+//!
+//! The daemon records the env-dep *names* per context after each compile and
+//! stores a fingerprint of their values in that compile's client env. Every
+//! hit path recomputes the fingerprint against the *current* request env and
+//! forces a recompile on mismatch. An env var's value is the content — this
+//! mirrors how include files are content-hashed.
+
+use zccache_hash::ContentHash;
+
+/// Domain-separation tag for [`env_dep_fingerprint`].
+const ENV_DEP_FP_DOMAIN: &[u8] = b"zccache-rustc-env-dep-fp-v1\0";
+
+/// Env-dep names excluded from fingerprinting.
+///
+/// These are path-valued and volatile per checkout location. Their
+/// *referenced content* is already covered elsewhere (`OUT_DIR` files appear
+/// as path deps in the same dep-info and are content-hashed), so folding the
+/// path string itself into the fingerprint would only cascade cache misses
+/// across workspace moves/clones — the exact failure `VOLATILE_CARGO_ENV_VARS`
+/// exists to prevent in the context key (issue #396).
+pub const VOLATILE_ENV_DEP_NAMES: &[&str] = &[
+    "OUT_DIR",
+    "CARGO_MANIFEST_DIR",
+    "CARGO_MANIFEST_PATH",
+    "CARGO_TARGET_DIR",
+];
+
+/// Fingerprint the values of `names` as found in `client_env`.
+///
+/// `names` must be sorted and deduplicated (the dep-info parser guarantees
+/// this) so the hash is order-independent. Returns `None` when `names` is
+/// empty — contexts without env deps carry no fingerprint and skip the gate.
+///
+/// An unset variable hashes differently from one set to the empty string,
+/// so `option_env!()` transitions are caught.
+#[must_use]
+pub fn env_dep_fingerprint(
+    names: &[String],
+    client_env: Option<&[(String, String)]>,
+) -> Option<ContentHash> {
+    if names.is_empty() {
+        return None;
+    }
+    let lookup = |name: &str| -> Option<&str> {
+        client_env?
+            .iter()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v.as_str())
+    };
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(ENV_DEP_FP_DOMAIN);
+    for name in names {
+        hasher.update(name.as_bytes());
+        hasher.update(b"\0");
+        match lookup(name) {
+            Some(value) => {
+                hasher.update(&[1]);
+                hasher.update(value.as_bytes());
+            }
+            None => {
+                hasher.update(&[0]);
+            }
+        }
+        hasher.update(b"\0");
+    }
+    Some(ContentHash::from_bytes(*hasher.finalize().as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn empty_names_have_no_fingerprint() {
+        assert_eq!(env_dep_fingerprint(&[], Some(&env(&[("A", "1")]))), None);
+        assert_eq!(env_dep_fingerprint(&[], None), None);
+    }
+
+    #[test]
+    fn value_change_changes_fingerprint() {
+        let names = vec!["STAMP".to_string()];
+        let one = env_dep_fingerprint(&names, Some(&env(&[("STAMP", "one")])));
+        let two = env_dep_fingerprint(&names, Some(&env(&[("STAMP", "two")])));
+        assert!(one.is_some());
+        assert_ne!(one, two);
+    }
+
+    #[test]
+    fn same_values_match_regardless_of_unrelated_env() {
+        let names = vec!["STAMP".to_string()];
+        let a = env_dep_fingerprint(&names, Some(&env(&[("STAMP", "x"), ("PATH", "p1")])));
+        let b = env_dep_fingerprint(&names, Some(&env(&[("PATH", "p2"), ("STAMP", "x")])));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn unset_differs_from_empty_string() {
+        let names = vec!["OPT".to_string()];
+        let unset = env_dep_fingerprint(&names, Some(&env(&[])));
+        let empty = env_dep_fingerprint(&names, Some(&env(&[("OPT", "")])));
+        assert!(unset.is_some());
+        assert_ne!(unset, empty);
+        // No env at all behaves like unset.
+        assert_eq!(unset, env_dep_fingerprint(&names, None));
+    }
+
+    #[test]
+    fn multiple_names_all_participate() {
+        let names = vec!["A".to_string(), "B".to_string()];
+        let base = env_dep_fingerprint(&names, Some(&env(&[("A", "1"), ("B", "2")])));
+        let a_changed = env_dep_fingerprint(&names, Some(&env(&[("A", "9"), ("B", "2")])));
+        let b_changed = env_dep_fingerprint(&names, Some(&env(&[("A", "1"), ("B", "9")])));
+        assert_ne!(base, a_changed);
+        assert_ne!(base, b_changed);
+        assert_ne!(a_changed, b_changed);
+    }
+}

--- a/crates/zccache-depgraph/src/graph/env_deps.rs
+++ b/crates/zccache-depgraph/src/graph/env_deps.rs
@@ -1,0 +1,112 @@
+//! `DepGraph::record_env_deps` / `DepGraph::env_deps_match` — the env-dep
+//! gate for rustc contexts (issue #1021).
+//!
+//! Carved out of `mod.rs` to keep each file under the 1k-LOC guard. See
+//! `crate::env_deps` for the fingerprint itself and the rationale.
+
+use super::super::context::ContextKey;
+use super::super::env_deps::env_dep_fingerprint;
+use super::DepGraph;
+use zccache_hash::ContentHash;
+
+impl DepGraph {
+    /// Record the env-dep names scanned from rustc dep-info after a compile,
+    /// plus the fingerprint of their values in that compile's client env.
+    ///
+    /// Called *after* `update()` on the store path: a concurrent reader in
+    /// the window between the two sees the OLD fingerprint and fails the
+    /// gate, which degrades to a safe recompile rather than a stale hit.
+    pub fn record_env_deps(
+        &self,
+        key: &ContextKey,
+        env_deps: Vec<String>,
+        env_dep_fp: Option<ContentHash>,
+    ) {
+        if let Some(mut entry) = self.contexts.get_mut(key) {
+            entry.env_deps = env_deps;
+            entry.env_dep_fp = env_dep_fp;
+        }
+    }
+
+    /// Check whether the context's recorded env-dep values match the current
+    /// request env. Returns `true` when the context has no recorded env deps
+    /// (C/C++ contexts, rustc crates without `env!()`), or is unknown — the
+    /// gate only ever *blocks* hits on a known mismatch.
+    ///
+    /// Every hit path must consult this: the request-level and context-level
+    /// zero-hash fast paths never recompute keys, so a changed value (e.g.
+    /// vergen's `cargo:rustc-env=GIT_SHA`) is otherwise invisible to them.
+    #[must_use]
+    pub fn env_deps_match(
+        &self,
+        key: &ContextKey,
+        client_env: Option<&[(String, String)]>,
+    ) -> bool {
+        let Some(entry) = self.contexts.get(key) else {
+            return true;
+        };
+        if entry.env_deps.is_empty() {
+            return true;
+        }
+        env_dep_fingerprint(&entry.env_deps, client_env) == entry.env_dep_fp
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::context::CompileContext;
+    use super::super::DepGraph;
+    use super::env_dep_fingerprint;
+    use zccache_core::NormalizedPath;
+
+    fn env(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    fn register_ctx(graph: &DepGraph) -> super::ContextKey {
+        let ctx = CompileContext {
+            source_file: NormalizedPath::from("/tmp/envdep.rs"),
+            include_search: Default::default(),
+            defines: Vec::new(),
+            flags: Vec::new(),
+            force_includes: Vec::new(),
+            unknown_flags: Vec::new(),
+        };
+        graph.register(ctx)
+    }
+
+    #[test]
+    fn unknown_context_and_no_env_deps_pass_the_gate() {
+        let graph = DepGraph::new();
+        let key = register_ctx(&graph);
+        let bogus = super::ContextKey::from_raw([9u8; 32]);
+        assert!(graph.env_deps_match(&bogus, None));
+        assert!(graph.env_deps_match(&key, Some(&env(&[("STAMP", "one")]))));
+    }
+
+    #[test]
+    fn value_change_fails_the_gate_and_same_value_passes() {
+        let graph = DepGraph::new();
+        let key = register_ctx(&graph);
+        let names = vec!["STAMP".to_string()];
+        let stored = env(&[("STAMP", "one")]);
+        let fp = env_dep_fingerprint(&names, Some(&stored));
+        graph.record_env_deps(&key, names, fp);
+
+        assert!(graph.env_deps_match(&key, Some(&env(&[("STAMP", "one")]))));
+        assert!(!graph.env_deps_match(&key, Some(&env(&[("STAMP", "two")]))));
+        assert!(!graph.env_deps_match(&key, Some(&env(&[]))));
+        assert!(!graph.env_deps_match(&key, None));
+    }
+
+    #[test]
+    fn recorded_names_with_missing_fingerprint_fail_closed() {
+        let graph = DepGraph::new();
+        let key = register_ctx(&graph);
+        graph.record_env_deps(&key, vec!["STAMP".to_string()], None);
+        assert!(!graph.env_deps_match(&key, Some(&env(&[("STAMP", "one")]))));
+    }
+}

--- a/crates/zccache-depgraph/src/graph/mod.rs
+++ b/crates/zccache-depgraph/src/graph/mod.rs
@@ -11,6 +11,7 @@
 //! - `maintenance` — `trim`, `clear`, stats, accessors, `ingest_compile_commands`.
 
 mod check;
+mod env_deps;
 mod maintenance;
 mod register;
 mod update;
@@ -64,6 +65,14 @@ pub struct ContextEntry {
     pub artifact_key: Option<ArtifactKey>,
     /// File hashes from the last update() — used for drift diagnostics.
     pub last_file_hashes: Vec<(NormalizedPath, ContentHash)>,
+    /// Env-var names this context reads via `env!()` / `option_env!()`,
+    /// recorded from rustc dep-info `# env-dep:` lines (sorted, deduped).
+    /// Empty for C/C++ contexts and rustc contexts without env deps.
+    pub env_deps: Vec<String>,
+    /// Fingerprint of `env_deps` values in the client env of the last stored
+    /// compile. Hit paths compare this against the current request env — a
+    /// mismatch forces a recompile (issue #1021).
+    pub env_dep_fp: Option<ContentHash>,
     /// When this entry was last accessed (for trimming).
     pub last_accessed: Instant,
     /// Current state.

--- a/crates/zccache-depgraph/src/graph/register.rs
+++ b/crates/zccache-depgraph/src/graph/register.rs
@@ -162,6 +162,8 @@ impl DepGraph {
                 has_computed_includes: false,
                 artifact_key: None,
                 last_file_hashes: Vec::new(),
+                env_deps: Vec::new(),
+                env_dep_fp: None,
                 last_accessed: Instant::now(),
                 state: ContextState::Cold,
             });

--- a/crates/zccache-depgraph/src/graph/tests.rs
+++ b/crates/zccache-depgraph/src/graph/tests.rs
@@ -789,6 +789,8 @@ fn warm_context_with_no_artifact_returns_cold_on_check() {
             has_computed_includes: false,
             artifact_key: None,
             last_file_hashes: Vec::new(),
+            env_deps: Vec::new(),
+            env_dep_fp: None,
             last_accessed: Instant::now(),
             state: ContextState::Warm,
         },

--- a/crates/zccache-depgraph/src/lib.rs
+++ b/crates/zccache-depgraph/src/lib.rs
@@ -8,6 +8,7 @@ pub mod args;
 pub mod compile_commands;
 pub mod context;
 pub mod depfile;
+pub mod env_deps;
 pub mod graph;
 pub mod msvc_args;
 pub mod rustc_args;
@@ -26,6 +27,7 @@ pub use context::{
     RustcCompileContext,
 };
 pub use depfile::{prepare_depfile, DepfileError, DepfileStrategy};
+pub use env_deps::{env_dep_fingerprint, VOLATILE_ENV_DEP_NAMES};
 pub use graph::{CacheVerdict, ContextState, DepGraph, DepGraphStats};
 pub use rustc_args::{parse_rustc_args, ExternCrate, RustcParsedArgs};
 pub use scanner::{IncludeDirective, IncludeKind, ScanResult};

--- a/crates/zccache-depgraph/src/snapshot/mod.rs
+++ b/crates/zccache-depgraph/src/snapshot/mod.rs
@@ -36,7 +36,8 @@ pub use persistence::{
 };
 
 /// On-disk format version. Bump when snapshot layout changes.
-pub const DEPGRAPH_VERSION: u32 = 5;
+/// v6: `ContextEntrySnapshot` gained `env_deps` + `env_dep_fp` (issue #1021).
+pub const DEPGRAPH_VERSION: u32 = 6;
 
 /// Magic bytes identifying a depgraph snapshot file ("ZCDG").
 pub const DEPGRAPH_MAGIC: [u8; 4] = [0x5A, 0x43, 0x44, 0x47];
@@ -88,6 +89,10 @@ pub struct ContextEntrySnapshot {
     pub artifact_key: Option<[u8; 32]>,
     pub last_file_hashes: Vec<(String, [u8; 32])>,
     pub rustc_externs: Vec<RustcExternSnapshot>,
+    /// Env-var names from rustc dep-info `# env-dep:` lines (issue #1021).
+    pub env_deps: Vec<String>,
+    /// Fingerprint of `env_deps` values at last stored compile.
+    pub env_dep_fp: Option<[u8; 32]>,
     /// 0=Cold, 1=Warm, 2=Stale
     pub state: u8,
 }
@@ -192,6 +197,8 @@ impl DepGraph {
                         .map(|(p, h)| (p.to_string_lossy().into_owned(), *h.as_bytes()))
                         .collect(),
                     rustc_externs,
+                    env_deps: ctx.env_deps.clone(),
+                    env_dep_fp: ctx.env_dep_fp.map(|h| *h.as_bytes()),
                     state: match ctx.state {
                         ContextState::Cold => 0,
                         ContextState::Warm => 1,
@@ -279,6 +286,8 @@ impl DepGraph {
                     .into_iter()
                     .map(|(p, h)| (NormalizedPath::from(p.as_str()), ContentHash::from_bytes(h)))
                     .collect(),
+                env_deps: c.env_deps,
+                env_dep_fp: c.env_dep_fp.map(ContentHash::from_bytes),
                 last_accessed: Instant::now(),
                 state: match c.state {
                     0 => ContextState::Cold,

--- a/crates/zccache-depgraph/src/snapshot/tests/round_trip.rs
+++ b/crates/zccache-depgraph/src/snapshot/tests/round_trip.rs
@@ -30,6 +30,36 @@ fn empty_graph_roundtrip() {
     assert_eq!(stats.context_count, 0);
 }
 
+/// `env_deps` + `env_dep_fp` survive save/load (issue #1021, format v6):
+/// the env-dep gate must keep working after a daemon restart or a stale
+/// hit slips through the restored graph.
+#[test]
+fn env_deps_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let path = test_path(&dir);
+    let graph = DepGraph::new();
+
+    let key = graph.register(make_ctx("/src/envdep.rs"));
+    let names = vec!["GIT_SHA".to_string(), "STAMP".to_string()];
+    let client_env = vec![
+        ("GIT_SHA".to_string(), "abc123".to_string()),
+        ("STAMP".to_string(), "one".to_string()),
+    ];
+    let fp = super::super::super::env_deps::env_dep_fingerprint(&names, Some(&client_env));
+    assert!(fp.is_some());
+    graph.record_env_deps(&key, names, fp);
+
+    save_to_file(&graph, &path).unwrap();
+    let loaded = load_from_file(&path).unwrap();
+
+    assert!(loaded.env_deps_match(&key, Some(&client_env)));
+    let changed = vec![
+        ("GIT_SHA".to_string(), "def456".to_string()),
+        ("STAMP".to_string(), "one".to_string()),
+    ];
+    assert!(!loaded.env_deps_match(&key, Some(&changed)));
+}
+
 #[test]
 fn populated_graph_roundtrip() {
     let dir = TempDir::new().unwrap();

--- a/crates/zccache-ipc/src/lib.rs
+++ b/crates/zccache-ipc/src/lib.rs
@@ -7,9 +7,9 @@
 #![allow(clippy::missing_errors_doc)]
 
 pub mod broker;
-pub mod probe;
 pub mod error;
 pub mod manifest;
+pub mod probe;
 pub mod transport;
 
 pub use broker::{

--- a/crates/zccache-ipc/src/manifest.rs
+++ b/crates/zccache-ipc/src/manifest.rs
@@ -232,5 +232,4 @@ mod tests {
         );
         assert_eq!(roots_by_kind(&loaded.roots), original);
     }
-
 }

--- a/crates/zccache-ipc/src/mod_tests.rs
+++ b/crates/zccache-ipc/src/mod_tests.rs
@@ -497,11 +497,19 @@ fn parent_and_versioned_cache_dir_resolve_to_the_same_identity() {
 
     let (ep_parent, lock_parent, id_parent) = {
         let _env = EnvGuard::set_cache_dir(&parent);
-        (default_endpoint(), lock_file_path(), backend_identity_path())
+        (
+            default_endpoint(),
+            lock_file_path(),
+            backend_identity_path(),
+        )
     };
     let (ep_versioned, lock_versioned, id_versioned) = {
         let _env = EnvGuard::set_cache_dir(&versioned);
-        (default_endpoint(), lock_file_path(), backend_identity_path())
+        (
+            default_endpoint(),
+            lock_file_path(),
+            backend_identity_path(),
+        )
     };
 
     assert_eq!(ep_parent, ep_versioned, "endpoints must converge");

--- a/crates/zccache/src/lib.rs
+++ b/crates/zccache/src/lib.rs
@@ -18,6 +18,14 @@ pub mod ci;
 /// tests) is unchanged.
 #[cfg(feature = "cli")]
 pub use zccache_cli_core::cli;
+/// The download-cache client, moved to `zccache-cli-core` (#1022 Split A).
+/// Re-exported so `zccache::download_client::…` is unchanged.
+#[cfg(feature = "download-client")]
+pub use zccache_cli_core::download_client;
+/// The download-cache daemon logic, moved to `zccache-cli-core` (#1022 Split A).
+/// Re-exported so `zccache::download_daemon::…` is unchanged.
+#[cfg(feature = "download-daemon")]
+pub use zccache_cli_core::download_daemon;
 /// zccache#940 — per-sub-phase JSONL trace for the embedded compile
 /// path. Diagnostic-only, gated by the `ZCCACHE_INNER_TRACE` env var.
 /// See module doc for the wire format and why it exists.
@@ -28,23 +36,15 @@ pub use zccache_core as core;
 /// the public path `zccache::daemon::…` (used by the bins, the CLI, and
 /// integration tests) is unchanged.
 pub use zccache_daemon_core::daemon;
-pub use zccache_depgraph as depgraph;
-#[cfg(feature = "download")]
-pub use zccache_download as download;
-/// The download-cache client, moved to `zccache-cli-core` (#1022 Split A).
-/// Re-exported so `zccache::download_client::…` is unchanged.
-#[cfg(feature = "download-client")]
-pub use zccache_cli_core::download_client;
-/// The download-cache daemon logic, moved to `zccache-cli-core` (#1022 Split A).
-/// Re-exported so `zccache::download_daemon::…` is unchanged.
-#[cfg(feature = "download-daemon")]
-pub use zccache_cli_core::download_daemon;
-#[cfg(feature = "download-protocol")]
-pub use zccache_download_protocol as download_protocol;
 /// The embedded `ZccacheService` API (soldr/fbuild), moved to
 /// `zccache-daemon-core` (#1018). Re-exported so `zccache::embedded::…` is
 /// unchanged.
 pub use zccache_daemon_core::embedded;
+pub use zccache_depgraph as depgraph;
+#[cfg(feature = "download")]
+pub use zccache_download as download;
+#[cfg(feature = "download-protocol")]
+pub use zccache_download_protocol as download_protocol;
 pub use zccache_fingerprint as fingerprint;
 pub use zccache_fscache as fscache;
 #[cfg(feature = "gha")]

--- a/crates/zccache/tests/daemon_rustc_adversarial_corner_cases_test.rs
+++ b/crates/zccache/tests/daemon_rustc_adversarial_corner_cases_test.rs
@@ -617,3 +617,76 @@ async fn rustc_multiple_cargo_env_vars() {
 
     h.shutdown().await;
 }
+
+/// Non-CARGO env vars read via `env!()` must invalidate the cache when their
+/// values change (issue #1021). A build.rs `cargo:rustc-env=STAMP=<value>`
+/// (vergen / shadow-rs / built) reaches rustc as a plain process env var that
+/// rustc records as a `# env-dep:STAMP=<value>` line in dep-info. The env
+/// filter in the context key only keeps CARGO_* vars, so without env-dep
+/// tracking a changed STAMP with identical argv/sources serves the stale
+/// artifact with the old value baked in.
+///
+/// Mimics cargo's invocation shape (`--emit=dep-info,link` + `--out-dir` +
+/// `-C metadata/extra-filename`) so the daemon can scan the dep-info file.
+#[tokio::test]
+#[ignore]
+async fn rustc_non_cargo_env_dep_change_invalidates_cache() {
+    let mut h = match TestHarness::new().await {
+        Some(h) => h,
+        None => return,
+    };
+
+    h.write_file(
+        "envdep.rs",
+        r#"pub fn stamp() -> &'static str { env!("STAMP") }"#,
+    );
+
+    let args = &[
+        "--edition",
+        "2021",
+        "--crate-type",
+        "lib",
+        "--crate-name",
+        "envdep",
+        "--emit=dep-info,link",
+        "-C",
+        "metadata=abc123",
+        "-C",
+        "extra-filename=-abc123",
+        "--out-dir",
+        ".",
+        "envdep.rs",
+    ];
+    let rlib = "libenvdep-abc123.rlib";
+
+    // Compile with STAMP=one → miss (cold).
+    let env_one: Vec<(String, String)> = vec![("STAMP".into(), "one".into())];
+    let (ec, cached) = h.compile_args(args, Some(env_one.clone())).await;
+    assert_eq!(ec, 0);
+    assert!(!cached, "first compile should be miss");
+    let obj_one = std::fs::read(h.path(rlib)).unwrap();
+
+    // Same STAMP value again → must still hit (no over-invalidation).
+    std::fs::remove_file(h.path(rlib)).unwrap();
+    let (ec, cached) = h.compile_args(args, Some(env_one)).await;
+    assert_eq!(ec, 0);
+    assert!(cached, "same-value recompile should hit");
+
+    // STAMP=two → MUST miss: the artifact must embed the new value.
+    // A false hit here serves an rlib with the stale "one" baked in.
+    let env_two: Vec<(String, String)> = vec![("STAMP".into(), "two".into())];
+    let (ec, cached) = h.compile_args(args, Some(env_two)).await;
+    assert_eq!(ec, 0);
+    assert!(
+        !cached,
+        "changed non-CARGO env-dep value MUST produce cache miss \
+         (false hit = stale env!() value baked into the artifact)"
+    );
+    let obj_two = std::fs::read(h.path(rlib)).unwrap();
+    assert_ne!(
+        obj_one, obj_two,
+        "different STAMP → different .rlib content"
+    );
+
+    h.shutdown().await;
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,6 +21,7 @@ This document is the index for zccache's architecture specification. Each subsys
 
 - **High-level design** → [overview.md](architecture/overview.md)
 - **"How does a cache hit work?"** → [data-flow.md](architecture/data-flow.md)
+- **Rustc cache key: env-deps, crate types, native-lib stance** → [data-flow.md § Rustc Cache-Key Semantics](architecture/data-flow.md#rustc-cache-key-semantics)
 - **CLI↔daemon communication** → [ipc.md](architecture/ipc.md)
 - **File change detection** → [metadata-cache.md](architecture/metadata-cache.md)
 - **Disk cache & eviction** → [artifact-store.md](architecture/artifact-store.md)

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -23,6 +23,7 @@ Architecture docs are split by subsystem. Read only what's relevant to your curr
 | Generic tool exec (`zccache exec`, issue #272) | [runtime.md § Generic tool exec](architecture/runtime.md#generic-tool-exec-zccache-exec) — `handle_exec.rs` + `cli/commands/exec.rs` |
 | Platform-specific issues | [portability.md](architecture/portability.md) |
 | Compile journal record shape | [journal-schema.md](journal-schema.md) |
+| Rustc cache-key semantics (env-deps #1021, crate types, native libs) | [data-flow.md § Rustc Cache-Key Semantics](architecture/data-flow.md#rustc-cache-key-semantics) |
 | `ZCCACHE_CACHE_DIR` contract + `zccache cache-root` | [runtime.md § Cache root invariants](architecture/runtime.md#cache-root-invariants) |
 | zccache vs sccache feature matrix | [FEATURE-MATRIX.md](FEATURE-MATRIX.md) — generated from [feature-matrix.yaml](feature-matrix.yaml) by `ci/render_feature_matrix.py` |
 

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -131,3 +131,53 @@ Non-cacheable patterns detected by the CLI:
 - `-E` / `-M` / `-MM` (preprocessing / dependency generation only).
 - `-` as input (stdin source).
 - Unrecognized compiler.
+
+## Rustc Cache-Key Semantics
+
+The rustc key is a two-level construction in `zccache-depgraph`:
+
+- **Context key** (`RustcCompileContext::context_key_with_root`): compiler
+  identity hash, all cache-relevant flags (`--crate-type`, `--edition`,
+  `--emit`, `--cfg`, codegen flags, lints, `--remap-path-prefix`, …),
+  extern crate identities, and the `CARGO_*` env subset (minus
+  `CARGO_MAKEFLAGS`, `CARGO_INCREMENTAL`, and the volatile path-valued
+  `CARGO_MANIFEST_DIR` / `CARGO_MANIFEST_PATH` / `CARGO_TARGET_DIR`).
+- **Artifact key** (`compute_rustc_artifact_key_with_root`): context key +
+  content hashes of the source, every dep-info file dependency, and every
+  `--extern` rlib/rmeta.
+
+**Env-var dependencies (issue #1021).** Non-`CARGO_` env values read via
+`env!()` / `option_env!()` — e.g. build-script `cargo:rustc-env=` values from
+vergen / shadow-rs / built — are tracked through the `# env-dep:` dep-info
+lines the compiler emits. After each compile the daemon records the env-dep
+*names* on the context entry (`DepGraph::record_env_deps`) plus a blake3
+fingerprint of their values in that compile's client env. Every hit path
+(request-level fast path, context-level fast path, depgraph verify, rustc
+check/build metadata-compat) gates on `DepGraph::env_deps_match` — a changed
+value forces a recompile instead of serving an artifact with the stale value
+baked in. Volatile path-valued names (`OUT_DIR`, `CARGO_MANIFEST_DIR`,
+`CARGO_MANIFEST_PATH`, `CARGO_TARGET_DIR`) are excluded: their referenced
+*content* is hashed as ordinary file deps, and fingerprinting the path string
+would cascade misses across checkout moves. Both fields persist in the
+depgraph snapshot (format v6). Compiles that emit no dep-info (`--emit=link`
+only) record no env-dep names and keep the pre-#1021 behavior for
+non-`CARGO_` vars.
+
+**Cacheable crate types.** `lib`, `rlib`, `staticlib`, `proc-macro`, `bin`
+(`RUSTC_CACHEABLE_CRATE_TYPES` in `zccache-compiler/src/parse_rustc.rs`).
+`dylib` / `cdylib` are deliberately non-cacheable: final shared-library
+artifacts recompile every time while their rlib deps still hit.
+
+**Native-library blind spot (recorded decision, issue #1021 item 3).**
+Link-step native libraries resolved via `-L`/`-l` are *not* content-hashed
+into `bin`/`staticlib` keys — sccache shares this blind spot, and hashing
+resolved system libraries on every link costs syscalls on the hot path with
+no field reports justifying it. Revisit (flip to hashing) if a real-world
+stale-bin report lands or before promoting any shared/remote artifact tier.
+
+**Incremental compilation.** `-C incremental` is excluded from the key and
+the compiler may use the incremental dir on a miss. sccache instead refuses
+to cache incremental compiles. Caveat accepted: incremental can change CGU
+partitioning (internal symbol names), so byte-level artifact identity is not
+guaranteed across incremental states; served artifacts always come from a
+real compile of the same keyed inputs.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,23 @@
+# #1021 rustc cache-key soundness tail (in flight, branch fix/1021-rustc-env-dep-keying)
+
+Issue: https://github.com/zackees/zccache/issues/1021
+
+- [x] 1. RED test `rustc_non_cargo_env_dep_change_invalidates_cache` (corner_cases file) —
+      confirmed RED (false hit), then GREEN after fix.
+- [x] 2. GREEN: `# env-dep:` names parsed from dep-info (`RustcDepScan`), recorded per context
+      (`DepGraph::record_env_deps` + snapshot v6), value fingerprint gated on EVERY hit path
+      (`env_deps_match`): request fast path, context fast path, hash_verify, compat, error-cache.
+- [x] 3. `parse_rustc.rs` incremental comment corrected (sccache refuses; CGU caveat noted).
+- [x] 4. Native-lib stance documented (data-flow.md § Rustc Cache-Key Semantics + README).
+- [x] 5. Crate-type allowlist + cdylib exclusion documented (also fixed stale README claim
+      that proc-macro/bin are passed through — they cache since parse_rustc.rs allowlist grew).
+- [x] 6. fmt + clippy clean; workspace lib tests pass; rustc integration suites pass.
+      NOTE: `./test` publish-order preflight broken on MAIN (zccache-cli-core /
+      zccache-daemon-core missing from RUST_PUBLISH_ORDER) — pre-existing, separate fix.
+      NOTE: `daemon_rustc_cache_worktree_test::test_rustc_sibling_git_worktree_equivalent_cache_sharing`
+      fails identically on unmodified main (line 511 "B edits must not poison A") — pre-existing.
+- [ ] 7. Docker linux validation; PR; merge; validate on main; close #1021.
+
 # #968 wedge/timeout burn-down — near complete
 
 Meta: https://github.com/zackees/zccache/issues/968


### PR DESCRIPTION
Closes #1021

## What

rustc records every `env!()` / `option_env!()` read as a `# env-dep:NAME[=VALUE]` line in dep-info. zccache discarded those lines and only ever keyed `CARGO_*` env, so a build-script `cargo:rustc-env=STAMP=x` (vergen / shadow-rs / built) with identical argv+sources served the **stale artifact with the old value baked in** — on every hit path, including the two zero-hash fast paths (`HIT_REQUEST`, `HIT_FAST`) that never recompute keys.

## How

- `parse_rustc_depinfo` now extracts env-dep **names** (sorted/deduped; `#` comment lines can no longer be misparsed as file deps) → `RustcDepScan`.
- After each stored compile, `DepGraph::record_env_deps` stores the names + a blake3 fingerprint of their values in that compile's client env on the context entry (recorded **after** `update()` so the race window degrades to a safe recompile). Persisted in the depgraph snapshot (**format v6**).
- Every hit path gates on `DepGraph::env_deps_match`: request-level fast path, context-level fast path, `hash_and_verify` verdict, rustc metadata-compat hit, and the cached-error path. Contexts without env deps skip the gate (one DashMap read).
- Volatile path-valued names (`OUT_DIR`, `CARGO_MANIFEST_DIR`, `CARGO_MANIFEST_PATH`, `CARGO_TARGET_DIR`) are excluded — their referenced content is hashed as file deps; fingerprinting the path string would cascade misses across checkout moves (same rationale as `VOLATILE_CARGO_ENV_VARS`, #396).

## Issue tail items (2–4)

- `parse_rustc.rs` incremental comment corrected: sccache **refuses** incremental (old comment claimed the opposite); CGU-partitioning caveat recorded.
- Native-lib `-L`/`-l` stance recorded as a **documented blind spot** (sccache parity, syscall cost) in `data-flow.md § Rustc Cache-Key Semantics` — flip to hashing if a real-world stale-bin report lands.
- Cacheable crate-type allowlist + `dylib`/`cdylib` exclusion documented; README no longer claims proc-macro/bin are passed through (they cache).

## RED → GREEN

`rustc_non_cargo_env_dep_change_invalidates_cache` (adversarial corner-cases suite): fails on old code with a false hit at the changed-value step; passes with the fix. Same-value recompile still hits (no over-invalidation).

## Testing

- Windows local: workspace lib tests (~1,730), clippy `-D warnings`, fmt; rustc integration suites: basic (6), corner-cases (7), mutations (6), concurrency (4), async-populate (5) — all green.
- **Docker Linux (rust:1.94.1)**: clippy `-D warnings`, workspace lib tests, corner-cases + basic integration suites — all green.
- New unit tests: dep-info env-dep parsing (7), env-dep fingerprint (5), DepGraph gate (3), snapshot v6 roundtrip (1).

## Notes for review

- Pre-existing on main, **not** from this PR: `./test` publish-order preflight fails (`RUST_PUBLISH_ORDER` missing `zccache-cli-core`/`zccache-daemon-core`), and `daemon_rustc_cache_worktree_test::test_rustc_sibling_git_worktree_equivalent_cache_sharing` fails at line 511 on unmodified main. Both verified against the main checkout; follow-ups coming separately.
- 9 files carry rustfmt-only reflows from `cargo fmt --all` under the pinned 1.94.1 toolchain (main had drift).
- No wire-format change → no `PROTOCOL_VERSION` bump; snapshot format bumped to v6 (old snapshots discarded → one-time cold start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)