### PR TITLE
fix(depgraph): name and size the snapshot a corrupt-state drop threw away (#1157)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/entry.rs
+++ b/crates/zccache-daemon-core/src/daemon/entry.rs
@@ -55,6 +55,18 @@ fn daemon_max_blocking_threads() -> usize {
     parallelism.saturating_mul(8).clamp(128, 512)
 }
 
+/// Size of a persisted snapshot for a state-loss event payload, or `None` when
+/// it cannot be stat'd.
+///
+/// #1157 asks the drop-path events to carry the file path and byte count so a
+/// post-incident search can size the loss. `None` is deliberate over `0`: a
+/// snapshot that vanished between classification and this stat is a different
+/// story from one that was present and empty, and collapsing them would make
+/// the forensics lie.
+fn snapshot_bytes(path: &std::path::Path) -> Option<u64> {
+    std::fs::metadata(path).ok().map(|meta| meta.len())
+}
+
 const DAEMON_PROFILE_ENV: &str = "ZCCACHE_DAEMON_PROFILE";
 const TOKIO_CONSOLE_PROFILE: &str = "tokio-console";
 const TOKIO_CONSOLE_BIND_ENV: &str = "TOKIO_CONSOLE_BIND";
@@ -488,6 +500,14 @@ fn run_server(args: Args) {
                             "file_version": file_version,
                             "expected_version": expected_version,
                             "consequence": "empty_graph",
+                            // #1157 asked for the path and byte count on *both*
+                            // drop paths; the index side carries them, so a
+                            // post-incident search could size the index loss but
+                            // not the graph loss. `bytes` is null when the file
+                            // vanished between classify and stat -- absent, not
+                            // zero, so it is not mistaken for an empty snapshot.
+                            "path": depgraph_path.display().to_string(),
+                            "bytes": snapshot_bytes(&depgraph_path),
                         }),
                     );
                     if let Some(ref w) = warning {
@@ -509,6 +529,8 @@ fn run_server(args: Args) {
                             "subsystem": "depgraph",
                             "message": message,
                             "consequence": "empty_graph",
+                            "path": depgraph_path.display().to_string(),
+                            "bytes": snapshot_bytes(&depgraph_path),
                         }),
                     );
                     if let Some(ref w) = warning {
@@ -765,6 +787,91 @@ mod tests {
         assert_eq!(record["file_version"], 3);
         assert_eq!(record["expected_version"], 4);
         assert_eq!(record["consequence"], "empty_graph");
+    }
+
+    /// #1157 asked the drop-path events to carry the file path *and* byte
+    /// count. The index side did; the depgraph side reported neither, so a
+    /// post-incident search could size the index loss but not the graph loss.
+    ///
+    /// Unlike the payload-contract test above, this drives the real function:
+    /// `snapshot_bytes` is where the only logic lives, and the distinction it
+    /// encodes — absent vs. present-but-empty — is the part worth pinning.
+    #[test]
+    fn snapshot_bytes_separates_a_missing_snapshot_from_an_empty_one() {
+        let temp = tempfile::tempdir().unwrap();
+
+        let missing = temp.path().join("never-written.bin");
+        assert_eq!(
+            snapshot_bytes(&missing),
+            None,
+            "a snapshot that is not there must report absent, not zero bytes — \
+             collapsing the two would make the forensics claim a file existed"
+        );
+
+        let empty = temp.path().join("empty.bin");
+        std::fs::write(&empty, b"").unwrap();
+        assert_eq!(
+            snapshot_bytes(&empty),
+            Some(0),
+            "a present-but-empty snapshot is a real, different failure and must \
+             be distinguishable from a missing one"
+        );
+
+        let populated = temp.path().join("populated.bin");
+        std::fs::write(&populated, b"corrupt-but-sizeable").unwrap();
+        assert_eq!(snapshot_bytes(&populated), Some(20));
+    }
+
+    /// The corrupt/IO arm is the variant a post-incident log search used to
+    /// miss entirely, and it still has no test that drives its call site (that
+    /// arm lives in a `spawn_blocking` closure in `run_daemon`). This pins its
+    /// payload contract, including the `path`/`bytes` fields #1157 asked for.
+    #[test]
+    fn depgraph_state_corrupt_event_carries_the_path_and_size_of_what_was_dropped() {
+        use crate::core::lifecycle as core_lifecycle;
+
+        assert!(
+            core_lifecycle::EVENT_ALL.contains(&core_lifecycle::EVENT_STATE_CORRUPT),
+            "an event outside the catalog cannot be given a log-audit rule"
+        );
+
+        let temp = tempfile::tempdir().unwrap();
+        let snapshot = temp.path().join("depgraph.bin");
+        std::fs::write(&snapshot, b"not a valid snapshot").unwrap();
+
+        core_lifecycle::write_event_in_cache_root(
+            temp.path(),
+            core_lifecycle::EVENT_STATE_CORRUPT,
+            serde_json::json!({
+                "subsystem": "depgraph",
+                "message": "decode failed",
+                "consequence": "empty_graph",
+                "path": snapshot.display().to_string(),
+                "bytes": snapshot_bytes(&snapshot),
+            }),
+        );
+
+        let log_path = temp
+            .path()
+            .join("logs")
+            .join(core_lifecycle::live_log_filename());
+        let body = std::fs::read_to_string(&log_path).expect("event must be written");
+        let record = body
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .find(|v| v["event"] == core_lifecycle::EVENT_STATE_CORRUPT)
+            .expect("the corrupt-state event must reach the lifecycle log");
+
+        assert_eq!(record["subsystem"], "depgraph");
+        assert_eq!(record["consequence"], "empty_graph");
+        assert_eq!(record["bytes"], 20, "the size of the dropped snapshot");
+        assert!(
+            record["path"]
+                .as_str()
+                .is_some_and(|p| p.ends_with("depgraph.bin")),
+            "the event must name the file that was dropped; got {:?}",
+            record["path"]
+        );
     }
 
     // #997: the daemon arg parser is now library-testable. Before the


### PR DESCRIPTION
Completes required-fix **3** of #1157. Deliberately scoped — see "What this is not" below.

## The gap

#1157 asks the state-loss events to carry the **file path and byte count** of what was dropped. After #1252 and #1268 the index path does:

```rust
// zccache-artifact/src/store.rs:192-204
write_event_in_cache_root(cache_root, EVENT_STATE_CORRUPT,
    json!({ "subsystem", "path", "bytes", "message", "consequence" }))
```

but **both** depgraph arms emitted neither:

```rust
// daemon/entry.rs — version_mismatch arm, and the corrupt/IoError arm
json!({ "subsystem": "depgraph", "message": …, "consequence": "empty_graph" })
```

So a post-incident search could size the index loss but not the graph loss — on the arm whose blast radius is *every workspace cold-recompiling*. That asymmetry is exactly the "fleet-wide 'everyone recompiled today' incidents were unattributable" problem the #1268 comment describes, left half-closed.

## The fix

A `snapshot_bytes` helper, applied to both arms. It returns `Option<u64>` rather than defaulting to `0`, and that distinction is the reason it's a helper rather than an inline `.len()`:

> a snapshot that vanished between classification and this stat is a different story from one that was present and empty, and collapsing them would make the forensics lie

An event claiming `bytes: 0` for a file that wasn't there asserts something false about the incident. `null` says "couldn't stat it", which is the truth.

## Tests

`snapshot_bytes` is **driven directly** across all three cases — missing → `None`, present-but-empty → `Some(0)`, populated → `Some(20)`. It holds the only logic in this change, so it gets a real unit test rather than a shape assertion.

The corrupt/IO arm also gains a payload-contract test. It previously had **none**, while its sibling version-mismatch arm did — meaning the variant that #1268's own comment calls out as "the one variant a post-incident log search missed" was also the one variant with no test.

Being explicit about the limitation: neither payload test drives its call site. That arm lives inside a `spawn_blocking` closure in `run_daemon` and reaching it needs a live daemon plus a version-skewed depgraph on disk — integration scope. The existing sibling test documents the same constraint, and I've kept that framing rather than implying more coverage than exists.

## What this is *not*

**#1157's headline ask is still unimplemented, and this PR does not change that.** The issue is titled "reconcile corrupt index/depgraph state **instead of** wholesale drop-and-recompile". Both drop sites still drop everything:

- **Fix 1** (rebuild the index by scanning legacy `<key>_<i>` groups, `.staged-v2` manifests, `.cowhash-*` sidecars): missing. `store.rs:180-215` still falls through to an empty `DashMap`; there is no rebuild helper anywhere in the tree.
- **Fix 2** (migrate a skewed depgraph, or keep artifact-key resolution usable after a graph reset): missing. Both `entry.rs` arms still end in `setter.install(None, warning)`; `classify_load` has no migration branch.

Three PRs now reference #1157 (#1252, #1268, this one) and **all three are observability only**. The recompile-the-world blast radius is unchanged. The issue should stay open.

## One thing worth flagging for whoever implements Fix 1

`store.rs:518-546` (`a_corrupt_index_records_a_durable_event_beside_it`, added by #1268) contains:

```rust
assert_eq!(store.len(), 0, "a corrupt blob still starts empty");
```

That **pins the drop behaviour in place**. It will fail the moment reconciliation works, and it should be inverted rather than treated as a regression. Better to know that now than to hit it mid-implementation and wonder whether the rebuild broke something.

## Verification

- `soldr cargo test -p zccache-daemon-core --features test-support,daemon-entry --lib` — **692 passed, 0 failed**
- `RUSTFLAGS="-D warnings" soldr cargo clippy --all-targets` — zero warnings
- `soldr cargo fmt --all -- --check` — clean

Refs #1157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)