### PR TITLE
fix(cache): capture host and profile dependent inputs

### DIFF
--- a/crates/zccache-compiler/src/gnu_flags.rs
+++ b/crates/zccache-compiler/src/gnu_flags.rs
@@ -30,6 +30,9 @@ pub const GNU_FLAGS_WITH_VALUE: &[&str] = &[
     "-std",
     "-x",
     "-arch",
+    "-march",
+    "-mtune",
+    "-mcpu",
     "-Xclang",
     "-mllvm",
     "--serialize-diagnostics",
@@ -47,7 +50,16 @@ mod tests {
 
     #[test]
     fn value_flags_include_cross_compilation_and_preprocessor_inputs() {
-        for flag in ["-target", "--target", "-arch", "-isysroot", "-imacros"] {
+        for flag in [
+            "-target",
+            "--target",
+            "-arch",
+            "-march",
+            "-mtune",
+            "-mcpu",
+            "-isysroot",
+            "-imacros",
+        ] {
             assert!(gnu_flag_takes_value(flag), "{flag} must consume its value");
         }
     }

--- a/crates/zccache-compiler/src/parse.rs
+++ b/crates/zccache-compiler/src/parse.rs
@@ -172,6 +172,18 @@ pub fn parse_invocation(compiler: &str, args: &[String]) -> ParsedInvocation {
             };
         }
 
+        // GCC accepts this spelling without an explicit profile path and
+        // derives the input location from compiler defaults. That implicit
+        // file cannot be registered in the depgraph as a content-hashed
+        // input, so caching it could replay an object built from regenerated
+        // PGO data. Explicit `-fprofile-use=<path>` remains cacheable and is
+        // registered by the depgraph parser.
+        if arg == "-fprofile-use" {
+            return ParsedInvocation::NonCacheable {
+                reason: "implicit -fprofile-use profile input is not cacheable".to_string(),
+            };
+        }
+
         if arg == "-c" {
             has_c_flag = true;
             i += 1;

--- a/crates/zccache-compiler/src/tests/cpp_parse.rs
+++ b/crates/zccache-compiler/src/tests/cpp_parse.rs
@@ -46,6 +46,12 @@ fn preprocessing_only_non_cacheable() {
 }
 
 #[test]
+fn implicit_profile_use_is_non_cacheable() {
+    let result = parse_invocation("gcc", &args(&["-c", "-fprofile-use", "hello.cpp"]));
+    assert!(matches!(result, ParsedInvocation::NonCacheable { .. }));
+}
+
+#[test]
 fn multi_file_split() {
     let result = parse_invocation("gcc", &args(&["-c", "a.cpp", "b.cpp"]));
     match result {

--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -61,6 +61,8 @@
 //! | `destination_write_failed` | daemon | cached artifact could not be written to its requested output | `artifact_key`, `path`, `errno` |
 //! | `legacy_artifact_path_accessed` | daemon | legacy artifact layout was reached (Phase 0 audit failure) | path-specific fields |
 //! | `miss_reason_unknown` | daemon | miss classification was not recognized (Phase 0 audit failure) | miss-specific fields |
+//! | `native_flag_host_salted` | daemon | a `native` CPU-selection flag made the compile key host-specific | `compiler_family` |
+//! | `time_macro_noncacheable` | daemon | a C/C++ time macro bypassed the compile cache | `source`, `input`, `macro_name` |
 //!
 //! ## Forensic walkthrough: the two-versions-on-one-pipe wedge
 //!
@@ -153,6 +155,8 @@ pub const EVENT_IN_FLIGHT_EXEC_WAIT_TIMEOUT: &str = "in_flight_exec_wait_timeout
 pub const EVENT_RUSTC_IDENTITY_PROBE_TIMEOUT: &str = "rustc_identity_probe_timeout";
 pub const EVENT_COW_UNREGISTERED_BLOB_EVICTED: &str = "cow_unregistered_blob_evicted";
 pub const EVENT_COW_BLOB_CORRUPTION_DETECTED: &str = "cow_blob_corruption_detected";
+pub const EVENT_NATIVE_FLAG_HOST_SALTED: &str = "native_flag_host_salted";
+pub const EVENT_TIME_MACRO_NONCACHEABLE: &str = "time_macro_noncacheable";
 
 /// Complete lifecycle-event catalog. Keep this additive and update the module
 /// schema table with every new event; log-audit and operator docs depend on it.
@@ -182,6 +186,8 @@ pub const EVENT_ALL: &[&str] = &[
     EVENT_RUSTC_IDENTITY_PROBE_TIMEOUT,
     EVENT_COW_UNREGISTERED_BLOB_EVICTED,
     EVENT_COW_BLOB_CORRUPTION_DETECTED,
+    EVENT_NATIVE_FLAG_HOST_SALTED,
+    EVENT_TIME_MACRO_NONCACHEABLE,
     EVENT_LEGACY_ARTIFACT_PATH_ACCESSED,
     EVENT_DESTINATION_WRITE_FAILED,
     EVENT_MISS_REASON_UNKNOWN,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/README.md
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/README.md
@@ -14,6 +14,7 @@ parent `handle_compile.rs` need no changes.
 | `hash_verify.rs` | Hash source + headers in parallel, run depgraph verdict |
 | `compile_exec.rs` | Prepare depfile / response file, spawn compiler, parse output |
 | `store_outcome.rs` | Successful-compile post path: scan deps, hash all, store artifact, emit miss profiles, schedule background watcher updates |
+| `time_macros.rs` | Detect nondeterministic C/C++ time macros before any cache lookup |
 
 ## Why a phase-per-file split
 

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -17,6 +17,7 @@ mod compile_exec;
 mod hash_verify;
 mod store_outcome;
 mod system_includes;
+mod time_macros;
 
 use super::super::*;
 use super::cached_hit::{
@@ -33,6 +34,7 @@ use compile_exec::{run_compile_exec, CompileExecOutcome, CompileExecRequest, Com
 use hash_verify::{hash_and_verify, HashSourceOutcome, HashVerifyInput, HashVerifyOutcome};
 use store_outcome::{store_successful_compile, StoreOutcomeRequest};
 use system_includes::{discover_system_includes, SystemIncludesOutcome};
+use time_macros::{find_time_macro_use, warn_time_macro_uncacheable};
 
 const DEPGRAPH_STARTUP_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
@@ -86,6 +88,49 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     );
     let request_cache_key_root =
         request_key_root(compiler_path, &effective_args, worktree_root.as_ref());
+
+    // `__DATE__`, `__TIME__`, and `__TIMESTAMP__` are source-level inputs
+    // whose expansion changes between otherwise-identical compiler requests.
+    // This check intentionally precedes the request cache: all later cache
+    // layers would be too late to prevent replaying an old timestamp object.
+    let preflight_parsed =
+        crate::compiler::parse_invocation(compiler_path.to_str().unwrap_or(""), &effective_args);
+    let time_macro_use = match &preflight_parsed {
+        crate::compiler::ParsedInvocation::Cacheable(compilation) => {
+            find_time_macro_use(compilation, cwd)
+        }
+        crate::compiler::ParsedInvocation::MultiFile { compilations, .. } => compilations
+            .iter()
+            .find_map(|compilation| find_time_macro_use(compilation, cwd)),
+        crate::compiler::ParsedInvocation::NonCacheable { .. } => None,
+    };
+    if let Some(found) = time_macro_use {
+        let bypass_compiler: NormalizedPath = compiler_path.into();
+        state.stats.record_compilation();
+        state.stats.record_non_cacheable();
+        record_session_stat(&state.sessions, &sid, |t| t.record_non_cacheable());
+        write_session_log(
+            &state.sessions,
+            &sid,
+            &format!(
+                "non-cacheable: {} in {}",
+                found.macro_name,
+                found.input_file.display()
+            ),
+        );
+        warn_time_macro_uncacheable(&found);
+        return run_compiler_direct(
+            &bypass_compiler,
+            args,
+            cwd,
+            &state.sessions,
+            &sid,
+            &client_env,
+            &stdin,
+            state.depfile_tmpdir.as_path(),
+        )
+        .await;
+    }
 
     // Snap the journal clock once so all file hashes in this request see a
     // consistent view (avoids per-file current_clock() syscalls).
@@ -229,6 +274,30 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         &state.compiler_hash_cache,
     )
     .await;
+    let native_cpu_family = match &build_result {
+        BuildContextResult::Cc { ctx, .. } => ctx
+            .flags
+            .iter()
+            .chain(&ctx.unknown_flags)
+            .any(|flag| crate::depgraph::native_cpu::is_cxx_native_cpu_flag(flag))
+            .then_some("cxx"),
+        BuildContextResult::Rustc { rustc_ctx, .. } => rustc_ctx
+            .codegen_flags
+            .iter()
+            .any(|flag| crate::depgraph::native_cpu::is_rustc_native_cpu_flag(flag))
+            .then_some("rustc"),
+    };
+    if let Some(compiler_family) = native_cpu_family {
+        tracing::info!(
+            event = "native_flag_host_salted",
+            compiler_family,
+            "native CPU selection makes this compile key host-specific"
+        );
+        crate::core::lifecycle::write_event(
+            crate::core::lifecycle::EVENT_NATIVE_FLAG_HOST_SALTED,
+            serde_json::json!({ "compiler_family": compiler_family }),
+        );
+    }
     let default_key_root = worktree_root.clone().unwrap_or_else(|| cwd_path.clone());
     // Issue #474: PCH (output ends in .pch / .gch) and MSVC compiles must
     // get a per-worktree cache key — the compiler embeds absolute paths in
@@ -252,8 +321,13 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     // captured paths look. `requires_worktree_in_key` is the single source
     // of truth — we mirror it here into both the context-key salt and the
     // request-cache `worktree_bound` flag so the two cache layers agree.
-    let worktree_bound = requires_worktree_in_key(compilation.family, source_mode_for_key);
-    let worktree_salt = if worktree_root.is_some() && worktree_bound {
+    let worktree_bound = cc_requires_worktree_salt(
+        compilation.family,
+        source_mode_for_key,
+        &effective_args,
+        default_key_root.as_path(),
+    );
+    let worktree_salt = if worktree_bound {
         Some(default_key_root.as_path())
     } else {
         None

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/time_macros.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/time_macros.rs
@@ -1,0 +1,246 @@
+//! Detect C/C++ time macros that make otherwise-identical compiles unstable.
+//!
+//! `__DATE__`, `__TIME__`, and `__TIMESTAMP__` are expanded by the
+//! preprocessor at compile time.  Their spelling is part of the source hash,
+//! but the expansion is not, so serving an artifact from a previous compile
+//! would freeze its timestamp.  Keep those translation units out of every
+//! compile cache layer unless/when an explicit sloppiness mode is introduced.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+
+use zccache_core::NormalizedPath;
+
+const TIME_MACROS: [&[u8]; 3] = [b"__DATE__", b"__TIME__", b"__TIMESTAMP__"];
+
+/// The first time-macro use seen for each translation unit is logged loudly.
+///
+/// This is process-local on purpose: the warning tells an operator why a
+/// particular daemon is bypassing the cache without turning a normal build
+/// with several includes into a warning flood.
+static WARNED_TRANSLATION_UNITS: OnceLock<Mutex<HashSet<NormalizedPath>>> = OnceLock::new();
+
+/// A detected time macro and the input file that contains it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct TimeMacroUse {
+    pub(super) source_file: NormalizedPath,
+    pub(super) input_file: NormalizedPath,
+    pub(super) macro_name: &'static str,
+}
+
+/// Scan a C/C++ compilation's source and force-included text inputs.
+///
+/// This must run before the request-level cache lookup.  Checking after a
+/// fast hit would still allow an existing timestamp-bearing artifact to be
+/// replayed.  Files that are not UTF-8 text (notably binary PCH inputs) are
+/// intentionally ignored: their tokens cannot be newly expanded during this
+/// preprocessing pass.
+pub(super) fn find_time_macro_use(
+    compilation: &crate::compiler::CacheableCompilation,
+    cwd: &Path,
+) -> Option<TimeMacroUse> {
+    if !matches!(
+        compilation.family,
+        crate::compiler::CompilerFamily::Gcc
+            | crate::compiler::CompilerFamily::Clang
+            | crate::compiler::CompilerFamily::Msvc
+    ) {
+        return None;
+    }
+
+    let source_file = absolute_path(&compilation.source_file, cwd);
+    let mut inputs = vec![source_file.clone()];
+    let parsed = if compilation.family == crate::compiler::CompilerFamily::Msvc
+        || crate::compiler::parse_msvc::looks_like_msvc_args(&compilation.original_args)
+    {
+        crate::depgraph::msvc_args::parse_msvc_args(&compilation.original_args, cwd)
+    } else {
+        crate::depgraph::args::parse_gnu_args(&compilation.original_args, cwd)
+    };
+    inputs.extend(parsed.force_includes);
+
+    let mut seen = HashSet::new();
+    for input_file in inputs {
+        if !seen.insert(input_file.clone()) {
+            continue;
+        }
+        if let Some(macro_name) = find_time_macro_in_file(&input_file) {
+            return Some(TimeMacroUse {
+                source_file,
+                input_file,
+                macro_name,
+            });
+        }
+    }
+    None
+}
+
+/// Emit the once-per-translation-unit diagnostic for a cache bypass.
+pub(super) fn warn_time_macro_uncacheable(found: &TimeMacroUse) {
+    let warned = WARNED_TRANSLATION_UNITS.get_or_init(|| Mutex::new(HashSet::new()));
+    let Ok(mut warned) = warned.lock() else {
+        // Poisoning a diagnostic-only mutex must not change compilation
+        // correctness.  The cache bypass already happened.
+        return;
+    };
+    if !warned.insert(found.source_file.clone()) {
+        return;
+    }
+    tracing::warn!(
+        event = "time_macro_noncacheable",
+        source = %found.source_file.display(),
+        input = %found.input_file.display(),
+        macro_name = found.macro_name,
+        "bypassing compile cache because a C/C++ time macro has a nondeterministic expansion"
+    );
+    crate::core::lifecycle::write_event(
+        crate::core::lifecycle::EVENT_TIME_MACRO_NONCACHEABLE,
+        serde_json::json!({
+            "source": found.source_file.display().to_string(),
+            "input": found.input_file.display().to_string(),
+            "macro_name": found.macro_name,
+        }),
+    );
+}
+
+fn absolute_path(path: &NormalizedPath, cwd: &Path) -> NormalizedPath {
+    if path.is_absolute() {
+        path.clone()
+    } else {
+        cwd.join(path).into()
+    }
+}
+
+fn find_time_macro_in_file(path: &Path) -> Option<&'static str> {
+    let bytes = std::fs::read(path).ok()?;
+    let text = std::str::from_utf8(&bytes).ok()?;
+    find_time_macro_in_text(text)
+}
+
+/// Return a macro that appears as a preprocessor token, not in a comment or
+/// ordinary string/character literal.  This deliberately stays a small lexer
+/// rather than trying to parse C++: macro expansion happens before C++ syntax
+/// matters, and raw strings are handled as opaque literals.
+fn find_time_macro_in_text(text: &str) -> Option<&'static str> {
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                i += 2;
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i = (i + 2).min(bytes.len());
+            }
+            b'"' => i = skip_quoted(bytes, i, b'"'),
+            b'\'' => i = skip_quoted(bytes, i, b'\''),
+            b'R' if bytes.get(i + 1) == Some(&b'"') => i = skip_raw_string(bytes, i),
+            _ => {
+                for macro_bytes in TIME_MACROS {
+                    if is_identifier_at(bytes, i, macro_bytes) {
+                        return match macro_bytes {
+                            b"__DATE__" => Some("__DATE__"),
+                            b"__TIME__" => Some("__TIME__"),
+                            b"__TIMESTAMP__" => Some("__TIMESTAMP__"),
+                            _ => None,
+                        };
+                    }
+                }
+                i += 1;
+            }
+        }
+    }
+    None
+}
+
+fn skip_quoted(bytes: &[u8], start: usize, quote: u8) -> usize {
+    let mut i = start + 1;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' {
+            i += 2;
+        } else if bytes[i] == quote {
+            return i + 1;
+        } else {
+            i += 1;
+        }
+    }
+    bytes.len()
+}
+
+fn skip_raw_string(bytes: &[u8], start: usize) -> usize {
+    let delimiter_start = start + 2;
+    let Some(open_paren) = bytes[delimiter_start..]
+        .iter()
+        .position(|byte| *byte == b'(')
+    else {
+        return start + 1;
+    };
+    let open_paren = delimiter_start + open_paren;
+    // C++ limits raw-string delimiters to 16 characters.  Anything longer is
+    // not a raw literal, so resume normal token scanning at the R.
+    if open_paren - delimiter_start > 16 {
+        return start + 1;
+    }
+    let mut terminator = Vec::with_capacity(open_paren - delimiter_start + 2);
+    terminator.push(b')');
+    terminator.extend_from_slice(&bytes[delimiter_start..open_paren]);
+    terminator.push(b'"');
+    let content = &bytes[open_paren + 1..];
+    content
+        .windows(terminator.len())
+        .position(|window| window == terminator.as_slice())
+        .map_or(bytes.len(), |offset| {
+            open_paren + 1 + offset + terminator.len()
+        })
+}
+
+fn is_identifier_at(bytes: &[u8], start: usize, needle: &[u8]) -> bool {
+    bytes.get(start..start + needle.len()) == Some(needle)
+        && !bytes
+            .get(start.wrapping_sub(1))
+            .is_some_and(|byte| is_identifier_byte(*byte))
+        && !bytes
+            .get(start + needle.len())
+            .is_some_and(|byte| is_identifier_byte(*byte))
+}
+
+fn is_identifier_byte(byte: u8) -> bool {
+    byte == b'_' || byte.is_ascii_alphanumeric()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_time_macros_as_tokens() {
+        for macro_name in ["__DATE__", "__TIME__", "__TIMESTAMP__"] {
+            assert_eq!(
+                find_time_macro_in_text(&format!("int x = {macro_name};")),
+                Some(macro_name)
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_non_expanding_text() {
+        for text in [
+            "// __DATE__\nint x;",
+            "/* __TIME__ */ int x;",
+            "const char *s = \"__TIMESTAMP__\";",
+            "const char c = '__DATE__'[0];",
+            "const char *s = R\"tag(__DATE__)tag\";",
+            "int __DATE__suffix = 0;",
+        ] {
+            assert_eq!(find_time_macro_in_text(text), None, "{text}");
+        }
+    }
+}

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -87,7 +87,12 @@ fn check_unit_cache(
     } else {
         crate::compiler::SourceMode::Normal
     };
-    let worktree_salt = if requires_worktree_in_key(compilation.family, source_mode_for_key) {
+    let worktree_salt = if cc_requires_worktree_salt(
+        compilation.family,
+        source_mode_for_key,
+        &compilation.original_args,
+        key_root.as_path(),
+    ) {
         Some(key_root.as_path())
     } else {
         None

--- a/crates/zccache-daemon-core/src/daemon/server/keys.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/keys.rs
@@ -231,6 +231,45 @@ pub fn requires_worktree_in_key(
     matches!(family, CompilerFamily::Msvc) || matches!(source_mode, SourceMode::Header)
 }
 
+/// Returns whether the effective C/C++ command line remaps every path-bearing
+/// output channel from `root`.
+///
+/// `-ffile-prefix-map` covers source and file paths on current compilers, but
+/// it is not sufficient by itself for portable cache sharing: older clang and
+/// some GCC releases require the explicit macro and debug variants too. A
+/// partial user map therefore remains worktree-bound rather than allowing an
+/// artifact with an absolute checkout path to cross a checkout boundary.
+pub(super) fn cc_prefix_maps_cover_root(args: &[String], root: &Path) -> bool {
+    [
+        "-ffile-prefix-map",
+        "-fmacro-prefix-map",
+        "-fdebug-prefix-map",
+    ]
+    .iter()
+    .all(|flag| has_cc_prefix_map_for_old(args, flag, root))
+}
+
+/// Returns whether a C/C++ context needs a stable checkout-specific salt.
+///
+/// Artifacts that cannot be scrubbed are always worktree-bound (PCH/GCH and
+/// MSVC). For ordinary clang/GCC compilations, sharing is permitted only
+/// after the effective argv proves that file, macro, and debug path remapping
+/// all cover the checkout root. Without that proof, retaining the root in the
+/// context key is the safe outcome: identical sources in two clones get
+/// distinct keys instead of replaying absolute paths from the first clone.
+pub(super) fn cc_requires_worktree_salt(
+    family: crate::compiler::CompilerFamily,
+    source_mode: crate::compiler::SourceMode,
+    args: &[String],
+    root: &Path,
+) -> bool {
+    use crate::compiler::CompilerFamily;
+
+    requires_worktree_in_key(family, source_mode)
+        || matches!(family, CompilerFamily::Gcc | CompilerFamily::Clang)
+            && !cc_prefix_maps_cover_root(args, root)
+}
+
 pub(super) fn request_key_root(
     compiler_path: &Path,
     args: &[String],

--- a/crates/zccache-daemon-core/src/daemon/server/tests/path_remap.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/path_remap.rs
@@ -268,6 +268,63 @@ fn requires_worktree_in_key_false_for_rustc() {
     ));
 }
 
+#[test]
+fn normal_clang_without_prefix_maps_requires_worktree_salt() {
+    let root = Path::new("/repo/worktree-a");
+    let args = vec!["-c".to_string(), "src/main.cpp".to_string()];
+
+    assert!(cc_requires_worktree_salt(
+        CompilerFamily::Clang,
+        SourceMode::Normal,
+        &args,
+        root,
+    ));
+}
+
+#[test]
+fn rustc_keeps_its_existing_remap_gate() {
+    let root = Path::new("/repo/worktree-a");
+    assert!(!cc_requires_worktree_salt(
+        CompilerFamily::Rustc,
+        SourceMode::Normal,
+        &[],
+        root,
+    ));
+}
+
+#[test]
+fn normal_clang_with_complete_prefix_maps_can_share() {
+    let root = Path::new("/repo/worktree-a");
+    let args = [
+        "-ffile-prefix-map",
+        "-fmacro-prefix-map",
+        "-fdebug-prefix-map",
+    ]
+    .into_iter()
+    .map(|flag| format!("{flag}={}=.", root.display()))
+    .collect::<Vec<_>>();
+
+    assert!(!cc_requires_worktree_salt(
+        CompilerFamily::Clang,
+        SourceMode::Normal,
+        &args,
+        root,
+    ));
+}
+
+#[test]
+fn partial_prefix_mapping_remains_worktree_bound() {
+    let root = Path::new("/repo/worktree-a");
+    let args = vec![format!("-ffile-prefix-map={}=.", root.display())];
+
+    assert!(cc_requires_worktree_salt(
+        CompilerFamily::Gcc,
+        SourceMode::Normal,
+        &args,
+        root,
+    ));
+}
+
 // ── Piece B: `compute_context_key` worktree-salt behaviour ─────────────────
 //
 // The salt lives on the context key (not the artifact key) so all artifact

--- a/crates/zccache-depgraph/src/args.rs
+++ b/crates/zccache-depgraph/src/args.rs
@@ -3,7 +3,7 @@
 //! Extracts include paths, defines, and cache-relevant flags from
 //! compiler command-line arguments.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::search_paths::IncludeSearchPaths;
 use zccache_compiler::gnu_flag_takes_value;
@@ -215,6 +215,20 @@ pub fn parse_gnu_args(args: &[String], cwd: &Path) -> ParsedArgs {
         }
 
         // Cache-relevant flags.
+        //
+        // PGO profile data is a non-argv compiler input. Keep the raw flag in
+        // the context key and feed its referenced file(s) through the same
+        // content-hashed path as `-include`: changing a `.profdata` / `.gcda`
+        // file in place must produce a new artifact key.
+        if let Some(path) = arg
+            .strip_prefix("-fprofile-use=")
+            .or_else(|| arg.strip_prefix("-fprofile-dir="))
+        {
+            result.flags.push(arg.clone());
+            result.force_includes.extend(profile_input_files(path, cwd));
+            i += 1;
+            continue;
+        }
         if arg.starts_with("-std=") || arg.starts_with("--std=") {
             result.flags.push(arg.clone());
             i += 1;
@@ -239,6 +253,18 @@ pub fn parse_gnu_args(args: &[String], cwd: &Path) -> ParsedArgs {
             result.flags.push(arg.clone());
             i += 1;
             continue;
+        }
+
+        // Exact GNU flags with a separate value must be recognized before
+        // the broad `-m*` / `-f*` branches below. In particular,
+        // `-march native` is host-dependent just like `-march=native`, so
+        // preserve the pair as one canonical cache-key flag.
+        if matches!(arg.as_str(), "-march" | "-mtune" | "-mcpu") {
+            if let Some(next) = args.get(i + 1) {
+                result.flags.push(format!("{arg}={next}"));
+                i += 2;
+                continue;
+            }
         }
 
         // Optimization, target, feature flags.
@@ -415,6 +441,54 @@ fn resolve_path(path: &str, cwd: &Path) -> NormalizedPath {
     }
 }
 
+/// Return the regular profile-data files rooted at `path`.
+///
+/// `-fprofile-use=<file>` commonly names a Clang `.profdata` file, while
+/// GCC's `-fprofile-use=<dir>` / `-fprofile-dir=<dir>` forms name a directory
+/// of `.gcda` files. The depgraph's established force-include input path
+/// content-hashes every returned file on both update and hit checks, so PGO
+/// data regenerated at the same pathname cannot serve a stale object.
+///
+/// A nonexistent or non-file root is retained as a single input. That makes
+/// the hash lookup fail and safely keeps the context cold rather than treating
+/// an unavailable profile input as irrelevant.
+fn profile_input_files(path: &str, cwd: &Path) -> Vec<NormalizedPath> {
+    let root = resolve_path(path, cwd);
+    let root_path = root.as_path();
+    if root_path.is_file() {
+        return vec![root];
+    }
+    if !root_path.is_dir() {
+        return vec![root];
+    }
+
+    fn visit(dir: &Path, files: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                files.push(path);
+            } else if path.is_dir() {
+                visit(&path, files);
+            }
+        }
+    }
+
+    let mut files = Vec::new();
+    visit(root_path, &mut files);
+    files.sort();
+    if files.is_empty() {
+        // An empty profile directory is not an input file yet. Retaining the
+        // directory itself makes the compilation cold instead of incorrectly
+        // treating `-fprofile-use` as cacheable without profile data.
+        vec![root]
+    } else {
+        files.into_iter().map(NormalizedPath::new).collect()
+    }
+}
+
 fn is_source_file(path: &Path) -> bool {
     let ext = path
         .extension()
@@ -430,6 +504,9 @@ fn is_source_file(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::context::compute_artifact_key;
+    use crate::CompileContext;
+    use tempfile::tempdir;
     use zccache_compiler::GNU_FLAGS_WITH_VALUE;
 
     fn args(s: &[&str]) -> Vec<String> {
@@ -517,6 +594,84 @@ mod tests {
     fn force_include() {
         let parsed = parse_gnu_args(&args(&["-include", "pch.h", "-c", "x.c"]), Path::new("/p"));
         assert_eq!(parsed.force_includes, vec![Path::new("/p/pch.h")]);
+    }
+
+    #[test]
+    fn profile_use_file_is_content_hashed_input() {
+        let temp = tempdir().expect("temp profile directory");
+        let source = temp.path().join("unit.c");
+        let profile = temp.path().join("unit.profdata");
+        std::fs::write(&source, "int unit(void) { return 1; }").expect("write source");
+        std::fs::write(&profile, "profile one").expect("write profile");
+
+        let parsed = parse_gnu_args(
+            &args(&[
+                &format!("-fprofile-use={}", profile.display()),
+                "-c",
+                &source.to_string_lossy(),
+            ]),
+            temp.path(),
+        );
+        assert_eq!(parsed.force_includes, vec![profile.as_path()]);
+        assert!(parsed
+            .flags
+            .contains(&format!("-fprofile-use={}", profile.display())));
+
+        let context = CompileContext::from_parsed_args(
+            parsed,
+            zccache_hash::hash_bytes(b"profile-test-compiler"),
+        );
+        let context_key = context.context_key();
+        let source_hash = zccache_hash::hash_file(&source).expect("hash source");
+        let first_profile_hash = zccache_hash::hash_file(&profile).expect("hash first profile");
+        let first = compute_artifact_key(
+            &context_key,
+            &mut [
+                (context.source_file.clone(), source_hash),
+                (context.force_includes[0].clone(), first_profile_hash),
+            ],
+            None,
+        );
+
+        std::fs::write(&profile, "profile two").expect("rewrite profile");
+        let second_profile_hash = zccache_hash::hash_file(&profile).expect("hash second profile");
+        let second = compute_artifact_key(
+            &context_key,
+            &mut [
+                (context.source_file.clone(), source_hash),
+                (context.force_includes[0].clone(), second_profile_hash),
+            ],
+            None,
+        );
+        assert_ne!(
+            first, second,
+            "profile content must change the artifact key"
+        );
+    }
+
+    #[test]
+    fn profile_dir_recursively_discovers_gcc_profile_inputs() {
+        let temp = tempdir().expect("temp profile directory");
+        let profile_dir = temp.path().join("profiles");
+        let nested = profile_dir.join("nested");
+        std::fs::create_dir_all(&nested).expect("create nested profile directory");
+        let first = profile_dir.join("first.gcda");
+        let second = nested.join("second.gcda");
+        std::fs::write(&first, "one").expect("write first profile");
+        std::fs::write(&second, "two").expect("write second profile");
+
+        let parsed = parse_gnu_args(
+            &args(&[
+                &format!("-fprofile-dir={}", profile_dir.display()),
+                "-c",
+                "unit.c",
+            ]),
+            temp.path(),
+        );
+        assert_eq!(
+            parsed.force_includes,
+            vec![first.as_path(), second.as_path()]
+        );
     }
 
     #[test]

--- a/crates/zccache-depgraph/src/context/mod.rs
+++ b/crates/zccache-depgraph/src/context/mod.rs
@@ -18,6 +18,7 @@ use zccache_core::NormalizedPath;
 use zccache_hash::ContentHash;
 
 use super::args::ParsedArgs;
+use super::native_cpu::{host_cpu_identity_salt, is_cxx_native_cpu_flag, is_rustc_native_cpu_flag};
 use super::rustc_args::RustcParsedArgs;
 use super::search_paths::IncludeSearchPaths;
 
@@ -224,7 +225,7 @@ pub fn compute_context_key(
     key_root: Option<&Path>,
     worktree_salt: Option<&Path>,
 ) -> ContextKey {
-    compute_context_key_with(ctx, key_root, worktree_salt, |path, root| {
+    compute_context_key_with_native_cpu_salt(ctx, key_root, worktree_salt, None, |path, root| {
         normalize_key_path(path, root).into()
     })
 }
@@ -245,6 +246,26 @@ pub fn compute_context_key_with<F>(
     ctx: &CompileContext,
     key_root: Option<&Path>,
     worktree_salt: Option<&Path>,
+    normalize: F,
+) -> ContextKey
+where
+    F: FnMut(&Path, Option<&Path>) -> Arc<str>,
+{
+    compute_context_key_with_native_cpu_salt(ctx, key_root, worktree_salt, None, normalize)
+}
+
+/// Variant of [`compute_context_key_with`] with an injectable opaque host-CPU
+/// salt for `-march=native`-style invocations.
+///
+/// Production callers pass `None`, which obtains the current host's stable
+/// salt. Tests and embedding applications can supply a synthetic salt to prove
+/// cross-host behavior without depending on the CPU that runs the test.
+#[must_use]
+pub fn compute_context_key_with_native_cpu_salt<F>(
+    ctx: &CompileContext,
+    key_root: Option<&Path>,
+    worktree_salt: Option<&Path>,
+    native_cpu_salt: Option<&str>,
     mut normalize: F,
 ) -> ContextKey
 where
@@ -260,6 +281,21 @@ where
     hasher.update(b"compiler\0");
     hasher.update(ctx.compiler_hash.as_bytes());
     hasher.update(b"\0");
+
+    if ctx
+        .flags
+        .iter()
+        .chain(&ctx.unknown_flags)
+        .any(|flag| is_cxx_native_cpu_flag(flag))
+    {
+        let salt = match native_cpu_salt {
+            Some(salt) => salt,
+            None => host_cpu_identity_salt(),
+        };
+        hasher.update(b"native-cpu-host\0");
+        hasher.update(salt.as_bytes());
+        hasher.update(b"\0");
+    }
 
     if let Some(salt) = worktree_salt {
         // Domain-tagged so the salt can't collide with any future hash
@@ -627,7 +663,7 @@ impl RustcCompileContext {
     /// Uses a different domain tag from C/C++ to avoid collisions.
     #[must_use]
     pub fn context_key(&self) -> ContextKey {
-        self.context_key_with_root(None)
+        self.context_key_with_root_and_native_cpu_salt(None, None)
     }
 
     /// Compute the context key, optionally normalizing project-local paths.
@@ -637,6 +673,20 @@ impl RustcCompileContext {
     /// workspaces can share cache keys across root-directory renames.
     #[must_use]
     pub fn context_key_with_root(&self, key_root: Option<&Path>) -> ContextKey {
+        self.context_key_with_root_and_native_cpu_salt(key_root, None)
+    }
+
+    /// Computes a context key with an injectable opaque native-CPU salt.
+    ///
+    /// A salt is folded in only for `-C target-cpu=native` (or the defensive
+    /// `target-feature=native` spelling), so explicit portable feature lists
+    /// retain their ordinary cross-host reuse behavior.
+    #[must_use]
+    pub fn context_key_with_root_and_native_cpu_salt(
+        &self,
+        key_root: Option<&Path>,
+        native_cpu_salt: Option<&str>,
+    ) -> ContextKey {
         let mut hasher = blake3::Hasher::new();
 
         hasher.update(b"zccache-rustc-context-key-v2\0");
@@ -646,6 +696,20 @@ impl RustcCompileContext {
         hasher.update(b"compiler\0");
         hasher.update(self.compiler_hash.as_bytes());
         hasher.update(b"\0");
+
+        if self
+            .codegen_flags
+            .iter()
+            .any(|flag| is_rustc_native_cpu_flag(flag))
+        {
+            let salt = match native_cpu_salt {
+                Some(salt) => salt,
+                None => host_cpu_identity_salt(),
+            };
+            hasher.update(b"native-cpu-host\0");
+            hasher.update(salt.as_bytes());
+            hasher.update(b"\0");
+        }
 
         // Source file.
         let source_file = normalize_key_path(&self.source_file, key_root);
@@ -817,6 +881,17 @@ impl RustcCompileContext {
         &self,
         key_root: Option<&Path>,
     ) -> Option<ContextKey> {
+        self.check_metadata_compat_key_with_root_and_native_cpu_salt(key_root, None)
+    }
+
+    /// Native-CPU-salt-injectable variant of
+    /// [`Self::check_metadata_compat_key_with_root`].
+    #[must_use]
+    pub fn check_metadata_compat_key_with_root_and_native_cpu_salt(
+        &self,
+        key_root: Option<&Path>,
+        native_cpu_salt: Option<&str>,
+    ) -> Option<ContextKey> {
         let normalized_emit = normalized_check_metadata_emit(&self.emit_types)?;
         if self.crate_types.iter().any(|ct| {
             matches!(
@@ -835,6 +910,20 @@ impl RustcCompileContext {
         hasher.update(b"compiler\0");
         hasher.update(self.compiler_hash.as_bytes());
         hasher.update(b"\0");
+
+        if self
+            .codegen_flags
+            .iter()
+            .any(|flag| is_rustc_native_cpu_flag(flag))
+        {
+            let salt = match native_cpu_salt {
+                Some(salt) => salt,
+                None => host_cpu_identity_salt(),
+            };
+            hasher.update(b"native-cpu-host\0");
+            hasher.update(salt.as_bytes());
+            hasher.update(b"\0");
+        }
 
         let source_file = normalize_key_path(&self.source_file, key_root);
         hasher.update(source_file.as_bytes());

--- a/crates/zccache-depgraph/src/context/tests/cc.rs
+++ b/crates/zccache-depgraph/src/context/tests/cc.rs
@@ -10,7 +10,7 @@ use zccache_core::NormalizedPath;
 use super::super::{
     compute_artifact_key, compute_artifact_key_normalized_inplace,
     compute_artifact_key_normalized_with_root, compute_artifact_key_with, compute_context_key,
-    CompileContext,
+    compute_context_key_with_native_cpu_salt, normalize_key_path, CompileContext,
 };
 use super::make_context;
 
@@ -344,6 +344,76 @@ fn different_flags_different_key() {
     let mut ctx2 = make_context("/src/a.c", &[], &[]);
     ctx2.flags = vec!["-std=c++20".into()];
     assert_ne!(ctx1.context_key(), ctx2.context_key());
+}
+
+/// Issue #1174: `native` is a host-dependent compiler expansion, not a
+/// portable literal cache input. Synthetic identities make the cross-host
+/// contract executable on every test runner.
+#[test]
+fn cxx_native_cpu_flags_are_host_salted() {
+    for native_flag in ["-march=native", "-mtune=native", "-mcpu=native"] {
+        let mut ctx = make_context("/src/a.c", &[], &[]);
+        ctx.flags = vec![native_flag.to_string()];
+
+        let host_a = compute_context_key_with_native_cpu_salt(
+            &ctx,
+            None,
+            None,
+            Some("synthetic-host-a-avx2"),
+            |path, root| normalize_key_path(path, root).into(),
+        );
+        let host_a_again = compute_context_key_with_native_cpu_salt(
+            &ctx,
+            None,
+            None,
+            Some("synthetic-host-a-avx2"),
+            |path, root| normalize_key_path(path, root).into(),
+        );
+        let host_b = compute_context_key_with_native_cpu_salt(
+            &ctx,
+            None,
+            None,
+            Some("synthetic-host-b-sse2"),
+            |path, root| normalize_key_path(path, root).into(),
+        );
+
+        assert_eq!(
+            host_a, host_a_again,
+            "{native_flag} must be stable on one host"
+        );
+        assert_ne!(host_a, host_b, "{native_flag} must not share across hosts");
+    }
+}
+
+#[test]
+fn cxx_explicit_cpu_flags_are_not_host_salted() {
+    let mut ctx = make_context("/src/a.c", &[], &[]);
+    ctx.flags = vec!["-march=x86-64-v3".to_string()];
+    let host_a =
+        compute_context_key_with_native_cpu_salt(&ctx, None, None, Some("host-a"), |p, r| {
+            normalize_key_path(p, r).into()
+        });
+    let host_b =
+        compute_context_key_with_native_cpu_salt(&ctx, None, None, Some("host-b"), |p, r| {
+            normalize_key_path(p, r).into()
+        });
+    assert_eq!(host_a, host_b);
+}
+
+#[test]
+fn separated_native_cxx_cpu_flags_are_preserved_for_host_salting() {
+    for flag in ["-march", "-mtune", "-mcpu"] {
+        let parsed = parse_gnu_args(
+            &[
+                flag.to_string(),
+                "native".to_string(),
+                "-c".to_string(),
+                "src/main.c".to_string(),
+            ],
+            Path::new("/work"),
+        );
+        assert_eq!(parsed.flags, vec![format!("{flag}=native")]);
+    }
 }
 
 /// Issue #1173: value-taking GNU flags must not discard their value while

--- a/crates/zccache-depgraph/src/context/tests/rustc.rs
+++ b/crates/zccache-depgraph/src/context/tests/rustc.rs
@@ -194,6 +194,30 @@ fn rustc_different_codegen_different_key() {
     assert_ne!(ctx1.context_key(), ctx2.context_key());
 }
 
+/// Issue #1174: `target-cpu=native` resolves against the host. An injectable
+/// salt proves that two different synthetic hosts cannot share its key.
+#[test]
+fn rustc_native_cpu_is_host_salted() {
+    let mut ctx = make_rustc_context("/src/lib.rs", "2021");
+    ctx.codegen_flags = vec!["target-cpu=native".to_string()];
+    let host_a = ctx.context_key_with_root_and_native_cpu_salt(None, Some("host-a-avx2"));
+    let host_a_again = ctx.context_key_with_root_and_native_cpu_salt(None, Some("host-a-avx2"));
+    let host_b = ctx.context_key_with_root_and_native_cpu_salt(None, Some("host-b-sse2"));
+
+    assert_eq!(host_a, host_a_again);
+    assert_ne!(host_a, host_b);
+}
+
+#[test]
+fn rustc_explicit_target_cpu_is_not_host_salted() {
+    let mut ctx = make_rustc_context("/src/lib.rs", "2021");
+    ctx.codegen_flags = vec!["target-cpu=x86-64-v3".to_string()];
+    assert_eq!(
+        ctx.context_key_with_root_and_native_cpu_salt(None, Some("host-a")),
+        ctx.context_key_with_root_and_native_cpu_salt(None, Some("host-b"))
+    );
+}
+
 #[test]
 fn rustc_cargo_metadata_affects_key() {
     let mut ctx1 = make_rustc_context("/src/lib.rs", "2021");

--- a/crates/zccache-depgraph/src/lib.rs
+++ b/crates/zccache-depgraph/src/lib.rs
@@ -10,6 +10,7 @@ pub mod context;
 pub mod depfile;
 pub mod graph;
 pub mod msvc_args;
+pub mod native_cpu;
 pub mod rustc_args;
 pub mod scanner;
 pub mod search_paths;

--- a/crates/zccache-depgraph/src/native_cpu.rs
+++ b/crates/zccache-depgraph/src/native_cpu.rs
@@ -1,0 +1,144 @@
+//! Host identity handling for compiler `native` CPU selections.
+//!
+//! `-march=native` and rustc's `-C target-cpu=native` are instructions to
+//! expand the target from the *current host*, rather than stable command-line
+//! values. Cache keys must therefore not be portable across arbitrary hosts
+//! for an invocation that contains one. We deliberately salt such keys rather
+//! than rewriting compiler argv: rewriting would require reproducing each
+//! compiler's CPU expansion semantics and could change the actual compile.
+
+use std::sync::OnceLock;
+
+/// Returns the opaque, stable-on-this-host salt for `native` CPU selections.
+///
+/// The value is a hash, so machine-identifying inputs never enter a persisted
+/// compilation context or cache key in clear text. It combines a host-local
+/// identifier with architecture and observed CPU capabilities. If a platform
+/// cannot expose a host identifier, the process id is a fail-closed fallback:
+/// it gives up reuse after a daemon restart rather than allowing an unknown
+/// host to share a `native` artifact.
+#[must_use]
+pub fn host_cpu_identity_salt() -> &'static str {
+    static SALT: OnceLock<String> = OnceLock::new();
+    SALT.get_or_init(|| host_cpu_identity_salt_from(&host_cpu_identity_material()))
+}
+
+/// Hashes supplied host identity material into the key-safe salt.
+///
+/// This is public specifically to make cross-host key behavior testable
+/// without mocking global process state or relying on the test machine's CPU.
+#[must_use]
+pub fn host_cpu_identity_salt_from(identity: &str) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"zccache-native-cpu-host-v1\0");
+    hasher.update(identity.as_bytes());
+    hasher.finalize().to_hex().to_string()
+}
+
+/// Whether a C/C++ key flag asks the compiler to select CPU settings locally.
+#[must_use]
+pub fn is_cxx_native_cpu_flag(flag: &str) -> bool {
+    matches!(flag, "-march=native" | "-mtune=native" | "-mcpu=native")
+}
+
+/// Whether a rustc codegen setting asks rustc/LLVM to select the local CPU.
+#[must_use]
+pub fn is_rustc_native_cpu_flag(flag: &str) -> bool {
+    matches!(flag, "target-cpu=native" | "target-feature=native")
+}
+
+fn host_cpu_identity_material() -> String {
+    let mut material = format!(
+        "arch={}\0os={}",
+        std::env::consts::ARCH,
+        std::env::consts::OS
+    );
+
+    // Linux exposes a per-install machine id, which avoids sharing a native
+    // artifact even when two machines happen to report the same CPU model.
+    // Keep the raw value local: the caller hashes all material before it can
+    // become part of a cache key or snapshot.
+    #[cfg(target_os = "linux")]
+    if let Ok(machine_id) = std::fs::read_to_string("/etc/machine-id") {
+        let machine_id = machine_id.trim();
+        if !machine_id.is_empty() {
+            material.push_str("\0machine-id=");
+            material.push_str(machine_id);
+        }
+    }
+
+    // Windows normally provides COMPUTERNAME and Unix systems commonly expose
+    // HOSTNAME. This is intentionally only an additional discriminator; the
+    // identity is already domain-separated and opaque after hashing.
+    for variable in ["COMPUTERNAME", "HOSTNAME"] {
+        if let Some(value) = std::env::var_os(variable) {
+            material.push('\0');
+            material.push_str(variable);
+            material.push('=');
+            material.push_str(&value.to_string_lossy());
+        }
+    }
+
+    append_observed_cpu_features(&mut material);
+
+    // A host without an exposed identifier must never collapse into a common
+    // cross-host salt. PID costs only a restart hit in that rare fallback.
+    if !material.contains("machine-id=")
+        && !material.contains("COMPUTERNAME=")
+        && !material.contains("HOSTNAME=")
+    {
+        material.push_str("\0pid=");
+        material.push_str(&std::process::id().to_string());
+    }
+
+    material
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn append_observed_cpu_features(material: &mut String) {
+    for (name, present) in [
+        ("sse2", std::arch::is_x86_feature_detected!("sse2")),
+        ("sse4.2", std::arch::is_x86_feature_detected!("sse4.2")),
+        ("avx", std::arch::is_x86_feature_detected!("avx")),
+        ("avx2", std::arch::is_x86_feature_detected!("avx2")),
+        ("avx512f", std::arch::is_x86_feature_detected!("avx512f")),
+        ("fma", std::arch::is_x86_feature_detected!("fma")),
+        ("bmi1", std::arch::is_x86_feature_detected!("bmi1")),
+        ("bmi2", std::arch::is_x86_feature_detected!("bmi2")),
+    ] {
+        if present {
+            material.push_str("\0feature=");
+            material.push_str(name);
+        }
+    }
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn append_observed_cpu_features(_: &mut String) {}
+
+#[cfg(test)]
+mod tests {
+    use super::{host_cpu_identity_salt_from, is_cxx_native_cpu_flag, is_rustc_native_cpu_flag};
+
+    #[test]
+    fn synthetic_host_identity_is_stable_but_host_specific() {
+        assert_eq!(
+            host_cpu_identity_salt_from("host-a-avx2"),
+            host_cpu_identity_salt_from("host-a-avx2")
+        );
+        assert_ne!(
+            host_cpu_identity_salt_from("host-a-avx2"),
+            host_cpu_identity_salt_from("host-b-sse2")
+        );
+    }
+
+    #[test]
+    fn native_flag_detection_is_exact() {
+        for flag in ["-march=native", "-mtune=native", "-mcpu=native"] {
+            assert!(is_cxx_native_cpu_flag(flag));
+        }
+        assert!(!is_cxx_native_cpu_flag("-march=x86-64-v3"));
+        assert!(is_rustc_native_cpu_flag("target-cpu=native"));
+        assert!(!is_rustc_native_cpu_flag("target-feature=+avx2"));
+    }
+}


### PR DESCRIPTION
Fixes #1174.\n\n- Host-salt C/C++ and rustc native CPU selections.\n- Content-hash explicit PGO inputs; reject implicit profile use.\n- Bind C/C++ cross-worktree reuse to complete prefix-map coverage.\n- Bypass cache for source/force-include time macros and emit lifecycle diagnostics.