### PR TITLE
fix(paths): normalize Dylint PathBuf backlog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4452,6 +4452,7 @@ name = "zccache-test-support"
 version = "1.12.15"
 dependencies = [
  "tempfile",
+ "zccache-core",
 ]
 
 [[package]]

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec_key.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec_key.rs
@@ -223,8 +223,8 @@ pub(super) fn persist_depfile_sidecar(
     }
 }
 
-pub(super) fn depfile_sidecar_path(artifact_dir: &Path, primary_hex: &str) -> PathBuf {
-    artifact_dir.join(format!("{primary_hex}.deps"))
+pub(super) fn depfile_sidecar_path(artifact_dir: &Path, primary_hex: &str) -> NormalizedPath {
+    artifact_dir.join(format!("{primary_hex}.deps")).into()
 }
 
 /// Parse the depfile the tool emitted, hash each listed file. `inputs` is

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -797,7 +797,7 @@ pub(super) async fn handle_link_ephemeral(
         if let Some(plan) = staged_plan.as_ref() {
             let unexpected_staged = plan.unexpected_staged_entries().unwrap_or_else(|error| {
                 tracing::warn!(%error, "failed to inspect staged linker output set");
-                vec![plan.primary_staged().as_path().to_path_buf()]
+                vec![plan.primary_staged().clone()]
             });
             if !side_effects_cacheable || !side_effects.is_empty() || !unexpected_staged.is_empty()
             {

--- a/crates/zccache-daemon-core/src/daemon/server/persist/directory_bundle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/directory_bundle.rs
@@ -3,7 +3,7 @@
 use super::*;
 use bincode::Options;
 use serde::{Deserialize, Serialize};
-use std::path::{Component, Path, PathBuf};
+use std::path::{Component, Path};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, UNIX_EPOCH};
 
@@ -41,17 +41,18 @@ pub(in crate::daemon::server) struct StagedDirectoryPlan {
     requested: NormalizedPath,
     staged: NormalizedPath,
     archive: NormalizedPath,
-    root: PathBuf,
+    root: NormalizedPath,
 }
 
 impl StagedDirectoryPlan {
     #[cfg(test)]
     pub(in crate::daemon::server) fn for_test(
-        root: PathBuf,
+        root: impl Into<NormalizedPath>,
         requested: NormalizedPath,
         staged: NormalizedPath,
     ) -> Self {
-        let archive = root.join("directory.bundle").into();
+        let root = root.into();
+        let archive = root.join("directory.bundle");
         Self {
             rewritten_args: Vec::new(),
             requested,
@@ -94,8 +95,8 @@ impl StagedDirectoryPlan {
                 });
             }
         };
-        let staged: NormalizedPath = root.join(filename).into();
-        let archive: NormalizedPath = root.join("directory.bundle").into();
+        let staged: NormalizedPath = root.join(filename);
+        let archive: NormalizedPath = root.join("directory.bundle");
         let rewritten_args = rewrite_dsymutil_args(args, staged.as_path());
         StagedPlanOutcome::Enabled(Self {
             rewritten_args,
@@ -133,7 +134,7 @@ impl StagedDirectoryPlan {
     }
 }
 
-fn create_private_directory(parent: &Path) -> std::io::Result<PathBuf> {
+fn create_private_directory(parent: &Path) -> std::io::Result<NormalizedPath> {
     for _ in 0..1_024 {
         let path = parent.join(format!(
             ".zccache-directory-{}-{}",
@@ -141,7 +142,7 @@ fn create_private_directory(parent: &Path) -> std::io::Result<PathBuf> {
             DIRECTORY_COUNTER.fetch_add(1, Ordering::Relaxed)
         ));
         match std::fs::create_dir(&path) {
-            Ok(()) => return Ok(path),
+            Ok(()) => return Ok(path.into()),
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(error) => return Err(error),
         }
@@ -345,7 +346,9 @@ fn modified_since_epoch(metadata: &std::fs::Metadata) -> Duration {
         .unwrap_or_default()
 }
 
-fn validated_relative_path(path: &str) -> std::io::Result<PathBuf> {
+/// A validated bundle member is deliberately relative, so it must not be
+/// normalized as a filesystem identity before it is joined to its target.
+fn validated_relative_path(path: &str) -> std::io::Result<Box<Path>> {
     let path = Path::new(path);
     if path.as_os_str().is_empty()
         || path
@@ -357,7 +360,7 @@ fn validated_relative_path(path: &str) -> std::io::Result<PathBuf> {
             "directory bundle contains an unsafe path",
         ));
     }
-    Ok(path.to_path_buf())
+    Ok(path.into())
 }
 
 fn install_directory(staged: &Path, requested: &Path) -> std::io::Result<()> {
@@ -530,6 +533,14 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         assert!(unpack_directory(&bytes, &temp.path().join("target")).is_err());
         assert!(!temp.path().join("escape").exists());
+    }
+
+    #[test]
+    fn validated_bundle_member_stays_relative() {
+        let member = validated_relative_path("Contents/Resources/DWARF/app").unwrap();
+
+        assert!(member.is_relative());
+        assert_eq!(member.as_ref(), Path::new("Contents/Resources/DWARF/app"));
     }
 
     #[test]

--- a/crates/zccache-daemon-core/src/daemon/server/persist/fs_caps.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/fs_caps.rs
@@ -70,7 +70,7 @@ pub(in crate::daemon::server) fn apply_reflink_switch(
 // differs across distinct mounts, including ones that reuse a device
 // id, because mount points are never reused verbatim.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-struct VolumePair(u128, u128, PathBuf);
+struct VolumePair(u128, u128, NormalizedPath);
 
 static CAPS: OnceLock<dashmap::DashMap<VolumePair, VolumeCaps>> = OnceLock::new();
 static CAPS_INSERT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -124,7 +124,7 @@ pub(in crate::daemon::server) fn fs_caps(src: &Path, dst: &Path) -> VolumeCaps {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     if cache().len() >= CAPS_CACHE_LIMIT {
         // Coarse bound on unbounded growth (issue #1042): the cache key
-        // includes a destination-parent PathBuf so distinct build-output
+        // includes a normalized destination parent so distinct build-output
         // directories never collide, but a daemon servicing many thousands
         // of distinct directories over its lifetime would otherwise grow
         // this map without limit. A full clear is simpler than LRU
@@ -173,13 +173,26 @@ fn probe_caps(src: &Path, dst: &Path) -> VolumeCaps {
     }
 }
 
-fn existing_path(path: &Path) -> Option<PathBuf> {
+fn existing_path(path: &Path) -> Option<NormalizedPath> {
     let mut candidate = path;
     loop {
         if candidate.exists() {
-            return Some(candidate.to_path_buf());
+            return Some(candidate.into());
         }
         candidate = candidate.parent()?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn volume_pair_normalizes_equivalent_probe_paths() {
+        let canonical = VolumePair(1, 1, NormalizedPath::new("probe/out"));
+        let equivalent = VolumePair(1, 1, NormalizedPath::new("probe/./out"));
+
+        assert_eq!(canonical, equivalent);
     }
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/persist/link_registry.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/link_registry.rs
@@ -1,27 +1,28 @@
 //! In-memory ledger for hardlink-tier materializations (#1039).
 
 use super::*;
+use crate::core::NormalizedPath;
 use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
 
 #[derive(Clone, Debug)]
 struct LinkRecord {
-    blob_path: PathBuf,
+    blob_path: NormalizedPath,
     expected_hash: [u8; 32],
-    outputs: BTreeSet<PathBuf>,
+    outputs: BTreeSet<NormalizedPath>,
     suspect: bool,
 }
 
 static REGISTRY: OnceLock<dashmap::DashMap<FileId, LinkRecord>> = OnceLock::new();
-static OUTPUT_IDS: OnceLock<dashmap::DashMap<PathBuf, FileId>> = OnceLock::new();
+static OUTPUT_IDS: OnceLock<dashmap::DashMap<NormalizedPath, FileId>> = OnceLock::new();
 static WATCHER_AVAILABLE: AtomicBool = AtomicBool::new(true);
 
 fn registry() -> &'static dashmap::DashMap<FileId, LinkRecord> {
     REGISTRY.get_or_init(dashmap::DashMap::new)
 }
 
-fn output_ids() -> &'static dashmap::DashMap<PathBuf, FileId> {
+fn output_ids() -> &'static dashmap::DashMap<NormalizedPath, FileId> {
     OUTPUT_IDS.get_or_init(dashmap::DashMap::new)
 }
 
@@ -41,13 +42,14 @@ fn hash_file(path: &Path) -> std::io::Result<[u8; 32]> {
     Ok(*hasher.finalize().as_bytes())
 }
 
-fn digest_path(blob_path: &Path) -> PathBuf {
+fn digest_path(blob_path: &Path) -> NormalizedPath {
     let name = blob_path.file_name().unwrap_or_default().to_string_lossy();
     let sidecar_name = format!(".cowhash-{}", blake3::hash(name.as_bytes()).to_hex());
     blob_path
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .join(sidecar_name)
+        .into()
 }
 
 /// Writes the digest sidecar keyed by `named_as`'s digest path, but hashes
@@ -90,7 +92,7 @@ pub(in crate::daemon::server) fn register_trusted_blob_for_test(
     registry().insert(
         id,
         LinkRecord {
-            blob_path: blob_path.to_path_buf(),
+            blob_path: blob_path.into(),
             expected_hash: [0; 32],
             outputs: BTreeSet::new(),
             suspect: false,
@@ -105,7 +107,7 @@ pub(in crate::daemon::server) fn register_trusted_blob_for_test(
 /// attempt. This lets artifact_io clean up after a later blob-rename failure
 /// without deleting a sidecar that existed before the attempt started.
 pub(in crate::daemon::server) struct AuthoritativeBlobDigest {
-    path: Option<PathBuf>,
+    path: Option<NormalizedPath>,
     digest: [u8; 32],
 }
 
@@ -313,7 +315,7 @@ pub(in crate::daemon::server) fn prepare_hardlink_registration(
                 }
                 let expected_hash = hash_file(blob_path)?;
                 entry.insert(LinkRecord {
-                    blob_path: blob_path.to_path_buf(),
+                    blob_path: blob_path.into(),
                     expected_hash,
                     outputs: BTreeSet::new(),
                     suspect: false,
@@ -323,23 +325,24 @@ pub(in crate::daemon::server) fn prepare_hardlink_registration(
         dashmap::mapref::entry::Entry::Vacant(entry) => {
             let expected_hash = hash_file(blob_path)?;
             entry.insert(LinkRecord {
-                blob_path: blob_path.to_path_buf(),
+                blob_path: blob_path.into(),
                 expected_hash,
                 outputs: BTreeSet::new(),
                 suspect: false,
             });
         }
     }
-    output_ids().insert(output_path.to_path_buf(), id);
+    output_ids().insert(output_path.into(), id);
     Ok(id)
 }
 
 pub(in crate::daemon::server) fn cancel_hardlink_registration(id: FileId, output_path: &Path) {
+    let output_path = NormalizedPath::new(output_path);
     if output_ids()
-        .get(output_path)
+        .get(&output_path)
         .is_some_and(|entry| *entry == id)
     {
-        output_ids().remove(output_path);
+        output_ids().remove(&output_path);
     }
 }
 
@@ -353,7 +356,8 @@ pub(in crate::daemon::server) fn commit_hardlink_registration(
             "hardlink registration disappeared before commit",
         ));
     };
-    match get_file_id(output_path) {
+    let output_path = NormalizedPath::new(output_path);
+    match get_file_id(output_path.as_path()) {
         Some(actual) if actual == id => {}
         Some(_mismatched) => {
             // The path now resolves to a *different* file identity than the
@@ -362,7 +366,7 @@ pub(in crate::daemon::server) fn commit_hardlink_registration(
             // re-hashes it before serving it.
             record.suspect = true;
             drop(record);
-            cancel_hardlink_registration(id, output_path);
+            cancel_hardlink_registration(id, output_path.as_path());
             return Err(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 "hardlink output identity changed before registration commit",
@@ -378,34 +382,36 @@ pub(in crate::daemon::server) fn commit_hardlink_registration(
             // commit failure the same way it already does for a failed
             // std::fs::hard_link, instead of hard-failing (issue #1042).
             drop(record);
-            cancel_hardlink_registration(id, output_path);
+            cancel_hardlink_registration(id, output_path.as_path());
             return Err(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 "hardlink output identity transiently unavailable before registration commit",
             ));
         }
     }
-    record.outputs.insert(output_path.to_path_buf());
+    record.outputs.insert(output_path);
     drop(record);
     Ok(())
 }
 
 pub(in crate::daemon::server) fn prepare_registered_detach(
     path: &Path,
-) -> Option<(FileId, PathBuf)> {
+) -> Option<(FileId, NormalizedPath)> {
+    let path = NormalizedPath::new(path);
     let id = output_ids()
-        .get(path)
+        .get(&path)
         .map(|entry| *entry)
-        .or_else(|| get_file_id(path))?;
+        .or_else(|| get_file_id(path.as_path()))?;
     registry()
         .get(&id)
         .map(|record| (id, record.blob_path.clone()))
 }
 
 pub(in crate::daemon::server) fn commit_registered_detach(id: FileId, path: &Path) {
-    output_ids().remove(path);
+    let path = NormalizedPath::new(path);
+    output_ids().remove(&path);
     let remove = if let Some(mut record) = registry().get_mut(&id) {
-        record.outputs.remove(path);
+        record.outputs.remove(&path);
         record.outputs.is_empty() && !record.suspect
     } else {
         false
@@ -443,7 +449,7 @@ pub(in crate::daemon::server) fn verify_registered_blob(blob_path: &Path) -> std
                 registry().insert(
                     id,
                     LinkRecord {
-                        blob_path: blob_path.to_path_buf(),
+                        blob_path: blob_path.into(),
                         expected_hash,
                         outputs: BTreeSet::new(),
                         suspect: false,
@@ -572,12 +578,13 @@ pub(in crate::daemon::server) fn mark_removed_links_suspect<'a>(
     paths: impl IntoIterator<Item = &'a Path>,
 ) {
     for path in paths {
-        let Some((_, id)) = output_ids().remove(path) else {
+        let path = NormalizedPath::new(path);
+        let Some((_, id)) = output_ids().remove(&path) else {
             continue;
         };
         if let Some(mut record) = registry().get_mut(&id) {
             record.suspect = true;
-            record.outputs.remove(path);
+            record.outputs.remove(&path);
         }
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_multi.rs
@@ -1,7 +1,7 @@
 //! Private staging plan for one unit of a multi-source C/C++ invocation.
 
 use super::*;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 static MULTI_PLAN_COUNTER: AtomicU64 = AtomicU64::new(1);
@@ -193,7 +193,7 @@ pub(in crate::daemon::server) struct StagedMultiUnitPlan {
     pub(in crate::daemon::server) depfile: NormalizedPath,
     pub(in crate::daemon::server) outputs: Vec<StagedOutputPlan>,
     pub(in crate::daemon::server) msvc_syntax: bool,
-    root: PathBuf,
+    root: NormalizedPath,
 }
 
 impl StagedMultiUnitPlan {
@@ -233,19 +233,19 @@ impl StagedMultiUnitPlan {
                 ),
             });
         };
-        let root = staging_dir.join(format!(
+        let root: NormalizedPath = staging_dir.join(format!(
             ".multi-{}-{}",
             std::process::id(),
             MULTI_PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
-        ));
+        )).into();
         if let Err(source) = std::fs::create_dir_all(&root) {
             return StagedPlanOutcome::Error(StagedPlanError {
                 reason: StagedPlanReason::StagingDirectoryCreate,
                 source,
             });
         }
-        let staged: NormalizedPath = root.join(filename).into();
-        let depfile: NormalizedPath = root.join("unit.d").into();
+        let staged: NormalizedPath = root.join(filename);
+        let depfile: NormalizedPath = root.join("unit.d");
         let user_depfile = args
             .iter()
             .any(|arg| matches!(arg.as_str(), "-MD" | "-MMD"));

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
@@ -11,7 +11,7 @@ use super::staged_store::{inject_staged_fault, StagedFaultGuard, StagedFaultPoin
 use super::staged_store::{materialization_error, staged_lane_enabled, StagedMaterializationStats};
 use crate::core::path::NormalizedPath;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 static PLAN_COUNTER: AtomicU64 = AtomicU64::new(1);
@@ -131,19 +131,19 @@ pub(in crate::daemon::server) struct StagedOutputPlan {
 pub(in crate::daemon::server) struct StagedCompilePlan {
     pub(in crate::daemon::server) outputs: Vec<StagedOutputPlan>,
     pub(in crate::daemon::server) rewritten_args: Vec<String>,
-    root: PathBuf,
+    root: NormalizedPath,
 }
 
 impl StagedCompilePlan {
     #[cfg(test)]
     pub(in crate::daemon::server) fn for_test(
-        root: PathBuf,
+        root: impl Into<NormalizedPath>,
         outputs: Vec<StagedOutputPlan>,
     ) -> Self {
         Self {
             outputs,
             rewritten_args: Vec::new(),
-            root,
+            root: root.into(),
         }
     }
 
@@ -165,11 +165,11 @@ impl StagedCompilePlan {
         if rustc_has_missing_option_value(args) {
             return StagedPlanOutcome::Unsupported(StagedPlanReason::MissingOptionValue);
         }
-        let root = staging_dir.join(format!(
+        let root: NormalizedPath = staging_dir.join(format!(
             ".compile-{}-{}",
             std::process::id(),
             PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
-        ));
+        )).into();
         if let Err(source) = std::fs::create_dir_all(&root) {
             return StagedPlanOutcome::Error(planning_error(
                 StagedPlanReason::StagingDirectoryCreate,
@@ -188,7 +188,7 @@ impl StagedCompilePlan {
                 let staged = root.join(file_name);
                 if outputs
                     .iter()
-                    .any(|output: &StagedOutputPlan| output.staged.as_path() == staged)
+                    .any(|output: &StagedOutputPlan| staged == output.staged.as_path())
                 {
                     return Ok(StagedPlanOutcome::Unsupported(
                         StagedPlanReason::OutputNameCollision,
@@ -196,7 +196,7 @@ impl StagedCompilePlan {
                 }
                 outputs.push(StagedOutputPlan {
                     requested: requested.clone(),
-                    staged: staged.into(),
+                    staged,
                 });
             }
             for (kind, path) in emit_specs(args) {
@@ -215,8 +215,7 @@ impl StagedCompilePlan {
                         staged: root
                             .join(Path::new(&path).file_name().ok_or_else(|| {
                                 missing_filename(StagedPlanReason::OutputMissingFilename)
-                            })?)
-                            .into(),
+                            })?),
                     });
                 }
             }
@@ -227,7 +226,7 @@ impl StagedCompilePlan {
                     .requested
                     .file_name()
                     .ok_or_else(|| missing_filename(StagedPlanReason::OutputMissingFilename))?;
-                output.staged = root.join(file_name).into();
+                output.staged = root.join(file_name);
             }
             if outputs.iter().enumerate().any(|(index, output)| {
                 outputs[..index]
@@ -363,11 +362,11 @@ impl StagedCompilePlan {
         {
             return StagedPlanOutcome::Unsupported(StagedPlanReason::MissingRequiredOutputFlag);
         }
-        let root = staging_dir.join(format!(
+        let root: NormalizedPath = staging_dir.join(format!(
             ".compile-{}-{}",
             std::process::id(),
             PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
-        ));
+        )).into();
         if let Err(source) = std::fs::create_dir_all(&root) {
             return StagedPlanOutcome::Error(planning_error(
                 StagedPlanReason::StagingDirectoryCreate,
@@ -379,7 +378,7 @@ impl StagedCompilePlan {
             let file_name = requested
                 .file_name()
                 .ok_or_else(|| missing_filename(StagedPlanReason::OutputMissingFilename))?;
-            let staged: NormalizedPath = root.join(file_name).into();
+            let staged: NormalizedPath = root.join(file_name);
             let requested_depfile = dep_flags.mf_path.clone().or_else(|| {
                 dep_flags
                     .has_md
@@ -479,7 +478,7 @@ impl StagedCompilePlan {
                     })?);
                 outputs.push(StagedOutputPlan {
                     requested: requested_depfile,
-                    staged: staged_depfile.into(),
+                    staged: staged_depfile,
                 });
             }
             Ok(StagedPlanOutcome::Enabled(Self {
@@ -506,11 +505,11 @@ impl StagedCompilePlan {
         if !staged_lane_enabled(crate::compiler::CompilerFamily::Gcc) {
             return StagedPlanOutcome::Unsupported(StagedPlanReason::LaneDisabled);
         }
-        let root = staging_dir.join(format!(
+        let root: NormalizedPath = staging_dir.join(format!(
             ".compile-{}-{}",
             std::process::id(),
             PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
-        ));
+        )).into();
         if let Err(source) = std::fs::create_dir_all(&root) {
             return StagedPlanOutcome::Error(planning_error(
                 StagedPlanReason::StagingDirectoryCreate,
@@ -522,7 +521,7 @@ impl StagedCompilePlan {
             let file_name = requested
                 .file_name()
                 .ok_or_else(|| missing_filename(StagedPlanReason::OutputMissingFilename))?;
-            let staged: NormalizedPath = root.join(file_name).into();
+            let staged: NormalizedPath = root.join(file_name);
             let requested_text = requested.to_string_lossy();
             let mut rewritten_args = args.to_vec();
             let mut replaced = false;
@@ -575,11 +574,11 @@ impl StagedCompilePlan {
         if has_unmodeled_link_output_option(args) {
             return StagedPlanOutcome::Unsupported(StagedPlanReason::UnmodeledSideOutput);
         }
-        let root = staging_dir.join(format!(
+        let root: NormalizedPath = staging_dir.join(format!(
             ".link-{}-{}",
             std::process::id(),
             PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
-        ));
+        )).into();
         if let Err(source) = std::fs::create_dir_all(&root) {
             return StagedPlanOutcome::Error(planning_error(
                 StagedPlanReason::StagingDirectoryCreate,
@@ -602,7 +601,7 @@ impl StagedCompilePlan {
                 let filename = requested
                     .file_name()
                     .ok_or_else(|| missing_filename(StagedPlanReason::OutputMissingFilename))?;
-                let staged: NormalizedPath = root.join(filename).into();
+                let staged: NormalizedPath = root.join(filename);
                 if outputs.iter().any(|output: &StagedOutputPlan| {
                     output.requested == requested || output.staged == staged
                 }) {
@@ -680,14 +679,14 @@ impl StagedCompilePlan {
             .map(|output| output.staged.clone())
     }
 
-    pub(in crate::daemon::server) fn unexpected_staged_entries(&self) -> io::Result<Vec<PathBuf>> {
-        let declared: std::collections::HashSet<PathBuf> = self
+    pub(in crate::daemon::server) fn unexpected_staged_entries(&self) -> io::Result<Vec<NormalizedPath>> {
+        let declared: std::collections::HashSet<NormalizedPath> = self
             .outputs
             .iter()
-            .map(|output| output.staged.as_path().to_path_buf())
+            .map(|output| output.staged.clone())
             .collect();
         Ok(std::fs::read_dir(&self.root)?
-            .map(|entry| entry.map(|entry| entry.path()))
+            .map(|entry| entry.map(|entry| entry.path().into()))
             .collect::<io::Result<Vec<_>>>()?
             .into_iter()
             .filter(|path| !declared.contains(path))
@@ -918,7 +917,7 @@ impl Drop for StagedCompilePlan {
 
 fn absolute(path: &Path, cwd: &Path) -> NormalizedPath {
     if path.is_absolute() {
-        path.to_path_buf().into()
+        path.into()
     } else {
         cwd.join(path).into()
     }

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -10,7 +10,7 @@ use super::*;
 use serde::{Deserialize, Serialize};
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 mod maintenance;
 pub(crate) use maintenance::{
@@ -239,8 +239,8 @@ pub(in crate::daemon::server) fn is_staged_artifact_root(path: &Path) -> bool {
     })
 }
 
-fn staged_root(artifact_dir: &Path) -> PathBuf {
-    artifact_dir.join(STAGED_ROOT)
+fn staged_root(artifact_dir: &Path) -> NormalizedPath {
+    artifact_dir.join(STAGED_ROOT).into()
 }
 
 fn open_store_lock(root: &Path) -> io::Result<File> {
@@ -273,23 +273,23 @@ fn validate_generation(generation_hex: &str) -> io::Result<()> {
     Ok(())
 }
 
-fn pointer_path(artifact_dir: &Path, key_hex: &str) -> PathBuf {
+fn pointer_path(artifact_dir: &Path, key_hex: &str) -> NormalizedPath {
     staged_root(artifact_dir).join(format!("{key_hex}.current"))
 }
 
-fn generation_dir(artifact_dir: &Path, key_hex: &str, generation_hex: &str) -> PathBuf {
+fn generation_dir(artifact_dir: &Path, key_hex: &str, generation_hex: &str) -> NormalizedPath {
     staged_root(artifact_dir).join(key_hex).join(generation_hex)
 }
 
-fn output_path(generation_dir: &Path, index: usize) -> PathBuf {
-    generation_dir.join(format!("output-{index}"))
+fn output_path(generation_dir: &Path, index: usize) -> NormalizedPath {
+    generation_dir.join(format!("output-{index}")).into()
 }
 
-fn manifest_path(generation_dir: &Path) -> PathBuf {
-    generation_dir.join("manifest.bin")
+fn manifest_path(generation_dir: &Path) -> NormalizedPath {
+    generation_dir.join("manifest.bin").into()
 }
 
-fn temporary_path(path: &Path, suffix: &str) -> PathBuf {
+fn temporary_path(path: &Path, suffix: &str) -> NormalizedPath {
     let nonce = STAGED_ARTIFACT_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     path.with_file_name(format!(
         ".{}.{}.{}-{}",
@@ -297,7 +297,7 @@ fn temporary_path(path: &Path, suffix: &str) -> PathBuf {
         std::process::id(),
         nonce,
         suffix
-    ))
+    )).into()
 }
 
 fn sync_file(path: &Path) -> io::Result<()> {
@@ -873,7 +873,7 @@ pub(in crate::daemon::server) fn load_staged_artifact_paths(
                 "staged output digest does not match its manifest",
             ));
         }
-        paths.push((output.index, path.into()));
+        paths.push((output.index, path));
     }
     if seen.iter().any(|was_seen| !was_seen) {
         return Err(io::Error::new(

--- a/crates/zccache-test-support/Cargo.toml
+++ b/crates/zccache-test-support/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 
 [dependencies]
 tempfile = { workspace = true }
+zccache-core = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/zccache-test-support/src/lib.rs
+++ b/crates/zccache-test-support/src/lib.rs
@@ -1,6 +1,8 @@
 //! Disposable real-filesystem fixtures with loud skip accounting (#1039).
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(any(windows, target_os = "macos"))]
+use std::path::PathBuf;
 use std::process::{Command, Output};
 use zccache_core::NormalizedPath;
 
@@ -331,7 +333,7 @@ fn linux_loop(name: &'static str, filesystem: &str, mkfs: &str) -> FixtureResult
     }
     Ok(FsFixture {
         name,
-        root: mount,
+        root: mount.into(),
         backing: Backing::LinuxLoop { temp, device },
     })
 }

--- a/crates/zccache-test-support/src/lib.rs
+++ b/crates/zccache-test-support/src/lib.rs
@@ -2,11 +2,12 @@
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+use zccache_core::NormalizedPath;
 
 #[derive(Debug)]
 pub struct FsFixture {
     name: &'static str,
-    root: PathBuf,
+    root: NormalizedPath,
     backing: Backing,
 }
 
@@ -61,7 +62,7 @@ impl FsFixture {
             .map_err(|error| skip(name, format!("native tempdir failed: {error}")))?;
         Ok(Self {
             name,
-            root: temp.path().to_path_buf(),
+            root: temp.path().into(),
             backing: Backing::Temp(temp),
         })
     }
@@ -110,7 +111,7 @@ impl FsFixture {
                 .map_err(|error| skip("tmpfs", format!("tempdir failed: {error}")))?;
             return Ok(Self {
                 name: "tmpfs",
-                root: temp.path().to_path_buf(),
+                root: temp.path().into(),
                 backing: Backing::Temp(temp),
             });
         }
@@ -159,7 +160,7 @@ impl FsFixture {
             let root = PathBuf::from(format!(r"\\localhost\{share}"));
             Ok(Self {
                 name: "smb-loopback",
-                root,
+                root: root.into(),
                 backing: Backing::WindowsSmb { temp, share },
             })
         }
@@ -257,7 +258,7 @@ fn windows_vhd_sized(name: &'static str, filesystem: &str, maximum_mb: u32) -> F
     }
     Ok(FsFixture {
         name,
-        root: mount,
+        root: mount.into(),
         backing: Backing::WindowsVhd { temp, image },
     })
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,6 +2,17 @@
 
 Meta: https://github.com/zackees/zccache/issues/968
 
+# #1136 PathBuf Dylint backlog
+
+Issue: https://github.com/zackees/zccache/issues/1136
+
+- [x] Classify and migrate persistent filesystem identities to `NormalizedPath`.
+- [x] Preserve bundle-relative paths without treating them as filesystem identities.
+- [x] Add regression coverage for normalized identity and relative bundle behavior.
+- [x] Run targeted daemon/test-support checks.
+- [ ] Validate the Linux Dylint CI job after merge.
+- [ ] Ship, merge, and validate the resolving PR; close #1136.
+
 ## Merged to main ✅
 - #967 (PR #969) client-disconnect cancellation
 - #962 (PR #970) orphan-pipe post-exit watchdog (Mode A)


### PR DESCRIPTION
Closes #1136

## Summary

- migrate daemon persistence, staged-output, sidecar, and fixture filesystem identities to `NormalizedPath`
- keep validated directory-bundle members relative via owned `Box<Path>` values
- add regression coverage for normalized capability-cache identity and relative bundle members

## Validation

- `soldr cargo test -p zccache-daemon-core --features test-support`
- `soldr cargo test -p zccache-test-support`
- `soldr cargo clippy -p zccache-daemon-core --lib --features test-support -- -D warnings`
- `soldr cargo clippy -p zccache-test-support --lib -- -D warnings`

Linux Dylint runs only on the main-branch CI workflow and will be verified after merge.