### PR TITLE
perf(ci): cut macOS/Windows runner queue starvation

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -6,6 +6,16 @@ on:
       os:
         required: true
         type: string
+      # `cargo check --workspace` is a strict subset of what the `test` job's
+      # `cargo test --workspace --lib --bins --no-run` already compiles on the
+      # same OS with the same RUSTFLAGS — it codegens and *links* the lib, the
+      # cfg(test) lib, and every bin. On macOS/Windows the extra job buys only
+      # a marginally earlier failure signal while consuming a scarce runner
+      # slot that queues for 16-32 minutes. Linux keeps it (cheap, unqueued).
+      run_check:
+        required: false
+        type: boolean
+        default: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,7 +24,9 @@ env:
 jobs:
   check:
     name: Check
+    if: inputs.run_check
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: zackees/setup-soldr@01aea6d47db8fedcafd350e2d42e19290c68824e
@@ -44,6 +56,10 @@ jobs:
   test:
     name: Test
     runs-on: ${{ inputs.os }}
+    # Without this the job inherits GitHub's 360-minute default, so a hung
+    # test holds a scarce macOS/Windows runner slot for six hours. Observed
+    # runtime is 2-5 minutes; 45 leaves ample headroom for a cold cache.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
       - uses: zackees/setup-soldr@01aea6d47db8fedcafd350e2d42e19290c68824e

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -28,6 +28,10 @@ on:
       - ".editorconfig"
       - "tasks/**"
 
+concurrency:
+  group: ci-linux-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   x86:
     uses: ./.github/workflows/ci-check.yml

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -28,13 +28,23 @@ on:
       - ".editorconfig"
       - "tasks/**"
 
-jobs:
-  x86:
-    uses: ./.github/workflows/ci-check.yml
-    with:
-      os: macos-14
+# Superseded PR runs used to keep holding macOS slots while a fresh run
+# queued behind them. Against GitHub's 5-concurrent-job macOS cap that is
+# what produced the 16 -> 32 -> 49 -> 59 minute queue staircase. Pushes to
+# main are never cancelled: release-auto.yml triggers on push-to-main
+# version bumps, so every commit that lands must be fully tested.
+concurrency:
+  group: ci-macos-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-  arm:
+jobs:
+  # macos-14 is Apple Silicon. This was previously two jobs, `x86` and `arm`,
+  # both pinned to macos-14 — byte-identical duplicates that also derived the
+  # same cache-key-suffix and so raced each other on cache save. Real Intel
+  # coverage would mean macos-13, which is deliberately avoided: see
+  # wrapper-e2e.yml, where that pool cost 15+ minutes of queue wait per run.
+  macos:
     uses: ./.github/workflows/ci-check.yml
     with:
       os: macos-14
+      run_check: false

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -28,13 +28,19 @@ on:
       - ".editorconfig"
       - "tasks/**"
 
+concurrency:
+  group: ci-windows-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   x86:
     uses: ./.github/workflows/ci-check.yml
     with:
       os: windows-latest
+      run_check: false
 
   arm:
     uses: ./.github/workflows/ci-check.yml
     with:
       os: windows-11-arm
+      run_check: false

--- a/.github/workflows/fs-matrix.yml
+++ b/.github/workflows/fs-matrix.yml
@@ -6,8 +6,34 @@ on:
     - cron: "17 6 * * 0"
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE*"
+      - "NOTICE*"
+      - "AUTHORS*"
+      - "CODEOWNERS"
+      - "CONTRIBUTING*"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - "tasks/**"
+
+concurrency:
+  group: fs-matrix-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   matrix:

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -37,6 +37,10 @@ on:
       - ".editorconfig"
       - "tasks/**"
 
+concurrency:
+  group: wrapper-e2e-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   wrapper-e2e:
     strategy:

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,33 @@
 # Lessons
 
