### PR TITLE
fix(daemon): observe the index-writer sends instead of discarding them (#1177)

### DIFF
--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -73,6 +73,7 @@
 //! | `native_flag_host_salted` | daemon | a `native` CPU-selection flag made the compile key host-specific | `compiler_family` |
 //! | `time_macro_noncacheable` | daemon | a C/C++ time macro bypassed the compile cache | `source`, `input`, `macro_name` |
 //! | `system_include_discovery_empty` | daemon | a C/C++ include probe returned no paths, so its compile bypassed the cache | `compiler`, `reason` |
+//! | `index_writer_gone` (#1177) | daemon | an index insert could not be handed to the index writer; published artifacts are no longer durably recorded | `artifact_key`, `consequence` |
 //! | `background_task_died` (#1177) | daemon | a supervised background loop stopped unexpectedly; periodic work it owned has stopped happening | `task`, `reason`, `restarts`, `restartable` |
 //! | `background_task_restarted` (#1177) | daemon | a supervised background loop was brought back after an unexpected stop | `task`, `restarts` |
 //! | `watcher_degraded` | daemon | the file watcher could not be armed, disabling both fast hit tiers | `reason`, `degradations` |
@@ -228,6 +229,14 @@ pub const EVENT_COW_BLOB_CORRUPTION_DETECTED: &str = "cow_blob_corruption_detect
 pub const EVENT_NATIVE_FLAG_HOST_SALTED: &str = "native_flag_host_salted";
 pub const EVENT_TIME_MACRO_NONCACHEABLE: &str = "time_macro_noncacheable";
 pub const EVENT_SYSTEM_INCLUDE_DISCOVERY_EMPTY: &str = "system_include_discovery_empty";
+/// The index-writer task is gone, so published artifacts are no longer being
+/// recorded durably (#1177).
+///
+/// The cache is effectively write-only from this point: every artifact it
+/// publishes is invisible to the next daemon start. Emitted once per daemon —
+/// the condition is permanent, so an event per compile would turn one fault
+/// into an unbounded log.
+pub const EVENT_INDEX_WRITER_GONE: &str = "index_writer_gone";
 /// A supervised background loop stopped unexpectedly (#1177).
 ///
 /// Every periodic task used to be a bare `tokio::spawn` with a dropped
@@ -291,6 +300,7 @@ pub const EVENT_ALL: &[&str] = &[
     EVENT_NATIVE_FLAG_HOST_SALTED,
     EVENT_TIME_MACRO_NONCACHEABLE,
     EVENT_SYSTEM_INCLUDE_DISCOVERY_EMPTY,
+    EVENT_INDEX_WRITER_GONE,
     EVENT_BACKGROUND_TASK_DIED,
     EVENT_BACKGROUND_TASK_RESTARTED,
     EVENT_WATCHER_DEGRADED,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
@@ -216,7 +216,19 @@ fn enqueue_persisted_index(
     let Some(meta) = outcome.meta else {
         return false;
     };
-    let _ = index_writer_tx.send(IndexWriterCommand::Insert(key_hex, meta));
+    // #1177: this send only fails when the index writer is gone, which means
+    // the daemon has silently stopped recording what it caches. `enqueue`
+    // needs the state to bound the report, so the one call site that has only
+    // the sender keeps the raw send and its own report.
+    if index_writer_tx
+        .send(IndexWriterCommand::Insert(key_hex.clone(), meta))
+        .is_err()
+    {
+        tracing::error!(
+            artifact_key = %key_hex,
+            "index writer is gone; persisted artifact will not survive a daemon restart"
+        );
+    }
     true
 }
 
@@ -374,9 +386,7 @@ fn store_rustc_outputs(
                         ))
                     })?;
                 } else {
-                    let _ = state_for_publish
-                        .index_writer_tx
-                        .send(IndexWriterCommand::Insert(key_hex, meta.clone()));
+                    enqueue_index_insert(state_for_publish.as_ref(), key_hex, meta.clone());
                 }
                 Ok::<_, std::io::Error>((snapshot, meta))
             })
