### PR TITLE
fix(cache): reconcile a corrupt artifact index instead of wiping the cache (#1157)

### DIFF
--- a/crates/zccache-artifact/Cargo.toml
+++ b/crates/zccache-artifact/Cargo.toml
@@ -13,6 +13,10 @@ publish = false
 [features]
 default = []
 cli = ["dep:flate2", "dep:tar"]
+# Fixture writers for the on-disk layouts (`layout::fixtures`). Dev-only:
+# lets crates above this one seed a real `.staged-v2` generation without
+# reimplementing the manifest format.
+test-support = []
 gha = ["dep:zccache-gha", "dep:flate2", "dep:tar"]
 
 [dependencies]

--- a/crates/zccache-artifact/README.md
+++ b/crates/zccache-artifact/README.md
@@ -1,3 +1,20 @@
 # zccache-artifact
 
 Unpublished internal crate for zccache artifact storage and Rust artifact plan save/restore.
+
+- `store.rs` — `ArtifactIndex` / `ArtifactStore`: the in-memory index and its
+  `index.bin` bincode snapshot. A load that finds the blob present but
+  unparseable starts empty *and* records it, so the daemon can tell corruption
+  apart from a cold cache (`take_started_corrupt`).
+- `layout.rs` — the shared read resolver for every on-disk artifact layout
+  (staged-v2, pack, flat-v1). Also `fixtures` (feature `test-support`) for
+  seeding a real staged generation from crates above this one.
+- `reconcile.rs` — rebuilding index entries from surviving on-disk payloads
+  when `index.bin` is unreadable (#1157). Read its module docs before widening
+  what it reconstructs: output filenames are not recoverable from disk and are
+  load-bearing for multi-output delivery, so only single-output staged
+  generations are rebuilt. The daemon owns *when* this runs
+  (`zccache-daemon-core::daemon::server::index_reconcile`); this crate only
+  supplies the scan.
+- `kv.rs` — the generic namespaced key/value store.
+- `rust_plan.rs` — Rust artifact plan bundle save/restore.

--- a/crates/zccache-artifact/src/layout.rs
+++ b/crates/zccache-artifact/src/layout.rs
@@ -155,7 +155,10 @@ fn legacy_path_validation_enabled() -> bool {
 /// [`verify_generation_outputs`], which is the expensive part (a full blake3
 /// read of every output).
 struct PublishedGeneration {
-    dir: std::path::PathBuf,
+    /// Normalized rather than `std::path::PathBuf`: `ban_std_pathbuf` is a
+    /// workspace lint, and the paths derived from this field are already
+    /// normalized at their use sites.
+    dir: NormalizedPath,
     outputs: Vec<StagedOutput>,
 }
 
@@ -178,7 +181,7 @@ fn load_published_generation(
         Err(error) => return Err(error),
     };
     validate_generation(&generation_hex)?;
-    let dir = root.join(key_hex).join(&generation_hex);
+    let dir: NormalizedPath = root.join(key_hex).join(&generation_hex).into();
     let manifest = load_manifest(&dir.join("manifest.bin"), key_hex, &generation_hex)?;
     if generation_digest(key_hex, &manifest.outputs) != generation_hex {
         return Err(invalid_data(

--- a/crates/zccache-artifact/src/layout.rs
+++ b/crates/zccache-artifact/src/layout.rs
@@ -147,12 +147,28 @@ fn legacy_path_validation_enabled() -> bool {
         })
 }
 
-/// Resolve and validate a staged-v2 generation without falling back.
-pub fn resolve_staged_artifact_files(
+/// The staged-v2 generation currently published for one artifact key, with
+/// its manifest already checked for identity, version, and self-consistency
+/// (the generation hex is a digest over the manifest's own output rows).
+///
+/// The payload files themselves are *not* verified yet — that is
+/// [`verify_generation_outputs`], which is the expensive part (a full blake3
+/// read of every output).
+struct PublishedGeneration {
+    dir: std::path::PathBuf,
+    outputs: Vec<StagedOutput>,
+}
+
+/// Read `<artifact_dir>/.staged-v2/<key>.current` and the manifest it points
+/// at, rejecting anything whose identity or self-digest does not check out.
+///
+/// `Ok(None)` means "this key has no published staged generation" — the
+/// caller falls back to pack / flat-v1. Every other failure is an error, so a
+/// tampered or truncated manifest is loud rather than silently skipped.
+fn load_published_generation(
     artifact_dir: &Path,
     key_hex: &str,
-    expected_sizes: &[u64],
-) -> io::Result<Option<Vec<NormalizedPath>>> {
+) -> io::Result<Option<PublishedGeneration>> {
     validate_key(key_hex)?;
     let root = artifact_dir.join(STAGED_ROOT);
     let pointer = root.join(format!("{key_hex}.current"));
@@ -162,32 +178,38 @@ pub fn resolve_staged_artifact_files(
         Err(error) => return Err(error),
     };
     validate_generation(&generation_hex)?;
-    let generation = root.join(key_hex).join(&generation_hex);
-    let manifest = load_manifest(&generation.join("manifest.bin"), key_hex, &generation_hex)?;
+    let dir = root.join(key_hex).join(&generation_hex);
+    let manifest = load_manifest(&dir.join("manifest.bin"), key_hex, &generation_hex)?;
     if generation_digest(key_hex, &manifest.outputs) != generation_hex {
         return Err(invalid_data(
             "staged generation digest does not match its manifest",
         ));
     }
-    if manifest.outputs.len() != expected_sizes.len() {
-        return Err(invalid_data(
-            "staged output count does not match artifact metadata",
-        ));
-    }
+    Ok(Some(PublishedGeneration {
+        dir,
+        outputs: manifest.outputs,
+    }))
+}
 
-    let mut paths = Vec::with_capacity(manifest.outputs.len());
-    let mut seen = vec![false; expected_sizes.len()];
-    for output in &manifest.outputs {
-        if output.index >= expected_sizes.len()
-            || seen[output.index]
-            || expected_sizes[output.index] != output.size
-        {
+/// Verify every payload file in a published generation against its manifest
+/// row (size then blake3 digest) and return the output paths in index order.
+///
+/// Also enforces that the manifest's indices are exactly `0..outputs.len()`
+/// with no repeats, so a caller can index the returned slice positionally.
+fn verify_generation_outputs(generation: &PublishedGeneration) -> io::Result<Vec<NormalizedPath>> {
+    let mut seen = vec![false; generation.outputs.len()];
+    let mut paths = Vec::with_capacity(generation.outputs.len());
+    for output in &generation.outputs {
+        if output.index >= seen.len() || seen[output.index] {
             return Err(invalid_data(
-                "staged output size does not match artifact metadata",
+                "staged manifest has a duplicate or out-of-range output index",
             ));
         }
         seen[output.index] = true;
-        let path: NormalizedPath = generation.join(format!("output-{}", output.index)).into();
+        let path: NormalizedPath = generation
+            .dir
+            .join(format!("output-{}", output.index))
+            .into();
         if fs::metadata(&path)?.len() != output.size {
             return Err(invalid_data(
                 "staged output size does not match its manifest",
@@ -201,11 +223,95 @@ pub fn resolve_staged_artifact_files(
         }
         paths.push((output.index, path));
     }
-    if seen.iter().any(|was_seen| !was_seen) {
-        return Err(invalid_data("staged manifest has a missing output index"));
-    }
     paths.sort_by_key(|(index, _)| *index);
-    Ok(Some(paths.into_iter().map(|(_, path)| path).collect()))
+    Ok(paths.into_iter().map(|(_, path)| path).collect())
+}
+
+/// Resolve and validate a staged-v2 generation without falling back.
+pub fn resolve_staged_artifact_files(
+    artifact_dir: &Path,
+    key_hex: &str,
+    expected_sizes: &[u64],
+) -> io::Result<Option<Vec<NormalizedPath>>> {
+    let Some(generation) = load_published_generation(artifact_dir, key_hex)? else {
+        return Ok(None);
+    };
+    if generation.outputs.len() != expected_sizes.len() {
+        return Err(invalid_data(
+            "staged output count does not match artifact metadata",
+        ));
+    }
+    for output in &generation.outputs {
+        if output.index >= expected_sizes.len() || expected_sizes[output.index] != output.size {
+            return Err(invalid_data(
+                "staged output size does not match artifact metadata",
+            ));
+        }
+    }
+    Ok(Some(verify_generation_outputs(&generation)?))
+}
+
+/// Every artifact key that currently has a published staged-v2 generation
+/// pointer, discovered by listing `<artifact_dir>/.staged-v2/*.current`.
+///
+/// Used by index reconciliation (#1157) to enumerate rebuild candidates when
+/// `index.bin` is unreadable and there is no key list to iterate. A missing
+/// staged root is an empty list, not an error.
+pub fn published_staged_keys(artifact_dir: &Path) -> io::Result<Vec<String>> {
+    let root = artifact_dir.join(STAGED_ROOT);
+    let entries = match fs::read_dir(&root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error),
+    };
+    let mut keys = Vec::new();
+    for entry in entries.flatten() {
+        if !entry.file_type().is_ok_and(|kind| kind.is_file()) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let Some(key) = name.strip_suffix(".current") else {
+            continue;
+        };
+        if validate_key(key).is_ok() {
+            keys.push(key.to_string());
+        }
+    }
+    keys.sort();
+    Ok(keys)
+}
+
+/// Fully verified per-output sizes for the published staged generation of
+/// `key_hex`, derived from the manifest alone.
+///
+/// This is [`resolve_staged_artifact_files`] with the index cross-check
+/// removed, for the one caller that has no index entry to cross-check
+/// against: rebuilding a corrupt `index.bin` from disk (#1157). The manifest
+/// is the authoritative record of the output count and sizes, and every
+/// payload is blake3-verified before a size is reported, so a reconstructed
+/// entry can never claim a size the bytes on disk do not back.
+///
+/// Also returns the manifest's mtime so the rebuilt entry can carry a stable
+/// `stored_at_secs` instead of `now()` — otherwise every restart would reset
+/// retention age for the whole cache.
+pub fn verified_staged_generation(
+    artifact_dir: &Path,
+    key_hex: &str,
+) -> io::Result<Option<(Vec<u64>, std::time::SystemTime)>> {
+    let Some(generation) = load_published_generation(artifact_dir, key_hex)? else {
+        return Ok(None);
+    };
+    verify_generation_outputs(&generation)?;
+    let mut sizes = vec![0_u64; generation.outputs.len()];
+    for output in &generation.outputs {
+        // `verify_generation_outputs` already proved the indices are exactly
+        // `0..len` with no repeats, so this cannot panic or overwrite.
+        sizes[output.index] = output.size;
+    }
+    let stored_at = fs::metadata(generation.dir.join("manifest.bin"))?
+        .modified()
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+    Ok(Some((sizes, stored_at)))
 }
 
 fn load_manifest(
@@ -339,6 +445,73 @@ fn invalid_data(message: impl Into<String>) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, message.into())
 }
 
+/// Fixture writers for the on-disk layouts this module reads.
+///
+/// Behind the `test-support` feature (and always available inside this
+/// crate's own tests) so crates above `zccache-artifact` can seed a genuine
+/// `.staged-v2` generation instead of hand-rolling the manifest encoding and
+/// drifting from it.
+#[cfg(any(test, feature = "test-support"))]
+// Fixture setup: a filesystem error here means the test's premise never got
+// established, so panicking with the failed step named is the correct and
+// most debuggable outcome. Never compiled into a shipping binary.
+#[allow(clippy::expect_used)]
+pub mod fixtures {
+    use super::{
+        generation_digest, StagedManifest, StagedOutput, STAGED_MANIFEST_VERSION, STAGED_ROOT,
+    };
+    use std::fs;
+    use std::path::Path;
+
+    /// Write a complete, self-consistent staged-v2 generation for `key_hex`
+    /// under `artifact_dir` and publish it via the `.current` pointer.
+    /// Returns the generation hex.
+    pub fn seed_staged_generation(
+        artifact_dir: &Path,
+        key_hex: &str,
+        payloads: &[&[u8]],
+    ) -> String {
+        let outputs: Vec<StagedOutput> = payloads
+            .iter()
+            .enumerate()
+            .map(|(index, payload)| StagedOutput {
+                index,
+                size: payload.len() as u64,
+                digest_hex: blake3::hash(payload).to_hex().to_string(),
+            })
+            .collect();
+        let generation_hex = generation_digest(key_hex, &outputs);
+        let generation_dir = artifact_dir
+            .join(STAGED_ROOT)
+            .join(key_hex)
+            .join(&generation_hex);
+        fs::create_dir_all(&generation_dir).expect("create staged generation dir");
+        for (index, payload) in payloads.iter().enumerate() {
+            fs::write(generation_dir.join(format!("output-{index}")), payload)
+                .expect("write staged output");
+        }
+        let manifest = StagedManifest {
+            version: STAGED_MANIFEST_VERSION,
+            key_hex: key_hex.to_string(),
+            generation_hex: generation_hex.clone(),
+            outputs,
+        };
+        fs::write(
+            generation_dir.join("manifest.bin"),
+            bincode::serialize(&manifest).expect("serialize staged manifest"),
+        )
+        .expect("write staged manifest");
+        fs::write(
+            artifact_dir
+                .join(STAGED_ROOT)
+                .join(format!("{key_hex}.current")),
+            &generation_hex,
+        )
+        .expect("write staged pointer");
+        generation_hex
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -369,49 +542,7 @@ mod tests {
         data
     }
 
-    fn seed_staged(
-        artifact_dir: &Path,
-        key_hex: &str,
-        payloads: &[&[u8]],
-    ) -> (String, Vec<StagedOutput>) {
-        let mut outputs = Vec::with_capacity(payloads.len());
-        for (index, payload) in payloads.iter().enumerate() {
-            outputs.push(StagedOutput {
-                index,
-                size: payload.len() as u64,
-                digest_hex: blake3::hash(payload).to_hex().to_string(),
-            });
-        }
-        let generation_hex = generation_digest(key_hex, &outputs);
-        let generation_dir = artifact_dir
-            .join(STAGED_ROOT)
-            .join(key_hex)
-            .join(&generation_hex);
-        fs::create_dir_all(&generation_dir).expect("create generation");
-        for (index, payload) in payloads.iter().enumerate() {
-            fs::write(generation_dir.join(format!("output-{index}")), payload)
-                .expect("write staged output");
-        }
-        let manifest = StagedManifest {
-            version: STAGED_MANIFEST_VERSION,
-            key_hex: key_hex.to_string(),
-            generation_hex: generation_hex.clone(),
-            outputs: outputs.clone(),
-        };
-        fs::write(
-            generation_dir.join("manifest.bin"),
-            bincode::serialize(&manifest).expect("serialize manifest"),
-        )
-        .expect("write manifest");
-        fs::write(
-            artifact_dir
-                .join(STAGED_ROOT)
-                .join(format!("{key_hex}.current")),
-            &generation_hex,
-        )
-        .expect("write pointer");
-        (generation_hex, outputs)
-    }
+    use super::fixtures::seed_staged_generation as seed_staged;
 
     #[test]
     fn resolves_legacy_pack_and_staged_layouts() {
@@ -473,7 +604,7 @@ mod tests {
     fn rejects_corrupt_staged_manifest_without_legacy_fallback() {
         let root = tempfile::tempdir().expect("tempdir");
         let key = "b".repeat(64);
-        let (generation, _) = seed_staged(root.path(), &key, &[b"valid"]);
+        let generation = seed_staged(root.path(), &key, &[b"valid"]);
         fs::write(
             root.path()
                 .join(STAGED_ROOT)

--- a/crates/zccache-artifact/src/lib.rs
+++ b/crates/zccache-artifact/src/lib.rs
@@ -8,15 +8,22 @@
 
 pub mod kv;
 mod layout;
+mod reconcile;
 mod rust_plan;
 mod store;
 
 pub use kv::{
     is_valid_namespace, Key, KvError, KvResult, KvStore, INLINE_THRESHOLD, MAX_VALUE_BYTES,
 };
+#[cfg(any(test, feature = "test-support"))]
+pub use layout::fixtures as layout_fixtures;
 pub use layout::{
     record_legacy_artifact_access, resolve_artifact_payloads, resolve_staged_artifact_files,
     LegacyArtifactAccessPurpose, ResolvedArtifactPayload, LEGACY_PATH_VALIDATE_ENV,
+};
+pub use reconcile::{
+    reconcile_index_from_disk, IndexReconciliation, DEFAULT_RECONCILE_BUDGET,
+    RECONCILED_OUTPUT_NAME,
 };
 #[cfg(feature = "gha")]
 pub use rust_plan::{

--- a/crates/zccache-artifact/src/reconcile.rs
+++ b/crates/zccache-artifact/src/reconcile.rs
@@ -1,0 +1,307 @@
+//! Rebuild a lost artifact index from the payloads that survived on disk.
+//!
+//! # Why
+//!
+//! `index.bin` is a single bincode blob. Before #1157, any deserialize error
+//! dropped the entire in-memory index and the daemon started empty — while
+//! every content-addressed payload was still sitting in the artifact
+//! directory, fully intact. One bad byte therefore cost a full cold recompile
+//! of every workspace on the machine, with no local cause an operator could
+//! see. This module is the reconciliation step: given the artifact directory,
+//! reconstruct as many index entries as can be reconstructed *safely*.
+//!
+//! # What can and cannot be reconstructed
+//!
+//! [`ArtifactIndex`] carries seven fields. Disk provides four of them:
+//!
+//! | field | recoverable? | from |
+//! |---|---|---|
+//! | `output_sizes` | yes | the `.staged-v2` manifest, blake3-verified against the payload bytes |
+//! | `total_size` | yes | sum of the above |
+//! | `stored_at_secs` | yes | the manifest's mtime (stable across restarts, so reconciliation is idempotent) |
+//! | `exit_code` | yes, as `0` | only successful compiles are ever stored (see `handle_compile::pipeline::store_outcome`) |
+//! | `stdout` / `stderr` | **no** | never written to disk beside the payloads |
+//! | `output_names` | **no** | the manifest records `index`, `size`, `digest` — never a filename |
+//!
+//! Empty `stdout`/`stderr` is a sanctioned degradation: a reconciled hit
+//! replays without the original compiler warnings. That loses diagnostics, not
+//! correctness.
+//!
+//! # Why single-output generations only
+//!
+//! The missing `output_names` is the reason this module reconstructs *less*
+//! than it could. For a single-output artifact the name is never consulted
+//! when placing the payload — the daemon writes payload 0 to the output path
+//! the *current* request asked for. For multi-output artifacts the name is
+//! load-bearing in three places, and guessing it produces a wrong cache hit,
+//! which is catastrophic where a miss is merely slow:
+//!
+//! * `handle_compile::cached_hit` places outputs at index >= 1 at
+//!   `secondary_output_dir.join(&names[i])`.
+//! * the rustc `--emit` compatibility path picks *which* payload satisfies
+//!   *which* requested output by matching names (and, failing that, by
+//!   matching the name's extension class).
+//! * `handle_exec` pairs declared outputs to payloads by exact name.
+//!
+//! So: generations with more than one output are counted and skipped.
+//!
+//! The synthetic name given to the surviving single output is deliberately
+//! chosen to match *nothing*: [`RECONCILED_OUTPUT_NAME`] carries an extension
+//! outside the rustc output-kind table, so the extension-class fallback in the
+//! `--emit` compat path returns `None` and the request takes a clean miss
+//! rather than receiving, say, an `.rmeta` payload delivered as an `.rlib`.
+//!
+//! # Why staged-v2 only
+//!
+//! Flat-v1 (`<key>_<i>`) and pack (`<key>.pack`) layouts are deliberately not
+//! reconciled. Neither records an authoritative output *count*: a flat group
+//! whose `_1` was removed is indistinguishable from a genuine single-output
+//! artifact, and reconstructing it as single-output would serve a truncated
+//! artifact as a complete hit. The staged manifest states the count outright,
+//! which is exactly the property reconciliation needs.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use crate::store::ArtifactIndex;
+
+/// Filename recorded for the single output of a reconciled entry.
+///
+/// Never a real compiler output name, and specifically chosen so that
+/// `handle_compile::cached_hit::rustc_output_kind` classifies it as `None`:
+/// the `--emit` compatibility path then refuses to map any requested output
+/// onto this payload and the request misses instead of receiving the wrong
+/// bytes under the right filename.
+pub const RECONCILED_OUTPUT_NAME: &str = "zccache-reconciled-output.zcunknown";
+
+/// Default wall-clock cap on a reconciliation scan.
+///
+/// Reconciliation runs on the daemon startup path, and the scan cost is
+/// `O(total cached bytes)` because every payload is blake3-verified. On a very
+/// large cache that is unbounded, so the scan stops at the budget and the
+/// daemon starts with whatever it recovered so far. Partial recovery beats a
+/// daemon that will not come up.
+pub const DEFAULT_RECONCILE_BUDGET: Duration = Duration::from_secs(5);
+
+/// Result of one reconciliation scan. Every field is reported in the
+/// `index_reconciled` lifecycle event so a partial recovery is attributable.
+#[derive(Debug, Default)]
+pub struct IndexReconciliation {
+    /// Rebuilt `(key, entry)` rows, ready to insert into an `ArtifactStore`.
+    pub entries: Vec<(String, ArtifactIndex)>,
+    /// Published staged generations found on disk (the candidate set).
+    pub candidates: usize,
+    /// Generations skipped because their output filenames are unrecoverable.
+    pub skipped_multi_output: usize,
+    /// Generations skipped because a manifest or payload failed verification.
+    pub skipped_unverifiable: usize,
+    /// Whether the scan stopped at the budget with candidates left unvisited.
+    pub truncated_by_budget: bool,
+    /// Wall-clock cost of the scan.
+    pub elapsed_ns: u64,
+}
+
+impl IndexReconciliation {
+    /// Number of entries recovered.
+    pub fn recovered(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+/// Rebuild index entries from the staged-v2 generations under `artifact_dir`.
+///
+/// Never fails: an unreadable staged root, an unreadable manifest, and a
+/// payload whose digest does not match are all counted and skipped, because
+/// the caller's alternative is an empty index either way.
+///
+/// `budget` is checked before each candidate, so `Duration::ZERO` returns
+/// immediately with `truncated_by_budget` set — which is how the budget
+/// behaviour is tested without sleeping.
+pub fn reconcile_index_from_disk(artifact_dir: &Path, budget: Duration) -> IndexReconciliation {
+    let started = Instant::now();
+    let mut outcome = IndexReconciliation::default();
+
+    let keys = match crate::layout::published_staged_keys(artifact_dir) {
+        Ok(keys) => keys,
+        Err(error) => {
+            tracing::warn!(
+                artifact_dir = %artifact_dir.display(),
+                "artifact index reconciliation could not list staged generations: {error}"
+            );
+            outcome.elapsed_ns = started.elapsed().as_nanos() as u64;
+            return outcome;
+        }
+    };
+    outcome.candidates = keys.len();
+
+    for key in keys {
+        if started.elapsed() >= budget {
+            outcome.truncated_by_budget = true;
+            break;
+        }
+        match crate::layout::verified_staged_generation(artifact_dir, &key) {
+            Ok(Some((sizes, stored_at))) => {
+                if sizes.len() != 1 {
+                    outcome.skipped_multi_output += 1;
+                    continue;
+                }
+                outcome.entries.push((key, rebuilt_entry(sizes, stored_at)));
+            }
+            // The pointer vanished between listing and reading (a concurrent
+            // publish or eviction). Not a corruption signal.
+            Ok(None) => outcome.skipped_unverifiable += 1,
+            Err(error) => {
+                tracing::debug!(
+                    %key,
+                    "artifact index reconciliation skipped an unverifiable generation: {error}"
+                );
+                outcome.skipped_unverifiable += 1;
+            }
+        }
+    }
+
+    outcome.elapsed_ns = started.elapsed().as_nanos() as u64;
+    outcome
+}
+
+/// Build the conservative index entry for one verified single-output
+/// generation: real sizes, a synthetic non-matching name, no captured
+/// output, and the success exit code that is the only one ever stored.
+fn rebuilt_entry(sizes: Vec<u64>, stored_at: SystemTime) -> ArtifactIndex {
+    let total_size = sizes.iter().copied().sum();
+    ArtifactIndex {
+        output_names: Arc::from(vec![RECONCILED_OUTPUT_NAME.to_string()]),
+        output_sizes: sizes,
+        stdout: Arc::new(Vec::new()),
+        stderr: Arc::new(Vec::new()),
+        exit_code: 0,
+        total_size,
+        stored_at_secs: stored_at
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::resolve_artifact_payloads;
+
+    #[test]
+    fn a_missing_staged_root_reconciles_to_nothing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let outcome = reconcile_index_from_disk(dir.path(), DEFAULT_RECONCILE_BUDGET);
+        assert_eq!(outcome.recovered(), 0);
+        assert_eq!(outcome.candidates, 0);
+        assert!(!outcome.truncated_by_budget);
+    }
+
+    #[test]
+    fn a_zero_budget_recovers_nothing_and_says_so() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = "a".repeat(64);
+        crate::layout::fixtures::seed_staged_generation(dir.path(), &key, &[b"payload"]);
+
+        let outcome = reconcile_index_from_disk(dir.path(), Duration::ZERO);
+        assert_eq!(outcome.candidates, 1, "the candidate was still discovered");
+        assert_eq!(outcome.recovered(), 0);
+        assert!(
+            outcome.truncated_by_budget,
+            "an exhausted budget must be reported, not silently look like an empty cache"
+        );
+    }
+
+    #[test]
+    fn a_single_output_generation_is_rebuilt_and_re_resolves() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = "b".repeat(64);
+        crate::layout::fixtures::seed_staged_generation(dir.path(), &key, &[b"object-bytes"]);
+
+        let outcome = reconcile_index_from_disk(dir.path(), DEFAULT_RECONCILE_BUDGET);
+        assert_eq!(outcome.recovered(), 1);
+        let (rebuilt_key, entry) = &outcome.entries[0];
+        assert_eq!(rebuilt_key, &key);
+        assert_eq!(entry.output_sizes, vec![b"object-bytes".len() as u64]);
+        assert_eq!(entry.total_size, b"object-bytes".len() as u64);
+        assert_eq!(entry.exit_code, 0);
+        assert!(entry.stdout.is_empty() && entry.stderr.is_empty());
+        assert_eq!(&*entry.output_names, &[RECONCILED_OUTPUT_NAME.to_string()]);
+
+        // The whole point: the rebuilt sizes must satisfy the same resolver
+        // the hit path uses, so the entry is actually re-hittable.
+        let payloads =
+            resolve_artifact_payloads(dir.path(), &key, &entry.output_sizes, true, "test::rebuilt")
+                .expect("resolve")
+                .expect("rebuilt entry must resolve to its payload");
+        assert_eq!(payloads.len(), 1);
+    }
+
+    #[test]
+    fn a_multi_output_generation_is_skipped_rather_than_guessed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = "c".repeat(64);
+        crate::layout::fixtures::seed_staged_generation(dir.path(), &key, &[b"object", b"depfile"]);
+
+        let outcome = reconcile_index_from_disk(dir.path(), DEFAULT_RECONCILE_BUDGET);
+        assert_eq!(
+            outcome.recovered(),
+            0,
+            "output filenames are unrecoverable, and guessing them is a wrong hit"
+        );
+        assert_eq!(outcome.skipped_multi_output, 1);
+    }
+
+    #[test]
+    fn a_tampered_payload_is_skipped_not_reconstructed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = "d".repeat(64);
+        let generation =
+            crate::layout::fixtures::seed_staged_generation(dir.path(), &key, &[b"original"]);
+        std::fs::write(
+            dir.path()
+                .join(".staged-v2")
+                .join(&key)
+                .join(&generation)
+                .join("output-0"),
+            b"tampered",
+        )
+        .expect("tamper");
+
+        let outcome = reconcile_index_from_disk(dir.path(), DEFAULT_RECONCILE_BUDGET);
+        assert_eq!(outcome.recovered(), 0);
+        assert_eq!(outcome.skipped_unverifiable, 1);
+    }
+
+    #[test]
+    fn reconciliation_is_idempotent_across_repeated_scans() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for (index, byte) in [b'1', b'2', b'3'].into_iter().enumerate() {
+            let key = (byte as char).to_string().repeat(64);
+            crate::layout::fixtures::seed_staged_generation(
+                dir.path(),
+                &key,
+                &[format!("payload-{index}").as_bytes()],
+            );
+        }
+
+        let first = reconcile_index_from_disk(dir.path(), DEFAULT_RECONCILE_BUDGET);
+        let second = reconcile_index_from_disk(dir.path(), DEFAULT_RECONCILE_BUDGET);
+        assert_eq!(first.recovered(), 3);
+        assert_eq!(second.recovered(), 3);
+
+        let keys = |outcome: &IndexReconciliation| -> Vec<String> {
+            outcome.entries.iter().map(|(k, _)| k.clone()).collect()
+        };
+        assert_eq!(keys(&first), keys(&second));
+        for ((_, a), (_, b)) in first.entries.iter().zip(second.entries.iter()) {
+            assert_eq!(a.output_sizes, b.output_sizes);
+            assert_eq!(
+                a.stored_at_secs, b.stored_at_secs,
+                "stored_at must come from the manifest mtime, not now(), or every \
+                 restart would reset retention age for the whole cache"
+            );
+        }
+    }
+}

--- a/crates/zccache-artifact/src/store.rs
+++ b/crates/zccache-artifact/src/store.rs
@@ -96,6 +96,14 @@ pub struct ArtifactStore {
     path: NormalizedPath,
     entries: DashMap<String, ArtifactIndex>,
     flush_lock: std::sync::Mutex<()>,
+    /// Set when a `load_from_disk` found the blob present but unparseable.
+    ///
+    /// This is the #1157 seam between the two crates. The corrupt arm lives
+    /// here, but the rebuild needs to scan the artifact directory and decide
+    /// a startup time budget — daemon concerns. `zccache-daemon-core` depends
+    /// on this crate, never the reverse, so the store only *reports* that it
+    /// started corrupt and the daemon owns the recovery policy.
+    started_corrupt: std::sync::atomic::AtomicBool,
 }
 
 impl ArtifactStore {
@@ -132,7 +140,23 @@ impl ArtifactStore {
             path: NormalizedPath::new(path),
             entries: DashMap::new(),
             flush_lock: std::sync::Mutex::new(()),
+            started_corrupt: std::sync::atomic::AtomicBool::new(false),
         }
+    }
+
+    /// Consume the "the on-disk blob was unreadable" signal, returning whether
+    /// it was set and clearing it.
+    ///
+    /// #1157: the daemon calls this once at startup. `true` means the index
+    /// this store is serving is empty *because the file did not parse*, not
+    /// because the cache is cold — so the surviving on-disk payloads are worth
+    /// scanning to rebuild entries from
+    /// ([`crate::reconcile_index_from_disk`]). Taking rather than peeking
+    /// keeps the expensive scan to a single winner when the background loader
+    /// races the on-first-miss synchronous load.
+    pub fn take_started_corrupt(&self) -> bool {
+        self.started_corrupt
+            .swap(false, std::sync::atomic::Ordering::AcqRel)
     }
 
     /// Read the on-disk index blob (if any) and insert every entry
@@ -178,10 +202,12 @@ impl ArtifactStore {
                     }
                 }
                 Err(e) => {
+                    self.started_corrupt
+                        .store(true, std::sync::atomic::Ordering::Release);
                     tracing::warn!(
                         path = %path.display(),
                         bytes = bytes.len(),
-                        "artifact index blob is corrupt, starting empty: {e}"
+                        "artifact index blob is corrupt, starting empty pending reconciliation: {e}"
                     );
                     // #1157: dropping the index re-misses every key while the
                     // content-addressed payloads are still on disk, so the
@@ -503,13 +529,47 @@ mod tests {
         assert!(store.get("another").is_some());
     }
 
+    /// This test used to be `open_corrupt_file_starts_empty`, and it asserted
+    /// only `store.len() == 0` — pinning "a corrupt blob is a cache wipe" as
+    /// the intended contract. #1157 finding 1 changed that: starting empty is
+    /// now the *load* behaviour, not the *final* behaviour. The store must
+    /// additionally hand the daemon the signal that lets it rebuild entries
+    /// from the payloads still on disk, because without the signal the daemon
+    /// cannot tell an unreadable index apart from a genuinely cold cache.
+    ///
+    /// The flag is a take, not a peek, so the rebuild scan runs once even
+    /// though `load_from_disk` has two call sites racing at startup.
     #[test]
-    fn open_corrupt_file_starts_empty() {
+    fn open_corrupt_file_starts_empty_but_flags_itself_for_reconciliation() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("index.bin");
         std::fs::write(&path, b"not valid bincode").unwrap();
+
         let store = ArtifactStore::open(&path).unwrap();
-        assert_eq!(store.len(), 0);
+        assert_eq!(store.len(), 0, "the unreadable blob still yields no rows");
+        assert!(
+            store.take_started_corrupt(),
+            "a corrupt load must be distinguishable from a cold cache"
+        );
+        assert!(
+            !store.take_started_corrupt(),
+            "the signal is consumed so only one caller pays for the rebuild scan"
+        );
+    }
+
+    #[test]
+    fn a_missing_or_healthy_index_is_not_flagged_as_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("index.bin");
+
+        let missing = ArtifactStore::open(&path).unwrap();
+        assert!(!missing.take_started_corrupt());
+
+        missing.insert("k", &sample_meta());
+        missing.flush().unwrap();
+        let healthy = ArtifactStore::open(&path).unwrap();
+        assert_eq!(healthy.len(), 1);
+        assert!(!healthy.take_started_corrupt());
     }
 
     /// #1157: starting empty on a corrupt index re-misses every key while the

--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -46,6 +46,7 @@
 //! | `wrapper-daemon-unavailable` (#1170) | CLI wrapper | the daemon could not be reached before request dispatch and the wrapper refused to run the tool uncached | `tool`, `cwd`, `endpoint`, `reason`, `phase`, `route`, `exit_code` |
 //! | `version_mismatch` | daemon | client / daemon protocol versions disagree | `daemon_protocol_version`, `client_protocol_version`, `reason` |
 //! | `state_corrupt` (#1157) | daemon | persisted state did not parse and was dropped rather than reconciled; consequence is a full cold recompile | `subsystem`, `consequence`, `message`, `path`, `bytes` |
+//! | `index_reconciled` (#1157) | daemon | a corrupt artifact index was rebuilt from surviving staged-v2 generations instead of starting empty | `recovered`, `candidates`, `skipped_multi_output`, `skipped_unverifiable`, `truncated_by_budget`, `budget_ms`, `elapsed_ns` |
 //! | `insecure_socket_dir` (#1171) | daemon | the directory holding the IPC endpoint was group/other-writable; another local user could substitute the socket | `path`, `outcome`, `detail` |
 //! | `insecure_deploy_dir` (#1172) | CLI | the directory the daemon binary is deployed into was group/other-writable; another local user could have replaced the binary the CLI executes | `path`, `outcome`, `detail` |
 //! | `ipc_peer_rejected` (#1171) | daemon | an accepted IPC connection was refused because the peer is not this user, or its credentials were unavailable | `reason`, `detail` |
@@ -131,6 +132,18 @@ pub const EVENT_VERSION_MISMATCH: &str = "version_mismatch";
 /// so the event carries `subsystem` and `consequence` and is what makes a
 /// fleet-wide "everyone recompiled today" incident attributable after the fact.
 pub const EVENT_STATE_CORRUPT: &str = "state_corrupt";
+/// A corrupt artifact index was rebuilt from the surviving on-disk payloads
+/// instead of being left empty (#1157, finding 1).
+///
+/// Always paired with the [`EVENT_STATE_CORRUPT`] row that recorded the
+/// unreadable blob — this one says how much of it came back. `recovered` is
+/// the number of index entries re-inserted, `skipped_multi_output` counts the
+/// generations deliberately left out because their output filenames are not
+/// recoverable from disk (delivering those by a guessed name is how a
+/// reconciliation turns into a wrong cache hit), and `truncated_by_budget`
+/// says the scan hit its wall-clock cap and stopped early rather than
+/// delaying daemon start.
+pub const EVENT_INDEX_RECONCILED: &str = "index_reconciled";
 /// The directory holding the IPC endpoint was group/other-writable (#1171).
 ///
 /// Reaching that socket is arbitrary process execution as the daemon user, so
@@ -280,6 +293,7 @@ pub const EVENT_ALL: &[&str] = &[
     EVENT_DIED_PRIVATE_OWNER_EXIT,
     EVENT_VERSION_MISMATCH,
     EVENT_STATE_CORRUPT,
+    EVENT_INDEX_RECONCILED,
     EVENT_INSECURE_SOCKET_DIR,
     EVENT_IPC_PEER_REJECTED,
     EVENT_INSECURE_DEPLOY_DIR,

--- a/crates/zccache-daemon-core/Cargo.toml
+++ b/crates/zccache-daemon-core/Cargo.toml
@@ -17,7 +17,7 @@ default = []
 # Pulls clap + tracing-subscriber; enabled by the hosting binary.
 daemon-entry = ["dep:clap", "dep:tracing-subscriber"]
 # Dev-only test utilities (zccache_daemon_core::test_support).
-test-support = ["dep:tracing-subscriber"]
+test-support = ["dep:tracing-subscriber", "zccache-artifact/test-support"]
 tokio-console = ["dep:console-subscriber"]
 
 [dependencies]

--- a/crates/zccache-daemon-core/src/daemon/server/README.md
+++ b/crates/zccache-daemon-core/src/daemon/server/README.md
@@ -9,6 +9,7 @@ Topic-focused submodules:
 - `lifecycle.rs` — `DaemonServer::{bind, bind_with_cache_dir}`, `new_shared_state`, accessors, test seams
 - `embedded.rs` — `EmbeddedDaemon` (in-process host integration): construction, background cache loads, compile entrypoint, flush/shutdown
 - `loaders.rs` — deferred cache-load handles (`DepGraphSetter`, the four `*Loader`s) + the `DaemonServer` factory methods that hand them out (bind-first / load-in-background, #640/#784)
+- `index_reconcile.rs` — startup rebuild of an unreadable `index.bin` from surviving staged-v2 payloads, under a wall-clock budget (#1157); emits `index_reconciled`
 - `run.rs` — `DaemonServer::run` main loop + watcher pipeline initializer
 - `state.rs` — `SharedState`, the daemon's central state object
 - `cached_artifact.rs` — `CachedArtifact`, `CachedPayload`, payload materialization, legacy `.meta` migration

--- a/crates/zccache-daemon-core/src/daemon/server/embedded.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/embedded.rs
@@ -111,6 +111,16 @@ impl EmbeddedDaemon {
             if let Err(e) = state.artifact_store.load_from_disk() {
                 tracing::warn!("embedded artifact index load failed, continuing empty: {e}");
             }
+            // #1157: same recovery as the standalone daemon's
+            // `ArtifactStoreLoader` — run it before snapshotting into
+            // `state.artifacts` so rebuilt entries are published together
+            // with the ones that loaded normally.
+            super::index_reconcile::reconcile_corrupt_index(
+                &state.artifact_store,
+                state.artifact_dir.as_path(),
+                state.cache_dir.as_path(),
+                super::index_reconcile::reconcile_budget(),
+            );
             let entries = state.artifact_store.load_all();
             let count = entries.len();
             for (key, meta) in entries {

--- a/crates/zccache-daemon-core/src/daemon/server/index_reconcile.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/index_reconcile.rs
@@ -1,0 +1,304 @@
+//! Startup recovery for an unreadable artifact index (#1157, finding 1).
+//!
+//! `zccache-artifact` owns the corrupt arm but cannot own the recovery: the
+//! rebuild scans the artifact directory, needs a wall-clock budget tied to
+//! daemon startup, and writes a lifecycle event into the cache root — all
+//! daemon concerns, and `zccache-daemon-core` is the crate that depends on
+//! `zccache-artifact`, never the reverse. So the store only reports that it
+//! started corrupt ([`ArtifactStore::take_started_corrupt`]) and the policy
+//! lives here.
+//!
+//! What gets rebuilt, and why deliberately less than everything on disk, is
+//! documented on `zccache_artifact::reconcile`. The short version: output
+//! filenames are not recoverable from any on-disk record, they are
+//! load-bearing for placing outputs at index >= 1, and a wrong cache hit is
+//! catastrophic where a miss is only slow — so only single-output staged
+//! generations come back.
+
+use std::path::Path;
+use std::time::Duration;
+
+use crate::artifact::{reconcile_index_from_disk, ArtifactStore, DEFAULT_RECONCILE_BUDGET};
+use crate::core::lifecycle::{write_event_in_cache_root, EVENT_INDEX_RECONCILED};
+
+/// Overrides the wall-clock cap on the startup rebuild scan, in milliseconds.
+///
+/// `0` disables reconciliation outright (the scan reports itself truncated
+/// and recovers nothing), which is the escape hatch if a pathological cache
+/// makes even the capped scan unwelcome on the startup path.
+pub(crate) const RECONCILE_BUDGET_ENV: &str = "ZCCACHE_INDEX_RECONCILE_BUDGET_MS";
+
+/// Resolve the rebuild budget from the environment, falling back to
+/// [`DEFAULT_RECONCILE_BUDGET`]. An unparseable value is ignored rather than
+/// fatal — this runs during startup and must never stop the daemon coming up.
+pub(crate) fn reconcile_budget() -> Duration {
+    std::env::var(RECONCILE_BUDGET_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .map_or(DEFAULT_RECONCILE_BUDGET, Duration::from_millis)
+}
+
+/// If `store` reported that its on-disk blob did not parse, rebuild what can
+/// be rebuilt from the surviving payloads under `artifact_dir` and insert it.
+///
+/// Returns the number of entries recovered (`0` when the index loaded fine,
+/// which is the overwhelmingly common case and costs one atomic read).
+///
+/// Existing in-memory entries always win: a request handler may already have
+/// stored a *complete* entry — with real output names and captured compiler
+/// output — for a key the scan also found, and the reconstructed entry is
+/// strictly poorer. Reconciliation fills holes, it never overwrites.
+pub(crate) fn reconcile_corrupt_index(
+    store: &ArtifactStore,
+    artifact_dir: &Path,
+    cache_dir: &Path,
+    budget: Duration,
+) -> usize {
+    if !store.take_started_corrupt() {
+        return 0;
+    }
+
+    let outcome = reconcile_index_from_disk(artifact_dir, budget);
+    let mut recovered = 0_usize;
+    for (key, meta) in &outcome.entries {
+        if store.get(key).is_none() {
+            store.insert(key, meta);
+            recovered += 1;
+        }
+    }
+
+    tracing::warn!(
+        artifact_dir = %artifact_dir.display(),
+        recovered,
+        candidates = outcome.candidates,
+        skipped_multi_output = outcome.skipped_multi_output,
+        skipped_unverifiable = outcome.skipped_unverifiable,
+        truncated_by_budget = outcome.truncated_by_budget,
+        elapsed_ns = outcome.elapsed_ns,
+        "artifact index was unreadable; rebuilt entries from surviving on-disk payloads"
+    );
+    write_event_in_cache_root(
+        cache_dir,
+        EVENT_INDEX_RECONCILED,
+        serde_json::json!({
+            "subsystem": "artifact_index",
+            "artifact_dir": artifact_dir.display().to_string(),
+            "recovered": recovered,
+            "candidates": outcome.candidates,
+            "skipped_multi_output": outcome.skipped_multi_output,
+            "skipped_unverifiable": outcome.skipped_unverifiable,
+            "truncated_by_budget": outcome.truncated_by_budget,
+            "budget_ms": budget.as_millis() as u64,
+            "elapsed_ns": outcome.elapsed_ns,
+        }),
+    );
+    recovered
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::artifact::layout_fixtures::seed_staged_generation;
+    use crate::artifact::{resolve_artifact_payloads, RECONCILED_OUTPUT_NAME};
+
+    /// A cache root with a corrupt `index.bin` and one healthy single-output
+    /// staged generation. Returns `(tempdir, cache_dir, artifact_dir, key)`.
+    fn corrupt_index_with_payload(
+        payload: &[u8],
+        key_byte: char,
+    ) -> (
+        tempfile::TempDir,
+        std::path::PathBuf,
+        std::path::PathBuf,
+        String,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache_dir = dir.path().to_path_buf();
+        let artifact_dir = cache_dir.join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).expect("artifact dir");
+        std::fs::write(cache_dir.join("index.bin"), b"not valid bincode").expect("corrupt index");
+        let key = key_byte.to_string().repeat(64);
+        seed_staged_generation(&artifact_dir, &key, &[payload]);
+        (dir, cache_dir, artifact_dir, key)
+    }
+
+    fn open_store(cache_dir: &Path) -> ArtifactStore {
+        ArtifactStore::open(&cache_dir.join("index.bin")).expect("open store")
+    }
+
+    #[test]
+    fn a_corrupt_index_is_rebuilt_into_re_hittable_entries() {
+        let payload = b"cached object bytes";
+        let (_dir, cache_dir, artifact_dir, key) = corrupt_index_with_payload(payload, 'a');
+
+        let store = open_store(&cache_dir);
+        assert_eq!(store.len(), 0, "the corrupt load still starts empty");
+
+        let recovered =
+            reconcile_corrupt_index(&store, &artifact_dir, &cache_dir, DEFAULT_RECONCILE_BUDGET);
+        assert_eq!(recovered, 1);
+
+        let entry = store.get(&key).expect("the key must be back in the index");
+        assert_eq!(entry.output_sizes, vec![payload.len() as u64]);
+        assert_eq!(&*entry.output_names, &[RECONCILED_OUTPUT_NAME.to_string()]);
+
+        // Re-hittable means the resolver the hit path uses finds the payload
+        // from the rebuilt metadata alone.
+        let payloads = resolve_artifact_payloads(
+            &artifact_dir,
+            &key,
+            &entry.output_sizes,
+            true,
+            "test::reconciled",
+        )
+        .expect("resolve")
+        .expect("the rebuilt entry must resolve to its surviving payload");
+        assert_eq!(payloads.len(), 1);
+    }
+
+    #[test]
+    fn the_rebuild_emits_a_durable_event_recording_the_outcome() {
+        let (_dir, cache_dir, artifact_dir, _key) = corrupt_index_with_payload(b"bytes", 'b');
+        let store = open_store(&cache_dir);
+        reconcile_corrupt_index(&store, &artifact_dir, &cache_dir, DEFAULT_RECONCILE_BUDGET);
+
+        let log = std::fs::read_to_string(
+            cache_dir
+                .join("logs")
+                .join(crate::core::lifecycle::live_log_filename()),
+        )
+        .expect("lifecycle log");
+        let row = log
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .find(|value| value["event"] == EVENT_INDEX_RECONCILED)
+            .expect("a rebuild must be attributable after the fact, not just a warn");
+        assert_eq!(row["recovered"], 1);
+        assert_eq!(row["candidates"], 1);
+        assert_eq!(row["truncated_by_budget"], false);
+        assert!(row["elapsed_ns"].is_number());
+    }
+
+    #[test]
+    fn an_exhausted_budget_falls_back_to_an_empty_index_without_sleeping() {
+        let (_dir, cache_dir, artifact_dir, key) = corrupt_index_with_payload(b"bytes", 'c');
+        let store = open_store(&cache_dir);
+
+        let recovered = reconcile_corrupt_index(&store, &artifact_dir, &cache_dir, Duration::ZERO);
+        assert_eq!(recovered, 0);
+        assert!(store.get(&key).is_none());
+        assert_eq!(store.len(), 0, "beyond the budget the daemon starts empty");
+
+        let log = std::fs::read_to_string(
+            cache_dir
+                .join("logs")
+                .join(crate::core::lifecycle::live_log_filename()),
+        )
+        .expect("lifecycle log");
+        assert!(
+            log.lines()
+                .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+                .any(|value| value["event"] == EVENT_INDEX_RECONCILED
+                    && value["truncated_by_budget"] == true),
+            "a truncated scan must say so, or a half-recovered cache looks like a cold one"
+        );
+    }
+
+    #[test]
+    fn a_healthy_index_is_never_scanned() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache_dir = dir.path().to_path_buf();
+        let artifact_dir = cache_dir.join("artifacts");
+        std::fs::create_dir_all(&artifact_dir).expect("artifact dir");
+        let key = "d".repeat(64);
+        seed_staged_generation(&artifact_dir, &key, &[b"bytes"]);
+
+        let store = open_store(&cache_dir);
+        let recovered =
+            reconcile_corrupt_index(&store, &artifact_dir, &cache_dir, DEFAULT_RECONCILE_BUDGET);
+        assert_eq!(recovered, 0);
+        assert!(
+            store.get(&key).is_none(),
+            "a cold cache must stay cold; reconciliation is only for a corrupt load"
+        );
+        assert!(
+            !cache_dir.join("logs").exists()
+                || !std::fs::read_to_string(
+                    cache_dir
+                        .join("logs")
+                        .join(crate::core::lifecycle::live_log_filename())
+                )
+                .unwrap_or_default()
+                .contains(EVENT_INDEX_RECONCILED),
+            "no corruption, no event"
+        );
+    }
+
+    #[test]
+    fn the_rebuild_is_idempotent_across_restarts() {
+        let payload = b"restart stable bytes";
+        let (_dir, cache_dir, artifact_dir, key) = corrupt_index_with_payload(payload, 'e');
+
+        let first = open_store(&cache_dir);
+        assert_eq!(
+            reconcile_corrupt_index(&first, &artifact_dir, &cache_dir, DEFAULT_RECONCILE_BUDGET),
+            1
+        );
+        let after_first = first.get(&key).expect("entry");
+        // The daemon flushes on shutdown; the second boot must not be
+        // disturbed by that healthy index existing.
+        first.flush().expect("flush");
+
+        // Second boot: corrupt the freshly flushed index again and rebuild.
+        std::fs::write(cache_dir.join("index.bin"), b"corrupt again").expect("re-corrupt");
+        let second = open_store(&cache_dir);
+        assert_eq!(
+            reconcile_corrupt_index(&second, &artifact_dir, &cache_dir, DEFAULT_RECONCILE_BUDGET),
+            1
+        );
+        let after_second = second.get(&key).expect("entry");
+
+        assert_eq!(after_first.output_sizes, after_second.output_sizes);
+        assert_eq!(after_first.total_size, after_second.total_size);
+        assert_eq!(
+            after_first.stored_at_secs, after_second.stored_at_secs,
+            "a restart loop must not keep resetting retention age for the whole cache"
+        );
+    }
+
+    #[test]
+    fn a_complete_in_memory_entry_is_never_replaced_by_a_poorer_rebuilt_one() {
+        let (_dir, cache_dir, artifact_dir, key) = corrupt_index_with_payload(b"bytes", 'f');
+        let store = open_store(&cache_dir);
+
+        let complete = crate::artifact::ArtifactIndex::new(
+            vec!["real-name.o".to_string()],
+            vec![5],
+            b"warning: unused variable".to_vec(),
+            Vec::new(),
+            0,
+        );
+        store.insert(&key, &complete);
+
+        let recovered =
+            reconcile_corrupt_index(&store, &artifact_dir, &cache_dir, DEFAULT_RECONCILE_BUDGET);
+        assert_eq!(recovered, 0);
+        let kept = store.get(&key).expect("entry");
+        assert_eq!(&*kept.output_names, &["real-name.o".to_string()]);
+        assert!(
+            !kept.stdout.is_empty(),
+            "captured compiler output must survive; the rebuilt entry has none"
+        );
+    }
+
+    /// The budget the daemon actually uses is injected as a parameter (every
+    /// test above passes its own, so none of them sleep). This only covers
+    /// the operator-facing override that resolves the default.
+    #[test]
+    fn an_absent_budget_override_resolves_to_the_default() {
+        if std::env::var(RECONCILE_BUDGET_ENV).is_ok() {
+            return;
+        }
+        assert_eq!(reconcile_budget(), DEFAULT_RECONCILE_BUDGET);
+    }
+}

--- a/crates/zccache-daemon-core/src/daemon/server/loaders.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/loaders.rs
@@ -199,6 +199,15 @@ impl ArtifactStoreLoader {
         if let Err(e) = self.store.load_from_disk() {
             tracing::warn!("artifact index load failed, continuing with empty store: {e}");
         }
+        // #1157: a blob that was present but unparseable is not a cold cache.
+        // Rebuild what the surviving payloads can prove before declaring the
+        // store loaded, so the first request after a corrupt boot can hit.
+        super::index_reconcile::reconcile_corrupt_index(
+            &self.store,
+            self.state.artifact_dir.as_path(),
+            self.state.cache_dir.as_path(),
+            super::index_reconcile::reconcile_budget(),
+        );
         self.state
             .artifact_store_loaded
             .store(true, Ordering::Release);

--- a/crates/zccache-daemon-core/src/daemon/server/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/mod.rs
@@ -167,6 +167,7 @@ mod handle_exec_probe;
 mod handle_link;
 mod handle_release_worktree_handles;
 mod in_flight;
+mod index_reconcile;
 mod inner_trace;
 mod keys;
 mod lifecycle;


### PR DESCRIPTION
Finding 1 of #1157, plus the index half of Finding 3.

## The defect

Any deserialize error on `index.bin` dropped the **entire** in-memory index. Every key re-missed while the content-addressed payloads sat untouched on disk. One corrupt byte = a cache wipe.

## What can actually be rebuilt — the answer shapes the whole PR

The issue assumes the on-disk state is sufficient. It is not, and the gap matters:

```rust
struct StagedOutput { index: usize, size: u64, digest_hex: String }
```

The staged manifest records **index, size and digest — never a filename**. `ArtifactIndex` needs output *names*, and they are load-bearing in three delivery paths:

- `cached_hit.rs:186` — outputs at index ≥ 1 are written to `secondary_output_dir.join(&names[i])`.
- `cached_hit.rs:377` `rustc_compat_payload_index_for` — picks which payload satisfies which requested `--emit`, **by name**. Guessing here delivers an `.rmeta` as an `.rlib`.
- `handle_exec.rs:779` — exact-name pairing.

A wrong hit is catastrophic in this cache; a miss is merely slow. So the reconstruction is deliberately **narrower than the issue asks for**:

- **Single-output staged-v2 generations only.** With one output the name is never consulted — payload 0 goes to the *current request's* `output_path`. Multi-output generations are counted and skipped.
- The synthetic name is `zccache-reconciled-output.zcunknown`, chosen so `rustc_output_kind` returns `None` (the extension is outside its table). The `--emit` compat path then refuses to map anything onto it and takes a clean miss; `handle_exec` misses on exact-name; `handle_link`'s directory-output prefix check fails into passthrough. Every route degrades to a **miss**, never to a mis-shaped write.
- **Flat-v1 and pack layouts are excluded.** Neither records an authoritative output *count*, so a flat group whose `_1` was evicted is indistinguishable from a genuine single-output artifact — rebuilding it would serve a truncated artifact as a complete hit. The staged manifest states the count outright, which is exactly the property reconciliation needs.

Every skip is counted and reported, so the shortfall is visible rather than silent.

## Layering

`zccache-artifact` exposes `take_started_corrupt()` — consuming, so only one of two racing `load_from_disk` callers pays for the scan. Policy (when, budget, event) lives in the daemon (`server/index_reconcile.rs`). The scan stays in `zccache-artifact` because the manifest reader already lives there, so **no dependency moves in either direction** and `disk_maintenance::scan_artifacts` was not needed.

Bounded by `ZCCACHE_INDEX_RECONCILE_BUDGET_MS` (default 5 s), checked per candidate so exhaustion truncates rather than delaying daemon start. Wired into **both** startup paths — standalone `loaders.rs` and `embedded.rs`.

## Tests (13 new)

Rebuild → re-hittable **through the real resolver**, not a stubbed one; durable event with counts; zero-budget truncation (no sleeping); idempotent across two corrupt-then-rebuild restarts including stable `stored_at_secs`; tampered payload skipped; multi-output skipped; a healthy index never scanned; a complete in-memory entry never downgraded.

`open_corrupt_file_starts_empty` **pinned the old behaviour** (`assert_eq!(len(), 0)`) — it is now `open_corrupt_file_starts_empty_but_flags_itself_for_reconciliation`, with a doc comment recording what it used to claim.

## Evidence

- `soldr cargo test -p zccache-artifact --lib` — **91 passed, 0 failed**, 1 ignored.
- `soldr cargo test -p zccache-daemon-core --features "test-support,daemon-entry" --lib` — **717 passed, 0 failed**, 25 ignored.
- `soldr cargo test -p zccache-core --lib lifecycle` — 13 passed.
- clippy `-D warnings` on all three crates — clean.
- `soldr cargo check --workspace --all-targets`, bare `check -p zccache-artifact -p zccache-daemon-core`, `fmt --check`, `ci/check_dylint_wiring.py` — all clean.
- The two wall-clock flakes pass when run alone.

## Gaps, stated plainly

1. **Multi-output artifacts are not recovered** — often `.o` + `.d` for C/C++ and `.rmeta` + `.rlib` for rustc, so on a real cache this recovers materially less than the issue imagined. The clean fix is to persist `output_names` into the staged manifest (a manifest version bump), which would make reconciliation complete. Recommended as the follow-up.
2. **Flat-v1 and pack caches recover nothing**, for the truncation reason above.
3. **Reconciled hits replay with no compiler warnings** (`stdout`/`stderr` are not on disk). Sanctioned by the issue text, but user-visible.
4. **Not Linux-Docker validated** — verified on a Windows host only. Nothing here is `cfg`-gated, but flagging the unverified surface rather than implying coverage.
5. `lifecycle.rs` is now 1063 LOC, over the 1000-line warn threshold. It was already 1049 before this change; splitting it is its own PR.

## #1157 after this

- **Finding 1** — done, with the narrowing above.
- **Finding 3, index half** — done: the rebuild outcome is a durable event, alongside the existing `state_corrupt` record of what was lost.
- **Finding 2** (depgraph `Corrupt`/`IoError` install an empty graph) — still open, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
