### PR TITLE
fix(cache): preserve C/C++ argv and MSVC environment key inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4323,6 +4323,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "uuid",
+ "zccache-compiler",
  "zccache-core",
  "zccache-hash",
 ]

--- a/crates/zccache-compiler/src/gnu_flags.rs
+++ b/crates/zccache-compiler/src/gnu_flags.rs
@@ -1,0 +1,63 @@
+//! Shared GNU/Clang command-line flag classification.
+//!
+//! The compiler-invocation classifier and depgraph key parser must agree on
+//! which exact flags consume the following argv element.  Keeping this table
+//! in the compiler crate lets the depgraph depend on the classifier's source
+//! of truth without creating a reverse dependency.
+
+/// GNU/Clang flags whose value is always the next argv element.
+///
+/// This intentionally contains only exact flag spellings.  Flags that allow a
+/// joined value (such as `-Ipath`) need parser-specific handling before this
+/// classification is consulted.
+pub const GNU_FLAGS_WITH_VALUE: &[&str] = &[
+    "-o",
+    "-D",
+    "-U",
+    "-I",
+    "-isystem",
+    "-iquote",
+    "-idirafter",
+    "-include",
+    "-include-pch",
+    "-imacros",
+    "-isysroot",
+    "-target",
+    "--target",
+    "-MF",
+    "-MQ",
+    "-MT",
+    "-std",
+    "-x",
+    "-arch",
+    "-Xclang",
+    "-mllvm",
+    "--serialize-diagnostics",
+];
+
+/// Returns whether an exact GNU/Clang flag consumes the following argv value.
+#[must_use]
+pub fn gnu_flag_takes_value(flag: &str) -> bool {
+    GNU_FLAGS_WITH_VALUE.contains(&flag)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{gnu_flag_takes_value, GNU_FLAGS_WITH_VALUE};
+
+    #[test]
+    fn value_flags_include_cross_compilation_and_preprocessor_inputs() {
+        for flag in ["-target", "--target", "-arch", "-isysroot", "-imacros"] {
+            assert!(gnu_flag_takes_value(flag), "{flag} must consume its value");
+        }
+    }
+
+    #[test]
+    fn value_flag_classifier_matches_the_exported_table() {
+        for flag in GNU_FLAGS_WITH_VALUE {
+            assert!(gnu_flag_takes_value(flag));
+        }
+        assert!(!gnu_flag_takes_value("-g"));
+        assert!(!gnu_flag_takes_value("--target=x86_64-unknown-linux-gnu"));
+    }
+}

--- a/crates/zccache-compiler/src/lib.rs
+++ b/crates/zccache-compiler/src/lib.rs
@@ -20,6 +20,7 @@
 
 pub mod arduino;
 mod detect;
+mod gnu_flags;
 pub mod output_policy;
 mod parse;
 pub mod parse_archiver;
@@ -37,6 +38,7 @@ use std::sync::Arc;
 use zccache_core::NormalizedPath;
 
 pub use detect::detect_family;
