### PR TITLE
security(deploy): create private dirs with their DACL, not after (#1172)

### DIFF
--- a/crates/zccache-cli-core/src/cli/runtime/deploy.rs
+++ b/crates/zccache-cli-core/src/cli/runtime/deploy.rs
@@ -144,7 +144,14 @@ fn hash_file(path: &Path) -> std::io::Result<[u8; 32]> {
 /// errors when it cannot; the refusal is loud on both surfaces, because
 /// "someone else can write your daemon's directory" is not a detail to swallow.
 fn ensure_deploy_dir_private(dir: &Path) -> std::io::Result<()> {
-    std::fs::create_dir_all(dir)?;
+    // Create with the owner-only descriptor already applied rather than
+    // `create_dir_all` + tighten. The two-step shape left the directory live
+    // with the inherited ACL in between, which is exactly the exposure this
+    // function exists to remove — harmless under `%USERPROFILE%`, but real for
+    // a `ZCCACHE_CACHE_DIR` relocated somewhere that hands down
+    // `BUILTIN\Users:(OI)(CI)(M)`. `ensure_dir_private` below still runs: it
+    // is the repair path for directories that already existed.
+    crate::core::config::create_dir_all_private(dir)?;
     match crate::core::config::ensure_dir_private(dir) {
         Ok(false) => Ok(()),
         Ok(true) => {
@@ -260,7 +267,11 @@ const DAEMON_SPAWN_LOGS_SUBDIR: &str = "logs";
 /// `Stdio::null` after warning.
 fn allocate_daemon_spawn_log_path() -> std::path::PathBuf {
     let dir = crate::core::config::daemon_state_dir().join(DAEMON_SPAWN_LOGS_SUBDIR);
-    let _ = std::fs::create_dir_all(dir.as_path());
+    // Private creation, not plain `create_dir_all`: log GC runs before
+    // `materialize_daemon_exe`, so on a cold cache this can be what first
+    // creates `daemon_state_dir` itself — ahead of the deploy directory's own
+    // tightening pass.
+    let _ = crate::core::config::create_dir_all_private(dir.as_path());
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos() as u64)

--- a/crates/zccache-core/Cargo.toml
+++ b/crates/zccache-core/Cargo.toml
@@ -27,6 +27,9 @@ windows-sys = { version = "0.59", features = [
     # #1172 F1e: Get/SetNamedSecurityInfoW + the SDDL converters used to put an
     # owner-only DACL on the daemon deploy directory.
     "Win32_Security_Authorization",
+    # #1172 residual: CreateDirectoryW, so the deploy directory is born with
+    # its owner-only DACL instead of being tightened after the fact.
+    "Win32_Storage_FileSystem",
     "Win32_System_Threading",
 ] }
 

--- a/crates/zccache-core/src/config/paths.rs
+++ b/crates/zccache-core/src/config/paths.rs
@@ -34,8 +34,10 @@ use crate::NormalizedPath;
 /// is not this function's call to make. Detecting and reporting an
 /// already-loose directory is #1171 item 4.
 ///
-/// On Windows this is exactly `create_dir_all`: directories are tightened by
-/// [`ensure_dir_private`] instead, which writes an explicit DACL (#1172 F1e).
+/// On Windows the owner-only DACL is supplied to `CreateDirectoryW` at
+/// creation time, so — as on unix — the directory is never briefly visible
+/// with a wider ACL (#1172 F1e and its residual). [`ensure_dir_private`]
+/// remains the repair path for directories that already exist.
 ///
 /// Ensure an existing directory is not group- or other-writable, tightening
 /// it in place if it is (#1171 item 4).
@@ -133,7 +135,16 @@ pub fn create_dir_all_private(path: &std::path::Path) -> std::io::Result<()> {
             .mode(0o700)
             .create(path)
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        // #1172 residual: this used to be a bare `create_dir_all`, leaving the
+        // directory live with the inherited ACL until `ensure_dir_private`
+        // tightened it. The descriptor now goes to `CreateDirectoryW` in
+        // `SECURITY_ATTRIBUTES`, matching what `mode(0o700)` gives the unix
+        // arm — the directory is never observable with any other DACL.
+        super::win_acl::create_dir_all_private(path)
+    }
+    #[cfg(not(any(unix, windows)))]
     {
         std::fs::create_dir_all(path)
     }

--- a/crates/zccache-core/src/config/win_acl.rs
+++ b/crates/zccache-core/src/config/win_acl.rs
@@ -49,8 +49,9 @@ use windows_sys::Win32::Security::Authorization::{
 use windows_sys::Win32::Security::{
     EqualSid, GetSecurityDescriptorDacl, GetTokenInformation, TokenUser, ACL,
     DACL_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR,
-    TOKEN_QUERY, TOKEN_USER,
+    SECURITY_ATTRIBUTES, TOKEN_QUERY, TOKEN_USER,
 };
+use windows_sys::Win32::Storage::FileSystem::CreateDirectoryW;
 use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
 /// Inheritance flags on every ACE we write: `OBJECT_INHERIT` +
@@ -113,6 +114,88 @@ pub(super) fn ensure_dir_private(path: &Path) -> io::Result<bool> {
         ));
     }
     Ok(true)
+}
+
+/// Create `path` with the owner-only DACL already on it, creating any missing
+/// parents the same way.
+///
+/// #1172 residual: `ensure_dir_private` can only tighten a directory that
+/// already exists, so every caller had the shape "create with whatever the
+/// parent hands down, then fix it". Between those two steps the directory is
+/// live with the inherited ACL. Under `%USERPROFILE%` that inheritance is
+/// already narrow and the window is harmless, but the relocated-root case this
+/// module exists for (`ZCCACHE_CACHE_DIR` on `C:\ProgramData\…` or a volume
+/// root) inherits `BUILTIN\Users:(OI)(CI)(M)` — and there another local user
+/// can win the race and populate the directory the daemon binary is about to
+/// be deployed into.
+///
+/// The unix arm never had this gap: `DirBuilder::mode(0o700)` passes the mode
+/// to `mkdir(2)` itself, so no directory is ever briefly group-writable. This
+/// is the Windows equivalent — the descriptor goes to `CreateDirectoryW` in
+/// `SECURITY_ATTRIBUTES`, so the directory is never visible with any other
+/// DACL.
+///
+/// Already-existing directories are left to `ensure_dir_private`: this only
+/// closes the window for directories *it* creates. `Ok(())` when the path
+/// exists as a directory already, so it composes like `create_dir_all`.
+pub(super) fn create_dir_all_private(path: &Path) -> io::Result<()> {
+    if path.is_dir() {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            create_dir_all_private(parent)?;
+        }
+    }
+    let user_sid = current_user_sid()?;
+    match create_dir_with_dacl(path, &owner_only_sddl(&user_sid)) {
+        Ok(()) => Ok(()),
+        // Lost a benign race with another zccache process creating the same
+        // directory. The winner applied the same descriptor, so this is a
+        // success, not a retry.
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists && path.is_dir() => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// `CreateDirectoryW` with `sddl` supplied at creation time.
+fn create_dir_with_dacl(path: &Path, sddl: &str) -> io::Result<()> {
+    let wide_sddl: Vec<u16> = sddl.encode_utf16().chain(std::iter::once(0)).collect();
+    let mut descriptor: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+    // SAFETY: `wide_sddl` is NUL-terminated and outlives the call; on success
+    // Windows allocates `descriptor`, released below.
+    let ok = unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            wide_sddl.as_ptr(),
+            SDDL_REVISION_1,
+            &mut descriptor,
+            std::ptr::null_mut(),
+        )
+    };
+    if ok == 0 || descriptor.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+
+    let attributes = SECURITY_ATTRIBUTES {
+        nLength: u32::try_from(std::mem::size_of::<SECURITY_ATTRIBUTES>()).unwrap_or(0),
+        lpSecurityDescriptor: descriptor.cast(),
+        bInheritHandle: 0,
+    };
+    let wide_path = wide(path);
+    // SAFETY: `wide_path` is NUL-terminated and `attributes` borrows the live
+    // descriptor freed below. The kernel copies the descriptor into the new
+    // object, so releasing ours afterwards is sound.
+    let created = unsafe { CreateDirectoryW(wide_path.as_ptr(), &attributes) };
+    let result = if created == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    };
+
+    // SAFETY: `descriptor` came from the SDDL conversion above and is freed
+    // exactly once, after the last use of `attributes`.
+    unsafe { LocalFree(descriptor as HLOCAL) };
+    result
 }
 
 /// The protected owner-only DACL written to an exposed directory.
@@ -516,6 +599,86 @@ mod tests {
         assert!(
             !is_owner_only("D:PAI(A;OICI;FA;;;WD)(A;OICI;FA;;;SY)", "S-1-5-18"),
             "Everyone must not be accepted just because SYSTEM is also listed"
+        );
+    }
+
+    /// The whole point of the residual fix: the directory must be owner-only
+    /// *at birth*, not tightened afterwards.
+    ///
+    /// This is also the empirical check that `SE_DACL_PROTECTED` survives
+    /// `CreateDirectoryW`. `D:P` in an SDDL sets the control bit on the
+    /// converted descriptor, but whether the kernel honors it through
+    /// `SECURITY_ATTRIBUTES` is not something the docs promise — and if it
+    /// does not, `is_owner_only` rejects the result (it requires `P`) and this
+    /// fails. A fix that quietly degraded to "created wide, tightened later"
+    /// would be worse than none, because it would look closed.
+    #[test]
+    fn a_freshly_created_dir_is_owner_only_without_a_tighten_pass() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = temp.path().join("deploy");
+
+        create_dir_all_private(&dir).unwrap();
+
+        let user_sid = current_user_sid().unwrap();
+        let sddl = dacl_sddl(&dir).unwrap();
+        assert!(
+            is_owner_only(&sddl, &user_sid),
+            "a directory created by create_dir_all_private must already be \
+             owner-only and protected; got {sddl}"
+        );
+        assert!(
+            !sddl.contains(";BU)"),
+            "BUILTIN\\Users must never appear on the deploy directory: {sddl}"
+        );
+        // Nothing left for the tighten pass to do — `Ok(false)` is
+        // "was already private".
+        assert!(
+            !ensure_dir_private(&dir).unwrap(),
+            "a directory born private must not need tightening"
+        );
+    }
+
+    /// Intermediate parents are created by the same path, so the window is not
+    /// simply moved up one level. A `v<VERSION>` dir born private under a
+    /// briefly-wide cache root would still be exposed through its parent.
+    #[test]
+    fn intermediate_parents_are_created_private_too() {
+        let temp = tempfile::tempdir().unwrap();
+        let leaf = temp.path().join("root").join("v1.2.3").join("nested");
+
+        create_dir_all_private(&leaf).unwrap();
+
+        let user_sid = current_user_sid().unwrap();
+        for dir in [
+            temp.path().join("root"),
+            temp.path().join("root").join("v1.2.3"),
+            leaf,
+        ] {
+            let sddl = dacl_sddl(&dir).unwrap();
+            assert!(
+                is_owner_only(&sddl, &user_sid),
+                "every level must be created private, {} was not: {sddl}",
+                dir.display()
+            );
+        }
+    }
+
+    /// Composes like `create_dir_all`: an existing directory is a no-op, not
+    /// an error, and its DACL is left for `ensure_dir_private` to judge.
+    #[test]
+    fn an_existing_directory_is_accepted_and_left_alone() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = temp.path().join("already-here");
+        std::fs::create_dir(&dir).unwrap();
+        let before = dacl_sddl(&dir).unwrap();
+
+        create_dir_all_private(&dir).unwrap();
+
+        assert_eq!(
+            dacl_sddl(&dir).unwrap(),
+            before,
+            "an existing directory must not be silently re-permissioned here; \
+             tightening is ensure_dir_private's job and it reports what it did"
         );
     }
 }


