### PR TITLE
fix(perf): run local scenarios with embedded zccache

### DIFF
--- a/PERF.md
+++ b/PERF.md
@@ -241,18 +241,16 @@ uv run python ci/perf_local.py                      # cold-tar-untar-warm × med
 uv run python ci/perf_local.py --scenario worktree-share
 uv run python ci/perf_local.py --fixture sqlite-link
 uv run python ci/perf_local.py --rebuild-images     # force docker build of all 3 images
-uv run python ci/perf_local.py --skip-soldr-build   # fast iteration after zccache-only change
 ```
 
 Architecture:
 
 - **`zccache-perf-soldr-builder`** — rust:alpine + musl-dev. Builds the
   static `soldr` binary at `.perf-local/binaries/soldr/soldr`.
-- **`zccache-perf-zccache-builder`** — rust:bookworm. Builds the
-  `zccache` trio at `.perf-local/binaries/zccache/`.
-- **`zccache-perf-runner`** — rust:bookworm + bash/tar/zstd/jq. Mounts
-  both binary dirs + the zccache source for `perf/scenarios/`, runs the
-  scenario, writes `result.json` + cache reports under
+- **`zccache-perf-zccache-builder`** — rust:bookworm development image
+  retained for the local test, lint, formatting, and shell subcommands.
+- **`zccache-perf-runner`** — runs scenarios with soldr embedding this
+  checkout's committed zccache HEAD and writes reports under
   `.perf-local/results/<scenario>/`.
 
 Source code is **volume-mounted** into the builder containers, and

--- a/ci/docker/README.md
+++ b/ci/docker/README.md
@@ -21,8 +21,8 @@ crates changed.
 | Image tag                          | Built from                  | Role                                                                                                |
 |------------------------------------|-----------------------------|-----------------------------------------------------------------------------------------------------|
 | `zccache-perf-soldr-builder`       | `soldr-builder.Dockerfile`  | rust:alpine + musl-dev. Volume-mount soldr source at `/src`, persistent `/target`, drop static `soldr` binary at `/out/soldr`. |
-| `zccache-perf-zccache-builder`     | `zccache-builder.Dockerfile`| rust:bookworm. Volume-mount zccache source at `/src`, persistent `/target`, drop `zccache`/`zccache-daemon`/`zccache-fp` at `/out/`. |
-| `zccache-perf-runner`              | `runner.Dockerfile`         | rust:bookworm + bash/tar/zstd/jq. Mounts the two `/out/` dirs above + the zccache source for scenario scripts + a host-side results dir. Runs `soldr update-zccache` then the scenario script. |
+| `zccache-perf-zccache-builder`     | `zccache-builder.Dockerfile`| rust:bookworm development image used by the local test, lint, and shell subcommands. |
+| `zccache-perf-runner`              | `runner.Dockerfile`         | Runs scenarios with soldr embedding this checkout's committed zccache HEAD. |
 
 ## Volume conventions
 
@@ -38,11 +38,7 @@ All volumes are managed by the orchestrator. The layout under `<repo>/.perf-loca
 │   ├── soldr/                  # so no-op rebuilds don't re-fetch ~175 MiB per run
 │   └── zccache/
 ├── binaries/
