### PR TITLE
fix(ci): run DashMap Dylint test on pinned nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
           export PATH="${DYLINT_CARGO_SHIM}:${PATH}"
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
-          soldr cargo test --manifest-path dylints/ban_dashmap_guard_across_blocking/Cargo.toml
+          soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_dashmap_guard_across_blocking/Cargo.toml
       - name: Run Dylint
         run: |
           export PATH="${CARGO_HOME}/bin:${PATH}"


### PR DESCRIPTION
Fixes the reproducible main-branch Dylint failure in run 30144726301.\n\nThe DashMap UI test was the sole Dylint library test launched through soldr cargo, while every other test uses soldr rustup run nightly-2026-05-26 cargo test. That mismatched the Dylint driver toolchain identity and triggered an incompatible crates.io driver rebuild. Align this test with the established pinned-nightly invocation.\n\nValidation: workflow command assertion and git diff --check. The pinned nightly is not installed in the local Windows toolchain cache; the same invocation is already green for the preceding Dylint libraries in the authoritative CI run.