### PR TITLE
test(integration): isolate two more daemon cache roots (#1322)

### DIFF
--- a/crates/zccache/tests/daemon_adversarial_corner_cases.rs
+++ b/crates/zccache/tests/daemon_adversarial_corner_cases.rs
@@ -33,14 +33,22 @@ type ClientConn = zccache::ipc::IpcClientConnection;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-async fn start_daemon() -> (String, JoinHandle<()>, Arc<Notify>) {
+/// Start a daemon rooted at its own tempdir (#1322).
+///
+/// `DaemonServer::bind` resolves the process-global cache root, so tests using
+/// it collide with any daemon already live on the default root. The `TempDir`
+/// is returned so the caller keeps it alive — dropping it would delete the
+/// cache root out from under the running daemon.
+async fn start_daemon() -> (String, JoinHandle<()>, Arc<Notify>, tempfile::TempDir) {
     let endpoint = zccache::ipc::unique_test_endpoint();
-    let mut server = DaemonServer::bind(&endpoint).unwrap();
+    let cache_root = tempfile::tempdir().expect("daemon cache tempdir");
+    let cache_dir: zccache::core::NormalizedPath = cache_root.path().join("zccache-cache").into();
+    let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
     let shutdown = server.shutdown_handle();
     let handle = tokio::spawn(async move {
         server.run(0).await.unwrap();
     });
-    (endpoint, handle, shutdown)
+    (endpoint, handle, shutdown, cache_root)
 }
 
 async fn start_session(
@@ -130,7 +138,7 @@ impl TestHarness {
         let log = tmp.path().join("log.txt");
         let cwd = tmp.path().to_string_lossy().into_owned();
 
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
         let session_id = start_session(&mut client, &clang, &cwd, &log.to_string_lossy()).await;
 
@@ -281,7 +289,7 @@ async fn corner_cache_survives_session_restart() {
     let log1 = tmp.path().join("log1.txt");
     let log2 = tmp.path().join("log2.txt");
 
-    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
 
     // Session A: compile
     let mut client1 = zccache::ipc::connect(&endpoint).await.unwrap();
@@ -360,7 +368,7 @@ async fn corner_thundering_herd_same_file() {
     let src = tmp.path().join("herd.cpp");
     std::fs::write(&src, "int f() { return 42; }\n").unwrap();
 
-    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
 
     let n_sessions = 4;
     let mut handles = Vec::new();
@@ -447,7 +455,7 @@ async fn corner_thundering_herd_all_warm() {
     let src = tmp.path().join("warm.cpp");
     std::fs::write(&src, "int f() { return 7; }\n").unwrap();
 
-    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
 
     // Warm the cache with a single compile
     {

--- a/crates/zccache/tests/daemon_integration_test.rs
+++ b/crates/zccache/tests/daemon_integration_test.rs
@@ -13,26 +13,41 @@
 use zccache::daemon::DaemonServer;
 use zccache::protocol::{Request, Response};
 
-/// Helper: start a daemon server on a unique endpoint and return the endpoint + shutdown handle.
+/// Helper: start a daemon server on a unique endpoint and return the endpoint +
+/// shutdown handle.
+///
+/// The daemon is rooted at its own tempdir (#1322). `DaemonServer::bind`
+/// resolves the *process-global* cache root, so every test using it contends
+/// with whatever daemon is already live on the developer's or runner's default
+/// root — failing with "another live daemon already holds this cache root as
+/// its writer". `lifecycle.rs` says so directly: everything outside the env
+/// guard "should bind an isolated root ... which needs no global state at all
+/// and therefore cannot participate in the race".
+///
+/// The `TempDir` is returned so the caller keeps it alive; dropping it would
+/// delete the cache root out from under the running daemon.
 async fn start_daemon() -> (
     String,
     tokio::task::JoinHandle<()>,
     std::sync::Arc<tokio::sync::Notify>,
+    tempfile::TempDir,
 ) {
     let endpoint = zccache::ipc::unique_test_endpoint();
-    let mut server = DaemonServer::bind(&endpoint).unwrap();
+    let cache_root = tempfile::tempdir().expect("daemon cache tempdir");
+    let cache_dir: zccache::core::NormalizedPath = cache_root.path().join("zccache-cache").into();
+    let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
     let shutdown = server.shutdown_handle();
     let handle = tokio::spawn(async move {
         server.run(0).await.unwrap();
     });
-    (endpoint, handle, shutdown)
+    (endpoint, handle, shutdown, cache_root)
 }
 
 #[tokio::test]
 #[ignore] // integration-level: starts real daemon with IPC
 async fn test_client_connects_and_pings_daemon() {
     zccache::test_support::test_timeout(async {
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
 
         let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
         client.send(&Request::Ping).await.unwrap();
@@ -49,7 +64,7 @@ async fn test_client_connects_and_pings_daemon() {
 #[ignore] // integration-level: starts real daemon with IPC
 async fn test_multiple_clients_concurrent() {
     zccache::test_support::test_timeout(async {
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
 
         let mut handles = Vec::new();
         for _ in 0..5 {
@@ -76,7 +91,7 @@ async fn test_multiple_clients_concurrent() {
 #[ignore] // integration-level: starts real daemon with IPC
 async fn test_session_start_with_nonexistent_compiler() {
     zccache::test_support::test_timeout(async {
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
 
         let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
         client
@@ -138,7 +153,7 @@ async fn test_session_start_with_clang_toolchain() {
     }
 
     zccache::test_support::test_timeout(async move {
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
 
         let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
         client
@@ -208,7 +223,7 @@ async fn test_full_client_flow() {
     }
 
     zccache::test_support::test_timeout(async move {
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
 
         let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
 
@@ -286,7 +301,7 @@ int main() {
         let output_obj = tmp.path().join("hello.o");
         let depfile = tmp.path().join("hello.d");
 
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
 
         // Start session with log file


### PR DESCRIPTION
Continues #1323's incremental conversion for #1322. Two more files, each verified by running it rather than by inspection.

## The defect

`DaemonServer::bind` resolves the **process-global** cache root, so these tests bind whatever root the machine already has:

```
cache root ~/.zccache/v1.13.0 unusable: another live daemon already holds this cache root as its writer
```

`lifecycle.rs:20-27` already mandates the fix, on `bind` itself:

> Everything else should bind an isolated root via `tests::bind_isolated_server`, which needs no global state at all and therefore cannot participate in the race.

Each helper now roots its daemon in its own tempdir and **returns the `TempDir`** so the caller keeps it alive — dropping it would delete the cache root out from under the running daemon.

## Measured, not assumed

| file | before | after |
|---|---|---|
| `daemon_integration_test` | **6 failed** | **6 passed** |
| `daemon_adversarial_corner_cases` | all failed at bind | **4 passed**, 1 failed |

## The remaining failure is not mine — and I checked

`corner_failed_compile_not_cached_then_header_appears` still fails, and I did not assume it was pre-existing. I reverted the file and re-ran:

- **baseline:** panics at **line 38** — the bind itself, before reaching any assertion
- **after:** panics at **line 240** — a genuine cache-hit assertion

So the test gets strictly further. The collision had been masking a real failure. Filed as #1328, where I have deliberately **not** claimed whether it is a caching bug or a stale expectation — with this suite unrun for an unknown period, either is plausible and it deserves its own investigation.

This is exactly what #1322 predicted: fixing the harness surfaces signal it was hiding. Expect more as the remaining files convert.

## Why two files and not thirty-four

32 files still use the old pattern. Converting them in one blind diff would be a large change to tests **CI never runs** — so a broken conversion would look converted and fail silently, which is the failure mode this whole issue is about. Each batch gets run instead.

## Evidence

- `daemon_integration_test -- --ignored` — 6 passed, 0 failed
- `daemon_adversarial_corner_cases -- --ignored` — 4 passed, 1 failed (#1328, pre-existing, now reachable)
- `soldr cargo clippy -p zccache --features "…" --all-targets -- -D warnings` under `RUSTFLAGS="-D warnings"` — exit 0
- `soldr cargo fmt --all`

Both files are `#[ignore]`d, so CI will not execute them either way — the validation above is local, which is the gap #1322 exists to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
