### PR TITLE
ci: add Docker-backed local pre-PR harness

### DIFF
--- a/ci/local_pre_pr.py
+++ b/ci/local_pre_pr.py
@@ -1,0 +1,66 @@
+"""Run the fast, Docker-backed checks intended before opening a PR.
+
+This wrapper deliberately delegates container setup, images, and volumes to
+``ci/perf_local.py`` so local checks use the same Linux environment as the
+authoritative performance harness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PERF_LOCAL = REPO_ROOT / "ci" / "perf_local.py"
+UV = "uv"
+
+
+def run_perf_local(*args: str) -> None:
+    command = [UV, "run", "--no-project", "python", str(PERF_LOCAL), *args]
+    print("$ " + " ".join(command), flush=True)
+    subprocess.run(command, cwd=REPO_ROOT, check=True)
+
+
+def run_fast_checks() -> None:
+    run_perf_local("fmt")
+    run_perf_local("clippy")
+    run_perf_local("test")
+
+
+def run_warm_benchmark() -> None:
+    durations: list[float] = []
+    for attempt in range(2):
+        started = time.perf_counter()
+        run_perf_local("cargo", "check", "--workspace", "--all-targets")
+        duration = time.perf_counter() - started
+        durations.append(duration)
+        print(f"[local-pre-pr] cargo check {attempt + 1}: {duration:.2f}s", flush=True)
+
+    warm_seconds = durations[-1]
+    if warm_seconds > 30:
+        raise SystemExit(
+            f"[local-pre-pr] warm no-op budget exceeded: {warm_seconds:.2f}s > 30s"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="also measure the two-pass warm no-op cargo check budget",
+    )
+    args = parser.parse_args()
+    try:
+        run_fast_checks()
+        if args.benchmark:
+            run_warm_benchmark()
+    except subprocess.CalledProcessError as error:
+        return error.returncode or 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tests/test_local_pre_pr.py
+++ b/ci/tests/test_local_pre_pr.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "local_pre_pr.py"
+SPEC = importlib.util.spec_from_file_location("local_pre_pr", MODULE_PATH)
+assert SPEC and SPEC.loader
+local_pre_pr = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(local_pre_pr)
+
+
+def test_run_perf_local_uses_shared_harness(monkeypatch):
+    calls: list[tuple[list[str], Path]] = []
+
+    def fake_run(command, *, cwd, check):
+        calls.append((command, cwd))
+
+    monkeypatch.setattr(local_pre_pr.subprocess, "run", fake_run)
+    local_pre_pr.run_perf_local("fmt")
+
+    assert calls == [
+        (
+            ["uv", "run", "--no-project", "python", str(local_pre_pr.PERF_LOCAL), "fmt"],
+            local_pre_pr.REPO_ROOT,
+        )
+    ]


### PR DESCRIPTION
## Summary\n- add ci/local_pre_pr.py for the shared Docker-backed fmt, clippy, and test checks\n- add an optional two-pass warm no-op cargo-check budget\n- add a regression test proving the wrapper delegates to ci/perf_local.py\n\n## Validation\n- uv run --no-project pytest ci/tests/test_local_pre_pr.py -q\n- uv run --no-project ruff check ci/local_pre_pr.py ci/tests/test_local_pre_pr.py\n- Docker execution was started against the existing perf-local images and timed out during the initial container build, without a test failure.\n\nRefs #785