### PR TITLE
fix(persist): gate async index publication on persist

### DIFF
--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -57,6 +57,7 @@
 //! | `rustc_identity_probe_timeout` | daemon | the rustc identity probe timed out and hashing fell back to file bytes | `compiler`, `timeout_ms`, `reason` |
 //! | `compiler_identity_fallback_flavor` | daemon | a rustc identity probe fell back to file bytes for one request; the fallback is not persisted | `compiler`, `compiler_family`, `reason` |
 //! | `staged_publication_failed` | daemon | a successful compile could not publish its staged generation | `reason`, `error`, `artifact_key` |
+//! | `persist_failed` | daemon | an asynchronous artifact persist failed, so no index entry was published | `artifact_key`, `paths`, `errno`, `error`, `gap_ms` |
 //! | `cow_unregistered_blob_evicted` | daemon | an unregistered COW blob was rejected and removed | `blob_path`, `link_count` |
 //! | `cow_blob_corruption_detected` | daemon | a registered COW blob no longer matched its expected digest | blob/hash/link fields |
 //! | `destination_write_failed` | daemon | cached artifact could not be written to its requested output | `artifact_key`, `path`, `errno` |
@@ -145,6 +146,7 @@ pub const EVENT_STAGED_PUBLICATION_CONFLICT: &str = "staged_publication_conflict
 pub const EVENT_STAGED_PUBLICATION_REPLACES_INVALID_GENERATION: &str =
     "staged_publication_replaces_invalid_generation";
 pub const EVENT_STAGED_PUBLICATION_FAILED: &str = "staged_publication_failed";
+pub const EVENT_PERSIST_FAILED: &str = "persist_failed";
 pub const EVENT_STAGED_SALVAGE_STARTED: &str = "staged_salvage_started";
 pub const EVENT_STAGED_SALVAGE_COMPLETE: &str = "staged_salvage_complete";
 pub const EVENT_STAGED_SALVAGE_FAILED: &str = "staged_salvage_failed";
@@ -180,6 +182,7 @@ pub const EVENT_ALL: &[&str] = &[
     EVENT_STAGED_PUBLICATION_CONFLICT,
     EVENT_STAGED_PUBLICATION_REPLACES_INVALID_GENERATION,
     EVENT_STAGED_PUBLICATION_FAILED,
+    EVENT_PERSIST_FAILED,
     EVENT_STAGED_SALVAGE_STARTED,
     EVENT_STAGED_SALVAGE_COMPLETE,
     EVENT_STAGED_SALVAGE_FAILED,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
@@ -19,7 +19,7 @@ pub(super) struct RequestCacheHitProbe<'a> {
     pub(super) snap_clock: Clock,
 }
 
