### PR TITLE
fix(daemon): stop reaping sessions that are still in use (#1324)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
@@ -965,8 +965,22 @@ fn reap_finished_sessions(state: &SharedState) {
 /// platform and leaves `is_process_alive` — which has its own tests — as the
 /// only thing depending on OS behaviour.
 fn reap_finished_sessions_with(state: &SharedState, is_alive: impl Fn(u32) -> bool) {
+    reap_finished_sessions_with_grace(
+        state,
+        is_alive,
+        crate::depgraph::session::DEAD_CLIENT_REAP_GRACE,
+    );
+}
+
+/// [`reap_finished_sessions_with`] with the dead-owner grace supplied by the
+/// caller, so tests can exercise reclamation without sleeping for it (#1324).
+fn reap_finished_sessions_with_grace(
+    state: &SharedState,
+    is_alive: impl Fn(u32) -> bool,
+    grace: std::time::Duration,
+) {
     let expired = state.sessions.cleanup_expired();
-    let dead = state.sessions.cleanup_dead_pids(is_alive);
+    let dead = state.sessions.cleanup_dead_pids_idle_for(is_alive, grace);
     let tombstones = reap_ended_session_tombstones(state, ENDED_SESSION_TTL);
     if !expired.is_empty() || !dead.is_empty() || tombstones > 0 {
         tracing::info!(

--- a/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
@@ -822,7 +822,13 @@ async fn reaping_removes_a_session_whose_client_died() {
         });
     assert_eq!(daemon.state.sessions.active_count(), 2);
 
-    reap_finished_sessions_with(&daemon.state, only_dead_client_is_gone);
+    // #1324: zero grace so these exercise reclamation itself, not the
+    // idle window that protects an in-use session from its exited starter.
+    reap_finished_sessions_with_grace(
+        &daemon.state,
+        only_dead_client_is_gone,
+        std::time::Duration::ZERO,
+    );
 
     // The crashed client is the case that leaked without bound: it never sent
     // SessionEnd, so nothing else would ever have removed it.
@@ -869,7 +875,13 @@ async fn reaping_is_a_noop_when_every_client_is_alive() {
     // for the life of the daemon, so a reaper that eventually evicted live
     // sessions would surface as builds mysteriously losing their session.
     for _ in 0..3 {
-        reap_finished_sessions_with(&daemon.state, only_dead_client_is_gone);
+        // #1324: zero grace so these exercise reclamation itself, not the
+        // idle window that protects an in-use session from its exited starter.
+        reap_finished_sessions_with_grace(
+            &daemon.state,
+            only_dead_client_is_gone,
+            std::time::Duration::ZERO,
+        );
     }
 
     assert!(daemon.state.sessions.context_count(&live).is_some());
@@ -1000,7 +1012,13 @@ async fn reaping_writes_a_durable_event_only_when_it_reclaims_something() {
     );
 
     let quiet_before = sessions_reaped_rows();
-    reap_finished_sessions_with(&daemon.state, only_dead_client_is_gone);
+    // #1324: zero grace so these exercise reclamation itself, not the
+    // idle window that protects an in-use session from its exited starter.
+    reap_finished_sessions_with_grace(
+        &daemon.state,
+        only_dead_client_is_gone,
+        std::time::Duration::ZERO,
+    );
     assert_eq!(
         sessions_reaped_rows(),
         quiet_before,
@@ -1021,7 +1039,13 @@ async fn reaping_writes_a_durable_event_only_when_it_reclaims_something() {
             owner_pids: Vec::new(),
         });
 
-    reap_finished_sessions_with(&daemon.state, only_dead_client_is_gone);
+    // #1324: zero grace so these exercise reclamation itself, not the
+    // idle window that protects an in-use session from its exited starter.
+    reap_finished_sessions_with_grace(
+        &daemon.state,
+        only_dead_client_is_gone,
+        std::time::Duration::ZERO,
+    );
 
     assert_eq!(
         sessions_reaped_rows(),

--- a/crates/zccache-depgraph/src/session.rs
+++ b/crates/zccache-depgraph/src/session.rs
@@ -15,6 +15,24 @@ use zccache_core::NormalizedPath;
 
 use super::context::ContextKey;
 
+/// How long a session must have been idle before a dead owner PID is grounds
+/// to reclaim it (#1324).
+///
+/// `client_pid` is the PID of whoever called `zccache session-start`. That is a
+/// short-lived CLI process which prints the session id and exits, so by the
+/// time any maintenance sweep runs the owner is *always* dead and dead-PID
+/// reaping degenerates into "drop every session on the next sweep". The
+/// sessions it was dropping were live builds: later `zccache <compiler>`
+/// invocations are separate processes that look the session up by id, so they
+/// found nothing and every session-scoped feature (logging, stats, tracking)
+/// silently stopped working while compiles kept succeeding.
+///
+/// Requiring idleness as well keeps #1165's leak protection — an abandoned
+/// session is still reclaimed — without severing one that is in active use.
+/// The window has to exceed a build's longest gap between compile requests,
+/// which is a link step, not a compile.
+pub const DEAD_CLIENT_REAP_GRACE: Duration = Duration::from_secs(15 * 60);
+
 /// Per-session depgraph/artifact lookup outcome counters.
 ///
 /// These counters intentionally separate the #787 failure shapes that the
@@ -427,20 +445,41 @@ impl SessionManager {
         expired
     }
 
-    /// Remove sessions whose client PID is no longer alive.
-    /// The caller provides a function that checks if a PID is alive.
+    /// Remove sessions whose client PID is no longer alive **and** which have
+    /// been idle for at least [`DEAD_CLIENT_REAP_GRACE`].
+    ///
+    /// The idleness half is load-bearing, not belt-and-braces: the owning PID
+    /// is the `zccache session-start` process, which exits immediately, so
+    /// liveness alone marks every session reclaimable the moment it is
+    /// created. See [`DEAD_CLIENT_REAP_GRACE`] for the full account (#1324).
     pub fn cleanup_dead_pids<F>(&self, is_alive: F) -> Vec<Session>
     where
         F: Fn(u32) -> bool,
     {
+        self.cleanup_dead_pids_idle_for(is_alive, DEAD_CLIENT_REAP_GRACE)
+    }
+
+    /// [`cleanup_dead_pids`](Self::cleanup_dead_pids) with an explicit grace
+    /// window, so tests can exercise the policy without sleeping.
+    pub fn cleanup_dead_pids_idle_for<F>(&self, is_alive: F, grace: Duration) -> Vec<Session>
+    where
+        F: Fn(u32) -> bool,
+    {
+        let cutoff = Instant::now().checked_sub(grace);
         let mut dead = Vec::new();
 
         self.sessions.retain(|_, session| {
             if is_alive(session.client_pid) {
-                true
-            } else {
-                dead.push(session.clone());
-                false
+                return true;
+            }
+            // No cutoff means the daemon has been up for less than the grace
+            // window, so nothing can have been idle that long yet.
+            match cutoff {
+                Some(cutoff) if session.last_activity < cutoff => {
+                    dead.push(session.clone());
+                    false
+                }
+                _ => true,
             }
         });
 
@@ -625,11 +664,64 @@ mod tests {
         mgr.create(config2);
         assert_eq!(mgr.active_count(), 2);
 
-        // PID 100 is dead, PID 200 is alive.
+        // PID 100 is dead, PID 200 is alive. Both sessions were just
+        // created, so neither is idle: a dead owner alone is not grounds to
+        // reclaim (#1324). Zero grace is used elsewhere to exercise the
+        // reaping half without sleeping.
         let dead = mgr.cleanup_dead_pids(|pid| pid != 100);
+        assert!(
+            dead.is_empty(),
+            "an active session must survive its owner exiting: {dead:?}"
+        );
+        assert_eq!(mgr.active_count(), 2);
+
+        // With the grace elapsed, the dead-owner session is reclaimed and the
+        // live-owner one is not.
+        let dead = mgr.cleanup_dead_pids_idle_for(|pid| pid != 100, Duration::ZERO);
         assert_eq!(dead.len(), 1);
         assert_eq!(dead[0].client_pid, 100);
         assert_eq!(mgr.active_count(), 1);
+    }
+
+    /// #1324: the owning PID is `zccache session-start`, which exits as soon
+    /// as it prints the session id. Reaping on liveness alone therefore
+    /// discarded every session on the first maintenance sweep, and the later
+    /// `zccache <compiler>` processes — separate PIDs looking the session up
+    /// by id — found nothing. Compiles still succeeded, so the only visible
+    /// symptom was that session-scoped features quietly did nothing.
+    #[test]
+    fn a_session_whose_starter_exited_survives_while_it_is_in_use() {
+        let mgr = SessionManager::new(Duration::from_secs(900));
+        let mut config = test_config();
+        config.client_pid = 4242;
+        let id = mgr.create(config);
+
+        // The starter process is gone — as it always is by this point.
+        let dead = mgr.cleanup_dead_pids(|_| false);
+
+        assert!(
+            dead.is_empty(),
+            "the session must outlive the CLI that registered it"
+        );
+        assert!(
+            mgr.exists(&id),
+            "a build's session must still resolve after `session-start` exits"
+        );
+    }
+
+    /// The leak protection #1165 added still has to work: an abandoned
+    /// session with a dead owner is reclaimed once it goes idle.
+    #[test]
+    fn an_idle_session_with_a_dead_owner_is_still_reclaimed() {
+        let mgr = SessionManager::new(Duration::from_secs(900));
+        let mut config = test_config();
+        config.client_pid = 4242;
+        let id = mgr.create(config);
+
+        let dead = mgr.cleanup_dead_pids_idle_for(|_| false, Duration::ZERO);
+
+        assert_eq!(dead.len(), 1, "abandoned sessions must not accumulate");
+        assert!(!mgr.exists(&id));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1324. Not a logging bug — **sessions were being reclaimed while still in use**, and the missing `--log` file was one symptom.

## The chain

1. `session.rs:146` — the CLI registers `client_pid: std::process::id()`, i.e. **its own** PID.
2. `zccache session-start` prints the session id and **exits**. That PID is now dead.
3. `disk_maintenance.rs:969` — maintenance calls `cleanup_dead_pids(is_alive)`.
4. `zccache-depgraph/src/session.rs:432` — that drops every session whose owner is not alive.
5. Later `zccache <compiler>` invocations — separate processes, `ZCCACHE_SESSION_ID` set — find nothing.

The owner is *structurally* dead: a short-lived CLI registering a session designed to outlive it and serve many later wrapper processes. So liveness-based reaping wasn't a tunable policy, it was "drop every session on the next sweep".

## Evidence

Instrumented `write_session_log` on a machine with no stray daemons:

```
compile exit=0  obj=yes  LOG=NO

ZCDBG write_session_log found=false has_log=false msg="[DIAG] depgraph_check: … verdict=Cold reason=cold_skip"
ZCDBG write_session_log found=false has_log=false msg="[MISS] …t.cpp -> …t.o (reason: cold_skip)"
ZCDBG write_session_log found=false has_log=false msg="[DIAG] update: …"
```

The writer **is** reached, three times, `found=false` every time. Lifecycle log for the same run showed a single `spawn` — so not a two-daemon split — and a `sessions_reaped` event.

## The fix

Dead-owner reaping now also requires the session to have been idle for `DEAD_CLIENT_REAP_GRACE` (15 min). #1165's leak protection is preserved — an abandoned session is still reclaimed once idle — but one that is actively compiling survives its starter exiting.

The window has to exceed a build's longest gap between compile requests. That gap is a **link step**, not a compile, which is why 15 minutes rather than something tighter.

## Verified end to end

After the fix, the same reproduction:

```
compile1 exit=0 obj=yes
compile2 exit=0 obj=yes
LOG_EXISTS=yes
[MISS] …t.cpp -> …t.o (reason: cold_skip)
[DIAG] depgraph_check: … verdict=Hit reason=fast_key_match
```

Cold miss then warm hit — exactly the `[MISS]`/`[HIT]` content the issue and `cli_session_lifecycle` both expect.

## Tests

Two existing tests encoded the old behaviour and **failed** when I made the change, which is the discrimination evidence: `cleanup_dead_pids` expected `left: 0, right: 1`. They now assert the new contract *and* the reclamation half via an explicit zero grace, so both directions stay covered.

Added:
- `a_session_whose_starter_exited_survives_while_it_is_in_use` — the regression itself.
- `an_idle_session_with_a_dead_owner_is_still_reclaimed` — #1165's protection did not quietly disappear.

Both the depgraph and daemon reapers gained an explicit-grace seam. Tests should not sleep through a 15-minute policy window, and injecting it beats mutating a global — the same pattern used for `resolve_pool_with_env` and in #1318.

## Scope, stated plainly

This is wider than `--log`. Anything session-keyed — session logs, `session-stats`, `track_stats` — was silently doing nothing while compiles kept succeeding and caching, so nothing errored. That also explains `session-end` printing nothing in my earlier runs.

## What I did not do

The more principled fix is for `session-start` to register the **caller's** PID rather than its own, since the build driver is the real owner and outlives the session. That changes the CLI contract and wants your call, so I left it. This change is correct independently of that decision — an in-use session should not be reclaimed regardless of which PID owns it.

## Evidence

- `zccache-daemon-core --features "test-support,daemon-entry" --lib` — **734 passed, 0 failed** (+2)
- `zccache-depgraph --lib` — **423 passed, 0 failed** (+2)
- `soldr cargo clippy --workspace --all-targets -- -D warnings` under `RUSTFLAGS="-D warnings"` — exit 0, 0 diagnostics
- `soldr cargo fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
