### PR TITLE
feat(protocol): surface index-writer health in DaemonStatus (#1177 B7)

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/status.rs
+++ b/crates/zccache-cli-core/src/cli/commands/status.rs
@@ -136,6 +136,15 @@ pub(crate) async fn cmd_status(endpoint: &str, json: bool) -> ExitCode {
                 };
                 println!("  Watcher:       {watcher}");
             }
+            if s.index_writer_gone {
+                // Worse than a performance cliff: the daemon still serves from
+                // memory, so it looks healthy, but nothing it publishes is
+                // being recorded and none of it survives a restart (#1177).
+                println!(
+                    "  Index writer:  GONE — new artifacts are not being recorded and will \
+                     not survive a restart; restart the daemon"
+                );
+            }
             println!();
             if s.total_links > 0 {
                 println!();

--- a/crates/zccache-daemon-core/src/daemon/compile_journal/tests/outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/tests/outcome.rs
@@ -159,6 +159,7 @@ fn test_extract_outcome_all_non_journalable() {
             dep_graph_persisted: false,
             watcher_active: true,
             watcher_degradations: 0,
+            index_writer_gone: false,
         }),
         Response::LookupResult(LR::Miss),
         Response::StoreResult(SR::Stored),

--- a/crates/zccache-daemon-core/src/daemon/server/connection/dispatch.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/connection/dispatch.rs
@@ -115,6 +115,7 @@ pub(super) async fn dispatch_request(
                     dep_graph_persisted: state.dep_graph_persisted.load(Ordering::Acquire),
                     watcher_active: state.watcher_active.load(Ordering::Acquire),
                     watcher_degradations: state.watcher_degradations.load(Ordering::Relaxed),
+                    index_writer_gone: state.index_writer_gone.load(Ordering::Relaxed),
                 }),
                 None,
             )

--- a/crates/zccache-daemon-core/src/daemon/server/embedded.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/embedded.rs
@@ -444,6 +444,7 @@ async fn status_snapshot(state: &SharedState) -> crate::protocol::DaemonStatus {
         dep_graph_persisted: state.dep_graph_persisted.load(Ordering::Acquire),
         watcher_active: state.watcher_active.load(Ordering::Acquire),
         watcher_degradations: state.watcher_degradations.load(Ordering::Relaxed),
+        index_writer_gone: state.index_writer_gone.load(Ordering::Relaxed),
     }
 }
 

--- a/crates/zccache-ipc/src/mod_tests.rs
+++ b/crates/zccache-ipc/src/mod_tests.rs
@@ -114,6 +114,7 @@ fn test_daemon_status(endpoint: &str) -> zccache_protocol::DaemonStatus {
         dep_graph_persisted: false,
         watcher_active: true,
         watcher_degradations: 0,
+        index_writer_gone: false,
     }
 }
 

