### PR TITLE
feat(cli): expose embedded rustfmt cache entrypoint

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/mod.rs
+++ b/crates/zccache-cli-core/src/cli/commands/mod.rs
@@ -39,6 +39,17 @@ use args::{
 };
 use util::{absolute_path, init_tracing, resolve_endpoint, run_async};
 
+/// Run rustfmt through zccache's format cache without entering the standalone
+/// CLI or daemon lifecycle. Embedders provide their managed cache root.
+pub fn run_embedded_rustfmt(
+    rustfmt_path: &Path,
+    args: &[String],
+    cwd: &Path,
+    cache_root: &Path,
+) -> ExitCode {
+    wrap::run_embedded_rustfmt(rustfmt_path, args, cwd, cache_root)
+}
+
 /// Parse argv, run the requested subcommand or wrapper path, and return
 /// the process exit code.
 pub fn run() -> ExitCode {

--- a/crates/zccache-cli-core/src/cli/commands/mod.rs
+++ b/crates/zccache-cli-core/src/cli/commands/mod.rs
@@ -54,6 +54,19 @@ pub fn run_embedded_rustfmt(
 /// the process exit code.
 pub fn run() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
+    run_with_args(&args)
+}
+
+/// Parse and dispatch an explicit full argv vector.
+///
+/// Embedders use this entrypoint to invoke daemon-free CLI subcommands without
+/// spawning a standalone `zccache` process. `args[0]` is the synthetic program
+/// name, matching the shape returned by [`std::env::args`].
+pub fn run_with_args(args: &[String]) -> ExitCode {
+    if args.is_empty() {
+        eprintln!("zccache: explicit argv must include a program name");
+        return ExitCode::FAILURE;
+    }
 
     // #998: hidden argv[0]-independent escape hatch into the daemon.
     // `zccache daemon-run <daemon-flags…>` forwards to the daemon entry with a
@@ -91,7 +104,7 @@ pub fn run() -> ExitCode {
     }
 
     use clap::Parser;
-    let cli = Cli::parse();
+    let cli = Cli::parse_from(args);
     let global_strict_paths = cli.strict_paths.clone();
 
     init_tracing();

--- a/crates/zccache-cli-core/src/cli/commands/tests/mod.rs
+++ b/crates/zccache-cli-core/src/cli/commands/tests/mod.rs
@@ -8,6 +8,7 @@ mod cache_ops;
 mod daemon;
 mod engine_profile;
 mod exit_code;
+mod run_with_args;
 mod session_warnings;
 mod snapshot;
 mod util;

--- a/crates/zccache-cli-core/src/cli/commands/tests/run_with_args.rs
+++ b/crates/zccache-cli-core/src/cli/commands/tests/run_with_args.rs
@@ -1,0 +1,29 @@
+//! Explicit-argv dispatch coverage for embedded CLI hosts (soldr#1593).
+
+use std::process::ExitCode;
+use std::time::{Duration, Instant};
+
+use super::super::run_with_args;
+
+#[test]
+fn perf_explicit_argv_dispatches_in_process_under_250ms() {
+    // Regression/perf contract for soldr#1593: an explicit embedded dispatch
+    // must stay a local function call rather than regaining process-spawn cost.
+    let args = [
+        "zccache".to_string(),
+        "cache-root".to_string(),
+        "--json".to_string(),
+    ];
+    let started = Instant::now();
+    assert_eq!(run_with_args(&args), ExitCode::SUCCESS);
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_millis(250),
+        "embedded cache-root dispatch took {elapsed:?}"
+    );
+}
+
+#[test]
+fn empty_explicit_argv_is_a_failure_not_a_panic() {
+    assert_eq!(run_with_args(&[]), ExitCode::FAILURE);
+}

--- a/crates/zccache-cli-core/src/cli/commands/wrap.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap.rs
@@ -62,7 +62,9 @@ pub(crate) fn run_wrap(
     let _ = std::env::set_current_dir(std::env::temp_dir());
 
     match routing::classify_invocation(&args[0], &tool_args) {
-        WrapperRoute::Formatter => rustfmt::run_rustfmt_cached(&wrapped_tool, &tool_args, &cwd),
+        WrapperRoute::Formatter => {
+            rustfmt::run_rustfmt_cached(&wrapped_tool, &tool_args, &cwd, None)
+        }
         WrapperRoute::LinkOrArchive => run_async(ipc::cmd_link_ephemeral(
             &endpoint,
             &wrapped_tool,
@@ -81,6 +83,15 @@ pub(crate) fn run_wrap(
             client_env,
         ),
     }
+}
+
+pub(crate) fn run_embedded_rustfmt(
+    rustfmt_path: &std::path::Path,
+    args: &[String],
+    cwd: &std::path::Path,
+    cache_root: &std::path::Path,
+) -> ExitCode {
+    rustfmt::run_rustfmt_cached(rustfmt_path, args, cwd, Some(cache_root))
 }
 
 fn run_compile_route(

--- a/crates/zccache-cli-core/src/cli/commands/wrap/rustfmt.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/rustfmt.rs
@@ -12,7 +12,12 @@ use super::passthrough::run_tool_direct;
 /// Files whose content hash is already in the format cache are skipped entirely,
 /// preserving their mtime and avoiding unnecessary downstream rebuilds. After
 /// formatting, the new content hash of each file is stored in the cache.
-pub(super) fn run_rustfmt_cached(rustfmt_path: &Path, args: &[String], cwd: &Path) -> ExitCode {
+pub(super) fn run_rustfmt_cached(
+    rustfmt_path: &Path,
+    args: &[String],
+    cwd: &Path,
+    cache_root: Option<&Path>,
+) -> ExitCode {
     use crate::compiler::parse_rustfmt::{find_rustfmt_config, parse_rustfmt_invocation};
 
     let parsed = match parse_rustfmt_invocation(args) {
@@ -53,7 +58,9 @@ pub(super) fn run_rustfmt_cached(rustfmt_path: &Path, args: &[String], cwd: &Pat
         hasher.finalize().to_hex()
     };
 
-    let cache_dir = crate::core::config::default_cache_dir()
+    let cache_dir = cache_root
+        .map(crate::core::NormalizedPath::new)
+        .unwrap_or_else(crate::core::config::default_cache_dir)
         .join("fmt")
         .join(&context_hash);
 


### PR DESCRIPTION
## Summary

- expose a narrow daemon-free embedded formatter-cache entrypoint
- add `run_with_args(&[String])` so hosts can dispatch maintenance commands without spawning a standalone zccache process
- accept the host-owned cache root explicitly
- keep the standalone wrapper route on the same implementation

## Why

soldr's cached formatter and maintenance-command routes need direct access to zccache without a restricted trampoline process. This unblocks zackees/soldr#1599 and is coordinated with zackees/soldr#1593 and zackees/soldr#1600.

## Validation

- native Windows: `soldr --no-cache cargo test -p zccache-cli-core --all-features` (218 passed, 2 ignored)
- native Windows: `soldr --no-cache cargo check -p zccache-cli-core --all-features --all-targets`
- native Windows: focused no-deps clippy with `-D warnings`
- Docker Linux: explicit-argv tests pass via `ci/perf_local.py`
- formatting and diff whitespace checks pass
- soldr integration: five focused formatter/cargo-fmt tests pass, including a two-run cache-hit assertion

Broader workspace clippy reaches pre-existing diagnostics in `zccache-compiler/src/parse_rustc.rs` and `zccache-depgraph/src/snapshot/persistence.rs`; this diff adds no clippy diagnostics.