### PR TITLE
fix: un-red main — #1193 Windows staged-paths fallout + deterministic Integration quiesce

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_paths.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_paths.rs
@@ -1,5 +1,7 @@
 //! Stable path identities for privately staged compiler outputs.
 
+#[cfg(windows)]
+use super::break_output_hardlink_before_compile;
 use crate::core::path::NormalizedPath;
 use std::io;
 use std::io::Write;
@@ -213,6 +215,29 @@ fn atomic_replace_bytes(path: &Path, bytes: &[u8]) -> io::Result<()> {
         file.write_all(bytes)?;
         file.sync_all()?;
         drop(file);
+        // The destination depfile is often the COW-lite hardlink materialized
+        // for the current build's output (persist/hardlink.rs marks
+        // materialized destinations read-only to protect the shared cache
+        // blob, and a hardlinked destination shares that read-only bit with
+        // the blob's inode/MFT record). `MoveFileExW(...,
+        // MOVEFILE_REPLACE_EXISTING)` fails with ERROR_ACCESS_DENIED on
+        // Windows when the existing destination is read-only. Naively
+        // clearing the attribute in place would also clear it on the shared
+        // blob; use the existing detach helper instead, which — when the
+        // destination is actually hardlinked to a blob — copies the content
+        // out, breaks the link, and restores read-only on the blob
+        // afterward. When not shared, it just clears the local bit.
+        //
+        // `std::fs::rename` (the non-Windows `replace_path`) needs no such
+        // dance: POSIX rename() only requires write access to the
+        // containing directory, never to the target file being replaced, so
+        // it already swaps the directory entry without touching the shared
+        // inode. Gate the detach to Windows to avoid the extra metadata
+        // stat + hard-link-count check on the Linux/macOS hot path.
+        #[cfg(windows)]
+        {
+            let _ = break_output_hardlink_before_compile(path);
+        }
         replace_path(&temporary, path)?;
         if let Ok(directory) = std::fs::File::open(parent) {
             let _ = directory.sync_all();
@@ -339,8 +364,13 @@ mod tests {
         expected
             .extend_from_slice(format!("{STAGED_OUTPUT_REMAP_ROOT}/libfixture.rlib").as_bytes());
         assert_eq!(canonical, expected);
-        let logical = rehydrate_staged_output_bytes(&canonical, &[output]);
-        assert_eq!(logical, b"\xff/current/target/libfixture.rlib");
+        let logical = rehydrate_staged_output_bytes(&canonical, std::slice::from_ref(&output));
+        // Rehydration writes the platform-native spelling of the requested
+        // output path (backslashes on Windows), not a slash-normalized one —
+        // depfiles are consumed by native build tooling on that platform.
+        let mut expected_logical = vec![0xff];
+        expected_logical.extend_from_slice(output.to_string_lossy().as_bytes());
+        assert_eq!(logical, expected_logical);
     }
 
     #[test]
@@ -366,9 +396,19 @@ mod tests {
         let depfile: NormalizedPath = "/target-b/foo.d".into();
         let canonical = format!("{STAGED_OUTPUT_REMAP_ROOT}/foo {STAGED_OUTPUT_REMAP_ROOT}/foo.d");
 
-        let logical = rehydrate_staged_output_bytes(canonical.as_bytes(), &[primary, depfile]);
+        let logical = rehydrate_staged_output_bytes(
+            canonical.as_bytes(),
+            &[primary.clone(), depfile.clone()],
+        );
 
-        assert_eq!(logical, b"/target-a/foo /target-b/foo.d");
+        // Native spelling, same rationale as
+        // `output_references_round_trip_without_utf8_conversion`.
+        let expected = format!(
+            "{} {}",
+            primary.to_string_lossy(),
+            depfile.to_string_lossy()
+        );
+        assert_eq!(logical, expected.as_bytes());
     }
 
     #[test]

--- a/crates/zccache-daemon-core/tests/legacy_path_validation.rs
+++ b/crates/zccache-daemon-core/tests/legacy_path_validation.rs
@@ -500,6 +500,33 @@ async fn wait_for_staged_publication(artifact_dir: &Path, minimum: usize) {
     });
 }
 
+/// Wait until the daemon reports at least `minimum` registered depgraph
+/// compile contexts.
+///
+/// The staged-pointer wait above proves the artifacts are durable, but the
+/// depgraph registration for multi-unit compiles is batched asynchronously
+/// after the response (`handle_compile_multi` fans out `apply_changes`), so
+/// a `Shutdown` right after the responses can still snapshot the depgraph
+/// before the multi units are registered — the warm daemon then evaluates
+/// them Cold (observed on the 2-core CI runner even with stable staged
+/// pointers). `DaemonStatus::dep_graph_contexts` makes the registration
+/// observable. TODO(#1161): remove alongside the publication wait once
+/// shutdown drains durably.
+async fn wait_for_depgraph_contexts(daemon: &mut Daemon, minimum: u64) {
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            if let Response::Status(status) = daemon.request(&Request::Status).await {
+                if status.dep_graph_contexts >= minimum {
+                    return;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for >= {minimum} depgraph compile contexts"));
+}
+
 fn staged_pointer_count(staged_root: &Path) -> usize {
     let Ok(entries) = std::fs::read_dir(staged_root) else {
         return 0;
@@ -644,6 +671,9 @@ async fn strict_layout_validation_aggregates_all_runtime_flows() {
     // migration artifact; link/exec publication is covered by the
     // stability requirement.
     wait_for_staged_publication(&artifact_dir, 4).await;
+    // ... and quiesce depgraph registration too: 3 compile contexts
+    // (single.o + the two multi units). See the helper's #1161 note.
+    wait_for_depgraph_contexts(&mut cold, 3).await;
     cold.stop().await;
 
     let cold_compile_count = line_count(&compile_count);


### PR DESCRIPTION
Main is red on Windows/CI (since #1193) and Integration (registration race). Two fixes:

## Windows: staged_paths (#1193 fallout)
- `atomic_replace_bytes` failed with `DestinationWrite`: `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` refuses a **read-only destination**, and the depfile destination is a COW-lite hardlink to the read-only cache blob. Fix: detach via the established `break_output_hardlink_before_compile` helper, `#[cfg(windows)]`-gated — clearing the read-only bit in place was rejected because the bit lives per-inode and is shared across hardlinks, so it would have stripped protection off the cache blob itself. Linux keeps the original zero-extra-syscall `rename()`.
- The two `staged_paths` round-trip tests hardcoded `/` separators against the intentionally platform-native rehydration contract (depfiles feed native make/ninja/cargo); expectations now derive from `NormalizedPath::to_string_lossy()`.

## Integration: legacy_path_validation determinism
The #1195 staged-pointer quiesce was insufficient — multi-unit depgraph registration is batched asynchronously after the compile response, so `Shutdown` could still snapshot the depgraph before the multi units registered (main run 30063050194 failed at the warm multi assert even with stable pointers). Now also polls `DaemonStatus::dep_graph_contexts >= 3` (single + two multi units) before stopping the cold daemon. `TODO(#1161)`: both waits go away when shutdown drains durably.

## Validation
Windows daemon-core lib suite **627 passed**; the 3 previously-failing tests individually green; fmt + clippy `-D warnings` clean on native Windows and `x86_64-unknown-linux-gnu` (`--all-targets`); Linux cross-check of the integration target clean. Linux runtime behavior unchanged (new call compiled out).

Unblocks PR #1196 (#1166), which inherits these three failures from main. Part of #1154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)