### PR TITLE
test(fs): require ReFS and large COW acceptance

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,7 +4,7 @@ GitHub Actions workflow definitions.
 
 - **ci.yml** - Runs fmt, Dylint, MSRV, and doc builds on main and pull requests.
 - **ci-check.yml** - Reusable check/test workflow used by the OS-specific CI workflows.
-- **fs-matrix.yml** - Provisions real ReFS/FAT, btrfs/ext4/vfat, and macOS disk-image fixtures for COW materialization acceptance.
+- **fs-matrix.yml** - Requires real ReFS/FAT, btrfs/ext4/vfat, and macOS fixtures on PRs; scheduled/manual runs also execute >4 GiB ReFS and btrfs COW acceptance.
 - **clippy.yml** - Runs Clippy on pushes to main for the README status badge.
 - **benchmark-stats.yml** - Manual/scheduled zccache vs bare compiler vs sccache benchmark publisher for the README images and rendered stats page.
 - **perf-guard.yml** - Main-only Rust, C, and C++ perf-regression guard that runs language jobs in parallel, fails below the zccache vs bare compiler or pinned-sccache speed floors, and uploads Markdown/JSON run artifacts.

--- a/.github/workflows/fs-matrix.yml
+++ b/.github/workflows/fs-matrix.yml
@@ -63,6 +63,7 @@ jobs:
 
   large-cow:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/fs-matrix.yml
+++ b/.github/workflows/fs-matrix.yml
@@ -1,6 +1,9 @@
 name: Filesystem Matrix
 
 on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 6 * * 0"
   push:
     branches: [main]
   pull_request:
@@ -50,6 +53,39 @@ jobs:
       - name: ReFS cluster-rounding acceptance
         if: runner.os == 'Windows'
         shell: bash
+        env:
+          ZCCACHE_REQUIRE_REFS: "1"
+          TEMP: ${{ runner.temp }}
+          TMP: ${{ runner.temp }}
         run: >-
           soldr cargo test -p zccache-daemon-core --features test-support
-          refs_non_cluster_multiple_round_trips_when_available -- --nocapture --test-threads=1
+          refs_non_cluster_multiple_round_trips -- --nocapture --test-threads=1
+
+  large-cow:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: zackees/setup-soldr@v0.9.62
+        with:
+          zccache-seed-strict: true
+          toolchain: 1.94.1
+          cache: true
+          cache-key-suffix: fs-large-cow-${{ matrix.os }}
+          linker: fast
+      - name: Install btrfs fixture tools
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y btrfs-progs
+      - name: Run required >4 GiB COW acceptance
+        shell: bash
+        env:
+          ZCCACHE_REQUIRE_LARGE_COW: "1"
+          TEMP: ${{ runner.temp }}
+          TMP: ${{ runner.temp }}
+        run: >-
+          soldr cargo test -p zccache-daemon-core --features test-support
+          reflink_larger_than_four_gib_uses_chunked_clone -- --nocapture --test-threads=1

--- a/crates/zccache-daemon-core/src/daemon/server/persist/link_registry.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/link_registry.rs
@@ -72,6 +72,33 @@ pub(in crate::daemon::server) fn write_authoritative_blob_digest(
     write_authoritative_blob_digest_for(blob_path, blob_path)
 }
 
+#[cfg(test)]
+pub(in crate::daemon::server) fn register_trusted_blob_for_test(
+    blob_path: &Path,
+) -> std::io::Result<()> {
+    let id = get_file_id(blob_path).ok_or_else(|| {
+        std::io::Error::other(format!(
+            "unable to identify test cache blob {}",
+            blob_path.display()
+        ))
+    })?;
+    if let Some((_, stale)) = registry().remove(&id) {
+        for output in stale.outputs {
+            output_ids().remove(&output);
+        }
+    }
+    registry().insert(
+        id,
+        LinkRecord {
+            blob_path: blob_path.to_path_buf(),
+            expected_hash: [0; 32],
+            outputs: BTreeSet::new(),
+            suspect: false,
+        },
+    );
+    Ok(())
+}
+
 /// Owns the digest sidecar published by one artifact-write attempt.
 ///
 /// Dropping an uncommitted guard removes only the sidecar installed by that

