### PR TITLE
feat: trace depgraph context registration state

### DIFF
--- a/crates/zccache-compile-trace/README.md
+++ b/crates/zccache-compile-trace/README.md
@@ -30,6 +30,7 @@ per-compile id and the sub-phase seams through
 | phase | path | emitted from |
 |---|---|---|
 | `embedded_daemon_compile` | always | outer span in `embedded.rs` |
+| `context_register_{equivalent,no_cross_root}_{warm,cold,stale}` | always | post-registration state in `pipeline/mod.rs` |
 | `input_hash` | miss | `pipeline/store_outcome.rs` (`hash_source_ns + hash_headers_ns`) |
 | `cache_lookup` | miss | `pipeline/store_outcome.rs` (`depgraph_check_ns`) |
 | `cache_load` | hit | `handle_compile/cached_hit.rs` (artifact index lookup + payload read) |

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -491,6 +491,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         context_key,
         rustc_metadata_compat_key,
         worktree_equivalent_context,
+        registered_context_state,
     ) = match build_result {
         BuildContextResult::Cc { mut ctx, dep_flags } => {
             dependency_mode.apply_to_cc_context(&mut ctx, &dep_flags);
@@ -511,6 +512,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 registration.map_key,
                 None,
                 registration.rebased_from_equivalent_root,
+                registration.state,
             )
         }
         BuildContextResult::Rustc {
@@ -565,11 +567,23 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 registration.map_key,
                 compat_map_key,
                 registration.rebased_from_equivalent_root,
+                registration.state,
             )
         }
     };
     let is_rustc = rustc_args_opt.is_some();
     record_context_key(&context_key);
+    // Make cross-worktree registration decisions visible in the existing
+    // opt-in inner trace. A `context_not_found` journal reason
+    // alone cannot distinguish "no equivalent context was indexed" from
+    // "an equivalent context was found but was itself cold". The six
+    // categorical phase names keep the disabled path allocation-free and
+    // let a production trace prove that boundary without logging source
+    // paths or compiler arguments.
+    super::super::inner_trace::record_context_registration(
+        worktree_equivalent_context,
+        registered_context_state,
+    );
     let rustc_extern_paths: Vec<NormalizedPath> = rustc_args_opt
         .as_ref()
         .map(|rustc_args| {

--- a/crates/zccache-daemon-core/src/daemon/server/inner_trace.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/inner_trace.rs
@@ -43,6 +43,34 @@ pub(crate) fn record_ns(phase: &str, elapsed_ns: u64) {
     });
 }
 
+/// Record the dependency-graph state immediately after context registration.
+///
+/// The durable journal's `context_not_found` reason intentionally stays
+/// compact. These categorical, opt-in trace markers distinguish a genuinely
+/// new context from an equivalent worktree context and show the selected
+/// entry's state without logging paths or compiler arguments.
+pub(crate) fn record_context_registration(
+    equivalent_root: bool,
+    state: crate::depgraph::ContextState,
+) {
+    record_ns(context_registration_phase(equivalent_root, state), 0);
+}
+
+fn context_registration_phase(
+    equivalent_root: bool,
+    state: crate::depgraph::ContextState,
+) -> &'static str {
+    use crate::depgraph::ContextState::{Cold, Stale, Warm};
+    match (equivalent_root, state) {
+        (true, Cold) => "context_register_equivalent_cold",
+        (true, Warm) => "context_register_equivalent_warm",
+        (true, Stale) => "context_register_equivalent_stale",
+        (false, Cold) => "context_register_no_cross_root_cold",
+        (false, Warm) => "context_register_no_cross_root_warm",
+        (false, Stale) => "context_register_no_cross_root_stale",
+    }
+}
+
 /// Run `fut` with `id` installed as the current embedded compile's trace id so
 /// sub-phase [`record_ns`] calls emitted within it attribute to `id`.
 pub(crate) async fn scope<F>(id: String, fut: F) -> F::Output
@@ -84,5 +112,34 @@ mod tests {
             record_ns("cache_store", 12_000);
         })
         .await;
+    }
+
+    #[test]
+    fn context_registration_markers_cover_every_state() {
+        use crate::depgraph::ContextState::{Cold, Stale, Warm};
+        assert_eq!(
+            context_registration_phase(true, Warm),
+            "context_register_equivalent_warm"
+        );
+        assert_eq!(
+            context_registration_phase(true, Cold),
+            "context_register_equivalent_cold"
+        );
+        assert_eq!(
+            context_registration_phase(true, Stale),
+            "context_register_equivalent_stale"
+        );
+        assert_eq!(
+            context_registration_phase(false, Warm),
+            "context_register_no_cross_root_warm"
+        );
+        assert_eq!(
+            context_registration_phase(false, Cold),
+            "context_register_no_cross_root_cold"
+        );
+        assert_eq!(
+            context_registration_phase(false, Stale),
+            "context_register_no_cross_root_stale"
+        );
     }
 }

