### PR TITLE
fix(daemon): isolate mutable state by stable namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,14 @@ such as `soldr-dev`. `zccache-daemon-dev` is not a separate shipped binary; it
 is represented by the documented namespace mode so the `zccache` CLI, wrapper
 mode, and direct daemon entrypoint all resolve the same daemon identity.
 
+All daemon-owned mutable state (indexes, metadata snapshots, depgraph,
+compiler/system-include hashes, journals, download markers, and runtime
+sidecars) follows that stable namespace under `<cache>/daemon-state/<namespace>`.
+The `ZCCACHE_DAEMON_STATE_DIR` override lets an embedding broker provide the
+already-derived private directory directly; legacy unnamespaced layouts remain
+valid and a namespaced daemon rebuilds from misses rather than depending on a
+successful migration of shared snapshots.
+
 ### Daemon wire migration
 
 The active daemon wire remains v15 bincode while the v16 prost schema and

--- a/crates/zccache-artifact/src/kv.rs
+++ b/crates/zccache-artifact/src/kv.rs
@@ -254,7 +254,7 @@ pub struct KvStore {
 impl KvStore {
     /// Open under the canonical zccache root (`default_cache_dir()`).
     pub fn open_default() -> KvResult<Self> {
-        let dir = zccache_core::config::default_cache_dir();
+        let dir = zccache_core::config::daemon_state_dir();
         Self::open(dir)
     }
 

--- a/crates/zccache-cli-core/src/cli/commands/meson_cache.rs
+++ b/crates/zccache-cli-core/src/cli/commands/meson_cache.rs
@@ -169,7 +169,7 @@ pub(crate) fn cmd_configure(
         }
     };
 
-    let cache_root = config::default_cache_dir();
+    let cache_root = config::daemon_state_dir();
     let entry_dir = Path::new(cache_root.as_path())
         .join("meson-configure")
         .join(&key_hex);

--- a/crates/zccache-cli-core/src/cli/commands/rust_plan.rs
+++ b/crates/zccache-cli-core/src/cli/commands/rust_plan.rs
@@ -237,7 +237,7 @@ pub(crate) async fn cmd_rust_plan(action: RustPlanCommands) -> ExitCode {
 fn resolve_rust_plan_cache_dir(explicit: Option<&str>) -> NormalizedPath {
     explicit
         .map(NormalizedPath::from)
-        .unwrap_or_else(|| crate::core::config::default_cache_dir().join("rust-artifacts"))
+        .unwrap_or_else(|| crate::core::config::daemon_state_dir().join("rust-artifacts"))
 }
 
 fn load_rust_plan_for_cli(

--- a/crates/zccache-cli-core/src/cli/commands/symbols.rs
+++ b/crates/zccache-cli-core/src/cli/commands/symbols.rs
@@ -23,7 +23,7 @@ pub(crate) fn cmd_symbols_symbolicate(dumps: Vec<PathBuf>) -> ExitCode {
     // sidecar — true dedup. The existing `symbols::install` is the
     // battle-tested fetch path; we just point its `--prefix` at our
     // shared dir.
-    let cache_root: PathBuf = crate::core::config::default_cache_dir().into_path_buf();
+    let cache_root: PathBuf = crate::core::config::daemon_state_dir().into_path_buf();
     let symbols_dir = crate::symbols::symbols_dir_for(&cache_root, &marker.version, &marker.triple);
     let symbols_dir_path: PathBuf = symbols_dir.into_path_buf();
 

--- a/crates/zccache-cli-core/src/cli/mod.rs
+++ b/crates/zccache-cli-core/src/cli/mod.rs
@@ -185,7 +185,7 @@ pub fn run_ino_convert_cached(
     }
     let cache_key = hasher.finalize().to_hex();
 
-    let cache_dir = crate::core::config::default_cache_dir().join("ino");
+    let cache_dir = crate::core::config::daemon_state_dir().join("ino");
     std::fs::create_dir_all(&cache_dir)?;
     let cached_cpp = cache_dir.join(format!("{cache_key}.ino.cpp"));
 
@@ -265,7 +265,7 @@ pub fn infer_download_archive_path(
     archive_format: ArchiveFormat,
 ) -> std::path::PathBuf {
     let file_name = infer_download_file_name(source, archive_format);
-    crate::core::config::default_cache_dir()
+    crate::core::config::daemon_state_dir()
         .join("downloads")
         .join("artifacts")
         .join(file_name)

--- a/crates/zccache-cli-core/src/cli/runtime.rs
+++ b/crates/zccache-cli-core/src/cli/runtime.rs
@@ -569,7 +569,7 @@ fn deployed_daemon_file_name() -> &'static str {
 /// `runtime-binaries/` copies allowed.
 #[must_use]
 pub fn deployed_daemon_path() -> NormalizedPath {
-    crate::core::config::default_cache_dir().join(deployed_daemon_file_name())
+    crate::core::config::daemon_state_dir().join(deployed_daemon_file_name())
 }
 
 /// Materialize the daemon binary at [`deployed_daemon_path`] by copying
@@ -648,7 +648,7 @@ const DAEMON_SPAWN_LOGS_SUBDIR: &str = "logs";
 /// path — the daemon's own opener will see the error and fall back to
 /// `Stdio::null` after warning.
 fn allocate_daemon_spawn_log_path() -> std::path::PathBuf {
-    let dir = crate::core::config::default_cache_dir().join(DAEMON_SPAWN_LOGS_SUBDIR);
+    let dir = crate::core::config::daemon_state_dir().join(DAEMON_SPAWN_LOGS_SUBDIR);
     let _ = std::fs::create_dir_all(dir.as_path());
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -689,7 +689,7 @@ const LOG_GC_CUTOFF: std::time::Duration = std::time::Duration::from_secs(60 * 6
 /// and deleting it mid-life would erase the very history that #323
 /// needed to diagnose the multi-spawn bug.
 pub fn gc_log_directory() {
-    let dir = crate::core::config::default_cache_dir().join(DAEMON_SPAWN_LOGS_SUBDIR);
+    let dir = crate::core::config::daemon_state_dir().join(DAEMON_SPAWN_LOGS_SUBDIR);
     gc_log_directory_in(dir.as_path(), LOG_GC_CUTOFF);
 }
 

--- a/crates/zccache-cli-core/src/cli/symbols.rs
+++ b/crates/zccache-cli-core/src/cli/symbols.rs
@@ -735,7 +735,7 @@ mod tests {
             .and_then(|s| s.to_str());
         assert_eq!(parent, Some("symbols"));
 
-        let expected_root = crate::core::config::default_cache_dir();
+        let expected_root = crate::core::config::daemon_state_dir();
         assert!(
             path.starts_with(expected_root.as_path()),
             "cache path {} should be under default_cache_dir {}",

--- a/crates/zccache-cli-core/src/download_client/artifact/lock.rs
+++ b/crates/zccache-cli-core/src/download_client/artifact/lock.rs
@@ -40,7 +40,7 @@ fn fetch_lock_path(request: &ResolvedFetchRequest) -> PathBuf {
         key.push_str(&crate::core::normalize_for_key(expanded_path));
     }
     let hash = stable_download_id(Path::new(&key));
-    crate::core::config::default_cache_dir()
+    crate::core::config::daemon_state_dir()
         .join("downloads")
         .join("locks")
         .join(format!("{hash}.lock"))

--- a/crates/zccache-cli-core/src/download_client/artifact/marker.rs
+++ b/crates/zccache-cli-core/src/download_client/artifact/marker.rs
@@ -28,7 +28,7 @@ pub(super) struct ArtifactMarker {
 
 pub(super) fn artifact_marker_path(cache_path: &Path) -> PathBuf {
     let hash = stable_download_id(cache_path);
-    crate::core::config::default_cache_dir()
+    crate::core::config::daemon_state_dir()
         .join("downloads")
         .join("artifact-state")
         .join(format!("{hash}.json"))
@@ -37,7 +37,7 @@ pub(super) fn artifact_marker_path(cache_path: &Path) -> PathBuf {
 
 pub(super) fn expanded_marker_path(expanded_path: &Path) -> PathBuf {
     let hash = stable_download_id(expanded_path);
-    crate::core::config::default_cache_dir()
+    crate::core::config::daemon_state_dir()
         .join("downloads")
         .join("expanded-state")
         .join(format!("{hash}.json"))

--- a/crates/zccache-cli-core/src/download_daemon/mod.rs
+++ b/crates/zccache-cli-core/src/download_daemon/mod.rs
@@ -353,7 +353,7 @@ async fn attach_job(
         return Ok((existing, false));
     }
 
-    let metadata_dir = crate::core::config::default_cache_dir()
+    let metadata_dir = crate::core::config::daemon_state_dir()
         .join("downloads")
         .join(&download_id);
     let initial_status = if destination.exists() && !options.force {

--- a/crates/zccache-core/src/config/README.md
+++ b/crates/zccache-core/src/config/README.md
@@ -5,12 +5,12 @@ Configuration types and cache-root resolution for zccache.
 Split into focused submodules (file-size discipline: every source file < 1,000 LOC):
 
 - **`mod.rs`** - Public `Config` struct + `Default` impl, top-level constants
-  (`CACHE_DIR_ENV`, `DAEMON_NAMESPACE_ENV`, `DEFAULT_IDLE_TIMEOUT_SECS`,
+  (`CACHE_DIR_ENV`, `DAEMON_NAMESPACE_ENV`, `DAEMON_STATE_DIR_ENV`, `DEFAULT_IDLE_TIMEOUT_SECS`,
   `COLOCATE_ENV`, etc.), and `pub use` re-exports of every public symbol so the
   facade path `zccache::core::config::<Name>` is preserved.
-- **`resolve.rs`** - Cache-root resolution: `default_cache_dir`,
+- **`resolve.rs`** - Cache-root and daemon-state resolution: `default_cache_dir`,
   `resolve_cache_root`, `resolve_cache_root_top_level`, `versioned_subdir`,
-  `CacheRootSource`, `cache_dir_override`, and the cross-volume colocation
+  `daemon_state_dir`, `CacheRootSource`, `cache_dir_override`, and the cross-volume colocation
   logic (`ZCCACHE_COLOCATE`, `volume_root`, `same_volume_root`).
 - **`paths.rs`** - Well-known subpath helpers under the cache root
   (`artifacts_dir`, `tmp_dir`, `depfile_dir`, `depgraph_dir`, `log_dir`,

--- a/crates/zccache-core/src/config/mod.rs
+++ b/crates/zccache-core/src/config/mod.rs
@@ -25,6 +25,12 @@ pub const CACHE_DIR_ENV: &str = "ZCCACHE_CACHE_DIR";
 /// without sharing IPC endpoints, lock files, or lifecycle logs.
 pub const DAEMON_NAMESPACE_ENV: &str = "ZCCACHE_DAEMON_NAMESPACE";
 
+/// Optional explicit root for daemon-owned mutable state. Embedding hosts can
+/// set this when the broker has already assigned a stable private directory;
+/// it is deliberately separate from `ZCCACHE_CACHE_DIR`, which remains the
+/// user-visible top-level root used for endpoint and shared artifact identity.
+pub const DAEMON_STATE_DIR_ENV: &str = "ZCCACHE_DAEMON_STATE_DIR";
+
 /// Human-readable namespace label reported when no explicit daemon namespace
 /// is configured. This label is diagnostic only; default endpoint/path names
 /// deliberately do not include it so existing users keep the same layout.
@@ -102,11 +108,12 @@ pub use paths::{
     tmp_dir, tmp_dir_from_cache_dir,
 };
 pub use resolve::{
-    cache_dir_override, default_cache_dir, effective_cache_root_from_top_level,
-    is_version_dir_name, prune_stale_version_dirs, prune_stale_version_dirs_in,
-    read_last_version_marker, resolve_cache_root, resolve_cache_root_top_level, versioned_subdir,
-    write_last_version_marker, write_last_version_marker_in, CacheRootSource, PruneReport,
-    LAST_VERSION_MARKER,
+    cache_dir_override, daemon_state_dir, daemon_state_dir_from_cache_dir,
+    daemon_state_dir_from_cache_dir_with_namespace, default_cache_dir,
+    effective_cache_root_from_top_level, is_version_dir_name, prune_stale_version_dirs,
+    prune_stale_version_dirs_in, read_last_version_marker, resolve_cache_root,
+    resolve_cache_root_top_level, versioned_subdir, write_last_version_marker,
+    write_last_version_marker_in, CacheRootSource, PruneReport, LAST_VERSION_MARKER,
 };
 
 /// Top-level configuration for zccache.

--- a/crates/zccache-core/src/config/paths.rs
+++ b/crates/zccache-core/src/config/paths.rs
@@ -12,7 +12,7 @@
 //! from issue #275. The `cache_root_invariant_all_subpaths_rooted` test in
 //! `tests.rs` guards that invariant.
 
-use super::resolve::default_cache_dir;
+use super::resolve::{daemon_state_dir_from_cache_dir, default_cache_dir};
 use crate::NormalizedPath;
 
 /// Returns the directory for content-addressed compiled outputs.
@@ -64,13 +64,13 @@ pub fn symbols_cache_dir() -> NormalizedPath {
 /// Returns the symbols-archive cache under an explicit cache root.
 #[must_use]
 pub fn symbols_cache_dir_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
-    cache_dir.join("symbols")
+    daemon_state_dir_from_cache_dir(cache_dir).join("symbols")
 }
 
 /// Returns the cargo registry archive cache under an explicit cache root.
 #[must_use]
 pub fn cargo_registry_cache_dir_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
-    cache_dir.join("cargo-registry")
+    daemon_state_dir_from_cache_dir(cache_dir).join("cargo-registry")
 }
 
 /// Returns the path to the artifact index database.
@@ -98,13 +98,13 @@ pub fn log_dir() -> NormalizedPath {
 /// [`default_cache_dir`].
 #[must_use]
 pub fn artifacts_dir_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
-    cache_dir.join("artifacts")
+    daemon_state_dir_from_cache_dir(cache_dir).join("artifacts")
 }
 
 /// Returns the tmp directory under an explicit cache root.
 #[must_use]
 pub fn tmp_dir_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
-    cache_dir.join("tmp")
+    daemon_state_dir_from_cache_dir(cache_dir).join("tmp")
 }
 
 /// Returns the depfile directory under an explicit cache root.
@@ -114,7 +114,7 @@ pub fn depfile_dir_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath 
 }
 
 pub(super) fn depgraph_dir_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
-    cache_dir.join("depgraph")
+    daemon_state_dir_from_cache_dir(cache_dir).join("depgraph")
 }
 
 /// Returns the artifact index path under an explicit cache root.
@@ -126,7 +126,7 @@ pub(super) fn depgraph_dir_from_cache_dir(cache_dir: &NormalizedPath) -> Normali
 /// `zccache clear` or delete `index.redb` manually.
 #[must_use]
 pub fn index_path_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
-    cache_dir.join("index.bin")
+    daemon_state_dir_from_cache_dir(cache_dir).join("index.bin")
 }
 
 /// Returns the on-disk path for the persisted `MetadataCache` snapshot.
@@ -137,7 +137,7 @@ pub fn index_path_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
 /// `soldr save`/`soldr load`) picks both files up automatically.
 #[must_use]
 pub fn metadata_path_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
-    cache_dir.join("metadata.bin")
+    daemon_state_dir_from_cache_dir(cache_dir).join("metadata.bin")
 }
 
 /// Returns the on-disk path for the persisted compiler-binary hash cache.
@@ -150,7 +150,7 @@ pub fn metadata_path_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPat
 /// load pipeline already bundles it.
 #[must_use]
 pub fn compiler_hash_cache_path_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
-    cache_dir.join("compiler_hash.bin")
+    daemon_state_dir_from_cache_dir(cache_dir).join("compiler_hash.bin")
 }
 
 /// Returns the on-disk path for the persisted `SystemIncludeCache` snapshot.
@@ -163,15 +163,15 @@ pub fn compiler_hash_cache_path_from_cache_dir(cache_dir: &NormalizedPath) -> No
 /// soldr save / load pipeline already bundles it.
 #[must_use]
 pub fn system_includes_cache_path_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
-    cache_dir.join("system_includes.bin")
+    daemon_state_dir_from_cache_dir(cache_dir).join("system_includes.bin")
 }
 
 pub(super) fn crash_dump_dir_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
-    cache_dir.join("crashes")
+    daemon_state_dir_from_cache_dir(cache_dir).join("crashes")
 }
 
 /// Returns the log directory under an explicit cache root.
 #[must_use]
 pub fn log_dir_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
-    cache_dir.join("logs")
+    daemon_state_dir_from_cache_dir(cache_dir).join("logs")
 }

--- a/crates/zccache-core/src/config/resolve.rs
+++ b/crates/zccache-core/src/config/resolve.rs
@@ -7,7 +7,7 @@
 //! the per-daemon-version subdir layout (issues #761 / #762 Phase 0).
 
 use super::namespace::home_dir_short_hash;
-use super::{CACHE_DIR_ENV, COLOCATE_ENV};
+use super::{CACHE_DIR_ENV, COLOCATE_ENV, DAEMON_NAMESPACE_ENV, DAEMON_STATE_DIR_ENV};
 use crate::NormalizedPath;
 use std::ffi::OsString;
 use std::path::Path;
@@ -21,6 +21,62 @@ use std::path::Path;
 #[must_use]
 pub fn default_cache_dir() -> NormalizedPath {
     default_cache_dir_from_env_value(std::env::var_os(CACHE_DIR_ENV))
+}
+
+/// Resolve the directory that owns daemon-local mutable snapshots.
+///
+/// An embedding host may provide an already-derived private path through
+/// `ZCCACHE_DAEMON_STATE_DIR`. Otherwise an explicitly named daemon gets a
+/// stable namespace below the top-level cache root. The default namespace
+/// intentionally retains the historical layout for backwards compatibility.
+#[must_use]
+pub fn daemon_state_dir() -> NormalizedPath {
+    let cache_dir = default_cache_dir();
+    if let Some(value) = std::env::var_os(DAEMON_STATE_DIR_ENV).filter(|value| !value.is_empty()) {
+        return normalize_cache_dir_override(std::path::Path::new(&value));
+    }
+    daemon_state_dir_from_cache_dir(&cache_dir)
+}
+
+/// Resolve daemon-local state under an explicit top-level cache root.
+#[must_use]
+pub fn daemon_state_dir_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
+    if let Some(value) = std::env::var_os(DAEMON_STATE_DIR_ENV).filter(|value| !value.is_empty()) {
+        return normalize_cache_dir_override(std::path::Path::new(&value));
+    }
+    daemon_state_dir_from_cache_dir_with_namespace(
+        cache_dir,
+        std::env::var_os(DAEMON_NAMESPACE_ENV).and_then(|value| value.into_string().ok()),
+    )
+}
+
+/// Pure path helper used by tests and embedding hosts that already have a
+/// normalized namespace. Sanitization makes the resulting path component
+/// bounded and safe on every supported filesystem.
+#[must_use]
+pub fn daemon_state_dir_from_cache_dir_with_namespace(
+    cache_dir: &NormalizedPath,
+    namespace: Option<String>,
+) -> NormalizedPath {
+    let Some(namespace) = namespace
+        .as_deref()
+        .and_then(super::namespace::sanitize_daemon_namespace)
+    else {
+        return cache_dir.clone();
+    };
+    if cache_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == namespace)
+        && cache_dir
+            .parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name == "daemon-state")
+    {
+        return cache_dir.clone();
+    }
+    cache_dir.join("daemon-state").join(namespace)
 }
 
 pub(super) fn default_cache_dir_from_env_value(value: Option<OsString>) -> NormalizedPath {
@@ -418,5 +474,37 @@ mod version_hygiene_tests {
         let missing = tmp.path().join("does-not-exist");
         let report = prune_stale_version_dirs_in(&missing, "v1.12.15");
         assert!(report.removed.is_empty() && report.skipped.is_empty());
+    }
+
+    #[test]
+    fn daemon_state_namespace_is_stable_and_distinct() {
+        let root = NormalizedPath::from("/tmp/zccache-root");
+        let a = daemon_state_dir_from_cache_dir_with_namespace(&root, Some("broker-a".into()));
+        let b = daemon_state_dir_from_cache_dir_with_namespace(&root, Some("broker-b".into()));
+        assert_ne!(a, b);
+        assert_eq!(
+            a,
+            daemon_state_dir_from_cache_dir_with_namespace(&root, Some("broker-a".into()))
+        );
+        assert!(a.as_path().ends_with("daemon-state/broker-a"));
+    }
+
+    #[test]
+    fn daemon_state_default_preserves_legacy_layout() {
+        let root = NormalizedPath::from("/tmp/zccache-root");
+        assert_eq!(
+            daemon_state_dir_from_cache_dir_with_namespace(&root, None),
+            root
+        );
+    }
+
+    #[test]
+    fn daemon_state_namespace_path_is_idempotent() {
+        let root = NormalizedPath::from("/tmp/zccache-root");
+        let state = daemon_state_dir_from_cache_dir_with_namespace(&root, Some("broker-a".into()));
+        assert_eq!(
+            daemon_state_dir_from_cache_dir_with_namespace(&state, Some("broker-a".into())),
+            state
+        );
     }
 }

--- a/crates/zccache-core/src/crash.rs
+++ b/crates/zccache-core/src/crash.rs
@@ -90,7 +90,7 @@ pub fn install(bin_stem: &'static str) -> CrashGuard {
 /// is mid-startup and an `eprintln!` would race with their own tracing
 /// init.
 fn write_last_run_marker(bin_stem: &str) -> std::io::Result<()> {
-    let cache_dir = super::config::default_cache_dir();
+    let cache_dir = super::config::daemon_state_dir();
     std::fs::create_dir_all(&cache_dir)?;
     let ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -100,7 +100,7 @@ fn write_last_run_marker(bin_stem: &str) -> std::io::Result<()> {
 }
 
 fn last_run_marker_path(bin_stem: &str) -> PathBuf {
-    let cache_dir = super::config::default_cache_dir();
+    let cache_dir = super::config::daemon_state_dir();
     cache_dir
         .join(format!("last_run_{bin_stem}.txt"))
         .as_path()

--- a/crates/zccache-daemon-core/src/daemon/entry.rs
+++ b/crates/zccache-daemon-core/src/daemon/entry.rs
@@ -300,6 +300,12 @@ fn run_server(args: Args) {
     // not on Defender's exclusion list. Non-fatal; no-ops off Windows
     // and when `ZCCACHE_QUIET` is set.
     let cache_root = crate::core::config::default_cache_dir();
+    let daemon_state_root = crate::core::config::daemon_state_dir();
+    tracing::info!(
+        daemon_namespace = %crate::core::config::daemon_namespace_label(),
+        mutable_state_dir = %daemon_state_root.display(),
+        "resolved daemon cache state"
+    );
     crate::core::defender::maybe_emit_first_run_banner(cache_root.as_path());
 
     #[expect(

--- a/crates/zccache-download-protocol/src/daemon_mgmt.rs
+++ b/crates/zccache-download-protocol/src/daemon_mgmt.rs
@@ -48,7 +48,7 @@ fn endpoint_for_cache_dir(cache_dir: &std::path::Path) -> String {
 
 /// Path to the daemon PID lock file.
 pub fn lock_file_path() -> NormalizedPath {
-    zccache_core::config::default_cache_dir().join("download-daemon.lock")
+    zccache_core::config::daemon_state_dir().join("download-daemon.lock")
 }
 
 /// Write the daemon PID to the lock file.


### PR DESCRIPTION
Closes #1085. Adds a stable daemon-state root selected by ZCCACHE_DAEMON_STATE_DIR or the sanitized ZCCACHE_DAEMON_NAMESPACE, routes daemon snapshots, depgraph, journals, runtime/download sidecars, artifact KV state, and materialized artifacts through that root, preserves the unnamespaced layout for compatibility, and logs the resolved mutable-state directory. Legacy shared snapshots are treated as rebuildable. Validation: Docker perf runner config tests (8 passed), workspace checks for zccache/daemon/CLI crates, fmt check, and diff check.