### PR TITLE
fix(cli): refuse degenerate uncached fallback by default

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/wrap.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap.rs
@@ -6,6 +6,7 @@
 
 mod diag;
 mod env;
+mod fallback;
 mod ipc;
 mod passthrough;
 mod routing;
@@ -51,6 +52,17 @@ fn write_wrapper_warning_line(
     writer.write_all(newline)
 }
 
+/// Emit a single wrapper warning line to stderr, yellow when the terminal
+/// supports it (issue #1211: cache/daemon degradations are never silent).
+fn emit_wrapper_warning(text: &str) {
+    let line = format!("{text}\n");
+    let _ = write_wrapper_warning_line(
+        &mut std::io::stderr(),
+        line.as_bytes(),
+        wrapper_stderr_color_enabled(),
+    );
+}
+
 /// Wrap a compiler or tool invocation.
 ///
 /// `args` is the full command: ["clang++", "-c", "foo.cpp", "-o", "foo.o"]
@@ -67,7 +79,9 @@ pub(crate) fn run_wrap(args: &[String], overrides: WrapperOverrides) -> ExitCode
     }
 
     if env::wrapper_disabled() {
-        return passthrough::run_passthrough(args);
+        // Never silent (issue #1211): the user opted out, but each uncached
+        // invocation still announces itself and the reason.
+        return passthrough::run_passthrough(args, Some("ZCCACHE_DISABLE is set"));
     }
 
     let strict_paths_mode = match env::effective_strict_paths_mode(overrides) {
@@ -100,7 +114,9 @@ pub(crate) fn run_wrap(args: &[String], overrides: WrapperOverrides) -> ExitCode
             cwd.into(),
             client_env,
         )),
