### PR TITLE
fix(link): isolate side-effect cache capture

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -202,6 +202,21 @@ pub(super) async fn handle_link_ephemeral(
     } else {
         cwd_path.join(&parsed_tool.output_file).into()
     };
+    let output_dir = output_path.parent().unwrap_or(cwd_path);
+
+    // A cache hit also writes the complete artifact set into the output
+    // directory. It must therefore share the same exclusion window as a cold
+    // link's snapshot/link/capture sequence.
+    let _side_effect_guard = if parsed_tool.is_archive {
+        None
+    } else {
+        Some(
+            state
+                .link_output_lock(NormalizedPath::from(output_dir))
+                .lock_owned()
+                .await,
+        )
+    };
     let archive_hash_speculating =
         parsed_tool.is_archive && archive_hash_cache_is_cold(state, tool_path, &inputs);
     let mut speculative_archive_plan = None;
@@ -573,8 +588,6 @@ pub(super) async fn handle_link_ephemeral(
         },
         |plan| plan.rewritten_args.clone(),
     );
-    let output_dir = output_path.parent().unwrap_or(cwd_path);
-
     // Snapshot the output directory before the link so we can detect
     // side-effect files (e.g., runtime DLLs deployed by compiler wrappers).
     // Issue #605 pass 1: archive tools (ar, lib, llvm-ar) only bundle their
