### PR TITLE
fix(ci): derive full Dylint toolchain name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           shim_dir="${RUNNER_TEMP}/dylint-cargo-shim"
           mkdir -p "${shim_dir}"
           nightly_bin="$(dirname "$(soldr rustup which --toolchain nightly-2026-05-26 rustc)")"
-          nightly_toolchain="$(basename "${nightly_bin}")"
+          nightly_toolchain="$(basename "$(dirname "${nightly_bin}")")"
           printf '#!/usr/bin/env bash\nsubcommand="ru""stup"\nexport RUSTUP_TOOLCHAIN="%s"\nexec soldr "${subcommand}" run "%s" cargo "$@"\n' "${nightly_toolchain}" "${nightly_toolchain}" > "${shim_dir}/cargo"
           chmod +x "${shim_dir}/cargo"
           echo "DYLINT_CARGO_SHIM=${shim_dir}" >> "${GITHUB_ENV}"

--- a/ci/tests/test_lint.py
+++ b/ci/tests/test_lint.py
@@ -30,7 +30,7 @@ def test_dylint_workflow_rehydrates_the_pinned_toolchain_for_driver_builds():
 
     assert "Configure Dylint driver Cargo shim" in dylint_job
     assert "nightly_bin=" in dylint_job
-    assert 'nightly_toolchain="$(basename "${nightly_bin}")"' in dylint_job
+    assert 'nightly_toolchain="$(basename "$(dirname "${nightly_bin}")")"' in dylint_job
     assert 'subcommand="ru""stup"' in dylint_job
     assert 'export RUSTUP_TOOLCHAIN="%s"' in dylint_job
     assert 'exec soldr "${subcommand}" run "%s" cargo "$@"' in dylint_job


### PR DESCRIPTION
Corrects the Dylint shim to use the parent toolchain directory name rather than its bin subdirectory. Validated: ci/tests/test_lint.py (7 passed), git diff --check.