### PR TITLE
perf: avoid rehashing declared linker inputs

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -204,6 +204,16 @@ pub(super) async fn handle_link_ephemeral(
         cwd_path.join(&parsed_tool.output_file).into()
     };
     let output_dir = output_path.parent().unwrap_or(cwd_path);
+    // Inputs which reside directly in the output directory are declared by
+    // the linker invocation, so they cannot be implicit output side effects.
+    // Skip them in both directory scans. This avoids re-hashing every object
+    // around a large driver link while retaining full coverage of undeclared
+    // sibling files (DLLs, PDBs, wrapper-deployed runtimes, etc.).
+    let sibling_input_names: std::collections::HashSet<std::ffi::OsString> = inputs
+        .iter()
+        .filter(|input| input.as_path().parent() == Some(output_dir))
+        .filter_map(|input| input.file_name().map(std::ffi::OsStr::to_os_string))
+        .collect();
 
     // A cache hit also writes the complete artifact set into the output
     // directory. It must therefore share the same exclusion window as a cold
@@ -590,7 +600,10 @@ pub(super) async fn handle_link_ephemeral(
     let dir_snapshot = if parsed_tool.is_archive || directory_plan.is_some() {
         None
     } else {
-        match super::super::side_effect::snapshot_directory(output_dir) {
+        match super::super::side_effect::snapshot_directory_excluding(
+            output_dir,
+            &sibling_input_names,
+        ) {
             Ok(snapshot) => Some(snapshot),
             Err(error) => {
                 side_effects_cacheable = false;
@@ -749,6 +762,7 @@ pub(super) async fn handle_link_ephemeral(
                         .iter()
                         .filter_map(|s| s.file_name().map(|n| n.to_os_string())),
                 )
+                .chain(sibling_input_names.iter().cloned())
                 .collect();
         // Issue #605 pass 1: matches the pre-link snapshot skip above —
         // archives have no side-effect files to detect.

--- a/crates/zccache-daemon-core/src/daemon/side_effect.rs
+++ b/crates/zccache-daemon-core/src/daemon/side_effect.rs
@@ -76,6 +76,18 @@ fn stable_file_entry(path: &Path) -> std::io::Result<FileEntry> {
 /// A nonexistent directory is empty because a linker may create it. Any other
 /// scan error is returned so the caller can fail cache population closed.
 pub fn snapshot_directory(dir: &Path) -> std::io::Result<DirSnapshot> {
+    snapshot_directory_excluding(dir, &HashSet::new())
+}
+
+/// Capture the current state of `dir`, excluding declared link inputs.
+///
+/// A declared input in the output directory cannot be an implicit linker
+/// output. Excluding it avoids hashing every object twice around a large
+/// driver link while preserving detection for all undeclared siblings.
+pub fn snapshot_directory_excluding(
+    dir: &Path,
+    excluded_names: &HashSet<std::ffi::OsString>,
+) -> std::io::Result<DirSnapshot> {
     let mut snap = DirSnapshot::default();
     let entries = match std::fs::read_dir(dir) {
         Ok(entries) => entries,
@@ -84,6 +96,9 @@ pub fn snapshot_directory(dir: &Path) -> std::io::Result<DirSnapshot> {
     };
     for entry in entries {
         let entry = entry?;
+        if excluded_names.contains(&entry.file_name()) {
+            continue;
+        }
         if entry.metadata()?.is_file() {
             let path = entry.path();
             snap.entries
@@ -233,6 +248,24 @@ mod tests {
         );
 
         assert!(found.is_empty());
+    }
+
+    #[test]
+    fn declared_sibling_input_is_excluded_from_both_scans() {
+        let dir = TempDir::new().unwrap();
+        let input = dir.path().join("input.o");
+        fs::write(&input, b"old input").unwrap();
+        let ignored = HashSet::from([std::ffi::OsString::from("input.o")]);
+        let snap = snapshot_directory_excluding(dir.path(), &ignored).unwrap();
+
+        fs::write(&input, b"new input").unwrap();
+        fs::write(dir.path().join("runtime.dll"), b"runtime").unwrap();
+
+        let found = complete(
+            detect_side_effects(&snap, dir.path(), OsStr::new("app.exe"), &ignored).unwrap(),
+        );
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].file_name, OsStr::new("runtime.dll"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- exclude declared linker inputs that share the output directory from the pre/post side-effect scans
- retain complete detection and caching of undeclared sibling outputs such as runtime DLLs and PDBs
- add a regression test covering both scan phases

The failed C++ driver-link guard showed ~31 ms of unaccounted cold-miss time. Its 51 object inputs live in the link output directory, so the previous safety scan re-hashed all of them both before and after the compiler process. Declared inputs are not implicit output side effects; limiting scans to undeclared siblings removes that redundant work without changing cache keys, fallback behavior, or output materialization.

## Validation
- `soldr cargo test -p zccache-daemon-core --features test-support side_effect`
- `soldr cargo test -p zccache-daemon-core --features test-support handle_link`