### PR TITLE
test(integration): isolate the dll and pch test daemon cache roots (#1322)

### DIFF
--- a/crates/zccache/tests/daemon_dll_cache_test.rs
+++ b/crates/zccache/tests/daemon_dll_cache_test.rs
@@ -14,18 +14,27 @@ use zccache::daemon::DaemonServer;
 use zccache::protocol::{Request, Response};
 
 /// Helper: start a daemon server on a unique endpoint.
+/// Start a daemon rooted at its own tempdir (#1322).
+///
+/// `DaemonServer::bind` resolves the process-global cache root, so tests using
+/// it collide with any daemon already live on the default root. The `TempDir`
+/// is returned so the caller keeps it alive — dropping it would delete the
+/// cache root out from under the running daemon.
 async fn start_daemon() -> (
     String,
     tokio::task::JoinHandle<()>,
     std::sync::Arc<tokio::sync::Notify>,
+    tempfile::TempDir,
 ) {
     let endpoint = zccache::ipc::unique_test_endpoint();
-    let mut server = DaemonServer::bind(&endpoint).unwrap();
+    let cache_root = tempfile::tempdir().expect("daemon cache tempdir");
+    let cache_dir: zccache::core::NormalizedPath = cache_root.path().join("zccache-cache").into();
+    let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
     let shutdown = server.shutdown_handle();
     let handle = tokio::spawn(async move {
         server.run(0).await.unwrap();
     });
-    (endpoint, handle, shutdown)
+    (endpoint, handle, shutdown, cache_root)
 }
 
 /// Compile a minimal C source to an object file using gcc.
@@ -68,7 +77,7 @@ async fn test_dll_cache_miss_then_hit() {
 
     let output_dll = tmp.path().join("libmath.dll");
 
-    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
 
     // Clear persisted artifacts to ensure test isolation from prior runs
@@ -181,7 +190,7 @@ async fn test_dll_cache_invalidated_on_input_change() {
 
     let output_dll = tmp.path().join("libfunc.dll");
 
-    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
 
     // Clear persisted artifacts to ensure test isolation from prior runs
@@ -290,7 +299,7 @@ async fn test_dll_non_deterministic_warning() {
 
     let output_dll = tmp.path().join("libwarn.dll");
 
-    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
 
     // Clear persisted artifacts to ensure test isolation from prior runs
@@ -369,7 +378,7 @@ async fn test_exe_cache_miss_then_hit() {
 
     let output_exe = tmp.path().join("main.exe");
 
-    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
 
     // Clear persisted artifacts to ensure test isolation from prior runs
@@ -493,7 +502,7 @@ async fn test_clang_link_cache_miss_then_hit() {
         .path()
         .join(if cfg!(windows) { "main.exe" } else { "main" });
 
-    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
 
     // Clear persisted artifacts to ensure test isolation

--- a/crates/zccache/tests/daemon_pch_cache_basic_test.rs
+++ b/crates/zccache/tests/daemon_pch_cache_basic_test.rs
@@ -25,16 +25,25 @@ type ClientConn = zccache::ipc::IpcConnection;
 #[cfg(windows)]
 type ClientConn = zccache::ipc::IpcClientConnection;
 
+/// Start a daemon rooted at its own tempdir (#1322).
+///
+/// `DaemonServer::bind` resolves the process-global cache root, so tests using
+/// it collide with any daemon already live on the default root. The `TempDir`
+/// is returned so the caller keeps it alive — dropping it would delete the
+/// cache root out from under the running daemon.
 async fn start_daemon() -> (
     String,
     tokio::task::JoinHandle<()>,
     std::sync::Arc<tokio::sync::Notify>,
+    tempfile::TempDir,
 ) {
     let endpoint = zccache::ipc::unique_test_endpoint();
-    let mut server = DaemonServer::bind(&endpoint).unwrap();
+    let cache_root = tempfile::tempdir().expect("daemon cache tempdir");
+    let cache_dir: zccache::core::NormalizedPath = cache_root.path().join("zccache-cache").into();
+    let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
     let shutdown = server.shutdown_handle();
     let handle = tokio::spawn(async move { server.run(0).await.unwrap() });
-    (endpoint, handle, shutdown)
+    (endpoint, handle, shutdown, cache_root)
 }
 
 async fn start_session(client: &mut ClientConn, cwd: &str, log_file: &str) -> String {
@@ -128,7 +137,7 @@ async fn pch_usage_is_cacheable() {
 
     std::fs::write(&source, "int main() { return PCH_VALUE; }\n").unwrap();
 
-    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
     let sid = start_session(&mut client, &cwd, &log.to_string_lossy()).await;
 
@@ -313,7 +322,7 @@ async fn pch_generation_is_cacheable() {
 
     std::fs::write(&header, "#define GEN_VALUE 1\n").unwrap();
 
-    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
     let sid = start_session(&mut client, &cwd, &log.to_string_lossy()).await;
 


### PR DESCRIPTION
Continues #1322's incremental conversion. Two more helpers root their daemon in a private tempdir and return the `TempDir` so the caller keeps it alive.

## Both files were already green — which is the risky case

After #1330, a green baseline is **not** evidence that isolation is safe. In that file six passing tests went to **zero** under isolation, because they were depending on the developer's warm `~/.zccache` rather than establishing their own state.

So both were run before and after:

| file | before | after |
|---|---|---|
| `daemon_dll_cache_test` | 5 passed | **5 passed** |
| `daemon_pch_cache_basic_test` | 2 passed | **2 passed** |

Unchanged. These genuinely build their own cache state rather than inheriting it, so isolating them is a no-op behaviourally and a correctness win structurally.

## Deliberately not converted: `daemon_depgraph_persistence_test`

It binds **twice on purpose** — the test restarts the daemon to prove the depgraph survives a restart. Both instances must therefore share one cache root.

Giving each call a fresh tempdir would make the second daemon start cold, so the test would "pass" or fail for reasons unrelated to persistence: it would silently stop testing the property it exists for. That needs a shared-root helper, not this pattern, so it is left for a batch that can do it properly.

Flagging it because it is the first file where the mechanical conversion is actively wrong rather than merely unverified.

## Evidence

- `daemon_dll_cache_test -- --ignored` — 5 passed, 0 failed
- `daemon_pch_cache_basic_test -- --ignored` — 2 passed, 0 failed
- `soldr cargo clippy -p zccache --features "…" --all-targets -- -D warnings` under `RUSTFLAGS="-D warnings"` — exit 0
- `soldr cargo fmt --all`

Both files are `#[ignore]`d, so CI will not execute them — validation is local, which is the gap #1322 describes.

**6 of 34 files converted** (#1323, #1329, #1331, this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
