### PR TITLE
fix(cli): route every daemon kill through the identity-bound path (#1161)

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/daemon.rs
+++ b/crates/zccache-cli-core/src/cli/commands/daemon.rs
@@ -3,7 +3,6 @@
 use crate::core::NormalizedPath;
 use std::process::ExitCode;
 
-use super::super::status_probe_timeout;
 use super::util::{connect, resolve_endpoint, run_async, LOST_CONNECTION_MSG};
 
 const DAEMON_PROFILE_ENV: &str = "ZCCACHE_DAEMON_PROFILE";
@@ -12,313 +11,6 @@ const TOKIO_CONSOLE_BIND_ENV: &str = "TOKIO_CONSOLE_BIND";
 const TOKIO_CONSOLE_OPEN_ENV: &str = "ZCCACHE_TOKIO_CONSOLE_OPEN";
 const TOKIO_CONSOLE_DEFAULT_BIND: &str = "127.0.0.1:6669";
 const PROFILE_START_REASON: &str = "tokio-console-profile-start";
-
-pub(crate) enum VersionCheck {
-    Ok,
-    /// Daemon is newer than client — safe to proceed.
-    DaemonNewer {
-        daemon_ver: String,
-    },
-    /// Daemon is older than client — must restart.
-    DaemonOlder {
-        daemon_ver: String,
-    },
-    /// Could not connect to the daemon at all.
-    Unreachable,
-    /// Connected but could not complete the version exchange (protocol mismatch, etc.).
-    CommError,
-    /// Client-side daemon wire configuration is invalid.
-    ClientConfigError(String),
-}
-
-/// Connect to the daemon and compare its version to ours.
-///
-/// The Status recv is bounded by [`status_probe_timeout`] so that a wedged
-/// daemon (alive socket, no response) surfaces as `CommError` in seconds
-/// rather than the 5-minute global default. The caller's recovery path
-/// (`ensure_daemon` → `stop_stale_daemon` → `spawn_and_wait`) then runs
-/// promptly. See issue #554.
-pub(crate) async fn check_daemon_version(endpoint: &str) -> VersionCheck {
-    match crate::ipc::daemon_control_roundtrip(
-        endpoint,
-        crate::ipc::DaemonControlRequest::Status,
-        Some(status_probe_timeout()),
-    )
-    .await
-    {
-        Ok(Some(crate::protocol::Response::Status(s))) => {
-            if s.version == crate::core::VERSION {
-                return VersionCheck::Ok;
-            }
-            let client_ver = crate::core::version::current();
-            match crate::core::version::Version::parse(&s.version) {
-                Some(daemon_ver) => match daemon_ver.cmp(&client_ver) {
-                    std::cmp::Ordering::Equal => VersionCheck::Ok,
-                    std::cmp::Ordering::Greater => VersionCheck::DaemonNewer {
-                        daemon_ver: s.version,
-                    },
-                    std::cmp::Ordering::Less => VersionCheck::DaemonOlder {
-                        daemon_ver: s.version,
-                    },
-                },
-                // Unparseable daemon version → treat as older (safe default)
-                None => VersionCheck::DaemonOlder {
-                    daemon_ver: s.version,
-                },
-            }
-        }
-        Err(crate::ipc::IpcError::Endpoint(message))
-            if message.contains(crate::protocol::wire_prost::WIRE_FORMAT_ENV) =>
-        {
-            VersionCheck::ClientConfigError(message)
-        }
-        Err(err) if crate::cli::client::is_daemon_unreachable_err(&err) => {
-            VersionCheck::Unreachable
-        }
-        _ => VersionCheck::CommError,
-    }
-}
-
-/// Spawn a new daemon and wait for it to become ready.
-///
-/// `outbound_pid` is `Some(pid)` when this spawn is the second half of
-/// a takeover orchestrated by `stop_stale_daemon` — the helper emits
-/// the linked `daemon-died{reason: takeover}` + `pipe-handover` pair
-/// once the new daemon's PID has been observed. `None` for a clean
-/// initial-start (no predecessor to record).  Issue #755 acceptance #2.
-pub(crate) async fn spawn_and_wait(
-    endpoint: &str,
-    reason: &str,
-    outbound_pid: Option<u32>,
-) -> Result<(), String> {
-    // Issue #982: embedding hosts forbid standalone daemon spawns.
-    // Checked before binary resolution so the refusal message is the
-    // guard's, not a misleading "cannot find zccache-daemon binary".
-    if crate::core::config::daemon_spawn_disabled() {
-        return Err(crate::core::config::no_spawn_error("zccache-daemon"));
-    }
-    tracing::debug!(%endpoint, reason, "spawning daemon");
-    // Issue #952: single-flight the spawn — same arbiter as the
-    // runtime.rs spawn path. Exactly one client in a cold-start herd
-    // spawns; the rest park on the ready-wait.
-    let spawn_slot = crate::cli::runtime::acquire_spawn_slot();
-    let meta = crate::core::lifecycle::client_meta(crate::core::VERSION);
-    if spawn_slot.is_some() {
-        // Record *why* the CLI is about to spawn a daemon so an operator
-        // can correlate each CLI decision with the resulting daemon PID
-        // by parsing the single `daemon-lifecycle.log`. See zccache#323
-        // for the diagnostic gap that motivated this.
-        crate::core::lifecycle::write_event(
-            crate::core::lifecycle::EVENT_SPAWN_ATTEMPT,
-            serde_json::json!({
-                "reason": reason,
-                "endpoint": endpoint,
-                "daemon_namespace": crate::core::config::daemon_namespace_label(),
-                "client_pid": std::process::id(),
-                // #755 acceptance #4: see runtime.rs for rationale.
-                "client_version": meta["client_version"],
-                "client_binary_path": meta["client_binary_path"],
-            }),
-        );
-        super::super::spawn_daemon(endpoint)?;
-    } else {
-        crate::core::lifecycle::write_event(
-            crate::core::lifecycle::EVENT_SPAWN_PARKED,
-            serde_json::json!({
-                "reason": reason,
-                "endpoint": endpoint,
-                "daemon_namespace": crate::core::config::daemon_namespace_label(),
-                "client_pid": std::process::id(),
-                "client_version": meta["client_version"],
-            }),
-        );
-    }
-
-    // Adaptive wait keyed on the daemon-lifecycle lockfile PID (issue #673):
-    // the previous 100-iteration / 10 s loop expired under thundering-herd
-    // builds while individual ERROR_PIPE_BUSY backoffs were still in flight.
-    // The shared helper polls past 10 s as long as a daemon owns the lockfile.
-    // The slot guard lives until READY so a late client can't win a
-    // second slot before the daemon binds (#952).
-    let wait_result = super::super::wait_for_daemon_ready(endpoint).await;
-    drop(spawn_slot);
-    wait_result?;
-
-    // #755 acceptance #2: emit linked daemon-died + pipe-handover events
-    // for the takeover case. Best-effort: if we can't read the new
-    // daemon's PID right after `wait_for_daemon_ready` (unlikely but
-    // possible under thundering-herd lockfile contention) we skip the
-    // linkage; the regular `spawn` line still records the new daemon.
-    if let Some(killed_pid) = outbound_pid {
-        if let Some(new_pid) = crate::ipc::check_running_daemon() {
-            crate::core::lifecycle::emit_takeover_lifecycle_events(
-                killed_pid,
-                new_pid,
-                crate::core::VERSION,
-                endpoint,
-            );
-        }
-    }
-    Ok(())
-}
-
-/// Stop a stale daemon that is unreachable or version-incompatible.
-///
-/// Attempts graceful shutdown via IPC first, then falls back to force-killing
-/// the process via the lock file PID. Waits for the endpoint to be released.
-///
-/// Returns `Some(pid)` with the killed daemon's PID when a force-kill
-/// actually fired — the caller threads this through `spawn_and_wait`
-/// so the linked daemon-died + pipe-handover events get an
-/// `outbound_pid`. `None` means no live daemon was found to kill
-/// (graceful shutdown succeeded, or no daemon was running). #755.
-pub(crate) async fn stop_stale_daemon(endpoint: &str) -> Option<u32> {
-    // Try graceful shutdown via IPC.
-    let _ = crate::ipc::daemon_control_roundtrip(
-        endpoint,
-        crate::ipc::DaemonControlRequest::Shutdown,
-        Some(status_probe_timeout()),
-    )
-    .await;
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-
-    // Force-kill via lock file PID if the daemon is still alive
-    let killed_pid = if let Some(pid) = crate::ipc::check_running_daemon() {
-        tracing::debug!(pid, "force-killing stale daemon process");
-        let kill_ok = crate::ipc::force_kill_process(pid).is_ok();
-        if kill_ok {
-            for _ in 0..50 {
-                if !crate::ipc::is_process_alive(pid) {
-                    break;
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            }
-        }
-        crate::ipc::remove_lock_file();
-        kill_ok.then_some(pid)
-    } else {
-        None
-    };
-
-    // Wait briefly for the endpoint (named pipe / socket) to be fully released
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-    killed_pid
-}
-
-/// Ensure the daemon is running **and version-compatible**.
-///
-/// Version checking is asymmetric: a newer daemon is accepted (it's
-/// backward-compatible), but an older daemon triggers a hard error
-/// telling the user to run `zccache stop` first.
-///
-/// Handles concurrent calls gracefully: when multiple processes race to start
-/// the daemon, only one wins the bind. The losers detect this and connect to
-/// the winning daemon instead of failing.
-pub(crate) async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
-    // Issue #982: under the host no-spawn guard a reachable,
-    // version-compatible daemon may still be used, but every other
-    // outcome — including the stale-daemon replace paths, which would
-    // stop the old daemon before respawning — fails here, BEFORE
-    // anything is stopped or killed.
-    if crate::core::config::daemon_spawn_disabled() {
-        return match check_daemon_version(endpoint).await {
-            VersionCheck::Ok | VersionCheck::DaemonNewer { .. } => Ok(()),
-            _ => Err(crate::core::config::no_spawn_error("zccache-daemon")),
-        };
-    }
-    // Fast path: connect + version check
-    match check_daemon_version(endpoint).await {
-        VersionCheck::Ok => return Ok(()),
-        VersionCheck::DaemonNewer { daemon_ver } => {
-            tracing::debug!(
-                daemon_ver,
-                client_ver = crate::core::VERSION,
-                "daemon is newer than client, proceeding"
-            );
-            return Ok(());
-        }
-        VersionCheck::DaemonOlder { daemon_ver } => {
-            tracing::info!(
-                daemon_ver,
-                client_ver = crate::core::VERSION,
-                "daemon is older than client, auto-recovering"
-            );
-            let killed_pid = stop_stale_daemon(endpoint).await;
-            return spawn_and_wait(
-                endpoint,
-                crate::core::lifecycle::REASON_REPLACED_STALE_VERSION,
-                killed_pid,
-            )
-            .await;
-        }
-        VersionCheck::CommError => {
-            tracing::info!("cannot communicate with daemon, auto-recovering");
-            let killed_pid = stop_stale_daemon(endpoint).await;
-            return spawn_and_wait(
-                endpoint,
-                crate::core::lifecycle::REASON_REPLACED_COMM_ERROR,
-                killed_pid,
-            )
-            .await;
-        }
-        VersionCheck::ClientConfigError(message) => return Err(message),
-        VersionCheck::Unreachable => {
-            // Fall through to lock-file check / spawn
-        }
-    }
-
-    // Check lock file for a running daemon we just can't reach yet
-    if let Some(pid) = crate::ipc::check_running_daemon() {
-        for _ in 0..20 {
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            match check_daemon_version(endpoint).await {
-                VersionCheck::Ok => return Ok(()),
-                VersionCheck::DaemonNewer { daemon_ver } => {
-                    tracing::debug!(
-                        daemon_ver,
-                        client_ver = crate::core::VERSION,
-                        "daemon is newer than client, proceeding"
-                    );
-                    return Ok(());
-                }
-                VersionCheck::DaemonOlder { daemon_ver } => {
-                    tracing::info!(
-                        daemon_ver,
-                        client_ver = crate::core::VERSION,
-                        "daemon is older than client during startup, auto-recovering"
-                    );
-                    let killed_pid = stop_stale_daemon(endpoint).await;
-                    return spawn_and_wait(
-                        endpoint,
-                        crate::core::lifecycle::REASON_REPLACED_STALE_VERSION,
-                        killed_pid,
-                    )
-                    .await;
-                }
-                VersionCheck::CommError => {
-                    tracing::info!(
-                        "cannot communicate with daemon during startup, auto-recovering"
-                    );
-                    let killed_pid = stop_stale_daemon(endpoint).await;
-                    return spawn_and_wait(
-                        endpoint,
-                        crate::core::lifecycle::REASON_REPLACED_COMM_ERROR,
-                        killed_pid,
-                    )
-                    .await;
-                }
-                VersionCheck::ClientConfigError(message) => return Err(message),
-                VersionCheck::Unreachable => continue,
-            }
-        }
-        return Err(format!(
-            "daemon process {pid} exists but not accepting connections"
-        ));
-    }
-
-    // No daemon running — spawn one
-    spawn_and_wait(endpoint, crate::core::lifecycle::REASON_INITIAL_START, None).await
-}
 
 /// Find the daemon binary. Looks next to the CLI binary first, then on PATH.
 pub(crate) fn find_daemon_binary() -> Option<NormalizedPath> {
@@ -364,7 +56,7 @@ pub(crate) fn which_on_path(name: &str) -> Option<NormalizedPath> {
 }
 
 pub(crate) async fn cmd_start(endpoint: &str) -> ExitCode {
-    match ensure_daemon(endpoint).await {
+    match crate::cli::runtime::ensure_daemon(endpoint).await {
         Ok(()) => {
             eprintln!("daemon running at {endpoint}");
             ExitCode::SUCCESS
@@ -382,8 +74,9 @@ pub(crate) async fn cmd_profile_start(endpoint: &str, bind: Option<&str>, open: 
     let env = profile_env_overrides(&bind, open);
     let _guard = ScopedEnv::apply(&env);
 
-    let killed_pid = stop_stale_daemon(endpoint).await;
-    if let Err(e) = spawn_and_wait(endpoint, PROFILE_START_REASON, killed_pid).await {
+    if let Err(e) =
+        crate::cli::runtime::replace_running_daemon(endpoint, PROFILE_START_REASON).await
+    {
         eprintln!("failed to start tokio-console daemon profile: {e}");
         return ExitCode::FAILURE;
     }
@@ -486,9 +179,23 @@ pub(crate) async fn cmd_stop(endpoint: &str) -> ExitCode {
     {
         Ok(response) => response,
         Err(e) if crate::cli::client::is_daemon_unreachable_err(&e) => {
-            let raw_lock_pid = crate::ipc::read_lock_file_pid();
-            let Some(pid) = crate::ipc::check_running_daemon().or(raw_lock_pid) else {
-                eprintln!("daemon not running at {endpoint}");
+            // #1161: this used to fall back to `.or(read_lock_file_pid())`.
+            // `check_running_daemon` returning `None` is precisely the
+            // stale-lock / recycled-PID signal — it removes the lock file in
+            // that case — so falling back to the raw number force-killed a PID
+            // that had already failed verification, which is the #132 defense
+            // being bypassed by the one path that always kills.
+            let Some(pid) = crate::ipc::check_running_daemon() else {
+                if let Some(stale) = crate::ipc::read_lock_file_pid() {
+                    eprintln!(
+                        "daemon not running at {endpoint}; lock file named process {stale}, \
+                         which is not a live zccache daemon — leaving it alone and clearing \
+                         the stale lock"
+                    );
+                    crate::ipc::remove_lock_file();
+                } else {
+                    eprintln!("daemon not running at {endpoint}");
+                }
                 // No daemon — but the index file might still be there from a
                 // crashed prior run. Probe once so callers (CI tar) can rely
                 // on the lock being gone after `zccache stop` returns.

--- a/crates/zccache-cli-core/src/cli/commands/exec.rs
+++ b/crates/zccache-cli-core/src/cli/commands/exec.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use crate::core::NormalizedPath;
 use crate::protocol::{ExecCachePolicy, ExecOutputStreams, Request, Response};
 
-use super::daemon::ensure_daemon;
 use super::util::{absolute_path, connect, exit_code_from_i32, resolve_endpoint};
+use crate::cli::runtime::ensure_daemon;
 
 /// Parsed view of `--input-file`, `--input-env`, etc. — pre-validates argv
 /// before sending the IPC request so misuse errors render before reaching the

--- a/crates/zccache-cli-core/src/cli/commands/fp.rs
+++ b/crates/zccache-cli-core/src/cli/commands/fp.rs
@@ -3,8 +3,8 @@
 use std::path::Path;
 use std::process::ExitCode;
 
-use super::daemon::ensure_daemon;
 use super::util::connect;
+use crate::cli::runtime::ensure_daemon;
 
 pub(crate) async fn cmd_fp_check(
     endpoint: &str,

--- a/crates/zccache-cli-core/src/cli/commands/session.rs
+++ b/crates/zccache-cli-core/src/cli/commands/session.rs
@@ -7,10 +7,10 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use super::super::session_end_idempotent;
-use super::daemon::ensure_daemon;
 use super::util::{
     connect, format_duration_ms, print_json_value, resolve_endpoint, LOST_CONNECTION_MSG,
 };
+use crate::cli::runtime::ensure_daemon;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SessionStartPrivateOptions {

--- a/crates/zccache-cli-core/src/cli/commands/tests/daemon.rs
+++ b/crates/zccache-cli-core/src/cli/commands/tests/daemon.rs
@@ -2,10 +2,11 @@
 //! protocol-mismatch auto-recovery path (issue #27), the bounded wait
 //! after a clean stop, and the bounded Status-probe (issue #554).
 
-use super::super::daemon::{
-    check_daemon_version, ensure_daemon, profile_env_overrides, tokio_console_bind,
-    wait_for_daemon_teardown, VersionCheck,
-};
+use super::super::daemon::{profile_env_overrides, tokio_console_bind, wait_for_daemon_teardown};
+// #1161: the recovery path these tests cover now has a single implementation
+// in `cli::runtime`. The duplicate in `commands::daemon` — which had none of
+// the identity gating, probe-before-replace, or drain budget — is gone.
+use crate::cli::runtime::{check_daemon_version, ensure_daemon, VersionCheck};
 
 // ── Protocol mismatch recovery (issue #27) ──────────────────
 

--- a/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use super::super::super::{link_retry_budget, wedge_recv_timeout};
-use super::super::daemon::{ensure_daemon, stop_stale_daemon};
 use super::super::util::{connect, exit_code_from_i32, slurp_stdin_if_piped, LOST_CONNECTION_MSG};
+use crate::cli::runtime::{current_daemon_instance, ensure_daemon, stop_wedged_daemon};
 
 pub(super) async fn cmd_compile(
     endpoint: &str,
@@ -18,6 +18,11 @@ pub(super) async fn cmd_compile(
     client_env: Vec<(String, String)>,
 ) -> ExitCode {
     let stdin_bytes = slurp_stdin_if_piped();
+    // #1161: name the instance we are about to talk to BEFORE the exchange.
+    // If this request wedges, the lock file may already name a replacement
+    // some other client spawned, and killing "whoever is current" is how one
+    // client's timeout becomes a kill chain through a `-j16` herd.
+    let served_by = current_daemon_instance();
     let mut conn = match connect(endpoint).await {
         Ok(c) => c,
         Err(e) => {
@@ -114,7 +119,7 @@ pub(super) async fn cmd_compile(
                          (missed wedge budget + failed probe); killing it and \
                          failing immediately — issue #955"
                     );
-                    stop_stale_daemon(endpoint).await;
+                    stop_wedged_daemon(endpoint, served_by.as_ref()).await;
                     ExitCode::FAILURE
                 }
             }
@@ -468,6 +473,10 @@ async fn cmd_compile_ephemeral_with_stdin(
         stdin: stdin_bytes.clone(),
     };
 
+    // #1161: identity of the instance this attempt targets, read before the
+    // exchange so a later wedge kill cannot land on a replacement.
+    let served_by = current_daemon_instance();
+
     // Issue #752: retry once on transport failure
     // (`lost connection to daemon`). Wedge has its own handling.
     // Recovery is a small jittered sleep — ensure_daemon's next call
@@ -490,7 +499,7 @@ async fn cmd_compile_ephemeral_with_stdin(
                 "zccache[err][W]: daemon at {endpoint} stopped responding within \
                  the wedge budget; killing it so the next compile starts fresh — issue #666"
             );
-            stop_stale_daemon(endpoint).await;
+            stop_wedged_daemon(endpoint, served_by.as_ref()).await;
             ExitCode::FAILURE
         }
         CompileRecvOutcome::Failed(msg) => match msg.phase {
@@ -528,6 +537,9 @@ pub(super) async fn cmd_link_ephemeral(
         env: Some(client_env),
     };
 
+    // #1161: see `cmd_compile_ephemeral` — identity before the exchange.
+    let served_by = current_daemon_instance();
+
     // Issue #752: retry once on transport failure
     // (`lost connection to daemon`). Wedge has its own handling.
     // See `cmd_compile_ephemeral` for the recovery-closure rationale.
@@ -548,7 +560,7 @@ pub(super) async fn cmd_link_ephemeral(
                  the wedge budget on a Link; killing it so the next request starts \
                  fresh — issue #666"
             );
-            stop_stale_daemon(endpoint).await;
+            stop_wedged_daemon(endpoint, served_by.as_ref()).await;
             ExitCode::FAILURE
         }
         CompileRecvOutcome::Failed(msg) => match msg.phase {

--- a/crates/zccache-cli-core/src/cli/runtime.rs
+++ b/crates/zccache-cli-core/src/cli/runtime.rs
@@ -19,8 +19,24 @@ pub fn run_async<T>(
         .block_on(future)
 }
 
+/// Identity of the daemon instance a client is about to talk to.
+///
+/// #1161: every kill must name the instance that actually failed, and the
+/// only way to do that is to read the identity **before** the exchange. By
+/// the time a request has failed, the lock file may already name a
+/// replacement some other client spawned — killing "whoever is current" is
+/// how one client's timeout becomes a kill chain through a `-j16` herd.
+///
+/// `None` means the identity could not be established, and every kill path
+/// treats that as a refusal rather than as a wildcard.
+#[must_use]
+pub fn current_daemon_instance(
+) -> Option<running_process::broker::protocol_v2::backend_handle::DaemonProcess> {
+    crate::ipc::read_backend_identity()
+}
+
 #[derive(Debug)]
-enum VersionCheck {
+pub(crate) enum VersionCheck {
     Ok,
     Unreachable,
     DaemonOlder { daemon_ver: String },
@@ -47,7 +63,7 @@ pub async fn connect_client(
     Ok(conn)
 }
 
-async fn check_daemon_version(endpoint: &str) -> VersionCheck {
+pub(crate) async fn check_daemon_version(endpoint: &str) -> VersionCheck {
     match crate::ipc::daemon_control_roundtrip(
         endpoint,
         crate::ipc::DaemonControlRequest::Status,
@@ -466,6 +482,55 @@ async fn stop_stale_daemon(
     endpoint: &str,
     failed_instance: Option<&running_process::broker::protocol_v2::backend_handle::DaemonProcess>,
 ) -> Option<u32> {
+    stop_daemon_instance(endpoint, failed_instance, GRACEFUL_DRAIN_BUDGET).await
+}
+
+/// How long a *wedged* daemon gets before the kill lands.
+///
+/// A daemon that already missed its per-request budget and then failed a
+/// follow-up responsiveness probe is not going to complete a 30 s durable
+/// drain — waiting the graceful budget would just delay the failure the
+/// fail-fast policy (#955) exists to surface immediately. The identity gate
+/// still applies: fail-fast is about *how long we wait*, never about *whom we
+/// kill*.
+const WEDGE_DRAIN_BUDGET: std::time::Duration = std::time::Duration::from_millis(200);
+
+/// Kill a daemon the wrapper found wedged — but only the instance it was
+/// talking to.
+///
+/// `wedged_instance` must be the identity captured **before** the request that
+/// wedged. `None` refuses the kill: under a build herd, "whoever the lock
+/// names now" is frequently a healthy replacement another client just spawned.
+pub async fn stop_wedged_daemon(
+    endpoint: &str,
+    wedged_instance: Option<&running_process::broker::protocol_v2::backend_handle::DaemonProcess>,
+) -> Option<u32> {
+    stop_daemon_instance(endpoint, wedged_instance, WEDGE_DRAIN_BUDGET).await
+}
+
+/// Deliberately replace the daemon currently serving `endpoint`.
+///
+/// Unlike the recovery paths, this is not triggered by a failure — the caller
+/// wants a daemon with different settings (today: the tokio-console profile).
+/// It is still identity-bound: the instance is read first and the stop refuses
+/// if the lock has since moved to someone else, so a profile restart cannot
+/// take out a replacement another client spawned in between.
+pub(crate) async fn replace_running_daemon(endpoint: &str, reason: &str) -> Result<(), String> {
+    let instance = current_daemon_instance();
+    let killed_pid = stop_stale_daemon(endpoint, instance.as_ref()).await;
+    spawn_and_wait(endpoint, reason, killed_pid).await
+}
+
+/// Shared body of [`stop_stale_daemon`] and [`stop_wedged_daemon`].
+///
+/// `drain_budget` is the only difference between them: the identity gate,
+/// the forensics, and the escalation are identical, because "which daemon may
+/// I kill" is not a question the caller's urgency gets to answer.
+async fn stop_daemon_instance(
+    endpoint: &str,
+    failed_instance: Option<&running_process::broker::protocol_v2::backend_handle::DaemonProcess>,
+    drain_budget: std::time::Duration,
+) -> Option<u32> {
     // Gate before the Shutdown request, not just before the kill: asking an
     // innocent daemon to retire is itself the damage this issue is about.
     match failed_instance {
@@ -509,7 +574,7 @@ async fn stop_stale_daemon(
     // `index.bin` and turning an orderly replacement into "recompile
     // everything". Wait for the drain the daemon is entitled to, and reserve
     // the fast kill for one that will not leave.
-    let drained_cleanly = wait_for_process_exit(pid, GRACEFUL_DRAIN_BUDGET).await;
+    let drained_cleanly = wait_for_process_exit(pid, drain_budget).await;
     if drained_cleanly {
         crate::ipc::remove_lock_file();
         // Return the pid even though nothing was killed: the caller uses it to
@@ -524,7 +589,7 @@ async fn stop_stale_daemon(
     // waited, so "why was my warm daemon killed" is answerable afterwards.
     tracing::warn!(
         pid,
-        waited_secs = GRACEFUL_DRAIN_BUDGET.as_secs(),
+        waited_ms = drain_budget.as_millis() as u64,
         stage = "post-shutdown-drain",
         "daemon did not exit within its drain budget; escalating to force kill"
     );
@@ -534,7 +599,7 @@ async fn stop_stale_daemon(
             "pid": pid,
             "reason": "drain_budget_exhausted",
             "stage": "post-shutdown-drain",
-            "waited_secs": GRACEFUL_DRAIN_BUDGET.as_secs(),
+            "waited_ms": drain_budget.as_millis() as u64,
             "endpoint": endpoint,
         }),
     );
@@ -1256,6 +1321,90 @@ mod tests {
         assert!(
             FORCE_KILL_REAP_BUDGET < GRACEFUL_DRAIN_BUDGET,
             "reaping a killed process is not the same wait as letting one drain"
+        );
+    }
+
+    /// An endpoint nothing is listening on. The refusal path must return
+    /// before touching it at all, so its only requirement is being unique.
+    fn never_bound_endpoint() -> String {
+        crate::ipc::unique_test_endpoint()
+    }
+
+    /// A `DaemonProcess` that cannot possibly be the one recorded on disk.
+    fn foreign_identity(
+        pid: u32,
+    ) -> running_process::broker::protocol_v2::backend_handle::DaemonProcess {
+        running_process::broker::protocol_v2::backend_handle::DaemonProcess {
+            pid,
+            exe_path: std::path::PathBuf::from("zccache-daemon"),
+            exe_sha256: [0u8; 32],
+            boot_id: "boot-that-never-was".to_string(),
+            ipc_endpoint: crate::ipc::running_process_endpoint("test-endpoint"),
+            started_at_unix_ms: 1,
+            idle_timeout_secs: None,
+        }
+    }
+
+    /// #1161 leg 1. The gate sits before the `Shutdown` request, not just
+    /// before the kill: asking an innocent daemon to retire is itself the
+    /// damage. A mismatch must therefore return without doing *anything* —
+    /// no roundtrip, no kill, no lock removal.
+    #[tokio::test]
+    async fn a_stop_is_refused_when_the_recorded_instance_is_not_the_one_that_failed() {
+        // No identity is written for this endpoint, so `daemon_identity_matches`
+        // is false for any argument — which is the mismatch case.
+        let victim = foreign_identity(std::process::id());
+        let start = std::time::Instant::now();
+
+        let killed = stop_daemon_instance(
+            &never_bound_endpoint(),
+            Some(&victim),
+            std::time::Duration::from_secs(30),
+        )
+        .await;
+
+        assert_eq!(killed, None, "a mismatched instance must not be stopped");
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(1),
+            "the refusal must short-circuit before any IPC or drain wait, took {:?}",
+            start.elapsed()
+        );
+    }
+
+    /// The `None` case is the one that used to be implicit: with no recorded
+    /// identity the old code re-read the lock file and killed whoever it
+    /// named. Refusing is the safe direction — it costs one clear error about
+    /// a daemon that is already not answering, where permitting costs killing
+    /// a live daemon that was never at fault.
+    #[tokio::test]
+    async fn a_stop_is_refused_when_the_caller_cannot_name_the_failed_instance() {
+        let start = std::time::Instant::now();
+
+        let killed = stop_daemon_instance(
+            &never_bound_endpoint(),
+            None,
+            std::time::Duration::from_secs(30),
+        )
+        .await;
+
+        assert_eq!(killed, None, "an unnamed instance must not be stopped");
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(1),
+            "the refusal must short-circuit, took {:?}",
+            start.elapsed()
+        );
+    }
+
+    /// The wedge path (#955 fail-fast) is allowed a much shorter drain than an
+    /// orderly replacement — a daemon that already failed a responsiveness
+    /// probe will not complete a 30 s durable drain. What it is *not* allowed
+    /// is a different answer to "whom may I kill": both entry points funnel
+    /// through the same identity gate.
+    #[test]
+    fn the_wedge_path_shortens_the_drain_but_not_the_identity_gate() {
+        assert!(
+            WEDGE_DRAIN_BUDGET < GRACEFUL_DRAIN_BUDGET,
+            "a wedged daemon must not be given the full graceful drain"
         );
     }
 }


### PR DESCRIPTION
The three PRs that landed against #1161 (#1257, #1258, #1260) all hardened `cli/runtime.rs`. **Nothing pointed the wrapper hot path at it.**

`cli/commands/daemon.rs` carried a full duplicate of `ensure_daemon` / `stop_stale_daemon` (plus `check_daemon_version` and `spawn_and_wait`), and *that* duplicate is what `wrap/ipc.rs`, `exec.rs`, `fp.rs` and `session.rs` imported. Only `cli/client.rs` reached the fixed copy. So every per-compile invocation still ran the unhardened path:

| Leg | `runtime.rs` (reached by `client.rs`) | `commands/daemon.rs` (reached by the wrapper) |
|---|---|---|
| Identity gate before Shutdown/kill | yes | **none — re-read the lock at kill time** |
| Probe before replacing on `CommError` | both arms | **unconditional replace** |
| Drain budget | 30 s, matched to `INDEX_WRITER_SHUTDOWN_DRAIN_TIMEOUT` | **200 ms → force kill** |
| Escalation forensics | `warn!` + `daemon-died` event | **bare `debug!`** |

## What this does

**Deletes the duplicate rather than hardening it twice.** `runtime.rs`'s version is a strict superset, and a second copy is how this regressed in the first place. `commands/daemon.rs` keeps only what is genuinely its own (binary discovery, tokio-console profile, `cmd_start`/`cmd_stop`).

**The three wrapper kill sites capture identity *before* the exchange.** By the time a request has failed, the lock file may already name a replacement another client spawned — killing "whoever is current" is exactly how one client's timeout becomes a kill chain through a `-j16` herd. Capturing at `stop_stale_daemon` entry would not have fixed it; the read has to happen before the request.

**The wedge path keeps its fast kill** (#955 fail-fast) via `stop_wedged_daemon`: a daemon that already missed its per-request budget *and* failed a follow-up probe will not complete a 30 s durable drain, and waiting would just delay the failure fail-fast exists to surface. Fail-fast governs **how long we wait, never whom we kill** — both entry points funnel through the same identity gate. That is asserted, not just intended.

**`cmd_profile_start`** gets the same treatment through `replace_running_daemon`, so a deliberate profile restart also cannot take out a replacement spawned in between.

## Extra defect, not in the issue

`cmd_stop` force-killed `check_running_daemon().or(read_lock_file_pid())`. `None` from `check_running_daemon` is *precisely* the stale-lock / recycled-PID signal — it removes the lock file in that case — so the `.or(...)` fallback force-killed a PID that had **just failed verification**. That is the #132 defense being bypassed by the one path that always kills, and `cmd_stop` never called `stop_stale_daemon`, so none of the earlier legs covered it. It now reports the stale lock, clears it, and leaves the unrelated process alone.

## Tests

Three gaps the earlier legs left — the identity *primitive* was tested, the *gate* was not:

- `a_stop_is_refused_when_the_recorded_instance_is_not_the_one_that_failed` — and asserts the refusal short-circuits before any IPC or drain wait, because the gate sits before the `Shutdown` request: asking an innocent daemon to retire is itself the damage.
- `a_stop_is_refused_when_the_caller_cannot_name_the_failed_instance` — the `None` case, which is what the old code turned into "kill whoever the lock names".
- `the_wedge_path_shortens_the_drain_but_not_the_identity_gate`.

## Evidence

- `soldr cargo test -p zccache-cli-core --features cli --lib` — **234 passed, 0 failed**, 2 ignored.
- `soldr cargo clippy -p zccache-cli-core --features cli --all-targets -- -D warnings` — clean.
- `soldr cargo check --workspace --all-targets` — clean.
- Unix legs are CI's to confirm (Docker was unavailable on this host); the change is platform-neutral.

## Left open on #1161

Leg 2's `<lock>.kill` single-flight slot. With the identity gate in place a kill chain cannot form — each refusal breaks it — so its remaining value is latency (parallel 30 s drains), not correctness. Flagging as a policy call rather than silently dropping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)