### PR TITLE
fix(watcher): re-arm after startup failure; scope overflow suspect-marking (#1156)

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/status.rs
+++ b/crates/zccache-cli-core/src/cli/commands/status.rs
@@ -123,6 +123,19 @@ pub(crate) async fn cmd_status(endpoint: &str, json: bool) -> ExitCode {
                 );
             }
             println!("  Metadata:      {} entries", s.metadata_entries);
+            {
+                // Watcher state is a performance cliff, not a cosmetic detail:
+                // with no watcher both fast hit tiers are disabled and every
+                // shared cache blob is re-hashed on read (issue #1156).
+                let watcher = match (s.watcher_active, s.watcher_degradations) {
+                    (true, 0) => "active".to_string(),
+                    (true, n) => format!("active (recovered from {n} degradation(s))"),
+                    (false, n) => {
+                        format!("DEGRADED — fast hit tiers disabled ({n} failure(s), retrying)")
+                    }
+                };
+                println!("  Watcher:       {watcher}");
+            }
             println!();
             if s.total_links > 0 {
                 println!();

--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -66,6 +66,9 @@
 //! | `native_flag_host_salted` | daemon | a `native` CPU-selection flag made the compile key host-specific | `compiler_family` |
 //! | `time_macro_noncacheable` | daemon | a C/C++ time macro bypassed the compile cache | `source`, `input`, `macro_name` |
 //! | `system_include_discovery_empty` | daemon | a C/C++ include probe returned no paths, so its compile bypassed the cache | `compiler`, `reason` |
+//! | `watcher_degraded` | daemon | the file watcher could not be armed, disabling both fast hit tiers | `reason`, `degradations` |
+//! | `watcher_rearmed` | daemon | a degraded daemon re-armed its file watcher | `attempt` |
+//! | `watcher_overflow` | daemon | the watcher event queue saturated; hardlink registry re-verified by stat signature | `links_unchanged`, `links_suspect` |
 //!
 //! ## Forensic walkthrough: the two-versions-on-one-pipe wedge
 //!
@@ -163,6 +166,14 @@ pub const EVENT_COW_BLOB_CORRUPTION_DETECTED: &str = "cow_blob_corruption_detect
 pub const EVENT_NATIVE_FLAG_HOST_SALTED: &str = "native_flag_host_salted";
 pub const EVENT_TIME_MACRO_NONCACHEABLE: &str = "time_macro_noncacheable";
 pub const EVENT_SYSTEM_INCLUDE_DISCOVERY_EMPTY: &str = "system_include_discovery_empty";
+/// The daemon is running without a file watcher: both fast hit tiers are
+/// disabled and shared cache blobs are re-hashed on every read.
+pub const EVENT_WATCHER_DEGRADED: &str = "watcher_degraded";
+/// A degraded daemon successfully re-armed its file watcher.
+pub const EVENT_WATCHER_REARMED: &str = "watcher_rearmed";
+/// The watcher event queue saturated; records how much of the hardlink
+/// registry the stat-signature sweep kept trusted versus marked suspect.
+pub const EVENT_WATCHER_OVERFLOW: &str = "watcher_overflow";
 
 /// Complete lifecycle-event catalog. Keep this additive and update the module
 /// schema table with every new event; log-audit and operator docs depend on it.
@@ -197,6 +208,9 @@ pub const EVENT_ALL: &[&str] = &[
     EVENT_NATIVE_FLAG_HOST_SALTED,
     EVENT_TIME_MACRO_NONCACHEABLE,
     EVENT_SYSTEM_INCLUDE_DISCOVERY_EMPTY,
+    EVENT_WATCHER_DEGRADED,
+    EVENT_WATCHER_REARMED,
+    EVENT_WATCHER_OVERFLOW,
     EVENT_LEGACY_ARTIFACT_PATH_ACCESSED,
     EVENT_DESTINATION_WRITE_FAILED,
     EVENT_MISS_REASON_UNKNOWN,

--- a/crates/zccache-daemon-core/src/daemon/compile_journal/tests/outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/tests/outcome.rs
@@ -157,6 +157,8 @@ fn test_extract_outcome_all_non_journalable() {
             dep_graph_version: 0,
             dep_graph_disk_size: 0,
             dep_graph_persisted: false,
+            watcher_active: true,
+            watcher_degradations: 0,
         }),
         Response::LookupResult(LR::Miss),
         Response::StoreResult(SR::Stored),

--- a/crates/zccache-daemon-core/src/daemon/server/connection/dispatch.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/connection/dispatch.rs
@@ -113,6 +113,8 @@ pub(super) async fn dispatch_request(
                         .map(|m| m.len())
                         .unwrap_or(0),
                     dep_graph_persisted: state.dep_graph_persisted.load(Ordering::Acquire),
+                    watcher_active: state.watcher_active.load(Ordering::Acquire),
+                    watcher_degradations: state.watcher_degradations.load(Ordering::Relaxed),
                 }),
                 None,
             )

--- a/crates/zccache-daemon-core/src/daemon/server/embedded.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/embedded.rs
@@ -438,6 +438,8 @@ async fn status_snapshot(state: &SharedState) -> crate::protocol::DaemonStatus {
             .map(|m| m.len())
             .unwrap_or(0),
         dep_graph_persisted: state.dep_graph_persisted.load(Ordering::Acquire),
+        watcher_active: state.watcher_active.load(Ordering::Acquire),
+        watcher_degradations: state.watcher_degradations.load(Ordering::Relaxed),
     }
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -220,6 +220,7 @@ pub(super) fn new_shared_state(
             },
             fast_hit_cache: DashMap::new(),
             watcher_active: AtomicBool::new(false),
+            watcher_degradations: AtomicU64::new(0),
             rsp_cache: DashMap::new(),
             request_cache: DashMap::new(),
             session_worktree_roots: DashMap::new(),

