### PR TITLE
fix(rust-plan): hydrate verified thin-v2 outputs

### DIFF
--- a/crates/zccache-artifact/src/rust_plan/selection.rs
+++ b/crates/zccache-artifact/src/rust_plan/selection.rs
@@ -28,6 +28,7 @@ pub(super) fn select_artifacts(
         plan.dropped_artifact_classes.iter().copied().collect();
     let excluded_names = excluded_package_names(&plan.packages);
     let thin_v2 = plan.cache_profile.as_deref() == Some("thin-v2");
+    let hydrated = thin_v2 && plan.cargo_artifacts_complete;
     let mut selected = Vec::new();
 
     for path in candidates {
@@ -59,7 +60,7 @@ pub(super) fn select_artifacts(
             // A file matching any dropped class is skipped even if its class is
             // also listed under `allowed_artifact_classes`. This is the
             // load-bearing change that lets thin-v2 actually prune the bundle.
-            if dropped.contains(&class) {
+            if !hydrated && dropped.contains(&class) {
                 summary.skip(rel, "artifact_class_disallowed_by_plan");
                 continue;
             }

--- a/crates/zccache-artifact/src/rust_plan/tests/thin_v2.rs
+++ b/crates/zccache-artifact/src/rust_plan/tests/thin_v2.rs
@@ -142,6 +142,38 @@ fn thin_v2_save_drops_rlib_rmeta_even_when_allowed_list_lists_them() {
 }
 
 #[test]
+fn hydrated_thin_v2_keeps_verified_primary_outputs() {
+    let dir = tempfile::tempdir().unwrap();
+    synthetic_target(dir.path());
+    let mut plan = sample_thin_v2_plan(dir.path());
+    plan.allowed_artifact_classes.extend([
+        RustArtifactClass::Rlib,
+        RustArtifactClass::Rmeta,
+        RustArtifactClass::ProcMacro,
+        RustArtifactClass::SharedLib,
+        RustArtifactClass::BuildScriptBuild,
+        RustArtifactClass::CargoFingerprintOutputs,
+    ]);
+    plan.cargo_artifact_paths = vec![
+        "debug/deps/libserde-abc.rlib".to_string(),
+        "debug/deps/libserde-abc.rmeta".to_string(),
+    ];
+    plan.cargo_artifacts_complete = true;
+
+    let cache = dir.path().join("cache");
+    save_rust_plan_local(&plan, &cache).unwrap();
+    let manifest = load_manifest(&rust_plan_bundle_dir(&cache, &rust_plan_cache_key(&plan)));
+    assert!(manifest
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.relative_path.ends_with("libserde-abc.rlib")));
+    assert!(manifest
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.relative_path.ends_with("libserde-abc.rmeta")));
+}
+
+#[test]
 fn thin_v2_save_keeps_fingerprint_meta_but_drops_fingerprint_outputs() {
     // Tests the split: files cargo reads to make a freshness decision
     // (`dep-*`, `lib-*`, `bin-*`, `output-*`, `build-script-*`,


### PR DESCRIPTION
Fixes the upstream half of soldr#1530. When soldr provides a complete Cargo artifact closure, thin-v2 retains only those verified primary outputs while preserving the existing drop policy for incomplete closures. Adds a regression test proving rlib/rmeta hydration.\n\nRefs zackees/soldr#1530.