### PR TITLE
fix(cache): account for mixed-format v2 eviction

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/eviction.rs
+++ b/crates/zccache-daemon-core/src/daemon/eviction.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+use super::server::persist::{evict_v2_artifact_keys, scan_v2_disk_artifacts};
 use super::server::{remove_cow_blob, CachedArtifact, FastHitEntry};
 
 /// Estimated bytes per metadata cache entry.
@@ -223,6 +224,7 @@ struct DiskArtifact {
     total_size: u64,
     mtime: std::time::SystemTime,
     files: Vec<NormalizedPath>,
+    staged: bool,
 }
 
 /// Evict on-disk artifacts when total disk usage exceeds `max_cache_size`.
@@ -268,8 +270,11 @@ pub(crate) fn evict_disk_artifacts(
             continue;
         };
 
-        // Derive the key stem: "abcd1234.meta" → "abcd1234", "abcd1234_0" → "abcd1234"
+        // Derive the key stem: "abcd1234.meta" → "abcd1234",
+        // "abcd1234.pack" → "abcd1234", "abcd1234_0" → "abcd1234".
         let key = if let Some(stem) = fname.strip_suffix(".meta") {
+            stem.to_string()
+        } else if let Some(stem) = fname.strip_suffix(".pack") {
             stem.to_string()
         } else if let Some(pos) = fname.rfind('_') {
             // Data file: key_hex_{index}
@@ -286,6 +291,7 @@ pub(crate) fn evict_disk_artifacts(
             total_size: 0,
             mtime: std::time::SystemTime::UNIX_EPOCH,
             files: Vec::new(),
+            staged: false,
         });
         group.total_size += size;
         // Use data file mtime as LRU proxy. For legacy .meta files, also
@@ -298,6 +304,28 @@ pub(crate) fn evict_disk_artifacts(
             }
         }
         group.files.push(path.into());
+    }
+
+    match scan_v2_disk_artifacts(artifact_dir) {
+        Ok(staged_artifacts) => {
+            for staged in staged_artifacts {
+                let key = staged.key;
+                let staged_size = staged.total_size;
+                let staged_mtime = staged.mtime;
+                total_disk = total_disk.saturating_add(staged_size);
+                let group = groups.entry(key.clone()).or_insert_with(|| DiskArtifact {
+                    key,
+                    total_size: 0,
+                    mtime: std::time::SystemTime::UNIX_EPOCH,
+                    files: Vec::new(),
+                    staged: true,
+                });
+                group.total_size = group.total_size.saturating_add(staged_size);
+                group.mtime = group.mtime.max(staged_mtime);
+                group.staged = true;
+            }
+        }
+        Err(error) => tracing::warn!(%error, "failed to scan staged artifacts for eviction"),
     }
 
     if total_disk <= max_cache_size {
@@ -339,6 +367,14 @@ pub(crate) fn evict_disk_artifacts(
                 deleted_since_yield = 0;
             }
         }
+    }
+    let staged_keys: std::collections::HashSet<String> = to_evict
+        .iter()
+        .filter(|artifact| artifact.staged)
+        .map(|artifact| artifact.key.clone())
+        .collect();
+    if let Err(error) = evict_v2_artifact_keys(artifact_dir, &staged_keys) {
+        tracing::warn!(%error, "failed to evict staged artifact generations");
     }
 
     // Remove from in-memory DashMap.
@@ -694,6 +730,16 @@ mod tests {
         std::fs::write(&data_path, vec![0u8; size]).unwrap();
     }
 
