### PR TITLE
fix(cache): reject degenerate compiler probe results

### DIFF
--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -55,6 +55,7 @@
 //! | `embedded_flush_step_timeout` | daemon | one embedded flush/save step exceeded its shutdown budget | `step`, `timeout_ms`, `reason` |
 //! | `in_flight_exec_wait_timeout` | daemon | an exec-cache waiter stopped coalescing and ran its own copy | `key`, `budget_ms`, `reason` |
 //! | `rustc_identity_probe_timeout` | daemon | the rustc identity probe timed out and hashing fell back to file bytes | `compiler`, `timeout_ms`, `reason` |
+//! | `compiler_identity_fallback_flavor` | daemon | a rustc identity probe fell back to file bytes for one request; the fallback is not persisted | `compiler`, `compiler_family`, `reason` |
 //! | `staged_publication_failed` | daemon | a successful compile could not publish its staged generation | `reason`, `error`, `artifact_key` |
 //! | `cow_unregistered_blob_evicted` | daemon | an unregistered COW blob was rejected and removed | `blob_path`, `link_count` |
 //! | `cow_blob_corruption_detected` | daemon | a registered COW blob no longer matched its expected digest | blob/hash/link fields |
@@ -63,6 +64,7 @@
 //! | `miss_reason_unknown` | daemon | miss classification was not recognized (Phase 0 audit failure) | miss-specific fields |
 //! | `native_flag_host_salted` | daemon | a `native` CPU-selection flag made the compile key host-specific | `compiler_family` |
 //! | `time_macro_noncacheable` | daemon | a C/C++ time macro bypassed the compile cache | `source`, `input`, `macro_name` |
+//! | `system_include_discovery_empty` | daemon | a C/C++ include probe returned no paths, so its compile bypassed the cache | `compiler`, `reason` |
 //!
 //! ## Forensic walkthrough: the two-versions-on-one-pipe wedge
 //!
@@ -153,10 +155,12 @@ pub const EVENT_DIED_PRIVATE_OWNER_EXIT: &str = "died-private-owner-exit";
 pub const EVENT_EMBEDDED_FLUSH_STEP_TIMEOUT: &str = "embedded_flush_step_timeout";
 pub const EVENT_IN_FLIGHT_EXEC_WAIT_TIMEOUT: &str = "in_flight_exec_wait_timeout";
 pub const EVENT_RUSTC_IDENTITY_PROBE_TIMEOUT: &str = "rustc_identity_probe_timeout";
+pub const EVENT_COMPILER_IDENTITY_FALLBACK_FLAVOR: &str = "compiler_identity_fallback_flavor";
 pub const EVENT_COW_UNREGISTERED_BLOB_EVICTED: &str = "cow_unregistered_blob_evicted";
 pub const EVENT_COW_BLOB_CORRUPTION_DETECTED: &str = "cow_blob_corruption_detected";
 pub const EVENT_NATIVE_FLAG_HOST_SALTED: &str = "native_flag_host_salted";
 pub const EVENT_TIME_MACRO_NONCACHEABLE: &str = "time_macro_noncacheable";
+pub const EVENT_SYSTEM_INCLUDE_DISCOVERY_EMPTY: &str = "system_include_discovery_empty";
 
 /// Complete lifecycle-event catalog. Keep this additive and update the module
 /// schema table with every new event; log-audit and operator docs depend on it.
@@ -184,10 +188,12 @@ pub const EVENT_ALL: &[&str] = &[
     EVENT_EMBEDDED_FLUSH_STEP_TIMEOUT,
     EVENT_IN_FLIGHT_EXEC_WAIT_TIMEOUT,
     EVENT_RUSTC_IDENTITY_PROBE_TIMEOUT,
+    EVENT_COMPILER_IDENTITY_FALLBACK_FLAVOR,
     EVENT_COW_UNREGISTERED_BLOB_EVICTED,
     EVENT_COW_BLOB_CORRUPTION_DETECTED,
     EVENT_NATIVE_FLAG_HOST_SALTED,
     EVENT_TIME_MACRO_NONCACHEABLE,
+    EVENT_SYSTEM_INCLUDE_DISCOVERY_EMPTY,
     EVENT_LEGACY_ARTIFACT_PATH_ACCESSED,
     EVENT_DESTINATION_WRITE_FAILED,
     EVENT_MISS_REASON_UNKNOWN,

--- a/crates/zccache-daemon-core/src/daemon/server/compiler_hash.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/compiler_hash.rs
@@ -24,7 +24,7 @@ use std::io::Write as _;
 ///
 /// Bump on any layout change to the `Persisted*` types so the loader
 /// rejects older / newer snapshots instead of mis-decoding them.
-pub(super) const FORMAT_VERSION: u32 = 1;
+pub(super) const FORMAT_VERSION: u32 = 2;
 
 /// Env override (milliseconds) for the `<compiler> -vV` identity probe
 /// timeout. See [`rustc_probe_timeout`].
@@ -112,11 +112,24 @@ fn output_within(mut cmd: std::process::Command, timeout: std::time::Duration) -
     }
 }
 
