### PR TITLE
fix(rust-plan): retain load-bearing fingerprint JSON in thin-v2 bundles

### DIFF
--- a/crates/zccache-artifact/src/rust_plan/selection.rs
+++ b/crates/zccache-artifact/src/rust_plan/selection.rs
@@ -165,32 +165,41 @@ fn path_has_dsym_ancestor(rel: &Path) -> bool {
 
 /// True for files cargo writes inside `.fingerprint/<crate>-<hash>/` that
 /// feed its freshness decision. soldr's `docs/THIN_TARGET_CACHE_PRUNING.md`
-/// Section 4.3 enumerates these prefixes. Everything else in the directory
-/// (notably the `*.json` debug files) is treated as output.
+/// Section 4.3 enumerates these prefixes.
+///
+/// soldr#1564: Cargo's `Fingerprint::load` reads the per-unit `<stem>.json`
+/// record (e.g. `lib-foo.json`, `bin-foo.json`,
+/// `build-script-build-foo.json`, `run-build-script-build-foo.json`)
+/// *in addition to* the opaque hash file with the same stem — the JSON is
+/// NOT a human-readable diagnostic, it's the serialized `Fingerprint`
+/// Cargo needs to even attempt a freshness comparison. Dropping it makes
+/// `cargo::core::compiler::fingerprint::load` fail with
+/// `failed to read .fingerprint/<unit>/<stem>.json`, forcing every unit
+/// Dirty regardless of whether the hash file and primary outputs survived
+/// the restore. So the `.json` suffix is stripped before matching
+/// prefixes, and a `<stem>.json` classifies identically to `<stem>`.
+/// Files whose stem does not match any load-bearing prefix (e.g. a
+/// `<pkg>-<hash>.json` file matching the fingerprint directory's own name)
+/// remain diagnostic-class output.
 fn is_fingerprint_meta_file(rel: &Path) -> bool {
     let Some(name) = rel.file_name().and_then(OsStr::to_str) else {
         return false;
     };
-    // Cargo writes human-readable diagnostics beside several hash records
-    // using the same stem plus `.json`. Reject the suffix before consulting
-    // prefixes so `bin-*.json` and build-script JSON cannot masquerade as
-    // load-bearing fingerprints.
-    if rel.extension() == Some(OsStr::new("json")) {
-        return false;
-    }
     if name == "invoked.timestamp" {
         return true;
     }
+    let stem = name.strip_suffix(".json").unwrap_or(name);
     // Cargo stores the load-bearing fingerprints for build-script compile
     // and execution units under these two prefixes. They are opaque hash
-    // records just like dep-/lib-/bin-*; adjacent JSON remains diagnostic.
-    if name.starts_with("build-script-") || name.starts_with("run-build-script-") {
+    // records just like dep-/lib-/bin-*, and their `.json` companions are
+    // load-bearing too (see doc comment above).
+    if stem.starts_with("build-script-") || stem.starts_with("run-build-script-") {
         return true;
     }
     matches!(
-        name.split('-').next(),
+        stem.split('-').next(),
         Some("dep" | "output" | "lib" | "bin")
-    ) && name.contains('-')
+    ) && stem.contains('-')
 }
 
 /// True for cargo's compiled build-script binaries. The base name is

--- a/crates/zccache-artifact/src/rust_plan/tests/thin_v2.rs
+++ b/crates/zccache-artifact/src/rust_plan/tests/thin_v2.rs
@@ -144,8 +144,10 @@ fn thin_v2_save_drops_rlib_rmeta_even_when_allowed_list_lists_them() {
 #[test]
 fn thin_v2_save_keeps_fingerprint_meta_but_drops_fingerprint_outputs() {
     // Tests the split: files cargo reads to make a freshness decision
-    // (`dep-*`, `lib-*`, `bin-*`, `output-*`, `invoked.timestamp`) are
-    // kept; everything else in `.fingerprint/<crate>/` is dropped.
+    // (`dep-*`, `lib-*`, `bin-*`, `output-*`, `build-script-*`,
+    // `run-build-script-*`, `invoked.timestamp`, and their `.json`
+    // companions -- soldr#1564) are kept; everything else in
+    // `.fingerprint/<crate>/` is dropped.
     let dir = tempfile::tempdir().unwrap();
     let target = dir.path().join("target").join("debug");
     // Meta files (kept):
@@ -237,11 +239,28 @@ fn thin_v2_save_keeps_fingerprint_meta_but_drops_fingerprint_outputs() {
         !kept_paths
             .iter()
             .any(|p| p.ends_with(".fingerprint/serde-abc/serde-abc.json")),
-        "fingerprint output .json must be dropped; got {kept_paths:?}",
+        "fingerprint output .json (no load-bearing prefix) must be dropped; got {kept_paths:?}",
+    );
+    // soldr#1564: `.json` companions of load-bearing prefixes (`bin-*`,
+    // `build-script-*`, `run-build-script-*`, ...) are load-bearing too --
+    // Cargo's Fingerprint::load reads them to make a freshness decision --
+    // and must be RETAINED, not dropped as diagnostic output.
+    assert!(
+        kept_paths
+            .iter()
+            .any(|p| p.ends_with(".fingerprint/serde-abc/bin-serde.json")),
+        "bin-*.json is load-bearing and must be kept; got {kept_paths:?}",
     );
     assert!(
-        !kept_paths.iter().any(|p| p.ends_with(".json")),
-        "all fingerprint diagnostic JSON must be dropped; got {kept_paths:?}",
+        kept_paths
+            .iter()
+            .any(|p| p.ends_with(".fingerprint/serde-abc/build-script-build-script-build.json")),
+        "build-script-*.json is load-bearing and must be kept; got {kept_paths:?}",
+    );
+    assert!(
+        kept_paths.iter().any(|p| p
+            .ends_with(".fingerprint/serde-abc/run-build-script-build-script-build.json")),
+        "run-build-script-*.json is load-bearing and must be kept; got {kept_paths:?}",
     );
     assert!(
         kept_paths.iter().any(|p| p.ends_with("deps/serde-abc.d")),
@@ -317,6 +336,9 @@ fn thin_v2_classifier_recognizes_new_classes() {
             "{name} is a load-bearing Cargo freshness hash",
         );
     }
+    // soldr#1564: `.json` companions of load-bearing prefixes are
+    // themselves load-bearing (Cargo's Fingerprint::load reads them), so
+    // they classify as Meta, not Outputs.
     for name in [
         "build-script-build-script-build.json",
         "run-build-script-build-script-build.json",
@@ -325,8 +347,8 @@ fn thin_v2_classifier_recognizes_new_classes() {
         let path = Path::new("debug/.fingerprint/serde-abc").join(name);
         assert_eq!(
             classify_artifact(&path, RustPlanMode::Thin, true),
-            Some(RustArtifactClass::CargoFingerprintOutputs),
-            "{name} is diagnostic JSON, not a freshness hash",
+            Some(RustArtifactClass::CargoFingerprintMeta),
+            "{name} is a load-bearing Cargo freshness record despite the .json suffix",
         );
     }
     // Legacy (thin_v2 = false) keeps the umbrella class so older


### PR DESCRIPTION
## Context

Discovered downstream in soldr#1564 (soldr#1527 round 3). `is_fingerprint_meta_file()` in `crates/zccache-artifact/src/rust_plan/selection.rs` rejected every `.fingerprint/<unit>/*.json` file outright before checking any prefix, on the assumption those are human-readable diagnostics. In reality Cargo's `Fingerprint::load()` reads exactly `lib-*.json` / `bin-*.json` / `build-script-*.json` / `run-build-script-*.json` to reconstruct the serialized fingerprint — dropping them means Cargo can never mark a restored unit Fresh; every fresh-target thin-v2 restore forces a full recompile regardless of how much output was actually restored.

## Fix

Strip a `.json` suffix before matching the existing load-bearing prefixes (`dep-`, `output-`, `lib-`, `bin-`, `build-script-`, `run-build-script-`, `invoked.timestamp`), so `<stem>.json` classifies identically to `<stem>`. Files with no matching prefix (e.g. `<pkg>-<hash>.json` matching the fingerprint dir's own name) still classify as diagnostic output and stay dropped.

## Tests (RED → GREEN)

Confirmed RED by stashing only the classifier fix: `thin_v2_classifier_recognizes_new_classes` and `thin_v2_save_keeps_fingerprint_meta_but_drops_fingerprint_outputs` failed, exactly reproducing the downstream bug. Restored the fix: all 5 `thin_v2_*` tests pass; full `zccache-artifact` suite 68/68. Updated two existing tests that had encoded the old (buggy) 'all .json is diagnostic' assumption to instead assert `bin-*.json`/`build-script-*.json`/`run-build-script-*.json` are retained while non-prefix-matching JSON stays dropped.

## Validation

- `cargo test -p zccache-artifact` — 68/68
- `cargo clippy -p zccache-artifact --all-targets -- -D warnings` — clean
- `cargo fmt -p zccache-artifact -- --check` — clean

rlib/rmeta retention is a separate, larger concern (tracked downstream as soldr#1530) and out of scope here — this fix only corrects the fingerprint-JSON misclassification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)