### PR TITLE
fix(daemon): ban DashMap guards across blocking work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,13 @@ jobs:
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_normalized_path_deref_containment/Cargo.toml
+      - name: Check Dylint Library Formatting (ban_dashmap_guard_across_blocking)
+        run: soldr cargo fmt --manifest-path dylints/ban_dashmap_guard_across_blocking/Cargo.toml --all -- --check
+      - name: Test Dylint Library (ban_dashmap_guard_across_blocking)
+        run: |
+          export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
+          export RUSTUP_TOOLCHAIN=nightly-2026-05-26
+          soldr cargo test --manifest-path dylints/ban_dashmap_guard_across_blocking/Cargo.toml
       - name: Run Dylint
         run: |
           export PATH="${CARGO_HOME}/bin:${PATH}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ exclude = [
     "dylints/ban_tmp_literal",
     "dylints/ban_legacy_artifact_path",
     "dylints/ban_normalized_path_deref_containment",
+    "dylints/ban_dashmap_guard_across_blocking",
 ]
 
 [workspace.package]

--- a/dylints/ban_dashmap_guard_across_blocking/Cargo.toml
+++ b/dylints/ban_dashmap_guard_across_blocking/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ban_dashmap_guard_across_blocking"
+version = "0.1.0"
+description = "Ban DashMap guards held across blocking operations"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+dylint_linting = "6.0.1"
+
+[dev-dependencies]
+dylint_testing = "6.0.1"
+
+[package.metadata.rust-analyzer]
+rustc_private = true
+
+[workspace]

--- a/dylints/ban_dashmap_guard_across_blocking/README.md
+++ b/dylints/ban_dashmap_guard_across_blocking/README.md
@@ -1,0 +1,6 @@
+# ban_dashmap_guard_across_blocking
+
+This Dylint rejects direct `DashMap::get` guards that remain live while their
+`if let` body waits, touches the filesystem or a process, or mutates a map.
+
+Clone the guarded value into an owned local before performing that work.

--- a/dylints/ban_dashmap_guard_across_blocking/rust-toolchain.toml
+++ b/dylints/ban_dashmap_guard_across_blocking/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2026-05-26"
+components = ["llvm-tools-preview", "rustc-dev", "rust-src"]

--- a/dylints/ban_dashmap_guard_across_blocking/src/README.md
+++ b/dylints/ban_dashmap_guard_across_blocking/src/README.md
@@ -1,0 +1,4 @@
+# Source
+
+The lint is intentionally syntax-directed. Its narrow direct-guard pattern
+keeps diagnostics predictable while protecting the daemon's cache-hit path.

