### PR TITLE
feat: stage declared linker output sets

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -313,7 +313,19 @@ pub(super) async fn handle_link_ephemeral(
             }
         }
     } else {
-        None
+        match StagedCompilePlan::link(
+            &state.artifact_dir,
+            args,
+            &output_path,
+            &parsed_tool.secondary_outputs,
+            cwd_path,
+        ) {
+            Ok(plan) => plan,
+            Err(error) => {
+                tracing::warn!(%error, "link staging plan failed; using legacy path");
+                None
+            }
+        }
     };
     let compiler_args = staged_plan
         .as_ref()
@@ -413,6 +425,26 @@ pub(super) async fn handle_link_ephemeral(
             .unwrap_or_default()
         };
 
+        if let Some(plan) = staged_plan.as_ref() {
+            let unexpected_staged = plan.unexpected_staged_entries().unwrap_or_else(|error| {
+                tracing::warn!(%error, "failed to inspect staged linker output set");
+                vec![plan.primary_staged().as_path().to_path_buf()]
+            });
+            if !side_effects.is_empty() || !unexpected_staged.is_empty() {
+                tracing::warn!(
+                    external_count = side_effects.len(),
+                    staged_count = unexpected_staged.len(),
+                    "undeclared linker side effects invalidate staged publication"
+                );
+                if let Err(error) = plan.materialize() {
+                    return Response::Error {
+                        message: format!("failed to materialize staged link output: {error}"),
+                    };
+                }
+                return result;
+            }
+        }
+
         let mut read_targets: Vec<(String, std::path::PathBuf)> =
             Vec::with_capacity(1 + parsed_tool.secondary_outputs.len() + side_effects.len());
         read_targets.push((
@@ -433,7 +465,11 @@ pub(super) async fn handle_link_ephemeral(
                 .unwrap_or_default()
                 .to_string_lossy()
                 .into_owned();
-            read_targets.push((name, sec_path));
+            let read_path = staged_plan
+                .as_ref()
+                .and_then(|plan| plan.staged_for_requested(&sec_path))
+                .map_or(sec_path.clone(), |path| path.into_path_buf());
+            read_targets.push((name, read_path));
         }
         for se in &side_effects {
             read_targets.push((
@@ -467,6 +503,13 @@ pub(super) async fn handle_link_ephemeral(
                 })
                 .collect()
         };
+
+        if staged_plan.is_some() && reads.iter().any(Option::is_none) {
+            let _ = staged_plan.as_ref().map(StagedCompilePlan::cleanup);
+            return Response::Error {
+                message: "successful linker omitted a staged output".to_string(),
+            };
+        }
 
         // Primary read gates the cache populate. If it fails, the link
         // succeeded but the output file is no longer readable — skip
@@ -528,7 +571,7 @@ pub(super) async fn handle_link_ephemeral(
                     }
                     if let Err(error) = plan.materialize() {
                         return Response::Error {
-                            message: format!("failed to materialize archive output: {error}"),
+                            message: format!("failed to materialize staged link output: {error}"),
                         };
                     }
                 } else {

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
@@ -391,6 +391,75 @@ impl StagedCompilePlan {
         }))
     }
 
