### PR TITLE
feat(cache): enable staged artifacts by default

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/embedded.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/embedded.rs
@@ -37,7 +37,8 @@ impl EmbeddedDaemon {
     ) -> Result<Self, crate::ipc::IpcError> {
         let backend_identity = crate::ipc::current_backend_identity(&endpoint)
             .map_err(|err| crate::ipc::IpcError::Endpoint(err.to_string()))?;
-        let (state, index_writer_rx) = new_shared_state(&endpoint, &cache_dir, backend_identity);
+        let (state, index_writer_rx) = new_shared_state(&endpoint, &cache_dir, backend_identity)
+            .map_err(|error| crate::ipc::IpcError::Endpoint(error.to_string()))?;
         // Arm the startup depgraph-load gate as early as possible — before
         // this state can serve any compile. The shared `dep_graph_load_complete`
         // flag inits `true` ("assume loaded"); the standalone daemon flips it
@@ -80,6 +81,9 @@ impl EmbeddedDaemon {
 
         let state = Arc::clone(&self.state);
         let artifact_load = tokio::task::spawn_blocking(move || {
+            if let Err(error) = state.staging.cleanup_abandoned() {
+                tracing::debug!(%error, "abandoned private staging cleanup skipped");
+            }
             if let Err(e) = state.artifact_store.load_from_disk() {
                 tracing::warn!("embedded artifact index load failed, continuing empty: {e}");
             }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -103,7 +103,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     };
     let staged_plan = if is_rustc {
         match StagedCompilePlan::rustc(
-            &state.artifact_dir,
+            state.staging.path(),
             effective_args,
             output_path,
             &expected_outputs,
@@ -118,7 +118,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         }
     } else {
         match StagedCompilePlan::cc(
-            &state.artifact_dir,
+            state.staging.path(),
             compilation.family,
             effective_args,
             output_path,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
@@ -40,7 +40,7 @@ struct ExecStagedPlan {
 
 impl ExecStagedPlan {
     fn build(
-        artifact_dir: &Path,
+        staging_dir: &Path,
         args: &[String],
         output_files: &[NormalizedPath],
         cwd: &Path,
@@ -48,7 +48,7 @@ impl ExecStagedPlan {
         if output_files.is_empty() {
             return None;
         }
-        let root = artifact_dir.join(".staged-v2").join(format!(
+        let root = staging_dir.join(format!(
             ".exec-{}-{}",
             std::process::id(),
             EXEC_STAGE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
@@ -312,7 +312,7 @@ pub(super) async fn handle_generic_tool_exec(
     // us an unambiguous exact-token rewrite for every output. Opaque output
     // syntax remains on the legacy path before spawn.
     let staged_plan = if exec_staging_enabled() {
-        ExecStagedPlan::build(&state.artifact_dir, args, output_files, cwd)
+        ExecStagedPlan::build(state.staging.path(), args, output_files, cwd)
     } else {
         None
     };
@@ -324,7 +324,7 @@ pub(super) async fn handle_generic_tool_exec(
         .map_or_else(|| output_files.to_vec(), ExecStagedPlan::staged_paths);
     for path in &execution_outputs {
         let path = path.as_path();
-        if let Err(error) = break_output_hardlink_before_compile(&path) {
+        if let Err(error) = break_output_hardlink_before_compile(path) {
             tracing::warn!(
                 event = "exec_output_detach_failed",
                 path = %path.display(),

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -311,7 +311,7 @@ pub(super) async fn handle_link_ephemeral(
         cwd_path.join(&parsed_tool.output_file).into()
     };
     let staged_plan = if parsed_tool.is_archive && parsed_tool.secondary_outputs.is_empty() {
-        match StagedCompilePlan::archive(&state.artifact_dir, args, &output_path, cwd_path) {
+        match StagedCompilePlan::archive(state.staging.path(), args, &output_path, cwd_path) {
             Ok(plan) => plan,
             Err(error) => {
                 tracing::warn!(%error, "archive staging plan failed; using legacy path");
@@ -320,7 +320,7 @@ pub(super) async fn handle_link_ephemeral(
         }
     } else {
         match StagedCompilePlan::link(
-            &state.artifact_dir,
+            state.staging.path(),
             args,
             &output_path,
             &parsed_tool.secondary_outputs,

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -32,7 +32,8 @@ impl DaemonServer {
         let listener = IpcListener::bind(endpoint)?;
         let backend_identity = crate::ipc::current_backend_identity(endpoint)
             .map_err(|err| crate::ipc::IpcError::Endpoint(err.to_string()))?;
-        let (state, index_writer_rx) = new_shared_state(endpoint, cache_dir, backend_identity);
+        let (state, index_writer_rx) = new_shared_state(endpoint, cache_dir, backend_identity)
+            .map_err(|error| crate::ipc::IpcError::Endpoint(error.to_string()))?;
 
         Ok(Self {
             listener,
@@ -47,10 +48,10 @@ pub(super) fn new_shared_state(
     endpoint: &str,
     cache_dir: &crate::core::NormalizedPath,
     backend_identity: running_process::broker::protocol_v2::backend_handle::DaemonProcess,
-) -> (
+) -> std::io::Result<(
     Arc<SharedState>,
     tokio::sync::mpsc::UnboundedReceiver<IndexWriterCommand>,
-) {
+)> {
     let shutdown = Arc::new(Notify::new());
     let now = now_secs();
     let instance = SERVER_INSTANCE.fetch_add(1, Ordering::Relaxed);
@@ -162,7 +163,7 @@ pub(super) fn new_shared_state(
         ),
     }
 
-    (
+    Ok((
         Arc::new(SharedState {
             endpoint: endpoint.to_string(),
             backend_identity,
@@ -183,6 +184,7 @@ pub(super) fn new_shared_state(
             stats: StatsCollector::new(),
             profiler: PhaseProfiler::new(),
             artifact_dir,
+            staging: StagingRoot::new(cache_dir.as_path(), instance)?,
             metadata_path,
             compiler_hash_cache_path,
             depfile_tmpdir: {
@@ -225,7 +227,7 @@ pub(super) fn new_shared_state(
             exec_cache: DashMap::new(),
         }),
         index_writer_rx,
-    )
+    ))
 }
 
 impl DaemonServer {

--- a/crates/zccache-daemon-core/src/daemon/server/persist/artifact_io.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/artifact_io.rs
@@ -169,7 +169,7 @@ pub(in crate::daemon::server) fn persist_artifact_paths_with_stats(
     key_hex: &str,
     sources: &[NormalizedPath],
 ) -> std::io::Result<PersistArtifactFileStats> {
-    if staged_artifacts_enabled() && !pack_mode_enabled() {
+    if staged_artifacts_enabled() && staged_key_supported(key_hex) && !pack_mode_enabled() {
         let stats = persist_staged_artifact_paths(artifact_dir, key_hex, sources)?;
         return Ok(PersistArtifactFileStats {
             reflink_count: stats.reflink_count,

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
@@ -29,7 +29,7 @@ impl StagedCompilePlan {
     /// Build a plan for the narrow Phase 3 Rust lane.  A plan is absent for
     /// unsupported invocations, preserving the proven legacy path.
     pub(in crate::daemon::server) fn rustc(
-        artifact_dir: &Path,
+        staging_dir: &Path,
         args: &[String],
         primary_output: &NormalizedPath,
         expected_outputs: &[NormalizedPath],
@@ -38,7 +38,7 @@ impl StagedCompilePlan {
         if !staged_lane_enabled(crate::compiler::CompilerFamily::Rustc) || emit_to_stdout(args) {
             return Ok(None);
         }
-        let root = artifact_dir.join(".staged-v2").join(format!(
+        let root = staging_dir.join(format!(
             ".compile-{}-{}",
             std::process::id(),
             PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
@@ -175,7 +175,7 @@ impl StagedCompilePlan {
     }
 
     pub(in crate::daemon::server) fn cc(
-        artifact_dir: &Path,
+        staging_dir: &Path,
         family: crate::compiler::CompilerFamily,
         args: &[String],
         primary_output: &NormalizedPath,
@@ -208,7 +208,7 @@ impl StagedCompilePlan {
         {
             return Ok(None);
         }
-        let root = artifact_dir.join(".staged-v2").join(format!(
+        let root = staging_dir.join(format!(
             ".compile-{}-{}",
             std::process::id(),
             PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
@@ -339,7 +339,7 @@ impl StagedCompilePlan {
     /// use a separate planner because silently omitting a PDB/import library
     /// would violate complete-set publication.
     pub(in crate::daemon::server) fn archive(
-        artifact_dir: &Path,
+        staging_dir: &Path,
         args: &[String],
         primary_output: &NormalizedPath,
         cwd: &Path,
@@ -347,7 +347,7 @@ impl StagedCompilePlan {
         if !staged_lane_enabled(crate::compiler::CompilerFamily::Gcc) {
             return Ok(None);
         }
-        let root = artifact_dir.join(".staged-v2").join(format!(
+        let root = staging_dir.join(format!(
             ".compile-{}-{}",
             std::process::id(),
             PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
@@ -395,7 +395,7 @@ impl StagedCompilePlan {
     /// by exact path replacement. Undeclared linker side effects are checked
     /// by the caller after the process exits; they invalidate publication.
     pub(in crate::daemon::server) fn link(
-        artifact_dir: &Path,
+        staging_dir: &Path,
         args: &[String],
         primary_output: &NormalizedPath,
         secondary_outputs: &[NormalizedPath],
@@ -407,7 +407,7 @@ impl StagedCompilePlan {
         if has_unmodeled_link_output_option(args) {
             return Ok(None);
         }
-        let root = artifact_dir.join(".staged-v2").join(format!(
+        let root = staging_dir.join(format!(
             ".link-{}-{}",
             std::process::id(),
             PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -1,11 +1,10 @@
-//! Opt-in immutable artifact generations for the staged-output rollout (#1056).
+//! Default-on immutable artifact generations for the staged-output rollout (#1056).
 //!
 //! This is the storage half of the staged compiler-output design. The compiler
-//! still writes its normal output path while this lane is opt-in, but the
+//! writes supported outputs into private staging before publication. The
 //! persisted generation is always independent: reflink when the filesystem can
-//! provide true COW, otherwise a byte copy. Hardlinks are deliberately not used
-//! here because a published generation must not share an inode with a live
-//! compiler output.
+//! provide true COW, otherwise a byte copy. Unsupported plans fall back before
+//! spawn, and `ZCCACHE_STAGED_ARTIFACTS=off` is the rollout kill switch.
 
 use super::*;
 use serde::{Deserialize, Serialize};
@@ -36,21 +35,19 @@ struct StagedOutput {
 }
 
 pub(in crate::daemon::server) fn staged_artifacts_enabled() -> bool {
-    std::env::var(STAGED_ARTIFACTS_ENV)
-        .ok()
-        .is_some_and(|value| {
-            !matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "" | "0" | "false" | "off" | "no"
-            )
-        })
+    std::env::var(STAGED_ARTIFACTS_ENV).map_or(true, |value| {
+        !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "off" | "no"
+        )
+    })
 }
 
 pub(in crate::daemon::server) fn staged_lane_enabled(
     family: crate::compiler::CompilerFamily,
 ) -> bool {
     let Ok(value) = std::env::var(STAGED_ARTIFACTS_ENV) else {
-        return false;
+        return true;
     };
     match value.trim().to_ascii_lowercase().as_str() {
         "all" | "1" | "true" | "yes" | "on" => true,
@@ -66,14 +63,18 @@ pub(in crate::daemon::server) fn staged_lane_enabled(
 }
 
 pub(in crate::daemon::server) fn staged_link_lane_enabled() -> bool {
-    std::env::var(STAGED_ARTIFACTS_ENV)
-        .ok()
-        .is_some_and(|value| {
-            matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "all" | "1" | "true" | "yes" | "on"
-            )
-        })
+    std::env::var(STAGED_ARTIFACTS_ENV).is_ok_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "all" | "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+pub(in crate::daemon::server) fn staged_key_supported(key_hex: &str) -> bool {
+    !key_hex.is_empty()
+        && key_hex.len() <= 128
+        && key_hex.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 pub(in crate::daemon::server) fn is_staged_artifact_path(path: &Path) -> bool {
@@ -105,10 +106,7 @@ fn staged_root(artifact_dir: &Path) -> PathBuf {
 }
 
 fn validate_key(key_hex: &str) -> io::Result<()> {
-    if key_hex.is_empty()
-        || !key_hex.bytes().all(|byte| byte.is_ascii_hexdigit())
-        || key_hex.len() > 128
-    {
+    if !staged_key_supported(key_hex) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "staged artifact key must be a bounded hexadecimal string",
@@ -249,11 +247,9 @@ fn copy_output(source: &Path, destination: &Path) -> io::Result<(bool, u64)> {
         let _ = fs::remove_file(destination);
         return result;
     }
-    let mut permissions = source_metadata.permissions();
     // Keep the destination writable while restoring timestamps. On Windows,
     // setting mtime on a read-only file fails with ERROR_ACCESS_DENIED.
-    permissions.set_readonly(false);
-    fs::set_permissions(destination, permissions)?;
+    make_writable(destination)?;
     let mtime = filetime::FileTime::from_last_modification_time(&source_metadata);
     filetime::set_file_mtime(destination, mtime)?;
     set_readonly(destination, true)?;

--- a/crates/zccache-daemon-core/src/daemon/server/run.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/run.rs
@@ -40,7 +40,11 @@ impl DaemonServer {
         {
             let cache_dir = cache_dir.clone();
             let artifact_dir = self.state.artifact_dir.clone();
+            let state = Arc::clone(&self.state);
             tokio::spawn(async move {
+                if let Err(error) = state.staging.cleanup_abandoned() {
+                    tracing::debug!(%error, "abandoned private staging cleanup skipped");
+                }
                 if let Err(error) = cleanup_staged_artifact_temps(&artifact_dir) {
                     tracing::debug!(%error, "staged artifact temp cleanup skipped");
                 }

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -8,6 +8,91 @@
 
 use super::*;
 
+const STAGING_LOCK_FILE: &str = ".active.lock";
+
+/// Per-daemon private output staging. The held lock distinguishes an active
+/// daemon from crash debris, so startup cleanup cannot remove another live
+/// daemon's compiler outputs.
+pub(super) struct StagingRoot {
+    path: NormalizedPath,
+    lock: Option<std::fs::File>,
+}
+
+impl StagingRoot {
+    pub(super) fn new(cache_dir: &Path, instance: u64) -> std::io::Result<Self> {
+        use fs2::FileExt;
+        use std::io::Write;
+
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = cache_dir
+            .join("staging")
+            .join(format!("{}-{instance}-{nonce}", std::process::id()));
+        std::fs::create_dir_all(&path)?;
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path.join(STAGING_LOCK_FILE))?;
+        // Never wait behind a cleaner that observed this just-created
+        // directory before we acquired its lock. Failing daemon startup is
+        // safer than returning a staging root a concurrent cleaner unlinked.
+        file.try_lock_exclusive()?;
+        writeln!(file, "{}", std::process::id())?;
+        Ok(Self {
+            path: path.into(),
+            lock: Some(file),
+        })
+    }
+
+    pub(super) fn path(&self) -> &Path {
+        self.path.as_path()
+    }
+
+    pub(super) fn cleanup_abandoned(&self) -> std::io::Result<usize> {
+        use fs2::FileExt;
+
+        let Some(parent) = self.path.parent() else {
+            return Ok(0);
+        };
+        let mut removed = 0;
+        for entry in std::fs::read_dir(parent)?.flatten() {
+            let path = entry.path();
+            if !path.is_dir() || path == self.path.as_path() {
+                continue;
+            }
+            let lock = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(path.join(STAGING_LOCK_FILE));
+            let Ok(lock) = lock else { continue };
+            if lock.try_lock_exclusive().is_err() {
+                continue;
+            }
+            FileExt::unlock(&lock)?;
+            drop(lock);
+            std::fs::remove_dir_all(&path)?;
+            removed += 1;
+        }
+        Ok(removed)
+    }
+}
+
+impl Drop for StagingRoot {
+    fn drop(&mut self) {
+        if let Some(lock) = self.lock.take() {
+            let _ = fs2::FileExt::unlock(&lock);
+            drop(lock);
+        }
+        let _ = std::fs::remove_dir_all(self.path.as_path());
+    }
+}
+
 /// Shared state accessible by all connection handlers.
 pub(super) struct SharedState {
     /// IPC endpoint this daemon bound. Reported through `zccache status` so
@@ -68,6 +153,8 @@ pub(super) struct SharedState {
     pub(super) profiler: PhaseProfiler,
     /// On-disk artifact cache for hardlink optimization on cache hits.
     pub(super) artifact_dir: NormalizedPath,
+    /// Private compiler/linker outputs, isolated from cache clear/eviction.
+    pub(super) staging: StagingRoot,
     /// On-disk path for the persisted [`MetadataCache`] snapshot.
     ///
     /// Written on flush (`Clear`) and shutdown (`Shutdown`); read at
@@ -284,4 +371,25 @@ pub(super) struct SharedState {
     /// `Request::ExecStore`. Slice 1 keeps this in-memory only; a
     /// follow-up slice swaps to `KvStore` for persistence.
     pub(super) exec_cache: DashMap<String, Arc<Vec<u8>>>,
+}
+
+#[cfg(test)]
+mod staging_tests {
+    use super::*;
+
+    #[test]
+    fn abandoned_cleanup_preserves_live_roots_and_removes_crash_debris() {
+        let temp = tempfile::tempdir().unwrap();
+        let live_a = StagingRoot::new(temp.path(), 1).unwrap();
+        let live_b = StagingRoot::new(temp.path(), 2).unwrap();
+        std::fs::write(live_b.path().join("active.o"), b"active").unwrap();
+
+        let abandoned = temp.path().join("staging").join("abandoned");
+        std::fs::create_dir_all(&abandoned).unwrap();
+        std::fs::write(abandoned.join("orphan.o"), b"orphan").unwrap();
+
+        assert_eq!(live_a.cleanup_abandoned().unwrap(), 1);
+        assert!(live_b.path().join("active.o").exists());
+        assert!(!abandoned.exists());
+    }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/tests/clear_handler.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/clear_handler.rs
@@ -108,3 +108,24 @@ async fn handle_clear_preserves_system_includes() {
     })
     .await;
 }
+
+#[tokio::test]
+async fn handle_clear_preserves_in_flight_private_staging() {
+    crate::test_support::test_timeout(async {
+        let endpoint = crate::ipc::unique_test_endpoint();
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+        let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+        let staged = server.test_state().staging.path().join("active-output.o");
+        std::fs::write(&staged, b"compiler result").unwrap();
+
+        let response = super::super::handle_clear::handle_clear(server.test_state()).await;
+        assert!(matches!(response, Response::Cleared { .. }));
+        assert_eq!(
+            std::fs::read(&staged).unwrap(),
+            b"compiler result",
+            "Clear must not delete a compiler result before salvage/materialization"
+        );
+    })
+    .await;
+}

--- a/crates/zccache-daemon-core/src/daemon/server/tests/deferred_cold_path.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/deferred_cold_path.rs
@@ -484,15 +484,12 @@ cat "$src" >> "$out"
 /// The test simulates the crash by **dropping** the `DaemonServer` (no
 /// graceful shutdown — no shutdown notify, no final WAL flush, no in-flight
 /// task drain) and binding a fresh server to the same cache root. Both
-/// daemons share the cache root via `ZCCACHE_CACHE_DIR` (set by
-/// `CacheDirEnvGuard`), so the second daemon reads whatever the first
-/// daemon managed to persist before the abrupt drop.
+/// daemons are explicitly bound to the same cache root, so the second daemon
+/// reads whatever the first managed to persist before the abrupt drop.
 #[tokio::test]
 async fn crash_mid_flight_recovery_never_surfaces_wrong_content() {
     let tmp = tempfile::tempdir().unwrap();
     let cache_root = tmp.path().join("zccache-cache");
-    let _guard = CacheDirEnvGuard::set(&cache_root);
-
     let cc = write_fake_cc(tmp.path());
     let src = tmp.path().join("crashy.c");
     std::fs::write(&src, b"int crashy(void) { return 9; }\n").unwrap();
@@ -510,7 +507,11 @@ async fn crash_mid_flight_recovery_never_surfaces_wrong_content() {
     // surfacing content from a different cache key, the wrong-hit we must
     // never see.
     let expected = {
-        let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
+        let server = DaemonServer::bind_with_cache_dir(
+            &crate::ipc::unique_test_endpoint(),
+            &cache_root.clone().into(),
+        )
+        .unwrap();
         let resp = handle_compile_ephemeral(
             &server.state,
             std::process::id(),
@@ -538,7 +539,11 @@ async fn crash_mid_flight_recovery_never_surfaces_wrong_content() {
     // Second daemon: same cache root, fresh process state. `load_all()` may
     // or may not have seen the first daemon's writes depending on whether
     // the artifact persist + WAL flush completed before the drop.
-    let server2 = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
+    let server2 = DaemonServer::bind_with_cache_dir(
+        &crate::ipc::unique_test_endpoint(),
+        &cache_root.clone().into(),
+    )
+    .unwrap();
     let resp = handle_compile_ephemeral(
         &server2.state,
         std::process::id(),

--- a/crates/zccache/tests/daemon_rustc_restore_test.rs
+++ b/crates/zccache/tests/daemon_rustc_restore_test.rs
@@ -317,6 +317,20 @@ fn single_artifact_key_in(cache_dir: &Path) -> String {
             keys.insert(key.to_string());
         }
     }
+    let staged_root = artifact_dir.join(".staged-v2");
+    if let Ok(entries) = std::fs::read_dir(staged_root) {
+        for entry in entries.flatten() {
+            if !entry.file_type().is_ok_and(|kind| kind.is_file()) {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if let Some(key) = name.strip_suffix(".current") {
+                if !key.is_empty() && key.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+                    keys.insert(key.to_string());
+                }
+            }
+        }
+    }
     assert_eq!(
         keys.len(),
         1,
@@ -341,6 +355,13 @@ fn remove_artifact_payloads(cache_dir: &Path, artifact_key_hex: &str) {
             std::fs::remove_file(path).expect("remove artifact payload");
             removed += 1;
         }
+    }
+    let staged_pointer = artifact_dir
+        .join(".staged-v2")
+        .join(format!("{artifact_key_hex}.current"));
+    if staged_pointer.is_file() {
+        std::fs::remove_file(staged_pointer).expect("remove staged artifact pointer");
+        removed += 1;
     }
     assert!(
         removed > 0,

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -8,7 +8,7 @@ For how cache keys are computed see [overview.md](overview.md) (section 2.8). Fo
 
 ## Immutable staged-output rollout
 
-The opt-in `ZCCACHE_STAGED_ARTIFACTS` lane makes the daemon's v2 generations
+The default-on staged-artifact lane makes the daemon's v2 generations
 the authoritative source for supported compiler misses. The compiler is
 redirected into a private directory before spawn; after a successful compile,
 all outputs are hashed and published as one digest-stamped generation, then
@@ -16,10 +16,11 @@ materialized to the requested paths. A failed publication can still salvage a
 successful compile from the private files, but it never exposes a partial
 cache hit.
 
-Rollout values are `rust` (Rust single and multi-output plans), `c-cpp`
-(ordinary single-object and single-PCH GCC/Clang plans including user-owned
-`-MF`/`-MD` depfiles; MSVC
-flag rewriting is supported only for explicit `/Fo` object paths), or
+`ZCCACHE_STAGED_ARTIFACTS=off` restores the legacy path as an immediate kill
+switch. Narrow diagnostic values are `rust` (Rust single and multi-output
+plans), `c-cpp` (ordinary single-object and single-PCH GCC/Clang plans
+including user-owned `-MF`/`-MD` depfiles; MSVC flag rewriting is supported
+only for explicit `/Fo` object paths), or
 `all`. Unsupported shapes—including multi-source compiler invocations, C++
 modules, unrewritable or undeclared linker outputs, opaque generic exec, and
 stdout output—remain on the
@@ -29,9 +30,10 @@ outputs for staticlibs, bins, proc macros, objects, assembly, LLVM IR/bitcode,
 MIR, and dep-info use their actual rustc extensions.
 
 Pure archive invocations with one output and no linker side effects use the
-same private transaction when the lane is `all`.
+same private transaction by default.
 
-Linker invocations participate in the `all` lane when the parser's primary
+Linker invocations remain `all`-gated because opaque tools can create
+undeclared siblings. They participate when the parser's primary
 and declared secondary destinations can all be rewritten before spawn. The
 private directory is checked for undeclared files/bundles after the linker
 exits, and the requested output directory is checked for external side
@@ -43,11 +45,11 @@ GNU semantic map destinations (`%` or a directory), and conditional
 LTCG/PGO/embedded-IDL/Windows-metadata outputs remain on the legacy path
 before spawn.
 
-Generic tool execution also participates in the `all` lane when every
-declared output is an exact argument token. Those paths are rewritten into a
-private staging directory before spawn and independently materialized after
-the run. Generic tools whose output paths are embedded in opaque arguments,
-environment variables, or undeclared side effects retain the legacy path.
+Generic tool execution participates by default when every declared output is
+an exact argument token. Those paths are rewritten into a private staging
+directory before spawn and independently materialized after the run. Generic
+tools whose output paths are embedded in opaque arguments, environment
+variables, or undeclared side effects retain the legacy path.
 
 Published v2 files are always independent copies or true reflinks of private
 compiler files. Hardlinks are never used between compiler staging and the
@@ -62,6 +64,12 @@ hardlink registry. This lets restart verification reject a mutate-then-delete
 alias attack before the backend is served. Read-only enforcement, watcher
 suspicion, file-identity registration, link-count limits, and copy fallback
 remain mandatory for the narrow semantic allowlist.
+
+Private compiler/linker files live under a per-daemon `{cache_root}/staging/`
+directory, outside the clearable artifact store. An advisory lock protects
+each live daemon's directory: startup cleanup reclaims only unlocked crash
+debris, while cache clear and eviction cannot delete outputs still needed for
+publication salvage or requested-path materialization.
 
 The v2 transaction is visible only after the complete generation and manifest
 are written and the per-key pointer is switched. Readers validate the pointer,
@@ -220,6 +228,6 @@ Unsupported shapes—including multi-source compiler invocations, C++ modules,
 unrewritable/undeclared linker outputs, opaque generic exec, and stdout
 output—remain on the
 legacy path before compiler spawn. Explicit Rust `--emit=kind=path`
-destinations are included in the complete cache-hit reverse map. The staged
-lane remains opt-in for output families that do not yet have complete-set
-plans.
+destinations are included in the complete cache-hit reverse map. Output
+families without complete-set plans select the legacy path before spawn; they
+are never partially staged.


### PR DESCRIPTION
Closes the default-on rollout slice of #1056.

## What changed

- enables v2 staged persistence and supported Rust/C/C++/archive/declared-exec plans by default
- retains `ZCCACHE_STAGED_ARTIFACTS=off` as the immediate kill switch
- keeps opaque linker staging `all`-gated until every conditional side-output family is modeled
- preserves legacy persistence for diagnostic/non-hex keys
- moves private compiler/linker outputs outside the clearable artifact store
- protects each daemon staging root with an advisory lock and reclaims only unlocked crash debris in standalone and embedded modes
- isolates the crash-recovery test from process-global cache-dir races

## Adversarial coverage

- clear preserves an in-flight private compiler output needed for salvage/materialization
- abandoned-root cleanup removes crash debris while preserving two concurrently live roots
- crash/restart recovery never surfaces wrong bytes with default staging enabled
- broad default-on daemon-core suites pass on Windows and Linux

## Validation

- Windows daemon-core: 481 tests, 0 failed (19 ignored)
- Linux Docker daemon-core: 488 tests, 0 failed (19 ignored)
- Linux Docker rustfmt: pass
- scoped Clippy (`--no-deps`, existing `question_mark` baseline lint allowed): pass

The parent remains open for the remaining conditional producer, migration/observability, platform-matrix, and sanctioned performance gates.