### PR TITLE
fix(cache): harden staged multi-source publication

### DIFF
--- a/crates/zccache-daemon-core/Cargo.toml
+++ b/crates/zccache-daemon-core/Cargo.toml
@@ -79,6 +79,8 @@ windows-sys = { version = "0.59", features = [
     "Win32_Security",
     "Win32_Storage_FileSystem",
     "Win32_System_JobObjects",
+    "Win32_System_IO",
+    "Win32_System_Ioctl",
     "Win32_System_Threading",
 ] }
 

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
@@ -89,6 +89,32 @@ pub(super) async fn run_compiler_direct(
     // compiler path; `detect_family` falls back to Gcc for unknown
     // names, which matches the historical behaviour.
     let family_hint = crate::compiler::detect_family(&compiler.to_string_lossy());
+    run_compiler_direct_with_family(
+        compiler,
+        args,
+        cwd,
+        sessions,
+        sid,
+        client_env,
+        stdin_bytes,
+        tmp_dir,
+        family_hint,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn run_compiler_direct_with_family(
+    compiler: &NormalizedPath,
+    args: &[String],
+    cwd: &Path,
+    sessions: &SessionManager,
+    sid: &SessionId,
+    client_env: &Option<Vec<(String, String)>>,
+    stdin_bytes: &[u8],
+    tmp_dir: &Path,
+    family_hint: crate::compiler::CompilerFamily,
+) -> Response {
     let _rsp_guard = match crate::compiler::response_file::write_response_file_if_needed(
         args,
         tmp_dir,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -4,36 +4,16 @@ use super::*;
 
 #[path = "handle_compile_multi_args.rs"]
 mod args;
+#[path = "handle_compile_multi_preflight.rs"]
+mod preflight;
 #[path = "handle_compile_multi_staged.rs"]
 mod staged;
+#[path = "handle_compile_multi_types.rs"]
+mod types;
 
 use args::filter_multi_source_args;
-
-/// A deferred output write for a cache hit.
-pub(super) struct PendingWrite {
-    out_path: NormalizedPath,
-    cache_file: NormalizedPath,
-    data: Vec<u8>,
-}
-
-/// Result of a per-unit cache check in multi-file compile.
-pub(super) enum UnitCacheResult {
-    /// Cache hit — output write is deferred for batching.
-    Hit {
-        stdout: Arc<Vec<u8>>,
-        stderr: Arc<Vec<u8>>,
-        artifact_bytes: u64,
-        source_path: NormalizedPath,
-        pending_writes: Vec<PendingWrite>,
-    },
-    /// Cache miss — needs compilation.
-    Miss {
-        source_path: NormalizedPath,
-        output_path: NormalizedPath,
-        context_key: ContextKey,
-        ctx: Box<CompileContext>,
-    },
-}
+use preflight::InputSnapshot;
+use types::{PendingWrite, UnitCacheResult};
 
 pub(super) fn materialize_multi_hit(
     targets: &[(NormalizedPath, NormalizedPath)],
@@ -213,6 +193,7 @@ pub(super) fn check_unit_cache(
                 output_path,
                 context_key,
                 ctx: Box::new(ctx),
+                input_snapshot: InputSnapshot::incomplete(snap_clock),
             };
         }
     };
@@ -350,11 +331,13 @@ pub(super) fn check_unit_cache(
     }
 
     state.fast_hit_cache.remove(&context_key);
+    let input_snapshot = InputSnapshot::capture(state, &source_path, &ctx, hash_map, snap_clock);
     UnitCacheResult::Miss {
         source_path,
         output_path,
         context_key,
         ctx: Box::new(ctx),
+        input_snapshot,
     }
 }
 
@@ -377,6 +360,20 @@ pub(super) async fn handle_compile_multi(
     let mut all_stdout = Vec::new();
     let mut all_stderr = Vec::new();
     let key_root = worktree_root.as_ref().unwrap_or(&cwd_path).clone();
+
+    if let Some(response) = preflight::run_unsupported_batch(
+        &state,
+        &sid,
+        &compiler,
+        &compilations,
+        &original_args,
+        &cwd_path,
+        &client_env,
+    )
+    .await
+    {
+        return response;
+    }
 
     // ── Pre-parse shared args once for all units ─────────────────────
     // All units share the same original_args (via Arc) — only source/output
@@ -548,8 +545,8 @@ pub(super) async fn handle_compile_multi(
         &source_indices,
         &unit_results,
         &cwd_path,
+        &key_root,
         &client_env,
-        snap_clock,
         &mut all_stdout,
         &mut all_stderr,
     )
@@ -685,6 +682,7 @@ pub(super) async fn handle_compile_multi(
                 output_path,
                 context_key,
                 ctx,
+                ..
             } => (
                 source_path.clone(),
                 output_path.clone(),

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_preflight.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_preflight.rs
@@ -1,0 +1,433 @@
+//! Whole-invocation planning before any cache lookup or requested-path write.
+
+use super::*;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct InputStamp {
+    len: u64,
+    modified: Option<std::time::SystemTime>,
+    created: Option<std::time::SystemTime>,
+    file_id: Option<FileId>,
+    change_marker: Option<i128>,
+}
+
+fn input_stamp(path: &Path) -> Option<InputStamp> {
+    let metadata = std::fs::metadata(path).ok()?;
+    Some(InputStamp {
+        len: metadata.len(),
+        modified: metadata.modified().ok(),
+        created: metadata.created().ok(),
+        file_id: get_file_id(path),
+        change_marker: get_file_change_marker(path),
+    })
+}
+
+fn stamps_have_native_markers(stamps: &HashMap<NormalizedPath, InputStamp>) -> bool {
+    stamps.values().all(|stamp| stamp.change_marker.is_some())
+}
+
+fn direct_response_family(
+    family: crate::compiler::CompilerFamily,
+    args: &[String],
+) -> crate::compiler::CompilerFamily {
+    if family == crate::compiler::CompilerFamily::Msvc
+        || crate::compiler::parse_msvc::looks_like_msvc_args(args)
+    {
+        crate::compiler::CompilerFamily::Msvc
+    } else {
+        family
+    }
+}
+
+fn derived_staged_side_outputs(
+    compilations: &[crate::compiler::CacheableCompilation],
+    args: &[String],
+    cwd: &NormalizedPath,
+) -> HashSet<NormalizedPath> {
+    let lower: Vec<String> = args.iter().map(|arg| arg.to_ascii_lowercase()).collect();
+    let split_dwarf = lower.iter().any(|arg| arg.starts_with("-gsplit-dwarf"));
+    let stack_usage = lower.iter().any(|arg| arg == "-fstack-usage");
+    let save_temps = lower.iter().any(|arg| arg.starts_with("-save-temps"));
+    let default_depfiles = lower
+        .iter()
+        .any(|arg| matches!(arg.as_str(), "-md" | "-mmd"))
+        && !args
+            .iter()
+            .any(|arg| arg == "-MF" || (arg.starts_with("-MF") && arg.len() > 3));
+    let coverage = lower.iter().any(|arg| {
+        matches!(
+            arg.as_str(),
+            "--coverage" | "-coverage" | "-fprofile-arcs" | "-ftest-coverage"
+        )
+    });
+    let time_trace = lower.iter().any(|arg| arg == "-ftime-trace");
+    let callgraph = lower.iter().any(|arg| arg.starts_with("-fcallgraph-info"));
+    let optimization_record = lower.iter().any(|arg| arg == "-fsave-optimization-record");
+    let sarif = lower
+        .iter()
+        .any(|arg| arg.starts_with("-fdiagnostics-format=sarif-file"));
+    let default_doc = lower
+        .iter()
+        .any(|arg| matches!(arg.as_str(), "/doc" | "-doc"));
+    let creates_pch = args.iter().any(|arg| {
+        arg.strip_prefix('/')
+            .or_else(|| arg.strip_prefix('-'))
+            .is_some_and(|body| body.starts_with("Yc"))
+    });
+    let explicit_pch = args.iter().any(|arg| {
+        arg.strip_prefix('/')
+            .or_else(|| arg.strip_prefix('-'))
+            .is_some_and(|body| body.starts_with("Fp"))
+    });
+    let default_assembly_listing = lower.iter().any(|arg| {
+        arg.strip_prefix('/')
+            .or_else(|| arg.strip_prefix('-'))
+            .is_some_and(|body| matches!(body, "fa" | "fac" | "fas" | "facs"))
+    });
+    let mut outputs = HashSet::new();
+    for compilation in compilations {
+        let source = if compilation.source_file.is_absolute() {
+            compilation.source_file.clone()
+        } else {
+            cwd.join(&compilation.source_file)
+        };
+        let object = if compilation.output_file.is_absolute() {
+            compilation.output_file.clone()
+        } else {
+            cwd.join(&compilation.output_file)
+        };
+        if split_dwarf {
+            outputs.insert(object.as_path().with_extension("dwo").into());
+        }
+        if default_depfiles {
+            outputs.insert(object.as_path().with_extension("d").into());
+        }
+        if stack_usage {
+            outputs.insert(object.as_path().with_extension("su").into());
+        }
+        if coverage {
+            outputs.insert(object.as_path().with_extension("gcno").into());
+        }
+        if time_trace {
+            outputs.insert(object.as_path().with_extension("json").into());
+        }
+        if callgraph {
+            outputs.insert(object.as_path().with_extension("ci").into());
+        }
+        if optimization_record {
+            outputs.insert(object.as_path().with_extension("opt.yaml").into());
+        }
+        if sarif {
+            outputs.insert(source.as_path().with_extension("sarif").into());
+        }
+        if default_doc {
+            outputs.insert(source.as_path().with_extension("xdc").into());
+        }
+        if default_assembly_listing {
+            outputs.insert(object.as_path().with_extension("asm").into());
+        }
+        if creates_pch && !explicit_pch {
+            outputs.insert(source.as_path().with_extension("pch").into());
+            if let Some(name) = source.file_stem() {
+                outputs.insert(cwd.join(Path::new(name).with_extension("pch")));
+            }
+        }
+        if save_temps {
+            let preprocessed = if source
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("c"))
+            {
+                "i"
+            } else {
+                "ii"
+            };
+            for extension in [preprocessed, "s"] {
+                outputs.insert(object.as_path().with_extension(extension).into());
+                if let Some(name) = source.file_stem() {
+                    outputs.insert(cwd.join(Path::new(name).with_extension(extension)));
+                }
+            }
+        }
+    }
+    outputs
+}
+
+#[derive(Clone)]
+pub(in crate::daemon::server) struct InputSnapshot {
+    pub(super) hashes: HashMap<NormalizedPath, ContentHash>,
+    stamps: HashMap<NormalizedPath, InputStamp>,
+    complete: bool,
+    clock: Clock,
+}
+
+impl InputSnapshot {
+    pub(super) fn incomplete(clock: Clock) -> Self {
+        Self {
+            hashes: HashMap::new(),
+            stamps: HashMap::new(),
+            complete: false,
+            clock,
+        }
+    }
+
+    pub(super) fn capture(
+        state: &SharedState,
+        source: &NormalizedPath,
+        ctx: &CompileContext,
+        mut hashes: HashMap<NormalizedPath, ContentHash>,
+        clock: Clock,
+    ) -> Self {
+        let scan = crate::depgraph::scanner::scan_recursive(source, &ctx.include_search);
+        let mut complete = true;
+        for path in scan.resolved.iter().chain(ctx.force_includes.iter()) {
+            if hashes.contains_key(path) {
+                continue;
+            }
+            match hash_file(&state.cache_system, path, clock) {
+                Ok(hash) => {
+                    hashes.insert(path.clone(), hash);
+                }
+                Err(_) => complete = false,
+            }
+        }
+        let stamps: HashMap<NormalizedPath, InputStamp> = hashes
+            .keys()
+            .filter_map(|path| input_stamp(path).map(|stamp| (path.clone(), stamp)))
+            .collect();
+        complete &= stamps.len() == hashes.len();
+        complete &= stamps_have_native_markers(&stamps);
+        Self {
+            hashes,
+            stamps,
+            complete,
+            clock,
+        }
+    }
+
+    pub(super) fn stable(
+        &self,
+        state: &SharedState,
+        paths: &[NormalizedPath],
+        current_hashes: &HashMap<NormalizedPath, ContentHash>,
+    ) -> bool {
+        self.complete
+            && self.hashes.len() == current_hashes.len()
+            && self.stamps.len() == paths.len()
+            && self
+                .hashes
+                .iter()
+                .all(|(path, before)| current_hashes.get(path) == Some(before))
+            && paths.iter().all(|path| {
+                input_stamp(path).as_ref() == self.stamps.get(path)
+                    && !state.cache_system.journal().changed_since(path, self.clock)
+            })
+    }
+}
+
+pub(super) async fn run_unsupported_batch(
+    state: &Arc<SharedState>,
+    sid: &SessionId,
+    compiler: &NormalizedPath,
+    compilations: &[crate::compiler::CacheableCompilation],
+    original_args: &[String],
+    cwd: &NormalizedPath,
+    client_env: &Option<Vec<(String, String)>>,
+) -> Option<Response> {
+    use crate::daemon::staged_stats::{StagedCounter, StagedTiming};
+    if !staged_lane_enabled(compilations[0].family) {
+        return None;
+    }
+    let started = std::time::Instant::now();
+    state.profiler.staged.count(StagedCounter::PlanAttempted);
+    let outputs: Vec<NormalizedPath> = compilations
+        .iter()
+        .map(|compilation| compilation.output_file.clone())
+        .collect();
+    let outcome =
+        classify_staged_multi_invocation(compilations[0].family, original_args, &outputs, cwd);
+    state
+        .profiler
+        .staged
+        .timing(StagedTiming::Planning, started.elapsed().as_nanos() as u64);
+    match outcome {
+        StagedPlanOutcome::Enabled(()) => {
+            state.profiler.staged.count(StagedCounter::PlanEnabled);
+            None
+        }
+        StagedPlanOutcome::Error(error) => {
+            state.profiler.staged.count(StagedCounter::PlanError);
+            state.profiler.staged.failure(error.reason.failure());
+            Some(Response::Error {
+                message: format!(
+                    "failed to plan private multi-source outputs: {}",
+                    error.source
+                ),
+            })
+        }
+        StagedPlanOutcome::Unsupported(reason) => {
+            state.profiler.staged.count(StagedCounter::PlanUnsupported);
+            state.profiler.staged.failure(reason.failure());
+            let response_family = direct_response_family(compilations[0].family, original_args);
+            let msvc_syntax = response_family == crate::compiler::CompilerFamily::Msvc;
+            let mut outputs: HashSet<NormalizedPath> = compilations
+                .iter()
+                .map(|compilation| {
+                    if compilation.output_file.is_absolute() {
+                        compilation.output_file.clone()
+                    } else {
+                        cwd.join(&compilation.output_file)
+                    }
+                })
+                .collect();
+            outputs.extend(explicit_staged_side_outputs(
+                original_args,
+                msvc_syntax,
+                cwd,
+            ));
+            outputs.extend(derived_staged_side_outputs(
+                compilations,
+                original_args,
+                cwd,
+            ));
+            // Primary outputs are the only paths this cache can have
+            // hardlinked on an earlier supported invocation. Unsupported
+            // side outputs are never persisted or materialized by zccache;
+            // explicit and safely derivable side paths above are detached as
+            // defense in depth, without mutating unrelated files under cwd.
+            for compilation in compilations {
+                let source = if compilation.source_file.is_absolute() {
+                    compilation.source_file.clone()
+                } else {
+                    cwd.join(&compilation.source_file)
+                };
+                outputs.remove(&source);
+            }
+            for output in outputs {
+                if let Err(error) = break_output_hardlink_before_compile(&output) {
+                    return Some(Response::Error {
+                        message: format!(
+                            "failed to detach hardlinked multi-source output {}: {error}",
+                            output.display()
+                        ),
+                    });
+                }
+            }
+            for _ in compilations {
+                state.stats.record_compilation();
+                state.stats.record_non_cacheable();
+                record_session_stat(&state.sessions, sid, |stats| {
+                    stats.record_non_cacheable();
+                });
+            }
+            let response = run_compiler_direct_with_family(
+                compiler,
+                original_args,
+                cwd,
+                &state.sessions,
+                sid,
+                client_env,
+                &[],
+                &state.depfile_tmpdir,
+                response_family,
+            )
+            .await;
+            if matches!(
+                &response,
+                Response::CompileResult { exit_code, .. } if *exit_code != 0
+            ) {
+                state.stats.record_error();
+                record_session_stat(&state.sessions, sid, |stats| stats.record_error());
+            }
+            Some(response)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clang_executable_with_msvc_syntax_selects_msvc_response_dialect() {
+        let args = vec!["/c".into(), "/Foshared\\".into(), "first.c".into()];
+        assert_eq!(
+            direct_response_family(crate::compiler::CompilerFamily::Clang, &args),
+            crate::compiler::CompilerFamily::Msvc
+        );
+    }
+
+    #[test]
+    fn missing_native_marker_fails_snapshot_completeness_closed() {
+        let stamp = InputStamp {
+            len: 1,
+            modified: None,
+            created: None,
+            file_id: None,
+            change_marker: None,
+        };
+        assert!(!stamps_have_native_markers(&HashMap::from([(
+            NormalizedPath::from("input.c"),
+            stamp,
+        )])));
+    }
+
+    #[test]
+    fn input_stamp_detects_aba_even_when_mtime_is_restored() {
+        let temp = tempfile::tempdir().unwrap();
+        let input = temp.path().join("input.c");
+        std::fs::write(&input, b"AAAA").unwrap();
+        let before = input_stamp(&input).unwrap();
+        let original_mtime =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&input).unwrap());
+
+        std::fs::write(&input, b"BBBB").unwrap();
+        std::fs::write(&input, b"AAAA").unwrap();
+        filetime::set_file_mtime(&input, original_mtime).unwrap();
+
+        let after = input_stamp(&input).unwrap();
+        assert_eq!(std::fs::read(&input).unwrap(), b"AAAA");
+        assert_eq!(after.modified, before.modified);
+        assert_eq!(after.file_id, before.file_id);
+        assert_ne!(
+            after, before,
+            "native change marker must detect A-to-B-to-A mutation"
+        );
+    }
+
+    #[tokio::test]
+    async fn input_snapshot_rejects_aba_with_identical_content_hash_and_mtime() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir: NormalizedPath = temp.path().join("cache").into();
+        let endpoint = crate::ipc::unique_test_endpoint();
+        let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+        let state = server.test_state_arc();
+        let input: NormalizedPath = temp.path().join("input.c").into();
+        std::fs::write(&input, b"AAAA").unwrap();
+        let original_mtime =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&input).unwrap());
+        let clock = state.cache_system.current_clock();
+        let before_hash = hash_file(&state.cache_system, &input, clock).unwrap();
+        let snapshot = InputSnapshot {
+            hashes: HashMap::from([(input.clone(), before_hash)]),
+            stamps: HashMap::from([(input.clone(), input_stamp(&input).unwrap())]),
+            complete: true,
+            clock,
+        };
+
+        std::fs::write(&input, b"BBBB").unwrap();
+        std::fs::write(&input, b"AAAA").unwrap();
+        filetime::set_file_mtime(&input, original_mtime).unwrap();
+        let current_hash = hash_file(
+            &state.cache_system,
+            &input,
+            state.cache_system.current_clock(),
+        )
+        .unwrap();
+        assert_eq!(current_hash, before_hash);
+        assert!(!snapshot.stable(
+            &state,
+            std::slice::from_ref(&input),
+            &HashMap::from([(input.clone(), current_hash)]),
+        ));
+    }
+}

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
@@ -9,6 +9,7 @@ struct StagedMiss {
     source_path: NormalizedPath,
     context_key: ContextKey,
     ctx: Box<CompileContext>,
+    input_snapshot: InputSnapshot,
     plan: StagedMultiUnitPlan,
     scan_result: Option<crate::depgraph::ScanResult>,
 }
