### PR TITLE
fix(daemon): add a bounded opt-in log-file sink (#1165 item 5)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/entry.rs
+++ b/crates/zccache-daemon-core/src/daemon/entry.rs
@@ -677,17 +677,41 @@ fn init_tracing(level: &str) {
     }
 }
 
+/// Install the stderr sink, plus the opt-in bounded file sink (#1165 item 5).
+///
+/// stderr stays the default and is never taken away: whoever supervises the
+/// daemon owns that stream and is expected to rotate it. `ZCCACHE_LOG_FILE`
+/// *adds* a size-capped file alongside it for operators who have no
+/// supervisor doing that — previously there was no bounded option at all.
 fn init_fmt_tracing(filter: tracing_subscriber::EnvFilter) {
     use tracing_subscriber::prelude::*;
 
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::fmt::layer()
+    let stderr_layer = tracing_subscriber::fmt::layer()
+        .with_target(true)
+        .with_thread_ids(true);
+
+    match super::log_sink::BoundedFileSink::from_env() {
+        Some(sink) => {
+            // ANSI off for the file: escape codes in a log an operator greps
+            // months later are noise, not colour.
+            let file_layer = tracing_subscriber::fmt::layer()
                 .with_target(true)
                 .with_thread_ids(true)
-                .with_filter(filter),
-        )
-        .init();
+                .with_ansi(false)
+                .with_writer(sink);
+            // The filter is applied once at the registry rather than per
+            // layer, so both sinks are guaranteed to agree on what they see.
+            tracing_subscriber::registry()
+                .with(stderr_layer)
+                .with(file_layer)
+                .with(filter)
+                .init();
+        }
+        None => tracing_subscriber::registry()
+            .with(stderr_layer)
+            .with(filter)
+            .init(),
+    }
 }
 
 #[cfg(feature = "tokio-console")]

