### PR TITLE
fix: add bounded daemon-owned artifact retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,31 @@ daemon state, and the default daemon endpoint. Separate cache roots therefore
 use separate daemon instances unless `ZCCACHE_ENDPOINT` is explicitly set.
 Relative override paths are normalized against the current working directory.
 
+### Cache size and retention
+
+The daemon owns retention for its exact effective cache root; no system
+scheduler is required. Cached artifacts default to 5% of filesystem capacity,
+clamped to 40-200 GiB and reduced when needed to preserve recovery free space.
+On filesystems too small for the 30 GiB recovery target, at most half of the
+volume is reserved so the cache retains a useful non-zero budget.
+Choose at most one override:
+
+```bash
+# Fixed artifact-store budget in bytes
+export ZCCACHE_CACHE_SIZE_BYTES=42949672960
+
+# Or a percentage of filesystem capacity (1 through 100)
+export ZCCACHE_CACHE_SIZE_PERCENT=5
+```
+
+At 85% of budget, entries older than four days are evicted in LRU order to
+70%. At 100% or when free space is low, LRU eviction applies regardless of age
+until usage reaches 80% and recovery free space is restored. A daily full pass
+expires entries older than 30 days, including during periods with no compile
+traffic while the daemon remains alive. The budget covers allocated artifact
+files plus pending writes; small root-local indexes, logs, and metadata are
+outside it.
+
 ### Daemon namespace override
 
 Set `ZCCACHE_DAEMON_NAMESPACE` to run a second zccache daemon identity against

--- a/crates/zccache-artifact/src/store.rs
+++ b/crates/zccache-artifact/src/store.rs
@@ -54,7 +54,8 @@ pub struct ArtifactIndex {
     pub exit_code: i32,
     /// Sum of all output file sizes (for eviction budget accounting).
     pub total_size: u64,
-    /// Unix epoch seconds when this artifact was stored.
+    /// Unix epoch seconds when this artifact was stored or last access was
+    /// checkpointed for retention. Reused for backward-compatible persistence.
     pub stored_at_secs: u64,
 }
 
