### PR TITLE
lint(dylint): add ban_discarded_write_result (#1177 Part A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,14 @@ jobs:
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_dashmap_guard_across_blocking/Cargo.toml
+      - name: Check Dylint Library Formatting (ban_discarded_write_result)
+        run: soldr cargo fmt --manifest-path dylints/ban_discarded_write_result/Cargo.toml --all -- --check
+      - name: Test Dylint Library (ban_discarded_write_result)
+        run: |
+          export PATH="${DYLINT_CARGO_SHIM}:${PATH}"
+          export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
+          export RUSTUP_TOOLCHAIN=nightly-2026-05-26
+          soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_discarded_write_result/Cargo.toml
       - name: Run Dylint
         run: |
           export PATH="${CARGO_HOME}/bin:${PATH}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ exclude = [
     "dylints/ban_legacy_artifact_path",
     "dylints/ban_normalized_path_deref_containment",
     "dylints/ban_dashmap_guard_across_blocking",
+    "dylints/ban_discarded_write_result",
 ]
 
 [workspace.package]

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -292,6 +292,8 @@ def lint_workspace():
             "dylints/ban_raw_subprocess_in_daemon/Cargo.toml",
             "dylints/ban_legacy_artifact_path/Cargo.toml",
             "dylints/ban_normalized_path_deref_containment/Cargo.toml",