+## macOS CI is queue-bound, not compute-bound — cut job *count*, not job duration (2026-07-28)
+
+Measured on macOS run `30378201671`: four jobs queued 16/32/49/59 min and ran
+43s/44s/3m26s/2m42s. **61.7 min wall clock, 7.5 min compute** — ~88% of macOS CI
+time is waiting for a runner slot against GitHub's 5-concurrent-job macOS cap.
+
+Two amplifiers were live at once: `ci-macos.yml` declared jobs `x86` and `arm`
+that *both* pinned `os: macos-14` (byte-identical duplicates, and they derived
+the same `cache-key-suffix` so they also raced on cache save), and ~24 of ~38 PR
+jobs had no `concurrency` block, so superseded runs kept holding slots while a
+fresh run queued behind them. That is what produces a monotone queue staircase.
+
+**Rule:** when CI feels slow, compare `startedAt - createdAt` against
+`completedAt - startedAt` per job before optimizing anything:
+`gh run view <id> --json jobs -q '.jobs[] | "\(.name)\t\(.startedAt)\t\(.completedAt)"'`.
+If queue dominates, the only lever that works is removing jobs from scarce pools
+(macOS > windows-11-arm > everything else). Making a job faster barely moves a
+number that is 88% waiting. `wrapper-e2e.yml` already recorded this once —
+dropping one redundant `macos-13` leg was worth "15+ minutes of queue wait".
+
+**Corollary — don't cross-compile to dodge this.** Building test binaries on
+Linux and shipping them to mac/Windows runners was considered and rejected: it
+does not reduce the number of queued jobs at all, the ~32 debug test binaries
+are 600 MB–1.5 GB (5–15 min of artifact transfer to avoid ~60–90s of compile),
+Linux→macOS needs the Xcode SDK on non-Apple hardware (license violation on a
+public repo), and `build-target/action.yml` already hard-fails cross-built
+`pc-windows-msvc` because of the #269 CRT-skew `STATUS_DLL_INIT_FAILED` class.
+
 ## Stopping a `soldr cargo` task can orphan its cargo child and wedge the build lock (2026-07-08)
 
 `TaskStop` on a background `soldr cargo test/check` kills the bash wrapper but


### PR DESCRIPTION
## Problem

macOS CI is **queue-bound, not compute-bound**. Measured on macOS run [`30378201671`](https://github.com/zackees/zccache/actions/runs/30378201671) (created 16:25:47):

| Job | Queued | Ran |
|---|---|---|
| x86 / Check | 16 min | 43 s |
| arm / Check | 32 min | 44 s |
| arm / Test | 49 min | 3 m 26 s |
| x86 / Test | 59 min | 2 m 42 s |

**61.7 min wall clock for 7.5 min of compute** — ~88% of macOS CI time is spent waiting for a runner slot. A second macOS run was still `queued` 30 minutes after creation.

Three compounding causes:

1. **`ci-macos.yml` declared `x86` and `arm` both pinned to `os: macos-14`** — byte-identical duplicates (both Apple Silicon). They also derived the same `cache-key-suffix` (`check-macos-14` / `test-macos-14`), so the twins raced each other on cache save.
2. **~24 of ~38 PR jobs had no `concurrency` block.** Every push to a PR branch enqueued a fresh full set while the superseded run still held slots. Against GitHub's 5-concurrent-job macOS cap, that produces exactly the monotone 16 → 32 → 49 → 59 min staircase above.
3. **6 macOS jobs enqueued per PR**, all on `macos-14`: 4 from `ci-macos.yml`, 1 from `wrapper-e2e.yml`, 1 from `fs-matrix.yml`. A single PR nearly saturated the pool by itself.

There was already in-repo precedent for the fix: `wrapper-e2e.yml:46-51` records that keeping one redundant `macos-13` leg "added 15+ minutes of queue wait per run for redundant coverage." Removing *jobs* is what works here.

## Changes

- **Collapse the duplicate macOS job.** `ci-macos.yml` now has a single `macos` job. Fixes the cache-key-collision race at the same time. Real Intel coverage would mean `macos-13`, deliberately avoided per the `wrapper-e2e.yml` note above.
- **Add `concurrency` with PR-only `cancel-in-progress`** to `ci-macos`, `ci-windows`, `ci-linux`, `wrapper-e2e`, `fs-matrix`. Pushes to `main` are never cancelled — `release-auto.yml` triggers on push-to-main version bumps, so every landing commit stays fully tested. Groups are per-workflow so the mac and Windows lanes don't cancel each other, and the blocks live on the **caller** workflows, not on the reusable `ci-check.yml` (reusable workflows run inside the caller's run).
- **New `run_check` input on `ci-check.yml`** (default `true`), set `false` for macOS/Windows. `cargo check --workspace` is a strict subset of what the Test job's `cargo test --workspace --lib --bins --no-run` already compiles on the same OS with the same `RUSTFLAGS: "-D warnings"` — that step codegens *and links* the lib, the `cfg(test)` lib, and every bin. The only gap is `#[cfg(not(test))]`-only code in a bin crate root. An earlier failure signal is worth little when the job queues 16–32 min first. **Linux keeps Check** (cheap, unqueued).
- **`paths-ignore` on `fs-matrix.yml`**, which had bare `push`/`pull_request` triggers and so ran a 3-OS filesystem matrix on documentation-only PRs while `ci.yml` correctly skipped them.
- **`timeout-minutes` on the `ci-check` jobs.** They previously inherited GitHub's 360-minute default, so a hung test could hold a scarce macOS slot for six hours.

