### PR TITLE
perf(cache): shorten artifact locks and defer metadata GC

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/eviction.rs
+++ b/crates/zccache-daemon-core/src/daemon/eviction.rs
@@ -6,13 +6,13 @@
 //! The legacy fixed-size disk helper remains test-only; production disk
 //! retention is daemon-owned in `server::disk_maintenance` (issue #1148).
 
-#[cfg(test)]
 use crate::core::NormalizedPath;
 use crate::depgraph::{ContextKey, DepGraph};
-use crate::fscache::CacheSystem;
+use crate::fscache::{CacheSystem, EvictionCandidate};
 use dashmap::DashMap;
 #[cfg(test)]
 use std::collections::HashMap;
+use std::collections::HashSet;
 #[cfg(test)]
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -26,7 +26,7 @@ use super::server::{CachedArtifact, FastHitEntry};
 /// Estimated bytes per metadata cache entry.
 const METADATA_ENTRY_BYTES: usize = 400;
 /// Estimated bytes per journal `last_change` entry.
-const JOURNAL_ENTRY_BYTES: usize = 280;
+pub(crate) const JOURNAL_ENTRY_BYTES: usize = 280;
 /// Estimated bytes per depgraph file entry.
 const DEPGRAPH_FILE_BYTES: usize = 600;
 /// Estimated bytes per depgraph context entry.
@@ -44,6 +44,54 @@ const FAST_HIT_BUDGET_TRIM_MAX_AGE: Duration = Duration::from_secs(5);
 const DISK_EVICTION_SCAN_YIELD_EVERY: usize = 512;
 #[cfg(test)]
 const DISK_EVICTION_DELETE_BATCH_SIZE: usize = 64;
+
+/// Read-only observations used by the write phase of memory eviction.
+pub(crate) struct MemoryEvictionPlan {
+    metadata_candidates: Vec<EvictionCandidate>,
+    target_bytes: u64,
+}
+
+impl MemoryEvictionPlan {
+    pub(crate) fn metadata_candidate_count(&self) -> usize {
+        self.metadata_candidates.len()
+    }
+
+    pub(crate) fn target_bytes(&self) -> u64 {
+        self.target_bytes
+    }
+
+    /// Build the forced-completion plan from candidates that were busy during
+    /// gentle eviction followed by the original, unvisited suffix. Candidates
+    /// reported refreshed are intentionally absent and protected for this
+    /// sweep.
+    pub(crate) fn completion_from(
+        &self,
+        offset: usize,
+        busy: &[EvictionCandidate],
+    ) -> Self {
+        let mut metadata_candidates = busy.to_vec();
+        metadata_candidates.extend_from_slice(
+            &self.metadata_candidates[offset.min(self.metadata_candidates.len())..],
+        );
+        Self {
+            metadata_candidates,
+            target_bytes: self.target_bytes,
+        }
+    }
+}
+
+pub(crate) struct MemoryEvictionOutcome {
+    pub(crate) freed_bytes: u64,
+    pub(crate) items_removed: usize,
+    pub(crate) refreshed: Vec<EvictionCandidate>,
+}
+
+pub(crate) struct GentleEvictionOutcome {
+    pub(crate) freed_bytes: u64,
+    pub(crate) items_removed: usize,
+    pub(crate) busy: Vec<EvictionCandidate>,
+    pub(crate) refreshed: Vec<EvictionCandidate>,
+}
 
 /// Snapshot of estimated memory usage across all in-memory caches.
 #[derive(Debug, Clone)]