+            "dylints/ban_dashmap_guard_across_blocking/Cargo.toml",
+            "dylints/ban_discarded_write_result/Cargo.toml",
         ):
             result = run_cmd(cargo_command(
                 "fmt",

--- a/dylints/README.md
+++ b/dylints/README.md
@@ -8,8 +8,10 @@ Custom Rust lints used by this workspace.
 - `ban_tmp_literal`: bans hardcoded `/tmp` path string literals — they only exist on POSIX (#828).
 - `ban_legacy_artifact_path`: bans ad-hoc reconstruction of the flat-v1 `<key>_<index>` artifact filename convention outside the artifact-layout owner.
 - `ban_normalized_path_deref_containment`: bans `std::path::Path` containment methods (`starts_with`, `strip_prefix`) resolved through `NormalizedPath`'s `Deref` autoderef instead of its inherent normalized methods.
+- `ban_dashmap_guard_across_blocking`: bans holding a `DashMap::get` guard across awaits, filesystem/process work, or a mutation of the same map.
+- `ban_discarded_write_result`: bans discarding the `Result` of a write-ish call (`let _ = …` / statement-position `.ok();`) in the daemon's persistence modules (#1163 / #1177).
 
-All six libraries use the published Dylint 6.0.1 crates and the pinned
+All eight libraries use the published Dylint 6.0.1 crates and the pinned
 `nightly-2026-05-26` toolchain. The supported `cargo-dylint` driver is used
 directly; no custom driver checkout or library alias repair is required.
 

--- a/dylints/ban_discarded_write_result/Cargo.toml
+++ b/dylints/ban_discarded_write_result/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ban_discarded_write_result"
+version = "0.1.0"
+description = "Ban discarded Results from write-ish calls in daemon persistence code"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# Match the dylint_linting pin used by the sibling dylints — same toolchain
+# (rust-toolchain.toml here), same upstream commit.
+dylint_linting = "6.0.1"
+
+[dev-dependencies]
+dylint_testing = "6.0.1"
+
+[package.metadata.rust-analyzer]
+rustc_private = true
+
+[workspace]

--- a/dylints/ban_discarded_write_result/README.md
+++ b/dylints/ban_discarded_write_result/README.md
@@ -1,0 +1,52 @@
+# ban_discarded_write_result
+
+This Dylint rejects a `Result` from a write-ish call being thrown away in the
+daemon's persistence paths — either via `let _ = <write call>;` or via a
+statement-position `<write call>.ok();`.
+
+The bug class is #1163: `miss_store.rs` sent artifact-index records with
+`let _ = …index_writer_tx.send(…)` and then unconditionally recorded the
+artifact as cached. If the send failed, the artifact never reached
+`index.bin` and the next daemon start re-missed it — silently. The same
+shape applies to a dropped `write`/`rename`/`persist`/`flush`: the caller
+proceeds as if durable state was written when it was not.
+
+## Scope
+
+Only the daemon's state-mutation modules are checked (see
+`DAEMON_SOURCE_PREFIXES` in `src/lib.rs`):
+
+- `crates/zccache-daemon-core/src/daemon/server/persist/`
+- `crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs`
+- `crates/zccache-daemon-core/src/daemon/server/wal.rs`
+
+Files under a `tests/` directory or named `*_tests.rs` are out of scope.
+
+## Callee names
+
+The matched set is deliberately tight so the lint does not drown in
+false positives from best-effort cleanup:
+
+`write`, `write_all`, `send`, `rename`, `persist`, `flush`, `sync_all`,
+`set_len`.
+
+Cleanup-shaped calls (`remove_file`, `remove_dir_all`, `set_readonly`) are
+intentionally **not** matched — discarding those is the normal idiom on an
+already-failing path.
+
+## Fixing a hit
+
+Propagate the error with `?`, or handle it explicitly and gate the
+follow-on state mutation on success:
+
+```rust
+if let Err(error) = tx.send(record) {
+    tracing::warn!(%error, "artifact index record dropped");
+    return Err(error.into());
+}
+state.artifacts.insert(key, entry);
+```
+
+If a site is genuinely fire-and-forget, add its path tail to
+`src/allowlist.txt` **with a comment explaining why the dropped error is
+safe**.

--- a/dylints/ban_discarded_write_result/rust-toolchain.toml
+++ b/dylints/ban_discarded_write_result/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2026-05-26"
+components = ["llvm-tools-preview", "rust-src", "rustc-dev"]

--- a/dylints/ban_discarded_write_result/src/README.md
+++ b/dylints/ban_discarded_write_result/src/README.md
@@ -1,0 +1,17 @@
+# Source
+
+`lib.rs` holds the whole lint. Detection is two shapes:
+
+1. `check_local` — `let _ = <expr>;` (a wildcard pattern) whose initializer
+   type is `core::result::Result`.
+2. `check_stmt` — a statement-position `<expr>.ok();` whose receiver type is
+   `core::result::Result`.
+
+In both cases the discarded expression is walked (bodies of nested closures
+are not entered) looking for a call whose callee name is in
+`WRITE_CALLEE_NAMES`. Only then does the lint fire.
+
+`allowlist.txt` is `include_str!`-embedded and matched against the tail of the
+source path with slashes normalized — the same mechanism as
+`ban_tmp_literal`. Every entry carries a comment justifying the dropped
+error.

--- a/dylints/ban_discarded_write_result/src/allowlist.txt
+++ b/dylints/ban_discarded_write_result/src/allowlist.txt
@@ -1,0 +1,50 @@
+# Each non-empty, non-comment line is matched against the tail of each source
+# file path (slashes normalized). Same mechanism as ban_tmp_literal.
+#
+# DO NOT add an entry without an inline comment explaining why the dropped
+# error is safe — i.e. why no caller proceeds as if durable state landed.
+# The default fix is to propagate with `?`, or to handle the error and gate
+# the follow-on state mutation on success.
+#
+# NOT allowlisted on purpose:
+#   handle_compile/miss_store.rs — the #1163 vector. Its discarded
+#   index-writer sends were fixed on main (PR #1292); the file stays in scope
+#   so the shape cannot re-enter.
+
+# ── Rollback on an already-failing path ─────────────────────────────────────
+# `AuthoritativeDigestRollback::restore_on_failure` re-writes the previous
+# digest sidecar after the persist it guards has already failed; the caller
+# is returning that original error either way. A failed restore degrades to
+# the verify-and-heal path on next read, so nothing downstream treats the
+# rollback as durable.
+crates/zccache-daemon-core/src/daemon/server/persist/artifact_io.rs
+
+# `replace_directory`'s non-Linux/macOS arm renames a backup directory back
+# into place only after `rename(staged, requested)` already failed, and then
+# returns that original error. The restore is best-effort by construction.
+crates/zccache-daemon-core/src/daemon/server/persist/directory_bundle.rs
+
+# ── Best-effort durability hint ─────────────────────────────────────────────
+# `directory.sync_all()` after a successful `replace_path` is a parent-dir
+# fsync hint; the enclosing code already treats failure to even open the
+# parent as acceptable (`if let Ok(directory) = ...`). The artifact is
+# content-addressed and reconstructible, so a lost dir-fsync costs a
+# re-materialize, not a wrong answer. Borderline — revisit if staged paths
+# ever become the authoritative record.
+crates/zccache-daemon-core/src/daemon/server/persist/staged_paths.rs
+
+# ── Test-orchestration channels ─────────────────────────────────────────────
+# `hook.rs` is the deterministic staged-pipeline pause hook used by race
+# tests. Its `send`/`try_send` peers are legitimately gone once the test
+# guard drops, and no persistence decision is made from the result. The
+# module is `#[cfg(test)]`, so this entry only matters for a local
+# `--all-targets` run; CI's `cargo dylint --all --workspace` never reaches it.
+crates/zccache-daemon-core/src/daemon/server/persist/staged_store/hook.rs
+
+# ── Intentional shutdown acks ───────────────────────────────────────────────
+# `wal.rs`'s `ack.send(())` replies target oneshot receivers that the caller
+# may have already abandoned (flush timeout, shutdown drain). The WAL state
+# is committed before the ack, so a dropped ack loses nothing durable. This
+# file must be allowlisted because `send` is deliberately in the matched
+# name set.
+crates/zccache-daemon-core/src/daemon/server/wal.rs

--- a/dylints/ban_discarded_write_result/src/lib.rs
+++ b/dylints/ban_discarded_write_result/src/lib.rs
@@ -1,0 +1,260 @@
+#![feature(rustc_private)]
+
+extern crate rustc_errors;
+extern crate rustc_hir;
+extern crate rustc_span;
+
+use rustc_errors::DiagDecorator;
+use rustc_hir::intravisit::{self, Visitor};
+use rustc_hir::{Expr, ExprKind, PatKind, QPath, Stmt, StmtKind};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_span::{symbol::Symbol, FileName, RemapPathScopeComponents, Span};
+
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// In the daemon's persistence modules, rejects a `Result` produced by a
+    /// write-ish call that is thrown away — either `let _ = <write call>;`
+    /// or a statement-position `<write call>.ok();`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// This is the #1163 bug class. `miss_store.rs` published artifact-index
+    /// records with `let _ = …index_writer_tx.send(…)` and then
+    /// unconditionally recorded the artifact as cached. When the send failed
+    /// the record never reached `index.bin`, so the next daemon start
+    /// re-missed the artifact — with no error anywhere. A dropped
+    /// `write`/`rename`/`persist`/`flush` has the same shape: the caller
+    /// proceeds as though durable state landed when it did not.
+    ///
+    /// ### Known problems
+    ///
+    /// Genuinely fire-and-forget sites (rollback on an already-failing path,
+    /// best-effort durability hints, test-orchestration channels) are
+    /// exempted per file via `src/allowlist.txt`, each with a comment
+    /// justifying the dropped error.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore
+    /// let _ = index_writer_tx.send(record);
+    /// state.artifacts.insert(key, entry);
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```rust,ignore
+    /// if let Err(error) = index_writer_tx.send(record) {
+    ///     tracing::warn!(%error, "artifact index record dropped");
+    ///     return Err(error.into());
+    /// }
+    /// state.artifacts.insert(key, entry);
+    /// ```
+    pub BAN_DISCARDED_WRITE_RESULT,
+    Deny,
+    "ban discarding the Result of a write-ish call in daemon persistence code"
+}
+
+/// Callee names whose dropped `Result` means durable state may silently not
+/// exist. Kept deliberately tight: cleanup-shaped calls (`remove_file`,
+/// `remove_dir_all`, `set_readonly`) are *not* listed, because discarding
+/// those on an already-failing path is the normal idiom and listing them
+/// would drown the real signal. `send` is listed on purpose — it is the
+/// #1163 vector.
+const WRITE_CALLEE_NAMES: &[&str] = &[
+    "write",
+    "write_all",
+    "send",
+    "rename",
+    "persist",
+    "flush",
+    "sync_all",
+    "set_len",
+];
+
+/// Only the daemon's state-mutation modules are in scope. Every entry is
+/// verified to exist by `ci/check_dylint_wiring.py`.
+const DAEMON_SOURCE_PREFIXES: &[&str] = &[
+    "crates/zccache-daemon-core/src/daemon/server/persist/",
+    "crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs",
+    "crates/zccache-daemon-core/src/daemon/server/wal.rs",
+];
+
+const ALLOWLIST: &str = include_str!("allowlist.txt");
+
+impl<'tcx> LateLintPass<'tcx> for BanDiscardedWriteResult {
+    fn check_stmt(&mut self, cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'tcx>) {
+        if !in_scope(cx, stmt.span) {
+            return;
+        }
+        match stmt.kind {
+            // Shape 1: `let _ = <expr>;`
+            StmtKind::Let(local) => {
+                if !matches!(local.pat.kind, PatKind::Wild) {
+                    return;
+                }
+                let Some(init) = local.init else {
+                    return;
+                };
+                if !is_result_ty(cx, init) {
+                    return;
+                }
+                if let Some(name) = find_write_callee(init) {
+                    emit_lint(cx, stmt.span, name, "let _ =");
+                }
+            }
+            // Shape 2: statement-position `<expr>.ok();`
+            StmtKind::Semi(expr) => {
+                let ExprKind::MethodCall(segment, receiver, _, _) = expr.kind else {
+                    return;
+                };
+                if segment.ident.name.as_str() != "ok" {
+                    return;
+                }
+                if !is_result_ty(cx, receiver) {
+                    return;
+                }
+                if let Some(name) = find_write_callee(receiver) {
+                    emit_lint(cx, stmt.span, name, ".ok();");
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn emit_lint(cx: &LateContext<'_>, span: Span, callee: Symbol, shape: &str) {
+    // Keep the substring "ui" out of this message: compiletest normalizes the
+    // UI-fixture directory name and would rewrite it to `$DIR` mid-word.
+    let message = format!(
+        "`{shape}` discards the `Result` of `{callee}`; durable state may silently not exist. \
+         Propagate with `?`, or handle the error and gate the follow-on state mutation on \
+         success. If the site is fire-and-forget by design, add its path to \
+         `dylints/ban_discarded_write_result/src/allowlist.txt` with a justifying comment"
+    );
+    cx.opt_span_lint(
+        BAN_DISCARDED_WRITE_RESULT,
+        Some(span),
+        DiagDecorator(move |diag| {
+            diag.primary_message(message.clone());
+        }),
+    );
+}
+
+/// Walks the discarded expression looking for a write-ish callee. Nested
+/// bodies (closures, async blocks) are not entered — the default
+/// `NestedFilter` is `None` — so a discarded outer `Result` is never blamed
+/// on a write buried in an unrelated closure.
+struct WriteCalleeFinder {
+    found: Option<Symbol>,
+}
+
+impl<'tcx> Visitor<'tcx> for WriteCalleeFinder {
+    fn visit_expr(&mut self, expr: &'tcx Expr<'tcx>) {
+        if self.found.is_some() {
+            return;
+        }
+        if let Some(name) = callee_name(expr) {
+            if WRITE_CALLEE_NAMES.contains(&&*name.as_str()) {
+                self.found = Some(name);
+                return;
+            }
+        }
+        intravisit::walk_expr(self, expr);
+    }
+}
+
+fn find_write_callee<'tcx>(expr: &'tcx Expr<'tcx>) -> Option<Symbol> {
+    let mut finder = WriteCalleeFinder { found: None };
+    finder.visit_expr(expr);
+    finder.found
+}
+
+fn callee_name(expr: &Expr<'_>) -> Option<Symbol> {
+    match expr.kind {
+        ExprKind::MethodCall(segment, ..) => Some(segment.ident.name),
+        ExprKind::Call(callee, _) => match callee.kind {
+            ExprKind::Path(ref qpath) => last_segment_name(qpath),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn last_segment_name(qpath: &QPath<'_>) -> Option<Symbol> {
+    match qpath {
+        QPath::Resolved(_, path) => path.segments.last().map(|segment| segment.ident.name),
+        QPath::TypeRelative(_, segment) => Some(segment.ident.name),
+    }
+}
+
+fn is_result_ty<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> bool {
+    cx.typeck_results()
+        .expr_ty(expr)
+        .peel_refs()
+        .ty_adt_def()
+        .is_some_and(|definition| {
+            cx.tcx
+                .def_path_str(definition.did())
+                .ends_with("result::Result")
+        })
+}
+
+fn in_scope(cx: &LateContext<'_>, span: Span) -> bool {
+    let normalized = normalize_slashes(&source_filename(cx, span));
+
+    // UI fixtures live beside this lint rather than beneath the daemon crate.
+    // Keeping that narrow exception lets the UI test exercise the real
+    // matcher without relaxing the production scope.
+    let is_ui_fixture = normalized.starts_with("ui/") || normalized.contains("/ui/");
+    if !is_ui_fixture
+        && !DAEMON_SOURCE_PREFIXES
+            .iter()
+            .any(|prefix| normalized.contains(prefix))
+    {
+        return false;
+    }
+    if normalized.contains("/tests/") || normalized.ends_with("_tests.rs") {
+        return false;
+    }
+    !is_allowlisted(&normalized)
+}
+
+fn is_allowlisted(normalized: &str) -> bool {
+    ALLOWLIST
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .any(|allowed| normalized.ends_with(allowed))
+}
+
+fn source_filename(cx: &LateContext<'_>, span: Span) -> String {
+    match cx.sess().source_map().span_to_filename(span) {
+        FileName::Real(real_filename) => real_filename
+            .local_path()
+            .map(|path| path.to_string_lossy().into_owned())
+            .unwrap_or_else(|| {
+                real_filename
+                    .path(RemapPathScopeComponents::DIAGNOSTICS)
+                    .to_string_lossy()
+                    .into_owned()
+            }),
+        filename => filename
+            .display(RemapPathScopeComponents::DIAGNOSTICS)
+            .to_string(),
+    }
+}
+
+fn normalize_slashes(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+#[cfg(test)]
+mod ui_test_support {
+    include!("../../ui_test_support.rs");
+}
+
+#[test]
+fn ui() {
+    ui_test_support::run(env!("CARGO_PKG_NAME"), env!("CARGO_MANIFEST_DIR"));
+}

--- a/dylints/ban_discarded_write_result/ui/README.md
+++ b/dylints/ban_discarded_write_result/ui/README.md
@@ -1,0 +1,13 @@
+# UI tests
+
+`*.rs` here are minimal programs that exercise specific lint behavior. For
+each, `dylint_testing::ui_test` compiles the file and asserts the resulting
+diagnostics match the adjacent `*.stderr` snapshot.
+
+- `disallowed.rs` — must trigger on `let _ = std::fs::write(..)`,
+  `let _ = tx.send(..)`, and a statement-position
+  `std::fs::rename(..).ok();`.
+- `allowed.rs` — the gated-on-success `if let Err(e) = write(..)` form, a
+  discarded non-`Result` (`println!`), a discarded non-write `Result`
+  (`parse`), and `let _ = std::fs::remove_file(..)` (cleanup names are not
+  in the matched set) must NOT trigger.

--- a/dylints/ban_discarded_write_result/ui/allowed.rs
+++ b/dylints/ban_discarded_write_result/ui/allowed.rs
@@ -1,0 +1,21 @@
+fn gated() -> std::io::Result<()> {
+    // The gated-on-success form is the fix; it must not fire.
+    if let Err(error) = std::fs::write("a", b"b") {
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn main() {
+    let _ = gated();
+
+    // Discarding a non-`Result` is fine.
+    let _ = println!("hello");
+
+    // Discarding a non-write `Result` is out of the matched name set.
+    let s = "7";
+    let _ = s.parse::<u8>();
+
+    // Cleanup-shaped names are deliberately not matched.
+    let _ = std::fs::remove_file("a");
+}

--- a/dylints/ban_discarded_write_result/ui/disallowed.rs
+++ b/dylints/ban_discarded_write_result/ui/disallowed.rs
@@ -1,0 +1,10 @@
+use std::sync::mpsc;
+
+fn main() {
+    let _ = std::fs::write("a", b"b");
+
+    let (tx, _rx) = mpsc::channel::<u8>();
+    let _ = tx.send(1);
+
+    std::fs::rename("a", "b").ok();
+}

--- a/dylints/ban_discarded_write_result/ui/disallowed.stderr
+++ b/dylints/ban_discarded_write_result/ui/disallowed.stderr
@@ -1,0 +1,22 @@
+error: `let _ =` discards the `Result` of `write`; durable state may silently not exist. Propagate with `?`, or handle the error and gate the follow-on state mutation on success. If the site is fire-and-forget by design, add its path to `dylints/ban_discarded_write_result/src/allowlist.txt` with a justifying comment
+  --> $DIR/disallowed.rs:4:5
+   |
+LL |     let _ = std::fs::write("a", b"b");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[deny(ban_discarded_write_result)]` on by default
+
+error: `let _ =` discards the `Result` of `send`; durable state may silently not exist. Propagate with `?`, or handle the error and gate the follow-on state mutation on success. If the site is fire-and-forget by design, add its path to `dylints/ban_discarded_write_result/src/allowlist.txt` with a justifying comment
+  --> $DIR/disallowed.rs:7:5
+   |
+LL |     let _ = tx.send(1);
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: `.ok();` discards the `Result` of `rename`; durable state may silently not exist. Propagate with `?`, or handle the error and gate the follow-on state mutation on success. If the site is fire-and-forget by design, add its path to `dylints/ban_discarded_write_result/src/allowlist.txt` with a justifying comment
+  --> $DIR/disallowed.rs:9:5
+   |
+LL |     std::fs::rename("a", "b").ok();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Part A of #1177. Unblocked by #1292, which fixed the three discarded index-writer sends the issue recorded as a precondition.

## What it bans

`let _ = <write-ish call>` and statement-position `.ok();` in the daemon's persistence modules. That spelling is how #1163 hid a lost index insert: the send failed, nothing observed it, and the daemon reported success while its durable state silently did not exist.

## Two deliberate narrowings

**Name set.** Eight calls whose failure means durable state may not exist: `write`, `write_all`, `send`, `rename`, `persist`, `flush`, `sync_all`, `set_len`. The issue's wider set (`remove_file`, `remove_dir_all`, `create_dir_all`, `insert`, `save`, …) was left out on purpose — it fires on ~40 legitimate cleanup sites and would have forced exactly the blanket allowlisting that makes a lint decorative.

**Path scope.** `persist/`, `handle_compile/miss_store.rs`, `wal.rs` — following the `*SOURCE_PREFIX*` pattern from `ban_raw_subprocess_in_daemon`. Every prefix is a real path (the wiring checker enforces that).

## The allowlist is load-bearing, not cover

Five entries, each with its justification inline. Running with the allowlist **emptied** produces exactly those five hits and no others — so it suppresses known-safe sites rather than papering over a scope that doesn't hold:

| Site | Why it is safe |
|---|---|
| `persist/artifact_io.rs` | digest-sidecar rollback on an *already-failing* persist; the caller returns the original error either way, and a failed restore degrades to verify-and-heal |
| `persist/directory_bundle.rs` | backup-restore reached only after `rename(staged, requested)` already failed; original error is returned |
| `persist/staged_paths.rs` | parent-dir fsync hint; the code already tolerates failing to *open* the parent. **Annotated as borderline** — the closest thing to a real durability gap found, kept visible rather than waved through |
| `persist/staged_store/hook.rs` | `#[cfg(test)]` pause hook; peers legitimately gone once the test guard drops. Does not fire in CI — entry kept with a comment saying so rather than dropped silently |
| `wal.rs` | shutdown/flush acks to receivers the caller may have abandoned; WAL state is committed *before* the ack. Must be listed because `send` is deliberately in the name set |

**No genuine bugs found.** Two facts worth recording:

- `miss_store.rs` is in scope and **un-allowlisted**, and produces **zero** hits — confirming #1292's fix holds and the #1163 shape cannot re-enter.
- `persist/staged_plan.rs:806-814`, the issue's other "SUSPECTED" site, **no longer exists on main**. That part of the issue is stale.

## Wiring

All four registration points, matching the existing per-library steps verbatim: root `Cargo.toml` exclude, `ci/lint.py` manifest list, `.github/workflows/ci.yml` (fmt + test steps), `dylints/README.md`.

**Also fixed a pre-existing gap**: `ban_dashmap_guard_across_blocking` was missing from both `ci/lint.py` and `dylints/README.md`. The wiring checker cannot catch that — it only asserts a marker string is present — so it had gone unnoticed. Also corrected "All six libraries" → eight.

## Evidence

- `uv run python ci/check_dylint_wiring.py` — exit 0.
- The library's own test suite on the pinned nightly — **3 passed, 0 failed** (`ui/disallowed.rs`, `ui/allowed.rs`, harness). The UI test is **not** `#[ignore]`d, unlike `ban_tmp_literal`, and `disallowed.stderr` is a real captured snapshot.
- Formatting check on the library manifest — clean.
- Workspace check, all targets — clean.
- Lint run against `zccache-daemon-core` (100% of its scope) with the allowlist in place: **0 violations**.

Note `ci/lint.py --dylint-only` skips on Windows by design, so the lint was driven through the dylint driver directly using `dylint_env()`'s semantics. **CI's Ubuntu Dylint job is the authoritative run.**

## After this

#1177's remaining item is B7's `Status` field for index-writer health — a wire change needing a `PROTOCOL_VERSION` bump. The `index_writer_gone` event from #1292 already makes the condition observable, so that is an additional surface rather than the only signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
