### PR TITLE
feat(cache): observe staged special producers

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
@@ -100,17 +100,21 @@ impl ExecStagedPlan {
             .collect()
     }
 
-    fn materialize(&self) -> std::io::Result<()> {
+    fn materialize(&self) -> std::io::Result<StagedMaterializationStats> {
+        let mut observed = StagedMaterializationStats::default();
         for (requested, staged) in &self.outputs {
             if let Some(parent) = requested.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            crate::daemon::server::persist::materialize_independent(
-                staged.as_path(),
-                requested.as_path(),
-            )?;
+            observed.add(
+                crate::daemon::server::persist::materialize_independent_with_stats(
+                    staged.as_path(),
+                    requested.as_path(),
+                )?,
+            );
         }
-        self.cleanup()
+        self.cleanup()?;
+        Ok(observed)
     }
 
     fn cleanup(&self) -> std::io::Result<()> {
@@ -311,11 +315,27 @@ pub(super) async fn handle_generic_tool_exec(
     // 9. Cache miss — stage declared outputs only when the tool's argv gives
     // us an unambiguous exact-token rewrite for every output. Opaque output
     // syntax remains on the legacy path before spawn.
+    use crate::daemon::staged_stats::{StagedCounter, StagedFailure, StagedTiming};
+    let planning_started = std::time::Instant::now();
+    state.profiler.staged.count(StagedCounter::PlanAttempted);
     let staged_plan = if exec_staging_enabled() {
         ExecStagedPlan::build(state.staging.path(), args, output_files, cwd)
     } else {
         None
     };
+    state.profiler.staged.timing(
+        StagedTiming::Planning,
+        planning_started.elapsed().as_nanos() as u64,
+    );
+    if staged_plan.is_some() {
+        state.profiler.staged.count(StagedCounter::PlanEnabled);
+    } else {
+        state.profiler.staged.count(StagedCounter::PlanUnsupported);
+        state
+            .profiler
+            .staged
+            .failure(StagedFailure::UnsupportedShape);
+    }
     let compiler_args = staged_plan
         .as_ref()
         .map_or(args, |plan| plan.rewritten_args.as_slice());
@@ -336,6 +356,7 @@ pub(super) async fn handle_generic_tool_exec(
             };
         }
     }
+    let compiler_started = std::time::Instant::now();
     let output = match spawn_tool(tool, compiler_args, cwd, &env).await {
         Ok(o) => o,
         Err(e) => {
@@ -344,6 +365,13 @@ pub(super) async fn handle_generic_tool_exec(
             };
         }
     };
+    if staged_plan.is_some() {
+        state.profiler.staged.count(StagedCounter::CompilerStaged);
+        state.profiler.staged.timing(
+            StagedTiming::Compiler,
+            compiler_started.elapsed().as_nanos() as u64,
+        );
+    }
 
     let exit_code = output.status.code().unwrap_or(1);
     let stdout = Arc::new(if output_streams.stdout {
@@ -441,10 +469,40 @@ pub(super) async fn handle_generic_tool_exec(
                 message: "successful generic tool omitted a staged output".to_string(),
             };
         }
-        if let Err(error) = plan.materialize() {
-            return Response::Error {
-                message: format!("failed to materialize generic tool outputs: {error}"),
-            };
+        use crate::daemon::staged_stats::{StagedBytes, StagedCounter, StagedFailure};
+        let materialize_started = std::time::Instant::now();
+        match plan.materialize() {
+            Ok(observed) => {
+                state
+                    .profiler
+                    .staged
+                    .add_count(StagedCounter::MaterializeReflink, observed.reflink_count);
+                state
+                    .profiler
+                    .staged
+                    .add_count(StagedCounter::MaterializeCopy, observed.copy_count);
+                state
+                    .profiler
+                    .staged
+                    .bytes(StagedBytes::Materialization, observed.copy_bytes);
+                state.profiler.staged.timing(
+                    StagedTiming::MissMaterialization,
+                    materialize_started.elapsed().as_nanos() as u64,
+                );
+            }
+            Err(error) => {
+                state
+                    .profiler
+                    .staged
+                    .count(StagedCounter::MaterializeFailure);
+                state
+                    .profiler
+                    .staged
+                    .failure(StagedFailure::RequestedMaterialization);
+                return Response::Error {
+                    message: format!("failed to materialize generic tool outputs: {error}"),
+                };
+            }
         }
     }
 

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -2,6 +2,50 @@
 
 use super::*;
 
+fn materialize_link_plan_observed(
+    state: &SharedState,
+    plan: &StagedCompilePlan,
+) -> std::io::Result<()> {
+    use crate::daemon::staged_stats::{StagedBytes, StagedCounter, StagedFailure, StagedTiming};
+    let started = std::time::Instant::now();
+    match plan.materialize() {
+        Ok(observed) => {
+            state
+                .profiler
+                .staged
+                .add_count(StagedCounter::MaterializeReflink, observed.reflink_count);
+            state
+                .profiler
+                .staged
+                .add_count(StagedCounter::MaterializeCopy, observed.copy_count);
+            state
+                .profiler
+                .staged
+                .bytes(StagedBytes::Materialization, observed.copy_bytes);
+            state.profiler.staged.timing(
+                StagedTiming::MissMaterialization,
+                started.elapsed().as_nanos() as u64,
+            );
+            Ok(())
+        }
+        Err(error) => {
+            state
+                .profiler
+                .staged
+                .count(StagedCounter::MaterializeFailure);
+            state
+                .profiler
+                .staged
+                .failure(StagedFailure::RequestedMaterialization);
+            state.profiler.staged.timing(
+                StagedTiming::MissMaterialization,
+                started.elapsed().as_nanos() as u64,
+            );
+            Err(error)
+        }
+    }
+}
+
 /// Handle a single-roundtrip ephemeral link/archive request.
 ///
 /// Parses the tool invocation, computes a cache key from the tool binary and
@@ -310,6 +354,9 @@ pub(super) async fn handle_link_ephemeral(
     } else {
         cwd_path.join(&parsed_tool.output_file).into()
     };
+    use crate::daemon::staged_stats::{StagedCounter, StagedFailure, StagedTiming};
+    let planning_started = std::time::Instant::now();
+    state.profiler.staged.count(StagedCounter::PlanAttempted);
     let staged_plan = if parsed_tool.is_archive && parsed_tool.secondary_outputs.is_empty() {
         match StagedCompilePlan::archive(state.staging.path(), args, &output_path, cwd_path) {
             Ok(plan) => plan,
@@ -333,6 +380,19 @@ pub(super) async fn handle_link_ephemeral(
             }
         }
     };
+    state.profiler.staged.timing(
+        StagedTiming::Planning,
+        planning_started.elapsed().as_nanos() as u64,
+    );
+    if staged_plan.is_some() {
+        state.profiler.staged.count(StagedCounter::PlanEnabled);
+    } else {
+        state.profiler.staged.count(StagedCounter::PlanUnsupported);
+        state
+            .profiler
+            .staged
+            .failure(StagedFailure::UnsupportedShape);
+    }
     let compiler_args = staged_plan
         .as_ref()
         .map_or_else(|| args.to_vec(), |plan| plan.rewritten_args.clone());
@@ -365,6 +425,7 @@ pub(super) async fn handle_link_ephemeral(
     let env_for_hook = env.clone();
 
     let t_compiler_process = profile_enabled.then(std::time::Instant::now);
+    let staged_compiler_started = staged_plan.as_ref().map(|_| std::time::Instant::now());
     let result = run_tool_passthrough(
         tool,
         &compiler_args,
@@ -378,6 +439,15 @@ pub(super) async fn handle_link_ephemeral(
     let compiler_process_ns = t_compiler_process
         .map(|t| t.elapsed().as_nanos() as u64)
         .unwrap_or(0);
+    if staged_plan.is_some() {
+        state.profiler.staged.count(StagedCounter::CompilerStaged);
+        state.profiler.staged.timing(
+            StagedTiming::Compiler,
+            staged_compiler_started
+                .map(|started| started.elapsed().as_nanos() as u64)
+                .unwrap_or(0),
+        );
+    }
 
     // 6b. Invoke optional post-link deploy command on successful link.
     // This handles the case where the compiler driver does NOT auto-deploy
@@ -442,7 +512,7 @@ pub(super) async fn handle_link_ephemeral(
                     staged_count = unexpected_staged.len(),
                     "undeclared linker side effects invalidate staged publication"
                 );
-                if let Err(error) = plan.materialize() {
+                if let Err(error) = materialize_link_plan_observed(state, plan) {
                     return Response::Error {
                         message: format!("failed to materialize staged link output: {error}"),
                     };
@@ -575,7 +645,7 @@ pub(super) async fn handle_link_ephemeral(
                             .index_writer_tx
                             .send(IndexWriterCommand::Insert(kh, persist_meta));
                     }
-                    if let Err(error) = plan.materialize() {
+                    if let Err(error) = materialize_link_plan_observed(state, plan) {
                         return Response::Error {
                             message: format!("failed to materialize staged link output: {error}"),
                         };

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -18,7 +18,7 @@ pub(crate) use maintenance::{
 };
 mod materialize;
 pub(in crate::daemon::server) use materialize::{
-    materialize_independent, materialize_independent_with_stats, StagedMaterializationStats,
+    materialize_independent_with_stats, StagedMaterializationStats,
 };
 
 pub(in crate::daemon::server) const STAGED_ARTIFACTS_ENV: &str = "ZCCACHE_STAGED_ARTIFACTS";
@@ -1063,7 +1063,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
         let destination = dir.path().join("work.db");
-        materialize_independent(&payloads[0], &destination).unwrap();
+        materialize_independent_with_stats(&payloads[0], &destination).unwrap();
         let mut page = vec![0x22_u8; 4096];
         page[37] = 0x99;
         fs::write(&destination, page).unwrap();

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/materialize.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/materialize.rs
@@ -22,14 +22,6 @@ impl StagedMaterializationStats {
     }
 }
 
-/// Materialize without sharing a writable inode with private or backend bytes.
-pub(in crate::daemon::server) fn materialize_independent(
-    source: &Path,
-    destination: &Path,
-) -> io::Result<()> {
-    materialize_independent_with_stats(source, destination).map(|_| ())
-}
-
 pub(in crate::daemon::server) fn materialize_independent_with_stats(
     source: &Path,
     destination: &Path,

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -97,8 +97,10 @@ Session phase profiles include a bounded `staged` summary. The compile-miss
 lane populates planning, compiler staging, hashing, publication, salvage, and
 requested-path materialization. V2 file hits report the tier that actually
 succeeded (reflink, hardlink-shared, or copy), copied bytes, failures, and
-elapsed ns; special-producer wiring remains tracked by #1071. The summary
-reports counters, nanosecond totals, copied-byte
+elapsed ns. Archive, declared-linker, and exact-exec misses use the same
+planning, private-tool execution, and materialization accounting. Deterministic
+fault attribution remains tracked by #1071. The summary reports counters,
+nanosecond totals, copied-byte
 totals, and stable failure reason IDs. Labels are daemon-owned constants:
 paths, argv, cache keys, and raw OS errors are never metric keys. Bincode
 protocol v18 carries this summary; the protobuf schema adds it as an optional


### PR DESCRIPTION
Continues #1071 and parent #1056. Does not close #1071.

## What changed

- instrument archive and declared-linker staging plans, private tool execution, and requested-path materialization;
- instrument exact generic-exec planning, private execution, and multi-output materialization;
- aggregate actual reflink/copy tier counts and copied bytes for special-producer misses;
- record bounded unsupported-plan and requested-materialization failures;
- remove the obsolete unobserved materialization wrapper so all private-output materialization returns physical observations.

## Validation

- daemon-core broad: 470 passed, 19 ignored, 0 failed
- archive planner focused test: pass
- linker cache/side-effect focused test: pass
- Linux soldr rustfmt: exact
- scoped Clippy: pass (known untouched `question_mark` warning explicitly allowed)
- pre-push Rust/docs review: clean

Remaining in #1071: deterministic fault hooks for publication/salvage edges and branch-specific planner reason attribution.