### PR TITLE
fix(embedded): run the same periodic maintenance in both modes (#1160)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/embedded.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/embedded.rs
@@ -74,6 +74,7 @@ impl EmbeddedDaemon {
             index_writer_rx: Some(index_writer_rx),
             index_writer_handle: Mutex::new(None),
             maintenance_handle: Mutex::new(None),
+            maintenance_tasks: Vec::new(),
         };
         daemon
             .start_background_tasks(runtime_handle, automatic_maintenance)
@@ -201,14 +202,31 @@ impl EmbeddedDaemon {
         })
         .await;
 
-        if automatic_maintenance {
-            let maintenance_handle = spawn_disk_maintenance(
-                Arc::clone(&self.state),
-                self.maintenance_policy,
-                runtime_handle.as_ref(),
-            );
-            *self.maintenance_handle.lock().await = Some(maintenance_handle);
-        }
+        // #1160: start the SAME schedule the standalone daemon starts. Before
+        // this, embedded ran no periodic task at all beyond the disk loop, so
+        // every in-memory budget was dead code inside a long-lived host, the
+        // depgraph was persisted only when the host called `flush()`, and
+        // interrupted-write staged temps were never reclaimed.
+        //
+        // `automatic_maintenance == false` means the host owns the *disk*
+        // passes (`MaintenanceOwnership::Host`) and drives them through
+        // `maintain_disk`. It does not mean the host owns memory eviction or
+        // depgraph persistence — no API exposes those — so only the disk
+        // member is suppressed.
+        let started = MaintenanceSchedule::new(
+            Arc::clone(&self.state),
+            self.maintenance_policy,
+            ServiceMode::Embedded,
+        )
+        .with_runtime_handle(runtime_handle)
+        .with_disk_maintenance(automatic_maintenance)
+        .start();
+        tracing::debug!(
+            tasks = ?started.started,
+            "embedded maintenance schedule started"
+        );
+        *self.maintenance_handle.lock().await = started.disk_maintenance;
+        self.maintenance_tasks = started.started;
     }
 
     pub(crate) async fn compile(

--- a/crates/zccache-daemon-core/src/daemon/server/maintenance_schedule.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/maintenance_schedule.rs
@@ -1,0 +1,467 @@
+//! The one periodic-maintenance schedule shared by both service modes
+//! (issue #1160).
+//!
+//! Before this module every background loop was hand-spawned in
+//! `DaemonServer::run`, and `EmbeddedDaemon::start_background_tasks` spawned a
+//! strict subset of them. That is drift by construction: a task added to
+//! `run.rs` simply never ran inside a long-lived embedded host, and the only
+//! symptom was something quietly not happening — memory never evicted, the
+//! depgraph never persisted between host flushes, interrupted-write temps never
+//! reclaimed.
+//!
+//! The fix is structural rather than a one-by-one port. [`MAINTENANCE_TASKS`]
+//! is the single declaration of what periodic work the daemon does;
+//! [`MaintenanceSchedule::start`] is the single site that spawns it; and the
+//! set of names it reports having started is asserted against the declaration
+//! in both modes by the parity test. A future task therefore runs in both modes
+//! unless it is explicitly flagged standalone-only **with a rationale**, and
+//! forgetting to flag it fails the test rather than shipping.
+//!
+//! ## Host-runtime contract
+//!
+//! Everything here spawns through [`MaintenanceSchedule::runtime_handle`] when
+//! the embedded host supplied one (zccache#922). A bare `tokio::spawn` would
+//! land on whichever runtime happened to be current at `start()` time, which is
+//! exactly the contract violation the handle exists to prevent — so
+//! `spawn_supervised` takes the handle too.
+
+use super::*;
+
+/// Interval between periodic depgraph snapshots. Matches the pre-#1160
+/// standalone loop; the reasoning is bounded crash loss, not throughput.
+const DEPGRAPH_SAVE_INTERVAL: Duration = Duration::from_secs(300);
+/// Poll period for the standalone idle watchdog.
+const IDLE_WATCHDOG_INTERVAL: Duration = Duration::from_secs(60);
+/// Poll period for private-daemon owner-PID liveness.
+const PRIVATE_DAEMON_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+pub(super) const TASK_STAGED_TEMP_SWEEP: &str = "staged-temp-sweep";
+pub(super) const TASK_MEMORY_EVICTION: &str = "memory-eviction";
+pub(super) const TASK_DISK_MAINTENANCE: &str = "disk-maintenance";
+pub(super) const TASK_DEPGRAPH_SAVE: &str = "depgraph-save";
+pub(super) const TASK_LEGACY_TEMP_ROOT_CLEANUP: &str = "legacy-temp-root-cleanup";
+pub(super) const TASK_IDLE_WATCHDOG: &str = "idle-watchdog";
+pub(super) const TASK_PRIVATE_DAEMON_OWNERS: &str = "private-daemon-owner-reaper";
+
+/// One member of the maintenance schedule.
+pub(super) struct MaintenanceTaskSpec {
+    pub(super) name: &'static str,
+    /// `None` means the task runs in both modes.
+    ///
+    /// `Some(rationale)` marks it standalone-only. The rationale is mandatory
+    /// so "embedded does not run this" is always an argued decision rather than
+    /// an omission nobody noticed, and so `zccache status`-style reporting can
+    /// explain the difference without reading this file.
+    pub(super) standalone_only: Option<&'static str>,
+}
+
+impl MaintenanceTaskSpec {
+    const fn shared(name: &'static str) -> Self {
+        Self {
+            name,
+            standalone_only: None,
+        }
+    }
+
+    const fn standalone_only(name: &'static str, rationale: &'static str) -> Self {
+        Self {
+            name,
+            standalone_only: Some(rationale),
+        }
+    }
+
+    pub(super) fn runs_in(&self, mode: ServiceMode) -> bool {
+        mode == ServiceMode::Standalone || self.standalone_only.is_none()
+    }
+}
+
+/// The complete declaration of the daemon's periodic maintenance.
+///
+/// Adding a row here without a `standalone_only` rationale makes the task run
+/// in both modes; that is the intended default.
+pub(super) const MAINTENANCE_TASKS: &[MaintenanceTaskSpec] = &[
+    MaintenanceTaskSpec::shared(TASK_STAGED_TEMP_SWEEP),
+    MaintenanceTaskSpec::shared(TASK_MEMORY_EVICTION),
+    MaintenanceTaskSpec::shared(TASK_DISK_MAINTENANCE),
+    MaintenanceTaskSpec::shared(TASK_DEPGRAPH_SAVE),
+    MaintenanceTaskSpec::standalone_only(
+        TASK_LEGACY_TEMP_ROOT_CLEANUP,
+        "reclaims per-process state that only the standalone daemon binary ever \
+         wrote under the system temp root; an embedded host has no such state, \
+         so running it there would scan a directory this process does not own",
+    ),
+    MaintenanceTaskSpec::standalone_only(
+        TASK_IDLE_WATCHDOG,
+        "terminates the process when no client has been seen for the configured \
+         idle timeout. The embedded service's lifetime is the host's to decide — \
+         self-terminating would take the host's own runtime state with it",
+    ),
+    MaintenanceTaskSpec::standalone_only(
+        TASK_PRIVATE_DAEMON_OWNERS,
+        "shuts the daemon down once its caller-supplied owner PIDs are gone. An \
+         embedded service's owner is the process it lives in, so the condition \
+         is unreachable and the shutdown it triggers would be a host-visible \
+         self-kill",
+    ),
+];
+
+/// Which service is starting the schedule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ServiceMode {
+    Standalone,
+    Embedded,
+}
+
+/// Injectable periods, so tests drive real ticks instead of sleeping.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct MaintenanceIntervals {
+    pub(super) memory_eviction: Duration,
+    pub(super) depgraph_save: Duration,
+}
+
+impl Default for MaintenanceIntervals {
+    fn default() -> Self {
+        Self {
+            memory_eviction: Duration::from_secs(
+                crate::core::config::Config::default().eviction_interval_secs,
+            ),
+            depgraph_save: DEPGRAPH_SAVE_INTERVAL,
+        }
+    }
+}
+
+/// What [`MaintenanceSchedule::start`] actually spawned.
+///
+/// `started` is built by pushing at each spawn site — never derived from
+/// [`MAINTENANCE_TASKS`] — so the parity test compares real behaviour against
+/// the declaration rather than the declaration against itself.
+pub(super) struct StartedMaintenance {
+    pub(super) started: Vec<&'static str>,
+    /// The disk-maintenance loop, which both shutdown paths join.
+    pub(super) disk_maintenance: Option<tokio::task::JoinHandle<()>>,
+}
+
+pub(super) struct MaintenanceSchedule {
+    state: Arc<SharedState>,
+    policy: MaintenancePolicy,
+    mode: ServiceMode,
+    intervals: MaintenanceIntervals,
+    runtime_handle: Option<tokio::runtime::Handle>,
+    /// Standalone idle timeout in seconds; 0 disables the watchdog.
+    idle_timeout_secs: u64,
+    /// When false the *disk* loop is owned by the host
+    /// ([`crate::embedded::MaintenanceOwnership::Host`]) and this schedule must
+    /// not start a second one. The in-memory members are unaffected: no host
+    /// API drives them, so suppressing them would restore the #1160 leak.
+    disk_maintenance_enabled: bool,
+}
+
+impl MaintenanceSchedule {
+    pub(super) fn new(
+        state: Arc<SharedState>,
+        policy: MaintenancePolicy,
+        mode: ServiceMode,
+    ) -> Self {
+        Self {
+            state,
+            policy,
+            mode,
+            intervals: MaintenanceIntervals::default(),
+            runtime_handle: None,
+            idle_timeout_secs: 0,
+            disk_maintenance_enabled: true,
+        }
+    }
+
+    pub(super) fn with_runtime_handle(mut self, handle: Option<tokio::runtime::Handle>) -> Self {
+        self.runtime_handle = handle;
+        self
+    }
+
+    pub(super) fn with_idle_timeout_secs(mut self, idle_timeout_secs: u64) -> Self {
+        self.idle_timeout_secs = idle_timeout_secs;
+        self
+    }
+
+    pub(super) fn with_disk_maintenance(mut self, enabled: bool) -> Self {
+        self.disk_maintenance_enabled = enabled;
+        self
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_intervals(mut self, intervals: MaintenanceIntervals) -> Self {
+        self.intervals = intervals;
+        self
+    }
+
+    fn spawn<Fut>(&self, task: Fut) -> tokio::task::JoinHandle<()>
+    where
+        Fut: std::future::Future<Output = ()> + Send + 'static,
+    {
+        match &self.runtime_handle {
+            Some(handle) => handle.spawn(task),
+            None => tokio::spawn(task),
+        }
+    }
+
+    fn is_shutting_down(&self) -> impl Fn() -> bool + Send + 'static {
+        let state = Arc::clone(&self.state);
+        move || state.shutdown_requested.load(Ordering::Acquire)
+    }
+
+    /// Start every task this mode owns and report what was started.
+    pub(super) fn start(self) -> StartedMaintenance {
+        let mut started = Vec::with_capacity(MAINTENANCE_TASKS.len());
+
+        started.push(self.start_staged_temp_sweep());
+        started.push(self.start_memory_eviction());
+        let disk_maintenance = if self.disk_maintenance_enabled {
+            let handle = spawn_disk_maintenance(
+                Arc::clone(&self.state),
+                self.policy,
+                self.runtime_handle.as_ref(),
+            );
+            started.push(TASK_DISK_MAINTENANCE);
+            Some(handle)
+        } else {
+            None
+        };
+        started.push(self.start_depgraph_save());
+
+        if self.mode == ServiceMode::Standalone {
+            started.push(self.start_legacy_temp_root_cleanup());
+            if self.idle_timeout_secs > 0 {
+                started.push(self.start_idle_watchdog());
+            }
+            started.push(self.start_private_daemon_owner_reaper());
+        }
+
+        // Surface the difference rather than leaving it implicit: a mode that
+        // silently runs less maintenance than another is the whole bug class
+        // #1160 is about, so the reason a member was skipped is emitted with
+        // the member.
+        for task in MAINTENANCE_TASKS
+            .iter()
+            .filter(|task| !task.runs_in(self.mode))
+        {
+            tracing::debug!(
+                task = task.name,
+                rationale = task.standalone_only.unwrap_or_default(),
+                "maintenance task is standalone-only and was not started"
+            );
+        }
+        debug_assert!(
+            started
+                .iter()
+                .all(|name| MAINTENANCE_TASKS.iter().any(|task| task.name == *name)),
+            "every started task must be declared in MAINTENANCE_TASKS"
+        );
+
+        StartedMaintenance {
+            started,
+            disk_maintenance,
+        }
+    }
+
+    /// Reclaim interrupted-write `.tmp` files under the staged artifact root.
+    ///
+    /// A publish that dies after the generation rename but before the pointer
+    /// commit leaves a complete orphaned generation that only this sweep
+    /// reclaims. On an embedded host that never restarts the process, "startup
+    /// only, standalone only" meant *never* (#1160c).
+    fn start_staged_temp_sweep(&self) -> &'static str {
+        let artifact_dir = self.state.artifact_dir.clone();
+        std::mem::drop(self.spawn(async move {
+            let swept = tokio::task::spawn_blocking(move || {
+                cleanup_staged_artifact_temps(artifact_dir.as_path())
+            })
+            .await;
+            match swept {
+                Ok(Ok(0)) | Err(_) => {}
+                Ok(Ok(removed)) => tracing::info!(removed, "swept staged artifact temp files"),
+                Ok(Err(error)) => tracing::debug!(%error, "staged artifact temp cleanup skipped"),
+            }
+        }));
+        TASK_STAGED_TEMP_SWEEP
+    }
+
+    /// Memory-budget eviction plus the ephemeral request/rsp cache trims.
+    ///
+    /// #1177: supervised. A panic here used to be silent — the task vanished
+    /// and memory simply stopped being evicted, which surfaces days later as
+    /// "the daemon got fat" with nothing in the log.
+    fn start_memory_eviction(&self) -> &'static str {
+        let state = Arc::clone(&self.state);
+        let budget = crate::core::config::Config::default().max_memory_bytes;
+        let interval = self.intervals.memory_eviction;
+        std::mem::drop(supervise::spawn_supervised(
+            TASK_MEMORY_EVICTION,
+            self.is_shutting_down(),
+            supervise::Restart::Idempotent,
+            self.runtime_handle.as_ref(),
+            move || {
+                let state = Arc::clone(&state);
+                async move {
+                    loop {
+                        tokio::time::sleep(interval).await;
+                        let req_removed =
+                            trim_request_cache(&state.request_cache, EPHEMERAL_CACHE_MAX_AGE);
+                        let req_validation_removed = trim_request_validation_cache(
+                            &state.request_validation_cache,
+                            EPHEMERAL_CACHE_MAX_AGE,
+                        );
+                        let rsp_removed = trim_rsp_cache(&state.rsp_cache, EPHEMERAL_CACHE_MAX_AGE);
+                        if req_removed > 0 || req_validation_removed > 0 || rsp_removed > 0 {
+                            tracing::debug!(
+                                request_cache_removed = req_removed,
+                                request_validation_cache_removed = req_validation_removed,
+                                rsp_cache_removed = rsp_removed,
+                                "trimmed ephemeral daemon caches"
+                            );
+                        }
+                        let (freed, items) =
+                            super::run::run_memory_eviction_pass(&state, budget).await;
+                        if items > 0 {
+                            tracing::info!(
+                                freed_bytes = freed,
+                                items_removed = items,
+                                "memory eviction"
+                            );
+                        }
+                    }
+                }
+            },
+        ));
+        TASK_MEMORY_EVICTION
+    }
+
+    /// Periodic depgraph snapshot.
+    ///
+    /// #1177: supervised. A silent death here means the depgraph stops being
+    /// persisted, so the next start is a cold graph and a full recompile — with
+    /// nothing recording why. #1160b: embedded persisted only inside a
+    /// host-driven `flush()`, so a host crash lost the entire delta rather than
+    /// one interval of it.
+    fn start_depgraph_save(&self) -> &'static str {
+        let state = Arc::clone(&self.state);
+        let interval = self.intervals.depgraph_save;
+        std::mem::drop(supervise::spawn_supervised(
+            TASK_DEPGRAPH_SAVE,
+            self.is_shutting_down(),
+            supervise::Restart::Idempotent,
+            self.runtime_handle.as_ref(),
+            move || {
+                let state = Arc::clone(&state);
+                async move {
+                    let path = depgraph_file_path_for_cache_dir(&state.cache_dir);
+                    loop {
+                        tokio::time::sleep(interval).await;
+                        if let Some(parent) = path.parent() {
+                            std::fs::create_dir_all(parent).ok();
+                        }
+                        let dg = state.dep_graph.load();
+                        match crate::depgraph::save_to_file(&dg, &path) {
+                            Ok(()) => {
+                                state.dep_graph_persisted.store(true, Ordering::Release);
+                                tracing::debug!("periodic depgraph save");
+                            }
+                            Err(e) => tracing::warn!("periodic depgraph save failed: {e}"),
+                        }
+                    }
+                }
+            },
+        ));
+        TASK_DEPGRAPH_SAVE
+    }
+
+    fn start_legacy_temp_root_cleanup(&self) -> &'static str {
+        let cache_dir = self.state.cache_dir.clone();
+        std::mem::drop(self.spawn(async move {
+            let cleaned = tokio::task::spawn_blocking(move || {
+                crate::core::config::cleanup_legacy_temp_root_state(
+                    &std::env::temp_dir(),
+                    cache_dir.as_path(),
+                    crate::ipc::is_process_alive,
+                )
+            })
+            .await
+            .unwrap_or(0);
+            if cleaned > 0 {
+                tracing::info!(cleaned, "cleaned legacy temp-root zccache state");
+            }
+        }));
+        TASK_LEGACY_TEMP_ROOT_CLEANUP
+    }
+
+    fn start_idle_watchdog(&self) -> &'static str {
+        let state = Arc::clone(&self.state);
+        let timeout = self.idle_timeout_secs;
+        std::mem::drop(self.spawn(async move {
+            loop {
+                tokio::time::sleep(IDLE_WATCHDOG_INTERVAL).await;
+                let last = state.last_activity.load(Ordering::Relaxed);
+                let idle = now_secs().saturating_sub(last);
+                if idle >= timeout {
+                    tracing::info!(idle_secs = idle, "idle timeout — shutting down");
+                    // Persist a "died-idle" lifecycle event so operators can
+                    // see why the daemon exited. Pair this with the "spawn"
+                    // entry to reconstruct daemon lifetime from the lifecycle
+                    // log alone — tracing stderr is NUL'd.
+                    crate::core::lifecycle::write_event(
+                        crate::core::lifecycle::EVENT_DIED_IDLE,
+                        serde_json::json!({
+                            "reason": crate::core::lifecycle::REASON_IDLE_TIMEOUT,
+                            "idle_secs": idle,
+                            "idle_timeout_secs": timeout,
+                        }),
+                    );
+                    state.shutdown_requested.store(true, Ordering::Release);
+                    state.shutdown.notify_waiters();
+                    break;
+                }
+            }
+        }));
+        TASK_IDLE_WATCHDOG
+    }
+
+    fn start_private_daemon_owner_reaper(&self) -> &'static str {
+        let state = Arc::clone(&self.state);
+        std::mem::drop(self.spawn(async move {
+            loop {
+                tokio::time::sleep(PRIVATE_DAEMON_POLL_INTERVAL).await;
+                if !state.private_daemon.is_enabled().await {
+                    continue;
+                }
+                let prune = state
+                    .private_daemon
+                    .prune_dead_owner_pids(crate::ipc::is_process_alive)
+                    .await;
+                if !prune.removed_pids.is_empty() {
+                    tracing::info!(
+                        removed_pids = ?prune.removed_pids,
+                        "private daemon owner PIDs exited"
+                    );
+                }
+                if prune.should_shutdown {
+                    tracing::info!("private daemon has no live owner PIDs - shutting down");
+                    crate::core::lifecycle::write_event(
+                        crate::core::lifecycle::EVENT_DIED_PRIVATE_OWNER_EXIT,
+                        serde_json::json!({
+                            "reason": "private-owner-pids-exited",
+                            "uptime_secs": now_secs().saturating_sub(state.start_time),
+                            "removed_pids": prune.removed_pids,
+                        }),
+                    );
+                    state.shutdown_requested.store(true, Ordering::Release);
+                    state.shutdown.notify_waiters();
+                    break;
+                }
+            }
+        }));
+        TASK_PRIVATE_DAEMON_OWNERS
+    }
+}
+
+#[cfg(test)]
+#[path = "tests/maintenance_schedule.rs"]
+mod tests;

