### PR TITLE
fix(protocol): give ExecProbe/ExecStore real prost arms (#840 slice 1)

### DIFF
--- a/crates/zccache-protocol/proto/zccache_v1.proto
+++ b/crates/zccache-protocol/proto/zccache_v1.proto
@@ -40,6 +40,8 @@ message Request {
     Empty list_rust_artifacts = 17;
     GenericToolExec generic_tool_exec = 18;
     ReleaseWorktreeHandles release_worktree_handles = 19;
+    ExecProbe exec_probe = 20;
+    ExecStore exec_store = 21;
   }
   string request_id = 100;
 }
@@ -65,6 +67,8 @@ message Response {
     Backpressure backpressure = 17;
     ReleaseWorktreeHandlesResult release_worktree_handles_result = 18;
     CompileProgress compile_progress = 19;
+    ExecProbeResult exec_probe_result = 20;
+    ExecStoreAck exec_store_ack = 21;
   }
   string request_id = 100;
 }
@@ -406,4 +410,30 @@ message ReleaseWorktreeHandlesResult {
   uint32 released = 2;
   repeated string sessions_dropped = 3;
   repeated Path unreleased = 4;
+}
+
+// Issue #838 / #840: caller-owned-tool exec cache. Where GenericToolExec
+// ships the command to the daemon, ExecProbe keeps the runner with the
+// caller and asks the daemon only for key derivation + lookup.
+message ExecProbe {
+  string name = 1;
+  repeated Path input_files = 2;
+  repeated EnvVar input_env = 3;
+  bytes input_extra = 4;
+}
+
+message ExecStore {
+  string cache_key_hex = 1;
+  bytes result_bytes = 2;
+}
+
+message ExecProbeResult {
+  string cache_key_hex = 1;
+  // Absent on miss. `optional` is load-bearing: an empty cached result is a
+  // legitimate hit, so it must stay distinguishable from "not cached".
+  optional bytes cached_bytes = 2;
+}
+
+message ExecStoreAck {
+  bool stored = 1;
 }

--- a/crates/zccache-protocol/src/wire_prost/api.rs
+++ b/crates/zccache-protocol/src/wire_prost/api.rs
@@ -159,8 +159,6 @@ pub const fn default_request_id(request: &crate::Request) -> &'static str {
         crate::Request::FingerprintInvalidate { .. } => "fingerprint-invalidate",
         crate::Request::ListRustArtifacts => "list-rust-artifacts",
         crate::Request::GenericToolExec { .. } => "generic-tool-exec",
-        // Issue #838: bincode-only for slice 1; the prost wire lane
-        // refuses these until the wheel-side consumer needs them.
         crate::Request::ExecProbe { .. } => "exec-probe",
         crate::Request::ExecStore { .. } => "exec-store",
     }

--- a/crates/zccache-protocol/src/wire_prost/request.rs
+++ b/crates/zccache-protocol/src/wire_prost/request.rs
@@ -189,14 +189,24 @@ pub fn request_to_prost(request: &crate::Request, request_id: &str) -> zccache_v
                 path: Some(path_to_prost(path)),
             })
         }
-        // Issue #838: ExecProbe / ExecStore are bincode-only in slice 1.
-        // The prost wire lane will gain proto definitions in a follow-up
-        // PR once a wheel consumer needs cross-protocol routing. For now,
-        // route a placeholder that the daemon's prost handler rejects;
-        // any in-process bincode path is unaffected.
-        crate::Request::ExecProbe { .. } | crate::Request::ExecStore { .. } => {
-            Body::Ping(zccache_v1::Empty {})
-        }
+        crate::Request::ExecProbe {
+            name,
+            input_files,
+            input_env,
+            input_extra,
+        } => Body::ExecProbe(zccache_v1::ExecProbe {
+            name: name.clone(),
+            input_files: paths_to_prost(input_files),
+            input_env: env_pairs_to_prost(input_env),
+            input_extra: input_extra.as_ref().clone(),
+        }),
+        crate::Request::ExecStore {
+            cache_key_hex,
+            result_bytes,
+        } => Body::ExecStore(zccache_v1::ExecStore {
+            cache_key_hex: cache_key_hex.clone(),
+            result_bytes: result_bytes.as_ref().clone(),
+        }),
     };
 
     zccache_v1::Request {
@@ -340,6 +350,16 @@ pub fn request_from_prost(request: zccache_v1::Request) -> Result<crate::Request
                 release.path,
                 "ReleaseWorktreeHandles.path",
             )?),
