### PR TITLE
Fix C++ dependency policy, warm-cache deadlock, and perf watchdog

### DIFF
--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -53,7 +53,7 @@ jobs:
 
   build-perf-benchmark:
     name: Build perf benchmark binary
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
 
@@ -96,10 +96,17 @@ jobs:
 
   perf-guard:
     name: ${{ matrix.label }} speed floor
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     needs: build-perf-benchmark
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    # The watchdog terminates one command at 75 minutes. Leave room for job
+    # setup, earlier matrix tests, summaries, and always-run artifact uploads.
+    timeout-minutes: 120
+    env:
+      PERF_GUARD_CONSOLE_OUTPUT: lite
+      PERF_GUARD_DIAGNOSTIC_AFTER_SECONDS: "3600"
+      PERF_GUARD_TIMEOUT_SECONDS: "4500"
+      PERF_GUARD_HEARTBEAT_SECONDS: "300"
     strategy:
       fail-fast: false
       matrix:
@@ -132,7 +139,8 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y clang
+          sudo apt-get install -y clang gdb
+          sudo sysctl -w kernel.yama.ptrace_scope=0
 
       - name: Download perf benchmark binary
         uses: actions/download-artifact@v7
@@ -179,6 +187,7 @@ jobs:
         if: matrix.language == 'c'
         shell: bash
         run: |
+          if [[ -f perf-guard-output/.watchdog-timeout ]]; then exit 0; fi
           python3 -m ci.perf_guard --run-benchmarks --language c --test perf_c_zccache_vs_bare \
             --attempts 3 --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
             --output-dir perf-guard-output/perf_c_zccache_vs_bare || true
@@ -187,22 +196,16 @@ jobs:
         if: matrix.language == 'c'
         shell: bash
         run: |
+          if [[ -f perf-guard-output/.watchdog-timeout ]]; then exit 0; fi
           python3 -m ci.perf_guard --run-benchmarks --language c --test perf_c_archive_link \
             --attempts 3 --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
             --output-dir perf-guard-output/perf_c_archive_link || true
-
-      - name: "C++ — perf_warm_cache_zccache_vs_sccache"
-        if: matrix.language == 'c++'
-        shell: bash
-        run: |
-          python3 -m ci.perf_guard --run-benchmarks --language c++ --test perf_warm_cache_zccache_vs_sccache \
-            --attempts 3 --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
-            --output-dir perf-guard-output/perf_warm_cache_zccache_vs_sccache || true
 
       - name: "C++ — perf_response_file"
         if: matrix.language == 'c++'
         shell: bash
         run: |
+          if [[ -f perf-guard-output/.watchdog-timeout ]]; then exit 0; fi
           python3 -m ci.perf_guard --run-benchmarks --language c++ --test perf_response_file \
             --attempts 3 --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
             --output-dir perf-guard-output/perf_response_file || true
@@ -211,6 +214,7 @@ jobs:
         if: matrix.language == 'c++'
         shell: bash
         run: |
+          if [[ -f perf-guard-output/.watchdog-timeout ]]; then exit 0; fi
           python3 -m ci.perf_guard --run-benchmarks --language c++ --test perf_cpp_sibling_remap_warm \
             --attempts 3 --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
             --output-dir perf-guard-output/perf_cpp_sibling_remap_warm || true
@@ -219,14 +223,28 @@ jobs:
         if: matrix.language == 'c++'
         shell: bash
         run: |
+          if [[ -f perf-guard-output/.watchdog-timeout ]]; then exit 0; fi
           python3 -m ci.perf_guard --run-benchmarks --language c++ --test perf_cpp_driver_link \
             --attempts 3 --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
             --output-dir perf-guard-output/perf_cpp_driver_link || true
+
+      # Keep the historically hanging multi-source benchmark last. A timeout
+      # marker skips every later benchmark in the job so summaries and the
+      # always-run artifact upload retain headroom.
+      - name: "C++ — perf_warm_cache_zccache_vs_sccache"
+        if: matrix.language == 'c++'
+        shell: bash
+        run: |
+          if [[ -f perf-guard-output/.watchdog-timeout ]]; then exit 0; fi
+          python3 -m ci.perf_guard --run-benchmarks --language c++ --test perf_warm_cache_zccache_vs_sccache \
+            --attempts 3 --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
+            --output-dir perf-guard-output/perf_warm_cache_zccache_vs_sccache || true
 
       - name: "Rust — perf_rustc_zccache_vs_sccache"
         if: matrix.language == 'rust'
         shell: bash
         run: |
+          if [[ -f perf-guard-output/.watchdog-timeout ]]; then exit 0; fi
           python3 -m ci.perf_guard --run-benchmarks --language rust --test perf_rustc_zccache_vs_sccache \
             --attempts 3 --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
             --output-dir perf-guard-output/perf_rustc_zccache_vs_sccache || true
@@ -235,6 +253,7 @@ jobs:
         if: matrix.language == 'rust'
         shell: bash
         run: |
+          if [[ -f perf-guard-output/.watchdog-timeout ]]; then exit 0; fi
           python3 -m ci.perf_guard --run-benchmarks --language rust --test perf_rustc_sibling_remap_warm \
             --attempts 3 --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
             --output-dir perf-guard-output/perf_rustc_sibling_remap_warm || true
@@ -243,6 +262,7 @@ jobs:
         if: matrix.language == 'rust'
         shell: bash
         run: |
+          if [[ -f perf-guard-output/.watchdog-timeout ]]; then exit 0; fi
           python3 -m ci.perf_guard --run-benchmarks --language rust --test perf_rust_workspace_link \
             --attempts 3 --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
             --output-dir perf-guard-output/perf_rust_workspace_link || true
@@ -267,9 +287,19 @@ jobs:
               fi
             done
           }