--- a/crates/zccache-depgraph/src/graph/mod.rs
+++ b/crates/zccache-depgraph/src/graph/mod.rs
@@ -241,6 +241,12 @@ pub struct ContextRegistration {
     /// map key prevents one checkout from replacing another's alias target.
     pub metadata_compat_map_key: Option<ContextKey>,
     pub rebased_from_equivalent_root: bool,
+    /// Entry state observed atomically by the registration operation.
+    ///
+    /// This is captured from the same `DashMap` guard that inserts or
+    /// refreshes the entry, so diagnostics do not need a second lookup that
+    /// could race a concurrent update.
+    pub state: ContextState,
 }
 
 /// Issue #582: cached check for `ZCCACHE_PROFILE_CC_MISS` so

--- a/crates/zccache-depgraph/src/graph/register.rs
+++ b/crates/zccache-depgraph/src/graph/register.rs
@@ -165,12 +165,14 @@ impl DepGraph {
         let instance_key = instance.map_key();
         if let Some(mut existing) = self.contexts.get_mut(&instance_key) {
             existing.last_accessed = Instant::now();
+            let state = existing.state;
             return ContextRegistration {
                 key,
                 map_key: instance_key,
                 instance,
                 metadata_compat_map_key: None,
                 rebased_from_equivalent_root: false,
+                state,
             };
         }
 
@@ -222,7 +224,7 @@ impl DepGraph {
                 candidate
             },
         );
-        self.contexts.entry(instance_key).or_insert(entry);
+        let state = self.contexts.entry(instance_key).or_insert(entry).state;
 
         let mut evicted = self
             .indexes
@@ -259,6 +261,7 @@ impl DepGraph {
             instance,
             metadata_compat_map_key: None,
             rebased_from_equivalent_root,
+            state,
         }
     }
 

--- a/crates/zccache-depgraph/src/graph/tests/worktree_variants.rs
+++ b/crates/zccache-depgraph/src/graph/tests/worktree_variants.rs
@@ -48,11 +48,18 @@ fn equivalent_worktree_b_update_preserves_a_artifact() {
     let root_a = NormalizedPath::from("/worktree-a");
     let root_b = NormalizedPath::from("/worktree-b");
     let a = graph.register_with_root_result(context("/worktree-a"), Some(root_a));
+    assert_eq!(a.state, ContextState::Cold);
     let artifact_a = graph
         .update(&a.map_key, scan("/worktree-a"), equivalent_hash)
         .expect("A must become warm");
 
     let b = graph.register_with_root_result(context("/worktree-b"), Some(root_b));
+    assert!(b.rebased_from_equivalent_root);
+    assert_eq!(
+        b.state,
+        ContextState::Warm,
+        "registration reports the state cloned from the equivalent root"
+    );
     assert_eq!(
         a.key, b.key,
         "equivalent roots retain one artifact identity"
@@ -84,6 +91,21 @@ fn equivalent_worktree_b_update_preserves_a_artifact() {
         CacheVerdict::Hit { artifact_key } if artifact_key == artifact_a
     ));
     assert_eq!(graph.stats().context_count, 2);
+}
+
+#[test]
+fn registration_reports_existing_stale_state_without_an_extra_lookup() {
+    let graph = DepGraph::new();
+    let root = NormalizedPath::from("/stale-worktree");
+    let first = graph.register_with_root_result(context("/stale-worktree"), Some(root.clone()));
+    graph
+        .update(&first.map_key, scan("/stale-worktree"), equivalent_hash)
+        .expect("context must become warm");
+    assert!(graph.mark_stale(&first.map_key));
+
+    let refreshed = graph.register_with_root_result(context("/stale-worktree"), Some(root));
+    assert_eq!(refreshed.map_key, first.map_key);
+    assert_eq!(refreshed.state, ContextState::Stale);
 }
 
 #[test]


### PR DESCRIPTION
Adds opt-in inner-trace markers for the dependency-graph state immediately after context registration. This distinguishes a new/local cold context from a warm/cold equivalent cross-worktree context without logging source paths or compiler arguments. It is needed to resolve the remaining real Dylint 6.0.1 sibling-worktree miss in zackees/soldr#1783.\n\nValidation:\n- soldr cargo fmt --all -- --check\n- soldr cargo test -p zccache-daemon-core --features test-support context_registration_markers_cover_every_state --lib