### PR TITLE
security(download): make the download engine https-only by default (#1172)

### DIFF
--- a/crates/zccache-cli-core/src/download_client/artifact/tests/fetch.rs
+++ b/crates/zccache-cli-core/src/download_client/artifact/tests/fetch.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use crate::download_client::DownloadClient;
 
-use super::super::{FetchRequest, FetchStateKind, FetchStatus, WaitMode};
+use super::super::{FetchStateKind, FetchStatus, WaitMode};
 use super::{
     fetch_with_retry, run_with_self_healing, sha256_hex, try_wait_for_test_condition, TestDaemon,
     TestHttpConfig, TestHttpServer,
@@ -31,7 +31,8 @@ fn fetch_cache_miss_then_hit_and_exists_stay_local() {
     });
     let client = DownloadClient::new(Some(daemon.endpoint.clone()));
     let dir = tempfile::tempdir().unwrap();
-    let mut request = FetchRequest::new(server.url.clone(), dir.path().join("artifact.bin"));
+    let mut request =
+        super::insecure_test_request(server.url.clone(), dir.path().join("artifact.bin"));
     request.expected_sha256 = Some(sha256_hex(&body));
 
     let first = fetch_with_retry(&client, request.clone()).unwrap();
@@ -67,7 +68,7 @@ fn fetch_checksum_mismatch_cleans_up_invalid_artifact() {
     let client = DownloadClient::new(Some(daemon.endpoint.clone()));
     let dir = tempfile::tempdir().unwrap();
     let destination = dir.path().join("bad.bin");
-    let mut request = FetchRequest::new(server.url.clone(), &destination);
+    let mut request = super::insecure_test_request(server.url.clone(), &destination);
     request.expected_sha256 = Some("00".repeat(32));
 
     let err = fetch_with_retry(&client, request.clone()).unwrap_err();
@@ -94,7 +95,8 @@ fn fetch_single_url_max_connections_uses_range_requests() {
     });
     let client = DownloadClient::new(Some(daemon.endpoint.clone()));
     let dir = tempfile::tempdir().unwrap();
-    let mut request = FetchRequest::new(server.url.clone(), dir.path().join("multipart.bin"));
+    let mut request =
+        super::insecure_test_request(server.url.clone(), dir.path().join("multipart.bin"));
     request.download_options.max_connections = Some(4);
     request.download_options.min_segment_size = Some(1024);
     request.expected_sha256 = Some(sha256_hex(&body));
@@ -150,7 +152,7 @@ fn fetch_explicit_multipart_urls_concatenates_and_stays_local() {
     let client = DownloadClient::new(Some(daemon.endpoint.clone()));
     let dir = tempfile::tempdir().unwrap();
     let destination = dir.path().join("artifact.bin");
-    let mut request = FetchRequest::new(
+    let mut request = super::insecure_test_request(
         vec![
             server_a.url.clone(),
             server_b.url.clone(),
@@ -213,7 +215,7 @@ fn fetch_no_wait_returns_locked_while_other_client_is_downloading() {
             let destination_for_thread = destination.clone();
             let download_thread = thread::spawn(move || {
                 let client = DownloadClient::new(Some(endpoint));
-                let request = FetchRequest::new(url, &destination_for_thread);
+                let request = super::insecure_test_request(url, &destination_for_thread);
                 fetch_with_retry(&client, request)
             });
 
@@ -224,7 +226,7 @@ fn fetch_no_wait_returns_locked_while_other_client_is_downloading() {
                     || request_started.load(Ordering::Acquire),
                 )?;
                 let client = DownloadClient::new(Some(daemon.endpoint.clone()));
-                let mut no_wait = FetchRequest::new(server.url.clone(), &destination);
+                let mut no_wait = super::insecure_test_request(server.url.clone(), &destination);
                 no_wait.wait_mode = WaitMode::NoWait;
                 let locked = fetch_with_retry(&client, no_wait)
                     .map_err(|err| format!("no-wait fetch failed: {err}"))?;
@@ -289,7 +291,7 @@ fn fetch_multipart_no_wait_returns_locked_while_other_client_is_downloading() {
             let destination_for_thread = destination.clone();
             let download_thread = thread::spawn(move || {
                 let client = DownloadClient::new(Some(endpoint));
-                let request = FetchRequest::new(source, &destination_for_thread);
+                let request = super::insecure_test_request(source, &destination_for_thread);
                 fetch_with_retry(&client, request)
             });
 
@@ -300,7 +302,7 @@ fn fetch_multipart_no_wait_returns_locked_while_other_client_is_downloading() {
                     || request_started.load(Ordering::Acquire),
                 )?;
                 let client = DownloadClient::new(Some(daemon.endpoint.clone()));
-                let mut no_wait = FetchRequest::new(
+                let mut no_wait = super::insecure_test_request(
                     vec![slow_server.url.clone(), fast_server.url.clone()],
                     &destination,
                 );
@@ -348,7 +350,7 @@ fn fetch_dry_run_avoids_network_and_filesystem_mutation() {
     let client = DownloadClient::new(Some(daemon.endpoint.clone()));
     let dir = tempfile::tempdir().unwrap();
     let destination = dir.path().join("dry.bin");
-    let mut request = FetchRequest::new(server.url.clone(), &destination);
+    let mut request = super::insecure_test_request(server.url.clone(), &destination);
     request.dry_run = true;
 
     let result = fetch_with_retry(&client, request).unwrap();
@@ -381,7 +383,7 @@ fn fetch_expands_7z_and_exists_reports_expanded_ready() {
     let client = DownloadClient::new(Some(daemon.endpoint.clone()));
     let cache_path = dir.path().join("cache").join("toolchain.7z");
     let expanded_path = dir.path().join("expanded");
-    let mut request = FetchRequest::new(server.url.clone(), &cache_path);
+    let mut request = super::insecure_test_request(server.url.clone(), &cache_path);
     request.destination_path_expanded = Some(expanded_path.clone().into());
     request.expected_sha256 = Some(sha256_hex(&archive_bytes));
 
@@ -425,12 +427,15 @@ fn fetch_without_expected_sha_then_validate_later_uses_stored_fingerprint() {
     let dir = tempfile::tempdir().unwrap();
     let destination = dir.path().join("delayed.bin");
 
-    let first =
-        fetch_with_retry(&client, FetchRequest::new(server.url.clone(), &destination)).unwrap();
+    let first = fetch_with_retry(
+        &client,
+        super::insecure_test_request(server.url.clone(), &destination),
+    )
+    .unwrap();
     assert_eq!(first.status, FetchStatus::Downloaded);
     assert_eq!(first.sha256, sha256_hex(&body));
 
-    let mut later = FetchRequest::new(server.url.clone(), &destination);
+    let mut later = super::insecure_test_request(server.url.clone(), &destination);
     later.expected_sha256 = Some(first.sha256.clone());
     let second = fetch_with_retry(&client, later.clone()).unwrap();
     assert_eq!(second.status, FetchStatus::AlreadyPresent);
@@ -469,12 +474,12 @@ fn expanded_state_remains_valid_when_expected_sha_is_added_later() {
     let cache_path = dir.path().join("cache").join("bundle.zip");
     let expanded_path = dir.path().join("expanded");
 
-    let mut initial = FetchRequest::new(server.url.clone(), &cache_path);
+    let mut initial = super::insecure_test_request(server.url.clone(), &cache_path);
     initial.destination_path_expanded = Some(expanded_path.clone().into());
     let first = fetch_with_retry(&client, initial).unwrap();
     assert_eq!(first.status, FetchStatus::Expanded);
 
-    let mut later = FetchRequest::new(server.url.clone(), &cache_path);
+    let mut later = super::insecure_test_request(server.url.clone(), &cache_path);
     later.destination_path_expanded = Some(expanded_path.clone().into());
     later.expected_sha256 = Some(first.sha256.clone());
     let second = fetch_with_retry(&client, later.clone()).unwrap();
@@ -504,9 +509,13 @@ fn force_is_rejected_for_existing_artifact_state() {
     let dir = tempfile::tempdir().unwrap();
     let destination = dir.path().join("immutable.bin");
 
-    let _ = fetch_with_retry(&client, FetchRequest::new(server.url.clone(), &destination)).unwrap();
+    let _ = fetch_with_retry(
+        &client,
+        super::insecure_test_request(server.url.clone(), &destination),
+    )
+    .unwrap();
 
-    let mut force = FetchRequest::new(server.url.clone(), &destination);
+    let mut force = super::insecure_test_request(server.url.clone(), &destination);
     force.force = true;
     let err = fetch_with_retry(&client, force).unwrap_err();
     assert!(err.contains("purge"));
@@ -539,7 +548,7 @@ fn fetch_rejects_unsafe_zip_entries_end_to_end() {
     let client = DownloadClient::new(Some(daemon.endpoint.clone()));
     let cache_path = dir.path().join("cache").join("unsafe.zip");
     let expanded_path = dir.path().join("expanded");
-    let mut request = FetchRequest::new(server.url.clone(), &cache_path);
+    let mut request = super::insecure_test_request(server.url.clone(), &cache_path);
     request.destination_path_expanded = Some(expanded_path.clone().into());
 
     let err = fetch_with_retry(&client, request).unwrap_err();

--- a/crates/zccache-cli-core/src/download_client/artifact/tests/mod.rs
+++ b/crates/zccache-cli-core/src/download_client/artifact/tests/mod.rs
@@ -512,3 +512,20 @@ fn tar_gz_extracts_regular_files() {
         b"hello"
     );
 }
+
+/// Build a [`FetchRequest`] aimed at one of this module's local test servers.
+///
+/// #1172 made the download engine https-only by default. These servers are
+/// plain `TcpListener`s with no certificate, so every request in the test
+/// suite has to opt out explicitly — which is the point of the flag: the
+/// insecure path stays reachable, but only by writing down that you want it.
+/// Centralised here so a new test cannot forget and get a confusing transport
+/// error instead of the behaviour it meant to assert.
+pub(super) fn insecure_test_request(
+    source: impl Into<super::DownloadSource>,
+    destination: impl Into<crate::core::NormalizedPath>,
+) -> super::FetchRequest {
+    let mut request = super::FetchRequest::new(source, destination);
+    request.download_options.allow_insecure_http = true;
+    request
+}

--- a/crates/zccache-cli/src/lib.rs
+++ b/crates/zccache-cli/src/lib.rs
@@ -424,6 +424,9 @@ impl NativeDownloadApi {
             force,
             max_connections,
             min_segment_size,
+            // #1172: inherit the https-only default rather than restating it,
+            // so a future security field cannot be dropped here silently.
+            ..Default::default()
         };
         let handle = self
             .client

--- a/crates/zccache-download/src/lib.rs
+++ b/crates/zccache-download/src/lib.rs
@@ -18,6 +18,20 @@ pub struct DownloadOptions {
     pub force: bool,
     pub max_connections: Option<usize>,
     pub min_segment_size: Option<u64>,
+    /// Permit plaintext `http://` for this download (#1172).
+    ///
+    /// The engine is https-only by default: downloaded artifacts are written
+    /// to disk and often executed or linked, and a checksum is optional at
+    /// most call sites, so the transport is frequently the only integrity
+    /// guarantee there is. `https_only` also makes an https→http **redirect**
+    /// fail rather than silently downgrade, which is the case a URL check at
+    /// the call site would miss.
+    ///
+    /// The escape hatch exists for local test servers, which have no
+    /// certificate. `#[serde(default)]` keeps it false — i.e. secure — for any
+    /// request serialized before this field existed.
+    #[serde(default)]
+    pub allow_insecure_http: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -131,6 +145,10 @@ pub async fn download_to_path(
 ) -> Result<Option<u64>, DownloadError> {
     let client = reqwest::Client::builder()
         .user_agent(format!("zccache-download/{}", zccache_core::VERSION))
+        // #1172: https-only unless the caller explicitly opted out. This also
+        // rejects an https→http redirect, which a URL check at the call site
+        // would not catch.
+        .https_only(!options.allow_insecure_http)
         .build()
         .map_err(|e| DownloadError::Http(e.to_string()))?;
 
@@ -715,6 +733,8 @@ mod tests {
                 force: false,
                 max_connections: Some(1),
                 min_segment_size: Some(1024),
+                // Local test server has no certificate (#1172).
+                allow_insecure_http: true,
             },
             progress,
             CancellationToken::new(),
@@ -772,6 +792,8 @@ mod tests {
                 force: false,
                 max_connections: Some(4),
                 min_segment_size: Some(1024),
+                // Local test server has no certificate (#1172).
+                allow_insecure_http: true,
             },
             Arc::new(|_, _, _| {}),
             CancellationToken::new(),
@@ -809,7 +831,11 @@ mod tests {
             &server.url,
             &destination,
             &metadata_dir,
-            &DownloadOptions::default(),
+            &DownloadOptions {
+                // Local test server has no certificate (#1172).
+                allow_insecure_http: true,
+                ..DownloadOptions::default()
+            },
             progress,
             CancellationToken::new(),
         )
@@ -852,6 +878,8 @@ mod tests {
                     force: false,
                     max_connections: Some(1),
                     min_segment_size: Some(4096),
+                    // Local test server has no certificate (#1172).
+                    allow_insecure_http: true,
                 },
                 progress,
                 cancel_clone,
@@ -893,5 +921,65 @@ mod tests {
         assert_eq!(percentage(1, Some(3)), Some(33.33));
         assert_eq!(percentage(2, Some(3)), Some(66.67));
         assert_eq!(percentage(0, None), None);
+    }
+
+    /// #1172: the engine is https-only by default. Downloaded artifacts are
+    /// written to disk and often executed or linked, and a checksum is
+    /// optional at most call sites, so the transport is frequently the only
+    /// integrity guarantee there is.
+    ///
+    /// This drives the real `download_to_path` against a real plaintext
+    /// server, so it fails if the builder ever stops applying the policy —
+    /// asserting on the flag alone would not.
+    #[tokio::test]
+    async fn plaintext_http_is_refused_unless_explicitly_allowed() {
+        let server = TestServer::start(TestServerConfig {
+            body: Arc::new(vec![0u8; 128]),
+            accept_ranges: false,
+            send_content_length: true,
+            chunk_size: 0,
+            chunk_delay_ms: 0,
+            etag: None,
+        })
+        .await;
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("payload.bin");
+        let metadata_dir = dir.path().join("metadata");
+
+        let refused = download_to_path(
+            &server.url,
+            &destination,
+            &metadata_dir,
+            // Default: the secure setting.
+            &DownloadOptions::default(),
+            Arc::new(|_, _, _| {}),
+            CancellationToken::new(),
+        )
+        .await;
+
+        assert!(
+            refused.is_err(),
+            "an http:// source must be refused by default, got {refused:?}"
+        );
+        assert!(
+            !destination.exists(),
+            "nothing may be written when the transport was refused"
+        );
+
+        // And the opt-out still works, so the escape hatch for local test
+        // servers is real rather than decorative.
+        let allowed = download_to_path(
+            &server.url,
+            &destination,
+            &metadata_dir,
+            &DownloadOptions {
+                allow_insecure_http: true,
+                ..DownloadOptions::default()
+            },
+            Arc::new(|_, _, _| {}),
+            CancellationToken::new(),
+        )
+        .await;
+        assert!(allowed.is_ok(), "explicit opt-in must still download");
     }
 }

--- a/crates/zccache/src/bin/zccache-download.rs
+++ b/crates/zccache/src/bin/zccache-download.rs
@@ -116,6 +116,8 @@ fn main() -> std::process::ExitCode {
                 force,
                 max_connections,
                 min_segment_size,
+                // #1172: inherit the https-only default.
+                ..Default::default()
             },
         ) {
             Ok(mut handle) => {
@@ -189,6 +191,8 @@ fn main() -> std::process::ExitCode {
                 force,
                 max_connections,
                 min_segment_size,
+                // #1172: inherit the https-only default.
+                ..Default::default()
             };
             match client.fetch(request) {
                 Ok(result) => {


### PR DESCRIPTION
Finding F2a of #1172, for the download engine. (#1296 already did the symbols client.)

## Why the transport matters here

`zccache-download` built its `reqwest` client with nothing but a user-agent. Artifacts it fetches are written to disk and often executed or linked, and a checksum is optional at most call sites — so for a large share of fetches the transport is the **only** integrity guarantee there is.

`https_only(true)` also rejects an **https→http redirect**, which is the case a URL check at the call site would miss entirely.

## Secure by default, with a named escape hatch

`DownloadOptions::allow_insecure_http` defaults to `false`, so the engine is https-only unless a caller explicitly opts out. `#[serde(default)]` means a request serialized before this field existed deserializes as *secure*, not as permissive — the safe direction for a defaulted security flag.

The escape hatch exists because this crate's own tests serve over plaintext `http://` from a local `TcpListener` with no certificate. Those four call sites now say `allow_insecure_http: true` with a comment naming why. That is the intended shape: the insecure path is reachable, but only by writing down that you want it.

## Test

`plaintext_http_is_refused_unless_explicitly_allowed` drives the real `download_to_path` against the real plaintext test server:

- with `DownloadOptions::default()` the download **fails** and **nothing is written** to the destination;
- with the opt-out it still succeeds, so the escape hatch is real rather than decorative.

It deliberately exercises the whole function rather than asserting on the flag — asserting the field's value would pass even if the builder stopped applying it.

## Evidence

- `soldr cargo test -p zccache-download --lib` — **6 passed, 0 failed** (5 before).
- `soldr cargo clippy -p zccache-download -p zccache-cli-core --features cli --all-targets -- -D warnings` — clean.
- `soldr cargo check --workspace --all-targets` — clean.

No protocol bump: `DownloadOptions` is not referenced by `zccache-download-protocol`, and the new field is `serde(default)` regardless.

## #1172 status after this

| Finding | State |
|---|---|
| F1a size-only reuse gate / F1c no content check before exec / F1d deploy-dir mode | fixed (#1295) |
| F1b atomic tmp+rename | already correct |
| F2e second unguarded extractor (**not in the issue text**) | fixed (#1296) |
| F2a `https_only` — symbols client | fixed (#1296) |
| F2a `https_only` — download engine | **this PR** |
| F2b `expected_sha256` fail-open / F2c checksum never mandatory | fixed (#1298) |
| F2d symbol fetches carry no checksum | open — needs release infra to publish a digest first |
| F1e Windows owner-only ACL on the deployed exe | open |
| F1f symbols footer carries no binary hash | open |
| #1159 audit rules | **mis-specified** — `AuditRule` is a log-content grep engine; these are static properties |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