--- a/dylints/ban_dashmap_guard_across_blocking/src/lib.rs
+++ b/dylints/ban_dashmap_guard_across_blocking/src/lib.rs
@@ -1,0 +1,113 @@
+#![feature(rustc_private)]
+
+extern crate rustc_errors;
+extern crate rustc_hir;
+extern crate rustc_span;
+
+use rustc_errors::DiagDecorator;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::LintContext;
+
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// Rejects a direct `if let Some(guard) = map.get(..)` whose body waits,
+    /// performs filesystem/process work, or mutates a map.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A DashMap guard holds a shard lock. Keeping it across work that can
+    /// block permits another operation on that shard to deadlock.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore
+    /// if let Some(entry) = cache.get(&key) {
+    ///     materialize(entry.value()).await?;
+    /// }
+    /// ```
+    ///
+    /// Clone the entry first, so the guard is dropped before the blocking
+    /// operation.
+    pub BAN_DASHMAP_GUARD_ACROSS_BLOCKING,
+    Deny,
+    "DashMap guard is held across blocking work"
+}
+
+impl<'tcx> rustc_lint::LateLintPass<'tcx> for BanDashmapGuardAcrossBlocking {
+    fn check_expr(&mut self, cx: &rustc_lint::LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        let ExprKind::If(condition, body, _) = expr.kind else {
+            return;
+        };
+        let Some(receiver) = dashmap_get_receiver(cx, condition) else {
+            return;
+        };
+        if !body_can_block_or_reenter(cx, body, &receiver) {
+            return;
+        }
+        cx.opt_span_lint(
+            BAN_DASHMAP_GUARD_ACROSS_BLOCKING,
+            Some(condition.span),
+            DiagDecorator(|diag| {
+                diag.primary_message(
+                    "a DashMap guard is live for this whole `if let` body; clone the entry before blocking or mutating the map",
+                );
+            }),
+        );
+    }
+}
+
+fn dashmap_get_receiver(cx: &rustc_lint::LateContext<'_>, condition: &Expr<'_>) -> Option<String> {
+    let ExprKind::Let(let_expression) = condition.kind else {
+        return None;
+    };
+    let initializer = let_expression.init;
+    let ExprKind::MethodCall(segment, receiver, _, _) = initializer.kind else {
+        return None;
+    };
+    if segment.ident.name.as_str() != "get" {
+        return None;
+    }
+    let is_dashmap = cx
+        .typeck_results()
+        .expr_ty(receiver)
+        .peel_refs()
+        .ty_adt_def()
+        .is_some_and(|definition| {
+            cx.tcx
+                .def_path_str(definition.did())
+                .ends_with("dashmap::DashMap")
+        });
+    is_dashmap.then(|| snippet(cx, receiver.span)).flatten()
+}
+
+fn body_can_block_or_reenter(
+    cx: &rustc_lint::LateContext<'_>,
+    body: &Expr<'_>,
+    receiver: &str,
+) -> bool {
+    let Some(source) = snippet(cx, body.span) else {
+        return false;
+    };
+    let blocks = [".await", "std::fs::", "tokio::fs::", "Command::", ".spawn("]
+        .iter()
+        .any(|needle| source.contains(needle));
+    let reenters_same_map = ["remove", "insert", "entry"]
+        .iter()
+        .any(|method| source.contains(&format!("{receiver}.{method}(")));
+    blocks || reenters_same_map
+}
+
+fn snippet(cx: &rustc_lint::LateContext<'_>, span: rustc_span::Span) -> Option<String> {
+    cx.sess().source_map().span_to_snippet(span).ok()
+}
+
+#[cfg(test)]
+mod ui_test_support {
+    include!("../../ui_test_support.rs");
+}
+
+#[test]
+fn ui() {
+    ui_test_support::run(env!("CARGO_PKG_NAME"), env!("CARGO_MANIFEST_DIR"));
+}

--- a/dylints/ban_dashmap_guard_across_blocking/ui/README.md
+++ b/dylints/ban_dashmap_guard_across_blocking/ui/README.md
@@ -1,0 +1,4 @@
+# UI fixtures
+
+`disallowed.rs` holds a direct guard over a map mutation; `allowed.rs` owns a
+clone before it mutates the map.

--- a/dylints/ban_dashmap_guard_across_blocking/ui/allowed.rs
+++ b/dylints/ban_dashmap_guard_across_blocking/ui/allowed.rs
@@ -1,0 +1,30 @@
+mod dashmap {
+    #[derive(Clone)]
+    pub struct DashMap;
+
+    impl DashMap {
+        pub fn new() -> Self {
+            Self
+        }
+
+        pub fn insert(&self, _: &str, _: String) {}
+
+        pub fn get(&self, _: &str) -> Option<Self> {
+            Some(Self)
+        }
+
+        pub fn remove(&self, _: &str) {}
+    }
+}
+
+use dashmap::DashMap;
+
+fn main() {
+    let cache = DashMap::new();
+    cache.insert("key", String::from("value"));
+    let entry = cache.get("key").map(|entry| entry.clone());
+    if let Some(entry) = entry {
+        let _ = entry;
+        cache.remove("key");
+    }
+}