+    fn write_fake_staged_artifact(dir: &Path, key: &str, size: usize) {
+        let root = dir.join(".staged-v2");
+        let generation = "b".repeat(64);
+        let generation_dir = root.join(key).join(&generation);
+        std::fs::create_dir_all(&generation_dir).unwrap();
+        std::fs::write(generation_dir.join("output-0"), vec![0u8; size]).unwrap();
+        std::fs::write(generation_dir.join("manifest.bin"), b"manifest").unwrap();
+        std::fs::write(root.join(format!("{key}.current")), generation).unwrap();
+    }
+
     #[test]
     fn disk_eviction_noop_under_budget() {
         let dir = tempfile::tempdir().unwrap();
@@ -740,6 +786,32 @@ mod tests {
         let (freed, removed) = evict_disk_artifacts(dir.path(), &artifacts, 0, None);
         assert!(freed > 0);
         assert_eq!(removed, 1);
+        assert!(artifacts.is_empty());
+    }
+
+    #[test]
+    fn disk_eviction_groups_and_removes_mixed_v1_pack_v2_key_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let artifacts: DashMap<String, CachedArtifact> = DashMap::new();
+        let key = "a".repeat(64);
+        write_fake_artifact(dir.path(), &key, 1024);
+        std::fs::write(dir.path().join(format!("{key}.pack")), vec![0u8; 512]).unwrap();
+        write_fake_staged_artifact(dir.path(), &key, 2048);
+        artifacts.insert(key.clone(), make_artifact(3584));
+
+        let (freed, removed) = evict_disk_artifacts(dir.path(), &artifacts, 0, None);
+
+        assert!(freed >= 3584);
+        assert_eq!(removed, 1, "mixed formats are one logical artifact");
+        assert!(!dir.path().join(format!("{key}.meta")).exists());
+        assert!(!dir.path().join(format!("{key}_0")).exists());
+        assert!(!dir.path().join(format!("{key}.pack")).exists());
+        assert!(!dir.path().join(".staged-v2").join(&key).exists());
+        assert!(!dir
+            .path()
+            .join(".staged-v2")
+            .join(format!("{key}.current"))
+            .exists());
         assert!(artifacts.is_empty());
     }
 

--- a/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
@@ -109,8 +109,17 @@ pub(super) fn ensure_payloads<'a>(
     artifact_dir: &Path,
     key_hex: &str,
 ) -> Option<&'a [CachedPayload]> {
