### PR TITLE
fix(depgraph): quarantine a rejected snapshot instead of destroying it (#1157 F2)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/depgraph_load.rs
+++ b/crates/zccache-daemon-core/src/daemon/depgraph_load.rs
@@ -1,0 +1,470 @@
+//! Startup policy for the persisted depgraph snapshot (#1157 finding 2).
+//!
+//! Extracted out of `daemon::entry`'s `spawn_blocking` closure so the arms
+//! that decide "warm graph or cold world" are reachable from a unit test.
+//! Before the extraction the drop paths could only be pinned by re-emitting
+//! their events by hand, which cannot catch an arm that stops firing.
+//!
+//! ## What a reset actually costs, and what it does not
+//!
+//! An artifact key is `H(logical_context_key, sorted(path → content_hash))`
+//! over the source *plus every resolved include* (`zccache-depgraph`,
+//! `context::compute_artifact_key`). That include set exists nowhere but the
+//! depgraph: the artifact index (`zccache-artifact::ArtifactIndex`) stores
+//! output names/sizes/stdout/stderr/exit-code and no input identity at all.
+//! So an empty graph means every translation unit reports `CacheVerdict::Cold`
+//! and is recompiled once, even though its artifact is still on disk and is
+//! re-adopted (same key, deduplicated) the moment the compiler hands the
+//! include list back. The blast radius is one recompile per TU — not a cache
+//! wipe.
+//!
+//! That also rules out "keep the artifact-key mapping across the reset"
+//! as stated in #1157: preserving the mapping *is* preserving the contexts,
+//! the contexts live in the rejected blob, and reading a foreign-version blob
+//! needs the old type definitions (the versioned migration this change
+//! deliberately does not implement). Reinterpreting it without one would be
+//! actively dangerous — a schema bump can be precisely because a new input
+//! class started feeding the key (`rustc_env_deps`, #1021), and a resurrected
+//! context missing that field could satisfy `check()` and serve an artifact
+//! built under different inputs. A wrong hit is catastrophic; a miss is slow.
+//!
+//! What this module does instead is stop the drop from being *destructive*:
+//! the rejected snapshot is moved aside rather than left for the next
+//! graceful shutdown to overwrite, and a sidecar written by this build's own
+//! schema version is loaded back. That makes the common real-world reset —
+//! a machine alternating between two binaries with different
+//! `DEPGRAPH_VERSION`s — a one-time cost per version instead of a full cold
+//! recompile on every switch, with no byte of foreign-schema data ever
+//! interpreted.
+
+use std::path::Path;
+
+use crate::depgraph::{quarantine, DepGraph, DepGraphLoadOutcome};
+
+/// Outcome of the startup load, ready to hand to `DepGraphSetter::install`.
+pub(crate) struct StartupLoad {
+    /// The graph to install, or `None` to start cold.
+    pub graph: Option<DepGraph>,
+    /// Operator-visible warning for a degraded load, printed to stderr and
+    /// surfaced in the session log.
+    pub warning: Option<String>,
+}
+
+/// Size of the snapshot at `path`, or `None` when it is not there.
+///
+/// The distinction matters in the forensics event: `null` means the file
+/// vanished between classification and this stat, while `0` means a real,
+/// present, empty snapshot. Collapsing them would let a post-incident search
+/// claim a file existed when it did not.
+pub(crate) fn snapshot_bytes(path: &Path) -> Option<u64> {
+    std::fs::metadata(path).ok().map(|meta| meta.len())
+}
+
+/// Classify the snapshot at `path` and decide what to install.
+///
+/// Emits the durable lifecycle event for every degraded arm before returning;
+/// callers only have to print the warning and install the result.
+pub(crate) fn load_for_startup(path: &Path) -> StartupLoad {
+    let start = std::time::Instant::now();
+    let outcome = crate::depgraph::classify_load(path);
+    let warning = outcome.warning(path);
+    match outcome {
+        DepGraphLoadOutcome::Loaded { graph } => {
+            let stats = graph.stats();
+            let (cold_ctxs, warm_ctxs, stale_ctxs) = graph.state_breakdown();
+            let ctxs_with_key = graph.contexts_with_artifact_key();
+            tracing::info!(
+                contexts = stats.context_count,
+                files = stats.file_count,
+                cold = cold_ctxs,
+                warm = warm_ctxs,
+                stale = stale_ctxs,
+                with_artifact_key = ctxs_with_key,
+                elapsed_ms = start.elapsed().as_millis() as u64,
+                "loaded depgraph from disk (background)"
+            );
+            StartupLoad {
+                graph: Some(graph),
+                warning: None,
+            }
+        }
+        DepGraphLoadOutcome::Missing => StartupLoad {
+            graph: None,
+            warning: None,
+        },
+        DepGraphLoadOutcome::VersionMismatch {
+            file_version,
+            expected_version,
+        } => {
+            let bytes = snapshot_bytes(path);
+            let quarantined =
+                quarantine::quarantine(path, &quarantine::quarantine_path(path, file_version));
+            let recovered = quarantine::recover(path);
+            tracing::warn!(
+                file_version,
+                expected_version,
+                recovered = recovered.is_some(),
+                "depgraph version mismatch — the on-disk snapshot was written by \
+                 a different schema version"
+            );
+            // #1157: a schema bump silently costs every workspace a full cold
+            // recompile. A `tracing::warn!` goes to whatever the operator
+            // happened to be capturing, so fleet-wide "everyone recompiled
+            // today" incidents were unattributable after the fact.
+            emit_reset_event(
+                crate::daemon::lifecycle::EVENT_VERSION_MISMATCH,
+                serde_json::json!({
+                    "subsystem": "depgraph",
+                    "file_version": file_version,
+                    "expected_version": expected_version,
+                    "path": path.display().to_string(),
+                    "bytes": bytes,
+                }),
+                path,
+                quarantined.as_ref(),
+                recovered.as_ref().map(|(_, from)| from),
+            );
+            finish(recovered, warning)
+        }
+        DepGraphLoadOutcome::Corrupt { ref message }
+        | DepGraphLoadOutcome::IoError { ref message } => {
+            let bytes = snapshot_bytes(path);
+            // Unlike the version-mismatch arm there is nothing salvageable in
+            // these bytes — they failed validation, so they are preserved for
+            // forensics in a single slot and never read back.
+            let quarantined = quarantine::quarantine(path, &quarantine::corrupt_sidecar_path(path));
+            let recovered = quarantine::recover(path);
+            tracing::warn!(
+                recovered = recovered.is_some(),
+                "depgraph load failed: {message}"
+            );
+            // #1157: the sibling `VersionMismatch` arm already emits a durable
+            // event, and this arm has the same blast radius. Leaving it on
+            // `tracing::warn!` alone made the corrupt case the one variant a
+            // post-incident log search missed.
+            emit_reset_event(
+                crate::core::lifecycle::EVENT_STATE_CORRUPT,
+                serde_json::json!({
+                    "subsystem": "depgraph",
+                    "message": message,
+                    "path": path.display().to_string(),
+                    "bytes": bytes,
+                }),
+                path,
+                quarantined.as_ref(),
+                recovered.as_ref().map(|(_, from)| from),
+            );
+            finish(recovered, warning)
+        }
+    }
+}
+
+/// Install the recovered sidecar when there is one, else start cold.
+///
+/// The warning is kept in both cases: the primary snapshot really was
+/// rejected, and an operator investigating a schema bump should see that even
+/// when a sidecar softened the blow.
+fn finish(
+    recovered: Option<(DepGraph, zccache_core::NormalizedPath)>,
+    warning: Option<String>,
+) -> StartupLoad {
+    match recovered {
+        Some((graph, from)) => {
+            tracing::info!(
+                sidecar = %from.as_path().display(),
+                contexts = graph.stats().context_count,
+                "recovered depgraph from a same-version quarantine sidecar"
+            );
+            StartupLoad {
+                graph: Some(graph),
+                warning,
+            }
+        }
+        None => StartupLoad {
+            graph: None,
+            warning,
+        },
+    }
+}
+
+/// Write the durable drop-path event, adding the disposition fields shared by
+/// both degraded arms.
+fn emit_reset_event(
+    event: &'static str,
+    mut payload: serde_json::Value,
+    primary: &Path,
+    quarantined_to: Option<&zccache_core::NormalizedPath>,
+    recovered_from: Option<&zccache_core::NormalizedPath>,
+) {
+    if let Some(map) = payload.as_object_mut() {
+        map.insert(
+            "consequence".to_string(),
+            serde_json::Value::from(if recovered_from.is_some() {
+                "recovered_from_quarantine"
+            } else {
+                "empty_graph"
+            }),
+        );
+        map.insert(
+            "quarantined_to".to_string(),
+            match quarantined_to {
+                Some(path) => serde_json::Value::from(path.as_path().display().to_string()),
+                None => serde_json::Value::Null,
+            },
+        );
+        map.insert(
+            "recovered_from".to_string(),
+            match recovered_from {
+                Some(path) => serde_json::Value::from(path.as_path().display().to_string()),
+                None => serde_json::Value::Null,
+            },
+        );
+    }
+    crate::daemon::lifecycle::write_event(event, payload);
+    quarantine::prune(primary);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::depgraph::DEPGRAPH_VERSION;
+
+    /// Drives the real call site (unlike the earlier hand-rolled payload
+    /// tests this replaces): writes a version-skewed snapshot, runs
+    /// `load_for_startup`, and reads the event back out of the lifecycle log.
+    struct Fixture {
+        _temp: tempfile::TempDir,
+        cache_root: std::path::PathBuf,
+        snapshot: std::path::PathBuf,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let temp = tempfile::tempdir().unwrap();
+            let cache_root = temp.path().join("cache");
+            let snapshot = cache_root.join("depgraph").join("depgraph.bin");
+            std::fs::create_dir_all(snapshot.parent().unwrap()).unwrap();
+            Self {
+                _temp: temp,
+                cache_root,
+                snapshot,
+            }
+        }
+
+        /// `write_event` resolves the cache root from the process environment;
+        /// point it at this fixture for the duration of one load.
+        fn load(&self) -> (StartupLoad, serde_json::Value) {
+            let _guard = CacheRootEnv::set(&self.cache_root);
+            let load = load_for_startup(&self.snapshot);
+            // Resolve the log exactly the way production's `write_event` does,
+            // so the test cannot pass by reading a path the daemon never uses.
+            let log = crate::core::lifecycle::log_file_path();
+            let body = std::fs::read_to_string(log.as_path())
+                .expect("a degraded load must write a durable lifecycle event");
+            let record = body
+                .lines()
+                .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+                .next_back()
+                .expect("the lifecycle log must contain a parseable record");
+            (load, record)
+        }
+
+        fn write_snapshot(&self, version: u32) {
+            let graph = crate::depgraph::DepGraph::new();
+            crate::depgraph::save_to_file(&graph, &self.snapshot).unwrap();
+            if version != DEPGRAPH_VERSION {
+                let mut bytes = std::fs::read(&self.snapshot).unwrap();
+                bytes[4..8].copy_from_slice(&version.to_le_bytes());
+                std::fs::write(&self.snapshot, &bytes).unwrap();
+            }
+        }
+    }
+
+    struct CacheRootEnv {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    static CACHE_ROOT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    impl CacheRootEnv {
+        fn set(root: &Path) -> Self {
+            let lock = CACHE_ROOT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let previous = std::env::var_os("ZCCACHE_CACHE_DIR");
+            std::env::set_var("ZCCACHE_CACHE_DIR", root);
+            Self {
+                _lock: lock,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for CacheRootEnv {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var("ZCCACHE_CACHE_DIR", value),
+                None => std::env::remove_var("ZCCACHE_CACHE_DIR"),
+            }
+        }
+    }
+
+    #[test]
+    fn version_mismatch_drives_the_event_and_quarantines_instead_of_clobbering() {
+        assert!(
+            crate::core::lifecycle::EVENT_ALL
+                .contains(&crate::daemon::lifecycle::EVENT_VERSION_MISMATCH),
+            "log-audit tooling and operator docs key on the catalog; an event \
+             outside it is invisible to them"
+        );
+
+        let fixture = Fixture::new();
+        let foreign = DEPGRAPH_VERSION + 1;
+        fixture.write_snapshot(foreign);
+        let size = std::fs::metadata(&fixture.snapshot).unwrap().len();
+
+        let (load, record) = fixture.load();
+
+        assert!(load.graph.is_none(), "a foreign schema must start cold");
+        assert!(load.warning.is_some(), "the operator must be told why");
+        assert_eq!(
+            record["event"],
+            crate::daemon::lifecycle::EVENT_VERSION_MISMATCH
+        );
+        // `subsystem` separates a depgraph schema bump from the daemon-version
+        // mismatch that already used this event name.
+        assert_eq!(record["subsystem"], "depgraph");
+        assert_eq!(record["file_version"], foreign);
+        assert_eq!(record["expected_version"], DEPGRAPH_VERSION);
+        assert_eq!(record["consequence"], "empty_graph");
+        assert_eq!(record["bytes"], size, "the size of what was dropped");
+        assert!(record["path"]
+            .as_str()
+            .is_some_and(|p| p.ends_with("depgraph.bin")));
+
+        let sidecar = crate::depgraph::quarantine::quarantine_path(&fixture.snapshot, foreign);
+        assert_eq!(
+            record["quarantined_to"].as_str(),
+            Some(sidecar.as_path().display().to_string().as_str()),
+            "the event must name where the rejected snapshot went"
+        );
+        assert!(
+            sidecar.as_path().exists() && !fixture.snapshot.exists(),
+            "the rejected snapshot must be preserved, not left for the next \
+             graceful shutdown to overwrite"
+        );
+        assert_eq!(record["recovered_from"], serde_json::Value::Null);
+    }
+
+    /// The oscillation case #1157 actually costs users: two binaries with
+    /// different `DEPGRAPH_VERSION`s sharing a cache root. Each side keeps its
+    /// own snapshot, so the second switch back is warm rather than a full cold
+    /// recompile.
+    #[test]
+    fn a_same_version_sidecar_is_recovered_after_the_primary_is_rejected() {
+        let fixture = Fixture::new();
+
+        // This build's own snapshot, parked by an earlier foreign-version run.
+        fixture.write_snapshot(DEPGRAPH_VERSION);
+        let mine =
+            crate::depgraph::quarantine::quarantine_path(&fixture.snapshot, DEPGRAPH_VERSION);
+        std::fs::rename(&fixture.snapshot, mine.as_path()).unwrap();
+
+        // The other binary left its own snapshot as the primary.
+        fixture.write_snapshot(DEPGRAPH_VERSION + 1);
+
+        let (load, record) = fixture.load();
+
+        assert!(
+            load.graph.is_some(),
+            "a sidecar carrying this build's exact schema version must be \
+             adopted — it passes the same magic/version/rkyv validation the \
+             primary snapshot does"
+        );
+        assert_eq!(record["consequence"], "recovered_from_quarantine");
+        assert_eq!(
+            record["recovered_from"].as_str(),
+            Some(mine.as_path().display().to_string().as_str())
+        );
+        assert!(
+            load.warning.is_some(),
+            "recovery softens the blow but the primary snapshot really was \
+             rejected; the operator still needs to see the schema skew"
+        );
+    }
+
+    #[test]
+    fn corrupt_bytes_drive_the_event_and_are_never_read_back() {
+        assert!(
+            crate::core::lifecycle::EVENT_ALL
+                .contains(&crate::core::lifecycle::EVENT_STATE_CORRUPT),
+            "an event outside the catalog cannot be given a log-audit rule"
+        );
+
+        let fixture = Fixture::new();
+        std::fs::write(&fixture.snapshot, b"not a valid snapshot").unwrap();
+
+        let (load, record) = fixture.load();
+
+        assert!(load.graph.is_none());
+        assert_eq!(record["event"], crate::core::lifecycle::EVENT_STATE_CORRUPT);
+        assert_eq!(record["subsystem"], "depgraph");
+        assert_eq!(record["consequence"], "empty_graph");
+        assert_eq!(record["bytes"], 20, "the size of the dropped snapshot");
+        assert!(record["path"]
+            .as_str()
+            .is_some_and(|p| p.ends_with("depgraph.bin")));
+
+        let sidecar = crate::depgraph::quarantine::corrupt_sidecar_path(&fixture.snapshot);
+        assert_eq!(
+            record["quarantined_to"].as_str(),
+            Some(sidecar.as_path().display().to_string().as_str())
+        );
+        assert_eq!(
+            std::fs::read(sidecar.as_path()).unwrap(),
+            b"not a valid snapshot",
+            "damaged bytes are kept for forensics"
+        );
+        // And the forensic copy is never a load candidate: re-running the load
+        // with the primary gone must still start cold, not resurrect it.
+        let (again, _) = fixture.load();
+        assert!(again.graph.is_none());
+    }
+
+    #[test]
+    fn snapshot_bytes_separates_a_missing_snapshot_from_an_empty_one() {
+        let temp = tempfile::tempdir().unwrap();
+
+        let missing = temp.path().join("never-written.bin");
+        assert_eq!(
+            snapshot_bytes(&missing),
+            None,
+            "a snapshot that is not there must report absent, not zero bytes — \
+             collapsing the two would make the forensics claim a file existed"
+        );
+
+        let empty = temp.path().join("empty.bin");
+        std::fs::write(&empty, b"").unwrap();
+        assert_eq!(
+            snapshot_bytes(&empty),
+            Some(0),
+            "a present-but-empty snapshot is a real, different failure and must \
+             be distinguishable from a missing one"
+        );
+
+        let populated = temp.path().join("populated.bin");
+        std::fs::write(&populated, b"corrupt-but-sizeable").unwrap();
+        assert_eq!(snapshot_bytes(&populated), Some(20));
+    }
+
+    #[test]
+    fn a_missing_snapshot_is_a_plain_cold_start_with_no_event() {
+        let fixture = Fixture::new();
+        let _guard = CacheRootEnv::set(&fixture.cache_root);
+        let load = load_for_startup(&fixture.snapshot);
+        assert!(load.graph.is_none());
+        assert!(
+            load.warning.is_none(),
+            "a first run is not a degraded load and must not warn"
+        );
+    }
+}

--- a/crates/zccache-daemon-core/src/daemon/depgraph_load.rs
+++ b/crates/zccache-daemon-core/src/daemon/depgraph_load.rs
@@ -261,11 +261,18 @@ mod tests {
             let log = crate::core::lifecycle::log_file_path();
             let body = std::fs::read_to_string(log.as_path())
                 .expect("a degraded load must write a durable lifecycle event");
+            // Select by THIS fixture's snapshot path, not by "the last line".
+            // The lifecycle log resolves from a process-global cache root, so a
+            // concurrently running test can append between our write and our
+            // read — taking the tail made this pass alone and fail in the
+            // suite. The tempdir path is unique per fixture, so it is an exact
+            // selector rather than a positional guess.
+            let wanted = self.snapshot.display().to_string();
             let record = body
                 .lines()
                 .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
-                .next_back()
-                .expect("the lifecycle log must contain a parseable record");
+                .rfind(|record: &serde_json::Value| record["path"] == wanted)
+                .expect("a degraded load must write an event naming its own snapshot");
             (load, record)
         }
 

--- a/crates/zccache-daemon-core/src/daemon/entry.rs
+++ b/crates/zccache-daemon-core/src/daemon/entry.rs
@@ -55,18 +55,6 @@ fn daemon_max_blocking_threads() -> usize {
     parallelism.saturating_mul(8).clamp(128, 512)
 }
 
-/// Size of a persisted snapshot for a state-loss event payload, or `None` when
-/// it cannot be stat'd.
-///
-/// #1157 asks the drop-path events to carry the file path and byte count so a
-/// post-incident search can size the loss. `None` is deliberate over `0`: a
-/// snapshot that vanished between classification and this stat is a different
-/// story from one that was present and empty, and collapsing them would make
-/// the forensics lie.
-fn snapshot_bytes(path: &std::path::Path) -> Option<u64> {
-    std::fs::metadata(path).ok().map(|meta| meta.len())
-}
-
 const DAEMON_PROFILE_ENV: &str = "ZCCACHE_DAEMON_PROFILE";
 const TOKIO_CONSOLE_PROFILE: &str = "tokio-console";
 const TOKIO_CONSOLE_BIND_ENV: &str = "TOKIO_CONSOLE_BIND";
@@ -454,91 +442,16 @@ fn run_server(args: Args) {
                 setter.install(None, None);
                 return;
             }
-            let start = std::time::Instant::now();
-            let outcome = crate::depgraph::classify_load(&depgraph_path);
-            let warning = outcome.warning(&depgraph_path);
-            match outcome {
-                crate::depgraph::DepGraphLoadOutcome::Loaded { graph } => {
-                    let stats = graph.stats();
-                    let (cold_ctxs, warm_ctxs, stale_ctxs) = graph.state_breakdown();
-                    let ctxs_with_key = graph.contexts_with_artifact_key();
-                    tracing::info!(
-                        contexts = stats.context_count,
-                        files = stats.file_count,
-                        cold = cold_ctxs,
-                        warm = warm_ctxs,
-                        stale = stale_ctxs,
-                        with_artifact_key = ctxs_with_key,
-                        elapsed_ms = start.elapsed().as_millis() as u64,
-                        "loaded depgraph from disk (background)"
-                    );
-                    setter.install(Some(graph), None);
-                }
-                crate::depgraph::DepGraphLoadOutcome::Missing => {
-                    setter.install(None, None);
-                }
-                crate::depgraph::DepGraphLoadOutcome::VersionMismatch {
-                    file_version,
-                    expected_version,
-                } => {
-                    tracing::warn!(
-                        file_version,
-                        expected_version,
-                        "depgraph version mismatch — starting with empty graph"
-                    );
-                    // #1157: a schema bump silently costs every workspace a
-                    // full cold recompile. A `tracing::warn!` goes to whatever
-                    // the operator happened to be capturing, so fleet-wide
-                    // "everyone recompiled today" incidents were unattributable
-                    // after the fact. The durable event is what makes them
-                    // diagnosable -- same reasoning as the spawn/death events
-                    // this log already carries.
-                    crate::daemon::lifecycle::write_event(
-                        crate::daemon::lifecycle::EVENT_VERSION_MISMATCH,
-                        serde_json::json!({
-                            "subsystem": "depgraph",
-                            "file_version": file_version,
-                            "expected_version": expected_version,
-                            "consequence": "empty_graph",
-                            // #1157 asked for the path and byte count on *both*
-                            // drop paths; the index side carries them, so a
-                            // post-incident search could size the index loss but
-                            // not the graph loss. `bytes` is null when the file
-                            // vanished between classify and stat -- absent, not
-                            // zero, so it is not mistaken for an empty snapshot.
-                            "path": depgraph_path.display().to_string(),
-                            "bytes": snapshot_bytes(&depgraph_path),
-                        }),
-                    );
-                    if let Some(ref w) = warning {
-                        eprintln!("{w}");
-                    }
-                    setter.install(None, warning);
-                }
-                crate::depgraph::DepGraphLoadOutcome::Corrupt { ref message }
-                | crate::depgraph::DepGraphLoadOutcome::IoError { ref message } => {
-                    tracing::warn!("depgraph load failed: {message} — starting with empty graph");
-                    // #1157: the sibling `VersionMismatch` arm already emits a
-                    // durable event, and this arm has the same blast radius —
-                    // an empty graph means every workspace cold-recompiles.
-                    // Leaving it on `tracing::warn!` alone made the corrupt
-                    // case the one variant a post-incident log search missed.
-                    crate::daemon::lifecycle::write_event(
-                        crate::core::lifecycle::EVENT_STATE_CORRUPT,
-                        serde_json::json!({
-                            "subsystem": "depgraph",
-                            "message": message,
-                            "consequence": "empty_graph",
-                            "path": depgraph_path.display().to_string(),
-                            "bytes": snapshot_bytes(&depgraph_path),
-                        }),
-                    );
-                    if let Some(ref w) = warning {
-                        eprintln!("{w}");
-                    }
-                    setter.install(None, warning);
-                }
+            // #1157: the classify/quarantine/recover policy lives in
+            // `daemon::depgraph_load` so its degraded arms are reachable from
+            // a unit test — inline here they could only ever be pinned by
+            // re-emitting their events by hand, which cannot catch an arm that
+            // stops firing.
+            let load = crate::daemon::depgraph_load::load_for_startup(&depgraph_path);
+            if let Some(ref w) = load.warning {
+                eprintln!("{w}");
             }
+            setter.install(load.graph, load.warning);
         });
 
         // Issue #784: move the compiler-hash cache load off the
@@ -759,144 +672,6 @@ fn init_tokio_console_tracing(filter: tracing_subscriber::EnvFilter, bind: &str)
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // #1157: the durable record of a depgraph schema bump.
-    //
-    // Scope, stated plainly: this pins the *payload contract* — the event
-    // name and the fields an operator greps for — by writing the same shape
-    // through the same API into a temp cache root. It does not drive the
-    // call site, because that arm lives inside a `spawn_blocking` closure in
-    // `run_daemon` and reaching it needs a live daemon plus a version-skewed
-    // depgraph file on disk, which is integration scope. The value here is
-    // that a future edit cannot silently rename a field or drop the event
-    // from the catalog.
-    #[test]
-    fn depgraph_version_mismatch_event_is_greppable_and_catalogued() {
-        use crate::core::lifecycle as core_lifecycle;
-        use crate::daemon::lifecycle;
-
-        assert!(
-            core_lifecycle::EVENT_ALL.contains(&lifecycle::EVENT_VERSION_MISMATCH),
-            "log-audit tooling and operator docs key on the catalog; an event \
-             outside it is invisible to them"
-        );
-
-        let temp = tempfile::tempdir().unwrap();
-        core_lifecycle::write_event_in_cache_root(
-            temp.path(),
-            lifecycle::EVENT_VERSION_MISMATCH,
-            serde_json::json!({
-                "subsystem": "depgraph",
-                "file_version": 3u32,
-                "expected_version": 4u32,
-                "consequence": "empty_graph",
-            }),
-        );
-
-        let log_path = temp
-            .path()
-            .join("logs")
-            .join(core_lifecycle::live_log_filename());
-        let body = std::fs::read_to_string(&log_path)
-            .expect("the event must land in <cache_root>/logs/<live log>");
-        let record = body
-            .lines()
-            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
-            .find(|v| v["event"] == lifecycle::EVENT_VERSION_MISMATCH)
-            .expect("the version-mismatch event must be written to the lifecycle log");
-
-        // `subsystem` is what separates a depgraph schema bump from the
-        // daemon-version mismatch that already used this event name.
-        assert_eq!(record["subsystem"], "depgraph");
-        assert_eq!(record["file_version"], 3);
-        assert_eq!(record["expected_version"], 4);
-        assert_eq!(record["consequence"], "empty_graph");
-    }
-
-    /// #1157 asked the drop-path events to carry the file path *and* byte
-    /// count. The index side did; the depgraph side reported neither, so a
-    /// post-incident search could size the index loss but not the graph loss.
-    ///
-    /// Unlike the payload-contract test above, this drives the real function:
-    /// `snapshot_bytes` is where the only logic lives, and the distinction it
-    /// encodes — absent vs. present-but-empty — is the part worth pinning.
-    #[test]
-    fn snapshot_bytes_separates_a_missing_snapshot_from_an_empty_one() {
-        let temp = tempfile::tempdir().unwrap();
-
-        let missing = temp.path().join("never-written.bin");
-        assert_eq!(
-            snapshot_bytes(&missing),
-            None,
-            "a snapshot that is not there must report absent, not zero bytes — \
-             collapsing the two would make the forensics claim a file existed"
-        );
-
-        let empty = temp.path().join("empty.bin");
-        std::fs::write(&empty, b"").unwrap();
-        assert_eq!(
-            snapshot_bytes(&empty),
-            Some(0),
-            "a present-but-empty snapshot is a real, different failure and must \
-             be distinguishable from a missing one"
-        );
-
-        let populated = temp.path().join("populated.bin");
-        std::fs::write(&populated, b"corrupt-but-sizeable").unwrap();
-        assert_eq!(snapshot_bytes(&populated), Some(20));
-    }
-
-    /// The corrupt/IO arm is the variant a post-incident log search used to
-    /// miss entirely, and it still has no test that drives its call site (that
-    /// arm lives in a `spawn_blocking` closure in `run_daemon`). This pins its
-    /// payload contract, including the `path`/`bytes` fields #1157 asked for.
-    #[test]
-    fn depgraph_state_corrupt_event_carries_the_path_and_size_of_what_was_dropped() {
-        use crate::core::lifecycle as core_lifecycle;
-
-        assert!(
-            core_lifecycle::EVENT_ALL.contains(&core_lifecycle::EVENT_STATE_CORRUPT),
-            "an event outside the catalog cannot be given a log-audit rule"
-        );
-
-        let temp = tempfile::tempdir().unwrap();
-        let snapshot = temp.path().join("depgraph.bin");
-        std::fs::write(&snapshot, b"not a valid snapshot").unwrap();
-
-        core_lifecycle::write_event_in_cache_root(
-            temp.path(),
-            core_lifecycle::EVENT_STATE_CORRUPT,
-            serde_json::json!({
-                "subsystem": "depgraph",
-                "message": "decode failed",
-                "consequence": "empty_graph",
-                "path": snapshot.display().to_string(),
-                "bytes": snapshot_bytes(&snapshot),
-            }),
-        );
-
-        let log_path = temp
-            .path()
-            .join("logs")
-            .join(core_lifecycle::live_log_filename());
-        let body = std::fs::read_to_string(&log_path).expect("event must be written");
-        let record = body
-            .lines()
-            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
-            .find(|v| v["event"] == core_lifecycle::EVENT_STATE_CORRUPT)
-            .expect("the corrupt-state event must reach the lifecycle log");
-
-        assert_eq!(record["subsystem"], "depgraph");
-        assert_eq!(record["consequence"], "empty_graph");
-        assert_eq!(record["bytes"], 20, "the size of the dropped snapshot");
-        assert!(
-            record["path"]
-                .as_str()
-                .is_some_and(|p| p.ends_with("depgraph.bin")),
-            "the event must name the file that was dropped; got {:?}",
-            record["path"]
-        );
-    }
 
     // #997: the daemon arg parser is now library-testable. Before the
     // extraction this lived in a bin and could not be unit-tested.

--- a/crates/zccache-daemon-core/src/daemon/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/mod.rs
@@ -9,6 +9,12 @@ pub(crate) mod child_watchdog;
 pub mod compile_journal;
 pub(crate) mod compile_output;
 pub mod crash;
+/// Startup classification / quarantine policy for the persisted depgraph
+/// snapshot (#1157). Gated with `entry` because the standalone daemon is its
+/// only production caller; `test` keeps it available to the server tests that
+/// drive a synthetic restart.
+#[cfg(any(feature = "daemon-entry", test))]
+pub(crate) mod depgraph_load;
 /// Standalone daemon process entry point (issue #997), gated so it only
 /// compiles when a binary that hosts it (`daemon-bin`, or the `cli`/`zccache`
 /// binary via argv[0] dispatch) pulls in clap + tracing-subscriber.

--- a/crates/zccache-daemon-core/src/daemon/server/tests/depgraph_reset_reachability.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/depgraph_reset_reachability.rs
@@ -1,0 +1,291 @@
+//! #1157 finding 2 — what a depgraph reset really costs, end to end.
+//!
+//! The issue assumed on-disk artifacts "remain hittable in principle" after
+//! the graph is dropped. They do not: an artifact key is
+//! `H(logical_context_key, sorted(path → content_hash))` over the source
+//! *plus every resolved include*, and that include set lives only in the
+//! depgraph — `zccache_artifact::ArtifactIndex` records outputs, stdout,
+//! stderr and exit code, and nothing about the inputs. So an empty graph
+//! forces `CacheVerdict::Cold` and one real recompile per translation unit.
+//!
+//! What survives is the *store*: the recompile recomputes the identical key
+//! and re-adopts the artifact, so the reset costs one recompile, not a cache
+//! wipe. Both halves are pinned below, because "we recompile once" and "we
+//! lost the cache" are very different incidents and the difference was
+//! previously untested.
+//!
+//! The third test covers the case the quarantine sidecar exists for: a cache
+//! root shared by two binaries with different `DEPGRAPH_VERSION`s. That used
+//! to destroy the other side's snapshot on every switch; now each side keeps
+//! its own and stays warm.
+
+use std::path::Path;
+
+use super::super::*;
+use super::multi_restart_context_key::{
+    quiesce_and_persist, spawn_index_writer, write_fake_multi_cc,
+};
+use super::CacheDirEnvGuard;
+
+/// Rewrite the LE `u32` schema tag at bytes 4..8 (immediately after the
+/// 4-byte magic) so `classify_load` reports `VersionMismatch` — the exact
+/// shape a real schema bump produces, without having to bump the constant.
+fn skew_snapshot_version(path: &Path) {
+    let mut bytes = std::fs::read(path).expect("a persisted snapshot must exist");
+    bytes[4..8].copy_from_slice(&(crate::depgraph::DEPGRAPH_VERSION + 1).to_le_bytes());
+    std::fs::write(path, &bytes).unwrap();
+}
+
+/// Install the startup decision the daemon really makes, rather than a
+/// test-local approximation: `daemon::entry` calls exactly this and installs
+/// exactly this graph.
+fn start_with_production_load(server: &DaemonServer, depgraph_path: &Path) -> bool {
+    let load = crate::daemon::depgraph_load::load_for_startup(depgraph_path);
+    let warm = load.graph.is_some();
+    server.dep_graph_setter().install(load.graph, load.warning);
+    warm
+}
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    cache_root: crate::core::NormalizedPath,
+    depgraph_path: crate::core::NormalizedPath,
+    cc: std::path::PathBuf,
+    work: std::path::PathBuf,
+    out: std::path::PathBuf,
+    args: Vec<String>,
+}
+
+impl Fixture {
+    fn new(stem: &str) -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_root: crate::core::NormalizedPath = tmp.path().join("zccache-cache").into();
+        let depgraph_path =
+            crate::core::config::depgraph_dir_from_cache_dir(&cache_root).join("depgraph.bin");
+        let cc = write_fake_multi_cc(tmp.path());
+        let work = tmp.path().join("work");
+        std::fs::create_dir_all(&work).unwrap();
+        let src = work.join(format!("{stem}.c"));
+        std::fs::write(&src, format!("int {stem}(void) {{ return 7; }}\n")).unwrap();
+        let out = work.join(format!("{stem}.o"));
+        let args = vec!["-c".to_string(), src.to_string_lossy().into_owned()];
+        Self {
+            _tmp: tmp,
+            cache_root,
+            depgraph_path,
+            cc,
+            work,
+            out,
+            args,
+        }
+    }
+
+    fn bind(&self) -> DaemonServer {
+        DaemonServer::bind_with_cache_dir(&crate::ipc::unique_test_endpoint(), &self.cache_root)
+            .unwrap()
+    }
+
+    async fn compile(&self, server: &DaemonServer) -> bool {
+        let response = handle_compile_ephemeral(
+            &server.state,
+            std::process::id(),
+            &self.work,
+            &self.cc,
+            &self.args,
+            &self.work,
+            None,
+            Vec::new(),
+        )
+        .await;
+        match response {
+            Response::CompileResult {
+                exit_code, cached, ..
+            } => {
+                assert_eq!(exit_code, 0, "the fake compiler must succeed");
+                cached
+            }
+            other => panic!("expected CompileResult, got {other:?}"),
+        }
+    }
+
+    /// Run one full daemon lifetime: bind, load the graph the production way,
+    /// compile, then perform the real shutdown durability drain.
+    async fn session(&self, load_graph: bool) -> bool {
+        let mut server = self.bind();
+        let writer = spawn_index_writer(&mut server);
+        if load_graph {
+            start_with_production_load(&server, self.depgraph_path.as_path());
+        }
+        let cached = self.compile(&server).await;
+        quiesce_and_persist(&server, writer, self.depgraph_path.as_path()).await;
+        cached
+    }
+}
+
+/// The honest blast radius of a schema bump: exactly one recompile per
+/// translation unit, and the artifact is re-adopted rather than lost.
+///
+/// If this ever flips to `cached == true` on the reset build, the premise
+/// behind #1157 finding 2 changed and the module docs above are stale.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn a_version_reset_costs_one_recompile_and_leaves_the_artifact_re_adoptable() {
+    let fixture = Fixture::new("reset_probe");
+    let _env_lock = CacheDirEnvGuard::lock();
+
+    assert!(
+        !fixture.session(false).await,
+        "the very first compile is a genuine cold miss"
+    );
+    let cold_bytes = std::fs::read(&fixture.out).unwrap();
+    std::fs::remove_file(&fixture.out).unwrap();
+
+    // Control: with the snapshot intact the next session is warm. Without
+    // this, the reset assertion below could pass for an unrelated reason.
+    assert!(
+        fixture.session(true).await,
+        "an intact snapshot must still hit — otherwise the reset assertion \
+         below proves nothing"
+    );
+    std::fs::remove_file(&fixture.out).unwrap();
+
+    // A schema bump: same bytes, foreign version tag.
+    skew_snapshot_version(fixture.depgraph_path.as_path());
+
+    let server = fixture.bind();
+    assert!(
+        !start_with_production_load(&server, fixture.depgraph_path.as_path()),
+        "a foreign schema version must not be installed"
+    );
+    assert!(
+        !fixture.compile(&server).await,
+        "the include set an artifact key is built from lives only in the \
+         depgraph, so an empty graph really does force a recompile — this is \
+         the cost #1157 describes, and it cannot be avoided without either a \
+         versioned migration or reinterpreting foreign-schema bytes"
+    );
+    assert_eq!(
+        std::fs::read(&fixture.out).unwrap(),
+        cold_bytes,
+        "the recompile must reproduce the same object"
+    );
+    let mut server = server;
+    let writer = spawn_index_writer(&mut server);
+    quiesce_and_persist(&server, writer, fixture.depgraph_path.as_path()).await;
+    drop(server);
+    std::fs::remove_file(&fixture.out).unwrap();
+
+    assert!(
+        fixture.session(true).await,
+        "the price of a reset is ONE recompile, not a poisoned cache: the \
+         recompile recomputes the identical artifact key and re-adopts the \
+         artifact that was on disk all along"
+    );
+    assert_eq!(std::fs::read(&fixture.out).unwrap(), cold_bytes);
+}
+
+/// A cache root shared by two binaries with different `DEPGRAPH_VERSION`s
+/// used to have each side destroy the other's snapshot on every switch, so
+/// both cold-recompiled the world forever. Each side now keeps its own
+/// version-tagged sidecar and comes back warm.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn an_oscillating_schema_version_stays_warm_through_the_quarantine_sidecar() {
+    let fixture = Fixture::new("oscillate");
+    let _env_lock = CacheDirEnvGuard::lock();
+
+    assert!(
+        !fixture.session(false).await,
+        "first compile is a cold miss"
+    );
+    let cold_bytes = std::fs::read(&fixture.out).unwrap();
+    std::fs::remove_file(&fixture.out).unwrap();
+
+    // Stand in for "the other binary ran here": it rejected our snapshot,
+    // parked it under our version tag, and left its own snapshot as primary.
+    let ours = crate::depgraph::quarantine::quarantine_path(
+        fixture.depgraph_path.as_path(),
+        crate::depgraph::DEPGRAPH_VERSION,
+    );
+    std::fs::rename(fixture.depgraph_path.as_path(), ours.as_path()).unwrap();
+    std::fs::copy(ours.as_path(), fixture.depgraph_path.as_path()).unwrap();
+    skew_snapshot_version(fixture.depgraph_path.as_path());
+
+    let server = fixture.bind();
+    assert!(
+        start_with_production_load(&server, fixture.depgraph_path.as_path()),
+        "our own parked snapshot carries this build's exact schema version and \
+         passes the same magic/version/rkyv validation the primary gets"
+    );
+    assert!(
+        fixture.compile(&server).await,
+        "recovering the sidecar must actually restore hits — a reset that only \
+         preserves bytes nobody reads back is not a fix"
+    );
+    assert_eq!(std::fs::read(&fixture.out).unwrap(), cold_bytes);
+
+    // The foreign snapshot was preserved rather than clobbered, so the other
+    // binary comes back warm too.
+    let theirs = crate::depgraph::quarantine::quarantine_path(
+        fixture.depgraph_path.as_path(),
+        crate::depgraph::DEPGRAPH_VERSION + 1,
+    );
+    assert!(
+        theirs.as_path().exists(),
+        "the rejected snapshot must be moved aside, not left for this \
+         daemon's graceful shutdown to overwrite"
+    );
+}
+
+/// Restart-loop regression (#1157's own test list): repeating the reset must
+/// be idempotent — no accumulation, no second-order failure.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn repeated_resets_are_idempotent() {
+    let fixture = Fixture::new("idempotent");
+    let _env_lock = CacheDirEnvGuard::lock();
+
+    assert!(!fixture.session(false).await);
+    std::fs::remove_file(&fixture.out).unwrap();
+
+    for round in 0..3 {
+        skew_snapshot_version(fixture.depgraph_path.as_path());
+        let server = fixture.bind();
+        assert!(!start_with_production_load(
+            &server,
+            fixture.depgraph_path.as_path()
+        ));
+        let cached = fixture.compile(&server).await;
+        assert!(!cached, "round {round}: a reset session recompiles");
+        let mut server = server;
+        let writer = spawn_index_writer(&mut server);
+        quiesce_and_persist(&server, writer, fixture.depgraph_path.as_path()).await;
+        drop(server);
+        std::fs::remove_file(&fixture.out).unwrap();
+
+        assert!(
+            fixture.session(true).await,
+            "round {round}: the session after a reset must be warm again"
+        );
+        std::fs::remove_file(&fixture.out).unwrap();
+    }
+
+    // Quarantine is capped: repeated resets reuse the same version-tagged
+    // sidecar rather than piling up snapshots in the depgraph directory.
+    let sidecars = std::fs::read_dir(
+        crate::core::config::depgraph_dir_from_cache_dir(&fixture.cache_root).as_path(),
+    )
+    .unwrap()
+    .flatten()
+    .filter(|entry| {
+        entry
+            .file_name()
+            .to_string_lossy()
+            .starts_with("depgraph.v")
+    })
+    .count();
+    assert_eq!(
+        sidecars, 1,
+        "three resets of the same foreign version must leave one sidecar"
+    );
+}

