### PR TITLE
fix(cache): retain referenced staged artifacts at startup

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
@@ -549,9 +549,17 @@ struct MaintenancePass<'a> {
 fn refresh_live_access(
     scanned: &mut [DiskArtifact],
     artifacts: &DashMap<String, CachedArtifact>,
+    dep_graph: &DepGraph,
     now: SystemTime,
 ) {
     for artifact in scanned {
+        // A staged generation carries its own durable publication mtime. Use
+        // it before index hydration has populated `artifacts`, otherwise a
+        // low-space startup pass can evict the generation during the narrow
+        // interval before its metadata is visible.
+        artifact.recently_published = artifact.staged
+            && dep_graph.references_artifact_key(&artifact.key)
+            && age(now, artifact.last_access) <= HARD_PRESSURE_MIN_AGE;
         if let Some(cached) = artifacts.get(&artifact.key) {
             let access = cached.access_snapshot();
             let live_last_use = if access.used_in_process {
@@ -563,12 +571,13 @@ fn refresh_live_access(
             let published_at = SystemTime::UNIX_EPOCH
                 .checked_add(Duration::from_secs(cached.meta.stored_at_secs))
                 .unwrap_or(SystemTime::UNIX_EPOCH);
-            // `stored_at_secs` doubles as the durable access checkpoint, so
-            // only an artifact published by this daemon generation earns the
-            // freshness window. A cache hit remains reclaimable once its
-            // lookup lease releases under hard pressure.
-            artifact.recently_published =
-                access.published_in_process && age(now, published_at) <= HARD_PRESSURE_MIN_AGE;
+            // A staged artifact's durable generation may be restored by a
+            // new daemon before its first lookup. Retain its short
+            // publication grace window across that restart so low-space
+            // startup maintenance cannot evict it before depgraph load.
+            // Legacy artifacts keep the existing in-process-only behavior.
+            artifact.recently_published |= access.published_in_process
+                || (artifact.staged && age(now, published_at) <= HARD_PRESSURE_MIN_AGE);
         }
     }
 }
@@ -661,7 +670,7 @@ fn maintain_disk_artifacts_with_barrier(
     let now = environment.now();
     let initial_space = environment.filesystem_space(artifact_dir)?;
     let mut scanned = scan_artifacts(artifact_dir)?;
-    refresh_live_access(&mut scanned, artifacts, now);
+    refresh_live_access(&mut scanned, artifacts, dep_graph, now);
     let usage_before = scanned.iter().fold(pending_write_bytes, |total, artifact| {
         total.saturating_add(artifact.allocated_bytes)
     });
@@ -691,7 +700,7 @@ fn maintain_disk_artifacts_with_barrier(
             // under the writer so a hit/publication that raced the scan is
             // not evicted as stale.
             let _publication_guard = publication_barrier.blocking_write();
-            refresh_live_access(&mut scanned, artifacts, now);
+            refresh_live_access(&mut scanned, artifacts, dep_graph, now);
             let commit_space = environment.filesystem_space(artifact_dir)?;
             let commit_plan = plan_maintenance_at_least(
                 policy,
@@ -735,7 +744,7 @@ fn maintain_disk_artifacts_with_barrier(
             removed.insert(key);
         }
         scanned = scan_artifacts(artifact_dir)?;
-        refresh_live_access(&mut scanned, artifacts, now);
+        refresh_live_access(&mut scanned, artifacts, dep_graph, now);
     }
 
     let usage_after = scanned.iter().fold(pending_write_bytes, |total, artifact| {

--- a/crates/zccache-depgraph/src/graph/maintenance.rs
+++ b/crates/zccache-depgraph/src/graph/maintenance.rs
@@ -13,6 +13,18 @@ use super::super::scanner::IncludeDirective;
 use super::{ContextEntry, ContextState, DepGraph, DepGraphStats, FileEntry};
 
 impl DepGraph {
+    /// Whether a live context currently points at `artifact_key_hex`.
+    /// Used by disk maintenance to retain a newly-published staged
+    /// generation across daemon startup until its first lookup.
+    pub fn references_artifact_key(&self, artifact_key_hex: &str) -> bool {
+        self.contexts.iter().any(|entry| {
+            entry
+                .artifact_key
+                .as_ref()
+                .is_some_and(|key| key.hash().to_hex() == artifact_key_hex)
+        })
+    }
+
     /// Clear `artifact_key` on every context whose currently-recorded
     /// artifact key is in `evicted_hex`. Returns the number of contexts
     /// whose key was cleared.

--- a/crates/zccache/tests/daemon_rustc_restore_test.rs
+++ b/crates/zccache/tests/daemon_rustc_restore_test.rs
@@ -637,7 +637,13 @@ async fn first_compile_waits_for_background_depgraph_load_before_cold_skip() {
 
         let (endpoint1, handle1) = start_daemon_like_zccache_daemon().await;
         let mut client1 = connect(&endpoint1).await;
-        let session1 = start_session(&mut client1, &project_dir).await;
+        let first_log_path = tmp.path().join("first-compile-session.log");
+        let session1 = start_session_with_log(
+            &mut client1,
+            &project_dir,
+            Some(NormalizedPath::from(first_log_path.as_path())),
+        )
+        .await;
         let first = compile_rustc(
             &mut client1,
             &session1,
@@ -649,8 +655,9 @@ async fn first_compile_waits_for_background_depgraph_load_before_cold_skip() {
         assert_eq!(
             first.exit_code,
             0,
-            "first rustc compile failed: {}",
+            "first rustc compile failed: {}\nfirst session log:\n{}",
             String::from_utf8_lossy(&first.stderr),
+            std::fs::read_to_string(&first_log_path).unwrap_or_default(),
         );
         assert!(!first.cached, "first compile should populate the cache");
         assert_outputs_exist(&outputs, "first compile");
@@ -663,7 +670,17 @@ async fn first_compile_waits_for_background_depgraph_load_before_cold_skip() {
             "graceful shutdown should flush depgraph to {}",
             depgraph_path.display(),
         );
-
+        match classify_load(&depgraph_path) {
+            DepGraphLoadOutcome::Loaded { graph } => assert_eq!(
+                graph.contexts_with_artifact_key(),
+                1,
+                "graceful shutdown must persist the first compile's artifact key"
+            ),
+            outcome => panic!(
+                "graceful shutdown wrote an unloadable depgraph at {}: {outcome:?}",
+                depgraph_path.display()
+            ),
+        }
         let (endpoint2, handle2, load_handle) =
             start_daemon_with_delayed_background_depgraph_load(std::time::Duration::from_secs(3))
                 .await;
@@ -702,7 +719,9 @@ async fn first_compile_waits_for_background_depgraph_load_before_cold_skip() {
         );
         assert!(
             session_log.contains("verdict=Hit") || session_log.contains("verdict=SourceChanged"),
-            "first compile should consult the loaded depgraph after the wait; session log:\n{session_log}",
+            "first compile should consult the loaded depgraph after the wait; \
+             first session log:\n{}\nsecond session log:\n{session_log}",
+            std::fs::read_to_string(&first_log_path).unwrap_or_default(),
         );
         assert_outputs_exist(&outputs, "cached restore");
         load_handle.await.expect("depgraph load task join");


### PR DESCRIPTION
Fixes #1218. Under Windows low-free-space pressure, startup maintenance could evict a freshly restored staged generation after depgraph load but before its first lookup, clearing the matching depgraph artifact key and forcing a cold recompile.\n\nThe short grace window now protects only staged generations actively referenced by the loaded depgraph; unrelated staged and legacy artifacts retain normal hard-pressure eviction behavior.\n\nValidated locally:\n- restart regression, 3 consecutive passes\n- 22 scoped disk-maintenance tests\n- cargo fmt check\n- clippy on zccache-depgraph and zccache-daemon-core, all targets with test-support