### PR TITLE
fix(cleanup): reclaim depfile dirs by age when a PID is reused (#1165 finding 6)

### DIFF
--- a/crates/zccache-core/src/config/cleanup.rs
+++ b/crates/zccache-core/src/config/cleanup.rs
@@ -8,6 +8,22 @@
 
 use super::paths::depfile_dir;
 use std::path::Path;
+use std::time::Duration;
+
+/// How old a depfile directory must be before it is reclaimed even though its
+/// PID still looks alive (#1165 finding 6).
+///
+/// `is_alive(pid)` is the primary signal, but PIDs are reused. Once the OS
+/// hands a dead daemon's number to an unrelated long-running process, that
+/// daemon's directory is pinned for as long as the new process lives — which
+/// on a busy machine with high PID churn is indefinitely.
+///
+/// Age is the backstop. A depfile directory belongs to one daemon instance and
+/// is removed on clean shutdown, so one this old is debris regardless of what
+/// currently holds its number. The window is deliberately generous: reclaiming
+/// a live daemon's directory breaks a build, while leaving debris a few days
+/// longer costs only disk.
+const DEPFILE_DIR_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 
 /// Remove legacy zccache state left directly under the OS temp directory.
 ///
@@ -37,8 +53,17 @@ pub fn cleanup_stale_depfile_dirs<F>(is_alive: F) -> usize
 where
     F: Fn(u32) -> bool,
 {
-    let base = depfile_dir();
-    let entries = match std::fs::read_dir(&base) {
+    sweep_depfile_dirs(depfile_dir().as_path(), is_alive, DEPFILE_DIR_MAX_AGE)
+}
+
+/// [`cleanup_stale_depfile_dirs`] with an explicit base directory and age
+/// floor, so tests can exercise both sides of the gate without touching the
+/// process-global depfile root or sleeping for a week.
+pub(super) fn sweep_depfile_dirs<F>(base: &Path, is_alive: F, max_age: Duration) -> usize
+where
+    F: Fn(u32) -> bool,
+{
+    let entries = match std::fs::read_dir(base) {
         Ok(entries) => entries,
         Err(_) => return 0,
     };
@@ -57,11 +82,18 @@ where
             Some(p) => p,
             None => continue,
         };
-        if !is_alive(pid) {
+        // #1165: a reused PID would otherwise pin this directory forever, so
+        // age reclaims it regardless of what currently holds that number.
+        let expired = dir_is_older_than(&path, max_age);
+        if !is_alive(pid) || expired {
             match std::fs::remove_dir_all(&path) {
                 Ok(()) => {
                     cleaned += 1;
-                    tracing::info!(path = %path.display(), "removed stale depfile dir");
+                    tracing::info!(
+                        path = %path.display(),
+                        reason = if expired { "age" } else { "dead_pid" },
+                        "removed stale depfile dir"
+                    );
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -73,6 +105,25 @@ where
         }
     }
     cleaned
+}
+
+/// Is this directory old enough that a live-looking PID can only mean reuse?
+///
+/// Errs toward "no": an unreadable mtime, or a clock that makes the directory
+/// look like it is from the future, both return false. Skipping real debris
+/// costs disk until the next sweep; reclaiming a live daemon's depfile
+/// directory breaks its build. Same bias as the staging-root age gate.
+fn dir_is_older_than(path: &Path, max_age: Duration) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    let Ok(modified) = metadata.modified() else {
+        return false;
+    };
+    let Ok(age) = std::time::SystemTime::now().duration_since(modified) else {
+        return false;
+    };
+    age >= max_age
 }
 
 fn cleanup_legacy_temp_cache_dir(temp_root: &Path, current_cache_dir: &Path) -> usize {

--- a/crates/zccache-core/src/config/tests.rs
+++ b/crates/zccache-core/src/config/tests.rs
@@ -6,7 +6,7 @@
 //! with the resolved depfile dir. Splitting them would force re-importing
 //! every private helper into multiple test modules.
 
-use super::cleanup::cleanup_legacy_temp_root_state;
+use super::cleanup::{cleanup_legacy_temp_root_state, sweep_depfile_dirs};
 use super::namespace::{
     daemon_namespace_from_env_value, home_dir_short_hash, is_safe_ipc_component_char,
     sanitize_ipc_component,
@@ -311,6 +311,58 @@ fn depfile_dir_under_tmp() {
     let dir = depfile_dir_from_cache_dir(&cache);
     assert!(dir.ends_with("depfiles"));
     assert!(dir.starts_with(tmp));
+}
+
+/// Seed `{pid}-{instance}` depfile directories under a fresh base.
+fn seed_depfile_dirs(pids: &[u32]) -> tempfile::TempDir {
+    let base = tempfile::tempdir().unwrap();
+    for (instance, pid) in pids.iter().enumerate() {
+        std::fs::create_dir_all(base.path().join(format!("{pid}-{instance}"))).unwrap();
+    }
+    base
+}
+
+fn dir_count(base: &std::path::Path) -> usize {
+    std::fs::read_dir(base).unwrap().flatten().count()
+}
+
+/// #1165 finding 6: `is_alive(pid)` alone pins a dead daemon's directory
+/// forever once the OS reuses its number for an unrelated long-running
+/// process. Age must reclaim it regardless of who currently holds the pid.
+#[test]
+fn an_expired_depfile_dir_is_reclaimed_even_while_its_pid_looks_alive() {
+    let base = seed_depfile_dirs(&[4242]);
+
+    // Every pid reports alive — only the age floor can act here.
+    let cleaned = sweep_depfile_dirs(base.path(), |_| true, std::time::Duration::ZERO);
+
+    assert_eq!(cleaned, 1, "age must reclaim a directory a live pid pins");
+    assert_eq!(dir_count(base.path()), 0);
+}
+
+/// The converse, and the more important half: a *live* daemon's directory
+/// must survive. Reclaiming one breaks a running build, so the age floor only
+/// applies once the directory is genuinely old.
+#[test]
+fn a_recent_depfile_dir_with_a_live_pid_is_kept() {
+    let base = seed_depfile_dirs(&[4242]);
+
+    let cleaned = sweep_depfile_dirs(base.path(), |_| true, std::time::Duration::from_secs(3600));
+
+    assert_eq!(cleaned, 0, "a live pid's fresh directory must not be swept");
+    assert_eq!(dir_count(base.path()), 1);
+}
+
+/// The dead-pid path still works with a generous age floor — age is a
+/// backstop for pid reuse, not a replacement for liveness.
+#[test]
+fn a_dead_pid_is_still_reclaimed_before_the_age_floor() {
+    let base = seed_depfile_dirs(&[4242]);
+
+    let cleaned = sweep_depfile_dirs(base.path(), |_| false, std::time::Duration::from_secs(3600));
+
+    assert_eq!(cleaned, 1);
+    assert_eq!(dir_count(base.path()), 0);
 }
 
 #[test]


### PR DESCRIPTION
Finding 6 of #1165 — the liveness half. Three findings remain after this.

## The bug

`cleanup_stale_depfile_dirs` removes a `{pid}-{instance}` directory only when `is_alive(pid)` reports the owner gone. PIDs are reused: once the OS hands a dead daemon's number to an unrelated long-running process, that directory is pinned for as long as the new process lives. On a machine with high PID churn that is effectively forever, and it is exactly the "slow orphan accumulation" the finding describes.

## Change

An age floor. A depfile directory belongs to one daemon instance and is removed on clean shutdown, so one older than `DEPFILE_DIR_MAX_AGE` (7 days) is debris regardless of what currently holds its number.

The window is deliberately generous, because the two failure modes are not symmetric: reclaiming a live daemon's depfile directory breaks a running build, while leaving debris a few days longer costs only disk.

For the same reason the age check **errs toward keeping** — an unreadable mtime, or a clock that makes the directory look like it is from the future, both report "not old". That matches the bias already used by the staging-root age gate, which exists for the same reason (soldr#1250).

## Testability

`sweep_depfile_dirs` now takes the base directory and the age floor, so both sides of the gate are exercised without touching the process-global depfile root and without sleeping for a week. Same shape as `StagingRoot::cleanup_abandoned_older_than`, which solved the identical problem.

The removal log records which signal fired (`reason = dead_pid | age`), so a surprising reclaim is attributable after the fact rather than being an unexplained missing directory.

## Verification

`zccache-core` 120 passed, `zccache-daemon-core` 685 passed — 0 failed. clippy `--all-targets -- -D warnings` clean, build clean under `RUSTFLAGS=-D warnings`, and `cargo doc --workspace --no-deps` clean under `RUSTDOCFLAGS=-D warnings` (checked up front this time — the `Documentation` lane caught a private-intra-doc-link in #1274, and it is cheap to run locally).

Three new tests, each confirmed by name:

- expired directory reclaimed **while every pid reports alive** — the pid-reuse case, confirmed **red** without the gate (`left: 0 / right: 1`)
- recent directory with a live pid **kept** — the more important half; reclaiming this breaks builds
- dead pid still reclaimed under a generous floor — age is a backstop for reuse, not a replacement for liveness

The five pre-existing depfile tests stayed green throughout, including while the gate was disabled, so this doesn't disturb the existing dead-pid behaviour.

## Not addressed

Running this sweep periodically rather than only at standalone startup is the other half of finding 6 and waits on #1160's scheduler.

Contributes to #1165 — deliberately not auto-closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