+pub use gnu_flags::{gnu_flag_takes_value, GNU_FLAGS_WITH_VALUE};
 pub use output_policy::{
     rustc_archive_hardlink_eligible, rustc_output_delivery, DeliveryPolicy, MutationContract,
     OutputClassification, OutputRole,

--- a/crates/zccache-compiler/src/parse.rs
+++ b/crates/zccache-compiler/src/parse.rs
@@ -7,7 +7,10 @@ use std::sync::Arc;
 use zccache_core::NormalizedPath;
 
 use super::detect::{detect_family, is_source_file, MODULE_EXTENSIONS};
-use super::{parse_msvc, CacheableCompilation, CompilerFamily, ParsedInvocation, SourceMode};
+use super::{
+    gnu_flag_takes_value, parse_msvc, CacheableCompilation, CompilerFamily, ParsedInvocation,
+    SourceMode,
+};
 
 /// Map a `-x <lang>` value to the corresponding source mode.
 /// Returns `None` for unrecognized language values (no special mode).
@@ -91,31 +94,6 @@ pub(crate) fn default_output(
         .unwrap_or("a");
     format!("{stem}.o")
 }
-
-/// Flags that take a following argument (value in next argv element).
-const FLAGS_WITH_VALUE: &[&str] = &[
-    "-o",
-    "-D",
-    "-U",
-    "-I",
-    "-isystem",
-    "-iquote",
-    "-idirafter",
-    "-include",
-    "-include-pch",
-    "-isysroot",
-    "-target",
-    "--target",
-    "-MF",
-    "-MQ",
-    "-MT",
-    "-std",
-    "-x",
-    "-arch",
-    "-Xclang",
-    "-mllvm",
-    "--serialize-diagnostics",
-];
 
 /// Parse a compiler invocation's arguments to determine cacheability.
 ///
@@ -224,8 +202,8 @@ pub fn parse_invocation(compiler: &str, args: &[String]) -> ParsedInvocation {
         }
 
         // Flags that take a value in the next arg — skip both flag and value
-        if let Some(&flag) = FLAGS_WITH_VALUE.iter().find(|&&f| f == arg.as_str()) {
-            if flag == "-x" && i + 1 < args.len() {
+        if gnu_flag_takes_value(arg) {
+            if arg == "-x" && i + 1 < args.len() {
                 current_mode =
                     source_mode_from_language(&args[i + 1]).unwrap_or(SourceMode::Normal);
             }

--- a/crates/zccache-compiler/src/response_file.rs
+++ b/crates/zccache-compiler/src/response_file.rs
@@ -203,7 +203,11 @@ fn expand_recursive(
     Ok(result)
 }
 
-fn read_response_file_text(path: &Path) -> std::io::Result<String> {
+/// Read a response file as text, honoring UTF-8 and BOM-marked UTF-16.
+///
+/// The daemon's cached response-file expander uses this too, so response-file
+/// decoding stays identical for request-key construction and direct expansion.
+pub fn read_response_file_text(path: &Path) -> std::io::Result<String> {
     let bytes = std::fs::read(path)?;
     if let Some(payload) = bytes.strip_prefix(&[0xff, 0xfe]) {
         return decode_utf16(payload, u16::from_le_bytes);

--- a/crates/zccache-daemon-core/src/daemon/server/keys.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/keys.rs
@@ -365,6 +365,17 @@ pub(super) fn request_env_fingerprint_vars(
         .flatten()
         .filter_map(|(key, value)| {
             let key = key.as_str();
+            // MSVC reads these variables as extra compiler arguments (`CL`
+            // before argv, `_CL_` after it). They therefore affect both the
+            // request cache and the depgraph context even though zccache does
+            // not synthesize them into argv. Windows environment names are
+            // case-insensitive, so canonicalize their names before hashing.
+            if key.eq_ignore_ascii_case("CL") || key.eq_ignore_ascii_case("_CL_") {
+                // Added below from the final matching entry. This mirrors
+                // `Command::env` replacement semantics if an untrusted IPC
+                // payload contains duplicate case variants.
+                return None;
+            }
             // Mirror `VOLATILE_CARGO_ENV_VARS` in `depgraph::context`: the
             // request-level fingerprint must drop the same path-cascading
             // CARGO_* vars the rustc context key drops, otherwise the
@@ -381,8 +392,44 @@ pub(super) fn request_env_fingerprint_vars(
             include.then_some((key, value.as_str()))
         })
         .collect();
+    for name in ["CL", "_CL_"] {
+        if let Some(value) = client_env.and_then(|env| {
+            env.iter()
+                .rev()
+                .find_map(|(key, value)| key.eq_ignore_ascii_case(name).then_some(value.as_str()))
+        }) {
+            vars.push((name, value));
+        }
+    }
     vars.sort_unstable();
     vars
+}
+
+/// Return cache-key flags for MSVC's command-line environment variables.
+///
+/// `cl.exe` reads `CL` and `_CL_` in addition to argv. Preserve their raw
+/// values rather than expanding them: the compiler remains the authority for
+/// its quoting and precedence semantics, while distinct environments cannot
+/// share a cached artifact. The names are case-insensitive on Windows.
+pub(super) fn msvc_env_key_flags(
+    family: crate::compiler::CompilerFamily,
+    client_env: &[(String, String)],
+) -> Vec<String> {
+    if family != crate::compiler::CompilerFamily::Msvc {
+        return Vec::new();
+    }
+
+    let mut flags = Vec::with_capacity(2);
+    for name in ["CL", "_CL_"] {
+        if let Some(value) = client_env
+            .iter()
+            .rev()
+            .find_map(|(key, value)| key.eq_ignore_ascii_case(name).then_some(value))
+        {
+            flags.push(format!("zccache:msvc-env:{name}={value}"));
+        }
+    }
+    flags
 }
 
 /// Compute a fast fingerprint of a compile request for the request-level cache.

--- a/crates/zccache-daemon-core/src/daemon/server/rsp_cache.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/rsp_cache.rs
@@ -132,10 +132,16 @@ pub(super) fn expand_rsp_recursive(
         hash: content_hash,
     });
 
+    // Keep daemon-side key expansion byte-for-byte aligned with the compiler
+    // response-file reader. In particular, MSVC commonly emits UTF-16LE
+    // response files; `read_to_string` rejected those and left the raw
+    // `@file` invisible to parsing and cache keys.
     let content =
-        std::fs::read_to_string(&canonical).map_err(|e| ResponseFileError::ReadError {
-            path: canonical.clone(),
-            source: e,
+        crate::compiler::response_file::read_response_file_text(&canonical).map_err(|e| {
+            ResponseFileError::ReadError {
+                path: canonical.clone(),
+                source: e,
+            }
         })?;
     let base_dir = canonical.parent().unwrap_or_else(|| Path::new("."));
     let mut expanded = Vec::new();

--- a/crates/zccache-daemon-core/src/daemon/server/rustc.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/rustc.rs
@@ -50,7 +50,7 @@ pub(super) fn build_compile_context(
         .get_or_hash_with(&compilation.compiler, hash_cc_identity)
         .unwrap_or(COMPILER_HASH_UNAVAILABLE);
 
-    build_cc_compile_context(compilation, cwd, system_includes, compiler_hash)
+    build_cc_compile_context(compilation, cwd, system_includes, client_env, compiler_hash)
 }
 
 /// Shared by the sync and async C/C++ context builders once the compiler
@@ -59,6 +59,7 @@ fn build_cc_compile_context(
     compilation: &crate::compiler::CacheableCompilation,
     cwd: &Path,
     system_includes: &[NormalizedPath],
+    client_env: &[(String, String)],
     compiler_hash: ContentHash,
 ) -> BuildContextResult {
     // Dispatch to the correct parser based on compiler family.
@@ -70,6 +71,9 @@ fn build_cc_compile_context(
     };
     let dep_flags = parsed.dep_flags.clone();
     let mut ctx = CompileContext::from_parsed_args(parsed, compiler_hash);
+    ctx.flags
+        .extend(msvc_env_key_flags(compilation.family, client_env));
+    ctx.flags.sort();
 
     // For multi-file compilations, the parsed source_file might be wrong
     // (it picks the first source from original_args). Override with the
@@ -117,7 +121,7 @@ pub(super) async fn build_compile_context_async(
         .await
         .unwrap_or(COMPILER_HASH_UNAVAILABLE);
 
-    build_cc_compile_context(compilation, cwd, system_includes, compiler_hash)
+    build_cc_compile_context(compilation, cwd, system_includes, client_env, compiler_hash)
 }
 
 /// Build compile context for a Rustc invocation.

--- a/crates/zccache-daemon-core/src/daemon/server/tests/fingerprint.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/fingerprint.rs
@@ -611,6 +611,51 @@ fn request_fingerprint_ignores_cargo_target_dir() {
 }
 
 #[test]
+fn msvc_cl_environment_salts_request_fingerprint_case_insensitively() {
+    let args = vec!["/c".to_string(), "main.c".to_string()];
+    let common = vec![("PATH".to_string(), "C:\\msvc".to_string())];
+    let with_cl = vec![
+        ("cl".to_string(), "/DANSWER=42".to_string()),
+        ("_CL_".to_string(), "/Z7".to_string()),
+    ];
+    let equivalent_case = vec![
+        ("CL".to_string(), "/DANSWER=42".to_string()),
+        ("_cl_".to_string(), "/Z7".to_string()),
+    ];
+
+    let base = request_fingerprint(
+        Path::new("cl.exe"),
+        &args,
+        Path::new("."),
+        None,
+        Some(&common),
+    );
+    let keyed = request_fingerprint(
+        Path::new("cl.exe"),
+        &args,
+        Path::new("."),
+        None,
+        Some(&with_cl),
+    );
+    let same = request_fingerprint(
+        Path::new("cl.exe"),
+        &args,
+        Path::new("."),
+        None,
+        Some(&equivalent_case),
+    );
+
+    assert_ne!(
+        base, keyed,
+        "CL and _CL_ affect cl.exe output and must salt the request key"
+    );
+    assert_eq!(
+        keyed, same,
+        "Windows CL environment names are case-insensitive"
+    );
+}
+
+#[test]
 fn request_fingerprint_keeps_external_out_dirs_distinct() {
     let args_a = vec![
         "--crate-name".to_string(),

--- a/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
@@ -28,6 +28,7 @@ mod pch;
 mod pending_cache_writes;
 mod post_link_hook;
 mod release_worktree_handles;
+mod rsp_cache;
 mod rustc_depinfo;
 mod server_ipc;
 mod session_errors;

--- a/crates/zccache-daemon-core/src/daemon/server/tests/rsp_cache.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/rsp_cache.rs
@@ -1,0 +1,24 @@
+//! Daemon-side response-file expansion regression tests.
+
+use super::super::*;
+
+#[tokio::test]
+async fn cached_expansion_parses_utf16le_response_file_for_cache_keys() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_dir: NormalizedPath = dir.path().join("cache").into();
+    let response = dir.path().join("compile.rsp");
+    let mut utf16le = vec![0xff, 0xfe];
+    for word in "/c \"\u{6e90}.cpp\" /Foobj\\\r\n".encode_utf16() {
+        utf16le.extend_from_slice(&word.to_le_bytes());
+    }
+    std::fs::write(&response, utf16le).unwrap();
+
+    let server =
+        DaemonServer::bind_with_cache_dir(&crate::ipc::unique_test_endpoint(), &cache_dir).unwrap();
+    let args = vec![format!("@{}", response.display())];
+    assert_eq!(
+        expand_args_cached(server.test_state(), &args, dir.path()),
+        vec!["/c", "\u{6e90}.cpp", "/Foobj\\"],
+        "UTF-16 response-file flags must be visible to daemon key parsing"
+    );
+}

--- a/crates/zccache-depgraph/Cargo.toml
+++ b/crates/zccache-depgraph/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 
 [dependencies]
 zccache-core = { workspace = true }
+zccache-compiler = { workspace = true }
 zccache-hash = { workspace = true }
 bincode = { workspace = true }
 blake3 = { workspace = true }

--- a/crates/zccache-depgraph/src/args.rs
+++ b/crates/zccache-depgraph/src/args.rs
@@ -6,6 +6,7 @@
 use std::path::Path;
 
 use super::search_paths::IncludeSearchPaths;
+use zccache_compiler::gnu_flag_takes_value;
 use zccache_core::NormalizedPath;
 
 /// Dependency-generation flags already present in the user's compiler args.
@@ -80,10 +81,12 @@ pub fn parse_gnu_args(args: &[String], cwd: &Path) -> ParsedArgs {
                 i += 2;
                 continue;
             }
-        } else if let Some(dir) = arg.strip_prefix("-I") {
-            result.include_search.user.push(resolve_path(dir, cwd));
-            i += 1;
-            continue;
+        } else if !matches!(arg.as_str(), "-isystem" | "-isysroot") {
+            if let Some(dir) = arg.strip_prefix("-I") {
+                result.include_search.user.push(resolve_path(dir, cwd));
+                i += 1;
+                continue;
+            }
         }
 
         // -isystem <dir>
@@ -170,6 +173,47 @@ pub fn parse_gnu_args(args: &[String], cwd: &Path) -> ParsedArgs {
             }
         }
 
+        // -imacros <file> is a force-included macro input whose contents
+        // must participate in depgraph invalidation just like -include.
+        if arg == "-imacros" {
+            if let Some(next) = args.get(i + 1) {
+                result.force_includes.push(resolve_path(next, cwd));
+                i += 2;
+                continue;
+            }
+        }
+
+        // GCC's -Wp, form forwards comma-separated options directly to the
+        // preprocessor. Retain the raw argument in the key, but also surface
+        // include and macro inputs to dependency discovery so a header that
+        // is reachable only through this spelling cannot become invisible.
+        if let Some(options) = arg.strip_prefix("-Wp,") {
+            let mut parts = options.split(',');
+            while let Some(option) = parts.next() {
+                match option {
+                    "-I" => {
+                        if let Some(path) = parts.next() {
+                            result.include_search.user.push(resolve_path(path, cwd));
+                        }
+                    }
+                    "-isystem" => {
+                        if let Some(path) = parts.next() {
+                            result.include_search.system.push(resolve_path(path, cwd));
+                        }
+                    }
+                    "-imacros" | "-include" => {
+                        if let Some(path) = parts.next() {
+                            result.force_includes.push(resolve_path(path, cwd));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            result.flags.push(arg.clone());
+            i += 1;
+            continue;
+        }
+
         // Cache-relevant flags.
         if arg.starts_with("-std=") || arg.starts_with("--std=") {
             result.flags.push(arg.clone());
@@ -202,7 +246,8 @@ pub fn parse_gnu_args(args: &[String], cwd: &Path) -> ParsedArgs {
             || arg.starts_with("-f")
             || arg.starts_with("-m")
             || arg.starts_with("-W")
-            || arg.starts_with("--target")
+            || arg.starts_with("-g")
+            || arg.starts_with("--target=")
             || arg == "-pthread"
             || arg == "-pipe"
         {
@@ -240,13 +285,22 @@ pub fn parse_gnu_args(args: &[String], cwd: &Path) -> ParsedArgs {
             continue;
         }
 
+        // The invocation classifier owns this table. Preserve both tokens in
+        // the context key for every remaining value-taking flag so a
+        // classifier update cannot make distinct argv shapes collide.
+        if gnu_flag_takes_value(arg) {
+            if let Some(next) = args.get(i + 1) {
+                result.flags.push(format!("{arg}={next}"));
+                i += 2;
+                continue;
+            }
+        }
+
         if arg == "-c"
             || arg == "-S"
             || arg == "-E"
             || arg == "-v"
             || arg == "-w"
-            || arg == "-g"
-            || arg.starts_with("-g")
             || arg.starts_with("-M")
             || arg == "-MP"
         {
@@ -258,7 +312,16 @@ pub fn parse_gnu_args(args: &[String], cwd: &Path) -> ParsedArgs {
         if !arg.starts_with('-') {
             source_candidates.push(resolve_path(arg, cwd));
         } else {
-            // Unrecognized flag â€” track for cache invalidation.
+            // Unknown flags fail safe: preserve a following non-source token
+            // too, so an unclassified value-taking compiler flag cannot
+            // silently collide with a different value.
+            if let Some(next) = args.get(i + 1) {
+                if !next.starts_with('-') && !is_source_file(&resolve_path(next, cwd)) {
+                    result.unknown_flags.push(format!("{arg}={next}"));
+                    i += 2;
+                    continue;
+                }
+            }
             result.unknown_flags.push(arg.clone());
         }
 
@@ -367,6 +430,7 @@ fn is_source_file(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zccache_compiler::GNU_FLAGS_WITH_VALUE;
 
     fn args(s: &[&str]) -> Vec<String> {
         s.iter().map(|x| x.to_string()).collect()
@@ -484,6 +548,77 @@ mod tests {
     }
 
     #[test]
+    fn cross_compile_and_debug_flags_preserve_their_values() {
+        let parsed = parse_gnu_args(
+            &args(&[
+                "-target",
+                "armv7-none-eabi",
+                "-arch",
+                "arm64",
+                "-isysroot",
+                "/sdk/a",
+                "--target",
+                "x86_64-unknown-linux-gnu",
+                "-g3",
+                "-c",
+                "x.c",
+            ]),
+            Path::new("/p"),
+        );
+        for flag in [
+            "-target=armv7-none-eabi",
+            "-arch=arm64",
+            "-isysroot=/sdk/a",
+            "--target=x86_64-unknown-linux-gnu",
+            "-g3",
+        ] {
+            assert!(parsed.flags.contains(&flag.to_string()), "missing {flag}");
+        }
+    }
+
+    #[test]
+    fn imacros_is_a_force_include() {
+        let parsed = parse_gnu_args(
+            &args(&["-imacros", "macros.h", "-c", "x.c"]),
+            Path::new("/p"),
+        );
+        assert_eq!(parsed.force_includes, vec![Path::new("/p/macros.h")]);
+    }
+
+    #[test]
+    fn wp_forwarded_include_and_macro_inputs_are_discovered() {
+        let parsed = parse_gnu_args(
+            &args(&["-Wp,-I,generated,-imacros,config.h", "-c", "x.c"]),
+            Path::new("/p"),
+        );
+        assert_eq!(parsed.include_search.user, vec![Path::new("/p/generated")]);
+        assert_eq!(parsed.force_includes, vec![Path::new("/p/config.h")]);
+        assert!(parsed
+            .flags
+            .contains(&"-Wp,-I,generated,-imacros,config.h".to_string()));
+    }
+
+    /// Mechanical #1173 drift guard: the invocation classifier owns the
+    /// value-taking table, and the key parser must consume every listed
+    /// value rather than reprocessing it as an unrelated positional token.
+    #[test]
+    fn classifier_value_flag_table_is_consumed_by_key_parser() {
+        for flag in GNU_FLAGS_WITH_VALUE {
+            let parsed = parse_gnu_args(
+                &[
+                    (*flag).into(),
+                    "classifier-value".into(),
+                    "-c".into(),
+                    "x.c".into(),
+                ],
+                Path::new("/p"),
+            );
+            assert_eq!(parsed.source_file, Path::new("/p/x.c"), "{flag}");
+            assert!(parsed.unknown_flags.is_empty(), "{flag}");
+        }
+    }
+
+    #[test]
     fn absolute_paths_not_prefixed() {
         let parsed = parse_gnu_args(
             &args(&["-I", "/usr/include", "-c", "/src/foo.c"]),
@@ -547,6 +682,15 @@ mod tests {
         assert!(parsed
             .unknown_flags
             .contains(&"--custom-flag=value".to_string()));
+    }
+
+    #[test]
+    fn unknown_flag_preserves_a_non_source_value() {
+        let parsed = parse_gnu_args(
+            &args(&["--vendor-mode", "strict", "-c", "foo.c"]),
+            Path::new("/p"),
+        );
+        assert_eq!(parsed.unknown_flags, vec!["--vendor-mode=strict"]);
     }
 
     #[test]

--- a/crates/zccache-depgraph/src/context/tests/cc.rs
+++ b/crates/zccache-depgraph/src/context/tests/cc.rs
@@ -3,7 +3,7 @@
 
 use std::path::Path;
 
-use crate::args::{ParsedArgs, UserDepFlags};
+use crate::args::{parse_gnu_args, ParsedArgs, UserDepFlags};
 use crate::search_paths::IncludeSearchPaths;
 use zccache_core::NormalizedPath;
 
@@ -344,6 +344,43 @@ fn different_flags_different_key() {
     let mut ctx2 = make_context("/src/a.c", &[], &[]);
     ctx2.flags = vec!["-std=c++20".into()];
     assert_ne!(ctx1.context_key(), ctx2.context_key());
+}
+
+/// Issue #1173: value-taking GNU flags must not discard their value while
+/// translating argv into a cache context. Every pair below used to collide.
+#[test]
+fn gnu_value_flags_are_context_key_sensitive() {
+    for (flag, first, second) in [
+        ("-target", "armv7-none-eabi", "x86_64-unknown-linux-gnu"),
+        ("--target", "armv7-none-eabi", "x86_64-unknown-linux-gnu"),
+        ("-arch", "arm64", "x86_64"),
+        ("-isysroot", "/sdk/one", "/sdk/two"),
+        ("-g", "", "3"),
+    ] {
+        let first_args = if flag == "-g" {
+            vec!["-g".into(), "-c".into(), "src/main.c".into()]
+        } else {
+            vec![flag.into(), first.into(), "-c".into(), "src/main.c".into()]
+        };
+        let second_args = if flag == "-g" {
+            vec!["-g3".into(), "-c".into(), "src/main.c".into()]
+        } else {
+            vec![flag.into(), second.into(), "-c".into(), "src/main.c".into()]
+        };
+        let first = CompileContext::from_parsed_args(
+            parse_gnu_args(&first_args, Path::new("/work")),
+            super::test_compiler_hash(),
+        );
+        let second = CompileContext::from_parsed_args(
+            parse_gnu_args(&second_args, Path::new("/work")),
+            super::test_compiler_hash(),
+        );
+        assert_ne!(
+            first.context_key(),
+            second.context_key(),
+            "{flag} must affect the key"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #1173.\n\n- share GNU value-flag classification between invocation and key parsers\n- fail safe for unknown flag values; key target, arch, sysroot, debug, imacros, and forwarded preprocessor inputs\n- key MSVC CL/_CL_ values and decode UTF-16 response files in daemon expansion\n- add parser drift and key-sensitivity regressions