### PR TITLE
fix(persist): harden staged publication failures

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/persist/artifact_io.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/artifact_io.rs
@@ -375,7 +375,7 @@ fn is_av_scan_transient(err: &std::io::Error) -> bool {
 }
 
 #[cfg(windows)]
-fn av_scan_retry<T, F>(mut op: F) -> std::io::Result<T>
+pub(in crate::daemon::server) fn av_scan_retry<T, F>(mut op: F) -> std::io::Result<T>
 where
     F: FnMut() -> std::io::Result<T>,
 {

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -397,17 +397,45 @@ fn replace_staged_path(source: &Path, destination: &Path) -> io::Result<()> {
             .encode_wide()
             .chain(Some(0))
             .collect();
-        let result = unsafe {
-            MoveFileExW(
-                source_wide.as_ptr(),
-                destination_wide.as_ptr(),
-                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
-            )
-        };
-        if result == 0 {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(())
+        av_scan_retry(|| {
+            let result = unsafe {
+                MoveFileExW(
+                    source_wide.as_ptr(),
+                    destination_wide.as_ptr(),
+                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+                )
+            };
+            if result == 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        })
+    }
+}
+
+fn rename_staged_generation(source: &Path, destination: &Path) -> io::Result<()> {
+    #[cfg(not(windows))]
+    {
+        fs::rename(source, destination)
+    }
+    #[cfg(windows)]
+    {
+        av_scan_retry(|| fs::rename(source, destination))
+    }
+}
+
+fn remove_uncommitted_generation(pointer: &Path, generation_hex: &str, generation: &Path) {
+    let pointer_committed = fs::read_to_string(pointer)
+        .ok()
+        .is_some_and(|value| value.trim() == generation_hex);
+    if !pointer_committed {
+        if let Err(error) = remove_staged_tree(generation) {
+            tracing::warn!(
+                path = %generation.display(),
+                %error,
+                "failed to remove staged generation after pointer commit failure"
+            );
         }
     }
 }
@@ -801,8 +829,9 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
         #[cfg(test)]
         fault::inject(artifact_dir, StagedFaultPoint::GenerationPublish)
             .map_err(|error| publish_error(StagedPublishFailure::GenerationPublish, error))?;
-        match fs::rename(&temporary_generation, &final_generation) {
-            Ok(()) => {}
+        let mut generation_renamed = false;
+        match rename_staged_generation(&temporary_generation, &final_generation) {
+            Ok(()) => generation_renamed = true,
             Err(error) if final_generation.exists() => {
                 let _ = error;
                 let _ = fs::remove_dir_all(&temporary_generation);
@@ -825,9 +854,16 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
         })?;
 
         #[cfg(test)]
-        fault::inject(artifact_dir, StagedFaultPoint::PointerCommit)
-            .map_err(|error| publish_error(StagedPublishFailure::PointerCommit, error))?;
+        if let Err(error) = fault::inject(artifact_dir, StagedFaultPoint::PointerCommit) {
+            if generation_renamed {
+                remove_uncommitted_generation(&pointer, &generation_hex, &final_generation);
+            }
+            return Err(publish_error(StagedPublishFailure::PointerCommit, error));
+        }
         atomic_write(&pointer, generation_hex.as_bytes()).map_err(|error| {
+            if generation_renamed {
+                remove_uncommitted_generation(&pointer, &generation_hex, &final_generation);
+            }
             publish_error(
                 StagedPublishFailure::PointerCommit,
                 io::Error::new(
@@ -838,9 +874,16 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
         })?;
         if let Some(parent) = pointer.parent() {
             #[cfg(test)]
-            fault::inject(artifact_dir, StagedFaultPoint::PointerSync)
-                .map_err(|error| publish_error(StagedPublishFailure::PointerCommit, error))?;
+            if let Err(error) = fault::inject(artifact_dir, StagedFaultPoint::PointerSync) {
+                if generation_renamed {
+                    remove_uncommitted_generation(&pointer, &generation_hex, &final_generation);
+                }
+                return Err(publish_error(StagedPublishFailure::PointerCommit, error));
+            }
             sync_directory(parent).map_err(|error| {
+                if generation_renamed {
+                    remove_uncommitted_generation(&pointer, &generation_hex, &final_generation);
+                }
                 publish_error(
                     StagedPublishFailure::PointerCommit,
                     io::Error::new(

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store_tests.rs
@@ -247,10 +247,19 @@ fn publication_fault_matrix_never_exposes_partial_generation() {
         }
         let key_root = staged_root(&artifact_dir).join(&key);
         if key_root.exists() {
-            assert!(fs::read_dir(key_root)
+            assert!(fs::read_dir(&key_root)
                 .unwrap()
                 .filter_map(Result::ok)
                 .all(|entry| !entry.file_name().to_string_lossy().starts_with(".tmp-")));
+            if point == StagedFaultPoint::PointerCommit {
+                assert!(
+                    fs::read_dir(&key_root)
+                        .unwrap()
+                        .filter_map(Result::ok)
+                        .all(|entry| entry.file_name() == PUBLISH_LOCK),
+                    "pointer-commit failure left an unreferenced final generation"
+                );
+            }
         }
         _fault.assert_all_consumed();
     }


### PR DESCRIPTION
## Summary
- retry staged generation publication and pointer replacement on transient Windows AV/share violations
- remove a successfully renamed generation when pointer commit fails before it is referenced
- add fault-matrix coverage that PointerCommit failure leaves no unreferenced generation

## Scope
This ships findings 2 and 3 from #1164. The resolve-to-materialize shared-lock fix is deliberately tracked separately in #1215 because it needs deterministic contention coverage and the retained performance-matrix baseline before merge.

## Validation
- `git diff --check`
- attempted `soldr cargo test -p zccache-daemon-core --lib staged_store -- --nocapture` twice; both attempts reached the local five-minute cold-build cap without compiler or test diagnostics. CI is the full validation gate.

Fixes #1164 in part.