### PR TITLE
fix(ci): keep dylint libraries on their nightly toolchain

### DIFF
--- a/ci/lint.py
+++ b/ci/lint.py
@@ -60,9 +60,22 @@ def run_cmd_capture(cmd):
 
 
 def dylint_env():
-    """Run cargo-dylint under the nightly toolchain without using +toolchain syntax."""
+    """Run cargo-dylint with the nightly toolchain ahead of stable shims.
+
+    cargo-dylint deliberately removes ``RUSTUP_TOOLCHAIN`` before compiling a
+    lint library. Put the selected toolchain's bin directory first on PATH so
+    those sanitized child commands still use the driver-compatible cargo and
+    rustc binaries.
+    """
     env = self_build_env()
     env["RUSTUP_TOOLCHAIN"] = DYLINT_TOOLCHAIN
+    rustc = subprocess.check_output(
+        ["rustup", "which", "--toolchain", DYLINT_TOOLCHAIN, "rustc"],
+        env=env,
+        text=True,
+    ).strip()
+    toolchain_bin = str(Path(rustc).resolve().parent)
+    env["PATH"] = os.pathsep.join([toolchain_bin, env.get("PATH", "")])
     return env
 
 

--- a/ci/tests/test_lint.py
+++ b/ci/tests/test_lint.py
@@ -1,0 +1,32 @@
+import os
+from pathlib import Path
+
+from ci import lint
+
+
+def test_dylint_env_puts_selected_toolchain_first(monkeypatch):
+    base_env = {"PATH": os.pathsep.join(["stable-bin", "other-bin"])}
+    rustc = Path("toolchains") / lint.DYLINT_TOOLCHAIN / "bin" / "rustc.exe"
+    captured = {}
+
+    monkeypatch.setattr(lint, "self_build_env", lambda: base_env.copy())
+
+    def fake_check_output(command, **kwargs):
+        captured["command"] = command
+        captured["env"] = kwargs["env"]
+        return f"{rustc}\n"
+
+    monkeypatch.setattr(lint.subprocess, "check_output", fake_check_output)
+
+    env = lint.dylint_env()
+
+    assert captured["command"] == [
+        "rustup",
+        "which",
+        "--toolchain",
+        lint.DYLINT_TOOLCHAIN,
+        "rustc",
+    ]
+    assert env["RUSTUP_TOOLCHAIN"] == lint.DYLINT_TOOLCHAIN
+    assert env["PATH"].split(os.pathsep)[0] == str(rustc.resolve().parent)
+    assert captured["env"] is env

--- a/dylints/ban_raw_subprocess_in_daemon/Cargo.toml
+++ b/dylints/ban_raw_subprocess_in_daemon/Cargo.toml
@@ -20,3 +20,5 @@ dylint_testing = { git = "https://github.com/trailofbits/dylint", rev = "4bd91ce
 
 [package.metadata.rust-analyzer]
 rustc_private = true
+
+[workspace]

--- a/dylints/ban_std_pathbuf/Cargo.toml
+++ b/dylints/ban_std_pathbuf/Cargo.toml
@@ -24,3 +24,5 @@ dylint_testing = { git = "https://github.com/trailofbits/dylint", rev = "4bd91ce
 
 [package.metadata.rust-analyzer]
 rustc_private = true
+
+[workspace]

--- a/dylints/ban_tmp_literal/Cargo.toml
+++ b/dylints/ban_tmp_literal/Cargo.toml
@@ -19,3 +19,5 @@ dylint_testing = { git = "https://github.com/trailofbits/dylint", rev = "4bd91ce
 
 [package.metadata.rust-analyzer]
 rustc_private = true
+
+[workspace]

--- a/dylints/ban_unrooted_tempdir/Cargo.toml
+++ b/dylints/ban_unrooted_tempdir/Cargo.toml
@@ -21,3 +21,5 @@ dylint_testing = { git = "https://github.com/trailofbits/dylint", rev = "4bd91ce
 
 [package.metadata.rust-analyzer]
 rustc_private = true
+
+[workspace]

--- a/dylints/rust-toolchain.toml
+++ b/dylints/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+# cargo-dylint removes RUSTUP_TOOLCHAIN before compiling each library. Keep
+# those builds on the same nightly used for the Dylint driver and CI tests.
+channel = "nightly-2026-03-26"
+components = ["llvm-tools-preview", "rust-src", "rustc-dev"]


### PR DESCRIPTION
## Summary

- Put the Dylint nightly toolchain bin directory first on PATH before cargo-dylint sanitizes RUSTUP_TOOLCHAIN.
- Make the intentionally excluded lint crates standalone Cargo workspaces.
- Add an explicit shared nightly toolchain boundary for the lint crates.
- Add a regression test for the sanitized-child environment.

Refs #1025

## Validation

- `uv run --no-project pytest ci/tests/test_lint.py ci/tests/test_build_dylint_driver.py -q` (5 passed)
- `uv run --no-project ruff check ci/lint.py ci/tests/test_lint.py` (passed)
- Native `soldr rustup run nightly-2026-03-26 cargo test` reached the Dylint dependency build; the local soldr wrapper still selected stable for the rustc-private dependency, so the PATH-selection regression is validated by the focused test and CI is the authoritative Dylint integration check.