### PR TITLE
fix: normalize Dylint rustc env dependencies

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/hash_verify.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/hash_verify.rs
@@ -166,9 +166,7 @@ pub(super) fn hash_and_verify(input: HashVerifyInput<'_>) -> HashSourceOutcome {
         // with the stored key.  Skips redundant journal freshness checks
         // and path clones that check_diagnostic performs.
         let env_value = |name: &str| -> Option<String> {
-            client_env
-                .and_then(|env| env.iter().find(|(k, _)| k == name))
-                .map(|(_, v)| v.clone())
+            rustc_env_dep_value(client_env, name).map(str::to_owned)
         };
         if let Some(artifact_key) = state.dep_graph.load().try_fast_hit_with_env(
             &context_key,
@@ -199,11 +197,7 @@ pub(super) fn hash_and_verify(input: HashVerifyInput<'_>) -> HashSourceOutcome {
                     &context_key,
                     is_fresh,
                     get_hash,
-                    |name| {
-                        client_env
-                            .and_then(|env| env.iter().find(|(k, _)| k == name))
-                            .map(|(_, v)| v.clone())
-                    },
+                    |name| rustc_env_dep_value(client_env, name).map(str::to_owned),
                 )
             };
             depgraph_check_ns = t4.elapsed().as_nanos() as u64;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -950,12 +950,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                         &rustc_current_externs,
                         is_fresh,
                         get_hash,
-                        |name| {
-                            client_env
-                                .as_deref()
-                                .and_then(|env| env.iter().find(|(k, _)| k == name))
-                                .map(|(_, v)| v.clone())
-                        },
+                        |name| rustc_env_dep_value(client_env.as_deref(), name).map(str::to_owned),
                     );
                 write_session_log(
                     &state.sessions,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -351,9 +351,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
     let rustc_env_dep_values: Vec<(String, Option<String>)> = rustc_env_dep_names
         .iter()
         .map(|name| {
-            let value = client_env
-                .and_then(|env| env.iter().find(|(k, _)| k == name))
-                .map(|(_, v)| v.clone());
+            let value = rustc_env_dep_value(client_env, name).map(str::to_owned);
             (name.clone(), value)
         })
         .collect();

--- a/crates/zccache-daemon-core/src/daemon/server/keys.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/keys.rs
@@ -12,6 +12,31 @@ pub(super) fn client_env_value<'a>(
         .filter(|value| !value.is_empty())
 }
 
