### PR TITLE
feat: apply semantic delivery policy to staged hits

### DIFF
--- a/crates/zccache-compiler/src/lib.rs
+++ b/crates/zccache-compiler/src/lib.rs
@@ -37,7 +37,10 @@ use std::sync::Arc;
 use zccache_core::NormalizedPath;
 
 pub use detect::detect_family;
-pub use output_policy::{DeliveryPolicy, MutationContract, OutputClassification, OutputRole};
+pub use output_policy::{
+    rustc_archive_hardlink_eligible, rustc_output_delivery, DeliveryPolicy, MutationContract,
+    OutputClassification, OutputRole,
+};
 pub use parse::parse_invocation;
 
 /// Supported compiler families.

--- a/crates/zccache-compiler/src/output_policy.rs
+++ b/crates/zccache-compiler/src/output_policy.rs
@@ -122,6 +122,52 @@ impl OutputClassification {
     }
 }
 
+/// Return the semantic delivery policy for a rustc output. The `.rlib`
+/// allowlist is gated by parsed crate type, so `--crate-type bin -o fake.rlib`
+/// remains independent. Rust metadata is a read-only compiler interface for
+/// every cacheable crate type.
+#[must_use]
+pub fn rustc_output_delivery(
+    archive_hardlink_eligible: bool,
+    output: &std::path::Path,
+) -> DeliveryPolicy {
+    let extension = output.extension().and_then(|ext| ext.to_str());
+    if extension == Some("rmeta") {
+        return DeliveryPolicy::HardlinkEligible;
+    }
+    if extension != Some("rlib") {
+        return DeliveryPolicy::IndependentOnly;
+    }
+    if archive_hardlink_eligible {
+        DeliveryPolicy::HardlinkEligible
+    } else {
+        DeliveryPolicy::IndependentOnly
+    }
+}
+
+/// Parse rustc crate-type flags for the archive hardlink allowlist.
+#[must_use]
+pub fn rustc_archive_hardlink_eligible(args: &[String]) -> bool {
+    let mut crate_types = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--crate-type" {
+            if let Some(value) = args.get(i + 1) {
+                crate_types.extend(value.split(','));
+            }
+            i += 2;
+            continue;
+        }
+        if let Some(value) = args[i].strip_prefix("--crate-type=") {
+            crate_types.extend(value.split(','));
+        }
+        i += 1;
+    }
+    crate_types
+        .into_iter()
+        .any(|crate_type| matches!(crate_type, "lib" | "rlib"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -156,5 +202,27 @@ mod tests {
             OutputClassification::for_compiler(CompilerFamily::Gcc, "custom.output").delivery,
             DeliveryPolicy::IndependentOnly
         );
+    }
+
+    #[test]
+    fn rust_archive_policy_requires_semantic_crate_type() {
+        assert_eq!(
+            rustc_output_delivery(true, std::path::Path::new("x.rlib")),
+            DeliveryPolicy::HardlinkEligible
+        );
+        assert_eq!(
+            rustc_output_delivery(false, std::path::Path::new("x.rlib")),
+            DeliveryPolicy::IndependentOnly
+        );
+        assert_eq!(
+            rustc_output_delivery(false, std::path::Path::new("x.rmeta")),
+            DeliveryPolicy::HardlinkEligible
+        );
+        assert!(rustc_archive_hardlink_eligible(&[
+            "--crate-type=rlib".into()
+        ]));
+        assert!(!rustc_archive_hardlink_eligible(&[
+            "--crate-type=bin".into()
+        ]));
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
@@ -50,6 +50,10 @@ pub(super) struct CachedHitMaterializeRequest<'a> {
     pub(super) downgrade_output_metadata: bool,
     pub(super) mtime_floor_paths: Vec<NormalizedPath>,
     pub(super) rustc_metadata_compat_outputs: Option<Vec<NormalizedPath>>,
+    /// `Some` identifies a parsed rustc invocation and records whether its
+    /// crate type authorizes `.rlib` delivery. `.rmeta` remains eligible for
+    /// any parsed rustc invocation; `None` keeps staged outputs independent.
+    pub(super) rustc_archive_hardlink_eligible: Option<bool>,
     pub(super) phases: CachedHitPhases,
 }
 
@@ -71,6 +75,7 @@ pub(super) fn materialize_cached_compile_hit(
         downgrade_output_metadata,
         mtime_floor_paths,
         rustc_metadata_compat_outputs,
+        rustc_archive_hardlink_eligible,
         phases,
     } = request;
 
@@ -151,7 +156,23 @@ pub(super) fn materialize_cached_compile_hit(
                 .collect();
             (targets, payloads.iter().cloned().collect())
         };
-    if !write_payloads_par_with_mtime_floor(&targets, &payloads_to_write, &mtime_floor_paths) {
+    let delivery_policies = targets
+        .iter()
+        .map(|(target, _)| {
+            rustc_archive_hardlink_eligible.map_or(
+                crate::compiler::DeliveryPolicy::IndependentOnly,
+                |archive_eligible| {
+                    crate::compiler::rustc_output_delivery(archive_eligible, target.as_path())
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+    if !write_payloads_par_with_mtime_floor_and_policies(
+        &targets,
+        &payloads_to_write,
+        &mtime_floor_paths,
+        &delivery_policies,
+    ) {
         return None;
     }
     let t2 = Instant::now();
@@ -310,6 +331,7 @@ mod tests {
             downgrade_output_metadata: true,
             mtime_floor_paths: Vec::new(),
             rustc_metadata_compat_outputs: None,
+            rustc_archive_hardlink_eligible: None,
             phases: CachedHitPhases::request_cache(0, 0),
         })
         .unwrap();
@@ -418,6 +440,7 @@ mod tests {
             downgrade_output_metadata: true,
             mtime_floor_paths: Vec::new(),
             rustc_metadata_compat_outputs: None,
+            rustc_archive_hardlink_eligible: None,
             phases: CachedHitPhases::request_cache(0, 0),
         })
         .expect("materialize_cached_compile_hit must succeed");
@@ -509,6 +532,7 @@ mod tests {
             downgrade_output_metadata: false,
             mtime_floor_paths: Vec::new(),
             rustc_metadata_compat_outputs: None,
+            rustc_archive_hardlink_eligible: None,
             phases: CachedHitPhases::request_cache(0, 0),
         })
         .expect("legacy single-output hit must still succeed");
@@ -588,6 +612,7 @@ mod tests {
                 downgrade_output_metadata: false,
                 mtime_floor_paths: Vec::new(),
                 rustc_metadata_compat_outputs: None,
+                rustc_archive_hardlink_eligible: None,
                 phases: CachedHitPhases::request_cache(0, 0),
             })
             .expect("materialize_cached_compile_hit must succeed");

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
@@ -111,6 +111,14 @@ pub(super) fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Option<R
     };
     let rustc_requested_outputs =
         rustc_explicit_requested_outputs(effective_args, &output_path, cwd);
+    let compiler_name = compiler_path
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let rustc_archive_hardlink_eligible = (compiler_name.contains("rustc")
+        || compiler_name == "clippy-driver")
+        .then(|| crate::compiler::rustc_archive_hardlink_eligible(effective_args));
     materialize_cached_compile_hit(CachedHitMaterializeRequest {
         state,
         sid,
@@ -126,6 +134,7 @@ pub(super) fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Option<R
         downgrade_output_metadata: false,
         mtime_floor_paths,
         rustc_metadata_compat_outputs: rustc_requested_outputs,
+        rustc_archive_hardlink_eligible,
         phases: CachedHitPhases::request_cache(request_cache_lookup_ns, cross_root_validate_ns),
     })
 }
