### PR TITLE
fix(cli): bound daemon recovery and stop paying it once per TU (#1170)

### DIFF
--- a/crates/zccache-cli-core/src/cli/README.md
+++ b/crates/zccache-cli-core/src/cli/README.md
@@ -1,3 +1,28 @@
 # Source
 
 Source files for `zccache-cli`.
+
+## Daemon acquisition and recovery (#1161, #1170)
+
+There is **one** implementation of "get me a working daemon":
+`runtime::ensure_daemon`. `commands/daemon.rs` used to carry a second,
+unhardened copy that the wrapper hot path imported; #1161 deleted it. Do not
+reintroduce a parallel stack — every kill-correctness fix has to hold on the
+path that actually runs per compile.
+
+- **`runtime.rs`** — the ladder itself: probe → classify → identity-scoped
+  cleanup → respawn → readiness. Every kill is bound to the instance the
+  caller failed to talk to, captured *before* the exchange
+  (`current_daemon_instance`); a kill that cannot name its target is refused.
+- **`recovery.rs`** — the bounds around the ladder. A total deadline
+  (`ZCCACHE_RECOVERY_BUDGET_MS`, default 30 s; `0` disables the cap) and a
+  cross-invocation breaker. The wrapper is a fresh process per translation
+  unit, so the breaker is a file (`<daemon-lock>.spawn-failed`): the first
+  exhaustion writes it, later invocations inside the cool-down (60 s,
+  doubling, capped at 10 min) fail immediately with the *original* reason, and
+  any success clears it. Without it a 1000-TU build against a dead daemon paid
+  the full ladder 1000 times.
+
+When recovery is exhausted the wrapper hard-errors — see
+`commands/wrap/unavailable.rs` for the exit code and event contract. There is
+no silent uncached fallback.

--- a/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
@@ -89,13 +89,7 @@ pub(super) async fn cmd_compile(
             // burst-load tail clears. If the probe itself fails or
             // times out, run the pre-#753 kill+respawn recovery.
             drop(conn);
-            let action = match wedge_probe_budget() {
-                Some(budget) => {
-                    classify_probe_outcome(probe_daemon_responsive(endpoint, budget).await)
-                }
-                None => WedgeAction::EscalateKill, // ZCCACHE_WEDGE_PROBE_BUDGET_MS=0
-            };
-            match action {
+            match wedge_action(endpoint).await {
                 WedgeAction::DowngradeNoKill => {
                     super::emit_wrapper_warning(&format!(
                         "zccache[warn][W]: daemon at {endpoint} answered probe within \
@@ -136,6 +130,23 @@ pub(super) async fn cmd_compile(
             eprintln!("zccache[err][R]: {}", msg.message);
             ExitCode::FAILURE
         }
+    }
+}
+
+/// Decide what a wedge means before acting on it.
+///
+/// #753 established that under burst-link load a "wedge" is usually a healthy
+/// daemon too busy to answer in time, and that killing it collapses the whole
+/// shared cohort. #1170 change 2 makes that classification apply to **every**
+/// wedge arm — the session arm had it, the two ephemeral arms killed
+/// unconditionally.
+///
+/// `ZCCACHE_WEDGE_PROBE_BUDGET_MS=0` disables the probe and preserves the
+/// pre-#753 unconditional-replace behaviour for anyone A/B-testing it.
+async fn wedge_action(endpoint: &str) -> WedgeAction {
+    match wedge_probe_budget() {
+        Some(budget) => classify_probe_outcome(probe_daemon_responsive(endpoint, budget).await),
+        None => WedgeAction::EscalateKill,
     }
 }
 
@@ -494,14 +505,46 @@ async fn cmd_compile_ephemeral_with_stdin(
         CompileRecvOutcome::Done(recv_result) => {
             report_relay_outcome(relay_compile_response_to_stdio(recv_result))
         }
-        CompileRecvOutcome::Wedged => {
-            eprintln!(
-                "zccache[err][W]: daemon at {endpoint} stopped responding within \
-                 the wedge budget; killing it so the next compile starts fresh — issue #666"
-            );
-            stop_wedged_daemon(endpoint, served_by.as_ref()).await;
-            ExitCode::FAILURE
-        }
+        // #1170 change 2: this arm used to kill unconditionally. A busy
+        // daemon under a `-j16` burst looks identical to a hung one from a
+        // single client's timeout, and killing it takes down the daemon every
+        // other worker is waiting on. Classify first, exactly as the session
+        // arm has since #753.
+        CompileRecvOutcome::Wedged => match wedge_action(endpoint).await {
+            WedgeAction::DowngradeNoKill => {
+                super::emit_wrapper_warning(&format!(
+                    "zccache[warn][W]: daemon at {endpoint} answered a probe within budget \
+                     but missed the per-request wedge budget — burst load, not a hung \
+                     daemon. Retrying once without killing — issues #753/#1170"
+                ));
+                match run_ephemeral_attempt(endpoint, &request).await {
+                    CompileRecvOutcome::Done(recv_result) => {
+                        report_relay_outcome(relay_compile_response_to_stdio(recv_result))
+                    }
+                    CompileRecvOutcome::Wedged => {
+                        eprintln!(
+                            "zccache[err][W]: daemon at {endpoint} missed the wedge budget \
+                             again after answering a probe; failing without killing a daemon \
+                             that is demonstrably alive"
+                        );
+                        ExitCode::FAILURE
+                    }
+                    CompileRecvOutcome::Failed(msg) => {
+                        eprintln!("zccache[err][R]: {}", msg.message);
+                        ExitCode::FAILURE
+                    }
+                }
+            }
+            WedgeAction::EscalateKill | WedgeAction::EscalateKillProbeError => {
+                eprintln!(
+                    "zccache[err][W]: daemon at {endpoint} stopped responding within \
+                     the wedge budget and failed the follow-up probe; killing it so the \
+                     next compile starts fresh — issue #666"
+                );
+                stop_wedged_daemon(endpoint, served_by.as_ref()).await;
+                ExitCode::FAILURE
+            }
+        },
         CompileRecvOutcome::Failed(msg) => match msg.phase {
             // #1170: this used to run the compiler directly, uncached, and
             // mirror its exit code — so a daemon outage that compiled fine
@@ -553,15 +596,44 @@ pub(super) async fn cmd_link_ephemeral(
         CompileRecvOutcome::Done(recv_result) => {
             report_relay_outcome(relay_link_response_to_stdio(recv_result))
         }
-        CompileRecvOutcome::Wedged => {
-            eprintln!(
-                "zccache[err][W]: daemon at {endpoint} stopped responding within \
-                 the wedge budget on a Link; killing it so the next request starts \
-                 fresh — issue #666"
-            );
-            stop_wedged_daemon(endpoint, served_by.as_ref()).await;
-            ExitCode::FAILURE
-        }
+        // #1170 change 2: classify before killing, as in `cmd_compile_ephemeral`.
+        // Links are the requests most likely to be slow for legitimate reasons,
+        // so this arm is if anything the more important of the two.
+        CompileRecvOutcome::Wedged => match wedge_action(endpoint).await {
+            WedgeAction::DowngradeNoKill => {
+                super::emit_wrapper_warning(&format!(
+                    "zccache[warn][W]: daemon at {endpoint} answered a probe within budget \
+                     but missed the per-request wedge budget on a Link — burst load, not a \
+                     hung daemon. Retrying once without killing — issues #753/#1170"
+                ));
+                match run_ephemeral_attempt(endpoint, &request).await {
+                    CompileRecvOutcome::Done(recv_result) => {
+                        report_relay_outcome(relay_link_response_to_stdio(recv_result))
+                    }
+                    CompileRecvOutcome::Wedged => {
+                        eprintln!(
+                            "zccache[err][W]: daemon at {endpoint} missed the wedge budget \
+                             again on a Link after answering a probe; failing without killing \
+                             a daemon that is demonstrably alive"
+                        );
+                        ExitCode::FAILURE
+                    }
+                    CompileRecvOutcome::Failed(msg) => {
+                        eprintln!("zccache[err][R]: {}", msg.message);
+                        ExitCode::FAILURE
+                    }
+                }
+            }
+            WedgeAction::EscalateKill | WedgeAction::EscalateKillProbeError => {
+                eprintln!(
+                    "zccache[err][W]: daemon at {endpoint} stopped responding within \
+                     the wedge budget on a Link and failed the follow-up probe; killing it \
+                     so the next request starts fresh — issue #666"
+                );
+                stop_wedged_daemon(endpoint, served_by.as_ref()).await;
+                ExitCode::FAILURE
+            }
+        },
         CompileRecvOutcome::Failed(msg) => match msg.phase {
             // #1170: as in `cmd_compile_ephemeral` — a link/archive step is
             // no more entitled to silently bypass the daemon than a compile.

--- a/crates/zccache-cli-core/src/cli/mod.rs
+++ b/crates/zccache-cli-core/src/cli/mod.rs
@@ -6,6 +6,7 @@ pub mod client;
 pub mod commands;
 pub mod defender;
 pub mod multicall;
+pub(crate) mod recovery;
 mod runtime;
 pub mod snapshot_fp;
 pub mod symbols;

--- a/crates/zccache-cli-core/src/cli/recovery.rs
+++ b/crates/zccache-cli-core/src/cli/recovery.rs
@@ -1,0 +1,283 @@
+//! Bounded daemon-recovery policy for the wrapper (issue #1170, change 2).
+//!
+//! Since #1170 made "daemon unavailable" a hard error, recovery has to be
+//! robust enough that a client can nearly always obtain a working daemon —
+//! and, when it genuinely cannot, fail the whole build *fast* instead of once
+//! per translation unit.
+//!
+//! Two mechanisms live here:
+//!
+//! - a **total deadline** across the probe → classify → clean up → respawn
+//!   ladder, so a pathological host cannot turn one compile into minutes of
+//!   retrying. Before this there was no overall cap at all.
+//! - a **cross-invocation breaker**. The wrapper is a fresh process per
+//!   TU, so nothing was shared between them: a 1000-TU build with a dead
+//!   daemon paid the full ladder 1000 times. The first exhaustion writes a
+//!   marker beside the daemon lock; subsequent invocations inside its
+//!   cool-down skip the ladder and hard-error immediately. Any successful
+//!   connect clears it.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// Total budget for one client's recovery ladder.
+pub(crate) const RECOVERY_BUDGET_ENV: &str = "ZCCACHE_RECOVERY_BUDGET_MS";
+
+/// Default total deadline. Comfortably above a healthy cold spawn (~1-5 s)
+/// including a 30 s drain of a retiring predecessor is *not* affordable here:
+/// the point of the cap is that a client gives up while a human still
+/// believes the build is running.
+const DEFAULT_RECOVERY_BUDGET: Duration = Duration::from_secs(30);
+
+/// First cool-down after the ladder is exhausted.
+const BREAKER_INITIAL_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// Ceiling for the doubling cool-down. Long enough that a persistently broken
+/// host stops paying anything, short enough that a fixed host recovers without
+/// the user hunting for a file to delete.
+const BREAKER_MAX_COOLDOWN: Duration = Duration::from_secs(10 * 60);
+
+/// Suffix of the breaker marker, alongside `<lock>.spawn` from #952.
+const BREAKER_MARKER_SUFFIX: &str = ".spawn-failed";
+
+/// Resolved recovery budget, `ZCCACHE_RECOVERY_BUDGET_MS` or the default.
+///
+/// `0` disables the cap — the escape hatch for anyone bisecting against the
+/// pre-#1170 unbounded behaviour. An unparseable value is ignored rather than
+/// fatal: this is on the compile hot path, and refusing to build because a
+/// tuning knob was misspelled is worse than the knob being ignored.
+pub(crate) fn recovery_budget() -> Option<Duration> {
+    recovery_budget_from(|name| std::env::var(name).ok())
+}
+
+fn recovery_budget_from<F>(lookup: F) -> Option<Duration>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let Some(raw) = lookup(RECOVERY_BUDGET_ENV) else {
+        return Some(DEFAULT_RECOVERY_BUDGET);
+    };
+    match raw.trim().parse::<u64>() {
+        Ok(0) => None,
+        Ok(ms) => Some(Duration::from_millis(ms)),
+        Err(_) => Some(DEFAULT_RECOVERY_BUDGET),
+    }
+}
+
+/// Where the breaker marker lives for the current endpoint.
+fn breaker_marker_path() -> PathBuf {
+    let lock = crate::ipc::lock_file_path();
+    PathBuf::from(format!("{}{BREAKER_MARKER_SUFFIX}", lock.display()))
+}
+
+/// Persisted breaker state. Serialized as JSON so an operator can read why
+/// their build is failing without attaching a debugger.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct BreakerMarker {
+    /// Wall-clock ms when the breaker last opened.
+    opened_at_unix_ms: u64,
+    /// How long invocations should skip the ladder from `opened_at_unix_ms`.
+    cooldown_ms: u64,
+    /// How many times the breaker has opened without an intervening success.
+    consecutive_failures: u32,
+    /// The failure that opened it, verbatim, so the fast-failing TUs can
+    /// report the *original* cause rather than "breaker open".
+    reason: String,
+}
+
+fn now_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// If the breaker is open and still inside its cool-down, the reason the
+/// ladder failed the first time.
+///
+/// Reads the marker rather than caching in memory: the whole point is that
+/// each TU is a separate process.
+pub(crate) fn breaker_reason_if_open() -> Option<String> {
+    let marker = read_marker(&breaker_marker_path())?;
+    let elapsed_ms = now_unix_ms().saturating_sub(marker.opened_at_unix_ms);
+    (elapsed_ms < marker.cooldown_ms).then_some(marker.reason)
+}
+
+fn read_marker(path: &std::path::Path) -> Option<BreakerMarker> {
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Record that the ladder was exhausted, doubling the cool-down if the
+/// breaker was already open.
+///
+/// Emits `daemon_spawn_breaker_open` **once per opening**, not once per TU —
+/// a 1000-TU build must not produce 1000 rows of the same fact.
+pub(crate) fn open_breaker(reason: &str) {
+    let path = breaker_marker_path();
+    let previous = read_marker(&path);
+    let consecutive_failures = previous
+        .as_ref()
+        .map_or(1, |marker| marker.consecutive_failures.saturating_add(1));
+    let cooldown = previous
+        .as_ref()
+        .map(|marker| {
+            Duration::from_millis(marker.cooldown_ms.saturating_mul(2))
+                .min(BREAKER_MAX_COOLDOWN)
+                .max(BREAKER_INITIAL_COOLDOWN)
+        })
+        .unwrap_or(BREAKER_INITIAL_COOLDOWN);
+
+    let marker = BreakerMarker {
+        opened_at_unix_ms: now_unix_ms(),
+        cooldown_ms: cooldown.as_millis() as u64,
+        consecutive_failures,
+        reason: reason.to_string(),
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(json) = serde_json::to_vec(&marker) {
+        let _ = std::fs::write(&path, json);
+    }
+
+    tracing::warn!(
+        reason,
+        cooldown_secs = cooldown.as_secs(),
+        consecutive_failures,
+        "daemon recovery exhausted; failing subsequent invocations immediately \
+         until the cool-down expires"
+    );
+    crate::core::lifecycle::write_event(
+        crate::core::lifecycle::EVENT_DAEMON_SPAWN_BREAKER_OPEN,
+        serde_json::json!({
+            "reason": reason,
+            "cooldown_ms": marker.cooldown_ms,
+            "consecutive_failures": consecutive_failures,
+        }),
+    );
+}
+
+/// Forget any breaker state. Called on every successful daemon acquisition,
+/// including the fast path — a working daemon is proof the outage is over,
+/// and leaving a stale marker would fast-fail a healthy build.
+pub(crate) fn clear_breaker() {
+    let _ = std::fs::remove_file(breaker_marker_path());
+}
+
+/// Remove state a dead daemon instance left behind.
+///
+/// #1170 change 2, step 3. Two artifacts were previously never cleaned on
+/// this path:
+///
+/// - `<lock>.spawn` (#952's single-flight slot) was only *lazily* reclaimed
+///   after 20 s, so a client that crashed between winning the slot and
+///   binding the daemon wedged the whole herd for that window.
+/// - the backend identity file was never removed at all, so a stale identity
+///   outlived the instance it described.
+pub(crate) fn clear_stale_daemon_state() {
+    let lock = crate::ipc::lock_file_path();
+    let spawn_slot = PathBuf::from(format!("{}.spawn", lock.display()));
+    let _ = std::fs::remove_file(spawn_slot);
+    let _ = std::fs::remove_file(crate::ipc::backend_identity_path().as_path());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_budget_defaults_and_zero_disables_the_cap() {
+        assert_eq!(
+            recovery_budget_from(|_| None),
+            Some(DEFAULT_RECOVERY_BUDGET)
+        );
+        assert_eq!(
+            recovery_budget_from(|_| Some("1500".to_string())),
+            Some(Duration::from_millis(1500))
+        );
+        assert_eq!(recovery_budget_from(|_| Some("0".to_string())), None);
+    }
+
+    /// A misspelled tuning knob must not fail the build. This runs on the
+    /// compile hot path, so the failure mode of a bad value has to be "the
+    /// knob is ignored", never "nothing compiles".
+    #[test]
+    fn an_unparseable_budget_falls_back_to_the_default() {
+        assert_eq!(
+            recovery_budget_from(|_| Some("banana".to_string())),
+            Some(DEFAULT_RECOVERY_BUDGET)
+        );
+    }
+
+    /// The cool-down doubles per consecutive failure and saturates at the
+    /// cap, so a persistently broken host stops paying while a transiently
+    /// broken one recovers quickly.
+    #[test]
+    fn the_cooldown_doubles_and_saturates() {
+        let mut cooldown = BREAKER_INITIAL_COOLDOWN;
+        for _ in 0..20 {
+            cooldown = (cooldown * 2).min(BREAKER_MAX_COOLDOWN);
+        }
+        assert_eq!(cooldown, BREAKER_MAX_COOLDOWN);
+        assert!(BREAKER_INITIAL_COOLDOWN < BREAKER_MAX_COOLDOWN);
+    }
+
+    /// The marker must survive a round trip through JSON: it is read by a
+    /// *different process* than the one that wrote it, which is the entire
+    /// reason it is on disk rather than in memory.
+    #[test]
+    fn a_marker_inside_its_cooldown_reports_the_original_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("daemon.lock.spawn-failed");
+        let marker = BreakerMarker {
+            opened_at_unix_ms: now_unix_ms(),
+            cooldown_ms: 60_000,
+            consecutive_failures: 1,
+            reason: "cannot start daemon: binary not found".to_string(),
+        };
+        std::fs::write(&path, serde_json::to_vec(&marker).unwrap()).unwrap();
+
+        let read = read_marker(&path).expect("marker round-trips");
+        assert_eq!(read.reason, marker.reason);
+        assert_eq!(read.consecutive_failures, 1);
+        let elapsed = now_unix_ms().saturating_sub(read.opened_at_unix_ms);
+        assert!(
+            elapsed < read.cooldown_ms,
+            "a freshly written marker must still be inside its cool-down"
+        );
+    }
+
+    /// An expired marker must not fast-fail. The cool-down is what lets a
+    /// fixed host recover on its own.
+    #[test]
+    fn a_marker_past_its_cooldown_no_longer_suppresses_recovery() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("daemon.lock.spawn-failed");
+        let marker = BreakerMarker {
+            // Opened well before the cool-down window.
+            opened_at_unix_ms: now_unix_ms().saturating_sub(120_000),
+            cooldown_ms: 60_000,
+            consecutive_failures: 1,
+            reason: "stale".to_string(),
+        };
+        std::fs::write(&path, serde_json::to_vec(&marker).unwrap()).unwrap();
+
+        let read = read_marker(&path).expect("marker round-trips");
+        let elapsed = now_unix_ms().saturating_sub(read.opened_at_unix_ms);
+        assert!(
+            elapsed >= read.cooldown_ms,
+            "the cool-down must be expired for this fixture to mean anything"
+        );
+    }
+
+    /// A corrupt or truncated marker must read as "no breaker". Failing
+    /// closed here would make an unparseable file permanently unbuildable.
+    #[test]
+    fn a_corrupt_marker_is_ignored_rather_than_fatal() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("daemon.lock.spawn-failed");
+        std::fs::write(&path, b"{not json").unwrap();
+        assert!(read_marker(&path).is_none());
+    }
+}

--- a/crates/zccache-cli-core/src/cli/runtime.rs
+++ b/crates/zccache-cli-core/src/cli/runtime.rs
@@ -577,6 +577,11 @@ async fn stop_daemon_instance(
     let drained_cleanly = wait_for_process_exit(pid, drain_budget).await;
     if drained_cleanly {
         crate::ipc::remove_lock_file();
+        // #1170 change 2, step 3: the lock file was never the whole of a dead
+        // instance's state. Clear the rest here rather than leaving `<lock>
+        // .spawn` to a 20 s staleness timer and the identity file to nothing
+        // at all.
+        super::recovery::clear_stale_daemon_state();
         // Return the pid even though nothing was killed: the caller uses it to
         // link old -> new in the takeover lifecycle events. Previously a
         // daemon that exited inside the 200 ms window returned `None` here and
@@ -609,13 +614,50 @@ async fn stop_daemon_instance(
         wait_for_process_exit(pid, FORCE_KILL_REAP_BUDGET).await;
     }
     crate::ipc::remove_lock_file();
+    super::recovery::clear_stale_daemon_state();
     let killed_pid = kill_ok.then_some(pid);
 
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     killed_pid
 }
 
+/// Acquire a working daemon, or fail loudly within a bounded budget.
+///
+/// #1170 change 2 wraps the ladder below in two bounds that did not exist:
+/// a **total deadline** (`ZCCACHE_RECOVERY_BUDGET_MS`, default 30 s — the
+/// worst case used to be minutes), and a **cross-invocation breaker**. The
+/// wrapper is a fresh process per translation unit, so nothing was shared
+/// between them: a 1000-TU build against a dead daemon paid the whole ladder
+/// 1000 times. Now the first exhaustion writes a marker and the rest fail in
+/// microseconds, reporting the *original* cause rather than "breaker open".
 pub async fn ensure_daemon(endpoint: &str) -> Result<(), String> {
+    if let Some(reason) = super::recovery::breaker_reason_if_open() {
+        return Err(format!(
+            "daemon recovery already failed on this cache root and is in its cool-down: {reason}"
+        ));
+    }
+    let outcome = match super::recovery::recovery_budget() {
+        Some(budget) => match tokio::time::timeout(budget, ensure_daemon_ladder(endpoint)).await {
+            Ok(outcome) => outcome,
+            Err(_) => Err(format!(
+                "daemon recovery exceeded its {}ms budget ({})",
+                budget.as_millis(),
+                super::recovery::RECOVERY_BUDGET_ENV
+            )),
+        },
+        None => ensure_daemon_ladder(endpoint).await,
+    };
+    match &outcome {
+        // A working daemon is proof the outage is over. Clearing on every
+        // success — not only after a recovery — is what stops a stale marker
+        // from fast-failing a healthy build.
+        Ok(()) => super::recovery::clear_breaker(),
+        Err(reason) => super::recovery::open_breaker(reason),
+    }
+    outcome
+}
+
+async fn ensure_daemon_ladder(endpoint: &str) -> Result<(), String> {
     // Issue #982: under the host no-spawn guard a reachable,
     // version-compatible daemon may still be used, but every other
     // outcome — including the stale-daemon replace paths, which would

--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -42,6 +42,7 @@
 //! | `pipe-handover` (#755) | CLI (on takeover) | new daemon claimed the endpoint a previous daemon held | `pid` (the new daemon), `inbound_pid`, `inbound_version`, `outbound_pid`, `reason`, `client_pid` |
 //! | `client-disconnected` (#755) | client | IPC connection broke mid-request | `endpoint`, `client_pid`, `client_version`, `client_binary_path`, `cause`, `detail` |
 //! | `wrapper-local-fallback` | CLI wrapper | retired by #1170; kept so historical logs still resolve and the audit rule can assert it never reappears | `reason`, tool fields |
+//! | `daemon_spawn_breaker_open` (#1170) | CLI wrapper | daemon recovery was exhausted; later invocations fail immediately until the cool-down expires | `reason`, `cooldown_ms`, `consecutive_failures` |
 //! | `wrapper-daemon-unavailable` (#1170) | CLI wrapper | the daemon could not be reached before request dispatch and the wrapper refused to run the tool uncached | `tool`, `cwd`, `endpoint`, `reason`, `phase`, `route`, `exit_code` |
 //! | `version_mismatch` | daemon | client / daemon protocol versions disagree | `daemon_protocol_version`, `client_protocol_version`, `reason` |
 //! | `state_corrupt` (#1157) | daemon | persisted state did not parse and was dropped rather than reconciled; consequence is a full cold recompile | `subsystem`, `consequence`, `message`, `path`, `bytes` |
@@ -191,6 +192,14 @@ pub const EVENT_WRAPPER_LOCAL_FALLBACK: &str = "wrapper-local-fallback";
 /// `wrapper-local-fallback` any more; its audit rule stays as the guard that
 /// it does not come back.
 pub const EVENT_WRAPPER_DAEMON_UNAVAILABLE: &str = "wrapper-daemon-unavailable";
+/// The bounded recovery ladder was exhausted and the wrapper opened its
+/// cross-invocation breaker (#1170).
+///
+/// Emitted once per opening, not once per translation unit: the breaker
+/// exists precisely so a 1000-TU build against a dead daemon fails in
+/// seconds rather than paying the ladder 1000 times, and an event per TU
+/// would reintroduce the cost it removes in the log.
+pub const EVENT_DAEMON_SPAWN_BREAKER_OPEN: &str = "daemon_spawn_breaker_open";
 /// Phase 0 log-audit event names. These are emitted by the owning cache paths;
 /// the audit catalog consumes the stable spellings rather than source regexes.
 pub const EVENT_LEGACY_ARTIFACT_PATH_ACCESSED: &str = "legacy_artifact_path_accessed";
@@ -251,6 +260,7 @@ pub const EVENT_ALL: &[&str] = &[
     EVENT_CLIENT_CANCELLED,
     EVENT_WRAPPER_LOCAL_FALLBACK,
     EVENT_WRAPPER_DAEMON_UNAVAILABLE,
+    EVENT_DAEMON_SPAWN_BREAKER_OPEN,
     EVENT_STAGED_PUBLICATION_CONFLICT,
     EVENT_STAGED_PUBLICATION_REPLACES_INVALID_GENERATION,
     EVENT_STAGED_PUBLICATION_FAILED,


### PR DESCRIPTION
**Required change 2** of #1170, completing the issue. #1287 made daemon-unavailable a hard error; in exchange the directive requires recovery robust enough to nearly always produce a working daemon — and cheap to give up on when it cannot.

## Three bounds that did not exist

### 1. A total deadline

The ladder had **no overall cap**. Worst case was minutes of retrying inside a single compile. `ZCCACHE_RECOVERY_BUDGET_MS` (default 30 s; `0` disables, as the escape hatch for bisecting against the old behaviour) now wraps probe → classify → clean up → respawn. The point of the cap is that a client gives up while a human still believes the build is running.

An unparseable value falls back to the default rather than failing. This is on the compile hot path — refusing to build because a tuning knob was misspelled is worse than the knob being ignored.

### 2. A cross-invocation breaker

The wrapper is a **fresh process per translation unit**, so nothing was shared between them: a 1000-TU build against a dead daemon paid the whole ladder 1000 times — 1000 × 30 s with the new cap, worse without it.

The first exhaustion writes `<daemon-lock>.spawn-failed`; invocations inside its cool-down (60 s, doubling, capped at 10 min) skip the ladder and fail immediately, reporting the **original** cause rather than "breaker open" — the operator needs the failure, not the mechanism.

Design points worth calling out:

- **Any successful acquisition clears it, including the fast path.** A working daemon is proof the outage is over; a stale marker would fast-fail a healthy build.
- **The event fires once per opening, not once per TU.** An event per TU would reintroduce in the log exactly the cost the breaker removes.
- **A corrupt marker reads as "no breaker".** Failing closed would make an unparseable file permanently unbuildable.
- It is a file, not memory, precisely because the sharing has to cross process boundaries.

### 3. Wedge classification on every arm

The session arm has probed before killing since #753. The two **ephemeral arms still killed unconditionally** — and a busy daemon under a `-j16` burst is indistinguishable from a hung one from a single client's timeout, so that arm took down the daemon every other worker was waiting on. That is the failure #753 was raised for, still live on two of three paths.

Both arms now classify, **retry once without killing** when the daemon answers the probe, and kill only when the follow-up probe also fails. `ZCCACHE_WEDGE_PROBE_BUDGET_MS=0` still preserves the pre-#753 unconditional-replace behaviour.

## Stale-state cleanup (step 3 of the ladder)

Two artifacts were never cleaned when an instance died:

- `<lock>.spawn` (#952's single-flight slot) — only *lazily* reclaimed after 20 s, so a client that crashed between winning the slot and binding the daemon wedged the whole herd for that window.
- the backend identity file — never removed at all, so a stale identity outlived the instance it described.

Both now go with the lock file, on the clean-drain and the force-kill path.

## Tests

Six new unit tests in `recovery.rs`: budget default / explicit / `0`-disables, unparseable-falls-back, cool-down doubles and saturates, marker round-trips through JSON inside its cool-down, an expired marker stops suppressing, and a corrupt marker is ignored rather than fatal.

## Evidence

- `soldr cargo test -p zccache-cli-core --features cli --lib` — **236 passed, 0 failed** (was 230 before this PR).
- `soldr cargo test -p zccache-core --lib lifecycle` — 13 passed; the catalog self-check covers `daemon_spawn_breaker_open` and its schema row.
- `soldr cargo clippy -p zccache-cli-core --features cli -p zccache-core --all-targets -- -D warnings` — clean.
- `soldr cargo check -p zccache-cli-core --features cli -p zccache-core --all-targets` — clean.

## Scope note

The recovery policy lives in a new `cli/recovery.rs` rather than in `runtime.rs`, which is already ~1.4K LOC and close to the `loc_guard` block threshold. `cli/README.md` now documents the single-implementation rule from #1161 alongside the new bounds, so the next person does not reintroduce a parallel stack.

With this merged, #1170's changes 1 and 2 are both on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)