--- a/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
@@ -14,6 +14,7 @@ mod connection_disconnect;
 mod connection_ipc;
 mod connection_self_profile;
 mod deferred_cold_path;
+mod depgraph_reset_reachability;
 mod disk_maintenance;
 mod embedded_flush;
 mod exec_probe;

--- a/crates/zccache-daemon-core/src/daemon/server/tests/multi_restart_context_key.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/multi_restart_context_key.rs
@@ -71,7 +71,7 @@ use super::CacheDirEnvGuard;
 /// `-MF`/`-MT` values are skipped so a depfile path ending in a source-like
 /// name can never be mistaken for an input.
 #[cfg(unix)]
-fn write_fake_multi_cc(dir: &Path) -> PathBuf {
+pub(super) fn write_fake_multi_cc(dir: &Path) -> PathBuf {
     use std::os::unix::fs::PermissionsExt;
 
     let tool = dir.join("cc");
@@ -114,7 +114,7 @@ exit 0
 }
 
 #[cfg(windows)]
-fn write_fake_multi_cc(dir: &Path) -> PathBuf {
+pub(super) fn write_fake_multi_cc(dir: &Path) -> PathBuf {
     let tool = dir.join("cc.cmd");
     std::fs::write(
         &tool,
@@ -178,7 +178,7 @@ fn restore_dep_graph_from_disk(server: &DaemonServer, path: &Path) {
     }
 }
 
-fn save_dep_graph_to_disk(server: &DaemonServer, path: &Path) {
+pub(super) fn save_dep_graph_to_disk(server: &DaemonServer, path: &Path) {
     let dg = server.state.dep_graph.load_full();
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).ok();
@@ -195,7 +195,7 @@ fn save_dep_graph_to_disk(server: &DaemonServer, path: &Path) {
 /// the entry, but the on-disk index never does. Mirrors `run.rs`'s startup
 /// snippet exactly so a synthetic restart in this harness sees what a real
 /// restart would see.
-fn spawn_index_writer(server: &mut DaemonServer) -> tokio::task::JoinHandle<()> {
+pub(super) fn spawn_index_writer(server: &mut DaemonServer) -> tokio::task::JoinHandle<()> {
     let rx = server
         .index_writer_rx
         .take()
@@ -218,7 +218,7 @@ fn spawn_index_writer(server: &mut DaemonServer) -> tokio::task::JoinHandle<()> 
 /// `pending_cache_writes` registration makes that observable — a previous
 /// version of this helper polled `in_flight_bytes` instead and still raced
 /// CI timing on the Linux runner (#1161).
-async fn quiesce_and_persist(
+pub(super) async fn quiesce_and_persist(
     server: &DaemonServer,
     index_writer_handle: tokio::task::JoinHandle<()>,
     depgraph_path: &Path,

--- a/crates/zccache-depgraph/src/lib.rs
+++ b/crates/zccache-depgraph/src/lib.rs
@@ -36,8 +36,8 @@ pub use session::{
     SessionStatsTracker,
 };
 pub use snapshot::{
-    classify_load, depgraph_file_path, load_from_file, save_to_file, DepGraphLoadOutcome,
-    SnapshotError, DEPGRAPH_VERSION,
+    classify_load, depgraph_file_path, load_from_file, quarantine, save_to_file,
+    DepGraphLoadOutcome, SnapshotError, DEPGRAPH_VERSION,
 };
 pub use system_includes::{
     discovery_args, discovery_args_fast, parse_cc1_system_include_output,

--- a/crates/zccache-depgraph/src/snapshot/README.md
+++ b/crates/zccache-depgraph/src/snapshot/README.md
@@ -2,5 +2,7 @@
 
 On-disk persistence of the dependency graph. `mod.rs` exposes the public
 API (`save_to_file`, `load_from_file`, `classify_load`); `persistence.rs`
-handles the file I/O; `tests/` (cfg(test)-only) splits per concern —
-roundtrip, persistence, behavioral.
+handles the file I/O; `quarantine.rs` moves a snapshot this build cannot
+read aside (instead of letting the next shutdown overwrite it) and loads
+back a sidecar written by this build's own `DEPGRAPH_VERSION`; `tests/`
+(cfg(test)-only) splits per concern — roundtrip, persistence, behavioral.

--- a/crates/zccache-depgraph/src/snapshot/mod.rs
+++ b/crates/zccache-depgraph/src/snapshot/mod.rs
@@ -28,6 +28,7 @@ use super::scanner::{IncludeDirective, IncludeKind};
 use super::search_paths::IncludeSearchPaths;
 
 mod persistence;
+pub mod quarantine;
 #[cfg(test)]
 mod tests;
 

--- a/crates/zccache-depgraph/src/snapshot/quarantine.rs
+++ b/crates/zccache-depgraph/src/snapshot/quarantine.rs
@@ -113,7 +113,7 @@ fn quarantined_version(name: &str) -> Option<u32> {
         .ok()
 }
 
-/// Delete quarantined sidecars beyond [`MAX_QUARANTINED_SNAPSHOTS`], oldest
+/// Delete quarantined sidecars beyond the retention cap, oldest
 /// first. The sidecar matching this build's [`DEPGRAPH_VERSION`] is never a
 /// pruning candidate — it is the one [`recover`] reads.
 ///

--- a/crates/zccache-depgraph/src/snapshot/quarantine.rs
+++ b/crates/zccache-depgraph/src/snapshot/quarantine.rs
@@ -1,0 +1,269 @@
+//! Quarantine and recovery for depgraph snapshots rejected at load (#1157).
+//!
+//! Before this module, a snapshot the running binary could not read — either
+//! because the schema version moved or because the bytes were damaged — was
+//! left in place and then *overwritten* by the next graceful shutdown. Two
+//! things followed from that:
+//!
+//! 1. The rejected bytes were destroyed, so a later migration (or simply
+//!    going back to the binary that wrote them) could never recover them.
+//! 2. A workspace alternating between two binaries with different
+//!    [`DEPGRAPH_VERSION`]s destroyed the other side's graph on every switch,
+//!    so *both* sides cold-recompiled the world forever.
+//!
+//! Quarantine fixes both without any reinterpretation of foreign bytes: a
+//! rejected snapshot is *moved aside* to a version-tagged sidecar, and a
+//! sidecar written by a binary with this build's exact `DEPGRAPH_VERSION` may
+//! be loaded back through the ordinary [`super::load_from_file`] path.
+//!
+//! ## Why this cannot produce a wrong cache hit
+//!
+//! Nothing here decodes, migrates, or partially salvages a snapshot whose
+//! version tag differs from this build's. A recovered sidecar goes through
+//! exactly the same magic + version + rkyv validation as `depgraph.bin`
+//! itself, so the only new claim is "a snapshot written by *this* schema
+//! version against *this* cache root is as trustworthy as the primary
+//! snapshot" — which is true by construction, and is anyway re-verified
+//! per-context against live file hashes by `DepGraph::check`.
+
+use std::path::Path;
+
+use zccache_core::NormalizedPath;
+
+use super::DEPGRAPH_VERSION;
+
+/// Most version-tagged sidecars kept in the depgraph directory. Steady state
+/// for a workspace oscillating between two binaries is exactly two (each
+/// version's own snapshot); anything beyond that is a version this machine
+/// has stopped running, and its snapshot is dead weight.
+const MAX_QUARANTINED_SNAPSHOTS: usize = 2;
+
+/// Sidecar filename prefix shared by every version-tagged quarantine file.
+const QUARANTINE_PREFIX: &str = "depgraph.v";
+
+/// Sidecar filename suffix shared by every version-tagged quarantine file.
+const QUARANTINE_SUFFIX: &str = ".bin";
+
+/// Single-slot sidecar for snapshots that failed *validation* rather than the
+/// version check. Kept for forensics only — never loaded back.
+const CORRUPT_SIDECAR_NAME: &str = "depgraph.corrupt.bin";
+
+/// Sidecar path holding the snapshot written by schema `version`.
+#[must_use]
+pub fn quarantine_path(primary: &Path, version: u32) -> NormalizedPath {
+    sidecar(
+        primary,
+        &format!("{QUARANTINE_PREFIX}{version}{QUARANTINE_SUFFIX}"),
+    )
+}
+
+/// Sidecar path for a snapshot that failed payload validation.
+#[must_use]
+pub fn corrupt_sidecar_path(primary: &Path) -> NormalizedPath {
+    sidecar(primary, CORRUPT_SIDECAR_NAME)
+}
+
+fn sidecar(primary: &Path, name: &str) -> NormalizedPath {
+    match primary.parent() {
+        Some(dir) => NormalizedPath::new(dir).join(name),
+        None => NormalizedPath::new(name),
+    }
+}
+
+/// Move `primary` aside to `dest`, replacing whatever was there.
+///
+/// Returns the destination on success and `None` if the move failed (the
+/// snapshot then stays where it is; the caller still starts cold, which is
+/// the pre-existing behaviour). A failure here must never be fatal: this is
+/// best-effort preservation, not a correctness dependency.
+#[must_use]
+pub fn quarantine(primary: &Path, dest: &NormalizedPath) -> Option<NormalizedPath> {
+    // Windows `rename` does not overwrite an existing destination.
+    let _ = std::fs::remove_file(dest.as_path());
+    match std::fs::rename(primary, dest.as_path()) {
+        Ok(()) => Some(dest.clone()),
+        Err(_) => None,
+    }
+}
+
+/// Load the sidecar written by this build's schema version, if one exists.
+///
+/// Deliberately routed through [`super::classify_load`] so a sidecar gets the
+/// identical magic/version/rkyv validation the primary snapshot gets. Any
+/// outcome other than `Loaded` yields `None` — a damaged sidecar is dropped
+/// silently rather than escalated, because the caller is *already* in the
+/// degraded path and a second warning about a backup file would not change
+/// what an operator does.
+#[must_use]
+pub fn recover(primary: &Path) -> Option<(super::super::graph::DepGraph, NormalizedPath)> {
+    let path = quarantine_path(primary, DEPGRAPH_VERSION);
+    if !path.as_path().exists() {
+        return None;
+    }
+    super::classify_load(path.as_path())
+        .into_graph()
+        .map(|graph| (graph, path))
+}
+
+/// Parse the schema version out of a quarantine sidecar's file name.
+fn quarantined_version(name: &str) -> Option<u32> {
+    name.strip_prefix(QUARANTINE_PREFIX)?
+        .strip_suffix(QUARANTINE_SUFFIX)?
+        .parse()
+        .ok()
+}
+
+/// Delete quarantined sidecars beyond [`MAX_QUARANTINED_SNAPSHOTS`], oldest
+/// first. The sidecar matching this build's [`DEPGRAPH_VERSION`] is never a
+/// pruning candidate — it is the one [`recover`] reads.
+///
+/// Returns the number of files removed.
+pub fn prune(primary: &Path) -> usize {
+    let Some(dir) = primary.parent() else {
+        return 0;
+    };
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut candidates: Vec<(std::time::SystemTime, NormalizedPath)> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name();
+            let version = quarantined_version(name.to_str()?)?;
+            if version == DEPGRAPH_VERSION {
+                return None;
+            }
+            let modified = entry.metadata().ok()?.modified().ok()?;
+            Some((modified, NormalizedPath::new(entry.path())))
+        })
+        .collect();
+    if candidates.len() <= MAX_QUARANTINED_SNAPSHOTS {
+        return 0;
+    }
+    // Newest first, so the tail past the cap is the oldest.
+    candidates.sort_by(|a, b| b.0.cmp(&a.0));
+    let mut removed = 0;
+    for (_, path) in candidates.drain(MAX_QUARANTINED_SNAPSHOTS..) {
+        if std::fs::remove_file(path.as_path()).is_ok() {
+            removed += 1;
+        }
+    }
+    removed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_snapshot_with_version(path: &Path, version: u32) {
+        let graph = crate::graph::DepGraph::new();
+        super::super::save_to_file(&graph, path).unwrap();
+        if version != DEPGRAPH_VERSION {
+            let mut bytes = std::fs::read(path).unwrap();
+            bytes[4..8].copy_from_slice(&version.to_le_bytes());
+            std::fs::write(path, &bytes).unwrap();
+        }
+    }
+
+    #[test]
+    fn quarantine_moves_the_rejected_snapshot_aside_instead_of_leaving_it_to_be_clobbered() {
+        let tmp = tempfile::tempdir().unwrap();
+        let primary = tmp.path().join("depgraph.bin");
+        write_snapshot_with_version(&primary, DEPGRAPH_VERSION + 1);
+        let original = std::fs::read(&primary).unwrap();
+
+        let dest = quarantine_path(&primary, DEPGRAPH_VERSION + 1);
+        let moved = quarantine(&primary, &dest).expect("quarantine must succeed");
+
+        assert!(
+            !primary.exists(),
+            "the rejected snapshot must be moved, not copied — leaving it in \
+             place is what let the next graceful shutdown destroy it"
+        );
+        assert_eq!(
+            std::fs::read(moved.as_path()).unwrap(),
+            original,
+            "the quarantined bytes must be preserved verbatim so a future \
+             migration has something to migrate"
+        );
+    }
+
+    #[test]
+    fn quarantine_overwrites_a_stale_sidecar_for_the_same_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        let primary = tmp.path().join("depgraph.bin");
+        let dest = quarantine_path(&primary, DEPGRAPH_VERSION + 1);
+        std::fs::write(dest.as_path(), b"stale").unwrap();
+
+        write_snapshot_with_version(&primary, DEPGRAPH_VERSION + 1);
+        let fresh = std::fs::read(&primary).unwrap();
+        quarantine(&primary, &dest).expect("quarantine must replace the stale sidecar");
+
+        assert_eq!(std::fs::read(dest.as_path()).unwrap(), fresh);
+    }
+
+    #[test]
+    fn recover_returns_only_a_sidecar_this_build_can_validate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let primary = tmp.path().join("depgraph.bin");
+
+        assert!(
+            recover(&primary).is_none(),
+            "no sidecar means no recovery, not a panic"
+        );
+
+        // A sidecar tagged with a foreign version must never be adopted: this
+        // is the exact byte-reinterpretation that would risk a wrong hit.
+        let foreign = quarantine_path(&primary, DEPGRAPH_VERSION);
+        write_snapshot_with_version(&primary, DEPGRAPH_VERSION + 1);
+        std::fs::rename(&primary, foreign.as_path()).unwrap();
+        assert!(
+            recover(&primary).is_none(),
+            "a sidecar whose embedded version tag is foreign must be rejected \
+             even though its file name claims the current version"
+        );
+
+        // A truncated sidecar fails payload validation and is dropped.
+        std::fs::write(foreign.as_path(), b"ZCDG").unwrap();
+        assert!(recover(&primary).is_none());
+
+        // The real thing round-trips.
+        write_snapshot_with_version(&primary, DEPGRAPH_VERSION);
+        std::fs::rename(&primary, foreign.as_path()).unwrap();
+        let (_graph, from) = recover(&primary).expect("a valid same-version sidecar must load");
+        assert_eq!(from.as_path(), foreign.as_path());
+    }
+
+    #[test]
+    fn prune_keeps_the_cap_and_never_touches_this_builds_sidecar() {
+        let tmp = tempfile::tempdir().unwrap();
+        let primary = tmp.path().join("depgraph.bin");
+
+        let mine = quarantine_path(&primary, DEPGRAPH_VERSION);
+        std::fs::write(mine.as_path(), b"mine").unwrap();
+        let mut foreign = Vec::new();
+        for offset in 1..=4u32 {
+            let path = quarantine_path(&primary, DEPGRAPH_VERSION + offset);
+            std::fs::write(path.as_path(), b"foreign").unwrap();
+            // Distinct mtimes so "oldest first" is well-defined on filesystems
+            // with coarse timestamps.
+            filetime::set_file_mtime(
+                path.as_path(),
+                filetime::FileTime::from_unix_time(1_700_000_000 + i64::from(offset), 0),
+            )
+            .unwrap();
+            foreign.push(path);
+        }
+
+        assert_eq!(prune(&primary), 4 - MAX_QUARANTINED_SNAPSHOTS);
+        assert!(
+            mine.as_path().exists(),
+            "pruning must never delete the sidecar recover() reads"
+        );
+        assert!(!foreign[0].as_path().exists(), "oldest goes first");
+        assert!(!foreign[1].as_path().exists());
+        assert!(foreign[2].as_path().exists());
+        assert!(foreign[3].as_path().exists());
+        assert_eq!(prune(&primary), 0, "pruning is idempotent");
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,6 +44,7 @@ failed cache-root audit retain its diagnostic JSONL evidence.
 - **Host no-spawn guard (`ZCCACHE_NO_SPAWN`, embedding hosts)** → [runtime.md § Host no-spawn guard](architecture/runtime.md#host-no-spawn-guard-zccache_no_spawn)
 - **Uncached-fallback policy (`ZCCACHE_FALLBACK`, CI hard-error)** → [runtime.md § Wrapper fallback policy](architecture/runtime.md#wrapper-fallback-policy-zccache_fallback-issue-1211)
 - **Standalone daemon identity, deployment & lifecycle (argv[0] single binary, version-rooted deploy, versioned endpoints)** → [runtime.md § Standalone daemon identity, deployment & lifecycle](architecture/runtime.md#standalone-daemon-identity-deployment--lifecycle)
+- **Rejected depgraph snapshots — quarantine, recovery, why no migration** → [runtime.md § Depgraph snapshot quarantine](architecture/runtime.md#depgraph-snapshot-quarantine)
 - **Windows/macOS/Linux differences** → [portability.md](architecture/portability.md)
 - **Compile journal fields & `miss_reason` enum** → [journal-schema.md](journal-schema.md)
 

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -386,7 +386,20 @@ The dep graph **is** persisted across daemon restarts (issue #262). At graceful 
 On startup, the daemon attempts to load the snapshot:
 
 - **Success:** the in-memory graph is populated from the file and `DaemonStatus.dep_graph_persisted` reports `true`. CI runs that restore `<cache_dir>` from a cache store skip the cold-seed compile entirely.
-- **Missing file / `VersionMismatch` / corrupt bytes:** a warning is logged and the daemon starts with an empty graph (the pre-fix behavior).
+- **Missing file:** a plain cold start, no warning and no event.
+- **`VersionMismatch` / corrupt bytes:** a warning is logged, a durable lifecycle event is written (`version_mismatch` or `state_corrupt`, with `subsystem=depgraph`, `path`, `bytes`, `quarantined_to`, `recovered_from`, `consequence`), and the rejected snapshot is **quarantined** rather than left for the next graceful shutdown to overwrite. See [Depgraph snapshot quarantine](#depgraph-snapshot-quarantine) below.
+
+#### Depgraph snapshot quarantine
+
+Issue #1157 finding 2. An artifact key is `H(logical_context_key, sorted(path → content_hash))` over the source *plus every resolved include*, and that include set exists **only** in the depgraph — `zccache_artifact::ArtifactIndex` records outputs/stdout/stderr/exit-code and nothing about inputs. So an empty graph really does force one recompile per translation unit. What survives is the artifact *store*: the recompile recomputes the identical key and re-adopts the artifact on disk, so a reset costs one recompile, not a cache wipe.
+
+Reinterpreting a foreign-schema snapshot to "keep artifact-key resolution usable" is deliberately **not** done: reading it needs the old type definitions (a versioned migration), and doing it without one is unsafe — a schema bump can be precisely because a new input class started feeding the key (`rustc_env_deps`, #1021), and a resurrected context missing that field could satisfy `check()` and serve an artifact built under different inputs.
+
+What the daemon does instead (`zccache_depgraph::quarantine`, driven by `daemon::depgraph_load::load_for_startup`):
+
+- A version-skewed `depgraph.bin` is **moved** to `depgraph.v<file_version>.bin`; bytes that failed validation go to the single-slot `depgraph.corrupt.bin` (forensics only, never read back).
+- A sidecar named for **this build's own** `DEPGRAPH_VERSION` is loaded back through the ordinary `classify_load` path — same magic/version/rkyv validation as the primary — so a cache root shared by two binaries with different schema versions keeps each side warm instead of destroying the other's snapshot on every switch.
+- Sidecars are capped (`MAX_QUARANTINED_SNAPSHOTS`, oldest pruned first); the current build's sidecar is never a pruning candidate.
 
 The snapshot load runs in a background blocking task after the IPC endpoint and readiness lockfile are available, so daemon startup stays fast. Compile handlers gate their first depgraph registration/check on that background task completing; otherwise a warm daemon can race the empty default graph and classify the first lookup as `cold_skip` before the persisted graph is installed.
 


### PR DESCRIPTION
Finding 2 of #1157. Investigating it changed what the fix should be, so the reasoning comes first.

## The issue's premise is right about the cost and wrong about the remedy

**Are cached artifacts still reachable after a graph reset? No — not without one recompile per TU.**

The artifact key is a hash over the source *plus every resolved include* (`depgraph/src/context/mod.rs:451`), and that input set is assembled from the depgraph context (`server/keys.rs:593`). With an empty graph `check()` returns `Cold` and the pipeline goes straight to `run_compile_exec` — there is **no pre-compile include scan** that could derive a key speculatively, so `lookup_artifact_with_disk_fallback` is never reached, because no key exists to reach it with.

I ran a probe before writing anything rather than concluding from reading: cold compile → persist → skew the version tag → restart → **not cached**.

**#1301 does not change this.** `ArtifactIndex` carries names, sizes, stdio, exit code — *zero input identity*. A reconciled index makes artifacts retrievable **by** key; it cannot produce the key.

**And option (b) as literally worded is what the wrong-hit rule forbids.** `ContextEntrySnapshot` holds `artifact_key` *inside* the context table — "preserve the mapping independently of the graph" and "preserve the graph" are the same statement. Worse, a schema bump can happen *precisely because* a new input class started feeding the key: `rustc_env_deps` was added to that struct in #1021. Resurrecting contexts predating that field would let a stale context satisfy `check()` and serve an artifact built under different inputs. **Zero foreign-schema entries are carried over**, and that is the reason.

The snapshot is also a single rkyv zero-copy archive behind one header, so field offsets move on any layout change — partial decode of a foreign-version blob is not available without the old type definitions, i.e. without the versioned migration that was explicitly out of scope.

## What is actually fixable: the drop was destructive

A rejected snapshot was left in place for the next graceful shutdown's `save_to_file` to **overwrite**. So the old graph was not merely unused — it was destroyed, and no future migration or binary downgrade could ever recover it.

Now it is moved aside as `depgraph.v<file_version>.bin`, and a sidecar tagged with *this build's own* version is loaded back **through the ordinary `classify_load`** — same magic, version and rkyv validation as the primary, so nothing is reinterpreted. Bytes that failed validation go to a single forensics-only slot that is never read back. Sidecars are capped and pruned oldest-first.

That turns the real-world reset — one cache root, two binaries with different `DEPGRAPH_VERSION`s, i.e. anyone bisecting or switching branches — from *"each side destroys the other's graph on every switch and both cold-recompile forever"* into *"each side keeps its own and stays warm"*. It is as close to option (b) as is reachable without migration, and it is provably hit-safe because recovery goes through the same validation as a normal load.

A genuine first-time schema bump still costs one recompile per TU. The module docs and `runtime.md § Depgraph snapshot quarantine` now **say so**, rather than leaving it as a surprise.

## The self-admitting tests are fixed

`depgraph_state_corrupt_event_carries_the_path_and_size_of_what_was_dropped` re-emitted its event by hand and admitted in a comment that it did not drive the call site. Both such tests now **drive it** — extracting the policy out of `entry.rs`'s `spawn_blocking` closure into `daemon/depgraph_load.rs` is what made that possible, and `entry.rs` drops 837 → 700 LOC on the way.

Three end-to-end tests drive the real compile pipeline through the existing restart harness: a reset costs **one** recompile and the artifact is re-adopted (with a control assertion proving the intact-snapshot path *hits*, so the miss assertion means something); the oscillation case recovers via sidecar and actually hits; repeated resets are idempotent and leave exactly one sidecar.

## A flake I introduced and fixed

The new event test passed alone and failed in the suite. The lifecycle log resolves from a process-global cache root, so a concurrent test can append between our write and our read — and the fixture was taking *the last line*. It now selects the record naming **its own** tempdir snapshot path, which is an exact selector rather than a positional guess. Same class of bug as the one in #1285; worth noting it recurs whenever a test reads that log.

## Evidence

- `soldr cargo test -p zccache-daemon-core --features "test-support,daemon-entry" --lib` — **722 passed, 0 failed**, 25 ignored (full suite, post-fix).
- `soldr cargo test -p zccache-depgraph --lib` — **421 passed, 0 failed**.
- clippy `-D warnings` on both crates, all targets — clean.
- `ci/check_dylint_wiring.py` — exit 0.

## Gaps

- **Windows-only validation.** The new code is platform-neutral filesystem work, but per the repo's Docker-Linux convention this wants a Linux run; CI's Integration leg is the authority.
- **Sidecar disk cost** — up to `MAX_QUARANTINED_SNAPSHOTS` extra snapshots in the depgraph dir. Bounded and pruned, but it is new disk usage that GC does not know about.
- A first-time schema bump is still a full cold recompile. Inherent without migration, now documented.

With this, #1157's Findings 1, 2 and 3 are all addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
