### PR TITLE
feat(rust-plan): accept Cargo artifact closures

### DIFF
--- a/crates/zccache-artifact/src/rust_plan/local.rs
+++ b/crates/zccache-artifact/src/rust_plan/local.rs
@@ -15,7 +15,7 @@ use super::schema::{
     ensure_supported_cache_schema_version, RustArtifactClass, RustArtifactPlanV1, RustPlanError,
     RUST_ARTIFACT_CACHE_SCHEMA_VERSION,
 };
-use super::selection::{collect_files, select_artifacts, SelectedArtifact};
+use super::selection::{resolve_cargo_artifacts, select_artifacts, SelectedArtifact};
 use super::summary::{RustPlanOperation, RustPlanSummary};
 use super::threads::resolve_rust_plan_tar_threads;
 
@@ -81,8 +81,7 @@ pub fn save_rust_plan_local(
         plan.journal_log_path.clone(),
     );
 
-    let mut candidates = Vec::new();
-    collect_files(plan.target_dir.as_path(), &mut candidates)?;
+    let mut candidates = resolve_cargo_artifacts(plan)?;
     candidates.sort();
 
     let selected = select_artifacts(plan, candidates, &mut summary);
@@ -503,8 +502,7 @@ pub fn save_rust_plan_delta_local(
         })
         .unwrap_or_default();
 
-    let mut candidates = Vec::new();
-    collect_files(plan.target_dir.as_path(), &mut candidates)?;
+    let mut candidates = resolve_cargo_artifacts(plan)?;
     candidates.sort();
     let selected = select_artifacts(plan, candidates, &mut summary);
 

--- a/crates/zccache-artifact/src/rust_plan/proto.rs
+++ b/crates/zccache-artifact/src/rust_plan/proto.rs
@@ -42,6 +42,10 @@ pub(super) mod rust_plan_proto {
         pub cache_profile: String,
         #[prost(uint32, repeated, tag = "14")]
         pub dropped_artifact_classes: Vec<u32>,
+        #[prost(string, repeated, tag = "15")]
+        pub cargo_artifact_paths: Vec<String>,
+        #[prost(bool, tag = "16")]
+        pub cargo_artifacts_complete: bool,
     }
 
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -272,6 +276,8 @@ pub(super) fn plan_to_proto(plan: &RustArtifactPlanV1) -> rust_plan_proto::RustA
             .copied()
             .map(artifact_class_to_proto)
             .collect(),
+        cargo_artifact_paths: plan.cargo_artifact_paths.clone(),
+        cargo_artifacts_complete: plan.cargo_artifacts_complete,
     }
 }
 
@@ -332,6 +338,8 @@ pub(super) fn plan_from_proto(
             .into_iter()
             .map(artifact_class_from_proto)
             .collect::<Result<Vec<_>, RustPlanError>>()?,
+        cargo_artifact_paths: proto.cargo_artifact_paths,
+        cargo_artifacts_complete: proto.cargo_artifacts_complete,
     };
     plan.validate()?;
     Ok(plan)