@@ -250,6 +259,8 @@ pub(super) async fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
         downgrade_output_metadata: true,
         mtime_floor_paths: input_paths.clone(),
         rustc_metadata_compat_outputs: rustc_requested_outputs,
+        rustc_archive_hardlink_eligible: is_rustc
+            .then(|| crate::compiler::rustc_archive_hardlink_eligible(effective_args)),
         phases: CachedHitPhases {
             parse_args_ns,
             build_context_ns,
@@ -386,6 +397,8 @@ pub(super) async fn try_depgraph_cached_hit(probe: DepgraphHitProbe<'_>) -> Opti
         downgrade_output_metadata: true,
         mtime_floor_paths: input_paths.clone(),
         rustc_metadata_compat_outputs: rustc_requested_outputs,
+        rustc_archive_hardlink_eligible: is_rustc
+            .then(|| crate::compiler::rustc_archive_hardlink_eligible(effective_args)),
         phases: CachedHitPhases {
             parse_args_ns,
             build_context_ns,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -666,6 +666,12 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                                 &ctx,
                             ),
                             rustc_metadata_compat_outputs: Some(requested_outputs),
+                            rustc_archive_hardlink_eligible: Some(
+                                rustc_args
+                                    .crate_types
+                                    .iter()
+                                    .any(|kind| matches!(kind.as_str(), "lib" | "rlib")),
+                            ),
                             phases: CachedHitPhases {
                                 parse_args_ns,
                                 build_context_ns,

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -382,6 +382,15 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
                     ),
                 )
             })?;
