### PR TITLE
feat(cache): model nested Dylint rustc invocations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,41 +103,17 @@ jobs:
       - name: Check Dylint Library Formatting (ban_normalized_path_deref_containment)
         run: soldr cargo fmt --manifest-path dylints/ban_normalized_path_deref_containment/Cargo.toml --all -- --check
       - name: Test Dylint Library (ban_std_pathbuf)
-        run: |
-          export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
-          export RUSTUP_TOOLCHAIN=nightly-2026-05-26
-          export PATH="$(dirname "${RUSTC}"):${CARGO_HOME}/bin:${PATH}"
-          soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_std_pathbuf/Cargo.toml
+        run: soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_std_pathbuf/Cargo.toml
       - name: Test Dylint Library (ban_unrooted_tempdir)
-        run: |
-          export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
-          export RUSTUP_TOOLCHAIN=nightly-2026-05-26
-          export PATH="$(dirname "${RUSTC}"):${CARGO_HOME}/bin:${PATH}"
-          soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_unrooted_tempdir/Cargo.toml
+        run: soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_unrooted_tempdir/Cargo.toml
       - name: Test Dylint Library (ban_tmp_literal)
-        run: |
-          export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
-          export RUSTUP_TOOLCHAIN=nightly-2026-05-26
-          export PATH="$(dirname "${RUSTC}"):${CARGO_HOME}/bin:${PATH}"
-          soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_tmp_literal/Cargo.toml
+        run: soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_tmp_literal/Cargo.toml
       - name: Test Dylint Library (ban_raw_subprocess_in_daemon)
-        run: |
-          export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
-          export RUSTUP_TOOLCHAIN=nightly-2026-05-26
-          export PATH="$(dirname "${RUSTC}"):${CARGO_HOME}/bin:${PATH}"
-          soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_raw_subprocess_in_daemon/Cargo.toml
+        run: soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_raw_subprocess_in_daemon/Cargo.toml
       - name: Test Dylint Library (ban_legacy_artifact_path)
-        run: |
-          export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
-          export RUSTUP_TOOLCHAIN=nightly-2026-05-26
-          export PATH="$(dirname "${RUSTC}"):${CARGO_HOME}/bin:${PATH}"
-          soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_legacy_artifact_path/Cargo.toml
+        run: soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_legacy_artifact_path/Cargo.toml
       - name: Test Dylint Library (ban_normalized_path_deref_containment)
-        run: |
-          export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
-          export RUSTUP_TOOLCHAIN=nightly-2026-05-26
-          export PATH="$(dirname "${RUSTC}"):${CARGO_HOME}/bin:${PATH}"
-          soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_normalized_path_deref_containment/Cargo.toml
+        run: soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_normalized_path_deref_containment/Cargo.toml
       - name: Run Dylint
         run: |
           export PATH="${CARGO_HOME}/bin:${PATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, feat/dylint-nested-cache]
+    branches: [main]
     paths-ignore:
       - "**/*.md"
       - "LICENSE*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, feat/dylint-nested-cache]
     paths-ignore:
       - "**/*.md"
       - "LICENSE*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,8 @@ jobs:
           cache-eviction-policy: protect-foundations
       - name: Check MSRV
         run: soldr cargo check --workspace
+      - name: Verify nested Dylint cache contract
+        run: soldr cargo test -p zccache --test daemon_dylint_cache_test -- --ignored
 
   docs:
     name: Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4233,6 +4233,7 @@ name = "zccache-compiler"
 version = "1.12.17"
 dependencies = [
  "clang",
+ "serde_json",
  "tempfile",
  "thiserror",
  "zccache-core",

--- a/ci/tests/test_lint.py
+++ b/ci/tests/test_lint.py
@@ -1,8 +1,25 @@
 import os
-from types import SimpleNamespace
+import re
 from pathlib import Path
+from types import SimpleNamespace
 
 from ci import lint
+
+
+def test_dylint_sources_do_not_set_a_dated_toolchain_globally():
+    forbidden = re.compile(
+        r"""set_var\s*\(\s*["']RUSTUP_TOOLCHAIN["']\s*,\s*["']nightly-\d{4}-\d{2}-\d{2}"""
+    )
+    violations = [
+        str(path.relative_to(lint.SCRIPT_DIR))
+        for path in (lint.SCRIPT_DIR / "dylints").rglob("*.rs")
+        if forbidden.search(path.read_text(encoding="utf-8"))
+    ]
+
+    assert not violations, (
+        "Dylint tests must inherit the front-door toolchain instead of mutating "
+        f"process-global RUSTUP_TOOLCHAIN: {violations}"
+    )
 
 
 def test_dylint_env_puts_selected_toolchain_first(monkeypatch):

--- a/crates/zccache-compiler/Cargo.toml
+++ b/crates/zccache-compiler/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 
 [dependencies]
 clang = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 zccache-core = { workspace = true }
 zccache-hash = { workspace = true }

--- a/crates/zccache-compiler/src/detect.rs
+++ b/crates/zccache-compiler/src/detect.rs
@@ -10,6 +10,49 @@ pub(crate) const SOURCE_EXTENSIONS: &[&str] = &[
 /// File extensions that imply module-interface mode even without `-x c++-module`.
 pub(crate) const MODULE_EXTENSIONS: &[&str] = &["cppm", "ixx"];
 
+fn executable_stem(executable: &str) -> &str {
+    let basename = executable
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(executable);
+    basename
+        .strip_suffix(".exe")
+        .or_else(|| basename.strip_suffix(".EXE"))
+        .unwrap_or(basename)
+}
+
+/// Whether `executable` is Dylint's compiler driver.
+///
+/// Keep this deliberately exact. Treating arbitrary `*-driver` programs as
+/// rustc-compatible would let an unrelated executable enter the Rust cache
+/// path without a modeled argv or cache-key contract.
+#[must_use]
+pub fn is_dylint_driver(executable: &str) -> bool {
+    executable_stem(executable) == "dylint-driver"
+}
+
+/// Return the inner rustc argv from Dylint's nested compiler shape.
+///
+/// Dylint invokes `<dylint-driver> <rustc> <rustc-args...>`. The outer
+/// driver and complete argv must still be executed unchanged; this slice is
+/// only for rustc-style parsing and key construction.
+pub fn dylint_inner_rustc_args<'a>(
+    compiler: &str,
+    args: &'a [String],
+) -> Result<Option<(&'a str, &'a [String])>, &'static str> {
+    if !is_dylint_driver(compiler) {
+        return Ok(None);
+    }
+    let Some((inner, rustc_args)) = args.split_first() else {
+        return Err("dylint-driver requires an inner rustc executable");
+    };
+    let inner_stem = executable_stem(inner);
+    if inner_stem != "rustc" && !inner_stem.starts_with("rustc-") {
+        return Err("dylint-driver inner rustc executable is missing or unsupported");
+    }
+    Ok(Some((inner.as_str(), rustc_args)))
+}
+
 /// Detect the compiler family from the compiler path.
 #[must_use]
 pub fn detect_family(compiler: &str) -> CompilerFamily {
@@ -21,7 +64,8 @@ pub fn detect_family(compiler: &str) -> CompilerFamily {
     };
     if name == "rustfmt" || name.starts_with("rustfmt-") {
         CompilerFamily::Rustfmt
-    } else if name == "rustc"
+    } else if is_dylint_driver(compiler)
+        || name == "rustc"
         || name.starts_with("rustc-")
         || name == "clippy-driver"
         || name.starts_with("clippy-driver-")