-        WrapperRoute::ProbeBypass => passthrough::run_passthrough(args),
+        // Silent by design: probe callers parse the tool's stderr, so a
+        // warning line here would corrupt the probe (see run_passthrough).
+        WrapperRoute::ProbeBypass => passthrough::run_passthrough(args, None),
         WrapperRoute::Compile => run_compile_route(
             &endpoint,
             &args[0],

--- a/crates/zccache-cli-core/src/cli/commands/wrap/fallback.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/fallback.rs
@@ -1,0 +1,122 @@
+//! Policy for degenerate uncached fallbacks (issue #1211).
+//!
+//! When the daemon/cache pipeline fails before dispatch, the wrapper
+//! historically ran the tool directly, uncached. On CI that hides real
+//! infrastructure failures behind slow-but-green builds, so the policy is:
+//! hard error on CI, yellow warning everywhere else — always carrying the
+//! concrete daemon-failure reason.
+
+/// Explicit override for the fallback policy: `error` or `warn`.
+/// Wins over CI auto-detection.
+pub(super) const FALLBACK_POLICY_ENV: &str = "ZCCACHE_FALLBACK";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FallbackPolicy {
+    /// Refuse the uncached fallback and fail the compile (CI default).
+    Error,
+    /// Warn (yellow) and run the tool uncached (interactive default).
+    Warn,
+}
+
+/// A resolved policy plus the human-readable source of the decision, so
+/// the refusal/warning message can say *why* this policy applies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ResolvedFallbackPolicy {
+    pub(super) policy: FallbackPolicy,
+    pub(super) source: String,
+}
+
+pub(super) fn resolve_fallback_policy() -> ResolvedFallbackPolicy {
+    resolve_fallback_policy_with_env(|name| std::env::var(name).ok())
+}
+
+/// Testable variant taking an env lookup closure. Resolution order:
+/// explicit `ZCCACHE_FALLBACK=error|warn` → default `Error`.
+///
+/// The default is `Error` on every host, not just CI (owner directive,
+/// 2026-07-24): cached artifacts are materialized as READ-ONLY hardlinks
+/// (COW-lite, #1038/#1039), so a direct uncached compiler run cannot
+/// overwrite them anyway — the fallback doesn't merely lose the cache,
+/// it fails or corrupts the build. An unreachable daemon is therefore a
+/// hard error; `ZCCACHE_FALLBACK=warn` is the explicit escape hatch for
+/// build trees that never received hardlinked artifacts. An unrecognized
+/// override value is reported loudly and treated as unset.
+pub(super) fn resolve_fallback_policy_with_env<F>(lookup: F) -> ResolvedFallbackPolicy
+where
+    F: Fn(&str) -> Option<String>,
+{
+    if let Some(value) = lookup(FALLBACK_POLICY_ENV) {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "error" => {
+                return ResolvedFallbackPolicy {
+                    policy: FallbackPolicy::Error,
+                    source: format!("{FALLBACK_POLICY_ENV}=error"),
+                }
+            }
+            "warn" => {
+                return ResolvedFallbackPolicy {
+                    policy: FallbackPolicy::Warn,
+                    source: format!("{FALLBACK_POLICY_ENV}=warn"),
+                }
+            }
+            other => {
+                eprintln!(
+                    "zccache[warn][F]: unrecognized {FALLBACK_POLICY_ENV}={other:?} \
+                     (expected \"error\" or \"warn\"); using the default policy"
+                );
+            }
+        }
+    }
+    ResolvedFallbackPolicy {
+        policy: FallbackPolicy::Error,
+        source: format!(
+            "default: uncached fallback is unsafe with read-only hardlinked \
+             artifacts; set {FALLBACK_POLICY_ENV}=warn to allow it"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(pairs: &'static [(&'static str, &'static str)]) -> impl Fn(&str) -> Option<String> {
+        move |name| {
+            pairs
+                .iter()
+                .find(|(key, _)| *key == name)
+                .map(|(_, value)| (*value).to_string())
+        }
+    }
+
+    #[test]
+    fn explicit_error_override_wins() {
+        let resolved = resolve_fallback_policy_with_env(env(&[("ZCCACHE_FALLBACK", "error")]));
+        assert_eq!(resolved.policy, FallbackPolicy::Error);
+        assert_eq!(resolved.source, "ZCCACHE_FALLBACK=error");
+    }
+
+    #[test]
+    fn explicit_warn_override_allows_fallback() {
+        let resolved = resolve_fallback_policy_with_env(env(&[("ZCCACHE_FALLBACK", "warn")]));
+        assert_eq!(resolved.policy, FallbackPolicy::Warn);
+        assert_eq!(resolved.source, "ZCCACHE_FALLBACK=warn");
+    }
+
+    #[test]
+    fn default_is_hard_error_on_every_host() {
+        let resolved = resolve_fallback_policy_with_env(env(&[]));
+        assert_eq!(resolved.policy, FallbackPolicy::Error);
+        assert!(
+            resolved.source.contains("read-only hardlinked"),
+            "refusal source must explain why the fallback is unsafe: {}",
+            resolved.source,
+        );
+    }
+
+    #[test]
+    fn unrecognized_override_falls_through_to_error_default() {
+        let resolved = resolve_fallback_policy_with_env(env(&[("ZCCACHE_FALLBACK", "banana")]));
+        assert_eq!(resolved.policy, FallbackPolicy::Error);
+    }
+}

--- a/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
@@ -27,6 +27,9 @@ pub(super) async fn cmd_compile(
                 crate::core::lifecycle::CAUSE_COMM_ERROR,
                 &reason,
             );
+            super::emit_wrapper_warning(&format!(
+                "zccache[warn][S]: {reason}; retrying via ephemeral session"
+            ));
             return cmd_compile_ephemeral_with_stdin(
                 endpoint,
                 compiler.as_path(),
@@ -89,12 +92,12 @@ pub(super) async fn cmd_compile(
             };
             match action {
                 WedgeAction::DowngradeNoKill => {
-                    eprintln!(
+                    super::emit_wrapper_warning(&format!(
                         "zccache[warn][W]: daemon at {endpoint} answered probe within \
                          budget but missed the per-request wedge budget — burst load, \
                          not a hung daemon. Recovering via ephemeral without killing — \
                          issue #753"
-                    );
+                    ));
                     cmd_compile_ephemeral(endpoint, compiler.as_path(), args, cwd, client_env).await
                 }
                 WedgeAction::EscalateKill | WedgeAction::EscalateKillProbeError => {

--- a/crates/zccache-cli-core/src/cli/commands/wrap/passthrough.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/passthrough.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use super::super::util::exit_code_from_i32;
+use super::fallback::{FallbackPolicy, ResolvedFallbackPolicy};
 use super::tool_resolution::resolve_compiler_path;
 
 #[cfg(test)]
@@ -36,11 +37,29 @@ fn run_with_released_cwd(
     cmd.status()
 }
 
-/// Run the compiler/tool directly without caching (`ZCCACHE_DISABLE` mode).
-pub(super) fn run_passthrough(args: &[String]) -> ExitCode {
+/// Run the compiler/tool directly without caching.
+///
+/// `reason`: `Some` for user-visible bypasses (`ZCCACHE_DISABLE`) — a yellow
+/// warning names the cause so the uncached path is never silent (issue
+/// #1211). `None` for the probe bypass (`ZCCACHE_PROBE_BYPASS`), which is
+/// machine-invoked: probe callers parse the tool's stderr (`clang -###`
+/// writes there), so injecting a warning line would corrupt the probe.
+pub(super) fn run_passthrough(args: &[String], reason: Option<&str>) -> ExitCode {
     let tool = &args[0];
     let tool_args = args.get(1..).unwrap_or(&[]);
     let resolved = resolve_compiler_path(tool);
+
+    if let Some(reason) = reason {
+        let warning = format!(
+            "zccache[warn][F]: {reason}; running {} directly, uncached\n",
+            resolved.display(),
+        );
+        let _ = super::write_wrapper_warning_line(
+            &mut std::io::stderr(),
+            warning.as_bytes(),
+            super::wrapper_stderr_color_enabled(),
+        );
+    }
 
     let mut cmd = std::process::Command::new(&resolved);
     cmd.args(tool_args);
@@ -65,33 +84,38 @@ pub(super) fn run_locally(
     stdin_bytes: &[u8],
     reason: &str,
 ) -> ExitCode {
-    run_locally_with_lifecycle_root(tool, args, cwd, env, stdin_bytes, reason, None)
+    run_locally_with_policy(
+        tool,
+        args,
+        cwd,
+        env,
+        stdin_bytes,
+        reason,
+        &super::fallback::resolve_fallback_policy(),
+        None,
+    )
 }
 
-fn run_locally_with_lifecycle_root(
+#[allow(clippy::too_many_arguments)]
+fn run_locally_with_policy(
     tool: &Path,
     args: &[String],
     cwd: &Path,
     env: &[(String, String)],
     stdin_bytes: &[u8],
     reason: &str,
+    policy: &ResolvedFallbackPolicy,
     lifecycle_root: Option<&Path>,
 ) -> ExitCode {
-    let warning = format!(
-        "zccache[warn][F]: {reason}; running {} directly, uncached\n",
-        tool.display(),
-    );
-    let _ = super::write_wrapper_warning_line(
-        &mut std::io::stderr(),
-        warning.as_bytes(),
-        super::wrapper_stderr_color_enabled(),
-    );
+    let blocked = policy.policy == FallbackPolicy::Error;
     let event = serde_json::json!({
         "tool": tool.to_string_lossy(),
         "cwd": cwd.to_string_lossy(),
         "reason": reason,
         "phase": "pre-dispatch",
         "route": "wrapper",
+        "outcome": if blocked { "blocked" } else { "ran" },
+        "policy_source": policy.source,
     });
     if let Some(root) = lifecycle_root {
         crate::core::lifecycle::write_event_in_cache_root(
@@ -105,6 +129,24 @@ fn run_locally_with_lifecycle_root(
             event,
         );
     }
+
+    if blocked {
+        eprintln!(
+            "zccache[err][F]: {reason}; refusing uncached fallback ({})",
+            policy.source,
+        );
+        return ExitCode::FAILURE;
+    }
+
+    let warning = format!(
+        "zccache[warn][F]: {reason}; running {} directly, uncached\n",
+        tool.display(),
+    );
+    let _ = super::write_wrapper_warning_line(
+        &mut std::io::stderr(),
+        warning.as_bytes(),
+        super::wrapper_stderr_color_enabled(),
+    );
 
     let mut command = std::process::Command::new(tool);
     command
@@ -182,7 +224,7 @@ mod tests {
 
         let mut args = vec![noop_tool().to_string_lossy().into_owned()];
         args.extend(noop_args());
-        let _ = run_passthrough(&args);
+        let _ = run_passthrough(&args, None);
 
         let after = std::env::current_dir().unwrap();
         // `tempfile`'s tempdir under `%TEMP%` would itself canonicalize
@@ -239,13 +281,19 @@ mod tests {
         let cache_root = tempfile::tempdir().unwrap();
         let tool = noop_tool();
         let args = noop_args();
-        let exit = run_locally_with_lifecycle_root(
+        // Explicit Warn policy: this test asserts the *run* branch, and must
+        // not flip to the blocked branch when the test itself runs on CI.
+        let exit = run_locally_with_policy(
             &tool,
             &args,
             &std::env::current_dir().unwrap(),
             &[("ZCCACHE_TEST_FALLBACK".to_string(), "1".to_string())],
             &[],
             "test pre-dispatch failure",
+            &ResolvedFallbackPolicy {
+                policy: FallbackPolicy::Warn,
+                source: "test override".to_string(),
+            },
             Some(cache_root.path()),
         );
 
@@ -267,5 +315,66 @@ mod tests {
         if let Some(cwd) = original_cwd {
             let _ = std::env::set_current_dir(cwd);
         }
+    }
+
+    /// Issue #1211: under the `Error` policy (the default everywhere) the
+    /// wrapper must refuse the uncached fallback — the tool is never
+    /// spawned and the compile fails, even though the tool itself would
+    /// exit 0.
+    #[test]
+    fn error_policy_blocks_local_fallback_without_running_tool() {
+        let _guard = CWD_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let cache_root = tempfile::tempdir().unwrap();
+        let tool = noop_tool();
+        let args = noop_args();
+        let exit = run_locally_with_policy(
+            &tool,
+            &args,
+            &std::env::current_dir().unwrap(),
+            &[],
+            &[],
+            "cannot connect to daemon at test-endpoint: refused",
+            &ResolvedFallbackPolicy {
+                policy: FallbackPolicy::Error,
+                source: "test strict policy".to_string(),
+            },
+            Some(cache_root.path()),
+        );
+
+        assert_eq!(
+            exit,
+            ExitCode::FAILURE,
+            "blocked fallback must fail the compile even though the tool exits 0",
+        );
+        let logs_dir = cache_root.path().join("logs");
+        let mut events = String::new();
+        for entry in std::fs::read_dir(&logs_dir).unwrap() {
+            events.push_str(&std::fs::read_to_string(entry.unwrap().path()).unwrap_or_default());
+        }
+        assert!(
+            events.contains("wrapper-local-fallback"),
+            "blocked fallback must still emit the lifecycle event: {events}",
+        );
+        assert!(
+            events.contains("\"outcome\":\"blocked\""),
+            "event must record outcome:blocked: {events}",
+        );
+        assert!(
+            events.contains("cannot connect to daemon at test-endpoint"),
+            "event must carry the daemon-failure reason: {events}",
+        );
+
+        // The lifecycle event is still emitted (outcome:"blocked") for
+        // forensics, so the audit rule fires unless allow-listed.
+        let report = zccache_audit::audit_cache_root(
+            cache_root.path(),
+            zccache_audit::LogAuditContext::Integration,
+            &zccache_audit::AuditOptions::default().allow_for_test(
+                "wrap::passthrough::error_policy_blocks_local_fallback_without_running_tool",
+                [zccache_audit::RuleId("no-wrapper-local-fallback")],
+            ),
+        )
+        .unwrap();
+        assert!(report.passed(), "{}", report.format_human());
     }
 }

--- a/crates/zccache-compiler/src/side_outputs.rs
+++ b/crates/zccache-compiler/src/side_outputs.rs
@@ -10,7 +10,7 @@
 /// `msvc_syntax` is true for both `cl.exe` and clang invocations using
 /// clang-cl-style slash flags.
 #[must_use]
-pub fn unmodeled_side_output_flag<'a>(args: &'a [String], msvc_syntax: bool) -> Option<&'a str> {
+pub fn unmodeled_side_output_flag(args: &[String], msvc_syntax: bool) -> Option<&str> {
     args.iter().map(String::as_str).find(|arg| {
         let lower = arg.to_ascii_lowercase();
         if msvc_syntax {

--- a/crates/zccache-daemon-core/src/daemon/server/tests/multi_restart_context_key.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/multi_restart_context_key.rs
@@ -183,7 +183,7 @@ fn save_dep_graph_to_disk(server: &DaemonServer, path: &Path) {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).ok();
     }
-    crate::depgraph::save_to_file(&dg, &path).expect("depgraph save must succeed");
+    crate::depgraph::save_to_file(&dg, path).expect("depgraph save must succeed");
 }
 
 /// `DaemonServer::run` spawns the background index-writer task (drains
@@ -233,6 +233,10 @@ async fn quiesce_and_persist(
 /// without a trustworthy per-file change sequence, so this verifies the
 /// supported durable path on every platform.
 #[tokio::test]
+// Holding the env-policy lock across the whole async test IS the point:
+// it serializes the process-global staged-artifact policy for the test's
+// full duration. Single-threaded test runtime, no lock-ordering hazard.
+#[allow(clippy::await_holding_lock)]
 async fn multi_file_compile_hits_warm_after_restart() {
     let tmp = tempfile::tempdir().unwrap();
     let cache_root: crate::core::NormalizedPath = tmp.path().join("zccache-cache").into();
@@ -346,6 +350,9 @@ async fn multi_file_compile_hits_warm_after_restart() {
 /// honest — if this one ever goes RED too, the bug moved somewhere shared
 /// (e.g. depgraph snapshot round-trip) rather than being multi-file-specific.
 #[tokio::test]
+// Same rationale as multi_file_compile_hits_warm_after_restart: the env
+// lock must span every await in the test body.
+#[allow(clippy::await_holding_lock)]
 async fn single_file_compile_hits_warm_after_restart() {
     let tmp = tempfile::tempdir().unwrap();
     let cache_root: crate::core::NormalizedPath = tmp.path().join("zccache-cache").into();

--- a/crates/zccache/tests/cli_wrapper_failure_boundaries.rs
+++ b/crates/zccache/tests/cli_wrapper_failure_boundaries.rs
@@ -49,6 +49,7 @@ fn run_wrapper(
     cache_dir: &Path,
     payload: &[u8],
     session_id: Option<&str>,
+    fallback_policy: &str,
 ) -> Output {
     let mut command = Command::new(zccache);
     command
@@ -57,6 +58,10 @@ fn run_wrapper(
         .env("ZCCACHE_CACHE_DIR", cache_dir)
         .env("ZCCACHE_NO_SPAWN", "1")
         .env("ZCCACHE_DAEMON_WIRE", "bincode")
+        // Issue #1211: the default policy is Error (uncached fallback is
+        // unsafe with read-only hardlinked artifacts), so the warn-path
+        // tests must opt in explicitly to keep exercising the fallback.
+        .env("ZCCACHE_FALLBACK", fallback_policy)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -101,6 +106,10 @@ fn assert_one_fallback(cache_dir: &Path, test_name: &'static str) {
         "expected one fallback event: {events:#?}"
     );
     assert_eq!(fallbacks[0]["phase"], "pre-dispatch");
+    assert_eq!(
+        fallbacks[0]["outcome"], "ran",
+        "warn-policy fallback must record that the tool actually ran"
+    );
 
     let effective =
         zccache::core::config::effective_cache_root_from_top_level(&cache_dir.to_path_buf().into());
@@ -142,7 +151,14 @@ fn ephemeral_pre_dispatch_fallback_preserves_process_contract() {
 
     let cache_dir = tempfile::tempdir().expect("cache tempdir");
     let payload = b"pre-dispatch-stdin\0with-a-nul\n";
-    let output = run_wrapper(&zccache, &echo_shim, cache_dir.path(), payload, None);
+    let output = run_wrapper(
+        &zccache,
+        &echo_shim,
+        cache_dir.path(),
+        payload,
+        None,
+        "warn",
+    );
     stop_daemon(&zccache, cache_dir.path());
 
     assert_eq!(output.status.code(), Some(7));
@@ -203,6 +219,7 @@ fn session_pre_dispatch_fallback_does_not_consume_stdin_twice() {
         cache_dir.path(),
         payload,
         Some(&session_id),
+        "warn",
     );
     stop_daemon(&zccache, cache_dir.path());
 
@@ -220,4 +237,65 @@ fn session_pre_dispatch_fallback_does_not_consume_stdin_twice() {
         cache_dir.path(),
         "session_pre_dispatch_fallback_does_not_consume_stdin_twice",
     );
+}
+
+/// Issue #1211: under the strict policy (`ZCCACHE_FALLBACK=error`, also the
+/// default on every host) a pre-dispatch daemon failure must fail the
+/// compile with the failure reason on stderr — the tool is never run
+/// uncached (it could not overwrite read-only hardlinked artifacts anyway).
+#[test]
+#[ignore = "integration test: launches the wrapper binary"]
+fn strict_policy_refuses_pre_dispatch_fallback() {
+    let zccache = binary_path("zccache");
+    let echo_shim = binary_path("echo_shim");
+    if !zccache.exists() || !echo_shim.exists() {
+        eprintln!("skipping: required binaries are not built");
+        return;
+    }
+
+    let cache_dir = tempfile::tempdir().expect("cache tempdir");
+    let payload = b"strict-mode-stdin\n";
+    let output = run_wrapper(
+        &zccache,
+        &echo_shim,
+        cache_dir.path(),
+        payload,
+        None,
+        "error",
+    );
+    stop_daemon(&zccache, cache_dir.path());
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "strict mode must fail the compile, not mirror the tool's exit code"
+    );
+    assert!(
+        !output
+            .stdout
+            .windows(b"ZCCACHE_PASSTHROUGH_STDOUT_MARKER".len())
+            .any(|window| window == b"ZCCACHE_PASSTHROUGH_STDOUT_MARKER"),
+        "strict mode must not run the tool uncached"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("refusing uncached fallback"),
+        "stderr must announce the refusal: {stderr}"
+    );
+    assert!(
+        stderr.contains("cannot start daemon") || stderr.contains("cannot connect to daemon"),
+        "stderr must carry the daemon-failure reason: {stderr}"
+    );
+
+    let events = lifecycle_events(cache_dir.path());
+    let fallbacks: Vec<_> = events
+        .iter()
+        .filter(|event| event["event"] == "wrapper-local-fallback")
+        .collect();
+    assert_eq!(
+        fallbacks.len(),
+        1,
+        "expected one blocked event: {events:#?}"
+    );
+    assert_eq!(fallbacks[0]["outcome"], "blocked");
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,6 +40,7 @@ failed cache-root audit retain its diagnostic JSONL evidence.
 - **Async/process bridge — watchdogs, cancellation & timeouts (deadlock hardening)** → [runtime.md § Async / process bridge](architecture/runtime.md#async--process-bridge-watchdogs-cancellation--timeouts)
 - **Where zccache writes on disk (`ZCCACHE_CACHE_DIR` contract)** → [runtime.md § Cache root invariants](architecture/runtime.md#cache-root-invariants)
 - **Host no-spawn guard (`ZCCACHE_NO_SPAWN`, embedding hosts)** → [runtime.md § Host no-spawn guard](architecture/runtime.md#host-no-spawn-guard-zccache_no_spawn)
+- **Uncached-fallback policy (`ZCCACHE_FALLBACK`, CI hard-error)** → [runtime.md § Wrapper fallback policy](architecture/runtime.md#wrapper-fallback-policy-zccache_fallback-issue-1211)
 - **Standalone daemon identity, deployment & lifecycle (argv[0] single binary, version-rooted deploy, versioned endpoints)** → [runtime.md § Standalone daemon identity, deployment & lifecycle](architecture/runtime.md#standalone-daemon-identity-deployment--lifecycle)
 - **Windows/macOS/Linux differences** → [portability.md](architecture/portability.md)
 - **Compile journal fields & `miss_reason` enum** → [journal-schema.md](journal-schema.md)

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -327,6 +327,17 @@ The test fixture is the `exec_test_tool` binary (built under `--features test-su
 
 ---
 
+## Wrapper fallback policy (`ZCCACHE_FALLBACK`, issue #1211)
+
+When the daemon/cache pipeline fails **before request dispatch** (daemon spawn failure, connect timeout, `ZCCACHE_NO_SPAWN` refusal), the wrapper historically ran the tool directly, uncached. That degenerate fallback is now policy-gated at the single chokepoint `wrap/passthrough.rs::run_locally`:
+
+- **`Error` (the default on every host):** the wrapper refuses the uncached fallback — the tool is never spawned, stderr gets `zccache[err][F]: <reason>; refusing uncached fallback (<policy source>)`, and the compile fails with exit 1. The `wrapper-local-fallback` lifecycle event is still emitted with `outcome:"blocked"` for forensics. Hard-error is the default everywhere (not just CI) because cached artifacts are materialized as **read-only hardlinks** (COW-lite, #1038/#1039): a direct uncached compiler run cannot overwrite them, so the fallback doesn't merely lose the cache — it fails or corrupts the build.
+- **`Warn` (opt-in via `ZCCACHE_FALLBACK=warn`):** yellow `zccache[warn][F]` warning carrying the failure reason, then the tool runs uncached (`outcome:"ran"`). Escape hatch for build trees that never received hardlinked artifacts.
+
+Post-dispatch transport failures (`FailurePhase::DeliveryUnknown`) were already fail-fast and are unchanged (double-compile hazard). `ZCCACHE_DISABLE=1` passthrough warns (never silent) but stays warn-only — it is a deliberate user opt-out; the probe bypass (`ZCCACHE_PROBE_BYPASS`) stays fully silent because probe callers parse the tool's stderr. The session→ephemeral downgrade and the wedge `DowngradeNoKill` recovery also announce themselves with yellow warnings naming the cause.
+
+---
+
 ## Crash Recovery
 
 ### Daemon Crash Recovery


### PR DESCRIPTION
Closes #1211.

## What

An unreachable daemon is now a **hard error by default on every host** in the wrapper. Cached artifacts are materialized as read-only hardlinks (COW-lite #1038/#1039), so the direct uncached fallback cannot overwrite them anyway — it breaks the build rather than merely losing the cache win (observed live: repeated `.rmeta is not writeable` failures from the direct-rustc lane while the daemon was down).

- New `wrap/fallback.rs`: `ZCCACHE_FALLBACK=error|warn` resolver; default `Error` with a source string explaining the rationale; unrecognized values are reported loudly and treated as unset.
- `run_locally` (the single chokepoint every involuntary uncached fallback flows through) is policy-gated: `Error` refuses the fallback — exit 1, `zccache[err][F]: <reason>; refusing uncached fallback (...)` on stderr, `wrapper-local-fallback` lifecycle event with `outcome:"blocked"`. `warn` keeps the previous yellow-warning + uncached-run behavior (`outcome:"ran"`).
- `ZCCACHE_DISABLE` passthrough is no longer silent — yellow warning naming the cause per invocation. `ZCCACHE_PROBE_BYPASS` stays silent by design (probe callers parse the tool's stderr, e.g. `clang -###`).
- The session→ephemeral downgrade and the wedge `DowngradeNoKill` recovery now announce themselves in yellow with the concrete reason.
- Post-dispatch `DeliveryUnknown` fail-fast arms unchanged (double-compile hazard).

## Tests

- Unit: resolver (default=Error, warn override, invalid value), blocked branch (tool never spawned, event carries reason + outcome), warn branch (exit-code mirroring preserved).
- Integration (`cli_wrapper_failure_boundaries.rs`): new `strict_policy_refuses_pre_dispatch_fallback` (exit 1, refusal + reason on stderr, no passthrough marker, blocked event); existing warn-path tests pin `ZCCACHE_FALLBACK=warn` explicitly and assert `outcome:"ran"`.
- Full unit suite green except `daemon_rustc_restore_test::first_compile_waits_for_background_depgraph_load_before_cold_skip`, which fails identically on clean main — tracked as #1218, unrelated to this change.

First commit clears two pre-existing clippy `-D warnings` blockers on the workspace gate (from #1203/#1199).

## Docs

`runtime.md` § Wrapper fallback policy + `ARCHITECTURE.md` breadcrumb.

Related: #1216 (heavy-load progress heartbeats will shrink the population of false daemon-unreachable events), soldr#1814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)