### PR TITLE
fix(ci): preserve Dylint cargo shim for guard lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
         run: soldr cargo fmt --manifest-path dylints/ban_dashmap_guard_across_blocking/Cargo.toml --all -- --check
       - name: Test Dylint Library (ban_dashmap_guard_across_blocking)
         run: |
+          export PATH="${DYLINT_CARGO_SHIM}:${PATH}"
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
           soldr cargo test --manifest-path dylints/ban_dashmap_guard_across_blocking/Cargo.toml


### PR DESCRIPTION
## Summary

Restore `DYLINT_CARGO_SHIM` to the new guard-lint UI-test step so Dylint builds its nested driver with the pinned nightly toolchain.

## Validation

- `uv run --no-project python ci/check_dylint_wiring.py`

Fixes the failed push-only Dylint test from #1224.