## Impact

macOS jobs per PR **6 → 2**, Windows **4 → 2**, plus superseded runs now cancel instead of holding slots. Expect macOS PR wall clock to drop from ~60 min toward compute time (~5 min) once the pool stops being saturated.

## Considered and rejected: cross-compile on Linux, test on mac/Windows

- **Doesn't touch the bottleneck.** Splitting build from test does not reduce the *number* of macOS jobs queued, and queue is 88% of the cost. Fixed overhead (provisioning, checkout, toolchain restore) dominates a 3m26s job.
- **Artifact transfer exceeds the savings.** `--lib --bins` produces ~32 statically-linked debug binaries (21 lib + 11 bin targets), each embedding tokio + prost + reqwest + rustls + redb + rayon + blake3: 600 MB–1.5 GB raw. That's 5–15 min of transfer to avoid ~60–90 s of compile — net negative.
- **Linux→macOS is a licensing violation on a public repo.** osxcross requires extracting the macOS SDK from Xcode, which Apple's license restricts to Apple hardware.
- **Contradicts an existing commitment.** `build-target/action.yml` hard-fails if `pc-windows-msvc` isn't built on an MSVC host — a guard added for #269 (`STATUS_DLL_INIT_FAILED` from CRT skew).

## Verification

- `actionlint` clean on all six changed workflows.
- All 23 workflow YAML files + composite actions parse.
- Job wiring asserted programmatically: `run_check` input defaults `true`; `if: inputs.run_check` is on the `check` job only (never `test`); all five `concurrency` blocks present with PR-only cancellation; `fs-matrix` `paths-ignore` present on both triggers.
- No branch protection or rulesets exist on this repo (`gh api .../branches/main/protection` → 404, `.../rulesets` → `[]`), so removing the macOS/Windows `Check` checks and renaming the macOS job breaks no required-check names.
- Post-merge: compare `startedAt - createdAt` per job against the 16/32/49/59-min baseline recorded above.

## Follow-ups (not in scope)

Catalogued during the investigation, worth filing separately:

- `ci/test.py:100-104` forces `--test-threads=1` across the whole ~2,984-test suite, serializing ~60–90 s of accumulated `sleep()` — including 27 × `Duration::from_millis(1100)` mtime-granularity waits (~30 s) that `filetime::set_file_mtime` could eliminate (already a workspace dep).
- `ci/test.py:32-48` prebuilds with a large feature union, then the test step builds with `default = []` — two disjoint feature unifications of a 445-package graph, i.e. the workspace compiles twice.
- `test-action.yml` runs 12 jobs with zero caching and pins a stale bootstrap `zccache-version: "1.11.4"`.
- `clippy.yml` / `coverage.yml` are push-to-main only, so lint and coverage regressions are only discoverable after merge (`ci.yml:63` gates `dylint` to `push` too).
- `integration.yml:25-26` has no `branches:` filter on `pull_request`, so it runs against PRs targeting any branch.
- `cache-cleanup.yml` is `workflow_dispatch`-only despite existing to solve the 10 GB cache budget problem that ~12 distinct `cache-key-suffix` namespaces create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
