### PR TITLE
security(deploy): give the deploy directory a real owner-only DACL on Windows (#1172 F1e)

### DIFF
--- a/crates/zccache-cli-core/src/cli/runtime/deploy.rs
+++ b/crates/zccache-cli-core/src/cli/runtime/deploy.rs
@@ -152,8 +152,17 @@ fn ensure_deploy_dir_private(dir: &Path) -> std::io::Result<()> {
                 event = "insecure_deploy_dir",
                 path = %dir.display(),
                 outcome = "tightened",
-                "daemon deploy directory was group/other-writable and has been tightened; \
-                 another local user could have replaced the daemon binary until now"
+                // Deliberately states what was observed, not the worst case it
+                // could imply. On Windows this also fires the first time a
+                // version directory is seen, because a directory inheriting an
+                // otherwise-narrow profile DACL is not *protected* — nobody
+                // else could necessarily write it. Claiming "another user could
+                // have replaced your daemon" there would be a false alarm, and
+                // false alarms are how a loud-forensics convention stops being
+                // read.
+                "daemon deploy directory was not restricted to this user and has been \
+                 tightened; anything able to write it could choose what the CLI executes \
+                 as the daemon"
             );
             crate::core::lifecycle::write_event(
                 crate::core::lifecycle::EVENT_INSECURE_DEPLOY_DIR,

--- a/crates/zccache-core/Cargo.toml
+++ b/crates/zccache-core/Cargo.toml
@@ -24,6 +24,9 @@ libc = "0.2"
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_Security",
+    # #1172 F1e: Get/SetNamedSecurityInfoW + the SDDL converters used to put an
+    # owner-only DACL on the daemon deploy directory.
+    "Win32_Security_Authorization",
     "Win32_System_Threading",
 ] }
 

