### PR TITLE
test(integration): bind the flow-test daemon to an isolated cache root (#1322)

### DIFF
--- a/crates/zccache/tests/cli_wrapper_failure_boundaries.rs
+++ b/crates/zccache/tests/cli_wrapper_failure_boundaries.rs
@@ -108,17 +108,49 @@ fn lifecycle_events(cache_dir: &Path) -> Vec<serde_json::Value> {
         .collect()
 }
 
-fn wait_for_daemon_shutdown(cache_dir: &Path) {
-    for _ in 0..80 {
-        if lifecycle_events(cache_dir)
-            .iter()
-            .any(|event| event["event"] == "died-shutdown")
+/// Wait until the daemon is genuinely unreachable, not merely until it said it
+/// was going away.
+///
+/// The `died-shutdown` lifecycle event is published *before* the listener
+/// stops accepting, so a wrapper run started on that signal alone can still
+/// connect, dispatch, and have the daemon run the tool — returning the tool's
+/// exit code (7) where the test demands the wrapper's refusal (125). Windows
+/// timing hid this; Linux CI failed on it intermittently.
+///
+/// So the event is the *first* gate and reachability is the second: `zccache
+/// status` exits non-zero once nothing answers the endpoint, which is the
+/// property the refusal contract actually depends on.
+fn wait_for_daemon_shutdown(zccache: &Path, cache_dir: &Path) {
+    let mut saw_event = false;
+    for _ in 0..200 {
+        if !saw_event
+            && lifecycle_events(cache_dir)
+                .iter()
+                .any(|event| event["event"] == "died-shutdown")
         {
+            saw_event = true;
+        }
+        if saw_event && !daemon_answers(zccache, cache_dir) {
             return;
         }
         std::thread::sleep(Duration::from_millis(25));
     }
-    panic!("daemon did not publish died-shutdown within the test deadline");
+    panic!(
+        "daemon still reachable after publishing died-shutdown (saw_event={saw_event}) \
+         within the test deadline"
+    );
+}
+
+/// Does anything still answer on this cache dir's endpoint?
+fn daemon_answers(zccache: &Path, cache_dir: &Path) -> bool {
+    Command::new(zccache)
+        .arg("status")
+        .env("ZCCACHE_CACHE_DIR", cache_dir)
+        .env("ZCCACHE_NO_SPAWN", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
 }
 
 /// The wrapper-infrastructure exit code from #1170. Kept as a literal here
@@ -254,7 +286,7 @@ fn session_pre_dispatch_failure_refuses_without_double_reading_stdin() {
         .expect("session id")
         .to_string();
     stop_daemon(&zccache, cache_dir.path());
-    wait_for_daemon_shutdown(cache_dir.path());
+    wait_for_daemon_shutdown(&zccache, cache_dir.path());
 
     let payload = b"session-refusal-stdin\0must-not-double-read\n";
     let output = run_wrapper(

--- a/crates/zccache/tests/daemon_cli_flow_test.rs
+++ b/crates/zccache/tests/daemon_cli_flow_test.rs
@@ -57,13 +57,29 @@ fn parse_session_id_from_json(json: &str) -> String {
     rest[..end].trim().trim_matches('"').to_string()
 }
 
-async fn start_daemon() -> (
+/// Start a daemon rooted at an isolated cache directory under `cache_root`.
+///
+/// `DaemonServer::bind` resolves the *process-global* cache root, so every
+/// test using it contends with whatever daemon is already live on the
+/// developer's (or runner's) default root — failing with "another live daemon
+/// already holds this cache root as its writer", or, if it wins the race,
+/// writing its logs somewhere the test does not look. `lifecycle.rs` says so
+/// directly: everything outside the env guard "should bind an isolated root
+/// ... which needs no global state at all and therefore cannot participate in
+/// the race".
+///
+/// The caller already owns a tempdir, so rooting the daemon in it costs
+/// nothing and makes the test independent of ambient machine state.
+async fn start_daemon(
+    cache_root: &std::path::Path,
+) -> (
     String,
     tokio::task::JoinHandle<()>,
     std::sync::Arc<tokio::sync::Notify>,
 ) {
     let endpoint = zccache::ipc::unique_test_endpoint();
-    let mut server = DaemonServer::bind(&endpoint).unwrap();
+    let cache_dir: zccache::core::NormalizedPath = cache_root.join("zccache-cache").into();
+    let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
     let shutdown = server.shutdown_handle();
     let handle = tokio::spawn(async move {
         server.run(0).await.unwrap();
@@ -90,7 +106,7 @@ async fn cli_binary_session_round_trip() {
 
         std::fs::write(&src, "int main() { return 0; }\n").unwrap();
 
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown) = start_daemon(tmp.path()).await;
 
         assert!(
             cli_binary.exists(),
@@ -199,7 +215,7 @@ async fn cli_binary_ephemeral_session() {
 
         std::fs::write(&src, "int main() { return 0; }\n").unwrap();
 
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown) = start_daemon(tmp.path()).await;
 
         let clang_str = clang.to_string_lossy().into_owned();
         let src_str = src.to_string_lossy().into_owned();
@@ -285,7 +301,7 @@ async fn cli_binary_compiler_override_cpp_session_c_file() {
         )
         .unwrap();
 
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown) = start_daemon(tmp.path()).await;
 
         // Start session (compiler-agnostic now)
         let output = std::process::Command::new(&cli_binary)


### PR DESCRIPTION
First concrete step on #1322. Converts one file to prove the pattern rather than landing a 35-file diff blind.

## What the triage found

I ran the sweep #1322 proposed: **35 binaries, 37 passed, 3 failed.** All three failures trace to one non-product cause.

`DaemonServer::bind` resolves the **process-global** cache root. These tests mint an isolated *endpoint* but bind the *default* root, so they contend with whatever daemon is already live:

```
daemon_cli_flow_test.rs:66  DaemonServer::bind(&endpoint).unwrap()
  Err: cache root ~/.zccache/v1.13.0 unusable:
       another live daemon already holds this cache root as its writer
```

And when the bind wins the race instead, the daemon writes its logs under the default root while the test reads its own tempdir — which is the `NotFound` I originally saw on `main`. Same root cause, different failure point depending on who held the lock.

## The codebase already documents this

`lifecycle.rs:20-27`, on `bind` itself:

> Everything else should bind an isolated root via `tests::bind_isolated_server`, which needs no global state at all and therefore cannot participate in the race.

The integration tests never adopted it. `bind_with_cache_dir` is already `pub`, and every caller in this file already owns a tempdir, so rooting the daemon in it costs nothing.

## Result

2 of 3 tests in this file now pass. All 3 previously failed at the bind on this machine.

The third, `cli_binary_session_round_trip`, still fails — but **further along**, on `--log` producing no session log. That is a separate, unexplained finding and I am deliberately not claiming it is a product bug: the equivalent daemon-core test (`server_ipc.rs:407`) asserts the same `[MISS]`/`[HIT]` content and the CLI wires `--log` → `SessionStart.log_file` correctly (`session.rs:148`), so something in between is unaccounted for. It needs its own investigation rather than a guess folded into this PR.

## I checked whether I caused it

`daemon_cli_flow_test` sets `ZCCACHE_ENDPOINT`, and my #1320 started forwarding `ZCCACHE_*` to the spawned daemon — a plausible mechanism. So I bisected to `506973c8`, before both #1320 and the parallel #1319.

The same tests fail there too, at the bind, before that change existed. **Not a regression from #1320.** Established by mechanism and by bisect, not by assuming.

## Scale of what remains

```
DaemonServer::bind(  in crates/zccache/tests/ : 39 call sites across 35 files
```

Essentially the whole integration suite. This is a **hard prerequisite** for #1322: gating that suite in CI without it produces failures that depend on whether a daemon happens to be live on the runner — red for reasons unrelated to the change under test, which is the worst kind of gate.

I am happy to convert the rest; it is mechanical but large, and each site needs a cache dir in scope, so it is worth agreeing the shape on one file first.

## Evidence

- `daemon_cli_flow_test -- --ignored` — 2 passed, 1 failed (was 0 passed, 3 failed at bind)
- `soldr cargo clippy -p zccache --features "…" --all-targets -- -D warnings` under `RUSTFLAGS="-D warnings"` — exit 0
- `soldr cargo fmt --all`

Note this file is `#[ignore]`d, so CI will not execute it either way — the validation above is local, and that is exactly the gap #1322 is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
