### PR TITLE
fix: stabilize Dylint driver cache identity

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/compiler_hash.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/compiler_hash.rs
@@ -696,6 +696,36 @@ pub(super) async fn hash_cc_identity_async(path: std::path::PathBuf) -> Option<C
     }
 }
 
+/// Identify a generated Dylint driver by its semantic version rather than its
+/// byte-for-byte executable image.
+///
+/// Cargo Dylint builds the driver in a fresh temporary package. Equivalent
+/// rebuilds can therefore differ in debug paths or linker build IDs even
+/// though `dylint-driver -V` and behavior are unchanged. Hashing the complete
+/// image prevents cache reuse across those rebuilds. The inner rustc identity
+/// and every loaded lint-library content hash are independently included in
+/// the Dylint cache-input fingerprint.
+pub(super) async fn hash_dylint_driver_identity_async(
+    path: std::path::PathBuf,
+    client_env: Vec<(String, String)>,
+) -> Option<ContentHash> {
+    let mut cmd = tokio::process::Command::new(&path);
+    cmd.arg("-V").envs(client_env);
+    crate::daemon::process::suppress_child_console_tokio(&mut cmd);
+    cmd.kill_on_drop(true);
+    let timeout = rustc_probe_timeout();
+    match tokio::time::timeout(timeout, cmd.output()).await {
+        Ok(Ok(output)) if output.status.success() && !output.stdout.is_empty() => {
+            Some(crate::hash::hash_bytes(&output.stdout))
+        }
+        Err(_) => {
+            warn_probe_timeout(&path, timeout);
+            crate::hash::hash_file(&path).ok()
+        }
+        _ => crate::hash::hash_file(&path).ok(),
+    }
+}
+
 #[allow(dead_code)] // The cache calls `rustc_identity_async` to retain provenance.
 pub(super) async fn hash_rustc_identity_async(path: std::path::PathBuf) -> Option<ContentHash> {
     let mut cmd = tokio::process::Command::new(&path);

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -106,11 +106,9 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             };
             let driver_identity = state
                 .compiler_hash_cache
-                .get_or_hash_with_async(compiler_path, |path| async move {
-                    tokio::task::spawn_blocking(move || crate::hash::hash_file(&path).ok())
-                        .await
-                        .ok()
-                        .flatten()
+                .get_or_hash_with_async(compiler_path, {
+                    let probe_env = client_env.clone().unwrap_or_default();
+                    |path| hash_dylint_driver_identity_async(path, probe_env)
                 })
                 .await
                 .ok_or_else(|| {

--- a/crates/zccache-daemon-core/src/daemon/server/tests/compiler_hash.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/compiler_hash.rs
@@ -259,6 +259,43 @@ fn hash_rustc_identity_falls_back_to_file_hash_when_spawn_fails() {
 
 // ── Issue #517: persisted compiler hash cache ───────────────────────────
 
+/// Cargo Dylint creates the driver from a fresh temporary package, so build
+/// IDs and embedded source paths can change while the driver's semantic
+/// version remains identical. Such rebuilds must retain one cache identity.
+#[cfg(unix)]
+#[tokio::test]
+async fn dylint_driver_identity_uses_version_not_executable_bytes() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let first = tmp.path().join("dylint-driver-a");
+    let second = tmp.path().join("dylint-driver-b");
+    std::fs::write(
+        &first,
+        b"#!/bin/sh\n# build-id: one\nprintf 'dylint-driver 6.0.1\\n'\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &second,
+        b"#!/bin/sh\n# build-id: two-and-a-different-size\nprintf 'dylint-driver 6.0.1\\n'\n",
+    )
+    .unwrap();
+    for path in [&first, &second] {
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
+
+    assert_ne!(
+        crate::hash::hash_file(&first).unwrap(),
+        crate::hash::hash_file(&second).unwrap()
+    );
+    assert_eq!(
+        hash_dylint_driver_identity_async(first, Vec::new()).await,
+        hash_dylint_driver_identity_async(second, Vec::new()).await
+    );
+}
+
 /// #1167: a transient `-vV` failure may use a file hash for the current
 /// request, but it must not be memoized. The next request retries and a good
 /// probe converges on the durable `-vV` identity instead of pinning a second

--- a/crates/zccache-depgraph/src/snapshot/tests/worktree_variants.rs
+++ b/crates/zccache-depgraph/src/snapshot/tests/worktree_variants.rs
@@ -85,3 +85,33 @@ fn equivalent_worktree_variants_survive_snapshot_roundtrip() {
         CacheVerdict::Hit { artifact_key } if artifact_key == artifact_b
     ));
 }
+
+#[test]
+fn new_equivalent_worktree_reuses_warm_context_after_snapshot_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let path = test_path(&dir);
+    let graph = DepGraph::new();
+    let a = graph.register_with_root_result(
+        context("/snapshot-a"),
+        Some(NormalizedPath::from("/snapshot-a")),
+    );
+    let artifact_a = graph
+        .update(&a.map_key, scan("/snapshot-a"), equal_hash)
+        .unwrap();
+
+    save_to_file(&graph, &path).unwrap();
+    let loaded = load_from_file(&path).unwrap();
+    let b = loaded.register_with_root_result(
+        context("/snapshot-b"),
+        Some(NormalizedPath::from("/snapshot-b")),
+    );
+
+    assert!(
+        b.rebased_from_equivalent_root,
+        "the restored logical-key index must expose the warm context to a new worktree"
+    );
+    assert!(matches!(
+        loaded.check(&b.map_key, always_fresh, equal_hash),
+        CacheVerdict::Hit { artifact_key } if artifact_key == artifact_a
+    ));
+}


### PR DESCRIPTION
## Summary
- identify generated Dylint drivers by their -V semantic version
- keep inner rustc and lint-library content hashes in the cache fingerprint
- cover byte-different equivalent drivers and persisted sibling-worktree reuse

## Why
Cargo Dylint rebuilds its driver from a temporary package. Equivalent binaries can differ through embedded temporary paths or linker build IDs, causing false cache misses across worktrees.

## Validation
- soldr --no-cache cargo check -p zccache-daemon-core --locked`n- soldr --no-cache cargo test -p zccache-depgraph new_equivalent_worktree_reuses_warm_context_after_snapshot_roundtrip --locked -- --nocapture`n- Windows test compilation with --features test-support (Unix semantic-driver test runs in CI)