### PR TITLE
fix(rust-plan): retain build-script fingerprint hashes

### DIFF
--- a/crates/zccache-artifact/src/rust_plan/selection.rs
+++ b/crates/zccache-artifact/src/rust_plan/selection.rs
@@ -171,7 +171,20 @@ fn is_fingerprint_meta_file(rel: &Path) -> bool {
     let Some(name) = rel.file_name().and_then(OsStr::to_str) else {
         return false;
     };
+    // Cargo writes human-readable diagnostics beside several hash records
+    // using the same stem plus `.json`. Reject the suffix before consulting
+    // prefixes so `bin-*.json` and build-script JSON cannot masquerade as
+    // load-bearing fingerprints.
+    if rel.extension() == Some(OsStr::new("json")) {
+        return false;
+    }
     if name == "invoked.timestamp" {
+        return true;
+    }
+    // Cargo stores the load-bearing fingerprints for build-script compile
+    // and execution units under these two prefixes. They are opaque hash
+    // records just like dep-/lib-/bin-*; adjacent JSON remains diagnostic.
+    if name.starts_with("build-script-") || name.starts_with("run-build-script-") {
         return true;
     }
     matches!(

--- a/crates/zccache-artifact/src/rust_plan/tests/thin_v2.rs
+++ b/crates/zccache-artifact/src/rust_plan/tests/thin_v2.rs
@@ -158,6 +158,26 @@ fn thin_v2_save_keeps_fingerprint_meta_but_drops_fingerprint_outputs() {
         &target.join(".fingerprint/serde-abc/lib-serde"),
         b"libstamp",
     );
+    write(
+        &target.join(".fingerprint/serde-abc/build-script-build-script-build"),
+        b"build-script-hash",
+    );
+    write(
+        &target.join(".fingerprint/serde-abc/run-build-script-build-script-build"),
+        b"run-build-script-hash",
+    );
+    write(
+        &target.join(".fingerprint/serde-abc/build-script-build-script-build.json"),
+        b"diagnostic",
+    );
+    write(
+        &target.join(".fingerprint/serde-abc/run-build-script-build-script-build.json"),
+        b"diagnostic",
+    );
+    write(
+        &target.join(".fingerprint/serde-abc/bin-serde.json"),
+        b"diagnostic",
+    );
     // Output file (dropped):
     write(
         &target.join(".fingerprint/serde-abc/serde-abc.json"),
@@ -202,10 +222,26 @@ fn thin_v2_save_keeps_fingerprint_meta_but_drops_fingerprint_outputs() {
         "lib-* must be kept; got {kept_paths:?}",
     );
     assert!(
+        kept_paths
+            .iter()
+            .any(|p| p.ends_with(".fingerprint/serde-abc/build-script-build-script-build")),
+        "build-script-* hashes must be kept; got {kept_paths:?}",
+    );
+    assert!(
+        kept_paths
+            .iter()
+            .any(|p| p.ends_with(".fingerprint/serde-abc/run-build-script-build-script-build")),
+        "run-build-script-* hashes must be kept; got {kept_paths:?}",
+    );
+    assert!(
         !kept_paths
             .iter()
             .any(|p| p.ends_with(".fingerprint/serde-abc/serde-abc.json")),
         "fingerprint output .json must be dropped; got {kept_paths:?}",
+    );
+    assert!(
+        !kept_paths.iter().any(|p| p.ends_with(".json")),
+        "all fingerprint diagnostic JSON must be dropped; got {kept_paths:?}",
     );
     assert!(
         kept_paths.iter().any(|p| p.ends_with("deps/serde-abc.d")),
@@ -270,6 +306,29 @@ fn thin_v2_classifier_recognizes_new_classes() {
         ),
         Some(RustArtifactClass::CargoFingerprintOutputs),
     );
+    for name in [
+        "build-script-build-script-build",
+        "run-build-script-build-script-build",
+    ] {
+        let path = Path::new("debug/.fingerprint/serde-abc").join(name);
+        assert_eq!(
+            classify_artifact(&path, RustPlanMode::Thin, true),
+            Some(RustArtifactClass::CargoFingerprintMeta),
+            "{name} is a load-bearing Cargo freshness hash",
+        );
+    }
+    for name in [
+        "build-script-build-script-build.json",
+        "run-build-script-build-script-build.json",
+        "bin-serde.json",
+    ] {
+        let path = Path::new("debug/.fingerprint/serde-abc").join(name);
+        assert_eq!(
+            classify_artifact(&path, RustPlanMode::Thin, true),
+            Some(RustArtifactClass::CargoFingerprintOutputs),
+            "{name} is diagnostic JSON, not a freshness hash",
+        );
+    }
     // Legacy (thin_v2 = false) keeps the umbrella class so older
     // callers see no behavior change.
     assert_eq!(


### PR DESCRIPTION
## Summary
- retain Cargo `build-script-*` and `run-build-script-*` freshness hashes in thin-v2 bundles
- reject `.json` before prefix classification so adjacent diagnostics remain excluded
- cover save-walker and direct classifier behavior

## Validation
- RED: thin-v2 save omitted both build-script hash classes
- `soldr --no-cache cargo test --manifest-path _vender/zccache/Cargo.toml -p zccache-artifact thin_v2 -- --nocapture` (8 passed)
- `soldr --no-cache cargo fmt --manifest-path _vender/zccache/Cargo.toml --all -- --check`
- `soldr --no-cache cargo clippy --manifest-path _vender/zccache/Cargo.toml -p zccache-artifact --all-targets -- -D warnings`
- real build-script fixture: retained both hash classes; incomplete fresh-target restore remained Cargo-dirty (`Compiling=1`, `Fresh=0`, 2 rustc wrapper units)

Refs zackees/soldr#1552