### PR TITLE
perf: reduce archive cold-path overhead

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/process.rs
+++ b/crates/zccache-daemon-core/src/daemon/process.rs
@@ -727,6 +727,41 @@ pub(crate) async fn tokio_command_output_with_priority_stdin(
     }
 }
 
+/// Run a leaf tool without the orphan-pipe watchdog used for compilers.
+/// Pure archivers do not spawn descendants, so Tokio can reap them directly.
+pub(crate) async fn tokio_leaf_command_output_with_priority(
+    cmd: &mut tokio::process::Command,
+    priority: CompilePriority,
+) -> io::Result<Output> {
+    use std::process::Stdio;
+
+    let (decision, _ticket) = priority.resolve_and_track();
+    let priority = decision.effective;
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    cmd.kill_on_drop(true);
+
+    #[cfg(windows)]
+    {
+        cmd.creation_flags(child_creation_flags(priority));
+    }
+
+    let child = cmd.spawn()?;
+    #[cfg(windows)]
+    {
+        if let Some(handle) = child.raw_handle() {
+            assign_child_to_daemon_job(handle);
+            apply_priority_to_child_windows(handle, priority);
+        }
+    }
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        apply_priority_to_child_unix(pid, priority);
+    }
+    child.wait_with_output().await
+}
+
 #[cfg(windows)]
 fn assign_child_to_daemon_job(raw_handle: std::os::windows::io::RawHandle) {
     let Some(job) = DAEMON_JOB.get_or_init(WindowsJob::new).as_ref() else {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_profile.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_profile.rs
@@ -248,6 +248,7 @@ pub(in crate::daemon::server) struct LinkMissProfile<'a> {
     pub(in crate::daemon::server) input_count: usize,
     pub(in crate::daemon::server) total_ns: u64,
     pub(in crate::daemon::server) parse_args_ns: u64,
+    pub(in crate::daemon::server) hash_wall_ns: u64,
     pub(in crate::daemon::server) tool_hash_ns: u64,
     pub(in crate::daemon::server) input_hash_ns: u64,
     pub(in crate::daemon::server) cache_lookup_ns: u64,
@@ -262,6 +263,7 @@ pub(in crate::daemon::server) fn emit_link_miss_profile(profile: LinkMissProfile
         input_count,
         total_ns,
         parse_args_ns,
+        hash_wall_ns,
         tool_hash_ns,
         input_hash_ns,
         cache_lookup_ns,
@@ -271,8 +273,7 @@ pub(in crate::daemon::server) fn emit_link_miss_profile(profile: LinkMissProfile
     } = profile;
 
     let accounted_ns = parse_args_ns
-        .saturating_add(tool_hash_ns)
-        .saturating_add(input_hash_ns)
+        .saturating_add(hash_wall_ns)
         .saturating_add(cache_lookup_ns)
         .saturating_add(compiler_process_ns)
         .saturating_add(output_read_ns)
@@ -283,7 +284,7 @@ pub(in crate::daemon::server) fn emit_link_miss_profile(profile: LinkMissProfile
         concat!(
             "zccache_link_miss_profile ",
             "family={} input_count={} total_ns={} parse_args_ns={} ",
-            "tool_hash_ns={} input_hash_ns={} cache_lookup_ns={} ",
+            "hash_wall_ns={} tool_hash_ns={} input_hash_ns={} cache_lookup_ns={} ",
             "compiler_process_ns={} output_read_ns={} ",
             "artifact_store_ns={} unaccounted_ns={}",
         ),
@@ -291,6 +292,7 @@ pub(in crate::daemon::server) fn emit_link_miss_profile(profile: LinkMissProfile
         input_count,
         total_ns,
         parse_args_ns,
+        hash_wall_ns,
         tool_hash_ns,
         input_hash_ns,
         cache_lookup_ns,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -162,8 +162,8 @@ pub(super) async fn handle_link_ephemeral(
     };
 
     // 3+4. Hash tool binary and input files concurrently via rayon::join
-    // (issue #566). Both phases are CPU-bound blake3 work over mmap'd
-    // files. Before this overlap, they ran strictly sequentially —
+    // (issue #566). Both phases are file reads plus CPU-bound blake3 work.
+    // Before this overlap, they ran strictly sequentially —
     // `tool_hash` (~150 MB rustc binary, 10–20 ms) blocked the start of
     // input hashing (50 .rlibs in parallel via #564, also 5–15 ms wall).
     // `rayon::join` reduces the combined wall-clock to ~max(tool_hash,
@@ -177,39 +177,49 @@ pub(super) async fn handle_link_ephemeral(
         link_path_remap_key_root,
     );
 
-    let inputs: Vec<&NormalizedPath> = parsed_tool
+    let inputs: Vec<NormalizedPath> = parsed_tool
         .input_files
         .iter()
         .chain(link_key_plan.extra_input_files.iter())
+        .map(|input| {
+            if input.is_absolute() {
+                input.clone()
+            } else {
+                cwd_path.join(input).into()
+            }
+        })
         .collect();
 
-    let t_hash = profile_enabled.then(std::time::Instant::now);
-    let (tool_hash_opt, hash_results) = rayon::join(
-        || hash_file_via_cache(state, tool_path),
-        || -> Vec<(NormalizedPath, Option<ContentHash>)> {
-            use rayon::prelude::*;
-            inputs
+    use rayon::prelude::*;
+
+    let hash_wall_started = profile_enabled.then(std::time::Instant::now);
+    let ((tool_hash_opt, tool_hash_ns), (hash_results, input_hash_ns)) = rayon::join(
+        || {
+            let started = profile_enabled.then(std::time::Instant::now);
+            let hash = hash_file_via_cache(state, tool_path);
+            let elapsed = started
+                .map(|started| started.elapsed().as_nanos() as u64)
+                .unwrap_or(0);
+            (hash, elapsed)
+        },
+        || {
+            let started = profile_enabled.then(std::time::Instant::now);
+            let hashes = inputs
                 .par_iter()
                 .map(|input| {
-                    let input_path: NormalizedPath = if input.is_absolute() {
-                        (*input).clone()
-                    } else {
-                        cwd_path.join(input).into()
-                    };
-                    let hash = hash_file_via_cache(state, &input_path);
-                    (input_path, hash)
+                    let hash = hash_normalized_file_via_cache(state, input);
+                    (input.clone(), hash)
                 })
-                .collect()
+                .collect::<Vec<(NormalizedPath, Option<ContentHash>)>>();
+            let elapsed = started
+                .map(|started| started.elapsed().as_nanos() as u64)
+                .unwrap_or(0);
+            (hashes, elapsed)
         },
     );
-    // Combined wall-clock budget for the overlapped phases. Reported as
-    // both tool_hash_ns and input_hash_ns in the LinkMissProfile for now
-    // — they're indistinguishable post-overlap. A future diagnostic
-    // change can split them via per-closure timers if needed.
-    let combined_hash_ns = t_hash.map(|t| t.elapsed().as_nanos() as u64).unwrap_or(0);
-    let tool_hash_ns = combined_hash_ns;
-    let input_hash_ns = combined_hash_ns;
-
+    let hash_wall_ns = hash_wall_started
+        .map(|started| started.elapsed().as_nanos() as u64)
+        .unwrap_or(0);
     let tool_hash = match tool_hash_opt {
         Some(h) => h,
         None => {
@@ -510,15 +520,19 @@ pub(super) async fn handle_link_ephemeral(
     let t_compiler_process = profile_enabled.then(std::time::Instant::now);
     let staged_compiler_started =
         (staged_plan.is_some() || directory_plan.is_some()).then(std::time::Instant::now);
-    let result = run_tool_passthrough(
-        tool,
-        &compiler_args,
-        cwd,
-        env,
-        &lineage,
-        state.depfile_tmpdir.as_path(),
-    )
-    .await;
+    let result = if parsed_tool.is_archive {
+        run_archive_tool_passthrough(tool, &compiler_args, cwd, env, &lineage).await
+    } else {
+        run_tool_passthrough(
+            tool,
+            &compiler_args,
+            cwd,
+            env,
+            &lineage,
+            state.depfile_tmpdir.as_path(),
+        )
+        .await
+    };
 
     let compiler_process_ns = t_compiler_process
         .map(|t| t.elapsed().as_nanos() as u64)
@@ -860,6 +874,7 @@ pub(super) async fn handle_link_ephemeral(
             input_count,
             total_ns,
             parse_args_ns,
+            hash_wall_ns,
             tool_hash_ns,
             input_hash_ns,
             cache_lookup_ns,
@@ -929,6 +944,37 @@ pub(super) async fn run_tool_passthrough(
         },
         Err(e) => Response::Error {
             message: format!("failed to run {}: {e}", tool.display()),
+        },
+    }
+}
+
+/// Run a parsed pure archiver without the general compiler-child watchdog.
+///
+/// Archivers are leaf processes: they only read declared inputs and write the
+/// requested archive. Waiting on the Tokio child directly avoids watchdog and
+/// blocking-pool setup costs that are material for a 10-20 ms `ar` run.
+async fn run_archive_tool_passthrough(
+    tool: &Path,
+    args: &[String],
+    cwd: &Path,
+    env: Option<Vec<(String, String)>>,
+    lineage: &super::super::lineage::Lineage,
+) -> Response {
+    let mut cmd = tokio::process::Command::new(tool);
+    cmd.args(args);
+    cmd.current_dir(cwd);
+    apply_client_env(&mut cmd, &env, lineage);
+    let priority = CompilePriority::from_client_env(env.as_deref());
+    match super::super::process::tokio_leaf_command_output_with_priority(&mut cmd, priority).await {
+        Ok(output) => Response::LinkResult {
+            exit_code: output.status.code().unwrap_or(1),
+            stdout: Arc::new(output.stdout),
+            stderr: Arc::new(output.stderr),
+            cached: false,
+            warning: None,
+        },
+        Err(error) => Response::Error {
+            message: format!("failed to run {}: {error}", tool.display()),
         },
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link_tests.rs
@@ -9,7 +9,10 @@ async fn archive_fast_path_preserves_client_env_and_lineage() {
     let lineage = crate::daemon::lineage::Lineage::current(Some(4242), None);
     let env = vec![
         ("PATH".to_string(), std::env::var("PATH").unwrap()),
-        ("ARCHIVE_FAST_PATH_SENTINEL".to_string(), "present".to_string()),
+        (
+            "ARCHIVE_FAST_PATH_SENTINEL".to_string(),
+            "present".to_string(),
+        ),
         ("MAKEFLAGS".to_string(), "--jobserver-auth=3,4".to_string()),
     ];
     let args = vec![
@@ -17,14 +20,9 @@ async fn archive_fast_path_preserves_client_env_and_lineage() {
         "printf '%s|%s|%s' \"$ARCHIVE_FAST_PATH_SENTINEL\" \"$ZCCACHE_CLIENT_PID\" \"${MAKEFLAGS-unset}\"".to_string(),
     ];
 
-    let response = run_archive_tool_passthrough(
-        Path::new("sh"),
-        &args,
-        temp.path(),
-        Some(env),
-        &lineage,
-    )
-    .await;
+    let response =
+        run_archive_tool_passthrough(Path::new("sh"), &args, temp.path(), Some(env), &lineage)
+            .await;
 
     match response {
         Response::LinkResult {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link_tests.rs
@@ -2,6 +2,44 @@
 
 use super::*;
 
+#[cfg(unix)]
+#[tokio::test]
+async fn archive_fast_path_preserves_client_env_and_lineage() {
+    let temp = tempfile::tempdir().unwrap();
+    let lineage = crate::daemon::lineage::Lineage::current(Some(4242), None);
+    let env = vec![
+        ("PATH".to_string(), std::env::var("PATH").unwrap()),
+        ("ARCHIVE_FAST_PATH_SENTINEL".to_string(), "present".to_string()),
+        ("MAKEFLAGS".to_string(), "--jobserver-auth=3,4".to_string()),
+    ];
+    let args = vec![
+        "-c".to_string(),
+        "printf '%s|%s|%s' \"$ARCHIVE_FAST_PATH_SENTINEL\" \"$ZCCACHE_CLIENT_PID\" \"${MAKEFLAGS-unset}\"".to_string(),
+    ];
+
+    let response = run_archive_tool_passthrough(
+        Path::new("sh"),
+        &args,
+        temp.path(),
+        Some(env),
+        &lineage,
+    )
+    .await;
+
+    match response {
+        Response::LinkResult {
+            exit_code,
+            stdout,
+            stderr,
+            ..
+        } => {
+            assert_eq!(exit_code, 0, "{}", String::from_utf8_lossy(&stderr));
+            assert_eq!(&*stdout, b"present|4242|unset");
+        }
+        other => panic!("expected LinkResult, got {other:?}"),
+    }
+}
+
 #[tokio::test]
 async fn failed_link_publication_salvages_output_without_becoming_cacheable() {
     let temp = tempfile::tempdir().unwrap();

--- a/crates/zccache-daemon-core/src/daemon/server/util.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/util.rs
@@ -70,6 +70,17 @@ pub(super) fn hash_file_via_cache(state: &SharedState, path: &Path) -> Option<Co
     crate::hash::hash_file(path).ok()
 }
 
+/// Hash a normalized path without repeating path normalization in the cache.
+pub(super) fn hash_normalized_file_via_cache(
+    state: &SharedState,
+    path: &NormalizedPath,
+) -> Option<ContentHash> {
+    if let Ok(hash) = state.cache_system.metadata().lookup_normalized(path) {
+        return Some(hash);
+    }
+    crate::hash::hash_file(path).ok()
+}
+
 /// Hash a file using the CacheSystem's metadata cache.
 ///
 /// This stat-verifies the file, hashes if needed (with TOCTOU protection),

--- a/crates/zccache-fscache/src/verify.rs
+++ b/crates/zccache-fscache/src/verify.rs
@@ -21,6 +21,16 @@ pub enum VerifyResult {
 }
 
 impl MetadataCache {
+    fn metadata_from_fs(fs_meta: std::fs::Metadata) -> Result<FileMetadata> {
+        Ok(FileMetadata {
+            mtime: fs_meta.modified()?,
+            size: fs_meta.len(),
+            confidence: Confidence::High,
+            last_verified: Instant::now(),
+            content_hash: None,
+        })
+    }
+
     /// Stat a file and return its current metadata at `High` confidence.
     ///
     /// This does NOT insert into the cache — it only reads from the filesystem.
@@ -29,17 +39,7 @@ impl MetadataCache {
     ///
     /// Returns an error if the file cannot be stat'd (not found, permission denied, etc.).
     pub fn stat_file(path: &Path) -> Result<FileMetadata> {
-        let fs_meta = std::fs::metadata(path)?;
-        let mtime = fs_meta.modified()?;
-        let size = fs_meta.len();
-
-        Ok(FileMetadata {
-            mtime,
-            size,
-            confidence: Confidence::High,
-            last_verified: Instant::now(),
-            content_hash: None,
-        })
+        Self::metadata_from_fs(std::fs::metadata(path)?)
     }
 
     /// Verify whether the cached entry for `path` still matches the filesystem.
@@ -87,11 +87,17 @@ impl MetadataCache {
     /// Returns an error if the file cannot be read.
     pub fn lookup(&self, path: &Path) -> Result<ContentHash> {
         let normalized = NormalizedPath::from(path);
-        let cached = self.get(&normalized);
+        self.lookup_normalized(&normalized)
+    }
+
+    /// Full cache lookup for a path the caller has already normalized.
+    pub fn lookup_normalized(&self, normalized: &NormalizedPath) -> Result<ContentHash> {
+        let path = normalized.as_path();
+        let cached = self.get(normalized);
 
         // Cache miss → stat, hash, insert.
         let entry = match cached {
-            None => return self.hash_and_insert(path),
+            None => return self.hash_and_insert(path, normalized),
             Some(e) => e,
         };
 
@@ -100,7 +106,7 @@ impl MetadataCache {
         let fresh = match Self::stat_file(path) {
             Ok(m) => m,
             Err(zccache_core::Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
-                self.remove(&normalized);
+                self.remove(normalized);
                 return Err(zccache_core::Error::FileNotFound(path.into()));
             }
             Err(e) => return Err(e),
@@ -132,24 +138,20 @@ impl MetadataCache {
         }
 
         // Stale, Low, or no cached hash — re-hash.
-        self.hash_and_insert(path)
+        self.hash_and_insert(path, normalized)
     }
 
     /// Stat the file, hash it, insert at High confidence, return hash.
-    fn hash_and_insert(&self, path: &Path) -> Result<ContentHash> {
-        let pre_stat = Self::stat_file(path)?;
-        let hash = hash_file_off_runtime(path)?;
-        let post_stat = Self::stat_file(path)?;
+    fn hash_and_insert(&self, path: &Path, normalized: &NormalizedPath) -> Result<ContentHash> {
+        let (pre_stat, hash, post_stat) = hash_file_snapshot(path)?;
 
         // TOCTOU check: if file changed during hashing, retry up to 3 times.
         if pre_stat.mtime != post_stat.mtime || pre_stat.size != post_stat.size {
             for _ in 0..3 {
-                let pre = Self::stat_file(path)?;
-                let h = hash_file_off_runtime(path)?;
-                let post = Self::stat_file(path)?;
+                let (pre, h, post) = hash_file_snapshot(path)?;
                 if pre.mtime == post.mtime && pre.size == post.size {
                     self.insert(
-                        path.into(),
+                        normalized.clone(),
                         FileMetadata {
                             content_hash: Some(*h.as_bytes()),
                             ..post
@@ -161,7 +163,7 @@ impl MetadataCache {
             // Still unstable after retries — return last hash but at Low confidence.
             let meta = Self::stat_file(path)?;
             self.insert(
-                path.into(),
+                normalized.clone(),
                 FileMetadata {
                     confidence: Confidence::Low,
                     content_hash: Some(*hash.as_bytes()),
@@ -172,7 +174,7 @@ impl MetadataCache {
         }
 
         self.insert(
-            path.into(),
+            normalized.clone(),
             FileMetadata {
                 content_hash: Some(*hash.as_bytes()),
                 ..post_stat
@@ -182,8 +184,12 @@ impl MetadataCache {
     }
 }
 
-fn hash_file_off_runtime(path: &Path) -> Result<ContentHash> {
-    Ok(zccache_hash::hash_file(path)?)
+fn hash_file_snapshot(path: &Path) -> Result<(FileMetadata, ContentHash, FileMetadata)> {
+    let file = std::fs::File::open(path)?;
+    let pre = MetadataCache::metadata_from_fs(file.metadata()?)?;
+    let hash = zccache_hash::hash_open_file(&file, pre.size)?;
+    let post = MetadataCache::stat_file(path)?;
+    Ok((pre, hash, post))
 }
 
 #[cfg(test)]

--- a/crates/zccache-hash/src/lib.rs
+++ b/crates/zccache-hash/src/lib.rs
@@ -125,11 +125,16 @@ pub fn hash_reader<R: Read>(mut reader: R) -> std::io::Result<ContentHash> {
 /// larger than the work below this point. Issue #556.
 const RAYON_HASH_THRESHOLD_BYTES: u64 = 128 * 1024;
 
-/// Hash the contents of a file using memory mapping.
+/// Mapping tiny files costs more than copying them into Blake3's working
+/// buffer. Archive and linker requests commonly hash dozens of small object
+/// files, so keep those reads on the already-open file handle.
+const MMAP_HASH_THRESHOLD_BYTES: u64 = 64 * 1024;
+
+/// Hash the contents of a file.
 ///
-/// Uses `memmap2` for zero-copy file access. The OS page cache ensures
-/// files recently read (e.g., during compilation) are hashed from memory,
-/// not disk. Falls back to buffered reading for empty files.
+/// Small files use buffered reads to avoid mmap setup overhead. Larger files
+/// use `memmap2` for zero-copy access; the OS page cache ensures files recently
+/// read (e.g., during compilation) are hashed from memory, not disk.
 ///
 /// Files at or above 128 KB use blake3's rayon-parallel hashing path
 /// (issue #556) — the cold compiler-binary hash (clang++ ~80-120 MB on
@@ -143,20 +148,35 @@ const RAYON_HASH_THRESHOLD_BYTES: u64 = 128 * 1024;
 /// # Safety
 ///
 /// Memory mapping is technically unsafe if another process modifies the file
-/// concurrently. The TOCTOU check in `MetadataCache::hash_and_insert` detects
-/// this by comparing stat before and after hashing.
+/// concurrently. Callers must prevent concurrent writes or compare metadata
+/// before and after hashing, as the metadata cache does.
 pub fn hash_file(path: &Path) -> std::io::Result<ContentHash> {
     let file = std::fs::File::open(path)?;
     let meta = file.metadata()?;
+    hash_open_file(&file, meta.len())
+}
 
-    if meta.len() == 0 {
+/// Hash an already-open file whose length was captured from that handle.
+///
+/// This lets callers that also need filesystem metadata avoid reopening and
+/// restating the file. The handle must be positioned at byte zero.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read or mapped.
+pub fn hash_open_file(file: &std::fs::File, len: u64) -> std::io::Result<ContentHash> {
+    if len == 0 {
         return Ok(hash_bytes(b""));
     }
 
-    // SAFETY: The caller (MetadataCache::hash_and_insert) stats before and
-    // after hashing to detect concurrent modification.
-    let mmap = unsafe { memmap2::Mmap::map(&file)? };
-    if meta.len() >= RAYON_HASH_THRESHOLD_BYTES {
+    if len < MMAP_HASH_THRESHOLD_BYTES {
+        return hash_reader(file);
+    }
+
+    // SAFETY: Mapping may observe concurrent modifications. Callers that need
+    // change detection must compare file metadata before and after hashing.
+    let mmap = unsafe { memmap2::Mmap::map(file)? };
+    if len >= RAYON_HASH_THRESHOLD_BYTES {
         // Issue #556: blake3's rayon-parallel path. ~4x speedup on a
         // 4-core CI runner for a 100 MB clang++ binary (cold compiler
         // hash, first-after-daemon-start cc/cpp link overhead).


### PR DESCRIPTION
## Summary

- bypass the general compiler orphan-pipe watchdog for parsed leaf archivers while preserving priority, Windows job assignment, client environment, lineage, and output capture
- hash small files through buffered reads and hash metadata-cache misses through the already-open file handle
- reuse normalized linker input paths and split link-miss hash wall/tool/input timing for actionable profiling

## Scope

This is a measured partial improvement for #1025 and the #1099 performance burn-down. It intentionally uses `Refs #1025` rather than a closing keyword: repeated archive cold samples still do not reliably clear the unchanged 0.75 floor, so #1025 remains open.

## Linux Docker validation

The sanctioned eight-cell matrix passed on commit `a368438` using soldr `bd9b788`:

| Fixture | Scenario | Speedup |
| --- | --- | ---: |
| medium | cold-tar-untar-warm | 12.37x |
| medium | worktree-share | 18.25x |
| medium | touch-no-change | 18.82x |
| medium | restore-no-clean-warm | 10.77x |
| sqlite-link | cold-tar-untar-warm | 9.57x |
| sqlite-link | worktree-share | 13.81x |
| sqlite-link | touch-no-change | 25.87x |
| sqlite-link | restore-no-clean-warm | 9.88x |

All cells reported valid infrastructure with zero soldr aborts, timeouts, daemon fallbacks, and no-cache retries. The two restore-no-clean rows had zero warm misses.

## Focused checks

- `zccache-hash`: 20 passed
- `zccache-fscache`: 114 passed
- `zccache-daemon-core handle_link::tests`: 4 passed
- Linux clippy for changed crates passed; daemon-core required suppressing two unrelated existing Rust 1.94 lints (`large_enum_variant`, `needless_return`)
- `soldr cargo check -p zccache-daemon-core --features test-support` passed on native Windows
- `soldr cargo fmt --all -- --check`
- `git diff --check`