--- a/crates/zccache-daemon-core/src/daemon/log_sink.rs
+++ b/crates/zccache-daemon-core/src/daemon/log_sink.rs
@@ -1,0 +1,273 @@
+//! Opt-in bounded file sink for daemon tracing output (issue #1165, item 5).
+//!
+//! The daemon's `tracing` output goes to stderr and always has. That is the
+//! right default — whoever supervises the process owns its stream — but it
+//! left operators with no bounded option at all: redirecting stderr to a file
+//! yourself grows without limit, and the daemon outlives the shell that
+//! started it.
+//!
+//! Setting `ZCCACHE_LOG_FILE=<path>` adds a **size-capped** file sink
+//! alongside stderr. It reuses the lifecycle log's rotation shape — one live
+//! file plus one archive, so the footprint is bounded at `2 × cap` — because
+//! that is the retention contract the rest of the daemon's logs already have,
+//! and a second rotation policy would be one more thing to reason about.
+//!
+//! ## Operational contract
+//!
+//! - **stderr is unchanged and still the default.** Service managers
+//!   (systemd, launchd, Windows services, CI runners) are expected to rotate
+//!   the daemon's stderr; nothing here does it for them.
+//! - The file sink is **additive**, not a redirect: turning it on does not
+//!   take output away from a supervisor already collecting stderr.
+//! - Writes are best-effort. A failing sink degrades to "no file output" and
+//!   never blocks or crashes the daemon — diagnostics must not be able to
+//!   take down the process they are diagnosing.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+/// Path of the optional bounded file sink.
+pub const LOG_FILE_ENV: &str = "ZCCACHE_LOG_FILE";
+
+/// Override for the per-file cap, in bytes.
+pub const LOG_FILE_MAX_BYTES_ENV: &str = "ZCCACHE_LOG_FILE_MAX_BYTES";
+
+/// Default cap for the live file. With one archive kept, the sink's total
+/// footprint is bounded at twice this. Chosen an order of magnitude above the
+/// lifecycle log's 1 MiB because this carries full `tracing` output, not one
+/// JSON line per process-boundary event.
+const DEFAULT_MAX_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Suffix of the single retained archive.
+const ARCHIVE_SUFFIX: &str = ".1";
+
+/// A size-capped append sink.
+///
+/// Each write opens, appends and closes, mirroring `lifecycle::write_event`.
+/// That is deliberately unoptimised: this sink is opt-in diagnostics rather
+/// than a hot path, and per-write open/append/close is what makes concurrent
+/// writers safe without holding a file handle across the daemon's lifetime.
+pub struct BoundedFileSink {
+    path: PathBuf,
+    max_bytes: u64,
+    /// Serializes the check-size-then-rotate sequence so two threads cannot
+    /// both decide to rotate and lose the archive.
+    rotate_lock: Mutex<()>,
+}
+
+impl BoundedFileSink {
+    /// Build a sink from the environment, or `None` when `ZCCACHE_LOG_FILE`
+    /// is unset or empty.
+    pub fn from_env() -> Option<Self> {
+        Self::from_env_with(|name| std::env::var(name).ok())
+    }
+
+    fn from_env_with<F>(lookup: F) -> Option<Self>
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        let path = lookup(LOG_FILE_ENV)?;
+        let path = path.trim();
+        if path.is_empty() {
+            return None;
+        }
+        // An unparseable or zero cap falls back to the default rather than
+        // disabling the bound: the whole reason this sink exists is that
+        // unbounded growth is the bug.
+        let max_bytes = lookup(LOG_FILE_MAX_BYTES_ENV)
+            .and_then(|raw| raw.trim().parse::<u64>().ok())
+            .filter(|bytes| *bytes > 0)
+            .unwrap_or(DEFAULT_MAX_BYTES);
+        Some(Self::new(PathBuf::from(path), max_bytes))
+    }
+
+    fn new(path: PathBuf, max_bytes: u64) -> Self {
+        Self {
+            path,
+            max_bytes,
+            rotate_lock: Mutex::new(()),
+        }
+    }
+
+    /// Rotate the live file to `.1` once it exceeds the cap, replacing any
+    /// previous archive.
+    fn rotate_if_oversized(&self) {
+        let _guard = self
+            .rotate_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let Ok(metadata) = std::fs::metadata(&self.path) else {
+            return;
+        };
+        if metadata.len() <= self.max_bytes {
+            return;
+        }
+        let _ = std::fs::rename(&self.path, archive_path(&self.path));
+    }
+
+    fn append(&self, buf: &[u8]) {
+        self.rotate_if_oversized();
+        if let Some(parent) = self.path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+        {
+            let _ = file.write_all(buf);
+        }
+    }
+}
+
+fn archive_path(path: &Path) -> PathBuf {
+    let mut name = path
+        .file_name()
+        .map(std::ffi::OsString::from)
+        .unwrap_or_default();
+    name.push(ARCHIVE_SUFFIX);
+    path.parent()
+        .map(|parent| parent.join(&name))
+        .unwrap_or_else(|| PathBuf::from(name))
+}
+
+/// One `tracing` event's worth of bytes.
+///
+/// `tracing_subscriber` writes an event in several calls, so buffering until
+/// `flush`/drop is what keeps a single event on a single line in the file.
+pub struct SinkWriter<'a> {
+    sink: &'a BoundedFileSink,
+    buffer: Vec<u8>,
+}
+
+impl Write for SinkWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buffer.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        if !self.buffer.is_empty() {
+            self.sink.append(&self.buffer);
+            self.buffer.clear();
+        }
+        Ok(())
+    }
+}
+
+impl Drop for SinkWriter<'_> {
+    fn drop(&mut self) {
+        let _ = self.flush();
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BoundedFileSink {
+    type Writer = SinkWriter<'a>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        SinkWriter {
+            sink: self,
+            buffer: Vec::with_capacity(256),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_sink_is_off_unless_a_path_is_configured() {
+        assert!(BoundedFileSink::from_env_with(|_| None).is_none());
+        assert!(BoundedFileSink::from_env_with(|_| Some("   ".to_string())).is_none());
+    }
+
+    #[test]
+    fn an_unparseable_or_zero_cap_falls_back_to_the_default() {
+        // Zero would mean "unbounded" if taken literally, which is the bug
+        // this sink exists to fix.
+        for raw in ["0", "banana", ""] {
+            let sink = BoundedFileSink::from_env_with(|name| {
+                Some(if name == LOG_FILE_ENV { "log.txt" } else { raw }.to_string())
+            })
+            .expect("a configured path enables the sink");
+            assert_eq!(sink.max_bytes, DEFAULT_MAX_BYTES);
+        }
+    }
+
+    /// The load-bearing property: the file stops growing. Without the cap an
+    /// operator who points the daemon at a file gets unbounded growth, which
+    /// is the finding.
+    #[test]
+    fn the_live_file_rotates_once_it_exceeds_the_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("daemon.log");
+        let sink = BoundedFileSink::new(path.clone(), 64);
+
+        for _ in 0..50 {
+            sink.append(b"a line of daemon output that is not especially short\n");
+        }
+
+        let live = std::fs::metadata(&path).expect("a live file exists").len();
+        assert!(
+            live <= 64 + 128,
+            "the live file must be near the cap, not the whole history: {live} bytes"
+        );
+        let archive = std::fs::metadata(archive_path(&path))
+            .expect("exactly one archive is retained")
+            .len();
+        assert!(archive > 0);
+        // Total footprint stays bounded: live + one archive, never a third.
+        let files = std::fs::read_dir(dir.path()).unwrap().count();
+        assert_eq!(files, 2, "one live file plus exactly one archive");
+    }
+
+    #[test]
+    fn a_sink_under_the_cap_keeps_everything_in_one_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("daemon.log");
+        let sink = BoundedFileSink::new(path.clone(), 1024);
+
+        sink.append(b"first\n");
+        sink.append(b"second\n");
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents, "first\nsecond\n");
+        assert!(!archive_path(&path).exists(), "nothing to archive yet");
+    }
+
+    /// Diagnostics must never take down the process they are diagnosing.
+    #[test]
+    fn an_unwritable_path_is_silently_tolerated() {
+        let dir = tempfile::tempdir().unwrap();
+        // A path whose parent is a *file* cannot be created.
+        let blocker = dir.path().join("not-a-dir");
+        std::fs::write(&blocker, b"x").unwrap();
+        let sink = BoundedFileSink::new(blocker.join("daemon.log"), 1024);
+
+        sink.append(b"this must not panic\n");
+    }
+
+    /// A whole event must land as one write, not be interleaved with another
+    /// thread's by the per-call `write`s `tracing_subscriber` makes.
+    #[test]
+    fn a_writer_buffers_until_flush() {
+        use tracing_subscriber::fmt::MakeWriter as _;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("daemon.log");
+        let sink = BoundedFileSink::new(path.clone(), 1024);
+
+        {
+            let mut writer = sink.make_writer();
+            writer.write_all(b"half ").unwrap();
+            assert!(
+                !path.exists(),
+                "nothing should reach disk before the event completes"
+            );
+            writer.write_all(b"an event\n").unwrap();
+        }
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "half an event\n");
+    }
+}

