### PR TITLE
fix(ci): test embedded zccache through soldr

### DIFF
--- a/.github/workflows/perf-rust-cluster.yml
+++ b/.github/workflows/perf-rust-cluster.yml
@@ -6,10 +6,8 @@ name: Perf Cluster Rust
 #     cargo + Swatinem cache + mold linker — no soldr/zccache
 #     wrapping cargo, would be circular with the binaries under
 #     test);
-#   - bench job pins the freshly-built zccache into soldr via
-#     `soldr update-zccache` before scenarios run;
-#   - fail loudly when either source build fails or when
-#     `soldr update-zccache --status` reports the pin is missing.
+#   - soldr's vendored submodule is moved to the zccache commit under
+#     test before soldr is built, so the tested daemon is embedded.
 
 on:
   workflow_dispatch:
@@ -262,6 +260,14 @@ jobs:
           path: soldr-src
           submodules: recursive
 
+      - name: Pin zccache source into soldr build
+        if: steps.gate.outputs.selected == 'true'
+        run: |
+          set -euo pipefail
+          git -C soldr-src/_vender/zccache fetch origin "$GITHUB_SHA"
+          git -C soldr-src/_vender/zccache checkout --detach "$GITHUB_SHA"
+          test "$(git -C soldr-src/_vender/zccache rev-parse HEAD)" = "$GITHUB_SHA"
+
       - name: Install Rust toolchain
         if: steps.gate.outputs.selected == 'true'
         run: |
@@ -296,13 +302,13 @@ jobs:
             echo "| repo | key |"
             echo "| --- | --- |"
             echo "| zccache | zccache-${{ matrix.platform }}-${{ github.sha }}-${bucket} |"
-            echo "| soldr   | soldr-${{ matrix.platform }}-${soldr_sha}-${bucket} |"
+            echo "| soldr   | soldr-${{ matrix.platform }}-${soldr_sha}-${{ github.sha }}-${bucket} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Restore prebuilt zccache binaries
         if: steps.gate.outputs.selected == 'true'
         id: cache_zccache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: staged/zccache
           key: zccache-${{ matrix.platform }}-${{ github.sha }}-${{ steps.keys.outputs.bucket }}
@@ -331,10 +337,10 @@ jobs:
       - name: Restore prebuilt soldr binary
         if: steps.gate.outputs.selected == 'true'
         id: cache_soldr
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: staged/soldr
-          key: soldr-${{ matrix.platform }}-${{ steps.keys.outputs.soldr_sha }}-${{ steps.keys.outputs.bucket }}
+          key: soldr-${{ matrix.platform }}-${{ steps.keys.outputs.soldr_sha }}-${{ github.sha }}-${{ steps.keys.outputs.bucket }}
 
       - name: Restore cargo cache for soldr build
         if: steps.gate.outputs.selected == 'true' && steps.cache_soldr.outputs.cache-hit != 'true'
@@ -436,9 +442,8 @@ jobs:
         if: steps.gate.outputs.selected == 'true'
         run: |
           # Workers need cargo on PATH so soldr cargo can dispatch to
-          # it. Soldr fetches/manages zccache itself on first use, but
-          # we override that below by pinning the freshly-built zccache
-          # via `soldr update-zccache`.
+          # it. The staged soldr already embeds the zccache commit under
+          # test.
           rustup show active-toolchain || rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Install fixture native deps
@@ -464,26 +469,6 @@ jobs:
           mkdir -p "$HOME/.local/bin"
           cp staged/soldr/soldr "$HOME/.local/bin/soldr"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Pin zccache via soldr update-zccache
-        if: steps.gate.outputs.selected == 'true'
-        run: |
-          set -euo pipefail
-          chmod +x staged/zccache/zccache staged/zccache/zccache-daemon staged/zccache/zccache-fp
-          soldr update-zccache "$(pwd)/staged/zccache" --json | tee zccache-pin.json
-          soldr update-zccache --status --json | tee zccache-pin-status.json
-          # `.pinned` was a boolean in the original `update-zccache` subcommand,
-          # but in the current (alias-backed) implementation it's an object
-          # containing `binaries`, `source_kind`, `source_value`, `version`, ...
-          # — or `null` when no pin is in effect. Treat any non-null value as
-          # success; additionally require `source_kind == "path"` so a residual
-          # managed-version pin can't masquerade as a successful local pin.
-          if ! jq -e '.pinned != null and .pinned.source_kind == "path"' \
-              zccache-pin-status.json >/dev/null; then
-            echo "::error::soldr update-zccache reports no local-path pin after pinning"
-            cat zccache-pin-status.json
-            exit 1
-          fi
 
       - name: Verify soldr is the source build
         if: steps.gate.outputs.selected == 'true'