--- a/dylints/ban_dashmap_guard_across_blocking/ui/disallowed.rs
+++ b/dylints/ban_dashmap_guard_across_blocking/ui/disallowed.rs
@@ -1,0 +1,33 @@
+mod dashmap {
+    pub struct DashMap;
+    pub struct Guard;
+
+    impl Guard {
+        pub fn value(&self) {}
+    }
+
+    impl DashMap {
+        pub fn new() -> Self {
+            Self
+        }
+
+        pub fn insert(&self, _: &str, _: String) {}
+
+        pub fn get(&self, _: &str) -> Option<Guard> {
+            Some(Guard)
+        }
+
+        pub fn remove(&self, _: &str) {}
+    }
+}
+
+use dashmap::DashMap;
+
+fn main() {
+    let cache = DashMap::new();
+    cache.insert("key", String::from("value"));
+    if let Some(entry) = cache.get("key") {
+        let _ = entry.value();
+        cache.remove("key");
+    }
+}

--- a/dylints/ban_dashmap_guard_across_blocking/ui/disallowed.stderr
+++ b/dylints/ban_dashmap_guard_across_blocking/ui/disallowed.stderr
@@ -1,0 +1,9 @@
+error: a DashMap guard is live for this whole `if let` body; clone the entry before blocking or mutating the map
+  --> $DIR/disallowed.rs:29:8
+   |
+LL |     if let Some(entry) = cache.get("key") {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[deny(ban_dashmap_guard_across_blocking)]` on by default
+
+error: aborting due to 1 previous error

--- a/dylints/ui_test_support.rs
+++ b/dylints/ui_test_support.rs
@@ -30,6 +30,25 @@ fn prepare_dylint_library(manifest_dir: &std::path::Path, crate_name: &str) {
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|| manifest_dir.join("target"));
     let target_debug = target_root.join("debug");
+    let plain_library = format!(
+        "{}{}{}",
+        std::env::consts::DLL_PREFIX,
+        library_name,
+        std::env::consts::DLL_SUFFIX
+    );
+    let target_debug = if target_debug.join(&plain_library).is_file() {
+        target_debug
+    } else {
+        std::fs::read_dir(&target_root)
+            .ok()
+            .and_then(|entries| {
+                entries.filter_map(Result::ok).find_map(|entry| {
+                    let candidate = entry.path().join("debug");
+                    candidate.join(&plain_library).is_file().then_some(candidate)
+                })
+            })
+            .unwrap_or(target_debug)
+    };
     let expected = target_debug.join(format!(
         "{}{}@{}{}",
         std::env::consts::DLL_PREFIX,
@@ -37,12 +56,7 @@ fn prepare_dylint_library(manifest_dir: &std::path::Path, crate_name: &str) {
         toolchain,
         std::env::consts::DLL_SUFFIX
     ));
-    let plain = target_debug.join(format!(
-        "{}{}{}",
-        std::env::consts::DLL_PREFIX,
-        library_name,
-        std::env::consts::DLL_SUFFIX
-    ));
+    let plain = target_debug.join(plain_library);
     if plain.exists() {
         std::fs::copy(&plain, &expected)
             .expect("toolchain-suffixed dylint library should be copied");


### PR DESCRIPTION
## Summary

- add `ban_dashmap_guard_across_blocking`, a deny Dylint for direct `DashMap::get` guards whose `if let` body blocks or re-enters the same map
- add allowed/disallowed UI fixtures, Dylint CI formatting/test coverage, and Windows target-triple support in the shared UI helper
- retain the existing owned-fast-hit regression that verifies the guard is dropped before map mutation

## Validation

- `soldr cargo fmt --manifest-path dylints/ban_dashmap_guard_across_blocking/Cargo.toml --all -- --check`
- pinned-nightly Dylint library check
- `uv run --no-project python ci/check_dylint_wiring.py`
- `soldr cargo test -p zccache-daemon-core --features test-support owned_fast_hit_entry_releases_map_guard_before_mutation`

Closes #1176