### PR TITLE
fix(warm): hold the staged store lock across warm's resolve->materialize (#1310)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4130,6 +4130,7 @@ dependencies = [
  "blake3",
  "dashmap",
  "flate2",
+ "fs2",
  "prost",
  "rayon",
  "redb",

--- a/crates/zccache-artifact/Cargo.toml
+++ b/crates/zccache-artifact/Cargo.toml
@@ -28,6 +28,7 @@ bincode = { workspace = true }
 blake3 = { workspace = true }
 dashmap = { workspace = true }
 flate2 = { workspace = true, optional = true }
+fs2 = { workspace = true }
 prost = { workspace = true }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }

--- a/crates/zccache-artifact/src/layout.rs
+++ b/crates/zccache-artifact/src/layout.rs
@@ -11,7 +11,8 @@ use std::path::Path;
 use std::sync::Arc;
 use zccache_core::NormalizedPath;
 
-const STAGED_ROOT: &str = ".staged-v2";
+use crate::staged_lock::STAGED_ROOT;
+
 const STAGED_MANIFEST_VERSION: u32 = 1;
 const PACK_MAGIC: &[u8; 4] = b"ZCPK";
 pub const LEGACY_PATH_VALIDATE_ENV: &str = "ZCCACHE_LEGACY_PATH_VALIDATE";

--- a/crates/zccache-artifact/src/lib.rs
+++ b/crates/zccache-artifact/src/lib.rs
@@ -10,6 +10,7 @@ pub mod kv;
 mod layout;
 mod reconcile;
 mod rust_plan;
