### PR TITLE
fix(cache): record a durable event when persisted state is dropped (#1157)

### DIFF
--- a/crates/zccache-artifact/src/store.rs
+++ b/crates/zccache-artifact/src/store.rs
@@ -180,8 +180,28 @@ impl ArtifactStore {
                 Err(e) => {
                     tracing::warn!(
                         path = %path.display(),
+                        bytes = bytes.len(),
                         "artifact index blob is corrupt, starting empty: {e}"
                     );
+                    // #1157: dropping the index re-misses every key while the
+                    // content-addressed payloads are still on disk, so the
+                    // symptom is a full cold recompile with no local cause.
+                    // The durable event is what ties that back to this file.
+                    // Written into the cache root that owns the index, so the
+                    // record lands beside the state it describes.
+                    if let Some(cache_root) = path.parent() {
+                        zccache_core::lifecycle::write_event_in_cache_root(
+                            cache_root,
+                            zccache_core::lifecycle::EVENT_STATE_CORRUPT,
+                            serde_json::json!({
+                                "subsystem": "artifact_index",
+                                "path": path.display().to_string(),
+                                "bytes": bytes.len(),
+                                "message": e.to_string(),
+                                "consequence": "empty_index",
+                            }),
+                        );
+                    }
                 }
             },
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -490,6 +510,40 @@ mod tests {
         std::fs::write(&path, b"not valid bincode").unwrap();
         let store = ArtifactStore::open(&path).unwrap();
         assert_eq!(store.len(), 0);
+    }
+
+    /// #1157: starting empty on a corrupt index re-misses every key while the
+    /// content-addressed payloads are still on disk, so the operator sees a
+    /// full cold recompile with no local cause. A `tracing::warn!` goes
+    /// wherever the operator happened to be capturing; the durable event is
+    /// what makes the incident attributable afterwards.
+    #[test]
+    fn a_corrupt_index_records_a_durable_event_beside_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("index.bin");
+        std::fs::write(&path, b"not valid bincode").unwrap();
+
+        let store = ArtifactStore::open(&path).unwrap();
+        assert_eq!(store.len(), 0, "a corrupt blob still starts empty");
+
+        let log_path = dir
+            .path()
+            .join("logs")
+            .join(zccache_core::lifecycle::live_log_filename());
+        let body = std::fs::read_to_string(&log_path)
+            .expect("the event must land in <cache_root>/logs/<live log>");
+        let corrupt = body
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .find(|v| v["event"] == zccache_core::lifecycle::EVENT_STATE_CORRUPT)
+            .expect("corruption must leave a durable record, not just a warn");
+        assert_eq!(corrupt["subsystem"], "artifact_index");
+        assert_eq!(corrupt["consequence"], "empty_index");
+        assert_eq!(
+            corrupt["bytes"],
+            b"not valid bincode".len(),
+            "the record must say how much unreadable state was dropped"
+        );
     }
 
     #[test]

--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -43,6 +43,7 @@
 //! | `client-disconnected` (#755) | client | IPC connection broke mid-request | `endpoint`, `client_pid`, `client_version`, `client_binary_path`, `cause`, `detail` |
 //! | `wrapper-local-fallback` | CLI wrapper | daemon dispatch failed before request delivery and the tool ran locally | `reason`, tool fields |
 //! | `version_mismatch` | daemon | client / daemon protocol versions disagree | `daemon_protocol_version`, `client_protocol_version`, `reason` |
+//! | `state_corrupt` (#1157) | daemon | persisted state did not parse and was dropped rather than reconciled; consequence is a full cold recompile | `subsystem`, `consequence`, `message`, `path`, `bytes` |
 //! | `staged_publication_conflict` | daemon | one cache key produced two different valid generations; first generation retained | `cache_key`, `existing_generation`, `candidate_generation`, `elapsed_ns` |
 //! | `staged_publication_replaces_invalid_generation` | daemon | a corrupt/incomplete selected generation was replaced by a validated compile result | `cache_key`, `invalid_generation`, `replacement_generation` |
 //! | `staged_salvage_started` | daemon | publication/index failed after a successful compile; requested outputs are being recovered | `reason`, `output_count`, `copied_bytes`, `elapsed_ns` |
@@ -111,6 +112,14 @@ pub const EVENT_SPAWN_PARKED: &str = "spawn-parked";
 pub const EVENT_DIED_IDLE: &str = "died-idle";
 pub const EVENT_DIED_SHUTDOWN: &str = "died-shutdown";
 pub const EVENT_VERSION_MISMATCH: &str = "version_mismatch";
