### PR TITLE
fix(daemon): bind auto-recovery kills to the instance that failed (#1161 leg 1)

### DIFF
--- a/crates/zccache-cli-core/src/cli/runtime.rs
+++ b/crates/zccache-cli-core/src/cli/runtime.rs
@@ -380,7 +380,43 @@ pub(crate) async fn wait_for_daemon_ready_with(
 }
 
 /// Stop a stale daemon that is unreachable or version-incompatible.
-async fn stop_stale_daemon(endpoint: &str) -> Option<u32> {
+/// Replace a daemon we failed to talk to.
+///
+/// `failed_instance` is the identity captured **before** the failed exchange.
+/// #1161: without it this function re-read the lock file at kill time and
+/// killed whoever was named there *now*. Under a `ninja -j16` burst that is a
+/// kill chain — client A times out against a saturated-but-healthy daemon and
+/// replaces it, client B arrives, reads the lock, and kills the freshly
+/// spawned replacement A just created.
+///
+/// `None` means the caller could not establish which instance it was talking
+/// to, and the kill is refused rather than aimed at whatever is current.
+async fn stop_stale_daemon(
+    endpoint: &str,
+    failed_instance: Option<&running_process::broker::protocol_v2::backend_handle::DaemonProcess>,
+) -> Option<u32> {
+    // Gate before the Shutdown request, not just before the kill: asking an
+    // innocent daemon to retire is itself the damage this issue is about.
+    match failed_instance {
+        Some(expected) if crate::ipc::daemon_identity_matches(expected) => {}
+        Some(expected) => {
+            tracing::warn!(
+                expected_pid = expected.pid,
+                expected_started_at_unix_ms = expected.started_at_unix_ms,
+                current_pid = crate::ipc::read_backend_identity().map(|d| d.pid),
+                "refusing to replace the daemon: the instance on disk is not the one that failed"
+            );
+            return None;
+        }
+        None => {
+            tracing::warn!(
+                "refusing to replace the daemon: no recorded identity for the failed instance; \
+                 run `zccache stop` if a stale daemon is genuinely wedged"
+            );
+            return None;
+        }
+    }
+
     let _ = crate::ipc::daemon_control_roundtrip(
         endpoint,
         crate::ipc::DaemonControlRequest::Shutdown,
@@ -421,6 +457,10 @@ pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
             _ => Err(crate::core::config::no_spawn_error("zccache-daemon")),
         };
     }
+    // #1161: capture *before* probing. This names the instance we are about
+    // to talk to, so a later kill can be bound to it rather than to whatever
+    // the lock file says once the probe has already failed.
+    let probed_instance = crate::ipc::read_backend_identity();
     match check_daemon_version(endpoint).await {
         VersionCheck::Ok | VersionCheck::DaemonNewer => return Ok(()),
         VersionCheck::DaemonOlder { daemon_ver } => {
@@ -429,7 +469,7 @@ pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
                 client_ver = crate::core::VERSION,
                 "daemon is older than client, auto-recovering"
             );
-            let killed_pid = stop_stale_daemon(endpoint).await;
+            let killed_pid = stop_stale_daemon(endpoint, probed_instance.as_ref()).await;
             return spawn_and_wait(
                 endpoint,
                 crate::core::lifecycle::REASON_REPLACED_STALE_VERSION,
@@ -439,7 +479,7 @@ pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
         }
         VersionCheck::CommError => {
             tracing::info!("cannot communicate with daemon, auto-recovering");
-            let killed_pid = stop_stale_daemon(endpoint).await;
+            let killed_pid = stop_stale_daemon(endpoint, probed_instance.as_ref()).await;
             return spawn_and_wait(
                 endpoint,
                 crate::core::lifecycle::REASON_REPLACED_COMM_ERROR,
@@ -456,6 +496,9 @@ pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
         for _ in 0..20 {
             tokio::time::sleep(backoff).await;
             backoff = (backoff * 2).min(std::time::Duration::from_millis(500));
+            // Re-read every iteration: a daemon replaced legitimately between
+            // attempts is a different instance, and the kill must follow.
+            let attempt_instance = crate::ipc::read_backend_identity();
             match check_daemon_version(endpoint).await {
                 VersionCheck::Ok | VersionCheck::DaemonNewer => return Ok(()),
                 VersionCheck::DaemonOlder { daemon_ver } => {
@@ -464,7 +507,7 @@ pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
                         client_ver = crate::core::VERSION,
                         "daemon is older than client during startup, auto-recovering"
                     );
-                    let killed_pid = stop_stale_daemon(endpoint).await;
+                    let killed_pid = stop_stale_daemon(endpoint, attempt_instance.as_ref()).await;
                     return spawn_and_wait(
                         endpoint,
                         crate::core::lifecycle::REASON_REPLACED_STALE_VERSION,
@@ -473,7 +516,7 @@ pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
                     .await;
                 }
                 VersionCheck::CommError => {
-                    let killed_pid = stop_stale_daemon(endpoint).await;
+                    let killed_pid = stop_stale_daemon(endpoint, attempt_instance.as_ref()).await;
                     return spawn_and_wait(
                         endpoint,
                         crate::core::lifecycle::REASON_REPLACED_COMM_ERROR,

--- a/crates/zccache-ipc/src/lib.rs
+++ b/crates/zccache-ipc/src/lib.rs
@@ -665,6 +665,55 @@ pub fn write_backend_identity(
     std::fs::write(path, json)
 }
 
+/// Read the persisted daemon identity, if one is recorded and parseable.
+///
+/// #1161: the identity has been *written* on every daemon start for a long
+/// time, and nothing read it back except `probe_backend_handle`'s inline load.
+/// Kill decisions verified only "PID is alive and its exe stem is
+/// `zccache-daemon`" — which a recycled PID belonging to a *different*
+/// zccache-daemon satisfies, so auto-recovery could kill an unrelated live
+/// instance.
+///
+/// `DaemonProcess` already carries what distinguishes instances:
+/// `started_at_unix_ms` (PID reuse within a boot) and `boot_id` (across
+/// boots). Exposing the read is what lets a kill be bound to the instance the
+/// caller actually failed to talk to.
+///
+/// `None` means "nothing recorded, or unreadable" — deliberately *not*
+/// "matches anything". See [`daemon_identity_matches`].
+#[must_use]
+pub fn read_backend_identity(
+) -> Option<running_process::broker::protocol_v2::backend_handle::DaemonProcess> {
+    std::fs::read(backend_identity_path())
+        .ok()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+}
+
+/// Is the daemon recorded on disk right now the same *instance* as `expected`?
+///
+/// Compares PID **and** start time **and** boot id. PID alone is not identity:
+/// the OS reuses PIDs, aggressively so on Windows, and the exe-stem check that
+/// guarded this before is satisfied by any `zccache-daemon` — including one
+/// serving a different namespace.
+///
+/// Returns `false` when nothing is recorded. That is the safe direction for a
+/// kill gate: refusing costs one clear error about a daemon that is already
+/// not answering, while permitting costs killing a live daemon that was never
+/// the one at fault. Note this deliberately differs from
+/// [`verify_pid_exe_stem`], whose `None => true` fallback is about *reading an
+/// exe path* on platforms that cannot — not about authorising a kill.
+#[must_use]
+pub fn daemon_identity_matches(
+    expected: &running_process::broker::protocol_v2::backend_handle::DaemonProcess,
+) -> bool {
+    let Some(current) = read_backend_identity() else {
+        return false;
+    };
+    current.pid == expected.pid
+        && current.started_at_unix_ms == expected.started_at_unix_ms
+        && current.boot_id == expected.boot_id
+}
+
 /// Load and actively verify the daemon identity through `BackendHandle`.
 ///
 /// Slice 24 of zccache#782: migrated to the `protocol_v2::backend_handle`
@@ -673,9 +722,7 @@ pub fn write_backend_identity(
 pub fn probe_backend_handle(
     endpoint: &str,
 ) -> Option<running_process::broker::protocol_v2::backend_handle::BackendHandle> {
-    let daemon = std::fs::read(backend_identity_path())
-        .ok()
-        .and_then(|bytes| serde_json::from_slice(&bytes).ok())?;
+    let daemon = read_backend_identity()?;
     let endpoint = running_process_endpoint(endpoint);
     running_process::broker::protocol_v2::backend_handle::BackendHandle::probe_with_service(
         "zccache",

--- a/crates/zccache-ipc/src/mod_tests.rs
+++ b/crates/zccache-ipc/src/mod_tests.rs
@@ -880,3 +880,83 @@ fn is_process_alive_returns_false_for_terminated_referenced_process() {
 
     unsafe { CloseHandle(pin) };
 }
+
+// ---------------------------------------------------------------------------
+// #1161 — identity-bound kills
+// ---------------------------------------------------------------------------
+
+fn fake_identity(
+    pid: u32,
+    started_at_unix_ms: u64,
+    boot_id: &str,
+) -> running_process::broker::protocol_v2::backend_handle::DaemonProcess {
+    running_process::broker::protocol_v2::backend_handle::DaemonProcess {
+        pid,
+        exe_path: std::path::PathBuf::from("zccache-daemon"),
+        exe_sha256: [0u8; 32],
+        boot_id: boot_id.to_string(),
+        ipc_endpoint: running_process_endpoint("test-endpoint"),
+        started_at_unix_ms,
+        idle_timeout_secs: None,
+    }
+}
+
+#[test]
+fn identity_matches_only_the_same_instance() {
+    let temp = tempfile::tempdir().unwrap();
+    let _env = EnvGuard::set_cache_dir(temp.path());
+
+    let live = fake_identity(4321, 1_700_000_000_000, "boot-a");
+    write_backend_identity(&live).unwrap();
+
+    assert!(
+        daemon_identity_matches(&live),
+        "the recorded instance must match itself"
+    );
+
+    // The bug this closes: a recycled PID belonging to a *different*
+    // zccache-daemon passed the old alive+exe-stem check, so auto-recovery
+    // could kill an unrelated live daemon. Same PID, different start time.
+    let recycled = fake_identity(4321, 1_700_000_999_000, "boot-a");
+    assert!(
+        !daemon_identity_matches(&recycled),
+        "a reused PID with a different start time is a different instance"
+    );
+
+    // Across a reboot the PID *and* start time can plausibly repeat; boot_id
+    // is what separates them.
+    let after_reboot = fake_identity(4321, 1_700_000_000_000, "boot-b");
+    assert!(
+        !daemon_identity_matches(&after_reboot),
+        "a different boot is a different instance even with identical pid/start"
+    );
+}
+
+#[test]
+fn absent_identity_never_matches() {
+    let temp = tempfile::tempdir().unwrap();
+    let _env = EnvGuard::set_cache_dir(temp.path());
+    // No identity written at all.
+    assert!(read_backend_identity().is_none());
+
+    // The safe direction for a kill gate: nothing recorded means "cannot
+    // establish which instance this is", not "kill whatever is there". The
+    // opposite default is what `verify_pid_exe_stem`'s `None => true` does,
+    // and that fallback is about reading an exe path -- not authorising a kill.
+    assert!(!daemon_identity_matches(&fake_identity(1, 1, "boot-a")));
+}
+
+#[test]
+fn unparseable_identity_never_matches() {
+    let temp = tempfile::tempdir().unwrap();
+    let _env = EnvGuard::set_cache_dir(temp.path());
+    let path = backend_identity_path();
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path.as_path(), b"{ truncated").unwrap();
+
+    assert!(read_backend_identity().is_none(), "garbage must not parse");
+    assert!(
+        !daemon_identity_matches(&fake_identity(1, 1, "boot-a")),
+        "a corrupt identity file must not authorise a kill"
+    );
+}


### PR DESCRIPTION
Advances #1161 — **leg 1 only**. Legs 2 and 3 untouched; the issue stays open. #1170 lists leg 1 as its hard dependency.

## The bug, in six lines

`stop_stale_daemon` chose its victim by re-reading the lock file *at kill time*:

```rust
let killed_pid = if let Some(pid) = crate::ipc::check_running_daemon() {
    let kill_ok = crate::ipc::force_kill_process(pid).is_ok();
```

Nothing binds that PID to the instance the caller failed to talk to. Under a `ninja -j16` burst: client A times out against a saturated-but-healthy daemon and replaces it; client B arrives, reads the lock — which now names **A's fresh replacement** — and kills it.

## The fix was mostly already built

`DaemonProcess` already carries `started_at_unix_ms` (PID reuse within a boot) and `boot_id` (across boots), and `write_backend_identity` has persisted it on **every daemon start** for a long time. Nothing read it back except `probe_backend_handle`'s inline load — so the identity was computed, serialised, written, and never consulted. That also explains #1170's note that `backend_identity_path` is "never cleaned today": staged for exactly this and left unwired.

So this is three small pieces, not new machinery:

- `read_backend_identity()` — extracted from that inline load
- `daemon_identity_matches()` — pid **and** start time **and** boot id
- `stop_stale_daemon(endpoint, failed_instance)` — refuses to touch anything else

**The gate runs before the `Shutdown` request, not just before the kill.** Asking an innocent daemon to retire is itself the damage this issue is about.

## The one real decision

**No recorded identity → refuse, not permit.**

Refusing costs one clear error about a daemon that is *already not answering*, and names `zccache stop`. Permitting costs killing a live daemon that was never at fault — unbounded damage, and precisely the hole Finding 3 describes.

This deliberately contradicts the nearest local precedent, `verify_pid_exe_stem`:

```rust
// Platform doesn't support reading the exe path. Fall back to the
// existing alive-only behavior so we don't regress on those platforms.
None => true,
```

That fallback is about *reading an exe path* where the OS won't tell you — not about authorising a kill. Same expression, different stakes.

**Migration is narrower than it looks:** a responsive pre-identity daemon never reaches this gate — it is classified `DaemonOlder` and replaced via the version-skew path. Only an *unresponsive* daemon predating identity-writing is affected, which is stale debris, and the refusal names the recovery.

If you would rather have permissive-on-absent for one release, that is a one-line change and I will make it — flagging it as the decision rather than burying it.

## Tests

Verified against the bug, not just for passing: reducing the comparison to pid-only fails `identity_matches_only_the_same_instance` while the others hold.

| test | with fix | pid-only |
|---|---|---|
| `identity_matches_only_the_same_instance` | pass | **FAIL** |
| `absent_identity_never_matches` | pass | pass |
| `unparseable_identity_never_matches` | pass | pass |

The recycled-PID and across-reboot cases are asserted separately, because `boot_id` is what separates a repeated pid+start-time pair after a restart.

`zccache-ipc` 51 passed, clippy `--all-targets -- -D warnings` exit 0, fmt clean.

## Not in scope

The issue's aggregate/drain-grace tests belong with legs 2 and 3 — they exercise probe-before-kill and the drain window, neither of which this changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
