### PR TITLE
fix(embedded): gate the drop-time checkpoint on every loaded-flag (#1162)

### DIFF
--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -69,6 +69,7 @@
 //! | `watcher_degraded` | daemon | the file watcher could not be armed, disabling both fast hit tiers | `reason`, `degradations` |
 //! | `watcher_rearmed` | daemon | a degraded daemon re-armed its file watcher | `attempt` |
 //! | `watcher_overflow` | daemon | the watcher event queue saturated; hardlink registry re-verified by stat signature | `links_unchanged`, `links_suspect` |
+//! | `embedded_dropped_without_shutdown` | daemon | a host dropped an embedded service without `shutdown()`; a best-effort checkpoint was written | `persisted`, `pid` |
 //!
 //! ## Forensic walkthrough: the two-versions-on-one-pipe wedge
 //!
@@ -174,6 +175,10 @@ pub const EVENT_WATCHER_REARMED: &str = "watcher_rearmed";
 /// The watcher event queue saturated; records how much of the hardlink
 /// registry the stat-signature sweep kept trusted versus marked suspect.
 pub const EVENT_WATCHER_OVERFLOW: &str = "watcher_overflow";
+/// A host dropped an embedded service without calling `shutdown()`. The state
+/// was salvaged by a best-effort checkpoint, but the host is misusing the API
+/// — this is the signal that says so, and log-audit rules can bound it.
+pub const EVENT_EMBEDDED_DROPPED_WITHOUT_SHUTDOWN: &str = "embedded_dropped_without_shutdown";
 
 /// Complete lifecycle-event catalog. Keep this additive and update the module
 /// schema table with every new event; log-audit and operator docs depend on it.
@@ -211,6 +216,7 @@ pub const EVENT_ALL: &[&str] = &[
     EVENT_WATCHER_DEGRADED,
     EVENT_WATCHER_REARMED,
     EVENT_WATCHER_OVERFLOW,
+    EVENT_EMBEDDED_DROPPED_WITHOUT_SHUTDOWN,
     EVENT_LEGACY_ARTIFACT_PATH_ACCESSED,
     EVENT_DESTINATION_WRITE_FAILED,
     EVENT_MISS_REASON_UNKNOWN,

--- a/crates/zccache-daemon-core/src/daemon/server/embedded.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/embedded.rs
@@ -505,16 +505,31 @@ where
 fn drop_time_checkpoint(state: &SharedState) {
     let mut persisted = Vec::new();
 
-    if state.artifact_store.flush().is_ok() {
+    // Every write below is gated on its own loaded-flag, not just metadata's.
+    // `ArtifactStore::flush` serializes the *whole* in-memory map over
+    // `index.bin`, so flushing a store whose on-disk entries have not been
+    // merged in yet would replace a populated index with an empty one — total
+    // cache loss, strictly worse than the unshut-drop this function exists to
+    // survive. The same argument applies to the depgraph snapshot.
+    //
+    // Today `start()` awaits all five loads before the handle exists, so these
+    // flags are always true here. They are checked anyway because that is a
+    // *non-local* invariant: `new_shared_state` already opens the index empty
+    // and merges it in the background (#784 phase 2d), and the moment that
+    // treatment reaches the embedded path an ungated flush here would silently
+    // destroy the accumulated index. Cheap gate, unbounded downside.
+    if state.artifact_store_loaded.load(Ordering::Acquire) && state.artifact_store.flush().is_ok() {
         persisted.push("index");
     }
 
-    let depgraph_path = depgraph_file_path_for_cache_dir(&state.cache_dir);
-    if let Some(parent) = depgraph_path.parent() {
-        std::fs::create_dir_all(parent).ok();
-    }
-    if crate::depgraph::save_to_file(&state.dep_graph.load_full(), &depgraph_path).is_ok() {
-        persisted.push("depgraph");
+    if state.dep_graph_load_complete.load(Ordering::Acquire) {
+        let depgraph_path = depgraph_file_path_for_cache_dir(&state.cache_dir);
+        if let Some(parent) = depgraph_path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        if crate::depgraph::save_to_file(&state.dep_graph.load_full(), &depgraph_path).is_ok() {
+            persisted.push("depgraph");
+        }
     }
 
     if state.metadata_cache_loaded.load(Ordering::Acquire)
@@ -532,7 +547,7 @@ fn drop_time_checkpoint(state: &SharedState) {
     // host worth surfacing even though we recovered the state.
     crate::core::lifecycle::write_event_in_cache_root(
         state.cache_dir.as_path(),
-        "embedded_dropped_without_shutdown",
+        crate::core::lifecycle::EVENT_EMBEDDED_DROPPED_WITHOUT_SHUTDOWN,
         serde_json::json!({
             "persisted": persisted,
             "pid": std::process::id(),

--- a/crates/zccache-daemon-core/src/daemon/server/tests/embedded_flush.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/embedded_flush.rs
@@ -272,6 +272,89 @@ async fn dropping_without_shutdown_still_checkpoints_the_index() {
     );
 }
 
+/// The drop-time checkpoint must never publish a snapshot it has not finished
+/// loading.
+///
+/// `ArtifactStore::flush` serializes the *entire* in-memory map over
+/// `index.bin`. If the on-disk entries have not been merged in yet, flushing
+/// replaces a populated index with an empty one — total cache loss, strictly
+/// worse than the unshut drop the checkpoint exists to survive.
+///
+/// `start()` currently awaits every load, so the production path cannot reach
+/// this state and no other test can either; that is exactly why the guard
+/// needs its own test. The invariant it protects is non-local — the standalone
+/// path already opens the index empty and merges it in the background (#784
+/// phase 2d), so the day that reaches the embedded service, an ungated flush
+/// here would silently destroy the accumulated index.
+#[tokio::test]
+async fn an_unloaded_checkpoint_leaves_on_disk_state_untouched() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_dir = crate::core::NormalizedPath::new(tmp.path());
+    let index_path = crate::core::config::index_path_from_cache_dir(&cache_dir);
+    let survivors = 7usize;
+
+    // A populated index from a previous, healthy run.
+    {
+        let daemon = EmbeddedDaemon::start(
+            crate::ipc::unique_test_endpoint(),
+            cache_dir.clone(),
+            None,
+            MaintenancePolicy::default(),
+        )
+        .await
+        .unwrap();
+        for i in 0..survivors {
+            daemon
+                .state
+                .artifact_store
+                .insert(&format!("{i:064x}"), &synthetic_index_entry(i as u64 + 1));
+        }
+        let _ = daemon.shutdown().await;
+    }
+    assert_eq!(
+        crate::artifact::ArtifactStore::open(index_path.as_path())
+            .expect("seeded index")
+            .len(),
+        survivors
+    );
+
+    // A service whose loads have not landed: its in-memory store is empty and
+    // must not be published over the good on-disk one.
+    {
+        let daemon = EmbeddedDaemon::start(
+            crate::ipc::unique_test_endpoint(),
+            cache_dir.clone(),
+            None,
+            MaintenancePolicy::default(),
+        )
+        .await
+        .unwrap();
+        daemon
+            .state
+            .artifact_store_loaded
+            .store(false, Ordering::Release);
+        daemon
+            .state
+            .dep_graph_load_complete
+            .store(false, Ordering::Release);
+        daemon
+            .state
+            .metadata_cache_loaded
+            .store(false, Ordering::Release);
+        daemon.state.artifact_store.clear();
+        assert_eq!(daemon.state.artifact_store.len(), 0);
+        // Dropped unshut, so the checkpoint runs — and must decline every write.
+    }
+
+    assert_eq!(
+        crate::artifact::ArtifactStore::open(index_path.as_path())
+            .expect("index must survive an unloaded checkpoint")
+            .len(),
+        survivors,
+        "an unloaded checkpoint must not publish an empty index over a populated one"
+    );
+}
+
 /// The graceful path must not pay for the backstop: `shutdown()` latches
 /// `shutdown_requested` before its final flush, so the drop-time checkpoint
 /// skips rather than writing everything a second time.


### PR DESCRIPTION
Follow-up hardening on #1267 (merged). Two review points from that PR, plus the test that proves the first one matters.

## 1. The loaded-gate was applied to metadata only

`drop_time_checkpoint` states the principle exactly right in its own doc comment:

> Loaded-gates are honoured for the same reason `run()` honours them: writing a partially loaded snapshot over a good on-disk one would trade this bug for a worse one.

but only metadata is actually gated. Index and depgraph are not.

`ArtifactStore::flush` serializes the **entire** in-memory map over `index.bin`. Flushing a store whose on-disk entries have not been merged in yet replaces a populated index with an empty one — **total cache loss**, strictly worse than the unshut drop the checkpoint exists to survive, which only costs the current session's entries. The content-addressed blobs survive on disk but become unreferenced, feeding the #1157 orphan class.

**This is not reachable today, and I want to be precise about that rather than overstate it.** `EmbeddedDaemon::start` → `start_with_maintenance` → `start_background_tasks(...).await`, and that awaits all five loads (artifact, metadata, compiler-hash, includes, depgraph) before the handle exists. At drop time the flags are always true and the ungated writes are correct.

The reason to gate anyway is that the correctness rests on a **non-local invariant** — "no load is ever deferred past `start()`" — and the repo is actively moving the other way. `new_shared_state` already opens the artifact index empty and merges it in a background `spawn_blocking` (#784 phase 2d), same for metadata (2b) and system includes (2c). The flags `artifact_store_loaded` / `dep_graph_load_complete` exist *because* loading is deferrable. The day that treatment reaches the embedded path, an ungated flush here silently destroys the accumulated index — and nothing in the current tests would catch it.

The gate is two atomic loads. Cheap guard, unbounded downside.

## 2. The event bypassed the lifecycle catalog

The checkpoint emitted a bare string literal, so `embedded_dropped_without_shutdown` was absent from `EVENT_ALL`. `lifecycle.rs` is explicit that this matters:

> Complete lifecycle-event catalog. Keep this additive and update the module schema table with every new event; log-audit and operator docs depend on it.

That dependency is functional, not documentary: #1159's log-audit rules key off the catalog, so an uncatalogued event cannot be given a `Forbidden` / `Bounded(N)` rule — and "a host dropped the service without shutting it down" is precisely the kind of signal worth `Bounded(0)` in perf runs. Now a declared const with an `EVENT_ALL` entry and a schema-table row.

## The test

`an_unloaded_checkpoint_leaves_on_disk_state_untouched` seeds a populated index via a clean shutdown, then starts a service, forces the three loaded-flags false, empties the in-memory store, and drops it unshut. The on-disk index must still hold all seven entries.

No existing test can reach that state, because `start()` always completes the loads — which is exactly why the guard needs its own test rather than relying on the production path to exercise it.

**Verified it is a real guard, not a tautology.** With the gate removed the test fails on the assertion that matters:

```
assertion `left == right` failed: an unloaded checkpoint must not publish an empty index over a populated one
  left: 0
 right: 7
```

7 entries → 0. That is the total-loss failure mode, reproduced.

## Verification

- `soldr cargo test -p zccache-daemon-core --features test-support,daemon-entry --lib` — **690 passed, 0 failed**
- `soldr cargo test -p zccache-core --lib` — **113 passed, 0 failed**
- `RUSTFLAGS="-D warnings" soldr cargo clippy -p zccache-daemon-core -p zccache-core --all-targets` — zero warnings
- `soldr cargo fmt --all -- --check` — clean

## Not addressed here

Two smaller notes from the #1267 review are left alone deliberately, since both are judgement calls rather than defects:

- `shutdown_requested` doubles as the suppression latch, so a `shutdown()` that fails partway followed by a drop skips the checkpoint and yields neither. A separate `checkpoint_done` latch would be unambiguous — but changing the latch semantics is a behavioural decision for whoever owns that path.
- The event is emitted unconditionally with a `persisted` list of successes only, so an all-failed drop logs `persisted: []`, which is accurate but easy to misread as "nothing needed persisting". A `failed` list alongside would make it self-describing.

Refs #1162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)