--- a/crates/zccache-daemon-core/src/daemon/server/persist/link_registry.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/link_registry.rs
@@ -594,6 +594,14 @@ pub(in crate::daemon::server) fn set_registry_watcher_available(available: bool)
     WATCHER_AVAILABLE.store(available, Ordering::Release);
 }
 
+/// Test-only seam: `WATCHER_AVAILABLE` is process-global, so a test that
+/// exercises watcher degradation must restore whatever it observed rather
+/// than assume the static's initial value. See `tests::watcher_lifecycle`.
+#[cfg(test)]
+pub(in crate::daemon::server) fn registry_watcher_available() -> bool {
+    WATCHER_AVAILABLE.load(Ordering::Acquire)
+}
+
 pub(in crate::daemon::server) fn mark_registered_links_suspect<'a>(
     paths: impl IntoIterator<Item = &'a Path>,
 ) {

--- a/crates/zccache-daemon-core/src/daemon/server/persist/link_registry.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/link_registry.rs
@@ -6,10 +6,22 @@ use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
 
+/// Cheap change signal for a registered blob: the `(mtime_ns, size)` pair
+/// observed at the moment its `expected_hash` was computed. Writing through
+/// any hardlink alias mutates the shared inode, so a changed signature on the
+/// blob path is evidence that some alias touched the bytes. This is the same
+/// signal the metadata cache already trusts at `Confidence::Medium`; it is
+/// used only to *avoid* work (skip a re-hash), never to accept bytes that
+/// failed a hash check.
+type StatSignature = (i128, u64);
+
 #[derive(Clone, Debug)]
 struct LinkRecord {
     blob_path: NormalizedPath,
     expected_hash: [u8; 32],
+    /// `None` when the stat could not be taken at registration time — such a
+    /// record has no cheap signal and always falls back to a full re-hash.
+    stat_signature: Option<StatSignature>,
     outputs: BTreeSet<NormalizedPath>,
     suspect: bool,
 }
@@ -17,6 +29,14 @@ struct LinkRecord {
 static REGISTRY: OnceLock<dashmap::DashMap<FileId, LinkRecord>> = OnceLock::new();
 static OUTPUT_IDS: OnceLock<dashmap::DashMap<NormalizedPath, FileId>> = OnceLock::new();
 static WATCHER_AVAILABLE: AtomicBool = AtomicBool::new(true);
+
+fn stat_signature(path: &Path) -> Option<StatSignature> {
+    let metadata = std::fs::metadata(path).ok()?;
+    let mtime = filetime::FileTime::from_last_modification_time(&metadata);
+    let mtime_ns =
+        i128::from(mtime.unix_seconds()) * 1_000_000_000 + i128::from(mtime.nanoseconds());
+    Some((mtime_ns, metadata.len()))
+}
 
 fn registry() -> &'static dashmap::DashMap<FileId, LinkRecord> {
     REGISTRY.get_or_init(dashmap::DashMap::new)
@@ -94,6 +114,7 @@ pub(in crate::daemon::server) fn register_trusted_blob_for_test(
         LinkRecord {
             blob_path: blob_path.into(),
             expected_hash: [0; 32],
+            stat_signature: stat_signature(blob_path),
             outputs: BTreeSet::new(),
             suspect: false,
         },
@@ -315,20 +336,29 @@ pub(in crate::daemon::server) fn prepare_hardlink_registration(
                 for stale in &entry.get().outputs {
                     output_ids().remove(stale);
                 }
+                // Stat before hashing: if the bytes change mid-hash the
+                // recorded signature is the pre-change one, so a later
+                // comparison reports "changed" and falls back to the full
+                // re-hash. Stat-after would record the post-change value and
+                // could vouch for a torn read.
+                let stat_signature = stat_signature(blob_path);
                 let expected_hash = hash_file(blob_path)?;
                 entry.insert(LinkRecord {
                     blob_path: blob_path.into(),
                     expected_hash,
+                    stat_signature,
                     outputs: BTreeSet::new(),
                     suspect: false,
                 });
             }
         }
         dashmap::mapref::entry::Entry::Vacant(entry) => {
+            let stat_signature = stat_signature(blob_path);
             let expected_hash = hash_file(blob_path)?;
             entry.insert(LinkRecord {
                 blob_path: blob_path.into(),
                 expected_hash,
+                stat_signature,
                 outputs: BTreeSet::new(),
                 suspect: false,
             });
@@ -447,12 +477,14 @@ pub(in crate::daemon::server) fn verify_registered_blob(blob_path: &Path) -> std
         // digest persisted when the immutable blob was stored. Link count is
         // not evidence: a poisoned alias may have been deleted before restart.
         if let Some(expected_hash) = read_authoritative_blob_digest(blob_path)? {
+            let stat_signature = stat_signature(blob_path);
             if hash_file(blob_path)? == expected_hash {
                 registry().insert(
                     id,
                     LinkRecord {
                         blob_path: blob_path.into(),
                         expected_hash,
+                        stat_signature,
                         outputs: BTreeSet::new(),
                         suspect: false,
                     },
@@ -504,6 +536,7 @@ pub(in crate::daemon::server) fn verify_registered_blob(blob_path: &Path) -> std
     {
         return Ok(());
     }
+    let refreshed_signature = stat_signature(blob_path);
     let actual = hash_file(blob_path)?;
     if actual == record.expected_hash {
         let remove = record.outputs.is_empty();
@@ -512,6 +545,7 @@ pub(in crate::daemon::server) fn verify_registered_blob(blob_path: &Path) -> std
             registry().remove(&id);
         } else if let Some(mut record) = registry().get_mut(&id) {
             record.suspect = false;
+            record.stat_signature = refreshed_signature;
         }
         return Ok(());
     }
@@ -591,10 +625,60 @@ pub(in crate::daemon::server) fn mark_removed_links_suspect<'a>(
     }
 }
 
+#[cfg(test)]
 pub(in crate::daemon::server) fn mark_all_registered_links_suspect() {
     for mut record in registry().iter_mut() {
         record.suspect = true;
     }
+}
+
+/// Outcome of a scoped overflow sweep, for logging.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(in crate::daemon::server) struct OverflowSweep {
+    /// Records whose cheap stat signature is unchanged — left trusted.
+    pub(in crate::daemon::server) unchanged: usize,
+    /// Records newly marked suspect (signature changed, missing, or unstattable).
+    pub(in crate::daemon::server) suspect: usize,
+}
+
+/// Watcher-overflow recovery that does not indiscriminately condemn the whole
+/// hardlink cache (issue #1156).
+///
+/// Overflow means "the event queue saturated", not "every file changed". A
+/// blanket `mark_all_registered_links_suspect()` turns one momentary burst —
+/// a wide `git checkout`, a parallel build — into a full blake3 re-hash of
+/// every shared blob on its next read. Instead, re-verify each record against
+/// the cheap `(mtime, size)` signature captured at registration: unchanged
+/// blobs stay trusted, and anything that changed, vanished, or cannot be
+/// stat'd is marked suspect so the read path still falls back to the full
+/// re-hash. Correctness is unchanged — the expensive check is skipped only
+/// where there is positive evidence the bytes were not touched.
+pub(in crate::daemon::server) fn mark_changed_registered_links_suspect() -> OverflowSweep {
+    let mut sweep = OverflowSweep::default();
+    for mut record in registry().iter_mut() {
+        if record.suspect {
+            sweep.suspect += 1;
+            continue;
+        }
+        let unchanged = record
+            .stat_signature
+            .is_some_and(|recorded| stat_signature(record.blob_path.as_path()) == Some(recorded));
+        if unchanged {
+            sweep.unchanged += 1;
+        } else {
+            record.suspect = true;
+            sweep.suspect += 1;
+        }
+    }
+    sweep
+}
+
+/// Test-only seam: the suspect flag of a single record. The registry is a
+/// process-global static, so tests running in parallel cannot assert on the
+/// aggregate sweep counters — they must scope assertions to their own blob.
+#[cfg(test)]
+pub(in crate::daemon::server) fn registered_link_suspect(id: FileId) -> Option<bool> {
+    registry().get(&id).map(|record| record.suspect)
 }
 
 pub(in crate::daemon::server) fn registered_blob_id(blob_path: &Path) -> Option<FileId> {

--- a/crates/zccache-daemon-core/src/daemon/server/run.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/run.rs
@@ -13,6 +13,13 @@ const MEMORY_GC_IDLE_GRACE: Duration = Duration::from_millis(250);
 const MEMORY_GC_GENTLE_RETRY: Duration = Duration::from_millis(50);
 const MEMORY_GC_FORCE_AFTER: Duration = Duration::from_secs(5);
 const MEMORY_GC_GENTLE_BATCH: usize = 256;
+/// Startup budget for taking the watcher lock before declaring degradation.
+const WATCHER_LOCK_TIMEOUT: Duration = Duration::from_secs(5);
+/// First re-arm attempt after a failed watcher init (issue #1156). Cheap
+/// enough to be always-on, so no config knob is exposed.
+const WATCHER_REARM_INITIAL_DELAY: Duration = Duration::from_secs(60);
+/// Backoff ceiling for watcher re-arm retries.
+const WATCHER_REARM_MAX_DELAY: Duration = Duration::from_secs(600);
 
 impl DaemonServer {
     /// Run the server, accepting connections until shutdown is signaled.
@@ -548,31 +555,110 @@ impl DaemonServer {
     /// Initialize the file watcher pipeline:
     /// `NotifyWatcher (OS thread) → SettleBuffer (tokio task) → CacheSystem consumer (tokio task)`
     async fn start_watcher_pipeline(&self) {
-        let ignore = Arc::new(crate::watcher::IgnoreFilter::default());
-        let (watcher, raw_rx) = match NotifyWatcher::new(ignore) {
-            Ok(w) => w,
-            Err(e) => {
-                set_registry_watcher_available(false);
-                tracing::warn!("failed to start file watcher: {e} — running without watcher");
-                return;
-            }
-        };
-
-        match tokio::time::timeout(Duration::from_secs(5), self.state.watcher.lock()).await {
-            Ok(mut watcher_guard) => {
-                *watcher_guard = Some(watcher);
-            }
-            Err(_) => {
-                set_registry_watcher_available(false);
-                tracing::warn!(
-                    "timed out acquiring watcher lock during startup; running without watcher"
-                );
-                return;
-            }
+        if arm_watcher_pipeline(&self.state).await {
+            return;
         }
-        set_registry_watcher_available(true);
-        self.state.watcher_active.store(true, Ordering::Release);
+        // Watcher init failed. Without a re-arm this is a lifetime sentence:
+        // both fast hit tiers bail on `watcher_active == false` and every
+        // shared blob is fully re-hashed on every hit, forever, off a single
+        // startup warn line. The common triggers (inotify `max_user_watches`
+        // exhaustion, a momentarily contended watcher lock) are transient, so
+        // retry on a capped backoff until the daemon shuts down (issue #1156).
+        let state = Arc::clone(&self.state);
+        tokio::spawn(async move {
+            let mut delay = WATCHER_REARM_INITIAL_DELAY;
+            let mut attempt = 0_u32;
+            while !state.shutdown_requested.load(Ordering::Acquire) {
+                tokio::select! {
+                    () = tokio::time::sleep(delay) => {}
+                    () = state.shutdown.notified() => {
+                        state.shutdown_requested.store(true, Ordering::Release);
+                        state.shutdown.notify_waiters();
+                        return;
+                    }
+                }
+                if state.shutdown_requested.load(Ordering::Acquire) {
+                    return;
+                }
+                attempt += 1;
+                if arm_watcher_pipeline(&state).await {
+                    tracing::info!(
+                        event = "watcher_rearmed",
+                        attempt,
+                        "file watcher re-armed after startup failure — fast hit tiers restored"
+                    );
+                    crate::core::lifecycle::write_event(
+                        crate::core::lifecycle::EVENT_WATCHER_REARMED,
+                        serde_json::json!({ "attempt": attempt }),
+                    );
+                    return;
+                }
+                delay = (delay * 2).min(WATCHER_REARM_MAX_DELAY);
+            }
+        });
+    }
+}
 
+/// Attempts one full arm of the watcher pipeline. Returns `true` when the
+/// watcher is live and the settle/consumer tasks are running; `false` leaves
+/// the daemon in the degraded (watcher-less) mode with the degradation
+/// recorded loudly.
+pub(super) async fn arm_watcher_pipeline(state: &Arc<SharedState>) -> bool {
+    let ignore = Arc::new(crate::watcher::IgnoreFilter::default());
+    let (watcher, raw_rx) = match NotifyWatcher::new(ignore) {
+        Ok(w) => w,
+        Err(e) => {
+            record_watcher_degradation(state, &format!("watcher init failed: {e}"));
+            return false;
+        }
+    };
+
+    match tokio::time::timeout(WATCHER_LOCK_TIMEOUT, state.watcher.lock()).await {
+        Ok(mut watcher_guard) => {
+            *watcher_guard = Some(watcher);
+        }
+        Err(_) => {
+            record_watcher_degradation(state, "timed out acquiring watcher lock");
+            return false;
+        }
+    }
+    set_registry_watcher_available(true);
+    state.watcher_active.store(true, Ordering::Release);
+    start_watcher_tasks(state, raw_rx);
+    tracing::info!("file watcher pipeline started");
+    true
+}
+
+/// Loud-forensics degradation record: a `warn!` plus a durable lifecycle
+/// event plus a monotonic counter surfaced in `zccache status`, so a daemon
+/// running without a watcher is visible without trawling startup logs.
+pub(super) fn record_watcher_degradation(state: &Arc<SharedState>, reason: &str) {
+    set_registry_watcher_available(false);
+    state.watcher_active.store(false, Ordering::Release);
+    let degradations = state.watcher_degradations.fetch_add(1, Ordering::Relaxed) + 1;
+    tracing::warn!(
+        event = "watcher_degraded",
+        reason,
+        degradations,
+        "running without file watcher — fast hit tiers disabled and shared \
+         blobs re-hash on every read; will retry"
+    );
+    crate::core::lifecycle::write_event(
+        crate::core::lifecycle::EVENT_WATCHER_DEGRADED,
+        serde_json::json!({
+            "reason": reason,
+            "degradations": degradations,
+        }),
+    );
+}
+
+/// Spawns the settle buffer and the `CacheSystem` consumer over a freshly
+/// armed watcher's raw event stream.
+fn start_watcher_tasks(
+    state: &Arc<SharedState>,
+    raw_rx: tokio::sync::mpsc::UnboundedReceiver<crate::watcher::WatchEvent>,
+) {
+    {
         // Settle buffer: coalesces raw events into batches after a quiet period.
         let (settled_tx, mut settled_rx) = tokio::sync::mpsc::unbounded_channel();
         let settle = SettleBuffer::default_window();
@@ -581,7 +667,7 @@ impl DaemonServer {
         });
 
         // Consumer: feeds settled events into CacheSystem for metadata invalidation.
-        let state = Arc::clone(&self.state);
+        let state = Arc::clone(state);
         tokio::spawn(async move {
             while !state.shutdown_requested.load(Ordering::Acquire) {
                 // Race the settled-event recv against the shutdown signal
@@ -649,16 +735,27 @@ impl DaemonServer {
                         }
                     }
                     SettledEvent::Overflow => {
-                        mark_all_registered_links_suspect();
-                        tracing::warn!("watcher overflow — downgrading all metadata");
+                        let sweep = mark_changed_registered_links_suspect();
+                        tracing::warn!(
+                            event = "watcher_overflow",
+                            links_unchanged = sweep.unchanged,
+                            links_suspect = sweep.suspect,
+                            "watcher overflow — downgrading all metadata; \
+                             hardlink registry re-verified by stat signature"
+                        );
+                        crate::core::lifecycle::write_event(
+                            crate::core::lifecycle::EVENT_WATCHER_OVERFLOW,
+                            serde_json::json!({
+                                "links_unchanged": sweep.unchanged,
+                                "links_suspect": sweep.suspect,
+                            }),
+                        );
                         state.cache_system.apply_overflow();
                     }
                 }
             }
             tracing::debug!("watcher consumer task exiting");
         });
-
-        tracing::info!("file watcher pipeline started");
     }
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -280,6 +280,10 @@ pub(super) struct SharedState {
     /// Whether the file watcher is active. Fast-hit cache is only used when
     /// the watcher is running, since we rely on it for change detection.
     pub(super) watcher_active: AtomicBool,
+    /// Monotonic count of watcher-arm failures since daemon start (issue
+    /// #1156). Surfaced in `zccache status` so an operator can see that a
+    /// daemon is running on its slow paths without trawling startup logs.
+    pub(super) watcher_degradations: AtomicU64,
     /// Response file expansion cache keyed by canonical root path.
     /// Each entry carries the transitive response-file hashes required to
     /// validate freshness before reusing the cached expansion.

--- a/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
@@ -35,6 +35,7 @@ mod session_errors;
 mod session_staged_attribution;
 mod staged_compiler_sets;
 mod system_includes_deferred;
+mod watcher_lifecycle;
 mod write_cached;
 
 /// RAII guard that overrides `ZCCACHE_CACHE_DIR` for the duration of a

--- a/crates/zccache-daemon-core/src/daemon/server/tests/watcher_lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/watcher_lifecycle.rs
@@ -12,6 +12,29 @@
 use super::super::run::{arm_watcher_pipeline, record_watcher_degradation};
 use super::super::*;
 
+/// Restores the process-global `WATCHER_AVAILABLE` flag on drop.
+///
+/// `record_watcher_degradation` flips that static off for the whole process,
+/// and `verify_registered_blob` consults it to decide whether a non-suspect,
+/// multi-linked blob may skip its re-hash. Unit tests in this crate run in
+/// parallel in one process, so a test that degrades the watcher must not leave
+/// the flag flipped for whatever else is mid-flight — and must restore what it
+/// *observed*, not the static's initial value, since another test may be
+/// holding it too.
+struct WatcherAvailabilityGuard(bool);
+
+impl WatcherAvailabilityGuard {
+    fn capture() -> Self {
+        Self(registry_watcher_available())
+    }
+}
+
+impl Drop for WatcherAvailabilityGuard {
+    fn drop(&mut self) {
+        set_registry_watcher_available(self.0);
+    }
+}
+
 /// Registers a blob/output hardlink pair and returns the registry identity,
 /// or `None` when the temp filesystem cannot make same-volume hardlinks.
 fn seed_registered_link(blob: &Path, output: &Path, bytes: &[u8]) -> Option<FileId> {
@@ -99,6 +122,7 @@ fn overflow_marks_an_unstattable_blob_suspect() {
 
 #[tokio::test]
 async fn watcher_degradation_is_recorded_and_recoverable() {
+    let _watcher_availability = WatcherAvailabilityGuard::capture();
     let dir = tempfile::tempdir().unwrap();
     let cache_dir: NormalizedPath = dir.path().join("cache").into();
     let server =

--- a/crates/zccache-daemon-core/src/daemon/server/tests/watcher_lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/watcher_lifecycle.rs
@@ -1,0 +1,138 @@
+//! Watcher-lifecycle regressions for issue #1156.
+//!
+//! Two silent degradations used to strand the daemon on its slowest paths:
+//! a failed watcher init was a lifetime sentence (no re-arm), and a transient
+//! event-queue overflow condemned the entire hardlink registry to a blake3
+//! re-hash storm. These tests pin the recovery behavior of both.
+//!
+//! The link registry is a process-global static, so every assertion here is
+//! scoped to the test's own record by `FileId` — the aggregate sweep counters
+//! also see records registered by tests running in parallel.
+
+use super::super::run::{arm_watcher_pipeline, record_watcher_degradation};
+use super::super::*;
+
+/// Registers a blob/output hardlink pair and returns the registry identity,
+/// or `None` when the temp filesystem cannot make same-volume hardlinks.
+fn seed_registered_link(blob: &Path, output: &Path, bytes: &[u8]) -> Option<FileId> {
+    std::fs::write(blob, bytes).unwrap();
+    if std::fs::hard_link(blob, output).is_err() {
+        return None;
+    }
+    register_hardlink(blob, output).unwrap();
+    registered_blob_id(blob)
+}
+
+#[test]
+fn overflow_keeps_stat_unchanged_blobs_trusted() {
+    let dir = tempfile::tempdir().unwrap();
+    let blob = dir.path().join("blob.rlib");
+    let output = dir.path().join("output.rlib");
+    let Some(id) = seed_registered_link(&blob, &output, b"original") else {
+        eprintln!("SKIP overflow_keeps_stat_unchanged_blobs_trusted: no hardlink support");
+        return;
+    };
+
+    // Overflow means "the event queue saturated", not "every file changed".
+    // An untouched blob must survive the sweep still trusted, so its next read
+    // does not pay a full blake3 re-hash.
+    mark_changed_registered_links_suspect();
+    assert_eq!(
+        registered_link_suspect(id),
+        Some(false),
+        "stat-unchanged blob must stay trusted across a watcher overflow"
+    );
+    verify_registered_blob(&blob).expect("untouched blob must still verify");
+    assert!(blob.exists(), "a trusted blob must not be evicted");
+}
+
+#[test]
+fn overflow_still_rejects_a_blob_poisoned_through_its_alias() {
+    let dir = tempfile::tempdir().unwrap();
+    let blob = dir.path().join("blob.rlib");
+    let output = dir.path().join("output.rlib");
+    let Some(id) = seed_registered_link(&blob, &output, b"original") else {
+        eprintln!("SKIP overflow_still_rejects_a_blob_poisoned_through_its_alias: no hardlinks");
+        return;
+    };
+
+    // Writing through the alias mutates the shared inode, so the blob's own
+    // (mtime, size) signature changes. The cheap sweep must notice and fall
+    // back to the full re-hash, which then rejects and evicts the blob.
+    make_writable(&output).unwrap();
+    std::fs::write(&output, b"poisoned with a different length").unwrap();
+
+    mark_changed_registered_links_suspect();
+    assert_eq!(
+        registered_link_suspect(id),
+        Some(true),
+        "a blob mutated through its alias must be marked suspect by the sweep"
+    );
+
+    let error = verify_registered_blob(&blob).expect_err("overflow poison must be rejected");
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    assert!(!blob.exists(), "a poisoned blob must be evicted");
+}
+
+#[test]
+fn overflow_marks_an_unstattable_blob_suspect() {
+    let dir = tempfile::tempdir().unwrap();
+    let blob = dir.path().join("blob.rlib");
+    let output = dir.path().join("output.rlib");
+    let Some(id) = seed_registered_link(&blob, &output, b"original") else {
+        eprintln!("SKIP overflow_marks_an_unstattable_blob_suspect: no hardlink support");
+        return;
+    };
+
+    // A blob that cannot be stat'd yields no cheap evidence, so the sweep must
+    // fall back to suspect rather than silently vouching for it.
+    make_writable(&blob).unwrap();
+    std::fs::remove_file(&blob).unwrap();
+
+    mark_changed_registered_links_suspect();
+    assert_eq!(
+        registered_link_suspect(id),
+        Some(true),
+        "an unstattable blob has no cheap evidence and must be marked suspect"
+    );
+}
+
+#[tokio::test]
+async fn watcher_degradation_is_recorded_and_recoverable() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_dir: NormalizedPath = dir.path().join("cache").into();
+    let server =
+        DaemonServer::bind_with_cache_dir(&crate::ipc::unique_test_endpoint(), &cache_dir).unwrap();
+    let state = server.test_state_arc();
+
+    // A failed watcher init must be visible, not a single startup warn line.
+    record_watcher_degradation(&state, "injected watcher init failure");
+    assert!(
+        !state.watcher_active.load(Ordering::Acquire),
+        "degradation must disable the fast hit tiers"
+    );
+    assert_eq!(
+        state.watcher_degradations.load(Ordering::Relaxed),
+        1,
+        "degradation must bump the status-visible counter"
+    );
+
+    // ...and it must be a temporary condition: re-arming restores the pipeline
+    // rather than leaving the daemon degraded for its whole lifetime.
+    assert!(
+        arm_watcher_pipeline(&state).await,
+        "re-arm must succeed once the injected failure clears"
+    );
+    assert!(
+        state.watcher_active.load(Ordering::Acquire),
+        "a successful re-arm must restore the fast hit tiers"
+    );
+    assert_eq!(
+        state.watcher_degradations.load(Ordering::Relaxed),
+        1,
+        "recovery must preserve the degradation count for post-hoc diagnosis"
+    );
+
+    state.shutdown_requested.store(true, Ordering::Release);
+    state.shutdown.notify_waiters();
+}

--- a/crates/zccache-ipc/src/mod_tests.rs
+++ b/crates/zccache-ipc/src/mod_tests.rs
@@ -112,6 +112,8 @@ fn test_daemon_status(endpoint: &str) -> zccache_protocol::DaemonStatus {
         dep_graph_version: zccache_depgraph::DEPGRAPH_VERSION,
         dep_graph_disk_size: 0,
         dep_graph_persisted: false,
+        watcher_active: true,
+        watcher_degradations: 0,
     }
 }
 

--- a/crates/zccache-protocol/proto/zccache_v1.proto
+++ b/crates/zccache-protocol/proto/zccache_v1.proto
@@ -256,6 +256,8 @@ message DaemonStatus {
   uint32 dep_graph_version = 25;
   uint64 dep_graph_disk_size = 26;
   bool dep_graph_persisted = 27;
+  bool watcher_active = 28;
+  uint64 watcher_degradations = 29;
 }
 
 message PrivateDaemonOwnerStatus {

--- a/crates/zccache-protocol/src/lib.rs
+++ b/crates/zccache-protocol/src/lib.rs
@@ -22,18 +22,23 @@ pub const UNKNOWN_MISS_WARNING_PREFIX: &str = "zccache[warn][M]:";
 /// This remains the active compatibility version until the v16 prost dispatcher
 /// is wired through the IPC transport. Do not change `PROTOCOL_VERSION` to v16
 /// while `encode_message` and `decode_message` still serialize bincode bodies.
-pub const BINCODE_PROTOCOL_VERSION: u32 = 20;
+pub const BINCODE_PROTOCOL_VERSION: u32 = 21;
 
 /// Prost daemon wire version.
 ///
 /// The prost schema and frame helpers use this value. A future change will make
 /// the daemon dispatch v15 bincode and v16 prost frames concurrently.
-pub const PROST_PROTOCOL_VERSION: u32 = 21;
+pub const PROST_PROTOCOL_VERSION: u32 = 22;
 
 /// Protocol version number. Bump this when the wire format changes:
 /// new/removed/reordered enum variants or struct field changes.
 /// Patch releases that don't change the protocol keep the same version.
 ///
+/// v21 (bincode) / v22 (prost): `DaemonStatus` gained `watcher_active` and
+///                  `watcher_degradations` so an operator can see that a
+///                  daemon is running without a file watcher — both fast hit
+///                  tiers disabled — instead of inferring it from startup
+///                  logs (issue #1156).
 /// v20 (bincode) / v21 (prost): added `Response::CompileProgress` — interim,
 ///                  non-terminal queue/in-flight heartbeats pushed on the
 ///                  request connection while a compile waits for a

--- a/crates/zccache-protocol/src/messages/compat/daemon_status.rs
+++ b/crates/zccache-protocol/src/messages/compat/daemon_status.rs
@@ -39,6 +39,8 @@ fn daemon_status_expanded_roundtrip() {
         dep_graph_version: 1,
         dep_graph_disk_size: 2_500_000,
         dep_graph_persisted: true,
+        watcher_active: true,
+        watcher_degradations: 0,
     };
     roundtrip(&status);
 }
@@ -73,6 +75,8 @@ fn daemon_status_version_field_roundtrips() {
         dep_graph_version: 0,
         dep_graph_disk_size: 0,
         dep_graph_persisted: false,
+        watcher_active: false,
+        watcher_degradations: 3,
     };
     roundtrip(&with_version);
 }

--- a/crates/zccache-protocol/src/messages/compat/mod.rs
+++ b/crates/zccache-protocol/src/messages/compat/mod.rs
@@ -85,6 +85,8 @@ pub(super) fn sample_daemon_status() -> DaemonStatus {
         dep_graph_version: 20,
         dep_graph_disk_size: 21,
         dep_graph_persisted: true,
+        watcher_active: true,
+        watcher_degradations: 22,
     }
 }
 
@@ -102,7 +104,10 @@ pub(super) fn sample_artifact() -> ArtifactData {
 
 // Compile-time check: PROTOCOL_VERSION must be positive.
 const _: () = assert!(super::super::PROTOCOL_VERSION > 0);
-// Compile-time check: PROTOCOL_VERSION == 20 after `Response::CompileProgress`
+// Compile-time check: PROTOCOL_VERSION == 21 after `DaemonStatus` gained
+// `watcher_active` / `watcher_degradations` (issue #1156: watcher degradation
+// must be visible in status, not only in startup logs). v20 was the pin after
+// `Response::CompileProgress`
 // was appended (issue #1216: interim compile queue heartbeats). v18 was the pin
 // after staged-output telemetry was added.
 // v17 added ExecProbe/ExecStore (issue #838 slice 1) for caller-owned tool caching (e.g. the
@@ -118,4 +123,4 @@ const _: () = assert!(super::super::PROTOCOL_VERSION > 0);
 // pin after SessionStats gained `phase_profile`. v8 was the pin after
 // Compile/CompileEphemeral gained `stdin` and ArtifactPayload replaced
 // ArtifactOutput.data: Arc<Vec<u8>> (issue #296 Option B).
-const _FINGERPRINT_VERSION: () = assert!(super::super::PROTOCOL_VERSION == 20);
+const _FINGERPRINT_VERSION: () = assert!(super::super::PROTOCOL_VERSION == 21);

--- a/crates/zccache-protocol/src/messages/status.rs
+++ b/crates/zccache-protocol/src/messages/status.rs
@@ -98,6 +98,12 @@ pub struct DaemonStatus {
     /// successfully written to disk since startup (periodic save or shutdown).
     /// `false` on a fresh daemon that has not yet flushed its first snapshot.
     pub dep_graph_persisted: bool,
+    /// Whether the file watcher is currently armed. `false` means both fast
+    /// hit tiers are disabled and shared cache blobs re-hash on every read.
+    pub watcher_active: bool,
+    /// Watcher-arm failures since daemon start (issue #1156). Non-zero with
+    /// `watcher_active == true` means the daemon recovered via a re-arm.
+    pub watcher_degradations: u64,
 }
 
 /// Per-session statistics, returned when the session opted in to tracking.

--- a/crates/zccache-protocol/src/wire_prost/convert.rs
+++ b/crates/zccache-protocol/src/wire_prost/convert.rs
@@ -424,6 +424,8 @@ pub(super) fn daemon_status_to_prost(status: &crate::DaemonStatus) -> zccache_v1
         dep_graph_version: status.dep_graph_version,
         dep_graph_disk_size: status.dep_graph_disk_size,
         dep_graph_persisted: status.dep_graph_persisted,
+        watcher_active: status.watcher_active,
+        watcher_degradations: status.watcher_degradations,
     }
 }
 
@@ -464,6 +466,8 @@ pub(super) fn daemon_status_from_prost(
         dep_graph_version: status.dep_graph_version,
         dep_graph_disk_size: status.dep_graph_disk_size,
         dep_graph_persisted: status.dep_graph_persisted,
+        watcher_active: status.watcher_active,
+        watcher_degradations: status.watcher_degradations,
     })
 }
 

