### PR TITLE
fix(ci): run only registered benchmark stats tests

### DIFF
--- a/ci/benchmark_stats.py
+++ b/ci/benchmark_stats.py
@@ -85,15 +85,6 @@ BENCHMARK_TESTS_BY_LANGUAGE = {
         "perf_rust_workspace_link",
     ),
 }
-BENCHMARK_COMMAND = [
-    *BENCHMARK_BASE_COMMAND,
-    "--",
-    "--nocapture",
-    "--ignored",
-    "--test-threads=1",
-]
-
-
 TABLES = {
     "## C Benchmark:": {
         "id": "c-inline",
@@ -191,6 +182,15 @@ def benchmark_commands_for_language(language: str) -> list[list[str]]:
     return [benchmark_command_for_test(test_name) for test_name in test_names]
 
 
+def benchmark_commands_for_all() -> list[list[str]]:
+    """Return only the benchmark tests represented in the published report."""
+    return [
+        benchmark_command_for_test(test_name)
+        for language in LANGUAGES
+        for test_name in BENCHMARK_TESTS_BY_LANGUAGE[language]
+    ]
+
+
 def _utc_now() -> str:
     return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
 
@@ -263,7 +263,9 @@ def collect_metadata() -> dict[str, Any]:
             "clang": _first_line(_run_quiet(["clang++", "--version"])),
             "sccache": _first_line(_run_quiet(["sccache", "--version"])),
         },
-        "benchmark_command": " ".join(BENCHMARK_COMMAND),
+        "benchmark_command": " ; ".join(
+            " ".join(command) for command in benchmark_commands_for_all()
+        ),
         "pages_url": os.environ.get("ZCCACHE_BENCHMARK_PAGES_URL", DEFAULT_PAGES_URL),
         "raw_image_base_url": raw_image_base_url,
         "raw_image_urls": {
@@ -300,26 +302,34 @@ def run_benchmarks(log_path: Path) -> str:
     env = benchmark_env(cache_dir)
 
     try:
-        result = subprocess.run(
-            BENCHMARK_COMMAND,
-            cwd=REPO_ROOT,
-            env=env,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            check=False,
-        )
+        outputs: list[str] = []
+        returncode = 0
+        commands = benchmark_commands_for_all()
+        for command in commands:
+            result = subprocess.run(
+                command,
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+            outputs.append(result.stdout)
+            if result.returncode != 0:
+                returncode = result.returncode
+                break
     finally:
         shutil.rmtree(cache_dir, ignore_errors=True)
 
-    output = result.stdout
+    output = "".join(outputs)
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text(output, encoding="utf-8")
     print(output, end="")
-    if result.returncode != 0:
-        raise SystemExit(result.returncode)
+    if returncode != 0:
+        raise SystemExit(returncode)
     return output
 
 

--- a/ci/perf_guard.py
+++ b/ci/perf_guard.py
@@ -125,7 +125,7 @@ def _benchmark_commands(
     if test_name is not None:
         return [benchmark_stats.benchmark_command_for_test(test_name)]
     if language is None:
-        return [benchmark_stats.BENCHMARK_COMMAND]
+        return benchmark_stats.benchmark_commands_for_all()
     return benchmark_stats.benchmark_commands_for_language(language)
 
 

--- a/ci/tests/test_benchmark_stats.py
+++ b/ci/tests/test_benchmark_stats.py
@@ -276,6 +276,43 @@ def test_benchmark_command_targets_existing_workspace_package():
     ]
 
 
+def test_all_benchmark_commands_are_registered_report_tests():
+    commands = benchmark_stats.benchmark_commands_for_all()
+    names = [command[command.index("--") + 1] for command in commands]
+    registered = [
+        test_name
+        for language in benchmark_stats.LANGUAGES
+        for test_name in benchmark_stats.BENCHMARK_TESTS_BY_LANGUAGE[language]
+    ]
+
+    assert names == registered
+    assert "perf_meson_probe_storm_wrapper" not in names
+
+
+def test_run_benchmarks_executes_each_registered_test(tmp_path, monkeypatch):
+    commands = benchmark_stats.benchmark_commands_for_all()
+    executed = []
+
+    class Result:
+        returncode = 0
+
+        def __init__(self, command):
+            self.stdout = f"ran {command[command.index('--') + 1]}\n"
+
+    def fake_run(command, **kwargs):
+        executed.append(command)
+        return Result(command)
+
+    monkeypatch.setattr(benchmark_stats.subprocess, "run", fake_run)
+
+    output = benchmark_stats.run_benchmarks(tmp_path / "bench.log")
+
+    assert executed == commands
+    assert output == "".join(
+        f"ran {command[command.index('--') + 1]}\n" for command in commands
+    )
+
+
 def test_zero_duration_cells_are_invalid_not_inflated():
     # #443: a 0.000s reading is a broken measurement — a cold (or even a warm
     # cache-hit) compile/link is never instant. It must be treated as invalid

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -583,6 +583,16 @@ def test_benchmark_language_commands_are_filtered():
     ]
 
 
+def test_unfiltered_benchmark_commands_are_reported_tests_only():
+    commands = perf_guard._benchmark_commands(None)
+
+    assert [command[command.index("--") + 1] for command in commands] == [
+        test_name
+        for language in benchmark_stats.LANGUAGES
+        for test_name in benchmark_stats.BENCHMARK_TESTS_BY_LANGUAGE[language]
+    ]
+
+
 def test_prebuilt_benchmark_binary_commands_are_filtered():
     commands = perf_guard._benchmark_commands("c++", Path("perf_bench_test"))
 


### PR DESCRIPTION
## Summary

- Run Benchmark Stats one explicitly registered ignored test at a time.
- Prevent unreported wrapper benchmarks from entering the published suite.
- Apply the same filtered command set when Perf Guard is invoked without a language.
- Add regression tests for command selection and execution.

Refs #1025

## Validation

- `uv run --no-project pytest ci/tests/test_benchmark_stats.py ci/tests/test_perf_guard.py -q` (61 passed)
- `uv run --no-project ruff check ci/benchmark_stats.py ci/perf_guard.py ci/tests/test_benchmark_stats.py ci/tests/test_perf_guard.py`