### PR TITLE
fix(ci): provision Dylint driver host target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           chmod +x "${shim_dir}/cargo"
           echo "${shim_dir}" >> "${GITHUB_PATH}"
       - name: Install Dylint nightly toolchain
-        run: soldr rustup toolchain install nightly-2026-05-26 --component llvm-tools-preview --component rust-src --component rustc-dev --profile minimal
+        run: soldr rustup toolchain install nightly-2026-05-26 --component llvm-tools-preview --component rust-src --component rustc-dev --target x86_64-unknown-linux-gnu --profile minimal
       - name: Install stable Rust components
         run: soldr rustup component add rustfmt
       - name: Install Dylint
@@ -119,37 +119,31 @@ jobs:
         run: |
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
-          export PATH="${CARGO_HOME}/bin:${PATH}"
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_std_pathbuf/Cargo.toml
       - name: Test Dylint Library (ban_unrooted_tempdir)
         run: |
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
-          export PATH="${CARGO_HOME}/bin:${PATH}"
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_unrooted_tempdir/Cargo.toml
       - name: Test Dylint Library (ban_tmp_literal)
         run: |
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
-          export PATH="${CARGO_HOME}/bin:${PATH}"
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_tmp_literal/Cargo.toml
       - name: Test Dylint Library (ban_raw_subprocess_in_daemon)
         run: |
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
-          export PATH="${CARGO_HOME}/bin:${PATH}"
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_raw_subprocess_in_daemon/Cargo.toml
       - name: Test Dylint Library (ban_legacy_artifact_path)
         run: |
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
-          export PATH="${CARGO_HOME}/bin:${PATH}"
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_legacy_artifact_path/Cargo.toml
       - name: Test Dylint Library (ban_normalized_path_deref_containment)
         run: |
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
-          export PATH="${CARGO_HOME}/bin:${PATH}"
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_normalized_path_deref_containment/Cargo.toml
       - name: Run Dylint
         run: |

--- a/ci/tests/test_lint.py
+++ b/ci/tests/test_lint.py
@@ -13,6 +13,8 @@ def test_dylint_workflow_rehydrates_the_pinned_toolchain_for_driver_builds():
 
     assert "Configure Dylint driver Cargo shim" in dylint_job
     assert "export RUSTUP_TOOLCHAIN=nightly-2026-05-26" in dylint_job
+    assert "--target x86_64-unknown-linux-gnu" in dylint_job
+    assert "export PATH=\"${CARGO_HOME}/bin:${PATH}\"" not in dylint_job
     assert "$(dirname \"${RUSTC}\")" not in dylint_job
 
 

--- a/ci/tests/test_lint.py
+++ b/ci/tests/test_lint.py
@@ -14,7 +14,8 @@ def test_dylint_workflow_rehydrates_the_pinned_toolchain_for_driver_builds():
     assert "Configure Dylint driver Cargo shim" in dylint_job
     assert "export RUSTUP_TOOLCHAIN=nightly-2026-05-26" in dylint_job
     assert "--target x86_64-unknown-linux-gnu" in dylint_job
-    assert "export PATH=\"${CARGO_HOME}/bin:${PATH}\"" not in dylint_job
+    library_tests = dylint_job.split("\n      - name: Run Dylint\n", 1)[0]
+    assert "export PATH=\"${CARGO_HOME}/bin:${PATH}\"" not in library_tests
     assert "$(dirname \"${RUSTC}\")" not in dylint_job
 
 


### PR DESCRIPTION
Make the Dylint Cargo shim precede the tool cache and install the nightly host target required by the driver. Focused workflow tests passed. Refs #1025