### PR TITLE
fix(tests): give every daemon-spinning test its own cache root (#1254, #1261)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/tests/link_cache.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/link_cache.rs
@@ -5,7 +5,7 @@
 use std::path::Path;
 
 use super::super::*;
-use super::CacheDirEnvGuard;
+use super::{bind_isolated_server, CacheDirEnvGuard};
 
 #[cfg(unix)]
 fn write_fake_linker(dir: &Path) -> std::path::PathBuf {
@@ -403,7 +403,7 @@ async fn parallel_same_directory_links_are_isolated() {
 #[tokio::test]
 async fn side_effect_lock_allows_different_output_directories() {
     let tmp = tempfile::tempdir().unwrap();
-    let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
+    let server = bind_isolated_server(tmp.path());
     let lock_a = server.state.link_output_lock(tmp.path().join("a").into());
     let same_lock_a = server.state.link_output_lock(tmp.path().join("a").into());
     let lock_b = server.state.link_output_lock(tmp.path().join("b").into());

--- a/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
@@ -38,6 +38,28 @@ mod system_includes_deferred;
 mod watcher_lifecycle;
 mod write_cached;
 
+/// Bind a daemon server on a fresh endpoint, rooted at a cache directory
+/// under `cache_root` that no other test can reach.
+///
+/// Prefer this over [`super::DaemonServer::bind`] in tests. `bind` resolves
+/// its cache directory from the process-global `ZCCACHE_CACHE_DIR`, so a test
+/// that calls it without holding [`CacheDirEnvGuard`]'s lock reads whatever
+/// root a *concurrently running* guarded test has installed. Two daemons then
+/// share one cache root and the loser fails to acquire it — surfacing as
+/// `bind(..).unwrap()` panicking with an `Endpoint` error rather than as any
+/// assertion in the test that happened to lose (issues #1254, #1261).
+pub(super) fn bind_isolated_server(cache_root: &Path) -> super::DaemonServer {
+    bind_isolated_server_at(&crate::ipc::unique_test_endpoint(), cache_root)
+}
+
+/// As [`bind_isolated_server`], for tests that need the endpoint themselves
+/// (to connect a client) and so must mint it before binding.
+pub(super) fn bind_isolated_server_at(endpoint: &str, cache_root: &Path) -> super::DaemonServer {
+    let cache_dir: crate::core::NormalizedPath = cache_root.join("zccache-cache").into();
+    super::DaemonServer::bind_with_cache_dir(endpoint, &cache_dir)
+        .expect("bind daemon on an isolated cache root")
+}
+
 /// RAII guard that overrides `ZCCACHE_CACHE_DIR` for the duration of a
 /// single test, restoring the previous value on drop. Shared between
 /// `link_cache` (link side-effects test) and `server_ipc`

--- a/crates/zccache-daemon-core/src/daemon/server/tests/pending_cache_writes.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/pending_cache_writes.rs
@@ -13,14 +13,15 @@ use std::time::{Duration, Instant};
 
 use super::super::pending_writes;
 use super::super::*;
+use super::bind_isolated_server;
 
 /// At daemon startup the pending registry must be empty — DD-025
 /// condition 3 requires the scope be per-process. A non-empty registry
 /// at bind time would mean some other state path is leaking into it.
 #[tokio::test]
 async fn pending_cache_writes_is_empty_on_fresh_daemon() {
-    let endpoint = crate::ipc::unique_test_endpoint();
-    let server = DaemonServer::bind(&endpoint).unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let server = bind_isolated_server(tmp.path());
     assert!(
         server.state.pending_cache_writes.is_empty(),
         "fresh daemon must have empty pending_cache_writes registry, found {}",
@@ -33,8 +34,8 @@ async fn pending_cache_writes_is_empty_on_fresh_daemon() {
 /// entry and waits; `complete` wakes it and clears the registry.
 #[tokio::test]
 async fn pending_registry_register_and_complete_through_shared_state() {
-    let endpoint = crate::ipc::unique_test_endpoint();
-    let server = DaemonServer::bind(&endpoint).unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let server = bind_isolated_server(tmp.path());
     let state = Arc::clone(&server.state);
 
     let key = "deadbeefcafebabe0000000000000000";
@@ -75,8 +76,8 @@ async fn pending_registry_register_and_complete_through_shared_state() {
 ///    succeed.
 #[tokio::test]
 async fn pending_registry_notify_timeout_through_shared_state() {
-    let endpoint = crate::ipc::unique_test_endpoint();
-    let server = DaemonServer::bind(&endpoint).unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let server = bind_isolated_server(tmp.path());
     let state = Arc::clone(&server.state);
 
     let key = "feedfacedeadbeef0000000000000000";
@@ -105,8 +106,8 @@ async fn pending_registry_notify_timeout_through_shared_state() {
 /// immediately — the registry is near-zero overhead at rest.
 #[tokio::test]
 async fn pending_registry_warm_lookup_pays_no_wait() {
-    let endpoint = crate::ipc::unique_test_endpoint();
-    let server = DaemonServer::bind(&endpoint).unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let server = bind_isolated_server(tmp.path());
     let state = Arc::clone(&server.state);
 
     // #1254: this asserted `elapsed < 2ms` against a 5ms wait budget. The

--- a/crates/zccache-daemon-core/src/daemon/server/tests/pending_cache_writes.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/pending_cache_writes.rs
@@ -12,7 +12,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use super::super::pending_writes;
-use super::super::*;
 use super::bind_isolated_server;
 
 /// At daemon startup the pending registry must be empty — DD-025

--- a/crates/zccache-daemon-core/src/daemon/server/tests/server_ipc.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/server_ipc.rs
@@ -7,21 +7,30 @@
 use super::super::*;
 use super::CacheDirEnvGuard;
 
-pub(super) async fn start_daemon() -> (String, tokio::task::JoinHandle<()>, Arc<Notify>) {
+/// The returned `TempDir` owns this daemon's cache root; callers must hold it
+/// for as long as the daemon runs. See [`super::bind_isolated_server`] for why
+/// tests must not let a daemon resolve the process-global cache directory.
+pub(super) async fn start_daemon() -> (
+    String,
+    tokio::task::JoinHandle<()>,
+    Arc<Notify>,
+    tempfile::TempDir,
+) {
+    let cache_root = tempfile::tempdir().unwrap();
     let endpoint = crate::ipc::unique_test_endpoint();
-    let mut server = DaemonServer::bind(&endpoint).unwrap();
+    let mut server = super::bind_isolated_server_at(&endpoint, cache_root.path());
     let shutdown = server.shutdown_handle();
     let handle = tokio::spawn(async move {
         server.run(0).await.unwrap();
     });
-    (endpoint, handle, shutdown)
+    (endpoint, handle, shutdown, cache_root)
 }
 
 #[tokio::test]
 #[ignore] // integration-level: starts real daemon with IPC + file watcher
 async fn test_server_ping_pong() {
     crate::test_support::test_timeout(async {
-        let (endpoint, server_task, shutdown) = start_daemon().await;
+        let (endpoint, server_task, shutdown, _cache_root) = start_daemon().await;
 
         let mut client = crate::ipc::connect(&endpoint).await.unwrap();
         client.send(&Request::Ping).await.unwrap();
@@ -38,7 +47,7 @@ async fn test_server_ping_pong() {
 #[ignore] // integration-level: starts real daemon with IPC + file watcher
 async fn test_server_shutdown_request() {
     crate::test_support::test_timeout(async {
-        let (endpoint, server_task, shutdown) = start_daemon().await;
+        let (endpoint, server_task, shutdown, _cache_root) = start_daemon().await;
 
         let mut client = crate::ipc::connect(&endpoint).await.unwrap();
         client.send(&Request::Shutdown).await.unwrap();
@@ -55,7 +64,7 @@ async fn test_server_shutdown_request() {
 #[ignore] // integration-level: starts real daemon with IPC + file watcher
 async fn test_server_clear_empty() {
     crate::test_support::test_timeout(async {
-        let (endpoint, server_task, shutdown) = start_daemon().await;
+        let (endpoint, server_task, shutdown, _cache_root) = start_daemon().await;
 
         let mut client = crate::ipc::connect(&endpoint).await.unwrap();
         client.send(&Request::Clear).await.unwrap();
@@ -86,7 +95,7 @@ async fn test_server_status() {
     crate::test_support::test_timeout(async {
         let tmp = tempfile::tempdir().unwrap();
         let _env = CacheDirEnvGuard::set(tmp.path());
-        let (endpoint, server_task, shutdown) = start_daemon().await;
+        let (endpoint, server_task, shutdown, _cache_root) = start_daemon().await;
 
         let mut client = crate::ipc::connect(&endpoint).await.unwrap();
         client.send(&Request::Status).await.unwrap();
@@ -117,7 +126,7 @@ async fn test_server_status_reports_explicit_daemon_namespace() {
     crate::test_support::test_timeout(async {
         let tmp = tempfile::tempdir().unwrap();
         let _env = CacheDirEnvGuard::set_with_namespace(tmp.path(), "soldr-dev");
-        let (endpoint, server_task, shutdown) = start_daemon().await;
+        let (endpoint, server_task, shutdown, _cache_root) = start_daemon().await;
 
         let mut client = crate::ipc::connect(&endpoint).await.unwrap();
         client.send(&Request::Status).await.unwrap();
@@ -142,7 +151,7 @@ async fn private_session_start_registers_redacted_status_and_owner_refs() {
     crate::test_support::test_timeout(async {
         let tmp = tempfile::tempdir().unwrap();
         let _env = CacheDirEnvGuard::set_with_namespace(tmp.path(), "soldr-dev");
-        let (endpoint, server_task, shutdown) = start_daemon().await;
+        let (endpoint, server_task, shutdown, _cache_root) = start_daemon().await;
 
         let mut client = crate::ipc::connect(&endpoint).await.unwrap();
         client
@@ -210,7 +219,7 @@ async fn private_session_start_accepts_top_level_cache_root() {
     crate::test_support::test_timeout(async {
         let tmp = tempfile::tempdir().unwrap();
         let _env = CacheDirEnvGuard::set_with_namespace(tmp.path(), "soldr-dev-parent-root");
-        let (endpoint, server_task, shutdown) = start_daemon().await;
+        let (endpoint, server_task, shutdown, _cache_root) = start_daemon().await;
 
         let mut client = crate::ipc::connect(&endpoint).await.unwrap();
         client
@@ -266,7 +275,7 @@ async fn cli_session_lifecycle() {
         )
         .unwrap();
 
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let mut client = crate::ipc::connect(&endpoint).await.unwrap();
 
         // session-start
@@ -640,7 +649,7 @@ async fn cli_compile_unknown_uuid_is_idempotent() {
         // production daemon writing the global index blob.
         let _cache_dir = CacheDirEnvGuard::set(&tmp.path().join("zccache-cache"));
 
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let mut client = crate::ipc::connect(&endpoint).await.unwrap();
 
         let cwd = tmp.path().to_string_lossy().into_owned();
@@ -696,7 +705,7 @@ async fn cli_clear_resets_cache() {
 
         std::fs::write(&src, "int main() { return 0; }\n").unwrap();
 
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let mut client = crate::ipc::connect(&endpoint).await.unwrap();
 
         // Start session
@@ -859,7 +868,7 @@ async fn cli_multi_file_compilation_runs_directly() {
         std::fs::write(&src_a, "int foo() { return 1; }\n").unwrap();
         std::fs::write(&src_b, "int bar() { return 2; }\n").unwrap();
 
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let mut client = crate::ipc::connect(&endpoint).await.unwrap();
 
         // Start session

--- a/crates/zccache-daemon-core/src/daemon/server/tests/session_errors.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/session_errors.rs
@@ -7,7 +7,7 @@ use super::server_ipc::start_daemon;
 #[ignore] // integration-level: starts real daemon with IPC
 async fn cli_session_end_invalid_id() {
     crate::test_support::test_timeout(async {
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let mut client = crate::ipc::connect(&endpoint).await.unwrap();
 
         client
@@ -39,7 +39,7 @@ async fn cli_session_end_invalid_id() {
 #[ignore] // integration-level: starts real daemon with IPC
 async fn cli_session_end_unknown_uuid_is_idempotent() {
     crate::test_support::test_timeout(async {
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let mut client = crate::ipc::connect(&endpoint).await.unwrap();
 
         client

--- a/crates/zccache-daemon-core/src/daemon/server/tests/session_staged_attribution.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/session_staged_attribution.rs
@@ -54,7 +54,7 @@ async fn concurrent_failed_requests_are_attributed_only_to_their_session() {
 
         let temp = tempfile::tempdir().unwrap();
         let endpoint = crate::ipc::unique_test_endpoint();
-        let mut server = DaemonServer::bind(&endpoint).unwrap();
+        let mut server = super::bind_isolated_server_at(&endpoint, temp.path());
         let state = server.test_state_arc();
         let shutdown = server.shutdown_handle();
         let server_task = tokio::spawn(async move { server.run(0).await.unwrap() });


### PR DESCRIPTION
## Root cause

`DaemonServer::bind` resolves its cache directory from the process-global `ZCCACHE_CACHE_DIR`. `CacheDirEnvGuard` sets that variable **and holds a global mutex** for the test's duration, so guarded tests serialize against each other.

Tests that call `bind()` *without* the guard take no lock. They read whichever root a **concurrently running guarded test** has installed, so two daemons contend for one cache root and the loser fails to acquire it.

The failure therefore happens at bind time, not in any assertion:

- #1254 reports a panic at `link_cache.rs:406:74` on head `a95ccf64`.
- At that commit, line 406 is `let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();` — and column 74 is exactly the `.unwrap()`.

That also explains the part of #1254 that looked strangest — "run 3 failed a *different* pair" — without needing a shared timing assumption. Every test #1254 names is in the unguarded set. Of the 19 `bind()` call sites under `server/tests/`, 13 are guarded (already serialized) and 6 were not.

## Relationship to #1255

#1255 fixed the wall-clock-margin half of #1254 (`pending_registry_warm_lookup_pays_no_wait` asserting `elapsed < 2ms` against a 5 ms budget). It also touched `link_cache.rs`, but not this test: `side_effect_lock_allows_different_output_directories` is byte-identical at `a95ccf64` and on current `main`, at the same line numbers, and its unguarded `bind()` is untouched. This PR is the other half.

## Change

- `bind_isolated_server{,_at}` in `tests/mod.rs`, binding via the existing `bind_with_cache_dir` on a per-test `TempDir`.
- The six previously unguarded call sites under `server/tests/` routed through them.
- `start_daemon` now owns and returns its cache root, isolating its 13 callers.

No production code changes; this is test-harness isolation only.

## Known gap — please read before closing #1261

I scoped my search to `server/tests/` and **that was too narrow**. `handle_compile/cached_hit.rs` has 4 more `DaemonServer::bind()` calls and zero `CacheDirEnvGuard` references, so they are unguarded in exactly the same way and are **not** fixed here:

```
handle_compile/cached_hit.rs   4 bind sites, 0 guards
```

Crate-wide after this PR: 13 `DaemonServer::bind(` remain — 1 in `entry.rs` (production, correct) and 12 guarded ones under `server/tests/`, plus those 4 in `cached_hit.rs`.

So this PR fixes every test #1254 *names*, but does not finish #1261's general "tests must not share a cache root" property. I'd suggest **closing #1254 and leaving #1261 open** for the `cached_hit.rs` sites, rather than closing both on this PR.

## Verification — and its limits

`clippy -D warnings` clean and the test build is clean under `RUSTFLAGS=-D warnings` (verified by exit code — an earlier "clippy clean" claim of mine was wrong because my log filter silently dropped soldr's timing-prefixed diagnostic lines; CI caught the resulting `unused import`). 681 passed / 0 failed locally, test count unchanged from `main`.

**I am not presenting the green runs as proof.** I ran the identical 3× on baseline `main` and it was *also* 3/3 green — since #1255 landed, the flake no longer reproduces locally for me, so this is not an A/B reproduction and I could not demonstrate the failure before fixing it.

The evidence is structural rather than empirical: an unguarded `bind()` reads a mutex-protected global without taking the lock, and the reported panic column lands precisely on that call. Independent of #1254, tests that spin up a daemon should not be able to reach each other's cache root.

## Unrelated, but worth knowing

`crates/zccache-daemon-core/target/` is not gitignored, and soldr writes `.soldr-fallback-output-scrub-v1` (+ `.lock`) into it during a build. A `git add -A` from the repo root sweeps them into a commit — it caught me here before I stripped them back out. Might be worth a `.gitignore` entry.

Closes #1254.
Contributes to #1261 (left open — see "Known gap" above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
