### PR TITLE
fix(ci): bound Perf Guard profile setup

### DIFF
--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -355,7 +355,10 @@ jobs:
             linux-tools-generic \
             "linux-tools-$(uname -r)" \
             || sudo apt-get install -y -qq linux-tools-common linux-tools-generic
-          soldr cargo install inferno --locked --quiet
+          # Profiling is diagnostic-only. Bound the first-time Inferno build
+          # so a registry/compiler stall cannot consume the entire Perf Guard
+          # job after the actual benchmark result has already been recorded.
+          timeout 10m soldr cargo install inferno --locked --quiet
 
           # Allow `perf record` to capture without elevated privileges.
           echo 1 | sudo tee /proc/sys/kernel/perf_event_paranoid >/dev/null


### PR DESCRIPTION
Bounds diagnostic Inferno installation so a profiling setup stall cannot consume the entire Perf Guard job after the benchmark result is recorded.