### PR TITLE
feat(lifecycle): give child terminations their own log file (soldr#1857)

### DIFF
--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -351,6 +351,36 @@ pub fn write_event(event_name: &str, extra: serde_json::Value) {
     }
 }
 
+/// Filename of the dedicated child-termination log.
+///
+/// Every process the daemon kills, and every child whose output pipe fails,
+/// is recorded here **in addition to** the main lifecycle log.
+pub const TERMINATION_LOG_FILENAME: &str = "child-terminations.jsonl";
+
+/// Append an event to a dedicated log file beside the main lifecycle log.
+///
+/// The lifecycle log interleaves every daemon event, so counting how often
+/// children are force-terminated means grepping a busy, rotating file and
+/// hoping nothing aged out. Terminations are the signal people actually chase
+/// when builds die without an explanation (soldr#1857), so they get their own
+/// stream — `logs/<file_name>` — which stays readable and countable with a
+/// plain `wc -l`.
+///
+/// Deliberately *additive*: callers still write the lifecycle event too, so
+/// existing tooling and the chronological daemon narrative are unaffected.
+/// Best-effort like the rest of this module — a failure here never disturbs
+/// the caller.
+pub fn write_event_to_named_log(file_name: &str, event_name: &str, extra: serde_json::Value) {
+    let log_path = super::config::log_dir().join(file_name);
+    if let Err(e) = try_write_to_path(log_path.as_path(), event_name, &extra) {
+        tracing::warn!(
+            event = event_name,
+            log = file_name,
+            "failed to write dedicated log event: {e}"
+        );
+    }
+}
+
 /// Write an event beneath an explicitly selected daemon-state root.
 ///
 /// Daemons embedded in tests and hosts can use a cache root that differs from
@@ -535,6 +565,47 @@ mod tests {
                 None => std::env::remove_var(crate::config::DAEMON_NAMESPACE_ENV),
             }
         }
+    }
+
+    #[test]
+    fn dedicated_log_receives_events_without_disturbing_the_lifecycle_log() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _env = EnvGuard::set_cache_dir(tmp.path());
+
+        write_event_to_named_log(
+            TERMINATION_LOG_FILENAME,
+            EVENT_CHILD_WAIT_WATCHDOG_FIRED,
+            serde_json::json!({"stage": "alive_hung_no_progress", "pid": 4242u64}),
+        );
+
+        let dedicated = crate::config::log_dir()
+            .as_path()
+            .join(TERMINATION_LOG_FILENAME);
+        let contents = std::fs::read_to_string(&dedicated).expect("dedicated log written");
+        let mine: Vec<serde_json::Value> = contents
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("line parses"))
+            .filter(|v| v["pid"] == 4242)
+            .collect();
+        assert_eq!(mine.len(), 1, "expected exactly our event: {contents}");
+        assert_eq!(mine[0]["event"], EVENT_CHILD_WAIT_WATCHDOG_FIRED);
+        assert_eq!(mine[0]["stage"], "alive_hung_no_progress");
+        // The envelope is the same as the main log's, so existing tooling
+        // parses this file unchanged.
+        assert!(mine[0]["ts_ms"].is_number(), "missing ts_ms envelope field");
+
+        // The whole point is that this is a *separate* stream: writing here
+        // must not append to the interleaved lifecycle log.
+        let lifecycle = log_file_path().as_path().to_path_buf();
+        let lifecycle_has_ours = std::fs::read_to_string(&lifecycle)
+            .unwrap_or_default()
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .any(|v| v["pid"] == 4242);
+        assert!(
+            !lifecycle_has_ours,
+            "dedicated-log write must not also land in the lifecycle log"
+        );
     }
 
     #[test]

--- a/crates/zccache-daemon-core/src/daemon/child_watchdog.rs
+++ b/crates/zccache-daemon-core/src/daemon/child_watchdog.rs
@@ -608,6 +608,23 @@ fn emit_pipe_read_error_diagnostics(
             "exit_code": status.code(),
         }),
     );