+/// Persisted state was unreadable and was dropped rather than reconciled
+/// (#1157). Distinct from [`EVENT_VERSION_MISMATCH`], which is an expected
+/// schema bump; this one means the bytes on disk did not parse at all.
+///
+/// Both consequences are the same for the operator — a full cold recompile —
+/// so the event carries `subsystem` and `consequence` and is what makes a
+/// fleet-wide "everyone recompiled today" incident attributable after the fact.
+pub const EVENT_STATE_CORRUPT: &str = "state_corrupt";
 
 /// Issue #755 events — daemon death + handover + client disconnect.
 /// Additive: existing tooling that filters on `event` continues to
@@ -185,6 +194,7 @@ pub const EVENT_ALL: &[&str] = &[
     EVENT_DIED_SHUTDOWN,
     EVENT_DIED_PRIVATE_OWNER_EXIT,
     EVENT_VERSION_MISMATCH,
+    EVENT_STATE_CORRUPT,
     EVENT_DAEMON_DIED,
     EVENT_PIPE_HANDOVER,
     EVENT_CLIENT_DISCONNECTED,

--- a/crates/zccache-daemon-core/src/daemon/entry.rs
+++ b/crates/zccache-daemon-core/src/daemon/entry.rs
@@ -498,6 +498,19 @@ fn run_server(args: Args) {
                 crate::depgraph::DepGraphLoadOutcome::Corrupt { ref message }
                 | crate::depgraph::DepGraphLoadOutcome::IoError { ref message } => {
                     tracing::warn!("depgraph load failed: {message} — starting with empty graph");
+                    // #1157: the sibling `VersionMismatch` arm already emits a
+                    // durable event, and this arm has the same blast radius —
+                    // an empty graph means every workspace cold-recompiles.
+                    // Leaving it on `tracing::warn!` alone made the corrupt
+                    // case the one variant a post-incident log search missed.
+                    crate::daemon::lifecycle::write_event(
+                        crate::core::lifecycle::EVENT_STATE_CORRUPT,
+                        serde_json::json!({
+                            "subsystem": "depgraph",
+                            "message": message,
+                            "consequence": "empty_graph",
+                        }),
+                    );
                     if let Some(ref w) = warning {
                         eprintln!("{w}");
                     }


### PR DESCRIPTION
Finding 3 of #1157 — the loud-events half. Findings 1 and 2 are **not** addressed here; see below.

## What was silent

Corrupt persisted state is dropped behind a bare `tracing::warn!`, so the resulting full cold recompile has no attributable cause afterwards — the warn goes wherever the operator happened to be capturing, if anywhere. Two paths, same blast radius:

- **Artifact index** (`store.rs`) — a corrupt `index.bin` re-misses every key while the content-addressed payloads are still sitting on disk. One bad byte, whole-cache symptom.
- **Depgraph** (`daemon/entry.rs`) — the sibling `VersionMismatch` arm already emitted a durable event, which made `Corrupt`/`IoError` precisely the variant a post-incident log search would miss.

## Change

New `EVENT_STATE_CORRUPT`, deliberately distinct from `EVENT_VERSION_MISMATCH`: a schema bump is *expected* and a byte that doesn't parse is *not*, and conflating them would make the version-mismatch signal useless for exactly the incident you'd want it for. Both carry `subsystem` and `consequence`; the index event adds the path and the byte count of the unreadable blob.

The index event is written into the cache root that owns that index, so the record lands beside the state it describes rather than in an ambient log — which matters when several roots exist on one machine.

## Verification

- `zccache-core` 113 passed, `zccache-artifact` 84 passed, `zccache-daemon-core` 689 passed — 0 failed.
- clippy `--all-targets -- -D warnings` clean across all three; test builds clean under `RUSTFLAGS=-D warnings`.
- New test `a_corrupt_index_records_a_durable_event_beside_it` confirmed **red** before green — with the emission disabled it fails on the missing log file, so it asserts the behaviour rather than passing vacuously.

The existing `event_catalog_contains_phase_zero_and_existing_events_once` test caught the new constant missing its row in the module schema table, which is a good guard — the catalog can't drift from the docs. Row added.

## Not addressed

Finding 1 (rebuild the index by scanning surviving `<key>_<i>` groups, `.staged-v2` manifests and `.cowhash-*` sidecars) and finding 2 (keep artifact-key resolution usable after a graph reset) are the reconciliation half, and both are substantially larger than this. They also want the bounded-scan budget decision the issue flags. #1157 should stay open for them.

Contributes to #1157 — deliberately not auto-closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
