### PR TITLE
chore(release): bump 1.12.15 -> 1.12.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4119,7 +4119,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "bincode",
  "blake3",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-audit"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli-core"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "bincode",
  "blake3",
@@ -4215,14 +4215,14 @@ dependencies = [
 
 [[package]]
 name = "zccache-compile-trace"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "zccache-audit",
 ]
 
 [[package]]
 name = "zccache-compiler"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "clang",
  "tempfile",
@@ -4233,7 +4233,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "crash-handler",
  "dashmap",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon-core"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "bincode",
  "blake3",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "blake3",
  "futures",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "bincode",
  "bytes",
@@ -4348,7 +4348,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "fs2",
  "globset",
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "bincode",
  "dashmap",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "reqwest",
  "serde",
@@ -4393,7 +4393,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "blake3",
  "memmap2",
@@ -4403,7 +4403,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "bytes",
  "dashmap",
@@ -4423,7 +4423,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "bincode",
  "bytes",
@@ -4441,7 +4441,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-symbols"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "tempfile",
  "zccache-core",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "tempfile",
  "zccache-core",
@@ -4457,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.12.15"
+version = "1.12.16"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.12.15"
+version = "1.12.16"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps the workspace release version from 1.12.15 to 1.12.16.

This triggers the repository's auto-release pipeline when merged to main.

Validation:
- soldr cargo check -p zccache --locked
- uv run --no-project -m ci.release_workflow check-registries