+    // Also record it in the dedicated termination stream so these are
+    // countable without grepping the interleaved lifecycle log (#1857).
+    crate::core::lifecycle::write_event_to_named_log(
+        crate::core::lifecycle::TERMINATION_LOG_FILENAME,
+        crate::core::lifecycle::EVENT_CHILD_WAIT_WATCHDOG_FIRED,
+        serde_json::json!({
+            "stage": "pipe_read_error",
+            "cmd": cmd_desc,
+            "pid": pid,
+            "error": error.to_string(),
+            "stdout_failed": stdout_failed,
+            "stderr_failed": stderr_failed,
+            "stdout_bytes": stdout_bytes,
+            "stderr_bytes": stderr_bytes,
+            "exit_code": status.code(),
+        }),
+    );
 }
 
 /// Read into `buf` from an optional reader, or pend forever when the reader is
@@ -668,6 +685,24 @@ fn emit_orphan_pipe_diagnostics(
             "reason": "orphaned grandchild inherited the pipe write handle; drain abandoned to free the compile-concurrency permit",
         }),
     );
+    // Also record it in the dedicated termination stream so these are
+    // countable without grepping the interleaved lifecycle log (#1857).
+    crate::core::lifecycle::write_event_to_named_log(
+        crate::core::lifecycle::TERMINATION_LOG_FILENAME,
+        crate::core::lifecycle::EVENT_CHILD_WAIT_WATCHDOG_FIRED,
+        serde_json::json!({
+            "stage": "post_exit_pipe_drain",
+            "cmd": cmd_desc,
+            "pid": pid,
+            "grace_ms": grace.as_millis() as u64,
+            "elapsed_since_exit_ms": elapsed_since_exit.as_millis() as u64,
+            "stdout_bytes": stdout_bytes,
+            "stderr_bytes": stderr_bytes,
+            "stdout_eof": stdout_done,
+            "stderr_eof": stderr_done,
+            "reason": "orphaned grandchild inherited the pipe write handle; drain abandoned to free the compile-concurrency permit",
+        }),
+    );
 }
 
 /// Loud + durable diagnostics for a fired alive-hung (Mode B) watchdog, per the
@@ -698,6 +733,22 @@ fn emit_stall_diagnostics(
          CPU is never affected."
     );
     crate::core::lifecycle::write_event(
+        crate::core::lifecycle::EVENT_CHILD_WAIT_WATCHDOG_FIRED,
+        serde_json::json!({
+            "stage": "alive_hung_no_progress",
+            "cmd": cmd_desc,
+            "pid": pid,
+            "stall_window_ms": stall_window.as_millis() as u64,
+            "since_progress_ms": since_progress.as_millis() as u64,
+            "stdout_bytes": stdout_bytes,
+            "stderr_bytes": stderr_bytes,
+            "reason": "no output and no CPU progress for the stall window; killed as wedged",
+        }),
+    );
+    // Also record it in the dedicated termination stream so these are
+    // countable without grepping the interleaved lifecycle log (#1857).
+    crate::core::lifecycle::write_event_to_named_log(
+        crate::core::lifecycle::TERMINATION_LOG_FILENAME,
         crate::core::lifecycle::EVENT_CHILD_WAIT_WATCHDOG_FIRED,
         serde_json::json!({
             "stage": "alive_hung_no_progress",


### PR DESCRIPTION
Follow-up to #1247, which added the detection. This makes force-terminations **trackable**.

## Why

`child_wait_watchdog_fired` events were only written to the main lifecycle log — interleaved with every other daemon event, in a file that rotates. Answering "how often are children actually being killed?" meant grepping a busy log and hoping nothing had aged out. That is exactly the question you end up asking when builds die with no explanation.

## What

Mirror every termination event into a dedicated `logs/child-terminations.jsonl`, covering all three paths:

- Mode A — orphan-pipe post-exit grace
- Mode B — stall kill (`TerminateProcess(handle, 1)`, the one that aliases onto `exit 1` on Windows)
- pipe-read error — added in #1247

`wc -l logs/child-terminations.jsonl` is now a direct answer, and `jq` over it gives the breakdown by `stage`.

## Deliberately additive

Callers still write the lifecycle event too, so the chronological daemon narrative and any existing tooling are untouched. The dedicated rows carry the **identical envelope** (`ts_ms`, `event`, `pid`, `daemon_namespace`), so the same parsers work on both files. Best-effort like the rest of the module — a failure to write here never disturbs the caller.

## Validation

- `cargo test -p zccache-core --lib lifecycle` — **13 passed**, including a new case asserting the event lands in the dedicated file with the standard envelope **and does not also land in** the lifecycle log
- `cargo clippy -p zccache-core -p zccache-daemon-core --all-targets --features test-support -- -D warnings` — clean

Refs soldr#1857