### PR TITLE
Fix Dylint cache hits across sibling worktrees

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -146,6 +146,16 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             )
         }
         .await;
+        if dylint_result.is_ok() {
+            if let Some(env) = client_env.as_deref() {
+                for (name, value) in env.iter().filter(|(name, _)| {
+                    crate::compiler::dylint_env_affects_output(name)
+                        || matches!(name.as_str(), "DYLINT_LIBS" | "ZCCACHE_WORKTREE_ROOT")
+                }) {
+                    record_dylint_input_hash(name, value.as_bytes());
+                }
+            }
+        }
         if let Err(reason) = dylint_result {
             let diagnostic = format!("zccache: Dylint cache disabled: {reason}\n");
             let bypass_compiler: NormalizedPath = compiler_path.into();
@@ -529,6 +539,50 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             );
             let rustc_key_root =
                 rustc_context_key_root(&rustc_args.remap_path_prefixes, worktree_root.as_ref());
+            if crate::compiler::is_dylint_driver(&compiler_path.to_string_lossy()) {
+                super::super::inner_trace::record_ns(
+                    match rust_remap_gate(&rustc_args.remap_path_prefixes, worktree_root.as_ref()) {
+                        RustRemapGate::Ok => "dylint_remap_gate_ok",
+                        RustRemapGate::Missing => "dylint_remap_gate_missing",
+                        RustRemapGate::OldOutsideRoot => "dylint_remap_gate_old_outside_root",
+                        RustRemapGate::Malformed => "dylint_remap_gate_malformed",
+                    },
+                    0,
+                );
+                super::super::inner_trace::record_ns(
+                    if rustc_key_root.is_some() {
+                        "dylint_key_root_present"
+                    } else {
+                        "dylint_key_root_missing"
+                    },
+                    0,
+                );
+                record_dylint_input_hash("context_compiler", rustc_ctx.compiler_hash.as_bytes());
+                record_dylint_input_hash(
+                    "context_source",
+                    rustc_ctx.source_file.as_path().to_string_lossy().as_bytes(),
+                );
+                record_dylint_input_hash(
+                    "context_codegen",
+                    format!("{:?}", rustc_ctx.codegen_flags).as_bytes(),
+                );
+                record_dylint_input_hash(
+                    "context_externs",
+                    format!("{:?}", rustc_ctx.extern_crates).as_bytes(),
+                );
+                record_dylint_input_hash(
+                    "context_unknown",
+                    format!("{:?}", rustc_ctx.unknown_flags).as_bytes(),
+                );
+                record_dylint_input_hash(
+                    "context_remap",
+                    format!("{:?}", rustc_ctx.remap_path_prefixes).as_bytes(),
+                );
+                record_dylint_input_hash(
+                    "context_env",
+                    format!("{:?}", rustc_ctx.env_vars).as_bytes(),
+                );
+            }
             let key = rustc_ctx.context_key_with_root(rustc_key_root.as_deref());
             let compat_key =
                 rustc_ctx.check_metadata_compat_key_with_root(rustc_key_root.as_deref());
@@ -1181,6 +1235,18 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         stderr: response_stderr,
         cached: false,
     }
