### PR TITLE
fix(ipc): repair or refuse a group-writable socket directory (#1171 item 4)

### DIFF
--- a/crates/zccache-core/src/config/mod.rs
+++ b/crates/zccache-core/src/config/mod.rs
@@ -103,8 +103,8 @@ pub use paths::{
     artifacts_dir, artifacts_dir_from_cache_dir, cargo_registry_cache_dir,
     cargo_registry_cache_dir_from_cache_dir, compiler_hash_cache_path_from_cache_dir,
     crash_dump_dir, create_dir_all_private, depfile_dir, depfile_dir_from_cache_dir, depgraph_dir,
-    depgraph_dir_from_cache_dir, index_path, index_path_from_cache_dir, log_dir,
-    log_dir_from_cache_dir, metadata_path_from_cache_dir, symbols_cache_dir,
+    depgraph_dir_from_cache_dir, ensure_dir_private, index_path, index_path_from_cache_dir,
+    log_dir, log_dir_from_cache_dir, metadata_path_from_cache_dir, symbols_cache_dir,
     symbols_cache_dir_from_cache_dir, system_includes_cache_path_from_cache_dir, tmp_dir,
     tmp_dir_from_cache_dir,
 };

--- a/crates/zccache-core/src/config/paths.rs
+++ b/crates/zccache-core/src/config/paths.rs
@@ -36,6 +36,57 @@ use crate::NormalizedPath;
 ///
 /// On Windows this is exactly `create_dir_all`: the equivalent control there
 /// is the pipe's DACL, which is #1171 item 2.
+/// Ensure an existing directory is not group- or other-writable, tightening
+/// it in place if it is (#1171 item 4).
+///
+/// [`create_dir_all_private`] only sets the mode on directories it creates, so
+/// an install predating that change still has a `0755` (or worse) cache root
+/// and socket directory. This is the repair path for those, and the reason it
+/// returns a `Result`: a directory that is group/other-writable and cannot be
+/// tightened is a real exposure, and the caller is expected to refuse to serve
+/// rather than continue quietly.
+///
+/// "Writable" is the test, not "readable". Another user reading the directory
+/// listing is uninteresting; another user *creating or replacing entries* in
+/// it is how the socket gets substituted.
+///
+/// Returns `Ok(false)` when nothing needed doing, `Ok(true)` when the mode was
+/// tightened, and `Err` when it is still loose afterwards. On Windows this is
+/// always `Ok(false)` — the equivalent control is the pipe DACL (#1171 item 2).
+pub fn ensure_dir_private(path: &std::path::Path) -> std::io::Result<bool> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mode = std::fs::metadata(path)?.permissions().mode() & 0o777;
+        if mode & 0o022 == 0 {
+            return Ok(false);
+        }
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+
+        // Re-read rather than trusting the write: on some filesystems (and
+        // under some mount options) `chmod` reports success without taking
+        // effect, and this is exactly the case where a false negative is
+        // expensive.
+        let now = std::fs::metadata(path)?.permissions().mode() & 0o777;
+        if now & 0o022 != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!(
+                    "{} is group/other-writable (mode {now:04o}) and could not be tightened",
+                    path.display()
+                ),
+            ));
+        }
+        Ok(true)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = std::fs::metadata(path)?;
+        Ok(false)
+    }
+}
+
 pub fn create_dir_all_private(path: &std::path::Path) -> std::io::Result<()> {
     #[cfg(unix)]
     {

--- a/crates/zccache-core/src/config/paths.rs
+++ b/crates/zccache-core/src/config/paths.rs
@@ -58,7 +58,28 @@ pub fn ensure_dir_private(path: &std::path::Path) -> std::io::Result<bool> {
     {
         use std::os::unix::fs::PermissionsExt;
 
-        let mode = std::fs::metadata(path)?.permissions().mode() & 0o777;
+        let meta = std::fs::metadata(path)?;
+        let full_mode = meta.permissions().mode();
+
+        // Never re-permission a directory zccache does not own.
+        //
+        // The sticky bit is the OS's marker for a *shared* temp root — `/tmp`
+        // and `/var/tmp` are `1777` by design, and their write permission is
+        // the point, with unlink protection supplying the safety. Tightening
+        // one would be wrong for every other process on the machine, and as
+        // root it would succeed: an earlier revision of this function tried
+        // exactly that and CI stopped it. A socket placed directly in such a
+        // root is not a layout zccache produces; its own `0600` mode is what
+        // protects it there.
+        const STICKY: u32 = 0o1000;
+        if full_mode & STICKY != 0 {
+            return Ok(false);
+        }
+        // A directory owned by someone else needs no special case: `chmod`
+        // fails with EPERM and this returns `Err`, which is the right answer
+        // anyway — the directory really is exposed and we really cannot fix
+        // it, so the caller should refuse rather than serve from it.
+        let mode = full_mode & 0o777;
         if mode & 0o022 == 0 {
             return Ok(false);
         }

--- a/crates/zccache-core/src/config/tests.rs
+++ b/crates/zccache-core/src/config/tests.rs
@@ -348,6 +348,59 @@ fn a_private_dir_is_created_owner_only_at_every_level() {
     }
 }
 
+/// #1171 item 4: `create_dir_all_private` only sets the mode on directories it
+/// creates, so installs predating it still have a loose cache root and socket
+/// directory. This is the repair path for those.
+#[cfg(unix)]
+#[test]
+fn a_group_writable_dir_is_tightened_in_place() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let dir = temp.path().join("loose");
+    std::fs::create_dir(&dir).unwrap();
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+    let changed = super::paths::ensure_dir_private(&dir).unwrap();
+
+    assert!(
+        changed,
+        "a world-writable dir must report that it was repaired"
+    );
+    let mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o700, "the repair must leave it owner-only");
+}
+
+/// Writable is the test, not readable. Another user reading the directory
+/// listing is uninteresting; another user creating entries in it is how the
+/// socket gets substituted. A `0755` dir must still be repaired (other-execute
+/// grants the search permission macOS relies on), but a `0700` one must be
+/// left alone rather than churned on every daemon start.
+#[cfg(unix)]
+#[test]
+fn an_already_private_dir_is_left_untouched() {
+    let temp = tempfile::tempdir().unwrap();
+    let dir = temp.path().join("private");
+    super::paths::create_dir_all_private(&dir).unwrap();
+
+    let changed = super::paths::ensure_dir_private(&dir).unwrap();
+
+    assert!(
+        !changed,
+        "an owner-only dir needs no repair and must report so"
+    );
+}
+
+/// A missing directory is an error, not a silent pass — the caller is about to
+/// bind a socket in it.
+#[cfg(unix)]
+#[test]
+fn ensuring_a_missing_dir_is_an_error() {
+    let temp = tempfile::tempdir().unwrap();
+    super::paths::ensure_dir_private(&temp.path().join("nope"))
+        .expect_err("a missing socket directory must not report success");
+}
+
 /// Re-creating an existing directory must succeed rather than erroring, since
 /// every daemon start walks this path.
 #[cfg(unix)]

--- a/crates/zccache-core/src/config/tests.rs
+++ b/crates/zccache-core/src/config/tests.rs
@@ -371,6 +371,37 @@ fn a_group_writable_dir_is_tightened_in_place() {
     assert_eq!(mode, 0o700, "the repair must leave it owner-only");
 }
 
+/// A sticky world-writable directory is a *shared* temp root (`/tmp`,
+/// `/var/tmp` are `1777` by design) and must never be tightened.
+///
+/// The first revision of this function did not check, so it tried to `chmod
+/// /tmp` to `0700` — the socket parent for `unique_test_endpoint`. Unprivileged
+/// that fails and the daemon refuses to bind, which is how CI caught it; as
+/// root it would have *succeeded* and broken every other process on the
+/// machine. Being unable to fix a shared root is not a reason to refuse
+/// either: a socket there is protected by its own `0600` mode.
+#[cfg(unix)]
+#[test]
+fn a_sticky_shared_temp_root_is_never_tightened() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let shared = temp.path().join("shared-tmp");
+    std::fs::create_dir(&shared).unwrap();
+    // 1777 — exactly /tmp's mode.
+    std::fs::set_permissions(&shared, std::fs::Permissions::from_mode(0o1777)).unwrap();
+
+    let changed = super::paths::ensure_dir_private(&shared)
+        .expect("a shared temp root must be accepted, not refused");
+
+    assert!(!changed, "a sticky shared root must be left alone");
+    let mode = std::fs::metadata(&shared).unwrap().permissions().mode() & 0o7777;
+    assert_eq!(
+        mode, 0o1777,
+        "tightening a shared temp root would break every other process using it"
+    );
+}
+
 /// Writable is the test, not readable. Another user reading the directory
 /// listing is uninteresting; another user creating entries in it is how the
 /// socket gets substituted. A `0755` dir must still be repaired (other-execute

