### PR TITLE
fix(wrap): compile locally when the daemon returns no verdict

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
@@ -18,12 +18,18 @@ pub(super) async fn cmd_compile(
     client_env: Vec<(String, String)>,
 ) -> ExitCode {
     let stdin_bytes = slurp_stdin_if_piped();
+    let locally = |reason: String| {
+        super::passthrough::run_locally(
+            compiler.as_path(),
+            &args,
+            cwd.as_path(),
+            &stdin_bytes,
+            &reason,
+        )
+    };
     let mut conn = match connect(endpoint).await {
         Ok(c) => c,
-        Err(e) => {
-            eprintln!("zccache[err][C]: cannot connect to daemon at {endpoint}: {e}");
-            return ExitCode::FAILURE;
-        }
+        Err(e) => return locally(format!("cannot connect to daemon at {endpoint}: {e}")),
     };
 
     let wire = crate::protocol::wire_prost::full_family_wire_format_from_env();
@@ -36,13 +42,15 @@ pub(super) async fn cmd_compile(
         stdin: stdin_bytes.clone(),
     };
     if let Err(e) = conn.send_request(&request, wire).await {
-        eprintln!("zccache[err][S]: failed to send to daemon: {e}");
-        return ExitCode::FAILURE;
+        return locally(format!("failed to send to daemon at {endpoint}: {e}"));
     }
 
     match compile_recv_with_wedge_detection(&mut conn, wedge_recv_timeout()).await {
         CompileRecvOutcome::Done(recv_result) => {
             relay_compile_response(recv_result, &mut std::io::stdout(), &mut std::io::stderr())
+                .unwrap_or_else(|| {
+                    locally(format!("daemon at {endpoint} returned no compile verdict"))
+                })
         }
         CompileRecvOutcome::Wedged => {
             // Daemon went past the wedge budget for *this* request. Pre-#753
@@ -78,19 +86,21 @@ pub(super) async fn cmd_compile(
                 WedgeAction::EscalateKill | WedgeAction::EscalateKillProbeError => {
                     // The daemon is genuinely wedged: it missed the
                     // per-request wedge budget AND failed the follow-up
-                    // responsiveness probe. Per the fail-fast policy (#955)
-                    // a *detected* wedge fails IMMEDIATELY — we do not mask
-                    // it with a slow uncached retry/fallback. Kill the
-                    // wedged daemon so the next invocation starts fresh,
-                    // then surface the failure now. (The root-cause daemon
-                    // fix keeps this path from triggering in normal builds.)
+                    // responsiveness probe. Kill it so the next invocation
+                    // starts fresh, then answer this request by compiling
+                    // locally: a wedged daemon is an infrastructure fault,
+                    // and failing the build is not an acceptable way to
+                    // report one. The wedge stays just as visible — this
+                    // warning, the lifecycle events, and the daemon kill all
+                    // still happen — it just no longer takes the build down
+                    // with it.
                     eprintln!(
-                        "zccache[err][W]: daemon at {endpoint} is wedged \
-                         (missed wedge budget + failed probe); killing it and \
-                         failing immediately — issue #955"
+                        "zccache[warn][W]: daemon at {endpoint} is wedged \
+                         (missed wedge budget + failed probe); killing it so the \
+                         next invocation starts fresh"
                     );
                     stop_stale_daemon(endpoint).await;
-                    ExitCode::FAILURE
+                    locally(format!("daemon at {endpoint} was wedged"))
                 }
             }
         }
@@ -103,8 +113,7 @@ pub(super) async fn cmd_compile(
                 crate::core::lifecycle::CAUSE_COMM_ERROR,
                 &msg,
             );
-            eprintln!("zccache[err][R]: {msg}");
-            ExitCode::FAILURE
+            locally(msg)
         }
     }
 }
@@ -341,10 +350,13 @@ pub(super) async fn cmd_compile_ephemeral(
         client_pid: std::process::id(),
         working_dir: cwd.clone(),
         compiler: compiler.into(),
-        args,
-        cwd,
+        args: args.clone(),
+        cwd: cwd.clone(),
         env: Some(client_env),
-        stdin: stdin_bytes,
+        stdin: stdin_bytes.clone(),
+    };
+    let locally = |reason: String| {
+        super::passthrough::run_locally(compiler, &args, cwd.as_path(), &stdin_bytes, &reason)
     };
 
     // Issue #752: retry once on transport failure
