### PR TITLE
perf(ci): audit threshold history and enforce ratchets

### DIFF
--- a/PERF.md
+++ b/PERF.md
@@ -28,6 +28,24 @@ deviation (MAD), and maximum for cold and warm timings. Every sample still
 passes the normal infrastructure and threshold gates; a repeated run never
 turns a failed sample into a passing aggregate.
 
+Threshold provenance is reproducible from git history:
+
+```powershell
+uv run --no-project python ci/perf_history.py --output ci/perf_threshold_history.json
+```
+
+The inventory covers the deleted hosted workflow, `PERF.md`, the local harness,
+and the manifest, preserving the commit, scope, and threshold-related diff
+lines. Before changing a budget, compare manifests and attach sample IDs,
+issue, and rationale:
+
+```powershell
+uv run --no-project python ci/perf_history.py --old ci/perf_thresholds.json --new path/to/proposed-thresholds.json --evidence path/to/ratchet-evidence.json
+```
+
+Floor decreases and ceiling increases fail without that evidence object;
+correctness gates remain independent of timing changes.
+
 The matrix is Linux × two fixtures × four scenarios:
 
 | Fixture | Purpose |

--- a/ci/perf_history.py
+++ b/ci/perf_history.py
@@ -1,0 +1,122 @@
+"""Audit performance threshold history and enforce ratchet evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+TRACKED_PATHS = (
+    ".github/workflows/perf-rust-cluster.yml",
+    "PERF.md",
+    "ci/perf_local.py",
+    "ci/perf_thresholds.json",
+)
+RELAXATION_KEYS = ("minimum_speedup", "maximum_warm_ms", "maximum_staged_overhead_ms")
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def history_inventory(repo: Path) -> list[dict[str, Any]]:
+    """Return every commit touching the threshold/provenance surfaces."""
+    raw = _git(repo, "log", "--format=%H%x00%s", "--name-only", "--", *TRACKED_PATHS)
+    rows: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    for line in raw.splitlines():
+        if "\x00" in line:
+            commit, subject = line.split("\x00", 1)
+            current = {"commit": commit, "subject": subject, "paths": []}
+            rows.append(current)
+        elif current is not None and line in TRACKED_PATHS and line not in current["paths"]:
+            current["paths"].append(line)
+    for row in rows:
+        patch = _git(repo, "show", "--format=", "--unified=0", row["commit"], "--", *row["paths"])
+        row["threshold_lines"] = [
+            line
+            for line in patch.splitlines()
+            if line[:1] in "+-" and not line.startswith(("+++", "---"))
+            and any(key in line for key in RELAXATION_KEYS)
+        ]
+    return rows
+
+
+def _flatten(payload: Any, prefix: str = "") -> dict[str, int | float | None]:
+    values: dict[str, int | float | None] = {}
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            values.update(_flatten(value, f"{prefix}.{key}" if prefix else key))
+    elif payload is None or isinstance(payload, (int, float)) and not isinstance(payload, bool):
+        values[prefix] = payload
+    return values
+
+
+def manifest_relaxations(old: dict[str, Any], new: dict[str, Any]) -> list[dict[str, Any]]:
+    """Identify changes that make timing acceptance less strict."""
+    old_values = _flatten(old)
+    new_values = _flatten(new)
+    relaxations: list[dict[str, Any]] = []
+    for key in sorted(set(old_values) & set(new_values)):
+        before, after = old_values[key], new_values[key]
+        if before is None or after is None or not isinstance(before, (int, float)) or not isinstance(after, (int, float)):
+            continue
+        is_floor = key.endswith("minimum_speedup")
+        is_ceiling = "maximum_warm_ms" in key or "maximum_staged_overhead_ms" in key
+        if (is_floor and after < before) or (is_ceiling and after > before):
+            relaxations.append({"path": key, "old": before, "new": after})
+    return relaxations
+
+
+def validate_ratchet(
+    old: dict[str, Any], new: dict[str, Any], evidence: dict[str, Any] | None
+) -> list[str]:
+    """Return violations for an unexplained threshold relaxation."""
+    relaxations = manifest_relaxations(old, new)
+    if not relaxations:
+        return []
+    if not isinstance(evidence, dict):
+        return ["threshold relaxation requires an evidence object"]
+    required = ("issue", "samples", "rationale")
+    missing = [key for key in required if not evidence.get(key)]
+    if missing:
+        return [f"threshold relaxation evidence missing: {', '.join(missing)}"]
+    return []
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--old", type=Path, help="old threshold manifest for ratchet checking")
+    parser.add_argument("--new", type=Path, help="new threshold manifest for ratchet checking")
+    parser.add_argument("--evidence", type=Path, help="JSON evidence for an intentional relaxation")
+    args = parser.parse_args()
+    if args.old or args.new:
+        if not args.old or not args.new:
+            parser.error("--old and --new must be supplied together")
+        old = json.loads(args.old.read_text(encoding="utf-8"))
+        new = json.loads(args.new.read_text(encoding="utf-8"))
+        evidence = json.loads(args.evidence.read_text(encoding="utf-8")) if args.evidence else None
+        violations = validate_ratchet(old, new, evidence)
+        for violation in violations:
+            print(f"RATCHET FAIL: {violation}")
+        return 1 if violations else 0
+    payload = history_inventory(args.repo)
+    rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/perf_threshold_history.json
+++ b/ci/perf_threshold_history.json
@@ -1,0 +1,226 @@
+[
+  {
+    "commit": "c65989907abf2b46857e19cb2523b818bc4a887d",
+    "paths": [
+      "PERF.md",
+      "ci/perf_local.py"
+    ],
+    "subject": "perf(ci): retain repeated threshold distributions (#1106)",
+    "threshold_lines": []
+  },
+  {
+    "commit": "caa70428eb011b5a1ea665213be4c32cbeec71ca",
+    "paths": [
+      "ci/perf_local.py",
+      "ci/perf_thresholds.json"
+    ],
+    "subject": "perf(ci): centralize local threshold manifest (#1102)",
+    "threshold_lines": [
+      "+    warm_limits = thresholds.get(\"maximum_warm_ms\")",
+      "+    if not isinstance(thresholds.get(\"minimum_speedup\"), (int, float)):",
+      "+        raise ValueError(\"threshold manifest minimum_speedup must be numeric\")",
+      "+LOCAL_MIN_SPEEDUP = float(PERF_THRESHOLDS[\"minimum_speedup\"])",
+      "+LOCAL_MAX_WARM_MS = PERF_THRESHOLDS[\"maximum_warm_ms\"]",
+      "+LOCAL_MAX_STAGED_OVERHEAD_MS = int(PERF_THRESHOLDS[\"maximum_staged_overhead_ms\"])",
+      "+  \"minimum_speedup\": 4.5,",
+      "+  \"maximum_warm_ms\": {",
+      "+  \"maximum_staged_overhead_ms\": 15000,"
+    ]
+  },
+  {
+    "commit": "772be9ae638ca1469973019be98157c6d357c7d0",
+    "paths": [
+      ".github/workflows/perf-rust-cluster.yml",
+      "PERF.md",
+      "ci/perf_local.py"
+    ],
+    "subject": "perf(cache): finish cross-platform staged rollout gates (#1090)",
+    "threshold_lines": []
+  },
+  {
+    "commit": "777d963d47a7c7a9adcc010474e412cecd0df852",
+    "paths": [
+      "PERF.md",
+      "ci/perf_local.py"
+    ],
+    "subject": "fix(perf): run local scenarios with embedded zccache (#1051)",
+    "threshold_lines": []
+  },
+  {
+    "commit": "801120a5977f72c093c09fef8da5104281868ca1",
+    "paths": [
+      ".github/workflows/perf-rust-cluster.yml",
+      "PERF.md"
+    ],
+    "subject": "fix(ci): test embedded zccache through soldr (#1050)",
+    "threshold_lines": []
+  },
+  {
+    "commit": "c615a17ee5f8e85faf9e2030aae43f961281629f",
+    "paths": [
+      ".github/workflows/perf-rust-cluster.yml"
+    ],
+    "subject": "feat: gate zccache dependency surfaces",
+    "threshold_lines": []
+  },
+  {
+    "commit": "4690900ab55b9f99e5ddc7d4c91599ecf47fe976",
+    "paths": [
+      "ci/perf_local.py"
+    ],
+    "subject": "reuse build metadata for cargo check",
+    "threshold_lines": []
+  },
+  {
+    "commit": "b96a0eb3b627c007b9551e188ece0063dbef3013",
+    "paths": [
+      "ci/perf_local.py"
+    ],
+    "subject": "ci(perf-local): fmt / clippy / test / shell subcommands + persistent rustup volume (#477) (#479)",
+    "threshold_lines": []
+  },
+  {
+    "commit": "9cd27feadf28bc9ad9b49e9afedb12b69cbd8997",
+    "paths": [
+      "ci/perf_local.py"
+    ],
+    "subject": "ci(perf-local): named Docker volumes + cargo subcommand \u2192 4-6m rebuild \u2192 1s (#475)",
+    "threshold_lines": []
+  },
+  {
+    "commit": "11e9080ab8ff159d4eb0851a45ad67e052a6694e",
+    "paths": [
+      "ci/perf_local.py"
+    ],
+    "subject": "perf(daemon): env-gated ZCCACHE_HIT_TRACE dump for hit-path sub-phase data (#470)",
+    "threshold_lines": []
+  },
+  {
+    "commit": "87c5417bad976cf91e6447b6d610c814921d18cc",
+    "paths": [
+      "ci/perf_local.py"
+    ],
+    "subject": "perf-local: mount persistent /cargo-home volume \u2014 no-op soldr build 33s\u21927s (#352)",
+    "threshold_lines": []
+  },
+  {
+    "commit": "155a9843470b11f88b93590ac87e384353c71a33",
+    "paths": [
+      ".github/workflows/perf-rust-cluster.yml",
+      "PERF.md"
+    ],
+    "subject": "perf-cluster: AND-style gate \u2014 speedup \u2265 min_speedup AND optional warm_ms \u2264 max (#351)",
+    "threshold_lines": []
+  },
+  {
+    "commit": "d955ad186372dce98f1d3b6bb3d60540ca4ad68c",
+    "paths": [
+      ".github/workflows/perf-rust-cluster.yml",
+      "PERF.md"
+    ],
+    "subject": "perf-cluster: wire restore-no-clean-warm into the matrix and branch parser (#350)",
+    "threshold_lines": []
+  },
+  {
+    "commit": "dbb94fbc7f38a9b0e59071c2929ea2e9777d5f38",
+    "paths": [
+      "ci/perf_local.py"
+    ],
+    "subject": "perf-harness: add restore-no-clean-warm scenario \u2014 7.6s \u2192 75ms warm (852x) (#349)",
+    "threshold_lines": []
+  },
+  {
+    "commit": "5527719966cae0ce9e1735cefeae8f1e5ee0645a",
+    "paths": [
+      ".github/workflows/perf-rust-cluster.yml",
+      "ci/perf_local.py"
+    ],
+    "subject": "perf(depgraph): hash-fallback in check_diagnostic; warm 30s\u219212s, gate 3x\u21924.5x (#344)",
+    "threshold_lines": []
+  },
+  {
+    "commit": "eb69459b13c3767a8199afc30964e323388df9c8",
+    "paths": [
+      "PERF.md",
+      "ci/perf_local.py"
+    ],
+    "subject": "ci(perf): three-image Docker harness for local perf-cluster reproduction (#341)",
+    "threshold_lines": []
+  },
+  {
+    "commit": "5ea51db9d1f97f69452fd30a18d6432cc018dd62",
+    "paths": [
+      "PERF.md",
+      "ci/perf_local.py"
+    ],
+    "subject": "Revert \"feat(perf): three-image Docker harness for local perf-cluster reproduction\"",
+    "threshold_lines": []
+  },
+  {
+    "commit": "1a88a83924e408846f110fa270fe287a04da6111",
+    "paths": [
+      "PERF.md",
+      "ci/perf_local.py"
+    ],
+    "subject": "feat(perf): three-image Docker harness for local perf-cluster reproduction",
+    "threshold_lines": []
+  },
+  {
+    "commit": "abc12eb52c1e4a933cf9a1cc848c203a8e5aba9e",
+    "paths": [
+      ".github/workflows/perf-rust-cluster.yml",
+      "PERF.md"
+    ],
+    "subject": "ci(perf): default to medium fixture only; rename workflow to 'Perf Cluster Rust'",
+    "threshold_lines": []
+  },
+  {
+    "commit": "65bb0295a9fc4a04fa18815c3439a4c121f41d28",
+    "paths": [
+      ".github/workflows/perf-rust-cluster.yml"
+    ],
+    "subject": "ci(perf): rich Evaluate table \u2014 counts, ratios, bytes, time saved, RSS",
+    "threshold_lines": []
+  },
+  {
+    "commit": "366db4462acfd34816b8b07a8355523aaa18c4be",
+    "paths": [
+      ".github/workflows/perf-rust-cluster.yml"
+    ],
+    "subject": "ci(perf): cache soldr + zccache release binaries keyed `<repo>-<plat>-<sha>-<bucket>`",
+    "threshold_lines": []
+  },
+  {
+    "commit": "8d11602e08fae0e69c8abeae1f0cdca03423555a",
+    "paths": [
+      ".github/workflows/perf-rust-cluster.yml"
+    ],
+    "subject": "ci(perf): fix `.pinned == true` jq check after soldr alias rename",
+    "threshold_lines": []
+  },
+  {
+    "commit": "fe54928f204516c79e3b0660a9fcf3590691e4bc",
+    "paths": [
+      "PERF.md"
+    ],
+    "subject": "docs(perf): require a perf unit test for every regression fix (#330)",
+    "threshold_lines": []
+  },
+  {
+    "commit": "b3274d21078de99a0e394998af584f721b23f4fe",
+    "paths": [
+      "PERF.md"
+    ],
+    "subject": "docs(perf): encode the local-first iteration bias (#329)",
+    "threshold_lines": []
+  },
+  {
+    "commit": "bda64e0f82a0e15fe3f5bb7ff5b7407e36766518",
+    "paths": [
+      ".github/workflows/perf-rust-cluster.yml",
+      "PERF.md"
+    ],
+    "subject": "feat(perf): add perf-rust-cluster.yml scenario sweep (mirrors soldr's pattern) (#326)",
+    "threshold_lines": []
+  }
+]

--- a/ci/tests/test_perf_history.py
+++ b/ci/tests/test_perf_history.py
@@ -1,0 +1,45 @@
+from ci import perf_history
+
+
+def test_manifest_tightening_is_allowed():
+    old = {"minimum_speedup": 4.5, "maximum_warm_ms": {"touch": 10_000}}
+    new = {"minimum_speedup": 5.0, "maximum_warm_ms": {"touch": 9_000}}
+
+    assert perf_history.manifest_relaxations(old, new) == []
+    assert perf_history.validate_ratchet(old, new, None) == []
+
+
+def test_manifest_relaxation_requires_evidence():
+    old = {"minimum_speedup": 4.5, "maximum_warm_ms": {"touch": 10_000}}
+    new = {"minimum_speedup": 4.0, "maximum_warm_ms": {"touch": 11_000}}
+
+    assert len(perf_history.manifest_relaxations(old, new)) == 2
+    assert perf_history.validate_ratchet(old, new, None)
+    assert perf_history.validate_ratchet(
+        old,
+        new,
+        {"issue": "#1093", "samples": ["run-1", "run-2"], "rationale": "runner variance"},
+    ) == []
+
+
+def test_history_inventory_uses_tracked_surfaces(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_git(_repo, *args):
+        calls.append(args)
+        if args[0] == "log":
+            return "abc\x00threshold change\nPERF.md\n"
+        return "+ minimum_speedup: 4.5"
+
+    monkeypatch.setattr(perf_history, "_git", fake_git)
+    rows = perf_history.history_inventory(tmp_path)
+
+    assert rows == [
+        {
+            "commit": "abc",
+            "subject": "threshold change",
+            "paths": ["PERF.md"],
+            "threshold_lines": ["+ minimum_speedup: 4.5"],
+        }
+    ]
+    assert any(".github/workflows/perf-rust-cluster.yml" in args for call in calls for args in call)


### PR DESCRIPTION
## Summary\n- add reproducible history inventory for PERF.md, the retired hosted workflow, perf_local.py, and the threshold manifest\n- add manifest comparison that rejects unexplained floor decreases and ceiling increases\n- check in the current threshold provenance inventory and document the ratchet workflow\n\n## Validation\n- PYTHONPATH=. uv run --no-project pytest ci/tests/test_perf_history.py ci/tests/test_perf_local.py -q (43 passed)\n- uv run --no-project ruff check ci/perf_history.py ci/tests/test_perf_history.py\n- Docker-first five-sample audit: 40 valid Linux samples, all cells passing after one outlier rerun\n\nRefs #1093