### PR TITLE
fix(embedded): actually emit audit events from the embedded service (#905)

### DIFF
--- a/crates/zccache-daemon-core/src/embedded.rs
+++ b/crates/zccache-daemon-core/src/embedded.rs
@@ -63,6 +63,10 @@ pub struct ZccacheService {
     /// service's lifetime; flush + shutdown are forwarded from the
     /// matching `ZccacheService` methods.
     audit_sink: Option<Arc<crate::audit_writer::AuditSink>>,
+    /// The host's audit configuration, retained so emitted events can carry
+    /// the selected mode and honor the host's redaction policy. `Arc` keeps
+    /// `Clone` on the service cheap.
+    audit: Arc<AuditConfig>,
 }
 
 /// Configuration for [`ZccacheService::start`].
@@ -517,7 +521,68 @@ impl ZccacheService {
             cancellation: config.cancellation,
             _host_inflight_guard: host_inflight_guard,
             audit_sink,
+            audit: Arc::new(config.audit),
         })
+    }
+
+    /// Emit one durable audit event, if the host enabled audit.
+    ///
+    /// #905: the sink was started, flushed and shut down but nothing ever
+    /// called `emit`, so a host that configured `audit.jsonl` got a file that
+    /// was created, rotated and always empty. This is the seam that feeds it.
+    ///
+    /// Costs one `Option` check when audit is off (`AuditMode::Off` makes
+    /// `AuditSink::start` return `None`), so the default path is unaffected.
+    ///
+    /// A failed emit is dropped, never propagated: losing an audit record must
+    /// not fail a compile that otherwise succeeded. `AuditSink` already owns
+    /// the backpressure policy and its own lost-event counter, so a caller
+    /// here has nothing useful to add.
+    fn emit_audit(
+        &self,
+        context: &AuditContext,
+        category: &'static str,
+        event: &'static str,
+        level: crate::audit::AuditLevel,
+        duration_ns: Option<u64>,
+        fields: &[(&'static str, serde_json::Value)],
+    ) {
+        let Some(sink) = &self.audit_sink else {
+            return;
+        };
+        let (Ok(event_id), Ok(span_id), Ok(category), Ok(event)) = (
+            crate::audit::AuditId::new(uuid::Uuid::new_v4().to_string()),
+            crate::audit::AuditId::new(uuid::Uuid::new_v4().to_string()),
+            crate::audit::AuditCategory::new(category),
+            crate::audit::AuditEventName::new(event),
+        ) else {
+            // Every argument is a compile-time constant or a fresh UUID, so
+            // this is unreachable in practice; returning beats unwrapping in
+            // a path that must never take down a compile.
+            return;
+        };
+        let mut record = crate::audit::AuditEvent::new(
+            event_id,
+            context.clone(),
+            span_id,
+            category,
+            event,
+            // No date-time dependency in this crate, and the repo convention
+            // is nanoseconds everywhere internally (see CLAUDE.md), so the
+            // timestamp is epoch nanos as a decimal string. It sorts
+            // lexically within a fixed width and needs no formatter.
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |since| since.as_nanos())
+                .to_string(),
+        );
+        record.level = level;
+        record.mode = self.audit.mode;
+        record.duration_ns = duration_ns;
+        for (key, value) in fields {
+            record = record.with_field(*key, value.clone());
+        }
+        let _ = sink.emit(record.apply_redaction(&self.audit.redaction));
     }
 
     /// Compile using the embedded daemon engine.
@@ -575,6 +640,25 @@ impl ZccacheService {
                 return Err(EmbeddedError::Cancelled);
             }
         }
