### PR TITLE
feat: add immutable staged artifact generations

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
@@ -110,6 +110,21 @@ pub(super) fn ensure_payloads<'a>(
     key_hex: &str,
 ) -> Option<&'a [CachedPayload]> {
     if cached.payloads.is_none() {
+        if staged_artifacts_enabled() {
+            match load_staged_artifact_paths(artifact_dir, key_hex, &cached.meta.output_sizes) {
+                Ok(Some(payloads)) => {
+                    cached.payloads = Some(Arc::from(
+                        payloads
+                            .into_iter()
+                            .map(CachedPayload::File)
+                            .collect::<Vec<_>>(),
+                    ));
+                    return cached.payloads.as_deref();
+                }
+                Ok(None) => {}
+                Err(_) => return None,
+            }
+        }
         let mut payloads = Vec::with_capacity(cached.meta.output_names.len());
         for i in 0..cached.meta.output_names.len() {
             let path = artifact_dir.join(format!("{key_hex}_{i}"));

--- a/crates/zccache-daemon-core/src/daemon/server/persist/artifact_io.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/artifact_io.rs
@@ -169,6 +169,15 @@ pub(in crate::daemon::server) fn persist_artifact_paths_with_stats(
     key_hex: &str,
     sources: &[NormalizedPath],
 ) -> std::io::Result<PersistArtifactFileStats> {
+    if staged_artifacts_enabled() && !pack_mode_enabled() {
+        let stats = persist_staged_artifact_paths(artifact_dir, key_hex, sources)?;
+        return Ok(PersistArtifactFileStats {
+            reflink_count: stats.reflink_count,
+            hardlink_count: 0,
+            copy_count: stats.copy_count,
+            copy_bytes: stats.copy_bytes,
+        });
+    }
     if pack_mode_enabled() {
         let bytes: Vec<Arc<Vec<u8>>> = sources
             .iter()

--- a/crates/zccache-daemon-core/src/daemon/server/persist/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/mod.rs
@@ -30,6 +30,7 @@ mod hardlink;
 mod link_registry;
 mod mtime;
 mod pack;
+mod staged_store;
 mod write_cached;
 
 pub(in crate::daemon::server) use artifact_io::*;
@@ -38,6 +39,7 @@ pub(in crate::daemon::server) use hardlink::*;
 pub(in crate::daemon::server) use link_registry::*;
 pub(in crate::daemon::server) use mtime::*;
 pub(in crate::daemon::server) use pack::*;
+pub(in crate::daemon::server) use staged_store::*;
 pub(in crate::daemon::server) use write_cached::*;
 
 #[cfg(test)]

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -1,0 +1,652 @@
+//! Opt-in immutable artifact generations for the staged-output rollout (#1056).
+//!
+//! This is the storage half of the staged compiler-output design. The compiler
+//! still writes its normal output path while this lane is opt-in, but the
+//! persisted generation is always independent: reflink when the filesystem can
+//! provide true COW, otherwise a byte copy. Hardlinks are deliberately not used
+//! here because a published generation must not share an inode with a live
+//! compiler output.
+
+use super::*;
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+
+pub(in crate::daemon::server) const STAGED_ARTIFACTS_ENV: &str = "ZCCACHE_STAGED_ARTIFACTS";
+
+const STAGED_ROOT: &str = ".staged-v2";
+const STAGED_MANIFEST_VERSION: u32 = 1;
+
+static STAGED_ARTIFACT_TMP_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct StagedManifest {
+    version: u32,
+    key_hex: String,
+    generation_hex: String,
+    outputs: Vec<StagedOutput>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct StagedOutput {
+    index: usize,
+    size: u64,
+    digest_hex: String,
+}
+
+pub(in crate::daemon::server) fn staged_artifacts_enabled() -> bool {
+    std::env::var(STAGED_ARTIFACTS_ENV)
+        .ok()
+        .is_some_and(|value| {
+            !matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "" | "0" | "false" | "off" | "no"
+            )
+        })
+}
+
+pub(in crate::daemon::server) fn is_staged_artifact_path(path: &Path) -> bool {
+    let components = path
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    let Some(window) = components.windows(4).last() else {
+        return false;
+    };
+    let root_matches = if cfg!(windows) {
+        window[0].eq_ignore_ascii_case(STAGED_ROOT)
+    } else {
+        window[0] == STAGED_ROOT
+    };
+    let key_matches = window[1].len() <= 128
+        && !window[1].is_empty()
+        && window[1].bytes().all(|byte| byte.is_ascii_hexdigit());
+    let generation_matches =
+        window[2].len() == 64 && window[2].bytes().all(|byte| byte.is_ascii_hexdigit());
+    let output_matches = window[3]
+        .strip_prefix("output-")
+        .is_some_and(|index| !index.is_empty() && index.bytes().all(|byte| byte.is_ascii_digit()));
+    root_matches && key_matches && generation_matches && output_matches
+}
+
+fn staged_root(artifact_dir: &Path) -> PathBuf {
+    artifact_dir.join(STAGED_ROOT)
+}
+
+fn validate_key(key_hex: &str) -> io::Result<()> {
+    if key_hex.is_empty()
+        || !key_hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+        || key_hex.len() > 128
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "staged artifact key must be a bounded hexadecimal string",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_generation(generation_hex: &str) -> io::Result<()> {
+    if generation_hex.len() != 64 || !generation_hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "staged artifact generation is not a blake3 digest",
+        ));
+    }
+    Ok(())
+}
+
+fn pointer_path(artifact_dir: &Path, key_hex: &str) -> PathBuf {
+    staged_root(artifact_dir).join(format!("{key_hex}.current"))
+}
+
+fn generation_dir(artifact_dir: &Path, key_hex: &str, generation_hex: &str) -> PathBuf {
+    staged_root(artifact_dir).join(key_hex).join(generation_hex)
+}
+
+fn output_path(generation_dir: &Path, index: usize) -> PathBuf {
+    generation_dir.join(format!("output-{index}"))
+}
+
+fn manifest_path(generation_dir: &Path) -> PathBuf {
+    generation_dir.join("manifest.bin")
+}
+
+fn temporary_path(path: &Path, suffix: &str) -> PathBuf {
+    let nonce = STAGED_ARTIFACT_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    path.with_file_name(format!(
+        ".{}.{}.{}-{}",
+        path.file_name().unwrap_or_default().to_string_lossy(),
+        std::process::id(),
+        nonce,
+        suffix
+    ))
+}
+
+fn sync_file(path: &Path) -> io::Result<()> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)?
+        .sync_all()
+}
+
+fn sync_directory(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        File::open(path)?.sync_all()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(())
+    }
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let temporary = temporary_path(path, "tmp");
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temporary)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        replace_staged_path(&temporary, path)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn replace_staged_path(source: &Path, destination: &Path) -> io::Result<()> {
+    #[cfg(not(windows))]
+    {
+        fs::rename(source, destination)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Storage::FileSystem::{
+            MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+        };
+
+        let source_wide: Vec<u16> = source.as_os_str().encode_wide().chain(Some(0)).collect();
+        let destination_wide: Vec<u16> = destination
+            .as_os_str()
+            .encode_wide()
+            .chain(Some(0))
+            .collect();
+        let result = unsafe {
+            MoveFileExW(
+                source_wide.as_ptr(),
+                destination_wide.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        };
+        if result == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn copy_independent(source: &Path, destination: &Path) -> io::Result<(bool, u64)> {
+    if reflink_copy::reflink(source, destination).is_ok() {
+        return Ok((true, 0));
+    }
+    // A failed reflink probe may leave a partial destination, including
+    // platform-specific attributes. Remove it before attempting the copy tier.
+    let _ = fs::remove_file(destination);
+    let bytes = fs::copy(source, destination)?;
+    Ok((false, bytes))
+}
+
+fn copy_output(source: &Path, destination: &Path) -> io::Result<(bool, u64)> {
+    let source_metadata = fs::metadata(source)?;
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let result = copy_independent(source, destination);
+    if result.is_err() {
+        let _ = fs::remove_file(destination);
+        return result;
+    }
+    fs::set_permissions(destination, source_metadata.permissions())?;
+    let mtime = filetime::FileTime::from_last_modification_time(&source_metadata);
+    filetime::set_file_mtime(destination, mtime)?;
+    set_readonly(destination, true)?;
+    result
+}
+
+fn digest_file(path: &Path) -> io::Result<(u64, String)> {
+    let mut file = File::open(path)?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0_u8; 1024 * 1024];
+    let mut size = 0_u64;
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+        size = size.saturating_add(read as u64);
+    }
+    Ok((size, hasher.finalize().to_hex().to_string()))
+}
+
+fn generation_digest(key_hex: &str, outputs: &[StagedOutput]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(key_hex.as_bytes());
+    for output in outputs {
+        hasher.update(&output.index.to_le_bytes());
+        hasher.update(&output.size.to_le_bytes());
+        hasher.update(output.digest_hex.as_bytes());
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+fn load_manifest(
+    path: &Path,
+    expected_key: &str,
+    expected_generation: &str,
+) -> io::Result<StagedManifest> {
+    let manifest: StagedManifest = bincode::deserialize(&fs::read(path)?).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid staged manifest: {error}"),
+        )
+    })?;
+    if manifest.version != STAGED_MANIFEST_VERSION
+        || manifest.key_hex != expected_key
+        || manifest.generation_hex != expected_generation
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "staged manifest identity/version mismatch",
+        ));
+    }
+    Ok(manifest)
+}
+
+pub(in crate::daemon::server) fn persist_staged_artifact_paths(
+    artifact_dir: &Path,
+    key_hex: &str,
+    sources: &[NormalizedPath],
+) -> io::Result<PersistArtifactFileStats> {
+    validate_key(key_hex)?;
+    if sources.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "cannot publish an empty staged artifact",
+        ));
+    }
+
+    let root = staged_root(artifact_dir);
+    let key_root = root.join(key_hex);
+    fs::create_dir_all(&key_root)?;
+    let temporary_generation = key_root.join(format!(
+        ".tmp-{}-{}",
+        std::process::id(),
+        STAGED_ARTIFACT_TMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir(&temporary_generation)?;
+
+    let result = (|| {
+        let mut outputs = Vec::with_capacity(sources.len());
+        let mut stats = PersistArtifactFileStats::default();
+        for (index, source) in sources.iter().enumerate() {
+            let destination = output_path(&temporary_generation, index);
+            let (reflink, copied_bytes) =
+                copy_output(source.as_path(), &destination).map_err(|error| {
+                    io::Error::new(
+                        error.kind(),
+                        format!(
+                            "staged output copy failed: {} -> {}: {error}",
+                            source.display(),
+                            destination.display()
+                        ),
+                    )
+                })?;
+            let (size, digest_hex) = digest_file(&destination).map_err(|error| {
+                io::Error::new(
+                    error.kind(),
+                    format!(
+                        "staged output hash failed: {}: {error}",
+                        destination.display()
+                    ),
+                )
+            })?;
+            outputs.push(StagedOutput {
+                index,
+                size,
+                digest_hex,
+            });
+            if reflink {
+                stats.reflink_count += 1;
+            } else {
+                stats.copy_count += 1;
+                stats.copy_bytes += copied_bytes;
+            }
+        }
+
+        let generation_hex = generation_digest(key_hex, &outputs);
+        validate_generation(&generation_hex)?;
+        let final_generation = generation_dir(artifact_dir, key_hex, &generation_hex);
+        let manifest = StagedManifest {
+            version: STAGED_MANIFEST_VERSION,
+            key_hex: key_hex.to_string(),
+            generation_hex: generation_hex.clone(),
+            outputs,
+        };
+        let manifest_bytes = bincode::serialize(&manifest).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("staged manifest encode failed: {error}"),
+            )
+        })?;
+        let temporary_manifest = manifest_path(&temporary_generation);
+        fs::write(&temporary_manifest, manifest_bytes).map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!("staged manifest write failed: {error}"),
+            )
+        })?;
+        sync_file(&temporary_manifest).map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!("staged manifest sync failed: {error}"),
+            )
+        })?;
+        sync_directory(&temporary_generation).map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!("staged generation sync failed: {error}"),
+            )
+        })?;
+
+        match fs::rename(&temporary_generation, &final_generation) {
+            Ok(()) => {}
+            Err(error) if final_generation.exists() => {
+                let _ = error;
+                let _ = fs::remove_dir_all(&temporary_generation);
+            }
+            Err(error) => return Err(error),
+        }
+        sync_directory(&key_root).map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!("staged generation parent sync failed: {error}"),
+            )
+        })?;
+
+        let pointer = pointer_path(artifact_dir, key_hex);
+        atomic_write(&pointer, generation_hex.as_bytes()).map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!("staged generation pointer publish failed: {error}"),
+            )
+        })?;
+        if let Some(parent) = pointer.parent() {
+            sync_directory(parent).map_err(|error| {
+                io::Error::new(
+                    error.kind(),
+                    format!("staged pointer parent sync failed: {error}"),
+                )
+            })?;
+        }
+        Ok(stats)
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_dir_all(&temporary_generation);
+    }
+    result
+}
+
+pub(in crate::daemon::server) fn load_staged_artifact_paths(
+    artifact_dir: &Path,
+    key_hex: &str,
+    expected_sizes: &[u64],
+) -> io::Result<Option<Vec<NormalizedPath>>> {
+    validate_key(key_hex)?;
+    let pointer = pointer_path(artifact_dir, key_hex);
+    let generation_hex = match fs::read_to_string(pointer) {
+        Ok(value) => value.trim().to_string(),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    validate_generation(&generation_hex)?;
+    let generation = generation_dir(artifact_dir, key_hex, &generation_hex);
+    let manifest = load_manifest(&manifest_path(&generation), key_hex, &generation_hex)?;
+    if generation_digest(key_hex, &manifest.outputs) != generation_hex {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "staged generation digest does not match its manifest",
+        ));
+    }
+    if manifest.outputs.len() != expected_sizes.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "staged output count does not match artifact metadata",
+        ));
+    }
+
+    let mut paths = Vec::with_capacity(manifest.outputs.len());
+    let mut seen = vec![false; expected_sizes.len()];
+    for output in &manifest.outputs {
+        if output.index >= expected_sizes.len()
+            || seen[output.index]
+            || expected_sizes[output.index] != output.size
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "staged output size does not match artifact metadata",
+            ));
+        }
+        seen[output.index] = true;
+        let path = output_path(&generation, output.index);
+        let metadata = fs::metadata(&path)?;
+        if metadata.len() != output.size {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "staged output size does not match its manifest",
+            ));
+        }
+        let (_, digest_hex) = digest_file(&path)?;
+        if digest_hex != output.digest_hex {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "staged output digest does not match its manifest",
+            ));
+        }
+        paths.push((output.index, path.into()));
+    }
+    if seen.iter().any(|was_seen| !was_seen) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "staged manifest has a missing output index",
+        ));
+    }
+    paths.sort_by_key(|(index, _)| *index);
+    Ok(Some(paths.into_iter().map(|(_, path)| path).collect()))
+}
+
+pub(in crate::daemon::server) fn cleanup_staged_artifact_temps(
+    artifact_dir: &Path,
+) -> io::Result<usize> {
+    let root = staged_root(artifact_dir);
+    let Ok(entries) = fs::read_dir(&root) else {
+        return Ok(0);
+    };
+    let mut removed = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file()
+            && path
+                .file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with("."))
+        {
+            fs::remove_file(path)?;
+            removed += 1;
+            continue;
+        }
+        if path.is_dir() {
+            for child in fs::read_dir(&path)?.flatten() {
+                let child_path = child.path();
+                if child_path
+                    .file_name()
+                    .is_some_and(|name| name.to_string_lossy().starts_with(".tmp-"))
+                {
+                    fs::remove_dir_all(child_path)?;
+                    removed += 1;
+                }
+            }
+        }
+    }
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn source_files(dir: &Path) -> Vec<NormalizedPath> {
+        let first = dir.join("source-a.rlib");
+        let second = dir.join("source-b.rmeta");
+        fs::write(&first, b"first immutable payload").unwrap();
+        fs::write(&second, b"second immutable payload").unwrap();
+        vec![first.into(), second.into()]
+    }
+
+    #[test]
+    fn staged_generation_is_independent_and_hash_addressed() {
+        let dir = tempfile::tempdir().unwrap();
+        let artifact_dir = dir.path().join("artifacts");
+        fs::create_dir_all(&artifact_dir).unwrap();
+        let sources = source_files(dir.path());
+        let stats =
+            persist_staged_artifact_paths(&artifact_dir, &"a".repeat(64), &sources).unwrap();
+
+        assert_eq!(stats.hardlink_count, 0);
+        assert_eq!(stats.reflink_count + stats.copy_count, 2);
+
+        let payloads = load_staged_artifact_paths(&artifact_dir, &"a".repeat(64), &[23, 24])
+            .unwrap()
+            .unwrap();
+        assert_eq!(payloads.len(), 2);
+        assert_eq!(fs::read(&payloads[0]).unwrap(), b"first immutable payload");
+        assert_eq!(fs::read(&payloads[1]).unwrap(), b"second immutable payload");
+        assert!(!same_file(sources[0].as_path(), payloads[0].as_path()));
+        assert!(fs::metadata(&payloads[0]).unwrap().permissions().readonly());
+
+        fs::write(&sources[0], b"mutated compiler output").unwrap();
+        assert_eq!(fs::read(&payloads[0]).unwrap(), b"first immutable payload");
+
+        let pointer = artifact_dir
+            .join(STAGED_ROOT)
+            .join(format!("{}.current", "a".repeat(64)));
+        let generation = fs::read_to_string(pointer).unwrap();
+        assert_eq!(generation.trim().len(), 64);
+        assert!(generation
+            .trim()
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit()));
+        assert!(!is_staged_artifact_path(
+            &artifact_dir
+                .join(STAGED_ROOT)
+                .join("not-a-generation")
+                .join("file")
+        ));
+        assert!(is_staged_artifact_path(&payloads[0]));
+    }
+
+    #[test]
+    fn staged_pointer_switches_only_after_the_new_generation_is_complete() {
+        let dir = tempfile::tempdir().unwrap();
+        let artifact_dir = dir.path().join("artifacts");
+        fs::create_dir_all(&artifact_dir).unwrap();
+        let sources = source_files(dir.path());
+        let key = "e".repeat(64);
+        persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
+
+        make_writable(&sources[0]).unwrap();
+        fs::write(&sources[0], b"replacement immutable payload").unwrap();
+        persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
+
+        let payloads = load_staged_artifact_paths(&artifact_dir, &key, &[29, 24])
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            fs::read(&payloads[0]).unwrap(),
+            b"replacement immutable payload"
+        );
+        assert_eq!(fs::read(&payloads[1]).unwrap(), b"second immutable payload");
+        assert!(!same_file(sources[0].as_path(), payloads[0].as_path()));
+    }
+
+    #[test]
+    fn staged_generation_rejects_same_size_corruption() {
+        let dir = tempfile::tempdir().unwrap();
+        let artifact_dir = dir.path().join("artifacts");
+        fs::create_dir_all(&artifact_dir).unwrap();
+        let sources = source_files(dir.path());
+        let key = "b".repeat(64);
+        persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
+        let payloads = load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
+            .unwrap()
+            .unwrap();
+
+        make_writable(&payloads[0]).unwrap();
+        let mut corrupted = fs::read(&payloads[0]).unwrap();
+        corrupted[0] ^= 0xff;
+        fs::write(&payloads[0], corrupted).unwrap();
+        assert_eq!(
+            load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn staged_generation_pointer_never_selects_partial_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let artifact_dir = dir.path().join("artifacts");
+        fs::create_dir_all(&artifact_dir).unwrap();
+        let sources = source_files(dir.path());
+        let key = "c".repeat(64);
+        persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
+
+        let pointer = artifact_dir
+            .join(STAGED_ROOT)
+            .join(format!("{key}.current"));
+        let generation = fs::read_to_string(pointer).unwrap();
+        let generation_dir = artifact_dir
+            .join(STAGED_ROOT)
+            .join(&key)
+            .join(generation.trim());
+        make_writable(&generation_dir.join("output-1")).unwrap();
+        fs::remove_file(generation_dir.join("output-1")).unwrap();
+        assert!(load_staged_artifact_paths(&artifact_dir, &key, &[23, 24]).is_err());
+    }
+
+    #[test]
+    fn staged_generation_cleans_abandoned_temporary_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let artifact_dir = dir.path().join("artifacts");
+        let key_root = artifact_dir.join(STAGED_ROOT).join("d".repeat(64));
+        fs::create_dir_all(&key_root).unwrap();
+        fs::create_dir(key_root.join(".tmp-crashed")).unwrap();
+        fs::create_dir(key_root.join("stable-generation")).unwrap();
+
+        assert_eq!(cleanup_staged_artifact_temps(&artifact_dir).unwrap(), 1);
+        assert!(!key_root.join(".tmp-crashed").exists());
+        assert!(key_root.join("stable-generation").exists());
+    }
+}

