### PR TITLE
feat: stage explicit linker side outputs

### DIFF
--- a/crates/zccache-compiler/src/parse_linker/compiler_driver.rs
+++ b/crates/zccache-compiler/src/parse_linker/compiler_driver.rs
@@ -68,14 +68,30 @@ pub(super) fn parse_compiler_driver_link(tool: &str, args: Vec<String>) -> Parse
 
         // -Wl, pass-through to linker — check for non-determinism and secondary outputs
         if arg.starts_with("-Wl,") {
-            for part in arg.split(',') {
-                if part == "--build-id=uuid" {
+            let parts = arg.split(',').collect::<Vec<_>>();
+            for (index, part) in parts.iter().enumerate() {
+                if *part == "--build-id=uuid" {
                     has_build_id_uuid = true;
                 }
                 // GNU/LLD --out-implib produces an import library (.dll.a) as a side effect.
                 // Meson/ninja uses: -Wl,--out-implib=path/to/foo.dll.a
                 if let Some(implib) = part.strip_prefix("--out-implib=") {
                     secondary_outputs.push(NormalizedPath::new(implib));
+                }
+                if let Some(map) = part.strip_prefix("-Map=") {
+                    if map != "-" {
+                        secondary_outputs.push(NormalizedPath::new(map));
+                    }
+                }
+                if (*part == "-Map" || *part == "--dependency-file")
+                    && parts.get(index + 1).is_some_and(|value| *value != "-")
+                {
+                    secondary_outputs.push(NormalizedPath::new(parts[index + 1]));
+                }
+                if let Some(depfile) = part.strip_prefix("--dependency-file=") {
+                    if depfile != "-" {
+                        secondary_outputs.push(NormalizedPath::new(depfile));
+                    }
                 }
             }
             cache_relevant_flags.push(arg.clone());
@@ -153,6 +169,9 @@ pub(super) fn parse_compiler_driver_link(tool: &str, args: Vec<String>) -> Parse
             reason: "no input files specified".to_string(),
         };
     }
+
+    let mut seen_outputs = std::collections::HashSet::new();
+    secondary_outputs.retain(|output| seen_outputs.insert(output.clone()));
 
     ParsedLinkerInvocation::Cacheable(CacheableLink {
         tool: NormalizedPath::new(tool),

--- a/crates/zccache-compiler/src/parse_linker/gnu_ld.rs
+++ b/crates/zccache-compiler/src/parse_linker/gnu_ld.rs
@@ -47,6 +47,49 @@ pub(super) fn parse_gnu_ld(
             continue;
         }
 
+        // File-producing diagnostics must be captured as secondary outputs.
+        // Stdout forms remain streams, not files.
+        if let Some(map) = arg.strip_prefix("-Map=") {
+            if map != "-" {
+                secondary_outputs.push(NormalizedPath::new(map));
+            }
+            cache_relevant_flags.push(arg.clone());
+            i += 1;
+            continue;
+        }
+        if arg == "-Map" {
+            cache_relevant_flags.push(arg.clone());
+            i += 1;
+            if i < args.len() {
+                if args[i] != "-" {
+                    secondary_outputs.push(NormalizedPath::new(&args[i]));
+                }
+                cache_relevant_flags.push(args[i].clone());
+            }
+            i += 1;
+            continue;
+        }
+        if let Some(depfile) = arg.strip_prefix("--dependency-file=") {
+            if depfile != "-" {
+                secondary_outputs.push(NormalizedPath::new(depfile));
+            }
+            cache_relevant_flags.push(arg.clone());
+            i += 1;
+            continue;
+        }
+        if arg == "--dependency-file" {
+            cache_relevant_flags.push(arg.clone());
+            i += 1;
+            if i < args.len() {
+                if args[i] != "-" {
+                    secondary_outputs.push(NormalizedPath::new(&args[i]));
+                }
+                cache_relevant_flags.push(args[i].clone());
+            }
+            i += 1;
+            continue;
+        }
+
         // -shared or --shared — shared library mode (cache-relevant: affects output type)
         if arg == "-shared" || arg == "--shared" {
             cache_relevant_flags.push(arg.clone());
@@ -197,6 +240,9 @@ pub(super) fn parse_gnu_ld(
             reason: "no input files specified".to_string(),
         };
     }
+
+    let mut seen_outputs = std::collections::HashSet::new();
+    secondary_outputs.retain(|output| seen_outputs.insert(output.clone()));
 
     ParsedLinkerInvocation::Cacheable(CacheableLink {
         tool: NormalizedPath::new(tool),

--- a/crates/zccache-compiler/src/parse_linker/msvc_link.rs
+++ b/crates/zccache-compiler/src/parse_linker/msvc_link.rs
@@ -20,6 +20,13 @@ pub(super) fn parse_msvc_link(tool: &str, args: Vec<String>) -> ParsedLinkerInvo
     let mut cache_relevant_flags: Vec<String> = Vec::new();
     let mut has_deterministic = false;
     let mut secondary_outputs: Vec<NormalizedPath> = Vec::new();
+    let mut has_debug = false;
+    let mut incremental = None;
+    let mut implicit_map = false;
+    let mut explicit_pdb = false;
+    let mut explicit_ilk = false;
+    let mut debug_outputs = Vec::new();
+    let mut incremental_outputs = Vec::new();
 
     for arg in &args {
         let upper = arg.to_uppercase();
@@ -55,6 +62,77 @@ pub(super) fn parse_msvc_link(tool: &str, args: Vec<String>) -> ParsedLinkerInvo
             continue;
         }
 
+        // Debug/incremental linker products. Explicit destinations are part
+        // of the declared output set. Implicit names are added after /OUT is
+        // known so the staging planner can reject the invocation before
+        // spawn unless it can redirect every product.
+        if upper == "/DEBUG:NONE" || upper == "-DEBUG:NONE" {
+            has_debug = false;
+            cache_relevant_flags.push(arg.clone());
+            continue;
+        }
+        if upper == "/DEBUG"
+            || upper == "-DEBUG"
+            || upper.starts_with("/DEBUG:")
+            || upper.starts_with("-DEBUG:")
+        {
+            has_debug = true;
+            cache_relevant_flags.push(arg.clone());
+            continue;
+        }
+        if upper == "/INCREMENTAL" || upper == "-INCREMENTAL" {
+            incremental = Some(true);
+            cache_relevant_flags.push(arg.clone());
+            continue;
+        }
+        if upper == "/INCREMENTAL:NO" || upper == "-INCREMENTAL:NO" {
+            incremental = Some(false);
+            cache_relevant_flags.push(arg.clone());
+            continue;
+        }
+        if upper == "/MAP" || upper == "-MAP" {
+            implicit_map = true;
+            cache_relevant_flags.push(arg.clone());
+            continue;
+        }
+        let explicit_output = [
+            "/PDB:",
+            "-PDB:",
+            "/PDBSTRIPPED:",
+            "-PDBSTRIPPED:",
+            "/ILK:",
+            "-ILK:",
+            "/MAP:",
+            "-MAP:",
+        ]
+        .into_iter()
+        .find(|prefix| upper.starts_with(prefix));
+        if let Some(prefix) = explicit_output {
+            let path = &arg[prefix.len()..];
+            if !path.is_empty() {
+                let output = NormalizedPath::new(path);
+                if prefix.eq_ignore_ascii_case("/PDB:")
+                    || prefix.eq_ignore_ascii_case("-PDB:")
+                    || prefix.eq_ignore_ascii_case("/PDBSTRIPPED:")
+                    || prefix.eq_ignore_ascii_case("-PDBSTRIPPED:")
+                {
+                    debug_outputs.push(output);
+                } else if prefix.eq_ignore_ascii_case("/ILK:")
+                    || prefix.eq_ignore_ascii_case("-ILK:")
+                {
+                    incremental_outputs.push(output);
+                } else {
+                    secondary_outputs.push(output);
+                }
+            }
+            explicit_pdb |=
+                prefix.eq_ignore_ascii_case("/PDB:") || prefix.eq_ignore_ascii_case("-PDB:");
+            explicit_ilk |=
+                prefix.eq_ignore_ascii_case("/ILK:") || prefix.eq_ignore_ascii_case("-ILK:");
+            cache_relevant_flags.push(arg.clone());
+            continue;
+        }
+
         // Other flags
         if arg.starts_with('/') || arg.starts_with('-') {
             cache_relevant_flags.push(arg.clone());
@@ -77,6 +155,28 @@ pub(super) fn parse_msvc_link(tool: &str, args: Vec<String>) -> ParsedLinkerInvo
         let ext = if is_dll { "dll" } else { "exe" };
         NormalizedPath::new(first.with_extension(ext))
     });
+    if has_debug {
+        secondary_outputs.extend(debug_outputs);
+    }
+    let incremental_enabled =
+        incremental == Some(true) || (has_debug && incremental != Some(false));
+    if incremental_enabled {
+        secondary_outputs.extend(incremental_outputs);
+    }
+    if has_debug && !explicit_pdb {
+        secondary_outputs.push(NormalizedPath::new(output_file.with_extension("pdb")));
+    }
+    // /DEBUG changes LINK's default to incremental linking unless explicitly
+    // disabled. Both /DEBUG's implicit case and explicit /INCREMENTAL create
+    // an ILK whose default name follows the image output.
+    if incremental_enabled && !explicit_ilk {
+        secondary_outputs.push(NormalizedPath::new(output_file.with_extension("ilk")));
+    }
+    if implicit_map {
+        secondary_outputs.push(NormalizedPath::new(output_file.with_extension("map")));
+    }
+    let mut seen_outputs = std::collections::HashSet::new();
+    secondary_outputs.retain(|output| seen_outputs.insert(output.clone()));
 
     ParsedLinkerInvocation::Cacheable(CacheableLink {
         tool: NormalizedPath::new(tool),

--- a/crates/zccache-compiler/src/parse_linker/tests/compiler_driver.rs
+++ b/crates/zccache-compiler/src/parse_linker/tests/compiler_driver.rs
@@ -180,3 +180,26 @@ fn gcc_no_secondary_outputs() {
         other => panic!("expected cacheable, got: {other:?}"),
     }
 }
+
+#[test]
+fn gcc_driver_declares_wl_map_and_dependency_outputs() {
+    let result = parse_linker_invocation(
+        "gcc",
+        args(&[
+            "-o",
+            "app",
+            "-Wl,-Map,reports/app.map,--dependency-file=deps/app.d",
+            "main.o",
+        ]),
+    );
+    let ParsedLinkerInvocation::Cacheable(c) = result else {
+        panic!("expected cacheable")
+    };
+    assert_eq!(
+        c.secondary_outputs,
+        vec![
+            NormalizedPath::new("reports/app.map"),
+            NormalizedPath::new("deps/app.d"),
+        ]
+    );
+}

--- a/crates/zccache-compiler/src/parse_linker/tests/gnu_ld.rs
+++ b/crates/zccache-compiler/src/parse_linker/tests/gnu_ld.rs
@@ -469,3 +469,37 @@ fn gnu_ld_no_secondary_outputs() {
         other => panic!("expected cacheable, got: {other:?}"),
     }
 }
+
+#[test]
+fn gnu_ld_declares_map_and_dependency_outputs() {
+    let result = parse_linker_invocation(
+        "ld",
+        args(&[
+            "-o",
+            "app",
+            "-Map=reports/app.map",
+            "--dependency-file",
+            "deps/app.d",
+            "main.o",
+        ]),
+    );
+    let ParsedLinkerInvocation::Cacheable(c) = result else {
+        panic!("expected cacheable")
+    };
+    assert_eq!(
+        c.secondary_outputs,
+        vec![
+            NormalizedPath::new("reports/app.map"),
+            NormalizedPath::new("deps/app.d"),
+        ]
+    );
+}
+
+#[test]
+fn gnu_ld_stdout_map_is_not_a_file_output() {
+    let result = parse_linker_invocation("ld", args(&["-o", "app", "-Map=-", "main.o"]));
+    let ParsedLinkerInvocation::Cacheable(c) = result else {
+        panic!("expected cacheable")
+    };
+    assert!(c.secondary_outputs.is_empty());
+}

--- a/crates/zccache-compiler/src/parse_linker/tests/msvc_link.rs
+++ b/crates/zccache-compiler/src/parse_linker/tests/msvc_link.rs
@@ -211,3 +211,98 @@ fn msvc_case_insensitive_dll_flag() {
         other => panic!("expected cacheable, got: {other:?}"),
     }
 }
+
+#[test]
+fn msvc_declares_explicit_debug_side_outputs() {
+    let result = parse_linker_invocation(
+        "link.exe",
+        args(&[
+            "/OUT:foo.exe",
+            "/DEBUG",
+            "/PDB:symbols/foo.pdb",
+            "/ILK:state/foo.ilk",
+            "/MAP:maps/foo.map",
+            "/PDBSTRIPPED:symbols/foo-public.pdb",
+            "main.obj",
+        ]),
+    );
+    let ParsedLinkerInvocation::Cacheable(c) = result else {
+        panic!("expected cacheable")
+    };
+    assert_eq!(
+        c.secondary_outputs,
+        vec![
+            NormalizedPath::new("maps/foo.map"),
+            NormalizedPath::new("symbols/foo.pdb"),
+            NormalizedPath::new("symbols/foo-public.pdb"),
+            NormalizedPath::new("state/foo.ilk"),
+        ]
+    );
+}
+
+#[test]
+fn msvc_declares_implicit_debug_incremental_and_map_outputs() {
+    let result = parse_linker_invocation(
+        "link.exe",
+        args(&["/DEBUG", "/MAP", "/OUT:bin/foo.exe", "main.obj"]),
+    );
+    let ParsedLinkerInvocation::Cacheable(c) = result else {
+        panic!("expected cacheable")
+    };
+    assert_eq!(
+        c.secondary_outputs,
+        vec![
+            NormalizedPath::new("bin/foo.pdb"),
+            NormalizedPath::new("bin/foo.ilk"),
+            NormalizedPath::new("bin/foo.map"),
+        ]
+    );
+}
+
+#[test]
+fn msvc_debug_incremental_no_omits_implicit_ilk() {
+    let result = parse_linker_invocation(
+        "link.exe",
+        args(&["/DEBUG", "/INCREMENTAL:NO", "/OUT:foo.exe", "main.obj"]),
+    );
+    let ParsedLinkerInvocation::Cacheable(c) = result else {
+        panic!("expected cacheable")
+    };
+    assert_eq!(c.secondary_outputs, vec![NormalizedPath::new("foo.pdb")]);
+}
+
+#[test]
+fn msvc_ignored_pdb_and_ilk_options_are_not_declared() {
+    let result = parse_linker_invocation(
+        "link.exe",
+        args(&[
+            "/OUT:foo.exe",
+            "/PDB:foo.pdb",
+            "/ILK:foo.ilk",
+            "/INCREMENTAL:NO",
+            "main.obj",
+        ]),
+    );
+    let ParsedLinkerInvocation::Cacheable(c) = result else {
+        panic!("expected cacheable")
+    };
+    assert!(c.secondary_outputs.is_empty());
+}
+
+#[test]
+fn msvc_debug_none_does_not_declare_debug_outputs() {
+    let result = parse_linker_invocation(
+        "link.exe",
+        args(&[
+            "/DEBUG:NONE",
+            "/PDB:foo.pdb",
+            "/ILK:foo.ilk",
+            "/OUT:foo.exe",
+            "main.obj",
+        ]),
+    );
+    let ParsedLinkerInvocation::Cacheable(c) = result else {
+        panic!("expected cacheable")
+    };
+    assert!(c.secondary_outputs.is_empty());
+}

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -253,8 +253,14 @@ pub(super) async fn handle_link_ephemeral(
             };
             let targets: Vec<(NormalizedPath, NormalizedPath)> = (0..payloads.len())
                 .map(|i| {
-                    let target: NormalizedPath = if payloads.len() == 1 {
+                    let target: NormalizedPath = if i == 0 {
                         output_path.clone()
+                    } else if let Some(secondary) = parsed_tool.secondary_outputs.get(i - 1) {
+                        if secondary.is_absolute() {
+                            secondary.clone()
+                        } else {
+                            cwd_path.join(secondary).into()
+                        }
                     } else {
                         output_path
                             .parent()

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
@@ -404,6 +404,9 @@ impl StagedCompilePlan {
         if !super::staged_link_lane_enabled() {
             return Ok(None);
         }
+        if has_unmodeled_link_output_option(args) {
+            return Ok(None);
+        }
         let root = artifact_dir.join(".staged-v2").join(format!(
             ".link-{}-{}",
             std::process::id(),
@@ -417,6 +420,10 @@ impl StagedCompilePlan {
             let mut outputs = Vec::with_capacity(requested_outputs.len());
             let mut rewritten_args = args.to_vec();
             for requested in requested_outputs {
+                let requested_text = requested.to_string_lossy();
+                if requested_text.contains('%') || requested.as_path().is_dir() {
+                    return Ok(None);
+                }
                 let filename = requested.file_name().ok_or_else(|| {
                     io::Error::new(io::ErrorKind::InvalidInput, "link output has no filename")
                 })?;
@@ -426,7 +433,6 @@ impl StagedCompilePlan {
                 }) {
                     return Ok(None);
                 }
-                let requested_text = requested.to_string_lossy();
                 let relative = requested
                     .strip_prefix(cwd)
                     .ok()
@@ -629,6 +635,37 @@ fn rewrite_link_output_arg<'a>(
         }
         _ => None,
     }
+}
+
+fn has_unmodeled_link_output_option(args: &[String]) -> bool {
+    args.iter().any(|arg| {
+        let lower = arg.to_ascii_lowercase();
+        [
+            "/pgd:",
+            "-pgd:",
+            "/ltcgout:",
+            "-ltcgout:",
+            "/idlout:",
+            "-idlout:",
+            "/tlbout:",
+            "-tlbout:",
+            "/winmdfile:",
+            "-winmdfile:",
+            "/midl:",
+            "-midl:",
+            "--stats=",
+        ]
+        .iter()
+        .any(|prefix| lower.starts_with(prefix))
+            || matches!(
+                lower.as_str(),
+                "/winmd" | "-winmd" | "/ltcg:incremental" | "-ltcg:incremental"
+            )
+            || matches!(
+                arg.as_str(),
+                "-map" | "-dependency_info" | "-object_path_lto" | "-save-temps"
+            )
+    })
 }
 
 impl Drop for StagedCompilePlan {
@@ -1034,5 +1071,120 @@ mod tests {
         )
         .unwrap();
         assert!(plan.is_none());
+    }
+
+    #[test]
+    fn link_plan_stages_explicit_msvc_debug_output_set() {
+        if !staged_tests_enabled() {
+            return;
+        }
+        let temp = tempdir().unwrap();
+        let primary: NormalizedPath = temp.path().join("app.exe").into();
+        let pdb: NormalizedPath = temp.path().join("app.pdb").into();
+        let ilk: NormalizedPath = temp.path().join("app.ilk").into();
+        let map: NormalizedPath = temp.path().join("app.map").into();
+        let args = [
+            format!("/OUT:{}", primary.display()),
+            format!("/PDB:{}", pdb.display()),
+            format!("/ILK:{}", ilk.display()),
+            format!("/MAP:{}", map.display()),
+        ];
+        let plan =
+            StagedCompilePlan::link(temp.path(), &args, &primary, &[pdb, ilk, map], temp.path())
+                .unwrap()
+                .unwrap();
+        assert_eq!(plan.outputs.len(), 4);
+        assert!(plan
+            .rewritten_args
+            .iter()
+            .all(|arg| arg.contains(".staged-v2")));
+        plan.cleanup().unwrap();
+    }
+
+    #[test]
+    fn link_plan_rejects_implicit_msvc_side_output_before_spawn() {
+        if !staged_tests_enabled() {
+            return;
+        }
+        let temp = tempdir().unwrap();
+        let primary: NormalizedPath = temp.path().join("app.exe").into();
+        let implicit_pdb: NormalizedPath = temp.path().join("app.pdb").into();
+        let plan = StagedCompilePlan::link(
+            temp.path(),
+            &["/DEBUG".into(), format!("/OUT:{}", primary.display())],
+            &primary,
+            &[implicit_pdb],
+            temp.path(),
+        )
+        .unwrap();
+        assert!(plan.is_none());
+    }
+
+    #[test]
+    fn link_plan_rejects_semantic_gnu_map_destination() {
+        if !staged_tests_enabled() {
+            return;
+        }
+        let temp = tempdir().unwrap();
+        let primary: NormalizedPath = temp.path().join("app").into();
+        let semantic_map: NormalizedPath = temp.path().join("%.map").into();
+        let plan = StagedCompilePlan::link(
+            temp.path(),
+            &[
+                "-o".into(),
+                primary.to_string_lossy().into_owned(),
+                format!("-Map={}", semantic_map.display()),
+            ],
+            &primary,
+            &[semantic_map],
+            temp.path(),
+        )
+        .unwrap();
+        assert!(plan.is_none());
+    }
+
+    #[test]
+    fn link_plan_rejects_unmodeled_output_option_before_spawn() {
+        if !staged_tests_enabled() {
+            return;
+        }
+        let temp = tempdir().unwrap();
+        let primary: NormalizedPath = temp.path().join("app.exe").into();
+        let plan = StagedCompilePlan::link(
+            temp.path(),
+            &[
+                format!("/OUT:{}", primary.display()),
+                "/LTCGOUT:state/app.iobj".into(),
+            ],
+            &primary,
+            &[],
+            temp.path(),
+        )
+        .unwrap();
+        assert!(plan.is_none());
+    }
+
+    #[test]
+    fn link_plan_accepts_case_sensitive_gnu_map_option() {
+        if !staged_tests_enabled() {
+            return;
+        }
+        let temp = tempdir().unwrap();
+        let primary: NormalizedPath = temp.path().join("app").into();
+        let map: NormalizedPath = temp.path().join("app.map").into();
+        let plan = StagedCompilePlan::link(
+            temp.path(),
+            &[
+                "-o".into(),
+                primary.to_string_lossy().into_owned(),
+                "-Map".into(),
+                map.to_string_lossy().into_owned(),
+            ],
+            &primary,
+            &[map],
+            temp.path(),
+        )
+        .unwrap();
+        assert!(plan.is_some());
     }
 }

--- a/crates/zccache/tests/daemon_link_cache_test.rs
+++ b/crates/zccache/tests/daemon_link_cache_test.rs
@@ -404,6 +404,81 @@ async fn test_link_path_remap_auto_hits_across_sibling_git_roots() {
 }
 
 #[tokio::test]
+#[ignore] // Integration test — starts a real daemon + compiler driver.
+async fn test_link_hit_restores_explicit_map_destination() {
+    let archiver = match zccache::test_support::find_on_path("ar")
+        .or_else(|| zccache::test_support::find_on_path("llvm-ar"))
+    {
+        Some(path) => path,
+        None => {
+            eprintln!("skipping test: neither ar nor llvm-ar found on PATH");
+            return;
+        }
+    };
+    let compiler = ["clang", "gcc"]
+        .into_iter()
+        .filter_map(zccache::test_support::find_on_path)
+        .find(|compiler| compiler_driver_link_is_feasible(compiler, &archiver).is_ok());
+    let Some(compiler) = compiler else {
+        eprintln!("skipping test: no usable clang/gcc compiler-driver link found");
+        return;
+    };
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("repo");
+    setup_equivalent_c_root(&compiler, &archiver, &root).unwrap();
+    std::fs::create_dir_all(root.join("reports")).unwrap();
+    let output = root.join("build").join(linked_binary_name("mapped"));
+    let map = root.join("reports/mapped.map");
+    let mut args = compiler_driver_link_args(&root, &output);
+    args.insert(2, "-Wl,-Map,reports/mapped.map".to_string());
+
+    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+    client.send(&Request::Clear).await.unwrap();
+    let _: Option<Response> = client.recv().await.unwrap();
+
+    for expected_cached in [false, true] {
+        client
+            .send(&Request::LinkEphemeral {
+                client_pid: std::process::id(),
+                tool: compiler.to_string_lossy().into_owned().into(),
+                args: args.clone(),
+                cwd: root.to_string_lossy().into_owned().into(),
+                env: None,
+            })
+            .await
+            .unwrap();
+        let response = client.recv().await.unwrap();
+        match response {
+            Some(Response::LinkResult {
+                exit_code, cached, ..
+            }) => {
+                assert_eq!(exit_code, 0);
+                assert_eq!(cached, expected_cached);
+            }
+            other => panic!("expected LinkResult, got: {other:?}"),
+        }
+        assert!(output.exists(), "primary output must exist");
+        assert!(
+            map.exists(),
+            "map must use its declared reports/ destination"
+        );
+        if !expected_cached {
+            std::fs::remove_file(&output).unwrap();
+            std::fs::remove_file(&map).unwrap();
+        }
+    }
+
+    assert!(
+        !root.join("build/mapped.map").exists(),
+        "hit must not relocate the map beside the primary output"
+    );
+    shutdown.notify_one();
+    server_handle.await.unwrap();
+}
+
+#[tokio::test]
 #[ignore] // Integration test — starts a real daemon. Run with `test --full`.
 async fn test_ar_cache_invalidated_on_input_change() {
     let ar_path = match zccache::test_support::find_on_path("ar") {

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -37,6 +37,11 @@ private directory is checked for undeclared files/bundles after the linker
 exits, and the requested output directory is checked for external side
 effects. Either condition prevents cache publication; declared outputs are
 independently salvaged to preserve a successful link.
+Explicit GNU/LLVM map and dependency-file paths and active MSVC PDB, ILK,
+stripped-PDB, and map paths are declared secondary outputs. Implicit names,
+GNU semantic map destinations (`%` or a directory), and conditional
+LTCG/PGO/embedded-IDL/Windows-metadata outputs remain on the legacy path
+before spawn.
 
 Generic tool execution also participates in the `all` lane when every
 declared output is an exact argument token. Those paths are rewritten into a


### PR DESCRIPTION
## Summary
- declare GNU/LLVM map and dependency-file outputs, including compiler-driver -Wl forms
- declare active MSVC PDB, stripped-PDB, ILK, and MAP outputs while respecting /DEBUG:NONE and /INCREMENTAL:NO`n- fail staging before spawn for implicit, semantic, ambiguous, and still-unmodeled output forms
- restore cache-hit secondary outputs to their exact parser-declared destinations instead of relocating them beside the primary

## Adversarial coverage
- conditional MSVC output activation and ignored-option cases
- absolute, embedded, ambiguous, implicit, semantic %, case-sensitive GNU, and unmodeled output planner cases
- real compiler-driver miss/delete/hit map restoration in a separate directory, with staged mode on Windows and Linux

## Validation
- Windows compiler suite: 335 passed
- Windows daemon-core suite: 457 passed, 19 ignored
- Windows real map miss/hit: passed in legacy and staged modes
- Linux Docker real staged map miss/hit: passed
- Linux Docker rustfmt: passed
- scoped Linux Docker Clippy: passed (existing unrelated warnings remain)

Related to #1056; this does not close the parent because conditional LTCG/PGO/embedded-IDL/Windows-metadata outputs, dSYM/bundle handling, semantic delivery policy, migration, observability, and final performance/default-on gates remain.