--- a/docs/architecture/metadata-cache.md
+++ b/docs/architecture/metadata-cache.md
@@ -84,6 +84,17 @@ Three layers, from fast to slow:
 - Events are sent from the watcher thread to the daemon's tokio runtime via a `tokio::sync::mpsc::channel`.
 - Fallback: if the native watcher fails to initialize (e.g., inotify watch limit exhausted), fall back to `notify::PollWatcher` with a 2-second interval.
 
+### Degradation and Re-arm (issue #1156)
+
+Arming can still fail outright — inotify `max_user_watches` exhaustion on a large tree is common and usually transient. A watcher-less daemon is a performance cliff, not a correctness problem: both fast hit tiers bail on `watcher_active == false`, and `verify_registered_blob` fully re-hashes every shared hardlink blob on every read. Left unhandled, one failed init at startup degrades the daemon for its entire lifetime.
+
+`daemon/server/run.rs` therefore treats a failed arm as temporary:
+
+- **Loud degradation.** `record_watcher_degradation` emits a `tracing::warn!`, writes a durable `watcher_degraded` lifecycle event, and bumps a monotonic counter surfaced as `Watcher:` in `zccache status` (`DaemonStatus::watcher_active` / `watcher_degradations`, protocol v21). Degradation is visible without trawling startup logs.
+- **Bounded re-arm.** A background task retries `arm_watcher_pipeline` starting at 60 s with exponential backoff capped at 600 s, until it succeeds or the daemon shuts down. Success flips `watcher_active` / `WATCHER_AVAILABLE` back on, starts the settle + consumer tasks, and writes a `watcher_rearmed` event. The retry is cheap enough to be always-on, so no config knob is exposed.
+
+The degradation counter is deliberately *not* reset on recovery: `active (recovered from N degradation(s))` in status is the post-hoc signal that the host is near its watch limit.
+
 ### Event Processing
 
 A dedicated tokio task receives events from the channel and processes them:
