### PR TITLE
fix(ci): preserve Dylint subcommand

### DIFF
--- a/ci/lint.py
+++ b/ci/lint.py
@@ -80,11 +80,13 @@ def dylint_env():
 
 
 def dylint_command() -> list[str]:
-    """Run cargo-dylint directly so soldr cannot reselect stable Rust."""
+    """Run the Dylint executable while preserving its Cargo subcommand argv."""
     executable = which("cargo-dylint")
     if executable is None:
         raise FileNotFoundError("cargo-dylint is required for workspace linting")
-    return [executable, "--all", "--workspace"]
+    # The standalone executable parses the same argv shape as the Cargo plugin.
+    # Keep the subcommand: without it, Clap delegates `--all` to Cargo itself.
+    return [executable, "dylint", "--all", "--workspace"]
 
 
 def ensure_dylint_aliases():

--- a/ci/tests/test_lint.py
+++ b/ci/tests/test_lint.py
@@ -32,10 +32,13 @@ def test_dylint_env_puts_selected_toolchain_first(monkeypatch):
     assert captured["env"] is env
 
 
-def test_dylint_command_bypasses_soldr_toolchain_selection(monkeypatch):
-    monkeypatch.setattr(
-        lint,
-        "which",
-        lambda name: "/opt/cargo-dylint" if name == "cargo-dylint" else None,
-    )
-    assert lint.dylint_command() == ["/opt/cargo-dylint", "--all", "--workspace"]
+def test_dylint_command_keeps_the_plugin_subcommand(monkeypatch):
+    executable = "/opt/dylint"
+    monkeypatch.setattr(lint, "which", lambda _: executable)
+
+    assert lint.dylint_command() == [
+        executable,
+        "dylint",
+        "--all",
+        "--workspace",
+    ]


### PR DESCRIPTION
## Summary

Fix the main-branch Dylint gate by invoking the standalone executable with its required Dylint subcommand.

## Validation

- `PYTHONPATH=. uv run --no-project pytest ci/tests/test_lint.py`
- Reviewed the Dylint 5.0.0 CLI contract.

This unblocks the release pipeline after #1133.