@@ -363,19 +375,19 @@ pub(super) async fn cmd_compile_ephemeral(
     match outcome {
         CompileRecvOutcome::Done(recv_result) => {
             relay_compile_response(recv_result, &mut std::io::stdout(), &mut std::io::stderr())
+                .unwrap_or_else(|| {
+                    locally(format!("daemon at {endpoint} returned no compile verdict"))
+                })
         }
         CompileRecvOutcome::Wedged => {
             eprintln!(
-                "zccache[err][W]: daemon at {endpoint} stopped responding within \
+                "zccache[warn][W]: daemon at {endpoint} stopped responding within \
                  the wedge budget; killing it so the next compile starts fresh — issue #666"
             );
             stop_stale_daemon(endpoint).await;
-            ExitCode::FAILURE
+            locally(format!("daemon at {endpoint} was wedged"))
         }
-        CompileRecvOutcome::Failed(msg) => {
-            eprintln!("zccache[err][R]: {msg}");
-            ExitCode::FAILURE
-        }
+        CompileRecvOutcome::Failed(msg) => locally(msg),
     }
 }
 
@@ -390,10 +402,13 @@ pub(super) async fn cmd_link_ephemeral(
     let request = crate::protocol::Request::LinkEphemeral {
         client_pid: std::process::id(),
         tool: tool.into(),
-        args,
-        cwd,
+        args: args.clone(),
+        cwd: cwd.clone(),
         env: Some(client_env),
     };
+    // A link takes no stdin: `cmd_link_ephemeral` never slurps one.
+    let locally =
+        |reason: String| super::passthrough::run_locally(tool, &args, cwd.as_path(), &[], &reason);
 
     // Issue #752: retry once on transport failure
     // (`lost connection to daemon`). Wedge has its own handling.
@@ -408,20 +423,20 @@ pub(super) async fn cmd_link_ephemeral(
     match outcome {
         CompileRecvOutcome::Done(recv_result) => {
             relay_link_response(recv_result, &mut std::io::stdout(), &mut std::io::stderr())
+                .unwrap_or_else(|| {
+                    locally(format!("daemon at {endpoint} returned no link verdict"))
+                })
         }
         CompileRecvOutcome::Wedged => {
             eprintln!(
-                "zccache[err][W]: daemon at {endpoint} stopped responding within \
+                "zccache[warn][W]: daemon at {endpoint} stopped responding within \
                  the wedge budget on a Link; killing it so the next request starts \
                  fresh — issue #666"
             );
             stop_stale_daemon(endpoint).await;
-            ExitCode::FAILURE
+            locally(format!("daemon at {endpoint} was wedged"))
         }
-        CompileRecvOutcome::Failed(msg) => {
-            eprintln!("zccache[err][R]: {msg}");
-            ExitCode::FAILURE
-        }
+        CompileRecvOutcome::Failed(msg) => locally(msg),
     }
 }
 
@@ -516,11 +531,19 @@ fn emit_client_disconnected_event(endpoint: &str, cause: &str, detail: &str) {
     );
 }
 
