### PR TITLE
fix(daemon): record session reaping durably and sweep depfile dirs periodically (#1165)

### DIFF
--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -46,6 +46,8 @@
 //! | `state_corrupt` (#1157) | daemon | persisted state did not parse and was dropped rather than reconciled; consequence is a full cold recompile | `subsystem`, `consequence`, `message`, `path`, `bytes` |
 //! | `insecure_socket_dir` (#1171) | daemon | the directory holding the IPC endpoint was group/other-writable; another local user could substitute the socket | `path`, `outcome`, `detail` |
 //! | `ipc_peer_rejected` (#1171) | daemon | an accepted IPC connection was refused because the peer is not this user, or its credentials were unavailable | `reason`, `detail` |
+//! | `sessions_reaped` (#1165) | daemon | periodic maintenance reclaimed session state whose owning client is gone or whose tombstone aged out | `expired`, `dead_client`, `tombstones`, `remaining`, `tombstones_remaining` |
+//! | `stale_depfile_dirs_swept` (#1165) | daemon | periodic maintenance reclaimed depfile directories from dead daemon instances | `cleaned` |
 //! | `staged_publication_conflict` | daemon | one cache key produced two different valid generations; first generation retained | `cache_key`, `existing_generation`, `candidate_generation`, `elapsed_ns` |
 //! | `staged_publication_replaces_invalid_generation` | daemon | a corrupt/incomplete selected generation was replaced by a validated compile result | `cache_key`, `invalid_generation`, `replacement_generation` |
 //! | `staged_salvage_started` | daemon | publication/index failed after a successful compile; requested outputs are being recovered | `reason`, `output_count`, `copied_bytes`, `elapsed_ns` |
@@ -139,6 +141,16 @@ pub const EVENT_INSECURE_SOCKET_DIR: &str = "insecure_socket_dir";
 /// reached the endpoint — the `0700` directory that is supposed to make that
 /// impossible has been bypassed or was never applied.
 pub const EVENT_IPC_PEER_REJECTED: &str = "ipc_peer_rejected";
+/// Periodic maintenance reclaimed session state (#1165).
+///
+/// Session registries grow with every client that dies without an explicit
+/// `SessionEnd`, so "how much is being reclaimed, how often" is the signal that
+/// separates a healthy daemon from one leaking a session per compile. Emitted
+/// only when something was actually reclaimed.
+pub const EVENT_SESSIONS_REAPED: &str = "sessions_reaped";
+/// Periodic maintenance reclaimed depfile directories belonging to dead daemon
+/// instances (#1165). Emitted only when something was actually reclaimed.
+pub const EVENT_STALE_DEPFILE_DIRS_SWEPT: &str = "stale_depfile_dirs_swept";
 
 /// Issue #755 events — daemon death + handover + client disconnect.
 /// Additive: existing tooling that filters on `event` continues to
@@ -220,6 +232,8 @@ pub const EVENT_ALL: &[&str] = &[
     EVENT_STATE_CORRUPT,
     EVENT_INSECURE_SOCKET_DIR,
     EVENT_IPC_PEER_REJECTED,
+    EVENT_SESSIONS_REAPED,
+    EVENT_STALE_DEPFILE_DIRS_SWEPT,
     EVENT_DAEMON_DIED,
     EVENT_PIPE_HANDOVER,
     EVENT_CLIENT_DISCONNECTED,

--- a/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
@@ -977,6 +977,55 @@ fn reap_finished_sessions_with(state: &SharedState, is_alive: impl Fn(u32) -> bo
             tombstones_remaining = state.ended_sessions.len(),
             "reaped finished sessions"
         );
+        // #1165 Finding 1: a `tracing::info!` is lost as soon as the daemon's
+        // stderr goes anywhere unbounded. The durable event is what makes
+        // "this daemon reclaims a session per compile" attributable after the
+        // fact, which is the growth mode the finding is about.
+        zccache_core::lifecycle::write_event(
+            zccache_core::lifecycle::EVENT_SESSIONS_REAPED,
+            serde_json::json!({
+                "expired": expired.len(),
+                "dead_client": dead.len(),
+                "tombstones": tombstones,
+                "remaining": state.sessions.active_count(),
+                "tombstones_remaining": state.ended_sessions.len(),
+            }),
+        );
+    }
+}
+
+/// Reclaim depfile directories left by daemon instances that are gone.
+///
+/// #1165 Finding 6: the startup sweep in `run.rs` bounds growth *across*
+/// daemon lifetimes but not *within* one, and it is on the standalone path
+/// only — an embedded host that never restarts the process never swept at all.
+/// Running it here fixes both, because `spawn_disk_maintenance` is the one
+/// maintenance loop both modes share.
+///
+/// Full passes only: the directories are age-floored at a week, so sweeping
+/// every pressure tick would be scanning for debris that cannot have appeared
+/// since the last scan.
+///
+/// The scan stats every candidate directory and may `remove_dir_all`, so it
+/// runs on the blocking pool rather than an executor worker.
+async fn sweep_stale_depfile_dirs() {
+    let cleaned = tokio::task::spawn_blocking(|| {
+        crate::core::config::cleanup_stale_depfile_dirs(crate::ipc::is_process_alive)
+    })
+    .await;
+    let cleaned = match cleaned {
+        Ok(cleaned) => cleaned,
+        Err(error) => {
+            tracing::warn!(%error, "stale depfile sweep worker failed");
+            return;
+        }
+    };
+    if cleaned > 0 {
+        tracing::info!(cleaned, "swept stale depfile directories");
+        zccache_core::lifecycle::write_event(
+            zccache_core::lifecycle::EVENT_STALE_DEPFILE_DIRS_SWEPT,
+            serde_json::json!({ "cleaned": cleaned }),
+        );
     }
 }
 