--- a/crates/zccache-daemon-core/src/daemon/server/persist/write_cached.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/write_cached.rs
@@ -37,9 +37,19 @@ fn materialize_cached_file(
     cache_file: &Path,
     delivery: crate::compiler::DeliveryPolicy,
 ) -> std::io::Result<StagedMaterializationStats> {
+    materialize_cached_file_observed(out_path, cache_file, delivery, false)
+}
+
+fn materialize_cached_file_observed(
+    out_path: &Path,
+    cache_file: &Path,
+    delivery: crate::compiler::DeliveryPolicy,
+    force_observation: bool,
+) -> std::io::Result<StagedMaterializationStats> {
     let staged = is_staged_artifact_path(cache_file);
+    let observe = force_observation || staged;
     let observed = |reflink_count, hardlink_count, copy_count, copy_bytes| {
-        if staged {
+        if observe {
             StagedMaterializationStats {
                 reflink_count,
                 hardlink_count,
@@ -165,6 +175,19 @@ fn materialize_cached_file(
     restore_cache_mtime(cache_file, out_path)?;
     touch_mtime(out_path);
     Ok(observed(0, 0, 1, copied_bytes))
+}
+
+#[cfg(test)]
+pub(in crate::daemon::server) fn write_cached_file_observed(
+    out_path: &Path,
+    cache_file: &Path,
+) -> std::io::Result<StagedMaterializationStats> {
+    materialize_cached_file_observed(
+        out_path,
+        cache_file,
+        crate::compiler::DeliveryPolicy::IndependentOnly,
+        true,
+    )
 }
 
 fn cleanup_failed_hardlink(

--- a/crates/zccache-daemon-core/src/daemon/server/tests/fs_matrix.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/fs_matrix.rs
@@ -255,6 +255,7 @@ fn reflink_larger_than_four_gib_uses_chunked_clone() {
     let old_time = filetime::FileTime::from_unix_time(1_000_000_000, 100);
     filetime::set_file_mtime(&blob, old_time).unwrap();
     drop(file);
+    write_authoritative_blob_digest(&blob).unwrap();
     let caps = fs_caps(&blob, &output);
     assert!(caps.reflink, "stress fixture must support reflinks");
     let observed = write_cached_file_observed(&output, &blob).unwrap();
@@ -276,7 +277,7 @@ fn reflink_larger_than_four_gib_uses_chunked_clone() {
     output_file.sync_all().unwrap();
     assert_eq!(read_at(&blob, FOUR_GIB + 9, 14), b"boundary-after");
     std::fs::remove_file(&output).unwrap();
-    std::fs::remove_file(&blob).unwrap();
+    remove_registered_blob(&blob).unwrap();
     assert!(!output.exists() && !blob.exists());
     println!(
         "large COW acceptance: executed fixture={} bytes={LENGTH} tier=reflink copied_bytes=0 mutation_isolated=true mtime_preserved=true file_identity=independent cleanup=true",

--- a/crates/zccache-daemon-core/src/daemon/server/tests/fs_matrix.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/fs_matrix.rs
@@ -256,7 +256,7 @@ fn reflink_larger_than_four_gib_uses_chunked_clone() {
     let old_time = filetime::FileTime::from_unix_time(1_000_000_000, 100);
     filetime::set_file_mtime(&blob, old_time).unwrap();
     drop(file);
-    write_authoritative_blob_digest(&blob).unwrap();
+    register_trusted_blob_for_test(&blob).unwrap();
     let caps = fs_caps(&blob, &output);
     assert!(caps.reflink, "stress fixture must support reflinks");
     let observed = write_cached_file_observed(&output, &blob).unwrap();

--- a/crates/zccache-daemon-core/src/daemon/server/tests/fs_matrix.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/fs_matrix.rs
@@ -210,6 +210,7 @@ fn refs_non_cluster_multiple_round_trips() {
     std::fs::write(&blob, &bytes).unwrap();
     let old_time = filetime::FileTime::from_unix_time(1_000_000_000, 100);
     filetime::set_file_mtime(&blob, old_time).unwrap();
+    write_authoritative_blob_digest(&blob).unwrap();
     let observed = write_cached_file_observed(&output, &blob).unwrap();
     assert_eq!(observed.reflink_count, 1, "ReFS must use the reflink tier");
     assert_eq!(observed.copy_bytes, 0);
@@ -221,7 +222,7 @@ fn refs_non_cluster_multiple_round_trips() {
     std::fs::write(&output, b"private").unwrap();
     assert_eq!(std::fs::read(&blob).unwrap(), bytes);
     std::fs::remove_file(&output).unwrap();
-    std::fs::remove_file(&blob).unwrap();
+    remove_registered_blob(&blob).unwrap();
     assert!(!output.exists() && !blob.exists());
     println!(
         "ReFS acceptance: executed tier=reflink copied_bytes=0 mutation_isolated=true mtime_preserved=true file_identity=independent cleanup=true"

--- a/crates/zccache-daemon-core/src/daemon/server/tests/fs_matrix.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/fs_matrix.rs
@@ -1,6 +1,7 @@
 //! Parameterized real-filesystem acceptance matrix for #1039.
 
 use super::super::*;
+use std::io::{Seek, SeekFrom, Write};
 use zccache_test_support::{FixtureResult, FsFixture};
 
 type Builder = fn() -> FixtureResult;
@@ -16,9 +17,9 @@ fn filesystem_materialization_matrix_prints_loud_summary() {
     for (row_name, cross_volume, builder) in builders {
         match builder() {
             Ok(fixture) => {
-                let tier = exercise_row(&fixture, cross_volume);
+                let evidence = exercise_row(&fixture, cross_volume);
                 executed_names.push(row_name);
-                executed.push(format!("{row_name} ({tier})"));
+                executed.push(format!("{row_name} ({evidence})"));
             }
             Err(skip) => skipped.push(format!("{} ({})", skip.name, skip.reason)),
         }
@@ -41,29 +42,31 @@ fn filesystem_materialization_matrix_prints_loud_summary() {
 }
 
 fn assert_required_ci_rows(executed: &[&str]) {
-    // refs-vhdx is intentionally NOT required here. Across many attempts on
-    // GitHub-hosted windows-latest runners, `diskpart create vdisk` /
-    // VDS-attach for this row alone failed deterministically within a
-    // single job (all 3 attempts of an in-workflow retry loop hit the
-    // identical "not enough space on the disk" error) despite confirmed
-    // plentiful real free space (32+ GB on C:, 143+ GB on D:) and every
-    // other windows_vhd-backed row (fat32-vhdx, exfat-vhdx, cross-volume;
-    // same VHDX machinery, non-ReFS) succeeding consistently. That points
-    // at a GH-Actions-runner-level VDS/Hyper-V constraint outside this
-    // code's control, not a materialization defect — see PR #1040 / issue
-    // #1039 for the investigation. The fixture still runs and is exercised
-    // whenever the environment cooperates; it's just not a hard gate.
     #[cfg(windows)]
-    let required = ["windows-ntfs-native", "fat32-vhdx"];
+    let required = [
+        "windows-ntfs-native",
+        "refs-vhdx",
+        "fat32-vhdx",
+        "exfat-vhdx",
+        "smb-loopback",
+        "windows-cross-volume",
+    ];
     #[cfg(target_os = "linux")]
     let required = [
         "linux-native-overlayfs",
         "ext4-loop",
         "btrfs-loop",
+        "tmpfs",
         "linux-cross-volume-tmpfs",
+        "vfat-loop",
     ];
     #[cfg(target_os = "macos")]
-    let required = ["apfs-native", "exfat-image", "mac-cross-volume-hfs"];
+    let required = [
+        "apfs-native",
+        "hfs-image",
+        "mac-cross-volume-hfs",
+        "exfat-image",
+    ];
     #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
     let required: [&str; 0] = [];
 
@@ -110,7 +113,7 @@ fn platform_builders() -> Vec<MatrixRow> {
     Vec::new()
 }
 
-fn exercise_row(fixture: &FsFixture, cross_volume: bool) -> &'static str {
+fn exercise_row(fixture: &FsFixture, cross_volume: bool) -> String {
     let source_fixture = cross_volume.then(|| tempfile::tempdir().unwrap());
     let source_root = source_fixture
         .as_ref()
@@ -133,19 +136,20 @@ fn exercise_row(fixture: &FsFixture, cross_volume: bool) -> &'static str {
     if cross_volume {
         assert!(!caps.reflink && !caps.hardlink);
     }
-    write_cached_output(&output, &blob, original).unwrap();
+    let observed = write_cached_file_observed(&output, &blob).unwrap();
     let output_time =
         filetime::FileTime::from_last_modification_time(&std::fs::metadata(&output).unwrap());
     assert_eq!(output_time.unix_seconds(), blob_time.unix_seconds());
+    let shares_file_identity = same_file(&blob, &output);
 
-    let tier = if caps.reflink {
-        assert!(!same_file(&blob, &output));
+    let tier = if observed.reflink_count == 1 {
+        assert!(!shares_file_identity);
         make_writable(&output).unwrap();
         std::fs::write(&output, b"private").unwrap();
         assert_eq!(std::fs::read(&blob).unwrap(), original);
         "reflink"
-    } else if caps.hardlink {
-        assert!(same_file(&blob, &output));
+    } else if observed.hardlink_count == 1 {
+        assert!(shares_file_identity);
         let mutation = std::fs::write(&output, b"poison");
         if mutation.is_ok() {
             mark_registered_links_suspect([output.as_path()]);
@@ -156,50 +160,137 @@ fn exercise_row(fixture: &FsFixture, cross_volume: bool) -> &'static str {
             assert_eq!(std::fs::read(&blob).unwrap(), original);
         }
         "hardlink-cow-lite"
-    } else {
-        assert!(!same_file(&blob, &output));
+    } else if observed.copy_count == 1 {
+        assert!(!shares_file_identity);
         std::fs::write(&output, b"private").unwrap();
         assert_eq!(std::fs::read(&blob).unwrap(), original);
         "copy"
+    } else {
+        panic!("materialization must report exactly one physical tier")
+    };
+    let copied_bytes = observed.copy_bytes;
+    let mutation_behavior = if tier == "hardlink-cow-lite" {
+        "detected-or-blocked"
+    } else {
+        "isolated"
+    };
+    let file_identity = if shares_file_identity {
+        "shared-protected"
+    } else {
+        "independent"
     };
     let _ = make_writable(&blob);
     let _ = make_writable(&output);
-    tier
+    if output.exists() {
+        std::fs::remove_file(&output).unwrap();
+    }
+    std::fs::remove_file(&blob).unwrap();
+    let cleanup = !output.exists() && !blob.exists();
+    assert!(cleanup);
+    format!(
+        "tier={tier} copied_bytes={copied_bytes} mutation_behavior={mutation_behavior} mtime_preserved=true file_identity={file_identity} cleanup={cleanup}"
+    )
 }
 
 /// ReFS uses cluster-rounded duplicate-extents calls for non-aligned lengths.
 #[cfg(windows)]
 #[test]
-fn refs_non_cluster_multiple_round_trips_when_available() {
-    let Ok(fixture) = FsFixture::refs_vhdx() else {
-        return;
+fn refs_non_cluster_multiple_round_trips() {
+    let fixture = match FsFixture::refs_vhdx() {
+        Ok(fixture) => fixture,
+        Err(skip) if std::env::var_os("ZCCACHE_REQUIRE_REFS").is_none() => {
+            println!("ReFS acceptance: skipped ({})", skip.reason);
+            return;
+        }
+        Err(skip) => panic!("required ReFS fixture unavailable: {skip:?}"),
     };
     let blob = fixture.root().join("unaligned.bin");
     let output = fixture.root().join("unaligned-out.bin");
     let bytes = vec![0xa5; 64 * 1024 + 17];
     std::fs::write(&blob, &bytes).unwrap();
-    write_authoritative_blob_digest(&blob).unwrap();
-    write_cached_output(&output, &blob, &bytes).unwrap();
-    assert_eq!(std::fs::read(output).unwrap(), bytes);
+    let old_time = filetime::FileTime::from_unix_time(1_000_000_000, 100);
+    filetime::set_file_mtime(&blob, old_time).unwrap();
+    let observed = write_cached_file_observed(&output, &blob).unwrap();
+    assert_eq!(observed.reflink_count, 1, "ReFS must use the reflink tier");
+    assert_eq!(observed.copy_bytes, 0);
+    assert!(!same_file(&blob, &output));
+    assert_eq!(std::fs::read(&output).unwrap(), bytes);
+    let output_time =
+        filetime::FileTime::from_last_modification_time(&std::fs::metadata(&output).unwrap());
+    assert_eq!(output_time.unix_seconds(), old_time.unix_seconds());
+    std::fs::write(&output, b"private").unwrap();
+    assert_eq!(std::fs::read(&blob).unwrap(), bytes);
+    std::fs::remove_file(&output).unwrap();
+    std::fs::remove_file(&blob).unwrap();
+    assert!(!output.exists() && !blob.exists());
+    println!(
+        "ReFS acceptance: executed tier=reflink copied_bytes=0 mutation_isolated=true mtime_preserved=true file_identity=independent cleanup=true"
+    );
 }
 
-/// >4 GiB clone chunking is intentionally opt-in for local disks.
-#[ignore = "stress tier: creates a sparse file larger than 4 GiB"]
+/// >4 GiB clone chunking executes only in the bounded scheduled/manual gate.
 #[test]
 fn reflink_larger_than_four_gib_uses_chunked_clone() {
+    if std::env::var_os("ZCCACHE_REQUIRE_LARGE_COW").is_none() {
+        println!("large COW acceptance: skipped (ZCCACHE_REQUIRE_LARGE_COW is unset)");
+        return;
+    }
     let fixture = platform_reflink_fixture().expect("reflink fixture prerequisite unavailable");
     let blob = fixture.root().join("large.bin");
     let output = fixture.root().join("large-out.bin");
-    let file = std::fs::File::create(&blob).unwrap();
-    file.set_len(4 * 1024 * 1024 * 1024 + 64 * 1024).unwrap();
-    write_authoritative_blob_digest(&blob).unwrap();
+    const FOUR_GIB: u64 = 4 * 1024 * 1024 * 1024;
+    const LENGTH: u64 = FOUR_GIB + 64 * 1024 + 17;
+    let mut file = std::fs::File::create(&blob).unwrap();
+    file.set_len(LENGTH).unwrap();
+    for (offset, marker) in [
+        (0, b"head".as_slice()),
+        (FOUR_GIB - 7, b"boundary-before".as_slice()),
+        (FOUR_GIB + 9, b"boundary-after".as_slice()),
+        (LENGTH - 4, b"tail".as_slice()),
+    ] {
+        file.seek(SeekFrom::Start(offset)).unwrap();
+        file.write_all(marker).unwrap();
+    }
+    file.sync_all().unwrap();
+    let old_time = filetime::FileTime::from_unix_time(1_000_000_000, 100);
+    filetime::set_file_mtime(&blob, old_time).unwrap();
+    drop(file);
     let caps = fs_caps(&blob, &output);
     assert!(caps.reflink, "stress fixture must support reflinks");
-    write_cached_file(&output, &blob).unwrap();
-    assert_eq!(
-        std::fs::metadata(output).unwrap().len(),
-        4 * 1024 * 1024 * 1024 + 64 * 1024
+    let observed = write_cached_file_observed(&output, &blob).unwrap();
+    assert_eq!(observed.reflink_count, 1);
+    assert_eq!(observed.copy_bytes, 0);
+    assert_eq!(std::fs::metadata(&output).unwrap().len(), LENGTH);
+    assert!(!same_file(&blob, &output));
+    assert_eq!(read_at(&output, FOUR_GIB - 7, 15), b"boundary-before");
+    assert_eq!(read_at(&output, FOUR_GIB + 9, 14), b"boundary-after");
+    let output_time =
+        filetime::FileTime::from_last_modification_time(&std::fs::metadata(&output).unwrap());
+    assert_eq!(output_time.unix_seconds(), old_time.unix_seconds());
+    let mut output_file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&output)
+        .unwrap();
+    output_file.seek(SeekFrom::Start(FOUR_GIB + 9)).unwrap();
+    output_file.write_all(b"private-output").unwrap();
+    output_file.sync_all().unwrap();
+    assert_eq!(read_at(&blob, FOUR_GIB + 9, 14), b"boundary-after");
+    std::fs::remove_file(&output).unwrap();
+    std::fs::remove_file(&blob).unwrap();
+    assert!(!output.exists() && !blob.exists());
+    println!(
+        "large COW acceptance: executed fixture={} bytes={LENGTH} tier=reflink copied_bytes=0 mutation_isolated=true mtime_preserved=true file_identity=independent cleanup=true",
+        fixture.name()
     );
+}
+
+fn read_at(path: &std::path::Path, offset: u64, length: usize) -> Vec<u8> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path).unwrap();
+    file.seek(SeekFrom::Start(offset)).unwrap();
+    let mut bytes = vec![0; length];
+    file.read_exact(&mut bytes).unwrap();
+    bytes
 }
 
 fn platform_reflink_fixture() -> FixtureResult {

--- a/crates/zccache-test-support/src/lib.rs
+++ b/crates/zccache-test-support/src/lib.rs
@@ -67,18 +67,10 @@ impl FsFixture {
     }
 
     pub fn refs_vhdx() -> FixtureResult {
-        // A 512 MB ceiling was tried to reduce ReFS's metadata footprint
-        // (its checksummed integrity streams scale with declared capacity
-        // even under `format ... quick`) but empirically triggered VDS's
-        // own "The volume size is too small" error — 1024 MB is below
-        // that failure's boundary and is the size known to pass ReFS's
-        // format step; the earlier intermittent "not enough space on the
-        // disk" failures at this same 1024 MB size are CI-runner-level
-        // VDS/diskpart flakiness (real free space was confirmed plentiful
-        // — 32+ GB on C:, 143+ GB on D: — in a run that still failed),
-        // mitigated by the retry loop wrapping this step in fs-matrix.yml
-        // rather than by changing the declared size further.
-        windows_vhd_sized("refs-vhdx", "refs", 1024)
+        // Dev Drive-era ReFS provisioning rejects tiny volumes even when the
+        // VHDX is dynamically expanding. Keep a 64 GiB virtual ceiling while
+        // paying only for allocated metadata/data blocks on the host volume.
+        windows_vhd_sized("refs-vhdx", "refs", 64 * 1024)
     }
 
     pub fn fat32_vhdx() -> FixtureResult {


### PR DESCRIPTION
## Summary
- make every local filesystem matrix row, including ReFS, a required hosted-CI gate
- record materialization tier, copied bytes, mutation isolation, mtime, file identity, and cleanup
- add scheduled/manual >4 GiB COW acceptance on ReFS and btrfs

## Validation
- soldr --no-cache cargo fmt --all -- --check
- soldr --no-cache cargo clippy -p zccache-daemon-core -p zccache-test-support --all-targets --features zccache-daemon-core/test-support --no-deps -- -D warnings
- focused filesystem matrix and large-COW test entrypoints

Closes #1083