### PR TITLE
security(deploy): create the versioned dir private from the crash guard (#1325)

### DIFF
--- a/crates/zccache-core/src/crash.rs
+++ b/crates/zccache-core/src/crash.rs
@@ -108,7 +108,14 @@ pub fn install(bin_stem: &'static str) -> CrashGuard {
 /// init.
 fn write_last_run_marker(bin_stem: &str) -> std::io::Result<()> {
     let cache_dir = super::config::daemon_state_dir();
-    std::fs::create_dir_all(&cache_dir)?;
+    // Private creation, not a bare `create_dir_all` (#1325). `install` runs as
+    // the first statement of the CLI's `run_main`, so this is what actually
+    // creates `<cache>/v<VERSION>` on a fresh root — before the lifecycle
+    // writer, before the spawn slot, and before the deploy. Creating it wide
+    // here silently defeated #1314: the deploy's own `create_dir_all_private`
+    // early-returns on an existing directory, so `ensure_dir_private` had to
+    // tighten after the fact and the #1172 window stayed open.
+    super::config::create_dir_all_private(&cache_dir)?;
     let ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -195,7 +202,8 @@ fn install_signal_handler() -> Option<crash_handler::CrashHandler> {
 
 fn write_signal_dump(ctx: &crash_handler::CrashContext) {
     let crash_dir = super::config::crash_dump_dir();
-    if std::fs::create_dir_all(&crash_dir).is_err() {
+    // Same tree as the deployed daemon binary; create it private (#1325).
+    if super::config::create_dir_all_private(&crash_dir).is_err() {
         return;
     }
     let sig_label = signal_label(ctx);
@@ -326,7 +334,7 @@ fn format_signal_summary(_cc: &crash_handler::CrashContext) -> String {
 /// context), so allocation here is fine.
 fn write_panic_dump(panic_info: &str, backtrace: &str) -> Option<NormalizedPath> {
     let crash_dir = super::config::crash_dump_dir();
-    std::fs::create_dir_all(&crash_dir).ok()?;
+    super::config::create_dir_all_private(&crash_dir).ok()?;
     let path = unique_dump_path(&crash_dir, "panic", "txt");
 
     let ts = SystemTime::now()

--- a/crates/zccache/tests/cli_wrapper_failure_boundaries.rs
+++ b/crates/zccache/tests/cli_wrapper_failure_boundaries.rs
@@ -321,3 +321,51 @@ fn session_pre_dispatch_failure_refuses_without_double_reading_stdin() {
         "session_pre_dispatch_failure_refuses_without_double_reading_stdin",
     );
 }
+
+/// #1325: the deploy directory must be *born* private, never tightened.
+///
+/// #1314 made `create_dir_all_private` apply the owner-only DACL at creation,
+/// but nothing asserted the end-to-end result — and it was silently bypassed
+/// for months of commits because `crash::install` (the first statement of the
+/// CLI's `run_main`) created `<cache>/v<VERSION>` with a plain
+/// `create_dir_all` before any private creator ran. The deploy's own
+/// `create_dir_all_private` then early-returned on the existing directory and
+/// `ensure_dir_private` tightened after the fact, leaving #1172's window open.
+///
+/// `insecure_deploy_dir` is the observable that distinguishes the two: it is
+/// emitted only when a tighten was necessary. Asserting its absence on a fresh
+/// cache root is what makes "born private" testable — a unit test on the
+/// creation primitive cannot catch an upstream caller creating the directory
+/// first, which is exactly how this regressed.
+#[test]
+#[ignore = "integration test: launches the wrapper binary"]
+fn a_fresh_cache_root_never_needs_its_deploy_dir_tightened() {
+    let zccache = binary_path("zccache");
+    if !zccache.exists() {
+        eprintln!("skipping: zccache binary is not built");
+        return;
+    }
+
+    let cache_dir = tempfile::tempdir().expect("cache tempdir");
+    // Any command that installs the crash guard and touches the daemon state
+    // dir will do; `status` is the cheapest and starts no daemon.
+    let output = Command::new(&zccache)
+        .arg("status")
+        .env("ZCCACHE_CACHE_DIR", cache_dir.path())
+        .env("ZCCACHE_NO_SPAWN", "1")
+        .env_remove("ZCCACHE_DISABLE")
+        .output()
+        .expect("run zccache status");
+
+    let tightened: Vec<_> = lifecycle_events(cache_dir.path())
+        .into_iter()
+        .filter(|event| event["event"] == "insecure_deploy_dir")
+        .collect();
+    assert!(
+        tightened.is_empty(),
+        "the deploy directory must be created private, not tightened after the \
+         fact — some caller is creating it with a plain create_dir_all before \
+         the private creator runs (#1325): {tightened:#?}\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
Closes #1325 — a bug in my own #1314.

## What was wrong

#1314 made the deploy directory get its owner-only DACL **at creation** rather than via a tighten-after pass, closing #1172's window. **It never took effect.** Something created `<cache>/v<VERSION>` first, so `create_dir_all_private` early-returned and `ensure_dir_private` still had to tighten — leaving the window open on the default path.

## The culprit

`crash::install` → `write_last_run_marker` (`crash.rs:109-111`):

```rust
let cache_dir = super::config::daemon_state_dir();
std::fs::create_dir_all(&cache_dir)?;
```

`install` is the **first statement** of the CLI's `run_main`. So on a fresh cache root this is what actually creates the versioned directory — ahead of the lifecycle writer, the spawn slot, and the deploy.

## How I found it, after failing to

I first converted three call sites on suspicion (lifecycle's log-dir creator, `acquire_spawn_slot_at`, the recovery marker), rebuilt, and re-measured. **The warning still fired on every run.** I reverted all three rather than ship unvalidated churn, and filed #1325 with the evidence instead of a guess.

Then I stopped reading code and instrumented: a temporary print in `create_dir_all_private` distinguishing "created" from "early-returned". One run:

```
ZCDBG existed:  …\<TMP>\v1.13.0     <-- FIRST call, already present
ZCDBG creating: …\<TMP>\v1.13.0\logs
```

The first invocation already reported the directory as existing, which located the creator upstream of everything I had been checking. That took one run; the code-reading had taken several rebuilds.

## Verification, on the exact observable

`insecure_deploy_dir outcome="tightened"` is emitted only when a tighten was necessary:

| | fresh-root runs | warnings |
|---|---|---|
| before | 3 | **3** |
| after | 3 | **0** |

`icacls` shows `<user>:(OI)(CI)(F)` + `SYSTEM:(OI)(CI)(F)` with no inherited entries in *both* cases — the end state was always correct. The difference is that it is now born that way rather than corrected after the fact, which is the whole point of #1314.

## The regression test #1325 asked for

**#1314 shipped believing it worked**, because its tests verified the creation primitive in isolation — `create_dir_all_private` does produce a protected DACL, and that test passes. What nothing asserted was the end-to-end result. A unit test on the primitive **structurally cannot** catch an upstream caller creating the directory first, which is exactly how this regressed.

The new test asserts the absence of the `insecure_deploy_dir` lifecycle event on a fresh cache root — the observable that distinguishes "born private" from "tightened". It lives in `cli_wrapper_failure_boundaries.rs`, which already has the `lifecycle_events` helper and, since #1321, actually runs in CI.

I did not run a separate sabotage check because the before/after table above **is** the discrimination evidence, measured on the real binary.

## Scope

Also converts the two `crashes/` creators in the same module — same versioned tree, same hazard.

Severity is unchanged from #1172's residual: **hardening, not a live exposure** under the default root, where the inherited profile DACL is already narrow. It matters for a relocated `ZCCACHE_CACHE_DIR` that hands down `BUILTIN\Users:(OI)(CI)(M)`.

## Evidence

- `cli_wrapper_failure_boundaries -- --ignored` — **3 passed, 0 failed** (was 2; +1)
- `zccache-core --lib` — 129 passed, 0 failed
- `soldr cargo clippy --workspace --all-targets -- -D warnings` under `RUSTFLAGS="-D warnings"` — exit 0, 0 diagnostics
- `soldr cargo fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
