### PR TITLE
feat(cache): observe staged hit materialization tiers

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
@@ -167,16 +167,60 @@ pub(super) fn materialize_cached_compile_hit(
             )
         })
         .collect::<Vec<_>>();
-    if !write_payloads_par_with_mtime_floor_and_policies(
+    let has_staged_payload = payloads_to_write.iter().any(
+        |payload| matches!(payload, CachedPayload::File(path) if is_staged_artifact_path(path)),
+    );
+    let observed = match write_payloads_par_with_mtime_floor_and_policies_observed(
         &targets,
         &payloads_to_write,
         &mtime_floor_paths,
         &delivery_policies,
     ) {
-        return None;
-    }
+        Some(observed) => observed,
+        None => {
+            if has_staged_payload {
+                use crate::daemon::staged_stats::{StagedCounter, StagedFailure, StagedTiming};
+                state
+                    .profiler
+                    .staged
+                    .count(StagedCounter::MaterializeFailure);
+                state
+                    .profiler
+                    .staged
+                    .failure(StagedFailure::RequestedMaterialization);
+                state.profiler.staged.timing(
+                    StagedTiming::HitMaterialization,
+                    t1.elapsed().as_nanos() as u64,
+                );
+            }
+            return None;
+        }
+    };
     let t2 = Instant::now();
     let write_output_ns = (t2 - t1).as_nanos() as u64;