+}
+
+fn record_dylint_input_hash(name: &str, value: &[u8]) {
+    let value_hash = crate::hash::hash_bytes(value).to_hex();
+    super::super::inner_trace::record_ns(
+        &format!(
+            "dylint_input_{}_{}",
+            name.to_ascii_lowercase(),
+            &value_hash[..12]
+        ),
+        0,
+    );
 }
 
 fn prepend_compile_stderr(mut response: Response, diagnostic: &[u8]) -> Response {

--- a/crates/zccache-depgraph/src/graph/check.rs
+++ b/crates/zccache-depgraph/src/graph/check.rs
@@ -19,29 +19,6 @@ use super::{
 };
 
 impl DepGraph {
-    /// Fold the context's recorded env-dep set (zccache#1021) into a
-    /// freshly-computed rustc artifact key using CURRENT env values from
-    /// `env_value`. No-op (returns `base` unchanged) for contexts without
-    /// recorded env-deps — the overwhelmingly common case — so their keys
-    /// stay byte-identical with prior releases.
-    fn fold_env_deps_for_key<E>(
-        &self,
-        key: &ContextKey,
-        base: ArtifactKey,
-        env_value: &E,
-    ) -> ArtifactKey
-    where
-        E: Fn(&str) -> Option<String>,
-    {
-        match self.rustc_env_dep_inputs(key) {
-            Some(deps) if !deps.is_empty() => {
-                let mut env_hashes = collect_rustc_env_hashes(&deps, env_value);
-                fold_rustc_env_deps_into_artifact_key(base, &mut env_hashes)
-            }
-            _ => base,
-        }
-    }
-
     /// [`Self::check_rustc_metadata_compat_diagnostic_with_env`] without an
     /// env lookup. For contexts with recorded env-deps this conservatively
     /// misses (safe direction); rustc callers should use the `_with_env`
@@ -213,16 +190,14 @@ impl DepGraph {
         // zccache#1021: the compat candidate serves its STORED artifact
         // key, so a changed env-dep value must refuse the alias instead of
         // shipping the artifact compiled under the old value.
-        if let Some(deps) = self.rustc_env_dep_inputs(&actual_key) {
-            if !deps.is_empty() {
-                let current = collect_rustc_env_hashes(&deps, &env_value);
-                if current != deps {
-                    return (
-                        CacheVerdict::Cold,
-                        "rustc metadata compatibility env-dep values changed".to_string(),
-                        Some(actual_key),
-                    );
-                }
+        if !entry.rustc_env_deps.is_empty() {
+            let current = collect_rustc_env_hashes(&entry.rustc_env_deps, &env_value);
+            if current != entry.rustc_env_deps {
+                return (
+                    CacheVerdict::Cold,
+                    "rustc metadata compatibility env-dep values changed".to_string(),
+                    Some(actual_key),
+                );
             }
         }
 
@@ -391,7 +366,8 @@ impl DepGraph {
                 entry.key_root.as_deref(),
                 |path, key_root| self.cached_normalize_key_path(path, key_root),
             );
-            self.fold_env_deps_for_key(&key, base, &env_value)
+            let mut env_hashes = collect_rustc_env_hashes(&entry.rustc_env_deps, &env_value);
+            fold_rustc_env_deps_into_artifact_key(base, &mut env_hashes)
         } else {
             compute_artifact_key_with(
                 &entry.logical_key,
@@ -613,7 +589,8 @@ impl DepGraph {
                 entry.key_root.as_deref(),
                 |path, key_root| self.cached_normalize_key_path(path, key_root),
             );
-            self.fold_env_deps_for_key(&key, base, &env_value)
+            let mut env_hashes = collect_rustc_env_hashes(&entry.rustc_env_deps, &env_value);
+            fold_rustc_env_deps_into_artifact_key(base, &mut env_hashes)
         } else {
             compute_artifact_key_with(
                 &entry.logical_key,
@@ -754,7 +731,8 @@ impl DepGraph {
                 entry.key_root.as_deref(),
                 |path, key_root| self.cached_normalize_key_path(path, key_root),
             );
-            self.fold_env_deps_for_key(&key, base, &env_value)
+            let mut env_hashes = collect_rustc_env_hashes(&entry.rustc_env_deps, &env_value);
+            fold_rustc_env_deps_into_artifact_key(base, &mut env_hashes)
         } else {
             compute_artifact_key_with(
                 &entry.logical_key,

--- a/crates/zccache-depgraph/src/graph/maintenance.rs
+++ b/crates/zccache-depgraph/src/graph/maintenance.rs
@@ -134,21 +134,6 @@ impl DepGraph {
             self.rustc_externs.remove(&key);
         }
 
-        let stale_env_deps: Vec<ContextKey> = self
-            .rustc_env_deps
-            .iter()
-            .filter_map(|entry| {
-                if live_contexts.contains(entry.key()) {
-                    None
-                } else {
-                    Some(*entry.key())
-                }
-            })
-            .collect();
-        for key in stale_env_deps {
-            self.rustc_env_deps.remove(&key);
-        }
-
         let stale_compat: Vec<ContextKey> = self
             .rustc_check_metadata_compat
             .iter()
@@ -201,7 +186,6 @@ impl DepGraph {
         self.contexts.clear();
         self.indexes.equivalent_contexts.clear();
         self.rustc_externs.clear();
-        self.rustc_env_deps.clear();
         self.rustc_check_metadata_compat.clear();
         self.indexes.path_key_cache.clear();
         self.checks.store(0, Ordering::Relaxed);
@@ -301,15 +285,13 @@ impl DepGraph {
     }
 
     /// Replace the recorded rustc env-dep snapshot for a context
-    /// (zccache#1021). An empty `deps` removes the entry.
+    /// (zccache#1021).
     pub fn set_rustc_env_deps(&self, key: ContextKey, deps: Vec<(String, Option<ContentHash>)>) {
         let Some(key) = self.resolve_instance_key(&key) else {
             return;
         };
-        if deps.is_empty() {
-            self.rustc_env_deps.remove(&key);
-        } else {
-            self.rustc_env_deps.insert(key, deps);
+        if let Some(mut entry) = self.contexts.get_mut(&key) {
+            entry.rustc_env_deps = deps;
         }
     }
 

--- a/crates/zccache-depgraph/src/graph/mod.rs
+++ b/crates/zccache-depgraph/src/graph/mod.rs
@@ -66,6 +66,11 @@ pub struct ContextEntry {
     pub artifact_key: Option<ArtifactKey>,
     /// File hashes from the last update() — used for drift diagnostics.
     pub last_file_hashes: Vec<(NormalizedPath, ContentHash)>,
+    /// Rustc `env!()`/`option_env!()` inputs folded into `artifact_key`.
+    ///
+    /// Keeping these beside the artifact key makes worktree rebasing,
+    /// persistence, and concurrent publication observe one coherent unit.
+    pub rustc_env_deps: Vec<(String, Option<ContentHash>)>,
     /// When this entry was last accessed (for trimming).
     pub last_accessed: Instant,
     /// Current state.
@@ -170,18 +175,6 @@ pub struct DepGraph {
     /// their paths are output-placement state. Their content hashes affect the
     /// rustc artifact key by crate name, but target-dir path prefixes must not.
     pub(super) rustc_externs: DashMap<ContextKey, Vec<(String, NormalizedPath)>>,
-    /// Rustc env-dep snapshots keyed by context (zccache#1021).
-    ///
-    /// rustc records every `env!()`/`option_env!()` read as a
-    /// `# env-dep:NAME[=value]` line in its dep-info. We store, per
-    /// context, the read variable NAMES with the blake3 hash of the value
-    /// each had at the last successful compile (`None` = the variable was
-    /// unset). Check paths re-resolve the CURRENT values via a
-    /// caller-supplied lookup and fold them into the artifact key, so a
-    /// changed `cargo:rustc-env` value (vergen `VERGEN_GIT_SHA` etc.)
-    /// misses instead of serving an artifact with the stale value baked
-    /// in. Non-rustc contexts never have an entry here.
-    pub(super) rustc_env_deps: DashMap<ContextKey, Vec<(String, Option<ContentHash>)>>,
     /// Rustc check/build metadata compatibility alias.
     ///
     /// Keyed by the checkout-specific form of
@@ -389,7 +382,6 @@ impl DepGraph {
             files: Box::new(DashMap::new()),
             contexts: DashMap::new(),
             rustc_externs: DashMap::new(),
-            rustc_env_deps: DashMap::new(),
             rustc_check_metadata_compat: DashMap::new(),
             indexes: Box::new(GraphIndexes::new()),
             checks: AtomicU64::new(0),
@@ -445,7 +437,9 @@ impl DepGraph {
         &self,
         key: &ContextKey,
     ) -> Option<Vec<(String, Option<ContentHash>)>> {
-        self.rustc_env_deps.get(key).map(|deps| deps.clone())
+        self.contexts
+            .get(key)
+            .map(|entry| entry.rustc_env_deps.clone())
     }
 
     /// Resolve a public logical key only when it identifies one safe mutable
@@ -462,17 +456,15 @@ impl DepGraph {
 
     /// Construct a `DepGraph` from pre-built maps, including rustc extern
     /// inputs and env-dep snapshots (zccache#1021).
-    pub(crate) fn from_maps_with_rustc_externs_and_env_deps(
+    pub(crate) fn from_maps_with_rustc_externs(
         files: DashMap<NormalizedPath, FileEntry>,
         contexts: DashMap<ContextKey, ContextEntry>,
         rustc_externs: DashMap<ContextKey, Vec<(String, NormalizedPath)>>,
-        rustc_env_deps: DashMap<ContextKey, Vec<(String, Option<ContentHash>)>>,
     ) -> Self {
         Self {
             files: Box::new(files),
             contexts,
             rustc_externs,
-            rustc_env_deps,
             rustc_check_metadata_compat: DashMap::new(),
             indexes: Box::new(GraphIndexes::new()),
             checks: AtomicU64::new(0),

--- a/crates/zccache-depgraph/src/graph/register.rs
+++ b/crates/zccache-depgraph/src/graph/register.rs
@@ -181,11 +181,13 @@ impl DepGraph {
             .equivalent_contexts
             .get(&key)
             .and_then(|instances| {
-                instances
-                    .iter()
-                    .find_map(|candidate| self.contexts.get(candidate).map(|entry| entry.clone()))
+                instances.iter().find_map(|candidate_key| {
+                    self.contexts
+                        .get(candidate_key)
+                        .map(|entry| (*candidate_key, entry.clone()))
+                })
             });
-        let rebased_from_equivalent_root = candidate.as_ref().is_some_and(|entry| {
+        let rebased_from_equivalent_root = candidate.as_ref().is_some_and(|(_, entry)| {
             entry.key_root.is_some() && key_root.is_some() && entry.key_root != key_root
         });
         let entry = candidate.map_or_else(
@@ -198,10 +200,11 @@ impl DepGraph {
                 has_computed_includes: false,
                 artifact_key: None,
                 last_file_hashes: Vec::new(),
+                rustc_env_deps: Vec::new(),
                 last_accessed: Instant::now(),
                 state: ContextState::Cold,
             },
-            |mut candidate| {
+            |(_, mut candidate)| {
                 let old_root = candidate.key_root.clone();
                 candidate.resolved_includes = candidate
                     .resolved_includes
@@ -244,7 +247,6 @@ impl DepGraph {
         if let Some(evicted) = evicted {
             self.contexts.remove(&evicted);
             self.rustc_externs.remove(&evicted);
-            self.rustc_env_deps.remove(&evicted);
             let stale_compat: Vec<ContextKey> = self
                 .rustc_check_metadata_compat
                 .iter()

--- a/crates/zccache-depgraph/src/graph/tests.rs
+++ b/crates/zccache-depgraph/src/graph/tests.rs
@@ -809,6 +809,7 @@ fn warm_context_with_no_artifact_returns_cold_on_check() {
             has_computed_includes: false,
             artifact_key: None,
             last_file_hashes: Vec::new(),
+            rustc_env_deps: Vec::new(),
             last_accessed: Instant::now(),
             state: ContextState::Warm,
         },

--- a/crates/zccache-depgraph/src/graph/tests/worktree_variants.rs
+++ b/crates/zccache-depgraph/src/graph/tests/worktree_variants.rs
@@ -94,6 +94,66 @@ fn equivalent_worktree_b_update_preserves_a_artifact() {
 }
 
 #[test]
+fn equivalent_rustc_worktree_rebases_env_dependencies() {
+    let graph = DepGraph::new();
+    let logical_key = ContextKey::from_raw([0x31; 32]);
+    let env_names = vec!["DYLINT_METADATA".to_string()];
+    let env_value = |_: &str| Some("same-metadata".to_string());
+
+    let a = graph.register_rustc_with_key_and_root_result(
+        logical_key,
+        context("/rustc-env-a"),
+        Some(NormalizedPath::from("/rustc-env-a")),
+        Vec::new(),
+        None,
+    );
+    let artifact_a = graph
+        .update_with_env(
+            &a.map_key,
+            ScanResult {
+                resolved: Vec::new(),
+                unresolved: Vec::new(),
+                has_computed: false,
+            },
+            equivalent_hash,
+            &env_names,
+            env_value,
+        )
+        .expect("A must become warm");
+
+    let b = graph.register_rustc_with_key_and_root_result(
+        logical_key,
+        context("/rustc-env-b"),
+        Some(NormalizedPath::from("/rustc-env-b")),
+        Vec::new(),
+        None,
+    );
+    assert!(b.rebased_from_equivalent_root);
+    assert_eq!(b.state, ContextState::Warm);
+    assert_eq!(
+        graph.get_rustc_env_deps(&b.map_key),
+        graph.get_rustc_env_deps(&a.map_key),
+        "the rebased artifact key and its env inputs must stay together"
+    );
+    assert!(matches!(
+        graph.check_with_env(&b.map_key, |_| true, equivalent_hash, env_value),
+        CacheVerdict::Hit { artifact_key } if artifact_key == artifact_a
+    ));
+    assert!(
+        matches!(
+            graph.check_with_env(
+                &b.map_key,
+                |_| true,
+                equivalent_hash,
+                |_| Some("changed-metadata".to_string()),
+            ),
+            CacheVerdict::Cold
+        ),
+        "a changed compile-time env input must still miss safely"
+    );
+}
+
+#[test]
 fn registration_reports_existing_stale_state_without_an_extra_lookup() {
     let graph = DepGraph::new();
     let root = NormalizedPath::from("/stale-worktree");

--- a/crates/zccache-depgraph/src/graph/update.rs
+++ b/crates/zccache-depgraph/src/graph/update.rs
@@ -62,7 +62,6 @@ impl DepGraph {
                 (name.clone(), hash_env_dep_value(value.as_deref()))
             })
             .collect();
-        self.set_rustc_env_deps(key, env_hashes.clone());
         // Issue #582: emit a `zccache_depgraph_update_breakdown` line when
         // `ZCCACHE_PROFILE_CC_MISS` is set so the next perf iteration has
         // sub-phase data for the remaining ~2.4 ms mean `depgraph_update_ns`.
@@ -146,6 +145,7 @@ impl DepGraph {
         entry.state = ContextState::Warm;
         entry.artifact_key = Some(artifact_key);
         entry.last_file_hashes = file_hashes;
+        entry.rustc_env_deps = env_hashes;
         let finalize_ns = t_finalize
             .map(|t| t.elapsed().as_nanos() as u64)
             .unwrap_or(0);

--- a/crates/zccache-depgraph/src/snapshot/mod.rs
+++ b/crates/zccache-depgraph/src/snapshot/mod.rs
@@ -182,10 +182,10 @@ impl DepGraph {
                         path: path.to_string_lossy().into_owned(),
                     })
                     .collect();
-                let rustc_env_deps = self
-                    .get_rustc_env_deps(key)
-                    .unwrap_or_default()
-                    .into_iter()
+                let rustc_env_deps = ctx
+                    .rustc_env_deps
+                    .iter()
+                    .cloned()
                     .map(|(name, value_hash)| RustcEnvDepSnapshot {
                         name,
                         value_hash: value_hash.map(|h| *h.as_bytes()),
@@ -276,8 +276,6 @@ impl DepGraph {
         let contexts: DashMap<ContextKey, ContextEntry> = DashMap::new();
         let equivalent_contexts: DashMap<ContextKey, Vec<ContextKey>> = DashMap::new();
         let rustc_externs: DashMap<ContextKey, Vec<(String, NormalizedPath)>> = DashMap::new();
-        let rustc_env_deps: DashMap<ContextKey, Vec<(String, Option<ContentHash>)>> =
-            DashMap::new();
         snap.contexts.into_par_iter().for_each(|c| {
             let key = ContextKey::from_raw(c.context_key);
             let logical_key = ContextKey::from_raw(c.logical_context_key);
@@ -339,6 +337,7 @@ impl DepGraph {
                     .into_iter()
                     .map(|(p, h)| (NormalizedPath::from(p.as_str()), ContentHash::from_bytes(h)))
                     .collect(),
+                rustc_env_deps: env_deps,
                 last_accessed: Instant::now(),
                 state: match c.state {
                     0 => ContextState::Cold,
@@ -354,17 +353,9 @@ impl DepGraph {
             if !externs.is_empty() {
                 rustc_externs.insert(key, externs);
             }
-            if !env_deps.is_empty() {
-                rustc_env_deps.insert(key, env_deps);
-            }
         });
 
-        let mut graph = DepGraph::from_maps_with_rustc_externs_and_env_deps(
-            files,
-            contexts,
-            rustc_externs,
-            rustc_env_deps,
-        );
+        let mut graph = DepGraph::from_maps_with_rustc_externs(files, contexts, rustc_externs);
         graph.indexes.equivalent_contexts = equivalent_contexts;
         graph
     }

--- a/crates/zccache-depgraph/src/snapshot/tests/worktree_variants.rs
+++ b/crates/zccache-depgraph/src/snapshot/tests/worktree_variants.rs
@@ -6,7 +6,7 @@ use tempfile::TempDir;
 use zccache_core::NormalizedPath;
 use zccache_hash::{hash_bytes, ContentHash};
 
-use super::super::super::context::CompileContext;
+use super::super::super::context::{CompileContext, ContextKey};
 use super::super::super::graph::{CacheVerdict, DepGraph};
 use super::super::super::scanner::ScanResult;
 use super::super::super::search_paths::IncludeSearchPaths;
@@ -112,6 +112,52 @@ fn new_equivalent_worktree_reuses_warm_context_after_snapshot_roundtrip() {
     );
     assert!(matches!(
         loaded.check(&b.map_key, always_fresh, equal_hash),
+        CacheVerdict::Hit { artifact_key } if artifact_key == artifact_a
+    ));
+}
+
+#[test]
+fn rebased_rustc_env_dependencies_survive_snapshot_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let path = test_path(&dir);
+    let graph = DepGraph::new();
+    let logical_key = ContextKey::from_raw([0x42; 32]);
+    let env_names = vec!["DYLINT_METADATA".to_string()];
+    let env_value = |_: &str| Some("same-metadata".to_string());
+    let a = graph.register_rustc_with_key_and_root_result(
+        logical_key,
+        context("/snapshot-env-a"),
+        Some(NormalizedPath::from("/snapshot-env-a")),
+        Vec::new(),
+        None,
+    );
+    let artifact_a = graph
+        .update_with_env(
+            &a.map_key,
+            scan("/snapshot-env-a"),
+            equal_hash,
+            &env_names,
+            env_value,
+        )
+        .unwrap();
+
+    save_to_file(&graph, &path).unwrap();
+    let loaded = load_from_file(&path).unwrap();
+    let b = loaded.register_rustc_with_key_and_root_result(
+        logical_key,
+        context("/snapshot-env-b"),
+        Some(NormalizedPath::from("/snapshot-env-b")),
+        Vec::new(),
+        None,
+    );
+
+    assert!(b.rebased_from_equivalent_root);
+    assert_eq!(
+        loaded.get_rustc_env_deps(&b.map_key),
+        loaded.get_rustc_env_deps(&a.map_key),
+    );
+    assert!(matches!(
+        loaded.check_with_env(&b.map_key, always_fresh, equal_hash, env_value),
         CacheVerdict::Hit { artifact_key } if artifact_key == artifact_a
     ));
 }

--- a/crates/zccache/tests/daemon_dylint_cache_test.rs
+++ b/crates/zccache/tests/daemon_dylint_cache_test.rs
@@ -351,17 +351,35 @@ async fn nested_dylint_hits_across_sibling_worktrees() {
 
         let mut outcomes = Vec::new();
         for root in &roots {
-            let output = root.join("target/libchecked.rlib");
-            std::fs::create_dir_all(output.parent().unwrap()).unwrap();
+            let deps = root.join("target/dylint/target/nightly/debug/deps");
+            let incremental = root.join("target/dylint/target/nightly/debug/incremental");
+            std::fs::create_dir_all(&deps).unwrap();
+            std::fs::create_dir_all(&incremental).unwrap();
             let args = vec![
                 rustc.display().to_string(),
+                "--crate-name".to_string(),
+                "checked".to_string(),
                 "--edition=2021".to_string(),
-                "--crate-type=lib".to_string(),
-                "--crate-name=checked".to_string(),
-                "--emit=link".to_string(),
                 "src/lib.rs".to_string(),
-                "-o".to_string(),
-                output.display().to_string(),
+                "--error-format=json".to_string(),
+                "--json=diagnostic-rendered-ansi,artifacts,future-incompat".to_string(),
+                "--crate-type".to_string(),
+                "lib".to_string(),
+                "--emit=dep-info,metadata".to_string(),
+                "-C".to_string(),
+                "embed-bitcode=no".to_string(),
+                "-C".to_string(),
+                "metadata=fixture".to_string(),
+                "-C".to_string(),
+                "extra-filename=-fixture".to_string(),
+                "--out-dir".to_string(),
+                deps.display().to_string(),
+                "-C".to_string(),
+                format!("incremental={}", incremental.display()),
+                "-C".to_string(),
+                "strip=debuginfo".to_string(),
+                "-L".to_string(),
+                format!("dependency={}", deps.display()),
             ];
             let dylint_libs =
                 serde_json::to_string(&vec![root.join("libworkspace_lint.so")]).unwrap();

--- a/crates/zccache/tests/daemon_dylint_cache_test.rs
+++ b/crates/zccache/tests/daemon_dylint_cache_test.rs
@@ -83,6 +83,7 @@ async fn start_session(client: &mut ClientConn, log_file: Option<NormalizedPath>
     }
 }
 
+#[allow(clippy::too_many_arguments)] // Test request fixture mirrors the wire fields.
 async fn compile(
     client: &mut ClientConn,
     session_id: &str,
@@ -334,7 +335,12 @@ async fn nested_dylint_hits_across_sibling_worktrees() {
         let roots = [tmp.path().join("checkout-a"), tmp.path().join("checkout-b")];
         for root in &roots {
             std::fs::create_dir_all(root.join("src")).unwrap();
-            std::fs::write(root.join("src/lib.rs"), "pub fn checked() -> u32 { 42 }\n").unwrap();
+            std::fs::write(
+                root.join("src/lib.rs"),
+                "pub const METADATA: Option<&str> = option_env!(\"DYLINT_METADATA\");\n\
+                 pub fn checked() -> u32 { 42 }\n",
+            )
+            .unwrap();
             std::fs::write(root.join("libworkspace_lint.so"), b"same-lint-library").unwrap();
         }
         std::fs::create_dir(roots[0].join(".git")).unwrap();

--- a/crates/zccache/tests/daemon_dylint_cache_test.rs
+++ b/crates/zccache/tests/daemon_dylint_cache_test.rs
@@ -91,15 +91,21 @@ async fn compile(
     cwd: &std::path::Path,
     dylint_libs: &str,
     dylint_metadata: &str,
+    path_remap: bool,
 ) -> (i32, bool, Vec<u8>, Vec<u8>) {
     let mut env: Vec<(String, String)> = std::env::vars().collect();
     env.retain(|(name, _)| {
         name != "DYLINT_LIBS"
             && name != "DYLINT_METADATA"
+            && name != "ZCCACHE_PATH_REMAP"
+            && name != "ZCCACHE_WORKTREE_ROOT"
             && name != "ZCCACHE_DYLINT_CACHE_INPUT_HASH"
     });
     env.push(("DYLINT_LIBS".to_string(), dylint_libs.to_string()));
     env.push(("DYLINT_METADATA".to_string(), dylint_metadata.to_string()));
+    if path_remap {
+        env.push(("ZCCACHE_PATH_REMAP".to_string(), "auto".to_string()));
+    }
     client
         .send(&Request::Compile {
             session_id: session_id.to_string(),
@@ -215,6 +221,7 @@ async fn nested_dylint_hits_and_invalidates_every_external_input() {
             tmp.path(),
             &dylint_libs,
             "metadata-v1",
+            false,
         )
         .await;
         assert_eq!(first.0, 0);
@@ -230,6 +237,7 @@ async fn nested_dylint_hits_and_invalidates_every_external_input() {
             tmp.path(),
             &dylint_libs,
             "metadata-v1",
+            false,
         )
         .await;
         assert_eq!(warm.0, 0);
@@ -247,6 +255,7 @@ async fn nested_dylint_hits_and_invalidates_every_external_input() {
             tmp.path(),
             &dylint_libs,
             "metadata-v1",
+            false,
         )
         .await;
         assert!(!library_changed.1, "library bytes must invalidate the hit");
@@ -260,6 +269,7 @@ async fn nested_dylint_hits_and_invalidates_every_external_input() {
             tmp.path(),
             &dylint_libs,
             "metadata-v2",
+            false,
         )
         .await;
         assert!(!env_changed.1, "DYLINT_* output state must invalidate");
@@ -274,6 +284,7 @@ async fn nested_dylint_hits_and_invalidates_every_external_input() {
             tmp.path(),
             &dylint_libs,
             "metadata-v2",
+            false,
         )
         .await;
         assert!(!driver_changed.1, "driver bytes must invalidate");
@@ -289,6 +300,7 @@ async fn nested_dylint_hits_and_invalidates_every_external_input() {
             tmp.path(),
             "not-json",
             "metadata-v2",
+            false,
         )
         .await;
         assert_eq!(malformed.0, 0, "malformed state must fail open");
@@ -296,6 +308,85 @@ async fn nested_dylint_hits_and_invalidates_every_external_input() {
         assert!(
             String::from_utf8_lossy(&malformed.3).contains("Dylint cache disabled"),
             "fail-open reason must be visible to the user"
+        );
+
+        shutdown.notify_one();
+        server_handle.await.unwrap();
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "integration-level: starts a real daemon and rustc"]
+async fn nested_dylint_hits_across_sibling_worktrees() {
+    let Some(rustc) = zccache::test_support::find_rustc() else {
+        eprintln!("skipping test: rustc not found");
+        return;
+    };
+
+    zccache::test_support::test_timeout(async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        let _cache_env = CacheDirEnvGuard::set(&cache);
+        let driver = tmp.path().join("dylint-driver");
+        write_driver(&driver, "workspace lint diagnostic");
+
+        let roots = [tmp.path().join("checkout-a"), tmp.path().join("checkout-b")];
+        for root in &roots {
+            std::fs::create_dir_all(root.join("src")).unwrap();
+            std::fs::write(root.join("src/lib.rs"), "pub fn checked() -> u32 { 42 }\n").unwrap();
+            std::fs::write(root.join("libworkspace_lint.so"), b"same-lint-library").unwrap();
+        }
+        std::fs::create_dir(roots[0].join(".git")).unwrap();
+        std::fs::write(
+            roots[1].join(".git"),
+            "gitdir: ../.git/worktrees/checkout-b\n",
+        )
+        .unwrap();
+
+        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let session_log = tmp.path().join("sibling-session.log");
+        let session_id = start_session(&mut client, Some(session_log.clone().into())).await;
+
+        let mut outcomes = Vec::new();
+        for root in &roots {
+            let output = root.join("target/libchecked.rlib");
+            std::fs::create_dir_all(output.parent().unwrap()).unwrap();
+            let args = vec![
+                rustc.display().to_string(),
+                "--edition=2021".to_string(),
+                "--crate-type=lib".to_string(),
+                "--crate-name=checked".to_string(),
+                "--emit=link".to_string(),
+                "src/lib.rs".to_string(),
+                "-o".to_string(),
+                output.display().to_string(),
+            ];
+            let dylint_libs =
+                serde_json::to_string(&vec![root.join("libworkspace_lint.so")]).unwrap();
+            outcomes.push(
+                compile(
+                    &mut client,
+                    &session_id,
+                    &driver,
+                    &args,
+                    root,
+                    &dylint_libs,
+                    "same-metadata",
+                    true,
+                )
+                .await,
+            );
+        }
+
+        assert_eq!(outcomes[0].0, 0);
+        assert!(!outcomes[0].1);
+        assert_eq!(outcomes[1].0, 0);
+        assert!(
+            outcomes[1].1,
+            "identical nested Dylint requests must hit across checkout roots\n{}",
+            std::fs::read_to_string(session_log).unwrap_or_default()
         );
 
         shutdown.notify_one();


### PR DESCRIPTION
## Summary
- preserve rustc env-dependency fingerprints when rebasing warm contexts across sibling worktrees
- keep env dependencies inside ContextEntry so artifact state and snapshot persistence are atomic
- add a Cargo-shaped Dylint integration test with option_env! plus snapshot round-trip coverage
- retain opt-in hash-only Dylint identity tracing for hosted diagnostics

## Validation
- cargo test -p zccache-depgraph (407 passed)
- cargo test -p zccache --test daemon_dylint_cache_test nested_dylint_hits_across_sibling_worktrees -- --ignored --exact --nocapture
- cargo clippy -p zccache-depgraph -p zccache --tests -- -D warnings
- cargo fmt --all -- --check
- clud-review: clean

Upstream dependency of zackees/soldr#1783.