### PR TITLE
fix(ipc): create the cache root and socket dir owner-only on unix (#1171)

### DIFF
--- a/crates/zccache-core/src/config/mod.rs
+++ b/crates/zccache-core/src/config/mod.rs
@@ -102,7 +102,7 @@ pub use namespace::{
 pub use paths::{
     artifacts_dir, artifacts_dir_from_cache_dir, cargo_registry_cache_dir,
     cargo_registry_cache_dir_from_cache_dir, compiler_hash_cache_path_from_cache_dir,
-    crash_dump_dir, depfile_dir, depfile_dir_from_cache_dir, depgraph_dir,
+    crash_dump_dir, create_dir_all_private, depfile_dir, depfile_dir_from_cache_dir, depgraph_dir,
     depgraph_dir_from_cache_dir, index_path, index_path_from_cache_dir, log_dir,
     log_dir_from_cache_dir, metadata_path_from_cache_dir, symbols_cache_dir,
     symbols_cache_dir_from_cache_dir, system_includes_cache_path_from_cache_dir, tmp_dir,

--- a/crates/zccache-core/src/config/paths.rs
+++ b/crates/zccache-core/src/config/paths.rs
@@ -15,6 +15,42 @@
 use super::resolve::{daemon_state_dir_from_cache_dir, default_cache_dir};
 use crate::NormalizedPath;
 
+/// Create `path` and any missing parents, owner-only where the OS expresses
+/// that in the filesystem (#1171).
+///
+/// The cache root and the daemon's socket directory were created with a plain
+/// `create_dir_all`, i.e. `0777 & ~umask` — normally `0755`, and `0777` under
+/// the `0`/`002` umasks CI images and containers often run with. Those
+/// directories hold the IPC endpoint, and anyone who can connect to it can
+/// have the daemon spawn a process of their choosing, so the directory mode is
+/// an access-control boundary rather than tidiness.
+///
+/// It is the *load-bearing* one on macOS and the BSDs, where the kernel does
+/// not enforce a socket's own mode bits on `connect()` — only search
+/// permission on the containing directory, which `0755` grants to everyone.
+///
+/// Only newly created directories get the mode; an existing directory keeps
+/// whatever it has, because silently re-permissioning a user's existing tree
+/// is not this function's call to make. Detecting and reporting an
+/// already-loose directory is #1171 item 4.
+///
+/// On Windows this is exactly `create_dir_all`: the equivalent control there
+/// is the pipe's DACL, which is #1171 item 2.
+pub fn create_dir_all_private(path: &std::path::Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(path)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(path)
+    }
+}
+
 /// Returns the directory for content-addressed compiled outputs.
 #[must_use]
 pub fn artifacts_dir() -> NormalizedPath {

--- a/crates/zccache-core/src/config/resolve.rs
+++ b/crates/zccache-core/src/config/resolve.rs
@@ -210,7 +210,9 @@ pub fn write_last_version_marker() -> std::io::Result<()> {
 /// Test seam for [`write_last_version_marker`]: write the marker under an
 /// explicit top-level dir.
 pub fn write_last_version_marker_in(top_level: &std::path::Path) -> std::io::Result<()> {
-    std::fs::create_dir_all(top_level)?;
+    // #1171: this is the first thing to create the top-level cache root on a
+    // fresh install, so it decides that directory's mode for good.
+    super::paths::create_dir_all_private(top_level)?;
     std::fs::write(
         top_level.join(LAST_VERSION_MARKER),
         format!("{}\n", crate::VERSION),

--- a/crates/zccache-core/src/config/tests.rs
+++ b/crates/zccache-core/src/config/tests.rs
@@ -313,6 +313,54 @@ fn depfile_dir_under_tmp() {
     assert!(dir.starts_with(tmp));
 }
 
+/// #1171: the cache root and socket directory were created with a plain
+/// `create_dir_all` — `0777 & ~umask`, i.e. `0755` normally and `0777` under
+/// the `0`/`002` umasks CI images often run with. Anyone who can reach the
+/// socket in there can have the daemon spawn a process of their choosing.
+///
+/// `0700` is also umask-proof: `mkdir(2)` masks the requested mode, and `0700`
+/// has no group/other bits for a umask to clear.
+#[cfg(unix)]
+#[test]
+fn a_private_dir_is_created_owner_only_at_every_level() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("root");
+    let nested = root.join("state").join("v1");
+
+    super::paths::create_dir_all_private(&nested).unwrap();
+
+    for dir in [
+        nested.as_path(),
+        root.join("state").as_path(),
+        root.as_path(),
+    ] {
+        let mode = std::fs::metadata(dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode,
+            0o700,
+            "{} must be owner-only; a group/other-searchable parent is what \
+             lets another local user reach the socket on macOS, where the \
+             kernel ignores the socket's own mode bits",
+            dir.display()
+        );
+    }
+}
+
+/// Re-creating an existing directory must succeed rather than erroring, since
+/// every daemon start walks this path.
+#[cfg(unix)]
+#[test]
+fn creating_a_private_dir_twice_is_idempotent() {
+    let temp = tempfile::tempdir().unwrap();
+    let dir = temp.path().join("root");
+
+    super::paths::create_dir_all_private(&dir).unwrap();
+    super::paths::create_dir_all_private(&dir)
+        .expect("a second create must be a no-op, not an AlreadyExists error");
+}
+
 /// Seed `{pid}-{instance}` depfile directories under a fresh base.
 fn seed_depfile_dirs(pids: &[u32]) -> tempfile::TempDir {
     let base = tempfile::tempdir().unwrap();

--- a/crates/zccache-ipc/src/lib.rs
+++ b/crates/zccache-ipc/src/lib.rs
@@ -526,7 +526,8 @@ fn lock_file_name(namespace: Option<&str>) -> String {
 pub fn write_lock_file(pid: u32) -> Result<(), std::io::Error> {
     let path = lock_file_path();
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+        // #1171: same directory family as the socket endpoint.
+        zccache_core::config::create_dir_all_private(parent)?;
     }
     std::fs::write(&path, pid.to_string())
 }
@@ -658,7 +659,8 @@ pub fn write_backend_identity(
 ) -> Result<(), std::io::Error> {
     let path = backend_identity_path();
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+        // #1171: same directory family as the socket endpoint.
+        zccache_core::config::create_dir_all_private(parent)?;
     }
     let json = serde_json::to_vec_pretty(daemon)
         .map_err(|err| std::io::Error::other(format!("serialize backend identity: {err}")))?;

--- a/crates/zccache-ipc/src/transport/mod.rs
+++ b/crates/zccache-ipc/src/transport/mod.rs
@@ -362,9 +362,22 @@ impl IpcListener {
             // Remove stale socket if it exists
             let _ = std::fs::remove_file(endpoint);
             if let Some(parent) = std::path::Path::new(endpoint).parent() {
-                std::fs::create_dir_all(parent)?;
+                // #1171: anyone who can connect to this socket can have the
+                // daemon spawn a process of their choosing, so the directory
+                // that contains it is an access-control boundary. A plain
+                // `create_dir_all` left it at `0777 & ~umask`.
+                zccache_core::config::create_dir_all_private(parent)?;
             }
             let listener = tokio::net::UnixListener::bind(endpoint)?;
+            // Tighten the socket itself too. On Linux this is what stops a
+            // permissive umask from leaving it world-connectable; on
+            // macOS/BSD the kernel ignores these bits on `connect()`, which
+            // is why the `0700` parent above is the load-bearing control
+            // there rather than this line.
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(endpoint, std::fs::Permissions::from_mode(0o600));
+            }
             Ok(Self {
                 inner: ListenerInner { listener },
             })


### PR DESCRIPTION
#1171 item 3, plus the socket `chmod` from item 1. The peer-credential check and the Windows DACL are **not** here — see the bottom.

## Why a directory mode is a security control here

The connectable Request surface accepts `Compile` / `GenericToolExec` carrying an attacker-chosen program, args, env and cwd, which the daemon spawns directly. Reaching the socket is therefore arbitrary process execution as the daemon user. The directory holding it is an access-control boundary, not tidiness.

Nothing enforced that. Grep found **no** `PermissionsExt`, `DirBuilderExt` or `0o700` anywhere in `zccache-core` or `zccache-ipc`, confirming the issue's finding. Both the cache root and the socket directory were created with a plain `create_dir_all` — `0777 & ~umask`, normally `0755`, and `0777` under the `0`/`002` umasks CI images and containers often run with.

## Change

`core::config::create_dir_all_private`, with the cache root (`write_last_version_marker_in`), the socket parent (transport `bind`), the lock-file dir and the backend-identity dir routed through it. The socket itself is `chmod`ed to `0600` after bind.

The split of responsibility is worth stating, because it is not symmetric:

- **`0700` parent — load-bearing on macOS/BSD.** Those kernels do not enforce a socket's own mode bits on `connect()`, only search permission on the containing directory, which `0755` grants to everyone. macOS *always* places the socket under `/tmp`, so it was reachable by any local user regardless of the socket's own mode.
- **`0600` socket — load-bearing on Linux**, where the mode is enforced and a permissive umask was the exposure.

`0700` is also umask-proof: `mkdir(2)` masks the requested mode, and `0700` has no group/other bits for a umask to clear. So this holds under `umask 0` too, which is exactly the CI/container case that made the old code worst.

## Deliberately not tightening existing directories

Only newly created directories get the mode. An existing `~/.zccache` keeps whatever it has, because silently re-permissioning a user's existing tree is a different decision with its own failure modes — and detecting and *reporting* an already-loose directory is item 4's job. Flagging this because it means the fix protects fresh installs and does not retroactively repair exposed ones.

## Verification

This is `cfg(unix)` code and I am on Windows, so local verification is cross-compilation plus CI:

- `cargo check --target x86_64-unknown-linux-gnu` — clean
- `cargo check --target aarch64-apple-darwin` — clean (the platform the `0700` parent actually protects)
- `cargo check --tests --target x86_64-unknown-linux-gnu` — clean, so the new `cfg(unix)` tests compile rather than being skipped into a false pass
- Windows native: `zccache-core` 120, `zccache-ipc` 51, `zccache-daemon-core` 686 — 0 failed
- clippy `--all-targets -- -D warnings` clean; `cargo doc --workspace --no-deps` clean under `RUSTDOCFLAGS=-D warnings`

Two new `cfg(unix)` tests, which run on the Linux and macOS lanes: every level of a recursively created path is `0700` (a group-searchable *parent* is the macOS hole, so asserting only the leaf would miss it), and a second create is idempotent rather than `AlreadyExists`, since every daemon start walks this path.

## Not addressed

Peer-credential verification on accept (`SO_PEERCRED` / `getpeereid`), the Windows named-pipe DACL (item 2 — still SUSPECTED, needs a runtime probe of whether the default descriptor grants a non-admin peer *write*), and item 4's refuse-to-start-loudly.

Contributes to #1171 — deliberately not auto-closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
