### PR TITLE
feat(cache): expose staged compile telemetry

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/mod.rs
@@ -22,6 +22,7 @@ pub mod lineage;
 pub(crate) mod process;
 pub mod server;
 pub mod side_effect;
+pub(crate) mod staged_stats;
 pub mod stats;
 pub mod trampoline;
 

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
@@ -125,6 +125,7 @@ pub(super) fn store_miss_artifact(request: MissArtifactStoreRequest<'_>) -> Miss
                 compile_start,
                 &mut stats,
                 t_artifact_build,
+                synchronous_persist,
             );
         } else {
             store_single_output(
@@ -177,6 +178,7 @@ fn store_rustc_outputs(
     compile_start: Instant,
     stats: &mut MissArtifactStoreStats,
     t_artifact_build: Instant,
+    synchronous_persist: bool,
 ) {
     let state = state_arc.as_ref();
     let t_artifact_meta_build = Instant::now();
@@ -221,6 +223,25 @@ fn store_rustc_outputs(
     stats.rust_snapshot_ns = t_persist_sync.elapsed().as_nanos() as u64;
     let persisted = match sync_persist_result {
         Ok(snapshot_stats) => {
+            if snapshot_stats.staged {
+                use crate::daemon::staged_stats::{StagedBytes, StagedCounter, StagedTiming};
+                state
+                    .profiler
+                    .staged
+                    .count(StagedCounter::PublicationSuccess);
+                state
+                    .profiler
+                    .staged
+                    .timing(StagedTiming::Hashing, snapshot_stats.staged_hash_ns);
+                state.profiler.staged.timing(
+                    StagedTiming::Publication,
+                    snapshot_stats.staged_publication_ns,
+                );
+                state
+                    .profiler
+                    .staged
+                    .bytes(StagedBytes::Publication, snapshot_stats.copy_bytes);
+            }
             stats.rust_snapshot_hardlink_count = snapshot_stats.hardlink_count;
             stats.rust_snapshot_copy_count = snapshot_stats.copy_count;
             stats.rust_snapshot_copy_bytes = snapshot_stats.copy_bytes;
@@ -231,6 +252,25 @@ fn store_rustc_outputs(
             true
         }
         Err(e) => {
+            if synchronous_persist {
+                use crate::daemon::staged_stats::{StagedCounter, StagedFailure};
+                state
+                    .profiler
+                    .staged
+                    .count(StagedCounter::PublicationFailure);
+                if e.kind() == std::io::ErrorKind::AlreadyExists {
+                    state
+                        .profiler
+                        .staged
+                        .count(StagedCounter::PublicationConflict);
+                    state
+                        .profiler
+                        .staged
+                        .failure(StagedFailure::PublicationConflict);
+                } else {
+                    state.profiler.staged.failure(StagedFailure::Publication);
+                }
+            }
             stats.rust_snapshot_error_count = stats.rust_snapshot_error_count.saturating_add(1);
             tracing::warn!(
                 key = %artifact_key_hex,
@@ -347,7 +387,58 @@ fn store_single_output(
         size: payload_size,
     };
     if synchronous_persist {
-        let written = persist_artifact_paths(&artifact_dir, &key_hex, &source_paths).is_ok();
+        use crate::daemon::staged_stats::{
+            StagedBytes, StagedCounter, StagedFailure, StagedTiming,
+        };
+        let staged_publication =
+            staged_artifacts_enabled() && staged_key_supported(&key_hex) && !pack_mode_enabled();
+        let written =
+            match persist_artifact_paths_with_stats(&artifact_dir, &key_hex, &source_paths) {
+                Ok(persisted) => {
+                    if persisted.staged {
+                        state
+                            .profiler
+                            .staged
+                            .count(StagedCounter::PublicationSuccess);
+                        state
+                            .profiler
+                            .staged
+                            .timing(StagedTiming::Hashing, persisted.staged_hash_ns);
+                        state
+                            .profiler
+                            .staged
+                            .timing(StagedTiming::Publication, persisted.staged_publication_ns);
+                        state
+                            .profiler
+                            .staged
+                            .bytes(StagedBytes::Publication, persisted.copy_bytes);
+                    }
+                    true
+                }
+                Err(error) => {
+                    stats.rust_snapshot_error_count =
+                        stats.rust_snapshot_error_count.saturating_add(1);
+                    if staged_publication {
+                        state
+                            .profiler
+                            .staged
+                            .count(StagedCounter::PublicationFailure);
+                        if error.kind() == std::io::ErrorKind::AlreadyExists {
+                            state
+                                .profiler
+                                .staged
+                                .count(StagedCounter::PublicationConflict);
+                            state
+                                .profiler
+                                .staged
+                                .failure(StagedFailure::PublicationConflict);
+                        } else {
+                            state.profiler.staged.failure(StagedFailure::Publication);
+                        }
+                    }
+                    false
+                }
+            };
         if written {
             let _ = state.index_writer_tx.send(IndexWriterCommand::Insert(
                 key_hex.clone(),

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -101,36 +101,50 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     } else {
         vec![output_path.clone()]
     };
-    let staged_plan = if is_rustc {
-        match StagedCompilePlan::rustc(
+    use crate::daemon::staged_stats::{StagedCounter, StagedFailure, StagedTiming};
+    let planning_started = std::time::Instant::now();
+    state.profiler.staged.count(StagedCounter::PlanAttempted);
+    let staged_plan_result = if is_rustc {
+        StagedCompilePlan::rustc(
             state.staging.path(),
             effective_args,
             output_path,
             &expected_outputs,
             cwd,
-        ) {
-            Ok(plan) => plan,
-            Err(e) => {
-                return CompileExecResult::Error(Response::Error {
-                    message: format!("failed to prepare private compiler staging: {e}"),
-                });
-            }
-        }
+        )
     } else {
-        match StagedCompilePlan::cc(
+        StagedCompilePlan::cc(
             state.staging.path(),
             compilation.family,
             effective_args,
             output_path,
             cwd,
             dep_flags,
-        ) {
-            Ok(plan) => plan,
-            Err(e) => {
-                return CompileExecResult::Error(Response::Error {
-                    message: format!("failed to prepare private compiler staging: {e}"),
-                });
-            }
+        )
+    };
+    state.profiler.staged.timing(
+        StagedTiming::Planning,
+        planning_started.elapsed().as_nanos() as u64,
+    );
+    let staged_plan = match staged_plan_result {
+        Ok(Some(plan)) => {
+            state.profiler.staged.count(StagedCounter::PlanEnabled);
+            Some(plan)
+        }
+        Ok(None) => {
+            state.profiler.staged.count(StagedCounter::PlanUnsupported);
+            state
+                .profiler
+                .staged
+                .failure(StagedFailure::UnsupportedShape);
+            None
+        }
+        Err(e) => {
+            state.profiler.staged.count(StagedCounter::PlanError);
+            state.profiler.staged.failure(StagedFailure::Planning);
+            return CompileExecResult::Error(Response::Error {
+                message: format!("failed to prepare private compiler staging: {e}"),
+            });
         }
     };
     let compiler_args = staged_plan.as_ref().map_or_else(
@@ -262,6 +276,13 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     )
     .await;
     let compiler_process_ns = t_compiler_process.elapsed().as_nanos() as u64;
+    if staged_plan.is_some() {
+        state.profiler.staged.count(StagedCounter::CompilerStaged);
+        state
+            .profiler
+            .staged
+            .timing(StagedTiming::Compiler, compiler_process_ns);
+    }
 
     if state.compile_concurrency.is_some() {
         let duration_ns = compile_span_start.elapsed().as_nanos() as u64;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -570,15 +570,107 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
     });
 
     if let Some(plan) = staged_plan {
-        if let Err(error) = plan.materialize() {
-            write_session_log(
-                &state.sessions,
-                sid,
-                &format!("[DIAG] staged_materialization_failed: {error}"),
+        use crate::daemon::staged_stats::{
+            StagedBytes, StagedCounter, StagedFailure, StagedTiming,
+        };
+        let salvage = rust_snapshot_error_count > 0;
+        let output_count = plan.output_paths().len();
+        let materialize_started = std::time::Instant::now();
+        if salvage {
+            state.profiler.staged.count(StagedCounter::SalvageAttempt);
+            crate::core::lifecycle::write_event(
+                "staged_salvage_started",
+                serde_json::json!({ "output_count": output_count }),
             );
-            return Some(Response::Error {
-                message: format!("failed to materialize compiler output: {error}"),
-            });
+        }
+        match plan.materialize() {
+            Ok(materialized) => {
+                let elapsed_ns = materialize_started.elapsed().as_nanos() as u64;
+                state.profiler.staged.add_count(
+                    StagedCounter::MaterializeReflink,
+                    materialized.reflink_count,
+                );
+                state
+                    .profiler
+                    .staged
+                    .add_count(StagedCounter::MaterializeCopy, materialized.copy_count);
+                state
+                    .profiler
+                    .staged
+                    .bytes(StagedBytes::Materialization, materialized.copy_bytes);
+                if salvage {
+                    state.profiler.staged.count(StagedCounter::SalvageSuccess);
+                    state
+                        .profiler
+                        .staged
+                        .timing(StagedTiming::Salvage, elapsed_ns);
+                    state
+                        .profiler
+                        .staged
+                        .bytes(StagedBytes::Salvage, materialized.copy_bytes);
+                    crate::core::lifecycle::write_event(
+                        "staged_salvage_complete",
+                        serde_json::json!({
+                            "output_count": output_count,
+                            "copied_bytes": materialized.copy_bytes,
+                            "elapsed_ns": elapsed_ns,
+                        }),
+                    );
+                } else {
+                    state
+                        .profiler
+                        .staged
+                        .timing(StagedTiming::MissMaterialization, elapsed_ns);
+                }
+            }
+            Err(error) => {
+                let elapsed_ns = materialize_started.elapsed().as_nanos() as u64;
+                state
+                    .profiler
+                    .staged
+                    .count(StagedCounter::MaterializeFailure);
+                state
+                    .profiler
+                    .staged
+                    .failure(StagedFailure::RequestedMaterialization);
+                if salvage {
+                    state.profiler.staged.count(StagedCounter::SalvageFailure);
+                    state.profiler.staged.failure(StagedFailure::Salvage);
+                    state
+                        .profiler
+                        .staged
+                        .timing(StagedTiming::Salvage, elapsed_ns);
+                    crate::core::lifecycle::write_event(
+                        "staged_salvage_failed",
+                        serde_json::json!({
+                            "reason": "requested_materialization",
+                            "output_count": output_count,
+                            "elapsed_ns": elapsed_ns,
+                        }),
+                    );
+                } else {
+                    state
+                        .profiler
+                        .staged
+                        .timing(StagedTiming::MissMaterialization, elapsed_ns);
+                    crate::core::lifecycle::write_event(
+                        "staged_materialization_failed",
+                        serde_json::json!({
+                            "reason": "requested_materialization",
+                            "output_count": output_count,
+                            "elapsed_ns": elapsed_ns,
+                        }),
+                    );
+                }
+                write_session_log(
+                    &state.sessions,
+                    sid,
+                    &format!("[DIAG] staged_materialization_failed: {error}"),
+                );
+                return Some(Response::Error {
+                    message: format!("failed to materialize compiler output: {error}"),
+                });
+            }
         }
     }
 

--- a/crates/zccache-daemon-core/src/daemon/server/persist/artifact_io.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/artifact_io.rs
@@ -176,6 +176,9 @@ pub(in crate::daemon::server) fn persist_artifact_paths_with_stats(
             hardlink_count: 0,
             copy_count: stats.copy_count,
             copy_bytes: stats.copy_bytes,
+            staged: true,
+            staged_hash_ns: stats.staged_hash_ns,
+            staged_publication_ns: stats.staged_publication_ns,
         });
     }
     if pack_mode_enabled() {
@@ -214,6 +217,9 @@ pub(in crate::daemon::server) fn persist_artifact_paths_with_stats(
                     hardlink_count: x.hardlink_count + y.hardlink_count,
                     copy_count: x.copy_count + y.copy_count,
                     copy_bytes: x.copy_bytes + y.copy_bytes,
+                    staged: x.staged || y.staged,
+                    staged_hash_ns: x.staged_hash_ns + y.staged_hash_ns,
+                    staged_publication_ns: x.staged_publication_ns + y.staged_publication_ns,
                 }),
                 (Err(e), _) | (_, Err(e)) => Err(e),
             },
@@ -226,6 +232,9 @@ pub(in crate::daemon::server) struct PersistArtifactFileStats {
     pub(in crate::daemon::server) hardlink_count: u64,
     pub(in crate::daemon::server) copy_count: u64,
     pub(in crate::daemon::server) copy_bytes: u64,
+    pub(in crate::daemon::server) staged: bool,
+    pub(in crate::daemon::server) staged_hash_ns: u64,
+    pub(in crate::daemon::server) staged_publication_ns: u64,
 }
 
 pub(in crate::daemon::server) fn persist_artifact_file(

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
@@ -4,7 +4,7 @@
 //! redirected before it starts, and unsupported output shapes must fall back
 //! before spawn rather than publishing a partial set afterwards.
 
-use super::staged_store::staged_lane_enabled;
+use super::staged_store::{staged_lane_enabled, StagedMaterializationStats};
 use crate::core::path::NormalizedPath;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -535,12 +535,13 @@ impl StagedCompilePlan {
         }
     }
 
-    pub(in crate::daemon::server) fn materialize(&self) -> io::Result<()> {
+    pub(in crate::daemon::server) fn materialize(&self) -> io::Result<StagedMaterializationStats> {
+        let mut stats = StagedMaterializationStats::default();
         for output in &self.outputs {
             if let Some(parent) = output.requested.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            crate::daemon::server::persist::materialize_independent(
+            let output_stats = crate::daemon::server::persist::materialize_independent_with_stats(
                 output.staged.as_path(),
                 output.requested.as_path(),
             )
@@ -554,8 +555,14 @@ impl StagedCompilePlan {
                     ),
                 )
             })?;
+            stats.reflink_count = stats
+                .reflink_count
+                .saturating_add(output_stats.reflink_count);
+            stats.copy_count = stats.copy_count.saturating_add(output_stats.copy_count);
+            stats.copy_bytes = stats.copy_bytes.saturating_add(output_stats.copy_bytes);
         }
-        self.cleanup()
+        self.cleanup()?;
+        Ok(stats)
     }
 
     /// Rust dep-info is an output too. Translate the private staging prefix

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -16,6 +16,10 @@ mod maintenance;
 pub(crate) use maintenance::{
     evict_staged_artifact_keys, scan_staged_disk_artifacts, StagedDiskArtifact,
 };
+mod materialize;
+pub(in crate::daemon::server) use materialize::{
+    materialize_independent, materialize_independent_with_stats, StagedMaterializationStats,
+};
 
 pub(in crate::daemon::server) const STAGED_ARTIFACTS_ENV: &str = "ZCCACHE_STAGED_ARTIFACTS";
 
@@ -283,30 +287,6 @@ fn copy_output(source: &Path, destination: &Path) -> io::Result<(bool, u64)> {
     result
 }
 
-/// Materialize a staged compiler output without sharing a writable inode with
-/// the private compiler file or the published backend generation.
-pub(in crate::daemon::server) fn materialize_independent(
-    source: &Path,
-    destination: &Path,
-) -> io::Result<()> {
-    if let Ok(metadata) = fs::metadata(destination) {
-        if metadata.is_dir() {
-            return Err(io::Error::new(
-                io::ErrorKind::IsADirectory,
-                format!(
-                    "output destination is a directory: {}",
-                    destination.display()
-                ),
-            ));
-        }
-        let _ = set_readonly(destination, false);
-        fs::remove_file(destination)?;
-    }
-    copy_output(source, destination).map(|_| {
-        let _ = set_readonly(destination, false);
-    })
-}
-
 fn digest_file(path: &Path) -> io::Result<(u64, String)> {
     let mut file = File::open(path)?;
     let mut hasher = blake3::Hasher::new();
@@ -439,7 +419,10 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
 
     let result = (|| {
         let mut outputs = Vec::with_capacity(sources.len());
-        let mut stats = PersistArtifactFileStats::default();
+        let mut stats = PersistArtifactFileStats {
+            staged: true,
+            ..PersistArtifactFileStats::default()
+        };
         for (index, source) in sources.iter().enumerate() {
             let destination = output_path(&temporary_generation, index);
             let (reflink, copied_bytes) =
@@ -453,6 +436,7 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
                         ),
                     )
                 })?;
+            let hash_started = std::time::Instant::now();
             let (size, digest_hex) = digest_file(&destination).map_err(|error| {
                 io::Error::new(
                     error.kind(),
@@ -462,6 +446,9 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
                     ),
                 )
             })?;
+            stats.staged_hash_ns = stats
+                .staged_hash_ns
+                .saturating_add(hash_started.elapsed().as_nanos() as u64);
             write_authoritative_blob_digest_for(&destination, &destination).map_err(|error| {
                 io::Error::new(
                     error.kind(),
@@ -599,6 +586,8 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
                 );
             }
         }
+        stats.staged_publication_ns =
+            (publish_started.elapsed().as_nanos() as u64).saturating_sub(stats.staged_hash_ns);
         tracing::info!(
             event = "staged_publication_complete",
             cache_key = key_hex,

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/materialize.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/materialize.rs
@@ -1,0 +1,78 @@
+//! Independent requested-path materialization and physical-work observations.
+
+use super::{copy_output, set_readonly};
+use std::fs;
+use std::io;
+use std::path::Path;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(in crate::daemon::server) struct StagedMaterializationStats {
+    pub(in crate::daemon::server) reflink_count: u64,
+    pub(in crate::daemon::server) copy_count: u64,
+    pub(in crate::daemon::server) copy_bytes: u64,
+}
+
+/// Materialize without sharing a writable inode with private or backend bytes.
+pub(in crate::daemon::server) fn materialize_independent(
+    source: &Path,
+    destination: &Path,
+) -> io::Result<()> {
+    materialize_independent_with_stats(source, destination).map(|_| ())
+}
+
+pub(in crate::daemon::server) fn materialize_independent_with_stats(
+    source: &Path,
+    destination: &Path,
+) -> io::Result<StagedMaterializationStats> {
+    if let Ok(metadata) = fs::metadata(destination) {
+        if metadata.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::IsADirectory,
+                format!(
+                    "output destination is a directory: {}",
+                    destination.display()
+                ),
+            ));
+        }
+        let _ = set_readonly(destination, false);
+        fs::remove_file(destination)?;
+    }
+    copy_output(source, destination).map(|(reflink, copy_bytes)| {
+        let _ = set_readonly(destination, false);
+        StagedMaterializationStats {
+            reflink_count: u64::from(reflink),
+            copy_count: u64::from(!reflink),
+            copy_bytes,
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{load_staged_artifact_paths, persist_staged_artifact_paths};
+    use super::*;
+
+    #[test]
+    fn staged_persist_and_materialization_report_physical_work() {
+        let dir = tempfile::tempdir().unwrap();
+        let artifact_dir = dir.path().join("artifacts");
+        fs::create_dir_all(&artifact_dir).unwrap();
+        let source = dir.path().join("source.rlib");
+        fs::write(&source, b"observable staged payload").unwrap();
+
+        let persisted =
+            persist_staged_artifact_paths(&artifact_dir, &"9".repeat(64), &[source.into()])
+                .unwrap();
+        assert!(persisted.staged);
+        assert_eq!(persisted.reflink_count + persisted.copy_count, 1);
+
+        let payload = load_staged_artifact_paths(&artifact_dir, &"9".repeat(64), &[25])
+            .unwrap()
+            .unwrap()
+            .remove(0);
+        let destination = dir.path().join("restored.rlib");
+        let materialized = materialize_independent_with_stats(&payload, &destination).unwrap();
+        assert_eq!(materialized.reflink_count + materialized.copy_count, 1);
+        assert_eq!(fs::read(destination).unwrap(), b"observable staged payload");
+    }
+}

--- a/crates/zccache-daemon-core/src/daemon/server/tests/server_ipc.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/server_ipc.rs
@@ -259,7 +259,10 @@ async fn cli_session_lifecycle() {
 
         std::fs::write(
             &src,
-            "#include <stdio.h>\nint main() { printf(\"hello\\n\"); return 0; }\n",
+            format!(
+                "// isolated fixture: {}\n#include <stdio.h>\nint main() {{ printf(\"hello\\n\"); return 0; }}\n",
+                tmp.path().display()
+            ),
         )
         .unwrap();
 
@@ -272,7 +275,7 @@ async fn cli_session_lifecycle() {
                 client_pid: std::process::id(),
                 working_dir: cwd.clone().into(),
                 log_file: Some(log.to_string_lossy().into_owned().into()),
-                track_stats: false,
+                track_stats: true,
                 journal_path: None,
                 profile: false,
                 private_daemon: None,
@@ -359,7 +362,23 @@ async fn cli_session_lifecycle() {
             .unwrap();
 
         match client.recv().await.unwrap() {
-            Some(Response::SessionEnded { .. }) => {}
+            Some(Response::SessionEnded { stats: Some(stats) }) => {
+                let staged = &stats.phase_profile.expect("phase profile").staged;
+                assert!(staged.counters["plan_attempted"] >= 1);
+                assert!(staged.counters["plan_enabled"] >= 1);
+                assert!(staged.counters["compiler_staged"] >= 1);
+                assert!(
+                    staged.counters["publication_success"] >= 1,
+                    "staged counters: {:?}; failures: {:?}",
+                    staged.counters,
+                    staged.failures
+                );
+                assert!(
+                    staged.counters["materialize_reflink"]
+                        + staged.counters["materialize_copy"]
+                        >= 1
+                );
+            }
             other => panic!("expected SessionEnded, got: {other:?}"),
         }
 

--- a/crates/zccache-daemon-core/src/daemon/staged_stats.rs
+++ b/crates/zccache-daemon-core/src/daemon/staged_stats.rs
@@ -1,0 +1,267 @@
+//! Bounded aggregate telemetry for immutable staged compiler outputs (#1071).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::protocol::StagedProfileSummary;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(usize)]
+pub(crate) enum StagedCounter {
+    PlanAttempted,
+    PlanEnabled,
+    PlanUnsupported,
+    PlanError,
+    CompilerStaged,
+    PublicationSuccess,
+    PublicationFailure,
+    PublicationConflict,
+    SalvageAttempt,
+    SalvageSuccess,
+    SalvageFailure,
+    MaterializeReflink,
+    MaterializeHardlink,
+    MaterializeCopy,
+    MaterializeFailure,
+}
+
+const COUNTERS: &[(StagedCounter, &str)] = &[
+    (StagedCounter::PlanAttempted, "plan_attempted"),
+    (StagedCounter::PlanEnabled, "plan_enabled"),
+    (StagedCounter::PlanUnsupported, "plan_unsupported"),
+    (StagedCounter::PlanError, "plan_error"),
+    (StagedCounter::CompilerStaged, "compiler_staged"),
+    (StagedCounter::PublicationSuccess, "publication_success"),
+    (StagedCounter::PublicationFailure, "publication_failure"),
+    (StagedCounter::PublicationConflict, "publication_conflict"),
+    (StagedCounter::SalvageAttempt, "salvage_attempt"),
+    (StagedCounter::SalvageSuccess, "salvage_success"),
+    (StagedCounter::SalvageFailure, "salvage_failure"),
+    (StagedCounter::MaterializeReflink, "materialize_reflink"),
+    (
+        StagedCounter::MaterializeHardlink,
+        "materialize_hardlink_shared",
+    ),
+    (StagedCounter::MaterializeCopy, "materialize_copy"),
+    (StagedCounter::MaterializeFailure, "materialize_failure"),
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(usize)]
+pub(crate) enum StagedTiming {
+    Planning,
+    Compiler,
+    Hashing,
+    Publication,
+    Salvage,
+    MissMaterialization,
+    HitMaterialization,
+}
+
+const TIMINGS: &[(StagedTiming, &str)] = &[
+    (StagedTiming::Planning, "planning"),
+    (StagedTiming::Compiler, "compiler_staging"),
+    (StagedTiming::Hashing, "hashing"),
+    (StagedTiming::Publication, "publication"),
+    (StagedTiming::Salvage, "salvage"),
+    (StagedTiming::MissMaterialization, "miss_materialization"),
+    (StagedTiming::HitMaterialization, "hit_materialization"),
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(usize)]
+pub(crate) enum StagedBytes {
+    Publication,
+    Salvage,
+    Materialization,
+}
+
+const BYTES: &[(StagedBytes, &str)] = &[
+    (StagedBytes::Publication, "publication_copied"),
+    (StagedBytes::Salvage, "salvage_copied"),
+    (StagedBytes::Materialization, "materialization_copied"),
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(usize)]
+pub(crate) enum StagedFailure {
+    UnsupportedShape,
+    Planning,
+    OutputValidation,
+    Hashing,
+    DurableDigest,
+    Manifest,
+    Publication,
+    PublicationConflict,
+    Salvage,
+    RequestedMaterialization,
+    CorruptObject,
+}
+
+const FAILURES: &[(StagedFailure, &str)] = &[
+    (StagedFailure::UnsupportedShape, "unsupported_shape"),
+    (StagedFailure::Planning, "planning"),
+    (StagedFailure::OutputValidation, "output_validation"),
+    (StagedFailure::Hashing, "hashing"),
+    (StagedFailure::DurableDigest, "durable_digest"),
+    (StagedFailure::Manifest, "manifest"),
+    (StagedFailure::Publication, "publication"),
+    (StagedFailure::PublicationConflict, "publication_conflict"),
+    (StagedFailure::Salvage, "salvage"),
+    (
+        StagedFailure::RequestedMaterialization,
+        "requested_materialization",
+    ),
+    (StagedFailure::CorruptObject, "corrupt_object"),
+];
+
+pub(crate) struct StagedProfiler {
+    counters: [AtomicU64; COUNTERS.len()],
+    timings_ns: [AtomicU64; TIMINGS.len()],
+    bytes: [AtomicU64; BYTES.len()],
+    failures: [AtomicU64; FAILURES.len()],
+}
+
+fn saturating_atomic_add(value: &AtomicU64, amount: u64) {
+    let _ = value.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_add(amount))
+    });
+}
+
+impl StagedProfiler {
+    pub(crate) fn new() -> Self {
+        Self {
+            counters: std::array::from_fn(|_| AtomicU64::new(0)),
+            timings_ns: std::array::from_fn(|_| AtomicU64::new(0)),
+            bytes: std::array::from_fn(|_| AtomicU64::new(0)),
+            failures: std::array::from_fn(|_| AtomicU64::new(0)),
+        }
+    }
+
+    pub(crate) fn count(&self, counter: StagedCounter) {
+        self.add_count(counter, 1);
+    }
+
+    pub(crate) fn add_count(&self, counter: StagedCounter, amount: u64) {
+        saturating_atomic_add(&self.counters[counter as usize], amount);
+    }
+
+    pub(crate) fn timing(&self, timing: StagedTiming, elapsed_ns: u64) {
+        saturating_atomic_add(&self.timings_ns[timing as usize], elapsed_ns);
+    }
+
+    pub(crate) fn bytes(&self, kind: StagedBytes, amount: u64) {
+        saturating_atomic_add(&self.bytes[kind as usize], amount);
+    }
+
+    pub(crate) fn failure(&self, failure: StagedFailure) {
+        saturating_atomic_add(&self.failures[failure as usize], 1);
+    }
+
+    pub(crate) fn reset(&self) {
+        for value in self
+            .counters
+            .iter()
+            .chain(&self.timings_ns)
+            .chain(&self.bytes)
+            .chain(&self.failures)
+        {
+            value.store(0, Ordering::Relaxed);
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> StagedProfileSummary {
+        StagedProfileSummary {
+            counters: COUNTERS
+                .iter()
+                .map(|(kind, name)| {
+                    (
+                        (*name).to_string(),
+                        self.counters[*kind as usize].load(Ordering::Relaxed),
+                    )
+                })
+                .collect(),
+            timings_ns: TIMINGS
+                .iter()
+                .map(|(kind, name)| {
+                    (
+                        (*name).to_string(),
+                        self.timings_ns[*kind as usize].load(Ordering::Relaxed),
+                    )
+                })
+                .collect(),
+            bytes: BYTES
+                .iter()
+                .map(|(kind, name)| {
+                    (
+                        (*name).to_string(),
+                        self.bytes[*kind as usize].load(Ordering::Relaxed),
+                    )
+                })
+                .collect(),
+            failures: FAILURES
+                .iter()
+                .map(|(kind, name)| {
+                    (
+                        (*name).to_string(),
+                        self.failures[*kind as usize].load(Ordering::Relaxed),
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+impl Default for StagedProfiler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_uses_only_bounded_non_sensitive_keys() {
+        let profiler = StagedProfiler::new();
+        let snapshot = profiler.snapshot();
+        for key in snapshot
+            .counters
+            .keys()
+            .chain(snapshot.timings_ns.keys())
+            .chain(snapshot.bytes.keys())
+            .chain(snapshot.failures.keys())
+        {
+            assert!(key
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte == b'_'));
+            assert!(!key.contains('/') && !key.contains('\\') && !key.contains(':'));
+        }
+    }
+
+    #[test]
+    fn accumulation_saturates_and_reset_clears_every_family() {
+        let profiler = StagedProfiler::new();
+        profiler.counters[StagedCounter::PlanAttempted as usize].store(u64::MAX, Ordering::Relaxed);
+        profiler.count(StagedCounter::PlanAttempted);
+        profiler.timing(StagedTiming::Planning, 7);
+        profiler.bytes(StagedBytes::Publication, 11);
+        profiler.failure(StagedFailure::Planning);
+
+        let saturated = profiler.snapshot();
+        assert_eq!(saturated.counters["plan_attempted"], u64::MAX);
+        assert_eq!(saturated.timings_ns["planning"], 7);
+        assert_eq!(saturated.bytes["publication_copied"], 11);
+        assert_eq!(saturated.failures["planning"], 1);
+
+        profiler.reset();
+        let reset = profiler.snapshot();
+        assert!(reset
+            .counters
+            .values()
+            .chain(reset.timings_ns.values())
+            .chain(reset.bytes.values())
+            .chain(reset.failures.values())
+            .all(|value| *value == 0));
+    }
+}

--- a/crates/zccache-daemon-core/src/daemon/stats.rs
+++ b/crates/zccache-daemon-core/src/daemon/stats.rs
@@ -210,6 +210,8 @@ impl Default for StatsCollector {
 ///
 /// All values are in nanoseconds. Thread-safe via atomics.
 pub struct PhaseProfiler {
+    /// Bounded staged-output pipeline telemetry.
+    pub(crate) staged: super::staged_stats::StagedProfiler,
     /// Number of profiled requests.
     pub count: AtomicU64,
     /// Parse compiler invocation args.
@@ -253,6 +255,7 @@ impl PhaseProfiler {
     #[must_use]
     pub fn new() -> Self {
         Self {
+            staged: super::staged_stats::StagedProfiler::new(),
             count: AtomicU64::new(0),
             parse_args_ns: AtomicU64::new(0),
             build_context_ns: AtomicU64::new(0),
@@ -318,6 +321,7 @@ impl PhaseProfiler {
 
     /// Reset all phase counters to zero.
     pub fn reset(&self) {
+        self.staged.reset();
         self.count.store(0, Ordering::Relaxed);
         self.parse_args_ns.store(0, Ordering::Relaxed);
         self.build_context_ns.store(0, Ordering::Relaxed);
@@ -373,6 +377,7 @@ impl PhaseProfiler {
             hash_all_ns: self.hash_all_ns.load(Ordering::Relaxed),
             artifact_store_ns: self.artifact_store_ns.load(Ordering::Relaxed),
             total_miss_ns: self.total_miss_ns.load(Ordering::Relaxed),
+            staged: self.staged.snapshot(),
         }
     }
 
@@ -458,6 +463,7 @@ pub struct PhaseTotals {
     pub hash_all_ns: u64,
     pub artifact_store_ns: u64,
     pub total_miss_ns: u64,
+    pub staged: crate::protocol::StagedProfileSummary,
 }
 
 impl From<PhaseTotals> for crate::protocol::PhaseProfileSummary {
@@ -481,6 +487,7 @@ impl From<PhaseTotals> for crate::protocol::PhaseProfileSummary {
             hash_all_ns: t.hash_all_ns,
             artifact_store_ns: t.artifact_store_ns,
             total_miss_ns: t.total_miss_ns,
+            staged: t.staged,
         }
     }
 }

--- a/crates/zccache-protocol/proto/zccache_v1.proto
+++ b/crates/zccache-protocol/proto/zccache_v1.proto
@@ -310,6 +310,14 @@ message PhaseProfileSummary {
   uint64 hash_all_ns = 16;
   uint64 artifact_store_ns = 17;
   uint64 total_miss_ns = 18;
+  StagedProfileSummary staged = 19;
+}
+
+message StagedProfileSummary {
+  map<string, uint64> counters = 1;
+  map<string, uint64> timings_ns = 2;
+  map<string, uint64> bytes = 3;
+  map<string, uint64> failures = 4;
 }
 
 message SessionStarted {

--- a/crates/zccache-protocol/src/README.md
+++ b/crates/zccache-protocol/src/README.md
@@ -1,7 +1,7 @@
 # zccache-protocol
 
 Wire protocol: `Request`/`Response` enums over a length-prefixed daemon frame.
-The active compatibility path is v15 bincode. The v16 prost schema is generated
+The active compatibility path is v18 bincode. The v16-family prost schema is generated
 from `proto/zccache_v1.proto` and scaffolded in `wire_prost.rs` so the daemon can
 later dispatch both v15 bincode and v16 prost frames during migration.
 
@@ -25,9 +25,9 @@ enum variants must still be appended in `messages/mod.rs` and require a
 
 ## Wire Migration
 
-`PROTOCOL_VERSION` remains `15` while the public `encode_message` and
+`PROTOCOL_VERSION` is `18` while the public `encode_message` and
 `decode_message` helpers emit and accept bincode bodies. `PROST_PROTOCOL_VERSION`
-is `16` for the prost path. The live daemon receive path dispatches both frame
+is `19` for the current prost schema revision. The live daemon receive path dispatches both frame
 versions, but only the control/maintenance request slice (`Ping`, `Status`,
 `Shutdown`, `Clear`, `ReleaseWorktreeHandles`) is converted from prost today,
 and only the matching control/maintenance response slice (`Pong`, `Status`,
@@ -36,9 +36,9 @@ back to prost replies.
 `ZCCACHE_DAEMON_WIRE` is honored for that client control slice: unset or `auto`
 tries prost first and falls back to v15 bincode on a clear old-daemon protocol
 rejection; `bincode` forces the old path. The live daemon can accept a direct
-v16 prost `ReleaseWorktreeHandles` request, but the high-level client selector
+v16-family prost `ReleaseWorktreeHandles` request, but the high-level client selector
 does not route it yet. Compile, session, artifact lookup/store, fingerprint,
-generic-tool, and download-daemon requests remain v15 bincode until their full
+generic-tool, and download-daemon requests remain on the bincode lane until their full
 protobuf conversion lands.
 
 ## Request Variants

--- a/crates/zccache-protocol/src/lib.rs
+++ b/crates/zccache-protocol/src/lib.rs
@@ -14,21 +14,21 @@ pub use messages::*;
 /// This remains the active compatibility version until the v16 prost dispatcher
 /// is wired through the IPC transport. Do not change `PROTOCOL_VERSION` to v16
 /// while `encode_message` and `decode_message` still serialize bincode bodies.
-pub const BINCODE_PROTOCOL_VERSION: u32 = 17;
+pub const BINCODE_PROTOCOL_VERSION: u32 = 18;
 
-/// Planned prost daemon wire version.
+/// Prost daemon wire version.
 ///
 /// The prost schema and frame helpers use this value. A future change will make
 /// the daemon dispatch v15 bincode and v16 prost frames concurrently.
-pub const PROST_PROTOCOL_VERSION: u32 = 16;
+pub const PROST_PROTOCOL_VERSION: u32 = 19;
 
 /// Protocol version number. Bump this when the wire format changes:
 /// new/removed/reordered enum variants or struct field changes.
 /// Patch releases that don't change the protocol keep the same version.
 ///
-/// v16 (planned): prost-encoded protobuf body. The v16 schema lives in
-///                  `proto/zccache_v1.proto`; v15 bincode remains accepted
-///                  during the transition.
+/// v19: v16-family prost body with staged-output telemetry. The schema lives in
+///                  `proto/zccache_v1.proto`; the bincode lane remains
+///                  separately versioned during the transition.
 /// v15 (current bincode): added `Request::ReleaseWorktreeHandles` /
 ///                  `Response::ReleaseWorktreeHandlesResult` so callers
 ///                  (soldr Tier 3 worktree teardown, issue #690) can ask
@@ -47,6 +47,8 @@ pub const PROST_PROTOCOL_VERSION: u32 = 16;
 ///                  Lets a Python binding cache an in-process function call
 ///                  via the daemon's KV store without serializing argv
 ///                  (subsumes #837 for Python consumers).
+/// v18: `PhaseProfileSummary` gained bounded staged-output pipeline
+///                  counters, timings, byte totals, and failure reasons.
 /// v11: `Request::GenericToolExec` gained Path A (include scan)
 ///                  + Path B (depfile) + `non_deterministic` +
 ///                  `key_args_filter` fields completing issue #272.
@@ -65,9 +67,9 @@ use prost::Message as ProstMessage;
 /// Message decoded from a version-dispatched daemon frame.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DecodedWireMessage<Bincode, Prost> {
-    /// v15 bincode payload, kept for old clients during the migration.
+    /// Bincode payload (historical variant name; current header version is v18).
     BincodeV15(Bincode),
-    /// v16 prost payload.
+    /// Prost payload (historical variant name; current header version is v19).
     ProstV16(Prost),
     /// Prost payload carried inside a running-process broker `Frame`
     /// envelope. `request_id` is the frame correlation id the responder

--- a/crates/zccache-protocol/src/messages/compat/mod.rs
+++ b/crates/zccache-protocol/src/messages/compat/mod.rs
@@ -102,8 +102,8 @@ pub(super) fn sample_artifact() -> ArtifactData {
 
 // Compile-time check: PROTOCOL_VERSION must be positive.
 const _: () = assert!(super::super::PROTOCOL_VERSION > 0);
-// Compile-time check: PROTOCOL_VERSION == 17 after `ExecProbe`/`ExecStore`
-// were added (issue #838 slice 1) for caller-owned tool caching (e.g. the
+// Compile-time check: PROTOCOL_VERSION == 18 after staged telemetry was added.
+// v17 added ExecProbe/ExecStore (issue #838 slice 1) for caller-owned tool caching (e.g. the
 // PyO3 `zccache.exec` binding for Python build orchestrators). v15 was
 // the pin after `ReleaseWorktreeHandles` was added for soldr Tier 3
 // worktree teardown (issue #690). v14 was the pin after private daemon
@@ -116,4 +116,4 @@ const _: () = assert!(super::super::PROTOCOL_VERSION > 0);
 // pin after SessionStats gained `phase_profile`. v8 was the pin after
 // Compile/CompileEphemeral gained `stdin` and ArtifactPayload replaced
 // ArtifactOutput.data: Arc<Vec<u8>> (issue #296 Option B).
-const _FINGERPRINT_VERSION: () = assert!(super::super::PROTOCOL_VERSION == 17);
+const _FINGERPRINT_VERSION: () = assert!(super::super::PROTOCOL_VERSION == 18);

--- a/crates/zccache-protocol/src/messages/compat/session_stats.rs
+++ b/crates/zccache-protocol/src/messages/compat/session_stats.rs
@@ -90,6 +90,7 @@ fn session_stats_with_phase_profile_roundtrip() {
             hash_all_ns: 95_000_000,
             artifact_store_ns: 120_000_000,
             total_miss_ns: 11_885_000_000,
+            staged: StagedProfileSummary::default(),
         }),
     };
     roundtrip(&stats);
@@ -103,6 +104,17 @@ fn session_stats_with_phase_profile_roundtrip() {
     assert_eq!(decoded.lookup_outcomes.depgraph_hit_artifact_hit, 103);
     assert_eq!(decoded.lookup_outcomes.depgraph_hit_artifact_miss, 2);
     assert_eq!(decoded.lookup_outcomes.depgraph_cold_skip, 7);
+
+    let mut pre_v18_json = serde_json::to_value(&stats).expect("serialize value");
+    pre_v18_json["phase_profile"]
+        .as_object_mut()
+        .expect("phase profile object")
+        .remove("staged");
+    let pre_v18: SessionStats = serde_json::from_value(pre_v18_json).expect("pre-v18 decode");
+    assert_eq!(
+        pre_v18.phase_profile.unwrap().staged,
+        StagedProfileSummary::default()
+    );
 
     // An old-daemon-style JSON that omits phase_profile must decode to
     // None (back-compat with PROTOCOL_VERSION 8 consumers that haven't

--- a/crates/zccache-protocol/src/messages/mod.rs
+++ b/crates/zccache-protocol/src/messages/mod.rs
@@ -22,7 +22,7 @@ pub use artifact::{
 pub use exec::{ExecCachePolicy, ExecOutputStreams};
 pub use status::{
     DaemonStatus, LookupOutcomes, PhaseProfileSummary, PrivateDaemonOwnerStatus,
-    PrivateDaemonStatus, SessionStats,
+    PrivateDaemonStatus, SessionStats, StagedProfileSummary,
 };
 
 /// Private daemon options carried by `SessionStart`.

--- a/crates/zccache-protocol/src/messages/status.rs
+++ b/crates/zccache-protocol/src/messages/status.rs
@@ -211,4 +211,23 @@ pub struct PhaseProfileSummary {
     pub artifact_store_ns: u64,
     /// Wall-clock total of the miss path.
     pub total_miss_ns: u64,
+    /// Staged-output pipeline counters, timings, bytes, and bounded failures.
+    #[serde(default)]
+    pub staged: StagedProfileSummary,
+}
+
+/// Aggregate staged-output telemetry.
+///
+/// Keys are a bounded vocabulary owned by the daemon, never user paths,
+/// command lines, cache keys, or raw operating-system error strings.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct StagedProfileSummary {
+    #[serde(default)]
+    pub counters: BTreeMap<String, u64>,
+    #[serde(default)]
+    pub timings_ns: BTreeMap<String, u64>,
+    #[serde(default)]
+    pub bytes: BTreeMap<String, u64>,
+    #[serde(default)]
+    pub failures: BTreeMap<String, u64>,
 }

--- a/crates/zccache-protocol/src/wire_prost/convert.rs
+++ b/crates/zccache-protocol/src/wire_prost/convert.rs
@@ -340,6 +340,29 @@ fn phase_profile_to_prost(profile: &crate::PhaseProfileSummary) -> zccache_v1::P
         hash_all_ns: profile.hash_all_ns,
         artifact_store_ns: profile.artifact_store_ns,
         total_miss_ns: profile.total_miss_ns,
+        staged: Some(staged_profile_to_prost(&profile.staged)),
+    }
+}
+
+fn staged_profile_to_prost(
+    profile: &crate::StagedProfileSummary,
+) -> zccache_v1::StagedProfileSummary {
+    zccache_v1::StagedProfileSummary {
+        counters: profile.counters.clone().into_iter().collect(),
+        timings_ns: profile.timings_ns.clone().into_iter().collect(),
+        bytes: profile.bytes.clone().into_iter().collect(),
+        failures: profile.failures.clone().into_iter().collect(),
+    }
+}
+
+fn staged_profile_from_prost(
+    profile: zccache_v1::StagedProfileSummary,
+) -> crate::StagedProfileSummary {
+    crate::StagedProfileSummary {
+        counters: profile.counters.into_iter().collect(),
+        timings_ns: profile.timings_ns.into_iter().collect(),
+        bytes: profile.bytes.into_iter().collect(),
+        failures: profile.failures.into_iter().collect(),
     }
 }
 
@@ -365,6 +388,10 @@ fn phase_profile_from_prost(
         hash_all_ns: profile.hash_all_ns,
         artifact_store_ns: profile.artifact_store_ns,
         total_miss_ns: profile.total_miss_ns,
+        staged: profile
+            .staged
+            .map(staged_profile_from_prost)
+            .unwrap_or_default(),
     }
 }
 

--- a/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
+++ b/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
@@ -202,7 +202,7 @@ mod full_family {
     use zccache::protocol::{
         ArtifactData, ArtifactOutput, ArtifactPayload, ExecCachePolicy, ExecOutputStreams,
         LookupOutcomes, LookupResult, PhaseProfileSummary, PrivateDaemonSessionOptions, Request,
-        Response, RustArtifactInfo, SessionStats, StoreResult,
+        Response, RustArtifactInfo, SessionStats, StagedProfileSummary, StoreResult,
     };
 
     fn roundtrip_request(request: Request) {
@@ -274,6 +274,14 @@ mod full_family {
                 hash_all_ns: 16,
                 artifact_store_ns: 17,
                 total_miss_ns: 18,
+                staged: StagedProfileSummary {
+                    counters: [("plan_enabled".to_string(), 2)].into_iter().collect(),
+                    timings_ns: [("planning".to_string(), 19)].into_iter().collect(),
+                    bytes: [("publication_copied".to_string(), 20)]
+                        .into_iter()
+                        .collect(),
+                    failures: [("unsupported_shape".to_string(), 1)].into_iter().collect(),
+                },
             }),
         }
     }

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -93,6 +93,18 @@ as a legacy format. Re-enabling a v2-aware reader makes those generations
 available again. Disk eviction groups coexisting v1/pack/v2 storage by cache
 key, accounts for all physical bytes, and removes the logical artifact once.
 
+Session phase profiles include a bounded `staged` summary. The compile-miss
+lane populates planning, compiler staging, hashing, publication, salvage, and
+requested-path materialization; hit-tier and special-producer wiring remains
+tracked by #1071. The summary reports counters, nanosecond totals, copied-byte
+totals, and stable failure reason IDs. Labels are daemon-owned constants:
+paths, argv, cache keys, and raw OS errors are never metric keys. Bincode
+protocol v18 carries this summary; the protobuf schema adds it as an optional
+message so older protobuf readers continue to ignore it safely. Clear resets
+these totals with the existing phase profiler. The additive protobuf field
+advances that lane to protocol v19. Salvage and requested-path materialization
+failures also emit durable lifecycle records.
+
 ## Directory Layout
 
 ```


### PR DESCRIPTION
Part of #1071 and parent #1056. This is Phase 8c-A; it intentionally does not close #1071.

## What changed

- add a fixed-vocabulary, saturating staged-output profiler nested in existing session phase stats;
- expose bounded counters, ns totals, copied-byte totals, and failure reasons without paths/argv/raw OS errors as labels;
- bump the changed bincode shape to protocol v18 and the revised v16-family protobuf lane header to v19;
- preserve pre-v18 session JSON through `serde(default)` and add exact protobuf conversion coverage;
- instrument compile planning, private compiler execution, v2 hashing/publication, publication conflicts/failures, salvage, and miss materialization;
- emit durable salvage started/complete/failed and requested-materialization-failed lifecycle records;
- return physical reflink/copy observations from independent materialization;
- keep the store file within its prior size by splitting materialization into a child module.

## Adversarial/compatibility coverage

- fixed label vocabulary rejects path-like/secrets-shaped keys;
- atomic totals saturate at `u64::MAX` and Clear/reset zeros every family;
- pre-v18 JSON without the nested field defaults safely;
- nonzero staged maps round-trip through the full protobuf session response;
- real filesystem publication/materialization reports exactly one physical tier;
- real ignored clang lifecycle proves staged C++ miss planning/compiler/publication/materialization appears in returned session stats;
- cross-run fixture identity is unique so same-key conflict coverage cannot contaminate the success test.

## Validation

- daemon-core broad: 470 passed, 19 ignored, 0 failed
- protocol: 51 passed, 0 failed
- full protobuf family: 25 passed, 0 failed
- real clang IPC lifecycle: 1 passed
- Linux soldr rustfmt: exact
- daemon-core scoped Clippy: pass (known untouched `question_mark` warning explicitly allowed)
- protocol + CLI all-target Clippy with warnings denied: pass
- pre-push Rust/docs/protocol review: clean after protocol-version and module-size fixes

## Follow-up retained in #1071

- cache-hit tier observations;
- archive/link/exact-exec wiring;
- stable per-branch planner reasons beyond the initial bounded fallback reason;
- deterministic fault hooks for every publication/salvage edge.