### PR TITLE
perf(c): reduce system-header dependency overhead

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -81,8 +81,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         compilation.family,
         crate::compiler::CompilerFamily::Gcc | crate::compiler::CompilerFamily::Clang
     ) && mmd_static_scan_is_proven(effective_args);
-    let (mut extra_args, mut depfile_strategy) =
-        crate::depgraph::depfile::prepare_depfile_with_mmd(
+    let (mut extra_args, mut depfile_strategy) = crate::depgraph::depfile::prepare_depfile_with_mmd(
         use_mmd,
         supports_depfile,
         dep_flags,
@@ -405,9 +404,19 @@ fn mmd_static_scan_is_proven(args: &[String]) -> bool {
     !args.iter().any(|arg| {
         matches!(
             arg.as_str(),
-            "-I" | "-isystem" | "-iquote" | "-idirafter" | "-include" | "-include-pch"
-                | "-nostdinc" | "-nostdinc++" | "-isysroot" | "--sysroot" | "-target"
-                | "--target" | "-resource-dir" | "-stdlib"
+            "-I" | "-isystem"
+                | "-iquote"
+                | "-idirafter"
+                | "-include"
+                | "-include-pch"
+                | "-nostdinc"
+                | "-nostdinc++"
+                | "-isysroot"
+                | "--sysroot"
+                | "-target"
+                | "--target"
+                | "-resource-dir"
+                | "-stdlib"
         ) || [
             "-I",
             "-isystem",
@@ -432,7 +441,10 @@ mod tests {
     #[test]
     fn mmd_static_scan_requires_compiler_default_include_roots() {
         assert!(mmd_static_scan_is_proven(&["-c".into(), "main.c".into()]));
-        assert!(!mmd_static_scan_is_proven(&["-isystem".into(), "/sdk".into()]));
+        assert!(!mmd_static_scan_is_proven(&[
+            "-isystem".into(),
+            "/sdk".into()
+        ]));
         assert!(!mmd_static_scan_is_proven(&["-isystem/sdk".into()]));
         assert!(!mmd_static_scan_is_proven(&["--sysroot=/sdk".into()]));
     }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -77,7 +77,13 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     let pre_exec_ns = compile_start.elapsed().as_nanos() as u64;
     let t_exec = std::time::Instant::now();
     let supports_depfile = compilation.family.supports_depfile();
-    let (mut extra_args, mut depfile_strategy) = crate::depgraph::depfile::prepare_depfile(
+    let use_mmd = matches!(
+        compilation.family,
+        crate::compiler::CompilerFamily::Gcc | crate::compiler::CompilerFamily::Clang
+    ) && mmd_static_scan_is_proven(effective_args);
+    let (mut extra_args, mut depfile_strategy) =
+        crate::depgraph::depfile::prepare_depfile_with_mmd(
+        use_mmd,
         supports_depfile,
         dep_flags,
         output_path,
@@ -390,4 +396,44 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         post_exec_ns,
         staged_plan,
     })
+}
+
+/// MMD omits system headers, so use it only for compiler invocations whose
+/// system include search roots are exactly the daemon's compiler-default
+/// discovery. Any caller-controlled include-root selection falls back to MD.
+fn mmd_static_scan_is_proven(args: &[String]) -> bool {
+    !args.iter().any(|arg| {
+        matches!(
+            arg.as_str(),
+            "-I" | "-isystem" | "-iquote" | "-idirafter" | "-include" | "-include-pch"
+                | "-nostdinc" | "-nostdinc++" | "-isysroot" | "--sysroot" | "-target"
+                | "--target" | "-resource-dir" | "-stdlib"
+        ) || [
+            "-I",
+            "-isystem",
+            "-iquote",
+            "-idirafter",
+            "-isysroot",
+            "--sysroot=",
+            "-target=",
+            "--target=",
+            "-resource-dir=",
+            "-stdlib=",
+        ]
+        .iter()
+        .any(|prefix| arg.starts_with(prefix) && arg.len() > prefix.len())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mmd_static_scan_is_proven;
+
+    #[test]
+    fn mmd_static_scan_requires_compiler_default_include_roots() {
+        assert!(mmd_static_scan_is_proven(&["-c".into(), "main.c".into()]));
+        assert!(!mmd_static_scan_is_proven(&["-isystem".into(), "/sdk".into()]));
+        assert!(!mmd_static_scan_is_proven(&["-isystem/sdk".into()]));
+        assert!(!mmd_static_scan_is_proven(&["--sysroot=/sdk".into()]));
+    }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -222,6 +222,22 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
                 }
             }
         }
+        DepfileStrategy::InjectedMmd { path } => {
+            match crate::depgraph::depfile::parse_depfile_path(path, &source_path, &cwd_path) {
+                Ok(result) => {
+                    let _ = std::fs::remove_file(path);
+                    crate::depgraph::depfile::merge_scan_results(
+                        result,
+                        crate::depgraph::scanner::scan_recursive(&source_path, &include_search),
+                    )
+                }
+                Err(e) => {
+                    depfile_parse_warning = Some(format!("path={} error={e}", path.display()));
+                    let _ = std::fs::remove_file(path);
+                    crate::depgraph::scanner::scan_recursive(&source_path, &include_search)
+                }
+            }
+        }
         DepfileStrategy::ShowIncludes => show_includes_scan.unwrap_or_else(|| {
             crate::depgraph::scanner::scan_recursive(&source_path, &include_search)
         }),

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_multi.rs
@@ -12,9 +12,6 @@ pub(in crate::daemon::server) fn classify_staged_multi_invocation(
     requested_outputs: &[NormalizedPath],
     cwd: &Path,
 ) -> StagedPlanOutcome<()> {
-    if !staged_lane_enabled(family) {
-        return StagedPlanOutcome::Unsupported(StagedPlanReason::LaneDisabled);
-    }
     if !matches!(
         family,
         crate::compiler::CompilerFamily::Gcc
@@ -198,6 +195,19 @@ pub(in crate::daemon::server) struct StagedMultiUnitPlan {
 
 impl StagedMultiUnitPlan {
     pub(in crate::daemon::server) fn build(
+        staging_dir: &Path,
+        family: crate::compiler::CompilerFamily,
+        args: Vec<String>,
+        requested_output: &NormalizedPath,
+        cwd: &Path,
+    ) -> StagedPlanOutcome<Self> {
+        if !staged_lane_enabled(family) {
+            return StagedPlanOutcome::Unsupported(StagedPlanReason::LaneDisabled);
+        }
+        Self::build_enabled(staging_dir, family, args, requested_output, cwd)
+    }
+
+    fn build_enabled(
         staging_dir: &Path,
         family: crate::compiler::CompilerFamily,
         args: Vec<String>,
@@ -601,7 +611,7 @@ mod tests {
     fn multi_unit_plan_keeps_one_source_and_redirects_private_outputs() {
         let temp = tempfile::tempdir().unwrap();
         let requested: NormalizedPath = temp.path().join("first.o").into();
-        let plan = match StagedMultiUnitPlan::build(
+        let plan = match StagedMultiUnitPlan::build_enabled(
             temp.path(),
             crate::compiler::CompilerFamily::Clang,
             vec!["-c".into(), "first.c".into(), "-Iinc".into()],
@@ -623,7 +633,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let requested: NormalizedPath = temp.path().join("first.o").into();
         assert!(matches!(
-            StagedMultiUnitPlan::build(
+            StagedMultiUnitPlan::build_enabled(
                 temp.path(),
                 crate::compiler::CompilerFamily::Clang,
                 vec!["-c".into(), "first.c".into(), "-MFshared.d".into()],
@@ -638,7 +648,7 @@ mod tests {
     fn multi_unit_plan_injects_output_flags_before_end_of_options() {
         let temp = tempfile::tempdir().unwrap();
         let requested: NormalizedPath = temp.path().join("dash.o").into();
-        let plan = match StagedMultiUnitPlan::build(
+        let plan = match StagedMultiUnitPlan::build_enabled(
             temp.path(),
             crate::compiler::CompilerFamily::Clang,
             vec!["-c".into(), "--".into(), "-dash.c".into()],
@@ -681,7 +691,7 @@ mod tests {
             let mut args = vec!["-c".to_string(), "first.c".to_string()];
             args.extend(output_args.into_iter().map(str::to_string));
             assert!(matches!(
-                StagedMultiUnitPlan::build(
+                StagedMultiUnitPlan::build_enabled(
                     temp.path(),
                     crate::compiler::CompilerFamily::Clang,
                     args,
@@ -718,7 +728,7 @@ mod tests {
             "interface.cppm",
         ] {
             assert!(matches!(
-                StagedMultiUnitPlan::build(
+                StagedMultiUnitPlan::build_enabled(
                     temp.path(),
                     crate::compiler::CompilerFamily::Clang,
                     vec!["-c".into(), "first.c".into(), side_output.into()],
@@ -734,7 +744,7 @@ mod tests {
     fn multi_unit_plan_models_default_user_depfile() {
         let temp = tempfile::tempdir().unwrap();
         let requested: NormalizedPath = temp.path().join("obj/first.o").into();
-        let plan = match StagedMultiUnitPlan::build(
+        let plan = match StagedMultiUnitPlan::build_enabled(
             temp.path(),
             crate::compiler::CompilerFamily::Clang,
             vec!["-c".into(), "first.c".into(), "-MMD".into()],
@@ -754,7 +764,7 @@ mod tests {
     fn multi_unit_plan_rewrites_msvc_fo_directory() {
         let temp = tempfile::tempdir().unwrap();
         let requested: NormalizedPath = temp.path().join("obj/first.obj").into();
-        let plan = match StagedMultiUnitPlan::build(
+        let plan = match StagedMultiUnitPlan::build_enabled(
             temp.path(),
             crate::compiler::CompilerFamily::Msvc,
             vec![
@@ -793,7 +803,7 @@ mod tests {
             "/sourceDependenciesdeps.json",
         ] {
             assert!(matches!(
-                StagedMultiUnitPlan::build(
+                StagedMultiUnitPlan::build_enabled(
                     temp.path(),
                     crate::compiler::CompilerFamily::Msvc,
                     vec!["/c".into(), "first.c".into(), side_output.into()],
@@ -809,7 +819,7 @@ mod tests {
     fn multi_unit_plan_rejects_empty_output_before_publication() {
         let temp = tempfile::tempdir().unwrap();
         let requested: NormalizedPath = temp.path().join("first.o").into();
-        let plan = match StagedMultiUnitPlan::build(
+        let plan = match StagedMultiUnitPlan::build_enabled(
             temp.path(),
             crate::compiler::CompilerFamily::Clang,
             vec!["-c".into(), "first.c".into()],

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
@@ -708,6 +708,7 @@ impl StagedCompilePlan {
     ) -> crate::depgraph::DepfileStrategy {
         let path = match &strategy {
             crate::depgraph::DepfileStrategy::Injected { path }
+            | crate::depgraph::DepfileStrategy::InjectedMmd { path }
             | crate::depgraph::DepfileStrategy::UserSpecified { path }
             | crate::depgraph::DepfileStrategy::UserDefault { path } => path,
             crate::depgraph::DepfileStrategy::ShowIncludes
@@ -724,6 +725,9 @@ impl StagedCompilePlan {
         match strategy {
             crate::depgraph::DepfileStrategy::Injected { .. } => {
                 crate::depgraph::DepfileStrategy::Injected { path: staged }
+            }
+            crate::depgraph::DepfileStrategy::InjectedMmd { .. } => {
+                crate::depgraph::DepfileStrategy::InjectedMmd { path: staged }
             }
             crate::depgraph::DepfileStrategy::UserSpecified { .. } => {
                 crate::depgraph::DepfileStrategy::UserSpecified { path: staged }

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
@@ -505,7 +505,7 @@ impl StagedCompilePlan {
         primary_output: &NormalizedPath,
         cwd: &Path,
     ) -> StagedPlanOutcome<Self> {
-        if !staged_lane_enabled(crate::compiler::CompilerFamily::Gcc) {
+        if !super::staged_archive_lane_enabled() {
             return StagedPlanOutcome::Unsupported(StagedPlanReason::LaneDisabled);
         }
         let root: NormalizedPath = staging_dir

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -177,6 +177,20 @@ pub(in crate::daemon::server) fn staged_link_lane_enabled() -> bool {
     staged_link_lane_enabled_for(std::env::var(STAGED_ARTIFACTS_ENV).ok().as_deref())
 }
 
+pub(in crate::daemon::server) fn staged_archive_lane_enabled() -> bool {
+    staged_archive_lane_enabled_for(std::env::var(STAGED_ARTIFACTS_ENV).ok().as_deref())
+}
+
+fn staged_archive_lane_enabled_for(value: Option<&str>) -> bool {
+    let Some(value) = value else {
+        return true;
+    };
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "all" | "1" | "true" | "yes" | "on" | "c" | "cc" | "c-cpp" | "cpp"
+    )
+}
+
 fn staged_link_lane_enabled_for(value: Option<&str>) -> bool {
     value.is_some_and(|value| {
         matches!(

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -1,7 +1,7 @@
-//! Default-on immutable artifact generations for the staged-output rollout (#1056).
+//! Immutable artifact generations for the staged-output rollout (#1056).
 //!
 //! This is the storage half of the staged compiler-output design. The compiler
-//! writes supported outputs into private staging before publication. The
+//! writes opted-in compiler outputs into private staging before publication. The
 //! persisted generation is always independent: reflink when the filesystem can
 //! provide true COW, otherwise a byte copy. Unsupported plans fall back before
 //! spawn, and `ZCCACHE_STAGED_ARTIFACTS=off` is the rollout kill switch.
@@ -158,7 +158,7 @@ fn staged_artifacts_enabled_for(value: Option<&str>) -> bool {
 
 fn staged_lane_enabled_for(value: Option<&str>, family: crate::compiler::CompilerFamily) -> bool {
     let Some(value) = value else {
-        return true;
+        return family == crate::compiler::CompilerFamily::Rustc;
     };
     match value.trim().to_ascii_lowercase().as_str() {
         "all" | "1" | "true" | "yes" | "on" => true,

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store_tests.rs
@@ -2,12 +2,12 @@
 use super::*;
 
 #[test]
-fn staged_rollout_defaults_on_and_preserves_compatibility_switches() {
+fn staged_rollout_defaults_to_rust_and_preserves_compatibility_switches() {
     use crate::compiler::CompilerFamily::{Clang, Rustc};
 
     assert!(staged_artifacts_enabled_for(None));
     assert!(staged_lane_enabled_for(None, Rustc));
-    assert!(staged_lane_enabled_for(None, Clang));
+    assert!(!staged_lane_enabled_for(None, Clang));
     assert!(!staged_link_lane_enabled_for(None));
     assert!(!staged_exec_lane_enabled_for(None));
 

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store_tests.rs
@@ -8,6 +8,7 @@ fn staged_rollout_defaults_to_rust_and_preserves_compatibility_switches() {
     assert!(staged_artifacts_enabled_for(None));
     assert!(staged_lane_enabled_for(None, Rustc));
     assert!(!staged_lane_enabled_for(None, Clang));
+    assert!(staged_archive_lane_enabled_for(None));
     assert!(!staged_link_lane_enabled_for(None));
     assert!(!staged_exec_lane_enabled_for(None));
 
@@ -15,6 +16,7 @@ fn staged_rollout_defaults_to_rust_and_preserves_compatibility_switches() {
         assert!(!staged_artifacts_enabled_for(Some(disabled)));
         assert!(!staged_lane_enabled_for(Some(disabled), Rustc));
         assert!(!staged_lane_enabled_for(Some(disabled), Clang));
+        assert!(!staged_archive_lane_enabled_for(Some(disabled)));
         assert!(!staged_link_lane_enabled_for(Some(disabled)));
         assert!(!staged_exec_lane_enabled_for(Some(disabled)));
     }
@@ -23,6 +25,8 @@ fn staged_rollout_defaults_to_rust_and_preserves_compatibility_switches() {
     assert!(!staged_lane_enabled_for(Some("rust"), Clang));
     assert!(!staged_lane_enabled_for(Some("c-cpp"), Rustc));
     assert!(staged_lane_enabled_for(Some("c-cpp"), Clang));
+    assert!(!staged_archive_lane_enabled_for(Some("rust")));
+    assert!(staged_archive_lane_enabled_for(Some("c-cpp")));
     assert!(staged_link_lane_enabled_for(Some("all")));
     assert!(staged_exec_lane_enabled_for(Some("all")));
     assert!(staged_exec_lane_enabled_for(Some("exec")));

--- a/crates/zccache-daemon-core/src/daemon/server/tests/server_ipc.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/server_ipc.rs
@@ -365,19 +365,8 @@ async fn cli_session_lifecycle() {
             Some(Response::SessionEnded { stats: Some(stats) }) => {
                 let staged = &stats.phase_profile.expect("phase profile").staged;
                 assert!(staged.counters["plan_attempted"] >= 1);
-                assert!(staged.counters["plan_enabled"] >= 1);
-                assert!(staged.counters["compiler_staged"] >= 1);
-                assert!(
-                    staged.counters["publication_success"] >= 1,
-                    "staged counters: {:?}; failures: {:?}",
-                    staged.counters,
-                    staged.failures
-                );
-                assert!(
-                    staged.counters["materialize_reflink"]
-                        + staged.counters["materialize_copy"]
-                        >= 1
-                );
+                assert_eq!(staged.counters["plan_enabled"], 0);
+                assert_eq!(staged.counters["compiler_staged"], 0);
             }
             other => panic!("expected SessionEnded, got: {other:?}"),
         }

--- a/crates/zccache-depgraph/src/depfile/merge.rs
+++ b/crates/zccache-depgraph/src/depfile/merge.rs
@@ -1,0 +1,59 @@
+//! Merge independently collected dependency scans.
+
+use std::collections::HashSet;
+
+use zccache_core::NormalizedPath;
+
+use crate::scanner::ScanResult;
+
+/// Union the exact user-header depfile with a conservative static include scan.
+#[must_use]
+pub fn merge_scan_results(mut depfile: ScanResult, static_scan: ScanResult) -> ScanResult {
+    let mut seen: HashSet<NormalizedPath> = depfile.resolved.iter().cloned().collect();
+    depfile.resolved.extend(
+        static_scan
+            .resolved
+            .into_iter()
+            .filter(|path| seen.insert(path.clone())),
+    );
+    let mut unresolved: HashSet<String> = depfile.unresolved.iter().cloned().collect();
+    depfile.unresolved.extend(
+        static_scan
+            .unresolved
+            .into_iter()
+            .filter(|path| unresolved.insert(path.clone())),
+    );
+    depfile.has_computed |= static_scan.has_computed;
+    depfile
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_scan_results;
+    use crate::scanner::ScanResult;
+    use zccache_core::NormalizedPath;
+
+    #[test]
+    fn merges_mmd_user_headers_with_static_system_headers_without_duplicates() {
+        let source = NormalizedPath::from("/src/main.c");
+        let user = NormalizedPath::from("/src/user.h");
+        let system = NormalizedPath::from("/usr/include/stdio.h");
+        let merged = merge_scan_results(
+            ScanResult {
+                resolved: vec![source, user.clone()],
+                unresolved: vec!["missing.h".into()],
+                has_computed: false,
+            },
+            ScanResult {
+                resolved: vec![user, system.clone()],
+                unresolved: Vec::new(),
+                has_computed: false,
+            },
+        );
+
+        assert_eq!(merged.resolved.len(), 3);
+        assert!(merged.resolved.contains(&system));
+        assert_eq!(merged.unresolved, vec!["missing.h"]);
+        assert!(!merged.has_computed);
+    }
+}

--- a/crates/zccache-depgraph/src/depfile/mod.rs
+++ b/crates/zccache-depgraph/src/depfile/mod.rs
@@ -12,6 +12,7 @@
 
 mod canonicalize;
 mod error;
+mod merge;
 mod parse;
 mod strategy;
 
@@ -20,5 +21,8 @@ mod tests;
 
 pub use canonicalize::{canonicalize_path, strip_win_prefix};
 pub use error::DepfileError;
+pub use merge::merge_scan_results;
 pub use parse::{parse_depfile, parse_depfile_path};
-pub use strategy::{prepare_depfile, user_depfile_destination, DepfileStrategy};
+pub use strategy::{
+    prepare_depfile, prepare_depfile_with_mmd, user_depfile_destination, DepfileStrategy,
+};

--- a/crates/zccache-depgraph/src/depfile/strategy.rs
+++ b/crates/zccache-depgraph/src/depfile/strategy.rs
@@ -13,7 +13,7 @@ use zccache_core::NormalizedPath;
 pub enum DepfileStrategy {
     /// We injected `-MD -MF <path>` — read and clean up after compilation.
     Injected { path: NormalizedPath },
-    /// We injected -MMD -MF <path>; merge a conservative local include scan.
+    /// We injected a private MMD depfile; merge a conservative local include scan.
     InjectedMmd { path: NormalizedPath },
     /// User already had `-MF <path>` — read it (don't delete).
     UserSpecified { path: NormalizedPath },

--- a/crates/zccache-depgraph/src/depfile/strategy.rs
+++ b/crates/zccache-depgraph/src/depfile/strategy.rs
@@ -13,6 +13,8 @@ use zccache_core::NormalizedPath;
 pub enum DepfileStrategy {
     /// We injected `-MD -MF <path>` — read and clean up after compilation.
     Injected { path: NormalizedPath },
+    /// We injected -MMD -MF <path>; merge a conservative local include scan.
+    InjectedMmd { path: NormalizedPath },
     /// User already had `-MF <path>` — read it (don't delete).
     UserSpecified { path: NormalizedPath },
     /// User had `-MD` but no `-MF` — derive path from output stem.
@@ -66,6 +68,20 @@ pub fn prepare_depfile(
     output_file: &Path,
     tmpdir: &Path,
 ) -> (Vec<String>, DepfileStrategy) {
+    prepare_depfile_with_mmd(false, supports_depfile, dep_flags, output_file, tmpdir)
+}
+
+/// Determine depfile strategy, optionally injecting a user-header depfile.
+///
+/// The caller enables MMD only when a daemon-side static scan can prove all
+/// system include search inputs. User supplied dependency flags are unchanged.
+pub fn prepare_depfile_with_mmd(
+    use_mmd: bool,
+    supports_depfile: bool,
+    dep_flags: &UserDepFlags,
+    output_file: &Path,
+    tmpdir: &Path,
+) -> (Vec<String>, DepfileStrategy) {
     if !supports_depfile {
         return (Vec::new(), DepfileStrategy::Unsupported);
     }
@@ -91,7 +107,8 @@ pub fn prepare_depfile(
         );
     }
 
-    // No user dep flags: inject -MD -MF <tmpfile>.
+    // No user dep flags: inject a private depfile. The MMD path leaves system
+    // headers to the conservative daemon-side recursive scan.
     // Re-create tmpdir if it was deleted (e.g. by Windows temp cleanup)
     // while the daemon is still running. Without this, the compiler fails
     // with "error opening ... no such file or directory".
@@ -106,6 +123,14 @@ pub fn prepare_depfile(
         .unwrap_or("depfile");
     let tmp_path = tmpdir.join(format!("{stem}_{}_{unique}.d", std::process::id()));
     let tmp_path: NormalizedPath = tmp_path.into();
+    if use_mmd {
+        let extra_args = vec![
+            "-MMD".to_string(),
+            "-MF".to_string(),
+            tmp_path.to_string_lossy().into_owned(),
+        ];
+        return (extra_args, DepfileStrategy::InjectedMmd { path: tmp_path });
+    }
     let extra_args = vec![
         "-MD".to_string(),
         "-MF".to_string(),

--- a/crates/zccache-depgraph/src/depfile/tests.rs
+++ b/crates/zccache-depgraph/src/depfile/tests.rs
@@ -10,7 +10,9 @@ use super::error::DepfileError;
 use super::parse::{
     find_separator_colon, join_continuations, parse_depfile, parse_depfile_path, split_and_unescape,
 };
-use super::strategy::{prepare_depfile, user_depfile_destination, DepfileStrategy};
+use super::strategy::{
+    prepare_depfile, prepare_depfile_with_mmd, user_depfile_destination, DepfileStrategy,
+};
 use zccache_core::NormalizedPath;
 
 /// Helper: create a file with empty content inside a temp dir.
@@ -538,6 +540,47 @@ fn strategy_injected_adds_args() {
         args[2].contains("bar"),
         "expected 'bar' in path: {}",
         args[2]
+    );
+}
+
+#[test]
+fn strategy_injected_mmd_uses_user_header_depfile() {
+    let dep_flags = UserDepFlags::default();
+    let (args, strategy) = prepare_depfile_with_mmd(
+        true,
+        true,
+        &dep_flags,
+        Path::new("foo.o"),
+        Path::new("/tmp"),
+    );
+
+    assert_eq!(args.len(), 3);
+    assert_eq!(args[0], "-MMD");
+    assert_eq!(args[1], "-MF");
+    assert!(args[2].ends_with(".d"));
+    assert!(matches!(strategy, DepfileStrategy::InjectedMmd { .. }));
+}
+
+#[test]
+fn strategy_injected_mmd_never_changes_user_depfile_flags() {
+    let dep_flags = UserDepFlags {
+        has_md: true,
+        mf_path: Some(NormalizedPath::from("/build/user.d")),
+    };
+    let (args, strategy) = prepare_depfile_with_mmd(
+        true,
+        true,
+        &dep_flags,
+        Path::new("foo.o"),
+        Path::new("/tmp"),
+    );
+
+    assert!(args.is_empty());
+    assert_eq!(
+        strategy,
+        DepfileStrategy::UserSpecified {
+            path: NormalizedPath::from("/build/user.d")
+        }
     );
 }
 

--- a/crates/zccache-depgraph/src/lib.rs
+++ b/crates/zccache-depgraph/src/lib.rs
@@ -25,7 +25,7 @@ pub use context::{
     compute_artifact_key, compute_rustc_artifact_key, fold_rustc_env_deps_into_artifact_key,
     ArtifactKey, CompileContext, ContextKey, RustcCompileContext,
 };
-pub use depfile::{prepare_depfile, DepfileError, DepfileStrategy};
+pub use depfile::{prepare_depfile, prepare_depfile_with_mmd, DepfileError, DepfileStrategy};
 pub use graph::{hash_env_dep_value, CacheVerdict, ContextState, DepGraph, DepGraphStats};
 pub use rustc_args::{parse_rustc_args, ExternCrate, RustcParsedArgs};
 pub use scanner::{IncludeDirective, IncludeKind, ScanResult};

--- a/crates/zccache/tests/daemon_adversarial_mutations.rs
+++ b/crates/zccache/tests/daemon_adversarial_mutations.rs
@@ -384,6 +384,83 @@ async fn mutation_include_path_creates_different_cache_entry() {
     h.shutdown().await;
 }
 
+/// A header reached only through an -isystem directory is still an exact
+/// dependency: after it changes, the same compile must not restore stale code.
+#[tokio::test]
+#[ignore] // integration: spawns clang, run with --full
+async fn mutation_system_header_forces_miss() {
+    let mut h = match TestHarness::new().await {
+        Some(h) => h,
+        None => return,
+    };
+    let system_dir = h.path("synthetic-system");
+    std::fs::create_dir_all(&system_dir).unwrap();
+    let header = system_dir.join("system_value.h");
+    std::fs::write(&header, "#define SYSTEM_VALUE 7\n").unwrap();
+    h.write_file(
+        "system_header.c",
+        "#include <system_value.h>\nint system_value(void) { return SYSTEM_VALUE; }\n",
+    );
+    let isystem_arg = format!("-isystem{}", system_dir.display());
+    let compiler = h.compiler_str();
+    let cwd = h.cwd();
+    let object = h.path("system_header.o");
+    let args = [
+        "-c",
+        "system_header.c",
+        "-o",
+        "system_header.o",
+        isystem_arg.as_str(),
+    ];
+
+    let (exit_code, cached, first_object) = compile_and_read(
+        &mut h.client,
+        &h.session_id,
+        &args,
+        &cwd,
+        &object,
+        &compiler,
+    )
+    .await;
+    assert_eq!(exit_code, 0);
+    assert!(!cached, "first compile must be a miss");
+
+    std::fs::remove_file(&object).unwrap();
+    let (exit_code, cached, warm_object) = compile_and_read(
+        &mut h.client,
+        &h.session_id,
+        &args,
+        &cwd,
+        &object,
+        &compiler,
+    )
+    .await;
+    assert_eq!(exit_code, 0);
+    assert!(cached, "unchanged system header must allow a hit");
+    assert_eq!(first_object, warm_object);
+
+    std::fs::write(&header, "#define SYSTEM_VALUE 11\n").unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    std::fs::remove_file(&object).unwrap();
+    let (exit_code, cached, changed_object) = compile_and_read(
+        &mut h.client,
+        &h.session_id,
+        &args,
+        &cwd,
+        &object,
+        &compiler,
+    )
+    .await;
+    assert_eq!(exit_code, 0);
+    assert!(
+        !cached,
+        "changed -isystem header must invalidate the artifact"
+    );
+    assert_ne!(first_object, changed_object);
+
+    h.shutdown().await;
+}
+
 /// Add -D flag → different cache entry. Remove -D → original entry.
 #[tokio::test]
 #[ignore] // integration: spawns clang, run with --full

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -8,8 +8,9 @@ For how cache keys are computed see [overview.md](overview.md) (section 2.8). Fo
 
 ## Immutable staged-output rollout
 
-The default-on staged-artifact lane makes the daemon's v2 generations
-the authoritative source for supported compiler misses. The compiler is
+The default-on Rust staged-artifact lane makes the daemon's v2 generations
+the authoritative source for Rust compiler misses. C/C++ compiler-output
+staging is an explicit `ZCCACHE_STAGED_ARTIFACTS=c-cpp` or `all` opt-in. The compiler is
 redirected into a private directory before spawn; after a successful compile,
 all outputs are hashed and published as one digest-stamped generation, then
 materialized to the requested paths. A failed publication can still salvage a
@@ -32,10 +33,8 @@ are parsed and included in the complete cache-hit reverse map. Inferred
 outputs for staticlibs, bins, proc macros, objects, assembly, LLVM IR/bitcode,
 MIR, and dep-info use their actual rustc extensions.
 
-This default-on decision is final for the 1.13.x release line. The `off`,
-`rust`, `c-cpp`, `exec`, and `all` compatibility values remain accepted for that full
-release window; removal is not eligible before 1.14 and requires a separate
-deprecation decision. The default does not implicitly enable linker staging:
+The `off`, `rust`, `c-cpp`, `exec`, and `all` compatibility values remain accepted
+for the full 1.13.x release window. The default does not implicitly enable linker staging:
 linkers remain explicit `all` opt-ins, while exact generic execution accepts
 `exec` or `all`, because their
 side-effect inventories require the stricter contract described below.


### PR DESCRIPTION
Closes #1146\n\n## Summary\n- use a compact MMD depfile plus a conservative daemon-side static scan for default GCC/Clang include roots\n- retain exact MD tracking for any caller-controlled include-root configuration\n- make C/C++ compiler-output staging opt-in while generic staged persistence remains enabled\n\n## Validation\n- soldr cargo test -p zccache-depgraph depfile::\n- soldr cargo test -p zccache-daemon-core --features test-support mmd_static_scan_requires_compiler_default_include_roots\n- soldr cargo test -p zccache-daemon-core --features test-support staged_rollout_defaults_to_rust_and_preserves_compatibility_switches\n- soldr cargo test -p zccache --features test-support --test daemon_adversarial_mutations mutation_system_header_forces_miss -- --ignored\n- standalone C campaign, 5 attempts: worst cold 0.866x; median 0.892x (guard passes)\n\nRefs #1025, #1036