### PR TITLE
fix(test-support): normalize macOS image fixture root

### DIFF
--- a/crates/zccache-test-support/src/lib.rs
+++ b/crates/zccache-test-support/src/lib.rs
@@ -382,7 +382,7 @@ fn mac_image(name: &'static str, filesystem: &str) -> FixtureResult {
     }
     Ok(FsFixture {
         name,
-        root: mount.clone(),
+        root: mount.clone().into(),
         backing: Backing::MacImage { temp, mount },
     })
 }


### PR DESCRIPTION
Fixes the macOS-only compilation failure on main.

FsFixture.root is a NormalizedPath; convert the macOS image mount PathBuf when constructing the fixture.

Validation:
- soldr cargo fmt --all -- --check
- soldr cargo check -p zccache-test-support
- soldr cargo test -p zccache-test-support