--- a/crates/zccache-artifact/src/rust_plan/schema.rs
+++ b/crates/zccache-artifact/src/rust_plan/schema.rs
@@ -191,6 +191,11 @@ pub struct RustArtifactPlanV1 {
     /// allow-list. Empty for legacy plans.
     #[serde(default)]
     pub dropped_artifact_classes: Vec<RustArtifactClass>,
+    /// Relative paths reported by Cargo's JSON artifact stream.
+    #[serde(default)]
+    pub cargo_artifact_paths: Vec<String>,
+    #[serde(default)]
+    pub cargo_artifacts_complete: bool,
 }
 
 impl RustArtifactPlanV1 {

--- a/crates/zccache-artifact/src/rust_plan/selection.rs
+++ b/crates/zccache-artifact/src/rust_plan/selection.rs
@@ -254,6 +254,46 @@ pub(super) fn collect_files(
     Ok(())
 }
 
+/// Use Cargo's post-build artifact closure when it is complete and safe.
+/// Any malformed or stale entry conservatively falls back to the recursive
+/// target walk so an incomplete message stream cannot under-save a target.
+pub(super) fn resolve_cargo_artifacts(
+    plan: &RustArtifactPlanV1,
+) -> Result<Vec<NormalizedPath>, RustPlanError> {
+    if !plan.cargo_artifacts_complete {
+        let mut files = Vec::new();
+        collect_files(plan.target_dir.as_path(), &mut files)?;
+        return Ok(files);
+    }
+
+    let mut files = Vec::with_capacity(plan.cargo_artifact_paths.len());
+    for relative in &plan.cargo_artifact_paths {
+        let path = Path::new(relative);
+        if path.is_absolute()
+            || path.components().any(|component| {
+                matches!(
+                    component,
+                    Component::ParentDir | Component::RootDir | Component::Prefix(_)
+                )
+            })
+        {
+            let mut fallback = Vec::new();
+            collect_files(plan.target_dir.as_path(), &mut fallback)?;
+            return Ok(fallback);
+        }
+        let full = plan.target_dir.join(path);
+        if !full.is_file() {
+            let mut fallback = Vec::new();
+            collect_files(plan.target_dir.as_path(), &mut fallback)?;
+            return Ok(fallback);
+        }
+        files.push(NormalizedPath::new(full));
+    }
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
 fn relative_path_string(path: &Path) -> String {
     path.components()
         .filter_map(|component| match component {

--- a/crates/zccache-artifact/src/rust_plan/tests/mod.rs
+++ b/crates/zccache-artifact/src/rust_plan/tests/mod.rs
@@ -57,6 +57,8 @@ pub(super) fn sample_plan(root: &Path, mode: RustPlanMode) -> RustArtifactPlanV1
         journal_log_path: Some(root.join("zccache-session.jsonl").into()),
         cache_profile: None,
         dropped_artifact_classes: Vec::new(),
+        cargo_artifact_paths: Vec::new(),
+        cargo_artifacts_complete: false,
     }
 }
 

--- a/crates/zccache-artifact/src/rust_plan/tests/save_restore.rs
+++ b/crates/zccache-artifact/src/rust_plan/tests/save_restore.rs
@@ -40,6 +40,47 @@ fn thin_save_restore_selects_dependency_artifacts_and_metadata() {
 }
 
 #[test]
+fn complete_cargo_closure_avoids_unreported_target_files() {
+    let dir = tempfile::tempdir().unwrap();
+    synthetic_target(dir.path());
+    let plan = RustArtifactPlanV1 {
+        cargo_artifact_paths: vec![
+            "debug/deps/libserde-abc.rlib".to_string(),
+            "debug/.fingerprint/serde-abc/dep-lib-serde".to_string(),
+        ],
+        cargo_artifacts_complete: true,
+        ..sample_plan(dir.path(), RustPlanMode::Thin)
+    };
+    let cache = dir.path().join("cache");
+
+    let saved = save_rust_plan_local(&plan, &cache).unwrap();
+    assert_eq!(saved.saved_file_count, 2);
+    let manifest = load_manifest(&rust_plan_bundle_dir(
+        &cache,
+        &rust_plan_cache_key(&plan),
+    ));
+    assert!(manifest
+        .artifacts
+        .iter()
+        .all(|artifact| artifact.relative_path != "debug/deps/libapp-abc.rlib"));
+}
+
+#[test]
+fn invalid_cargo_closure_falls_back_to_recursive_walk() {
+    let dir = tempfile::tempdir().unwrap();
+    synthetic_target(dir.path());
+    let plan = RustArtifactPlanV1 {
+        cargo_artifact_paths: vec!["../outside.rlib".to_string()],
+        cargo_artifacts_complete: true,
+        ..sample_plan(dir.path(), RustPlanMode::Thin)
+    };
+    let cache = dir.path().join("cache");
+
+    let saved = save_rust_plan_local(&plan, &cache).unwrap();
+    assert_eq!(saved.saved_file_count, 6);
+}
+
+#[test]
 fn save_writes_protobuf_manifest_and_restore_preserves_mtime() {
     let dir = tempfile::tempdir().unwrap();
     synthetic_target(dir.path());

--- a/crates/zccache-artifact/src/rust_plan/tests/save_restore.rs
+++ b/crates/zccache-artifact/src/rust_plan/tests/save_restore.rs
@@ -55,10 +55,7 @@ fn complete_cargo_closure_avoids_unreported_target_files() {
 
     let saved = save_rust_plan_local(&plan, &cache).unwrap();
     assert_eq!(saved.saved_file_count, 2);
-    let manifest = load_manifest(&rust_plan_bundle_dir(
-        &cache,
-        &rust_plan_cache_key(&plan),
-    ));
+    let manifest = load_manifest(&rust_plan_bundle_dir(&cache, &rust_plan_cache_key(&plan)));
     assert!(manifest
         .artifacts
         .iter()

--- a/crates/zccache-artifact/src/rust_plan_manifest.proto
+++ b/crates/zccache-artifact/src/rust_plan_manifest.proto
@@ -17,6 +17,8 @@ message RustArtifactPlanV1 {
   string journal_log_path = 12;
   string cache_profile = 13;
   repeated uint32 dropped_artifact_classes = 14;
+  repeated string cargo_artifact_paths = 15;
+  bool cargo_artifacts_complete = 16;
 }
 
 message RustToolchainIdentity {


### PR DESCRIPTION
Implements the upstream half of soldr#1546. Rust artifact plans can carry a complete relative Cargo JSON artifact closure; malformed, stale, or incomplete closures conservatively fall back to the recursive target walk. Adds protobuf/JSON compatibility and save-path tests.\n\nRefs zackees/soldr#1546.