+        }),
+        Some(Body::ExecProbe(probe)) => Ok(crate::Request::ExecProbe {
+            name: probe.name,
+            input_files: paths_from_prost(probe.input_files),
+            input_env: env_pairs_from_prost(probe.input_env),
+            input_extra: std::sync::Arc::new(probe.input_extra),
+        }),
+        Some(Body::ExecStore(store)) => Ok(crate::Request::ExecStore {
+            cache_key_hex: store.cache_key_hex,
+            result_bytes: std::sync::Arc::new(store.result_bytes),
         }),
         None => Err("v16 prost request is missing its request body".to_string()),
     }

--- a/crates/zccache-protocol/src/wire_prost/response.rs
+++ b/crates/zccache-protocol/src/wire_prost/response.rs
@@ -137,11 +137,15 @@ pub fn response_to_prost(response: &crate::Response, request_id: &str) -> zccach
             in_flight: *in_flight,
             phase: phase.clone(),
         }),
-        // Issue #838: ExecProbeResult / ExecStoreAck are bincode-only in
-        // slice 1. The prost wire lane will gain proto definitions once a
-        // wheel consumer needs cross-protocol routing.
-        crate::Response::ExecProbeResult { .. } | crate::Response::ExecStoreAck { .. } => {
-            Body::Pong(zccache_v1::Empty {})
+        crate::Response::ExecProbeResult {
+            cache_key_hex,
+            cached_bytes,
+        } => Body::ExecProbeResult(zccache_v1::ExecProbeResult {
+            cache_key_hex: cache_key_hex.clone(),
+            cached_bytes: cached_bytes.as_ref().map(|bytes| bytes.as_ref().clone()),
+        }),
+        crate::Response::ExecStoreAck { stored } => {
+            Body::ExecStoreAck(zccache_v1::ExecStoreAck { stored: *stored })
         }
     };
 
@@ -246,6 +250,11 @@ pub fn response_from_prost(response: zccache_v1::Response) -> Result<crate::Resp
             in_flight: progress.in_flight,
             phase: progress.phase,
         }),
+        Some(Body::ExecProbeResult(result)) => Ok(crate::Response::ExecProbeResult {
+            cache_key_hex: result.cache_key_hex,
+            cached_bytes: result.cached_bytes.map(std::sync::Arc::new),
+        }),
+        Some(Body::ExecStoreAck(ack)) => Ok(crate::Response::ExecStoreAck { stored: ack.stored }),
         None => Err("v16 prost response is missing its response body".to_string()),
     }
 }

--- a/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
+++ b/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
@@ -617,3 +617,201 @@ mod full_family {
         assert!(supported_control_response_from_prost(prost).is_err());
     }
 }