--- a/crates/zccache-core/src/config/README.md
+++ b/crates/zccache-core/src/config/README.md
@@ -16,6 +16,12 @@ Split into focused submodules (file-size discipline: every source file < 1,000 L
   (`artifacts_dir`, `tmp_dir`, `depfile_dir`, `depgraph_dir`, `log_dir`,
   `crash_dump_dir`, `index_path`, `metadata_path_from_cache_dir`,
   `symbols_cache_dir`, `cargo_registry_cache_dir`, etc.).
+- **`win_acl.rs`** *(Windows only)* - The Windows half of
+  `paths::ensure_dir_private` (#1172 F1e): reads a directory's DACL as SDDL and,
+  when it is not protected-and-owner-only, writes
+  `D:P(A;OICI;FA;;;<user>)(A;OICI;FA;;;SY)` and verifies it by read-back. This is
+  the access-control boundary on the daemon deploy directory, whose contents the
+  CLI executes. Mirrors `zccache-ipc`'s `transport/pipe_security.rs` (#1272).
 - **`namespace.rs`** - `ZCCACHE_DAEMON_NAMESPACE` parsing
   (`daemon_namespace`, `daemon_namespace_label`), IPC sanitization
   (`sanitize_ipc_component`, `sanitize_daemon_namespace`), and the FNV-1a

--- a/crates/zccache-core/src/config/mod.rs
+++ b/crates/zccache-core/src/config/mod.rs
@@ -11,6 +11,10 @@ pub mod cleanup;
 pub mod namespace;
 pub mod paths;
 pub mod resolve;
+/// Owner-only directory DACLs (#1172 F1e) — the Windows half of
+/// [`paths::ensure_dir_private`].
+#[cfg(windows)]
+mod win_acl;
 
 use super::NormalizedPath;
 

--- a/crates/zccache-core/src/config/paths.rs
+++ b/crates/zccache-core/src/config/paths.rs
@@ -34,8 +34,9 @@ use crate::NormalizedPath;
 /// is not this function's call to make. Detecting and reporting an
 /// already-loose directory is #1171 item 4.
 ///
-/// On Windows this is exactly `create_dir_all`: the equivalent control there
-/// is the pipe's DACL, which is #1171 item 2.
+/// On Windows this is exactly `create_dir_all`: directories are tightened by
+/// [`ensure_dir_private`] instead, which writes an explicit DACL (#1172 F1e).
+///
 /// Ensure an existing directory is not group- or other-writable, tightening
 /// it in place if it is (#1171 item 4).
 ///
@@ -51,8 +52,14 @@ use crate::NormalizedPath;
 /// it is how the socket gets substituted.
 ///
 /// Returns `Ok(false)` when nothing needed doing, `Ok(true)` when the mode was
-/// tightened, and `Err` when it is still loose afterwards. On Windows this is
-/// always `Ok(false)` — the equivalent control is the pipe DACL (#1171 item 2).
+/// tightened, and `Err` when it is still loose afterwards.
+///
+/// On Windows the same three outcomes come from a DACL rather than mode bits
+/// (#1172 F1e): a directory whose ACL is not protected-and-owner-only gets
+/// `D:P(A;OICI;FA;;;<user>)(A;OICI;FA;;;SY)` written to it, verified by
+/// read-back. This used to be a no-op, which left the daemon deploy directory
+/// — a directory the CLI *executes* a binary out of — unguarded. See
+/// `config::win_acl`.
 pub fn ensure_dir_private(path: &std::path::Path) -> std::io::Result<bool> {
     #[cfg(unix)]
     {
@@ -101,7 +108,16 @@ pub fn ensure_dir_private(path: &std::path::Path) -> std::io::Result<bool> {
         }
         Ok(true)
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        // #1172 F1e: the Windows arm used to be a bare `metadata()` probe, so
+        // the directory the CLI copies the daemon binary into — and then
+        // executes — had no enforced access control at all. `win_acl` applies
+        // the file-object equivalent of `0700`: a protected DACL naming the
+        // deploying user and SYSTEM.
+        super::win_acl::ensure_dir_private(path)
+    }
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = std::fs::metadata(path)?;
         Ok(false)

--- a/crates/zccache-core/src/config/win_acl.rs
+++ b/crates/zccache-core/src/config/win_acl.rs
@@ -43,12 +43,13 @@ use std::path::Path;
 use windows_sys::Win32::Foundation::{LocalFree, ERROR_SUCCESS, HLOCAL};
 use windows_sys::Win32::Security::Authorization::{
     ConvertSecurityDescriptorToStringSecurityDescriptorW, ConvertSidToStringSidW,
-    ConvertStringSecurityDescriptorToSecurityDescriptorW, GetNamedSecurityInfoW,
-    SetNamedSecurityInfoW, SDDL_REVISION_1, SE_FILE_OBJECT,
+    ConvertStringSecurityDescriptorToSecurityDescriptorW, ConvertStringSidToSidW,
+    GetNamedSecurityInfoW, SetNamedSecurityInfoW, SDDL_REVISION_1, SE_FILE_OBJECT,
 };
 use windows_sys::Win32::Security::{
-    GetSecurityDescriptorDacl, GetTokenInformation, TokenUser, ACL, DACL_SECURITY_INFORMATION,
-    PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, TOKEN_QUERY, TOKEN_USER,
+    EqualSid, GetSecurityDescriptorDacl, GetTokenInformation, TokenUser, ACL,
+    DACL_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR,
+    TOKEN_QUERY, TOKEN_USER,
 };
 use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
@@ -140,7 +141,53 @@ pub(super) fn is_owner_only(sddl: &str, user_sid: &str) -> bool {
     if rest.contains("NO_ACCESS_CONTROL") {
         return false;
     }
-    aces(rest).all(|trustee| trustee == user_sid || ALLOWED_TRUSTEES.contains(&trustee))
+    aces(rest).all(|trustee| trustee_is_self_or_admin(trustee, user_sid))
+}
+
+/// Is this ACE trustee the running user, SYSTEM, or Administrators?
+///
+/// Compares **SIDs, not strings**. `ConvertSecurityDescriptorToStringSecurityDescriptorW`
+/// substitutes a two-letter alias for well-known SIDs, and which SIDs count as
+/// "well-known" is not something the caller controls: a process running as the
+/// built-in Administrator gets its own account rendered as `LA`, so a raw-SID
+/// string comparison reports the directory as exposed *after we just tightened
+/// it*, and the read-back check then fails a DACL that is in fact correct.
+///
+/// CI found this — the Windows runner runs as that account and my dev host
+/// does not.
+fn trustee_is_self_or_admin(trustee: &str, user_sid: &str) -> bool {
+    if trustee == user_sid || ALLOWED_TRUSTEES.contains(&trustee) {
+        return true;
+    }
+    // Resolve both sides; `ConvertStringSidToSidW` accepts an alias as happily
+    // as a raw SID, which is exactly the normalization the string compare
+    // above lacks.
+    match (sid_bytes(trustee), sid_bytes(user_sid)) {
+        (Some(mut lhs), Some(mut rhs)) => {
+            // SAFETY: both buffers hold a valid SID copied out under
+            // `GetLengthSid`, and `EqualSid` only reads them.
+            unsafe { EqualSid(lhs.as_mut_ptr().cast(), rhs.as_mut_ptr().cast()) != 0 }
+        }
+        _ => false,
+    }
+}
+
+/// Copy the binary SID an SDDL trustee denotes, alias or raw.
+fn sid_bytes(trustee: &str) -> Option<Vec<u8>> {
+    let wide: Vec<u16> = trustee.encode_utf16().chain(std::iter::once(0)).collect();
+    let mut psid: windows_sys::Win32::Security::PSID = std::ptr::null_mut();
+    // SAFETY: `wide` is NUL-terminated; on success the SID is LocalAlloc'd and
+    // freed below on every path.
+    if unsafe { ConvertStringSidToSidW(wide.as_ptr(), &mut psid) } == 0 || psid.is_null() {
+        return None;
+    }
+    // SAFETY: `psid` is a valid SID from the call above.
+    let len = unsafe { windows_sys::Win32::Security::GetLengthSid(psid) } as usize;
+    // SAFETY: `psid` points at `len` readable bytes.
+    let bytes = unsafe { std::slice::from_raw_parts(psid.cast::<u8>(), len) }.to_vec();
+    // SAFETY: `psid` came from `ConvertStringSidToSidW`, which LocalAllocs.
+    unsafe { LocalFree(psid.cast::<std::ffi::c_void>()) };
+    Some(bytes)
 }
 
 /// Yield the trustee field of every ACE in an SDDL DACL body.
@@ -433,5 +480,42 @@ mod tests {
     fn an_unprotected_dacl_is_not_owner_only() {
         assert!(!is_owner_only("D:AI(A;OICIID;FA;;;S-1-5-18)", "S-1-5-18"));
         assert!(!is_owner_only("D:NO_ACCESS_CONTROL", "S-1-5-18"));
+    }
+
+    /// The alias case CI caught and this host could not.
+    ///
+    /// `ConvertSecurityDescriptorToStringSecurityDescriptorW` renders
+    /// well-known SIDs as two-letter aliases. A process running as the
+    /// built-in Administrator gets its *own* account back as `LA`, so a raw
+    /// string comparison declared the directory exposed immediately after
+    /// tightening it — and the read-back check then rejected a DACL that was
+    /// actually correct. The GitHub Windows runner runs as that account; my
+    /// dev host does not, which is exactly why this needs a test rather than a
+    /// manual probe.
+    #[test]
+    fn a_trustee_alias_matches_the_same_sid_written_longhand() {
+        // SYSTEM, both spellings, in both argument positions.
+        assert!(trustee_is_self_or_admin("SY", "S-1-5-18"));
+        assert!(trustee_is_self_or_admin("S-1-5-18", "SY"));
+
+        // The shape CI hit: the ACE for the running user comes back aliased
+        // while the SID we compare against is spelled out longhand.
+        assert!(
+            is_owner_only("D:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;S-1-5-18)", "S-1-5-18"),
+            "an aliased trustee must resolve to its SID, not be read as a stranger"
+        );
+
+        // `LA` is the built-in Administrator *account*, not SYSTEM — a
+        // different principal, and it must not be waved through just because
+        // it happens to be an alias. (Getting this backwards is what made the
+        // first version of this test fail.)
+        assert!(!trustee_is_self_or_admin("LA", "S-1-5-18"));
+
+        // And the comparison must still reject an actual stranger.
+        assert!(!trustee_is_self_or_admin("WD", "S-1-5-18"));
+        assert!(
+            !is_owner_only("D:PAI(A;OICI;FA;;;WD)(A;OICI;FA;;;SY)", "S-1-5-18"),
+            "Everyone must not be accepted just because SYSTEM is also listed"
+        );
     }
 }

--- a/crates/zccache-core/src/config/win_acl.rs
+++ b/crates/zccache-core/src/config/win_acl.rs
@@ -1,0 +1,437 @@
+//! Owner-only DACL for the daemon deploy directory on Windows (#1172 F1e).
+//!
+//! [`ensure_dir_private`](super::paths::ensure_dir_private) expressed "private"
+//! as unix mode bits and did nothing at all on Windows, so the directory the
+//! CLI copies the daemon binary into — and then *executes* — was left with
+//! whatever the profile tree inherits. That is normally
+//!
+//! ```text
+//! D:AI(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)(A;OICIID;FA;;;S-1-5-21-…-1001)
+//! ```
+//!
+//! under `%USERPROFILE%`, which is already narrow — but nothing *enforced* it.
+//! A cache root relocated by `ZCCACHE_CACHE_DIR` to `C:\ProgramData\…`,
+//! `C:\zccache`, or any directory created off the volume root inherits
+//! `BUILTIN\Users:(OI)(CI)(M)` or `CREATOR OWNER` grants instead, and then any
+//! local account can replace `zccache-daemon.exe` between the CLI's integrity
+//! check and the spawn. Whoever can write that directory chooses what the CLI
+//! runs as the daemon.
+//!
+//! The replacement mirrors the named-pipe descriptor from #1272
+//! (`transport/pipe_security.rs`): `D:P(A;OICI;FA;;;<user>)(A;OICI;FA;;;SY)`.
+//! The `P` (PROTECTED) flag is load-bearing — without it the inherited `Users`
+//! and `CREATOR OWNER` aces this exists to remove come straight back. `OICI`
+//! makes the deployed binary itself inherit the same pair, so the file is
+//! covered and not just its directory.
+//!
+//! Two deliberate differences from the pipe:
+//!
+//! * The trustee is the **current token user's SID**, not `OW` (OWNER RIGHTS).
+//!   `OW` resolves through object ownership, and a directory created by an
+//!   elevated process is owned by `BUILTIN\Administrators`, not by the user —
+//!   which would leave the CLI unable to write its own deploy directory. The
+//!   explicit SID is the account that actually deploys and spawns.
+//! * `SYSTEM` and `BUILTIN\Administrators` are *accepted* when already present
+//!   on a directory, and never treated as a finding. An administrator can take
+//!   ownership regardless, so an ACE for them grants nothing an attacker at
+//!   that privilege level did not already have.
+
+use std::io;
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
+
+use windows_sys::Win32::Foundation::{LocalFree, ERROR_SUCCESS, HLOCAL};
+use windows_sys::Win32::Security::Authorization::{
+    ConvertSecurityDescriptorToStringSecurityDescriptorW, ConvertSidToStringSidW,
+    ConvertStringSecurityDescriptorToSecurityDescriptorW, GetNamedSecurityInfoW,
+    SetNamedSecurityInfoW, SDDL_REVISION_1, SE_FILE_OBJECT,
+};
+use windows_sys::Win32::Security::{
+    GetSecurityDescriptorDacl, GetTokenInformation, TokenUser, ACL, DACL_SECURITY_INFORMATION,
+    PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, TOKEN_QUERY, TOKEN_USER,
+};
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+/// Inheritance flags on every ACE we write: `OBJECT_INHERIT` +
+/// `CONTAINER_INHERIT`, so the deployed `zccache-daemon.exe` carries the same
+/// owner-only pair rather than relying on the directory alone.
+const ACE_INHERIT_FLAGS: &str = "OICI";
+
+/// `FILE_ALL_ACCESS`. Spelled as the file-object right rather than the generic
+/// `GA` the pipe uses, because `icacls` and the round-tripped SDDL report a
+/// file-object DACL in mapped form and an unmapped `GA` would make the
+/// already-private comparison below never match its own output.
+const ACE_RIGHTS: &str = "FA";
+
+/// Trustees that may appear in a deploy-directory DACL without it counting as
+/// exposed. Both the two-letter SDDL alias and the raw SID are listed because
+/// which one comes back from
+/// `ConvertSecurityDescriptorToStringSecurityDescriptorW` is not contractual.
+const ALLOWED_TRUSTEES: &[&str] = &[
+    "SY",           // NT AUTHORITY\SYSTEM
+    "S-1-5-18",     //   "
+    "BA",           // BUILTIN\Administrators
+    "S-1-5-32-544", //   "
+];
+
+/// Number of `;`-separated fields in an SDDL ACE; the trustee is the last one.
+const ACE_FIELDS: usize = 6;
+
+/// Ensure `path` is writable only by the current user (plus SYSTEM and
+/// Administrators), applying an explicit protected DACL when it is not.
+///
+/// Returns `Ok(false)` when the directory was already private, `Ok(true)` when
+/// it was tightened, and `Err` when it is still exposed afterwards — the same
+/// three outcomes the unix arm reports, so the caller's "tightened" /
+/// "refused" lifecycle contract is unchanged.
+pub(super) fn ensure_dir_private(path: &Path) -> io::Result<bool> {
+    // Matches the unix arm's `metadata()` probe: a missing directory is an
+    // error, not a silent pass — the caller is about to deploy a binary here.
+    let _ = std::fs::metadata(path)?;
+
+    let user_sid = current_user_sid()?;
+    let current = dacl_sddl(path)?;
+    if is_owner_only(&current, &user_sid) {
+        return Ok(false);
+    }
+
+    apply_dacl(path, &owner_only_sddl(&user_sid))?;
+
+    // Read back rather than trusting the write. `SetNamedSecurityInfoW` can
+    // report success on filesystems that do not carry ACLs at all (FAT32, some
+    // network redirectors), and this is exactly the case where a false negative
+    // is expensive.
+    let after = dacl_sddl(path)?;
+    if !is_owner_only(&after, &user_sid) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "{} is writable by other local users (DACL {after}) and could not be tightened",
+                path.display()
+            ),
+        ));
+    }
+    Ok(true)
+}
+
+/// The protected owner-only DACL written to an exposed directory.
+fn owner_only_sddl(user_sid: &str) -> String {
+    format!("D:P(A;{ACE_INHERIT_FLAGS};{ACE_RIGHTS};;;{user_sid})(A;{ACE_INHERIT_FLAGS};{ACE_RIGHTS};;;SY)")
+}
+
+/// Is this DACL protected from inheritance *and* free of any trustee other
+/// than the deploying user, SYSTEM, and Administrators?
+///
+/// Both halves matter. An unprotected DACL whose current aces happen to be
+/// narrow is one `icacls` reset — or one move to a differently-permissioned
+/// parent — away from re-acquiring `BUILTIN\Users`, so it is reported as
+/// needing repair rather than accepted.
+pub(super) fn is_owner_only(sddl: &str, user_sid: &str) -> bool {
+    let Some(rest) = sddl.strip_prefix("D:") else {
+        return false;
+    };
+    let flags = rest.split('(').next().unwrap_or_default();
+    if !flags.contains('P') {
+        return false;
+    }
+    // A NULL DACL grants everyone everything and renders as a flag word, with
+    // no aces to iterate — the `P` check above already rejects it, but the
+    // ace loop must not be read as "no aces means private".
+    if rest.contains("NO_ACCESS_CONTROL") {
+        return false;
+    }
+    aces(rest).all(|trustee| trustee == user_sid || ALLOWED_TRUSTEES.contains(&trustee))
+}
+
+/// Yield the trustee field of every ACE in an SDDL DACL body.
+fn aces(body: &str) -> impl Iterator<Item = &str> {
+    body.split('(').skip(1).filter_map(|ace| {
+        let ace = ace.split(')').next()?;
+        let fields: Vec<&str> = ace.split(';').collect();
+        (fields.len() >= ACE_FIELDS).then(|| fields[ACE_FIELDS - 1])
+    })
+}
+
+/// UTF-16, NUL-terminated — what every `*W` entry point below expects.
+fn wide(path: &Path) -> Vec<u16> {
+    path.as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+/// String SID of the user this process runs as.
+fn current_user_sid() -> io::Result<String> {
+    let mut token: windows_sys::Win32::Foundation::HANDLE = std::ptr::null_mut();
+    // SAFETY: `GetCurrentProcess` returns a pseudo-handle that needs no
+    // release; `token` is a valid out-pointer we close below on every path.
+    let ok = unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let result = token_user_sid(token);
+    // SAFETY: `token` was opened above and is closed exactly once here.
+    unsafe { windows_sys::Win32::Foundation::CloseHandle(token) };
+    result
+}
+
+fn token_user_sid(token: windows_sys::Win32::Foundation::HANDLE) -> io::Result<String> {
+    let mut needed: u32 = 0;
+    // SAFETY: the first call is the documented size probe — a null buffer with
+    // zero length is expected to fail with ERROR_INSUFFICIENT_BUFFER and fill
+    // `needed`.
+    unsafe {
+        GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut needed);
+    }
+    if needed == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut buffer = vec![0u8; needed as usize];
+    // SAFETY: `buffer` is at least `needed` bytes and outlives the call.
+    let ok = unsafe {
+        GetTokenInformation(
+            token,
+            TokenUser,
+            buffer.as_mut_ptr().cast(),
+            needed,
+            &mut needed,
+        )
+    };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: on success Windows wrote a TOKEN_USER at the head of `buffer`,
+    // whose `Sid` points into that same allocation and stays valid while
+    // `buffer` lives.
+    let sid = unsafe { (*buffer.as_ptr().cast::<TOKEN_USER>()).User.Sid };
+
+    let mut text: *mut u16 = std::ptr::null_mut();
+    // SAFETY: `sid` is the live SID above; `text` is a valid out-pointer that
+    // Windows fills with a LocalAlloc'd string we free below.
+    let ok = unsafe { ConvertSidToStringSidW(sid, &mut text) };
+    if ok == 0 || text.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+    let sid_string = wide_to_string(text);
+    // SAFETY: `text` came from ConvertSidToStringSidW, whose documented
+    // release is LocalFree, and is freed exactly once.
+    unsafe { LocalFree(text as HLOCAL) };
+    Ok(sid_string)
+}
+
+/// Read `path`'s DACL back as SDDL. This is the honest observation the
+/// tightening decision and the tests are both made from — never the constant
+/// we passed in.
+pub(super) fn dacl_sddl(path: &Path) -> io::Result<String> {
+    let wide_path = wide(path);
+    let mut descriptor: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+    let mut dacl: *mut ACL = std::ptr::null_mut();
+
+    // SAFETY: `wide_path` is NUL-terminated and outlives the call; all
+    // out-pointers are valid. On success Windows allocates `descriptor` and we
+    // release it below with the documented LocalFree.
+    let status = unsafe {
+        GetNamedSecurityInfoW(
+            wide_path.as_ptr(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut dacl,
+            std::ptr::null_mut(),
+            &mut descriptor,
+        )
+    };
+    if status != ERROR_SUCCESS {
+        return Err(io::Error::from_raw_os_error(status as i32));
+    }
+
+    let mut text: *mut u16 = std::ptr::null_mut();
+    // SAFETY: `descriptor` is the descriptor just returned and still live.
+    let ok = unsafe {
+        ConvertSecurityDescriptorToStringSecurityDescriptorW(
+            descriptor,
+            SDDL_REVISION_1,
+            DACL_SECURITY_INFORMATION,
+            &mut text,
+            std::ptr::null_mut(),
+        )
+    };
+    if ok == 0 || text.is_null() {
+        let err = io::Error::last_os_error();
+        // SAFETY: `descriptor` is live and freed exactly once on this path.
+        unsafe { LocalFree(descriptor as HLOCAL) };
+        return Err(err);
+    }
+    let sddl = wide_to_string(text);
+    // SAFETY: both allocations came from Win32 LocalAlloc-family calls and are
+    // each freed exactly once here.
+    unsafe {
+        LocalFree(text as HLOCAL);
+        LocalFree(descriptor as HLOCAL);
+    }
+    Ok(sddl)
+}
+
+/// Install `sddl`'s DACL on `path`, protected from inheritance.
+fn apply_dacl(path: &Path, sddl: &str) -> io::Result<()> {
+    let wide_sddl: Vec<u16> = sddl.encode_utf16().chain(std::iter::once(0)).collect();
+    let mut descriptor: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+    // SAFETY: `wide_sddl` is NUL-terminated and outlives the call; on success
+    // Windows allocates `descriptor`, released below.
+    let ok = unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            wide_sddl.as_ptr(),
+            SDDL_REVISION_1,
+            &mut descriptor,
+            std::ptr::null_mut(),
+        )
+    };
+    if ok == 0 || descriptor.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+
+    let mut dacl: *mut ACL = std::ptr::null_mut();
+    let mut present: i32 = 0;
+    let mut defaulted: i32 = 0;
+    // SAFETY: `descriptor` is the live descriptor above; `dacl` borrows from
+    // it and stays valid until the LocalFree below.
+    let ok =
+        unsafe { GetSecurityDescriptorDacl(descriptor, &mut present, &mut dacl, &mut defaulted) };
+    let result = if ok == 0 || present == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        let mut wide_path = wide(path);
+        // SAFETY: `wide_path` is a NUL-terminated mutable buffer and `dacl`
+        // points into the descriptor that is still live for this call. The
+        // DACL is copied into the object's security descriptor by the kernel,
+        // so releasing ours afterwards is sound.
+        let status = unsafe {
+            SetNamedSecurityInfoW(
+                wide_path.as_mut_ptr(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                dacl,
+                std::ptr::null_mut(),
+            )
+        };
+        if status == ERROR_SUCCESS {
+            Ok(())
+        } else {
+            Err(io::Error::from_raw_os_error(status as i32))
+        }
+    };
+
+    // SAFETY: `descriptor` came from the SDDL conversion above and is freed
+    // exactly once, after the last use of the `dacl` pointer into it.
+    unsafe { LocalFree(descriptor as HLOCAL) };
+    result
+}
+
+/// Copy a NUL-terminated Windows string out of a Win32 allocation.
+fn wide_to_string(text: *const u16) -> String {
+    let mut len = 0usize;
+    // SAFETY: `text` is a NUL-terminated buffer produced by Win32; the walk
+    // stops at that terminator and never reads past it.
+    while unsafe { *text.add(len) } != 0 {
+        len += 1;
+    }
+    // SAFETY: `len` units precede the terminator found above.
+    let slice = unsafe { std::slice::from_raw_parts(text, len) };
+    String::from_utf16_lossy(slice)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #1172 F1e: the deploy directory holds a binary the CLI executes, so
+    /// anything that can write it chooses what runs as the daemon. This drives
+    /// the real code path and reads the DACL back off the created directory,
+    /// so it fails against the pre-fix no-op rather than restating a constant.
+    #[test]
+    fn a_users_writable_deploy_dir_is_tightened_to_owner_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = temp.path().join("deploy");
+        std::fs::create_dir(&dir).unwrap();
+
+        // Give BUILTIN\Users modify, inherited-style — the grant a cache root
+        // under C:\ or C:\ProgramData picks up, and the one that makes this a
+        // finding rather than a hardening nicety.
+        let user_sid = current_user_sid().unwrap();
+        apply_dacl(
+            &dir,
+            &format!("D:(A;OICI;FA;;;{user_sid})(A;OICI;0x1301bf;;;BU)"),
+        )
+        .unwrap();
+        let before = dacl_sddl(&dir).unwrap();
+        println!("DACL before: {before}");
+        assert!(
+            !is_owner_only(&before, &user_sid),
+            "the test fixture must start exposed, got {before}"
+        );
+
+        let changed = super::ensure_dir_private(&dir).unwrap();
+
+        let after = dacl_sddl(&dir).unwrap();
+        println!("DACL after:  {after}");
+        assert!(changed, "an exposed dir must report that it was repaired");
+        assert!(
+            is_owner_only(&after, &user_sid),
+            "the repair must leave the deploy dir owner-only, got {after}"
+        );
+        assert!(
+            !after.contains(";BU)"),
+            "BUILTIN\\Users must not retain write access: {after}"
+        );
+
+        // The point of the DACL is that the CLI can still deploy into it.
+        std::fs::write(dir.join("zccache-daemon.exe"), b"probe").unwrap();
+    }
+
+    /// Idempotence matters: this runs on every daemon spawn, and a directory
+    /// that reported "tightened" forever would emit a security lifecycle event
+    /// on every compile.
+    #[test]
+    fn an_already_private_dir_is_left_untouched() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = temp.path().join("deploy");
+        std::fs::create_dir(&dir).unwrap();
+
+        super::ensure_dir_private(&dir).unwrap();
+        let second = super::ensure_dir_private(&dir).unwrap();
+
+        assert!(
+            !second,
+            "a dir already tightened must need no repair the second time"
+        );
+    }
+
+    /// A missing directory is an error, not a silent pass — the caller is
+    /// about to copy a binary into it.
+    #[test]
+    fn ensuring_a_missing_dir_is_an_error() {
+        let temp = tempfile::tempdir().unwrap();
+        super::ensure_dir_private(&temp.path().join("nope"))
+            .expect_err("a missing deploy directory must not report success");
+    }
+
+    /// The SDDL we write must be accepted by Windows and must satisfy our own
+    /// predicate — a typo would otherwise loop forever between "not private"
+    /// and a set that never converges.
+    #[test]
+    fn the_owner_only_sddl_round_trips() {
+        let user_sid = current_user_sid().unwrap();
+        assert!(is_owner_only(&owner_only_sddl(&user_sid), &user_sid));
+    }
+
+    /// An unprotected DACL is one `icacls` reset away from re-inheriting
+    /// `BUILTIN\Users`, so it must not be accepted as private.
+    #[test]
+    fn an_unprotected_dacl_is_not_owner_only() {
+        assert!(!is_owner_only("D:AI(A;OICIID;FA;;;S-1-5-18)", "S-1-5-18"));
+        assert!(!is_owner_only("D:NO_ACCESS_CONTROL", "S-1-5-18"));
+    }
+}


