### PR TITLE
ci: repair read-only restored integration outputs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -81,6 +81,14 @@ jobs:
           # than setup-soldr's 5 GiB default.
           SOLDR_TARGET_BLOCK_FREE_GB: "2"
         run: |
+          # The build cache can contain zccache COW materializations, whose
+          # artifacts are intentionally read-only while shared with the cache.
+          # This prebuild bypasses zccache, so rustc cannot detach them before
+          # overwriting a stale output. The restored target tree is private to
+          # this runner; make those files writable before invoking rustc.
+          if [[ -d target ]]; then
+            find target -type f ! -perm -u+w -exec chmod u+w {} +
+          fi
           soldr cargo test --workspace --features "$ZCCACHE_INTEGRATION_FEATURES" --no-fail-fast --no-run
           soldr cargo build -p zccache --features ci-bin --bin zccache-ci
       - name: Stop setup-soldr builder cache before tests


### PR DESCRIPTION
Fixes the reproducible Integration failure in which rustc cannot overwrite a restored read-only rmeta output while the prebuild has ZCCACHE_DISABLE=1. The runner-private restored target files are made owner-writable before rustc starts. Cache behavior and runtime artifacts are unchanged. Local validation: git diff --check, workflow YAML parse, and Bash syntax check.