### PR TITLE
test(perf): swallow compile progress heartbeats

### DIFF
--- a/crates/zccache/tests/perf_bench/c_project.rs
+++ b/crates/zccache/tests/perf_bench/c_project.rs
@@ -10,9 +10,9 @@
 
 use std::path::Path;
 use std::time::{Duration, Instant};
-use zccache::protocol::{Request, Response};
+use zccache::protocol::Request;
 
-use super::common::{clean_objects, ClientConn, NUM_FILES};
+use super::common::{clean_objects, recv_compile_result, ClientConn, NUM_FILES};
 
 pub fn c_source_names() -> Vec<String> {
     (0..NUM_FILES).map(|i| format!("unit_{i:03}.c")).collect()
@@ -197,12 +197,8 @@ pub async fn zccache_compile_c_single(
             })
             .await
             .unwrap();
-        match client.recv().await.unwrap() {
-            Some(Response::CompileResult { exit_code, .. }) => {
-                assert_eq!(exit_code, 0, "C compile failed for {src}");
-            }
-            other => panic!("expected CompileResult, got: {other:?}"),
-        }
+        let (exit_code, ..) = recv_compile_result(client).await;
+        assert_eq!(exit_code, 0, "C compile failed for {src}");
     }
     start.elapsed()
 }

--- a/crates/zccache/tests/perf_bench/common.rs
+++ b/crates/zccache/tests/perf_bench/common.rs
@@ -337,6 +337,25 @@ pub fn stop_sccache(sccache: &Path) {
     std::env::remove_var("SCCACHE_DIR");
 }
 
+/// Receive the terminal response for a compile request, ignoring heartbeats.
+pub async fn recv_compile_result(
+    client: &mut ClientConn,
+) -> (i32, std::sync::Arc<Vec<u8>>, std::sync::Arc<Vec<u8>>, bool) {
+    loop {
+        match client.recv().await.unwrap() {
+            Some(Response::CompileProgress { .. }) => continue,
+            Some(Response::CompileResult {
+                exit_code,
+                stdout,
+                stderr,
+                cached,
+            }) => return (exit_code, stdout, stderr, cached),
+            Some(Response::Error { message }) => panic!("compile error: {message}"),
+            other => panic!("expected CompileResult, got: {other:?}"),
+        }
+    }
+}
+
 pub async fn clear_zccache(client: &mut ClientConn) {
     client.send(&Request::Clear).await.unwrap();
     match client.recv().await.unwrap() {

--- a/crates/zccache/tests/perf_bench/cpp_project.rs
+++ b/crates/zccache/tests/perf_bench/cpp_project.rs
@@ -12,9 +12,9 @@
 
 use std::path::Path;
 use std::time::{Duration, Instant};
-use zccache::protocol::{Request, Response};
+use zccache::protocol::Request;
 
-use super::common::{clean_objects, ClientConn, NUM_FILES};
+use super::common::{clean_objects, recv_compile_result, ClientConn, NUM_FILES};
 use super::response_file::generate_response_files;
 
 pub fn source_names() -> Vec<String> {
@@ -160,12 +160,8 @@ pub async fn zccache_compile_single(
             })
             .await
             .unwrap();
-        match client.recv().await.unwrap() {
-            Some(Response::CompileResult { exit_code, .. }) => {
-                assert_eq!(exit_code, 0, "compile failed for {src}");
-            }
-            other => panic!("expected CompileResult, got: {other:?}"),
-        }
+        let (exit_code, ..) = recv_compile_result(client).await;
+        assert_eq!(exit_code, 0, "compile failed for {src}");
     }
     start.elapsed()
 }
@@ -195,18 +191,12 @@ pub async fn zccache_compile_multi(
         })
         .await
         .unwrap();
-    match client.recv().await.unwrap() {
-        Some(Response::CompileResult {
-            exit_code, cached, ..
-        }) => {
-            assert_eq!(exit_code, 0, "multi-file compile failed");
-            assert_eq!(
-                cached, expected_cached,
-                "multi-file compile returned an unexpected cache state"
-            );
-        }
-        other => panic!("expected CompileResult, got: {other:?}"),
-    }
+    let (exit_code, _, _, cached) = recv_compile_result(client).await;
+    assert_eq!(exit_code, 0, "multi-file compile failed");
+    assert_eq!(
+        cached, expected_cached,
+        "multi-file compile returned an unexpected cache state"
+    );
     start.elapsed()
 }
 