--- a/crates/zccache-daemon-core/src/daemon/server/persist/write_cached.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/write_cached.rs
@@ -22,8 +22,17 @@ pub(in crate::daemon::server) fn write_cached_file(
 }
 
 fn materialize_cached_file(out_path: &Path, cache_file: &Path) -> std::io::Result<()> {
-    verify_registered_blob(cache_file)?;
+    let staged = is_staged_artifact_path(cache_file);
+    if !staged {
+        verify_registered_blob(cache_file)?;
+    }
     if same_file(out_path, cache_file) {
+        if staged {
+            let floor =
+                filetime::FileTime::from_last_modification_time(&std::fs::metadata(cache_file)?);
+            detach_with_floored_mtime(out_path, cache_file, floor)?;
+            return Ok(());
+        }
         set_readonly(cache_file, readonly_enabled())?;
         match compute_sibling_floor(out_path)? {
             Some(floor) => detach_with_floored_mtime(out_path, cache_file, floor)?,
@@ -46,7 +55,7 @@ fn materialize_cached_file(out_path: &Path, cache_file: &Path) -> std::io::Resul
     // call sites in this module; a genuinely-too-many-links file still
     // fails the real `std::fs::hard_link` call below, which already has
     // a graceful copy fallback.
-    if hardlink_below_limit(caps, hard_link_count(cache_file).unwrap_or_default()) {
+    if !staged && hardlink_below_limit(caps, hard_link_count(cache_file).unwrap_or_default()) {
         // Only flip the blob read-only *after* the link actually lands.
         // Read-only exists to protect the blob once it's shared; setting
         // it beforehand serves no purpose on the attempt path and, if

--- a/crates/zccache-daemon-core/src/daemon/server/run.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/run.rs
@@ -41,6 +41,9 @@ impl DaemonServer {
             let cache_dir = cache_dir.clone();
             let artifact_dir = self.state.artifact_dir.clone();
             tokio::spawn(async move {
+                if let Err(error) = cleanup_staged_artifact_temps(&artifact_dir) {
+                    tracing::debug!(%error, "staged artifact temp cleanup skipped");
+                }
                 let marker = cache_dir.join(".legacy-blob-digests-migrated-v1");
                 if marker.exists() {
                     tracing::debug!(path = %marker.display(), "legacy blob digest migration already complete");

--- a/crates/zccache-daemon-core/src/daemon/server/tests/pack.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/pack.rs
@@ -81,6 +81,17 @@ fn persist_artifact_paths_preserves_compiler_output_writability() {
     ];
     persist_artifact_paths(dir.path(), key, &sources).unwrap();
 
+    if staged_artifacts_enabled() {
+        let payloads = load_staged_artifact_paths(dir.path(), key, &[10, 11])
+            .unwrap()
+            .unwrap();
+        assert_eq!(std::fs::read(&payloads[0]).unwrap(), b"rlib-bytes");
+        assert_eq!(std::fs::read(&payloads[1]).unwrap(), b"rmeta-bytes");
+        assert!(!same_file(&src_a, &payloads[0]));
+        assert!(!same_file(&src_b, &payloads[1]));
+        return;
+    }
+
     let cache_a = dir.path().join("deadc0de_0");
     let cache_b = dir.path().join("deadc0de_1");
     assert_eq!(std::fs::read(&cache_a).unwrap(), b"rlib-bytes");

--- a/crates/zccache-daemon-core/src/daemon/server/tests/write_cached.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/write_cached.rs
@@ -267,6 +267,31 @@ fn persist_artifact_file_writes_digest_before_publishing() {
     assert!(cache.exists(), "blob must not have been evicted");
 }
 
+#[test]
+fn staged_generation_materializes_independently_from_the_backend() {
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    std::fs::create_dir_all(&artifact_dir).unwrap();
+    let source = dir.path().join("source.rlib");
+    let output = dir.path().join("target.rlib");
+    std::fs::write(&source, b"staged immutable artifact").unwrap();
+
+    persist_staged_artifact_paths(&artifact_dir, &"f".repeat(64), &[source.clone().into()])
+        .unwrap();
+    let payloads = load_staged_artifact_paths(&artifact_dir, &"f".repeat(64), &[25])
+        .unwrap()
+        .unwrap();
+    write_cached_file(&output, &payloads[0]).unwrap();
+
+    assert!(!same_file(&output, &payloads[0]));
+    assert!(!std::fs::metadata(&output).unwrap().permissions().readonly());
+    std::fs::write(&output, b"mutated target output").unwrap();
+    assert_eq!(
+        std::fs::read(&payloads[0]).unwrap(),
+        b"staged immutable artifact"
+    );
+}
+
 /// Regression test for issue #1042 finding #1: fix #1 (writing the digest
 /// sidecar *before* the publishing rename, not after) is what actually
 /// closes the "valid blob evicted on restart" gap for freshly-persisted


### PR DESCRIPTION
## Summary

Implements Phase 1 of #1056 in #1057:

- Adds an opt-in ZCCACHE_STAGED_ARTIFACTS=1 immutable artifact-generation lane.
- Persists complete multi-output generations under .staged-v2/<key>/<generation>/.
- Uses independent reflink or byte-copy storage; published generations never hardlink to live compiler outputs.
- Hashes every output and atomically switches a per-key generation pointer.
- Validates manifest identity, output count/indexes, sizes, and content digests before serving.
- Cleans abandoned staging directories at daemon startup.
- Forces staged generations through independent reflink/copy materialization.
- Keeps legacy flat payload reads and writes available when the flag is disabled or no staged generation exists.

Compiler output argument rewriting is intentionally left for the later Rust and C/C++ phases of #1056. The new lane is disabled by default.

## Verification

- Windows staged-generation tests: 5 passed.
- Windows staged-mode persistence smoke test: passed.
- Windows full zccache-daemon-core suite: 441 passed, 19 ignored.
- Linux Docker staged-generation tests: 5 passed.
- Linux Docker staged-mode persistence smoke test: passed.
- Linux Docker full zccache-daemon-core suite: 449 passed, 19 ignored.
- Windows workspace check: passed.
- Linux Docker formatting check: passed.
- Daemon clippy remains blocked by two pre-existing warnings in zccache-compiler and zccache-depgraph; no changed-file warning was reported.

Closes #1057
Related to #1056