### PR DESCRIPTION
Closes the residual I flagged when auditing #1172: *"`create_dir_all_private` is still a plain `create_dir_all` on Windows, so a freshly created deploy directory has a narrow window between creation and the DACL write."*

## The asymmetry

Unix is atomic — `DirBuilder::new().recursive(true).mode(0o700)` passes the mode to `mkdir(2)`, so no directory is ever briefly group-writable. `crates/zccache-core/src/config/tests.rs:325` asserts that for every level including intermediate parents.

Windows had no equivalent seam in `std`, so the shape was create-then-tighten. And the deploy directory did not even use that helper — `ensure_deploy_dir_private` called `std::fs::create_dir_all` directly (`deploy.rs:147`) and tightened on the next line. `ensure_dir_private` also *reads* the DACL before writing, widening the gap by two more Win32 round-trips.

## Being precise about severity — this is mostly hardening

I checked rather than assuming, and the honest answer is narrower than "attacker replaces your daemon binary":

- Under the default `%USERPROFILE%\.zccache` root, the inherited DACL is already `SY` / `BA` / the user. The transient ACL grants no third party anything, so **the window is harmless there**. The module header already says as much.
- It is a real exposure only in the relocated-root case this module was written for — `ZCCACHE_CACHE_DIR` pointed at `C:\ProgramData\…`, `C:\zccache`, or a volume root, which inherit `BUILTIN\Users:(OI)(CI)(M)` or `CREATOR OWNER`.
- Even there, the content-hash gate at `deploy.rs:205` means a planted **wrong-content** file gets overwritten by the tmp+rename rather than executed. The realistic exploit is directory-level — planting a junction/reparse point, or winning the create of a parent segment so the later `SetNamedSecurityInfoW` retargets — not simple binary substitution.

