### PR TITLE
fix(staged): evict a cache key once it is proven non-deterministic

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
@@ -417,6 +417,21 @@ fn store_rustc_outputs(
                         reason,
                         &error,
                     );
+                    // #1244: the on-disk generation and pointer are already
+                    // gone. Drop the index row too, or lookups keep resolving
+                    // a key whose payload no longer exists.
+                    if reason == StagedPublishFailure::Conflict {
+                        if let Err(error) = state_ref
+                            .index_writer_tx
+                            .send(IndexWriterCommand::Remove(vec![completion_key.clone()]))
+                        {
+                            tracing::warn!(
+                                %error,
+                                key = %completion_key,
+                                "failed to enqueue index removal for evicted conflicting key"
+                            );
+                        }
+                    }
                     state_ref.artifacts.remove(&completion_key);
                 }
                 Err(error) => {

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -70,6 +70,11 @@ pub(in crate::daemon::server) enum StagedPublishFailure {
     GenerationPublish,
     PointerCommit,
     IndexCommit,
+    /// Two complete, internally valid generations disagree for one key.
+    ///
+    /// Since #1244 this outcome also **evicts** the key: the prior generation
+    /// and its pointer are removed rather than left as the authoritative
+    /// answer. See the conflict branch in `publish_staged_generation`.
     Conflict,
 }
 
@@ -732,6 +737,38 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
             let previous = previous_value.trim();
             if !previous.is_empty() && previous != generation_hex {
                 if validate_staged_generation(artifact_dir, key_hex, previous).is_ok() {
+                    // #1244: the key has now been *proven* not to determine
+                    // the bytes — two complete, internally valid generations
+                    // disagree. Preserving either one means serving an answer
+                    // we know might be wrong, which is a silent miscompile.
+                    //
+                    // Evict instead, so the next lookup is an honest miss.
+                    // This is the "failure mode is a miss, never a wrong
+                    // answer" invariant stated for the pending-write path.
+                    //
+                    // Removal is best-effort and deliberately non-fatal,
+                    // mirroring the replaced-invalid-generation path below: on
+                    // Windows another session may hold the generation tree
+                    // open mid-materialization, and a sharing violation must
+                    // not turn a detected conflict into a hard publish error.
+                    let mut evicted = true;
+                    let previous_path = generation_dir(artifact_dir, key_hex, previous);
+                    if let Err(error) = remove_staged_tree(&previous_path) {
+                        evicted = false;
+                        tracing::warn!(
+                            path = %previous_path.display(),
+                            %error,
+                            "failed to remove conflicting staged generation"
+                        );
+                    }
+                    if let Err(error) = remove_staged_tree(&pointer) {
+                        evicted = false;
+                        tracing::warn!(
+                            path = %pointer.display(),
+                            %error,
+                            "failed to remove staged pointer for conflicting key"
+                        );
+                    }
                     write_staged_lifecycle_event(
                         artifact_dir,
                         crate::core::lifecycle::EVENT_STAGED_PUBLICATION_CONFLICT,
@@ -739,6 +776,7 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
                             "cache_key": key_hex,
                             "existing_generation": previous,
                             "candidate_generation": generation_hex,
+                            "evicted": evicted,
                             "elapsed_ns": publish_started.elapsed().as_nanos() as u64,
                         }),
                     );
@@ -747,7 +785,8 @@ pub(in crate::daemon::server) fn persist_staged_artifact_paths(
                         cache_key = key_hex,
                         existing_generation = previous,
                         candidate_generation = generation_hex,
-                        "same cache key produced a different complete output generation"
+                        evicted,
+                        "same cache key produced a different complete output generation; evicting the key"
                     );
                     return Err(publish_error(
                         StagedPublishFailure::Conflict,

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store_tests.rs
@@ -117,7 +117,7 @@ fn staged_generation_publishes_beyond_legacy_max_path() {
 }
 
 #[test]
-fn staged_publication_rejects_nondeterministic_same_key_output() {
+fn staged_publication_evicts_nondeterministic_same_key_output() {
     let dir = tempfile::tempdir().unwrap();
     let _cache_dir = crate::daemon::server::tests::CacheDirEnvGuard::set(dir.path());
     let artifact_dir = dir.path().join("artifacts");
@@ -131,12 +131,15 @@ fn staged_publication_rejects_nondeterministic_same_key_output() {
     let error = persist_staged_artifact_paths(&artifact_dir, &key, &sources).unwrap_err();
     assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
 
-    let payloads = load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
-        .unwrap()
-        .unwrap();
-    assert_eq!(fs::read(&payloads[0]).unwrap(), b"first immutable payload");
-    assert_eq!(fs::read(&payloads[1]).unwrap(), b"second immutable payload");
-    assert!(!same_file(sources[0].as_path(), payloads[0].as_path()));
+    // #1244: the key has been proven not to determine the bytes, so neither
+    // candidate may be served. Previously the first generation was preserved
+    // and kept being handed out — a silent miscompile. It must now be a miss.
+    assert!(
+        load_staged_artifact_paths(&artifact_dir, &key, &[23, 24])
+            .unwrap()
+            .is_none(),
+        "conflicting key must be evicted, not left resolving to the stale generation"
+    );
 
     let log = fs::read_to_string(
         dir.path()
@@ -153,6 +156,11 @@ fn staged_publication_rejects_nondeterministic_same_key_output() {
         .expect("durable staged publication conflict event");
     assert_ne!(event["existing_generation"], event["candidate_generation"]);
     assert!(event["elapsed_ns"].as_u64().is_some());
+    assert_eq!(
+        event["evicted"],
+        serde_json::Value::Bool(true),
+        "conflict event must record whether the eviction actually landed"
+    );
 }
 
 #[test]
@@ -331,13 +339,20 @@ fn concurrent_same_key_publishers_never_overwrite_each_other() {
             .count(),
         1
     );
-    let payloads = load_staged_artifact_paths(&artifact_dir, &key, &[12])
-        .unwrap()
-        .unwrap();
-    assert!(matches!(
-        fs::read(&payloads[0]).unwrap().as_slice(),
-        b"generation-a" | b"generation-b"
-    ));
+    // #1244: two publishers racing the *same* key with *different* bytes is
+    // itself the non-determinism case. The winner is no more trustworthy than
+    // the loser, so the key is evicted rather than resolving to whichever
+    // thread happened to arrive first.
+    //
+    // The invariant this test guards is unchanged: no interleaving is ever
+    // observable, and a partially-written generation is never exposed. What
+    // changed is that "one of the two survives" became "neither survives".
+    assert!(
+        load_staged_artifact_paths(&artifact_dir, &key, &[12])
+            .unwrap()
+            .is_none(),
+        "racing publishers with differing bytes must evict, not pick a winner"
+    );
 }
 
 #[test]

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -138,9 +138,16 @@ v1 and pack formats remain readable during rollout.
 Publication holds a shared store lock plus an exclusive per-key lock. Cleanup
 and cache Clear hold the store lock exclusively, so neither can remove an
 active transaction. If a valid generation already exists and the same cache
-key produces different bytes, publication fails closed, preserves the first
-generation, and emits a durable `staged_publication_conflict` lifecycle event.
-An invalid/corrupt prior generation may be replaced and is recorded as
+key produces different bytes, publication fails closed **and evicts the key**:
+the prior generation and its pointer are removed, so the next lookup is a
+miss rather than a possibly-wrong hit. Once two complete, internally valid
+generations disagree, the key has been proven not to determine the bytes, and
+serving either candidate would be a silent miscompile. The eviction is
+best-effort — a removal that loses a race (for example a Windows sharing
+violation while another session materializes the generation) is reported via
+the `evicted` field rather than escalating into a publish error. Both cases
+emit a durable `staged_publication_conflict` lifecycle event. An
+invalid/corrupt prior generation may be replaced and is recorded as
 `staged_publication_replaces_invalid_generation`.
 
 Mixed-format lookup is explicit during migration: v2 is attempted first,


### PR DESCRIPTION
Closes #1244.

## The bug

When two complete, internally valid generations disagreed for one cache key, `publish_staged_generation` emitted the conflict event and returned early — leaving the **first** generation authoritative (pointer unchanged, index row unchanged) while discarding the generation that was correct for the build in progress.

So the daemon proved the key did not determine the bytes, and then kept serving the stale answer.

That is a silent miscompile, not a caching inefficiency. It was observed in the wild as a bad `windows` rlib: `cargo test` failed under the cache, and the identical command with `--no-cache` succeeded.

## The fix

Evict the key. Under the already-held exclusive publish lock, remove the prior generation tree and its pointer, and drop the index row from the detached persist path. The next lookup is then an honest miss.

This is the *"failure mode is a miss, never a wrong answer"* invariant the pending-write path already states — the staged publication path just wasn't honoring it.

**Removal is best-effort and deliberately non-fatal**, mirroring the existing replaced-invalid-generation path a few lines below. On Windows another session can hold the generation tree open mid-materialization, and a sharing violation must not escalate a *detected* conflict into a hard publish error. The lifecycle event now carries an `evicted` field so a partial eviction is visible rather than silent.

**No new failure variant.** I initially added `ConflictEvicted`, and the compiler pointed out `Conflict` was then never constructed — eviction is the only conflict outcome now, so a second variant was pure ceremony. `Conflict` simply means "detected and evicted", which also avoids a new `id()` string, a new fault-matrix row, and a new stats bucket.

## Two tests rewritten, not patched

Both asserted the behavior being removed:

- **`staged_publication_rejects_…` → `…_evicts_…`** — now asserts the key resolves to nothing instead of returning the stale payload, and that the conflict event records `evicted: true`.
- **`concurrent_same_key_publishers_never_overwrite_each_other`** — this one is a genuine semantic decision, not a mechanical edit. Two threads racing the same key with *different* bytes is itself the non-determinism case, so neither survives. The invariant the test actually guards — no interleaving is ever observable, no partial generation is ever exposed — is unchanged; what changed is that "one of the two survives" became "neither does".

## Availability trade-off

A persistently non-deterministic key now becomes a permanent miss with repeated evictions, rather than a stable wrong answer. That is the correct trade — a wrong answer is unbounded damage, a miss is bounded cost — but it does mean the `bounded_publication_conflicts` audit rule (max 1 per run) may start tripping in perf runs while such keys exist.

The follow-up making `-C incremental` compiles non-cacheable removes the dominant source of those keys. That precondition is confirmed live: 28 of 400 sampled compile-journal entries carry `-C incremental=…cargo-target\pep517\…` — the same lane that miscompiled — and `parse_rustc.rs` already documents incremental as able to "alter codegen-unit partitioning (and thus internal symbol names) between otherwise-identical compiles."

## Docs

`docs/architecture/artifact-store.md` stated publication "preserves the first generation", which now contradicts the code. Rewritten to describe eviction, the proof-of-non-determinism rationale, and the best-effort semantics.

## Validation

- `cargo test -p zccache-daemon-core --lib --features test-support` → **662 passed, 0 failed**
- `cargo fmt --all -- --check` → clean
- `cargo clippy -p zccache-daemon-core --all-targets --features test-support -- -D warnings` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