+pub mod staged_lock;
 mod store;
 
 pub use kv::{
@@ -21,6 +22,8 @@ pub use layout::{
     record_legacy_artifact_access, resolve_artifact_payloads, resolve_staged_artifact_files,
     LegacyArtifactAccessPurpose, ResolvedArtifactPayload, LEGACY_PATH_VALIDATE_ENV,
 };
+pub use staged_lock::StagedReadGuard;
+
 pub use reconcile::{
     reconcile_index_from_disk, IndexReconciliation, DEFAULT_RECONCILE_BUDGET,
     RECONCILED_OUTPUT_NAME,

--- a/crates/zccache-artifact/src/staged_lock.rs
+++ b/crates/zccache-artifact/src/staged_lock.rs
@@ -1,0 +1,216 @@
+//! The staged-v2 store lock, shared by every process that touches a generation.
+//!
+//! # Why this lives here and not in the daemon
+//!
+//! A staged generation can be deleted by daemon maintenance at any moment.
+//! Anything that *resolves* a generation path and then *materializes* it
+//! (hardlink/reflink/copy into a caller-owned destination) must hold the
+//! shared read lock across the whole window, or the tree can vanish between
+//! the two — yielding a failed restore at best and a truncated artifact that
+//! cargo accepts as a valid rlib at worst.
+//!
+//! The lock is an `fs2` advisory lock on a real file, so it is **cross-process
+//! by construction**. That matters because the readers are not all in the
+//! daemon: `zccache warm` runs entirely in the CLI process (it opens the redb
+//! index directly and never sends an IPC request) while a daemon may be
+//! concurrently running GC.
+//!
+//! Both sides therefore have to agree on *which* file to lock. Keeping one
+//! copy of that decision in `zccache-artifact` — the crate both the daemon and
+//! `warm` already consume for layout resolution — is what makes the exclusion
+//! real. Two independent definitions of `.staged-v2/.store.lock` would keep
+//! compiling, keep passing their own tests, and silently stop excluding each
+//! other the moment either side changed a name.
+
+use std::fs::{self, File, Metadata, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// The staged-v2 store directory name, relative to the artifact dir.
+pub const STAGED_ROOT: &str = ".staged-v2";
+/// The lock file inside [`STAGED_ROOT`]. Exposed because callers that enumerate
+/// the staged root must exclude it from "is this tree empty" checks.
+pub const STORE_LOCK: &str = ".store.lock";
+
+/// `<artifact_dir>/.staged-v2`.
+pub fn staged_root(artifact_dir: &Path) -> PathBuf {
+    artifact_dir.join(STAGED_ROOT)
+}
+
+/// Whether `metadata` describes a symlink (unix) or any reparse point
+/// (Windows). Staged access refuses to traverse either.
+pub fn is_staged_link_or_reparse(metadata: &Metadata) -> bool {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    }
+    #[cfg(not(windows))]
+    {
+        metadata.file_type().is_symlink()
+    }
+}
+
+/// `Ok(false)` when the root is simply absent; `Err` when it exists but is
+/// something we refuse to treat as the staged root (a link/reparse point, or
+/// not a directory).
+pub fn validate_staged_root_path(root: &Path) -> io::Result<bool> {
+    let metadata = match fs::symlink_metadata(root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    if is_staged_link_or_reparse(&metadata) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing staged artifact access through linked/reparse root: {}",
+                root.display()
+            ),
+        ));
+    }
+    if !metadata.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "staged artifact root is not a directory: {}",
+                root.display()
+            ),
+        ));
+    }
+    Ok(true)
+}
+
+/// Open (creating if needed) the store lock file for an already-validated root.
+pub fn open_store_lock(root: &Path) -> io::Result<File> {
+    if !validate_staged_root_path(root)? {
+        fs::create_dir_all(root)?;
+        if !validate_staged_root_path(root)? {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("staged artifact root disappeared: {}", root.display()),
+            ));
+        }
+    }
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(root.join(STORE_LOCK))
+}
+
+/// Shared (reader) ownership of the staged store.
+///
+/// Maintenance and eviction take the same lock exclusively, so holding this
+/// keeps every published generation alive for the guard's lifetime. Drop
+/// releases it — including on unwind, which is why this is an RAII type rather
+/// than a lock/unlock pair.
+#[derive(Debug)]
+pub struct StagedReadGuard {
+    _store_lock: File,
+}
+
+impl StagedReadGuard {
+    /// Take the shared lock, creating the staged root if it does not exist.
+    ///
+    /// Prefer [`StagedReadGuard::acquire_if_present`] for read-only callers:
+    /// this variant will materialize an empty `.staged-v2` directory in a cache
+    /// that has never staged anything.
+    pub fn acquire(artifact_dir: &Path) -> io::Result<Self> {
+        let store_lock = open_store_lock(&staged_root(artifact_dir))?;
+        fs2::FileExt::lock_shared(&store_lock)?;
+        Ok(Self {
+            _store_lock: store_lock,
+        })
+    }
+
+    /// Take the shared lock only if a staged root already exists.
+    ///
+    /// `Ok(None)` means there is no staged store, so no generation can be
+    /// resolved and there is nothing for maintenance to delete out from under
+    /// the caller — the unlocked path is safe rather than merely tolerated.
+    pub fn acquire_if_present(artifact_dir: &Path) -> io::Result<Option<Self>> {
+        let root = staged_root(artifact_dir);
+        if !validate_staged_root_path(&root)? {
+            return Ok(None);
+        }
+        Self::acquire(artifact_dir).map(Some)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_staged_root_means_no_guard_and_no_directory_is_created() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let guard = StagedReadGuard::acquire_if_present(dir.path()).unwrap();
+
+        assert!(guard.is_none(), "absent staged root must not take a lock");
+        assert!(
+            !staged_root(dir.path()).exists(),
+            "a read-only probe must not create the staged root"
+        );
+    }
+
+    #[test]
+    fn an_existing_staged_root_yields_a_guard() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(staged_root(dir.path())).unwrap();
+
+        let guard = StagedReadGuard::acquire_if_present(dir.path()).unwrap();
+
+        assert!(guard.is_some(), "present staged root must be locked");
+    }
+
+    /// The whole point of the type: readers share, so a batch restore never
+    /// serializes against another reader.
+    #[test]
+    fn two_readers_hold_the_lock_at_once() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(staged_root(dir.path())).unwrap();
+
+        let first = StagedReadGuard::acquire(dir.path()).unwrap();
+        let second = StagedReadGuard::acquire(dir.path()).unwrap();
+
+        drop((first, second));
+    }
+
+    /// Pins the exclusion this module exists to provide, across the same
+    /// lock file the daemon's maintenance uses.
+    #[test]
+    fn an_exclusive_holder_blocks_a_reader_until_it_releases() {
+        use std::sync::mpsc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = staged_root(dir.path());
+        fs::create_dir_all(&root).unwrap();
+
+        let exclusive = open_store_lock(&root).unwrap();
+        fs2::FileExt::lock_exclusive(&exclusive).unwrap();
+
+        let (tx, rx) = mpsc::channel();
+        let path = dir.path().to_path_buf();
+        let reader = std::thread::spawn(move || {
+            let guard = StagedReadGuard::acquire(&path).unwrap();
+            tx.send(()).unwrap();
+            drop(guard);
+        });
+
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_millis(250))
+                .is_err(),
+            "reader must not acquire while an exclusive lock is held"
+        );
+
+        drop(exclusive);
+
+        rx.recv_timeout(std::time::Duration::from_secs(10))
+            .expect("reader must acquire once the exclusive lock is released");
+        reader.join().unwrap();
+    }
+}

