### PR TITLE
perf: add standalone Linux Docker campaign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Thumbs.db
 
 # Local perf harness scratch (ci/perf_local.py + ci/docker/* output)
 .perf-local/
+.perf-standalone/
 
 # Local bench scratch (Stop-hook cold-cache benchmark output + helper script)
 tasks/bench-output/

--- a/PERF.md
+++ b/PERF.md
@@ -161,6 +161,37 @@ uv run --no-project ci/perf_local.py test
 
 See [`ci/docker/README.md`](ci/docker/README.md) for image and volume layout.
 
+## Standalone compiler campaign
+
+The standalone campaign runs the registered C, C++, Emscripten, and Rust
+`perf_bench_test` scenarios in one pinned Linux image. The image uses soldr to
+prepare Rust into a cached Docker layer, then seeds soldr/Cargo/rustup state
+into a named runtime volume. Source is mounted read-only, and timed samples
+invoke the prebuilt benchmark binary directly.
+
+Run one diagnostic sample while iterating:
+
+```powershell
+uv run --no-project python -m ci.perf_standalone --language c --test perf_c_zccache_vs_bare --attempts 1 --rebuild-image
+```
+
+Run the complete five-sample campaign from a clean committed checkout:
+
+```powershell
+uv run --no-project python -m ci.perf_standalone
+```
+
+Resume an interrupted campaign without mixing commit, image, fixture, host, or
+attempt identities:
+
+```powershell
+uv run --no-project python -m ci.perf_standalone --resume
+```
+
+Evidence is retained under `.perf-standalone/results/`. Each campaign has a
+JSON index and Markdown table linking raw logs, parsed rows, cache phase/byte
+telemetry, command provenance, and resource usage for every test.
+
 ## Cross-platform responsibility
 
 Linux Docker is the sanctioned timing environment. Native Windows, macOS, and

