### PR TITLE
feat(ipc): push CompileProgress heartbeats so queued compiles aren't wedges

### DIFF
--- a/ci/wire_stability_snapshot.txt
+++ b/ci/wire_stability_snapshot.txt
@@ -44,6 +44,10 @@ CompileEphemeral	5	cwd	Path
 CompileEphemeral	6	env	EnvVar
 CompileEphemeral	7	env_is_set	bool
 CompileEphemeral	8	stdin	bytes
+CompileProgress	1	queue_position	uint32
+CompileProgress	2	queue_depth	uint32
+CompileProgress	3	in_flight	uint32
+CompileProgress	4	phase	string
 CompileResult	1	exit_code	int32
 CompileResult	2	stdout	bytes
 CompileResult	3	stderr	bytes
@@ -131,6 +135,10 @@ LinkResult	2	stdout	bytes
 LinkResult	3	stderr	bytes
 LinkResult	4	cached	bool
 Lookup	1	cache_key	string
+LookupOutcomes	1	depgraph_hit_artifact_hit	uint64
+LookupOutcomes	2	depgraph_hit_artifact_miss	uint64
+LookupOutcomes	3	depgraph_cold_skip	uint64
+LookupOutcomes	4	depgraph_other_miss	map<string, uint64>
 LookupResult	1	hit	ArtifactData
 LookupResult	2	miss	Empty
 Path	1	value	string
@@ -152,6 +160,7 @@ PhaseProfileSummary	15	include_scan_ns	uint64
 PhaseProfileSummary	16	hash_all_ns	uint64
 PhaseProfileSummary	17	artifact_store_ns	uint64
 PhaseProfileSummary	18	total_miss_ns	uint64
+PhaseProfileSummary	19	staged	StagedProfileSummary
 PrivateDaemonOwnerStatus	1	pid	uint32
 PrivateDaemonOwnerStatus	2	ref_count	uint64
 PrivateDaemonSessionOptions	4	owner_pids	uint32
@@ -202,6 +211,7 @@ Response	15	rust_artifact_list	RustArtifactList
 Response	16	generic_tool_exec_result	GenericToolExecResult
 Response	17	backpressure	Backpressure
 Response	18	release_worktree_handles_result	ReleaseWorktreeHandlesResult
+Response	19	compile_progress	CompileProgress
 Response	100	request_id	string
 RustArtifactBundleManifest	1	manifest_schema_version	uint32
 RustArtifactBundleManifest	2	plan_schema_version	uint32
@@ -232,11 +242,17 @@ RustArtifactPlanV1	11	cache_schema_version	uint32
 RustArtifactPlanV1	12	journal_log_path	string
 RustArtifactPlanV1	13	cache_profile	string
 RustArtifactPlanV1	14	dropped_artifact_classes	uint32
+RustArtifactPlanV1	15	cargo_artifact_paths	string
+RustArtifactPlanV1	16	cargo_artifacts_complete	bool
 RustBundledArtifact	1	relative_path	string
 RustBundledArtifact	2	class	uint32
 RustBundledArtifact	3	size	uint64
 RustBundledArtifact	4	content_hash	string
 RustBundledArtifact	5	mtime_unix_nanos	uint64
+RustBundledArtifact	6	owner	uint32
+RustPlanArtifactOwner	1	relative_path	string
+RustPlanArtifactOwner	2	package_id	string
+RustPlanArtifactOwner	3	owner	uint32
 RustPlanInputs	1	features_hash	string
 RustPlanInputs	2	rustflags_hash	string
 RustPlanInputs	3	env_hash	string
@@ -246,6 +262,10 @@ RustPlanInputs	6	manifest_hashes	string
 RustPlanPackages	1	selected_package_ids	string
 RustPlanPackages	2	workspace_package_ids	string
 RustPlanPackages	3	excluded_path_package_ids	string
+RustPlanPackages	4	ownership_policy	string
+RustPlanPackages	5	ownership_mode	uint32
+RustPlanPackages	6	artifact_owners	RustPlanArtifactOwner
+RustPlanPackages	7	ownership_complete	bool
 RustToolchainIdentity	1	rustc	string
 RustToolchainIdentity	2	cargo	string
 RustToolchainIdentity	3	channel	string
@@ -268,6 +288,10 @@ SessionStats	9	unique_sources	uint64
 SessionStats	10	bytes_read	uint64
 SessionStats	11	bytes_written	uint64
 SessionStatsRequest	1	session_id	string
+StagedProfileSummary	1	counters	map<string, uint64>
+StagedProfileSummary	2	timings_ns	map<string, uint64>
+StagedProfileSummary	3	bytes	map<string, uint64>
+StagedProfileSummary	4	failures	map<string, uint64>
 Store	1	cache_key	string
 Store	2	artifact	ArtifactData
 StoreResult	1	kind	StoreResultKind