@@ -339,12 +329,8 @@ pub async fn zccache_compile_cpp_single_with_env(
             })
             .await
             .unwrap();
-        match client.recv().await.unwrap() {
-            Some(Response::CompileResult { exit_code, .. }) => {
-                assert_eq!(exit_code, 0, "compile failed for {src}");
-            }
-            other => panic!("expected CompileResult, got: {other:?}"),
-        }
+        let (exit_code, ..) = recv_compile_result(client).await;
+        assert_eq!(exit_code, 0, "compile failed for {src}");
     }
     start.elapsed()
 }

--- a/crates/zccache/tests/perf_bench/link.rs
+++ b/crates/zccache/tests/perf_bench/link.rs
@@ -16,9 +16,9 @@ use zccache::protocol::{Request, Response};
 
 use super::common::{
     clean_link_outputs, clear_dir_contents, clear_zccache, dir_size_bytes, find_sccache, fmt_bytes,
-    fmt_dur, fmt_ratio, median, print_trials, run_tool_timed, start_daemon, start_fresh_sccache,
-    stop_sccache, try_run_sccache_tool_timed, try_run_tool, ClientConn, NUM_FILES, RUSTC_NUM_FILES,
-    WARM_TRIALS,
+    fmt_dur, fmt_ratio, median, print_trials, recv_compile_result, run_tool_timed, start_daemon,
+    start_fresh_sccache, stop_sccache, try_run_sccache_tool_timed, try_run_tool, ClientConn,
+    NUM_FILES, RUSTC_NUM_FILES, WARM_TRIALS,
 };
 use super::cpp_project::{generate_project, source_names};
 use super::rust_project::{
@@ -480,27 +480,17 @@ pub async fn run_zccache_rust_final_link_timed(
     // link/compile during recv(), so stopping the clock before it timed only
     // the IPC send (~0.000s) and made every link benchmark report a bogus
     // 0.000s cold/warm with absurd speedup ratios.
-    let response = client.recv().await.unwrap();
+    let (exit_code, _, stderr, cached) = recv_compile_result(client).await;
     let elapsed = start.elapsed();
-    match response {
-        Some(Response::CompileResult {
-            exit_code,
-            stderr,
-            cached,
-            ..
-        }) => {
-            assert_eq!(
-                exit_code,
-                0,
-                "zccache Rust link failed:\n{}",
-                String::from_utf8_lossy(&stderr)
-            );
-            assert_eq!(
-                cached, expected_cached,
-                "zccache Rust link cached={cached}, expected {expected_cached}"
-            );
-        }
-        other => panic!("expected CompileResult, got: {other:?}"),
-    }
+    assert_eq!(
+        exit_code,
+        0,
+        "zccache Rust link failed:\n{}",
+        String::from_utf8_lossy(&stderr)
+    );
+    assert_eq!(
+        cached, expected_cached,
+        "zccache Rust link cached={cached}, expected {expected_cached}"
+    );
     elapsed
 }

--- a/crates/zccache/tests/perf_bench/response_file.rs
+++ b/crates/zccache/tests/perf_bench/response_file.rs
@@ -11,9 +11,11 @@
 
 use std::path::Path;
 use std::time::{Duration, Instant};
-use zccache::protocol::{Request, Response};
+use zccache::protocol::Request;
 
-use super::common::{clean_objects, ClientConn, NUM_FILES, RSP_NUM_DEFINES, RSP_NUM_INCLUDES};
+use super::common::{
+    clean_objects, recv_compile_result, ClientConn, NUM_FILES, RSP_NUM_DEFINES, RSP_NUM_INCLUDES,
+};
 
 // ── Response-file generation ─────────────────────────────────────────────
 
@@ -194,12 +196,8 @@ pub async fn zccache_compile_single_rsp(
             })
             .await
             .unwrap();
-        match client.recv().await.unwrap() {
-            Some(Response::CompileResult { exit_code, .. }) => {
-                assert_eq!(exit_code, 0, "rsp compile failed for {src}");
-            }
-            other => panic!("expected CompileResult, got: {other:?}"),
-        }
+        let (exit_code, ..) = recv_compile_result(client).await;
+        assert_eq!(exit_code, 0, "rsp compile failed for {src}");
     }
     start.elapsed()
 }
@@ -223,11 +221,7 @@ pub async fn zccache_compile_multi_rsp(
         })
         .await
         .unwrap();
