### PR TITLE
test(cache): add deterministic staged fault seams

### DIFF
--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -44,6 +44,10 @@
 //! | `version_mismatch` | daemon | client / daemon protocol versions disagree | `daemon_protocol_version`, `client_protocol_version`, `reason` |
 //! | `staged_publication_conflict` | daemon | one cache key produced two different valid generations; first generation retained | `cache_key`, `existing_generation`, `candidate_generation`, `elapsed_ns` |
 //! | `staged_publication_replaces_invalid_generation` | daemon | a corrupt/incomplete selected generation was replaced by a validated compile result | `cache_key`, `invalid_generation`, `replacement_generation` |
+//! | `staged_salvage_started` | daemon | publication/index failed after a successful compile; requested outputs are being recovered | `reason`, `output_count`, `copied_bytes`, `elapsed_ns` |
+//! | `staged_salvage_complete` | daemon | every requested output was independently recovered | `reason`, `output_count`, `copied_bytes`, `elapsed_ns` |
+//! | `staged_salvage_failed` | daemon | recovery stopped before the complete requested output set existed | `reason`, `output_count`, `copied_bytes`, `elapsed_ns` |
+//! | `staged_materialization_failed` | daemon | a published miss/hit could not fulfill every requested output path | `reason`, `output_count`, `copied_bytes`, `elapsed_ns` |
 //!
 //! ## Forensic walkthrough: the two-versions-on-one-pipe wedge
 //!

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
@@ -180,6 +180,7 @@ pub(super) fn materialize_cached_compile_hit(
         None => {
             if has_staged_payload {
                 use crate::daemon::staged_stats::{StagedCounter, StagedFailure, StagedTiming};
+                let elapsed_ns = t1.elapsed().as_nanos() as u64;
                 state
                     .profiler
                     .staged
@@ -188,9 +189,18 @@ pub(super) fn materialize_cached_compile_hit(
                     .profiler
                     .staged
                     .failure(StagedFailure::RequestedMaterialization);
-                state.profiler.staged.timing(
-                    StagedTiming::HitMaterialization,
-                    t1.elapsed().as_nanos() as u64,
+                state
+                    .profiler
+                    .staged
+                    .timing(StagedTiming::HitMaterialization, elapsed_ns);
+                crate::core::lifecycle::write_event(
+                    "staged_materialization_failed",
+                    serde_json::json!({
+                        "reason": "requested_materialization",
+                        "output_count": targets.len(),
+                        "copied_bytes": 0,
+                        "elapsed_ns": elapsed_ns,
+                    }),
                 );
             }
             return None;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
@@ -43,9 +43,44 @@ pub(super) struct MissArtifactStoreStats {
     pub(super) rust_snapshot_copy_count: u64,
     pub(super) rust_snapshot_copy_bytes: u64,
     pub(super) rust_snapshot_error_count: u64,
+    pub(super) staged_failure_reason: Option<&'static str>,
     pub(super) artifact_index_build_ns: u64,
     pub(super) artifact_index_persist_ns: u64,
     pub(super) artifact_memory_insert_ns: u64,
+}
+
+fn record_staged_publication_failure(state: &SharedState, reason: StagedPublishFailure) {
+    use crate::daemon::staged_stats::{StagedCounter, StagedFailure};
+    state
+        .profiler
+        .staged
+        .count(StagedCounter::PublicationFailure);
+    if reason == StagedPublishFailure::Conflict {
+        state
+            .profiler
+            .staged
+            .count(StagedCounter::PublicationConflict);
+        state
+            .profiler
+            .staged
+            .failure(StagedFailure::PublicationConflict);
+    } else {
+        state.profiler.staged.failure(reason.failure());
+    }
+}
+
+fn send_staged_index_insert(
+    state: &SharedState,
+    key: String,
+    metadata: ArtifactIndex,
+) -> Result<(), StagedPublishFailure> {
+    #[cfg(test)]
+    inject_staged_fault(&state.artifact_dir, StagedFaultPoint::IndexCommit)
+        .map_err(|_| StagedPublishFailure::IndexCommit)?;
+    state
+        .index_writer_tx
+        .send(IndexWriterCommand::Insert(key, metadata))
+        .map_err(|_| StagedPublishFailure::IndexCommit)
 }
 
 pub(super) fn store_miss_artifact(request: MissArtifactStoreRequest<'_>) -> MissArtifactStoreStats {
@@ -223,54 +258,58 @@ fn store_rustc_outputs(
     stats.rust_snapshot_ns = t_persist_sync.elapsed().as_nanos() as u64;
     let persisted = match sync_persist_result {
         Ok(snapshot_stats) => {
-            if snapshot_stats.staged {
-                use crate::daemon::staged_stats::{StagedBytes, StagedCounter, StagedTiming};
-                state
-                    .profiler
-                    .staged
-                    .count(StagedCounter::PublicationSuccess);
-                state
-                    .profiler
-                    .staged
-                    .timing(StagedTiming::Hashing, snapshot_stats.staged_hash_ns);
-                state.profiler.staged.timing(
-                    StagedTiming::Publication,
-                    snapshot_stats.staged_publication_ns,
-                );
-                state
-                    .profiler
-                    .staged
-                    .bytes(StagedBytes::Publication, snapshot_stats.copy_bytes);
-            }
             stats.rust_snapshot_hardlink_count = snapshot_stats.hardlink_count;
             stats.rust_snapshot_copy_count = snapshot_stats.copy_count;
             stats.rust_snapshot_copy_bytes = snapshot_stats.copy_bytes;
-            let _ = state.index_writer_tx.send(IndexWriterCommand::Insert(
-                artifact_key_hex.to_string(),
-                meta.clone(),
-            ));
-            true
+            let index_failure = if snapshot_stats.staged {
+                send_staged_index_insert(state, artifact_key_hex.to_string(), meta.clone()).err()
+            } else {
+                let _ = state.index_writer_tx.send(IndexWriterCommand::Insert(
+                    artifact_key_hex.to_string(),
+                    meta.clone(),
+                ));
+                None
+            };
+            if let Some(reason) = index_failure {
+                record_staged_publication_failure(state, reason);
+                stats.staged_failure_reason = Some(reason.id());
+                stats.rust_snapshot_error_count = stats.rust_snapshot_error_count.saturating_add(1);
+                tracing::warn!(
+                    key = %artifact_key_hex,
+                    reason = "index_commit",
+                    "staged artifact generation published but index commit failed"
+                );
+                false
+            } else {
+                if snapshot_stats.staged {
+                    use crate::daemon::staged_stats::{StagedBytes, StagedCounter, StagedTiming};
+                    state
+                        .profiler
+                        .staged
+                        .count(StagedCounter::PublicationSuccess);
+                    state
+                        .profiler
+                        .staged
+                        .timing(StagedTiming::Hashing, snapshot_stats.staged_hash_ns);
+                    state.profiler.staged.timing(
+                        StagedTiming::Publication,
+                        snapshot_stats.staged_publication_ns,
+                    );
+                    state
+                        .profiler
+                        .staged
+                        .bytes(StagedBytes::Publication, snapshot_stats.copy_bytes);
+                }
+                true
+            }
         }
         Err(e) => {
+            let failure_reason =
+                staged_publish_failure(&e).unwrap_or(StagedPublishFailure::StoreSetup);
             if synchronous_persist {
-                use crate::daemon::staged_stats::{StagedCounter, StagedFailure};
-                state
-                    .profiler
-                    .staged
-                    .count(StagedCounter::PublicationFailure);
-                if e.kind() == std::io::ErrorKind::AlreadyExists {
-                    state
-                        .profiler
-                        .staged
-                        .count(StagedCounter::PublicationConflict);
-                    state
-                        .profiler
-                        .staged
-                        .failure(StagedFailure::PublicationConflict);
-                } else {
-                    state.profiler.staged.failure(StagedFailure::Publication);
-                }
+                record_staged_publication_failure(state, failure_reason);
             }
+            stats.staged_failure_reason = Some(failure_reason.id());
             stats.rust_snapshot_error_count = stats.rust_snapshot_error_count.saturating_add(1);
             tracing::warn!(
                 key = %artifact_key_hex,
@@ -387,66 +426,67 @@ fn store_single_output(
         size: payload_size,
     };
     if synchronous_persist {
-        use crate::daemon::staged_stats::{
-            StagedBytes, StagedCounter, StagedFailure, StagedTiming,
-        };
+        use crate::daemon::staged_stats::{StagedBytes, StagedCounter, StagedTiming};
         let staged_publication =
             staged_artifacts_enabled() && staged_key_supported(&key_hex) && !pack_mode_enabled();
         let written =
             match persist_artifact_paths_with_stats(&artifact_dir, &key_hex, &source_paths) {
                 Ok(persisted) => {
-                    if persisted.staged {
-                        state
-                            .profiler
-                            .staged
-                            .count(StagedCounter::PublicationSuccess);
-                        state
-                            .profiler
-                            .staged
-                            .timing(StagedTiming::Hashing, persisted.staged_hash_ns);
-                        state
-                            .profiler
-                            .staged
-                            .timing(StagedTiming::Publication, persisted.staged_publication_ns);
-                        state
-                            .profiler
-                            .staged
-                            .bytes(StagedBytes::Publication, persisted.copy_bytes);
+                    let index_failure = if persisted.staged {
+                        send_staged_index_insert(state, key_hex.clone(), persist_meta.clone()).err()
+                    } else {
+                        None
+                    };
+                    if let Some(reason) = index_failure {
+                        stats.staged_failure_reason = Some(reason.id());
+                        stats.rust_snapshot_error_count =
+                            stats.rust_snapshot_error_count.saturating_add(1);
+                        record_staged_publication_failure(state, reason);
+                        false
+                    } else {
+                        if persisted.staged {
+                            state
+                                .profiler
+                                .staged
+                                .count(StagedCounter::PublicationSuccess);
+                            state
+                                .profiler
+                                .staged
+                                .timing(StagedTiming::Hashing, persisted.staged_hash_ns);
+                            state
+                                .profiler
+                                .staged
+                                .timing(StagedTiming::Publication, persisted.staged_publication_ns);
+                            state
+                                .profiler
+                                .staged
+                                .bytes(StagedBytes::Publication, persisted.copy_bytes);
+                        }
+                        true
                     }
-                    true
                 }
                 Err(error) => {
+                    let failure_reason =
+                        staged_publish_failure(&error).unwrap_or(StagedPublishFailure::StoreSetup);
                     stats.rust_snapshot_error_count =
                         stats.rust_snapshot_error_count.saturating_add(1);
+                    stats.staged_failure_reason = Some(failure_reason.id());
                     if staged_publication {
-                        state
-                            .profiler
-                            .staged
-                            .count(StagedCounter::PublicationFailure);
-                        if error.kind() == std::io::ErrorKind::AlreadyExists {
-                            state
-                                .profiler
-                                .staged
-                                .count(StagedCounter::PublicationConflict);
-                            state
-                                .profiler
-                                .staged
-                                .failure(StagedFailure::PublicationConflict);
-                        } else {
-                            state.profiler.staged.failure(StagedFailure::Publication);
-                        }
+                        record_staged_publication_failure(state, failure_reason);
                     }
                     false
                 }
             };
-        if written {
+        if written && !staged_publication {
             let _ = state.index_writer_tx.send(IndexWriterCommand::Insert(
                 key_hex.clone(),
                 persist_meta.clone(),
             ));
         }
         stats.persist_enqueue_ns = t_persist_enqueue.elapsed().as_nanos() as u64;
-        state.artifacts.insert(artifact_key_hex.to_string(), cached);
+        if written {
+            state.artifacts.insert(artifact_key_hex.to_string(), cached);
+        }
         let latency_ns = compile_start.elapsed().as_nanos() as u64;
         state.stats.record_miss(latency_ns, artifact_bytes);
         let src = source_path.clone();

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -542,6 +542,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         rust_snapshot_copy_count,
         rust_snapshot_copy_bytes,
         rust_snapshot_error_count,
+        staged_failure_reason,
         artifact_index_build_ns,
         artifact_index_persist_ns,
         artifact_memory_insert_ns,
@@ -574,13 +575,19 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
             StagedBytes, StagedCounter, StagedFailure, StagedTiming,
         };
         let salvage = rust_snapshot_error_count > 0;
+        let salvage_reason = staged_failure_reason.unwrap_or("publication");
         let output_count = plan.output_paths().len();
         let materialize_started = std::time::Instant::now();
         if salvage {
             state.profiler.staged.count(StagedCounter::SalvageAttempt);
             crate::core::lifecycle::write_event(
                 "staged_salvage_started",
-                serde_json::json!({ "output_count": output_count }),
+                serde_json::json!({
+                    "reason": salvage_reason,
+                    "output_count": output_count,
+                    "copied_bytes": 0,
+                    "elapsed_ns": 0,
+                }),
             );
         }
         match plan.materialize() {
@@ -611,6 +618,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
                     crate::core::lifecycle::write_event(
                         "staged_salvage_complete",
                         serde_json::json!({
+                            "reason": salvage_reason,
                             "output_count": output_count,
                             "copied_bytes": materialized.copy_bytes,
                             "elapsed_ns": elapsed_ns,
@@ -625,6 +633,19 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
             }
             Err(error) => {
                 let elapsed_ns = materialize_started.elapsed().as_nanos() as u64;
+                let progress = materialization_error_progress(&error);
+                state
+                    .profiler
+                    .staged
+                    .add_count(StagedCounter::MaterializeReflink, progress.reflink_count);
+                state
+                    .profiler
+                    .staged
+                    .add_count(StagedCounter::MaterializeCopy, progress.copy_count);
+                state
+                    .profiler
+                    .staged
+                    .bytes(StagedBytes::Materialization, progress.copy_bytes);
                 state
                     .profiler
                     .staged
@@ -640,11 +661,16 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
                         .profiler
                         .staged
                         .timing(StagedTiming::Salvage, elapsed_ns);
+                    state
+                        .profiler
+                        .staged
+                        .bytes(StagedBytes::Salvage, progress.copy_bytes);
                     crate::core::lifecycle::write_event(
                         "staged_salvage_failed",
                         serde_json::json!({
                             "reason": "requested_materialization",
                             "output_count": output_count,
+                            "copied_bytes": progress.copy_bytes,
                             "elapsed_ns": elapsed_ns,
                         }),
                     );
@@ -658,6 +684,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
                         serde_json::json!({
                             "reason": "requested_materialization",
                             "output_count": output_count,
+                            "copied_bytes": progress.copy_bytes,
                             "elapsed_ns": elapsed_ns,
                         }),
                     );

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
@@ -112,18 +112,32 @@ impl ExecStagedPlan {
 
     fn materialize(&self) -> std::io::Result<StagedMaterializationStats> {
         let mut observed = StagedMaterializationStats::default();
+        #[cfg(test)]
+        let mut fault_index = 0;
         for (requested, staged) in &self.outputs {
-            if let Some(parent) = requested.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            observed.add(
-                crate::daemon::server::persist::materialize_independent_with_stats(
-                    staged.as_path(),
+            #[cfg(test)]
+            {
+                let index = fault_index;
+                fault_index += 1;
+                inject_staged_fault(
                     requested.as_path(),
-                )?,
-            );
+                    StagedFaultPoint::MaterializeOutput(index),
+                )
+                .map_err(|error| materialization_error(error, observed))?;
+            }
+            if let Some(parent) = requested.parent() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|error| materialization_error(error, observed))?;
+            }
+            let output = crate::daemon::server::persist::materialize_independent_with_stats(
+                staged.as_path(),
+                requested.as_path(),
+            )
+            .map_err(|error| materialization_error(error, observed))?;
+            observed.add(output);
         }
-        self.cleanup()?;
+        self.cleanup()
+            .map_err(|error| materialization_error(error, observed))?;
         Ok(observed)
     }
 
@@ -509,6 +523,20 @@ pub(super) async fn handle_generic_tool_exec(
                 );
             }
             Err(error) => {
+                let elapsed_ns = materialize_started.elapsed().as_nanos() as u64;
+                let progress = materialization_error_progress(&error);
+                state
+                    .profiler
+                    .staged
+                    .add_count(StagedCounter::MaterializeReflink, progress.reflink_count);
+                state
+                    .profiler
+                    .staged
+                    .add_count(StagedCounter::MaterializeCopy, progress.copy_count);
+                state
+                    .profiler
+                    .staged
+                    .bytes(StagedBytes::Materialization, progress.copy_bytes);
                 state
                     .profiler
                     .staged
@@ -517,6 +545,19 @@ pub(super) async fn handle_generic_tool_exec(
                     .profiler
                     .staged
                     .failure(StagedFailure::RequestedMaterialization);
+                state
+                    .profiler
+                    .staged
+                    .timing(StagedTiming::MissMaterialization, elapsed_ns);
+                crate::core::lifecycle::write_event(
+                    "staged_materialization_failed",
+                    serde_json::json!({
+                        "reason": "requested_materialization",
+                        "output_count": plan.outputs.len(),
+                        "copied_bytes": progress.copy_bytes,
+                        "elapsed_ns": elapsed_ns,
+                    }),
+                );
                 return Response::Error {
                     message: format!("failed to materialize generic tool outputs: {error}"),
                 };
@@ -904,76 +945,8 @@ fn normalize_for_key(path: &Path) -> String {
 }
 
 #[cfg(test)]
-mod coalesce_tests {
-    //! Issue #971: `coalesce_wait` must never strand a waiter — not on a
-    //! lost wakeup (mode 1), not on a replaced slot (mode 2), and not on a
-    //! wedged owner (mode 3, bounded fallback).
-    use super::{coalesce_wait, CoalesceOutcome};
-    use dashmap::DashMap;
-    use std::sync::Arc;
-    use std::time::Duration;
-    use tokio::sync::Notify;
-
-    /// Fail fast instead of hanging the suite if a regression reintroduces the
-    /// wedge these tests exist to prevent.
-    async fn guarded(fut: impl std::future::Future<Output = CoalesceOutcome>) -> CoalesceOutcome {
-        tokio::time::timeout(Duration::from_secs(30), fut)
-            .await
-            .expect("coalesce_wait hung — the #971 fix regressed")
-    }
-
-    #[tokio::test]
-    async fn slot_gone_resolves_without_waiting() {
-        // Owner already finished and removed the slot before we parked. The
-        // re-check must see it gone and return immediately rather than block on
-        // a notify that will never fire again (the mode-1 lost-wakeup guard).
-        let map: DashMap<String, Arc<Notify>> = DashMap::new();
-        let ours = Arc::new(Notify::new()); // key is NOT in the map
-        let out = guarded(coalesce_wait(&map, "k", ours, Duration::from_secs(30))).await;
-        assert_eq!(out, CoalesceOutcome::SlotResolved);
-    }
-
-    #[tokio::test]
-    async fn slot_replaced_resolves() {
-        // A new owner installed a different Notify for the same key. Parking on
-        // our stale Arc would hang forever; the ptr_eq re-check returns instead.
-        let map: DashMap<String, Arc<Notify>> = DashMap::new();
-        let ours = Arc::new(Notify::new());
-        map.insert("k".to_string(), Arc::new(Notify::new())); // different Arc
-        let out = guarded(coalesce_wait(&map, "k", ours, Duration::from_secs(30))).await;
-        assert_eq!(out, CoalesceOutcome::SlotResolved);
-    }
-
-    #[tokio::test]
-    async fn woken_by_owner_notify() {
-        // Normal path: we hold the same Arc that is in the map; a sibling task
-        // fires notify_waiters and we wake.
-        let map: DashMap<String, Arc<Notify>> = DashMap::new();
-        let shared = Arc::new(Notify::new());
-        map.insert("k".to_string(), Arc::clone(&shared));
-        let waker = {
-            let shared = Arc::clone(&shared);
-            tokio::spawn(async move {
-                tokio::time::sleep(Duration::from_millis(20)).await;
-                shared.notify_waiters();
-            })
-        };
-        let out = guarded(coalesce_wait(&map, "k", shared, Duration::from_secs(30))).await;
-        assert_eq!(out, CoalesceOutcome::Woken);
-        waker.await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn times_out_when_owner_wedged() {
-        // Owner holds the slot and never fires: the waiter must fall back after
-        // the budget (mode-3 bounded wait) rather than hang forever.
-        let map: DashMap<String, Arc<Notify>> = DashMap::new();
-        let shared = Arc::new(Notify::new());
-        map.insert("k".to_string(), Arc::clone(&shared));
-        let out = guarded(coalesce_wait(&map, "k", shared, Duration::from_millis(50))).await;
-        assert_eq!(out, CoalesceOutcome::TimedOut);
-    }
-}
+#[path = "handle_exec_coalesce_tests.rs"]
+mod coalesce_tests;
 
 #[cfg(test)]
 #[path = "handle_exec_tests.rs"]

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec_coalesce_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec_coalesce_tests.rs
@@ -1,0 +1,56 @@
+//! Deterministic coverage for the exact-exec coalescing races from #971.
+
+use super::{coalesce_wait, CoalesceOutcome};
+use dashmap::DashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Notify;
+
+async fn guarded(future: impl std::future::Future<Output = CoalesceOutcome>) -> CoalesceOutcome {
+    tokio::time::timeout(Duration::from_secs(30), future)
+        .await
+        .expect("coalesce_wait hung — the #971 fix regressed")
+}
+
+#[tokio::test]
+async fn slot_gone_resolves_without_waiting() {
+    let map = DashMap::new();
+    let ours = Arc::new(Notify::new());
+    let outcome = guarded(coalesce_wait(&map, "k", ours, Duration::from_secs(30))).await;
+    assert_eq!(outcome, CoalesceOutcome::SlotResolved);
+}
+
+#[tokio::test]
+async fn slot_replaced_resolves_without_waiting() {
+    let map = DashMap::new();
+    let ours = Arc::new(Notify::new());
+    map.insert("k".to_string(), Arc::new(Notify::new()));
+    let outcome = guarded(coalesce_wait(&map, "k", ours, Duration::from_secs(30))).await;
+    assert_eq!(outcome, CoalesceOutcome::SlotResolved);
+}
+
+#[tokio::test]
+async fn owner_notification_wakes_waiter() {
+    let map = DashMap::new();
+    let shared = Arc::new(Notify::new());
+    map.insert("k".to_string(), Arc::clone(&shared));
+    let waker = {
+        let shared = Arc::clone(&shared);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            shared.notify_waiters();
+        })
+    };
+    let outcome = guarded(coalesce_wait(&map, "k", shared, Duration::from_secs(30))).await;
+    assert_eq!(outcome, CoalesceOutcome::Woken);
+    waker.await.unwrap();
+}
+
+#[tokio::test]
+async fn wedged_owner_times_out() {
+    let map = DashMap::new();
+    let shared = Arc::new(Notify::new());
+    map.insert("k".to_string(), Arc::clone(&shared));
+    let outcome = guarded(coalesce_wait(&map, "k", shared, Duration::from_millis(50))).await;
+    assert_eq!(outcome, CoalesceOutcome::TimedOut);
+}

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -29,6 +29,20 @@ fn materialize_link_plan_observed(
             Ok(())
         }
         Err(error) => {
+            let elapsed_ns = started.elapsed().as_nanos() as u64;
+            let progress = materialization_error_progress(&error);
+            state
+                .profiler
+                .staged
+                .add_count(StagedCounter::MaterializeReflink, progress.reflink_count);
+            state
+                .profiler
+                .staged
+                .add_count(StagedCounter::MaterializeCopy, progress.copy_count);
+            state
+                .profiler
+                .staged
+                .bytes(StagedBytes::Materialization, progress.copy_bytes);
             state
                 .profiler
                 .staged
@@ -37,9 +51,18 @@ fn materialize_link_plan_observed(
                 .profiler
                 .staged
                 .failure(StagedFailure::RequestedMaterialization);
-            state.profiler.staged.timing(
-                StagedTiming::MissMaterialization,
-                started.elapsed().as_nanos() as u64,
+            state
+                .profiler
+                .staged
+                .timing(StagedTiming::MissMaterialization, elapsed_ns);
+            crate::core::lifecycle::write_event(
+                "staged_materialization_failed",
+                serde_json::json!({
+                    "reason": "requested_materialization",
+                    "output_count": plan.output_paths().len(),
+                    "copied_bytes": progress.copy_bytes,
+                    "elapsed_ns": elapsed_ns,
+                }),
             );
             Err(error)
         }

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
@@ -4,7 +4,11 @@
 //! redirected before it starts, and unsupported output shapes must fall back
 //! before spawn rather than publishing a partial set afterwards.
 
-use super::staged_store::{staged_lane_enabled, StagedMaterializationStats};
+#[cfg(test)]
+use super::staged_store::materialization_error_progress;
+#[cfg(test)]
+use super::staged_store::{inject_staged_fault, StagedFaultGuard, StagedFaultPoint};
+use super::staged_store::{materialization_error, staged_lane_enabled, StagedMaterializationStats};
 use crate::core::path::NormalizedPath;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -101,17 +105,6 @@ pub(in crate::daemon::server) enum StagedPlanOutcome<T> {
     Enabled(T),
     Unsupported(StagedPlanReason),
     Error(StagedPlanError),
-}
-
-#[cfg(test)]
-impl<T> StagedPlanOutcome<T> {
-    fn unwrap(self) -> Option<T> {
-        match self {
-            Self::Enabled(value) => Some(value),
-            Self::Unsupported(_) => None,
-            Self::Error(error) => panic!("planner failed: {:?}: {}", error.reason, error.source),
-        }
-    }
 }
 
 fn planning_error(reason: StagedPlanReason, source: io::Error) -> StagedPlanError {
@@ -715,22 +708,38 @@ impl StagedCompilePlan {
 
     pub(in crate::daemon::server) fn materialize(&self) -> io::Result<StagedMaterializationStats> {
         let mut stats = StagedMaterializationStats::default();
+        #[cfg(test)]
+        let mut fault_index = 0;
         for output in &self.outputs {
+            #[cfg(test)]
+            {
+                let index = fault_index;
+                fault_index += 1;
+                inject_staged_fault(
+                    output.requested.as_path(),
+                    StagedFaultPoint::MaterializeOutput(index),
+                )
+                .map_err(|error| materialization_error(error, stats))?;
+            }
             if let Some(parent) = output.requested.parent() {
-                std::fs::create_dir_all(parent)?;
+                std::fs::create_dir_all(parent)
+                    .map_err(|error| materialization_error(error, stats))?;
             }
             let output_stats = crate::daemon::server::persist::materialize_independent_with_stats(
                 output.staged.as_path(),
                 output.requested.as_path(),
             )
             .map_err(|error| {
-                io::Error::new(
-                    error.kind(),
-                    format!(
-                        "{} -> {}: {error}",
-                        output.staged.display(),
-                        output.requested.display()
+                materialization_error(
+                    io::Error::new(
+                        error.kind(),
+                        format!(
+                            "{} -> {}: {error}",
+                            output.staged.display(),
+                            output.requested.display()
+                        ),
                     ),
+                    stats,
                 )
             })?;
             stats.reflink_count = stats
@@ -739,7 +748,8 @@ impl StagedCompilePlan {
             stats.copy_count = stats.copy_count.saturating_add(output_stats.copy_count);
             stats.copy_bytes = stats.copy_bytes.saturating_add(output_stats.copy_bytes);
         }
-        self.cleanup()?;
+        self.cleanup()
+            .map_err(|error| materialization_error(error, stats))?;
         Ok(stats)
     }
 

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan_tests.rs
@@ -2,6 +2,16 @@
 use super::*;
 use tempfile::tempdir;
 
+impl<T> StagedPlanOutcome<T> {
+    fn unwrap(self) -> Option<T> {
+        match self {
+            Self::Enabled(value) => Some(value),
+            Self::Unsupported(_) => None,
+            Self::Error(error) => panic!("planner failed: {:?}: {}", error.reason, error.source),
+        }
+    }
+}
+
 fn staged_tests_enabled() -> bool {
     std::env::var_os(super::super::staged_store::STAGED_ARTIFACTS_ENV).is_some()
 }
@@ -545,6 +555,36 @@ fn planner_errors_keep_precise_reasons() {
             ..
         })
     ));
+}
+
+#[test]
+fn output_fault_stops_partial_salvage_before_completion() {
+    if !staged_tests_enabled() {
+        return;
+    }
+    let temp = tempdir().unwrap();
+    let archive: NormalizedPath = temp.path().join("target/libx.rlib").into();
+    let metadata: NormalizedPath = temp.path().join("target/libx.rmeta").into();
+    let plan = StagedCompilePlan::rustc(
+        temp.path(),
+        &["--out-dir".into(), temp.path().display().to_string()],
+        &archive,
+        &[archive.clone(), metadata.clone()],
+        temp.path(),
+    )
+    .unwrap()
+    .unwrap();
+    for (index, staged) in plan.output_paths().iter().enumerate() {
+        std::fs::write(staged, format!("complete output {index}")).unwrap();
+    }
+    let fault = StagedFaultGuard::arm(temp.path(), [StagedFaultPoint::MaterializeOutput(1)]);
+    let error = plan.materialize().unwrap_err();
+    let progress = materialization_error_progress(&error);
+    assert_eq!(progress.reflink_count + progress.copy_count, 1);
+    assert!(progress.copy_bytes == 0 || progress.copy_bytes == 17);
+    assert_eq!(std::fs::read(&archive).unwrap(), b"complete output 0");
+    assert!(!metadata.exists());
+    fault.assert_all_consumed();
 }
 
 #[test]

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -18,7 +18,14 @@ pub(crate) use maintenance::{
 };
 mod materialize;
 pub(in crate::daemon::server) use materialize::{
-    materialize_independent_with_stats, StagedMaterializationStats,
+    materialization_error, materialization_error_progress, materialize_independent_with_stats,
+    StagedMaterializationStats,
+};
+#[cfg(test)]
+mod fault;
+#[cfg(test)]
+pub(in crate::daemon::server) use fault::{
+    inject as inject_staged_fault, StagedFaultGuard, StagedFaultPoint,
 };
 
 pub(in crate::daemon::server) const STAGED_ARTIFACTS_ENV: &str = "ZCCACHE_STAGED_ARTIFACTS";
@@ -29,6 +36,83 @@ const PUBLISH_LOCK: &str = ".publish.lock";
 const STORE_LOCK: &str = ".store.lock";
 
 static STAGED_ARTIFACT_TMP_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::daemon::server) enum StagedPublishFailure {
+    StoreSetup,
+    OutputCopy,
+    Hash,
+    DurableDigest,
+    Manifest,
+    GenerationPublish,
+    PointerCommit,
+    IndexCommit,
+    Conflict,
+}
+
+impl StagedPublishFailure {
+    pub(in crate::daemon::server) const fn id(self) -> &'static str {
+        match self {
+            Self::StoreSetup => "publication",
+            Self::OutputCopy => "publication_output_copy",
+            Self::Hash => "hashing",
+            Self::DurableDigest => "durable_digest",
+            Self::Manifest => "manifest",
+            Self::GenerationPublish => "generation_publish",
+            Self::PointerCommit => "pointer_commit",
+            Self::IndexCommit => "index_commit",
+            Self::Conflict => "publication_conflict",
+        }
+    }
+
+    pub(in crate::daemon::server) const fn failure(
+        self,
+    ) -> crate::daemon::staged_stats::StagedFailure {
+        use crate::daemon::staged_stats::StagedFailure;
+        match self {
+            Self::StoreSetup => StagedFailure::Publication,
+            Self::OutputCopy => StagedFailure::PublicationOutputCopy,
+            Self::Hash => StagedFailure::Hashing,
+            Self::DurableDigest => StagedFailure::DurableDigest,
+            Self::Manifest => StagedFailure::Manifest,
+            Self::GenerationPublish => StagedFailure::GenerationPublish,
+            Self::PointerCommit => StagedFailure::PointerCommit,
+            Self::IndexCommit => StagedFailure::IndexCommit,
+            Self::Conflict => StagedFailure::PublicationConflict,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct StagedPublishError {
+    reason: StagedPublishFailure,
+    source: io::Error,
+}
+
+impl std::fmt::Display for StagedPublishError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.source.fmt(formatter)
+    }
+}
+
+impl std::error::Error for StagedPublishError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+fn publish_error(reason: StagedPublishFailure, source: io::Error) -> io::Error {
+    io::Error::new(source.kind(), StagedPublishError { reason, source })
+}
+
+pub(in crate::daemon::server) fn staged_publish_failure(
+    error: &io::Error,
+) -> Option<StagedPublishFailure> {
+    error
+        .get_ref()
+        .and_then(|source| source.downcast_ref::<StagedPublishError>())
+        .map(|error| error.reason)
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct StagedManifest {
@@ -255,7 +339,17 @@ fn replace_staged_path(source: &Path, destination: &Path) -> io::Result<()> {
 }
 
 fn copy_independent(source: &Path, destination: &Path) -> io::Result<(bool, u64)> {
-    if reflink_copy::reflink(source, destination).is_ok() {
+    let reflink_allowed = {
+        #[cfg(test)]
+        {
+            fault::inject(destination, StagedFaultPoint::MaterializeReflink).is_ok()
+        }
+        #[cfg(not(test))]
+        {
+            true
+        }
+    };
+    if reflink_allowed && reflink_copy::reflink(source, destination).is_ok() {
         return Ok((true, 0));
     }
     // A failed reflink probe may leave a partial destination, including
@@ -264,6 +358,8 @@ fn copy_independent(source: &Path, destination: &Path) -> io::Result<(bool, u64)
         let _ = set_readonly(destination, false);
     }
     let _ = fs::remove_file(destination);
+    #[cfg(test)]
+    fault::inject(destination, StagedFaultPoint::MaterializeCopy)?;
     let bytes = fs::copy(source, destination)?;
     Ok((false, bytes))
 }
@@ -399,23 +495,32 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
     }
 
     let root = staged_root(artifact_dir);
-    let store_lock = open_store_lock(&root)?;
-    fs2::FileExt::lock_shared(&store_lock)?;
+    let store_lock = open_store_lock(&root)
+        .map_err(|error| publish_error(StagedPublishFailure::StoreSetup, error))?;
+    fs2::FileExt::lock_shared(&store_lock)
+        .map_err(|error| publish_error(StagedPublishFailure::StoreSetup, error))?;
     let key_root = root.join(key_hex);
-    fs::create_dir_all(&key_root)?;
+    fs::create_dir_all(&key_root)
+        .map_err(|error| publish_error(StagedPublishFailure::StoreSetup, error))?;
     let publish_lock = OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
         .truncate(false)
-        .open(key_root.join(PUBLISH_LOCK))?;
-    fs2::FileExt::lock_exclusive(&publish_lock)?;
+        .open(key_root.join(PUBLISH_LOCK))
+        .map_err(|error| publish_error(StagedPublishFailure::StoreSetup, error))?;
+    fs2::FileExt::lock_exclusive(&publish_lock)
+        .map_err(|error| publish_error(StagedPublishFailure::StoreSetup, error))?;
     let temporary_generation = key_root.join(format!(
         ".tmp-{}-{}",
         std::process::id(),
         STAGED_ARTIFACT_TMP_COUNTER.fetch_add(1, Ordering::Relaxed)
     ));
-    fs::create_dir(&temporary_generation)?;
+    #[cfg(test)]
+    fault::inject(artifact_dir, StagedFaultPoint::GenerationCreate)
+        .map_err(|error| publish_error(StagedPublishFailure::StoreSetup, error))?;
+    fs::create_dir(&temporary_generation)
+        .map_err(|error| publish_error(StagedPublishFailure::StoreSetup, error))?;
 
     let result = (|| {
         let mut outputs = Vec::with_capacity(sources.len());
@@ -425,36 +530,54 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
         };
         for (index, source) in sources.iter().enumerate() {
             let destination = output_path(&temporary_generation, index);
+            #[cfg(test)]
+            fault::inject(artifact_dir, StagedFaultPoint::OutputCopy(index))
+                .map_err(|error| publish_error(StagedPublishFailure::OutputCopy, error))?;
             let (reflink, copied_bytes) =
                 copy_output(source.as_path(), &destination).map_err(|error| {
-                    io::Error::new(
-                        error.kind(),
-                        format!(
-                            "staged output copy failed: {} -> {}: {error}",
-                            source.display(),
-                            destination.display()
+                    publish_error(
+                        StagedPublishFailure::OutputCopy,
+                        io::Error::new(
+                            error.kind(),
+                            format!(
+                                "staged output copy failed: {} -> {}: {error}",
+                                source.display(),
+                                destination.display()
+                            ),
                         ),
                     )
                 })?;
             let hash_started = std::time::Instant::now();
+            #[cfg(test)]
+            fault::inject(artifact_dir, StagedFaultPoint::OutputHash(index))
+                .map_err(|error| publish_error(StagedPublishFailure::Hash, error))?;
             let (size, digest_hex) = digest_file(&destination).map_err(|error| {
-                io::Error::new(
-                    error.kind(),
-                    format!(
-                        "staged output hash failed: {}: {error}",
-                        destination.display()
+                publish_error(
+                    StagedPublishFailure::Hash,
+                    io::Error::new(
+                        error.kind(),
+                        format!(
+                            "staged output hash failed: {}: {error}",
+                            destination.display()
+                        ),
                     ),
                 )
             })?;
             stats.staged_hash_ns = stats
                 .staged_hash_ns
                 .saturating_add(hash_started.elapsed().as_nanos() as u64);
+            #[cfg(test)]
+            fault::inject(artifact_dir, StagedFaultPoint::DurableDigest(index))
+                .map_err(|error| publish_error(StagedPublishFailure::DurableDigest, error))?;
             write_authoritative_blob_digest_for(&destination, &destination).map_err(|error| {
-                io::Error::new(
-                    error.kind(),
-                    format!(
-                        "staged output durable digest failed: {}: {error}",
-                        destination.display()
+                publish_error(
+                    StagedPublishFailure::DurableDigest,
+                    io::Error::new(
+                        error.kind(),
+                        format!(
+                            "staged output durable digest failed: {}: {error}",
+                            destination.display()
+                        ),
                     ),
                 )
             })?;
@@ -495,9 +618,12 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
                         candidate_generation = generation_hex,
                         "same cache key produced a different complete output generation"
                     );
-                    return Err(io::Error::new(
-                        io::ErrorKind::AlreadyExists,
-                        "same cache key produced different staged output bytes",
+                    return Err(publish_error(
+                        StagedPublishFailure::Conflict,
+                        io::Error::new(
+                            io::ErrorKind::AlreadyExists,
+                            "same cache key produced different staged output bytes",
+                        ),
                     ));
                 }
                 crate::core::lifecycle::write_event(
@@ -522,57 +648,101 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
             outputs,
         };
         let manifest_bytes = bincode::serialize(&manifest).map_err(|error| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("staged manifest encode failed: {error}"),
+            publish_error(
+                StagedPublishFailure::Manifest,
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("staged manifest encode failed: {error}"),
+                ),
             )
         })?;
         let temporary_manifest = manifest_path(&temporary_generation);
+        #[cfg(test)]
+        fault::inject(artifact_dir, StagedFaultPoint::ManifestWrite)
+            .map_err(|error| publish_error(StagedPublishFailure::Manifest, error))?;
         fs::write(&temporary_manifest, manifest_bytes).map_err(|error| {
-            io::Error::new(
-                error.kind(),
-                format!("staged manifest write failed: {error}"),
+            publish_error(
+                StagedPublishFailure::Manifest,
+                io::Error::new(
+                    error.kind(),
+                    format!("staged manifest write failed: {error}"),
+                ),
             )
         })?;
+        #[cfg(test)]
+        fault::inject(artifact_dir, StagedFaultPoint::ManifestSync)
+            .map_err(|error| publish_error(StagedPublishFailure::Manifest, error))?;
         sync_file(&temporary_manifest).map_err(|error| {
-            io::Error::new(
-                error.kind(),
-                format!("staged manifest sync failed: {error}"),
+            publish_error(
+                StagedPublishFailure::Manifest,
+                io::Error::new(
+                    error.kind(),
+                    format!("staged manifest sync failed: {error}"),
+                ),
             )
         })?;
+        #[cfg(test)]
+        fault::inject(artifact_dir, StagedFaultPoint::GenerationSync)
+            .map_err(|error| publish_error(StagedPublishFailure::GenerationPublish, error))?;
         sync_directory(&temporary_generation).map_err(|error| {
-            io::Error::new(
-                error.kind(),
-                format!("staged generation sync failed: {error}"),
+            publish_error(
+                StagedPublishFailure::GenerationPublish,
+                io::Error::new(
+                    error.kind(),
+                    format!("staged generation sync failed: {error}"),
+                ),
             )
         })?;
 
+        #[cfg(test)]
+        fault::inject(artifact_dir, StagedFaultPoint::GenerationPublish)
+            .map_err(|error| publish_error(StagedPublishFailure::GenerationPublish, error))?;
         match fs::rename(&temporary_generation, &final_generation) {
             Ok(()) => {}
             Err(error) if final_generation.exists() => {
                 let _ = error;
                 let _ = fs::remove_dir_all(&temporary_generation);
             }
-            Err(error) => return Err(error),
+            Err(error) => {
+                return Err(publish_error(
+                    StagedPublishFailure::GenerationPublish,
+                    error,
+                ));
+            }
         }
         sync_directory(&key_root).map_err(|error| {
-            io::Error::new(
-                error.kind(),
-                format!("staged generation parent sync failed: {error}"),
+            publish_error(
+                StagedPublishFailure::GenerationPublish,
+                io::Error::new(
+                    error.kind(),
+                    format!("staged generation parent sync failed: {error}"),
+                ),
             )
         })?;
 
+        #[cfg(test)]
+        fault::inject(artifact_dir, StagedFaultPoint::PointerCommit)
+            .map_err(|error| publish_error(StagedPublishFailure::PointerCommit, error))?;
         atomic_write(&pointer, generation_hex.as_bytes()).map_err(|error| {
-            io::Error::new(
-                error.kind(),
-                format!("staged generation pointer publish failed: {error}"),
+            publish_error(
+                StagedPublishFailure::PointerCommit,
+                io::Error::new(
+                    error.kind(),
+                    format!("staged generation pointer publish failed: {error}"),
+                ),
             )
         })?;
         if let Some(parent) = pointer.parent() {
+            #[cfg(test)]
+            fault::inject(artifact_dir, StagedFaultPoint::PointerSync)
+                .map_err(|error| publish_error(StagedPublishFailure::PointerCommit, error))?;
             sync_directory(parent).map_err(|error| {
-                io::Error::new(
-                    error.kind(),
-                    format!("staged pointer parent sync failed: {error}"),
+                publish_error(
+                    StagedPublishFailure::PointerCommit,
+                    io::Error::new(
+                        error.kind(),
+                        format!("staged pointer parent sync failed: {error}"),
+                    ),
                 )
             })?;
         }
@@ -774,301 +944,5 @@ pub(in crate::daemon::server) fn clear_staged_artifacts(artifact_dir: &Path) -> 
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-
-    fn source_files(dir: &Path) -> Vec<NormalizedPath> {
-        let first = dir.join("source-a.rlib");
-        let second = dir.join("source-b.rmeta");
-        fs::write(&first, b"first immutable payload").unwrap();
-        fs::write(&second, b"second immutable payload").unwrap();
-        vec![first.into(), second.into()]
-    }
-
-    #[test]
-    fn staged_generation_is_independent_and_hash_addressed() {
-        let dir = tempfile::tempdir().unwrap();
-        let artifact_dir = dir.path().join("artifacts");
-        fs::create_dir_all(&artifact_dir).unwrap();
-        let sources = source_files(dir.path());
-        let stats =
-            persist_staged_artifact_paths(&artifact_dir, &"a".repeat(64), &sources).unwrap();
-
-        assert_eq!(stats.hardlink_count, 0);
-        assert_eq!(stats.reflink_count + stats.copy_count, 2);
-
-        let payloads = load_staged_artifact_paths(&artifact_dir, &"a".repeat(64), &[23, 24])
-            .unwrap()
-            .unwrap();
-        assert_eq!(payloads.len(), 2);
-        assert_eq!(fs::read(&payloads[0]).unwrap(), b"first immutable payload");
-        assert_eq!(fs::read(&payloads[1]).unwrap(), b"second immutable payload");
-        assert!(!same_file(sources[0].as_path(), payloads[0].as_path()));
-        assert!(fs::metadata(&payloads[0]).unwrap().permissions().readonly());
-
-        fs::write(&sources[0], b"mutated compiler output").unwrap();
-        assert_eq!(fs::read(&payloads[0]).unwrap(), b"first immutable payload");
-
-        let pointer = artifact_dir
-            .join(STAGED_ROOT)
-            .join(format!("{}.current", "a".repeat(64)));
-        let generation = fs::read_to_string(pointer).unwrap();
-        assert_eq!(generation.trim().len(), 64);
-        assert!(generation
-            .trim()
-            .bytes()
-            .all(|byte| byte.is_ascii_hexdigit()));
-        assert!(!is_staged_artifact_path(
-            &artifact_dir
-                .join(STAGED_ROOT)
-                .join("not-a-generation")
-                .join("file")
-        ));
-        assert!(is_staged_artifact_path(&payloads[0]));
-    }
-
-    #[test]
-    fn staged_publication_rejects_nondeterministic_same_key_output() {
-        let dir = tempfile::tempdir().unwrap();
-        let _cache_dir = crate::daemon::server::tests::CacheDirEnvGuard::set(dir.path());
-        let artifact_dir = dir.path().join("artifacts");
-        fs::create_dir_all(&artifact_dir).unwrap();
-        let sources = source_files(dir.path());
-        let key = "e".repeat(64);
-        persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
-
-        make_writable(&sources[0]).unwrap();
-        fs::write(&sources[0], b"replacement immutable payload").unwrap();
-        let error = persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap_err();
-        assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
-
-        let payloads = load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
-            .unwrap()
-            .unwrap();
-        assert_eq!(fs::read(&payloads[0]).unwrap(), b"first immutable payload");
-        assert_eq!(fs::read(&payloads[1]).unwrap(), b"second immutable payload");
-        assert!(!same_file(sources[0].as_path(), payloads[0].as_path()));
-
-        let log = fs::read_to_string(crate::core::lifecycle::log_file_path()).unwrap();
-        let event: serde_json::Value = log
-            .lines()
-            .filter_map(|line| serde_json::from_str(line).ok())
-            .find(|event: &serde_json::Value| {
-                event["event"] == "staged_publication_conflict" && event["cache_key"] == key
-            })
-            .expect("durable staged publication conflict event");
-        assert_ne!(event["existing_generation"], event["candidate_generation"]);
-        assert!(event["elapsed_ns"].as_u64().is_some());
-    }
-
-    #[test]
-    fn staged_publication_can_replace_a_proven_corrupt_generation() {
-        let dir = tempfile::tempdir().unwrap();
-        let artifact_dir = dir.path().join("artifacts");
-        fs::create_dir_all(&artifact_dir).unwrap();
-        let sources = source_files(dir.path());
-        let key = "9".repeat(64);
-        persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
-        let old_generation = fs::read_to_string(pointer_path(&artifact_dir, &key)).unwrap();
-        let payloads = load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
-            .unwrap()
-            .unwrap();
-        make_writable(&payloads[0]).unwrap();
-        fs::write(&payloads[0], b"corrupt").unwrap();
-
-        fs::write(&sources[0], b"replacement immutable payload").unwrap();
-        persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
-        let replacement = load_staged_artifact_paths(&artifact_dir, &key, &[29, 24])
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            fs::read(&replacement[0]).unwrap(),
-            b"replacement immutable payload"
-        );
-        assert!(!generation_dir(&artifact_dir, &key, old_generation.trim()).exists());
-    }
-
-    #[test]
-    fn concurrent_same_key_publishers_never_overwrite_each_other() {
-        let dir = tempfile::tempdir().unwrap();
-        let artifact_dir = dir.path().join("artifacts");
-        fs::create_dir_all(&artifact_dir).unwrap();
-        let source_a: NormalizedPath = dir.path().join("a.o").into();
-        let source_b: NormalizedPath = dir.path().join("b.o").into();
-        fs::write(&source_a, b"generation-a").unwrap();
-        fs::write(&source_b, b"generation-b").unwrap();
-        let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
-        let key = "8".repeat(64);
-
-        let publishers: Vec<_> = [source_a, source_b]
-            .into_iter()
-            .map(|source| {
-                let barrier = std::sync::Arc::clone(&barrier);
-                let artifact_dir = artifact_dir.clone();
-                let key = key.clone();
-                std::thread::spawn(move || {
-                    barrier.wait();
-                    persist_staged_artifact_paths(&artifact_dir, &key, &[source])
-                })
-            })
-            .collect();
-        barrier.wait();
-        let results: Vec<_> = publishers
-            .into_iter()
-            .map(|publisher| publisher.join().unwrap())
-            .collect();
-        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
-        assert_eq!(
-            results
-                .iter()
-                .filter(|result| result
-                    .as_ref()
-                    .is_err_and(|error| error.kind() == io::ErrorKind::AlreadyExists))
-                .count(),
-            1
-        );
-        let payloads = load_staged_artifact_paths(&artifact_dir, &key, &[12])
-            .unwrap()
-            .unwrap();
-        assert!(matches!(
-            fs::read(&payloads[0]).unwrap().as_slice(),
-            b"generation-a" | b"generation-b"
-        ));
-    }
-
-    #[test]
-    fn staged_generation_rejects_same_size_corruption() {
-        let dir = tempfile::tempdir().unwrap();
-        let artifact_dir = dir.path().join("artifacts");
-        fs::create_dir_all(&artifact_dir).unwrap();
-        let sources = source_files(dir.path());
-        let key = "b".repeat(64);
-        persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
-        let payloads = load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
-            .unwrap()
-            .unwrap();
-
-        make_writable(&payloads[0]).unwrap();
-        let mut corrupted = fs::read(&payloads[0]).unwrap();
-        corrupted[0] ^= 0xff;
-        fs::write(&payloads[0], corrupted).unwrap();
-        assert_eq!(
-            load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
-                .unwrap_err()
-                .kind(),
-            io::ErrorKind::InvalidData
-        );
-    }
-
-    #[test]
-    fn staged_generation_pointer_never_selects_partial_set() {
-        let dir = tempfile::tempdir().unwrap();
-        let artifact_dir = dir.path().join("artifacts");
-        fs::create_dir_all(&artifact_dir).unwrap();
-        let sources = source_files(dir.path());
-        let key = "c".repeat(64);
-        persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
-
-        let pointer = artifact_dir
-            .join(STAGED_ROOT)
-            .join(format!("{key}.current"));
-        let generation = fs::read_to_string(pointer).unwrap();
-        let generation_dir = artifact_dir
-            .join(STAGED_ROOT)
-            .join(&key)
-            .join(generation.trim());
-        make_writable(&generation_dir.join("output-1")).unwrap();
-        fs::remove_file(generation_dir.join("output-1")).unwrap();
-        assert!(load_staged_artifact_paths(&artifact_dir, &key, &[23, 24]).is_err());
-    }
-
-    #[test]
-    fn staged_generation_cleans_abandoned_temporary_directories() {
-        let dir = tempfile::tempdir().unwrap();
-        let artifact_dir = dir.path().join("artifacts");
-        let key_root = artifact_dir.join(STAGED_ROOT).join("d".repeat(64));
-        fs::create_dir_all(&key_root).unwrap();
-        fs::create_dir(key_root.join(".tmp-crashed")).unwrap();
-        fs::create_dir(key_root.join("stable-generation")).unwrap();
-        fs::create_dir(key_root.join("orphan-generation")).unwrap();
-        fs::write(key_root.join(PUBLISH_LOCK), b"").unwrap();
-        fs::write(
-            artifact_dir
-                .join(STAGED_ROOT)
-                .join(format!("{}.current", "d".repeat(64))),
-            "stable-generation",
-        )
-        .unwrap();
-
-        assert_eq!(cleanup_staged_artifact_temps(&artifact_dir).unwrap(), 2);
-        assert!(!key_root.join(".tmp-crashed").exists());
-        assert!(key_root.join("stable-generation").exists());
-        assert!(!key_root.join("orphan-generation").exists());
-        assert!(key_root.join(PUBLISH_LOCK).exists());
-    }
-
-    #[test]
-    fn staged_clear_removes_every_visible_generation_but_keeps_coordination_lock() {
-        let dir = tempfile::tempdir().unwrap();
-        let artifact_dir = dir.path().join("artifacts");
-        fs::create_dir_all(&artifact_dir).unwrap();
-        let sources = source_files(dir.path());
-        let key = "7".repeat(64);
-        persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
-        #[cfg(unix)]
-        let outside = {
-            let outside = dir.path().join("outside-clear-boundary");
-            fs::create_dir(&outside).unwrap();
-            fs::write(outside.join("must-survive"), b"outside").unwrap();
-            std::os::unix::fs::symlink(
-                &outside,
-                artifact_dir.join(STAGED_ROOT).join("hostile-symlink"),
-            )
-            .unwrap();
-            outside
-        };
-
-        assert!(clear_staged_artifacts(&artifact_dir).unwrap() > 0);
-        #[cfg(unix)]
-        assert_eq!(fs::read(outside.join("must-survive")).unwrap(), b"outside");
-        assert!(load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
-            .unwrap()
-            .is_none());
-        let remaining: Vec<_> = fs::read_dir(artifact_dir.join(STAGED_ROOT))
-            .unwrap()
-            .flatten()
-            .map(|entry| entry.file_name())
-            .collect();
-        assert_eq!(remaining, vec![std::ffi::OsString::from(STORE_LOCK)]);
-    }
-
-    #[test]
-    fn mutable_page_writer_never_shares_backend_inode() {
-        // This is intentionally a database-shaped page writer rather than
-        // the sqlite-link compile fixture: it exercises truncate, same-size
-        // page replacement, and a journal-like sibling file.
-        let dir = tempfile::tempdir().unwrap();
-        let artifact_dir = dir.path().join("artifacts");
-        fs::create_dir_all(&artifact_dir).unwrap();
-        let backend = dir.path().join("backend.db");
-        let journal = dir.path().join("backend.db-wal");
-        fs::write(&backend, vec![0x11_u8; 4096]).unwrap();
-        fs::write(&journal, b"journal-before-checkpoint").unwrap();
-        let sources = vec![backend.clone().into(), journal.clone().into()];
-        persist_staged_artifact_paths(&artifact_dir, &"f".repeat(64), &sources).unwrap();
-        let journal_size = fs::metadata(&journal).unwrap().len();
-        let payloads =
-            load_staged_artifact_paths(&artifact_dir, &"f".repeat(64), &[4096, journal_size])
-                .unwrap()
-                .unwrap();
-        let destination = dir.path().join("work.db");
-        materialize_independent_with_stats(&payloads[0], &destination).unwrap();
-        let mut page = vec![0x22_u8; 4096];
-        page[37] = 0x99;
-        fs::write(&destination, page).unwrap();
-        assert_eq!(fs::read(&backend).unwrap(), vec![0x11_u8; 4096]);
-        assert_ne!(fs::read(&destination).unwrap(), fs::read(&backend).unwrap());
-        assert!(!same_file(&payloads[0], &destination));
-    }
-}
+#[path = "staged_store_tests.rs"]
+mod tests;

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/README.md
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/README.md
@@ -1,0 +1,5 @@
+# Staged store internals
+
+- `maintenance.rs` scans and evicts complete immutable generations.
+- `materialize.rs` restores requested outputs with physical-tier observations.
+- `fault.rs` provides path-scoped deterministic fault injection in tests only.

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/fault.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/fault.rs
@@ -1,0 +1,104 @@
+//! Deterministic, path-scoped staged-pipeline fault injection for tests.
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::daemon::server) enum StagedFaultPoint {
+    GenerationCreate,
+    OutputCopy(usize),
+    OutputHash(usize),
+    DurableDigest(usize),
+    ManifestWrite,
+    ManifestSync,
+    GenerationSync,
+    GenerationPublish,
+    PointerCommit,
+    PointerSync,
+    IndexCommit,
+    MaterializeOutput(usize),
+    MaterializeReflink,
+    MaterializeHardlink,
+    MaterializeCopy,
+}
+
+struct ActiveFaults {
+    token: u64,
+    scope: PathBuf,
+    points: Vec<StagedFaultPoint>,
+}
+
+static NEXT_TOKEN: AtomicU64 = AtomicU64::new(1);
+static ACTIVE: OnceLock<Mutex<Vec<ActiveFaults>>> = OnceLock::new();
+
+fn active() -> &'static Mutex<Vec<ActiveFaults>> {
+    ACTIVE.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+pub(in crate::daemon::server) struct StagedFaultGuard {
+    token: u64,
+}
+
+impl StagedFaultGuard {
+    pub(in crate::daemon::server) fn arm(
+        scope: &Path,
+        points: impl IntoIterator<Item = StagedFaultPoint>,
+    ) -> Self {
+        let token = NEXT_TOKEN.fetch_add(1, Ordering::Relaxed);
+        active()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .push(ActiveFaults {
+                token,
+                scope: scope.to_path_buf(),
+                points: points.into_iter().collect(),
+            });
+        Self { token }
+    }
+
+    pub(in crate::daemon::server) fn assert_all_consumed(&self) {
+        let active = active().lock().unwrap_or_else(|error| error.into_inner());
+        let pending = active
+            .iter()
+            .find(|faults| faults.token == self.token)
+            .map_or(0, |faults| faults.points.len());
+        assert_eq!(
+            pending, 0,
+            "{pending} staged fault point(s) were not reached"
+        );
+    }
+}
+
+impl Drop for StagedFaultGuard {
+    fn drop(&mut self) {
+        active()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .retain(|faults| faults.token != self.token);
+    }
+}
+
+pub(in crate::daemon::server) fn inject(
+    scope_path: &Path,
+    point: StagedFaultPoint,
+) -> io::Result<()> {
+    let mut active = active().lock().unwrap_or_else(|error| error.into_inner());
+    for faults in active.iter_mut() {
+        if !scope_path.starts_with(&faults.scope) {
+            continue;
+        }
+        if let Some(index) = faults
+            .points
+            .iter()
+            .position(|candidate| *candidate == point)
+        {
+            faults.points.remove(index);
+            return Err(io::Error::other(format!(
+                "injected staged fault: {point:?}"
+            )));
+        }
+    }
+    Ok(())
+}

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/materialize.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/materialize.rs
@@ -22,6 +22,43 @@ impl StagedMaterializationStats {
     }
 }
 
+#[derive(Debug)]
+struct StagedMaterializationError {
+    source: io::Error,
+    progress: StagedMaterializationStats,
+}
+
+impl std::fmt::Display for StagedMaterializationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.source.fmt(formatter)
+    }
+}
+
+impl std::error::Error for StagedMaterializationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+pub(in crate::daemon::server) fn materialization_error(
+    source: io::Error,
+    progress: StagedMaterializationStats,
+) -> io::Error {
+    io::Error::new(
+        source.kind(),
+        StagedMaterializationError { source, progress },
+    )
+}
+
+pub(in crate::daemon::server) fn materialization_error_progress(
+    error: &io::Error,
+) -> StagedMaterializationStats {
+    error
+        .get_ref()
+        .and_then(|source| source.downcast_ref::<StagedMaterializationError>())
+        .map_or_else(StagedMaterializationStats::default, |error| error.progress)
+}
+
 pub(in crate::daemon::server) fn materialize_independent_with_stats(
     source: &Path,
     destination: &Path,
@@ -52,7 +89,10 @@ pub(in crate::daemon::server) fn materialize_independent_with_stats(
 
 #[cfg(test)]
 mod tests {
-    use super::super::{load_staged_artifact_paths, persist_staged_artifact_paths};
+    use super::super::{
+        load_staged_artifact_paths, persist_staged_artifact_paths, StagedFaultGuard,
+        StagedFaultPoint,
+    };
     use super::*;
 
     #[test]
@@ -77,5 +117,40 @@ mod tests {
         let materialized = materialize_independent_with_stats(&payload, &destination).unwrap();
         assert_eq!(materialized.reflink_count + materialized.copy_count, 1);
         assert_eq!(fs::read(destination).unwrap(), b"observable staged payload");
+    }
+
+    #[test]
+    fn independent_materialization_faults_fall_back_or_fail_cleanly() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.rlib");
+        fs::write(&source, b"independent materialization payload").unwrap();
+
+        let fallback = dir.path().join("fallback.rlib");
+        let reflink_fault =
+            StagedFaultGuard::arm(&fallback, [StagedFaultPoint::MaterializeReflink]);
+        let observed = materialize_independent_with_stats(&source, &fallback).unwrap();
+        assert_eq!(observed.reflink_count, 0);
+        assert_eq!(observed.copy_count, 1);
+        assert_eq!(observed.copy_bytes, 35);
+        assert_eq!(
+            fs::read(&fallback).unwrap(),
+            b"independent materialization payload"
+        );
+        reflink_fault.assert_all_consumed();
+
+        let failed = dir.path().join("failed.rlib");
+        let all_faults = StagedFaultGuard::arm(
+            &failed,
+            [
+                StagedFaultPoint::MaterializeReflink,
+                StagedFaultPoint::MaterializeCopy,
+            ],
+        );
+        materialize_independent_with_stats(&source, &failed).unwrap_err();
+        assert!(
+            !failed.exists(),
+            "failed copy tier left a partial destination"
+        );
+        all_faults.assert_all_consumed();
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store_tests.rs
@@ -1,0 +1,392 @@
+//! Transaction, race, migration, cleanup, and deterministic fault tests.
+use super::*;
+use std::fs;
+
+fn source_files(dir: &Path) -> Vec<NormalizedPath> {
+    let first = dir.join("source-a.rlib");
+    let second = dir.join("source-b.rmeta");
+    fs::write(&first, b"first immutable payload").unwrap();
+    fs::write(&second, b"second immutable payload").unwrap();
+    vec![first.into(), second.into()]
+}
+
+#[test]
+fn staged_generation_is_independent_and_hash_addressed() {
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    let sources = source_files(dir.path());
+    let stats = persist_staged_artifact_paths(&artifact_dir, &"a".repeat(64), &sources).unwrap();
+
+    assert_eq!(stats.hardlink_count, 0);
+    assert_eq!(stats.reflink_count + stats.copy_count, 2);
+
+    let payloads = load_staged_artifact_paths(&artifact_dir, &"a".repeat(64), &[23, 24])
+        .unwrap()
+        .unwrap();
+    assert_eq!(payloads.len(), 2);
+    assert_eq!(fs::read(&payloads[0]).unwrap(), b"first immutable payload");
+    assert_eq!(fs::read(&payloads[1]).unwrap(), b"second immutable payload");
+    assert!(!same_file(sources[0].as_path(), payloads[0].as_path()));
+    assert!(fs::metadata(&payloads[0]).unwrap().permissions().readonly());
+
+    fs::write(&sources[0], b"mutated compiler output").unwrap();
+    assert_eq!(fs::read(&payloads[0]).unwrap(), b"first immutable payload");
+
+    let pointer = artifact_dir
+        .join(STAGED_ROOT)
+        .join(format!("{}.current", "a".repeat(64)));
+    let generation = fs::read_to_string(pointer).unwrap();
+    assert_eq!(generation.trim().len(), 64);
+    assert!(generation
+        .trim()
+        .bytes()
+        .all(|byte| byte.is_ascii_hexdigit()));
+    assert!(!is_staged_artifact_path(
+        &artifact_dir
+            .join(STAGED_ROOT)
+            .join("not-a-generation")
+            .join("file")
+    ));
+    assert!(is_staged_artifact_path(&payloads[0]));
+}
+
+#[test]
+fn staged_publication_rejects_nondeterministic_same_key_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let _cache_dir = crate::daemon::server::tests::CacheDirEnvGuard::set(dir.path());
+    let artifact_dir = dir.path().join("artifacts");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    let sources = source_files(dir.path());
+    let key = "e".repeat(64);
+    persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
+
+    make_writable(&sources[0]).unwrap();
+    fs::write(&sources[0], b"replacement immutable payload").unwrap();
+    let error = persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+
+    let payloads = load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
+        .unwrap()
+        .unwrap();
+    assert_eq!(fs::read(&payloads[0]).unwrap(), b"first immutable payload");
+    assert_eq!(fs::read(&payloads[1]).unwrap(), b"second immutable payload");
+    assert!(!same_file(sources[0].as_path(), payloads[0].as_path()));
+
+    let log = fs::read_to_string(crate::core::lifecycle::log_file_path()).unwrap();
+    let event: serde_json::Value = log
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .find(|event: &serde_json::Value| {
+            event["event"] == "staged_publication_conflict" && event["cache_key"] == key
+        })
+        .expect("durable staged publication conflict event");
+    assert_ne!(event["existing_generation"], event["candidate_generation"]);
+    assert!(event["elapsed_ns"].as_u64().is_some());
+}
+
+#[test]
+fn publication_fault_matrix_never_exposes_partial_generation() {
+    let cases = [
+        (
+            StagedFaultPoint::GenerationCreate,
+            StagedPublishFailure::StoreSetup,
+            "publication",
+        ),
+        (
+            StagedFaultPoint::OutputCopy(1),
+            StagedPublishFailure::OutputCopy,
+            "publication_output_copy",
+        ),
+        (
+            StagedFaultPoint::OutputHash(1),
+            StagedPublishFailure::Hash,
+            "hashing",
+        ),
+        (
+            StagedFaultPoint::DurableDigest(1),
+            StagedPublishFailure::DurableDigest,
+            "durable_digest",
+        ),
+        (
+            StagedFaultPoint::ManifestWrite,
+            StagedPublishFailure::Manifest,
+            "manifest",
+        ),
+        (
+            StagedFaultPoint::ManifestSync,
+            StagedPublishFailure::Manifest,
+            "manifest",
+        ),
+        (
+            StagedFaultPoint::GenerationSync,
+            StagedPublishFailure::GenerationPublish,
+            "generation_publish",
+        ),
+        (
+            StagedFaultPoint::GenerationPublish,
+            StagedPublishFailure::GenerationPublish,
+            "generation_publish",
+        ),
+        (
+            StagedFaultPoint::PointerCommit,
+            StagedPublishFailure::PointerCommit,
+            "pointer_commit",
+        ),
+        (
+            StagedFaultPoint::PointerSync,
+            StagedPublishFailure::PointerCommit,
+            "pointer_commit",
+        ),
+    ];
+
+    for (point, expected_reason, failure_key) in cases {
+        let dir = tempfile::tempdir().unwrap();
+        let artifact_dir = dir.path().join("artifacts");
+        fs::create_dir_all(&artifact_dir).unwrap();
+        let first = dir.path().join("first.rlib");
+        let second = dir.path().join("second.rmeta");
+        fs::write(&first, b"first complete output").unwrap();
+        fs::write(&second, b"second complete output").unwrap();
+        let key = "7".repeat(64);
+        let _fault = StagedFaultGuard::arm(&artifact_dir, [point]);
+
+        let error =
+            persist_staged_artifact_paths(&artifact_dir, &key, &[first.into(), second.into()])
+                .unwrap_err();
+        assert_eq!(
+            staged_publish_failure(&error),
+            Some(expected_reason),
+            "wrong failure reason for {point:?}: {error}"
+        );
+        let profiler = crate::daemon::staged_stats::StagedProfiler::new();
+        profiler.failure(expected_reason.failure());
+        assert_eq!(profiler.snapshot().failures[failure_key], 1);
+        let loaded = load_staged_artifact_paths(&artifact_dir, &key, &[21, 22]).unwrap();
+        if point == StagedFaultPoint::PointerSync {
+            let loaded = loaded.expect("post-commit sync failure keeps a complete generation");
+            assert_eq!(fs::read(&loaded[0]).unwrap(), b"first complete output");
+            assert_eq!(fs::read(&loaded[1]).unwrap(), b"second complete output");
+        } else {
+            assert!(loaded.is_none(), "{point:?} exposed a partial generation");
+        }
+        let key_root = staged_root(&artifact_dir).join(&key);
+        if key_root.exists() {
+            assert!(fs::read_dir(key_root)
+                .unwrap()
+                .filter_map(Result::ok)
+                .all(|entry| !entry.file_name().to_string_lossy().starts_with(".tmp-")));
+        }
+        _fault.assert_all_consumed();
+    }
+}
+
+#[test]
+fn staged_publication_can_replace_a_proven_corrupt_generation() {
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    let sources = source_files(dir.path());
+    let key = "9".repeat(64);
+    persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
+    let old_generation = fs::read_to_string(pointer_path(&artifact_dir, &key)).unwrap();
+    let payloads = load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
+        .unwrap()
+        .unwrap();
+    make_writable(&payloads[0]).unwrap();
+    fs::write(&payloads[0], b"corrupt").unwrap();
+
+    fs::write(&sources[0], b"replacement immutable payload").unwrap();
+    persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
+    let replacement = load_staged_artifact_paths(&artifact_dir, &key, &[29, 24])
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        fs::read(&replacement[0]).unwrap(),
+        b"replacement immutable payload"
+    );
+    assert!(!generation_dir(&artifact_dir, &key, old_generation.trim()).exists());
+}
+
+#[test]
+fn concurrent_same_key_publishers_never_overwrite_each_other() {
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    let source_a: NormalizedPath = dir.path().join("a.o").into();
+    let source_b: NormalizedPath = dir.path().join("b.o").into();
+    fs::write(&source_a, b"generation-a").unwrap();
+    fs::write(&source_b, b"generation-b").unwrap();
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+    let key = "8".repeat(64);
+
+    let publishers: Vec<_> = [source_a, source_b]
+        .into_iter()
+        .map(|source| {
+            let barrier = std::sync::Arc::clone(&barrier);
+            let artifact_dir = artifact_dir.clone();
+            let key = key.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                persist_staged_artifact_paths(&artifact_dir, &key, &[source])
+            })
+        })
+        .collect();
+    barrier.wait();
+    let results: Vec<_> = publishers
+        .into_iter()
+        .map(|publisher| publisher.join().unwrap())
+        .collect();
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| result
+                .as_ref()
+                .is_err_and(|error| error.kind() == io::ErrorKind::AlreadyExists))
+            .count(),
+        1
+    );
+    let payloads = load_staged_artifact_paths(&artifact_dir, &key, &[12])
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        fs::read(&payloads[0]).unwrap().as_slice(),
+        b"generation-a" | b"generation-b"
+    ));
+}
+
+#[test]
+fn staged_generation_rejects_same_size_corruption() {
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    let sources = source_files(dir.path());
+    let key = "b".repeat(64);
+    persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
+    let payloads = load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
+        .unwrap()
+        .unwrap();
+
+    make_writable(&payloads[0]).unwrap();
+    let mut corrupted = fs::read(&payloads[0]).unwrap();
+    corrupted[0] ^= 0xff;
+    fs::write(&payloads[0], corrupted).unwrap();
+    assert_eq!(
+        load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::InvalidData
+    );
+}
+
+#[test]
+fn staged_generation_pointer_never_selects_partial_set() {
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    let sources = source_files(dir.path());
+    let key = "c".repeat(64);
+    persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
+
+    let pointer = artifact_dir
+        .join(STAGED_ROOT)
+        .join(format!("{key}.current"));
+    let generation = fs::read_to_string(pointer).unwrap();
+    let generation_dir = artifact_dir
+        .join(STAGED_ROOT)
+        .join(&key)
+        .join(generation.trim());
+    make_writable(&generation_dir.join("output-1")).unwrap();
+    fs::remove_file(generation_dir.join("output-1")).unwrap();
+    assert!(load_staged_artifact_paths(&artifact_dir, &key, &[23, 24]).is_err());
+}
+
+#[test]
+fn staged_generation_cleans_abandoned_temporary_directories() {
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    let key_root = artifact_dir.join(STAGED_ROOT).join("d".repeat(64));
+    fs::create_dir_all(&key_root).unwrap();
+    fs::create_dir(key_root.join(".tmp-crashed")).unwrap();
+    fs::create_dir(key_root.join("stable-generation")).unwrap();
+    fs::create_dir(key_root.join("orphan-generation")).unwrap();
+    fs::write(key_root.join(PUBLISH_LOCK), b"").unwrap();
+    fs::write(
+        artifact_dir
+            .join(STAGED_ROOT)
+            .join(format!("{}.current", "d".repeat(64))),
+        "stable-generation",
+    )
+    .unwrap();
+
+    assert_eq!(cleanup_staged_artifact_temps(&artifact_dir).unwrap(), 2);
+    assert!(!key_root.join(".tmp-crashed").exists());
+    assert!(key_root.join("stable-generation").exists());
+    assert!(!key_root.join("orphan-generation").exists());
+    assert!(key_root.join(PUBLISH_LOCK).exists());
+}
+
+#[test]
+fn staged_clear_removes_every_visible_generation_but_keeps_coordination_lock() {
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    let sources = source_files(dir.path());
+    let key = "7".repeat(64);
+    persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap();
+    #[cfg(unix)]
+    let outside = {
+        let outside = dir.path().join("outside-clear-boundary");
+        fs::create_dir(&outside).unwrap();
+        fs::write(outside.join("must-survive"), b"outside").unwrap();
+        std::os::unix::fs::symlink(
+            &outside,
+            artifact_dir.join(STAGED_ROOT).join("hostile-symlink"),
+        )
+        .unwrap();
+        outside
+    };
+
+    assert!(clear_staged_artifacts(&artifact_dir).unwrap() > 0);
+    #[cfg(unix)]
+    assert_eq!(fs::read(outside.join("must-survive")).unwrap(), b"outside");
+    assert!(load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
+        .unwrap()
+        .is_none());
+    let remaining: Vec<_> = fs::read_dir(artifact_dir.join(STAGED_ROOT))
+        .unwrap()
+        .flatten()
+        .map(|entry| entry.file_name())
+        .collect();
+    assert_eq!(remaining, vec![std::ffi::OsString::from(STORE_LOCK)]);
+}
+
+#[test]
+fn mutable_page_writer_never_shares_backend_inode() {
+    // This is intentionally a database-shaped page writer rather than
+    // the sqlite-link compile fixture: it exercises truncate, same-size
+    // page replacement, and a journal-like sibling file.
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    let backend = dir.path().join("backend.db");
+    let journal = dir.path().join("backend.db-wal");
+    fs::write(&backend, vec![0x11_u8; 4096]).unwrap();
+    fs::write(&journal, b"journal-before-checkpoint").unwrap();
+    let sources = vec![backend.clone().into(), journal.clone().into()];
+    persist_staged_artifact_paths(&artifact_dir, &"f".repeat(64), &sources).unwrap();
+    let journal_size = fs::metadata(&journal).unwrap().len();
+    let payloads =
+        load_staged_artifact_paths(&artifact_dir, &"f".repeat(64), &[4096, journal_size])
+            .unwrap()
+            .unwrap();
+    let destination = dir.path().join("work.db");
+    materialize_independent_with_stats(&payloads[0], &destination).unwrap();
+    let mut page = vec![0x22_u8; 4096];
+    page[37] = 0x99;
+    fs::write(&destination, page).unwrap();
+    assert_eq!(fs::read(&backend).unwrap(), vec![0x11_u8; 4096]);
+    assert_ne!(fs::read(&destination).unwrap(), fs::read(&backend).unwrap());
+    assert!(!same_file(&payloads[0], &destination));
+}

--- a/crates/zccache-daemon-core/src/daemon/server/persist/write_cached.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/write_cached.rs
@@ -73,7 +73,17 @@ fn materialize_cached_file(
     }
     remove_materialized_output(out_path)?;
     let caps = fs_caps(cache_file, out_path);
-    if caps.reflink && reflink_copy::reflink(cache_file, out_path).is_ok() {
+    let reflink_allowed = {
+        #[cfg(test)]
+        {
+            inject_staged_fault(out_path, StagedFaultPoint::MaterializeReflink).is_ok()
+        }
+        #[cfg(not(test))]
+        {
+            true
+        }
+    };
+    if reflink_allowed && caps.reflink && reflink_copy::reflink(cache_file, out_path).is_ok() {
         make_writable(out_path)?;
         restore_cache_mtime(cache_file, out_path)?;
         touch_mtime(out_path);
@@ -86,9 +96,12 @@ fn materialize_cached_file(
     // call sites in this module; a genuinely-too-many-links file still
     // fails the real `std::fs::hard_link` call below, which already has
     // a graceful copy fallback.
-    if hardlink_allowed
-        && hardlink_below_limit(caps, hard_link_count(cache_file).unwrap_or_default())
-    {
+    let hardlink_candidate = hardlink_allowed
+        && hardlink_below_limit(caps, hard_link_count(cache_file).unwrap_or_default());
+    #[cfg(test)]
+    let hardlink_candidate = hardlink_candidate
+        && inject_staged_fault(out_path, StagedFaultPoint::MaterializeHardlink).is_ok();
+    if hardlink_candidate {
         // Only flip the blob read-only *after* the link actually lands.
         // Read-only exists to protect the blob once it's shared; setting
         // it beforehand serves no purpose on the attempt path and, if
@@ -144,6 +157,8 @@ fn materialize_cached_file(
             }
         }
     }
+    #[cfg(test)]
+    inject_staged_fault(out_path, StagedFaultPoint::MaterializeCopy)?;
     let copied_bytes = std::fs::copy(cache_file, out_path)?;
     make_writable(out_path)?;
     restore_cache_mtime(cache_file, out_path)?;

--- a/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
@@ -25,6 +25,7 @@ mod post_link_hook;
 mod release_worktree_handles;
 mod rustc_depinfo;
 mod server_ipc;
+mod session_errors;
 mod system_includes_deferred;
 mod write_cached;
 

--- a/crates/zccache-daemon-core/src/daemon/server/tests/server_ipc.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/server_ipc.rs
@@ -7,7 +7,7 @@
 use super::super::*;
 use super::CacheDirEnvGuard;
 
-async fn start_daemon() -> (String, tokio::task::JoinHandle<()>, Arc<Notify>) {
+pub(super) async fn start_daemon() -> (String, tokio::task::JoinHandle<()>, Arc<Notify>) {
     let endpoint = crate::ipc::unique_test_endpoint();
     let mut server = DaemonServer::bind(&endpoint).unwrap();
     let shutdown = server.shutdown_handle();
@@ -416,72 +416,219 @@ async fn cli_session_lifecycle() {
     .await;
 }
 
-/// Ending a session with a malformed (non-UUID) ID returns an error.
 #[tokio::test]
-#[ignore] // integration-level: starts real daemon with IPC
-async fn cli_session_end_invalid_id() {
-    crate::test_support::test_timeout(async {
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+#[ignore] // integration-level: real clang + daemon IPC + deterministic store faults
+async fn staged_publication_fault_salvages_or_fails_closed_with_forensics() {
+    let Some(clang) = crate::test_support::find_clang() else {
+        return;
+    };
+    crate::test_support::test_timeout(async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().join("cache");
+        let _cache_env = CacheDirEnvGuard::set(&cache_dir);
+        let endpoint = crate::ipc::unique_test_endpoint();
+        let mut server = DaemonServer::bind(&endpoint).unwrap();
+        let state = server.test_state_arc();
+        let shutdown = server.shutdown_handle();
+        let server_task = tokio::spawn(async move { server.run(0).await.unwrap() });
         let mut client = crate::ipc::connect(&endpoint).await.unwrap();
+        let cwd = tmp.path().to_string_lossy().into_owned();
+        let source = tmp.path().join("fault-success.c");
+        let output = tmp.path().join("fault-success.o");
+        let failed_source = tmp.path().join("fault-failed.c");
+        let failed_output = tmp.path().join("fault-failed.o");
+        let index_source = tmp.path().join("fault-index.c");
+        let index_output = tmp.path().join("fault-index.o");
+        std::fs::write(&source, "int staged_fault_success(void) { return 1; }\n").unwrap();
+        std::fs::write(
+            &failed_source,
+            "int staged_fault_failed(void) { return 2; }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &index_source,
+            "int staged_fault_index(void) { return 3; }\n",
+        )
+        .unwrap();
 
         client
-            .send(&Request::SessionEnd {
-                session_id: 999999.to_string(),
+            .send(&Request::SessionStart {
+                client_pid: std::process::id(),
+                working_dir: cwd.clone().into(),
+                log_file: None,
+                track_stats: true,
+                journal_path: None,
+                profile: false,
+                private_daemon: None,
             })
             .await
             .unwrap();
+        let session_id = match client.recv().await.unwrap() {
+            Some(Response::SessionStarted { session_id, .. }) => session_id,
+            other => panic!("expected SessionStarted, got {other:?}"),
+        };
+        let compile = |session_id: String, source: &Path, output: &Path| Request::Compile {
+            session_id,
+            args: vec![
+                "-c".to_string(),
+                source.to_string_lossy().into_owned(),
+                "-o".to_string(),
+                output.to_string_lossy().into_owned(),
+            ],
+            cwd: cwd.clone().into(),
+            compiler: clang.to_string_lossy().into_owned().into(),
+            env: None,
+            stdin: Vec::new(),
+        };
 
-        match client.recv().await.unwrap() {
-            Some(Response::Error { message }) => {
-                assert!(
-                    message.contains("unknown session") || message.contains("invalid session"),
-                    "expected session error, got: {message}"
-                );
-            }
-            other => panic!("expected Error, got: {other:?}"),
-        }
+        let publish_fault =
+            StagedFaultGuard::arm(&state.artifact_dir, [StagedFaultPoint::PointerCommit]);
+        client
+            .send(&compile(session_id.clone(), &source, &output))
+            .await
+            .unwrap();
+        assert!(matches!(
+            client.recv().await.unwrap(),
+            Some(Response::CompileResult {
+                exit_code: 0,
+                cached: false,
+                ..
+            })
+        ));
+        assert!(output.exists(), "successful compile was not salvaged");
+        publish_fault.assert_all_consumed();
 
-        shutdown.notify_one();
-        server_handle.await.unwrap();
-    })
-    .await;
-}
+        let publish_fault =
+            StagedFaultGuard::arm(&state.artifact_dir, [StagedFaultPoint::PointerCommit]);
+        let salvage_fault =
+            StagedFaultGuard::arm(&failed_output, [StagedFaultPoint::MaterializeOutput(0)]);
+        client
+            .send(&compile(session_id.clone(), &failed_source, &failed_output))
+            .await
+            .unwrap();
+        assert!(matches!(
+            client.recv().await.unwrap(),
+            Some(Response::Error { .. })
+        ));
+        assert!(
+            !failed_output.exists(),
+            "failed salvage reported a requested output"
+        );
+        publish_fault.assert_all_consumed();
+        salvage_fault.assert_all_consumed();
 
-/// Ending an unknown session (well-formed UUID, but daemon has no record
-/// of it) is idempotent and returns SessionEnded { stats: None }.
-///
-/// This simulates the scenario where the daemon was restarted between
-/// `session-start` and `session-end` (e.g. zccache-ci kills the daemon
-/// mid-build to unlock target binaries on Windows). Build wrappers like
-/// soldr call `session-end` at process exit and must not see a spurious
-/// failure when the in-memory session is gone.
-#[tokio::test]
-#[ignore] // integration-level: starts real daemon with IPC
-async fn cli_session_end_unknown_uuid_is_idempotent() {
-    crate::test_support::test_timeout(async {
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
-        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
+        let index_fault =
+            StagedFaultGuard::arm(&state.artifact_dir, [StagedFaultPoint::IndexCommit]);
+        client
+            .send(&compile(session_id.clone(), &index_source, &index_output))
+            .await
+            .unwrap();
+        assert!(matches!(
+            client.recv().await.unwrap(),
+            Some(Response::CompileResult {
+                exit_code: 0,
+                cached: false,
+                ..
+            })
+        ));
+        assert!(index_output.exists(), "index failure was not salvaged");
+        index_fault.assert_all_consumed();
+
+        // Failed index publication must not leave a process-local cache entry.
+        // The identical request must execute again, not become a false hit.
+        std::fs::remove_file(&index_output).unwrap();
+        client
+            .send(&compile(session_id.clone(), &index_source, &index_output))
+            .await
+            .unwrap();
+        assert!(matches!(
+            client.recv().await.unwrap(),
+            Some(Response::CompileResult {
+                exit_code: 0,
+                cached: false,
+                ..
+            })
+        ));
+        assert!(
+            index_output.exists(),
+            "retry after index failure did not compile"
+        );
 
         client
             .send(&Request::SessionEnd {
-                // A well-formed UUID that the daemon has never seen.
-                session_id: "00000000-0000-0000-0000-000000000000".to_string(),
+                session_id: session_id.clone(),
             })
             .await
             .unwrap();
-
-        match client.recv().await.unwrap() {
-            Some(Response::SessionEnded { stats }) => {
-                assert!(
-                    stats.is_none(),
-                    "no stats expected for unknown session, got: {stats:?}"
-                );
+        let staged = match client.recv().await.unwrap() {
+            Some(Response::SessionEnded { stats: Some(stats) }) => {
+                stats.phase_profile.unwrap().staged
             }
-            other => panic!("expected SessionEnded for unknown UUID, got: {other:?}"),
-        }
+            other => panic!("expected SessionEnded stats, got {other:?}"),
+        };
+        assert_eq!(staged.counters["publication_failure"], 3);
+        assert_eq!(staged.failures["pointer_commit"], 2);
+        assert_eq!(staged.failures["index_commit"], 1);
+        assert_eq!(staged.counters["salvage_attempt"], 3);
+        assert_eq!(staged.counters["salvage_success"], 2);
+        assert_eq!(staged.counters["salvage_failure"], 1);
+        assert_eq!(staged.counters["materialize_failure"], 1);
+        assert!(staged.timings_ns.contains_key("salvage"));
 
         shutdown.notify_one();
-        server_handle.await.unwrap();
+        server_task.await.unwrap();
+        let restarted = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
+        drop(restarted);
+
+        let lifecycle_path = crate::core::lifecycle::log_file_path();
+        assert!(lifecycle_path.as_path().starts_with(&cache_dir));
+        let lifecycle = std::fs::read_dir(lifecycle_path.parent().unwrap())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .contains("daemon-lifecycle")
+            })
+            .map(|entry| std::fs::read_to_string(entry.path()).unwrap())
+            .collect::<String>();
+        assert_eq!(
+            lifecycle
+                .matches("\"event\":\"staged_salvage_started\"")
+                .count(),
+            3
+        );
+        assert_eq!(
+            lifecycle
+                .matches("\"event\":\"staged_salvage_complete\"")
+                .count(),
+            2
+        );
+        assert_eq!(
+            lifecycle
+                .matches("\"event\":\"staged_salvage_failed\"")
+                .count(),
+            1
+        );
+        for event in lifecycle
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .filter(|event| {
+                event["event"]
+                    .as_str()
+                    .is_some_and(|name| name.starts_with("staged_salvage_"))
+            })
+        {
+            let reason = event["reason"].as_str().expect("bounded salvage reason");
+            assert!(reason
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte == b'_'));
+            assert!(event["output_count"].is_u64());
+            assert!(event["copied_bytes"].is_u64());
+            assert!(event["elapsed_ns"].is_u64());
+        }
+        assert!(!lifecycle.contains(&state.staging.path().to_string_lossy().as_ref()));
     })
     .await;
 }

--- a/crates/zccache-daemon-core/src/daemon/server/tests/session_errors.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/session_errors.rs
@@ -1,0 +1,64 @@
+//! Session error-path IPC tests kept separate from the main lifecycle matrix.
+
+use super::super::*;
+use super::server_ipc::start_daemon;
+
+#[tokio::test]
+#[ignore] // integration-level: starts real daemon with IPC
+async fn cli_session_end_invalid_id() {
+    crate::test_support::test_timeout(async {
+        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
+
+        client
+            .send(&Request::SessionEnd {
+                session_id: 999999.to_string(),
+            })
+            .await
+            .unwrap();
+
+        match client.recv().await.unwrap() {
+            Some(Response::Error { message }) => {
+                assert!(
+                    message.contains("unknown session") || message.contains("invalid session"),
+                    "expected session error, got: {message}"
+                );
+            }
+            other => panic!("expected Error, got: {other:?}"),
+        }
+
+        shutdown.notify_one();
+        server_handle.await.unwrap();
+    })
+    .await;
+}
+
+/// A well-formed but unknown session is expected after daemon restart, so
+/// session-end remains idempotent and returns no stale statistics.
+#[tokio::test]
+#[ignore] // integration-level: starts real daemon with IPC
+async fn cli_session_end_unknown_uuid_is_idempotent() {
+    crate::test_support::test_timeout(async {
+        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
+
+        client
+            .send(&Request::SessionEnd {
+                session_id: "00000000-0000-0000-0000-000000000000".to_string(),
+            })
+            .await
+            .unwrap();
+
+        match client.recv().await.unwrap() {
+            Some(Response::SessionEnded { stats }) => assert!(
+                stats.is_none(),
+                "no stats expected for unknown session, got: {stats:?}"
+            ),
+            other => panic!("expected SessionEnded for unknown UUID, got: {other:?}"),
+        }
+
+        shutdown.notify_one();
+        server_handle.await.unwrap();
+    })
+    .await;
+}

--- a/crates/zccache-daemon-core/src/daemon/server/tests/write_cached.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/write_cached.rs
@@ -337,6 +337,72 @@ fn staged_generation_hardlinks_only_when_semantically_authorized() {
 }
 
 #[test]
+fn staged_hit_tier_faults_fall_through_without_misattribution() {
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    std::fs::create_dir_all(&artifact_dir).unwrap();
+    let source = dir.path().join("source.rlib");
+    std::fs::write(&source, b"tier fault payload").unwrap();
+    let key = "b".repeat(64);
+    persist_staged_artifact_paths(&artifact_dir, &key, &[source.into()]).unwrap();
+    let payloads = load_staged_artifact_paths(&artifact_dir, &key, &[18])
+        .unwrap()
+        .unwrap();
+    let output = dir.path().join("target.rlib");
+    if !fs_caps(&payloads[0], &output).hardlink {
+        eprintln!("SKIP staged_hit_tier_faults: fixture has no hardlink capability");
+        return;
+    }
+    let faults = StagedFaultGuard::arm(
+        &output,
+        [
+            StagedFaultPoint::MaterializeReflink,
+            StagedFaultPoint::MaterializeHardlink,
+        ],
+    );
+    let payload = CachedPayload::File(payloads[0].clone());
+    let targets = vec![(&output, &payloads[0])];
+    let observed = write_payloads_par_with_mtime_floor_and_policies_observed(
+        &targets,
+        &[payload],
+        &Vec::<NormalizedPath>::new(),
+        &[crate::compiler::DeliveryPolicy::HardlinkEligible],
+    )
+    .unwrap();
+    assert_eq!(observed.reflink_count, 0);
+    assert_eq!(observed.hardlink_count, 0);
+    assert_eq!(observed.copy_count, 1);
+    assert_eq!(observed.copy_bytes, 18);
+    faults.assert_all_consumed();
+}
+
+#[test]
+fn staged_hit_copy_fault_leaves_no_partial_destination() {
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    std::fs::create_dir_all(&artifact_dir).unwrap();
+    let source = dir.path().join("source.rmeta");
+    std::fs::write(&source, b"copy failure payload").unwrap();
+    let key = "c".repeat(64);
+    persist_staged_artifact_paths(&artifact_dir, &key, &[source.into()]).unwrap();
+    let payload = load_staged_artifact_paths(&artifact_dir, &key, &[20])
+        .unwrap()
+        .unwrap()
+        .remove(0);
+    let output = dir.path().join("target.rmeta");
+    let faults = StagedFaultGuard::arm(
+        &output,
+        [
+            StagedFaultPoint::MaterializeReflink,
+            StagedFaultPoint::MaterializeCopy,
+        ],
+    );
+    write_cached_file(&output, &payload).unwrap_err();
+    assert!(!output.exists());
+    faults.assert_all_consumed();
+}
+
+#[test]
 fn staged_generation_digest_survives_registry_restart() {
     let dir = tempfile::tempdir().unwrap();
     let artifact_dir = dir.path().join("artifacts");

--- a/crates/zccache-daemon-core/src/daemon/staged_stats.rs
+++ b/crates/zccache-daemon-core/src/daemon/staged_stats.rs
@@ -104,6 +104,10 @@ pub(crate) enum StagedFailure {
     DurableDigest,
     Manifest,
     Publication,
+    PublicationOutputCopy,
+    GenerationPublish,
+    PointerCommit,
+    IndexCommit,
     PublicationConflict,
     Salvage,
     RequestedMaterialization,
@@ -164,6 +168,13 @@ const FAILURES: &[(StagedFailure, &str)] = &[
     (StagedFailure::DurableDigest, "durable_digest"),
     (StagedFailure::Manifest, "manifest"),
     (StagedFailure::Publication, "publication"),
+    (
+        StagedFailure::PublicationOutputCopy,
+        "publication_output_copy",
+    ),
+    (StagedFailure::GenerationPublish, "generation_publish"),
+    (StagedFailure::PointerCommit, "pointer_commit"),
+    (StagedFailure::IndexCommit, "index_commit"),
     (StagedFailure::PublicationConflict, "publication_conflict"),
     (StagedFailure::Salvage, "salvage"),
     (
@@ -322,5 +333,32 @@ mod tests {
             .chain(reset.bytes.values())
             .chain(reset.failures.values())
             .all(|value| *value == 0));
+    }
+
+    #[test]
+    fn concurrent_fault_accounting_has_no_lost_updates() {
+        let profiler = std::sync::Arc::new(StagedProfiler::new());
+        let threads = 16_u64;
+        let increments = 1_000_u64;
+        let workers: Vec<_> = (0..threads)
+            .map(|_| {
+                let profiler = std::sync::Arc::clone(&profiler);
+                std::thread::spawn(move || {
+                    for _ in 0..increments {
+                        profiler.count(StagedCounter::PublicationFailure);
+                        profiler.failure(StagedFailure::PointerCommit);
+                        profiler.timing(StagedTiming::Publication, 1);
+                    }
+                })
+            })
+            .collect();
+        for worker in workers {
+            worker.join().unwrap();
+        }
+        let snapshot = profiler.snapshot();
+        let expected = threads * increments;
+        assert_eq!(snapshot.counters["publication_failure"], expected);
+        assert_eq!(snapshot.failures["pointer_commit"], expected);
+        assert_eq!(snapshot.timings_ns["publication"], expected);
     }
 }

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -98,9 +98,9 @@ lane populates planning, compiler staging, hashing, publication, salvage, and
 requested-path materialization. V2 file hits report the tier that actually
 succeeded (reflink, hardlink-shared, or copy), copied bytes, failures, and
 elapsed ns. Archive, declared-linker, and exact-exec misses use the same
-planning, private-tool execution, and materialization accounting. Deterministic
-fault attribution remains tracked by #1071. The summary reports counters,
-nanosecond totals, copied-byte
+planning, private-tool execution, and materialization accounting. Publication,
+salvage, and materialization use path-scoped, one-shot test faults at commit and
+per-output edges. The summary reports counters, nanosecond totals, copied-byte
 totals, and stable failure reason IDs. Labels are daemon-owned constants:
 paths, argv, cache keys, and raw OS errors are never metric keys. Bincode
 protocol v18 carries this summary; the protobuf schema adds it as an optional


### PR DESCRIPTION
## Summary

- add path-scoped one-shot hooks for every staged publication commit edge, per-output salvage, and reflink/hardlink/copy materialization tier
- preserve partial physical observations in typed materialization errors and map publication failures to bounded stable reason IDs
- fail closed on index commit errors: salvage requested outputs, emit durable forensics, and do not publish a process-local cache entry
- split large test modules while adding publication matrices, tier fallback/cleanup tests, concurrent counter tests, and a real-clang IPC restart scenario

## Adversarial guarantees

- no partial generation is selected at any injected publication edge
- a post-pointer sync failure may expose only a complete validated generation
- partial salvage never reports completion and requested-path failure cannot report success
- failed index commit cannot turn the identical retry into a cache hit
- lifecycle records survive daemon restart and contain bounded fields without staging-path leakage

## Validation

- Windows: warning-denied daemon-core suite (481 passed, 20 ignored)
- Linux Docker: warning-denied daemon-core suite (488 passed, 20 ignored)
- focused fault family (22 passed, 1 intentionally ignored)
- real clang IPC fault/forensics test (passed)
- Linux Docker rustfmt check (passed)
- Linux Docker clippy with warnings denied (passed)

Part of #1071 and #1056.