+    ensure_payloads_with_staged_policy(cached, artifact_dir, key_hex, staged_artifacts_enabled())
+}
+
+pub(super) fn ensure_payloads_with_staged_policy<'a>(
+    cached: &'a mut CachedArtifact,
+    artifact_dir: &Path,
+    key_hex: &str,
+    staged_enabled: bool,
+) -> Option<&'a [CachedPayload]> {
     if cached.payloads.is_none() {
-        if staged_artifacts_enabled() {
+        if staged_enabled {
             match load_staged_artifact_paths(artifact_dir, key_hex, &cached.meta.output_sizes) {
                 Ok(Some(payloads)) => {
                     cached.payloads = Some(Arc::from(

--- a/crates/zccache-daemon-core/src/daemon/server/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/mod.rs
@@ -135,7 +135,7 @@ mod link_helpers;
 mod loaders;
 mod pch;
 mod pending_writes;
-mod persist;
+pub(crate) mod persist;
 mod private_daemon;
 mod request_cache;
 mod rsp_cache;

--- a/crates/zccache-daemon-core/src/daemon/server/persist/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/mod.rs
@@ -44,5 +44,18 @@ pub(in crate::daemon::server) use staged_plan::*;
 pub(in crate::daemon::server) use staged_store::*;
 pub(in crate::daemon::server) use write_cached::*;
 
+pub(crate) type V2DiskArtifact = staged_store::StagedDiskArtifact;
+
+pub(crate) fn scan_v2_disk_artifacts(artifact_dir: &Path) -> std::io::Result<Vec<V2DiskArtifact>> {
+    staged_store::scan_staged_disk_artifacts(artifact_dir)
+}
+
+pub(crate) fn evict_v2_artifact_keys(
+    artifact_dir: &Path,
+    keys: &std::collections::HashSet<String>,
+) -> std::io::Result<u64> {
+    staged_store::evict_staged_artifact_keys(artifact_dir, keys)
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -12,6 +12,11 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
+mod maintenance;
+pub(crate) use maintenance::{
+    evict_staged_artifact_keys, scan_staged_disk_artifacts, StagedDiskArtifact,
+};
+
 pub(in crate::daemon::server) const STAGED_ARTIFACTS_ENV: &str = "ZCCACHE_STAGED_ARTIFACTS";
 
 const STAGED_ROOT: &str = ".staged-v2";

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/maintenance.rs
@@ -1,0 +1,87 @@
+//! Disk-budget scanning and eviction for staged v2 artifact generations.
+
+use super::{open_store_lock, pointer_path, remove_staged_tree, staged_key_supported, staged_root};
+use std::collections::HashSet;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::time::SystemTime;
+
+pub(crate) struct StagedDiskArtifact {
+    pub(crate) key: String,
+    pub(crate) total_size: u64,
+    pub(crate) mtime: SystemTime,
+}
+
+fn staged_tree_stats(path: &Path) -> io::Result<(u64, SystemTime)> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() {
+        return Ok((0, SystemTime::UNIX_EPOCH));
+    }
+    let mut size = metadata.len();
+    let mut mtime = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+    if metadata.is_dir() {
+        for entry in fs::read_dir(path)?.flatten() {
+            let (child_size, child_mtime) = staged_tree_stats(&entry.path())?;
+            size = size.saturating_add(child_size);
+            mtime = mtime.max(child_mtime);
+        }
+    }
+    Ok((size, mtime))
+}
+
+pub(crate) fn scan_staged_disk_artifacts(
+    artifact_dir: &Path,
+) -> io::Result<Vec<StagedDiskArtifact>> {
+    let root = staged_root(artifact_dir);
+    if !root.is_dir() {
+        return Ok(Vec::new());
+    }
+    let store_lock = open_store_lock(&root)?;
+    fs2::FileExt::lock_shared(&store_lock)?;
+    let mut artifacts = Vec::new();
+    for entry in fs::read_dir(&root)?.flatten() {
+        let key_root = entry.path();
+        if !entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+            continue;
+        }
+        let key = entry.file_name().to_string_lossy().into_owned();
+        if !staged_key_supported(&key) {
+            continue;
+        }
+        let (mut total_size, mut mtime) = staged_tree_stats(&key_root)?;
+        let pointer = pointer_path(artifact_dir, &key);
+        if let Ok(metadata) = fs::symlink_metadata(&pointer) {
+            total_size = total_size.saturating_add(metadata.len());
+            mtime = mtime.max(metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH));
+        }
+        artifacts.push(StagedDiskArtifact {
+            key,
+            total_size,
+            mtime,
+        });
+    }
+    Ok(artifacts)
+}
+
+pub(crate) fn evict_staged_artifact_keys(
+    artifact_dir: &Path,
+    keys: &HashSet<String>,
+) -> io::Result<u64> {
+    if keys.is_empty() {
+        return Ok(0);
+    }
+    let root = staged_root(artifact_dir);
+    if !root.is_dir() {
+        return Ok(0);
+    }
+    let store_lock = open_store_lock(&root)?;
+    fs2::FileExt::lock_exclusive(&store_lock)?;
+    let mut bytes_removed: u64 = 0;
+    for key in keys.iter().filter(|key| staged_key_supported(key)) {
+        bytes_removed = bytes_removed.saturating_add(remove_staged_tree(&root.join(key))?);
+        bytes_removed =
+            bytes_removed.saturating_add(remove_staged_tree(&pointer_path(artifact_dir, key))?);
+    }
+    Ok(bytes_removed)
+}

--- a/crates/zccache-daemon-core/src/daemon/server/tests/clear_handler.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/clear_handler.rs
@@ -127,6 +127,19 @@ async fn handle_clear_preserves_in_flight_private_staging() {
             &[published.into()],
         )
         .unwrap();
+        let legacy_key = "5".repeat(64);
+        let pack_key = "4".repeat(64);
+        let legacy_path = server
+            .test_state()
+            .artifact_dir
+            .join(format!("{legacy_key}_0"));
+        let pack_path = pack_path_for(server.test_state().artifact_dir.as_path(), &pack_key);
+        std::fs::write(&legacy_path, b"legacy result").unwrap();
+        std::fs::write(
+            &pack_path,
+            build_pack(&[Arc::new(b"packed result".to_vec())]),
+        )
+        .unwrap();
 
         let response = super::super::handle_clear::handle_clear(server.test_state()).await;
         assert!(matches!(
@@ -148,6 +161,8 @@ async fn handle_clear_preserves_in_flight_private_staging() {
         )
         .unwrap()
         .is_none());
+        assert!(!legacy_path.exists());
+        assert!(!pack_path.exists());
     })
     .await;
 }

--- a/crates/zccache-daemon-core/src/daemon/server/tests/pack.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/pack.rs
@@ -105,6 +105,73 @@ fn persist_artifact_paths_preserves_compiler_output_writability() {
 }
 
 #[test]
+fn mixed_v1_pack_v2_lookup_and_downgrade_policy_are_explicit() {
+    let dir = tempfile::tempdir().unwrap();
+    let v1_key = "1".repeat(64);
+    let pack_key = "2".repeat(64);
+    let v2_key = "3".repeat(64);
+    std::fs::write(dir.path().join(format!("{v1_key}_0")), b"legacy-flat").unwrap();
+    std::fs::write(
+        pack_path_for(dir.path(), &pack_key),
+        build_pack(&[Arc::new(b"legacy-pack".to_vec())]),
+    )
+    .unwrap();
+    let v2_source: NormalizedPath = dir.path().join("v2-source.o").into();
+    std::fs::write(&v2_source, b"staged-v2").unwrap();
+    persist_staged_artifact_paths(dir.path(), &v2_key, &[v2_source]).unwrap();
+
+    let index = |name: &str, size: u64| {
+        CachedArtifact::from_index(ArtifactIndex::new(
+            vec![name.to_string()],
+            vec![size],
+            Arc::new(Vec::new()),
+            Arc::new(Vec::new()),
+            0,
+        ))
+    };
+    let bytes = |payload: &CachedPayload| match payload {
+        CachedPayload::File(path) => std::fs::read(path).unwrap(),
+        CachedPayload::Bytes(bytes) => bytes.as_ref().clone(),
+    };
+
+    let mut v1 = index("legacy.o", 11);
+    let mut pack = index("packed.o", 11);
+    let mut v2 = index("staged.o", 9);
+    assert_eq!(
+        bytes(&ensure_payloads_with_staged_policy(&mut v1, dir.path(), &v1_key, true).unwrap()[0]),
+        b"legacy-flat"
+    );
+    assert_eq!(
+        bytes(
+            &ensure_payloads_with_staged_policy(&mut pack, dir.path(), &pack_key, true).unwrap()[0]
+        ),
+        b"legacy-pack"
+    );
+    assert_eq!(
+        bytes(&ensure_payloads_with_staged_policy(&mut v2, dir.path(), &v2_key, true).unwrap()[0]),
+        b"staged-v2"
+    );
+
+    // Downgrade/kill-switch policy: legacy layouts remain readable, while a
+    // v2-only entry is a safe miss rather than being reinterpreted.
+    let mut downgraded_v1 = index("legacy.o", 11);
+    let mut downgraded_pack = index("packed.o", 11);
+    let mut downgraded_v2 = index("staged.o", 9);
+    assert!(
+        ensure_payloads_with_staged_policy(&mut downgraded_v1, dir.path(), &v1_key, false)
+            .is_some()
+    );
+    assert!(
+        ensure_payloads_with_staged_policy(&mut downgraded_pack, dir.path(), &pack_key, false)
+            .is_some()
+    );
+    assert!(
+        ensure_payloads_with_staged_policy(&mut downgraded_v2, dir.path(), &v2_key, false)
+            .is_none()
+    );
+}
+
+#[test]
 fn persist_artifact_paths_falls_back_to_copy_when_source_missing() {
     std::env::remove_var("ZCCACHE_PACK_ARTIFACTS");
     let dir = tempfile::tempdir().unwrap();

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -85,6 +85,14 @@ generation, and emits a durable `staged_publication_conflict` lifecycle event.
 An invalid/corrupt prior generation may be replaced and is recorded as
 `staged_publication_replaces_invalid_generation`.
 
+Mixed-format lookup is explicit during migration: v2 is attempted first,
+then flat v1 payloads, then pack payloads. Disabling staged artifacts (or
+downgrading to a reader without v2 support) leaves v1/pack entries readable
+and treats v2-only entries as cache misses; v2 bytes are never reinterpreted
+as a legacy format. Re-enabling a v2-aware reader makes those generations
+available again. Disk eviction groups coexisting v1/pack/v2 storage by cache
+key, accounts for all physical bytes, and removes the logical artifact once.
+
 ## Directory Layout
 
 ```


### PR DESCRIPTION
Closes #1069.
Part of #1056 (Phase 8 migration/cleanup).

## What changed

- make mixed v2-aware lookup and kill-switch/downgrade behavior explicit and testable;
- account for staged-v2 generation trees and `.pack` payloads in disk budgets;
- group coexisting flat v1, pack, and v2 bytes by logical cache key;
- evict v2 generations under the shared store's exclusive lock alongside legacy payloads;
- prove mixed-format Clear removes cache storage while preserving private in-flight compiler staging;
- document lookup order, downgrade-safe misses, and mixed-format eviction semantics.

## Adversarial coverage

- one cache root serves independent flat-v1, pack, and v2 keys;
- disabled-v2 reader still serves legacy layouts and safely misses v2-only data;
- one logical key deliberately has flat-v1 + pack + v2 physical storage and is counted/removed once;
- Clear spans all three persisted layouts without crossing into private compiler staging.

## Validation

- Windows focused mixed lookup/downgrade test: pass (1/1)
- Windows focused mixed Clear/private-staging test: pass (1/1)
- Windows focused mixed v1/pack/v2 eviction test: pass (1/1)
- Windows `zccache-daemon-core --features test-support`: pass (486 tests, 0 failed)
- Linux Docker `zccache-daemon-core --features test-support`: pass (474 passed, 19 ignored, 0 failed)
- Linux soldr rustfmt: pass
- Linux soldr scoped Clippy: pass (pre-existing `question_mark` lint explicitly allowed)
- pre-push Rust/docs review: clean after splitting maintenance code into its own module