-│   ├── soldr/soldr             # static soldr binary produced by builder
-│   └── zccache/                # zccache trio produced by builder
-│       ├── zccache
-│       ├── zccache-daemon
-│       └── zccache-fp
+│   └── soldr/soldr             # static soldr binary with zccache embedded
 └── results/
     └── <scenario>/             # result.json + cache reports per run
 ```

--- a/ci/docker/perf_entrypoint.sh
+++ b/ci/docker/perf_entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Runs inside the zccache-perf-runner container. Reproduces the per-cell
 # bench job from .github/workflows/perf-rust-cluster.yml end-to-end on a
-# pre-built pair of (soldr, zccache trio) binaries.
+# pre-built soldr binary with this checkout's zccache embedded.
 #
 # Env contract (set by ci/perf_local.py):
 #   SCENARIO  - cold-tar-untar-warm | worktree-share | touch-no-change
@@ -9,7 +9,6 @@
 #
 # Mount contract (all required, fail loud if missing):
 #   /usr/local/bin/soldr    - the soldr binary (mode +x)
-#   /zccache-bin/           - {zccache,zccache-daemon,zccache-fp}
 #   /zccache-src/           - the zccache repo (read-only)
 #   /results/               - host-writable; result.json + reports land here
 
@@ -34,38 +33,12 @@ require_mount() {
 require_env SCENARIO
 require_env FIXTURE
 require_mount /usr/local/bin/soldr file
-require_mount /zccache-bin dir
 require_mount /zccache-src dir
 require_mount /results dir
-
-# Confirm binaries are present + executable. The error here is friendlier
-# than the later soldr-side failure if a binary is missing.
-for bin in zccache zccache-daemon zccache-fp; do
-    if [[ ! -x "/zccache-bin/${bin}" ]]; then
-        echo "ERROR: /zccache-bin/${bin} missing or not executable" >&2
-        exit 2
-    fi
-done
 
 # The soldr binary is mounted read-only from the host's binaries/ dir.
 # The builder image set +x on it at build time so no chmod is needed
 # here (and chmod would fail on a read-only mount).
-# `soldr update-zccache` expects a writable copy under its managed dir.
-# We point it at /zccache-bin (read-only mount is fine; soldr copies out).
-soldr update-zccache /zccache-bin --json | tee /results/zccache-pin.json
-soldr update-zccache --status --json | tee /results/zccache-pin-status.json
-
-# Same sanity check as .github/workflows/perf-rust-cluster.yml step
-# "Pin zccache via soldr update-zccache". `.pinned` is an object in the
-# current alias-backed subcommand; non-null + source_kind="path" means a
-# local-path pin is in effect.
-if ! jq -e '.pinned != null and .pinned.source_kind == "path"' \
-        /results/zccache-pin-status.json >/dev/null; then
-    echo "ERROR: soldr update-zccache reports no local-path pin after pinning" >&2
-    cat /results/zccache-pin-status.json >&2
-    exit 1
-fi
-
 # Work dir for the fixture extraction. The scenario scripts write under
 # this dir and expect to own it. We use /tmp/perf-work so the persistent
 # /results volume isn't polluted with intermediate state.
@@ -105,6 +78,10 @@ copy_if_exists "${scenario_root}/cold-shutdown.json"
 copy_if_exists "${scenario_root}/warm-shutdown.json"
 copy_if_exists "${scenario_root}/save-report.json"
 copy_if_exists "${scenario_root}/load-report.json"
+copy_if_exists "${scenario_root}/cache-warm/daemon-spawn.log"
+find "${scenario_root}/cache-warm/cache/soldr-daemon" -maxdepth 3 \
+    -printf '%y %p -> %l\n' >"${scenario_root}/warm-daemon-files.txt" 2>/dev/null || true
+copy_if_exists "${scenario_root}/warm-daemon-files.txt"
 copy_if_exists "${scenario_root}/cold-zccache-logs"
 copy_if_exists "${scenario_root}/warm-zccache-logs"
 copy_if_exists "${scenario_root}/rss-${SCENARIO}.csv"

--- a/ci/docker/runner.Dockerfile
+++ b/ci/docker/runner.Dockerfile
@@ -7,7 +7,6 @@
 # the base is rust:1.94.1, but the runner doesn't build anything itself).
 # Instead it mounts in:
 #   - the soldr binary produced by soldr-builder
-#   - the zccache trio produced by zccache-builder
 #   - the zccache source (read-only, for perf/scenarios/, perf/lib/,
 #     perf/fixtures/)
 #   - a results dir on the host
@@ -23,7 +22,6 @@
 #
 #   docker run --rm \
 #     -v <repo>/.perf-local/binaries/soldr/soldr:/usr/local/bin/soldr:ro \
-#     -v <repo>/.perf-local/binaries/zccache:/zccache-bin:ro \
 #     -v <repo>:/zccache-src:ro \
 #     -v <repo>/.perf-local/results/<scenario>:/results \
 #     -e SCENARIO=cold-tar-untar-warm \
@@ -47,11 +45,9 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # The entrypoint expects all the above mounts to be in place. It then:
-#   1. soldr update-zccache /zccache-bin  (pin the freshly-built zccache)
-#   2. soldr update-zccache --status --json  (sanity-verify pin)
-#   3. bash perf/lib/extract.sh $FIXTURE $WORK_DIR
-#   4. bash perf/scenarios/$SCENARIO/run.sh $WORK_DIR/$FIXTURE
-#   5. Copy result.json + *-cache-report.json + *-zccache-logs/ to /results
+#   1. bash perf/lib/extract.sh $FIXTURE $WORK_DIR
+#   2. bash perf/scenarios/$SCENARIO/run.sh $WORK_DIR/$FIXTURE
+#   3. Copy result.json + *-cache-report.json + *-zccache-logs/ to /results
 COPY perf_entrypoint.sh /usr/local/bin/perf_entrypoint.sh
 RUN chmod +x /usr/local/bin/perf_entrypoint.sh
 

--- a/ci/perf_local.py
+++ b/ci/perf_local.py
@@ -6,11 +6,10 @@ Three Docker images (see `ci/docker/README.md`) collaborate:
 1. `zccache-perf-soldr-builder` — rust:alpine + musl-dev. Volume-mounts a
    local soldr checkout, builds a static `soldr` binary into a host-side
    `binaries/soldr/` dir.
-2. `zccache-perf-zccache-builder` — rust:bookworm. Volume-mounts the
-   zccache repo, builds the `zccache` trio into `binaries/zccache/`.
-3. `zccache-perf-runner` — rust:bookworm + bash/tar/zstd/jq. Mounts both
-   binary dirs + the zccache source for `perf/scenarios/`, runs the
-   scenario, writes result.json + cache reports back to host.
+2. `zccache-perf-zccache-builder` — the warmed development image used by
+   local test, lint, formatting, and shell subcommands.
+3. `zccache-perf-runner` — mounts soldr with this checkout's committed
+   zccache HEAD embedded, runs a scenario, and writes reports to the host.
 
 Build state — cargo `/target` and `CARGO_HOME` — lives in named Docker
 volumes (`zccache-perf-target-{soldr,zccache}` and
@@ -160,30 +159,101 @@ def image_exists(tag: str) -> bool:
 
 def build_image(tag: str, dockerfile: Path, context: Path, *, force: bool) -> None:
     if not force and image_exists(tag):
-        print(f"[perf-local] image {tag} already built, skipping (use --rebuild-images to force)")
+        print(
+            f"[perf-local] image {tag} already built, skipping (use --rebuild-images to force)"
+        )
         return
     print(f"[perf-local] building image {tag} from {dockerfile.relative_to(REPO_ROOT)}")
-    run([
-        "docker", "build",
-        "-t", tag,
-        "-f", str(dockerfile),
-        str(context),
-    ])
+    run(
+        [
+            "docker",
+            "build",
+            "-t",
+            tag,
+            "-f",
+            str(dockerfile),
+            str(context),
+        ]
+    )
 
 
 def build_all_images(*, force: bool) -> None:
-    build_image(IMAGE_SOLDR,   DOCKER_DIR / "soldr-builder.Dockerfile",   DOCKER_DIR, force=force)
-    build_image(IMAGE_ZCCACHE, DOCKER_DIR / "zccache-builder.Dockerfile", DOCKER_DIR, force=force)
-    build_image(IMAGE_RUNNER,  DOCKER_DIR / "runner.Dockerfile",          DOCKER_DIR, force=force)
+    build_image(
+        IMAGE_SOLDR, DOCKER_DIR / "soldr-builder.Dockerfile", DOCKER_DIR, force=force
+    )
+    build_image(
+        IMAGE_ZCCACHE,
+        DOCKER_DIR / "zccache-builder.Dockerfile",
+        DOCKER_DIR,
+        force=force,
+    )
+    build_image(IMAGE_RUNNER, DOCKER_DIR / "runner.Dockerfile", DOCKER_DIR, force=force)
 
 
 # ---------------------------------------------------------------------------
 # Source preparation
 
 
+def git_head(repo: Path) -> str:
+    """Return the exact commit checked out in ``repo``."""
+    return subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def git_is_dirty(repo: Path) -> bool:
+    """True when ``repo`` has tracked or untracked working-tree changes."""
+    return bool(
+        subprocess.run(
+            ["git", "-C", str(repo), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    )
+
+
+def pin_soldr_zccache_source(soldr_src: Path) -> None:
+    """Build soldr with the zccache checkout under test embedded in it.
+
+    soldr consumes zccache as a git submodule, so cloning soldr alone is no
+    longer enough. Mirror the Perf Cluster workflow: materialize all soldr
+    submodules, then move its zccache submodule to this checkout's exact SHA.
+    """
+    if git_is_dirty(REPO_ROOT):
+        raise RuntimeError(
+            "the zccache checkout is dirty; commit or stash changes before running "
+            "perf_local.py so embedded source cannot differ from the requested run"
+        )
+    zccache_sha = git_head(REPO_ROOT)
+    vendored = soldr_src / "_vender" / "zccache"
+    run(
+        [
+            "git",
+            "-C",
+            str(soldr_src),
+            "submodule",
+            "update",
+            "--init",
+            "--recursive",
+        ]
+    )
+    # Fetch locally so unpublished commits can be measured before push.
+    run(["git", "-C", str(vendored), "fetch", str(REPO_ROOT), zccache_sha])
+    run(["git", "-C", str(vendored), "checkout", "--detach", zccache_sha])
+    actual_sha = git_head(vendored)
+    if actual_sha != zccache_sha:
+        raise RuntimeError(
+            "failed to pin soldr's embedded zccache: "
+            f"expected {zccache_sha}, found {actual_sha}"
+        )
+
+
 def ensure_soldr_source() -> Path:
-    """Shallow-clone soldr's main HEAD into .perf-local/soldr-src/ (or refresh
-    if already there). Returns the checkout path."""
+    """Refresh soldr main and embed this checkout's committed zccache HEAD."""
     src = PERF_LOCAL / "soldr-src"
     if (src / ".git").is_dir():
         print(f"[perf-local] refreshing soldr source at {src}")
@@ -192,11 +262,20 @@ def ensure_soldr_source() -> Path:
     else:
         src.mkdir(parents=True, exist_ok=True)
         print(f"[perf-local] cloning soldr@{SOLDR_REF} -> {src}")
-        run(["git", "clone", "--depth", "1", "--branch", SOLDR_REF, SOLDR_REPO, str(src)])
-    sha = subprocess.run(
-        ["git", "-C", str(src), "rev-parse", "HEAD"],
-        capture_output=True, text=True, check=True,
-    ).stdout.strip()
+        run(
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                SOLDR_REF,
+                SOLDR_REPO,
+                str(src),
+            ]
+        )
+    pin_soldr_zccache_source(src)
+    sha = git_head(src)
     print(f"[perf-local] soldr-src now at {sha[:12]}")
     return src
 
@@ -208,10 +287,9 @@ def ensure_volume_dirs() -> dict[str, Path]:
     we keep host directories only for things that need to be visible from
     the host file system."""
     layout = {
-        "soldr_src":         PERF_LOCAL / "soldr-src",
-        "bin_soldr":         PERF_LOCAL / "binaries" / "soldr",
-        "bin_zccache":       PERF_LOCAL / "binaries" / "zccache",
-        "results":           PERF_LOCAL / "results",
+        "soldr_src": PERF_LOCAL / "soldr-src",
+        "bin_soldr": PERF_LOCAL / "binaries" / "soldr",
+        "results": PERF_LOCAL / "results",
     }
     for path in layout.values():
         path.mkdir(parents=True, exist_ok=True)
@@ -232,26 +310,22 @@ def host_volume(host: Path, container: str, mode: str = "") -> str:
 
 def run_soldr_builder(layout: dict[str, Path]) -> None:
     print(f"[perf-local] building soldr binary -> {layout['bin_soldr']}")
-    run([
-        "docker", "run", "--rm",
-        "-v", host_volume(layout["soldr_src"],        "/src", "ro"),
-        "-v", f"{VOLUME_TARGET_SOLDR}:/target",
-        "-v", f"{VOLUME_CARGO_HOME_SOLDR}:/cargo-home",
-        "-v", host_volume(layout["bin_soldr"],        "/out"),
-        IMAGE_SOLDR,
-    ])
-
-
-def run_zccache_builder(layout: dict[str, Path]) -> None:
-    print(f"[perf-local] building zccache trio -> {layout['bin_zccache']}")
-    run([
-        "docker", "run", "--rm",
-        "-v", host_volume(REPO_ROOT,                    "/src", "ro"),
-        "-v", f"{VOLUME_TARGET_ZCCACHE}:/target",
-        "-v", f"{VOLUME_CARGO_HOME_ZCCACHE}:/cargo-home",
-        "-v", host_volume(layout["bin_zccache"],        "/out"),
-        IMAGE_ZCCACHE,
-    ])
+    run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            host_volume(layout["soldr_src"], "/src", "ro"),
+            "-v",
+            f"{VOLUME_TARGET_SOLDR}:/target",
+            "-v",
+            f"{VOLUME_CARGO_HOME_SOLDR}:/cargo-home",
+            "-v",
+            host_volume(layout["bin_soldr"], "/out"),
+            IMAGE_SOLDR,
+        ]
+    )
 
 
 def run_scenario(layout: dict[str, Path], scenario: str, fixture: str) -> Path:
@@ -281,17 +355,25 @@ def run_scenario(layout: dict[str, Path], scenario: str, fixture: str) -> Path:
     env_flags: list[str] = []
     for k, v in pass_through_env:
         env_flags.extend(["-e", f"{k}={v}"])
-    run([
-        "docker", "run", "--rm",
-        "-v", host_volume(soldr_bin,              "/usr/local/bin/soldr", "ro"),
-        "-v", host_volume(layout["bin_zccache"],  "/zccache-bin",         "ro"),
-        "-v", host_volume(REPO_ROOT,              "/zccache-src",         "ro"),
-        "-v", host_volume(results_dir,            "/results"),
-        "-e", f"SCENARIO={scenario}",
-        "-e", f"FIXTURE={fixture}",
-        *env_flags,
-        IMAGE_RUNNER,
-    ])
+    run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            host_volume(soldr_bin, "/usr/local/bin/soldr", "ro"),
+            "-v",
+            host_volume(REPO_ROOT, "/zccache-src", "ro"),
+            "-v",
+            host_volume(results_dir, "/results"),
+            "-e",
+            f"SCENARIO={scenario}",
+            "-e",
+            f"FIXTURE={fixture}",
+            *env_flags,
+            IMAGE_RUNNER,
+        ]
+    )
     elapsed = time.monotonic() - start
     print(f"[perf-local] scenario completed in {elapsed:.1f}s")
     return results_dir
@@ -350,7 +432,9 @@ def render_summary(results_dir: Path, scenario: str, fixture: str) -> int:
     cold_ms = result.get(cold_key)
     warm_ms = result.get(warm_key)
     if cold_ms is None or warm_ms is None or warm_ms <= 0:
-        print(f"[perf-local] FAIL: bad timing in result.json (cold={cold_ms} warm={warm_ms})")
+        print(
+            f"[perf-local] FAIL: bad timing in result.json (cold={cold_ms} warm={warm_ms})"
+        )
         return 1
     speedup = cold_ms / warm_ms
 
@@ -463,19 +547,39 @@ def render_phase_breakdown(phase_profile) -> None:
     src_ns = int(phase_profile.get("hash_source_ns") or 0)
     hdr_ns = int(phase_profile.get("hash_headers_ns") or 0)
     rows = [
-        ("parse_args",                  int(phase_profile.get("parse_args_ns") or 0),           hit_count),
-        ("build_context",               int(phase_profile.get("build_context_ns") or 0),         hit_count),
-        ("metadata cache (source+hdrs)", src_ns + hdr_ns,                                        hit_count),
-        ("depgraph_check",              int(phase_profile.get("depgraph_check_ns") or 0),        hit_count),
-        ("request_cache_lookup",        int(phase_profile.get("request_cache_lookup_ns") or 0),  hit_count),
-        ("cross_root_validate",         int(phase_profile.get("cross_root_validate_ns") or 0),   hit_count),
-        ("artifact_lookup",             int(phase_profile.get("artifact_lookup_ns") or 0),       hit_count),
-        ("write_output (materialize)",  int(phase_profile.get("write_output_ns") or 0),          hit_count),
-        ("bookkeeping",                 int(phase_profile.get("bookkeeping_ns") or 0),           hit_count),
-        ("compiler_exec",               int(phase_profile.get("compiler_exec_ns") or 0),         miss_count),
-        ("include_scan",                int(phase_profile.get("include_scan_ns") or 0),          miss_count),
-        ("hash_all",                    int(phase_profile.get("hash_all_ns") or 0),              miss_count),
-        ("artifact_store",              int(phase_profile.get("artifact_store_ns") or 0),        miss_count),
+        ("parse_args", int(phase_profile.get("parse_args_ns") or 0), hit_count),
+        ("build_context", int(phase_profile.get("build_context_ns") or 0), hit_count),
+        ("metadata cache (source+hdrs)", src_ns + hdr_ns, hit_count),
+        ("depgraph_check", int(phase_profile.get("depgraph_check_ns") or 0), hit_count),
+        (
+            "request_cache_lookup",
+            int(phase_profile.get("request_cache_lookup_ns") or 0),
+            hit_count,
+        ),
+        (
+            "cross_root_validate",
+            int(phase_profile.get("cross_root_validate_ns") or 0),
+            hit_count,
+        ),
+        (
+            "artifact_lookup",
+            int(phase_profile.get("artifact_lookup_ns") or 0),
+            hit_count,
+        ),
+        (
+            "write_output (materialize)",
+            int(phase_profile.get("write_output_ns") or 0),
+            hit_count,
+        ),
+        ("bookkeeping", int(phase_profile.get("bookkeeping_ns") or 0), hit_count),
+        ("compiler_exec", int(phase_profile.get("compiler_exec_ns") or 0), miss_count),
+        ("include_scan", int(phase_profile.get("include_scan_ns") or 0), miss_count),
+        ("hash_all", int(phase_profile.get("hash_all_ns") or 0), miss_count),
+        (
+            "artifact_store",
+            int(phase_profile.get("artifact_store_ns") or 0),
+            miss_count,
+        ),
     ]
     rows.sort(key=lambda r: r[1], reverse=True)
 
@@ -540,11 +644,16 @@ def build_zccache_docker_cmd(
     if interactive:
         cmd.append("-it")
     cmd += [
-        "-v", host_volume(REPO_ROOT, "/src", src_mode),
-        "-v", f"{VOLUME_TARGET_ZCCACHE}:/target",
-        "-v", f"{VOLUME_CARGO_HOME_ZCCACHE}:/cargo-home",
-        "-v", f"{VOLUME_RUST_STATE}:/root/.rustup",
-        "-w", "/src",
+        "-v",
+        host_volume(REPO_ROOT, "/src", src_mode),
+        "-v",
+        f"{VOLUME_TARGET_ZCCACHE}:/target",
+        "-v",
+        f"{VOLUME_CARGO_HOME_ZCCACHE}:/cargo-home",
+        "-v",
+        f"{VOLUME_RUST_STATE}:/root/.rustup",
+        "-w",
+        "/src",
     ]
     if bash_script is not None:
         cmd += ["--entrypoint", "/bin/bash", IMAGE_ZCCACHE, "-c", bash_script]
@@ -721,16 +830,6 @@ def main() -> int:
         action="store_true",
         help="Force a rebuild of all three Docker images even if cached.",
     )
-    parser.add_argument(
-        "--skip-soldr-build",
-        action="store_true",
-        help="Skip the soldr-builder run (reuse an existing binary). Useful for fast iteration after a zccache-only change.",
-    )
-    parser.add_argument(
-        "--skip-zccache-build",
-        action="store_true",
-        help="Skip the zccache-builder run (reuse an existing binary). Useful for fast iteration when only the scenario script changed.",
-    )
     args = parser.parse_args()
 
     if not docker_available():
@@ -748,12 +847,8 @@ def main() -> int:
     layout = ensure_volume_dirs()
     build_all_images(force=args.rebuild_images)
 
-    if not args.skip_soldr_build:
-        ensure_soldr_source()
-        run_soldr_builder(layout)
-
-    if not args.skip_zccache_build:
-        run_zccache_builder(layout)
+    ensure_soldr_source()
+    run_soldr_builder(layout)
 
     results_dir = run_scenario(layout, args.scenario, args.fixture)
     return render_summary(results_dir, args.scenario, args.fixture)

--- a/ci/tests/test_perf_local.py
+++ b/ci/tests/test_perf_local.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 from pathlib import Path
 
 
@@ -24,6 +25,66 @@ def _load_perf_local():
 
 
 perf_local = _load_perf_local()
+
+
+def test_pin_soldr_zccache_source_initializes_and_pins_current_checkout(
+    tmp_path, monkeypatch
+):
+    soldr_src = tmp_path / "soldr-src"
+    commands = []
+
+    monkeypatch.setattr(
+        perf_local,
+        "run",
+        lambda command, **_kwargs: commands.append(command)
+        or subprocess.CompletedProcess(command, 0),
+    )
+    monkeypatch.setattr(perf_local, "git_head", lambda _repo: "abc123")
+    monkeypatch.setattr(perf_local, "git_is_dirty", lambda _repo: False)
+
+    perf_local.pin_soldr_zccache_source(soldr_src)
+
+    vendored = soldr_src / "_vender" / "zccache"
+    assert commands == [
+        [
+            "git",
+            "-C",
+            str(soldr_src),
+            "submodule",
+            "update",
+            "--init",
+            "--recursive",
+        ],
+        ["git", "-C", str(vendored), "fetch", str(perf_local.REPO_ROOT), "abc123"],
+        ["git", "-C", str(vendored), "checkout", "--detach", "abc123"],
+    ]
+
+
+def test_pin_soldr_zccache_source_rejects_wrong_checkout(tmp_path, monkeypatch):
+    soldr_src = tmp_path / "soldr-src"
+    heads = iter(["abc123", "def456"])
+    monkeypatch.setattr(perf_local, "run", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(perf_local, "git_head", lambda _repo: next(heads))
+    monkeypatch.setattr(perf_local, "git_is_dirty", lambda _repo: False)
+
+    try:
+        perf_local.pin_soldr_zccache_source(soldr_src)
+    except RuntimeError as error:
+        assert "expected abc123" in str(error)
+        assert "found def456" in str(error)
+    else:
+        raise AssertionError("mismatched embedded zccache checkout must fail")
+
+
+def test_pin_soldr_zccache_source_rejects_dirty_checkout(tmp_path, monkeypatch):
+    monkeypatch.setattr(perf_local, "git_is_dirty", lambda _repo: True)
+
+    try:
+        perf_local.pin_soldr_zccache_source(tmp_path / "soldr-src")
+    except RuntimeError as error:
+        assert "commit or stash" in str(error)
+    else:
+        raise AssertionError("dirty zccache source must not be silently ignored")
 
 
 # ── fmt_ms ───────────────────────────────────────────────────────────────────
@@ -155,7 +216,11 @@ def _write_scenario_results(
     (results_dir / "result.json").write_text(json.dumps(result))
 
     if cache_report is not None:
-        report_name = "b-cache-report.json" if scenario == "worktree-share" else "warm-cache-report.json"
+        report_name = (
+            "b-cache-report.json"
+            if scenario == "worktree-share"
+            else "warm-cache-report.json"
+        )
         (results_dir / report_name).write_text(
             json.dumps({"last_session": cache_report})
         )
@@ -330,22 +395,22 @@ def _phase_profile_with_writeoutput_dominant() -> dict:
     return {
         "hit_count": 100,
         "miss_count": 5,
-        "parse_args_ns":           5_000_000,    # 5ms
-        "build_context_ns":       12_000_000,    # 12ms
-        "hash_source_ns":         80_000_000,    # 80ms
-        "hash_headers_ns":        76_000_000,    # 76ms — sums w/ source to 156ms
-        "depgraph_check_ns":     198_000_000,    # 198ms
-        "request_cache_lookup_ns": 4_000_000,    # 4ms
-        "cross_root_validate_ns":  8_000_000,
-        "artifact_lookup_ns":     42_000_000,    # 42ms
-        "write_output_ns":       312_000_000,    # 312ms — dominant
-        "bookkeeping_ns":          3_000_000,
-        "total_hit_ns":          740_000_000,
-        "compiler_exec_ns":      900_000_000,    # 900ms across 5 misses
-        "include_scan_ns":        25_000_000,
-        "hash_all_ns":            12_000_000,
-        "artifact_store_ns":      18_000_000,
-        "total_miss_ns":         955_000_000,
+        "parse_args_ns": 5_000_000,  # 5ms
+        "build_context_ns": 12_000_000,  # 12ms
+        "hash_source_ns": 80_000_000,  # 80ms
+        "hash_headers_ns": 76_000_000,  # 76ms — sums w/ source to 156ms
+        "depgraph_check_ns": 198_000_000,  # 198ms
+        "request_cache_lookup_ns": 4_000_000,  # 4ms
+        "cross_root_validate_ns": 8_000_000,
+        "artifact_lookup_ns": 42_000_000,  # 42ms
+        "write_output_ns": 312_000_000,  # 312ms — dominant
+        "bookkeeping_ns": 3_000_000,
+        "total_hit_ns": 740_000_000,
+        "compiler_exec_ns": 900_000_000,  # 900ms across 5 misses
+        "include_scan_ns": 25_000_000,
+        "hash_all_ns": 12_000_000,
+        "artifact_store_ns": 18_000_000,
+        "total_miss_ns": 955_000_000,
     }
 
 
@@ -392,7 +457,8 @@ def test_render_summary_includes_phase_breakdown(tmp_path, capsys):
     # largest total (compiler_exec at 900ms beats write_output at 312ms).
     breakdown = out.split("Phase breakdown", 1)[1]
     first_data_row = next(
-        line for line in breakdown.splitlines()
+        line
+        for line in breakdown.splitlines()
         if line.startswith("| ") and "Phase" not in line and "---" not in line
     )
     assert "compiler_exec" in first_data_row

--- a/ci/tests/test_perf_rust_cluster_embedded.py
+++ b/ci/tests/test_perf_rust_cluster_embedded.py
@@ -5,6 +5,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "perf-rust-cluster.yml"
+LOCAL_ENTRYPOINT = ROOT / "ci" / "docker" / "perf_entrypoint.sh"
+LOCAL_RUNNER = ROOT / "ci" / "docker" / "runner.Dockerfile"
+LOCAL_ORCHESTRATOR = ROOT / "ci" / "perf_local.py"
 
 
 def workflow_text() -> str:
@@ -20,8 +23,7 @@ def test_perf_cluster_builds_soldr_with_the_zccache_commit_under_test() -> None:
 
     assert 'git -C soldr-src/_vender/zccache fetch origin "$GITHUB_SHA"' in pin_step
     assert (
-        'git -C soldr-src/_vender/zccache checkout --detach "$GITHUB_SHA"'
-        in pin_step
+        'git -C soldr-src/_vender/zccache checkout --detach "$GITHUB_SHA"' in pin_step
     )
     assert 'rev-parse HEAD)" = "$GITHUB_SHA"' in pin_step
     assert workflow.index(pin_step_name) < workflow.index("Build soldr (release)")
@@ -32,6 +34,27 @@ def test_perf_cluster_does_not_use_removed_runtime_zccache_pinning() -> None:
     workflow = workflow_text()
 
     assert "soldr update-zccache" not in workflow
+
+
+def test_perf_local_does_not_use_removed_runtime_zccache_pinning() -> None:
+    local_harness = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (LOCAL_ENTRYPOINT, LOCAL_RUNNER, LOCAL_ORCHESTRATOR)
+    )
+
+    assert "soldr update-zccache" not in local_harness
+    assert "/zccache-bin" not in local_harness
+    assert '"--skip-soldr-build",' not in LOCAL_ORCHESTRATOR.read_text(encoding="utf-8")
+
+
+def test_perf_local_lists_daemon_runtime_without_copying_special_files() -> None:
+    entrypoint = LOCAL_ENTRYPOINT.read_text(encoding="utf-8")
+
+    assert "warm-daemon-files.txt" in entrypoint
+    assert (
+        'copy_if_exists "${scenario_root}/cache-warm/cache/soldr-daemon"'
+        not in entrypoint
+    )
 
 
 def test_perf_cluster_pins_cache_action_to_an_immutable_commit() -> None:


### PR DESCRIPTION
## Summary
- initialize soldr submodules and embed the committed local zccache HEAD in local perf builds
- remove the obsolete runtime update-zccache pin and standalone trio mount from scenario runs
- reject dirty source trees so local measurements cannot silently test stale code
- preserve daemon startup diagnostics without copying Unix sockets

## Validation
- 49 focused Python tests passed
- Ruff passed
- Black check passed
- local restore-no-clean-warm reproduced the pre-fix 1.16x daemon failure and validated soldr#1594 at 45.68x with 37 hits / 0 misses

Coordinates with zackees/soldr#1594.