@@ -1039,6 +1088,9 @@ pub(super) fn spawn_disk_maintenance(
             } else {
                 MaintenanceKind::Pressure
             };
+            if kind == MaintenanceKind::Full {
+                sweep_stale_depfile_dirs().await;
+            }
             if kind == MaintenanceKind::Pressure {
                 match pressure_scan_needed(&state, policy) {
                     Ok(false) => {

--- a/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
@@ -956,3 +956,126 @@ async fn tombstone_reaping_is_a_noop_when_nothing_is_stale() {
     }
     assert!(daemon.state.ended_sessions.contains_key(&fresh));
 }
+
+/// Count `sessions_reaped` rows currently in the lifecycle log.
+///
+/// The log path resolves from the process-global cache root, so a test cannot
+/// assume it owns the file — a concurrently running test may have written to
+/// it, and the resolved path can outlive any one test's env guard. Asserting
+/// on the *delta* across a single call is therefore the only stable shape;
+/// asserting a total, or an absence, is a flake waiting to happen.
+fn sessions_reaped_rows() -> usize {
+    let Ok(log) = std::fs::read_to_string(crate::core::lifecycle::log_file_path()) else {
+        return 0;
+    };
+    log.lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter(|event| event["event"] == crate::core::lifecycle::EVENT_SESSIONS_REAPED)
+        .count()
+}
+
+/// #1165 Finding 1: reaping was visible only as a `tracing::info!`, which is
+/// gone the moment the daemon's stderr goes somewhere unbounded. The durable
+/// event is what makes "this daemon reclaims a session per compile"
+/// attributable after the fact.
+///
+/// Both directions are asserted in one test, in order: a quiet pass must stay
+/// silent (this runs every maintenance tick for the daemon's life, so an
+/// unconditional emit would itself become the unbounded surface the issue is
+/// about), and a pass that reclaims something must leave a record.
+#[tokio::test]
+async fn reaping_writes_a_durable_event_only_when_it_reclaims_something() {
+    let root = tempfile::tempdir().unwrap();
+    let _cache_env = crate::daemon::server::tests::CacheDirEnvGuard::set(root.path());
+    let cache_dir: crate::core::NormalizedPath = root.path().join("cache").into();
+    let daemon = Arc::new(
+        EmbeddedDaemon::start(
+            crate::ipc::unique_test_endpoint(),
+            cache_dir.clone(),
+            None,
+            bytes_policy(1),
+        )
+        .await
+        .unwrap(),
+    );
+
+    let quiet_before = sessions_reaped_rows();
+    reap_finished_sessions_with(&daemon.state, only_dead_client_is_gone);
+    assert_eq!(
+        sessions_reaped_rows(),
+        quiet_before,
+        "a pass that reclaims nothing must not write an event"
+    );
+
+    daemon
+        .state
+        .sessions
+        .create(crate::depgraph::SessionConfig {
+            client_pid: DEAD_CLIENT_PID,
+            working_dir: root.path().into(),
+            log_file: None,
+            track_stats: true,
+            journal_path: None,
+            profile: false,
+            private_env: Vec::new(),
+            owner_pids: Vec::new(),
+        });
+
+    reap_finished_sessions_with(&daemon.state, only_dead_client_is_gone);
+
+    assert_eq!(
+        sessions_reaped_rows(),
+        quiet_before + 1,
+        "reclaiming a dead client's session must leave exactly one record"
+    );
+    let log = std::fs::read_to_string(crate::core::lifecycle::log_file_path()).unwrap();
+    let event: serde_json::Value = log
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .rfind(|event: &serde_json::Value| {
+            event["event"] == crate::core::lifecycle::EVENT_SESSIONS_REAPED
+        })
+        .expect("a sessions_reaped event");
+    assert_eq!(event["dead_client"], 1);
+    assert_eq!(
+        event["remaining"], 0,
+        "the event must carry what is left, not just what went"
+    );
+}
+
+/// #1165 Finding 6: the depfile sweep ran at startup only. That bounds growth
+/// *across* daemon lifetimes but not *within* one, and the startup call site
+/// is on the standalone path — an embedded host that never restarts its
+/// process never swept at all. Both modes share this maintenance loop, so
+/// running it here is what closes the gap.
+#[tokio::test]
+async fn the_periodic_sweep_reclaims_a_dead_instances_depfile_dir() {
+    let root = tempfile::tempdir().unwrap();
+    let _cache_env = crate::daemon::server::tests::CacheDirEnvGuard::set(root.path());
+
+    let depfiles = crate::core::config::depfile_dir();
+    let dead = depfiles.join(format!("{DEAD_CLIENT_PID}-0"));
+    std::fs::create_dir_all(&dead).unwrap();
+    std::fs::write(dead.join("some.d"), b"a.o: a.c").unwrap();
+    let live = depfiles.join(format!("{}-0", std::process::id()));
+    std::fs::create_dir_all(&live).unwrap();
+
+    sweep_stale_depfile_dirs().await;
+
+    assert!(
+        !dead.exists(),
+        "a depfile dir owned by a dead daemon instance must be reclaimed"
+    );
+    assert!(
+        live.exists(),
+        "reclaiming must not touch a running instance's depfile dir — that breaks its build"
+    );
+    let log = std::fs::read_to_string(crate::core::lifecycle::log_file_path())
+        .expect("the sweep must leave a durable record");
+    assert!(
+        log.lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .any(|event| event["event"] == crate::core::lifecycle::EVENT_STALE_DEPFILE_DIRS_SWEPT),
+        "the sweep should record what it reclaimed"
+    );
+}

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -20,6 +20,12 @@ Tokio runtime:     multi-threaded (default thread count)
     - on miss: spawns compiler, stores result
     - sends response
   Background disk maintenance task (startup + 5-minute pressure checks)
+    - every pass: reaps sessions whose client died and `ended_sessions`
+      tombstones past their TTL (`sessions_reaped` when it reclaims anything)
+    - full passes only: sweeps `tmp/depfiles/<pid>-<instance>/` belonging to
+      dead daemon instances (`stale_depfile_dirs_swept`). Standalone mode also
+      sweeps once at startup; the periodic pass is what bounds growth *within*
+      one daemon lifetime and is the only sweep an embedded host ever gets.
   Watcher event processing task
 
 Dedicated OS thread:  file watcher (notify)


### PR DESCRIPTION
Two items of #1165 that earlier PRs skipped without comment. Neither appears in any issue comment — they surfaced from a per-finding re-audit of the issue against current `main`.

## Finding 1 — the reap was invisible

The reaping itself landed, but its only trace was a `tracing::info!`. That is gone the moment the daemon's stderr goes somewhere unbounded — which is the exact condition this issue is about — so *"this daemon reclaims a session per compile"* was unattributable after the fact.

`sessions_reaped` now records `expired`, `dead_client`, `tombstones`, `remaining`, `tombstones_remaining`: what went **and** what is left, because the leak shape is the residue, not the delta.

Emitted only when something was actually reclaimed. This runs every maintenance tick for the daemon's whole life, so an unconditional emit would itself become the unbounded observability surface the issue is about — the test asserts both directions.

## Finding 6 — the sweep was startup-only

The liveness/age half landed in #1275, but `cleanup_stale_depfile_dirs` stayed on the startup path. Two consequences:

- it bounds depfile-dir growth *across* daemon lifetimes but not *within* one;
- the startup call site is `server/run.rs` — the **standalone** path. An embedded host that never restarts its process never swept at all.

Moving it onto the maintenance loop fixes both at once, because `spawn_disk_maintenance` is the one loop standalone and embedded share.

**Full passes only.** The dirs are age-floored at a week, so sweeping every 5-minute pressure tick would be scanning for debris that cannot have appeared since the last scan. It runs on the blocking pool — it stats every candidate and may `remove_dir_all`.

## Tests

- `reaping_writes_a_durable_event_only_when_it_reclaims_something` — quiet pass writes nothing; a dead-client pass writes exactly one row with `dead_client=1`, `remaining=0`. Asserts on the **delta** in row count, not a total or an absence: the lifecycle log path resolves from the process-global cache root, so no test can assume it owns the file. (The first version of this as two separate tests passed alone and failed under the suite for exactly that reason.)
- `the_periodic_sweep_reclaims_a_dead_instances_depfile_dir` — a dead instance's dir goes, a live instance's dir stays (reclaiming that one breaks a running build), and the event is recorded.

## Evidence

- `soldr cargo test -p zccache-daemon-core --features "test-support,daemon-entry" --lib disk_maintenance` — **28 passed, 0 failed**.
- `soldr cargo test -p zccache-core --lib lifecycle` — 13 passed (the catalog self-check covers both new constants + their schema rows).
- `soldr cargo clippy -p zccache-daemon-core -p zccache-core --all-targets --features "test-support,daemon-entry" -- -D warnings` — clean.
- `soldr cargo check -p zccache-daemon-core --all-targets --target x86_64-unknown-linux-gnu` — clean.

## Still open on #1165

- **Item 5** (`ZCCACHE_LOG_FILE` + the stderr contract) — never discussed on the issue either; it needs a bounded file sink and belongs in its own PR.
- **Item 2** (per-session `*.jsonl` retention) — should not be implemented as written; posting the reasoning on the issue separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)