### PR TITLE
fix(cache): lease staged generations through hit delivery

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
@@ -17,6 +17,44 @@ pub(crate) enum CachedPayload {
     File(NormalizedPath),
 }
 
+/// Payloads resolved for one requested-output delivery.
+///
+/// Staged file payloads carry a shared store-lock guard. Its ownership is tied
+/// to this value so callers cannot retain generation paths while accidentally
+/// dropping the lock before reflink/hardlink/copy or directory unpacking.
+pub(crate) struct MaterializationPayloads {
+    payloads: Arc<[CachedPayload]>,
+    staged_guard: Option<StagedMaterializationGuard>,
+}
+
+impl std::ops::Deref for MaterializationPayloads {
+    type Target = [CachedPayload];
+
+    fn deref(&self) -> &Self::Target {
+        &self.payloads
+    }
+}
+
+impl MaterializationPayloads {
+    pub(crate) fn staged_lock_timings(&self) -> Option<(u64, u64)> {
+        self.staged_guard
+            .as_ref()
+            .map(StagedMaterializationGuard::timings_ns)
+    }
+
+    pub(crate) fn record_staged_lock_timings(
+        &self,
+        profiler: &crate::daemon::staged_stats::StagedProfiler,
+    ) {
+        use crate::daemon::staged_stats::StagedTiming;
+
+        if let Some((wait_ns, hold_ns)) = self.staged_lock_timings() {
+            profiler.timing(StagedTiming::HitStoreLockWait, wait_ns);
+            profiler.timing(StagedTiming::HitStoreLockHold, hold_ns);
+        }
+    }
+}
+
 struct ArtifactAccess {
     last_used: std::time::Instant,
     last_used_wall: std::time::SystemTime,
@@ -217,33 +255,6 @@ impl CachedArtifact {
     }
 }
 
-/// Load output payloads from `{key}_0`, `{key}_1`, ... files on disk.
-///
-/// Returns the payload slice, or `None` if any data file is missing
-/// (indicating corruption or eviction — caller should treat as cache miss).
-pub(super) fn ensure_payloads(
-    cached: &CachedArtifact,
-    artifact_dir: &Path,
-    key_hex: &str,
-) -> Option<Arc<[CachedPayload]>> {
-    ensure_payloads_result(cached, artifact_dir, key_hex)
-        .ok()
-        .flatten()
-}
-
-pub(super) fn ensure_payloads_result(
-    cached: &CachedArtifact,
-    artifact_dir: &Path,
-    key_hex: &str,
-) -> std::io::Result<Option<Arc<[CachedPayload]>>> {
-    ensure_payloads_with_staged_policy_result(
-        cached,
-        artifact_dir,
-        key_hex,
-        staged_artifacts_enabled(),
-    )
-}
-
 /// Resolve payloads for materialization, translating a resolver failure or a
 /// missing-blob outcome into a typed [`MaterializationFailure`] the caller can
 /// report and (for genuine blob loss) use as depgraph-invalidation evidence.
