### PR TITLE
chore(deps): update running-process to 4.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +961,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
@@ -1972,6 +1991,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,8 +2614,8 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.6.4"
-source = "git+https://github.com/zackees/running-process.git?rev=59556ebbb779a66a95811c75bb1533cf3db1c525#59556ebbb779a66a95811c75bb1533cf3db1c525"
+version = "4.8.0"
+source = "git+https://github.com/zackees/running-process.git?rev=0374db2b2d3d9f4b4bb8db7c9372855853316f2f#0374db2b2d3d9f4b4bb8db7c9372855853316f2f"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2592,6 +2624,7 @@ dependencies = [
  "getrandom 0.4.2",
  "interprocess",
  "libc",
+ "png",
  "prost",
  "prost-build",
  "prost-types",
@@ -2605,6 +2638,7 @@ dependencies = [
  "toml",
  "winapi",
  "windows-sys 0.59.0",
+ "x11rb",
 ]
 
 [[package]]
@@ -4013,6 +4047,23 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ lzma-rs = "0.3"
 sevenz-rust = "0.6"
 rkyv = "0.8"
 mimalloc = "0.1"
-running-process = { version = "4.6.0", git = "https://github.com/zackees/running-process.git", rev = "59556ebbb779a66a95811c75bb1533cf3db1c525", default-features = false, features = ["client-async"] }
+running-process = { version = "4.8.0", git = "https://github.com/zackees/running-process.git", rev = "0374db2b2d3d9f4b4bb8db7c9372855853316f2f", default-features = false, features = ["client-async"] }
 zccache = { path = "crates/zccache" }
 zccache-artifact = { path = "crates/zccache-artifact" }
 zccache-audit = { path = "crates/zccache-audit" }


### PR DESCRIPTION
## Summary

- pin running-process 4.8.0 at its published release commit `0374db2b2d3d9f4b4bb8db7c9372855853316f2f`
- preserve `default-features = false` with `client-async`
- refresh the lockfile; the graph resolves exactly one running-process package identity

Coordinated with FastLED/fbuild#1239. This PR must land before the next zccache release and fbuild dependency repin.

## Validation

- `soldr cargo tree -i running-process --locked`
- `soldr cargo check --workspace --all-targets`
- `soldr cargo clippy --workspace --all-targets -- -D warnings`
- `SOLDR_RUSTC_WRAPPER=none soldr cargo test -p zccache --lib -j 2`
- `git diff --check`
- pre-push dependency review: clean

The repository-wide unit wrapper exceeded its ten-minute local command window while several unrelated workspaces were compiling concurrently. Its first focused retry hit a silent cache-wrapper exit; the identical focused test passed with the repository-documented wrapper diagnostic escape hatch.