### PR TITLE
fix(release): retain gha sha2 dependency for crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4084,6 +4084,7 @@ dependencies = [
  "sadness-generator",
  "serde",
  "serde_json",
+ "sha2",
  "sysinfo",
  "tar",
  "tempfile",

--- a/ci/tests/test_publish_amalgamate.py
+++ b/ci/tests/test_publish_amalgamate.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import shutil
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -7,11 +9,31 @@ import pytest
 from ci import release_checks
 from ci.publish_amalgamate import (
     AmalgamatedModule,
+    INTERNAL_MODULES,
     drop_python_extension_bindings,
     prepare_zccache_crate_for_publish,
     rewrite_rust_source_for_amalgamation,
     rewrite_zccache_manifest,
 )
+
+
+def test_zccache_publish_manifest_keeps_gha_feature_dependencies(
+    tmp_path: Path,
+) -> None:
+    source = Path(__file__).parents[2] / "crates" / "zccache" / "Cargo.toml"
+    manifest_path = tmp_path / "Cargo.toml"
+    shutil.copyfile(source, manifest_path)
+    rewrite_zccache_manifest(
+        manifest_path,
+        {module.crate: module.module for module in INTERNAL_MODULES},
+    )
+    manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["features"]["gha"] == ["dep:reqwest", "dep:sha2"]
+    assert manifest["dependencies"]["sha2"] == {
+        "workspace": True,
+        "optional": True,
+    }
 
 
 def test_rewrite_rust_source_rebases_crate_root_and_internal_crate_paths() -> None:

--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -98,6 +98,7 @@ memmap2 = { workspace = true }
 
 # gha
 reqwest = { workspace = true, features = ["json"], optional = true }
+sha2 = { workspace = true, optional = true }
 
 # protocol
 bincode = { workspace = true }


### PR DESCRIPTION
## Root cause\n\nThe crates.io packaging transform replaces the internal zccache-gha dependency with eqwest and sha2 feature dependencies. The facade manifest declared eqwest but not sha2, so the rewritten gha feature was invalid.\n\n## Fix\n\nDeclare optional workspace sha2 in crates/zccache and cover the actual release-manifest rewrite with a regression test.\n\n## Validation\n\n- Focused release-manifest regression suite passed (6 tests).\n- Feature-enabled zccache check passed.