### PR TITLE
fix(daemon): probe before replacing a daemon that timed out (#1161 leg 2)

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/wrap.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap.rs
@@ -7,7 +7,7 @@
 mod diag;
 mod env;
 mod fallback;
-mod ipc;
+pub(crate) mod ipc;
 mod passthrough;
 mod routing;
 mod rustfmt;

--- a/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
@@ -325,7 +325,7 @@ where
 /// Returned by [`classify_probe_outcome`] from a pure-function input
 /// so the decision matrix is unit-testable without a real daemon.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum WedgeAction {
+pub(crate) enum WedgeAction {
     /// Probe came back inside its budget — the daemon is alive and
     /// answering on its IPC endpoint. The wedge on the original
     /// request must have been triggered by the daemon being too busy
@@ -350,7 +350,7 @@ pub(super) enum WedgeAction {
 /// to a wedge action. Production callers wire `attempt_daemon_ping`
 /// (below) as the probe; tests pass stub outcomes directly. Issue
 /// [#753].
-pub(super) fn classify_probe_outcome(
+pub(crate) fn classify_probe_outcome(
     probe: Result<Result<(), crate::ipc::IpcError>, tokio::time::error::Elapsed>,
 ) -> WedgeAction {
     match probe {
@@ -372,7 +372,7 @@ pub(super) fn classify_probe_outcome(
 ///
 /// Production caller for [`classify_probe_outcome`] in the Wedged
 /// arm. Issue #753.
-async fn probe_daemon_responsive(
+pub(crate) async fn probe_daemon_responsive(
     endpoint: &str,
     budget: std::time::Duration,
 ) -> Result<Result<(), crate::ipc::IpcError>, tokio::time::error::Elapsed> {
@@ -401,11 +401,11 @@ async fn probe_daemon_responsive(
 /// with `ZCCACHE_WEDGE_PROBE_BUDGET_MS`. Set to `0` to disable the
 /// probe entirely (pre-#753 unconditional kill behavior — useful for
 /// diagnostic A/B against the fix).
-pub(super) const WEDGE_PROBE_DEFAULT_MS: u64 = 3_000;
+pub(crate) const WEDGE_PROBE_DEFAULT_MS: u64 = 3_000;
 
 /// Returns the probe budget configured for this run. `None` means
 /// "probe disabled — kill unconditionally" (the pre-#753 behavior).
-pub(super) fn wedge_probe_budget() -> Option<std::time::Duration> {
+pub(crate) fn wedge_probe_budget() -> Option<std::time::Duration> {
     let ms = std::env::var("ZCCACHE_WEDGE_PROBE_BUDGET_MS")
         .ok()
         .and_then(|s| s.trim().parse::<u64>().ok())

--- a/crates/zccache-cli-core/src/cli/runtime.rs
+++ b/crates/zccache-cli-core/src/cli/runtime.rs
@@ -380,6 +380,31 @@ pub(crate) async fn wait_for_daemon_ready_with(
 }
 
 /// Stop a stale daemon that is unreachable or version-incompatible.
+/// Does a short follow-up probe say the daemon is alive after all?
+///
+/// #1161 leg 2. `check_daemon_version` maps a `Status` timeout to
+/// `CommError`, which the recovery path treated as "replace it". But a
+/// timeout is not evidence of death — it is equally the signature of a
+/// daemon busy serving a `-j16` burst. #753 already established the fix on
+/// the wedge path: ask again, cheaply, and only escalate if that also fails.
+/// This reuses that classifier rather than inventing a second policy.
+///
+/// `true` means "alive, just slow — leave it alone". Probe disabled via
+/// `ZCCACHE_WEDGE_PROBE_BUDGET_MS=0` reads as `false`, preserving the
+/// unconditional-replace behaviour for anyone A/B-testing against it.
+async fn probe_says_daemon_is_merely_busy(endpoint: &str) -> bool {
+    use crate::cli::commands::wrap::ipc::{
+        classify_probe_outcome, probe_daemon_responsive, wedge_probe_budget, WedgeAction,
+    };
+    let Some(budget) = wedge_probe_budget() else {
+        return false;
+    };
+    matches!(
+        classify_probe_outcome(probe_daemon_responsive(endpoint, budget).await),
+        WedgeAction::DowngradeNoKill
+    )
+}
+
 /// Replace a daemon we failed to talk to.
 ///
 /// `failed_instance` is the identity captured **before** the failed exchange.
@@ -478,6 +503,20 @@ pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
             .await;
         }
         VersionCheck::CommError => {
+            // #1161 leg 2: a `CommError` here is usually a *Status probe
+            // timeout*, and `check_daemon_version` deliberately does not treat
+            // a timeout as "unreachable". Under load that is exactly what a
+            // saturated-but-healthy daemon produces, and replacing it is how a
+            // cohort of clients destroys the warm daemon they are all waiting
+            // on. Ask a second, cheaper question before concluding it is dead
+            // — the same probe #753 already applies on the wedge path.
+            if probe_says_daemon_is_merely_busy(endpoint).await {
+                tracing::info!(
+                    "daemon answered a probe after a status timeout; treating it as busy \
+                     rather than replacing it"
+                );
+                return Ok(());
+            }
             tracing::info!("cannot communicate with daemon, auto-recovering");
             let killed_pid = stop_stale_daemon(endpoint, probed_instance.as_ref()).await;
             return spawn_and_wait(
@@ -516,6 +555,13 @@ pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
                     .await;
                 }
                 VersionCheck::CommError => {
+                    // Same reasoning as the arm above, and this one matters
+                    // more: this loop runs while a daemon is still starting
+                    // up, which is precisely when it is too busy to answer a
+                    // 2 s Status ping.
+                    if probe_says_daemon_is_merely_busy(endpoint).await {
+                        continue;
+                    }
                     let killed_pid = stop_stale_daemon(endpoint, attempt_instance.as_ref()).await;
                     return spawn_and_wait(
                         endpoint,
@@ -1021,5 +1067,63 @@ mod tests {
         .expect_err("daemon-exit path must fail, not hang");
         assert!(err.contains("exited"), "wrong error: {err}");
         assert!(err.contains("99999"), "PID should appear: {err}");
+    }
+
+    // ---------------------------------------------------------------------
+    // #1161 leg 2 — probe before kill
+    // ---------------------------------------------------------------------
+
+    // `classify_probe_outcome` itself is already covered in `wrap/ipc.rs`
+    // (pong/error/timeout). What is new here is the wrapper below and the
+    // CommError arms that consult it, so that is what these exercise.
+
+    #[tokio::test]
+    async fn a_disabled_probe_budget_keeps_the_unconditional_replace() {
+        // ZCCACHE_WEDGE_PROBE_BUDGET_MS=0 is the documented A/B switch back to
+        // pre-#753 behaviour. It must not accidentally become "never replace":
+        // with the probe off there is no evidence of life, so the answer is
+        // "not merely busy" and recovery proceeds.
+        let _guard = EnvVarGuard::set("ZCCACHE_WEDGE_PROBE_BUDGET_MS", "0");
+        assert!(
+            !probe_says_daemon_is_merely_busy("definitely-not-a-real-endpoint").await,
+            "a disabled probe must not be read as proof the daemon is healthy"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unreachable_endpoint_is_not_merely_busy() {
+        // Nothing listening: the probe fails fast with a transport error,
+        // which classifies as escalate. Guards against the inverted default,
+        // where a probe failure would wrongly protect a dead daemon and wedge
+        // the client forever.
+        let _guard = EnvVarGuard::set("ZCCACHE_WEDGE_PROBE_BUDGET_MS", "250");
+        assert!(
+            !probe_says_daemon_is_merely_busy(&crate::ipc::unique_test_endpoint()).await,
+            "an endpoint with no daemon must not be treated as busy-but-healthy"
+        );
+    }
+
+    /// Restores the previous value on drop so these cases cannot leak into
+    /// the rest of the binary's tests.
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
     }
 }


### PR DESCRIPTION
Advances #1161 — **leg 2's probe half**. The `<lock>.kill` single-flight slot and leg 3 (drain grace) are untouched; the issue stays open.

## The bug

`check_daemon_version` maps a `Status` probe timeout to `CommError`, and both `CommError` arms in `ensure_daemon` treated that as *replace it*.

A timeout is not evidence of death. It is equally the signature of a daemon busy serving a `-j16` burst — and that is exactly when a **cohort** of clients all reach this arm simultaneously and destroy the warm daemon they are collectively waiting on.

## The fix

#753 already established the answer on the wedge path: ask again, cheaply, and escalate only if that also fails. This **reuses that classifier** rather than inventing a second policy — `probe_daemon_responsive` and `classify_probe_outcome` move from `pub(super)` to `pub(crate)` and are consulted from `runtime.rs`.

Only `DowngradeNoKill` — a Pong inside the budget, i.e. *positive evidence of life* — spares the daemon. A probe timeout or transport error still escalates.

**Applied to both arms.** The retry-loop one arguably matters more: that loop runs while a daemon is still starting up, which is precisely when it is too busy to answer a 2 s ping.

`ZCCACHE_WEDGE_PROBE_BUDGET_MS=0` still means "no probe", and reads as *not merely busy* so recovery proceeds. The documented pre-#753 A/B switch keeps working rather than silently inverting into "never replace" — `a_disabled_probe_budget_keeps_the_unconditional_replace` pins that.

## Pairs with leg 1

#1257 stopped us killing the **wrong** daemon. This stops us killing the **right** one unnecessarily. Together they cover the kill-chain scenario in Finding 1: client A no longer replaces a busy-but-healthy daemon, and if it does replace something, client B can no longer aim at A's fresh spawn.

## A trap worth recording

`zccache-cli-core`'s `cli` module is behind the **`cli` feature**. So:

- `cargo test -p zccache-cli-core --lib` runs **zero tests**
- `cargo check -p zccache-cli-core --all-targets` compiles **none** of this code

My first validation pass used both and reported success while nothing had been built. With `--features cli`: **228 passed**, clippy `--all-targets --features cli -- -D warnings` exit 0. This is the second such gate I have hit in this codebase (the first being `daemon-entry` in `zccache-daemon-core`), so it seems worth stating in the PR rather than only in a commit message.

## Tests

- `a_disabled_probe_budget_keeps_the_unconditional_replace` — the A/B switch must not invert into "never replace"
- `an_unreachable_endpoint_is_not_merely_busy` — guards the opposite inversion, where a failing probe wrongly protects a dead daemon and wedges the client forever

I deliberately did **not** re-test `classify_probe_outcome` itself: `wrap/ipc.rs` already covers its three outcomes, and duplicating that would assert the same matrix twice while testing none of the new wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
