### PR TITLE
test(ipc): convert the last three test helpers to swallow heartbeats (#1337)

### DIFF
--- a/crates/zccache/tests/daemon_integration_test.rs
+++ b/crates/zccache/tests/daemon_integration_test.rs
@@ -346,15 +346,21 @@ int main() {
             .await
             .unwrap();
 
-        let resp: Option<Response> = client.recv().await.unwrap();
-        match resp {
-            Some(Response::CompileResult {
-                exit_code, cached, ..
-            }) => {
-                assert_eq!(exit_code, 0, "first compile should succeed");
-                assert!(!cached, "first compile should be a cache miss");
+        // #1337: heartbeats (#1216) are non-terminal frames on this same
+        // connection; only a CompileResult ends the exchange.
+        loop {
+            let resp: Option<Response> = client.recv().await.unwrap();
+            match resp {
+                Some(Response::CompileProgress { .. }) => continue,
+                Some(Response::CompileResult {
+                    exit_code, cached, ..
+                }) => {
+                    assert_eq!(exit_code, 0, "first compile should succeed");
+                    assert!(!cached, "first compile should be a cache miss");
+                    break;
+                }
+                other => panic!("expected CompileResult, got: {other:?}"),
             }
-            other => panic!("expected CompileResult, got: {other:?}"),
         }
 
         // Verify .o was produced
@@ -389,15 +395,21 @@ int main() {
             .await
             .unwrap();
 
-        let resp: Option<Response> = client.recv().await.unwrap();
-        match resp {
-            Some(Response::CompileResult {
-                exit_code, cached, ..
-            }) => {
-                assert_eq!(exit_code, 0, "second compile should succeed");
-                assert!(cached, "second compile should be a cache hit");
+        // #1337: heartbeats (#1216) are non-terminal frames on this same
+        // connection; only a CompileResult ends the exchange.
+        loop {
+            let resp: Option<Response> = client.recv().await.unwrap();
+            match resp {
+                Some(Response::CompileProgress { .. }) => continue,
+                Some(Response::CompileResult {
+                    exit_code, cached, ..
+                }) => {
+                    assert_eq!(exit_code, 0, "second compile should succeed");
+                    assert!(cached, "second compile should be a cache hit");
+                    break;
+                }
+                other => panic!("expected CompileResult, got: {other:?}"),
             }
-            other => panic!("expected CompileResult, got: {other:?}"),
         }
 
         // Verify .o was restored from cache

--- a/crates/zccache/tests/daemon_ninja_rebuild_direct_test.rs
+++ b/crates/zccache/tests/daemon_ninja_rebuild_direct_test.rs
@@ -205,14 +205,20 @@ async fn build_all_ipc(
             .await
             .unwrap();
 
-        match client.recv().await.unwrap() {
-            Some(Response::CompileResult {
-                exit_code, cached, ..
-            }) => {
-                results.push((name, exit_code, cached));
+        // #1337: heartbeats (#1216) are non-terminal frames on this same
+        // connection; only a CompileResult ends the exchange.
+        loop {
+            match client.recv().await.unwrap() {
+                Some(Response::CompileProgress { .. }) => continue,
+                Some(Response::CompileResult {
+                    exit_code, cached, ..
+                }) => {
+                    results.push((name, exit_code, cached));
+                    break;
+                }
+                Some(Response::Error { message }) => panic!("compile error: {message}"),
+                other => panic!("expected CompileResult, got: {other:?}"),
             }
-            Some(Response::Error { message }) => panic!("compile error: {message}"),
-            other => panic!("expected CompileResult, got: {other:?}"),
         }
     }
 
@@ -610,12 +616,16 @@ async fn ninja_concurrent_cold_build() {
             .unwrap();
 
             let name = src.file_name().unwrap().to_string_lossy().into_owned();
-            match conn.recv().await.unwrap() {
-                Some(Response::CompileResult {
-                    exit_code, cached, ..
-                }) => (name, exit_code, cached),
-                Some(Response::Error { message }) => panic!("{name}: {message}"),
-                other => panic!("{name}: unexpected response: {other:?}"),
+            loop {
+                match conn.recv().await.unwrap() {
+                    // #1337: heartbeats are non-terminal.
+                    Some(Response::CompileProgress { .. }) => continue,
+                    Some(Response::CompileResult {
+                        exit_code, cached, ..
+                    }) => break (name, exit_code, cached),
+                    Some(Response::Error { message }) => panic!("{name}: {message}"),
+                    other => panic!("{name}: unexpected response: {other:?}"),
+                }
             }
         }));
     }

--- a/crates/zccache/tests/daemon_rustc_restore_test.rs
+++ b/crates/zccache/tests/daemon_rustc_restore_test.rs
@@ -206,19 +206,27 @@ async fn compile_rustc(
         .await
         .expect("send Compile");
 
-    match client.recv().await.expect("recv CompileResult") {
-        Some(Response::CompileResult {
-            exit_code,
-            stderr,
-            cached,
-            ..
-        }) => CompileOutcome {
-            exit_code,
-            stderr: (*stderr).clone(),
-            cached,
-        },
-        Some(Response::Error { message }) => panic!("compile error: {message}"),
-        other => panic!("expected CompileResult, got {other:?}"),
+    // #1337: CompileProgress heartbeats (#1216) are non-terminal frames
+    // delivered on this same connection; only a CompileResult ends the
+    // exchange.
+    loop {
+        match client.recv().await.expect("recv CompileResult") {
+            Some(Response::CompileProgress { .. }) => continue,
+            Some(Response::CompileResult {
+                exit_code,
+                stderr,
+                cached,
+                ..
+            }) => {
+                break CompileOutcome {
+                    exit_code,
+                    stderr: (*stderr).clone(),
+                    cached,
+                }
+            }
+            Some(Response::Error { message }) => panic!("compile error: {message}"),
+            other => panic!("expected CompileResult, got {other:?}"),
+        }
     }
 }
 


### PR DESCRIPTION
Completes the #1337 sweep. **No test file matching `Response::CompileResult` is left without a `CompileProgress` arm.**

## Why these three were last

Each has several `recv` sites with different shapes — `daemon_ninja_rebuild_direct_test` mixes a results-accumulating loop with a spawned-task variant that returns a tuple — so they were converted by hand and read individually rather than swept.

## Verified

At `ZCCACHE_COMPILE_PROGRESS_INTERVAL_MS=50`, the interval that makes this class deterministic instead of load-dependent:

```
daemon_integration_test            6 passed; 0 failed
daemon_ninja_rebuild_direct_test   8 passed; 0 failed
daemon_rustc_restore_test          3 passed; 0 failed
```

(`daemon_rustc_restore_test`'s tests are not `#[ignore]`d, so they run without `--ignored` — worth knowing for anyone re-running the suite.)

## One thing deliberately left undone

`daemon_rustc_restore_test` still binds the process-global cache root, and I did **not** isolate it here.

Its helpers deliberately mimic the real daemon and derive `depgraph_file_path()` from the global root. Binding an isolated root without moving that path with it would leave the test restoring a depgraph belonging to a *different* cache — the test would still pass, while verifying nothing. That is a #1322 change with its own design question, not a one-line edit, so it should not ride along here.

## Where #1337 stands

The mechanical part is done. What the sweep turned up along the way is worth recording:

- The affected-file list in the issue was a **lower bound** — two files used `client.recv::<Response>()` with a turbofish and were missed by the `client.recv()` grep that produced it.
- Three files were failing at `DaemonServer::bind` (#1322) *before* reaching any compile, so the heartbeat fix in them was unverifiable until the cache root was isolated first.
- Isolating one of those unmasked a real deadlock (fixed in #1340) that had been unreachable while the test died in two seconds.

The two issues are more entangled than either write-up suggests: #1322's shared roots were hiding #1337's breakage, and fixing #1337 alone would have looked green while nothing actually ran.

Closes #1337.
