### PR TITLE
fix(perf): restore cold-multi publication and warm hits

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -15,6 +15,15 @@ use args::filter_multi_source_args;
 use preflight::InputSnapshot;
 use types::{PendingWrite, UnitCacheResult};
 
+struct UnitCacheCheck<'a> {
+    cwd_path: &'a Path,
+    key_root: &'a NormalizedPath,
+    system_includes: &'a [NormalizedPath],
+    shared_base: Option<&'a CompileContext>,
+    scan_cache: &'a crate::depgraph::scanner::RecursiveScanCache,
+    cache_now: Instant,
+}
+
 pub(super) fn materialize_multi_hit(
     targets: &[(NormalizedPath, NormalizedPath)],
     payloads: &[CachedPayload],
@@ -27,15 +36,19 @@ pub(super) fn materialize_multi_hit(
 /// If `shared_base` is provided, the CompileContext is built by cloning it and
 /// overriding the source_file, avoiding redundant arg parsing for multi-file
 /// compilations where all units share the same flags.
-pub(super) fn check_unit_cache(
+fn check_unit_cache(
     state: &SharedState,
     compilation: &crate::compiler::CacheableCompilation,
-    cwd_path: &Path,
-    key_root: &NormalizedPath,
-    system_includes: &[NormalizedPath],
-    shared_base: Option<&CompileContext>,
-    cache_now: Instant,
+    check: UnitCacheCheck<'_>,
 ) -> UnitCacheResult {
+    let UnitCacheCheck {
+        cwd_path,
+        key_root,
+        system_includes,
+        shared_base,
+        scan_cache,
+        cache_now,
+    } = check;
     let t0 = std::time::Instant::now();
     let snap_clock = state.cache_system.current_clock();
     state.stats.record_compilation();
@@ -331,7 +344,7 @@ pub(super) fn check_unit_cache(
     }
 
     state.fast_hit_cache.remove(&context_key);
-    let input_snapshot = InputSnapshot::capture(state, &source_path, &ctx, hash_map, snap_clock);
+    let input_snapshot = InputSnapshot::capture(state, &source_path, &ctx, hash_map, scan_cache);
     UnitCacheResult::Miss {
         source_path,
         output_path,
@@ -399,6 +412,7 @@ pub(super) async fn handle_compile_multi(
 
     // ── Phase 1: Check cache for each unit (parallel, as-completed) ──
     let mut join_set = tokio::task::JoinSet::new();
+    let scan_cache = Arc::new(crate::depgraph::scanner::RecursiveScanCache::default());
     for (idx, compilation) in compilations.iter().enumerate() {
         let state = Arc::clone(&state);
         let cwd_path = cwd_path.clone();
@@ -406,6 +420,7 @@ pub(super) async fn handle_compile_multi(
         let system_includes = system_includes.clone();
         let compilation = compilation.clone();
         let shared_base = Arc::clone(&shared_base);
+        let scan_cache = Arc::clone(&scan_cache);
         let cache_now = compile_start;
         join_set.spawn_blocking(move || {
             (
@@ -413,11 +428,14 @@ pub(super) async fn handle_compile_multi(
                 check_unit_cache(
                     &state,
                     &compilation,
-                    &cwd_path,
-                    &key_root,
-                    &system_includes,
-                    Some(&shared_base),
-                    cache_now,
+                    UnitCacheCheck {
+                        cwd_path: &cwd_path,
+                        key_root: &key_root,
+                        system_includes: &system_includes,
+                        shared_base: Some(&shared_base),
+                        scan_cache: &scan_cache,
+                        cache_now,
+                    },
                 ),
             )
         });

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_preflight.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_preflight.rs
@@ -11,6 +11,21 @@ struct InputStamp {
     change_marker: Option<i128>,
 }
 
+pub(super) struct InputStampSet {
+    stamps: HashMap<NormalizedPath, InputStamp>,
+}
+
+impl InputStampSet {
+    pub(super) fn capture(paths: &[NormalizedPath]) -> Self {
+        Self {
+            stamps: paths
+                .iter()
+                .filter_map(|path| input_stamp(path).map(|stamp| (path.clone(), stamp)))
+                .collect(),
+        }
+    }
+}
+
 fn input_stamp(path: &Path) -> Option<InputStamp> {
     let metadata = std::fs::metadata(path).ok()?;
     Some(InputStamp {
@@ -160,6 +175,41 @@ pub(in crate::daemon::server) struct InputSnapshot {
     clock: Clock,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::daemon::server) enum InputSnapshotIssue {
+    Incomplete,
+    InputSetChanged,
+    StampSetChanged,
+    ContentChanged,
+    StampChanged,
+    JournalChanged,
+}
+
+impl InputSnapshotIssue {
+    pub(super) const fn id(self) -> &'static str {
+        match self {
+            Self::Incomplete => "snapshot_incomplete",
+            Self::InputSetChanged => "snapshot_input_set_changed",
+            Self::StampSetChanged => "snapshot_stamp_set_changed",
+            Self::ContentChanged => "snapshot_content_changed",
+            Self::StampChanged => "snapshot_stamp_changed",
+            Self::JournalChanged => "snapshot_journal_changed",
+        }
+    }
+
+    pub(super) const fn failure(self) -> crate::daemon::staged_stats::StagedFailure {
+        use crate::daemon::staged_stats::StagedFailure;
+        match self {
+            Self::Incomplete => StagedFailure::SnapshotIncomplete,
+            Self::InputSetChanged => StagedFailure::SnapshotInputSetChanged,
+            Self::StampSetChanged => StagedFailure::SnapshotStampSetChanged,
+            Self::ContentChanged => StagedFailure::SnapshotContentChanged,
+            Self::StampChanged => StagedFailure::SnapshotStampChanged,
+            Self::JournalChanged => StagedFailure::SnapshotJournalChanged,
+        }
+    }
+}
+
 impl InputSnapshot {
     pub(super) fn incomplete(clock: Clock) -> Self {
         Self {
@@ -174,27 +224,44 @@ impl InputSnapshot {
         state: &SharedState,
         source: &NormalizedPath,
         ctx: &CompileContext,
-        mut hashes: HashMap<NormalizedPath, ContentHash>,
-        clock: Clock,
+        hashes: HashMap<NormalizedPath, ContentHash>,
+        scan_cache: &crate::depgraph::scanner::RecursiveScanCache,
     ) -> Self {
-        let scan = crate::depgraph::scanner::scan_recursive(source, &ctx.include_search);
-        let mut complete = true;
-        for path in scan.resolved.iter().chain(ctx.force_includes.iter()) {
-            if hashes.contains_key(path) {
-                continue;
-            }
-            match hash_file(&state.cache_system, path, clock) {
-                Ok(hash) => {
-                    hashes.insert(path.clone(), hash);
-                }
-                Err(_) => complete = false,
-            }
-        }
-        let stamps: HashMap<NormalizedPath, InputStamp> = hashes
-            .keys()
+        let scan = crate::depgraph::scanner::scan_recursive_cached(
+            source,
+            &ctx.include_search,
+            scan_cache,
+        );
+        let paths: HashSet<NormalizedPath> = hashes
+            .into_keys()
+            .chain(scan.resolved)
+            .chain(ctx.force_includes.iter().cloned())
+            .collect();
+        let paths: Vec<NormalizedPath> = paths.into_iter().collect();
+        state.cache_system.register_tracked(&paths);
+        let clock = state.cache_system.current_clock();
+        let before_stamps: HashMap<NormalizedPath, InputStamp> = paths
+            .iter()
             .filter_map(|path| input_stamp(path).map(|stamp| (path.clone(), stamp)))
             .collect();
-        complete &= stamps.len() == hashes.len();
+        let hashes: HashMap<NormalizedPath, ContentHash> = {
+            use rayon::prelude::*;
+            paths
+                .par_iter()
+                .filter_map(|path| {
+                    hash_file(&state.cache_system, path, clock)
+                        .ok()
+                        .map(|hash| (path.clone(), hash))
+                })
+                .collect()
+        };
+        let stamps: HashMap<NormalizedPath, InputStamp> = paths
+            .iter()
+            .filter_map(|path| input_stamp(path).map(|stamp| (path.clone(), stamp)))
+            .collect();
+        let mut complete = hashes.len() == paths.len();
+        complete &= before_stamps == stamps;
+        complete &= stamps.len() == paths.len();
         complete &= stamps_have_native_markers(&stamps);
         Self {
             hashes,
@@ -204,23 +271,42 @@ impl InputSnapshot {
         }
     }
 
-    pub(super) fn stable(
+    pub(super) fn issue_with_stamps(
         &self,
         state: &SharedState,
         paths: &[NormalizedPath],
         current_hashes: &HashMap<NormalizedPath, ContentHash>,
-    ) -> bool {
-        self.complete
-            && self.hashes.len() == current_hashes.len()
-            && self.stamps.len() == paths.len()
-            && self
-                .hashes
-                .iter()
-                .all(|(path, before)| current_hashes.get(path) == Some(before))
-            && paths.iter().all(|path| {
-                input_stamp(path).as_ref() == self.stamps.get(path)
-                    && !state.cache_system.journal().changed_since(path, self.clock)
-            })
+        current_stamps: &InputStampSet,
+    ) -> Option<InputSnapshotIssue> {
+        if !self.complete {
+            return Some(InputSnapshotIssue::Incomplete);
+        }
+        if self.hashes.len() != current_hashes.len() {
+            return Some(InputSnapshotIssue::InputSetChanged);
+        }
+        if self.stamps.len() != paths.len() {
+            return Some(InputSnapshotIssue::StampSetChanged);
+        }
+        if !self
+            .hashes
+            .iter()
+            .all(|(path, before)| current_hashes.get(path) == Some(before))
+        {
+            return Some(InputSnapshotIssue::ContentChanged);
+        }
+        if !paths
+            .iter()
+            .all(|path| current_stamps.stamps.get(path) == self.stamps.get(path))
+        {
+            return Some(InputSnapshotIssue::StampChanged);
+        }
+        if paths
+            .iter()
+            .any(|path| state.cache_system.journal().changed_since(path, self.clock))
+        {
+            return Some(InputSnapshotIssue::JournalChanged);
+        }
+        None
     }
 }
 
@@ -424,10 +510,13 @@ mod tests {
         )
         .unwrap();
         assert_eq!(current_hash, before_hash);
-        assert!(!snapshot.stable(
-            &state,
-            std::slice::from_ref(&input),
-            &HashMap::from([(input.clone(), current_hash)]),
-        ));
+        assert!(snapshot
+            .issue_with_stamps(
+                &state,
+                std::slice::from_ref(&input),
+                &HashMap::from([(input.clone(), current_hash)]),
+                &InputStampSet::capture(std::slice::from_ref(&input)),
+            )
+            .is_some());
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
@@ -1,6 +1,7 @@
 //! All-or-nothing private execution for cache-missed multi-source units.
 
 use super::args::filter_multi_source_args;
+use super::preflight::InputStampSet;
 use super::*;
 use crate::daemon::{lineage::Lineage, process};
 
@@ -26,6 +27,12 @@ struct PublishedMiss {
     dep_dirs: Vec<NormalizedPath>,
     artifact_bytes: u64,
     validation_clock: Clock,
+}
+
+struct StagedCompilerOutput {
+    unit_index: usize,
+    output: std::process::Output,
+    elapsed_ns: u64,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -137,10 +144,11 @@ pub(super) async fn try_handle_staged_misses(
         })
         .collect();
     let mut failed_exit_code = None;
-
     let lineage = Lineage::current(session_client_pid(state, sid), Some(sid.to_string()));
-    for miss in &mut misses {
-        let compiler_started = std::time::Instant::now();
+    let client_pid = lineage.client_pid.unwrap_or(0);
+    let priority = CompilePriority::from_client_env(client_env.as_deref());
+    let mut compiler_set = tokio::task::JoinSet::new();
+    for miss in &misses {
         let mut compiler_args = miss.plan.rewritten_args.clone();
         if miss.plan.msvc_syntax
             && !compiler_args
@@ -172,15 +180,87 @@ pub(super) async fn try_handle_staged_misses(
             command.args(&compiler_args).current_dir(cwd);
         }
         apply_client_env(&mut command, client_env, &lineage);
-        let priority = CompilePriority::from_client_env(client_env.as_deref());
-        let output = match process::tokio_command_output_with_priority(&mut command, priority).await
-        {
-            Ok(output) => output,
+        command.kill_on_drop(true);
+        let compile_concurrency = state.compile_concurrency.clone();
+        let unit_index = miss.unit_index;
+        compiler_set.spawn(async move {
+            let available_before = compile_concurrency
+                .as_ref()
+                .map_or(usize::MAX, |semaphore| semaphore.available_permits());
+            let _permit = if let Some(semaphore) = compile_concurrency.as_ref() {
+                Arc::clone(semaphore).acquire_owned().await.ok()
+            } else {
+                None
+            };
+            if compile_concurrency.is_some() {
+                tracing::info!(
+                    event = "compile_start",
+                    client_pid,
+                    available_before,
+                    "compile_start client_pid={client_pid} available_before={available_before}",
+                );
+            }
+            let compiler_started = std::time::Instant::now();
+            let output = process::tokio_command_output_with_priority(&mut command, priority).await;
+            let elapsed_ns = compiler_started.elapsed().as_nanos() as u64;
+            if compile_concurrency.is_some() {
+                let exit_code = output
+                    .as_ref()
+                    .ok()
+                    .and_then(|value| value.status.code())
+                    .unwrap_or(-1);
+                tracing::info!(
+                    event = "compile_end",
+                    client_pid,
+                    duration_ns = elapsed_ns,
+                    exit_code,
+                    "compile_end client_pid={client_pid} duration_ns={elapsed_ns} exit_code={exit_code}",
+                );
+            }
+            let output = output.map_err(|error| {
+                format!("failed to run staged multi-source compiler: {error}")
+            })?;
+            drop(rsp_guard);
+            Ok::<_, String>(StagedCompilerOutput {
+                unit_index,
+                output,
+                elapsed_ns,
+            })
+        });
+    }
+
+    let mut compiler_outputs: Vec<Option<StagedCompilerOutput>> = std::iter::repeat_with(|| None)
+        .take(unit_results.len())
+        .collect();
+    let mut compiler_error = None;
+    while let Some(result) = compiler_set.join_next().await {
+        match result {
+            Ok(Ok(output)) => {
+                let unit_index = output.unit_index;
+                compiler_outputs[unit_index] = Some(output);
+            }
+            Ok(Err(error)) => {
+                compiler_error.get_or_insert(error);
+            }
             Err(error) => {
-                return Some(Response::Error {
-                    message: format!("failed to run staged multi-source compiler: {error}"),
+                compiler_error.get_or_insert_with(|| {
+                    format!("staged multi-source compiler task failed: {error}")
                 });
             }
+        };
+    }
+    if let Some(message) = compiler_error {
+        return Some(Response::Error { message });
+    }
+
+    for miss in &mut misses {
+        let Some(StagedCompilerOutput {
+            output, elapsed_ns, ..
+        }) = compiler_outputs[miss.unit_index].take()
+        else {
+            return Some(Response::Error {
+                message: "staged multi-source compiler produced no result".to_string(),
+            });
         };
         state
             .profiler
@@ -188,7 +268,7 @@ pub(super) async fn try_handle_staged_misses(
             .count(crate::daemon::staged_stats::StagedCounter::CompilerStaged);
         state.profiler.staged.timing(
             crate::daemon::staged_stats::StagedTiming::Compiler,
-            compiler_started.elapsed().as_nanos() as u64,
+            elapsed_ns,
         );
         let exit_code = output.status.code().unwrap_or(-1);
         let stderr = if miss.plan.msvc_syntax {
@@ -237,31 +317,29 @@ pub(super) async fn try_handle_staged_misses(
         }
     }
 
-    let mut published = Vec::with_capacity(misses.len());
-    for (miss, output_sizes) in misses.into_iter().zip(validated_sizes) {
-        let artifact_bytes = output_sizes.iter().sum();
-        let mut scan_result =
-            miss.scan_result
-                .unwrap_or_else(|| {
-                    match crate::depgraph::depfile::parse_depfile_path(
-                        &miss.plan.depfile,
+    let mut validation_inputs = Vec::with_capacity(misses.len());
+    let mut tracked_union = HashSet::new();
+    for miss in &mut misses {
+        let mut scan_result = miss.scan_result.take().unwrap_or_else(|| {
+            match crate::depgraph::depfile::parse_depfile_path(
+                &miss.plan.depfile,
+                &miss.source_path,
+                cwd,
+            ) {
+                Ok(result) => result,
+                Err(error) => {
+                    tracing::warn!(
+                        source = %miss.source_path.display(),
+                        %error,
+                        "staged multi-source depfile parse failed; using recursive scan"
+                    );
+                    crate::depgraph::scanner::scan_recursive(
                         &miss.source_path,
-                        cwd,
-                    ) {
-                        Ok(result) => result,
-                        Err(error) => {
-                            tracing::warn!(
-                                source = %miss.source_path.display(),
-                                %error,
-                                "staged multi-source depfile parse failed; using recursive scan"
-                            );
-                            crate::depgraph::scanner::scan_recursive(
-                                &miss.source_path,
-                                &miss.ctx.include_search,
-                            )
-                        }
-                    }
-                });
+                        &miss.ctx.include_search,
+                    )
+                }
+            }
+        });
         let mut tracked: HashSet<NormalizedPath> =
             miss.input_snapshot.hashes.keys().cloned().collect();
         tracked.insert(miss.source_path.clone());
@@ -278,24 +356,56 @@ pub(super) async fn try_handle_staged_misses(
                 })
                 .cloned(),
         );
-        state.cache_system.register_tracked(&tracked_paths);
         let dep_dirs = tracked_paths
             .iter()
             .filter_map(|path| path.parent().map(NormalizedPath::from))
             .collect();
-        let current_clock = state.cache_system.current_clock();
-        let hash_map: HashMap<NormalizedPath, ContentHash> = {
-            use rayon::prelude::*;
-            tracked_paths
-                .par_iter()
-                .filter_map(|path| {
-                    hash_file(&state.cache_system, path, current_clock)
-                        .ok()
-                        .map(|hash| (path.clone(), hash))
-                })
-                .collect()
-        };
-        let stable = miss.input_snapshot.stable(state, &tracked_paths, &hash_map);
+        tracked_union.extend(tracked_paths.iter().cloned());
+        validation_inputs.push((scan_result, tracked_paths, dep_dirs));
+    }
+
+    let tracked_union: Vec<NormalizedPath> = tracked_union.into_iter().collect();
+    state.cache_system.register_tracked(&tracked_union);
+    let current_clock = state.cache_system.current_clock();
+    let shared_hashes: HashMap<NormalizedPath, ContentHash> = {
+        use rayon::prelude::*;
+        tracked_union
+            .par_iter()
+            .filter_map(|path| {
+                hash_file(&state.cache_system, path, current_clock)
+                    .ok()
+                    .map(|hash| (path.clone(), hash))
+            })
+            .collect()
+    };
+    let current_stamps = InputStampSet::capture(&tracked_union);
+
+    let mut published = Vec::with_capacity(misses.len());
+    for ((miss, output_sizes), (scan_result, tracked_paths, dep_dirs)) in misses
+        .into_iter()
+        .zip(validated_sizes)
+        .zip(validation_inputs)
+    {
+        let artifact_bytes = output_sizes.iter().sum();
+        let hash_map: HashMap<NormalizedPath, ContentHash> = tracked_paths
+            .iter()
+            .filter_map(|path| shared_hashes.get(path).map(|hash| (path.clone(), *hash)))
+            .collect();
+        let snapshot_issue = miss.input_snapshot.issue_with_stamps(
+            state,
+            &tracked_paths,
+            &hash_map,
+            &current_stamps,
+        );
+        if let Some(issue) = snapshot_issue {
+            state.profiler.staged.failure(issue.failure());
+            tracing::debug!(
+                source = %miss.source_path.display(),
+                reason = issue.id(),
+                "multi-source cache publication suppressed because inputs were unstable"
+            );
+        }
+        let stable = snapshot_issue.is_none();
         let mut cache_entry = None;
         let mut graph_update = None;
         if stable {

--- a/crates/zccache-daemon-core/src/daemon/server/tests/staged_compiler_sets.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/staged_compiler_sets.rs
@@ -42,6 +42,151 @@ fn assert_compile(response: Option<Response>, expected_cached: bool) {
     }
 }
 
+#[cfg(not(windows))]
+async fn assert_staged_multi_source_include_heavy_hit(compiler: NormalizedPath) {
+    crate::test_support::test_timeout(async move {
+        let temp = tempfile::tempdir().unwrap();
+        let work_dir = temp.path().join("work");
+        let cache_dir: NormalizedPath = temp.path().join("cache").into();
+        let generate_project = || {
+            std::fs::create_dir_all(work_dir.join("include")).unwrap();
+            std::fs::write(
+                work_dir.join("include/common.h"),
+                "#pragma once\ninline int shared_value() { return 7; }\n",
+            )
+            .unwrap();
+            for (name, offset) in [("first", 1), ("second", 2)] {
+                std::fs::write(
+                    work_dir.join(format!("{name}.cpp")),
+                    format!(
+                        "#include \"common.h\"\n#include <cmath>\nint {name}() {{ return shared_value() + static_cast<int>(std::sin({offset}.0)); }}\n"
+                    ),
+                )
+                .unwrap();
+            }
+        };
+        generate_project();
+
+        let (endpoint, server, shutdown, state) = start_daemon(&cache_dir).await;
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
+        let cwd: NormalizedPath = work_dir.clone().into();
+        client
+            .send(&Request::SessionStart {
+                client_pid: std::process::id(),
+                working_dir: cwd.clone(),
+                log_file: None,
+                track_stats: true,
+                journal_path: None,
+                profile: false,
+                private_daemon: None,
+            })
+            .await
+            .unwrap();
+        let session_id = match client.recv().await.unwrap() {
+            Some(Response::SessionStarted { session_id, .. }) => session_id,
+            other => panic!("expected SessionStarted, got {other:?}"),
+        };
+
+        client
+            .send(&Request::Compile {
+                session_id: session_id.clone(),
+                args: vec![
+                    "-c".into(),
+                    "first.cpp".into(),
+                    "-Iinclude".into(),
+                    "-O2".into(),
+                    "-std=c++17".into(),
+                ],
+                cwd: cwd.clone(),
+                compiler: compiler.clone(),
+                env: None,
+                stdin: Vec::new(),
+            })
+            .await
+            .unwrap();
+        assert_compile(client.recv().await.unwrap(), false);
+
+        client.send(&Request::Clear).await.unwrap();
+        assert!(matches!(
+            client.recv().await.unwrap(),
+            Some(Response::Cleared { .. })
+        ));
+        std::fs::remove_dir_all(&work_dir).unwrap();
+        generate_project();
+
+        let request = || Request::Compile {
+            session_id: session_id.clone(),
+            args: vec![
+                "-c".into(),
+                "first.cpp".into(),
+                "second.cpp".into(),
+                "-Iinclude".into(),
+                "-O2".into(),
+                "-std=c++17".into(),
+            ],
+            cwd: cwd.clone(),
+            compiler: compiler.clone(),
+            env: None,
+            stdin: Vec::new(),
+        };
+        client.send(&request()).await.unwrap();
+        assert_compile(client.recv().await.unwrap(), false);
+        let first_object = work_dir.join("first.o");
+        let second_object = work_dir.join("second.o");
+        let expected_first = std::fs::read(&first_object).unwrap();
+        let expected_second = std::fs::read(&second_object).unwrap();
+        let compiler_staged = state.profiler.staged.snapshot().counters["compiler_staged"];
+
+        std::fs::remove_file(&first_object).unwrap();
+        std::fs::remove_file(&second_object).unwrap();
+        client.send(&request()).await.unwrap();
+        let warm_response = client.recv().await.unwrap();
+        assert_eq!(std::fs::read(&first_object).unwrap(), expected_first);
+        assert_eq!(std::fs::read(&second_object).unwrap(), expected_second);
+        let staged = state.profiler.staged.snapshot();
+        for reason in [
+            "snapshot_incomplete",
+            "snapshot_input_set_changed",
+            "snapshot_stamp_set_changed",
+            "snapshot_content_changed",
+            "snapshot_stamp_changed",
+            "snapshot_journal_changed",
+        ] {
+            assert_eq!(staged.failures[reason], 0, "unexpected {reason}");
+        }
+        assert_eq!(
+            staged.counters["compiler_staged"],
+            compiler_staged,
+            "warm multi-source hit must not execute the compiler"
+        );
+        assert_compile(warm_response, true);
+
+        shutdown.notify_one();
+        server.await.unwrap();
+    })
+    .await;
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+#[ignore = "integration: real clang++ + daemon IPC"]
+async fn staged_multi_source_hits_after_clear_and_include_heavy_cold_compile() {
+    let Some(compiler) = crate::test_support::find_clang() else {
+        return;
+    };
+    assert_staged_multi_source_include_heavy_hit(compiler).await;
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+#[ignore = "integration: real em++ + daemon IPC"]
+async fn staged_empp_multi_source_hits_after_include_heavy_cold_compile() {
+    let Some(compiler) = crate::test_support::find_on_path("em++") else {
+        return;
+    };
+    assert_staged_multi_source_include_heavy_hit(compiler).await;
+}
+
 #[cfg(windows)]
 #[tokio::test]
 #[ignore = "integration: real clang-cl + daemon IPC"]

--- a/crates/zccache-daemon-core/src/daemon/staged_stats.rs
+++ b/crates/zccache-daemon-core/src/daemon/staged_stats.rs
@@ -114,6 +114,12 @@ pub(crate) enum StagedFailure {
     Salvage,
     RequestedMaterialization,
     CorruptObject,
+    SnapshotIncomplete,
+    SnapshotInputSetChanged,
+    SnapshotStampSetChanged,
+    SnapshotContentChanged,
+    SnapshotStampChanged,
+    SnapshotJournalChanged,
 }
 
 const FAILURES: &[(StagedFailure, &str)] = &[
@@ -184,6 +190,27 @@ const FAILURES: &[(StagedFailure, &str)] = &[
         "requested_materialization",
     ),
     (StagedFailure::CorruptObject, "corrupt_object"),
+    (StagedFailure::SnapshotIncomplete, "snapshot_incomplete"),
+    (
+        StagedFailure::SnapshotInputSetChanged,
+        "snapshot_input_set_changed",
+    ),
+    (
+        StagedFailure::SnapshotStampSetChanged,
+        "snapshot_stamp_set_changed",
+    ),
+    (
+        StagedFailure::SnapshotContentChanged,
+        "snapshot_content_changed",
+    ),
+    (
+        StagedFailure::SnapshotStampChanged,
+        "snapshot_stamp_changed",
+    ),
+    (
+        StagedFailure::SnapshotJournalChanged,
+        "snapshot_journal_changed",
+    ),
 ];
 
 pub(crate) struct StagedProfiler {

--- a/crates/zccache-depgraph/src/scanner.rs
+++ b/crates/zccache-depgraph/src/scanner.rs
@@ -5,8 +5,10 @@
 //! all `#include` directives are returned unconditionally.
 
 use std::path::Path;
+use std::sync::Arc;
 
 use super::search_paths::IncludeSearchPaths;
+use dashmap::DashMap;
 use zccache_core::NormalizedPath;
 
 /// The kind of `#include` directive.
@@ -16,6 +18,10 @@ pub enum IncludeKind {
     Quoted,
     /// `#include <foo.h>` â€” angle-bracket include.
     AngleBracket,
+    /// A quoted `#include_next` directive.
+    QuotedNext,
+    /// An angle-bracket `#include_next` directive.
+    AngleBracketNext,
     /// `#include MACRO` â€” computed include, cannot resolve by text scanning.
     Computed(String),
 }
@@ -30,6 +36,16 @@ pub struct IncludeDirective {
     pub path: String,
     /// 1-based line number in the file.
     pub line: u32,
+}
+
+/// Request-scoped memo for parsed source/header directives.
+///
+/// A multi-source compile commonly gives every unit the same standard-library
+/// graph. Sharing this memo preserves each unit's independent recursive result
+/// while avoiding repeated reads and parsing of those common headers.
+#[derive(Default)]
+pub struct RecursiveScanCache {
+    directives: DashMap<NormalizedPath, Arc<Vec<IncludeDirective>>>,
 }
 
 /// Result of a recursive include scan.
@@ -149,8 +165,46 @@ pub fn resolve_include(
             }
             None
         }
+        IncludeKind::QuotedNext => resolve_include_next(
+            &directive.path,
+            search.quoted_search_dirs(),
+            including_file_dir,
+        ),
+        IncludeKind::AngleBracketNext => resolve_include_next(
+            &directive.path,
+            search.angle_search_dirs(),
+            including_file_dir,
+        ),
         IncludeKind::Computed(_) => None,
     }
+}
+
+fn resolve_include_next<'a>(
+    path: &str,
+    search_dirs: impl Iterator<Item = &'a Path>,
+    including_file_dir: &Path,
+) -> Option<NormalizedPath> {
+    let including_dir = try_normalize(including_file_dir)?;
+    let dirs: Vec<&Path> = search_dirs.collect();
+    let current_root = dirs
+        .iter()
+        .enumerate()
+        .filter_map(|(index, dir)| {
+            let normalized = try_normalize(dir)?;
+            including_dir
+                .starts_with(normalized.as_path())
+                .then(|| (index, normalized.as_path().components().count()))
+        })
+        .fold(None, |best, candidate| match best {
+            Some((_, best_depth)) if best_depth >= candidate.1 => best,
+            _ => Some(candidate),
+        })
+        .map(|(index, _)| index);
+    let start = current_root.map_or(0, |index| index + 1);
+    dirs.into_iter().skip(start).find_map(|dir| {
+        let candidate = dir.join(path);
+        candidate.is_file().then(|| normalize(&candidate))
+    })
 }
 
 /// Recursively scan a source file for all transitive includes.
@@ -166,6 +220,23 @@ pub fn resolve_include(
 /// parallelization). Callers in `graph.rs` only iterate the list to hash
 /// all files; no order invariant is broken.
 pub fn scan_recursive(source: &Path, search: &IncludeSearchPaths) -> ScanResult {
+    scan_recursive_impl(source, search, None)
+}
+
+/// Recursively scan with a request-scoped parsed-directive memo.
+pub fn scan_recursive_cached(
+    source: &Path,
+    search: &IncludeSearchPaths,
+    cache: &RecursiveScanCache,
+) -> ScanResult {
+    scan_recursive_impl(source, search, Some(cache))
+}
+
+fn scan_recursive_impl(
+    source: &Path,
+    search: &IncludeSearchPaths,
+    cache: Option<&RecursiveScanCache>,
+) -> ScanResult {
     use dashmap::DashSet;
     use rayon::prelude::*;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -194,6 +265,7 @@ pub fn scan_recursive(source: &Path, search: &IncludeSearchPaths) -> ScanResult 
                     &resolved,
                     &unresolved,
                     &has_computed,
+                    cache,
                 )
             })
             .collect();
@@ -224,10 +296,22 @@ fn scan_one_level(
     resolved: &std::sync::Mutex<Vec<NormalizedPath>>,
     unresolved: &std::sync::Mutex<Vec<String>>,
     has_computed: &std::sync::atomic::AtomicBool,
+    cache: Option<&RecursiveScanCache>,
 ) -> Vec<NormalizedPath> {
-    let directives = match scan_includes(file) {
-        Ok(d) => d,
-        Err(_) => return Vec::new(),
+    let directives = if let Some(cache) = cache {
+        let key = NormalizedPath::from(file);
+        Arc::clone(
+            cache
+                .directives
+                .entry(key)
+                .or_insert_with(|| Arc::new(scan_includes(file).unwrap_or_default()))
+                .value(),
+        )
+    } else {
+        match scan_includes(file) {
+            Ok(directives) => Arc::new(directives),
+            Err(_) => return Vec::new(),
+        }
     };
 
     let file_dir = file.parent().unwrap_or(Path::new("."));
@@ -237,7 +321,7 @@ fn scan_one_level(
     let mut local_unresolved: Vec<String> = Vec::new();
     let mut saw_computed = false;
 
-    for directive in &directives {
+    for directive in directives.iter() {
         match &directive.kind {
             IncludeKind::Computed(_) => {
                 saw_computed = true;
@@ -285,8 +369,8 @@ fn join_continuations(source: &str) -> String {
         if ch == '\\' {
             match chars.peek() {
                 Some('\n') => {
-                    chars.next(); // consume the newline
-                                  // Don't emit either the backslash or the newline.
+                    // Don't emit either the backslash or the newline.
+                    chars.next();
                 }
                 Some('\r') => {
                     chars.next(); // consume \r
@@ -376,8 +460,12 @@ fn parse_include_from_line(line: &str) -> Option<IncludeDirective> {
     let after_hash = trimmed.strip_prefix('#')?;
     let after_hash = after_hash.trim();
 
-    // Must be "include"
-    let after_include = after_hash.strip_prefix("include")?;
+    let (after_include, include_next) = if let Some(rest) = after_hash.strip_prefix("include_next")
+    {
+        (rest, true)
+    } else {
+        (after_hash.strip_prefix("include")?, false)
+    };
 
     // "include" must not be part of a longer identifier.
     if let Some(next_ch) = after_include.chars().next() {
@@ -400,7 +488,11 @@ fn parse_include_from_line(line: &str) -> Option<IncludeDirective> {
             return None;
         }
         return Some(IncludeDirective {
-            kind: IncludeKind::Quoted,
+            kind: if include_next {
+                IncludeKind::QuotedNext
+            } else {
+                IncludeKind::Quoted
+            },
             path: path.to_string(),
             line: 0, // Filled in by caller.
         });
@@ -414,7 +506,11 @@ fn parse_include_from_line(line: &str) -> Option<IncludeDirective> {
             return None;
         }
         return Some(IncludeDirective {
-            kind: IncludeKind::AngleBracket,
+            kind: if include_next {
+                IncludeKind::AngleBracketNext
+            } else {
+                IncludeKind::AngleBracket
+            },
             path: path.to_string(),
             line: 0,
         });
@@ -585,6 +681,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_include_next_directives() {
+        let includes = scan_includes_str("#include_next <system.h>\n#include_next \"quoted.h\"\n");
+        assert_eq!(includes.len(), 2);
+        assert_eq!(includes[0].kind, IncludeKind::AngleBracketNext);
+        assert_eq!(includes[0].path, "system.h");
+        assert_eq!(includes[1].kind, IncludeKind::QuotedNext);
+        assert_eq!(includes[1].path, "quoted.h");
+    }
+
+    #[test]
     fn not_include_directive() {
         let source = "#define FOO 1\n#ifdef BAR\n#endif\n";
         let includes = scan_includes_str(source);
@@ -729,6 +835,55 @@ mod tests {
     }
 
     #[test]
+    fn resolve_include_next_skips_current_search_root() {
+        let dir = TempDir::new().unwrap();
+        let first = dir.path().join("first");
+        let second = dir.path().join("second");
+        std::fs::create_dir_all(&first).unwrap();
+        std::fs::create_dir_all(&second).unwrap();
+        std::fs::write(first.join("same.h"), "// first").unwrap();
+        std::fs::write(second.join("same.h"), "// second").unwrap();
+        let directive = IncludeDirective {
+            kind: IncludeKind::AngleBracketNext,
+            path: "same.h".into(),
+            line: 1,
+        };
+        let search = IncludeSearchPaths {
+            system: vec![first.clone().into(), second.clone().into()],
+            ..Default::default()
+        };
+
+        let result = resolve_include(&directive, &search, &first).unwrap();
+
+        assert_eq!(result, normalize(&second.join("same.h")));
+    }
+
+    #[test]
+    fn resolve_include_next_uses_most_specific_nested_search_root() {
+        let dir = TempDir::new().unwrap();
+        let outer = dir.path().join("include");
+        let inner = outer.join("cxx");
+        let next = dir.path().join("next");
+        std::fs::create_dir_all(&inner).unwrap();
+        std::fs::create_dir_all(&next).unwrap();
+        std::fs::write(inner.join("same.h"), "// inner").unwrap();
+        std::fs::write(next.join("same.h"), "// next").unwrap();
+        let directive = IncludeDirective {
+            kind: IncludeKind::AngleBracketNext,
+            path: "same.h".into(),
+            line: 1,
+        };
+        let search = IncludeSearchPaths {
+            system: vec![outer.into(), inner.clone().into(), next.clone().into()],
+            ..Default::default()
+        };
+
+        let result = resolve_include(&directive, &search, &inner).unwrap();
+
+        assert_eq!(result, normalize(&next.join("same.h")));
+    }
+
+    #[test]
     fn resolve_computed_returns_none() {
         let directive = IncludeDirective {
             kind: IncludeKind::Computed("MACRO".to_string()),
@@ -863,6 +1018,24 @@ mod tests {
 
         // a.h, b.h, common.h â€” each once.
         assert_eq!(result.resolved.len(), 3);
+    }
+
+    #[test]
+    fn recursive_scan_cache_shares_parsing_but_preserves_per_source_results() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("one.c"), "#include \"shared.h\"\n").unwrap();
+        std::fs::write(dir.path().join("two.c"), "#include \"shared.h\"\n").unwrap();
+        std::fs::write(dir.path().join("shared.h"), "#include \"nested.h\"\n").unwrap();
+        std::fs::write(dir.path().join("nested.h"), "// leaf\n").unwrap();
+        let cache = RecursiveScanCache::default();
+        let search = IncludeSearchPaths::default();
+
+        let one = scan_recursive_cached(&dir.path().join("one.c"), &search, &cache);
+        let two = scan_recursive_cached(&dir.path().join("two.c"), &search, &cache);
+
+        assert_eq!(one.resolved.len(), 2);
+        assert_eq!(two.resolved.len(), 2);
+        assert_eq!(cache.directives.len(), 4);
     }
 
     #[test]

--- a/crates/zccache-depgraph/src/snapshot/mod.rs
+++ b/crates/zccache-depgraph/src/snapshot/mod.rs
@@ -63,7 +63,7 @@ pub struct FileEntrySnapshot {
 
 #[derive(Archive, Serialize, Deserialize)]
 pub struct IncludeDirectiveSnapshot {
-    /// 0=Quoted, 1=AngleBracket, 2=Computed
+    /// 0=Quoted, 1=AngleBracket, 2=Computed, 3=QuotedNext, 4=AngleBracketNext
     pub kind: u8,
     pub path: String,
     pub line: u32,
@@ -154,6 +154,8 @@ impl DepGraph {
                             IncludeKind::Quoted => 0,
                             IncludeKind::AngleBracket => 1,
                             IncludeKind::Computed(_) => 2,
+                            IncludeKind::QuotedNext => 3,
+                            IncludeKind::AngleBracketNext => 4,
                         },
                         path: d.path.clone(),
                         line: d.line,
@@ -247,6 +249,8 @@ impl DepGraph {
                     let kind = match d.kind {
                         0 => IncludeKind::Quoted,
                         1 => IncludeKind::AngleBracket,
+                        3 => IncludeKind::QuotedNext,
+                        4 => IncludeKind::AngleBracketNext,
                         _ => IncludeKind::Computed(d.path.clone()),
                     };
                     IncludeDirective {

--- a/crates/zccache-depgraph/src/snapshot/tests/round_trip.rs
+++ b/crates/zccache-depgraph/src/snapshot/tests/round_trip.rs
@@ -55,6 +55,16 @@ fn populated_graph_roundtrip() {
                 path: "PLATFORM_HEADER".into(),
                 line: 3,
             },
+            IncludeDirective {
+                kind: IncludeKind::QuotedNext,
+                path: "quoted-next.h".into(),
+                line: 4,
+            },
+            IncludeDirective {
+                kind: IncludeKind::AngleBracketNext,
+                path: "angle-next.h".into(),
+                line: 5,
+            },
         ],
     );
 
@@ -108,10 +118,12 @@ fn populated_graph_roundtrip() {
     let includes = loaded
         .get_file_includes(&NormalizedPath::from("/src/main.cpp"))
         .unwrap();
-    assert_eq!(includes.len(), 3);
+    assert_eq!(includes.len(), 5);
     assert_eq!(includes[0].kind, IncludeKind::Quoted);
     assert_eq!(includes[1].kind, IncludeKind::AngleBracket);
     assert!(matches!(includes[2].kind, IncludeKind::Computed(_)));
+    assert_eq!(includes[3].kind, IncludeKind::QuotedNext);
+    assert_eq!(includes[4].kind, IncludeKind::AngleBracketNext);
 
     // Verify context state survived.
     assert_eq!(loaded.get_state(&key), Some(ContextState::Warm));

--- a/crates/zccache-depgraph/src/system_includes.rs
+++ b/crates/zccache-depgraph/src/system_includes.rs
@@ -110,7 +110,7 @@ pub fn discovery_args_fast() -> Vec<&'static str> {
 }
 
 /// Parse the `-cc1` line from clang's `-###` output and extract every
-/// `-internal-isystem` / `-internal-externc-isystem` path.
+/// `-iwithsysroot`, `-internal-isystem`, and `-internal-externc-isystem` path.
 ///
 /// The driver prints exactly one line per invocation that looks like:
 ///
@@ -147,16 +147,42 @@ pub fn parse_cc1_system_include_output(output: &str) -> Vec<NormalizedPath> {
         if !tokens.iter().any(|t| t == "-cc1") {
             continue;
         }
-        let mut iter = tokens.iter();
+        let sysroot = tokens
+            .windows(2)
+            .find_map(|pair| (pair[0] == "-isysroot").then_some(pair[1].as_str()));
+        let mut with_sysroot = Vec::new();
+        let mut internal = Vec::new();
+        let mut iter = tokens.iter().peekable();
         while let Some(token) = iter.next() {
             if token == "-internal-isystem" || token == "-internal-externc-isystem" {
                 if let Some(path) = iter.next() {
                     if !path.is_empty() {
-                        paths.push(NormalizedPath::new(path));
+                        internal.push(NormalizedPath::new(path));
                     }
+                }
+            } else if let Some(joined_path) = token.strip_prefix("-iwithsysroot") {
+                let path = if joined_path.is_empty() {
+                    iter.next().map(String::as_str)
+                } else {
+                    Some(joined_path)
+                };
+                if let Some(path) = path.filter(|path| !path.is_empty()) {
+                    let resolved = sysroot.map_or_else(
+                        || NormalizedPath::new(path),
+                        |root| {
+                            NormalizedPath::new(
+                                Path::new(root).join(path.trim_start_matches(['/', '\\'])),
+                            )
+                        },
+                    );
+                    with_sysroot.push(resolved);
                 }
             }
         }
+        // Clang appends these flags to the cc1 argv after its internal
+        // directories, but searches them first (as shown by `-v -E`).
+        paths.extend(with_sysroot);
+        paths.extend(internal);
         // Only the first cc1 line — multi-arch / multi-tu drivers may
         // emit several but the include search order is identical.
         if !paths.is_empty() {
@@ -745,6 +771,24 @@ InstalledDir: /usr/bin
         let paths = parse_cc1_system_include_output(output);
         assert_eq!(paths.len(), 1);
         assert_eq!(paths[0], NormalizedPath::new("/opt/Custom Include Path/v1"));
+    }
+
+    #[test]
+    fn parse_cc1_output_resolves_emscripten_iwithsysroot_in_search_order() {
+        let output = r#" "/emsdk/upstream/bin/clang-20" "-cc1" "-isysroot" "/emsdk/upstream/emscripten/cache/sysroot" "-internal-isystem" "/emsdk/upstream/emscripten/cache/sysroot/include/c++/v1" "-internal-isystem" "/emsdk/upstream/lib/clang/20/include" "-iwithsysroot/include/fakesdl" "-iwithsysroot/include/compat" "-x" "c++" "/dev/null"
+"#;
+
+        let paths = parse_cc1_system_include_output(output);
+
+        assert_eq!(
+            paths,
+            vec![
+                NormalizedPath::new("/emsdk/upstream/emscripten/cache/sysroot/include/fakesdl"),
+                NormalizedPath::new("/emsdk/upstream/emscripten/cache/sysroot/include/compat"),
+                NormalizedPath::new("/emsdk/upstream/emscripten/cache/sysroot/include/c++/v1"),
+                NormalizedPath::new("/emsdk/upstream/lib/clang/20/include"),
+            ]
+        );
     }
 
     #[test]

--- a/crates/zccache/tests/perf_bench/cpp_project.rs
+++ b/crates/zccache/tests/perf_bench/cpp_project.rs
@@ -176,6 +176,7 @@ pub async fn zccache_compile_multi(
     compiler: &str,
     cwd: &str,
     sources: &[String],
+    expected_cached: bool,
 ) -> Duration {
     clean_objects(Path::new(cwd));
     let mut args: Vec<String> = vec!["-c".into()];
@@ -195,8 +196,14 @@ pub async fn zccache_compile_multi(
         .await
         .unwrap();
     match client.recv().await.unwrap() {
-        Some(Response::CompileResult { exit_code, .. }) => {
+        Some(Response::CompileResult {
+            exit_code, cached, ..
+        }) => {
             assert_eq!(exit_code, 0, "multi-file compile failed");
+            assert_eq!(
+                cached, expected_cached,
+                "multi-file compile returned an unexpected cache state"
+            );
         }
         other => panic!("expected CompileResult, got: {other:?}"),
     }

--- a/crates/zccache/tests/perf_bench/tests_cpp.rs
+++ b/crates/zccache/tests/perf_bench/tests_cpp.rs
@@ -223,14 +223,22 @@ async fn perf_warm_cache_zccache_vs_sccache() {
     warmup_compiler(&compiler, zc_dir.path());
 
     eprint!("        multi cold:   ");
-    let zc_cold_multi =
-        zccache_compile_multi(&mut client, &session_id, &compiler, &zc_cwd, &sources).await;
+    let zc_cold_multi = zccache_compile_multi(
+        &mut client,
+        &session_id,
+        &compiler,
+        &zc_cwd,
+        &sources,
+        false,
+    )
+    .await;
     eprintln!("{}", fmt_dur(zc_cold_multi));
 
     let mut zc_multi_times = Vec::with_capacity(WARM_TRIALS);
     for _ in 0..WARM_TRIALS {
         zc_multi_times.push(
-            zccache_compile_multi(&mut client, &session_id, &compiler, &zc_cwd, &sources).await,
+            zccache_compile_multi(&mut client, &session_id, &compiler, &zc_cwd, &sources, true)
+                .await,
         );
     }
     print_trials("multi warm:", &zc_multi_times);

--- a/crates/zccache/tests/perf_bench/tests_emcc.rs
+++ b/crates/zccache/tests/perf_bench/tests_emcc.rs
@@ -192,13 +192,21 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
     let _ = client.recv::<Response>().await;
     nuke_and_regenerate(zc_dir.path());
     warmup_compiler(&compiler, zc_dir.path());
-    let zc_cold_multi =
-        zccache_compile_multi(&mut client, &session_id, &compiler, &zc_cwd, &sources).await;
+    let zc_cold_multi = zccache_compile_multi(
+        &mut client,
+        &session_id,
+        &compiler,
+        &zc_cwd,
+        &sources,
+        false,
+    )
+    .await;
     eprintln!("        multi cold:   {}", fmt_dur(zc_cold_multi));
     let mut zc_warm_multi = Vec::with_capacity(WARM_TRIALS);
     for _ in 0..WARM_TRIALS {
         zc_warm_multi.push(
-            zccache_compile_multi(&mut client, &session_id, &compiler, &zc_cwd, &sources).await,
+            zccache_compile_multi(&mut client, &session_id, &compiler, &zc_cwd, &sources, true)
+                .await,
         );
     }
     print_trials("multi warm:", &zc_warm_multi);


### PR DESCRIPTION
Closes #1123

## Summary
- make include-heavy cold multi-source snapshots complete on Linux, including `#include_next` and Emscripten `-iwithsysroot` compatibility headers
- preserve ABA/race safety with bounded suppression diagnostics and request-wide post-compile validation
- run staged compiler misses concurrently under the existing global semaphore and memoize shared header parsing per request
- require benchmark cold/warm cache-state correctness and add real clang++/em++ regressions

## Validation
- `soldr cargo test -p zccache-depgraph` (378 passed)
- `soldr cargo test -p zccache-daemon-core --features test-support` (528 passed, 25 ignored)
- targeted Windows clippy with `-D warnings` (passes; existing large-enum lint explicitly allowed)
- offline Linux Docker real clang++ + em++ focused regressions (2 passed)
- Linux Docker Emscripten strict screen, 5 attempts on `0f11e42`: all 8 checks pass; multi-cold median 6.086s, 1.021x bare / 1.098x sccache; multi-warm median 12ms
- Linux Docker C++ strict screen, 5 attempts on parent implementation SHA `950615d`: all 8 checks pass; multi-cold median 5.413s, 2.025x bare / 1.983x sccache; multi-warm median 10ms

## Retained evidence
- `.perf-standalone/results/0f11e424bf22-emscripten-perf-emcc-warm-cache-zccache-vs-sccache-a5/`
- `.perf-standalone/results/950615d5cbab-c-perf-warm-cache-zccache-vs-sccache-a5/`

No threshold, timeout, no-cache, fallback, or correctness relaxation.