### PR TITLE
perf(ci): centralize local threshold manifest

### DIFF
--- a/ci/perf_local.py
+++ b/ci/perf_local.py
@@ -75,6 +75,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DOCKER_DIR = REPO_ROOT / "ci" / "docker"
 PERF_LOCAL = REPO_ROOT / ".perf-local"
+PERF_THRESHOLDS_PATH = REPO_ROOT / "ci" / "perf_thresholds.json"
 
 SOLDR_REPO = "https://github.com/zackees/soldr.git"
 SOLDR_REF = "main"
@@ -125,19 +126,26 @@ ROLLOUT_SCENARIOS = (
 DEFAULT_SCENARIO = "cold-tar-untar-warm"
 DEFAULT_FIXTURE = "medium"
 
-# Local Docker Desktop measurements are intentionally separate from hosted
-# runner budgets. The 8 GiB VM runs with CARGO_BUILD_JOBS=2; these ceilings
-# leave roughly 2x headroom over the accepted #1084 matrix while preserving a
-# meaningful user-visible floor.
-LOCAL_MIN_SPEEDUP = 4.5
-LOCAL_MAX_WARM_MS = {
-    "cold-tar-untar-warm": None,
-    "restore-no-clean-warm": 10_000,
-    "worktree-share": 15_000,
-    "touch-no-change": 10_000,
-}
-LOCAL_MAX_STAGED_OVERHEAD_MS = 15_000
-LOCAL_MAX_MATERIALIZATION_COPIED_BYTES = 2 * (1 << 30)
+def load_perf_thresholds() -> dict:
+    """Load and validate the single source of truth for local timing gates."""
+    thresholds = json.loads(PERF_THRESHOLDS_PATH.read_text(encoding="utf-8"))
+    if thresholds.get("schema_version") != 1:
+        raise ValueError("unsupported perf threshold manifest schema")
+    warm_limits = thresholds.get("maximum_warm_ms")
+    if not isinstance(warm_limits, dict) or set(warm_limits) != set(ROLLOUT_SCENARIOS):
+        raise ValueError("threshold manifest must define every rollout scenario")
+    if not isinstance(thresholds.get("minimum_speedup"), (int, float)):
+        raise ValueError("threshold manifest minimum_speedup must be numeric")
+    return thresholds
+
+
+PERF_THRESHOLDS = load_perf_thresholds()
+LOCAL_MIN_SPEEDUP = float(PERF_THRESHOLDS["minimum_speedup"])
+LOCAL_MAX_WARM_MS = PERF_THRESHOLDS["maximum_warm_ms"]
+LOCAL_MAX_STAGED_OVERHEAD_MS = int(PERF_THRESHOLDS["maximum_staged_overhead_ms"])
+LOCAL_MAX_MATERIALIZATION_COPIED_BYTES = int(
+    PERF_THRESHOLDS["maximum_materialization_copied_bytes"]
+)
 
 
 # ---------------------------------------------------------------------------
@@ -730,7 +738,7 @@ def render_summary(results_dir: Path, scenario: str, fixture: str) -> int:
     daemon_rss = result.get("peak_daemon_rss_bytes")
     compile_rss = result.get("peak_compile_rss_bytes")
 
-    threshold = 4.5
+    threshold = LOCAL_MIN_SPEEDUP
     verdict = "PASS" if speedup >= threshold else "FAIL"
 
     print()

--- a/ci/perf_thresholds.json
+++ b/ci/perf_thresholds.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "environment": "linux-docker",
+  "minimum_speedup": 4.5,
+  "maximum_warm_ms": {
+    "cold-tar-untar-warm": null,
+    "worktree-share": 15000,
+    "touch-no-change": 10000,
+    "restore-no-clean-warm": 10000
+  },
+  "maximum_staged_overhead_ms": 15000,
+  "maximum_materialization_copied_bytes": 2147483648
+}

--- a/ci/tests/test_perf_local.py
+++ b/ci/tests/test_perf_local.py
@@ -183,6 +183,16 @@ def test_fmt_ms_minutes_seconds():
     assert perf_local.fmt_ms(120_000) == "2m00s"
 
 
+def test_threshold_manifest_is_authoritative_for_evaluation_and_rendering():
+    assert perf_local.PERF_THRESHOLDS_PATH.is_file()
+    assert perf_local.LOCAL_MIN_SPEEDUP == perf_local.PERF_THRESHOLDS["minimum_speedup"]
+    assert perf_local.LOCAL_MAX_WARM_MS == perf_local.PERF_THRESHOLDS["maximum_warm_ms"]
+    assert (
+        perf_local.LOCAL_MAX_STAGED_OVERHEAD_MS
+        == perf_local.PERF_THRESHOLDS["maximum_staged_overhead_ms"]
+    )
+
+
 def test_fmt_ms_seconds_with_fraction():
     # >= 1000 ms shows seconds with two decimals
     assert perf_local.fmt_ms(1_500) == "1.50s"


### PR DESCRIPTION
## Summary\n- move Linux Docker timing budgets into a versioned JSON manifest\n- make evaluation and rendered summaries consume the same values\n- add a regression test for manifest authority\n\nRefs #1093\n\n## Validation\n- uv run --no-project pytest ci/tests/test_perf_local.py -q (39 passed)\n- uv run --no-project ruff check ci/perf_local.py ci/tests/test_perf_local.py