### PR TITLE
fix(depgraph): isolate equivalent worktree state

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -269,7 +269,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 ctx,
                 dep_flags,
                 None,
-                registration.key,
+                registration.map_key,
                 None,
                 registration.rebased_from_equivalent_root,
             )
@@ -316,8 +316,8 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 compat_ctx,
                 UserDepFlags::default(),
                 Some(rustc_args),
-                registration.key,
-                compat_key,
+                registration.map_key,
+                registration.metadata_compat_map_key,
                 registration.rebased_from_equivalent_root,
             )
         }

--- a/crates/zccache-daemon-core/src/daemon/server/keys.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/keys.rs
@@ -594,8 +594,15 @@ pub(super) fn request_cache_artifact_matches(
         file_hashes.push((path, hash));
     }
 
+    let Some(logical_context_key) = state
+        .dep_graph
+        .load()
+        .logical_context_key(&entry.context_key)
+    else {
+        return false;
+    };
     let artifact_key = crate::depgraph::compute_artifact_key(
-        &entry.context_key,
+        &logical_context_key,
         &mut file_hashes,
         Some(root.as_path()),
     );

--- a/crates/zccache-depgraph/src/graph/check.rs
+++ b/crates/zccache-depgraph/src/graph/check.rs
@@ -266,10 +266,14 @@ impl DepGraph {
         G: Fn(&Path) -> Option<ContentHash>,
         E: Fn(&str) -> Option<String>,
     {
+        let Some(key) = self.resolve_instance_key(key) else {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+            return CacheVerdict::Cold;
+        };
         self.checks.fetch_add(1, Ordering::Relaxed);
 
-        let rustc_externs = self.rustc_extern_inputs(key);
-        let mut entry = match self.contexts.get_mut(key) {
+        let rustc_externs = self.rustc_extern_inputs(&key);
+        let mut entry = match self.contexts.get_mut(&key) {
             Some(e) => e,
             None => {
                 self.misses.fetch_add(1, Ordering::Relaxed);
@@ -373,16 +377,16 @@ impl DepGraph {
                 return CacheVerdict::Cold;
             };
             let base = compute_rustc_artifact_key_with_root_with(
-                key,
+                &entry.logical_key,
                 &mut file_hashes,
                 &mut extern_hashes,
                 entry.key_root.as_deref(),
                 |path, key_root| self.cached_normalize_key_path(path, key_root),
             );
-            self.fold_env_deps_for_key(key, base, &env_value)
+            self.fold_env_deps_for_key(&key, base, &env_value)
         } else {
             compute_artifact_key_with(
-                key,
+                &entry.logical_key,
                 &mut file_hashes,
                 entry.key_root.as_deref(),
                 |path, key_root| self.cached_normalize_key_path(path, key_root),
@@ -464,10 +468,14 @@ impl DepGraph {
         G: Fn(&Path) -> Option<ContentHash>,
         E: Fn(&str) -> Option<String>,
     {
+        let Some(key) = self.resolve_instance_key(key) else {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+            return (CacheVerdict::Cold, "context_key not registered".to_string());
+        };
         self.checks.fetch_add(1, Ordering::Relaxed);
 
-        let rustc_externs = self.rustc_extern_inputs(key);
-        let mut entry = match self.contexts.get_mut(key) {
+        let rustc_externs = self.rustc_extern_inputs(&key);
+        let mut entry = match self.contexts.get_mut(&key) {
             Some(e) => e,
             None => {
                 self.misses.fetch_add(1, Ordering::Relaxed);
@@ -591,16 +599,16 @@ impl DepGraph {
                 return (CacheVerdict::Cold, "rustc extern hash missing".to_string());
             };
             let base = compute_rustc_artifact_key_with_root_with(
-                key,
+                &entry.logical_key,
                 &mut file_hashes,
                 &mut extern_hashes,
                 entry.key_root.as_deref(),
                 |path, key_root| self.cached_normalize_key_path(path, key_root),
             );
-            self.fold_env_deps_for_key(key, base, &env_value)
+            self.fold_env_deps_for_key(&key, base, &env_value)
         } else {
             compute_artifact_key_with(
-                key,
+                &entry.logical_key,
                 &mut file_hashes,
                 entry.key_root.as_deref(),
                 |path, key_root| self.cached_normalize_key_path(path, key_root),
@@ -704,8 +712,9 @@ impl DepGraph {
         G: Fn(&Path) -> Option<ContentHash>,
         E: Fn(&str) -> Option<String>,
     {
-        let rustc_externs = self.rustc_extern_inputs(key);
-        let entry = self.contexts.get(key)?;
+        let key = self.resolve_instance_key(key)?;
+        let rustc_externs = self.rustc_extern_inputs(&key);
+        let entry = self.contexts.get(&key)?;
 
         if entry.state == ContextState::Cold || entry.has_computed_includes {
             return None;
@@ -731,16 +740,16 @@ impl DepGraph {
         let computed = if let Some(externs) = rustc_externs.as_deref() {
             let mut extern_hashes = collect_rustc_extern_hashes(externs, &get_hash)?;
             let base = compute_rustc_artifact_key_with_root_with(
-                key,
+                &entry.logical_key,
                 &mut file_hashes,
                 &mut extern_hashes,
                 entry.key_root.as_deref(),
                 |path, key_root| self.cached_normalize_key_path(path, key_root),
             );
-            self.fold_env_deps_for_key(key, base, &env_value)
+            self.fold_env_deps_for_key(&key, base, &env_value)
         } else {
             compute_artifact_key_with(
-                key,
+                &entry.logical_key,
                 &mut file_hashes,
                 entry.key_root.as_deref(),
                 |path, key_root| self.cached_normalize_key_path(path, key_root),

--- a/crates/zccache-depgraph/src/graph/maintenance.rs
+++ b/crates/zccache-depgraph/src/graph/maintenance.rs
@@ -100,6 +100,11 @@ impl DepGraph {
             }
         }
 
+        self.indexes.equivalent_contexts.retain(|_, instances| {
+            instances.retain(|instance| self.contexts.contains_key(instance));
+            !instances.is_empty()
+        });
+
         let live_contexts: std::collections::HashSet<ContextKey> =
             self.contexts.iter().map(|entry| *entry.key()).collect();
         let stale_externs: Vec<ContextKey> = self
@@ -130,6 +135,21 @@ impl DepGraph {
             .collect();
         for key in stale_env_deps {
             self.rustc_env_deps.remove(&key);
+        }
+
+        let stale_compat: Vec<ContextKey> = self
+            .rustc_check_metadata_compat
+            .iter()
+            .filter_map(|entry| {
+                if live_contexts.contains(entry.value()) {
+                    None
+                } else {
+                    Some(*entry.key())
+                }
+            })
+            .collect();
+        for key in stale_compat {
+            self.rustc_check_metadata_compat.remove(&key);
         }
 
         // Also trim file entries not referenced by any context.
@@ -167,9 +187,11 @@ impl DepGraph {
     pub fn clear(&self) {
         self.files.clear();
         self.contexts.clear();
+        self.indexes.equivalent_contexts.clear();
         self.rustc_externs.clear();
         self.rustc_env_deps.clear();
-        self.path_key_cache.clear();
+        self.rustc_check_metadata_compat.clear();
+        self.indexes.path_key_cache.clear();
         self.checks.store(0, Ordering::Relaxed);
         self.hits.store(0, Ordering::Relaxed);
         self.misses.store(0, Ordering::Relaxed);
@@ -190,7 +212,18 @@ impl DepGraph {
     /// Get the state of a context entry.
     #[must_use]
     pub fn get_state(&self, key: &ContextKey) -> Option<ContextState> {
-        self.contexts.get(key).map(|e| e.state)
+        self.resolve_instance_key(key)
+            .and_then(|key| self.contexts.get(&key).map(|e| e.state))
+    }
+
+    /// Return the root-normalized identity for an exact mutable instance.
+    /// Request-cache validation uses this to recompute the content-addressed
+    /// artifact key without accidentally folding the checkout discriminator
+    /// into cache identity.
+    #[must_use]
+    pub fn logical_context_key(&self, key: &ContextKey) -> Option<ContextKey> {
+        self.resolve_instance_key(key)
+            .and_then(|key| self.contexts.get(&key).map(|e| e.logical_key))
     }
 
     /// Count contexts by state. Returned as `(cold, warm, stale)`.
@@ -231,13 +264,15 @@ impl DepGraph {
     /// Get the resolved includes for a context.
     #[must_use]
     pub fn get_includes(&self, key: &ContextKey) -> Option<Vec<NormalizedPath>> {
-        self.contexts.get(key).map(|e| e.resolved_includes.clone())
+        self.resolve_instance_key(key)
+            .and_then(|key| self.contexts.get(&key).map(|e| e.resolved_includes.clone()))
     }
 
     /// Get rustc extern input paths for a context.
     #[must_use]
     pub fn get_rustc_externs(&self, key: &ContextKey) -> Option<Vec<(String, NormalizedPath)>> {
-        self.rustc_extern_inputs(key)
+        self.resolve_instance_key(key)
+            .and_then(|key| self.rustc_extern_inputs(&key))
     }
 
     /// Get the recorded rustc env-dep snapshot for a context
@@ -249,12 +284,16 @@ impl DepGraph {
         &self,
         key: &ContextKey,
     ) -> Option<Vec<(String, Option<ContentHash>)>> {
-        self.rustc_env_dep_inputs(key)
+        self.resolve_instance_key(key)
+            .and_then(|key| self.rustc_env_dep_inputs(&key))
     }
 
     /// Replace the recorded rustc env-dep snapshot for a context
     /// (zccache#1021). An empty `deps` removes the entry.
     pub fn set_rustc_env_deps(&self, key: ContextKey, deps: Vec<(String, Option<ContentHash>)>) {
+        let Some(key) = self.resolve_instance_key(&key) else {
+            return;
+        };
         if deps.is_empty() {
             self.rustc_env_deps.remove(&key);
         } else {
@@ -292,7 +331,10 @@ impl DepGraph {
     /// Mark a context as stale, requiring rescan on next check.
     /// Returns `true` if the context existed and was marked stale.
     pub fn mark_stale(&self, key: &ContextKey) -> bool {
-        if let Some(mut entry) = self.contexts.get_mut(key) {
+        let Some(key) = self.resolve_instance_key(key) else {
+            return false;
+        };
+        if let Some(mut entry) = self.contexts.get_mut(&key) {
             entry.state = ContextState::Stale;
             true
         } else {

--- a/crates/zccache-depgraph/src/graph/mod.rs
+++ b/crates/zccache-depgraph/src/graph/mod.rs
@@ -22,7 +22,7 @@ use std::time::Instant;
 
 use dashmap::DashMap;
 use zccache_core::NormalizedPath;
-use zccache_hash::ContentHash;
+use zccache_hash::{ContentHash, StreamHasher};
 
 use super::context::{ArtifactKey, CompileContext, ContextKey};
 use super::scanner::IncludeDirective;
@@ -50,6 +50,8 @@ pub enum ContextState {
 /// A compilation context entry in the graph.
 #[derive(Debug, Clone)]
 pub struct ContextEntry {
+    /// Root-normalized identity used for content-addressed artifact keys.
+    pub logical_key: ContextKey,
     /// The compilation context (source + flags).
     pub context: CompileContext,
     /// Optional root used to normalize project-local paths in cache keys.
@@ -68,6 +70,53 @@ pub struct ContextEntry {
     pub last_accessed: Instant,
     /// Current state.
     pub state: ContextState,
+}
+
+/// Checkout-specific identity for mutable dependency-graph state.
+///
+/// Its logical component remains root-normalized for artifact sharing. Its
+/// concrete component is deliberately excluded from artifact-key computation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ContextInstanceKey {
+    logical: ContextKey,
+    concrete: ContentHash,
+}
+
+impl ContextInstanceKey {
+    #[must_use]
+    pub fn logical(self) -> ContextKey {
+        self.logical
+    }
+
+    #[must_use]
+    pub fn concrete(self) -> ContentHash {
+        self.concrete
+    }
+
+    pub(crate) fn new(
+        logical: ContextKey,
+        source_file: &NormalizedPath,
+        key_root: Option<&NormalizedPath>,
+    ) -> Self {
+        let mut hash = StreamHasher::new();
+        hash.update(b"zccache-context-instance-v1\0");
+        hash.update(logical.hash().as_bytes());
+        hash.update(source_file.case_key().unwrap_or_default().as_bytes());
+        hash.update(b"\0");
+        match key_root {
+            Some(root) => hash.update(root.case_key().unwrap_or_default().as_bytes()),
+            None => hash.update(b"no-key-root"),
+        };
+        Self {
+            logical,
+            concrete: hash.finalize(),
+        }
+    }
+
+    #[must_use]
+    pub fn map_key(self) -> ContextKey {
+        ContextKey::from_raw(*self.concrete.as_bytes())
+    }
 }
 
 /// Result of checking a context against the file cache.
@@ -112,7 +161,7 @@ impl std::fmt::Debug for DepGraph {
 
 pub struct DepGraph {
     /// Shared file nodes: path → scanned includes.
-    pub(super) files: DashMap<NormalizedPath, FileEntry>,
+    pub(super) files: Box<DashMap<NormalizedPath, FileEntry>>,
     /// Per-context entries: context key → include list + state.
     pub(super) contexts: DashMap<ContextKey, ContextEntry>,
     /// Rustc-only extern inputs keyed by context.
@@ -135,8 +184,9 @@ pub struct DepGraph {
     pub(super) rustc_env_deps: DashMap<ContextKey, Vec<(String, Option<ContentHash>)>>,
     /// Rustc check/build metadata compatibility alias.
     ///
-    /// Keyed by `RustcCompileContext::check_metadata_compat_key_with_root`.
-    /// Values are exact build-style context keys that can supply `.rmeta`
+    /// Keyed by the checkout-specific form of
+    /// `RustcCompileContext::check_metadata_compat_key_with_root`.
+    /// Values are exact build-style instance keys that can supply `.rmeta`
     /// and dep-info outputs to a check-style request.
     pub(super) rustc_check_metadata_compat: DashMap<ContextKey, ContextKey>,
     /// Issue #550: cached normalize_key_path results, keyed by
@@ -147,7 +197,7 @@ pub struct DepGraph {
     /// `Arc<str>` result lets subsequent compiles in the same daemon
     /// session reuse the work — measured at ~2 ms saved per cpp-inline
     /// cold compile after the cache is warm. Capped to bound memory.
-    pub(super) path_key_cache: DashMap<PathKeyCacheKey, Arc<str>>,
+    pub(super) indexes: Box<GraphIndexes>,
     /// Stats counters.
     pub(super) checks: AtomicU64,
     pub(super) hits: AtomicU64,
@@ -163,9 +213,33 @@ pub(super) struct PathKeyCacheKey {
     pub(super) key_root: Option<NormalizedPath>,
 }
 
+/// Heap-owned auxiliary indexes so their growth does not enlarge `DepGraph`
+/// values carried by the persisted-load result enum.
+pub(super) struct GraphIndexes {
+    pub(super) equivalent_contexts: DashMap<ContextKey, Vec<ContextKey>>,
+    pub(super) path_key_cache: DashMap<PathKeyCacheKey, Arc<str>>,
+}
+
+impl GraphIndexes {
+    fn new() -> Self {
+        Self {
+            equivalent_contexts: DashMap::new(),
+            path_key_cache: DashMap::new(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ContextRegistration {
+    /// Root-normalized key used only for content-addressed artifact identity.
     pub key: ContextKey,
+    /// Checkout-specific key used for all mutable dependency-graph access.
+    pub map_key: ContextKey,
+    pub instance: ContextInstanceKey,
+    /// Checkout-specific metadata-compatibility alias, when rustc registered
+    /// one. The public compatibility key remains root-normalized, while this
+    /// map key prevents one checkout from replacing another's alias target.
+    pub metadata_compat_map_key: Option<ContextKey>,
     pub rebased_from_equivalent_root: bool,
 }
 
@@ -306,12 +380,12 @@ impl DepGraph {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            files: DashMap::new(),
+            files: Box::new(DashMap::new()),
             contexts: DashMap::new(),
             rustc_externs: DashMap::new(),
             rustc_env_deps: DashMap::new(),
             rustc_check_metadata_compat: DashMap::new(),
-            path_key_cache: DashMap::new(),
+            indexes: Box::new(GraphIndexes::new()),
             checks: AtomicU64::new(0),
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
@@ -347,7 +421,7 @@ impl DepGraph {
     /// Number of cached entries in `path_key_cache`. Test-only.
     #[cfg(test)]
     pub fn path_key_cache_len(&self) -> usize {
-        self.path_key_cache.len()
+        self.indexes.path_key_cache.len()
     }
 
     pub(super) fn rustc_extern_inputs(
@@ -368,6 +442,18 @@ impl DepGraph {
         self.rustc_env_deps.get(key).map(|deps| deps.clone())
     }
 
+    /// Resolve a public logical key only when it identifies one safe mutable
+    /// instance. Callers that hold a registration pass its instance map key,
+    /// which takes the first branch. Ambiguous legacy lookups conservatively
+    /// miss instead of selecting another checkout's state.
+    pub(super) fn resolve_instance_key(&self, key: &ContextKey) -> Option<ContextKey> {
+        if self.contexts.contains_key(key) {
+            return Some(*key);
+        }
+        let instances = self.indexes.equivalent_contexts.get(key)?;
+        (instances.len() == 1).then_some(instances[0])
+    }
+
     /// Construct a `DepGraph` from pre-built maps, including rustc extern
     /// inputs and env-dep snapshots (zccache#1021).
     pub(crate) fn from_maps_with_rustc_externs_and_env_deps(
@@ -377,12 +463,12 @@ impl DepGraph {
         rustc_env_deps: DashMap<ContextKey, Vec<(String, Option<ContentHash>)>>,
     ) -> Self {
         Self {
-            files,
+            files: Box::new(files),
             contexts,
             rustc_externs,
             rustc_env_deps,
             rustc_check_metadata_compat: DashMap::new(),
-            path_key_cache: DashMap::new(),
+            indexes: Box::new(GraphIndexes::new()),
             checks: AtomicU64::new(0),
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
@@ -398,3 +484,6 @@ impl Default for DepGraph {
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+#[path = "tests/worktree_variants.rs"]
+mod worktree_variants;

--- a/crates/zccache-depgraph/src/graph/register.rs
+++ b/crates/zccache-depgraph/src/graph/register.rs
@@ -152,12 +152,14 @@ impl DepGraph {
             .indexes
             .equivalent_contexts
             .get(&key)
-            .and_then(|instances| instances.iter().find_map(|candidate| {
-                self.contexts.get(candidate).map(|entry| entry.clone())
-            }));
-        let rebased_from_equivalent_root = candidate
-            .as_ref()
-            .is_some_and(|entry| entry.key_root.is_some() && key_root.is_some() && entry.key_root != key_root);
+            .and_then(|instances| {
+                instances
+                    .iter()
+                    .find_map(|candidate| self.contexts.get(candidate).map(|entry| entry.clone()))
+            });
+        let rebased_from_equivalent_root = candidate.as_ref().is_some_and(|entry| {
+            entry.key_root.is_some() && key_root.is_some() && entry.key_root != key_root
+        });
         let entry = candidate.map_or_else(
             || ContextEntry {
                 logical_key: key,
@@ -182,7 +184,10 @@ impl DepGraph {
                     .last_file_hashes
                     .iter()
                     .map(|(path, hash)| {
-                        (rebase_project_path(path, old_root.as_ref(), key_root.as_ref()), *hash)
+                        (
+                            rebase_project_path(path, old_root.as_ref(), key_root.as_ref()),
+                            *hash,
+                        )
                     })
                     .collect();
                 candidate.context = ctx.clone();
@@ -193,11 +198,16 @@ impl DepGraph {
         );
         self.contexts.entry(instance_key).or_insert(entry);
 
-        let mut evicted = self.indexes.equivalent_contexts.entry(key).and_modify(|instances| {
-            if !instances.contains(&instance_key) {
-                instances.push(instance_key);
-            }
-        }).or_insert_with(|| vec![instance_key]);
+        let mut evicted = self
+            .indexes
+            .equivalent_contexts
+            .entry(key)
+            .and_modify(|instances| {
+                if !instances.contains(&instance_key) {
+                    instances.push(instance_key);
+                }
+            })
+            .or_insert_with(|| vec![instance_key]);
         let evicted = if evicted.len() > MAX_EQUIVALENT_CONTEXTS {
             Some(evicted.remove(0))
         } else {

--- a/crates/zccache-depgraph/src/graph/register.rs
+++ b/crates/zccache-depgraph/src/graph/register.rs
@@ -241,7 +241,10 @@ impl DepGraph {
     /// `check_diagnostic` would return `Cold` without examining any hashes.
     #[must_use]
     pub fn is_cold(&self, key: &ContextKey) -> bool {
-        match self.contexts.get(key) {
+        let Some(key) = self.resolve_instance_key(key) else {
+            return true;
+        };
+        match self.contexts.get(&key) {
             Some(entry) => entry.state == ContextState::Cold,
             None => true,
         }

--- a/crates/zccache-depgraph/src/graph/register.rs
+++ b/crates/zccache-depgraph/src/graph/register.rs
@@ -94,7 +94,7 @@ impl DepGraph {
         key_root: Option<NormalizedPath>,
     ) -> ContextRegistration {
         let registration = self.register_context_entry(key, ctx, key_root);
-        self.rustc_externs.remove(&registration.key);
+        self.rustc_externs.remove(&registration.map_key);
         registration
     }
 
@@ -111,13 +111,20 @@ impl DepGraph {
         externs: Vec<(String, NormalizedPath)>,
         check_metadata_compat_key: Option<ContextKey>,
     ) -> ContextRegistration {
-        let registration = self.register_context_entry(key, ctx, key_root);
-        self.rustc_externs.insert(registration.key, externs);
-        if let Some(compat_key) = check_metadata_compat_key {
+        let source_file = ctx.source_file.clone();
+        let registration = self.register_context_entry(key, ctx, key_root.clone());
+        self.rustc_externs.insert(registration.map_key, externs);
+        let metadata_compat_map_key = check_metadata_compat_key.map(|compat_key| {
+            super::ContextInstanceKey::new(compat_key, &source_file, key_root.as_ref()).map_key()
+        });
+        if let Some(compat_map_key) = metadata_compat_map_key {
             self.rustc_check_metadata_compat
-                .insert(compat_key, registration.key);
+                .insert(compat_map_key, registration.map_key);
         }
-        registration
+        ContextRegistration {
+            metadata_compat_map_key,
+            ..registration
+        }
     }
 
     pub(super) fn register_context_entry(
@@ -126,37 +133,36 @@ impl DepGraph {
         ctx: CompileContext,
         key_root: Option<NormalizedPath>,
     ) -> ContextRegistration {
-        let mut rebased_from_equivalent_root = false;
-        self.contexts
-            .entry(key)
-            .and_modify(|entry| {
-                if entry.context.source_file != ctx.source_file || entry.key_root != key_root {
-                    let old_root = entry.key_root.clone();
-                    rebased_from_equivalent_root =
-                        old_root.is_some() && key_root.is_some() && old_root != key_root;
-                    entry.resolved_includes = entry
-                        .resolved_includes
-                        .iter()
-                        .map(|path| rebase_project_path(path, old_root.as_ref(), key_root.as_ref()))
-                        .collect();
-                    entry.last_file_hashes = entry
-                        .last_file_hashes
-                        .iter()
-                        .map(|(path, hash)| {
-                            (
-                                rebase_project_path(path, old_root.as_ref(), key_root.as_ref()),
-                                *hash,
-                            )
-                        })
-                        .collect();
-                    entry.context = ctx.clone();
-                    entry.key_root = key_root.clone();
-                }
-                entry.last_accessed = Instant::now();
-            })
-            .or_insert_with(|| ContextEntry {
-                context: ctx,
-                key_root,
+        const MAX_EQUIVALENT_CONTEXTS: usize = 4;
+
+        let instance = super::ContextInstanceKey::new(key, &ctx.source_file, key_root.as_ref());
+        let instance_key = instance.map_key();
+        if let Some(mut existing) = self.contexts.get_mut(&instance_key) {
+            existing.last_accessed = Instant::now();
+            return ContextRegistration {
+                key,
+                map_key: instance_key,
+                instance,
+                metadata_compat_map_key: None,
+                rebased_from_equivalent_root: false,
+            };
+        }
+
+        let candidate = self
+            .indexes
+            .equivalent_contexts
+            .get(&key)
+            .and_then(|instances| instances.iter().find_map(|candidate| {
+                self.contexts.get(candidate).map(|entry| entry.clone())
+            }));
+        let rebased_from_equivalent_root = candidate
+            .as_ref()
+            .is_some_and(|entry| entry.key_root.is_some() && key_root.is_some() && entry.key_root != key_root);
+        let entry = candidate.map_or_else(
+            || ContextEntry {
+                logical_key: key,
+                context: ctx.clone(),
+                key_root: key_root.clone(),
                 resolved_includes: Vec::new(),
                 unresolved_includes: Vec::new(),
                 has_computed_includes: false,
@@ -164,10 +170,58 @@ impl DepGraph {
                 last_file_hashes: Vec::new(),
                 last_accessed: Instant::now(),
                 state: ContextState::Cold,
-            });
+            },
+            |mut candidate| {
+                let old_root = candidate.key_root.clone();
+                candidate.resolved_includes = candidate
+                    .resolved_includes
+                    .iter()
+                    .map(|path| rebase_project_path(path, old_root.as_ref(), key_root.as_ref()))
+                    .collect();
+                candidate.last_file_hashes = candidate
+                    .last_file_hashes
+                    .iter()
+                    .map(|(path, hash)| {
+                        (rebase_project_path(path, old_root.as_ref(), key_root.as_ref()), *hash)
+                    })
+                    .collect();
+                candidate.context = ctx.clone();
+                candidate.key_root = key_root.clone();
+                candidate.last_accessed = Instant::now();
+                candidate
+            },
+        );
+        self.contexts.entry(instance_key).or_insert(entry);
+
+        let mut evicted = self.indexes.equivalent_contexts.entry(key).and_modify(|instances| {
+            if !instances.contains(&instance_key) {
+                instances.push(instance_key);
+            }
+        }).or_insert_with(|| vec![instance_key]);
+        let evicted = if evicted.len() > MAX_EQUIVALENT_CONTEXTS {
+            Some(evicted.remove(0))
+        } else {
+            None
+        };
+        if let Some(evicted) = evicted {
+            self.contexts.remove(&evicted);
+            self.rustc_externs.remove(&evicted);
+            self.rustc_env_deps.remove(&evicted);
+            let stale_compat: Vec<ContextKey> = self
+                .rustc_check_metadata_compat
+                .iter()
+                .filter_map(|entry| (*entry.value() == evicted).then_some(*entry.key()))
+                .collect();
+            for compat_key in stale_compat {
+                self.rustc_check_metadata_compat.remove(&compat_key);
+            }
+        }
 
         ContextRegistration {
             key,
+            map_key: instance_key,
+            instance,
+            metadata_compat_map_key: None,
             rebased_from_equivalent_root,
         }
     }

--- a/crates/zccache-depgraph/src/graph/tests.rs
+++ b/crates/zccache-depgraph/src/graph/tests.rs
@@ -110,11 +110,21 @@ fn invalidate_artifact_keys_clears_only_matching() {
 
     // Pre-condition: both contexts have artifact_key populated.
     assert!(
-        graph.contexts.get(&key_a).unwrap().artifact_key.is_some(),
+        graph
+            .contexts
+            .get(&graph.resolve_instance_key(&key_a).unwrap())
+            .unwrap()
+            .artifact_key
+            .is_some(),
         "fixture: A must start with artifact_key set"
     );
     assert!(
-        graph.contexts.get(&key_b).unwrap().artifact_key.is_some(),
+        graph
+            .contexts
+            .get(&graph.resolve_instance_key(&key_b).unwrap())
+            .unwrap()
+            .artifact_key
+            .is_some(),
         "fixture: B must start with artifact_key set"
     );
 
@@ -127,11 +137,19 @@ fn invalidate_artifact_keys_clears_only_matching() {
     // Post-condition: A's artifact_key is None; B's is intact (and still
     // equals its original hex).
     assert!(
-        graph.contexts.get(&key_a).unwrap().artifact_key.is_none(),
+        graph
+            .contexts
+            .get(&graph.resolve_instance_key(&key_a).unwrap())
+            .unwrap()
+            .artifact_key
+            .is_none(),
         "issue #680: A's artifact_key must be cleared — pre-fix this stayed \
          populated and surfaced as a wasted hit"
     );
-    let surviving = graph.contexts.get(&key_b).unwrap();
+    let surviving = graph
+        .contexts
+        .get(&graph.resolve_instance_key(&key_b).unwrap())
+        .unwrap();
     assert_eq!(
         surviving
             .artifact_key
@@ -782,6 +800,7 @@ fn warm_context_with_no_artifact_returns_cold_on_check() {
     graph.contexts.insert(
         key,
         ContextEntry {
+            logical_key: key,
             context: ctx,
             key_root: None,
             resolved_includes: vec![NormalizedPath::from("/inc/b.h")],

--- a/crates/zccache-depgraph/src/graph/tests/README.md
+++ b/crates/zccache-depgraph/src/graph/tests/README.md
@@ -1,0 +1,4 @@
+# Dependency graph tests
+
+Focused regression tests for dependency-graph behavior that are too specialized
+for the main graph test module.

--- a/crates/zccache-depgraph/src/graph/tests/worktree_variants.rs
+++ b/crates/zccache-depgraph/src/graph/tests/worktree_variants.rs
@@ -1,0 +1,166 @@
+//! Worktree-instance isolation regressions for the dependency graph.
+
+use std::path::Path;
+use std::sync::{Arc, Barrier};
+
+use zccache_core::NormalizedPath;
+use zccache_hash::{hash_bytes, ContentHash};
+
+use super::super::context::{CompileContext, ContextKey};
+use super::super::scanner::ScanResult;
+use super::super::search_paths::IncludeSearchPaths;
+use super::{CacheVerdict, ContextState, DepGraph};
+
+fn context(root: &str) -> CompileContext {
+    CompileContext {
+        source_file: NormalizedPath::from(format!("{root}/src/lib.rs").as_str()),
+        include_search: IncludeSearchPaths::default(),
+        defines: Vec::new(),
+        flags: Vec::new(),
+        force_includes: Vec::new(),
+        unknown_flags: Vec::new(),
+    }
+}
+
+fn scan(root: &str) -> ScanResult {
+    ScanResult {
+        resolved: vec![NormalizedPath::from(format!("{root}/include/shared.h").as_str())],
+        unresolved: Vec::new(),
+        has_computed: false,
+    }
+}
+
+fn equivalent_hash(path: &Path) -> Option<ContentHash> {
+    Some(hash_bytes(
+        path.file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .as_bytes(),
+    ))
+}
+
+#[test]
+fn equivalent_worktree_b_update_preserves_a_artifact() {
+    let graph = DepGraph::new();
+    let root_a = NormalizedPath::from("/worktree-a");
+    let root_b = NormalizedPath::from("/worktree-b");
+    let a = graph.register_with_root_result(context("/worktree-a"), Some(root_a));
+    let artifact_a = graph
+        .update(&a.map_key, scan("/worktree-a"), equivalent_hash)
+        .expect("A must become warm");
+
+    let b = graph.register_with_root_result(context("/worktree-b"), Some(root_b));
+    assert_eq!(a.key, b.key, "equivalent roots retain one artifact identity");
+    assert_ne!(a.map_key, b.map_key, "mutable state must be checkout-specific");
+    assert!(matches!(
+        graph.check(&b.map_key, |_| true, equivalent_hash),
+        CacheVerdict::Hit { artifact_key } if artifact_key == artifact_a
+    ));
+
+    let changed_b = |path: &Path| {
+        let bytes: &[u8] = if path.ends_with("lib.rs") {
+            b"B changed"
+        } else {
+            b"same header"
+        };
+        Some(hash_bytes(bytes))
+    };
+    let artifact_b = graph
+        .update(&b.map_key, scan("/worktree-b"), changed_b)
+        .expect("B update must succeed");
+    assert_ne!(artifact_a, artifact_b, "edited B needs a distinct artifact");
+
+    assert!(matches!(
+        graph.check(&a.map_key, |_| true, equivalent_hash),
+        CacheVerdict::Hit { artifact_key } if artifact_key == artifact_a
+    ));
+    assert_eq!(graph.stats().context_count, 2);
+}
+
+#[test]
+fn concurrent_equivalent_registration_keeps_independent_instances() {
+    let graph = Arc::new(DepGraph::new());
+    let barrier = Arc::new(Barrier::new(2));
+    let mut joins = Vec::new();
+    for root in ["/concurrent-a", "/concurrent-b"] {
+        let graph = Arc::clone(&graph);
+        let barrier = Arc::clone(&barrier);
+        joins.push(std::thread::spawn(move || {
+            let registration = graph.register_with_root_result(
+                context(root),
+                Some(NormalizedPath::from(root)),
+            );
+            barrier.wait();
+            graph
+                .update(&registration.map_key, scan(root), equivalent_hash)
+                .expect("concurrent update must succeed");
+            registration
+        }));
+    }
+    let first = joins.remove(0).join().unwrap();
+    let second = joins.remove(0).join().unwrap();
+    assert_eq!(first.key, second.key);
+    assert_ne!(first.map_key, second.map_key);
+    assert_eq!(graph.stats().context_count, 2);
+    assert_eq!(graph.get_state(&first.map_key), Some(ContextState::Warm));
+    assert_eq!(graph.get_state(&second.map_key), Some(ContextState::Warm));
+}
+
+#[test]
+fn equivalent_variant_bound_evicts_to_a_conservative_miss() {
+    let graph = DepGraph::new();
+    let mut registrations = Vec::new();
+    for index in 0..5 {
+        let root = format!("/evict-{index}");
+        let registration = graph.register_with_root_result(
+            context(&root),
+            Some(NormalizedPath::from(root.as_str())),
+        );
+        graph.update(&registration.map_key, scan(&root), equivalent_hash);
+        registrations.push(registration);
+    }
+    assert_eq!(graph.stats().context_count, 4);
+    assert!(matches!(
+        graph.check(&registrations[0].map_key, |_| true, equivalent_hash),
+        CacheVerdict::Cold
+    ));
+    for registration in registrations.iter().skip(1) {
+        assert_eq!(graph.get_state(&registration.map_key), Some(ContextState::Warm));
+    }
+}
+
+#[test]
+fn rustc_metadata_compatibility_aliases_are_checkout_specific() {
+    let graph = DepGraph::new();
+    let logical_key = ContextKey::from_raw([0x11; 32]);
+    let compat_key = ContextKey::from_raw([0x22; 32]);
+    let root_a = NormalizedPath::from("/compat-a");
+    let root_b = NormalizedPath::from("/compat-b");
+
+    let a = graph.register_rustc_with_key_and_root_result(
+        logical_key,
+        context("/compat-a"),
+        Some(root_a),
+        Vec::new(),
+        Some(compat_key),
+    );
+    let b = graph.register_rustc_with_key_and_root_result(
+        logical_key,
+        context("/compat-b"),
+        Some(root_b),
+        Vec::new(),
+        Some(compat_key),
+    );
+
+    let alias_a = a.metadata_compat_map_key.expect("A compat alias");
+    let alias_b = b.metadata_compat_map_key.expect("B compat alias");
+    assert_ne!(alias_a, alias_b);
+    assert_eq!(
+        graph.rustc_check_metadata_compat.get(&alias_a).map(|entry| *entry),
+        Some(a.map_key)
+    );
+    assert_eq!(
+        graph.rustc_check_metadata_compat.get(&alias_b).map(|entry| *entry),
+        Some(b.map_key)
+    );
+}

--- a/crates/zccache-depgraph/src/graph/tests/worktree_variants.rs
+++ b/crates/zccache-depgraph/src/graph/tests/worktree_variants.rs
@@ -24,7 +24,9 @@ fn context(root: &str) -> CompileContext {
 
 fn scan(root: &str) -> ScanResult {
     ScanResult {
-        resolved: vec![NormalizedPath::from(format!("{root}/include/shared.h").as_str())],
+        resolved: vec![NormalizedPath::from(
+            format!("{root}/include/shared.h").as_str(),
+        )],
         unresolved: Vec::new(),
         has_computed: false,
     }
@@ -50,8 +52,14 @@ fn equivalent_worktree_b_update_preserves_a_artifact() {
         .expect("A must become warm");
 
     let b = graph.register_with_root_result(context("/worktree-b"), Some(root_b));
-    assert_eq!(a.key, b.key, "equivalent roots retain one artifact identity");
-    assert_ne!(a.map_key, b.map_key, "mutable state must be checkout-specific");
+    assert_eq!(
+        a.key, b.key,
+        "equivalent roots retain one artifact identity"
+    );
+    assert_ne!(
+        a.map_key, b.map_key,
+        "mutable state must be checkout-specific"
+    );
     assert!(matches!(
         graph.check(&b.map_key, |_| true, equivalent_hash),
         CacheVerdict::Hit { artifact_key } if artifact_key == artifact_a
@@ -86,10 +94,8 @@ fn concurrent_equivalent_registration_keeps_independent_instances() {
         let graph = Arc::clone(&graph);
         let barrier = Arc::clone(&barrier);
         joins.push(std::thread::spawn(move || {
-            let registration = graph.register_with_root_result(
-                context(root),
-                Some(NormalizedPath::from(root)),
-            );
+            let registration =
+                graph.register_with_root_result(context(root), Some(NormalizedPath::from(root)));
             barrier.wait();
             graph
                 .update(&registration.map_key, scan(root), equivalent_hash)
@@ -112,10 +118,8 @@ fn equivalent_variant_bound_evicts_to_a_conservative_miss() {
     let mut registrations = Vec::new();
     for index in 0..5 {
         let root = format!("/evict-{index}");
-        let registration = graph.register_with_root_result(
-            context(&root),
-            Some(NormalizedPath::from(root.as_str())),
-        );
+        let registration = graph
+            .register_with_root_result(context(&root), Some(NormalizedPath::from(root.as_str())));
         graph.update(&registration.map_key, scan(&root), equivalent_hash);
         registrations.push(registration);
     }
@@ -125,7 +129,10 @@ fn equivalent_variant_bound_evicts_to_a_conservative_miss() {
         CacheVerdict::Cold
     ));
     for registration in registrations.iter().skip(1) {
-        assert_eq!(graph.get_state(&registration.map_key), Some(ContextState::Warm));
+        assert_eq!(
+            graph.get_state(&registration.map_key),
+            Some(ContextState::Warm)
+        );
     }
 }
 
@@ -156,11 +163,17 @@ fn rustc_metadata_compatibility_aliases_are_checkout_specific() {
     let alias_b = b.metadata_compat_map_key.expect("B compat alias");
     assert_ne!(alias_a, alias_b);
     assert_eq!(
-        graph.rustc_check_metadata_compat.get(&alias_a).map(|entry| *entry),
+        graph
+            .rustc_check_metadata_compat
+            .get(&alias_a)
+            .map(|entry| *entry),
         Some(a.map_key)
     );
     assert_eq!(
-        graph.rustc_check_metadata_compat.get(&alias_b).map(|entry| *entry),
+        graph
+            .rustc_check_metadata_compat
+            .get(&alias_b)
+            .map(|entry| *entry),
         Some(b.map_key)
     );
 }

--- a/crates/zccache-depgraph/src/graph/update.rs
+++ b/crates/zccache-depgraph/src/graph/update.rs
@@ -52,6 +52,7 @@ impl DepGraph {
         G: Fn(&std::path::Path) -> Option<ContentHash>,
         E: Fn(&str) -> Option<String>,
     {
+        let key = self.resolve_instance_key(key)?;
         // Snapshot the env-dep values the compile actually saw, replacing
         // any prior snapshot (the name set can change across compiles).
         let mut env_hashes: Vec<(String, Option<ContentHash>)> = env_dep_names
@@ -61,7 +62,7 @@ impl DepGraph {
                 (name.clone(), hash_env_dep_value(value.as_deref()))
             })
             .collect();
-        self.set_rustc_env_deps(*key, env_hashes.clone());
+        self.set_rustc_env_deps(key, env_hashes.clone());
         // Issue #582: emit a `zccache_depgraph_update_breakdown` line when
         // `ZCCACHE_PROFILE_CC_MISS` is set so the next perf iteration has
         // sub-phase data for the remaining ~2.4 ms mean `depgraph_update_ns`.
@@ -70,8 +71,8 @@ impl DepGraph {
         let t_total = profile_enabled.then(Instant::now);
 
         let t_entry = profile_enabled.then(Instant::now);
-        let rustc_externs = self.rustc_extern_inputs(key);
-        let mut entry = self.contexts.get_mut(key)?;
+        let rustc_externs = self.rustc_extern_inputs(&key);
+        let mut entry = self.contexts.get_mut(&key)?;
         let entry_get_ns = t_entry.map(|t| t.elapsed().as_nanos() as u64).unwrap_or(0);
 
         // Always update include lists (useful for diagnostics even if hashing fails).
@@ -115,7 +116,7 @@ impl DepGraph {
         let artifact_key = if let Some(externs) = rustc_externs.as_deref() {
             let mut extern_hashes = collect_rustc_extern_hashes(externs, &get_hash)?;
             let base = compute_rustc_artifact_key_with_root_with(
-                key,
+                &entry.logical_key,
                 &mut file_hashes,
                 &mut extern_hashes,
                 entry.key_root.as_deref(),
@@ -131,7 +132,7 @@ impl DepGraph {
             // `key_root: None` (was #585's compute_artifact_key_normalized_inplace)
             // and `key_root: Some` in one shape.
             crate::context::compute_artifact_key_normalized_with_root(
-                key,
+                &entry.logical_key,
                 &file_hashes,
                 entry.key_root.as_deref(),
             )

--- a/crates/zccache-depgraph/src/snapshot/mod.rs
+++ b/crates/zccache-depgraph/src/snapshot/mod.rs
@@ -36,7 +36,7 @@ pub use persistence::{
 };
 
 /// On-disk format version. Bump when snapshot layout changes.
-pub const DEPGRAPH_VERSION: u32 = 6;
+pub const DEPGRAPH_VERSION: u32 = 7;
 
 /// Magic bytes identifying a depgraph snapshot file ("ZCDG").
 pub const DEPGRAPH_MAGIC: [u8; 4] = [0x5A, 0x43, 0x44, 0x47];
@@ -71,7 +71,10 @@ pub struct IncludeDirectiveSnapshot {
 
 #[derive(Archive, Serialize, Deserialize)]
 pub struct ContextEntrySnapshot {
+    /// Checkout-specific map key for mutable graph state.
     pub context_key: [u8; 32],
+    /// Root-normalized identity used for artifact-key computation.
+    pub logical_context_key: [u8; 32],
     pub key_root: Option<String>,
     pub source_file: String,
     pub iquote: Vec<String>,
@@ -190,6 +193,7 @@ impl DepGraph {
                     .collect();
                 ContextEntrySnapshot {
                     context_key: *key.hash().as_bytes(),
+                    logical_context_key: *ctx.logical_key.hash().as_bytes(),
                     key_root: ctx
                         .key_root
                         .as_ref()
@@ -270,11 +274,13 @@ impl DepGraph {
         });
 
         let contexts: DashMap<ContextKey, ContextEntry> = DashMap::new();
+        let equivalent_contexts: DashMap<ContextKey, Vec<ContextKey>> = DashMap::new();
         let rustc_externs: DashMap<ContextKey, Vec<(String, NormalizedPath)>> = DashMap::new();
         let rustc_env_deps: DashMap<ContextKey, Vec<(String, Option<ContentHash>)>> =
             DashMap::new();
         snap.contexts.into_par_iter().for_each(|c| {
             let key = ContextKey::from_raw(c.context_key);
+            let logical_key = ContextKey::from_raw(c.logical_context_key);
             let externs: Vec<(String, NormalizedPath)> = c
                 .rustc_externs
                 .into_iter()
@@ -299,6 +305,7 @@ impl DepGraph {
                 unknown_flags: c.unknown_flags,
             };
             let entry = ContextEntry {
+                logical_key,
                 context,
                 key_root: c.key_root.map(|root| NormalizedPath::from(root.as_str())),
                 resolved_includes: strings_to_paths(c.resolved_includes),
@@ -318,6 +325,10 @@ impl DepGraph {
                 },
             };
             contexts.insert(key, entry);
+            equivalent_contexts
+                .entry(logical_key)
+                .and_modify(|instances| instances.push(key))
+                .or_insert_with(|| vec![key]);
             if !externs.is_empty() {
                 rustc_externs.insert(key, externs);
             }
@@ -326,12 +337,14 @@ impl DepGraph {
             }
         });
 
-        DepGraph::from_maps_with_rustc_externs_and_env_deps(
+        let mut graph = DepGraph::from_maps_with_rustc_externs_and_env_deps(
             files,
             contexts,
             rustc_externs,
             rustc_env_deps,
-        )
+        );
+        graph.indexes.equivalent_contexts = equivalent_contexts;
+        graph
     }
 }
 

--- a/crates/zccache-depgraph/src/snapshot/tests/mod.rs
+++ b/crates/zccache-depgraph/src/snapshot/tests/mod.rs
@@ -13,6 +13,7 @@ use super::super::search_paths::IncludeSearchPaths;
 mod behavioral;
 mod persistence;
 mod round_trip;
+mod worktree_variants;
 
 /// Default snapshot path inside a tempdir.
 pub(super) fn test_path(dir: &TempDir) -> NormalizedPath {

--- a/crates/zccache-depgraph/src/snapshot/tests/worktree_variants.rs
+++ b/crates/zccache-depgraph/src/snapshot/tests/worktree_variants.rs
@@ -1,0 +1,80 @@
+//! Snapshot regression coverage for equivalent worktree variants.
+
+use std::path::Path;
+
+use tempfile::TempDir;
+use zccache_core::NormalizedPath;
+use zccache_hash::{hash_bytes, ContentHash};
+
+use super::super::super::context::CompileContext;
+use super::super::super::graph::{CacheVerdict, DepGraph};
+use super::super::super::scanner::ScanResult;
+use super::super::super::search_paths::IncludeSearchPaths;
+use super::super::super::snapshot::{load_from_file, save_to_file};
+use super::{test_path, always_fresh};
+
+fn context(root: &str) -> CompileContext {
+    CompileContext {
+        source_file: NormalizedPath::from(format!("{root}/src/lib.rs").as_str()),
+        include_search: IncludeSearchPaths::default(),
+        defines: Vec::new(),
+        flags: Vec::new(),
+        force_includes: Vec::new(),
+        unknown_flags: Vec::new(),
+    }
+}
+
+fn scan(root: &str) -> ScanResult {
+    ScanResult {
+        resolved: vec![NormalizedPath::from(format!("{root}/include/shared.h").as_str())],
+        unresolved: Vec::new(),
+        has_computed: false,
+    }
+}
+
+fn equal_hash(path: &Path) -> Option<ContentHash> {
+    Some(hash_bytes(
+        path.file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .as_bytes(),
+    ))
+}
+
+#[test]
+fn equivalent_worktree_variants_survive_snapshot_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let path = test_path(&dir);
+    let graph = DepGraph::new();
+    let a = graph.register_with_root_result(
+        context("/snapshot-a"),
+        Some(NormalizedPath::from("/snapshot-a")),
+    );
+    let artifact_a = graph
+        .update(&a.map_key, scan("/snapshot-a"), equal_hash)
+        .unwrap();
+    let b = graph.register_with_root_result(
+        context("/snapshot-b"),
+        Some(NormalizedPath::from("/snapshot-b")),
+    );
+    let changed_b = |path: &Path| {
+        let bytes: &[u8] = if path.ends_with("lib.rs") { b"changed B" } else { b"header" };
+        Some(hash_bytes(bytes))
+    };
+    let artifact_b = graph
+        .update(&b.map_key, scan("/snapshot-b"), changed_b)
+        .unwrap();
+    assert_ne!(artifact_a, artifact_b);
+
+    save_to_file(&graph, &path).unwrap();
+    let loaded = load_from_file(&path).unwrap();
+    assert_eq!(loaded.stats().context_count, 2);
+    assert!(matches!(
+        loaded.check(&a.map_key, always_fresh, equal_hash),
+        CacheVerdict::Hit { artifact_key } if artifact_key == artifact_a
+    ));
+    assert!(matches!(
+        loaded.check(&b.map_key, always_fresh, changed_b),
+        CacheVerdict::Hit { artifact_key } if artifact_key == artifact_b
+    ));
+}

--- a/crates/zccache-depgraph/src/snapshot/tests/worktree_variants.rs
+++ b/crates/zccache-depgraph/src/snapshot/tests/worktree_variants.rs
@@ -11,7 +11,7 @@ use super::super::super::graph::{CacheVerdict, DepGraph};
 use super::super::super::scanner::ScanResult;
 use super::super::super::search_paths::IncludeSearchPaths;
 use super::super::super::snapshot::{load_from_file, save_to_file};
-use super::{test_path, always_fresh};
+use super::{always_fresh, test_path};
 
 fn context(root: &str) -> CompileContext {
     CompileContext {
@@ -26,7 +26,9 @@ fn context(root: &str) -> CompileContext {
 
 fn scan(root: &str) -> ScanResult {
     ScanResult {
-        resolved: vec![NormalizedPath::from(format!("{root}/include/shared.h").as_str())],
+        resolved: vec![NormalizedPath::from(
+            format!("{root}/include/shared.h").as_str(),
+        )],
         unresolved: Vec::new(),
         has_computed: false,
     }
@@ -58,7 +60,11 @@ fn equivalent_worktree_variants_survive_snapshot_roundtrip() {
         Some(NormalizedPath::from("/snapshot-b")),
     );
     let changed_b = |path: &Path| {
-        let bytes: &[u8] = if path.ends_with("lib.rs") { b"changed B" } else { b"header" };
+        let bytes: &[u8] = if path.ends_with("lib.rs") {
+            b"changed B"
+        } else {
+            b"header"
+        };
         Some(hash_bytes(bytes))
     };
     let artifact_b = graph

--- a/crates/zccache-depgraph/src/watcher_support.rs
+++ b/crates/zccache-depgraph/src/watcher_support.rs
@@ -189,7 +189,8 @@ impl DepGraph {
     }
 
     /// Check if a newly created file shadows any existing resolved include
-    /// in any context. Returns context keys that should be marked stale.
+    /// in any context. Returns exact mutable-instance keys that should be
+    /// marked stale.
     ///
     /// A shadow occurs when `new_file` has the same filename as an existing
     /// resolved include, and `new_file`'s directory appears earlier (higher
@@ -243,7 +244,7 @@ impl DepGraph {
     }
 
     /// Check if a newly created file resolves any previously unresolved
-    /// `#include` in any context. Returns affected context keys.
+    /// `#include` in any context. Returns affected mutable-instance keys.
     #[must_use]
     pub fn check_new_resolve(&self, new_file: &Path) -> Vec<ContextKey> {
         let new_name = match new_file.file_name() {
@@ -473,7 +474,7 @@ mod tests {
 
         // New foo.h appears in /high (higher priority).
         let affected = graph.check_shadow(Path::new("/high/foo.h"));
-        assert_eq!(affected, vec![key]);
+        assert_eq!(affected, vec![graph.resolve_instance_key(&key).unwrap()]);
     }
 
     #[test]
@@ -564,7 +565,7 @@ mod tests {
 
         // New foo.h in -iquote dir (higher priority).
         let affected = graph.check_shadow(Path::new("/iquote/foo.h"));
-        assert_eq!(affected, vec![key]);
+        assert_eq!(affected, vec![graph.resolve_instance_key(&key).unwrap()]);
     }
 
     #[test]
@@ -598,7 +599,7 @@ mod tests {
         graph.update(&key, scan, dummy_hash);
 
         let affected = graph.check_new_resolve(Path::new("/inc/missing.h"));
-        assert_eq!(affected, vec![key]);
+        assert_eq!(affected, vec![graph.resolve_instance_key(&key).unwrap()]);
     }
 
     #[test]
@@ -634,7 +635,7 @@ mod tests {
 
         // New file with matching filename.
         let affected = graph.check_new_resolve(Path::new("/inc/sub/missing.h"));
-        assert_eq!(affected, vec![key]);
+        assert_eq!(affected, vec![graph.resolve_instance_key(&key).unwrap()]);
     }
 
     // --- mark_stale tests ---

--- a/crates/zccache/tests/daemon_rustc_cache_worktree_test.rs
+++ b/crates/zccache/tests/daemon_rustc_cache_worktree_test.rs
@@ -37,6 +37,25 @@ async fn start_daemon() -> (
     (endpoint, handle, shutdown)
 }
 
+/// Start an isolated daemon so content-addressed artifacts from a prior test
+/// run cannot turn this test's first observation of a new source into a hit.
+async fn start_daemon_with_cache_dir(
+    cache_dir: &std::path::Path,
+) -> (
+    String,
+    tokio::task::JoinHandle<()>,
+    std::sync::Arc<tokio::sync::Notify>,
+) {
+    let endpoint = zccache::ipc::unique_test_endpoint();
+    let mut server =
+        DaemonServer::bind_with_cache_dir(&endpoint, &NormalizedPath::new(cache_dir)).unwrap();
+    let shutdown = server.shutdown_handle();
+    let handle = tokio::spawn(async move {
+        server.run(0).await.unwrap();
+    });
+    (endpoint, handle, shutdown)
+}
+
 /// Helper: start session with an explicit working directory.
 async fn start_session_in(client: &mut ClientConn, working_dir: &std::path::Path) -> String {
     client
@@ -353,175 +372,189 @@ async fn compile_worktree_app_to_target_with_env(
 ///
 /// This intentionally leaves `ZCCACHE_WORKTREE_ROOT` unset so the automatic Git
 /// root path is covered.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore] // integration-level: starts real daemon with IPC + rustc
-async fn test_rustc_sibling_git_worktree_equivalent_cache_sharing() {
-    let rustc = match zccache::test_support::find_rustc() {
-        Some(p) => p,
-        None => {
-            eprintln!("skipping test: rustc not found");
-            return;
-        }
-    };
+#[test]
+fn test_rustc_sibling_git_worktree_equivalent_cache_sharing() {
+    // This test keeps two IPC clients, daemon handles, and several artifact
+    // byte buffers live in one generated async future. That is a test-harness
+    // stack shape; the production daemon owns a separate runtime and spawns
+    // request work independently. Give this integration runtime enough worker
+    // stack explicitly instead of requiring the ambient RUST_MIN_STACK knob.
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .thread_stack_size(16 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let rustc = match zccache::test_support::find_rustc() {
+                Some(p) => p,
+                None => {
+                    eprintln!("skipping test: rustc not found");
+                    return;
+                }
+            };
 
-    zccache::test_support::test_timeout(async move {
-        let tmp = tempfile::tempdir().unwrap();
-        let root_a = tmp.path().join("worktree-a");
-        let root_b = tmp.path().join("worktree-b");
+            zccache::test_support::test_timeout(async move {
+                let tmp = tempfile::tempdir().unwrap();
+                let root_a = tmp.path().join("worktree-a");
+                let root_b = tmp.path().join("worktree-b");
 
-        if !init_git_root(&root_a) || !init_git_root(&root_b) {
-            return;
-        }
+                if !init_git_root(&root_a) || !init_git_root(&root_b) {
+                    return;
+                }
 
-        write_worktree_project(&root_a, 7, 1);
-        write_worktree_project(&root_b, 7, 1);
+                write_worktree_project(&root_a, 7, 1);
+                write_worktree_project(&root_b, 7, 1);
 
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
-        let mut client_a = zccache::ipc::connect(&endpoint).await.unwrap();
-        let mut client_b = zccache::ipc::connect(&endpoint).await.unwrap();
-        let session_a = start_session_in(&mut client_a, &root_a).await;
-        let session_b = start_session_in(&mut client_b, &root_b).await;
+                let (endpoint, server_handle, shutdown) =
+                    start_daemon_with_cache_dir(&tmp.path().join("cache")).await;
+                let mut client_a = zccache::ipc::connect(&endpoint).await.unwrap();
+                let mut client_b = zccache::ipc::connect(&endpoint).await.unwrap();
+                let session_a = start_session_in(&mut client_a, &root_a).await;
+                let session_b = start_session_in(&mut client_b, &root_b).await;
 
-        let rustc_str = rustc.to_string_lossy().to_string();
-        let dep_a = root_a.join("target/libdep.rlib");
-        let dep_b = root_b.join("target/libdep.rlib");
-        let app_a = root_a.join("target/libapp.rlib");
-        let app_b = root_b.join("target/libapp.rlib");
+                let rustc_str = rustc.to_string_lossy().to_string();
+                let dep_a = root_a.join("target/libdep.rlib");
+                let dep_b = root_b.join("target/libdep.rlib");
+                let app_a = root_a.join("target/libapp.rlib");
+                let app_b = root_b.join("target/libapp.rlib");
 
-        let (exit_code, cached) = compile_worktree_dep_with_env(
-            &mut client_a,
-            &session_a,
-            &rustc_str,
-            &root_a,
-            Some(path_remap_auto_env()),
-        )
-        .await;
-        assert_eq!(exit_code, 0, "A dependency compile should succeed");
-        assert!(!cached, "A dependency compile should be a cold miss");
-        assert!(dep_a.exists(), "A dependency output should exist");
+                let (exit_code, cached) = compile_worktree_dep_with_env(
+                    &mut client_a,
+                    &session_a,
+                    &rustc_str,
+                    &root_a,
+                    Some(path_remap_auto_env()),
+                )
+                .await;
+                assert_eq!(exit_code, 0, "A dependency compile should succeed");
+                assert!(!cached, "A dependency compile should be a cold miss");
+                assert!(dep_a.exists(), "A dependency output should exist");
 
-        let (exit_code, cached) = compile_worktree_app_with_env(
-            &mut client_a,
-            &session_a,
-            &rustc_str,
-            &root_a,
-            Some(path_remap_auto_env()),
-        )
-        .await;
-        assert_eq!(exit_code, 0, "A app compile should succeed");
-        assert!(!cached, "A app compile should be a cold miss");
-        let app_a_original = std::fs::read(&app_a).unwrap();
+                let (exit_code, cached) = compile_worktree_app_with_env(
+                    &mut client_a,
+                    &session_a,
+                    &rustc_str,
+                    &root_a,
+                    Some(path_remap_auto_env()),
+                )
+                .await;
+                assert_eq!(exit_code, 0, "A app compile should succeed");
+                assert!(!cached, "A app compile should be a cold miss");
+                let app_a_original = std::fs::read(&app_a).unwrap();
 
-        let (exit_code, cached) = compile_worktree_dep_with_env(
-            &mut client_b,
-            &session_b,
-            &rustc_str,
-            &root_b,
-            Some(path_remap_auto_env()),
-        )
-        .await;
-        assert_eq!(
-            exit_code, 0,
-            "B equivalent dependency compile should succeed"
-        );
-        assert!(
-            cached,
-            "B equivalent dependency compile should hit A's worktree-equivalent entry"
-        );
-        assert!(dep_b.exists(), "B dependency output should be restored");
+                let (exit_code, cached) = compile_worktree_dep_with_env(
+                    &mut client_b,
+                    &session_b,
+                    &rustc_str,
+                    &root_b,
+                    Some(path_remap_auto_env()),
+                )
+                .await;
+                assert_eq!(
+                    exit_code, 0,
+                    "B equivalent dependency compile should succeed"
+                );
+                assert!(
+                    cached,
+                    "B equivalent dependency compile should hit A's worktree-equivalent entry"
+                );
+                assert!(dep_b.exists(), "B dependency output should be restored");
 
-        let (exit_code, cached) = compile_worktree_app_with_env(
-            &mut client_b,
-            &session_b,
-            &rustc_str,
-            &root_b,
-            Some(path_remap_auto_env()),
-        )
-        .await;
-        assert_eq!(exit_code, 0, "B equivalent app compile should succeed");
-        assert!(
-            cached,
-            "B equivalent app compile should hit A's worktree-equivalent entry"
-        );
-        assert!(app_b.exists(), "B app output should be restored");
+                let (exit_code, cached) = compile_worktree_app_with_env(
+                    &mut client_b,
+                    &session_b,
+                    &rustc_str,
+                    &root_b,
+                    Some(path_remap_auto_env()),
+                )
+                .await;
+                assert_eq!(exit_code, 0, "B equivalent app compile should succeed");
+                assert!(
+                    cached,
+                    "B equivalent app compile should hit A's worktree-equivalent entry"
+                );
+                assert!(app_b.exists(), "B app output should be restored");
 
-        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
-        write_worktree_project(&root_b, 7, 2);
-        remove_file_if_exists(&app_b);
-        let (exit_code, cached) = compile_worktree_app_with_env(
-            &mut client_b,
-            &session_b,
-            &rustc_str,
-            &root_b,
-            Some(path_remap_auto_env()),
-        )
-        .await;
-        assert_eq!(
-            exit_code, 0,
-            "B app compile after source edit should succeed"
-        );
-        assert!(!cached, "B source edit should force a conservative miss");
+                tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+                write_worktree_project(&root_b, 7, 2);
+                remove_file_if_exists(&app_b);
+                let (exit_code, cached) = compile_worktree_app_with_env(
+                    &mut client_b,
+                    &session_b,
+                    &rustc_str,
+                    &root_b,
+                    Some(path_remap_auto_env()),
+                )
+                .await;
+                assert_eq!(
+                    exit_code, 0,
+                    "B app compile after source edit should succeed"
+                );
+                assert!(!cached, "B source edit should force a conservative miss");
 
-        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
-        write_worktree_project(&root_b, 99, 1);
-        remove_file_if_exists(&dep_b);
-        remove_file_if_exists(&app_b);
+                tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+                write_worktree_project(&root_b, 99, 1);
+                remove_file_if_exists(&dep_b);
+                remove_file_if_exists(&app_b);
 
-        let (exit_code, cached) = compile_worktree_dep_with_env(
-            &mut client_b,
-            &session_b,
-            &rustc_str,
-            &root_b,
-            Some(path_remap_auto_env()),
-        )
-        .await;
-        assert_eq!(
-            exit_code, 0,
-            "B dependency compile after dependency edit should succeed"
-        );
-        assert!(!cached, "B dependency edit should miss");
+                let (exit_code, cached) = compile_worktree_dep_with_env(
+                    &mut client_b,
+                    &session_b,
+                    &rustc_str,
+                    &root_b,
+                    Some(path_remap_auto_env()),
+                )
+                .await;
+                assert_eq!(
+                    exit_code, 0,
+                    "B dependency compile after dependency edit should succeed"
+                );
+                assert!(!cached, "B dependency edit should miss");
 
-        let (exit_code, cached) = compile_worktree_app_with_env(
-            &mut client_b,
-            &session_b,
-            &rustc_str,
-            &root_b,
-            Some(path_remap_auto_env()),
-        )
-        .await;
-        assert_eq!(
-            exit_code, 0,
-            "B app compile after dependency edit should succeed"
-        );
-        assert!(
-            !cached,
-            "B app should miss when its root-relative dependency content changes"
-        );
+                let (exit_code, cached) = compile_worktree_app_with_env(
+                    &mut client_b,
+                    &session_b,
+                    &rustc_str,
+                    &root_b,
+                    Some(path_remap_auto_env()),
+                )
+                .await;
+                assert_eq!(
+                    exit_code, 0,
+                    "B app compile after dependency edit should succeed"
+                );
+                assert!(
+                    !cached,
+                    "B app should miss when its root-relative dependency content changes"
+                );
 
-        remove_file_if_exists(&app_a);
-        let (exit_code, cached) = compile_worktree_app_with_env(
-            &mut client_a,
-            &session_a,
-            &rustc_str,
-            &root_a,
-            Some(path_remap_auto_env()),
-        )
-        .await;
-        assert_eq!(exit_code, 0, "A original app compile should still succeed");
-        assert!(
-            cached,
-            "B edits must not poison A's original worktree-equivalent cache entry"
-        );
-        assert_eq!(
-            std::fs::read(&app_a).unwrap(),
-            app_a_original,
-            "A cached output should remain byte-identical after B misses"
-        );
+                remove_file_if_exists(&app_a);
+                let (exit_code, cached) = compile_worktree_app_with_env(
+                    &mut client_a,
+                    &session_a,
+                    &rustc_str,
+                    &root_a,
+                    Some(path_remap_auto_env()),
+                )
+                .await;
+                assert_eq!(exit_code, 0, "A original app compile should still succeed");
+                assert!(
+                    cached,
+                    "B edits must not poison A's original worktree-equivalent cache entry"
+                );
+                assert_eq!(
+                    std::fs::read(&app_a).unwrap(),
+                    app_a_original,
+                    "A cached output should remain byte-identical after B misses"
+                );
 
-        shutdown.notify_one();
-        server_handle.await.unwrap();
-    })
-    .await;
+                shutdown.notify_one();
+                server_handle.await.unwrap();
+            })
+            .await;
+        });
 }
 
 /// Issue #396: a real `git worktree` pair should share rustc artifacts even

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -104,6 +104,15 @@ Wave 6 status:
 - Marked internal and PyPI extension crates `publish = false`; crates.io publish order is now only the public `zccache` crate.
 - Release publish now performs a real `cargo package` verification on the transformed crate before upload.
 - Verified on 2026-07-09: focused release Python tests, full `ci/tests`, `bash ./test`, workspace clippy all-target/all-feature, and transformed `zccache` package verification with `RUSTFLAGS=-D warnings`.
+# #1131 remaining cache-isolation bugs
+
+- [x] #912: merge and validate output-directory side-effect isolation (#1132).
+- [x] #1028: keep distinct mutable dependency-graph variants per worktree
+  while retaining root-normalized artifact identity.
+- [x] Add A/B/A, concurrent registration, bounded-variant, and snapshot
+  round-trip coverage; validate the Windows worktree integration without
+  `RUST_MIN_STACK`.
+
 # #1039 capability-driven COW materialization
 
 Issue: https://github.com/zackees/zccache/issues/1039


### PR DESCRIPTION
## Summary
- keep root-normalized logical artifact keys while assigning each checkout its own mutable depgraph instance
- scope rustc extern/env/metadata-compat state and watcher invalidation to the exact instance; bound variants and persist the new shape as snapshot v7
- add variant, concurrency, eviction, persistence, and real Windows daemon worktree coverage with an isolated artifact cache

Closes #1028

## Validation
- soldr cargo test -p zccache-depgraph
- soldr cargo clippy -p zccache-depgraph --all-targets -- -D warnings
- soldr cargo clippy -p zccache-daemon-core --features test-support --lib -- -D warnings
- soldr cargo test -p zccache --test daemon_rustc_cache_worktree_test -- test_rustc_sibling_git_worktree_equivalent_cache_sharing --ignored --nocapture