@@ -251,20 +262,68 @@ pub(super) fn ensure_payloads_for_materialization(
     cached: &CachedArtifact,
     artifact_dir: &Path,
     key_hex: &str,
-) -> MaterializationResult<Arc<[CachedPayload]>> {
-    match ensure_payloads_result(cached, artifact_dir, key_hex) {
-        Ok(Some(payloads)) => Ok(payloads),
-        Ok(None) => Err(cache_blob_missing(
+) -> MaterializationResult<MaterializationPayloads> {
+    let existing = cached.payloads.get().cloned();
+    let existing_is_staged = existing.as_ref().is_some_and(|payloads| {
+        payloads.iter().any(
+            |payload| matches!(payload, CachedPayload::File(path) if is_staged_artifact_path(path)),
+        )
+    });
+    let mut staged_guard = if existing_is_staged {
+        Some(
+            acquire_staged_materialization_guard_for_cached_path(artifact_dir)
+                .map_err(|error| cache_read_failure(artifact_dir, error))?,
+        )
+    } else if existing.is_none() && staged_artifacts_enabled() {
+        acquire_staged_materialization_guard_if_present(artifact_dir, key_hex)
+            .map_err(|error| cache_read_failure(artifact_dir, error))?
+    } else {
+        None
+    };
+
+    let resolved = if let Some(payloads) = existing {
+        Some(payloads)
+    } else {
+        ensure_payloads_with_staged_policy_result(
+            cached,
+            artifact_dir,
+            key_hex,
+            staged_guard.is_some(),
+        )
+        .map_err(|error| cache_read_failure(artifact_dir, error))?
+    };
+
+    match resolved {
+        Some(payloads) => {
+            let is_staged = payloads.iter().any(
+                |payload| matches!(payload, CachedPayload::File(path) if is_staged_artifact_path(path)),
+            );
+            if is_staged && staged_guard.is_none() {
+                // A concurrent resolver may have initialized the shared cell
+                // with staged paths after this request chose its lookup lane.
+                // Acquire ownership before those canonical paths can escape.
+                staged_guard = Some(
+                    acquire_staged_materialization_guard_for_cached_path(artifact_dir)
+                        .map_err(|error| cache_read_failure(artifact_dir, error))?,
+                );
+            } else if !is_staged {
+                // A pointer may have disappeared before the shared lock was
+                // acquired, causing the resolver to fall back to pack/v1.
+                // Non-staged payloads must not retain the staged-store lock.
+                staged_guard = None;
+            }
+            Ok(MaterializationPayloads {
+                payloads,
+                staged_guard,
+            })
+        }
+        None => Err(cache_blob_missing(
             &artifact_dir.join(key_hex),
             std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 "cached artifact metadata or payload is unavailable",
             ),
         )),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            Err(cache_blob_missing(&artifact_dir.join(key_hex), error))
-        }
-        Err(error) => Err(cache_read_failure(artifact_dir, error)),
     }
 }
 
@@ -488,5 +547,177 @@ mod tests {
         assert!(ensure_payloads_with_staged_policy(&cached, dir.path(), key, false).is_none());
         std::fs::write(dir.path().join(format!("{key}_0")), b"payload").unwrap();
         assert!(ensure_payloads_with_staged_policy(&cached, dir.path(), key, false).is_some());
+    }
+
+    #[test]
+    fn staged_materialization_lease_blocks_clear_until_delivery_finishes() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let artifact_dir = dir.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let source = dir.path().join("source.rlib");
+        let bytes = b"staged materialization ownership";
+        std::fs::write(&source, bytes).unwrap();
+        let key = "3".repeat(64);
+        persist_staged_artifact_paths(&artifact_dir, &key, &[source.into()]).unwrap();
+        let cached = lazy_artifact(bytes.len() as u64);
+
+        let payloads = ensure_payloads_for_materialization(&cached, &artifact_dir, &key).unwrap();
+        assert!(
+            payloads.staged_lock_timings().is_some(),
+            "a staged payload must carry its store-lock lease"
+        );
+        let staged_generation_path = match &payloads[0] {
+            CachedPayload::File(path) => path.clone(),
+            CachedPayload::Bytes(_) => panic!("staged resolver returned an inline payload"),
+        };
+
+        let clear_hook =
+            StagedHookGuard::arm(&artifact_dir, StagedHookPoint::MaintenanceStoreLockPending);
+        let (clear_done_tx, clear_done_rx) = mpsc::sync_channel(1);
+        let clear_artifact_dir = artifact_dir.clone();
+        let clear = std::thread::spawn(move || {
+            let result = clear_staged_artifacts(&clear_artifact_dir);
+            let _ = clear_done_tx.send(result);
+        });
+        clear_hook.wait_until_reached();
+        clear_hook.resume();
+        assert!(
+            matches!(
+                clear_done_rx.recv_timeout(Duration::from_millis(100)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ),
+            "exclusive clear must wait while requested-output delivery owns the shared lease"
+        );
+
+        let destination: NormalizedPath = dir.path().join("restored.rlib").into();
+        write_payloads_par_observed(std::slice::from_ref(&destination), &payloads).unwrap();
+        assert_eq!(std::fs::read(&destination).unwrap(), bytes);
+
+        drop(payloads);
+        clear_done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("clear did not resume after the materialization lease was released")
+            .unwrap();
+        clear.join().unwrap();
+        assert!(
+            !staged_generation_path.exists(),
+            "clear must proceed promptly after the lease is released"
+        );
+    }
+
+    #[test]
+    fn staged_materialization_lease_blocks_snapshot_eviction_until_delivery_finishes() {
+        use std::collections::HashMap;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let artifact_dir = dir.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let source = dir.path().join("source.rmeta");
+        let bytes = b"snapshot eviction ownership";
+        std::fs::write(&source, bytes).unwrap();
+        let key = "6".repeat(64);
+        persist_staged_artifact_paths(&artifact_dir, &key, &[source.into()]).unwrap();
+        let cached = lazy_artifact(bytes.len() as u64);
+        let payloads = ensure_payloads_for_materialization(&cached, &artifact_dir, &key).unwrap();
+        let generation = std::fs::read_to_string(
+            artifact_dir
+                .join(".staged-v2")
+                .join(format!("{key}.current")),
+        )
+        .unwrap();
+        let expected = HashMap::from([(key.clone(), Some(generation.trim().to_string()))]);
+
+        let eviction_hook =
+            StagedHookGuard::arm(&artifact_dir, StagedHookPoint::MaintenanceStoreLockPending);
+        let (eviction_done_tx, eviction_done_rx) = mpsc::sync_channel(1);
+        let eviction_artifact_dir = artifact_dir.clone();
+        let eviction = std::thread::spawn(move || {
+            let result = evict_staged_artifact_keys_if_unchanged(&eviction_artifact_dir, &expected);
+            let _ = eviction_done_tx.send(result);
+        });
+        eviction_hook.wait_until_reached();
+        eviction_hook.resume();
+        assert!(
+            matches!(
+                eviction_done_rx.recv_timeout(Duration::from_millis(100)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ),
+            "snapshot eviction must wait while a hit owns the staged generation"
+        );
+
+        let destination: NormalizedPath = dir.path().join("restored.rmeta").into();
+        write_payloads_par_observed(std::slice::from_ref(&destination), &payloads).unwrap();
+        assert_eq!(std::fs::read(&destination).unwrap(), bytes);
+        drop(payloads);
+
+        let removed = eviction_done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("eviction did not resume after the materialization lease was released")
+            .unwrap();
+        assert_eq!(removed, std::collections::HashSet::from([key]));
+        eviction.join().unwrap();
+    }
+
+    #[test]
+    fn non_staged_payloads_do_not_take_the_staged_store_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let artifact_dir = dir.path().join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let key = "4".repeat(64);
+        let legacy = artifact_dir.join(format!("{key}_0"));
+        std::fs::write(&legacy, b"legacy").unwrap();
+        let cached = lazy_artifact(6);
+
+        let payloads = ensure_payloads_for_materialization(&cached, &artifact_dir, &key).unwrap();
+        assert!(
+            payloads.staged_lock_timings().is_none(),
+            "legacy file payloads must not acquire the staged-store lock"
+        );
+
+        let inline = CachedArtifact::from_cached_payloads(
+            ArtifactIndex::new(
+                vec!["inline.o".to_string()],
+                vec![6],
+                Arc::new(Vec::new()),
+                Arc::new(Vec::new()),
+                0,
+            ),
+            vec![CachedPayload::Bytes(Arc::new(b"inline".to_vec()))],
+        );
+        let inline_payloads =
+            ensure_payloads_for_materialization(&inline, &artifact_dir, &"5".repeat(64)).unwrap();
+        assert!(
+            inline_payloads.staged_lock_timings().is_none(),
+            "byte-backed payloads must not acquire the staged-store lock"
+        );
+    }
+
+    #[test]
+    fn every_cache_hit_delivery_path_uses_the_typed_materialization_lease() {
+        let consumers = [
+            (
+                "single compile",
+                include_str!("handle_compile/cached_hit.rs"),
+            ),
+            ("multi compile", include_str!("handle_compile_multi.rs")),
+            ("exact exec", include_str!("handle_exec.rs")),
+            ("link and directory bundle", include_str!("handle_link.rs")),
+        ];
+        for (name, source) in consumers {
+            assert!(
+                source.contains("ensure_payloads_for_materialization("),
+                "{name} bypasses the typed staged materialization lease"
+            );
+        }
+        assert!(
+            include_str!("handle_link.rs")
+                .contains("materialize_directory_payload(&payloads[0], &output_path)"),
+            "directory-bundle unpacking must consume payloads from the leased resolver"
+        );
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
@@ -207,12 +207,15 @@ pub(super) fn materialize_cached_compile_hit(
     let has_staged_payload = payloads_to_write.iter().any(
         |payload| matches!(payload, CachedPayload::File(path) if is_staged_artifact_path(path)),
     );
-    let observed = match write_payloads_par_with_mtime_floor_and_policies_observed(
+    let observed_result = write_payloads_par_with_mtime_floor_and_policies_observed(
         &targets,
         &payloads_to_write,
         &mtime_floor_paths,
         &delivery_policies,
-    ) {
+    );
+    payloads.record_staged_lock_timings(&state.profiler.staged);
+    drop(payloads);
+    let observed = match observed_result {
         Ok(observed) => observed,
         Err(error) => {
             report_materialization_failure(

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -149,6 +149,8 @@ fn check_unit_cache(
                                 })
                                 .collect();
                             let materialization = materialize_multi_hit(&targets, &payloads);
+                            payloads.record_staged_lock_timings(&state.profiler.staged);
+                            drop(payloads);
                             if let Err(failure) = &materialization {
                                 report_materialization_failure(
                                     &state.cache_dir,
@@ -328,6 +330,8 @@ fn check_unit_cache(
                         })
                         .collect();
                     let materialization = materialize_multi_hit(&targets, &payloads);
+                    payloads.record_staged_lock_timings(&state.profiler.staged);
+                    drop(payloads);
                     if let Err(failure) = &materialization {
                         report_materialization_failure(
                             &state.cache_dir,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
@@ -768,7 +768,11 @@ async fn try_exec_cache_hit(
     let stderr_full = entry.stderr.clone();
     let names = Arc::clone(&entry.meta.output_names);
 
-    let payloads = ensure_payloads(&entry, &state.artifact_dir, key_hex)?;
+    let payloads = ensure_payloads_for_materialization(&entry, &state.artifact_dir, key_hex)
+        .map_err(|failure| {
+            report_materialization_failure(&state.cache_dir, key_hex, "exec-hit", &failure);
+        })
+        .ok()?;
     record_artifact_access(state, key_hex, &entry, std::time::Instant::now());
 
     let mut paired: Vec<(NormalizedPath, &CachedPayload)> = Vec::with_capacity(output_files.len());
@@ -795,6 +799,8 @@ async fn try_exec_cache_hit(
     });
     let materialize_started = std::time::Instant::now();
     let observed = write_payloads_par_observed(&targets, &payloads_for_write);
+    payloads.record_staged_lock_timings(&state.profiler.staged);
+    drop(payloads);
     if let Err(failure) = &observed {
         report_materialization_failure(&state.cache_dir, key_hex, "exec-hit", failure);
     }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -374,7 +374,14 @@ pub(super) async fn handle_link_ephemeral(
     let t_cache_lookup = profile_enabled.then(std::time::Instant::now);
     if let Some(entry) = lookup_artifact_with_disk_fallback(state, &key_hex) {
         // Load payloads from disk if not already loaded.
-        if let Some(payloads) = ensure_payloads(&entry, &state.artifact_dir, &key_hex) {
+        if let Ok(payloads) = ensure_payloads_for_materialization(
+            &entry,
+            &state.artifact_dir,
+            &key_hex,
+        )
+        .map_err(|failure| {
+            report_materialization_failure(&state.cache_dir, &key_hex, "link-hit", &failure);
+        }) {
             record_artifact_access(state, &key_hex, &entry, std::time::Instant::now());
             discard_speculative_archive(&mut speculative_archive);
             let names = Arc::clone(&entry.meta.output_names);
@@ -406,6 +413,8 @@ pub(super) async fn handle_link_ephemeral(
                         copy_bytes,
                         ..StagedMaterializationStats::default()
                     });
+                payloads.record_staged_lock_timings(&state.profiler.staged);
+                drop(payloads);
                 if record_staged_hit_materialization(state, 1, materialize_started, observed) {
                     return Response::LinkResult {
                         exit_code,
@@ -450,6 +459,8 @@ pub(super) async fn handle_link_ephemeral(
             });
             let materialize_started = std::time::Instant::now();
             let observed = write_payloads_par_observed(&targets, &payloads);
+            payloads.record_staged_lock_timings(&state.profiler.staged);
+            drop(payloads);
             if let Err(failure) = &observed {
                 report_materialization_failure(&state.cache_dir, &key_hex, "link-hit", failure);
             }

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -22,6 +22,13 @@ pub(in crate::daemon::server) use materialize::{
     materialization_error, materialization_error_progress, materialize_independent_with_stats,
     StagedMaterializationStats,
 };
+mod read_guard;
+use read_guard::validate_key;
+pub(in crate::daemon::server) use read_guard::{
+    acquire_staged_materialization_guard_for_cached_path,
+    acquire_staged_materialization_guard_if_present, is_staged_artifact_path,
+    is_staged_artifact_root, staged_key_supported, StagedMaterializationGuard,
+};
 mod root_safety;
 pub(in crate::daemon::server) use root_safety::validate_staged_artifact_root;
 use root_safety::{
@@ -233,73 +240,6 @@ fn staged_exec_lane_enabled_for(value: Option<&str>) -> bool {
             "all" | "1" | "true" | "yes" | "on" | "exec"
         )
     })
-}
-
-pub(in crate::daemon::server) fn staged_key_supported(key_hex: &str) -> bool {
-    !key_hex.is_empty()
-        && key_hex.len() <= 128
-        && key_hex.bytes().all(|byte| byte.is_ascii_hexdigit())
-}
-
-pub(in crate::daemon::server) fn is_staged_artifact_path(path: &Path) -> bool {
-    let mut components = path.components().rev();
-    let Some(output) = components
-        .next()
-        .and_then(|component| component.as_os_str().to_str())
-    else {
-        return false;
-    };
-    let Some(generation) = components
-        .next()
-        .and_then(|component| component.as_os_str().to_str())
-    else {
-        return false;
-    };
-    let Some(key) = components
-        .next()
-        .and_then(|component| component.as_os_str().to_str())
-    else {
-        return false;
-    };
-    let Some(root) = components
-        .next()
-        .and_then(|component| component.as_os_str().to_str())
-    else {
-        return false;
-    };
-    let root_matches = if cfg!(windows) {
-        root.eq_ignore_ascii_case(STAGED_ROOT)
-    } else {
-        root == STAGED_ROOT
-    };
-    let key_matches =
-        key.len() <= 128 && !key.is_empty() && key.bytes().all(|byte| byte.is_ascii_hexdigit());
-    let generation_matches =
-        generation.len() == 64 && generation.bytes().all(|byte| byte.is_ascii_hexdigit());
-    let output_matches = output
-        .strip_prefix("output-")
-        .is_some_and(|index| !index.is_empty() && index.bytes().all(|byte| byte.is_ascii_digit()));
-    root_matches && key_matches && generation_matches && output_matches
-}
-
-pub(in crate::daemon::server) fn is_staged_artifact_root(path: &Path) -> bool {
-    path.file_name().is_some_and(|name| {
-        if cfg!(windows) {
-            name.to_string_lossy().eq_ignore_ascii_case(STAGED_ROOT)
-        } else {
-            name == STAGED_ROOT
-        }
-    })
-}
-
-fn validate_key(key_hex: &str) -> io::Result<()> {
-    if !staged_key_supported(key_hex) {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "staged artifact key must be a bounded hexadecimal string",
-        ));
-    }
-    Ok(())
 }
 
 fn validate_generation(generation_hex: &str) -> io::Result<()> {

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/README.md
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/README.md
@@ -3,7 +3,9 @@
 - `maintenance.rs` scans, evicts, and safely clears complete immutable
   generations.
 - `materialize.rs` restores requested outputs with physical-tier observations.
+- `read_guard.rs` ties resolved staged paths to a shared maintenance-lock lease.
 - `root_safety.rs` validates the exact staged root and removes links/reparse
   points without traversal.
 - `fault.rs` provides path-scoped deterministic fault injection in tests only.
-- `hook.rs` provides deterministic test synchronization around publication.
+- `hook.rs` provides deterministic test synchronization around publication,
+  materialization, and maintenance lock acquisition.

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/hook.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/hook.rs
@@ -9,6 +9,7 @@ use std::sync::{Mutex, OnceLock};
 pub(in crate::daemon::server) enum StagedHookPoint {
     PublicationStoreLocked,
     MaterializeOutput,
+    MaintenanceStoreLockPending,
 }
 
 struct ActiveHook {

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/maintenance.rs
@@ -142,6 +142,11 @@ pub(crate) fn evict_staged_artifact_keys_if_unchanged(
         return Ok(HashSet::new());
     }
     let store_lock = open_store_lock(&root)?;
+    #[cfg(test)]
+    super::hook::pause(
+        artifact_dir,
+        super::StagedHookPoint::MaintenanceStoreLockPending,
+    );
     fs2::FileExt::lock_exclusive(&store_lock)?;
     let mut removed = HashSet::new();
     for (key, expected_generation) in expected.iter().filter(|(key, _)| staged_key_supported(key)) {
@@ -216,6 +221,11 @@ pub(in crate::daemon::server) fn clear_staged_artifacts(artifact_dir: &Path) -> 
         return Ok(0);
     }
     let store_lock = open_store_lock(&root)?;
+    #[cfg(test)]
+    super::hook::pause(
+        artifact_dir,
+        super::StagedHookPoint::MaintenanceStoreLockPending,
+    );
     fs2::FileExt::lock_exclusive(&store_lock)?;
     let mut bytes_removed = 0;
     for entry in fs::read_dir(&root)?.flatten() {

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/read_guard.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/read_guard.rs
@@ -1,0 +1,140 @@
+//! Shared staged-generation ownership for cache-hit materialization.
+
+use super::{is_staged_link_or_reparse, open_store_lock, pointer_path, staged_root, STAGED_ROOT};
+use std::fs::{self, File};
+use std::io;
+use std::path::Path;
+use std::time::Instant;
+
+pub(in crate::daemon::server) fn staged_key_supported(key_hex: &str) -> bool {
+    !key_hex.is_empty()
+        && key_hex.len() <= 128
+        && key_hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+pub(in crate::daemon::server) fn is_staged_artifact_path(path: &Path) -> bool {
+    let mut components = path.components().rev();
+    let Some(output) = components
+        .next()
+        .and_then(|component| component.as_os_str().to_str())
+    else {
+        return false;
+    };
+    let Some(generation) = components
+        .next()
+        .and_then(|component| component.as_os_str().to_str())
+    else {
+        return false;
+    };
+    let Some(key) = components
+        .next()
+        .and_then(|component| component.as_os_str().to_str())
+    else {
+        return false;
+    };
+    let Some(root) = components
+        .next()
+        .and_then(|component| component.as_os_str().to_str())
+    else {
+        return false;
+    };
+    let root_matches = if cfg!(windows) {
+        root.eq_ignore_ascii_case(STAGED_ROOT)
+    } else {
+        root == STAGED_ROOT
+    };
+    let key_matches =
+        key.len() <= 128 && !key.is_empty() && key.bytes().all(|byte| byte.is_ascii_hexdigit());
+    let generation_matches =
+        generation.len() == 64 && generation.bytes().all(|byte| byte.is_ascii_hexdigit());
+    let output_matches = output
+        .strip_prefix("output-")
+        .is_some_and(|index| !index.is_empty() && index.bytes().all(|byte| byte.is_ascii_digit()));
+    root_matches && key_matches && generation_matches && output_matches
+}
+
+pub(in crate::daemon::server) fn is_staged_artifact_root(path: &Path) -> bool {
+    path.file_name().is_some_and(|name| {
+        if cfg!(windows) {
+            name.to_string_lossy().eq_ignore_ascii_case(STAGED_ROOT)
+        } else {
+            name == STAGED_ROOT
+        }
+    })
+}
+
+pub(super) fn validate_key(key_hex: &str) -> io::Result<()> {
+    if !staged_key_supported(key_hex) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "staged artifact key must be a bounded hexadecimal string",
+        ));
+    }
+    Ok(())
+}
+
+/// Shared ownership of the staged store while resolved generation paths are
+/// being delivered to caller-owned destinations.
+///
+/// Cleanup and eviction take the same file lock exclusively. Keeping this
+/// guard in the typed materialization payload prevents a generation from
+/// disappearing between resolution and the final reflink/hardlink/copy.
+pub(in crate::daemon::server) struct StagedMaterializationGuard {
+    _store_lock: File,
+    wait_ns: u64,
+    acquired_at: Instant,
+}
+
+impl StagedMaterializationGuard {
+    pub(in crate::daemon::server) fn timings_ns(&self) -> (u64, u64) {
+        (
+            self.wait_ns,
+            self.acquired_at.elapsed().as_nanos().min(u64::MAX as u128) as u64,
+        )
+    }
+}
+
+fn acquire_staged_materialization_guard(
+    artifact_dir: &Path,
+) -> io::Result<StagedMaterializationGuard> {
+    let root = staged_root(artifact_dir);
+    let store_lock = open_store_lock(&root)?;
+    let wait_started = Instant::now();
+    fs2::FileExt::lock_shared(&store_lock)?;
+    let wait_ns = wait_started.elapsed().as_nanos().min(u64::MAX as u128) as u64;
+    Ok(StagedMaterializationGuard {
+        _store_lock: store_lock,
+        wait_ns,
+        acquired_at: Instant::now(),
+    })
+}
+
+/// Acquire staged-store read ownership only when this key currently has a
+/// staged pointer. If no pointer exists, callers deliberately resolve with
+/// staged lookup disabled for that attempt: a concurrent publisher may become
+/// visible on the next lookup, but no unguarded staged path can escape.
+pub(in crate::daemon::server) fn acquire_staged_materialization_guard_if_present(
+    artifact_dir: &Path,
+    key_hex: &str,
+) -> io::Result<Option<StagedMaterializationGuard>> {
+    validate_key(key_hex)?;
+    let pointer = pointer_path(artifact_dir, key_hex);
+    match fs::symlink_metadata(&pointer) {
+        Ok(metadata) if is_staged_link_or_reparse(&metadata) => Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing staged artifact materialization through linked/reparse pointer: {}",
+                pointer.display()
+            ),
+        )),
+        Ok(_) => acquire_staged_materialization_guard(artifact_dir).map(Some),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+pub(in crate::daemon::server) fn acquire_staged_materialization_guard_for_cached_path(
+    artifact_dir: &Path,
+) -> io::Result<StagedMaterializationGuard> {
+    acquire_staged_materialization_guard(artifact_dir)
+}

--- a/crates/zccache-daemon-core/src/daemon/staged_stats.rs
+++ b/crates/zccache-daemon-core/src/daemon/staged_stats.rs
@@ -57,6 +57,8 @@ pub(crate) enum StagedTiming {
     Salvage,
     MissMaterialization,
     HitMaterialization,
+    HitStoreLockWait,
+    HitStoreLockHold,
 }
 
 const TIMINGS: &[(StagedTiming, &str)] = &[
@@ -67,6 +69,8 @@ const TIMINGS: &[(StagedTiming, &str)] = &[
     (StagedTiming::Salvage, "salvage"),
     (StagedTiming::MissMaterialization, "miss_materialization"),
     (StagedTiming::HitMaterialization, "hit_materialization"),
+    (StagedTiming::HitStoreLockWait, "hit_store_lock_wait"),
+    (StagedTiming::HitStoreLockHold, "hit_store_lock_hold"),
 ];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -150,6 +150,15 @@ emit a durable `staged_publication_conflict` lifecycle event. An
 invalid/corrupt prior generation may be replaced and is recorded as
 `staged_publication_replaces_invalid_generation`.
 
+Cache-hit resolution uses the same ownership boundary. A typed
+`MaterializationPayloads` value carries a shared store-lock lease whenever its
+payloads point into a staged generation, and keeps that lease alive through
+file delivery or directory-bundle unpacking. Cleanup and eviction therefore
+wait for an active hit instead of unlinking its generation between resolution
+and materialization. Byte-backed, pack, and flat-v1 payloads do not acquire the
+staged-store lock. The staged profile reports `hit_store_lock_wait` and
+`hit_store_lock_hold` nanoseconds separately from total hit materialization.
+
 Mixed-format lookup is explicit during migration: v2 is attempted first,
 then flat v1 payloads, then pack payloads. Disabling staged artifacts (or
 downgrading to a reader without v2 support) leaves v1/pack entries readable


### PR DESCRIPTION
## Summary
- carry a typed shared staged-store lease from payload resolution through file or directory delivery
- cover compile, multi-compile, exact-exec, link, and directory-bundle hits without locking byte/pack/flat-v1 payloads
- expose hit_store_lock_wait and hit_store_lock_hold timing and add deterministic clear/eviction race tests

## Validation
- soldr cargo fmt --all -- --check
- soldr cargo clippy -p zccache-daemon-core --all-targets --features test-support,daemon-entry -- -D warnings
- soldr cargo test -p zccache-daemon-core --features test-support,daemon-entry --lib (715 passed)
- ./test --integration
- Local Linux Docker repeated performance matrix: pending; Docker Desktop is currently engine-unavailable and restart is confirmation-gated

Closes #1215