### PR TITLE
test(integration): isolate three more daemon cache roots (#1322)

### DIFF
--- a/crates/zccache/tests/daemon_pch_cache_invalidation_test.rs
+++ b/crates/zccache/tests/daemon_pch_cache_invalidation_test.rs
@@ -29,16 +29,25 @@ type ClientConn = zccache::ipc::IpcConnection;
 #[cfg(windows)]
 type ClientConn = zccache::ipc::IpcClientConnection;
 
+/// Start a daemon rooted at its own tempdir (#1322).
+///
+/// `DaemonServer::bind` resolves the process-global cache root, so tests using
+/// it collide with any daemon already live on the default root. The `TempDir`
+/// is returned so the caller keeps it alive — dropping it would delete the
+/// cache root out from under the running daemon.
 async fn start_daemon() -> (
     String,
     tokio::task::JoinHandle<()>,
     std::sync::Arc<tokio::sync::Notify>,
+    tempfile::TempDir,
 ) {
     let endpoint = zccache::ipc::unique_test_endpoint();
-    let mut server = DaemonServer::bind(&endpoint).unwrap();
+    let cache_root = tempfile::tempdir().expect("daemon cache tempdir");
+    let cache_dir: zccache::core::NormalizedPath = cache_root.path().join("zccache-cache").into();
+    let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
     let shutdown = server.shutdown_handle();
     let handle = tokio::spawn(async move { server.run(0).await.unwrap() });
-    (endpoint, handle, shutdown)
+    (endpoint, handle, shutdown, cache_root)
 }
 
 async fn start_session(client: &mut ClientConn, cwd: &str, log_file: &str) -> String {
@@ -144,7 +153,7 @@ async fn pch_sub_header_change_invalidates_cache() {
     .unwrap();
     std::fs::write(&source, "int main() { return SUB_VALUE; }\n").unwrap();
 
-    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
     let sid = start_session(&mut client, &cwd, &log.to_string_lossy()).await;
 
@@ -321,7 +330,7 @@ async fn pch_build_dir_separation_sub_header_change() {
     .unwrap();
     std::fs::write(&source, "int main() { return SUB_VALUE; }\n").unwrap();
 
-    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
     let sid = start_session(&mut client, &cwd, &log.to_string_lossy()).await;
 
@@ -478,7 +487,7 @@ async fn pch_chained_sub_header_change() {
     .unwrap();
     std::fs::write(&source, "int main() { return SUB_VALUE + TEST_EXTRA; }\n").unwrap();
 
-    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
     let sid = start_session(&mut client, &cwd, &log.to_string_lossy()).await;
 
@@ -731,7 +740,7 @@ async fn pch_rebuild_no_spurious_output_in_source_tree() {
     let pch_output = build_dir.join("pch.h.pch");
     let main_obj = build_dir.join("main.o");
 
-    let (endpoint, server_handle, shutdown) = start_daemon().await;
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
     let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
     let sid = start_session(&mut client, &cwd, &log.to_string_lossy()).await;
 

--- a/crates/zccache/tests/daemon_profile_test.rs
+++ b/crates/zccache/tests/daemon_profile_test.rs
@@ -244,7 +244,12 @@ async fn profile_compile_phases() {
     use tokio::sync::Mutex;
 
     let endpoint = zccache::ipc::unique_test_endpoint();
-    let server = DaemonServer::bind(&endpoint).unwrap();
+    // #1322: private cache root, else this collides with any daemon already
+    // live on the process-global default. `_cache_root` must outlive the
+    // daemon — dropping it deletes the cache root from under it.
+    let _cache_root = tempfile::tempdir().expect("daemon cache tempdir");
+    let cache_dir: zccache::core::NormalizedPath = _cache_root.path().join("zccache-cache").into();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
     let shutdown = server.shutdown_handle();
     let server = Arc::new(Mutex::new(Some(server)));
     let server_clone = Arc::clone(&server);

--- a/crates/zccache/tests/daemon_session_stats_test.rs
+++ b/crates/zccache/tests/daemon_session_stats_test.rs
@@ -29,18 +29,27 @@ type ClientConn = zccache::ipc::IpcClientConnection;
 #[cfg(not(windows))]
 type ClientConn = zccache::ipc::IpcConnection;
 
+/// Start a daemon rooted at its own tempdir (#1322).
+///
+/// `DaemonServer::bind` resolves the process-global cache root, so tests using
+/// it collide with any daemon already live on the default root. The `TempDir`
+/// is returned so the caller keeps it alive — dropping it would delete the
+/// cache root out from under the running daemon.
 async fn start_daemon() -> (
     String,
     tokio::task::JoinHandle<()>,
     std::sync::Arc<tokio::sync::Notify>,
+    tempfile::TempDir,
 ) {
     let endpoint = zccache::ipc::unique_test_endpoint();
-    let mut server = DaemonServer::bind(&endpoint).unwrap();
+    let cache_root = tempfile::tempdir().expect("daemon cache tempdir");
+    let cache_dir: zccache::core::NormalizedPath = cache_root.path().join("zccache-cache").into();
+    let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
     let shutdown = server.shutdown_handle();
     let handle = tokio::spawn(async move {
         server.run(0).await.unwrap();
     });
-    (endpoint, handle, shutdown)
+    (endpoint, handle, shutdown, cache_root)
 }
 
 /// Helper: send a SessionStats request and extract the stats.
@@ -117,7 +126,7 @@ async fn session_stats_mid_session_query() {
             })
             .collect();
 
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
 
         // ── Start session with stats tracking ──
@@ -215,7 +224,7 @@ async fn session_stats_mid_session_query() {
 #[ignore] // integration-level: starts real daemon with IPC
 async fn session_stats_not_tracked_returns_none() {
     zccache::test_support::test_timeout(async {
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
 
         client
@@ -250,7 +259,7 @@ async fn session_stats_not_tracked_returns_none() {
 #[ignore] // integration-level: starts real daemon with IPC
 async fn session_stats_unknown_session() {
     zccache::test_support::test_timeout(async {
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
 
         client


### PR DESCRIPTION
Continues #1322's incremental conversion. Three files, eight tests recovered.

## All three were dead at the bind

None of these could start on a machine with a live daemon:

```
cache root ~/.zccache/v1.13.0 unusable: another live daemon already holds this cache root as its writer
```

Baselined before, run after:

| file | before | after |
|---|---|---|
| `daemon_pch_cache_invalidation_test` | 0 passed, 4 failed | **4 passed** |
| `daemon_profile_test` | 0 passed, 1 failed | **1 passed** |
| `daemon_session_stats_test` | 0 passed, 3 failed | **3 passed** |

Eight tests that previously could not run now do.

## One file needed a different shape

`daemon_profile_test` binds inline rather than through a `start_daemon` helper — it keeps the server in an `Arc<Mutex<Option<_>>>` so the test can read the profiler after shutdown. The tempdir is bound to a local there instead of being threaded through a return tuple. Same guarantee, different plumbing: it must outlive the daemon, since dropping it deletes the cache root out from under it.

## Scope, corrected

**8 of 29 relevant files** converted so far. The remaining figure is **24 unguarded**, not 34 total — five callers already set `ZCCACHE_CACHE_DIR` through a `CacheDirGuard` and are safe by construction. `lifecycle.rs:20-27` states this directly: guarded callers serialize on a mutex and cannot participate in the race. Converting them would be churn, and in at least one case (`daemon_depgraph_persistence_test`) actively wrong — it binds twice on purpose to prove the depgraph survives a restart, so a per-call tempdir would start the second daemon cold and silently stop testing persistence.

## Evidence

- `daemon_pch_cache_invalidation_test -- --ignored` — 4 passed, 0 failed
- `daemon_profile_test -- --ignored` — 1 passed, 0 failed
- `daemon_session_stats_test -- --ignored` — 3 passed, 0 failed
- `soldr cargo clippy -p zccache --features "…" --all-targets -- -D warnings` under `RUSTFLAGS="-D warnings"` — exit 0
- `soldr cargo fmt --all`

All three are `#[ignore]`d, so CI will not execute them — validation is local, which is the gap #1322 describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