+/// The provenance of a cached compiler identity.
+///
+/// A rustc `-vV` identity is the only rustc flavor that may survive a
+/// daemon restart. File-content fallbacks are intentionally ephemeral: a
+/// transient probe failure must not pin an otherwise healthy toolchain into
+/// a second cache-key space (#1167).
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) enum CompilerIdentityFlavor {
+    Generic,
+    RustcVv,
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub(super) struct CompilerHashEntry {
     pub(super) mtime: std::time::SystemTime,
     pub(super) size: u64,
     pub(super) hash: ContentHash,
+    pub(super) flavor: CompilerIdentityFlavor,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -187,8 +200,15 @@ impl CompilerHashCache {
             return Some(hash);
         }
 
-        self.entries
-            .insert(key, CompilerHashEntry { mtime, size, hash });
+        self.entries.insert(
+            key,
+            CompilerHashEntry {
+                mtime,
+                size,
+                hash,
+                flavor: CompilerIdentityFlavor::Generic,
+            },
+        );
         Some(hash)
     }
 
@@ -226,8 +246,132 @@ impl CompilerHashCache {
             return Some(hash);
         }
 
-        self.entries
-            .insert(key, CompilerHashEntry { mtime, size, hash });
+        self.entries.insert(
+            key,
+            CompilerHashEntry {
+                mtime,
+                size,
+                hash,
+                flavor: CompilerIdentityFlavor::Generic,
+            },
+        );
+        Some(hash)
+    }
+
+    /// Resolve a rustc identity while only caching a confirmed `-vV` result.
+    ///
+    /// A file hash is safe for the request that observed a failed or timed-out
+    /// probe, but caching it would make that transient outcome a durable cache
+    /// split. The persisted `RustcVv` flavor is therefore also a preference:
+    /// once a binary has produced a valid `-vV` result, restarts reuse that
+    /// result; a fallback is always retried on the next request.
+    pub(super) fn get_or_hash_rustc_with<F>(&self, path: &Path, hasher: F) -> Option<ContentHash>
+    where
+        F: FnOnce(&Path) -> Option<RustcIdentity>,
+    {
+        let metadata = std::fs::metadata(path).ok()?;
+        let mtime = metadata.modified().ok()?;
+        let size = metadata.len();
+        let key = NormalizedPath::new(path);
+
+        let previous = self.entries.get(&key).map(|entry| entry.clone());
+        if let Some(entry) = &previous {
+            if entry.mtime == mtime
+                && entry.size == size
+                && entry.flavor == CompilerIdentityFlavor::RustcVv
+            {
+                return Some(entry.hash);
+            }
+        }
+
+        let identity = hasher(path)?;
+        let hash = identity.hash();
+        if previous.is_some_and(|entry| {
+            entry.flavor == CompilerIdentityFlavor::RustcVv && entry.hash != hash
+        }) {
+            crate::daemon::compile_journal::record_miss_reason(
+                crate::daemon::compile_journal::miss_reason::VERSION_SKEW,
+            );
+        }
+        let post_metadata = std::fs::metadata(path).ok()?;
+        let post_mtime = post_metadata.modified().ok()?;
+        let post_size = post_metadata.len();
+        if post_mtime != mtime || post_size != size {
+            return Some(hash);
+        }
+
+        self.entries.insert(
+            key,
+            CompilerHashEntry {
+                mtime,
+                size,
+                hash,
+                flavor: if identity.is_verified_vv() {
+                    CompilerIdentityFlavor::RustcVv
+                } else {
+                    // Keep the fallback value stable for a broken/stub
+                    // compiler and across a restart, but never fast-hit it:
+                    // the `RustcVv`-only early return above retries `-vV`
+                    // on every request and upgrades this marker on success.
+                    CompilerIdentityFlavor::Generic
+                },
+            },
+        );
+        Some(hash)
+    }
+
+    pub(super) fn get_or_hash_rustc_identity(&self, path: &Path) -> Option<ContentHash> {
+        self.get_or_hash_rustc_with(path, rustc_identity)
+    }
+
+    pub(super) async fn get_or_hash_rustc_identity_async(
+        &self,
+        path: &Path,
+    ) -> Option<ContentHash> {
+        let metadata = std::fs::metadata(path).ok()?;
+        let mtime = metadata.modified().ok()?;
+        let size = metadata.len();
+        let key = NormalizedPath::new(path);
+
+        let previous = self.entries.get(&key).map(|entry| entry.clone());
+        if let Some(entry) = &previous {
+            if entry.mtime == mtime
+                && entry.size == size
+                && entry.flavor == CompilerIdentityFlavor::RustcVv
+            {
+                return Some(entry.hash);
+            }
+        }
+
+        let identity = rustc_identity_async(path.to_path_buf()).await?;
+        let hash = identity.hash();
+        if previous.is_some_and(|entry| {
+            entry.flavor == CompilerIdentityFlavor::RustcVv && entry.hash != hash
+        }) {
+            crate::daemon::compile_journal::record_miss_reason(
+                crate::daemon::compile_journal::miss_reason::VERSION_SKEW,
+            );
+        }
+        let post_metadata = std::fs::metadata(path).ok()?;
+        let post_mtime = post_metadata.modified().ok()?;
+        let post_size = post_metadata.len();
+        if post_mtime != mtime || post_size != size {
+            return Some(hash);
+        }
+
+        self.entries.insert(
+            key,
+            CompilerHashEntry {
+                mtime,
+                size,
+                hash,
+                flavor: if identity.is_verified_vv() {
+                    CompilerIdentityFlavor::RustcVv
+                } else {
+                    CompilerIdentityFlavor::Generic
+                },
+            },
+        );
         Some(hash)
     }
 
