### PR TITLE
fix(stats): isolate staged session telemetry

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/connection.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/connection.rs
@@ -22,6 +22,18 @@ enum ResponseWire {
 
 const SERVER_REQUEST_RECV_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
 
+pub(super) fn session_phase_profile(
+    state: &SharedState,
+    session_id: &SessionId,
+) -> crate::protocol::PhaseProfileSummary {
+    let mut totals = state.profiler.totals_snapshot();
+    totals.staged = state.session_staged_profiles.get(session_id).map_or_else(
+        || crate::daemon::staged_stats::StagedProfiler::new().snapshot(),
+        |profile| profile.snapshot(),
+    );
+    totals.into()
+}
+
 /// Run a child-spawning handler (compile / link / exec) while concurrently
 /// watching the client connection for disconnect (issue #967, meta #968).
 ///
@@ -370,7 +382,13 @@ pub(super) async fn handle_connection(
                             );
                         }
                     }
-                    compile_response_for_session(
+                    let request_profile = parsed_session_id.as_ref().and_then(|sid| {
+                        state
+                            .session_staged_profiles
+                            .get(sid)
+                            .map(|profile| Arc::clone(profile.value()))
+                    });
+                    let request = compile_response_for_session(
                         &state,
                         parsed_session_id,
                         session_id,
@@ -379,8 +397,14 @@ pub(super) async fn handle_connection(
                         compiler,
                         env,
                         stdin,
-                    )
-                    .await
+                    );
+                    match request_profile {
+                        Some(profile) => {
+                            crate::daemon::staged_stats::scope_request_profile(profile, request)
+                                .await
+                        }
+                        None => request.await,
+                    }
                 };
                 match guarded_dispatch(&mut conn, handler).await {
                     Some((response, ctx)) => (response, ctx),
@@ -447,10 +471,9 @@ pub(super) async fn handle_connection(
                                     bytes_read: f.bytes_read,
                                     bytes_written: f.bytes_written,
                                     lookup_outcomes: f.lookup_outcomes.into(),
-                                    // Daemon-wide phase totals — see
-                                    // PhaseProfileSummary doc for the
-                                    // single-vs-multi-session caveat.
-                                    phase_profile: Some(state.profiler.totals_snapshot().into()),
+                                    // Legacy phase fields remain daemon-wide;
+                                    // staged telemetry is request/session-owned.
+                                    phase_profile: Some(session_phase_profile(&state, &sid)),
                                 }
                             });
                             Response::SessionStatsResult { stats }
