### PR TITLE
fix(hash): harden mtime trust and key framing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4359,6 +4359,7 @@ dependencies = [
 name = "zccache-fingerprint"
 version = "1.12.17"
 dependencies = [
+ "filetime",
  "fs2",
  "globset",
  "jwalk",
@@ -4380,6 +4381,7 @@ version = "1.12.17"
 dependencies = [
  "bincode",
  "dashmap",
+ "filetime",
  "rayon",
  "serde",
  "tempfile",

--- a/crates/zccache-fingerprint/Cargo.toml
+++ b/crates/zccache-fingerprint/Cargo.toml
@@ -35,6 +35,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+filetime = { workspace = true }
 tempfile = { workspace = true }
 
 [build-dependencies]

--- a/crates/zccache-fingerprint/src/hash_cache.rs
+++ b/crates/zccache-fingerprint/src/hash_cache.rs
@@ -62,9 +62,9 @@ impl HashCache {
     /// Computes an aggregate blake3 hash of all files (sorted by relative path)
     /// and compares against the cached hash.
     ///
-    /// Uses an mtime fast-path: if the cache file is newer than all source files
-    /// and the previous status was success with the same file count, returns
-    /// `Skip` without reading any file contents.
+    /// Uses an mtime fast-path: if the cache file is newer than all source files,
+    /// their maximum mtime is unchanged since the successful snapshot, and the
+    /// file count is unchanged, returns `Skip` without reading any file contents.
     pub fn check(&self, files: &[ScannedFile]) -> Result<CacheDecision> {
         // Mtime fast-path: skip content hashing when cache is newer than all sources.
         if let Some(decision) = self.try_mtime_fast_path(files)? {
@@ -159,7 +159,11 @@ impl HashCache {
         // Read the cache to check status and file count.
         let cached: Option<HashCacheData> = persist::read_json(&self.cache_file)?;
         match cached {
-            Some(data) if data.status == "success" && data.file_count == files.len() => {
+            Some(data)
+                if data.status == "success"
+                    && data.file_count == files.len()
+                    && data.max_source_mtime_ns == max_source_mtime =>
+            {
                 tracing::debug!("mtime fast-path: cache is newer than all sources, skipping");
                 Ok(Some(CacheDecision::Skip))
             }
@@ -176,6 +180,7 @@ impl HashCache {
 mod tests {
     use super::super::scan;
     use super::*;
+    use filetime::{set_file_mtime, FileTime};
     use std::fs;
     use tempfile::TempDir;
 
@@ -230,6 +235,25 @@ mod tests {
         cache.mark_success().unwrap();
 
         create_file(src.path(), "a.rs", "v2");
+        let decision = cache.check(&scan_dir(src.path())).unwrap();
+        assert_eq!(decision, CacheDecision::Run(RunReason::ContentChanged));
+    }
+
+    #[test]
+    fn backwards_mtime_with_changed_content_does_not_take_fast_path() {
+        let (src, cache_dir) = setup();
+        let source = src.path().join("a.rs");
+        create_file(src.path(), "a.rs", "v1");
+
+        let cache = HashCache::new(cache_dir.path().join("fp.json"));
+        cache.check(&scan_dir(src.path())).unwrap();
+        cache.mark_success().unwrap();
+
+        create_file(src.path(), "a.rs", "v2");
+        // A clock rollback (or checkout) can make changed content older than
+        // the cache file. The stored source mtime must reject the fast path.
+        set_file_mtime(&source, FileTime::from_unix_time(1, 0)).unwrap();
+
         let decision = cache.check(&scan_dir(src.path())).unwrap();
         assert_eq!(decision, CacheDecision::Run(RunReason::ContentChanged));
     }

--- a/crates/zccache-fingerprint/src/two_layer.rs
+++ b/crates/zccache-fingerprint/src/two_layer.rs
@@ -31,9 +31,9 @@ impl TwoLayerCache {
     /// Compares each file against cached state. Writes a `.pending` file with
     /// the current snapshot so that `mark_success()` can promote it atomically.
     ///
-    /// Uses an mtime fast-path: if the cache file is newer than all source files
-    /// and the previous status was success with the same file count, returns
-    /// `Skip` without per-file stat+hash checks.
+    /// Uses an mtime fast-path: if the cache file is newer than all source files,
+    /// their maximum mtime is unchanged since the successful snapshot, and the
+    /// file count is unchanged, returns `Skip` without per-file stat+hash checks.
     pub fn check(&self, files: &[ScannedFile]) -> Result<CacheDecision> {
         // Mtime fast-path: skip per-file checks when cache is newer than all sources.
         if let Some(decision) = self.try_mtime_fast_path(files)? {
@@ -169,7 +169,11 @@ impl TwoLayerCache {
 
         let cached: Option<TwoLayerData> = persist::read_json(&self.cache_file)?;
         match cached {
-            Some(data) if data.status == "success" && data.files.len() == files.len() => {
+            Some(data)
+                if data.status == "success"
+                    && data.files.len() == files.len()
+                    && data.max_source_mtime_ns == max_source_mtime =>
+            {
                 tracing::debug!("mtime fast-path: cache is newer than all sources, skipping");
                 Ok(Some(CacheDecision::Skip))
             }
@@ -217,6 +221,7 @@ impl TwoLayerCache {
 mod tests {
     use super::super::{persist, scan};
     use super::*;
+    use filetime::{set_file_mtime, FileTime};
     use std::fs;
     use tempfile::TempDir;
 
@@ -279,6 +284,25 @@ mod tests {
         // Ensure mtime changes (filesystem granularity).
         std::thread::sleep(std::time::Duration::from_millis(1100));
         create_file(src.path(), "a.rs", "version 2");
+
+        let decision = cache.check(&scan(src.path())).unwrap();
+        assert_eq!(decision, CacheDecision::Run(RunReason::ContentChanged));
+    }
+
+    #[test]
+    fn backwards_mtime_with_changed_content_does_not_take_fast_path() {
+        let (src, cache_dir) = setup();
+        let source = src.path().join("a.rs");
+        create_file(src.path(), "a.rs", "version 1");
+
+        let cache = TwoLayerCache::new(cache_dir.path().join("fp.json"));
+        cache.check(&scan(src.path())).unwrap();
+        cache.mark_success().unwrap();
+
+        create_file(src.path(), "a.rs", "version 2");
+        // A clock rollback (or checkout) can make changed content older than
+        // the cache file. The stored source mtime must reject the fast path.
+        set_file_mtime(&source, FileTime::from_unix_time(1, 0)).unwrap();
 
         let decision = cache.check(&scan(src.path())).unwrap();
         assert_eq!(decision, CacheDecision::Run(RunReason::ContentChanged));

--- a/crates/zccache-fscache/Cargo.toml
+++ b/crates/zccache-fscache/Cargo.toml
@@ -21,6 +21,7 @@ zccache-core = { workspace = true }
 zccache-hash = { workspace = true }
 
 [dev-dependencies]
+filetime = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/zccache-fscache/src/metadata.rs
+++ b/crates/zccache-fscache/src/metadata.rs
@@ -13,10 +13,10 @@ use zccache_core::NormalizedPath;
 /// metadata entry against a fresh `stat()` (`get_cached_hash_if_stat_valid`).
 ///
 /// Set to 1 full second so archive-extraction truncation (tar / zstd-tar /
-/// soldr-save-load all flatten sub-second nanos to 0) and FAT32-style 2-sec
-/// granularity drift are both absorbed. Two real content changes inside a
-/// 1-second window are rare in normal builds; the journal + watcher catch
-/// them via mtime-independent paths.
+/// soldr-save-load all flatten sub-second nanos to 0) is absorbed. The
+/// tolerance applies only when either timestamp has a zero sub-second field,
+/// which is the signature of that truncation. Native fine-grained timestamps
+/// remain exact so a same-size edit cannot be mistaken for an archive restore.
 ///
 /// Override at daemon startup via `ZCCACHE_MTIME_TOLERANCE_NS`:
 /// - `0` → strict byte-equal mtime match (pre-issue-#469 behavior).
@@ -43,7 +43,8 @@ fn mtime_tolerance_ns() -> u64 {
 ///
 /// Match if:
 /// - The two values are byte-equal (no truncation happened), OR
-/// - `|a - b| <= mtime_tolerance_ns()`.
+/// - `|a - b| < mtime_tolerance_ns()` and either timestamp has a zero
+///   sub-second field, the archive-truncation signature.
 ///
 /// Setting the tolerance to `0` (via `ZCCACHE_MTIME_TOLERANCE_NS=0`)
 /// disables the second branch entirely and restores strict byte-equal
@@ -58,9 +59,12 @@ fn mtimes_match(a: SystemTime, b: SystemTime) -> bool {
     }
     let (a_secs, a_nanos) = mtime_components(a);
     let (b_secs, b_nanos) = mtime_components(b);
+    if a_nanos != 0 && b_nanos != 0 {
+        return false;
+    }
     let a_total = (a_secs as u128) * 1_000_000_000 + (a_nanos as u128);
     let b_total = (b_secs as u128) * 1_000_000_000 + (b_nanos as u128);
-    a_total.abs_diff(b_total) <= tolerance_ns as u128
+    a_total.abs_diff(b_total) < tolerance_ns as u128
 }
 
 fn mtime_components(t: SystemTime) -> (u64, u32) {
@@ -461,7 +465,9 @@ impl Default for MetadataCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use filetime::{set_file_mtime, FileTime};
     use std::collections::HashSet;
+    use std::fs;
 
     // ── mtime tolerance (issue #469) ─────────────────────────────────────
 
@@ -492,13 +498,21 @@ mod tests {
     }
 
     #[test]
-    fn mtimes_match_within_default_tolerance_window() {
-        // Drift = 500 ms (half the 1 s tolerance) → match.
+    fn mtimes_match_only_with_archive_truncation_signature() {
+        // A timestamp at a whole second can be an archive-restored version of
+        // the other timestamp, so the sub-second drift is tolerated.
         assert!(mtimes_match(ts(1_000, 0), ts(1_000, 500_000_000)));
-        // Drift = 999 ms — just inside the boundary.
         assert!(mtimes_match(ts(1_000, 0), ts(1_000, 999_999_999)));
-        // Equal to the tolerance boundary — `<=` accepts.
-        assert!(mtimes_match(ts(1_000, 0), ts(1_001, 0)));
+
+        // Fine-grained timestamps are exact, even when the difference is
+        // much smaller than the one-second archive tolerance.
+        assert!(!mtimes_match(
+            ts(1_000, 100_000_000),
+            ts(1_000, 500_000_000)
+        ));
+
+        // The tolerance is strictly less than one second.
+        assert!(!mtimes_match(ts(1_000, 0), ts(1_001, 0)));
     }
 
     #[test]
@@ -519,6 +533,60 @@ mod tests {
         // not panic, should compare equal to other pre-epoch values.
         let pre = SystemTime::UNIX_EPOCH - Duration::from_secs(1);
         assert!(mtimes_match(pre, pre));
+    }
+
+    #[test]
+    fn stat_fast_path_rejects_same_size_fine_grained_mtime_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("input.c");
+        fs::write(&file, b"old!").unwrap();
+
+        let cached_mtime = ts(1_000, 100_000_000);
+        let fresh_mtime = ts(1_000, 500_000_000);
+        set_file_mtime(&file, FileTime::from_system_time(fresh_mtime)).unwrap();
+
+        let path = NormalizedPath::from(file.as_path());
+        let cache = MetadataCache::new();
+        cache.insert(
+            path.clone(),
+            FileMetadata {
+                mtime: cached_mtime,
+                size: 4,
+                confidence: Confidence::High,
+                last_verified: Instant::now(),
+                content_hash: Some([42; 32]),
+            },
+        );
+
+        // A watcher event may not have arrived yet, but the stat safety net
+        // must not return the stale hash for a same-size native-resolution
+        // timestamp change within the former one-second blanket window.
+        assert!(cache.get_cached_hash_if_stat_valid(&path).is_none());
+    }
+
+    #[test]
+    fn stat_fast_path_accepts_archive_truncated_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("input.c");
+        fs::write(&file, b"same").unwrap();
+
+        let cached_mtime = ts(1_000, 141_490_982);
+        set_file_mtime(&file, FileTime::from_system_time(ts(1_000, 0))).unwrap();
+
+        let path = NormalizedPath::from(file.as_path());
+        let cache = MetadataCache::new();
+        cache.insert(
+            path.clone(),
+            FileMetadata {
+                mtime: cached_mtime,
+                size: 4,
+                confidence: Confidence::High,
+                last_verified: Instant::now(),
+                content_hash: Some([42; 32]),
+            },
+        );
+
+        assert!(cache.get_cached_hash_if_stat_valid(&path).is_some());
     }
 
     #[test]

--- a/crates/zccache-hash/src/cache_key.rs
+++ b/crates/zccache-hash/src/cache_key.rs
@@ -71,7 +71,7 @@ impl CacheKeyBuilder {
         let mut hasher = blake3::Hasher::new();
 
         // Domain separation tag
-        hasher.update(b"zccache-cache-key-v1");
+        hasher.update(b"zccache-cache-key-v2\0");
 
         // Compiler identity
         #[expect(
@@ -107,7 +107,9 @@ impl CacheKeyBuilder {
         // Dependency hashes (BTreeMap is already sorted)
         for (name, hash) in &self.dependency_hashes {
             hasher.update(name.as_bytes());
+            hasher.update(b"\0");
             hasher.update(hash.as_bytes());
+            hasher.update(b"\0");
         }
 
         ContentHash::from_bytes(*hasher.finalize().as_bytes())
@@ -118,6 +120,22 @@ impl CacheKeyBuilder {
 mod tests {
     use super::super::hash_bytes;
     use super::*;
+
+    fn legacy_v1_key(
+        compiler: ContentHash,
+        source: ContentHash,
+        dependencies: &[(&str, ContentHash)],
+    ) -> ContentHash {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"zccache-cache-key-v1");
+        hasher.update(compiler.as_bytes());
+        hasher.update(source.as_bytes());
+        for (name, hash) in dependencies {
+            hasher.update(name.as_bytes());
+            hasher.update(hash.as_bytes());
+        }
+        ContentHash::from_bytes(*hasher.finalize().as_bytes())
+    }
 
     #[test]
     fn cache_key_deterministic() {
@@ -201,5 +219,43 @@ mod tests {
             .build();
 
         assert_ne!(k1, k2, "swapping compile arg order must change the key");
+    }
+
+    #[test]
+    fn dependency_boundaries_cannot_shift_into_hash_bytes() {
+        let compiler = hash_bytes(b"gcc-12");
+        let source = hash_bytes(b"int main() {}");
+        let tail = ContentHash::from_bytes([9; 32]);
+
+        // Under v1, the leading `b` moves from a hash into the dependency
+        // name, while the leading `c` of the next name moves into that hash.
+        let first_dependencies = [("a", ContentHash::from_bytes([b'b'; 32])), ("cd", tail)];
+        let mut shifted_hash = [b'b'; 32];
+        shifted_hash[31] = b'c';
+        let second_dependencies = [("ab", ContentHash::from_bytes(shifted_hash)), ("d", tail)];
+        assert_eq!(
+            legacy_v1_key(compiler, source, &first_dependencies),
+            legacy_v1_key(compiler, source, &second_dependencies)
+        );
+
+        let first = CacheKeyBuilder::new()
+            .compiler(compiler)
+            .source(source)
+            .dependency(first_dependencies[0].0, first_dependencies[0].1)
+            .dependency(first_dependencies[1].0, first_dependencies[1].1)
+            .build();
+        let second = CacheKeyBuilder::new()
+            .compiler(compiler)
+            .source(source)
+            .dependency(second_dependencies[0].0, second_dependencies[0].1)
+            .dependency(second_dependencies[1].0, second_dependencies[1].1)
+            .build();
+
+        assert_ne!(first, second);
+        assert_ne!(
+            first,
+            legacy_v1_key(compiler, source, &first_dependencies),
+            "the v2 domain tag must invalidate v1 link-cache keys"
+        );
     }
 }


### PR DESCRIPTION
Fixes #1168.\n\n- restrict filesystem mtime tolerance to archive-style truncation\n- require fingerprint snapshots to retain the same max source mtime before skipping\n- delimit dependency cache-key fields and move to the v2 domain\n\nValidation: focused unit tests (365), integration tests, fmt, and targeted clippy.