+/// Relay a daemon response that carries a compiler verdict.
+///
+/// `Some(code)` means the daemon reported what the compiler actually did —
+/// success or a genuine compile error, cached or fresh — and that code is the
+/// build's answer. `None` means the daemon produced no verdict at all (lost
+/// connection, daemon-side error, unexpected message); the caller answers by
+/// running the compiler itself rather than inventing a failure the compiler
+/// never reported. See [`super::passthrough::run_locally`].
 fn relay_compile_response<W: Write, E: Write>(
     recv_result: Option<crate::protocol::Response>,
     stdout: &mut W,
     stderr: &mut E,
-) -> ExitCode {
+) -> Option<ExitCode> {
     match recv_result {
         Some(crate::protocol::Response::CompileResult {
             exit_code,
@@ -530,31 +553,35 @@ fn relay_compile_response<W: Write, E: Write>(
         }) => {
             let _ = stdout.write_all(&out);
             let _ = stderr.write_all(&err);
-            exit_code_from_i32(exit_code)
+            Some(exit_code_from_i32(exit_code))
         }
         Some(crate::protocol::Response::Error { message }) => {
             let _ = writeln!(stderr, "zccache[err][E]: daemon error: {message}");
-            ExitCode::FAILURE
+            None
         }
         None => {
             let _ = writeln!(stderr, "{LOST_CONNECTION_MSG}");
-            ExitCode::FAILURE
+            None
         }
         Some(other) => {
             let _ = writeln!(
                 stderr,
                 "zccache[err][U]: unexpected response from daemon: {other:?}"
             );
-            ExitCode::FAILURE
+            None
         }
     }
 }
 
+/// Relay a daemon response that carries a linker/archiver verdict.
+///
+/// Same contract as [`relay_compile_response`]: `None` means the daemon
+/// produced no verdict, and the caller runs the tool itself.
 fn relay_link_response<W: Write, E: Write>(
     recv_result: Option<crate::protocol::Response>,
     stdout: &mut W,
     stderr: &mut E,
-) -> ExitCode {
+) -> Option<ExitCode> {
     match recv_result {
         Some(crate::protocol::Response::LinkResult {
             exit_code,
@@ -568,22 +595,22 @@ fn relay_link_response<W: Write, E: Write>(
             if let Some(w) = warning {
                 let _ = writeln!(stderr, "zccache warning: {w}");
             }
-            exit_code_from_i32(exit_code)
+            Some(exit_code_from_i32(exit_code))
         }
         Some(crate::protocol::Response::Error { message }) => {
             let _ = writeln!(stderr, "zccache[err][E]: daemon error: {message}");
-            ExitCode::FAILURE
+            None
         }
         None => {
             let _ = writeln!(stderr, "{LOST_CONNECTION_MSG}");
-            ExitCode::FAILURE
+            None
         }
         Some(other) => {
             let _ = writeln!(
                 stderr,
                 "zccache[err][U]: unexpected response from daemon: {other:?}"
             );
-            ExitCode::FAILURE
+            None
         }
     }
 }
@@ -609,9 +636,104 @@ mod tests {
             &mut stderr,
         );
 
-        assert_eq!(exit, ExitCode::from(7));
+        assert_eq!(exit, Some(ExitCode::from(7)));
         assert_eq!(stdout, b"compiler-out");
         assert_eq!(stderr, b"compiler-err");
+    }
+
+    // ── Transparency: a daemon fault is not a compile verdict ──────────
+    //
+    // The wrapper may only report what the compiler actually did. A real
+    // `CompileResult` — including a genuine compile error — is the build's
+    // answer and is relayed verbatim. Every other outcome means the daemon
+    // produced no verdict, and the relay must say so (`None`) so the caller
+    // runs the compiler instead of failing a build that compiles cleanly
+    // without the wrapper.
+
+    #[test]
+    fn compile_relay_reports_a_real_compile_error_as_a_verdict() {
+        // rustc genuinely failed: the daemon ran it and it exited 1. That is
+        // the compiler's own answer and must pass through untouched — the
+        // fallback must NOT mask it by recompiling.
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let exit = relay_compile_response(
+            Some(crate::protocol::Response::CompileResult {
+                exit_code: 1,
+                stdout: Arc::new(Vec::new()),
+                stderr: Arc::new(b"error[E0425]: cannot find value `x`".to_vec()),
+                cached: true,
+            }),
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(
+            exit,
+            Some(ExitCode::from(1)),
+            "a real compile error is a verdict and must be relayed, not retried"
+        );
+        assert_eq!(stderr, b"error[E0425]: cannot find value `x`");
+    }
+
+    #[test]
+    fn compile_relay_reports_no_verdict_when_connection_is_lost() {
+        // The daemon crashed or was killed mid-request. Pre-fix this returned
+        // ExitCode::FAILURE, so cargo reported `could not compile <crate>`
+        // with no diagnostics for a crate that compiles fine.
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let exit = relay_compile_response(None, &mut stdout, &mut stderr);
+
+        assert_eq!(
+            exit, None,
+            "a lost daemon connection is an infrastructure fault, not a compile error"
+        );
+    }
+
+    #[test]
+    fn compile_relay_reports_no_verdict_on_daemon_error() {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let exit = relay_compile_response(
+            Some(crate::protocol::Response::Error {
+                message: "internal daemon failure".to_string(),
+            }),
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(exit, None, "a daemon-side error is not a compile verdict");
+    }
+
+    #[test]
+    fn compile_relay_reports_no_verdict_on_unexpected_response() {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let exit = relay_compile_response(
+            Some(crate::protocol::Response::Pong),
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(
+            exit, None,
+            "a protocol desync is not a compile verdict either"
+        );
+    }
+
+    #[test]
+    fn link_relay_reports_no_verdict_when_connection_is_lost() {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let exit = relay_link_response(None, &mut stdout, &mut stderr);
+
+        assert_eq!(exit, None, "a lost daemon connection is not a link verdict");
     }
 
     // ── Issue #666: wedge-detection helper ──────────────────────────────
@@ -956,7 +1078,7 @@ mod tests {
             &mut stderr,
         );
 
-        assert_eq!(exit, ExitCode::SUCCESS);
+        assert_eq!(exit, Some(ExitCode::SUCCESS));
         assert_eq!(stdout, b"link-out");
         assert_eq!(
             String::from_utf8(stderr).unwrap(),

--- a/crates/zccache-cli-core/src/cli/commands/wrap/passthrough.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/passthrough.rs
@@ -1,5 +1,7 @@
-//! Direct execution paths used when wrapper caching is disabled or unsupported.
+//! Direct execution paths used when wrapper caching is disabled, unsupported,
+//! or unavailable.
 
+use std::io::Write;
 use std::path::Path;
 use std::process::ExitCode;
 
@@ -33,6 +35,71 @@ fn run_with_released_cwd(
         release_cwd_for_command(cmd, &cwd);
     }
     cmd.status()
+}
+
+/// Run the real tool because the daemon could not return a verdict for it.
+///
+/// Wrapping a compiler in zccache must not change whether the build succeeds:
+/// an unreachable, wedged, crashed, or protocol-broken daemon is an
+/// infrastructure fault, not a compile error. Reporting one as a failed compile
+/// makes cargo print `could not compile <crate>` with no diagnostics and breaks
+/// builds that compile cleanly without the wrapper, and no `cargo clean` can
+/// clear it because the fault is in the wrapper, not in `target/`. Only a real
+/// compiler verdict (`Response::CompileResult`, cached or fresh) is relayed
+/// as-is; every other outcome lands here and is answered by running the tool.
+///
+/// The fault stays observable rather than fatal: `reason` names it on stderr,
+/// and the caller has already written the matching `client-disconnected`
+/// lifecycle event and killed a wedged daemon so the next invocation starts
+/// fresh. sccache resolves a lost server the same way ("the server looks like
+/// it shut down unexpectedly, compiling locally instead").
+///
+/// `cwd` is passed explicitly because the wrapper has already released its own
+/// working directory (see `run_wrap`), and `stdin` carries the bytes the
+/// wrapper slurped off its stdin so a piped invocation replays them instead of
+/// handing the child an exhausted pipe.
+pub(super) fn run_locally(
+    tool: &Path,
+    args: &[String],
+    cwd: &Path,
+    stdin: &[u8],
+    reason: &str,
+) -> ExitCode {
+    eprintln!(
+        "zccache[warn][F]: {reason}; running {} directly, uncached",
+        tool.display()
+    );
+
+    let mut cmd = std::process::Command::new(tool);
+    cmd.args(args).current_dir(cwd);
+    if !stdin.is_empty() {
+        cmd.stdin(std::process::Stdio::piped());
+    }
+
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            eprintln!("zccache[err][F]: failed to run {}: {e}", tool.display());
+            return ExitCode::FAILURE;
+        }
+    };
+    if !stdin.is_empty() {
+        // Dropping the handle at the end of this block closes the pipe, which
+        // is the child's EOF — without it a compiler reading stdin hangs.
+        if let Some(mut pipe) = child.stdin.take() {
+            let _ = pipe.write_all(stdin);
+        }
+    }
+    match child.wait() {
+        Ok(status) => exit_code_from_i32(status.code().unwrap_or(1)),
+        Err(e) => {
+            eprintln!(
+                "zccache[err][F]: failed to wait for {}: {e}",
+                tool.display()
+            );
+            ExitCode::FAILURE
+        }
+    }
 }
 
 /// Run the compiler/tool directly without caching (`ZCCACHE_DISABLE` mode).

--- a/crates/zccache/tests/cli_wrapper_daemon_fallback.rs
+++ b/crates/zccache/tests/cli_wrapper_daemon_fallback.rs
@@ -1,0 +1,198 @@
+//! The wrapper must never turn a daemon fault into a build failure.
+//!
+//! `zccache` is wired in as cargo's `rustc-wrapper`, so every rustc invocation
+//! in the build goes through it. That makes one property load-bearing: wrapping
+//! a compiler must not change whether the build succeeds. When the daemon is
+//! unreachable, wedged, crashed, or talking a protocol the client can't parse,
+//! it has produced no verdict about the compile — and the only honest answer is
+//! to run the compiler and report what it actually did.
+//!
+//! Pre-fix, every one of those paths returned `ExitCode::FAILURE` without ever
+//! running the compiler, so cargo reported
+//!
+//! ```text
+//! error: could not compile `naga` (lib)
+//! Caused by: process didn't exit successfully: `zccache rustc --crate-name naga ...` (exit status: 1)
+//! ```
+//!
+//! for a crate that compiles cleanly with `RUSTC_WRAPPER=""`. No `cargo clean`
+//! could clear it: the fault was in the wrapper, not in `target/`.
+//!
+//! These tests need no daemon — `ZCCACHE_NO_SPAWN=1` plus an isolated cache
+//! root makes the daemon deterministically unavailable, which is exactly the
+//! "client cannot get a verdict" condition. `echo_shim` stands in for the
+//! compiler: it proves the tool really ran (markers), that its exit code is
+//! reported verbatim, and that piped stdin is replayed rather than swallowed.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+const STDOUT_MARKER: &[u8] = b"ZCCACHE_PASSTHROUGH_STDOUT_MARKER\n";
+const STDERR_MARKER: &[u8] = b"ZCCACHE_PASSTHROUGH_STDERR_MARKER\n";
+
+fn binary_path(stem: &str) -> std::path::PathBuf {
+    // Test binaries live at target/<profile>/deps/<name>-<hash>; the profile
+    // dir two levels up holds the crate's bins.
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop(); // deps/
+    p.pop(); // target/<profile>/
+    if cfg!(windows) {
+        p.push(format!("{stem}.exe"));
+    } else {
+        p.push(stem);
+    }
+    p
+}
+
+/// Run `zccache <echo_shim> <exit_code>` against a deliberately unavailable
+/// daemon, returning the wrapper's (exit code, stdout, stderr).
+fn run_with_daemon_unavailable(
+    stdin_payload: &[u8],
+    exit_code: i32,
+    session_id: Option<&str>,
+) -> (i32, Vec<u8>, Vec<u8>) {
+    let zccache = binary_path("zccache");
+    let echo_shim = binary_path("echo_shim");
+    assert!(
+        zccache.exists(),
+        "zccache binary missing at {zccache:?} — build with --features zccache-bin"
+    );
+    assert!(
+        echo_shim.exists(),
+        "echo_shim binary missing at {echo_shim:?} — build with --features test-support"
+    );
+    let cache_dir = tempfile::Builder::new()
+        .prefix("zccache-daemon-fallback-")
+        .tempdir()
+        .expect("tempdir");
+
+    let mut cmd = Command::new(&zccache);
+    cmd.arg(&echo_shim)
+        .arg(exit_code.to_string())
+        .env("ZCCACHE_CACHE_DIR", cache_dir.path())
+        .env(
+            "ZCCACHE_DAEMON_NAMESPACE",
+            format!("fallback-{}", std::process::id()),
+        )
+        // The daemon cannot be started, so the client cannot obtain a verdict:
+        // the same condition a crashed or unreachable daemon produces.
+        .env("ZCCACHE_NO_SPAWN", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    match session_id {
+        Some(sid) => {
+            cmd.env("ZCCACHE_SESSION_ID", sid);
+        }
+        None => {
+            cmd.env_remove("ZCCACHE_SESSION_ID");
+        }
+    }
+
+    let mut child = cmd.spawn().expect("spawn zccache wrapper");
+    {
+        let mut stdin = child.stdin.take().expect("piped stdin");
+        stdin.write_all(stdin_payload).expect("write stdin payload");
+    }
+    let output = child.wait_with_output().expect("wait_with_output");
+    (
+        output.status.code().unwrap_or(-1),
+        output.stdout,
+        output.stderr,
+    )
+}
+
+fn assert_tool_actually_ran(stdout: &[u8], stderr: &[u8]) {
+    assert!(
+        stdout
+            .windows(STDOUT_MARKER.len())
+            .any(|w| w == STDOUT_MARKER),
+        "the wrapper never ran the tool: STDOUT_MARKER missing. \
+         A daemon fault must fall back to running the real compiler, not exit 1.\n\
+         stdout = {:?}\nstderr = {:?}",
+        String::from_utf8_lossy(stdout),
+        String::from_utf8_lossy(stderr)
+    );
+    assert!(
+        stderr
+            .windows(STDERR_MARKER.len())
+            .any(|w| w == STDERR_MARKER),
+        "STDERR_MARKER missing from wrapper stderr.\nstderr = {:?}",
+        String::from_utf8_lossy(stderr)
+    );
+}
+
+/// The naga case: cargo's rustc-wrapper route (no `ZCCACHE_SESSION_ID`, so
+/// `cmd_compile_ephemeral`). An unavailable daemon must not fail the build.
+#[test]
+fn daemon_unavailable_still_runs_the_compiler() {
+    let (code, stdout, stderr) = run_with_daemon_unavailable(b"", 0, None);
+    assert_tool_actually_ran(&stdout, &stderr);
+    assert_eq!(
+        code,
+        0,
+        "a clean compile must stay clean when the daemon is unavailable.\nstderr = {:?}",
+        String::from_utf8_lossy(&stderr)
+    );
+}
+
+/// The fallback must not paper over real failures: the tool's own non-zero
+/// exit code is the build's answer and must be reported verbatim.
+#[test]
+fn daemon_unavailable_preserves_the_tools_exit_code() {
+    let (code, stdout, stderr) = run_with_daemon_unavailable(b"", 3, None);
+    assert_tool_actually_ran(&stdout, &stderr);
+    assert_eq!(
+        code, 3,
+        "the tool exited 3; the wrapper must report 3, not 0 and not 1"
+    );
+}
+
+/// The session route (`cmd_compile`, used when a host sets
+/// `ZCCACHE_SESSION_ID`) reaches the daemon through a different function and
+/// must honour the same contract.
+#[test]
+fn daemon_unavailable_still_runs_the_compiler_on_the_session_route() {
+    let (code, stdout, stderr) = run_with_daemon_unavailable(b"", 0, Some("fallback-session"));
+    assert_tool_actually_ran(&stdout, &stderr);
+    assert_eq!(
+        code,
+        0,
+        "the session route must fall back too.\nstderr = {:?}",
+        String::from_utf8_lossy(&stderr)
+    );
+}
+
+/// The wrapper slurps its own stdin before talking to the daemon. On the
+/// fallback path those bytes must be replayed to the child, or a compiler
+/// reading from stdin would see an empty input and silently produce the
+/// wrong artifact.
+#[test]
+fn daemon_unavailable_replays_piped_stdin_to_the_compiler() {
+    let payload: Vec<u8> = (0..=255u8).cycle().take(4096).collect();
+    let (code, stdout, stderr) = run_with_daemon_unavailable(&payload, 0, None);
+    assert_tool_actually_ran(&stdout, &stderr);
+    assert_eq!(code, 0);
+
+    let marker_end = stderr
+        .windows(STDERR_MARKER.len())
+        .position(|w| w == STDERR_MARKER)
+        .expect("STDERR_MARKER present")
+        + STDERR_MARKER.len();
+    assert!(
+        stderr[marker_end..]
+            .windows(payload.len())
+            .any(|w| w == payload.as_slice()),
+        "the {} bytes piped into the wrapper never reached the tool — \
+         the fallback must replay slurped stdin, not hand the child an exhausted pipe",
+        payload.len()
+    );
+}


### PR DESCRIPTION
## What breaks

`zccache` is wired in as cargo's `rustc-wrapper`, so every rustc invocation in a build goes through it. Every infrastructure failure in the wrapper returned `ExitCode::FAILURE` without ever running the compiler:

- daemon spawn refused
- connect failed
- send failed
- connection lost mid-request
- daemon-side `Response::Error`
- unexpected response variant
- detected wedge

cargo sees the wrapper exit 1 with no diagnostics and reports

```text
error: could not compile `naga` (lib)
Caused by: process didn't exit successfully: `zccache rustc --crate-name naga ...` (exit status: 1)
```

for a crate that compiles cleanly with `RUSTC_WRAPPER=""`. No `cargo clean` clears it, because the fault is in the wrapper rather than in `target/`. Under parallel builds the daemon resets connections in bursts, so this lands on whichever crate happens to be compiling.

## Why compiling locally is the correct answer

A compiler cache is transparent by contract: wrapping rustc must not change whether the build succeeds.

Only `Response::CompileResult` is a compiler verdict — cached or fresh, success or a genuine compile error — and it is still relayed verbatim, exit code included. Every other outcome means the daemon produced no verdict about this compile, so the wrapper runs the real compiler and reports what it actually did. This generalizes the policy already accepted for protocol mismatch (#27) to every path that cannot produce a verdict. sccache resolves a lost server the same way ("the server looks like it shut down unexpectedly, compiling locally instead").

The faults stay observable rather than fatal: each names itself on stderr, the client-disconnected lifecycle events still fire, and a wedged daemon is still killed so the next invocation starts fresh. Slurped stdin is replayed to the child so a piped invocation is not handed an exhausted pipe.

## One hunk changes the #955 wedge policy — your call

A *detected* wedge (missed wedge budget **and** failed responsiveness probe) currently fails immediately by the fail-fast policy in #955. Here it still kills the daemon, then answers the request by compiling locally.

This is a deliberate policy change and it is separable: the wedge stays exactly as visible (the warning, the lifecycle events, the daemon kill all still happen) and only stops taking the build down with it. If you would rather keep fail-fast for a detected wedge, that hunk can be dropped without touching the rest — the other paths do not depend on it.

## Test

`crates/zccache/tests/cli_wrapper_daemon_fallback.rs` — 4 tests, no daemon required. `ZCCACHE_NO_SPAWN=1` plus an isolated cache root makes the daemon deterministically unavailable, which is exactly the "client cannot get a verdict" condition; `echo_shim` stands in for the compiler and proves it really ran. They cover both wrapper routes (ephemeral and session), exit-code passthrough, and stdin replay.

```
cargo test -p zccache --features zccache-bin,test-support --test cli_wrapper_daemon_fallback
```

Without the two production hunks (test retained, `wrap/ipc.rs` + `wrap/passthrough.rs` reverted), all 4 fail:

```text
the wrapper never ran the tool: STDOUT_MARKER missing. A daemon fault must fall back
to running the real compiler, not exit 1.
stdout = ""
stderr = "zccache[err][R]: cannot start daemon at ...: zccache-daemon spawn disabled
          by host (ZCCACHE_NO_SPAWN=1); ..."

test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out
```

With them:

```text
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

The existing relay unit tests in `wrap/ipc.rs` pin that a real compile error stays a verdict rather than triggering a fallback recompile.

## Base

Branched from f6c77c7 rather than current main. The 22 commits since do not touch `wrap/ipc.rs` or `wrap/passthrough.rs`, and the change cherry-picks onto main with no conflicts. Carries no version bump.
