### PR TITLE
fix(ci): force Dylint driver shim on PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
           nightly_cargo="${nightly_bin}/cargo"
           printf '#!/usr/bin/env bash\nexport RUSTUP_TOOLCHAIN=nightly-2026-05-26\nexport PATH="%s:${PATH}"\nexec "%s" "$@"\n' "${nightly_bin}" "${nightly_cargo}" > "${shim_dir}/cargo"
           chmod +x "${shim_dir}/cargo"
+          echo "DYLINT_CARGO_SHIM=${shim_dir}" >> "${GITHUB_ENV}"
           echo "${shim_dir}" >> "${GITHUB_PATH}"
       - name: Install Dylint nightly toolchain
         run: soldr rustup toolchain install nightly-2026-05-26 --component llvm-tools-preview --component rust-src --component rustc-dev --target x86_64-unknown-linux-gnu --profile minimal
@@ -118,31 +119,37 @@ jobs:
         run: soldr cargo fmt --manifest-path dylints/ban_normalized_path_deref_containment/Cargo.toml --all -- --check
       - name: Test Dylint Library (ban_std_pathbuf)
         run: |
+          export PATH="${DYLINT_CARGO_SHIM}:${PATH}"
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_std_pathbuf/Cargo.toml
       - name: Test Dylint Library (ban_unrooted_tempdir)
         run: |
+          export PATH="${DYLINT_CARGO_SHIM}:${PATH}"
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_unrooted_tempdir/Cargo.toml
       - name: Test Dylint Library (ban_tmp_literal)
         run: |
+          export PATH="${DYLINT_CARGO_SHIM}:${PATH}"
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_tmp_literal/Cargo.toml
       - name: Test Dylint Library (ban_raw_subprocess_in_daemon)
         run: |
+          export PATH="${DYLINT_CARGO_SHIM}:${PATH}"
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_raw_subprocess_in_daemon/Cargo.toml
       - name: Test Dylint Library (ban_legacy_artifact_path)
         run: |
+          export PATH="${DYLINT_CARGO_SHIM}:${PATH}"
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_legacy_artifact_path/Cargo.toml
       - name: Test Dylint Library (ban_normalized_path_deref_containment)
         run: |
+          export PATH="${DYLINT_CARGO_SHIM}:${PATH}"
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_normalized_path_deref_containment/Cargo.toml

--- a/ci/tests/test_lint.py
+++ b/ci/tests/test_lint.py
@@ -32,6 +32,8 @@ def test_dylint_workflow_rehydrates_the_pinned_toolchain_for_driver_builds():
     assert "export RUSTUP_TOOLCHAIN=nightly-2026-05-26" in dylint_job
     assert "nightly_bin=" in dylint_job
     assert 'export PATH="%s:${PATH}"' in dylint_job
+    assert 'echo "DYLINT_CARGO_SHIM=${shim_dir}" >> "${GITHUB_ENV}"' in dylint_job
+    assert 'export PATH="${DYLINT_CARGO_SHIM}:${PATH}"' in dylint_job
     assert "--target x86_64-unknown-linux-gnu" in dylint_job
     library_tests = dylint_job.split("\n      - name: Run Dylint\n", 1)[0]
     assert "export PATH=\"${CARGO_HOME}/bin:${PATH}\"" not in library_tests


### PR DESCRIPTION
## Summary
- export the Dylint compiler-shim directory through `GITHUB_ENV`
- prepend that directory explicitly in every Dylint library test step
- enforce the execution-time PATH setup with the workflow contract test

## Why

The UI harness removes the selected-toolchain environment variable before spawning its driver build. Main CI proved that a `GITHUB_PATH` entry alone did not win over the stable toolchain proxy. Explicit step-level PATH ordering makes the nested build use the pinned nightly toolchain.

## Validation

- workflow contract tests: 7 passed
- `git diff --check`

Repairs the remaining main Dylint failure after #1214.