-    match client.recv().await.unwrap() {
-        Some(Response::CompileResult { exit_code, .. }) => {
-            assert_eq!(exit_code, 0, "multi-file rsp compile failed");
-        }
-        other => panic!("expected CompileResult, got: {other:?}"),
-    }
+    let (exit_code, ..) = recv_compile_result(client).await;
+    assert_eq!(exit_code, 0, "multi-file rsp compile failed");
     start.elapsed()
 }

--- a/crates/zccache/tests/perf_bench/rust_project.rs
+++ b/crates/zccache/tests/perf_bench/rust_project.rs
@@ -11,9 +11,9 @@
 
 use std::path::Path;
 use std::time::{Duration, Instant};
-use zccache::protocol::{Request, Response};
+use zccache::protocol::Request;
 
-use super::common::{ClientConn, RUSTC_NUM_FILES};
+use super::common::{recv_compile_result, ClientConn, RUSTC_NUM_FILES};
 
 pub fn generate_rust_project(dir: &Path) {
     // Create output directory (mimics cargo's target/debug/deps)
@@ -213,12 +213,8 @@ pub async fn run_zccache_rustc_batch(
             })
             .await
             .unwrap();
-        match client.recv().await.unwrap() {
-            Some(Response::CompileResult { exit_code, .. }) => {
-                assert_eq!(exit_code, 0, "zccache rustc failed for {src}")
-            }
-            other => panic!("expected CompileResult, got: {other:?}"),
-        }
+        let (exit_code, ..) = recv_compile_result(client).await;
+        assert_eq!(exit_code, 0, "zccache rustc failed for {src}");
     }
     start.elapsed()
 }
@@ -250,12 +246,8 @@ pub async fn run_zccache_rustc_batch_with_env(
             })
             .await
             .unwrap();
-        match client.recv().await.unwrap() {
-            Some(Response::CompileResult { exit_code, .. }) => {
-                assert_eq!(exit_code, 0, "zccache rustc failed for {src}")
-            }
-            other => panic!("expected CompileResult, got: {other:?}"),
-        }
+        let (exit_code, ..) = recv_compile_result(client).await;
+        assert_eq!(exit_code, 0, "zccache rustc failed for {src}");
     }
     start.elapsed()
 }

--- a/crates/zccache/tests/perf_bench/tests_probe_storm.rs
+++ b/crates/zccache/tests/perf_bench/tests_probe_storm.rs
@@ -27,7 +27,9 @@ use std::time::{Duration, Instant};
 
 use zccache::protocol::{Request, Response};
 
-use super::common::{fmt_dur, fmt_ratio, median, print_trials, start_daemon, WARM_TRIALS};
+use super::common::{
+    fmt_dur, fmt_ratio, median, print_trials, recv_compile_result, start_daemon, WARM_TRIALS,
+};
 
 /// Number of unique probe TUs. Matches the rough order-of-magnitude of
 /// what meson emits during a configure for a moderately-sized project
@@ -116,12 +118,8 @@ async fn zccache_probe_storm(
             })
             .await
             .unwrap();
-        match client.recv::<Response>().await.unwrap() {
-            Some(Response::CompileResult { exit_code, .. }) => {
-                assert_eq!(exit_code, 0, "probe compile via zccache failed");
-            }
-            other => panic!("expected CompileResult, got: {other:?}"),
-        }
+        let (exit_code, ..) = recv_compile_result(client).await;
+        assert_eq!(exit_code, 0, "probe compile via zccache failed");
     }
     start.elapsed()
 }


### PR DESCRIPTION
## Summary

- drain non-terminal `CompileProgress` frames in one shared perf-benchmark helper
- route all ten direct compile consumers through the helper
- preserve Rust final-link timing through the terminal `CompileResult`

Fixes #1344

## Test Plan

- [x] `soldr cargo fmt --all -- --check`
- [x] `soldr cargo check -p zccache --test perf_bench_test`
- [x] `ZCCACHE_COMPILE_PROGRESS_INTERVAL_MS=50 soldr cargo test -p zccache --test perf_bench_test -- perf_response_file --nocapture --ignored`
- [x] `ZCCACHE_COMPILE_PROGRESS_INTERVAL_MS=50 soldr cargo test -p zccache --test perf_bench_test -- perf_warm_cache_zccache_vs_sccache --nocapture --ignored`
- [x] `soldr cargo clippy -p zccache --test perf_bench_test -- -D warnings`
- [x] high-effort code review: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)