### PR TITLE
feat(cache): attribute staged planner outcomes

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -101,7 +101,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     } else {
         vec![output_path.clone()]
     };
-    use crate::daemon::staged_stats::{StagedCounter, StagedFailure, StagedTiming};
+    use crate::daemon::staged_stats::{StagedCounter, StagedTiming};
     let planning_started = std::time::Instant::now();
     state.profiler.staged.count(StagedCounter::PlanAttempted);
     let staged_plan_result = if is_rustc {
@@ -127,23 +127,23 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         planning_started.elapsed().as_nanos() as u64,
     );
     let staged_plan = match staged_plan_result {
-        Ok(Some(plan)) => {
+        StagedPlanOutcome::Enabled(plan) => {
             state.profiler.staged.count(StagedCounter::PlanEnabled);
             Some(plan)
         }
-        Ok(None) => {
+        StagedPlanOutcome::Unsupported(reason) => {
             state.profiler.staged.count(StagedCounter::PlanUnsupported);
-            state
-                .profiler
-                .staged
-                .failure(StagedFailure::UnsupportedShape);
+            state.profiler.staged.failure(reason.failure());
             None
         }
-        Err(e) => {
+        StagedPlanOutcome::Error(error) => {
             state.profiler.staged.count(StagedCounter::PlanError);
-            state.profiler.staged.failure(StagedFailure::Planning);
+            state.profiler.staged.failure(error.reason.failure());
             return CompileExecResult::Error(Response::Error {
-                message: format!("failed to prepare private compiler staging: {e}"),
+                message: format!(
+                    "failed to prepare private compiler staging: {}",
+                    error.source
+                ),
             });
         }
     };

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
@@ -44,28 +44,38 @@ impl ExecStagedPlan {
         args: &[String],
         output_files: &[NormalizedPath],
         cwd: &Path,
-    ) -> Option<Self> {
+    ) -> StagedPlanOutcome<Self> {
+        if !exec_staging_enabled() {
+            return StagedPlanOutcome::Unsupported(StagedPlanReason::LaneDisabled);
+        }
         if output_files.is_empty() {
-            return None;
+            return StagedPlanOutcome::Unsupported(StagedPlanReason::NoDeclaredOutputs);
         }
         let root = staging_dir.join(format!(
             ".exec-{}-{}",
             std::process::id(),
             EXEC_STAGE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         ));
-        std::fs::create_dir_all(&root).ok()?;
+        if let Err(source) = std::fs::create_dir_all(&root) {
+            return StagedPlanOutcome::Error(StagedPlanError {
+                reason: StagedPlanReason::StagingDirectoryCreate,
+                source,
+            });
+        }
         let result = (|| {
             let mut outputs = Vec::with_capacity(output_files.len());
             let mut rewritten_args = args.to_vec();
             for declared in output_files {
                 let requested: NormalizedPath = absolutize(declared.as_path(), cwd).into();
-                let filename = requested.file_name()?;
+                let Some(filename) = requested.file_name() else {
+                    return StagedPlanOutcome::Unsupported(StagedPlanReason::OutputMissingFilename);
+                };
                 let staged: NormalizedPath = root.join(filename).into();
                 if outputs
                     .iter()
                     .any(|(_, existing): &(NormalizedPath, NormalizedPath)| existing == &staged)
                 {
-                    return None;
+                    return StagedPlanOutcome::Unsupported(StagedPlanReason::OutputNameCollision);
                 }
                 let requested_text = requested.to_string_lossy();
                 let declared_text = declared.to_string_lossy();
@@ -77,17 +87,17 @@ impl ExecStagedPlan {
                     }
                 }
                 if !replaced {
-                    return None;
+                    return StagedPlanOutcome::Unsupported(StagedPlanReason::OutputNotInArguments);
                 }
                 outputs.push((requested, staged));
             }
-            Some(Self {
+            StagedPlanOutcome::Enabled(Self {
                 outputs,
                 rewritten_args,
                 root: root.clone(),
             })
         })();
-        if result.is_none() {
+        if !matches!(result, StagedPlanOutcome::Enabled(_)) {
             let _ = std::fs::remove_dir_all(&root);
         }
         result
@@ -315,27 +325,35 @@ pub(super) async fn handle_generic_tool_exec(
     // 9. Cache miss — stage declared outputs only when the tool's argv gives
     // us an unambiguous exact-token rewrite for every output. Opaque output
     // syntax remains on the legacy path before spawn.
-    use crate::daemon::staged_stats::{StagedCounter, StagedFailure, StagedTiming};
+    use crate::daemon::staged_stats::{StagedCounter, StagedTiming};
     let planning_started = std::time::Instant::now();
     state.profiler.staged.count(StagedCounter::PlanAttempted);
-    let staged_plan = if exec_staging_enabled() {
-        ExecStagedPlan::build(state.staging.path(), args, output_files, cwd)
-    } else {
-        None
-    };
+    let staged_plan_result = ExecStagedPlan::build(state.staging.path(), args, output_files, cwd);
     state.profiler.staged.timing(
         StagedTiming::Planning,
         planning_started.elapsed().as_nanos() as u64,
     );
-    if staged_plan.is_some() {
-        state.profiler.staged.count(StagedCounter::PlanEnabled);
-    } else {
-        state.profiler.staged.count(StagedCounter::PlanUnsupported);
-        state
-            .profiler
-            .staged
-            .failure(StagedFailure::UnsupportedShape);
-    }
+    let staged_plan = match staged_plan_result {
+        StagedPlanOutcome::Enabled(plan) => {
+            state.profiler.staged.count(StagedCounter::PlanEnabled);
+            Some(plan)
+        }
+        StagedPlanOutcome::Unsupported(reason) => {
+            state.profiler.staged.count(StagedCounter::PlanUnsupported);
+            state.profiler.staged.failure(reason.failure());
+            None
+        }
+        StagedPlanOutcome::Error(error) => {
+            state.profiler.staged.count(StagedCounter::PlanError);
+            state.profiler.staged.failure(error.reason.failure());
+            tracing::warn!(
+                reason = error.reason.id(),
+                error = %error.source,
+                "exact-exec staging plan failed; using legacy path"
+            );
+            None
+        }
+    };
     let compiler_args = staged_plan
         .as_ref()
         .map_or(args, |plan| plan.rewritten_args.as_slice());
@@ -521,265 +539,9 @@ pub(super) async fn handle_generic_tool_exec(
 // ─── Key composition ─────────────────────────────────────────────────────
 
 #[allow(clippy::too_many_arguments)]
-fn compose_primary_key(
-    tool_id: &ContentHash,
-    args: &[String],
-    env: &[(String, String)],
-    cwd: &Path,
-    cwd_in_key: bool,
-    input_pairs: &[(String, ContentHash)],
-    scan_pairs: &[(String, ContentHash)],
-    output_files: &[NormalizedPath],
-    input_extra: &Arc<Vec<u8>>,
-) -> ContentHash {
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(EXEC_KEY_DOMAIN);
-    hasher.update(tool_id.as_bytes());
-
-    hasher.update(b"args:");
-    hasher.update(&(args.len() as u64).to_le_bytes());
-    for a in args {
-        hasher.update(&(a.len() as u64).to_le_bytes());
-        hasher.update(a.as_bytes());
-    }
-
-    let mut env_sorted: Vec<(&str, &str)> =
-        env.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
-    env_sorted.sort_by(|a, b| a.0.cmp(b.0));
-    hasher.update(b"env:");
-    hasher.update(&(env_sorted.len() as u64).to_le_bytes());
-    for (k, v) in &env_sorted {
-        hasher.update(&(k.len() as u64).to_le_bytes());
-        hasher.update(k.as_bytes());
-        hasher.update(&(v.len() as u64).to_le_bytes());
-        hasher.update(v.as_bytes());
-    }
-
-    if cwd_in_key {
-        let cwd_str = normalize_for_key(cwd);
-        hasher.update(b"cwd:");
-        hasher.update(&(cwd_str.len() as u64).to_le_bytes());
-        hasher.update(cwd_str.as_bytes());
-    } else {
-        hasher.update(b"cwd:omitted");
-    }
-
-    mix_path_hash_pairs(&mut hasher, b"inputs:", input_pairs);
-    mix_path_hash_pairs(&mut hasher, b"scan:", scan_pairs);
-
-    let mut out_names: Vec<String> = output_files
-        .iter()
-        .map(|p| p.to_string_lossy().into_owned())
-        .collect();
-    out_names.sort();
-    hasher.update(b"outs:");
-    hasher.update(&(out_names.len() as u64).to_le_bytes());
-    for name in &out_names {
-        hasher.update(&(name.len() as u64).to_le_bytes());
-        hasher.update(name.as_bytes());
-    }
-
-    hasher.update(b"extra:");
-    hasher.update(&(input_extra.len() as u64).to_le_bytes());
-    hasher.update(input_extra);
-
-    ContentHash::from_bytes(*hasher.finalize().as_bytes())
-}
-
-/// Compose the full key by extending the primary with depfile-derived deps.
-/// The pairs MUST be sorted by path (the helpers that build them already do
-/// this); we re-sort defensively so the function is robust against future
-/// callers that forget.
-fn compose_full_key(primary: &ContentHash, dep_pairs: &[(String, ContentHash)]) -> ContentHash {
-    let mut sorted = dep_pairs.to_vec();
-    sorted.sort_by(|a, b| a.0.cmp(&b.0));
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(b"zccache-exec-full-key-v2");
-    hasher.update(primary.as_bytes());
-    mix_path_hash_pairs(&mut hasher, b"depfile:", &sorted);
-    ContentHash::from_bytes(*hasher.finalize().as_bytes())
-}
-
-fn mix_path_hash_pairs(hasher: &mut blake3::Hasher, tag: &[u8], pairs: &[(String, ContentHash)]) {
-    hasher.update(tag);
-    hasher.update(&(pairs.len() as u64).to_le_bytes());
-    for (path, hash) in pairs {
-        hasher.update(&(path.len() as u64).to_le_bytes());
-        hasher.update(path.as_bytes());
-        hasher.update(hash.as_bytes());
-    }
-}
-
-// ─── Key args filter ─────────────────────────────────────────────────────
-
-fn apply_key_args_filter(args: &[String], patterns: &[String]) -> Result<Vec<String>, String> {
-    if patterns.is_empty() {
-        return Ok(args.to_vec());
-    }
-    let regexes: Vec<regex::Regex> = patterns
-        .iter()
-        .map(|p| regex::Regex::new(p).map_err(|e| format!("{p:?}: {e}")))
-        .collect::<Result<_, _>>()?;
-    Ok(args
-        .iter()
-        .filter(|a| !regexes.iter().any(|r| r.is_match(a)))
-        .cloned()
-        .collect())
-}
-
-// ─── Path A: include scan ───────────────────────────────────────────────
-
-fn run_include_scan(
-    state: &Arc<SharedState>,
-    cwd: &Path,
-    seeds: &[NormalizedPath],
-    include_dirs: &[NormalizedPath],
-    system_include_dirs: &[NormalizedPath],
-    iquote_dirs: &[NormalizedPath],
-) -> Result<Vec<(String, ContentHash)>, String> {
-    if seeds.is_empty() {
-        return Ok(Vec::new());
-    }
-    let search = IncludeSearchPaths {
-        iquote: iquote_dirs
-            .iter()
-            .map(|p| absolutize_norm(p, cwd))
-            .collect(),
-        user: include_dirs
-            .iter()
-            .map(|p| absolutize_norm(p, cwd))
-            .collect(),
-        system: system_include_dirs
-            .iter()
-            .map(|p| absolutize_norm(p, cwd))
-            .collect(),
-        after: Vec::new(),
-    };
-
-    let mut resolved: Vec<NormalizedPath> = Vec::new();
-    for seed in seeds {
-        let abs = absolutize_norm(seed, cwd);
-        let scan = scan_recursive(abs.as_path(), &search);
-        resolved.extend(scan.resolved);
-        if scan.has_computed {
-            tracing::warn!(
-                seed = %abs.display(),
-                "include scan encountered #include MACRO (computed include) — key may be over-broad"
-            );
-        }
-    }
-    // Dedup + sort by path so the key is stable.
-    resolved.sort();
-    resolved.dedup();
-
-    let mut pairs: Vec<(String, ContentHash)> = Vec::with_capacity(resolved.len());
-    for header in &resolved {
-        let abs = header.as_path();
-        let hash = hash_file_via_cache(state, abs)
-            .ok_or_else(|| format!("include-scan: cannot hash {}", abs.display()))?;
-        pairs.push((normalize_for_key(abs), hash));
-    }
-    Ok(pairs)
-}
-
-// ─── Path B: depfile + sidecar ──────────────────────────────────────────
-
-/// On a warm invocation, load the dep set the previous run persisted under
-/// `<primary_hex>.deps`. Returns `None` when no sidecar exists (first run)
-/// or when any listed dep file no longer exists — that case forces a fresh
-/// first-run because the cached dep set is stale.
-fn load_depfile_sidecar(
-    state: &Arc<SharedState>,
-    primary_hex: &str,
-    _cwd: &Path,
-) -> Option<Vec<(String, ContentHash)>> {
-    let path = depfile_sidecar_path(&state.artifact_dir, primary_hex);
-    let content = std::fs::read_to_string(&path).ok()?;
-    let mut pairs: Vec<(String, ContentHash)> = Vec::new();
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let abs = Path::new(trimmed);
-        if !abs.exists() {
-            tracing::debug!(
-                missing = %abs.display(),
-                "depfile sidecar references vanished file; treating as miss"
-            );
-            return None;
-        }
-        let hash = hash_file_via_cache(state, abs)?;
-        pairs.push((normalize_for_key(abs), hash));
-    }
-    pairs.sort_by(|a, b| a.0.cmp(&b.0));
-    Some(pairs)
-}
-
-fn persist_depfile_sidecar(
-    state: &Arc<SharedState>,
-    primary_hex: &str,
-    dep_pairs: &[(String, ContentHash)],
-) {
-    let path = depfile_sidecar_path(&state.artifact_dir, primary_hex);
-    let mut content = String::new();
-    for (p, _) in dep_pairs {
-        content.push_str(p);
-        content.push('\n');
-    }
-    if let Err(e) = std::fs::write(&path, content) {
-        tracing::warn!(path = %path.display(), err = %e, "failed to write depfile sidecar");
-    }
-}
-
-fn depfile_sidecar_path(artifact_dir: &Path, primary_hex: &str) -> PathBuf {
-    artifact_dir.join(format!("{primary_hex}.deps"))
-}
-
-/// Parse the depfile the tool emitted, hash each listed file. `inputs` is
-/// the already-declared primary input set; we exclude any path that's
-/// already in that set so the dep-set hash doesn't double-count them.
-fn harvest_depfile(
-    state: &Arc<SharedState>,
-    depfile_path: &Path,
-    cwd: &Path,
-    inputs: &[(String, ContentHash)],
-) -> Result<Vec<(String, ContentHash)>, String> {
-    let content =
-        std::fs::read_to_string(depfile_path).map_err(|e| format!("read depfile: {e}"))?;
-    // `parse_depfile` takes a `source` path it excludes from results; we
-    // pass an empty path so nothing is excluded — exec doesn't have a
-    // single "source", any included files get filtered against the
-    // declared input set below.
-    let scan = crate::depgraph::depfile::parse_depfile(&content, Path::new(""), cwd)
-        .map_err(|e| format!("parse depfile: {e}"))?;
-
-    let declared: std::collections::HashSet<&str> =
-        inputs.iter().map(|(p, _)| p.as_str()).collect();
-
-    let mut pairs: Vec<(String, ContentHash)> = Vec::new();
-    for dep in &scan.resolved {
-        let abs = dep.as_path();
-        if !abs.exists() {
-            return Err(format!(
-                "depfile references missing file: {}",
-                abs.display()
-            ));
-        }
-        let key = normalize_for_key(abs);
-        if declared.contains(key.as_str()) {
-            continue;
-        }
-        let hash = hash_file_via_cache(state, abs)
-            .ok_or_else(|| format!("cannot hash dep {}", abs.display()))?;
-        pairs.push((key, hash));
-    }
-    pairs.sort_by(|a, b| a.0.cmp(&b.0));
-    Ok(pairs)
-}
-
-// ─── Coalescing ─────────────────────────────────────────────────────────
-
+#[path = "handle_exec_key.rs"]
+mod key;
+use key::*;
 enum InFlight {
     /// We acquired the slot ourselves (no peer was running).
     Owner,
@@ -1214,163 +976,5 @@ mod coalesce_tests {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn h(byte: u8) -> ContentHash {
-        ContentHash::from_bytes([byte; 32])
-    }
-
-    fn empty_extra() -> Arc<Vec<u8>> {
-        Arc::new(Vec::new())
-    }
-
-    #[test]
-    fn primary_key_changes_when_input_hash_changes() {
-        let k1 = compose_primary_key(
-            &h(1),
-            &["--json".into()],
-            &[("PATH".into(), "/bin".into())],
-            Path::new("/p"),
-            true,
-            &[("src/a.cpp".into(), h(2))],
-            &[],
-            &[NormalizedPath::from("out.json")],
-            &empty_extra(),
-        );
-        let k2 = compose_primary_key(
-            &h(1),
-            &["--json".into()],
-            &[("PATH".into(), "/bin".into())],
-            Path::new("/p"),
-            true,
-            &[("src/a.cpp".into(), h(3))],
-            &[],
-            &[NormalizedPath::from("out.json")],
-            &empty_extra(),
-        );
-        assert_ne!(k1, k2);
-    }
-
-    #[test]
-    fn primary_key_stable_for_env_order() {
-        let k1 = compose_primary_key(
-            &h(1),
-            &[],
-            &[
-                ("PATH".into(), "/bin".into()),
-                ("LINT_VER".into(), "1".into()),
-            ],
-            Path::new("/p"),
-            true,
-            &[],
-            &[],
-            &[],
-            &empty_extra(),
-        );
-        let k2 = compose_primary_key(
-            &h(1),
-            &[],
-            &[
-                ("LINT_VER".into(), "1".into()),
-                ("PATH".into(), "/bin".into()),
-            ],
-            Path::new("/p"),
-            true,
-            &[],
-            &[],
-            &[],
-            &empty_extra(),
-        );
-        assert_eq!(k1, k2);
-    }
-
-    #[test]
-    fn full_key_extends_primary_with_depfile_deps() {
-        let primary = compose_primary_key(
-            &h(1),
-            &[],
-            &[],
-            Path::new("/p"),
-            true,
-            &[],
-            &[],
-            &[],
-            &empty_extra(),
-        );
-        let k_no_deps = compose_full_key(&primary, &[]);
-        let k_with = compose_full_key(&primary, &[("h.h".into(), h(9))]);
-        // Without deps, full key is *not* equal to primary because of the
-        // domain tag — but it must differ from a key with deps.
-        assert_ne!(k_no_deps, k_with);
-    }
-
-    #[test]
-    fn full_key_order_independent_for_dep_pairs() {
-        let primary = compose_primary_key(
-            &h(1),
-            &[],
-            &[],
-            Path::new("/p"),
-            true,
-            &[],
-            &[],
-            &[],
-            &empty_extra(),
-        );
-        let a = vec![("a.h".into(), h(2)), ("b.h".into(), h(3))];
-        let b = vec![("b.h".into(), h(3)), ("a.h".into(), h(2))];
-        assert_eq!(
-            compose_full_key(&primary, &a),
-            compose_full_key(&primary, &b)
-        );
-    }
-
-    #[test]
-    fn key_args_filter_drops_matching_args() {
-        let filtered = apply_key_args_filter(
-            &[
-                "compile".into(),
-                "--verbose".into(),
-                "--no-color".into(),
-                "src.cpp".into(),
-            ],
-            &["^--verbose$".into(), "^--no-color$".into()],
-        )
-        .unwrap();
-        assert_eq!(filtered, vec!["compile".to_string(), "src.cpp".to_string()]);
-    }
-
-    #[test]
-    fn key_args_filter_invalid_regex_errors() {
-        let err = apply_key_args_filter(&["a".into()], &["(".into()]).unwrap_err();
-        assert!(err.contains('('));
-    }
-
-    #[test]
-    fn primary_key_differs_when_scan_changes() {
-        let k1 = compose_primary_key(
-            &h(1),
-            &[],
-            &[],
-            Path::new("/p"),
-            true,
-            &[],
-            &[("hdr.h".into(), h(7))],
-            &[],
-            &empty_extra(),
-        );
-        let k2 = compose_primary_key(
-            &h(1),
-            &[],
-            &[],
-            Path::new("/p"),
-            true,
-            &[],
-            &[("hdr.h".into(), h(8))],
-            &[],
-            &empty_extra(),
-        );
-        assert_ne!(k1, k2);
-    }
-}
+#[path = "handle_exec_tests.rs"]
+mod tests;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec_key.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec_key.rs
@@ -1,0 +1,272 @@
+//! Cache-key, dependency-scan, and depfile-sidecar helpers for generic exec.
+
+use super::*;
+
+pub(super) fn compose_primary_key(
+    tool_id: &ContentHash,
+    args: &[String],
+    env: &[(String, String)],
+    cwd: &Path,
+    cwd_in_key: bool,
+    input_pairs: &[(String, ContentHash)],
+    scan_pairs: &[(String, ContentHash)],
+    output_files: &[NormalizedPath],
+    input_extra: &Arc<Vec<u8>>,
+) -> ContentHash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(EXEC_KEY_DOMAIN);
+    hasher.update(tool_id.as_bytes());
+
+    hasher.update(b"args:");
+    hasher.update(&(args.len() as u64).to_le_bytes());
+    for a in args {
+        hasher.update(&(a.len() as u64).to_le_bytes());
+        hasher.update(a.as_bytes());
+    }
+
+    let mut env_sorted: Vec<(&str, &str)> =
+        env.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+    env_sorted.sort_by(|a, b| a.0.cmp(b.0));
+    hasher.update(b"env:");
+    hasher.update(&(env_sorted.len() as u64).to_le_bytes());
+    for (k, v) in &env_sorted {
+        hasher.update(&(k.len() as u64).to_le_bytes());
+        hasher.update(k.as_bytes());
+        hasher.update(&(v.len() as u64).to_le_bytes());
+        hasher.update(v.as_bytes());
+    }
+
+    if cwd_in_key {
+        let cwd_str = normalize_for_key(cwd);
+        hasher.update(b"cwd:");
+        hasher.update(&(cwd_str.len() as u64).to_le_bytes());
+        hasher.update(cwd_str.as_bytes());
+    } else {
+        hasher.update(b"cwd:omitted");
+    }
+
+    mix_path_hash_pairs(&mut hasher, b"inputs:", input_pairs);
+    mix_path_hash_pairs(&mut hasher, b"scan:", scan_pairs);
+
+    let mut out_names: Vec<String> = output_files
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    out_names.sort();
+    hasher.update(b"outs:");
+    hasher.update(&(out_names.len() as u64).to_le_bytes());
+    for name in &out_names {
+        hasher.update(&(name.len() as u64).to_le_bytes());
+        hasher.update(name.as_bytes());
+    }
+
+    hasher.update(b"extra:");
+    hasher.update(&(input_extra.len() as u64).to_le_bytes());
+    hasher.update(input_extra);
+
+    ContentHash::from_bytes(*hasher.finalize().as_bytes())
+}
+
+/// Compose the full key by extending the primary with depfile-derived deps.
+/// The pairs MUST be sorted by path (the helpers that build them already do
+/// this); we re-sort defensively so the function is robust against future
+/// callers that forget.
+pub(super) fn compose_full_key(
+    primary: &ContentHash,
+    dep_pairs: &[(String, ContentHash)],
+) -> ContentHash {
+    let mut sorted = dep_pairs.to_vec();
+    sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"zccache-exec-full-key-v2");
+    hasher.update(primary.as_bytes());
+    mix_path_hash_pairs(&mut hasher, b"depfile:", &sorted);
+    ContentHash::from_bytes(*hasher.finalize().as_bytes())
+}
+
+pub(super) fn mix_path_hash_pairs(
+    hasher: &mut blake3::Hasher,
+    tag: &[u8],
+    pairs: &[(String, ContentHash)],
+) {
+    hasher.update(tag);
+    hasher.update(&(pairs.len() as u64).to_le_bytes());
+    for (path, hash) in pairs {
+        hasher.update(&(path.len() as u64).to_le_bytes());
+        hasher.update(path.as_bytes());
+        hasher.update(hash.as_bytes());
+    }
+}
+
+// ─── Key args filter ─────────────────────────────────────────────────────
+
+pub(super) fn apply_key_args_filter(
+    args: &[String],
+    patterns: &[String],
+) -> Result<Vec<String>, String> {
+    if patterns.is_empty() {
+        return Ok(args.to_vec());
+    }
+    let regexes: Vec<regex::Regex> = patterns
+        .iter()
+        .map(|p| regex::Regex::new(p).map_err(|e| format!("{p:?}: {e}")))
+        .collect::<Result<_, _>>()?;
+    Ok(args
+        .iter()
+        .filter(|a| !regexes.iter().any(|r| r.is_match(a)))
+        .cloned()
+        .collect())
+}
+
+// ─── Path A: include scan ───────────────────────────────────────────────
+
+pub(super) fn run_include_scan(
+    state: &Arc<SharedState>,
+    cwd: &Path,
+    seeds: &[NormalizedPath],
+    include_dirs: &[NormalizedPath],
+    system_include_dirs: &[NormalizedPath],
+    iquote_dirs: &[NormalizedPath],
+) -> Result<Vec<(String, ContentHash)>, String> {
+    if seeds.is_empty() {
+        return Ok(Vec::new());
+    }
+    let search = IncludeSearchPaths {
+        iquote: iquote_dirs
+            .iter()
+            .map(|p| absolutize_norm(p, cwd))
+            .collect(),
+        user: include_dirs
+            .iter()
+            .map(|p| absolutize_norm(p, cwd))
+            .collect(),
+        system: system_include_dirs
+            .iter()
+            .map(|p| absolutize_norm(p, cwd))
+            .collect(),
+        after: Vec::new(),
+    };
+
+    let mut resolved: Vec<NormalizedPath> = Vec::new();
+    for seed in seeds {
+        let abs = absolutize_norm(seed, cwd);
+        let scan = scan_recursive(abs.as_path(), &search);
+        resolved.extend(scan.resolved);
+        if scan.has_computed {
+            tracing::warn!(
+                seed = %abs.display(),
+                "include scan encountered #include MACRO (computed include) — key may be over-broad"
+            );
+        }
+    }
+    // Dedup + sort by path so the key is stable.
+    resolved.sort();
+    resolved.dedup();
+
+    let mut pairs: Vec<(String, ContentHash)> = Vec::with_capacity(resolved.len());
+    for header in &resolved {
+        let abs = header.as_path();
+        let hash = hash_file_via_cache(state, abs)
+            .ok_or_else(|| format!("include-scan: cannot hash {}", abs.display()))?;
+        pairs.push((normalize_for_key(abs), hash));
+    }
+    Ok(pairs)
+}
+
+// ─── Path B: depfile + sidecar ──────────────────────────────────────────
+
+/// On a warm invocation, load the dep set the previous run persisted under
+/// `<primary_hex>.deps`. Returns `None` when no sidecar exists (first run)
+/// or when any listed dep file no longer exists — that case forces a fresh
+/// first-run because the cached dep set is stale.
+pub(super) fn load_depfile_sidecar(
+    state: &Arc<SharedState>,
+    primary_hex: &str,
+    _cwd: &Path,
+) -> Option<Vec<(String, ContentHash)>> {
+    let path = depfile_sidecar_path(&state.artifact_dir, primary_hex);
+    let content = std::fs::read_to_string(&path).ok()?;
+    let mut pairs: Vec<(String, ContentHash)> = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let abs = Path::new(trimmed);
+        if !abs.exists() {
+            tracing::debug!(
+                missing = %abs.display(),
+                "depfile sidecar references vanished file; treating as miss"
+            );
+            return None;
+        }
+        let hash = hash_file_via_cache(state, abs)?;
+        pairs.push((normalize_for_key(abs), hash));
+    }
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
+    Some(pairs)
+}
+
+pub(super) fn persist_depfile_sidecar(
+    state: &Arc<SharedState>,
+    primary_hex: &str,
+    dep_pairs: &[(String, ContentHash)],
+) {
+    let path = depfile_sidecar_path(&state.artifact_dir, primary_hex);
+    let mut content = String::new();
+    for (p, _) in dep_pairs {
+        content.push_str(p);
+        content.push('\n');
+    }
+    if let Err(e) = std::fs::write(&path, content) {
+        tracing::warn!(path = %path.display(), err = %e, "failed to write depfile sidecar");
+    }
+}
+
+pub(super) fn depfile_sidecar_path(artifact_dir: &Path, primary_hex: &str) -> PathBuf {
+    artifact_dir.join(format!("{primary_hex}.deps"))
+}
+
+/// Parse the depfile the tool emitted, hash each listed file. `inputs` is
+/// the already-declared primary input set; we exclude any path that's
+/// already in that set so the dep-set hash doesn't double-count them.
+pub(super) fn harvest_depfile(
+    state: &Arc<SharedState>,
+    depfile_path: &Path,
+    cwd: &Path,
+    inputs: &[(String, ContentHash)],
+) -> Result<Vec<(String, ContentHash)>, String> {
+    let content =
+        std::fs::read_to_string(depfile_path).map_err(|e| format!("read depfile: {e}"))?;
+    // `parse_depfile` takes a `source` path it excludes from results; we
+    // pass an empty path so nothing is excluded — exec doesn't have a
+    // single "source", any included files get filtered against the
+    // declared input set below.
+    let scan = crate::depgraph::depfile::parse_depfile(&content, Path::new(""), cwd)
+        .map_err(|e| format!("parse depfile: {e}"))?;
+
+    let declared: std::collections::HashSet<&str> =
+        inputs.iter().map(|(p, _)| p.as_str()).collect();
+
+    let mut pairs: Vec<(String, ContentHash)> = Vec::new();
+    for dep in &scan.resolved {
+        let abs = dep.as_path();
+        if !abs.exists() {
+            return Err(format!(
+                "depfile references missing file: {}",
+                abs.display()
+            ));
+        }
+        let key = normalize_for_key(abs);
+        if declared.contains(key.as_str()) {
+            continue;
+        }
+        let hash = hash_file_via_cache(state, abs)
+            .ok_or_else(|| format!("cannot hash dep {}", abs.display()))?;
+        pairs.push((key, hash));
+    }
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(pairs)
+}
+
+// ─── Coalescing ─────────────────────────────────────────────────────────

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec_tests.rs
@@ -1,0 +1,216 @@
+//! Key-composition and exact-exec staging planner tests.
+use super::*;
+use tempfile::tempdir;
+
+fn h(byte: u8) -> ContentHash {
+    ContentHash::from_bytes([byte; 32])
+}
+
+fn empty_extra() -> Arc<Vec<u8>> {
+    Arc::new(Vec::new())
+}
+
+#[test]
+fn primary_key_changes_when_input_hash_changes() {
+    let k1 = compose_primary_key(
+        &h(1),
+        &["--json".into()],
+        &[("PATH".into(), "/bin".into())],
+        Path::new("/p"),
+        true,
+        &[("src/a.cpp".into(), h(2))],
+        &[],
+        &[NormalizedPath::from("out.json")],
+        &empty_extra(),
+    );
+    let k2 = compose_primary_key(
+        &h(1),
+        &["--json".into()],
+        &[("PATH".into(), "/bin".into())],
+        Path::new("/p"),
+        true,
+        &[("src/a.cpp".into(), h(3))],
+        &[],
+        &[NormalizedPath::from("out.json")],
+        &empty_extra(),
+    );
+    assert_ne!(k1, k2);
+}
+
+#[test]
+fn primary_key_stable_for_env_order() {
+    let k1 = compose_primary_key(
+        &h(1),
+        &[],
+        &[
+            ("PATH".into(), "/bin".into()),
+            ("LINT_VER".into(), "1".into()),
+        ],
+        Path::new("/p"),
+        true,
+        &[],
+        &[],
+        &[],
+        &empty_extra(),
+    );
+    let k2 = compose_primary_key(
+        &h(1),
+        &[],
+        &[
+            ("LINT_VER".into(), "1".into()),
+            ("PATH".into(), "/bin".into()),
+        ],
+        Path::new("/p"),
+        true,
+        &[],
+        &[],
+        &[],
+        &empty_extra(),
+    );
+    assert_eq!(k1, k2);
+}
+
+#[test]
+fn full_key_extends_primary_with_depfile_deps() {
+    let primary = compose_primary_key(
+        &h(1),
+        &[],
+        &[],
+        Path::new("/p"),
+        true,
+        &[],
+        &[],
+        &[],
+        &empty_extra(),
+    );
+    let k_no_deps = compose_full_key(&primary, &[]);
+    let k_with = compose_full_key(&primary, &[("h.h".into(), h(9))]);
+    // Without deps, full key is *not* equal to primary because of the
+    // domain tag — but it must differ from a key with deps.
+    assert_ne!(k_no_deps, k_with);
+}
+
+#[test]
+fn full_key_order_independent_for_dep_pairs() {
+    let primary = compose_primary_key(
+        &h(1),
+        &[],
+        &[],
+        Path::new("/p"),
+        true,
+        &[],
+        &[],
+        &[],
+        &empty_extra(),
+    );
+    let a = vec![("a.h".into(), h(2)), ("b.h".into(), h(3))];
+    let b = vec![("b.h".into(), h(3)), ("a.h".into(), h(2))];
+    assert_eq!(
+        compose_full_key(&primary, &a),
+        compose_full_key(&primary, &b)
+    );
+}
+
+#[test]
+fn key_args_filter_drops_matching_args() {
+    let filtered = apply_key_args_filter(
+        &[
+            "compile".into(),
+            "--verbose".into(),
+            "--no-color".into(),
+            "src.cpp".into(),
+        ],
+        &["^--verbose$".into(), "^--no-color$".into()],
+    )
+    .unwrap();
+    assert_eq!(filtered, vec!["compile".to_string(), "src.cpp".to_string()]);
+}
+
+#[test]
+fn key_args_filter_invalid_regex_errors() {
+    let err = apply_key_args_filter(&["a".into()], &["(".into()]).unwrap_err();
+    assert!(err.contains('('));
+}
+
+#[test]
+fn primary_key_differs_when_scan_changes() {
+    let k1 = compose_primary_key(
+        &h(1),
+        &[],
+        &[],
+        Path::new("/p"),
+        true,
+        &[],
+        &[("hdr.h".into(), h(7))],
+        &[],
+        &empty_extra(),
+    );
+    let k2 = compose_primary_key(
+        &h(1),
+        &[],
+        &[],
+        Path::new("/p"),
+        true,
+        &[],
+        &[("hdr.h".into(), h(8))],
+        &[],
+        &empty_extra(),
+    );
+    assert_ne!(k1, k2);
+}
+
+#[test]
+fn exact_exec_planner_rejections_have_stable_reasons() {
+    if std::env::var_os(crate::daemon::server::persist::STAGED_ARTIFACTS_ENV).is_none() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    assert!(matches!(
+        ExecStagedPlan::build(temp.path(), &[], &[], temp.path()),
+        StagedPlanOutcome::Unsupported(StagedPlanReason::NoDeclaredOutputs)
+    ));
+
+    let first: NormalizedPath = temp.path().join("one/result.bin").into();
+    let second: NormalizedPath = temp.path().join("two/result.bin").into();
+    assert!(matches!(
+        ExecStagedPlan::build(
+            temp.path(),
+            &[
+                first.to_string_lossy().into_owned(),
+                second.to_string_lossy().into_owned(),
+            ],
+            &[first, second],
+            temp.path(),
+        ),
+        StagedPlanOutcome::Unsupported(StagedPlanReason::OutputNameCollision)
+    ));
+
+    let output: NormalizedPath = temp.path().join("result.bin").into();
+    assert!(matches!(
+        ExecStagedPlan::build(
+            temp.path(),
+            &["--output=result.bin".into()],
+            &[output],
+            temp.path(),
+        ),
+        StagedPlanOutcome::Unsupported(StagedPlanReason::OutputNotInArguments)
+    ));
+}
+
+#[test]
+fn exact_exec_disabled_lane_has_stable_reason() {
+    if std::env::var_os(crate::daemon::server::persist::STAGED_ARTIFACTS_ENV).is_some() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let output: NormalizedPath = temp.path().join("result.bin").into();
+    assert!(matches!(
+        ExecStagedPlan::build(
+            temp.path(),
+            &[output.to_string_lossy().into_owned()],
+            &[output],
+            temp.path(),
+        ),
+        StagedPlanOutcome::Unsupported(StagedPlanReason::LaneDisabled)
+    ));
+}

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -354,45 +354,45 @@ pub(super) async fn handle_link_ephemeral(
     } else {
         cwd_path.join(&parsed_tool.output_file).into()
     };
-    use crate::daemon::staged_stats::{StagedCounter, StagedFailure, StagedTiming};
+    use crate::daemon::staged_stats::{StagedCounter, StagedTiming};
     let planning_started = std::time::Instant::now();
     state.profiler.staged.count(StagedCounter::PlanAttempted);
-    let staged_plan = if parsed_tool.is_archive && parsed_tool.secondary_outputs.is_empty() {
-        match StagedCompilePlan::archive(state.staging.path(), args, &output_path, cwd_path) {
-            Ok(plan) => plan,
-            Err(error) => {
-                tracing::warn!(%error, "archive staging plan failed; using legacy path");
-                None
-            }
-        }
+    let staged_plan_result = if parsed_tool.is_archive && parsed_tool.secondary_outputs.is_empty() {
+        StagedCompilePlan::archive(state.staging.path(), args, &output_path, cwd_path)
     } else {
-        match StagedCompilePlan::link(
+        StagedCompilePlan::link(
             state.staging.path(),
             args,
             &output_path,
             &parsed_tool.secondary_outputs,
             cwd_path,
-        ) {
-            Ok(plan) => plan,
-            Err(error) => {
-                tracing::warn!(%error, "link staging plan failed; using legacy path");
-                None
-            }
-        }
+        )
     };
     state.profiler.staged.timing(
         StagedTiming::Planning,
         planning_started.elapsed().as_nanos() as u64,
     );
-    if staged_plan.is_some() {
-        state.profiler.staged.count(StagedCounter::PlanEnabled);
-    } else {
-        state.profiler.staged.count(StagedCounter::PlanUnsupported);
-        state
-            .profiler
-            .staged
-            .failure(StagedFailure::UnsupportedShape);
-    }
+    let staged_plan = match staged_plan_result {
+        StagedPlanOutcome::Enabled(plan) => {
+            state.profiler.staged.count(StagedCounter::PlanEnabled);
+            Some(plan)
+        }
+        StagedPlanOutcome::Unsupported(reason) => {
+            state.profiler.staged.count(StagedCounter::PlanUnsupported);
+            state.profiler.staged.failure(reason.failure());
+            None
+        }
+        StagedPlanOutcome::Error(error) => {
+            state.profiler.staged.count(StagedCounter::PlanError);
+            state.profiler.staged.failure(error.reason.failure());
+            tracing::warn!(
+                reason = error.reason.id(),
+                error = %error.source,
+                "link staging plan failed; using legacy path"
+            );
+            None
+        }
+    };
     let compiler_args = staged_plan
         .as_ref()
         .map_or_else(|| args.to_vec(), |plan| plan.rewritten_args.clone());

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
@@ -12,6 +12,122 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 static PLAN_COUNTER: AtomicU64 = AtomicU64::new(1);
 
+/// Bounded planner decisions used for aggregate telemetry. These IDs are part
+/// of the observability contract: never derive them from argv, paths, or OS
+/// error text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::daemon::server) enum StagedPlanReason {
+    LaneDisabled,
+    OutputToStdout,
+    OutputNameCollision,
+    UnmodeledSideOutput,
+    UnsupportedOutputRole,
+    MissingRequiredOutputFlag,
+    MissingOptionValue,
+    OutputMissingFilename,
+    UnsupportedOutputPath,
+    AmbiguousOutputArgument,
+    OutputNotInArguments,
+    NoDeclaredOutputs,
+    StagingDirectoryCreate,
+}
+
+impl StagedPlanReason {
+    #[cfg(test)]
+    pub(in crate::daemon::server) const ALL: [Self; 13] = [
+        Self::LaneDisabled,
+        Self::OutputToStdout,
+        Self::OutputNameCollision,
+        Self::UnmodeledSideOutput,
+        Self::UnsupportedOutputRole,
+        Self::MissingRequiredOutputFlag,
+        Self::MissingOptionValue,
+        Self::OutputMissingFilename,
+        Self::UnsupportedOutputPath,
+        Self::AmbiguousOutputArgument,
+        Self::OutputNotInArguments,
+        Self::NoDeclaredOutputs,
+        Self::StagingDirectoryCreate,
+    ];
+
+    pub(in crate::daemon::server) const fn id(self) -> &'static str {
+        match self {
+            Self::LaneDisabled => "lane_disabled",
+            Self::OutputToStdout => "output_to_stdout",
+            Self::OutputNameCollision => "output_name_collision",
+            Self::UnmodeledSideOutput => "unmodeled_side_output",
+            Self::UnsupportedOutputRole => "unsupported_output_role",
+            Self::MissingRequiredOutputFlag => "missing_required_output_flag",
+            Self::MissingOptionValue => "missing_option_value",
+            Self::OutputMissingFilename => "output_missing_filename",
+            Self::UnsupportedOutputPath => "unsupported_output_path",
+            Self::AmbiguousOutputArgument => "ambiguous_output_argument",
+            Self::OutputNotInArguments => "output_not_in_arguments",
+            Self::NoDeclaredOutputs => "no_declared_outputs",
+            Self::StagingDirectoryCreate => "staging_directory_create",
+        }
+    }
+
+    pub(in crate::daemon::server) const fn failure(
+        self,
+    ) -> crate::daemon::staged_stats::StagedFailure {
+        use crate::daemon::staged_stats::StagedFailure;
+        match self {
+            Self::LaneDisabled => StagedFailure::PlanLaneDisabled,
+            Self::OutputToStdout => StagedFailure::PlanOutputToStdout,
+            Self::OutputNameCollision => StagedFailure::PlanOutputNameCollision,
+            Self::UnmodeledSideOutput => StagedFailure::PlanUnmodeledSideOutput,
+            Self::UnsupportedOutputRole => StagedFailure::PlanUnsupportedOutputRole,
+            Self::MissingRequiredOutputFlag => StagedFailure::PlanMissingRequiredOutputFlag,
+            Self::MissingOptionValue => StagedFailure::PlanMissingOptionValue,
+            Self::OutputMissingFilename => StagedFailure::PlanOutputMissingFilename,
+            Self::UnsupportedOutputPath => StagedFailure::PlanUnsupportedOutputPath,
+            Self::AmbiguousOutputArgument => StagedFailure::PlanAmbiguousOutputArgument,
+            Self::OutputNotInArguments => StagedFailure::PlanOutputNotInArguments,
+            Self::NoDeclaredOutputs => StagedFailure::PlanNoDeclaredOutputs,
+            Self::StagingDirectoryCreate => StagedFailure::PlanStagingDirectoryCreate,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(in crate::daemon::server) struct StagedPlanError {
+    pub(in crate::daemon::server) reason: StagedPlanReason,
+    pub(in crate::daemon::server) source: io::Error,
+}
+
+#[derive(Debug)]
+pub(in crate::daemon::server) enum StagedPlanOutcome<T> {
+    Enabled(T),
+    Unsupported(StagedPlanReason),
+    Error(StagedPlanError),
+}
+
+#[cfg(test)]
+impl<T> StagedPlanOutcome<T> {
+    fn unwrap(self) -> Option<T> {
+        match self {
+            Self::Enabled(value) => Some(value),
+            Self::Unsupported(_) => None,
+            Self::Error(error) => panic!("planner failed: {:?}: {}", error.reason, error.source),
+        }
+    }
+}
+
+fn planning_error(reason: StagedPlanReason, source: io::Error) -> StagedPlanError {
+    StagedPlanError { reason, source }
+}
+
+fn missing_filename(reason: StagedPlanReason) -> StagedPlanError {
+    planning_error(
+        reason,
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "planned output has no filename",
+        ),
+    )
+}
+
 #[derive(Debug, Clone)]
 pub(in crate::daemon::server) struct StagedOutputPlan {
     pub(in crate::daemon::server) requested: NormalizedPath,
@@ -34,144 +150,178 @@ impl StagedCompilePlan {
         primary_output: &NormalizedPath,
         expected_outputs: &[NormalizedPath],
         cwd: &Path,
-    ) -> io::Result<Option<Self>> {
-        if !staged_lane_enabled(crate::compiler::CompilerFamily::Rustc) || emit_to_stdout(args) {
-            return Ok(None);
+    ) -> StagedPlanOutcome<Self> {
+        if !staged_lane_enabled(crate::compiler::CompilerFamily::Rustc) {
+            return StagedPlanOutcome::Unsupported(StagedPlanReason::LaneDisabled);
+        }
+        if emit_to_stdout(args) {
+            return StagedPlanOutcome::Unsupported(StagedPlanReason::OutputToStdout);
+        }
+        if rustc_has_missing_option_value(args) {
+            return StagedPlanOutcome::Unsupported(StagedPlanReason::MissingOptionValue);
         }
         let root = staging_dir.join(format!(
             ".compile-{}-{}",
             std::process::id(),
             PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
         ));
-        std::fs::create_dir_all(&root)?;
-
-        let mut primary = absolute(primary_output, cwd);
-        let mut outputs = Vec::with_capacity(expected_outputs.len());
-        for requested in expected_outputs {
-            let requested = absolute(requested, cwd);
-            let file_name = requested.file_name().ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidInput, "rustc output has no filename")
-            })?;
-            let staged = root.join(file_name);
-            if outputs
-                .iter()
-                .any(|output: &StagedOutputPlan| output.staged.as_path() == staged)
-            {
-                let _ = std::fs::remove_dir_all(&root);
-                return Ok(None);
-            }
-            outputs.push(StagedOutputPlan {
-                requested: requested.clone(),
-                staged: staged.into(),
-            });
+        if let Err(source) = std::fs::create_dir_all(&root) {
+            return StagedPlanOutcome::Error(planning_error(
+                StagedPlanReason::StagingDirectoryCreate,
+                source,
+            ));
         }
-        for (kind, path) in emit_specs(args) {
-            let requested = absolute(Path::new(&path), cwd);
-            if kind == "link" {
-                primary = requested.clone();
-            }
-            let replacement = outputs.iter().position(|output| {
-                output.requested == requested || output_kind(&output.requested) == kind
-            });
-            if let Some(index) = replacement {
-                outputs[index].requested = requested;
-            } else {
+
+        let result = (|| -> Result<StagedPlanOutcome<Self>, StagedPlanError> {
+            let mut primary = absolute(primary_output, cwd);
+            let mut outputs = Vec::with_capacity(expected_outputs.len());
+            for requested in expected_outputs {
+                let requested = absolute(requested, cwd);
+                let file_name = requested
+                    .file_name()
+                    .ok_or_else(|| missing_filename(StagedPlanReason::OutputMissingFilename))?;
+                let staged = root.join(file_name);
+                if outputs
+                    .iter()
+                    .any(|output: &StagedOutputPlan| output.staged.as_path() == staged)
+                {
+                    return Ok(StagedPlanOutcome::Unsupported(
+                        StagedPlanReason::OutputNameCollision,
+                    ));
+                }
                 outputs.push(StagedOutputPlan {
-                    requested,
-                    staged: root
-                        .join(Path::new(&path).file_name().ok_or_else(|| {
-                            io::Error::new(io::ErrorKind::InvalidInput, "emit path has no filename")
-                        })?)
-                        .into(),
+                    requested: requested.clone(),
+                    staged: staged.into(),
                 });
             }
-        }
-        let mut names = std::collections::HashSet::new();
-        outputs.retain(|output| names.insert(output.requested.clone()));
-        for output in &mut outputs {
-            let file_name = output.requested.file_name().ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidInput, "rustc output has no filename")
-            })?;
-            output.staged = root.join(file_name).into();
-        }
-        let staged_primary = outputs
-            .iter()
-            .find(|output| output.requested == primary)
-            .map(|output| output.staged.clone())
-            .ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "primary output missing from Rust plan",
-                )
-            })?;
+            for (kind, path) in emit_specs(args) {
+                let requested = absolute(Path::new(&path), cwd);
+                if kind == "link" {
+                    primary = requested.clone();
+                }
+                let replacement = outputs.iter().position(|output| {
+                    output.requested == requested || output_kind(&output.requested) == kind
+                });
+                if let Some(index) = replacement {
+                    outputs[index].requested = requested;
+                } else {
+                    outputs.push(StagedOutputPlan {
+                        requested,
+                        staged: root
+                            .join(Path::new(&path).file_name().ok_or_else(|| {
+                                missing_filename(StagedPlanReason::OutputMissingFilename)
+                            })?)
+                            .into(),
+                    });
+                }
+            }
+            let mut names = std::collections::HashSet::new();
+            outputs.retain(|output| names.insert(output.requested.clone()));
+            for output in &mut outputs {
+                let file_name = output
+                    .requested
+                    .file_name()
+                    .ok_or_else(|| missing_filename(StagedPlanReason::OutputMissingFilename))?;
+                output.staged = root.join(file_name).into();
+            }
+            if outputs.iter().enumerate().any(|(index, output)| {
+                outputs[..index]
+                    .iter()
+                    .any(|previous| previous.staged == output.staged)
+            }) {
+                return Ok(StagedPlanOutcome::Unsupported(
+                    StagedPlanReason::OutputNameCollision,
+                ));
+            }
+            let staged_primary = outputs
+                .iter()
+                .find(|output| output.requested == primary)
+                .map(|output| output.staged.clone())
+                .ok_or_else(|| {
+                    planning_error(
+                        StagedPlanReason::MissingRequiredOutputFlag,
+                        io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "primary output missing from Rust plan",
+                        ),
+                    )
+                })?;
 
-        let mut rewritten_args = args.to_vec();
-        let mut replaced_output = false;
-        let mut replaced_out_dir = false;
-        let mut i = 0;
-        while i < rewritten_args.len() {
-            if rewritten_args[i] == "-o" {
-                if i + 1 >= rewritten_args.len() {
-                    return Ok(None);
-                }
-                rewritten_args[i + 1] = staged_primary.to_string_lossy().into_owned();
-                replaced_output = true;
-                i += 2;
-                continue;
-            }
-            if rewritten_args[i] == "--out-dir" {
-                if i + 1 >= rewritten_args.len() {
-                    let _ = std::fs::remove_dir_all(&root);
-                    return Ok(None);
-                }
-                rewritten_args[i + 1] = root.to_string_lossy().into_owned();
-                replaced_out_dir = true;
-                i += 2;
-                continue;
-            }
-            if rewritten_args[i].starts_with("--out-dir=") {
-                rewritten_args[i] = format!("--out-dir={}", root.display());
-                replaced_out_dir = true;
-                i += 1;
-                continue;
-            }
-            if rewritten_args[i] == "--emit" {
-                if let Some(value) = rewritten_args.get_mut(i + 1) {
-                    rewrite_emit_value(value, &outputs, cwd);
-                }
-                i += 2;
-                continue;
-            }
-            if rewritten_args[i].starts_with("--emit=") {
-                let value = rewritten_args[i]["--emit=".len()..].to_string();
-                let mut rewritten = value;
-                rewrite_emit_value(&mut rewritten, &outputs, cwd);
-                rewritten_args[i] = format!("--emit={rewritten}");
-                i += 1;
-                continue;
-            }
-            if let Some(value) = rewritten_args[i].strip_prefix("-o") {
-                if !value.is_empty() {
-                    rewritten_args[i] = format!("-o{}", staged_primary.display());
+            let mut rewritten_args = args.to_vec();
+            let mut replaced_output = false;
+            let mut replaced_out_dir = false;
+            let mut i = 0;
+            while i < rewritten_args.len() {
+                if rewritten_args[i] == "-o" {
+                    if i + 1 >= rewritten_args.len() {
+                        return Ok(StagedPlanOutcome::Unsupported(
+                            StagedPlanReason::MissingOptionValue,
+                        ));
+                    }
+                    rewritten_args[i + 1] = staged_primary.to_string_lossy().into_owned();
                     replaced_output = true;
+                    i += 2;
+                    continue;
                 }
+                if rewritten_args[i] == "--out-dir" {
+                    if i + 1 >= rewritten_args.len() {
+                        return Ok(StagedPlanOutcome::Unsupported(
+                            StagedPlanReason::MissingOptionValue,
+                        ));
+                    }
+                    rewritten_args[i + 1] = root.to_string_lossy().into_owned();
+                    replaced_out_dir = true;
+                    i += 2;
+                    continue;
+                }
+                if rewritten_args[i].starts_with("--out-dir=") {
+                    rewritten_args[i] = format!("--out-dir={}", root.display());
+                    replaced_out_dir = true;
+                    i += 1;
+                    continue;
+                }
+                if rewritten_args[i] == "--emit" {
+                    if let Some(value) = rewritten_args.get_mut(i + 1) {
+                        rewrite_emit_value(value, &outputs, cwd);
+                    }
+                    i += 2;
+                    continue;
+                }
+                if rewritten_args[i].starts_with("--emit=") {
+                    let value = rewritten_args[i]["--emit=".len()..].to_string();
+                    let mut rewritten = value;
+                    rewrite_emit_value(&mut rewritten, &outputs, cwd);
+                    rewritten_args[i] = format!("--emit={rewritten}");
+                    i += 1;
+                    continue;
+                }
+                if let Some(value) = rewritten_args[i].strip_prefix("-o") {
+                    if !value.is_empty() {
+                        rewritten_args[i] = format!("-o{}", staged_primary.display());
+                        replaced_output = true;
+                    }
+                }
+                i += 1;
             }
-            i += 1;
-        }
-        if !replaced_output && !replaced_out_dir && emit_specs(args).is_empty() {
-            rewritten_args.push("-o".to_string());
-            rewritten_args.push(staged_primary.to_string_lossy().into_owned());
-        }
-        if outputs.len() > 1 && !replaced_out_dir {
-            rewritten_args.push("--out-dir".to_string());
-            rewritten_args.push(root.to_string_lossy().into_owned());
-        }
+            if !replaced_output && !replaced_out_dir && emit_specs(args).is_empty() {
+                rewritten_args.push("-o".to_string());
+                rewritten_args.push(staged_primary.to_string_lossy().into_owned());
+            }
+            if outputs.len() > 1 && !replaced_out_dir {
+                rewritten_args.push("--out-dir".to_string());
+                rewritten_args.push(root.to_string_lossy().into_owned());
+            }
 
-        Ok(Some(Self {
-            outputs,
-            rewritten_args,
-            root,
-        }))
+            Ok(StagedPlanOutcome::Enabled(Self {
+                outputs,
+                rewritten_args,
+                root: root.clone(),
+            }))
+        })();
+        if !matches!(result, Ok(StagedPlanOutcome::Enabled(_))) {
+            let _ = std::fs::remove_dir_all(&root);
+        }
+        result.unwrap_or_else(StagedPlanOutcome::Error)
     }
 
     pub(in crate::daemon::server) fn cc(
@@ -181,12 +331,12 @@ impl StagedCompilePlan {
         primary_output: &NormalizedPath,
         cwd: &Path,
         dep_flags: &crate::depgraph::UserDepFlags,
-    ) -> io::Result<Option<Self>> {
+    ) -> StagedPlanOutcome<Self> {
         if !staged_lane_enabled(family) {
-            return Ok(None);
+            return StagedPlanOutcome::Unsupported(StagedPlanReason::LaneDisabled);
         }
         if cc_has_unsupported_side_outputs(args) {
-            return Ok(None);
+            return StagedPlanOutcome::Unsupported(StagedPlanReason::UnmodeledSideOutput);
         }
         let output_role = crate::compiler::OutputClassification::for_compiler(
             family,
@@ -198,7 +348,7 @@ impl StagedCompilePlan {
             crate::compiler::OutputRole::Object
                 | crate::compiler::OutputRole::PrecompiledHeaderOrModule
         ) {
-            return Ok(None);
+            return StagedPlanOutcome::Unsupported(StagedPlanReason::UnsupportedOutputRole);
         }
         if family == crate::compiler::CompilerFamily::Msvc
             && !args.iter().any(|arg| {
@@ -206,133 +356,137 @@ impl StagedCompilePlan {
                     .is_some_and(|prefix| prefix.eq_ignore_ascii_case("/fo"))
             })
         {
-            return Ok(None);
+            return StagedPlanOutcome::Unsupported(StagedPlanReason::MissingRequiredOutputFlag);
         }
         let root = staging_dir.join(format!(
             ".compile-{}-{}",
             std::process::id(),
             PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
         ));
-        std::fs::create_dir_all(&root)?;
-        let requested = absolute(primary_output, cwd);
-        let file_name = requested.file_name().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "compiler output has no filename",
-            )
-        })?;
-        let staged: NormalizedPath = root.join(file_name).into();
-        let requested_depfile = dep_flags.mf_path.clone().or_else(|| {
-            dep_flags
-                .has_md
-                .then(|| requested.as_path().with_extension("d").into())
-        });
-        let mut rewritten_args = args.to_vec();
-        let mut replaced = false;
-        let mut i = 0;
-        while i < rewritten_args.len() {
-            if family == crate::compiler::CompilerFamily::Msvc
-                && rewritten_args[i].eq_ignore_ascii_case("/fo")
-            {
-                if i + 1 >= rewritten_args.len() {
-                    let _ = std::fs::remove_dir_all(&root);
-                    return Ok(None);
-                }
-                rewritten_args[i + 1] = staged.to_string_lossy().into_owned();
-                replaced = true;
-                i += 2;
-                continue;
-            }
-            if family == crate::compiler::CompilerFamily::Msvc
-                && rewritten_args[i]
-                    .get(..3)
-                    .is_some_and(|prefix| prefix.eq_ignore_ascii_case("/fo"))
-            {
-                let prefix = rewritten_args[i].get(..3).unwrap_or("/Fo");
-                rewritten_args[i] = format!("{prefix}{}", staged.display());
-                replaced = true;
-                i += 1;
-                continue;
-            }
-            if rewritten_args[i] == "-o" {
-                if i + 1 >= rewritten_args.len() {
-                    let _ = std::fs::remove_dir_all(&root);
-                    return Ok(None);
-                }
-                rewritten_args[i + 1] = staged.to_string_lossy().into_owned();
-                replaced = true;
-                i += 2;
-                continue;
-            }
-            if let Some(value) = rewritten_args[i].strip_prefix("-o") {
-                if !value.is_empty() {
-                    rewritten_args[i] = format!("-o{}", staged.display());
-                    replaced = true;
-                }
-            }
-            if let Some(requested_depfile) = requested_depfile.as_ref() {
-                if rewritten_args[i] == "-MF" {
+        if let Err(source) = std::fs::create_dir_all(&root) {
+            return StagedPlanOutcome::Error(planning_error(
+                StagedPlanReason::StagingDirectoryCreate,
+                source,
+            ));
+        }
+        let result = (|| -> Result<StagedPlanOutcome<Self>, StagedPlanError> {
+            let requested = absolute(primary_output, cwd);
+            let file_name = requested
+                .file_name()
+                .ok_or_else(|| missing_filename(StagedPlanReason::OutputMissingFilename))?;
+            let staged: NormalizedPath = root.join(file_name).into();
+            let requested_depfile = dep_flags.mf_path.clone().or_else(|| {
+                dep_flags
+                    .has_md
+                    .then(|| requested.as_path().with_extension("d").into())
+            });
+            let mut rewritten_args = args.to_vec();
+            let mut replaced = false;
+            let mut i = 0;
+            while i < rewritten_args.len() {
+                if family == crate::compiler::CompilerFamily::Msvc
+                    && rewritten_args[i].eq_ignore_ascii_case("/fo")
+                {
                     if i + 1 >= rewritten_args.len() {
-                        let _ = std::fs::remove_dir_all(&root);
-                        return Ok(None);
+                        return Ok(StagedPlanOutcome::Unsupported(
+                            StagedPlanReason::MissingOptionValue,
+                        ));
                     }
-                    let staged_depfile =
-                        root.join(requested_depfile.file_name().ok_or_else(|| {
-                            io::Error::new(
-                                io::ErrorKind::InvalidInput,
-                                "depfile output has no filename",
-                            )
-                        })?);
-                    rewritten_args[i + 1] = staged_depfile.to_string_lossy().into_owned();
+                    rewritten_args[i + 1] = staged.to_string_lossy().into_owned();
+                    replaced = true;
                     i += 2;
                     continue;
                 }
-                if let Some(value) = rewritten_args[i].strip_prefix("-MF") {
+                if family == crate::compiler::CompilerFamily::Msvc
+                    && rewritten_args[i]
+                        .get(..3)
+                        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("/fo"))
+                {
+                    let prefix = rewritten_args[i].get(..3).unwrap_or("/Fo");
+                    rewritten_args[i] = format!("{prefix}{}", staged.display());
+                    replaced = true;
+                    i += 1;
+                    continue;
+                }
+                if rewritten_args[i] == "-o" {
+                    if i + 1 >= rewritten_args.len() {
+                        return Ok(StagedPlanOutcome::Unsupported(
+                            StagedPlanReason::MissingOptionValue,
+                        ));
+                    }
+                    rewritten_args[i + 1] = staged.to_string_lossy().into_owned();
+                    replaced = true;
+                    i += 2;
+                    continue;
+                }
+                if let Some(value) = rewritten_args[i].strip_prefix("-o") {
                     if !value.is_empty() {
-                        let staged_depfile =
-                            root.join(requested_depfile.file_name().ok_or_else(|| {
-                                io::Error::new(
-                                    io::ErrorKind::InvalidInput,
-                                    "depfile output has no filename",
-                                )
-                            })?);
-                        rewritten_args[i] = format!("-MF{}", staged_depfile.display());
-                        continue;
+                        rewritten_args[i] = format!("-o{}", staged.display());
+                        replaced = true;
                     }
                 }
+                if let Some(requested_depfile) = requested_depfile.as_ref() {
+                    if rewritten_args[i] == "-MF" {
+                        if i + 1 >= rewritten_args.len() {
+                            return Ok(StagedPlanOutcome::Unsupported(
+                                StagedPlanReason::MissingOptionValue,
+                            ));
+                        }
+                        let staged_depfile =
+                            root.join(requested_depfile.file_name().ok_or_else(|| {
+                                missing_filename(StagedPlanReason::OutputMissingFilename)
+                            })?);
+                        rewritten_args[i + 1] = staged_depfile.to_string_lossy().into_owned();
+                        i += 2;
+                        continue;
+                    }
+                    if let Some(value) = rewritten_args[i].strip_prefix("-MF") {
+                        if !value.is_empty() {
+                            let staged_depfile =
+                                root.join(requested_depfile.file_name().ok_or_else(|| {
+                                    missing_filename(StagedPlanReason::OutputMissingFilename)
+                                })?);
+                            rewritten_args[i] = format!("-MF{}", staged_depfile.display());
+                            continue;
+                        }
+                    }
+                }
+                i += 1;
             }
-            i += 1;
-        }
-        if dep_flags.mf_path.is_some()
-            && !args
-                .iter()
-                .any(|arg| arg == "-MF" || arg.starts_with("-MF"))
-        {
+            if dep_flags.mf_path.is_some()
+                && !args
+                    .iter()
+                    .any(|arg| arg == "-MF" || arg.starts_with("-MF"))
+            {
+                return Ok(StagedPlanOutcome::Unsupported(
+                    StagedPlanReason::MissingRequiredOutputFlag,
+                ));
+            }
+            if !replaced {
+                rewritten_args.push("-o".to_string());
+                rewritten_args.push(staged.to_string_lossy().into_owned());
+            }
+            let mut outputs = vec![StagedOutputPlan { requested, staged }];
+            if let Some(requested_depfile) = requested_depfile {
+                let staged_depfile =
+                    root.join(requested_depfile.file_name().ok_or_else(|| {
+                        missing_filename(StagedPlanReason::OutputMissingFilename)
+                    })?);
+                outputs.push(StagedOutputPlan {
+                    requested: requested_depfile,
+                    staged: staged_depfile.into(),
+                });
+            }
+            Ok(StagedPlanOutcome::Enabled(Self {
+                outputs,
+                rewritten_args,
+                root: root.clone(),
+            }))
+        })();
+        if !matches!(result, Ok(StagedPlanOutcome::Enabled(_))) {
             let _ = std::fs::remove_dir_all(&root);
-            return Ok(None);
         }
-        if !replaced {
-            rewritten_args.push("-o".to_string());
-            rewritten_args.push(staged.to_string_lossy().into_owned());
-        }
-        let mut outputs = vec![StagedOutputPlan { requested, staged }];
-        if let Some(requested_depfile) = requested_depfile {
-            let staged_depfile = root.join(requested_depfile.file_name().ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "depfile output has no filename",
-                )
-            })?);
-            outputs.push(StagedOutputPlan {
-                requested: requested_depfile,
-                staged: staged_depfile.into(),
-            });
-        }
-        Ok(Some(Self {
-            outputs,
-            rewritten_args,
-            root,
-        }))
+        result.unwrap_or_else(StagedPlanOutcome::Error)
     }
 
     /// Stage a pure archive invocation. Linkers with secondary side outputs
@@ -343,52 +497,61 @@ impl StagedCompilePlan {
         args: &[String],
         primary_output: &NormalizedPath,
         cwd: &Path,
-    ) -> io::Result<Option<Self>> {
+    ) -> StagedPlanOutcome<Self> {
         if !staged_lane_enabled(crate::compiler::CompilerFamily::Gcc) {
-            return Ok(None);
+            return StagedPlanOutcome::Unsupported(StagedPlanReason::LaneDisabled);
         }
         let root = staging_dir.join(format!(
             ".compile-{}-{}",
             std::process::id(),
             PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
         ));
-        std::fs::create_dir_all(&root)?;
-        let requested = absolute(primary_output, cwd);
-        let file_name = requested.file_name().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "archive output has no filename",
-            )
-        })?;
-        let staged: NormalizedPath = root.join(file_name).into();
-        let requested_text = requested.to_string_lossy();
-        let mut rewritten_args = args.to_vec();
-        let mut replaced = false;
-        for arg in &mut rewritten_args {
-            if *arg == requested_text {
-                *arg = staged.to_string_lossy().into_owned();
-                replaced = true;
-            }
+        if let Err(source) = std::fs::create_dir_all(&root) {
+            return StagedPlanOutcome::Error(planning_error(
+                StagedPlanReason::StagingDirectoryCreate,
+                source,
+            ));
         }
-        if !replaced {
-            let file_name = requested.file_name().unwrap_or_default().to_string_lossy();
+        let result = (|| -> Result<StagedPlanOutcome<Self>, StagedPlanError> {
+            let requested = absolute(primary_output, cwd);
+            let file_name = requested
+                .file_name()
+                .ok_or_else(|| missing_filename(StagedPlanReason::OutputMissingFilename))?;
+            let staged: NormalizedPath = root.join(file_name).into();
+            let requested_text = requested.to_string_lossy();
+            let mut rewritten_args = args.to_vec();
+            let mut replaced = false;
             for arg in &mut rewritten_args {
-                if arg == file_name.as_ref() {
+                if *arg == requested_text {
                     *arg = staged.to_string_lossy().into_owned();
                     replaced = true;
-                    break;
                 }
             }
-        }
-        if !replaced {
+            if !replaced {
+                let file_name = requested.file_name().unwrap_or_default().to_string_lossy();
+                for arg in &mut rewritten_args {
+                    if arg == file_name.as_ref() {
+                        *arg = staged.to_string_lossy().into_owned();
+                        replaced = true;
+                        break;
+                    }
+                }
+            }
+            if !replaced {
+                return Ok(StagedPlanOutcome::Unsupported(
+                    StagedPlanReason::OutputNotInArguments,
+                ));
+            }
+            Ok(StagedPlanOutcome::Enabled(Self {
+                outputs: vec![StagedOutputPlan { requested, staged }],
+                rewritten_args,
+                root: root.clone(),
+            }))
+        })();
+        if !matches!(result, Ok(StagedPlanOutcome::Enabled(_))) {
             let _ = std::fs::remove_dir_all(&root);
-            return Ok(None);
         }
-        Ok(Some(Self {
-            outputs: vec![StagedOutputPlan { requested, staged }],
-            rewritten_args,
-            root,
-        }))
+        result.unwrap_or_else(StagedPlanOutcome::Error)
     }
 
     /// Build a linker plan only when every declared output can be redirected
@@ -400,20 +563,25 @@ impl StagedCompilePlan {
         primary_output: &NormalizedPath,
         secondary_outputs: &[NormalizedPath],
         cwd: &Path,
-    ) -> io::Result<Option<Self>> {
+    ) -> StagedPlanOutcome<Self> {
         if !super::staged_link_lane_enabled() {
-            return Ok(None);
+            return StagedPlanOutcome::Unsupported(StagedPlanReason::LaneDisabled);
         }
         if has_unmodeled_link_output_option(args) {
-            return Ok(None);
+            return StagedPlanOutcome::Unsupported(StagedPlanReason::UnmodeledSideOutput);
         }
         let root = staging_dir.join(format!(
             ".link-{}-{}",
             std::process::id(),
             PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
         ));
-        std::fs::create_dir_all(&root)?;
-        let result = (|| {
+        if let Err(source) = std::fs::create_dir_all(&root) {
+            return StagedPlanOutcome::Error(planning_error(
+                StagedPlanReason::StagingDirectoryCreate,
+                source,
+            ));
+        }
+        let result = (|| -> Result<StagedPlanOutcome<Self>, StagedPlanError> {
             let mut requested_outputs = Vec::with_capacity(1 + secondary_outputs.len());
             requested_outputs.push(absolute(primary_output, cwd));
             requested_outputs.extend(secondary_outputs.iter().map(|output| absolute(output, cwd)));
@@ -422,16 +590,20 @@ impl StagedCompilePlan {
             for requested in requested_outputs {
                 let requested_text = requested.to_string_lossy();
                 if requested_text.contains('%') || requested.as_path().is_dir() {
-                    return Ok(None);
+                    return Ok(StagedPlanOutcome::Unsupported(
+                        StagedPlanReason::UnsupportedOutputPath,
+                    ));
                 }
-                let filename = requested.file_name().ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "link output has no filename")
-                })?;
+                let filename = requested
+                    .file_name()
+                    .ok_or_else(|| missing_filename(StagedPlanReason::OutputMissingFilename))?;
                 let staged: NormalizedPath = root.join(filename).into();
                 if outputs.iter().any(|output: &StagedOutputPlan| {
                     output.requested == requested || output.staged == staged
                 }) {
-                    return Ok(None);
+                    return Ok(StagedPlanOutcome::Unsupported(
+                        StagedPlanReason::OutputNameCollision,
+                    ));
                 }
                 let relative = requested
                     .strip_prefix(cwd)
@@ -446,24 +618,30 @@ impl StagedCompilePlan {
                         staged.to_string_lossy().as_ref(),
                     ) {
                         Some(arg_replaced) => replaced |= arg_replaced,
-                        None => return Ok(None),
+                        None => {
+                            return Ok(StagedPlanOutcome::Unsupported(
+                                StagedPlanReason::AmbiguousOutputArgument,
+                            ));
+                        }
                     }
                 }
                 if !replaced {
-                    return Ok(None);
+                    return Ok(StagedPlanOutcome::Unsupported(
+                        StagedPlanReason::OutputNotInArguments,
+                    ));
                 }
                 outputs.push(StagedOutputPlan { requested, staged });
             }
-            Ok(Some(Self {
+            Ok(StagedPlanOutcome::Enabled(Self {
                 outputs,
                 rewritten_args,
                 root: root.clone(),
             }))
         })();
-        if matches!(result, Ok(None) | Err(_)) {
+        if !matches!(result, Ok(StagedPlanOutcome::Enabled(_))) {
             let _ = std::fs::remove_dir_all(&root);
         }
-        result
+        result.unwrap_or_else(StagedPlanOutcome::Error)
     }
 
     pub(in crate::daemon::server) fn output_paths(&self) -> Vec<NormalizedPath> {
@@ -739,6 +917,22 @@ fn emit_to_stdout(args: &[String]) -> bool {
     })
 }
 
+fn rustc_has_missing_option_value(args: &[String]) -> bool {
+    args.iter().enumerate().any(|(index, arg)| {
+        if matches!(arg.as_str(), "-o" | "--out-dir" | "--emit") {
+            return args.get(index + 1).is_none_or(String::is_empty);
+        }
+        arg.strip_prefix("--out-dir=").is_some_and(str::is_empty)
+            || arg.strip_prefix("--emit=").is_some_and(|value| {
+                value.is_empty()
+                    || value.split(',').any(|part| {
+                        part.split_once('=')
+                            .is_some_and(|(_, path)| path.is_empty())
+                    })
+            })
+    })
+}
+
 fn output_kind(path: &Path) -> String {
     match path.extension().and_then(|extension| extension.to_str()) {
         Some("rmeta") => "metadata",
@@ -776,422 +970,5 @@ fn rewrite_emit_value(value: &mut String, outputs: &[StagedOutputPlan], cwd: &Pa
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::tempdir;
-
-    fn staged_tests_enabled() -> bool {
-        std::env::var_os(super::super::staged_store::STAGED_ARTIFACTS_ENV).is_some()
-    }
-
-    #[test]
-    fn rust_plan_rewrites_output_before_spawn() {
-        if !staged_tests_enabled() {
-            return;
-        }
-        let temp = tempdir().unwrap();
-        let output: NormalizedPath = temp.path().join("target/libx.rlib").into();
-        let plan = StagedCompilePlan::rustc(
-            temp.path(),
-            &[
-                "--crate-type=rlib".into(),
-                "-o".into(),
-                output.to_string_lossy().into_owned(),
-            ],
-            &output,
-            std::slice::from_ref(&output),
-            temp.path(),
-        )
-        .unwrap()
-        .unwrap();
-        assert!(!plan
-            .rewritten_args
-            .contains(&output.to_string_lossy().into_owned()));
-        assert!(plan
-            .primary_staged()
-            .as_path()
-            .starts_with(temp.path().join(".staged-v2")));
-        plan.cleanup().unwrap();
-    }
-
-    #[test]
-    fn explicit_emit_destination_is_staged_and_mapped() {
-        if !staged_tests_enabled() {
-            return;
-        }
-        let temp = tempdir().unwrap();
-        let output: NormalizedPath = temp.path().join("x.rlib").into();
-        let plan = StagedCompilePlan::rustc(
-            temp.path(),
-            &["--emit=link,dep-info=custom.d".into()],
-            &output,
-            std::slice::from_ref(&output),
-            temp.path(),
-        )
-        .unwrap()
-        .unwrap();
-        assert!(plan.outputs.iter().any(|output| {
-            output.requested.file_name().and_then(|name| name.to_str()) == Some("custom.d")
-        }));
-        assert!(plan
-            .rewritten_args
-            .iter()
-            .any(|arg| arg.contains("dep-info=") && arg.contains(".staged-v2")));
-        plan.cleanup().unwrap();
-    }
-
-    #[test]
-    fn cc_plan_rewrites_concatenated_output_flag() {
-        if !staged_tests_enabled() {
-            return;
-        }
-        let temp = tempdir().unwrap();
-        let output: NormalizedPath = temp.path().join("hello.o").into();
-        let plan = StagedCompilePlan::cc(
-            temp.path(),
-            crate::compiler::CompilerFamily::Clang,
-            &["-c".into(), "hello.cpp".into(), "-ohello.o".into()],
-            &output,
-            temp.path(),
-            &crate::depgraph::UserDepFlags::default(),
-        )
-        .unwrap()
-        .unwrap();
-        assert!(plan
-            .rewritten_args
-            .iter()
-            .any(|arg| arg.starts_with("-o") && arg.contains(".staged-v2")));
-        plan.cleanup().unwrap();
-    }
-
-    #[test]
-    fn cc_plan_stages_user_depfile_without_leaking_private_path() {
-        if !staged_tests_enabled() {
-            return;
-        }
-        let temp = tempdir().unwrap();
-        let output: NormalizedPath = temp.path().join("hello.o").into();
-        let depfile: NormalizedPath = temp.path().join("deps/hello.d").into();
-        let dep_flags = crate::depgraph::UserDepFlags {
-            has_md: true,
-            mf_path: Some(depfile.clone()),
-        };
-        let plan = StagedCompilePlan::cc(
-            temp.path(),
-            crate::compiler::CompilerFamily::Clang,
-            &[
-                "-c".into(),
-                "hello.cpp".into(),
-                "-o".into(),
-                "hello.o".into(),
-                "-MD".into(),
-                "-MF".into(),
-                depfile.to_string_lossy().into_owned(),
-            ],
-            &output,
-            temp.path(),
-            &dep_flags,
-        )
-        .unwrap()
-        .unwrap();
-        assert_eq!(plan.outputs.len(), 2);
-        assert!(plan
-            .rewritten_args
-            .windows(2)
-            .any(|args| args[0] == "-MF" && args[1].contains(".staged-v2")));
-        let rewritten =
-            plan.rewrite_depfile_strategy(crate::depgraph::DepfileStrategy::UserSpecified {
-                path: depfile,
-            });
-        assert!(matches!(
-            rewritten,
-            crate::depgraph::DepfileStrategy::UserSpecified { path }
-                if path.as_path().starts_with(temp.path().join(".staged-v2"))
-        ));
-        plan.cleanup().unwrap();
-    }
-
-    #[test]
-    fn cc_plan_stages_single_precompiled_header_output() {
-        if !staged_tests_enabled() {
-            return;
-        }
-        let temp = tempdir().unwrap();
-        let output: NormalizedPath = temp.path().join("header.pch").into();
-        let plan = StagedCompilePlan::cc(
-            temp.path(),
-            crate::compiler::CompilerFamily::Clang,
-            &[
-                "-x".into(),
-                "c-header".into(),
-                "header.h".into(),
-                "-o".into(),
-                output.to_string_lossy().into_owned(),
-            ],
-            &output,
-            temp.path(),
-            &crate::depgraph::UserDepFlags::default(),
-        )
-        .unwrap()
-        .unwrap();
-        let stage_root = plan
-            .primary_staged()
-            .parent()
-            .and_then(Path::parent)
-            .unwrap();
-        let compile_dir = plan.primary_staged().parent().unwrap();
-        assert_eq!(stage_root, temp.path().join(".staged-v2"));
-        assert!(compile_dir
-            .file_name()
-            .is_some_and(|name| name.to_string_lossy().starts_with(".compile-")));
-        plan.cleanup().unwrap();
-    }
-
-    #[test]
-    fn msvc_plan_rewrites_fo_without_inventing_gcc_flags() {
-        if !staged_tests_enabled() {
-            return;
-        }
-        let temp = tempdir().unwrap();
-        let output: NormalizedPath = temp.path().join("hello.obj").into();
-        let plan = StagedCompilePlan::cc(
-            temp.path(),
-            crate::compiler::CompilerFamily::Msvc,
-            &["/c".into(), "hello.cpp".into(), "/Fo:hello.obj".into()],
-            &output,
-            temp.path(),
-            &crate::depgraph::UserDepFlags::default(),
-        )
-        .unwrap()
-        .unwrap();
-        assert!(plan
-            .rewritten_args
-            .iter()
-            .any(|arg| arg.to_ascii_lowercase().starts_with("/fo")));
-        assert!(!plan.rewritten_args.iter().any(|arg| arg == "-o"));
-        plan.cleanup().unwrap();
-    }
-
-    #[test]
-    fn archive_plan_rewrites_exact_output_token() {
-        if !staged_tests_enabled() {
-            return;
-        }
-        let temp = tempdir().unwrap();
-        let output: NormalizedPath = temp.path().join("libhello.a").into();
-        let plan = StagedCompilePlan::archive(
-            temp.path(),
-            &["rcs".into(), "libhello.a".into(), "hello.o".into()],
-            &output,
-            temp.path(),
-        )
-        .unwrap()
-        .unwrap();
-        assert!(plan
-            .rewritten_args
-            .iter()
-            .any(|arg| arg.contains(".staged-v2")));
-        plan.cleanup().unwrap();
-    }
-
-    #[test]
-    fn link_plan_rewrites_primary_and_declared_secondary_outputs() {
-        if !staged_tests_enabled() {
-            return;
-        }
-        let temp = tempdir().unwrap();
-        let primary: NormalizedPath = temp.path().join("app.exe").into();
-        let import: NormalizedPath = temp.path().join("app.lib").into();
-        let plan = StagedCompilePlan::link(
-            temp.path(),
-            &[
-                "-o".into(),
-                "app.exe".into(),
-                "-Wl,--out-implib,app.lib".into(),
-            ],
-            &primary,
-            std::slice::from_ref(&import),
-            temp.path(),
-        )
-        .unwrap()
-        .unwrap();
-        assert_eq!(plan.outputs.len(), 2);
-        assert!(plan
-            .rewritten_args
-            .iter()
-            .any(|arg| arg.contains(".staged-v2") && arg.contains("app.exe")));
-        assert!(plan
-            .rewritten_args
-            .iter()
-            .any(|arg| arg.contains(".staged-v2") && arg.contains("app.lib")));
-        std::fs::write(
-            plan.primary_staged().parent().unwrap().join("implicit.pdb"),
-            b"debug",
-        )
-        .unwrap();
-        assert_eq!(plan.unexpected_staged_entries().unwrap().len(), 1);
-        plan.cleanup().unwrap();
-    }
-
-    #[test]
-    fn link_plan_rewrites_absolute_output_once_and_ignores_substrings() {
-        if !staged_tests_enabled() {
-            return;
-        }
-        let temp = tempdir().unwrap();
-        let primary: NormalizedPath = temp.path().join("app.exe").into();
-        let absolute = primary.to_string_lossy().into_owned();
-        let plan = StagedCompilePlan::link(
-            temp.path(),
-            &[
-                "-o".into(),
-                absolute,
-                "--trace-symbol=app.exe.helper".into(),
-            ],
-            &primary,
-            &[],
-            temp.path(),
-        )
-        .unwrap()
-        .unwrap();
-        assert_eq!(
-            plan.rewritten_args[1],
-            plan.primary_staged().to_string_lossy()
-        );
-        assert_eq!(plan.rewritten_args[2], "--trace-symbol=app.exe.helper");
-        plan.cleanup().unwrap();
-    }
-
-    #[test]
-    fn link_plan_rejects_ambiguous_output_token() {
-        if !staged_tests_enabled() {
-            return;
-        }
-        let temp = tempdir().unwrap();
-        let primary: NormalizedPath = temp.path().join("app.exe").into();
-        let plan = StagedCompilePlan::link(
-            temp.path(),
-            &["-Wl,-Map,app.exe,app.exe".into()],
-            &primary,
-            &[],
-            temp.path(),
-        )
-        .unwrap();
-        assert!(plan.is_none());
-    }
-
-    #[test]
-    fn link_plan_stages_explicit_msvc_debug_output_set() {
-        if !staged_tests_enabled() {
-            return;
-        }
-        let temp = tempdir().unwrap();
-        let primary: NormalizedPath = temp.path().join("app.exe").into();
-        let pdb: NormalizedPath = temp.path().join("app.pdb").into();
-        let ilk: NormalizedPath = temp.path().join("app.ilk").into();
-        let map: NormalizedPath = temp.path().join("app.map").into();
-        let args = [
-            format!("/OUT:{}", primary.display()),
-            format!("/PDB:{}", pdb.display()),
-            format!("/ILK:{}", ilk.display()),
-            format!("/MAP:{}", map.display()),
-        ];
-        let plan =
-            StagedCompilePlan::link(temp.path(), &args, &primary, &[pdb, ilk, map], temp.path())
-                .unwrap()
-                .unwrap();
-        assert_eq!(plan.outputs.len(), 4);
-        assert!(plan
-            .rewritten_args
-            .iter()
-            .all(|arg| arg.contains(".staged-v2")));
-        plan.cleanup().unwrap();
-    }
-
-    #[test]
-    fn link_plan_rejects_implicit_msvc_side_output_before_spawn() {
-        if !staged_tests_enabled() {
-            return;
-        }
-        let temp = tempdir().unwrap();
-        let primary: NormalizedPath = temp.path().join("app.exe").into();
-        let implicit_pdb: NormalizedPath = temp.path().join("app.pdb").into();
-        let plan = StagedCompilePlan::link(
-            temp.path(),
-            &["/DEBUG".into(), format!("/OUT:{}", primary.display())],
-            &primary,
-            &[implicit_pdb],
-            temp.path(),
-        )
-        .unwrap();
-        assert!(plan.is_none());
-    }
-
-    #[test]
-    fn link_plan_rejects_semantic_gnu_map_destination() {
-        if !staged_tests_enabled() {
-            return;
-        }
-        let temp = tempdir().unwrap();
-        let primary: NormalizedPath = temp.path().join("app").into();
-        let semantic_map: NormalizedPath = temp.path().join("%.map").into();
-        let plan = StagedCompilePlan::link(
-            temp.path(),
-            &[
-                "-o".into(),
-                primary.to_string_lossy().into_owned(),
-                format!("-Map={}", semantic_map.display()),
-            ],
-            &primary,
-            &[semantic_map],
-            temp.path(),
-        )
-        .unwrap();
-        assert!(plan.is_none());
-    }
-
-    #[test]
-    fn link_plan_rejects_unmodeled_output_option_before_spawn() {
-        if !staged_tests_enabled() {
-            return;
-        }
-        let temp = tempdir().unwrap();
-        let primary: NormalizedPath = temp.path().join("app.exe").into();
-        let plan = StagedCompilePlan::link(
-            temp.path(),
-            &[
-                format!("/OUT:{}", primary.display()),
-                "/LTCGOUT:state/app.iobj".into(),
-            ],
-            &primary,
-            &[],
-            temp.path(),
-        )
-        .unwrap();
-        assert!(plan.is_none());
-    }
-
-    #[test]
-    fn link_plan_accepts_case_sensitive_gnu_map_option() {
-        if !staged_tests_enabled() {
-            return;
-        }
-        let temp = tempdir().unwrap();
-        let primary: NormalizedPath = temp.path().join("app").into();
-        let map: NormalizedPath = temp.path().join("app.map").into();
-        let plan = StagedCompilePlan::link(
-            temp.path(),
-            &[
-                "-o".into(),
-                primary.to_string_lossy().into_owned(),
-                "-Map".into(),
-                map.to_string_lossy().into_owned(),
-            ],
-            &primary,
-            &[map],
-            temp.path(),
-        )
-        .unwrap();
-        assert!(plan.is_some());
-    }
-}
+#[path = "staged_plan_tests.rs"]
+mod tests;

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan_tests.rs
@@ -1,0 +1,572 @@
+//! Adversarial planner and reverse-map tests for immutable staged outputs.
+use super::*;
+use tempfile::tempdir;
+
+fn staged_tests_enabled() -> bool {
+    std::env::var_os(super::super::staged_store::STAGED_ARTIFACTS_ENV).is_some()
+}
+
+#[test]
+fn rust_plan_rewrites_output_before_spawn() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let output: NormalizedPath = temp.path().join("target/libx.rlib").into();
+    let plan = StagedCompilePlan::rustc(
+        temp.path(),
+        &[
+            "--crate-type=rlib".into(),
+            "-o".into(),
+            output.to_string_lossy().into_owned(),
+        ],
+        &output,
+        std::slice::from_ref(&output),
+        temp.path(),
+    )
+    .unwrap()
+    .unwrap();
+    assert!(!plan
+        .rewritten_args
+        .contains(&output.to_string_lossy().into_owned()));
+    assert!(plan.primary_staged().as_path().starts_with(temp.path()));
+    plan.cleanup().unwrap();
+}
+
+#[test]
+fn explicit_emit_destination_is_staged_and_mapped() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let output: NormalizedPath = temp.path().join("x.rlib").into();
+    let plan = StagedCompilePlan::rustc(
+        temp.path(),
+        &["--emit=link,dep-info=custom.d".into()],
+        &output,
+        std::slice::from_ref(&output),
+        temp.path(),
+    )
+    .unwrap()
+    .unwrap();
+    assert!(plan.outputs.iter().any(|output| {
+        output.requested.file_name().and_then(|name| name.to_str()) == Some("custom.d")
+    }));
+    assert!(plan
+        .rewritten_args
+        .iter()
+        .any(|arg| arg.contains("dep-info=") && arg.contains(".compile-")));
+    plan.cleanup().unwrap();
+}
+
+#[test]
+fn cc_plan_rewrites_concatenated_output_flag() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let output: NormalizedPath = temp.path().join("hello.o").into();
+    let plan = StagedCompilePlan::cc(
+        temp.path(),
+        crate::compiler::CompilerFamily::Clang,
+        &["-c".into(), "hello.cpp".into(), "-ohello.o".into()],
+        &output,
+        temp.path(),
+        &crate::depgraph::UserDepFlags::default(),
+    )
+    .unwrap()
+    .unwrap();
+    assert!(plan
+        .rewritten_args
+        .iter()
+        .any(|arg| arg.starts_with("-o") && arg.contains(".compile-")));
+    plan.cleanup().unwrap();
+}
+
+#[test]
+fn cc_plan_stages_user_depfile_without_leaking_private_path() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let output: NormalizedPath = temp.path().join("hello.o").into();
+    let depfile: NormalizedPath = temp.path().join("deps/hello.d").into();
+    let dep_flags = crate::depgraph::UserDepFlags {
+        has_md: true,
+        mf_path: Some(depfile.clone()),
+    };
+    let plan = StagedCompilePlan::cc(
+        temp.path(),
+        crate::compiler::CompilerFamily::Clang,
+        &[
+            "-c".into(),
+            "hello.cpp".into(),
+            "-o".into(),
+            "hello.o".into(),
+            "-MD".into(),
+            "-MF".into(),
+            depfile.to_string_lossy().into_owned(),
+        ],
+        &output,
+        temp.path(),
+        &dep_flags,
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(plan.outputs.len(), 2);
+    assert!(plan
+        .rewritten_args
+        .windows(2)
+        .any(|args| args[0] == "-MF" && args[1].contains(".compile-")));
+    let rewritten =
+        plan.rewrite_depfile_strategy(crate::depgraph::DepfileStrategy::UserSpecified {
+            path: depfile,
+        });
+    assert!(matches!(
+        rewritten,
+        crate::depgraph::DepfileStrategy::UserSpecified { path }
+            if path.as_path().starts_with(temp.path())
+    ));
+    plan.cleanup().unwrap();
+}
+
+#[test]
+fn cc_plan_stages_single_precompiled_header_output() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let output: NormalizedPath = temp.path().join("header.pch").into();
+    let plan = StagedCompilePlan::cc(
+        temp.path(),
+        crate::compiler::CompilerFamily::Clang,
+        &[
+            "-x".into(),
+            "c-header".into(),
+            "header.h".into(),
+            "-o".into(),
+            output.to_string_lossy().into_owned(),
+        ],
+        &output,
+        temp.path(),
+        &crate::depgraph::UserDepFlags::default(),
+    )
+    .unwrap()
+    .unwrap();
+    let stage_root = plan
+        .primary_staged()
+        .parent()
+        .and_then(Path::parent)
+        .unwrap();
+    let compile_dir = plan.primary_staged().parent().unwrap();
+    assert_eq!(stage_root, temp.path());
+    assert!(compile_dir
+        .file_name()
+        .is_some_and(|name| name.to_string_lossy().starts_with(".compile-")));
+    plan.cleanup().unwrap();
+}
+
+#[test]
+fn msvc_plan_rewrites_fo_without_inventing_gcc_flags() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let output: NormalizedPath = temp.path().join("hello.obj").into();
+    let plan = StagedCompilePlan::cc(
+        temp.path(),
+        crate::compiler::CompilerFamily::Msvc,
+        &["/c".into(), "hello.cpp".into(), "/Fo:hello.obj".into()],
+        &output,
+        temp.path(),
+        &crate::depgraph::UserDepFlags::default(),
+    )
+    .unwrap()
+    .unwrap();
+    assert!(plan
+        .rewritten_args
+        .iter()
+        .any(|arg| arg.to_ascii_lowercase().starts_with("/fo")));
+    assert!(!plan.rewritten_args.iter().any(|arg| arg == "-o"));
+    plan.cleanup().unwrap();
+}
+
+#[test]
+fn archive_plan_rewrites_exact_output_token() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let output: NormalizedPath = temp.path().join("libhello.a").into();
+    let plan = StagedCompilePlan::archive(
+        temp.path(),
+        &["rcs".into(), "libhello.a".into(), "hello.o".into()],
+        &output,
+        temp.path(),
+    )
+    .unwrap()
+    .unwrap();
+    assert!(plan
+        .rewritten_args
+        .iter()
+        .any(|arg| arg.contains(".compile-")));
+    plan.cleanup().unwrap();
+}
+
+#[test]
+fn link_plan_rewrites_primary_and_declared_secondary_outputs() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let primary: NormalizedPath = temp.path().join("app.exe").into();
+    let import: NormalizedPath = temp.path().join("app.lib").into();
+    let plan = StagedCompilePlan::link(
+        temp.path(),
+        &[
+            "-o".into(),
+            "app.exe".into(),
+            "-Wl,--out-implib,app.lib".into(),
+        ],
+        &primary,
+        std::slice::from_ref(&import),
+        temp.path(),
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(plan.outputs.len(), 2);
+    assert!(plan
+        .rewritten_args
+        .iter()
+        .any(|arg| arg.contains(".link-") && arg.contains("app.exe")));
+    assert!(plan
+        .rewritten_args
+        .iter()
+        .any(|arg| arg.contains(".link-") && arg.contains("app.lib")));
+    std::fs::write(
+        plan.primary_staged().parent().unwrap().join("implicit.pdb"),
+        b"debug",
+    )
+    .unwrap();
+    assert_eq!(plan.unexpected_staged_entries().unwrap().len(), 1);
+    plan.cleanup().unwrap();
+}
+
+#[test]
+fn link_plan_rewrites_absolute_output_once_and_ignores_substrings() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let primary: NormalizedPath = temp.path().join("app.exe").into();
+    let absolute = primary.to_string_lossy().into_owned();
+    let plan = StagedCompilePlan::link(
+        temp.path(),
+        &[
+            "-o".into(),
+            absolute,
+            "--trace-symbol=app.exe.helper".into(),
+        ],
+        &primary,
+        &[],
+        temp.path(),
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(
+        plan.rewritten_args[1],
+        plan.primary_staged().to_string_lossy()
+    );
+    assert_eq!(plan.rewritten_args[2], "--trace-symbol=app.exe.helper");
+    plan.cleanup().unwrap();
+}
+
+#[test]
+fn link_plan_rejects_ambiguous_output_token() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let primary: NormalizedPath = temp.path().join("app.exe").into();
+    let plan = StagedCompilePlan::link(
+        temp.path(),
+        &["-Wl,-Map,app.exe,app.exe".into()],
+        &primary,
+        &[],
+        temp.path(),
+    );
+    assert!(matches!(
+        plan,
+        StagedPlanOutcome::Unsupported(StagedPlanReason::AmbiguousOutputArgument)
+    ));
+}
+
+#[test]
+fn link_plan_stages_explicit_msvc_debug_output_set() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let primary: NormalizedPath = temp.path().join("app.exe").into();
+    let pdb: NormalizedPath = temp.path().join("app.pdb").into();
+    let ilk: NormalizedPath = temp.path().join("app.ilk").into();
+    let map: NormalizedPath = temp.path().join("app.map").into();
+    let args = [
+        format!("/OUT:{}", primary.display()),
+        format!("/PDB:{}", pdb.display()),
+        format!("/ILK:{}", ilk.display()),
+        format!("/MAP:{}", map.display()),
+    ];
+    let plan = StagedCompilePlan::link(temp.path(), &args, &primary, &[pdb, ilk, map], temp.path())
+        .unwrap()
+        .unwrap();
+    assert_eq!(plan.outputs.len(), 4);
+    assert!(plan.rewritten_args.iter().all(|arg| arg.contains(".link-")));
+    plan.cleanup().unwrap();
+}
+
+#[test]
+fn link_plan_rejects_implicit_msvc_side_output_before_spawn() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let primary: NormalizedPath = temp.path().join("app.exe").into();
+    let implicit_pdb: NormalizedPath = temp.path().join("app.pdb").into();
+    let plan = StagedCompilePlan::link(
+        temp.path(),
+        &["/DEBUG".into(), format!("/OUT:{}", primary.display())],
+        &primary,
+        &[implicit_pdb],
+        temp.path(),
+    )
+    .unwrap();
+    assert!(plan.is_none());
+}
+
+#[test]
+fn link_plan_rejects_semantic_gnu_map_destination() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let primary: NormalizedPath = temp.path().join("app").into();
+    let semantic_map: NormalizedPath = temp.path().join("%.map").into();
+    let plan = StagedCompilePlan::link(
+        temp.path(),
+        &[
+            "-o".into(),
+            primary.to_string_lossy().into_owned(),
+            format!("-Map={}", semantic_map.display()),
+        ],
+        &primary,
+        &[semantic_map],
+        temp.path(),
+    );
+    assert!(matches!(
+        plan,
+        StagedPlanOutcome::Unsupported(StagedPlanReason::UnsupportedOutputPath)
+    ));
+}
+
+#[test]
+fn link_plan_rejects_unmodeled_output_option_before_spawn() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let primary: NormalizedPath = temp.path().join("app.exe").into();
+    let plan = StagedCompilePlan::link(
+        temp.path(),
+        &[
+            format!("/OUT:{}", primary.display()),
+            "/LTCGOUT:state/app.iobj".into(),
+        ],
+        &primary,
+        &[],
+        temp.path(),
+    );
+    assert!(matches!(
+        plan,
+        StagedPlanOutcome::Unsupported(StagedPlanReason::UnmodeledSideOutput)
+    ));
+}
+
+#[test]
+fn planner_reason_ids_are_bounded_and_non_sensitive() {
+    let profiler = crate::daemon::staged_stats::StagedProfiler::new();
+    let mut ids = std::collections::HashSet::new();
+    for reason in StagedPlanReason::ALL {
+        let id = reason.id();
+        assert!(!id.is_empty());
+        assert!(id
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte == b'_'));
+        assert!(!id.contains('/') && !id.contains('\\') && !id.contains(':'));
+        assert!(ids.insert(id), "duplicate planner reason ID: {id}");
+        profiler.failure(reason.failure());
+    }
+    let failures = profiler.snapshot().failures;
+    for id in ids {
+        assert_eq!(failures[&format!("plan_{id}")], 1);
+    }
+}
+
+#[test]
+fn compile_and_archive_rejections_keep_precise_reasons() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let output: NormalizedPath = temp.path().join("hello.o").into();
+    assert!(matches!(
+        StagedCompilePlan::rustc(
+            temp.path(),
+            &["--emit=link=-".into()],
+            &output,
+            std::slice::from_ref(&output),
+            temp.path(),
+        ),
+        StagedPlanOutcome::Unsupported(StagedPlanReason::OutputToStdout)
+    ));
+    assert!(matches!(
+        StagedCompilePlan::rustc(
+            temp.path(),
+            &["-o".into()],
+            &output,
+            std::slice::from_ref(&output),
+            temp.path(),
+        ),
+        StagedPlanOutcome::Unsupported(StagedPlanReason::MissingOptionValue)
+    ));
+    let duplicate_a: NormalizedPath = temp.path().join("one/same.rlib").into();
+    let duplicate_b: NormalizedPath = temp.path().join("two/same.rlib").into();
+    assert!(matches!(
+        StagedCompilePlan::rustc(
+            temp.path(),
+            &["--out-dir".into(), temp.path().display().to_string()],
+            &duplicate_a,
+            &[duplicate_a.clone(), duplicate_b],
+            temp.path(),
+        ),
+        StagedPlanOutcome::Unsupported(StagedPlanReason::OutputNameCollision)
+    ));
+    assert!(matches!(
+        StagedCompilePlan::cc(
+            temp.path(),
+            crate::compiler::CompilerFamily::Clang,
+            &["-c".into(), "hello.cpp".into(), "-fmodules".into()],
+            &output,
+            temp.path(),
+            &crate::depgraph::UserDepFlags::default(),
+        ),
+        StagedPlanOutcome::Unsupported(StagedPlanReason::UnmodeledSideOutput)
+    ));
+    let executable: NormalizedPath = temp.path().join("hello.exe").into();
+    assert!(matches!(
+        StagedCompilePlan::cc(
+            temp.path(),
+            crate::compiler::CompilerFamily::Clang,
+            &["-o".into(), "hello.exe".into()],
+            &executable,
+            temp.path(),
+            &crate::depgraph::UserDepFlags::default(),
+        ),
+        StagedPlanOutcome::Unsupported(StagedPlanReason::UnsupportedOutputRole)
+    ));
+    assert!(matches!(
+        StagedCompilePlan::cc(
+            temp.path(),
+            crate::compiler::CompilerFamily::Msvc,
+            &["/c".into(), "hello.cpp".into()],
+            &output,
+            temp.path(),
+            &crate::depgraph::UserDepFlags::default(),
+        ),
+        StagedPlanOutcome::Unsupported(StagedPlanReason::MissingRequiredOutputFlag)
+    ));
+    assert!(matches!(
+        StagedCompilePlan::cc(
+            temp.path(),
+            crate::compiler::CompilerFamily::Clang,
+            &["-o".into()],
+            &output,
+            temp.path(),
+            &crate::depgraph::UserDepFlags::default(),
+        ),
+        StagedPlanOutcome::Unsupported(StagedPlanReason::MissingOptionValue)
+    ));
+    let archive: NormalizedPath = temp.path().join("libhello.a").into();
+    assert!(matches!(
+        StagedCompilePlan::archive(
+            temp.path(),
+            &["rcs".into(), "different.a".into()],
+            &archive,
+            temp.path(),
+        ),
+        StagedPlanOutcome::Unsupported(StagedPlanReason::OutputNotInArguments)
+    ));
+}
+
+#[test]
+fn planner_errors_keep_precise_reasons() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let output: NormalizedPath = temp.path().join("hello.rlib").into();
+    let blocked_root = temp.path().join("not-a-directory");
+    std::fs::write(&blocked_root, b"file").unwrap();
+    assert!(matches!(
+        StagedCompilePlan::rustc(
+            &blocked_root,
+            &["-o".into(), "hello.rlib".into()],
+            &output,
+            std::slice::from_ref(&output),
+            temp.path(),
+        ),
+        StagedPlanOutcome::Error(StagedPlanError {
+            reason: StagedPlanReason::StagingDirectoryCreate,
+            ..
+        })
+    ));
+
+    let root_output: NormalizedPath = Path::new(std::path::MAIN_SEPARATOR_STR).into();
+    assert!(matches!(
+        StagedCompilePlan::rustc(
+            temp.path(),
+            &["-o".into(), root_output.to_string_lossy().into_owned()],
+            &root_output,
+            std::slice::from_ref(&root_output),
+            temp.path(),
+        ),
+        StagedPlanOutcome::Error(StagedPlanError {
+            reason: StagedPlanReason::OutputMissingFilename,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn link_plan_accepts_case_sensitive_gnu_map_option() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let primary: NormalizedPath = temp.path().join("app").into();
+    let map: NormalizedPath = temp.path().join("app.map").into();
+    let plan = StagedCompilePlan::link(
+        temp.path(),
+        &[
+            "-o".into(),
+            primary.to_string_lossy().into_owned(),
+            "-Map".into(),
+            map.to_string_lossy().into_owned(),
+        ],
+        &primary,
+        &[map],
+        temp.path(),
+    )
+    .unwrap();
+    assert!(plan.is_some());
+}

--- a/crates/zccache-daemon-core/src/daemon/staged_stats.rs
+++ b/crates/zccache-daemon-core/src/daemon/staged_stats.rs
@@ -86,6 +86,19 @@ const BYTES: &[(StagedBytes, &str)] = &[
 pub(crate) enum StagedFailure {
     UnsupportedShape,
     Planning,
+    PlanLaneDisabled,
+    PlanOutputToStdout,
+    PlanOutputNameCollision,
+    PlanUnmodeledSideOutput,
+    PlanUnsupportedOutputRole,
+    PlanMissingRequiredOutputFlag,
+    PlanMissingOptionValue,
+    PlanOutputMissingFilename,
+    PlanUnsupportedOutputPath,
+    PlanAmbiguousOutputArgument,
+    PlanOutputNotInArguments,
+    PlanNoDeclaredOutputs,
+    PlanStagingDirectoryCreate,
     OutputValidation,
     Hashing,
     DurableDigest,
@@ -100,6 +113,52 @@ pub(crate) enum StagedFailure {
 const FAILURES: &[(StagedFailure, &str)] = &[
     (StagedFailure::UnsupportedShape, "unsupported_shape"),
     (StagedFailure::Planning, "planning"),
+    (StagedFailure::PlanLaneDisabled, "plan_lane_disabled"),
+    (StagedFailure::PlanOutputToStdout, "plan_output_to_stdout"),
+    (
+        StagedFailure::PlanOutputNameCollision,
+        "plan_output_name_collision",
+    ),
+    (
+        StagedFailure::PlanUnmodeledSideOutput,
+        "plan_unmodeled_side_output",
+    ),
+    (
+        StagedFailure::PlanUnsupportedOutputRole,
+        "plan_unsupported_output_role",
+    ),
+    (
+        StagedFailure::PlanMissingRequiredOutputFlag,
+        "plan_missing_required_output_flag",
+    ),
+    (
+        StagedFailure::PlanMissingOptionValue,
+        "plan_missing_option_value",
+    ),
+    (
+        StagedFailure::PlanOutputMissingFilename,
+        "plan_output_missing_filename",
+    ),
+    (
+        StagedFailure::PlanUnsupportedOutputPath,
+        "plan_unsupported_output_path",
+    ),
+    (
+        StagedFailure::PlanAmbiguousOutputArgument,
+        "plan_ambiguous_output_argument",
+    ),
+    (
+        StagedFailure::PlanOutputNotInArguments,
+        "plan_output_not_in_arguments",
+    ),
+    (
+        StagedFailure::PlanNoDeclaredOutputs,
+        "plan_no_declared_outputs",
+    ),
+    (
+        StagedFailure::PlanStagingDirectoryCreate,
+        "plan_staging_directory_create",
+    ),
     (StagedFailure::OutputValidation, "output_validation"),
     (StagedFailure::Hashing, "hashing"),
     (StagedFailure::DurableDigest, "durable_digest"),

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -118,6 +118,18 @@ Issue: https://github.com/zackees/zccache/issues/1039
 - [ ] Validate on Windows 10 and Linux Docker, then run repo lint/test/review gates.
 - [ ] Push one PR with RED evidence, wait for GHA/review, fix, squash merge, verify issue closure.
 
+# #1056 immutable staged-output burn-down
+
+Parent: https://github.com/zackees/zccache/issues/1056
+Current child: https://github.com/zackees/zccache/issues/1071
+
+- [ ] Replace lossy staged planner `Option` results with enabled/unsupported/error outcomes.
+- [ ] Attribute every compile/archive/link/exact-exec rejection to one bounded stable reason.
+- [ ] Add deterministic publication, salvage, and materialization fault hooks and adversarial tests.
+- [ ] Validate #1071 on Windows and Linux Docker, merge its PR(s), then close the child.
+- [ ] Re-audit every remaining parent producer, filesystem, mutable-output, and perf exit gate.
+- [ ] Implement and merge all remaining parent slices before closing #1056.
+
 # Fix-forward after #1049 and soldr embedded-zccache integration
 
 - [x] Capture RED for the obsolete `soldr update-zccache` perf bootstrap.


### PR DESCRIPTION
Continues #1071 and parent #1056. Does not close #1071.\n\n## What changed\n\n- replace lossy compile/archive/link/exact-exec planner Option results with typed Enabled, Unsupported(reason), and Error(reason) outcomes;\n- expose 13 bounded, non-sensitive planner reason IDs through the existing staged session failure map;\n- preserve each lane's existing pre-spawn behavior: compile planning I/O errors remain explicit errors, while linker/exact-exec planning errors retain legacy fallback;\n- add adversarial reason tests for stdout, collisions, missing values/flags, unsupported roles/side outputs/paths, ambiguous or absent argv tokens, and staging-directory errors;\n- split oversized planner and generic-exec code/tests below the repository 1,000-line limit.\n\n## Validation\n\n- Windows daemon-core: 475 passed, 19 ignored, 0 failed\n- Linux Docker daemon-core: 477 passed, 19 ignored, 0 failed\n- staged planner focused: 18 passed\n- exact-exec enabled + disabled reason tests: passed\n- Linux rustfmt: exact\n- scoped Linux Clippy: passed (two untouched baseline lints explicitly allowed)\n- pre-push Rust review: clean\n\nDiagnostic note: forcing ZCCACHE_STAGED_ARTIFACTS=all exposes two existing link-cache failures; the sibling-side-effect failure reproduces unchanged on origin/main and remains parent #1056 work. The supported default configuration is fully green.