+    /// Build a linker plan only when every declared output can be redirected
+    /// by exact path replacement. Undeclared linker side effects are checked
+    /// by the caller after the process exits; they invalidate publication.
+    pub(in crate::daemon::server) fn link(
+        artifact_dir: &Path,
+        args: &[String],
+        primary_output: &NormalizedPath,
+        secondary_outputs: &[NormalizedPath],
+        cwd: &Path,
+    ) -> io::Result<Option<Self>> {
+        if !super::staged_link_lane_enabled() {
+            return Ok(None);
+        }
+        let root = artifact_dir.join(".staged-v2").join(format!(
+            ".link-{}-{}",
+            std::process::id(),
+            PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&root)?;
+        let result = (|| {
+            let mut requested_outputs = Vec::with_capacity(1 + secondary_outputs.len());
+            requested_outputs.push(absolute(primary_output, cwd));
+            requested_outputs.extend(secondary_outputs.iter().map(|output| absolute(output, cwd)));
+            let mut outputs = Vec::with_capacity(requested_outputs.len());
+            let mut rewritten_args = args.to_vec();
+            for requested in requested_outputs {
+                let filename = requested.file_name().ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "link output has no filename")
+                })?;
+                let staged: NormalizedPath = root.join(filename).into();
+                if outputs.iter().any(|output: &StagedOutputPlan| {
+                    output.requested == requested || output.staged == staged
+                }) {
+                    return Ok(None);
+                }
+                let requested_text = requested.to_string_lossy();
+                let relative = requested
+                    .strip_prefix(cwd)
+                    .ok()
+                    .map(|path| path.to_string_lossy().into_owned());
+                let mut replaced = false;
+                for arg in &mut rewritten_args {
+                    let candidates = [Some(requested_text.as_ref()), relative.as_deref()];
+                    match rewrite_link_output_arg(
+                        arg,
+                        candidates.into_iter().flatten(),
+                        staged.to_string_lossy().as_ref(),
+                    ) {
+                        Some(arg_replaced) => replaced |= arg_replaced,
+                        None => return Ok(None),
+                    }
+                }
+                if !replaced {
+                    return Ok(None);
+                }
+                outputs.push(StagedOutputPlan { requested, staged });
+            }
+            Ok(Some(Self {
+                outputs,
+                rewritten_args,
+                root: root.clone(),
+            }))
+        })();
+        if matches!(result, Ok(None) | Err(_)) {
+            let _ = std::fs::remove_dir_all(&root);
+        }
+        result
+    }
+
     pub(in crate::daemon::server) fn output_paths(&self) -> Vec<NormalizedPath> {
         self.outputs
             .iter()
@@ -400,6 +469,30 @@ impl StagedCompilePlan {
 
     pub(in crate::daemon::server) fn primary_staged(&self) -> &NormalizedPath {
         &self.outputs[0].staged
+    }
+
+    pub(in crate::daemon::server) fn staged_for_requested(
+        &self,
+        requested: &Path,
+    ) -> Option<NormalizedPath> {
+        self.outputs
+            .iter()
+            .find(|output| output.requested.as_path() == requested)
+            .map(|output| output.staged.clone())
+    }
+
+    pub(in crate::daemon::server) fn unexpected_staged_entries(&self) -> io::Result<Vec<PathBuf>> {
+        let declared: std::collections::HashSet<PathBuf> = self
+            .outputs
+            .iter()
+            .map(|output| output.staged.as_path().to_path_buf())
+            .collect();
+        Ok(std::fs::read_dir(&self.root)?
+            .map(|entry| entry.map(|entry| entry.path()))
+            .collect::<io::Result<Vec<_>>>()?
+            .into_iter()
+            .filter(|path| !declared.contains(path))
+            .collect())
     }
 
     pub(in crate::daemon::server) fn rewrite_depfile_strategy(
@@ -498,6 +591,43 @@ impl StagedCompilePlan {
                 Err(error)
             }
         })
+    }
+}
+
+/// Rewrite one exact or delimiter-bounded linker output path. Returning
+/// `None` means the token was ambiguous and the caller must use the legacy
+/// path before spawning the linker.
+fn rewrite_link_output_arg<'a>(
+    arg: &mut String,
+    candidates: impl Iterator<Item = &'a str>,
+    staged: &str,
+) -> Option<bool> {
+    let mut ranges = Vec::new();
+    for candidate in candidates.filter(|candidate| !candidate.is_empty()) {
+        if arg == candidate {
+            ranges.push((0, arg.len()));
+            continue;
+        }
+        for (start, _) in arg.match_indices(candidate) {
+            let end = start + candidate.len();
+            let before = arg[..start].chars().next_back();
+            let after = arg[end..].chars().next();
+            if before.is_some_and(|ch| matches!(ch, '=' | ':' | ','))
+                && after.is_none_or(|ch| ch == ',')
+            {
+                ranges.push((start, end));
+            }
+        }
+    }
+    ranges.sort_unstable();
+    ranges.dedup();
+    match ranges.as_slice() {
+        [] => Some(false),
+        &[(start, end)] => {
+            arg.replace_range(start..end, staged);
+            Some(true)
+        }
+        _ => None,
     }
 }
 
@@ -818,5 +948,91 @@ mod tests {
             .iter()
             .any(|arg| arg.contains(".staged-v2")));
         plan.cleanup().unwrap();
