### PR TITLE
feat(embedded): stream bounded compiler output

### DIFF
--- a/ci/docker/perf_entrypoint.sh
+++ b/ci/docker/perf_entrypoint.sh
@@ -56,8 +56,14 @@ if [[ ! -f "${scenario_script}" ]]; then
     echo "ERROR: scenario script not found: ${scenario_script}" >&2
     exit 2
 fi
+scenario_stdout="/results/scenario-stdout.log"
 bash "${scenario_script}" "${WORK_DIR}/${FIXTURE}" \
-    | tee "/results/result.json"
+    | tee "${scenario_stdout}"
+# soldr may print machine-readable command output before the scenario's final
+# result object. Preserve that evidence, but keep result.json to its documented
+# single-object contract.
+tail -n 1 "${scenario_stdout}" >"/results/result.json"
+jq -e 'type == "object"' "/results/result.json" >/dev/null
 
 # Step 3: copy the cache reports, shutdown reports, RSS CSV, and the
 # per-session zccache logs that the GHA workflow's upload-artifact step

--- a/ci/tests/test_perf_rust_cluster_embedded.py
+++ b/ci/tests/test_perf_rust_cluster_embedded.py
@@ -35,7 +35,7 @@ def test_perf_local_retains_daemon_runtime_from_every_cache_root() -> None:
     entrypoint = LOCAL_ENTRYPOINT.read_text(encoding="utf-8")
 
     assert "daemon-files.txt" in entrypoint
-    assert "find \"${scenario_root}\" -type f -name daemon-spawn.log" in entrypoint
+    assert 'find "${scenario_root}" -type f -name daemon-spawn.log' in entrypoint
     assert 'destination="/results/daemon-runtime/${relative}"' in entrypoint
 
 
@@ -49,6 +49,14 @@ def test_perf_local_retains_worktree_reports_and_abort_evidence() -> None:
         "soldr-aborts-*.jsonl",
     ):
         assert artifact in entrypoint
+
+
+def test_perf_local_isolates_the_final_result_from_command_stdout() -> None:
+    entrypoint = LOCAL_ENTRYPOINT.read_text(encoding="utf-8")
+
+    assert 'tee "${scenario_stdout}"' in entrypoint
+    assert 'tail -n 1 "${scenario_stdout}" >"/results/result.json"' in entrypoint
+    assert 'jq -e \'type == "object"\' "/results/result.json"' in entrypoint
 
 
 def test_perf_local_runner_installs_scenario_dependencies() -> None:

--- a/crates/zccache-daemon-core/src/daemon/child_watchdog.rs
+++ b/crates/zccache-daemon-core/src/daemon/child_watchdog.rs
@@ -36,6 +36,9 @@ use std::time::{Duration, Instant};
 
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::process::Child;
+use tokio::sync::mpsc;
+
+use super::compile_output::RawOutputChunk;
 
 /// Default post-exit drain grace. Once the child has exited, the daemon waits
 /// at most this long for stdout/stderr to reach EOF before concluding an orphan
@@ -219,6 +222,25 @@ pub(crate) async fn wait_with_output_watchdog(
     .await
 }
 
+/// Streaming variant of [`wait_with_output_watchdog`]. The watchdog remains
+/// the only owner of the child pipes, but forwards each read through a bounded
+/// channel instead of retaining stdout/stderr itself.
+pub(crate) async fn wait_with_output_watchdog_streaming(
+    child: Child,
+    cmd_desc: &str,
+    sender: mpsc::Sender<RawOutputChunk>,
+) -> std::io::Result<Output> {
+    watchdog_inner_impl(
+        child,
+        cmd_desc,
+        post_exit_grace(),
+        stall_window(),
+        STALL_TICK,
+        Some(sender),
+    )
+    .await
+}
+
 /// [`wait_with_output_watchdog`] with an explicit post-exit drain grace and
 /// Mode B (alive-hung) disabled, so tests can pin the grace without mutating
 /// the process-global environment (which would race across parallel tests). A
