### PR TITLE
fix(release): build selected revision on manual recovery

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -149,7 +149,12 @@ jobs:
           else
             TAG="${RAW_TAG#refs/tags/}"
             if [ -z "$TAG" ]; then
-              if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+              if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                # A manual recovery run must build the selected revision, not
+                # an existing release tag that may predate its workflow fix.
+                TAG="$VERSION"
+                CHECKOUT_REF="$GITHUB_SHA"
+              elif git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
                 TAG="$VERSION"
                 CHECKOUT_REF="$VERSION"
               elif git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then


### PR DESCRIPTION
## Root cause\n\nManual recovery runs preferred an existing version tag for checkout. After a partial release created 1.12.16, subsequent reruns therefore rebuilt that stale commit rather than the selected main revision containing the packaging repairs.\n\n## Fix\n\nFor workflow_dispatch with no explicit tag, retain the version as the release tag but set the checkout ref to the selected revision (GITHUB_SHA).\n\n## Validation\n\n- Workflow diff whitespace/structural check passed.