+
+// ── Exhaustiveness trip-wire (issue #840) ──────────────────────────────
+//
+// Why this exists: `ExecProbe`/`ExecStore` were added to the enum and to
+// the bincode lane, but their prost arms were left as `Body::Ping` /
+// `Body::Pong` stubs. Nothing failed. Every test in `full_family` above is
+// a hand-written per-variant `#[test]`, so a new variant simply had no
+// test and compiled green — while `request_to_prost` silently encoded an
+// ExecProbe as a bare Ping, which `request_from_prost` then decoded back
+// as `Request::Ping`. Payload discarded, no error, indistinguishable from
+// a legitimate keepalive.
+//
+// The bincode lane did not have this hole because
+// `messages/compat/variant_indices.rs` pins every variant in one list, so
+// an omission is visible there. This module gives the prost lane a match
+// that stops compiling when a variant is added.
+
+mod exhaustive_prost_coverage {
+    use std::sync::Arc;
+    use zccache::protocol::wire_prost::{
+        default_request_id, request_from_prost, request_to_prost, response_from_prost,
+        response_to_prost,
+    };
+    use zccache::protocol::{Request, Response};
+
+    /// Name every `Request` variant.
+    ///
+    /// This match is deliberately exhaustive with no `_` arm: adding a
+    /// variant to `Request` makes this fail to compile. When that happens,
+    /// add the variant here and give it a prost roundtrip test — the
+    /// roundtrip assertion is what proves the prost arms are real rather
+    /// than stubs.
+    fn request_variant_name(request: &Request) -> &'static str {
+        match request {
+            Request::Ping => "Ping",
+            Request::Shutdown => "Shutdown",
+            Request::Status => "Status",
+            Request::Clear => "Clear",
+            Request::Lookup { .. } => "Lookup",
+            Request::Store { .. } => "Store",
+            Request::SessionStart { .. } => "SessionStart",
+            Request::Compile { .. } => "Compile",
+            Request::SessionEnd { .. } => "SessionEnd",
+            Request::CompileEphemeral { .. } => "CompileEphemeral",
+            Request::LinkEphemeral { .. } => "LinkEphemeral",
+            Request::SessionStats { .. } => "SessionStats",
+            Request::FingerprintCheck { .. } => "FingerprintCheck",
+            Request::FingerprintMarkSuccess { .. } => "FingerprintMarkSuccess",
+            Request::FingerprintMarkFailure { .. } => "FingerprintMarkFailure",
+            Request::FingerprintInvalidate { .. } => "FingerprintInvalidate",
+            Request::ListRustArtifacts => "ListRustArtifacts",
+            Request::GenericToolExec { .. } => "GenericToolExec",
+            Request::ReleaseWorktreeHandles { .. } => "ReleaseWorktreeHandles",
+            Request::ExecProbe { .. } => "ExecProbe",
+            Request::ExecStore { .. } => "ExecStore",
+        }
+    }
+
+    /// Name every `Response` variant. Same contract as above.
+    fn response_variant_name(response: &Response) -> &'static str {
+        match response {
+            Response::Pong => "Pong",
+            Response::ShuttingDown => "ShuttingDown",
+            Response::Status { .. } => "Status",
+            Response::LookupResult { .. } => "LookupResult",
+            Response::StoreResult { .. } => "StoreResult",
+            Response::SessionStarted { .. } => "SessionStarted",
+            Response::CompileResult { .. } => "CompileResult",
+            Response::SessionEnded { .. } => "SessionEnded",
+            Response::LinkResult { .. } => "LinkResult",
+            Response::Error { .. } => "Error",
+            Response::Cleared { .. } => "Cleared",
+            Response::SessionStatsResult { .. } => "SessionStatsResult",
+            Response::FingerprintCheckResult { .. } => "FingerprintCheckResult",
+            Response::FingerprintAck => "FingerprintAck",
+            Response::RustArtifactList { .. } => "RustArtifactList",
+            Response::GenericToolExecResult { .. } => "GenericToolExecResult",
+            Response::Backpressure { .. } => "Backpressure",
+            Response::ReleaseWorktreeHandlesResult { .. } => "ReleaseWorktreeHandlesResult",
+            Response::CompileProgress { .. } => "CompileProgress",
+            Response::ExecProbeResult { .. } => "ExecProbeResult",
+            Response::ExecStoreAck { .. } => "ExecStoreAck",
+        }
+    }
+
+    /// The exec variants, with payloads a stub cannot fake.
+    ///
+    /// Every field is non-default: a `Body::Ping` stub loses all of them,
+    /// so roundtrip equality fails loudly instead of comparing empty
+    /// strings to empty strings.
+    fn exec_requests() -> Vec<Request> {
+        vec![
+            Request::ExecProbe {
+                name: "noexcept_ast".to_string(),
+                input_files: vec!["src/foo.cpp".into(), "ci/rules.json".into()],
+                input_env: vec![
+                    ("LINT_VERSION".to_string(), "1.2.3".to_string()),
+                    ("PATH".to_string(), "/usr/bin".to_string()),
+                ],
+                input_extra: Arc::new(b"schema-v1".to_vec()),
+            },
+            // The all-empty probe: a distinct wire shape, and the one case
+            // a Ping stub would accidentally satisfy.
+            Request::ExecProbe {
+                name: String::new(),
+                input_files: vec![],
+                input_env: vec![],
+                input_extra: Arc::new(Vec::new()),
+            },
+            Request::ExecStore {
+                cache_key_hex: "0123456789abcdef".repeat(4),
+                result_bytes: Arc::new(b"opaque-result-bytes".to_vec()),
+            },
+        ]
+    }
+
+    fn exec_responses() -> Vec<Response> {
+        vec![
+            Response::ExecProbeResult {
+                cache_key_hex: "a".repeat(64),
+                cached_bytes: Some(Arc::new(b"cached".to_vec())),
+            },
+            Response::ExecProbeResult {
+                cache_key_hex: "b".repeat(64),
+                cached_bytes: None,
+            },
+            // An empty cached payload is a HIT, not a miss. If `optional`
+            // were dropped from the proto field this would decode as
+            // `None` and silently turn every empty-result hit into a miss.
+            Response::ExecProbeResult {
+                cache_key_hex: "c".repeat(64),
+                cached_bytes: Some(Arc::new(Vec::new())),
+            },
+            Response::ExecStoreAck { stored: true },
+            Response::ExecStoreAck { stored: false },
+        ]
+    }
+
+    #[test]
+    fn exec_requests_survive_a_prost_roundtrip() {
+        for request in exec_requests() {
+            let request_id = default_request_id(&request);
+            let decoded = request_from_prost(request_to_prost(&request, request_id)).unwrap();
+            assert_eq!(
+                decoded,
+                request,
+                "{} lost data crossing the prost lane",
+                request_variant_name(&request)
+            );
+        }
+    }
+
+    #[test]
+    fn exec_responses_survive_a_prost_roundtrip() {
+        for response in exec_responses() {
+            let decoded = response_from_prost(response_to_prost(&response, "resp-1")).unwrap();
+            assert_eq!(
+                decoded,
+                response,
+                "{} lost data crossing the prost lane",
+                response_variant_name(&response)
+            );
+        }
+    }
+
+    /// The specific regression: an exec request must not arrive as a Ping.
+    ///
+    /// Roundtrip equality already covers this, but assert the decoded
+    /// variant explicitly — under the old stubs this was the exact
+    /// observable failure, and naming it tells the next reader what
+    /// "broken" looked like.
+    #[test]
+    fn exec_requests_do_not_degrade_into_ping() {
+        for request in exec_requests() {
+            let request_id = default_request_id(&request);
+            let decoded = request_from_prost(request_to_prost(&request, request_id)).unwrap();
+            assert_ne!(
+                decoded,
+                Request::Ping,
+                "{} encoded as a bare Ping — the prost arm is a stub",
+                request_variant_name(&request)
+            );
+        }
+    }
+
+    #[test]
+    fn exec_responses_do_not_degrade_into_pong() {
+        for response in exec_responses() {
+            let decoded = response_from_prost(response_to_prost(&response, "resp-1")).unwrap();
+            assert_ne!(
+                decoded,
+                Response::Pong,
+                "{} encoded as a bare Pong — the prost arm is a stub",
+                response_variant_name(&response)
+            );
+        }
+    }
+}