-          shopt -s nullglob
-          for dir in perf-guard-output/*/; do
-            name="$(basename "$dir")"
+          case "${{ matrix.language }}" in
+            c)
+              expected=(perf_c_zccache_vs_bare perf_c_archive_link)
+              ;;
+            c++)
+              expected=(perf_response_file perf_cpp_sibling_remap_warm perf_cpp_driver_link perf_warm_cache_zccache_vs_sccache)
+              ;;
+            rust)
+              expected=(perf_rustc_zccache_vs_sccache perf_rustc_sibling_remap_warm perf_rust_workspace_link)
+              ;;
+          esac
+          for name in "${expected[@]}"; do
+            dir="perf-guard-output/$name"
             result_file="$dir/perf-guard-result.txt"
             summary_file="$dir/perf-guard-summary.md"
             echo "::group::$name"
@@ -291,7 +321,6 @@ jobs:
             fi
             echo "::endgroup::"
           done
-          shopt -u nullglob
           echo "status=$overall" >> "$GITHUB_OUTPUT"
 
       - name: Upload perf guard artifacts
@@ -320,7 +349,7 @@ jobs:
             linux-tools-generic \
             "linux-tools-$(uname -r)" \
             || sudo apt-get install -y -qq linux-tools-common linux-tools-generic
-          cargo install inferno --locked --quiet
+          soldr cargo install inferno --locked --quiet
 
           # Allow `perf record` to capture without elevated privileges.
           echo 1 | sudo tee /proc/sys/kernel/perf_event_paranoid >/dev/null
@@ -342,7 +371,7 @@ jobs:
 
           for test_name in $FAILED_TESTS; do
             echo "::group::perf record: $test_name"
-            perf record \
+            timeout 10m perf record \
               -F 999 \
               -g --call-graph dwarf \
               -o "$test_name.perf.data" \

--- a/README.md
+++ b/README.md
@@ -700,6 +700,35 @@ A few things worth knowing:
   paths in both the diagnostic stream and (for PCH/MSVC) the artifact bytes
   themselves.
 
+### C/C++ dependency policy
+
+By default zccache asks GCC and Clang for an `-MD` dependency manifest and
+tracks every compiler-selected user and system header. The manifest is the
+pay-once cost: later C and C++ requests use the same direct-mode depgraph and
+do not rediscover the include closure.
+
+`--fast` is a broad opt-in preset. It currently omits system headers from new
+C/C++ manifests by using `-MMD`; `--skip-system-headers` selects that behavior
+directly. An explicit fine-grained setting overrides the preset:
+
+```bash
+zccache --fast clang++ -c src/main.cpp -o main.o
+zccache --skip-system-headers clang -c src/main.c -o main.o
+zccache --fast --scan-system-headers clang++ -c src/main.cpp -o main.o
+```
+
+The configuration equivalents are `ZCCACHE_FAST=1` and
+`ZCCACHE_SCAN_SYSTEM_HEADERS=0|1`. Policy flags must appear before the compiler
+name; identically named arguments after it are passed through to the compiler.
+User-supplied dependency switches remain authoritative: an explicit `-MD`
+manifest is tracked in full, while an explicit `-MMD` manifest is trusted as
+the compiler-classified user-header set.
+
+“System headers” follows the compiler's standard classification and includes
+the C library, C++ standard library, SDK, and compiler builtin headers. Skipping
+them trades correctness for speed: an SDK/header update that does not change
+the compiler executable can leave an otherwise matching cached object stale.
+
 ### Strict path validation
 
 Use `--strict-paths` or `ZCCACHE_STRICT_PATHS` to fail fast when compiler path

--- a/ci/perf_guard.py
+++ b/ci/perf_guard.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -14,7 +13,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from ci import benchmark_stats, perf_distribution
+from ci import benchmark_stats, perf_distribution, perf_watchdog
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -175,62 +174,61 @@ def run_benchmarks_once(
     language: str | None = None,
     benchmark_binary: Path | None = None,
     test_name: str | None = None,
+    watchdog_config: perf_watchdog.WatchdogConfig | None = None,
 ) -> tuple[int, str]:
-    outputs: list[str] = []
+    watchdog_config = watchdog_config or perf_watchdog.config_from_env()
     returncode = 0
     commands = _benchmark_commands(language, benchmark_binary, test_name)
     total_start = time.monotonic()
-    for cmd_index, command in enumerate(commands, start=1):
-        label = _command_label(command)
-        banner = (
-            f"[perf-guard] [{cmd_index}/{len(commands)}] "
-            f"[T+{_format_elapsed(time.monotonic() - total_start)}] "
-            f"starting {label}\n"
-        )
-        sys.stdout.write(banner)
-        sys.stdout.flush()
-        outputs.append(banner)
-
-        cache_dir = Path(tempfile.mkdtemp(prefix="zccache-perf-guard-cache-"))
-        env = _benchmark_env(cache_dir, language)
-        cmd_start = time.monotonic()
-        try:
-            with subprocess.Popen(
-                command,
-                cwd=REPO_ROOT,
-                env=env,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                bufsize=1,
-            ) as proc:
-                assert proc.stdout is not None
-                for line in proc.stdout:
-                    sys.stdout.write(line)
-                    sys.stdout.flush()
-                    outputs.append(line)
-                proc.wait()
-                cmd_returncode = proc.returncode
-            if cmd_returncode != 0 and returncode == 0:
-                returncode = cmd_returncode
-            cmd_elapsed = time.monotonic() - cmd_start
-            footer = (
-                f"[perf-guard] [{cmd_index}/{len(commands)}] "
-                f"finished {label} "
-                f"(exit={cmd_returncode}, elapsed={_format_elapsed(cmd_elapsed)})\n"
-            )
-            sys.stdout.write(footer)
-            sys.stdout.flush()
-            outputs.append(footer)
-        finally:
-            shutil.rmtree(cache_dir, ignore_errors=True)
-
-    output = "".join(outputs)
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    log_path.write_text(output, encoding="utf-8")
-    return returncode, output
+    with log_path.open("w", encoding="utf-8", buffering=1) as log:
+        for cmd_index, command in enumerate(commands, start=1):
+            label = _command_label(command)
+            def status(message: str) -> None:
+                line = f"[perf-guard] {message}\n"
+                log.write(line)
+                log.flush()
+                sys.stdout.write(line)
+                sys.stdout.flush()
+            status(
+                f"[{cmd_index}/{len(commands)}] "
+                f"[T+{_format_elapsed(time.monotonic() - total_start)}] starting {label}"
+            )
+            cache_dir = Path(tempfile.mkdtemp(prefix="zccache-perf-guard-cache-"))
+            env = _benchmark_env(cache_dir, language)
+            cmd_start = time.monotonic()
+            timed_out = False
+            try:
+                result = perf_watchdog.run_streamed_command(
+                    command,
+                    cwd=REPO_ROOT,
+                    env=env,
+                    log=log,
+                    output_dir=log_path.parent,
+                    cache_dir=cache_dir,
+                    label=label,
+                    config=watchdog_config,
+                    status=status,
+                )
+                timed_out = result.timed_out
+                cmd_returncode = result.returncode
+                if cmd_returncode != 0 and returncode == 0:
+                    returncode = cmd_returncode
+                cmd_elapsed = time.monotonic() - cmd_start
+                status(
+                    f"[{cmd_index}/{len(commands)}] finished {label} "
+                    f"(exit={cmd_returncode}, elapsed={_format_elapsed(cmd_elapsed)})"
+                )
+            finally:
+                perf_watchdog.preserve_runtime_logs_and_remove_cache(
+                    cache_dir, log_path.parent, f"{cmd_index}-{label}"
+                )
+            if timed_out:
+                marker = log_path.parent.parent / ".watchdog-timeout"
+                marker.write_text(f"{label}\n", encoding="utf-8")
+                status(f"stopping this attempt after {label} timed out")
+                break
+    return returncode, log_path.read_text(encoding="utf-8")
 
 
 def _benchmark_env(cache_dir: Path, language: str | None) -> dict[str, str]:
@@ -821,6 +819,8 @@ def _run_attempts(
         )
         if returncode != 0:
             command_failures.append(attempt)
+        if returncode == perf_watchdog.TIMEOUT_EXIT_CODE:
+            break
 
         interim = evaluate_attempts(
             parsed_attempts,

--- a/ci/perf_watchdog.py
+++ b/ci/perf_watchdog.py
@@ -1,0 +1,559 @@
+"""Durable output streaming and live-hang diagnostics for perf-guard children."""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import re
+import shutil
+import signal
+import subprocess
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO, Callable
+
+
+TIMEOUT_EXIT_CODE = 124
+
+
+@dataclass(frozen=True)
+class WatchdogConfig:
+    diagnostic_after_seconds: float = 60.0 * 60.0
+    timeout_seconds: float = 75.0 * 60.0
+    heartbeat_seconds: float = 5.0 * 60.0
+    console_output: str = "full"
+    debugger_timeout_seconds: float = 30.0
+    enable_debugger: bool = True
+    output_drain_grace_seconds: float = 2.0
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    timed_out: bool
+
+
+def config_from_env(env: dict[str, str] | None = None) -> WatchdogConfig:
+    values = os.environ if env is None else env
+
+    def number(name: str, default: float) -> float:
+        value = float(values.get(name, default))
+        if value < 0:
+            raise ValueError(f"{name} must be non-negative")
+        return value
+
+    console_output = values.get("PERF_GUARD_CONSOLE_OUTPUT", "full")
+    if console_output not in ("full", "lite"):
+        raise ValueError("PERF_GUARD_CONSOLE_OUTPUT must be 'full' or 'lite'")
+    return WatchdogConfig(
+        diagnostic_after_seconds=number("PERF_GUARD_DIAGNOSTIC_AFTER_SECONDS", 3600),
+        timeout_seconds=number("PERF_GUARD_TIMEOUT_SECONDS", 4500),
+        heartbeat_seconds=number("PERF_GUARD_HEARTBEAT_SECONDS", 300),
+        console_output=console_output,
+    )
+
+
+def run_streamed_command(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    log: IO[str],
+    output_dir: Path,
+    cache_dir: Path,
+    label: str,
+    config: WatchdogConfig,
+    status: Callable[[str], None],
+) -> CommandResult:
+    """Run one child while continuously flushing its merged output to disk."""
+    popen_options: dict[str, object] = {}
+    if os.name == "nt":
+        popen_options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        popen_options["start_new_session"] = True
+
+    runtime_roots_file = _runtime_roots_file(output_dir, label)
+    runtime_roots_file.parent.mkdir(parents=True, exist_ok=True)
+    runtime_roots_file.unlink(missing_ok=True)
+    child_env = env.copy()
+    child_env["PERF_GUARD_RUNTIME_ROOTS_FILE"] = str(runtime_roots_file)
+
+    with subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=child_env,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
+        **popen_options,
+    ) as proc:
+        assert proc.stdout is not None
+        lines: queue.Queue[str | None] = queue.Queue()
+
+        def read_output() -> None:
+            try:
+                for line in proc.stdout:
+                    lines.put(line)
+            finally:
+                lines.put(None)
+
+        reader = threading.Thread(target=read_output, name="perf-output-reader", daemon=True)
+        reader.start()
+        started = time.monotonic()
+        last_output = started
+        next_heartbeat = started + config.heartbeat_seconds
+        diagnostic_at = started + config.diagnostic_after_seconds
+        timeout_at = started + config.timeout_seconds
+        diagnostic_taken = False
+        reader_done = False
+        root_exited_at: float | None = None
+        last_line = "<no child output>"
+        recent_lines: deque[str] = deque(maxlen=40)
+
+        try:
+            while True:
+                now = time.monotonic()
+                try:
+                    item = lines.get(timeout=0.25)
+                except queue.Empty:
+                    item = ""
+                if item is None:
+                    reader_done = True
+                elif item:
+                    log.write(item)
+                    log.flush()
+                    last_output = now
+                    last_line = item.rstrip()[-500:]
+                    recent_lines.append(item.rstrip())
+                    if config.console_output == "full" or _is_lite_console_line(item):
+                        print(item, end="", flush=True)
+
+                running = proc.poll() is None
+                if not diagnostic_taken and now >= diagnostic_at and running:
+                    diagnostic_taken = True
+                    phase = _infer_phase(recent_lines)
+                    _safe_status(
+                        status,
+                        f"{label} is still running after {_elapsed(now - started)}; "
+                        f"last phase={phase!r}; capturing logs and symbolic stacks",
+                    )
+                    try:
+                        capture_hang_diagnostics(
+                            proc.pid,
+                            command=command,
+                            output_dir=output_dir,
+                            cache_dir=cache_dir,
+                            runtime_roots_file=runtime_roots_file,
+                            label=label,
+                            reason="diagnostic-threshold",
+                            elapsed_seconds=now - started,
+                            silent_seconds=now - last_output,
+                            last_line=last_line,
+                            recent_output=list(recent_lines),
+                            config=config,
+                            status=status,
+                        )
+                    except Exception as error:  # diagnostics must never defeat timeout cleanup
+                        _safe_status(status, f"hang diagnostic capture failed: {error}")
+                    try:
+                        _append_step_summary(
+                            f"### Perf watchdog: {label}\n\n"
+                            f"Still running after {_elapsed(now - started)}. Live stacks and full "
+                            f"logs are in the perf-guard artifact. Last phase: `{phase}`. "
+                            f"Last output: `{last_line}`\n"
+                        )
+                    except OSError as error:
+                        _safe_status(status, f"step-summary write failed: {error}")
+
+                if now >= next_heartbeat and running:
+                    _safe_status(
+                        status,
+                        f"{label} heartbeat: elapsed={_elapsed(now - started)}, "
+                        f"silent={_elapsed(now - last_output)}, last={last_line!r}",
+                    )
+                    next_heartbeat = now + config.heartbeat_seconds
+
+                if now >= timeout_at and running:
+                    _safe_status(
+                        status,
+                        f"{label} exceeded {_elapsed(config.timeout_seconds)}; "
+                        "terminating its process group immediately",
+                    )
+                    _terminate_process_group(proc, status)
+                    reader.join(timeout=5)
+                    _drain_output_queue(lines, log, config.console_output)
+                    return CommandResult(TIMEOUT_EXIT_CODE, timed_out=True)
+
+                returncode = proc.poll()
+                if returncode is not None:
+                    if root_exited_at is None:
+                        root_exited_at = now
+                    if reader_done and lines.empty():
+                        reader.join(timeout=1)
+                        return CommandResult(returncode, timed_out=False)
+                    if now - root_exited_at >= config.output_drain_grace_seconds:
+                        _safe_status(
+                            status,
+                            f"{label} root exited but descendants kept output open; "
+                            "terminating the remaining process group",
+                        )
+                        _terminate_process_group(proc, status)
+                        reader.join(timeout=5)
+                        _drain_output_queue(lines, log, config.console_output)
+                        return CommandResult(returncode, timed_out=False)
+        except BaseException:
+            _terminate_process_group(proc, status)
+            reader.join(timeout=5)
+            _drain_output_queue(lines, log, config.console_output)
+            raise
+
+
+def capture_hang_diagnostics(
+    root_pid: int,
+    *,
+    command: list[str],
+    output_dir: Path,
+    cache_dir: Path,
+    runtime_roots_file: Path,
+    label: str,
+    reason: str,
+    elapsed_seconds: float,
+    silent_seconds: float,
+    last_line: str,
+    recent_output: list[str],
+    config: WatchdogConfig,
+    status: Callable[[str], None],
+) -> Path:
+    stamp = time.strftime("%Y%m%d-%H%M%S", time.gmtime())
+    destination = output_dir / "diagnostics" / f"{_safe_name(label)}-{reason}-{stamp}"
+    destination.mkdir(parents=True, exist_ok=True)
+    pids = _process_tree(root_pid)
+    summary = {
+        "reason": reason,
+        "root_pid": root_pid,
+        "pids": pids,
+        "elapsed_seconds": elapsed_seconds,
+        "silent_seconds": silent_seconds,
+        "last_line": last_line,
+        "inferred_phase": _infer_phase(recent_output),
+        "recent_output": recent_output,
+        "command": command,
+    }
+    (destination / "summary.json").write_text(
+        json.dumps(summary, indent=2) + "\n", encoding="utf-8"
+    )
+    (destination / "summary.md").write_text(
+        "# Perf hang snapshot\n\n"
+        f"- Reason: `{reason}`\n"
+        f"- Root PID: `{root_pid}`\n"
+        f"- Elapsed: `{_elapsed(elapsed_seconds)}`\n"
+        f"- Time since output: `{_elapsed(silent_seconds)}`\n"
+        f"- Processes: `{', '.join(map(str, pids)) or 'none'}`\n"
+        f"- Inferred phase: `{_infer_phase(recent_output)}`\n"
+        f"- Last output: `{last_line}`\n\n"
+        "## Recent output\n\n```text\n"
+        + "\n".join(recent_output)
+        + "\n```\n",
+        encoding="utf-8",
+    )
+    _capture_process_snapshot(pids, destination)
+    preserve_zccache_logs(
+        cache_dir,
+        destination / "zccache-runtime",
+        runtime_roots_file=runtime_roots_file,
+    )
+
+    debugger = shutil.which("gdb") if config.enable_debugger else None
+    if debugger is None:
+        status("live debugger unavailable; /proc and process-tree snapshots were retained")
+    else:
+        for pid in _debugger_target_pids(root_pid, pids):
+            status(f"capturing all-thread symbolic stack for PID {pid}")
+            stack_path = destination / f"gdb-{pid}.txt"
+            debugger_exit: int | None = None
+            with stack_path.open("w", encoding="utf-8", errors="replace") as output:
+                try:
+                    result = subprocess.run(
+                        [
+                            debugger,
+                            "-batch",
+                            "-nx",
+                            "-ex",
+                            "set pagination off",
+                            "-ex",
+                            "set print thread-events off",
+                            "-ex",
+                            "thread apply all bt full",
+                            "-p",
+                            str(pid),
+                        ],
+                        stdout=output,
+                        stderr=subprocess.STDOUT,
+                        check=False,
+                        timeout=config.debugger_timeout_seconds,
+                    )
+                    debugger_exit = result.returncode
+                    output.write(f"\n[gdb exit={result.returncode}]\n")
+                except subprocess.TimeoutExpired:
+                    output.write("\n[gdb timed out and was terminated]\n")
+            stack_text = stack_path.read_text(encoding="utf-8", errors="replace")
+            if debugger_exit != 0 or not re.search(r"(^|\n)(Thread\s|#0\s)", stack_text):
+                _safe_status(
+                    status,
+                    f"symbolic stack capture for PID {pid} was incomplete "
+                    f"(gdb exit={debugger_exit})",
+                )
+    return destination
+
+
+def preserve_zccache_logs(
+    cache_dir: Path,
+    destination: Path,
+    *,
+    runtime_roots_file: Path | None = None,
+) -> None:
+    """Copy diagnostic metadata without uploading the potentially huge cache."""
+    copied = False
+    roots = [cache_dir]
+    if runtime_roots_file is not None:
+        try:
+            roots.extend(
+                Path(line.strip())
+                for line in runtime_roots_file.read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            )
+        except OSError:
+            pass
+    unique_roots = list(dict.fromkeys(root.resolve() for root in roots))
+    for root_index, root in enumerate(unique_roots):
+        candidates = [root]
+        try:
+            candidates.extend(
+                child
+                for child in root.iterdir()
+                if child.is_dir() and child.name.startswith("v")
+            )
+        except OSError:
+            pass
+        for candidate in candidates:
+            target = destination / f"root-{root_index}"
+            if candidate != root:
+                target /= candidate.name
+            for name in ("logs", "crashes", "daemon"):
+                source = candidate / name
+                if source.exists():
+                    try:
+                        shutil.copytree(source, target / name, dirs_exist_ok=True)
+                        copied = True
+                    except OSError:
+                        pass
+            for pattern in ("*.json", "*.jsonl", "*.log", "*.symref"):
+                for source in candidate.glob(pattern):
+                    try:
+                        target.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(source, target / source.name)
+                        copied = True
+                    except OSError:
+                        pass
+    if not copied:
+        destination.mkdir(parents=True, exist_ok=True)
+        (destination / "README.txt").write_text(
+            "No zccache runtime logs or crash records existed at capture time.\n",
+            encoding="utf-8",
+        )
+
+
+def preserve_runtime_logs_and_remove_cache(
+    cache_dir: Path, output_dir: Path, label: str
+) -> None:
+    preserve_zccache_logs(
+        cache_dir,
+        output_dir / "runtime-logs" / label,
+        runtime_roots_file=_runtime_roots_file(output_dir, label),
+    )
+    shutil.rmtree(cache_dir, ignore_errors=True)
+
+
+def _capture_process_snapshot(pids: list[int], destination: Path) -> None:
+    if pids and shutil.which("ps"):
+        with (destination / "process-tree.txt").open("w", encoding="utf-8") as output:
+            subprocess.run(
+                [
+                    "ps",
+                    "-ww",
+                    "-o",
+                    "pid,ppid,stat,etime,wchan:32,comm,args",
+                    "-p",
+                    ",".join(map(str, pids)),
+                ],
+                stdout=output,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+    for pid in pids:
+        proc_dir = Path("/proc") / str(pid)
+        pid_dir = destination / f"proc-{pid}"
+        pid_dir.mkdir(parents=True, exist_ok=True)
+        for name in ("cmdline", "status", "wchan", "stack", "maps"):
+            try:
+                data = (proc_dir / name).read_bytes()
+            except OSError as error:
+                data = f"unavailable: {error}\n".encode()
+            if name == "cmdline":
+                data = data.replace(b"\0", b" ")
+            (pid_dir / f"{name}.txt").write_bytes(data)
+
+
+def _process_tree(root_pid: int) -> list[int]:
+    if os.name == "nt" or not Path("/proc").is_dir():
+        return [root_pid]
+    children: dict[int, list[int]] = {}
+    for proc_dir in Path("/proc").iterdir():
+        if not proc_dir.name.isdigit():
+            continue
+        try:
+            stat = (proc_dir / "stat").read_text(encoding="utf-8")
+            fields = stat[stat.rfind(")") + 2 :].split()
+            parent = int(fields[1])
+            pid = int(proc_dir.name)
+        except (OSError, ValueError, IndexError):
+            continue
+        children.setdefault(parent, []).append(pid)
+    result: list[int] = []
+    pending = [root_pid]
+    while pending:
+        pid = pending.pop(0)
+        if pid in result:
+            continue
+        if pid == root_pid or (Path("/proc") / str(pid)).exists():
+            result.append(pid)
+            pending.extend(children.get(pid, ()))
+    return result
+
+
+def _debugger_target_pids(root_pid: int, pids: list[int]) -> list[int]:
+    """Limit live attaches to the benchmark root and zccache processes.
+
+    The process snapshot still covers the full tree. Avoiding every compiler
+    child keeps a large tree from pushing the 75-minute termination deadline
+    back by one debugger timeout per process.
+    """
+    targets = [root_pid]
+    for pid in pids:
+        if pid == root_pid:
+            continue
+        try:
+            command = (Path("/proc") / str(pid) / "cmdline").read_bytes().lower()
+        except OSError:
+            continue
+        if b"zccache" in command:
+            targets.append(pid)
+    return targets[:4]
+
+
+def _terminate_process_group(
+    proc: subprocess.Popen[str], status: Callable[[str], None]
+) -> None:
+    try:
+        if os.name == "nt":
+            subprocess.run(
+                ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+                timeout=10,
+            )
+        else:
+            os.killpg(proc.pid, signal.SIGTERM)
+        proc.wait(timeout=10)
+        return
+    except (OSError, subprocess.TimeoutExpired):
+        _safe_status(status, "graceful termination did not finish; forcing process-group shutdown")
+    try:
+        if os.name == "nt":
+            proc.kill()
+        else:
+            os.killpg(proc.pid, signal.SIGKILL)
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        _safe_status(status, f"PID {proc.pid} survived forced shutdown")
+
+
+def _safe_status(status: Callable[[str], None], message: str) -> None:
+    try:
+        status(message)
+    except Exception:
+        pass
+
+
+def _runtime_roots_file(output_dir: Path, label: str) -> Path:
+    return output_dir / "runtime-roots" / f"{_safe_name(label)}.txt"
+
+
+def _drain_output_queue(
+    lines: queue.Queue[str | None], log: IO[str], console_output: str
+) -> None:
+    while True:
+        try:
+            item = lines.get_nowait()
+        except queue.Empty:
+            break
+        if not item:
+            continue
+        log.write(item)
+        log.flush()
+        if console_output == "full" or _is_lite_console_line(item):
+            print(item, end="", flush=True)
+
+
+def _is_lite_console_line(line: str) -> bool:
+    text = line.strip()
+    lower = text.lower()
+    return (
+        text.startswith(("===", "---", "test result:", "running "))
+        or (text.startswith("test ") and text.endswith(("... ok", "... FAILED")))
+        or "benchmark" in lower
+        or re.match(r"^\[\d+/\d+\]", text) is not None
+        or any(marker in lower for marker in ("single cold:", "single warm:", "multi cold:", "multi warm:"))
+        or text.startswith(("SKIP:", "FAILED", "error:"))
+    )
+
+
+def _append_step_summary(markdown: str) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if path:
+        with Path(path).open("a", encoding="utf-8") as summary:
+            summary.write(markdown.rstrip() + "\n\n")
+
+
+def _elapsed(seconds: float) -> str:
+    total = max(0, int(seconds))
+    minutes, secs = divmod(total, 60)
+    return f"{minutes}m{secs:02d}s"
+
+
+def _safe_name(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-") or "command"
+
+
+def _infer_phase(lines: list[str] | deque[str]) -> str:
+    for line in reversed(lines):
+        text = line.strip()
+        if not text:
+            continue
+        if text.startswith(("===", "---")) or any(
+            marker in text.lower()
+            for marker in ("cold", "warm", "multi-file", "single-file", "benchmark")
+        ):
+            return text[-200:]
+    return lines[-1][-200:] if lines else "no output"

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from ci import benchmark_stats, perf_guard
+from ci import benchmark_stats, perf_guard, perf_watchdog
 
 
 PASSING_LOG = """
@@ -877,24 +877,15 @@ def test_run_benchmarks_once_uses_fresh_cache_per_command(tmp_path, monkeypatch)
     def fake_rmtree(path: Path, ignore_errors: bool) -> None:
         removed_cache_dirs.append(Path(path))
 
-    class FakePopen:
-        def __init__(self, command, **kwargs) -> None:
-            command_cache_dirs.append(kwargs["env"]["ZCCACHE_CACHE_DIR"])
-            self.returncode = 0
-            self.stdout = iter([f"{command[-1]}\n"])
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb) -> None:
-            return None
-
-        def wait(self) -> int:
-            return self.returncode
+    def fake_streamed_command(command, **kwargs):
+        command_cache_dirs.append(kwargs["env"]["ZCCACHE_CACHE_DIR"])
+        kwargs["log"].write(f"{command[-1]}\n")
+        kwargs["log"].flush()
+        return perf_watchdog.CommandResult(0, timed_out=False)
 
     monkeypatch.setattr(perf_guard.tempfile, "mkdtemp", fake_mkdtemp)
-    monkeypatch.setattr(perf_guard.shutil, "rmtree", fake_rmtree)
-    monkeypatch.setattr(perf_guard.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(perf_watchdog.shutil, "rmtree", fake_rmtree)
+    monkeypatch.setattr(perf_watchdog, "run_streamed_command", fake_streamed_command)
 
     returncode, output = perf_guard.run_benchmarks_once(tmp_path / "attempt.log", "c++")
 
@@ -907,6 +898,31 @@ def test_run_benchmarks_once_uses_fresh_cache_per_command(tmp_path, monkeypatch)
     assert "finished two" in output
     assert command_cache_dirs == made_cache_dirs
     assert removed_cache_dirs == cache_dirs
+
+
+def test_run_benchmarks_once_stops_after_first_timeout(tmp_path, monkeypatch):
+    commands = [["bench", "one"], ["bench", "two"]]
+    started: list[str] = []
+    monkeypatch.setattr(
+        perf_guard,
+        "_benchmark_commands",
+        lambda language, benchmark_binary, test_name=None: commands,
+    )
+
+    def fake_streamed_command(command, **kwargs):
+        started.append(command[-1])
+        return perf_watchdog.CommandResult(124, timed_out=True)
+
+    monkeypatch.setattr(perf_watchdog, "run_streamed_command", fake_streamed_command)
+    output_dir = tmp_path / "perf-guard-output" / "synthetic"
+
+    returncode, _ = perf_guard.run_benchmarks_once(
+        output_dir / "attempt.log", "c++"
+    )
+
+    assert returncode == 124
+    assert started == ["one"]
+    assert (tmp_path / "perf-guard-output" / ".watchdog-timeout").is_file()
 
 
 def test_benchmark_env_uses_auto_priority_and_profiles_rust(

--- a/ci/tests/test_perf_watchdog.py
+++ b/ci/tests/test_perf_watchdog.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from ci import perf_watchdog
+
+
+def _run(
+    tmp_path: Path, code: str, config: perf_watchdog.WatchdogConfig
+) -> tuple[perf_watchdog.CommandResult, str, list[str]]:
+    log_path = tmp_path / "attempt.log"
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    statuses: list[str] = []
+    with log_path.open("w", encoding="utf-8", buffering=1) as log:
+        result = perf_watchdog.run_streamed_command(
+            [sys.executable, "-c", code],
+            cwd=tmp_path,
+            env=os.environ.copy(),
+            log=log,
+            output_dir=tmp_path / "output",
+            cache_dir=cache_dir,
+            label="synthetic-child",
+            config=config,
+            status=statuses.append,
+        )
+    return result, log_path.read_text(encoding="utf-8"), statuses
+
+
+def test_streamed_child_output_is_written_to_durable_log(tmp_path: Path) -> None:
+    config = perf_watchdog.WatchdogConfig(
+        diagnostic_after_seconds=10,
+        timeout_seconds=20,
+        heartbeat_seconds=10,
+        console_output="lite",
+        enable_debugger=False,
+    )
+    result, log, _ = _run(
+        tmp_path,
+        "import time; print('first', flush=True); time.sleep(0.05); print('second')",
+        config,
+    )
+    assert result.returncode == 0
+    assert not result.timed_out
+    assert log.splitlines() == ["first", "second"]
+
+
+def test_timeout_captures_summary_and_terminates_child(tmp_path: Path) -> None:
+    config = perf_watchdog.WatchdogConfig(
+        diagnostic_after_seconds=0.05,
+        timeout_seconds=0.2,
+        heartbeat_seconds=0.05,
+        console_output="lite",
+        debugger_timeout_seconds=0.1,
+        enable_debugger=False,
+    )
+    result, log, statuses = _run(
+        tmp_path,
+        "import time; print('waiting', flush=True); time.sleep(30)",
+        config,
+    )
+    assert result == perf_watchdog.CommandResult(
+        perf_watchdog.TIMEOUT_EXIT_CODE, timed_out=True
+    )
+    assert "waiting" in log
+    summaries = list((tmp_path / "output" / "diagnostics").glob("*/summary.json"))
+    assert len(summaries) == 1
+    assert any("symbolic stacks" in message for message in statuses)
+    assert any("terminating" in message for message in statuses)
+
+
+def test_environment_configuration_uses_confirmed_60_and_75_minute_windows() -> None:
+    config = perf_watchdog.config_from_env(
+        {
+            "PERF_GUARD_DIAGNOSTIC_AFTER_SECONDS": "3600",
+            "PERF_GUARD_TIMEOUT_SECONDS": "4500",
+            "PERF_GUARD_HEARTBEAT_SECONDS": "300",
+            "PERF_GUARD_CONSOLE_OUTPUT": "lite",
+        }
+    )
+    assert config.diagnostic_after_seconds == 3600
+    assert config.timeout_seconds == 4500
+    assert config.heartbeat_seconds == 300
+    assert config.console_output == "lite"
+
+
+def test_lite_console_keeps_phase_lines_but_filters_verbose_output() -> None:
+    assert perf_watchdog._is_lite_console_line("  [3/3] zccache")
+    assert perf_watchdog._is_lite_console_line("        multi warm: starting")
+    assert perf_watchdog._is_lite_console_line("## C++ Benchmark")
+    assert not perf_watchdog._is_lite_console_line("verbose internal diagnostic")
+
+
+def test_debugger_targets_root_and_zccache_descendants(tmp_path: Path, monkeypatch) -> None:
+    proc_root = tmp_path / "proc"
+    (proc_root / "11").mkdir(parents=True)
+    (proc_root / "12").mkdir()
+    (proc_root / "13").mkdir()
+    (proc_root / "12" / "cmdline").write_bytes(b"/usr/bin/clang\0-c\0")
+    (proc_root / "13" / "cmdline").write_bytes(b"/tmp/zccache\0daemon\0")
+
+    real_path = perf_watchdog.Path
+
+    def fake_path(value):
+        if value == "/proc":
+            return proc_root
+        return real_path(value)
+
+    monkeypatch.setattr(perf_watchdog, "Path", fake_path)
+    assert perf_watchdog._debugger_target_pids(11, [11, 12, 13]) == [11, 13]
+
+
+def test_diagnostic_failure_cannot_prevent_hard_timeout(tmp_path: Path, monkeypatch) -> None:
+    def fail_capture(*args, **kwargs):
+        raise OSError("rotating log disappeared")
+
+    monkeypatch.setattr(perf_watchdog, "capture_hang_diagnostics", fail_capture)
+    config = perf_watchdog.WatchdogConfig(
+        diagnostic_after_seconds=0.05,
+        timeout_seconds=0.2,
+        heartbeat_seconds=10,
+        console_output="lite",
+        enable_debugger=False,
+    )
+
+    result, _, statuses = _run(
+        tmp_path,
+        "import time; time.sleep(30)",
+        config,
+    )
+
+    assert result.timed_out
+    assert any("diagnostic capture failed" in message for message in statuses)
+
+
+def test_hard_timeout_does_not_repeat_full_diagnostic_capture(
+    tmp_path: Path, monkeypatch
+) -> None:
+    captures: list[str] = []
+
+    def record_capture(*args, **kwargs):
+        captures.append(kwargs["reason"])
+        return tmp_path / "diagnostics"
+
+    monkeypatch.setattr(perf_watchdog, "capture_hang_diagnostics", record_capture)
+    config = perf_watchdog.WatchdogConfig(
+        diagnostic_after_seconds=0.05,
+        timeout_seconds=0.2,
+        heartbeat_seconds=10,
+        console_output="lite",
+        enable_debugger=False,
+    )
+
+    result, _, _ = _run(tmp_path, "import time; time.sleep(30)", config)
+
+    assert result.timed_out
+    assert captures == ["diagnostic-threshold"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Unix process-group regression")
+def test_root_exit_with_inherited_output_is_bounded(tmp_path: Path) -> None:
+    config = perf_watchdog.WatchdogConfig(
+        diagnostic_after_seconds=10,
+        timeout_seconds=20,
+        heartbeat_seconds=10,
+        output_drain_grace_seconds=0.1,
+        console_output="lite",
+        enable_debugger=False,
+    )
+    code = (
+        "import subprocess, sys; "
+        "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])"
+    )
+
+    result, _, statuses = _run(tmp_path, code, config)
+
+    assert result.returncode == 0
+    assert any("descendants kept output open" in message for message in statuses)
+
+
+def test_preserve_logs_reads_versioned_and_benchmark_sidecar_roots(tmp_path: Path) -> None:
+    configured = tmp_path / "configured"
+    benchmark = tmp_path / "benchmark"
+    (configured / "v1" / "logs").mkdir(parents=True)
+    (configured / "v1" / "logs" / "configured.log").write_text("configured")
+    (benchmark / "logs").mkdir(parents=True)
+    (benchmark / "logs" / "benchmark.log").write_text("benchmark")
+    sidecar = tmp_path / "runtime-roots.txt"
+    sidecar.write_text(f"{benchmark}\n", encoding="utf-8")
+    destination = tmp_path / "artifact"
+
+    perf_watchdog.preserve_zccache_logs(
+        configured, destination, runtime_roots_file=sidecar
+    )
+
+    assert list(destination.rglob("configured.log"))
+    assert list(destination.rglob("benchmark.log"))

--- a/crates/zccache-cli-core/src/cli/commands/args/mod.rs
+++ b/crates/zccache-cli-core/src/cli/commands/args/mod.rs
@@ -29,6 +29,10 @@ Environment variables:
                                 worktrees. Opt-in; default is off. See README
                                 'Path remapping' for guarantees and pitfalls.
   ZCCACHE_STRICT_PATHS=MODE     Same as --strict-paths (off | consistent | absolute).
+  ZCCACHE_FAST=BOOL             Enable the broad fast compile-policy preset.
+  ZCCACHE_SCAN_SYSTEM_HEADERS=BOOL
+                                Track system headers (default true). Overrides
+                                the --fast preset when explicitly configured.
   ZCCACHE_CACHE_DIR=PATH        Override the per-user cache root.
 ";
 
@@ -64,6 +68,24 @@ pub(crate) struct Cli {
         require_equals = true
     )]
     pub strict_paths: Option<String>,
