### PR TITLE
fix(cache): reject unmodeled single-file side outputs

### DIFF
--- a/crates/zccache-compiler/src/lib.rs
+++ b/crates/zccache-compiler/src/lib.rs
@@ -29,6 +29,7 @@ pub mod parse_msvc;
 mod parse_rustc;
 pub mod parse_rustfmt;
 pub mod response_file;
+pub mod side_outputs;
 pub mod strict_paths;
 
 #[cfg(test)]
@@ -44,6 +45,7 @@ pub use output_policy::{
     OutputClassification, OutputRole,
 };
 pub use parse::parse_invocation;
+pub use side_outputs::unmodeled_side_output_flag;
 
 /// Supported compiler families.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/zccache-compiler/src/parse.rs
+++ b/crates/zccache-compiler/src/parse.rs
@@ -8,8 +8,8 @@ use zccache_core::NormalizedPath;
 
 use super::detect::{detect_family, is_source_file, MODULE_EXTENSIONS};
 use super::{
-    gnu_flag_takes_value, parse_msvc, CacheableCompilation, CompilerFamily, ParsedInvocation,
-    SourceMode,
+    gnu_flag_takes_value, parse_msvc, unmodeled_side_output_flag, CacheableCompilation,
+    CompilerFamily, ParsedInvocation, SourceMode,
 };
 
 /// Map a `-x <lang>` value to the corresponding source mode.
