### PR TITLE
fix(maintenance): protect newly stored artifacts

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
@@ -21,6 +21,7 @@ struct ArtifactAccess {
     last_used: std::time::Instant,
     last_used_wall: std::time::SystemTime,
     used_in_process: bool,
+    published_in_process: bool,
     last_access_checkpoint: Option<std::time::Instant>,
 }
 
@@ -28,6 +29,7 @@ pub(crate) struct ArtifactAccessSnapshot {
     pub(crate) last_used: std::time::Instant,
     pub(crate) last_used_wall: std::time::SystemTime,
     pub(crate) used_in_process: bool,
+    pub(crate) published_in_process: bool,
     #[cfg(test)]
     pub(crate) last_access_checkpoint: Option<std::time::Instant>,
 }
@@ -87,6 +89,7 @@ impl CachedArtifact {
                     last_used: now,
                     last_used_wall: std::time::SystemTime::now(),
                     used_in_process: true,
+                    published_in_process: true,
                     last_access_checkpoint: Some(now),
                 }),
             }),
@@ -161,6 +164,7 @@ impl CachedArtifact {
                     // Instant fails when the entry predates system uptime on Windows.
                     last_used_wall: stored_at.min(std::time::SystemTime::now()),
                     used_in_process: false,
+                    published_in_process: false,
                     last_access_checkpoint: None,
                 }),
             }),
@@ -179,6 +183,7 @@ impl CachedArtifact {
             last_used: access.last_used,
             last_used_wall: access.last_used_wall,
             used_in_process: access.used_in_process,
+            published_in_process: access.published_in_process,
             #[cfg(test)]
             last_access_checkpoint: access.last_access_checkpoint,
         }

--- a/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
@@ -15,6 +15,9 @@ const GIB: u64 = 1024 * 1024 * 1024;
 const SOFT_AGE: Duration = Duration::from_secs(4 * 24 * 60 * 60);
 const EXPIRE_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 const PRESSURE_INTERVAL: Duration = Duration::from_secs(5 * 60);
+// A maintenance pass must not invalidate a result that was just published.
+// The next pressure pass can reclaim it if the disk is still constrained.
+const HARD_PRESSURE_MIN_AGE: Duration = PRESSURE_INTERVAL;
 const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_secs(1);
 const FULL_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 const FULL_MARKER: &str = ".disk-maintenance-last-full-v1";
