### PR TITLE
fix(tests): isolate the cached_hit cache roots too (#1261)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
@@ -407,7 +407,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn target_paths_get_fresh_mtime_through_shared_materializer() {
         let dir = tempfile::tempdir().unwrap();
-        let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
+        let server = crate::daemon::server::tests::bind_isolated_server(dir.path());
         let state = server.state.as_ref();
         let cache_dir = state.artifact_dir.clone();
         let source_path: NormalizedPath = dir.path().join("source.cc").into();
@@ -500,7 +500,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn cached_hit_restores_user_depfile_alongside_object() {
         let dir = tempfile::tempdir().unwrap();
-        let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
+        let server = crate::daemon::server::tests::bind_isolated_server(dir.path());
         let state = server.state.as_ref();
         let cache_dir = state.artifact_dir.clone();
 
@@ -621,7 +621,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn cached_hit_object_only_artifact_ignores_depfile_dest() {
         let dir = tempfile::tempdir().unwrap();
-        let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
+        let server = crate::daemon::server::tests::bind_isolated_server(dir.path());
         let state = server.state.as_ref();
         let cache_dir = state.artifact_dir.clone();
 
@@ -702,7 +702,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn warm_hit_materialization_under_budget() {
         let dir = tempfile::tempdir().unwrap();
-        let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
+        let server = crate::daemon::server::tests::bind_isolated_server(dir.path());
         let state = server.state.as_ref();
         let cache_dir = state.artifact_dir.clone();
         let source_path: NormalizedPath = dir.path().join("source.cc").into();


### PR DESCRIPTION
Finishes the gap I documented in #1262.

## What was left

#1262 fixed the unguarded `DaemonServer::bind` call sites under `server/tests/`, but I scoped that search to that one directory and missed four more:

```
handle_compile/cached_hit.rs    4 bind sites, 0 CacheDirEnvGuard references
```

They are the same defect by the same mechanism: `bind` resolves its cache directory from the process-global `ZCCACHE_CACHE_DIR`, and `CacheDirEnvGuard` both sets that variable and holds a global mutex. A test that binds without the guard takes no lock, so it can land in whatever cache root a *concurrently running* guarded test installed, and the two daemons then contend for one root.

## Change

All four routed through the `bind_isolated_server` helper added in #1262. Each already had a `dir` TempDir in scope, so this only redirects the cache root — no other behaviour changes, and no production code is touched.

**Correction (see comment below):** I originally claimed this left only `entry.rs` and guarded sites. That was wrong — `server/lifecycle.rs` has one more unguarded bind in its own test module (`DaemonServer::bind( = 1`, `CacheDirEnvGuard = 0` on `origin/main@be1f578a`). #1265 fixes it. My inventory was taken against a working tree holding uncommitted edits that never landed, instead of against a committed ref.

## Verification

- Test build clean under `RUSTFLAGS=-D warnings` (checked by exit code).
- `clippy --all-targets -- -D warnings`: finished, zero warnings.
- `681 passed; 0 failed` — unchanged count, so nothing was skipped or dropped.

Two of the tests touched here (`warm_hit_materialization_under_budget` and, nearby, `perf_cow_materialization_128_hits_under_two_seconds`) are wall-clock budget assertions and will fail under heavy machine load regardless of this change; both pass in isolation. Flagging so a load-induced red on them is not mistaken for this PR.

Contributes to #1261 — deliberately **not** auto-closing it, since #1265 carries the remaining `lifecycle.rs` bind and the cache-root fault reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