### PR DESCRIPTION
Finding F1e of #1172. Completes the deploy-directory half started in #1295.

## The gap

#1295 made the daemon deploy directory owner-only through `ensure_dir_private` — but that function's non-unix arm was a **no-op**. On Windows the directory got no protection at all, while the CLI happily executed whatever binary it found there.

## What this does

`ensure_dir_private` gets a real Windows implementation:

1. read the live DACL (`GetNamedSecurityInfoW`),
2. return "already private" if it is **protected** (`D:P…`) and grants nobody outside {token user, `SY`, `BA`},
3. otherwise write `D:P(A;OICI;FA;;;<user-sid>)(A;OICI;FA;;;SY)`,
4. **read it back and re-check** — FAT32 and some network redirectors report success without applying anything, and a security fix that silently no-ops is worse than an absent one.

Administrators and SYSTEM keeping access is not a finding: an admin already owns the machine. Same reasoning as the pipe DACL in #1272.

Unix behaviour is unchanged — verified by cross-checking the linux target, not just by reading the `cfg`.

### Two deliberate departures from the pipe's SDDL

- **Explicit token-user SID rather than `OW`.** A directory created from an elevated shell is owned by `BUILTIN\Administrators`, so an `OW`-based ACE could lock the normal-user CLI out of its own deploy directory.
- **`FA` rather than `GA`.** A file-object DACL round-trips in *mapped* form, so an unmapped `GA` would never compare equal to its own read-back — the code would re-tighten on every single spawn.