@@ -582,10 +595,21 @@ pub(super) async fn handle_link_ephemeral(
     // side-effect files. Skip both pre-link snapshot and post-link rescan
     // for archives — saves a `read_dir` + per-entry `stat` on every archive
     // cold-miss.
+    let mut side_effects_cacheable = true;
+    let mut side_effects_uncacheable_reason = None;
     let dir_snapshot = if parsed_tool.is_archive || directory_plan.is_some() {
-        super::super::side_effect::DirSnapshot::default()
+        None
     } else {
-        super::super::side_effect::snapshot_directory(output_dir)
+        match super::super::side_effect::snapshot_directory(output_dir) {
+            Ok(snapshot) => Some(snapshot),
+            Err(error) => {
+                side_effects_cacheable = false;
+                side_effects_uncacheable_reason = Some(format!(
+                    "failed to snapshot link output directory: {error}"
+                ));
+                None
+            }
+        }
     };
 
     // Extract post-link deploy command from env (if any) BEFORE we consume
@@ -713,12 +737,10 @@ pub(super) async fn handle_link_ephemeral(
             return with_link_warning(result, nd_warning);
         }
 
-        // Enumerate (name, path) for primary + declared secondaries +
-        // detected side-effects in cache-index order so that `outputs[i]`
-        // maps to `{key}_i` on disk after the parallel reads below. Missing
-        // secondaries and read errors are dropped (preserves the prior
-        // serial behavior). Side-effect detection uses the full set of
-        // declared output names so it doesn't double-capture them.
+        // Enumerate primary, declared secondaries, and detected side effects
+        // in cache-index order so `outputs[i]` maps to `{key}_i` on disk.
+        // Every entry must be captured successfully; partial artifacts are
+        // uncacheable. Declared names are excluded from implicit discovery.
         let primary_name_os = parsed_tool
             .output_file
             .file_name()
@@ -735,24 +757,48 @@ pub(super) async fn handle_link_ephemeral(
                 .collect();
         // Issue #605 pass 1: matches the pre-link snapshot skip above —
         // archives have no side-effect files to detect.
-        let side_effects = if parsed_tool.is_archive {
+        let side_effects = if parsed_tool.is_archive || !side_effects_cacheable {
             Vec::new()
-        } else {
-            super::super::side_effect::detect_side_effects(
-                &dir_snapshot,
+        } else if let Some(snapshot) = dir_snapshot.as_ref() {
+            match super::super::side_effect::detect_side_effects(
+                snapshot,
                 output_dir,
                 &primary_name_os,
                 &already_captured,
-            )
-            .unwrap_or_default()
+            ) {
+                Ok(super::super::side_effect::SideEffectScan::Complete(files)) => files,
+                Ok(super::super::side_effect::SideEffectScan::Uncacheable { reason }) => {
+                    side_effects_cacheable = false;
+                    side_effects_uncacheable_reason = Some(reason);
+                    Vec::new()
+                }
+                Err(error) => {
+                    side_effects_cacheable = false;
+                    side_effects_uncacheable_reason =
+                        Some(format!("failed to scan link side effects: {error}"));
+                    Vec::new()
+                }
+            }
+        } else {
+            side_effects_cacheable = false;
+            side_effects_uncacheable_reason =
+                Some("link output directory snapshot was unavailable".to_string());
+            Vec::new()
         };
+
+        if !side_effects_cacheable {
+            tracing::warn!(
+                reason = side_effects_uncacheable_reason.as_deref().unwrap_or("unknown"),
+                "successful link is uncacheable because side-effect capture was incomplete"
+            );
+        }
 
         if let Some(plan) = staged_plan.as_ref() {
             let unexpected_staged = plan.unexpected_staged_entries().unwrap_or_else(|error| {
                 tracing::warn!(%error, "failed to inspect staged linker output set");
                 vec![plan.primary_staged().as_path().to_path_buf()]
             });
-            if !side_effects.is_empty() || !unexpected_staged.is_empty() {
+            if !side_effects_cacheable || !side_effects.is_empty() || !unexpected_staged.is_empty() {
                 tracing::warn!(
                     external_count = side_effects.len(),
                     staged_count = unexpected_staged.len(),
@@ -767,7 +813,7 @@ pub(super) async fn handle_link_ephemeral(
             }
         }
 
-        let mut read_targets: Vec<(String, std::path::PathBuf)> =
+        let mut read_targets: Vec<(String, std::path::PathBuf, Option<ContentHash>)> =
             Vec::with_capacity(1 + parsed_tool.secondary_outputs.len() + side_effects.len());
         read_targets.push((
             primary_name_os.to_string_lossy().into_owned(),
@@ -775,6 +821,7 @@ pub(super) async fn handle_link_ephemeral(
                 || std::path::PathBuf::from(output_path.as_path()),
                 |plan| std::path::PathBuf::from(plan.primary_staged().as_path()),
             ),
+            None,
         ));
         for secondary in &parsed_tool.secondary_outputs {
             let sec_path = if secondary.is_absolute() {
@@ -791,12 +838,13 @@ pub(super) async fn handle_link_ephemeral(
                 .as_ref()
                 .and_then(|plan| plan.staged_for_requested(&sec_path))
                 .map_or(sec_path.clone(), |path| path.into_path_buf());
-            read_targets.push((name, read_path));
+            read_targets.push((name, read_path, None));
         }
         for se in &side_effects {
             read_targets.push((
                 se.file_name.to_string_lossy().into_owned(),
                 std::path::PathBuf::from(se.path.as_path()),
+                Some(se.content_hash),
             ));
         }
 
@@ -804,44 +852,47 @@ pub(super) async fn handle_link_ephemeral(
         // loop when there's only the primary output — rayon dispatch cost
         // (~150 µs) is comparable to one fs::read for small outputs.
         let output_read_started = profile_enabled.then(std::time::Instant::now);
-        let reads: Vec<Option<ArtifactOutput>> = if read_targets.len() <= 1 {
-            read_targets
-                .iter()
-                .map(|(name, path)| {
-                    std::fs::read(path).ok().map(|data| ArtifactOutput {
-                        name: name.clone(),
-                        payload: ArtifactPayload::Bytes(Arc::new(data)),
-                    })
+        let reads: std::io::Result<Vec<ArtifactOutput>> = read_targets
+            .iter()
+            .map(|(name, path, expected_hash)| {
+                let data = std::fs::read(path)?;
+                if let Some(expected_hash) = expected_hash {
+                    if crate::hash::hash_bytes(&data) != *expected_hash {
+                        return Err(std::io::Error::other(format!(
+                            "side-effect changed after scan: {}",
+                            path.display()
+                        )));
+                    }
+                }
+                Ok(ArtifactOutput {
+                    name: name.clone(),
+                    payload: ArtifactPayload::Bytes(Arc::new(data)),
                 })
-                .collect()
-        } else {
-            use rayon::prelude::*;
-            read_targets
-                .par_iter()
-                .map(|(name, path)| {
-                    std::fs::read(path).ok().map(|data| ArtifactOutput {
-                        name: name.clone(),
-                        payload: ArtifactPayload::Bytes(Arc::new(data)),
-                    })
-                })
-                .collect()
-        };
+            })
+            .collect();
         output_read_ns = output_read_started
             .map(|started| started.elapsed().as_nanos() as u64)
             .unwrap_or(0);
 
-        if staged_plan.is_some() && reads.iter().any(Option::is_none) {
-            let _ = staged_plan.as_ref().map(StagedCompilePlan::cleanup);
-            return Response::Error {
-                message: "successful linker omitted a staged output".to_string(),
-            };
-        }
+        let outputs = match reads {
+            Ok(outputs) if side_effects_cacheable => Some(outputs),
+            Ok(_) => None,
+            Err(error) if staged_plan.is_some() => {
+                let _ = staged_plan.as_ref().map(StagedCompilePlan::cleanup);
+                return Response::Error {
+                    message: format!("successful linker omitted a staged output: {error}"),
+                };
+            }
+            Err(error) => {
+                tracing::warn!(%error, "successful link is uncacheable because output capture failed");
+                None
+            }
+        };
 
         // Primary read gates the cache populate. If it fails, the link
         // succeeded but the output file is no longer readable — skip
         // caching, same as the prior serial behavior.
-        if reads.first().and_then(|r| r.as_ref()).is_some() {
-            let outputs: Vec<ArtifactOutput> = reads.into_iter().flatten().collect();
+        if let Some(outputs) = outputs {
             // Log side-effect captures (preserves prior tracing).
             let side_effect_start = 1 + parsed_tool.secondary_outputs.len();
             for o in outputs.iter().skip(side_effect_start) {
@@ -874,8 +925,16 @@ pub(super) async fn handle_link_ephemeral(
                 let persist_meta = cached.meta.clone();
                 let source_paths: Vec<NormalizedPath> = read_targets
                     .iter()
-                    .map(|(_, p)| NormalizedPath::from(p.as_path()))
+                    .map(|(_, path, _)| NormalizedPath::from(path.as_path()))
                     .collect();
+                let mut payloads = Vec::with_capacity(artifact.outputs.len());
+                for output in &artifact.outputs {
+                    let Some(bytes) = output.payload.as_bytes() else {
+                        tracing::warn!(file = %output.name, "link output lacks immutable bytes");
+                        return result;
+                    };
+                    payloads.push(Arc::clone(bytes));
+                }
                 let payload_size: usize = artifact
                     .outputs
                     .iter()
@@ -920,7 +979,7 @@ pub(super) async fn handle_link_ephemeral(
                             .expect("persist_semaphore is owned by ServerState and never closed");
                         let written = tokio::task::spawn_blocking(move || {
                             let _guard = guard;
-                            let _ = persist_artifact_paths(&artifact_dir, &kh, &source_paths);
+                            let _ = persist_artifact_payloads(&artifact_dir, &kh, &payloads);
                             (kh, persist_meta)
                         })
                         .await;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -604,9 +604,8 @@ pub(super) async fn handle_link_ephemeral(
             Ok(snapshot) => Some(snapshot),
             Err(error) => {
                 side_effects_cacheable = false;
-                side_effects_uncacheable_reason = Some(format!(
-                    "failed to snapshot link output directory: {error}"
-                ));
+                side_effects_uncacheable_reason =
+                    Some(format!("failed to snapshot link output directory: {error}"));
                 None
             }
         }
@@ -788,7 +787,9 @@ pub(super) async fn handle_link_ephemeral(
 
         if !side_effects_cacheable {
             tracing::warn!(
-                reason = side_effects_uncacheable_reason.as_deref().unwrap_or("unknown"),
+                reason = side_effects_uncacheable_reason
+                    .as_deref()
+                    .unwrap_or("unknown"),
                 "successful link is uncacheable because side-effect capture was incomplete"
             );
         }
@@ -798,7 +799,8 @@ pub(super) async fn handle_link_ephemeral(
                 tracing::warn!(%error, "failed to inspect staged linker output set");
                 vec![plan.primary_staged().as_path().to_path_buf()]
             });
-            if !side_effects_cacheable || !side_effects.is_empty() || !unexpected_staged.is_empty() {
+            if !side_effects_cacheable || !side_effects.is_empty() || !unexpected_staged.is_empty()
+            {
                 tracing::warn!(
                     external_count = side_effects.len(),
                     staged_count = unexpected_staged.len(),

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -172,6 +172,7 @@ pub(super) fn new_shared_state(
             private_daemon: PrivateDaemonLifecycle::new(),
             sessions: SessionManager::new(std::time::Duration::from_secs(300)),
             session_staged_profiles: DashMap::new(),
+            link_output_locks: DashMap::new(),
             system_includes: Mutex::new(system_includes_loaded),
             system_includes_cache_path,
             dep_graph: arc_swap::ArcSwap::from_pointee(DepGraph::new()),

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -114,6 +114,12 @@ pub(super) struct SharedState {
     /// Request-owned staged telemetry for active tracked sessions.
     pub(super) session_staged_profiles:
         DashMap<SessionId, Arc<crate::daemon::staged_stats::StagedProfiler>>,
+    /// Per-output-directory exclusion for the legacy link side-effect scan.
+    ///
+    /// The scan attributes every changed sibling to one link invocation, so
+    /// two managed links must not overlap their snapshot/link/capture windows
+    /// in the same directory. Weak values let idle directory locks disappear.
+    pub(super) link_output_locks: DashMap<NormalizedPath, std::sync::Weak<Mutex<()>>>,
     pub(super) system_includes: Mutex<SystemIncludeCache>,
     /// Dependency graph: tracks include relationships and cache verdicts.
     ///
@@ -374,6 +380,31 @@ pub(super) struct SharedState {
     /// `Request::ExecStore`. Slice 1 keeps this in-memory only; a
     /// follow-up slice swaps to `KvStore` for persistence.
     pub(super) exec_cache: DashMap<String, Arc<Vec<u8>>>,
+}
+
+impl SharedState {
+    /// Return the lock that owns legacy side-effect capture for `output_dir`.
+    ///
+    /// The returned `Arc` is independent of the DashMap entry guard so callers
+    /// can await `lock_owned` without retaining a map shard lock.
+    pub(super) fn link_output_lock(&self, output_dir: NormalizedPath) -> Arc<Mutex<()>> {
+        match self.link_output_locks.entry(output_dir) {
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                if let Some(lock) = entry.get().upgrade() {
+                    lock
+                } else {
+                    let lock = Arc::new(Mutex::new(()));
+                    entry.insert(Arc::downgrade(&lock));
+                    lock
+                }
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                let lock = Arc::new(Mutex::new(()));
+                entry.insert(Arc::downgrade(&lock));
+                lock
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/zccache-daemon-core/src/daemon/server/tests/link_cache.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/link_cache.rs
@@ -65,6 +65,67 @@ printf 'binary\n' > "$out"
     tool
 }
 
+/// A linker that leaves a marker only when two linker processes run in the
+/// same output directory at once. Its active marker is a directory, which the
+/// side-effect scanner intentionally ignores; the collision marker is a file.
+#[cfg(unix)]
+fn write_overlap_detecting_linker(dir: &Path) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tool = dir.join("overlap-clang");
+    std::fs::write(
+        &tool,
+        r#"#!/bin/sh
+out=
+while [ "$#" -gt 0 ]; do
+if [ "$1" = "-o" ]; then
+    shift
+    out=$1
+fi
+shift || true
+done
+if [ -z "$out" ]; then
+exit 2
+fi
+out_dir=$(dirname "$out")
+if ! mkdir "$out_dir/.zccache-link-active" 2>/dev/null; then
+    printf 'overlap\n' > "$out_dir/parallel-link-collision"
+fi
+sleep 0.2
+printf 'binary-%s\n' "$(basename "$out")" > "$out"
+printf 'sidecar-%s\n' "$(basename "$out")" > "$out.sidecar"
+rmdir "$out_dir/.zccache-link-active" 2>/dev/null || true
+"#,
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&tool).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&tool, permissions).unwrap();
+    tool
+}
+
+#[cfg(windows)]
+fn write_overlap_detecting_linker(dir: &Path) -> std::path::PathBuf {
+    let tool = dir.join("overlap-clang.cmd");
+    std::fs::write(
+        &tool,
+        r#"@echo off
+set "OUT=%~2"
+if "%OUT%"=="" exit /b 2
+for %%I in ("%OUT%") do set "OUTDIR=%%~dpI"
+mkdir "%OUTDIR%\.zccache-link-active" >nul 2>nul
+if errorlevel 1 > "%OUTDIR%parallel-link-collision" echo overlap
+ping -n 2 127.0.0.1 >nul
+> "%OUT%" echo binary-%~nx2
+> "%OUT%.sidecar" echo sidecar-%~nx2
+rmdir "%OUTDIR%\.zccache-link-active" >nul 2>nul
+exit /b 0
+"#,
+    )
+    .unwrap();
+    tool
+}
+
 #[cfg(unix)]
 fn write_fake_dsymutil(dir: &Path) -> std::path::PathBuf {
     use std::os::unix::fs::PermissionsExt;
@@ -235,6 +296,141 @@ async fn link_cache_hit_restores_sibling_side_effects() {
     assert!(
         wasm_map.exists(),
         "cache hit should restore the wasm map sidecar"
+    );
+}
+
+/// #912: two cold links in the same output directory must not overlap their
+/// snapshot/link/rescan windows. Otherwise each can claim the other's newly
+/// created sidecar as part of its own cached artifact.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parallel_same_directory_links_are_isolated() {
+    if staged_link_lane_enabled() {
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let fake_linker = write_overlap_detecting_linker(tmp.path());
+    let input_a = tmp.path().join("a.o");
+    let input_b = tmp.path().join("b.o");
+    let output_a = tmp.path().join("a.exe");
+    let output_b = tmp.path().join("b.exe");
+    let sidecar_a = output_a.with_extension("exe.sidecar");
+    let sidecar_b = output_b.with_extension("exe.sidecar");
+    std::fs::write(&input_a, b"input-a").unwrap();
+    std::fs::write(&input_b, b"input-b").unwrap();
+
+    let _cache_dir = CacheDirEnvGuard::set(&tmp.path().join("zccache-cache"));
+    let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
+    let args_a = vec![
+        "-o".to_string(),
+        output_a.to_string_lossy().into_owned(),
+        input_a.to_string_lossy().into_owned(),
+    ];
+    let args_b = vec![
+        "-o".to_string(),
+        output_b.to_string_lossy().into_owned(),
+        input_b.to_string_lossy().into_owned(),
+    ];
+
+    let (first_a, first_b) = tokio::join!(
+        handle_link_ephemeral(
+            &server.state,
+            std::process::id(),
+            &fake_linker,
+            &args_a,
+            tmp.path(),
+            None,
+        ),
+        handle_link_ephemeral(
+            &server.state,
+            std::process::id(),
+            &fake_linker,
+            &args_b,
+            tmp.path(),
+            None,
+        )
+    );
+    assert!(matches!(
+        first_a,
+        Response::LinkResult {
+            exit_code: 0,
+            cached: false,
+            ..
+        }
+    ));
+    assert!(matches!(
+        first_b,
+        Response::LinkResult {
+            exit_code: 0,
+            cached: false,
+            ..
+        }
+    ));
+    assert!(
+        !tmp.path().join("parallel-link-collision").exists(),
+        "links sharing an output directory must not overlap"
+    );
+
+    std::fs::remove_file(&output_a).unwrap();
+    std::fs::remove_file(&sidecar_a).unwrap();
+    std::fs::remove_file(&sidecar_b).unwrap();
+    let hit_a = handle_link_ephemeral(
+        &server.state,
+        std::process::id(),
+        &fake_linker,
+        &args_a,
+        tmp.path(),
+        None,
+    )
+    .await;
+    assert!(matches!(
+        hit_a,
+        Response::LinkResult {
+            exit_code: 0,
+            cached: true,
+            ..
+        }
+    ));
+    assert!(std::fs::read(sidecar_a)
+        .unwrap()
+        .starts_with(b"sidecar-a.exe"));
+    assert!(
+        !sidecar_b.exists(),
+        "a cache hit must not restore b's sidecar"
+    );
+}
+
+/// #912: the side-effect lock is keyed by output directory, not globally.
+#[tokio::test]
+async fn side_effect_lock_allows_different_output_directories() {
+    let tmp = tempfile::tempdir().unwrap();
+    let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
+    let lock_a = server
+        .state
+        .link_output_lock(tmp.path().join("a").into());
+    let same_lock_a = server
+        .state
+        .link_output_lock(tmp.path().join("a").into());
+    let lock_b = server
+        .state
+        .link_output_lock(tmp.path().join("b").into());
+    assert!(std::sync::Arc::ptr_eq(&lock_a, &same_lock_a));
+    assert!(!std::sync::Arc::ptr_eq(&lock_a, &lock_b));
+
+    let _guard_a = lock_a.lock_owned().await;
+    let _guard_b = tokio::time::timeout(
+        std::time::Duration::from_millis(50),
+        lock_b.lock_owned(),
+    )
+    .await
+    .expect("a lock held for one output directory must not block another");
+    assert!(
+        tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            same_lock_a.lock_owned(),
+        )
+        .await
+        .is_err(),
+        "the same output directory must remain exclusive"
     );
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/tests/link_cache.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/link_cache.rs
@@ -404,25 +404,16 @@ async fn parallel_same_directory_links_are_isolated() {
 async fn side_effect_lock_allows_different_output_directories() {
     let tmp = tempfile::tempdir().unwrap();
     let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
-    let lock_a = server
-        .state
-        .link_output_lock(tmp.path().join("a").into());
-    let same_lock_a = server
-        .state
-        .link_output_lock(tmp.path().join("a").into());
-    let lock_b = server
-        .state
-        .link_output_lock(tmp.path().join("b").into());
+    let lock_a = server.state.link_output_lock(tmp.path().join("a").into());
+    let same_lock_a = server.state.link_output_lock(tmp.path().join("a").into());
+    let lock_b = server.state.link_output_lock(tmp.path().join("b").into());
     assert!(std::sync::Arc::ptr_eq(&lock_a, &same_lock_a));
     assert!(!std::sync::Arc::ptr_eq(&lock_a, &lock_b));
 
     let _guard_a = lock_a.lock_owned().await;
-    let _guard_b = tokio::time::timeout(
-        std::time::Duration::from_millis(50),
-        lock_b.lock_owned(),
-    )
-    .await
-    .expect("a lock held for one output directory must not block another");
+    let _guard_b = tokio::time::timeout(std::time::Duration::from_millis(50), lock_b.lock_owned())
+        .await
+        .expect("a lock held for one output directory must not block another");
     assert!(
         tokio::time::timeout(
             std::time::Duration::from_millis(50),

--- a/crates/zccache-daemon-core/src/daemon/side_effect.rs
+++ b/crates/zccache-daemon-core/src/daemon/side_effect.rs
@@ -167,7 +167,9 @@ mod tests {
     fn complete(scan: SideEffectScan) -> Vec<SideEffectFile> {
         match scan {
             SideEffectScan::Complete(files) => files,
-            SideEffectScan::Uncacheable { reason } => panic!("unexpected uncacheable scan: {reason}"),
+            SideEffectScan::Uncacheable { reason } => {
+                panic!("unexpected uncacheable scan: {reason}")
+            }
         }
     }
 

--- a/crates/zccache-daemon-core/src/daemon/side_effect.rs
+++ b/crates/zccache-daemon-core/src/daemon/side_effect.rs
@@ -8,15 +8,18 @@
 //! sibling files as side effects to cache.
 
 use crate::core::NormalizedPath;
+use crate::hash::{hash_file, ContentHash};
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::path::Path;
 use std::time::SystemTime;
 
-/// Maximum size (bytes) for a single side-effect file. Larger files are skipped.
+/// Maximum size (bytes) for a single side-effect file. Larger files make the
+/// whole link result uncacheable: storing a partial output set is incorrect.
 const MAX_SIDE_EFFECT_SIZE: u64 = 50 * 1024 * 1024; // 50 MB
 
-/// Maximum number of side-effect files captured per link invocation.
+/// Maximum number of side-effect files captured per link invocation. Exceeding
+/// this makes the whole link result uncacheable.
 const MAX_SIDE_EFFECT_COUNT: usize = 10;
 
 /// Snapshot of a directory: filename → (size, mtime).
@@ -28,37 +31,66 @@ pub struct DirSnapshot {
 struct FileEntry {
     size: u64,
     modified: SystemTime,
+    content_hash: ContentHash,
 }
 
 /// A detected side-effect file ready to be cached.
+#[derive(Debug)]
 pub struct SideEffectFile {
     pub path: NormalizedPath,
     pub file_name: std::ffi::OsString,
+    pub content_hash: ContentHash,
 }
 
-/// Capture the current state of `dir`. Returns an empty snapshot if the
-/// directory does not exist or cannot be read (e.g., it will be created
-/// by the linker).
-pub fn snapshot_directory(dir: &Path) -> DirSnapshot {
+/// Result of scanning a link output directory for implicit outputs.
+///
+/// A successful linker invocation may still be uncacheable when zccache cannot
+/// retain the complete output set. Callers must return the linker result but
+/// skip cache population for [`Self::Uncacheable`].
+pub enum SideEffectScan {
+    Complete(Vec<SideEffectFile>),
+    Uncacheable { reason: String },
+}
+
+fn stable_file_entry(path: &Path) -> std::io::Result<FileEntry> {
+    let before = std::fs::metadata(path)?;
+    let content_hash = hash_file(path)?;
+    let after = std::fs::metadata(path)?;
+    let before_modified = before.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+    let after_modified = after.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+    if before.len() != after.len() || before_modified != after_modified {
+        return Err(std::io::Error::other(format!(
+            "file changed while snapshotting: {}",
+            path.display()
+        )));
+    }
+    Ok(FileEntry {
+        size: after.len(),
+        modified: after_modified,
+        content_hash,
+    })
+}
+
+/// Capture the current state of `dir`.
+///
+/// A nonexistent directory is empty because a linker may create it. Any other
+/// scan error is returned so the caller can fail cache population closed.
+pub fn snapshot_directory(dir: &Path) -> std::io::Result<DirSnapshot> {
     let mut snap = DirSnapshot::default();
     let entries = match std::fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(_) => return snap,
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(snap),
+        Err(error) => return Err(error),
     };
-    for entry in entries.flatten() {
-        if let Ok(meta) = entry.metadata() {
-            if meta.is_file() {
-                snap.entries.insert(
-                    entry.file_name(),
-                    FileEntry {
-                        size: meta.len(),
-                        modified: meta.modified().unwrap_or(SystemTime::UNIX_EPOCH),
-                    },
-                );
-            }
+    for entry in entries {
+        let entry = entry?;
+        if entry.metadata()?.is_file() {
+            let path = entry.path();
+            snap.entries
+                .insert(entry.file_name(), stable_file_entry(&path)?);
         }
     }
-    snap
+    Ok(snap)
 }
 
 /// Re-scan `dir` and return files that are new or changed since `before`,
@@ -68,10 +100,11 @@ pub fn detect_side_effects(
     dir: &Path,
     primary_name: &OsStr,
     already_captured: &HashSet<std::ffi::OsString>,
-) -> std::io::Result<Vec<SideEffectFile>> {
+) -> std::io::Result<SideEffectScan> {
     let mut results = Vec::new();
 
-    for entry in std::fs::read_dir(dir)?.flatten() {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
         let name = entry.file_name();
 
         // Skip the primary output and already-captured secondaries.
@@ -79,46 +112,46 @@ pub fn detect_side_effects(
             continue;
         }
 
-        let meta = match entry.metadata() {
-            Ok(m) if m.is_file() => m,
-            _ => continue,
-        };
+        if !entry.metadata()?.is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let current = stable_file_entry(&path)?;
 
-        // Skip files that existed before the link with the same size+mtime.
+        // Strong content identity catches same-size changes on filesystems
+        // whose timestamp resolution is too coarse to distinguish rewrites.
         if let Some(prev) = before.entries.get(&name) {
-            let same_size = prev.size == meta.len();
-            let same_mtime = meta.modified().map(|m| m == prev.modified).unwrap_or(false);
-            if same_size && same_mtime {
+            if prev.size == current.size
+                && prev.modified == current.modified
+                && prev.content_hash == current.content_hash
+            {
                 continue;
             }
         }
 
-        // Enforce size limit.
-        if meta.len() > MAX_SIDE_EFFECT_SIZE {
-            tracing::warn!(
-                file = %name.to_string_lossy(),
-                size = meta.len(),
-                limit = MAX_SIDE_EFFECT_SIZE,
-                "side-effect file exceeds size limit, skipping"
-            );
-            continue;
+        if current.size > MAX_SIDE_EFFECT_SIZE {
+            return Ok(SideEffectScan::Uncacheable {
+                reason: format!(
+                    "side-effect {} exceeds {MAX_SIDE_EFFECT_SIZE}-byte limit",
+                    name.to_string_lossy()
+                ),
+            });
         }
 
         results.push(SideEffectFile {
-            path: entry.path().into(),
+            path: path.into(),
             file_name: name,
+            content_hash: current.content_hash,
         });
 
-        if results.len() >= MAX_SIDE_EFFECT_COUNT {
-            tracing::warn!(
-                limit = MAX_SIDE_EFFECT_COUNT,
-                "side-effect file count limit reached, truncating"
-            );
-            break;
+        if results.len() > MAX_SIDE_EFFECT_COUNT {
+            return Ok(SideEffectScan::Uncacheable {
+                reason: format!("side-effect count exceeds {MAX_SIDE_EFFECT_COUNT}"),
+            });
         }
     }
 
-    Ok(results)
+    Ok(SideEffectScan::Complete(results))
 }
 
 #[cfg(test)]
@@ -127,16 +160,28 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
+    fn snapshot(dir: &Path) -> DirSnapshot {
+        snapshot_directory(dir).unwrap()
+    }
+
+    fn complete(scan: SideEffectScan) -> Vec<SideEffectFile> {
+        match scan {
+            SideEffectScan::Complete(files) => files,
+            SideEffectScan::Uncacheable { reason } => panic!("unexpected uncacheable scan: {reason}"),
+        }
+    }
+
     #[test]
     fn new_dll_detected() {
         let dir = TempDir::new().unwrap();
-        let snap = snapshot_directory(dir.path());
+        let snap = snapshot(dir.path());
 
         // Simulate linker deploying a DLL after the snapshot.
         fs::write(dir.path().join("asan_runtime.dll"), b"fake dll").unwrap();
 
-        let found =
-            detect_side_effects(&snap, dir.path(), OsStr::new("app.exe"), &HashSet::new()).unwrap();
+        let found = complete(
+            detect_side_effects(&snap, dir.path(), OsStr::new("app.exe"), &HashSet::new()).unwrap(),
+        );
 
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].file_name, "asan_runtime.dll");
@@ -147,11 +192,12 @@ mod tests {
         let dir = TempDir::new().unwrap();
         fs::write(dir.path().join("existing.dll"), b"old dll").unwrap();
 
-        let snap = snapshot_directory(dir.path());
+        let snap = snapshot(dir.path());
 
         // No changes after snapshot.
-        let found =
-            detect_side_effects(&snap, dir.path(), OsStr::new("app.exe"), &HashSet::new()).unwrap();
+        let found = complete(
+            detect_side_effects(&snap, dir.path(), OsStr::new("app.exe"), &HashSet::new()).unwrap(),
+        );
 
         assert!(found.is_empty());
     }
@@ -159,12 +205,13 @@ mod tests {
     #[test]
     fn primary_output_excluded() {
         let dir = TempDir::new().unwrap();
-        let snap = snapshot_directory(dir.path());
+        let snap = snapshot(dir.path());
 
         fs::write(dir.path().join("app.dll"), b"primary").unwrap();
 
-        let found =
-            detect_side_effects(&snap, dir.path(), OsStr::new("app.dll"), &HashSet::new()).unwrap();
+        let found = complete(
+            detect_side_effects(&snap, dir.path(), OsStr::new("app.dll"), &HashSet::new()).unwrap(),
+        );
 
         assert!(found.is_empty());
     }
@@ -172,15 +219,16 @@ mod tests {
     #[test]
     fn already_captured_excluded() {
         let dir = TempDir::new().unwrap();
-        let snap = snapshot_directory(dir.path());
+        let snap = snapshot(dir.path());
 
         fs::write(dir.path().join("foo.dll"), b"secondary").unwrap();
 
         let mut captured = HashSet::new();
         captured.insert(std::ffi::OsString::from("foo.dll"));
 
-        let found =
-            detect_side_effects(&snap, dir.path(), OsStr::new("app.exe"), &captured).unwrap();
+        let found = complete(
+            detect_side_effects(&snap, dir.path(), OsStr::new("app.exe"), &captured).unwrap(),
+        );
 
         assert!(found.is_empty());
     }
@@ -188,14 +236,15 @@ mod tests {
     #[test]
     fn non_shared_sibling_detected() {
         let dir = TempDir::new().unwrap();
-        let snap = snapshot_directory(dir.path());
+        let snap = snapshot(dir.path());
 
         fs::write(dir.path().join("debug.pdb"), b"pdb data").unwrap();
         fs::write(dir.path().join("build.log"), b"log data").unwrap();
         fs::write(dir.path().join("output.obj"), b"obj data").unwrap();
 
-        let found =
-            detect_side_effects(&snap, dir.path(), OsStr::new("app.exe"), &HashSet::new()).unwrap();
+        let found = complete(
+            detect_side_effects(&snap, dir.path(), OsStr::new("app.exe"), &HashSet::new()).unwrap(),
+        );
 
         assert_eq!(found.len(), 3);
         let names: HashSet<_> = found.iter().map(|f| f.file_name.clone()).collect();
@@ -207,7 +256,7 @@ mod tests {
     #[test]
     fn size_limit_enforced() {
         let dir = TempDir::new().unwrap();
-        let snap = snapshot_directory(dir.path());
+        let snap = snapshot(dir.path());
 
         // Create a file exceeding MAX_SIDE_EFFECT_SIZE (use sparse-like approach).
         let big_path = dir.path().join("huge.dll");
@@ -217,13 +266,13 @@ mod tests {
         let found =
             detect_side_effects(&snap, dir.path(), OsStr::new("app.exe"), &HashSet::new()).unwrap();
 
-        assert!(found.is_empty());
+        assert!(matches!(found, SideEffectScan::Uncacheable { .. }));
     }
 
     #[test]
     fn count_limit_enforced() {
         let dir = TempDir::new().unwrap();
-        let snap = snapshot_directory(dir.path());
+        let snap = snapshot(dir.path());
 
         for i in 0..15 {
             fs::write(dir.path().join(format!("lib{i}.dll")), b"dll").unwrap();
@@ -232,12 +281,12 @@ mod tests {
         let found =
             detect_side_effects(&snap, dir.path(), OsStr::new("app.exe"), &HashSet::new()).unwrap();
 
-        assert_eq!(found.len(), MAX_SIDE_EFFECT_COUNT);
+        assert!(matches!(found, SideEffectScan::Uncacheable { .. }));
     }
 
     #[test]
     fn nonexistent_dir_snapshot_is_empty() {
-        let snap = snapshot_directory(Path::new("/nonexistent/path/xyz"));
+        let snap = snapshot(Path::new("/nonexistent/path/xyz"));
         assert!(snap.entries.is_empty());
     }
 
@@ -246,14 +295,34 @@ mod tests {
         let dir = TempDir::new().unwrap();
         fs::write(dir.path().join("runtime.dll"), b"v1").unwrap();
 
-        let snap = snapshot_directory(dir.path());
+        let snap = snapshot(dir.path());
 
         // Overwrite with different content (different size → detected).
         fs::write(dir.path().join("runtime.dll"), b"version2-longer").unwrap();
 
-        let found =
-            detect_side_effects(&snap, dir.path(), OsStr::new("app.exe"), &HashSet::new()).unwrap();
+        let found = complete(
+            detect_side_effects(&snap, dir.path(), OsStr::new("app.exe"), &HashSet::new()).unwrap(),
+        );
 
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].file_name, "runtime.dll");
+    }
+
+    #[test]
+    fn same_size_same_mtime_rewrite_is_detected() {
+        let dir = TempDir::new().unwrap();
+        let runtime = dir.path().join("runtime.dll");
+        fs::write(&runtime, b"v1").unwrap();
+        let fixed_mtime = filetime::FileTime::from_unix_time(1_700_000_000, 0);
+        filetime::set_file_mtime(&runtime, fixed_mtime).unwrap();
+        let snap = snapshot(dir.path());
+
+        fs::write(&runtime, b"v2").unwrap();
+        filetime::set_file_mtime(&runtime, fixed_mtime).unwrap();
+
+        let found = complete(
+            detect_side_effects(&snap, dir.path(), OsStr::new("app.exe"), &HashSet::new()).unwrap(),
+        );
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].file_name, "runtime.dll");
     }


### PR DESCRIPTION
Closes #912\n\n## Summary\n- serialize link cache hits and misses per output directory while side effects are observed and captured\n- fail closed on incomplete side-effect scans or output capture, while preserving a successful linker result\n- persist immutable captured payload bytes instead of mutable live output paths\n- add Windows/Unix coverage for same-directory isolation, different-directory independence, limits, and same-size/same-mtime rewrites\n\n## Validation\n- soldr cargo fmt --all -- --check\n- soldr cargo clippy -p zccache-daemon-core --features test-support --lib -- -D warnings\n- soldr cargo test -p zccache-daemon-core --features test-support link_cache --lib\n- soldr cargo test -p zccache-daemon-core --features test-support side_effect --lib