### PR TITLE
fix(watchdog): never return a failed compile with no explanation (soldr#1857)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/child_watchdog.rs
+++ b/crates/zccache-daemon-core/src/daemon/child_watchdog.rs
@@ -311,6 +311,15 @@ async fn watchdog_inner_impl(
     let mut ebuf = vec![0u8; 64 * 1024];
     let mut stdout_done = stdout.is_none();
     let mut stderr_done = stderr.is_none();
+    // Pipe-read failures, kept rather than discarded (soldr#1857). An
+    // `io::Error` here ends the drain exactly like a clean EOF, so without
+    // recording it a broken pipe is indistinguishable from "the child printed
+    // nothing" — and the caller is left with a non-zero exit and no cause. The
+    // module contract above is explicit that the watchdog complains loudly and
+    // writes a durable event when it abandons a drain; these two arms were the
+    // one path that did neither.
+    let mut stdout_read_error: Option<std::io::Error> = None;
+    let mut stderr_read_error: Option<std::io::Error> = None;
     // Exit status + the instant the child exited, captured together so the
     // grace deadline never needs an `unwrap`.
     let mut exited: Option<(ExitStatus, Instant)> = None;
@@ -328,6 +337,26 @@ async fn watchdog_inner_impl(
     loop {
         // Clean completion: process exited AND both pipes reached EOF.
         if let (Some((status, _)), true, true) = (exited, stdout_done, stderr_done) {
+            if let Some(e) = stderr_read_error.as_ref().or(stdout_read_error.as_ref()) {
+                emit_pipe_read_error_diagnostics(
+                    cmd_desc,
+                    child_pid,
+                    e,
+                    stdout_read_error.is_some(),
+                    stderr_read_error.is_some(),
+                    stdout_bytes,
+                    stderr_bytes,
+                    &status,
+                );
+                deliver_fault_note(
+                    &status,
+                    stderr_bytes,
+                    stream.as_ref(),
+                    &mut err,
+                    &format!("reading its output pipe failed ({e})"),
+                )
+                .await;
+            }
             return Ok(Output {
                 status,
                 stdout: out,
@@ -387,7 +416,10 @@ async fn watchdog_inner_impl(
                     }
                     last_progress = Instant::now();
                 }
-                Err(_) => stdout_done = true,
+                Err(e) => {
+                    stdout_read_error = Some(e);
+                    stdout_done = true;
+                }
             },
             r = read_opt(stderr.as_mut(), &mut ebuf), if !stderr_done => match r {
                 Ok(0) => stderr_done = true,
@@ -406,7 +438,10 @@ async fn watchdog_inner_impl(
                     }
                     last_progress = Instant::now();
                 }
-                Err(_) => stderr_done = true,
+                Err(e) => {
+                    stderr_read_error = Some(e);
+                    stderr_done = true;
+                }
             },
             () = grace_deadline, if exited.is_some() => {
                 if let Some((status, at)) = exited {
@@ -461,17 +496,118 @@ async fn watchdog_inner_impl(
                     // caller holds is freed as soon as we return.
                     let _ = child.start_kill();
                     return match child.wait().await {
-                        Ok(status) => Ok(Output {
-                            status,
-                            stdout: out,
-                            stderr: err,
-                        }),
+                        Ok(status) => {
+                            deliver_fault_note(
+                                &status,
+                                stderr_bytes,
+                                stream.as_ref(),
+                                &mut err,
+                                &format!(
+                                    "zccache killed it after {}s with no output and no CPU                                      progress (ZCCACHE_STALL_WINDOW_MS)",
+                                    stall_window.as_secs()
+                                ),
+                            )
+                            .await;
+                            Ok(Output {
+                                status,
+                                stdout: out,
+                                stderr: err,
+                            })
+                        }
                         Err(e) => Err(e),
                     };
                 }
             }
         }
     }
+}
+
+/// Give a failing child's output a cause when the child itself supplied none.
+///
+/// Why this is needed at all: on Windows [`Child::start_kill`] is
+/// `TerminateProcess(handle, 1)`, so a child **we** killed reports **exactly**
+/// `exit code 1` — byte-identical to a genuine `rustc` failure. Mode B only
+/// fires when there has been no output, so stderr is empty by construction.
+/// The caller therefore saw `error: could not compile <crate>` with an empty
+/// cause and no way to tell "your code is broken" from "we shot the compiler".
+/// On Unix the same kill yields `status.code() == None` (reported as `-1`),
+/// which is precisely why this only ever reproduced on Windows (soldr#1857).
+///
+/// Only annotates when the child both failed and said nothing: `stderr_bytes`
+/// counts bytes actually read from the pipe, so it is the honest signal on the
+/// streaming path too (where `err` stays empty because bytes went to the
+/// consumer rather than the buffer). A compile that produced real diagnostics
+/// is never touched.
+async fn deliver_fault_note(
+    status: &ExitStatus,
+    stderr_bytes: usize,
+    stream: Option<&mpsc::Sender<RawOutputChunk>>,
+    err: &mut Vec<u8>,
+    reason: &str,
+) {
+    if status.success() || stderr_bytes > 0 {
+        return;
+    }
+    let note = format!(
+        "zccache: the compiler produced no diagnostics — {reason}
+"
+    )
+    .into_bytes();
+    match stream {
+        // Streaming path: the buffered `err` is discarded downstream, so the
+        // note has to travel as a chunk or it never reaches the caller.
+        Some(sender) => {
+            let _ = sender.send(RawOutputChunk::Stderr(note)).await;
+        }
+        None => err.extend_from_slice(&note),
+    }
+}
+
+/// Complain about a pipe-read failure, matching the forensics contract in this
+/// module's header: warn loudly and write a durable lifecycle event.
+///
+/// Before soldr#1857 both read arms were `Err(_) => done = true`, which ended
+/// the drain exactly like a clean EOF while discarding the error. That made a
+/// broken pipe the one output-loss path in this file with **no** telemetry at
+/// all, so a non-zero exit with empty stderr was unattributable after the fact.
+#[allow(clippy::too_many_arguments)]
+fn emit_pipe_read_error_diagnostics(
+    cmd_desc: &str,
+    pid: Option<u32>,
+    error: &std::io::Error,
+    stdout_failed: bool,
+    stderr_failed: bool,
+    stdout_bytes: usize,
+    stderr_bytes: usize,
+    status: &ExitStatus,
+) {
+    tracing::warn!(
+        event = "child_wait_watchdog_fired",
+        stage = "pipe_read_error",
+        cmd = %cmd_desc,
+        pid = pid.unwrap_or(0),
+        error = %error,
+        stdout_failed,
+        stderr_failed,
+        stdout_bytes,
+        stderr_bytes,
+        exit_code = status.code().unwrap_or(-1),
+        "reading the child's output pipe failed; the drain ended early and any          diagnostics still buffered in that pipe are lost. The exit status is          still the child's real one, so a non-zero exit here may carry no          explanation of its own (soldr#1857)."
+    );
+    crate::core::lifecycle::write_event(
+        crate::core::lifecycle::EVENT_CHILD_WAIT_WATCHDOG_FIRED,
+        serde_json::json!({
+            "stage": "pipe_read_error",
+            "cmd": cmd_desc,
+            "pid": pid,
+            "error": error.to_string(),
+            "stdout_failed": stdout_failed,
+            "stderr_failed": stderr_failed,
+            "stdout_bytes": stdout_bytes,
+            "stderr_bytes": stderr_bytes,
+            "exit_code": status.code(),
+        }),
+    );
 }
 
 /// Read into `buf` from an optional reader, or pend forever when the reader is
@@ -587,6 +723,64 @@ mod tests {
             .stdin(Stdio::null())
             .kill_on_drop(true);
         cmd
+    }
+
+    /// soldr#1857: a failing child that explained nothing must come back with a
+    /// synthesized cause, so the caller is never left with a bare non-zero exit.
+    #[tokio::test]
+    async fn silent_failure_gets_a_synthesized_cause() {
+        let status = status_of(1).await;
+        let mut err = Vec::new();
+        deliver_fault_note(&status, 0, None, &mut err, "we killed it for testing").await;
+
+        let text = String::from_utf8_lossy(&err).into_owned();
+        assert!(
+            text.contains("produced no diagnostics"),
+            "expected the silence to be named; got {text:?}"
+        );
+        assert!(
+            text.contains("we killed it for testing"),
+            "expected the reason to be carried through; got {text:?}"
+        );
+    }
+
+    /// The guard that keeps this from becoming noise: a child that already
+    /// explained itself is left byte-for-byte alone.
+    #[tokio::test]
+    async fn failure_with_diagnostics_is_not_annotated() {
+        let status = status_of(1).await;
+        let mut err = b"error[E0308]: mismatched types
+"
+        .to_vec();
+        let before = err.clone();
+        // stderr_bytes > 0 == the child said something.
+        deliver_fault_note(&status, err.len(), None, &mut err, "irrelevant").await;
+
+        assert_eq!(err, before);
+    }
+
+    /// A successful compile is silent by design and must never be annotated.
+    #[tokio::test]
+    async fn success_is_never_annotated() {
+        let status = status_of(0).await;
+        let mut err = Vec::new();
+        deliver_fault_note(&status, 0, None, &mut err, "irrelevant").await;
+
+        assert!(err.is_empty(), "exit 0 must stay silent, got {err:?}");
+    }
+
+    /// A real `ExitStatus` with the requested code. `ExitStatus` has no
+    /// portable constructor, so spawn a shell that exits with it.
+    async fn status_of(code: i32) -> ExitStatus {
+        #[cfg(windows)]
+        let mut cmd = tokio::process::Command::new("cmd");
+        #[cfg(windows)]
+        cmd.args(["/c", &format!("exit {code}")]);
+        #[cfg(unix)]
+        let mut cmd = tokio::process::Command::new("sh");
+        #[cfg(unix)]
+        cmd.args(["-c", &format!("exit {code}")]);
+        cmd.status().await.expect("spawn child")
     }
 
     /// Happy path: a well-behaved child that prints and exits must return its

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/error_cache.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/error_cache.rs
@@ -27,8 +27,18 @@ fn should_cache_rustc_error(
     rustc_args: &crate::depgraph::RustcParsedArgs,
     exit_code: i32,
     cwd: &Path,
+    stderr: &[u8],
 ) -> bool {
-    exit_code > 0
+    // A failure that explained nothing is not a compile error worth
+    // remembering. On Windows a child the watchdog kills exits with exactly
+    // code 1 and no stderr (`TerminateProcess(handle, 1)`), which is
+    // indistinguishable here from a genuine rustc rejection — see
+    // `child_watchdog::deliver_fault_note` and soldr#1857. Caching one of those
+    // turns a transient, load-dependent fault into a sticky replayed
+    // `cached_error` for every later build of that unit, which is far worse
+    // than simply recompiling.
+    !stderr.is_empty()
+        && exit_code > 0
         && rustc_depinfo_exists(rustc_args, cwd)
         && !rustc_args.emit_types.iter().any(|emit| emit == "link")
 }
@@ -46,7 +56,7 @@ pub(super) async fn maybe_store_rustc_error_artifact(
     exit_code: i32,
     snap_clock: Clock,
 ) -> Option<String> {
-    if !should_cache_rustc_error(rustc_args, exit_code, cwd_path) {
+    if !should_cache_rustc_error(rustc_args, exit_code, cwd_path, stderr) {
         return None;
     }
 
@@ -179,15 +189,22 @@ mod tests {
         ];
         let parsed = crate::depgraph::parse_rustc_args(&args, tmp.path());
 
-        assert!(!should_cache_rustc_error(&parsed, 1, tmp.path()));
+        assert!(!should_cache_rustc_error(&parsed, 1, tmp.path(), b"boom"));
 
         std::fs::write(tmp.path().join("probe.d"), "probe.d: probe.rs\n").unwrap();
-        assert!(should_cache_rustc_error(&parsed, 1, tmp.path()));
-        assert!(!should_cache_rustc_error(&parsed, -1, tmp.path()));
+        assert!(should_cache_rustc_error(&parsed, 1, tmp.path(), b"boom"));
+        assert!(!should_cache_rustc_error(&parsed, -1, tmp.path(), b"boom"));
+        // soldr#1857: a failure with no diagnostics must never be cached.
+        assert!(!should_cache_rustc_error(&parsed, 1, tmp.path(), b""));
 
         let mut link_args = args.clone();
         link_args[2] = "--emit=dep-info,link".to_string();
         let link_parsed = crate::depgraph::parse_rustc_args(&link_args, tmp.path());
-        assert!(!should_cache_rustc_error(&link_parsed, 1, tmp.path()));
+        assert!(!should_cache_rustc_error(
+            &link_parsed,
+            1,
+            tmp.path(),
+            b"boom"
+        ));
     }
 }


### PR DESCRIPTION
Fixes the root cause of soldr#1857.

## Symptom

On Windows, ~**2.8%** of compiles dispatched to the embedded service came back with `exit_code: 1` and **completely empty stderr** — Cargo printed `error: could not compile <crate>` with no cause. Measured 29 failures in 1050 compiles in a single window, on innocuous third-party crates (`constant_time_eq`, `windows`, `ring`) that build fine on retry.

It reads as flakiness rather than a defect, and it makes a real regression indistinguishable from noise.

## Root cause — two mechanisms, both Windows-specific

**1. A kill is indistinguishable from a compile failure.**

`Child::start_kill` is `TerminateProcess(handle, 1)` on Windows, so a child **we** killed reports **exactly exit code 1** — byte-identical to a genuine rustc rejection. Mode B only fires when there has been no output, so stderr is empty by construction.

On Unix the same kill yields `status.code() == None` (reported as `-1`). That asymmetry is precisely why this only ever reproduced on Windows, and why it went unexplained for so long.

**2. Pipe-read failures were discarded.**

Both drain arms did `Err(_) => done = true` — ending the drain exactly like a clean EOF while dropping the `io::Error` on the floor. No warning, no metric, no lifecycle event. It was the only output-loss path in this file with **zero** telemetry, which directly contradicts the contract stated in the module's own header:

> When the grace elapses the watchdog abandons the drain, returns the output captured so far with the real exit status, and — per the daemon's forensics rule — complains loudly (`tracing::warn!`) and writes a durable lifecycle event so the wedge is investigable after the fact.

**3. The amplifier.** `should_cache_rustc_error` had no emptiness check, so an exit-1-with-empty-stderr whose `.d` file happened to exist was stored and replayed as `cached_error` for every later build of that unit — turning a transient, load-dependent fault permanently sticky.

## The fix

- **`deliver_fault_note`** synthesizes a cause whenever a child both failed *and* said nothing, naming the reason (stall kill with the window, or the pipe error). It keys off `stderr_bytes` — bytes actually read — rather than the `err` buffer, so it stays honest on the streaming path where bytes go to the consumer and `err` is empty by design. A compile that produced real diagnostics is never touched.
- **Pipe-read errors are captured and reported**: `tracing::warn!` plus a durable `EVENT_CHILD_WAIT_WATCHDOG_FIRED` lifecycle event with a new `pipe_read_error` stage, carrying the error, which stream failed, byte counts, and the exit code.
- **`should_cache_rustc_error` now requires non-empty stderr.**

## Tests

Three new cases pin the boundary so this cannot become noise:

| Test | Asserts |
|---|---|
| `silent_failure_gets_a_synthesized_cause` | failure + silence → the cause is named and carried through |
| `failure_with_diagnostics_is_not_annotated` | an existing `error[E0308]` is left **byte-for-byte** alone |
| `success_is_never_annotated` | exit 0 stays silent |

Plus an `error_cache` case asserting an empty-stderr failure is never cached.

## Validation

- `cargo test -p zccache-daemon-core --features test-support --lib child_watchdog` — **12 passed** (9 pre-existing + 3 new)
- `cargo test -p zccache-daemon-core --features test-support --lib error_cache` — **2 passed**
- `cargo clippy -p zccache-daemon-core --all-targets --features test-support -- -D warnings` — clean

## Caveat worth stating

This makes the fault **identifiable and non-sticky**; whether it also makes it *rarer* depends on why children were being killed or pipes breaking in the first place. The honest expectation is that failures now arrive with a cause naming which mechanism fired, which is what turns soldr#1857 from a mystery into something measurable. Confirmation will be by absence over time plus the new lifecycle events, not by a single green run.
