### PR TITLE
fix: preserve cross-target output and isolate host-counter tests

### DIFF
--- a/crates/zccache-compiler/src/parse_rustc.rs
+++ b/crates/zccache-compiler/src/parse_rustc.rs
@@ -39,8 +39,11 @@ fn rustc_proc_macro_filename(crate_name: &str, extra: &str) -> String {
 
 /// Host executable file-name pattern for `--crate-type bin`. Windows
 /// adds `.exe`; unix has no extension.
-fn rustc_bin_filename(crate_name: &str, extra: &str) -> String {
-    if cfg!(target_os = "windows") {
+fn rustc_bin_filename(crate_name: &str, extra: &str, target: Option<&str>) -> String {
+    let windows_target = target
+        .map(|triple| triple.split('-').any(|part| part == "windows"))
+        .unwrap_or(cfg!(target_os = "windows"));
+    if windows_target {
         format!("{crate_name}{extra}.exe")
     } else {
         format!("{crate_name}{extra}")
@@ -87,6 +90,7 @@ pub(crate) fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedI
     let mut out_dir: Option<String> = None;
     let mut crate_name: Option<String> = None;
     let mut extra_filename: Option<String> = None;
+    let mut target: Option<&str> = None;
     let mut emit_types: Vec<String> = Vec::new();
     let mut explicit_link_output: Option<String> = None;
     let mut explicit_output: Option<String> = None;
@@ -171,6 +175,19 @@ pub(crate) fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedI
             }
         } else if let Some(val) = arg.strip_prefix("--out-dir=") {
             out_dir = Some(val.to_string());
+            i += 1;
+            continue;
+        }
+
+        // --target <triple> or --target=<triple>
+        if arg == "--target" {
+            if let Some(next) = args.get(i + 1) {
+                target = Some(next.as_str());
+                i += 2;
+                continue;
+            }
+        } else if let Some(val) = arg.strip_prefix("--target=") {
+            target = Some(val);
             i += 1;
             continue;
         }
@@ -323,7 +340,7 @@ pub(crate) fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedI
         } else if is_proc_macro {
             rustc_proc_macro_filename(name, suffix)
         } else if is_bin {
-            rustc_bin_filename(name, suffix)
+            rustc_bin_filename(name, suffix, target)
         } else if crate_types.iter().any(|t| t == "staticlib") {
             format!("lib{name}{suffix}.a")
         } else {
@@ -358,7 +375,7 @@ pub(crate) fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedI
         } else if is_proc_macro {
             rustc_proc_macro_filename(name, "")
         } else if is_bin {
-            rustc_bin_filename(name, "")
+            rustc_bin_filename(name, "", target)
         } else if crate_types.iter().any(|t| t == "staticlib") {
             format!("lib{name}.a")
         } else {

--- a/crates/zccache-compiler/src/tests/rustc.rs
+++ b/crates/zccache-compiler/src/tests/rustc.rs
@@ -124,6 +124,33 @@ fn rustc_bin_primary_output_uses_executable_extension() {
 }
 
 #[test]
+fn rustc_cross_windows_bin_uses_executable_extension() {
+    let result = parse_invocation(
+        "rustc",
+        &args(&[
+            "--target",
+            "x86_64-pc-windows-msvc",
+            "--crate-name",
+            "soldr",
+            "--crate-type",
+            "bin",
+            "--out-dir",
+            "/tmp/target/deps",
+            "/path/to/main.rs",
+        ]),
+    );
+    let cc = match result {
+        ParsedInvocation::Cacheable(c) => c,
+        other => panic!("expected cacheable, got: {other:?}"),
+    };
+    assert!(
+        cc.output_file.to_string_lossy().ends_with("soldr.exe"),
+        "cross-target Windows bins must use .exe: {}",
+        cc.output_file.to_string_lossy()
+    );
+}
+
+#[test]
 fn rustc_dylib_is_non_cacheable() {
     let result = parse_invocation("rustc", &args(&["--crate-type", "dylib", "src/lib.rs"]));
     assert!(matches!(result, ParsedInvocation::NonCacheable { .. }));

--- a/crates/zccache-daemon-core/src/daemon/process.rs
+++ b/crates/zccache-daemon-core/src/daemon/process.rs
@@ -222,7 +222,7 @@ impl CompilePriority {
         let cpu_usage_percent = matches!(self, Self::Auto)
             .then(current_cpu_usage_percent)
             .flatten();
-        let in_flight = current_in_flight_compiles().saturating_add(current_host_in_flight());
+        let in_flight = total_in_flight(current_in_flight_compiles());
         self.resolve_with_cpu_usage_and_ci(cpu_usage_percent, is_ci_host().is_some(), in_flight)
     }
 
@@ -245,9 +245,7 @@ impl CompilePriority {
         let cpu_usage_percent = matches!(self, Self::Auto)
             .then(current_cpu_usage_percent)
             .flatten();
-        let in_flight = ticket
-            .in_flight_before()
-            .saturating_add(current_host_in_flight());
+        let in_flight = total_in_flight(ticket.in_flight_before());
         let decision = self.resolve_with_cpu_usage_and_ci(
             cpu_usage_percent,
             is_ci_host().is_some(),
@@ -482,6 +480,10 @@ fn current_host_in_flight() -> usize {
         .as_ref()
         .map(|counter| counter.load(Ordering::Acquire))
         .unwrap_or(0)
+}
+
+fn total_in_flight(zccache_in_flight: usize) -> usize {
+    zccache_in_flight.saturating_add(current_host_in_flight())
 }
 
 /// Register a host-supplied in-flight counter (zccache#924). Called
@@ -1137,8 +1139,8 @@ mod tests {
         let _registration_guard = register_host_in_flight_counter(Arc::clone(&counter));
         assert_eq!(current_host_in_flight(), 5);
 
-        let summed = current_in_flight_compiles().saturating_add(current_host_in_flight());
-        assert!(summed >= 5, "host counter must be summed into in-flight");
+        let summed = total_in_flight(0);
+        assert_eq!(summed, 5, "host counter must be summed into in-flight");
         let decision =
             CompilePriority::Auto.resolve_with_cpu_usage_and_ci(Some(10.0), false, summed);
         assert_eq!(
@@ -1151,11 +1153,12 @@ mod tests {
         // sees the change.
         counter.store(0, Ordering::Release);
         assert_eq!(current_host_in_flight(), 0);
-        let summed = current_in_flight_compiles().saturating_add(current_host_in_flight());
+        let summed = total_in_flight(0);
         let decision =
             CompilePriority::Auto.resolve_with_cpu_usage_and_ci(Some(10.0), false, summed);
-        // With host_in_flight = 0 and no concurrent zccache ticket held,
-        // the summed count is 0 and interactive Auto picks Normal.
+        // The injected zccache count is deliberately 0, so unrelated
+        // concurrent tests holding real compile tickets cannot affect this
+        // host-counter contract.
         assert_eq!(
             decision.effective,
             CompilePriority::Normal,
@@ -1197,7 +1200,7 @@ mod tests {
         // CI runners and interactive hosts.
         let counter = Arc::new(AtomicUsize::new(usize::MAX));
         let _guard = register_host_in_flight_counter(Arc::clone(&counter));
-        let summed = 1usize.saturating_add(current_host_in_flight());
+        let summed = total_in_flight(1);
         assert_eq!(
             summed,
             usize::MAX,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -1,8 +1,8 @@
 //! Ephemeral link/archive request handler.
 
-use super::*;
 use super::link_hash::*;
 use super::link_process::*;
+use super::*;
 
 fn publish_and_materialize_staged_link(
     state: &SharedState,

--- a/crates/zccache-daemon-core/src/daemon/server/link_hash.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/link_hash.rs
@@ -74,9 +74,7 @@ pub(super) fn archive_hash_cache_is_cold(
             .any(|input| metadata.get_cached_hash(input).is_none())
 }
 
-pub(super) fn discard_speculative_archive(
-    speculative: &mut Option<CompletedSpeculativeArchive>,
-) {
+pub(super) fn discard_speculative_archive(speculative: &mut Option<CompletedSpeculativeArchive>) {
     if let Some(speculative) = speculative.take() {
         let _ = speculative.plan.cleanup();
     }

--- a/crates/zccache-daemon-core/src/daemon/server/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/mod.rs
@@ -132,8 +132,8 @@ mod in_flight;
 mod inner_trace;
 mod keys;
 mod lifecycle;
-mod link_helpers;
 mod link_hash;
+mod link_helpers;
 mod link_process;
 mod loaders;
 mod pch;
@@ -165,13 +165,13 @@ use handle_compile_ephemeral::*;
 use handle_compile_multi::handle_compile_multi;
 use handle_exec::handle_generic_tool_exec;
 use handle_link::handle_link_ephemeral;
-#[cfg(test)]
-use link_process::run_post_link_deploy_hook;
 use handle_release_worktree_handles::handle_release_worktree_handles;
 use in_flight::*;
 use keys::*;
 use lifecycle::*;
 use link_helpers::*;
+#[cfg(test)]
+use link_process::run_post_link_deploy_hook;
 use pch::*;
 use persist::*;
 


### PR DESCRIPTION
## Summary

- restore target-aware .exe output naming for Linux-hosted Windows rustc invocations
- centralize embedded-host and zccache in-flight accounting
- isolate the host-counter priority test from unrelated parallel compile tickets

## Why

The Windows output fix existed only on the soldr-pinned side branch, while current main contains 16 newer archive and embedded-service improvements. Current main also fails two Linux test lanes because the host-counter test assumes the process-global compile count is zero.

## Validation

- zccache-compiler Windows cross-target regression: passed
- zccache-daemon-core full library suite: 528 passed, 25 ignored
- rustfmt: clean
- git diff --check: clean
- targeted clippy reached an unrelated pre-existing large_enum_variant failure in zccache-depgraph

Coordinated with zackees/soldr#1707. This PR must merge before soldr updates its submodule pin.