-pub(super) fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Option<Response> {
+pub(super) async fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Option<Response> {
     let RequestCacheHitProbe {
         state,
         sid,
@@ -115,6 +115,18 @@ pub(super) fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Option<R
         || !inputs_match
     {
         return None;
+    }
+
+    // A cold miss may have installed a provisional in-memory payload while
+    // its durable write is pending. It is immediately usable in-process; only
+    // wait when that entry is not yet visible, then re-lookup after publish.
+    if !state.artifacts.contains_key(artifact_key_hex) {
+        pending_writes::await_pending(
+            &state.pending_cache_writes,
+            artifact_key_hex,
+            pending_writes::PENDING_PAYLOAD_WAIT_TIMEOUT,
+        )
+        .await;
     }
 
     let hit_label = if same_root {
@@ -223,16 +235,19 @@ pub(super) async fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
     // Issue #610, DD-025: if a cold-miss for this artifact key is still
     // publishing to the in-memory cache, briefly wait so the materialize
     // step below hits instead of falling through to a recompile-on-race.
-    // Capped at PENDING_WAIT_TIMEOUT (5 ms) inside the helper; common case
-    // (no pending entry) returns immediately. `await_pending` clones the
-    // inner `Arc<Notify>` before yielding so no DashMap shard lock
+    // A provisional in-memory payload remains usable for this process while
+    // persistence is in flight. Wait only if it is not yet visible; then a
+    // completion can publish it before we re-lookup. `await_pending` clones
+    // the inner `Arc<Notify>` before yielding so no DashMap shard lock
     // straddles the await.
-    pending_writes::await_pending(
-        &state.pending_cache_writes,
-        &entry_artifact_key_hex,
-        pending_writes::PENDING_WAIT_TIMEOUT,
-    )
-    .await;
+    if !state.artifacts.contains_key(&entry_artifact_key_hex) {
+        pending_writes::await_pending(
+            &state.pending_cache_writes,
+            &entry_artifact_key_hex,
+            pending_writes::PENDING_PAYLOAD_WAIT_TIMEOUT,
+        )
+        .await;
+    }
 
     let secondary_output_dir = if is_rustc {
         output_path.parent().unwrap_or(cwd_path).into()

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
@@ -163,6 +163,56 @@ pub(super) fn store_miss_artifact(request: MissArtifactStoreRequest<'_>) -> Miss
 
 const MAX_STAGED_PUBLICATION_ERROR_CHARS: usize = 512;
 
+/// Result of the detached single-output persist operation.
+///
+/// The background task is deliberately required to hand this back to its
+/// async parent: an index row is only valid after the artifact files have
+/// been published.  Keeping this as a named, must-use outcome prevents a
+/// future logging-only error branch from silently turning a failed persist
+/// into a durable dangling index entry.
+#[derive(Debug)]
+#[must_use = "a persist outcome must gate index publication"]
+struct PersistOutcome {
+    published: bool,
+    meta: Option<ArtifactIndex>,
+}
+
+impl PersistOutcome {
+    const fn published(meta: ArtifactIndex) -> Self {
+        Self {
+            published: true,
+            meta: Some(meta),
+        }
+    }
+
+    const fn failed() -> Self {
+        Self {
+            published: false,
+            meta: None,
+        }
+    }
+}
+
+/// The only async single-output index-publication gate.
+///
+/// Keep the outcome consumption next to the channel send: a failed persist
+/// must remain a clean miss rather than becoming an index row whose payload
+/// never existed.
+fn enqueue_persisted_index(
+    outcome: PersistOutcome,
+    index_writer_tx: &tokio::sync::mpsc::UnboundedSender<IndexWriterCommand>,
+    key_hex: String,
+) -> bool {
+    if !outcome.published {
+        return false;
+    }
+    let Some(meta) = outcome.meta else {
+        return false;
+    };
+    let _ = index_writer_tx.send(IndexWriterCommand::Insert(key_hex, meta));
+    true
+}
+
 /// Record the full persistence failure at the stage where publication is
 /// abandoned. The profiler retains the compact reason ID; the lifecycle and
 /// session logs retain a bounded OS error so an operator can identify the
@@ -462,6 +512,11 @@ fn store_single_output(
         .map(|o| o.payload.size_bytes())
         .sum();
     let cached = CachedArtifact::from_artifact_data(&artifact);
+    let persist_payloads: Vec<Arc<Vec<u8>>> = artifact
+        .outputs
+        .iter()
+        .filter_map(|output| output.payload.as_bytes().cloned())
+        .collect();
     stats.artifact_build_ns = t_artifact_build.elapsed().as_nanos() as u64;
     let t_persist_enqueue = Instant::now();
 
@@ -563,21 +618,22 @@ fn store_single_output(
         return;
     }
 
-    // Publish the live entry before transferring the same read guard to the
-    // detached task. A queued writer can never observe a gap between the map
-    // insertion and the disk/index publication it must drain.
-    state.artifacts.insert(artifact_key_hex.to_string(), cached);
-    let sem = Arc::clone(&state.persist_semaphore);
-    let state_ref = Arc::clone(state_arc);
-    let index_writer_tx = state.index_writer_tx.clone();
-    let completion_key = artifact_key_hex.to_string();
     // Issue #610, DD-025 condition 1: pending-write registration around
     // the C/C++ cold-miss persist spawn. Concurrent lookups can observe
     // that disk publication is in flight and (optionally) wait briefly
     // for it instead of recompiling-on-race. Completion is signalled on
     // both success and failure paths (failure wakes waiters → re-lookup
     // misses → recompile; the DD-025 failure-mode-is-miss invariant).
+    // Publish the in-process payload before handing persistence to the
+    // detached task. A failed persist removes this provisional entry, while
+    // the typed outcome below prevents the durable index publication.
+    state.artifacts.insert(artifact_key_hex.to_string(), cached);
     let _pending = pending_writes::register(&state.pending_cache_writes, artifact_key_hex);
+    let sem = Arc::clone(&state.persist_semaphore);
+    let state_ref = Arc::clone(state_arc);
+    let index_writer_tx = state.index_writer_tx.clone();
+    let lifecycle_cache_root = state.cache_dir.clone();
+    let completion_key = artifact_key_hex.to_string();
     tokio::spawn(async move {
         #[expect(
             clippy::expect_used,
@@ -602,22 +658,45 @@ fn store_single_output(
             // src_size_now= — is baked into the error by
             // `persist::enrich_persist_err`).
             let gap_ms = t_persist_enqueue.elapsed().as_millis() as u64;
-            match persist_artifact_paths(&artifact_dir, &key_hex, &source_paths) {
-                Ok(()) => {
-                    let _ = index_writer_tx.send(IndexWriterCommand::Insert(key_hex, persist_meta));
-                }
+            match persist_artifact_payloads(&artifact_dir, &key_hex, &persist_payloads) {
+                Ok(()) => PersistOutcome::published(persist_meta),
                 Err(e) => {
                     tracing::warn!(
                         key = %key_hex,
+                        paths = ?source_paths,
+                        errno = ?e.raw_os_error(),
                         gap_ms,
                         "failed to persist artifact output: {e}"
                     );
+                    crate::core::lifecycle::write_event_in_cache_root(
+                        lifecycle_cache_root.as_path(),
+                        crate::core::lifecycle::EVENT_PERSIST_FAILED,
+                        serde_json::json!({
+                            "artifact_key": key_hex,
+                            "paths": source_paths.iter().map(|path| path.as_path().display().to_string()).collect::<Vec<_>>(),
+                            "errno": e.raw_os_error(),
+                            "error": e.to_string(),
+                            "gap_ms": gap_ms,
+                        }),
+                    );
+                    PersistOutcome::failed()
                 }
             }
         })
         .await;
-        if let Err(error) = written {
-            tracing::warn!(%error, "artifact persistence task failed to join");
+        match written {
+            Ok(outcome) => {
+                if !enqueue_persisted_index(outcome, &index_writer_tx, completion_key.clone()) {
+                    // This entry was only provisional while the filesystem
+                    // publish ran. Do not retain a lookup row for a failed
+                    // persist, or a later hit could point at missing payloads.
+                    state_ref.artifacts.remove(&completion_key);
+                }
+            }
+            Err(error) => {
+                tracing::warn!(%error, "artifact persistence task failed to join");
+                state_ref.artifacts.remove(&completion_key);
+            }
         }
         // Always complete the pending entry, even on JoinError, so
         // waiters cannot hang past the spawn's lifetime.
@@ -638,10 +717,26 @@ fn store_single_output(
 #[cfg(test)]
 mod staged_publication_diagnostic_tests {
     use super::{
-        preserve_staged_depfile_for_persistence, truncate_staged_publication_error,
-        MAX_STAGED_PUBLICATION_ERROR_CHARS,
+        enqueue_persisted_index, preserve_staged_depfile_for_persistence,
+        truncate_staged_publication_error, PersistOutcome, MAX_STAGED_PUBLICATION_ERROR_CHARS,
     };
     use crate::core::NormalizedPath;
+
+    #[test]
+    fn failed_async_persist_never_enqueues_an_index_insert() {
+        let (index_tx, mut index_rx) = tokio::sync::mpsc::unbounded_channel();
+        let queued = enqueue_persisted_index(
+            PersistOutcome::failed(),
+            &index_tx,
+            "failed-persist-key".to_string(),
+        );
+
+        assert!(!queued, "a failed persist must not be indexed");
+        assert!(
+            index_rx.try_recv().is_err(),
+            "failed persist must not send IndexWriterCommand::Insert"
+        );
+    }
 
     #[test]
     fn publication_error_is_bounded_without_splitting_utf8() {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -148,7 +148,9 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         client_env: client_env.as_deref(),
         compile_start,
         snap_clock,
-    }) {
+    })
+    .await
+    {
         return response;
     }
 


### PR DESCRIPTION
Fixes #1163.\n\nAsync single-output persistence now returns a must-use outcome carrying index metadata; an index row is enqueued only after publication succeeds. Failed or aborted persistence removes the live entry, wakes pending readers, and emits an explicit-root persist_failed lifecycle event.\n\nValidation: independent review, formatter/diff checks, focused unit attempted locally (Windows compilation window exceeded without test/compiler error).