@@ -469,10 +479,7 @@ fn store_rustc_outputs(
                     Err(reason) => (Some(reason), 0),
                 }
             } else {
-                let _ = state.index_writer_tx.send(IndexWriterCommand::Insert(
-                    artifact_key_hex.to_string(),
-                    meta.clone(),
-                ));
+                enqueue_index_insert(state, artifact_key_hex.to_string(), meta.clone());
                 (None, 0)
             };
             if let Some(reason) = index_failure {
@@ -723,10 +730,7 @@ fn store_single_output(
                 }
             };
         if written && !staged_publication {
-            let _ = state.index_writer_tx.send(IndexWriterCommand::Insert(
-                key_hex.clone(),
-                persist_meta.clone(),
-            ));
+            enqueue_index_insert(state, key_hex.clone(), persist_meta.clone());
         }
         stats.persist_enqueue_ns = t_persist_enqueue.elapsed().as_nanos() as u64;
         if written {

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -288,6 +288,7 @@ pub(super) fn new_shared_state(
             artifact_store_loaded: AtomicBool::new(false),
             shutdown_event_logged: AtomicBool::new(false),
             shutdown_requested: AtomicBool::new(false),
+            index_writer_gone: AtomicBool::new(false),
             fingerprint: FingerprintManager::new(),
             dep_graph_persisted: AtomicBool::new(false),
             dep_graph_load_complete: AtomicBool::new(true),

--- a/crates/zccache-daemon-core/src/daemon/server/staged_publish.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/staged_publish.rs
@@ -22,6 +22,41 @@ pub(super) fn record_staged_publication_failure(state: &SharedState, reason: Sta
     }
 }
 
+/// Hand an index insert to the index writer, observing the send result.
+///
+/// #1177 Part A: three call sites did `let _ = index_writer_tx.send(..)`. That
+/// send only fails when the index-writer task is **gone**, which means the
+/// daemon has silently stopped durably recording anything it caches — every
+/// artifact it publishes from that moment on is invisible to the next daemon
+/// start, so the cache is quietly write-only. The old spelling made that
+/// indistinguishable from success.
+///
+/// Reported once per daemon rather than once per compile: the condition is
+/// permanent (the receiver does not come back), so an event per compile would
+/// turn one fault into an unbounded log. The first occurrence carries the
+/// artifact key so the failure has a concrete anchor.
+pub(super) fn enqueue_index_insert(state: &SharedState, key: String, metadata: ArtifactIndex) {
+    if state
+        .index_writer_tx
+        .send(IndexWriterCommand::Insert(key.clone(), metadata))
+        .is_err()
+        && !state.index_writer_gone.swap(true, Ordering::AcqRel)
+    {
+        tracing::error!(
+            artifact_key = %key,
+            "index writer is gone; published artifacts are no longer being recorded \
+             durably and will not survive a daemon restart"
+        );
+        crate::core::lifecycle::write_event(
+            crate::core::lifecycle::EVENT_INDEX_WRITER_GONE,
+            serde_json::json!({
+                "artifact_key": key,
+                "consequence": "published artifacts are not durably indexed",
+            }),
+        );
+    }
+}
+
 pub(super) fn send_staged_index_insert(
     state: &SharedState,
     key: String,

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -526,6 +526,10 @@ pub(super) struct SharedState {
     /// instead of consuming the public shutdown Notify, so legacy
     /// `shutdown_handle().notify_one()` callers still wake the accept loop.
     pub(super) shutdown_requested: AtomicBool,
+    /// Latched when an index-writer send fails, i.e. the writer task is gone
+    /// (#1177). The condition is permanent — the receiver does not come back —
+    /// so this bounds the report to one per daemon instead of one per compile.
+    pub(super) index_writer_gone: AtomicBool,
     /// Fingerprint manager: tracks per-watch dirty state for `zccache fp` commands.
     pub(super) fingerprint: FingerprintManager,
     /// Whether the in-memory dep graph is backed by a persisted snapshot.

--- a/crates/zccache-daemon-core/src/daemon/server/tests/index_writer_gone.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/index_writer_gone.rs
@@ -1,0 +1,67 @@
+//! #1177: an index insert that cannot reach the index writer must be observed.
+//!
+//! The send only fails when the writer task is gone, and that means the daemon
+//! has silently stopped recording what it caches — every artifact published
+//! from then on is invisible to the next daemon start, so the cache is
+//! effectively write-only. `let _ = tx.send(..)` made that indistinguishable
+//! from success, which is the whole point of the finding.
+
+use std::sync::atomic::Ordering;
+
+use crate::daemon::server::staged_publish::enqueue_index_insert;
+
+use super::CacheDirEnvGuard;
+
+/// Build metadata whose contents do not matter — the test is about the send
+/// path, not the payload.
+fn dummy_meta() -> crate::artifact::ArtifactIndex {
+    crate::artifact::ArtifactIndex::new(
+        vec!["out.o".to_string()],
+        vec![1],
+        Vec::new(),
+        Vec::new(),
+        0,
+    )
+}
+
+fn index_writer_gone_rows(log: &str) -> usize {
+    log.lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter(|event| event["event"] == crate::core::lifecycle::EVENT_INDEX_WRITER_GONE)
+        .count()
+}
+
+/// A dead index writer is reported once, loudly — and only once, because the
+/// condition is permanent and an event per compile would turn one fault into
+/// an unbounded log (the very growth #1165 was about).
+#[tokio::test]
+async fn a_dead_index_writer_is_reported_once_not_once_per_compile() {
+    let root = tempfile::tempdir().unwrap();
+    let _cache_env = CacheDirEnvGuard::set(root.path());
+    let server = super::bind_isolated_server(root.path());
+    let state = std::sync::Arc::clone(&server.state);
+
+    // Drop the receiving half: this is exactly the state the daemon is in
+    // after the index-writer task dies.
+    drop(server);
+
+    let before = std::fs::read_to_string(crate::core::lifecycle::log_file_path())
+        .map(|log| index_writer_gone_rows(&log))
+        .unwrap_or(0);
+
+    for index in 0..3 {
+        enqueue_index_insert(&state, format!("key-{index}"), dummy_meta());
+    }
+
+    assert!(
+        state.index_writer_gone.load(Ordering::Acquire),
+        "a failed send must latch the degraded flag"
+    );
+    let log = std::fs::read_to_string(crate::core::lifecycle::log_file_path())
+        .expect("the failure must be durably recorded");
+    assert_eq!(
+        index_writer_gone_rows(&log) - before,
+        1,
+        "three failed sends must produce exactly one event, not three"
+    );
+}

--- a/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
@@ -19,6 +19,7 @@ mod embedded_flush;
 mod exec_probe;
 mod fingerprint;
 mod fs_matrix;
+mod index_writer_gone;
 mod link_cache;
 mod metadata_deferred;
 mod multi_restart_context_key;


### PR DESCRIPTION
Unblocks **Part A** of #1177.

## The blocked decision

The issue's own comment thread identified three `let _ = index_writer_tx.send(..)` sites in `miss_store.rs` as a precondition for the `ban_discarded_write_result` lint: it cannot land un-allowlisted while they exist, and allowlisting the file it most needs to cover defeats the point. The decision was recorded and then **never taken either way** — the sites are still there on `main`.

Taking it: fix them.

## Why they matter

That send fails only when the index-writer task is **gone**. When it is, the daemon has silently stopped durably recording what it caches — every artifact it publishes from that moment on is invisible to the next daemon start, so the cache is effectively **write-only while still reporting success**. `let _ =` made that indistinguishable from a send that worked, which is precisely the class of defect the lint exists to catch.

## The fix

`enqueue_index_insert` sends and, on failure, latches a flag and reports **once per daemon**:

- The receiver does not come back, so the condition is permanent. An event per compile would turn one fault into an unbounded log — the exact growth mode #1165 spent a whole issue removing.
- The first occurrence carries the artifact key, so the failure has a concrete anchor rather than being a bare "something broke".
- `tracing::error!` **and** a durable `index_writer_gone` event, per the forensics rule, with an explicit `consequence` field — the operator needs to know the cache is not being recorded, not just that a channel closed.

One of the three call sites keeps a raw send: it holds only the sender, not the state needed to bound the report. It logs its own error rather than pretending the send succeeded.

## Test

`a_dead_index_writer_is_reported_once_not_once_per_compile` drops the receiving half — exactly the state the daemon is in after the writer task dies — then enqueues three inserts and asserts the flag latches and **exactly one** event is written, not three. It measures the *delta* in row count rather than a total, since the lifecycle log path is process-global.

## Evidence

- `soldr cargo test -p zccache-daemon-core --features "test-support,daemon-entry" --lib` — **704 passed, 0 failed**, 25 ignored.
- `soldr cargo test -p zccache-core --lib lifecycle` — 13 passed (catalog + schema row for `index_writer_gone`).
- `soldr cargo clippy -p zccache-daemon-core -p zccache-core --features "test-support,daemon-entry" --all-targets -- -D warnings` — clean.
- `soldr cargo check -p zccache-daemon-core` (**default features**) — clean.

## What remains on #1177

- **Part A proper** — the `ban_discarded_write_result` dylint crate plus its four registration points. Now unblocked: with these sites fixed it can land without allowlisting `miss_store.rs`.
- **B7's `Status` field** — a wire change needing a `PROTOCOL_VERSION` bump; the durable event added here already makes the condition observable, so the Status surface is an addition rather than the only signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)