### PR TITLE
test(integration): isolate the fingerprint test's daemon cache root (#1322)

### DIFF
--- a/crates/zccache/tests/daemon_fingerprint_test.rs
+++ b/crates/zccache/tests/daemon_fingerprint_test.rs
@@ -15,18 +15,27 @@ use zccache::daemon::DaemonServer;
 use zccache::protocol::{Request, Response};
 
 /// Helper: start a daemon server on a unique endpoint.
+/// Start a daemon rooted at its own tempdir (#1322).
+///
+/// `DaemonServer::bind` resolves the process-global cache root, so tests using
+/// it collide with any daemon already live on the default root. The `TempDir`
+/// is returned so the caller keeps it alive — dropping it would delete the
+/// cache root out from under the running daemon.
 async fn start_daemon() -> (
     String,
     tokio::task::JoinHandle<()>,
     std::sync::Arc<tokio::sync::Notify>,
+    tempfile::TempDir,
 ) {
     let endpoint = zccache::ipc::unique_test_endpoint();
-    let mut server = DaemonServer::bind(&endpoint).unwrap();
+    let cache_root = tempfile::tempdir().expect("daemon cache tempdir");
+    let cache_dir: zccache::core::NormalizedPath = cache_root.path().join("zccache-cache").into();
+    let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
     let shutdown = server.shutdown_handle();
     let handle = tokio::spawn(async move {
         server.run(0).await.unwrap();
     });
-    (endpoint, handle, shutdown)
+    (endpoint, handle, shutdown, cache_root)
 }
 
 fn create_file(dir: &std::path::Path, rel: &str, content: &str) {
@@ -41,7 +50,7 @@ fn create_file(dir: &std::path::Path, rel: &str, content: &str) {
 #[ignore] // integration-level: starts real daemon
 async fn test_fingerprint_check_miss_then_skip() {
     zccache::test_support::test_timeout(async {
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let src = tempfile::TempDir::new().unwrap();
         let cache_dir = tempfile::TempDir::new().unwrap();
 
@@ -111,7 +120,7 @@ async fn test_fingerprint_check_miss_then_skip() {
 #[ignore] // integration-level: starts real daemon
 async fn test_fingerprint_mark_failure_forces_rerun() {
     zccache::test_support::test_timeout(async {
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let src = tempfile::TempDir::new().unwrap();
         let cache_dir = tempfile::TempDir::new().unwrap();
 
@@ -177,7 +186,7 @@ async fn test_fingerprint_mark_failure_forces_rerun() {
 #[ignore] // integration-level: starts real daemon
 async fn test_fingerprint_invalidate() {
     zccache::test_support::test_timeout(async {
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let src = tempfile::TempDir::new().unwrap();
         let cache_dir = tempfile::TempDir::new().unwrap();
 
@@ -249,7 +258,7 @@ async fn test_fingerprint_invalidate() {
 #[ignore] // integration-level: starts real daemon
 async fn test_fingerprint_two_watches_independent() {
     zccache::test_support::test_timeout(async {
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let src = tempfile::TempDir::new().unwrap();
         let cache_dir = tempfile::TempDir::new().unwrap();
 


### PR DESCRIPTION
Continues #1322's incremental conversion. **One file shipped out of three attempted** — the other two are reverted, and why is the interesting part.

## Shipped

`daemon_fingerprint_test` now roots its daemon in its own tempdir and returns the `TempDir` so the caller keeps it alive. Verified: **4 passed, 0 failed**.

## Reverted, and what it found

I baselined all three before converting. `daemon_adversarial_mutations` went **6 passed → 0 passed**:

```
mutation_touch_source_no_invalidation
  touch with same content should still hit cache (content hash unchanged)
```

Cache-hit assertions, not bind errors. Those tests were passing only because the daemon shared the developer's **warm `~/.zccache`**. Given a cold private root, their assumptions do not hold.

That is a stronger version of this issue's thesis than the collision it opened with: the earlier files were *racing* the shared cache root; these are *depending* on it. A test that only passes against a warm ambient cache is not coverage — it cannot fail for the reason it claims to test.

Filed as #1330, where I deliberately did **not** decide whether the tests are wrong (assuming a populated cache) or zccache is (mtime invalidating despite an unchanged content hash, which `crates/CLAUDE.md` says must not happen). The second reading would be significant, so it wants checking rather than assuming.

`daemon_burst_link_test` is unchanged — its single test failed identically before and after — so isolation buys nothing there until the underlying failure is understood. Reverted to keep this diff to what it improves.

## Why one file per PR is worth the pace

A blind bulk conversion of all 34 files would have turned **six passing tests red in a file CI never runs**. Nobody would have noticed, and the file would have looked converted. That is precisely the failure mode #1322 exists to describe, so the conversion itself must not reproduce it.

Baselining before converting is what caught it. Each batch gets executed, not inspected.

## Evidence

- `daemon_fingerprint_test -- --ignored` — 4 passed, 0 failed
- `soldr cargo clippy -p zccache --features "…" --all-targets -- -D warnings` under `RUSTFLAGS="-D warnings"` — exit 0
- `soldr cargo fmt --all`

The file is `#[ignore]`d, so CI will not execute it either way — validation above is local, which is the gap #1322 is about.

Running total: 4 of 34 files converted (#1323, #1329, this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