### PR DESCRIPTION
Phase A / Slice 1 of #840. I went in expecting cleanup debt and found silent corruption.

## What the stubs actually did

`request_to_prost` encoded **both** exec variants as a bare `Ping`, infallibly, discarding every field:

```rust
crate::Request::ExecProbe { .. } | crate::Request::ExecStore { .. } => {
    Body::Ping(zccache_v1::Empty {})
}
```

It returns `zccache_v1::Request`, not `Result` — no `Err`, no `None`, no `unimplemented!()`. And `request_from_prost` has no inverse arm, so `Body::Ping` maps unconditionally back to `Request::Ping`.

End to end over prost: client sends `ExecProbe { name, input_files, input_env, input_extra }` → wire `Ping` → daemon sees `Request::Ping` → replies `Pong` → client gets a `Pong` where it expected an `ExecProbeResult`. **No error, no version mismatch, no log line** — indistinguishable from a legitimate keepalive. Same on the response side via `Body::Pong`.

The comment above the stub said it routed *"a placeholder that the daemon's prost handler rejects"*. That was simply false: the dispatcher (`connection/mod.rs:347`, and `:368` for the FrameV1 lane) calls the full `request_from_prost`, not the narrow `supported_control_request_to_prost` gate that does reject. A second comment in `api.rs` claiming the lane "refuses these" sat on `default_request_id`, which refuses nothing and happily returns `"exec-probe"`. Both removed.

