### PR TITLE
fix(ci): invoke cargo-dylint outside soldr wrapper

### DIFF
--- a/ci/lint.py
+++ b/ci/lint.py
@@ -79,6 +79,14 @@ def dylint_env():
     return env
 
 
+def dylint_command() -> list[str]:
+    """Run cargo-dylint directly so soldr cannot reselect stable Rust."""
+    executable = which("cargo-dylint")
+    if executable is None:
+        raise FileNotFoundError("cargo-dylint is required for workspace linting")
+    return [executable, "--all", "--workspace"]
+
+
 def ensure_dylint_aliases():
     """Create cargo-dylint's expected `name@toolchain` aliases when missing."""
     libraries_root = SCRIPT_DIR / "target" / "dylint" / "libraries"
@@ -174,7 +182,7 @@ def lint_dylint_only():
     if result != 0:
         return result
 
-    dylint_cmd = cargo_command("dylint", "--all", "--workspace")
+    dylint_cmd = dylint_command()
 
     # cargo-dylint expects libraries on disk as `<name>@<toolchain>.<ext>` but
     # cargo emits them as bare `<name>.<ext>`. Each freshly-built library

--- a/ci/tests/test_lint.py
+++ b/ci/tests/test_lint.py
@@ -30,3 +30,12 @@ def test_dylint_env_puts_selected_toolchain_first(monkeypatch):
     assert env["RUSTUP_TOOLCHAIN"] == lint.DYLINT_TOOLCHAIN
     assert env["PATH"].split(os.pathsep)[0] == str(rustc.resolve().parent)
     assert captured["env"] is env
+
+
+def test_dylint_command_bypasses_soldr_toolchain_selection(monkeypatch):
+    monkeypatch.setattr(
+        lint,
+        "which",
+        lambda name: "/opt/cargo-dylint" if name == "cargo-dylint" else None,
+    )
+    assert lint.dylint_command() == ["/opt/cargo-dylint", "--all", "--workspace"]


### PR DESCRIPTION
## Summary\n- invoke cargo-dylint directly instead of through soldr cargo selection\n- preserve the pinned nightly PATH for cargo-dylint's sanitized library builds\n- add a regression test for the command boundary\n\nRefs #1025\n\n## Validation\n- PYTHONPATH=worktree uv run --no-project pytest ci/tests/test_lint.py ci/tests/test_build_dylint_driver.py -q (6 passed)\n- uv run --no-project ruff check ci/lint.py ci/tests/test_lint.py