So: a real gap in a security boundary, worth closing because it is cheap and because the unix side already had it, but not a live RCE in the default configuration. I would rather say that than dress it up.

## The fix

`create_dir_with_dacl` passes the owner-only descriptor to `CreateDirectoryW` in `SECURITY_ATTRIBUTES`, so the directory is never observable with any other DACL. `create_dir_all_private`'s Windows arm now uses it, creating intermediate parents the same way — otherwise the window just moves up a level, and a `v<VERSION>` dir born private under a briefly-wide root is still reachable through its parent.

An existing directory is a no-op that leaves the DACL alone, so it still composes like `create_dir_all` and tightening stays `ensure_dir_private`'s job (which reports what it did).

## I verified the mechanism before building on it

The audit flagged a caveat that decided whether this approach was viable at all: **`SE_DACL_PROTECTED` surviving `SECURITY_ATTRIBUTES` is not documented behavior.** `D:P` in an SDDL sets the control bit on the converted descriptor, but whether the kernel honors it through `CreateDirectoryW` is not promised. If it did not, the read-back would report "not protected", `ensure_dir_private` would tighten anyway, and the fix would be **cosmetic while looking closed** — the worst outcome.

So the test drives the real creation path and reads the DACL back, asserting `is_owner_only`, which requires the `P` bit. It passes on Windows, which settles it empirically. It also asserts the following `ensure_dir_private` returns `false` — nothing left to tighten.

