### PR TITLE
fix(cache): include C/C++ compiler binary identity in the cache key (#1166)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/eviction.rs
+++ b/crates/zccache-daemon-core/src/daemon/eviction.rs
@@ -681,6 +681,7 @@ mod tests {
             flags: Vec::new(),
             force_includes: Vec::new(),
             unknown_flags: Vec::new(),
+            compiler_hash: crate::hash::hash_bytes(b"test-fixture"),
         }
     }
 

--- a/crates/zccache-daemon-core/src/daemon/server/compiler_hash.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/compiler_hash.rs
@@ -389,6 +389,67 @@ pub(super) fn hash_rustc_identity(path: &Path) -> Option<ContentHash> {
     }
 }
 
+/// Compute a content hash that uniquely identifies a C/C++ compiler build
+/// (clang, gcc, MSVC `cl.exe`), mirroring [`hash_rustc_identity`] for issue
+/// #1166: the C/C++ compile cache key did not previously vary on compiler
+/// binary identity, so an in-place toolchain upgrade (same path, new
+/// binary content) could serve stale object files from cache.
+///
+/// Prefers `<compiler> --version` output over a full blake3 over the
+/// binary, for the same cold-path cost reasons as the rustc `-vV` probe
+/// (issue #517). Falls back to the file-content hash on spawn failure,
+/// non-zero exit, or empty stdout so cache keys are still well-defined for
+/// stubbed binaries (unit tests) and broken toolchains, or for compilers
+/// (e.g. some `cl.exe` invocations) that only print version info to
+/// stderr — see the TODO below.
+pub(super) fn hash_cc_identity(path: &Path) -> Option<ContentHash> {
+    let mut cmd = std::process::Command::new(path);
+    cmd.arg("--version");
+    crate::daemon::process::suppress_child_console(&mut cmd);
+    let timeout = rustc_probe_timeout();
+    match output_within(cmd, timeout) {
+        ProbeOutcome::Completed(output) if output.status.success() && !output.stdout.is_empty() => {
+            Some(crate::hash::hash_bytes(&output.stdout))
+        }
+        ProbeOutcome::TimedOut => {
+            warn_probe_timeout(path, timeout);
+            crate::hash::hash_file(path).ok()
+        }
+        // Spawn failure (stub binaries in unit tests), non-zero exit, or
+        // empty stdout (e.g. MSVC `cl.exe`, which prints its banner to
+        // stderr and errors without input) — fall through to the
+        // file-content hash so keys stay well-defined.
+        //
+        // TODO(#1167): this degenerate-probe fallback reuses
+        // `hash_rustc_identity`'s existing shape as-is. Issue #1167 will
+        // define stricter fallback/degenerate-result policy (e.g.
+        // distinguishing "compiler present but --version unsupported"
+        // from "compiler missing entirely"); do not add new policy here.
+        _ => crate::hash::hash_file(path).ok(),
+    }
+}
+
+/// Async sibling of [`hash_cc_identity`]. See that function's doc comment
+/// for the rationale (issue #1166).
+pub(super) async fn hash_cc_identity_async(path: std::path::PathBuf) -> Option<ContentHash> {
+    let mut cmd = tokio::process::Command::new(&path);
+    cmd.arg("--version");
+    crate::daemon::process::suppress_child_console_tokio(&mut cmd);
+    cmd.kill_on_drop(true);
+    let timeout = rustc_probe_timeout();
+    match tokio::time::timeout(timeout, cmd.output()).await {
+        Ok(Ok(output)) if output.status.success() && !output.stdout.is_empty() => {
+            Some(crate::hash::hash_bytes(&output.stdout))
+        }
+        Err(_) => {
+            warn_probe_timeout(&path, timeout);
+            crate::hash::hash_file(&path).ok()
+        }
+        // TODO(#1167): see the sync `hash_cc_identity` fallback arm above.
+        _ => crate::hash::hash_file(&path).ok(),
+    }
+}
+
 pub(super) async fn hash_rustc_identity_async(path: std::path::PathBuf) -> Option<ContentHash> {
     let mut cmd = tokio::process::Command::new(&path);
     cmd.arg("-vV");

--- a/crates/zccache-daemon-core/src/daemon/server/dependency_policy.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/dependency_policy.rs
@@ -292,7 +292,8 @@ mod tests {
             let args: Vec<String> = args.iter().map(|arg| (*arg).to_string()).collect();
             let parsed = crate::depgraph::args::parse_gnu_args(&args, Path::new("/work"));
             let dep_flags = parsed.dep_flags.clone();
-            let mut context = CompileContext::from_parsed_args(parsed);
+            let mut context =
+                CompileContext::from_parsed_args(parsed, crate::hash::hash_bytes(b"test-fixture"));
             DependencyDiscoveryMode::AllHeaders.apply_to_cc_context(&mut context, &dep_flags);
             context.context_key()
         };
@@ -312,7 +313,8 @@ mod tests {
             let args: Vec<String> = args.iter().map(|arg| (*arg).to_string()).collect();
             let parsed = crate::depgraph::args::parse_gnu_args(&args, Path::new("/work"));
             let dep_flags = parsed.dep_flags.clone();
-            let mut context = CompileContext::from_parsed_args(parsed);
+            let mut context =
+                CompileContext::from_parsed_args(parsed, crate::hash::hash_bytes(b"test-fixture"));
             DependencyDiscoveryMode::AllHeaders.apply_to_cc_context(&mut context, &dep_flags);
             DependencyDiscoveryMode::apply_user_depfile_content_to_cc_context(
                 &mut context,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/error_cache.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/error_cache.rs
@@ -125,6 +125,7 @@ mod tests {
             flags: Vec::new(),
             force_includes: Vec::new(),
             unknown_flags: Vec::new(),
+            compiler_hash: crate::hash::hash_bytes(b"test-fixture"),
         };
         let context_key = ctx.context_key();
         let cache_dir: NormalizedPath = tmp.path().join("cache").into();

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -499,7 +499,14 @@ pub(super) async fn handle_compile_multi(
             crate::depgraph::args::parse_gnu_args(&first.original_args, &cwd_path)
         };
         let dep_flags = parsed.dep_flags.clone();
-        let mut base = CompileContext::from_parsed_args(parsed);
+        // Issue #1166: compiler identity must vary the shared base
+        // context's key too, mirroring the non-shared per-unit path's
+        // `build_compile_context` call above.
+        let compiler_hash = state
+            .compiler_hash_cache
+            .get_or_hash_with(&first.compiler, hash_cc_identity)
+            .unwrap_or(COMPILER_HASH_UNAVAILABLE);
+        let mut base = CompileContext::from_parsed_args(parsed, compiler_hash);
         for path in &system_includes {
             if !base.include_search.system.contains(path) {
                 base.include_search.system.push(path.clone());

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_types.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_types.rs
@@ -150,6 +150,7 @@ mod tests {
             flags: Vec::new(),
             force_includes: Vec::new(),
             unknown_flags: Vec::new(),
+            compiler_hash: crate::hash::hash_bytes(b"test-fixture"),
         };
         let context_key = graph.register(context);
         let artifact_key = graph

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -410,6 +410,7 @@ mod tests {
             flags: Vec::new(),
             force_includes: Vec::new(),
             unknown_flags: Vec::new(),
+            compiler_hash: crate::hash::hash_bytes(b"test-fixture"),
         }
     }
 

--- a/crates/zccache-daemon-core/src/daemon/server/rustc.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/rustc.rs
@@ -2,6 +2,16 @@
 
 use super::*;
 
+/// Fallback compiler-identity hash used only when `CompilerHashCache`
+/// cannot even `stat` the compiler binary (the initial `std::fs::metadata`
+/// call in `get_or_hash_with[_async]` fails) — a pathological case since
+/// the compiler was already spawned to reach this code path. `compiler_hash`
+/// is a required (non-`Option`) field on `CompileContext` /
+/// `RustcCompileContext` (issue #1166), so callers need a concrete value
+/// even in this edge case; a fixed sentinel keeps the resulting context key
+/// well-defined and deterministic rather than panicking.
+pub(super) const COMPILER_HASH_UNAVAILABLE: ContentHash = ContentHash::from_bytes([0u8; 32]);
+
 /// Build a CompileContext and UserDepFlags from a CacheableCompilation and session info.
 /// Result of building a compile context — varies by compiler family.
 pub(super) enum BuildContextResult {
@@ -32,6 +42,25 @@ pub(super) fn build_compile_context(
         return build_rustc_compile_context(compilation, cwd, client_env, compiler_hash_cache);
     }
 
+    // Compiler identity for the cache key (issue #1166): an in-place
+    // toolchain upgrade (same path, new clang/gcc/cl.exe binary content)
+    // must not reuse a stale cache key. Mirrors the rustc branch's `-vV`
+    // probe (issue #517) via `hash_cc_identity` (`--version`).
+    let compiler_hash = compiler_hash_cache
+        .get_or_hash_with(&compilation.compiler, hash_cc_identity)
+        .unwrap_or(COMPILER_HASH_UNAVAILABLE);
+
+    build_cc_compile_context(compilation, cwd, system_includes, compiler_hash)
+}
+
+/// Shared by the sync and async C/C++ context builders once the compiler
+/// identity hash has been resolved (issue #1166).
+fn build_cc_compile_context(
+    compilation: &crate::compiler::CacheableCompilation,
+    cwd: &Path,
+    system_includes: &[NormalizedPath],
+    compiler_hash: ContentHash,
+) -> BuildContextResult {
     // Dispatch to the correct parser based on compiler family.
     let parsed = match compilation.family {
         crate::compiler::CompilerFamily::Msvc => {
@@ -40,7 +69,7 @@ pub(super) fn build_compile_context(
         _ => crate::depgraph::args::parse_gnu_args(&compilation.original_args, cwd),
     };
     let dep_flags = parsed.dep_flags.clone();
-    let mut ctx = CompileContext::from_parsed_args(parsed);
+    let mut ctx = CompileContext::from_parsed_args(parsed, compiler_hash);
 
     // For multi-file compilations, the parsed source_file might be wrong
     // (it picks the first source from original_args). Override with the
@@ -79,13 +108,16 @@ pub(super) async fn build_compile_context_async(
         .await;
     }
 
-    build_compile_context(
-        compilation,
-        cwd,
-        system_includes,
-        client_env,
-        compiler_hash_cache,
-    )
+    // Async sibling of the sync Cc branch above: hash the compiler binary
+    // off the blocking-spawn path so the tokio worker thread is not
+    // parked on the `--version` probe (issue #1166; mirrors the rustc
+    // async branch's use of `hash_rustc_identity_async`).
+    let compiler_hash = compiler_hash_cache
+        .get_or_hash_with_async(&compilation.compiler, hash_cc_identity_async)
+        .await
+        .unwrap_or(COMPILER_HASH_UNAVAILABLE);
+
+    build_cc_compile_context(compilation, cwd, system_includes, compiler_hash)
 }
 
 /// Build compile context for a Rustc invocation.
@@ -107,8 +139,9 @@ pub(super) fn build_rustc_compile_context(
     // identity bytes that get hashed change. Failure falls through to
     // the binary hash so cache keys stay well-defined for stub
     // binaries (unit tests) and broken toolchains.
-    let compiler_hash =
-        compiler_hash_cache.get_or_hash_with(&compilation.compiler, hash_rustc_identity);
+    let compiler_hash = compiler_hash_cache
+        .get_or_hash_with(&compilation.compiler, hash_rustc_identity)
+        .unwrap_or(COMPILER_HASH_UNAVAILABLE);
 
     let rustc_ctx = crate::depgraph::RustcCompileContext::from_parsed_args(
         &rustc_args,
@@ -125,6 +158,7 @@ pub(super) fn build_rustc_compile_context(
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash,
     };
 
     BuildContextResult::Rustc {
@@ -144,7 +178,8 @@ pub(super) async fn build_rustc_compile_context_async(
 
     let compiler_hash = compiler_hash_cache
         .get_or_hash_with_async(&compilation.compiler, hash_rustc_identity_async)
-        .await;
+        .await
+        .unwrap_or(COMPILER_HASH_UNAVAILABLE);
 
     let rustc_ctx = crate::depgraph::RustcCompileContext::from_parsed_args(
         &rustc_args,
@@ -159,6 +194,7 @@ pub(super) async fn build_rustc_compile_context_async(
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash,
     };
 
     BuildContextResult::Rustc {

--- a/crates/zccache-daemon-core/src/daemon/server/tests/cache_trim.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/cache_trim.rs
@@ -14,6 +14,7 @@ fn test_context_key(source: &str) -> ContextKey {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: crate::hash::hash_bytes(b"test-fixture"),
     }
     .context_key()
 }

--- a/crates/zccache-daemon-core/src/daemon/server/tests/compiler_hash.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/compiler_hash.rs
@@ -120,7 +120,7 @@ fn rustc_context_build_reuses_compiler_hash_cache() {
         unknown_flags: Vec::new(),
     };
     let cache = CompilerHashCache::new();
-    let expected_hash = crate::hash::hash_file(&compiler).ok();
+    let expected_hash = crate::hash::hash_file(&compiler).expect("hash the fake compiler binary");
 
     let first = build_rustc_compile_context(&compilation, tmp.path(), &[], &cache);
     let second = build_rustc_compile_context(&compilation, tmp.path(), &[], &cache);
@@ -136,6 +136,80 @@ fn rustc_context_build_reuses_compiler_hash_cache() {
     assert_eq!(first_hash, expected_hash);
     assert_eq!(second_hash, expected_hash);
     assert_eq!(cache.len(), 1);
+}
+
+/// Issue #1166: the C/C++ `build_compile_context` branch must fold the
+/// compiler binary's identity hash into the resulting `ContextKey`,
+/// mirroring `rustc_context_build_reuses_compiler_hash_cache` above.
+/// Swapping the on-disk "compiler" binary's content (same path, new
+/// mtime/size) must produce a different `ContextKey` for an otherwise
+/// identical compilation — the exact WRONG-HIT scenario issue #1166
+/// describes for an in-place toolchain upgrade.
+#[test]
+fn cc_context_build_reuses_compiler_hash_cache() {
+    let tmp = tempfile::tempdir().unwrap();
+    let compiler = tmp.path().join("cc");
+    let source = tmp.path().join("main.c");
+    let output = tmp.path().join("main.o");
+    std::fs::write(&compiler, b"fake cc v1").unwrap();
+    filetime::set_file_mtime(
+        &compiler,
+        filetime::FileTime::from_unix_time(1_000_000_000, 0),
+    )
+    .unwrap();
+    std::fs::write(&source, b"int main(void) { return 0; }").unwrap();
+
+    let args: Vec<String> = vec![
+        compiler.to_string_lossy().into_owned(),
+        "-c".into(),
+        source.to_string_lossy().into_owned(),
+        "-o".into(),
+        output.to_string_lossy().into_owned(),
+    ];
+    let compilation = crate::compiler::CacheableCompilation {
+        compiler: compiler.clone().into(),
+        family: crate::compiler::CompilerFamily::Gcc,
+        source_file: source.clone().into(),
+        output_file: output.into(),
+        original_args: std::sync::Arc::from(args),
+        unknown_flags: Vec::new(),
+    };
+    let cache = CompilerHashCache::new();
+
+    let first_key = match build_compile_context(&compilation, tmp.path(), &[], &[], &cache) {
+        BuildContextResult::Cc { ctx, .. } => ctx.context_key(),
+        BuildContextResult::Rustc { .. } => panic!("expected Cc context"),
+    };
+    // Re-run against the SAME binary content: must reuse the cache
+    // (proven by the cache having exactly one entry) and produce the
+    // same key.
+    let second_key = match build_compile_context(&compilation, tmp.path(), &[], &[], &cache) {
+        BuildContextResult::Cc { ctx, .. } => ctx.context_key(),
+        BuildContextResult::Rustc { .. } => panic!("expected Cc context"),
+    };
+    assert_eq!(
+        first_key, second_key,
+        "identical compiler content must produce identical context keys"
+    );
+    assert_eq!(cache.len(), 1, "compiler hash must be cached, not rehashed");
+
+    // In-place toolchain upgrade: same path, new binary content/mtime.
+    std::fs::write(&compiler, b"fake cc v2, totally different codegen").unwrap();
+    filetime::set_file_mtime(
+        &compiler,
+        filetime::FileTime::from_unix_time(1_000_000_500, 0),
+    )
+    .unwrap();
+
+    let third_key = match build_compile_context(&compilation, tmp.path(), &[], &[], &cache) {
+        BuildContextResult::Cc { ctx, .. } => ctx.context_key(),
+        BuildContextResult::Rustc { .. } => panic!("expected Cc context"),
+    };
+    assert_ne!(
+        first_key, third_key,
+        "an in-place compiler binary upgrade (same path, new content) must \
+         change the C/C++ context key — issue #1166's WRONG-HIT scenario"
+    );
 }
 
 // ── Issue #517 Option 3: rustc -vV identity instead of binary hash ─────

--- a/crates/zccache-daemon-core/src/daemon/server/tests/path_remap.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/path_remap.rs
@@ -291,6 +291,7 @@ mod context_key_salt {
             flags: Vec::new(),
             force_includes: Vec::new(),
             unknown_flags: Vec::new(),
+            compiler_hash: crate::hash::hash_bytes(b"test-fixture"),
         }
     }
 

--- a/crates/zccache-depgraph/src/context/mod.rs
+++ b/crates/zccache-depgraph/src/context/mod.rs
@@ -90,12 +90,20 @@ pub struct CompileContext {
     /// Sorted unknown flags — not recognized by the parser but still
     /// affect compilation output, so they must be part of the cache key.
     pub unknown_flags: Vec<String>,
+    /// Hash of the compiler binary identity (issue #1166). Non-`Option` by
+    /// design: making this field required means "compute a context key
+    /// without compiler identity" is unrepresentable at the type level. An
+    /// in-place toolchain upgrade (same path, new binary content) must
+    /// always change this hash and therefore the resulting context key —
+    /// otherwise a stale cache entry can be served for a compiler that no
+    /// longer produces the same output.
+    pub compiler_hash: ContentHash,
 }
 
 impl CompileContext {
     /// Build a `CompileContext` from parsed arguments (consumes the args to avoid cloning).
     #[must_use]
-    pub fn from_parsed_args(args: ParsedArgs) -> Self {
+    pub fn from_parsed_args(args: ParsedArgs, compiler_hash: ContentHash) -> Self {
         let mut defines = args.defines;
         defines.sort();
         let mut flags = args.flags;
@@ -110,6 +118,7 @@ impl CompileContext {
             flags,
             force_includes: args.force_includes,
             unknown_flags,
+            compiler_hash,
         }
     }
 
@@ -244,6 +253,13 @@ where
     let mut hasher = blake3::Hasher::new();
 
     hasher.update(b"zccache-context-key-v1\0");
+
+    // Compiler binary identity (issue #1166): an in-place toolchain
+    // upgrade (same path, new binary content) must change the context
+    // key. Unconditional (non-Option field) so this is impossible to omit.
+    hasher.update(b"compiler\0");
+    hasher.update(ctx.compiler_hash.as_bytes());
+    hasher.update(b"\0");
 
     if let Some(salt) = worktree_salt {
         // Domain-tagged so the salt can't collide with any future hash
@@ -536,8 +552,12 @@ pub struct RustcCompileContext {
     pub remap_path_prefixes: Vec<String>,
     /// Sorted CARGO_* environment variables that affect compilation via `env!()`.
     pub env_vars: Vec<(String, String)>,
-    /// Hash of the compiler binary (different rustc versions produce different output).
-    pub compiler_hash: Option<ContentHash>,
+    /// Hash of the compiler binary (different rustc versions produce
+    /// different output). Non-`Option` by design (issue #1166): see the
+    /// doc comment on `CompileContext::compiler_hash` for the rationale —
+    /// making this required at the type level closes the hole where a
+    /// `None` compiler_hash silently omits compiler identity from the key.
+    pub compiler_hash: ContentHash,
 }
 
 impl RustcCompileContext {
@@ -549,7 +569,7 @@ impl RustcCompileContext {
     pub fn from_parsed_args(
         args: &RustcParsedArgs,
         client_env: &[(String, String)],
-        compiler_hash: Option<ContentHash>,
+        compiler_hash: ContentHash,
     ) -> Self {
         let mut crate_types = args.crate_types.clone();
         crate_types.sort();
@@ -621,12 +641,11 @@ impl RustcCompileContext {
 
         hasher.update(b"zccache-rustc-context-key-v2\0");
 
-        // Compiler binary hash (different rustc versions -> different output).
-        if let Some(ref ch) = self.compiler_hash {
-            hasher.update(b"compiler\0");
-            hasher.update(ch.as_bytes());
-            hasher.update(b"\0");
-        }
+        // Compiler binary hash (different rustc versions -> different
+        // output). Unconditional (non-Option field, issue #1166).
+        hasher.update(b"compiler\0");
+        hasher.update(self.compiler_hash.as_bytes());
+        hasher.update(b"\0");
 
         // Source file.
         let source_file = normalize_key_path(&self.source_file, key_root);
@@ -811,11 +830,11 @@ impl RustcCompileContext {
         let mut hasher = blake3::Hasher::new();
         hasher.update(b"zccache-rustc-check-metadata-compat-key-v1\0");
 
-        if let Some(ref ch) = self.compiler_hash {
-            hasher.update(b"compiler\0");
-            hasher.update(ch.as_bytes());
-            hasher.update(b"\0");
-        }
+        // Unconditional (non-Option field, issue #1166) — see
+        // `context_key_with_root` above for the rationale.
+        hasher.update(b"compiler\0");
+        hasher.update(self.compiler_hash.as_bytes());
+        hasher.update(b"\0");
 
         let source_file = normalize_key_path(&self.source_file, key_root);
         hasher.update(source_file.as_bytes());

--- a/crates/zccache-depgraph/src/context/tests/cc.rs
+++ b/crates/zccache-depgraph/src/context/tests/cc.rs
@@ -63,6 +63,7 @@ fn windows_context_key_normalizes_equivalent_path_spellings() {
         flags: Vec::new(),
         force_includes: vec![NormalizedPath::from(r"C:\work\pch\base.h")],
         unknown_flags: Vec::new(),
+        compiler_hash: super::test_compiler_hash(),
     };
     let ctx2 = CompileContext {
         source_file: NormalizedPath::from("c:/work/src/main.cpp"),
@@ -74,6 +75,7 @@ fn windows_context_key_normalizes_equivalent_path_spellings() {
         flags: Vec::new(),
         force_includes: vec![NormalizedPath::from("c:/work/pch/base.h")],
         unknown_flags: Vec::new(),
+        compiler_hash: super::test_compiler_hash(),
     };
 
     assert_eq!(ctx1.context_key(), ctx2.context_key());
@@ -89,6 +91,7 @@ fn windows_artifact_key_normalizes_equivalent_path_spellings() {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: super::test_compiler_hash(),
     };
     let key = ctx.context_key();
 
@@ -310,10 +313,28 @@ fn from_parsed_args_sorts() {
         dep_flags: UserDepFlags::default(),
         unknown_flags: vec!["--zzz".into(), "--aaa".into()],
     };
-    let ctx = CompileContext::from_parsed_args(args);
+    let ctx = CompileContext::from_parsed_args(args, super::test_compiler_hash());
     assert_eq!(ctx.defines, vec!["AAA", "ZZZ"]);
     assert_eq!(ctx.flags, vec!["-O2", "-Wall"]);
     assert_eq!(ctx.unknown_flags, vec!["--aaa", "--zzz"]);
+}
+
+/// Issue #1166: the C/C++ compile cache key must vary on compiler binary
+/// identity, mirroring `rustc_compiler_hash_affects_key` /
+/// `rustc_different_compiler_versions_different_key` in
+/// `context/tests/rustc.rs`. An in-place toolchain upgrade (same path, new
+/// clang/gcc/cl.exe binary content) must not reuse a stale cache key.
+#[test]
+fn different_compiler_binaries_different_key() {
+    let mut ctx1 = make_context("/src/a.c", &[], &[]);
+    ctx1.compiler_hash = zccache_hash::hash_bytes(b"clang-17.0.0");
+    let mut ctx2 = make_context("/src/a.c", &[], &[]);
+    ctx2.compiler_hash = zccache_hash::hash_bytes(b"clang-18.0.0");
+    assert_ne!(
+        ctx1.context_key(),
+        ctx2.context_key(),
+        "different compiler hash must produce different context key"
+    );
 }
 
 #[test]

--- a/crates/zccache-depgraph/src/context/tests/mod.rs
+++ b/crates/zccache-depgraph/src/context/tests/mod.rs
@@ -5,11 +5,20 @@
 
 use zccache_core::NormalizedPath;
 
+use zccache_hash::ContentHash;
+
 use super::{CompileContext, RustcCompileContext};
 use crate::search_paths::IncludeSearchPaths;
 
 mod cc;
 mod rustc;
+
+/// Fixed test `ContentHash` used by shared fixtures below that don't care
+/// about a specific compiler-identity value. Tests that assert
+/// compiler-hash-affects-key behavior build their own distinct values.
+pub(super) fn test_compiler_hash() -> ContentHash {
+    zccache_hash::hash_bytes(b"test-compiler-fixture")
+}
 
 /// Minimal C/C++ `CompileContext` with the given source, optional user-include
 /// dirs and defines. Defines are sorted to match `from_parsed_args` invariant.
@@ -31,6 +40,7 @@ pub(super) fn make_context(source: &str, user_dirs: &[&str], defines: &[&str]) -
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: test_compiler_hash(),
     }
 }
 
@@ -56,7 +66,7 @@ pub(super) fn make_rustc_context(source: &str, edition: &str) -> RustcCompileCon
         unknown_flags: Vec::new(),
         remap_path_prefixes: Vec::new(),
         env_vars: Vec::new(),
-        compiler_hash: None,
+        compiler_hash: test_compiler_hash(),
     }
 }
 

--- a/crates/zccache-depgraph/src/context/tests/rustc.rs
+++ b/crates/zccache-depgraph/src/context/tests/rustc.rs
@@ -11,7 +11,7 @@ use zccache_core::NormalizedPath;
 use super::super::{
     compute_rustc_artifact_key, compute_rustc_artifact_key_with_root, RustcCompileContext,
 };
-use super::{make_context, make_rustc_context, make_rustc_context_with_env};
+use super::{make_context, make_rustc_context, make_rustc_context_with_env, test_compiler_hash};
 
 #[cfg(windows)]
 #[test]
@@ -34,7 +34,7 @@ fn windows_rustc_context_key_normalizes_equivalent_source_path_spellings() {
         unknown_flags: Vec::new(),
         remap_path_prefixes: Vec::new(),
         env_vars: Vec::new(),
-        compiler_hash: None,
+        compiler_hash: test_compiler_hash(),
     };
     let mut ctx2 = ctx1.clone();
     ctx2.source_file = NormalizedPath::from("c:/work/src/lib.rs");
@@ -277,7 +277,7 @@ fn rustc_context_key_differs_from_cc() {
 fn rustc_compiler_hash_affects_key() {
     let ctx1 = make_rustc_context("/src/lib.rs", "2021");
     let mut ctx2 = make_rustc_context("/src/lib.rs", "2021");
-    ctx2.compiler_hash = Some(zccache_hash::hash_bytes(b"rustc-1.94.1"));
+    ctx2.compiler_hash = zccache_hash::hash_bytes(b"rustc-1.94.1");
     assert_ne!(
         ctx1.context_key(),
         ctx2.context_key(),
@@ -288,9 +288,9 @@ fn rustc_compiler_hash_affects_key() {
 #[test]
 fn rustc_different_compiler_versions_different_key() {
     let mut ctx1 = make_rustc_context("/src/lib.rs", "2021");
-    ctx1.compiler_hash = Some(zccache_hash::hash_bytes(b"rustc-1.94.1"));
+    ctx1.compiler_hash = zccache_hash::hash_bytes(b"rustc-1.94.1");
     let mut ctx2 = make_rustc_context("/src/lib.rs", "2021");
-    ctx2.compiler_hash = Some(zccache_hash::hash_bytes(b"rustc-1.94.2"));
+    ctx2.compiler_hash = zccache_hash::hash_bytes(b"rustc-1.94.2");
     assert_ne!(ctx1.context_key(), ctx2.context_key());
 }
 
@@ -354,7 +354,7 @@ fn rustc_from_parsed_args() {
         sysroot: None,
         output_file: None,
     };
-    let ctx = RustcCompileContext::from_parsed_args(&args, &[], None);
+    let ctx = RustcCompileContext::from_parsed_args(&args, &[], test_compiler_hash());
     // Crate types sorted
     assert_eq!(ctx.crate_types, vec!["lib", "rlib"]);
     // Emit types sorted
@@ -522,7 +522,7 @@ fn rustc_from_parsed_args_drops_cargo_target_dir() {
         ("CARGO_PKG_NAME".to_string(), "foo".to_string()),
         ("CARGO_PKG_VERSION".to_string(), "1.2.3".to_string()),
     ];
-    let ctx = RustcCompileContext::from_parsed_args(&args, &client_env, None);
+    let ctx = RustcCompileContext::from_parsed_args(&args, &client_env, test_compiler_hash());
     assert!(
         !ctx.env_vars.iter().any(|(k, _)| k == "CARGO_TARGET_DIR"),
         "from_parsed_args must drop CARGO_TARGET_DIR from env_vars; got {:?}",

--- a/crates/zccache-depgraph/src/graph/maintenance.rs
+++ b/crates/zccache-depgraph/src/graph/maintenance.rs
@@ -356,7 +356,22 @@ impl DepGraph {
             .iter()
             .map(|cmd| {
                 let parsed = cmd.parse();
-                let mut ctx = CompileContext::from_parsed_args(parsed);
+                // Issue #1166: compiler identity must be part of the
+                // context key. `compile_commands.json` ingestion is a
+                // bulk warm-priming path (not the live IPC hot path,
+                // which always recomputes via the daemon's
+                // probe-then-fallback `CompilerHashCache`), so a plain
+                // file-content hash is used here. If it doesn't bit-match
+                // the live probe-based hash for the same compiler, the
+                // primed entry simply won't be hit (cheap extra miss,
+                // never a wrong hit — the daemon's own compile-time hash
+                // is always the source of truth for real cache lookups).
+                let compiler_hash = parsed
+                    .compiler
+                    .as_ref()
+                    .and_then(|p| zccache_hash::hash_file(p.as_path()).ok())
+                    .unwrap_or_else(|| zccache_hash::hash_bytes(b"unknown-compiler"));
+                let mut ctx = CompileContext::from_parsed_args(parsed, compiler_hash);
 
                 // Merge system includes into the context's search paths.
                 // These go into the `system` field, appended after any

--- a/crates/zccache-depgraph/src/graph/tests.rs
+++ b/crates/zccache-depgraph/src/graph/tests.rs
@@ -18,6 +18,7 @@ fn make_ctx(source: &str) -> CompileContext {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     }
 }
 
@@ -960,6 +961,7 @@ fn register_context_produces_deterministic_key() {
         flags: vec!["-O2".to_string()],
         force_includes: vec![NormalizedPath::from("/proj/include/prefix.h")],
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
 
     let first = graph.register_with_root_and_salt_result(ctx.clone(), None, None);
@@ -993,6 +995,7 @@ fn cached_context_key_matches_uncached_for_identical_inputs() {
         flags: vec!["-O2".to_string()],
         force_includes: vec![NormalizedPath::from("/proj/include/prefix.h")],
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
 
     let uncached = compute_context_key(&ctx, None, None);

--- a/crates/zccache-depgraph/src/graph/tests/worktree_variants.rs
+++ b/crates/zccache-depgraph/src/graph/tests/worktree_variants.rs
@@ -19,6 +19,7 @@ fn context(root: &str) -> CompileContext {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     }
 }
 

--- a/crates/zccache-depgraph/src/session.rs
+++ b/crates/zccache-depgraph/src/session.rs
@@ -550,6 +550,7 @@ mod tests {
             flags: Vec::new(),
             force_includes: Vec::new(),
             unknown_flags: Vec::new(),
+            compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
         };
         let key = ctx.context_key();
 
@@ -571,6 +572,7 @@ mod tests {
             flags: Vec::new(),
             force_includes: Vec::new(),
             unknown_flags: Vec::new(),
+            compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
         };
         assert!(!mgr.add_context(&SessionId::new(), ctx.context_key()));
     }

--- a/crates/zccache-depgraph/src/snapshot/mod.rs
+++ b/crates/zccache-depgraph/src/snapshot/mod.rs
@@ -303,6 +303,28 @@ impl DepGraph {
                 flags: c.flags,
                 force_includes: strings_to_paths(c.force_includes),
                 unknown_flags: c.unknown_flags,
+                // Issue #1166 snapshot compatibility: `ContextEntrySnapshot`
+                // persists only the already-computed `context_key` /
+                // `artifact_key` raw bytes (see the struct above), never a
+                // serialized `CompileContext`. This reconstructed
+                // `CompileContext` is used post-load only for freshness
+                // bookkeeping (`entry.context.source_file`,
+                // `.force_includes`, `.include_search` — see
+                // `graph/check.rs`, `graph/update.rs`,
+                // `graph/maintenance.rs`, `watcher_support.rs`); it is
+                // NEVER re-hashed via `.context_key()` to recompute a
+                // lookup key. So this placeholder value cannot cause a
+                // wrong hit: any live compile request computes a *fresh*
+                // context key via `compute_context_key_with`, which now
+                // unconditionally folds the real compiler_hash. A snapshot
+                // written by a pre-#1166 binary has stale on-disk
+                // `context_key` bytes computed WITHOUT compiler identity;
+                // those bytes will never match a freshly computed
+                // (compiler-hash-including) key, so old entries are simply
+                // never looked up again post-upgrade — cold-miss and
+                // re-register, not silently-wrong-hit. No snapshot schema
+                // version bump or explicit migration is needed.
+                compiler_hash: ContentHash::from_bytes([0u8; 32]),
             };
             let entry = ContextEntry {
                 logical_key,

--- a/crates/zccache-depgraph/src/snapshot/tests/behavioral.rs
+++ b/crates/zccache-depgraph/src/snapshot/tests/behavioral.rs
@@ -49,6 +49,7 @@ fn loaded_graph_serves_cache_hits() {
         flags: vec!["-O2".into(), "-std=c++17".into()],
         force_includes: vec![NormalizedPath::from("/pch.h")],
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let key = graph.register(ctx);
 
@@ -122,6 +123,7 @@ fn context_key_consistent_after_roundtrip() {
         flags: vec!["-Wall".into()],
         force_includes: vec![NormalizedPath::from("/fi/pch.h")],
         unknown_flags: vec!["--custom".into()],
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let original_key = ctx.context_key();
     graph.register(ctx);
@@ -168,6 +170,7 @@ fn context_key_consistent_after_roundtrip() {
         flags: snap.contexts[0].flags.clone(),
         force_includes: strings_to_paths(snap.contexts[0].force_includes.clone()),
         unknown_flags: snap.contexts[0].unknown_flags.clone(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let recomputed_key = loaded_ctx.context_key();
     assert_eq!(
@@ -203,6 +206,7 @@ fn unicode_paths_roundtrip() {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let key = graph.register(ctx);
     let hash = zccache_hash::hash_bytes(b"x");
@@ -279,6 +283,7 @@ fn double_roundtrip_idempotent() {
             flags: vec!["-O2".into()],
             force_includes: Vec::new(),
             unknown_flags: Vec::new(),
+            compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
         };
         let key = graph.register(ctx);
         graph.update(
@@ -353,6 +358,7 @@ fn overlapping_contexts_roundtrip() {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let ctx_b = CompileContext {
         source_file: NormalizedPath::from("/src/b.cpp"),
@@ -364,6 +370,7 @@ fn overlapping_contexts_roundtrip() {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
 
     let key_a = graph.register(ctx_a);
@@ -554,6 +561,7 @@ fn large_graph_roundtrip() {
             flags: vec!["-O2".into(), format!("-std=c++{}", 14 + (i % 4) * 3)],
             force_includes: Vec::new(),
             unknown_flags: Vec::new(),
+            compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
         };
         let key = graph.register(ctx);
 
@@ -608,6 +616,7 @@ fn register_after_load_finds_existing() {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let original_key = graph.register(ctx.clone());
     graph.update(

--- a/crates/zccache-depgraph/src/snapshot/tests/mod.rs
+++ b/crates/zccache-depgraph/src/snapshot/tests/mod.rs
@@ -30,6 +30,7 @@ pub(super) fn make_ctx(source: &str) -> CompileContext {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     }
 }
 

--- a/crates/zccache-depgraph/src/snapshot/tests/round_trip.rs
+++ b/crates/zccache-depgraph/src/snapshot/tests/round_trip.rs
@@ -81,6 +81,7 @@ fn populated_graph_roundtrip() {
         flags: vec!["-std=c++17".into()],
         force_includes: vec![NormalizedPath::from("/pch.h")],
         unknown_flags: vec!["--custom".into()],
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let key = graph.register(ctx);
 
@@ -469,6 +470,7 @@ fn empty_strings_roundtrip() {
         flags: vec![String::new()],
         force_includes: vec![NormalizedPath::from("")],
         unknown_flags: vec![String::new()],
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let key = graph.register(ctx);
 

--- a/crates/zccache-depgraph/src/snapshot/tests/worktree_variants.rs
+++ b/crates/zccache-depgraph/src/snapshot/tests/worktree_variants.rs
@@ -21,6 +21,7 @@ fn context(root: &str) -> CompileContext {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     }
 }
 

--- a/crates/zccache-depgraph/src/watcher_support.rs
+++ b/crates/zccache-depgraph/src/watcher_support.rs
@@ -298,6 +298,7 @@ mod tests {
             flags: Vec::new(),
             force_includes: Vec::new(),
             unknown_flags: Vec::new(),
+            compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
         }
     }
 

--- a/crates/zccache-hash/src/lib.rs
+++ b/crates/zccache-hash/src/lib.rs
@@ -15,7 +15,7 @@ pub struct ContentHash([u8; 32]);
 impl ContentHash {
     /// Create a `ContentHash` from raw bytes.
     #[must_use]
-    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
         Self(bytes)
     }
 

--- a/crates/zccache/tests/daemon_depgraph_persistence_test.rs
+++ b/crates/zccache/tests/daemon_depgraph_persistence_test.rs
@@ -100,6 +100,7 @@ fn make_ctx(source: &str) -> CompileContext {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     }
 }
 

--- a/crates/zccache/tests/daemon_depgraph_warm_classify_test.rs
+++ b/crates/zccache/tests/daemon_depgraph_warm_classify_test.rs
@@ -64,6 +64,7 @@ fn make_ctx(source: &str) -> CompileContext {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     }
 }
 

--- a/crates/zccache/tests/depgraph_drift_detection_test.rs
+++ b/crates/zccache/tests/depgraph_drift_detection_test.rs
@@ -40,6 +40,7 @@ fn make_ctx(source: &str) -> CompileContext {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     }
 }
 

--- a/crates/zccache/tests/depgraph_stress_adversarial_test.rs
+++ b/crates/zccache/tests/depgraph_stress_adversarial_test.rs
@@ -111,6 +111,7 @@ fn adversarial_circular_includes() {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let key = graph.register(ctx);
     graph.update(&key, scan, disk_hash_oracle());
@@ -188,6 +189,7 @@ fn adversarial_computed_include_propagates() {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let key = graph.register(ctx);
     graph.update(&key, scan, disk_hash_oracle());
@@ -228,6 +230,7 @@ fn adversarial_shared_header_many_contexts() {
             flags: Vec::new(),
             force_includes: Vec::new(),
             unknown_flags: Vec::new(),
+            compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
         };
         let key = graph.register(ctx);
 
@@ -286,6 +289,7 @@ fn adversarial_rapid_state_transitions() {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let key = graph.register(ctx);
 
@@ -343,6 +347,7 @@ fn adversarial_no_includes() {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let key = graph.register(ctx);
 
@@ -388,6 +393,7 @@ fn adversarial_all_includes_unresolved() {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let key = graph.register(ctx);
 
@@ -427,6 +433,7 @@ fn adversarial_watch_set_large_graph() {
             flags: Vec::new(),
             force_includes: Vec::new(),
             unknown_flags: Vec::new(),
+            compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
         };
         let key = graph.register(ctx);
 
@@ -473,6 +480,7 @@ fn adversarial_trim_cleans_orphaned_files() {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let key = graph.register(ctx);
 
@@ -539,6 +547,7 @@ fn adversarial_deterministic_artifact_keys() {
         flags: vec!["-O2".into()],
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let key1 = graph1.register(ctx1);
     let scan1 = scanner::scan_recursive(&src, &search);
@@ -553,6 +562,7 @@ fn adversarial_deterministic_artifact_keys() {
         flags: vec!["-O2".into()],
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let key2 = graph2.register(ctx2);
     let scan2 = scanner::scan_recursive(&src, &search);

--- a/crates/zccache/tests/depgraph_stress_concurrent_test.rs
+++ b/crates/zccache/tests/depgraph_stress_concurrent_test.rs
@@ -105,6 +105,7 @@ fn stress_concurrent_register_scan_check() {
                     flags: vec!["-O2".into()],
                     force_includes: Vec::new(),
                     unknown_flags: Vec::new(),
+                    compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
                 };
 
                 let key = graph.register(ctx);
@@ -157,6 +158,7 @@ fn stress_concurrent_register_and_trim() {
                     flags: Vec::new(),
                     force_includes: Vec::new(),
                     unknown_flags: Vec::new(),
+                    compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
                 };
                 let key = graph.register(ctx);
 
@@ -215,6 +217,7 @@ fn stress_concurrent_shadow_detection() {
                     flags: Vec::new(),
                     force_includes: Vec::new(),
                     unknown_flags: Vec::new(),
+                    compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
                 };
                 let key = graph.register(ctx);
 

--- a/crates/zccache/tests/depgraph_stress_integration_test.rs
+++ b/crates/zccache/tests/depgraph_stress_integration_test.rs
@@ -119,6 +119,7 @@ fn integration_full_build_pipeline() {
         flags: vec!["-std=c++17".into()],
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let ctx_util = CompileContext {
         source_file: util_cpp.clone(),
@@ -127,6 +128,7 @@ fn integration_full_build_pipeline() {
         flags: vec!["-std=c++17".into()],
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
 
     let key_main = graph.register(ctx_main);
@@ -298,6 +300,7 @@ fn integration_shadow_detection_real_files() {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let key = graph.register(ctx);
 
@@ -353,6 +356,7 @@ fn integration_new_resolve_real_files() {
         flags: Vec::new(),
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let registration = graph.register_with_root_result(ctx, None);
     let key = registration.map_key;
@@ -430,6 +434,7 @@ End of search list.
         flags: vec!["-O2".into()],
         force_includes: Vec::new(),
         unknown_flags: Vec::new(),
+        compiler_hash: zccache_hash::hash_bytes(b"test-fixture"),
     };
     let key = graph.register(ctx);
     mgr.add_context(&session_id, key);


### PR DESCRIPTION
Closes #1166 — first child of the #1154 Phase 1 (key-space correctness) wave.

## The wrong hit

An in-place toolchain upgrade (same `clang`/`gcc`/`cl.exe` path, new binary content) produced **identical C/C++ cache keys** and served stale objects compiled by the old toolchain. The rustc branch already folded compiler identity into its key (#517); the Cc branch accepted the `compiler_hash_cache` parameter and dropped it on the floor.

## Fix

- `compiler_hash` is now a **required (non-`Option`) field** on `CompileContext` and `RustcCompileContext`; all three key sites fold it unconditionally — `compute_context_key_with`, `context_key_with_root`, and the `check_metadata_compat_key_with_root` guard the issue text didn't mention. Computing a key without compiler identity is now unrepresentable at the type level.
- New `hash_cc_identity[_async]`: `--version` probe with binary-content-hash fallback via the stat-revalidating `CompilerHashCache` — mirrors the rustc `-vV` probe shape. Probe runs once per compiler per daemon (cached); warm-hit latency unaffected. Degenerate-probe policy is #1167's scope (`TODO(#1167)` markers at the fallback arms). MSVC gets the binary-hash fallback for free.
- The multi-unit compile path hashes the compiler for its shared base context too.
- `compile_commands.json` depgraph priming hashes the parsed compiler path.

## Compat & protocol

- **Snapshot compat (traced):** `ContextEntrySnapshot` persists only computed keys; the `CompileContext` reconstructed at snapshot load is used for freshness bookkeeping and never re-hashed. Stale pre-#1166 snapshots simply never match the new keys → one-time cold miss + re-register, never a wrong hit, no panic, no snapshot version bump.
- **No IPC exposure** — contexts are daemon-internal; `PROTOCOL_VERSION` unchanged (DD-018 checked).
- **Expected effect on rollout:** every C/C++ key changes once (intended — old keys lacked identity).
- Known theoretical edge deferred to #1167: two *different* compilers whose binaries both fail to read fall back to the same `COMPILER_HASH_UNAVAILABLE` sentinel; pathological (the binary was just executed to get there).

## TDD

RED first, then GREEN:
- `context/tests/cc.rs::different_compiler_binaries_different_key` — same argv/source, different compiler binary → different key
- `daemon/server/tests/compiler_hash.rs::cc_context_build_reuses_compiler_hash_cache` — in-place binary swap at the same path → key changes; cache reuse proven

## Validation

fmt clean · workspace check + clippy under `-D warnings` · daemon-core 625 lib tests · depgraph 395 · compiler 358 · Linux cross-check (`--target x86_64-unknown-linux-gnu`) clean. (3 daemon-core failures reproduced on unmodified main via stash — pre-existing Windows flakes, unrelated.)

Part of #1154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)