@@ -245,15 +267,26 @@ async fn wait_with_output_watchdog_with_grace(
 ///
 /// With both zero this is a plain `wait_with_output`.
 async fn watchdog_inner(
-    mut child: Child,
+    child: Child,
     cmd_desc: &str,
     grace: Duration,
     stall_window: Duration,
     stall_tick: Duration,
 ) -> std::io::Result<Output> {
+    watchdog_inner_impl(child, cmd_desc, grace, stall_window, stall_tick, None).await
+}
+
+async fn watchdog_inner_impl(
+    mut child: Child,
+    cmd_desc: &str,
+    grace: Duration,
+    stall_window: Duration,
+    stall_tick: Duration,
+    stream: Option<mpsc::Sender<RawOutputChunk>>,
+) -> std::io::Result<Output> {
     // Both modes disabled: historical behavior (host opt-out for exotic
     // pipelines needing strict EOF semantics).
-    if grace.is_zero() && stall_window.is_zero() {
+    if grace.is_zero() && stall_window.is_zero() && stream.is_none() {
         return child.wait_with_output().await;
     }
 
@@ -265,6 +298,8 @@ async fn watchdog_inner(
     let mut stderr = child.stderr.take();
     let mut out: Vec<u8> = Vec::new();
     let mut err: Vec<u8> = Vec::new();
+    let mut stdout_bytes = 0usize;
+    let mut stderr_bytes = 0usize;
     // Heap-allocated read buffers, NOT `[0u8; 64 * 1024]` stack arrays: these
     // are live across the `select!` await, so a stack array would embed 128 KiB
     // in this future — and thus in the whole deeply-nested compile-pipeline
@@ -338,7 +373,18 @@ async fn watchdog_inner(
             r = read_opt(stdout.as_mut(), &mut sbuf), if !stdout_done => match r {
                 Ok(0) => stdout_done = true,
                 Ok(n) => {
-                    out.extend_from_slice(&sbuf[..n]);
+                    stdout_bytes += n;
+                    if let Some(sender) = stream.as_ref() {
+                        sender
+                            .send(RawOutputChunk::Stdout(sbuf[..n].to_vec()))
+                            .await
+                            .map_err(|_| std::io::Error::new(
+                                std::io::ErrorKind::BrokenPipe,
+                                "compiler output consumer disconnected",
+                            ))?;
+                    } else {
+                        out.extend_from_slice(&sbuf[..n]);
+                    }
                     last_progress = Instant::now();
                 }
                 Err(_) => stdout_done = true,
@@ -346,7 +392,18 @@ async fn watchdog_inner(
             r = read_opt(stderr.as_mut(), &mut ebuf), if !stderr_done => match r {
                 Ok(0) => stderr_done = true,
                 Ok(n) => {
-                    err.extend_from_slice(&ebuf[..n]);
+                    stderr_bytes += n;
+                    if let Some(sender) = stream.as_ref() {
+                        sender
+                            .send(RawOutputChunk::Stderr(ebuf[..n].to_vec()))
+                            .await
+                            .map_err(|_| std::io::Error::new(
+                                std::io::ErrorKind::BrokenPipe,
+                                "compiler output consumer disconnected",
+                            ))?;
+                    } else {
+                        err.extend_from_slice(&ebuf[..n]);
+                    }
                     last_progress = Instant::now();
                 }
                 Err(_) => stderr_done = true,
@@ -358,8 +415,8 @@ async fn watchdog_inner(
                         child_pid,
                         grace,
                         at.elapsed(),
-                        out.len(),
-                        err.len(),
+                        stdout_bytes,
+                        stderr_bytes,
                         stdout_done,
                         stderr_done,
                     );
@@ -396,8 +453,8 @@ async fn watchdog_inner(
                         child_pid,
                         stall_window,
                         last_progress.elapsed(),
-                        out.len(),
-                        err.len(),
+                        stdout_bytes,
+                        stderr_bytes,
                     );
                     // Kill the wedged child and reap it to recover the real
                     // (killed) exit status; the compile-concurrency permit the
@@ -556,6 +613,46 @@ mod tests {
                 "stdout was: {:?}",
                 String::from_utf8_lossy(&out.stdout)
             );
+        })
+        .await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn streaming_sink_preserves_output_and_orphan_watchdog() {
+        crate::test_support::test_timeout(async {
+            let mut cmd = tokio::process::Command::new("sh");
+            cmd.args(["-c", "sleep 30 & printf 'live\\n'"]);
+            let child = piped(cmd).spawn().expect("spawn");
+            let (sender, mut receiver) = mpsc::channel(8);
+            let wait = watchdog_inner_impl(
+                child,
+                "stream-orphan",
+                Duration::from_millis(300),
+                Duration::ZERO,
+                STALL_TICK,
+                Some(sender),
+            );
+            let collect = async {
+                let mut stdout = Vec::new();
+                while let Some(chunk) = receiver.recv().await {
+                    if let RawOutputChunk::Stdout(bytes) = chunk {
+                        stdout.extend(bytes);
+                    }
+                }
+                stdout
+            };
+            let started = Instant::now();
+            let (output, stdout) = tokio::join!(wait, collect);
+            let output = output.expect("watchdog wait");
+
+            assert!(started.elapsed() < Duration::from_secs(10));
+            assert!(output.status.success());
+            assert!(
+                output.stdout.is_empty(),
+                "streaming sink owns captured bytes"
+            );
+            assert_eq!(stdout, b"live\n");
         })
         .await;
     }
@@ -726,6 +823,26 @@ mod tests {
                 !out.status.success(),
                 "a killed wedged child must not report success"
             );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn streaming_sink_preserves_alive_hung_watchdog() {
+        crate::test_support::test_timeout(async {
+            let child = piped(sleeper_cmd()).spawn().expect("spawn");
+            let (sender, mut receiver) = mpsc::channel(8);
+            let wait = watchdog_inner_impl(
+                child,
+                "stream-sleeper",
+                Duration::ZERO,
+                Duration::from_millis(150),
+                Duration::from_millis(50),
+                Some(sender),
+            );
+            let drain = async { while receiver.recv().await.is_some() {} };
+            let (output, ()) = tokio::join!(wait, drain);
+            assert!(!output.expect("watchdog wait").status.success());
         })
         .await;
     }

--- a/crates/zccache-daemon-core/src/daemon/compile_output.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_output.rs
@@ -1,0 +1,371 @@
+//! Bounded live compiler-output plumbing for the embedded API (issue #937).
+
+use std::collections::VecDeque;
+use std::future::Future;
+use std::io;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+const DEFAULT_CAPTURE_LIMIT: usize = 1024 * 1024;
+const CAPTURE_LIMIT_ENV: &str = "ZCCACHE_STREAM_CAPTURE_LIMIT_BYTES";
+
+#[derive(Debug)]
+pub(crate) enum OutputChunk {
+    Stdout(Vec<u8>),
+    Stderr(Vec<u8>),
+}
+
+#[derive(Debug)]
+pub(crate) enum RawOutputChunk {
+    Stdout(Vec<u8>),
+    Stderr(Vec<u8>),
+}
+
+#[derive(Clone)]
+pub(crate) struct OutputContext {
+    sender: mpsc::Sender<OutputChunk>,
+    capture_limit: usize,
+    live_compiler: Arc<AtomicBool>,
+}
+
+impl OutputContext {
+    pub(crate) fn new(sender: mpsc::Sender<OutputChunk>) -> Self {
+        Self {
+            sender,
+            capture_limit: capture_limit(),
+            live_compiler: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub(crate) fn mark_live(&self) {
+        self.live_compiler.store(true, Ordering::Release);
+    }
+
+    pub(crate) fn was_live(&self) -> bool {
+        self.live_compiler.load(Ordering::Acquire)
+    }
+}
+
+tokio::task_local! {
+    static OUTPUT_CONTEXT: OutputContext;
+}
+
+pub(crate) async fn scope<F: Future>(context: OutputContext, future: F) -> F::Output {
+    OUTPUT_CONTEXT.scope(context, future).await
+}
+
+pub(crate) fn current() -> Option<OutputContext> {
+    OUTPUT_CONTEXT.try_with(Clone::clone).ok()
+}
+
+pub(crate) enum StderrFilter<'a> {
+    None,
+    ShowIncludes { source: &'a Path, cwd: &'a Path },
+}
+
+pub(crate) struct CapturedOutput {
+    pub(crate) stdout: Vec<u8>,
+    pub(crate) stderr: Vec<u8>,
+    pub(crate) show_includes_scan: Option<crate::depgraph::ScanResult>,
+}
+
+pub(crate) async fn consume(
+    mut receiver: mpsc::Receiver<RawOutputChunk>,
+    context: OutputContext,
+    stderr_filter: StderrFilter<'_>,
+) -> io::Result<CapturedOutput> {
+    context.mark_live();
+    let mut stdout = BoundedCapture::new(context.capture_limit, "stdout");
+    let mut stderr = BoundedCapture::new(context.capture_limit, "stderr");
+    let mut show_includes = match stderr_filter {
+        StderrFilter::None => None,
+        StderrFilter::ShowIncludes { source, cwd } => Some(
+            crate::depgraph::show_includes::ShowIncludesParser::new(source, cwd),
+        ),
+    };
+
+    while let Some(chunk) = receiver.recv().await {
+        match chunk {
+            RawOutputChunk::Stdout(bytes) => {
+                if let Some(bytes) = stdout.push(&bytes) {
+                    send(&context.sender, OutputChunk::Stdout(bytes)).await?;
+                }
+            }
+            RawOutputChunk::Stderr(bytes) => {
+                let mut filtered = Vec::new();
+                if let Some(parser) = show_includes.as_mut() {
+                    parser.push(&bytes, &mut filtered);
+                } else {
+                    filtered = bytes;
+                }
+                if let Some(bytes) = stderr.push(&filtered) {
+                    send(&context.sender, OutputChunk::Stderr(bytes)).await?;
+                }
+            }
+        }
+    }
+
+    let show_includes_scan = if let Some(parser) = show_includes {
+        let mut filtered = Vec::new();
+        let scan = parser.finish(&mut filtered);
+        if let Some(bytes) = stderr.push(&filtered) {
+            send(&context.sender, OutputChunk::Stderr(bytes)).await?;
+        }
+        Some(scan)
+    } else {
+        None
+    };
+
+    if let Some(bytes) = stdout.finish() {
+        send(&context.sender, OutputChunk::Stdout(bytes)).await?;
+    }
+    if let Some(bytes) = stderr.finish() {
+        send(&context.sender, OutputChunk::Stderr(bytes)).await?;
+    }
+
+    Ok(CapturedOutput {
+        stdout: stdout.into_bytes(),
+        stderr: stderr.into_bytes(),
+        show_includes_scan,
+    })
+}
+
+async fn send(sender: &mpsc::Sender<OutputChunk>, chunk: OutputChunk) -> io::Result<()> {
+    sender.send(chunk).await.map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "embedded compile output receiver disconnected",
+        )
+    })
+}
+
+/// Retains a live-emitted head and a ring-buffered tail so truncation keeps
+/// both early context and the final diagnostic lines.
+struct BoundedCapture {
+    bytes: Vec<u8>,
+    limit: usize,
+    head_limit: usize,
+    tail: VecDeque<u8>,
+    total: usize,
+    stream: &'static str,
+}
+
+impl BoundedCapture {
+    fn new(limit: usize, stream: &'static str) -> Self {
+        let head_limit = limit.div_ceil(2);
+        Self {
+            bytes: Vec::with_capacity(limit.min(64 * 1024)),
+            limit,
+            head_limit,
+            tail: VecDeque::new(),
+            total: 0,
+            stream,
+        }
+    }
+
+    fn push(&mut self, bytes: &[u8]) -> Option<Vec<u8>> {
+        if bytes.is_empty() {
+            return None;
+        }
+        self.total = self.total.saturating_add(bytes.len());
+        let head_remaining = self.head_limit.saturating_sub(self.bytes.len());
+        let immediate_len = head_remaining.min(bytes.len());
+        let immediate = if immediate_len > 0 {
+            self.bytes.extend_from_slice(&bytes[..immediate_len]);
+            Some(bytes[..immediate_len].to_vec())
+        } else {
+            None
+        };
+
+        let tail_capacity = self.limit - self.head_limit;
+        if tail_capacity > 0 {
+            self.tail.extend(&bytes[immediate_len..]);
+            let excess = self.tail.len().saturating_sub(tail_capacity);
+            self.tail.drain(..excess);
+        }
+        immediate
+    }
+
+    fn finish(&mut self) -> Option<Vec<u8>> {
+        if self.tail.is_empty() {
+            return None;
+        }
+        let marker = (self.total > self.limit).then(|| {
+            format!(
+                "\n[zccache: {} truncated to {} bytes; set {} to change the limit]\n",
+                self.stream, self.limit, CAPTURE_LIMIT_ENV
+            )
+        });
+        let mut emitted = Vec::with_capacity(
+            self.tail.len() + marker.as_ref().map_or(0, std::string::String::len),
+        );
+        if let Some(marker) = marker {
+            emitted.extend_from_slice(marker.as_bytes());
+        }
+        emitted.extend(self.tail.drain(..));
+        self.bytes.extend_from_slice(&emitted);
+        Some(emitted)
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+fn capture_limit() -> usize {
+    std::env::var(CAPTURE_LIMIT_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|limit| *limit > 0)
+        .unwrap_or(DEFAULT_CAPTURE_LIMIT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(unix)]
+    use crate::daemon::process::CompilePriority;
+
+    #[test]
+    fn bounded_capture_emits_and_stores_the_same_truncation_marker() {
+        let mut capture = BoundedCapture::new(4, "stderr");
+        let mut emitted = capture.push(b"abcdef").expect("emitted head");
+        emitted.extend(capture.finish().expect("emitted tail"));
+        assert_eq!(emitted, capture.into_bytes());
+        assert!(String::from_utf8_lossy(&emitted).contains("truncated to 4 bytes"));
+        assert!(emitted.ends_with(b"ef"));
+    }
+
+    #[test]
+    fn capture_below_limit_is_delayed_but_not_truncated() {
+        let mut capture = BoundedCapture::new(8, "stdout");
+        let mut emitted = capture.push(b"abcdef").expect("emitted head");
+        emitted.extend(capture.finish().expect("emitted suffix"));
+        assert_eq!(emitted, b"abcdef");
+        assert_eq!(emitted, capture.into_bytes());
+    }
+
+    #[tokio::test]
+    async fn synthetic_large_diagnostic_is_bounded_and_replay_identical() {
+        let (sender, mut chunks) = mpsc::channel(8);
+        let context = OutputContext {
+            sender,
+            capture_limit: 1024,
+            live_compiler: Arc::new(AtomicBool::new(false)),
+        };
+        let (raw_sender, raw_receiver) = mpsc::channel(8);
+        raw_sender
+            .send(RawOutputChunk::Stderr(vec![b'x'; 2 * 1024 * 1024]))
+            .await
+            .expect("raw output receiver");
+        drop(raw_sender);
+
+        let captured = super::consume(raw_receiver, context, StderrFilter::None)
+            .await
+            .expect("capture");
+        let mut emitted = Vec::new();
+        while let Ok(chunk) = chunks.try_recv() {
+            let OutputChunk::Stderr(bytes) = chunk else {
+                panic!("expected stderr")
+            };
+            emitted.extend(bytes);
+        }
+        assert_eq!(emitted, captured.stderr);
+        assert!(captured.stderr.len() < 2048);
+        assert!(String::from_utf8_lossy(&captured.stderr).contains("truncated to 1024 bytes"));
+        assert!(captured.stderr.ends_with(&vec![b'x'; 512]));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn first_chunk_arrives_while_child_is_still_running() {
+        let (sender, mut chunks) = mpsc::channel(8);
+        let context = OutputContext::new(sender);
+        let (raw_sender, raw_receiver) = mpsc::channel(8);
+        let mut command = tokio::process::Command::new("sh");
+        command.args([
+            "-c",
+            "printf 'first\\n' >&2; sleep 1; printf 'second\\n' >&2",
+        ]);
+
+        let process = crate::daemon::process::tokio_command_output_streaming_with_priority_stdin(
+            &mut command,
+            CompilePriority::Normal,
+            None,
+            raw_sender,
+        );
+        let consume = super::consume(raw_receiver, context, StderrFilter::None);
+        let operation = async {
+            let (process, capture) = tokio::join!(process, consume);
+            (
+                process.expect("child process"),
+                capture.expect("captured output"),
+            )
+        };
+        tokio::pin!(operation);
+
+        let started = std::time::Instant::now();
+        let first = tokio::select! {
+            chunk = chunks.recv() => chunk.expect("first output chunk"),
+            _ = &mut operation => panic!("child exited before first output callback"),
+        };
+        assert!(started.elapsed() < std::time::Duration::from_millis(800));
+        assert!(matches!(first, OutputChunk::Stderr(bytes) if bytes == b"first\n"));
+
+        let (process, capture) = operation.await;
+        assert!(process.status.success());
+        assert!(started.elapsed() >= std::time::Duration::from_millis(800));
+        assert_eq!(capture.stderr, b"first\nsecond\n");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn dropping_streaming_operation_kills_and_reaps_child() {
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let pid_path = temp.path().join("child.pid");
+        let script = format!(
+            "echo $$ > '{}'; printf 'started\\n' >&2; exec sleep 30",
+            pid_path.display()
+        );
+        let (sender, mut chunks) = mpsc::channel(8);
+        let context = OutputContext::new(sender);
+        let operation = async move {
+            let (raw_sender, raw_receiver) = mpsc::channel(8);
+            let mut command = tokio::process::Command::new("sh");
+            command.args(["-c", &script]);
+            let process =
+                crate::daemon::process::tokio_command_output_streaming_with_priority_stdin(
+                    &mut command,
+                    CompilePriority::Normal,
+                    None,
+                    raw_sender,
+                );
+            let consume = super::consume(raw_receiver, context, StderrFilter::None);
+            tokio::join!(process, consume)
+        };
+        let mut operation = Box::pin(operation);
+
+        let first = tokio::select! {
+            chunk = chunks.recv() => chunk.expect("startup output"),
+            _ = &mut operation => panic!("child exited before cancellation"),
+        };
+        assert!(matches!(first, OutputChunk::Stderr(bytes) if bytes == b"started\n"));
+        let pid: u32 = std::fs::read_to_string(&pid_path)
+            .expect("pid file")
+            .trim()
+            .parse()
+            .expect("pid");
+
+        drop(operation);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while std::path::Path::new(&format!("/proc/{pid}")).exists() {
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("cancelled child should be reaped");
+    }
+}

--- a/crates/zccache-daemon-core/src/daemon/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/mod.rs
@@ -7,6 +7,7 @@
 
 pub(crate) mod child_watchdog;
 pub mod compile_journal;
+pub(crate) mod compile_output;
 pub mod crash;
 /// Standalone daemon process entry point (issue #997), gated so it only
 /// compiles when a binary that hosts it (`daemon-bin`, or the `cli`/`zccache`

--- a/crates/zccache-daemon-core/src/daemon/process.rs
+++ b/crates/zccache-daemon-core/src/daemon/process.rs
@@ -658,6 +658,27 @@ pub(crate) async fn tokio_command_output_with_priority_stdin(
     priority: CompilePriority,
     stdin_bytes: Option<&[u8]>,
 ) -> io::Result<Output> {
+    tokio_command_output_with_priority_stdin_inner(cmd, priority, stdin_bytes, None).await
+}
+
+/// Streaming counterpart used by the embedded compile API. Process setup,
+/// priority, job assignment, stdin, and watchdog behavior are identical to
+/// [`tokio_command_output_with_priority_stdin`]; only pipe capture differs.
+pub(crate) async fn tokio_command_output_streaming_with_priority_stdin(
+    cmd: &mut tokio::process::Command,
+    priority: CompilePriority,
+    stdin_bytes: Option<&[u8]>,
+    sender: tokio::sync::mpsc::Sender<crate::daemon::compile_output::RawOutputChunk>,
+) -> io::Result<Output> {
+    tokio_command_output_with_priority_stdin_inner(cmd, priority, stdin_bytes, Some(sender)).await
+}
+
+async fn tokio_command_output_with_priority_stdin_inner(
+    cmd: &mut tokio::process::Command,
+    priority: CompilePriority,
+    stdin_bytes: Option<&[u8]>,
+    stream: Option<tokio::sync::mpsc::Sender<crate::daemon::compile_output::RawOutputChunk>>,
+) -> io::Result<Output> {
     let (decision, _ticket) = priority.resolve_and_track();
     let priority = decision.effective;
     let pipe_stdin = matches!(stdin_bytes, Some(b) if !b.is_empty());
@@ -690,7 +711,17 @@ pub(crate) async fn tokio_command_output_with_priority_stdin(
                 let _ = stdin.shutdown().await;
             }
         }
-        crate::daemon::child_watchdog::wait_with_output_watchdog(child, &cmd_desc).await
+        match stream {
+            Some(sender) => {
+                crate::daemon::child_watchdog::wait_with_output_watchdog_streaming(
+                    child, &cmd_desc, sender,
+                )
+                .await
+            }
+            None => {
+                crate::daemon::child_watchdog::wait_with_output_watchdog(child, &cmd_desc).await
+            }
+        }
     }
 
     #[cfg(unix)]
@@ -716,13 +747,24 @@ pub(crate) async fn tokio_command_output_with_priority_stdin(
                 let _ = stdin.shutdown().await;
             }
         }
-        crate::daemon::child_watchdog::wait_with_output_watchdog(child, &cmd_desc).await
+        match stream {
+            Some(sender) => {
+                crate::daemon::child_watchdog::wait_with_output_watchdog_streaming(
+                    child, &cmd_desc, sender,
+                )
+                .await
+            }
+            None => {
+                crate::daemon::child_watchdog::wait_with_output_watchdog(child, &cmd_desc).await
+            }
+        }
     }
 
     #[cfg(not(any(unix, windows)))]
     {
         let _ = stdin_bytes;
         let _ = &cmd_desc;
+        let _ = stream;
         cmd.output().await
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -270,11 +270,36 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     };
     let compile_span_start = std::time::Instant::now();
 
-    let result = crate::daemon::process::tokio_command_output_with_priority(
-        &mut cmd,
-        compiler_priority_decision.effective,
-    )
-    .await;
+    let (result, streamed_output) = if let Some(context) = crate::daemon::compile_output::current()
+    {
+        let (sender, receiver) = tokio::sync::mpsc::channel(8);
+        let filter = if depfile_strategy == DepfileStrategy::ShowIncludes {
+            crate::daemon::compile_output::StderrFilter::ShowIncludes {
+                source: source_path.as_path(),
+                cwd: cwd_path.as_path(),
+            }
+        } else {
+            crate::daemon::compile_output::StderrFilter::None
+        };
+        let process = crate::daemon::process::tokio_command_output_streaming_with_priority_stdin(
+            &mut cmd,
+            compiler_priority_decision.effective,
+            None,
+            sender,
+        );
+        let consume = crate::daemon::compile_output::consume(receiver, context, filter);
+        let (process_result, capture_result) = tokio::join!(process, consume);
+        (process_result, Some(capture_result))
+    } else {
+        (
+            crate::daemon::process::tokio_command_output_with_priority(
+                &mut cmd,
+                compiler_priority_decision.effective,
+            )
+            .await,
+            None,
+        )
+    };
     let compiler_process_ns = t_compiler_process.elapsed().as_nanos() as u64;
     if staged_plan.is_some() {
         state.profiler.staged.count(StagedCounter::CompilerStaged);
@@ -308,25 +333,37 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
             });
         }
     };
+    let streamed_output = match streamed_output {
+        Some(Ok(output)) => Some(output),
+        Some(Err(e)) => {
+            return CompileExecResult::Error(Response::Error {
+                message: format!("failed to stream compiler output: {e}"),
+            });
+        }
+        None => None,
+    };
     let compiler_exec_ns = t_exec.elapsed().as_nanos() as u64;
     let compiler_prep_ns = compiler_exec_ns.saturating_sub(compiler_process_ns);
 
     let t_post_exec = std::time::Instant::now();
     let exit_code = output.status.code().unwrap_or(-1);
-    let stdout = Arc::new(output.stdout);
-
-    // For MSVC /showIncludes: parse dependency info from stderr and
-    // filter out the /showIncludes lines before returning to the client.
-    let (show_includes_scan, stderr_bytes) = if depfile_strategy == DepfileStrategy::ShowIncludes {
+    let (stdout_bytes, show_includes_scan, stderr_bytes) = if let Some(streamed) = streamed_output {
+        (
+            streamed.stdout,
+            streamed.show_includes_scan,
+            streamed.stderr,
+        )
+    } else if depfile_strategy == DepfileStrategy::ShowIncludes {
         let (scan, filtered) = crate::depgraph::show_includes::parse_show_includes(
             &output.stderr,
             source_path,
             cwd_path,
         );
-        (Some(scan), filtered)
+        (output.stdout, Some(scan), filtered)
     } else {
-        (None, output.stderr)
+        (output.stdout, None, output.stderr)
     };
+    let stdout = Arc::new(stdout_bytes);
     let stderr = Arc::new(stderr_bytes);
     let post_exec_ns = t_post_exec.elapsed().as_nanos() as u64;
 

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
@@ -140,19 +140,54 @@ pub(super) async fn run_compiler_direct_with_family(
     }
     apply_client_env(&mut cmd, client_env, &lineage);
     let compiler_priority = CompilePriority::from_client_env(client_env.as_deref());
-    let result = super::super::process::tokio_command_output_with_priority_stdin(
-        &mut cmd,
-        compiler_priority,
-        if stdin_bytes.is_empty() {
-            None
-        } else {
-            Some(stdin_bytes)
-        },
-    )
-    .await;
+    let stdin = if stdin_bytes.is_empty() {
+        None
+    } else {
+        Some(stdin_bytes)
+    };
+    let (result, streamed_output) = if let Some(context) = crate::daemon::compile_output::current()
+    {
+        let (sender, receiver) = tokio::sync::mpsc::channel(8);
+        let process = super::super::process::tokio_command_output_streaming_with_priority_stdin(
+            &mut cmd,
+            compiler_priority,
+            stdin,
+            sender,
+        );
+        let consume = crate::daemon::compile_output::consume(
+            receiver,
+            context,
+            crate::daemon::compile_output::StderrFilter::None,
+        );
+        let (process_result, capture_result) = tokio::join!(process, consume);
+        (process_result, Some(capture_result))
+    } else {
+        (
+            super::super::process::tokio_command_output_with_priority_stdin(
+                &mut cmd,
+                compiler_priority,
+                stdin,
+            )
+            .await,
+            None,
+        )
+    };
 
     match result {
-        Ok(output) => {
+        Ok(mut output) => {
+            if let Some(capture) = streamed_output {
+                match capture {
+                    Ok(capture) => {
+                        output.stdout = capture.stdout;
+                        output.stderr = capture.stderr;
+                    }
+                    Err(e) => {
+                        return Response::Error {
+                            message: format!("failed to stream compiler output: {e}"),
+                        };
+                    }
+                }
+            }
             let exit_code = output.status.code().unwrap_or(-1);
             write_session_log(sessions, sid, &format!("[DIRECT] exit_code={exit_code}"));
             Response::CompileResult {

--- a/crates/zccache-daemon-core/src/embedded.rs
+++ b/crates/zccache-daemon-core/src/embedded.rs
@@ -250,25 +250,17 @@ pub enum CacheOutcome {
 }
 
 /// Streaming compile event (issue #937). Yielded by
-/// [`ZccacheService::compile_streaming`] as rustc produces output —
+/// [`ZccacheService::compile_streaming`] as the compiler produces output —
 /// `Stdout` and `Stderr` chunks arrive incrementally; the terminal
 /// `Done` event carries the exit code and cache outcome.
 ///
-/// **MVP shape — internally pass-through today.** The current
-/// implementation runs the existing buffered `compile` path under
-/// the hood and emits a single `Stdout` chunk + single `Stderr`
-/// chunk + `Done` at the end. The wire format and consumer code on
-/// the soldr side (soldr#982 commit 82e26f4) already speaks this
-/// shape, so consumers can rely on it as a stable API. The
-/// daemon-internal refactor that pumps rustc pipes into chunks as
-/// bytes arrive is the cross-cutting work tracked in #937 itself —
-/// when it lands, only the producer side of this enum's emission
-/// changes; the public API stays.
+/// Live chunks use a bounded channel and retained output is capped with an
+/// explicit truncation marker. Cache hits replay through the same event shape.
 #[derive(Debug, Clone)]
 pub enum CompileChunk {
-    /// A chunk of rustc's stdout bytes.
+    /// A chunk of compiler stdout bytes.
     Stdout(Vec<u8>),
-    /// A chunk of rustc's stderr bytes.
+    /// A chunk of compiler stderr bytes.
     Stderr(Vec<u8>),
     /// Terminal event with the compile's outcome metadata.
     Done {
@@ -378,6 +370,34 @@ impl ZccacheService {
     /// effect — there is no orphaned `rustc` left behind. Hosts should
     /// treat `Cancelled` as terminal (no retry inside the same shutdown).
     pub async fn compile(&self, request: CompileRequest) -> Result<CompileResponse> {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let mut done = None;
+        self.compile_streaming(request, |chunk| match chunk {
+            CompileChunk::Stdout(bytes) => stdout.extend_from_slice(&bytes),
+            CompileChunk::Stderr(bytes) => stderr.extend_from_slice(&bytes),
+            CompileChunk::Done {
+                exit_code,
+                cached,
+                cache_outcome,
+                compile_id,
+            } => done = Some((exit_code, cached, cache_outcome, compile_id)),
+        })
+        .await?;
+        let (exit_code, cached, cache_outcome, compile_id) = done.ok_or_else(|| {
+            EmbeddedError::Compile("streaming compile completed without a Done event".to_string())
+        })?;
+        Ok(CompileResponse {
+            exit_code,
+            stdout,
+            stderr,
+            cached,
+            cache_outcome,
+            compile_id,
+        })
+    }
+
+    async fn compile_inner(&self, request: CompileRequest) -> Result<CompileResponse> {
         let compile_id = request
             .audit
             .compile_id
@@ -430,32 +450,47 @@ impl ZccacheService {
         })
     }
 
-    /// Streaming compile (issue #937). Invokes `on_chunk` once per
-    /// stdout/stderr chunk, then once with the terminal `Done` event.
+    /// Streaming compile (issue #937). Invokes `on_chunk` as compiler output
+    /// arrives, then once with the terminal `Done` event. Per-stream ordering
+    /// is preserved; ordering between stdout and stderr follows the pipe drain.
     ///
-    /// **MVP: pass-through over the existing buffered `compile`.**
-    /// The current implementation runs `compile()` to completion and
-    /// emits one `Stdout` + one `Stderr` + one `Done` chunk. The full
-    /// streaming-source refactor (pump rustc pipes directly into the
-    /// chunk emitter) is the cross-cutting work tracked in #937 — when
-    /// it lands inside the daemon pipeline, only the producer side of
-    /// this method changes; the public API stays.
-    ///
-    /// Consumers can rely on this API today via the soldr-side
-    /// streaming wire format (soldr#982 commit `82e26f4`,
-    /// `PROTOCOL_VERSION = 7`). When the daemon-side pipeline refactor
-    /// lands the chunk granularity gets finer; consumer code doesn't
-    /// need to change.
+    /// The callback runs inline and applies backpressure to the bounded drain.
+    /// Retained output is capped at 1 MiB per stream by default; set
+    /// `ZCCACHE_STREAM_CAPTURE_LIMIT_BYTES` to a positive byte count to change
+    /// it. Truncation is explicit and the same marker is cached and replayed.
     pub async fn compile_streaming<F>(&self, request: CompileRequest, mut on_chunk: F) -> Result<()>
     where
         F: FnMut(CompileChunk),
     {
-        let response = self.compile(request).await?;
-        if !response.stdout.is_empty() {
-            on_chunk(CompileChunk::Stdout(response.stdout));
+        const CHUNK_BYTES: usize = 64 * 1024;
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(8);
+        let context = crate::daemon::compile_output::OutputContext::new(sender);
+        let compile =
+            crate::daemon::compile_output::scope(context.clone(), self.compile_inner(request));
+        tokio::pin!(compile);
+
+        let response = loop {
+            tokio::select! {
+                biased;
+                chunk = receiver.recv() => {
+                    if let Some(chunk) = chunk {
+                        emit_output_chunk(&mut on_chunk, chunk);
+                    }
+                }
+                result = &mut compile => break result?,
+            }
+        };
+        while let Ok(chunk) = receiver.try_recv() {
+            emit_output_chunk(&mut on_chunk, chunk);
         }
-        if !response.stderr.is_empty() {
-            on_chunk(CompileChunk::Stderr(response.stderr));
+
+        if !context.was_live() {
+            for chunk in response.stdout.chunks(CHUNK_BYTES) {
+                on_chunk(CompileChunk::Stdout(chunk.to_vec()));
+            }
+            for chunk in response.stderr.chunks(CHUNK_BYTES) {
+                on_chunk(CompileChunk::Stderr(chunk.to_vec()));
+            }
         }
         on_chunk(CompileChunk::Done {
             exit_code: response.exit_code,
@@ -539,6 +574,20 @@ impl ZccacheService {
     }
 }
 
+fn emit_output_chunk<F>(on_chunk: &mut F, chunk: crate::daemon::compile_output::OutputChunk)
+where
+    F: FnMut(CompileChunk),
+{
+    match chunk {
+        crate::daemon::compile_output::OutputChunk::Stdout(bytes) => {
+            on_chunk(CompileChunk::Stdout(bytes));
+        }
+        crate::daemon::compile_output::OutputChunk::Stderr(bytes) => {
+            on_chunk(CompileChunk::Stderr(bytes));
+        }
+    }
+}
+
 impl ServiceStats {
     fn from_snapshot(snapshot: EmbeddedStatsSnapshot) -> Self {
         let status = snapshot.status;
@@ -606,6 +655,26 @@ mod streaming_tests {
     //! consumer-visible event order.
 
     use super::*;
+    use tempfile::TempDir;
+
+    async fn start_test_service(temp: &TempDir) -> ZccacheService {
+        let mut audit = AuditConfig::default();
+        audit.mode = crate::audit::AuditMode::Off;
+        ZccacheService::start(ZccacheConfig {
+            host: HostIdentity {
+                product: "streaming-test".into(),
+                instance_id: uuid::Uuid::new_v4().to_string(),
+                workspace_id: "streaming-workspace".into(),
+            },
+            cache_root: temp.path().join("cache").into(),
+            audit,
+            limits: ServiceLimits::default(),
+            runtime: RuntimeHooks::default(),
+            cancellation: None,
+        })
+        .await
+        .expect("service start")
+    }
 
     #[test]
     fn compile_chunk_done_carries_outcome_fields() {
@@ -641,6 +710,74 @@ mod streaming_tests {
             CompileChunk::Stderr(bytes) => assert_eq!(bytes, b"warn"),
             other => panic!("expected Stderr, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn cache_hit_replays_byte_identical_streams() {
+        let Some(compiler) = crate::test_support::find_clang() else {
+            return;
+        };
+        let temp = TempDir::new().expect("tempdir");
+        let source = temp.path().join("warning.c");
+        let output = temp.path().join("warning.o");
+        std::fs::write(
+            &source,
+            "#warning stream-replay\nint value(void) { return 1; }\n",
+        )
+        .expect("source");
+        let service = start_test_service(&temp).await;
+        let request = CompileRequest {
+            audit: AuditContext::new(
+                crate::audit::AuditId::new("stream-run").expect("id"),
+                crate::audit::AuditId::new("stream-trace").expect("id"),
+            ),
+            compiler,
+            args: vec![
+                "-c".into(),
+                source.to_string_lossy().into_owned(),
+                "-o".into(),
+                output.to_string_lossy().into_owned(),
+            ],
+            cwd: temp.path().into(),
+            env: Vec::new(),
+            stdin: Vec::new(),
+        };
+
+        let mut miss_stdout = Vec::new();
+        let mut miss_stderr = Vec::new();
+        let mut miss_cached = None;
+        service
+            .compile_streaming(request.clone(), |chunk| match chunk {
+                CompileChunk::Stdout(bytes) => miss_stdout.extend(bytes),
+                CompileChunk::Stderr(bytes) => miss_stderr.extend(bytes),
+                CompileChunk::Done { cached, .. } => miss_cached = Some(cached),
+            })
+            .await
+            .expect("cache miss compile");
+        assert_eq!(miss_cached, Some(false));
+        assert!(!miss_stderr.is_empty());
+
+        std::fs::remove_file(&output).expect("remove first output");
+        let mut hit_stdout = Vec::new();
+        let mut hit_stderr = Vec::new();
+        let mut hit_cached = None;
+        service
+            .compile_streaming(request, |chunk| match chunk {
+                CompileChunk::Stdout(bytes) => hit_stdout.extend(bytes),
+                CompileChunk::Stderr(bytes) => hit_stderr.extend(bytes),
+                CompileChunk::Done { cached, .. } => hit_cached = Some(cached),
+            })
+            .await
+            .expect("cache hit compile");
+
+        assert_eq!(hit_cached, Some(true));
+        assert_eq!(hit_stdout, miss_stdout);
+        assert_eq!(hit_stderr, miss_stderr);
+        assert!(output.exists(), "cache hit must restore the output file");
+        service
+            .shutdown(ShutdownMode::Graceful)
+            .await
+            .expect("shutdown");
     }
 }
 

--- a/crates/zccache-depgraph/src/show_includes.rs
+++ b/crates/zccache-depgraph/src/show_includes.rs
@@ -12,13 +12,133 @@
 //! locale, producing a [`ScanResult`] with `has_computed = false`.
 
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+use zccache_core::NormalizedPath;
 
 use super::depfile::canonicalize_path;
 use super::scanner::ScanResult;
 
 /// Well-known English prefix â€” checked first as a fast path.
 const ENGLISH_PREFIX: &str = "Note: including file:";
+
+/// Maximum partial line retained while waiting for a newline. Include paths
+/// are line-oriented and comfortably below this size; an oversized diagnostic
+/// is passed through incrementally so one malformed line cannot defeat the
+/// streaming compile path's memory bound.
+const MAX_PARTIAL_LINE_BYTES: usize = 64 * 1024;
+
+/// Incremental `/showIncludes` parser used by the live compiler-output path.
+///
+/// Complete lines are classified as chunks arrive. Non-include stderr is
+/// appended to the caller-provided output buffer with its original line
+/// endings, while include paths are accumulated for [`ScanResult`].
+pub struct ShowIncludesParser {
+    source_canonical: NormalizedPath,
+    cwd: PathBuf,
+    prefix: Option<String>,
+    seen: HashSet<NormalizedPath>,
+    resolved: Vec<NormalizedPath>,
+    partial: Vec<u8>,
+    passthrough_line: bool,
+}
+
+impl ShowIncludesParser {
+    pub fn new(source: &Path, cwd: &Path) -> Self {
+        Self {
+            source_canonical: canonicalize_path(source, cwd),
+            cwd: cwd.to_path_buf(),
+            prefix: None,
+            seen: HashSet::new(),
+            resolved: Vec::new(),
+            partial: Vec::new(),
+            passthrough_line: false,
+        }
+    }
+
+    /// Consume another stderr chunk and append filtered bytes to `output`.
+    pub fn push(&mut self, mut chunk: &[u8], output: &mut Vec<u8>) {
+        while !chunk.is_empty() {
+            if self.passthrough_line {
+                if let Some(newline) = chunk.iter().position(|byte| *byte == b'\n') {
+                    output.extend_from_slice(&chunk[..=newline]);
+                    chunk = &chunk[newline + 1..];
+                    self.passthrough_line = false;
+                } else {
+                    output.extend_from_slice(chunk);
+                    return;
+                }
+                continue;
+            }
+
+            if let Some(newline) = chunk.iter().position(|byte| *byte == b'\n') {
+                self.partial.extend_from_slice(&chunk[..=newline]);
+                chunk = &chunk[newline + 1..];
+                self.finish_line(output);
+            } else {
+                self.partial.extend_from_slice(chunk);
+                if self.partial.len() > MAX_PARTIAL_LINE_BYTES {
+                    output.extend_from_slice(&self.partial);
+                    self.partial.clear();
+                    self.passthrough_line = true;
+                }
+                return;
+            }
+        }
+    }
+
+    /// Flush a final unterminated line and return the dependency scan.
+    pub fn finish(mut self, output: &mut Vec<u8>) -> ScanResult {
+        if !self.partial.is_empty() {
+            self.finish_line(output);
+        }
+        ScanResult {
+            resolved: self.resolved,
+            unresolved: Vec::new(),
+            has_computed: false,
+        }
+    }
+
+    fn finish_line(&mut self, output: &mut Vec<u8>) {
+        let raw = std::mem::take(&mut self.partial);
+        let text_end = raw
+            .strip_suffix(b"\n")
+            .unwrap_or(&raw)
+            .strip_suffix(b"\r")
+            .unwrap_or_else(|| raw.strip_suffix(b"\n").unwrap_or(&raw));
+        let line = String::from_utf8_lossy(text_end);
+
+        if self.prefix.is_none() {
+            self.prefix = if line.starts_with(ENGLISH_PREFIX) {
+                Some(ENGLISH_PREFIX.to_string())
+            } else {
+                extract_prefix_candidate(&line)
+            };
+        }
+
+        let Some(prefix) = self.prefix.as_deref() else {
+            output.extend_from_slice(&raw);
+            return;
+        };
+        let Some(path_str) = line.strip_prefix(prefix) else {
+            output.extend_from_slice(&raw);
+            return;
+        };
+        let path_str = path_str.trim();
+        if path_str.is_empty() {
+            return;
+        }
+        let dep_path = Path::new(path_str);
+        let abs_path = if dep_path.is_absolute() {
+            canonicalize_path(dep_path, &self.cwd)
+        } else {
+            canonicalize_path(&self.cwd.join(dep_path), &self.cwd)
+        };
+        if abs_path != self.source_canonical && self.seen.insert(abs_path.clone()) {
+            self.resolved.push(abs_path);
+        }
+    }
+}
 
 /// Parse MSVC `/showIncludes` stderr output into a [`ScanResult`].
 ///
@@ -249,6 +369,46 @@ mod tests {
         let filtered_str = String::from_utf8(filtered).unwrap();
         assert!(filtered_str.contains("warning C4996"));
         assert!(!filtered_str.contains("including file"));
+    }
+
+    #[test]
+    fn incremental_parser_handles_lines_split_across_chunks() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cwd = dir.path();
+        let header = cwd.join("split.h");
+        let source = cwd.join("main.cpp");
+        std::fs::write(&header, "").unwrap();
+        std::fs::write(&source, "").unwrap();
+
+        let stderr = format!(
+            "Note: including file: {}\r\nwarning C4996: split warning\r\n",
+            header.display()
+        );
+        let mut parser = ShowIncludesParser::new(&source, cwd);
+        let mut filtered = Vec::new();
+        for chunk in stderr.as_bytes().chunks(3) {
+            parser.push(chunk, &mut filtered);
+        }
+        let scan = parser.finish(&mut filtered);
+
+        assert_eq!(scan.resolved.len(), 1);
+        assert_eq!(filtered, b"warning C4996: split warning\r\n");
+    }
+
+    #[test]
+    fn incremental_parser_bounds_oversized_unterminated_line() {
+        let mut parser = ShowIncludesParser::new(Path::new("main.cpp"), Path::new("."));
+        let diagnostic = vec![b'x'; MAX_PARTIAL_LINE_BYTES * 2];
+        let mut filtered = Vec::new();
+
+        for chunk in diagnostic.chunks(4096) {
+            parser.push(chunk, &mut filtered);
+            assert!(parser.partial.len() <= MAX_PARTIAL_LINE_BYTES);
+        }
+        let scan = parser.finish(&mut filtered);
+
+        assert!(scan.resolved.is_empty());
+        assert_eq!(filtered, diagnostic);
     }
 
     #[cfg(windows)]

--- a/docs/architecture/embedded-service.md
+++ b/docs/architecture/embedded-service.md
@@ -157,14 +157,36 @@ pub struct CompileResponse {
     pub compile_id: String,
 }
 
+pub enum CompileChunk {
+    Stdout(Vec<u8>),
+    Stderr(Vec<u8>),
+    Done { /* outcome metadata */ },
+}
+
 impl ZccacheService {
     pub async fn start(config: ZccacheConfig) -> Result<Self>;
     pub async fn compile(&self, request: CompileRequest) -> Result<CompileResponse>;
+    pub async fn compile_streaming<F>(&self, request: CompileRequest, on_chunk: F) -> Result<()>
+    where
+        F: FnMut(CompileChunk);
     pub async fn stats(&self) -> Result<ServiceStats>;
     pub async fn flush(&self) -> Result<FlushReport>;
     pub async fn shutdown(self, mode: ShutdownMode) -> Result<ShutdownReport>;
 }
 ```
+
+`compile_streaming` is the canonical producer. `compile` is a buffered adapter
+that collects the same chunks. Compiler misses and direct invocations emit
+output while the child is running; cache hits replay stored output in 64 KiB
+chunks. Ordering is preserved within stdout and stderr, while cross-stream
+ordering follows the runtime pipe drain.
+
+The callback runs inline. A slow callback therefore applies backpressure to a
+bounded channel and eventually to the compiler pipes. Retained output is capped
+at 1 MiB per stream by default, configurable through
+`ZCCACHE_STREAM_CAPTURE_LIMIT_BYTES`. When a stream exceeds the cap, zccache
+keeps a live-emitted head plus a bounded tail and inserts an explicit marker
+between them; those capped bytes and marker are what a later cache hit replays.
 
 ### MVP API Acceptance
 


### PR DESCRIPTION
## Summary

- make `compile_streaming` deliver compiler pipe chunks before child exit and make buffered `compile` collect the same producer
- retain a bounded head plus tail per stream with an explicit truncation marker, incremental `/showIncludes` parsing, and byte-identical cache replay
- preserve cancellation, process priority/job assignment, orphan-pipe and alive-stall watchdog behavior
- isolate perf `result.json` from soldr command stdout discovered during the required Docker matrix

## Validation

- Linux Docker daemon-core: 537 passed, 24 ignored (`--test-threads=1`)
- Linux Docker focused streaming/watchdog/parser tests passed
- Linux Docker clippy passed for changed crates (allowing only pre-existing Rust 1.94 lints)
- native Windows `soldr cargo check -p zccache-daemon-core --features test-support --all-targets`
- full Linux Docker 2-fixture x 4-scenario matrix passed: 9.49x-24.78x, all infrastructure-valid, zero aborts/timeouts/no-cache retries/daemon fallbacks

Closes #937