@@ -354,6 +498,107 @@ fn write_atomic_durable(tmp: &Path, target: &Path, bytes: &[u8]) -> std::io::Res
     Ok(())
 }
 
+/// A rustc identity together with whether it was proven by `-vV`.
+pub(super) enum RustcIdentity {
+    VerifiedVv(ContentHash),
+    FileFallback(ContentHash),
+}
+
+impl RustcIdentity {
+    fn hash(&self) -> ContentHash {
+        match self {
+            Self::VerifiedVv(hash) | Self::FileFallback(hash) => *hash,
+        }
+    }
+
+    fn is_verified_vv(&self) -> bool {
+        matches!(self, Self::VerifiedVv(_))
+    }
+}
+
+fn warn_rustc_identity_fallback(path: &Path, reason: &'static str) {
+    tracing::warn!(
+        event = "compiler_identity_fallback_flavor",
+        compiler = %path.display(),
+        compiler_family = "rustc",
+        reason,
+        "rustc identity probe did not yield `-vV`; using an uncached file-hash fallback for this request"
+    );
+    crate::core::lifecycle::write_event(
+        crate::core::lifecycle::EVENT_COMPILER_IDENTITY_FALLBACK_FLAVOR,
+        serde_json::json!({
+            "compiler": path.display().to_string(),
+            "compiler_family": "rustc",
+            "reason": reason,
+        }),
+    );
+}
+
+fn rustc_identity(path: &Path) -> Option<RustcIdentity> {
+    let mut cmd = std::process::Command::new(path);
+    cmd.arg("-vV");
+    crate::daemon::process::suppress_child_console(&mut cmd);
+    let timeout = rustc_probe_timeout();
+    match output_within(cmd, timeout) {
+        ProbeOutcome::Completed(output) if output.status.success() && !output.stdout.is_empty() => {
+            Some(RustcIdentity::VerifiedVv(crate::hash::hash_bytes(
+                &output.stdout,
+            )))
+        }
+        ProbeOutcome::TimedOut => {
+            warn_probe_timeout(path, timeout);
+            warn_rustc_identity_fallback(path, "probe_timeout");
+            crate::hash::hash_file(path)
+                .ok()
+                .map(RustcIdentity::FileFallback)
+        }
+        ProbeOutcome::SpawnFailed => {
+            warn_rustc_identity_fallback(path, "probe_spawn_failed");
+            crate::hash::hash_file(path)
+                .ok()
+                .map(RustcIdentity::FileFallback)
+        }
+        ProbeOutcome::Completed(_) => {
+            warn_rustc_identity_fallback(path, "probe_degenerate_output");
+            crate::hash::hash_file(path)
+                .ok()
+                .map(RustcIdentity::FileFallback)
+        }
+    }
+}
+
+async fn rustc_identity_async(path: std::path::PathBuf) -> Option<RustcIdentity> {
+    let mut cmd = tokio::process::Command::new(&path);
+    cmd.arg("-vV");
+    crate::daemon::process::suppress_child_console_tokio(&mut cmd);
+    cmd.kill_on_drop(true);
+    let timeout = rustc_probe_timeout();
+    match tokio::time::timeout(timeout, cmd.output()).await {
+        Ok(Ok(output)) if output.status.success() && !output.stdout.is_empty() => Some(
+            RustcIdentity::VerifiedVv(crate::hash::hash_bytes(&output.stdout)),
+        ),
+        Err(_) => {
+            warn_probe_timeout(&path, timeout);
+            warn_rustc_identity_fallback(&path, "probe_timeout");
+            crate::hash::hash_file(&path)
+                .ok()
+                .map(RustcIdentity::FileFallback)
+        }
+        Ok(Err(_)) => {
+            warn_rustc_identity_fallback(&path, "probe_spawn_failed");
+            crate::hash::hash_file(&path)
+                .ok()
+                .map(RustcIdentity::FileFallback)
+        }
+        Ok(Ok(_)) => {
+            warn_rustc_identity_fallback(&path, "probe_degenerate_output");
+            crate::hash::hash_file(&path)
+                .ok()
+                .map(RustcIdentity::FileFallback)
+        }
+    }
+}
+
 /// Compute a content hash that uniquely identifies a rustc /
 /// clippy-driver / rustfmt build, preferring `<compiler> -vV` output
 /// over a full blake3 over the binary. `-vV` prints the toolchain
