### PR TITLE
test(daemon): keep the corner-cases cache root alive for the daemon's lifetime (#1328)

### DIFF
--- a/crates/zccache/tests/daemon_adversarial_corner_cases.rs
+++ b/crates/zccache/tests/daemon_adversarial_corner_cases.rs
@@ -126,6 +126,12 @@ async fn compile_and_read(
 struct TestHarness {
     clang: NormalizedPath,
     tmp: tempfile::TempDir,
+    /// The daemon's isolated cache root, kept alive for as long as the daemon
+    /// itself (#1328). Binding this to `_cache_root` inside `new()` dropped
+    /// the TempDir the moment the constructor returned, deleting the cache
+    /// directory out from under the still-running daemon — so nothing could
+    /// ever be stored and *every* compile in this harness reported a miss.
+    _cache_root: tempfile::TempDir,
     #[expect(dead_code)]
     endpoint: String,
     server_handle: JoinHandle<()>,
@@ -141,13 +147,14 @@ impl TestHarness {
         let log = tmp.path().join("log.txt");
         let cwd = tmp.path().to_string_lossy().into_owned();
 
-        let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, cache_root) = start_daemon().await;
         let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
         let session_id = start_session(&mut client, &clang, &cwd, &log.to_string_lossy()).await;
 
         Some(Self {
             clang,
             tmp,
+            _cache_root: cache_root,
             endpoint,
             server_handle,
             shutdown,


### PR DESCRIPTION
The failing assertion was neither a caching bug nor a stale expectation. **The test harness was deleting the cache.**

## Root cause

```rust
let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
```

In `TestHarness::new()`, the isolated cache root's `TempDir` is bound to `_cache_root` — so it drops the moment the constructor returns, **deleting the daemon's cache directory while the daemon keeps running**. The daemon could never store anything, so every compile in this harness reported a miss. `corner_failed_compile_not_cached_then_header_appears` was simply the only test that asserted a hit.

## How it was narrowed

The issue explicitly left open whether this was a cache-correctness defect or test rot, so I measured instead of guessing. Each probe eliminated a hypothesis:

| Probe | Result |
|---|---|
| Repeat the "poisoned" source 4 more times | never cached |
| Control source, same header, **no prior failed compile** | never cached |
| Header-free source | never cached |
| Source whose header existed before any compile | never cached |
| Same source via a **second session** on the same daemon | never cached |

That ruled out the failed compile, the late-created header, and session scope in turn. Nothing cached at all — which pointed at the cache root rather than any caching logic. A 1.5 s watcher-settle delay also made no difference, ruling out an invalidation race.

## The fix

The `TempDir` is now owned by `TestHarness`. **The same latent bug was fixed in the watcher harness while converting #1337** — I introduced it there and caught it in review; here it already existed.

Only the constructor case is wrong. The other 36 `_cache_root` bindings in this suite live in test functions, where the binding already outlives the daemon, so they are left alone.

## Verified

```
ZCCACHE_COMPILE_PROGRESS_INTERVAL_MS=50  --test daemon_adversarial_corner_cases -- --ignored

test result: ok. 5 passed; 0 failed
```

Was 4 passed / 1 failed.

## Worth noting

This is the second defect where the fix for #1322 exposed something that had been invisible, and the second where an "isolated cache root" was isolated in name only. The pattern to watch for in the remaining conversions: **a returned `TempDir` bound to `_name` in a constructor is silently a no-op**, and the test still passes as long as it never asserts a cache hit.

Closes #1328.
