### PR TITLE
fix(exec): read the materialized destination, not the staged cache path (#1215)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
@@ -832,9 +832,37 @@ async fn try_exec_cache_hit(
     for (abs, payload) in targets.iter().zip(payloads_for_write.iter()) {
         let bytes: Arc<Vec<u8>> = match payload {
             CachedPayload::Bytes(b) => Arc::clone(b),
-            CachedPayload::File(p) => match std::fs::read(p.as_path()) {
+            // #1215: read the destination we just materialized, never the
+            // cache path. The staged lease was released above, so a
+            // `CachedPayload::File` pointing into a staged generation could be
+            // evicted by maintenance between that drop and this read — the
+            // exact resolve-to-materialize race the lease exists to close, and
+            // the one path that still had it. `abs` is this build's own output
+            // and needs no lease.
+            //
+            // A failure here is also no longer survivable-by-omission: the old
+            // code substituted an empty payload, so a client asking for a
+            // cached artifact got zero bytes reported as a hit. A wrong answer
+            // is worse than a miss.
+            CachedPayload::File(_) => match std::fs::read(abs.as_path()) {
                 Ok(b) => Arc::new(b),
-                Err(_) => Arc::new(Vec::new()),
+                Err(error) => {
+                    tracing::warn!(
+                        key = %key_hex,
+                        path = %abs.display(),
+                        "exec hit materialized an output that could not be read back: {error}"
+                    );
+                    report_materialization_failure(
+                        &state.cache_dir,
+                        key_hex,
+                        "exec-hit-readback",
+                        &MaterializationFailure::DestinationWrite(DestinationWriteFailure {
+                            path: abs.clone(),
+                            error,
+                        }),
+                    );
+                    return None;
+                }
             },
         };
         response_outputs.push(ArtifactOutput {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec_tests.rs
@@ -277,6 +277,79 @@ async fn staged_exec_disk_hit_reports_physical_materialization_tier() {
     assert!(staged.timings_ns.contains_key("hit_materialization"));
 }
 
+/// #1215: the exec hit's response bytes must come from the destination we just
+/// materialized, not from the cache path.
+///
+/// The old code read `CachedPayload::File(p)` — a staged generation path —
+/// *after* dropping the staged materialization lease. That is the exact
+/// resolve-to-materialize race the lease exists to close, and exec was the one
+/// delivery path that still had it. Worse, a failed read substituted an empty
+/// payload, so a client asking for a cached artifact received **zero bytes
+/// reported as a hit**.
+///
+/// This pins the response against the destination: the bytes the client is
+/// handed must equal what actually landed on disk.
+#[tokio::test]
+async fn exec_hit_response_bytes_come_from_the_materialized_destination() {
+    let temp = tempdir().unwrap();
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let cache_dir: NormalizedPath = temp.path().join("cache").into();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+    let source: NormalizedPath = temp.path().join("private-result.bin").into();
+    let expected = b"staged exec payload bytes";
+    std::fs::write(&source, expected).unwrap();
+    let artifact = ArtifactData {
+        outputs: vec![ArtifactOutput {
+            name: "result.bin".to_string(),
+            payload: ArtifactPayload::Bytes(Arc::new(expected.to_vec())),
+        }],
+        stdout: Arc::new(Vec::new()),
+        stderr: Arc::new(Vec::new()),
+        exit_code: 0,
+    };
+    let metadata = CachedArtifact::from_artifact_data(&artifact).meta.clone();
+    let key = "e".repeat(64);
+    let cached = store_exec_artifact(&server.state, key.clone(), artifact, Some(vec![source]))
+        .await
+        .unwrap()
+        .expect("staged stores defer memory visibility until materialization");
+    server.state.artifacts.insert(key.clone(), cached);
+    server.state.artifacts.remove(&key);
+    server.state.artifact_store.insert(&key, &metadata);
+
+    let response = try_exec_cache_hit(
+        &server.state,
+        &key,
+        temp.path(),
+        &[NormalizedPath::from("result.bin")],
+        ExecOutputStreams::default(),
+    )
+    .await;
+
+    let Some(Response::GenericToolExecResult { output_files, .. }) = response else {
+        panic!("expected a staged exec hit");
+    };
+    assert_eq!(output_files.len(), 1);
+    let ArtifactPayload::Bytes(bytes) = &output_files[0].payload else {
+        panic!("exec replays outputs inline as bytes");
+    };
+    assert!(
+        !bytes.is_empty(),
+        "an empty payload reported as a hit is the failure mode this pins: the \
+         client would silently receive a zero-byte artifact"
+    );
+    assert_eq!(
+        bytes.as_slice(),
+        expected,
+        "response bytes must match what was materialized to the destination"
+    );
+    assert_eq!(
+        std::fs::read(temp.path().join("result.bin")).unwrap(),
+        expected,
+        "and the destination on disk must agree with what the client was told"
+    );
+}
+
 #[test]
 fn primary_key_changes_when_input_hash_changes() {
     let k1 = compose_primary_key(


### PR DESCRIPTION
Closes the one staged delivery path that #1280's materialization lease did not actually cover, found while auditing #1215's acceptance criteria against current `main`.

## The bug

`handle_exec.rs` builds its response by re-reading each payload **after** releasing the staged lease:

```rust
drop(payloads);                                  // lease released here
...
CachedPayload::File(p) => match std::fs::read(p.as_path()) {   // staged generation path
    Ok(b) => Arc::new(b),
    Err(_) => Arc::new(Vec::new()),                            // silently empty
}
```

Two distinct defects in four lines:

1. **The race #1215 exists to close, still open.** `p` is a staged generation path. With the lease dropped, maintenance can evict that generation between the `drop` and this read — exactly the resolve-to-materialize window `#1280` closed everywhere else. I checked all five delivery paths: compile, both multi-output lanes, link, and directory bundle keep every payload read inside the guard. **Exec was the only one that didn't.**

2. **A wrong answer on failure.** `Err(_) => Arc::new(Vec::new())` hands the client a **zero-byte artifact reported as a cache hit**. In a cache whose governing rule is that a wrong hit is catastrophic and a miss is merely slow, silently substituting empty bytes is the worst available outcome — worse than the race that can cause it.

## The fix

Read `abs` — the destination we *just materialized* — instead of the cache path. It needs no lease because it is this build's own output, and it is what the client is actually receiving, so the response can no longer disagree with what landed on disk.

A read failure now reports a materialization failure and returns `None` (a miss) rather than fabricating an empty payload. The other exec failure paths already return `None`; this one was the outlier.

## Test

`exec_hit_response_bytes_come_from_the_materialized_destination` drives a real staged exec hit through `try_exec_cache_hit` and asserts the response bytes are non-empty, equal the expected payload, and agree with the destination on disk. The non-empty assertion is deliberately separate and explains itself — that is the silent-corruption mode, and an equality assertion alone would not say why it matters.

*(Note for reviewers: the test initially reported "0 passed; 747 filtered out" because I spliced it inside the preceding function by line number, where it was a nested item that never ran. Re-anchored properly; it now runs and passes.)*

## Evidence

- `soldr cargo test -p zccache-daemon-core --features "test-support,daemon-entry" --lib` — **723 passed, 0 failed**, 25 ignored (722 before).
- `soldr cargo clippy -p zccache-daemon-core --features "test-support,daemon-entry" --all-targets -- -D warnings` — clean.
- `soldr cargo check -p zccache-daemon-core` (default features) — clean.

## Scope — #1215 stays open

This fixes a correctness hole; it does **not** satisfy #1215's perf acceptance criteria, and I am not claiming it does. From the audit, the remaining work is:

1. **The authoritative `--matrix --repeat 5` campaign**, which is the explicit reason the owner reopened #1215 after #1280 auto-closed it — the merged tree failed `medium/cold-tar-untar-warm` at **2.30x vs a 4.50x floor**, with `lock_hold` at 1477.7 ms. I cannot produce that dossier credibly here: two runs of unmodified code on this 4-CPU VM differ by ~10 s, so single-sample wall-clock cannot attribute a regression of that size. `lock_hold` is a direct profiler measurement and *is* resolvable — which makes item 2 the useful next step.
2. **`read_guard.rs` starts its wait timer after `staged_root()` and `open_store_lock()`**, and the `symlink_metadata` probe is untimed — so acquisition overhead is under-reported and cannot currently attribute the regression. The owner flagged this himself on 2026-07-30 and it is still unfixed.
3. **`cli/commands/cache_ops.rs` (`warm_target`)** resolves staged payloads with no guard at all. Outside this issue's enumerated five hit paths, but a real unguarded resolve→materialize path worth its own issue.

Correctness criteria 1–4 of #1215 are genuinely met on `main` — deterministic hook-based race tests, all five entry points, and non-staged payloads correctly taking no lock. I have posted the full per-criterion audit to the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
