### PR TITLE
perf(rust): detach staged publication from response

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
@@ -118,12 +118,7 @@ pub(super) async fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Op
     // its durable write is pending. It is immediately usable in-process; only
     // wait when that entry is not yet visible, then re-lookup after publish.
     if !state.artifacts.contains_key(artifact_key_hex) {
-        pending_writes::await_pending(
-            &state.pending_cache_writes,
-            artifact_key_hex,
-            pending_writes::PENDING_PAYLOAD_WAIT_TIMEOUT,
-        )
-        .await;
+        pending_writes::await_pending_payload(&state.pending_cache_writes, artifact_key_hex).await;
     }
 
     let hit_label = if same_root {
@@ -238,12 +233,8 @@ pub(super) async fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
     // the inner `Arc<Notify>` before yielding so no DashMap shard lock
     // straddles the await.
     if !state.artifacts.contains_key(&entry_artifact_key_hex) {
-        pending_writes::await_pending(
-            &state.pending_cache_writes,
-            &entry_artifact_key_hex,
-            pending_writes::PENDING_PAYLOAD_WAIT_TIMEOUT,
-        )
-        .await;
+        pending_writes::await_pending_payload(&state.pending_cache_writes, &entry_artifact_key_hex)
+            .await;
     }
 
     let secondary_output_dir = if is_rustc {
@@ -406,12 +397,7 @@ pub(super) async fn try_depgraph_cached_hit(
     // background task. If the build removes its just-produced output before
     // that task completes, a depgraph hit can otherwise fail to materialize
     // and unnecessarily recompile. The fast-hit path has the same guard.
-    pending_writes::await_pending(
-        &state.pending_cache_writes,
-        artifact_key_hex,
-        pending_writes::PENDING_PAYLOAD_WAIT_TIMEOUT,
-    )
-    .await;
+    pending_writes::await_pending_payload(&state.pending_cache_writes, artifact_key_hex).await;
 
     let response = materialize_cached_compile_hit(CachedHitMaterializeRequest {
         state,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
@@ -25,6 +25,9 @@ pub(super) struct MissArtifactStoreRequest<'a> {
     /// Owns the private canonical depfile source until detached persistence
     /// has copied it. `None` for non-staged compiles.
     pub(super) user_depfile_persist_temp: Option<tempfile::TempDir>,
+    /// Retains private Rust compiler outputs until detached staged publication
+    /// has durably consumed them.
+    pub(super) staged_persist_plan: Option<StagedCompilePlan>,
     pub(super) rustc_all_outputs: Option<&'a [RustcOutputFile]>,
     pub(super) stdout: &'a Arc<Vec<u8>>,
     pub(super) stderr: &'a Arc<Vec<u8>>,
@@ -66,6 +69,7 @@ pub(super) fn store_miss_artifact(request: MissArtifactStoreRequest<'_>) -> Miss
         output_data,
         user_depfile,
         user_depfile_persist_temp,
+        staged_persist_plan,
         rustc_all_outputs,
         stdout,
         stderr,
@@ -133,6 +137,7 @@ pub(super) fn store_miss_artifact(request: MissArtifactStoreRequest<'_>) -> Miss
                 &mut stats,
                 t_artifact_build,
                 synchronous_persist,
+                staged_persist_plan,
                 publication_guard,
             );
         } else {
@@ -290,6 +295,7 @@ fn store_rustc_outputs(
     stats: &mut MissArtifactStoreStats,
     t_artifact_build: Instant,
     synchronous_persist: bool,
+    staged_persist_plan: Option<StagedCompilePlan>,
     publication_guard: tokio::sync::OwnedRwLockReadGuard<()>,
 ) {
     let state = state_arc.as_ref();
@@ -328,6 +334,106 @@ fn store_rustc_outputs(
     );
     stats.artifact_index_build_ns = t_artifact_index_build.elapsed().as_nanos() as u64;
     stats.artifact_build_ns = t_artifact_build.elapsed().as_nanos() as u64;
+
+    if let Some(staged_plan) = staged_persist_plan {
+        let _pending = pending_writes::register(&state.pending_cache_writes, artifact_key_hex);
+        let state_ref = Arc::clone(state_arc);
+        let state_for_publish = Arc::clone(state_arc);
+        let artifact_dir = state.artifact_dir.clone();
+        let key_hex = artifact_key_hex.to_string();
+        let sid = *sid;
+        let completion_key = artifact_key_hex.to_string();
+        let t_persist_enqueue = Instant::now();
+        tokio::spawn(async move {
+            #[expect(
+                clippy::expect_used,
+                reason = "persist_semaphore is owned by ServerState for the daemon's lifetime; AcquireError here would be a logic bug"
+            )]
+            let _permit = state_ref
+                .persist_semaphore
+                .acquire()
+                .await
+                .expect("persist_semaphore is owned by ServerState and never closed");
+            let published = tokio::task::spawn_blocking(move || {
+                let _publication_guard = publication_guard;
+                let _staged_plan = staged_plan;
+                let snapshot =
+                    persist_artifact_paths_with_stats(&artifact_dir, &key_hex, &source_paths)?;
+                if snapshot.staged {
+                    send_staged_index_insert(
+                        state_for_publish.as_ref(),
+                        key_hex.clone(),
+                        meta.clone(),
+                    )
+                    .map_err(|reason| {
+                        std::io::Error::other(format!(
+                            "staged artifact index commit failed: {}",
+                            reason.id()
+                        ))
+                    })?;
+                } else {
+                    let _ = state_for_publish
+                        .index_writer_tx
+                        .send(IndexWriterCommand::Insert(key_hex, meta.clone()));
+                }
+                Ok::<_, std::io::Error>((snapshot, meta))
+            })
+            .await;
+            match published {
+                Ok(Ok((snapshot, meta))) => {
+                    state_ref
+                        .artifacts
+                        .insert(completion_key.clone(), CachedArtifact::from_index(meta));
+                    use crate::daemon::staged_stats::{StagedBytes, StagedCounter, StagedTiming};
+                    if snapshot.staged {
+                        state_ref
+                            .profiler
+                            .staged
+                            .count(StagedCounter::PublicationSuccess);
+                        state_ref
+                            .profiler
+                            .staged
+                            .timing(StagedTiming::Hashing, snapshot.staged_hash_ns);
+                        state_ref
+                            .profiler
+                            .staged
+                            .timing(StagedTiming::Publication, snapshot.staged_publication_ns);
+                        state_ref
+                            .profiler
+                            .staged
+                            .bytes(StagedBytes::Publication, snapshot.copy_bytes);
+                    }
+                }
+                Ok(Err(error)) => {
+                    let reason =
+                        staged_publish_failure(&error).unwrap_or(StagedPublishFailure::StoreSetup);
+                    record_staged_publication_failure(state_ref.as_ref(), reason);
+                    report_staged_publication_failure(
+                        state_ref.as_ref(),
+                        &sid,
+                        &completion_key,
+                        reason,
+                        &error,
+                    );
+                    state_ref.artifacts.remove(&completion_key);
+                }
+                Err(error) => {
+                    tracing::warn!(%error, key = %completion_key, "staged artifact persistence task failed to join");
+                    state_ref.artifacts.remove(&completion_key);
+                }
+            }
+            pending_writes::complete(&state_ref.pending_cache_writes, &completion_key);
+        });
+        stats.persist_enqueue_ns = t_persist_enqueue.elapsed().as_nanos() as u64;
+        let latency_ns = compile_start.elapsed().as_nanos() as u64;
+        state.stats.record_miss(latency_ns, artifact_bytes);
+        let src = source_path.clone();
+        record_session_stat(&state.sessions, &sid, move |t| {
+            t.record_miss(src, artifact_bytes);
+        });
+        drop(_pending);
+        return;
+    }
 
     let t_persist_sync = Instant::now();
     let sync_persist_result =

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -533,7 +533,62 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
             }
         }
     }
-    let synchronous_persist = synchronous_persist && staged_cc_materialization.is_none();
+    // Rust has the same private output plan as C/C++, but publication used to
+    // run before requested-output materialization so the plan's sources could
+    // not disappear underneath the durable store. Materialize first without
+    // cleanup, then transfer plan ownership to the detached publisher.
+    let staged_rust_persist_plan =
+        if let Some(plan) = is_rustc.then(|| staged_plan.take()).flatten() {
+            use crate::daemon::staged_stats::{
+                StagedBytes, StagedCounter, StagedFailure, StagedTiming,
+            };
+            let started = std::time::Instant::now();
+            match plan.materialize_without_cleanup() {
+                Ok(materialized) => {
+                    state.profiler.staged.add_count(
+                        StagedCounter::MaterializeReflink,
+                        materialized.reflink_count,
+                    );
+                    state
+                        .profiler
+                        .staged
+                        .add_count(StagedCounter::MaterializeCopy, materialized.copy_count);
+                    state
+                        .profiler
+                        .staged
+                        .bytes(StagedBytes::Materialization, materialized.copy_bytes);
+                    state.profiler.staged.timing(
+                        StagedTiming::MissMaterialization,
+                        started.elapsed().as_nanos() as u64,
+                    );
+                    compiler_output_path = output_path.clone();
+                    state.cache_system.apply_changes(vec![output_path.clone()]);
+                    Some(plan)
+                }
+                Err(error) => {
+                    state
+                        .profiler
+                        .staged
+                        .count(StagedCounter::MaterializeFailure);
+                    state
+                        .profiler
+                        .staged
+                        .failure(StagedFailure::RequestedMaterialization);
+                    state.profiler.staged.timing(
+                        StagedTiming::MissMaterialization,
+                        started.elapsed().as_nanos() as u64,
+                    );
+                    return Some(Response::Error {
+                        message: format!("failed to materialize compiler output: {error}"),
+                    });
+                }
+            }
+        } else {
+            None
+        };
+    let synchronous_persist = synchronous_persist
+        && staged_cc_materialization.is_none()
+        && staged_rust_persist_plan.is_none();
 
     // Acquire exactly one owned guard and either retain it for synchronous
     // publication or transfer it to the detached persist task. Re-acquiring a
@@ -556,6 +611,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
                 output_data,
                 user_depfile: user_depfile_capture,
                 user_depfile_persist_temp,
+                staged_persist_plan: staged_rust_persist_plan,
                 rustc_all_outputs: rustc_all_outputs.as_deref(),
                 stdout: &stdout,
                 stderr: &stderr,
@@ -580,142 +636,11 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         rust_snapshot_copy_count,
         rust_snapshot_copy_bytes,
         rust_snapshot_error_count,
-        staged_failure_reason,
+        staged_failure_reason: _,
         artifact_index_build_ns,
         artifact_index_persist_ns,
         artifact_memory_insert_ns,
     } = store_stats;
-
-    if let Some(plan) = staged_plan {
-        use crate::daemon::staged_stats::{
-            StagedBytes, StagedCounter, StagedFailure, StagedTiming,
-        };
-        let salvage = rust_snapshot_error_count > 0;
-        let salvage_reason = staged_failure_reason.unwrap_or("publication");
-        let output_count = plan.output_paths().len();
-        let materialize_started = std::time::Instant::now();
-        if salvage {
-            state.profiler.staged.count(StagedCounter::SalvageAttempt);
-            crate::core::lifecycle::write_event(
-                crate::core::lifecycle::EVENT_STAGED_SALVAGE_STARTED,
-                serde_json::json!({
-                    "reason": salvage_reason,
-                    "output_count": output_count,
-                    "copied_bytes": 0,
-                    "elapsed_ns": 0,
-                }),
-            );
-        }
-        match plan.materialize() {
-            Ok(materialized) => {
-                let elapsed_ns = materialize_started.elapsed().as_nanos() as u64;
-                state.profiler.staged.add_count(
-                    StagedCounter::MaterializeReflink,
-                    materialized.reflink_count,
-                );
-                state
-                    .profiler
-                    .staged
-                    .add_count(StagedCounter::MaterializeCopy, materialized.copy_count);
-                state
-                    .profiler
-                    .staged
-                    .bytes(StagedBytes::Materialization, materialized.copy_bytes);
-                if salvage {
-                    state.profiler.staged.count(StagedCounter::SalvageSuccess);
-                    state
-                        .profiler
-                        .staged
-                        .timing(StagedTiming::Salvage, elapsed_ns);
-                    state
-                        .profiler
-                        .staged
-                        .bytes(StagedBytes::Salvage, materialized.copy_bytes);
-                    crate::core::lifecycle::write_event(
-                        crate::core::lifecycle::EVENT_STAGED_SALVAGE_COMPLETE,
-                        serde_json::json!({
-                            "reason": salvage_reason,
-                            "output_count": output_count,
-                            "copied_bytes": materialized.copy_bytes,
-                            "elapsed_ns": elapsed_ns,
-                        }),
-                    );
-                } else {
-                    state
-                        .profiler
-                        .staged
-                        .timing(StagedTiming::MissMaterialization, elapsed_ns);
-                }
-            }
-            Err(error) => {
-                let elapsed_ns = materialize_started.elapsed().as_nanos() as u64;
-                let progress = materialization_error_progress(&error);
-                state
-                    .profiler
-                    .staged
-                    .add_count(StagedCounter::MaterializeReflink, progress.reflink_count);
-                state
-                    .profiler
-                    .staged
-                    .add_count(StagedCounter::MaterializeCopy, progress.copy_count);
-                state
-                    .profiler
-                    .staged
-                    .bytes(StagedBytes::Materialization, progress.copy_bytes);
-                state
-                    .profiler
-                    .staged
-                    .count(StagedCounter::MaterializeFailure);
-                state
-                    .profiler
-                    .staged
-                    .failure(StagedFailure::RequestedMaterialization);
-                if salvage {
-                    state.profiler.staged.count(StagedCounter::SalvageFailure);
-                    state.profiler.staged.failure(StagedFailure::Salvage);
-                    state
-                        .profiler
-                        .staged
-                        .timing(StagedTiming::Salvage, elapsed_ns);
-                    state
-                        .profiler
-                        .staged
-                        .bytes(StagedBytes::Salvage, progress.copy_bytes);
-                    crate::core::lifecycle::write_event(
-                        crate::core::lifecycle::EVENT_STAGED_SALVAGE_FAILED,
-                        serde_json::json!({
-                            "reason": "requested_materialization",
-                            "output_count": output_count,
-                            "copied_bytes": progress.copy_bytes,
-                            "elapsed_ns": elapsed_ns,
-                        }),
-                    );
-                } else {
-                    state
-                        .profiler
-                        .staged
-                        .timing(StagedTiming::MissMaterialization, elapsed_ns);
-                    crate::core::lifecycle::write_event(
-                        crate::core::lifecycle::EVENT_STAGED_MATERIALIZATION_FAILED,
-                        serde_json::json!({
-                            "reason": "requested_materialization",
-                            "output_count": output_count,
-                            "copied_bytes": progress.copy_bytes,
-                            "elapsed_ns": elapsed_ns,
-                        }),
-                    );
-                }
-                write_session_log(
-                    &state.sessions,
-                    sid,
-                    &format!("[DIAG] staged_materialization_failed: {error}"),
-                );
-                return Some(Response::Error {
-                    message: format!("failed to materialize compiler output: {error}"),
-                });
-            }
-        }
-    }
 
     // Record miss phase profile
     let total_ns = compile_start.elapsed().as_nanos() as u64;

--- a/crates/zccache-daemon-core/src/daemon/server/pending_writes.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/pending_writes.rs
@@ -70,11 +70,10 @@ use tokio::sync::Notify;
 pub(super) const PENDING_WAIT_TIMEOUT: Duration = Duration::from_millis(5);
 
 /// Longer wait used when the depgraph has already proven a cache hit and the
-/// only remaining race is rustc payload publication. This stays within the
-/// documented pending-entry blast radius while avoiding an immediate
-/// recompile if the build removes its just-produced output before the async
-/// persist task has linked/copied the cache payloads.
-pub(super) const PENDING_PAYLOAD_WAIT_TIMEOUT: Duration = Duration::from_millis(50);
+/// only remaining race is rustc staged-payload publication. This prevents an
+/// immediate duplicate compile while a large artifact is being durably
+/// snapshotted; ordinary pending-write probes retain their 5 ms bound.
+pub(super) const PENDING_PAYLOAD_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Informational upper bound on how long a pending entry is expected to
 /// live. Used by adversarial tests to flag leaked entries — not enforced
@@ -134,12 +133,37 @@ pub(super) async fn await_pending(
     key: &str,
     timeout: Duration,
 ) -> bool {
+    await_pending_capped(pending, key, timeout, PENDING_WAIT_TIMEOUT).await
+}
+
+/// Wait for a known payload-publication race. Callers use this only after a
+/// cache key has already been proven, so waiting for durable publication is
+/// preferable to recompiling the same artifact through an uncached path.
+pub(super) async fn await_pending_payload(
+    pending: &DashMap<String, Arc<Notify>>,
+    key: &str,
+) -> bool {
+    await_pending_capped(
+        pending,
+        key,
+        PENDING_PAYLOAD_WAIT_TIMEOUT,
+        PENDING_PAYLOAD_WAIT_TIMEOUT,
+    )
+    .await
+}
+
+async fn await_pending_capped(
+    pending: &DashMap<String, Arc<Notify>>,
+    key: &str,
+    timeout: Duration,
+    maximum: Duration,
+) -> bool {
     let Some(notify) = pending.get(key).map(|entry| Arc::clone(&entry)) else {
         return false;
     };
     // Cap the caller's requested timeout at the pending-entry blast radius so
     // a mis-specified caller can't extend the registry's scope indefinitely.
-    let capped = timeout.min(PENDING_PAYLOAD_WAIT_TIMEOUT);
+    let capped = timeout.min(maximum);
     if capped.is_zero() {
         return true;
     }

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
@@ -799,6 +799,18 @@ impl StagedCompilePlan {
     }
 
     pub(in crate::daemon::server) fn materialize(&self) -> io::Result<StagedMaterializationStats> {
+        let stats = self.materialize_without_cleanup()?;
+        self.cleanup()
+            .map_err(|error| materialization_error(error, stats))?;
+        Ok(stats)
+    }
+
+    /// Materialize the requested outputs while retaining the private staging
+    /// root for a detached durable publisher. The caller must keep this plan
+    /// alive until publication has consumed every staged source.
+    pub(in crate::daemon::server) fn materialize_without_cleanup(
+        &self,
+    ) -> io::Result<StagedMaterializationStats> {
         let mut stats = StagedMaterializationStats::default();
         let requested_outputs = self
             .outputs
@@ -847,8 +859,6 @@ impl StagedCompilePlan {
                     .map_err(|error| materialization_error(error, stats))?;
             }
         }
-        self.cleanup()
-            .map_err(|error| materialization_error(error, stats))?;
         Ok(stats)
     }
 

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan_tests.rs
@@ -197,6 +197,45 @@ fn logical_depfile_rewrite_failure_is_propagated_before_publication() {
 }
 
 #[test]
+fn deferred_materialization_keeps_staged_source_for_durable_publication() {
+    let temp = tempdir().unwrap();
+    let root: NormalizedPath = temp.path().join("private").into();
+    std::fs::create_dir_all(root.as_path()).unwrap();
+    let requested: NormalizedPath = temp.path().join("requested/libfixture.rlib").into();
+    let staged: NormalizedPath = root.join("libfixture.rlib");
+    std::fs::write(staged.as_path(), b"compiled artifact").unwrap();
+    let plan = StagedCompilePlan::for_test(
+        root.clone(),
+        vec![StagedOutputPlan {
+            requested: requested.clone(),
+            staged: staged.clone(),
+            role: StagedOutputRole::Regular,
+        }],
+    );
+
+    plan.materialize_without_cleanup().unwrap();
+
+    assert_eq!(
+        std::fs::read(requested.as_path()).unwrap(),
+        b"compiled artifact"
+    );
+    assert!(
+        staged.exists(),
+        "publisher must retain access to the staged source"
+    );
+    assert!(
+        root.exists(),
+        "staging root must outlive response materialization"
+    );
+
+    plan.cleanup().unwrap();
+    assert!(
+        !root.exists(),
+        "publisher cleanup must reclaim the private staging root"
+    );
+}
+
+#[test]
 fn cc_custom_mf_destination_is_classified_as_a_depfile() {
     if !staged_tests_enabled() {
         return;


### PR DESCRIPTION
## Summary
- materialize staged Rust outputs before responding, while retaining the private staging plan for detached durable publication
- publish the in-memory artifact only after durable storage and index publication succeed
- make a proven Rust payload-publication race wait up to five seconds rather than recompiling through an uncached path

## Local validation
- `soldr cargo check -p zccache-daemon-core`
- `soldr cargo clippy -p zccache-daemon-core --all-targets --features test-support -- -D warnings`
- targeted staged-plan and pending-write tests
- `ZCCACHE_PROFILE_RUST_MISS=1 soldr cargo test -p zccache --test perf_bench_test -- perf_rust_workspace_link --nocapture --ignored`
  - cold 0.207s, `rust_snapshot_ns=0`; immediate warm trials were cache hits (median 0.013s)

Relates to #1215.