@@ -258,6 +258,12 @@ pub fn parse_invocation(compiler: &str, args: &[String]) -> ParsedInvocation {
     if source_files.is_empty() {
         return ParsedInvocation::NonCacheable {
             reason: "no source file found".to_string(),
+        };
+    }
+
+    if let Some(flag) = unmodeled_side_output_flag(args, false) {
+        return ParsedInvocation::NonCacheable {
+            reason: format!("unmodeled compiler side output requested by {flag}"),
         };
     }
 

--- a/crates/zccache-compiler/src/parse_msvc.rs
+++ b/crates/zccache-compiler/src/parse_msvc.rs
@@ -20,7 +20,7 @@
 
 use std::sync::Arc;
 
-use super::{CacheableCompilation, CompilerFamily, ParsedInvocation};
+use super::{unmodeled_side_output_flag, CacheableCompilation, CompilerFamily, ParsedInvocation};
 use zccache_core::NormalizedPath;
 
 /// Source file extensions recognised by the MSVC / clang-cl parser.
@@ -143,6 +143,7 @@ pub fn parse_msvc_invocation(
     let mut output_file: Option<String> = None;
     let mut source_files: Vec<(String, usize)> = Vec::new();
     let mut unknown_flags: Vec<String> = Vec::new();
+    let mut has_external_pdb_debug_info = false;
     // Pending source-language override from /Tc<file> / /Tp<file>.
     // Those flags both name and language-tag the file in one go.
 
@@ -181,6 +182,18 @@ pub fn parse_msvc_invocation(
         // pass this verbatim. Both prefixes accepted.
         if is_exact_flag(arg, "c") {
             has_c_flag = true;
+            i += 1;
+            continue;
+        }
+
+        // `/Zi` and `/ZI` put debug type information in a shared PDB. A
+        // single-file cache entry contains only the object, so replaying one
+        // would silently omit (or stale) that side output. `/Z7` would be
+        // self-contained, but changing the caller's requested debug format
+        // here would require an argv rewrite before both keying and execution.
+        if flag_body(arg).eq_ignore_ascii_case("zi") {
+            has_external_pdb_debug_info = true;
+            unknown_flags.push(arg.clone());
             i += 1;
             continue;
         }
@@ -355,6 +368,16 @@ pub fn parse_msvc_invocation(
     if source_files.is_empty() {
         return ParsedInvocation::NonCacheable {
             reason: "no source file found in MSVC/clang-cl invocation".to_string(),
+        };
+    }
+    if source_files.len() == 1 && has_external_pdb_debug_info {
+        return ParsedInvocation::NonCacheable {
+            reason: "MSVC /Zi debug info writes an external PDB side output".to_string(),
+        };
+    }
+    if let Some(flag) = unmodeled_side_output_flag(args, true) {
+        return ParsedInvocation::NonCacheable {
+            reason: format!("unmodeled compiler side output requested by {flag}"),
         };
     }
 
@@ -683,19 +706,54 @@ mod tests {
     }
 
     #[test]
-    fn debug_info_flags() {
+    fn zi_debug_info_is_non_cacheable_because_it_writes_a_pdb() {
         let result = parse_msvc_invocation(
             "clang-cl",
             &args(&["/c", "/Zi", "/Fd:vc.pdb", "/Fo:hello.obj", "hello.c"]),
             CompilerFamily::Msvc,
         );
         match result {
-            ParsedInvocation::Cacheable(c) => {
-                assert_eq!(c.output_file, NormalizedPath::new("hello.obj"));
-                assert!(c.unknown_flags.contains(&"/Zi".to_string()));
-                assert!(c.unknown_flags.contains(&"/Fd:vc.pdb".to_string()));
+            ParsedInvocation::NonCacheable { reason } => {
+                assert_eq!(
+                    reason,
+                    "MSVC /Zi debug info writes an external PDB side output"
+                );
             }
-            other => panic!("expected cacheable, got: {other:?}"),
+            other => panic!("expected non-cacheable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn zi_is_case_insensitive() {
+        let result = parse_msvc_invocation(
+            "cl.exe",
+            &args(&["/c", "/ZI", "/Fo:hello.obj", "hello.c"]),
+            CompilerFamily::Msvc,
+        );
+        assert!(matches!(
+            result,
+            ParsedInvocation::NonCacheable { ref reason }
+                if reason == "MSVC /Zi debug info writes an external PDB side output"
+        ));
+    }
+
+    #[test]
+    fn msvc_side_output_flags_are_non_cacheable_for_single_file_compiles() {
+        for flag in [
+            "/Fd:unit.pdb",
+            "/Fp:unit.pch",
+            "/FAcs",
+            "/sourceDependencies",
+        ] {
+            let result = parse_msvc_invocation(
+                "cl.exe",
+                &args(&["/c", flag, "/Fo:hello.obj", "hello.c"]),
+                CompilerFamily::Msvc,
+            );
+            assert!(
+                matches!(result, ParsedInvocation::NonCacheable { .. }),
+                "{flag}"
+            );
         }
     }
 

--- a/crates/zccache-compiler/src/side_outputs.rs
+++ b/crates/zccache-compiler/src/side_outputs.rs
@@ -1,0 +1,111 @@
+//! Compiler flags that produce side artifacts outside the primary output.
+//!
+//! A cache entry currently stores the primary object and declared depfile, so
+//! these flags must bypass the compile cache until their extra outputs are
+//! captured.  Keep this narrow: PCH and module interface invocations whose
+//! only product is their primary output remain cacheable.
+
+/// Return the argv element that requests an unmodeled compiler side output.
+///
+/// `msvc_syntax` is true for both `cl.exe` and clang invocations using
+/// clang-cl-style slash flags.
+#[must_use]
+pub fn unmodeled_side_output_flag<'a>(args: &'a [String], msvc_syntax: bool) -> Option<&'a str> {
+    args.iter().map(String::as_str).find(|arg| {
+        let lower = arg.to_ascii_lowercase();
+        if msvc_syntax {
+            let body = arg
+                .strip_prefix('/')
+                .or_else(|| arg.strip_prefix('-'))
+                .unwrap_or(arg);
+            let lower_body = body.to_ascii_lowercase();
+            body.starts_with("Fd")
+                || body.starts_with("Fp")
+                || body.starts_with("Fr")
+                || body.starts_with("FR")
+                || body.starts_with("Fi")
+                || body.starts_with("Fa")
+                || matches!(lower_body.as_str(), "fa" | "fac" | "fas" | "facs")
+                || lower_body.starts_with("yc")
+                || lower_body.starts_with("doc")
+                || lower_body.starts_with("module:")
+                || lower_body.starts_with("headerunit")
+                || lower_body.starts_with("sourcedependencies")
+                || matches!(lower.as_str(), "/zi" | "-zi")
+                || lower.starts_with("/ifc")
+                || lower.starts_with("-ifc")
+                || matches!(lower.as_str(), "/interface" | "-interface")
+        } else {
+            lower.starts_with("--serialize-diagnostics")
+                || lower.starts_with("-dependency-file")
+                || lower.starts_with("-mj")
+                || (lower.starts_with("-fmodule") && lower != "-fmodules-ts")
+                || lower == "-save-temps"
+                || lower.starts_with("-save-temps=")
+                || lower.starts_with("-gsplit-dwarf")
+                || lower.starts_with("-fdump-")
+                || matches!(
+                    lower.as_str(),
+                    "--coverage" | "-coverage" | "-fprofile-arcs" | "-ftest-coverage"
+                )
+                || lower == "-ftime-trace"
+                || lower.starts_with("-ftime-trace=")
+                || lower == "-fstack-usage"
+                || lower.starts_with("-fcallgraph-info")
+                || lower == "-fsave-optimization-record"
+                || lower.starts_with("-foptimization-record-file")
+                || lower.starts_with("-fopt-info")
+                || lower.starts_with("-fdiagnostics-file=")
+                || lower.starts_with("-fdiagnostics-format=sarif-file")
+                || (lower.starts_with("-wa,") && lower.contains('='))
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::unmodeled_side_output_flag;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn recognizes_single_tu_gnu_side_outputs() {
+        for flag in [
+            "-gsplit-dwarf",
+            "--coverage",
+            "-ftime-trace",
+            "-fstack-usage",
+            "-save-temps",
+            "-fmodules",
+        ] {
+            assert_eq!(
+                unmodeled_side_output_flag(&args(&["-c", "unit.c", flag]), false),
+                Some(flag),
+                "{flag} must bypass object-only caching"
+            );
+        }
+    }
+
+    #[test]
+    fn recognizes_msvc_pdb_and_listing_side_outputs_case_insensitively() {
+        for flag in ["/Zi", "/ZI", "/Fd:unit.pdb", "/FAcs", "/sourceDependencies"] {
+            assert_eq!(
+                unmodeled_side_output_flag(&args(&["/c", "unit.c", flag]), true),
+                Some(flag),
+                "{flag} must bypass object-only caching"
+            );
+        }
+    }
+
+    #[test]
+    fn primary_output_only_pch_and_module_forms_are_not_side_outputs() {
+        for flag in ["c++-header", "c++-module", "module.cppm"] {
+            assert!(
+                unmodeled_side_output_flag(&args(&["-c", flag]), false).is_none(),
+                "{flag} is not itself an unmodeled side output"
+            );
+        }
+    }
+}

--- a/crates/zccache-compiler/src/tests/cpp_parse.rs
+++ b/crates/zccache-compiler/src/tests/cpp_parse.rs
@@ -52,6 +52,25 @@ fn implicit_profile_use_is_non_cacheable() {
 }
 
 #[test]
+fn side_output_flags_are_non_cacheable_for_single_file_compiles() {
+    for flag in [
+        "-gsplit-dwarf",
+        "--coverage",
+        "-ftime-trace",
+        "-fstack-usage",
+        "-save-temps",
+        "-fmodules",
+    ] {
+        let result = parse_invocation("gcc", &args(&["-c", flag, "hello.cpp"]));
+        assert!(matches!(
+            result,
+            ParsedInvocation::NonCacheable { ref reason }
+                if reason == &format!("unmodeled compiler side output requested by {flag}")
+        ));
+    }
+}
+
+#[test]
 fn multi_file_split() {
     let result = parse_invocation("gcc", &args(&["-c", "a.cpp", "b.cpp"]));
     match result {

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_multi.rs
@@ -479,65 +479,27 @@ fn has_file_valued_msvc_output(args: &[String]) -> bool {
 }
 
 fn has_unmodeled_multi_output(args: &[String], msvc_syntax: bool) -> bool {
+    if crate::compiler::unmodeled_side_output_flag(args, msvc_syntax).is_some() {
+        return true;
+    }
+    // Multi-source PCH/module shapes have compiler-owned output maps.  They
+    // are distinct from the single-file primary-output forms, which remain
+    // cacheable because they do not create an unmodeled side artifact.
     args.iter().any(|arg| {
         let lower = arg.to_ascii_lowercase();
         if msvc_syntax {
-            let body = arg
-                .strip_prefix('/')
-                .or_else(|| arg.strip_prefix('-'))
-                .unwrap_or(arg);
-            let lower_body = body.to_ascii_lowercase();
-            body.starts_with("Fd")
-                || body.starts_with("Fp")
-                || body.starts_with("Fr")
-                || body.starts_with("FR")
-                || body.starts_with("Fi")
-                || body.starts_with("Fa")
-                || matches!(lower_body.as_str(), "fa" | "fac" | "fas" | "facs")
-                || body.starts_with("Yc")
-                || lower_body.starts_with("doc")
-                || lower_body.starts_with("module:")
-                || lower_body.starts_with("headerunit")
-                || lower_body.starts_with("sourcedependencies")
-                || matches!(lower.as_str(), "/zi" | "-zi")
-                || lower.starts_with("/ifc")
-                || lower.starts_with("-ifc")
-                || lower == "/interface"
-                || lower == "-interface"
+            false
         } else {
-            lower.starts_with("--serialize-diagnostics")
-                || lower.starts_with("-dependency-file")
-                || lower.starts_with("-mj")
-                || lower.starts_with("-fmodule")
-                || lower == "-save-temps"
-                || lower.starts_with("-save-temps=")
-                || lower.starts_with("-gsplit-dwarf")
-                || lower.starts_with("-fdump-")
-                || lower == "--coverage"
-                || lower == "-coverage"
-                || lower == "-fprofile-arcs"
-                || lower == "-ftest-coverage"
-                || lower == "-ftime-trace"
-                || lower.starts_with("-ftime-trace=")
-                || lower == "-fstack-usage"
-                || lower.starts_with("-fcallgraph-info")
-                || lower == "-fsave-optimization-record"
-                || lower.starts_with("-foptimization-record-file")
-                || lower.starts_with("-fopt-info")
-                || lower.starts_with("-fdiagnostics-file=")
-                || lower.starts_with("-fdiagnostics-format=sarif-file")
-                || (lower.starts_with("-wa,") && lower.contains("="))
-                || matches!(
-                    lower.as_str(),
-                    "c++-module"
-                        | "c-header"
-                        | "c++-header"
-                        | "objective-c-header"
-                        | "objective-c++-header"
-                        | "c-header-unit"
-                        | "c++-header-unit"
-                )
-                || lower.ends_with(".cppm")
+            matches!(
+                lower.as_str(),
+                "c++-module"
+                    | "c-header"
+                    | "c++-header"
+                    | "objective-c-header"
+                    | "objective-c++-header"
+                    | "c-header-unit"
+                    | "c++-header-unit"
+            ) || lower.ends_with(".cppm")
                 || lower.ends_with(".ixx")
         }
     })


### PR DESCRIPTION
Fixes #1175.\n\nReject single-file compile caching when compiler arguments request side artifacts that object-only entries cannot restore. Share the multi-file hazard table with GNU and MSVC parsing, including external PDB paths and /Zi.\n\nValidation: formatter, diff check, focused zccache-compiler parser regressions.