Both are recorded in the module header, because both are the kind of thing that looks like a typo later.

## Observed behaviour on a real Windows host

This is the part that matters for a security change, so it was probed rather than assumed. A directory granted `BUILTIN\Users:(OI)(CI)(M)`, run through the public API:

```
SDDL BEFORE: D:PAI(A;OICI;FA;;;S-1-5-21-…-1001)(A;OICI;0x1301bf;;;BU)
ensure_dir_private -> tightened=true
SDDL AFTER:  D:PAI(A;OICI;FA;;;S-1-5-21-…-1001)(A;OICI;FA;;;SY)

icacls AFTER (deployed binary, inherited):
  …\zccache-daemon.exe  <user>:(I)(F)
                        NT AUTHORITY\SYSTEM:(I)(F)
```

`BUILTIN\Users` is gone, the DACL is protected, and `OICI` propagates to the deployed `zccache-daemon.exe` — so the **binary** is covered, not merely its directory. A write into the directory afterwards still succeeds, so the CLI can still deploy.

Five Windows-gated tests carry this: the tightening (asserting on the read-back DACL and proving the CLI retains write access), idempotence, missing-dir error, SDDL round-trip, and rejection of unprotected / `NO_ACCESS_CONTROL` DACLs. The test *is* the probe, per the pattern #1272 established.

