### PR TITLE
fix(rust-plan): classify Cargo underscore build scripts

### DIFF
--- a/crates/zccache-artifact/src/rust_plan/selection.rs
+++ b/crates/zccache-artifact/src/rust_plan/selection.rs
@@ -202,11 +202,16 @@ fn is_fingerprint_meta_file(rel: &Path) -> bool {
     ) && stem.contains('-')
 }
 
-/// True for cargo's compiled build-script binaries. The base name is
-/// `build-script-build`; the `.exe` suffix appears on Windows targets.
+/// True for Cargo's compiled build-script binaries. Cargo creates both a
+/// dash-named alias (`build-script-build`) and an underscore-and-hash binary
+/// (`build_script_build-<hash>`) that its fingerprint records reference.
+/// The `.exe` suffix appears on Windows targets.
 fn is_build_script_build_file(name: &str) -> bool {
     let stem = name.strip_suffix(".exe").unwrap_or(name);
-    stem == "build-script-build" || stem.starts_with("build-script-build-")
+    stem == "build-script-build"
+        || stem.starts_with("build-script-build-")
+        || stem == "build_script_build"
+        || stem.starts_with("build_script_build-")
 }
 
 fn is_likely_proc_macro_dylib(rel: &Path) -> bool {

--- a/crates/zccache-artifact/src/rust_plan/tests/thin_v2.rs
+++ b/crates/zccache-artifact/src/rust_plan/tests/thin_v2.rs
@@ -283,6 +283,22 @@ fn thin_v2_classifier_recognizes_new_classes() {
         Some(RustArtifactClass::BuildScriptBuild),
     );
 
+    // zccache#1047: Cargo also emits an underscore-and-hash binary next to
+    // the dash-named alias. Its fingerprint records this exact path, so it
+    // must survive any plan that retains BuildScriptBuild artifacts. This
+    // name comes from the soldr#1579 Cargo repro rather than an invented
+    // fixture shape.
+    assert_eq!(
+        classify_artifact(
+            Path::new(
+                "debug/build/verify-noop-70a17bdca3084565/build_script_build-70a17bdca3084565"
+            ),
+            RustPlanMode::Thin,
+            true,
+        ),
+        Some(RustArtifactClass::BuildScriptBuild),
+    );
+
     assert_eq!(
         classify_artifact(
             Path::new("debug/deps/libserde-abc.dwo"),


### PR DESCRIPTION
## Summary

- recognize Cargo's underscore-and-hash `build_script_build-<hash>` binary as `BuildScriptBuild`
- preserve the existing dash-named alias and Windows `.exe` handling
- add a RED→GREEN regression using the real artifact name observed by soldr#1579

## Tests

- `soldr cargo test -p zccache-artifact thin_v2_classifier_recognizes_new_classes` (RED before, GREEN after)
- `soldr cargo test -p zccache-artifact` (69 passed, 1 ignored)
- `soldr --no-cache cargo clippy -p zccache-artifact --all-targets -- -D warnings`
- `soldr --no-cache rustfmt --edition 2021 --check` on both changed files

Coordinated with zackees/soldr#1582 and zackees/soldr#1579. This dependent PR must merge before soldr PR #1582 can bump the submodule and validate the end-to-end Fresh/Compiling improvement.

Closes #1047