--- a/crates/zccache-compiler/src/detect.rs
+++ b/crates/zccache-compiler/src/detect.rs
@@ -11,10 +11,7 @@ pub(crate) const SOURCE_EXTENSIONS: &[&str] = &[
 pub(crate) const MODULE_EXTENSIONS: &[&str] = &["cppm", "ixx"];
 
 fn executable_stem(executable: &str) -> &str {
-    let basename = executable
-        .rsplit(['/', '\\'])
-        .next()
-        .unwrap_or(executable);
+    let basename = executable.rsplit(['/', '\\']).next().unwrap_or(executable);
     basename
         .strip_suffix(".exe")
         .or_else(|| basename.strip_suffix(".EXE"))

--- a/crates/zccache-compiler/src/dylint.rs
+++ b/crates/zccache-compiler/src/dylint.rs
@@ -4,7 +4,7 @@
 //! dependency graph. A nested driver request is cacheable only when every
 //! library named by `DYLINT_LIBS` can be content-hashed.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use zccache_core::NormalizedPath;
 use zccache_hash::ContentHash;
@@ -84,7 +84,7 @@ where
         .rev()
         .find_map(|(name, value)| (name == DYLINT_LIBS_ENV).then_some(value))
         .ok_or_else(|| format!("{DYLINT_LIBS_ENV} is missing; running uncached"))?;
-    let libraries: Vec<PathBuf> = serde_json::from_str(encoded)
+    let libraries: Vec<NormalizedPath> = serde_json::from_str(encoded)
         .map_err(|error| format!("{DYLINT_LIBS_ENV} is invalid JSON: {error}; running uncached"))?;
     if libraries.is_empty() {
         return Err(format!(
@@ -99,18 +99,18 @@ where
     hasher.update(inner_rustc_identity.as_bytes());
     hasher.update(&[0]);
     for library in libraries {
-        let path = if library.is_absolute() {
+        let path = if library.as_path().is_absolute() {
             library
         } else {
-            cwd.join(library)
+            NormalizedPath::from(cwd.join(library.as_path()))
         };
-        let library_name = path.file_name().ok_or_else(|| {
+        let library_name = path.as_path().file_name().ok_or_else(|| {
             format!(
                 "Dylint library {} has no file name; running uncached",
                 path.display()
             )
         })?;
-        let content = hash_library(&path)?;
+        let content = hash_library(path.as_path())?;
         hasher.update(library_name.to_string_lossy().as_bytes());
         hasher.update(b"=");
         hasher.update(content.as_bytes());
@@ -137,12 +137,12 @@ where
     Ok(true)
 }
 
-fn resolve_input_path(input: &str, cwd: &Path) -> PathBuf {
+fn resolve_input_path(input: &str, cwd: &Path) -> NormalizedPath {
     let path = Path::new(input);
     if path.is_absolute() {
-        path.to_path_buf()
+        NormalizedPath::from(path)
     } else {
-        cwd.join(path)
+        NormalizedPath::from(cwd.join(path))
     }
 }
 

--- a/crates/zccache-compiler/src/dylint.rs
+++ b/crates/zccache-compiler/src/dylint.rs
@@ -1,0 +1,156 @@
+//! Dylint-specific cache input validation.
+//!
+//! Dylint loads lint libraries dynamically, outside rustc's ordinary
+//! dependency graph. A nested driver request is cacheable only when every
+//! library named by `DYLINT_LIBS` can be content-hashed.
+
+use std::path::{Path, PathBuf};
+
+use zccache_core::NormalizedPath;
+use zccache_hash::ContentHash;
+
+use crate::dylint_inner_rustc_args;
+
+pub const DYLINT_LIBS_ENV: &str = "DYLINT_LIBS";
+pub const DYLINT_CACHE_INPUT_HASH_ENV: &str = "ZCCACHE_DYLINT_CACHE_INPUT_HASH";
+
+/// Whether an environment variable can affect Dylint diagnostics or driver
+/// behavior and therefore belongs in both request and artifact identities.
+#[must_use]
+pub fn dylint_env_affects_output(name: &str) -> bool {
+    (name.starts_with("DYLINT_") && name != DYLINT_LIBS_ENV)
+        || matches!(name, "RUSTUP_HOME" | "RUSTUP_TOOLCHAIN")
+        || name == "CLIPPY_DISABLE_DOCS_LINKS"
+        || name == DYLINT_CACHE_INPUT_HASH_ENV
+}
+
+/// Validate and hash the non-rustc inputs to a nested Dylint request.
+///
+/// Returns `Ok(false)` for ordinary compilers. For Dylint, the function
+/// parses `DYLINT_LIBS` as JSON, hashes every named library, and installs one
+/// synthetic, non-replayed environment value that downstream request/context
+/// key builders can consume. Any ambiguity is an error so callers can execute
+/// the driver directly without caching.
+pub fn prepare_dylint_cache_env(
+    driver: &NormalizedPath,
+    args: &[String],
+    cwd: &Path,
+    env: &mut Vec<(String, String)>,
+) -> Result<bool, String> {
+    let inner_rustc = match dylint_inner_rustc_args(driver.to_str().unwrap_or(""), args) {
+        Ok(None) => return Ok(false),
+        Ok(Some((inner_rustc, _))) => inner_rustc,
+        Err(reason) => return Err(format!("{reason}; running uncached")),
+    };
+    let inner_rustc = resolve_input_path(inner_rustc, cwd);
+    let driver_identity = hash_input(driver.as_path(), "Dylint driver")?;
+    let inner_identity = hash_input(&inner_rustc, "Dylint inner rustc")?;
+    prepare_dylint_cache_env_with_identities(
+        driver,
+        args,
+        cwd,
+        env,
+        driver_identity,
+        inner_identity,
+        |path| hash_input(path, "Dylint library"),
+    )
+}
+
+/// Cached-identity variant used by the daemon hot path.
+///
+/// The caller supplies the already memoized outer-driver and inner-rustc
+/// identities, avoiding a full executable rehash for every compilation unit.
+pub fn prepare_dylint_cache_env_with_identities<F>(
+    driver: &NormalizedPath,
+    args: &[String],
+    cwd: &Path,
+    env: &mut Vec<(String, String)>,
+    driver_identity: ContentHash,
+    inner_rustc_identity: ContentHash,
+    mut hash_library: F,
+) -> Result<bool, String>
+where
+    F: FnMut(&Path) -> Result<ContentHash, String>,
+{
+    match dylint_inner_rustc_args(driver.to_str().unwrap_or(""), args) {
+        Ok(None) => return Ok(false),
+        Ok(Some(_)) => {}
+        Err(reason) => return Err(format!("{reason}; running uncached")),
+    }
+
+    env.retain(|(name, _)| name != DYLINT_CACHE_INPUT_HASH_ENV);
+    let encoded = env
+        .iter()
+        .rev()
+        .find_map(|(name, value)| (name == DYLINT_LIBS_ENV).then_some(value))
+        .ok_or_else(|| format!("{DYLINT_LIBS_ENV} is missing; running uncached"))?;
+    let libraries: Vec<PathBuf> = serde_json::from_str(encoded)
+        .map_err(|error| format!("{DYLINT_LIBS_ENV} is invalid JSON: {error}; running uncached"))?;
+    if libraries.is_empty() {
+        return Err(format!(
+            "{DYLINT_LIBS_ENV} names no lint libraries; running uncached"
+        ));
+    }
+
+    let mut hasher = zccache_hash::StreamHasher::new();
+    hasher.update(b"zccache-dylint-cache-input-v1\0");
+    hasher.update(driver_identity.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(inner_rustc_identity.as_bytes());
+    hasher.update(&[0]);
+    for library in libraries {
+        let path = if library.is_absolute() {
+            library
+        } else {
+            cwd.join(library)
+        };
+        let library_name = path.file_name().ok_or_else(|| {
+            format!(
+                "Dylint library {} has no file name; running uncached",
+                path.display()
+            )
+        })?;
+        let content = hash_library(&path)?;
+        hasher.update(library_name.to_string_lossy().as_bytes());
+        hasher.update(b"=");
+        hasher.update(content.as_bytes());
+        hasher.update(&[0]);
+    }
+
+    let mut output_env: Vec<(&str, &str)> = env
+        .iter()
+        .filter(|(name, _)| dylint_env_affects_output(name))
+        .map(|(name, value)| (name.as_str(), value.as_str()))
+        .collect();
+    output_env.sort_unstable();
+    for (name, value) in output_env {
+        hasher.update(name.as_bytes());
+        hasher.update(b"=");
+        hasher.update(value.as_bytes());
+        hasher.update(&[0]);
+    }
+
+    env.push((
+        DYLINT_CACHE_INPUT_HASH_ENV.to_string(),
+        hasher.finalize().to_hex(),
+    ));
+    Ok(true)
+}
+
+fn resolve_input_path(input: &str, cwd: &Path) -> PathBuf {
+    let path = Path::new(input);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
+fn hash_input(path: &Path, kind: &str) -> Result<ContentHash, String> {
+    zccache_hash::hash_file(path).map_err(|error| {
+        format!(
+            "cannot hash {kind} {}: {error}; running uncached",
+            path.display()
+        )
+    })
+}

--- a/crates/zccache-compiler/src/lib.rs
+++ b/crates/zccache-compiler/src/lib.rs
@@ -20,6 +20,7 @@
 
 pub mod arduino;
 mod detect;
+mod dylint;
 mod gnu_flags;
 pub mod output_policy;
 mod parse;
@@ -38,7 +39,11 @@ mod tests;
 use std::sync::Arc;
 use zccache_core::NormalizedPath;
 
-pub use detect::detect_family;
+pub use detect::{detect_family, dylint_inner_rustc_args, is_dylint_driver};
+pub use dylint::{
+    dylint_env_affects_output, prepare_dylint_cache_env,
+    prepare_dylint_cache_env_with_identities, DYLINT_CACHE_INPUT_HASH_ENV, DYLINT_LIBS_ENV,
+};
 pub use gnu_flags::{gnu_flag_takes_value, GNU_FLAGS_WITH_VALUE};
 pub use output_policy::{
     rustc_archive_hardlink_eligible, rustc_output_delivery, DeliveryPolicy, MutationContract,

--- a/crates/zccache-compiler/src/lib.rs
+++ b/crates/zccache-compiler/src/lib.rs
@@ -41,8 +41,8 @@ use zccache_core::NormalizedPath;
 
 pub use detect::{detect_family, dylint_inner_rustc_args, is_dylint_driver};
 pub use dylint::{
-    dylint_env_affects_output, prepare_dylint_cache_env,
-    prepare_dylint_cache_env_with_identities, DYLINT_CACHE_INPUT_HASH_ENV, DYLINT_LIBS_ENV,
+    dylint_env_affects_output, prepare_dylint_cache_env, prepare_dylint_cache_env_with_identities,
+    DYLINT_CACHE_INPUT_HASH_ENV, DYLINT_LIBS_ENV,
 };
 pub use gnu_flags::{gnu_flag_takes_value, GNU_FLAGS_WITH_VALUE};
 pub use output_policy::{

--- a/crates/zccache-compiler/src/parse_rustc.rs
+++ b/crates/zccache-compiler/src/parse_rustc.rs
@@ -97,6 +97,16 @@ const RUSTC_FLAGS_WITH_VALUE: &[&str] = &[
 /// Cacheable: `--crate-type` is `lib`, `rlib`, `staticlib`, `proc-macro`, or `bin`.
 /// Non-cacheable: `dylib`, `cdylib`.
 pub(crate) fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedInvocation {
+    let execution_args = args;
+    let args = match super::dylint_inner_rustc_args(compiler, args) {
+        Ok(Some((_inner_rustc, rustc_args))) => rustc_args,
+        Ok(None) => args,
+        Err(reason) => {
+            return ParsedInvocation::NonCacheable {
+                reason: reason.to_string(),
+            };
+        }
+    };
     let mut crate_types: Vec<String> = Vec::new();
     let mut source_file: Option<String> = None;
     let mut output_file: Option<String> = None;
@@ -417,7 +427,7 @@ pub(crate) fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedI
         family: CompilerFamily::Rustc,
         source_file: NormalizedPath::new(source),
         output_file: NormalizedPath::new(output),
-        original_args: Arc::from(args.to_vec()),
+        original_args: Arc::from(execution_args.to_vec()),
         unknown_flags,
     })
 }

--- a/crates/zccache-compiler/src/tests/dylint_driver.rs
+++ b/crates/zccache-compiler/src/tests/dylint_driver.rs
@@ -1,0 +1,300 @@
+//! Dylint's nested driver adapter.
+
+use super::super::{
+    detect_family, parse_invocation, prepare_dylint_cache_env, CompilerFamily,
+    ParsedInvocation, DYLINT_CACHE_INPUT_HASH_ENV, DYLINT_LIBS_ENV,
+};
+use zccache_core::NormalizedPath;
+
+fn args(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_string()).collect()
+}
+
+#[test]
+fn detects_only_the_explicit_dylint_driver_as_rust() {
+    assert_eq!(detect_family("dylint-driver"), CompilerFamily::Rustc);
+    assert_eq!(
+        detect_family("/tmp/dylint/driver/dylint-driver"),
+        CompilerFamily::Rustc
+    );
+    assert_eq!(
+        detect_family(r"C:\dylint\driver\dylint-driver.exe"),
+        CompilerFamily::Rustc
+    );
+    assert_ne!(detect_family("arbitrary-driver"), CompilerFamily::Rustc);
+}
+
+#[test]
+fn parses_inner_rustc_args_but_preserves_nested_execution_argv() {
+    let nested = args(&[
+        "/toolchains/nightly/bin/rustc",
+        "--crate-name",
+        "violating_fixture",
+        "--crate-type",
+        "lib",
+        "--emit",
+        "metadata",
+        "--out-dir",
+        "target",
+        "src/lib.rs",
+    ]);
+
+    match parse_invocation("/tmp/dylint-driver", &nested) {
+        ParsedInvocation::Cacheable(compilation) => {
+            assert_eq!(compilation.family, CompilerFamily::Rustc);
+            assert_eq!(compilation.source_file.to_string_lossy(), "src/lib.rs");
+            assert_eq!(
+                compilation.original_args.as_ref(),
+                nested.as_slice(),
+                "the daemon must execute the driver with the inner rustc path intact"
+            );
+        }
+        other => panic!("expected cacheable nested Dylint invocation, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_dylint_driver_without_an_inner_rustc() {
+    let invocation = parse_invocation(
+        "dylint-driver",
+        &args(&["--crate-name", "fixture", "src/lib.rs"]),
+    );
+    assert!(matches!(
+        invocation,
+        ParsedInvocation::NonCacheable { ref reason }
+            if reason.contains("inner rustc")
+    ));
+}
+
+fn cache_input_hash(env: &[(String, String)]) -> &str {
+    env.iter()
+        .find_map(|(key, value)| {
+            (key == DYLINT_CACHE_INPUT_HASH_ENV).then_some(value.as_str())
+        })
+        .expect("prepared Dylint env must contain a content hash")
+}
+
+#[test]
+fn library_content_and_output_environment_invalidate_the_input_hash() {
+    let temp = tempfile::tempdir().unwrap();
+    let driver = temp.path().join("dylint-driver");
+    let rustc = temp.path().join("rustc");
+    let library = temp.path().join("libfixture.so");
+    std::fs::write(&driver, b"driver").unwrap();
+    std::fs::write(&rustc, b"rustc").unwrap();
+    std::fs::write(&library, b"lint-v1").unwrap();
+    let args = vec![
+        rustc.to_string_lossy().into_owned(),
+        "--crate-name".into(),
+        "fixture".into(),
+        "--crate-type".into(),
+        "lib".into(),
+        "src/lib.rs".into(),
+    ];
+    let libs = serde_json::to_string(&[library.clone()]).unwrap();
+    let make_env =
+        |metadata: &str, no_deps: &str, rustup_home: &str, toolchain: &str, docs_links: &str| {
+        vec![
+            (DYLINT_LIBS_ENV.into(), libs.clone()),
+            ("DYLINT_METADATA".into(), metadata.into()),
+            ("DYLINT_NO_DEPS".into(), no_deps.into()),
+            ("RUSTUP_HOME".into(), rustup_home.into()),
+            ("RUSTUP_TOOLCHAIN".into(), toolchain.into()),
+            ("CLIPPY_DISABLE_DOCS_LINKS".into(), docs_links.into()),
+        ]
+    };
+
+    let mut baseline = make_env(
+        r#"{"mode":"one"}"#,
+        "0",
+        "/rustup/fixture",
+        "nightly-fixture",
+        "0",
+    );
+    prepare_dylint_cache_env(
+        &NormalizedPath::new(&driver),
+        &args,
+        temp.path(),
+        &mut baseline,
+    )
+    .unwrap();
+    let baseline_hash = cache_input_hash(&baseline).to_string();
+
+    std::fs::write(&driver, b"driver-v2").unwrap();
+    let mut changed_driver = make_env(
+        r#"{"mode":"one"}"#,
+        "0",
+        "/rustup/fixture",
+        "nightly-fixture",
+        "0",
+    );
+    prepare_dylint_cache_env(
+        &NormalizedPath::new(&driver),
+        &args,
+        temp.path(),
+        &mut changed_driver,
+    )
+    .unwrap();
+    assert_ne!(baseline_hash, cache_input_hash(&changed_driver));
+
+    std::fs::write(&driver, b"driver").unwrap();
+    std::fs::write(&rustc, b"rustc-v2").unwrap();
+    let mut changed_rustc = make_env(
+        r#"{"mode":"one"}"#,
+        "0",
+        "/rustup/fixture",
+        "nightly-fixture",
+        "0",
+    );
+    prepare_dylint_cache_env(
+        &NormalizedPath::new(&driver),
+        &args,
+        temp.path(),
+        &mut changed_rustc,
+    )
+    .unwrap();
+    assert_ne!(baseline_hash, cache_input_hash(&changed_rustc));
+
+    std::fs::write(&rustc, b"rustc").unwrap();
+    std::fs::write(&library, b"lint-v2").unwrap();
+    let mut changed_library = make_env(
+        r#"{"mode":"one"}"#,
+        "0",
+        "/rustup/fixture",
+        "nightly-fixture",
+        "0",
+    );
+    prepare_dylint_cache_env(
+        &NormalizedPath::new(&driver),
+        &args,
+        temp.path(),
+        &mut changed_library,
+    )
+    .unwrap();
+    assert_ne!(baseline_hash, cache_input_hash(&changed_library));
+
+    std::fs::write(&library, b"lint-v1").unwrap();
+    let renamed_library = temp.path().join("librenamed_fixture.so");
+    std::fs::write(&renamed_library, b"lint-v1").unwrap();
+    let mut changed_library_name = make_env(
+        r#"{"mode":"one"}"#,
+        "0",
+        "/rustup/fixture",
+        "nightly-fixture",
+        "0",
+    );
+    let renamed_libs = serde_json::to_string(&[renamed_library]).unwrap();
+    changed_library_name
+        .iter_mut()
+        .find(|(name, _)| name == DYLINT_LIBS_ENV)
+        .unwrap()
+        .1 = renamed_libs;
+    prepare_dylint_cache_env(
+        &NormalizedPath::new(&driver),
+        &args,
+        temp.path(),
+        &mut changed_library_name,
+    )
+    .unwrap();
+    assert_ne!(
+        baseline_hash,
+        cache_input_hash(&changed_library_name),
+        "the Dylint library name controls the injected dylint_lib cfg"
+    );
+
+    for (label, mut changed_environment) in [
+        (
+            "DYLINT_METADATA",
+            make_env(
+                r#"{"mode":"two"}"#,
+                "0",
+                "/rustup/fixture",
+                "nightly-fixture",
+                "0",
+            ),
+        ),
+        (
+            "DYLINT_NO_DEPS",
+            make_env(
+                r#"{"mode":"one"}"#,
+                "1",
+                "/rustup/fixture",
+                "nightly-fixture",
+                "0",
+            ),
+        ),
+        (
+            "RUSTUP_HOME",
+            make_env(
+                r#"{"mode":"one"}"#,
+                "0",
+                "/rustup/other",
+                "nightly-fixture",
+                "0",
+            ),
+        ),
+        (
+            "RUSTUP_TOOLCHAIN",
+            make_env(
+                r#"{"mode":"one"}"#,
+                "0",
+                "/rustup/fixture",
+                "nightly-fixture-2",
+                "0",
+            ),
+        ),
+        (
+            "CLIPPY_DISABLE_DOCS_LINKS",
+            make_env(
+                r#"{"mode":"one"}"#,
+                "0",
+                "/rustup/fixture",
+                "nightly-fixture",
+                "1",
+            ),
+        ),
+    ] {
+        prepare_dylint_cache_env(
+            &NormalizedPath::new(&driver),
+            &args,
+            temp.path(),
+            &mut changed_environment,
+        )
+        .unwrap();
+        assert_ne!(
+            baseline_hash,
+            cache_input_hash(&changed_environment),
+            "{label} must invalidate the Dylint identity"
+        );
+    }
+}
+
+#[test]
+fn library_state_fails_open_when_missing_malformed_or_unhashable() {
+    let temp = tempfile::tempdir().unwrap();
+    let driver = NormalizedPath::new(temp.path().join("dylint-driver"));
+    let rustc = temp.path().join("rustc");
+    std::fs::write(&driver, b"driver").unwrap();
+    std::fs::write(&rustc, b"rustc").unwrap();
+    let args = vec![rustc.to_string_lossy().into_owned(), "src/lib.rs".into()];
+
+    let mut missing_env = Vec::new();
+    let missing =
+        prepare_dylint_cache_env(&driver, &args, temp.path(), &mut missing_env).unwrap_err();
+    assert!(missing.contains(DYLINT_LIBS_ENV));
+
+    let mut malformed_env = vec![(DYLINT_LIBS_ENV.into(), "not-json".into())];
+    let malformed =
+        prepare_dylint_cache_env(&driver, &args, temp.path(), &mut malformed_env).unwrap_err();
+    assert!(malformed.contains("JSON"));
+
+    let absent_path = temp.path().join("missing.so");
+    let mut unhashable = vec![(
+        DYLINT_LIBS_ENV.into(),
+        serde_json::to_string(&[absent_path]).unwrap(),
+    )];
+    let error =
+        prepare_dylint_cache_env(&driver, &args, temp.path(), &mut unhashable).unwrap_err();
+    assert!(error.contains("uncached"));
+    assert!(error.contains("missing.so"));
+}

--- a/crates/zccache-compiler/src/tests/dylint_driver.rs
+++ b/crates/zccache-compiler/src/tests/dylint_driver.rs
@@ -42,7 +42,7 @@ fn parses_inner_rustc_args_but_preserves_nested_execution_argv() {
     match parse_invocation("/tmp/dylint-driver", &nested) {
         ParsedInvocation::Cacheable(compilation) => {
             assert_eq!(compilation.family, CompilerFamily::Rustc);
-            assert_eq!(compilation.source_file.to_string_lossy(), "src/lib.rs");
+            assert_eq!(compilation.source_file, NormalizedPath::new("src/lib.rs"));
             assert_eq!(
                 compilation.original_args.as_ref(),
                 nested.as_slice(),

--- a/crates/zccache-compiler/src/tests/dylint_driver.rs
+++ b/crates/zccache-compiler/src/tests/dylint_driver.rs
@@ -1,8 +1,8 @@
 //! Dylint's nested driver adapter.
 
 use super::super::{
-    detect_family, parse_invocation, prepare_dylint_cache_env, CompilerFamily,
-    ParsedInvocation, DYLINT_CACHE_INPUT_HASH_ENV, DYLINT_LIBS_ENV,
+    detect_family, parse_invocation, prepare_dylint_cache_env, CompilerFamily, ParsedInvocation,
+    DYLINT_CACHE_INPUT_HASH_ENV, DYLINT_LIBS_ENV,
 };
 use zccache_core::NormalizedPath;
 
@@ -68,9 +68,7 @@ fn rejects_dylint_driver_without_an_inner_rustc() {
 
 fn cache_input_hash(env: &[(String, String)]) -> &str {
     env.iter()
-        .find_map(|(key, value)| {
-            (key == DYLINT_CACHE_INPUT_HASH_ENV).then_some(value.as_str())
-        })
+        .find_map(|(key, value)| (key == DYLINT_CACHE_INPUT_HASH_ENV).then_some(value.as_str()))
         .expect("prepared Dylint env must contain a content hash")
 }
 
@@ -94,15 +92,15 @@ fn library_content_and_output_environment_invalidate_the_input_hash() {
     let libs = serde_json::to_string(&[library.clone()]).unwrap();
     let make_env =
         |metadata: &str, no_deps: &str, rustup_home: &str, toolchain: &str, docs_links: &str| {
-        vec![
-            (DYLINT_LIBS_ENV.into(), libs.clone()),
-            ("DYLINT_METADATA".into(), metadata.into()),
-            ("DYLINT_NO_DEPS".into(), no_deps.into()),
-            ("RUSTUP_HOME".into(), rustup_home.into()),
-            ("RUSTUP_TOOLCHAIN".into(), toolchain.into()),
-            ("CLIPPY_DISABLE_DOCS_LINKS".into(), docs_links.into()),
-        ]
-    };
+            vec![
+                (DYLINT_LIBS_ENV.into(), libs.clone()),
+                ("DYLINT_METADATA".into(), metadata.into()),
+                ("DYLINT_NO_DEPS".into(), no_deps.into()),
+                ("RUSTUP_HOME".into(), rustup_home.into()),
+                ("RUSTUP_TOOLCHAIN".into(), toolchain.into()),
+                ("CLIPPY_DISABLE_DOCS_LINKS".into(), docs_links.into()),
+            ]
+        };
 
     let mut baseline = make_env(
         r#"{"mode":"one"}"#,
@@ -293,8 +291,7 @@ fn library_state_fails_open_when_missing_malformed_or_unhashable() {
         DYLINT_LIBS_ENV.into(),
         serde_json::to_string(&[absent_path]).unwrap(),
     )];
-    let error =
-        prepare_dylint_cache_env(&driver, &args, temp.path(), &mut unhashable).unwrap_err();
+    let error = prepare_dylint_cache_env(&driver, &args, temp.path(), &mut unhashable).unwrap_err();
     assert!(error.contains("uncached"));
     assert!(error.contains("missing.so"));
 }

--- a/crates/zccache-compiler/src/tests/mod.rs
+++ b/crates/zccache-compiler/src/tests/mod.rs
@@ -10,6 +10,7 @@ pub mod clippy_driver;
 pub mod cpp_output;
 pub mod cpp_parse;
 pub mod detect;
+pub mod dylint_driver;
 pub mod modules;
 pub mod rustc;
 

--- a/crates/zccache-daemon-core/src/daemon/server/client_env.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/client_env.rs
@@ -34,7 +34,10 @@ pub(super) fn apply_client_env(
 /// receives those names through IPC, not the fds themselves, so replaying them
 /// into daemon-spawned compilers produces Cargo's stale-jobserver warning.
 pub(super) fn client_env_var_is_safe_to_replay(key: &str) -> bool {
-    !matches!(key, "MAKEFLAGS" | "CARGO_MAKEFLAGS")
+    !matches!(
+        key,
+        "MAKEFLAGS" | "CARGO_MAKEFLAGS" | crate::compiler::DYLINT_CACHE_INPUT_HASH_ENV
+    )
 }
 
 /// Sync-command counterpart of [`apply_client_env`].

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
@@ -501,11 +501,8 @@ fn rustc_requested_depfile(effective_args: &[String], cwd: &Path) -> Option<Norm
 }
 
 fn effective_rustc_args<'a>(compiler_path: &Path, effective_args: &'a [String]) -> &'a [String] {
-    crate::compiler::dylint_inner_rustc_args(
-        &compiler_path.to_string_lossy(),
-        effective_args,
-    )
-    .ok()
-    .flatten()
-    .map_or(effective_args, |(_, args)| args)
+    crate::compiler::dylint_inner_rustc_args(&compiler_path.to_string_lossy(), effective_args)
+        .ok()
+        .flatten()
+        .map_or(effective_args, |(_, args)| args)
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
@@ -62,14 +62,11 @@ pub(super) async fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Op
     // hits, this routes the depfile to worktree B's path even though the
     // entry was created from worktree A — same semantics as
     // `source_path` / `output_path`.
-    let compiler_name = compiler_path
-        .file_stem()
-        .and_then(|name| name.to_str())
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    let is_rustc = compiler_name.contains("rustc") || compiler_name == "clippy-driver";
+    let is_rustc = crate::compiler::detect_family(&compiler_path.to_string_lossy())
+        == crate::compiler::CompilerFamily::Rustc;
+    let rustc_args = effective_rustc_args(compiler_path, effective_args);
     let current_depfile_dest: Option<NormalizedPath> = if is_rustc {
-        rustc_requested_depfile(effective_args, cwd)
+        rustc_requested_depfile(rustc_args, cwd)
     } else {
         None
     }
@@ -134,10 +131,9 @@ pub(super) async fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Op
     } else {
         "HIT_WORKTREE_REQUEST"
     };
-    let rustc_requested_outputs =
-        rustc_explicit_requested_outputs(effective_args, &output_path, cwd);
+    let rustc_requested_outputs = rustc_explicit_requested_outputs(rustc_args, &output_path, cwd);
     let rustc_archive_hardlink_eligible =
-        is_rustc.then(|| crate::compiler::rustc_archive_hardlink_eligible(effective_args));
+        is_rustc.then(|| crate::compiler::rustc_archive_hardlink_eligible(rustc_args));
     materialize_cached_compile_hit(CachedHitMaterializeRequest {
         state,
         sid,
@@ -259,14 +255,15 @@ pub(super) async fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
     } else {
         "HIT_FAST"
     };
+    let rustc_args = effective_rustc_args(compiler_path, effective_args);
     let input_paths = request_cache_input_paths(state, &context_key, source_path, ctx);
     let current_depfile_dest: Option<NormalizedPath> = if is_rustc {
-        rustc_requested_depfile(effective_args, cwd_path.as_path())
+        rustc_requested_depfile(rustc_args, cwd_path.as_path())
     } else {
         dep_flags.and_then(|flags| user_depfile_destination(flags, output_path.as_path()))
     };
     let rustc_requested_outputs = if is_rustc {
-        rustc_explicit_requested_outputs(effective_args, output_path, cwd_path)
+        rustc_explicit_requested_outputs(rustc_args, output_path, cwd_path)
     } else {
         None
     };
@@ -286,7 +283,7 @@ pub(super) async fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
         mtime_floor_paths: input_paths.clone(),
         rustc_metadata_compat_outputs: rustc_requested_outputs,
         rustc_archive_hardlink_eligible: is_rustc
-            .then(|| crate::compiler::rustc_archive_hardlink_eligible(effective_args)),
+            .then(|| crate::compiler::rustc_archive_hardlink_eligible(rustc_args)),
         phases: CachedHitPhases {
             parse_args_ns,
             build_context_ns,
@@ -390,14 +387,15 @@ pub(super) async fn try_depgraph_cached_hit(
     } else {
         "HIT"
     };
+    let rustc_args = effective_rustc_args(compiler_path, effective_args);
     let input_paths = request_cache_input_paths(state, &context_key, source_path, ctx);
     let current_depfile_dest: Option<NormalizedPath> = if is_rustc {
-        rustc_requested_depfile(effective_args, cwd_path.as_path())
+        rustc_requested_depfile(rustc_args, cwd_path.as_path())
     } else {
         dep_flags.and_then(|flags| user_depfile_destination(flags, output_path.as_path()))
     };
     let rustc_requested_outputs = if is_rustc {
-        rustc_explicit_requested_outputs(effective_args, output_path, cwd_path)
+        rustc_explicit_requested_outputs(rustc_args, output_path, cwd_path)
     } else {
         None
     };
@@ -430,7 +428,7 @@ pub(super) async fn try_depgraph_cached_hit(
         mtime_floor_paths: input_paths.clone(),
         rustc_metadata_compat_outputs: rustc_requested_outputs,
         rustc_archive_hardlink_eligible: is_rustc
-            .then(|| crate::compiler::rustc_archive_hardlink_eligible(effective_args)),
+            .then(|| crate::compiler::rustc_archive_hardlink_eligible(rustc_args)),
         phases: CachedHitPhases {
             parse_args_ns,
             build_context_ns,
@@ -500,4 +498,14 @@ fn rustc_explicit_requested_outputs(
 fn rustc_requested_depfile(effective_args: &[String], cwd: &Path) -> Option<NormalizedPath> {
     let parsed = crate::depgraph::parse_rustc_args(effective_args, cwd);
     crate::daemon::server::rustc_depfile_output_path(&parsed, cwd)
+}
+
+fn effective_rustc_args<'a>(compiler_path: &Path, effective_args: &'a [String]) -> &'a [String] {
+    crate::compiler::dylint_inner_rustc_args(
+        &compiler_path.to_string_lossy(),
+        effective_args,
+    )
+    .ok()
+    .flatten()
+    .map_or(effective_args, |(_, args)| args)
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -49,6 +49,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         client_env,
         stdin,
     } = req;
+    let mut client_env = client_env;
     let state = state_arc.as_ref();
     let compile_start = std::time::Instant::now();
     let sid = match session_id.parse::<SessionId>() {
@@ -86,6 +87,89 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         worktree_root.as_ref(),
         client_env.as_deref(),
     );
+
+    if crate::compiler::is_dylint_driver(&compiler_path.to_string_lossy()) {
+        let dylint_result = async {
+            let (inner_rustc, _) = crate::compiler::dylint_inner_rustc_args(
+                &compiler_path.to_string_lossy(),
+                &effective_args,
+            )
+            .map_err(str::to_string)?
+            .ok_or_else(|| "Dylint nested invocation was not recognized".to_string())?;
+            let inner_rustc = {
+                let path = Path::new(inner_rustc);
+                if path.is_absolute() {
+                    path.to_path_buf()
+                } else {
+                    cwd.join(path)
+                }
+            };
+            let driver_identity = state
+                .compiler_hash_cache
+                .get_or_hash_with_async(compiler_path, |path| async move {
+                    tokio::task::spawn_blocking(move || crate::hash::hash_file(&path).ok())
+                        .await
+                        .ok()
+                        .flatten()
+                })
+                .await
+                .ok_or_else(|| {
+                    format!("cannot identify Dylint driver {}", compiler_path.display())
+                })?;
+            let inner_rustc_identity = state
+                .compiler_hash_cache
+                .get_or_hash_rustc_identity_async(&inner_rustc)
+                .await
+                .ok_or_else(|| {
+                    format!("cannot identify Dylint inner rustc {}", inner_rustc.display())
+                })?;
+            let env = client_env.get_or_insert_with(Vec::new);
+            crate::compiler::prepare_dylint_cache_env_with_identities(
+                &NormalizedPath::new(compiler_path),
+                &effective_args,
+                cwd,
+                env,
+                driver_identity,
+                inner_rustc_identity,
+                |path| {
+                    state
+                        .compiler_hash_cache
+                        .get_or_hash_with(path, |path| crate::hash::hash_file(path).ok())
+                        .ok_or_else(|| {
+                            format!(
+                                "cannot hash Dylint library {}; running uncached",
+                                path.display()
+                            )
+                    })
+                },
+            )
+        }
+        .await;
+        if let Err(reason) = dylint_result {
+            let diagnostic = format!("zccache: Dylint cache disabled: {reason}\n");
+            let bypass_compiler: NormalizedPath = compiler_path.into();
+            state.stats.record_compilation();
+            state.stats.record_non_cacheable();
+            record_session_stat(&state.sessions, &sid, |t| t.record_non_cacheable());
+            write_session_log(
+                &state.sessions,
+                &sid,
+                &format!("non-cacheable: Dylint cache disabled: {reason}"),
+            );
+            let response = run_compiler_direct(
+                &bypass_compiler,
+                args,
+                cwd,
+                &state.sessions,
+                &sid,
+                &client_env,
+                &stdin,
+                state.depfile_tmpdir.as_path(),
+            )
+            .await;
+            return prepend_compile_stderr(response, diagnostic.as_bytes());
+        }
+    }
     let request_cache_key_root =
         request_key_root(compiler_path, &effective_args, worktree_root.as_ref());
 
@@ -1039,6 +1123,17 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         stderr: response_stderr,
         cached: false,
     }
+}
+
+fn prepend_compile_stderr(mut response: Response, diagnostic: &[u8]) -> Response {
+    if let Response::CompileResult { stderr, .. } = &mut response {
+        let existing = std::mem::take(Arc::make_mut(stderr));
+        let mut combined = Vec::with_capacity(diagnostic.len() + existing.len());
+        combined.extend_from_slice(diagnostic);
+        combined.extend(existing);
+        *Arc::make_mut(stderr) = combined;
+    }
+    response
 }
 
 fn invalidate_missing_depgraph_artifact(

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -121,7 +121,10 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 .get_or_hash_rustc_identity_async(&inner_rustc)
                 .await
                 .ok_or_else(|| {
-                    format!("cannot identify Dylint inner rustc {}", inner_rustc.display())
+                    format!(
+                        "cannot identify Dylint inner rustc {}",
+                        inner_rustc.display()
+                    )
                 })?;
             let env = client_env.get_or_insert_with(Vec::new);
             crate::compiler::prepare_dylint_cache_env_with_identities(
@@ -140,7 +143,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                                 "cannot hash Dylint library {}; running uncached",
                                 path.display()
                             )
-                    })
+                        })
                 },
             )
         }

--- a/crates/zccache-daemon-core/src/daemon/server/keys.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/keys.rs
@@ -304,6 +304,16 @@ pub(super) fn effective_compile_args(
         }
 
         let mut effective = Vec::with_capacity(expanded_args.len() + 2);
+        if crate::compiler::is_dylint_driver(&compiler_path.to_string_lossy()) {
+            let Some((inner_rustc, rustc_args)) = expanded_args.split_first() else {
+                return expanded_args.to_vec();
+            };
+            effective.push(inner_rustc.clone());
+            effective.push("--remap-path-prefix".to_string());
+            effective.push(format!("{}=.", root_path.to_string_lossy()));
+            effective.extend_from_slice(rustc_args);
+            return effective;
+        }
         effective.push("--remap-path-prefix".to_string());
         effective.push(format!("{}=.", root_path.to_string_lossy()));
         effective.extend_from_slice(expanded_args);
@@ -427,7 +437,12 @@ pub(super) fn request_env_fingerprint_vars(
                 && key != "CARGO_MANIFEST_DIR"
                 && key != "CARGO_MANIFEST_PATH"
                 && key != "CARGO_TARGET_DIR")
-                || matches!(key, "ZCCACHE_FAST" | "ZCCACHE_SCAN_SYSTEM_HEADERS");
+                || matches!(
+                    key,
+                    "ZCCACHE_FAST"
+                        | "ZCCACHE_SCAN_SYSTEM_HEADERS"
+                        | crate::compiler::DYLINT_CACHE_INPUT_HASH_ENV
+                );
             include.then_some((key, value.as_str()))
         })
         .collect();

--- a/crates/zccache-daemon-core/src/daemon/server/rustc.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/rustc.rs
@@ -145,7 +145,7 @@ pub(super) fn build_rustc_compile_context(
     // this request but deliberately not memoized, so a transient failure
     // cannot persist a second toolchain identity flavor (#1167).
     let compiler_hash = compiler_hash_cache
-        .get_or_hash_rustc_identity(&compiler_identity_path)
+        .get_or_hash_rustc_identity(compiler_identity_path.as_path())
         .unwrap_or(COMPILER_HASH_UNAVAILABLE);
 
     let rustc_ctx = crate::depgraph::RustcCompileContext::from_parsed_args(
@@ -183,7 +183,7 @@ pub(super) async fn build_rustc_compile_context_async(
     let compiler_identity_path = rustc_identity_path(compilation, cwd);
 
     let compiler_hash = compiler_hash_cache
-        .get_or_hash_rustc_identity_async(&compiler_identity_path)
+        .get_or_hash_rustc_identity_async(compiler_identity_path.as_path())
         .await
         .unwrap_or(COMPILER_HASH_UNAVAILABLE);
 
@@ -223,7 +223,7 @@ fn rustc_args(compilation: &crate::compiler::CacheableCompilation) -> &[String] 
 fn rustc_identity_path(
     compilation: &crate::compiler::CacheableCompilation,
     cwd: &Path,
-) -> std::path::PathBuf {
+) -> NormalizedPath {
     let inner = crate::compiler::dylint_inner_rustc_args(
         compilation.compiler.to_str().unwrap_or(""),
         &compilation.original_args,
@@ -233,9 +233,9 @@ fn rustc_identity_path(
     .map(|(inner, _)| Path::new(inner))
     .unwrap_or(compilation.compiler.as_path());
     if inner.is_absolute() {
-        inner.to_path_buf()
+        NormalizedPath::new(inner)
     } else {
-        cwd.join(inner)
+        NormalizedPath::new(cwd).join(inner)
     }
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/rustc.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/rustc.rs
@@ -131,7 +131,8 @@ pub(super) fn build_rustc_compile_context(
     client_env: &[(String, String)],
     compiler_hash_cache: &CompilerHashCache,
 ) -> BuildContextResult {
-    let rustc_args = crate::depgraph::parse_rustc_args(&compilation.original_args, cwd);
+    let rustc_args = crate::depgraph::parse_rustc_args(rustc_args(compilation), cwd);
+    let compiler_identity_path = rustc_identity_path(compilation, cwd);
 
     // Compiler identity for the cache key. Different rustc versions
     // produce different output for the same source, so the identity
@@ -144,7 +145,7 @@ pub(super) fn build_rustc_compile_context(
     // this request but deliberately not memoized, so a transient failure
     // cannot persist a second toolchain identity flavor (#1167).
     let compiler_hash = compiler_hash_cache
-        .get_or_hash_rustc_identity(&compilation.compiler)
+        .get_or_hash_rustc_identity(&compiler_identity_path)
         .unwrap_or(COMPILER_HASH_UNAVAILABLE);
 
     let rustc_ctx = crate::depgraph::RustcCompileContext::from_parsed_args(
@@ -178,10 +179,11 @@ pub(super) async fn build_rustc_compile_context_async(
     client_env: &[(String, String)],
     compiler_hash_cache: &CompilerHashCache,
 ) -> BuildContextResult {
-    let rustc_args = crate::depgraph::parse_rustc_args(&compilation.original_args, cwd);
+    let rustc_args = crate::depgraph::parse_rustc_args(rustc_args(compilation), cwd);
+    let compiler_identity_path = rustc_identity_path(compilation, cwd);
 
     let compiler_hash = compiler_hash_cache
-        .get_or_hash_rustc_identity_async(&compilation.compiler)
+        .get_or_hash_rustc_identity_async(&compiler_identity_path)
         .await
         .unwrap_or(COMPILER_HASH_UNAVAILABLE);
 
@@ -205,6 +207,35 @@ pub(super) async fn build_rustc_compile_context_async(
         rustc_ctx: Box::new(rustc_ctx),
         compat_ctx,
         rustc_args: Box::new(rustc_args),
+    }
+}
+
+fn rustc_args(compilation: &crate::compiler::CacheableCompilation) -> &[String] {
+    crate::compiler::dylint_inner_rustc_args(
+        compilation.compiler.to_str().unwrap_or(""),
+        &compilation.original_args,
+    )
+    .ok()
+    .flatten()
+    .map_or(compilation.original_args.as_ref(), |(_, args)| args)
+}
+
+fn rustc_identity_path(
+    compilation: &crate::compiler::CacheableCompilation,
+    cwd: &Path,
+) -> std::path::PathBuf {
+    let inner = crate::compiler::dylint_inner_rustc_args(
+        compilation.compiler.to_str().unwrap_or(""),
+        &compilation.original_args,
+    )
+    .ok()
+    .flatten()
+    .map(|(inner, _)| Path::new(inner))
+    .unwrap_or(compilation.compiler.as_path());
+    if inner.is_absolute() {
+        inner.to_path_buf()
+    } else {
+        cwd.join(inner)
     }
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/tests/client_env.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/client_env.rs
@@ -88,3 +88,23 @@ fn apply_client_env_sync_filters_stale_jobserver_vars_for_tool_spawns() {
         Some("100")
     );
 }
+
+#[test]
+fn internal_dylint_cache_salt_is_never_replayed() {
+    let env = vec![
+        (
+            crate::compiler::DYLINT_CACHE_INPUT_HASH_ENV.to_string(),
+            "internal-only".to_string(),
+        ),
+        ("DYLINT_METADATA".to_string(), "user-value".to_string()),
+    ];
+    let mut cmd = std::process::Command::new("env");
+    apply_client_env_sync(&mut cmd, Some(&env), &test_lineage());
+
+    let envs = collect_command_env(cmd.get_envs());
+    assert_eq!(
+        env_value(&envs, crate::compiler::DYLINT_CACHE_INPUT_HASH_ENV),
+        None
+    );
+    assert_eq!(env_value(&envs, "DYLINT_METADATA"), Some("user-value"));
+}

--- a/crates/zccache-daemon-core/src/daemon/server/tests/fingerprint.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/fingerprint.rs
@@ -508,6 +508,39 @@ fn request_fingerprint_includes_rust_key_env() {
     assert_ne!(a, b);
 }
 
+#[test]
+fn request_fingerprint_includes_internal_dylint_cache_salt() {
+    let args = vec![
+        "/toolchains/nightly/bin/rustc".to_string(),
+        "src/lib.rs".to_string(),
+    ];
+    let env_a = vec![(
+        crate::compiler::DYLINT_CACHE_INPUT_HASH_ENV.to_string(),
+        "library-v1".to_string(),
+    )];
+    let env_b = vec![(
+        crate::compiler::DYLINT_CACHE_INPUT_HASH_ENV.to_string(),
+        "library-v2".to_string(),
+    )];
+
+    let a = request_fingerprint(
+        Path::new("/tmp/dylint-driver"),
+        &args,
+        Path::new("/workspace"),
+        Some(Path::new("/workspace")),
+        Some(&env_a),
+    );
+    let b = request_fingerprint(
+        Path::new("/tmp/dylint-driver"),
+        &args,
+        Path::new("/workspace"),
+        Some(Path::new("/workspace")),
+        Some(&env_b),
+    );
+
+    assert_ne!(a, b);
+}
+
 /// Dependency policy changes the effective C/C++ manifest and must therefore
 /// partition the request-level cache as well as the depgraph context key.
 #[test]

--- a/crates/zccache-daemon-core/src/daemon/server/tests/path_remap.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/path_remap.rs
@@ -23,6 +23,33 @@
 use super::super::*;
 use crate::compiler::{CompilerFamily, SourceMode};
 
+#[test]
+fn dylint_remap_is_injected_after_the_inner_rustc() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root_path = tmp.path().join("workspace");
+    let root = NormalizedPath::new(&root_path);
+    let env = vec![(PATH_REMAP_ENV.to_string(), "auto".to_string())];
+    let args = vec![
+        "/toolchains/nightly/bin/rustc".to_string(),
+        "--crate-name".to_string(),
+        "lint_target".to_string(),
+        "src/lib.rs".to_string(),
+    ];
+
+    let effective = effective_compile_args(
+        &args,
+        Path::new("/tmp/dylint-driver"),
+        &root_path,
+        Some(&root),
+        Some(&env),
+    );
+
+    assert_eq!(effective[0], args[0]);
+    assert_eq!(effective[1], "--remap-path-prefix");
+    assert_eq!(effective[2], format!("{}=.", root_path.display()));
+    assert_eq!(&effective[3..], &args[1..]);
+}
+
 // ── Piece A: flag injection ────────────────────────────────────────────────
 
 #[test]

--- a/crates/zccache-depgraph/src/args.rs
+++ b/crates/zccache-depgraph/src/args.rs
@@ -3,7 +3,7 @@
 //! Extracts include paths, defines, and cache-relevant flags from
 //! compiler command-line arguments.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use super::search_paths::IncludeSearchPaths;
 use zccache_compiler::gnu_flag_takes_value;
@@ -462,14 +462,14 @@ fn profile_input_files(path: &str, cwd: &Path) -> Vec<NormalizedPath> {
         return vec![root];
     }
 
-    fn visit(dir: &Path, files: &mut Vec<PathBuf>) {
+    fn visit(dir: &Path, files: &mut Vec<NormalizedPath>) {
         let Ok(entries) = std::fs::read_dir(dir) else {
             return;
         };
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_file() {
-                files.push(path);
+                files.push(NormalizedPath::new(path));
             } else if path.is_dir() {
                 visit(&path, files);
             }
@@ -485,7 +485,7 @@ fn profile_input_files(path: &str, cwd: &Path) -> Vec<NormalizedPath> {
         // treating `-fprofile-use` as cacheable without profile data.
         vec![root]
     } else {
-        files.into_iter().map(NormalizedPath::new).collect()
+        files
     }
 }
 

--- a/crates/zccache-depgraph/src/context/mod.rs
+++ b/crates/zccache-depgraph/src/context/mod.rs
@@ -627,10 +627,11 @@ impl RustcCompileContext {
         let mut env_vars: Vec<(String, String)> = client_env
             .iter()
             .filter(|(k, _)| {
-                k.starts_with("CARGO_")
+                (k.starts_with("CARGO_")
                     && k != "CARGO_MAKEFLAGS"
                     && k != "CARGO_INCREMENTAL"
-                    && !VOLATILE_CARGO_ENV_VARS.contains(&k.as_str())
+                    && !VOLATILE_CARGO_ENV_VARS.contains(&k.as_str()))
+                    || k == "ZCCACHE_DYLINT_CACHE_INPUT_HASH"
             })
             .cloned()
             .collect();

--- a/crates/zccache-depgraph/src/context/tests/rustc.rs
+++ b/crates/zccache-depgraph/src/context/tests/rustc.rs
@@ -545,6 +545,10 @@ fn rustc_from_parsed_args_drops_cargo_target_dir() {
         ("CARGO_TARGET_DIR".to_string(), "/repo/target-a".to_string()),
         ("CARGO_PKG_NAME".to_string(), "foo".to_string()),
         ("CARGO_PKG_VERSION".to_string(), "1.2.3".to_string()),
+        (
+            "ZCCACHE_DYLINT_CACHE_INPUT_HASH".to_string(),
+            "driver-library-and-env-identity".to_string(),
+        ),
     ];
     let ctx = RustcCompileContext::from_parsed_args(&args, &client_env, test_compiler_hash());
     assert!(
@@ -555,6 +559,13 @@ fn rustc_from_parsed_args_drops_cargo_target_dir() {
     assert!(
         ctx.env_vars.iter().any(|(k, _)| k == "CARGO_PKG_NAME"),
         "from_parsed_args must keep CARGO_PKG_NAME; got {:?}",
+        ctx.env_vars
+    );
+    assert!(
+        ctx.env_vars
+            .iter()
+            .any(|(k, _)| k == "ZCCACHE_DYLINT_CACHE_INPUT_HASH"),
+        "from_parsed_args must keep the internal Dylint cache salt; got {:?}",
         ctx.env_vars
     );
 }

--- a/crates/zccache/tests/daemon_dylint_cache_test.rs
+++ b/crates/zccache/tests/daemon_dylint_cache_test.rs
@@ -1,0 +1,254 @@
+//! End-to-end cache contract for Dylint's nested compiler invocation.
+
+#![cfg(unix)]
+#![allow(
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_used
+)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::sync::Arc;
+
+use zccache::core::NormalizedPath;
+use zccache::daemon::DaemonServer;
+use zccache::protocol::{Request, Response};
+
+type ClientConn = zccache::ipc::IpcConnection;
+
+async fn start_daemon() -> (
+    String,
+    tokio::task::JoinHandle<()>,
+    Arc<tokio::sync::Notify>,
+) {
+    let endpoint = zccache::ipc::unique_test_endpoint();
+    let mut server = DaemonServer::bind(&endpoint).unwrap();
+    let shutdown = server.shutdown_handle();
+    let handle = tokio::spawn(async move {
+        server.run(0).await.unwrap();
+    });
+    (endpoint, handle, shutdown)
+}
+
+async fn start_session(client: &mut ClientConn) -> String {
+    client
+        .send(&Request::SessionStart {
+            client_pid: std::process::id(),
+            working_dir: std::env::current_dir().unwrap().into(),
+            log_file: None,
+            track_stats: false,
+            journal_path: None,
+            profile: false,
+            private_daemon: None,
+        })
+        .await
+        .unwrap();
+    match client.recv().await.unwrap() {
+        Some(Response::SessionStarted { session_id, .. }) => session_id,
+        other => panic!("expected SessionStarted, got {other:?}"),
+    }
+}
+
+async fn compile(
+    client: &mut ClientConn,
+    session_id: &str,
+    driver: &std::path::Path,
+    args: &[String],
+    cwd: &std::path::Path,
+    dylint_libs: &str,
+    dylint_metadata: &str,
+) -> (i32, bool, Vec<u8>, Vec<u8>) {
+    let mut env: Vec<(String, String)> = std::env::vars().collect();
+    env.retain(|(name, _)| {
+        name != "DYLINT_LIBS"
+            && name != "DYLINT_METADATA"
+            && name != "ZCCACHE_DYLINT_CACHE_INPUT_HASH"
+    });
+    env.push(("DYLINT_LIBS".to_string(), dylint_libs.to_string()));
+    env.push(("DYLINT_METADATA".to_string(), dylint_metadata.to_string()));
+    client
+        .send(&Request::Compile {
+            session_id: session_id.to_string(),
+            args: args.to_vec(),
+            cwd: cwd.into(),
+            compiler: NormalizedPath::new(driver),
+            env: Some(env),
+            stdin: Vec::new(),
+        })
+        .await
+        .unwrap();
+
+    match client.recv().await.unwrap() {
+        Some(Response::CompileResult {
+            exit_code,
+            cached,
+            stdout,
+            stderr,
+        }) => (
+            exit_code,
+            cached,
+            Arc::unwrap_or_clone(stdout),
+            Arc::unwrap_or_clone(stderr),
+        ),
+        Some(Response::Error { message }) => panic!("compile error: {message}"),
+        other => panic!("unexpected response: {other:?}"),
+    }
+}
+
+fn write_driver(path: &std::path::Path, diagnostic: &str) {
+    std::fs::write(
+        path,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' '{diagnostic}' >&2\ninner=\"$1\"\nshift\nexec \"$inner\" \"$@\"\n"
+        ),
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "integration-level: starts a real daemon and rustc"]
+async fn nested_dylint_hits_and_invalidates_every_external_input() {
+    let Some(rustc) = zccache::test_support::find_rustc() else {
+        eprintln!("skipping test: rustc not found");
+        return;
+    };
+
+    zccache::test_support::test_timeout(async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        let previous_cache = std::env::var_os("ZCCACHE_CACHE_DIR");
+        std::env::set_var("ZCCACHE_CACHE_DIR", &cache);
+
+        let driver = tmp.path().join("dylint-driver");
+        let library = tmp.path().join("libworkspace_lint.so");
+        let source = tmp.path().join("lib.rs");
+        let output = tmp.path().join("libchecked.rlib");
+        write_driver(&driver, "workspace lint diagnostic v1");
+        std::fs::write(&library, b"lint-library-v1").unwrap();
+        std::fs::write(&source, "pub fn checked() -> u32 { 42 }\n").unwrap();
+
+        let args = vec![
+            rustc.display().to_string(),
+            "--edition".to_string(),
+            "2021".to_string(),
+            "--crate-type".to_string(),
+            "lib".to_string(),
+            "--crate-name".to_string(),
+            "checked".to_string(),
+            "--emit=link".to_string(),
+            source.display().to_string(),
+            "-o".to_string(),
+            output.display().to_string(),
+        ];
+        let dylint_libs = serde_json::to_string(&vec![library.clone()]).unwrap();
+
+        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let session_id = start_session(&mut client).await;
+
+        let first = compile(
+            &mut client,
+            &session_id,
+            &driver,
+            &args,
+            tmp.path(),
+            &dylint_libs,
+            "metadata-v1",
+        )
+        .await;
+        assert_eq!(first.0, 0);
+        assert!(!first.1);
+        assert!(String::from_utf8_lossy(&first.3).contains("workspace lint diagnostic v1"));
+
+        std::fs::remove_file(&output).unwrap();
+        let warm = compile(
+            &mut client,
+            &session_id,
+            &driver,
+            &args,
+            tmp.path(),
+            &dylint_libs,
+            "metadata-v1",
+        )
+        .await;
+        assert_eq!(warm.0, 0);
+        assert!(warm.1);
+        assert_eq!(warm.2, first.2);
+        assert_eq!(warm.3, first.3, "cached diagnostics must be replayed");
+
+        std::fs::write(&library, b"lint-library-v2-with-new-content").unwrap();
+        std::fs::remove_file(&output).unwrap();
+        let library_changed = compile(
+            &mut client,
+            &session_id,
+            &driver,
+            &args,
+            tmp.path(),
+            &dylint_libs,
+            "metadata-v1",
+        )
+        .await;
+        assert!(!library_changed.1, "library bytes must invalidate the hit");
+
+        std::fs::remove_file(&output).unwrap();
+        let env_changed = compile(
+            &mut client,
+            &session_id,
+            &driver,
+            &args,
+            tmp.path(),
+            &dylint_libs,
+            "metadata-v2",
+        )
+        .await;
+        assert!(!env_changed.1, "DYLINT_* output state must invalidate");
+
+        write_driver(&driver, "workspace lint diagnostic version two");
+        std::fs::remove_file(&output).unwrap();
+        let driver_changed = compile(
+            &mut client,
+            &session_id,
+            &driver,
+            &args,
+            tmp.path(),
+            &dylint_libs,
+            "metadata-v2",
+        )
+        .await;
+        assert!(!driver_changed.1, "driver bytes must invalidate");
+        assert!(
+            String::from_utf8_lossy(&driver_changed.3)
+                .contains("workspace lint diagnostic version two")
+        );
+
+        std::fs::remove_file(&output).unwrap();
+        let malformed = compile(
+            &mut client,
+            &session_id,
+            &driver,
+            &args,
+            tmp.path(),
+            "not-json",
+            "metadata-v2",
+        )
+        .await;
+        assert_eq!(malformed.0, 0, "malformed state must fail open");
+        assert!(!malformed.1);
+        assert!(
+            String::from_utf8_lossy(&malformed.3).contains("Dylint cache disabled"),
+            "fail-open reason must be visible to the user"
+        );
+
+        shutdown.notify_one();
+        server_handle.await.unwrap();
+        match previous_cache {
+            Some(value) => std::env::set_var("ZCCACHE_CACHE_DIR", value),
+            None => std::env::remove_var("ZCCACHE_CACHE_DIR"),
+        }
+    })
+    .await;
+}

--- a/crates/zccache/tests/daemon_dylint_cache_test.rs
+++ b/crates/zccache/tests/daemon_dylint_cache_test.rs
@@ -220,10 +220,8 @@ async fn nested_dylint_hits_and_invalidates_every_external_input() {
         )
         .await;
         assert!(!driver_changed.1, "driver bytes must invalidate");
-        assert!(
-            String::from_utf8_lossy(&driver_changed.3)
-                .contains("workspace lint diagnostic version two")
-        );
+        assert!(String::from_utf8_lossy(&driver_changed.3)
+            .contains("workspace lint diagnostic version two"));
 
         std::fs::remove_file(&output).unwrap();
         let malformed = compile(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,6 +25,7 @@ failed cache-root audit retain its diagnostic JSONL evidence.
 
 - **High-level design** → [overview.md](architecture/overview.md)
 - **"How does a cache hit work?"** → [data-flow.md](architecture/data-flow.md)
+- **Nested Dylint driver caching** → [data-flow.md](architecture/data-flow.md#nested-dylint-driver-caching)
 - **CLI↔daemon communication** → [ipc.md](architecture/ipc.md)
 - **File change detection** → [metadata-cache.md](architecture/metadata-cache.md)
 - **Disk cache & eviction** → [artifact-store.md](architecture/artifact-store.md)

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -17,6 +17,7 @@ Architecture docs are split by subsystem. Read only what's relevant to your curr
 | Daemon-owned disk retention | [artifact-store.md](architecture/artifact-store.md), [runtime.md](architecture/runtime.md), [embedded-service.md](architecture/embedded-service.md) |
 | `zccache-hash` | [overview.md](architecture/overview.md) (2.8) |
 | `zccache-compiler` | [overview.md](architecture/overview.md) (2.9), [data-flow.md](architecture/data-flow.md) |
+| Nested Dylint compiler caching | [data-flow.md](architecture/data-flow.md#nested-dylint-driver-caching) |
 | `zccache-core` | [overview.md](architecture/overview.md) |
 | Embedded host-daemon integration | [embedded-service.md](architecture/embedded-service.md) |
 | Embedded maintenance limits and shutdown | [embedded-service.md](architecture/embedded-service.md#maintenance-limits-and-task-ownership) |

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -167,3 +167,47 @@ its own:
   serve a stale binary; the accepted trade-off avoids per-link hashing
   of large system libraries. Revisit if a real-world stale-bin report
   lands.
+
+## Nested Dylint Driver Caching
+
+Dylint invokes Rust through a two-level compiler command:
+
+```text
+dylint-driver <rustc> <rustc arguments...>
+```
+
+zccache recognizes only the exact `dylint-driver` executable basename. It
+preserves the outer executable and nested argv layout, while parsing the
+arguments after the inner rustc path as an ordinary Rust compilation. When
+automatic path remapping is enabled and a mapping is needed, its rustc flag is
+inserted after the inner compiler path so the nested command shape remains
+valid.
+
+The cache identity adds the content identities of the outer driver, inner
+rustc, and the name plus content of every dynamic library listed in the JSON
+`DYLINT_LIBS` array (the name controls Dylint's injected `dylint_lib` cfg). It
+also includes `RUSTUP_HOME`, `RUSTUP_TOOLCHAIN`, and all output-affecting
+`DYLINT_*` variables. Dylint's diagnostic-link control
+`CLIPPY_DISABLE_DOCS_LINKS` is keyed as well. The daemon folds those inputs into an internal
+`ZCCACHE_DYLINT_CACHE_INPUT_HASH` salt used by both the request cache and Rust
+artifact context; the salt is never replayed to the driver process. Executable
+and library identities use the daemon's metadata-backed identity cache, so a
+warm lint unit does not re-hash a large rustc binary.
+
+Missing, malformed, empty, or unhashable `DYLINT_LIBS` state disables caching
+for that invocation. The driver still runs with its original argv,
+environment, stdin, stdout, stderr, and exit status, and stderr receives a
+visible `Dylint cache disabled` reason. Successful misses store the driver's
+diagnostics, so a hit replays the same stdout and stderr rather than suppressing
+lint output.
+
+This cache is separate from Cargo incremental compilation:
+
+- Cargo incremental state accelerates work inside one target directory and
+  toolchain invocation.
+- zccache restores whole Dylint-produced Rust artifacts across clean target
+  directories. Equivalent worktrees can share those artifacts when effective
+  path remapping normalizes their roots and source, toolchain, driver,
+  libraries, and output-affecting environment all match.
+- Different targets or different Dylint/rustc identities intentionally do not
+  share artifacts.

--- a/dylints/ban_std_pathbuf/src/lib.rs
+++ b/dylints/ban_std_pathbuf/src/lib.rs
@@ -230,7 +230,6 @@ impl Drop for CurrentDirGuard {
 #[test]
 fn ui() {
     let _guard = CurrentDirGuard::set(std::path::Path::new(env!("CARGO_MANIFEST_DIR")));
-    std::env::set_var("RUSTUP_TOOLCHAIN", "nightly-2026-05-26");
     prepare_dylint_library();
     dylint_testing::ui_test(env!("CARGO_PKG_NAME"), "ui");
 }

--- a/dylints/ban_tmp_literal/src/lib.rs
+++ b/dylints/ban_tmp_literal/src/lib.rs
@@ -199,7 +199,6 @@ impl Drop for CurrentDirGuard {
 #[ignore = "no .stderr snapshots yet — verify via `cargo dylint --all --workspace`"]
 fn ui() {
     let _guard = CurrentDirGuard::set(std::path::Path::new(env!("CARGO_MANIFEST_DIR")));
-    std::env::set_var("RUSTUP_TOOLCHAIN", "nightly-2026-05-26");
     prepare_dylint_library();
     dylint_testing::ui_test(env!("CARGO_PKG_NAME"), "ui");
 }

--- a/dylints/ban_unrooted_tempdir/src/lib.rs
+++ b/dylints/ban_unrooted_tempdir/src/lib.rs
@@ -234,7 +234,6 @@ impl Drop for CurrentDirGuard {
 #[ignore = "no .stderr snapshots yet — verify via `cargo dylint --all --workspace`"]
 fn ui() {
     let _guard = CurrentDirGuard::set(std::path::Path::new(env!("CARGO_MANIFEST_DIR")));
-    std::env::set_var("RUSTUP_TOOLCHAIN", "nightly-2026-05-26");
     prepare_dylint_library();
     dylint_testing::ui_test(env!("CARGO_PKG_NAME"), "ui");
 }

--- a/dylints/ui_test_support.rs
+++ b/dylints/ui_test_support.rs
@@ -16,6 +16,14 @@ impl Drop for CurrentDirGuard {
 }
 
 fn prepare_dylint_library(manifest_dir: &std::path::Path, crate_name: &str) {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let status = std::process::Command::new(cargo)
+        .arg("build")
+        .current_dir(manifest_dir)
+        .status()
+        .expect("cargo build should start");
+    assert!(status.success(), "cargo build should succeed");
+
     let toolchain = std::env::var("RUSTUP_TOOLCHAIN").expect("RUSTUP_TOOLCHAIN should be set");
     let library_name = crate_name.replace('-', "_");
     let target_root = std::env::var_os("CARGO_TARGET_DIR")

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,16 @@
+# soldr#1783 safe nested Dylint caching
+
+- [x] RED: model only the explicit nested Dylint compiler shape as Rust.
+- [x] Hash driver, inner compiler, loaded lint-library contents, and output-affecting environment.
+- [x] Fail open with a diagnostic for missing, malformed, or unhashable lint-library state.
+- [x] Cover warm hits, invalidations, diagnostics, output/exit status, and ordinary Rust regressions.
+- [x] Remove process-global dated-nightly overrides and guard against their return.
+- [ ] Exercise the supported Soldr front door in upstream CI.
+- [ ] After Soldr lands its shim, follow up upstream to run Dylint CI and the real benchmark through `soldr cargo dylint`.
+- [x] Document Cargo incremental reuse versus cross-target/worktree cache reuse.
+- [ ] Run focused tests, Linux Docker integration, lint/docs, and sanctioned performance evidence.
+- [ ] Open, drive, merge, and validate the upstream PR before updating Soldr.
+
 # Soldr embedded durability Lavra follow-up
 
 - [x] Split oversized embedded/staged-store source files without changing public API.


### PR DESCRIPTION
## Summary
- model Dylint's nested dylint-driver -> rustc invocation while preserving the executed argv
- add a Dylint-specific cache identity covering driver/compiler/library/toolchain/environment state
- bypass caching with a visible diagnostic when required nested state cannot be hashed
- add regression coverage and document nested-wrapper behavior

## Validation
- focused compiler parser tests passed in the Docker Linux harness
- Dylint depgraph cache-salt regression passed in the Docker Linux harness
- Rust, CI, Python, and docs review buckets are clean
- branch CI exposed and fixed rustfmt drift; final PR checks are the authoritative merge gate

## Coordination
This is the zccache foundation for the end-to-end soldr work. A follow-up will switch real Dylint CI and benchmark coverage to the soldr cargo dylint front door after the corresponding soldr change lands.

Refs zackees/soldr#1783
Coordinated with zackees/soldr#1788