### PR TITLE
fix(cli): send CLI diagnostics to stderr, not stdout

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/util.rs
+++ b/crates/zccache-cli-core/src/cli/commands/util.rs
@@ -164,8 +164,22 @@ pub(crate) fn format_bytes(bytes: u64) -> String {
     }
 }
 
+/// Install the CLI's tracing subscriber, writing diagnostics to **stderr**.
+///
+/// `tracing_subscriber::fmt()` defaults to stdout, which put every CLI
+/// `warn!` into the one stream that carries machine-readable output. The
+/// concrete failure: `zccache session-start` prints a JSON object on stdout
+/// and callers parse it, so a single warning (for example the
+/// `insecure_deploy_dir` notice, which fires the first time a version
+/// directory is seen) made that JSON unparseable. The wrapper is the more
+/// serious case — `zccache cc` / `c++` relay compiler stdout verbatim and
+/// that byte stream is public contract, so a diagnostic landing in it can
+/// corrupt output a build system consumes.
+///
+/// Diagnostics go to stderr; stdout carries only the command's result.
 pub(crate) fn init_tracing() {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),


### PR DESCRIPTION
`tracing_subscriber::fmt()` defaults to **stdout**, so every CLI `warn!` was emitted into the one stream that carries machine-readable output.

## How I found it

Auditing #1223's exit criteria, I found that the tests asserting the documented exit-125 daemon-unavailable contract are `#[ignore]`d **and CI never passes `--ignored`** — `.github/workflows/integration.yml:120` runs the suite without it; the only `--ignored` invocation there is `legacy_path_validation`. So that contract is verified nowhere.

I ran them locally. One fails on clean `main`:

```
session-start JSON: Error("expected value", line: 1, column: 1)
```

`zccache session-start` prints a JSON object on stdout and callers parse it. A single `insecure_deploy_dir` warning — which fires the first time a version directory is seen — prepended a tracing line to stdout and made it unparseable.

## Why this matters beyond one test

The wrapper is the worse case. `zccache cc` / `c++` relay compiler stdout verbatim, and CLAUDE.md calls that byte stream stable public surface — it is how soldr routes `cc-rs` build-script work. A diagnostic landing in stdout during a wrapper run can corrupt output a build system consumes. The failing test is the cheap symptom; that is the expensive one.

Diagnostics go to stderr; stdout carries only the command's result.

## Verification

Confirmed by observation, not inference. Before the fix, `zccache session-start` wrote 413 bytes of ANSI-coloured tracing output to **stdout**, with the JSON absent. After it, that line appears on stderr and the JSON-parse failure is gone — the test proceeds past line 233.

## What this does NOT fix, stated plainly

That test still fails, for a **different, pre-existing reason** which I am reporting separately rather than folding in here. The spawned daemon logs:

```
resolved daemon cache state daemon_namespace=default mutable_state_dir=C:\Users\niteris\.zccache\v1.13.0
WARN cache root already has a live writer; refusing to start a second one pid=61296
ERROR failed to bind …: another live daemon already holds this cache root as its writer
```

The test sets `ZCCACHE_CACHE_DIR` to a tempdir. The CLI honours it (the deploy directory is under the tempdir), but the spawned daemon resolves `daemon_state_dir()` to the **default** `~/.zccache/v1.13.0` and collides with whatever daemon is already live there. The mechanism looks like the sanitized spawn: `running_process::spawn_daemon` rebuilds the environment block and lineage vars are re-added explicitly via `cmd.env(...)`, but `ZCCACHE_CACHE_DIR` is not among them.

I have not touched that. Whether the sanitizer should forward the cache root, or the daemon should learn it another way, is a design call — and the sanitization is presumably deliberate.

## Evidence

- `zccache-cli-core --features cli --lib` — 246 passed, 0 failed
- `soldr cargo clippy -p zccache-cli-core --features cli --all-targets -- -D warnings` under `RUSTFLAGS="-D warnings"` — exit 0
- `cli_wrapper_failure_boundaries -- --ignored` — `ephemeral_pre_dispatch_failure_is_a_hard_error_with_the_infra_exit_code` **passes**; the session test's JSON failure is resolved and it now fails only on the daemon-collision above
- `soldr cargo fmt --all`

## No test added, deliberately

Asserting "no tracing output on stdout" needs a subscriber installed in-process, and `init_tracing` uses the global `.init()` — a unit test would be asserting on global state that other tests in the same binary share. The honest coverage is the integration test that already exists and now gets further; making it actually run in CI is the real gap, and it is blocked on the cache-root issue above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