--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -44,6 +44,7 @@
 //! | `wrapper-local-fallback` | CLI wrapper | daemon dispatch failed before request delivery and the tool ran locally | `reason`, tool fields |
 //! | `version_mismatch` | daemon | client / daemon protocol versions disagree | `daemon_protocol_version`, `client_protocol_version`, `reason` |
 //! | `state_corrupt` (#1157) | daemon | persisted state did not parse and was dropped rather than reconciled; consequence is a full cold recompile | `subsystem`, `consequence`, `message`, `path`, `bytes` |
+//! | `insecure_socket_dir` (#1171) | daemon | the directory holding the IPC endpoint was group/other-writable; another local user could substitute the socket | `path`, `outcome`, `detail` |
 //! | `staged_publication_conflict` | daemon | one cache key produced two different valid generations; first generation retained | `cache_key`, `existing_generation`, `candidate_generation`, `elapsed_ns` |
 //! | `staged_publication_replaces_invalid_generation` | daemon | a corrupt/incomplete selected generation was replaced by a validated compile result | `cache_key`, `invalid_generation`, `replacement_generation` |
 //! | `staged_salvage_started` | daemon | publication/index failed after a successful compile; requested outputs are being recovered | `reason`, `output_count`, `copied_bytes`, `elapsed_ns` |
