### PR TITLE
fix(ci): gate unused object-store allocation path behind cfg(test) — un-red main

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/eviction.rs
+++ b/crates/zccache-daemon-core/src/daemon/eviction.rs
@@ -64,11 +64,7 @@ impl MemoryEvictionPlan {
     /// gentle eviction followed by the original, unvisited suffix. Candidates
     /// reported refreshed are intentionally absent and protected for this
     /// sweep.
-    pub(crate) fn completion_from(
-        &self,
-        offset: usize,
-        busy: &[EvictionCandidate],
-    ) -> Self {
+    pub(crate) fn completion_from(&self, offset: usize, busy: &[EvictionCandidate]) -> Self {
         let mut metadata_candidates = busy.to_vec();
         metadata_candidates.extend_from_slice(
             &self.metadata_candidates[offset.min(self.metadata_candidates.len())..],
@@ -260,8 +256,7 @@ pub(crate) fn plan_eviction_to_target_excluding(
         .div_ceil(METADATA_ENTRY_BYTES)
         .max(1)
         .min(snap.metadata_entries);
-    let mut metadata_candidates =
-        cache_system.oldest_eviction_candidates(snap.metadata_entries);
+    let mut metadata_candidates = cache_system.oldest_eviction_candidates(snap.metadata_entries);
     metadata_candidates.retain(|candidate| !protected_paths.contains(candidate.path()));
     metadata_candidates.truncate(metadata_count);
     Some(MemoryEvictionPlan {
@@ -348,14 +343,11 @@ pub(crate) fn evict_to_budget_with_plan_detailed(
             .div_ceil(METADATA_ENTRY_BYTES)
             .max(1)
             .min(cache_system.metadata().len());
-        let selected = &plan.metadata_candidates[..entries_to_evict.min(
-            plan.metadata_candidates.len(),
-        )];
-        let (result, journal_removed) =
-            cache_system.evict_candidates_detailed(selected);
+        let selected =
+            &plan.metadata_candidates[..entries_to_evict.min(plan.metadata_candidates.len())];
+        let (result, journal_removed) = cache_system.evict_candidates_detailed(selected);
         let freed =
-            (result.removed * METADATA_ENTRY_BYTES
-                + journal_removed * JOURNAL_ENTRY_BYTES) as u64;
+            (result.removed * METADATA_ENTRY_BYTES + journal_removed * JOURNAL_ENTRY_BYTES) as u64;
         total_freed += freed;
         total_items += result.removed + journal_removed;
         to_free = to_free.saturating_sub(freed);
@@ -856,8 +848,7 @@ mod tests {
             },
         );
 
-        let (freed, items) =
-            evict_to_budget_with_plan(1, &cs, &dg, &fh, &art, 0, &plan);
+        let (freed, items) = evict_to_budget_with_plan(1, &cs, &dg, &fh, &art, 0, &plan);
 
         assert_eq!(freed, 0);
         assert_eq!(items, 0);
@@ -898,8 +889,7 @@ mod tests {
 
         assert!(blocking_items > 0);
         assert!(
-            memory_snapshot(&cs, &dg, &fh, &art, 0).total_bytes as u64
-                <= plan.target_bytes(),
+            memory_snapshot(&cs, &dg, &fh, &art, 0).total_bytes as u64 <= plan.target_bytes(),
             "idle/forced completion must reach the original headroom target"
         );
     }
@@ -921,18 +911,10 @@ mod tests {
         let plan = plan_eviction_to_budget(budget, &cs, &dg, &fh, &art, 0)
             .expect("metadata should exceed the tiny budget");
         let busy = plan.metadata_candidates.clone();
-        let completion =
-            plan.completion_from(plan.metadata_candidate_count(), &busy);
+        let completion = plan.completion_from(plan.metadata_candidate_count(), &busy);
 
-        let outcome = evict_to_budget_with_plan_detailed(
-            budget,
-            &cs,
-            &dg,
-            &fh,
-            &art,
-            0,
-            &completion,
-        );
+        let outcome =
+            evict_to_budget_with_plan_detailed(budget, &cs, &dg, &fh, &art, 0, &completion);
 
         assert_eq!(outcome.items_removed, 1);
         assert!(cs.metadata().is_empty());
@@ -958,16 +940,9 @@ mod tests {
             plan_eviction_to_budget(10_000, &cs, &dg, &fh, &art, 0).is_none(),
             "9.6 KiB is below the configured 10 KiB trigger"
         );
-        let replacement = plan_eviction_to_target_excluding(
-            9_000,
-            &cs,
-            &dg,
-            &fh,
-            &art,
-            0,
-            &HashSet::new(),
-        )
-        .expect("forced completion must continue toward the original 90% target");
+        let replacement =
+            plan_eviction_to_target_excluding(9_000, &cs, &dg, &fh, &art, 0, &HashSet::new())
+                .expect("forced completion must continue toward the original 90% target");
         assert_eq!(replacement.target_bytes(), 9_000);
         assert!(!replacement.metadata_candidates.is_empty());
     }
@@ -1063,9 +1038,10 @@ mod tests {
                 Vec::new(),
                 0,
             ),
-            vec![CachedPayload::Bytes(
-                std::sync::Arc::new(vec![0u8; payload_size]),
-            )],
+            vec![CachedPayload::Bytes(std::sync::Arc::new(vec![
+                0u8;
+                payload_size
+            ]))],
         )
     }
 

--- a/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
@@ -138,10 +138,7 @@ impl CachedArtifact {
 
     /// Create from index metadata and an already-resolved payload list.
     #[cfg(test)]
-    pub(crate) fn from_cached_payloads(
-        meta: ArtifactIndex,
-        payloads: Vec<CachedPayload>,
-    ) -> Self {
+    pub(crate) fn from_cached_payloads(meta: ArtifactIndex, payloads: Vec<CachedPayload>) -> Self {
         Self::with_payloads(meta, Arc::from(payloads))
     }
 
@@ -189,10 +186,7 @@ impl CachedArtifact {
 
     /// Record one hit and return updated index metadata when its durable
     /// checkpoint is due.
-    pub(crate) fn record_access(
-        &self,
-        now: std::time::Instant,
-    ) -> Option<ArtifactIndex> {
+    pub(crate) fn record_access(&self, now: std::time::Instant) -> Option<ArtifactIndex> {
         const PERSIST_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
         let mut access = self.access();
@@ -388,8 +382,7 @@ mod tests {
         let cached = lazy_artifact(7);
         let owned_clone = cached.clone();
 
-        let first =
-            ensure_payloads_with_staged_policy(&cached, dir.path(), key, false).unwrap();
+        let first = ensure_payloads_with_staged_policy(&cached, dir.path(), key, false).unwrap();
         let second =
             ensure_payloads_with_staged_policy(&owned_clone, dir.path(), key, false).unwrap();
 
@@ -442,12 +435,8 @@ mod tests {
         let key = "retry-cell";
         let cached = lazy_artifact(7);
 
-        assert!(
-            ensure_payloads_with_staged_policy(&cached, dir.path(), key, false).is_none()
-        );
+        assert!(ensure_payloads_with_staged_policy(&cached, dir.path(), key, false).is_none());
         std::fs::write(dir.path().join(format!("{key}_0")), b"payload").unwrap();
-        assert!(
-            ensure_payloads_with_staged_policy(&cached, dir.path(), key, false).is_some()
-        );
+        assert!(ensure_payloads_with_staged_policy(&cached, dir.path(), key, false).is_some());
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -111,9 +111,7 @@ fn check_unit_cache(
                 // cloning all .o data (~50-200KB per file) into PendingWrite.
                 // Each check_unit_cache runs in its own spawn_blocking task,
                 // so writes are already parallel across units.
-                if let Some(cached) =
-                    lookup_artifact_with_disk_fallback(state, artifact_key_hex)
-                {
+                if let Some(cached) = lookup_artifact_with_disk_fallback(state, artifact_key_hex) {
                     if let Some(payloads) =
                         ensure_payloads(&cached, &state.artifact_dir, artifact_key_hex)
                     {
@@ -235,8 +233,7 @@ fn check_unit_cache(
         let artifact_key_hex = artifact_key.hash().to_hex();
         if let Some(cached) = lookup_artifact_with_disk_fallback(state, &artifact_key_hex) {
             let t_lookup = t0.elapsed();
-            if let Some(payloads) =
-                ensure_payloads(&cached, &state.artifact_dir, &artifact_key_hex)
+            if let Some(payloads) = ensure_payloads(&cached, &state.artifact_dir, &artifact_key_hex)
             {
                 record_artifact_access(
                     state,

--- a/crates/zccache-daemon-core/src/daemon/server/persist/object_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/object_store.rs
@@ -6,16 +6,26 @@
 //! object name.  The counter is stored as little-endian bytes so the low byte
 //! naturally distributes sequential objects across the fixed bucket set.
 
-use super::*;
-use std::fs::{self, File, OpenOptions};
-use std::io::{self, Read, Write};
-use std::path::{Path, PathBuf};
 use std::collections::HashSet;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+#[cfg(test)]
+use std::fs::{File, OpenOptions};
+#[cfg(test)]
+use std::io::{Read, Write};
 
 const OBJECTS_ROOT: &str = "objects";
 const DELETING_ROOT: &str = "deleting";
 const POINTERS_ROOT: &str = ".object-pointers";
+// The allocation/pointer half of this module (counter, `allocate_object_id`,
+// pointer read/write/remove) is exercised only by the in-file tests until the
+// #1164 publication path lands its real consumers; it is `#[cfg(test)]`-gated
+// so `-D warnings` non-test builds see no dead code.
+#[cfg(test)]
 const COUNTER_FILE: &str = ".object-counter";
+#[cfg(test)]
 const COUNTER_LOCK: &str = ".object-counter.lock";
 const BUCKET_COUNT: u16 = 256;
 const HEX: &[u8; 16] = b"0123456789abcdef";
@@ -75,14 +85,18 @@ fn pointer_root(artifact_dir: &Path) -> PathBuf {
     artifact_dir.join(POINTERS_ROOT)
 }
 
+#[cfg(test)]
 pub(crate) fn object_path(artifact_dir: &Path, id: ArtifactObjectId) -> PathBuf {
     object_root(artifact_dir).join(id.bucket()).join(id.leaf())
 }
 
 pub(crate) fn deleting_object_path(artifact_dir: &Path, id: ArtifactObjectId) -> PathBuf {
-    deleting_root(artifact_dir).join(id.bucket()).join(id.leaf())
+    deleting_root(artifact_dir)
+        .join(id.bucket())
+        .join(id.leaf())
 }
 
+#[cfg(test)]
 pub(crate) fn object_pointer_path(artifact_dir: &Path, key: &str) -> PathBuf {
     pointer_root(artifact_dir).join(format!("{key}.object"))
 }
@@ -104,10 +118,16 @@ pub(crate) fn ensure_object_layout(artifact_dir: &Path) -> io::Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
 fn sync_file(path: &Path) -> io::Result<()> {
-    OpenOptions::new().read(true).write(true).open(path)?.sync_all()
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)?
+        .sync_all()
 }
 
+#[cfg(test)]
 fn write_counter(path: &Path, value: u64) -> io::Result<()> {
     let temporary = path.with_file_name(format!(".{COUNTER_FILE}.tmp-{}", std::process::id()));
     {
@@ -125,6 +145,7 @@ fn write_counter(path: &Path, value: u64) -> io::Result<()> {
     result
 }
 
+#[cfg(test)]
 fn read_counter(path: &Path) -> io::Result<Option<u64>> {
     let mut bytes = [0_u8; 8];
     let mut file = match File::open(path) {
@@ -136,6 +157,7 @@ fn read_counter(path: &Path) -> io::Result<Option<u64>> {
     Ok(Some(u64::from_le_bytes(bytes)))
 }
 
+#[cfg(test)]
 fn path_occupied(artifact_dir: &Path, id: ArtifactObjectId) -> bool {
     object_path(artifact_dir, id).exists()
         || deleting_object_path(artifact_dir, id).exists()
@@ -148,6 +170,7 @@ fn path_occupied(artifact_dir: &Path, id: ArtifactObjectId) -> bool {
 /// Allocate and durably checkpoint one object ID. The lock is intentionally
 /// separate from the publication lock: unrelated keys can publish in
 /// parallel, while ID allocation remains serialized across processes.
+#[cfg(test)]
 pub(crate) fn allocate_object_id(artifact_dir: &Path) -> io::Result<ArtifactObjectId> {
     ensure_object_layout(artifact_dir)?;
     let lock_path = artifact_dir.join(COUNTER_LOCK);
@@ -190,6 +213,7 @@ pub(crate) fn allocate_object_id(artifact_dir: &Path) -> io::Result<ArtifactObje
     }
 }
 
+#[cfg(test)]
 pub(crate) fn read_object_pointer(
     artifact_dir: &Path,
     key: &str,
@@ -202,11 +226,15 @@ pub(crate) fn read_object_pointer(
     };
     let value = value.trim();
     let id = ArtifactObjectId::parse(value).ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidData, "invalid artifact object pointer")
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid artifact object pointer",
+        )
     })?;
     Ok(Some(id))
 }
 
+#[cfg(test)]
 pub(crate) fn write_object_pointer(
     artifact_dir: &Path,
     key: &str,
@@ -214,7 +242,11 @@ pub(crate) fn write_object_pointer(
 ) -> io::Result<()> {
     ensure_object_layout(artifact_dir)?;
     let target = object_pointer_path(artifact_dir, key);
-    let temporary = target.with_file_name(format!(".{}.tmp-{}", target.file_name().unwrap_or_default().to_string_lossy(), std::process::id()));
+    let temporary = target.with_file_name(format!(
+        ".{}.tmp-{}",
+        target.file_name().unwrap_or_default().to_string_lossy(),
+        std::process::id()
+    ));
     {
         let mut file = OpenOptions::new()
             .create_new(true)
@@ -234,6 +266,7 @@ pub(crate) fn write_object_pointer(
     result
 }
 
+#[cfg(test)]
 pub(crate) fn remove_object_pointer_if_matches(
     artifact_dir: &Path,
     key: &str,
@@ -305,7 +338,10 @@ mod tests {
     fn little_endian_names_spread_low_byte_first() {
         assert_eq!(ArtifactObjectId(0).name(), "0000000000000000");
         assert_eq!(ArtifactObjectId(1).name(), "0100000000000000");
-        assert_eq!(ArtifactObjectId(0x0123_4567_89ab_cdef).name(), "efcdab8967452301");
+        assert_eq!(
+            ArtifactObjectId(0x0123_4567_89ab_cdef).name(),
+            "efcdab8967452301"
+        );
         assert_eq!(
             ArtifactObjectId::parse("efcdab8967452301"),
             Some(ArtifactObjectId(0x0123_4567_89ab_cdef))
@@ -332,7 +368,10 @@ mod tests {
         fs::create_dir_all(object_path(dir.path(), stale)).unwrap();
         let allocated = allocate_object_id(dir.path()).unwrap();
         assert_eq!(allocated, ArtifactObjectId(9));
-        assert_eq!(read_counter(&dir.path().join(COUNTER_FILE)).unwrap(), Some(9));
+        assert_eq!(
+            read_counter(&dir.path().join(COUNTER_FILE)).unwrap(),
+            Some(9)
+        );
     }
 
     #[test]

--- a/crates/zccache-daemon-core/src/daemon/server/run.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/run.rs
@@ -747,8 +747,7 @@ async fn run_memory_eviction_pass(state: &Arc<SharedState>, budget: u64) -> (u64
             // journal rows. Settle that debt before deciding whether the
             // original headroom target still requires destructive work.
             let journal_removed = state.cache_system.cleanup_eviction_journal();
-            total_freed += (journal_removed
-                * super::super::eviction::JOURNAL_ENTRY_BYTES) as u64;
+            total_freed += (journal_removed * super::super::eviction::JOURNAL_ENTRY_BYTES) as u64;
             total_items += journal_removed;
 
             let dep_graph_guard = state.dep_graph.load();
@@ -768,22 +767,19 @@ async fn run_memory_eviction_pass(state: &Arc<SharedState>, budget: u64) -> (u64
             // timestamp-refreshed entries, then replenish from a current
             // read-only plan until the target is met or every remaining
             // metadata candidate is protected for this sweep.
-            let mut completion_plan =
-                plan.completion_from(candidate_offset, &busy_candidates);
+            let mut completion_plan = plan.completion_from(candidate_offset, &busy_candidates);
             loop {
-                let completion_had_candidates =
-                    completion_plan.metadata_candidate_count() > 0;
+                let completion_had_candidates = completion_plan.metadata_candidate_count() > 0;
                 let dep_graph_guard = state.dep_graph.load();
-                let outcome =
-                    super::super::eviction::evict_to_budget_with_plan_detailed(
-                        budget,
-                        &state.cache_system,
-                        &dep_graph_guard,
-                        &state.fast_hit_cache,
-                        &state.artifacts,
-                        state.in_flight_bytes.load(Ordering::Relaxed),
-                        &completion_plan,
-                    );
+                let outcome = super::super::eviction::evict_to_budget_with_plan_detailed(
+                    budget,
+                    &state.cache_system,
+                    &dep_graph_guard,
+                    &state.fast_hit_cache,
+                    &state.artifacts,
+                    state.in_flight_bytes.load(Ordering::Relaxed),
+                    &completion_plan,
+                );
                 drop(dep_graph_guard);
                 total_freed += outcome.freed_bytes;
                 total_items += outcome.items_removed;
@@ -806,23 +802,20 @@ async fn run_memory_eviction_pass(state: &Arc<SharedState>, budget: u64) -> (u64
                     drop(dep_graph_guard);
                     return (total_freed, total_items);
                 }
-                let next =
-                    super::super::eviction::plan_eviction_to_target_excluding(
-                        plan.target_bytes(),
-                        &state.cache_system,
-                        &dep_graph_guard,
-                        &state.fast_hit_cache,
-                        &state.artifacts,
-                        state.in_flight_bytes.load(Ordering::Relaxed),
-                        &protected_paths,
-                    );
+                let next = super::super::eviction::plan_eviction_to_target_excluding(
+                    plan.target_bytes(),
+                    &state.cache_system,
+                    &dep_graph_guard,
+                    &state.fast_hit_cache,
+                    &state.artifacts,
+                    state.in_flight_bytes.load(Ordering::Relaxed),
+                    &protected_paths,
+                );
                 drop(dep_graph_guard);
                 let Some(next) = next else {
                     return (total_freed, total_items);
                 };
-                if current.metadata_entries > 0
-                    && next.metadata_candidate_count() == 0
-                {
+                if current.metadata_entries > 0 && next.metadata_candidate_count() == 0 {
                     return (total_freed, total_items);
                 }
                 if forced_completion_stalled(

--- a/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
@@ -49,11 +49,7 @@ impl MaintenanceEnvironment for GatedScanEnvironment {
     }
 
     fn filesystem_space(&self, _root: &Path) -> io::Result<FilesystemSpace> {
-        if self
-            .calls
-            .fetch_add(1, std::sync::atomic::Ordering::AcqRel)
-            == 0
-        {
+        if self.calls.fetch_add(1, std::sync::atomic::Ordering::AcqRel) == 0 {
             self.scan_entered.wait();
             self.release_scan.wait();
         }

--- a/crates/zccache-daemon-core/src/daemon/server/tests/pack.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/pack.rs
@@ -142,9 +142,7 @@ fn mixed_v1_pack_v2_lookup_and_downgrade_policy_are_explicit() {
         b"legacy-flat"
     );
     assert_eq!(
-        bytes(
-            &ensure_payloads_with_staged_policy(&pack, dir.path(), &pack_key, true).unwrap()[0]
-        ),
+        bytes(&ensure_payloads_with_staged_policy(&pack, dir.path(), &pack_key, true).unwrap()[0]),
         b"legacy-pack"
     );
     assert_eq!(
@@ -158,16 +156,14 @@ fn mixed_v1_pack_v2_lookup_and_downgrade_policy_are_explicit() {
     let downgraded_pack = index("packed.o", 11);
     let downgraded_v2 = index("staged.o", 9);
     assert!(
-        ensure_payloads_with_staged_policy(&downgraded_v1, dir.path(), &v1_key, false)
-            .is_some()
+        ensure_payloads_with_staged_policy(&downgraded_v1, dir.path(), &v1_key, false).is_some()
     );
     assert!(
         ensure_payloads_with_staged_policy(&downgraded_pack, dir.path(), &pack_key, false)
             .is_some()
     );
     assert!(
-        ensure_payloads_with_staged_policy(&downgraded_v2, dir.path(), &v2_key, false)
-            .is_none()
+        ensure_payloads_with_staged_policy(&downgraded_v2, dir.path(), &v2_key, false).is_none()
     );
 }
 


### PR DESCRIPTION
Main is red since #1182: the Linux/macOS `-D warnings` builds fail with 13 dead-code errors in `persist/object_store.rs` because the allocation/pointer half of the module (counter, `allocate_object_id`, pointer read/write/remove) has no non-test consumer yet — its real consumers land with the #1164 publication path.

## Fix
- `#[cfg(test)]`-gate the unused items (with a comment pointing at #1164 so the gate is removed when the consumers land)
- Replace the `use super::*` blanket import with explicit imports (test-only ones gated)
- Apply the rustfmt formatting the same builds flagged across 6 sibling files

## Validation
- `soldr cargo fmt --all -- --check` clean
- `RUSTFLAGS="-D warnings" soldr cargo check --workspace --all-targets` clean
- `soldr cargo clippy --workspace --all-targets -- -D warnings` clean
- `soldr cargo test -p zccache-daemon-core --lib --features test-support`: 600 passed, 0 failed

Part of the #1154 burn-down program (unblocks all subsequent child PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)