## Also: the warning no longer overclaims

The `insecure_deploy_dir` message said *"another local user could have replaced the daemon binary until now"*. On Windows that now fires the first time each version directory is seen, because a directory inheriting an otherwise-narrow profile DACL is not **protected** — even though nobody else could necessarily write it.

Asserting a compromise window that may not have existed is a false alarm, and false alarms are exactly how a loud-forensics convention stops being read. The message now states what was observed — the directory was not restricted to this user — and what the consequence would be.

## Evidence

- `soldr cargo test -p zccache-core --lib` — **125 passed, 0 failed** (5 new).
- `soldr cargo test -p zccache-cli-core --features cli --lib` — **245 passed, 0 failed**, 2 ignored.
- `soldr cargo clippy -p zccache-core -p zccache-cli-core --features cli --all-targets -- -D warnings` — clean.
- `soldr cargo check --workspace --all-targets`, `soldr cargo check -p zccache-core` (default features), `RUSTDOCFLAGS="-D warnings" … doc` — all clean.
- `soldr cargo check -p zccache-core --target x86_64-unknown-linux-gnu` — clean; the unix arm is unregressed.

## Residual, flagged not hidden

`create_dir_all_private` is still a plain `create_dir_all` on Windows, so a freshly created deploy directory has a narrow window between creation and the DACL write. Closing it needs `SECURITY_ATTRIBUTES` on `CreateDirectoryW`, for which `std` offers no seam. Out of F1e's scope, but real — worth its own issue if you want it closed.

## #1172 after this

Remaining: **F1f** (symbols footer carries no binary hash) and **F2d** (symbol fetches carry no checksum — blocked on the release publishing a digest). The issue's proposed #1159 audit rules remain unimplementable as written; details in my earlier comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