--- a/crates/zccache-daemon-core/src/daemon/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/mod.rs
@@ -19,6 +19,10 @@ pub mod fingerprint;
 pub mod jobserver;
 pub mod lifecycle;
 pub mod lineage;
+/// Bounded opt-in tracing file sink (#1165). Gated with `entry` because it is
+/// a `tracing_subscriber` layer and that dependency is optional — the daemon
+/// library is also built by hosts that install their own subscriber.
+#[cfg(feature = "daemon-entry")]
 pub mod log_sink;
 pub(crate) mod process;
 pub mod server;

--- a/crates/zccache-daemon-core/src/daemon/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/mod.rs
@@ -19,6 +19,7 @@ pub mod fingerprint;
 pub mod jobserver;
 pub mod lifecycle;
 pub mod lineage;
+pub mod log_sink;
 pub(crate) mod process;
 pub mod server;
 pub mod side_effect;

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -333,14 +333,35 @@ The test fixture is the `exec_test_tool` binary (built under `--features test-su
 
 ---
 
-## Wrapper fallback policy (`ZCCACHE_FALLBACK`, issue #1211)
+## Daemon unavailable is a hard error (issue #1170)
 
-When the daemon/cache pipeline fails **before request dispatch** (daemon spawn failure, connect timeout, `ZCCACHE_NO_SPAWN` refusal), the wrapper historically ran the tool directly, uncached. That degenerate fallback is now policy-gated at the single chokepoint `wrap/passthrough.rs::run_locally`:
+When the daemon/cache pipeline fails **before request dispatch** (daemon spawn failure, connect timeout, `ZCCACHE_NO_SPAWN` refusal), the wrapper **refuses to run the tool**. There is no uncached fallback.
 
-- **`Error` (the default on every host):** the wrapper refuses the uncached fallback — the tool is never spawned, stderr gets `zccache[err][F]: <reason>; refusing uncached fallback (<policy source>)`, and the compile fails with exit 1. The `wrapper-local-fallback` lifecycle event is still emitted with `outcome:"blocked"` for forensics. Hard-error is the default everywhere (not just CI) because cached artifacts are materialized as **read-only hardlinks** (COW-lite, #1038/#1039): a direct uncached compiler run cannot overwrite them, so the fallback doesn't merely lose the cache — it fails or corrupts the build.
-- **`Warn` (opt-in via `ZCCACHE_FALLBACK=warn`):** yellow `zccache[warn][F]` warning carrying the failure reason, then the tool runs uncached (`outcome:"ran"`). Escape hatch for build trees that never received hardlinked artifacts.
+The removed fallback mirrored the tool's exit code, so a daemon outage that happened to compile fine exited `0` — the build stayed green and the outage was invisible. #1039's read-only hardlinked artifacts made it worse than a lost cache: a direct compiler run cannot overwrite them, so the fallback frequently failed or corrupted the build. `ZCCACHE_FALLBACK` (the #1211 policy gate, which had already defaulted to `Error`) is gone with it.
 
-Post-dispatch transport failures (`FailurePhase::DeliveryUnknown`) were already fail-fast and are unchanged (double-compile hazard). `ZCCACHE_DISABLE=1` passthrough warns (never silent) but stays warn-only — it is a deliberate user opt-out; the probe bypass (`ZCCACHE_PROBE_BYPASS`) stays fully silent because probe callers parse the tool's stderr. The session→ephemeral downgrade and the wedge `DowngradeNoKill` recovery also announce themselves with yellow warnings naming the cause.
+The refusal is loud on three surfaces (`wrap/unavailable.rs`):
+
+- **exit 125** — wrapper-infrastructure failure, the git/env/docker convention, deliberately outside the 1/2 a compiler uses for diagnostics so CI classifies an infra failure from the code alone. This is part of the stable `zccache cc` / `zccache c++` contract.
+- **stderr** — `zccache[err][D]: daemon unavailable at <endpoint> (<reason>); refusing to run <tool> uncached.`
+- **a durable event** — `wrapper-daemon-unavailable`, and the `no-daemon-unavailable` audit rule forbids it in perf and integration runs (a run that hit it did not use the cache, so it measured something else).
+
+**The only sanctioned bypasses**, both explicit and opt-in: `ZCCACHE_DISABLE=1` (full passthrough, never contacts the daemon; warns, never silent) and `ZCCACHE_PROBE_BYPASS` (meson-probe TUs exec directly; fully silent because probe callers parse the tool's stderr). Post-dispatch transport failures (`FailurePhase::DeliveryUnknown`) were already fail-fast and are unchanged — the hazard there is a double compile.
+
+### The bounded recovery ladder
+
+Because unavailability is now fatal, recovery has to be robust *and* bounded (`cli/recovery.rs`):
+
+- **Total deadline** — `ZCCACHE_RECOVERY_BUDGET_MS`, default 30 s, `0` disables. Previously the ladder had no overall cap and the worst case was minutes inside one compile.
+- **Wedge classification on every arm** — a wedge is probed before any kill (#753). A busy daemon under a `-j16` burst is indistinguishable from a hung one from one client's timeout; the wrapper retries once without killing and kills only when the follow-up probe also fails.
+- **Identity-scoped cleanup** — the kill names the instance that failed (#1161), and clears the lock file, `<lock>.spawn`, and the backend identity file together.
+- **Cross-invocation breaker** — the wrapper is a fresh process per TU, so ladder exhaustion writes `<daemon-lock>.spawn-failed`. Invocations inside its cool-down (60 s, doubling, capped at 10 min) fail immediately with the *original* reason, so a 1000-TU build fails in seconds rather than paying the ladder 1000 times. Any successful acquisition clears it; `daemon_spawn_breaker_open` fires once per opening, not per TU.
+
+## Daemon log output (issue #1165)
+
+The daemon's `tracing` output goes to **stderr**, and that is the operational contract: whoever supervises the process (systemd, launchd, a Windows service, a CI runner) owns that stream and is **expected to rotate it**. zccache does not rotate a stream it does not own.
+
+For operators with no such supervisor, `ZCCACHE_LOG_FILE=<path>` adds a **size-capped** file sink alongside stderr — additive, never a redirect, so a supervisor already collecting stderr keeps getting everything. It retains one live file plus one archive, so the footprint is bounded at `2 ×` the cap (`ZCCACHE_LOG_FILE_MAX_BYTES`, default 16 MiB), matching the lifecycle log's retention shape. Writes are best-effort: a failing sink degrades to no file output and never blocks or crashes the daemon.
+
 
 ---
 


### PR DESCRIPTION
The last open item of #1165, and one that appeared in **no comment on the issue** — a repo-wide grep for `ZCCACHE_LOG_FILE` returned zero hits, so it was silently skipped rather than deferred.

## The gap

The daemon's `tracing` output goes to stderr and always has. That is the right default — whoever supervises the process owns its stream — but it left operators with **no bounded option at all**: redirecting stderr to a file yourself grows without limit, and the daemon outlives the shell that started it.

## The change

`ZCCACHE_LOG_FILE=<path>` adds a size-capped file sink **alongside** stderr, never instead of it, so a supervisor already collecting stderr keeps getting everything. It reuses the lifecycle log's rotation shape — one live file plus one archive, footprint bounded at `2 ×` the cap (`ZCCACHE_LOG_FILE_MAX_BYTES`, default 16 MiB) — because that is the retention contract the rest of the daemon's logs already have, and a second rotation policy would be one more thing to reason about.

Design points:

- **Everything is best-effort.** An unwritable path, an unparseable cap, a failing rename — all degrade to "no file output". Diagnostics must never take down the process they are diagnosing; there is a test for the unwritable case specifically.
- **A zero or garbage cap falls back to the default rather than meaning "unbounded"** — unbounded growth is the bug being fixed, so that is the one interpretation the knob must not have.
- **The writer buffers until flush.** `tracing_subscriber` writes an event in several calls, so buffering is what keeps one event on one line instead of interleaving with another thread's.
- **ANSI is off for the file.** Escape codes in a log an operator greps months later are noise.
- The filter is applied once at the registry rather than per layer, so both sinks are guaranteed to agree on what they see.

## Documentation fix included

`docs/architecture/runtime.md` had a section documenting the `ZCCACHE_FALLBACK` policy — **which #1287 removed**. It described behaviour that no longer exists on `main`. Replaced with the hard-error contract (exit 125, the three surfaces, the two sanctioned bypasses), the bounded recovery ladder from #1288, and the stderr-ownership contract this item asks to be written down: *service managers are expected to rotate the daemon's stderr; zccache does not rotate a stream it does not own.*

## Evidence

- `soldr cargo test -p zccache-daemon-core --features "test-support,daemon-entry" --lib log_sink` — **6 passed, 0 failed**: off-unless-configured, cap fallback, rotation actually bounds the live file *and* leaves exactly two files, under-cap keeps one file, unwritable path tolerated, writer buffers until flush.
- `soldr cargo clippy -p zccache-daemon-core --features "test-support,daemon-entry" --all-targets -- -D warnings` — clean.
- `soldr cargo check -p zccache-daemon-core --features "test-support,daemon-entry" --all-targets` — clean.

Note the feature flags: `zccache-daemon-core` needs `test-support,daemon-entry` or a plain `--lib` exits 0 having run nothing.

## After this, #1165 is

| Item | Status |
|---|---|
| 1 — session reaping + `sessions_reaped` event | done (#1285) |
| 2 — per-session `*.jsonl` retention | **not implemented — unsafe as written**, reasoning posted on the issue; needs an owner decision |
| 3 — `audit.jsonl` rotation | done (#1274) |
| 4 — `crashes/` cap | done (#1271) |
| 5 — stderr contract + `ZCCACHE_LOG_FILE` | **this PR** |
| 6 — depfile periodic sweep | done (#1285) |
| 7 — delete `event_log.rs` | done (#1273) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)