+
+    /// Enable the broad fast compile-policy preset.
+    ///
+    /// For C/C++, this uses direct-mode manifests without system headers.
+    /// Explicit fine-grained policy flags override this preset.
+    #[arg(long)]
+    pub fast: bool,
+
+    /// Track compiler-classified system headers (the correctness-first default).
+    #[arg(long, conflicts_with = "skip_system_headers")]
+    pub scan_system_headers: bool,
+
+    /// Omit compiler-classified system headers from C/C++ dependency manifests.
+    ///
+    /// This can return stale cache entries when an SDK or toolchain's headers
+    /// change independently of its compiler executable.
+    #[arg(long, conflicts_with = "scan_system_headers")]
+    pub skip_system_headers: bool,
 
     #[command(subcommand)]
     pub command: Option<Commands>,
@@ -220,6 +242,15 @@ pub(crate) enum Commands {
             require_equals = true
         )]
         strict_paths: Option<String>,
+        /// Enable the broad fast compile-policy preset.
+        #[arg(long)]
+        fast: bool,
+        /// Track compiler-classified system headers.
+        #[arg(long, conflicts_with = "skip_system_headers")]
+        scan_system_headers: bool,
+        /// Omit compiler-classified system headers from dependency manifests.
+        #[arg(long, conflicts_with = "scan_system_headers")]
+        skip_system_headers: bool,
         /// The compiler and its arguments.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,