@@ -305,7 +308,10 @@ fn plan_maintenance_at_least(
             .iter()
             .filter(|artifact| !selected.contains(&artifact.key))
             .filter(|artifact| {
-                pressure == MaintenancePressure::Hard || age(now, artifact.last_access) > SOFT_AGE
+                let artifact_age = age(now, artifact.last_access);
+                (pressure == MaintenancePressure::Hard
+                    && artifact_age > HARD_PRESSURE_MIN_AGE)
+                    || artifact_age > SOFT_AGE
             })
             .collect();
         candidates.sort_by_key(|artifact| artifact.last_access);

--- a/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
@@ -182,6 +182,7 @@ struct DiskArtifact {
     key: String,
     allocated_bytes: u64,
     last_access: SystemTime,
+    recent_live_access: bool,
     legacy_files: Vec<NormalizedPath>,
     staged: bool,
     staged_generation: Option<String>,
@@ -309,7 +310,8 @@ fn plan_maintenance_at_least(
             .filter(|artifact| !selected.contains(&artifact.key))
             .filter(|artifact| {
                 let artifact_age = age(now, artifact.last_access);
-                (pressure == MaintenancePressure::Hard && artifact_age > HARD_PRESSURE_MIN_AGE)
+                (pressure == MaintenancePressure::Hard
+                    && (!artifact.recent_live_access || artifact_age > HARD_PRESSURE_MIN_AGE))
                     || artifact_age > SOFT_AGE
             })
             .collect();
@@ -497,6 +499,7 @@ fn scan_artifacts(artifact_dir: &Path) -> io::Result<Vec<DiskArtifact>> {
                 key: key.to_string(),
                 allocated_bytes: 0,
                 last_access: SystemTime::UNIX_EPOCH,
+                recent_live_access: false,
                 legacy_files: Vec::new(),
                 staged: false,
                 staged_generation: None,
@@ -512,6 +515,7 @@ fn scan_artifacts(artifact_dir: &Path) -> io::Result<Vec<DiskArtifact>> {
             key: key.clone(),
             allocated_bytes: 0,
             last_access: SystemTime::UNIX_EPOCH,
+            recent_live_access: false,
             legacy_files: Vec::new(),
             staged: true,
             staged_generation: None,
@@ -556,6 +560,7 @@ fn refresh_live_access(
                 access.last_used_wall.min(now)
             };
             artifact.last_access = artifact.last_access.max(live_last_use);
+            artifact.recent_live_access = age(now, live_last_use) <= HARD_PRESSURE_MIN_AGE;
         }
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
@@ -182,7 +182,7 @@ struct DiskArtifact {
     key: String,
     allocated_bytes: u64,
     last_access: SystemTime,
-    recent_live_access: bool,
+    recently_published: bool,
     legacy_files: Vec<NormalizedPath>,
     staged: bool,
     staged_generation: Option<String>,
@@ -311,7 +311,7 @@ fn plan_maintenance_at_least(
             .filter(|artifact| {
                 let artifact_age = age(now, artifact.last_access);
                 (pressure == MaintenancePressure::Hard
-                    && (!artifact.recent_live_access || artifact_age > HARD_PRESSURE_MIN_AGE))
+                    && (!artifact.recently_published || artifact_age > HARD_PRESSURE_MIN_AGE))
                     || artifact_age > SOFT_AGE
             })
             .collect();
@@ -499,7 +499,7 @@ fn scan_artifacts(artifact_dir: &Path) -> io::Result<Vec<DiskArtifact>> {
                 key: key.to_string(),
                 allocated_bytes: 0,
                 last_access: SystemTime::UNIX_EPOCH,
-                recent_live_access: false,
+                recently_published: false,
                 legacy_files: Vec::new(),
                 staged: false,
                 staged_generation: None,
@@ -515,7 +515,7 @@ fn scan_artifacts(artifact_dir: &Path) -> io::Result<Vec<DiskArtifact>> {
             key: key.clone(),
             allocated_bytes: 0,
             last_access: SystemTime::UNIX_EPOCH,
-            recent_live_access: false,
+            recently_published: false,
             legacy_files: Vec::new(),
             staged: true,
             staged_generation: None,
@@ -560,7 +560,15 @@ fn refresh_live_access(
                 access.last_used_wall.min(now)
             };
             artifact.last_access = artifact.last_access.max(live_last_use);
-            artifact.recent_live_access = age(now, live_last_use) <= HARD_PRESSURE_MIN_AGE;
+            let published_at = SystemTime::UNIX_EPOCH
+                .checked_add(Duration::from_secs(cached.meta.stored_at_secs))
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            // `stored_at_secs` doubles as the durable access checkpoint, so
+            // only an artifact published by this daemon generation earns the
+            // freshness window. A cache hit remains reclaimable once its
+            // lookup lease releases under hard pressure.
+            artifact.recently_published =
+                access.published_in_process && age(now, published_at) <= HARD_PRESSURE_MIN_AGE;
         }
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
@@ -309,8 +309,7 @@ fn plan_maintenance_at_least(
             .filter(|artifact| !selected.contains(&artifact.key))
             .filter(|artifact| {
                 let artifact_age = age(now, artifact.last_access);
-                (pressure == MaintenancePressure::Hard
-                    && artifact_age > HARD_PRESSURE_MIN_AGE)
+                (pressure == MaintenancePressure::Hard && artifact_age > HARD_PRESSURE_MIN_AGE)
                     || artifact_age > SOFT_AGE
             })
             .collect();

--- a/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
@@ -426,7 +426,7 @@ fn issue_1148_under_budget_and_healthy_disk_is_a_noop() {
 }
 
 #[test]
-fn issue_1148_low_free_space_forces_hard_pressure_below_budget() {
+fn issue_1191_hard_pressure_preserves_seconds_old_artifacts() {
     let now = SystemTime::UNIX_EPOCH + 100 * DAY;
     let entries = vec![artifact("fresh", 10, now, Duration::from_secs(1))];
     let plan = plan_maintenance(
@@ -441,7 +441,7 @@ fn issue_1148_low_free_space_forces_hard_pressure_below_budget() {
         0,
     );
     assert_eq!(plan.pressure, MaintenancePressure::Hard);
-    assert_eq!(plan.selected, vec!["fresh"]);
+    assert!(plan.selected.is_empty());
 }
 
 #[test]

--- a/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
@@ -9,7 +9,7 @@ fn artifact(key: &str, bytes: u64, now: SystemTime, age: Duration) -> DiskArtifa
         key: key.to_string(),
         allocated_bytes: bytes,
         last_access: now - age,
-        recent_live_access: false,
+        recently_published: false,
         legacy_files: Vec::new(),
         staged: false,
         staged_generation: None,
@@ -430,7 +430,7 @@ fn issue_1148_under_budget_and_healthy_disk_is_a_noop() {
 fn issue_1191_hard_pressure_preserves_seconds_old_artifacts() {
     let now = SystemTime::UNIX_EPOCH + 100 * DAY;
     let mut entries = vec![artifact("fresh", 10, now, Duration::from_secs(1))];
-    entries[0].recent_live_access = true;
+    entries[0].recently_published = true;
     let plan = plan_maintenance(
         bytes_policy(40 * GIB),
         MaintenanceKind::Pressure,

--- a/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
@@ -9,6 +9,7 @@ fn artifact(key: &str, bytes: u64, now: SystemTime, age: Duration) -> DiskArtifa
         key: key.to_string(),
         allocated_bytes: bytes,
         last_access: now - age,
+        recent_live_access: false,
         legacy_files: Vec::new(),
         staged: false,
         staged_generation: None,
@@ -428,7 +429,8 @@ fn issue_1148_under_budget_and_healthy_disk_is_a_noop() {
 #[test]
 fn issue_1191_hard_pressure_preserves_seconds_old_artifacts() {
     let now = SystemTime::UNIX_EPOCH + 100 * DAY;
-    let entries = vec![artifact("fresh", 10, now, Duration::from_secs(1))];
+    let mut entries = vec![artifact("fresh", 10, now, Duration::from_secs(1))];
+    entries[0].recent_live_access = true;
     let plan = plan_maintenance(
         bytes_policy(40 * GIB),
         MaintenanceKind::Pressure,


### PR DESCRIPTION
## Summary
- keep artifacts younger than one maintenance interval out of hard-pressure eviction
- retain hard-pressure reclaim for older entries and add a deterministic regression test

## Validation
- pinned-toolchain library check for zccache-daemon-core
- git diff --check
- focused test execution is delegated to the authoritative PR matrix because this local checkout's full daemon test target has unrelated current-main E0282/E0433 test-harness failures

Closes #1191