### PR TITLE
fix(perf-local): let the soldr builder rewrite its Cargo.lock

### DIFF
--- a/ci/perf_local.py
+++ b/ci/perf_local.py
@@ -415,7 +415,17 @@ def run_soldr_builder(layout: dict[str, Path], *, force: bool = False) -> None:
             "run",
             "--rm",
             "-v",
-            host_volume(layout["soldr_src"], "/src", "ro"),
+            # Writable, deliberately. Embedding this checkout's zccache SHA can
+            # change zccache's *version* (any `chore(release)` bump does), and
+            # soldr's `Cargo.lock` pins it — so cargo must rewrite the lock, and
+            # a read-only `/src` fails the build with `failed to write
+            # /src/Cargo.lock`. That made the whole local perf gate unusable
+            # after every release until someone deleted `.perf-local/soldr-src`.
+            #
+            # Safe because `soldr-src` is a harness-managed scratch clone, not a
+            # user checkout: `ensure_soldr_source` hard-resets it whenever the
+            # requested soldr ref moves, so a rewritten lock never accumulates.
+            host_volume(layout["soldr_src"], "/src"),
             "-v",
             f"{VOLUME_TARGET_SOLDR}:/target",
             "-v",


### PR DESCRIPTION
The local Docker perf harness — which PERF.md names as **the** sanctioned gate — has been unusable since the 1.13.0 release. Every invocation died before running anything:

```
error: failed to write /src/Cargo.lock
subprocess.CalledProcessError: Command '['docker', 'run', ... 'zccache-perf-soldr-builder']'
  returned non-zero exit status 101
```

## Cause

`run_soldr_builder` mounts the soldr checkout at `/src` **read-only**. That is fine until the embedded zccache changes *version* — and `pin_soldr_zccache_source` embeds this checkout's SHA into soldr's `_vender/zccache` submodule, so **any `chore(release)` bump does exactly that**.

soldr's `Cargo.lock` pins `zccache` by version:

```
name = "zccache"
version = "1.12.17"     # while the embedded submodule is now 1.13.0
```

so cargo must rewrite the lock — and cannot, because `/src` is read-only.

The failure is not self-describing: the harness surfaces it as a bare `CalledProcessError` on a `docker run`, with the real message on the container's stderr. It also **persists across runs**, because `ensure_soldr_source` only hard-resets `soldr-src` when the requested *soldr ref* moves — the stale lock is not what it is looking at. The only recovery was to know to delete `.perf-local/soldr-src` by hand.

## Fix

Drop the `ro` on that one mount.

Safe because `soldr-src` is a **harness-managed scratch clone**, not a user checkout: `ensure_soldr_source` clones it, fetches it, and hard-resets it whenever the requested ref moves, so a rewritten lock never accumulates. The comment at the call site records both halves — why it must be writable, and why that is not a reproducibility hole.

## Verification

Same cell, same host (Docker Desktop Linux VM, 4 CPU / 8 GiB, harness default `--jobs 2`).

**Before** — dies in the builder, no scenario runs:
```
error: failed to write /src/Cargo.lock
```

**After** — lock rewrites to `version = "1.13.0"`, build proceeds, scenario completes:
```
| Fixture | Scenario            | Verdict | Speedup | Need   | Cold  | Warm   |
| medium  | cold-tar-untar-warm | PASS    | 7.09x   | >=4.50x| 3m40s | 31.08s |
```

Evidence retained under `.perf-local/results/medium/cold-tar-untar-warm/`.

## Why this matters beyond one command

PERF.md forbids substituting ad-hoc timing for this harness, so while it was broken **the entire perf lane was blocked** — #1025, #1036, #1116, #1146, #1158 and #1215 all gate on it. And the trigger is a release bump, which is exactly when someone is most likely to want a perf check and least likely to suspect the harness.

I found it while trying to run the #1158 A/B (the `now()`-seeded batch mtime floor); that investigation resumes now that the gate works.

## Scope note

This is the minimal fix — one mount mode plus a comment. I have deliberately **not** touched `ensure_soldr_source`'s reset condition, even though "only reset when the ref moved" is what let the stale lock survive. Widening that reset would slow every run by re-materializing submodules, and it is not needed once the lock can be written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