+    }
+
+    #[test]
+    fn link_plan_rewrites_primary_and_declared_secondary_outputs() {
+        if !staged_tests_enabled() {
+            return;
+        }
+        let temp = tempdir().unwrap();
+        let primary: NormalizedPath = temp.path().join("app.exe").into();
+        let import: NormalizedPath = temp.path().join("app.lib").into();
+        let plan = StagedCompilePlan::link(
+            temp.path(),
+            &[
+                "-o".into(),
+                "app.exe".into(),
+                "-Wl,--out-implib,app.lib".into(),
+            ],
+            &primary,
+            std::slice::from_ref(&import),
+            temp.path(),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(plan.outputs.len(), 2);
+        assert!(plan
+            .rewritten_args
+            .iter()
+            .any(|arg| arg.contains(".staged-v2") && arg.contains("app.exe")));
+        assert!(plan
+            .rewritten_args
+            .iter()
+            .any(|arg| arg.contains(".staged-v2") && arg.contains("app.lib")));
+        std::fs::write(
+            plan.primary_staged().parent().unwrap().join("implicit.pdb"),
+            b"debug",
+        )
+        .unwrap();
+        assert_eq!(plan.unexpected_staged_entries().unwrap().len(), 1);
+        plan.cleanup().unwrap();
+    }
+
+    #[test]
+    fn link_plan_rewrites_absolute_output_once_and_ignores_substrings() {
+        if !staged_tests_enabled() {
+            return;
+        }
+        let temp = tempdir().unwrap();
+        let primary: NormalizedPath = temp.path().join("app.exe").into();
+        let absolute = primary.to_string_lossy().into_owned();
+        let plan = StagedCompilePlan::link(
+            temp.path(),
+            &[
+                "-o".into(),
+                absolute,
+                "--trace-symbol=app.exe.helper".into(),
+            ],
+            &primary,
+            &[],
+            temp.path(),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            plan.rewritten_args[1],
+            plan.primary_staged().to_string_lossy()
+        );
+        assert_eq!(plan.rewritten_args[2], "--trace-symbol=app.exe.helper");
+        plan.cleanup().unwrap();
+    }
+
+    #[test]
+    fn link_plan_rejects_ambiguous_output_token() {
+        if !staged_tests_enabled() {
+            return;
+        }
+        let temp = tempdir().unwrap();
+        let primary: NormalizedPath = temp.path().join("app.exe").into();
+        let plan = StagedCompilePlan::link(
+            temp.path(),
+            &["-Wl,-Map,app.exe,app.exe".into()],
+            &primary,
+            &[],
+            temp.path(),
+        )
+        .unwrap();
+        assert!(plan.is_none());
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -65,6 +65,17 @@ pub(in crate::daemon::server) fn staged_lane_enabled(
     }
 }
 
+pub(in crate::daemon::server) fn staged_link_lane_enabled() -> bool {
+    std::env::var(STAGED_ARTIFACTS_ENV)
+        .ok()
+        .is_some_and(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "all" | "1" | "true" | "yes" | "on"
+            )
+        })
+}
+
 pub(in crate::daemon::server) fn is_staged_artifact_path(path: &Path) -> bool {
     let components = path
         .components()

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -21,7 +21,8 @@ Rollout values are `rust` (Rust single and multi-output plans), `c-cpp`
 `-MF`/`-MD` depfiles; MSVC
 flag rewriting is supported only for explicit `/Fo` object paths), or
 `all`. Unsupported shapes—including multi-source compiler invocations, C++
-modules, linker side outputs, generic exec, and stdout output—remain on the
+modules, unrewritable or undeclared linker outputs, opaque generic exec, and
+stdout output—remain on the
 legacy path before compiler spawn. Explicit Rust `--emit=kind=path` outputs
 are parsed and included in the complete cache-hit reverse map. Inferred
 outputs for staticlibs, bins, proc macros, objects, assembly, LLVM IR/bitcode,
@@ -29,6 +30,13 @@ MIR, and dep-info use their actual rustc extensions.
 
 Pure archive invocations with one output and no linker side effects use the
 same private transaction when the lane is `all`.
+
+Linker invocations participate in the `all` lane when the parser's primary
+and declared secondary destinations can all be rewritten before spawn. The
+private directory is checked for undeclared files/bundles after the linker
+exits, and the requested output directory is checked for external side
+effects. Either condition prevents cache publication; declared outputs are
+independently salvaged to preserve a successful link.
 
 Generic tool execution also participates in the `all` lane when every
 declared output is an exact argument token. Those paths are rewritten into a
@@ -196,7 +204,8 @@ remove read-only attributes before deletion.
 `ZCCACHE_DISABLE_REFLINK=1` disables cloning and `ZCCACHE_COW_READONLY=0`
 disables read-only enforcement. Neither setting adds an IPC roundtrip.
 Unsupported shapes—including multi-source compiler invocations, C++ modules,
-linker side outputs, opaque generic exec, and stdout output—remain on the
+unrewritable/undeclared linker outputs, opaque generic exec, and stdout
+output—remain on the
 legacy path before compiler spawn. Explicit Rust `--emit=kind=path`
 destinations are included in the complete cache-hit reverse map. The staged
 lane remains opt-in for output families that do not yet have complete-set


### PR DESCRIPTION
## Summary\n\n- stage linker primary and parser-declared secondary outputs before spawn\n- publish only complete declared output sets\n- reject cache publication when private or requested output directories contain undeclared linker side effects\n- independently salvage declared outputs when publication is invalidated\n\n## Validation\n\n- Windows: staged linker planner unit test\n- Windows: 	est_link_path_remap_auto_hits_across_sibling_git_roots\n- Linux Docker: same linker miss/hit/worktree test\n- Linux Docker: soldr cargo fmt --all --check\n\nRelated to #1056.