### PR TITLE
security(ipc): verify the peer uid on every accepted connection (#1171)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4419,6 +4419,7 @@ dependencies = [
  "bytes",
  "dashmap",
  "interprocess",
+ "libc",
  "prost",
  "running-process",
  "serde",

--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -130,6 +130,14 @@ pub const EVENT_STATE_CORRUPT: &str = "state_corrupt";
 /// to serve, because "this was exposed until now" is the operator's business
 /// either way.
 pub const EVENT_INSECURE_SOCKET_DIR: &str = "insecure_socket_dir";
+/// An accepted IPC connection was refused because the peer is not the daemon's
+/// own user, or because the kernel would not report the peer's identity (#1171).
+///
+/// Carries `reason` (`foreign-uid` / `peer-cred-unavailable`) and a `detail`
+/// string. Any occurrence means something other than this user's toolchain
+/// reached the endpoint — the `0700` directory that is supposed to make that
+/// impossible has been bypassed or was never applied.
+pub const EVENT_IPC_PEER_REJECTED: &str = "ipc_peer_rejected";
 
 /// Issue #755 events — daemon death + handover + client disconnect.
 /// Additive: existing tooling that filters on `event` continues to
@@ -210,6 +218,7 @@ pub const EVENT_ALL: &[&str] = &[
     EVENT_VERSION_MISMATCH,
     EVENT_STATE_CORRUPT,
     EVENT_INSECURE_SOCKET_DIR,
+    EVENT_IPC_PEER_REJECTED,
     EVENT_DAEMON_DIED,
     EVENT_PIPE_HANDOVER,
     EVENT_CLIENT_DISCONNECTED,

--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -45,6 +45,7 @@
 //! | `version_mismatch` | daemon | client / daemon protocol versions disagree | `daemon_protocol_version`, `client_protocol_version`, `reason` |
 //! | `state_corrupt` (#1157) | daemon | persisted state did not parse and was dropped rather than reconciled; consequence is a full cold recompile | `subsystem`, `consequence`, `message`, `path`, `bytes` |
 //! | `insecure_socket_dir` (#1171) | daemon | the directory holding the IPC endpoint was group/other-writable; another local user could substitute the socket | `path`, `outcome`, `detail` |
+//! | `ipc_peer_rejected` (#1171) | daemon | an accepted IPC connection was refused because the peer is not this user, or its credentials were unavailable | `reason`, `detail` |
 //! | `staged_publication_conflict` | daemon | one cache key produced two different valid generations; first generation retained | `cache_key`, `existing_generation`, `candidate_generation`, `elapsed_ns` |
 //! | `staged_publication_replaces_invalid_generation` | daemon | a corrupt/incomplete selected generation was replaced by a validated compile result | `cache_key`, `invalid_generation`, `replacement_generation` |
 //! | `staged_salvage_started` | daemon | publication/index failed after a successful compile; requested outputs are being recovered | `reason`, `output_count`, `copied_bytes`, `elapsed_ns` |

--- a/crates/zccache-ipc/Cargo.toml
+++ b/crates/zccache-ipc/Cargo.toml
@@ -25,6 +25,10 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["tracing"] }
 tracing = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+# `geteuid` for the accept-time peer-identity check (#1171).
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = { workspace = true }
 zccache-depgraph = { workspace = true }

--- a/crates/zccache-ipc/src/transport/mod.rs
+++ b/crates/zccache-ipc/src/transport/mod.rs
@@ -532,15 +532,38 @@ impl IpcListener {
     pub async fn accept(&mut self) -> Result<IpcConnection, IpcError> {
         #[cfg(unix)]
         {
-            let (stream, _addr) = self.inner.listener.accept().await?;
-            let (reader, writer) = tokio::io::split(stream);
-            Ok(IpcConnection {
-                reader,
-                writer,
-                read_buf: BytesMut::with_capacity(4096),
-                recv_timeout: None,
-                next_frame_request_id: 1,
-            })
+            let self_uid = unix::self_uid();
+            loop {
+                let (stream, _addr) = self.inner.listener.accept().await?;
+                if let Err(rejection) = unix::verify_peer_is_self(&stream, self_uid) {
+                    // Drop the connection without replying: the peer is not
+                    // entitled to a protocol error that would confirm the
+                    // daemon's version or liveness.
+                    drop(stream);
+                    tracing::warn!(
+                        event = "ipc_peer_rejected",
+                        reason = rejection.reason(),
+                        "refused an IPC connection: {}",
+                        rejection.detail()
+                    );
+                    zccache_core::lifecycle::write_event(
+                        zccache_core::lifecycle::EVENT_IPC_PEER_REJECTED,
+                        serde_json::json!({
+                            "reason": rejection.reason(),
+                            "detail": rejection.detail(),
+                        }),
+                    );
+                    continue;
+                }
+                let (reader, writer) = tokio::io::split(stream);
+                return Ok(IpcConnection {
+                    reader,
+                    writer,
+                    read_buf: BytesMut::with_capacity(4096),
+                    recv_timeout: None,
+                    next_frame_request_id: 1,
+                });
+            }
         }
         #[cfg(windows)]
         {

--- a/crates/zccache-ipc/src/transport/tests.rs
+++ b/crates/zccache-ipc/src/transport/tests.rs
@@ -252,3 +252,49 @@ async fn test_parallel_connections() {
     }
     server.await.unwrap();
 }
+
+/// #1171: the accept path must recognise a same-user peer and refuse a foreign
+/// one. A second real uid is not available in a test, so the daemon-side uid is
+/// injected — a peer that is genuinely us fails the check when the daemon
+/// believes it is someone else, which is the same comparison the real path
+/// makes with the arguments swapped.
+#[cfg(unix)]
+#[tokio::test]
+async fn peer_verification_accepts_self_and_rejects_foreign_uid() {
+    let (stream, _peer) = tokio::net::UnixStream::pair().unwrap();
+    let me = unix::self_uid();
+
+    unix::verify_peer_is_self(&stream, me).expect("our own connection must be trusted");
+
+    let rejection = unix::verify_peer_is_self(&stream, me.wrapping_add(1))
+        .expect_err("a peer whose uid differs from the daemon's must be refused");
+    assert_eq!(rejection.reason(), "foreign-uid");
+    assert!(
+        rejection.detail().contains("is not the daemon uid"),
+        "rejection detail should name both uids, got: {}",
+        rejection.detail()
+    );
+}
+
+/// A same-user client still completes a full round trip through the real
+/// `accept()` loop — the check must not cost the happy path a connection.
+#[cfg(unix)]
+#[tokio::test]
+async fn same_user_client_is_served_through_the_peer_check() {
+    let endpoint = unique_test_endpoint();
+    let mut listener = IpcListener::bind(&endpoint).unwrap();
+
+    let server = tokio::spawn(async move {
+        let mut conn = listener.accept().await.unwrap();
+        let msg: Option<Request> = conn.recv().await.unwrap();
+        assert_eq!(msg, Some(Request::Ping));
+        conn.send(&Response::Pong).await.unwrap();
+    });
+
+    let mut client = connect(&endpoint).await.unwrap();
+    client.send(&Request::Ping).await.unwrap();
+    let resp: Option<Response> = client.recv().await.unwrap();
+    assert_eq!(resp, Some(Response::Pong));
+
+    server.await.unwrap();
+}

--- a/crates/zccache-ipc/src/transport/unix.rs
+++ b/crates/zccache-ipc/src/transport/unix.rs
@@ -10,6 +10,70 @@ use super::IpcConnection;
 
 const UNIX_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Why an accepted connection was refused before it could send a request.
+///
+/// The connectable `Request` surface is process execution as the daemon user
+/// (#1171), so "who is on the other end" is a security decision, not
+/// diagnostics. Both variants are rejections: if the kernel cannot tell us the
+/// peer's identity we cannot claim the peer is us, and failing open there would
+/// hand the whole control back to whatever made the lookup fail.
+#[derive(Debug)]
+pub(super) enum PeerRejection {
+    /// The peer authenticated as a different local user.
+    ForeignUid { peer_uid: u32, self_uid: u32 },
+    /// The kernel would not report the peer's credentials.
+    Unknown(std::io::Error),
+}
+
+impl PeerRejection {
+    /// Stable `reason` field for the lifecycle event.
+    pub(super) fn reason(&self) -> &'static str {
+        match self {
+            PeerRejection::ForeignUid { .. } => "foreign-uid",
+            PeerRejection::Unknown(_) => "peer-cred-unavailable",
+        }
+    }
+
+    /// Human-readable detail for the log line and the event payload.
+    pub(super) fn detail(&self) -> String {
+        match self {
+            PeerRejection::ForeignUid { peer_uid, self_uid } => {
+                format!("peer uid {peer_uid} is not the daemon uid {self_uid}")
+            }
+            PeerRejection::Unknown(err) => format!("peer credentials unavailable: {err}"),
+        }
+    }
+}
+
+/// Effective uid of this process — the identity every peer must match.
+pub(super) fn self_uid() -> u32 {
+    // SAFETY: `geteuid` takes no arguments, cannot fail, and touches no memory.
+    unsafe { libc::geteuid() }
+}
+
+/// Verify that an accepted connection comes from the daemon's own user.
+///
+/// `self_uid` is injected rather than read inside so the rejection path is
+/// testable without a second real user on the host: a test binds, connects to
+/// itself, and passes a uid the peer cannot possibly have.
+///
+/// This is defense-in-depth behind the `0700` socket directory. The directory
+/// mode is the load-bearing control on macOS/BSD, where the kernel ignores mode
+/// bits on `connect()`; this check is what makes "same-user only" an assertion
+/// the daemon itself enforces rather than a property of where the socket lives.
+pub(super) fn verify_peer_is_self(
+    stream: &tokio::net::UnixStream,
+    self_uid: u32,
+) -> Result<(), PeerRejection> {
+    let cred = stream.peer_cred().map_err(PeerRejection::Unknown)?;
+    let peer_uid = cred.uid();
+    if peer_uid == self_uid {
+        Ok(())
+    } else {
+        Err(PeerRejection::ForeignUid { peer_uid, self_uid })
+    }
+}
+
 /// Connect to an IPC endpoint as a client.
 ///
 /// On Unix, returns an `IpcConnection`. On Windows, returns an

--- a/docs/architecture/ipc.md
+++ b/docs/architecture/ipc.md
@@ -39,6 +39,25 @@ from that cache root. Unix uses `<cache>/daemon.sock` or
 pipe and appends `-<ns>` when a daemon namespace is configured. Explicit
 `ZCCACHE_ENDPOINT` still overrides the derived endpoint.
 
+## Endpoint Access Control (#1171)
+
+The connectable `Request` surface is process execution as the daemon user, so
+same-user is the trust boundary and the OS enforces it rather than the endpoint's
+location:
+
+- The socket's parent directory is created `0700`, and the socket itself is
+  `chmod` 0600 after `bind`. The directory is the load-bearing control on
+  macOS/BSD, where the kernel ignores a socket's mode bits on `connect()`.
+- A directory found group/other-writable is tightened, or the daemon refuses to
+  bind; either outcome emits `insecure_socket_dir`.
+- Every accepted connection is checked against the daemon's own euid via
+  `SO_PEERCRED` / `getpeereid`. A foreign uid — or a peer whose credentials the
+  kernel will not report — is dropped without a reply and emits
+  `ipc_peer_rejected` with `reason=foreign-uid` / `peer-cred-unavailable`.
+- Windows pipe instances are created with an explicit owner-only DACL
+  (`D:P(A;;GA;;;OW)(A;;GA;;;SY)`), replacing the default descriptor that granted
+  Everyone and ANONYMOUS LOGON read access.
+
 ## Connection Lifecycle
 
 **CLI side (drop-in wrapper mode):**


### PR DESCRIPTION
Closes the last open finding of #1171 (Finding 1's peer-credential half; items 1's mode bits, 3 and 4 landed in #1277/#1278, and the Windows leg in #1272/#1279).

## What

Every accepted unix connection now has its peer euid verified against the daemon's own, via `SO_PEERCRED` (Linux) / `getpeereid` (macOS/BSD) through `UnixStream::peer_cred`.

- A foreign uid is **dropped without a reply** — the peer is not entitled to a protocol error that would confirm the daemon's version or liveness.
- A peer whose credentials the kernel will not report is refused the same way. If we cannot establish the peer's identity we cannot claim it is us; failing open would hand the control back to whatever made the lookup fail.
- Both refusals emit `tracing::warn!` **and** the new `ipc_peer_rejected` lifecycle event (`reason=foreign-uid` / `peer-cred-unavailable`), per the loud-diagnostics rule. A rejection never wedges the listener — `accept()` loops to the next connection.

This is defense-in-depth behind the `0700` socket directory, which stays the load-bearing control on macOS/BSD where the kernel ignores a socket's mode bits on `connect()`. The check is what makes "same-user only" something the daemon asserts rather than a property of where the socket happens to live.

## Testability seam

`verify_peer_is_self(stream, self_uid)` takes the daemon-side uid as a parameter rather than reading `geteuid()` inside. A second real uid is not available in a test, so the test passes a uid the peer cannot have — the same comparison the real path makes, with the arguments swapped.

## Evidence

- `soldr cargo test -p zccache-ipc --lib` (Windows host): **53 passed, 0 failed**.
- `soldr cargo check -p zccache-ipc --all-targets --target x86_64-unknown-linux-gnu`: clean — the unix arm compiles.
- `soldr cargo clippy -p zccache-ipc --all-targets --target x86_64-unknown-linux-gnu -- -D warnings`: clean.
- `soldr cargo clippy -p zccache-ipc -p zccache-core --all-targets -- -D warnings` (Windows): clean.
- The two new tests are `#[cfg(unix)]`, so **CI's Linux and macOS legs are the authoritative run** for them. Docker was unavailable on this host at authoring time; flagging that plainly rather than implying a local unix run happened.

## Notes

- Adds a `cfg(unix)`-gated `libc` dependency to `zccache-ipc` for `geteuid`; the crate had none.
- `docs/architecture/ipc.md` gains an "Endpoint Access Control" section covering the full #1171 set (dir mode, socket mode, repair-or-refuse, peer check, Windows DACL) so the policy is documented in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)