@@ -18,9 +19,13 @@ struct PublishedMiss {
     context_key: ContextKey,
     plan: StagedMultiUnitPlan,
     cache_entry: Option<(String, CachedArtifact)>,
-    salvage_reason: Option<&'static str>,
+    graph_update: Option<(
+        crate::depgraph::ScanResult,
+        HashMap<NormalizedPath, ContentHash>,
+    )>,
     dep_dirs: Vec<NormalizedPath>,
     artifact_bytes: u64,
+    validation_clock: Clock,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -33,24 +38,19 @@ pub(super) async fn try_handle_staged_misses(
     source_indices: &[usize],
     unit_results: &[UnitCacheResult],
     cwd: &NormalizedPath,
+    key_root: &NormalizedPath,
     client_env: &Option<Vec<(String, String)>>,
-    snap_clock: Clock,
     all_stdout: &mut Vec<u8>,
     all_stderr: &mut Vec<u8>,
 ) -> Option<Response> {
-    let case_insensitive_outputs = compilations
-        .iter()
-        .any(|compilation| compilation.family == crate::compiler::CompilerFamily::Msvc)
-        || crate::compiler::parse_msvc::looks_like_msvc_args(original_args);
     let mut requested_outputs = HashSet::new();
     for compilation in compilations {
-        let output = compilation.output_file.to_string_lossy();
-        let identity = if case_insensitive_outputs {
-            output.to_ascii_lowercase()
+        let output = if compilation.output_file.is_absolute() {
+            compilation.output_file.clone()
         } else {
-            output.into_owned()
+            cwd.join(&compilation.output_file)
         };
-        if !requested_outputs.insert(identity) {
+        if !requested_outputs.insert(output) {
             use crate::daemon::staged_stats::{StagedCounter, StagedFailure};
             state.profiler.staged.count(StagedCounter::PlanAttempted);
             state.profiler.staged.count(StagedCounter::PlanUnsupported);
@@ -68,6 +68,7 @@ pub(super) async fn try_handle_staged_misses(
             output_path,
             context_key,
             ctx,
+            input_snapshot,
         } = unit
         else {
             continue;
@@ -117,6 +118,7 @@ pub(super) async fn try_handle_staged_misses(
             source_path: source_path.clone(),
             context_key: *context_key,
             ctx: ctx.clone(),
+            input_snapshot: input_snapshot.clone(),
             plan,
             scan_result: None,
         });
@@ -150,7 +152,11 @@ pub(super) async fn try_handle_staged_misses(
         let rsp_guard = match crate::compiler::response_file::write_response_file_if_needed(
             &compiler_args,
             &state.depfile_tmpdir,
-            compilations[0].family,
+            if miss.plan.msvc_syntax {
+                crate::compiler::CompilerFamily::Msvc
+            } else {
+                compilations[miss.unit_index].family
+            },
         ) {
             Ok(guard) => guard,
             Err(error) => {
@@ -234,7 +240,7 @@ pub(super) async fn try_handle_staged_misses(
     let mut published = Vec::with_capacity(misses.len());
     for (miss, output_sizes) in misses.into_iter().zip(validated_sizes) {
         let artifact_bytes = output_sizes.iter().sum();
-        let scan_result =
+        let mut scan_result =
             miss.scan_result
                 .unwrap_or_else(|| {
                     match crate::depgraph::depfile::parse_depfile_path(
@@ -256,33 +262,52 @@ pub(super) async fn try_handle_staged_misses(
                         }
                     }
                 });
-        let tracked_paths: Vec<NormalizedPath> = std::iter::once(miss.source_path.clone())
-            .chain(scan_result.resolved.iter().cloned())
-            .collect();
+        let mut tracked: HashSet<NormalizedPath> =
+            miss.input_snapshot.hashes.keys().cloned().collect();
+        tracked.insert(miss.source_path.clone());
+        tracked.extend(scan_result.resolved.iter().cloned());
+        tracked.extend(miss.ctx.force_includes.iter().cloned());
+        let tracked_paths: Vec<NormalizedPath> = tracked.into_iter().collect();
+        let resolved: HashSet<NormalizedPath> = scan_result.resolved.iter().cloned().collect();
+        scan_result.resolved.extend(
+            miss.input_snapshot
+                .hashes
+                .keys()
+                .filter(|path| {
+                    path.as_path() != miss.source_path.as_path() && !resolved.contains(*path)
+                })
+                .cloned(),
+        );
         state.cache_system.register_tracked(&tracked_paths);
         let dep_dirs = tracked_paths
             .iter()
             .filter_map(|path| path.parent().map(NormalizedPath::from))
             .collect();
+        let current_clock = state.cache_system.current_clock();
         let hash_map: HashMap<NormalizedPath, ContentHash> = {
             use rayon::prelude::*;
             tracked_paths
                 .par_iter()
                 .filter_map(|path| {
-                    hash_file(&state.cache_system, path, snap_clock)
+                    hash_file(&state.cache_system, path, current_clock)
                         .ok()
                         .map(|hash| (path.clone(), hash))
                 })
                 .collect()
         };
-        let get_hash = |path: &Path| hash_map.get(&NormalizedPath::new(path)).copied();
-        let artifact_key = state
-            .dep_graph
-            .load()
-            .update(&miss.context_key, scan_result, get_hash);
+        let stable = miss.input_snapshot.stable(state, &tracked_paths, &hash_map);
         let mut cache_entry = None;
-        let mut salvage_reason = None;
-        if let Some(artifact_key) = artifact_key {
+        let mut graph_update = None;
+        if stable {
+            let file_hashes: Vec<(NormalizedPath, ContentHash)> = hash_map
+                .iter()
+                .map(|(path, hash)| (path.clone(), *hash))
+                .collect();
+            let artifact_key = crate::depgraph::context::compute_artifact_key_normalized_with_root(
+                &miss.context_key,
+                &file_hashes,
+                Some(key_root.as_path()),
+            );
             let key = artifact_key.hash().to_hex();
             let output_names = miss
                 .plan
@@ -297,42 +322,33 @@ pub(super) async fn try_handle_staged_misses(
                         .into_owned()
                 })
                 .collect();
-            let empty = Arc::new(Vec::new());
+            let (stdout, stderr) = &ordered_output[miss.unit_index];
             let metadata = ArtifactIndex::new(
                 output_names,
                 output_sizes,
-                Arc::clone(&empty),
-                Arc::clone(&empty),
+                Arc::new(stdout.clone()),
+                Arc::new(stderr.clone()),
                 0,
             );
-            let staged_paths: Vec<NormalizedPath> = miss
-                .plan
-                .outputs
-                .iter()
-                .map(|output| output.staged.clone())
-                .collect();
-            match publish_artifact_paths_observed(state, &key, metadata.clone(), &staged_paths) {
-                Ok(_) => cache_entry = Some((key, CachedArtifact::from_index(metadata))),
-                Err(reason) => salvage_reason = Some(reason.id()),
-            }
+            cache_entry = Some((key, CachedArtifact::from_index(metadata)));
+            graph_update = Some((scan_result, hash_map));
         }
         published.push(PublishedMiss {
             source_path: miss.source_path,
             context_key: miss.context_key,
             plan: miss.plan,
             cache_entry,
-            salvage_reason,
+            graph_update,
             dep_dirs,
             artifact_bytes,
+            validation_clock: current_clock,
         });
     }
 
     let mut changed_outputs = Vec::new();
     let mut dependency_directories = HashSet::new();
-    let mut completed = Vec::with_capacity(published.len());
-    for miss in published {
-        if let Err(error) = materialize_multi_plan_observed(state, &miss.plan, miss.salvage_reason)
-        {
+    for miss in &published {
+        if let Err(error) = materialize_multi_plan_observed(state, &miss.plan, None) {
             return Some(Response::Error {
                 message: format!("failed to materialize multi-source output: {error}"),
             });
@@ -343,15 +359,64 @@ pub(super) async fn try_handle_staged_misses(
                 .iter()
                 .map(|output| output.requested.clone()),
         );
-        dependency_directories.extend(miss.dep_dirs);
+        dependency_directories.extend(miss.dep_dirs.iter().cloned());
+    }
+
+    let mut completed = Vec::with_capacity(published.len());
+    for mut miss in published {
+        if let Some((key, metadata)) = miss
+            .cache_entry
+            .as_ref()
+            .map(|(key, cached)| (key.clone(), cached.meta.clone()))
+        {
+            let staged_paths: Vec<NormalizedPath> = miss
+                .plan
+                .outputs
+                .iter()
+                .map(|output| output.staged.clone())
+                .collect();
+            if let Err(reason) =
+                publish_artifact_paths_observed(state, &key, metadata, &staged_paths)
+            {
+                record_prepublication_salvage_success(state, miss.plan.outputs.len(), reason.id());
+                miss.cache_entry = None;
+                miss.graph_update = None;
+            } else if let Some((scan_result, hash_map)) = miss.graph_update.take() {
+                if let Some((_, cached)) = miss.cache_entry.as_ref() {
+                    state.artifacts.insert(key.clone(), cached.clone());
+                }
+                let get_hash = |path: &Path| hash_map.get(&NormalizedPath::new(path)).copied();
+                let committed_key = state
+                    .dep_graph
+                    .load()
+                    .update(&miss.context_key, scan_result, get_hash)
+                    .map(|artifact_key| artifact_key.hash().to_hex());
+                if committed_key.as_deref() != Some(key.as_str()) {
+                    tracing::error!(
+                        expected = %key,
+                        actual = ?committed_key,
+                        "staged multi-source artifact key changed during depgraph commit"
+                    );
+                    let mut invalid = HashSet::from([key.clone()]);
+                    invalid.extend(committed_key);
+                    state.dep_graph.load().invalidate_artifact_keys(&invalid);
+                    state.artifacts.remove(&key);
+                    miss.cache_entry = None;
+                }
+            }
+        }
+        if let Err(error) = miss.plan.cleanup() {
+            tracing::warn!(%error, "failed to clean staged multi-source workspace");
+        }
         completed.push((
             miss.source_path,
             miss.context_key,
             miss.cache_entry,
             miss.artifact_bytes,
+            miss.validation_clock,
         ));
     }
-    for (source, context_key, cache_entry, artifact_bytes) in completed {
+    for (source, context_key, cache_entry, artifact_bytes, validation_clock) in completed {
         state.stats.record_miss(0, artifact_bytes);
         record_session_stat(&state.sessions, sid, move |stats| {
             stats.record_miss(source, artifact_bytes);
@@ -361,7 +426,7 @@ pub(super) async fn try_handle_staged_misses(
             state.fast_hit_cache.insert(
                 context_key,
                 FastHitEntry {
-                    clock: state.cache_system.current_clock(),
+                    clock: validation_clock,
                     artifact_key_hex: key,
                     cached_at: std::time::Instant::now(),
                 },

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_types.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_types.rs
@@ -1,0 +1,26 @@
+//! Shared result types for multi-source cache checks and staged execution.
+
+use super::*;
+
+pub(in crate::daemon::server) struct PendingWrite {
+    pub(in crate::daemon::server) out_path: NormalizedPath,
+    pub(in crate::daemon::server) cache_file: NormalizedPath,
+    pub(in crate::daemon::server) data: Vec<u8>,
+}
+
+pub(in crate::daemon::server) enum UnitCacheResult {
+    Hit {
+        stdout: Arc<Vec<u8>>,
+        stderr: Arc<Vec<u8>>,
+        artifact_bytes: u64,
+        source_path: NormalizedPath,
+        pending_writes: Vec<PendingWrite>,
+    },
+    Miss {
+        source_path: NormalizedPath,
+        output_path: NormalizedPath,
+        context_key: ContextKey,
+        ctx: Box<CompileContext>,
+        input_snapshot: InputSnapshot,
+    },
+}

--- a/crates/zccache-daemon-core/src/daemon/server/persist/hardlink.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/hardlink.rs
@@ -246,6 +246,13 @@ pub(in crate::daemon::server) fn get_file_id(path: &Path) -> Option<FileId> {
     })
 }
 
+#[cfg(unix)]
+pub(in crate::daemon::server) fn get_file_change_marker(path: &Path) -> Option<i128> {
+    use std::os::unix::fs::MetadataExt;
+    let metadata = std::fs::metadata(path).ok()?;
+    Some(i128::from(metadata.ctime()) * 1_000_000_000 + i128::from(metadata.ctime_nsec()))
+}
+
 #[cfg(windows)]
 pub(in crate::daemon::server) fn same_file(a: &Path, b: &Path) -> bool {
     get_file_id(a)
@@ -309,5 +316,72 @@ pub(in crate::daemon::server) fn get_file_id(path: &Path) -> Option<FileId> {
             volume_serial: u64::from(legacy.dwVolumeSerialNumber),
             identifier,
         })
+    }
+}
+
+#[cfg(windows)]
+/// Returns the file's USN sequence. `ChangeTime` is deliberately not a
+/// fallback: `SetFileTime` can restore it along with mtime and hide an ABA
+/// mutation. Callers disable publication when the filesystem has no USN.
+pub(in crate::daemon::server) fn get_file_change_marker(path: &Path) -> Option<i128> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Foundation::{CloseHandle, GENERIC_READ, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+    use windows_sys::Win32::System::Ioctl::{
+        FSCTL_READ_FILE_USN_DATA, READ_FILE_USN_DATA, USN_RECORD_V2, USN_RECORD_V3,
+    };
+    use windows_sys::Win32::System::IO::DeviceIoControl;
+
+    let wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    unsafe {
+        let handle = CreateFileW(
+            wide.as_ptr(),
+            GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS,
+            std::ptr::null_mut(),
+        );
+        if handle == INVALID_HANDLE_VALUE {
+            return None;
+        }
+        let query = READ_FILE_USN_DATA {
+            MinMajorVersion: 2,
+            MaxMajorVersion: 4,
+        };
+        let mut record = [0_u8; 512];
+        let mut returned = 0_u32;
+        let usn_ok = DeviceIoControl(
+            handle,
+            FSCTL_READ_FILE_USN_DATA,
+            (&raw const query).cast(),
+            std::mem::size_of::<READ_FILE_USN_DATA>() as u32,
+            record.as_mut_ptr().cast(),
+            record.len() as u32,
+            &raw mut returned,
+            std::ptr::null_mut(),
+        );
+        if usn_ok != 0 && returned >= 8 {
+            let major = u16::from_ne_bytes([record[4], record[5]]);
+            let usn = match major {
+                2 if returned as usize >= std::mem::size_of::<USN_RECORD_V2>() => {
+                    Some(std::ptr::read_unaligned(record.as_ptr().cast::<USN_RECORD_V2>()).Usn)
+                }
+                3 if returned as usize >= std::mem::size_of::<USN_RECORD_V3>() => {
+                    Some(std::ptr::read_unaligned(record.as_ptr().cast::<USN_RECORD_V3>()).Usn)
+                }
+                _ => None,
+            };
+            if let Some(usn) = usn {
+                let _ = CloseHandle(handle);
+                return Some(i128::from(usn));
+            }
+        }
+        let _ = CloseHandle(handle);
+        None
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_multi.rs
@@ -6,6 +6,187 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 static MULTI_PLAN_COUNTER: AtomicU64 = AtomicU64::new(1);
 
+pub(in crate::daemon::server) fn classify_staged_multi_invocation(
+    family: crate::compiler::CompilerFamily,
+    args: &[String],
+    requested_outputs: &[NormalizedPath],
+    cwd: &Path,
+) -> StagedPlanOutcome<()> {
+    if !staged_lane_enabled(family) {
+        return StagedPlanOutcome::Unsupported(StagedPlanReason::LaneDisabled);
+    }
+    if !matches!(
+        family,
+        crate::compiler::CompilerFamily::Gcc
+            | crate::compiler::CompilerFamily::Clang
+            | crate::compiler::CompilerFamily::Msvc
+    ) {
+        return StagedPlanOutcome::Unsupported(StagedPlanReason::UnsupportedOutputRole);
+    }
+    let msvc_syntax = family == crate::compiler::CompilerFamily::Msvc
+        || crate::compiler::parse_msvc::looks_like_msvc_args(args);
+    if has_unmodeled_multi_output(args, msvc_syntax) {
+        return StagedPlanOutcome::Unsupported(StagedPlanReason::UnmodeledSideOutput);
+    }
+    if (!msvc_syntax && has_gnu_explicit_output(args))
+        || (msvc_syntax && has_file_valued_msvc_output(args))
+    {
+        return StagedPlanOutcome::Unsupported(StagedPlanReason::AmbiguousOutputArgument);
+    }
+
+    let mut unique = std::collections::HashSet::new();
+    for output in requested_outputs {
+        let absolute: NormalizedPath = if output.is_absolute() {
+            output.clone()
+        } else {
+            cwd.join(output).into()
+        };
+        if absolute.file_name().is_none() {
+            return StagedPlanOutcome::Error(StagedPlanError {
+                reason: StagedPlanReason::OutputMissingFilename,
+                source: std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "multi-source output has no filename",
+                ),
+            });
+        }
+        if !unique.insert(absolute) {
+            return StagedPlanOutcome::Unsupported(StagedPlanReason::OutputNameCollision);
+        }
+    }
+    StagedPlanOutcome::Enabled(())
+}
+
+pub(in crate::daemon::server) fn explicit_staged_side_outputs(
+    args: &[String],
+    msvc_syntax: bool,
+    cwd: &Path,
+) -> Vec<NormalizedPath> {
+    let mut values = Vec::new();
+    let creates_pch = args.iter().any(|arg| {
+        arg.strip_prefix('/')
+            .or_else(|| arg.strip_prefix('-'))
+            .is_some_and(|body| body.starts_with("Yc"))
+    });
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        let mut value = None;
+        if msvc_syntax {
+            let body = arg
+                .strip_prefix('/')
+                .or_else(|| arg.strip_prefix('-'))
+                .unwrap_or(arg);
+            let lower = body.to_ascii_lowercase();
+            if lower == "sourcedependencies"
+                || lower == "sourcedependencies:directives"
+                || lower == "module:output"
+                || lower == "ifcoutput"
+            {
+                value = args.get(index + 1).map(String::as_str);
+                if value.is_some() {
+                    index += 1;
+                }
+            } else if lower.starts_with("module:output") {
+                value = Some(&body["module:output".len()..]);
+            } else if lower.starts_with("sourcedependencies") {
+                value = Some(&body["sourceDependencies".len()..]);
+            } else if let Some(rest) = body.strip_prefix("ifcOutput") {
+                value = Some(rest.strip_prefix(':').unwrap_or(rest));
+            } else {
+                for prefix in ["Fd", "Fa", "Fr", "FR", "Fi"] {
+                    if let Some(rest) = body.strip_prefix(prefix) {
+                        if rest.is_empty() {
+                            if matches!(prefix, "Fd" | "Fi") {
+                                value = args.get(index + 1).map(String::as_str);
+                                if value.is_some() {
+                                    index += 1;
+                                }
+                            }
+                        } else {
+                            value = Some(rest.strip_prefix(':').unwrap_or(rest));
+                        }
+                        break;
+                    }
+                }
+                if lower == "doc" {
+                    value = args.get(index + 1).map(String::as_str);
+                    if value.is_some() {
+                        index += 1;
+                    }
+                } else if let Some(rest) = lower.strip_prefix("doc:") {
+                    value = Some(&body[body.len() - rest.len()..]);
+                } else if let Some(rest) = body.strip_prefix("doc") {
+                    if Path::new(rest).extension().is_some() {
+                        value = Some(rest);
+                    }
+                }
+                if creates_pch {
+                    if body == "Fp" {
+                        value = args.get(index + 1).map(String::as_str);
+                        if value.is_some() {
+                            index += 1;
+                        }
+                    } else if let Some(rest) = body.strip_prefix("Fp") {
+                        value = Some(rest.strip_prefix(':').unwrap_or(rest));
+                    }
+                }
+            }
+        } else {
+            for flag in [
+                "--serialize-diagnostics",
+                "-dependency-file",
+                "-foptimization-record-file",
+                "-fdiagnostics-file",
+                "-MF",
+                "-MJ",
+            ] {
+                if arg == flag {
+                    value = args.get(index + 1).map(String::as_str);
+                    if value.is_some() {
+                        index += 1;
+                    }
+                    break;
+                }
+                if let Some(rest) = arg.strip_prefix(flag) {
+                    if !rest.is_empty() {
+                        value = Some(rest.strip_prefix('=').unwrap_or(rest));
+                        break;
+                    }
+                }
+            }
+            if value.is_none()
+                && (arg.starts_with("-fopt-info") || arg.starts_with("-ftime-trace="))
+            {
+                value = arg.split_once('=').map(|(_, path)| path);
+            }
+            if value.is_none() && arg.starts_with("-Wa,") {
+                value = arg.rsplit_once('=').map(|(_, path)| path);
+            }
+            if value.is_none() {
+                if arg == "-fmodule-output" {
+                    value = args.get(index + 1).map(String::as_str);
+                    if value.is_some() {
+                        index += 1;
+                    }
+                } else if let Some(path) = arg.strip_prefix("-fmodule-output=") {
+                    value = Some(path);
+                }
+            }
+        }
+        if let Some(path) = value.filter(|path| !path.is_empty()) {
+            let path = Path::new(path);
+            values.push(if path.is_absolute() {
+                path.into()
+            } else {
+                cwd.join(path).into()
+            });
+        }
+        index += 1;
+    }
+    values
+}
+
 #[derive(Debug)]
 pub(in crate::daemon::server) struct StagedMultiUnitPlan {
     pub(in crate::daemon::server) rewritten_args: Vec<String>,
@@ -23,27 +204,20 @@ impl StagedMultiUnitPlan {
         requested_output: &NormalizedPath,
         cwd: &Path,
     ) -> StagedPlanOutcome<Self> {
-        if !staged_lane_enabled(family) {
-            return StagedPlanOutcome::Unsupported(StagedPlanReason::LaneDisabled);
-        }
-        if !matches!(
+        match classify_staged_multi_invocation(
             family,
-            crate::compiler::CompilerFamily::Gcc
-                | crate::compiler::CompilerFamily::Clang
-                | crate::compiler::CompilerFamily::Msvc
+            &args,
+            std::slice::from_ref(requested_output),
+            cwd,
         ) {
-            return StagedPlanOutcome::Unsupported(StagedPlanReason::UnsupportedOutputRole);
+            StagedPlanOutcome::Enabled(()) => {}
+            StagedPlanOutcome::Unsupported(reason) => {
+                return StagedPlanOutcome::Unsupported(reason)
+            }
+            StagedPlanOutcome::Error(error) => return StagedPlanOutcome::Error(error),
         }
         let msvc_syntax = family == crate::compiler::CompilerFamily::Msvc
             || crate::compiler::parse_msvc::looks_like_msvc_args(&args);
-        if has_unmodeled_multi_output(&args, msvc_syntax) {
-            return StagedPlanOutcome::Unsupported(StagedPlanReason::UnmodeledSideOutput);
-        }
-        if (!msvc_syntax && has_gnu_explicit_output(&args))
-            || (msvc_syntax && has_file_valued_msvc_output(&args))
-        {
-            return StagedPlanOutcome::Unsupported(StagedPlanReason::AmbiguousOutputArgument);
-        }
 
         let requested = if requested_output.is_absolute() {
             requested_output.clone()
@@ -140,8 +314,6 @@ impl StagedMultiUnitPlan {
             observed.copy_count = observed.copy_count.saturating_add(output_stats.copy_count);
             observed.copy_bytes = observed.copy_bytes.saturating_add(output_stats.copy_bytes);
         }
-        self.cleanup()
-            .map_err(|error| materialization_error(error, observed))?;
         Ok(observed)
     }
 
@@ -172,7 +344,7 @@ impl StagedMultiUnitPlan {
             .collect()
     }
 
-    fn cleanup(&self) -> std::io::Result<()> {
+    pub(in crate::daemon::server) fn cleanup(&self) -> std::io::Result<()> {
         std::fs::remove_dir_all(&self.root).or_else(|error| {
             if error.kind() == std::io::ErrorKind::NotFound {
                 Ok(())
@@ -225,30 +397,23 @@ fn has_unmodeled_multi_output(args: &[String], msvc_syntax: bool) -> bool {
     args.iter().any(|arg| {
         let lower = arg.to_ascii_lowercase();
         if msvc_syntax {
-            [
-                "/fd",
-                "-fd",
-                "/fp",
-                "-fp",
-                "/fa",
-                "-fa",
-                "/fr",
-                "-fr",
-                "/yc",
-                "-yc",
-                "/doc",
-                "-doc",
-                "/module:",
-                "-module:",
-                "/headerunit",
-                "-headerunit",
-                "/sourcedependencies",
-                "-sourcedependencies",
-            ]
-            .iter()
-            .any(|prefix| lower.starts_with(prefix))
-                || arg.starts_with("/Fi")
-                || arg.starts_with("-Fi")
+            let body = arg
+                .strip_prefix('/')
+                .or_else(|| arg.strip_prefix('-'))
+                .unwrap_or(arg);
+            let lower_body = body.to_ascii_lowercase();
+            body.starts_with("Fd")
+                || body.starts_with("Fp")
+                || body.starts_with("Fr")
+                || body.starts_with("FR")
+                || body.starts_with("Fi")
+                || body.starts_with("Fa")
+                || matches!(lower_body.as_str(), "fa" | "fac" | "fas" | "facs")
+                || body.starts_with("Yc")
+                || lower_body.starts_with("doc")
+                || lower_body.starts_with("module:")
+                || lower_body.starts_with("headerunit")
+                || lower_body.starts_with("sourcedependencies")
                 || matches!(lower.as_str(), "/zi" | "-zi")
                 || lower.starts_with("/ifc")
                 || lower.starts_with("-ifc")
@@ -256,11 +421,12 @@ fn has_unmodeled_multi_output(args: &[String], msvc_syntax: bool) -> bool {
                 || lower == "-interface"
         } else {
             lower.starts_with("--serialize-diagnostics")
+                || lower.starts_with("-dependency-file")
                 || lower.starts_with("-mj")
                 || lower.starts_with("-fmodule")
                 || lower == "-save-temps"
                 || lower.starts_with("-save-temps=")
-                || lower == "-gsplit-dwarf"
+                || lower.starts_with("-gsplit-dwarf")
                 || lower.starts_with("-fdump-")
                 || lower == "--coverage"
                 || lower == "-coverage"
@@ -271,7 +437,7 @@ fn has_unmodeled_multi_output(args: &[String], msvc_syntax: bool) -> bool {
                 || lower == "-fstack-usage"
                 || lower.starts_with("-fcallgraph-info")
                 || lower == "-fsave-optimization-record"
-                || lower.starts_with("-foptimization-record-file=")
+                || lower.starts_with("-foptimization-record-file")
                 || lower.starts_with("-fopt-info")
                 || lower.starts_with("-fdiagnostics-file=")
                 || lower.starts_with("-fdiagnostics-format=sarif-file")
@@ -327,6 +493,107 @@ impl Drop for StagedMultiUnitPlan {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(any(windows, target_os = "macos"))]
+    #[test]
+    fn invocation_rejects_case_alias_output_names() {
+        let temp = tempfile::tempdir().unwrap();
+        let args = vec!["-c".into(), "one.c".into(), "two.c".into()];
+        let outputs = vec![
+            temp.path().join("objects/Foo.o").into(),
+            temp.path().join("objects/foo.o").into(),
+        ];
+        assert!(matches!(
+            classify_staged_multi_invocation(
+                crate::compiler::CompilerFamily::Clang,
+                &args,
+                &outputs,
+                temp.path(),
+            ),
+            StagedPlanOutcome::Unsupported(StagedPlanReason::OutputNameCollision)
+        ));
+    }
+
+    #[test]
+    fn explicit_side_outputs_collect_gnu_and_msvc_paths() {
+        let cwd = Path::new("workspace");
+        let gnu = vec![
+            "-MF".into(),
+            "shared.d".into(),
+            "-fdiagnostics-file=diag.json".into(),
+        ];
+        assert_eq!(
+            explicit_staged_side_outputs(&gnu, false, cwd),
+            vec![cwd.join("shared.d"), cwd.join("diag.json")]
+        );
+        let msvc = vec![
+            "/Fd:shared.pdb".into(),
+            "/doccomments.xdc".into(),
+            "/sourceDependencies:directives".into(),
+            "deps.json".into(),
+            "/module:output".into(),
+            "module.ifc".into(),
+        ];
+        assert_eq!(
+            explicit_staged_side_outputs(&msvc, true, cwd),
+            vec![
+                cwd.join("shared.pdb"),
+                cwd.join("comments.xdc"),
+                cwd.join("deps.json"),
+                cwd.join("module.ifc")
+            ]
+        );
+    }
+
+    #[test]
+    fn explicit_side_outputs_never_treat_msvc_inputs_as_outputs() {
+        let cwd = Path::new("workspace");
+        let args = vec![
+            "/FIforced.h".into(),
+            "/Yuprefix.h".into(),
+            "/Fpprefix.pch".into(),
+            "/favor:INTEL64".into(),
+        ];
+        assert!(explicit_staged_side_outputs(&args, true, cwd).is_empty());
+    }
+
+    #[test]
+    fn msvc_favor_tuning_option_remains_stageable() {
+        let temp = tempfile::tempdir().unwrap();
+        let args = vec![
+            "/c".into(),
+            "/favor:INTEL64".into(),
+            "first.c".into(),
+            "second.c".into(),
+        ];
+        assert!(matches!(
+            classify_staged_multi_invocation(
+                crate::compiler::CompilerFamily::Msvc,
+                &args,
+                &[
+                    temp.path().join("first.obj").into(),
+                    temp.path().join("second.obj").into(),
+                ],
+                temp.path(),
+            ),
+            StagedPlanOutcome::Enabled(())
+        ));
+    }
+
+    #[test]
+    fn explicit_side_outputs_collect_assembler_listing_and_created_pch() {
+        let cwd = Path::new("workspace");
+        let gnu = vec!["-Wa,-adhln=listing.txt".into()];
+        assert_eq!(
+            explicit_staged_side_outputs(&gnu, false, cwd),
+            vec![cwd.join("listing.txt")]
+        );
+        let msvc = vec!["/Ycprefix.h".into(), "/Fpprefix.pch".into()];
+        assert_eq!(
+            explicit_staged_side_outputs(&msvc, true, cwd),
+            vec![cwd.join("prefix.pch")]
+        );
+    }
 
     #[test]
     fn multi_unit_plan_keeps_one_source_and_redirects_private_outputs() {
@@ -430,15 +697,18 @@ mod tests {
         let requested: NormalizedPath = temp.path().join("first.o").into();
         for side_output in [
             "--serialize-diagnostics=shared.dia",
+            "-dependency-file",
             "-MJshared.json",
             "-fmodule-file=math.pcm",
             "-save-temps",
             "-gsplit-dwarf",
+            "-gsplit-dwarf=single",
             "-fdump-tree-all",
             "--coverage",
             "-ftime-trace",
             "-fstack-usage",
             "-fsave-optimization-record",
+            "-foptimization-record-file=optimization.yaml",
             "-fopt-info-vec=optimization.txt",
             "-fdiagnostics-format=sarif-file",
             "-Wa,-adhln=listing.txt",

--- a/crates/zccache-daemon-core/src/daemon/server/staged_materialize.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/staged_materialize.rs
@@ -137,6 +137,26 @@ fn record_salvage_start(
     );
 }
 
+pub(super) fn record_prepublication_salvage_success(
+    state: &SharedState,
+    output_count: usize,
+    reason: &'static str,
+) {
+    use crate::daemon::staged_stats::{StagedCounter, StagedTiming};
+    record_salvage_start(state, output_count, Some(reason));
+    state.profiler.staged.count(StagedCounter::SalvageSuccess);
+    state.profiler.staged.timing(StagedTiming::Salvage, 0);
+    crate::core::lifecycle::write_event(
+        "staged_salvage_complete",
+        serde_json::json!({
+            "reason": reason,
+            "output_count": output_count,
+            "copied_bytes": 0,
+            "elapsed_ns": 0,
+        }),
+    );
+}
+
 pub(super) fn materialize_link_plan_observed(
     state: &SharedState,
     plan: &StagedCompilePlan,

--- a/crates/zccache-daemon-core/src/daemon/server/tests/staged_compiler_sets.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/staged_compiler_sets.rs
@@ -140,6 +140,8 @@ async fn staged_multi_source_clang_cl_restores_directory_outputs_from_response_f
             .unwrap()
             .flatten()
             .all(|entry| entry.path().extension().is_none_or(|ext| ext != "rsp")));
+        let staged = state.profiler.staged.snapshot();
+        assert_eq!(staged.counters["plan_attempted"], staged.counters["plan_enabled"]);
 
         shutdown.notify_one();
         server.await.unwrap();
@@ -389,8 +391,200 @@ async fn staged_multi_source_materialization_failure_reports_error_before_index_
         assert!(first_object.exists());
         assert!(!second_object.exists());
         assert!(state.artifacts.is_empty());
+        assert_eq!(state.dep_graph.load().contexts_with_artifact_key(), 0);
+        let pointer_count = std::fs::read_dir(state.artifact_dir.join(".staged-v2"))
+            .map(|entries| {
+                entries
+                    .flatten()
+                    .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "current"))
+                    .count()
+            })
+            .unwrap_or(0);
+        assert_eq!(pointer_count, 0);
         let staged = state.profiler.staged.snapshot();
         assert_eq!(staged.counters["materialize_failure"], 1);
+
+        shutdown.notify_one();
+        server.await.unwrap();
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "integration: real clang + daemon IPC"]
+async fn unsupported_shared_depfile_always_runs_original_batch_and_detaches_outputs() {
+    let Some(clang) = crate::test_support::find_clang() else {
+        return;
+    };
+    crate::test_support::test_timeout(async move {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir: NormalizedPath = temp.path().join("cache").into();
+        let first = temp.path().join("first.c");
+        let second = temp.path().join("second.c");
+        let first_object = temp.path().join("first.o");
+        let second_object = temp.path().join("second.o");
+        let shared_depfile = temp.path().join("shared.d");
+        let sentinel = temp.path().join("cache-sentinel.o");
+        let depfile_sentinel = temp.path().join("depfile-sentinel.d");
+        std::fs::write(&first, "int first(void) { return 1; }\n").unwrap();
+        std::fs::write(&second, "int second(void) { return 2; }\n").unwrap();
+        let (endpoint, server, shutdown, state) = start_daemon(&cache_dir).await;
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
+        let cwd: NormalizedPath = temp.path().into();
+        client
+            .send(&Request::SessionStart {
+                client_pid: std::process::id(),
+                working_dir: cwd.clone(),
+                log_file: None,
+                track_stats: true,
+                journal_path: None,
+                profile: false,
+                private_daemon: None,
+            })
+            .await
+            .unwrap();
+        let session_id = match client.recv().await.unwrap() {
+            Some(Response::SessionStarted { session_id, .. }) => session_id,
+            other => panic!("expected SessionStarted, got {other:?}"),
+        };
+        let args = vec![
+            "-c".into(),
+            "-MMD".into(),
+            "-MF".into(),
+            shared_depfile.to_string_lossy().into_owned(),
+            first.to_string_lossy().into_owned(),
+            second.to_string_lossy().into_owned(),
+        ];
+        let request = || Request::Compile {
+            session_id: session_id.clone(),
+            args: args.clone(),
+            cwd: cwd.clone(),
+            compiler: clang.to_string_lossy().into_owned().into(),
+            env: None,
+            stdin: Vec::new(),
+        };
+
+        client.send(&request()).await.unwrap();
+        assert_compile(client.recv().await.unwrap(), false);
+        assert!(first_object.is_file() && second_object.is_file());
+        assert!(shared_depfile.is_file());
+
+        let sentinel_bytes = std::fs::read(&first_object).unwrap();
+        let depfile_sentinel_bytes = std::fs::read(&shared_depfile).unwrap();
+        std::fs::hard_link(&first_object, &sentinel).unwrap();
+        std::fs::hard_link(&shared_depfile, &depfile_sentinel).unwrap();
+        client.send(&request()).await.unwrap();
+        assert_compile(client.recv().await.unwrap(), false);
+        assert!(shared_depfile.is_file());
+        assert_eq!(std::fs::read(&sentinel).unwrap(), sentinel_bytes);
+        assert_eq!(
+            std::fs::read(&depfile_sentinel).unwrap(),
+            depfile_sentinel_bytes
+        );
+
+        std::fs::write(&first, "this is not valid C\n").unwrap();
+        client.send(&request()).await.unwrap();
+        match client.recv().await.unwrap() {
+            Some(Response::CompileResult {
+                exit_code, cached, ..
+            }) => {
+                assert_ne!(exit_code, 0);
+                assert!(!cached);
+            }
+            other => panic!("expected failed CompileResult, got {other:?}"),
+        }
+        client
+            .send(&Request::SessionEnd {
+                session_id: session_id.clone(),
+            })
+            .await
+            .unwrap();
+        match client.recv().await.unwrap() {
+            Some(Response::SessionEnded { stats: Some(stats) }) => {
+                assert_eq!(stats.errors, 1);
+                assert_eq!(stats.compilations, 6);
+            }
+            other => panic!("expected SessionEnded stats, got {other:?}"),
+        }
+        let staged = state.profiler.staged.snapshot();
+        assert_eq!(staged.counters["plan_attempted"], 3);
+        assert_eq!(staged.counters["plan_unsupported"], 3);
+        assert_eq!(staged.counters["plan_enabled"], 0);
+
+        shutdown.notify_one();
+        server.await.unwrap();
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "integration: real clang + daemon IPC"]
+async fn unsupported_mode_detaches_default_depfiles_from_prior_staged_outputs() {
+    let Some(clang) = crate::test_support::find_clang() else {
+        return;
+    };
+    crate::test_support::test_timeout(async move {
+        let temp = tempfile::tempdir().unwrap();
+        let first = temp.path().join("first.c");
+        let second = temp.path().join("second.c");
+        let header = temp.path().join("new.h");
+        let first_depfile = temp.path().join("first.d");
+        let sentinel = temp.path().join("depfile-cache-sentinel.d");
+        std::fs::write(&first, "int first(void) { return 1; }\n").unwrap();
+        std::fs::write(&second, "int second(void) { return 2; }\n").unwrap();
+        let cache_dir: NormalizedPath = temp.path().join("cache").into();
+        let (endpoint, server, shutdown, _state) = start_daemon(&cache_dir).await;
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
+        let cwd: NormalizedPath = temp.path().into();
+        client
+            .send(&Request::SessionStart {
+                client_pid: std::process::id(),
+                working_dir: cwd.clone(),
+                log_file: None,
+                track_stats: true,
+                journal_path: None,
+                profile: false,
+                private_daemon: None,
+            })
+            .await
+            .unwrap();
+        let session_id = match client.recv().await.unwrap() {
+            Some(Response::SessionStarted { session_id, .. }) => session_id,
+            other => panic!("expected SessionStarted, got {other:?}"),
+        };
+        let base_args = vec![
+            "-c".into(),
+            "-MMD".into(),
+            first.to_string_lossy().into_owned(),
+            second.to_string_lossy().into_owned(),
+        ];
+        let request = |args: Vec<String>| Request::Compile {
+            session_id: session_id.clone(),
+            args,
+            cwd: cwd.clone(),
+            compiler: clang.to_string_lossy().into_owned().into(),
+            env: None,
+            stdin: Vec::new(),
+        };
+        client.send(&request(base_args.clone())).await.unwrap();
+        assert_compile(client.recv().await.unwrap(), false);
+        let sentinel_bytes = std::fs::read(&first_depfile).unwrap();
+        std::fs::hard_link(&first_depfile, &sentinel).unwrap();
+
+        std::fs::write(&header, "#define NEW_VALUE 3\n").unwrap();
+        std::fs::write(
+            &first,
+            "#include \"new.h\"\nint first(void) { return NEW_VALUE; }\n",
+        )
+        .unwrap();
+        let mut unsupported_args = base_args;
+        unsupported_args.insert(2, "--coverage".into());
+        client.send(&request(unsupported_args)).await.unwrap();
+        assert_compile(client.recv().await.unwrap(), false);
+        assert_eq!(std::fs::read(&sentinel).unwrap(), sentinel_bytes);
+        assert!(std::fs::read_to_string(&first_depfile)
+            .unwrap()
+            .contains("new.h"));
 
         shutdown.notify_one();
         server.await.unwrap();


### PR DESCRIPTION
Refs #1081

## Summary

Hardens the merged ordinary multi-source C/C++ staged-cache path so whole-invocation semantics remain correct under cache hits, unsupported side outputs, hardlinks, compiler/input races, and publication faults.

- classify the complete invocation before any cache lookup or requested-path write
- run unsupported batches once with original argv after detaching zccache-managed primary/default-depfile outputs plus explicit/derivable side outputs
- preserve MSVC response-file syntax for clang.exe with CL-style arguments
- reject platform-aware output aliases, including case aliases on Windows/default macOS
- materialize every requested unit before publishing any cache generation
- publish disk generation, then live artifact, then depgraph mapping; roll back mismatches
- suppress publication after input ABA mutation using Unix ctime or Windows file USN, failing closed without a native marker
- preserve the pre-hash validation clock for fast-hit freshness
- retain per-unit stdout/stderr and accurate direct-fallback stats
- explicitly clean staging roots and preserve the rollout kill switch legacy fallback

## Adversarial coverage

- hardlinked object, explicit shared depfile, and previously staged default depfile sentinels
- unsupported direct fallback, materialization and publication faults, compiler failure
- A-to-B-to-A input mutation with restored mtime, including Windows USN
- forced clang-cl response files, read-only outputs, Unicode paths
- MSVC input/output grammar and GNU side-output spelling matrices
- case-alias collisions, planner counters, and session stats

## Validation

- Windows full suite: ./test
- Linux full wrapper-equivalent workspace suite
- Windows and Linux focused real-clang adversarial tests
- strict clippy with warnings denied
- rustfmt check
- strict clud-review: clean