### PR TITLE
test(cache): prove staged maintenance race safety

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -27,6 +27,10 @@ mod fault;
 pub(in crate::daemon::server) use fault::{
     inject as inject_staged_fault, StagedFaultGuard, StagedFaultPoint,
 };
+#[cfg(test)]
+mod hook;
+#[cfg(test)]
+pub(in crate::daemon::server) use hook::{StagedHookGuard, StagedHookPoint};
 
 pub(in crate::daemon::server) const STAGED_ARTIFACTS_ENV: &str = "ZCCACHE_STAGED_ARTIFACTS";
 
@@ -36,6 +40,10 @@ const PUBLISH_LOCK: &str = ".publish.lock";
 const STORE_LOCK: &str = ".store.lock";
 
 static STAGED_ARTIFACT_TMP_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+fn exclusive_publication_ns(total_ns: u64, hashing_ns: u64) -> u64 {
+    total_ns.saturating_sub(hashing_ns)
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(in crate::daemon::server) enum StagedPublishFailure {
@@ -499,6 +507,8 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
         .map_err(|error| publish_error(StagedPublishFailure::StoreSetup, error))?;
     fs2::FileExt::lock_shared(&store_lock)
         .map_err(|error| publish_error(StagedPublishFailure::StoreSetup, error))?;
+    #[cfg(test)]
+    hook::pause(artifact_dir, StagedHookPoint::PublicationStoreLocked);
     let key_root = root.join(key_hex);
     fs::create_dir_all(&key_root)
         .map_err(|error| publish_error(StagedPublishFailure::StoreSetup, error))?;
@@ -756,8 +766,8 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
                 );
             }
         }
