### PR TITLE
test(daemon): stop asserting logical invariants with wall-clock margins (#1254)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/tests/link_cache.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/link_cache.rs
@@ -410,17 +410,24 @@ async fn side_effect_lock_allows_different_output_directories() {
     assert!(std::sync::Arc::ptr_eq(&lock_a, &same_lock_a));
     assert!(!std::sync::Arc::ptr_eq(&lock_a, &lock_b));
 
-    let _guard_a = lock_a.lock_owned().await;
-    let _guard_b = tokio::time::timeout(std::time::Duration::from_millis(50), lock_b.lock_owned())
-        .await
+    // #1254: these were `tokio::time::timeout(50ms, lock_owned())`, which made
+    // a *logical* claim ("b is not blocked by a") depend on wall-clock
+    // scheduling. Acquiring an uncontended mutex is instant, but under the
+    // parallel test load of this crate the task can simply fail to be
+    // scheduled inside 50 ms, and the test then reports contention that never
+    // happened. It failed on arm in CI and on Windows locally within an hour.
+    //
+    // `try_lock_owned` answers the same question with no deadline at all:
+    // uncontended succeeds immediately, contended fails immediately. There is
+    // no duration left for load to distort.
+    let _guard_a = lock_a
+        .try_lock_owned()
+        .expect("an unheld lock must be acquirable");
+    let _guard_b = lock_b
+        .try_lock_owned()
         .expect("a lock held for one output directory must not block another");
     assert!(
-        tokio::time::timeout(
-            std::time::Duration::from_millis(50),
-            same_lock_a.lock_owned(),
-        )
-        .await
-        .is_err(),
+        same_lock_a.try_lock_owned().is_err(),
         "the same output directory must remain exclusive"
     );
 }

--- a/crates/zccache-daemon-core/src/daemon/server/tests/pending_cache_writes.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/pending_cache_writes.rs
@@ -109,18 +109,33 @@ async fn pending_registry_warm_lookup_pays_no_wait() {
     let server = DaemonServer::bind(&endpoint).unwrap();
     let state = Arc::clone(&server.state);
 
+    // #1254: this asserted `elapsed < 2ms` against a 5ms wait budget. The
+    // claim is right -- the no-wait path must not consume the budget -- but a
+    // 2 ms wall-clock margin is smaller than the scheduling jitter this
+    // crate's parallel tests produce, so it failed intermittently while the
+    // code behaved correctly.
+    //
+    // Same claim, with a margin load cannot bridge: give the call a budget of
+    // seconds and assert it returned in a fraction of it. Falling through
+    // takes microseconds, so a passing run is still instant; only a genuine
+    // regression to waiting pays the budget, and it then misses this bound by
+    // orders of magnitude rather than by jitter.
+    const WAIT_BUDGET: Duration = Duration::from_secs(10);
+    const NO_WAIT_CEILING: Duration = Duration::from_secs(2);
+
     let start = Instant::now();
     let observed = pending_writes::await_pending(
         &state.pending_cache_writes,
         "warmkey0000000000000000000000000",
-        Duration::from_millis(5),
+        WAIT_BUDGET,
     )
     .await;
     let elapsed = start.elapsed();
 
     assert!(!observed, "no pending entry must report false");
     assert!(
-        elapsed < Duration::from_millis(2),
-        "warm-lookup no-wait path took {elapsed:?}"
+        elapsed < NO_WAIT_CEILING,
+        "warm-lookup no-wait path took {elapsed:?}, so it waited on the \
+         {WAIT_BUDGET:?} budget instead of falling through"
     );
 }


### PR DESCRIPTION
Advances #1254. Fixes the two flakes that share a root cause; the issue stays open for a third that does not.

## Root cause

Both tests proved a **logical** property by measuring **elapsed real time**, with margins smaller than the scheduling jitter this crate's parallel tests produce. The code was correct; the clock was the variable.

### `side_effect_lock_allows_different_output_directories`

```rust
let _guard_b = tokio::time::timeout(Duration::from_millis(50), lock_b.lock_owned())
    .await
    .expect("a lock held for one output directory must not block another");
```

Acquiring an *uncontended* mutex is instant. The failure mode was the task not being **scheduled** inside 50 ms, which the test then reported as contention that never occurred.

`try_lock_owned` answers the same question with no deadline at all — uncontended succeeds immediately, contended fails immediately. There is no duration left for load to distort.

### `pending_registry_warm_lookup_pays_no_wait`

```rust
assert!(elapsed < Duration::from_millis(2), "warm-lookup no-wait path took {elapsed:?}");
```

A 2 ms wall-clock margin against a 5 ms budget. The claim is right — the no-wait path must not consume the budget — the margin was not. Now the call gets a budget of **seconds** and the assertion allows a fraction of it: falling through still takes microseconds, so a passing run stays instant, while a genuine regression to waiting misses the bound by orders of magnitude rather than by jitter.

## Both keep their purpose

Verified rather than assumed: globalizing `link_output_lock` (making it ignore the output directory) still **fails** the first test — the #912 regression it exists to catch.

## Evidence

| | before | after |
|---|---|---|
| local full runs | 1 in 3 failed one of these | **4 consecutive clean** |

Prior data on the same tests: `side_effect_lock` failed on `arm / Test` in CI and on Windows locally within an hour; `pending_registry_warm_lookup_pays_no_wait` failed on a separate local run.

## Deliberately not included

- **`pending_cache_writes.rs:94`** uses the same shape (`elapsed < 100 ms` against a 5 ms budget) but with a 20x margin and has not been observed failing. Changing a passing test without evidence adds risk; flagging it instead.
- **`session_staged_attribution::concurrent_failed_requests_are_attributed_only_to_their_session`** flaked once during this validation and once earlier. It is a real concurrency test over IPC with a server task, not an elapsed-time assertion, so it has a different cause and needs its own diagnosis. #1254 stays open for it.

## Why this matters beyond tidiness

A flake at this rate lands on unrelated PRs and reads as their breakage. That happened repeatedly today — several real bugs were initially mis-attributed to whichever PR happened to surface them.
