### PR TITLE
test(rustc): swallow CompileProgress heartbeats in the IPC helper (#1337)

### DIFF
--- a/crates/zccache/tests/daemon_rustc_cache_basic_test.rs
+++ b/crates/zccache/tests/daemon_rustc_cache_basic_test.rs
@@ -77,12 +77,22 @@ async fn compile(
         .await
         .unwrap();
 
-    match client.recv().await.unwrap() {
-        Some(Response::CompileResult {
-            exit_code, cached, ..
-        }) => (exit_code, cached),
-        Some(Response::Error { message }) => panic!("compile error: {message}"),
-        other => panic!("unexpected response: {other:?}"),
+    // #1216 pushes non-terminal `CompileProgress` heartbeats on the same
+    // connection while a compile is queued or running. The real wrapper
+    // swallows them (`wrap/ipc.rs`); this helper predates the feature and
+    // treated the first frame as terminal, so it panicked with
+    // "unexpected response: Some(CompileProgress { .. })" as soon as a compile
+    // took long enough to emit one. Nothing caught it because this file is
+    // `#[ignore]`d and CI does not run it (#1322).
+    loop {
+        match client.recv().await.unwrap() {
+            Some(Response::CompileProgress { .. }) => continue,
+            Some(Response::CompileResult {
+                exit_code, cached, ..
+            }) => return (exit_code, cached),
+            Some(Response::Error { message }) => panic!("compile error: {message}"),
+            other => panic!("unexpected response: {other:?}"),
+        }
     }
 }
 


### PR DESCRIPTION
Fixes one instance of #1337, found while baselining files for #1322.

## What broke

`daemon_rustc_cache_basic_test` failed with:

```
unexpected response: Some(CompileProgress {
    queue_position: 0, queue_depth: 0, in_flight: 1, phase: "compiling" })
```

#1216 pushes non-terminal `CompileProgress` frames on the *same* connection as the request. The production wrapper swallows them (`wrap/ipc.rs`, with a test named `compile_progress_is_never_relayed_as_a_terminal_response`). This test helper predates the feature and treated the first frame received as terminal.

```
before: 4 passed, 3 failed
after:  6 passed, 1 failed
```

## The remaining failure is not this

`test_rustc_check_metadata_hits_build_metadata_link` still fails on a genuine cache-hit assertion — "check-style compile should hit build-style artifact" — which is behaviour, not frame handling. Same open question as #1328: real defect or stale expectation. Not guessed at here.

## The wider problem, filed as #1337

**25 of the 27 test files matching `Response::CompileResult` never handle `CompileProgress`.** The heartbeat interval is 5 s, so those tests pass when a compile is fast and fail when it is slow — load-dependent flakiness by construction, in files CI never runs.

That is worth stating plainly because it changes how earlier failures in this suite should be read. I have attributed several intermittent failures during #1322 work to runner load; at least some were probably this.

I did **not** fix all 25 here. Each helper differs in shape and return type, several have multiple `recv` sites, and a blind sweep across files CI does not execute is the exact failure mode #1322 exists to document. #1337 also suggests a shared `recv_terminal()` helper, since every file hand-rolls the same match — which is why one protocol addition broke all of them simultaneously.

## Evidence

- `daemon_rustc_cache_basic_test -- --ignored` — 6 passed, 1 failed (was 4 passed, 3 failed)
- `soldr cargo check -p zccache --features "…" --test daemon_rustc_cache_basic_test` — exit 0
- `soldr cargo fmt --all`

`#[ignore]`d, so CI will not execute it — validation is local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
