### PR TITLE
fix(embedded): checkpoint durable state when a service is dropped unshut (#1162)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/embedded.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/embedded.rs
@@ -486,6 +486,75 @@ where
     }
 }
 
+/// Last-resort persistence for a service dropped without `shutdown()`.
+///
+/// Persistence otherwise lives only in the explicit `flush()` / `shutdown()`
+/// paths, so a host error, early return, or panic-unwind that drops the handle
+/// discarded the index, depgraph and metadata outright — the same end state as
+/// SIGKILL, on the primary embedded compile path (#1162 finding 3).
+///
+/// This is deliberately *not* a graceful shutdown. It skips the coordination
+/// `flush_embedded_state` does — draining pending writes, taking the
+/// publication guard — because both are async and `Drop` cannot await. What it
+/// can do is call the persistence primitives, which are all synchronous, and
+/// that is enough to turn total loss into a checkpoint.
+///
+/// Loaded-gates are honoured for the same reason `run()` honours them: writing
+/// a partially loaded snapshot over a good on-disk one would trade this bug for
+/// a worse one.
+fn drop_time_checkpoint(state: &SharedState) {
+    let mut persisted = Vec::new();
+
+    if state.artifact_store.flush().is_ok() {
+        persisted.push("index");
+    }
+
+    let depgraph_path = depgraph_file_path_for_cache_dir(&state.cache_dir);
+    if let Some(parent) = depgraph_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    if crate::depgraph::save_to_file(&state.dep_graph.load_full(), &depgraph_path).is_ok() {
+        persisted.push("depgraph");
+    }
+
+    if state.metadata_cache_loaded.load(Ordering::Acquire)
+        && state
+            .cache_system
+            .metadata()
+            .save_to_disk(state.metadata_path.as_path())
+            .is_ok()
+    {
+        persisted.push("metadata");
+    }
+
+    // Loud, per the "no silent degradation" rule: reaching here at all means a
+    // host dropped the service without shutting it down, which is a bug in the
+    // host worth surfacing even though we recovered the state.
+    crate::core::lifecycle::write_event_in_cache_root(
+        state.cache_dir.as_path(),
+        "embedded_dropped_without_shutdown",
+        serde_json::json!({
+            "persisted": persisted,
+            "pid": std::process::id(),
+        }),
+    );
+    tracing::warn!(
+        persisted = ?persisted,
+        "embedded service dropped without shutdown(); persisted a best-effort checkpoint"
+    );
+}
+
+impl Drop for EmbeddedDaemon {
+    fn drop(&mut self) {
+        // `shutdown()` latches this before its final flush, so the graceful
+        // path skips the checkpoint instead of writing everything twice.
+        if self.state.shutdown_requested.load(Ordering::Acquire) {
+            return;
+        }
+        drop_time_checkpoint(&self.state);
+    }
+}
+
 async fn flush_embedded_state(
     state: &Arc<SharedState>,
     index_writer_handle: &mut Option<tokio::task::JoinHandle<()>>,

--- a/crates/zccache-daemon-core/src/daemon/server/tests/embedded_flush.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/embedded_flush.rs
@@ -228,6 +228,83 @@ async fn publisher_queued_behind_shutdown_writer_rechecks_latched_flag() {
     let _ = daemon.shutdown().await;
 }
 
+/// #1162 finding 3: persistence used to live only in the explicit
+/// `flush()`/`shutdown()` paths, so a host error, early return, or
+/// panic-unwind that dropped the handle discarded the index outright — the
+/// same end state as SIGKILL, on the primary embedded compile path.
+///
+/// Dropping without `shutdown()` must still leave a checkpoint on disk.
+#[tokio::test]
+async fn dropping_without_shutdown_still_checkpoints_the_index() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let index_path = crate::core::config::index_path_from_cache_dir(&cache_dir);
+    let expected = 12usize;
+
+    {
+        let daemon = EmbeddedDaemon::start(
+            crate::ipc::unique_test_endpoint(),
+            cache_dir.clone(),
+            None,
+            MaintenancePolicy::default(),
+        )
+        .await
+        .unwrap();
+
+        for i in 0..expected {
+            daemon
+                .state
+                .artifact_store
+                .insert(&format!("{i:064x}"), &synthetic_index_entry(i as u64 + 1));
+        }
+        assert_eq!(daemon.state.artifact_store.len(), expected);
+
+        // The whole point: no `shutdown()`, no `flush()` — just drop it, the
+        // way a `?` on an error path in the host would.
+    }
+
+    let reopened = crate::artifact::ArtifactStore::open(index_path.as_path())
+        .expect("drop must leave a readable index behind");
+    assert_eq!(
+        reopened.len(),
+        expected,
+        "dropping the service without shutdown() must still checkpoint the index"
+    );
+}
+
+/// The graceful path must not pay for the backstop: `shutdown()` latches
+/// `shutdown_requested` before its final flush, so the drop-time checkpoint
+/// skips rather than writing everything a second time.
+#[tokio::test]
+async fn shutdown_suppresses_the_drop_time_checkpoint() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let daemon = EmbeddedDaemon::start(
+        crate::ipc::unique_test_endpoint(),
+        cache_dir.clone(),
+        None,
+        MaintenancePolicy::default(),
+    )
+    .await
+    .unwrap();
+    daemon
+        .state
+        .artifact_store
+        .insert(&format!("{:064x}", 1), &synthetic_index_entry(1));
+
+    let _ = daemon.shutdown().await;
+    let state = Arc::clone(&daemon.state);
+    drop(daemon);
+
+    assert!(
+        state.shutdown_requested.load(Ordering::Acquire),
+        "shutdown must latch the flag the drop-time checkpoint gates on"
+    );
+    let index_path = crate::core::config::index_path_from_cache_dir(&cache_dir);
+    let reopened = crate::artifact::ArtifactStore::open(index_path.as_path()).unwrap();
+    assert_eq!(reopened.len(), 1, "the graceful flush must still be intact");
+}
+
 fn synthetic_index_entry(total_size: u64) -> crate::artifact::ArtifactIndex {
     crate::artifact::ArtifactIndex::new(
         vec!["foo.o".to_string()],


### PR DESCRIPTION
Finding 3, the last of #1162. Findings 1 and 2 landed in #1266.

## The bug

Persistence exists only in the explicit `flush()` / `shutdown()` paths. A host error, early return, or panic-unwind that drops the handle discarded the index, depgraph and metadata outright — the same end state as SIGKILL, on the primary embedded compile path.

Demonstrated, not assumed. With the checkpoint disabled, the new test reports:

```
assertion `left == right` failed: dropping the service without shutdown() must still checkpoint the index
  left: 0
 right: 12
```

`left: 0` — not a partial loss, the whole index.

## Why `Drop for EmbeddedDaemon`, not `ZccacheService`

The issue proposed either. Only this one works: `ZccacheService` is `#[derive(Clone)]` over an `Arc<EmbeddedDaemon>`, so a `Drop` there fires on **every clone**, flushing repeatedly while the service is still live. `EmbeddedDaemon` sits behind the `Arc` and is dropped exactly once. (Same reasoning the existing `_host_inflight_guard` field already uses to avoid double-registering.)

## Why this can be synchronous

`Drop` cannot await, and I was expecting to need a runtime-flavour dance — `Handle::block_on` panics on a worker thread, `block_in_place` panics on a current-thread runtime, and a detached task would let the process exit first, i.e. *look* fixed while not fixing anything.

None of that is needed, because the persistence primitives are already synchronous — `ArtifactStore::flush`, `save_to_file`, `save_to_disk`. What is async in `flush_embedded_state` is the *coordination*: draining pending writes and taking the publication guard. A last-resort backstop can skip both.

So this is explicitly **not** a graceful shutdown. It is the difference between total loss and a checkpoint.

## Care taken

- **Loaded-gates honoured**, exactly as `run()` does: a partially loaded metadata snapshot is not written over a good on-disk one. Trading this bug for a silently corrupted snapshot would be a bad deal.
- **`shutdown()` suppresses it** — it latches `shutdown_requested` before its final flush, so the graceful path doesn't write everything twice. Covered by `shutdown_suppresses_the_drop_time_checkpoint`.
- **Loud**: emits an `embedded_dropped_without_shutdown` lifecycle event and a `warn!` listing what was persisted. Recovering the state doesn't make the host's missing `shutdown()` less of a bug, and silent recovery would hide it forever.

## Verification

- `689 passed; 0 failed`; clippy `--all-targets -- -D warnings` finished with zero warnings; test build clean under `RUSTFLAGS=-D warnings`.
- Both new tests confirmed present by name in the run output, and the primary one confirmed **red** with the fix disabled (above) before being confirmed green — so it tests the behaviour rather than passing vacuously.

Closes #1162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