@@ -364,6 +609,7 @@ fn write_atomic_durable(tmp: &Path, target: &Path, bytes: &[u8]) -> std::io::Res
 /// Falls back to the file-content hash on spawn failure, non-zero
 /// exit, or empty stdout so cache keys are still well-defined for
 /// stubbed binaries (unit tests) or broken toolchains.
+#[allow(dead_code)] // Direct helper retained for the identity-output unit test.
 pub(super) fn hash_rustc_identity(path: &Path) -> Option<ContentHash> {
     let mut cmd = std::process::Command::new(path);
     cmd.arg("-vV");
@@ -450,6 +696,7 @@ pub(super) async fn hash_cc_identity_async(path: std::path::PathBuf) -> Option<C
     }
 }
 
+#[allow(dead_code)] // The cache calls `rustc_identity_async` to retain provenance.
 pub(super) async fn hash_rustc_identity_async(path: std::path::PathBuf) -> Option<ContentHash> {
     let mut cmd = tokio::process::Command::new(&path);
     cmd.arg("-vV");

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -187,6 +187,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     let compiler_priority = CompilePriority::from_client_env(client_env.as_deref());
     let SystemIncludesOutcome {
         includes: system_includes,
+        empty_discovery,
         system_includes_ns,
         system_watch_ns,
     } = discover_system_includes(
@@ -197,6 +198,32 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         want_rust_miss_profile,
     )
     .await;
+
+    if empty_discovery {
+        // Issue #1167: an empty successful C/C++ probe is ambiguous, not an
+        // assertion that the compiler has no default includes. Do not build a
+        // context or artifact key from it; run this request directly and let
+        // the next request re-probe.
+        state.stats.record_compilation();
+        state.stats.record_non_cacheable();
+        record_session_stat(&state.sessions, &sid, |t| t.record_non_cacheable());
+        write_session_log(
+            &state.sessions,
+            &sid,
+            "non-cacheable: system include discovery returned zero paths",
+        );
+        return run_compiler_direct(
+            &compiler,
+            args,
+            cwd,
+            &state.sessions,
+            &sid,
+            &client_env,
+            &stdin,
+            state.depfile_tmpdir.as_path(),
+        )
+        .await;
+    }
 
     state.sessions.touch(&sid);
 

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/system_includes.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/system_includes.rs
@@ -27,6 +27,9 @@ const SYSTEM_INCLUDE_DISCOVERY_TIMEOUT: std::time::Duration = std::time::Duratio
 
 pub(super) struct SystemIncludesOutcome {
     pub(super) includes: Vec<NormalizedPath>,
+    /// A C/C++ probe ran but did not yield any include roots. This is an
+    /// unknown/degraded result, not proof that the compiler has no defaults.
+    pub(super) empty_discovery: bool,
     pub(super) system_includes_ns: u64,
     pub(super) system_watch_ns: u64,
 }
@@ -55,8 +58,8 @@ pub(super) async fn discover_system_includes(
     let t_system_includes = want_rust_miss_profile.then(std::time::Instant::now);
     let compiler_family = crate::compiler::detect_family(&compiler.to_string_lossy());
     let needs_discovery = compiler_family.needs_system_include_discovery();
-    let system_includes = if !needs_discovery {
-        Vec::new()
+    let (system_includes, empty_discovery) = if !needs_discovery {
+        (Vec::new(), false)
     } else {
         // Issue #541 option B: for the clang family the daemon prefers
         // `clang -###` discovery (~3-5 ms) over the slower `-v -E`
@@ -72,7 +75,7 @@ pub(super) async fn discover_system_includes(
             cache.get(compiler).map(|paths| paths.to_vec())
         };
         if let Some(paths) = cached {
-            paths
+            (paths, false)
         } else {
             let discovered =
                 discover_system_include_paths(compiler, lineage, compiler_priority, use_fast).await;
@@ -82,11 +85,12 @@ pub(super) async fn discover_system_includes(
             // `tokio::task::spawn_blocking` and any failure is logged but
             // does not surface to the compile request (the in-memory L1
             // entry is still authoritative for this daemon's lifetime).
-            let (resolved, inserted_snapshot) = {
+            let (resolved, inserted_snapshot, empty_discovery) = {
                 let mut cache = state.system_includes.lock().await;
                 if let Some(paths) = cache.get(compiler) {
-                    (paths.to_vec(), None)
-                } else if let Some(discovered) = discovered {
+                    (paths.to_vec(), None, false)
+                } else if discovery_result_is_cacheable(discovered.as_deref()) {
+                    let discovered = discovered.expect("checked non-empty discovery result");
                     cache.insert(compiler.clone(), discovered);
                     let paths = cache
                         .get(compiler)
@@ -101,11 +105,19 @@ pub(super) async fn discover_system_includes(
                     // practice) — orders of magnitude cheaper than the
                     // `<compiler> -###` / `-v -E` spawn we just paid for.
                     let snapshot = cache.clone();
-                    (paths, Some(snapshot))
+                    (paths, Some(snapshot), false)
+                } else if discovered.is_some() {
+                    // Issue #1167: a process that succeeds but reports zero
+                    // paths is not a stable compiler property. Never put it
+                    // in L1/L2; the next request must probe again.
+                    (Vec::new(), None, true)
                 } else {
-                    (Vec::new(), None)
+                    (Vec::new(), None, false)
                 }
             };
+            if empty_discovery {
+                warn_empty_system_include_discovery(compiler);
+            }
             // Issue #784 phase 2c invariant: don't write-through until
             // the on-disk snapshot has been merged into the live cache.
             // Saving a subset over the loaded-from-disk superset would
@@ -125,7 +137,7 @@ pub(super) async fn discover_system_includes(
                     });
                 }
             }
-            resolved
+            (resolved, empty_discovery)
         }
     };
     let system_includes_ns = t_system_includes
@@ -141,9 +153,34 @@ pub(super) async fn discover_system_includes(
 
     SystemIncludesOutcome {
         includes: system_includes,
+        empty_discovery,
         system_includes_ns,
         system_watch_ns,
     }
+}
+
+/// Record an ambiguous C/C++ probe result. Repeated events deliberately stay
+/// loud: they indicate an unhealthy wrapper, shim, or security product rather
+/// than a one-time compiler property.
+fn warn_empty_system_include_discovery(compiler: &NormalizedPath) {
+    tracing::warn!(
+        event = "system_include_discovery_empty",
+        compiler = %compiler.display(),
+        "compiler system-include discovery returned no paths; bypassing the compile cache and retrying discovery on the next request"
+    );
+    crate::core::lifecycle::write_event(
+        crate::core::lifecycle::EVENT_SYSTEM_INCLUDE_DISCOVERY_EMPTY,
+        serde_json::json!({
+            "compiler": compiler.display().to_string(),
+            "reason": "probe succeeded but yielded zero system include paths",
+        }),
+    );
+}
+
+/// Only a non-empty C/C++ probe result proves an include-root set that can be
+/// safely reused by future requests or persisted across daemon restarts.
+fn discovery_result_is_cacheable(paths: Option<&[NormalizedPath]>) -> bool {
+    paths.is_some_and(|paths| !paths.is_empty())
 }
 
 async fn discover_system_include_paths(
@@ -210,4 +247,23 @@ async fn run_discovery_command(
         SYSTEM_INCLUDE_DISCOVERY_TIMEOUT,
     )
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_successful_discovery_is_not_cacheable() {
+        // Issue #1167: accepting this result would persist an incompatible
+        // context key until the compiler binary itself changes.
+        assert!(!discovery_result_is_cacheable(Some(&[])));
+        assert!(!discovery_result_is_cacheable(None));
+    }
+
+    #[test]
+    fn nonempty_discovery_is_cacheable() {
+        let paths = [NormalizedPath::new("/toolchain/include")];
+        assert!(discovery_result_is_cacheable(Some(&paths)));
+    }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/rustc.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/rustc.rs
@@ -140,11 +140,11 @@ pub(super) fn build_rustc_compile_context(
     // Issue #517: prefer `rustc -vV` output (~10 ms spawn) over a full
     // blake3 over the ~150 MB binary (~50-60 ms on Linux). The cache
     // is still keyed by the binary's (path, mtime, size); only the
-    // identity bytes that get hashed change. Failure falls through to
-    // the binary hash so cache keys stay well-defined for stub
-    // binaries (unit tests) and broken toolchains.
+    // identity bytes that get hashed change. A probe fallback is safe for
+    // this request but deliberately not memoized, so a transient failure
+    // cannot persist a second toolchain identity flavor (#1167).
     let compiler_hash = compiler_hash_cache
-        .get_or_hash_with(&compilation.compiler, hash_rustc_identity)
+        .get_or_hash_rustc_identity(&compilation.compiler)
         .unwrap_or(COMPILER_HASH_UNAVAILABLE);
 
     let rustc_ctx = crate::depgraph::RustcCompileContext::from_parsed_args(
@@ -181,7 +181,7 @@ pub(super) async fn build_rustc_compile_context_async(
     let rustc_args = crate::depgraph::parse_rustc_args(&compilation.original_args, cwd);
 
     let compiler_hash = compiler_hash_cache
-        .get_or_hash_with_async(&compilation.compiler, hash_rustc_identity_async)
+        .get_or_hash_rustc_identity_async(&compilation.compiler)
         .await
         .unwrap_or(COMPILER_HASH_UNAVAILABLE);
 

--- a/crates/zccache-daemon-core/src/daemon/server/tests/compiler_hash.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/compiler_hash.rs
@@ -259,6 +259,79 @@ fn hash_rustc_identity_falls_back_to_file_hash_when_spawn_fails() {
 
 // ── Issue #517: persisted compiler hash cache ───────────────────────────
 
+/// #1167: a transient `-vV` failure may use a file hash for the current
+/// request, but it must not be memoized. The next request retries and a good
+/// probe converges on the durable `-vV` identity instead of pinning a second
+/// cache-key flavor.
+#[test]
+fn rustc_identity_fallback_is_not_cached_and_next_success_converges() {
+    let tmp = tempfile::tempdir().unwrap();
+    let compiler = tmp.path().join("rustc.exe");
+    std::fs::write(&compiler, b"fake rustc").unwrap();
+    let cache = CompilerHashCache::new();
+    let fallback = ContentHash::from_bytes([1; 32]);
+    let verified = ContentHash::from_bytes([2; 32]);
+
+    assert_eq!(
+        cache.get_or_hash_rustc_with(&compiler, |_| Some(RustcIdentity::FileFallback(fallback))),
+        Some(fallback),
+    );
+    assert_eq!(
+        cache.len(),
+        1,
+        "fallback marker keeps repeated failures stable"
+    );
+
+    assert_eq!(
+        cache.get_or_hash_rustc_with(&compiler, |_| Some(RustcIdentity::VerifiedVv(verified))),
+        Some(verified),
+    );
+    assert_eq!(cache.len(), 1, "verified -vV identity must be memoized");
+
+    let calls = AtomicUsize::new(0);
+    assert_eq!(
+        cache.get_or_hash_rustc_with(&compiler, |_| {
+            calls.fetch_add(1, Ordering::Relaxed);
+            Some(RustcIdentity::FileFallback(fallback))
+        }),
+        Some(verified),
+    );
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        0,
+        "verified identity must win"
+    );
+}
+
+/// The durable `-vV` preference survives a daemon restart. This is the
+/// convergence guarantee for cache-sharing runners: a one-off later timeout
+/// cannot replace the already proven identity with a file-hash flavor.
+#[test]
+fn rustc_verified_identity_persists_across_restart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let compiler = tmp.path().join("rustc.exe");
+    let snapshot = tmp.path().join("compiler_hash.bin");
+    std::fs::write(&compiler, b"fake rustc").unwrap();
+    let verified = ContentHash::from_bytes([3; 32]);
+
+    let cache = CompilerHashCache::new();
+    cache.get_or_hash_rustc_with(&compiler, |_| Some(RustcIdentity::VerifiedVv(verified)));
+    cache.save_to_disk(&snapshot).unwrap();
+
+    let restored = CompilerHashCache::load_from_disk(&snapshot).unwrap();
+    let calls = AtomicUsize::new(0);
+    assert_eq!(
+        restored.get_or_hash_rustc_with(&compiler, |_| {
+            calls.fetch_add(1, Ordering::Relaxed);
+            Some(RustcIdentity::FileFallback(ContentHash::from_bytes(
+                [4; 32],
+            )))
+        }),
+        Some(verified),
+    );
+    assert_eq!(calls.load(Ordering::Relaxed), 0);
+}
+
 #[test]
 fn compiler_hash_cache_save_then_load_roundtrip_preserves_entries() {
     let tmp = tempfile::tempdir().unwrap();
@@ -478,6 +551,7 @@ fn compiler_hash_cache_merge_from_drains_other() {
             mtime,
             size: 1,
             hash: ContentHash::from_bytes([1; 32]),
+            flavor: CompilerIdentityFlavor::Generic,
         },
     );
 
@@ -488,6 +562,7 @@ fn compiler_hash_cache_merge_from_drains_other() {
             mtime,
             size: 1,
             hash: ContentHash::from_bytes([2; 32]),
+            flavor: CompilerIdentityFlavor::Generic,
         },
     );
 

--- a/crates/zccache-daemon-core/src/daemon/server/tests/multi_restart_context_key.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/multi_restart_context_key.rs
@@ -82,6 +82,12 @@ out=
 srcs=
 while [ "$#" -gt 0 ]; do
     case "$1" in
+        -v)
+            printf '%s\n' '#include <...> search starts here:' >&2
+            printf '%s\n' ' /usr/include' >&2
+            printf '%s\n' 'End of search list.' >&2
+            exit 0
+            ;;
         -o) shift; out=$1 ;;
         -MF|-MT) shift ;;
         *.c) srcs="$srcs $1" ;;
@@ -123,6 +129,12 @@ if "%~1"=="-o" (
     shift
     shift
     goto loop
+)
+if "%~1"=="-v" (
+    >&2 echo #include ^<...^> search starts here:
+    >&2 echo  C:\fake-system-include
+    >&2 echo End of search list.
+    exit /b 0
 )
 if "%~1"=="-MF" (
     shift

--- a/crates/zccache-depgraph/src/system_includes.rs
+++ b/crates/zccache-depgraph/src/system_includes.rs
@@ -266,10 +266,12 @@ impl SystemIncludeCache {
 
     /// Look up cached system include paths for a compiler, verifying stat.
     ///
-    /// Returns `None` when either the cache has no entry OR the compiler
-    /// binary's (mtime, size) no longer matches the entry's fingerprint.
-    /// Stat errors (e.g., compiler removed) also return `None` so the
-    /// caller falls through to rediscovery.
+    /// Returns `None` when either the cache has no entry, its path list is
+    /// empty, OR the compiler binary's (mtime, size) no longer matches the
+    /// entry's fingerprint. An empty probe result is ambiguous rather than
+    /// proof that a compiler has no defaults, so it must force rediscovery.
+    /// Stat errors (e.g., compiler removed) also return `None` so the caller
+    /// falls through to rediscovery.
     #[must_use]
     pub fn get(&self, compiler: &Path) -> Option<&[NormalizedPath]> {
         let key = NormalizedPath::new(compiler);
@@ -277,7 +279,7 @@ impl SystemIncludeCache {
         let metadata = std::fs::metadata(compiler).ok()?;
         let mtime = metadata.modified().ok()?;
         let size = metadata.len();
-        if entry.mtime == mtime && entry.size == size {
+        if !entry.paths.is_empty() && entry.mtime == mtime && entry.size == size {
             Some(entry.paths.as_slice())
         } else {
             None
@@ -287,10 +289,15 @@ impl SystemIncludeCache {
     /// Store discovered system include paths for a compiler.
     ///
     /// Captures the compiler binary's (mtime, size) at insert time so a
-    /// subsequent `get` can stat-verify. If the stat fails (compiler
+    /// subsequent `get` can stat-verify. Empty results are deliberately not
+    /// cached: an apparently successful probe with no paths is degraded and
+    /// must be retried on the next compile. If the stat fails (compiler
     /// removed mid-insert), the entry is silently dropped — better to
     /// re-discover than to cache without a valid fingerprint.
     pub fn insert(&mut self, compiler: NormalizedPath, paths: Vec<NormalizedPath>) {
+        if paths.is_empty() {
+            return;
+        }
         let Ok(metadata) = std::fs::metadata(compiler.as_path()) else {
             return;
         };
@@ -314,10 +321,11 @@ impl SystemIncludeCache {
     {
         let compiler_key = NormalizedPath::new(compiler);
         let stat_match = self.cache.get(&compiler_key).is_some_and(|entry| {
-            std::fs::metadata(compiler)
-                .ok()
-                .and_then(|m| m.modified().ok().map(|mt| (mt, m.len())))
-                .is_some_and(|(mt, size)| mt == entry.mtime && size == entry.size)
+            !entry.paths.is_empty()
+                && std::fs::metadata(compiler)
+                    .ok()
+                    .and_then(|m| m.modified().ok().map(|mt| (mt, m.len())))
+                    .is_some_and(|(mt, size)| mt == entry.mtime && size == entry.size)
         });
         if !stat_match {
             let paths = discover(compiler);
@@ -335,7 +343,9 @@ impl SystemIncludeCache {
     }
 
     /// Drain entries from a freshly loaded `SystemIncludeCache` into
-    /// `self` using `HashMap::extend`.
+    /// `self` using `HashMap::extend`. Empty entries from snapshots written
+    /// by older releases are discarded because they are not valid reusable
+    /// discovery results.
     ///
     /// Issue #784 phase 2c: lets a background `spawn_blocking` task
     /// load the on-disk snapshot AFTER the daemon has written its
@@ -346,7 +356,12 @@ impl SystemIncludeCache {
     /// rejects a stale `(mtime, size)` before trusting the cached
     /// paths, so a partially-loaded snapshot cannot poison results).
     pub fn merge_from(&mut self, other: Self) {
-        self.cache.extend(other.cache);
+        self.cache.extend(
+            other
+                .cache
+                .into_iter()
+                .filter(|(_, entry)| !entry.paths.is_empty()),
+        );
     }
 
     /// Number of cached entries.
@@ -377,6 +392,7 @@ impl SystemIncludeCache {
         let entries: Vec<(NormalizedPath, SystemIncludeEntry)> = self
             .cache
             .iter()
+            .filter(|(_, entry)| !entry.paths.is_empty())
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
 
@@ -458,7 +474,9 @@ impl SystemIncludeCache {
             HashMap::with_capacity(snapshot.entries.len());
         let entry_count = snapshot.entries.len();
         for (key, value) in snapshot.entries {
-            cache.insert(key, value);
+            if !value.paths.is_empty() {
+                cache.insert(key, value);
+            }
         }
         tracing::info!(
             path = %path.display(),
@@ -623,6 +641,34 @@ End of search list.
         let cache = SystemIncludeCache::new();
         cache.save_to_disk(&snapshot).unwrap();
         assert!(!snapshot.exists());
+    }
+
+    #[test]
+    fn empty_discovery_entries_are_never_reused_or_persisted() {
+        // Issue #1167: snapshots from older releases may contain an empty
+        // result. It is degraded probe state, not a reusable assertion that
+        // the compiler has no system includes.
+        let tmp = tempfile::tempdir().unwrap();
+        let compiler = tmp.path().join("clang++");
+        let snapshot = tmp.path().join("system_includes.bin");
+        touch(&compiler, b"#!/bin/sh\n# compiler\n");
+        let metadata = std::fs::metadata(&compiler).unwrap();
+        let mut cache = SystemIncludeCache::new();
+        cache.cache.insert(
+            NormalizedPath::new(&compiler),
+            SystemIncludeEntry {
+                mtime: metadata.modified().unwrap(),
+                size: metadata.len(),
+                paths: Vec::new(),
+            },
+        );
+
+        assert!(cache.get(&compiler).is_none());
+        cache.save_to_disk(&snapshot).unwrap();
+        assert!(
+            !snapshot.exists(),
+            "empty discoveries must not be written back to disk"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1167.\n\n- Do not cache or persist empty C/C++ system-include discovery results; bypass affected requests and re-probe.\n- Persist only verified rustc -vV compiler identities; use fallback file hashes for one request without pinning a second key flavor.\n- Emit durable lifecycle events for both degraded outcomes.