### PR TITLE
ci: run ignored integration and stress tests weekly (#1322)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,6 +4,7 @@ GitHub Actions workflow definitions.
 
 - **ci.yml** - Runs fmt, Dylint, MSRV, and doc builds on main and pull requests.
 - **ci-check.yml** - Reusable check/test workflow used by the OS-specific CI workflows.
+- **integration.yml** - Runs the normal Linux workspace integration suite on pushes and PRs; weekly/manual runs additionally execute every ignored integration/stress test without gating pull requests.
 - **fs-matrix.yml** - Requires real ReFS/FAT, btrfs/ext4/vfat, and macOS fixtures on PRs; scheduled/manual runs also execute >4 GiB ReFS and btrfs COW acceptance.
 - **clippy.yml** - Runs Clippy on pushes to main for the README status badge.
 - **benchmark-stats.yml** - Manual/scheduled zccache vs bare compiler vs sccache benchmark publisher for the README images and rendered stats page.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,9 @@ name: Integration
 # fastest platform (Linux).
 
 on:
+  workflow_dispatch:
+  schedule:
+    - cron: "43 5 * * 0"
   push:
     branches: [main]
     paths-ignore:
@@ -36,7 +39,9 @@ on:
       - "tasks/**"
 
 concurrency:
-  group: integration-${{ github.ref }}
+  # Keep scheduled/manual discovery runs together while separating them from
+  # normal push/PR gates on the same ref.
+  group: integration-${{ github.ref }}-${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'discovery' || github.event_name }}
   cancel-in-progress: true
 
 env:
@@ -181,6 +186,45 @@ jobs:
         run: |
           unset ZCCACHE_CACHE_DIR
           soldr cargo test -p zccache-daemon-core --test legacy_path_validation -- --ignored --test-threads=1
+      - name: Test ignored integration and stress suite
+        if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        shell: bash
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/integration
+          SOLDR_CACHE_LIFECYCLE: command
+          SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
+          SOLDR_TARGET_BLOCK_FREE_GB: "2"
+        run: |
+          set +e
+          unset ZCCACHE_CACHE_DIR
+          start=$SECONDS
+          timeout 90m soldr cargo test --workspace --features "$ZCCACHE_INTEGRATION_FEATURES" --no-fail-fast -- \
+            --ignored --test-threads=1 \
+            --skip bench_ --skip perf_ --skip profile_ \
+            --skip cold_path_stress_profile --skip cold_path_concurrent_stress \
+            --skip cold_path_first_file_penalty --skip persist_pool_bench 2>&1 | tee ignored-test-output.txt
+          status=${PIPESTATUS[0]}
+          dur=$((SECONDS - start))
+          echo "- **Ignored integration/stress (Linux)**: ${dur}s" >> "$GITHUB_STEP_SUMMARY"
+          if [ $status -ne 0 ]; then
+            {
+              echo '## Ignored Integration Test Failures'
+              echo '```'
+              awk '/^failures:$/,/^test result:/' ignored-test-output.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit $status
+      - name: Remove ignored-suite harness journals before strict audit
+        if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        shell: bash
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/integration
+        run: |
+          journal_root="$SOLDR_CACHE_DIR/cache/zccache/daemon-state"
+          if [[ -d "$journal_root" ]]; then
+            find "$journal_root" -type f -path '*/logs/*.jsonl' -print -delete
+          fi
       - name: Stop isolated test cache
         if: always()
         shell: bash


### PR DESCRIPTION
## Summary

- add a weekly/manual ignored integration and stress discovery lane
- keep push and pull-request Integration behavior unchanged
- reuse the existing isolated Linux self-test cache, cleanup, shutdown, and audit
- collect all failures with `--no-fail-fast` and bound discovery to 90 minutes
- exclude hosted timing/profile benchmarks per `PERF.md`

## Why this closes #1322

The issue's core finding is that ignored integration/stress tests are compiled but execute on no workflow. This adds the issue's proposed option 1 without putting a partly-red, expensive suite into every merge gate:

- `push` / `pull_request`: existing normal Integration job only; discovery step is skipped
- weekly schedule / manual dispatch: normal Integration checks first, then ignored integration/stress discovery

Scheduled and manual discovery runs share a concurrency lane, while normal push/PR runs cannot cancel them.

## Failure behavior

The discovery command is deliberately observational and recall-oriented:

```sh
soldr cargo test --workspace --features "$ZCCACHE_INTEGRATION_FEATURES" \
  --no-fail-fast -- --ignored --test-threads=1 ...
```

A red result is useful signal: every failing binary is allowed to run, failures are extracted into the step summary, and Cargo's status is preserved. Regardless of failure, journal cleanup, isolated-cache shutdown/archive, and strict log audit still run.

The raw ignored suite also contains hosted timing/profile benchmarks, which `CLAUDE.md`/`PERF.md` reserve for the sanctioned perf path. Those exact name families/cases are excluded; stress/correctness fixtures remain included.

## Scope

Only two files changed:

- `.github/workflows/integration.yml`
- `.github/workflows/README.md`

No Rust tests, ignore annotations, or fixtures were rewritten.

## Validation

- `actionlint .github/workflows/integration.yml` — pass
- `git diff --check` — pass
- high-effort review caught and fixed:
  - hosted perf/profile tests leaking into discovery
  - discovery failure skipping later targeted checks/cleanup in the first draft
- PR Integration must show the new discovery step **skipped** on `pull_request`
- after merge, manually dispatch Integration on `main` to validate actual ignored-test execution and post the resulting failure inventory to #1322

Closes #1322.