--- a/crates/zccache-protocol/proto/zccache_v1.proto
+++ b/crates/zccache-protocol/proto/zccache_v1.proto
@@ -258,6 +258,7 @@ message DaemonStatus {
   bool dep_graph_persisted = 27;
   bool watcher_active = 28;
   uint64 watcher_degradations = 29;
+  bool index_writer_gone = 30;
 }
 
 message PrivateDaemonOwnerStatus {

--- a/crates/zccache-protocol/src/lib.rs
+++ b/crates/zccache-protocol/src/lib.rs
@@ -22,18 +22,24 @@ pub const UNKNOWN_MISS_WARNING_PREFIX: &str = "zccache[warn][M]:";
 /// This remains the active compatibility version until the v16 prost dispatcher
 /// is wired through the IPC transport. Do not change `PROTOCOL_VERSION` to v16
 /// while `encode_message` and `decode_message` still serialize bincode bodies.
-pub const BINCODE_PROTOCOL_VERSION: u32 = 21;
+pub const BINCODE_PROTOCOL_VERSION: u32 = 23;
 
 /// Prost daemon wire version.
 ///
 /// The prost schema and frame helpers use this value. A future change will make
 /// the daemon dispatch v15 bincode and v16 prost frames concurrently.
-pub const PROST_PROTOCOL_VERSION: u32 = 22;
+pub const PROST_PROTOCOL_VERSION: u32 = 24;
 
 /// Protocol version number. Bump this when the wire format changes:
 /// new/removed/reordered enum variants or struct field changes.
 /// Patch releases that don't change the protocol keep the same version.
 ///
+/// v23 (bincode) / v24 (prost): `DaemonStatus` gained `index_writer_gone` so
+///                  an operator can see that a daemon has stopped recording
+///                  what it caches — the cache is effectively write-only and
+///                  nothing it publishes survives a restart (issue #1177).
+///                  Both lanes bump past the previous prost version so no
+///                  historical header value is re-used by the other lane.
 /// v21 (bincode) / v22 (prost): `DaemonStatus` gained `watcher_active` and
 ///                  `watcher_degradations` so an operator can see that a
 ///                  daemon is running without a file watcher — both fast hit

--- a/crates/zccache-protocol/src/messages/compat/daemon_status.rs
+++ b/crates/zccache-protocol/src/messages/compat/daemon_status.rs
@@ -41,6 +41,7 @@ fn daemon_status_expanded_roundtrip() {
         dep_graph_persisted: true,
         watcher_active: true,
         watcher_degradations: 0,
+        index_writer_gone: false,
     };
     roundtrip(&status);
 }
@@ -77,6 +78,7 @@ fn daemon_status_version_field_roundtrips() {
         dep_graph_persisted: false,
         watcher_active: false,
         watcher_degradations: 3,
+        index_writer_gone: true,
     };
     roundtrip(&with_version);
 }

--- a/crates/zccache-protocol/src/messages/compat/mod.rs
+++ b/crates/zccache-protocol/src/messages/compat/mod.rs
@@ -87,6 +87,7 @@ pub(super) fn sample_daemon_status() -> DaemonStatus {
         dep_graph_persisted: true,
         watcher_active: true,
         watcher_degradations: 22,
+        index_writer_gone: false,
     }
 }
 
@@ -104,7 +105,10 @@ pub(super) fn sample_artifact() -> ArtifactData {
 
 // Compile-time check: PROTOCOL_VERSION must be positive.
 const _: () = assert!(super::super::PROTOCOL_VERSION > 0);
-// Compile-time check: PROTOCOL_VERSION == 21 after `DaemonStatus` gained
+// Compile-time check: PROTOCOL_VERSION == 23 after `DaemonStatus` gained
+// `index_writer_gone` (issue #1177: a daemon that has stopped recording what
+// it caches still looks healthy, so the condition has to be reportable rather
+// than only inferable from the lifecycle log). v21 was the pin after
 // `watcher_active` / `watcher_degradations` (issue #1156: watcher degradation
 // must be visible in status, not only in startup logs). v20 was the pin after
 // `Response::CompileProgress`
@@ -123,4 +127,4 @@ const _: () = assert!(super::super::PROTOCOL_VERSION > 0);
 // pin after SessionStats gained `phase_profile`. v8 was the pin after
 // Compile/CompileEphemeral gained `stdin` and ArtifactPayload replaced
 // ArtifactOutput.data: Arc<Vec<u8>> (issue #296 Option B).
-const _FINGERPRINT_VERSION: () = assert!(super::super::PROTOCOL_VERSION == 21);
+const _FINGERPRINT_VERSION: () = assert!(super::super::PROTOCOL_VERSION == 23);

--- a/crates/zccache-protocol/src/messages/status.rs
+++ b/crates/zccache-protocol/src/messages/status.rs
@@ -104,6 +104,13 @@ pub struct DaemonStatus {
     /// Watcher-arm failures since daemon start (issue #1156). Non-zero with
     /// `watcher_active == true` means the daemon recovered via a re-arm.
     pub watcher_degradations: u64,
+    /// Whether the index writer has gone away (issue #1177).
+    ///
+    /// `true` means published artifacts are no longer being recorded durably:
+    /// the cache still serves this daemon's in-memory state but nothing it
+    /// publishes will survive a restart. Distinct from a slow daemon, and not
+    /// otherwise visible without reading the lifecycle log.
+    pub index_writer_gone: bool,
 }
 
 /// Per-session statistics, returned when the session opted in to tracking.

--- a/crates/zccache-protocol/src/wire_prost/convert.rs
+++ b/crates/zccache-protocol/src/wire_prost/convert.rs
@@ -426,6 +426,7 @@ pub(super) fn daemon_status_to_prost(status: &crate::DaemonStatus) -> zccache_v1
         dep_graph_persisted: status.dep_graph_persisted,
         watcher_active: status.watcher_active,
         watcher_degradations: status.watcher_degradations,
+        index_writer_gone: status.index_writer_gone,
     }
 }
 