--- a/crates/zccache-daemon-core/src/daemon/server/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/mod.rs
@@ -87,6 +87,11 @@ pub(crate) struct EmbeddedDaemon {
     index_writer_rx: Option<tokio::sync::mpsc::UnboundedReceiver<IndexWriterCommand>>,
     index_writer_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     maintenance_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Periodic tasks this service started, as reported by
+    /// [`maintenance_schedule::MaintenanceSchedule::start`] (#1160). Retained
+    /// so the parity guard can assert against a real embedded service rather
+    /// than against the schedule in isolation.
+    maintenance_tasks: Vec<&'static str>,
 }
 
 pub(crate) struct EmbeddedCompileRequest {
@@ -169,6 +174,7 @@ mod link_hash;
 mod link_helpers;
 mod link_process;
 mod loaders;
+mod maintenance_schedule;
 mod pch;
 mod pending_writes;
 pub(crate) mod persist;
@@ -208,6 +214,7 @@ use lifecycle::*;
 use link_helpers::*;
 #[cfg(test)]
 use link_process::run_post_link_deploy_hook;
+use maintenance_schedule::*;
 use pch::*;
 use persist::*;
 

--- a/crates/zccache-daemon-core/src/daemon/server/run.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/run.rs
@@ -44,12 +44,15 @@ impl DaemonServer {
         }
 
         let cache_dir = self.state.cache_dir.clone();
-        let temp_root = std::env::temp_dir();
 
         // Migrate legacy blob digests once per cache root. Keep this off the
         // Tokio runtime thread because the helper hashes files synchronously.
         // The marker is published only after a successful migration so a
         // failed attempt remains retryable on the next daemon start.
+        //
+        // The staged-artifact temp sweep that used to live here is now a
+        // member of `MaintenanceSchedule` so the embedded service runs it too
+        // (#1160c).
         {
             let cache_dir = cache_dir.clone();
             let artifact_dir = self.state.artifact_dir.clone();
@@ -57,9 +60,6 @@ impl DaemonServer {
             tokio::spawn(async move {
                 if let Err(error) = state.staging.cleanup_abandoned() {
                     tracing::debug!(%error, "abandoned private staging cleanup skipped");
-                }
-                if let Err(error) = cleanup_staged_artifact_temps(&artifact_dir) {
-                    tracing::debug!(%error, "staged artifact temp cleanup skipped");
                 }
                 let marker = cache_dir.join(".legacy-blob-digests-migrated-v1");
                 if marker.exists() {
@@ -113,17 +113,8 @@ impl DaemonServer {
             let _ = std::fs::remove_file(&legacy_lock);
         }
 
-        // Remove legacy temp-root state from older builds before starting the daemon.
-        {
-            let cleaned = crate::core::config::cleanup_legacy_temp_root_state(
-                &temp_root,
-                &cache_dir,
-                crate::ipc::is_process_alive,
-            );
-            if cleaned > 0 {
-                tracing::info!(cleaned, "cleaned legacy temp-root zccache state");
-            }
-        }
+        // Legacy temp-root state removal is a standalone-only member of
+        // `MaintenanceSchedule` (see its rationale) and starts below.
 
         // Clean up stale depfile directories from dead daemon instances.
         {
@@ -136,174 +127,30 @@ impl DaemonServer {
 
         self.start_watcher_pipeline().await;
 
-        // Start idle watchdog if timeout is configured.
-        if idle_timeout_secs > 0 {
-            let state = Arc::clone(&self.state);
-            let timeout = idle_timeout_secs;
-            tokio::spawn(async move {
-                loop {
-                    tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-                    let last = state.last_activity.load(Ordering::Relaxed);
-                    let idle = now_secs().saturating_sub(last);
-                    if idle >= timeout {
-                        tracing::info!(idle_secs = idle, "idle timeout — shutting down");
-                        // Persist a "died-idle" lifecycle event so operators
-                        // can see why the daemon exited. Pair this with the
-                        // "spawn" entry to reconstruct daemon lifetime from
-                        // the lifecycle log alone — tracing stderr is NUL'd.
-                        super::super::lifecycle::write_event(
-                            super::super::lifecycle::EVENT_DIED_IDLE,
-                            serde_json::json!({
-                                "reason": super::super::lifecycle::REASON_IDLE_TIMEOUT,
-                                "idle_secs": idle,
-                                "idle_timeout_secs": timeout,
-                            }),
-                        );
-                        state.shutdown_requested.store(true, Ordering::Release);
-                        state.shutdown.notify_waiters();
-                        break;
-                    }
-                }
-            });
-        }
-
-        // Private daemons are owned by caller-supplied PIDs. Once the last
-        // live owner disappears, shut down even if the normal idle timeout is
-        // disabled or still far in the future.
-        {
-            let state = Arc::clone(&self.state);
-            tokio::spawn(async move {
-                loop {
-                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                    if !state.private_daemon.is_enabled().await {
-                        continue;
-                    }
-                    let prune = state
-                        .private_daemon
-                        .prune_dead_owner_pids(crate::ipc::is_process_alive)
-                        .await;
-                    if !prune.removed_pids.is_empty() {
-                        tracing::info!(
-                            removed_pids = ?prune.removed_pids,
-                            "private daemon owner PIDs exited"
-                        );
-                    }
-                    if prune.should_shutdown {
-                        tracing::info!("private daemon has no live owner PIDs - shutting down");
-                        crate::core::lifecycle::write_event(
-                            crate::core::lifecycle::EVENT_DIED_PRIVATE_OWNER_EXIT,
-                            serde_json::json!({
-                                "reason": "private-owner-pids-exited",
-                                "uptime_secs": now_secs().saturating_sub(state.start_time),
-                                "removed_pids": prune.removed_pids,
-                            }),
-                        );
-                        state.shutdown_requested.store(true, Ordering::Release);
-                        state.shutdown.notify_waiters();
-                        break;
-                    }
-                }
-            });
-        }
-
         // Start background artifact loading (non-blocking so daemon responds
         // immediately — Bug 6 fix).
         {
             std::mem::drop(spawn_artifact_loader(Arc::clone(&self.state), None).await);
         }
 
-        // Start memory eviction background task.
+        // Every periodic loop this daemon owns starts here, from the single
+        // schedule the embedded service also starts (#1160). Nothing periodic
+        // may be hand-spawned in this function any more: a task added here
+        // alone would silently not run inside an embedded host, which is the
+        // exact drift the schedule exists to make impossible.
         //
-        // #1177: supervised. A panic here used to be silent — the task
-        // vanished and memory simply stopped being evicted, which surfaces
-        // days later as "the daemon got fat" with nothing in the log.
-        {
-            let state = Arc::clone(&self.state);
-            let shutdown_state = Arc::clone(&self.state);
-            let budget = crate::core::config::Config::default().max_memory_bytes;
-            let interval_secs = crate::core::config::Config::default().eviction_interval_secs;
-            std::mem::drop(supervise::spawn_supervised(
-                "memory-eviction",
-                move || shutdown_state.shutdown_requested.load(Ordering::Acquire),
-                supervise::Restart::Idempotent,
-                move || {
-                    let state = Arc::clone(&state);
-                    async move {
-                        loop {
-                            tokio::time::sleep(std::time::Duration::from_secs(interval_secs)).await;
-                            let req_removed =
-                                trim_request_cache(&state.request_cache, EPHEMERAL_CACHE_MAX_AGE);
-                            let req_validation_removed = trim_request_validation_cache(
-                                &state.request_validation_cache,
-                                EPHEMERAL_CACHE_MAX_AGE,
-                            );
-                            let rsp_removed =
-                                trim_rsp_cache(&state.rsp_cache, EPHEMERAL_CACHE_MAX_AGE);
-                            if req_removed > 0 || req_validation_removed > 0 || rsp_removed > 0 {
-                                tracing::debug!(
-                                    request_cache_removed = req_removed,
-                                    request_validation_cache_removed = req_validation_removed,
-                                    rsp_cache_removed = rsp_removed,
-                                    "trimmed ephemeral daemon caches"
-                                );
-                            }
-                            let (freed, items) = run_memory_eviction_pass(&state, budget).await;
-                            if items > 0 {
-                                tracing::info!(
-                                    freed_bytes = freed,
-                                    items_removed = items,
-                                    "memory eviction"
-                                );
-                            }
-                        }
-                    }
-                },
-            ));
-        }
-
-        // The daemon is the primary maintenance owner. It checks this exact
-        // cache root at startup and every five minutes, with persisted daily
-        // full-age catch-up after idle periods or restarts (issue #1148).
-        let mut maintenance_handle = Some(spawn_disk_maintenance(
+        // The standalone-only members (legacy temp-root cleanup, idle
+        // watchdog, private-daemon owner reaping) carry their rationale in
+        // `MAINTENANCE_TASKS`.
+        let started = MaintenanceSchedule::new(
             Arc::clone(&self.state),
             maintenance_policy,
-            None,
-        ));
-
-        // Start periodic depgraph save task (every 5 minutes).
-        //
-        // #1177: supervised. A silent death here means the depgraph stops
-        // being persisted, so the next daemon start is a cold graph and a
-        // full recompile — with nothing recording why.
-        {
-            let state = Arc::clone(&self.state);
-            let shutdown_state = Arc::clone(&self.state);
-            std::mem::drop(supervise::spawn_supervised(
-                "depgraph-save",
-                move || shutdown_state.shutdown_requested.load(Ordering::Acquire),
-                supervise::Restart::Idempotent,
-                move || {
-                    let state = Arc::clone(&state);
-                    async move {
-                        let path = depgraph_file_path_for_cache_dir(&state.cache_dir);
-                        loop {
-                            tokio::time::sleep(std::time::Duration::from_secs(300)).await;
-                            if let Some(parent) = path.parent() {
-                                std::fs::create_dir_all(parent).ok();
-                            }
-                            let dg = state.dep_graph.load();
-                            match crate::depgraph::save_to_file(&dg, &path) {
-                                Ok(()) => {
-                                    state.dep_graph_persisted.store(true, Ordering::Release);
-                                    tracing::debug!("periodic depgraph save");
-                                }
-                                Err(e) => tracing::warn!("periodic depgraph save failed: {e}"),
-                            }
-                        }
-                    }
-                },
-            ));
-        }
+            ServiceMode::Standalone,
+        )
+        .with_idle_timeout_secs(idle_timeout_secs)
+        .start();
+        tracing::debug!(tasks = ?started.started, "maintenance schedule started");
+        let mut maintenance_handle = started.disk_maintenance;
 
         loop {
             tokio::select! {
@@ -835,7 +682,12 @@ pub(super) fn start_watcher_tasks(
     }
 }
 
-async fn run_memory_eviction_pass(state: &Arc<SharedState>, budget: u64) -> (u64, usize) {
+/// One memory-budget eviction sweep. Driven by the `memory-eviction` member of
+/// [`super::maintenance_schedule::MaintenanceSchedule`] in both service modes.
+pub(super) async fn run_memory_eviction_pass(
+    state: &Arc<SharedState>,
+    budget: u64,
+) -> (u64, usize) {
     let started = Instant::now();
     let mut total_freed = 0_u64;
     let mut total_items = 0_usize;

--- a/crates/zccache-daemon-core/src/daemon/server/supervise.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/supervise.rs
@@ -63,10 +63,17 @@ fn exit_reason(outcome: &Result<(), tokio::task::JoinError>) -> &'static str {
 ///
 /// `factory` builds the task future; it is called again on each restart, so it
 /// must capture whatever the loop needs by clone rather than by move-once.
+///
+/// `runtime_handle` carries the embedded host's runtime (zccache#922). Both the
+/// supervisor and every task it starts must land on it — a bare `tokio::spawn`
+/// would put supervised work on whatever runtime happened to be current at the
+/// call, which is precisely the contract the handle exists to enforce. `None`
+/// means "use the ambient runtime", which is the standalone daemon's case.
 pub(super) fn spawn_supervised<S, F, Fut>(
     name: &'static str,
     is_shutting_down: S,
     restart: Restart,
+    runtime_handle: Option<&tokio::runtime::Handle>,
     factory: F,
 ) -> tokio::task::JoinHandle<()>
 where
@@ -74,11 +81,18 @@ where
     F: Fn() -> Fut + Send + 'static,
     Fut: std::future::Future<Output = ()> + Send + 'static,
 {
-    tokio::spawn(async move {
+    let spawn_handle = runtime_handle.cloned();
+    let runtime_handle = runtime_handle.cloned();
+    let supervisor = async move {
         let mut restarts = 0u32;
         let mut backoff = RESTART_INITIAL_BACKOFF;
         loop {
-            let outcome = tokio::spawn(factory()).await;
+            let task = factory();
+            let outcome = match &runtime_handle {
+                Some(handle) => handle.spawn(task),
+                None => tokio::spawn(task),
+            }
+            .await;
 
             // A task ending during shutdown is the expected path, not a fault.
             if is_shutting_down() {
@@ -123,7 +137,11 @@ where
                 serde_json::json!({ "task": name, "restarts": restarts }),
             );
         }
-    })
+    };
+    match spawn_handle {
+        Some(handle) => handle.spawn(supervisor),
+        None => tokio::spawn(supervisor),
+    }
 }
 
 #[cfg(test)]

--- a/crates/zccache-daemon-core/src/daemon/server/tests/maintenance_schedule.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/maintenance_schedule.rs
@@ -1,0 +1,255 @@
+//! Mode-parity and embedded-behaviour tests for the shared maintenance
+//! schedule (issue #1160).
+//!
+//! The parity test is the recurrence guard: it compares the task names each
+//! mode *actually started* against the declaration in `MAINTENANCE_TASKS`, so
+//! a future task hand-spawned into one mode alone — the failure mode that
+//! produced #1148, #1160 and #1165 finding 6 — fails here rather than shipping.
+//!
+//! The behaviour tests inject short intervals instead of sleeping through the
+//! production 30 s / 300 s periods.
+
+use super::*;
+
+use std::collections::BTreeSet;
+
+const TICK: Duration = Duration::from_millis(20);
+const DEADLINE: Duration = Duration::from_secs(10);
+const POLL: Duration = Duration::from_millis(10);
+
+fn fast_intervals() -> MaintenanceIntervals {
+    MaintenanceIntervals {
+        memory_eviction: TICK,
+        depgraph_save: TICK,
+    }
+}
+
+/// Build a real `SharedState` over a throwaway cache root.
+///
+/// The schedule is state-driven, so a test double would only assert that the
+/// double was called. Building the real thing also proves the tasks can start
+/// against a freshly created root, which is what both services do.
+fn test_state(cache_dir: &crate::core::NormalizedPath) -> Arc<SharedState> {
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let identity = crate::ipc::current_backend_identity(&endpoint).expect("backend identity");
+    let (state, _index_writer_rx) =
+        new_shared_state(&endpoint, cache_dir, identity).expect("shared state");
+    state
+}
+
+/// Let every started loop observe shutdown so the temp root can be removed.
+fn stop(state: &Arc<SharedState>) {
+    state.shutdown_requested.store(true, Ordering::Release);
+    state.shutdown.notify_waiters();
+}
+
+async fn wait_until(mut ready: impl FnMut() -> bool) -> bool {
+    tokio::time::timeout(DEADLINE, async {
+        while !ready() {
+            tokio::time::sleep(POLL).await;
+        }
+    })
+    .await
+    .is_ok()
+}
+
+fn declared(mode: ServiceMode) -> BTreeSet<&'static str> {
+    MAINTENANCE_TASKS
+        .iter()
+        .filter(|task| task.runs_in(mode))
+        .map(|task| task.name)
+        .collect()
+}
+
+/// Embedded must start every member that is not explicitly standalone-only,
+/// and standalone must start everything. Both sides are compared against what
+/// `start()` reported spawning, not against the table alone.
+#[tokio::test]
+async fn embedded_starts_every_task_that_is_not_standalone_only() {
+    let standalone_root = tempfile::tempdir().expect("standalone root");
+    let embedded_root = tempfile::tempdir().expect("embedded root");
+    let standalone_state = test_state(&crate::core::NormalizedPath::new(standalone_root.path()));
+    let embedded_state = test_state(&crate::core::NormalizedPath::new(embedded_root.path()));
+
+    let standalone = MaintenanceSchedule::new(
+        Arc::clone(&standalone_state),
+        MaintenancePolicy::default(),
+        ServiceMode::Standalone,
+    )
+    .with_intervals(fast_intervals())
+    // Non-zero so the idle watchdog is actually started; with 0 the standalone
+    // daemon deliberately omits it and the comparison below would be vacuous.
+    .with_idle_timeout_secs(3600)
+    .start();
+    let embedded = MaintenanceSchedule::new(
+        Arc::clone(&embedded_state),
+        MaintenancePolicy::default(),
+        ServiceMode::Embedded,
+    )
+    .with_intervals(fast_intervals())
+    .start();
+
+    let standalone_started: BTreeSet<&'static str> = standalone.started.iter().copied().collect();
+    let embedded_started: BTreeSet<&'static str> = embedded.started.iter().copied().collect();
+
+    assert_eq!(
+        standalone_started,
+        declared(ServiceMode::Standalone),
+        "standalone must start exactly the declared schedule"
+    );
+    assert_eq!(
+        embedded_started,
+        declared(ServiceMode::Embedded),
+        "embedded must start exactly the declared schedule"
+    );
+
+    let missing_in_embedded: BTreeSet<&'static str> = standalone_started
+        .difference(&embedded_started)
+        .copied()
+        .collect();
+    let standalone_only: BTreeSet<&'static str> = MAINTENANCE_TASKS
+        .iter()
+        .filter(|task| task.standalone_only.is_some())
+        .map(|task| task.name)
+        .collect();
+    assert_eq!(
+        missing_in_embedded, standalone_only,
+        "a task may only be absent from embedded mode when it is flagged \
+         standalone-only with a rationale in MAINTENANCE_TASKS"
+    );
+
+    stop(&standalone_state);
+    stop(&embedded_state);
+}
+
+/// The parity test above drives the schedule directly, which proves the
+/// schedule is right but not that the embedded service still calls it. This
+/// closes that loop against a real `EmbeddedDaemon`: before #1160 it started no
+/// periodic task at all.
+#[tokio::test]
+async fn a_real_embedded_service_starts_the_whole_embedded_schedule() {
+    let root = tempfile::tempdir().expect("cache root");
+    let daemon = EmbeddedDaemon::start(
+        crate::ipc::unique_test_endpoint(),
+        crate::core::NormalizedPath::new(root.path()),
+        None,
+        MaintenancePolicy::default(),
+    )
+    .await
+    .expect("embedded daemon");
+
+    let started: BTreeSet<&'static str> = daemon.maintenance_tasks.iter().copied().collect();
+    assert_eq!(
+        started,
+        declared(ServiceMode::Embedded),
+        "the embedded service must start every non-standalone-only member"
+    );
+
+    let report = daemon.shutdown().await;
+    assert!(report.is_complete());
+}
+
+/// The flag is only honest if it carries an argument. An empty rationale would
+/// let a future omission pass the parity test above by simply flagging itself.
+#[test]
+fn every_standalone_only_task_states_why() {
+    for task in MAINTENANCE_TASKS {
+        if let Some(rationale) = task.standalone_only {
+            assert!(
+                rationale.len() > 40,
+                "standalone-only task {} needs a real rationale, got {rationale:?}",
+                task.name
+            );
+        }
+    }
+}
+
+/// #1160(b): embedded persisted the depgraph only inside a host-driven
+/// `flush()`, so a host crash lost the whole delta rather than one interval of
+/// it. A tick must now write the snapshot with no host call at all.
+#[tokio::test]
+async fn embedded_saves_the_depgraph_on_a_tick() {
+    let root = tempfile::tempdir().expect("cache root");
+    let cache_dir = crate::core::NormalizedPath::new(root.path());
+    let state = test_state(&cache_dir);
+    let depgraph_path = depgraph_file_path_for_cache_dir(&cache_dir);
+    std::fs::remove_file(&depgraph_path).ok();
+    state.dep_graph_persisted.store(false, Ordering::Release);
+
+    let started = MaintenanceSchedule::new(
+        Arc::clone(&state),
+        MaintenancePolicy::default(),
+        ServiceMode::Embedded,
+    )
+    .with_intervals(fast_intervals())
+    .start();
+    assert!(started.started.contains(&TASK_DEPGRAPH_SAVE));
+
+    let saved = wait_until(|| depgraph_path.exists()).await;
+    stop(&state);
+    assert!(
+        saved,
+        "embedded mode must persist the depgraph on its own tick, without a host flush()"
+    );
+    assert!(
+        state.dep_graph_persisted.load(Ordering::Acquire),
+        "a periodic save must mark the graph persisted"
+    );
+}
+
+/// #1160(c): the staged-temp sweep was startup-only and standalone-only, so an
+/// embedded host that never restarts its process never reclaimed an
+/// interrupted publish's leftovers.
+#[tokio::test]
+async fn embedded_sweeps_staged_artifact_temps() {
+    let root = tempfile::tempdir().expect("cache root");
+    let cache_dir = crate::core::NormalizedPath::new(root.path());
+    let state = test_state(&cache_dir);
+
+    let staged_root = state.artifact_dir.join(".staged-v2");
+    std::fs::create_dir_all(&staged_root).expect("staged root");
+    let orphan = staged_root.join(".interrupted-write.tmp");
+    std::fs::write(&orphan, b"partial").expect("orphan temp");
+
+    let started = MaintenanceSchedule::new(
+        Arc::clone(&state),
+        MaintenancePolicy::default(),
+        ServiceMode::Embedded,
+    )
+    .with_intervals(fast_intervals())
+    .start();
+    assert!(started.started.contains(&TASK_STAGED_TEMP_SWEEP));
+
+    let swept = wait_until(|| !orphan.exists()).await;
+    stop(&state);
+    assert!(
+        swept,
+        "embedded mode must reclaim interrupted-write staged temp files"
+    );
+}
+
+/// Host-owned disk maintenance suppresses only the disk loop. Suppressing the
+/// in-memory members with it would restore the #1160(a) leak, because no host
+/// API drives eviction or depgraph persistence.
+#[tokio::test]
+async fn host_owned_disk_maintenance_keeps_the_in_memory_members() {
+    let root = tempfile::tempdir().expect("cache root");
+    let state = test_state(&crate::core::NormalizedPath::new(root.path()));
+
+    let started = MaintenanceSchedule::new(
+        Arc::clone(&state),
+        MaintenancePolicy::default(),
+        ServiceMode::Embedded,
+    )
+    .with_intervals(fast_intervals())
+    .with_disk_maintenance(false)
+    .start();
+
+    assert!(started.disk_maintenance.is_none());
+    assert!(!started.started.contains(&TASK_DISK_MAINTENANCE));
+    assert!(started.started.contains(&TASK_MEMORY_EVICTION));
+    assert!(started.started.contains(&TASK_DEPGRAPH_SAVE));
+    assert!(started.started.contains(&TASK_STAGED_TEMP_SWEEP));
+
+    stop(&state);
+}

--- a/crates/zccache-daemon-core/src/daemon/server/tests/supervise.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/supervise.rs
@@ -30,6 +30,7 @@ async fn a_panicking_idempotent_task_is_restarted() {
         "test-panicker",
         never_shutting_down(),
         Restart::Idempotent,
+        None,
         move || {
             let counter = Arc::clone(&counter);
             async move {
@@ -80,6 +81,7 @@ async fn a_non_restartable_task_is_not_brought_back() {
         "test-unique",
         never_shutting_down(),
         Restart::Never,
+        None,
         move || {
             let counter = Arc::clone(&counter);
             async move {
@@ -114,6 +116,7 @@ async fn a_task_ending_during_shutdown_is_not_treated_as_a_fault() {
         "test-shutdown",
         move || flag.load(Ordering::Acquire),
         Restart::Idempotent,
+        None,
         move || {
             let counter = Arc::clone(&counter);
             async move {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,6 +36,7 @@ failed cache-root audit retain its diagnostic JSONL evidence.
 - **soldr target artifact contract** → [rust-artifact-plan.md](architecture/rust-artifact-plan.md)
 - **Embedded soldr/fbuild service integration** → [embedded-service.md](architecture/embedded-service.md)
 - **Embedded maintenance limits and shutdown reporting** → [embedded-service.md § Maintenance limits and task ownership](architecture/embedded-service.md#maintenance-limits-and-task-ownership)
+- **Shared periodic maintenance schedule (both service modes)** → [embedded-service.md § Maintenance limits and task ownership](architecture/embedded-service.md#maintenance-limits-and-task-ownership)
 - **Legacy action target snapshots** → [target-cache.md](architecture/target-cache.md)
 - **Thread safety & crash safety** → [runtime.md](architecture/runtime.md)
 - **Async/process bridge — watchdogs, cancellation & timeouts (deadlock hardening)** → [runtime.md § Async / process bridge](architecture/runtime.md#async--process-bridge-watchdogs-cancellation--timeouts)

--- a/docs/architecture/embedded-service.md
+++ b/docs/architecture/embedded-service.md
@@ -262,8 +262,27 @@ single policy shared with standalone mode.
 
 ### Maintenance limits and task ownership
 
+Both service modes start the **same** periodic set from one declaration:
+`MAINTENANCE_TASKS` in `daemon/server/maintenance_schedule.rs` (issue #1160).
+`DaemonServer::run` and `EmbeddedDaemon::start_background_tasks` each build a
+`MaintenanceSchedule` and call `start()`; nothing periodic may be hand-spawned
+in either. Shared members: the staged-artifact temp sweep, memory-budget
+eviction plus the ephemeral request/rsp trims, disk maintenance, and the
+periodic depgraph save. A member may be absent from embedded mode only when it
+is flagged `standalone_only` with a rationale — today the legacy temp-root
+cleanup, the idle watchdog, and private-daemon owner reaping, all of which
+either scan state an embedded host never wrote or would self-terminate the
+host's process. The parity test asserts each mode starts exactly its declared
+set, so adding a task to one mode alone fails rather than ships.
+
+`MaintenanceOwnership::Host` suppresses only the **disk** member; the in-memory
+members keep running, because no host API drives eviction or depgraph
+persistence and suppressing them would restore the unbounded growth #1160 is
+about.
+
 With `MaintenanceOwnership::Embedded`, embedded mode owns one disk-maintenance
-task in addition to the artifact-index writer. Both tasks spawn through
+task in addition to the artifact-index writer. Every schedule member — and the
+`spawn_supervised` supervisor wrapping the restartable ones — spawns through
 `RuntimeHooks::handle` when the host supplies one, so persistent work stays on
 the host-selected Tokio runtime. Maintenance waits for artifact-index
 hydration, runs an initial pressure or due full pass, performs cheap pressure

--- a/dylints/ban_unrooted_tempdir/src/allowlist.txt
+++ b/dylints/ban_unrooted_tempdir/src/allowlist.txt
@@ -26,12 +26,13 @@ crates/zccache-cli-core/src/cli/commands/wrap.rs
 # there at zccache runtime.
 crates/zccache-daemon-core/src/test_support/mod.rs
 
-# Daemon startup walks $TMPDIR to clean up legacy state from older zccache
-# installs (see `cleanup_legacy_temp_root_state`). The response-file write
-# paths at lines 2235/6817 are transient sidecars whose lifetime is bounded
-# by the compiler subprocess and which deliberately don't live under the
-# user-visible `~/.zccache/` tree. Migrating those is a follow-up.
-crates/zccache-daemon-core/src/daemon/server/run.rs
+# The legacy temp-root cleanup walks $TMPDIR looking for state older zccache
+# installs left there (see `cleanup_legacy_temp_root_state`). Reading the
+# system temp dir IS the job — the debris it reclaims is by definition not
+# under `~/.zccache/`, so there is nothing to re-root. It creates nothing
+# there. Moved here from `run.rs` by #1160, which made it a member of the
+# shared maintenance schedule; `run.rs` no longer touches $TMPDIR at all.
+crates/zccache-daemon-core/src/daemon/server/maintenance_schedule.rs
 
 # diag.rs reads `std::env::temp_dir()` purely to display its value in a
 # diagnostic dump (`zccache wrap --diag`). Nothing is created at the


### PR DESCRIPTION
Closes the embedded-mode maintenance gap in #1160.

## The gap

`spawn_disk_maintenance` was already shared by both modes, and #1285 folded session reaping and the stale-depfile sweep into it. But **memory-budget eviction, the ephemeral cache trims, the periodic depgraph save, and the staged-temp sweep were all spawned in `run.rs` only**. An embedded host — soldr, fbuild — ran none of them, so in a long-lived host process the caches grew unbounded and the depgraph was persisted only when the host explicitly called `flush()`/`shutdown()`.

## The shape of the fix

The important part is not moving four loops. It is that **there is now one declaration of what periodic maintenance exists**, and both modes start from it:

```rust
pub(super) const MAINTENANCE_TASKS: &[MaintenanceTaskSpec] = &[
    MaintenanceTaskSpec::shared(TASK_STAGED_TEMP_SWEEP),
    MaintenanceTaskSpec::shared(TASK_MEMORY_EVICTION),
    MaintenanceTaskSpec::shared(TASK_DISK_MAINTENANCE),
    MaintenanceTaskSpec::shared(TASK_DEPGRAPH_SAVE),
    MaintenanceTaskSpec::standalone_only(TASK_IDLE_WATCHDOG, "...self-terminating would take the host's own runtime state with it"),
    // ...
];
```

`shared` is the default; **standalone-only requires a rationale string**, so the next person adding a task cannot quietly give it to one mode. The three exclusions each state why the task is meaningless or actively harmful in-process — the idle watchdog and the private-owner reaper both end in process termination, which is the host's decision, not ours.

This extends the existing `disk_maintenance` loop and `spawn_supervised` rather than introducing a second scheduler.

## The host-runtime contract

`spawn_supervised` used bare `tokio::spawn`. Reusing it from embedded mode would have silently violated zccache#922 — all embedded work spawns on the host's runtime handle. It now takes `runtime_handle: Option<&Handle>` and uses it for **both** the supervisor and each restarted inner task, matching what `spawn_disk_maintenance` already did.

`MaintenanceOwnership::Host` now suppresses **only** the disk member. Memory eviction and the depgraph save keep running, because no host API drives them — suppressing them was never what "the host owns disk maintenance" meant.

## Tests

Six, and the first is the point:

- **`embedded_starts_every_task_that_is_not_standalone_only`** — the recurrence guard. It compares both modes' *actually-started* sets against the declaration and requires the difference to equal exactly the flagged set. Adding a task to one mode only fails it.
- `a_real_embedded_service_starts_the_whole_embedded_schedule` — same assertion against a live `EmbeddedDaemon`, so it also catches embedded ceasing to call the schedule at all.
- `every_standalone_only_task_states_why`, `embedded_saves_the_depgraph_on_a_tick` (20 ms injected interval — a real tick, not a sleep), `embedded_sweeps_staged_artifact_temps`, `host_owned_disk_maintenance_keeps_the_in_memory_members`.

**I verified the guard actually bites** rather than trusting it: re-flagging `memory-eviction` as standalone-only made three of the six fail with *"the embedded service must start every non-standalone-only member"*. Reverted, and the suite is green again.

## Evidence

- `soldr cargo test -p zccache-daemon-core --features "test-support,daemon-entry" --lib` — **710 passed, 0 failed**, 25 ignored (was 704 before this PR).
- `soldr cargo clippy -p zccache-daemon-core -p zccache-core --features "test-support,daemon-entry" --all-targets -- -D warnings` — clean.
- `soldr cargo check -p zccache-daemon-core` (**default features**) — clean. Checked deliberately: an optional-dependency mistake in this crate has broken the default-feature build twice.
- `soldr cargo check --workspace --all-targets` — clean.
- `run.rs` drops 1071 → 922 LOC; the new module is 467.

## Deliberately not done

The issue's parenthetical *"(surfaced in Status/report output)"* for the standalone-only rationales. That is a `DaemonStatus` field and therefore a `PROTOCOL_VERSION` bump; the rationales are logged at `debug!` when a task is skipped. Say the word and it is a small follow-up — flagging rather than folding a wire change into a behaviour fix.

`./test --integration` and Linux Docker validation from the issue's gate list were not run locally; **CI's Integration (Linux) leg is the authoritative run**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