--- a/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
@@ -193,30 +193,76 @@ fn report_relay_outcome(outcome: RelayOutcome) -> ExitCode {
 /// pipe, protocol error) maps to [`CompileRecvOutcome::Failed`] so the
 /// caller does not respawn the daemon on errors that have nothing to do
 /// with a wedge.
+///
+/// # Progress-based wedge detection (issue #1216)
+///
+/// This is a **loop**, not a single recv: the daemon pushes non-terminal
+/// [`crate::protocol::Response::CompileProgress`] heartbeats on this same
+/// connection while the compile waits for a compile-concurrency permit. Each
+/// heartbeat is reported to the user and restarts the budget, so the budget
+/// means "the daemon has gone quiet for this long" rather than "this compile
+/// took this long". A compile legitimately queued for longer than the budget
+/// therefore completes on its original connection with its cached-path
+/// result — no probe, no ephemeral re-run, no kill — while a daemon that
+/// emits *nothing* for a full budget still trips the #753/#955 handling.
 async fn compile_recv_with_wedge_detection<C: ConnRecv>(
     conn: &mut C,
     budget: Option<std::time::Duration>,
 ) -> CompileRecvOutcome {
-    match budget {
-        Some(budget) => match conn.recv_with_timeout(budget).await {
-            Ok(opt) => CompileRecvOutcome::Done(opt),
-            Err(crate::ipc::IpcError::Timeout(_)) => CompileRecvOutcome::Wedged,
-            Err(e) => CompileRecvOutcome::Failed(TransportFailure {
-                message: format!("broken connection to daemon: {e}"),
-                phase: FailurePhase::DeliveryUnknown,
-            }),
-        },
-        None => match conn
-            .recv_with_timeout(crate::ipc::DEFAULT_CLIENT_RECV_TIMEOUT)
-            .await
-        {
-            Ok(opt) => CompileRecvOutcome::Done(opt),
-            Err(e) => CompileRecvOutcome::Failed(TransportFailure {
-                message: format!("broken connection to daemon: {e}"),
-                phase: FailurePhase::DeliveryUnknown,
-            }),
-        },
+    let recv_timeout = budget.unwrap_or(crate::ipc::DEFAULT_CLIENT_RECV_TIMEOUT);
+    loop {
+        match conn.recv_with_timeout(recv_timeout).await {
+            Ok(Some(crate::protocol::Response::CompileProgress {
+                queue_position,
+                queue_depth,
+                in_flight,
+                phase,
+            })) => {
+                report_compile_progress(queue_position, queue_depth, in_flight, &phase);
+                // Budget restarts on the next loop iteration — this is the
+                // progress reset that makes wedge detection progress-based.
+            }
+            Ok(opt) => return CompileRecvOutcome::Done(opt),
+            // Only a configured budget turns a quiet daemon into a wedge; with
+            // `budget == None` wedge classification is disabled, so the IPC
+            // default timeout is reported as a plain transport failure.
+            Err(crate::ipc::IpcError::Timeout(_)) if budget.is_some() => {
+                return CompileRecvOutcome::Wedged
+            }
+            Err(e) => {
+                return CompileRecvOutcome::Failed(TransportFailure {
+                    message: format!("broken connection to daemon: {e}"),
+                    phase: FailurePhase::DeliveryUnknown,
+                })
+            }
+        }
     }
+}
+
+/// Human-readable one-liner for a `CompileProgress` heartbeat.
+///
+/// Kept separate from the printing so it can be asserted in unit tests
+/// without capturing stderr.
+fn compile_progress_line(
+    queue_position: u32,
+    queue_depth: u32,
+    in_flight: u32,
+    phase: &str,
+) -> String {
+    if queue_depth == 0 && queue_position == 0 {
+        format!("zccache[info][Q]: daemon under load: {phase}, {in_flight} compiles in flight")
+    } else {
+        format!(
+            "zccache[info][Q]: daemon under load: {phase}, position {queue_position} of \
+             {queue_depth} queued, {in_flight} in flight"
+        )
+    }
+}
+
+fn report_compile_progress(queue_position: u32, queue_depth: u32, in_flight: u32, phase: &str) {
+    let line = compile_progress_line(queue_position, queue_depth, in_flight, phase);
+    // Diagnostic only: never let a failed status write affect the compile.
+    let _ = writeln!(std::io::stderr(), "{line}");
 }
 
 /// Tiny seam over the platform-specific IPC connection types so the
@@ -848,6 +894,11 @@ mod tests {
         Ok(crate::protocol::Response),
         TimesOut,
         BrokenPipe,
+        /// Issue #1216: a timed script of frames. Each step sleeps for its
+        /// delay and then yields its frame; once the script is exhausted the
+        /// fake behaves like [`FakeBehavior::TimesOut`], so a test only has
+        /// to enumerate the frames it cares about.
+        Scripted(std::collections::VecDeque<(std::time::Duration, crate::protocol::Response)>),
     }
 
     impl ConnRecv for FakeConn {
@@ -855,14 +906,44 @@ mod tests {
             &mut self,
             timeout: std::time::Duration,
         ) -> Result<Option<crate::protocol::Response>, crate::ipc::IpcError> {
-            match &self.behavior {
+            match &mut self.behavior {
                 FakeBehavior::Ok(r) => Ok(Some(r.clone())),
                 FakeBehavior::TimesOut => {
                     tokio::time::sleep(timeout).await;
                     Err(crate::ipc::IpcError::Timeout(timeout))
                 }
                 FakeBehavior::BrokenPipe => Err(crate::ipc::IpcError::ConnectionClosed),
+                FakeBehavior::Scripted(steps) => match steps.pop_front() {
+                    Some((delay, response)) if delay < timeout => {
+                        tokio::time::sleep(delay).await;
+                        Ok(Some(response))
+                    }
+                    // The scripted gap exceeds the caller's budget: the recv
+                    // must trip, exactly as the real transport would.
+                    Some(_) | None => {
+                        tokio::time::sleep(timeout).await;
+                        Err(crate::ipc::IpcError::Timeout(timeout))
+                    }
+                },
             }
+        }
+    }
+
+    fn progress(queue_position: u32, queue_depth: u32) -> crate::protocol::Response {
+        crate::protocol::Response::CompileProgress {
+            queue_position,
+            queue_depth,
+            in_flight: 8,
+            phase: "queued".to_string(),
+        }
+    }
+
+    fn compile_result(exit_code: i32) -> crate::protocol::Response {
+        crate::protocol::Response::CompileResult {
+            exit_code,
+            stdout: std::sync::Arc::new(Vec::new()),
+            stderr: std::sync::Arc::new(Vec::new()),
+            cached: true,
         }
     }
 
@@ -913,6 +994,105 @@ mod tests {
                 && elapsed < std::time::Duration::from_millis(1100),
             "wedge detection took {elapsed:?} against a never-responding fake; \
              issue #666 expects fail-fast at the configured budget"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn compile_progress_heartbeats_reset_the_wedge_budget() {
+        // Issue #1216: three 900 ms gaps total 2.7 s — nearly 3× the 1 s
+        // budget. Pre-#1216 the single blocking recv would have tripped at
+        // 1 s and classified a perfectly healthy, queued compile as wedged.
+        // Every frame (including non-terminal ones) restarts the budget, so
+        // the terminal result is relayed instead.
+        let gap = std::time::Duration::from_millis(900);
+        let mut conn = FakeConn {
+            behavior: FakeBehavior::Scripted(
+                [
+                    (gap, progress(2, 3)),
+                    (gap, progress(1, 2)),
+                    (gap, compile_result(0)),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+        };
+        let started = tokio::time::Instant::now();
+        let outcome = compile_recv_with_wedge_detection(&mut conn, TEST_BUDGET).await;
+        let elapsed = started.elapsed();
+        assert!(
+            matches!(
+                outcome,
+                CompileRecvOutcome::Done(Some(crate::protocol::Response::CompileResult {
+                    exit_code: 0,
+                    cached: true,
+                    ..
+                }))
+            ),
+            "queued-but-progressing compile must deliver its terminal result on \
+             the original connection"
+        );
+        assert!(
+            elapsed >= std::time::Duration::from_millis(2700),
+            "the loop must actually have waited out all three gaps, got {elapsed:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn silence_after_heartbeats_still_trips_wedge_detection() {
+        // The complement of the test above: a daemon that heartbeats and then
+        // goes completely quiet is genuinely wedged and must still get the
+        // #753/#955 treatment. Progress-based detection must not become
+        // "never detect a wedge".
+        let mut conn = FakeConn {
+            behavior: FakeBehavior::Scripted(
+                [(std::time::Duration::from_millis(900), progress(4, 5))]
+                    .into_iter()
+                    .collect(),
+            ),
+        };
+        let outcome = compile_recv_with_wedge_detection(&mut conn, TEST_BUDGET).await;
+        assert!(
+            matches!(outcome, CompileRecvOutcome::Wedged),
+            "an exhausted script (no further frames) must trip the budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn compile_progress_is_never_relayed_as_a_terminal_response() {
+        // Belt-and-braces: `relay_compile_response` treats any unexpected
+        // variant as a hard `[U]` failure, so a heartbeat that leaked past the
+        // recv loop would fail the compile. Assert the loop swallows it.
+        let mut conn = FakeConn {
+            behavior: FakeBehavior::Scripted(
+                [
+                    (std::time::Duration::ZERO, progress(0, 0)),
+                    (std::time::Duration::ZERO, compile_result(7)),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+        };
+        let outcome = compile_recv_with_wedge_detection(&mut conn, TEST_BUDGET).await;
+        let CompileRecvOutcome::Done(response) = outcome else {
+            panic!("expected a terminal response");
+        };
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let relayed = relay_compile_response(response, &mut stdout, &mut stderr);
+        assert_eq!(relayed, RelayOutcome::Verdict(exit_code_from_i32(7)));
+    }
+
+    #[test]
+    fn compile_progress_line_names_position_depth_and_in_flight() {
+        assert_eq!(
+            compile_progress_line(2, 5, 8, "queued"),
+            "zccache[info][Q]: daemon under load: queued, position 2 of 5 queued, 8 in flight"
+        );
+        // Nothing queued: the position/depth pair carries no information, so
+        // the line drops it rather than printing "position 0 of 0".
+        assert_eq!(
+            compile_progress_line(0, 0, 3, "compiling"),
+            "zccache[info][Q]: daemon under load: compiling, 3 compiles in flight"
         );
     }
 

--- a/crates/zccache-compiler/src/tests/dylint_driver.rs
+++ b/crates/zccache-compiler/src/tests/dylint_driver.rs
@@ -89,7 +89,7 @@ fn library_content_and_output_environment_invalidate_the_input_hash() {
         "lib".into(),
         "src/lib.rs".into(),
     ];
-    let libs = serde_json::to_string(&[library.clone()]).unwrap();
+    let libs = serde_json::to_string(std::slice::from_ref(&library)).unwrap();
     let make_env =
         |metadata: &str, no_deps: &str, rustup_home: &str, toolchain: &str, docs_links: &str| {
             vec![

--- a/crates/zccache-daemon-core/src/daemon/server/compile_progress.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/compile_progress.rs
@@ -1,0 +1,381 @@
+//! Issue #1216 — compile-queue visibility.
+//!
+//! Under contention a `Compile` request can sit for minutes inside
+//! `Semaphore::acquire_owned().await` (see
+//! [`super::compile_concurrency`]). Before this module that wait was
+//! completely silent: the wrapper did exactly one blocking `recv` with a
+//! 180 s wedge budget, so a legitimately-queued compile was
+//! indistinguishable from a hung daemon and got the #753/#955 wedge
+//! treatment — probe, then either an ephemeral re-run that threw away the
+//! daemon's in-progress work or a kill.
+//!
+//! Two pieces live here:
+//!
+//! - [`CompileQueueGauge`] — the daemon-global counters the semaphore
+//!   itself cannot report. `tokio::sync::Semaphore` exposes
+//!   `available_permits()` but no waiter count, and the initial capacity is
+//!   unrecoverable once permits are handed out. Every gated compile
+//!   registers via [`CompileQueueGauge::enqueue`] and calls
+//!   [`CompileQueueGuard::admit`] the moment its permit is granted.
+//! - [`CompileProgressSlot`] — the *per-request* view (this request's
+//!   queue ticket), published through a task-local so the connection layer
+//!   can build a heartbeat frame without plumbing a progress handle through
+//!   `handle_compile` → `pipeline` → `compile_exec`.
+//!
+//! ## Why a task-local
+//!
+//! The heartbeat is emitted by the connection layer
+//! ([`super::connection::guarded_dispatch_with_progress`]) because that is
+//! the only place holding the `IpcConnection`. The queue ticket, however, is
+//! only known deep inside the compile pipeline. The compile handler is
+//! `await`ed inline by `guarded_dispatch` — never spawned — so both ends run
+//! on the same tokio task and a task-local scoped around the handler
+//! future reaches the acquire site without touching five function
+//! signatures. If the ticket is ever taken on a *different* task the
+//! task-local lookup simply misses and the heartbeat reports position 0 —
+//! degraded, never wrong.
+//!
+//! ## Queue position semantics
+//!
+//! Tickets are monotonic and `admitted` counts how many tickets have left
+//! the queue (granted a permit, or cancelled — a cancelled waiter still
+//! advances the cursor so the requests behind it do not stall). tokio's
+//! semaphore is FIFO-fair, so `ticket - admitted` is the number of compiles
+//! still ahead of this one.
+
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::Arc;
+
+use crate::protocol::Response;
+
+/// Phase label reported while the request is waiting for a permit.
+pub(in crate::daemon) const PHASE_QUEUED: &str = "queued";
+
+/// Phase label reported once the request holds a permit (or the
+/// concurrency cap is disabled entirely).
+pub(in crate::daemon) const PHASE_COMPILING: &str = "compiling";
+
+/// Sentinel for "this request has not reached the compile gate yet".
+const NO_TICKET: u64 = u64::MAX;
+
+/// Daemon-global compile-queue counters.
+///
+/// Cheap relaxed atomics — these are diagnostics on the heartbeat path,
+/// never a correctness gate, so no ordering stronger than `Relaxed` is
+/// warranted.
+#[derive(Debug, Default)]
+pub(in crate::daemon) struct CompileQueueGauge {
+    waiting: AtomicU32,
+    in_flight: AtomicU32,
+    next_ticket: AtomicU64,
+    admitted: AtomicU64,
+}
+
+impl CompileQueueGauge {
+    /// Register a new waiter at the compile gate.
+    ///
+    /// Call immediately *before* awaiting the permit; call
+    /// [`CompileQueueGuard::admit`] immediately after it is granted. The
+    /// returned guard restores the counters on drop, including the
+    /// cancellation path (client disconnect, handler dropped mid-await).
+    pub(in crate::daemon) fn enqueue(self: &Arc<Self>) -> CompileQueueGuard {
+        let ticket = self.next_ticket.fetch_add(1, Ordering::Relaxed);
+        self.waiting.fetch_add(1, Ordering::Relaxed);
+        if let Some(slot) = current_slot() {
+            slot.ticket.store(ticket, Ordering::Relaxed);
+            slot.admitted.store(false, Ordering::Relaxed);
+        }
+        CompileQueueGuard {
+            gauge: Arc::clone(self),
+            ticket,
+            admitted: false,
+        }
+    }
+
+    /// Requests currently blocked waiting for a permit.
+    pub(in crate::daemon) fn waiting(&self) -> u32 {
+        self.waiting.load(Ordering::Relaxed)
+    }
+
+    /// Compiler children currently holding a permit.
+    pub(in crate::daemon) fn in_flight(&self) -> u32 {
+        self.in_flight.load(Ordering::Relaxed)
+    }
+
+    /// Monotonic count of tickets that have left the queue.
+    fn admitted(&self) -> u64 {
+        self.admitted.load(Ordering::Relaxed)
+    }
+}
+
+/// RAII tracker for one request's trip through the compile gate.
+pub(in crate::daemon) struct CompileQueueGuard {
+    gauge: Arc<CompileQueueGauge>,
+    ticket: u64,
+    admitted: bool,
+}
+
+impl CompileQueueGuard {
+    /// Record that this request's permit was granted.
+    pub(in crate::daemon) fn admit(&mut self) {
+        if self.admitted {
+            return;
+        }
+        self.admitted = true;
+        self.gauge.admitted.fetch_add(1, Ordering::Relaxed);
+        self.gauge.waiting.fetch_sub(1, Ordering::Relaxed);
+        self.gauge.in_flight.fetch_add(1, Ordering::Relaxed);
+        if let Some(slot) = current_slot() {
+            slot.admitted.store(true, Ordering::Relaxed);
+        }
+    }
+}
+
+impl Drop for CompileQueueGuard {
+    fn drop(&mut self) {
+        if self.admitted {
+            self.gauge.in_flight.fetch_sub(1, Ordering::Relaxed);
+        } else {
+            // Cancelled before admission. Advance the cursor anyway so the
+            // waiters behind this one keep reporting a shrinking position.
+            self.gauge.waiting.fetch_sub(1, Ordering::Relaxed);
+            self.gauge.admitted.fetch_add(1, Ordering::Relaxed);
+        }
+        if let Some(slot) = current_slot() {
+            if slot.ticket.load(Ordering::Relaxed) == self.ticket {
+                slot.ticket.store(NO_TICKET, Ordering::Relaxed);
+                slot.admitted.store(true, Ordering::Relaxed);
+            }
+        }
+    }
+}
+
+/// Per-request progress view, published by the compile gate and read by
+/// the connection layer's heartbeat ticker.
+#[derive(Debug)]
+pub(in crate::daemon) struct CompileProgressSlot {
+    ticket: AtomicU64,
+    admitted: AtomicBool,
+}
+
+impl Default for CompileProgressSlot {
+    fn default() -> Self {
+        Self {
+            ticket: AtomicU64::new(NO_TICKET),
+            admitted: AtomicBool::new(false),
+        }
+    }
+}
+
+impl CompileProgressSlot {
+    /// Number of compiles still ahead of this request, `0` once it holds a
+    /// permit or has not reached the gate yet.
+    fn queue_position(&self, gauge: &CompileQueueGauge) -> u32 {
+        let ticket = self.ticket.load(Ordering::Relaxed);
+        if ticket == NO_TICKET || self.admitted.load(Ordering::Relaxed) {
+            return 0;
+        }
+        u32::try_from(ticket.saturating_sub(gauge.admitted())).unwrap_or(u32::MAX)
+    }
+
+    fn phase(&self) -> &'static str {
+        if self.ticket.load(Ordering::Relaxed) != NO_TICKET
+            && !self.admitted.load(Ordering::Relaxed)
+        {
+            PHASE_QUEUED
+        } else {
+            PHASE_COMPILING
+        }
+    }
+}
+
+/// Build the interim heartbeat frame for `slot` against the global `gauge`.
+pub(in crate::daemon) fn progress_response(
+    slot: &CompileProgressSlot,
+    gauge: &CompileQueueGauge,
+) -> Response {
+    Response::CompileProgress {
+        queue_position: slot.queue_position(gauge),
+        queue_depth: gauge.waiting(),
+        in_flight: gauge.in_flight(),
+        phase: slot.phase().to_string(),
+    }
+}
+
+tokio::task_local! {
+    static PROGRESS_SLOT: Arc<CompileProgressSlot>;
+}
+
+/// Run `future` with `slot` installed as the current request's progress slot.
+pub(in crate::daemon) fn scope<F>(
+    slot: Arc<CompileProgressSlot>,
+    future: F,
+) -> impl std::future::Future<Output = F::Output>
+where
+    F: std::future::Future,
+{
+    PROGRESS_SLOT.scope(slot, future)
+}
+
+fn current_slot() -> Option<Arc<CompileProgressSlot>> {
+    PROGRESS_SLOT.try_with(Arc::clone).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn positions(response: &Response) -> (u32, u32, u32, String) {
+        match response {
+            Response::CompileProgress {
+                queue_position,
+                queue_depth,
+                in_flight,
+                phase,
+            } => (*queue_position, *queue_depth, *in_flight, phase.clone()),
+            other => panic!("expected CompileProgress, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gauge_tracks_waiting_and_in_flight() {
+        let gauge = Arc::new(CompileQueueGauge::default());
+        let mut first = gauge.enqueue();
+        let second = gauge.enqueue();
+        assert_eq!(gauge.waiting(), 2);
+        assert_eq!(gauge.in_flight(), 0);
+
+        first.admit();
+        assert_eq!(gauge.waiting(), 1);
+        assert_eq!(gauge.in_flight(), 1);
+
+        drop(first);
+        assert_eq!(gauge.in_flight(), 0);
+        drop(second);
+        assert_eq!(gauge.waiting(), 0);
+    }
+
+    #[test]
+    fn cancelled_waiter_still_advances_the_cursor() {
+        let gauge = Arc::new(CompileQueueGauge::default());
+        let head = gauge.enqueue();
+        let tail = gauge.enqueue();
+        assert_eq!(tail.ticket, 1);
+        // Head is dropped without ever being admitted (client disconnect).
+        drop(head);
+        assert_eq!(gauge.admitted(), 1, "cursor must advance past the cancel");
+        let slot = CompileProgressSlot {
+            ticket: AtomicU64::new(tail.ticket),
+            admitted: AtomicBool::new(false),
+        };
+        assert_eq!(
+            slot.queue_position(&gauge),
+            0,
+            "tail is now next in line, nobody ahead of it"
+        );
+    }
+
+    #[test]
+    fn position_counts_waiters_ahead() {
+        let gauge = Arc::new(CompileQueueGauge::default());
+        let mut first = gauge.enqueue();
+        let _second = gauge.enqueue();
+        let third = gauge.enqueue();
+        let slot = CompileProgressSlot {
+            ticket: AtomicU64::new(third.ticket),
+            admitted: AtomicBool::new(false),
+        };
+        let (position, depth, in_flight, phase) = positions(&progress_response(&slot, &gauge));
+        assert_eq!(position, 2, "two compiles ahead");
+        assert_eq!(depth, 3);
+        assert_eq!(in_flight, 0);
+        assert_eq!(phase, PHASE_QUEUED);
+
+        first.admit();
+        let (position, depth, in_flight, _) = positions(&progress_response(&slot, &gauge));
+        assert_eq!(position, 1, "one admitted, position shrinks");
+        assert_eq!(depth, 2);
+        assert_eq!(in_flight, 1);
+    }
+
+    #[test]
+    fn admitted_slot_reports_compiling_at_position_zero() {
+        let gauge = Arc::new(CompileQueueGauge::default());
+        let slot = CompileProgressSlot {
+            ticket: AtomicU64::new(7),
+            admitted: AtomicBool::new(true),
+        };
+        let (position, _, _, phase) = positions(&progress_response(&slot, &gauge));
+        assert_eq!(position, 0);
+        assert_eq!(phase, PHASE_COMPILING);
+    }
+
+    #[test]
+    fn unreached_gate_reports_compiling() {
+        let gauge = Arc::new(CompileQueueGauge::default());
+        let slot = CompileProgressSlot::default();
+        let (position, _, _, phase) = positions(&progress_response(&slot, &gauge));
+        assert_eq!(position, 0);
+        assert_eq!(
+            phase, PHASE_COMPILING,
+            "a request that never queues is simply running"
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_publishes_the_ticket_into_the_task_local_slot() {
+        let gauge = Arc::new(CompileQueueGauge::default());
+        let slot = Arc::new(CompileProgressSlot::default());
+        let observed = scope(Arc::clone(&slot), {
+            let gauge = Arc::clone(&gauge);
+            let slot = Arc::clone(&slot);
+            async move {
+                let mut guard = gauge.enqueue();
+                let queued = positions(&progress_response(&slot, &gauge));
+                guard.admit();
+                let running = positions(&progress_response(&slot, &gauge));
+                drop(guard);
+                let done = positions(&progress_response(&slot, &gauge));
+                (queued, running, done)
+            }
+        })
+        .await;
+        assert_eq!(observed.0 .3, PHASE_QUEUED);
+        assert_eq!(observed.0 .1, 1, "one waiter while queued");
+        assert_eq!(observed.1 .3, PHASE_COMPILING);
+        assert_eq!(observed.1 .2, 1, "one in flight once admitted");
+        assert_eq!(observed.2 .2, 0, "guard drop releases the in-flight slot");
+    }
+
+    #[tokio::test]
+    async fn concurrent_enqueues_hand_out_unique_shrinking_positions() {
+        let gauge = Arc::new(CompileQueueGauge::default());
+        let mut handles = Vec::new();
+        for _ in 0..32 {
+            let gauge = Arc::clone(&gauge);
+            handles.push(tokio::spawn(async move {
+                let slot = Arc::new(CompileProgressSlot::default());
+                scope(Arc::clone(&slot), async move {
+                    let mut guard = gauge.enqueue();
+                    let ticket = guard.ticket;
+                    guard.admit();
+                    ticket
+                })
+                .await
+            }));
+        }
+        let mut tickets = Vec::new();
+        for handle in handles {
+            tickets.push(handle.await.expect("task"));
+        }
+        tickets.sort_unstable();
+        assert_eq!(
+            tickets,
+            (0..32).collect::<Vec<u64>>(),
+            "every waiter gets a unique ticket under concurrency"
+        );
+        assert_eq!(gauge.waiting(), 0, "all waiters drained");
+        assert_eq!(gauge.in_flight(), 0, "all guards dropped");
+        assert_eq!(gauge.admitted(), 32);
+    }
+}

--- a/crates/zccache-daemon-core/src/daemon/server/connection/README.md
+++ b/crates/zccache-daemon-core/src/daemon/server/connection/README.md
@@ -6,7 +6,10 @@ discipline) into:
 
 - `mod.rs` — `handle_connection` (the read/dispatch/send loop), `ResponseWire`,
   `PendingJournalContext`, `guarded_dispatch` (issue #967 disconnect-cancel
-  guard), `log_client_cancelled`, `send_response_for_wire`,
+  guard), `guarded_dispatch_with_progress` (issue #1216 `CompileProgress`
+  heartbeat ticker — see [`docs/architecture/ipc.md` § Compile progress
+  heartbeats](../../../../../../docs/architecture/ipc.md#compile-progress-heartbeats-issue-1216)),
+  `log_client_cancelled`, `send_response_for_wire`,
   `session_phase_profile`. Owns the journal-entry bookkeeping that wraps each
   dispatched request.
 - `dispatch.rs` — `dispatch_request` / `DispatchOutcome`: the per-`Request`

--- a/crates/zccache-daemon-core/src/daemon/server/connection/dispatch.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/connection/dispatch.rs
@@ -196,7 +196,7 @@ pub(super) async fn dispatch_request(
                     None => request.await,
                 }
             };
-            match guarded_dispatch(conn, handler).await {
+            match guarded_dispatch_with_progress(conn, response_wire, state, handler).await {
                 Some((response, ctx)) => (response, ctx),
                 None => {
                     log_client_cancelled("compile");
@@ -242,7 +242,7 @@ pub(super) async fn dispatch_request(
                     )),
                 )
             };
-            match guarded_dispatch(conn, handler).await {
+            match guarded_dispatch_with_progress(conn, response_wire, state, handler).await {
                 Some((response, ctx)) => (response, ctx),
                 None => {
                     log_client_cancelled("compile_ephemeral");

--- a/crates/zccache-daemon-core/src/daemon/server/connection/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/connection/mod.rs
@@ -40,6 +40,20 @@ enum ResponseWire {
 
 const SERVER_REQUEST_RECV_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
 
+/// Interval between `CompileProgress` heartbeats pushed on an in-flight
+/// compile connection (issue #1216).
+///
+/// Must stay comfortably below every client-side budget it has to keep
+/// alive: the wrapper's 180 s wedge budget
+/// (`ZCCACHE_WEDGE_RECV_TIMEOUT_SECS`) and soldr's 30 s embedded dispatch
+/// budget (soldr#1657). 5 s clears both with a wide margin while costing at
+/// most a few dozen small frames over a minutes-long compile.
+const COMPILE_PROGRESS_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Override for [`COMPILE_PROGRESS_INTERVAL`], in milliseconds. `0`
+/// disables heartbeats entirely (the pre-#1216 behavior).
+const COMPILE_PROGRESS_INTERVAL_ENV: &str = "ZCCACHE_COMPILE_PROGRESS_INTERVAL_MS";
+
 pub(in crate::daemon::server) struct PendingJournalContext {
     context: JournalContext,
     attributed_miss_reason: Option<&'static str>,
@@ -106,6 +120,117 @@ where
         biased;
         out = handler => Some(out),
         () = conn.wait_for_disconnect() => None,
+    }
+}
+
+/// Resolve the heartbeat interval, or `None` when heartbeats are disabled.
+fn compile_progress_interval() -> Option<std::time::Duration> {
+    let Some(raw) = std::env::var(COMPILE_PROGRESS_INTERVAL_ENV).ok() else {
+        return Some(COMPILE_PROGRESS_INTERVAL);
+    };
+    match raw.trim().parse::<u64>() {
+        Ok(0) => None,
+        Ok(ms) => Some(std::time::Duration::from_millis(ms)),
+        Err(_) => {
+            tracing::warn!(
+                env = COMPILE_PROGRESS_INTERVAL_ENV,
+                value = raw,
+                "invalid {COMPILE_PROGRESS_INTERVAL_ENV}; using the default interval"
+            );
+            Some(COMPILE_PROGRESS_INTERVAL)
+        }
+    }
+}
+
+/// [`guarded_dispatch`] plus interim `CompileProgress` heartbeats (issue #1216).
+///
+/// Used for the two compile lanes, whose handlers can legitimately park for
+/// minutes inside the compile-concurrency gate. While the handler runs, a
+/// ticker pushes a non-terminal `CompileProgress` frame on the *same*
+/// connection every [`COMPILE_PROGRESS_INTERVAL`]. The wrapper resets its
+/// wedge budget on each one (`wrap/ipc.rs`), so a queued-but-progressing
+/// compile keeps its original connection and cached-path result instead of
+/// being probed, re-run ephemerally, or killed — while a daemon that emits
+/// *nothing* for a full budget still trips the #753/#955 wedge handling.
+///
+/// The per-request queue ticket is published through the
+/// [`super::compile_progress`] task-local scoped around `handler` here,
+/// which is why no progress handle has to be threaded through
+/// `handle_compile` → `pipeline` → `compile_exec`.
+///
+/// ## Old-client safety
+///
+/// Heartbeats are only emitted after the request has been decoded, so the
+/// client's wire version is already known to be one this daemon speaks. A
+/// client too old to understand `CompileProgress` fails version negotiation
+/// before reaching this function (both lanes were bumped in #1216), so it can
+/// never receive a frame it cannot decode.
+///
+/// ## Borrow shape
+///
+/// The ticker arm deliberately does *nothing* but fall out of the `select!`:
+/// `conn.wait_for_disconnect()` mutably borrows `conn` for the whole
+/// `select!` expression, so the heartbeat write has to happen after that
+/// expression ends. `wait_for_disconnect` is cancellation-safe and preserves
+/// buffered bytes, so re-entering it each iteration is sound.
+async fn guarded_dispatch_with_progress<F>(
+    conn: &mut IpcConnection,
+    response_wire: &ResponseWire,
+    state: &SharedState,
+    handler: F,
+) -> Option<(Response, Option<PendingJournalContext>)>
+where
+    F: std::future::Future<Output = (Response, Option<PendingJournalContext>)>,
+{
+    let Some(interval) = compile_progress_interval() else {
+        return guarded_dispatch(conn, handler).await;
+    };
+    let slot = Arc::new(super::compile_progress::CompileProgressSlot::default());
+    let handler = super::compile_progress::scope(Arc::clone(&slot), handler);
+    let mut handler = std::pin::pin!(handler);
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // `interval` fires immediately on first tick; burn it so the first
+    // heartbeat lands one full interval into the compile rather than at t=0.
+    ticker.tick().await;
+    loop {
+        tokio::select! {
+            biased;
+            out = &mut handler => return Some(out),
+            () = conn.wait_for_disconnect() => return None,
+            _ = ticker.tick() => {}
+        }
+        // Borrow of `conn` from the `select!` above has ended here.
+        let progress = super::compile_progress::progress_response(&slot, &state.compile_queue);
+        if let Response::CompileProgress {
+            queue_position,
+            queue_depth,
+            in_flight,
+            ref phase,
+        } = progress
+        {
+            tracing::info!(
+                event = "compile_progress",
+                queue_position,
+                queue_depth,
+                in_flight,
+                phase = phase.as_str(),
+                "compile_progress phase={phase} queue_position={queue_position} \
+                 queue_depth={queue_depth} in_flight={in_flight}",
+            );
+        }
+        if let Err(error) = send_response_for_wire(conn, response_wire, &progress).await {
+            // The client is gone or the pipe broke. Don't fail the compile
+            // over a lost diagnostic — let the handler finish and let the
+            // terminal write report the real transport error.
+            tracing::warn!(
+                event = "compile_progress_send_failed",
+                error = %error,
+                "failed to push a compile progress heartbeat; \
+                 continuing without further heartbeats"
+            );
+            return guarded_dispatch(conn, handler).await;
+        }
     }
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -261,10 +261,17 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     // structured so an integration test (sub-task #817) can parse the
     // log and assert no two compile intervals overlap when the cap is
     // 1 (sub-task #5 of the meta).
+    //
+    // Issue #1216: the wait is registered in `state.compile_queue` so the
+    // connection layer can push `CompileProgress` heartbeats naming this
+    // request's queue position while it sits here. `_queue_guard` restores
+    // the counters on every exit path, including cancellation.
     let client_pid = lineage.client_pid.unwrap_or(0);
+    let mut _queue_guard = state.compile_queue.enqueue();
     let _permit = if let Some(sem) = state.compile_concurrency.as_ref() {
         let available_before = sem.available_permits();
         let permit = Arc::clone(sem).acquire_owned().await.ok();
+        _queue_guard.admit();
         tracing::info!(
             event = "compile_start",
             client_pid,
@@ -273,6 +280,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         );
         permit
     } else {
+        _queue_guard.admit();
         None
     };
     let compile_span_start = std::time::Instant::now();

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
@@ -208,14 +208,24 @@ pub(super) async fn try_handle_staged_misses(
         apply_client_env(&mut command, client_env, &lineage);
         command.kill_on_drop(true);
         let compile_concurrency = state.compile_concurrency.clone();
+        // Issue #1216: keep the global queue gauge accurate for the staged
+        // lane too. These waits run on spawned tasks, so the per-request
+        // task-local slot is out of reach — the daemon-wide `queue_depth` /
+        // `in_flight` counters still are not, and those are what other
+        // clients' heartbeats report.
+        let compile_queue = Arc::clone(&state.compile_queue);
         let unit_index = miss.unit_index;
         compiler_set.spawn(async move {
             let available_before = compile_concurrency
                 .as_ref()
                 .map_or(usize::MAX, |semaphore| semaphore.available_permits());
+            let mut queue_guard = compile_queue.enqueue();
             let _permit = if let Some(semaphore) = compile_concurrency.as_ref() {
-                Arc::clone(semaphore).acquire_owned().await.ok()
+                let permit = Arc::clone(semaphore).acquire_owned().await.ok();
+                queue_guard.admit();
+                permit
             } else {
+                queue_guard.admit();
                 None
             };
             if compile_concurrency.is_some() {

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -234,6 +234,9 @@ pub(super) fn new_shared_state(
             artifact_publication: Arc::new(tokio::sync::RwLock::new(())),
             persist_semaphore: Arc::new(tokio::sync::Semaphore::new(persist_workers_default())),
             compile_concurrency,
+            compile_queue: Arc::new(
+                crate::daemon::server::compile_progress::CompileQueueGauge::default(),
+            ),
             artifact_store,
             index_writer_tx,
             index_writer_shutdown,

--- a/crates/zccache-daemon-core/src/daemon/server/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/mod.rs
@@ -146,6 +146,7 @@ mod cache_trim;
 mod cached_artifact;
 mod client_env;
 mod compile_concurrency;
+mod compile_progress;
 mod compiler_hash;
 mod connection;
 mod dependency_policy;

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -275,6 +275,12 @@ pub(super) struct SharedState {
     /// `None` when the override is `0` (or `unlimited`) — preserves the
     /// historical uncapped behavior for users who want it.
     pub(super) compile_concurrency: Option<Arc<tokio::sync::Semaphore>>,
+    /// Issue #1216 — compile-queue counters backing the `CompileProgress`
+    /// heartbeats. `tokio::sync::Semaphore` reports available permits but
+    /// not its waiter count or original capacity, so the gate maintains
+    /// its own gauge. Always present, even when the cap is disabled — an
+    /// uncapped daemon still reports in-flight compiles.
+    pub(super) compile_queue: Arc<super::compile_progress::CompileQueueGauge>,
     /// In-memory artifact index (bincode blob-backed) for fast startup and
     /// persistence. Hot-path reads and writes go through `state.artifacts`;
     /// this store holds the same data and snapshots it to disk periodically.

--- a/crates/zccache-protocol/proto/zccache_v1.proto
+++ b/crates/zccache-protocol/proto/zccache_v1.proto
@@ -64,6 +64,7 @@ message Response {
     GenericToolExecResult generic_tool_exec_result = 16;
     Backpressure backpressure = 17;
     ReleaseWorktreeHandlesResult release_worktree_handles_result = 18;
+    CompileProgress compile_progress = 19;
   }
   string request_id = 100;
 }
@@ -388,6 +389,13 @@ message Backpressure {
   uint32 queue_depth = 1;
   uint32 retry_after_ms = 2;
   string reason = 3;
+}
+
+message CompileProgress {
+  uint32 queue_position = 1;
+  uint32 queue_depth = 2;
+  uint32 in_flight = 3;
+  string phase = 4;
 }
 
 message ReleaseWorktreeHandlesResult {

--- a/crates/zccache-protocol/src/README.md
+++ b/crates/zccache-protocol/src/README.md
@@ -1,7 +1,7 @@
 # zccache-protocol
 
 Wire protocol: `Request`/`Response` enums over a length-prefixed daemon frame.
-The active compatibility path is v18 bincode. The v16-family prost schema is generated
+The active compatibility path is v20 bincode. The v16-family prost schema is generated
 from `proto/zccache_v1.proto` and scaffolded in `wire_prost.rs` so the daemon can
 later dispatch both v15 bincode and v16 prost frames during migration.
 
@@ -25,9 +25,12 @@ enum variants must still be appended in `messages/mod.rs` and require a
 
 ## Wire Migration
 
-`PROTOCOL_VERSION` is `18` while the public `encode_message` and
+`PROTOCOL_VERSION` is `20` while the public `encode_message` and
 `decode_message` helpers emit and accept bincode bodies. `PROST_PROTOCOL_VERSION`
-is `19` for the current prost schema revision. The live daemon receive path dispatches both frame
+is `21` for the current prost schema revision. Because the header version byte is
+what selects the decoding lane, a bump must never re-use a value the *other* lane
+has previously shipped — that is why #1216 moved bincode 18 → 20 and prost
+19 → 21 rather than 18 → 19. The live daemon receive path dispatches both frame
 versions, but only the control/maintenance request slice (`Ping`, `Status`,
 `Shutdown`, `Clear`, `ReleaseWorktreeHandles`) is converted from prost today,
 and only the matching control/maintenance response slice (`Pong`, `Status`,

--- a/crates/zccache-protocol/src/lib.rs
+++ b/crates/zccache-protocol/src/lib.rs
@@ -22,18 +22,24 @@ pub const UNKNOWN_MISS_WARNING_PREFIX: &str = "zccache[warn][M]:";
 /// This remains the active compatibility version until the v16 prost dispatcher
 /// is wired through the IPC transport. Do not change `PROTOCOL_VERSION` to v16
 /// while `encode_message` and `decode_message` still serialize bincode bodies.
-pub const BINCODE_PROTOCOL_VERSION: u32 = 18;
+pub const BINCODE_PROTOCOL_VERSION: u32 = 20;
 
 /// Prost daemon wire version.
 ///
 /// The prost schema and frame helpers use this value. A future change will make
 /// the daemon dispatch v15 bincode and v16 prost frames concurrently.
-pub const PROST_PROTOCOL_VERSION: u32 = 19;
+pub const PROST_PROTOCOL_VERSION: u32 = 21;
 
 /// Protocol version number. Bump this when the wire format changes:
 /// new/removed/reordered enum variants or struct field changes.
 /// Patch releases that don't change the protocol keep the same version.
 ///
+/// v20 (bincode) / v21 (prost): added `Response::CompileProgress` — interim,
+///                  non-terminal queue/in-flight heartbeats pushed on the
+///                  request connection while a compile waits for a
+///                  compile-concurrency permit (issue #1216). Both lanes are
+///                  bumped past the previous prost version so no historical
+///                  header value is ever re-used by the other lane.
 /// v19: v16-family prost body with staged-output telemetry. The schema lives in
 ///                  `proto/zccache_v1.proto`; the bincode lane remains
 ///                  separately versioned during the transition.

--- a/crates/zccache-protocol/src/messages/compat/mod.rs
+++ b/crates/zccache-protocol/src/messages/compat/mod.rs
@@ -102,7 +102,9 @@ pub(super) fn sample_artifact() -> ArtifactData {
 
 // Compile-time check: PROTOCOL_VERSION must be positive.
 const _: () = assert!(super::super::PROTOCOL_VERSION > 0);
-// Compile-time check: PROTOCOL_VERSION == 18 after staged telemetry was added.
+// Compile-time check: PROTOCOL_VERSION == 20 after `Response::CompileProgress`
+// was appended (issue #1216: interim compile queue heartbeats). v18 was the pin
+// after staged-output telemetry was added.
 // v17 added ExecProbe/ExecStore (issue #838 slice 1) for caller-owned tool caching (e.g. the
 // PyO3 `zccache.exec` binding for Python build orchestrators). v15 was
 // the pin after `ReleaseWorktreeHandles` was added for soldr Tier 3
@@ -116,4 +118,4 @@ const _: () = assert!(super::super::PROTOCOL_VERSION > 0);
 // pin after SessionStats gained `phase_profile`. v8 was the pin after
 // Compile/CompileEphemeral gained `stdin` and ArtifactPayload replaced
 // ArtifactOutput.data: Arc<Vec<u8>> (issue #296 Option B).
-const _FINGERPRINT_VERSION: () = assert!(super::super::PROTOCOL_VERSION == 18);
+const _FINGERPRINT_VERSION: () = assert!(super::super::PROTOCOL_VERSION == 20);

--- a/crates/zccache-protocol/src/messages/compat/variant_indices.rs
+++ b/crates/zccache-protocol/src/messages/compat/variant_indices.rs
@@ -282,6 +282,15 @@ fn response_variant_indices_are_append_only() {
             },
         ),
         (19, Response::ExecStoreAck { stored: true }),
+        (
+            20,
+            Response::CompileProgress {
+                queue_position: 2,
+                queue_depth: 5,
+                in_flight: 8,
+                phase: "queued".to_string(),
+            },
+        ),
     ];
 
     for (expected, response) in response_cases {

--- a/crates/zccache-protocol/src/messages/mod.rs
+++ b/crates/zccache-protocol/src/messages/mod.rs
@@ -497,4 +497,37 @@ pub enum Response {
         /// Operational outcome of the store.
         stored: bool,
     },
+    /// Interim, **non-terminal** progress heartbeat for an in-flight
+    /// `Compile` / `CompileEphemeral` request (issue #1216).
+    ///
+    /// The daemon pushes these on the *same* connection that carries the
+    /// request while the compile is queued behind the compile-concurrency
+    /// semaphore or otherwise still running. They exist so a legitimately
+    /// slow-but-progressing compile is distinguishable from a wedged
+    /// daemon: the wrapper resets its wedge budget on every frame it sees
+    /// (see `wrap/ipc.rs`), so wedge detection becomes progress-based
+    /// rather than wall-clock-based.
+    ///
+    /// Unlike [`Response::Backpressure`] this is **not** a retry request —
+    /// the client keeps waiting on the same connection and the daemon still
+    /// delivers a terminal `CompileResult` / `Error` afterwards. A client
+    /// that does not understand the variant must never see one: the daemon
+    /// only emits heartbeats after the request has been decoded, i.e. once
+    /// the client's own wire version is known.
+    ///
+    /// NOTE: Appended at end to preserve bincode variant indices.
+    CompileProgress {
+        /// Number of compile requests admitted ahead of this one that have
+        /// not yet been granted a concurrency permit — i.e. how many
+        /// waiters are still in front of us. `0` means this request holds a
+        /// permit (or the semaphore is disabled) and is actively compiling.
+        queue_position: u32,
+        /// Total number of requests currently waiting for a permit.
+        queue_depth: u32,
+        /// Number of compiler children currently holding a permit.
+        in_flight: u32,
+        /// Coarse phase label. Diagnostic — known values: `"queued"`,
+        /// `"compiling"`.
+        phase: String,
+    },
 }

--- a/crates/zccache-protocol/src/wire_prost/response.rs
+++ b/crates/zccache-protocol/src/wire_prost/response.rs
@@ -126,6 +126,17 @@ pub fn response_to_prost(response: &crate::Response, request_id: &str) -> zccach
             sessions_dropped: sessions_dropped.clone(),
             unreleased: unreleased.iter().map(path_to_prost).collect(),
         }),
+        crate::Response::CompileProgress {
+            queue_position,
+            queue_depth,
+            in_flight,
+            phase,
+        } => Body::CompileProgress(zccache_v1::CompileProgress {
+            queue_position: *queue_position,
+            queue_depth: *queue_depth,
+            in_flight: *in_flight,
+            phase: phase.clone(),
+        }),
         // Issue #838: ExecProbeResult / ExecStoreAck are bincode-only in
         // slice 1. The prost wire lane will gain proto definitions once a
         // wheel consumer needs cross-protocol routing.
@@ -229,6 +240,12 @@ pub fn response_from_prost(response: zccache_v1::Response) -> Result<crate::Resp
                 unreleased: result.unreleased.into_iter().map(path_from_prost).collect(),
             })
         }
+        Some(Body::CompileProgress(progress)) => Ok(crate::Response::CompileProgress {
+            queue_position: progress.queue_position,
+            queue_depth: progress.queue_depth,
+            in_flight: progress.in_flight,
+            phase: progress.phase,
+        }),
         None => Err("v16 prost response is missing its response body".to_string()),
     }
 }

--- a/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
+++ b/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
@@ -589,6 +589,18 @@ mod full_family {
         });
     }
 
+    /// Issue #1216: interim compile heartbeats must survive the prost lane —
+    /// the wrapper only resets its wedge budget on frames it can decode.
+    #[test]
+    fn compile_progress_response_roundtrips() {
+        roundtrip_response(Response::CompileProgress {
+            queue_position: 3,
+            queue_depth: 9,
+            in_flight: 16,
+            phase: "queued".to_string(),
+        });
+    }
+
     #[test]
     fn control_converters_reject_non_control_families() {
         use zccache::protocol::wire_prost::{

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@ This document is the index for zccache's architecture specification. Each subsys
 |---|---|---|
 | [architecture/overview.md](architecture/overview.md) | ~280 | System diagram, all 9 component descriptions and key interfaces |
 | [architecture/data-flow.md](architecture/data-flow.md) | ~160 | Cache hit, cache miss, passthrough traces + rustc key-scope rules (env-deps, incremental, crate types) |
-| [architecture/ipc.md](architecture/ipc.md) | ~60 | Transport abstraction, socket discovery, connection lifecycle, errors |
+| [architecture/ipc.md](architecture/ipc.md) | ~100 | Transport abstraction, socket discovery, connection lifecycle, compile progress heartbeats, errors |
 | [architecture/metadata-cache.md](architecture/metadata-cache.md) | ~130 | In-memory cache data model, confidence levels, watcher integration |
 | [architecture/artifact-store.md](architecture/artifact-store.md) | ~130 | Disk layout, redb index schema, LRU eviction, corruption detection |
 | [architecture/rust-artifact-plan.md](architecture/rust-artifact-plan.md) | ~120 | Rust plan ownership, thin/full semantics, restore hardening, backends, diagnostics, CLI contract |
@@ -27,6 +27,7 @@ failed cache-root audit retain its diagnostic JSONL evidence.
 - **"How does a cache hit work?"** → [data-flow.md](architecture/data-flow.md)
 - **Nested Dylint driver caching** → [data-flow.md](architecture/data-flow.md#nested-dylint-driver-caching)
 - **CLI↔daemon communication** → [ipc.md](architecture/ipc.md)
+- **Compile queue visibility, progress-based wedge detection** → [ipc.md § Compile progress heartbeats](architecture/ipc.md#compile-progress-heartbeats-issue-1216)
 - **File change detection** → [metadata-cache.md](architecture/metadata-cache.md)
 - **Disk cache & eviction** → [artifact-store.md](architecture/artifact-store.md)
 - **Daemon-owned bounded disk retention** → [artifact-store.md](architecture/artifact-store.md#daemon-owned-retention-policy)

--- a/docs/architecture/ipc.md
+++ b/docs/architecture/ipc.md
@@ -69,6 +69,44 @@ per invocation.
    A connection may carry multiple requests (session mode) or a single
    `CompileEphemeral` (drop-in mode).
 
+## Compile progress heartbeats (issue #1216)
+
+A compile can legitimately park for minutes inside the daemon's global
+compile-concurrency gate (`server/compile_concurrency.rs`). That wait used to
+be entirely silent, so the wrapper's single blocking `recv` could not tell
+"queued behind 40 other compiles" from "daemon hung" — it tripped its wedge
+budget (`ZCCACHE_WEDGE_RECV_TIMEOUT_SECS`, default 180 s) and applied the
+#753/#955 recovery, throwing away in-progress daemon work or killing the
+daemon outright.
+
+`Response::CompileProgress { queue_position, queue_depth, in_flight, phase }`
+closes that gap **without any extra roundtrip**: it is an interim,
+non-terminal frame pushed on the connection that already carries the request.
+
+- **Daemon.** `connection::guarded_dispatch_with_progress` wraps the
+  `Compile` / `CompileEphemeral` handler in a ticker
+  (`COMPILE_PROGRESS_INTERVAL`, 5 s; `ZCCACHE_COMPILE_PROGRESS_INTERVAL_MS=0`
+  disables). Each tick emits one frame plus a structured
+  `event="compile_progress"` log line. Counters come from
+  `server/compile_progress.rs`: `tokio::sync::Semaphore` reports available
+  permits but neither its waiter count nor its capacity, so the gate keeps its
+  own `CompileQueueGauge`. The *per-request* queue ticket reaches the
+  connection layer through a task-local slot rather than a progress handle
+  threaded through `handle_compile` → `pipeline` → `compile_exec` — sound
+  because the handler is awaited inline by `guarded_dispatch`, never spawned.
+- **Wrapper.** `wrap/ipc.rs::compile_recv_with_wedge_detection` is a recv
+  *loop*: a `CompileProgress` frame prints a `zccache[info][Q]` status line
+  and restarts the budget. Wedge detection therefore measures **daemon
+  silence**, not compile duration — a queued-but-progressing compile keeps its
+  original connection and cached-path result, while a daemon that emits
+  nothing for a full budget still trips the existing wedge handling.
+- **Compatibility.** Heartbeats are only emitted after the request has been
+  decoded, so the client's wire version is already known. Both lanes were
+  bumped in #1216 (bincode 18 → 20, prost 19 → 21, skipping 19 so the header
+  byte that selects the lane never re-uses a value the other lane shipped), so
+  a client too old to decode `CompileProgress` fails version negotiation long
+  before a heartbeat could reach it.
+
 ## Error Handling
 
 - If the daemon crashes mid-request, the CLI receives a broken-pipe error. The CLI falls back to running the compiler directly (non-cached) and prints a warning to stderr.

--- a/docs/architecture/ipc.md
+++ b/docs/architecture/ipc.md
@@ -100,6 +100,13 @@ non-terminal frame pushed on the connection that already carries the request.
   silence**, not compile duration — a queued-but-progressing compile keeps its
   original connection and cached-path result, while a daemon that emits
   nothing for a full budget still trips the existing wedge handling.
+- **Not covered: the embedded lane.** `server/embedded.rs` calls
+  `handle_compile_ephemeral` directly and has no `IpcConnection`, so an
+  in-process host (soldr/fbuild via `ZccacheService`) sees no heartbeats and
+  its own dispatch budget (30 s, soldr#1657) is unaffected. The
+  `CompileQueueGauge` counters *are* maintained on that path, since the gate
+  itself is shared — so exposing the same queue view to an embedded host is a
+  cheap follow-up (a callback or a gauge accessor), not a redesign.
 - **Compatibility.** Heartbeats are only emitted after the request has been
   decoded, so the client's wire version is already known. Both lanes were
   bumped in #1216 (bincode 18 → 20, prost 19 → 21, skipping 19 so the header


### PR DESCRIPTION
Closes #1216. Part of the #1223 reliability burn-down (Phase 3).

## Problem

Under contention a compile legitimately parks for minutes inside the daemon's global compile-concurrency gate. That wait was **completely silent**: the wrapper did exactly one blocking `recv` with a 180 s wedge budget, so a queued compile was indistinguishable from a hung daemon and got the #753/#955 treatment — probe, then either an ephemeral re-run that threw away the daemon's in-progress work, or a kill.

## Solution

`Response::CompileProgress { queue_position, queue_depth, in_flight, phase }` — an interim, **non-terminal** frame pushed on the connection that already carries the request. Zero extra roundtrips (CLAUDE.md).

**Daemon.** `guarded_dispatch_with_progress` wraps the `Compile`/`CompileEphemeral` handler in a 5 s ticker (`ZCCACHE_COMPILE_PROGRESS_INTERVAL_MS=0` disables), emitting one frame plus a structured `event="compile_progress"` log line per tick. The ticker arm deliberately does nothing but fall out of the `select!` — `conn.wait_for_disconnect()` holds the `&mut conn` borrow for the whole expression, so the write happens after it ends (`wait_for_disconnect` is cancellation-safe and preserves buffered bytes).

**Counters.** New `server/compile_progress.rs`. `tokio::sync::Semaphore` exposes `available_permits()` but neither a waiter count nor its original capacity, so the gate keeps its own `CompileQueueGauge`. Both acquire sites register (`compile_exec.rs` and the staged lane in `handle_compile_multi_staged.rs`).

The *per-request* queue ticket reaches the connection layer through a **task-local slot** rather than a progress handle threaded through `handle_compile` → `pipeline` → `compile_exec`. This is sound because the handler is awaited inline by `guarded_dispatch`, never spawned — and it degrades to position 0 rather than to something wrong if that ever stops holding. A waiter cancelled before admission still advances the cursor, so requests behind it keep reporting a shrinking position instead of stalling.

**Wrapper.** `compile_recv_with_wedge_detection` becomes a recv **loop**: a `CompileProgress` frame prints a `zccache[info][Q]: daemon under load: queued, position 2 of 5 queued, 8 in flight` line and restarts the budget. Wedge detection now measures **daemon silence**, not compile duration — matching the established progress-based watchdog philosophy.

## Protocol version (DD-018)

bincode **18 → 20**, prost **19 → 21**. Skipping 19 is deliberate: the header version byte is what selects the decoding lane, so a bump must never re-use a value the *other* lane has shipped (18 → 19 would alias old prost frames as bincode). Bumping both lanes also gives graceful degradation for free — a client too old to decode `CompileProgress` fails version negotiation long before a heartbeat could reach it.

## Acceptance criteria

- [x] Compile queued past the wedge budget completes on its original connection with the cached-path result; no probe, no ephemeral re-run, no kill — `compile_progress_heartbeats_reset_the_wedge_budget` (2.7 s of gaps under a 1 s budget)
- [x] Wrapper surfaces a human-readable position/depth/in-flight line — `compile_progress_line_names_position_depth_and_in_flight`
- [x] A truly silent daemon still trips wedge handling — `silence_after_heartbeats_still_trips_wedge_detection`
- [x] Protocol bumped, wire snapshot + compat asserts + variant-index guard updated; old/new client combinations degrade gracefully
- [x] Unit tests: budget reset, terminal-after-heartbeats relay, waiter-counter accuracy under concurrent acquires

## Tests

11 new unit tests (7 gauge/slot, 4 wrapper) + a prost roundtrip. `./test`: **2418 passed, 0 failed**. `soldr cargo clippy --workspace --all-targets -- -D warnings` clean. `ci/check_wire_stability.py` clean.

## Incidental

- Fixes a pre-existing `clippy::cloned_ref_to_slice_refs` failure in `zccache-compiler/src/tests/dylint_driver.rs` that was already denying `-D warnings` CI on main.
- Regenerating the wire snapshot also recorded previously-undrifted **additive** fields (`LookupOutcomes`, `PhaseProfileSummary.staged`, `StagedProfileSummary`). The guard only flags removals/changes, which is why they never failed CI.

## Not included

Issue #1216's optional complement (b) — enriching `Pong` with load counts to inform the post-wedge kill/no-kill decision. It is not in the acceptance criteria and `Pong` is currently `Empty` in the proto, so it would be a second shape change; worth a follow-up now that the counters exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)