### PR TITLE
ci: mark split engine crates publish=false to unblock ./test preflight (#1027)

### DIFF
--- a/crates/zccache-cli-core/Cargo.toml
+++ b/crates/zccache-cli-core/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "zccache CLI subsystem: commands, wrapper mode, client, and the download client/daemon (#1022 crate split)"
+# Internal engine crate — amalgamated into the published `zccache` monocrate
+# (Wave 7 model, see ci/release_checks.py). Never published standalone.
+publish = false
 
 [features]
 default = []

--- a/crates/zccache-daemon-core/Cargo.toml
+++ b/crates/zccache-daemon-core/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "zccache daemon subsystem: IPC server, compile/link/exec handlers, embedded service (#1018 crate split)"
+# Internal engine crate — amalgamated into the published `zccache` monocrate
+# (Wave 7 model, see ci/release_checks.py). Never published standalone.
+publish = false
 
 [features]
 default = []


### PR DESCRIPTION
Closes #1027

## What

`./test` on current main fails before running any Rust test:

```
Rust publish-order checks failed:
  - RUST_PUBLISH_ORDER is missing publishable crates: zccache-cli-core, zccache-daemon-core
```

The #1019 (`zccache-daemon-core`) and #1023 (`zccache-cli-core`) splits left the new crates publishable. Both are internal engine crates amalgamated into the published `zccache` monocrate (Wave 7 model per `ci/release_checks.py`), so the fix is `publish = false` on both — mirroring `zccache-depgraph` and the other split-out crates — not adding them to `RUST_PUBLISH_ORDER`.

## Testing

- RED: `validate_rust_publish_order()` fails on a fresh worktree of main (captured).
- GREEN: passes after the two-line change; `./test` proceeds into the Rust unit suite.
- Manifest-metadata-only change (`publish` flag) — no code, no build-graph, no platform surface, so no docker-linux run for this one; the preflight check is platform-independent Python.
- Note: `daemon_spawn_lockfile_budget_test` fails on **unmodified main** as well (worse there: 2/2 failing) — pre-existing, will be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)