### PR TITLE
chore(release): bump 1.12.17 -> 1.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -4148,7 +4148,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-audit"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4167,7 +4167,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli-core"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -4222,14 +4222,14 @@ dependencies = [
 
 [[package]]
 name = "zccache-compile-trace"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "zccache-audit",
 ]
 
 [[package]]
 name = "zccache-compiler"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "clang",
  "serde_json",
@@ -4241,7 +4241,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "crash-handler",
  "dashmap",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon-core"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -4330,7 +4330,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "blake3",
  "futures",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "filetime",
  "fs2",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "dashmap",
@@ -4393,7 +4393,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "blake3",
  "memmap2",
@@ -4414,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "bytes",
  "dashmap",
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -4453,7 +4453,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-symbols"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "tempfile",
  "zccache-core",
@@ -4461,7 +4461,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "tempfile",
  "zccache-audit",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.12.17"
+version = "1.13.0"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.12.17"
+version = "1.13.0"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps `[workspace.package].version` so `release-auto.yml`'s `detect-bump` job ships the release on merge — the everyday path from CLAUDE.md. 1.12.17 is already fully published on PyPI and as a GitHub release, so the workflow's preflight would fail fast without this.

## Why minor, not patch

**162 commits** since 1.12.17, and two of them change documented public surface:

- **`zccache cc` / `zccache c++` now exit `125` when the daemon is unavailable** (#1287). CLAUDE.md names the exit-code contract of these subcommands as "part of the contract" — soldr's `CC`/`CXX` injection routes `cc-rs` build-script work through them. The previous behaviour ran the tool uncached and *mirrored its exit code*, so a daemon outage that happened to compile fine exited `0`.
- **`ZCCACHE_FALLBACK` is removed** (#1287). #1211 had already defaulted it to `error`; keeping a `warn` value would have kept the silent-degradation path alive.

Also: `PROTOCOL_VERSION` moved (bincode 21 → 23, prost 22 → 24) across #1294 and the earlier status work. Version skew between CLI and daemon is handled by the existing auto-recovery path, but it is a wire change and a patch number would understate it.

## What ships

**Security**
- Owner-only IPC endpoint: peer-uid verification on every accepted connection, `0700` dirs, `0600` socket, Windows pipe DACL (#1284, #1277–#1279)
- Deploy integrity: the daemon binary is verified by **content** rather than by size before it is executed, and its directory is owner-only on both unix and Windows (#1295, #1300)
- Path-traversal fix in symbol-archive extraction — an unguarded second extractor with no `..`, absolute-path, or symlink checks, fed by an unchecked archive (#1296)
- Downloads are https-only by default, with opt-in mandatory checksums (#1298, #1299)

**Reliability**
- Daemon-unavailable is a hard error behind a bounded recovery ladder with a cross-invocation breaker, so a 1000-TU build fails in seconds instead of paying the ladder 1000 times (#1287, #1288)
- Every daemon kill is bound to the instance that actually failed — the previous fixes were landing on a duplicate code path the wrapper never executed (#1286)
- Background loops are supervised instead of being dropped handles; a panic no longer silently stops eviction or depgraph saves (#1291)
- A corrupt artifact index is reconciled from surviving on-disk generations instead of wiping the cache, and a rejected depgraph snapshot is quarantined instead of destroyed (#1301, #1303)
- Embedded and standalone modes now run the same periodic maintenance, enforced by a parity test (#1297)
- Observability surfaces are bounded: session reaping, `audit.jsonl` rotation, crash-dump cap, opt-in `ZCCACHE_LOG_FILE` (#1285, #1289, and earlier)

**New knobs** (all default-off or default-safe): `ZCCACHE_RECOVERY_BUDGET_MS`, `ZCCACHE_LOG_FILE`, `ZCCACHE_LOG_FILE_MAX_BYTES`, `ZCCACHE_REQUIRE_CHECKSUM`, `ZCCACHE_INDEX_RECONCILE_BUDGET_MS`.

**Tooling**: new `ban_discarded_write_result` dylint, with the three discarded index-writer sends it was blocked on fixed rather than allowlisted (#1292, #1293).

## Verification

- Base commit `54646e4c` is **green on `main` across every workflow** — Linux, macOS, Windows, Integration, Clippy, Wire stability, Filesystem Matrix, Auto-Release.
- `soldr cargo check --workspace --all-targets` clean at 1.13.0.
- `Cargo.lock` regenerated: 21 workspace crates, same shape as the previous bump commit (`fc55e71d`).

Version lives in exactly one place (`[workspace.package]`); there is no `pyproject.toml` version or CHANGELOG to keep in step.

## Known-open, not shipped as fixed

The perf lane (#1025 / #1146) is **not** addressed here. A local sanctioned-matrix run on current `main` fails 7/8 cells; evidence and the split between a hardware artifact and the genuine `sqlite-link` ratio failure are recorded on #1025. This release carries no perf claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
