### PR TITLE
build: measure and reject daemon handler split

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -4,6 +4,8 @@ Python scripts for development tooling. Rust commands go through `soldr <tool>` 
 
 ## Top-Level Scripts
 
+- **`uv run --no-project python ci/incremental_build.py --samples 5 --output incremental-build.json`** - Measures warm rebuilds after touching compile, link, exec, connection, and shared-state surfaces. Records timing distributions, rebuilt packages, and aggregate process-tree RSS.
+- **`uv run --no-project python ci/compile_boundary.py`** - Reports compile-handler references to server-private symbols and rejects new glob imports. Pass `--deny-all-globs` after the remaining legacy imports are removed.
 - **`./lint`** - Workspace linting (rustfmt + clippy), supports single-file mode
 - **`./test`** - Workspace tests, supports per-crate filtering
 - **`./perf.sh`** - Performance benchmarks (zccache vs sccache vs bare clang)

--- a/ci/compile_boundary.py
+++ b/ci/compile_boundary.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Inventory compile-handler coupling and reject new glob imports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVER = Path("crates/zccache-daemon-core/src/daemon/server")
+COMPILE_ROOT_FILES = {
+    "handle_compile.rs",
+    "handle_compile_ephemeral.rs",
+    "handle_compile_multi.rs",
+    "handle_compile_multi_args.rs",
+    "handle_compile_multi_preflight.rs",
+    "handle_compile_multi_staged.rs",
+    "handle_compile_multi_types.rs",
+}
+ALLOWED_GLOB_IMPORTS = {
+    "handle_compile.rs",
+    "handle_compile/cached_hit.rs",
+    "handle_compile/error_cache.rs",
+    "handle_compile_ephemeral.rs",
+    "handle_compile_multi.rs",
+    "handle_compile_multi_args.rs",
+    "handle_compile_multi_preflight.rs",
+    "handle_compile_multi_staged.rs",
+    "handle_compile_multi_types.rs",
+}
+GLOB_IMPORT = re.compile(r"^\s*use\s+(?:super|crate::daemon::server)::\*;", re.MULTILINE)
+PRIVATE_ITEM = re.compile(
+    r"\bpub\(super\)\s+(?:async\s+)?"
+    r"(?:struct|enum|trait|fn|const|static|type)\s+([A-Za-z_][A-Za-z0-9_]*)"
+)
+
+
+def compile_files(root: Path) -> list[Path]:
+    server = root / SERVER
+    files = [server / name for name in sorted(COMPILE_ROOT_FILES)]
+    files.extend(sorted((server / "handle_compile").rglob("*.rs")))
+    return files
+
+
+def module_private_items(text: str) -> set[str]:
+    """Find module-level private items while excluding impl/test members."""
+    items: set[str] = set()
+    depth = 0
+    for line in text.splitlines():
+        code = line.split("//", 1)[0]
+        if depth == 0:
+            items.update(PRIVATE_ITEM.findall(code))
+        depth += code.count("{") - code.count("}")
+        depth = max(depth, 0)
+    return items
+
+
+def inventory(root: Path) -> dict[str, object]:
+    server = root / SERVER
+    files = compile_files(root)
+    glob_files = [path.relative_to(server).as_posix() for path in files if GLOB_IMPORT.search(path.read_text(encoding="utf-8"))]
+    private_symbols: set[str] = set()
+    compile_set = {path.resolve() for path in files}
+    for path in server.rglob("*.rs"):
+        if path.resolve() not in compile_set:
+            private_symbols.update(module_private_items(path.read_text(encoding="utf-8")))
+    references: dict[str, list[str]] = {}
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        relative = path.relative_to(server).as_posix()
+        for symbol in private_symbols:
+            if re.search(rf"\b{re.escape(symbol)}\b", text):
+                references.setdefault(symbol, []).append(relative)
+    unexpected = sorted(set(glob_files) - ALLOWED_GLOB_IMPORTS)
+    return {
+        "schema_version": 1,
+        "compile_files": len(files),
+        "glob_imports": sorted(glob_files),
+        "allowed_glob_imports": sorted(ALLOWED_GLOB_IMPORTS),
+        "unexpected_glob_imports": unexpected,
+        "server_private_references": {key: sorted(value) for key, value in sorted(references.items())},
+        "server_private_symbol_count": len(references),
+        "shared_state_reference_files": sorted(path.relative_to(server).as_posix() for path in files if re.search(r"\bSharedState\b", path.read_text(encoding="utf-8"))),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--deny-all-globs", action="store_true")
+    args = parser.parse_args()
+    result = inventory(args.root)
+    encoded = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    if result["unexpected_glob_imports"]:
+        return 1
+    if args.deny_all_globs and result["glob_imports"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/incremental_build.py
+++ b/ci/incremental_build.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Measure representative warm incremental zccache rebuilds.
+
+The benchmark uses ``soldr cargo`` and touches source mtimes without changing
+file contents. Results are JSON so crate-boundary changes can be compared using
+the same edit surfaces before and after a split.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import os
+import platform
+import statistics
+import subprocess
+import tempfile
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EDIT_SURFACES = {
+    "compile": Path("crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs"),
+    "link": Path("crates/zccache-daemon-core/src/daemon/server/handle_link.rs"),
+    "exec": Path("crates/zccache-daemon-core/src/daemon/server/handle_exec.rs"),
+    "connection": Path("crates/zccache-daemon-core/src/daemon/server/connection.rs"),
+    "shared": Path("crates/zccache-daemon-core/src/daemon/server/state.rs"),
+}
+
+
+@dataclass(frozen=True)
+class BuildSample:
+    surface: str
+    sample: int
+    elapsed_ns: int
+    peak_rss_bytes: int | None
+    rebuilt_packages: list[str]
+    touched_path: str
+
+
+def package_name(package_id: str, manifest_path: str | None = None) -> str:
+    """Return a stable package name from Cargo's package_id string."""
+    tail = package_id.rsplit("#", 1)[-1]
+    candidate = tail.split("@", 1)[0]
+    if candidate and not candidate[0].isdigit():
+        return candidate
+    if manifest_path:
+        return Path(manifest_path).parent.name
+    return candidate
+
+
+def parse_rebuilt_packages(output: str) -> list[str]:
+    rebuilt: set[str] = set()
+    for line in output.splitlines():
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if message.get("reason") != "compiler-artifact" or message.get("fresh", False):
+            continue
+        package_id = message.get("package_id")
+        if isinstance(package_id, str):
+            manifest_path = message.get("manifest_path")
+            rebuilt.add(
+                package_name(
+                    package_id,
+                    manifest_path if isinstance(manifest_path, str) else None,
+                )
+            )
+    return sorted(rebuilt)
+
+
+def summarize(samples: list[BuildSample]) -> dict[str, object]:
+    elapsed = [sample.elapsed_ns for sample in samples]
+    rss = [sample.peak_rss_bytes for sample in samples if sample.peak_rss_bytes is not None]
+    median = int(statistics.median(elapsed))
+    return {
+        "samples": len(samples),
+        "min_ns": min(elapsed),
+        "median_ns": median,
+        "max_ns": max(elapsed),
+        "mad_ns": int(statistics.median(abs(value - median) for value in elapsed)),
+        "peak_rss_bytes": max(rss) if rss else None,
+        "rebuilt_packages": sorted({pkg for sample in samples for pkg in sample.rebuilt_packages}),
+    }
+
+
+def _windows_process_rss() -> dict[int, tuple[int, int]]:
+    from ctypes import wintypes
+
+    th32cs_snapp_process = 0x00000002
+    process_query_limited_information = 0x1000
+    process_vm_read = 0x0010
+    invalid_handle_value = ctypes.c_void_p(-1).value
+
+    class ProcessEntry32W(ctypes.Structure):
+        _fields_ = [
+            ("dwSize", wintypes.DWORD),
+            ("cntUsage", wintypes.DWORD),
+            ("th32ProcessID", wintypes.DWORD),
+            ("th32DefaultHeapID", ctypes.c_size_t),
+            ("th32ModuleID", wintypes.DWORD),
+            ("cntThreads", wintypes.DWORD),
+            ("th32ParentProcessID", wintypes.DWORD),
+            ("pcPriClassBase", wintypes.LONG),
+            ("dwFlags", wintypes.DWORD),
+            ("szExeFile", wintypes.WCHAR * 260),
+        ]
+
+    class ProcessMemoryCounters(ctypes.Structure):
+        _fields_ = [
+            ("cb", wintypes.DWORD),
+            ("PageFaultCount", wintypes.DWORD),
+            ("PeakWorkingSetSize", ctypes.c_size_t),
+            ("WorkingSetSize", ctypes.c_size_t),
+            ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),
+            ("QuotaPagedPoolUsage", ctypes.c_size_t),
+            ("QuotaPeakNonPagedPoolUsage", ctypes.c_size_t),
+            ("QuotaNonPagedPoolUsage", ctypes.c_size_t),
+            ("PagefileUsage", ctypes.c_size_t),
+            ("PeakPagefileUsage", ctypes.c_size_t),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    psapi = ctypes.WinDLL("psapi", use_last_error=True)
+    kernel32.CreateToolhelp32Snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
+    kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+    kernel32.Process32FirstW.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(ProcessEntry32W),
+    ]
+    kernel32.Process32FirstW.restype = wintypes.BOOL
+    kernel32.Process32NextW.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(ProcessEntry32W),
+    ]
+    kernel32.Process32NextW.restype = wintypes.BOOL
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    psapi.GetProcessMemoryInfo.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(ProcessMemoryCounters),
+        wintypes.DWORD,
+    ]
+    psapi.GetProcessMemoryInfo.restype = wintypes.BOOL
+    snapshot = kernel32.CreateToolhelp32Snapshot(th32cs_snapp_process, 0)
+    if snapshot == invalid_handle_value:
+        return {}
+    rows: dict[int, tuple[int, int]] = {}
+    try:
+        entry = ProcessEntry32W()
+        entry.dwSize = ctypes.sizeof(entry)
+        ok = kernel32.Process32FirstW(snapshot, ctypes.byref(entry))
+        while ok:
+            pid = int(entry.th32ProcessID)
+            handle = kernel32.OpenProcess(process_query_limited_information | process_vm_read, False, pid)
+            rss = 0
+            if handle:
+                counters = ProcessMemoryCounters()
+                counters.cb = ctypes.sizeof(counters)
+                if psapi.GetProcessMemoryInfo(handle, ctypes.byref(counters), counters.cb):
+                    rss = int(counters.WorkingSetSize)
+                kernel32.CloseHandle(handle)
+            rows[pid] = (int(entry.th32ParentProcessID), rss)
+            ok = kernel32.Process32NextW(snapshot, ctypes.byref(entry))
+    finally:
+        kernel32.CloseHandle(snapshot)
+    return rows
+
+
+def _unix_process_rss() -> dict[int, tuple[int, int]]:
+    result = subprocess.run(
+        ["ps", "-axo", "pid=,ppid=,rss="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    rows: dict[int, tuple[int, int]] = {}
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) == 3 and all(part.isdigit() for part in parts):
+            pid, ppid, rss_kib = map(int, parts)
+            rows[pid] = (ppid, rss_kib * 1024)
+    return rows
+
+
+def process_tree_rss(root_pid: int) -> int:
+    rows = _windows_process_rss() if os.name == "nt" else _unix_process_rss()
+    descendants = {root_pid}
+    changed = True
+    while changed:
+        changed = False
+        for pid, (ppid, _) in rows.items():
+            if ppid in descendants and pid not in descendants:
+                descendants.add(pid)
+                changed = True
+    return sum(rows.get(pid, (0, 0))[1] for pid in descendants)
+
+
+def _monitor_rss(process: subprocess.Popen[str], result: list[int]) -> None:
+    peak = 0
+    while process.poll() is None:
+        peak = max(peak, process_tree_rss(process.pid))
+        time.sleep(0.05)
+    peak = max(peak, process_tree_rss(process.pid))
+    result.append(peak)
+
+
+def run_build(command: list[str], root: Path) -> tuple[int, int | None, str, str]:
+    with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as stdout_file, tempfile.TemporaryFile(mode="w+", encoding="utf-8") as stderr_file:
+        started = time.perf_counter_ns()
+        process = subprocess.Popen(
+            command,
+            cwd=root,
+            stdout=stdout_file,
+            stderr=stderr_file,
+            text=True,
+        )
+        rss_result: list[int] = []
+        monitor = threading.Thread(target=_monitor_rss, args=(process, rss_result), daemon=True)
+        monitor.start()
+        return_code = process.wait()
+        monitor.join()
+        elapsed_ns = time.perf_counter_ns() - started
+        stdout_file.seek(0)
+        stderr_file.seek(0)
+        stdout = stdout_file.read()
+        stderr = stderr_file.read()
+    if return_code != 0:
+        raise RuntimeError(f"build failed ({return_code})\n{stderr}")
+    return elapsed_ns, (rss_result[0] if rss_result else None), stdout, stderr
+
+
+def build_command(package: str, profile: str, jobs: int | None) -> list[str]:
+    command = [
+        "soldr",
+        "cargo",
+        "build",
+        "--locked",
+        "--package",
+        package,
+        "--message-format=json-render-diagnostics",
+    ]
+    if profile != "dev":
+        command.extend(["--profile", profile])
+    if jobs is not None:
+        command.extend(["--jobs", str(jobs)])
+    return command
+
+
+def git_output(root: Path, *args: str) -> str:
+    return subprocess.run(["git", *args], cwd=root, check=True, capture_output=True, text=True).stdout.strip()
+
+
+def measure(args: argparse.Namespace) -> dict[str, object]:
+    command = build_command(args.package, args.profile, args.jobs)
+    run_build(command, args.root)
+    selected = list(EDIT_SURFACES) if args.surface == "all" else [args.surface]
+    all_samples: dict[str, list[BuildSample]] = {}
+    for surface in selected:
+        relative = EDIT_SURFACES[surface]
+        path = args.root / relative
+        original = path.stat()
+        samples: list[BuildSample] = []
+        try:
+            for sample_number in range(1, args.samples + 1):
+                time.sleep(args.touch_delay)
+                os.utime(path, None)
+                elapsed_ns, peak_rss, stdout, _ = run_build(command, args.root)
+                samples.append(
+                    BuildSample(
+                        surface=surface,
+                        sample=sample_number,
+                        elapsed_ns=elapsed_ns,
+                        peak_rss_bytes=peak_rss,
+                        rebuilt_packages=parse_rebuilt_packages(stdout),
+                        touched_path=relative.as_posix(),
+                    )
+                )
+        finally:
+            os.utime(path, ns=(original.st_atime_ns, original.st_mtime_ns))
+        all_samples[surface] = samples
+    return {
+        "schema_version": 1,
+        "commit": git_output(args.root, "rev-parse", "HEAD"),
+        "dirty": bool(git_output(args.root, "status", "--porcelain")),
+        "platform": platform.platform(),
+        "profile": args.profile,
+        "package": args.package,
+        "command": command,
+        "samples": {name: [asdict(sample) for sample in values] for name, values in all_samples.items()},
+        "summary": {name: summarize(values) for name, values in all_samples.items()},
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--surface", choices=["all", *EDIT_SURFACES], default="all")
+    parser.add_argument("--samples", type=int, default=5)
+    parser.add_argument("--touch-delay", type=float, default=1.05)
+    parser.add_argument("--package", default="zccache")
+    parser.add_argument("--profile", default="dev")
+    parser.add_argument("--jobs", type=int)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    if args.samples < 1:
+        parser.error("--samples must be positive")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    result = measure(args)
+    encoded = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tests/test_incremental_build.py
+++ b/ci/tests/test_incremental_build.py
@@ -1,0 +1,80 @@
+from ci import compile_boundary, incremental_build
+
+
+def test_parse_rebuilt_packages_ignores_fresh_and_non_json_lines():
+    output = "\n".join(
+        [
+            "Compiling example",
+            '{"reason":"compiler-artifact","package_id":"path+file:///repo/crates/zccache-daemon-core#1.0.0","manifest_path":"/repo/crates/zccache-daemon-core/Cargo.toml","fresh":false}',
+            '{"reason":"compiler-artifact","package_id":"path+file:///repo#zccache@1.0.0","fresh":true}',
+        ]
+    )
+
+    assert incremental_build.parse_rebuilt_packages(output) == ["zccache-daemon-core"]
+
+
+def test_summarize_reports_distribution_and_union():
+    samples = [
+        incremental_build.BuildSample("compile", 1, 10, 100, ["a"], "a.rs"),
+        incremental_build.BuildSample("compile", 2, 20, 200, ["a", "b"], "a.rs"),
+        incremental_build.BuildSample("compile", 3, 30, 150, ["b"], "a.rs"),
+    ]
+
+    assert incremental_build.summarize(samples) == {
+        "samples": 3,
+        "min_ns": 10,
+        "median_ns": 20,
+        "max_ns": 30,
+        "mad_ns": 10,
+        "peak_rss_bytes": 200,
+        "rebuilt_packages": ["a", "b"],
+    }
+
+
+def test_compile_boundary_rejects_new_glob_import(tmp_path):
+    server = tmp_path / compile_boundary.SERVER
+    subtree = server / "handle_compile"
+    subtree.mkdir(parents=True)
+    for name in compile_boundary.COMPILE_ROOT_FILES:
+        (server / name).write_text("", encoding="utf-8")
+    (subtree / "new_stage.rs").write_text("use super::*;\n", encoding="utf-8")
+    (server / "helper.rs").write_text("pub(super) fn private_helper() {}\n", encoding="utf-8")
+
+    result = compile_boundary.inventory(tmp_path)
+
+    assert result["unexpected_glob_imports"] == ["handle_compile/new_stage.rs"]
+
+
+def test_compile_boundary_reports_private_symbol_references(tmp_path):
+    server = tmp_path / compile_boundary.SERVER
+    subtree = server / "handle_compile"
+    subtree.mkdir(parents=True)
+    for name in compile_boundary.COMPILE_ROOT_FILES:
+        (server / name).write_text("", encoding="utf-8")
+    (subtree / "stage.rs").write_text("fn call() { private_helper(); }\n", encoding="utf-8")
+    (server / "helper.rs").write_text("pub(super) fn private_helper() {}\n", encoding="utf-8")
+
+    result = compile_boundary.inventory(tmp_path)
+
+    assert result["server_private_references"] == {"private_helper": ["handle_compile/stage.rs"]}
+
+
+def test_module_private_items_excludes_impl_methods():
+    source = """
+pub(super) struct SharedState {}
+impl SharedState {
+    pub(super) fn new() -> Self { Self {} }
+}
+pub(super) fn module_helper() {}
+"""
+
+    assert compile_boundary.module_private_items(source) == {
+        "SharedState",
+        "module_helper",
+    }
+
+
+def test_repository_compile_boundary_does_not_add_glob_imports():
+    result = compile_boundary.inventory(compile_boundary.ROOT)
+
+    assert result["unexpected_glob_imports"] == []


### PR DESCRIPTION
## Summary

- add a reproducible five-surface warm incremental-build benchmark using the required `soldr cargo` entrypoint
- record per-sample wall time, rebuilt packages, build profile, commit/dirty state, and aggregate process-tree peak RSS on Windows/Linux/macOS
- add a compile-boundary inventory and repository test that rejects growth beyond the nine existing glob imports
- formally reject Split B using #1022's explicit complexity gate

## Split B decision

A clean five-sample native Windows campaign at `3e41916` measured:

| Edited surface | Median | MAD | Peak RSS | Rebuilt packages |
| --- | ---: | ---: | ---: | --- |
| compile pipeline | 3.880 s | 45 ms | 139 MiB | `zccache-daemon-core`, `zccache` |
| link handler | 3.698 s | 43 ms | 157 MiB | same |
| exec handler | 3.810 s | 162 ms | 157 MiB | same |
| connection dispatch | 3.677 s | 43 ms | 152 MiB | same |
| shared state | 3.722 s | 11 ms | 197 MiB | same |

The current compile boundary is not narrow enough to extract safely:

- 18 compile files
- 9 existing `use super::*` imports
- 15 files directly reference `SharedState`
- 23 distinct `SharedState` fields are consumed
- 50 module-level server-private helpers/types are referenced

Moving the handler would therefore require moving or publicly exposing most of the server substrate, including caches, depgraph lifecycle, persistence, staging, stats/profiling, request caches, watcher state, and compiler execution. That is the exact #1022 rejection gate: reject when isolation requires moving most of the 32K server module or exposing a large unstable internal API. Global LTO is not introduced to hide this boundary.

Split A remains the useful crate partition. Split B is closed as measured and rejected, not silently deferred.

## Validation

- `uv run --no-project --with pytest python -m pytest ci/tests/test_incremental_build.py -q` (6 passed)
- Ruff check and format check pass
- clean 25-sample native Windows benchmark completed with `dirty: false`
- boundary inventory reports zero unexpected glob imports

Closes #1022
Refs #1099