### PR TITLE
test(daemon): isolate the mutation-test cache root (#1330, #1322)

### DIFF
--- a/crates/zccache/tests/daemon_adversarial_mutations.rs
+++ b/crates/zccache/tests/daemon_adversarial_mutations.rs
@@ -31,18 +31,30 @@ type ClientConn = zccache::ipc::IpcClientConnection;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
+/// Start a daemon on a unique endpoint with an isolated cache root (#1322,
+/// #1330).
+///
+/// The returned `TempDir` MUST be kept alive for as long as the daemon runs.
+/// Binding it to `_cache_root` in a caller that returns (a `new()`
+/// constructor, say) drops it immediately and deletes the cache directory out
+/// from under the running daemon — the daemon then stores nothing and every
+/// compile reports a miss, which looks exactly like a cold-cache failure.
+/// That is #1328.
 async fn start_daemon() -> (
     String,
     tokio::task::JoinHandle<()>,
     std::sync::Arc<tokio::sync::Notify>,
+    tempfile::TempDir,
 ) {
     let endpoint = zccache::ipc::unique_test_endpoint();
-    let mut server = DaemonServer::bind(&endpoint).unwrap();
+    let cache_root = tempfile::tempdir().expect("daemon cache tempdir");
+    let cache_dir: zccache::core::NormalizedPath = cache_root.path().join("zccache-cache").into();
+    let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
     let shutdown = server.shutdown_handle();
     let handle = tokio::spawn(async move {
         server.run(0).await.unwrap();
     });
-    (endpoint, handle, shutdown)
+    (endpoint, handle, shutdown, cache_root)
 }
 
 async fn start_session(
@@ -122,6 +134,8 @@ async fn compile_and_read(
 struct TestHarness {
     clang: NormalizedPath,
     tmp: tempfile::TempDir,
+    /// Kept alive for the daemon's lifetime — see `start_daemon` (#1328).
+    _cache_root: tempfile::TempDir,
     #[expect(dead_code)]
     endpoint: String,
     server_handle: tokio::task::JoinHandle<()>,
@@ -137,13 +151,14 @@ impl TestHarness {
         let log = tmp.path().join("log.txt");
         let cwd = tmp.path().to_string_lossy().into_owned();
 
-        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let (endpoint, server_handle, shutdown, cache_root) = start_daemon().await;
         let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
         let session_id = start_session(&mut client, &clang, &cwd, &log.to_string_lossy()).await;
 
         Some(Self {
             clang,
             tmp,
+            _cache_root: cache_root,
             endpoint,
             server_handle,
             shutdown,


### PR DESCRIPTION
Isolates the mutation-test cache root — and **corrects the premise of #1330**, which I filed.

## The reported finding does not reproduce

#1330 claimed these six tests pass 6/6 only because they share the developer's warm `~/.zccache`, and go 0/6 against a private root — i.e. that they cannot fail for the reason they claim to test.

That is not what happens. With a private root whose `TempDir` is **correctly owned**, they pass **6/6 on a genuinely cold cache**, reproducibly:

```
run 1 (default interval)                       6 passed; 0 failed
run 2 (ZCCACHE_COMPILE_PROGRESS_INTERVAL_MS=50) 6 passed; 0 failed
```

I verified the isolation is real rather than nominal, since being fooled by a fake-isolated root is exactly what caused this:

```
DIAG cache_dir=C:\Users\niteris\.clud\tmp\.tmp3r8Vhl\zccache-cache
```

A fresh per-test tempdir. Not `~/.zccache`.

## What the original 0/6 actually was

#1328. The `TempDir` was bound to `_cache_root` inside `TestHarness::new()`, so it dropped the moment the constructor returned, **deleting the cache directory out from under the running daemon**. The daemon stored nothing, so every compile missed — which is indistinguishable from a cold-cache failure at the assertion level.

Both readings #1330 offered were therefore built on bad evidence:

- *"The tests are wrong"* — they are not; they establish their own state and pass cold.
- *"zccache is wrong"* — there is **no** caching defect here. In particular `mutation_touch_source_no_invalidation` ("touch a file, content unchanged, must still hit") passes on a cold root, so content-hash-as-ground-truth holds. I flagged that reading as significant if true; it is not true, and I would rather retract it explicitly than leave a suspected correctness defect on the record.

## What is still worth having

The conversion itself. These tests genuinely did bind the process-global root, so they raced other daemons even though they did not depend on a warm cache. `start_daemon` now documents the ownership requirement at the seam where it is easy to get wrong:

> The returned `TempDir` MUST be kept alive for as long as the daemon runs. Binding it to `_cache_root` in a caller that returns drops it immediately and deletes the cache directory out from under the running daemon — the daemon then stores nothing and every compile reports a miss, which looks exactly like a cold-cache failure.

That footgun has now produced two wrong conclusions (#1328's "cache-hit bug", #1330's "warm-cache dependency") and one bug I introduced and caught in review. Documenting it at the source seemed better than fixing the third instance later.

Closes #1330.