+/// Resolve the value rustc recorded as an environment dependency.
+///
+/// A nested Dylint driver exposes `DYLINT_LIBS` to rustc as checkout-local
+/// absolute paths.  [`crate::compiler::prepare_dylint_cache_env`] has already
+/// replaced those paths with a synthetic hash covering the driver, inner
+/// rustc, lint-library names and contents, and output-affecting environment.
+/// Folding rustc's `DYLINT_LIBS` dep through that hash keeps artifact identity
+/// content-addressed across equivalent sibling worktrees.
+pub(super) fn rustc_env_dep_value<'a>(
+    client_env: Option<&'a [(String, String)]>,
+    name: &str,
+) -> Option<&'a str> {
+    let env = client_env?;
+    if name == crate::compiler::DYLINT_LIBS_ENV {
+        if let Some((_, value)) = env
+            .iter()
+            .find(|(key, _)| key == crate::compiler::DYLINT_CACHE_INPUT_HASH_ENV)
+        {
+            return Some(value);
+        }
+    }
+    env.iter()
+        .find_map(|(key, value)| (key == name).then_some(value.as_str()))
+}
+
 pub(super) fn path_remap_auto_enabled(client_env: Option<&[(String, String)]>) -> bool {
     client_env_value(client_env, PATH_REMAP_ENV)
         .is_some_and(|value| value.eq_ignore_ascii_case("auto"))

--- a/crates/zccache-daemon-core/src/daemon/server/tests/fingerprint.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/fingerprint.rs
@@ -6,6 +6,42 @@
 
 use super::super::*;
 
+#[test]
+fn rustc_dylint_libs_env_dep_uses_synthetic_content_identity() {
+    let env = vec![
+        (
+            crate::compiler::DYLINT_LIBS_ENV.to_string(),
+            r#"["/checkout-a/target/libfixture.so"]"#.to_string(),
+        ),
+        (
+            crate::compiler::DYLINT_CACHE_INPUT_HASH_ENV.to_string(),
+            "content-identity".to_string(),
+        ),
+    ];
+
+    assert_eq!(
+        rustc_env_dep_value(Some(&env), crate::compiler::DYLINT_LIBS_ENV),
+        Some("content-identity")
+    );
+}
+
+#[test]
+fn rustc_env_dep_value_preserves_non_dylint_and_unprepared_values() {
+    let env = vec![
+        (
+            crate::compiler::DYLINT_LIBS_ENV.to_string(),
+            r#"["/checkout-a/target/libfixture.so"]"#.to_string(),
+        ),
+        ("BUILD_STAMP".to_string(), String::new()),
+    ];
+
+    assert_eq!(
+        rustc_env_dep_value(Some(&env), crate::compiler::DYLINT_LIBS_ENV),
+        Some(r#"["/checkout-a/target/libfixture.so"]"#)
+    );
+    assert_eq!(rustc_env_dep_value(Some(&env), "BUILD_STAMP"), Some(""));
+}
+
 #[cfg(windows)]
 #[test]
 fn request_fingerprint_normalizes_equivalent_windows_paths() {

--- a/crates/zccache-daemon-core/src/daemon/server/util.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/util.rs
@@ -230,9 +230,7 @@ pub(super) fn context_env_deps_fresh(
         return true;
     };
     deps.iter().all(|(name, recorded_hash)| {
-        let current = client_env
-            .and_then(|env| env.iter().find(|(k, _)| k == name))
-            .map(|(_, v)| v.as_str());
+        let current = rustc_env_dep_value(client_env, name);
         crate::depgraph::hash_env_dep_value(current) == *recorded_hash
     })
 }

--- a/crates/zccache/tests/daemon_dylint_cache_test.rs
+++ b/crates/zccache/tests/daemon_dylint_cache_test.rs
@@ -337,7 +337,8 @@ async fn nested_dylint_hits_across_sibling_worktrees() {
             std::fs::create_dir_all(root.join("src")).unwrap();
             std::fs::write(
                 root.join("src/lib.rs"),
-                "pub const METADATA: Option<&str> = option_env!(\"DYLINT_METADATA\");\n\
+                "pub const LIBS: Option<&str> = option_env!(\"DYLINT_LIBS\");\n\
+                 pub const METADATA: Option<&str> = option_env!(\"DYLINT_METADATA\");\n\
                  pub fn checked() -> u32 { 42 }\n",
             )
             .unwrap();

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -194,6 +194,15 @@ artifact context; the salt is never replayed to the driver process. Executable
 and library identities use the daemon's metadata-backed identity cache, so a
 warm lint unit does not re-hash a large rustc binary.
 
+The real Dylint driver may cause rustc dep-info to record `DYLINT_LIBS` as an
+environment dependency. Its raw value contains checkout-local absolute library
+paths, so the daemon resolves that recorded dependency through
+`ZCCACHE_DYLINT_CACHE_INPUT_HASH` for lookup, freshness checks, and
+publication. This preserves rustc's env-dependency invalidation while making
+equivalent sibling worktrees depend on the already-validated library content
+identity instead of path spelling. Ordinary rustc requests and Dylint requests
+that did not complete input preparation continue to use the raw env value.
+
 Missing, malformed, empty, or unhashable `DYLINT_LIBS` state disables caching
 for that invocation. The driver still runs with its original argv,
 environment, stdin, stdout, stderr, and exit status, and stderr receives a

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -272,3 +272,14 @@ Issue: https://github.com/zackees/zccache/issues/1117
 - [x] Cover blocking and nonblocking timestamp races with focused tests.
 - [x] Cover gentle-to-forced handoff, held-shard retry, and maintenance/Clear
   artifact-lease ordering with deterministic tests.
+
+# Dylint sibling env-dep identity follow-up
+
+- [x] Reproduce the real-driver sibling miss by making rustc record
+  `DYLINT_LIBS` as an env dependency while library paths differ by worktree.
+- [x] Fold path-valued `DYLINT_LIBS` env deps through the existing synthetic
+  Dylint content identity for lookup, freshness, and publication.
+- [x] Validate the focused integration, depgraph suite, formatting, clippy,
+  and review gate in Linux Docker.
+- [ ] Merge the upstream PR, bump soldr's vendored commit, rerun the hosted
+  real Dylint/watchdog acceptance, and close the meta issue.


### PR DESCRIPTION
## Summary
- normalize rustc-recorded `DYLINT_LIBS` env dependencies through zccache's existing synthetic Dylint content identity
- apply the normalized value consistently to lookup, freshness, metadata compatibility, and publication
- make the sibling-worktree integration fixture record `DYLINT_LIBS` in dep-info and document the behavior

## Validation
- RED before fix: `nested_dylint_hits_across_sibling_worktrees` missed in checkout B with a different artifact key
- GREEN after fix: focused ignored integration passes in Linux Docker
- depgraph suite: 407 passed
- daemon helper unit tests pass with `test-support`
- formatting check passes
- scoped clippy passes for `zccache-daemon-core` and `daemon_dylint_cache_test`
- pre-push review: clean

The workspace-wide all-targets clippy currently stops on a pre-existing Rust 1.94 `cloned_ref_to_slice_refs` warning in `crates/zccache-compiler/src/tests/dylint_driver.rs`; changed targets are clean.