### PR TITLE
fix(artifact): drop a useless conversion left by #1301

### DIFF
--- a/crates/zccache-artifact/src/layout.rs
+++ b/crates/zccache-artifact/src/layout.rs
@@ -209,10 +209,9 @@ fn verify_generation_outputs(generation: &PublishedGeneration) -> io::Result<Vec
             ));
         }
         seen[output.index] = true;
-        let path: NormalizedPath = generation
-            .dir
-            .join(format!("output-{}", output.index))
-            .into();
+        // `dir` is already a `NormalizedPath`, so `join` yields one — the
+        // `.into()` this replaced became a no-op when the field changed type.
+        let path = generation.dir.join(format!("output-{}", output.index));
         if fs::metadata(&path)?.len() != output.size {
             return Err(invalid_data(
                 "staged output size does not match its manifest",


### PR DESCRIPTION
**`main` is currently red** under the command CLAUDE.md tells contributors to run:

```
soldr cargo clippy --workspace --all-targets -- -D warnings
→ error: useless conversion to the same type: `zccache_core::NormalizedPath`
  --> crates/zccache-artifact/src/layout.rs:212
```

## My regression, and how it got in

#1301 switched `PublishedGeneration::dir` from `std::path::PathBuf` to `NormalizedPath` to satisfy `ban_std_pathbuf` (CI's Dylint job caught *that* one). That made the `.into()` on `dir.join(...)` a no-op, which `clippy::useless_conversion` denies.

**Why CI stayed green:** the Dylint job runs a plain check under the dylint driver, not clippy, and the PR's other legs do not deny warnings for this crate. So the workspace clippy gate the docs prescribe is not a gate CI enforces — a clean checkout of `main` fails it.

That gap deserves attention independently of this fix: a documented command that fails on `main` trains people to stop running it. I have not changed CI here — flagging rather than unilaterally adding a job.

## The fix

Remove the redundant `.into()`; `NormalizedPath::join` already yields a `NormalizedPath`. A comment records why, so the next reader does not re-add it by analogy with the surrounding conversions that *are* load-bearing.

## Evidence

- Clippy on `zccache-artifact`, all targets, `-D warnings` — clean (this was the failing target).
- Clippy on the **whole workspace**, all targets, `-D warnings` — clean.
- `soldr cargo test -p zccache-artifact --lib` — **91 passed, 0 failed**, 1 ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