+            write_authoritative_blob_digest_for(&destination, &destination).map_err(|error| {
+                io::Error::new(
+                    error.kind(),
+                    format!(
+                        "staged output durable digest failed: {}: {error}",
+                        destination.display()
+                    ),
+                )
+            })?;
             outputs.push(StagedOutput {
                 index,
                 size,

--- a/crates/zccache-daemon-core/src/daemon/server/persist/write_cached.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/write_cached.rs
@@ -11,23 +11,35 @@ pub(in crate::daemon::server) fn write_cached_output(
         remove_materialized_output(out_path)?;
         return std::fs::write(out_path, data);
     }
-    materialize_cached_file(out_path, cache_file)
+    materialize_cached_file(
+        out_path,
+        cache_file,
+        crate::compiler::DeliveryPolicy::IndependentOnly,
+    )
 }
 
 pub(in crate::daemon::server) fn write_cached_file(
     out_path: &Path,
     cache_file: &Path,
 ) -> std::io::Result<()> {
-    materialize_cached_file(out_path, cache_file)
+    materialize_cached_file(
+        out_path,
+        cache_file,
+        crate::compiler::DeliveryPolicy::IndependentOnly,
+    )
 }
 
-fn materialize_cached_file(out_path: &Path, cache_file: &Path) -> std::io::Result<()> {
+fn materialize_cached_file(
+    out_path: &Path,
+    cache_file: &Path,
+    delivery: crate::compiler::DeliveryPolicy,
+) -> std::io::Result<()> {
     let staged = is_staged_artifact_path(cache_file);
-    if !staged {
-        verify_registered_blob(cache_file)?;
-    }
+    verify_registered_blob(cache_file)?;
+    let hardlink_allowed =
+        !staged || matches!(delivery, crate::compiler::DeliveryPolicy::HardlinkEligible);
     if same_file(out_path, cache_file) {
-        if staged {
+        if !hardlink_allowed {
             let floor =
                 filetime::FileTime::from_last_modification_time(&std::fs::metadata(cache_file)?);
             detach_with_floored_mtime(out_path, cache_file, floor)?;
@@ -55,7 +67,9 @@ fn materialize_cached_file(out_path: &Path, cache_file: &Path) -> std::io::Resul
     // call sites in this module; a genuinely-too-many-links file still
     // fails the real `std::fs::hard_link` call below, which already has
     // a graceful copy fallback.
-    if !staged && hardlink_below_limit(caps, hard_link_count(cache_file).unwrap_or_default()) {
+    if hardlink_allowed
+        && hardlink_below_limit(caps, hard_link_count(cache_file).unwrap_or_default())
+    {
         // Only flip the blob read-only *after* the link actually lands.
         // Read-only exists to protect the blob once it's shared; setting
         // it beforehand serves no purpose on the attempt path and, if
@@ -215,6 +229,18 @@ pub(in crate::daemon::server) fn write_cached_payload(
     }
 }
 
+pub(in crate::daemon::server) fn write_cached_payload_with_policy(
+    out_path: &Path,
+    cache_file: &Path,
+    payload: &CachedPayload,
+    delivery: crate::compiler::DeliveryPolicy,
+) -> std::io::Result<()> {
+    match payload {
+        CachedPayload::Bytes(data) => write_cached_output(out_path, cache_file, data),
+        CachedPayload::File(path) => materialize_cached_file(out_path, path, delivery),
+    }
+}
+
 pub(in crate::daemon::server) const PAR_WRITE_THRESHOLD: usize = 4;
 
 pub(in crate::daemon::server) fn write_payloads_par<P, Q>(
@@ -245,6 +271,7 @@ where
         .all(|((out, cache), payload)| write_one(out.as_ref(), cache.as_ref(), payload))
 }
 
+#[cfg(test)]
 pub(in crate::daemon::server) fn write_payloads_par_with_mtime_floor<P, Q, R>(
     targets: &[(P, Q)],
     payloads: &[CachedPayload],
@@ -255,14 +282,58 @@ where
     Q: AsRef<Path> + Sync,
     R: AsRef<Path>,
 {
-    if !write_payloads_par(targets, payloads) {
-        return false;
+    let policies = vec![crate::compiler::DeliveryPolicy::IndependentOnly; targets.len()];
+    write_payloads_par_with_mtime_floor_and_policies(targets, payloads, floor_paths, &policies)
+}
+
+pub(in crate::daemon::server) fn write_payloads_par_with_mtime_floor_and_policies<P, Q, R>(
+    targets: &[(P, Q)],
+    payloads: &[CachedPayload],
+    floor_paths: &[R],
+    policies: &[crate::compiler::DeliveryPolicy],
+) -> bool
+where
+    P: AsRef<Path> + Sync,
+    Q: AsRef<Path> + Sync,
+    R: AsRef<Path>,
+{
+    debug_assert_eq!(targets.len(), payloads.len());
+    debug_assert_eq!(targets.len(), policies.len());
+    let write_one = |out: &Path,
+                     cache: &Path,
+                     payload: &CachedPayload,
+                     policy: crate::compiler::DeliveryPolicy|
+     -> bool {
+        if let Some(parent) = out.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        write_cached_payload_with_policy(out, cache, payload, policy).is_ok()
+    };
+    let ok = if targets.len() < PAR_WRITE_THRESHOLD {
+        targets
+            .iter()
+            .zip(payloads)
+            .zip(policies)
+            .all(|(((out, cache), payload), policy)| {
+                write_one(out.as_ref(), cache.as_ref(), payload, *policy)
+            })
+    } else {
+        use rayon::prelude::*;
+        targets
+            .par_iter()
+            .zip(payloads.par_iter())
+            .zip(policies.par_iter())
+            .all(|(((out, cache), payload), policy)| {
+                write_one(out.as_ref(), cache.as_ref(), payload, *policy)
+            })
+    };
+    if ok {
+        let batch_floor = std::time::SystemTime::now();
+        floor_materialized_outputs_to_input_max(
+            targets.iter().map(|(out, _)| out.as_ref()),
+            floor_paths.iter().map(|path| path.as_ref()),
+            batch_floor,
+        );
     }
-    let batch_floor = std::time::SystemTime::now();
-    floor_materialized_outputs_to_input_max(
-        targets.iter().map(|(out, _)| out.as_ref()),
-        floor_paths.iter().map(|path| path.as_ref()),
-        batch_floor,
-    );
-    true
+    ok
 }

--- a/crates/zccache-daemon-core/src/daemon/server/tests/write_cached.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/write_cached.rs
@@ -292,6 +292,61 @@ fn staged_generation_materializes_independently_from_the_backend() {
     );
 }
 
+#[test]
+fn staged_generation_hardlinks_only_when_semantically_authorized() {
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    std::fs::create_dir_all(&artifact_dir).unwrap();
+    let source = dir.path().join("source.rlib");
+    let output = dir.path().join("target.rlib");
+    std::fs::write(&source, b"semantic rust archive").unwrap();
+    let key = "e".repeat(64);
+    persist_staged_artifact_paths(&artifact_dir, &key, &[source.into()]).unwrap();
+    let payloads = load_staged_artifact_paths(&artifact_dir, &key, &[21])
+        .unwrap()
+        .unwrap();
+    let payload = CachedPayload::File(payloads[0].clone());
+    write_cached_payload_with_policy(
+        &output,
+        &payloads[0],
+        &payload,
+        crate::compiler::DeliveryPolicy::HardlinkEligible,
+    )
+    .unwrap();
+    if !require_hardlink(
+        &output,
+        &payloads[0],
+        "staged_generation_hardlinks_only_when_semantically_authorized",
+    ) {
+        return;
+    }
+
+    make_writable(&output).unwrap();
+    std::fs::write(&output, b"poisoned rust archive").unwrap();
+    mark_registered_links_suspect([output.as_path()]);
+    assert!(
+        verify_registered_blob(&payloads[0]).is_err(),
+        "a hardlink contract violation must be rejected before serve"
+    );
+}
+
+#[test]
+fn staged_generation_digest_survives_registry_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    std::fs::create_dir_all(&artifact_dir).unwrap();
+    let source = dir.path().join("source.rmeta");
+    std::fs::write(&source, b"semantic rust metadata").unwrap();
+    let key = "d".repeat(64);
+    persist_staged_artifact_paths(&artifact_dir, &key, &[source.into()]).unwrap();
+    let payloads = load_staged_artifact_paths(&artifact_dir, &key, &[22])
+        .unwrap()
+        .unwrap();
+    forget_blob_registration_for_restart_test(&payloads[0]);
+    verify_registered_blob(&payloads[0])
+        .expect("the v2 generation digest must rebuild registry trust after restart");
+}
+
 /// Regression test for issue #1042 finding #1: fix #1 (writing the digest
 /// sidecar *before* the publishing rename, not after) is what actually
 /// closes the "valid blob evicted on restart" gap for freshly-persisted

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -50,10 +50,18 @@ the run. Generic tools whose output paths are embedded in opaque arguments,
 environment variables, or undeclared side effects retain the legacy path.
 
 Published v2 files are always independent copies or true reflinks of private
-compiler files. Hardlinks are not used by the staged lane. Requested output
-materialization also uses reflink/copy only; this is especially important for
-SQLite, databases, incremental state, depfiles, and unknown outputs because an
-NTFS hardlink is a shared mutable inode, not COW.
+compiler files. Hardlinks are never used between compiler staging and the
+backend. Requested-output delivery may use the hardlink-shared tier only for
+parser-authorized rustc metadata and `lib`/`rlib` archives; a `.rlib` suffix
+without the matching rustc crate type is not authorization. SQLite, databases,
+incremental state, depfiles, executables, and unknown outputs remain on
+reflink/copy because an NTFS hardlink is a shared mutable inode, not COW.
+
+Every v2 output carries the same durable COW digest sidecar used by the legacy
+hardlink registry. This lets restart verification reject a mutate-then-delete
+alias attack before the backend is served. Read-only enforcement, watcher
+suspicion, file-identity registration, link-count limits, and copy fallback
+remain mandatory for the narrow semantic allowlist.
 
 The v2 transaction is visible only after the complete generation and manifest
 are written and the per-key pointer is switched. Readers validate the pointer,


### PR DESCRIPTION
## Summary
- route v2 cache hits through per-output semantic delivery policy
- allow hardlink-shared delivery only for rustc .rmeta and .rlib outputs whose parsed crate type is lib/lib`n- keep spoofed .rlib names, databases, depfiles, executables, and unknown outputs on reflink/copy
- publish durable COW digest sidecars for every v2 output so restart verification can rebuild trust
- retain read-only enforcement, file-identity registration, watcher suspicion, link-count ceilings, and copy fallback

## Adversarial coverage
- --crate-type bin -o fake.rlib remains independent
- authorized staged Rust archive uses hardlink tier when the filesystem lacks reflink and supports hardlinks
- deliberate in-place mutation is marked suspect and rejected before serve
- mutate/delete-alias restart trust is backed by a durable digest
- mutable staged outputs remain independently materialized

## Validation
- Windows compiler: 337 passed
- Windows daemon-core: 460 passed, 19 ignored
- Linux Docker daemon-core: 467 passed, 19 ignored
- focused staged policy/restart/mutation tests: 7 passed on Windows and Linux
- Docker rustfmt: passed
- scoped Docker Clippy: passed with three pre-existing unrelated warnings

Related to #1056. The parent remains open for remaining conditional producer coverage, default-on rollout/migration, observability, and final sanctioned performance gates.