### PR TITLE
Update running-process to 4.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,9 +2582,9 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.5.9"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be0eb94932636a97372ec049442550886de8870f15a76b037e75262f8b9c8ff"
+checksum = "bf0356f69757ad31567c9ba44cc6be901228c449122d20cd2567e49a99eec549"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ lzma-rs = "0.3"
 sevenz-rust = "0.6"
 rkyv = "0.8"
 mimalloc = "0.1"
-running-process = { version = "4.5.9", default-features = false, features = ["client-async"] }
+running-process = { version = "4.6.0", default-features = false, features = ["client-async"] }
 zccache = { path = "crates/zccache" }
 zccache-artifact = { path = "crates/zccache-artifact" }
 zccache-audit = { path = "crates/zccache-audit" }


### PR DESCRIPTION
## Summary

- update running-process and the lockfile to 4.6.0
- pick up Auto daemon environment isolation through the existing running_process::spawn_daemon call
- prevent inherited CLUD and RUNNING_PROCESS lineage markers from turning zccache into a false orphan-reaper target

## Validation

- soldr cargo check -p zccache-cli-core
- git diff --check

Depends on zackees/running-process#653 and running-process 4.6.0: https://github.com/zackees/running-process/releases/tag/4.6.0