### PR TITLE
style: apply Linux rustfmt path staging layout

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_multi.rs
@@ -233,11 +233,13 @@ impl StagedMultiUnitPlan {
                 ),
             });
         };
-        let root: NormalizedPath = staging_dir.join(format!(
-            ".multi-{}-{}",
-            std::process::id(),
-            MULTI_PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
-        )).into();
+        let root: NormalizedPath = staging_dir
+            .join(format!(
+                ".multi-{}-{}",
+                std::process::id(),
+                MULTI_PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
+            ))
+            .into();
         if let Err(source) = std::fs::create_dir_all(&root) {
             return StagedPlanOutcome::Error(StagedPlanError {
                 reason: StagedPlanReason::StagingDirectoryCreate,

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
@@ -165,11 +165,13 @@ impl StagedCompilePlan {
         if rustc_has_missing_option_value(args) {
             return StagedPlanOutcome::Unsupported(StagedPlanReason::MissingOptionValue);
         }
-        let root: NormalizedPath = staging_dir.join(format!(
-            ".compile-{}-{}",
-            std::process::id(),
-            PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
-        )).into();
+        let root: NormalizedPath = staging_dir
+            .join(format!(
+                ".compile-{}-{}",
+                std::process::id(),
+                PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
+            ))
+            .into();
         if let Err(source) = std::fs::create_dir_all(&root) {
             return StagedPlanOutcome::Error(planning_error(
                 StagedPlanReason::StagingDirectoryCreate,
@@ -212,10 +214,9 @@ impl StagedCompilePlan {
                 } else {
                     outputs.push(StagedOutputPlan {
                         requested,
-                        staged: root
-                            .join(Path::new(&path).file_name().ok_or_else(|| {
-                                missing_filename(StagedPlanReason::OutputMissingFilename)
-                            })?),
+                        staged: root.join(Path::new(&path).file_name().ok_or_else(|| {
+                            missing_filename(StagedPlanReason::OutputMissingFilename)
+                        })?),
                     });
                 }
             }
@@ -362,11 +363,13 @@ impl StagedCompilePlan {
         {
             return StagedPlanOutcome::Unsupported(StagedPlanReason::MissingRequiredOutputFlag);
         }
-        let root: NormalizedPath = staging_dir.join(format!(
-            ".compile-{}-{}",
-            std::process::id(),
-            PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
-        )).into();
+        let root: NormalizedPath = staging_dir
+            .join(format!(
+                ".compile-{}-{}",
+                std::process::id(),
+                PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
+            ))
+            .into();
         if let Err(source) = std::fs::create_dir_all(&root) {
             return StagedPlanOutcome::Error(planning_error(
                 StagedPlanReason::StagingDirectoryCreate,
@@ -505,11 +508,13 @@ impl StagedCompilePlan {
         if !staged_lane_enabled(crate::compiler::CompilerFamily::Gcc) {
             return StagedPlanOutcome::Unsupported(StagedPlanReason::LaneDisabled);
         }
-        let root: NormalizedPath = staging_dir.join(format!(
-            ".compile-{}-{}",
-            std::process::id(),
-            PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
-        )).into();
+        let root: NormalizedPath = staging_dir
+            .join(format!(
+                ".compile-{}-{}",
+                std::process::id(),
+                PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
+            ))
+            .into();
         if let Err(source) = std::fs::create_dir_all(&root) {
             return StagedPlanOutcome::Error(planning_error(
                 StagedPlanReason::StagingDirectoryCreate,
@@ -574,11 +579,13 @@ impl StagedCompilePlan {
         if has_unmodeled_link_output_option(args) {
             return StagedPlanOutcome::Unsupported(StagedPlanReason::UnmodeledSideOutput);
         }
-        let root: NormalizedPath = staging_dir.join(format!(
-            ".link-{}-{}",
-            std::process::id(),
-            PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
-        )).into();
+        let root: NormalizedPath = staging_dir
+            .join(format!(
+                ".link-{}-{}",
+                std::process::id(),
+                PLAN_COUNTER.fetch_add(1, Ordering::Relaxed)
+            ))
+            .into();
         if let Err(source) = std::fs::create_dir_all(&root) {
             return StagedPlanOutcome::Error(planning_error(
                 StagedPlanReason::StagingDirectoryCreate,
@@ -679,7 +686,9 @@ impl StagedCompilePlan {
             .map(|output| output.staged.clone())
     }
 
-    pub(in crate::daemon::server) fn unexpected_staged_entries(&self) -> io::Result<Vec<NormalizedPath>> {
+    pub(in crate::daemon::server) fn unexpected_staged_entries(
+        &self,
+    ) -> io::Result<Vec<NormalizedPath>> {
         let declared: std::collections::HashSet<NormalizedPath> = self
             .outputs
             .iter()

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -297,7 +297,8 @@ fn temporary_path(path: &Path, suffix: &str) -> NormalizedPath {
         std::process::id(),
         nonce,
         suffix
-    )).into()
+    ))
+    .into()
 }
 
 fn sync_file(path: &Path) -> io::Result<()> {


### PR DESCRIPTION
Fixes the Formatting CI failure from #1138.\n\nThe Linux rustfmt 1.94.1 job requires only the line-wrapping changes shown here; no behavior changes.\n\nValidation:\n- git diff --check\n- prior #1138 targeted daemon tests and scoped clippy passed\n\nRefs #1136.