### PR TITLE
fix(watcher): degrade instead of serving stale hits when the consumer dies (#1177)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/run.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/run.rs
@@ -661,7 +661,7 @@ pub(super) fn record_watcher_degradation(state: &Arc<SharedState>, reason: &str)
 
 /// Spawns the settle buffer and the `CacheSystem` consumer over a freshly
 /// armed watcher's raw event stream.
-fn start_watcher_tasks(
+pub(super) fn start_watcher_tasks(
     state: &Arc<SharedState>,
     raw_rx: tokio::sync::mpsc::UnboundedReceiver<crate::watcher::WatchEvent>,
 ) {
@@ -674,8 +674,9 @@ fn start_watcher_tasks(
         });
 
         // Consumer: feeds settled events into CacheSystem for metadata invalidation.
+        let supervised = Arc::clone(state);
         let state = Arc::clone(state);
-        tokio::spawn(async move {
+        let consumer = tokio::spawn(async move {
             while !state.shutdown_requested.load(Ordering::Acquire) {
                 // Race the settled-event recv against the shutdown signal
                 // (issue #974). Without this the loop only re-checks
@@ -762,6 +763,47 @@ fn start_watcher_tasks(
                 }
             }
             tracing::debug!("watcher consumer task exiting");
+        });
+
+        // #1177 part B: the consumer's handle used to be dropped, so a panic
+        // here killed metadata invalidation silently and the daemon kept
+        // serving fast hits from state nothing was invalidating any more —
+        // stale hits, i.e. a correctness failure, until the next restart.
+        //
+        // It cannot simply be restarted: the task owns `settled_rx`, which a
+        // panic drops, so a fresh loop would have no events to consume and
+        // would look healthy while delivering nothing.
+        //
+        // Instead, fail the way an unarmable watcher already fails (#1156):
+        // clear `watcher_active`, which both fast-hit tiers gate on, and say
+        // so. That converts a silent correctness bug into the documented
+        // degradation the rest of the daemon already handles — slower, but
+        // never wrong.
+        tokio::spawn(async move {
+            let outcome = consumer.await;
+            if supervised.shutdown_requested.load(Ordering::Acquire) {
+                return;
+            }
+            let reason = match &outcome {
+                Err(err) if err.is_panic() => "consumer_panicked",
+                Err(_) => "consumer_cancelled",
+                Ok(()) => "consumer_exited",
+            };
+            supervised.watcher_active.store(false, Ordering::Release);
+            tracing::warn!(
+                event = "watcher_degraded",
+                reason,
+                "watcher consumer stopped before shutdown — metadata invalidation \
+                 is no longer running; both fast hit tiers are disabled so hits \
+                 are re-verified instead of trusted"
+            );
+            crate::core::lifecycle::write_event(
+                crate::core::lifecycle::EVENT_WATCHER_DEGRADED,
+                serde_json::json!({
+                    "reason": reason,
+                    "degradations": ["fast_hit_tiers_disabled", "metadata_invalidation_stopped"],
+                }),
+            );
         });
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/tests/watcher_lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/watcher_lifecycle.rs
@@ -9,7 +9,7 @@
 //! scoped to the test's own record by `FileId` — the aggregate sweep counters
 //! also see records registered by tests running in parallel.
 
-use super::super::run::{arm_watcher_pipeline, record_watcher_degradation};
+use super::super::run::{arm_watcher_pipeline, record_watcher_degradation, start_watcher_tasks};
 use super::super::*;
 
 /// Restores the process-global `WATCHER_AVAILABLE` flag on drop.
@@ -117,6 +117,50 @@ fn overflow_marks_an_unstattable_blob_suspect() {
         registered_link_suspect(id),
         Some(true),
         "an unstattable blob has no cheap evidence and must be marked suspect"
+    );
+}
+
+/// #1177 part B: the watcher consumer's `JoinHandle` used to be dropped, so if
+/// that task died the daemon kept serving fast hits from metadata nothing was
+/// invalidating any more — stale hits, until the next restart.
+///
+/// It cannot be restarted (the task owns the settled-event receiver, which
+/// dies with it), so the supervisor degrades instead: clearing `watcher_active`
+/// makes both fast-hit tiers re-verify rather than trust. Slower, never wrong.
+#[tokio::test]
+async fn a_watcher_consumer_that_stops_before_shutdown_degrades_the_daemon() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_dir: NormalizedPath = dir.path().join("cache").into();
+    let server =
+        DaemonServer::bind_with_cache_dir(&crate::ipc::unique_test_endpoint(), &cache_dir).unwrap();
+    let state = server.test_state_arc();
+    state.watcher_active.store(true, Ordering::Release);
+
+    // Dropping the raw sender ends the settle task, which drops the settled
+    // sender, which ends the consumer — the same shape as the consumer dying,
+    // without needing to induce a panic inside tokio.
+    let (raw_tx, raw_rx) = tokio::sync::mpsc::unbounded_channel();
+    start_watcher_tasks(&state, raw_rx);
+    drop(raw_tx);
+
+    // The supervisor runs on its own task; give it a bounded chance to observe
+    // the exit rather than asserting on a race. Polls instead of sleeping a
+    // fixed interval so a fast machine finishes immediately and a loaded one
+    // still gets its chance.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut degraded = false;
+    while std::time::Instant::now() < deadline {
+        if !state.watcher_active.load(Ordering::Acquire) {
+            degraded = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    assert!(
+        degraded,
+        "a consumer that stops before shutdown must disable the fast hit tiers, \
+         not leave them trusting metadata nothing is invalidating"
     );
 }
 


### PR DESCRIPTION
Part B's highest-consequence finding from #1177. The rest of that issue is capability loss; this one is **wrong answers**.

## The bug

The watcher consumer's `JoinHandle` was dropped (`run.rs:678`). If that task died, metadata invalidation stopped — but `watcher_active` stayed `true`, so both fast-hit tiers kept trusting metadata nothing was invalidating any more. The daemon serves **stale hits** until the next restart, with no signal that anything happened.

## Why not restart-with-backoff

The issue prescribes restarting idempotent loops. That does not work for this task, and the reason is worth recording:

```rust
let (settled_tx, mut settled_rx) = tokio::sync::mpsc::unbounded_channel();
...
tokio::spawn(async move { /* owns settled_rx */ });
```

The consumer **owns** `settled_rx`. A panic drops it, so a restarted loop would have no events to consume. It would sit there healthy-looking and deliver nothing — strictly worse than the current bug, because it removes the symptom while keeping the fault.

## What this does instead

Retain the handle and supervise it. On any exit before shutdown — panic, cancellation, or a clean return — clear `watcher_active`, warn, and emit `EVENT_WATCHER_DEGRADED` naming which of the three happened.

That is not a new failure mode: `watcher_active` is exactly the flag both fast-hit tiers already gate on (`hit_branches.rs:35,203`), and #1156 established the same degradation for a watcher that cannot be armed. So a dead consumer now takes a path the daemon already knows how to handle — hits get re-verified rather than trusted. **Slower, never wrong**, which is the right trade when the alternative is a wrong cache hit.

The supervisor deliberately does nothing when `shutdown_requested` is set, so ordinary shutdown stays silent.

## Verification

`686 passed; 0 failed`; clippy `--all-targets -- -D warnings` clean; build clean under `RUSTFLAGS=-D warnings`; `cargo doc --workspace --no-deps` clean under `RUSTDOCFLAGS=-D warnings`.

The new test closes the channel rather than inducing a panic inside tokio — dropping the raw sender ends the settle task, which drops the settled sender, which ends the consumer. Same supervisor path, fully deterministic, no reliance on panic-in-runtime semantics.

Confirmed **red** before green: with the `watcher_active` store removed it fails on

```
a consumer that stops before shutdown must disable the fast hit tiers,
not leave them trusting metadata nothing is invalidating
```

## Not addressed

The other part-B supervision targets (index writer, disk-GC loop, periodic depgraph save, eviction loops) and part A's `ban_discarded_write_result` dylint. Those are capability-loss modes and independent of this one; the issue itself suggests splitting if review size demands.

Contributes to #1177 — deliberately not auto-closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