@@ -121,6 +132,13 @@ When the OS event queue overflows (inotify queue full, FSEvents `kFSEventStreamE
 2. **Log a warning** indicating watcher overflow.
 3. **Re-register watches** if the watcher was in a recoverable state.
 4. Subsequent lookups will stat-verify every file — expensive but correct.
+
+**Scoped hardlink-registry recovery (issue #1156).** Overflow means "the event queue saturated", not "every file changed" — the usual triggers are a wide `git checkout` or a burst of parallel build output. Marking the whole hardlink registry suspect turns that momentary burst into a full blake3 re-hash of every shared blob on its next read. Instead, `mark_changed_registered_links_suspect` re-verifies each record against the cheap `(mtime, size)` signature captured when its `expected_hash` was computed:
+
+- **Signature unchanged** → the record stays trusted and skips the re-hash. Writing through any hardlink alias mutates the shared inode, so an unchanged signature on the blob path is positive evidence no alias touched the bytes — the same signal the metadata cache already trusts at `Medium` confidence.
+- **Signature changed, missing, or unstattable** → marked suspect, so the read path still falls back to the full re-hash and rejects/evicts a poisoned blob.
+
+The signature is captured *before* hashing, never after: a stat-after would record the post-change value and could vouch for a torn read. Correctness is unchanged — the cheap check only ever *skips* work where there is evidence the bytes are intact, and never accepts bytes that failed a hash check. The sweep's `links_unchanged` / `links_suspect` split is recorded in a `watcher_overflow` lifecycle event.
 
 ### Scope Management
 


### PR DESCRIPTION
Closes #1156.

Two watcher-lifecycle behaviors silently stranded the daemon on its slowest paths for the rest of its lifetime.

## 1. Failed watcher init was a lifetime sentence → bounded re-arm

`NotifyWatcher::new` failing — or the 5 s startup watcher lock timing out — logged one `warn`, called `set_registry_watcher_available(false)`, and returned. `watcher_active` was only ever set `true` once at startup, so there was no way back. While degraded:

- both fast hit tiers bail immediately (`hit_branches.rs:35`, `:191`), so every compile pays full source+header hashing;
- `verify_registered_blob` fully re-hashes every shared (`link_count > 1`) cache blob on every hit.

A transient inotify `max_user_watches` exhaustion on a large tree therefore degraded the daemon for hours off a single log line.

Arming is now a retriable operation (`arm_watcher_pipeline`). On failure a background task retries every 60 s with exponential backoff capped at 600 s, until it succeeds or the daemon shuts down; success flips `watcher_active` / `WATCHER_AVAILABLE` back on and starts the settle + consumer tasks in place. The retry is cheap enough to be always-on, so no config knob is added. The shutdown branch follows the existing `notify_waiters()` rebroadcast pattern used by the accept and consumer loops.

## 2. Overflow condemned the whole hardlink registry → scoped stat sweep

`SettledEvent::Overflow` called `mark_all_registered_links_suspect()`. Overflow means *the event queue saturated*, not *every file changed* — the usual triggers are a wide `git checkout` or a burst of parallel build output — so one momentary burst cascaded into a full blake3 re-hash of every shared blob on its next read.

`mark_changed_registered_links_suspect` now re-verifies each record against the cheap `(mtime, size)` signature captured at registration:

- **unchanged** → stays trusted, skips the re-hash. Writing through any hardlink alias mutates the shared inode, so an unchanged signature on the blob path is positive evidence no alias touched the bytes — the same signal the metadata cache already trusts at `Confidence::Medium`.
- **changed / missing / unstattable** → marked suspect, so the read path still falls back to the full re-hash and rejects+evicts a poisoned blob.

The signature is captured **before** hashing, never after: a stat-after would record the post-change value and could vouch for a torn read. Correctness is unchanged — the cheap check only ever *skips* work where there is evidence the bytes are intact, and never accepts bytes that failed a hash check.

## Loud degradation

Per the loud-forensics convention, running without a watcher is no longer inferable only from startup logs:

- `record_watcher_degradation` emits a `tracing::warn!` plus durable `watcher_degraded` / `watcher_rearmed` / `watcher_overflow` lifecycle events (the overflow event records the `links_unchanged` / `links_suspect` split);
- `DaemonStatus` gained `watcher_active` + `watcher_degradations`, surfaced as a `Watcher:` line in `zccache status` (`DEGRADED — fast hit tiers disabled (N failure(s), retrying)`). The counter is deliberately not reset on recovery — `active (recovered from N degradation(s))` is the signal that the host is near its watch limit.

`PROTOCOL_VERSION` 20 → 21 (prost 21 → 22) per the wire-format convention, with the proto field additions and the compat fingerprint pin updated.

## Tests

New `daemon/server/tests/watcher_lifecycle.rs` (4 tests, all passing):

- overflow keeps a stat-unchanged blob trusted and still verifying;
- overflow still rejects+evicts a blob poisoned through its alias (signature changed → falls back to the full re-hash);
- an unstattable blob has no cheap evidence and is marked suspect;
- degradation bumps the status-visible counter and disables the fast tiers, and a subsequent `arm_watcher_pipeline` restores them while preserving the count.

The link registry is a process-global static, so every assertion is scoped to the test's own `FileId` rather than the aggregate sweep counters.

## Gates

- `soldr cargo test -p zccache-daemon-core --features test-support,daemon-entry --lib` — **681 passed, 0 failed**
- `soldr cargo test -p zccache-protocol -p zccache-ipc --all-targets` — pass
- `soldr cargo clippy -p zccache-protocol -p zccache-cli-core -p zccache-core --all-targets --features cli -- -D warnings` — clean
- `soldr cargo fmt --all -- --check` — clean

Hit-path code is untouched on the armed path (the overflow sweep is strictly cheaper than the blanket marking it replaces), so no perf-matrix threshold is at stake.

Docs: `docs/architecture/metadata-cache.md` gains "Degradation and Re-arm" and the scoped-overflow-recovery subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)