@@ -468,6 +469,7 @@ pub(super) fn daemon_status_from_prost(
         dep_graph_persisted: status.dep_graph_persisted,
         watcher_active: status.watcher_active,
         watcher_degradations: status.watcher_degradations,
+        index_writer_gone: status.index_writer_gone,
     })
 }
 


### PR DESCRIPTION
The last open item of #1177 (Part B, item B7). Completes the issue.

## Why this needs to be in `Status`

#1292 made a dead index writer *observable* — it emits `index_writer_gone` to the lifecycle log. But the operator-facing symptom is nasty precisely because it is invisible: the daemon keeps serving from memory and **looks completely healthy**, while nothing it publishes is being recorded and none of it will survive a restart. "The cache is write-only right now" is not something anyone should have to discover by grepping a log file after the fact.

`zccache status` now says so directly:

```
  Index writer:  GONE — new artifacts are not being recorded and will not
                 survive a restart; restart the daemon
```

The line is printed only when the condition holds, so healthy output is unchanged.

## Wire change

`DaemonStatus` gains `index_writer_gone: bool`, threaded through both lanes exactly as #1156 did for `watcher_active` / `watcher_degradations`:

- `messages/status.rs` (bincode struct) and `proto/zccache_v1.proto` field 30
- `wire_prost/convert.rs` in both directions
- populated from `SharedState.index_writer_gone` in the standalone (`connection/dispatch.rs`) and embedded (`server/embedded.rs`) status paths — both, so an embedded host is not left blind
- `PROTOCOL_VERSION` bumped: **bincode 21 → 23, prost 22 → 24**. Both lanes move so no historical header value is ever re-used by the other lane, following the convention the file documents.

The `_FINGERPRINT_VERSION` compile-time pin caught the bump before anything ran — which is exactly its job, and worth noting as evidence the guard works rather than as an obstacle. Its comment now records v23's reason and preserves the v21 entry in the history chain.

## Evidence

- Workspace check, all targets — clean.
- Workspace clippy `-D warnings` — clean.
- `zccache-protocol` + `zccache-ipc` lib tests — 53 + 51 passed, 0 failed. These cover the bincode/prost round trip, and the compat fixtures now carry both `false` and `true` for the new field so the flag is exercised in both states rather than defaulting through.
- `zccache-daemon-core` lib tests — **704 passed, 0 failed**, 25 ignored.

Two wall-clock perf tests (`perf_cow_materialization_128_hits_under_two_seconds`, `warm_hit_materialization_under_budget`) failed on one loaded run of my host and pass in isolation and on a quiet re-run. They are timing budgets unrelated to this change — the same COW-materialization budget that flaked on CI for #1291 and passed on re-run. Recording it rather than quietly re-running until green.

## #1177 is complete with this

| Part | Status |
|---|---|
| A — `ban_discarded_write_result` dylint + wiring | #1293 |
| A — blocker: three discarded index-writer sends | #1292 |
| B — watcher consumer supervised | #1276 (pre-existing) |
| B — supervision helper + eviction/depgraph loops | #1291 |
| B — `background_task_died` / `background_task_restarted` events | #1291 |
| B7 — index-writer health surfaced in `Status` | **this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
