### PR TITLE
perf: preserve standalone host provenance

### DIFF
--- a/ci/perf_standalone.py
+++ b/ci/perf_standalone.py
@@ -47,6 +47,7 @@ COMPETING_PROCESSES = {
     "sccache",
 }
 BUSY_CPU_PERCENT = 5.0
+HOST_PROCESS_ENUMERATION_TIMEOUT_SECONDS = 30
 RECIPE_FILES = (
     DOCKERFILE,
     REPO_ROOT / "ci/docker/standalone_perf_entrypoint.sh",
@@ -149,6 +150,7 @@ def validate_resume_identity(
 ) -> None:
     for field in (
         "commit",
+        "ref",
         "image_digest",
         "host_fingerprint",
         "inventory",
@@ -368,7 +370,7 @@ def _process_names() -> list[str]:
                 capture_output=True,
                 text=True,
                 check=False,
-                timeout=10,
+                timeout=HOST_PROCESS_ENUMERATION_TIMEOUT_SECONDS,
             )
         except subprocess.TimeoutExpired as error:
             raise RuntimeError("host process enumeration timed out") from error
@@ -420,7 +422,7 @@ def _windows_process_snapshot() -> dict[int, tuple[str, float]] | None:
             capture_output=True,
             text=True,
             check=False,
-            timeout=10,
+            timeout=HOST_PROCESS_ENUMERATION_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired:
         return None
@@ -649,6 +651,7 @@ def _enrich_summary(
     metadata.update(
         {
             "git_sha": identity["commit"],
+            "git_ref": identity["ref"],
             "dirty": identity["dirty"],
             "image_digest": identity["image_digest"],
             "host_fingerprint": identity["host_fingerprint"],
@@ -759,6 +762,7 @@ def run_campaign(args: argparse.Namespace) -> Path:
     host = _host_identity()
     identity = {
         "commit": commit,
+        "ref": _git_output("rev-parse", "--abbrev-ref", "HEAD"),
         "dirty": False,
         "image_digest": _image_digest(),
         "host_fingerprint": host["fingerprint"],

--- a/ci/tests/test_perf_standalone.py
+++ b/ci/tests/test_perf_standalone.py
@@ -78,6 +78,7 @@ def test_pinned_tool_versions_are_required():
 def test_resume_identity_rejects_commit_image_host_or_inventory_changes():
     identity = {
         "commit": "abc123",
+        "ref": "perf/example",
         "image_digest": "sha256:image",
         "host_fingerprint": "host-a",
         "inventory": [["c", "perf_c_zccache_vs_bare"]],
@@ -160,6 +161,8 @@ def test_invalid_or_fallback_sample_cannot_enter_campaign():
 
 
 def test_busy_host_detection_uses_competing_container_cpu_and_process_names():
+    assert perf_standalone.HOST_PROCESS_ENUMERATION_TIMEOUT_SECONDS >= 30
+
     assert not perf_standalone.busy_reasons(
         containers=[("soldr-perf-local", 0.02)],
         process_names=[],
@@ -330,6 +333,7 @@ def test_summary_metadata_is_corrected_to_campaign_identity(tmp_path):
     )
     identity = {
         "commit": "abc123",
+        "ref": "perf/example",
         "dirty": False,
         "image_digest": "sha256:image",
         "host_fingerprint": "host-a",
@@ -345,6 +349,7 @@ def test_summary_metadata_is_corrected_to_campaign_identity(tmp_path):
     )
 
     assert enriched["metadata"]["git_sha"] == "abc123"
+    assert enriched["metadata"]["git_ref"] == "perf/example"
     assert enriched["metadata"]["dirty"] is False
     assert enriched["metadata"]["docker_command"] == command
     assert enriched["infrastructure"]["cache_telemetry"] == telemetry


### PR DESCRIPTION
Refs #1116

## Summary
- source standalone `git_ref` from the host checkout and lock it into resume identity instead of accepting a container-side Windows worktree error
- increase the Windows pre-sample process-enumeration timeout from 10 to 30 seconds after repeated `tasklist` timeouts
- leave all performance floors, quiet-host criteria, and timed commands unchanged

## Verification
- `31 passed` in `ci/tests/test_perf_standalone.py` + `ci/tests/test_perf_embedded.py`
- `uvx ruff check ci/perf_standalone.py ci/tests/test_perf_standalone.py`
- `git diff --check`

## Reproduction
The local standalone Docker smoke produced a valid `git_sha` but `git_ref` was `fatal: not a git repository: /src/C:/.../.git/worktrees/...`; the host ref now overwrites that field alongside the existing host SHA.