### PR TITLE
test(daemon): exercise queue progress through the production compile gate (#1223)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/compile_progress.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/compile_progress.rs
@@ -115,6 +115,45 @@ pub(in crate::daemon) struct CompileQueueGuard {
     admitted: bool,
 }
 
+/// Owns one admitted compile slot and its queue-accounting guard.
+///
+/// Field order intentionally drops the semaphore permit first, then updates
+/// the diagnostic gauge, matching the inline production sequence this type
+/// replaces.
+pub(in crate::daemon) struct CompileGateGuard {
+    _permit: Option<tokio::sync::OwnedSemaphorePermit>,
+    _queue_guard: CompileQueueGuard,
+}
+
+/// Enter the production compile gate while publishing queue progress.
+///
+/// Returns the available-permit count sampled before waiting so the existing
+/// `compile_start` diagnostic can retain its exact payload.
+pub(in crate::daemon) async fn acquire_compile_gate(
+    semaphore: Option<&Arc<tokio::sync::Semaphore>>,
+    gauge: &Arc<CompileQueueGauge>,
+) -> (CompileGateGuard, Option<usize>) {
+    let mut queue_guard = gauge.enqueue();
+    let (permit, available_before) = if let Some(semaphore) = semaphore {
+        let available_before = semaphore.available_permits();
+        let permit = Arc::clone(semaphore)
+            .acquire_owned()
+            .await
+            .expect("compile concurrency semaphore must remain open");
+        (Some(permit), Some(available_before))
+    } else {
+        (None, None)
+    };
+    queue_guard.admit();
+    (
+        CompileGateGuard {
+            _permit: permit,
+            _queue_guard: queue_guard,
+        },
+        available_before,
+    )
+}
+
 impl CompileQueueGuard {
     /// Record that this request's permit was granted.
     pub(in crate::daemon) fn admit(&mut self) {

--- a/crates/zccache-daemon-core/src/daemon/server/connection/tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/connection/tests.rs
@@ -63,27 +63,65 @@ fn an_unparseable_interval_falls_back_rather_than_disabling() {
     );
 }
 
-/// The end-to-end shape criterion B of #1223 asks for: a compile that does
-/// not finish promptly must push progress frames to the waiting client, and
-/// the terminal response must still arrive afterwards.
+/// Criterion B of #1223: saturating the production compile gate must produce
+/// a truthful queued heartbeat on the request connection, then preserve the
+/// terminal response after the permit becomes available.
+///
+/// This intentionally isolates the gate/connection contract without spawning
+/// a compiler. Cache hits return before this gate, so the criterion here is
+/// continued service on the original connection, not cached-result semantics.
 #[tokio::test]
-async fn a_slow_compile_pushes_progress_frames_then_the_terminal_response() {
+async fn a_saturated_compile_gate_reports_queued_then_delivers_the_terminal_response() {
     let temp = tempfile::tempdir().expect("temp cache root");
     let endpoint = crate::ipc::unique_test_endpoint();
-    let server = super::super::tests::bind_isolated_server_at(&endpoint, temp.path());
+    let mut server = super::super::tests::bind_isolated_server_at(&endpoint, temp.path());
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+    Arc::get_mut(&mut server.state)
+        .expect("test owns the only SharedState reference")
+        .compile_concurrency = Some(Arc::clone(&semaphore));
 
-    let mut server = server;
+    // Occupy the sole slot through the same helper used by compile_exec. The
+    // request below must queue until its heartbeat reaches the client.
+    let (held_gate, _) = super::super::compile_progress::acquire_compile_gate(
+        server.state.compile_concurrency.as_ref(),
+        &server.state.compile_queue,
+    )
+    .await;
+    let (queued_tx, queued_rx) = tokio::sync::oneshot::channel();
+    let release = tokio::spawn(async move {
+        let did_observe_queued_progress =
+            tokio::time::timeout(std::time::Duration::from_secs(5), queued_rx)
+                .await
+                .is_ok_and(|result| result.is_ok());
+        drop(held_gate);
+        did_observe_queued_progress
+    });
+
     let client_endpoint = endpoint.clone();
     let client = tokio::spawn(async move {
         let mut client = crate::ipc::connect(&client_endpoint)
             .await
             .expect("client connects");
         client.send(&Request::Ping).await.expect("client sends");
-        let mut progress_frames = 0_usize;
+        let mut queued_tx = Some(queued_tx);
         loop {
             match client.recv::<Response>().await.expect("client receives") {
-                Some(Response::CompileProgress { .. }) => progress_frames += 1,
-                Some(terminal) => return (progress_frames, terminal),
+                Some(Response::CompileProgress {
+                    queue_position,
+                    queue_depth,
+                    in_flight,
+                    phase,
+                }) if queued_tx.is_some() => {
+                    assert_eq!(queue_position, 0, "queued request is next in line");
+                    assert_eq!(queue_depth, 1, "exactly one request is waiting");
+                    assert_eq!(in_flight, 1, "the sole compile slot is occupied");
+                    assert_eq!(phase, super::super::compile_progress::PHASE_QUEUED);
+                    if let Some(tx) = queued_tx.take() {
+                        tx.send(()).expect("release gate holder");
+                    }
+                }
+                Some(Response::CompileProgress { .. }) => {}
+                Some(terminal) => return terminal,
                 None => panic!("connection closed before a terminal response"),
             }
         }
@@ -93,13 +131,18 @@ async fn a_slow_compile_pushes_progress_frames_then_the_terminal_response() {
     let _ = conn.recv::<Request>().await.expect("server reads request");
 
     let outcome = guarded_dispatch_with_progress_every(
-        // Fast cadence supplied directly. Reading it from the environment
-        // would race every other test in this binary.
         Some(std::time::Duration::from_millis(40)),
         &mut conn,
         &ResponseWire::BincodeV15,
         &server.state,
-        slow_handler(std::time::Duration::from_millis(260)),
+        async {
+            let (_gate, _) = super::super::compile_progress::acquire_compile_gate(
+                server.state.compile_concurrency.as_ref(),
+                &server.state.compile_queue,
+            )
+            .await;
+            (Response::Pong, None)
+        },
     )
     .await;
 
@@ -108,17 +151,15 @@ async fn a_slow_compile_pushes_progress_frames_then_the_terminal_response() {
         .await
         .expect("terminal response is written");
 
-    let (progress_frames, terminal) = client.await.expect("client task");
+    let terminal = tokio::time::timeout(std::time::Duration::from_secs(5), client)
+        .await
+        .expect("client receives progress and terminal response before deadline")
+        .expect("client task");
     assert!(
-        progress_frames >= 1,
-        "a compile outliving the heartbeat interval must push at least one \
-         CompileProgress frame; got {progress_frames}"
+        release.await.expect("gate holder task"),
+        "client must observe queued progress before the held slot is released"
     );
-    assert_eq!(
-        terminal,
-        Response::Pong,
-        "progress frames must not replace or corrupt the terminal response"
-    );
+    assert_eq!(terminal, Response::Pong);
 }
 
 /// The documented kill switch has to actually switch off, and the compile

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -264,25 +264,23 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     //
     // Issue #1216: the wait is registered in `state.compile_queue` so the
     // connection layer can push `CompileProgress` heartbeats naming this
-    // request's queue position while it sits here. `_queue_guard` restores
-    // the counters on every exit path, including cancellation.
+    // request's queue position while it sits here. `_compile_gate` restores
+    // the permit and counters on every exit path, including cancellation.
     let client_pid = lineage.client_pid.unwrap_or(0);
-    let mut _queue_guard = state.compile_queue.enqueue();
-    let _permit = if let Some(sem) = state.compile_concurrency.as_ref() {
-        let available_before = sem.available_permits();
-        let permit = Arc::clone(sem).acquire_owned().await.ok();
-        _queue_guard.admit();
+    let (_compile_gate, available_before) =
+        crate::daemon::server::compile_progress::acquire_compile_gate(
+            state.compile_concurrency.as_ref(),
+            &state.compile_queue,
+        )
+        .await;
+    if let Some(available_before) = available_before {
         tracing::info!(
             event = "compile_start",
             client_pid,
             available_before,
             "compile_start client_pid={client_pid} available_before={available_before}",
         );
-        permit
-    } else {
-        _queue_guard.admit();
-        None
-    };
+    }
     let compile_span_start = std::time::Instant::now();
 
     let (result, streamed_output) = if let Some(context) = crate::daemon::compile_output::current()


### PR DESCRIPTION
## Summary

- extract the existing single-compile semaphore + queue-accounting acquisition into one internal RAII helper
- drive that production gate through the real `CompileProgress` heartbeat loop and a real IPC connection
- prove a capacity-one saturated gate reports truthful queued metrics, then delivers the terminal response after admission
- fail loudly if the compile semaphore is ever closed instead of silently running uncapped

## Criterion B — precise contract

The original meta says the queued request should "complete on the cached path." That sequence cannot occur in production: cache hits return before `run_compile_exec`, while the semaphore is reached only after cache lookup has missed.

The reliability contract that matters is:

> A request queued at the compiler gate stays on its original daemon/IPC connection, receives progress that keeps the client wedge budget alive, and receives its terminal response after admission — rather than being mistaken for a hung daemon or rerun through an uncached fallback.

The upgraded existing connection test proves exactly that without spawning a compiler:

1. configure the real `SharedState.compile_concurrency` to capacity 1;
2. occupy its only slot through the same production helper used by `run_compile_exec`;
3. queue a second acquisition inside `guarded_dispatch_with_progress_every`;
4. receive over a real `IpcConnection`:
   - `phase == "queued"`
   - `queue_position == 0`
   - `queue_depth == 1`
   - `in_flight == 1`
5. release the first slot;
6. receive terminal `Pong` on the same connection.

Bounded coordination prevents a heartbeat regression from hanging the test.

## Scope

Three focused files:

- `compile_progress.rs` — internal gate guard/helper
- `compile_exec.rs` — replace only the previous inline acquisition
- `connection/tests.rs` — upgrade one existing test

No protocol, wrapper semantics, staged/multi-source lane, compiler fixture, or broad integration test was changed.

## RED → GREEN

RED before helper extraction:

```
error[E0425]: cannot find function `acquire_compile_gate`
```

GREEN:

```
focused saturated-gate test: 1 passed
connection tests:             6 passed
compile_progress tests:       7 passed
compile_concurrency tests:   10 passed
```

Also passed:

- `soldr cargo fmt --all -- --check`
- focused `cargo clippy ... -- -D warnings`
- `git diff --check`

## Criterion A disposition after merge

This PR deliberately does not change wrapper exit codes. Exit 125 is documented for **pre-dispatch** daemon unavailability. A mid-build daemon death is `DeliveryUnknown`; exit 1 remains the honest result because the compiler may already have run. The unsafe uncached fallback was structurally removed, and the executable refusal tests prove the tool does not run in the pre-dispatch case.

Closes #1223.
