### PR TITLE
fix(ci): rehydrate Dylint driver toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
     name: Dylint
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    env:
+      # Dylint removes RUSTUP_TOOLCHAIN before its nested driver build. Cargo
+      # rehydrates this configuration value for that build script without
+      # changing the shared CARGO_HOME cache.
+      CARGO_ENV_RUSTUP_TOOLCHAIN: nightly-2026-05-26
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6

--- a/ci/tests/test_lint.py
+++ b/ci/tests/test_lint.py
@@ -5,6 +5,17 @@ from pathlib import Path
 from ci import lint
 
 
+def test_dylint_workflow_rehydrates_the_pinned_toolchain_for_driver_builds():
+    workflow = (lint.SCRIPT_DIR / ".github/workflows/ci.yml").read_text(
+        encoding="utf-8"
+    )
+    dylint_job = workflow.split("\n  dylint:\n", 1)[1].split("\n  msrv:\n", 1)[0]
+
+    assert (
+        f"CARGO_ENV_RUSTUP_TOOLCHAIN: {lint.DYLINT_TOOLCHAIN}" in dylint_job
+    )
+
+
 def test_dylint_env_puts_selected_toolchain_first(monkeypatch):
     base_env = {"PATH": os.pathsep.join(["stable-bin", "other-bin"])}
     rustup = Path("host-shims") / "rustup"


### PR DESCRIPTION
Fixes the Dylint driver build missing its pinned toolchain without changing shared Cargo caches.

Validation: focused lint and Dylint-wiring tests (10 passed); git diff --check.

Refs #1025