+        // Carry the resolved `compile_id` on every event for this compile, so
+        // the host's own records correlate by id rather than by timestamp.
+        let audit = {
+            let mut audit = request.audit.clone();
+            audit.compile_id = crate::audit::AuditId::new(compile_id.clone()).ok();
+            audit
+        };
+        let started = std::time::Instant::now();
+        self.emit_audit(
+            &audit,
+            crate::audit::AuditCategory::ZCCACHE_COMPILE,
+            crate::audit::AuditEventName::COMPILE_STARTED,
+            crate::audit::AuditLevel::Info,
+            None,
+            &[(
+                "compiler",
+                serde_json::Value::from(request.compiler.as_path().display().to_string()),
+            )],
+        );
         let compile_future = self.daemon.compile(EmbeddedCompileRequest {
             compiler: request.compiler.into_path_buf(),
             args: request.args,
@@ -582,16 +666,34 @@ impl ZccacheService {
             env: Some(request.env),
             stdin: request.stdin,
         });
-        let response = match &self.cancellation {
+        let outcome = match &self.cancellation {
             Some(token) => {
                 let cancelled = token.cancelled();
                 tokio::select! {
                     biased;
-                    () = cancelled => return Err(EmbeddedError::Cancelled),
-                    result = compile_future => result.map_err(EmbeddedError::Compile)?,
+                    () = cancelled => Err(EmbeddedError::Cancelled),
+                    result = compile_future => result.map_err(EmbeddedError::Compile),
                 }
             }
-            None => compile_future.await.map_err(EmbeddedError::Compile)?,
+            None => compile_future.await.map_err(EmbeddedError::Compile),
+        };
+        // Every `compile.started` must get a `compile.finished`, including on
+        // the cancel and spawn-failure paths. An audit log with dangling
+        // starts cannot be used to measure anything, and those are exactly
+        // the compiles an operator most wants to find.
+        let response = match outcome {
+            Ok(response) => response,
+            Err(error) => {
+                self.emit_audit(
+                    &audit,
+                    crate::audit::AuditCategory::ZCCACHE_COMPILE,
+                    crate::audit::AuditEventName::COMPILE_FINISHED,
+                    crate::audit::AuditLevel::Error,
+                    Some(u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX)),
+                    &[("error", serde_json::Value::from(error.to_string()))],
+                );
+                return Err(error);
+            }
         };
         let cache_outcome = if response.exit_code != 0 {
             CacheOutcome::Error
@@ -600,6 +702,47 @@ impl ZccacheService {
         } else {
             CacheOutcome::Miss
         };
+        let elapsed_ns = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        // No `cache_key` field: the key is derived inside the engine and is
+        // not visible at this boundary. Emitting `cache.lookup` with the key
+        // needs plumbing through `EmbeddedCompileRequest` — deliberately left
+        // to a follow-up rather than guessed at here.
+        match cache_outcome {
+            CacheOutcome::Hit => self.emit_audit(
+                &audit,
+                crate::audit::AuditCategory::ZCCACHE_CACHE_LOOKUP,
+                crate::audit::AuditEventName::CACHE_HIT,
+                crate::audit::AuditLevel::Info,
+                Some(elapsed_ns),
+                &[],
+            ),
+            CacheOutcome::Miss => self.emit_audit(
+                &audit,
+                crate::audit::AuditCategory::ZCCACHE_CACHE_LOOKUP,
+                crate::audit::AuditEventName::CACHE_MISS,
+                crate::audit::AuditLevel::Info,
+                Some(elapsed_ns),
+                &[],
+            ),
+            // A failed compile is not a cache outcome; `compile.finished`
+            // below carries the exit code.
+            CacheOutcome::Error => {}
+        }
+        self.emit_audit(
+            &audit,
+            crate::audit::AuditCategory::ZCCACHE_COMPILE,
+            crate::audit::AuditEventName::COMPILE_FINISHED,
+            if response.exit_code == 0 {
+                crate::audit::AuditLevel::Info
+            } else {
+                crate::audit::AuditLevel::Error
+            },
+            Some(elapsed_ns),
+            &[
+                ("exit_code", serde_json::Value::from(response.exit_code)),
+                ("cached", serde_json::Value::from(response.cached)),
+            ],
+        );
         Ok(CompileResponse {
             exit_code: response.exit_code,
             stdout: response.stdout.as_ref().clone(),

--- a/crates/zccache-daemon-core/src/embedded/tests.rs
+++ b/crates/zccache-daemon-core/src/embedded/tests.rs
@@ -729,3 +729,218 @@ mod staged_depfile_restart_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod audit_emission_tests {
+    //! #905: the audit sink was started, flushed and shut down but nothing
+    //! ever called `emit`, so a host that configured `audit.jsonl` got a file
+    //! that was created and rotated and always empty. These tests pin that
+    //! events actually reach the log.
+
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    /// Locate the audit JSONL under `root`, wherever the effective cache /
+    /// audit root landed.
+    fn find_audit_log(dir: &std::path::Path) -> Option<PathBuf> {
+        let entries = std::fs::read_dir(dir).ok()?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(found) = find_audit_log(&path) {
+                    return Some(found);
+                }
+            } else if path.file_name().and_then(|name| name.to_str()) == Some("audit.jsonl") {
+                return Some(path);
+            }
+        }
+        None
+    }
+
+    fn audit_lines(root: &std::path::Path) -> Vec<serde_json::Value> {
+        let Some(path) = find_audit_log(root) else {
+            return Vec::new();
+        };
+        let Ok(content) = std::fs::read_to_string(path) else {
+            return Vec::new();
+        };
+        content
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| serde_json::from_str(line).expect("audit log must be valid JSONL"))
+            .collect()
+    }
+
+    async fn start_audited_service(temp: &TempDir, instance: &str) -> ZccacheService {
+        ZccacheService::start(ZccacheConfig {
+            host: HostIdentity {
+                product: "zccache-test".into(),
+                instance_id: instance.into(),
+                workspace_id: instance.into(),
+            },
+            cache_root: temp.path().join("zccache").into(),
+            audit: AuditConfig {
+                output_root: Some(temp.path().join("audit").to_string_lossy().into_owned()),
+                ..AuditConfig::default()
+            },
+            limits: ServiceLimits::default(),
+            runtime: RuntimeHooks::default(),
+            cancellation: None,
+        })
+        .await
+        .expect("audited embedded service starts")
+    }
+
+    /// The unspawnable compiler still drives the full emit path (the journal
+    /// tests above use the same trick), so this needs no compiler on the host.
+    fn unspawnable_request(run: &str) -> CompileRequest {
+        CompileRequest {
+            audit: AuditContext::new(
+                crate::audit::AuditId::new(run).expect("non-empty"),
+                crate::audit::AuditId::new("audit-trace").expect("non-empty"),
+            ),
+            compiler: PathBuf::from("/nonexistent/compiler-that-never-runs").into(),
+            args: vec!["--version".into()],
+            cwd: std::env::current_dir().expect("cwd").into(),
+            env: Vec::new(),
+            stdin: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_compile_writes_events_to_the_host_audit_log() {
+        let temp = TempDir::new().expect("temp root");
+        let service = start_audited_service(&temp, "audit-emission").await;
+
+        let _ = service.compile(unspawnable_request("audit-run")).await;
+
+        // `flush` forwards to the sink, so the assertion is deterministic
+        // rather than a sleep-and-hope.
+        service.flush().await.expect("flush drains the audit sink");
+        let events = audit_lines(temp.path());
+
+        assert!(
+            !events.is_empty(),
+            "a compile under AuditMode::Normal must write audit events; an \
+             empty log is the #905 regression"
+        );
+        let names: Vec<&str> = events
+            .iter()
+            .filter_map(|event| event["event"].as_str())
+            .collect();
+        assert!(
+            names.contains(&"compile.started"),
+            "expected compile.started, got {names:?}"
+        );
+        assert!(
+            names.contains(&"compile.finished"),
+            "expected compile.finished, got {names:?}"
+        );
+
+        service
+            .shutdown(ShutdownMode::Graceful)
+            .await
+            .expect("graceful shutdown after audited compile");
+    }
+
+    /// The host's causal ids must reach the record. Before #905 the context
+    /// was accepted and discarded, leaving timestamp correlation as the only
+    /// way to tie a zccache event back to the host's run.
+    #[tokio::test]
+    async fn events_carry_the_host_supplied_correlation_ids() {
+        let temp = TempDir::new().expect("temp root");
+        let service = start_audited_service(&temp, "audit-context").await;
+
+        let _ = service.compile(unspawnable_request("host-run-42")).await;
+        service.flush().await.expect("flush drains the audit sink");
+
+        let events = audit_lines(temp.path());
+        let started = events
+            .iter()
+            .find(|event| event["event"] == "compile.started")
+            .expect("compile.started must be present");
+
+        assert_eq!(
+            started["run_id"], "host-run-42",
+            "the host's run_id must survive into the record: {started}"
+        );
+        assert_eq!(
+            started["trace_id"], "audit-trace",
+            "the host's trace_id must survive into the record: {started}"
+        );
+        assert!(
+            started["compile_id"]
+                .as_str()
+                .is_some_and(|id| !id.is_empty()),
+            "every compile event needs a compile_id to group on: {started}"
+        );
+
+        let finished = events
+            .iter()
+            .find(|event| event["event"] == "compile.finished")
+            .expect("compile.finished must be present");
+        assert_eq!(
+            finished["compile_id"], started["compile_id"],
+            "start and finish must share one compile_id or they cannot be paired"
+        );
+        assert_eq!(
+            finished["level"], "error",
+            "a failed compile must not be logged at info: {finished}"
+        );
+        // The unspawnable compiler fails before the engine yields an exit
+        // code, so the terminal event carries the error text instead. What
+        // matters is that the event exists at all — the first cut of this
+        // change returned early on that path and emitted a `compile.started`
+        // with no matching finish.
+        assert!(
+            finished["fields"]["error"]
+                .as_str()
+                .is_some_and(|error| !error.is_empty()),
+            "a compile that failed before producing an exit code must record \
+             why: {finished}"
+        );
+
+        service
+            .shutdown(ShutdownMode::Graceful)
+            .await
+            .expect("graceful shutdown");
+    }
+
+    /// `AuditMode::Off` must stay a true no-op — no sink, no file, no cost.
+    #[tokio::test]
+    async fn audit_off_writes_nothing() {
+        let temp = TempDir::new().expect("temp root");
+        let service = ZccacheService::start(ZccacheConfig {
+            host: HostIdentity {
+                product: "zccache-test".into(),
+                instance_id: "audit-off".into(),
+                workspace_id: "audit-off".into(),
+            },
+            cache_root: temp.path().join("zccache").into(),
+            audit: AuditConfig {
+                mode: crate::audit::AuditMode::Off,
+                output_root: Some(temp.path().join("audit").to_string_lossy().into_owned()),
+                ..AuditConfig::default()
+            },
+            limits: ServiceLimits::default(),
+            runtime: RuntimeHooks::default(),
+            cancellation: None,
+        })
+        .await
+        .expect("service starts with audit off");
+
+        let _ = service.compile(unspawnable_request("off-run")).await;
+        service.flush().await.expect("flush with no sink");
+
+        assert!(
+            find_audit_log(temp.path()).is_none(),
+            "AuditMode::Off must not create an audit log at all"
+        );
+
+        service
+            .shutdown(ShutdownMode::Graceful)
+            .await
+            .expect("graceful shutdown with audit off");
+    }
+}

--- a/docs/architecture/embedded-service.md
+++ b/docs/architecture/embedded-service.md
@@ -19,7 +19,8 @@ The MVP boundary is:
 |---|---|---|
 | Architecture contract | Landed | This document records lifecycle, ownership, audit, and shutdown expectations. |
 | Public Rust API | MVP landed | `zccache::embedded` exports `ZccacheService` and stable config/request/stats types for start, compile, stats, disk maintenance, flush, and shutdown. |
-| Durable audit schema | MVP landed | `zccache::audit` exports serializable schema/config/event/finding/manifest types; hot-path emission and fixtures remain follow-up work. |
+| Durable audit schema | MVP landed | `zccache::audit` exports serializable schema/config/event/finding/manifest types. |
+| Audit emission | Partial | `ZccacheService::compile` emits `compile.started`, `cache.hit`/`cache.miss` and `compile.finished` carrying the host's `AuditContext` (#905). Engine-internal events (`cache.lookup` with the key, `compiler.spawn`/`compiler.exit`, depgraph) still need plumbing through `EmbeddedCompileRequest`. |
 | soldr embedded integration | Landed | soldr uses the direct embedded service and owns its cache root, runtime handle, audit context, and shutdown sequence. |
 | fbuild embedded integration | Open | zccache#908 follows the same service contract, adjusted for fbuild's daemon/runtime model. |
 | Vendored hotfix workflow | Documented | zccache#909 is recorded in [`vendored-hotfix-workflow.md`](vendored-hotfix-workflow.md). |
@@ -185,11 +186,14 @@ pub struct HostIdentity {
 }
 
 pub struct AuditContext {
-    pub run_id: String,
-    pub trace_id: String,
-    pub parent_span_id: Option<String>,
-    pub command_id: Option<String>,
-    pub session_id: Option<String>,
+    pub run_id: AuditId,
+    pub build_id: Option<AuditId>,
+    pub trace_id: AuditId,
+    pub span_id: Option<AuditId>,
+    pub parent_span_id: Option<AuditId>,
+    pub command_id: Option<AuditId>,
+    pub compile_id: Option<AuditId>,
+    pub session_id: Option<AuditId>,
 }
 
 pub struct CompileRequest {
@@ -409,7 +413,8 @@ events inside the current `tracing` span.
 
 ### Event Shape
 
-The concrete Rust schema lives in `crates/zccache/src/audit.rs`. The durable
+The concrete Rust schema lives in `crates/zccache-audit/src/lib.rs` (moved
+there by the #1018 crate split; re-exported as `zccache::audit`). The durable
 event stream uses schema `soldr.audit.v1` and `schema_version: 1`. The base
 shape is:
 


### PR DESCRIPTION
Closes the functional half of #905. I audited that issue per-criterion before writing anything, because this repo's issues routinely outlive the work — and here most of it *had* landed. What hadn't was load-bearing.

## The bug

`AuditSink::emit` had **zero production callers**. Grepping `.emit(` across every crate outside `audit_writer.rs` returned nothing; its only callers were that file's own unit tests. Meanwhile `ZccacheService` holds the sink, starts it, forwards `flush` to it, and drains it on shutdown.

So a host that configured `audit.jsonl` got a file that was created, rotated, flushed, GC'd — and always empty. Every mechanism worked except the one that puts data in it.

`AuditContext` had the matching half. It's accepted on every `CompileRequest` and is a rich causal type (`run_id`, `build_id`, `trace_id`, `span_id`, `parent_span_id`, `command_id`, `compile_id`, `session_id`), but the only use was:

```rust
let compile_id = request.audit.compile_id.clone()
    .or_else(|| request.audit.command_id.clone())
    ...
```

echoed back in `CompileResponse`. Everything else was dropped — `EmbeddedCompileRequest` has no audit field at all. An in-tree comment at `daemon/server/embedded.rs:249` already concedes the consequence: *"the two sides can be cross-correlated by timestamp."*

## The fix

`compile.started`, `cache.hit`/`cache.miss`, `compile.finished` — all carrying the host's context and a shared `compile_id` so start and finish pair up.

`AuditMode::Off` makes `AuditSink::start` return `None`, so emission is one `Option` check on the default path. A failed emit is dropped, not propagated — losing an audit record must not fail a compile that otherwise succeeded, and `AuditSink` already owns backpressure policy and its own lost-event counter.

## My first cut was wrong, and the test caught it

I initially emitted `compile.finished` only on the success path. The unspawnable-compiler test came back with `["compile.started"]` and nothing else — because a spawn failure returns `Err` and early-returns straight past the finish emission.

An audit log with dangling starts can't be used to measure anything, and unfinished compiles are precisely what an operator goes looking for. `compile.finished` now fires on the error and cancellation paths too, carrying the error text. I'd rather report that I got it wrong on the first pass than quietly fix it, because it's the kind of asymmetry that survives review easily.

## What I deliberately did not do

No `cache.lookup` with the cache key, no `compiler.spawn`/`compiler.exit`, no depgraph events. The key is derived inside the engine and isn't visible at the service boundary; emitting those needs a field on `EmbeddedCompileRequest`. I'd rather emit nothing there than guess, so the design doc's status table now says **"Audit emission | Partial"** and names exactly what's missing — replacing a line that claimed the schema was "MVP landed" with emission as vague follow-up work.

Note the three `tests/audit-fixtures/embedded-*.jsonl` files are **not** the current schema — they use a nested `context`/`fields` shape with `timestamp_ms`, while `AuditEvent` serializes flat with `ts`. They're an aspirational soldr-side format that no test references. I left them alone rather than treat them as a spec they aren't; worth their own decision (adopt or delete).

## Also fixed

Two stale references in `embedded-service.md` that would send a reader to a file that doesn't exist:
- audit schema path — `crates/zccache/src/audit.rs` → `crates/zccache-audit/src/lib.rs` (moved by the #1018 crate split)
- the documented `AuditContext` — had `String` fields instead of `AuditId` and was missing `build_id`, `span_id`, `compile_id`

## Timestamps

`ts` is epoch nanoseconds as a decimal string. This crate has no date-time dependency, and CLAUDE.md's convention is nanoseconds internally with formatting at the display layer. The field is a `String` and the writer passes it through, so this doesn't change the schema — flagging it since the field doc says "normally RFC 3339".

## Evidence

- `zccache-daemon-core --features "test-support,daemon-entry" --lib` — **727 passed, 0 failed** (was 724; +3)
- `zccache --test embedded_service_test` — 2 passed, 0 failed
- `soldr cargo clippy --workspace --all-targets -- -D warnings` under `RUSTFLAGS="-D warnings"` — exit 0, 0 diagnostics
- `soldr cargo check -p zccache-daemon-core` (default features, no feature flags) — exit 0
- `soldr cargo fmt --all`

New tests: an audited compile writes events; events carry the host's `run_id`/`trace_id` and a paired `compile_id`; and `AuditMode::Off` creates no log at all.

## Remaining on #905 — I am not claiming this closes it

Per my audit, proposal items 1/2/3/4/7 and acceptance criteria A–E were already met on `main`. This PR lands item 5 (audit context propagation) for the compile path. Three things remain, and I'd rather leave the issue open than declare victory:

1. **Item 6 — structured event sink integration.** There is no host-implementable trait anywhere in the workspace; a host can only hand zccache a file path. If item 6 means "the host plugs in its own sink", that is genuinely unbuilt.
2. **`ServiceLimits::max_parallel_compiles` is inert.** Public, documented in the design doc, and read by nothing (one grep hit: its own declaration). Wiring it or deleting it changes the public API, so that's your call, not mine.
3. **`ShutdownMode::Force` is not a forced shutdown.** It differs from `Graceful` only in skipping the audit drain; `daemon.shutdown()` runs identically and in-flight compiles are not aborted. Callers wanting abort must use `ZccacheConfig::cancellation`. Either the name or the behavior should change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
