### PR TITLE
fix(daemon): isolate the last unguarded test bind and stop mis-reporting cache-root faults (#1261)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/embedded.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/embedded.rs
@@ -51,9 +51,9 @@ impl EmbeddedDaemon {
         automatic_maintenance: bool,
     ) -> Result<Self, crate::ipc::IpcError> {
         let backend_identity = crate::ipc::current_backend_identity(&endpoint)
-            .map_err(|err| crate::ipc::IpcError::Endpoint(err.to_string()))?;
+            .map_err(|err| super::lifecycle::daemon_identity_error(&endpoint, &err))?;
         let (state, index_writer_rx) = new_shared_state(&endpoint, &cache_dir, backend_identity)
-            .map_err(|error| crate::ipc::IpcError::Endpoint(error.to_string()))?;
+            .map_err(|error| super::lifecycle::cache_root_error(&cache_dir, &error))?;
         // Arm the startup depgraph-load gate as early as possible — before
         // this state can serve any compile. The shared `dep_graph_load_complete`
         // flag inits `true` ("assume loaded"); the standalone daemon flips it

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -14,10 +14,16 @@ impl DaemonServer {
     /// Create a new daemon server bound to the given endpoint, using the
     /// configured cache directory (resolved via [`crate::core::config::default_cache_dir`]).
     ///
-    /// Production callers should use this. Tests that need to isolate their
-    /// cache directory must use [`Self::bind_with_cache_dir`] instead — this
-    /// reads `ZCCACHE_CACHE_DIR` from a process-global env, which races when
-    /// multiple tests run in parallel.
+    /// Production callers should use this. Tests must not, unless they hold
+    /// `tests::CacheDirEnvGuard` for the whole call: this resolves the root
+    /// from the process-global `ZCCACHE_CACHE_DIR`, so an unguarded test
+    /// reads whatever root a *concurrently running* guarded test installed,
+    /// and the two daemons then contend for one cache root (#1254, #1261).
+    ///
+    /// The guard serializes its holders on a mutex, so guarded callers are
+    /// safe. Everything else should bind an isolated root via
+    /// `tests::bind_isolated_server`, which needs no global state at all and
+    /// therefore cannot participate in the race.
     pub fn bind(endpoint: &str) -> Result<Self, crate::ipc::IpcError> {
         Self::bind_with_cache_dir(endpoint, &crate::core::config::default_cache_dir())
     }
@@ -31,9 +37,9 @@ impl DaemonServer {
     ) -> Result<Self, crate::ipc::IpcError> {
         let listener = IpcListener::bind(endpoint)?;
         let backend_identity = crate::ipc::current_backend_identity(endpoint)
-            .map_err(|err| crate::ipc::IpcError::Endpoint(err.to_string()))?;
+            .map_err(|err| daemon_identity_error(endpoint, &err))?;
         let (state, index_writer_rx) = new_shared_state(endpoint, cache_dir, backend_identity)
-            .map_err(|error| crate::ipc::IpcError::Endpoint(error.to_string()))?;
+            .map_err(|error| cache_root_error(cache_dir, &error))?;
 
         Ok(Self {
             listener,
@@ -52,6 +58,36 @@ impl DaemonServer {
     pub(crate) fn depgraph_file_path(&self) -> crate::core::NormalizedPath {
         depgraph_file_path_for_cache_dir(&self.state.cache_dir)
     }
+}
+
+/// Report a cache-root preparation failure as the filesystem fault it is.
+///
+/// Preparing the cache root is a filesystem operation, not an endpoint one.
+/// Both bind paths used to flatten `new_shared_state`'s `io::Error` into
+/// `IpcError::Endpoint(String)`, so a cache-root collision surfaced as
+/// "endpoint error: Cannot create a file when that file already exists" —
+/// which reads as a named-pipe fault and sent the #1259 diagnosis down the
+/// wrong path entirely (#1261). Preserve the `ErrorKind` so callers can still
+/// match on it, and name the offending root so the log explains itself.
+pub(super) fn cache_root_error(
+    cache_dir: &crate::core::NormalizedPath,
+    error: &std::io::Error,
+) -> crate::ipc::IpcError {
+    crate::ipc::IpcError::Io(std::io::Error::new(
+        error.kind(),
+        format!(
+            "cache root {} unusable: {error}",
+            cache_dir.as_path().display()
+        ),
+    ))
+}
+
+/// Report a daemon-identity failure with the endpoint it was resolved for.
+pub(super) fn daemon_identity_error(
+    endpoint: &str,
+    error: &running_process::broker::protocol_v2::backend_handle::IdentityError,
+) -> crate::ipc::IpcError {
+    crate::ipc::IpcError::Endpoint(format!("daemon identity for {endpoint}: {error}"))
 }
 
 /// Return the dependency-graph snapshot path for one daemon cache root.
@@ -423,6 +459,42 @@ impl DaemonServer {
 mod tests {
     use super::*;
 
+    /// #1261: a cache root the daemon cannot prepare must report itself as a
+    /// filesystem fault naming the root, not as an opaque endpoint error.
+    ///
+    /// The old mapping flattened `new_shared_state`'s `io::Error` into
+    /// `IpcError::Endpoint(String)`, so a cache-root collision surfaced as
+    /// "endpoint error: Cannot create a file when that file already exists"
+    /// — which reads as a named-pipe fault and sent the #1259 diagnosis down
+    /// the wrong path entirely. Binding onto a *file* is the portable way to
+    /// make root preparation fail on every platform.
+    #[tokio::test]
+    async fn unusable_cache_root_reports_a_filesystem_error_naming_the_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let not_a_dir = tmp.path().join("cache-root-is-a-file");
+        std::fs::write(&not_a_dir, b"occupied").unwrap();
+
+        // `DaemonServer` is not `Debug`, so `expect_err` is unavailable here.
+        let Err(error) = DaemonServer::bind_with_cache_dir(
+            &crate::ipc::unique_test_endpoint(),
+            &not_a_dir.clone().into(),
+        ) else {
+            panic!("a cache root that is a regular file must not bind");
+        };
+
+        assert!(
+            matches!(error, crate::ipc::IpcError::Io(_)),
+            "cache-root preparation failure must not masquerade as an endpoint \
+             error; got {error:?}"
+        );
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains(&not_a_dir.display().to_string()),
+            "the error must name the offending cache root so the log is \
+             self-explanatory; got {rendered}"
+        );
+    }
+
     fn make_ctx(source: &str) -> crate::depgraph::CompileContext {
         crate::depgraph::CompileContext {
             source_file: source.into(),
@@ -455,7 +527,8 @@ mod tests {
 
     #[tokio::test]
     async fn depgraph_load_gate_waits_until_loaded_graph_is_visible() {
-        let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
+        let cache_root = tempfile::tempdir().unwrap();
+        let server = crate::daemon::server::tests::bind_isolated_server(cache_root.path());
         let state = Arc::clone(&server.state);
         let setter = server.dep_graph_setter();
 


### PR DESCRIPTION
Finishes #1261. Stacks on top of #1262 (merged) and #1264 (open) — no overlap: this touches `lifecycle.rs` and `embedded.rs` only, so it can land before or after #1264.

## 1. The last unguarded bind

`server/lifecycle.rs:458`, inside that file's own `#[cfg(test)] mod tests`:

```rust
#[tokio::test]
async fn depgraph_load_gate_waits_until_loaded_graph_is_visible() {
    let server = DaemonServer::bind(&crate::ipc::unique_test_endpoint()).unwrap();
```

Verified against `main` @ `be1f578a` (with #1262 in): the file has **0** `CacheDirEnvGuard` references and **0** `bind_isolated_server` references, so this test takes no lock and can bind into whatever root a concurrently running guarded test installed — the same defect and mechanism as the sites already fixed.

It survived both prior sweeps because each was scoped to a *directory* (`server/tests/`, then `handle_compile/`) rather than to the crate. Crate-wide inventory after this PR and #1264 (17 real call sites; an 18th grep hit in `multi_restart_context_key.rs:244` is a comment):

| Where | Count | Status |
|---|---|---|
| `entry.rs:347` | 1 | production, correct |
| `tests/deferred_cold_path.rs` | 5 | guarded |
| `tests/link_cache.rs` | 4 | guarded |
| `tests/server_ipc.rs` | 2 | guarded (`:578` sits inside the test that takes the guard at `:426`) |
| `handle_compile/cached_hit.rs` | 4 | fixed by #1264 |
| `lifecycle.rs:458` | 1 | **fixed here** |

That closes the property: every remaining caller is either production or serialized on the guard's mutex.

## 2. Cache-root faults no longer masquerade as endpoint errors

This is issue item 3, and it is the item that actually cost the most time.

Both bind paths flattened `new_shared_state`'s `io::Error` into `IpcError::Endpoint(String)`. So a cache-root collision printed as:

```
Endpoint("Cannot create a file when that file already exists. (os error 183)")
```

which reads as a named-pipe fault. That is why #1259's red looked like an IPC problem — and I want to be concrete about the cost rather than abstract: it sent **my own** first root-cause analysis to entirely the wrong subsystem. I wrote up a confident diagnosis blaming a temp-path race in the `running-process` dependency (`manifest.rs::temp_path_for`, pid+nanos with no per-call counter) before establishing that `DaemonProcess::current_process` writes no files at all and that code is never reached from `bind`. The misleading error variant is what made that story plausible enough to chase.

Fix: one shared `cache_root_error` helper that preserves the `ErrorKind` (so callers can still match on it) and names the offending root:

```
Io("cache root C:\...\zccache-cache unusable: Cannot create a file when that file already exists. (os error 183)")
```

`embedded.rs:53-56` carried the identical flattening, so the embedded service mis-reported the same way; fixing only `lifecycle.rs` would have left half the problem in place. Both now route through the same helper, plus a `daemon_identity_error` helper that names the endpoint.

**Checked for behaviour change:** nothing classifies bind failures by variant. The only `IpcError` variant matching is `control_wire_mismatch_error`, which is client-side control-request negotiation, and it treats a non-`BrokenPipe`/`ConnectionReset`/`UnexpectedEof` `Io` exactly as it treated `Endpoint` — `false`. Every other `IpcError::Endpoint` construction in the workspace is unrelated CLI code.

## 3. Regression test

Nothing would have stopped item 2 from silently reverting, so `unusable_cache_root_reports_a_filesystem_error_naming_the_root` binds onto a path that is a regular file — portable across platforms — and asserts the error is `IpcError::Io` and contains the root path. It fails against the old mapping on the variant assertion alone.

## Verification

- `soldr cargo test -p zccache-daemon-core --features test-support,daemon-entry --lib` — **682 passed, 0 failed**
- `RUSTFLAGS="-D warnings" soldr cargo clippy ... --all-targets` — zero warnings
- `soldr cargo fmt --all -- --check` — clean
- Ran the full suite **4 consecutive times** while developing this (with the `cached_hit.rs` isolation applied locally): 681/682 passed, 0 failed each time. Relevant to @zackees's wall-clock note on #1264 — `warm_hit_materialization_under_budget` did not destabilise under isolation.

## Honest scope note

Issue item 2 asks whether `bind()` should exist for tests at all. I did not implement that, deliberately. The obvious mechanism — `#[cfg_attr(test, deprecated)]` on `bind` — fires on all 11 *legitimately* guarded sites plus the production caller, needing ~12 `#[allow(deprecated)]` annotations. Those tests genuinely need the env var, because the code they exercise reads the global config internally (e.g. `lifecycle::log_file_path()` in `server_ipc.rs:581`), so converting them to isolated roots would break them. I sharpened the `bind` doc contract to state the invariant instead. If you want the compile-time enforcement anyway, it's a separate change with a different risk profile and should be its own PR.

Closes #1261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)