### PR TITLE
fix(release): install uv before generating manifest

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -345,6 +345,8 @@ jobs:
         with:
           ref: ${{ needs.preflight.outputs.checkout_ref }}
 
+      - uses: astral-sh/setup-uv@v6
+
       - uses: actions/download-artifact@v8
         with:
           pattern: release-*


### PR DESCRIPTION
## Root cause\n\nThe Publish GitHub Release job ran uv run --no-project ci/build_release_manifest.py without installing uv, causing the 1.12.16 auto-release run to stop with uv: command not found.\n\n## Fix\n\nInstall uv with stral-sh/setup-uv@v6 in that job before generating the release manifest.\n\n## Validation\n\n- git diff --check\n- Confirmed the failed job and exact command in run 29885775813.