--- a/crates/zccache-artifact/src/staged_lock.rs
+++ b/crates/zccache-artifact/src/staged_lock.rs
@@ -24,7 +24,8 @@
 
 use std::fs::{self, File, Metadata, OpenOptions};
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use zccache_core::NormalizedPath;
 
 /// The staged-v2 store directory name, relative to the artifact dir.
 pub const STAGED_ROOT: &str = ".staged-v2";
@@ -33,8 +34,8 @@ pub const STAGED_ROOT: &str = ".staged-v2";
 pub const STORE_LOCK: &str = ".store.lock";
 
 /// `<artifact_dir>/.staged-v2`.
-pub fn staged_root(artifact_dir: &Path) -> PathBuf {
-    artifact_dir.join(STAGED_ROOT)
+pub fn staged_root(artifact_dir: &Path) -> NormalizedPath {
+    artifact_dir.join(STAGED_ROOT).into()
 }
 
 /// Whether `metadata` describes a symlink (unix) or any reparse point
@@ -119,7 +120,7 @@ impl StagedReadGuard {
     /// this variant will materialize an empty `.staged-v2` directory in a cache
     /// that has never staged anything.
     pub fn acquire(artifact_dir: &Path) -> io::Result<Self> {
-        let store_lock = open_store_lock(&staged_root(artifact_dir))?;
+        let store_lock = open_store_lock(staged_root(artifact_dir).as_path())?;
         fs2::FileExt::lock_shared(&store_lock)?;
         Ok(Self {
             _store_lock: store_lock,
@@ -133,7 +134,7 @@ impl StagedReadGuard {
     /// the caller — the unlocked path is safe rather than merely tolerated.
     pub fn acquire_if_present(artifact_dir: &Path) -> io::Result<Option<Self>> {
         let root = staged_root(artifact_dir);
-        if !validate_staged_root_path(&root)? {
+        if !validate_staged_root_path(root.as_path())? {
             return Ok(None);
         }
         Self::acquire(artifact_dir).map(Some)
@@ -152,7 +153,7 @@ mod tests {
 
         assert!(guard.is_none(), "absent staged root must not take a lock");
         assert!(
-            !staged_root(dir.path()).exists(),
+            !staged_root(dir.path()).as_path().exists(),
             "a read-only probe must not create the staged root"
         );
     }
@@ -160,7 +161,7 @@ mod tests {
     #[test]
     fn an_existing_staged_root_yields_a_guard() {
         let dir = tempfile::tempdir().unwrap();
-        fs::create_dir_all(staged_root(dir.path())).unwrap();
+        fs::create_dir_all(staged_root(dir.path()).as_path()).unwrap();
 
         let guard = StagedReadGuard::acquire_if_present(dir.path()).unwrap();
 
@@ -172,7 +173,7 @@ mod tests {
     #[test]
     fn two_readers_hold_the_lock_at_once() {
         let dir = tempfile::tempdir().unwrap();
-        fs::create_dir_all(staged_root(dir.path())).unwrap();
+        fs::create_dir_all(staged_root(dir.path()).as_path()).unwrap();
 
         let first = StagedReadGuard::acquire(dir.path()).unwrap();
         let second = StagedReadGuard::acquire(dir.path()).unwrap();
@@ -188,9 +189,9 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let root = staged_root(dir.path());
-        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(root.as_path()).unwrap();
 
-        let exclusive = open_store_lock(&root).unwrap();
+        let exclusive = open_store_lock(root.as_path()).unwrap();
         fs2::FileExt::lock_exclusive(&exclusive).unwrap();
 
         let (tx, rx) = mpsc::channel();

--- a/crates/zccache-cli-core/src/cli/commands/cache_ops.rs
+++ b/crates/zccache-cli-core/src/cli/commands/cache_ops.rs
@@ -380,6 +380,17 @@ pub(crate) fn warm_target(
         .set_accessed(now)
         .set_modified(now);
 
+    // Hold shared staged-store ownership across BOTH the resolve loop and the
+    // materialization below. `warm` runs in the CLI process, not the daemon,
+    // so a daemon GC can be evicting generations concurrently; without this
+    // lock a generation resolved below can be deleted before it is linked.
+    // Resolution here is fully batched before any materialization, so the
+    // exposed window is the entire index scan (1k-5k entries), not a few
+    // syscalls. `_if_present` keeps a cache that never staged anything on the
+    // unlocked path instead of creating an empty `.staged-v2` as a side effect.
+    let _staged_guard = crate::artifact::StagedReadGuard::acquire_if_present(artifact_dir)
+        .map_err(|error| format!("failed to lock staged artifact store: {error}"))?;
+
     // Resolve the layout once, then flatten artifact/output nesting so
     // workers receive payload capabilities rather than inferred cache paths.
     // CI cache restores can be 1k–5k entries, and per-file syscalls dominate,

--- a/crates/zccache-cli-core/src/cli/commands/tests/cache_ops.rs
+++ b/crates/zccache-cli-core/src/cli/commands/tests/cache_ops.rs
@@ -336,9 +336,12 @@ fn warm_waits_for_the_staged_store_lock_before_materializing() {
 
     drop(gc_lock);
 
-    rx.recv_timeout(std::time::Duration::from_secs(30))
+    let outcome = rx
+        .recv_timeout(std::time::Duration::from_secs(30))
         .expect("warm must proceed once the exclusive lock is released");
-    let (restored, _skipped, errors) = warm.join().unwrap().unwrap();
+    warm.join().unwrap().ok();
+    let (restored, _skipped, errors) =
+        outcome.expect("warm should succeed once it can take the lock");
     assert_eq!(errors, 0, "warm should succeed after acquiring the lock");
     assert_eq!(restored, 1, "the staged payload should be restored");
 }

--- a/crates/zccache-cli-core/src/cli/commands/tests/cache_ops.rs
+++ b/crates/zccache-cli-core/src/cli/commands/tests/cache_ops.rs
@@ -279,3 +279,66 @@ fn warm_returns_error_on_missing_index() {
     );
     assert!(result.is_err());
 }
+
+/// `warm` runs in the CLI process while a daemon may be running GC, so it must
+/// take the staged store's shared lock across resolve->materialize. Pinning it
+/// via the exclusive side is what makes this test discriminate: without the
+/// guard, `warm_target` completes immediately even while GC holds the store.
+#[test]
+fn warm_waits_for_the_staged_store_lock_before_materializing() {
+    use std::sync::mpsc;
+
+    let dir = tempfile::tempdir().unwrap();
+    let artifact_dir = dir.path().join("artifacts");
+    let target_dir = dir.path().join("target");
+    let index_path = dir.path().join("index.redb");
+    std::fs::create_dir_all(&artifact_dir).unwrap();
+
+    let key = "aaaaaaaabbbbbbbb";
+    let store = crate::artifact::ArtifactStore::open(&index_path).unwrap();
+    store.insert(
+        key,
+        &crate::artifact::ArtifactIndex::new(
+            vec!["libstaged-abc123.rlib".to_string()],
+            vec![b"staged-rlib".len() as u64],
+            vec![],
+            vec![],
+            0,
+        ),
+    );
+    store.flush().unwrap();
+    drop(store);
+    seed_staged_fixture(&artifact_dir, key, b"staged-rlib");
+
+    // Stand in for daemon maintenance holding the store exclusively.
+    let staged = zccache_artifact::staged_lock::staged_root(&artifact_dir);
+    let gc_lock = zccache_artifact::staged_lock::open_store_lock(&staged).unwrap();
+    fs2::FileExt::lock_exclusive(&gc_lock).unwrap();
+
+    // The outcome travels through the channel, not just a unit tick, so that an
+    // early `Err` return (which would also unblock the recv and look exactly
+    // like "warm ignored the lock") names itself instead of failing as a
+    // mystery.
+    let (tx, rx) = mpsc::channel();
+    let warm = std::thread::spawn(move || {
+        let outcome = warm_target(&index_path, &artifact_dir, &target_dir, "debug", None);
+        tx.send(outcome.clone()).unwrap();
+        outcome
+    });
+
+    if let Ok(early) = rx.recv_timeout(std::time::Duration::from_millis(250)) {
+        panic!(
+            "warm returned {early:?} while the staged store was held exclusively; \
+             it must block instead -- returning here means it either materialized \
+             without the guard or failed before reaching it"
+        );
+    }
+
+    drop(gc_lock);
+
+    rx.recv_timeout(std::time::Duration::from_secs(30))
+        .expect("warm must proceed once the exclusive lock is released");
+    let (restored, _skipped, errors) = warm.join().unwrap().unwrap();
+    assert_eq!(errors, 0, "warm should succeed after acquiring the lock");
+    assert_eq!(restored, 1, "the staged payload should be restored");
+}

--- a/crates/zccache-cli-core/src/cli/commands/tests/cache_ops.rs
+++ b/crates/zccache-cli-core/src/cli/commands/tests/cache_ops.rs
@@ -312,7 +312,7 @@ fn warm_waits_for_the_staged_store_lock_before_materializing() {
 
     // Stand in for daemon maintenance holding the store exclusively.
     let staged = zccache_artifact::staged_lock::staged_root(&artifact_dir);
-    let gc_lock = zccache_artifact::staged_lock::open_store_lock(&staged).unwrap();
+    let gc_lock = zccache_artifact::staged_lock::open_store_lock(staged.as_path()).unwrap();
     fs2::FileExt::lock_exclusive(&gc_lock).unwrap();
 
     // The outcome travels through the channel, not just a unit tick, so that an

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -47,10 +47,14 @@ pub(in crate::daemon::server) use hook::{StagedHookGuard, StagedHookPoint};
 
 pub(in crate::daemon::server) const STAGED_ARTIFACTS_ENV: &str = "ZCCACHE_STAGED_ARTIFACTS";
 
-const STAGED_ROOT: &str = ".staged-v2";
+// The staged root and store-lock names are owned by `zccache-artifact` and
+// imported rather than redeclared: `zccache warm` runs in the CLI process and
+// locks the same file to exclude this daemon's GC. Two independent string
+// constants would keep compiling while silently ceasing to exclude each other.
+use zccache_artifact::staged_lock::{STAGED_ROOT, STORE_LOCK};
+
 const STAGED_MANIFEST_VERSION: u32 = 1;
 const PUBLISH_LOCK: &str = ".publish.lock";
-const STORE_LOCK: &str = ".store.lock";
 
 static STAGED_ARTIFACT_TMP_COUNTER: AtomicU64 = AtomicU64::new(1);
 

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/root_safety.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/root_safety.rs
@@ -1,43 +1,23 @@
 //! Exact-root validation and safe link/reparse removal for staged artifacts.
 
-use super::{STAGED_ROOT, STORE_LOCK};
 use crate::core::NormalizedPath;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File};
 use std::io;
 use std::path::Path;
 
+// Root naming, root validation and lock-file opening are delegated to
+// `zccache-artifact` so the daemon and the in-process `zccache warm` command
+// contend on one lock. See `zccache_artifact::staged_lock`.
+pub(super) use zccache_artifact::staged_lock::{
+    is_staged_link_or_reparse, validate_staged_root_path,
+};
+
 pub(super) fn staged_root(artifact_dir: &Path) -> NormalizedPath {
-    artifact_dir.join(STAGED_ROOT).into()
+    zccache_artifact::staged_lock::staged_root(artifact_dir).into()
 }
 
 pub(super) fn open_store_lock(root: &Path) -> io::Result<File> {
-    if !validate_staged_root_path(root)? {
-        fs::create_dir_all(root)?;
-        if !validate_staged_root_path(root)? {
-            return Err(io::Error::new(
-                io::ErrorKind::NotFound,
-                format!("staged artifact root disappeared: {}", root.display()),
-            ));
-        }
-    }
-    OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(root.join(STORE_LOCK))
-}
-
-#[cfg(windows)]
-pub(super) fn is_staged_link_or_reparse(metadata: &fs::Metadata) -> bool {
-    use std::os::windows::fs::MetadataExt;
-    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
-    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
-}
-
-#[cfg(not(windows))]
-pub(super) fn is_staged_link_or_reparse(metadata: &fs::Metadata) -> bool {
-    metadata.file_type().is_symlink()
+    zccache_artifact::staged_lock::open_store_lock(root)
 }
 
 #[cfg(windows)]
@@ -60,33 +40,6 @@ pub(super) fn remove_staged_link_or_reparse(
     _metadata: &fs::Metadata,
 ) -> io::Result<()> {
     fs::remove_file(path)
-}
-
-pub(super) fn validate_staged_root_path(root: &Path) -> io::Result<bool> {
-    let metadata = match fs::symlink_metadata(root) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => return Err(error),
-    };
-    if is_staged_link_or_reparse(&metadata) {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            format!(
-                "refusing staged artifact access through linked/reparse root: {}",
-                root.display()
-            ),
-        ));
-    }
-    if !metadata.is_dir() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!(
-                "staged artifact root is not a directory: {}",
-                root.display()
-            ),
-        ));
-    }
-    Ok(true)
 }
 
 pub(in crate::daemon::server) fn validate_staged_artifact_root(

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/root_safety.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/root_safety.rs
@@ -1,24 +1,16 @@
 //! Exact-root validation and safe link/reparse removal for staged artifacts.
 
-use crate::core::NormalizedPath;
-use std::fs::{self, File};
+use std::fs;
 use std::io;
 use std::path::Path;
 
-// Root naming, root validation and lock-file opening are delegated to
-// `zccache-artifact` so the daemon and the in-process `zccache warm` command
-// contend on one lock. See `zccache_artifact::staged_lock`.
+// Root naming, root validation and lock-file opening are re-exported from
+// `zccache-artifact` rather than reimplemented here, so the daemon and the
+// in-process `zccache warm` command provably contend on one lock file.
+// See `zccache_artifact::staged_lock`.
 pub(super) use zccache_artifact::staged_lock::{
-    is_staged_link_or_reparse, validate_staged_root_path,
+    is_staged_link_or_reparse, open_store_lock, staged_root, validate_staged_root_path,
 };
-
-pub(super) fn staged_root(artifact_dir: &Path) -> NormalizedPath {
-    zccache_artifact::staged_lock::staged_root(artifact_dir).into()
-}
-
-pub(super) fn open_store_lock(root: &Path) -> io::Result<File> {
-    zccache_artifact::staged_lock::open_store_lock(root)
-}
 
 #[cfg(windows)]
 pub(super) fn remove_staged_link_or_reparse(

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -153,3 +153,28 @@ same-sweep re-plan, and selects replacement candidates until it reaches the
 headroom target or only protected metadata remains. Also settle orphaned
 journal rows explicitly: a gentle metadata deletion can otherwise leave memory
 debt after the metadata entry itself is gone.
+
+## Never validate a soldr command with a `^error`-anchored grep
+
+Local `clippy --all-targets -- -D warnings` reported clean; CI then failed the
+integration leg on `unused_must_use` in a test I had just edited. The lint was
+in the local output the whole time. `soldr` prefixes every line with a timing
+column (`   88.69 error: ...`) and emits ANSI colour, so an anchored
+`grep -E "^(error|warning)"` matches nothing and a clean-looking filter is
+indistinguishable from a clean build.
+
+Judge a build by its **exit code**, not by a line filter:
+
+```sh
+soldr cargo clippy -p <crate> --all-targets -- -D warnings >/tmp/out.txt 2>&1
+echo "exit=$?  diagnostics=$(grep -cE 'warning:|error(\[|:)' /tmp/out.txt)"
+```
+
+Two independent signals, neither anchored. Also export `RUSTFLAGS="-D warnings"`
+to match CI: rustc lints like `unused_must_use` are denied there, and passing
+`-- -D warnings` to clippy alone does not reproduce the same gate.
+
+This was already recorded in memory as "Validating soldr output on Windows" and
+I still repeated it, which is the actual lesson: the failure mode is silent and
+looks exactly like success, so the filter has to be structurally incapable of
+lying rather than merely correct on the day it was written.


### PR DESCRIPTION
Closes #1310. Found while auditing #1215, which fixed this exact race class for the five *daemon* hit paths — `warm` was outside its enumeration because it is not a daemon hit path.

## The bug

`warm_target` resolves staged-v2 generation paths (`cache_ops.rs:398`, `include_staged = true`), batches **the entire index** into a work vec before materializing anything (`:391-420`, 1k–5k entries on CI restores), then hardlinks/copies in a rayon `par_iter` — holding no lock. Daemon GC takes `.staged-v2/.store.lock` exclusively before `remove_staged_tree` (`maintenance.rs:126,150,229`).

`warm` runs **in the CLI process** — `cmd_warm` opens the redb index directly and never sends an IPC request (the `Warm` subcommand declares `--endpoint` and the dispatch discards it). So this is a genuine cross-process race against a running daemon, and an advisory file lock is the correct mechanism rather than an in-process one.

The only prior protection was a best-effort probe at `:451-455` whose own comment concedes the problem:

```rust
// The file can still disappear after resolution.
if !src.exists() {
```

**Worst case is not a failed restore.** A `copy` reading a tree that is being unlinked concurrently can write a **truncated rlib** into `target/<profile>/deps/`. Cargo does not content-verify rlibs — they are keyed by the hash in their filename — so it accepts it. That is a wrong hit.

## Why this moves code instead of just adding a call

The existing guard is unreachable from the CLI: `StagedMaterializationGuard` and both acquire functions are `pub(in crate::daemon::server)`, `MaterializationPayloads` is `pub(crate)`, and there is no public re-export.

The tempting shortcut is a second `fs2` lock in the CLI on a path spelled `.staged-v2/.store.lock`. I deliberately did not do that. `.staged-v2` was **already** declared twice (`layout.rs:14` and `staged_store.rs:50`), and two independent constants naming one lock file keep compiling, keep passing their own tests, and silently stop excluding each other the moment either side changes. A lock is worth nothing unless both processes provably contend on the same file.

So the lock now lives in `zccache-artifact` — the crate both sides already consume, whose module doc already says *"The daemon and offline `zccache warm` command both consume this module"* — and the daemon **imports** it rather than keeping its own copy. Net effect is one definition of the staged root, the lock file, root validation, and lock acquisition.

`acquire_if_present` returns `None` when no staged root exists, so a cache that never staged anything stays on the unlocked path instead of getting an empty `.staged-v2` created as a side effect of a read-only command.

## The test discriminates — I verified it by sabotage

Last time I shipped in this area I wrote a timing test, discovered it passed with the fix reverted, and deleted it. So I checked this one the same way before trusting it: with the guard replaced by `None`, it fails with

> warm must block while the staged store is held exclusively

and with the guard in place it passes. It holds the store exclusively (standing in for GC), runs `warm_target` in a thread, asserts it does **not** complete, releases, then asserts it completes and restores the payload.

The outcome travels through the channel rather than a unit tick, so an early `Err` return — which would also unblock the recv and look identical to "ignored the lock" — names itself instead of failing as a mystery.

## One thing I could not resolve, stated plainly

The **first** combined run of the three suites showed `245 passed; 1 failed` in `zccache-cli-core`. My grep did not capture the test name, and I have not reproduced it since: **15 subsequent cli-core runs are clean**, including 3 exact repetitions of the multi-suite load condition that produced it (9/9 green at 95 / 246 / 724).

I could not attribute it, so I am not claiming it was unrelated. Flagging it rather than quietly moving on — if it resurfaces, the diagnostic added above should name it.

## Evidence

- `zccache-artifact --lib` — 95 passed, 0 failed
- `zccache-cli-core --features cli --lib` — 246 passed, 0 failed
- `zccache-daemon-core --features "test-support,daemon-entry" --lib` — 724 passed, 0 failed
- `soldr cargo clippy --workspace --all-targets -- -D warnings` — clean (workspace-wide, not just the touched crates: a prior PR of mine passed every CI leg while leaving `main` red under this, since the Dylint job runs `check`)
- `soldr cargo fmt --all`

## Not covered

The lock is held for the whole warm, so a concurrent GC waits until the restore finishes. That is intentional — `warm` is an explicit bulk operation and correctness wins over eviction latency — but it is a real behavioural change worth knowing about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
