### PR TITLE
feat: persist compile context keys in journals

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/compile_journal/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/mod.rs
@@ -89,6 +89,7 @@ pub mod miss_reason {
 
 tokio::task_local! {
     static ACTIVE_MISS_REASON: Cell<Option<&'static str>>;
+    static ACTIVE_CONTEXT_KEY: std::cell::RefCell<Option<String>>;
 }
 
 /// Run one request with an isolated miss-attribution slot.
@@ -98,15 +99,20 @@ tokio::task_local! {
 /// task-local scope can exhaust Tokio's default worker stack on Windows.
 pub async fn capture_miss_reason<F>(
     future: std::pin::Pin<Box<F>>,
-) -> (F::Output, Option<&'static str>)
+) -> (F::Output, Option<&'static str>, Option<String>)
 where
     F: Future + ?Sized,
 {
-    ACTIVE_MISS_REASON
-        .scope(Cell::new(None), async move {
-            let output = future.await;
-            let reason = ACTIVE_MISS_REASON.with(Cell::get);
-            (output, reason)
+    ACTIVE_CONTEXT_KEY
+        .scope(std::cell::RefCell::new(None), async move {
+            ACTIVE_MISS_REASON
+                .scope(Cell::new(None), async move {
+                    let output = future.await;
+                    let reason = ACTIVE_MISS_REASON.with(Cell::get);
+                    let context_key = ACTIVE_CONTEXT_KEY.with(|slot| slot.borrow().clone());
+                    (output, reason, context_key)
+                })
+                .await
         })
         .await
 }
@@ -120,6 +126,17 @@ pub fn record_miss_reason(reason: &'static str) {
         if replace {
             slot.set(Some(reason));
         }
+    });
+}
+
+/// Attach the normalized dependency-graph context key to the active compile's
+/// durable journal entry. This makes cross-worktree miss investigations
+/// possible even when the command uses an ephemeral session whose text log is
+/// removed before an external collector can copy it.
+pub fn record_context_key(key: &crate::depgraph::ContextKey) {
+    let value = key.hash().to_hex().to_string();
+    let _ = ACTIVE_CONTEXT_KEY.try_with(|slot| {
+        *slot.borrow_mut() = Some(value);
     });
 }
 
@@ -162,6 +179,9 @@ pub struct JournalEntry {
     pub session_id: Option<String>,
     /// Wall-clock nanoseconds.
     pub latency_ns: u128,
+    /// Root-normalized dependency-graph context identity.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_key: Option<String>,
 
     // ─── Extended profile-mode fields (issue #256). ─────────────────────
     // All optional; emission is gated behind `--profile` in a follow-up PR.
@@ -271,6 +291,7 @@ impl JournalEntry {
             exit_code,
             session_id: ctx.session_id,
             latency_ns,
+            context_key: None,
             crate_name: None,
             crate_type: None,
             output_ext: None,
@@ -278,6 +299,12 @@ impl JournalEntry {
             miss_diff: None,
             self_profile_ns: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_context_key(mut self, context_key: Option<String>) -> Self {
+        self.context_key = context_key;
+        self
     }
 
     /// Issue #256: populate the extended profile-mode fields on an entry.

--- a/crates/zccache-daemon-core/src/daemon/compile_journal/tests/entry.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/tests/entry.rs
@@ -274,6 +274,7 @@ fn serializes_extended_fields_when_present() {
         exit_code: 0,
         session_id: Some("sess-1".to_string()),
         latency_ns: 1_234_567,
+        context_key: None,
         crate_name: Some("soldr_cli".to_string()),
         crate_type: Some("bin".to_string()),
         output_ext: Some("exe".to_string()),
@@ -327,6 +328,16 @@ fn serializes_extended_fields_when_present() {
     assert_eq!(v["self_profile_ns"]["lookup"], 410_000_u64);
     assert_eq!(v["self_profile_ns"]["decompress"], 14_100_000_u64);
     assert_eq!(v["self_profile_ns"]["store"], 203_000_000_u64);
+}
+
+#[test]
+fn serializes_context_key_without_profile_mode() {
+    let key = "ab".repeat(32);
+    let entry = JournalEntry::new(make_ctx(vec!["src/lib.rs"]), "miss", 0, 10, None)
+        .with_context_key(Some(key.clone()));
+    let value = serde_json::to_value(entry).unwrap();
+    assert_eq!(value["context_key"], key);
+    assert!(value.get("crate_name").is_none());
 }
 
 #[test]

--- a/crates/zccache-daemon-core/src/daemon/compile_journal/tests/miss_reason.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/tests/miss_reason.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use crate::protocol::Response;
 
 use super::super::{
-    capture_miss_reason, extract_outcome, miss_reason, record_miss_reason, CompileJournal,
-    JournalContext, JournalEntry, MissDiff,
+    capture_miss_reason, extract_outcome, miss_reason, record_context_key, record_miss_reason,
+    CompileJournal, JournalContext, JournalEntry, MissDiff,
 };
 use super::wait_for_lines;
 
@@ -137,7 +137,7 @@ fn every_miss_reason_has_a_production_emitter() {
 
 #[tokio::test]
 async fn miss_attribution_keeps_the_most_specific_observation() {
-    let (_, reason) = capture_miss_reason(Box::pin(async {
+    let (_, reason, _) = capture_miss_reason(Box::pin(async {
         record_miss_reason(miss_reason::CONTEXT_NOT_FOUND);
         record_miss_reason(miss_reason::VERSION_SKEW);
         record_miss_reason(miss_reason::INPUT_FINGERPRINT_MISMATCH);
@@ -145,6 +145,16 @@ async fn miss_attribution_keeps_the_most_specific_observation() {
     }))
     .await;
     assert_eq!(reason, Some(miss_reason::DESTINATION_WRITE_FAILED));
+}
+
+#[tokio::test]
+async fn compile_scope_captures_the_context_key() {
+    let key = crate::depgraph::ContextKey::from_raw([0x2a; 32]);
+    let (_, _, captured) = capture_miss_reason(Box::pin(async {
+        record_context_key(&key);
+    }))
+    .await;
+    assert_eq!(captured, Some("2a".repeat(32)));
 }
 
 // ─── JournalEntry::new miss_reason threading ──────────────────────────────

--- a/crates/zccache-daemon-core/src/daemon/compile_journal/tests/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/tests/mod.rs
@@ -59,6 +59,7 @@ pub(super) fn legacy_entry(
         exit_code,
         session_id,
         latency_ns,
+        context_key: None,
         crate_name: None,
         crate_type: None,
         output_ext: None,

--- a/crates/zccache-daemon-core/src/daemon/server/connection/dispatch.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/connection/dispatch.rs
@@ -221,7 +221,7 @@ pub(super) async fn dispatch_request(
                     env.clone(),
                     None,
                 );
-                let (resp, attributed_miss_reason) =
+                let (resp, attributed_miss_reason, context_key) =
                     capture_miss_reason(Box::pin(handle_compile_ephemeral(
                         state,
                         client_pid,
@@ -235,7 +235,11 @@ pub(super) async fn dispatch_request(
                     .await;
                 (
                     resp,
-                    Some(PendingJournalContext::new(ctx, attributed_miss_reason)),
+                    Some(PendingJournalContext::new(
+                        ctx,
+                        attributed_miss_reason,
+                        context_key,
+                    )),
                 )
             };
             match guarded_dispatch(conn, handler).await {
@@ -355,7 +359,7 @@ pub(super) async fn dispatch_request(
                 );
                 let resp =
                     handle_link_ephemeral(state, client_pid, &tool, &ctx.args, &cwd, env).await;
-                (resp, Some(PendingJournalContext::new(ctx, None)))
+                (resp, Some(PendingJournalContext::new(ctx, None, None)))
             };
             match guarded_dispatch(conn, handler).await {
                 Some((response, ctx)) => (response, ctx),
@@ -548,20 +552,25 @@ async fn compile_response_for_session(
         clippy::expect_used,
         reason = "ctx.session_id is set to Some(session_id) immediately above (line 704); the Option wrap is purely for the JournalContext return field"
     )]
-    let (resp, attributed_miss_reason) = capture_miss_reason(Box::pin(handle_compile(
-        state,
-        ctx.session_id
-            .as_deref()
-            .expect("session_id set by JournalContext constructor above"),
-        &ctx.args,
-        &cwd,
-        &compiler,
-        env,
-        stdin,
-    )))
-    .await;
+    let (resp, attributed_miss_reason, context_key) =
+        capture_miss_reason(Box::pin(handle_compile(
+            state,
+            ctx.session_id
+                .as_deref()
+                .expect("session_id set by JournalContext constructor above"),
+            &ctx.args,
+            &cwd,
+            &compiler,
+            env,
+            stdin,
+        )))
+        .await;
     (
         resp,
-        Some(PendingJournalContext::new(ctx, attributed_miss_reason)),
+        Some(PendingJournalContext::new(
+            ctx,
+            attributed_miss_reason,
+            context_key,
+        )),
     )
 }

--- a/crates/zccache-daemon-core/src/daemon/server/connection/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/connection/mod.rs
@@ -43,13 +43,19 @@ const SERVER_REQUEST_RECV_TIMEOUT: std::time::Duration = std::time::Duration::fr
 pub(in crate::daemon::server) struct PendingJournalContext {
     context: JournalContext,
     attributed_miss_reason: Option<&'static str>,
+    context_key: Option<String>,
 }
 
 impl PendingJournalContext {
-    fn new(context: JournalContext, attributed_miss_reason: Option<&'static str>) -> Self {
+    fn new(
+        context: JournalContext,
+        attributed_miss_reason: Option<&'static str>,
+        context_key: Option<String>,
+    ) -> Self {
         Self {
             context,
             attributed_miss_reason,
+            context_key,
         }
     }
 }
@@ -280,6 +286,7 @@ pub(super) async fn handle_connection(
             let PendingJournalContext {
                 context: ctx,
                 attributed_miss_reason,
+                context_key,
             } = pending;
             let (outcome, exit_code, miss_reason) = extract_outcome(&response)?;
             let latency_ns = journal_start.elapsed().as_nanos();
@@ -307,9 +314,10 @@ pub(super) async fn handle_connection(
                 miss_reason,
                 session_journal_path,
                 profile_on,
+                context_key,
             ))
         });
-        if let Some((ctx, _, _, latency_ns, reason, _, _)) = journal_payload.as_ref() {
+        if let Some((ctx, _, _, latency_ns, reason, _, _, _)) = journal_payload.as_ref() {
             if *reason == Some(miss_reason::UNKNOWN) {
                 append_unknown_miss_warning(&mut response, ctx, *latency_ns);
             }
@@ -328,9 +336,11 @@ pub(super) async fn handle_connection(
             miss_reason,
             session_journal_path,
             profile_on,
+            context_key,
         )) = journal_payload
         {
-            let entry = JournalEntry::new(ctx, outcome, exit_code, latency_ns, miss_reason);
+            let entry = JournalEntry::new(ctx, outcome, exit_code, latency_ns, miss_reason)
+                .with_context_key(context_key);
             // Issue #256: extended-journal fields are populated only
             // for sessions that opted in via session-start --profile.
             //

--- a/crates/zccache-daemon-core/src/daemon/server/embedded.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/embedded.rs
@@ -245,7 +245,7 @@ impl EmbeddedDaemon {
         // cache_store) attribute their sub-phase records to this compile_id.
         // No-op unless ZCCACHE_INNER_TRACE is set; the IPC wrapper path does
         // not open a scope, so only embedded compiles emit sub-phase records.
-        let (mut response, attributed_miss_reason) =
+        let (mut response, attributed_miss_reason, context_key) =
             capture_miss_reason(Box::pin(super::inner_trace::scope(
                 compile_id.clone(),
                 handle_compile_ephemeral(
@@ -286,7 +286,8 @@ impl EmbeddedDaemon {
                     latency_ns,
                 );
             }
-            let entry = JournalEntry::new(journal_ctx, outcome, exit_code, latency_ns, miss_reason);
+            let entry = JournalEntry::new(journal_ctx, outcome, exit_code, latency_ns, miss_reason)
+                .with_context_key(context_key);
             self.state.journal.log(&entry, None);
         }
         match response {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -569,6 +569,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         }
     };
     let is_rustc = rustc_args_opt.is_some();
+    record_context_key(&context_key);
     let rustc_extern_paths: Vec<NormalizedPath> = rustc_args_opt
         .as_ref()
         .map(|rustc_args| {

--- a/crates/zccache-daemon-core/src/daemon/server/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/mod.rs
@@ -7,8 +7,8 @@
 //! see the common type vocabulary.
 
 use super::compile_journal::{
-    capture_miss_reason, extract_outcome, miss_reason, record_miss_reason, CompileJournal,
-    JournalContext, JournalEntry, SelfProfileSpans,
+    capture_miss_reason, extract_outcome, miss_reason, record_context_key, record_miss_reason,
+    CompileJournal, JournalContext, JournalEntry, SelfProfileSpans,
 };
 use super::fingerprint::FingerprintManager;
 use super::process::CompilePriority;

--- a/crates/zccache-daemon-core/src/daemon/server/tests/compiler_hash.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/compiler_hash.rs
@@ -74,7 +74,7 @@ async fn changed_compiler_identity_attributes_version_skew() {
     .unwrap();
     let cache = CompilerHashCache::new();
 
-    let (_, reason) = crate::daemon::compile_journal::capture_miss_reason(Box::pin(async {
+    let (_, reason, _) = crate::daemon::compile_journal::capture_miss_reason(Box::pin(async {
         cache.get_or_hash_with(&compiler, |_| Some(ContentHash::from_bytes([1; 32])));
         std::fs::write(&compiler, b"second compiler").unwrap();
         filetime::set_file_mtime(

--- a/crates/zccache-daemon-core/src/daemon/server/tests/write_cached.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/write_cached.rs
@@ -873,7 +873,7 @@ async fn destination_failure_survives_and_journals_concrete_reason() {
     std::fs::write(&blocker, b"blocker").unwrap();
     let target: NormalizedPath = blocker.join("output.o").into();
 
-    let (failure, reason) = capture_miss_reason(Box::pin(async {
+    let (failure, reason, _) = capture_miss_reason(Box::pin(async {
         let failure =
             materialize_multi_hit(&[target], &[CachedPayload::File(blob.clone())]).unwrap_err();
         report_materialization_failure(dir.path(), "artifact-key", "unit-test", &failure);
@@ -936,7 +936,7 @@ async fn deleted_cache_blob_invalidates_with_no_artifact_reason() {
     let missing: NormalizedPath = dir.path().join("gone.o").into();
     let target: NormalizedPath = dir.path().join("restored.o").into();
 
-    let (failure, reason) = capture_miss_reason(Box::pin(async {
+    let (failure, reason, _) = capture_miss_reason(Box::pin(async {
         let failure =
             materialize_multi_hit(&[target], &[CachedPayload::File(missing)]).unwrap_err();
         report_materialization_failure(dir.path(), "artifact-key", "unit-test", &failure);

--- a/docs/journal-schema.md
+++ b/docs/journal-schema.md
@@ -19,6 +19,7 @@ scripts) can rely on.
 | `exit_code`    | integer         | yes            | Process exit code. `-1` is reserved for daemon-side errors. |
 | `session_id`   | string \| null  | yes            | UUID for session-attached requests; `null` for ephemeral. |
 | `latency_ns`   | integer         | yes            | Wall-clock nanoseconds (per the project's `_ns` convention). |
+| `context_key`  | string          | no             | Full root-normalized dep-graph context hash. Present once cache-key construction completes; useful for comparing ephemeral cross-worktree requests. |
 | `crate_name`   | string          | no             | Populated when parseable from `--crate-name` (rustc). |
 | `crate_type`   | string          | no             | Canonical: `lib`, `bin`, `proc-macro`, `build-script`, `test`, `bench`, `example`. |
 | `output_ext`   | string          | no             | Derived from `crate_type` — `rlib`, `exe`, `so`, etc. |


### PR DESCRIPTION
## Summary
- attach the full normalized dep-graph context key to compile journal records once key construction completes
- carry it through IPC and embedded compile paths, including ephemeral sessions
- document the optional field and cover task-local capture plus serialization

This makes cross-worktree context_not_found investigations possible after ephemeral text logs have been removed.

## Validation
- soldr --no-cache cargo check -p zccache-daemon-core --locked
- focused context capture and serialization tests with test-support
- soldr --no-cache cargo fmt --all -- --check