### PR TITLE
feat(cli): let embedders own rustfmt child policy

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/mod.rs
+++ b/crates/zccache-cli-core/src/cli/commands/mod.rs
@@ -50,6 +50,24 @@ pub fn run_embedded_rustfmt(
     wrap::run_embedded_rustfmt(rustfmt_path, args, cwd, cache_root)
 }
 
+/// Run the formatter cache while delegating child execution to the host.
+///
+/// Embedders can use the runner to apply their own timeout, environment, and
+/// platform spawn policy while zccache retains ownership of cache lookup and
+/// marker updates. The returned integer is the exact child exit status.
+pub fn run_embedded_rustfmt_with_runner<F>(
+    rustfmt_path: &Path,
+    args: &[String],
+    cwd: &Path,
+    cache_root: &Path,
+    runner: F,
+) -> std::io::Result<i32>
+where
+    F: FnOnce(&mut std::process::Command) -> std::io::Result<i32>,
+{
+    wrap::run_embedded_rustfmt_with_runner(rustfmt_path, args, cwd, cache_root, runner)
+}
+
 /// Parse argv, run the requested subcommand or wrapper path, and return
 /// the process exit code.
 pub fn run() -> ExitCode {

--- a/crates/zccache-cli-core/src/cli/commands/wrap.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap.rs
@@ -94,6 +94,19 @@ pub(crate) fn run_embedded_rustfmt(
     rustfmt::run_rustfmt_cached(rustfmt_path, args, cwd, Some(cache_root))
 }
 
+pub(crate) fn run_embedded_rustfmt_with_runner<F>(
+    rustfmt_path: &std::path::Path,
+    args: &[String],
+    cwd: &std::path::Path,
+    cache_root: &std::path::Path,
+    runner: F,
+) -> std::io::Result<i32>
+where
+    F: FnOnce(&mut std::process::Command) -> std::io::Result<i32>,
+{
+    rustfmt::run_rustfmt_cached_with_runner(rustfmt_path, args, cwd, Some(cache_root), runner)
+}
+
 fn run_compile_route(
     endpoint: &str,
     raw_tool: &str,

--- a/crates/zccache-cli-core/src/cli/commands/wrap/passthrough.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/passthrough.rs
@@ -6,6 +6,9 @@ use std::process::ExitCode;
 use super::super::util::exit_code_from_i32;
 use super::tool_resolution::resolve_compiler_path;
 
+#[cfg(test)]
+pub(super) static CWD_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Release the wrapper's own CWD handle on the build dir before spawning
 /// a child, while keeping the child's CWD pointing at the original
 /// directory so relative paths in argv still resolve.
@@ -15,16 +18,19 @@ use super::tool_resolution::resolve_compiler_path;
 /// Windows the parent's CWD holds an implicit kernel handle on the
 /// build directory, blocking `shutil.rmtree` until the wrapper exits.
 /// This helper restores parity with the cached-path behavior.
+pub(super) fn release_cwd_for_command(cmd: &mut std::process::Command, child_cwd: &Path) {
+    cmd.current_dir(child_cwd);
+    // Release the wrapper's own CWD handle before spawning. The child inherits
+    // `cmd.current_dir(...)` regardless of where the parent ends up, so
+    // argv-relative paths still resolve from the caller-supplied directory.
+    let _ = std::env::set_current_dir(std::env::temp_dir());
+}
+
 fn run_with_released_cwd(
     cmd: &mut std::process::Command,
 ) -> std::io::Result<std::process::ExitStatus> {
     if let Ok(cwd) = std::env::current_dir() {
-        cmd.current_dir(&cwd);
-        // Release the wrapper's own CWD handle before spawning. The
-        // child inherits `cmd.current_dir(...)` regardless of where the
-        // parent ends up, so argv-relative paths still resolve from
-        // the build dir.
-        let _ = std::env::set_current_dir(std::env::temp_dir());
+        release_cwd_for_command(cmd, &cwd);
     }
     cmd.status()
 }
@@ -46,27 +52,9 @@ pub(super) fn run_passthrough(args: &[String]) -> ExitCode {
     }
 }
 
-/// Run a tool directly and return its exit code.
-pub(super) fn run_tool_direct(tool: &Path, args: &[String]) -> ExitCode {
-    let mut cmd = std::process::Command::new(tool);
-    cmd.args(args);
-    match run_with_released_cwd(&mut cmd) {
-        Ok(status) => exit_code_from_i32(status.code().unwrap_or(1)),
-        Err(e) => {
-            eprintln!("zccache: failed to run {}: {e}", tool.display());
-            ExitCode::FAILURE
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Process-global lock so the two CWD-mutating tests don't race.
-    /// `env::set_current_dir` is process-wide; running these in parallel
-    /// would produce nondeterministic results.
-    static CWD_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn noop_tool() -> std::path::PathBuf {
         if cfg!(windows) {
@@ -123,7 +111,7 @@ mod tests {
     /// exit) must also release the wrapper's CWD — same correctness
     /// rationale as `run_passthrough`.
     #[test]
-    fn run_tool_direct_releases_wrapper_cwd() {
+    fn direct_rustfmt_policy_releases_wrapper_cwd() {
         let _guard = CWD_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let original_cwd = std::env::current_dir().ok();
         let build_dir = tempfile::tempdir().unwrap();
@@ -132,13 +120,16 @@ mod tests {
 
         let tool = noop_tool();
         let args: Vec<String> = noop_args();
-        let _ = run_tool_direct(&tool, &args);
+        let mut command = std::process::Command::new(&tool);
+        command.args(&args);
+        release_cwd_for_command(&mut command, &canonical_build_dir);
+        let _ = command.status();
 
         let after = std::env::current_dir().unwrap();
         let after_canonical = std::fs::canonicalize(&after).unwrap_or(after);
         assert_ne!(
             after_canonical, canonical_build_dir,
-            "issue #555: run_tool_direct must release the wrapper's CWD",
+            "issue #555: direct rustfmt execution must release the wrapper's CWD",
         );
 
         if let Some(cwd) = original_cwd {

--- a/crates/zccache-cli-core/src/cli/commands/wrap/rustfmt.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/rustfmt.rs
@@ -5,8 +5,6 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use super::super::util::exit_code_from_i32;
-use super::passthrough::run_tool_direct;
-
 /// Run rustfmt with format caching.
 ///
 /// Files whose content hash is already in the format cache are skipped entirely,
@@ -18,13 +16,37 @@ pub(super) fn run_rustfmt_cached(
     cwd: &Path,
     cache_root: Option<&Path>,
 ) -> ExitCode {
+    match run_rustfmt_cached_with_runner(rustfmt_path, args, cwd, cache_root, |cmd| {
+        Ok(cmd.status()?.code().unwrap_or(1))
+    }) {
+        Ok(code) => exit_code_from_i32(code),
+        Err(e) => {
+            eprintln!("zccache: failed to run rustfmt: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+pub(super) fn run_rustfmt_cached_with_runner<F>(
+    rustfmt_path: &Path,
+    args: &[String],
+    cwd: &Path,
+    cache_root: Option<&Path>,
+    runner: F,
+) -> std::io::Result<i32>
+where
+    F: FnOnce(&mut std::process::Command) -> std::io::Result<i32>,
+{
     use crate::compiler::parse_rustfmt::{find_rustfmt_config, parse_rustfmt_invocation};
 
     let parsed = match parse_rustfmt_invocation(args) {
         Some(p) => p,
         None => {
             // --help, --version, or stdin mode: pass through.
-            return run_tool_direct(rustfmt_path, args);
+            let mut cmd = std::process::Command::new(rustfmt_path);
+            cmd.args(args);
+            super::passthrough::release_cwd_for_command(&mut cmd, cwd);
+            return runner(&mut cmd);
         }
     };
 
@@ -98,16 +120,10 @@ pub(super) fn run_rustfmt_cached(
     }
 
     if miss_files.is_empty() {
-        return ExitCode::SUCCESS;
+        return Ok(0);
     }
 
-    let exit_i32 = match run_rustfmt_on_files(rustfmt_path, args, &miss_files, &parsed) {
-        Ok(code) => code,
-        Err(e) => {
-            eprintln!("zccache: failed to run rustfmt: {e}");
-            return ExitCode::FAILURE;
-        }
-    };
+    let exit_i32 = run_rustfmt_on_files(rustfmt_path, args, cwd, &miss_files, &parsed, runner)?;
 
     if exit_i32 == 0 {
         for (abs, was_hit, cached_hash) in &all_files {
@@ -126,23 +142,76 @@ pub(super) fn run_rustfmt_cached(
         }
     }
 
-    exit_code_from_i32(exit_i32)
+    Ok(exit_i32)
 }
 
-fn run_rustfmt_on_files(
+fn run_rustfmt_on_files<F>(
     rustfmt_path: &Path,
     original_args: &[String],
+    cwd: &Path,
     files: &[NormalizedPath],
     parsed: &crate::compiler::parse_rustfmt::ParsedRustfmt,
-) -> Result<i32, std::io::Error> {
+    runner: F,
+) -> Result<i32, std::io::Error>
+where
+    F: FnOnce(&mut std::process::Command) -> std::io::Result<i32>,
+{
     let mut cmd = std::process::Command::new(rustfmt_path);
     cmd.args(&parsed.flags);
     for f in files {
         cmd.arg(f);
     }
+    super::passthrough::release_cwd_for_command(&mut cmd, cwd);
 
     let _ = original_args;
 
-    let status = cmd.status()?;
-    Ok(status.code().unwrap_or(1))
+    runner(&mut cmd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct CwdRestore(Option<std::path::PathBuf>);
+
+    impl Drop for CwdRestore {
+        fn drop(&mut self) {
+            if let Some(cwd) = self.0.take() {
+                let _ = std::env::set_current_dir(cwd);
+            }
+        }
+    }
+
+    #[test]
+    fn embedded_runner_controls_child_and_preserves_exact_exit_code() {
+        let _lock = super::super::passthrough::CWD_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let _cwd_restore = CwdRestore(std::env::current_dir().ok());
+        let root = tempfile::tempdir().unwrap();
+        let rustfmt = root.path().join("rustfmt-test-bin");
+        let source = root.path().join("input.rs");
+        std::fs::write(&rustfmt, b"fake formatter identity").unwrap();
+        std::fs::write(&source, b"fn main( ) {}\n").unwrap();
+        let args = vec![source.display().to_string()];
+        let mut called = false;
+
+        let code = run_rustfmt_cached_with_runner(
+            &rustfmt,
+            &args,
+            root.path(),
+            Some(&root.path().join("cache")),
+            |command| {
+                called = true;
+                assert_eq!(command.get_program(), rustfmt.as_os_str());
+                assert_eq!(command.get_current_dir(), Some(root.path()));
+                assert!(command.get_args().any(|arg| arg == source.as_os_str()));
+                Ok(37)
+            },
+        )
+        .unwrap();
+
+        assert!(called);
+        assert_eq!(code, 37);
+    }
 }


### PR DESCRIPTION
## Summary

- add a host runner callback to the embedded rustfmt cache API
- preserve exact child exit codes before conversion to ExitCode
- let embedding hosts apply timeout, environment, and platform process policy
- retain the existing default wrapper behavior and CWD-release contract

Coordinated with zackees/soldr#1593. Follow-up to #1054 and zackees/soldr#1600.

## Validation

- native Windows focused test
- native Windows all-target check
- native Windows focused no-deps clippy with -D warnings
- Docker Linux focused test
- formatting and diff checks