@@ -124,6 +172,7 @@ pub(crate) fn memory_snapshot(
 /// Evicts to 90% of budget to avoid thrashing.
 ///
 /// Returns `(estimated_freed_bytes, items_removed)`.
+#[cfg(test)]
 pub(crate) fn evict_to_budget(
     budget_bytes: u64,
     cache_system: &CacheSystem,
@@ -132,6 +181,68 @@ pub(crate) fn evict_to_budget(
     artifacts: &DashMap<String, CachedArtifact>,
     in_flight_bytes: usize,
 ) -> (u64, usize) {
+    let Some(plan) = plan_eviction_to_budget(
+        budget_bytes,
+        cache_system,
+        dep_graph,
+        fast_hit_cache,
+        artifacts,
+        in_flight_bytes,
+    ) else {
+        return (0, 0);
+    };
+    evict_to_budget_with_plan(
+        budget_bytes,
+        cache_system,
+        dep_graph,
+        fast_hit_cache,
+        artifacts,
+        in_flight_bytes,
+        &plan,
+    )
+}
+
+/// Read-only phase of memory eviction.
+pub(crate) fn plan_eviction_to_budget(
+    budget_bytes: u64,
+    cache_system: &CacheSystem,
+    dep_graph: &DepGraph,
+    fast_hit_cache: &DashMap<ContextKey, FastHitEntry>,
+    artifacts: &DashMap<String, CachedArtifact>,
+    in_flight_bytes: usize,
+) -> Option<MemoryEvictionPlan> {
+    let snap = memory_snapshot(
+        cache_system,
+        dep_graph,
+        fast_hit_cache,
+        artifacts,
+        in_flight_bytes,
+    );
+    if (snap.total_bytes as u64) <= budget_bytes {
+        return None;
+    }
+    plan_eviction_to_target_excluding(
+        (budget_bytes as f64 * 0.9) as u64,
+        cache_system,
+        dep_graph,
+        fast_hit_cache,
+        artifacts,
+        in_flight_bytes,
+        &HashSet::new(),
+    )
+}
+
+/// Re-plan from current state while preserving timestamp-refreshed paths for
+/// the duration of one GC sweep.
+pub(crate) fn plan_eviction_to_target_excluding(
+    target_bytes: u64,
+    cache_system: &CacheSystem,
+    dep_graph: &DepGraph,
+    fast_hit_cache: &DashMap<ContextKey, FastHitEntry>,
+    artifacts: &DashMap<String, CachedArtifact>,
+    in_flight_bytes: usize,
+    protected_paths: &HashSet<NormalizedPath>,
+) -> Option<MemoryEvictionPlan> {
     let snap = memory_snapshot(
         cache_system,
         dep_graph,
@@ -140,15 +251,78 @@ pub(crate) fn evict_to_budget(
         in_flight_bytes,
     );
 
-    if (snap.total_bytes as u64) <= budget_bytes {
-        return (0, 0);
+    if (snap.total_bytes as u64) <= target_bytes {
+        return None;
     }
 
-    // Target 90% of budget to avoid evicting a tiny bit every cycle.
-    let target = (budget_bytes as f64 * 0.9) as u64;
+    let to_free = snap.total_bytes as u64 - target_bytes;
+    let metadata_count = (to_free as usize)
+        .div_ceil(METADATA_ENTRY_BYTES)
+        .max(1)
+        .min(snap.metadata_entries);
+    let mut metadata_candidates =
+        cache_system.oldest_eviction_candidates(snap.metadata_entries);
+    metadata_candidates.retain(|candidate| !protected_paths.contains(candidate.path()));
+    metadata_candidates.truncate(metadata_count);
+    Some(MemoryEvictionPlan {
+        metadata_candidates,
+        target_bytes,
+    })
+}
+
+/// Write phase of memory eviction using observations made by
+/// [`plan_eviction_to_budget`].
+#[cfg(test)]
+pub(crate) fn evict_to_budget_with_plan(
+    _budget_bytes: u64,
+    cache_system: &CacheSystem,
+    dep_graph: &DepGraph,
+    fast_hit_cache: &DashMap<ContextKey, FastHitEntry>,
+    artifacts: &DashMap<String, CachedArtifact>,
+    in_flight_bytes: usize,
+    plan: &MemoryEvictionPlan,
+) -> (u64, usize) {
+    let outcome = evict_to_budget_with_plan_detailed(
+        _budget_bytes,
+        cache_system,
+        dep_graph,
+        fast_hit_cache,
+        artifacts,
+        in_flight_bytes,
+        plan,
+    );
+    (outcome.freed_bytes, outcome.items_removed)
+}
+
+pub(crate) fn evict_to_budget_with_plan_detailed(
+    _budget_bytes: u64,
+    cache_system: &CacheSystem,
+    dep_graph: &DepGraph,
+    fast_hit_cache: &DashMap<ContextKey, FastHitEntry>,
+    artifacts: &DashMap<String, CachedArtifact>,
+    in_flight_bytes: usize,
+    plan: &MemoryEvictionPlan,
+) -> MemoryEvictionOutcome {
+    let snap = memory_snapshot(
+        cache_system,
+        dep_graph,
+        fast_hit_cache,
+        artifacts,
+        in_flight_bytes,
+    );
+    if (snap.total_bytes as u64) <= plan.target_bytes {
+        return MemoryEvictionOutcome {
+            freed_bytes: 0,
+            items_removed: 0,
+            refreshed: Vec::new(),
+        };
+    }
+
+    let target = plan.target_bytes;
     let mut to_free = snap.total_bytes as u64 - target;
     let mut total_freed: u64 = 0;
     let mut total_items: usize = 0;
+    let mut refreshed = Vec::new();
 
     // Priority 1: fast-hit cache (cheapest to lose).
     //
@@ -170,15 +344,43 @@ pub(crate) fn evict_to_budget(
 
     // Priority 2: metadata + journal.
     if to_free > 0 && !cache_system.metadata().is_empty() {
-        let entries_to_evict = (to_free as usize / METADATA_ENTRY_BYTES)
+        let entries_to_evict = (to_free as usize)
+            .div_ceil(METADATA_ENTRY_BYTES)
             .max(1)
             .min(cache_system.metadata().len());
-        let (meta_removed, journal_removed) = cache_system.evict_oldest(entries_to_evict);
+        let selected = &plan.metadata_candidates[..entries_to_evict.min(
+            plan.metadata_candidates.len(),
+        )];
+        let (result, journal_removed) =
+            cache_system.evict_candidates_detailed(selected);
         let freed =
-            (meta_removed * METADATA_ENTRY_BYTES + journal_removed * JOURNAL_ENTRY_BYTES) as u64;
+            (result.removed * METADATA_ENTRY_BYTES
+                + journal_removed * JOURNAL_ENTRY_BYTES) as u64;
         total_freed += freed;
-        total_items += meta_removed + journal_removed;
+        total_items += result.removed + journal_removed;
         to_free = to_free.saturating_sub(freed);
+        refreshed.extend(result.refreshed);
+        // A refreshed candidate is deliberately preserved. Stop this pass
+        // before evicting the more expensive depgraph; a later read phase can
+        // select a replacement candidate from a current view.
+        if result.removed < selected.len() {
+            return MemoryEvictionOutcome {
+                freed_bytes: total_freed,
+                items_removed: total_items,
+                refreshed,
+            };
+        }
+        // The read phase intentionally excluded entries already examined by
+        // a gentle write phase. Do not jump to depgraph eviction merely
+        // because those protected entries made this candidate slice shorter
+        // than the current estimate asks for.
+        if selected.len() < entries_to_evict {
+            return MemoryEvictionOutcome {
+                freed_bytes: total_freed,
+                items_removed: total_items,
+                refreshed,
+            };
+        }
     }
 
     // Priority 3: depgraph contexts (trim all, then orphaned files cleaned up).
@@ -196,7 +398,36 @@ pub(crate) fn evict_to_budget(
         }
     }
 
-    (total_freed, total_items)
+    MemoryEvictionOutcome {
+        freed_bytes: total_freed,
+        items_removed: total_items,
+        refreshed,
+    }
+}
+
+/// Opportunistic write phase used while compile traffic remains active.
+///
+/// Busy shards and entries refreshed since the plan was created are skipped.
+/// Expensive fast-hit and depgraph trimming remain deferred until a quiet or
+/// forced pass.
+pub(crate) fn try_evict_metadata_plan(
+    cache_system: &CacheSystem,
+    plan: &MemoryEvictionPlan,
+    offset: usize,
+    max_candidates: usize,
+) -> GentleEvictionOutcome {
+    let start = offset.min(plan.metadata_candidates.len());
+    let end = start
+        .saturating_add(max_candidates)
+        .min(plan.metadata_candidates.len());
+    let selected = &plan.metadata_candidates[start..end];
+    let result = cache_system.try_evict_candidates_detailed(selected);
+    GentleEvictionOutcome {
+        freed_bytes: (result.removed * METADATA_ENTRY_BYTES) as u64,
+        items_removed: result.removed,
+        busy: result.busy,
+        refreshed: result.refreshed,
+    }
 }
 
 fn trim_fast_hit_cache_two_pass(
@@ -204,11 +435,11 @@ fn trim_fast_hit_cache_two_pass(
     max_age: Duration,
 ) -> usize {
     let now = Instant::now();
-    let expired: Vec<ContextKey> = cache
+    let expired: Vec<(ContextKey, Instant)> = cache
         .iter()
         .filter_map(|entry| {
             if now.saturating_duration_since(entry.value().cached_at) > max_age {
-                Some(*entry.key())
+                Some((*entry.key(), entry.value().cached_at))
             } else {
                 None
             }
@@ -216,8 +447,11 @@ fn trim_fast_hit_cache_two_pass(
         .collect();
 
     let mut removed = 0;
-    for key in expired {
-        if cache.remove(&key).is_some() {
+    for (key, observed_cached_at) in expired {
+        if cache
+            .remove_if(&key, |_, entry| entry.cached_at == observed_cached_at)
+            .is_some()
+        {
             removed += 1;
         }
     }
@@ -593,6 +827,152 @@ mod tests {
     }
 
     #[test]
+    fn planned_eviction_preserves_metadata_refreshed_before_write_pass() {
+        let (cs, dg, fh, art) = empty_caches();
+        let path = NormalizedPath::from("/tmp/refreshed-between-passes.c");
+        let selected_at = Instant::now() - Duration::from_secs(120);
+        cs.metadata().insert(
+            path.clone(),
+            FileMetadata {
+                mtime: SystemTime::now(),
+                size: 100,
+                confidence: Confidence::High,
+                last_verified: selected_at,
+                content_hash: None,
+            },
+        );
+        dg.register(make_ctx("/tmp/refreshed-between-passes.c"));
+
+        let plan = plan_eviction_to_budget(1, &cs, &dg, &fh, &art, 0)
+            .expect("tiny budget should produce an eviction plan");
+        cs.metadata().insert(
+            path.clone(),
+            FileMetadata {
+                mtime: SystemTime::now(),
+                size: 100,
+                confidence: Confidence::High,
+                last_verified: selected_at + Duration::from_secs(1),
+                content_hash: None,
+            },
+        );
+
+        let (freed, items) =
+            evict_to_budget_with_plan(1, &cs, &dg, &fh, &art, 0, &plan);
+
+        assert_eq!(freed, 0);
+        assert_eq!(items, 0);
+        assert!(cs.metadata().get(&path).is_some());
+        assert_eq!(
+            dg.stats().context_count,
+            1,
+            "a stale metadata candidate must stop this pass before depgraph eviction",
+        );
+    }
+
+    #[test]
+    fn blocking_completion_uses_only_unconsumed_gentle_candidates() {
+        let (cs, dg, fh, art) = empty_caches();
+        for i in 0..300 {
+            cs.metadata().insert(
+                NormalizedPath::from(format!("/tmp/gentle-transition-{i}.c")),
+                FileMetadata {
+                    mtime: SystemTime::now(),
+                    size: 100,
+                    confidence: Confidence::High,
+                    last_verified: Instant::now(),
+                    content_hash: None,
+                },
+            );
+        }
+
+        let budget = 10_000;
+        let plan = plan_eviction_to_budget(budget, &cs, &dg, &fh, &art, 0)
+            .expect("metadata should exceed the tiny budget");
+        assert!(plan.metadata_candidate_count() > 256);
+
+        let gentle = try_evict_metadata_plan(&cs, &plan, 0, 256);
+        assert_eq!(gentle.items_removed, 256);
+        let remaining = plan.completion_from(256, &gentle.busy);
+        let (_, blocking_items) =
+            evict_to_budget_with_plan(budget, &cs, &dg, &fh, &art, 0, &remaining);
+
+        assert!(blocking_items > 0);
+        assert!(
+            memory_snapshot(&cs, &dg, &fh, &art, 0).total_bytes as u64
+                <= plan.target_bytes(),
+            "idle/forced completion must reach the original headroom target"
+        );
+    }
+
+    #[test]
+    fn forced_completion_retries_candidates_that_were_lock_busy() {
+        let (cs, dg, fh, art) = empty_caches();
+        cs.metadata().insert(
+            NormalizedPath::from("/tmp/busy-forced-retry.c"),
+            FileMetadata {
+                mtime: SystemTime::now(),
+                size: 100,
+                confidence: Confidence::High,
+                last_verified: Instant::now(),
+                content_hash: None,
+            },
+        );
+        let budget = 1;
+        let plan = plan_eviction_to_budget(budget, &cs, &dg, &fh, &art, 0)
+            .expect("metadata should exceed the tiny budget");
+        let busy = plan.metadata_candidates.clone();
+        let completion =
+            plan.completion_from(plan.metadata_candidate_count(), &busy);
+
+        let outcome = evict_to_budget_with_plan_detailed(
+            budget,
+            &cs,
+            &dg,
+            &fh,
+            &art,
+            0,
+            &completion,
+        );
+
+        assert_eq!(outcome.items_removed, 1);
+        assert!(cs.metadata().is_empty());
+    }
+
+    #[test]
+    fn replacement_plan_keeps_original_headroom_target() {
+        let (cs, dg, fh, art) = empty_caches();
+        for i in 0..24 {
+            cs.metadata().insert(
+                NormalizedPath::from(format!("/tmp/headroom-{i}.c")),
+                FileMetadata {
+                    mtime: SystemTime::now(),
+                    size: 100,
+                    confidence: Confidence::High,
+                    last_verified: Instant::now(),
+                    content_hash: None,
+                },
+            );
+        }
+
+        assert!(
+            plan_eviction_to_budget(10_000, &cs, &dg, &fh, &art, 0).is_none(),
+            "9.6 KiB is below the configured 10 KiB trigger"
+        );
+        let replacement = plan_eviction_to_target_excluding(
+            9_000,
+            &cs,
+            &dg,
+            &fh,
+            &art,
+            0,
+            &HashSet::new(),
+        )
+        .expect("forced completion must continue toward the original 90% target");
+        assert_eq!(replacement.target_bytes(), 9_000);
+        assert!(!replacement.metadata_candidates.is_empty());
+    }
+
+    #[test]
     fn evict_cascades_to_depgraph() {
         let (cs, dg, fh, art) = empty_caches();
 
@@ -675,24 +1055,18 @@ mod tests {
 
     fn make_artifact(payload_size: usize) -> CachedArtifact {
         use crate::artifact::ArtifactIndex;
-        CachedArtifact {
-            meta: ArtifactIndex::new(
+        CachedArtifact::from_cached_payloads(
+            ArtifactIndex::new(
                 vec!["test.o".to_string()],
                 vec![payload_size as u64],
                 Vec::new(),
                 Vec::new(),
                 0,
             ),
-            stdout: std::sync::Arc::new(Vec::new()),
-            stderr: std::sync::Arc::new(Vec::new()),
-            payloads: Some(std::sync::Arc::from(vec![CachedPayload::Bytes(
+            vec![CachedPayload::Bytes(
                 std::sync::Arc::new(vec![0u8; payload_size]),
-            )])),
-            last_used: Instant::now(),
-            last_used_wall: std::time::SystemTime::now(),
-            used_in_process: true,
-            last_access_checkpoint: Some(Instant::now()),
-        }
+            )],
+        )
     }
 
     #[test]

--- a/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
@@ -7,6 +7,7 @@
 //! `ArtifactStore` on first startup after an upgrade.
 
 use super::*;
+use std::sync::OnceLock;
 
 #[derive(Clone)]
 pub(crate) enum CachedPayload {
@@ -16,32 +17,82 @@ pub(crate) enum CachedPayload {
     File(NormalizedPath),
 }
 
-#[derive(Clone)]
+struct ArtifactAccess {
+    last_used: std::time::Instant,
+    last_used_wall: std::time::SystemTime,
+    used_in_process: bool,
+    last_access_checkpoint: Option<std::time::Instant>,
+}
+
+pub(crate) struct ArtifactAccessSnapshot {
+    pub(crate) last_used: std::time::Instant,
+    pub(crate) last_used_wall: std::time::SystemTime,
+    pub(crate) used_in_process: bool,
+    #[cfg(test)]
+    pub(crate) last_access_checkpoint: Option<std::time::Instant>,
+}
+
 /// Cached compilation artifact with lazy payload loading.
 ///
 /// Metadata (output names, sizes, stdout, stderr, exit code) is always in
 /// memory after startup. Output payloads are either already in memory or are
 /// represented by cache files so hits can hardlink without eager reads.
+#[derive(Clone)]
 pub(crate) struct CachedArtifact {
+    inner: Arc<CachedArtifactInner>,
+}
+
+/// Immutable artifact body plus the two lazily-mutated per-artifact cells.
+///
+/// Keeping the complete body behind one `Arc` makes cloning a live-map entry
+/// allocation-free even though `ArtifactIndex` contains an output-size `Vec`.
+pub(crate) struct CachedArtifactInner {
     pub(crate) meta: ArtifactIndex,
     /// Arc-wrapped stdout/stderr for cheap IPC response clones.
     pub(crate) stdout: Arc<Vec<u8>>,
     pub(crate) stderr: Arc<Vec<u8>>,
-    /// Lazily-resolved output payloads. `None` = not yet checked on disk.
-    /// Arc-wrapped so cache-hit clones are O(1) refcount bumps.
-    pub(crate) payloads: Option<Arc<[CachedPayload]>>,
-    /// When this artifact was last used (inserted or returned as a hit).
-    pub(crate) last_used: std::time::Instant,
-    /// Wall-clock last use used by durable retention across reboots.
-    pub(crate) last_used_wall: std::time::SystemTime,
-    /// Whether `last_used` represents a real access in this process.
-    pub(crate) used_in_process: bool,
-    /// Last time this process checkpointed wall-clock access to the index.
-    /// Restored entries use `None`, so their first hit is persisted promptly.
-    pub(crate) last_access_checkpoint: Option<std::time::Instant>,
+    /// Lazily-resolved output payloads shared by owned cache-entry clones.
+    ///
+    /// The enclosing artifact `Arc` lets lookup release its DashMap read guard
+    /// immediately. Filesystem discovery then initializes this cell without
+    /// holding a map shard lock.
+    payloads: OnceLock<Arc<[CachedPayload]>>,
+    /// Per-artifact access state used by durable retention.
+    ///
+    /// This lock is independent of the DashMap shard, so one hot artifact
+    /// cannot block unrelated keys that happen to hash into the same shard.
+    access: std::sync::Mutex<ArtifactAccess>,
+}
+
+impl std::ops::Deref for CachedArtifact {
+    type Target = CachedArtifactInner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
 }
 
 impl CachedArtifact {
+    fn with_payloads(meta: ArtifactIndex, payloads: Arc<[CachedPayload]>) -> Self {
+        let stdout = Arc::clone(&meta.stdout);
+        let stderr = Arc::clone(&meta.stderr);
+        let now = std::time::Instant::now();
+        Self {
+            inner: Arc::new(CachedArtifactInner {
+                meta,
+                stdout,
+                stderr,
+                payloads: OnceLock::from(payloads),
+                access: std::sync::Mutex::new(ArtifactAccess {
+                    last_used: now,
+                    last_used_wall: std::time::SystemTime::now(),
+                    used_in_process: true,
+                    last_access_checkpoint: Some(now),
+                }),
+            }),
+        }
+    }
+
     /// Create from a freshly compiled `ArtifactData`. Payload mapping is
     /// 1:1 between the protocol `ArtifactPayload` enum and the internal
     /// `CachedPayload` enum.
@@ -57,12 +108,9 @@ impl CachedArtifact {
             Arc::clone(&artifact.stderr),
             artifact.exit_code,
         );
-        let now = std::time::Instant::now();
-        Self {
+        Self::with_payloads(
             meta,
-            stdout: Arc::clone(&artifact.stdout),
-            stderr: Arc::clone(&artifact.stderr),
-            payloads: Some(Arc::from(
+            Arc::from(
                 artifact
                     .outputs
                     .iter()
@@ -71,34 +119,30 @@ impl CachedArtifact {
                         ArtifactPayload::Path(p) => CachedPayload::File(p.clone()),
                     })
                     .collect::<Vec<_>>(),
-            )),
-            last_used: now,
-            last_used_wall: std::time::SystemTime::now(),
-            used_in_process: true,
-            last_access_checkpoint: Some(now),
-        }
+            ),
+        )
     }
 
     /// Create from index metadata and already-created payload files.
     pub(super) fn from_file_payloads(meta: ArtifactIndex, payloads: Vec<NormalizedPath>) -> Self {
-        let stdout = Arc::clone(&meta.stdout);
-        let stderr = Arc::clone(&meta.stderr);
-        let now = std::time::Instant::now();
-        Self {
+        Self::with_payloads(
             meta,
-            stdout,
-            stderr,
-            payloads: Some(Arc::from(
+            Arc::from(
                 payloads
                     .into_iter()
                     .map(CachedPayload::File)
                     .collect::<Vec<_>>(),
-            )),
-            last_used: now,
-            last_used_wall: std::time::SystemTime::now(),
-            used_in_process: true,
-            last_access_checkpoint: Some(now),
-        }
+            ),
+        )
+    }
+
+    /// Create from index metadata and an already-resolved payload list.
+    #[cfg(test)]
+    pub(crate) fn from_cached_payloads(
+        meta: ArtifactIndex,
+        payloads: Vec<CachedPayload>,
+    ) -> Self {
+        Self::with_payloads(meta, Arc::from(payloads))
     }
 
     /// Create from index metadata (lazy payloads not loaded yet).
@@ -109,17 +153,68 @@ impl CachedArtifact {
             .checked_add(std::time::Duration::from_secs(meta.stored_at_secs))
             .unwrap_or(std::time::UNIX_EPOCH);
         Self {
-            meta,
-            stdout,
-            stderr,
-            payloads: None,
-            last_used: std::time::Instant::now(),
-            // Keep durable age in wall-clock form. Reconstructing it as an
-            // Instant fails when the entry predates system uptime on Windows.
-            last_used_wall: stored_at.min(std::time::SystemTime::now()),
-            used_in_process: false,
-            last_access_checkpoint: None,
+            inner: Arc::new(CachedArtifactInner {
+                meta,
+                stdout,
+                stderr,
+                payloads: OnceLock::new(),
+                access: std::sync::Mutex::new(ArtifactAccess {
+                    last_used: std::time::Instant::now(),
+                    // Keep durable age in wall-clock form. Reconstructing it as an
+                    // Instant fails when the entry predates system uptime on Windows.
+                    last_used_wall: stored_at.min(std::time::SystemTime::now()),
+                    used_in_process: false,
+                    last_access_checkpoint: None,
+                }),
+            }),
         }
+    }
+
+    fn access(&self) -> std::sync::MutexGuard<'_, ArtifactAccess> {
+        self.access
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    pub(crate) fn access_snapshot(&self) -> ArtifactAccessSnapshot {
+        let access = self.access();
+        ArtifactAccessSnapshot {
+            last_used: access.last_used,
+            last_used_wall: access.last_used_wall,
+            used_in_process: access.used_in_process,
+            #[cfg(test)]
+            last_access_checkpoint: access.last_access_checkpoint,
+        }
+    }
+
+    /// Record one hit and return updated index metadata when its durable
+    /// checkpoint is due.
+    pub(crate) fn record_access(
+        &self,
+        now: std::time::Instant,
+    ) -> Option<ArtifactIndex> {
+        const PERSIST_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
+        let mut access = self.access();
+        access.last_used = now;
+        access.used_in_process = true;
+        if access
+            .last_access_checkpoint
+            .is_some_and(|checkpoint| now.saturating_duration_since(checkpoint) < PERSIST_INTERVAL)
+        {
+            return None;
+        }
+        access.last_access_checkpoint = Some(now);
+        let wall_now = std::time::SystemTime::now();
+        access.last_used_wall = wall_now;
+        drop(access);
+
+        let mut meta = self.meta.clone();
+        meta.stored_at_secs = wall_now
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        Some(meta)
     }
 }
 
@@ -127,63 +222,78 @@ impl CachedArtifact {
 ///
 /// Returns the payload slice, or `None` if any data file is missing
 /// (indicating corruption or eviction — caller should treat as cache miss).
-pub(super) fn ensure_payloads<'a>(
-    cached: &'a mut CachedArtifact,
+pub(super) fn ensure_payloads(
+    cached: &CachedArtifact,
     artifact_dir: &Path,
     key_hex: &str,
-) -> Option<&'a [CachedPayload]> {
+) -> Option<Arc<[CachedPayload]>> {
     ensure_payloads_with_staged_policy(cached, artifact_dir, key_hex, staged_artifacts_enabled())
 }
 
-pub(super) fn ensure_payloads_with_staged_policy<'a>(
-    cached: &'a mut CachedArtifact,
+pub(super) fn ensure_payloads_with_staged_policy(
+    cached: &CachedArtifact,
     artifact_dir: &Path,
     key_hex: &str,
     staged_enabled: bool,
-) -> Option<&'a [CachedPayload]> {
-    if cached.payloads.is_none() {
-        if staged_enabled {
-            match load_staged_artifact_paths(artifact_dir, key_hex, &cached.meta.output_sizes) {
-                Ok(Some(payloads)) => {
-                    cached.payloads = Some(Arc::from(
-                        payloads
-                            .into_iter()
-                            .map(CachedPayload::File)
-                            .collect::<Vec<_>>(),
-                    ));
-                    return cached.payloads.as_deref();
-                }
-                Ok(None) => {}
-                Err(_) => return None,
-            }
-        }
-        let mut payloads = Vec::with_capacity(cached.meta.output_names.len());
-        for i in 0..cached.meta.output_names.len() {
-            let path = artifact_dir.join(format!("{key_hex}_{i}"));
-            if let Ok(meta) = std::fs::metadata(&path) {
-                if meta.is_file()
-                    && cached
-                        .meta
-                        .output_sizes
-                        .get(i)
-                        .is_none_or(|expected| *expected == meta.len())
-                {
-                    payloads.push(CachedPayload::File(path.into()));
-                    continue;
-                }
-            }
-            // Fallback: artifact may be stored in a `.pack` file (pack mode).
-            let bytes = try_load_packed_payload(artifact_dir, key_hex, i)?;
-            if let Some(expected) = cached.meta.output_sizes.get(i) {
-                if *expected != bytes.len() as u64 {
-                    return None;
-                }
-            }
-            payloads.push(CachedPayload::Bytes(Arc::new(bytes)));
-        }
-        cached.payloads = Some(Arc::from(payloads));
+) -> Option<Arc<[CachedPayload]>> {
+    if let Some(payloads) = cached.payloads.get() {
+        return Some(Arc::clone(payloads));
     }
-    cached.payloads.as_deref()
+
+    let loaded: Arc<[CachedPayload]> = if staged_enabled {
+        match load_staged_artifact_paths(artifact_dir, key_hex, &cached.meta.output_sizes) {
+            Ok(Some(payloads)) => Arc::from(
+                payloads
+                    .into_iter()
+                    .map(CachedPayload::File)
+                    .collect::<Vec<_>>(),
+            ),
+            Ok(None) => load_legacy_payloads(cached, artifact_dir, key_hex)
+                .or_else(|| cached.payloads.get().cloned())?,
+            Err(_) => return cached.payloads.get().cloned(),
+        }
+    } else {
+        load_legacy_payloads(cached, artifact_dir, key_hex)
+            .or_else(|| cached.payloads.get().cloned())?
+    };
+
+    // Another request may have completed the same discovery concurrently.
+    // Whichever result initializes the cell first is canonical; both are
+    // derived from the same immutable artifact index and cache files.
+    let _ = cached.payloads.set(loaded);
+    cached.payloads.get().cloned()
+}
+
+fn load_legacy_payloads(
+    cached: &CachedArtifact,
+    artifact_dir: &Path,
+    key_hex: &str,
+) -> Option<Arc<[CachedPayload]>> {
+    let mut payloads = Vec::with_capacity(cached.meta.output_names.len());
+    for i in 0..cached.meta.output_names.len() {
+        let path = artifact_dir.join(format!("{key_hex}_{i}"));
+        if let Ok(meta) = std::fs::metadata(&path) {
+            if meta.is_file()
+                && cached
+                    .meta
+                    .output_sizes
+                    .get(i)
+                    .is_none_or(|expected| *expected == meta.len())
+            {
+                payloads.push(CachedPayload::File(path.into()));
+                continue;
+            }
+        }
+        // Fallback: artifact may be stored in a `.pack` file (pack mode).
+        let bytes = try_load_packed_payload(artifact_dir, key_hex, i)?;
+        if let Some(expected) = cached.meta.output_sizes.get(i) {
+            if *expected != bytes.len() as u64 {
+                return None;
+            }
+        }
+        payloads.push(CachedPayload::Bytes(Arc::new(bytes)));
+    }
+    Some(Arc::from(payloads))
 }
 
 /// Migrate legacy `.meta` files to the in-memory artifact index.
@@ -254,4 +364,90 @@ pub(super) fn migrate_meta_files(
         tracing::info!(count, "migrated legacy .meta files to artifact index");
     }
     count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lazy_artifact(payload_size: u64) -> CachedArtifact {
+        CachedArtifact::from_index(ArtifactIndex::new(
+            vec!["output.o".to_string()],
+            vec![payload_size],
+            Arc::new(Vec::new()),
+            Arc::new(Vec::new()),
+            0,
+        ))
+    }
+
+    #[test]
+    fn owned_clones_share_lazy_payload_initialization() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = "shared-cell";
+        std::fs::write(dir.path().join(format!("{key}_0")), b"payload").unwrap();
+        let cached = lazy_artifact(7);
+        let owned_clone = cached.clone();
+
+        let first =
+            ensure_payloads_with_staged_policy(&cached, dir.path(), key, false).unwrap();
+        let second =
+            ensure_payloads_with_staged_policy(&owned_clone, dir.path(), key, false).unwrap();
+
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn perf_owned_clone_is_one_arc_refcount_and_does_not_pin_dashmap() {
+        let artifacts = DashMap::new();
+        artifacts.insert("key", lazy_artifact(7));
+        let owned = {
+            let entry = artifacts.get("key").unwrap();
+            entry.value().clone()
+        };
+        let before = Arc::strong_count(&owned.inner);
+        let clones: Vec<_> = (0..1_024).map(|_| owned.clone()).collect();
+
+        assert_eq!(Arc::strong_count(&owned.inner), before + clones.len());
+        assert!(
+            clones
+                .iter()
+                .all(|clone| Arc::ptr_eq(&owned.inner, &clone.inner)),
+            "owned lookup clones must not duplicate ArtifactIndex vectors"
+        );
+        assert!(
+            artifacts.remove("key").is_some(),
+            "an owned clone must not retain a DashMap shard guard"
+        );
+    }
+
+    #[test]
+    fn owned_clones_share_access_updates() {
+        let cached = lazy_artifact(0);
+        let owned_clone = cached.clone();
+        assert!(!cached.access_snapshot().used_in_process);
+
+        let now = std::time::Instant::now();
+        let persisted = owned_clone.record_access(now);
+
+        assert!(persisted.is_some());
+        let access = cached.access_snapshot();
+        assert!(access.used_in_process);
+        assert_eq!(access.last_used, now);
+        assert!(access.last_access_checkpoint.is_some());
+    }
+
+    #[test]
+    fn failed_payload_discovery_can_be_retried() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = "retry-cell";
+        let cached = lazy_artifact(7);
+
+        assert!(
+            ensure_payloads_with_staged_policy(&cached, dir.path(), key, false).is_none()
+        );
+        std::fs::write(dir.path().join(format!("{key}_0")), b"payload").unwrap();
+        assert!(
+            ensure_payloads_with_staged_policy(&cached, dir.path(), key, false).is_some()
+        );
+    }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
@@ -530,10 +530,11 @@ fn refresh_live_access(
 ) {
     for artifact in scanned {
         if let Some(cached) = artifacts.get(&artifact.key) {
-            let live_last_use = if cached.used_in_process {
-                now.checked_sub(cached.last_used.elapsed()).unwrap_or(now)
+            let access = cached.access_snapshot();
+            let live_last_use = if access.used_in_process {
+                now.checked_sub(access.last_used.elapsed()).unwrap_or(now)
             } else {
-                cached.last_used_wall.min(now)
+                access.last_used_wall.min(now)
             };
             artifact.last_access = artifact.last_access.max(live_last_use);
         }
@@ -587,10 +588,10 @@ fn remove_planned_artifacts(
     }
 
     let keys: Vec<&str> = removed_keys.iter().map(String::as_str).collect();
-    // Remove the fallback source before the live map. A cache hit that
-    // already holds a DashMap guard can finish and enqueue its access
-    // checkpoint; `remove` waits for that guard, and the subsequent Remove
-    // command is ordered after every such Insert. New lookups cannot
+    // The caller owns the publication barrier's write side. Every cache hit
+    // that acquired an owned read lease has therefore finished payload
+    // discovery and enqueued its access checkpoint; the subsequent Remove is
+    // ordered after every such Insert. New lookups cannot acquire a lease and
     // rehydrate the entry from ArtifactStore in the gap.
     artifact_store.remove_batch(&keys);
     dep_graph.invalidate_artifact_keys(&removed_keys.iter().cloned().collect());
@@ -603,7 +604,15 @@ fn remove_planned_artifacts(
     Ok(removed_keys)
 }
 
+#[cfg(test)]
 fn maintain_disk_artifacts(pass: MaintenancePass<'_>) -> io::Result<DiskMaintenanceReport> {
+    maintain_disk_artifacts_with_barrier(pass, None)
+}
+
+fn maintain_disk_artifacts_with_barrier(
+    pass: MaintenancePass<'_>,
+    publication_barrier: Option<&Arc<tokio::sync::RwLock<()>>>,
+) -> io::Result<DiskMaintenanceReport> {
     let MaintenancePass {
         artifact_dir,
         artifacts,
@@ -639,16 +648,51 @@ fn maintain_disk_artifacts(pass: MaintenancePass<'_>) -> io::Result<DiskMaintena
             pending_write_bytes,
             pressure,
         );
+        if plan.selected.is_empty() {
+            pressure = plan.pressure;
+            break;
+        }
+        let (plan, removed_this_round) = if let Some(publication_barrier) = publication_barrier {
+            // Filesystem scanning and candidate planning are read-only and may
+            // take seconds on a large cache. Only exclude cache hits for the
+            // short destructive commit, then refresh live access and re-plan
+            // under the writer so a hit/publication that raced the scan is
+            // not evicted as stale.
+            let _publication_guard = publication_barrier.blocking_write();
+            refresh_live_access(&mut scanned, artifacts, now);
+            let commit_space = environment.filesystem_space(artifact_dir)?;
+            let commit_plan = plan_maintenance_at_least(
+                policy,
+                kind,
+                now,
+                commit_space,
+                &scanned,
+                pending_write_bytes,
+                pressure,
+            );
+            let removed = remove_planned_artifacts(
+                artifact_dir,
+                &scanned,
+                &commit_plan,
+                artifacts,
+                artifact_store,
+                index_writer_tx,
+                dep_graph,
+            )?;
+            (commit_plan, removed)
+        } else {
+            let removed = remove_planned_artifacts(
+                artifact_dir,
+                &scanned,
+                &plan,
+                artifacts,
+                artifact_store,
+                index_writer_tx,
+                dep_graph,
+            )?;
+            (plan, removed)
+        };
         pressure = plan.pressure;
-        let removed_this_round = remove_planned_artifacts(
-            artifact_dir,
-            &scanned,
-            &plan,
-            artifacts,
-            artifact_store,
-            index_writer_tx,
-            dep_graph,
-        )?;
         if removed_this_round.is_empty() {
             break;
         }
@@ -727,7 +771,6 @@ pub(super) async fn maintain_state_disk(
             "disk maintenance skipped because daemon shutdown is in progress",
         ));
     }
-    let _publication_guard = state.artifact_publication.write().await;
     let cache_dir = state.cache_dir.clone();
     let index_writer_tx = state.index_writer_tx.clone();
     let maintenance_index_writer_tx = index_writer_tx.clone();
@@ -735,17 +778,20 @@ pub(super) async fn maintain_state_disk(
     let maintenance_state = Arc::clone(&state);
     let report = tokio::task::spawn_blocking(move || {
         let dep_graph = maintenance_state.dep_graph.load_full();
-        maintain_disk_artifacts(MaintenancePass {
-            artifact_dir: maintenance_state.artifact_dir.as_path(),
-            artifacts: &maintenance_state.artifacts,
-            artifact_store: &maintenance_state.artifact_store,
-            index_writer_tx: Some(&maintenance_index_writer_tx),
-            dep_graph: &dep_graph,
-            pending_write_bytes,
-            policy,
-            kind,
-            environment: &RealMaintenanceEnvironment,
-        })
+        maintain_disk_artifacts_with_barrier(
+            MaintenancePass {
+                artifact_dir: maintenance_state.artifact_dir.as_path(),
+                artifacts: &maintenance_state.artifacts,
+                artifact_store: &maintenance_state.artifact_store,
+                index_writer_tx: Some(&maintenance_index_writer_tx),
+                dep_graph: &dep_graph,
+                pending_write_bytes,
+                policy,
+                kind,
+                environment: &RealMaintenanceEnvironment,
+            },
+            Some(&maintenance_state.artifact_publication),
+        )
     })
     .await
     .map_err(io::Error::other)??;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile.rs
@@ -30,6 +30,7 @@ pub(super) async fn handle_compile(
     client_env: Option<Vec<(String, String)>>,
     stdin: Vec<u8>,
 ) -> Response {
+    let _active_request = state_arc.begin_cache_request();
     pipeline::handle_compile_request(CompileRequest {
         state_arc,
         session_id,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
@@ -87,9 +87,9 @@ pub(super) fn materialize_cached_compile_hit(
     // reuses `t0` for the maintenance-visible `last_used` write without an
     // additional clock read (issue #1148).
     let t0 = Instant::now();
-    let mut cached_ref = lookup_artifact_with_disk_fallback(state, artifact_key_hex)?;
-    ensure_payloads(&mut cached_ref, &state.artifact_dir, artifact_key_hex)?;
-    record_artifact_access(state, artifact_key_hex, &mut cached_ref, t0);
+    let cached = lookup_artifact_with_disk_fallback(state, artifact_key_hex)?;
+    let payloads = ensure_payloads(&cached, &state.artifact_dir, artifact_key_hex)?;
+    record_artifact_access(state, artifact_key_hex, &cached, t0);
     let t1 = Instant::now();
     let artifact_lookup_ns = (t1 - t0).as_nanos() as u64;
 
@@ -99,13 +99,11 @@ pub(super) fn materialize_cached_compile_hit(
     // set.
     crate::daemon::server::inner_trace::record_ns("cache_load", artifact_lookup_ns);
 
-    let payloads = Arc::clone(cached_ref.payloads.as_ref()?);
-    let names = Arc::clone(&cached_ref.meta.output_names);
-    let exit_code = cached_ref.meta.exit_code;
-    let stdout = cached_ref.stdout.clone();
-    let stderr = cached_ref.stderr.clone();
-    let artifact_bytes = cached_ref.meta.total_size;
-    drop(cached_ref);
+    let names = Arc::clone(&cached.meta.output_names);
+    let exit_code = cached.meta.exit_code;
+    let stdout = cached.stdout.clone();
+    let stderr = cached.stderr.clone();
+    let artifact_bytes = cached.meta.total_size;
 
     // Issue #643: when the miss path stashed the user's depfile bytes as a
     // second output and the current request supplies a `-MF` destination,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -111,34 +111,22 @@ fn check_unit_cache(
                 // cloning all .o data (~50-200KB per file) into PendingWrite.
                 // Each check_unit_cache runs in its own spawn_blocking task,
                 // so writes are already parallel across units.
-                if let Some(mut cached_ref) =
+                if let Some(cached) =
                     lookup_artifact_with_disk_fallback(state, artifact_key_hex)
                 {
-                    let loaded =
-                        ensure_payloads(&mut cached_ref, &state.artifact_dir, artifact_key_hex)
-                            .is_some();
-                    if loaded {
+                    if let Some(payloads) =
+                        ensure_payloads(&cached, &state.artifact_dir, artifact_key_hex)
+                    {
                         record_artifact_access(
                             state,
                             artifact_key_hex,
-                            &mut cached_ref,
+                            &cached,
                             std::time::Instant::now(),
                         );
-                        #[expect(
-                            clippy::expect_used,
-                            reason = "ensure_payloads on the preceding line returned Some, which is the contract guaranteeing cached_ref.payloads is now populated"
-                        )]
-                        let payloads = Arc::clone(
-                            cached_ref
-                                .payloads
-                                .as_ref()
-                                .expect("ensure_payloads above returned without error"),
-                        );
-                        let names = Arc::clone(&cached_ref.meta.output_names);
-                        let artifact_bytes: u64 = cached_ref.meta.total_size;
-                        let stdout = cached_ref.stdout.clone();
-                        let stderr = cached_ref.stderr.clone();
-                        drop(cached_ref);
+                        let names = Arc::clone(&cached.meta.output_names);
+                        let artifact_bytes: u64 = cached.meta.total_size;
+                        let stdout = cached.stdout.clone();
+                        let stderr = cached.stderr.clone();
 
                         let targets: Vec<(NormalizedPath, NormalizedPath)> = (0..payloads.len())
                             .map(|i| {
@@ -245,32 +233,21 @@ fn check_unit_cache(
     | crate::depgraph::CacheVerdict::SourceChanged { artifact_key } = verdict
     {
         let artifact_key_hex = artifact_key.hash().to_hex();
-        if let Some(mut cached_ref) = lookup_artifact_with_disk_fallback(state, &artifact_key_hex) {
+        if let Some(cached) = lookup_artifact_with_disk_fallback(state, &artifact_key_hex) {
             let t_lookup = t0.elapsed();
-            let loaded =
-                ensure_payloads(&mut cached_ref, &state.artifact_dir, &artifact_key_hex).is_some();
-            if loaded {
+            if let Some(payloads) =
+                ensure_payloads(&cached, &state.artifact_dir, &artifact_key_hex)
+            {
                 record_artifact_access(
                     state,
                     &artifact_key_hex,
-                    &mut cached_ref,
+                    &cached,
                     std::time::Instant::now(),
                 );
-                #[expect(
-                    clippy::expect_used,
-                    reason = "ensure_payloads on the preceding line returned Some, which is the contract guaranteeing cached_ref.payloads is now populated"
-                )]
-                let payloads = Arc::clone(
-                    cached_ref
-                        .payloads
-                        .as_ref()
-                        .expect("ensure_payloads above returned without error"),
-                );
-                let names = Arc::clone(&cached_ref.meta.output_names);
-                let artifact_bytes: u64 = cached_ref.meta.total_size;
-                let stdout = cached_ref.stdout.clone();
-                let stderr = cached_ref.stderr.clone();
-                drop(cached_ref);
+                let names = Arc::clone(&cached.meta.output_names);
+                let artifact_bytes: u64 = cached.meta.total_size;
+                let stdout = cached.stdout.clone();
+                let stderr = cached.stderr.clone();
 
                 let targets: Vec<(NormalizedPath, NormalizedPath)> = (0..payloads.len())
                     .map(|i| {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
@@ -206,6 +206,7 @@ pub(super) async fn handle_generic_tool_exec(
     non_deterministic: bool,
     key_args_filter: &[String],
 ) -> Response {
+    let _active_request = state.begin_cache_request();
     // 1. Filtered args for the cache key (the tool always sees the raw args).
     let key_args = match apply_key_args_filter(args, key_args_filter) {
         Ok(v) => v,
@@ -760,20 +761,15 @@ async fn try_exec_cache_hit(
     output_files: &[NormalizedPath],
     output_streams: ExecOutputStreams,
 ) -> Option<Response> {
-    let mut entry = lookup_artifact_with_disk_fallback(state, key_hex)?;
+    let entry = lookup_artifact_with_disk_fallback(state, key_hex)?;
 
     let exit_code = entry.meta.exit_code;
     let stdout_full = entry.stdout.clone();
     let stderr_full = entry.stderr.clone();
     let names = Arc::clone(&entry.meta.output_names);
 
-    let payloads_loaded = ensure_payloads(&mut entry, &state.artifact_dir, key_hex).is_some();
-    if !payloads_loaded {
-        return None;
-    }
-    record_artifact_access(state, key_hex, &mut entry, std::time::Instant::now());
-    let payloads = Arc::clone(entry.payloads.as_ref()?);
-    drop(entry);
+    let payloads = ensure_payloads(&entry, &state.artifact_dir, key_hex)?;
+    record_artifact_access(state, key_hex, &entry, std::time::Instant::now());
 
     let mut paired: Vec<(NormalizedPath, &CachedPayload)> = Vec::with_capacity(output_files.len());
     for declared in output_files {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec_probe.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec_probe.rs
@@ -37,6 +37,7 @@ pub(super) fn handle_exec_probe(
     input_env: &[(String, String)],
     input_extra: &Arc<Vec<u8>>,
 ) -> Response {
+    let _active_request = state.begin_cache_request();
     let cache_key_hex =
         match compose_exec_probe_key(state, name, input_files, input_env, input_extra) {
             Ok(hex) => hex,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec_tests.rs
@@ -240,7 +240,7 @@ async fn staged_exec_disk_hit_reports_physical_materialization_tier() {
         stderr: Arc::new(Vec::new()),
         exit_code: 0,
     };
-    let metadata = CachedArtifact::from_artifact_data(&artifact).meta;
+    let metadata = CachedArtifact::from_artifact_data(&artifact).meta.clone();
     let key = "d".repeat(64);
     let cached = store_exec_artifact(&server.state, key.clone(), artifact, Some(vec![source]))
         .await

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -51,6 +51,7 @@ pub(super) async fn handle_link_ephemeral(
     cwd: &Path,
     env: Option<Vec<(String, String)>>,
 ) -> Response {
+    let _active_request = state.begin_cache_request();
     // Issue #535: collect phase counters when `ZCCACHE_PROFILE_CC_MISS` is set
     // so the bench / perf-guard logs carry breakdown data for cold link/
     // archive operations (c-static-library-link, cpp-driver-link).
@@ -361,28 +362,15 @@ pub(super) async fn handle_link_ephemeral(
 
     // 5. Cache lookup
     let t_cache_lookup = profile_enabled.then(std::time::Instant::now);
-    if let Some(mut entry) = lookup_artifact_with_disk_fallback(state, &key_hex) {
+    if let Some(entry) = lookup_artifact_with_disk_fallback(state, &key_hex) {
         // Load payloads from disk if not already loaded.
-        let loaded = ensure_payloads(&mut entry, &state.artifact_dir, &key_hex).is_some();
-        if loaded {
-            record_artifact_access(state, &key_hex, &mut entry, std::time::Instant::now());
+        if let Some(payloads) = ensure_payloads(&entry, &state.artifact_dir, &key_hex) {
+            record_artifact_access(state, &key_hex, &entry, std::time::Instant::now());
             discard_speculative_archive(&mut speculative_archive);
-            #[expect(
-                clippy::expect_used,
-                reason = "ensure_payloads on the preceding line returned Some, which is the contract guaranteeing entry.payloads is now populated"
-            )]
-            let payloads = Arc::clone(
-                entry
-                    .payloads
-                    .as_ref()
-                    .expect("ensure_payloads above returned without error"),
-            );
             let names = Arc::clone(&entry.meta.output_names);
             let exit_code = entry.meta.exit_code;
             let stdout = entry.stdout.clone();
             let stderr = entry.stderr.clone();
-            drop(entry); // Release DashMap lock
-
             tracing::debug!(%key_hex, "link cache hit");
             state.stats.record_link_hit();
 

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link_tests.rs
@@ -179,7 +179,7 @@ async fn failed_link_publication_salvages_output_without_becoming_cacheable() {
         stderr: Arc::new(Vec::new()),
         exit_code: 0,
     };
-    let metadata = CachedArtifact::from_artifact_data(&artifact).meta;
+    let metadata = CachedArtifact::from_artifact_data(&artifact).meta.clone();
     let fault = StagedFaultGuard::arm(&server.state.artifact_dir, [StagedFaultPoint::IndexCommit]);
 
     let key = "a".repeat(64);
@@ -224,7 +224,7 @@ async fn failed_link_publication_and_salvage_fail_closed() {
         stderr: Arc::new(Vec::new()),
         exit_code: 0,
     };
-    let metadata = CachedArtifact::from_artifact_data(&artifact).meta;
+    let metadata = CachedArtifact::from_artifact_data(&artifact).meta.clone();
     let publish_fault = StagedFaultGuard::arm(
         &server.state.artifact_dir,
         [StagedFaultPoint::PointerCommit],

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -182,6 +182,8 @@ pub(super) fn new_shared_state(
             watched_dirs: Mutex::new(HashSet::new()),
             shutdown,
             last_activity: AtomicU64::new(now),
+            active_cache_requests: AtomicUsize::new(0),
+            cache_requests_idle: Notify::new(),
             start_time: now,
             stats: StatsCollector::new(),
             profiler: PhaseProfiler::new(),

--- a/crates/zccache-daemon-core/src/daemon/server/run.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/run.rs
@@ -9,6 +9,10 @@
 use super::*;
 
 const ACCEPT_STALL_WATCHDOG_INTERVAL: Duration = Duration::from_secs(600);
+const MEMORY_GC_IDLE_GRACE: Duration = Duration::from_millis(250);
+const MEMORY_GC_GENTLE_RETRY: Duration = Duration::from_millis(50);
+const MEMORY_GC_FORCE_AFTER: Duration = Duration::from_secs(5);
+const MEMORY_GC_GENTLE_BATCH: usize = 256;
 
 impl DaemonServer {
     /// Run the server, accepting connections until shutdown is signaled.
@@ -224,16 +228,7 @@ impl DaemonServer {
                             "trimmed ephemeral daemon caches"
                         );
                     }
-                    let dep_graph_guard = state.dep_graph.load();
-                    let (freed, items) = super::super::eviction::evict_to_budget(
-                        budget,
-                        &state.cache_system,
-                        &dep_graph_guard,
-                        &state.fast_hit_cache,
-                        &state.artifacts,
-                        state.in_flight_bytes.load(Ordering::Relaxed),
-                    );
-                    drop(dep_graph_guard);
+                    let (freed, items) = run_memory_eviction_pass(&state, budget).await;
                     if items > 0 {
                         tracing::info!(
                             freed_bytes = freed,
@@ -720,6 +715,186 @@ impl DaemonServer {
     }
 }
 
+async fn run_memory_eviction_pass(state: &Arc<SharedState>, budget: u64) -> (u64, usize) {
+    let started = Instant::now();
+    let mut total_freed = 0_u64;
+    let mut total_items = 0_usize;
+    let mut candidate_offset = 0_usize;
+    let plan = {
+        let dep_graph_guard = state.dep_graph.load();
+        let plan = super::super::eviction::plan_eviction_to_budget(
+            budget,
+            &state.cache_system,
+            &dep_graph_guard,
+            &state.fast_hit_cache,
+            &state.artifacts,
+            state.in_flight_bytes.load(Ordering::Relaxed),
+        );
+        drop(dep_graph_guard);
+        plan
+    };
+    let Some(plan) = plan else {
+        return (0, 0);
+    };
+    let mut gentle_finished = false;
+    let mut busy_candidates = Vec::new();
+    let mut protected_paths = std::collections::HashSet::new();
+
+    loop {
+        let active_requests = state.active_cache_requests();
+        if active_requests == 0 || started.elapsed() >= MEMORY_GC_FORCE_AFTER {
+            // Nonblocking metadata removal intentionally leaves orphaned
+            // journal rows. Settle that debt before deciding whether the
+            // original headroom target still requires destructive work.
+            let journal_removed = state.cache_system.cleanup_eviction_journal();
+            total_freed += (journal_removed
+                * super::super::eviction::JOURNAL_ENTRY_BYTES) as u64;
+            total_items += journal_removed;
+
+            let dep_graph_guard = state.dep_graph.load();
+            let current = super::super::eviction::memory_snapshot(
+                &state.cache_system,
+                &dep_graph_guard,
+                &state.fast_hit_cache,
+                &state.artifacts,
+                state.in_flight_bytes.load(Ordering::Relaxed),
+            );
+            drop(dep_graph_guard);
+            if current.total_bytes as u64 <= plan.target_bytes() {
+                return (total_freed, total_items);
+            }
+
+            // Retry lock-busy candidates in blocking mode, preserve only
+            // timestamp-refreshed entries, then replenish from a current
+            // read-only plan until the target is met or every remaining
+            // metadata candidate is protected for this sweep.
+            let mut completion_plan =
+                plan.completion_from(candidate_offset, &busy_candidates);
+            loop {
+                let completion_had_candidates =
+                    completion_plan.metadata_candidate_count() > 0;
+                let dep_graph_guard = state.dep_graph.load();
+                let outcome =
+                    super::super::eviction::evict_to_budget_with_plan_detailed(
+                        budget,
+                        &state.cache_system,
+                        &dep_graph_guard,
+                        &state.fast_hit_cache,
+                        &state.artifacts,
+                        state.in_flight_bytes.load(Ordering::Relaxed),
+                        &completion_plan,
+                    );
+                drop(dep_graph_guard);
+                total_freed += outcome.freed_bytes;
+                total_items += outcome.items_removed;
+                protected_paths.extend(
+                    outcome
+                        .refreshed
+                        .iter()
+                        .map(|candidate| candidate.path().clone()),
+                );
+
+                let dep_graph_guard = state.dep_graph.load();
+                let current = super::super::eviction::memory_snapshot(
+                    &state.cache_system,
+                    &dep_graph_guard,
+                    &state.fast_hit_cache,
+                    &state.artifacts,
+                    state.in_flight_bytes.load(Ordering::Relaxed),
+                );
+                if current.total_bytes as u64 <= plan.target_bytes() {
+                    drop(dep_graph_guard);
+                    return (total_freed, total_items);
+                }
+                let next =
+                    super::super::eviction::plan_eviction_to_target_excluding(
+                        plan.target_bytes(),
+                        &state.cache_system,
+                        &dep_graph_guard,
+                        &state.fast_hit_cache,
+                        &state.artifacts,
+                        state.in_flight_bytes.load(Ordering::Relaxed),
+                        &protected_paths,
+                    );
+                drop(dep_graph_guard);
+                let Some(next) = next else {
+                    return (total_freed, total_items);
+                };
+                if current.metadata_entries > 0
+                    && next.metadata_candidate_count() == 0
+                {
+                    return (total_freed, total_items);
+                }
+                if forced_completion_stalled(
+                    outcome.items_removed,
+                    completion_had_candidates,
+                    current.metadata_entries,
+                ) {
+                    // Remaining pressure comes only from non-evictable state
+                    // (for example in-flight persistence bytes, artifact-map
+                    // overhead, or intentionally preserved recent fast hits).
+                    return (total_freed, total_items);
+                }
+                completion_plan = next;
+            }
+        }
+
+        if started.elapsed() < MEMORY_GC_IDLE_GRACE {
+            tokio::select! {
+                () = state.cache_requests_idle.notified() => {}
+                () = tokio::time::sleep(
+                    MEMORY_GC_IDLE_GRACE.saturating_sub(started.elapsed())
+                ) => {}
+            }
+            continue;
+        }
+
+        if !gentle_finished {
+            let outcome = super::super::eviction::try_evict_metadata_plan(
+                &state.cache_system,
+                &plan,
+                candidate_offset,
+                MEMORY_GC_GENTLE_BATCH,
+            );
+            total_freed += outcome.freed_bytes;
+            total_items += outcome.items_removed;
+            busy_candidates.extend(outcome.busy);
+            protected_paths.extend(
+                outcome
+                    .refreshed
+                    .iter()
+                    .map(|candidate| candidate.path().clone()),
+            );
+            candidate_offset = candidate_offset.saturating_add(MEMORY_GC_GENTLE_BATCH);
+
+            let dep_graph_guard = state.dep_graph.load();
+            let current = super::super::eviction::memory_snapshot(
+                &state.cache_system,
+                &dep_graph_guard,
+                &state.fast_hit_cache,
+                &state.artifacts,
+                state.in_flight_bytes.load(Ordering::Relaxed),
+            );
+            drop(dep_graph_guard);
+            gentle_finished = current.total_bytes as u64 <= plan.target_bytes()
+                || candidate_offset >= plan.metadata_candidate_count();
+        }
+
+        tokio::select! {
+            () = state.cache_requests_idle.notified() => {}
+            () = tokio::time::sleep(MEMORY_GC_GENTLE_RETRY) => {}
+        }
+    }
+}
+
+fn forced_completion_stalled(
+    items_removed: usize,
+    completion_had_candidates: bool,
+    metadata_entries: usize,
+) -> bool {
+    items_removed == 0 && !completion_had_candidates && metadata_entries == 0
+}
+
 /// Start index hydration with publication ownership acquired before spawn.
 /// The optional gate is a deterministic test seam for Clear/startup races.
 pub(super) async fn spawn_artifact_loader(
@@ -766,4 +941,17 @@ pub(super) async fn spawn_artifact_loader(
         }
         state.artifacts_loaded.store(true, Ordering::Release);
     })
+}
+
+#[cfg(test)]
+mod memory_eviction_controller_tests {
+    use super::forced_completion_stalled;
+
+    #[test]
+    fn in_flight_only_pressure_terminates_after_no_progress() {
+        assert!(forced_completion_stalled(0, false, 0));
+        assert!(!forced_completion_stalled(1, false, 0));
+        assert!(!forced_completion_stalled(0, true, 0));
+        assert!(!forced_completion_stalled(0, false, 1));
+    }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -93,6 +93,29 @@ impl Drop for StagingRoot {
     }
 }
 
+/// RAII marker covering one complete compile-cache request.
+///
+/// The compiler-child counter in `daemon::process` is intentionally narrower:
+/// it excludes cache hits, pre-hashing, and post-compile publication. Metadata
+/// GC uses this request-level counter to prefer quiet periods without making
+/// correctness depend on finding one.
+pub(super) struct ActiveCacheRequest<'a> {
+    state: &'a SharedState,
+}
+
+impl Drop for ActiveCacheRequest<'_> {
+    fn drop(&mut self) {
+        if self
+            .state
+            .active_cache_requests
+            .fetch_sub(1, Ordering::AcqRel)
+            == 1
+        {
+            self.state.cache_requests_idle.notify_one();
+        }
+    }
+}
+
 /// Shared state accessible by all connection handlers.
 pub(super) struct SharedState {
     /// IPC endpoint this daemon bound. Reported through `zccache status` so
@@ -154,6 +177,12 @@ pub(super) struct SharedState {
     pub(super) shutdown: Arc<Notify>,
     /// Epoch seconds of last client activity (for idle timeout).
     pub(super) last_activity: AtomicU64,
+    /// Metadata-cache consumers active from request entry through hit
+    /// materialization or miss publication (compile, link, generic exec, and
+    /// caller-owned exec probes).
+    pub(super) active_cache_requests: AtomicUsize,
+    /// Wakes deferred metadata GC when the active request count reaches zero.
+    pub(super) cache_requests_idle: Notify,
     /// Daemon start time (epoch seconds).
     pub(super) start_time: u64,
     /// Global stats collector.
@@ -389,6 +418,15 @@ pub(super) struct SharedState {
 }
 
 impl SharedState {
+    pub(super) fn begin_cache_request(&self) -> ActiveCacheRequest<'_> {
+        self.active_cache_requests.fetch_add(1, Ordering::AcqRel);
+        ActiveCacheRequest { state: self }
+    }
+
+    pub(super) fn active_cache_requests(&self) -> usize {
+        self.active_cache_requests.load(Ordering::Acquire)
+    }
+
     /// Return the lock that owns legacy side-effect capture for `output_dir`.
     ///
     /// The returned `Arc` is independent of the DashMap entry guard so callers

--- a/crates/zccache-daemon-core/src/daemon/server/tests/clear_handler.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/clear_handler.rs
@@ -238,3 +238,62 @@ async fn handle_clear_cannot_be_overtaken_by_delayed_startup_hydration() {
     })
     .await;
 }
+
+#[tokio::test]
+async fn handle_clear_waits_for_owned_cache_lookup_lease() {
+    crate::test_support::test_timeout(async {
+        let endpoint = crate::ipc::unique_test_endpoint();
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+        let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+        let index_writer = tokio::spawn(run_index_writer(
+            server.index_writer_rx.take().unwrap(),
+            Arc::clone(&server.state.artifact_store),
+            Arc::clone(&server.state.index_writer_shutdown),
+        ));
+        let key = "7".repeat(64);
+        let meta = ArtifactIndex::new(
+            vec!["leased.o".to_string()],
+            vec![14],
+            Vec::new(),
+            Vec::new(),
+            0,
+        );
+        server.state.artifact_store.insert(&key, &meta);
+        server
+            .state
+            .artifacts
+            .insert(key.clone(), CachedArtifact::from_index(meta));
+        let payload_path = server.state.artifact_dir.join(format!("{key}_0"));
+        std::fs::write(&payload_path, b"leased payload").unwrap();
+
+        let lookup = lookup_artifact_with_disk_fallback(&server.state, &key)
+            .expect("live artifact should acquire a publication lease");
+        let clear_state = Arc::clone(&server.state);
+        let mut clear =
+            tokio::spawn(
+                async move { super::super::handle_clear::handle_clear(&clear_state).await },
+            );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), &mut clear)
+                .await
+                .is_err(),
+            "Clear must wait for an owned lookup to finish materializing"
+        );
+        record_artifact_access(&server.state, &key, &lookup, Instant::now());
+        drop(lookup);
+
+        let response = tokio::time::timeout(std::time::Duration::from_secs(5), clear)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(response, Response::Cleared { .. }));
+        assert!(!server.state.artifacts.contains_key(&key));
+        assert!(server.state.artifact_store.get(&key).is_none());
+        assert!(!payload_path.exists());
+
+        server.state.index_writer_shutdown.notify_waiters();
+        index_writer.await.unwrap();
+    })
+    .await;
+}

--- a/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
@@ -36,6 +36,34 @@ impl MaintenanceEnvironment for FixedEnvironment {
     }
 }
 
+struct GatedScanEnvironment {
+    now: SystemTime,
+    calls: std::sync::atomic::AtomicUsize,
+    scan_entered: std::sync::Barrier,
+    release_scan: std::sync::Barrier,
+}
+
+impl MaintenanceEnvironment for GatedScanEnvironment {
+    fn now(&self) -> SystemTime {
+        self.now
+    }
+
+    fn filesystem_space(&self, _root: &Path) -> io::Result<FilesystemSpace> {
+        if self
+            .calls
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel)
+            == 0
+        {
+            self.scan_entered.wait();
+            self.release_scan.wait();
+        }
+        Ok(FilesystemSpace {
+            capacity_bytes: 1000 * GIB,
+            free_bytes: 500 * GIB,
+        })
+    }
+}
+
 #[test]
 fn issue_1148_default_budget_is_five_percent_clamped_to_40_200_gib() {
     let policy = MaintenancePolicy::default();
@@ -142,6 +170,51 @@ fn issue_1148_eviction_updates_files_live_map_index_and_only_owned_root() {
         std::fs::read(sibling.join("sentinel")).unwrap(),
         b"owned by another product"
     );
+}
+
+#[test]
+fn read_only_maintenance_scan_does_not_exclude_cache_hit_leases() {
+    let root = tempfile::tempdir().unwrap();
+    let artifact_dir = root.path().join("artifacts");
+    std::fs::create_dir_all(&artifact_dir).unwrap();
+    std::fs::write(artifact_dir.join("old.meta"), vec![0_u8; 4096]).unwrap();
+    let artifacts = DashMap::new();
+    let store = ArtifactStore::open_empty(&root.path().join("index.bin"));
+    let dep_graph = DepGraph::new();
+    let publication_barrier = Arc::new(tokio::sync::RwLock::new(()));
+    let environment = GatedScanEnvironment {
+        now: SystemTime::UNIX_EPOCH + 100 * DAY,
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        scan_entered: std::sync::Barrier::new(2),
+        release_scan: std::sync::Barrier::new(2),
+    };
+
+    std::thread::scope(|scope| {
+        let maintenance = scope.spawn(|| {
+            maintain_disk_artifacts_with_barrier(
+                MaintenancePass {
+                    artifact_dir: &artifact_dir,
+                    artifacts: &artifacts,
+                    artifact_store: &store,
+                    index_writer_tx: None,
+                    dep_graph: &dep_graph,
+                    pending_write_bytes: 0,
+                    policy: bytes_policy(1),
+                    kind: MaintenanceKind::Pressure,
+                    environment: &environment,
+                },
+                Some(&publication_barrier),
+            )
+        });
+
+        environment.scan_entered.wait();
+        let cache_hit_lease = Arc::clone(&publication_barrier)
+            .try_read_owned()
+            .expect("read-only scan must not queue or hold the publication writer");
+        drop(cache_hit_lease);
+        environment.release_scan.wait();
+        maintenance.join().unwrap().unwrap();
+    });
 }
 
 #[test]
@@ -543,9 +616,10 @@ fn issue_1148_future_persisted_access_is_clamped_at_restore() {
         .unwrap()
         .as_secs();
     let restored = CachedArtifact::from_index(meta);
-    assert!(restored.last_used_wall <= SystemTime::now());
-    assert!(!restored.used_in_process);
-    assert!(restored.last_access_checkpoint.is_none());
+    let access = restored.access_snapshot();
+    assert!(access.last_used_wall <= SystemTime::now());
+    assert!(!access.used_in_process);
+    assert!(access.last_access_checkpoint.is_none());
 }
 
 #[test]
@@ -558,7 +632,7 @@ fn issue_1148_windows_allocated_size_combines_high_low_and_falls_back() {
 }
 
 #[tokio::test]
-async fn issue_1148_publication_barrier_orders_insert_before_gc_remove() {
+async fn artifact_lookup_lease_orders_access_insert_before_gc_remove() {
     let root = tempfile::tempdir().unwrap();
     let cache_dir: crate::core::NormalizedPath = root.path().join("cache").into();
     let daemon = Arc::new(
@@ -583,7 +657,6 @@ async fn issue_1148_publication_barrier_orders_insert_before_gc_remove() {
     std::fs::write(artifact_dir.join(format!("{key}.meta")), vec![0_u8; 4096]).unwrap();
     let meta = ArtifactIndex::new(vec![], vec![], Vec::new(), Vec::new(), 0);
 
-    let publication_guard = daemon.state.artifact_publication.read().await;
     daemon
         .state
         .artifacts
@@ -593,14 +666,22 @@ async fn issue_1148_publication_barrier_orders_insert_before_gc_remove() {
         .index_writer_tx
         .send(IndexWriterCommand::Insert(key.clone(), meta))
         .unwrap();
+    let lookup = lookup_artifact_with_disk_fallback(&daemon.state, &key)
+        .expect("live artifact should acquire a publication lease");
     let maintenance_daemon = Arc::clone(&daemon);
-    let maintenance = tokio::spawn(async move {
+    let mut maintenance = tokio::spawn(async move {
         maintenance_daemon
             .maintain_disk(MaintenanceKind::Pressure)
             .await
     });
-    tokio::task::yield_now().await;
-    drop(publication_guard);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(25), &mut maintenance)
+            .await
+            .is_err(),
+        "maintenance must wait while an owned cache lookup is materializing"
+    );
+    record_artifact_access(&daemon.state, &key, &lookup, Instant::now());
+    drop(lookup);
 
     let report = maintenance.await.unwrap().unwrap();
     assert_eq!(report.artifacts_removed, 1);

--- a/crates/zccache-daemon-core/src/daemon/server/tests/pack.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/pack.rs
@@ -134,39 +134,39 @@ fn mixed_v1_pack_v2_lookup_and_downgrade_policy_are_explicit() {
         CachedPayload::Bytes(bytes) => bytes.as_ref().clone(),
     };
 
-    let mut v1 = index("legacy.o", 11);
-    let mut pack = index("packed.o", 11);
-    let mut v2 = index("staged.o", 9);
+    let v1 = index("legacy.o", 11);
+    let pack = index("packed.o", 11);
+    let v2 = index("staged.o", 9);
     assert_eq!(
-        bytes(&ensure_payloads_with_staged_policy(&mut v1, dir.path(), &v1_key, true).unwrap()[0]),
+        bytes(&ensure_payloads_with_staged_policy(&v1, dir.path(), &v1_key, true).unwrap()[0]),
         b"legacy-flat"
     );
     assert_eq!(
         bytes(
-            &ensure_payloads_with_staged_policy(&mut pack, dir.path(), &pack_key, true).unwrap()[0]
+            &ensure_payloads_with_staged_policy(&pack, dir.path(), &pack_key, true).unwrap()[0]
         ),
         b"legacy-pack"
     );
     assert_eq!(
-        bytes(&ensure_payloads_with_staged_policy(&mut v2, dir.path(), &v2_key, true).unwrap()[0]),
+        bytes(&ensure_payloads_with_staged_policy(&v2, dir.path(), &v2_key, true).unwrap()[0]),
         b"staged-v2"
     );
 
     // Downgrade/kill-switch policy: legacy layouts remain readable, while a
     // v2-only entry is a safe miss rather than being reinterpreted.
-    let mut downgraded_v1 = index("legacy.o", 11);
-    let mut downgraded_pack = index("packed.o", 11);
-    let mut downgraded_v2 = index("staged.o", 9);
+    let downgraded_v1 = index("legacy.o", 11);
+    let downgraded_pack = index("packed.o", 11);
+    let downgraded_v2 = index("staged.o", 9);
     assert!(
-        ensure_payloads_with_staged_policy(&mut downgraded_v1, dir.path(), &v1_key, false)
+        ensure_payloads_with_staged_policy(&downgraded_v1, dir.path(), &v1_key, false)
             .is_some()
     );
     assert!(
-        ensure_payloads_with_staged_policy(&mut downgraded_pack, dir.path(), &pack_key, false)
+        ensure_payloads_with_staged_policy(&downgraded_pack, dir.path(), &pack_key, false)
             .is_some()
     );
     assert!(
-        ensure_payloads_with_staged_policy(&mut downgraded_v2, dir.path(), &v2_key, false)
+        ensure_payloads_with_staged_policy(&downgraded_v2, dir.path(), &v2_key, false)
             .is_none()
     );
 }

--- a/crates/zccache-daemon-core/src/daemon/server/util.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/util.rs
@@ -263,21 +263,54 @@ pub(super) fn context_env_deps_fresh(
 /// 3. On disk-store hit, hydrate the DashMap so subsequent lookups
 ///    skip the fallback entirely.
 ///
-/// # Why two `get_mut` calls
+/// # Guard lifetime
 ///
-/// DashMap forbids holding a shard lock (`get_mut` returns a guard
-/// holding it) across an `insert` on the same map — that would
-/// deadlock. We release the first guard's `None` arm, do the
-/// disk-store lookup + insert, then take a fresh `get_mut` to hand
-/// back. The `insert` + re-`get_mut` is on the cold path (DashMap
-/// miss + disk-store hit), so the extra hash is dwarfed by the
-/// hardlink/write work that follows.
-pub(super) fn lookup_artifact_with_disk_fallback<'a>(
-    state: &'a SharedState,
+/// The returned value owns an allocation-free artifact clone and a read lease
+/// on the artifact-publication barrier. The DashMap guard therefore exists
+/// only long enough to clone one `Arc`; filesystem payload discovery and
+/// access checkpointing never hold a shard lock. Disk maintenance and Clear
+/// take the barrier's write side, so they cannot delete files or order an
+/// index removal ahead of an already-started hit.
+pub(super) struct CachedArtifactLookup {
+    cached: CachedArtifact,
+    _publication_guard: tokio::sync::OwnedRwLockReadGuard<()>,
+}
+
+impl CachedArtifactLookup {
+    fn new(
+        cached: CachedArtifact,
+        publication_guard: tokio::sync::OwnedRwLockReadGuard<()>,
+    ) -> Self {
+        Self {
+            cached,
+            _publication_guard: publication_guard,
+        }
+    }
+}
+
+impl std::ops::Deref for CachedArtifactLookup {
+    type Target = CachedArtifact;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cached
+    }
+}
+
+pub(super) fn lookup_artifact_with_disk_fallback(
+    state: &SharedState,
     key_hex: &str,
-) -> Option<dashmap::mapref::one::RefMut<'a, String, CachedArtifact>> {
-    if let Some(entry) = state.artifacts.get_mut(key_hex) {
-        return Some(entry);
+) -> Option<CachedArtifactLookup> {
+    // Maintenance/Clear already owns or is queued for the write side. Treat
+    // this as a cache miss instead of making a request wait behind destructive
+    // work. Tokio's fair RwLock also rejects new readers once a writer queues.
+    let publication_guard = Arc::clone(&state.artifact_publication)
+        .try_read_owned()
+        .ok()?;
+    if let Some(entry) = state.artifacts.get(key_hex) {
+        return Some(CachedArtifactLookup::new(
+            entry.value().clone(),
+            publication_guard,
+        ));
     }
     // Issue #784 phase 2d: the artifact-index blob is no longer read at
     // bind time — `bind_with_cache_dir` constructs an empty store and a
@@ -300,10 +333,13 @@ pub(super) fn lookup_artifact_with_disk_fallback<'a>(
             .store(true, std::sync::atomic::Ordering::Release);
     }
     let meta = state.artifact_store.get(key_hex)?;
-    state
+    let cached = CachedArtifact::from_index(meta);
+    let cached = state
         .artifacts
-        .insert(key_hex.to_string(), CachedArtifact::from_index(meta));
-    state.artifacts.get_mut(key_hex)
+        .entry(key_hex.to_string())
+        .or_insert(cached)
+        .clone();
+    Some(CachedArtifactLookup::new(cached, publication_guard))
 }
 
 /// Refresh an artifact's maintenance-visible access time at most once per
@@ -313,29 +349,14 @@ pub(super) fn lookup_artifact_with_disk_fallback<'a>(
 pub(super) fn record_artifact_access(
     state: &SharedState,
     key_hex: &str,
-    artifact: &mut CachedArtifact,
+    artifact: &CachedArtifact,
     now: Instant,
 ) {
-    const PERSIST_INTERVAL: Duration = Duration::from_secs(60 * 60);
-    artifact.last_used = now;
-    artifact.used_in_process = true;
-    if artifact
-        .last_access_checkpoint
-        .is_some_and(|checkpoint| now.saturating_duration_since(checkpoint) < PERSIST_INTERVAL)
-    {
-        return;
+    if let Some(meta) = artifact.record_access(now) {
+        let _ = state
+            .index_writer_tx
+            .send(IndexWriterCommand::Insert(key_hex.to_string(), meta));
     }
-    artifact.last_access_checkpoint = Some(now);
-    let wall_now = std::time::SystemTime::now();
-    artifact.last_used_wall = wall_now;
-    artifact.meta.stored_at_secs = wall_now
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    let _ = state.index_writer_tx.send(IndexWriterCommand::Insert(
-        key_hex.to_string(),
-        artifact.meta.clone(),
-    ));
 }
 
 #[cfg(all(test, windows))]

--- a/crates/zccache-fscache/src/cache_system.rs
+++ b/crates/zccache-fscache/src/cache_system.rs
@@ -6,7 +6,7 @@
 //! lookups that eliminate redundant stat calls across concurrent clients.
 
 use super::clock::{ChangeJournal, Clock};
-use super::metadata::MetadataCache;
+use super::metadata::{CandidateEvictionResult, EvictionCandidate, MetadataCache};
 use std::sync::{Arc, OnceLock};
 use tokio::sync::Semaphore;
 use zccache_core::{NormalizedPath, Result};
@@ -283,6 +283,61 @@ impl CacheSystem {
         let meta_removed = self.metadata.evict_oldest(count);
         let journal_removed = self.cleanup_journal();
         (meta_removed, journal_removed)
+    }
+
+    /// Read-only phase of two-pass metadata eviction.
+    #[must_use]
+    pub fn oldest_eviction_candidates(&self, count: usize) -> Vec<EvictionCandidate> {
+        self.metadata.oldest_eviction_candidates(count)
+    }
+
+    /// Blocking write phase of two-pass metadata eviction.
+    ///
+    /// Candidates refreshed since the read phase are preserved.
+    pub fn evict_candidates(&self, candidates: &[EvictionCandidate]) -> (usize, usize) {
+        let (result, journal_removed) = self.evict_candidates_detailed(candidates);
+        (result.removed, journal_removed)
+    }
+
+    /// Detailed blocking write phase for traffic-aware eviction.
+    pub fn evict_candidates_detailed(
+        &self,
+        candidates: &[EvictionCandidate],
+    ) -> (CandidateEvictionResult, usize) {
+        let result = self.metadata.evict_candidates_detailed(candidates);
+        // A prior nonblocking pass may have removed metadata while
+        // deliberately deferring journal shard writes. Always settle that
+        // debt on a blocking pass, even when every candidate in this slice
+        // was already removed or refreshed.
+        let journal_removed = self.cleanup_journal();
+        (result, journal_removed)
+    }
+
+    /// Nonblocking write phase of two-pass metadata eviction.
+    ///
+    /// Busy shards and candidates refreshed since the read phase are skipped.
+    /// Journal cleanup is deferred to a blocking pass because `retain_paths`
+    /// would take write locks across that map; orphaned journal entries remain
+    /// correctness-safe in the meantime.
+    pub fn try_evict_candidates(&self, candidates: &[EvictionCandidate]) -> (usize, usize) {
+        let result = self.try_evict_candidates_detailed(candidates);
+        (result.removed, 0)
+    }
+
+    /// Detailed nonblocking write phase for traffic-aware eviction.
+    pub fn try_evict_candidates_detailed(
+        &self,
+        candidates: &[EvictionCandidate],
+    ) -> CandidateEvictionResult {
+        self.metadata.try_evict_candidates_detailed(candidates)
+    }
+
+    /// Settle orphaned journal rows left by nonblocking eviction.
+    ///
+    /// This takes blocking write locks and is therefore reserved for the idle
+    /// or forced completion phase of traffic-aware GC.
+    pub fn cleanup_eviction_journal(&self) -> usize {
+        self.cleanup_journal()
     }
 
     /// Remove journal `last_change` entries not in the metadata cache.
@@ -672,6 +727,23 @@ mod tests {
         assert_eq!(meta_removed, 1);
         assert_eq!(journal_removed, 1);
         assert!(cache.metadata().is_empty());
+    }
+
+    #[test]
+    fn blocking_cleanup_settles_journal_debt_after_gentle_eviction() {
+        let cache = CacheSystem::new();
+        let dir = TempDir::new().unwrap();
+        let path = create_file(&dir, "gentle.c", "data");
+        cache.lookup_since(&path, Clock::ZERO).unwrap();
+        cache.apply_changes(vec![path]);
+
+        let candidates = cache.oldest_eviction_candidates(1);
+        assert_eq!(cache.try_evict_candidates(&candidates), (1, 0));
+        assert!(cache.metadata().is_empty());
+        assert_eq!(cache.journal().last_change_len(), 1);
+
+        assert_eq!(cache.cleanup_eviction_journal(), 1);
+        assert_eq!(cache.journal().last_change_len(), 0);
     }
 
     #[test]

--- a/crates/zccache-fscache/src/lib.rs
+++ b/crates/zccache-fscache/src/lib.rs
@@ -11,6 +11,8 @@ pub mod verify;
 
 pub use cache_system::CacheSystem;
 pub use clock::{ChangeJournal, Clock};
-pub use metadata::{Confidence, FileMetadata, MetadataCache};
+pub use metadata::{
+    CandidateEvictionResult, Confidence, EvictionCandidate, FileMetadata, MetadataCache,
+};
 pub use persistence::FORMAT_VERSION;
 pub use verify::VerifyResult;

--- a/crates/zccache-fscache/src/metadata.rs
+++ b/crates/zccache-fscache/src/metadata.rs
@@ -1,5 +1,6 @@
 //! File metadata types and cache implementation.
 
+use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use rayon::prelude::*;
 use std::sync::OnceLock;
@@ -96,6 +97,37 @@ pub struct FileMetadata {
     pub last_verified: Instant,
     /// Cached content hash (blake3, 32 bytes), if computed.
     pub content_hash: Option<[u8; 32]>,
+}
+
+/// One entry selected by the read-only phase of metadata eviction.
+///
+/// The write phase must compare `last_verified` again while holding the
+/// entry's shard write lock. A lookup may refresh the entry between the two
+/// phases; in that case this candidate is stale and must not remove the newly
+/// refreshed value.
+#[derive(Debug, Clone)]
+pub struct EvictionCandidate {
+    path: NormalizedPath,
+    last_verified: Instant,
+}
+
+impl EvictionCandidate {
+    /// Path observed by the read-only candidate pass.
+    #[must_use]
+    pub fn path(&self) -> &NormalizedPath {
+        &self.path
+    }
+}
+
+/// Detailed result of conditionally deleting an eviction-candidate slice.
+#[derive(Debug, Default)]
+pub struct CandidateEvictionResult {
+    /// Candidates removed with the same timestamp observed by the read pass.
+    pub removed: usize,
+    /// Candidates whose shard could not be acquired without blocking.
+    pub busy: Vec<EvictionCandidate>,
+    /// Candidates whose verification timestamp changed after the read pass.
+    pub refreshed: Vec<EvictionCandidate>,
 }
 
 /// Concurrent file metadata cache.
@@ -314,21 +346,93 @@ impl MetadataCache {
     /// Evict the `count` oldest entries by `last_verified`.
     /// Returns the number actually removed (may be less than `count`).
     pub fn evict_oldest(&self, count: usize) -> usize {
+        let candidates = self.oldest_eviction_candidates(count);
+        self.evict_candidates(&candidates)
+    }
+
+    /// Collect the `count` oldest entries without taking any shard write lock.
+    ///
+    /// This is the read-only phase of two-pass eviction. The returned
+    /// candidates are observations, not deletion authority: callers must use
+    /// [`Self::evict_candidates`] or [`Self::try_evict_candidates`] so a
+    /// refresh between the two phases is preserved.
+    pub fn oldest_eviction_candidates(&self, count: usize) -> Vec<EvictionCandidate> {
         if count == 0 {
-            return 0;
+            return Vec::new();
         }
         // Collect (path, last_verified) then sort oldest first.
-        let mut entries: Vec<(NormalizedPath, Instant)> = self
+        let mut entries: Vec<EvictionCandidate> = self
             .entries
             .iter()
-            .map(|e| (e.key().clone(), e.value().last_verified))
+            .map(|entry| EvictionCandidate {
+                path: entry.key().clone(),
+                last_verified: entry.value().last_verified,
+            })
             .collect();
-        entries.sort_by_key(|(_path, ts)| *ts);
-        let to_remove = entries.len().min(count);
-        for (path, _) in entries.into_iter().take(to_remove) {
-            self.entries.remove(&path);
+        entries.sort_by_key(|candidate| candidate.last_verified);
+        entries.truncate(count);
+        entries
+    }
+
+    /// Remove candidates whose verification timestamp still matches the
+    /// read-only selection pass.
+    ///
+    /// Each entry is revalidated while its shard write lock is held. Entries
+    /// refreshed, replaced, or removed since candidate collection are skipped.
+    pub fn evict_candidates(&self, candidates: &[EvictionCandidate]) -> usize {
+        self.evict_candidates_detailed(candidates).removed
+    }
+
+    /// Detailed blocking write phase, including timestamp-refreshed entries.
+    pub fn evict_candidates_detailed(
+        &self,
+        candidates: &[EvictionCandidate],
+    ) -> CandidateEvictionResult {
+        let mut result = CandidateEvictionResult::default();
+        for candidate in candidates {
+            if let Entry::Occupied(entry) = self.entries.entry(candidate.path.clone()) {
+                if entry.get().last_verified == candidate.last_verified {
+                    entry.remove();
+                    result.removed += 1;
+                } else {
+                    result.refreshed.push(candidate.clone());
+                }
+            }
         }
-        to_remove
+        result
+    }
+
+    /// Nonblocking variant of [`Self::evict_candidates`].
+    ///
+    /// A candidate on a busy shard is skipped so active cache traffic wins.
+    /// A later GC pass may retry it. Timestamp revalidation has the same
+    /// semantics as the blocking variant.
+    pub fn try_evict_candidates(&self, candidates: &[EvictionCandidate]) -> usize {
+        self.try_evict_candidates_detailed(candidates).removed
+    }
+
+    /// Detailed nonblocking write phase, distinguishing lock contention from
+    /// timestamp refreshes so a later forced pass can retry only busy entries.
+    pub fn try_evict_candidates_detailed(
+        &self,
+        candidates: &[EvictionCandidate],
+    ) -> CandidateEvictionResult {
+        let mut result = CandidateEvictionResult::default();
+        for candidate in candidates {
+            let Some(entry) = self.entries.try_entry(candidate.path.clone()) else {
+                result.busy.push(candidate.clone());
+                continue;
+            };
+            if let Entry::Occupied(entry) = entry {
+                if entry.get().last_verified == candidate.last_verified {
+                    entry.remove();
+                    result.removed += 1;
+                } else {
+                    result.refreshed.push(candidate.clone());
+                }
+            }
+        }
+        result
     }
 
     /// Iterate all cached paths.
@@ -716,6 +820,101 @@ mod tests {
         let removed = cache.evict_oldest(2);
         assert_eq!(removed, 2);
         assert_eq!(cache.len(), 3);
+    }
+
+    #[test]
+    fn eviction_candidate_preserves_entry_refreshed_after_read_pass() {
+        let cache = MetadataCache::new();
+        let path = NormalizedPath::from("/tmp/refreshed.c");
+        let selected_at = Instant::now() - Duration::from_secs(120);
+        cache.insert(
+            path.clone(),
+            FileMetadata {
+                mtime: SystemTime::now(),
+                size: 10,
+                confidence: Confidence::High,
+                last_verified: selected_at,
+                content_hash: None,
+            },
+        );
+
+        let candidates = cache.oldest_eviction_candidates(1);
+        assert_eq!(candidates.len(), 1);
+
+        let refreshed_at = selected_at + Duration::from_secs(60);
+        cache.insert(
+            path.clone(),
+            FileMetadata {
+                mtime: SystemTime::now(),
+                size: 10,
+                confidence: Confidence::High,
+                last_verified: refreshed_at,
+                content_hash: None,
+            },
+        );
+
+        assert_eq!(cache.evict_candidates(&candidates), 0);
+        assert_eq!(cache.get(&path).unwrap().last_verified, refreshed_at);
+    }
+
+    #[test]
+    fn nonblocking_eviction_revalidates_candidate_timestamp() {
+        let cache = MetadataCache::new();
+        let path = NormalizedPath::from("/tmp/refreshed-try.c");
+        let selected_at = Instant::now() - Duration::from_secs(120);
+        cache.insert(
+            path.clone(),
+            FileMetadata {
+                mtime: SystemTime::now(),
+                size: 10,
+                confidence: Confidence::High,
+                last_verified: selected_at,
+                content_hash: None,
+            },
+        );
+
+        let candidates = cache.oldest_eviction_candidates(1);
+        cache.insert(
+            path.clone(),
+            FileMetadata {
+                mtime: SystemTime::now(),
+                size: 10,
+                confidence: Confidence::High,
+                last_verified: selected_at + Duration::from_secs(1),
+                content_hash: None,
+            },
+        );
+
+        assert_eq!(cache.try_evict_candidates(&candidates), 0);
+        assert!(cache.get(&path).is_some());
+    }
+
+    #[test]
+    fn nonblocking_eviction_reports_busy_candidate_for_forced_retry() {
+        let cache = MetadataCache::new();
+        let path = NormalizedPath::from("/tmp/busy-try.c");
+        cache.insert(
+            path.clone(),
+            FileMetadata {
+                mtime: SystemTime::now(),
+                size: 10,
+                confidence: Confidence::High,
+                last_verified: Instant::now(),
+                content_hash: None,
+            },
+        );
+        let candidates = cache.oldest_eviction_candidates(1);
+        let shard_guard = cache.entries.get_mut(&path).unwrap();
+
+        let gentle = cache.try_evict_candidates_detailed(&candidates);
+        assert_eq!(gentle.removed, 0);
+        assert_eq!(gentle.busy.len(), 1);
+        assert!(gentle.refreshed.is_empty());
+        drop(shard_guard);
+
+        let forced = cache.evict_candidates_detailed(&gentle.busy);
+        assert_eq!(forced.removed, 1);
+        assert!(cache.get(&path).is_none());
     }
 
     #[test]

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -52,3 +52,76 @@ proxies weren't seeded; `soldr cargo install` resolves the right toolchain
 front-door. The host PreToolUse hook enforces this, but `docker exec` bypasses
 the hook, so the discipline has to be applied manually in container scripts.
 **Rule:** any container-side build/lint script uses `soldr <tool>`.
+
+## A snapshot plus mutable delta is only read-fast under restricted semantics
+
+For a strongly consistent general map, readers must check the mutable delta
+before the immutable snapshot so updates and tombstones override old values.
+That makes a steady-state hit pay a concurrent-map miss plus a snapshot lookup,
+which is usually worse than one `DashMap` hit. Snapshot-first is valid for
+append-only, immutable, unique keys, but removals must be published atomically
+before backing data is deleted. Treat this as a specialized artifact-index
+design, not a generic `DashMap` replacement.
+
+Before replacing a concurrent map, also audit the guard lifetime. In the
+artifact hit path, `get_mut` held an exclusive DashMap shard guard through lazy
+payload filesystem resolution and retention checkpointing. Sharing those
+mutable fields through per-entry cells now lets lookup clone an owned entry
+under a short read guard, attacking contention with much less consistency and
+merge machinery.
+
+## Source immutability is request-scoped, not build-session-scoped
+
+A daemon session can contain many compiler invocations, and generated sources,
+headers, and Rust extern artifacts can legitimately appear or change between
+them. It is reasonable to optimize for inputs remaining stable during one
+compiler invocation, but cache publication must still fail closed if that
+assumption is violated: otherwise a transient racy compile becomes a persistent
+artifact under the wrong key. Keep a request-local owned hash snapshot; do not
+pin a build-long immutable metadata generation.
+
+Metadata GC is not an input mutation. Removing a metadata or journal entry only
+forces a later stat/rehash because a missing journal entry is conservatively
+treated as changed. A concurrent sweep can discard a freshly refreshed entry
+due to the current snapshot-then-remove implementation, but that is a
+performance race, not a correctness race.
+
+## Pressure GC should mark, defer, and conditionally sweep
+
+Separate metadata eviction into a shared-read candidate scan and a bounded
+conditional purge. Each candidate carries the observed entry revision; the
+purge rechecks that revision while holding the shard write lock and skips a
+locked or refreshed entry. Defer the purge while whole cache requests are
+active, then escalate from idle-only to nonblocking opportunistic batches and
+finally a bounded blocking pass. The existing compiler-child counter is too
+narrow because it misses cache hits, pre-hashing, and post-compile publication.
+
+`last_verified` is not an LRU timestamp: the stat-verified journal fast path
+does not refresh it. A GC policy that wants to preserve hot inputs needs a
+separate approximate last-access epoch or CLOCK/reference bit, preferably
+updated with a relaxed atomic rather than a DashMap write on every read.
+
+## A short map guard still needs an explicit backing-data lease
+
+Cloning an artifact out of a `DashMap` removes shard contention, but it also
+removes the old implicit guarantee that disk maintenance cannot delete payload
+files while a hit discovers or materializes them. Keep the owned artifact body
+behind one `Arc` and pair lookup with a publication read lease. Maintenance and
+Clear take the write side only for destructive work, which orders late access
+WAL inserts before removal without holding a map shard.
+
+Do not hold that global writer during a large read-only filesystem scan. Scan
+and plan concurrently with hits, then acquire the writer, refresh live access,
+re-plan, and commit deletion. Otherwise every warm lookup either waits or
+becomes a cold compile for the duration of each maintenance scan.
+
+## Nonblocking GC must distinguish contention from freshness
+
+A failed `try_entry` says only that a shard is busy; it does not authorize
+protecting that candidate for the whole sweep. Report busy and
+timestamp-refreshed candidates separately. Forced completion retries busy
+candidates with blocking entry locks, excludes refreshed paths from any
+same-sweep re-plan, and selects replacement candidates until it reaches the
+headroom target or only protected metadata remains. Also settle orphaned
+journal rows explicitly: a gentle metadata deletion can otherwise leave memory
+debt after the metadata entry itself is gone.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -205,3 +205,46 @@ Issue: https://github.com/zackees/zccache/issues/1117
 - [x] Retain wall/CPU/TTFB/output, RSS, cache/artifact, phase, command, and identity data.
 - [x] Run focused tests, Linux Docker diagnostics, and five valid samples per cell.
 - [ ] Publish floor dossiers, merge the PR, and close #1117.
+
+# DashMap read-snapshot investigation
+
+- [x] Classify DashMaps by lookup/write semantics and select viable candidates.
+- [x] Inspect existing performance evidence for lock or lookup overhead.
+- [x] Bound the possible win from retained warm-path phase profiles.
+- [x] Evaluate merge cost, stale-read correctness, memory, and operational complexity.
+- [x] Report whether the design is worth implementing and where.
+- [x] Shorten artifact lookup guards before considering a two-map redesign.
+- [x] Share lazy payload and access state across owned cache-entry clones.
+
+# Source-cache session immutability and GC investigation
+
+- [x] Define source immutability boundaries for one compile and a build session.
+- [x] Trace watcher, lookup, hashing, and metadata-cache mutations.
+- [x] Audit periodic memory GC and explicit clear during active compiles.
+- [x] Check regression tests and history for concurrent-change contracts.
+- [x] Report whether an immutable per-session snapshot is safe.
+
+# Traffic-aware source metadata GC investigation
+
+- [x] Find existing compile/activity and memory-pressure signals.
+- [x] Determine how to split candidate discovery from conditional deletion.
+- [x] Design idle deferral with bounded starvation and memory-pressure escalation.
+- [x] Identify candidate freshness, hot-entry, and journal cleanup requirements.
+- [x] Report the recommended implementation shape.
+
+# Traffic-aware source metadata GC implementation
+
+- [x] Track complete compile-cache requests with an RAII activity guard.
+- [x] Split metadata eviction into read-only candidate collection and conditional deletion.
+- [x] Preserve entries whose verification timestamp changes between the two passes.
+- [x] Defer blocking deletion for an idle grace period, then use nonblocking batches.
+- [x] Force a blocking pass after bounded persistent traffic.
+- [x] Distinguish lock-busy candidates from timestamp-refreshed candidates so
+  forced completion retries only the former.
+- [x] Settle deferred journal cleanup when traffic becomes idle or escalation fires.
+- [x] Keep disk-maintenance scans read-only and take the publication writer
+  only for the revalidated destructive commit.
+- [x] Count compile, link, generic-exec, and exec-probe metadata consumers.
+- [x] Cover blocking and nonblocking timestamp races with focused tests.
+- [x] Cover gentle-to-forced handoff, held-shard retry, and maintenance/Clear
+  artifact-lease ordering with deterministic tests.


### PR DESCRIPTION
## Summary
- shorten DashMap artifact guard lifetimes by returning owned, O(1) `Arc` clones behind a publication lease
- make disk maintenance scan read-only, then revalidate and delete under a short publication write lease
- add traffic-aware two-pass source metadata GC that waits for idle traffic, escalates under persistent pressure, and never purges entries refreshed after the first pass
- track compile, link, exec, and probe activity so GC yields to active compilation while still forcing reclamation when required

## Validation
- `./test` (workspace tests and doctests; no failures)
- strict clippy for `zccache-daemon-core` and `zccache-fscache`
- `soldr cargo fmt --all --check`
- `git diff --check`
- rustdoc with `RUSTDOCFLAGS=-D warnings`
- sanctioned Docker perf matrix: first two cells infrastructure-valid before requested early stop
  - medium/cold-tar-untar-warm: 133.89s cold, 10.29s warm, 13.01x, 98.84% hit rate
  - medium/worktree-share: 168.35s A, 38.72s B, 4.35x, 5.16% cache growth