### PR TITLE
test(profile): isolate cache roots + swallow heartbeats in profile tests (#1322, #1337)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -380,6 +380,23 @@ impl DaemonServer {
         self.state.profiler.snapshot()
     }
 
+    /// Cloneable handle for sampling the phase profiler *while the server is
+    /// running* (for benchmarks).
+    ///
+    /// `profile_snapshot` takes `&self`, so a profiling test that hands the
+    /// server to a `run()` task can only reach it by wrapping the server in a
+    /// `Mutex` — and `run()` holds that lock for the daemon's entire lifetime,
+    /// so any mid-run `lock().await.profile_snapshot()` deadlocks. Take this
+    /// handle *before* moving the server into the task and sample without
+    /// locking. See `daemon_cold_path_profile_test`.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn profile_handle(&self) -> ProfileHandle {
+        ProfileHandle {
+            state: Arc::clone(&self.state),
+        }
+    }
+
     /// Test-only seam: exercise the DashMap → on-disk-`ArtifactStore`
     /// fallback used by every artifact-lookup site.
     ///
@@ -569,5 +586,22 @@ mod tests {
             "first compile must see the loaded warm graph instead of the empty default"
         );
         assert!(state.dep_graph_persisted.load(Ordering::Acquire));
+    }
+}
+
+/// Lock-free handle for sampling a running daemon's phase profiler.
+///
+/// See [`DaemonServer::profile_handle`] for why this exists.
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct ProfileHandle {
+    state: Arc<SharedState>,
+}
+
+impl ProfileHandle {
+    /// Snapshot the phase profiler without acquiring any lock.
+    #[must_use]
+    pub fn snapshot(&self) -> super::super::stats::ProfileSnapshot {
+        self.state.profiler.snapshot()
     }
 }

--- a/crates/zccache/tests/daemon_cold_path_profile_test.rs
+++ b/crates/zccache/tests/daemon_cold_path_profile_test.rs
@@ -217,12 +217,17 @@ async fn compile_one(
         })
         .await
         .unwrap();
-    let (exit_code, cached) = match client.recv::<Response>().await.unwrap() {
-        Some(Response::CompileResult {
-            exit_code, cached, ..
-        }) => (exit_code, cached),
-        Some(Response::Error { message }) => panic!("compile error: {message}"),
-        other => panic!("expected CompileResult, got: {other:?}"),
+    // #1337: CompileProgress heartbeats (#1216) are non-terminal frames on
+    // this same connection; only a CompileResult ends the exchange.
+    let (exit_code, cached) = loop {
+        match client.recv::<Response>().await.unwrap() {
+            Some(Response::CompileProgress { .. }) => continue,
+            Some(Response::CompileResult {
+                exit_code, cached, ..
+            }) => break (exit_code, cached),
+            Some(Response::Error { message }) => panic!("compile error: {message}"),
+            other => panic!("expected CompileResult, got: {other:?}"),
+        }
     };
     (exit_code, cached, start.elapsed())
 }
