### PR TITLE
ci: run perf guards through soldr cache

### DIFF
--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -49,7 +49,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          soldr --no-cache cargo test -p zccache-daemon-core --features test-support perf_cow_materialization_128_hits_under_two_seconds
+          soldr cargo test -p zccache-daemon-core --features test-support perf_cow_materialization_128_hits_under_two_seconds
 
   build-perf-benchmark:
     name: Build perf benchmark binary
@@ -70,7 +70,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          soldr --no-cache cargo test -p zccache --test perf_bench_test --no-run
+          soldr cargo test -p zccache --test perf_bench_test --no-run
           bench_bin="$(
             find target/debug/deps \
               -maxdepth 1 \

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -664,10 +664,11 @@ def test_perf_workflow_has_dedicated_cow_materialization_gate():
     assert "    if: github.ref == 'refs/heads/main'" in speed_floor_job
     assert "name: COW materialization hit budget" in job
     assert (
-        "soldr --no-cache cargo test -p zccache-daemon-core "
+        "soldr cargo test -p zccache-daemon-core "
         "--features test-support "
         "perf_cow_materialization_128_hits_under_two_seconds" in job
     )
+    assert "--no-cache" not in job + build_job + speed_floor_job
 
 
 def test_run_benchmarks_once_uses_fresh_cache_per_command(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary\n- remove the soldr --no-cache fallback from the COW budget and perf benchmark build\n- keep performance guards exercising the fixed soldr/zccache path\n- add a regression assertion that the perf workflow contains no no-cache command\n\n## Docker-first validation\n- soldr cargo test -p zccache-daemon-core --features test-support perf_cow_materialization_128_hits_under_two_seconds passed\n- uv run --no-project pytest ci/tests/test_perf_guard.py -q (35 passed)\n\nRefs #1025