-        stats.staged_publication_ns =
-            (publish_started.elapsed().as_nanos() as u64).saturating_sub(stats.staged_hash_ns);
+        let total_ns = publish_started.elapsed().as_nanos() as u64;
+        stats.staged_publication_ns = exclusive_publication_ns(total_ns, stats.staged_hash_ns);
         tracing::info!(
             event = "staged_publication_complete",
             cache_key = key_hex,
@@ -766,7 +776,7 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
             reflink_count = stats.reflink_count,
             copy_count = stats.copy_count,
             copy_bytes = stats.copy_bytes,
-            elapsed_ns = publish_started.elapsed().as_nanos() as u64,
+            elapsed_ns = total_ns,
             "published immutable staged artifact generation"
         );
         Ok(stats)

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/hook.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/hook.rs
@@ -1,0 +1,93 @@
+//! Deterministic, path-scoped staged-pipeline pause hooks for race tests.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, SyncSender};
+use std::sync::{Mutex, OnceLock};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::daemon::server) enum StagedHookPoint {
+    PublicationStoreLocked,
+    MaterializeOutput,
+}
+
+struct ActiveHook {
+    token: u64,
+    scope: PathBuf,
+    point: StagedHookPoint,
+    reached: SyncSender<()>,
+    resume: Receiver<()>,
+}
+
+static NEXT_TOKEN: AtomicU64 = AtomicU64::new(1);
+static ACTIVE: OnceLock<Mutex<Vec<ActiveHook>>> = OnceLock::new();
+
+fn active() -> &'static Mutex<Vec<ActiveHook>> {
+    ACTIVE.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+pub(in crate::daemon::server) struct StagedHookGuard {
+    token: u64,
+    reached: Receiver<()>,
+    resume: SyncSender<()>,
+}
+
+impl StagedHookGuard {
+    pub(in crate::daemon::server) fn arm(scope: &Path, point: StagedHookPoint) -> Self {
+        let token = NEXT_TOKEN.fetch_add(1, Ordering::Relaxed);
+        let (reached_tx, reached) = mpsc::sync_channel(1);
+        let (resume, resume_rx) = mpsc::sync_channel(1);
+        active()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .push(ActiveHook {
+                token,
+                scope: scope.to_path_buf(),
+                point,
+                reached: reached_tx,
+                resume: resume_rx,
+            });
+        Self {
+            token,
+            reached,
+            resume,
+        }
+    }
+
+    pub(in crate::daemon::server) fn wait_until_reached(&self) {
+        self.reached
+            .recv()
+            .expect("staged hook operation ended before reaching its pause point");
+    }
+
+    pub(in crate::daemon::server) fn resume(&self) {
+        self.resume
+            .send(())
+            .expect("staged hook operation ended before it was resumed");
+    }
+}
+
+impl Drop for StagedHookGuard {
+    fn drop(&mut self) {
+        active()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .retain(|hook| hook.token != self.token);
+        let _ = self.resume.try_send(());
+    }
+}
+
+pub(in crate::daemon::server) fn pause(scope_path: &Path, point: StagedHookPoint) {
+    let hook = {
+        let mut active = active().lock().unwrap_or_else(|error| error.into_inner());
+        let Some(index) = active
+            .iter()
+            .position(|hook| scope_path.starts_with(&hook.scope) && hook.point == point)
+        else {
+            return;
+        };
+        active.remove(index)
+    };
+    let _ = hook.reached.send(());
+    let _ = hook.resume.recv();
+}

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/materialize.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/materialize.rs
@@ -63,6 +63,8 @@ pub(in crate::daemon::server) fn materialize_independent_with_stats(
     source: &Path,
     destination: &Path,
 ) -> io::Result<StagedMaterializationStats> {
+    #[cfg(test)]
+    super::hook::pause(destination, super::StagedHookPoint::MaterializeOutput);
     if let Ok(metadata) = fs::metadata(destination) {
         if metadata.is_dir() {
             return Err(io::Error::new(

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store_tests.rs
@@ -11,6 +11,15 @@ fn source_files(dir: &Path) -> Vec<NormalizedPath> {
 }
 
 #[test]
+fn publication_timing_is_exclusive_of_hashing() {
+    let hashing_ns = 37;
+    let publication_ns = exclusive_publication_ns(100, hashing_ns);
+    assert_eq!(publication_ns, 63);
+    assert_eq!(hashing_ns + publication_ns, 100);
+    assert_eq!(exclusive_publication_ns(10, 11), 0);
+}
+
+#[test]
 fn staged_generation_is_independent_and_hash_addressed() {
     let dir = tempfile::tempdir().unwrap();
     let artifact_dir = dir.path().join("artifacts");
@@ -254,6 +263,121 @@ fn concurrent_same_key_publishers_never_overwrite_each_other() {
         fs::read(&payloads[0]).unwrap().as_slice(),
         b"generation-a" | b"generation-b"
     ));
+}
+
+#[test]
+fn clear_waits_for_in_flight_publication_then_removes_the_generation() {
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    let sources = source_files(dir.path());
+    let key = "1".repeat(64);
+    let hook = StagedHookGuard::arm(&artifact_dir, StagedHookPoint::PublicationStoreLocked);
+    let publisher = {
+        let artifact_dir = artifact_dir.clone();
+        let key = key.clone();
+        std::thread::spawn(move || persist_staged_artifact_paths(&artifact_dir, &key, &sources))
+    };
+    hook.wait_until_reached();
+
+    let (started_tx, started_rx) = std::sync::mpsc::sync_channel(1);
+    let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+    let clearer = {
+        let artifact_dir = artifact_dir.clone();
+        std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            done_tx.send(clear_staged_artifacts(&artifact_dir)).unwrap();
+        })
+    };
+    started_rx.recv().unwrap();
+    assert!(matches!(
+        done_rx.try_recv(),
+        Err(std::sync::mpsc::TryRecvError::Empty)
+    ));
+
+    hook.resume();
+    publisher.join().unwrap().unwrap();
+    assert!(done_rx.recv().unwrap().unwrap() > 0);
+    clearer.join().unwrap();
+    assert!(load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn eviction_waits_for_in_flight_publication_then_removes_the_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    let sources = source_files(dir.path());
+    let key = "2".repeat(64);
+    let hook = StagedHookGuard::arm(&artifact_dir, StagedHookPoint::PublicationStoreLocked);
+    let publisher = {
+        let artifact_dir = artifact_dir.clone();
+        let key = key.clone();
+        std::thread::spawn(move || persist_staged_artifact_paths(&artifact_dir, &key, &sources))
+    };
+    hook.wait_until_reached();
+
+    let (started_tx, started_rx) = std::sync::mpsc::sync_channel(1);
+    let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+    let evictor = {
+        let artifact_dir = artifact_dir.clone();
+        let key = key.clone();
+        std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            done_tx
+                .send(evict_staged_artifact_keys(
+                    &artifact_dir,
+                    &std::collections::HashSet::from([key]),
+                ))
+                .unwrap();
+        })
+    };
+    started_rx.recv().unwrap();
+    assert!(matches!(
+        done_rx.try_recv(),
+        Err(std::sync::mpsc::TryRecvError::Empty)
+    ));
+
+    hook.resume();
+    publisher.join().unwrap().unwrap();
+    assert!(done_rx.recv().unwrap().unwrap() > 0);
+    evictor.join().unwrap();
+    assert!(load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn clear_during_salvage_cannot_remove_private_compiler_outputs() {
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    let published = source_files(dir.path());
+    persist_staged_artifact_paths(&artifact_dir, &"3".repeat(64), &published).unwrap();
+
+    let private_root = dir.path().join("private-staging");
+    fs::create_dir_all(&private_root).unwrap();
+    let staged: NormalizedPath = private_root.join("result.rlib").into();
+    let requested: NormalizedPath = dir.path().join("result.rlib").into();
+    fs::write(&staged, b"successful compiler output").unwrap();
+    let plan = StagedCompilePlan::for_test(
+        private_root,
+        vec![StagedOutputPlan {
+            requested: requested.clone(),
+            staged,
+        }],
+    );
+    let hook = StagedHookGuard::arm(&requested, StagedHookPoint::MaterializeOutput);
+    let salvage = std::thread::spawn(move || plan.materialize());
+    hook.wait_until_reached();
+
+    assert!(clear_staged_artifacts(&artifact_dir).unwrap() > 0);
+    assert!(!requested.exists());
+    hook.resume();
+    salvage.join().unwrap().unwrap();
+    assert_eq!(fs::read(&requested).unwrap(), b"successful compiler output");
 }
 
 #[test]


### PR DESCRIPTION
Completes the remaining explicit adversarial evidence in #1071 after #1078 unified special-producer handlers.

## What changed

- adds test-only, path-scoped one-shot pause hooks for publication and requested-output materialization
- freezes publication while it owns the shared staged-store lock and proves Clear and eviction cannot complete until publication releases it
- freezes salvage materialization while Clear removes published generations and proves private compiler output remains available for successful delivery
- captures one total publication timestamp, derives an exclusive publication phase by subtracting hashing, and tests the accounting identity and saturation edge
- uses channels/hooks only; no sleeps or wall-clock assertions

## Validation

- focused timing/race tests: 4 passed on Windows
- Windows daemon-core broad: 492 passed, 20 ignored
- Linux Docker daemon-core broad: 499 passed, 20 ignored
- Linux Docker rustfmt: clean
- Linux Docker changed-crate Clippy with warnings denied: clean

This PR is intentionally test-heavy: production behavior changes only to capture one monotonic total timestamp instead of reading the clock twice.

Refs #1056