@@ -421,7 +426,13 @@ async fn cold_path_stress_profile() {
     // Single daemon for all sizes — avoids index.redb lock contention.
     // We take profiler snapshots before/after each size to compute per-size averages.
     let endpoint = zccache::ipc::unique_test_endpoint();
-    let server = DaemonServer::bind(&endpoint).unwrap();
+    // #1322: bind an isolated cache root. Plain `bind` inherits the
+    // process-global cache dir, so this test failed on any machine with a live
+    // daemon: "another live daemon already holds this cache root as its
+    // writer" — before reaching any compile.
+    let cache_root = tempfile::tempdir().expect("daemon cache tempdir");
+    let cache_dir: zccache::core::NormalizedPath = cache_root.path().join("zccache-cache").into();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
     let shutdown = server.shutdown_handle();
     let server = Arc::new(Mutex::new(server));
     let server_clone = Arc::clone(&server);
@@ -622,7 +633,13 @@ async fn cold_path_concurrent_stress() {
 
     // Single daemon serving all sessions
     let endpoint = zccache::ipc::unique_test_endpoint();
-    let server = DaemonServer::bind(&endpoint).unwrap();
+    // #1322: bind an isolated cache root. Plain `bind` inherits the
+    // process-global cache dir, so this test failed on any machine with a live
+    // daemon: "another live daemon already holds this cache root as its
+    // writer" — before reaching any compile.
+    let cache_root = tempfile::tempdir().expect("daemon cache tempdir");
+    let cache_dir: zccache::core::NormalizedPath = cache_root.path().join("zccache-cache").into();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
     let shutdown = server.shutdown_handle();
     let server = Arc::new(Mutex::new(server));
     let server_clone = Arc::clone(&server);
@@ -753,7 +770,13 @@ async fn cold_path_first_file_penalty() {
 
     // Single daemon for all trials
     let endpoint = zccache::ipc::unique_test_endpoint();
-    let mut server = DaemonServer::bind(&endpoint).unwrap();
+    // #1322: bind an isolated cache root. Plain `bind` inherits the
+    // process-global cache dir, so this test failed on any machine with a live
+    // daemon: "another live daemon already holds this cache root as its
+    // writer" — before reaching any compile.
+    let cache_root = tempfile::tempdir().expect("daemon cache tempdir");
+    let cache_dir: zccache::core::NormalizedPath = cache_root.path().join("zccache-cache").into();
+    let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
     let shutdown = server.shutdown_handle();
     let handle = tokio::spawn(async move { server.run(0).await.unwrap() });
     tokio::time::sleep(Duration::from_millis(100)).await;

--- a/crates/zccache/tests/daemon_cold_path_profile_test.rs
+++ b/crates/zccache/tests/daemon_cold_path_profile_test.rs
@@ -434,6 +434,13 @@ async fn cold_path_stress_profile() {
     let cache_dir: zccache::core::NormalizedPath = cache_root.path().join("zccache-cache").into();
     let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
     let shutdown = server.shutdown_handle();
+    // #1322 unmasked a deadlock here: `run()` below holds this mutex for the
+    // daemon's entire lifetime, so the mid-loop
+    // `server.lock().await.profile_snapshot()` this replaces could never
+    // acquire it and the test hung forever. It was invisible while the test
+    // still died at `bind` in two seconds. Sample through a lock-free handle
+    // taken before the server moves into the run task.
+    let profile_handle = server.profile_handle();
     let server = Arc::new(Mutex::new(server));
     let server_clone = Arc::clone(&server);
     let handle = tokio::spawn(async move {
@@ -511,7 +518,7 @@ async fn cold_path_stress_profile() {
 
         // Take cumulative snapshot — we'll use the latest snapshot per size
         // since the profiler gives averages across all requests.
-        let profile = server.lock().await.profile_snapshot();
+        let profile = profile_handle.snapshot();
         all_results.push((file_count, cold_result, profile.clone()));
 
         eprintln!();

--- a/crates/zccache/tests/daemon_profile_multi_test.rs
+++ b/crates/zccache/tests/daemon_profile_multi_test.rs
@@ -78,7 +78,14 @@ async fn profile_multi_file_warm_path() {
 
     // Start daemon — keep server accessible for profile_snapshot()
     let endpoint = zccache::ipc::unique_test_endpoint();
-    let server = DaemonServer::bind(&endpoint).unwrap();
+    // #1322: bind an isolated cache root. Plain `bind` inherits the
+    // process-global cache dir, so this test fails on any machine with a live
+    // daemon ("another live daemon already holds this cache root as its
+    // writer") and, worse, shares cached artifacts with the developer's own
+    // builds — which for a *profiling* test silently changes what is measured.
+    let cache_root = tempfile::tempdir().expect("daemon cache tempdir");
+    let cache_dir: zccache::core::NormalizedPath = cache_root.path().join("zccache-cache").into();
+    let server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
     let shutdown = server.shutdown_handle();
 
     // We need to share the server so we can call profile_snapshot() later.
@@ -135,11 +142,16 @@ async fn profile_multi_file_warm_path() {
             })
             .await
             .unwrap();
-        match client.recv::<Response>().await.unwrap() {
-            Some(Response::CompileResult { exit_code, .. }) => {
-                assert_eq!(exit_code, 0);
+        loop {
+            match client.recv::<Response>().await.unwrap() {
+                // #1337: heartbeats (#1216) are non-terminal.
+                Some(Response::CompileProgress { .. }) => continue,
+                Some(Response::CompileResult { exit_code, .. }) => {
+                    assert_eq!(exit_code, 0);
+                    break;
+                }
+                other => panic!("expected CompileResult, got: {other:?}"),
             }
-            other => panic!("expected CompileResult, got: {other:?}"),
         }
     }
     eprintln!("  Cold done: {:.3}s\n", t0.elapsed().as_secs_f64());
@@ -165,14 +177,19 @@ async fn profile_multi_file_warm_path() {
             })
             .await
             .unwrap();
-        match client.recv::<Response>().await.unwrap() {
-            Some(Response::CompileResult {
-                exit_code, cached, ..
-            }) => {
-                assert_eq!(exit_code, 0);
-                assert!(cached, "iter {i} should be cached");
+        loop {
+            match client.recv::<Response>().await.unwrap() {
+                // #1337: heartbeats (#1216) are non-terminal.
+                Some(Response::CompileProgress { .. }) => continue,
+                Some(Response::CompileResult {
+                    exit_code, cached, ..
+                }) => {
+                    assert_eq!(exit_code, 0);
+                    assert!(cached, "iter {i} should be cached");
+                    break;
+                }
+                other => panic!("expected CompileResult, got: {other:?}"),
             }
-            other => panic!("expected CompileResult, got: {other:?}"),
         }
         let elapsed = t.elapsed();
         multi_times.push(elapsed);


### PR DESCRIPTION
Third batch for #1337 / #1322 — the two profiling test files.

## These were missed by the original audit

Both call `client.recv::<Response>()` with a turbofish. The `client.recv()` grep used to enumerate affected files did not match that form, so both were listed as "0 recv sites" and looked like false positives. They are not — they were affected all along.

Worth noting for the remaining burn-down: the affected-file list in #1337 is a lower bound, not a census.

## What is fixed

**Heartbeats (#1337)** — three `recv` sites converted to loop past non-terminal `CompileProgress` frames.

**Cache-root isolation (#1322)** — `daemon_cold_path_profile_test` bound the process-global cache root at three sites, so all three of its tests died before compiling anything:

```
another live daemon already holds this cache root as its writer
```

For a *profiling* test the shared root is worse than a hard failure. When it does bind — i.e. when no other daemon happens to hold the lock — it shares cached artifacts with the developer's own builds, which silently changes what the profile measures. `daemon_profile_multi_test` was in exactly that state: it passed on a re-run only because the daemon holding the lock had exited.

## Verified

At `ZCCACHE_COMPILE_PROGRESS_INTERVAL_MS=50`:

```
daemon_profile_multi_test        1 passed; 0 failed
cold_path_concurrent_stress      failed at bind  ->  ok
cold_path_first_file_penalty     failed at bind  ->  ok
```

## One test is explicitly not claimed

`cold_path_stress_profile` is **not** verified here. With an isolated (empty) cache root it now performs the full cold workload it was always meant to, instead of dying at `bind` in two seconds, and it had not finished inside a 1500 s cap. I have no pre-change baseline for it precisely because it never got past `bind`.

A default-interval run is in flight to establish how long it legitimately takes. Until that lands I cannot distinguish "this stress test is genuinely long" from "the 50 ms heartbeat interval floods the connection", and I would rather say so than assert a green I did not observe.

Refs #1337, #1322.
