### PR TITLE
security(download): let a caller insist on checksum verification (#1172)

### DIFF
--- a/crates/zccache-cli-core/src/download_client/artifact/mod.rs
+++ b/crates/zccache-cli-core/src/download_client/artifact/mod.rs
@@ -110,6 +110,19 @@ pub struct FetchRequest {
     pub destination_path: NormalizedPath,
     pub destination_path_expanded: Option<NormalizedPath>,
     pub expected_sha256: Option<String>,
+    /// Refuse to accept an artifact that carries no `expected_sha256` (#1172).
+    ///
+    /// The checksum was optional at every call site, and a request without one
+    /// validated *successfully* — so "no integrity check" and "integrity check
+    /// passed" were the same outcome. Setting this makes the absence itself an
+    /// error, which is the only way a caller can insist on verification
+    /// without inspecting how the request was built.
+    ///
+    /// `#[serde(default)]` so an older serialized request still deserializes
+    /// as "not required", preserving today's behaviour for callers that have
+    /// not opted in.
+    #[serde(default)]
+    pub require_checksum: bool,
     pub archive_format: ArchiveFormat,
     pub wait_mode: WaitMode,
     pub dry_run: bool,
@@ -117,7 +130,40 @@ pub struct FetchRequest {
     pub download_options: DownloadOptions,
 }
 
+/// Env var that makes every fetch require a checksum (#1172).
+///
+/// Fleet-level policy: an operator or CI job can turn integrity checking from
+/// per-call-site opt-in into a floor nobody can forget, without auditing every
+/// caller. Unset (the default) preserves today's behaviour.
+pub const REQUIRE_CHECKSUM_ENV: &str = "ZCCACHE_REQUIRE_CHECKSUM";
+
+/// Does policy require every fetch to carry a checksum?
+fn checksum_required_by_policy() -> bool {
+    checksum_required_by_policy_with(|name| std::env::var(name).ok())
+}
+
+fn checksum_required_by_policy_with<F>(lookup: F) -> bool
+where
+    F: Fn(&str) -> Option<String>,
+{
+    lookup(REQUIRE_CHECKSUM_ENV).is_some_and(|value| {
+        let value = value.trim();
+        !value.is_empty()
+            && !matches!(
+                value.to_ascii_lowercase().as_str(),
+                "0" | "false" | "no" | "off" | "n"
+            )
+    })
+}
+
 impl FetchRequest {
+    /// Require a checksum for this fetch regardless of policy.
+    #[must_use]
+    pub fn require_checksum(mut self) -> Self {
+        self.require_checksum = true;
+        self
+    }
+
     #[must_use]
     pub fn new(
         source: impl Into<DownloadSource>,
@@ -128,6 +174,7 @@ impl FetchRequest {
             destination_path: destination_path.into(),
             destination_path_expanded: None,
             expected_sha256: None,
+            require_checksum: checksum_required_by_policy(),
             archive_format: ArchiveFormat::Auto,
             wait_mode: WaitMode::Block,
             dry_run: false,

--- a/crates/zccache-cli-core/src/download_client/artifact/resolve.rs
+++ b/crates/zccache-cli-core/src/download_client/artifact/resolve.rs
@@ -11,6 +11,7 @@ pub(super) struct ResolvedFetchRequest {
     pub(super) cache_path: NormalizedPath,
     pub(super) expanded_path: Option<NormalizedPath>,
     pub(super) expected_sha256: Option<String>,
+    pub(super) require_checksum: bool,
     pub(super) archive_format: ArchiveFormat,
     pub(super) wait_mode: WaitMode,
     pub(super) dry_run: bool,
@@ -28,6 +29,7 @@ pub(super) fn resolve_request(request: &FetchRequest) -> Result<ResolvedFetchReq
             .map(|p| normalize_target(p, true))
             .transpose()?,
         expected_sha256: request.expected_sha256.clone().map(normalize_sha256),
+        require_checksum: request.require_checksum,
         archive_format: request.archive_format,
         wait_mode: request.wait_mode,
         dry_run: request.dry_run,
@@ -48,6 +50,7 @@ pub(super) fn resolve_request_no_create(
             .map(|p| normalize_target(p, false))
             .transpose()?,
         expected_sha256: request.expected_sha256.clone().map(normalize_sha256),
+        require_checksum: request.require_checksum,
         archive_format: request.archive_format,
         wait_mode: request.wait_mode,
         dry_run: request.dry_run,

--- a/crates/zccache-cli-core/src/download_client/artifact/state.rs
+++ b/crates/zccache-cli-core/src/download_client/artifact/state.rs
@@ -89,11 +89,14 @@ pub(super) fn artifact_matches_request(
     request: &ResolvedFetchRequest,
     fingerprint: &ArtifactFingerprint,
 ) -> bool {
-    request
-        .expected_sha256
-        .as_ref()
-        .map(|expected_sha256| fingerprint.sha256 == *expected_sha256)
-        .unwrap_or(true)
+    match request.expected_sha256.as_ref() {
+        Some(expected_sha256) => fingerprint.sha256 == *expected_sha256,
+        // #1172: `unwrap_or(true)` meant "no checksum supplied" and "checksum
+        // matched" were the same answer, so a caller could not tell an
+        // unverified artifact from a verified one. When the caller asked for
+        // verification, absence is a failure, not a pass.
+        None => !request.require_checksum,
+    }
 }
 
 pub(super) fn validate_artifact(
@@ -103,6 +106,17 @@ pub(super) fn validate_artifact(
         return Err(format!(
             "downloaded artifact missing at {}",
             request.cache_path.display()
+        ));
+    }
+    // #1172: refuse before hashing. A required-but-absent checksum is a
+    // configuration failure, and reporting it as such is more useful than
+    // silently validating nothing.
+    if request.require_checksum && request.expected_sha256.is_none() {
+        return Err(format!(
+            "refusing to accept {}: no expected sha256 was supplied and checksum \
+             verification is required (set one on the request, or unset {})",
+            request.cache_path.display(),
+            super::REQUIRE_CHECKSUM_ENV,
         ));
     }
     let fingerprint =
@@ -126,5 +140,91 @@ pub(super) fn cleanup_invalid_fetch_state(request: &ResolvedFetchRequest) {
     if let Some(expanded_path) = &request.expanded_path {
         let _ = remove_path_if_exists(expanded_path);
         let _ = remove_path_if_exists(&expanded_marker_path(expanded_path));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::download_client::artifact::{
+        checksum_required_by_policy_with, FetchRequest, REQUIRE_CHECKSUM_ENV,
+    };
+
+    fn fingerprint(sha256: &str) -> ArtifactFingerprint {
+        ArtifactFingerprint {
+            bytes: 1,
+            sha256: sha256.to_string(),
+        }
+    }
+
+    fn resolved(expected: Option<&str>, require: bool) -> ResolvedFetchRequest {
+        let mut request = FetchRequest::new("https://example.invalid/a.tar", "/tmp/a.tar");
+        request.expected_sha256 = expected.map(str::to_string);
+        request.require_checksum = require;
+        super::super::resolve::resolve_request_no_create(&request).expect("resolve")
+    }
+
+    /// #1172: `unwrap_or(true)` made "no checksum supplied" and "checksum
+    /// matched" the same answer, so a caller could not tell an unverified
+    /// artifact from a verified one. When verification was asked for, absence
+    /// must be a failure.
+    #[test]
+    fn a_missing_checksum_does_not_pass_as_a_match_when_verification_is_required() {
+        let any = fingerprint("aa");
+        assert!(
+            artifact_matches_request(&resolved(None, false), &any),
+            "without the requirement, today's permissive behaviour is preserved"
+        );
+        assert!(
+            !artifact_matches_request(&resolved(None, true), &any),
+            "with the requirement, an unverified artifact must not match"
+        );
+    }
+
+    #[test]
+    fn a_supplied_checksum_is_still_compared_normally() {
+        assert!(artifact_matches_request(
+            &resolved(Some("aa"), true),
+            &fingerprint("aa")
+        ));
+        assert!(!artifact_matches_request(
+            &resolved(Some("aa"), true),
+            &fingerprint("bb")
+        ));
+    }
+
+    /// The error has to name the knob, or an operator who turned the policy on
+    /// fleet-wide gets a failure they cannot act on.
+    #[test]
+    fn requiring_a_checksum_without_supplying_one_is_a_named_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.tar");
+        std::fs::write(&path, b"payload").unwrap();
+
+        let mut request = FetchRequest::new("https://example.invalid/a.tar", path.clone());
+        request.require_checksum = true;
+        let resolved = super::super::resolve::resolve_request_no_create(&request).expect("resolve");
+
+        let error = validate_artifact(&resolved).expect_err("must refuse");
+        assert!(
+            error.contains(REQUIRE_CHECKSUM_ENV),
+            "the refusal must name the policy knob: {error}"
+        );
+    }
+
+    #[test]
+    fn the_policy_env_var_is_off_by_default_and_accepts_falsey_values() {
+        assert!(!checksum_required_by_policy_with(|_| None));
+        assert!(!checksum_required_by_policy_with(|_| Some("0".to_string())));
+        assert!(!checksum_required_by_policy_with(|_| Some(
+            "false".to_string()
+        )));
+        assert!(!checksum_required_by_policy_with(|_| Some(
+            "  ".to_string()
+        )));
+        assert!(checksum_required_by_policy_with(|_| Some("1".to_string())));
+        assert!(checksum_required_by_policy_with(|_| Some(
+            "yes".to_string()
+        )));
     }
 }


### PR DESCRIPTION
Findings F2b and F2c of #1172.

## The defect

`artifact_matches_request` ended in `.unwrap_or(true)`:

```rust
request.expected_sha256.as_ref()
    .map(|expected| fingerprint.sha256 == *expected)
    .unwrap_or(true)
```

So **"no checksum was supplied" and "the checksum matched" produced the same answer.** `validate_artifact` had the same shape — a request with no `expected_sha256` validated *successfully*. A caller could not distinguish an artifact that was verified from one that was never checked, and since the checksum is optional at every call site (CLI flag, PyO3 bindings, internal fetches), the unverified path was the default one.

## The fix

`FetchRequest::require_checksum` turns the absence into a failure:

- `artifact_matches_request` — a required-but-absent checksum no longer matches, so a cached artifact with no recorded digest is not silently accepted.
- `validate_artifact` — refuses **before hashing**, because a required-but-absent checksum is a configuration failure, and saying so is more useful than hashing and then validating nothing. The error names the policy knob, or an operator who enabled it fleet-wide gets a failure they cannot act on.

Two ways to turn it on:

- per-request, `FetchRequest::require_checksum()` — for callers that know their source publishes digests;
- fleet-wide, `ZCCACHE_REQUIRE_CHECKSUM` — so an operator or CI job can make verification a floor nobody can forget, without auditing every call site.

**Default is unchanged.** The field is `#[serde(default)]`, so an older serialized request still deserializes as "not required" and today's behaviour is preserved for callers that have not opted in. This is a capability, not a flag day — making it unconditional would break every internal fetch whose source publishes no digest, which is a separate piece of work (F2d) with a release-infrastructure dependency.

## Tests

- `a_missing_checksum_does_not_pass_as_a_match_when_verification_is_required` — asserts **both** directions: permissive without the requirement (so the default really is unchanged), refusing with it.
- `a_supplied_checksum_is_still_compared_normally` — match and mismatch, so the change cannot degenerate into "always false".
- `requiring_a_checksum_without_supplying_one_is_a_named_error` — the error must name the knob.
- `the_policy_env_var_is_off_by_default_and_accepts_falsey_values` — `0`/`false`/blank are off; the env lookup is injected rather than mutating process env, so the test cannot race a sibling.

## Evidence

- `soldr cargo test -p zccache-cli-core --features cli --lib` — **245 passed, 0 failed**, 2 ignored (241 before).
- `soldr cargo clippy -p zccache-cli-core --features cli --all-targets -- -D warnings` — clean.
- `soldr cargo check --workspace --all-targets` — clean.

No protocol bump: `FetchRequest` is not carried on the download-daemon wire (`zccache-download-protocol` does not reference it), and the new field is `serde(default)` regardless.

## Still open on #1172

- **F2d** — symbol fetches carry no checksum at all. That is not just a code change: the release does not currently publish a digest for the debug archives, so it needs release-infra work first. #1296 already set `https_only(true)` there so the transport is at least not downgradeable.
- **F2a** for `zccache-download`'s own client — its test suite serves over `http://`, so `https_only` there needs a test-only opt-out.
- **F1e** (Windows owner-only ACL), **F1f** (symbols footer digest).
- The issue's proposed `binary_integrity_unverified` / `insecure_download` audit rules remain **unimplementable as written** — `AuditRule` is a log-content grep engine and these are static properties. Detail and a suggested three-way re-scoping are in my earlier comment on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
