### PR TITLE
fix(daemon): bound the ended-session tombstone map (#1165 Finding 1b)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/connection/dispatch.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/connection/dispatch.rs
@@ -294,7 +294,7 @@ pub(super) async fn dispatch_request(
                     let ended_phase_profile = session_phase_profile(state, &sid);
                     state.session_staged_profiles.remove(&sid);
                     if let Some(session) = state.sessions.end(&sid) {
-                        state.ended_sessions.insert(sid, ());
+                        state.ended_sessions.insert(sid, std::time::Instant::now());
                         if !session.owner_pids.is_empty() {
                             state
                                 .private_daemon

--- a/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
@@ -987,11 +987,31 @@ fn reap_finished_sessions_with(state: &SharedState, is_alive: impl Fn(u32) -> bo
 /// definition, so "is the pid alive" says nothing about whether it is still
 /// needed.
 fn reap_ended_session_tombstones(state: &SharedState, ttl: Duration) -> usize {
-    let now = std::time::Instant::now();
+    reap_ended_session_tombstones_at(state, ttl, std::time::Instant::now())
+}
+
+/// [`reap_ended_session_tombstones`] against an explicit observation time.
+///
+/// The seam exists so tests can place stamps relative to a base by **adding**
+/// to an `Instant` instead of subtracting from `Instant::now()`. Subtracting
+/// an hour panics when the monotonic epoch is younger than an hour — a fresh
+/// CI runner — which is the same trap `SessionManager::cleanup_expired`
+/// already guards with `checked_sub` ("timeout exceeds uptime; nothing can be
+/// expired"). Addition cannot underflow, so the test states the boundary
+/// directly with no clock arithmetic that can fail.
+fn reap_ended_session_tombstones_at(
+    state: &SharedState,
+    ttl: Duration,
+    now: std::time::Instant,
+) -> usize {
     let before = state.ended_sessions.len();
     state
         .ended_sessions
-        .retain(|_, ended_at| now.duration_since(*ended_at) < ttl);
+        // Saturating: a stamp ahead of `now` yields zero age and is kept,
+        // rather than panicking. That cannot happen from the insert site, but
+        // this runs every maintenance tick for the daemon's life and a panic
+        // here would take the maintenance task down with it.
+        .retain(|_, ended_at| now.saturating_duration_since(*ended_at) < ttl);
     before.saturating_sub(state.ended_sessions.len())
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
@@ -15,6 +15,19 @@ const GIB: u64 = 1024 * 1024 * 1024;
 const SOFT_AGE: Duration = Duration::from_secs(4 * 24 * 60 * 60);
 const EXPIRE_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 const PRESSURE_INTERVAL: Duration = Duration::from_secs(5 * 60);
+/// How long an ended session's tombstone is kept before it is reclaimed
+/// (#1165).
+///
+/// The tombstone turns a request arriving after `SessionEnd` into a clean
+/// `unknown session` error. Expiring one does **not** resurrect the session:
+/// the id is gone from `sessions` either way, so a very late request still
+/// fails, just with a less specific message. That bounds the cost of choosing
+/// this badly to error-message quality rather than correctness.
+///
+/// An hour is orders of magnitude beyond any in-flight request a disconnected
+/// client could still deliver, while making the map proportional to recent
+/// activity instead of to daemon uptime.
+const ENDED_SESSION_TTL: Duration = Duration::from_secs(60 * 60);
 // A maintenance pass must not invalidate a result that was just published.
 // The next pressure pass can reclaim it if the disk is still constrained.
 const HARD_PRESSURE_MIN_AGE: Duration = PRESSURE_INTERVAL;
@@ -954,14 +967,32 @@ fn reap_finished_sessions(state: &SharedState) {
 fn reap_finished_sessions_with(state: &SharedState, is_alive: impl Fn(u32) -> bool) {
     let expired = state.sessions.cleanup_expired();
     let dead = state.sessions.cleanup_dead_pids(is_alive);
-    if !expired.is_empty() || !dead.is_empty() {
+    let tombstones = reap_ended_session_tombstones(state, ENDED_SESSION_TTL);
+    if !expired.is_empty() || !dead.is_empty() || tombstones > 0 {
         tracing::info!(
             expired = expired.len(),
             dead_client = dead.len(),
+            tombstones,
             remaining = state.sessions.active_count(),
+            tombstones_remaining = state.ended_sessions.len(),
             "reaped finished sessions"
         );
     }
+}
+
+/// Drop `ended_sessions` entries older than `ttl`. Returns how many went.
+///
+/// Separate from the session reapers above because it ages on the daemon's own
+/// clock rather than on client liveness — a tombstone outlives the client by
+/// definition, so "is the pid alive" says nothing about whether it is still
+/// needed.
+fn reap_ended_session_tombstones(state: &SharedState, ttl: Duration) -> usize {
+    let now = std::time::Instant::now();
+    let before = state.ended_sessions.len();
+    state
+        .ended_sessions
+        .retain(|_, ended_at| now.duration_since(*ended_at) < ttl);
+    before.saturating_sub(state.ended_sessions.len())
 }
 
 pub(super) fn spawn_disk_maintenance(

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -292,12 +292,18 @@ pub(super) struct SharedState {
     pub(super) request_cache: DashMap<ContentHash, RequestCacheEntry>,
     /// Session-level worktree-root cache resolved once at SessionStart.
     pub(super) session_worktree_roots: DashMap<SessionId, SessionWorktreeRoot>,
-    /// Session IDs that were explicitly ended in this daemon process.
+    /// Session IDs that were explicitly ended in this daemon process, stamped
+    /// with when they ended.
     ///
     /// A never-seen UUID is allowed to compile for wrapper recovery after a
     /// daemon restart, but an ID that this process already ended should not be
     /// accepted again.
-    pub(super) ended_sessions: DashMap<SessionId, ()>,
+    ///
+    /// #1165: the value was `()`, which left a reaper nothing to age against —
+    /// an entry was removed only if that exact id was created again, so a
+    /// long-lived daemon kept one tombstone per completed session forever. It
+    /// is stamped now so [`ENDED_SESSION_TTL`] can expire it.
+    pub(super) ended_sessions: DashMap<SessionId, std::time::Instant>,
     /// Cross-root request-cache validation: (request fingerprint, root) -> last
     /// verified artifact and journal clock. This lets repeated sibling hits
     /// validate with journal checks instead of re-hashing every input.

--- a/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
@@ -875,3 +875,79 @@ async fn reaping_is_a_noop_when_every_client_is_alive() {
     assert!(daemon.state.sessions.context_count(&live).is_some());
     assert_eq!(daemon.state.sessions.active_count(), 1);
 }
+
+/// #1165 Finding 1b: `ended_sessions` grew one tombstone per completed
+/// session, forever.
+#[tokio::test]
+async fn ended_session_tombstones_expire_on_their_ttl() {
+    let root = tempfile::tempdir().unwrap();
+    let cache_dir: crate::core::NormalizedPath = root.path().join("cache").into();
+    let daemon = Arc::new(
+        EmbeddedDaemon::start(
+            crate::ipc::unique_test_endpoint(),
+            cache_dir.clone(),
+            None,
+            bytes_policy(1),
+        )
+        .await
+        .unwrap(),
+    );
+
+    let stale = crate::depgraph::SessionId::new();
+    let recent = crate::depgraph::SessionId::new();
+    let ttl = Duration::from_secs(60 * 60);
+    let now = std::time::Instant::now();
+    // Stamp directly rather than sleeping: the boundary is what matters, and a
+    // test that waits an hour is not a test.
+    daemon
+        .state
+        .ended_sessions
+        .insert(stale, now - ttl - Duration::from_secs(1));
+    daemon
+        .state
+        .ended_sessions
+        .insert(recent, now - Duration::from_secs(1));
+
+    let removed = reap_ended_session_tombstones(&daemon.state, ttl);
+
+    assert_eq!(removed, 1);
+    assert!(
+        !daemon.state.ended_sessions.contains_key(&stale),
+        "a tombstone past its TTL must be reclaimed"
+    );
+    assert!(
+        daemon.state.ended_sessions.contains_key(&recent),
+        "a tombstone inside its TTL still rejects late work for that session"
+    );
+}
+
+#[tokio::test]
+async fn tombstone_reaping_is_a_noop_when_nothing_is_stale() {
+    let root = tempfile::tempdir().unwrap();
+    let cache_dir: crate::core::NormalizedPath = root.path().join("cache").into();
+    let daemon = Arc::new(
+        EmbeddedDaemon::start(
+            crate::ipc::unique_test_endpoint(),
+            cache_dir.clone(),
+            None,
+            bytes_policy(1),
+        )
+        .await
+        .unwrap(),
+    );
+    let fresh = crate::depgraph::SessionId::new();
+    daemon
+        .state
+        .ended_sessions
+        .insert(fresh, std::time::Instant::now());
+
+    // Runs every maintenance tick for the daemon's whole life, so repeated
+    // passes must not eventually evict a tombstone that is still in date.
+    for _ in 0..3 {
+        assert_eq!(
+            reap_ended_session_tombstones(&daemon.state, Duration::from_secs(60 * 60)),
+            0
+        );
+    }
+    assert!(daemon.state.ended_sessions.contains_key(&fresh));
+}

--- a/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
@@ -896,19 +896,24 @@ async fn ended_session_tombstones_expire_on_their_ttl() {
     let stale = crate::depgraph::SessionId::new();
     let recent = crate::depgraph::SessionId::new();
     let ttl = Duration::from_secs(60 * 60);
-    let now = std::time::Instant::now();
-    // Stamp directly rather than sleeping: the boundary is what matters, and a
-    // test that waits an hour is not a test.
-    daemon
-        .state
-        .ended_sessions
-        .insert(stale, now - ttl - Duration::from_secs(1));
-    daemon
-        .state
-        .ended_sessions
-        .insert(recent, now - Duration::from_secs(1));
+    // Build stamps by ADDING to a base and moving the observation time
+    // forward, never by subtracting from `Instant::now()`. Still no sleeping:
+    // the boundary is what matters, and a test that waits an hour is not a
+    // test.
+    //
+    // The first version did `now - ttl - 1s` and panicked on CI. Subtracting
+    // an hour from a monotonic clock whose epoch is younger than an hour
+    // underflows, and a freshly booted runner is exactly that.
+    // `SessionManager::cleanup_expired` guards the same trap with
+    // `checked_sub` ("timeout exceeds uptime; nothing can be expired") -- the
+    // precedent was in the file I was already reading.
+    let base = std::time::Instant::now();
+    let observed_at = base + ttl + Duration::from_secs(1);
+    daemon.state.ended_sessions.insert(stale, base);
+    // Age at `observed_at` is 1s, comfortably inside the TTL.
+    daemon.state.ended_sessions.insert(recent, base + ttl);
 
-    let removed = reap_ended_session_tombstones(&daemon.state, ttl);
+    let removed = reap_ended_session_tombstones_at(&daemon.state, ttl, observed_at);
 
     assert_eq!(removed, 1);
     assert!(


### PR DESCRIPTION
Advances #1165. Closes Finding 1b (`ended_sessions`); the issue stays open for Findings 2 and 3.

## The leak

`ended_sessions` gained an entry per completed session and lost one **only** if that exact id was created again (`server/session.rs:79`). A long-lived daemon therefore kept a tombstone for every session it had ever ended.

The value type was `()` — which is why the obvious fix does not work. A reaper had nothing to age against: the map recorded *that* a session ended, not *when*. Stamping the insert is the enabling change, not incidental.

## On the TTL, which is the only real decision here

I flagged on the issue that this looked like a correctness question, because the tombstone exists to reject late arrivals. Reading the read site settles it more cheaply than I expected:

```rust
if state.ended_sessions.contains_key(&sid) {
    return Response::Error { message: format!("unknown session: {session_id}") };
}
```

Expiring a tombstone does **not** resurrect the session — the id is gone from `sessions` either way, so a request arriving after expiry still fails, just with a less specific message. Nothing creates a session from a stray compile; only an explicit create does, and that already clears the tombstone.

So the cost of choosing this badly is **error-message quality, not correctness**. That is what makes an hour comfortable: orders of magnitude beyond any in-flight request a disconnected client could still deliver, while making the map proportional to recent activity rather than to daemon uptime.

## Placement

Reaped from `reap_finished_sessions` (added in #1253), but as its own function. A tombstone outlives its client by definition, so "is the pid alive" says nothing about whether it is still needed — it ages on the daemon's clock, not on client liveness.

## Tests

Stamp `Instant`s directly rather than sleeping: the boundary is what matters, and a test that waits an hour is not a test.

Verified against the bug — replacing the retain predicate with `|_, _| true` (the old never-expire behaviour) fails the expiry test while the no-op test keeps passing:

| test | with fix | never-expire |
|---|---|---|
| `ended_session_tombstones_expire_on_their_ttl` | pass | **FAIL** |
| `tombstone_reaping_is_a_noop_when_nothing_is_stale` | pass | pass |

The no-op test exists because this runs every maintenance tick for the daemon's life; a reaper that *eventually* evicted in-date tombstones would surface as late requests getting the wrong error.

## Validation

677 passed on two consecutive runs. clippy `--all-targets --features "test-support,daemon-entry" -- -D warnings` exit 0, fmt clean.

## Remaining on #1165

- Finding 2 — per-session `*.jsonl` orphans. Worth re-examining before implementing: the path comes from the client via `SessionConfig.journal_path`, so "delete on CloseSession" would have the daemon removing a file the caller asked it to write at a location the caller chose.
- Finding 3 — `audit.jsonl` rotation.
