### PR TITLE
docs(journal): record session-journal retention as caller-owned (#1165 item 2)

### DIFF
--- a/crates/zccache-depgraph/src/session.rs
+++ b/crates/zccache-depgraph/src/session.rs
@@ -259,6 +259,16 @@ pub struct SessionConfig {
     /// Whether to track per-session statistics.
     pub track_stats: bool,
     /// Path for per-session JSONL compile journal (must end in .jsonl).
+    ///
+    /// **Caller-owned (#1165).** The daemon never defaults this — omit it and
+    /// no per-session journal is written — and it never deletes the file, not
+    /// even on `close_session`. Applying a retention policy would mean the
+    /// daemon unlinking files in a directory the *client* chose, by a filter
+    /// it invented; session journal names have no shared prefix, so any filter
+    /// broad enough to catch real journals could catch unrelated user files.
+    ///
+    /// A caller that mints a fresh path per session must rotate or clean them
+    /// itself. See `docs/journal-schema.md` → "Retention and file ownership".
     pub journal_path: Option<NormalizedPath>,
     /// Issue #256: opt in to the extended journal schema. When true,
     /// the daemon populates crate_name, crate_type, output_ext, and

--- a/docs/journal-schema.md
+++ b/docs/journal-schema.md
@@ -128,6 +128,41 @@ execution, include scanning, and artifact storage. Tokio Console is for live
 Tokio runtime symptoms such as blocked tasks, long polls, wakeups, timers, and
 resource contention.
 
+## Retention and file ownership (issue #1165)
+
+Two different files, two different owners. This is the part that decides who is
+responsible for deleting anything.
+
+**Daemon-owned, bounded by the daemon:**
+
+| File | Bound |
+|---|---|
+| `<cache_dir>/logs/compile_journal.jsonl` | rotated by the journal writer's own size/GC policy |
+| `<cache_dir>/logs/daemon-lifecycle.log` | 1 MiB live + one `.1` archive |
+| `<cache_dir>/logs/audit.jsonl` | 50 MB × 3 files |
+| `<cache_dir>/crashes/` | newest `CRASH_DUMP_KEEP` dumps, `.reported` markers reaped with their dump |
+| `$ZCCACHE_LOG_FILE` (opt-in tracing sink) | `ZCCACHE_LOG_FILE_MAX_BYTES` live + one archive |
+
+**Caller-owned, and deliberately never touched by the daemon:** the per-session
+journal at `SessionConfig.journal_path`.
+
+That path is **supplied by the client** on `SessionStart`, and the daemon never
+defaults it — omit it and no per-session journal is written at all. `close_session`
+therefore drops the handle and leaves the file exactly where the caller asked for
+it.
+
+This is by design, and the alternative was considered and rejected. A retention
+policy here would mean the daemon enumerating a directory *the client chose*
+(`/tmp`, a home directory, a build tree) and unlinking files by a filter it
+invented — session journal names are client-chosen with no shared prefix, so any
+filter broad enough to catch real journals is broad enough to catch unrelated
+user files. Bounding one small JSONL per session is not worth a mechanism that
+can delete outside the cache root.
+
+**If you pass `journal_path`, you own retention.** A caller that mints a fresh
+path per session (a CI job, a build wrapper) must rotate or clean them itself.
+A caller that reuses one path, or omits it, has nothing to clean.
+
 ## Stability & versioning
 
 The journal is **additive-by-default**: new optional fields may appear in


### PR DESCRIPTION
The last open item of #1165, resolved **as by-design rather than implemented**. Reasoning was posted on the issue before writing this; nobody has objected, and the code confirms the premise.

## Why not implement it as written

> keep last N (default 20) session files per logs dir, delete older on close

`SessionConfig.journal_path` is **client-supplied, and the daemon never defaults it** — there is no daemon-constructed session-journal path anywhere in the tree. So the literal instruction has the daemon enumerate a directory the *client* chose (`/tmp`, a home directory, a build tree) and unlink files by a filter it invents. Session journal names are client-chosen with no shared prefix, so any filter broad enough to catch real journals is broad enough to catch unrelated user files.

That trades one small leaked JSONL per session for **unbounded deletion outside the cache root** — strictly worse than the bug.

There is also no leak in the default configuration: omit `journal_path` and no per-session journal is written at all. The growth exists only for callers that mint a fresh path per session, in a directory they own.

## What this does instead

States the boundary in the two places a caller will actually hit it:

- **On the field itself** (`SessionConfig::journal_path`) — the daemon never defaults it and never deletes it, why a retention policy there would be unsafe, and that a caller minting a path per session owns rotation.
- **In `docs/journal-schema.md`**, in a new "Retention and file ownership" section — a table of every **daemon-owned** log and its bound, next to the one caller-owned file and why it is different.

The table is worth having on its own: it is the first place the full retention picture is written down, and every row in it is bounded as of #1271 (`crashes/`), #1274 (`audit.jsonl`), #1285 (session state, depfile dirs) and #1289 (`ZCCACHE_LOG_FILE`).

## Evidence

- `soldr cargo check -p zccache-depgraph --all-targets` — clean.
- `soldr cargo fmt --all` — clean.
- Docs-only plus one doc comment; no behaviour change.

**With this, every item of #1165 is resolved** — 5 implemented, 1 disposed of with rationale. Closing the issue once this merges.

If the owner would rather have the daemon own session journals by default (`<cache_root>/logs/sessions/<session_id>.jsonl`, pruned within the cache root only), that is a coherent alternative — it moves where `zccache analyze` points, so it is a product decision, and I would rather surface it than quietly make it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)