## Severity: latent, not live

No client constructs `ExecProbe`/`ExecStore` today — the only references outside the protocol crate are daemon-side handlers and tests. And `full_family_wire_format_from_env()` returns `BincodeV15` for `Auto` (and for invalid values), so the default path never touches it.

But `ZCCACHE_DAEMON_WIRE=prost` (also `prost-v16`, `v16`, `frame`, `frame-v1`) is a supported, documented value that routes straight through the stub. This was a booby trap primed for the first wheel-side consumer — exactly the one the stub comment said it was waiting for.

## The fix

Four proto messages, appended at Request tags 20/21 and Response tags 20/21 — existing tags untouched — plus real converters in both directions.

`cached_bytes` is deliberately `optional bytes`. An empty cached result is a **hit**, not a miss; without `optional`, proto3 would flatten `Some(vec![])` to `None` and silently convert every empty-result hit into a miss. There is a test for exactly that case.

## Why this happened, and the guard

The bincode lane didn't have this hole. `messages/compat/variant_indices.rs` pins every variant in one list, so an omission is visible — and indeed `ExecProbe` *was* correctly added there.

The prost lane has no such list. Every test in the `full_family` module is a hand-written per-variant `#[test]`, despite that module's own header comment asserting *"Every non-control request/response family must survive a prost-conversion round trip exactly."* A new variant just had no test and compiled green.

So I added a module that matches exhaustively over both enums with no `_` arm. Adding a variant now stops compiling until someone looks at it.

**I verified the guard catches the original bug rather than assuming it.** Restoring the `Body::Ping` stub:

```
test exhaustive_prost_coverage::exec_requests_survive_a_prost_roundtrip ... FAILED
test exhaustive_prost_coverage::exec_requests_do_not_degrade_into_ping ... FAILED
assertion `left == right` failed: ExecProbe lost data crossing the prost lane
assertion `left != right` failed: ExecProbe encoded as a bare Ping — the prost arm is a stub
```

Then restored the real arms and re-ran green.

**Being precise about how strong the guard is:** the exhaustive match is a genuine compile-time trip-wire for *noticing* a new variant. It does not mechanically force a roundtrip test to exist for it — that still takes a human reading the doc comment. I looked at making coverage airtight without a new dependency and didn't find a way that wasn't more machinery than the problem warrants. This matches the precedent set by `variant_indices.rs`, which is a hand-maintained list that has worked.

## Scope

`#840` stays open — this is Slice 1 of a multi-phase burn-down. Phase B (flipping `Auto` to prost) and Phase C/D are untouched, and flipping the default hot-path wire format is not something I'd ship without the perf gate.

No `PROTOCOL_VERSION` bump: bincode variant indices are untouched, and appended proto tags are backward compatible. An old daemon receiving tag 20 sees no known body and returns the existing "missing request body" error — a clean failure, not corruption.

## Evidence

- `zccache --test daemon_wire_prost_roundtrip` — 30 passed, 0 failed (was 26; +4)
- `zccache-protocol --lib` — 51 passed, 0 failed
- `zccache-daemon-core --features "test-support,daemon-entry" --lib` — 724 passed, 0 failed
- `soldr cargo clippy --workspace --all-targets -- -D warnings` under `RUSTFLAGS="-D warnings"` — exit 0, 0 diagnostics
- `soldr cargo fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