--- a/crates/zccache-cli-core/src/cli/commands/mod.rs
+++ b/crates/zccache-cli-core/src/cli/commands/mod.rs
@@ -106,13 +106,13 @@ pub fn run_with_args(args: &[String]) -> ExitCode {
 
     // Auto-detect: if first arg isn't a known subcommand or a --flag, enter wrap mode.
     // e.g., `zccache clang++ -c foo.cpp -o foo.o`
-    match wrap::strip_leading_strict_paths_flags(&args[1..]) {
-        Ok((strict_paths, wrapper_args))
+    match wrap::strip_leading_wrapper_flags(&args[1..]) {
+        Ok((overrides, wrapper_args))
             if !wrapper_args.is_empty()
                 && !KNOWN_SUBCOMMANDS.contains(&wrapper_args[0].as_str())
                 && !wrapper_args[0].starts_with("--") =>
         {
-            return wrap::run_wrap(&wrapper_args, strict_paths);
+            return wrap::run_wrap(&wrapper_args, overrides);
         }
         Err(err) => {
             eprintln!("zccache: {err}");
@@ -123,7 +123,18 @@ pub fn run_with_args(args: &[String]) -> ExitCode {
 
     use clap::Parser;
     let cli = Cli::parse_from(args);
-    let global_strict_paths = cli.strict_paths.clone();
+    let global_overrides = match wrap::parse_wrapper_overrides(
+        cli.strict_paths.as_deref(),
+        cli.fast,
+        cli.scan_system_headers,
+        cli.skip_system_headers,
+    ) {
+        Ok(overrides) => overrides,
+        Err(err) => {
+            eprintln!("zccache: {err}");
+            return ExitCode::FAILURE;
+        }
+    };
 
     init_tracing();
 
@@ -147,10 +158,10 @@ pub fn run_with_args(args: &[String]) -> ExitCode {
         }
     };
 
-    dispatch(command, global_strict_paths.as_deref())
+    dispatch(command, global_overrides)
 }
 
-fn dispatch(command: Commands, global_strict_paths: Option<&str>) -> ExitCode {
+fn dispatch(command: Commands, global_overrides: wrap::WrapperOverrides) -> ExitCode {
     match command {
         Commands::Start => daemon::run_start(),
         Commands::Stop => daemon::run_stop(),
@@ -335,17 +346,26 @@ fn dispatch(command: Commands, global_strict_paths: Option<&str>) -> ExitCode {
             let endpoint = resolve_endpoint(endpoint.as_deref());
             run_async(session::cmd_session_stats(&endpoint, session_id, json))
         }
-        Commands::Wrap { strict_paths, args } => {
-            let strict_paths = match wrap::parse_optional_strict_paths(
-                strict_paths.as_deref().or(global_strict_paths),
+        Commands::Wrap {
+            strict_paths,
+            fast,
+            scan_system_headers,
+            skip_system_headers,
+            args,
+        } => {
+            let overrides = match wrap::parse_wrapper_overrides(
+                strict_paths.as_deref(),
+                fast,
+                scan_system_headers,
+                skip_system_headers,
             ) {
-                Ok(mode) => mode,
+                Ok(overrides) => overrides.overlay(global_overrides),
                 Err(err) => {
                     eprintln!("zccache: {err}");
                     return ExitCode::FAILURE;
                 }
             };
-            wrap::run_wrap(&args, strict_paths)
+            wrap::run_wrap(&args, overrides)
         }
         Commands::Inspect { key } => {
             eprintln!("zccache inspect {key}: not yet implemented");
@@ -465,14 +485,7 @@ fn dispatch(command: Commands, global_strict_paths: Option<&str>) -> ExitCode {
             let mut wrap_args: Vec<String> = Vec::with_capacity(args.len() + 1);
             wrap_args.push("cc".to_string());
             wrap_args.extend(args);
-            let strict_paths = match wrap::parse_optional_strict_paths(global_strict_paths) {
-                Ok(mode) => mode,
-                Err(err) => {
-                    eprintln!("zccache: {err}");
-                    return ExitCode::FAILURE;
-                }
-            };
-            wrap::run_wrap(&wrap_args, strict_paths)
+            wrap::run_wrap(&wrap_args, global_overrides)
         }
         Commands::Cache { command } => match command {
             args::CacheCommands::Size { json } => cache_ops::cmd_cache_size(json),

--- a/crates/zccache-cli-core/src/cli/commands/tests/args_parsing.rs
+++ b/crates/zccache-cli-core/src/cli/commands/tests/args_parsing.rs
@@ -15,6 +15,42 @@ use super::super::session::{
 use crate::artifact::rust_plan_gha_version;
 
 #[test]
+fn compile_policy_flags_parse_at_global_and_explicit_wrap_paths() {
+    use clap::Parser;
+
+    let global = Cli::try_parse_from([
+        "zccache",
+        "--fast",
+        "--skip-system-headers",
+        "status",
+    ])
+    .unwrap();
+    assert!(global.fast);
+    assert!(global.skip_system_headers);
+    assert!(!global.scan_system_headers);
+
+    let explicit = Cli::try_parse_from([
+        "zccache",
+        "wrap",
+        "--fast",
+        "--scan-system-headers",
+        "clang",
+        "-c",
+        "main.c",
+    ])
+    .unwrap();
+    assert!(matches!(
+        explicit.command,
+        Some(Commands::Wrap {
+            fast: true,
+            scan_system_headers: true,
+            skip_system_headers: false,
+            ..
+        })
+    ));
+}
+
+#[test]
 fn rust_plan_cli_parses_validate_restore_save() {
     use clap::Parser;
     let validate = Cli::try_parse_from([

--- a/crates/zccache-cli-core/src/cli/commands/wrap.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap.rs
@@ -17,7 +17,9 @@ use std::process::ExitCode;
 
 use super::util::{resolve_endpoint, run_async};
 
-pub(crate) use env::{parse_optional_strict_paths, strip_leading_strict_paths_flags};
+pub(crate) use env::{
+    parse_wrapper_overrides, strip_leading_wrapper_flags, WrapperOverrides,
+};
 use routing::WrapperRoute;
 
 /// Wrap a compiler or tool invocation.
@@ -29,7 +31,7 @@ use routing::WrapperRoute;
 /// per-request override. If unset, auto-creates an ephemeral session.
 pub(crate) fn run_wrap(
     args: &[String],
-    strict_paths_override: Option<StrictPathsMode>,
+    overrides: WrapperOverrides,
 ) -> ExitCode {
     diag::emit(args);
 
@@ -42,7 +44,7 @@ pub(crate) fn run_wrap(
         return passthrough::run_passthrough(args);
     }
 
-    let strict_paths_mode = match env::effective_strict_paths_mode(strict_paths_override) {
+    let strict_paths_mode = match env::effective_strict_paths_mode(overrides) {
         Ok(mode) => mode,
         Err(err) => {
             eprintln!("zccache: {err}");
@@ -53,7 +55,7 @@ pub(crate) fn run_wrap(
     let wrapped_tool = tool_resolution::resolve_compiler_path(&args[0]);
     let tool_args: Vec<String> = args.get(1..).unwrap_or(&[]).to_vec();
     let cwd = std::env::current_dir().unwrap_or_default();
-    let client_env = env::client_env(strict_paths_override);
+    let client_env = env::client_env(overrides);
     let endpoint = resolve_endpoint(None);
 
     // Release the CWD handle on the build directory. On Windows, a process's

--- a/crates/zccache-cli-core/src/cli/commands/wrap/env.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/env.rs
@@ -2,25 +2,82 @@
 
 use crate::compiler::strict_paths::StrictPathsMode;
 
-pub(crate) fn strip_leading_strict_paths_flags(
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct WrapperOverrides {
+    pub(crate) strict_paths: Option<StrictPathsMode>,
+    pub(crate) fast: bool,
+    pub(crate) scan_system_headers: Option<bool>,
+}
+
+impl WrapperOverrides {
+    pub(crate) fn overlay(self, base: Self) -> Self {
+        Self {
+            strict_paths: self.strict_paths.or(base.strict_paths),
+            fast: self.fast || base.fast,
+            scan_system_headers: self.scan_system_headers.or(base.scan_system_headers),
+        }
+    }
+}
+
+pub(crate) fn strip_leading_wrapper_flags(
     args: &[String],
-) -> Result<(Option<StrictPathsMode>, Vec<String>), String> {
-    let mut strict_paths = None;
+) -> Result<(WrapperOverrides, Vec<String>), String> {
+    let mut overrides = WrapperOverrides::default();
     let mut index = 0;
 
     while let Some(arg) = args.get(index) {
         if arg == "--strict-paths" {
-            strict_paths = Some(StrictPathsMode::Absolute);
+            overrides.strict_paths = Some(StrictPathsMode::Absolute);
             index += 1;
         } else if let Some(value) = arg.strip_prefix("--strict-paths=") {
-            strict_paths = Some(StrictPathsMode::parse(value).map_err(|err| err.to_string())?);
+            overrides.strict_paths =
+                Some(StrictPathsMode::parse(value).map_err(|err| err.to_string())?);
+            index += 1;
+        } else if arg == "--fast" {
+            overrides.fast = true;
+            index += 1;
+        } else if arg == "--scan-system-headers" {
+            set_scan_override(&mut overrides, true)?;
+            index += 1;
+        } else if arg == "--skip-system-headers" {
+            set_scan_override(&mut overrides, false)?;
             index += 1;
         } else {
             break;
         }
     }
 
-    Ok((strict_paths, args[index..].to_vec()))
+    Ok((overrides, args[index..].to_vec()))
+}
+
+pub(crate) fn parse_wrapper_overrides(
+    strict_paths: Option<&str>,
+    fast: bool,
+    scan_system_headers: bool,
+    skip_system_headers: bool,
+) -> Result<WrapperOverrides, String> {
+    let mut overrides = WrapperOverrides {
+        strict_paths: parse_optional_strict_paths(strict_paths)?,
+        fast,
+        scan_system_headers: None,
+    };
+    if scan_system_headers {
+        set_scan_override(&mut overrides, true)?;
+    }
+    if skip_system_headers {
+        set_scan_override(&mut overrides, false)?;
+    }
+    Ok(overrides)
+}
+
+fn set_scan_override(overrides: &mut WrapperOverrides, value: bool) -> Result<(), String> {
+    if overrides.scan_system_headers.is_some_and(|current| current != value) {
+        return Err(
+            "--scan-system-headers conflicts with --skip-system-headers; choose one".to_string(),
+        );
+    }
+    overrides.scan_system_headers = Some(value);
+    Ok(())
 }
 
 pub(crate) fn parse_optional_strict_paths(
@@ -32,9 +89,9 @@ pub(crate) fn parse_optional_strict_paths(
 }
 
 pub(super) fn effective_strict_paths_mode(
-    strict_paths_override: Option<StrictPathsMode>,
+    overrides: WrapperOverrides,
 ) -> Result<StrictPathsMode, String> {
-    if let Some(mode) = strict_paths_override {
+    if let Some(mode) = overrides.strict_paths {
         return Ok(mode);
     }
 
@@ -70,10 +127,20 @@ fn windows_pch_guard_default_for(is_windows: bool, guard_value: Option<&str>) ->
     }
 }
 
-pub(super) fn client_env(strict_paths_override: Option<StrictPathsMode>) -> Vec<(String, String)> {
+pub(super) fn client_env(overrides: WrapperOverrides) -> Vec<(String, String)> {
     let mut env: Vec<(String, String)> = std::env::vars().collect();
-    if let Some(mode) = strict_paths_override {
+    if let Some(mode) = overrides.strict_paths {
         set_client_env(&mut env, "ZCCACHE_STRICT_PATHS", mode.as_str().to_string());
+    }
+    if overrides.fast {
+        set_client_env(&mut env, "ZCCACHE_FAST", "1".to_string());
+    }
+    if let Some(scan) = overrides.scan_system_headers {
+        set_client_env(
+            &mut env,
+            "ZCCACHE_SCAN_SYSTEM_HEADERS",
+            if scan { "1" } else { "0" }.to_string(),
+        );
     }
     env
 }
@@ -95,17 +162,47 @@ mod tests {
     use super::*;
 
     #[test]
-    fn strip_leading_strict_paths_flags_consumes_only_prefix() {
+    fn strip_leading_wrapper_flags_consumes_only_prefix() {
         let args = vec![
             "--strict-paths=consistent".to_string(),
             "rustc".to_string(),
             "--strict-paths=absolute".to_string(),
         ];
 
-        let (mode, rest) = strip_leading_strict_paths_flags(&args).unwrap();
+        let (overrides, rest) = strip_leading_wrapper_flags(&args).unwrap();
 
-        assert_eq!(mode, Some(StrictPathsMode::Consistent));
+        assert_eq!(
+            overrides.strict_paths,
+            Some(StrictPathsMode::Consistent)
+        );
         assert_eq!(rest, vec!["rustc", "--strict-paths=absolute"]);
+    }
+
+    #[test]
+    fn fast_and_header_policy_flags_are_consumed_before_compiler() {
+        let args = vec![
+            "--fast".to_string(),
+            "--skip-system-headers".to_string(),
+            "clang".to_string(),
+            "--fast".to_string(),
+        ];
+        let (overrides, rest) = strip_leading_wrapper_flags(&args).unwrap();
+        assert!(overrides.fast);
+        assert_eq!(overrides.scan_system_headers, Some(false));
+        assert_eq!(rest, vec!["clang", "--fast"]);
+    }
+
+    #[test]
+    fn explicit_scan_setting_overrides_fast_preset() {
+        let overrides = parse_wrapper_overrides(None, true, true, false).unwrap();
+        assert!(overrides.fast);
+        assert_eq!(overrides.scan_system_headers, Some(true));
+    }
+
+    #[test]
+    fn contradictory_scan_flags_are_rejected() {
+        let error = parse_wrapper_overrides(None, false, true, true).unwrap_err();
+        assert!(error.contains("conflicts"));
     }
 
     #[test]

--- a/crates/zccache-core/src/path.rs
+++ b/crates/zccache-core/src/path.rs
@@ -155,6 +155,21 @@ impl NormalizedPath {
     pub fn join(&self, path: impl AsRef<Path>) -> Self {
         Self::new(self.path.join(path))
     }
+
+    /// Return whether this path is contained beneath `base`, using the same
+    /// platform-aware representation as equality and hashing.
+    ///
+    /// `Path::starts_with` compares the stored spelling directly. That is not
+    /// sufficient for a `NormalizedPath`: Windows canonicalization can add an
+    /// extended-length prefix, and Windows/macOS paths can differ only in
+    /// casing while still naming the same location. Parsing the normalized
+    /// keys back into paths preserves component boundaries, avoiding ordinary
+    /// string-prefix false positives such as `/include2` beneath `/include`.
+    #[must_use]
+    pub fn starts_with(&self, base: impl AsRef<Path>) -> bool {
+        let base = Self::new(base);
+        Path::new(self.key.as_ref()).starts_with(Path::new(base.key.as_ref()))
+    }
 }
 
 impl AsRef<Path> for NormalizedPath {
@@ -348,6 +363,27 @@ pub fn normalize_msys_path(path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalized_starts_with_preserves_component_boundaries() {
+        let path = NormalizedPath::new("/sdk/include/vector");
+        assert!(path.starts_with("/sdk/include"));
+        assert!(!path.starts_with("/sdk/inc"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn normalized_starts_with_accepts_extended_prefix_and_case_variants() {
+        let path = NormalizedPath::new(r"C:\Users\Builder\include\vector");
+        assert!(path.starts_with(r"\\?\c:\users\BUILDER\include"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn normalized_starts_with_accepts_macos_case_variants() {
+        let path = NormalizedPath::new("/private/var/folders/T/include/vector");
+        assert!(path.starts_with("/PRIVATE/VAR/FOLDERS/t/include"));
+    }
 
     #[test]
     fn normalize_removes_dot() {

--- a/crates/zccache-daemon-core/src/daemon/server/dependency_policy.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/dependency_policy.rs
@@ -1,0 +1,352 @@
+//! Request-scoped C/C++ dependency discovery policy.
+
+use super::*;
+
+const FAST_ENV: &str = "ZCCACHE_FAST";
+const SCAN_SYSTEM_HEADERS_ENV: &str = "ZCCACHE_SCAN_SYSTEM_HEADERS";
+
+/// How compiler-selected C/C++ dependencies are recorded on a cache miss.
+///
+/// Both variants use the depgraph as a direct-mode manifest on later requests.
+/// They differ only in whether the compiler includes system headers in the
+/// first manifest (`-MD`) or omits them (`-MMD`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum DependencyDiscoveryMode {
+    AllHeaders,
+    SkipSystemHeaders,
+}
+
+impl DependencyDiscoveryMode {
+    pub(super) fn from_client_env(
+        client_env: Option<&[(String, String)]>,
+    ) -> Result<Self, String> {
+        if let Some(value) = client_env_value(client_env, SCAN_SYSTEM_HEADERS_ENV) {
+            return parse_bool(SCAN_SYSTEM_HEADERS_ENV, value).map(|scan| {
+                if scan {
+                    Self::AllHeaders
+                } else {
+                    Self::SkipSystemHeaders
+                }
+            });
+        }
+
+        let fast = client_env_value(client_env, FAST_ENV)
+            .map(|value| parse_bool(FAST_ENV, value))
+            .transpose()?
+            .unwrap_or(false);
+        Ok(if fast {
+            Self::SkipSystemHeaders
+        } else {
+            Self::AllHeaders
+        })
+    }
+
+    pub(super) fn injected_depfile_flag(self) -> &'static str {
+        match self {
+            Self::AllHeaders => "-MD",
+            Self::SkipSystemHeaders => "-MMD",
+        }
+    }
+
+    pub(super) fn use_mmd(self) -> bool {
+        matches!(self, Self::SkipSystemHeaders)
+    }
+
+    /// Salt C/C++ context keys so a partial fast-mode manifest can never be
+    /// reused after the caller switches back to the correctness-first mode.
+    pub(super) fn apply_to_cc_context(
+        self,
+        ctx: &mut CompileContext,
+        dep_flags: &UserDepFlags,
+    ) {
+        let marker = match self {
+            Self::AllHeaders => "zccache:dependency-discovery=all-headers",
+            Self::SkipSystemHeaders => "zccache:dependency-discovery=skip-system-headers",
+        };
+        if !ctx.unknown_flags.iter().any(|flag| flag == marker) {
+            ctx.unknown_flags.push(marker.to_string());
+        }
+        let depfile_marker = if dep_flags.has_mmd {
+            "zccache:user-depfile=mmd"
+        } else if dep_flags.has_md {
+            "zccache:user-depfile=md"
+        } else {
+            "zccache:user-depfile=none"
+        };
+        if !ctx.unknown_flags.iter().any(|flag| flag == depfile_marker) {
+            ctx.unknown_flags.push(depfile_marker.to_string());
+        }
+    }
+
+    pub(super) fn apply_user_depfile_content_to_cc_context(
+        ctx: &mut CompileContext,
+        dep_flags: &UserDepFlags,
+        args: &[String],
+    ) {
+        if !dep_flags.has_md {
+            return;
+        }
+        let mut index = 0;
+        let mut content_index = 0;
+        while index < args.len() {
+            let arg = &args[index];
+            if arg == "-MF" {
+                if args.get(index + 1).is_some_and(|value| value == "-") {
+                    ctx.unknown_flags
+                        .push("zccache:user-depfile-output=stdout".to_string());
+                    content_index += 1;
+                }
+                index += 2;
+                continue;
+            }
+            if arg == "-MF-" {
+                ctx.unknown_flags
+                    .push("zccache:user-depfile-output=stdout".to_string());
+                content_index += 1;
+            } else if !arg.starts_with("-MF") {
+                ctx.unknown_flags.push(format!(
+                    "zccache:user-depfile-argv={content_index}:{}:{arg}",
+                    arg.len()
+                ));
+                content_index += 1;
+            }
+            index += 1;
+        }
+    }
+
+    /// Apply the same user-vs-system root precedence used by the compiler's
+    /// include search when a static preflight must approximate `-MMD`.
+    pub(super) fn retain_tracked_headers(
+        self,
+        headers: &mut Vec<NormalizedPath>,
+        include_search: &crate::depgraph::IncludeSearchPaths,
+    ) {
+        headers.retain(|path| self.tracks_header(path, include_search));
+    }
+
+    pub(super) fn tracks_header(
+        self,
+        path: &NormalizedPath,
+        include_search: &crate::depgraph::IncludeSearchPaths,
+    ) -> bool {
+        if self == Self::AllHeaders {
+            return true;
+        }
+        let selected_by_user_root = include_search
+            .iquote
+            .iter()
+            .chain(&include_search.user)
+            .any(|root| path.starts_with(root.as_path()));
+        selected_by_user_root
+            || !include_search
+                .system
+                .iter()
+                .chain(&include_search.after)
+                .any(|root| path.starts_with(root.as_path()))
+    }
+
+    /// Approximate compiler provenance before a private `-MMD` manifest exists.
+    /// A quoted path resolved relative to the including file remains a user
+    /// dependency even when both files happen to live beneath a broad SDK root.
+    pub(super) fn tracks_static_include(
+        self,
+        including_file: &Path,
+        directive: &crate::depgraph::scanner::IncludeDirective,
+        path: &NormalizedPath,
+        include_search: &crate::depgraph::IncludeSearchPaths,
+    ) -> bool {
+        if matches!(
+            directive.kind,
+            crate::depgraph::scanner::IncludeKind::Quoted
+        ) && including_file.parent().is_some_and(|parent| {
+            NormalizedPath::from(parent.join(&directive.path)) == *path
+        }) {
+            return true;
+        }
+        self.tracks_header(path, include_search)
+    }
+
+    /// Make a scanner fallback conservative when compiler provenance is lost.
+    pub(super) fn apply_static_fallback(
+        self,
+        result: &mut crate::depgraph::ScanResult,
+        include_search: &crate::depgraph::IncludeSearchPaths,
+    ) {
+        if self == Self::SkipSystemHeaders {
+            self.retain_tracked_headers(&mut result.resolved, include_search);
+            result.has_computed = true;
+        } else {
+            result.has_computed |= !result.unresolved.is_empty();
+        }
+    }
+}
+
+fn parse_bool(name: &str, value: &str) -> Result<bool, String> {
+    let value = value.trim();
+    if value == "1"
+        || value.eq_ignore_ascii_case("true")
+        || value.eq_ignore_ascii_case("yes")
+        || value.eq_ignore_ascii_case("on")
+    {
+        Ok(true)
+    } else if value == "0"
+        || value.eq_ignore_ascii_case("false")
+        || value.eq_ignore_ascii_case("no")
+        || value.eq_ignore_ascii_case("off")
+    {
+        Ok(false)
+    } else {
+        Err(format!(
+            "{name} must be one of 1/0, true/false, yes/no, or on/off (got {value:?})"
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(values: &[(&str, &str)]) -> Vec<(String, String)> {
+        values
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn safe_mode_is_default() {
+        assert_eq!(
+            DependencyDiscoveryMode::from_client_env(None).unwrap(),
+            DependencyDiscoveryMode::AllHeaders
+        );
+    }
+
+    #[test]
+    fn fast_preset_skips_system_headers() {
+        let values = env(&[(FAST_ENV, "1")]);
+        assert_eq!(
+            DependencyDiscoveryMode::from_client_env(Some(&values)).unwrap(),
+            DependencyDiscoveryMode::SkipSystemHeaders
+        );
+    }
+
+    #[test]
+    fn fine_grained_setting_overrides_fast() {
+        let values = env(&[(FAST_ENV, "1"), (SCAN_SYSTEM_HEADERS_ENV, " TRUE ")]);
+        assert_eq!(
+            DependencyDiscoveryMode::from_client_env(Some(&values)).unwrap(),
+            DependencyDiscoveryMode::AllHeaders
+        );
+    }
+
+    #[test]
+    fn user_root_wins_when_nested_beneath_system_root() {
+        let search = crate::depgraph::IncludeSearchPaths {
+            user: vec!["/sdk/vendor".into()],
+            system: vec!["/sdk".into()],
+            ..Default::default()
+        };
+        let user_header: NormalizedPath = "/sdk/vendor/api.hpp".into();
+        let system_header: NormalizedPath = "/sdk/stdlib/vector".into();
+        let mut headers = vec![user_header.clone(), system_header.clone()];
+
+        DependencyDiscoveryMode::SkipSystemHeaders
+            .retain_tracked_headers(&mut headers, &search);
+
+        assert_eq!(headers, vec![user_header]);
+    }
+
+    #[test]
+    fn quoted_sibling_remains_user_input_beneath_system_root() {
+        let search = crate::depgraph::IncludeSearchPaths {
+            system: vec!["/sdk".into()],
+            ..Default::default()
+        };
+        let directive = crate::depgraph::scanner::IncludeDirective {
+            kind: crate::depgraph::scanner::IncludeKind::Quoted,
+            path: "config.hpp".into(),
+            line: 1,
+        };
+
+        assert!(DependencyDiscoveryMode::SkipSystemHeaders.tracks_static_include(
+            Path::new("/sdk/project/main.cpp"),
+            &directive,
+            &NormalizedPath::from("/sdk/project/config.hpp"),
+            &search,
+        ));
+    }
+
+    #[test]
+    fn unresolved_safe_mode_fallback_disables_direct_hits() {
+        let mut result = crate::depgraph::ScanResult {
+            resolved: Vec::new(),
+            unresolved: vec!["compiler-resolved-only.h".into()],
+            has_computed: false,
+        };
+
+        DependencyDiscoveryMode::AllHeaders
+            .apply_static_fallback(&mut result, &Default::default());
+
+        assert!(result.has_computed);
+    }
+
+    #[test]
+    fn user_depfile_modes_salt_context_keys() {
+        let context_for = |args: &[&str]| {
+            let args: Vec<String> = args.iter().map(|arg| (*arg).to_string()).collect();
+            let parsed = crate::depgraph::args::parse_gnu_args(&args, Path::new("/work"));
+            let dep_flags = parsed.dep_flags.clone();
+            let mut context = CompileContext::from_parsed_args(parsed);
+            DependencyDiscoveryMode::AllHeaders.apply_to_cc_context(&mut context, &dep_flags);
+            context.context_key()
+        };
+
+        let none = context_for(&["-c", "main.c"]);
+        let md = context_for(&["-c", "main.c", "-MD"]);
+        let mmd = context_for(&["-c", "main.c", "-MMD"]);
+
+        assert_ne!(none, md);
+        assert_ne!(md, mmd);
+        assert_ne!(none, mmd);
+    }
+
+    #[test]
+    fn depfile_content_shape_salts_context_keys() {
+        let context_for = |args: &[&str]| {
+            let args: Vec<String> = args.iter().map(|arg| (*arg).to_string()).collect();
+            let parsed = crate::depgraph::args::parse_gnu_args(&args, Path::new("/work"));
+            let dep_flags = parsed.dep_flags.clone();
+            let mut context = CompileContext::from_parsed_args(parsed);
+            DependencyDiscoveryMode::AllHeaders.apply_to_cc_context(&mut context, &dep_flags);
+            DependencyDiscoveryMode::apply_user_depfile_content_to_cc_context(
+                &mut context,
+                &dep_flags,
+                &args,
+            );
+            context.context_key()
+        };
+
+        let output_a = context_for(&["-c", "main.c", "-o", "a.o", "-MD"]);
+        let output_b = context_for(&["-c", "main.c", "-o", "/work/a.o", "-MD"]);
+        let target = context_for(&[
+            "-c",
+            "main.c",
+            "-o",
+            "a.o",
+            "-MD",
+            "-MT",
+            "explicit.o",
+            "-MP",
+        ]);
+        let moved_depfile = context_for(&[
+            "-c", "main.c", "-o", "a.o", "-MD", "-MF", "other.d",
+        ]);
+        let stdout_depfile =
+            context_for(&["-c", "main.c", "-o", "a.o", "-MD", "-MF", "-"]);
+
+        assert_ne!(output_a, output_b);
+        assert_ne!(output_a, target);
+        assert_eq!(output_a, moved_depfile);
+        assert_ne!(output_a, stdout_depfile);
+    }
+}

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -23,6 +23,7 @@ pub(super) struct CompileExecRequest<'a> {
     pub(super) lineage: &'a crate::daemon::lineage::Lineage,
     pub(super) compile_start: std::time::Instant,
     pub(super) snap_clock: Clock,
+    pub(super) dependency_mode: DependencyDiscoveryMode,
 }
 
 pub(super) struct CompileExecOutcome {
@@ -69,6 +70,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         lineage,
         compile_start,
         snap_clock,
+        dependency_mode,
     } = req;
 
     let state = state_arc.as_ref();
@@ -80,7 +82,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     let use_mmd = matches!(
         compilation.family,
         crate::compiler::CompilerFamily::Gcc | crate::compiler::CompilerFamily::Clang
-    ) && mmd_static_scan_is_proven(effective_args);
+    ) && dependency_mode.use_mmd();
     let (mut extra_args, mut depfile_strategy) = crate::depgraph::depfile::prepare_depfile_with_mmd(
         use_mmd,
         supports_depfile,
@@ -395,57 +397,4 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         post_exec_ns,
         staged_plan,
     })
-}
-
-/// MMD omits system headers, so use it only for compiler invocations whose
-/// system include search roots are exactly the daemon's compiler-default
-/// discovery. Any caller-controlled include-root selection falls back to MD.
-fn mmd_static_scan_is_proven(args: &[String]) -> bool {
-    !args.iter().any(|arg| {
-        matches!(
-            arg.as_str(),
-            "-I" | "-isystem"
-                | "-iquote"
-                | "-idirafter"
-                | "-include"
-                | "-include-pch"
-                | "-nostdinc"
-                | "-nostdinc++"
-                | "-isysroot"
-                | "--sysroot"
-                | "-target"
-                | "--target"
-                | "-resource-dir"
-                | "-stdlib"
-        ) || [
-            "-I",
-            "-isystem",
-            "-iquote",
-            "-idirafter",
-            "-isysroot",
-            "--sysroot=",
-            "-target=",
-            "--target=",
-            "-resource-dir=",
-            "-stdlib=",
-        ]
-        .iter()
-        .any(|prefix| arg.starts_with(prefix) && arg.len() > prefix.len())
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::mmd_static_scan_is_proven;
-
-    #[test]
-    fn mmd_static_scan_requires_compiler_default_include_roots() {
-        assert!(mmd_static_scan_is_proven(&["-c".into(), "main.c".into()]));
-        assert!(!mmd_static_scan_is_proven(&[
-            "-isystem".into(),
-            "/sdk".into()
-        ]));
-        assert!(!mmd_static_scan_is_proven(&["-isystem/sdk".into()]));
-        assert!(!mmd_static_scan_is_proven(&["--sysroot=/sdk".into()]));
-    }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -70,6 +70,10 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         let compiler = compiler_path.display().to_string();
         return compile_failure_stderr(err.diagnostic(&compiler, &expanded_args));
     }
+    let dependency_mode = match DependencyDiscoveryMode::from_client_env(client_env.as_deref()) {
+        Ok(mode) => mode,
+        Err(err) => return compile_failure_stderr(format!("zccache: {err}")),
+    };
 
     let worktree_root = compile_worktree_root(state, &sid, cwd, client_env.as_deref());
     let effective_args = effective_compile_args(
@@ -190,7 +194,9 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 worktree_root.clone(),
                 system_includes,
                 client_env,
+                stdin,
                 compile_start,
+                dependency_mode,
             )
             .await;
         }
@@ -259,7 +265,16 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         rustc_metadata_compat_key,
         worktree_equivalent_context,
     ) = match build_result {
-        BuildContextResult::Cc { ctx, dep_flags } => {
+        BuildContextResult::Cc {
+            mut ctx,
+            dep_flags,
+        } => {
+            dependency_mode.apply_to_cc_context(&mut ctx, &dep_flags);
+            DependencyDiscoveryMode::apply_user_depfile_content_to_cc_context(
+                &mut ctx,
+                &dep_flags,
+                &compilation.original_args,
+            );
             let registration = state.dep_graph.load().register_with_root_and_salt_result(
                 ctx.clone(),
                 Some(default_key_root.clone()),
@@ -734,6 +749,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         lineage: &lineage,
         compile_start,
         snap_clock,
+        dependency_mode,
     })
     .await;
     let CompileExecOutcome {
@@ -809,6 +825,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             cwd_path: &cwd_path,
             ctx: &ctx,
             compilation: &compilation,
+            dependency_mode,
             rustc_args_opt: rustc_args_opt.as_deref(),
             rustc_extern_paths: &rustc_extern_paths,
             client_env: client_env.as_deref(),

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -25,6 +25,7 @@ pub(super) struct StoreOutcomeRequest<'a> {
     pub(super) cwd_path: &'a NormalizedPath,
     pub(super) ctx: &'a CompileContext,
     pub(super) compilation: &'a crate::compiler::CacheableCompilation,
+    pub(super) dependency_mode: DependencyDiscoveryMode,
     pub(super) rustc_args_opt: Option<&'a crate::depgraph::RustcParsedArgs>,
     pub(super) rustc_extern_paths: &'a [NormalizedPath],
     /// Request env the compile ran under — the value source for rustc
@@ -128,6 +129,7 @@ struct CompileScanRequest {
     depfile_strategy: DepfileStrategy,
     show_includes_scan: Option<crate::depgraph::ScanResult>,
     include_search: crate::depgraph::IncludeSearchPaths,
+    dependency_mode: DependencyDiscoveryMode,
 }
 
 struct CompileScanCollection {
@@ -162,6 +164,7 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
         depfile_strategy,
         show_includes_scan,
         include_search,
+        dependency_mode,
     } = req;
 
     if is_rustc {
@@ -193,16 +196,27 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
 
     let mut user_depfile_capture = None;
     let mut depfile_parse_warning = None;
-    let scan_result = match &depfile_strategy {
+    let mut used_static_fallback = false;
+    let mut scan_result = match &depfile_strategy {
         DepfileStrategy::Injected { path }
-        | DepfileStrategy::UserSpecified { path }
-        | DepfileStrategy::UserDefault { path } => {
+        | DepfileStrategy::UserSpecified { path, .. }
+        | DepfileStrategy::UserDefault { path, .. } => {
             let want_capture = matches!(
                 depfile_strategy,
                 DepfileStrategy::UserSpecified { .. } | DepfileStrategy::UserDefault { .. }
             );
+            let augment_system_headers = matches!(
+                depfile_strategy,
+                DepfileStrategy::UserSpecified {
+                    augment_system_headers: true,
+                    ..
+                } | DepfileStrategy::UserDefault {
+                    augment_system_headers: true,
+                    ..
+                }
+            );
             match crate::depgraph::depfile::parse_depfile_path(path, &source_path, &cwd_path) {
-                Ok(result) => {
+                Ok(mut result) => {
                     if want_capture {
                         if let Ok(bytes) = std::fs::read(path) {
                             user_depfile_capture = Some((path.clone(), bytes));
@@ -211,9 +225,19 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
                     if matches!(depfile_strategy, DepfileStrategy::Injected { .. }) {
                         let _ = std::fs::remove_file(path);
                     }
+                    if augment_system_headers {
+                        result = crate::depgraph::depfile::merge_scan_results_conservative(
+                            result,
+                            crate::depgraph::scanner::scan_recursive(
+                                &source_path,
+                                &include_search,
+                            ),
+                        );
+                    }
                     result
                 }
                 Err(e) => {
+                    used_static_fallback = true;
                     depfile_parse_warning = Some(format!("path={} error={e}", path.display()));
                     if matches!(depfile_strategy, DepfileStrategy::Injected { .. }) {
                         let _ = std::fs::remove_file(path);
@@ -226,12 +250,10 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
             match crate::depgraph::depfile::parse_depfile_path(path, &source_path, &cwd_path) {
                 Ok(result) => {
                     let _ = std::fs::remove_file(path);
-                    crate::depgraph::depfile::merge_scan_results(
-                        result,
-                        crate::depgraph::scanner::scan_recursive(&source_path, &include_search),
-                    )
+                    result
                 }
                 Err(e) => {
+                    used_static_fallback = true;
                     depfile_parse_warning = Some(format!("path={} error={e}", path.display()));
                     let _ = std::fs::remove_file(path);
                     crate::depgraph::scanner::scan_recursive(&source_path, &include_search)
@@ -239,12 +261,20 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
             }
         }
         DepfileStrategy::ShowIncludes => show_includes_scan.unwrap_or_else(|| {
+            used_static_fallback = true;
             crate::depgraph::scanner::scan_recursive(&source_path, &include_search)
         }),
         DepfileStrategy::Unsupported => {
+            used_static_fallback = true;
             crate::depgraph::scanner::scan_recursive(&source_path, &include_search)
         }
     };
+    apply_static_fallback_policy(
+        dependency_mode,
+        used_static_fallback,
+        &mut scan_result,
+        &include_search,
+    );
 
     CompileScanCollection {
         scan_result,
@@ -253,6 +283,21 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
         depfile_parse_warning,
     }
 }
+
+fn apply_static_fallback_policy(
+    dependency_mode: DependencyDiscoveryMode,
+    used_static_fallback: bool,
+    result: &mut crate::depgraph::ScanResult,
+    include_search: &crate::depgraph::IncludeSearchPaths,
+) {
+    if used_static_fallback {
+        dependency_mode.apply_static_fallback(result, include_search);
+    }
+}
+
+#[cfg(test)]
+#[path = "store_outcome_tests.rs"]
+mod tests;
 
 /// Drive the post-compile success path. Returns `Some(Response)` only when an
 /// output-collection failure forces an uncached `CompileResult`; otherwise
@@ -273,6 +318,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         cwd_path,
         ctx,
         compilation,
+        dependency_mode,
         rustc_args_opt,
         rustc_extern_paths,
         client_env,
@@ -396,6 +442,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         depfile_strategy,
         show_includes_scan,
         include_search: ctx.include_search.clone(),
+        dependency_mode,
     })
     .await;
     if let Some(warning) = &scan_collection.depfile_parse_warning {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -194,6 +194,10 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
         };
     }
 
+    // Static scans canonicalize resolved headers. Resolve include roots once
+    // so fallback filtering uses the same path spelling on every platform.
+    let include_search = include_search.canonicalized();
+
     let mut user_depfile_capture = None;
     let mut depfile_parse_warning = None;
     let mut used_static_fallback = false;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome_tests.rs
@@ -1,0 +1,58 @@
+use super::*;
+
+#[test]
+fn mmd_fallback_tracks_user_headers_but_omits_system_roots() {
+    let temp = tempfile::tempdir().unwrap();
+    let user_dir = temp.path().join("user");
+    let system_dir = temp.path().join("system");
+    std::fs::create_dir_all(&user_dir).unwrap();
+    std::fs::create_dir_all(&system_dir).unwrap();
+    let source: NormalizedPath = temp.path().join("main.cpp").into();
+    let user_header: NormalizedPath = user_dir.join("user.hpp").into();
+    let system_header: NormalizedPath = system_dir.join("system.hpp").into();
+    std::fs::write(&source, "#include <user.hpp>\n#include <system.hpp>\n").unwrap();
+    std::fs::write(&user_header, "#define USER 1\n").unwrap();
+    std::fs::write(&system_header, "#define SYSTEM 1\n").unwrap();
+    let search = crate::depgraph::IncludeSearchPaths {
+        user: vec![user_dir.into()],
+        system: vec![system_dir.into()],
+        ..Default::default()
+    };
+
+    let mut result = crate::depgraph::scanner::scan_recursive(&source, &search);
+    apply_static_fallback_policy(
+        DependencyDiscoveryMode::SkipSystemHeaders,
+        true,
+        &mut result,
+        &search,
+    );
+
+    assert!(result.resolved.contains(&user_header));
+    assert!(!result.resolved.contains(&system_header));
+    assert!(result.unresolved.is_empty());
+    assert!(result.has_computed);
+}
+
+#[test]
+fn compiler_manifest_keeps_user_header_beneath_system_root() {
+    let search = crate::depgraph::IncludeSearchPaths {
+        system: vec!["/sdk".into()],
+        ..Default::default()
+    };
+    let sibling: NormalizedPath = "/sdk/project/config.hpp".into();
+    let mut result = crate::depgraph::ScanResult {
+        resolved: vec![sibling.clone()],
+        unresolved: Vec::new(),
+        has_computed: false,
+    };
+
+    apply_static_fallback_policy(
+        DependencyDiscoveryMode::SkipSystemHeaders,
+        false,
+        &mut result,
+        &search,
+    );
+
+    assert_eq!(result.resolved, vec![sibling]);
+    assert!(!result.has_computed);
+}

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome_tests.rs
@@ -7,17 +7,21 @@ fn mmd_fallback_tracks_user_headers_but_omits_system_roots() {
     let system_dir = temp.path().join("system");
     std::fs::create_dir_all(&user_dir).unwrap();
     std::fs::create_dir_all(&system_dir).unwrap();
-    let source: NormalizedPath = temp.path().join("main.cpp").into();
-    let user_header: NormalizedPath = user_dir.join("user.hpp").into();
-    let system_header: NormalizedPath = system_dir.join("system.hpp").into();
+    let source = temp.path().join("main.cpp");
+    let user_header = user_dir.join("user.hpp");
+    let system_header = system_dir.join("system.hpp");
     std::fs::write(&source, "#include <user.hpp>\n#include <system.hpp>\n").unwrap();
     std::fs::write(&user_header, "#define USER 1\n").unwrap();
     std::fs::write(&system_header, "#define SYSTEM 1\n").unwrap();
+    let source: NormalizedPath = std::fs::canonicalize(source).unwrap().into();
+    let user_header: NormalizedPath = std::fs::canonicalize(user_header).unwrap().into();
+    let system_header: NormalizedPath = std::fs::canonicalize(system_header).unwrap().into();
     let search = crate::depgraph::IncludeSearchPaths {
         user: vec![user_dir.into()],
         system: vec![system_dir.into()],
         ..Default::default()
-    };
+    }
+    .canonicalized();
 
     let mut result = crate::depgraph::scanner::scan_recursive(&source, &search);
     apply_static_fallback_policy(

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -13,29 +13,12 @@ mod types;
 
 use args::filter_multi_source_args;
 use preflight::InputSnapshot;
-use types::{PendingWrite, UnitCacheResult};
+pub(super) use types::materialize_multi_hit;
+use types::{
+    legacy_depfile_policy, owned_fast_hit_entry, MissOutcome, PendingWrite, PersistTaskParams,
+    UnitCacheCheck, UnitCacheResult,
+};
 
-struct UnitCacheCheck<'a> {
-    cwd_path: &'a Path,
-    key_root: &'a NormalizedPath,
-    system_includes: &'a [NormalizedPath],
-    shared_base: Option<&'a CompileContext>,
-    scan_cache: &'a crate::depgraph::scanner::RecursiveScanCache,
-    cache_now: Instant,
-}
-
-pub(super) fn materialize_multi_hit(
-    targets: &[(NormalizedPath, NormalizedPath)],
-    payloads: &[CachedPayload],
-) -> bool {
-    write_payloads_par(targets, payloads)
-}
-
-/// Check cache for a single compilation unit. Returns Hit (output written) or Miss.
-///
-/// If `shared_base` is provided, the CompileContext is built by cloning it and
-/// overriding the source_file, avoiding redundant arg parsing for multi-file
-/// compilations where all units share the same flags.
 fn check_unit_cache(
     state: &SharedState,
     compilation: &crate::compiler::CacheableCompilation,
@@ -46,8 +29,10 @@ fn check_unit_cache(
         key_root,
         system_includes,
         shared_base,
+        shared_dep_flags,
         scan_cache,
         cache_now,
+        dependency_mode,
     } = check;
     let t0 = std::time::Instant::now();
     let snap_clock = state.cache_system.current_clock();
@@ -64,15 +49,13 @@ fn check_unit_cache(
         cwd_path.join(&compilation.output_file).into()
     };
 
-    let (ctx, _dep_flags) = if let Some(base) = shared_base {
+    let shared_context = shared_base.is_some();
+    let (mut ctx, dep_flags) = if let Some(base) = shared_base {
         let mut ctx = base.clone();
         ctx.source_file = source_path.clone();
         (
             ctx,
-            UserDepFlags {
-                has_md: false,
-                mf_path: None,
-            },
+            shared_dep_flags.cloned().unwrap_or_default(),
         )
     } else {
         match build_compile_context(
@@ -86,11 +69,15 @@ fn check_unit_cache(
             BuildContextResult::Rustc { compat_ctx, .. } => (compat_ctx, UserDepFlags::default()),
         }
     };
+    if !shared_context {
+        dependency_mode.apply_to_cc_context(&mut ctx, &dep_flags);
+    }
+    DependencyDiscoveryMode::apply_user_depfile_content_to_cc_context(
+        &mut ctx,
+        &dep_flags,
+        &compilation.original_args,
+    );
     let t_ctx = t0.elapsed();
-    // Issue #474: PCH / MSVC compiles take a per-worktree salt so the
-    // resulting cache entry can't be cross-served between sibling
-    // worktrees. Mirror of the single-file gate in
-    // `pipeline.rs::handle_compile_request`.
     let source_mode_for_key = if matches!(
         compilation
             .output_file
@@ -116,10 +103,9 @@ fn check_unit_cache(
     let t_register = t0.elapsed();
 
     // ── Ultra-fast path: per-file freshness skip ────────────────────
-    // If the watcher is active and none of the source/header files have
-    // changed since the last verified hit, skip ALL hash/depgraph work.
     if state.watcher_active.load(Ordering::Acquire) {
-        if let Some(entry) = state.fast_hit_cache.get(&context_key) {
+        let entry = owned_fast_hit_entry(&state.fast_hit_cache, &context_key);
+        if let Some(entry) = entry {
             if cache_entry_fresh_at(cache_now, entry.cached_at, FAST_HIT_MAX_AGE)
                 && context_files_fresh(state, &context_key, &source_path, entry.clock)
             {
@@ -197,7 +183,6 @@ fn check_unit_cache(
         }
     }
 
-    // Hash source
     let source_hash = match hash_file(&state.cache_system, &source_path, snap_clock) {
         Ok(h) => h,
         Err(_) => {
@@ -212,7 +197,6 @@ fn check_unit_cache(
     };
     let t_hash_source = t0.elapsed();
 
-    // Hash known headers + force-includes in parallel
     let mut hash_map: HashMap<NormalizedPath, ContentHash> = HashMap::new();
     hash_map.insert(source_path.clone(), source_hash);
     {
@@ -235,7 +219,6 @@ fn check_unit_cache(
     }
     let t_hash_headers = t0.elapsed();
 
-    // Depgraph check
     let verdict = {
         let is_fresh = |p: &Path| {
             let path = NormalizedPath::new(p);
@@ -255,7 +238,6 @@ fn check_unit_cache(
     };
     let t_depgraph = t0.elapsed();
 
-    // Try to serve from cache
     let depgraph_claimed_hit = matches!(verdict, crate::depgraph::CacheVerdict::Hit { .. });
     if let crate::depgraph::CacheVerdict::Hit { artifact_key }
     | crate::depgraph::CacheVerdict::SourceChanged { artifact_key } = verdict
@@ -344,7 +326,14 @@ fn check_unit_cache(
     }
 
     state.fast_hit_cache.remove(&context_key);
-    let input_snapshot = InputSnapshot::capture(state, &source_path, &ctx, hash_map, scan_cache);
+    let input_snapshot = InputSnapshot::capture(
+        state,
+        &source_path,
+        &ctx,
+        hash_map,
+        scan_cache,
+        dependency_mode,
+    );
     UnitCacheResult::Miss {
         source_path,
         output_path,
@@ -367,7 +356,9 @@ pub(super) async fn handle_compile_multi(
     worktree_root: Option<NormalizedPath>,
     system_includes: Vec<NormalizedPath>,
     client_env: Option<Vec<(String, String)>>,
+    stdin: Vec<u8>,
     compile_start: Instant,
+    dependency_mode: DependencyDiscoveryMode,
 ) -> Response {
     let snap_clock = state.cache_system.current_clock();
     let mut all_stdout = Vec::new();
@@ -382,6 +373,7 @@ pub(super) async fn handle_compile_multi(
         &original_args,
         &cwd_path,
         &client_env,
+        &stdin,
     )
     .await
     {
@@ -392,7 +384,7 @@ pub(super) async fn handle_compile_multi(
     // All units share the same original_args (via Arc) — only source/output
     // differ. Parse the flags once and reuse the base CompileContext, avoiding
     // redundant arg parsing for each of the N compilation units.
-    let shared_base: Arc<CompileContext> = {
+    let (shared_base, shared_dep_flags): (Arc<CompileContext>, UserDepFlags) = {
         let first = &compilations[0];
         let parsed = if first.family == crate::compiler::CompilerFamily::Msvc
             || crate::compiler::parse_msvc::looks_like_msvc_args(&first.original_args)
@@ -401,13 +393,15 @@ pub(super) async fn handle_compile_multi(
         } else {
             crate::depgraph::args::parse_gnu_args(&first.original_args, &cwd_path)
         };
+        let dep_flags = parsed.dep_flags.clone();
         let mut base = CompileContext::from_parsed_args(parsed);
         for path in &system_includes {
             if !base.include_search.system.contains(path) {
                 base.include_search.system.push(path.clone());
             }
         }
-        Arc::new(base)
+        dependency_mode.apply_to_cc_context(&mut base, &dep_flags);
+        (Arc::new(base), dep_flags)
     };
 
     // ── Phase 1: Check cache for each unit (parallel, as-completed) ──
@@ -420,6 +414,7 @@ pub(super) async fn handle_compile_multi(
         let system_includes = system_includes.clone();
         let compilation = compilation.clone();
         let shared_base = Arc::clone(&shared_base);
+        let shared_dep_flags = shared_dep_flags.clone();
         let scan_cache = Arc::clone(&scan_cache);
         let cache_now = compile_start;
         join_set.spawn_blocking(move || {
@@ -433,15 +428,16 @@ pub(super) async fn handle_compile_multi(
                         key_root: &key_root,
                         system_includes: &system_includes,
                         shared_base: Some(&shared_base),
+                        shared_dep_flags: Some(&shared_dep_flags),
                         scan_cache: &scan_cache,
                         cache_now,
+                        dependency_mode,
                     },
                 ),
             )
         });
     }
 
-    // Collect results in original order
     let mut indexed_results: Vec<(usize, UnitCacheResult)> = Vec::with_capacity(compilations.len());
     while let Some(result) = join_set.join_next().await {
         match result {
@@ -482,7 +478,6 @@ pub(super) async fn handle_compile_multi(
                 );
             }
         }
-        // Drain pending writes from hits for batched parallel execution
         if let UnitCacheResult::Hit {
             ref mut pending_writes,
             ..
@@ -567,14 +562,13 @@ pub(super) async fn handle_compile_multi(
         &client_env,
         &mut all_stdout,
         &mut all_stderr,
+        dependency_mode,
     )
     .await
     {
         return response;
     }
 
-    // Build compiler args from original_args, removing hit source files by index.
-    // This preserves all original flags (including unknown ones) exactly as passed.
     let supports_depfile = compilations[0].family.supports_depfile();
     let hit_indices: HashSet<usize> = {
         let miss_set: HashSet<&NormalizedPath> = miss_sources.iter().copied().collect();
@@ -603,8 +597,11 @@ pub(super) async fn handle_compile_multi(
         .collect();
     let mut compiler_args =
         filter_multi_source_args(&original_args, &source_indices, &retained_source_indices);
+    let depfile_policy = legacy_depfile_policy(&original_args, dependency_mode);
     if supports_depfile {
-        compiler_args.push("-MD".to_string());
+        if let Some(flag) = depfile_policy.injected_flag {
+            compiler_args.push(flag.to_string());
+        }
     }
 
     let _rsp_guard = match crate::compiler::response_file::write_response_file_if_needed(
@@ -680,18 +677,6 @@ pub(super) async fn handle_compile_multi(
     // batch the sequential version dominated wall time (~12ms × 50 = 600ms).
     // We fan out the per-miss work onto `spawn_blocking` and batch the async
     // sync points (watch_directories, apply_changes) at the end.
-    struct MissOutcome {
-        dep_dirs: Vec<NormalizedPath>,
-        output_path: NormalizedPath,
-        persist: Option<PersistTaskParams>,
-    }
-    struct PersistTaskParams {
-        artifact_key_hex: String,
-        persist_meta: ArtifactIndex,
-        payloads: Vec<Arc<Vec<u8>>>,
-        payload_size: usize,
-    }
-
     let mut miss_set: tokio::task::JoinSet<MissOutcome> = tokio::task::JoinSet::new();
     for unit in &unit_results {
         let (source_path, output_path, context_key, ctx) = match unit {
@@ -713,6 +698,7 @@ pub(super) async fn handle_compile_multi(
         let state_task = Arc::clone(&state);
         let cwd_path_task = cwd_path.clone();
         let sid_task = sid;
+        let dependency_mode_task = dependency_mode;
         miss_set.spawn_blocking(move || {
             // The compiler just wrote `output_path`; we only need its size for
             // bookkeeping (artifact-bytes stats, ArtifactIndex.output_sizes).
@@ -725,10 +711,9 @@ pub(super) async fn handle_compile_multi(
                 .map(|m| m.len())
                 .unwrap_or(0);
 
-            // Scan includes: use depfile if available, fall back to scanner.
-            let scan_result = if supports_depfile {
+            let mut used_static_fallback = !supports_depfile;
+            let mut scan_result = if supports_depfile {
                 let d_path = source_path.with_extension("d");
-                // Multi-file -MD places .d files relative to the source
                 let cwd_d_path = cwd_path_task.join(
                     d_path
                         .file_name()
@@ -754,6 +739,7 @@ pub(super) async fn handle_compile_multi(
                         result
                     }
                     Err(e) => {
+                        used_static_fallback = true;
                         tracing::warn!(
                             "multi-file depfile parse failed for {}: {e}",
                             source_path.display()
@@ -764,13 +750,25 @@ pub(super) async fn handle_compile_multi(
             } else {
                 crate::depgraph::scanner::scan_recursive(&source_path, &ctx.include_search)
             };
+            if !used_static_fallback
+                && dependency_mode_task == DependencyDiscoveryMode::AllHeaders
+                && depfile_policy.excludes_system_headers
+            {
+                scan_result = crate::depgraph::depfile::merge_scan_results_conservative(
+                    scan_result,
+                    crate::depgraph::scanner::scan_recursive(&source_path, &ctx.include_search),
+                );
+            }
+            if used_static_fallback {
+                dependency_mode_task
+                    .apply_static_fallback(&mut scan_result, &ctx.include_search);
+            }
 
             let tracked_paths: Vec<NormalizedPath> = std::iter::once(source_path.clone())
                 .chain(scan_result.resolved.iter().cloned())
                 .collect();
             state_task.cache_system.register_tracked(&tracked_paths);
 
-            // Collect parent dirs for the batched watch_directories call.
             let dep_dirs: Vec<NormalizedPath> = {
                 let mut dirs = HashSet::new();
                 if let Some(parent) = source_path.parent() {
@@ -784,7 +782,6 @@ pub(super) async fn handle_compile_multi(
                 dirs.into_iter().collect()
             };
 
-            // Hash all files (source + headers) in parallel via rayon.
             let hash_map: HashMap<NormalizedPath, ContentHash> = {
                 use rayon::prelude::*;
                 let all_paths: Vec<&NormalizedPath> = std::iter::once(&source_path)
@@ -804,6 +801,7 @@ pub(super) async fn handle_compile_multi(
                 let path = NormalizedPath::new(p);
                 hash_map.get(&path).copied()
             };
+            let allow_fast_hit = !scan_result.has_computed;
             let update_result =
                 state_task
                     .dep_graph
@@ -877,15 +875,17 @@ pub(super) async fn handle_compile_multi(
                     .artifacts
                     .insert(artifact_key_hex.clone(), cached);
 
-                let current_clock = state_task.cache_system.current_clock();
-                state_task.fast_hit_cache.insert(
-                    context_key,
-                    FastHitEntry {
-                        clock: current_clock,
-                        artifact_key_hex: artifact_key_hex.clone(),
-                        cached_at: std::time::Instant::now(),
-                    },
-                );
+                if allow_fast_hit {
+                    let current_clock = state_task.cache_system.current_clock();
+                    state_task.fast_hit_cache.insert(
+                        context_key,
+                        FastHitEntry {
+                            clock: current_clock,
+                            artifact_key_hex: artifact_key_hex.clone(),
+                            cached_at: std::time::Instant::now(),
+                        },
+                    );
+                }
 
                 state_task.stats.record_miss(0, artifact_bytes);
                 let src = source_path.clone();
@@ -911,7 +911,6 @@ pub(super) async fn handle_compile_multi(
         });
     }
 
-    // Collect outcomes and batch the async sync points.
     let mut all_dep_dirs: HashSet<NormalizedPath> = HashSet::new();
     let mut all_miss_outputs: Vec<NormalizedPath> = Vec::new();
     let mut persist_jobs: Vec<PersistTaskParams> = Vec::new();
@@ -932,11 +931,9 @@ pub(super) async fn handle_compile_multi(
         }
     }
 
-    // Single batched watch_directories call (was 1 per miss).
     let dep_dirs_vec: Vec<NormalizedPath> = all_dep_dirs.into_iter().collect();
     watch_directories(&state, &dep_dirs_vec).await;
 
-    // Spawn the artifact-persist tasks now that locks are released.
     for job in persist_jobs {
         let artifact_dir = state.artifact_dir.clone();
         let key_hex = job.artifact_key_hex;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -843,18 +843,11 @@ pub(super) async fn handle_compile_multi(
                         persist: None,
                     };
                 }
-                let cache_file_path = state_task
-                    .artifact_dir
-                    .join(format!("{artifact_key_hex}_0"));
-
                 // Build the cached artifact directly (avoid constructing the
                 // full ArtifactData wrapper just to compute the same fields).
-                // Payloads point at the *cache* file (the just-hardlinked
-                // copy), not the original output path: cargo may rewrite
-                // the output on the next build via tmp+rename, which would
-                // detach the old inode from the user-visible path while the
-                // cache-side hardlink keeps it alive — the cache copy is the
-                // stable reference.
+                // Keep payloads lazy so the first hit resolves whichever
+                // persistence layout is active. Staged artifacts do not live
+                // at the legacy `{key}_0` path.
                 let empty = Arc::new(Vec::new());
                 let meta = ArtifactIndex::new(
                     vec![output_name],
@@ -863,13 +856,7 @@ pub(super) async fn handle_compile_multi(
                     Arc::clone(&empty),
                     0,
                 );
-                let cached = CachedArtifact {
-                    meta: meta.clone(),
-                    stdout: Arc::clone(&empty),
-                    stderr: Arc::clone(&empty),
-                    payloads: Some(Arc::from(vec![CachedPayload::File(cache_file_path)])),
-                    last_used: std::time::Instant::now(),
-                };
+                let cached = CachedArtifact::from_index(meta.clone());
 
                 state_task
                     .artifacts

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_preflight.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_preflight.rs
@@ -228,25 +228,28 @@ impl InputSnapshot {
         scan_cache: &crate::depgraph::scanner::RecursiveScanCache,
         dependency_mode: DependencyDiscoveryMode,
     ) -> Self {
+        // `scan_recursive*` canonicalizes resolved headers. Canonicalize the
+        // roots once as well so pruning compares equivalent path spellings.
+        let include_search = ctx.include_search.canonicalized();
         let scan = match dependency_mode {
             DependencyDiscoveryMode::AllHeaders => {
                 crate::depgraph::scanner::scan_recursive_cached(
                     source,
-                    &ctx.include_search,
+                    &include_search,
                     scan_cache,
                 )
             }
             DependencyDiscoveryMode::SkipSystemHeaders => {
                 crate::depgraph::scanner::scan_recursive_cached_pruned(
                     source,
-                    &ctx.include_search,
+                    &include_search,
                     scan_cache,
                     &|including_file, directive, path| {
                         dependency_mode.tracks_static_include(
                             including_file,
                             directive,
                             path,
-                            &ctx.include_search,
+                            &include_search,
                         )
                     },
                 )

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_preflight.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_preflight.rs
@@ -226,12 +226,32 @@ impl InputSnapshot {
         ctx: &CompileContext,
         hashes: HashMap<NormalizedPath, ContentHash>,
         scan_cache: &crate::depgraph::scanner::RecursiveScanCache,
+        dependency_mode: DependencyDiscoveryMode,
     ) -> Self {
-        let scan = crate::depgraph::scanner::scan_recursive_cached(
-            source,
-            &ctx.include_search,
-            scan_cache,
-        );
+        let scan = match dependency_mode {
+            DependencyDiscoveryMode::AllHeaders => {
+                crate::depgraph::scanner::scan_recursive_cached(
+                    source,
+                    &ctx.include_search,
+                    scan_cache,
+                )
+            }
+            DependencyDiscoveryMode::SkipSystemHeaders => {
+                crate::depgraph::scanner::scan_recursive_cached_pruned(
+                    source,
+                    &ctx.include_search,
+                    scan_cache,
+                    &|including_file, directive, path| {
+                        dependency_mode.tracks_static_include(
+                            including_file,
+                            directive,
+                            path,
+                            &ctx.include_search,
+                        )
+                    },
+                )
+            }
+        };
         let paths: HashSet<NormalizedPath> = hashes
             .into_keys()
             .chain(scan.resolved)
@@ -310,6 +330,87 @@ impl InputSnapshot {
     }
 }
 
+fn detach_direct_batch_outputs(
+    compilations: &[crate::compiler::CacheableCompilation],
+    original_args: &[String],
+    cwd: &NormalizedPath,
+) -> Result<(), Response> {
+    let response_family = direct_response_family(compilations[0].family, original_args);
+    let msvc_syntax = response_family == crate::compiler::CompilerFamily::Msvc;
+    let mut outputs: HashSet<NormalizedPath> = compilations
+        .iter()
+        .map(|compilation| {
+            if compilation.output_file.is_absolute() {
+                compilation.output_file.clone()
+            } else {
+                cwd.join(&compilation.output_file)
+            }
+        })
+        .collect();
+    outputs.extend(explicit_staged_side_outputs(
+        original_args,
+        msvc_syntax,
+        cwd,
+    ));
+    outputs.extend(derived_staged_side_outputs(
+        compilations,
+        original_args,
+        cwd,
+    ));
+    for compilation in compilations {
+        let source = if compilation.source_file.is_absolute() {
+            compilation.source_file.clone()
+        } else {
+            cwd.join(&compilation.source_file)
+        };
+        outputs.remove(&source);
+    }
+    for output in outputs {
+        if let Err(error) = break_output_hardlink_before_compile(&output) {
+            return Err(Response::Error {
+                message: format!(
+                    "failed to detach hardlinked multi-source output {}: {error}",
+                    output.display()
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+pub(super) async fn run_depfile_stdout_batch(
+    state: &Arc<SharedState>,
+    sid: &SessionId,
+    compiler: &NormalizedPath,
+    compilations: &[crate::compiler::CacheableCompilation],
+    original_args: &[String],
+    cwd: &NormalizedPath,
+    client_env: &Option<Vec<(String, String)>>,
+    stdin: &[u8],
+) -> Option<Response> {
+    if !super::types::depfile_targets_stdout(original_args) {
+        return None;
+    }
+    state.stats.record_non_cacheable();
+    record_session_stat(&state.sessions, sid, |stats| stats.record_non_cacheable());
+    if let Err(response) = detach_direct_batch_outputs(compilations, original_args, cwd) {
+        return Some(response);
+    }
+    Some(
+        run_compiler_direct(
+            compiler,
+            original_args,
+            cwd,
+            &state.sessions,
+            sid,
+            client_env,
+            stdin,
+            state.depfile_tmpdir.as_path(),
+        )
+        .await,
+    )
+}
+
 pub(super) async fn run_unsupported_batch(
     state: &Arc<SharedState>,
     sid: &SessionId,
@@ -318,8 +419,23 @@ pub(super) async fn run_unsupported_batch(
     original_args: &[String],
     cwd: &NormalizedPath,
     client_env: &Option<Vec<(String, String)>>,
+    stdin: &[u8],
 ) -> Option<Response> {
     use crate::daemon::staged_stats::{StagedCounter, StagedTiming};
+    if let Some(response) = run_depfile_stdout_batch(
+        state,
+        sid,
+        compiler,
+        compilations,
+        original_args,
+        cwd,
+        client_env,
+        stdin,
+    )
+    .await
+    {
+        return Some(response);
+    }
     if !staged_lane_enabled(compilations[0].family) {
         return None;
     }
@@ -354,49 +470,10 @@ pub(super) async fn run_unsupported_batch(
             state.profiler.staged.count(StagedCounter::PlanUnsupported);
             state.profiler.staged.failure(reason.failure());
             let response_family = direct_response_family(compilations[0].family, original_args);
-            let msvc_syntax = response_family == crate::compiler::CompilerFamily::Msvc;
-            let mut outputs: HashSet<NormalizedPath> = compilations
-                .iter()
-                .map(|compilation| {
-                    if compilation.output_file.is_absolute() {
-                        compilation.output_file.clone()
-                    } else {
-                        cwd.join(&compilation.output_file)
-                    }
-                })
-                .collect();
-            outputs.extend(explicit_staged_side_outputs(
-                original_args,
-                msvc_syntax,
-                cwd,
-            ));
-            outputs.extend(derived_staged_side_outputs(
-                compilations,
-                original_args,
-                cwd,
-            ));
-            // Primary outputs are the only paths this cache can have
-            // hardlinked on an earlier supported invocation. Unsupported
-            // side outputs are never persisted or materialized by zccache;
-            // explicit and safely derivable side paths above are detached as
-            // defense in depth, without mutating unrelated files under cwd.
-            for compilation in compilations {
-                let source = if compilation.source_file.is_absolute() {
-                    compilation.source_file.clone()
-                } else {
-                    cwd.join(&compilation.source_file)
-                };
-                outputs.remove(&source);
-            }
-            for output in outputs {
-                if let Err(error) = break_output_hardlink_before_compile(&output) {
-                    return Some(Response::Error {
-                        message: format!(
-                            "failed to detach hardlinked multi-source output {}: {error}",
-                            output.display()
-                        ),
-                    });
-                }
+            if let Err(response) =
+                detach_direct_batch_outputs(compilations, original_args, cwd)
+            {
+                return Some(response);
             }
             for _ in compilations {
                 state.stats.record_compilation();

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
@@ -27,6 +27,7 @@ struct PublishedMiss {
     dep_dirs: Vec<NormalizedPath>,
     artifact_bytes: u64,
     validation_clock: Clock,
+    allow_fast_hit: bool,
 }
 
 struct StagedCompilerOutput {
@@ -49,6 +50,7 @@ pub(super) async fn try_handle_staged_misses(
     client_env: &Option<Vec<(String, String)>>,
     all_stdout: &mut Vec<u8>,
     all_stderr: &mut Vec<u8>,
+    dependency_mode: DependencyDiscoveryMode,
 ) -> Option<Response> {
     let mut requested_outputs = HashSet::new();
     for compilation in compilations {
@@ -88,12 +90,13 @@ pub(super) async fn try_handle_staged_misses(
         use crate::daemon::staged_stats::{StagedCounter, StagedTiming};
         let planning_started = std::time::Instant::now();
         state.profiler.staged.count(StagedCounter::PlanAttempted);
-        let outcome = StagedMultiUnitPlan::build(
+        let outcome = StagedMultiUnitPlan::build_with_depfile_flag(
             state.staging.path(),
             compilations[index].family,
             unit_args,
             output_path,
             cwd,
+            dependency_mode.injected_depfile_flag(),
         );
         state.profiler.staged.timing(
             StagedTiming::Planning,
@@ -320,6 +323,7 @@ pub(super) async fn try_handle_staged_misses(
     let mut validation_inputs = Vec::with_capacity(misses.len());
     let mut tracked_union = HashSet::new();
     for miss in &mut misses {
+        let mut depfile_parse_failed = false;
         let mut scan_result = miss.scan_result.take().unwrap_or_else(|| {
             match crate::depgraph::depfile::parse_depfile_path(
                 &miss.plan.depfile,
@@ -328,6 +332,7 @@ pub(super) async fn try_handle_staged_misses(
             ) {
                 Ok(result) => result,
                 Err(error) => {
+                    depfile_parse_failed = true;
                     tracing::warn!(
                         source = %miss.source_path.display(),
                         %error,
@@ -340,6 +345,22 @@ pub(super) async fn try_handle_staged_misses(
                 }
             }
         });
+        if !depfile_parse_failed
+            && dependency_mode == DependencyDiscoveryMode::AllHeaders
+            && miss.plan.depfile_excludes_system_headers
+        {
+            scan_result = crate::depgraph::depfile::merge_scan_results_conservative(
+                scan_result,
+                crate::depgraph::scanner::scan_recursive(
+                    &miss.source_path,
+                    &miss.ctx.include_search,
+                ),
+            );
+        }
+        if depfile_parse_failed {
+            dependency_mode
+                .apply_static_fallback(&mut scan_result, &miss.ctx.include_search);
+        }
         let mut tracked: HashSet<NormalizedPath> =
             miss.input_snapshot.hashes.keys().cloned().collect();
         tracked.insert(miss.source_path.clone());
@@ -386,6 +407,7 @@ pub(super) async fn try_handle_staged_misses(
         .zip(validated_sizes)
         .zip(validation_inputs)
     {
+        let allow_fast_hit = !scan_result.has_computed;
         let artifact_bytes = output_sizes.iter().sum();
         let hash_map: HashMap<NormalizedPath, ContentHash> = tracked_paths
             .iter()
@@ -452,6 +474,7 @@ pub(super) async fn try_handle_staged_misses(
             dep_dirs,
             artifact_bytes,
             validation_clock: current_clock,
+            allow_fast_hit,
         });
     }
 
@@ -524,23 +547,34 @@ pub(super) async fn try_handle_staged_misses(
             miss.cache_entry,
             miss.artifact_bytes,
             miss.validation_clock,
+            miss.allow_fast_hit,
         ));
     }
-    for (source, context_key, cache_entry, artifact_bytes, validation_clock) in completed {
+    for (
+        source,
+        context_key,
+        cache_entry,
+        artifact_bytes,
+        validation_clock,
+        allow_fast_hit,
+    ) in completed
+    {
         state.stats.record_miss(0, artifact_bytes);
         record_session_stat(&state.sessions, sid, move |stats| {
             stats.record_miss(source, artifact_bytes);
         });
         if let Some((key, cached)) = cache_entry {
             state.artifacts.insert(key.clone(), cached);
-            state.fast_hit_cache.insert(
-                context_key,
-                FastHitEntry {
-                    clock: validation_clock,
-                    artifact_key_hex: key,
-                    cached_at: std::time::Instant::now(),
-                },
-            );
+            if allow_fast_hit {
+                state.fast_hit_cache.insert(
+                    context_key,
+                    FastHitEntry {
+                        clock: validation_clock,
+                        artifact_key_hex: key,
+                        cached_at: std::time::Instant::now(),
+                    },
+                );
+            }
         }
     }
     watch_directories(

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_types.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_types.rs
@@ -2,10 +2,94 @@
 
 use super::*;
 
+pub(in crate::daemon::server) fn materialize_multi_hit(
+    targets: &[(NormalizedPath, NormalizedPath)],
+    payloads: &[CachedPayload],
+) -> bool {
+    write_payloads_par(targets, payloads)
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct LegacyDepfilePolicy {
+    pub(super) injected_flag: Option<&'static str>,
+    pub(super) excludes_system_headers: bool,
+}
+
+pub(super) fn legacy_depfile_policy(
+    args: &[String],
+    dependency_mode: DependencyDiscoveryMode,
+) -> LegacyDepfilePolicy {
+    let user_excludes_system_headers = args.iter().fold(None, |current, arg| {
+        if arg == "-MMD" {
+            Some(true)
+        } else if arg == "-MD" {
+            Some(false)
+        } else {
+            current
+        }
+    });
+    LegacyDepfilePolicy {
+        injected_flag: user_excludes_system_headers
+            .is_none()
+            .then(|| dependency_mode.injected_depfile_flag()),
+        excludes_system_headers: user_excludes_system_headers
+            .unwrap_or_else(|| dependency_mode.use_mmd()),
+    }
+}
+
+pub(super) fn depfile_targets_stdout(args: &[String]) -> bool {
+    let mut stdout = false;
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "-MF" {
+            stdout = args.get(index + 1).is_some_and(|value| value == "-");
+            index += 2;
+            continue;
+        }
+        if let Some(path) = arg.strip_prefix("-MF").filter(|path| !path.is_empty()) {
+            stdout = path == "-";
+        }
+        index += 1;
+    }
+    stdout
+}
+
 pub(in crate::daemon::server) struct PendingWrite {
     pub(in crate::daemon::server) out_path: NormalizedPath,
     pub(in crate::daemon::server) cache_file: NormalizedPath,
     pub(in crate::daemon::server) data: Vec<u8>,
+}
+
+pub(super) struct UnitCacheCheck<'a> {
+    pub(super) cwd_path: &'a Path,
+    pub(super) key_root: &'a NormalizedPath,
+    pub(super) system_includes: &'a [NormalizedPath],
+    pub(super) shared_base: Option<&'a CompileContext>,
+    pub(super) shared_dep_flags: Option<&'a UserDepFlags>,
+    pub(super) scan_cache: &'a crate::depgraph::scanner::RecursiveScanCache,
+    pub(super) cache_now: Instant,
+    pub(super) dependency_mode: DependencyDiscoveryMode,
+}
+
+pub(super) struct MissOutcome {
+    pub(super) dep_dirs: Vec<NormalizedPath>,
+    pub(super) output_path: NormalizedPath,
+    pub(super) persist: Option<PersistTaskParams>,
+}
+
+pub(super) struct PersistTaskParams {
+    pub(super) artifact_key_hex: String,
+    pub(super) persist_meta: ArtifactIndex,
+    pub(super) payloads: Vec<Arc<Vec<u8>>>,
+    pub(super) payload_size: usize,
+}
+
+pub(super) fn owned_fast_hit_entry(
+    cache: &DashMap<ContextKey, FastHitEntry>,
+    key: &ContextKey,
+) -> Option<FastHitEntry> {
+    cache.get(key).map(|entry| entry.clone())
 }
 
 pub(in crate::daemon::server) enum UnitCacheResult {
@@ -23,4 +107,57 @@ pub(in crate::daemon::server) enum UnitCacheResult {
         ctx: Box<CompileContext>,
         input_snapshot: InputSnapshot,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owned_fast_hit_entry_releases_map_guard_before_mutation() {
+        let cache = DashMap::new();
+        let key = ContextKey::from_raw([7; 32]);
+        cache.insert(
+            key,
+            FastHitEntry {
+                clock: Clock::ZERO,
+                artifact_key_hex: "artifact".to_string(),
+                cached_at: Instant::now(),
+            },
+        );
+
+        let entry = owned_fast_hit_entry(&cache, &key).unwrap();
+        assert_eq!(entry.artifact_key_hex, "artifact");
+        assert!(cache.remove(&key).is_some());
+    }
+
+    #[test]
+    fn legacy_depfile_policy_preserves_explicit_user_mode() {
+        let fast_md = legacy_depfile_policy(
+            &["-MMD".into(), "-MD".into()],
+            DependencyDiscoveryMode::SkipSystemHeaders,
+        );
+        assert!(fast_md.injected_flag.is_none());
+        assert!(!fast_md.excludes_system_headers);
+
+        let safe_mmd = legacy_depfile_policy(
+            &["-MD".into(), "-MMD".into()],
+            DependencyDiscoveryMode::AllHeaders,
+        );
+        assert!(safe_mmd.injected_flag.is_none());
+        assert!(safe_mmd.excludes_system_headers);
+    }
+
+    #[test]
+    fn depfile_stdout_detection_uses_last_mf_value() {
+        assert!(depfile_targets_stdout(&[
+            "-MFdeps.d".into(),
+            "-MF".into(),
+            "-".into(),
+        ]));
+        assert!(!depfile_targets_stdout(&[
+            "-MF-".into(),
+            "-MFdeps.d".into(),
+        ]));
+    }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/keys.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/keys.rs
@@ -371,12 +371,13 @@ pub(super) fn request_env_fingerprint_vars(
             // fast-path miss/hit decision diverges from the slow-path key
             // computation and worktrees with different target-dir leaf names
             // never reach the artifact lookup (issue #396).
-            let include = key.starts_with("CARGO_")
+            let include = (key.starts_with("CARGO_")
                 && key != "CARGO_MAKEFLAGS"
                 && key != "CARGO_INCREMENTAL"
                 && key != "CARGO_MANIFEST_DIR"
                 && key != "CARGO_MANIFEST_PATH"
-                && key != "CARGO_TARGET_DIR";
+                && key != "CARGO_TARGET_DIR")
+                || matches!(key, "ZCCACHE_FAST" | "ZCCACHE_SCAN_SYSTEM_HEADERS");
             include.then_some((key, value.as_str()))
         })
         .collect();
@@ -422,6 +423,7 @@ pub(super) fn request_fingerprint(
         h.update(&[0]);
         i += 1;
     }
+    update_user_depfile_raw_fingerprint(&mut h, args);
     let cwd = normalize_path_for_request_key(cwd, key_root);
     h.update(cwd.as_bytes());
     h.update(&[0]);
@@ -432,6 +434,34 @@ pub(super) fn request_fingerprint(
         h.update(&[0]);
     }
     h.finalize()
+}
+
+fn update_user_depfile_raw_fingerprint(
+    hasher: &mut crate::hash::StreamHasher,
+    args: &[String],
+) {
+    if !args.iter().any(|arg| matches!(arg.as_str(), "-MD" | "-MMD")) {
+        return;
+    }
+    hasher.update(b"user-depfile-raw-argv\0");
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "-MF" {
+            if args.get(index + 1).is_some_and(|value| value == "-") {
+                hasher.update(b"-MF-stdout\0");
+            }
+            index += 2;
+            continue;
+        }
+        if arg == "-MF-" {
+            hasher.update(b"-MF-stdout\0");
+        } else if !arg.starts_with("-MF") {
+            hasher.update(arg.as_bytes());
+            hasher.update(&[0]);
+        }
+        index += 1;
+    }
 }
 
 pub(super) fn request_cache_input_paths(

--- a/crates/zccache-daemon-core/src/daemon/server/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/mod.rs
@@ -37,6 +37,7 @@ use super::stats::{HitPhases, MissPhases, PhaseProfiler, StatsCollector};
 /// When the journal clock hasn't advanced since the last verified hit for a
 /// context, we can skip all stat/hash/depgraph work and jump straight to
 /// artifact lookup.
+#[derive(Clone)]
 pub(crate) struct FastHitEntry {
     pub(crate) clock: Clock,
     pub(crate) artifact_key_hex: String,
@@ -119,6 +120,7 @@ mod compile_concurrency;
 mod compiler_hash;
 mod connection;
 mod directory_link;
+mod dependency_policy;
 mod embedded;
 mod handle_clear;
 mod handle_compile;
@@ -159,6 +161,7 @@ use client_env::*;
 use compiler_hash::*;
 use connection::handle_connection;
 use directory_link::*;
+use dependency_policy::*;
 use handle_clear::*;
 use handle_compile::handle_compile;
 use handle_compile_ephemeral::*;

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_multi.rs
@@ -190,29 +190,57 @@ pub(in crate::daemon::server) struct StagedMultiUnitPlan {
     pub(in crate::daemon::server) depfile: NormalizedPath,
     pub(in crate::daemon::server) outputs: Vec<StagedOutputPlan>,
     pub(in crate::daemon::server) msvc_syntax: bool,
+    pub(in crate::daemon::server) depfile_excludes_system_headers: bool,
     root: NormalizedPath,
 }
 
 impl StagedMultiUnitPlan {
-    pub(in crate::daemon::server) fn build(
+    pub(in crate::daemon::server) fn build_with_depfile_flag(
         staging_dir: &Path,
         family: crate::compiler::CompilerFamily,
         args: Vec<String>,
         requested_output: &NormalizedPath,
         cwd: &Path,
+        depfile_flag: &str,
     ) -> StagedPlanOutcome<Self> {
         if !staged_lane_enabled(family) {
             return StagedPlanOutcome::Unsupported(StagedPlanReason::LaneDisabled);
         }
-        Self::build_enabled(staging_dir, family, args, requested_output, cwd)
+        Self::build_enabled_with_depfile_flag(
+            staging_dir,
+            family,
+            args,
+            requested_output,
+            cwd,
+            depfile_flag,
+        )
     }
 
+    #[cfg(test)]
     fn build_enabled(
         staging_dir: &Path,
         family: crate::compiler::CompilerFamily,
         args: Vec<String>,
         requested_output: &NormalizedPath,
         cwd: &Path,
+    ) -> StagedPlanOutcome<Self> {
+        Self::build_enabled_with_depfile_flag(
+            staging_dir,
+            family,
+            args,
+            requested_output,
+            cwd,
+            "-MD",
+        )
+    }
+
+    fn build_enabled_with_depfile_flag(
+        staging_dir: &Path,
+        family: crate::compiler::CompilerFamily,
+        args: Vec<String>,
+        requested_output: &NormalizedPath,
+        cwd: &Path,
+        depfile_flag: &str,
     ) -> StagedPlanOutcome<Self> {
         match classify_staged_multi_invocation(
             family,
@@ -261,13 +289,22 @@ impl StagedMultiUnitPlan {
         let user_depfile = args
             .iter()
             .any(|arg| matches!(arg.as_str(), "-MD" | "-MMD"));
+        let depfile_excludes_system_headers = args.iter().fold(false, |current, arg| {
+            if arg == "-MMD" {
+                true
+            } else if arg == "-MD" {
+                false
+            } else {
+                current
+            }
+        });
         let rewritten_args = if msvc_syntax {
             rewrite_msvc_output(args, &staged)
         } else {
             let mut rewritten = args;
             let mut injected = vec!["-o".to_string(), staged.to_string_lossy().into_owned()];
             if !user_depfile {
-                injected.push("-MD".to_string());
+                injected.push(depfile_flag.to_string());
             }
             injected.extend(["-MF".to_string(), depfile.to_string_lossy().into_owned()]);
             if !has_depfile_target(&rewritten) {
@@ -292,6 +329,7 @@ impl StagedMultiUnitPlan {
             depfile,
             outputs,
             msvc_syntax,
+            depfile_excludes_system_headers,
             root,
         })
     }
@@ -757,6 +795,7 @@ mod tests {
         assert_eq!(plan.outputs.len(), 2);
         assert_eq!(plan.outputs[1].requested, requested.with_extension("d"));
         assert_eq!(plan.outputs[1].staged, plan.depfile);
+        assert!(plan.depfile_excludes_system_headers);
         assert!(!plan.rewritten_args.iter().any(|arg| arg == "-MD"));
     }
 

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
@@ -709,8 +709,8 @@ impl StagedCompilePlan {
         let path = match &strategy {
             crate::depgraph::DepfileStrategy::Injected { path }
             | crate::depgraph::DepfileStrategy::InjectedMmd { path }
-            | crate::depgraph::DepfileStrategy::UserSpecified { path }
-            | crate::depgraph::DepfileStrategy::UserDefault { path } => path,
+            | crate::depgraph::DepfileStrategy::UserSpecified { path, .. }
+            | crate::depgraph::DepfileStrategy::UserDefault { path, .. } => path,
             crate::depgraph::DepfileStrategy::ShowIncludes
             | crate::depgraph::DepfileStrategy::Unsupported => return strategy,
         };
@@ -729,11 +729,23 @@ impl StagedCompilePlan {
             crate::depgraph::DepfileStrategy::InjectedMmd { .. } => {
                 crate::depgraph::DepfileStrategy::InjectedMmd { path: staged }
             }
-            crate::depgraph::DepfileStrategy::UserSpecified { .. } => {
-                crate::depgraph::DepfileStrategy::UserSpecified { path: staged }
+            crate::depgraph::DepfileStrategy::UserSpecified {
+                augment_system_headers,
+                ..
+            } => {
+                crate::depgraph::DepfileStrategy::UserSpecified {
+                    path: staged,
+                    augment_system_headers,
+                }
             }
-            crate::depgraph::DepfileStrategy::UserDefault { .. } => {
-                crate::depgraph::DepfileStrategy::UserDefault { path: staged }
+            crate::depgraph::DepfileStrategy::UserDefault {
+                augment_system_headers,
+                ..
+            } => {
+                crate::depgraph::DepfileStrategy::UserDefault {
+                    path: staged,
+                    augment_system_headers,
+                }
             }
             crate::depgraph::DepfileStrategy::ShowIncludes
             | crate::depgraph::DepfileStrategy::Unsupported => strategy,

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan_tests.rs
@@ -103,7 +103,9 @@ fn cc_plan_stages_user_depfile_without_leaking_private_path() {
     let depfile: NormalizedPath = temp.path().join("deps/hello.d").into();
     let dep_flags = crate::depgraph::UserDepFlags {
         has_md: true,
+        has_mmd: false,
         mf_path: Some(depfile.clone()),
+        depfile_to_stdout: false,
     };
     let plan = StagedCompilePlan::cc(
         temp.path(),
@@ -131,10 +133,11 @@ fn cc_plan_stages_user_depfile_without_leaking_private_path() {
     let rewritten =
         plan.rewrite_depfile_strategy(crate::depgraph::DepfileStrategy::UserSpecified {
             path: depfile,
+            augment_system_headers: false,
         });
     assert!(matches!(
         rewritten,
-        crate::depgraph::DepfileStrategy::UserSpecified { path }
+        crate::depgraph::DepfileStrategy::UserSpecified { path, .. }
             if path.as_path().starts_with(temp.path())
     ));
     plan.cleanup().unwrap();

--- a/crates/zccache-daemon-core/src/daemon/server/tests/fingerprint.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/fingerprint.rs
@@ -508,6 +508,71 @@ fn request_fingerprint_includes_rust_key_env() {
     assert_ne!(a, b);
 }
 
+/// Dependency policy changes the effective C/C++ manifest and must therefore
+/// partition the request-level cache as well as the depgraph context key.
+#[test]
+fn request_fingerprint_separates_dependency_policy_env() {
+    let args = vec!["-c".to_string(), "src/main.cpp".to_string()];
+    let safe = vec![(
+        "ZCCACHE_SCAN_SYSTEM_HEADERS".to_string(),
+        "1".to_string(),
+    )];
+    let fast = vec![("ZCCACHE_FAST".to_string(), "1".to_string())];
+
+    let safe_key = request_fingerprint(
+        Path::new("/usr/bin/clang++"),
+        &args,
+        Path::new("/workspace"),
+        Some(Path::new("/workspace")),
+        Some(&safe),
+    );
+    let fast_key = request_fingerprint(
+        Path::new("/usr/bin/clang++"),
+        &args,
+        Path::new("/workspace"),
+        Some(Path::new("/workspace")),
+        Some(&fast),
+    );
+
+    assert_ne!(safe_key, fast_key);
+}
+
+#[test]
+fn request_fingerprint_preserves_raw_user_depfile_paths() {
+    let root_a = Path::new("/repo/worktree-a");
+    let root_b = Path::new("/repo/worktree-b");
+    let args_a = vec![
+        "-c".into(),
+        "/repo/worktree-a/src/main.cpp".into(),
+        "-o".into(),
+        "/repo/worktree-a/main.o".into(),
+        "-MD".into(),
+        "-MF".into(),
+        "/repo/worktree-a/deps.d".into(),
+    ];
+    let mut args_b = args_a.clone();
+    args_b[1] = "/repo/worktree-b/src/main.cpp".into();
+    args_b[3] = "/repo/worktree-b/main.o".into();
+    args_b[6] = "/repo/worktree-b/deps.d".into();
+
+    let a = request_fingerprint(Path::new("clang++"), &args_a, root_a, Some(root_a), None);
+    let b = request_fingerprint(Path::new("clang++"), &args_b, root_b, Some(root_b), None);
+    assert_ne!(a, b, "verbatim depfile prerequisites differ across roots");
+
+    args_b[1] = args_a[1].clone();
+    args_b[3] = args_a[3].clone();
+    args_b[5] = "-MF-".into();
+    args_b.remove(6);
+    let stdout = request_fingerprint(
+        Path::new("clang++"),
+        &args_b,
+        root_a,
+        Some(root_a),
+        None,
+    );
+    assert_ne!(a, stdout);
+}
+
 /// Issue #396 — `CARGO_TARGET_DIR` is output-placement state and must NOT
 /// alter the request fingerprint. Without this filter, two worktrees whose
 /// only difference is the target-dir leaf name produce divergent fingerprints

--- a/crates/zccache-depgraph/src/args.rs
+++ b/crates/zccache-depgraph/src/args.rs
@@ -13,8 +13,12 @@ use zccache_core::NormalizedPath;
 pub struct UserDepFlags {
     /// User has -MD or -MMD (emit depfile as side-effect of compilation).
     pub has_md: bool,
+    /// User selected -MMD, so their depfile intentionally omits system headers.
+    pub has_mmd: bool,
     /// User has -MF `<path>` (explicit depfile output path).
     pub mf_path: Option<NormalizedPath>,
+    /// User selected `-MF -`, so dependency output is part of compiler stdout.
+    pub depfile_to_stdout: bool,
 }
 
 /// Result of parsing compiler arguments.
@@ -210,6 +214,7 @@ pub fn parse_gnu_args(args: &[String], cwd: &Path) -> ParsedArgs {
         // Dependency-generation flags: track but don't include in cache key.
         if arg == "-MD" || arg == "-MMD" {
             result.dep_flags.has_md = true;
+            result.dep_flags.has_mmd = arg == "-MMD";
             i += 1;
             continue;
         }
@@ -217,9 +222,15 @@ pub fn parse_gnu_args(args: &[String], cwd: &Path) -> ParsedArgs {
         // -MF takes a following argument â€” capture path.
         if arg == "-MF" {
             if let Some(next) = args.get(i + 1) {
-                result.dep_flags.mf_path = Some(resolve_path(next, cwd));
+                result.dep_flags.depfile_to_stdout = next == "-";
+                result.dep_flags.mf_path = (next != "-").then(|| resolve_path(next, cwd));
             }
             i += 2;
+            continue;
+        } else if let Some(path) = arg.strip_prefix("-MF").filter(|path| !path.is_empty()) {
+            result.dep_flags.depfile_to_stdout = path == "-";
+            result.dep_flags.mf_path = (path != "-").then(|| resolve_path(path, cwd));
+            i += 1;
             continue;
         }
 
@@ -599,6 +610,7 @@ mod tests {
     fn dep_flags_md_detected() {
         let parsed = parse_gnu_args(&args(&["-MMD", "-c", "foo.c"]), Path::new("/p"));
         assert!(parsed.dep_flags.has_md);
+        assert!(parsed.dep_flags.has_mmd);
     }
 
     #[test]
@@ -608,6 +620,20 @@ mod tests {
             parsed.dep_flags.mf_path.as_deref(),
             Some(Path::new("/p/deps.d"))
         );
+    }
+
+    #[test]
+    fn dep_flags_joined_mf_and_stdout_detected() {
+        let joined = parse_gnu_args(&args(&["-MFdeps.d", "-c", "foo.c"]), Path::new("/p"));
+        assert_eq!(
+            joined.dep_flags.mf_path.as_deref(),
+            Some(Path::new("/p/deps.d"))
+        );
+        assert!(!joined.dep_flags.depfile_to_stdout);
+
+        let stdout = parse_gnu_args(&args(&["-MF-", "-c", "foo.c"]), Path::new("/p"));
+        assert!(stdout.dep_flags.mf_path.is_none());
+        assert!(stdout.dep_flags.depfile_to_stdout);
     }
 
     #[test]

--- a/crates/zccache-depgraph/src/depfile/merge.rs
+++ b/crates/zccache-depgraph/src/depfile/merge.rs
@@ -27,9 +27,20 @@ pub fn merge_scan_results(mut depfile: ScanResult, static_scan: ScanResult) -> S
     depfile
 }
 
+/// Merge a compiler manifest with a static scan without trusting incomplete
+/// static resolution for direct-mode hits.
+#[must_use]
+pub fn merge_scan_results_conservative(
+    depfile: ScanResult,
+    mut static_scan: ScanResult,
+) -> ScanResult {
+    static_scan.has_computed |= !static_scan.unresolved.is_empty();
+    merge_scan_results(depfile, static_scan)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::merge_scan_results;
+    use super::{merge_scan_results, merge_scan_results_conservative};
     use crate::scanner::ScanResult;
     use zccache_core::NormalizedPath;
 
@@ -55,5 +66,23 @@ mod tests {
         assert!(merged.resolved.contains(&system));
         assert_eq!(merged.unresolved, vec!["missing.h"]);
         assert!(!merged.has_computed);
+    }
+
+    #[test]
+    fn conservative_merge_disables_direct_mode_for_unresolved_static_include() {
+        let merged = merge_scan_results_conservative(
+            ScanResult {
+                resolved: Vec::new(),
+                unresolved: Vec::new(),
+                has_computed: false,
+            },
+            ScanResult {
+                resolved: Vec::new(),
+                unresolved: vec!["compiler-only-system-header.h".into()],
+                has_computed: false,
+            },
+        );
+
+        assert!(merged.has_computed);
     }
 }

--- a/crates/zccache-depgraph/src/depfile/mod.rs
+++ b/crates/zccache-depgraph/src/depfile/mod.rs
@@ -21,7 +21,7 @@ mod tests;
 
 pub use canonicalize::{canonicalize_path, strip_win_prefix};
 pub use error::DepfileError;
-pub use merge::merge_scan_results;
+pub use merge::{merge_scan_results, merge_scan_results_conservative};
 pub use parse::{parse_depfile, parse_depfile_path};
 pub use strategy::{
     prepare_depfile, prepare_depfile_with_mmd, user_depfile_destination, DepfileStrategy,

--- a/crates/zccache-depgraph/src/depfile/strategy.rs
+++ b/crates/zccache-depgraph/src/depfile/strategy.rs
@@ -16,9 +16,17 @@ pub enum DepfileStrategy {
     /// We injected a private MMD depfile; merge a conservative local include scan.
     InjectedMmd { path: NormalizedPath },
     /// User already had `-MF <path>` — read it (don't delete).
-    UserSpecified { path: NormalizedPath },
+    UserSpecified {
+        path: NormalizedPath,
+        /// Merge a full recursive scan because the user selected `-MMD`
+        /// while zccache remains in its correctness-first policy.
+        augment_system_headers: bool,
+    },
     /// User had `-MD` but no `-MF` — derive path from output stem.
-    UserDefault { path: NormalizedPath },
+    UserDefault {
+        path: NormalizedPath,
+        augment_system_headers: bool,
+    },
     /// MSVC `/showIncludes` — parse stderr after compilation.
     ShowIncludes,
     /// Compiler doesn't support depfiles — use fallback scanner.
@@ -45,6 +53,9 @@ pub fn user_depfile_destination(
     dep_flags: &UserDepFlags,
     output_file: &Path,
 ) -> Option<NormalizedPath> {
+    if dep_flags.depfile_to_stdout {
+        return None;
+    }
     if let Some(ref mf_path) = dep_flags.mf_path {
         return Some(mf_path.clone());
     }
@@ -85,6 +96,9 @@ pub fn prepare_depfile_with_mmd(
     if !supports_depfile {
         return (Vec::new(), DepfileStrategy::Unsupported);
     }
+    if dep_flags.depfile_to_stdout {
+        return (Vec::new(), DepfileStrategy::Unsupported);
+    }
 
     // User already specified -MF <path>: use their file.
     if let Some(ref mf_path) = dep_flags.mf_path {
@@ -92,6 +106,7 @@ pub fn prepare_depfile_with_mmd(
             Vec::new(),
             DepfileStrategy::UserSpecified {
                 path: mf_path.clone(),
+                augment_system_headers: dep_flags.has_mmd && !use_mmd,
             },
         );
     }
@@ -103,6 +118,7 @@ pub fn prepare_depfile_with_mmd(
             Vec::new(),
             DepfileStrategy::UserDefault {
                 path: d_path.into(),
+                augment_system_headers: dep_flags.has_mmd && !use_mmd,
             },
         );
     }

--- a/crates/zccache-depgraph/src/depfile/tests.rs
+++ b/crates/zccache-depgraph/src/depfile/tests.rs
@@ -444,14 +444,17 @@ fn strategy_unsupported() {
 fn strategy_user_mf() {
     let dep_flags = UserDepFlags {
         has_md: true,
+        has_mmd: false,
         mf_path: Some(NormalizedPath::from("/build/deps.d")),
+        depfile_to_stdout: false,
     };
     let (args, strategy) = prepare_depfile(true, &dep_flags, Path::new("foo.o"), Path::new("/tmp"));
     assert!(args.is_empty());
     assert_eq!(
         strategy,
         DepfileStrategy::UserSpecified {
-            path: NormalizedPath::from("/build/deps.d")
+            path: NormalizedPath::from("/build/deps.d"),
+            augment_system_headers: false,
         }
     );
 }
@@ -460,14 +463,17 @@ fn strategy_user_mf() {
 fn strategy_user_md_no_mf() {
     let dep_flags = UserDepFlags {
         has_md: true,
+        has_mmd: false,
         mf_path: None,
+        depfile_to_stdout: false,
     };
     let (args, strategy) = prepare_depfile(true, &dep_flags, Path::new("foo.o"), Path::new("/tmp"));
     assert!(args.is_empty());
     assert_eq!(
         strategy,
         DepfileStrategy::UserDefault {
-            path: NormalizedPath::from("foo.d")
+            path: NormalizedPath::from("foo.d"),
+            augment_system_headers: false,
         }
     );
 }
@@ -478,7 +484,9 @@ fn strategy_user_md_no_mf() {
 fn user_depfile_destination_returns_mf_path_when_present() {
     let dep_flags = UserDepFlags {
         has_md: true,
+        has_mmd: false,
         mf_path: Some(NormalizedPath::from("/build/explicit.d")),
+        depfile_to_stdout: false,
     };
     assert_eq!(
         user_depfile_destination(&dep_flags, Path::new("/out/foo.o")),
@@ -491,7 +499,9 @@ fn user_depfile_destination_returns_mf_path_when_present() {
 fn user_depfile_destination_derives_default_from_output_when_md_only() {
     let dep_flags = UserDepFlags {
         has_md: true,
+        has_mmd: false,
         mf_path: None,
+        depfile_to_stdout: false,
     };
     assert_eq!(
         user_depfile_destination(&dep_flags, Path::new("/out/foo.o")),
@@ -508,6 +518,24 @@ fn user_depfile_destination_none_when_user_has_no_dep_flags() {
         None,
         "no user dep flags = injected strategy = not the user's depfile",
     );
+}
+
+#[test]
+fn depfile_stdout_is_not_treated_as_a_materialized_file() {
+    let dep_flags = UserDepFlags {
+        has_md: true,
+        has_mmd: false,
+        mf_path: None,
+        depfile_to_stdout: true,
+    };
+    assert_eq!(
+        user_depfile_destination(&dep_flags, Path::new("/out/foo.o")),
+        None
+    );
+    let (args, strategy) =
+        prepare_depfile(true, &dep_flags, Path::new("/out/foo.o"), Path::new("/tmp"));
+    assert!(args.is_empty());
+    assert_eq!(strategy, DepfileStrategy::Unsupported);
 }
 
 #[test]
@@ -565,7 +593,9 @@ fn strategy_injected_mmd_uses_user_header_depfile() {
 fn strategy_injected_mmd_never_changes_user_depfile_flags() {
     let dep_flags = UserDepFlags {
         has_md: true,
+        has_mmd: false,
         mf_path: Some(NormalizedPath::from("/build/user.d")),
+        depfile_to_stdout: false,
     };
     let (args, strategy) = prepare_depfile_with_mmd(
         true,
@@ -579,7 +609,35 @@ fn strategy_injected_mmd_never_changes_user_depfile_flags() {
     assert_eq!(
         strategy,
         DepfileStrategy::UserSpecified {
-            path: NormalizedPath::from("/build/user.d")
+            path: NormalizedPath::from("/build/user.d"),
+            augment_system_headers: false,
+        }
+    );
+}
+
+#[test]
+fn safe_policy_augments_user_mmd_manifest() {
+    let dep_flags = UserDepFlags {
+        has_md: true,
+        has_mmd: true,
+        mf_path: Some(NormalizedPath::from("/build/user.d")),
+        depfile_to_stdout: false,
+    };
+
+    let (args, strategy) = prepare_depfile_with_mmd(
+        false,
+        true,
+        &dep_flags,
+        Path::new("foo.o"),
+        Path::new("/tmp"),
+    );
+
+    assert!(args.is_empty());
+    assert_eq!(
+        strategy,
+        DepfileStrategy::UserSpecified {
+            path: NormalizedPath::from("/build/user.d"),
+            augment_system_headers: true,
         }
     );
 }

--- a/crates/zccache-depgraph/src/scanner.rs
+++ b/crates/zccache-depgraph/src/scanner.rs
@@ -1073,7 +1073,9 @@ mod tests {
             user: vec![user_dir.clone().into()],
             system: vec![system_dir.clone().into()],
             ..Default::default()
-        };
+        }
+        .canonicalized();
+        let user_dir = std::fs::canonicalize(user_dir).unwrap();
         let cache = RecursiveScanCache::default();
 
         let result = scan_recursive_cached_pruned(

--- a/crates/zccache-depgraph/src/scanner.rs
+++ b/crates/zccache-depgraph/src/scanner.rs
@@ -220,7 +220,7 @@ fn resolve_include_next<'a>(
 /// parallelization). Callers in `graph.rs` only iterate the list to hash
 /// all files; no order invariant is broken.
 pub fn scan_recursive(source: &Path, search: &IncludeSearchPaths) -> ScanResult {
-    scan_recursive_impl(source, search, None)
+    scan_recursive_impl(source, search, None, &|_, _, _| true)
 }
 
 /// Recursively scan with a request-scoped parsed-directive memo.
@@ -229,13 +229,28 @@ pub fn scan_recursive_cached(
     search: &IncludeSearchPaths,
     cache: &RecursiveScanCache,
 ) -> ScanResult {
-    scan_recursive_impl(source, search, Some(cache))
+    scan_recursive_impl(source, search, Some(cache), &|_, _, _| true)
+}
+
+/// Recursively scan with a request-scoped memo, pruning rejected headers.
+///
+/// A rejected header is neither returned nor scanned for transitive includes.
+/// This is useful when a caller intentionally excludes an entire include-root
+/// class and wants to avoid paying to read and parse that subtree.
+pub fn scan_recursive_cached_pruned(
+    source: &Path,
+    search: &IncludeSearchPaths,
+    cache: &RecursiveScanCache,
+    retain: &(dyn Fn(&Path, &IncludeDirective, &NormalizedPath) -> bool + Sync),
+) -> ScanResult {
+    scan_recursive_impl(source, search, Some(cache), retain)
 }
 
 fn scan_recursive_impl(
     source: &Path,
     search: &IncludeSearchPaths,
     cache: Option<&RecursiveScanCache>,
+    retain: &(dyn Fn(&Path, &IncludeDirective, &NormalizedPath) -> bool + Sync),
 ) -> ScanResult {
     use dashmap::DashSet;
     use rayon::prelude::*;
@@ -266,6 +281,7 @@ fn scan_recursive_impl(
                     &unresolved,
                     &has_computed,
                     cache,
+                    retain,
                 )
             })
             .collect();
@@ -297,6 +313,7 @@ fn scan_one_level(
     unresolved: &std::sync::Mutex<Vec<String>>,
     has_computed: &std::sync::atomic::AtomicBool,
     cache: Option<&RecursiveScanCache>,
+    retain: &(dyn Fn(&Path, &IncludeDirective, &NormalizedPath) -> bool + Sync),
 ) -> Vec<NormalizedPath> {
     let directives = if let Some(cache) = cache {
         let key = NormalizedPath::from(file);
@@ -328,7 +345,7 @@ fn scan_one_level(
             }
             _ => {
                 if let Some(abs_path) = resolve_include(directive, search, file_dir) {
-                    if visited.insert(abs_path.clone()) {
+                    if retain(file, directive, &abs_path) && visited.insert(abs_path.clone()) {
                         local_resolved.push(abs_path.clone());
                         new_for_next.push(abs_path);
                     }
@@ -1036,6 +1053,39 @@ mod tests {
         assert_eq!(one.resolved.len(), 2);
         assert_eq!(two.resolved.len(), 2);
         assert_eq!(cache.directives.len(), 4);
+    }
+
+    #[test]
+    fn recursive_scan_prunes_rejected_header_subtrees() {
+        let dir = TempDir::new().unwrap();
+        let user_dir = dir.path().join("user");
+        let system_dir = dir.path().join("system");
+        std::fs::create_dir_all(&user_dir).unwrap();
+        std::fs::create_dir_all(&system_dir).unwrap();
+        std::fs::write(
+            dir.path().join("main.c"),
+            "#include <user.h>\n#include <system.h>\n",
+        )
+        .unwrap();
+        std::fs::write(user_dir.join("user.h"), "// user\n").unwrap();
+        std::fs::write(system_dir.join("system.h"), "#include SYSTEM_COMPUTED\n").unwrap();
+        let search = IncludeSearchPaths {
+            user: vec![user_dir.clone().into()],
+            system: vec![system_dir.clone().into()],
+            ..Default::default()
+        };
+        let cache = RecursiveScanCache::default();
+
+        let result = scan_recursive_cached_pruned(
+            &dir.path().join("main.c"),
+            &search,
+            &cache,
+            &|_, _, path| path.starts_with(&user_dir),
+        );
+
+        assert_eq!(result.resolved, vec![normalize(&user_dir.join("user.h"))]);
+        assert!(!result.has_computed);
+        assert_eq!(cache.directives.len(), 2);
     }
 
     #[test]

--- a/crates/zccache-depgraph/src/search_paths.rs
+++ b/crates/zccache-depgraph/src/search_paths.rs
@@ -30,6 +30,35 @@ pub struct IncludeSearchPaths {
 }
 
 impl IncludeSearchPaths {
+    /// Resolve existing search roots once so scanner results and root-policy
+    /// comparisons use the same filesystem spelling.
+    ///
+    /// Recursive scans canonicalize resolved headers. On Windows and macOS,
+    /// temporary and user-provided paths may reach the same directory through
+    /// different casing, short names, or symlink aliases. Keeping raw roots in
+    /// that situation makes a header resolve successfully and then fail its
+    /// user-vs-system root classification.
+    #[must_use]
+    pub fn canonicalized(&self) -> Self {
+        fn roots(paths: &[NormalizedPath]) -> Vec<NormalizedPath> {
+            paths
+                .iter()
+                .map(|path| {
+                    std::fs::canonicalize(path.as_path())
+                        .map(NormalizedPath::from)
+                        .unwrap_or_else(|_| path.clone())
+                })
+                .collect()
+        }
+
+        Self {
+            iquote: roots(&self.iquote),
+            user: roots(&self.user),
+            system: roots(&self.system),
+            after: roots(&self.after),
+        }
+    }
+
     /// Iterate search dirs for a quoted include (`#include "foo.h"`),
     /// starting after the including file's own directory.
     pub fn quoted_search_dirs(&self) -> impl Iterator<Item = &Path> {

--- a/crates/zccache/tests/perf_bench/common.rs
+++ b/crates/zccache/tests/perf_bench/common.rs
@@ -54,6 +54,20 @@ pub async fn start_daemon() -> (
     std::sync::Arc<tokio::sync::Notify>,
 ) {
     let cache_dir = zccache::test_support::temp_cache_dir().unwrap();
+    if let Some(sidecar) = std::env::var_os("PERF_GUARD_RUNTIME_ROOTS_FILE") {
+        use std::io::Write;
+        let sidecar = std::path::PathBuf::from(sidecar);
+        if let Some(parent) = sidecar.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(sidecar)
+        {
+            let _ = writeln!(file, "{}", cache_dir.path().display());
+        }
+    }
     let endpoint = zccache::ipc::unique_test_endpoint();
     let normalized = zccache::core::NormalizedPath::new(cache_dir.path());
     let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &normalized).unwrap();

--- a/crates/zccache/tests/perf_bench/tests_cpp.rs
+++ b/crates/zccache/tests/perf_bench/tests_cpp.rs
@@ -204,16 +204,27 @@ async fn perf_warm_cache_zccache_vs_sccache() {
 
     nuke_and_regenerate(zc_dir.path());
     warmup_compiler(&compiler, zc_dir.path());
-    eprint!("        single cold:  ");
+    eprintln!("        single cold:  starting");
     let zc_cold_single =
         zccache_compile_single(&mut client, &session_id, &compiler, &zc_cwd, &sources).await;
-    eprintln!("{}", fmt_dur(zc_cold_single));
+    eprintln!("        single cold:  {}", fmt_dur(zc_cold_single));
 
     let mut zc_single_times = Vec::with_capacity(WARM_TRIALS);
-    for _ in 0..WARM_TRIALS {
-        zc_single_times.push(
-            zccache_compile_single(&mut client, &session_id, &compiler, &zc_cwd, &sources).await,
+    for trial in 0..WARM_TRIALS {
+        eprintln!(
+            "        single warm:  trial {}/{} starting",
+            trial + 1,
+            WARM_TRIALS
         );
+        let elapsed =
+            zccache_compile_single(&mut client, &session_id, &compiler, &zc_cwd, &sources).await;
+        eprintln!(
+            "        single warm:  trial {}/{} finished in {}",
+            trial + 1,
+            WARM_TRIALS,
+            fmt_dur(elapsed)
+        );
+        zc_single_times.push(elapsed);
     }
     print_trials("single warm:", &zc_single_times);
 
@@ -222,7 +233,7 @@ async fn perf_warm_cache_zccache_vs_sccache() {
     nuke_and_regenerate(zc_dir.path());
     warmup_compiler(&compiler, zc_dir.path());
 
-    eprint!("        multi cold:   ");
+    eprintln!("        multi cold:   starting");
     let zc_cold_multi = zccache_compile_multi(
         &mut client,
         &session_id,
@@ -232,14 +243,25 @@ async fn perf_warm_cache_zccache_vs_sccache() {
         false,
     )
     .await;
-    eprintln!("{}", fmt_dur(zc_cold_multi));
+    eprintln!("        multi cold:   {}", fmt_dur(zc_cold_multi));
 
     let mut zc_multi_times = Vec::with_capacity(WARM_TRIALS);
-    for _ in 0..WARM_TRIALS {
-        zc_multi_times.push(
-            zccache_compile_multi(&mut client, &session_id, &compiler, &zc_cwd, &sources, true)
-                .await,
+    for trial in 0..WARM_TRIALS {
+        eprintln!(
+            "        multi warm:   trial {}/{} starting",
+            trial + 1,
+            WARM_TRIALS
         );
+        let elapsed =
+            zccache_compile_multi(&mut client, &session_id, &compiler, &zc_cwd, &sources, true)
+                .await;
+        eprintln!(
+            "        multi warm:   trial {}/{} finished in {}",
+            trial + 1,
+            WARM_TRIALS,
+            fmt_dur(elapsed)
+        );
+        zc_multi_times.push(elapsed);
     }
     print_trials("multi warm:", &zc_multi_times);
     let zccache_cache_bytes = dir_size_bytes(zccache_cache_dir.path());


### PR DESCRIPTION
Fixes #1150.
Refs #1152.

## Summary

- add a correctness-first C/C++ dependency policy with --fast, --skip-system-headers, --scan-system-headers, and matching environment configuration
- use compiler-classified -MD/-MMD manifests consistently across single and multi-source paths, conservatively handling static fallbacks and preserving user depfile semantics
- prune system-header subtrees during fast-mode multi-source preflight instead of scanning and discarding them
- fix the warm multi-source deadlock by releasing the DashMap fast-hit guard before artifact materialization/removal
- fix the legacy multi-source store path so staged entries resolve their active persistence layout lazily instead of recording a nonexistent legacy key_0 file
- make NormalizedPath containment and include-root canonicalization consistent across Windows/macOS path spellings
- add a 60-minute diagnostic / 75-minute termination perf watchdog with streamed lite logs, downloadable full logs, process snapshots, and bounded GDB all-thread stacks
- make perf aggregation fail closed on missing results and stop later benchmarks after a timeout

## Root cause

The historical C++ run completed bare Clang, sccache, zccache single-file cold/warm, and zccache multi-file cold. The first warm 50-source zccache request then blocked forever. check_unit_cache retained a DashMap get guard while materializing a fast-hit artifact; when materialization failed, the error path attempted remove on the same shard and self-deadlocked. The request JoinSet therefore never completed.

A second defect made that error path routine for the legacy multi-source handler: staged persistence wrote under .staged-v2, but the in-memory CachedArtifact eagerly stored artifact_dir/key_0. Warm restore received ENOENT, evicted an otherwise valid entry, and recompiled the entire batch. The fix constructs CachedArtifact from its index with lazy payload resolution, so restore follows the active persistence layout.

CI also exposed that the new -MMD policy compared canonical scanner results against lexical roots through raw Path::starts_with. Windows extended prefixes/short names and macOS aliases/case folding could therefore misclassify user headers. Roots are now canonicalized once outside the per-header loop, and NormalizedPath containment uses its normalized comparison key.

## Validation

- focused Docker RED/GREEN reproducer: cold 43.186s, warm 0.133s, cached=true after the staged-path fix
- permanent ignored CLI regression: cli_multi_file_compilation_runs_directly passes on Linux (real clang + daemon IPC)
- mmd_fallback_tracks_user_headers_but_omits_system_roots passes on Linux
- recursive_scan_prunes_rejected_header_subtrees passes on Windows
- NormalizedPath extended-prefix/case and component-boundary regressions pass on Windows
- soldr cargo fmt --all -- --check
- git diff --check
- earlier branch validation: depgraph suite, focused daemon policy/depfile/materialization/preflight/deadlock tests, CLI policy parsing, perf target build, watchdog suite, and actionlint

The broader cache-path and normalized-path look-alike audits, Dylint prevention, and aggregate legacy-layout integration validation are tracked in #1152.