### PR TITLE
perf(staged): count the full guard acquisition in HitStoreLockWait (#1215)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/read_guard.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/read_guard.rs
@@ -97,9 +97,25 @@ impl StagedMaterializationGuard {
 fn acquire_staged_materialization_guard(
     artifact_dir: &Path,
 ) -> io::Result<StagedMaterializationGuard> {
+    acquire_staged_materialization_guard_from(artifact_dir, Instant::now())
+}
+
+/// Acquire the shared read lock, attributing everything since `wait_started`
+/// to the wait.
+///
+/// #1215: the timer used to start *after* `staged_root` and `open_store_lock`,
+/// so `HitStoreLockWait` reported only the `lock_shared` call. Opening the lock
+/// file is a real filesystem operation on every staged hit, and the caller's
+/// pointer probe is another — excluding both meant the telemetry could not
+/// account for guard-acquisition cost, which is exactly what it exists to
+/// attribute. Callers that probe first pass their own start instant so their
+/// probe lands inside the window.
+fn acquire_staged_materialization_guard_from(
+    artifact_dir: &Path,
+    wait_started: Instant,
+) -> io::Result<StagedMaterializationGuard> {
     let root = staged_root(artifact_dir);
     let store_lock = open_store_lock(&root)?;
-    let wait_started = Instant::now();
     fs2::FileExt::lock_shared(&store_lock)?;
     let wait_ns = wait_started.elapsed().as_nanos().min(u64::MAX as u128) as u64;
     Ok(StagedMaterializationGuard {
@@ -117,6 +133,9 @@ pub(in crate::daemon::server) fn acquire_staged_materialization_guard_if_present
     artifact_dir: &Path,
     key_hex: &str,
 ) -> io::Result<Option<StagedMaterializationGuard>> {
+    // Start before the pointer probe (#1215): `symlink_metadata` is a stat on
+    // every staged hit and belongs to acquisition cost, not to free time.
+    let wait_started = Instant::now();
     validate_key(key_hex)?;
     let pointer = pointer_path(artifact_dir, key_hex);
     match fs::symlink_metadata(&pointer) {
@@ -127,7 +146,7 @@ pub(in crate::daemon::server) fn acquire_staged_materialization_guard_if_present
                 pointer.display()
             ),
         )),
-        Ok(_) => acquire_staged_materialization_guard(artifact_dir).map(Some),
+        Ok(_) => acquire_staged_materialization_guard_from(artifact_dir, wait_started).map(Some),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
         Err(error) => Err(error),
     }
@@ -137,4 +156,25 @@ pub(in crate::daemon::server) fn acquire_staged_materialization_guard_for_cached
     artifact_dir: &Path,
 ) -> io::Result<StagedMaterializationGuard> {
     acquire_staged_materialization_guard(artifact_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    /// The `_if_present` path starts its timer before the pointer probe, so a
+    /// key with no staged pointer costs a stat and reports no guard at all.
+    #[test]
+    fn a_key_without_a_staged_pointer_acquires_no_guard() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(staged_root(dir.path())).unwrap();
+
+        let guard =
+            acquire_staged_materialization_guard_if_present(dir.path(), &"a".repeat(64)).unwrap();
+
+        assert!(
+            guard.is_none(),
+            "no staged pointer means no lock is taken; callers resolve with \
+             staged lookup disabled for that attempt"
+        );
+    }
 }


### PR DESCRIPTION
Fixes the telemetry gap the owner flagged on #1215 (2026-07-30), which was still unfixed on `main`.

## The gap

`HitStoreLockWait` started its timer **after** the work it was supposed to measure:

```rust
let root = staged_root(artifact_dir);
let store_lock = open_store_lock(&root)?;   // file open — not counted
let wait_started = Instant::now();          // ← timer starts here
fs2::FileExt::lock_shared(&store_lock)?;
```

and `acquire_staged_materialization_guard_if_present` does an untimed `fs::symlink_metadata` pointer probe before calling it. So the metric reported only the `lock_shared` call, while two real per-hit filesystem operations sat outside the window.

That matters right now: #1215 was reopened because the merged tree regressed `medium/cold-tar-untar-warm` to **2.30x against a 4.50x floor**, with `lock_hold` at **1477.7 ms**. `lock_hold` is a direct profiler measurement rather than wall-clock, which makes it the one number here that is trustworthy on modest hardware — but the companion `lock_wait` was under-reporting, so acquisition cost could not be attributed.

## The change

The timer now spans the whole acquisition. Callers that probe first (`_if_present`) pass their own start instant, so the `symlink_metadata` lands inside the window; the direct-path caller starts its own.

Behaviour is otherwise unchanged — this only moves where a clock is read.

## On tests — I removed the one I first wrote, and why

I wrote a test that held the exclusive lock for 150 ms and asserted the reported wait covered it. **I then verified it against a deliberately reverted timer, and it still passed** — because `lock_shared` blocks for the full interval either way, so it never discriminated this change. It also **failed under full-suite load** while passing in isolation.

A test that is flaky *and* doesn't guard the thing it accompanies is worse than no test: it costs someone a debugging session and buys nothing. Deleted.

Pinning the actual delta would need injectable latency in `open_store_lock` / `symlink_metadata`, which does not exist today and is not worth building for a clock move. The argument for the change stands on its own: those calls are real per-hit work and belong inside the window. I would rather say that plainly than ship a test that implies more verification than happened.

What remains is `a_key_without_a_staged_pointer_acquires_no_guard` — deterministic, and it pins the `_if_present` contract that a missing pointer takes no lock at all.

## Evidence

- `soldr cargo test -p zccache-daemon-core --features "test-support,daemon-entry" --lib` — **724 passed, 0 failed**, 25 ignored. Run **twice** to confirm the flake is gone.
- `soldr cargo clippy -p zccache-daemon-core --features "test-support,daemon-entry" --all-targets -- -D warnings` — clean.
- `soldr cargo check -p zccache-daemon-core` (default features) — clean.

## Scope

#1215 stays open. This unblocks attribution; it does not produce the `--matrix --repeat 5` dossier that issue requires, and I have not claimed a perf change. With acquisition now fully counted, the next run of that campaign can actually say whether the 1477.7 ms sits in the wait or the hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
