### PR TITLE
test(daemon): cover the compile-progress heartbeat emitter (#1223)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/connection/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/connection/mod.rs
@@ -16,6 +16,8 @@ use crate::protocol::{
 
 mod attribution;
 mod dispatch;
+#[cfg(test)]
+mod tests;
 
 #[cfg(test)]
 pub(in crate::daemon::server) use attribution::redacted_args_preview;
@@ -125,7 +127,14 @@ where
 
 /// Resolve the heartbeat interval, or `None` when heartbeats are disabled.
 fn compile_progress_interval() -> Option<std::time::Duration> {
-    let Some(raw) = std::env::var(COMPILE_PROGRESS_INTERVAL_ENV).ok() else {
+    compile_progress_interval_from(std::env::var(COMPILE_PROGRESS_INTERVAL_ENV).ok().as_deref())
+}
+
+/// The env-var parse, taking the raw value rather than reading the process
+/// environment, so it is testable without mutating global state that every
+/// other test in this binary shares.
+fn compile_progress_interval_from(raw: Option<&str>) -> Option<std::time::Duration> {
+    let Some(raw) = raw else {
         return Some(COMPILE_PROGRESS_INTERVAL);
     };
     match raw.trim().parse::<u64>() {
@@ -182,7 +191,32 @@ async fn guarded_dispatch_with_progress<F>(
 where
     F: std::future::Future<Output = (Response, Option<PendingJournalContext>)>,
 {
-    let Some(interval) = compile_progress_interval() else {
+    guarded_dispatch_with_progress_every(
+        compile_progress_interval(),
+        conn,
+        response_wire,
+        state,
+        handler,
+    )
+    .await
+}
+
+/// [`guarded_dispatch_with_progress`] with the cadence supplied by the caller.
+///
+/// Split out so a test can drive the heartbeat loop on a millisecond cadence
+/// without setting a process-global env var that every other test in this
+/// binary would race against.
+async fn guarded_dispatch_with_progress_every<F>(
+    interval: Option<std::time::Duration>,
+    conn: &mut IpcConnection,
+    response_wire: &ResponseWire,
+    state: &SharedState,
+    handler: F,
+) -> Option<(Response, Option<PendingJournalContext>)>
+where
+    F: std::future::Future<Output = (Response, Option<PendingJournalContext>)>,
+{
+    let Some(interval) = interval else {
         return guarded_dispatch(conn, handler).await;
     };
     let slot = Arc::new(super::compile_progress::CompileProgressSlot::default());

--- a/crates/zccache-daemon-core/src/daemon/server/connection/tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/connection/tests.rs
@@ -1,0 +1,172 @@
+//! Coverage for the compile-progress heartbeat emitter (#1216 / #1223).
+//!
+//! `guarded_dispatch_with_progress` is the only code that puts a
+//! `CompileProgress` frame onto a real connection, and it had no tests at
+//! all — `connection/` had no test module. The gauge arithmetic in
+//! `compile_progress.rs` and the client-side receive loop in
+//! `wrap/ipc.rs` were both well covered, so the *ends* were tested and the
+//! wire between them was not.
+//!
+//! These tests drive the real loop over a real `IpcConnection` pair and
+//! assert the frames arrive, then that the terminal response still lands.
+
+use super::*;
+use crate::protocol::{Request, Response};
+
+/// A handler future standing in for a compile that takes long enough to be
+/// worth reporting on. Returns a terminal response the caller can identify.
+async fn slow_handler(duration: std::time::Duration) -> (Response, Option<PendingJournalContext>) {
+    tokio::time::sleep(duration).await;
+    (Response::Pong, None)
+}
+
+#[test]
+fn an_unset_interval_uses_the_default_cadence() {
+    assert_eq!(
+        compile_progress_interval_from(None),
+        Some(COMPILE_PROGRESS_INTERVAL)
+    );
+}
+
+#[test]
+fn zero_disables_heartbeats_entirely() {
+    assert_eq!(
+        compile_progress_interval_from(Some("0")),
+        None,
+        "0 is the documented kill switch; it must not fall back to the default"
+    );
+}
+
+#[test]
+fn an_explicit_interval_is_honored_and_whitespace_tolerated() {
+    assert_eq!(
+        compile_progress_interval_from(Some("250")),
+        Some(std::time::Duration::from_millis(250))
+    );
+    assert_eq!(
+        compile_progress_interval_from(Some("  250  ")),
+        Some(std::time::Duration::from_millis(250))
+    );
+}
+
+#[test]
+fn an_unparseable_interval_falls_back_rather_than_disabling() {
+    // The dangerous failure mode is silently disabling heartbeats on a
+    // typo, which would look exactly like a wedged daemon to the client.
+    assert_eq!(
+        compile_progress_interval_from(Some("soon")),
+        Some(COMPILE_PROGRESS_INTERVAL)
+    );
+    assert_eq!(
+        compile_progress_interval_from(Some("")),
+        Some(COMPILE_PROGRESS_INTERVAL)
+    );
+}
+
+/// The end-to-end shape criterion B of #1223 asks for: a compile that does
+/// not finish promptly must push progress frames to the waiting client, and
+/// the terminal response must still arrive afterwards.
+#[tokio::test]
+async fn a_slow_compile_pushes_progress_frames_then_the_terminal_response() {
+    let temp = tempfile::tempdir().expect("temp cache root");
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let server = super::super::tests::bind_isolated_server_at(&endpoint, temp.path());
+
+    let mut server = server;
+    let client_endpoint = endpoint.clone();
+    let client = tokio::spawn(async move {
+        let mut client = crate::ipc::connect(&client_endpoint)
+            .await
+            .expect("client connects");
+        client.send(&Request::Ping).await.expect("client sends");
+        let mut progress_frames = 0_usize;
+        loop {
+            match client.recv::<Response>().await.expect("client receives") {
+                Some(Response::CompileProgress { .. }) => progress_frames += 1,
+                Some(terminal) => return (progress_frames, terminal),
+                None => panic!("connection closed before a terminal response"),
+            }
+        }
+    });
+
+    let mut conn = server.listener.accept().await.expect("server accepts");
+    let _ = conn.recv::<Request>().await.expect("server reads request");
+
+    let outcome = guarded_dispatch_with_progress_every(
+        // Fast cadence supplied directly. Reading it from the environment
+        // would race every other test in this binary.
+        Some(std::time::Duration::from_millis(40)),
+        &mut conn,
+        &ResponseWire::BincodeV15,
+        &server.state,
+        slow_handler(std::time::Duration::from_millis(260)),
+    )
+    .await;
+
+    let (response, _journal) = outcome.expect("handler completes rather than disconnecting");
+    super::send_response_for_wire(&mut conn, &ResponseWire::BincodeV15, &response)
+        .await
+        .expect("terminal response is written");
+
+    let (progress_frames, terminal) = client.await.expect("client task");
+    assert!(
+        progress_frames >= 1,
+        "a compile outliving the heartbeat interval must push at least one \
+         CompileProgress frame; got {progress_frames}"
+    );
+    assert_eq!(
+        terminal,
+        Response::Pong,
+        "progress frames must not replace or corrupt the terminal response"
+    );
+}
+
+/// The documented kill switch has to actually switch off, and the compile
+/// must still complete.
+#[tokio::test]
+async fn a_disabled_interval_pushes_no_frames_but_still_completes() {
+    let temp = tempfile::tempdir().expect("temp cache root");
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let server = super::super::tests::bind_isolated_server_at(&endpoint, temp.path());
+
+    let mut server = server;
+    let client_endpoint = endpoint.clone();
+    let client = tokio::spawn(async move {
+        let mut client = crate::ipc::connect(&client_endpoint)
+            .await
+            .expect("client connects");
+        client.send(&Request::Ping).await.expect("client sends");
+        let mut progress_frames = 0_usize;
+        loop {
+            match client.recv::<Response>().await.expect("client receives") {
+                Some(Response::CompileProgress { .. }) => progress_frames += 1,
+                Some(terminal) => return (progress_frames, terminal),
+                None => panic!("connection closed before a terminal response"),
+            }
+        }
+    });
+
+    let mut conn = server.listener.accept().await.expect("server accepts");
+    let _ = conn.recv::<Request>().await.expect("server reads request");
+
+    let outcome = guarded_dispatch_with_progress_every(
+        None,
+        &mut conn,
+        &ResponseWire::BincodeV15,
+        &server.state,
+        slow_handler(std::time::Duration::from_millis(120)),
+    )
+    .await;
+
+    let (response, _journal) = outcome.expect("handler completes");
+    super::send_response_for_wire(&mut conn, &ResponseWire::BincodeV15, &response)
+        .await
+        .expect("terminal response is written");
+
+    let (progress_frames, terminal) = client.await.expect("client task");
+    assert_eq!(
+        progress_frames, 0,
+        "a disabled interval must emit nothing at all"
+    );
+    assert_eq!(terminal, Response::Pong);
+}


### PR DESCRIPTION
Closes the one item from my #1223 exit-criteria audit that was unblocked today: criterion B was **uncovered end-to-end**.

## The gap

`guarded_dispatch_with_progress` (`connection/mod.rs:176`) is the only code that puts a `CompileProgress` frame onto a connection, and it had **no tests at all** — `connection/` had no test module.

What made this easy to miss is that both *ends* were well covered:
- daemon-side gauge arithmetic and position/phase semantics — 6 tests in `compile_progress.rs`
- client-side receive loop including wedge-budget reset — 4 tests in `wrap/ipc.rs`
- prost roundtrip of one synthetic frame

The wire between them was not. `compile_progress_interval()` and its env parsing were also untested, and nothing in the repo sets that env var outside the source.

## Injecting the cadence rather than setting an env var

Splits `guarded_dispatch_with_progress_every(interval, ..)` out of the env-reading wrapper, and `compile_progress_interval_from(raw)` out of `compile_progress_interval()`.

Both follow the crate's existing `resolve_pool_with_env` shape. The alternative — setting `ZCCACHE_COMPILE_PROGRESS_INTERVAL_MS` inside a test — mutates a process-global that every other test in the same binary shares, which is precisely the kind of cross-test env leak that produces flakes nobody can reproduce.

## The end-to-end test

Real `IpcListener` + `connect` pair, real frames on a real connection. It asserts progress frames arrive *and* that the terminal response still lands intact afterwards — a heartbeat that corrupted or replaced the terminal response would be worse than no heartbeat.

**No compiler required.** The handler is just a future, so a `tokio::time::sleep` stands in for a slow compile. That keeps it a fast, dependency-free unit test rather than an `#[ignore]`d integration test that never runs (see #1317 for why that distinction matters here).

## Verified it discriminates

Same check I have been applying since deleting a non-discriminating timing test earlier in this backlog. With the heartbeat send stubbed out:

```
a compile outliving the heartbeat interval must push at least one CompileProgress frame; got 0
```

Restored, it passes.

## The parsing tests, and the one that matters

`0` is the documented kill switch and must not fall back to the default. But the more valuable assertion is that an **unparseable** value falls back rather than disabling: silently emitting nothing on a typo would look exactly like a wedged daemon to the client, which is the failure mode #1216 exists to prevent.

## Not covered, stated plainly

This covers the **emitter**, not the semaphore. Nothing yet saturates the real compile-concurrency gate with concurrent requests and watches a queued compile report a shrinking position. That needs `ZCCACHE_MAX_PARALLEL_COMPILES=1` plus two real compiles, so it wants a real compiler and belongs with the integration tests.

Relatedly, `crates/zccache/tests/compile_concurrency_gating.rs` still reads as coverage it does not provide — it constructs a local `tokio::sync::Semaphore` and touches no zccache code. Its header is honest about this; its name and location are not. Flagged on #1223.

## Evidence

- `zccache-daemon-core --features "test-support,daemon-entry" --lib` — **733 passed, 0 failed** (was 727; +6)
- `soldr cargo clippy --workspace --all-targets -- -D warnings` under `RUSTFLAGS="-D warnings"` — exit 0, 0 diagnostics
- `soldr cargo fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