The three new tests were the first ones in this module to exercise a *creation* path; every pre-existing test creates the directory with plain `std::fs::create_dir` and then exercises the tighten path.

## One more site

`allocate_daemon_spawn_log_path` used plain `create_dir_all` for `<daemon_state_dir>/logs/`. Log GC runs before `materialize_daemon_exe`, so on a cold cache that call can be what first creates `daemon_state_dir` itself — ahead of the deploy directory's tightening pass. Now routed through the same helper.

The two `zccache-ipc` sites (`write_lock_file`, `write_backend_identity`) already called `create_dir_all_private` and create that same directory, so they pick this up for free — previously they were creating the daemon state dir on Windows with no ACL handling at all.

## Evidence

- `zccache-core --lib` — **129 passed, 0 failed** (+3)
- `zccache-cli-core --features cli --lib` — 246 passed, 0 failed
- `zccache-ipc --lib` — 53 passed, 0 failed
- `soldr cargo clippy --workspace --all-targets -- -D warnings` under `RUSTFLAGS="-D warnings"` — exit 0, 0 diagnostics
- `soldr cargo check -p zccache-core --target x86_64-unknown-linux-gnu` — exit 0. This is a Windows-only change, so I cross-checked the non-Windows arms rather than waiting for CI to tell me: the `#[cfg(not(unix))]` arm became `#[cfg(windows)]` + `#[cfg(not(any(unix, windows)))]`.
- `soldr cargo fmt --all`

Adds `Win32_Storage_FileSystem` to `zccache-core`'s `windows-sys` features (`CreateDirectoryW`); `windows-sys 0.59` was already a dependency.

## Not covered

`ensure_deploy_dir_private` still has no end-to-end test — the new tests cover the creation primitive, not the deploy call site. And the relocated-root exploit path itself is untested; reproducing it needs a second local account, which is not something CI can stand up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
