### PR TITLE
ci: actually repair the corrupted musl rust-std component (#1025 follow-up)

### DIFF
--- a/.github/workflows/ci-check-cross.yml
+++ b/.github/workflows/ci-check-cross.yml
@@ -76,8 +76,20 @@ jobs:
           echo 'fn main() {}' > /tmp/std_probe.rs
           if ! soldr rustc --target ${{ inputs.target }} --emit=metadata \
               --out-dir /tmp /tmp/std_probe.rs; then
-            echo "rust-std for ${{ inputs.target }} is corrupt in the cached toolchain — reinstalling"
-            soldr rustup component remove "rust-std-${{ inputs.target }}" || true
+            echo "rust-std for ${{ inputs.target }} is corrupt in the cached toolchain — purging component state"
+            # `rustup component remove`/`target add` both no-op on this
+            # corruption: the per-component manifest file is missing but the
+            # toolchain's component registry still lists it, so rustup thinks
+            # the target is installed (verified on main run 2026-07-10
+            # 03:41Z — the remove+add round-trip completed in <200 ms and the
+            # re-probe failed identically). Surgically drop the registry
+            # entry and leftover files so `target add` performs a real
+            # install.
+            SYSROOT=$(soldr rustc --print sysroot)
+            echo "sysroot: $SYSROOT"
+            sed -i '/rust-std-${{ inputs.target }}/d' "$SYSROOT/lib/rustlib/components" || true
+            rm -f "$SYSROOT/lib/rustlib/manifest-rust-std-${{ inputs.target }}"
+            rm -rf "$SYSROOT/lib/rustlib/${{ inputs.target }}"
             soldr rustup target add ${{ inputs.target }}
             soldr rustc --target ${{ inputs.target }} --emit=metadata \
               --out-dir /tmp /tmp/std_probe.rs


### PR DESCRIPTION
Refs #1025

The #1032 probe detected the corrupted cached `rust-std-aarch64-unknown-linux-musl` but its repair was a no-op: `rustup component remove` fails on the same missing manifest, and `rustup target add` consults the component registry — which still lists the component — so it no-ops (main run 03:41Z: remove+add completed in <200 ms, re-probe failed identically).

This purges the component state surgically (registry line in `$SYSROOT/lib/rustlib/components`, the missing-manifest stub, and the target rustlib dir) so `target add` performs a real install; the re-probe still gates the result.

YAML parse-checked. The next main run's arm-musl lane is the verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)