--- a/ci/docker/standalone-perf.Dockerfile
+++ b/ci/docker/standalone-perf.Dockerfile
@@ -1,0 +1,83 @@
+# syntax=docker/dockerfile:1.7
+
+FROM emscripten/emsdk:3.1.74@sha256:af45409f3199d88db4b1b03af0098532c8fb33a375ac257463eeb0a622870d06
+
+ARG RUST_VERSION=1.94.1
+ARG CLANG_MAJOR=14
+ARG SCCACHE_VERSION=0.10.0
+ARG SCCACHE_SHA256=1fbb35e135660d04a2d5e42b59c7874d39b3deb17de56330b25b713ec59f849b
+ARG SOLDR_VERSION=0.8.16
+ARG SOLDR_SHA256=95e338a6a1dd941c248f95148557c434ce735392cba867007b7997d531200830
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    CARGO_TARGET_DIR=/target \
+    RUST_VERSION=${RUST_VERSION} \
+    SOLDR_COMMAND_OUTPUT_TIMEOUT_SECS=600 \
+    PATH=/emsdk:/emsdk/upstream/emscripten:/usr/local/bin:${PATH}
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        clang-14 \
+        curl \
+        git \
+        jq \
+        libssl-dev \
+        llvm-14 \
+        pkg-config \
+        procps \
+        time \
+        zstd \
+ && rm -rf /var/lib/apt/lists/* \
+ && ln -sf /usr/bin/clang-${CLANG_MAJOR} /usr/local/bin/clang \
+ && ln -sf /usr/bin/clang++-${CLANG_MAJOR} /usr/local/bin/clang++ \
+ && ln -sf /usr/bin/llvm-ar-${CLANG_MAJOR} /usr/local/bin/llvm-ar
+
+RUN curl --fail --location --silent --show-error \
+        "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+        -o /tmp/sccache.tar.gz \
+ && echo "${SCCACHE_SHA256}  /tmp/sccache.tar.gz" | sha256sum --check - \
+ && tar -xzf /tmp/sccache.tar.gz -C /tmp \
+ && install -m 0755 \
+        "/tmp/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache" \
+        /usr/local/bin/sccache \
+ && rm -rf /tmp/sccache*
+
+RUN curl --fail --location --silent --show-error \
+        "https://github.com/zackees/soldr/releases/download/v${SOLDR_VERSION}/soldr-v${SOLDR_VERSION}-x86_64-unknown-linux-musl.tar.zst" \
+        -o /tmp/soldr.tar.zst \
+ && echo "${SOLDR_SHA256}  /tmp/soldr.tar.zst" | sha256sum --check - \
+ && mkdir /tmp/soldr \
+ && tar --zstd -xf /tmp/soldr.tar.zst -C /tmp/soldr \
+ && install -m 0755 "$(find /tmp/soldr -type f -name soldr -print -quit)" /usr/local/bin/soldr \
+ && rm -rf /tmp/soldr /tmp/soldr.tar.zst
+
+# The musl soldr release runs on this older glibc base. Tell its managed
+# rustup to install the native GNU host toolchain, then cache that complete
+# soldr-owned state in an image layer for runtime volume seeding.
+COPY rust-toolchain.toml /tmp/soldr-bootstrap/rust-toolchain.toml
+RUN HOME=/opt/soldr-seed soldr bootstrap \
+ && HOME=/opt/soldr-seed soldr rustup set default-host x86_64-unknown-linux-gnu \
+ && cd /tmp/soldr-bootstrap \
+ && HOME=/opt/soldr-seed soldr toolchain prepare \
+ && HOME=/opt/soldr-seed soldr cargo --version \
+ && HOME=/opt/soldr-seed soldr rustc --version \
+ && rm -rf /tmp/soldr-bootstrap
+ENV SOLDR_VERSION=${SOLDR_VERSION}
+RUN touch "/opt/soldr-seed/.standalone-toolchain-${SOLDR_VERSION}-${RUST_VERSION}"
+
+COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /usr/local/bin/uv
+COPY ci/docker/standalone_perf_entrypoint.sh /usr/local/bin/standalone-perf
+RUN chmod 0755 /usr/local/bin/standalone-perf
+
+ARG CAMPAIGN_RECIPE_SHA=unknown
+LABEL org.zccache.campaign.rust="${RUST_VERSION}" \
+      org.zccache.campaign.clang="${CLANG_MAJOR}" \
+      org.zccache.campaign.sccache="${SCCACHE_VERSION}" \
+      org.zccache.campaign.soldr="${SOLDR_VERSION}" \
+      org.zccache.campaign.emsdk="3.1.74" \
+      org.zccache.campaign.recipe="${CAMPAIGN_RECIPE_SHA}"
+
+WORKDIR /src
+ENTRYPOINT ["/usr/local/bin/standalone-perf"]

--- a/ci/docker/standalone_perf_entrypoint.sh
+++ b/ci/docker/standalone_perf_entrypoint.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+require_mount() {
+    local path="$1"
+    if [[ ! -e "${path}" ]]; then
+        echo "ERROR: required mount missing: ${path}" >&2
+        exit 2
+    fi
+}
+
+require_mount /src/Cargo.toml
+require_mount /artifacts
+require_mount /results
+
+seed_soldr_home() {
+    local soldr_root="${HOME}/.soldr"
+    local sentinel=".standalone-toolchain-${SOLDR_VERSION}-${RUST_VERSION}"
+    if [[ ! -f "/opt/soldr-seed/${sentinel}" ]]; then
+        echo "ERROR: cached soldr toolchain seed is incomplete" >&2
+        exit 2
+    fi
+    if [[ ! -f "${soldr_root}/${sentinel}" ]]; then
+        mkdir -p "${soldr_root}"
+        find "${soldr_root}" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+        cp -a /opt/soldr-seed/.soldr/. "${soldr_root}/"
+        touch "${soldr_root}/${sentinel}"
+    fi
+    export CARGO_HOME="${soldr_root}/cargo"
+    export RUSTUP_HOME="${soldr_root}/rustup"
+}
+
+command="${1:-}"
+case "${command}" in
+    build)
+        seed_soldr_home
+        cd /src
+        soldr cargo test -p zccache --test perf_bench_test --release --no-run
+        benchmark="$({
+            find /target/release/deps -maxdepth 1 -type f \
+                -name 'perf_bench_test-*' -perm /111 -printf '%T@ %p\n'
+        } | sort -nr | head -n 1 | cut -d' ' -f2-)"
+        if [[ -z "${benchmark}" || ! -x "${benchmark}" ]]; then
+            echo "ERROR: perf_bench_test executable was not produced" >&2
+            exit 2
+        fi
+        install -m 0755 "${benchmark}" /artifacts/perf_bench_test
+        ;;
+    verify)
+        seed_soldr_home
+        benchmark_sha256=""
+        if [[ -f /artifacts/perf_bench_test ]]; then
+            benchmark_sha256="$(sha256sum /artifacts/perf_bench_test | cut -d' ' -f1)"
+        fi
+        jq -n \
+            --arg rustc "$(soldr rustc --version | head -n 1)" \
+            --arg clang "$(clang++ --version | head -n 1)" \
+            --arg sccache "$(sccache --version | head -n 1)" \
+            --arg emscripten "$(em++ --version | head -n 1)" \
+            --arg soldr "$(soldr version | head -n 1)" \
+            --arg benchmark_sha256 "${benchmark_sha256}" \
+            '{rustc: $rustc, clang: $clang, sccache: $sccache, emscripten: $emscripten, soldr: $soldr, benchmark_sha256: $benchmark_sha256}'
+        ;;
+    run)
+        require_mount /artifacts/perf_bench_test
+        language="${2:?language is required}"
+        test_name="${3:?test name is required}"
+        attempts="${4:?attempt count is required}"
+        cd /src
+        /usr/bin/time -v -o /results/resource-usage.txt \
+            uv run --no-project python -m ci.perf_guard \
+                --run-benchmarks \
+                --language "${language}" \
+                --test "${test_name}" \
+                --attempts "${attempts}" \
+                --collect-all-attempts \
+                --benchmark-binary /artifacts/perf_bench_test \
+                --output-dir /results
+        ;;
+    *)
+        echo "usage: standalone-perf {build|verify|run <language> <test> <attempts>}" >&2
+        exit 2
+        ;;
+esac

--- a/ci/perf_standalone.py
+++ b/ci/perf_standalone.py
@@ -1,0 +1,834 @@
+"""Run the registered standalone performance suite in pinned Linux Docker."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from ci import benchmark_stats
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = REPO_ROOT / "ci/docker/standalone-perf.Dockerfile"
+IMAGE = "zccache-standalone-perf:1"
+DEFAULT_RESULTS_ROOT = REPO_ROOT / ".perf-standalone/results"
+DEFAULT_ATTEMPTS = 5
+BUILD_VOLUMES = {
+    "zccache-standalone-soldr-home": "/root/.soldr",
+    "zccache-standalone-target": "/target",
+    "zccache-standalone-artifacts": "/artifacts",
+}
+TOOL_VERSION_MARKERS = {
+    "rustc": "rustc 1.94.1",
+    "clang": "clang version 14.",
+    "sccache": "sccache 0.10.0",
+    "emscripten": "3.1.74",
+    "soldr": "0.8.16",
+}
+COMPETING_CONTAINERS = ("perf", "docker-build-soldr")
+COMPETING_PROCESSES = {
+    "cargo",
+    "clang",
+    "clang++",
+    "em++",
+    "emcc",
+    "perf_bench_test",
+    "rustc",
+    "sccache",
+}
+BUSY_CPU_PERCENT = 5.0
+RECIPE_FILES = (
+    DOCKERFILE,
+    REPO_ROOT / "ci/docker/standalone_perf_entrypoint.sh",
+    REPO_ROOT / "rust-toolchain.toml",
+)
+
+
+def campaign_inventory() -> list[tuple[str, str]]:
+    return [
+        (language, test_name)
+        for language in benchmark_stats.LANGUAGES
+        for test_name in benchmark_stats.BENCHMARK_TESTS_BY_LANGUAGE[language]
+    ]
+
+
+def recipe_sha256() -> str:
+    digest = hashlib.sha256()
+    for path in RECIPE_FILES:
+        digest.update(path.relative_to(REPO_ROOT).as_posix().encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def docker_build_command() -> list[str]:
+    return [
+        "docker",
+        "build",
+        "--build-arg",
+        f"CAMPAIGN_RECIPE_SHA={recipe_sha256()}",
+        "--file",
+        str(DOCKERFILE),
+        "--tag",
+        IMAGE,
+        str(REPO_ROOT),
+    ]
+
+
+def default_campaign_dir(
+    commit: str,
+    language: str | None,
+    test_name: str | None,
+    attempts: int,
+) -> Path:
+    selection = "full" if language is None else f"{language}-{test_name or 'all'}"
+    slug = re.sub(r"[^a-z0-9]+", "-", selection.lower()).strip("-")
+    return DEFAULT_RESULTS_ROOT / f"{commit[:12]}-{slug}-a{attempts}"
+
+
+def _mount(source: str | Path, destination: str, *, kind: str, readonly: bool) -> str:
+    value = f"type={kind},src={source},dst={destination}"
+    return value + (",readonly" if readonly else "")
+
+
+def docker_run_command(
+    *,
+    repo_root: Path,
+    results_dir: Path,
+    container_name: str,
+    entrypoint_args: list[str],
+    artifacts_read_only: bool = True,
+) -> list[str]:
+    command = ["docker", "run", "--rm", "--name", container_name]
+    command.extend(
+        [
+            "--mount",
+            _mount(repo_root.resolve(), "/src", kind="bind", readonly=True),
+            "--mount",
+            _mount(results_dir.resolve(), "/results", kind="bind", readonly=False),
+        ]
+    )
+    for volume, destination in BUILD_VOLUMES.items():
+        command.extend(
+            [
+                "--mount",
+                _mount(
+                    volume,
+                    destination,
+                    kind="volume",
+                    readonly=destination == "/artifacts" and artifacts_read_only,
+                ),
+            ]
+        )
+    command.extend([IMAGE, *entrypoint_args])
+    return command
+
+
+def validate_tool_versions(versions: dict[str, str]) -> None:
+    for tool, marker in TOOL_VERSION_MARKERS.items():
+        actual = versions.get(tool)
+        if not isinstance(actual, str) or marker not in actual:
+            raise ValueError(
+                f"{tool} version mismatch: expected marker {marker!r}, got {actual!r}"
+            )
+
+
+def validate_resume_identity(
+    existing: dict[str, Any], current: dict[str, Any]
+) -> None:
+    for field in (
+        "commit",
+        "image_digest",
+        "host_fingerprint",
+        "inventory",
+        "attempts",
+        "fixture",
+    ):
+        if existing.get(field) != current.get(field):
+            raise ValueError(
+                f"resume identity mismatch for {field}: "
+                f"{existing.get(field)!r} != {current.get(field)!r}"
+            )
+
+
+def validate_sample_summary(summary: dict[str, Any], expected_attempts: int) -> None:
+    if summary.get("passed") is not True:
+        raise ValueError("sample did not pass the strict perf guard")
+    if summary.get("attempt_policy") != "all-required":
+        raise ValueError("sample was not collected with the all-required policy")
+    if summary.get("attempt_count") != expected_attempts:
+        raise ValueError("sample attempt count is incomplete")
+    if summary.get("command_failures"):
+        raise ValueError("sample contains command failures")
+    if summary.get("missing_requirements"):
+        raise ValueError("sample contains missing benchmark rows")
+    infrastructure = summary.get("infrastructure")
+    if not isinstance(infrastructure, dict) or infrastructure.get("valid") is not True:
+        raise ValueError("sample infrastructure is invalid")
+    if infrastructure.get("invalid_reasons"):
+        raise ValueError("sample contains infrastructure invalidity")
+    if infrastructure.get("fallback_count") != 0:
+        raise ValueError("sample contains fallback telemetry")
+    telemetry = infrastructure.get("cache_telemetry")
+    if not isinstance(telemetry, dict) or not telemetry.get("rows"):
+        raise ValueError("sample contains no cache hit/miss telemetry")
+    if telemetry.get("fallback_count") != 0:
+        raise ValueError("sample cache telemetry contains a fallback")
+    cache_byte_fields = (
+        "bare_cache_bytes",
+        "sccache_cache_bytes",
+        "zccache_cache_bytes",
+    )
+    for row in telemetry["rows"]:
+        if row.get("cache_phase") not in {"warm-hit-path", "cold-miss-path"}:
+            raise ValueError("sample row contains an unknown cache phase")
+        if row.get("cache_bytes_reported") is not True:
+            raise ValueError("sample row does not report cache bytes")
+        if any(not isinstance(row.get(field), int) for field in cache_byte_fields):
+            raise ValueError("sample row contains invalid cache-byte telemetry")
+    statuses = summary.get("statuses")
+    if not isinstance(statuses, list) or not statuses:
+        raise ValueError("sample contains no scenario statuses")
+    for status in statuses:
+        samples = status.get("samples")
+        if not isinstance(samples, list) or len(samples) != expected_attempts:
+            raise ValueError("scenario has an incomplete sample distribution")
+        for sample in samples:
+            if not sample.get("attempt_json") or not sample.get("raw_log"):
+                raise ValueError("scenario sample is missing raw artifact references")
+
+
+def busy_reasons(
+    containers: list[tuple[str, float]], process_names: list[str]
+) -> list[str]:
+    reasons = []
+    for name, cpu_percent in containers:
+        lowered = name.lower()
+        if any(marker in lowered for marker in COMPETING_CONTAINERS) and cpu_percent >= BUSY_CPU_PERCENT:
+            reasons.append(f"container {name} is using {cpu_percent:.2f}% CPU")
+    for name in sorted(set(process_names)):
+        normalized = Path(name).stem.lower()
+        if normalized in COMPETING_PROCESSES:
+            reasons.append(f"host process {name} is active")
+    return reasons
+
+
+def artifact_paths(campaign_dir: Path, sample_dir: Path) -> dict[str, Any]:
+    def relative(path: Path) -> str:
+        return path.relative_to(campaign_dir).as_posix()
+
+    return {
+        "summary_json": relative(sample_dir / "perf-guard-summary.json"),
+        "summary_markdown": relative(sample_dir / "perf-guard-summary.md"),
+        "result": relative(sample_dir / "perf-guard-result.txt"),
+        "resource_usage": relative(sample_dir / "resource-usage.txt"),
+        "raw_logs": [relative(path) for path in sorted(sample_dir.glob("attempt-*.log"))],
+        "attempt_json": [
+            relative(path) for path in sorted(sample_dir.glob("attempt-*.json"))
+        ],
+    }
+
+
+def validate_completed_results(
+    campaign_dir: Path, campaign: dict[str, Any], expected_attempts: int
+) -> None:
+    for item in campaign.get("results", []):
+        artifacts = item.get("artifacts")
+        if not isinstance(artifacts, dict):
+            raise ValueError("completed campaign result has no artifact index")
+        raw_logs = artifacts.get("raw_logs")
+        attempt_json = artifacts.get("attempt_json")
+        if not isinstance(raw_logs, list) or not isinstance(attempt_json, list):
+            raise ValueError("completed campaign result has invalid sample artifacts")
+        if len(raw_logs) != expected_attempts or len(attempt_json) != expected_attempts:
+            raise ValueError("completed campaign result has incomplete sample artifacts")
+        paths = [
+            artifacts.get("summary_json"),
+            artifacts.get("summary_markdown"),
+            artifacts.get("result"),
+            artifacts.get("resource_usage"),
+            *raw_logs,
+            *attempt_json,
+        ]
+        if any(not isinstance(path, str) for path in paths):
+            raise ValueError("completed campaign result has an invalid artifact path")
+        missing = [path for path in paths if not (campaign_dir / path).is_file()]
+        if missing:
+            raise ValueError(
+                "completed campaign result is missing artifacts: " + ", ".join(missing)
+            )
+        validate_sample_summary(
+            _load_json(campaign_dir / artifacts["summary_json"]), expected_attempts
+        )
+
+
+def _run(
+    command: list[str],
+    *,
+    capture: bool = False,
+    check: bool = True,
+    timeout_seconds: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    print("+ " + subprocess.list2cmdline(command), flush=True)
+    return subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=capture,
+        check=check,
+        timeout=timeout_seconds,
+    )
+
+
+def _git_output(*args: str) -> str:
+    return _run(["git", *args], capture=True).stdout.strip()
+
+
+def _ensure_clean_checkout() -> str:
+    if _git_output("status", "--porcelain"):
+        raise RuntimeError("standalone campaign requires a clean committed checkout")
+    return _git_output("rev-parse", "HEAD")
+
+
+def _build_image(rebuild: bool) -> None:
+    inspected = subprocess.run(
+        [
+            "docker",
+            "image",
+            "inspect",
+            "--format",
+            '{{index .Config.Labels "org.zccache.campaign.recipe"}}',
+            IMAGE,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    current_recipe = inspected.stdout.strip() if inspected.returncode == 0 else None
+    if rebuild or current_recipe != recipe_sha256():
+        _run(docker_build_command())
+
+
+def _ensure_volumes() -> None:
+    for volume in BUILD_VOLUMES:
+        _run(["docker", "volume", "create", volume], capture=True)
+
+
+def _image_digest() -> str:
+    return _run(
+        ["docker", "image", "inspect", "--format", "{{.Id}}", IMAGE],
+        capture=True,
+    ).stdout.strip()
+
+
+def _container_stats() -> list[tuple[str, float]]:
+    try:
+        output = _run(
+            [
+                "docker",
+                "stats",
+                "--no-stream",
+                "--format",
+                "{{.Name}}|{{.CPUPerc}}",
+            ],
+            capture=True,
+            timeout_seconds=15,
+        ).stdout
+    except subprocess.TimeoutExpired as error:
+        raise RuntimeError("Docker container activity probe timed out") from error
+    parsed = []
+    for line in output.splitlines():
+        name, separator, percent = line.partition("|")
+        if separator:
+            try:
+                parsed.append((name, float(percent.rstrip("%"))))
+            except ValueError:
+                continue
+    return parsed
+
+
+def _process_names() -> list[str]:
+    if os.name == "nt":
+        try:
+            result = subprocess.run(
+                ["tasklist", "/fo", "csv", "/nh"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise RuntimeError("host process enumeration timed out") from error
+        if result.returncode != 0 or not result.stdout.strip():
+            raise RuntimeError("host process enumeration failed")
+        output = result.stdout
+        return [row[0] for row in csv.reader(output.splitlines()) if row]
+    output = subprocess.run(
+        ["ps", "-eo", "comm="],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def active_windows_process_names(
+    first: dict[int, tuple[str, float]],
+    second: dict[int, tuple[str, float]],
+    minimum_cpu_seconds: float = 0.001,
+) -> list[str]:
+    cargo_present = any(
+        Path(name).stem.lower() == "cargo" for name, _ in second.values()
+    )
+    active = []
+    for pid, (name, cpu_seconds) in second.items():
+        normalized = Path(name).stem.lower()
+        if normalized not in COMPETING_PROCESSES:
+            continue
+        if normalized != "rustc":
+            active.append(name)
+            continue
+        previous = first.get(pid)
+        cpu_progress = previous is None or (
+            cpu_seconds - previous[1] >= minimum_cpu_seconds
+        )
+        if cargo_present or cpu_progress:
+            active.append(name)
+    return active
+
+
+def _windows_process_snapshot() -> dict[int, tuple[str, float]] | None:
+    import ctypes
+    from ctypes import wintypes
+
+    try:
+        result = subprocess.run(
+            ["tasklist", "/fo", "csv", "/nh"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetProcessTimes.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+    ]
+    kernel32.GetProcessTimes.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    snapshot = {}
+    for row in csv.reader(result.stdout.splitlines()):
+        if len(row) < 2 or Path(row[0]).stem.lower() not in COMPETING_PROCESSES:
+            continue
+        try:
+            pid = int(row[1])
+        except ValueError:
+            continue
+        handle = kernel32.OpenProcess(0x1000, False, pid)
+        if not handle:
+            continue
+        try:
+            creation = wintypes.FILETIME()
+            exit_time = wintypes.FILETIME()
+            kernel = wintypes.FILETIME()
+            user = wintypes.FILETIME()
+            if not kernel32.GetProcessTimes(
+                handle,
+                ctypes.byref(creation),
+                ctypes.byref(exit_time),
+                ctypes.byref(kernel),
+                ctypes.byref(user),
+            ):
+                continue
+            kernel_ticks = kernel.dwLowDateTime | (kernel.dwHighDateTime << 32)
+            user_ticks = user.dwLowDateTime | (user.dwHighDateTime << 32)
+            snapshot[pid] = (row[0], (kernel_ticks + user_ticks) / 10_000_000)
+        finally:
+            kernel32.CloseHandle(handle)
+    return snapshot
+
+
+def _active_process_names() -> list[str]:
+    if os.name != "nt":
+        return _process_names()
+    names = _process_names()
+    competing = [
+        name
+        for name in names
+        if Path(name).stem.lower() in COMPETING_PROCESSES
+    ]
+    if not any(Path(name).stem.lower() == "rustc" for name in competing):
+        return competing
+    if any(Path(name).stem.lower() != "rustc" for name in competing):
+        return competing
+    first = _windows_process_snapshot()
+    if first is None:
+        return competing
+    started = time.monotonic()
+    time.sleep(1.0)
+    second = _windows_process_snapshot()
+    if second is None:
+        return competing
+    elapsed = time.monotonic() - started
+    minimum_cpu_seconds = (
+        elapsed * max(os.cpu_count() or 1, 1) * BUSY_CPU_PERCENT / 100.0
+    )
+    return active_windows_process_names(first, second, minimum_cpu_seconds)
+
+
+def _require_quiet_host(samples: int = 3, delay_seconds: float = 2.0) -> None:
+    for sample in range(samples):
+        process_reasons = busy_reasons([], _active_process_names())
+        if process_reasons:
+            raise RuntimeError("host is busy: " + "; ".join(process_reasons))
+        reasons = busy_reasons(_container_stats(), [])
+        if reasons:
+            raise RuntimeError("host is busy: " + "; ".join(reasons))
+        if sample + 1 < samples:
+            time.sleep(delay_seconds)
+
+
+def stable_docker_identity(info: dict[str, Any]) -> dict[str, Any]:
+    fields = (
+        "ID",
+        "Name",
+        "ServerVersion",
+        "Driver",
+        "OperatingSystem",
+        "OSType",
+        "Architecture",
+        "NCPU",
+        "MemTotal",
+        "DockerRootDir",
+        "KernelVersion",
+    )
+    return {field: info.get(field) for field in fields}
+
+
+def _host_identity() -> dict[str, Any]:
+    docker = _run(
+        ["docker", "info", "--format", "{{json .}}"], capture=True
+    ).stdout.strip()
+    payload = {
+        "node": platform.node(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "cpu_count": os.cpu_count(),
+        "docker": stable_docker_identity(json.loads(docker)),
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    payload["fingerprint"] = hashlib.sha256(canonical.encode()).hexdigest()
+    return payload
+
+
+def _build_benchmark(campaign_dir: Path) -> list[str]:
+    command = docker_run_command(
+        repo_root=REPO_ROOT,
+        results_dir=campaign_dir,
+        container_name="zccache-standalone-build",
+        entrypoint_args=["build"],
+        artifacts_read_only=False,
+    )
+    _run(command)
+    return command
+
+
+def _tool_versions(campaign_dir: Path) -> tuple[dict[str, str], str, list[str]]:
+    command = docker_run_command(
+        repo_root=REPO_ROOT,
+        results_dir=campaign_dir,
+        container_name="zccache-standalone-verify",
+        entrypoint_args=["verify"],
+    )
+    versions = json.loads(_run(command, capture=True).stdout)
+    validate_tool_versions(versions)
+    benchmark_sha256 = versions.pop("benchmark_sha256", "")
+    if not isinstance(benchmark_sha256, str) or not re.fullmatch(
+        r"[0-9a-f]{64}", benchmark_sha256
+    ):
+        raise ValueError("benchmark fixture SHA-256 is missing or invalid")
+    return versions, benchmark_sha256, command
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _peak_rss_bytes(path: Path) -> int | None:
+    if not path.is_file():
+        return None
+    match = re.search(
+        r"Maximum resident set size \(kbytes\):\s*(\d+)",
+        path.read_text(encoding="utf-8", errors="replace"),
+    )
+    return int(match.group(1)) * 1024 if match else None
+
+
+def _sample_cache_telemetry(sample_dir: Path) -> dict[str, Any]:
+    rows = []
+    for path in sorted(sample_dir.glob("attempt-*.json")):
+        attempt = _load_json(path)
+        for row in attempt.get("rows", []):
+            if not isinstance(row, dict):
+                continue
+            mode = row.get("mode")
+            cache_phase = {
+                "warm": "warm-hit-path",
+                "cold": "cold-miss-path",
+            }.get(mode, "unknown")
+            rows.append(
+                {
+                    "attempt": attempt.get("attempt"),
+                    "benchmark": row.get("benchmark"),
+                    "scenario": row.get("scenario"),
+                    "cache_phase": cache_phase,
+                    "cache_bytes_reported": row.get("cache_bytes_reported"),
+                    "bare_cache_bytes": row.get("bare_cache_bytes"),
+                    "sccache_cache_bytes": row.get("sccache_cache_bytes"),
+                    "zccache_cache_bytes": row.get("zccache_cache_bytes"),
+                }
+            )
+    return {
+        "warm_hit_path_rows": sum(
+            row["cache_phase"] == "warm-hit-path" for row in rows
+        ),
+        "cold_miss_path_rows": sum(
+            row["cache_phase"] == "cold-miss-path" for row in rows
+        ),
+        "fallback_count": 0,
+        "rows": rows,
+    }
+
+
+def _enrich_summary(
+    path: Path,
+    returncode: int,
+    identity: dict[str, Any],
+    command: list[str],
+    telemetry: dict[str, Any],
+) -> dict[str, Any]:
+    summary = _load_json(path)
+    reasons = []
+    if returncode != 0:
+        reasons.append(f"benchmark container exited with status {returncode}")
+    if summary.get("command_failures"):
+        reasons.append("perf guard reported command failures")
+    if summary.get("missing_requirements"):
+        reasons.append("perf guard reported missing rows")
+    metadata = summary.setdefault("metadata", {})
+    metadata.update(
+        {
+            "git_sha": identity["commit"],
+            "dirty": identity["dirty"],
+            "image_digest": identity["image_digest"],
+            "host_fingerprint": identity["host_fingerprint"],
+            "docker_command": command,
+        }
+    )
+    summary["infrastructure"] = {
+        "valid": not reasons,
+        "invalid_reasons": reasons,
+        "fallback_count": 0,
+        "cache_telemetry": telemetry,
+        "fallback_contract": (
+            "timed phase executes the prebuilt perf_bench_test directly; "
+            "soldr is absent from the timed command path"
+        ),
+    }
+    _write_json(path, summary)
+    return summary
+
+
+def _run_sample(
+    campaign_dir: Path,
+    language: str,
+    test_name: str,
+    attempts: int,
+    identity: dict[str, Any],
+) -> dict[str, Any]:
+    sample_dir = campaign_dir / language.replace("+", "p") / test_name
+    sample_dir.mkdir(parents=True, exist_ok=True)
+    command = docker_run_command(
+        repo_root=REPO_ROOT,
+        results_dir=sample_dir,
+        container_name=f"zccache-standalone-{language.replace('+', 'p')}-{test_name}"[:63],
+        entrypoint_args=["run", language, test_name, str(attempts)],
+    )
+    result = _run(command, check=False)
+    summary_path = sample_dir / "perf-guard-summary.json"
+    if not summary_path.is_file():
+        raise RuntimeError(
+            f"benchmark did not produce {summary_path} (exit={result.returncode})"
+        )
+    telemetry = _sample_cache_telemetry(sample_dir)
+    summary = _enrich_summary(
+        summary_path, result.returncode, identity, command, telemetry
+    )
+    validate_sample_summary(summary, attempts)
+    return {
+        "language": language,
+        "test": test_name,
+        "passed": True,
+        "peak_rss_bytes": _peak_rss_bytes(sample_dir / "resource-usage.txt"),
+        "command": command,
+        "cache_telemetry": telemetry,
+        "artifacts": artifact_paths(campaign_dir, sample_dir),
+    }
+
+
+def _render_markdown(campaign: dict[str, Any]) -> str:
+    lines = [
+        "# Standalone Linux Docker performance campaign",
+        "",
+        f"- Commit: `{campaign['identity']['commit']}`",
+        f"- Image: `{campaign['identity']['image_digest']}`",
+        f"- Attempts per test: {campaign['identity']['attempts']}",
+        f"- Host: `{campaign['identity']['host_fingerprint']}`",
+        "",
+        "| Language | Test | Status | Peak RSS | Summary | Raw logs |",
+        "|---|---|---|---:|---|---|",
+    ]
+    for item in campaign["results"]:
+        rss = item.get("peak_rss_bytes")
+        rss_text = "n/a" if rss is None else f"{rss / 1024 / 1024:.1f} MiB"
+        artifacts = item["artifacts"]
+        log_links = ", ".join(
+            f"[#{index}]({path})"
+            for index, path in enumerate(artifacts["raw_logs"], start=1)
+        )
+        lines.append(
+            f"| {item['language']} | `{item['test']}` | PASS | {rss_text} | "
+            f"[JSON]({artifacts['summary_json']}) | {log_links} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _selected_inventory(language: str | None, test_name: str | None) -> list[tuple[str, str]]:
+    inventory = campaign_inventory()
+    if language:
+        inventory = [item for item in inventory if item[0] == language]
+    if test_name:
+        inventory = [item for item in inventory if item[1] == test_name]
+    if not inventory:
+        raise ValueError("no registered benchmark matches the requested filters")
+    return inventory
+
+
+def run_campaign(args: argparse.Namespace) -> Path:
+    commit = _ensure_clean_checkout()
+    inventory = _selected_inventory(args.language, args.test)
+    _build_image(args.rebuild_image)
+    _ensure_volumes()
+    campaign_dir = (
+        args.output_dir
+        or default_campaign_dir(commit, args.language, args.test, args.attempts)
+    ).resolve()
+    campaign_dir.mkdir(parents=True, exist_ok=True)
+    benchmark_build_command = _build_benchmark(campaign_dir)
+    versions, benchmark_sha256, verify_command = _tool_versions(campaign_dir)
+    host = _host_identity()
+    identity = {
+        "commit": commit,
+        "dirty": False,
+        "image_digest": _image_digest(),
+        "host_fingerprint": host["fingerprint"],
+        "inventory": [list(item) for item in inventory],
+        "attempts": args.attempts,
+        "fixture": {
+            "binary": "perf_bench_test",
+            "sha256": benchmark_sha256,
+        },
+    }
+    identity_path = campaign_dir / "campaign-identity.json"
+    if identity_path.exists():
+        if not args.resume:
+            raise RuntimeError(f"campaign already exists: {campaign_dir}; pass --resume")
+        validate_resume_identity(_load_json(identity_path), identity)
+    else:
+        _write_json(identity_path, identity)
+
+    campaign_path = campaign_dir / "campaign.json"
+    campaign = _load_json(campaign_path) if args.resume and campaign_path.exists() else {
+        "schema_version": 1,
+        "identity": identity,
+        "host": host,
+        "tool_versions": versions,
+        "commands": {
+            "image_build": docker_build_command(),
+            "benchmark_build": benchmark_build_command,
+            "verify": verify_command,
+        },
+        "results": [],
+    }
+    if args.resume:
+        validate_completed_results(campaign_dir, campaign, args.attempts)
+    completed = {(item["language"], item["test"]) for item in campaign["results"]}
+    for language, test_name in inventory:
+        if (language, test_name) in completed:
+            continue
+        _require_quiet_host()
+        item = _run_sample(
+            campaign_dir, language, test_name, args.attempts, identity
+        )
+        campaign["results"].append(item)
+        _write_json(campaign_path, campaign)
+        (campaign_dir / "README.md").write_text(
+            _render_markdown(campaign), encoding="utf-8"
+        )
+    return campaign_dir
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--language", choices=benchmark_stats.LANGUAGES)
+    parser.add_argument("--test")
+    parser.add_argument("--attempts", type=int, default=DEFAULT_ATTEMPTS)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--rebuild-image", action="store_true")
+    args = parser.parse_args()
+    if args.attempts < 1:
+        parser.error("--attempts must be at least 1")
+    if args.test and not args.language:
+        parser.error("--test requires --language")
+    try:
+        output = run_campaign(args)
+    except (RuntimeError, ValueError, subprocess.CalledProcessError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print(f"campaign complete: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tests/test_perf_standalone.py
+++ b/ci/tests/test_perf_standalone.py
@@ -1,0 +1,412 @@
+import json
+
+import pytest
+
+from ci import benchmark_stats, perf_standalone
+
+
+def test_campaign_inventory_matches_registered_benchmarks():
+    expected = [
+        (language, test_name)
+        for language in benchmark_stats.LANGUAGES
+        for test_name in benchmark_stats.BENCHMARK_TESTS_BY_LANGUAGE[language]
+    ]
+
+    assert perf_standalone.campaign_inventory() == expected
+
+
+def test_default_campaign_paths_separate_diagnostics_and_attempt_counts():
+    diagnostic = perf_standalone.default_campaign_dir(
+        "abcdef1234567890", "c++", "perf_response_file", 1
+    )
+    full = perf_standalone.default_campaign_dir(
+        "abcdef1234567890", None, None, 5
+    )
+
+    assert diagnostic.name == "abcdef123456-c-perf-response-file-a1"
+    assert full.name == "abcdef123456-full-a5"
+
+
+def test_docker_recipe_hash_covers_every_image_input():
+    original = perf_standalone.recipe_sha256()
+    assert len(original) == 64
+    command = perf_standalone.docker_build_command()
+
+    assert "--build-arg" in command
+    assert f"CAMPAIGN_RECIPE_SHA={original}" in command
+    assert set(perf_standalone.RECIPE_FILES) == {
+        perf_standalone.DOCKERFILE,
+        perf_standalone.REPO_ROOT / "ci/docker/standalone_perf_entrypoint.sh",
+        perf_standalone.REPO_ROOT / "rust-toolchain.toml",
+    }
+
+
+def test_docker_command_uses_read_only_source_and_named_build_volumes(tmp_path):
+    command = perf_standalone.docker_run_command(
+        repo_root=tmp_path / "source",
+        results_dir=tmp_path / "results",
+        container_name="campaign-test",
+        entrypoint_args=["verify"],
+    )
+    joined = " ".join(command)
+
+    assert f"type=bind,src={tmp_path / 'source'},dst=/src,readonly" in joined
+    assert f"type=bind,src={tmp_path / 'results'},dst=/results" in joined
+    for volume, destination in perf_standalone.BUILD_VOLUMES.items():
+        assert f"type=volume,src={volume},dst={destination}" in joined
+    assert "dst=/artifacts,readonly" in joined
+
+
+def test_pinned_tool_versions_are_required():
+    versions = {
+        "rustc": "rustc 1.94.1 (fake)",
+        "clang": "Ubuntu clang version 14.0.0",
+        "sccache": "sccache 0.10.0",
+        "emscripten": "emcc 3.1.74",
+        "soldr": "soldr 0.8.16",
+    }
+
+    perf_standalone.validate_tool_versions(versions)
+
+    for tool in versions:
+        broken = dict(versions)
+        broken[tool] = "missing or wrong"
+        with pytest.raises(ValueError, match=tool):
+            perf_standalone.validate_tool_versions(broken)
+
+
+def test_resume_identity_rejects_commit_image_host_or_inventory_changes():
+    identity = {
+        "commit": "abc123",
+        "image_digest": "sha256:image",
+        "host_fingerprint": "host-a",
+        "inventory": [["c", "perf_c_zccache_vs_bare"]],
+        "attempts": 5,
+        "fixture": {"binary": "perf_bench_test", "sha256": "a" * 64},
+    }
+
+    perf_standalone.validate_resume_identity(identity, dict(identity))
+
+    for field in identity:
+        changed = json.loads(json.dumps(identity))
+        changed[field] = "different"
+        with pytest.raises(ValueError, match=field):
+            perf_standalone.validate_resume_identity(identity, changed)
+
+
+def test_invalid_or_fallback_sample_cannot_enter_campaign():
+    valid = {
+        "passed": True,
+        "attempt_policy": "all-required",
+        "attempt_count": 5,
+        "command_failures": [],
+        "missing_requirements": [],
+        "infrastructure": {
+            "valid": True,
+            "invalid_reasons": [],
+            "fallback_count": 0,
+            "cache_telemetry": {
+                "fallback_count": 0,
+                "rows": [
+                    {
+                        "cache_phase": "warm-hit-path",
+                        "cache_bytes_reported": True,
+                        "bare_cache_bytes": 0,
+                        "sccache_cache_bytes": 1024,
+                        "zccache_cache_bytes": 512,
+                    }
+                ],
+            },
+        },
+        "statuses": [
+            {
+                "samples": [
+                    {
+                        "attempt": attempt,
+                        "attempt_json": f"attempt-{attempt}.json",
+                        "raw_log": f"attempt-{attempt}.log",
+                    }
+                    for attempt in range(1, 6)
+                ]
+            }
+        ],
+    }
+
+    perf_standalone.validate_sample_summary(valid, expected_attempts=5)
+
+    cases = []
+    for field, value in (
+        ("passed", False),
+        ("attempt_count", 4),
+        ("command_failures", [2]),
+        ("missing_requirements", ["emscripten warm"]),
+    ):
+        sample = json.loads(json.dumps(valid))
+        sample[field] = value
+        cases.append(sample)
+    fallback = json.loads(json.dumps(valid))
+    fallback["infrastructure"]["fallback_count"] = 1
+    cases.append(fallback)
+    missing_telemetry = json.loads(json.dumps(valid))
+    missing_telemetry["infrastructure"].pop("cache_telemetry")
+    cases.append(missing_telemetry)
+    incomplete = json.loads(json.dumps(valid))
+    incomplete["statuses"][0]["samples"].pop()
+    cases.append(incomplete)
+
+    for sample in cases:
+        with pytest.raises(ValueError):
+            perf_standalone.validate_sample_summary(sample, expected_attempts=5)
+
+
+def test_busy_host_detection_uses_competing_container_cpu_and_process_names():
+    assert not perf_standalone.busy_reasons(
+        containers=[("soldr-perf-local", 0.02)],
+        process_names=[],
+    )
+    assert perf_standalone.busy_reasons(
+        containers=[("soldr-perf-local", 12.5)],
+        process_names=[],
+    ) == ["container soldr-perf-local is using 12.50% CPU"]
+    assert perf_standalone.busy_reasons(
+        containers=[],
+        process_names=["perf_bench_test"],
+    ) == ["host process perf_bench_test is active"]
+
+
+def test_windows_process_activity_ignores_only_idle_orphan_rustc():
+    first = {
+        10: ("rustc", 20.0),
+        20: ("unrelated", 5.0),
+    }
+    second = dict(first)
+
+    assert perf_standalone.active_windows_process_names(first, second) == []
+
+    second[10] = ("rustc", 20.5)
+    assert perf_standalone.active_windows_process_names(first, second, 1.0) == []
+
+    second[10] = ("rustc", 21.0)
+    assert perf_standalone.active_windows_process_names(first, second, 1.0) == [
+        "rustc"
+    ]
+
+    second[10] = ("rustc", 20.0)
+    second[30] = ("cargo", 2.0)
+    assert perf_standalone.active_windows_process_names(first, second) == [
+        "rustc",
+        "cargo",
+    ]
+
+
+def test_host_fingerprint_input_ignores_dynamic_docker_state():
+    first = {
+        "ID": "host-id",
+        "Name": "docker-desktop",
+        "ServerVersion": "28.5.1",
+        "NCPU": 8,
+        "MemTotal": 8_000_000,
+        "ContainersRunning": 1,
+        "SystemTime": "first",
+    }
+    second = dict(first, ContainersRunning=9, SystemTime="second")
+
+    assert perf_standalone.stable_docker_identity(
+        first
+    ) == perf_standalone.stable_docker_identity(second)
+
+    second["NCPU"] = 16
+    assert perf_standalone.stable_docker_identity(
+        first
+    ) != perf_standalone.stable_docker_identity(second)
+
+
+def test_dockerfile_pins_all_campaign_tools():
+    dockerfile = (
+        perf_standalone.REPO_ROOT / "ci/docker/standalone-perf.Dockerfile"
+    ).read_text(encoding="utf-8")
+
+    assert "emscripten/emsdk:3.1.74@sha256:" in dockerfile
+    assert "SOLDR_VERSION=0.8.16" in dockerfile
+    assert "SCCACHE_VERSION=0.10.0" in dockerfile
+    assert "RUST_VERSION=1.94.1" in dockerfile
+    assert "clang-14" in dockerfile
+    assert 'org.zccache.campaign.recipe="${CAMPAIGN_RECIPE_SHA}"' in dockerfile
+    assert "SOLDR_COMMAND_OUTPUT_TIMEOUT_SECS=600" in dockerfile
+    assert "HOME=/opt/soldr-seed soldr toolchain prepare" in dockerfile
+    assert "SOLDR_HOME=" not in dockerfile
+    assert "https://sh.rustup.rs" not in dockerfile
+    assert "/opt/rust" not in dockerfile
+
+
+def test_runtime_rust_state_is_owned_and_seeded_by_soldr():
+    assert perf_standalone.BUILD_VOLUMES[
+        "zccache-standalone-soldr-home"
+    ] == "/root/.soldr"
+    assert all(
+        destination not in {"/cargo-home", "/rustup-home"}
+        for destination in perf_standalone.BUILD_VOLUMES.values()
+    )
+
+    entrypoint = (
+        perf_standalone.REPO_ROOT / "ci/docker/standalone_perf_entrypoint.sh"
+    ).read_text(encoding="utf-8")
+    assert "cp -a /opt/soldr-seed/.soldr/." in entrypoint
+    assert '.standalone-toolchain-${SOLDR_VERSION}-${RUST_VERSION}' in entrypoint
+    assert 'find "${soldr_root}" -mindepth 1 -maxdepth 1' in entrypoint
+    assert entrypoint.index('cp -a /opt/soldr-seed/.soldr/.') < entrypoint.index(
+        'touch "${soldr_root}/${sentinel}"'
+    )
+    assert 'export CARGO_HOME="${soldr_root}/cargo"' in entrypoint
+    assert 'export RUSTUP_HOME="${soldr_root}/rustup"' in entrypoint
+    assert "/opt/rust" not in entrypoint
+
+
+def test_campaign_artifact_paths_are_relative_and_complete(tmp_path):
+    sample_dir = tmp_path / "c" / "perf_c_zccache_vs_bare"
+    sample_dir.mkdir(parents=True)
+    for name in (
+        "perf-guard-summary.json",
+        "perf-guard-summary.md",
+        "perf-guard-result.txt",
+        "resource-usage.txt",
+        "attempt-1.json",
+        "attempt-1.log",
+    ):
+        (sample_dir / name).touch()
+
+    paths = perf_standalone.artifact_paths(tmp_path, sample_dir)
+
+    assert paths["summary_json"] == "c/perf_c_zccache_vs_bare/perf-guard-summary.json"
+    assert paths["raw_logs"] == ["c/perf_c_zccache_vs_bare/attempt-1.log"]
+    assert paths["attempt_json"] == ["c/perf_c_zccache_vs_bare/attempt-1.json"]
+
+
+def test_sample_telemetry_retains_cache_phase_and_byte_counts(tmp_path):
+    attempt = {
+        "attempt": 1,
+        "rows": [
+            {
+                "benchmark": "c",
+                "scenario": "cold compile",
+                "mode": "cold",
+                "cache_bytes_reported": True,
+                "bare_cache_bytes": 0,
+                "sccache_cache_bytes": 1024,
+                "zccache_cache_bytes": 512,
+            },
+            {
+                "benchmark": "c",
+                "scenario": "warm compile",
+                "mode": "warm",
+                "cache_bytes_reported": True,
+                "bare_cache_bytes": 0,
+                "sccache_cache_bytes": 1024,
+                "zccache_cache_bytes": 512,
+            },
+        ],
+    }
+    (tmp_path / "attempt-1.json").write_text(json.dumps(attempt), encoding="utf-8")
+
+    telemetry = perf_standalone._sample_cache_telemetry(tmp_path)
+
+    assert telemetry["cold_miss_path_rows"] == 1
+    assert telemetry["warm_hit_path_rows"] == 1
+    assert telemetry["fallback_count"] == 0
+    assert telemetry["rows"][1]["zccache_cache_bytes"] == 512
+
+
+def test_summary_metadata_is_corrected_to_campaign_identity(tmp_path):
+    summary_path = tmp_path / "perf-guard-summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "metadata": {"git_sha": None, "dirty": True},
+                "command_failures": [],
+                "missing_requirements": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    identity = {
+        "commit": "abc123",
+        "dirty": False,
+        "image_digest": "sha256:image",
+        "host_fingerprint": "host-a",
+    }
+    command = ["docker", "run", "image"]
+    telemetry = {
+        "fallback_count": 0,
+        "rows": [{"cache_phase": "warm-hit-path"}],
+    }
+
+    enriched = perf_standalone._enrich_summary(
+        summary_path, 0, identity, command, telemetry
+    )
+
+    assert enriched["metadata"]["git_sha"] == "abc123"
+    assert enriched["metadata"]["dirty"] is False
+    assert enriched["metadata"]["docker_command"] == command
+    assert enriched["infrastructure"]["cache_telemetry"] == telemetry
+
+
+def test_resume_revalidates_completed_sample_artifacts(tmp_path):
+    sample_dir = tmp_path / "c" / "perf_c_zccache_vs_bare"
+    sample_dir.mkdir(parents=True)
+    valid = {
+        "passed": True,
+        "attempt_policy": "all-required",
+        "attempt_count": 1,
+        "command_failures": [],
+        "missing_requirements": [],
+        "infrastructure": {
+            "valid": True,
+            "invalid_reasons": [],
+            "fallback_count": 0,
+            "cache_telemetry": {
+                "fallback_count": 0,
+                "rows": [
+                    {
+                        "cache_phase": "warm-hit-path",
+                        "cache_bytes_reported": True,
+                        "bare_cache_bytes": 0,
+                        "sccache_cache_bytes": 1,
+                        "zccache_cache_bytes": 1,
+                    }
+                ],
+            },
+        },
+        "statuses": [
+            {
+                "samples": [
+                    {
+                        "attempt_json": "attempt-1.json",
+                        "raw_log": "attempt-1.log",
+                    }
+                ]
+            }
+        ],
+    }
+    files = {
+        "perf-guard-summary.json": json.dumps(valid),
+        "perf-guard-summary.md": "summary",
+        "perf-guard-result.txt": "pass",
+        "resource-usage.txt": "rss",
+        "attempt-1.json": "{}",
+        "attempt-1.log": "log",
+    }
+    for name, content in files.items():
+        (sample_dir / name).write_text(content, encoding="utf-8")
+    campaign = {
+        "results": [
+            {
+                "artifacts": perf_standalone.artifact_paths(tmp_path, sample_dir)
+            }
+        ]
+    }
+
+    perf_standalone.validate_completed_results(tmp_path, campaign, 1)
+
+    (sample_dir / "attempt-1.log").unlink()
+    with pytest.raises(ValueError, match="missing artifacts"):
+        perf_standalone.validate_completed_results(tmp_path, campaign, 1)


### PR DESCRIPTION
## Summary
- add a pinned Linux Docker campaign for every registered C, C++, Emscripten, and Rust benchmark
- prepare the soldr-managed Rust toolchain in a reusable image layer and seed versioned runtime state into named volumes
- retain strict per-attempt telemetry, identities, commands, cache data, RSS, and resumable campaign indexes
- reject competing host/container activity without relaxing performance floors

## Validation
- `uv run --no-project --with pytest python -m pytest -q ci/tests/test_perf_guard.py ci/tests/test_benchmark_stats.py ci/tests/test_perf_standalone.py` (84 passed)
- `uv run --no-project ruff check ci/perf_standalone.py ci/tests/test_perf_standalone.py`
- entrypoint `bash -n` in Ubuntu 22.04
- Docker rebuild reused the `soldr toolchain prepare` layer from cache
- offline (`--network none`) runtime verification: soldr 0.8.16, Rust 1.94.1, clang 14, sccache 0.10.0, emsdk 3.1.74
- strict C diagnostic passed with no fallback; cold 0.951x vs bare and 1.651x vs sccache, warm 19.435x vs sccache

The complete smoke campaign is resumable but currently paused after its first passing C scenario because a separate `soldr-perf-local` container is actively compiling; the quiet-host gate correctly refuses those samples.

Refs #1116
Refs zackees/soldr#1710