### PR TITLE
test(dylint): match pinned-nightly diagnostic newline

### DIFF
--- a/dylints/ban_dashmap_guard_across_blocking/ui/disallowed.stderr
+++ b/dylints/ban_dashmap_guard_across_blocking/ui/disallowed.stderr
@@ -7,3 +7,4 @@ LL |     if let Some(entry) = cache.get("key") {
    = note: `#[deny(ban_dashmap_guard_across_blocking)]` on by default
 
 error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes the remaining DashMap UI fixture drift after #1228 restored the pinned Dylint driver.\n\nThe new run reaches the real lint diagnostic successfully; compiletest reports only one extra terminal blank line from nightly-2026-05-26. Update the checked-in .stderr fixture to match that authoritative output.\n\nValidation: inspected the CI-produced diagnostic and verified the fixture ends in the required two newlines. (The fixture intentionally has a blank final line, so git diff --check reports its standard whitespace warning.)