+    if has_staged_payload {
+        use crate::daemon::staged_stats::{StagedBytes, StagedCounter, StagedTiming};
+        state
+            .profiler
+            .staged
+            .add_count(StagedCounter::MaterializeReflink, observed.reflink_count);
+        state
+            .profiler
+            .staged
+            .add_count(StagedCounter::MaterializeHardlink, observed.hardlink_count);
+        state
+            .profiler
+            .staged
+            .add_count(StagedCounter::MaterializeCopy, observed.copy_count);
+        state
+            .profiler
+            .staged
+            .bytes(StagedBytes::Materialization, observed.copy_bytes);
+        state
+            .profiler
+            .staged
+            .timing(StagedTiming::HitMaterialization, write_output_ns);
+    }
 
     let cached_error = exit_code != 0;
     if !cached_error && downgrade_output_metadata {

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/materialize.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/materialize.rs
@@ -8,8 +8,18 @@ use std::path::Path;
 #[derive(Clone, Copy, Debug, Default)]
 pub(in crate::daemon::server) struct StagedMaterializationStats {
     pub(in crate::daemon::server) reflink_count: u64,
+    pub(in crate::daemon::server) hardlink_count: u64,
     pub(in crate::daemon::server) copy_count: u64,
     pub(in crate::daemon::server) copy_bytes: u64,
+}
+
+impl StagedMaterializationStats {
+    pub(in crate::daemon::server) fn add(&mut self, other: Self) {
+        self.reflink_count = self.reflink_count.saturating_add(other.reflink_count);
+        self.hardlink_count = self.hardlink_count.saturating_add(other.hardlink_count);
+        self.copy_count = self.copy_count.saturating_add(other.copy_count);
+        self.copy_bytes = self.copy_bytes.saturating_add(other.copy_bytes);
+    }
 }
 
 /// Materialize without sharing a writable inode with private or backend bytes.
@@ -41,6 +51,7 @@ pub(in crate::daemon::server) fn materialize_independent_with_stats(
         let _ = set_readonly(destination, false);
         StagedMaterializationStats {
             reflink_count: u64::from(reflink),
+            hardlink_count: 0,
             copy_count: u64::from(!reflink),
             copy_bytes,
         }

--- a/crates/zccache-daemon-core/src/daemon/server/persist/write_cached.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/write_cached.rs
@@ -16,6 +16,7 @@ pub(in crate::daemon::server) fn write_cached_output(
         cache_file,
         crate::compiler::DeliveryPolicy::IndependentOnly,
     )
+    .map(|_| ())
 }
 
 pub(in crate::daemon::server) fn write_cached_file(
@@ -27,30 +28,48 @@ pub(in crate::daemon::server) fn write_cached_file(
         cache_file,
         crate::compiler::DeliveryPolicy::IndependentOnly,
     )
+    .map(|_| ())
 }
 
 fn materialize_cached_file(
     out_path: &Path,
     cache_file: &Path,
     delivery: crate::compiler::DeliveryPolicy,
-) -> std::io::Result<()> {
+) -> std::io::Result<StagedMaterializationStats> {
     let staged = is_staged_artifact_path(cache_file);
+    let observed = |reflink_count, hardlink_count, copy_count, copy_bytes| {
+        if staged {
+            StagedMaterializationStats {
+                reflink_count,
+                hardlink_count,
+                copy_count,
+                copy_bytes,
+            }
+        } else {
+            StagedMaterializationStats::default()
+        }
+    };
     verify_registered_blob(cache_file)?;
     let hardlink_allowed =
         !staged || matches!(delivery, crate::compiler::DeliveryPolicy::HardlinkEligible);
     if same_file(out_path, cache_file) {
         if !hardlink_allowed {
+            let bytes = std::fs::metadata(cache_file)?.len();
             let floor =
                 filetime::FileTime::from_last_modification_time(&std::fs::metadata(cache_file)?);
             detach_with_floored_mtime(out_path, cache_file, floor)?;
-            return Ok(());
+            return Ok(observed(0, 0, 1, bytes));
         }
         set_readonly(cache_file, readonly_enabled())?;
         match compute_sibling_floor(out_path)? {
-            Some(floor) => detach_with_floored_mtime(out_path, cache_file, floor)?,
+            Some(floor) => {
+                let bytes = std::fs::metadata(cache_file)?.len();
+                detach_with_floored_mtime(out_path, cache_file, floor)?;
+                return Ok(observed(0, 0, 1, bytes));
+            }
             None => register_hardlink(cache_file, out_path)?,
         }
-        return Ok(());
+        return Ok(observed(0, 1, 0, 0));
     }
     remove_materialized_output(out_path)?;
     let caps = fs_caps(cache_file, out_path);
@@ -58,7 +77,7 @@ fn materialize_cached_file(
         make_writable(out_path)?;
         restore_cache_mtime(cache_file, out_path)?;
         touch_mtime(out_path);
-        return Ok(());
+        return Ok(observed(1, 0, 0, 0));
     }
     // A failed link-count query must not be read as "at capacity" — that
     // silently defeats the hardlink tier (falls through to a full copy)
@@ -91,7 +110,7 @@ fn materialize_cached_file(
                     match commit_hardlink_registration(registration, out_path) {
                         Ok(()) => {
                             touch_mtime(out_path);
-                            return Ok(());
+                            return Ok(observed(0, 1, 0, 0));
                         }
                         Err(error) => {
                             // A failure here (including a transient stat/handle
@@ -125,11 +144,11 @@ fn materialize_cached_file(
             }
         }
     }
-    std::fs::copy(cache_file, out_path)?;
+    let copied_bytes = std::fs::copy(cache_file, out_path)?;
     make_writable(out_path)?;
     restore_cache_mtime(cache_file, out_path)?;
     touch_mtime(out_path);
-    Ok(())
+    Ok(observed(0, 0, 1, copied_bytes))
 }
 
 fn cleanup_failed_hardlink(
@@ -229,14 +248,17 @@ pub(in crate::daemon::server) fn write_cached_payload(
     }
 }
 
-pub(in crate::daemon::server) fn write_cached_payload_with_policy(
+pub(in crate::daemon::server) fn write_cached_payload_with_policy_stats(
     out_path: &Path,
     cache_file: &Path,
     payload: &CachedPayload,
     delivery: crate::compiler::DeliveryPolicy,
-) -> std::io::Result<()> {
+) -> std::io::Result<StagedMaterializationStats> {
     match payload {
-        CachedPayload::Bytes(data) => write_cached_output(out_path, cache_file, data),
+        CachedPayload::Bytes(data) => {
+            write_cached_output(out_path, cache_file, data)?;
+            Ok(StagedMaterializationStats::default())
+        }
         CachedPayload::File(path) => materialize_cached_file(out_path, path, delivery),
     }
 }
@@ -286,6 +308,7 @@ where
     write_payloads_par_with_mtime_floor_and_policies(targets, payloads, floor_paths, &policies)
 }
 
+#[cfg(test)]
 pub(in crate::daemon::server) fn write_payloads_par_with_mtime_floor_and_policies<P, Q, R>(
     targets: &[(P, Q)],
     payloads: &[CachedPayload],
@@ -297,43 +320,68 @@ where
     Q: AsRef<Path> + Sync,
     R: AsRef<Path>,
 {
+    write_payloads_par_with_mtime_floor_and_policies_observed(
+        targets,
+        payloads,
+        floor_paths,
+        policies,
+    )
+    .is_some()
+}
+
+pub(in crate::daemon::server) fn write_payloads_par_with_mtime_floor_and_policies_observed<
+    P,
+    Q,
+    R,
+>(
+    targets: &[(P, Q)],
+    payloads: &[CachedPayload],
+    floor_paths: &[R],
+    policies: &[crate::compiler::DeliveryPolicy],
+) -> Option<StagedMaterializationStats>
+where
+    P: AsRef<Path> + Sync,
+    Q: AsRef<Path> + Sync,
+    R: AsRef<Path>,
+{
     debug_assert_eq!(targets.len(), payloads.len());
     debug_assert_eq!(targets.len(), policies.len());
     let write_one = |out: &Path,
                      cache: &Path,
                      payload: &CachedPayload,
                      policy: crate::compiler::DeliveryPolicy|
-     -> bool {
+     -> std::io::Result<StagedMaterializationStats> {
         if let Some(parent) = out.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
-        write_cached_payload_with_policy(out, cache, payload, policy).is_ok()
+        write_cached_payload_with_policy_stats(out, cache, payload, policy)
     };
-    let ok = if targets.len() < PAR_WRITE_THRESHOLD {
-        targets
-            .iter()
-            .zip(payloads)
-            .zip(policies)
-            .all(|(((out, cache), payload), policy)| {
-                write_one(out.as_ref(), cache.as_ref(), payload, *policy)
-            })
+    let observed = if targets.len() < PAR_WRITE_THRESHOLD {
+        let mut observed = StagedMaterializationStats::default();
+        for (((out, cache), payload), policy) in targets.iter().zip(payloads).zip(policies) {
+            observed.add(write_one(out.as_ref(), cache.as_ref(), payload, *policy).ok()?);
+        }
+        observed
     } else {
         use rayon::prelude::*;
         targets
             .par_iter()
             .zip(payloads.par_iter())
             .zip(policies.par_iter())
-            .all(|(((out, cache), payload), policy)| {
+            .map(|(((out, cache), payload), policy)| {
                 write_one(out.as_ref(), cache.as_ref(), payload, *policy)
             })
+            .try_reduce(StagedMaterializationStats::default, |mut total, one| {
+                total.add(one);
+                Ok(total)
+            })
+            .ok()?
     };
-    if ok {
-        let batch_floor = std::time::SystemTime::now();
-        floor_materialized_outputs_to_input_max(
-            targets.iter().map(|(out, _)| out.as_ref()),
-            floor_paths.iter().map(|path| path.as_ref()),
-            batch_floor,
-        );
-    }
-    ok
+    let batch_floor = std::time::SystemTime::now();
+    floor_materialized_outputs_to_input_max(
+        targets.iter().map(|(out, _)| out.as_ref()),
+        floor_paths.iter().map(|path| path.as_ref()),
+        batch_floor,
+    );
+    Some(observed)
 }

--- a/crates/zccache-daemon-core/src/daemon/server/tests/write_cached.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/write_cached.rs
@@ -306,13 +306,19 @@ fn staged_generation_hardlinks_only_when_semantically_authorized() {
         .unwrap()
         .unwrap();
     let payload = CachedPayload::File(payloads[0].clone());
-    write_cached_payload_with_policy(
-        &output,
-        &payloads[0],
-        &payload,
-        crate::compiler::DeliveryPolicy::HardlinkEligible,
+    let targets = vec![(&output, &payloads[0])];
+    let observed = write_payloads_par_with_mtime_floor_and_policies_observed(
+        &targets,
+        &[payload],
+        &Vec::<NormalizedPath>::new(),
+        &[crate::compiler::DeliveryPolicy::HardlinkEligible],
     )
     .unwrap();
+    assert_eq!(
+        observed.reflink_count + observed.hardlink_count + observed.copy_count,
+        1,
+        "a staged file restore reports exactly one successful tier"
+    );
     if !require_hardlink(
         &output,
         &payloads[0],

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -95,8 +95,10 @@ key, accounts for all physical bytes, and removes the logical artifact once.
 
 Session phase profiles include a bounded `staged` summary. The compile-miss
 lane populates planning, compiler staging, hashing, publication, salvage, and
-requested-path materialization; hit-tier and special-producer wiring remains
-tracked by #1071. The summary reports counters, nanosecond totals, copied-byte
+requested-path materialization. V2 file hits report the tier that actually
+succeeded (reflink, hardlink-shared, or copy), copied bytes, failures, and
+elapsed ns; special-producer wiring remains tracked by #1071. The summary
+reports counters, nanosecond totals, copied-byte
 totals, and stable failure reason IDs. Labels are daemon-owned constants:
 paths, argv, cache keys, and raw OS errors are never metric keys. Bincode
 protocol v18 carries this summary; the protobuf schema adds it as an optional


### PR DESCRIPTION
Continues #1071 and parent #1056. Does not close #1071.

## What changed

- return physical tier observations from the existing cached-file materializer;
- distinguish actual successful reflink, hardlink-shared, and copy fallback results;
- aggregate multi-output restores with saturating counts/bytes;
- record v2 hit materialization ns, copied bytes, tier counts, and bounded failures in the staged profiler added by #1072;
- leave legacy/in-memory byte hits unlabelled because no v2 filesystem tier ran;
- preserve mtime flooring only after every output succeeds;
- avoid a new allocation on the common one/two-output hit path.

## Adversarial coverage

- semantic Rust archive restore reports exactly one actual tier before hardlink mutation testing;
- fallback reports the tier that succeeded, not the tier first attempted;
- same-daemon in-memory hits are not falsely counted as v2 filesystem restores;
- staged restore failure records bounded failure/timing and still fails closed;
- warm-hit budget test remains green.

## Validation

- daemon-core broad: 470 passed, 19 ignored, 0 failed
- real clang IPC lifecycle: pass
- staged semantic hardlink/tier fixture: pass
- warm-hit materialization budget: pass
- Linux soldr rustfmt: exact
- scoped Clippy: pass (known untouched `question_mark` warning explicitly allowed)
- pre-push Rust/docs review: clean

Remaining in #1071: archive/link/exact-exec wiring, branch-specific planner reasons, and deterministic publication/salvage fault hooks.