@@ -470,6 +493,8 @@ pub(super) async fn handle_connection(
                 match session_id.parse::<SessionId>() {
                     Ok(sid) => {
                         state.session_worktree_roots.remove(&sid);
+                        let ended_phase_profile = session_phase_profile(&state, &sid);
+                        state.session_staged_profiles.remove(&sid);
                         if let Some(session) = state.sessions.end(&sid) {
                             state.ended_sessions.insert(sid, ());
                             if !session.owner_pids.is_empty() {
@@ -497,7 +522,7 @@ pub(super) async fn handle_connection(
                                     bytes_read: f.bytes_read,
                                     bytes_written: f.bytes_written,
                                     lookup_outcomes: f.lookup_outcomes.into(),
-                                    phase_profile: Some(state.profiler.totals_snapshot().into()),
+                                    phase_profile: Some(ended_phase_profile),
                                 }
                             });
                             Response::SessionEnded { stats }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_clear.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_clear.rs
@@ -46,6 +46,9 @@ pub(super) async fn handle_clear(state: &SharedState) -> Response {
     // Reset stats and profiler.
     state.stats.reset();
     state.profiler.reset();
+    for profile in &state.session_staged_profiles {
+        profile.value().reset();
+    }
 
     // Delete on-disk artifact files in parallel. V2 generations are a
     // directory tree and coordinate with active publishers through their

--- a/crates/zccache-daemon-core/src/daemon/server/handle_release_worktree_handles.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_release_worktree_handles.rs
@@ -67,6 +67,7 @@ pub(super) async fn handle_release_worktree_handles(
         // down. Order matches connection.rs:295 to keep the two sites
         // visually comparable.
         state.session_worktree_roots.remove(&sid);
+        state.session_staged_profiles.remove(&sid);
         if let Some(ended) = state.sessions.end(&sid) {
             if !ended.owner_pids.is_empty() {
                 state

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -171,6 +171,7 @@ pub(super) fn new_shared_state(
             cache_dir: cache_dir.clone(),
             private_daemon: PrivateDaemonLifecycle::new(),
             sessions: SessionManager::new(std::time::Duration::from_secs(300)),
+            session_staged_profiles: DashMap::new(),
             system_includes: Mutex::new(system_includes_loaded),
             system_includes_cache_path,
             dep_graph: arc_swap::ArcSwap::from_pointee(DepGraph::new()),

--- a/crates/zccache-daemon-core/src/daemon/server/session.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/session.rs
@@ -70,6 +70,12 @@ pub(super) async fn handle_session_start(
     };
 
     let session_id = state.sessions.create(session_config);
+    if args.track_stats {
+        state.session_staged_profiles.insert(
+            session_id,
+            Arc::new(crate::daemon::staged_stats::StagedProfiler::new()),
+        );
+    }
     state.ended_sessions.remove(&session_id);
     state.session_worktree_roots.insert(
         session_id,

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -111,6 +111,9 @@ pub(super) struct SharedState {
     /// Private daemon lifetime/ref-count state.
     pub(super) private_daemon: PrivateDaemonLifecycle,
     pub(super) sessions: SessionManager,
+    /// Request-owned staged telemetry for active tracked sessions.
+    pub(super) session_staged_profiles:
+        DashMap<SessionId, Arc<crate::daemon::staged_stats::StagedProfiler>>,
     pub(super) system_includes: Mutex<SystemIncludeCache>,
     /// Dependency graph: tracks include relationships and cache verdicts.
     ///

--- a/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
@@ -26,6 +26,7 @@ mod release_worktree_handles;
 mod rustc_depinfo;
 mod server_ipc;
 mod session_errors;
+mod session_staged_attribution;
 mod system_includes_deferred;
 mod write_cached;
 

--- a/crates/zccache-daemon-core/src/daemon/server/tests/session_staged_attribution.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/session_staged_attribution.rs
@@ -1,0 +1,181 @@
+//! Cross-session isolation for staged pipeline telemetry (#1071).
+
+use super::super::*;
+use crate::protocol::StagedProfileSummary;
+
+#[cfg(unix)]
+type TestClientConnection = crate::ipc::IpcConnection;
+#[cfg(windows)]
+type TestClientConnection = crate::ipc::IpcClientConnection;
+
+async fn start_tracked_session(client: &mut TestClientConnection, cwd: &Path) -> SessionId {
+    client
+        .send(&Request::SessionStart {
+            client_pid: std::process::id(),
+            working_dir: cwd.into(),
+            log_file: None,
+            track_stats: true,
+            journal_path: None,
+            profile: false,
+            private_daemon: None,
+        })
+        .await
+        .unwrap();
+    match client.recv().await.unwrap() {
+        Some(Response::SessionStarted { session_id, .. }) => session_id.parse().unwrap(),
+        other => panic!("expected SessionStarted, got {other:?}"),
+    }
+}
+
+async fn session_staged(
+    client: &mut TestClientConnection,
+    session_id: SessionId,
+) -> StagedProfileSummary {
+    client
+        .send(&Request::SessionStats {
+            session_id: session_id.to_string(),
+        })
+        .await
+        .unwrap();
+    match client.recv().await.unwrap() {
+        Some(Response::SessionStatsResult { stats: Some(stats) }) => {
+            stats.phase_profile.unwrap().staged
+        }
+        other => panic!("expected SessionStatsResult, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn concurrent_failed_requests_are_attributed_only_to_their_session() {
+    crate::test_support::test_timeout(async {
+        use crate::daemon::staged_stats::{
+            scope_request_profile, StagedCounter, StagedFailure, StagedTiming,
+        };
+
+        let temp = tempfile::tempdir().unwrap();
+        let endpoint = crate::ipc::unique_test_endpoint();
+        let mut server = DaemonServer::bind(&endpoint).unwrap();
+        let state = server.test_state_arc();
+        let shutdown = server.shutdown_handle();
+        let server_task = tokio::spawn(async move { server.run(0).await.unwrap() });
+        let mut first_client = crate::ipc::connect(&endpoint).await.unwrap();
+        let mut second_client = crate::ipc::connect(&endpoint).await.unwrap();
+        let first_id = start_tracked_session(&mut first_client, temp.path()).await;
+        let second_id = start_tracked_session(&mut second_client, temp.path()).await;
+        let first_profile = Arc::clone(
+            state
+                .session_staged_profiles
+                .get(&first_id)
+                .unwrap()
+                .value(),
+        );
+        let second_profile = Arc::clone(
+            state
+                .session_staged_profiles
+                .get(&second_id)
+                .unwrap()
+                .value(),
+        );
+        let barrier = Arc::new(tokio::sync::Barrier::new(3));
+
+        let first_task = {
+            let state = Arc::clone(&state);
+            let barrier = Arc::clone(&barrier);
+            tokio::spawn(scope_request_profile(first_profile, async move {
+                barrier.wait().await;
+                state
+                    .profiler
+                    .staged
+                    .count(StagedCounter::PublicationFailure);
+                state.profiler.staged.failure(StagedFailure::PointerCommit);
+                state.profiler.staged.timing(StagedTiming::Publication, 7);
+            }))
+        };
+        let second_task = {
+            let state = Arc::clone(&state);
+            let barrier = Arc::clone(&barrier);
+            tokio::spawn(scope_request_profile(second_profile, async move {
+                barrier.wait().await;
+                state
+                    .profiler
+                    .staged
+                    .count(StagedCounter::MaterializeFailure);
+                state
+                    .profiler
+                    .staged
+                    .failure(StagedFailure::RequestedMaterialization);
+                state
+                    .profiler
+                    .staged
+                    .timing(StagedTiming::MissMaterialization, 11);
+            }))
+        };
+
+        barrier.wait().await;
+        first_task.await.unwrap();
+        second_task.await.unwrap();
+
+        // Unscoped work models an ephemeral link/exec request. It belongs only
+        // to daemon totals and must not appear in either tracked session.
+        state.profiler.staged.count(StagedCounter::PlanError);
+        state.profiler.staged.failure(StagedFailure::Planning);
+
+        let first = session_staged(&mut first_client, first_id).await;
+        assert_eq!(first.counters["publication_failure"], 1);
+        assert_eq!(first.counters["materialize_failure"], 0);
+        assert_eq!(first.counters["plan_error"], 0);
+        assert_eq!(first.failures["pointer_commit"], 1);
+        assert_eq!(first.failures["requested_materialization"], 0);
+        assert_eq!(first.timings_ns["publication"], 7);
+        assert_eq!(first.timings_ns["miss_materialization"], 0);
+
+        let second = session_staged(&mut second_client, second_id).await;
+        assert_eq!(second.counters["publication_failure"], 0);
+        assert_eq!(second.counters["materialize_failure"], 1);
+        assert_eq!(second.counters["plan_error"], 0);
+        assert_eq!(second.failures["pointer_commit"], 0);
+        assert_eq!(second.failures["requested_materialization"], 1);
+        assert_eq!(second.timings_ns["publication"], 0);
+        assert_eq!(second.timings_ns["miss_materialization"], 11);
+
+        let aggregate = state.profiler.staged.snapshot();
+        assert_eq!(aggregate.counters["publication_failure"], 1);
+        assert_eq!(aggregate.counters["materialize_failure"], 1);
+        assert_eq!(aggregate.counters["plan_error"], 1);
+
+        first_client
+            .send(&Request::SessionEnd {
+                session_id: first_id.to_string(),
+            })
+            .await
+            .unwrap();
+        match first_client.recv().await.unwrap() {
+            Some(Response::SessionEnded { stats: Some(stats) }) => {
+                let ended = stats.phase_profile.unwrap().staged;
+                assert_eq!(ended.counters["publication_failure"], 1);
+                assert_eq!(ended.counters["materialize_failure"], 0);
+                assert_eq!(ended.counters["plan_error"], 0);
+            }
+            other => panic!("expected SessionEnded stats, got {other:?}"),
+        }
+        assert!(!state.session_staged_profiles.contains_key(&first_id));
+
+        first_client.send(&Request::Clear).await.unwrap();
+        assert!(matches!(
+            first_client.recv().await.unwrap(),
+            Some(Response::Cleared { .. })
+        ));
+        let second = session_staged(&mut second_client, second_id).await;
+        assert!(second
+            .counters
+            .values()
+            .chain(second.timings_ns.values())
+            .chain(second.bytes.values())
+            .chain(second.failures.values())
+            .all(|value| *value == 0));
+
+        shutdown.notify_one();
+        server_task.await.unwrap();
+    })
+    .await;
+}

--- a/crates/zccache-daemon-core/src/daemon/staged_stats.rs
+++ b/crates/zccache-daemon-core/src/daemon/staged_stats.rs
@@ -1,6 +1,8 @@
 //! Bounded aggregate telemetry for immutable staged compiler outputs (#1071).
 
+use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use crate::protocol::StagedProfileSummary;
 
@@ -191,6 +193,19 @@ pub(crate) struct StagedProfiler {
     failures: [AtomicU64; FAILURES.len()],
 }
 
+tokio::task_local! {
+    static REQUEST_STAGED_PROFILE: Arc<StagedProfiler>;
+}
+
+/// Mirror staged observations made while `future` runs into one request's
+/// owning session without changing the daemon-wide aggregate call sites.
+pub(crate) async fn scope_request_profile<T>(
+    profile: Arc<StagedProfiler>,
+    future: impl Future<Output = T>,
+) -> T {
+    REQUEST_STAGED_PROFILE.scope(profile, future).await
+}
+
 fn saturating_atomic_add(value: &AtomicU64, amount: u64) {
     let _ = value.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
         Some(current.saturating_add(amount))
@@ -212,18 +227,46 @@ impl StagedProfiler {
     }
 
     pub(crate) fn add_count(&self, counter: StagedCounter, amount: u64) {
-        saturating_atomic_add(&self.counters[counter as usize], amount);
+        self.add_count_direct(counter, amount);
+        self.mirror(|profile| profile.add_count_direct(counter, amount));
     }
 
     pub(crate) fn timing(&self, timing: StagedTiming, elapsed_ns: u64) {
-        saturating_atomic_add(&self.timings_ns[timing as usize], elapsed_ns);
+        self.timing_direct(timing, elapsed_ns);
+        self.mirror(|profile| profile.timing_direct(timing, elapsed_ns));
     }
 
     pub(crate) fn bytes(&self, kind: StagedBytes, amount: u64) {
-        saturating_atomic_add(&self.bytes[kind as usize], amount);
+        self.bytes_direct(kind, amount);
+        self.mirror(|profile| profile.bytes_direct(kind, amount));
     }
 
     pub(crate) fn failure(&self, failure: StagedFailure) {
+        self.failure_direct(failure);
+        self.mirror(|profile| profile.failure_direct(failure));
+    }
+
+    fn mirror(&self, record: impl FnOnce(&StagedProfiler)) {
+        let _ = REQUEST_STAGED_PROFILE.try_with(|profile| {
+            if !std::ptr::eq(self, profile.as_ref()) {
+                record(profile);
+            }
+        });
+    }
+
+    fn add_count_direct(&self, counter: StagedCounter, amount: u64) {
+        saturating_atomic_add(&self.counters[counter as usize], amount);
+    }
+
+    fn timing_direct(&self, timing: StagedTiming, elapsed_ns: u64) {
+        saturating_atomic_add(&self.timings_ns[timing as usize], elapsed_ns);
+    }
+
+    fn bytes_direct(&self, kind: StagedBytes, amount: u64) {
+        saturating_atomic_add(&self.bytes[kind as usize], amount);
+    }
+
+    fn failure_direct(&self, failure: StagedFailure) {
         saturating_atomic_add(&self.failures[failure as usize], 1);
     }
 
@@ -360,5 +403,64 @@ mod tests {
         assert_eq!(snapshot.counters["publication_failure"], expected);
         assert_eq!(snapshot.failures["pointer_commit"], expected);
         assert_eq!(snapshot.timings_ns["publication"], expected);
+    }
+
+    #[tokio::test]
+    async fn concurrent_request_profiles_do_not_cross_attribute() {
+        let aggregate = Arc::new(StagedProfiler::new());
+        let first = Arc::new(StagedProfiler::new());
+        let second = Arc::new(StagedProfiler::new());
+        let barrier = Arc::new(tokio::sync::Barrier::new(3));
+
+        let first_task = {
+            let aggregate = Arc::clone(&aggregate);
+            let profile = Arc::clone(&first);
+            let barrier = Arc::clone(&barrier);
+            tokio::spawn(scope_request_profile(profile, async move {
+                barrier.wait().await;
+                for _ in 0..17 {
+                    aggregate.count(StagedCounter::PublicationFailure);
+                    aggregate.failure(StagedFailure::PointerCommit);
+                    aggregate.timing(StagedTiming::Publication, 3);
+                    tokio::task::yield_now().await;
+                }
+            }))
+        };
+        let second_task = {
+            let aggregate = Arc::clone(&aggregate);
+            let profile = Arc::clone(&second);
+            let barrier = Arc::clone(&barrier);
+            tokio::spawn(scope_request_profile(profile, async move {
+                barrier.wait().await;
+                for _ in 0..23 {
+                    aggregate.count(StagedCounter::PublicationFailure);
+                    aggregate.failure(StagedFailure::Manifest);
+                    aggregate.timing(StagedTiming::Publication, 5);
+                    tokio::task::yield_now().await;
+                }
+            }))
+        };
+
+        barrier.wait().await;
+        first_task.await.unwrap();
+        second_task.await.unwrap();
+
+        let aggregate = aggregate.snapshot();
+        assert_eq!(aggregate.counters["publication_failure"], 40);
+        assert_eq!(aggregate.failures["pointer_commit"], 17);
+        assert_eq!(aggregate.failures["manifest"], 23);
+        assert_eq!(aggregate.timings_ns["publication"], 166);
+
+        let first = first.snapshot();
+        assert_eq!(first.counters["publication_failure"], 17);
+        assert_eq!(first.failures["pointer_commit"], 17);
+        assert_eq!(first.failures["manifest"], 0);
+        assert_eq!(first.timings_ns["publication"], 51);
+
+        let second = second.snapshot();
+        assert_eq!(second.counters["publication_failure"], 23);
+        assert_eq!(second.failures["pointer_commit"], 0);
+        assert_eq!(second.failures["manifest"], 23);
+        assert_eq!(second.timings_ns["publication"], 115);
     }
 }

--- a/crates/zccache-protocol/src/messages/status.rs
+++ b/crates/zccache-protocol/src/messages/status.rs
@@ -129,15 +129,13 @@ pub struct SessionStats {
     /// Depgraph/artifact lookup outcome breakdown.
     #[serde(default)]
     pub lookup_outcomes: LookupOutcomes,
-    /// Daemon-wide phase-timing aggregate. `None` from older daemons that
-    /// don't populate the field; `Some` from PROTOCOL_VERSION >= 9 daemons.
+    /// Phase-timing aggregate. `None` from older daemons that don't populate
+    /// the field; `Some` from PROTOCOL_VERSION >= 9 daemons.
     ///
-    /// Aggregate is daemon-wide totals since the last
-    /// `PhaseProfiler::reset()` (which is called on `Request::Clear`). For
-    /// fresh-daemon perf scenarios this is equivalent to "this session's
-    /// phase totals". For long-lived daemons handling overlapping sessions,
-    /// totals cross-contaminate — that's acceptable for v1 and revisited if
-    /// a real consumer needs per-session isolation.
+    /// Legacy hit/miss fields are daemon-wide totals since the last Clear.
+    /// The nested staged-pipeline summary is request-owned and isolated to
+    /// this tracked session; concurrent or ephemeral requests cannot change it.
+    /// Clear resets both the daemon aggregate and active-session summaries.
     pub phase_profile: Option<PhaseProfileSummary>,
 }
 

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -100,7 +100,10 @@ succeeded (reflink, hardlink-shared, or copy), copied bytes, failures, and
 elapsed ns. Archive, declared-linker, and exact-exec misses use the same
 planning, private-tool execution, and materialization accounting. Publication,
 salvage, and materialization use path-scoped, one-shot test faults at commit and
-per-output edges. The summary reports counters, nanosecond totals, copied-byte
+per-output edges. Task-local mirroring attributes compile observations to the
+owning tracked session while preserving daemon aggregates; concurrent sessions
+and unscoped ephemeral requests cannot cross-contaminate staged totals. The
+summary reports counters, nanosecond totals, copied-byte
 totals, and stable failure reason IDs. Labels are daemon-owned constants:
 paths, argv, cache keys, and raw OS errors are never metric keys. Bincode
 protocol v18 carries this summary; the protobuf schema adds it as an optional

--- a/docs/journal-schema.md
+++ b/docs/journal-schema.md
@@ -86,7 +86,9 @@ reads only the documented fields; it tolerates malformed lines
 ## Engine phase profiling
 
 `session-stats --json` and `session-end --json` include `phase_profile` when
-the daemon can report aggregate cache-engine phase totals. Use
+the daemon can report cache-engine phase totals. Legacy hit/miss fields remain
+daemon-wide; the nested staged-pipeline summary contains only work attributed
+to that tracked session. Use
 `zccache engine-profile <stats-json>` to render the hit/miss phase breakdown
 from `last-session-stats.json` or captured session-stats JSON. Add `--json`
 for the stable machine-readable form.


### PR DESCRIPTION
## Summary

- mirror staged observations from each tracked Compile request into a task-local owning-session profiler while retaining daemon aggregates
- expose the session-owned staged summary through existing SessionStats/SessionEnd responses without changing the wire shape
- prevent concurrent sessions and unscoped ephemeral link/exec work from cross-attributing counters, reasons, bytes, or timings
- reset active session summaries on Clear and remove them on SessionEnd/worktree release

## Adversarial tests

- barrier-interleaved request scopes use distinct counts, reasons, and timings and prove exact aggregate/session identities
- two live IPC sessions receive only their own failure telemetry
- unscoped ephemeral-style observations remain daemon-only
- SessionEnd returns the final owned snapshot and removes it
- Clear resets every family for remaining active sessions
- real-clang publication/salvage fault test still reports exact session totals

## Validation

- Windows warning-denied daemon-core suite: 483 passed, 20 ignored
- Linux Docker warning-denied daemon-core suite: 490 passed, 20 ignored
- real clang fault/forensics integration: passed
- Docker rustfmt check: passed after final formatting correction
- Linux Docker clippy with warnings denied: passed

Part of #1071 and #1056.