--- a/PERF.md
+++ b/PERF.md
@@ -4,6 +4,8 @@ zccache has one performance workflow today: **`.github/workflows/perf-rust-clust
 
 For the per-scenario design rationale (what each cell proves), see [`perf/README.md`](perf/README.md).
 
+> **Embedded integration update:** soldr now embeds zccache. The cluster checks the zccache commit under test out inside soldr's vendored submodule before building soldr; the historical runtime pin command is no longer used.
+
 ## Setup
 
 No secrets required. Both repos are public; `actions/checkout` reads them with the default `GITHUB_TOKEN`.

--- a/ci/tests/test_perf_rust_cluster_embedded.py
+++ b/ci/tests/test_perf_rust_cluster_embedded.py
@@ -1,0 +1,46 @@
+"""Regression tests for the embedded-zccache perf-cluster bootstrap."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "perf-rust-cluster.yml"
+
+
+def workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_perf_cluster_builds_soldr_with_the_zccache_commit_under_test() -> None:
+    workflow = workflow_text()
+    pin_step_name = "Pin zccache source into soldr build"
+    pin_step = workflow.split(f"- name: {pin_step_name}", 1)[1].split(
+        "\n      - name:", 1
+    )[0]
+
+    assert 'git -C soldr-src/_vender/zccache fetch origin "$GITHUB_SHA"' in pin_step
+    assert (
+        'git -C soldr-src/_vender/zccache checkout --detach "$GITHUB_SHA"'
+        in pin_step
+    )
+    assert 'rev-parse HEAD)" = "$GITHUB_SHA"' in pin_step
+    assert workflow.index(pin_step_name) < workflow.index("Build soldr (release)")
+    assert "${{ github.sha }}" in workflow.split("key: soldr-", 1)[1].splitlines()[0]
+
+
+def test_perf_cluster_does_not_use_removed_runtime_zccache_pinning() -> None:
+    workflow = workflow_text()
+
+    assert "soldr update-zccache" not in workflow
+
+
+def test_perf_cluster_pins_cache_action_to_an_immutable_commit() -> None:
+    workflow = workflow_text()
+    expected_sha = "0057852bfaa89a56745cba8c7296529d2fc39830"
+    cache_refs = [
+        line.split("actions/cache@", 1)[1].split()[0]
+        for line in workflow.splitlines()
+        if "uses: actions/cache@" in line
+    ]
+
+    assert cache_refs == [expected_sha, expected_sha]

--- a/crates/zccache-artifact/src/rust_plan/local.rs
+++ b/crates/zccache-artifact/src/rust_plan/local.rs
@@ -416,13 +416,12 @@ fn restore_one_artifact(
         }
     }
     if dst.exists() && !allow_overwrite_existing {
-        let matches_manifest = std::fs::metadata(&dst)
-            .is_ok_and(|metadata| {
-                metadata.len() == artifact.size
-                    && zccache_hash::hash_file(&dst)
-                        .map(|hash| hash.to_hex() == artifact.content_hash)
-                        .unwrap_or(false)
-            });
+        let matches_manifest = std::fs::metadata(&dst).is_ok_and(|metadata| {
+            metadata.len() == artifact.size
+                && zccache_hash::hash_file(&dst)
+                    .map(|hash| hash.to_hex() == artifact.content_hash)
+                    .unwrap_or(false)
+        });
         return RestoreArtifactOutcome::Skipped {
             path,
             reason: if matches_manifest {

--- a/crates/zccache-artifact/src/rust_plan/tests/restore_errors.rs
+++ b/crates/zccache-artifact/src/rust_plan/tests/restore_errors.rs
@@ -111,7 +111,10 @@ fn restore_overlays_missing_files_without_overwriting_existing_conflicts() {
 
     assert_eq!(std::fs::read(&existing).unwrap(), b"local-conflict");
     assert_eq!(std::fs::read(&missing).unwrap(), missing_original);
-    assert_eq!(restored.skipped_reasons.get("destination_conflict"), Some(&1));
+    assert_eq!(
+        restored.skipped_reasons.get("destination_conflict"),
+        Some(&1)
+    );
     assert_eq!(restored.restored_file_count, 1);
 }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -117,3 +117,13 @@ Issue: https://github.com/zackees/zccache/issues/1039
 - [ ] Add perf regression gate and user/architecture/feature-matrix docs.
 - [ ] Validate on Windows 10 and Linux Docker, then run repo lint/test/review gates.
 - [ ] Push one PR with RED evidence, wait for GHA/review, fix, squash merge, verify issue closure.
+
+# Fix-forward after #1049 and soldr embedded-zccache integration
+
+- [x] Capture RED for the obsolete `soldr update-zccache` perf bootstrap.
+- [x] Build soldr with the current zccache commit checked out in its vendored submodule.
+- [x] Key the staged soldr binary by both the soldr and zccache commits.
+- [x] Remove the obsolete runtime pin step.
+- [x] Format the #1049 Rust changes and update the performance documentation.
+- [x] Run focused tests, formatting, clippy, and review gates.
+- [ ] Merge upstream, bump soldr's submodule, validate, and merge downstream.


### PR DESCRIPTION
## Summary
- build soldr with the exact zccache commit under test checked out in its vendored submodule
- key the staged soldr binary by both repository SHAs and remove the deleted runtime pin command
- pin actions/cache to v4.3.0's immutable commit
- format the rust-plan overlay changes merged in #1049 and add workflow regression coverage

## Validation
- `uv run --no-project pytest ci/tests/test_perf_rust_cluster_embedded.py -q` — 3 passed
- `soldr --no-cache cargo test -p zccache-artifact --lib` — 72 passed, 1 ignored
- `soldr --no-cache cargo clippy -p zccache-artifact --all-targets -- -D warnings` — passed
- `soldr --no-cache cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- pre-push Rust, Python, CI, and docs review — clean
- broad Python sweep — 192 passed, 1 skipped, plus one pre-existing release-test drift on main
- full `./test` compiled and began running the workspace suite; local five-minute harness cutoff closed its output pipe before completion

Coordinated with zackees/soldr integration PR to follow after this dependency merges.

Coordinated with zackees/soldr#1589.