@@ -93,6 +94,7 @@ impl ArtifactIndex {
 pub struct ArtifactStore {
     path: NormalizedPath,
     entries: DashMap<String, ArtifactIndex>,
+    flush_lock: std::sync::Mutex<()>,
 }
 
 impl ArtifactStore {
@@ -128,6 +130,7 @@ impl ArtifactStore {
         Self {
             path: NormalizedPath::new(path),
             entries: DashMap::new(),
+            flush_lock: std::sync::Mutex::new(()),
         }
     }
 
@@ -239,6 +242,13 @@ impl ArtifactStore {
             .collect()
     }
 
+    /// Sum logical payload bytes without cloning index rows.
+    pub fn total_size_bytes(&self) -> u64 {
+        self.entries.iter().fold(0_u64, |total, entry| {
+            total.saturating_add(entry.value().total_size)
+        })
+    }
+
     /// Number of entries currently held.
     pub fn len(&self) -> usize {
         self.entries.len()
@@ -265,6 +275,10 @@ impl ArtifactStore {
     /// some serialisation of in-flight inserts (acceptable for the
     /// crash-recovery contract).
     pub fn flush(&self) -> std::io::Result<()> {
+        let _flush_guard = self
+            .flush_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let snapshot: Vec<(String, ArtifactIndex)> = self
             .entries
             .iter()

--- a/crates/zccache-cli-core/src/cli/commands/tests/args_parsing.rs
+++ b/crates/zccache-cli-core/src/cli/commands/tests/args_parsing.rs
@@ -18,13 +18,8 @@ use crate::artifact::rust_plan_gha_version;
 fn compile_policy_flags_parse_at_global_and_explicit_wrap_paths() {
     use clap::Parser;
 
-    let global = Cli::try_parse_from([
-        "zccache",
-        "--fast",
-        "--skip-system-headers",
-        "status",
-    ])
-    .unwrap();
+    let global =
+        Cli::try_parse_from(["zccache", "--fast", "--skip-system-headers", "status"]).unwrap();
     assert!(global.fast);
     assert!(global.skip_system_headers);
     assert!(!global.scan_system_headers);

--- a/crates/zccache-cli-core/src/cli/commands/wrap.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap.rs
@@ -17,9 +17,7 @@ use std::process::ExitCode;
 
 use super::util::{resolve_endpoint, run_async};
 
-pub(crate) use env::{
-    parse_wrapper_overrides, strip_leading_wrapper_flags, WrapperOverrides,
-};
+pub(crate) use env::{parse_wrapper_overrides, strip_leading_wrapper_flags, WrapperOverrides};
 use routing::WrapperRoute;
 
 /// Wrap a compiler or tool invocation.
@@ -29,10 +27,7 @@ use routing::WrapperRoute;
 ///
 /// If `ZCCACHE_SESSION_ID` is set, uses that session and sends the tool as a
 /// per-request override. If unset, auto-creates an ephemeral session.
-pub(crate) fn run_wrap(
-    args: &[String],
-    overrides: WrapperOverrides,
-) -> ExitCode {
+pub(crate) fn run_wrap(args: &[String], overrides: WrapperOverrides) -> ExitCode {
     diag::emit(args);
 
     if args.is_empty() {

--- a/crates/zccache-cli-core/src/cli/commands/wrap/env.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/env.rs
@@ -71,7 +71,10 @@ pub(crate) fn parse_wrapper_overrides(
 }
 
 fn set_scan_override(overrides: &mut WrapperOverrides, value: bool) -> Result<(), String> {
-    if overrides.scan_system_headers.is_some_and(|current| current != value) {
+    if overrides
+        .scan_system_headers
+        .is_some_and(|current| current != value)
+    {
         return Err(
             "--scan-system-headers conflicts with --skip-system-headers; choose one".to_string(),
         );
@@ -171,10 +174,7 @@ mod tests {
 
         let (overrides, rest) = strip_leading_wrapper_flags(&args).unwrap();
 
-        assert_eq!(
-            overrides.strict_paths,
-            Some(StrictPathsMode::Consistent)
-        );
+        assert_eq!(overrides.strict_paths, Some(StrictPathsMode::Consistent));
         assert_eq!(rest, vec!["rustc", "--strict-paths=absolute"]);
     }
 

--- a/crates/zccache-core/src/config/mod.rs
+++ b/crates/zccache-core/src/config/mod.rs
@@ -122,7 +122,9 @@ pub use resolve::{
 pub struct Config {
     /// Path to the artifact cache directory.
     pub cache_dir: NormalizedPath,
-    /// Maximum artifact cache size in bytes.
+    /// Deprecated compatibility value retained for serialized config/API
+    /// stability. Runtime retention ignores it and uses the dynamic budget or
+    /// `ZCCACHE_CACHE_SIZE_BYTES` / `ZCCACHE_CACHE_SIZE_PERCENT`.
     pub max_cache_size: u64,
     /// Daemon idle timeout in seconds before auto-shutdown.
     pub idle_timeout_secs: u64,
@@ -136,7 +138,9 @@ pub struct Config {
     pub max_memory_bytes: u64,
     /// How often (in seconds) the memory eviction background task runs (default: 30).
     pub eviction_interval_secs: u64,
-    /// How often (in seconds) the disk artifact GC task runs (default: 300).
+    /// Deprecated compatibility value retained for serialized config/API
+    /// stability. Daemon-owned pressure checks run every five minutes and full
+    /// age maintenance every 24 hours.
     pub disk_gc_interval_secs: u64,
 }
 
@@ -144,7 +148,10 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             cache_dir: default_cache_dir(),
-            max_cache_size: 10 * 1024 * 1024 * 1024, // 10 GB
+            // Compatibility field for callers that still inspect Config.
+            // Runtime disk maintenance now uses a dynamic 5% filesystem
+            // budget clamped to 40-200 GiB (issue #1148).
+            max_cache_size: 40 * 1024 * 1024 * 1024,
             idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
             enable_watcher: true,
             watcher_poll_fallback: false,

--- a/crates/zccache-daemon-core/src/daemon/eviction.rs
+++ b/crates/zccache-daemon-core/src/daemon/eviction.rs
@@ -3,20 +3,25 @@
 //! Estimates in-memory cache size using per-entry constants and evicts
 //! entries in priority order when the total exceeds the configured budget.
 //!
-//! Disk artifact eviction (`evict_disk_artifacts`) is separate: it enforces
-//! `max_cache_size` by removing the oldest `.meta` + data files from the
-//! artifact directory.
+//! The legacy fixed-size disk helper remains test-only; production disk
+//! retention is daemon-owned in `server::disk_maintenance` (issue #1148).
 
+#[cfg(test)]
 use crate::core::NormalizedPath;
 use crate::depgraph::{ContextKey, DepGraph};
 use crate::fscache::CacheSystem;
 use dashmap::DashMap;
+#[cfg(test)]
 use std::collections::HashMap;
+#[cfg(test)]
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+#[cfg(test)]
 use super::server::persist::{evict_v2_artifact_keys, scan_v2_disk_artifacts};
-use super::server::{remove_cow_blob, CachedArtifact, FastHitEntry};
+#[cfg(test)]
+use super::server::remove_cow_blob;
+use super::server::{CachedArtifact, FastHitEntry};
 
 /// Estimated bytes per metadata cache entry.
 const METADATA_ENTRY_BYTES: usize = 400;
@@ -35,7 +40,9 @@ const ARTIFACT_OVERHEAD_BYTES: usize = 200;
 /// cache, but recently-cached entries — including those being filled
 /// in-flight when the trim races — survive. (#454)
 const FAST_HIT_BUDGET_TRIM_MAX_AGE: Duration = Duration::from_secs(5);
+#[cfg(test)]
 const DISK_EVICTION_SCAN_YIELD_EVERY: usize = 512;
+#[cfg(test)]
 const DISK_EVICTION_DELETE_BATCH_SIZE: usize = 64;
 
 /// Snapshot of estimated memory usage across all in-memory caches.
@@ -111,7 +118,8 @@ pub(crate) fn memory_snapshot(
 /// 3. Depgraph contexts + orphaned files (rebuilt on next compile)
 ///
 /// Artifacts are **not** evicted here — disk GC (`evict_disk_artifacts`)
-/// handles artifact lifecycle based on `max_cache_size`.
+/// is retained only for legacy unit coverage; daemon-owned disk maintenance
+/// handles production artifact lifecycle using the shared retention policy.
 ///
 /// Evicts to 90% of budget to avoid thrashing.
 ///
@@ -219,6 +227,7 @@ fn trim_fast_hit_cache_two_pass(
 // ── Disk artifact eviction ──────────────────────────────────────────────
 
 /// Info about one artifact group on disk (`.meta` + data files).
+#[cfg(test)]
 struct DiskArtifact {
     key: String,
     total_size: u64,
@@ -245,6 +254,7 @@ struct DiskArtifact {
 /// in this module) pass `None`.
 ///
 /// Returns `(bytes_freed, artifacts_removed)`.
+#[cfg(test)]
 pub(crate) fn evict_disk_artifacts(
     artifact_dir: &Path,
     artifacts: &DashMap<String, CachedArtifact>,
@@ -679,6 +689,9 @@ mod tests {
                 std::sync::Arc::new(vec![0u8; payload_size]),
             )])),
             last_used: Instant::now(),
+            last_used_wall: std::time::SystemTime::now(),
+            used_in_process: true,
+            last_access_checkpoint: Some(Instant::now()),
         }
     }
 

--- a/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
@@ -32,6 +32,13 @@ pub(crate) struct CachedArtifact {
     pub(crate) payloads: Option<Arc<[CachedPayload]>>,
     /// When this artifact was last used (inserted or returned as a hit).
     pub(crate) last_used: std::time::Instant,
+    /// Wall-clock last use used by durable retention across reboots.
+    pub(crate) last_used_wall: std::time::SystemTime,
+    /// Whether `last_used` represents a real access in this process.
+    pub(crate) used_in_process: bool,
+    /// Last time this process checkpointed wall-clock access to the index.
+    /// Restored entries use `None`, so their first hit is persisted promptly.
+    pub(crate) last_access_checkpoint: Option<std::time::Instant>,
 }
 
 impl CachedArtifact {
@@ -50,6 +57,7 @@ impl CachedArtifact {
             Arc::clone(&artifact.stderr),
             artifact.exit_code,
         );
+        let now = std::time::Instant::now();
         Self {
             meta,
             stdout: Arc::clone(&artifact.stdout),
@@ -64,7 +72,10 @@ impl CachedArtifact {
                     })
                     .collect::<Vec<_>>(),
             )),
-            last_used: std::time::Instant::now(),
+            last_used: now,
+            last_used_wall: std::time::SystemTime::now(),
+            used_in_process: true,
+            last_access_checkpoint: Some(now),
         }
     }
 
@@ -72,6 +83,7 @@ impl CachedArtifact {
     pub(super) fn from_file_payloads(meta: ArtifactIndex, payloads: Vec<NormalizedPath>) -> Self {
         let stdout = Arc::clone(&meta.stdout);
         let stderr = Arc::clone(&meta.stderr);
+        let now = std::time::Instant::now();
         Self {
             meta,
             stdout,
@@ -82,7 +94,10 @@ impl CachedArtifact {
                     .map(CachedPayload::File)
                     .collect::<Vec<_>>(),
             )),
-            last_used: std::time::Instant::now(),
+            last_used: now,
+            last_used_wall: std::time::SystemTime::now(),
+            used_in_process: true,
+            last_access_checkpoint: Some(now),
         }
     }
 
@@ -90,12 +105,20 @@ impl CachedArtifact {
     pub(super) fn from_index(meta: ArtifactIndex) -> Self {
         let stdout = Arc::clone(&meta.stdout);
         let stderr = Arc::clone(&meta.stderr);
+        let stored_at = std::time::UNIX_EPOCH
+            .checked_add(std::time::Duration::from_secs(meta.stored_at_secs))
+            .unwrap_or(std::time::UNIX_EPOCH);
         Self {
             meta,
             stdout,
             stderr,
             payloads: None,
             last_used: std::time::Instant::now(),
+            // Keep durable age in wall-clock form. Reconstructing it as an
+            // Instant fails when the entry predates system uptime on Windows.
+            last_used_wall: stored_at.min(std::time::SystemTime::now()),
+            used_in_process: false,
+            last_access_checkpoint: None,
         }
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/dependency_policy.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/dependency_policy.rs
@@ -17,9 +17,7 @@ pub(super) enum DependencyDiscoveryMode {
 }
 
 impl DependencyDiscoveryMode {
-    pub(super) fn from_client_env(
-        client_env: Option<&[(String, String)]>,
-    ) -> Result<Self, String> {
+    pub(super) fn from_client_env(client_env: Option<&[(String, String)]>) -> Result<Self, String> {
         if let Some(value) = client_env_value(client_env, SCAN_SYSTEM_HEADERS_ENV) {
             return parse_bool(SCAN_SYSTEM_HEADERS_ENV, value).map(|scan| {
                 if scan {
@@ -54,11 +52,7 @@ impl DependencyDiscoveryMode {
 
     /// Salt C/C++ context keys so a partial fast-mode manifest can never be
     /// reused after the caller switches back to the correctness-first mode.
-    pub(super) fn apply_to_cc_context(
-        self,
-        ctx: &mut CompileContext,
-        dep_flags: &UserDepFlags,
-    ) {
+    pub(super) fn apply_to_cc_context(self, ctx: &mut CompileContext, dep_flags: &UserDepFlags) {
         let marker = match self {
             Self::AllHeaders => "zccache:dependency-discovery=all-headers",
             Self::SkipSystemHeaders => "zccache:dependency-discovery=skip-system-headers",
@@ -148,6 +142,7 @@ impl DependencyDiscoveryMode {
     /// Approximate compiler provenance before a private `-MMD` manifest exists.
     /// A quoted path resolved relative to the including file remains a user
     /// dependency even when both files happen to live beneath a broad SDK root.
+    #[allow(clippy::cmp_owned)] // Normalization is required before comparing a quoted relative path.
     pub(super) fn tracks_static_include(
         self,
         including_file: &Path,
@@ -158,9 +153,10 @@ impl DependencyDiscoveryMode {
         if matches!(
             directive.kind,
             crate::depgraph::scanner::IncludeKind::Quoted
-        ) && including_file.parent().is_some_and(|parent| {
-            NormalizedPath::from(parent.join(&directive.path)) == *path
-        }) {
+        ) && including_file
+            .parent()
+            .is_some_and(|parent| NormalizedPath::from(parent.join(&directive.path)) == *path)
+        {
             return true;
         }
         self.tracks_header(path, include_search)
@@ -250,8 +246,7 @@ mod tests {
         let system_header: NormalizedPath = "/sdk/stdlib/vector".into();
         let mut headers = vec![user_header.clone(), system_header.clone()];
 
-        DependencyDiscoveryMode::SkipSystemHeaders
-            .retain_tracked_headers(&mut headers, &search);
+        DependencyDiscoveryMode::SkipSystemHeaders.retain_tracked_headers(&mut headers, &search);
 
         assert_eq!(headers, vec![user_header]);
     }
@@ -268,12 +263,14 @@ mod tests {
             line: 1,
         };
 
-        assert!(DependencyDiscoveryMode::SkipSystemHeaders.tracks_static_include(
-            Path::new("/sdk/project/main.cpp"),
-            &directive,
-            &NormalizedPath::from("/sdk/project/config.hpp"),
-            &search,
-        ));
+        assert!(
+            DependencyDiscoveryMode::SkipSystemHeaders.tracks_static_include(
+                Path::new("/sdk/project/main.cpp"),
+                &directive,
+                &NormalizedPath::from("/sdk/project/config.hpp"),
+                &search,
+            )
+        );
     }
 
     #[test]
@@ -284,8 +281,7 @@ mod tests {
             has_computed: false,
         };
 
-        DependencyDiscoveryMode::AllHeaders
-            .apply_static_fallback(&mut result, &Default::default());
+        DependencyDiscoveryMode::AllHeaders.apply_static_fallback(&mut result, &Default::default());
 
         assert!(result.has_computed);
     }
@@ -338,11 +334,8 @@ mod tests {
             "explicit.o",
             "-MP",
         ]);
-        let moved_depfile = context_for(&[
-            "-c", "main.c", "-o", "a.o", "-MD", "-MF", "other.d",
-        ]);
-        let stdout_depfile =
-            context_for(&["-c", "main.c", "-o", "a.o", "-MD", "-MF", "-"]);
+        let moved_depfile = context_for(&["-c", "main.c", "-o", "a.o", "-MD", "-MF", "other.d"]);
+        let stdout_depfile = context_for(&["-c", "main.c", "-o", "a.o", "-MD", "-MF", "-"]);
 
         assert_ne!(output_a, output_b);
         assert_ne!(output_a, target);

--- a/crates/zccache-daemon-core/src/daemon/server/directory_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/directory_link.rs
@@ -66,3 +66,16 @@ pub(super) fn cache_staged_directory_link(
     }
     Ok(())
 }
+
+/// Deliver a successful staged directory link without admitting it to the
+/// cache. Used when shutdown has closed the publication barrier to late
+/// arrivals but the caller's requested output must still be materialized.
+pub(super) fn materialize_uncached_staged_directory_link(
+    state: &SharedState,
+    plan: &StagedDirectoryPlan,
+) -> std::io::Result<()> {
+    if let Err(error) = plan.pack() {
+        tracing::warn!(%error, "directory output is not bundle-cacheable");
+    }
+    materialize_directory_plan_observed(state, plan, None)
+}

--- a/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
@@ -1,0 +1,875 @@
+//! Shared bounded disk-retention policy for standalone and embedded services.
+//!
+//! Every entry point receives one exact artifact root.  This module never
+//! discovers a parent directory or a sibling product root (issue #1148).
+
+use super::*;
+use std::collections::{HashMap, HashSet};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+pub(crate) const CACHE_BYTES_ENV: &str = "ZCCACHE_CACHE_SIZE_BYTES";
+pub(crate) const CACHE_PERCENT_ENV: &str = "ZCCACHE_CACHE_SIZE_PERCENT";
+const GIB: u64 = 1024 * 1024 * 1024;
+const SOFT_AGE: Duration = Duration::from_secs(4 * 24 * 60 * 60);
+const EXPIRE_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+const PRESSURE_INTERVAL: Duration = Duration::from_secs(5 * 60);
+const FULL_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+const FULL_MARKER: &str = ".disk-maintenance-last-full-v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MaintenanceKind {
+    Pressure,
+    Full,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BudgetSpec {
+    Dynamic,
+    Bytes(u64),
+    Percent(u8),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MaintenancePolicy {
+    budget: BudgetSpec,
+}
+
+impl Default for MaintenancePolicy {
+    fn default() -> Self {
+        Self {
+            budget: BudgetSpec::Dynamic,
+        }
+    }
+}
+
+impl MaintenancePolicy {
+    pub(crate) fn from_env() -> Result<Self, String> {
+        Self::from_values(
+            std::env::var(CACHE_BYTES_ENV).ok().as_deref(),
+            std::env::var(CACHE_PERCENT_ENV).ok().as_deref(),
+        )
+    }
+
+    fn from_values(bytes: Option<&str>, percent: Option<&str>) -> Result<Self, String> {
+        match (
+            bytes.filter(|v| !v.trim().is_empty()),
+            percent.filter(|v| !v.trim().is_empty()),
+        ) {
+            (Some(_), Some(_)) => Err(format!(
+                "{CACHE_BYTES_ENV} and {CACHE_PERCENT_ENV} are mutually exclusive"
+            )),
+            (Some(value), None) => {
+                let bytes = value.parse::<u64>().map_err(|_| {
+                    format!("{CACHE_BYTES_ENV} must be a positive integer byte count")
+                })?;
+                if bytes == 0 {
+                    return Err(format!("{CACHE_BYTES_ENV} must be greater than zero"));
+                }
+                Ok(Self {
+                    budget: BudgetSpec::Bytes(bytes),
+                })
+            }
+            (None, Some(value)) => {
+                let percent = value.parse::<u8>().map_err(|_| {
+                    format!("{CACHE_PERCENT_ENV} must be an integer from 1 through 100")
+                })?;
+                if !(1..=100).contains(&percent) {
+                    return Err(format!(
+                        "{CACHE_PERCENT_ENV} must be an integer from 1 through 100"
+                    ));
+                }
+                Ok(Self {
+                    budget: BudgetSpec::Percent(percent),
+                })
+            }
+            (None, None) => Ok(Self::default()),
+        }
+    }
+
+    pub(crate) fn from_limits(bytes: Option<u64>, percent: Option<u8>) -> Result<Self, String> {
+        match (bytes, percent) {
+            (Some(_), Some(_)) => {
+                Err("max_cache_bytes and max_cache_percent are mutually exclusive".to_string())
+            }
+            (Some(0), None) => Err("max_cache_bytes must be greater than zero".to_string()),
+            (Some(bytes), None) => Ok(Self {
+                budget: BudgetSpec::Bytes(bytes),
+            }),
+            (None, Some(percent)) if !(1..=100).contains(&percent) => {
+                Err("max_cache_percent must be an integer from 1 through 100".to_string())
+            }
+            (None, Some(percent)) => Ok(Self {
+                budget: BudgetSpec::Percent(percent),
+            }),
+            (None, None) => Ok(Self::default()),
+        }
+    }
+
+    fn budget_bytes(self, capacity_bytes: u64) -> u64 {
+        let requested = match self.budget {
+            BudgetSpec::Dynamic => capacity_bytes
+                .saturating_mul(5)
+                .checked_div(100)
+                .unwrap_or(0)
+                .clamp(40 * GIB, 200 * GIB),
+            BudgetSpec::Bytes(bytes) => bytes,
+            BudgetSpec::Percent(percent) => capacity_bytes
+                .saturating_mul(u64::from(percent))
+                .checked_div(100)
+                .unwrap_or(0),
+        };
+        // Keep the requested recovery reserve attainable on ordinary disks.
+        // On small disks, half the volume is the largest feasible reserve.
+        let recovery_reserve = recovery_free_bytes(capacity_bytes);
+        requested.min(capacity_bytes.saturating_sub(recovery_reserve))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FilesystemSpace {
+    pub(crate) capacity_bytes: u64,
+    pub(crate) free_bytes: u64,
+}
+
+pub(crate) trait MaintenanceEnvironment: Send + Sync {
+    fn now(&self) -> SystemTime;
+    fn filesystem_space(&self, root: &Path) -> io::Result<FilesystemSpace>;
+}
+
+pub(crate) struct RealMaintenanceEnvironment;
+
+impl MaintenanceEnvironment for RealMaintenanceEnvironment {
+    fn now(&self) -> SystemTime {
+        SystemTime::now()
+    }
+
+    fn filesystem_space(&self, root: &Path) -> io::Result<FilesystemSpace> {
+        Ok(FilesystemSpace {
+            capacity_bytes: fs2::total_space(root)?,
+            free_bytes: fs2::available_space(root)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MaintenancePressure {
+    None,
+    Soft,
+    Hard,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DiskMaintenanceReport {
+    pub(crate) kind: MaintenanceKind,
+    pub(crate) pressure: MaintenancePressure,
+    pub(crate) budget_bytes: u64,
+    pub(crate) usage_before_bytes: u64,
+    pub(crate) usage_after_bytes: u64,
+    pub(crate) bytes_reclaimed: u64,
+    pub(crate) artifacts_removed: usize,
+    pub(crate) expired_artifacts_removed: usize,
+    pub(crate) pending_write_bytes: u64,
+}
+
+#[derive(Debug)]
+struct DiskArtifact {
+    key: String,
+    allocated_bytes: u64,
+    last_access: SystemTime,
+    legacy_files: Vec<PathBuf>,
+    staged: bool,
+    staged_generation: Option<String>,
+}
+
+#[derive(Debug)]
+struct MaintenancePlan {
+    pressure: MaintenancePressure,
+    selected: Vec<String>,
+    expired: HashSet<String>,
+}
+
+fn low_space_bytes(capacity: u64) -> u64 {
+    capacity
+        .saturating_mul(5)
+        .checked_div(100)
+        .unwrap_or(0)
+        .max(20 * GIB)
+        .min(capacity)
+}
+
+fn recovery_free_bytes(capacity: u64) -> u64 {
+    let desired = capacity
+        .saturating_mul(8)
+        .checked_div(100)
+        .unwrap_or(0)
+        .max(30 * GIB);
+    // On small volumes the absolute 30 GiB target is not simultaneously
+    // attainable with a useful cache. Reserve at most half the volume so the
+    // dynamic budget remains non-zero (and exceeds 10 GiB once capacity is
+    // above 20 GiB).
+    desired.min(capacity / 2)
+}
+
+fn age(now: SystemTime, then: SystemTime) -> Duration {
+    now.duration_since(then).unwrap_or_default()
+}
+
+#[cfg(test)]
+fn plan_maintenance(
+    policy: MaintenancePolicy,
+    kind: MaintenanceKind,
+    now: SystemTime,
+    space: FilesystemSpace,
+    artifacts: &[DiskArtifact],
+    pending_write_bytes: u64,
+) -> MaintenancePlan {
+    plan_maintenance_at_least(
+        policy,
+        kind,
+        now,
+        space,
+        artifacts,
+        pending_write_bytes,
+        MaintenancePressure::None,
+    )
+}
+
+fn plan_maintenance_at_least(
+    policy: MaintenancePolicy,
+    kind: MaintenanceKind,
+    now: SystemTime,
+    space: FilesystemSpace,
+    artifacts: &[DiskArtifact],
+    pending_write_bytes: u64,
+    minimum_pressure: MaintenancePressure,
+) -> MaintenancePlan {
+    let budget = policy.budget_bytes(space.capacity_bytes);
+    let artifact_bytes = artifacts.iter().fold(0_u64, |total, artifact| {
+        total.saturating_add(artifact.allocated_bytes)
+    });
+    let usage = artifact_bytes.saturating_add(pending_write_bytes);
+    let mut selected = HashSet::new();
+    let mut reclaimed = 0_u64;
+    let mut expired = HashSet::new();
+
+    if kind == MaintenanceKind::Full {
+        for artifact in artifacts
+            .iter()
+            .filter(|artifact| age(now, artifact.last_access) > EXPIRE_AGE)
+        {
+            selected.insert(artifact.key.clone());
+            expired.insert(artifact.key.clone());
+            reclaimed = reclaimed.saturating_add(artifact.allocated_bytes);
+        }
+    }
+
+    let projected_usage = usage.saturating_sub(reclaimed);
+    let projected_free = space.free_bytes.saturating_add(reclaimed);
+    let hard = projected_usage >= budget || projected_free < low_space_bytes(space.capacity_bytes);
+    let soft = !hard && projected_usage >= budget.saturating_mul(85) / 100;
+    let detected_pressure = if hard {
+        MaintenancePressure::Hard
+    } else if soft {
+        MaintenancePressure::Soft
+    } else {
+        MaintenancePressure::None
+    };
+    let pressure = match (minimum_pressure, detected_pressure) {
+        (MaintenancePressure::Hard, _) | (_, MaintenancePressure::Hard) => {
+            MaintenancePressure::Hard
+        }
+        (MaintenancePressure::Soft, _) | (_, MaintenancePressure::Soft) => {
+            MaintenancePressure::Soft
+        }
+        _ => MaintenancePressure::None,
+    };
+
+    let desired_reclaim = match pressure {
+        MaintenancePressure::Hard => {
+            let usage_need = projected_usage.saturating_sub(budget.saturating_mul(80) / 100);
+            let free_need =
+                recovery_free_bytes(space.capacity_bytes).saturating_sub(projected_free);
+            usage_need.max(free_need)
+        }
+        MaintenancePressure::Soft => {
+            projected_usage.saturating_sub(budget.saturating_mul(70) / 100)
+        }
+        MaintenancePressure::None => 0,
+    };
+
+    if desired_reclaim > 0 {
+        let mut candidates: Vec<&DiskArtifact> = artifacts
+            .iter()
+            .filter(|artifact| !selected.contains(&artifact.key))
+            .filter(|artifact| {
+                pressure == MaintenancePressure::Hard || age(now, artifact.last_access) > SOFT_AGE
+            })
+            .collect();
+        candidates.sort_by_key(|artifact| artifact.last_access);
+        let mut pressure_reclaimed = 0_u64;
+        for artifact in candidates {
+            if pressure_reclaimed >= desired_reclaim {
+                break;
+            }
+            selected.insert(artifact.key.clone());
+            pressure_reclaimed = pressure_reclaimed.saturating_add(artifact.allocated_bytes);
+        }
+    }
+
+    let mut selected: Vec<String> = selected.into_iter().collect();
+    selected.sort();
+    MaintenancePlan {
+        pressure,
+        selected,
+        expired,
+    }
+}
+
+fn add_file(
+    path: &Path,
+    artifact: &mut DiskArtifact,
+    seen: &mut HashSet<FileId>,
+) -> io::Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_file() {
+        return Ok(());
+    }
+    artifact.last_access = artifact
+        .last_access
+        .max(metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH));
+    if get_file_id(path).is_none_or(|id| seen.insert(id)) {
+        artifact.allocated_bytes = artifact
+            .allocated_bytes
+            .saturating_add(allocated_bytes(path, &metadata));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn allocated_bytes(_path: &Path, metadata: &std::fs::Metadata) -> u64 {
+    use std::os::unix::fs::MetadataExt;
+    metadata.blocks().saturating_mul(512)
+}
+
+#[cfg(not(unix))]
+fn allocated_bytes(path: &Path, metadata: &std::fs::Metadata) -> u64 {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Foundation::{GetLastError, SetLastError};
+    use windows_sys::Win32::Storage::FileSystem::GetCompressedFileSizeW;
+
+    let path = windows_verbatim_file_path(path).unwrap_or_else(|_| path.to_path_buf());
+    let wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    let mut high = 0_u32;
+    unsafe {
+        SetLastError(0);
+        let low = GetCompressedFileSizeW(wide.as_ptr(), &mut high);
+        windows_allocated_size_result(low, high, GetLastError(), metadata.len())
+    }
+}
+
+#[cfg(any(test, windows))]
+fn windows_allocated_size_result(low: u32, high: u32, error: u32, fallback: u64) -> u64 {
+    if low == u32::MAX && error != 0 {
+        fallback
+    } else {
+        (u64::from(high) << 32) | u64::from(low)
+    }
+}
+
+#[cfg(windows)]
+fn is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(not(windows))]
+fn is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
+    metadata.file_type().is_symlink()
+}
+
+fn validate_owned_artifact_root(artifact_dir: &Path) -> io::Result<()> {
+    let metadata = std::fs::symlink_metadata(artifact_dir)?;
+    if is_link_or_reparse(&metadata) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing disk maintenance through linked artifact root: {}",
+                artifact_dir.display()
+            ),
+        ));
+    }
+    if !metadata.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "artifact root is not a directory: {}",
+                artifact_dir.display()
+            ),
+        ));
+    }
+    validate_staged_artifact_root(artifact_dir)?;
+    Ok(())
+}
+
+fn add_tree(
+    root: &Path,
+    artifact: &mut DiskArtifact,
+    seen: &mut HashSet<FileId>,
+) -> io::Result<()> {
+    if root.is_file() {
+        return add_file(root, artifact, seen);
+    }
+    if !root.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(root)?.flatten() {
+        let path = entry.path();
+        let metadata = std::fs::symlink_metadata(&path)?;
+        if is_link_or_reparse(&metadata) {
+            continue;
+        }
+        if metadata.is_dir() {
+            add_tree(&path, artifact, seen)?;
+        } else if metadata.is_file() {
+            add_file(&path, artifact, seen)?;
+        }
+    }
+    Ok(())
+}
+
+fn legacy_key(name: &str) -> Option<&str> {
+    if name.starts_with('.') {
+        return None;
+    }
+    let key = name
+        .strip_suffix(".meta")
+        .or_else(|| name.strip_suffix(".pack"))
+        .or_else(|| {
+            let (key, output) = name.rsplit_once('_')?;
+            output
+                .bytes()
+                .all(|byte| byte.is_ascii_digit())
+                .then_some(key)
+        })?;
+    (key.len() <= 128 && !key.is_empty()).then_some(key)
+}
+
+fn scan_artifacts(artifact_dir: &Path) -> io::Result<Vec<DiskArtifact>> {
+    let mut groups: HashMap<String, DiskArtifact> = HashMap::new();
+    let mut seen = HashSet::new();
+    if !artifact_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    for entry in std::fs::read_dir(artifact_dir)?.flatten() {
+        let path = entry.path();
+        if !entry.file_type().is_ok_and(|kind| kind.is_file()) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let Some(key) = legacy_key(&name) else {
+            continue;
+        };
+        let artifact = groups
+            .entry(key.to_string())
+            .or_insert_with(|| DiskArtifact {
+                key: key.to_string(),
+                allocated_bytes: 0,
+                last_access: SystemTime::UNIX_EPOCH,
+                legacy_files: Vec::new(),
+                staged: false,
+                staged_generation: None,
+            });
+        add_file(&path, artifact, &mut seen)?;
+        artifact.legacy_files.push(path);
+    }
+
+    let staged_root = artifact_dir.join(".staged-v2");
+    for staged in scan_v2_disk_artifacts(artifact_dir)? {
+        let key = staged.key;
+        let artifact = groups.entry(key.clone()).or_insert_with(|| DiskArtifact {
+            key: key.clone(),
+            allocated_bytes: 0,
+            last_access: SystemTime::UNIX_EPOCH,
+            legacy_files: Vec::new(),
+            staged: true,
+            staged_generation: None,
+        });
+        artifact.staged = true;
+        artifact.staged_generation = staged.generation;
+        artifact.last_access = artifact.last_access.max(staged.mtime);
+        add_tree(&staged_root.join(&key), artifact, &mut seen)?;
+        add_file(
+            &staged_root.join(format!("{key}.current")),
+            artifact,
+            &mut seen,
+        )
+        .ok();
+    }
+    Ok(groups.into_values().collect())
+}
+
+struct MaintenancePass<'a> {
+    artifact_dir: &'a Path,
+    artifacts: &'a DashMap<String, CachedArtifact>,
+    artifact_store: &'a ArtifactStore,
+    index_writer_tx: Option<&'a tokio::sync::mpsc::UnboundedSender<IndexWriterCommand>>,
+    dep_graph: &'a DepGraph,
+    pending_write_bytes: u64,
+    policy: MaintenancePolicy,
+    kind: MaintenanceKind,
+    environment: &'a dyn MaintenanceEnvironment,
+}
+
+fn refresh_live_access(
+    scanned: &mut [DiskArtifact],
+    artifacts: &DashMap<String, CachedArtifact>,
+    now: SystemTime,
+) {
+    for artifact in scanned {
+        if let Some(cached) = artifacts.get(&artifact.key) {
+            let live_last_use = if cached.used_in_process {
+                now.checked_sub(cached.last_used.elapsed()).unwrap_or(now)
+            } else {
+                cached.last_used_wall.min(now)
+            };
+            artifact.last_access = artifact.last_access.max(live_last_use);
+        }
+    }
+}
+
+fn remove_planned_artifacts(
+    artifact_dir: &Path,
+    scanned: &[DiskArtifact],
+    plan: &MaintenancePlan,
+    artifacts: &DashMap<String, CachedArtifact>,
+    artifact_store: &ArtifactStore,
+    index_writer_tx: Option<&tokio::sync::mpsc::UnboundedSender<IndexWriterCommand>>,
+    dep_graph: &DepGraph,
+) -> io::Result<Vec<String>> {
+    let planned: HashSet<&str> = plan.selected.iter().map(String::as_str).collect();
+    let staged_expected: HashMap<String, Option<String>> = scanned
+        .iter()
+        .filter(|artifact| artifact.staged && planned.contains(artifact.key.as_str()))
+        .map(|artifact| (artifact.key.clone(), artifact.staged_generation.clone()))
+        .collect();
+    let staged_removed = evict_v2_artifact_keys_if_unchanged(artifact_dir, &staged_expected)?;
+    let selected: HashSet<&str> = scanned
+        .iter()
+        .filter(|artifact| {
+            planned.contains(artifact.key.as_str())
+                && (!artifact.staged || staged_removed.contains(&artifact.key))
+        })
+        .map(|artifact| artifact.key.as_str())
+        .collect();
+    for artifact in scanned
+        .iter()
+        .filter(|artifact| selected.contains(artifact.key.as_str()))
+    {
+        for file in &artifact.legacy_files {
+            if let Err(error) = remove_cow_blob(file) {
+                if error.kind() != io::ErrorKind::NotFound {
+                    return Err(error);
+                }
+            }
+        }
+    }
+    let removed_keys: Vec<String> = plan
+        .selected
+        .iter()
+        .filter(|key| selected.contains(key.as_str()))
+        .cloned()
+        .collect();
+    if removed_keys.is_empty() {
+        return Ok(removed_keys);
+    }
+
+    let keys: Vec<&str> = removed_keys.iter().map(String::as_str).collect();
+    // Remove the fallback source before the live map. A cache hit that
+    // already holds a DashMap guard can finish and enqueue its access
+    // checkpoint; `remove` waits for that guard, and the subsequent Remove
+    // command is ordered after every such Insert. New lookups cannot
+    // rehydrate the entry from ArtifactStore in the gap.
+    artifact_store.remove_batch(&keys);
+    dep_graph.invalidate_artifact_keys(&removed_keys.iter().cloned().collect());
+    for key in &removed_keys {
+        artifacts.remove(key);
+    }
+    if let Some(tx) = index_writer_tx {
+        let _ = tx.send(IndexWriterCommand::Remove(removed_keys.clone()));
+    }
+    Ok(removed_keys)
+}
+
+fn maintain_disk_artifacts(pass: MaintenancePass<'_>) -> io::Result<DiskMaintenanceReport> {
+    let MaintenancePass {
+        artifact_dir,
+        artifacts,
+        artifact_store,
+        index_writer_tx,
+        dep_graph,
+        pending_write_bytes,
+        policy,
+        kind,
+        environment,
+    } = pass;
+
+    validate_owned_artifact_root(artifact_dir)?;
+    let now = environment.now();
+    let initial_space = environment.filesystem_space(artifact_dir)?;
+    let mut scanned = scan_artifacts(artifact_dir)?;
+    refresh_live_access(&mut scanned, artifacts, now);
+    let usage_before = scanned.iter().fold(pending_write_bytes, |total, artifact| {
+        total.saturating_add(artifact.allocated_bytes)
+    });
+    let mut pressure = MaintenancePressure::None;
+    let mut removed = HashSet::new();
+    let mut expired_removed = HashSet::new();
+
+    loop {
+        let space = environment.filesystem_space(artifact_dir)?;
+        let plan = plan_maintenance_at_least(
+            policy,
+            kind,
+            now,
+            space,
+            &scanned,
+            pending_write_bytes,
+            pressure,
+        );
+        pressure = plan.pressure;
+        let removed_this_round = remove_planned_artifacts(
+            artifact_dir,
+            &scanned,
+            &plan,
+            artifacts,
+            artifact_store,
+            index_writer_tx,
+            dep_graph,
+        )?;
+        if removed_this_round.is_empty() {
+            break;
+        }
+        for key in removed_this_round {
+            if plan.expired.contains(&key) {
+                expired_removed.insert(key.clone());
+            }
+            removed.insert(key);
+        }
+        scanned = scan_artifacts(artifact_dir)?;
+        refresh_live_access(&mut scanned, artifacts, now);
+    }
+
+    let usage_after = scanned.iter().fold(pending_write_bytes, |total, artifact| {
+        total.saturating_add(artifact.allocated_bytes)
+    });
+    Ok(DiskMaintenanceReport {
+        kind,
+        pressure,
+        budget_bytes: policy.budget_bytes(initial_space.capacity_bytes),
+        usage_before_bytes: usage_before,
+        usage_after_bytes: usage_after,
+        bytes_reclaimed: usage_before.saturating_sub(usage_after),
+        artifacts_removed: removed.len(),
+        expired_artifacts_removed: expired_removed.len(),
+        pending_write_bytes,
+    })
+}
+
+fn full_marker_path(cache_dir: &Path) -> PathBuf {
+    cache_dir.join(FULL_MARKER)
+}
+
+fn full_maintenance_due(cache_dir: &Path, now: SystemTime) -> bool {
+    let Ok(contents) = std::fs::read_to_string(full_marker_path(cache_dir)) else {
+        return true;
+    };
+    let Ok(last_secs) = contents.trim().parse::<u64>() else {
+        return true;
+    };
+    let now_secs = now
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    last_secs > now_secs || now_secs - last_secs >= FULL_INTERVAL.as_secs()
+}
+
+fn record_full_maintenance(cache_dir: &Path, now: SystemTime) -> io::Result<()> {
+    std::fs::create_dir_all(cache_dir)?;
+    let marker = full_marker_path(cache_dir);
+    let temp = cache_dir.join(format!("{FULL_MARKER}.{}.tmp", std::process::id()));
+    let now_secs = now
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    std::fs::write(&temp, format!("{now_secs}\n"))?;
+    match std::fs::rename(&temp, &marker) {
+        Ok(()) => Ok(()),
+        Err(error) if marker.exists() => {
+            std::fs::remove_file(&marker)?;
+            std::fs::rename(&temp, &marker).map_err(|_| error)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+pub(super) async fn maintain_state_disk(
+    state: Arc<SharedState>,
+    policy: MaintenancePolicy,
+    kind: MaintenanceKind,
+) -> io::Result<DiskMaintenanceReport> {
+    let _maintenance_guard = state.disk_maintenance.lock().await;
+    if state.shutdown_requested.load(Ordering::Acquire) {
+        return Err(io::Error::new(
+            io::ErrorKind::Interrupted,
+            "disk maintenance skipped because daemon shutdown is in progress",
+        ));
+    }
+    let _publication_guard = state.artifact_publication.write().await;
+    let cache_dir = state.cache_dir.clone();
+    let index_writer_tx = state.index_writer_tx.clone();
+    let maintenance_index_writer_tx = index_writer_tx.clone();
+    let pending_write_bytes = state.in_flight_bytes.load(Ordering::Relaxed) as u64;
+    let maintenance_state = Arc::clone(&state);
+    let report = tokio::task::spawn_blocking(move || {
+        let dep_graph = maintenance_state.dep_graph.load_full();
+        maintain_disk_artifacts(MaintenancePass {
+            artifact_dir: maintenance_state.artifact_dir.as_path(),
+            artifacts: &maintenance_state.artifacts,
+            artifact_store: &maintenance_state.artifact_store,
+            index_writer_tx: Some(&maintenance_index_writer_tx),
+            dep_graph: &dep_graph,
+            pending_write_bytes,
+            policy,
+            kind,
+            environment: &RealMaintenanceEnvironment,
+        })
+    })
+    .await
+    .map_err(io::Error::other)??;
+
+    if report.artifacts_removed > 0
+        && !flush_index_writer(&index_writer_tx, Duration::from_secs(30)).await
+    {
+        return Err(io::Error::other(
+            "artifact-index removals did not flush before the maintenance deadline",
+        ));
+    }
+
+    if kind == MaintenanceKind::Full {
+        record_full_maintenance(cache_dir.as_path(), SystemTime::now())?;
+    }
+    tracing::info!(
+        maintenance_kind = ?report.kind,
+        pressure = ?report.pressure,
+        budget_bytes = report.budget_bytes,
+        usage_before_bytes = report.usage_before_bytes,
+        usage_after_bytes = report.usage_after_bytes,
+        bytes_reclaimed = report.bytes_reclaimed,
+        artifacts_removed = report.artifacts_removed,
+        expired_artifacts_removed = report.expired_artifacts_removed,
+        pending_write_bytes = report.pending_write_bytes,
+        cache_root = %cache_dir.display(),
+        "disk maintenance pass complete"
+    );
+    Ok(report)
+}
+
+async fn wait_for_artifact_load(state: &SharedState) -> bool {
+    loop {
+        if state.shutdown_requested.load(Ordering::Acquire) {
+            return false;
+        }
+        if state.artifacts_loaded.load(Ordering::Acquire)
+            && state.dep_graph_load_complete.load(Ordering::Acquire)
+        {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+fn pressure_scan_needed(state: &SharedState, policy: MaintenancePolicy) -> io::Result<bool> {
+    let space = RealMaintenanceEnvironment.filesystem_space(state.artifact_dir.as_path())?;
+    if space.free_bytes < low_space_bytes(space.capacity_bytes) {
+        return Ok(true);
+    }
+    let indexed = state.artifact_store.total_size_bytes();
+    let pending = state.in_flight_bytes.load(Ordering::Relaxed) as u64;
+    // A deliberately early logical gate keeps ordinary five-minute checks
+    // memory-only. Near half-budget we pay for exact allocated-block/FileId
+    // accounting; daily full passes always do the physical scan.
+    Ok(indexed.saturating_add(pending)
+        >= policy.budget_bytes(space.capacity_bytes).saturating_mul(50) / 100)
+}
+
+pub(super) fn spawn_disk_maintenance(
+    state: Arc<SharedState>,
+    policy: MaintenancePolicy,
+    runtime_handle: Option<&tokio::runtime::Handle>,
+) -> tokio::task::JoinHandle<()> {
+    let task = async move {
+        if !wait_for_artifact_load(&state).await {
+            return;
+        }
+        loop {
+            if state.shutdown_requested.load(Ordering::Acquire) {
+                break;
+            }
+            let kind = if full_maintenance_due(state.cache_dir.as_path(), SystemTime::now()) {
+                MaintenanceKind::Full
+            } else {
+                MaintenanceKind::Pressure
+            };
+            if kind == MaintenanceKind::Pressure {
+                match pressure_scan_needed(&state, policy) {
+                    Ok(false) => {
+                        tracing::debug!(
+                            cache_root = %state.cache_dir.display(),
+                            "disk maintenance skipped exact scan below logical preflight threshold"
+                        );
+                        tokio::select! {
+                            () = tokio::time::sleep(PRESSURE_INTERVAL) => {}
+                            () = state.shutdown.notified() => {}
+                        }
+                        continue;
+                    }
+                    Ok(true) => {}
+                    Err(error) => tracing::warn!(%error, "disk maintenance preflight failed"),
+                }
+            }
+            if let Err(error) = maintain_state_disk(Arc::clone(&state), policy, kind).await {
+                tracing::warn!(
+                    %error,
+                    maintenance_kind = ?kind,
+                    cache_root = %state.cache_dir.display(),
+                    "disk maintenance pass failed"
+                );
+            }
+            if state.shutdown_requested.load(Ordering::Acquire) {
+                break;
+            }
+            tokio::select! {
+                () = tokio::time::sleep(PRESSURE_INTERVAL) => {}
+                () = state.shutdown.notified() => {
+                    if state.shutdown_requested.load(Ordering::Acquire) {
+                        break;
+                    }
+                }
+            }
+            if state.shutdown_requested.load(Ordering::Acquire) {
+                break;
+            }
+        }
+    };
+    match runtime_handle {
+        Some(handle) => handle.spawn(task),
+        None => tokio::spawn(task),
+    }
+}
+
+#[cfg(test)]
+#[path = "tests/disk_maintenance_unit.rs"]
+mod tests;

--- a/crates/zccache-daemon-core/src/daemon/server/embedded.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/embedded.rs
@@ -34,6 +34,7 @@ impl EmbeddedDaemon {
         endpoint: String,
         cache_dir: crate::core::NormalizedPath,
         runtime_handle: Option<tokio::runtime::Handle>,
+        maintenance_policy: MaintenancePolicy,
     ) -> Result<Self, crate::ipc::IpcError> {
         let backend_identity = crate::ipc::current_backend_identity(&endpoint)
             .map_err(|err| crate::ipc::IpcError::Endpoint(err.to_string()))?;
@@ -55,8 +56,10 @@ impl EmbeddedDaemon {
 
         let mut daemon = Self {
             state,
+            maintenance_policy,
             index_writer_rx: Some(index_writer_rx),
             index_writer_handle: Mutex::new(None),
+            maintenance_handle: Mutex::new(None),
         };
         daemon.start_background_tasks(runtime_handle).await;
         Ok(daemon)
@@ -177,6 +180,13 @@ impl EmbeddedDaemon {
             state.dep_graph_load_notify.notify_waiters();
         })
         .await;
+
+        let maintenance_handle = spawn_disk_maintenance(
+            Arc::clone(&self.state),
+            self.maintenance_policy,
+            runtime_handle.as_ref(),
+        );
+        *self.maintenance_handle.lock().await = Some(maintenance_handle);
     }
 
     pub(crate) async fn compile(
@@ -287,13 +297,29 @@ impl EmbeddedDaemon {
         }
     }
 
+    pub(crate) async fn maintain_disk(
+        &self,
+        kind: MaintenanceKind,
+    ) -> std::io::Result<DiskMaintenanceReport> {
+        maintain_state_disk(Arc::clone(&self.state), self.maintenance_policy, kind).await
+    }
+
     pub(crate) async fn flush(&self) -> EmbeddedFlushReport {
+        let _maintenance_guard = self.state.disk_maintenance.lock().await;
         let mut index_writer_handle = self.index_writer_handle.lock().await;
         flush_embedded_state(&self.state, &mut index_writer_handle, false).await
     }
 
     pub(crate) async fn shutdown(&self) -> EmbeddedFlushReport {
         self.state.shutdown_requested.store(true, Ordering::Release);
+        self.state.shutdown.notify_waiters();
+        if let Some(handle) = self.maintenance_handle.lock().await.take() {
+            let _ = handle.await;
+        }
+        // A host-requested pass can run independently of the background
+        // handle. Wait for it before the final index flush; new passes reject
+        // the latched shutdown flag after acquiring this mutex.
+        let _maintenance_guard = self.state.disk_maintenance.lock().await;
         let mut index_writer_handle = self.index_writer_handle.lock().await;
         let report = flush_embedded_state(&self.state, &mut index_writer_handle, true).await;
         let _ = std::fs::remove_dir_all(&self.state.depfile_tmpdir);
@@ -395,6 +421,11 @@ async fn flush_embedded_state(
         std::time::Duration::from_secs(30),
     )
     .await;
+
+    // Detached publishers acquire an owned read guard before their handler
+    // returns. Taking the write guard here waits for every such handoff before
+    // the index writer is flushed or stopped, so no row can arrive afterward.
+    let _publication_guard = state.artifact_publication.write().await;
 
     let index_writer_drained =
         flush_index_writer(&state.index_writer_tx, std::time::Duration::from_secs(30)).await;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_clear.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_clear.rs
@@ -5,6 +5,19 @@ use super::*;
 
 /// Handle a Clear request: wipe all caches and reset stats.
 pub(super) async fn handle_clear(state: &SharedState) -> Response {
+    let _maintenance_guard = state.disk_maintenance.lock().await;
+    let pending_drained = pending_writes::await_all(
+        &state.pending_cache_writes,
+        std::time::Duration::from_secs(30),
+    )
+    .await;
+    if !pending_drained {
+        tracing::warn!(
+            pending = state.pending_cache_writes.len(),
+            "timed out waiting for pending artifact writes before Clear"
+        );
+    }
+    let _publication_guard = state.artifact_publication.write().await;
     // Snapshot counts before clearing.
     let artifacts_removed = {
         let count = state.artifacts.len() as u64;
@@ -69,9 +82,12 @@ pub(super) async fn handle_clear(state: &SharedState) -> Response {
         });
     }
 
-    // Clear the in-memory artifact index and persist the empty state.
-    state.artifact_store.clear();
-    let _ = Arc::clone(&state.artifact_store).flush_async().await;
+    // Cancel queued inserts, clear the in-memory artifact index, and persist
+    // the empty state as one index-writer command. This prevents a pre-Clear
+    // WAL row from resurrecting an artifact after its files were removed.
+    if !clear_index_writer(&state.index_writer_tx, std::time::Duration::from_secs(30)).await {
+        tracing::warn!("timed out clearing the persistent artifact index");
+    }
 
     // Persist the (now empty) metadata cache so the prior on-disk
     // snapshot stays consistent with the live state. Empty snapshots

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
@@ -84,11 +84,12 @@ pub(super) fn materialize_cached_compile_hit(
     // via `.elapsed()`); each costs ~50ns on Linux and ~500ns on Windows
     // (QueryPerformanceCounter). The phase split below now uses 4 clock
     // reads (`t0..t3`) and derives every `_ns` value by arithmetic — plus
-    // drops the `cached_ref.last_used = Instant::now()` write which was a
-    // dead store (no readers anywhere in the workspace).
+    // reuses `t0` for the maintenance-visible `last_used` write without an
+    // additional clock read (issue #1148).
     let t0 = Instant::now();
     let mut cached_ref = lookup_artifact_with_disk_fallback(state, artifact_key_hex)?;
     ensure_payloads(&mut cached_ref, &state.artifact_dir, artifact_key_hex)?;
+    record_artifact_access(state, artifact_key_hex, &mut cached_ref, t0);
     let t1 = Instant::now();
     let artifact_lookup_ns = (t1 - t0).as_nanos() as u64;
 

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/error_cache.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/error_cache.rs
@@ -34,7 +34,7 @@ fn should_cache_rustc_error(
 }
 
 #[allow(clippy::too_many_arguments)] // Localized error-cache insertion path.
-pub(super) fn maybe_store_rustc_error_artifact(
+pub(super) async fn maybe_store_rustc_error_artifact(
     state: &SharedState,
     context_key: &ContextKey,
     source_path: &NormalizedPath,
@@ -49,6 +49,10 @@ pub(super) fn maybe_store_rustc_error_artifact(
     if !should_cache_rustc_error(rustc_args, exit_code, cwd_path) {
         return None;
     }
+
+    // Error artifacts publish synchronously, but still participate in the
+    // same Clear/GC/flush ordering contract as successful artifacts.
+    let _publication_guard = begin_artifact_publication(state).await?;
 
     // Error-cache path ignores env-dep names: failed compiles are keyed
     // conservatively and re-validated on every replay (zccache#1021).
@@ -94,6 +98,70 @@ pub(super) fn maybe_store_rustc_error_artifact(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn rustc_error_publication_waits_for_clear_barrier() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source: NormalizedPath = tmp.path().join("probe.rs").into();
+        std::fs::write(&source, "fn main() { missing(); }\n").unwrap();
+        std::fs::write(
+            tmp.path().join("probe.d"),
+            format!("probe.d: {}\n", source.display()),
+        )
+        .unwrap();
+        let args = vec![
+            "--crate-name".to_string(),
+            "probe".to_string(),
+            "--emit=dep-info,metadata".to_string(),
+            "--out-dir".to_string(),
+            tmp.path().to_string_lossy().into_owned(),
+            source.to_string_lossy().into_owned(),
+        ];
+        let rustc_args = crate::depgraph::parse_rustc_args(&args, tmp.path());
+        let ctx = CompileContext {
+            source_file: source.clone(),
+            include_search: crate::depgraph::IncludeSearchPaths::default(),
+            defines: Vec::new(),
+            flags: Vec::new(),
+            force_includes: Vec::new(),
+            unknown_flags: Vec::new(),
+        };
+        let context_key = ctx.context_key();
+        let cache_dir: NormalizedPath = tmp.path().join("cache").into();
+        let server =
+            DaemonServer::bind_with_cache_dir(&crate::ipc::unique_test_endpoint(), &cache_dir)
+                .unwrap();
+        let state = Arc::clone(&server.state);
+        let publication_write = Arc::clone(&state.artifact_publication).write_owned().await;
+        let stdout = Arc::new(Vec::new());
+        let stderr = Arc::new(b"cannot find function `missing`".to_vec());
+        let mut publish = tokio::spawn(async move {
+            maybe_store_rustc_error_artifact(
+                &state,
+                &context_key,
+                &source,
+                &NormalizedPath::new(tmp.path()),
+                &ctx,
+                &rustc_args,
+                &stdout,
+                &stderr,
+                1,
+                state.cache_system.current_clock(),
+            )
+            .await
+        });
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), &mut publish)
+                .await
+                .is_err(),
+            "error-cache publication must wait for the Clear/GC write barrier"
+        );
+        drop(publication_write);
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), publish)
+            .await
+            .unwrap()
+            .unwrap();
+    }
 
     #[test]
     fn rustc_error_cache_requires_depinfo_and_no_link_emit() {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
@@ -28,6 +28,7 @@ pub(super) struct MissArtifactStoreRequest<'a> {
     pub(super) exit_code: i32,
     pub(super) compile_start: Instant,
     pub(super) synchronous_persist: bool,
+    pub(super) publication_guard: tokio::sync::OwnedRwLockReadGuard<()>,
 }
 
 #[derive(Default)]
@@ -67,6 +68,7 @@ pub(super) fn store_miss_artifact(request: MissArtifactStoreRequest<'_>) -> Miss
         exit_code,
         compile_start,
         synchronous_persist,
+        publication_guard,
     } = request;
     let state = state_arc.as_ref();
     let t_store = Instant::now();
@@ -127,6 +129,7 @@ pub(super) fn store_miss_artifact(request: MissArtifactStoreRequest<'_>) -> Miss
                 &mut stats,
                 t_artifact_build,
                 synchronous_persist,
+                publication_guard,
             );
         } else {
             store_single_output(
@@ -144,6 +147,7 @@ pub(super) fn store_miss_artifact(request: MissArtifactStoreRequest<'_>) -> Miss
                 &mut stats,
                 t_artifact_build,
                 synchronous_persist,
+                publication_guard,
             );
         }
     }
@@ -204,6 +208,10 @@ fn truncate_staged_publication_error(error: &str) -> String {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::items_after_test_module,
+    reason = "diagnostic helper tests stay beside the helper they exercise"
+)]
 mod staged_publication_diagnostic_tests {
     use super::{truncate_staged_publication_error, MAX_STAGED_PUBLICATION_ERROR_CHARS};
 
@@ -248,6 +256,7 @@ fn store_rustc_outputs(
     stats: &mut MissArtifactStoreStats,
     t_artifact_build: Instant,
     synchronous_persist: bool,
+    publication_guard: tokio::sync::OwnedRwLockReadGuard<()>,
 ) {
     let state = state_arc.as_ref();
     let t_artifact_meta_build = Instant::now();
@@ -374,6 +383,7 @@ fn store_rustc_outputs(
         t.record_miss(src, artifact_bytes);
     });
     stats.artifact_insert_stats_ns = t_artifact_insert_stats.elapsed().as_nanos() as u64;
+    drop(publication_guard);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -392,6 +402,7 @@ fn store_single_output(
     stats: &mut MissArtifactStoreStats,
     t_artifact_build: Instant,
     synchronous_persist: bool,
+    publication_guard: tokio::sync::OwnedRwLockReadGuard<()>,
 ) {
     let state = state_arc.as_ref();
     // Issue #643: stash the user's depfile as a second output so cache
@@ -533,11 +544,17 @@ fn store_single_output(
             t.record_miss(src, artifact_bytes)
         });
         stats.artifact_insert_stats_ns = t_persist_enqueue.elapsed().as_nanos() as u64;
+        drop(publication_guard);
         return;
     }
 
+    // Publish the live entry before transferring the same read guard to the
+    // detached task. A queued writer can never observe a gap between the map
+    // insertion and the disk/index publication it must drain.
+    state.artifacts.insert(artifact_key_hex.to_string(), cached);
     let sem = Arc::clone(&state.persist_semaphore);
     let state_ref = Arc::clone(state_arc);
+    let index_writer_tx = state.index_writer_tx.clone();
     let completion_key = artifact_key_hex.to_string();
     // Issue #610, DD-025 condition 1: pending-write registration around
     // the C/C++ cold-miss persist spawn. Concurrent lookups can observe
@@ -557,6 +574,7 @@ fn store_single_output(
             .expect("persist_semaphore is owned by ServerState and never closed");
         let written = tokio::task::spawn_blocking(move || {
             let _guard = guard;
+            let _publication_guard = publication_guard;
             // Issue #728: `gap_ms` = wall-clock between
             // "linker-success-recorded" (immediately before this spawn was
             // scheduled) and "persist-attempt-started" (now, inside the
@@ -568,20 +586,22 @@ fn store_single_output(
             // src_size_now= — is baked into the error by
             // `persist::enrich_persist_err`).
             let gap_ms = t_persist_enqueue.elapsed().as_millis() as u64;
-            if let Err(e) = persist_artifact_paths(&artifact_dir, &key_hex, &source_paths) {
-                tracing::warn!(
-                    key = %key_hex,
-                    gap_ms,
-                    "failed to persist artifact output: {e}"
-                );
+            match persist_artifact_paths(&artifact_dir, &key_hex, &source_paths) {
+                Ok(()) => {
+                    let _ = index_writer_tx.send(IndexWriterCommand::Insert(key_hex, persist_meta));
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        key = %key_hex,
+                        gap_ms,
+                        "failed to persist artifact output: {e}"
+                    );
+                }
             }
-            (key_hex, persist_meta)
         })
         .await;
-        if let Ok((key_hex, meta)) = written {
-            let _ = state_ref
-                .index_writer_tx
-                .send(IndexWriterCommand::Insert(key_hex, meta));
+        if let Err(error) = written {
+            tracing::warn!(%error, "artifact persistence task failed to join");
         }
         // Always complete the pending entry, even on JoinError, so
         // waiters cannot hang past the spawn's lifetime.
@@ -590,8 +610,6 @@ fn store_single_output(
     stats.persist_enqueue_ns = t_persist_enqueue.elapsed().as_nanos() as u64;
 
     let t_artifact_insert_stats = Instant::now();
-    state.artifacts.insert(artifact_key_hex.to_string(), cached);
-
     let latency_ns = compile_start.elapsed().as_nanos() as u64;
     state.stats.record_miss(latency_ns, artifact_bytes);
     let src = source_path.clone();

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -265,10 +265,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         rustc_metadata_compat_key,
         worktree_equivalent_context,
     ) = match build_result {
-        BuildContextResult::Cc {
-            mut ctx,
-            dep_flags,
-        } => {
+        BuildContextResult::Cc { mut ctx, dep_flags } => {
             dependency_mode.apply_to_cc_context(&mut ctx, &dep_flags);
             DependencyDiscoveryMode::apply_user_depfile_content_to_cc_context(
                 &mut ctx,
@@ -793,7 +790,9 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 &stderr,
                 exit_code,
                 snap_clock,
-            ) {
+            )
+            .await
+            {
                 write_session_log(
                     &state.sessions,
                     &sid,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -232,10 +232,7 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
                     if augment_system_headers {
                         result = crate::depgraph::depfile::merge_scan_results_conservative(
                             result,
-                            crate::depgraph::scanner::scan_recursive(
-                                &source_path,
-                                &include_search,
-                            ),
+                            crate::depgraph::scanner::scan_recursive(&source_path, &include_search),
                         );
                     }
                     result
@@ -652,6 +649,38 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
     }
     let synchronous_persist = synchronous_persist && staged_cc_materialization.is_none();
 
+    // Acquire exactly one owned guard and either retain it for synchronous
+    // publication or transfer it to the detached persist task. Re-acquiring a
+    // fair RwLock while already holding a read guard can self-deadlock when a
+    // Clear/GC writer is queued between the two reads.
+    let store_stats = if let Some(publication_guard) = begin_artifact_publication(state_arc).await {
+        // #955: the miss persist (a large rustc `.rlib` copy when it can't be
+        // hardlinked cross-volume) is synchronous; run it under block_in_place
+        // so it doesn't park the tokio worker. See process::run_cpu_blocking.
+        crate::daemon::process::run_cpu_blocking(|| {
+            store_miss_artifact(MissArtifactStoreRequest {
+                state_arc,
+                sid,
+                context_key,
+                source_path,
+                output_path: &compiler_output_path,
+                scan_result,
+                rustc_env_dep_values,
+                hash_map: &hash_map,
+                output_data,
+                user_depfile: user_depfile_capture,
+                rustc_all_outputs: rustc_all_outputs.as_deref(),
+                stdout: &stdout,
+                stderr: &stderr,
+                exit_code,
+                compile_start,
+                synchronous_persist,
+                publication_guard,
+            })
+        })
+    } else {
+        MissArtifactStoreStats::default()
+    };
     let MissArtifactStoreStats {
         artifact_store_ns,
         depgraph_update_ns,
@@ -668,29 +697,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         artifact_index_build_ns,
         artifact_index_persist_ns,
         artifact_memory_insert_ns,
-        // #955: the miss persist (a large rustc `.rlib` copy when it can't be
-        // hardlinked cross-volume) is synchronous; run it under block_in_place
-        // so it doesn't park the tokio worker. See process::run_cpu_blocking.
-    } = crate::daemon::process::run_cpu_blocking(|| {
-        store_miss_artifact(MissArtifactStoreRequest {
-            state_arc,
-            sid,
-            context_key,
-            source_path,
-            output_path: &compiler_output_path,
-            scan_result,
-            rustc_env_dep_values,
-            hash_map: &hash_map,
-            output_data,
-            user_depfile: user_depfile_capture,
-            rustc_all_outputs: rustc_all_outputs.as_deref(),
-            stdout: &stdout,
-            stderr: &stderr,
-            exit_code,
-            compile_start,
-            synchronous_persist,
-        })
-    });
+    } = store_stats;
 
     if let Some(plan) = staged_plan {
         use crate::daemon::staged_stats::{

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -53,10 +53,7 @@ fn check_unit_cache(
     let (mut ctx, dep_flags) = if let Some(base) = shared_base {
         let mut ctx = base.clone();
         ctx.source_file = source_path.clone();
-        (
-            ctx,
-            shared_dep_flags.cloned().unwrap_or_default(),
-        )
+        (ctx, shared_dep_flags.cloned().unwrap_or_default())
     } else {
         match build_compile_context(
             compilation,
@@ -117,11 +114,16 @@ fn check_unit_cache(
                 if let Some(mut cached_ref) =
                     lookup_artifact_with_disk_fallback(state, artifact_key_hex)
                 {
-                    cached_ref.last_used = std::time::Instant::now();
                     let loaded =
                         ensure_payloads(&mut cached_ref, &state.artifact_dir, artifact_key_hex)
                             .is_some();
                     if loaded {
+                        record_artifact_access(
+                            state,
+                            artifact_key_hex,
+                            &mut cached_ref,
+                            std::time::Instant::now(),
+                        );
                         #[expect(
                             clippy::expect_used,
                             reason = "ensure_payloads on the preceding line returned Some, which is the contract guaranteeing cached_ref.payloads is now populated"
@@ -244,11 +246,16 @@ fn check_unit_cache(
     {
         let artifact_key_hex = artifact_key.hash().to_hex();
         if let Some(mut cached_ref) = lookup_artifact_with_disk_fallback(state, &artifact_key_hex) {
-            cached_ref.last_used = std::time::Instant::now();
             let t_lookup = t0.elapsed();
             let loaded =
                 ensure_payloads(&mut cached_ref, &state.artifact_dir, &artifact_key_hex).is_some();
             if loaded {
+                record_artifact_access(
+                    state,
+                    &artifact_key_hex,
+                    &mut cached_ref,
+                    std::time::Instant::now(),
+                );
                 #[expect(
                     clippy::expect_used,
                     reason = "ensure_payloads on the preceding line returned Some, which is the contract guaranteeing cached_ref.payloads is now populated"
@@ -760,8 +767,7 @@ pub(super) async fn handle_compile_multi(
                 );
             }
             if used_static_fallback {
-                dependency_mode_task
-                    .apply_static_fallback(&mut scan_result, &ctx.include_search);
+                dependency_mode_task.apply_static_fallback(&mut scan_result, &ctx.include_search);
             }
 
             let tracked_paths: Vec<NormalizedPath> = std::iter::once(source_path.clone())
@@ -797,6 +803,13 @@ pub(super) async fn handle_compile_multi(
                     .collect()
             };
 
+            let Some(_publication_guard) = begin_artifact_publication_blocking(&state_task) else {
+                return MissOutcome {
+                    dep_dirs,
+                    output_path,
+                    persist: None,
+                };
+            };
             let get_hash = |p: &Path| {
                 let path = NormalizedPath::new(p);
                 hash_map.get(&path).copied()
@@ -922,6 +935,9 @@ pub(super) async fn handle_compile_multi(
     watch_directories(&state, &dep_dirs_vec).await;
 
     for job in persist_jobs {
+        let Some(publication_guard_for_task) = begin_artifact_publication(&state).await else {
+            continue;
+        };
         let artifact_dir = state.artifact_dir.clone();
         let key_hex = job.artifact_key_hex;
         let persist_meta = job.persist_meta;
@@ -935,7 +951,7 @@ pub(super) async fn handle_compile_multi(
             size: payload_size,
         };
         let sem = Arc::clone(&state.persist_semaphore);
-        let state_ref = Arc::clone(&state);
+        let index_writer_tx = state.index_writer_tx.clone();
         // Issue #728: capture the per-job enqueue Instant so the WARN below
         // can report `gap_ms` = "linker-success-recorded → persist-attempt-
         // started" (distinguishes queue starvation under burst load from
@@ -952,21 +968,25 @@ pub(super) async fn handle_compile_multi(
                 .expect("persist_semaphore is owned by ServerState and never closed");
             let written = tokio::task::spawn_blocking(move || {
                 let _guard = guard;
+                let _publication_guard = publication_guard_for_task;
                 let gap_ms = t_persist_enqueue.elapsed().as_millis() as u64;
-                if let Err(e) = persist_artifact_payloads(&artifact_dir, &key_hex, &payloads) {
-                    tracing::warn!(
-                        key = %key_hex,
-                        gap_ms,
-                        "failed to persist artifact output: {e}"
-                    );
+                match persist_artifact_payloads(&artifact_dir, &key_hex, &payloads) {
+                    Ok(()) => {
+                        let _ =
+                            index_writer_tx.send(IndexWriterCommand::Insert(key_hex, persist_meta));
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key_hex,
+                            gap_ms,
+                            "failed to persist artifact output: {e}"
+                        );
+                    }
                 }
-                (key_hex, persist_meta)
             })
             .await;
-            if let Ok((key_hex, meta)) = written {
-                let _ = state_ref
-                    .index_writer_tx
-                    .send(IndexWriterCommand::Insert(key_hex, meta));
+            if let Err(error) = written {
+                tracing::warn!(%error, "multi-source artifact persistence task failed to join");
             }
         });
     }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_preflight.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_preflight.rs
@@ -233,11 +233,7 @@ impl InputSnapshot {
         let include_search = ctx.include_search.canonicalized();
         let scan = match dependency_mode {
             DependencyDiscoveryMode::AllHeaders => {
-                crate::depgraph::scanner::scan_recursive_cached(
-                    source,
-                    &include_search,
-                    scan_cache,
-                )
+                crate::depgraph::scanner::scan_recursive_cached(source, &include_search, scan_cache)
             }
             DependencyDiscoveryMode::SkipSystemHeaders => {
                 crate::depgraph::scanner::scan_recursive_cached_pruned(
@@ -333,6 +329,7 @@ impl InputSnapshot {
     }
 }
 
+#[allow(clippy::result_large_err)] // Response is the established handler control-flow type.
 fn detach_direct_batch_outputs(
     compilations: &[crate::compiler::CacheableCompilation],
     original_args: &[String],
@@ -381,6 +378,7 @@ fn detach_direct_batch_outputs(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)] // Mirrors the multi-source dispatch surface.
 pub(super) async fn run_depfile_stdout_batch(
     state: &Arc<SharedState>,
     sid: &SessionId,
@@ -414,6 +412,7 @@ pub(super) async fn run_depfile_stdout_batch(
     )
 }
 
+#[allow(clippy::too_many_arguments)] // Mirrors the multi-source dispatch surface.
 pub(super) async fn run_unsupported_batch(
     state: &Arc<SharedState>,
     sid: &SessionId,
@@ -473,9 +472,7 @@ pub(super) async fn run_unsupported_batch(
             state.profiler.staged.count(StagedCounter::PlanUnsupported);
             state.profiler.staged.failure(reason.failure());
             let response_family = direct_response_family(compilations[0].family, original_args);
-            if let Err(response) =
-                detach_direct_batch_outputs(compilations, original_args, cwd)
-            {
+            if let Err(response) = detach_direct_batch_outputs(compilations, original_args, cwd) {
                 return Some(response);
             }
             for _ in compilations {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
@@ -30,6 +30,28 @@ struct PublishedMiss {
     allow_fast_hit: bool,
 }
 
+fn insert_staged_multi_cache_visibility(
+    state: &SharedState,
+    _publication_guard: &tokio::sync::OwnedRwLockReadGuard<()>,
+    context_key: ContextKey,
+    validation_clock: Clock,
+    key: String,
+    cached: CachedArtifact,
+    allow_fast_hit: bool,
+) {
+    state.artifacts.insert(key.clone(), cached);
+    if allow_fast_hit {
+        state.fast_hit_cache.insert(
+            context_key,
+            FastHitEntry {
+                clock: validation_clock,
+                artifact_key_hex: key,
+                cached_at: std::time::Instant::now(),
+            },
+        );
+    }
+}
+
 struct StagedCompilerOutput {
     unit_index: usize,
     output: std::process::Output,
@@ -358,8 +380,7 @@ pub(super) async fn try_handle_staged_misses(
             );
         }
         if depfile_parse_failed {
-            dependency_mode
-                .apply_static_fallback(&mut scan_result, &miss.ctx.include_search);
+            dependency_mode.apply_static_fallback(&mut scan_result, &miss.ctx.include_search);
         }
         let mut tracked: HashSet<NormalizedPath> =
             miss.input_snapshot.hashes.keys().cloned().collect();
@@ -495,8 +516,13 @@ pub(super) async fn try_handle_staged_misses(
         dependency_directories.extend(miss.dep_dirs.iter().cloned());
     }
 
-    let mut completed = Vec::with_capacity(published.len());
     for mut miss in published {
+        let publication_guard = begin_artifact_publication(state).await;
+        if publication_guard.is_none() {
+            miss.cache_entry = None;
+            miss.graph_update = None;
+        }
+        let _publication_guard = publication_guard;
         if let Some((key, metadata)) = miss
             .cache_entry
             .as_ref()
@@ -515,9 +541,6 @@ pub(super) async fn try_handle_staged_misses(
                 miss.cache_entry = None;
                 miss.graph_update = None;
             } else if let Some((scan_result, hash_map)) = miss.graph_update.take() {
-                if let Some((_, cached)) = miss.cache_entry.as_ref() {
-                    state.artifacts.insert(key.clone(), cached.clone());
-                }
                 let get_hash = |path: &Path| hash_map.get(&NormalizedPath::new(path)).copied();
                 let committed_key = state
                     .dep_graph
@@ -538,44 +561,29 @@ pub(super) async fn try_handle_staged_misses(
                 }
             }
         }
+        if let Some((key, cached)) = miss.cache_entry.take() {
+            insert_staged_multi_cache_visibility(
+                state,
+                _publication_guard
+                    .as_ref()
+                    .expect("cacheable staged multi miss owns a publication guard"),
+                miss.context_key,
+                miss.validation_clock,
+                key,
+                cached,
+                miss.allow_fast_hit,
+            );
+        }
+        drop(_publication_guard);
         if let Err(error) = miss.plan.cleanup() {
             tracing::warn!(%error, "failed to clean staged multi-source workspace");
         }
-        completed.push((
-            miss.source_path,
-            miss.context_key,
-            miss.cache_entry,
-            miss.artifact_bytes,
-            miss.validation_clock,
-            miss.allow_fast_hit,
-        ));
-    }
-    for (
-        source,
-        context_key,
-        cache_entry,
-        artifact_bytes,
-        validation_clock,
-        allow_fast_hit,
-    ) in completed
-    {
-        state.stats.record_miss(0, artifact_bytes);
+        state.stats.record_miss(0, miss.artifact_bytes);
+        let artifact_bytes = miss.artifact_bytes;
+        let source = miss.source_path;
         record_session_stat(&state.sessions, sid, move |stats| {
             stats.record_miss(source, artifact_bytes);
         });
-        if let Some((key, cached)) = cache_entry {
-            state.artifacts.insert(key.clone(), cached);
-            if allow_fast_hit {
-                state.fast_hit_cache.insert(
-                    context_key,
-                    FastHitEntry {
-                        clock: validation_clock,
-                        artifact_key_hex: key,
-                        cached_at: std::time::Instant::now(),
-                    },
-                );
-            }
-        }
     }
     watch_directories(
         state,
@@ -589,4 +597,67 @@ pub(super) async fn try_handle_staged_misses(
         stderr: Arc::new(std::mem::take(all_stderr)),
         cached: false,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn staged_multi_visibility_stays_inside_queued_clear_barrier() {
+        let temp = tempfile::tempdir().unwrap();
+        let endpoint = crate::ipc::unique_test_endpoint();
+        let cache_dir: NormalizedPath = temp.path().join("cache").into();
+        let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+        let index_writer = tokio::spawn(run_index_writer(
+            server.index_writer_rx.take().unwrap(),
+            Arc::clone(&server.state.artifact_store),
+            Arc::clone(&server.state.index_writer_shutdown),
+        ));
+        let publication_guard = begin_artifact_publication(&server.state).await.unwrap();
+        let clear_state = Arc::clone(&server.state);
+        let mut clear =
+            tokio::spawn(
+                async move { super::super::handle_clear::handle_clear(&clear_state).await },
+            );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), &mut clear)
+                .await
+                .is_err(),
+            "Clear must queue behind staged multi publication"
+        );
+
+        let key = "5".repeat(64);
+        let context_key = ContextKey::from_raw([5; 32]);
+        let cached = CachedArtifact::from_index(ArtifactIndex::new(
+            vec!["unit.o".to_string()],
+            vec![1],
+            Vec::new(),
+            Vec::new(),
+            0,
+        ));
+        insert_staged_multi_cache_visibility(
+            &server.state,
+            &publication_guard,
+            context_key,
+            Clock::ZERO,
+            key.clone(),
+            cached,
+            true,
+        );
+        assert!(server.state.artifacts.contains_key(&key));
+        assert!(server.state.fast_hit_cache.contains_key(&context_key));
+
+        drop(publication_guard);
+        let response = tokio::time::timeout(std::time::Duration::from_secs(5), clear)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(response, Response::Cleared { .. }));
+        assert!(!server.state.artifacts.contains_key(&key));
+        assert!(!server.state.fast_hit_cache.contains_key(&context_key));
+
+        server.state.index_writer_shutdown.notify_waiters();
+        index_writer.await.unwrap();
+    }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
@@ -470,7 +470,19 @@ pub(super) async fn handle_generic_tool_exec(
     let cacheable_exit = true; // exit codes are part of the cached payload — even non-zero
     let mut staged_publication_failure = None;
     let mut staged_cached_artifact = None;
-    if store_allowed && all_captured && !too_large && depfile_ok && cacheable_exit {
+    let staged_publication_guard = if staged_plan.is_some() {
+        begin_artifact_publication(state).await
+    } else {
+        None
+    };
+    let publication_allowed = staged_plan.is_none() || staged_publication_guard.is_some();
+    if store_allowed
+        && all_captured
+        && !too_large
+        && depfile_ok
+        && cacheable_exit
+        && publication_allowed
+    {
         let artifact = ArtifactData {
             outputs: cache_outputs,
             stdout: Arc::clone(&stdout),
@@ -512,6 +524,7 @@ pub(super) async fn handle_generic_tool_exec(
             state.artifacts.insert(final_full_hex.clone(), cached);
         }
     }
+    drop(staged_publication_guard);
 
     drop(coalesce_guard); // Releasing the guard wakes any waiters.
 
@@ -748,7 +761,6 @@ async fn try_exec_cache_hit(
     output_streams: ExecOutputStreams,
 ) -> Option<Response> {
     let mut entry = lookup_artifact_with_disk_fallback(state, key_hex)?;
-    entry.last_used = std::time::Instant::now();
 
     let exit_code = entry.meta.exit_code;
     let stdout_full = entry.stdout.clone();
@@ -759,6 +771,7 @@ async fn try_exec_cache_hit(
     if !payloads_loaded {
         return None;
     }
+    record_artifact_access(state, key_hex, &mut entry, std::time::Instant::now());
     let payloads = Arc::clone(entry.payloads.as_ref()?);
     drop(entry);
 
@@ -836,13 +849,64 @@ async fn try_exec_cache_hit(
 
 // ─── Store ──────────────────────────────────────────────────────────────
 
-async fn store_exec_artifact(
+pub(super) struct PublicationHandoffGate {
+    acquired: Notify,
+    resume: Notify,
+}
+
+#[cfg(test)]
+impl PublicationHandoffGate {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            acquired: Notify::new(),
+            resume: Notify::new(),
+        })
+    }
+
+    async fn wait_until_acquired(&self) {
+        self.acquired.notified().await;
+    }
+
+    fn resume(&self) {
+        self.resume.notify_one();
+    }
+}
+
+pub(super) async fn store_exec_artifact(
     state: &Arc<SharedState>,
     key_hex: String,
     artifact: ArtifactData,
     staged_sources: Option<Vec<NormalizedPath>>,
 ) -> Result<Option<CachedArtifact>, StagedPublishFailure> {
+    store_exec_artifact_inner(state, key_hex, artifact, staged_sources, None).await
+}
+
+#[cfg(test)]
+pub(super) async fn store_exec_artifact_with_handoff_gate(
+    state: &Arc<SharedState>,
+    key_hex: String,
+    artifact: ArtifactData,
+    gate: Arc<PublicationHandoffGate>,
+) -> Result<Option<CachedArtifact>, StagedPublishFailure> {
+    store_exec_artifact_inner(state, key_hex, artifact, None, Some(gate)).await
+}
+
+async fn store_exec_artifact_inner(
+    state: &Arc<SharedState>,
+    key_hex: String,
+    artifact: ArtifactData,
+    staged_sources: Option<Vec<NormalizedPath>>,
+    handoff_gate: Option<Arc<PublicationHandoffGate>>,
+) -> Result<Option<CachedArtifact>, StagedPublishFailure> {
     let cached = CachedArtifact::from_artifact_data(&artifact);
+    let publication_guard = if staged_sources.is_none() {
+        let Some(guard) = begin_artifact_publication(state).await else {
+            return Ok(None);
+        };
+        Some(guard)
+    } else {
+        None
+    };
     if let Some(sources) = staged_sources {
         publish_artifact_paths_observed(state, &key_hex, cached.meta.clone(), &sources)?;
         return Ok(Some(cached));
@@ -861,8 +925,15 @@ async fn store_exec_artifact(
             // so expose their index entry to the final shutdown flush now.
             state.artifact_store.insert(&key_hex, &persist_meta);
         }
-        let state_ref = Arc::clone(state);
+        if let Some(gate) = handoff_gate {
+            gate.acquired.notify_one();
+            gate.resume.notified().await;
+        }
+        state.artifacts.insert(key_hex.clone(), cached);
         let sem = Arc::clone(&state.persist_semaphore);
+        let publication_guard_for_task =
+            publication_guard.expect("direct exec publication acquired an owned guard");
+        let index_writer_tx = state.index_writer_tx.clone();
         tokio::spawn(async move {
             #[expect(
                 clippy::expect_used,
@@ -873,18 +944,18 @@ async fn store_exec_artifact(
                 .await
                 .expect("persist_semaphore is owned by ServerState and never closed");
             let written = tokio::task::spawn_blocking(move || {
-                let _ = persist_artifact_payloads(&artifact_dir, &key_for_persist, &payloads);
-                (key_for_persist, persist_meta)
+                let _publication_guard = publication_guard_for_task;
+                if persist_artifact_payloads(&artifact_dir, &key_for_persist, &payloads).is_ok() {
+                    let _ = index_writer_tx
+                        .send(IndexWriterCommand::Insert(key_for_persist, persist_meta));
+                }
             })
             .await;
-            if let Ok((kh, meta)) = written {
-                let _ = state_ref
-                    .index_writer_tx
-                    .send(IndexWriterCommand::Insert(kh, meta));
+            if let Err(error) = written {
+                tracing::warn!(%error, "exec artifact persistence task failed to join");
             }
         });
     }
-    state.artifacts.insert(key_hex, cached);
     Ok(None)
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec_tests.rs
@@ -11,6 +11,122 @@ fn empty_extra() -> Arc<Vec<u8>> {
 }
 
 #[tokio::test]
+async fn detached_exec_publisher_cannot_resurrect_artifact_after_clear() {
+    let temp = tempdir().unwrap();
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let cache_dir: NormalizedPath = temp.path().join("cache").into();
+    let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+    let index_writer = tokio::spawn(run_index_writer(
+        server.index_writer_rx.take().unwrap(),
+        Arc::clone(&server.state.artifact_store),
+        Arc::clone(&server.state.index_writer_shutdown),
+    ));
+
+    let permit_count = server.state.persist_semaphore.available_permits() as u32;
+    let blocked_persist = Arc::clone(&server.state.persist_semaphore)
+        .acquire_many_owned(permit_count)
+        .await
+        .unwrap();
+    let key = "9".repeat(64);
+    let artifact = ArtifactData {
+        outputs: vec![ArtifactOutput {
+            name: "result.bin".to_string(),
+            payload: ArtifactPayload::Bytes(Arc::new(b"pre-clear artifact".to_vec())),
+        }],
+        stdout: Arc::new(Vec::new()),
+        stderr: Arc::new(Vec::new()),
+        exit_code: 0,
+    };
+    store_exec_artifact(&server.state, key.clone(), artifact, None)
+        .await
+        .unwrap();
+
+    let clear_state = Arc::clone(&server.state);
+    let mut clear =
+        tokio::spawn(async move { super::super::handle_clear::handle_clear(&clear_state).await });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(25), &mut clear)
+            .await
+            .is_err(),
+        "Clear must wait for the detached publisher's pre-spawn guard handoff"
+    );
+
+    drop(blocked_persist);
+    let response = tokio::time::timeout(std::time::Duration::from_secs(5), clear)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(response, Response::Cleared { .. }));
+    assert!(!server.state.artifacts.contains_key(&key));
+    assert!(server.state.artifact_store.get(&key).is_none());
+    assert!(!server.state.artifact_dir.join(format!("{key}_0")).exists());
+
+    server.state.index_writer_shutdown.notify_waiters();
+    index_writer.await.unwrap();
+}
+
+#[tokio::test]
+async fn detached_exec_handoff_does_not_reacquire_behind_queued_clear() {
+    let temp = tempdir().unwrap();
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let cache_dir: NormalizedPath = temp.path().join("cache").into();
+    let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+    let index_writer = tokio::spawn(run_index_writer(
+        server.index_writer_rx.take().unwrap(),
+        Arc::clone(&server.state.artifact_store),
+        Arc::clone(&server.state.index_writer_shutdown),
+    ));
+    let permit_count = server.state.persist_semaphore.available_permits() as u32;
+    let blocked_persist = Arc::clone(&server.state.persist_semaphore)
+        .acquire_many_owned(permit_count)
+        .await
+        .unwrap();
+    let key = "a".repeat(64);
+    let artifact = ArtifactData {
+        outputs: vec![ArtifactOutput {
+            name: "result.bin".to_string(),
+            payload: ArtifactPayload::Bytes(Arc::new(b"single-guard handoff".to_vec())),
+        }],
+        stdout: Arc::new(Vec::new()),
+        stderr: Arc::new(Vec::new()),
+        exit_code: 0,
+    };
+    let gate = PublicationHandoffGate::new();
+    let publisher_state = Arc::clone(&server.state);
+    let publisher_gate = Arc::clone(&gate);
+    let mut publisher = tokio::spawn(async move {
+        store_exec_artifact_with_handoff_gate(&publisher_state, key, artifact, publisher_gate).await
+    });
+    gate.wait_until_acquired().await;
+
+    let clear_state = Arc::clone(&server.state);
+    let mut clear =
+        tokio::spawn(async move { super::super::handle_clear::handle_clear(&clear_state).await });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(25), &mut clear)
+            .await
+            .is_err(),
+        "Clear must queue behind the publisher's first read guard"
+    );
+
+    gate.resume();
+    tokio::time::timeout(std::time::Duration::from_secs(5), &mut publisher)
+        .await
+        .expect("publisher must transfer its guard instead of reacquiring")
+        .unwrap()
+        .unwrap();
+    drop(blocked_persist);
+    let response = tokio::time::timeout(std::time::Duration::from_secs(5), clear)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(response, Response::Cleared { .. }));
+
+    server.state.index_writer_shutdown.notify_waiters();
+    index_writer.await.unwrap();
+}
+
+#[tokio::test]
 async fn staged_exec_publication_failure_never_inserts_cache_entry() {
     let temp = tempdir().unwrap();
     let endpoint = crate::ipc::unique_test_endpoint();

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -362,10 +362,10 @@ pub(super) async fn handle_link_ephemeral(
     // 5. Cache lookup
     let t_cache_lookup = profile_enabled.then(std::time::Instant::now);
     if let Some(mut entry) = lookup_artifact_with_disk_fallback(state, &key_hex) {
-        entry.last_used = std::time::Instant::now();
         // Load payloads from disk if not already loaded.
         let loaded = ensure_payloads(&mut entry, &state.artifact_dir, &key_hex).is_some();
         if loaded {
+            record_artifact_access(state, &key_hex, &mut entry, std::time::Instant::now());
             discard_speculative_archive(&mut speculative_archive);
             #[expect(
                 clippy::expect_used,
@@ -728,7 +728,13 @@ pub(super) async fn handle_link_ephemeral(
     } = result
     {
         if let Some(plan) = directory_plan.as_ref() {
-            if let Err(error) = cache_staged_directory_link(state, plan, &key_hex, stdout, stderr) {
+            let publication_guard = begin_artifact_publication(state).await;
+            let materialized = if publication_guard.is_some() {
+                cache_staged_directory_link(state, plan, &key_hex, stdout, stderr)
+            } else {
+                materialize_uncached_staged_directory_link(state, plan)
+            };
+            if let Err(error) = materialized {
                 return Response::Error {
                     message: format!("failed to materialize staged directory output: {error}"),
                 };
@@ -921,6 +927,21 @@ pub(super) async fn handle_link_ephemeral(
             // from 2 (compiler + cache) to 1 (compiler + hardlink). Cross-volume
             // case falls back to `std::fs::copy` — identical to prior semantics.
             let artifact_store_started = profile_enabled.then(std::time::Instant::now);
+            // One owned guard covers both the live-map insert and disk/index
+            // publication. The exact same guard is transferred to detached
+            // work, avoiding the fair-RwLock self-deadlock caused by acquiring
+            // a second read while a writer is queued.
+            let Some(guard) = begin_artifact_publication(state).await else {
+                if let Some(plan) = staged_plan.as_ref() {
+                    if let Err(error) = materialize_link_plan_observed(state, plan, None) {
+                        return Response::Error {
+                            message: format!("failed to materialize staged link output: {error}"),
+                        };
+                    }
+                }
+                return with_link_warning(result, nd_warning);
+            };
+            let mut publication_guard = Some(guard);
             let cacheable = {
                 let artifact_dir = state.artifact_dir.clone();
                 let kh = key_hex.clone();
@@ -969,7 +990,11 @@ pub(super) async fn handle_link_ephemeral(
                     }
                 } else {
                     let sem = Arc::clone(&state.persist_semaphore);
-                    let state_ref = Arc::clone(state);
+                    state.artifacts.insert(key_hex.clone(), cached.clone());
+                    let publication_guard_for_task = publication_guard
+                        .take()
+                        .expect("link publication acquired an owned guard");
+                    let index_writer_tx = state.index_writer_tx.clone();
                     tokio::spawn(async move {
                         #[expect(
                             clippy::expect_used,
@@ -981,14 +1006,15 @@ pub(super) async fn handle_link_ephemeral(
                             .expect("persist_semaphore is owned by ServerState and never closed");
                         let written = tokio::task::spawn_blocking(move || {
                             let _guard = guard;
-                            let _ = persist_artifact_payloads(&artifact_dir, &kh, &payloads);
-                            (kh, persist_meta)
+                            let _publication_guard = publication_guard_for_task;
+                            if persist_artifact_payloads(&artifact_dir, &kh, &payloads).is_ok() {
+                                let _ = index_writer_tx
+                                    .send(IndexWriterCommand::Insert(kh, persist_meta));
+                            }
                         })
                         .await;
-                        if let Ok((kh, meta)) = written {
-                            let _ = state_ref
-                                .index_writer_tx
-                                .send(IndexWriterCommand::Insert(kh, meta));
+                        if let Err(error) = written {
+                            tracing::warn!(%error, "link artifact persistence task failed to join");
                         }
                     });
                     true
@@ -998,10 +1024,11 @@ pub(super) async fn handle_link_ephemeral(
                 .map(|started| started.elapsed().as_nanos() as u64)
                 .unwrap_or(0);
 
-            if cacheable {
+            if cacheable && publication_guard.is_some() {
                 state.artifacts.insert(key_hex.clone(), cached);
                 tracing::debug!(%key_hex, "link artifact cached");
             }
+            drop(publication_guard);
         } else if staged_plan.is_some() {
             return Response::Error {
                 message: "successful archive omitted its staged output".to_string(),

--- a/crates/zccache-daemon-core/src/daemon/server/keys.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/keys.rs
@@ -436,11 +436,11 @@ pub(super) fn request_fingerprint(
     h.finalize()
 }
 
-fn update_user_depfile_raw_fingerprint(
-    hasher: &mut crate::hash::StreamHasher,
-    args: &[String],
-) {
-    if !args.iter().any(|arg| matches!(arg.as_str(), "-MD" | "-MMD")) {
+fn update_user_depfile_raw_fingerprint(hasher: &mut crate::hash::StreamHasher, args: &[String]) {
+    if !args
+        .iter()
+        .any(|arg| matches!(arg.as_str(), "-MD" | "-MMD"))
+    {
         return;
     }
     hasher.update(b"user-depfile-raw-argv\0");

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -207,6 +207,8 @@ pub(super) fn new_shared_state(
             pch_source_map: DashMap::new(),
             journal: CompileJournal::new(crate::core::config::log_dir_from_cache_dir(cache_dir)),
             in_flight_bytes: AtomicUsize::new(0),
+            disk_maintenance: Mutex::new(()),
+            artifact_publication: Arc::new(tokio::sync::RwLock::new(())),
             persist_semaphore: Arc::new(tokio::sync::Semaphore::new(persist_workers_default())),
             compile_concurrency,
             artifact_store,

--- a/crates/zccache-daemon-core/src/daemon/server/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/mod.rs
@@ -83,8 +83,10 @@ pub struct DaemonServer {
 /// accepting an [`IpcListener`].
 pub(crate) struct EmbeddedDaemon {
     state: Arc<SharedState>,
+    maintenance_policy: MaintenancePolicy,
     index_writer_rx: Option<tokio::sync::mpsc::UnboundedReceiver<IndexWriterCommand>>,
     index_writer_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    maintenance_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 pub(crate) struct EmbeddedCompileRequest {
@@ -119,8 +121,9 @@ mod client_env;
 mod compile_concurrency;
 mod compiler_hash;
 mod connection;
-mod directory_link;
 mod dependency_policy;
+mod directory_link;
+mod disk_maintenance;
 mod embedded;
 mod handle_clear;
 mod handle_compile;
@@ -160,8 +163,9 @@ pub(crate) use cached_artifact::{CachedArtifact, CachedPayload};
 use client_env::*;
 use compiler_hash::*;
 use connection::handle_connection;
-use directory_link::*;
 use dependency_policy::*;
+use directory_link::*;
+pub(crate) use disk_maintenance::*;
 use handle_clear::*;
 use handle_compile::handle_compile;
 use handle_compile_ephemeral::*;

--- a/crates/zccache-daemon-core/src/daemon/server/persist/directory_bundle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/directory_bundle.rs
@@ -372,7 +372,7 @@ fn install_directory(staged: &Path, requested: &Path) -> std::io::Result<()> {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     {
         atomic_exchange_directories(staged, requested)?;
-        return remove_directory_if_present(staged);
+        remove_directory_if_present(staged)
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {

--- a/crates/zccache-daemon-core/src/daemon/server/persist/fs_caps.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/fs_caps.rs
@@ -184,6 +184,10 @@ fn existing_path(path: &Path) -> Option<NormalizedPath> {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::items_after_test_module,
+    reason = "platform-specific volume identity implementations follow this shared test"
+)]
 mod tests {
     use super::*;
 

--- a/crates/zccache-daemon-core/src/daemon/server/persist/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/mod.rs
@@ -54,11 +54,19 @@ pub(crate) fn scan_v2_disk_artifacts(artifact_dir: &Path) -> std::io::Result<Vec
     staged_store::scan_staged_disk_artifacts(artifact_dir)
 }
 
+#[cfg(test)]
 pub(crate) fn evict_v2_artifact_keys(
     artifact_dir: &Path,
     keys: &std::collections::HashSet<String>,
 ) -> std::io::Result<u64> {
     staged_store::evict_staged_artifact_keys(artifact_dir, keys)
+}
+
+pub(crate) fn evict_v2_artifact_keys_if_unchanged(
+    artifact_dir: &Path,
+    expected: &std::collections::HashMap<String, Option<String>>,
+) -> std::io::Result<std::collections::HashSet<String>> {
+    staged_store::evict_staged_artifact_keys_if_unchanged(artifact_dir, expected)
 }
 
 #[cfg(test)]

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
@@ -732,21 +732,17 @@ impl StagedCompilePlan {
             crate::depgraph::DepfileStrategy::UserSpecified {
                 augment_system_headers,
                 ..
-            } => {
-                crate::depgraph::DepfileStrategy::UserSpecified {
-                    path: staged,
-                    augment_system_headers,
-                }
-            }
+            } => crate::depgraph::DepfileStrategy::UserSpecified {
+                path: staged,
+                augment_system_headers,
+            },
             crate::depgraph::DepfileStrategy::UserDefault {
                 augment_system_headers,
                 ..
-            } => {
-                crate::depgraph::DepfileStrategy::UserDefault {
-                    path: staged,
-                    augment_system_headers,
-                }
-            }
+            } => crate::depgraph::DepfileStrategy::UserDefault {
+                path: staged,
+                augment_system_headers,
+            },
             crate::depgraph::DepfileStrategy::ShowIncludes
             | crate::depgraph::DepfileStrategy::Unsupported => strategy,
         }

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -13,13 +13,20 @@ use std::io::{self, Read, Write};
 use std::path::Path;
 
 mod maintenance;
+#[cfg(test)]
+pub(crate) use maintenance::evict_staged_artifact_keys;
 pub(crate) use maintenance::{
-    evict_staged_artifact_keys, scan_staged_disk_artifacts, StagedDiskArtifact,
+    evict_staged_artifact_keys_if_unchanged, scan_staged_disk_artifacts, StagedDiskArtifact,
 };
 mod materialize;
 pub(in crate::daemon::server) use materialize::{
     materialization_error, materialization_error_progress, materialize_independent_with_stats,
     StagedMaterializationStats,
+};
+mod root_safety;
+pub(in crate::daemon::server) use root_safety::validate_staged_artifact_root;
+use root_safety::{
+    is_staged_link_or_reparse, open_store_lock, remove_staged_link_or_reparse, staged_root,
 };
 #[cfg(test)]
 mod fault;
@@ -251,20 +258,6 @@ pub(in crate::daemon::server) fn is_staged_artifact_root(path: &Path) -> bool {
             name == STAGED_ROOT
         }
     })
-}
-
-fn staged_root(artifact_dir: &Path) -> NormalizedPath {
-    artifact_dir.join(STAGED_ROOT).into()
-}
-
-fn open_store_lock(root: &Path) -> io::Result<File> {
-    fs::create_dir_all(root)?;
-    OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(root.join(STORE_LOCK))
 }
 
 fn validate_key(key_hex: &str) -> io::Result<()> {
@@ -963,8 +956,8 @@ fn remove_staged_tree(path: &Path) -> io::Result<u64> {
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(0),
         Err(error) => return Err(error),
     };
-    if metadata.file_type().is_symlink() {
-        fs::remove_file(path)?;
+    if is_staged_link_or_reparse(&metadata) {
+        remove_staged_link_or_reparse(path, &metadata)?;
         return Ok(0);
     }
     if metadata.is_dir() {
@@ -982,7 +975,7 @@ fn remove_staged_tree(path: &Path) -> io::Result<u64> {
 
 pub(in crate::daemon::server) fn clear_staged_artifacts(artifact_dir: &Path) -> io::Result<u64> {
     let root = staged_root(artifact_dir);
-    if !root.is_dir() {
+    if !validate_staged_artifact_root(artifact_dir)? {
         return Ok(0);
     }
     let store_lock = open_store_lock(&root)?;

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/maintenance.rs
@@ -1,7 +1,10 @@
 //! Disk-budget scanning and eviction for staged v2 artifact generations.
 
-use super::{open_store_lock, pointer_path, remove_staged_tree, staged_key_supported, staged_root};
-use std::collections::HashSet;
+use super::{
+    is_staged_link_or_reparse, open_store_lock, pointer_path, remove_staged_tree,
+    staged_key_supported, staged_root, validate_staged_artifact_root,
+};
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -9,14 +12,23 @@ use std::time::SystemTime;
 
 pub(crate) struct StagedDiskArtifact {
     pub(crate) key: String,
+    #[cfg(test)]
     pub(crate) total_size: u64,
     pub(crate) mtime: SystemTime,
+    /// Committed generation observed while holding the shared store lock.
+    pub(crate) generation: Option<String>,
 }
 
 fn staged_tree_stats(path: &Path) -> io::Result<(u64, SystemTime)> {
     let metadata = fs::symlink_metadata(path)?;
-    if metadata.file_type().is_symlink() {
-        return Ok((0, SystemTime::UNIX_EPOCH));
+    if is_staged_link_or_reparse(&metadata) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing staged artifact scan through linked/reparse path: {}",
+                path.display()
+            ),
+        ));
     }
     let mut size = metadata.len();
     let mut mtime = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
@@ -34,36 +46,70 @@ pub(crate) fn scan_staged_disk_artifacts(
     artifact_dir: &Path,
 ) -> io::Result<Vec<StagedDiskArtifact>> {
     let root = staged_root(artifact_dir);
-    if !root.is_dir() {
+    if !validate_staged_artifact_root(artifact_dir)? {
         return Ok(Vec::new());
     }
     let store_lock = open_store_lock(&root)?;
     fs2::FileExt::lock_shared(&store_lock)?;
+    scan_staged_disk_artifacts_locked(artifact_dir, root.as_path())
+}
+
+fn scan_staged_disk_artifacts_locked(
+    artifact_dir: &Path,
+    root: &Path,
+) -> io::Result<Vec<StagedDiskArtifact>> {
     let mut artifacts = Vec::new();
-    for entry in fs::read_dir(&root)?.flatten() {
+    for entry in fs::read_dir(root)?.flatten() {
         let key_root = entry.path();
-        if !entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+        let key_metadata = fs::symlink_metadata(&key_root)?;
+        if is_staged_link_or_reparse(&key_metadata) {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!(
+                    "refusing staged artifact scan through linked/reparse key root: {}",
+                    key_root.display()
+                ),
+            ));
+        }
+        if !key_metadata.is_dir() {
             continue;
         }
         let key = entry.file_name().to_string_lossy().into_owned();
         if !staged_key_supported(&key) {
             continue;
         }
-        let (mut total_size, mut mtime) = staged_tree_stats(&key_root)?;
+        let (mut _total_size, mut mtime) = staged_tree_stats(&key_root)?;
         let pointer = pointer_path(artifact_dir, &key);
-        if let Ok(metadata) = fs::symlink_metadata(&pointer) {
-            total_size = total_size.saturating_add(metadata.len());
+        let generation = if let Ok(metadata) = fs::symlink_metadata(&pointer) {
+            if is_staged_link_or_reparse(&metadata) {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!(
+                        "refusing staged artifact scan through linked/reparse pointer: {}",
+                        pointer.display()
+                    ),
+                ));
+            }
+            _total_size = _total_size.saturating_add(metadata.len());
             mtime = mtime.max(metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH));
-        }
+            fs::read_to_string(&pointer)
+                .ok()
+                .map(|value| value.trim().to_string())
+        } else {
+            None
+        };
         artifacts.push(StagedDiskArtifact {
             key,
-            total_size,
+            #[cfg(test)]
+            total_size: _total_size,
             mtime,
+            generation,
         });
     }
     Ok(artifacts)
 }
 
+#[cfg(test)]
 pub(crate) fn evict_staged_artifact_keys(
     artifact_dir: &Path,
     keys: &HashSet<String>,
@@ -72,11 +118,65 @@ pub(crate) fn evict_staged_artifact_keys(
         return Ok(0);
     }
     let root = staged_root(artifact_dir);
-    if !root.is_dir() {
+    if !validate_staged_artifact_root(artifact_dir)? {
         return Ok(0);
     }
     let store_lock = open_store_lock(&root)?;
     fs2::FileExt::lock_exclusive(&store_lock)?;
+    evict_staged_artifact_keys_locked(artifact_dir, root.as_path(), keys)
+}
+
+/// Delete only staged generations that still match the maintenance snapshot.
+/// The exclusive lock makes compare-and-delete atomic with respect to staged
+/// publication without blocking writers during legacy scans or planning.
+pub(crate) fn evict_staged_artifact_keys_if_unchanged(
+    artifact_dir: &Path,
+    expected: &HashMap<String, Option<String>>,
+) -> io::Result<HashSet<String>> {
+    if expected.is_empty() {
+        return Ok(HashSet::new());
+    }
+    let root = staged_root(artifact_dir);
+    if !validate_staged_artifact_root(artifact_dir)? {
+        return Ok(HashSet::new());
+    }
+    let store_lock = open_store_lock(&root)?;
+    fs2::FileExt::lock_exclusive(&store_lock)?;
+    let mut removed = HashSet::new();
+    for (key, expected_generation) in expected.iter().filter(|(key, _)| staged_key_supported(key)) {
+        let pointer = pointer_path(artifact_dir, key);
+        let current = match fs::symlink_metadata(&pointer) {
+            Ok(metadata) if is_staged_link_or_reparse(&metadata) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!(
+                        "refusing staged artifact eviction through linked/reparse pointer: {}",
+                        pointer.display()
+                    ),
+                ));
+            }
+            Ok(_) => fs::read_to_string(&pointer)
+                .ok()
+                .map(|value| value.trim().to_string()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error),
+        };
+        if &current != expected_generation {
+            continue;
+        }
+        remove_staged_tree(&root.join(key))?;
+        remove_staged_tree(&pointer_path(artifact_dir, key))?;
+        removed.insert(key.clone());
+    }
+    Ok(removed)
+}
+
+#[cfg(test)]
+fn evict_staged_artifact_keys_locked(
+    artifact_dir: &Path,
+    root: &Path,
+    keys: &HashSet<String>,
+) -> io::Result<u64> {
     let mut bytes_removed: u64 = 0;
     for key in keys.iter().filter(|key| staged_key_supported(key)) {
         bytes_removed = bytes_removed.saturating_add(remove_staged_tree(&root.join(key))?);

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/root_safety.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/root_safety.rs
@@ -1,0 +1,96 @@
+//! Exact-root validation and safe link/reparse removal for staged artifacts.
+
+use super::{STAGED_ROOT, STORE_LOCK};
+use crate::core::NormalizedPath;
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::path::Path;
+
+pub(super) fn staged_root(artifact_dir: &Path) -> NormalizedPath {
+    artifact_dir.join(STAGED_ROOT).into()
+}
+
+pub(super) fn open_store_lock(root: &Path) -> io::Result<File> {
+    if !validate_staged_root_path(root)? {
+        fs::create_dir_all(root)?;
+        if !validate_staged_root_path(root)? {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("staged artifact root disappeared: {}", root.display()),
+            ));
+        }
+    }
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(root.join(STORE_LOCK))
+}
+
+#[cfg(windows)]
+pub(super) fn is_staged_link_or_reparse(metadata: &fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(not(windows))]
+pub(super) fn is_staged_link_or_reparse(metadata: &fs::Metadata) -> bool {
+    metadata.file_type().is_symlink()
+}
+
+#[cfg(windows)]
+pub(super) fn remove_staged_link_or_reparse(
+    path: &Path,
+    metadata: &fs::Metadata,
+) -> io::Result<()> {
+    use std::os::windows::fs::MetadataExt;
+    const FILE_ATTRIBUTE_DIRECTORY: u32 = 0x10;
+    if metadata.file_attributes() & FILE_ATTRIBUTE_DIRECTORY != 0 {
+        fs::remove_dir(path)
+    } else {
+        fs::remove_file(path)
+    }
+}
+
+#[cfg(not(windows))]
+pub(super) fn remove_staged_link_or_reparse(
+    path: &Path,
+    _metadata: &fs::Metadata,
+) -> io::Result<()> {
+    fs::remove_file(path)
+}
+
+pub(super) fn validate_staged_root_path(root: &Path) -> io::Result<bool> {
+    let metadata = match fs::symlink_metadata(root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    if is_staged_link_or_reparse(&metadata) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing staged artifact access through linked/reparse root: {}",
+                root.display()
+            ),
+        ));
+    }
+    if !metadata.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "staged artifact root is not a directory: {}",
+                root.display()
+            ),
+        ));
+    }
+    Ok(true)
+}
+
+pub(in crate::daemon::server) fn validate_staged_artifact_root(
+    artifact_dir: &Path,
+) -> io::Result<bool> {
+    validate_staged_root_path(staged_root(artifact_dir).as_path())
+}

--- a/crates/zccache-daemon-core/src/daemon/server/run.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/run.rs
@@ -16,6 +16,8 @@ impl DaemonServer {
     /// `idle_timeout_secs`: if non-zero, the daemon shuts down after this many
     /// seconds with no client activity. Pass 0 to disable.
     pub async fn run(&mut self, idle_timeout_secs: u64) -> Result<(), crate::ipc::IpcError> {
+        let maintenance_policy =
+            MaintenancePolicy::from_env().map_err(crate::ipc::IpcError::Endpoint)?;
         tracing::info!(
             persist_workers = self.state.persist_semaphore.available_permits(),
             "daemon server running"
@@ -196,42 +198,7 @@ impl DaemonServer {
         // Start background artifact loading (non-blocking so daemon responds
         // immediately — Bug 6 fix).
         {
-            let state = Arc::clone(&self.state);
-            let state2 = Arc::clone(&self.state);
-            tokio::spawn(async move {
-                let artifact_dir = state.artifact_dir.clone();
-                let state_ref = Arc::clone(&state);
-                let loaded = tokio::task::spawn_blocking(move || {
-                    // Load the in-memory index that `ArtifactStore::open` already
-                    // hydrated from the on-disk blob.
-                    let entries = state_ref.artifact_store.load_all();
-                    if !entries.is_empty() {
-                        let count = entries.len();
-                        for (key, meta) in entries {
-                            state_ref
-                                .artifacts
-                                .insert(key, CachedArtifact::from_index(meta));
-                        }
-                        count
-                    } else {
-                        // Migration: legacy `.meta` files predate the redb index
-                        // and the current bincode blob; populate the live store
-                        // from them so the first session after upgrade still has
-                        // its warm cache.
-                        migrate_meta_files(
-                            &artifact_dir,
-                            &state_ref.artifacts,
-                            &state_ref.artifact_store,
-                        )
-                    }
-                })
-                .await
-                .unwrap_or(0);
-                if loaded > 0 {
-                    tracing::info!(loaded, "background artifact loading complete");
-                }
-                state2.artifacts_loaded.store(true, Ordering::Release);
-            });
+            std::mem::drop(spawn_artifact_loader(Arc::clone(&self.state), None).await);
         }
 
         // Start memory eviction background task.
@@ -278,26 +245,14 @@ impl DaemonServer {
             });
         }
 
-        // Start disk artifact GC background task.
-        {
-            let state = Arc::clone(&self.state);
-            let max_cache_size = crate::core::config::Config::default().max_cache_size;
-            let interval_secs = crate::core::config::Config::default().disk_gc_interval_secs;
-            tokio::spawn(async move {
-                // Run once immediately at startup to reclaim excess disk from Bug 5.
-                run_disk_gc_pass(Arc::clone(&state), max_cache_size, "initial").await;
-                loop {
-                    if state.shutdown_requested.load(Ordering::Acquire) {
-                        break;
-                    }
-                    tokio::time::sleep(std::time::Duration::from_secs(interval_secs)).await;
-                    if state.shutdown_requested.load(Ordering::Acquire) {
-                        break;
-                    }
-                    run_disk_gc_pass(Arc::clone(&state), max_cache_size, "periodic").await;
-                }
-            });
-        }
+        // The daemon is the primary maintenance owner. It checks this exact
+        // cache root at startup and every five minutes, with persisted daily
+        // full-age catch-up after idle periods or restarts (issue #1148).
+        let mut maintenance_handle = Some(spawn_disk_maintenance(
+            Arc::clone(&self.state),
+            maintenance_policy,
+            None,
+        ));
 
         // Start periodic depgraph save task (every 5 minutes).
         {
@@ -351,6 +306,9 @@ impl DaemonServer {
                     // notify_one(). Rebroadcast so whichever task observes the
                     // edge first wakes the rest of the shutdown path.
                     self.state.shutdown.notify_waiters();
+                    if let Some(handle) = maintenance_handle.take() {
+                        let _ = handle.await;
+                    }
                     tracing::info!("daemon server shutting down");
                     // Drop the watcher to stop the OS thread and close channels.
                     // The settle buffer and consumer tasks will exit when their
@@ -388,6 +346,13 @@ impl DaemonServer {
                             "timed out waiting for pending artifact writes before WAL drain"
                         );
                     }
+
+                    // Every detached publisher receives an owned read guard
+                    // before its request handler returns. Wait for those
+                    // handoffs before stopping the WAL writer and performing
+                    // the final index snapshot.
+                    let _publication_guard =
+                        self.state.artifact_publication.write().await;
 
                     // Signal the index-writer to drain its WAL to disk, then
                     // wait briefly for it. Without this, unflushed entries are
@@ -755,25 +720,50 @@ impl DaemonServer {
     }
 }
 
-async fn run_disk_gc_pass(state: Arc<SharedState>, max_cache_size: u64, pass: &'static str) {
-    let dir = state.artifact_dir.clone();
-    let artifacts = state.artifacts.clone();
-    // Issue #680: pass the current depgraph snapshot so contexts pointing at
-    // evicted artifacts are invalidated synchronously. Pre-fix the depgraph
-    // kept stale Hit pointers and the next compile reported `artifact_not_found`.
-    let dg = state.dep_graph.load_full();
-    let result = tokio::task::spawn_blocking(move || {
-        super::super::eviction::evict_disk_artifacts(&dir, &artifacts, max_cache_size, Some(&dg))
-    })
-    .await;
-    if let Ok((freed, removed)) = result {
-        if removed > 0 {
-            tracing::info!(
-                freed_bytes = freed,
-                artifacts_removed = removed,
-                gc_pass = pass,
-                "disk GC"
-            );
+/// Start index hydration with publication ownership acquired before spawn.
+/// The optional gate is a deterministic test seam for Clear/startup races.
+pub(super) async fn spawn_artifact_loader(
+    state: Arc<SharedState>,
+    start_gate: Option<Arc<Notify>>,
+) -> tokio::task::JoinHandle<()> {
+    // Acquire before spawning so Clear cannot overtake the startup loader and
+    // then have pre-Clear entries inserted afterward.
+    let publication_guard = Arc::clone(&state.artifact_publication).read_owned().await;
+    tokio::spawn(async move {
+        let _publication_guard = publication_guard;
+        if let Some(gate) = start_gate {
+            gate.notified().await;
         }
-    }
+        let artifact_dir = state.artifact_dir.clone();
+        let state_ref = Arc::clone(&state);
+        let loaded = tokio::task::spawn_blocking(move || {
+            // Load the in-memory index that `ArtifactStore::open` already
+            // hydrated from the on-disk blob.
+            let entries = state_ref.artifact_store.load_all();
+            if !entries.is_empty() {
+                let count = entries.len();
+                for (key, meta) in entries {
+                    state_ref
+                        .artifacts
+                        .insert(key, CachedArtifact::from_index(meta));
+                }
+                count
+            } else {
+                // Migration: legacy `.meta` files predate the redb index and
+                // the current bincode blob; populate the live store from them
+                // so the first session after upgrade still has its warm cache.
+                migrate_meta_files(
+                    &artifact_dir,
+                    &state_ref.artifacts,
+                    &state_ref.artifact_store,
+                )
+            }
+        })
+        .await
+        .unwrap_or(0);
+        if loaded > 0 {
+            tracing::info!(loaded, "background artifact loading complete");
+        }
+        state.artifacts_loaded.store(true, Ordering::Release);
+    })
 }

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -229,6 +229,12 @@ pub(super) struct SharedState {
     pub(super) journal: CompileJournal,
     /// Bytes currently in spawn_blocking persistence tasks, invisible to eviction.
     pub(super) in_flight_bytes: AtomicUsize,
+    /// Serializes background and host-requested disk-maintenance passes for
+    /// this exact cache root.
+    pub(super) disk_maintenance: Mutex<()>,
+    /// Shared by publishers and exclusively owned by maintenance/Clear from
+    /// cache-file mutation through index/live-map mutation.
+    pub(super) artifact_publication: Arc<tokio::sync::RwLock<()>>,
     /// Limits concurrent disk persistence tasks to prevent memory pileup
     /// when disk I/O is slow and compilation requests are fast.
     pub(super) persist_semaphore: Arc<tokio::sync::Semaphore>,

--- a/crates/zccache-daemon-core/src/daemon/server/tests/clear_handler.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/clear_handler.rs
@@ -115,7 +115,15 @@ async fn handle_clear_preserves_in_flight_private_staging() {
         let endpoint = crate::ipc::unique_test_endpoint();
         let tmp = tempfile::tempdir().unwrap();
         let cache_dir = crate::core::NormalizedPath::new(tmp.path());
-        let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+        let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+        // `handle_clear` normally runs inside `DaemonServer::run`, where the
+        // index writer consumes and acknowledges its durable Clear command.
+        // This direct unit-level invocation must start that same worker.
+        let index_writer = tokio::spawn(run_index_writer(
+            server.index_writer_rx.take().unwrap(),
+            Arc::clone(&server.state.artifact_store),
+            Arc::clone(&server.state.index_writer_shutdown),
+        ));
         let staged = server.test_state().staging.path().join("active-output.o");
         std::fs::write(&staged, b"compiler result").unwrap();
         let published = tmp.path().join("published-output.o");
@@ -163,6 +171,70 @@ async fn handle_clear_preserves_in_flight_private_staging() {
         .is_none());
         assert!(!legacy_path.exists());
         assert!(!pack_path.exists());
+        server.state.index_writer_shutdown.notify_waiters();
+        index_writer.await.unwrap();
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn handle_clear_cannot_be_overtaken_by_delayed_startup_hydration() {
+    crate::test_support::test_timeout(async {
+        let endpoint = crate::ipc::unique_test_endpoint();
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+        let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+        let index_writer = tokio::spawn(run_index_writer(
+            server.index_writer_rx.take().unwrap(),
+            Arc::clone(&server.state.artifact_store),
+            Arc::clone(&server.state.index_writer_shutdown),
+        ));
+        let key = "3".repeat(64);
+        let meta = ArtifactIndex::new(
+            vec!["old.o".to_string()],
+            vec![16],
+            Vec::new(),
+            Vec::new(),
+            0,
+        );
+        server.state.artifact_store.insert(&key, &meta);
+        std::fs::write(
+            server.state.artifact_dir.join(format!("{key}_0")),
+            b"old startup artifact",
+        )
+        .unwrap();
+
+        let gate = Arc::new(Notify::new());
+        let loader = super::super::run::spawn_artifact_loader(
+            Arc::clone(&server.state),
+            Some(Arc::clone(&gate)),
+        )
+        .await;
+        let clear_state = Arc::clone(&server.state);
+        let mut clear =
+            tokio::spawn(
+                async move { super::super::handle_clear::handle_clear(&clear_state).await },
+            );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), &mut clear)
+                .await
+                .is_err(),
+            "Clear must wait for startup hydration that already owns publication"
+        );
+
+        gate.notify_one();
+        loader.await.unwrap();
+        let response = tokio::time::timeout(std::time::Duration::from_secs(5), clear)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(response, Response::Cleared { .. }));
+        assert!(!server.state.artifacts.contains_key(&key));
+        assert!(server.state.artifact_store.get(&key).is_none());
+        assert!(!server.state.artifact_dir.join(format!("{key}_0")).exists());
+
+        server.state.index_writer_shutdown.notify_waiters();
+        index_writer.await.unwrap();
     })
     .await;
 }

--- a/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance.rs
@@ -1,0 +1,162 @@
+//! Embedded disk-maintenance API regression tests (issue #1148).
+
+use crate::embedded::{
+    AuditConfig, DiskCacheLimits, DiskMaintenanceKind, DiskMaintenancePressure, HostIdentity,
+    RuntimeHooks, ServiceLimits, ShutdownMode, ZccacheConfig, ZccacheService,
+};
+
+fn test_config(cache_root: crate::core::NormalizedPath, product: &str) -> ZccacheConfig {
+    let mut audit = AuditConfig::default();
+    audit.mode = crate::audit::AuditMode::Off;
+    ZccacheConfig {
+        host: HostIdentity {
+            product: product.into(),
+            instance_id: uuid::Uuid::new_v4().to_string(),
+            workspace_id: format!("{product}-workspace"),
+        },
+        cache_root,
+        audit,
+        limits: ServiceLimits::default(),
+        runtime: RuntimeHooks::default(),
+        cancellation: None,
+    }
+}
+
+#[tokio::test]
+async fn embedded_api_maintains_only_its_configured_root() {
+    let temp = tempfile::TempDir::new().expect("temporary root");
+    let service = ZccacheService::start_with_disk_limits(
+        test_config(temp.path().join("owned").into(), "maintenance-test"),
+        DiskCacheLimits {
+            max_cache_bytes: Some(1),
+            ..DiskCacheLimits::default()
+        },
+    )
+    .await
+    .expect("service start");
+    let cache_root = service.stats().await.expect("stats").cache_root;
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while !cache_root.join(".disk-maintenance-last-full-v1").exists() {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("startup maintenance marker");
+
+    let artifact_dir = cache_root.join("artifacts");
+    std::fs::create_dir_all(&artifact_dir).expect("artifact directory");
+    std::fs::write(artifact_dir.join("key.meta"), vec![0_u8; 1024]).expect("metadata fixture");
+    std::fs::write(artifact_dir.join("key_0"), vec![0_u8; 4096]).expect("payload fixture");
+    let sibling = temp.path().join("another-product");
+    std::fs::create_dir_all(&sibling).expect("sibling root");
+    std::fs::write(sibling.join("sentinel"), b"must survive").expect("sibling sentinel");
+
+    let concurrent = service.clone();
+    let (first, second) = tokio::join!(
+        service.maintain_disk(DiskMaintenanceKind::Pressure),
+        concurrent.maintain_disk(DiskMaintenanceKind::Pressure)
+    );
+    let reports = [first.expect("first pass"), second.expect("second pass")];
+    assert!(reports
+        .iter()
+        .all(|report| report.kind == DiskMaintenanceKind::Pressure));
+    assert!(reports
+        .iter()
+        .any(|report| report.pressure == DiskMaintenancePressure::Hard));
+    assert_eq!(
+        reports
+            .iter()
+            .map(|report| report.artifacts_removed)
+            .sum::<usize>(),
+        1
+    );
+    assert!(!artifact_dir.join("key.meta").exists());
+    assert!(!artifact_dir.join("key_0").exists());
+    assert_eq!(
+        std::fs::read(sibling.join("sentinel")).expect("sibling remains"),
+        b"must survive"
+    );
+
+    service
+        .shutdown(ShutdownMode::Graceful)
+        .await
+        .expect("service shutdown");
+}
+
+#[tokio::test]
+async fn embedded_startup_reclaims_seeded_cache_before_any_compile_traffic() {
+    let temp = tempfile::TempDir::new().expect("temporary root");
+    let top_level: crate::core::NormalizedPath = temp.path().join("product-root").into();
+    let effective = crate::core::config::effective_cache_root_from_top_level(&top_level);
+    let artifact_dir = effective.join("artifacts");
+    std::fs::create_dir_all(&artifact_dir).expect("artifact root");
+    let key = "a".repeat(64);
+    std::fs::write(artifact_dir.join(format!("{key}.meta")), vec![0_u8; 4096])
+        .expect("seed metadata");
+    std::fs::write(artifact_dir.join(format!("{key}_0")), vec![0_u8; 4096]).expect("seed payload");
+
+    let service = ZccacheService::start_with_disk_limits(
+        test_config(top_level, "seeded-maintenance-test"),
+        DiskCacheLimits {
+            max_cache_bytes: Some(1),
+            ..DiskCacheLimits::default()
+        },
+    )
+    .await
+    .expect("service start");
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while !effective.join(".disk-maintenance-last-full-v1").exists() {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("startup catch-up maintenance");
+
+    assert!(!artifact_dir.join(format!("{key}.meta")).exists());
+    assert!(!artifact_dir.join(format!("{key}_0")).exists());
+    service
+        .shutdown(ShutdownMode::Graceful)
+        .await
+        .expect("service shutdown");
+}
+
+#[tokio::test]
+async fn standalone_daemon_startup_expires_seeded_stale_cache() {
+    let temp = tempfile::TempDir::new().expect("temporary root");
+    let cache_dir: crate::core::NormalizedPath = temp.path().join("standalone-root").into();
+    let artifact_dir = crate::core::config::artifacts_dir_from_cache_dir(&cache_dir);
+    std::fs::create_dir_all(&artifact_dir).expect("artifact root");
+    let key = "e".repeat(64);
+    let meta_path = artifact_dir.join(format!("{key}.meta"));
+    let payload_path = artifact_dir.join(format!("{key}_0"));
+    std::fs::write(&meta_path, b"invalid legacy metadata").expect("seed metadata");
+    std::fs::write(&payload_path, vec![0_u8; 4096]).expect("seed payload");
+    let stale = filetime::FileTime::from_system_time(
+        std::time::SystemTime::now() - std::time::Duration::from_secs(31 * 24 * 60 * 60),
+    );
+    filetime::set_file_mtime(&meta_path, stale).expect("age metadata");
+    filetime::set_file_mtime(&payload_path, stale).expect("age payload");
+
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let mut server = super::super::DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir)
+        .expect("standalone bind");
+    let shutdown = server.shutdown_handle();
+    let task = tokio::spawn(async move { server.run(0).await });
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while !cache_dir.join(".disk-maintenance-last-full-v1").exists() {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("standalone startup maintenance");
+
+    assert!(!meta_path.exists());
+    assert!(!payload_path.exists());
+    shutdown.notify_one();
+    task.await
+        .expect("standalone task join")
+        .expect("standalone shutdown");
+}

--- a/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
@@ -1,0 +1,657 @@
+//! Unit tests for daemon-owned bounded retention (issue #1148).
+
+use super::*;
+
+const DAY: Duration = Duration::from_secs(24 * 60 * 60);
+
+fn artifact(key: &str, bytes: u64, now: SystemTime, age: Duration) -> DiskArtifact {
+    DiskArtifact {
+        key: key.to_string(),
+        allocated_bytes: bytes,
+        last_access: now - age,
+        legacy_files: Vec::new(),
+        staged: false,
+        staged_generation: None,
+    }
+}
+
+fn bytes_policy(bytes: u64) -> MaintenancePolicy {
+    MaintenancePolicy {
+        budget: BudgetSpec::Bytes(bytes),
+    }
+}
+
+struct FixedEnvironment {
+    now: SystemTime,
+    space: FilesystemSpace,
+}
+
+impl MaintenanceEnvironment for FixedEnvironment {
+    fn now(&self) -> SystemTime {
+        self.now
+    }
+
+    fn filesystem_space(&self, _root: &Path) -> io::Result<FilesystemSpace> {
+        Ok(self.space)
+    }
+}
+
+#[test]
+fn issue_1148_default_budget_is_five_percent_clamped_to_40_200_gib() {
+    let policy = MaintenancePolicy::default();
+    assert_eq!(policy.budget_bytes(30 * GIB), 15 * GIB);
+    assert_eq!(policy.budget_bytes(40 * GIB), 20 * GIB);
+    assert_eq!(policy.budget_bytes(100 * GIB), 40 * GIB);
+    assert_eq!(policy.budget_bytes(1024 * GIB), 51 * GIB + 214_748_364);
+    assert_eq!(policy.budget_bytes(10_000 * GIB), 200 * GIB);
+}
+
+#[test]
+fn issue_1148_override_parser_rejects_ambiguity_and_invalid_values() {
+    assert!(MaintenancePolicy::from_values(Some("1"), Some("5")).is_err());
+    assert!(MaintenancePolicy::from_values(Some("0"), None).is_err());
+    assert!(MaintenancePolicy::from_values(None, Some("0")).is_err());
+    assert!(MaintenancePolicy::from_values(None, Some("101")).is_err());
+    assert_eq!(
+        MaintenancePolicy::from_values(Some("42949672960"), None)
+            .unwrap()
+            .budget_bytes(1024 * GIB),
+        40 * GIB
+    );
+    assert!(MaintenancePolicy::from_limits(Some(1), Some(5)).is_err());
+    assert!(MaintenancePolicy::from_limits(Some(0), None).is_err());
+    assert!(MaintenancePolicy::from_limits(None, Some(101)).is_err());
+    assert_eq!(
+        MaintenancePolicy::from_values(None, Some("10"))
+            .unwrap()
+            .budget_bytes(1024 * GIB),
+        102 * GIB + 429_496_729
+    );
+}
+
+#[test]
+fn issue_1148_full_marker_makes_missed_idle_pass_due_on_restart() {
+    let root = tempfile::tempdir().unwrap();
+    let now = SystemTime::UNIX_EPOCH + 100 * DAY;
+    assert!(full_maintenance_due(root.path(), now));
+    record_full_maintenance(root.path(), now).unwrap();
+    assert!(!full_maintenance_due(
+        root.path(),
+        now + FULL_INTERVAL - Duration::from_secs(1)
+    ));
+    assert!(full_maintenance_due(root.path(), now + FULL_INTERVAL));
+    assert!(full_maintenance_due(
+        root.path(),
+        now - Duration::from_secs(1)
+    ));
+    std::fs::write(full_marker_path(root.path()), b"corrupt\n").unwrap();
+    assert!(full_maintenance_due(root.path(), now));
+}
+
+#[test]
+fn issue_1148_eviction_updates_files_live_map_index_and_only_owned_root() {
+    let root = tempfile::tempdir().unwrap();
+    let artifact_dir = root.path().join("owned").join("artifacts");
+    let sibling = root.path().join("sibling");
+    std::fs::create_dir_all(&artifact_dir).unwrap();
+    std::fs::create_dir_all(&sibling).unwrap();
+    std::fs::write(artifact_dir.join("key.meta"), vec![0_u8; 1024]).unwrap();
+    std::fs::write(artifact_dir.join("key_0"), vec![0_u8; 4096]).unwrap();
+    std::fs::write(sibling.join("sentinel"), b"owned by another product").unwrap();
+
+    let meta = ArtifactIndex::new(
+        vec!["output.o".to_string()],
+        vec![4096],
+        Vec::new(),
+        Vec::new(),
+        0,
+    );
+    let artifacts = DashMap::new();
+    artifacts.insert("key".to_string(), CachedArtifact::from_index(meta.clone()));
+    let store = ArtifactStore::open_empty(&root.path().join("index.bin"));
+    store.insert("key", &meta);
+    let dep_graph = DepGraph::new();
+    let report = maintain_disk_artifacts(MaintenancePass {
+        artifact_dir: &artifact_dir,
+        artifacts: &artifacts,
+        artifact_store: &store,
+        index_writer_tx: None,
+        dep_graph: &dep_graph,
+        pending_write_bytes: 0,
+        policy: bytes_policy(1),
+        kind: MaintenanceKind::Pressure,
+        environment: &FixedEnvironment {
+            now: SystemTime::UNIX_EPOCH + 100 * DAY,
+            space: FilesystemSpace {
+                capacity_bytes: 1000 * GIB,
+                free_bytes: 500 * GIB,
+            },
+        },
+    })
+    .unwrap();
+
+    assert_eq!(report.pressure, MaintenancePressure::Hard);
+    assert_eq!(report.artifacts_removed, 1);
+    assert!(report.bytes_reclaimed > 0);
+    assert_eq!(report.usage_after_bytes, 0);
+    assert!(!artifact_dir.join("key.meta").exists());
+    assert!(!artifact_dir.join("key_0").exists());
+    assert!(!artifacts.contains_key("key"));
+    assert!(store.get("key").is_none());
+    assert_eq!(
+        std::fs::read(sibling.join("sentinel")).unwrap(),
+        b"owned by another product"
+    );
+}
+
+#[test]
+fn issue_1148_live_and_persisted_access_control_full_expiry() {
+    let root = tempfile::tempdir().unwrap();
+    let artifact_dir = root.path().join("artifacts");
+    std::fs::create_dir_all(&artifact_dir).unwrap();
+    let meta_path = artifact_dir.join("key.meta");
+    let payload_path = artifact_dir.join("key_0");
+    std::fs::write(&meta_path, vec![0_u8; 1024]).unwrap();
+    std::fs::write(&payload_path, vec![0_u8; 4096]).unwrap();
+    let now = SystemTime::now();
+    let old = now - 31 * DAY;
+    let old_time = filetime::FileTime::from_system_time(old);
+    filetime::set_file_mtime(&meta_path, old_time).unwrap();
+    filetime::set_file_mtime(&payload_path, old_time).unwrap();
+
+    let store = ArtifactStore::open_empty(&root.path().join("index.bin"));
+    let dep_graph = DepGraph::new();
+    let environment = FixedEnvironment {
+        now,
+        space: FilesystemSpace {
+            capacity_bytes: 1000 * GIB,
+            free_bytes: 500 * GIB,
+        },
+    };
+    let fresh_meta = ArtifactIndex::new(
+        vec!["output.o".to_string()],
+        vec![4096],
+        Vec::new(),
+        Vec::new(),
+        0,
+    );
+    let artifacts = DashMap::new();
+    artifacts.insert(
+        "key".to_string(),
+        CachedArtifact::from_index(fresh_meta.clone()),
+    );
+    store.insert("key", &fresh_meta);
+
+    let protected = maintain_disk_artifacts(MaintenancePass {
+        artifact_dir: &artifact_dir,
+        artifacts: &artifacts,
+        artifact_store: &store,
+        index_writer_tx: None,
+        dep_graph: &dep_graph,
+        pending_write_bytes: 0,
+        policy: bytes_policy(1000 * GIB),
+        kind: MaintenanceKind::Full,
+        environment: &environment,
+    })
+    .unwrap();
+    assert_eq!(protected.artifacts_removed, 0);
+    assert!(meta_path.exists());
+
+    artifacts.clear();
+    store.clear();
+    let mut stale_meta = fresh_meta;
+    stale_meta.stored_at_secs = old
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    artifacts.insert(
+        "key".to_string(),
+        CachedArtifact::from_index(stale_meta.clone()),
+    );
+    store.insert("key", &stale_meta);
+    let expired = maintain_disk_artifacts(MaintenancePass {
+        artifact_dir: &artifact_dir,
+        artifacts: &artifacts,
+        artifact_store: &store,
+        index_writer_tx: None,
+        dep_graph: &dep_graph,
+        pending_write_bytes: 0,
+        policy: bytes_policy(1000 * GIB),
+        kind: MaintenanceKind::Full,
+        environment: &environment,
+    })
+    .unwrap();
+    assert_eq!(expired.expired_artifacts_removed, 1);
+    assert!(!meta_path.exists());
+    assert!(!payload_path.exists());
+}
+
+#[test]
+fn issue_1148_soft_pressure_only_removes_entries_older_than_four_days() {
+    let now = SystemTime::UNIX_EPOCH + 100 * DAY;
+    let entries = vec![
+        artifact("boundary", 10, now, 4 * DAY),
+        artifact("stale", 20, now, 4 * DAY + Duration::from_secs(1)),
+        artifact("fresh", 60, now, DAY),
+    ];
+    let plan = plan_maintenance(
+        bytes_policy(100),
+        MaintenanceKind::Pressure,
+        now,
+        FilesystemSpace {
+            capacity_bytes: 1000 * GIB,
+            free_bytes: 500 * GIB,
+        },
+        &entries,
+        0,
+    );
+    assert_eq!(plan.pressure, MaintenancePressure::Soft);
+    assert_eq!(plan.selected, vec!["stale"]);
+}
+
+#[test]
+fn issue_1148_hard_pressure_removes_fresh_lru_to_eighty_percent() {
+    let now = SystemTime::UNIX_EPOCH + 100 * DAY;
+    let entries = vec![
+        artifact("old", 30, now, 2 * DAY),
+        artifact("new", 80, now, DAY),
+    ];
+    let plan = plan_maintenance(
+        bytes_policy(100),
+        MaintenanceKind::Pressure,
+        now,
+        FilesystemSpace {
+            capacity_bytes: 1000 * GIB,
+            free_bytes: 500 * GIB,
+        },
+        &entries,
+        0,
+    );
+    assert_eq!(plan.pressure, MaintenancePressure::Hard);
+    assert_eq!(plan.selected, vec!["old"]);
+}
+
+#[test]
+fn issue_1148_full_pass_expires_only_older_than_thirty_days() {
+    let now = SystemTime::UNIX_EPOCH + 100 * DAY;
+    let entries = vec![
+        artifact("boundary", 10, now, 30 * DAY),
+        artifact("expired", 10, now, 30 * DAY + Duration::from_secs(1)),
+    ];
+    let plan = plan_maintenance(
+        bytes_policy(1000),
+        MaintenanceKind::Full,
+        now,
+        FilesystemSpace {
+            capacity_bytes: 1000 * GIB,
+            free_bytes: 500 * GIB,
+        },
+        &entries,
+        0,
+    );
+    assert_eq!(plan.pressure, MaintenancePressure::None);
+    assert_eq!(plan.selected, vec!["expired"]);
+}
+
+#[cfg(unix)]
+#[test]
+fn issue_1148_hardlinks_are_counted_once_and_sibling_root_is_untouched() {
+    let root = tempfile::tempdir().unwrap();
+    let artifact_dir = root.path().join("owned");
+    let sibling = root.path().join("sibling");
+    std::fs::create_dir_all(&artifact_dir).unwrap();
+    std::fs::create_dir_all(&sibling).unwrap();
+    std::fs::write(artifact_dir.join("key.meta"), vec![0_u8; 4096]).unwrap();
+    std::fs::hard_link(artifact_dir.join("key.meta"), artifact_dir.join("key_0")).unwrap();
+    std::fs::write(sibling.join("sentinel"), b"do not inspect or delete").unwrap();
+    let scanned = scan_artifacts(&artifact_dir).unwrap();
+    assert_eq!(scanned.len(), 1);
+    let meta_path = artifact_dir.join("key.meta");
+    let allocated = allocated_bytes(&meta_path, &std::fs::metadata(&meta_path).unwrap());
+    assert_eq!(scanned[0].allocated_bytes, allocated);
+    assert_eq!(
+        std::fs::read(sibling.join("sentinel")).unwrap(),
+        b"do not inspect or delete"
+    );
+}
+
+#[test]
+fn issue_1148_under_budget_and_healthy_disk_is_a_noop() {
+    let now = SystemTime::UNIX_EPOCH + 100 * DAY;
+    let entries = vec![artifact("fresh", 49, now, DAY)];
+    let plan = plan_maintenance(
+        bytes_policy(100),
+        MaintenanceKind::Pressure,
+        now,
+        FilesystemSpace {
+            capacity_bytes: 1000 * GIB,
+            free_bytes: 500 * GIB,
+        },
+        &entries,
+        0,
+    );
+    assert_eq!(plan.pressure, MaintenancePressure::None);
+    assert!(plan.selected.is_empty());
+}
+
+#[test]
+fn issue_1148_low_free_space_forces_hard_pressure_below_budget() {
+    let now = SystemTime::UNIX_EPOCH + 100 * DAY;
+    let entries = vec![artifact("fresh", 10, now, Duration::from_secs(1))];
+    let plan = plan_maintenance(
+        bytes_policy(40 * GIB),
+        MaintenanceKind::Pressure,
+        now,
+        FilesystemSpace {
+            capacity_bytes: 100 * GIB,
+            free_bytes: 19 * GIB,
+        },
+        &entries,
+        0,
+    );
+    assert_eq!(plan.pressure, MaintenancePressure::Hard);
+    assert_eq!(plan.selected, vec!["fresh"]);
+}
+
+#[test]
+fn issue_1148_private_publication_temps_are_never_cache_entries() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(root.path().join(".abc_0.tmp-123-4"), vec![0_u8; 4096]).unwrap();
+    std::fs::write(root.path().join(".cowhash-deadbeef"), b"digest").unwrap();
+    assert!(scan_artifacts(root.path()).unwrap().is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn issue_1148_cross_artifact_hardlink_replans_until_target_is_real() {
+    let root = tempfile::tempdir().unwrap();
+    let artifact_dir = root.path().join("artifacts");
+    std::fs::create_dir_all(&artifact_dir).unwrap();
+    let first = "a".repeat(64);
+    let second = "b".repeat(64);
+    let first_path = artifact_dir.join(format!("{first}.meta"));
+    let second_path = artifact_dir.join(format!("{second}.meta"));
+    std::fs::write(&first_path, vec![0_u8; 4096]).unwrap();
+    std::fs::hard_link(&first_path, &second_path).unwrap();
+
+    let artifacts = DashMap::new();
+    let store = ArtifactStore::open_empty(&root.path().join("index.bin"));
+    let dep_graph = DepGraph::new();
+    let report = maintain_disk_artifacts(MaintenancePass {
+        artifact_dir: &artifact_dir,
+        artifacts: &artifacts,
+        artifact_store: &store,
+        index_writer_tx: None,
+        dep_graph: &dep_graph,
+        pending_write_bytes: 0,
+        policy: bytes_policy(1),
+        kind: MaintenanceKind::Pressure,
+        environment: &FixedEnvironment {
+            now: SystemTime::now(),
+            space: FilesystemSpace {
+                capacity_bytes: 1000 * GIB,
+                free_bytes: 500 * GIB,
+            },
+        },
+    })
+    .unwrap();
+
+    assert_eq!(report.artifacts_removed, 2);
+    assert_eq!(report.usage_after_bytes, 0);
+    assert!(!first_path.exists());
+    assert!(!second_path.exists());
+}
+
+#[test]
+fn issue_1148_mixed_legacy_pack_and_staged_layouts_are_reclaimed() {
+    let root = tempfile::tempdir().unwrap();
+    let artifact_dir = root.path().join("artifacts");
+    std::fs::create_dir_all(&artifact_dir).unwrap();
+    let legacy = "a".repeat(64);
+    let packed = "b".repeat(64);
+    let staged = "c".repeat(64);
+    std::fs::write(
+        artifact_dir.join(format!("{legacy}.meta")),
+        vec![0_u8; 4096],
+    )
+    .unwrap();
+    std::fs::write(
+        artifact_dir.join(format!("{packed}.pack")),
+        vec![0_u8; 4096],
+    )
+    .unwrap();
+    let source = root.path().join("staged-source");
+    std::fs::write(&source, vec![0_u8; 4096]).unwrap();
+    persist_staged_artifact_paths(&artifact_dir, &staged, &[source.into()]).unwrap();
+
+    let artifacts = DashMap::new();
+    let store = ArtifactStore::open_empty(&root.path().join("index.bin"));
+    let dep_graph = DepGraph::new();
+    let report = maintain_disk_artifacts(MaintenancePass {
+        artifact_dir: &artifact_dir,
+        artifacts: &artifacts,
+        artifact_store: &store,
+        index_writer_tx: None,
+        dep_graph: &dep_graph,
+        pending_write_bytes: 0,
+        policy: bytes_policy(1),
+        kind: MaintenanceKind::Pressure,
+        environment: &FixedEnvironment {
+            now: SystemTime::now(),
+            space: FilesystemSpace {
+                capacity_bytes: 1000 * GIB,
+                free_bytes: 500 * GIB,
+            },
+        },
+    })
+    .unwrap();
+
+    assert_eq!(report.artifacts_removed, 3);
+    assert_eq!(report.usage_after_bytes, 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn issue_1148_linked_artifact_root_cannot_escape_product_ownership() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().unwrap();
+    let sibling = root.path().join("another-product");
+    let linked = root.path().join("artifacts");
+    std::fs::create_dir_all(&sibling).unwrap();
+    std::fs::write(sibling.join("sentinel"), b"survives").unwrap();
+    symlink(&sibling, &linked).unwrap();
+
+    let artifacts = DashMap::new();
+    let store = ArtifactStore::open_empty(&root.path().join("index.bin"));
+    let dep_graph = DepGraph::new();
+    let error = maintain_disk_artifacts(MaintenancePass {
+        artifact_dir: &linked,
+        artifacts: &artifacts,
+        artifact_store: &store,
+        index_writer_tx: None,
+        dep_graph: &dep_graph,
+        pending_write_bytes: 0,
+        policy: bytes_policy(1),
+        kind: MaintenanceKind::Pressure,
+        environment: &FixedEnvironment {
+            now: SystemTime::now(),
+            space: FilesystemSpace {
+                capacity_bytes: 1000 * GIB,
+                free_bytes: 500 * GIB,
+            },
+        },
+    })
+    .unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    assert_eq!(
+        std::fs::read(sibling.join("sentinel")).unwrap(),
+        b"survives"
+    );
+}
+
+#[cfg(any(unix, windows))]
+#[test]
+fn issue_1148_linked_staged_root_cannot_escape_product_ownership() {
+    let root = tempfile::tempdir().unwrap();
+    let artifact_dir = root.path().join("owned").join("artifacts");
+    let sibling = root.path().join("another-product");
+    let linked_staged = artifact_dir.join(".staged-v2");
+    std::fs::create_dir_all(&artifact_dir).unwrap();
+    std::fs::create_dir_all(&sibling).unwrap();
+    std::fs::write(sibling.join("sentinel"), b"survives nested link").unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&sibling, &linked_staged).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(&sibling, &linked_staged).unwrap();
+
+    let artifacts = DashMap::new();
+    let store = ArtifactStore::open_empty(&root.path().join("index.bin"));
+    let dep_graph = DepGraph::new();
+    let error = maintain_disk_artifacts(MaintenancePass {
+        artifact_dir: &artifact_dir,
+        artifacts: &artifacts,
+        artifact_store: &store,
+        index_writer_tx: None,
+        dep_graph: &dep_graph,
+        pending_write_bytes: 0,
+        policy: bytes_policy(1),
+        kind: MaintenanceKind::Pressure,
+        environment: &FixedEnvironment {
+            now: SystemTime::now(),
+            space: FilesystemSpace {
+                capacity_bytes: 1000 * GIB,
+                free_bytes: 500 * GIB,
+            },
+        },
+    })
+    .unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    assert_eq!(
+        std::fs::read(sibling.join("sentinel")).unwrap(),
+        b"survives nested link"
+    );
+}
+
+#[test]
+fn issue_1148_future_persisted_access_is_clamped_at_restore() {
+    let mut meta = ArtifactIndex::new(vec![], vec![], Vec::new(), Vec::new(), 0);
+    meta.stored_at_secs = (SystemTime::now() + 365 * DAY)
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let restored = CachedArtifact::from_index(meta);
+    assert!(restored.last_used_wall <= SystemTime::now());
+    assert!(!restored.used_in_process);
+    assert!(restored.last_access_checkpoint.is_none());
+}
+
+#[test]
+fn issue_1148_windows_allocated_size_combines_high_low_and_falls_back() {
+    assert_eq!(
+        windows_allocated_size_result(7, 1, 0, 99),
+        (1_u64 << 32) | 7
+    );
+    assert_eq!(windows_allocated_size_result(u32::MAX, 0, 5, 99), 99);
+}
+
+#[tokio::test]
+async fn issue_1148_publication_barrier_orders_insert_before_gc_remove() {
+    let root = tempfile::tempdir().unwrap();
+    let cache_dir: crate::core::NormalizedPath = root.path().join("cache").into();
+    let daemon = Arc::new(
+        EmbeddedDaemon::start(
+            crate::ipc::unique_test_endpoint(),
+            cache_dir.clone(),
+            None,
+            bytes_policy(1),
+        )
+        .await
+        .unwrap(),
+    );
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !full_marker_path(cache_dir.as_path()).exists() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+    let key = "d".repeat(64);
+    let artifact_dir = daemon.state.artifact_dir.clone();
+    std::fs::write(artifact_dir.join(format!("{key}.meta")), vec![0_u8; 4096]).unwrap();
+    let meta = ArtifactIndex::new(vec![], vec![], Vec::new(), Vec::new(), 0);
+
+    let publication_guard = daemon.state.artifact_publication.read().await;
+    daemon
+        .state
+        .artifacts
+        .insert(key.clone(), CachedArtifact::from_index(meta.clone()));
+    daemon
+        .state
+        .index_writer_tx
+        .send(IndexWriterCommand::Insert(key.clone(), meta))
+        .unwrap();
+    let maintenance_daemon = Arc::clone(&daemon);
+    let maintenance = tokio::spawn(async move {
+        maintenance_daemon
+            .maintain_disk(MaintenanceKind::Pressure)
+            .await
+    });
+    tokio::task::yield_now().await;
+    drop(publication_guard);
+
+    let report = maintenance.await.unwrap().unwrap();
+    assert_eq!(report.artifacts_removed, 1);
+    assert!(!daemon.state.artifacts.contains_key(&key));
+    let index_path = crate::core::config::index_path_from_cache_dir(&cache_dir);
+    let reopened = ArtifactStore::open(index_path.as_path()).unwrap();
+    assert!(reopened.get(&key).is_none());
+    let _ = daemon.shutdown().await;
+}
+
+#[tokio::test]
+async fn issue_1148_shutdown_waits_for_running_maintenance() {
+    let root = tempfile::tempdir().unwrap();
+    let cache_dir: crate::core::NormalizedPath = root.path().join("cache").into();
+    let daemon = Arc::new(
+        EmbeddedDaemon::start(
+            crate::ipc::unique_test_endpoint(),
+            cache_dir.clone(),
+            None,
+            bytes_policy(1),
+        )
+        .await
+        .unwrap(),
+    );
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !full_marker_path(cache_dir.as_path()).exists() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+    let publication_guard = daemon.state.artifact_publication.read().await;
+    let maintenance_daemon = Arc::clone(&daemon);
+    let maintenance = tokio::spawn(async move {
+        maintenance_daemon
+            .maintain_disk(MaintenanceKind::Pressure)
+            .await
+    });
+    tokio::task::yield_now().await;
+
+    let shutdown_daemon = Arc::clone(&daemon);
+    let mut shutdown = tokio::spawn(async move { shutdown_daemon.shutdown().await });
+    assert!(
+        tokio::time::timeout(Duration::from_millis(25), &mut shutdown)
+            .await
+            .is_err(),
+        "shutdown must wait for the pass holding/awaiting the publication barrier"
+    );
+    drop(publication_guard);
+
+    let _ = maintenance.await.unwrap();
+    let report = shutdown.await.unwrap();
+    assert!(report.pending_writes_drained);
+}

--- a/crates/zccache-daemon-core/src/daemon/server/tests/embedded_flush.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/embedded_flush.rs
@@ -2,14 +2,43 @@
 
 use super::super::*;
 
+async fn schedule_blocked_exec_publisher(
+    state: &Arc<SharedState>,
+    key: &str,
+) -> tokio::sync::OwnedSemaphorePermit {
+    let permit_count = state.persist_semaphore.available_permits() as u32;
+    let blocked = Arc::clone(&state.persist_semaphore)
+        .acquire_many_owned(permit_count)
+        .await
+        .unwrap();
+    let artifact = ArtifactData {
+        outputs: vec![ArtifactOutput {
+            name: "result.bin".to_string(),
+            payload: ArtifactPayload::Bytes(Arc::new(b"durable before lifecycle return".to_vec())),
+        }],
+        stdout: Arc::new(Vec::new()),
+        stderr: Arc::new(Vec::new()),
+        exit_code: 0,
+    };
+    super::super::handle_exec::store_exec_artifact(state, key.to_string(), artifact, None)
+        .await
+        .unwrap();
+    blocked
+}
+
 #[tokio::test(start_paused = true)]
 async fn embedded_flush_persists_queued_index_rows_before_returning() {
     let tmp = tempfile::tempdir().unwrap();
     let cache_dir = crate::core::NormalizedPath::new(tmp.path());
     let endpoint = crate::ipc::unique_test_endpoint();
-    let daemon = EmbeddedDaemon::start(endpoint, cache_dir.clone(), None)
-        .await
-        .unwrap();
+    let daemon = EmbeddedDaemon::start(
+        endpoint,
+        cache_dir.clone(),
+        None,
+        MaintenancePolicy::default(),
+    )
+    .await
+    .unwrap();
     let state = Arc::clone(&daemon.state);
 
     let expected = 37usize;
@@ -33,6 +62,160 @@ async fn embedded_flush_persists_queued_index_rows_before_returning() {
     assert_eq!(reopened.len(), state.artifact_store.len());
     assert_eq!(reopened.len(), expected);
 
+    let _ = daemon.shutdown().await;
+}
+
+#[tokio::test]
+async fn embedded_flush_waits_for_detached_publisher_handoff() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let daemon = Arc::new(
+        EmbeddedDaemon::start(
+            crate::ipc::unique_test_endpoint(),
+            cache_dir.clone(),
+            None,
+            MaintenancePolicy::default(),
+        )
+        .await
+        .unwrap(),
+    );
+    let key = "7".repeat(64);
+    let blocked = schedule_blocked_exec_publisher(&daemon.state, &key).await;
+
+    let flush_daemon = Arc::clone(&daemon);
+    let mut flush = tokio::spawn(async move { flush_daemon.flush().await });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(25), &mut flush)
+            .await
+            .is_err(),
+        "flush must wait for a detached publisher scheduled before it"
+    );
+    drop(blocked);
+    let report = tokio::time::timeout(std::time::Duration::from_secs(5), flush)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(report.pending_writes_drained);
+    assert!(daemon.state.artifact_store.get(&key).is_some());
+    let reopened = crate::artifact::ArtifactStore::open(
+        crate::core::config::index_path_from_cache_dir(&cache_dir).as_path(),
+    )
+    .unwrap();
+    assert!(reopened.get(&key).is_some());
+    let _ = daemon.shutdown().await;
+}
+
+#[tokio::test]
+async fn embedded_shutdown_waits_for_detached_publisher_before_stopping_writer() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let daemon = Arc::new(
+        EmbeddedDaemon::start(
+            crate::ipc::unique_test_endpoint(),
+            cache_dir.clone(),
+            None,
+            MaintenancePolicy::default(),
+        )
+        .await
+        .unwrap(),
+    );
+    let key = "8".repeat(64);
+    let blocked = schedule_blocked_exec_publisher(&daemon.state, &key).await;
+
+    let shutdown_daemon = Arc::clone(&daemon);
+    let mut shutdown = tokio::spawn(async move { shutdown_daemon.shutdown().await });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(25), &mut shutdown)
+            .await
+            .is_err(),
+        "shutdown must wait before stopping the index writer"
+    );
+    drop(blocked);
+    let report = tokio::time::timeout(std::time::Duration::from_secs(5), shutdown)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(report.pending_writes_drained);
+    let reopened = crate::artifact::ArtifactStore::open(
+        crate::core::config::index_path_from_cache_dir(&cache_dir).as_path(),
+    )
+    .unwrap();
+    assert!(reopened.get(&key).is_some());
+}
+
+#[tokio::test]
+async fn publisher_arriving_after_embedded_shutdown_cannot_reopen_cache() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let daemon = Arc::new(
+        EmbeddedDaemon::start(
+            crate::ipc::unique_test_endpoint(),
+            cache_dir,
+            None,
+            MaintenancePolicy::default(),
+        )
+        .await
+        .unwrap(),
+    );
+    let key = "6".repeat(64);
+    let report = daemon.shutdown().await;
+    assert!(report.pending_writes_drained);
+
+    let artifact = ArtifactData {
+        outputs: vec![ArtifactOutput {
+            name: "late.bin".to_string(),
+            payload: ArtifactPayload::Bytes(Arc::new(b"must not publish".to_vec())),
+        }],
+        stdout: Arc::new(Vec::new()),
+        stderr: Arc::new(Vec::new()),
+        exit_code: 0,
+    };
+    super::super::handle_exec::store_exec_artifact(&daemon.state, key.clone(), artifact, None)
+        .await
+        .unwrap();
+
+    assert!(!daemon.state.artifacts.contains_key(&key));
+    assert!(daemon.state.artifact_store.get(&key).is_none());
+    assert!(!daemon.state.artifact_dir.join(format!("{key}_0")).exists());
+}
+
+#[tokio::test]
+async fn publisher_queued_behind_shutdown_writer_rechecks_latched_flag() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let daemon = Arc::new(
+        EmbeddedDaemon::start(
+            crate::ipc::unique_test_endpoint(),
+            cache_dir,
+            None,
+            MaintenancePolicy::default(),
+        )
+        .await
+        .unwrap(),
+    );
+    let shutdown_writer = Arc::clone(&daemon.state.artifact_publication)
+        .write_owned()
+        .await;
+    let publisher_state = Arc::clone(&daemon.state);
+    let mut publisher =
+        tokio::spawn(async move { begin_artifact_publication(&publisher_state).await });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(25), &mut publisher)
+            .await
+            .is_err(),
+        "publisher must queue behind the shutdown writer"
+    );
+
+    daemon
+        .state
+        .shutdown_requested
+        .store(true, Ordering::Release);
+    drop(shutdown_writer);
+    let guard = tokio::time::timeout(std::time::Duration::from_secs(5), publisher)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(guard.is_none(), "queued publisher must re-check shutdown");
     let _ = daemon.shutdown().await;
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/tests/fingerprint.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/fingerprint.rs
@@ -513,10 +513,7 @@ fn request_fingerprint_includes_rust_key_env() {
 #[test]
 fn request_fingerprint_separates_dependency_policy_env() {
     let args = vec!["-c".to_string(), "src/main.cpp".to_string()];
-    let safe = vec![(
-        "ZCCACHE_SCAN_SYSTEM_HEADERS".to_string(),
-        "1".to_string(),
-    )];
+    let safe = vec![("ZCCACHE_SCAN_SYSTEM_HEADERS".to_string(), "1".to_string())];
     let fast = vec![("ZCCACHE_FAST".to_string(), "1".to_string())];
 
     let safe_key = request_fingerprint(
@@ -563,13 +560,7 @@ fn request_fingerprint_preserves_raw_user_depfile_paths() {
     args_b[3] = args_a[3].clone();
     args_b[5] = "-MF-".into();
     args_b.remove(6);
-    let stdout = request_fingerprint(
-        Path::new("clang++"),
-        &args_b,
-        root_a,
-        Some(root_a),
-        None,
-    );
+    let stdout = request_fingerprint(Path::new("clang++"), &args_b, root_a, Some(root_a), None);
     assert_ne!(a, stdout);
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
@@ -11,6 +11,7 @@ mod clear_handler;
 mod client_env;
 mod compiler_hash;
 mod deferred_cold_path;
+mod disk_maintenance;
 mod embedded_flush;
 mod exec_probe;
 mod fingerprint;

--- a/crates/zccache-daemon-core/src/daemon/server/util.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/util.rs
@@ -2,6 +2,36 @@
 
 use super::*;
 
+/// Enter an artifact-publication critical section unless shutdown has closed
+/// the daemon to new publishers.
+///
+/// The shutdown flag must be checked *after* acquiring the fair Tokio lock:
+/// a request may have started before shutdown but queued behind shutdown's
+/// writer. In that case it must not publish after the writer drains and the
+/// index task has stopped.
+pub(super) async fn begin_artifact_publication(
+    state: &SharedState,
+) -> Option<tokio::sync::OwnedRwLockReadGuard<()>> {
+    let guard = Arc::clone(&state.artifact_publication).read_owned().await;
+    if state.shutdown_requested.load(Ordering::Acquire) {
+        None
+    } else {
+        Some(guard)
+    }
+}
+
+/// Blocking-worker counterpart to [`begin_artifact_publication`].
+pub(super) fn begin_artifact_publication_blocking(
+    state: &SharedState,
+) -> Option<tokio::sync::RwLockReadGuard<'_, ()>> {
+    let guard = state.artifact_publication.blocking_read();
+    if state.shutdown_requested.load(Ordering::Acquire) {
+        None
+    } else {
+        Some(guard)
+    }
+}
+
 /// How many artifact-persist tasks may be in flight concurrently.
 ///
 /// The daemon's persist path writes each cached artifact to disk via
@@ -274,6 +304,38 @@ pub(super) fn lookup_artifact_with_disk_fallback<'a>(
         .artifacts
         .insert(key_hex.to_string(), CachedArtifact::from_index(meta));
     state.artifacts.get_mut(key_hex)
+}
+
+/// Refresh an artifact's maintenance-visible access time at most once per
+/// hour. The in-memory timestamp protects hot entries immediately; the
+/// throttled index update preserves that access across daemon restarts without
+/// adding a clock read or WAL write to every cache hit (issue #1148).
+pub(super) fn record_artifact_access(
+    state: &SharedState,
+    key_hex: &str,
+    artifact: &mut CachedArtifact,
+    now: Instant,
+) {
+    const PERSIST_INTERVAL: Duration = Duration::from_secs(60 * 60);
+    artifact.last_used = now;
+    artifact.used_in_process = true;
+    if artifact
+        .last_access_checkpoint
+        .is_some_and(|checkpoint| now.saturating_duration_since(checkpoint) < PERSIST_INTERVAL)
+    {
+        return;
+    }
+    artifact.last_access_checkpoint = Some(now);
+    let wall_now = std::time::SystemTime::now();
+    artifact.last_used_wall = wall_now;
+    artifact.meta.stored_at_secs = wall_now
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let _ = state.index_writer_tx.send(IndexWriterCommand::Insert(
+        key_hex.to_string(),
+        artifact.meta.clone(),
+    ));
 }
 
 #[cfg(all(test, windows))]

--- a/crates/zccache-daemon-core/src/daemon/server/wal.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/wal.rs
@@ -4,6 +4,8 @@ use super::*;
 
 pub(super) enum IndexWriterCommand {
     Insert(String, ArtifactIndex),
+    Remove(Vec<String>),
+    Clear(tokio::sync::oneshot::Sender<()>),
     Flush(tokio::sync::oneshot::Sender<()>),
 }
 
@@ -138,6 +140,27 @@ async fn process_index_writer_command(
                 flush_wal_to_disk(store, wal).await;
             }
         }
+        IndexWriterCommand::Remove(keys) => {
+            for key in &keys {
+                wal.remove(key);
+            }
+            let refs: Vec<&str> = keys.iter().map(String::as_str).collect();
+            let removed = store.remove_batch(&refs);
+            match Arc::clone(store).flush_async().await {
+                Ok(()) => tracing::info!(removed, "artifact-index removals flushed to disk"),
+                Err(error) => {
+                    tracing::warn!(removed, %error, "artifact-index removal flush failed")
+                }
+            }
+        }
+        IndexWriterCommand::Clear(ack) => {
+            wal.clear();
+            store.clear();
+            if let Err(error) = Arc::clone(store).flush_async().await {
+                tracing::warn!(%error, "cleared artifact index flush failed");
+            }
+            let _ = ack.send(());
+        }
         IndexWriterCommand::Flush(ack) => {
             flush_wal_to_disk(store, wal).await;
             let _ = ack.send(());
@@ -151,6 +174,17 @@ pub(super) async fn flush_index_writer(
 ) -> bool {
     let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
     if tx.send(IndexWriterCommand::Flush(ack_tx)).is_err() {
+        return false;
+    }
+    matches!(tokio::time::timeout(timeout, ack_rx).await, Ok(Ok(())))
+}
+
+pub(super) async fn clear_index_writer(
+    tx: &tokio::sync::mpsc::UnboundedSender<IndexWriterCommand>,
+    timeout: std::time::Duration,
+) -> bool {
+    let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+    if tx.send(IndexWriterCommand::Clear(ack_tx)).is_err() {
         return false;
     }
     matches!(tokio::time::timeout(timeout, ack_rx).await, Ok(Ok(())))
@@ -173,5 +207,48 @@ pub(super) async fn flush_wal_to_disk(
     match res {
         Ok(()) => tracing::info!(committed = count, "WAL flushed to disk"),
         Err(e) => tracing::warn!(count, "WAL flush to disk failed: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn remove_cancels_pending_insert_and_persists_deletion() {
+        let temp = tempfile::tempdir().expect("temporary index directory");
+        let index_path = temp.path().join("index.bin");
+        let store = Arc::new(ArtifactStore::open_empty(&index_path));
+        let mut wal = std::collections::HashMap::new();
+        let key = "a".repeat(64);
+        let meta = ArtifactIndex::new(
+            vec!["output.o".to_string()],
+            vec![4096],
+            Vec::new(),
+            Vec::new(),
+            0,
+        );
+
+        process_index_writer_command(
+            IndexWriterCommand::Insert(key.clone(), meta),
+            &store,
+            &mut wal,
+            usize::MAX,
+        )
+        .await;
+        assert!(wal.contains_key(&key));
+
+        process_index_writer_command(
+            IndexWriterCommand::Remove(vec![key.clone()]),
+            &store,
+            &mut wal,
+            usize::MAX,
+        )
+        .await;
+
+        assert!(!wal.contains_key(&key));
+        assert!(store.get(&key).is_none());
+        let reopened = ArtifactStore::open(&index_path).expect("reopen persisted index");
+        assert!(reopened.get(&key).is_none());
     }
 }

--- a/crates/zccache-daemon-core/src/embedded.rs
+++ b/crates/zccache-daemon-core/src/embedded.rs
@@ -11,7 +11,9 @@ use tokio_util::sync::CancellationToken;
 
 use crate::core::NormalizedPath;
 use crate::daemon::server::{
-    EmbeddedCompileRequest, EmbeddedDaemon, EmbeddedFlushReport, EmbeddedStatsSnapshot,
+    DiskMaintenanceReport as InternalDiskMaintenanceReport, EmbeddedCompileRequest, EmbeddedDaemon,
+    EmbeddedFlushReport, EmbeddedStatsSnapshot, MaintenanceKind as InternalMaintenanceKind,
+    MaintenancePolicy, MaintenancePressure as InternalMaintenancePressure,
 };
 
 pub use crate::audit::{AuditConfig, AuditContext};
@@ -219,6 +221,26 @@ pub struct ServiceLimits {
     pub host_in_flight: Option<Arc<std::sync::atomic::AtomicUsize>>,
 }
 
+/// Optional artifact-store limits for [`ZccacheService::start_with_disk_limits`].
+#[derive(Debug, Clone, Default)]
+pub struct DiskCacheLimits {
+    /// Maximum physical bytes for cached artifacts in this exact service root.
+    ///
+    /// Mutually exclusive with [`Self::max_cache_percent`]. `None` uses the
+    /// dynamic default: 5% of filesystem capacity, clamped to 40-200 GiB and
+    /// reduced as needed to preserve the disk-recovery reserve (capped at half
+    /// the volume on small filesystems so the cache remains useful). Small
+    /// root-local state such as indexes, logs, and daemon metadata is outside
+    /// this artifact-store budget.
+    pub max_cache_bytes: Option<u64>,
+    /// Maximum percentage of filesystem capacity for cached artifacts in this
+    /// exact service root.
+    ///
+    /// Valid values are 1 through 100. Mutually exclusive with
+    /// [`Self::max_cache_bytes`].
+    pub max_cache_percent: Option<u8>,
+}
+
 /// One compile invocation submitted to the embedded service.
 #[derive(Debug, Clone)]
 pub struct CompileRequest {
@@ -293,6 +315,42 @@ pub struct FlushReport {
     pub metadata_entries: u64,
 }
 
+/// Scope of a host-requested disk-maintenance pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiskMaintenanceKind {
+    /// Apply disk-pressure thresholds only.
+    Pressure,
+    /// Also expire entries older than 30 days.
+    Full,
+}
+
+/// Pressure tier observed during a disk-maintenance pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiskMaintenancePressure {
+    None,
+    Soft,
+    Hard,
+}
+
+/// Report returned by [`ZccacheService::maintain_disk`].
+#[derive(Debug, Clone)]
+pub struct DiskMaintenanceReport {
+    pub kind: DiskMaintenanceKind,
+    pub pressure: DiskMaintenancePressure,
+    /// Resolved artifact-store budget for this pass.
+    pub budget_bytes: u64,
+    /// Allocated artifact bytes plus in-flight writes before maintenance.
+    pub usage_before_bytes: u64,
+    /// Allocated artifact bytes plus in-flight writes after maintenance.
+    pub usage_after_bytes: u64,
+    /// Difference between `usage_before_bytes` and `usage_after_bytes`.
+    pub bytes_reclaimed: u64,
+    pub artifacts_removed: usize,
+    pub expired_artifacts_removed: usize,
+    /// In-flight artifact bytes included in both usage measurements.
+    pub pending_write_bytes: u64,
+}
+
 /// Current service statistics.
 #[derive(Debug, Clone)]
 pub struct ServiceStats {
@@ -327,12 +385,34 @@ impl ZccacheService {
     /// embedded work shares their runtime (for tokio-console attach unity,
     /// for graceful-shutdown signalling, etc.).
     pub async fn start(config: ZccacheConfig) -> Result<Self> {
+        Self::start_with_disk_limits(config, DiskCacheLimits::default()).await
+    }
+
+    /// Start an embedded service with an explicit artifact-store budget.
+    ///
+    /// This separate constructor keeps existing `ServiceLimits` struct
+    /// literals source-compatible while allowing hosts to own independent
+    /// cache budgets for each exact product root.
+    pub async fn start_with_disk_limits(
+        config: ZccacheConfig,
+        disk_limits: DiskCacheLimits,
+    ) -> Result<Self> {
         let endpoint = embedded_endpoint(&config.host);
         let cache_root =
             crate::core::config::effective_cache_root_from_top_level(&config.cache_root);
-        let daemon = EmbeddedDaemon::start(endpoint, cache_root, config.runtime.handle.clone())
-            .await
-            .map_err(|err| EmbeddedError::Start(err.to_string()))?;
+        let maintenance_policy = MaintenancePolicy::from_limits(
+            disk_limits.max_cache_bytes,
+            disk_limits.max_cache_percent,
+        )
+        .map_err(EmbeddedError::Start)?;
+        let daemon = EmbeddedDaemon::start(
+            endpoint,
+            cache_root,
+            config.runtime.handle.clone(),
+            maintenance_policy,
+        )
+        .await
+        .map_err(|err| EmbeddedError::Start(err.to_string()))?;
         // zccache#924: register the optional host-in-flight counter so
         // CompilePriority::Auto sees host-side subprocess pressure when
         // deciding Normal vs Low. The RAII guard is held on the service
@@ -509,6 +589,32 @@ impl ZccacheService {
         Ok(ServiceStats::from_snapshot(self.daemon.stats().await))
     }
 
+    /// Run disk maintenance against this service's exact configured cache root.
+    ///
+    /// The embedded service also runs pressure checks every five minutes and a
+    /// persisted full-age pass every 24 hours. Hosts can call this method after
+    /// their own activity or disk-pressure signal without scanning sibling
+    /// product roots.
+    pub async fn maintain_disk(
+        &self,
+        kind: DiskMaintenanceKind,
+    ) -> std::io::Result<DiskMaintenanceReport> {
+        if self.shutdown.load(Ordering::Acquire) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotConnected,
+                "embedded zccache service is already shut down",
+            ));
+        }
+        let kind = match kind {
+            DiskMaintenanceKind::Pressure => InternalMaintenanceKind::Pressure,
+            DiskMaintenanceKind::Full => InternalMaintenanceKind::Full,
+        };
+        self.daemon
+            .maintain_disk(kind)
+            .await
+            .map(DiskMaintenanceReport::from_report)
+    }
+
     /// Flush pending embedded service state to disk.
     ///
     /// Honors [`ZccacheConfig::cancellation`] (zccache#923) the same way
@@ -619,6 +725,29 @@ impl FlushReport {
             pending_writes_drained: report.pending_writes_drained,
             artifact_entries: report.artifact_entries,
             metadata_entries: report.metadata_entries,
+        }
+    }
+}
+
+impl DiskMaintenanceReport {
+    fn from_report(report: InternalDiskMaintenanceReport) -> Self {
+        Self {
+            kind: match report.kind {
+                InternalMaintenanceKind::Pressure => DiskMaintenanceKind::Pressure,
+                InternalMaintenanceKind::Full => DiskMaintenanceKind::Full,
+            },
+            pressure: match report.pressure {
+                InternalMaintenancePressure::None => DiskMaintenancePressure::None,
+                InternalMaintenancePressure::Soft => DiskMaintenancePressure::Soft,
+                InternalMaintenancePressure::Hard => DiskMaintenancePressure::Hard,
+            },
+            budget_bytes: report.budget_bytes,
+            usage_before_bytes: report.usage_before_bytes,
+            usage_after_bytes: report.usage_after_bytes,
+            bytes_reclaimed: report.bytes_reclaimed,
+            artifacts_removed: report.artifacts_removed,
+            expired_artifacts_removed: report.expired_artifacts_removed,
+            pending_write_bytes: report.pending_write_bytes,
         }
     }
 }

--- a/crates/zccache-depgraph/src/scanner.rs
+++ b/crates/zccache-depgraph/src/scanner.rs
@@ -305,6 +305,7 @@ fn scan_recursive_impl(
 /// per-file results are buffered locally and pushed in a single batch at
 /// the end. This keeps Mutex contention proportional to (file count) and
 /// not to (include count).
+#[allow(clippy::too_many_arguments)] // One internal frontier worker over shared scan state.
 fn scan_one_level(
     file: &Path,
     search: &IncludeSearchPaths,

--- a/crates/zccache-test-support/src/lib.rs
+++ b/crates/zccache-test-support/src/lib.rs
@@ -111,11 +111,11 @@ impl FsFixture {
                 .prefix("zccache-tmpfs-")
                 .tempdir_in(root)
                 .map_err(|error| skip("tmpfs", format!("tempdir failed: {error}")))?;
-            return Ok(Self {
+            Ok(Self {
                 name: "tmpfs",
                 root: temp.path().into(),
                 backing: Backing::Temp(temp),
-            });
+            })
         }
         #[cfg(not(target_os = "linux"))]
         Err(skip("tmpfs", "tmpfs fixture is Linux-only"))

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,6 +24,7 @@ This document is the index for zccache's architecture specification. Each subsys
 - **CLI↔daemon communication** → [ipc.md](architecture/ipc.md)
 - **File change detection** → [metadata-cache.md](architecture/metadata-cache.md)
 - **Disk cache & eviction** → [artifact-store.md](architecture/artifact-store.md)
+- **Daemon-owned bounded disk retention** → [artifact-store.md](architecture/artifact-store.md#daemon-owned-retention-policy)
 - **Transactional directory outputs** → [artifact-store.md](architecture/artifact-store.md#immutable-staged-output-rollout)
 - **Reflink / hardlink COW safety** → [artifact-store.md](architecture/artifact-store.md#capability-driven-cow-materialization)
 - **soldr target artifact contract** → [rust-artifact-plan.md](architecture/rust-artifact-plan.md)

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -14,6 +14,7 @@ Architecture docs are split by subsystem. Read only what's relevant to your curr
 | `zccache-watcher` | [metadata-cache.md](architecture/metadata-cache.md) (watcher section) |
 | `zccache-artifact` | [artifact-store.md](architecture/artifact-store.md) |
 | Cross-filesystem COW materialization | [artifact-store.md](architecture/artifact-store.md), [portability.md](architecture/portability.md) |
+| Daemon-owned disk retention | [artifact-store.md](architecture/artifact-store.md), [runtime.md](architecture/runtime.md), [embedded-service.md](architecture/embedded-service.md) |
 | `zccache-hash` | [overview.md](architecture/overview.md) (2.8) |
 | `zccache-compiler` | [overview.md](architecture/overview.md) (2.9), [data-flow.md](architecture/data-flow.md) |
 | `zccache-core` | [overview.md](architecture/overview.md) |

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -323,7 +323,7 @@ Example: cache key `a1b2c3d4...` is stored at `<cache_root>/artifacts/a1/b2/a1b2
 
 **Context:** Without eviction, the disk cache grows without bound, eventually consuming all available disk space.
 
-**Decision:** Evict artifacts by LRU (Least Recently Used) based on last-access time. Track access times in the redb index. A background eviction task runs when the cache size exceeds a configurable threshold (default: 10 GB).
+**Decision:** Evict artifacts by LRU (Least Recently Used) based on last-access time. The daemon owns periodic maintenance for its exact cache root. The default budget is 5% of filesystem capacity clamped to 40-200 GiB, with mutually-exclusive byte or percent overrides. Pressure tiers use 85%/100% high-water marks, while full passes expire entries older than 30 days. The normative policy is [the artifact-store retention section](architecture/artifact-store.md#daemon-owned-retention-policy).
 
 **Rationale:**
 - Simple and predictable. Easy to understand, easy to debug.
@@ -334,7 +334,7 @@ Example: cache key `a1b2c3d4...` is stored at `<cache_root>/artifacts/a1/b2/a1b2
 | Strategy | Why not |
 |----------|---------|
 | LFU (Least Frequently Used) | More complex to implement. Marginal benefit over LRU for this workload. |
-| TTL-based expiry | Poor fit. Artifacts do not have a natural expiration time. A rarely-changed library might be cached for weeks and still be valid. |
+| TTL-only expiry | Poor fit as the sole policy. Absolute 30-day expiry now complements LRU so idle caches are eventually reclaimed. |
 | Size-weighted LRU | Premature optimization. Adds complexity for marginal benefit in v1. |
 
 **Consequences:**
@@ -513,18 +513,12 @@ The daemon can crash at any point. The recovery strategy ensures no data corrupt
 
 ### Q9: LRU Eviction — Details
 
-**Trigger:** A background task periodically checks total cache size (sum of artifact sizes tracked in redb). When the size exceeds the configured threshold (default: 10 GB), eviction begins.
-
-**Process:**
-1. Query the `access_log` table in redb, sorted by `last_access_timestamp` ascending.
-2. Delete the oldest artifacts (remove directory from disk, remove entries from redb) until cache size drops below `threshold * 0.9` (the 90% low-water mark prevents eviction from triggering again immediately).
-3. Eviction runs in a background tokio task with lower priority. It yields between deletions to avoid starving IPC handlers.
-
-**Access time tracking:** Every cache hit writes the current timestamp to the `access_log` table. These writes are batched (e.g., flushed every 5 seconds or every 100 hits) to avoid write amplification.
-
-**Manual controls:**
-- `zccache clear` removes all artifacts and resets the index.
-- `zccache config set max_cache_size <bytes>` adjusts the threshold.
+The original fixed 10 GB / 90% sketch has been superseded by DD-013's
+daemon-owned, reserve-aware pressure and age policy. The current thresholds,
+schedule, accounting, environment overrides, embedded API, and exact-root
+ownership contract live in
+[artifact-store.md](architecture/artifact-store.md#daemon-owned-retention-policy).
+`zccache clear` remains the explicit full purge control.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -118,9 +118,11 @@ This document describes the phased implementation plan for **zccache**, a high-p
   - Access time tracking (for LRU eviction)
   - Total cache size tracking
 - LRU eviction:
-  - Configurable max cache size (default: 10 GB)
-  - Eviction triggered when cache exceeds high-water mark (e.g., 95% of max)
-  - Evicts least-recently-accessed entries until below low-water mark (e.g., 80% of max)
+  - Dynamic 5% cache budget (40-200 GiB) with byte/percent overrides
+  - Soft pressure at 85% evicts entries older than 4 days to 70% of budget
+  - Hard pressure at 100% or low free space evicts LRU entries regardless of age
+    to 80% of budget and the recovery free-space target
+  - Daily full maintenance expires entries older than 30 days
 - Corruption detection:
   - Manifest includes blake3 checksum of artifact data
   - On read, verify checksum; if mismatch, delete entry and return miss

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -268,23 +268,56 @@ redb is chosen for its properties:
 - Single-file database.
 - Good read concurrency (multiple concurrent readers, single writer).
 
-## Eviction Policy
+## Daemon-owned retention policy
 
-**Policy:** LRU by `last_access` time.
+The long-lived daemon is the primary maintenance owner. It applies one shared
+policy to the exact effective cache root used by that daemon, whether the
+service is standalone or embedded. It never discovers or scans a parent,
+sibling product directory, another version root, or a global root registry.
+No systemd, launchd, or Windows Task Scheduler installation is required.
 
-**Trigger:** After each artifact store operation, check total cache size. If it exceeds `max_size` (configurable, default 10 GB):
+The artifact-store budget covers allocated artifact files plus pending artifact
+writes. Small root-local state such as indexes, depgraphs, logs, journals, and
+daemon metadata is outside this budget. The default is 5% of filesystem
+capacity, clamped to 40-200 GiB. The resolved budget is reduced when necessary
+to preserve the recovery free-space reserve. On small filesystems the reserve
+is capped at half the volume, avoiding a zero or 10 GiB-and-below default on
+ordinary 30-40 GiB development volumes. Operators can select one
+mutually-exclusive override:
 
-1. Open a redb read transaction.
-2. Iterate all entries, sorted by `last_access` ascending.
-3. Collect entries to evict until projected size is at most `max_size * 0.9` (evict to 90% to avoid thrashing).
-4. Open a redb write transaction.
-5. For each entry to evict:
-   a. Delete the artifact directory from disk.
-   b. Remove the entry from the redb `artifacts` table.
-   c. Increment the `evictions` counter.
-6. Commit the transaction.
+- `ZCCACHE_CACHE_SIZE_BYTES=<positive bytes>` for a standalone daemon;
+- `ZCCACHE_CACHE_SIZE_PERCENT=<1..100>` for a standalone daemon;
+- `ZccacheService::start_with_disk_limits` plus
+  `DiskCacheLimits::{max_cache_bytes,max_cache_percent}` for an embedded
+  service.
 
-Eviction runs as a background tokio task and does not block lookups or stores.
+Maintenance counts allocated physical blocks on Unix and uses
+`GetCompressedFileSizeW` on Windows, then deduplicates files by native identity
+so hardlinks inside the owned root are not double-counted. Pending writes
+are charged to usage before a pass chooses a pressure tier. Cache hits refresh
+the in-memory access time and checkpoint it to the artifact index at most once
+per hour, preserving recent use across restarts without a write per hit.
+
+| Tier | Trigger | Eligible entries | Target |
+|---|---|---|---|
+| None | Usage below 85% and free space healthy | A full pass still expires entries older than 30 days | No pressure eviction |
+| Soft | Usage at least 85% of budget | LRU entries older than 4 days | 70% of budget |
+| Hard | Usage at least 100%, or free space below `min(capacity, max(5%, 20 GiB))` | LRU regardless of age | 80% of budget and `min(capacity / 2, max(8%, 30 GiB))` free where feasible |
+
+The daemon runs a pressure pass at startup and every five minutes. A full age
+pass is due every 24 hours. Successful full passes write
+`.disk-maintenance-last-full-v1` inside the exact cache root; a missing, corrupt,
+or overdue marker causes startup catch-up. Consequently the 30-day expiry is
+eventual even when no new compile requests arrive while the daemon remains
+alive, and restarts catch up after daemon downtime.
+
+Each selected logical key is removed across legacy flat/pack files and staged
+v2 generations. The live artifact map, persistent artifact index, and depgraph
+references are invalidated only after file removal succeeds. Reports rescan the
+owned root, so `usage_after_bytes` and `bytes_reclaimed` reflect what is no
+longer present rather than an eviction estimate. The embedded
+`ZccacheService::maintain_disk` method lets a host request an immediate pressure
+or full pass against that same root; it does not broaden ownership.
 
 ## Corruption Detection
 

--- a/docs/architecture/embedded-service.md
+++ b/docs/architecture/embedded-service.md
@@ -9,7 +9,7 @@ zccache#903 and the implementation anchor for zccache#904 through zccache#910.
 Issue #903 defines the embedded-service direction and the MVP acceptance
 surface. In the current tree, the first public Rust API is exported as
 `zccache::embedded::ZccacheService`. It is an MVP boundary for host daemons to
-start, inspect, flush, and shut down an in-process zccache engine; soldr/fbuild
+start, inspect, maintain, flush, and shut down an in-process zccache engine; soldr/fbuild
 integration and durable event emission are still follow-up work.
 
 The MVP boundary is:
@@ -17,7 +17,7 @@ The MVP boundary is:
 | Area | Status | Notes |
 |---|---|---|
 | Architecture contract | Landed | This document records lifecycle, ownership, audit, and shutdown expectations. |
-| Public Rust API | MVP landed | `zccache::embedded` exports `ZccacheService` and stable config/request/stats types for start, compile, stats, flush, and shutdown. |
+| Public Rust API | MVP landed | `zccache::embedded` exports `ZccacheService` and stable config/request/stats types for start, compile, stats, disk maintenance, flush, and shutdown. |
 | Durable audit schema | MVP landed | `zccache::audit` exports serializable schema/config/event/finding/manifest types; hot-path emission and fixtures remain follow-up work. |
 | soldr embedded integration | Open | zccache#907 should switch soldr from wrapper/private-daemon use to direct embedded calls once the integration is ready. |
 | fbuild embedded integration | Open | zccache#908 follows the same service contract, adjusted for fbuild's daemon/runtime model. |
@@ -97,7 +97,7 @@ inside that runtime and exposes explicit handles for flush, stats, and shutdown.
 |---|---|---|
 | Product identity | Product name, instance id, workspace id | Validation of identity fields used by zccache |
 | Runtime | Tokio runtime and top-level cancellation token | Child tasks, blocking-task policy, runtime instrumentation hooks |
-| Cache | Root directory selection and namespace | Artifact store, metadata cache, depgraph, temp dirs under the cache root |
+| Cache | Root directory selection, namespace, and optional byte/percent budget | Artifact store, root-local retention, metadata cache, depgraph, temp dirs under the cache root |
 | Audit | Top-level run id, output directory, event sink | zccache child spans/events, compile journal, phase summaries |
 | Lifecycle | Build begin/plan/execute/terminate | Service start, flush, stats, graceful shutdown, forced shutdown |
 | Process execution | Host policy constraints and cancellation | Compiler/tool subprocess execution and capture semantics |
@@ -124,6 +124,21 @@ pub struct ZccacheConfig {
     pub audit: AuditConfig,
     pub limits: ServiceLimits,
     pub runtime: RuntimeHooks,
+}
+
+pub struct ServiceLimits {
+    pub max_parallel_compiles: Option<usize>,
+    // host_in_flight omitted here
+}
+
+pub struct DiskCacheLimits {
+    pub max_cache_bytes: Option<u64>,
+    pub max_cache_percent: Option<u8>,
+}
+
+pub enum DiskMaintenanceKind {
+    Pressure,
+    Full,
 }
 
 pub struct HostIdentity {
@@ -165,15 +180,36 @@ pub enum CompileChunk {
 
 impl ZccacheService {
     pub async fn start(config: ZccacheConfig) -> Result<Self>;
+    pub async fn start_with_disk_limits(
+        config: ZccacheConfig,
+        disk_limits: DiskCacheLimits,
+    ) -> Result<Self>;
     pub async fn compile(&self, request: CompileRequest) -> Result<CompileResponse>;
     pub async fn compile_streaming<F>(&self, request: CompileRequest, on_chunk: F) -> Result<()>
     where
         F: FnMut(CompileChunk);
     pub async fn stats(&self) -> Result<ServiceStats>;
+    pub async fn maintain_disk(
+        &self,
+        kind: DiskMaintenanceKind,
+    ) -> std::io::Result<DiskMaintenanceReport>;
     pub async fn flush(&self) -> Result<FlushReport>;
     pub async fn shutdown(self, mode: ShutdownMode) -> Result<ShutdownReport>;
 }
 ```
+
+`DiskCacheLimits::max_cache_bytes` and `max_cache_percent` are mutually
+exclusive. `start` uses the shared dynamic artifact-store budget;
+`start_with_disk_limits` accepts overrides without adding fields to the
+existing public `ServiceLimits` struct. The budget
+accounts for allocated artifact files and pending writes, not small root-local
+indexes, depgraphs, logs, journals, or daemon metadata. The service starts its
+own pressure/full maintenance loop on the host runtime and touches only the
+effective versioned root derived from `cache_root`. The host may request an
+immediate pass through `maintain_disk`, but that call never scans parent or
+sibling product roots. See
+[artifact-store.md](artifact-store.md#daemon-owned-retention-policy) for the
+single policy shared with standalone mode.
 
 `compile_streaming` is the canonical producer. `compile` is a buffered adapter
 that collects the same chunks. Compiler misses and direct invocations emit
@@ -196,6 +232,7 @@ without a real compiler invocation:
 - `ZccacheService::start(config)` creates an isolated in-process service rooted
   under the host-provided cache directory.
 - `stats()` returns a service-level snapshot before any compile request.
+- `maintain_disk()` reports an immediate root-local pressure or full pass.
 - `flush()` is callable before host audit/report generation.
 - `shutdown(ShutdownMode::Graceful)` releases tasks and reports whether any
   work was dropped or left unflushed.

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -19,7 +19,7 @@ Tokio runtime:     multi-threaded (default thread count)
     - looks up artifact store
     - on miss: spawns compiler, stores result
     - sends response
-  Background eviction task (if triggered)
+  Background disk maintenance task (startup + 5-minute pressure checks)
   Watcher event processing task
 
 Dedicated OS thread:  file watcher (notify)
@@ -398,6 +398,15 @@ persistent write escapes it**. Issue #275 closes that contract.
 
 [resolve]: ../../crates/zccache-core/src/config.rs
 
+### Maintenance ownership
+
+Each daemon maintains only its resolved effective root. Embedded soldr/fbuild
+instances therefore cannot inspect or delete standalone `~/.zccache` state or
+another product's root. The daemon is the primary scheduler; persisted daily
+catch-up removes the need for an OS scheduler. Budget, pressure, age, and
+accounting semantics are defined in
+[artifact-store.md](artifact-store.md#daemon-owned-retention-policy).
+
 ### Resolution rules
 
 | Source | When it fires | `cache-root --json` value |
@@ -469,6 +478,7 @@ cache root via one of the helpers in `zccache::core::config`:
 | Subpath | Owner | Resolver |
 |---|---|---|
 | `artifacts/` | daemon — content-addressed artifact store + sibling tmp files for atomic rename | `artifacts_dir_from_cache_dir` |
+| `.disk-maintenance-last-full-v1` | daemon — timestamp of the last successful full-age retention pass | exact effective cache root |
 | `tmp/` | daemon — recursively wiped on startup (orphaned in-progress writes) | `tmp_dir_from_cache_dir` |
 | `tmp/depfiles/<pid>-<instance>/` | daemon — compiler-injected depfiles and Windows response files (`*.rsp`) | `depfile_dir_from_cache_dir` |
 | `depgraph/depgraph.bin` | daemon — rkyv snapshot of the dep graph | `depgraph_file_path` |

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,16 @@
+# #1148 bounded embedded/standalone disk retention
+
+Issue: https://github.com/zackees/zccache/issues/1148
+
+- [x] Confirm standalone/embedded lifecycle parity gap and exact-root ownership.
+- [x] Add shared policy/scanner seams with RED tests for budgets, ages, pressure, hardlinks, and sibling sentinels.
+- [x] Wire the shared pass into standalone and embedded startup/periodic lifecycles.
+- [x] Expose host-callable embedded maintenance and structured reports.
+- [x] Persist/catch up the daily age-maintenance deadline inside the configured root.
+- [x] Update architecture/runtime documentation.
+- [x] Run focused/full tests, fmt, clippy, Windows compile, and review.
+- [ ] Open the PR, pass CI, merge, and validate main.
+
 # #1063 thin-v3 ownership-aware durable export
 
 Parent: zackees/soldr#1609 · Policy: `thin-v3-lifetime-partition-v1`


### PR DESCRIPTION
## Summary

- make the daemon the primary owner of disk retention for its exact configured cache root, with startup maintenance, 5-minute pressure checks, and persisted 24-hour full-pass catch-up
- replace the 10 GiB runtime default with 5% of filesystem capacity clamped to 40-200 GiB, plus mutually-exclusive fixed-byte and percentage overrides
- enforce soft pressure at 85% (LRU entries older than 4 days to 70%), hard pressure at 100% or low free space (unaged LRU to 80% plus recovery reserve), and eventual 30-day expiry
- account physical allocation with hardlink identity deduplication, checkpoint cache-hit access times, and rescan iteratively after eviction
- expose embedded per-root disk limits, host-requested maintenance, and structured reports without changing existing `ServiceLimits` literals
- serialize Clear/GC/shutdown against all artifact publication, including detached tasks, and reject publishers queued behind shutdown
- reject linked/reparse staged roots and never scan, migrate, hardlink, or delete sibling product roots
- document the policy, ownership boundary, lifecycle, overrides, and report semantics

## Validation

- `soldr cargo test -p zccache-daemon-core --features test-support` — 593 passed, 26 intentionally ignored
- `soldr cargo test -p zccache-core` — 106 passed
- focused fair-RwLock handoff, queued-shutdown-reader, staged multi-source Clear, stale-age, hardlink-dedup, exact-root, startup/catch-up, and disk-pressure tests
- `soldr cargo fmt --all -- --check`
- `soldr cargo clippy --workspace --all-targets -- -D warnings`
- Windows MSVC compile-with-tests: `soldr cargo check -p zccache-daemon-core --target x86_64-pc-windows-msvc --features test-support --tests`
- independent Rust and documentation review: no remaining HIGH/MEDIUM blockers

Closes #1148