@@ -121,6 +122,14 @@ pub const EVENT_VERSION_MISMATCH: &str = "version_mismatch";
 /// so the event carries `subsystem` and `consequence` and is what makes a
 /// fleet-wide "everyone recompiled today" incident attributable after the fact.
 pub const EVENT_STATE_CORRUPT: &str = "state_corrupt";
+/// The directory holding the IPC endpoint was group/other-writable (#1171).
+///
+/// Reaching that socket is arbitrary process execution as the daemon user, so
+/// another local user who can create entries in this directory can substitute
+/// the endpoint. Emitted whether the mode was repaired or the daemon refused
+/// to serve, because "this was exposed until now" is the operator's business
+/// either way.
+pub const EVENT_INSECURE_SOCKET_DIR: &str = "insecure_socket_dir";
 
 /// Issue #755 events — daemon death + handover + client disconnect.
 /// Additive: existing tooling that filters on `event` continues to
@@ -200,6 +209,7 @@ pub const EVENT_ALL: &[&str] = &[
     EVENT_DIED_PRIVATE_OWNER_EXIT,
     EVENT_VERSION_MISMATCH,
     EVENT_STATE_CORRUPT,
+    EVENT_INSECURE_SOCKET_DIR,
     EVENT_DAEMON_DIED,
     EVENT_PIPE_HANDOVER,
     EVENT_CLIENT_DISCONNECTED,

--- a/crates/zccache-ipc/src/transport/mod.rs
+++ b/crates/zccache-ipc/src/transport/mod.rs
@@ -367,6 +367,49 @@ impl IpcListener {
                 // that contains it is an access-control boundary. A plain
                 // `create_dir_all` left it at `0777 & ~umask`.
                 zccache_core::config::create_dir_all_private(parent)?;
+                // #1171 item 4: the line above only sets the mode on
+                // directories it creates, so an install predating that change
+                // still has a loose one. Repair it, and if it cannot be
+                // repaired refuse to serve — binding into a directory other
+                // local users can write means they can substitute this socket,
+                // and the endpoint is arbitrary process execution.
+                match zccache_core::config::ensure_dir_private(parent) {
+                    Ok(false) => {}
+                    Ok(true) => {
+                        tracing::warn!(
+                            event = "insecure_socket_dir",
+                            path = %parent.display(),
+                            outcome = "tightened",
+                            "socket directory was group/other-writable and has been \
+                             tightened to 0700; another local user could have \
+                             substituted the endpoint until now"
+                        );
+                        zccache_core::lifecycle::write_event(
+                            zccache_core::lifecycle::EVENT_INSECURE_SOCKET_DIR,
+                            serde_json::json!({
+                                "path": parent.display().to_string(),
+                                "outcome": "tightened",
+                            }),
+                        );
+                    }
+                    Err(err) => {
+                        tracing::error!(
+                            event = "insecure_socket_dir",
+                            path = %parent.display(),
+                            outcome = "refused",
+                            "refusing to bind: {err}"
+                        );
+                        zccache_core::lifecycle::write_event(
+                            zccache_core::lifecycle::EVENT_INSECURE_SOCKET_DIR,
+                            serde_json::json!({
+                                "path": parent.display().to_string(),
+                                "outcome": "refused",
+                                "detail": err.to_string(),
+                            }),
+                        );
+                        return Err(err.into());
+                    }
+                }
             }
             let listener = tokio::net::UnixListener::bind(endpoint)?;
             // Tighten the socket itself too. On Linux this is what stops a


### PR DESCRIPTION
#1171 item 4, and the repair path for the gap I flagged when landing #1277.

## Why this is needed on top of #1277

`DirBuilder` only applies a mode to directories it *creates*. #1277 therefore protects fresh installs and does nothing for every install that predates it — which still has a `0755` (or looser) cache root and socket directory. That is precisely the population the bug exposes.

## Change

`core::config::ensure_dir_private` tightens an existing group/other-writable directory to `0700`, and reports failure if it is still loose afterwards. Wired into transport `bind`:

| outcome | behaviour |
|---|---|
| already owner-only | nothing, silently |
| repaired | `warn!` + `EVENT_INSECURE_SOCKET_DIR` `outcome=tightened` |
| cannot repair | `error!` + event `outcome=refused`, **bind fails** |

**Refusing is the point.** Binding into a directory other local users can write means they can substitute the socket, and the endpoint accepts `Compile`/`GenericToolExec` carrying an attacker-chosen program — arbitrary process execution as the daemon user. Continuing to serve there quietly would be the wrong trade.

Three decisions worth surfacing:

**The event fires even when the repair succeeds.** "This was exposed until now" is the operator's business either way, and a silent fix would hide the window during which a substituted socket could already have been placed. A repaired directory is not the same as a directory that was never exposed.

**The mode is re-read after `chmod` rather than trusting it.** Some filesystems and mount options report success without effect; a false negative here is expensive, and this is exactly the place not to assume.

**Writable is the test, not readable.** Another user listing the directory is uninteresting. Another user *creating entries* in it is the attack.

## Verification

`cfg(unix)` code again, so local verification is cross-compilation plus CI:

- `cargo check --tests --target x86_64-unknown-linux-gnu` and `--target aarch64-apple-darwin` — both clean, so the new `cfg(unix)` tests compile rather than being skipped into a false pass
- Windows native: `zccache-core` 120, `zccache-ipc` 51 — 0 failed
- clippy `--all-targets -- -D warnings` clean; `cargo doc --workspace --no-deps` clean under `RUSTDOCFLAGS=-D warnings`

Three new `cfg(unix)` tests, running on the Linux and macOS lanes: a `0777` directory is tightened to `0700` and reports it; an already-private one reports no change (so this does not churn on every daemon start); and a missing directory is an error rather than a silent pass, since the caller is about to bind a socket in it.

The `insecure_socket_dir` constant carries an `EVENT_ALL` entry and a module schema-table row — the catalog test enforces that pairing, and it is why the event is greppable by #1159's audit rules rather than being a bare string literal.

## Not addressed

Peer-credential verification on accept (`SO_PEERCRED` / `getpeereid`) and the Windows named-pipe DACL (item 2, still SUSPECTED pending a runtime probe of whether the default descriptor grants a non-admin peer *write*).

Contributes to #1171 — deliberately not auto-closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
