### PR TITLE
ci: run the exit-125 daemon-unavailable contract tests (#1317)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -148,10 +148,13 @@ jobs:
         shell: bash
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/integration
-          # These tests spawn the wrapper binary and assert its real process
-          # exit code, so they own their own tempdir caches and their journals
-          # are build orchestration rather than the runtime this job audits.
-          ZCCACHE_DISABLE: "1"
+          # Deliberately NO `ZCCACHE_DISABLE` here. The adjacent
+          # artifact-layout step sets it for journal hygiene, and copying that
+          # across is what made the first version of this step fail: the
+          # wrapper honours the bypass before any endpoint resolution, so both
+          # tests ran the tool and mirrored its exit code (7) instead of
+          # refusing with 125. A step that verifies "no silent bypass exists"
+          # must not set the bypass. The tests now also strip it themselves.
         run: |
           # #1317: these are #[ignore]d (they launch the wrapper binary), and
           # the main run above does not pass --ignored, so the exit-125

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -144,6 +144,27 @@ jobs:
           if [[ -d "$journal_root" ]]; then
             find "$journal_root" -type f -path '*/logs/*.jsonl' -print -delete
           fi
+      - name: Wrapper daemon-unavailable contract (exit 125)
+        shell: bash
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/integration
+          # These tests spawn the wrapper binary and assert its real process
+          # exit code, so they own their own tempdir caches and their journals
+          # are build orchestration rather than the runtime this job audits.
+          ZCCACHE_DISABLE: "1"
+        run: |
+          # #1317: these are #[ignore]d (they launch the wrapper binary), and
+          # the main run above does not pass --ignored, so the exit-125
+          # daemon-unavailable contract documented in CLAUDE.md was verified
+          # nowhere. They are the only end-to-end coverage of it: real binary,
+          # real exit code, the `zccache[err][D]:` stderr, exactly one durable
+          # `wrapper-daemon-unavailable` event, and no local-fallback event.
+          #
+          # Kept as its own step rather than folded into the main run so a
+          # failure here is legible on sight instead of buried in a
+          # workspace-wide log.
+          unset ZCCACHE_CACHE_DIR
+          soldr cargo test -p zccache --features "$ZCCACHE_INTEGRATION_FEATURES" --test cli_wrapper_failure_boundaries -- --ignored --test-threads=1
       - name: Strict artifact-layout validation
         shell: bash
         env:

--- a/crates/zccache/tests/cli_wrapper_failure_boundaries.rs
+++ b/crates/zccache/tests/cli_wrapper_failure_boundaries.rs
@@ -254,6 +254,18 @@ fn session_pre_dispatch_failure_refuses_without_double_reading_stdin() {
         "the session route must reach the same hard error as the ephemeral one"
     );
     assert_tool_never_ran(&output);
+    // #1317: the name promised a stdin property nothing checked — the
+    // distinctive payload was passed in and then ignored. The refusal path
+    // never replays stdin, so the marker must not surface on either stream;
+    // a wrapper that echoed or re-emitted what it slurped would show it here.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for (stream, text) in [("stdout", &stdout), ("stderr", &stderr)] {
+        assert!(
+            !text.contains("must-not-double-read"),
+            "refusal must not replay the stdin payload; {stream} carried it: {text}"
+        );
+    }
     assert_one_refusal(
         cache_dir.path(),
         "session_pre_dispatch_failure_refuses_without_double_reading_stdin",

--- a/crates/zccache/tests/cli_wrapper_failure_boundaries.rs
+++ b/crates/zccache/tests/cli_wrapper_failure_boundaries.rs
@@ -58,6 +58,24 @@ fn run_wrapper(
         .env("ZCCACHE_CACHE_DIR", cache_dir)
         .env("ZCCACHE_NO_SPAWN", "1")
         .env("ZCCACHE_DAEMON_WIRE", "bincode")
+        // These tests assert that the refusal contract holds. They must not
+        // inherit the sanctioned bypasses they exist to contrast against:
+        // `ZCCACHE_DISABLE` and `ZCCACHE_PROBE_BYPASS` both passthrough-exec
+        // the tool *before* any endpoint resolution, so an inherited one turns
+        // "refused with 125" into "ran the tool and mirrored its exit code"
+        // with no assertion able to tell the difference.
+        //
+        // This is not hypothetical: the CI step added for #1317 set
+        // `ZCCACHE_DISABLE=1` for journal hygiene, and both tests failed with
+        // `left: Some(7)` — the shim's own code. Reproduced on Windows by
+        // exporting the same variable, so it was never platform-specific.
+        //
+        // `ZCCACHE_ENDPOINT` is removed too: `resolve_endpoint` honours it
+        // *ahead of* the cache dir, so an inherited value would silently point
+        // these tests at a real daemon and defeat the tempdir isolation.
+        .env_remove("ZCCACHE_DISABLE")
+        .env_remove("ZCCACHE_PROBE_BYPASS")
+        .env_remove("ZCCACHE_ENDPOINT")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());


### PR DESCRIPTION
Closes #1317. Unblocked by #1320 — until that landed these tests could not pass on any host with a live daemon.

## The gap

CLAUDE.md calls this contract stable, load-bearing surface:

> **Daemon-unavailable is a hard error, exit code 125 (#1170).** […] deliberately outside the 1/2 a compiler uses for diagnostics, so CI can classify an infrastructure failure from the code alone.

The only end-to-end coverage of it — `cli_wrapper_failure_boundaries.rs` — is `#[ignore]`d, and `integration.yml`'s main run does not pass `--ignored`. The only `--ignored` invocation in that workflow is scoped to `legacy_path_validation`. So the contract was verified **nowhere on any push**.

Everything else that touches 125 is a constant assertion (`DAEMON_UNAVAILABLE_EXIT_CODE == 125`) or a direct call to `refuse_uncached_run` that never spawns a process and never checks the stderr or the lifecycle event.

## What the new step gates

Real binary, real process exit code `125`, the tool never ran, `zccache[err][D]:` on stderr, exactly one durable `wrapper-daemon-unavailable` event with `phase=="pre-dispatch"`, and no `wrapper-local-fallback` event.

Kept as its own step rather than folded into the main run: a failure is then legible on sight instead of buried in a workspace-wide log, and the main run keeps its current `--test-threads=1` semantics untouched.

## Making the session test's name true

`session_pre_dispatch_failure_refuses_without_double_reading_stdin` promised a stdin property and asserted **nothing** about stdin. A distinctive payload was passed in and then ignored.

It now asserts the marker does not surface on either stream, so a wrapper that echoed or replayed what it slurped fails the test. I chose this over renaming because the intent was worth keeping — the refusal path genuinely must not replay stdin, and the payload was already there waiting to be checked.

A name that promises coverage it does not have is worse than a plain one, because the next reader trusts it. That is the same failure mode as `compile_concurrency_gating.rs` (still open on #1223) and as the `#[ignore]` gap this PR closes: things that look like coverage and are not.

## Validation

- `cli_wrapper_failure_boundaries -- --ignored` on Windows — **2 passed, 0 failed**, including the new stdin assertion
- Workflow YAML parses, and the new step is ordered before `Strict artifact-layout validation`

**Caveat I want visible:** these tests have only ever been validated on **Windows**. This PR is the first time they run on a Linux runner. That is precisely why it is a separate PR from #1320 — if they turn out flaky or platform-dependent there, the failure is isolated to this change and diagnosable, rather than tangled with the env-forwarding fix.

If CI here goes red, the right read is "this test does not hold on Linux yet", not "the contract is broken" — and I will investigate rather than paper over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
