### PR TITLE
docs: correct the redb references that misdescribe the artifact index

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ zccache status
 ```
 
 When set and non-empty, the override is used for `artifacts/`, `tmp/`,
-`depgraph/`, `index.redb`, `crashes/`, `logs/`, daemon lock files, download
+`depgraph/`, `index.bin`, `crashes/`, `logs/`, daemon lock files, download
 daemon state, and the default daemon endpoint. Separate cache roots therefore
 use separate daemon instances unless `ZCCACHE_ENDPOINT` is explicitly set.
 Relative override paths are normalized against the current working directory.
@@ -1252,7 +1252,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full system design.
 | `zccache-ipc` | Transport layer (Unix sockets / named pipes) |
 | `zccache-hash` | blake3 hashing and cache key computation |
 | `zccache-fscache` | In-memory file metadata cache |
-| `zccache-artifact` | Disk-backed artifact store with redb index |
+| `zccache-artifact` | Disk-backed artifact store with bincode index |
 | `zccache-watcher` | File watcher subsystem: daemon `notify` pipeline plus Rust-backed Python watcher bindings |
 | `zccache-compiler` | Compiler detection and argument parsing |
 | `zccache-gha` | GitHub Actions Cache API client |

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -68,7 +68,7 @@ zccache-test-support (dev-only test utilities)
 - **zccache-protocol** — `Request`/`Response` enums, `ArtifactData`, length-prefixed bincode framing; bump `PROTOCOL_VERSION` on any wire-format change
 - **zccache-ipc** — Platform IPC endpoint discovery (`default_endpoint()`: Unix sockets vs named pipes)
 - **zccache-fscache** — `MetadataCache` (DashMap-backed) with `Confidence` levels and time-based decay
-- **zccache-artifact** — Content-addressed disk store with 2-level hex sharding, redb index for LRU eviction; also Rust-plan bundle save/restore
+- **zccache-artifact** — Content-addressed disk store with 2-level hex sharding, in-memory index snapshotted to a bincode blob (`index.bin`) for LRU eviction; also Rust-plan bundle save/restore
 - **zccache-watcher** — `FileWatcher` trait over notify crate; dedicated OS thread, events via tokio channel
 - **zccache-compiler** — `CompilerFamily` detection, `ParsedInvocation` for cacheability checks (clang/gcc/msvc/rustc/clang-cl), plus `parse_linker`, `parse_archiver`, `parse_msvc`, `parse_rustfmt`, `response_file`, `strict_paths`, `arduino` submodules
 - **zccache-depgraph** — Persistent dependency graph for cache invalidation; snapshot save/load, dep walker
@@ -101,7 +101,7 @@ zccache-test-support (dev-only test utilities)
 
 **Cache keys:** blake3 hash of: compiler identity + sorted args + sorted env vars + source content hash + dependency hashes. Domain separation tag "zccache-cache-key-v1".
 
-**Concurrency:** Tokio tasks for IPC, DashMap for metadata cache (sharded lock-free reads), redb MVCC for artifact index, file watcher on dedicated OS thread.
+**Concurrency:** Tokio tasks for IPC, DashMap for metadata cache (sharded lock-free reads), DashMap for the artifact index (disk I/O only in the background WAL writer's `flush()`), file watcher on dedicated OS thread.
 
 ## File-size discipline
 

--- a/crates/zccache-cli-core/src/cli/commands/tests/cache_ops.rs
+++ b/crates/zccache-cli-core/src/cli/commands/tests/cache_ops.rs
@@ -271,7 +271,7 @@ fn warm_skips_missing_payloads() {
 fn warm_returns_error_on_missing_index() {
     let dir = tempfile::tempdir().unwrap();
     let result = warm_target(
-        &dir.path().join("nonexistent.redb"),
+        &dir.path().join("nonexistent.bin"),
         &dir.path().join("artifacts"),
         &dir.path().join("target"),
         "debug",
@@ -291,7 +291,7 @@ fn warm_waits_for_the_staged_store_lock_before_materializing() {
     let dir = tempfile::tempdir().unwrap();
     let artifact_dir = dir.path().join("artifacts");
     let target_dir = dir.path().join("target");
-    let index_path = dir.path().join("index.redb");
+    let index_path = dir.path().join("index.bin");
     std::fs::create_dir_all(&artifact_dir).unwrap();
 
     let key = "aaaaaaaabbbbbbbb";

--- a/crates/zccache/tests/daemon_cold_path_profile_test.rs
+++ b/crates/zccache/tests/daemon_cold_path_profile_test.rs
@@ -423,7 +423,7 @@ async fn cold_path_stress_profile() {
     let mut all_results: Vec<(usize, ColdPassResult, zccache::daemon::ProfileSnapshot)> =
         Vec::new();
 
-    // Single daemon for all sizes — avoids index.redb lock contention.
+    // Single daemon for all sizes — avoids cache-root writer-lock contention.
     // We take profiler snapshots before/after each size to compute per-size averages.
     let endpoint = zccache::ipc::unique_test_endpoint();
     // #1322: bind an isolated cache root. Plain `bind` inherits the

--- a/crates/zccache/tests/daemon_persist_pool_bench.rs
+++ b/crates/zccache/tests/daemon_persist_pool_bench.rs
@@ -6,7 +6,7 @@
 //!         let _permit = persist_semaphore.acquire().await;
 //!         spawn_blocking(|| {
 //!             for payload in payloads { std::fs::write(path, payload) }
-//!             artifact_store.insert(key, meta)   // redb
+//!             artifact_store.insert(key, meta)   // in-memory index
 //!         }).await
 //!     })
 //!
@@ -184,8 +184,8 @@ fn artifact_filename(key_hex: &str, idx: usize) -> String {
 }
 
 fn open_store(dir: &Path) -> Arc<ArtifactStore> {
-    let store_path = dir.join("index.redb");
-    Arc::new(ArtifactStore::open(&store_path).expect("open redb store"))
+    let store_path = dir.join("index.bin");
+    Arc::new(ArtifactStore::open(&store_path).expect("open artifact store"))
 }
 
 /// Pack header layout for `.pack` files:
@@ -220,7 +220,7 @@ fn build_pack(payloads: &[Arc<Vec<u8>>]) -> Vec<u8> {
 }
 
 /// Strategy A: today's behaviour. semaphore=8, serial writes within task,
-/// redb insert inside the spawn_blocking under the semaphore.
+/// Index insert inside the spawn_blocking under the semaphore.
 async fn run_strategy_serial_in_task(
     artifact_dir: PathBuf,
     store: Arc<ArtifactStore>,
@@ -252,7 +252,7 @@ async fn run_strategy_serial_in_task(
 }
 
 /// Strategy B: fan out each payload as its own spawn_blocking. The semaphore
-/// caps total in-flight writes, not "tasks". redb insert still inside, but
+/// caps total in-flight writes, not "tasks". Index insert still inside, but
 /// only one of the payloads (the last) carries the insert so we don't
 /// duplicate it.
 async fn run_strategy_fanout_payloads(
@@ -284,7 +284,7 @@ async fn run_strategy_fanout_payloads(
                 .ok();
             }));
         }
-        // After all payloads land, commit the redb row. Off the disk-write semaphore.
+        // After all payloads land, record the index row. Off the disk-write semaphore.
         handles.push(tokio::spawn(async move {
             for h in payload_handles {
                 let _ = h.await;
@@ -305,9 +305,9 @@ async fn run_strategy_fanout_payloads(
 }
 
 /// Strategy D: today's serial-within-task disk writes (semaphore-gated), but
-/// redb commits flow through a separate single-writer task fed by an unbounded
+/// Index writes flow through a separate single-writer task fed by an unbounded
 /// channel. Mirrors the new implementation in `server.rs` after iteration 2.
-async fn run_strategy_serial_in_task_async_redb(
+async fn run_strategy_serial_in_task_async_store(
     artifact_dir: PathBuf,
     store: Arc<ArtifactStore>,
     jobs: Vec<Job>,
@@ -366,9 +366,9 @@ async fn run_strategy_serial_in_task_async_redb(
 
 /// Strategy E: packed write — concatenate every payload of a job into a
 /// single `.pack` file (one `std::fs::write` per job instead of N), plus the
-/// same async redb channel as Strategy D. Goal: collapse Defender's
+/// same async index channel as Strategy D. Goal: collapse Defender's
 /// per-file scan overhead, which is the *unit* of the slowdown on Windows.
-async fn run_strategy_packed_async_redb(
+async fn run_strategy_packed_async_store(
     artifact_dir: PathBuf,
     store: Arc<ArtifactStore>,
     jobs: Vec<Job>,
@@ -424,9 +424,9 @@ async fn run_strategy_packed_async_redb(
     let _ = writer.await;
 }
 
-/// Strategy C: fanout + batched redb commits (single writer task drains a
+/// Strategy C: fanout + batched index writes (single writer task drains a
 /// channel of completed jobs and inserts them in batches of 32).
-async fn run_strategy_fanout_batched_redb(
+async fn run_strategy_fanout_batched_store(
     artifact_dir: PathBuf,
     store: Arc<ArtifactStore>,
     jobs: Vec<Job>,
@@ -574,15 +574,27 @@ async fn persist_pool_bench() {
         ("fanout payloads", "fanout_payloads", 32),
         ("fanout payloads", "fanout_payloads", 64),
         ("fanout payloads", "fanout_payloads", 128),
-        ("fanout + batched redb", "fanout_batched_redb", 32),
-        ("fanout + batched redb", "fanout_batched_redb", 64),
-        ("fanout + batched redb", "fanout_batched_redb", 128),
-        ("serial + async redb (new)", "serial_in_task_async_redb", 8),
-        ("serial + async redb (new)", "serial_in_task_async_redb", 16),
-        ("serial + async redb (new)", "serial_in_task_async_redb", 32),
-        ("packed + async redb", "packed_async_redb", 8),
-        ("packed + async redb", "packed_async_redb", 16),
-        ("packed + async redb", "packed_async_redb", 32),
+        ("fanout + batched store", "fanout_batched_store", 32),
+        ("fanout + batched store", "fanout_batched_store", 64),
+        ("fanout + batched store", "fanout_batched_store", 128),
+        (
+            "serial + async store (new)",
+            "serial_in_task_async_store",
+            8,
+        ),
+        (
+            "serial + async store (new)",
+            "serial_in_task_async_store",
+            16,
+        ),
+        (
+            "serial + async store (new)",
+            "serial_in_task_async_store",
+            32,
+        ),
+        ("packed + async store", "packed_async_store", 8),
+        ("packed + async store", "packed_async_store", 16),
+        ("packed + async store", "packed_async_store", 32),
     ];
 
     let mut rows = Vec::new();
@@ -622,8 +634,8 @@ async fn persist_pool_bench() {
                     )
                     .await;
                 }
-                "fanout_batched_redb" => {
-                    run_strategy_fanout_batched_redb(
+                "fanout_batched_store" => {
+                    run_strategy_fanout_batched_store(
                         artifact_dir.clone(),
                         Arc::clone(&store),
                         jobs,
@@ -631,8 +643,8 @@ async fn persist_pool_bench() {
                     )
                     .await;
                 }
-                "serial_in_task_async_redb" => {
-                    run_strategy_serial_in_task_async_redb(
+                "serial_in_task_async_store" => {
+                    run_strategy_serial_in_task_async_store(
                         artifact_dir.clone(),
                         Arc::clone(&store),
                         jobs,
@@ -640,8 +652,8 @@ async fn persist_pool_bench() {
                     )
                     .await;
                 }
-                "packed_async_redb" => {
-                    run_strategy_packed_async_redb(
+                "packed_async_store" => {
+                    run_strategy_packed_async_store(
                         artifact_dir.clone(),
                         Arc::clone(&store),
                         jobs,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@ This document is the index for zccache's architecture specification. Each subsys
 | [architecture/data-flow.md](architecture/data-flow.md) | ~160 | Cache hit, cache miss, passthrough traces + rustc key-scope rules (env-deps, incremental, crate types) |
 | [architecture/ipc.md](architecture/ipc.md) | ~100 | Transport abstraction, socket discovery, connection lifecycle, compile progress heartbeats, errors |
 | [architecture/metadata-cache.md](architecture/metadata-cache.md) | ~130 | In-memory cache data model, confidence levels, watcher integration |
-| [architecture/artifact-store.md](architecture/artifact-store.md) | ~130 | Disk layout, redb index schema, LRU eviction, corruption detection |
+| [architecture/artifact-store.md](architecture/artifact-store.md) | ~130 | Disk layout, bincode index schema, LRU eviction, corruption detection |
 | [architecture/rust-artifact-plan.md](architecture/rust-artifact-plan.md) | ~120 | Rust plan ownership, thin/full semantics, restore hardening, backends, diagnostics, CLI contract |
 | [architecture/embedded-service.md](architecture/embedded-service.md) | ~290 | Embedded service MVP boundary, audit continuity, soldr/fbuild integration design |
 | [architecture/target-cache.md](architecture/target-cache.md) | ~70 | Legacy action target snapshot ownership, outputs, and rust-plan boundary |

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -192,7 +192,10 @@ This document records the key architectural and technical decisions for **zccach
 
 ---
 
-## DD-008: redb for Artifact Index
+## DD-008: redb for Artifact Index — SUPERSEDED
+
+> [!IMPORTANT]
+> **Superseded.** The artifact index is no longer redb — it is an in-memory `DashMap` snapshotted to a bincode blob at `index.bin`. The decision below is kept for the historical record; see **Superseded by** at the end of this entry for why it changed, and [architecture/artifact-store.md](architecture/artifact-store.md) for the current design.
 
 **Context:** The artifact cache needs a persistent index that maps cache keys to artifact locations and tracks access times for LRU eviction. The index must survive daemon restarts and be corruption-resistant.
 
@@ -216,6 +219,14 @@ This document records the key architectural and technical decisions for **zccach
 **Consequences:**
 - The redb file lives in the cache directory. If corrupted, it can be deleted and rebuilt by scanning the content-addressed artifact store.
 - redb's API is simpler than SQL, which limits future query flexibility. Acceptable for the current access patterns.
+
+**Superseded by:** the bincode index blob (`index.bin`). The premise above — that the index must be *queried* from disk — turned out to be wrong. The daemon keeps a complete authoritative copy of the index in memory (`SharedState::artifacts`), so the on-disk file is read exactly once, at startup, and is otherwise write-only. Under that access pattern redb's per-transaction fsync was pure cost: one sequential blob write per flush replaced one fsync per commit, and startup became a single `fs::read` + deserialize.
+
+The tradeoff accepted in exchange is coarser durability — a crash *between* flushes loses the whole delta, where redb would recover to the last committed transaction. That is tolerable because the artifact files themselves stay on disk, so the worst case is a re-miss on the unflushed keys. Graceful shutdown flushes synchronously.
+
+Note that the "corrupted → delete and rebuild" consequence above survives the change: `ArtifactStore` reports `started_corrupt` and the daemon owns the rebuild policy.
+
+Legacy `index.redb` files are left on disk untouched by the migration; remove them with `zccache clear` or by hand. The full rationale lives with the code, in the `## Why not redb` module doc of [`crates/zccache-artifact/src/store.rs`](../crates/zccache-artifact/src/store.rs).
 
 ---
 
@@ -338,7 +349,7 @@ Example: cache key `a1b2c3d4...` is stored at `<cache_root>/artifacts/a1/b2/a1b2
 | Size-weighted LRU | Premature optimization. Adds complexity for marginal benefit in v1. |
 
 **Consequences:**
-- Every cache hit updates the access time in redb. This is a write on the read path, but redb writes are fast and batched.
+- Every cache hit updates the access time in the in-memory index. This is a write on the read path, but it touches only a DashMap shard — the disk snapshot happens on the background writer's timer.
 - Eviction runs in the background and does not block cache lookups.
 - Users can manually clear the cache or adjust the threshold via configuration.
 
@@ -422,7 +433,10 @@ This catches the scenario where a file is deleted and a new file is created at t
 
 ---
 
-### Q3: Artifact Index — redb
+### Q3: Artifact Index
+
+> [!NOTE]
+> Describes the superseded redb design; see DD-008 and [architecture/artifact-store.md](architecture/artifact-store.md) for the bincode index in use today.
 
 The redb database contains two tables:
 
@@ -442,7 +456,7 @@ redb provides ACID transactions, so a crash during an index update never leaves 
 The daemon is built async-first on tokio:
 - **IPC listener** runs as a tokio task, spawning a new task per connection.
 - **Compiler execution** uses `tokio::process::Command` for non-blocking child process management.
-- **Cache operations** are synchronous but fast (in-memory DashMap lookups, redb reads). They run on the tokio runtime without blocking issues because individual operations complete in microseconds.
+- **Cache operations** are synchronous but fast (in-memory DashMap lookups). They run on the tokio runtime without blocking issues because individual operations complete in microseconds.
 - **Disk I/O** for artifact reads/writes uses `tokio::fs` or `spawn_blocking` for operations that may take longer.
 
 The CLI is *not* fully async. It uses `tokio::runtime::Runtime::block_on` to make a single IPC request and wait for the response.
@@ -495,7 +509,7 @@ The daemon can crash at any point. The recovery strategy ensures no data corrupt
 
 1. **Artifact store:** Content-addressed and written atomically (DD-010). A crash during a write leaves a temp directory that is cleaned up on next startup. No corrupt artifacts at final paths.
 
-2. **redb index:** ACID transactions. A crash during a write rolls back the incomplete transaction. The database is consistent on recovery. If the database file is irrecoverably corrupted, delete it and rebuild from the artifact directory.
+2. **`index.bin`:** rewritten whole on each flush, so it is never half-updated. A crash between flushes loses that delta and costs a re-miss. If the blob is unparseable, the daemon rebuilds it from the artifact directory.
 
 3. **Metadata cache (in-memory):** Lost on crash. Rebuilt lazily on next access. This is by design: the metadata cache is a performance optimization, not a source of truth.
 
@@ -505,7 +519,7 @@ The daemon can crash at any point. The recovery strategy ensures no data corrupt
 
 **Startup sequence after crash:**
 1. Clean up stale temp directories in the artifact store.
-2. Open (or rebuild) the redb index.
+2. Load (or rebuild) the index from `index.bin`.
 3. Remove stale socket/pipe files.
 4. Start listening for connections.
 
@@ -581,7 +595,7 @@ v1 is deliberately minimal. The goal is a correct, useful tool for the most comm
 
 **Rationale:**
 - Eliminates cold-start penalty after daemon restarts.
-- The cache directory is the same one used for the redb index and other persistent state.
+- The cache directory is the same one used for the artifact index and other persistent state.
 - `.meta` sidecars are simple and atomic (write-then-rename pattern).
 
 **Alternatives Considered:**
@@ -688,7 +702,7 @@ still only redirects zccache indirectly.
 **Decision:** `ZCCACHE_CACHE_DIR` is the supported cache-root override. When set
 and non-empty, all paths derived from `zccache_core::config::default_cache_dir()`
 use that root directly, including artifacts, temp files, depgraph state,
-`index.redb`, crash dumps, logs, cargo/download helper state, and lock files.
+`index.bin`, crash dumps, logs, cargo/download helper state, and lock files.
 Relative values are normalized against the current working directory.
 
 Default daemon endpoints also derive from the override. On Unix, zccache uses a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -113,7 +113,7 @@ This document describes the phased implementation plan for **zccache**, a high-p
   - Storage layout: `<cache_root>/objects/<first-2-hex>/<remaining-hex>/`
   - Atomic writes: write to temp dir under `<cache_root>/tmp/`, then rename into place
   - Manifest file per artifact: output file(s), stdout, stderr, exit code, timestamp, size, checksum
-- `redb` index for:
+- Index (originally planned as `redb`; shipped as an in-memory map snapshotted to `index.bin` — see DD-008) for:
   - Cache key to artifact path mapping
   - Access time tracking (for LRU eviction)
   - Total cache size tracking
@@ -144,10 +144,13 @@ This document describes the phased implementation plan for **zccache**, a high-p
 - Corrupt artifacts (tampered data) are detected and removed on read
 - `zccache stats` reports accurate numbers
 - `zccache clear` removes all entries and resets stats
-- Cache survives daemon restart (redb persistence)
+- Cache survives daemon restart (index persisted to disk)
 - Cache key is deterministic: same inputs always produce same key
 
 **Risks:** `redb` edge cases under highly concurrent access (many simultaneous writes to the same table). **Mitigation:** Run stress tests with 50+ concurrent writers; wrap `redb` access behind a service with controlled concurrency; keep the `redb` schema simple (two tables: keys, access times).
+
+> [!NOTE]
+> Retained as written for the historical record. This risk was real but was resolved by removing the database rather than by taming it: the index became an in-memory `DashMap` whose only writer is the daemon's background flush (DD-008, superseded). The "wrap access behind a service with controlled concurrency" mitigation is essentially what shipped.
 
 ---
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -8,7 +8,7 @@ Detailed design specification for zccache, split by subsystem.
 | [data-flow.md](data-flow.md) | Cache hit/miss/passthrough step-by-step traces |
 | [ipc.md](ipc.md) | Transport abstraction, socket discovery, connection lifecycle |
 | [metadata-cache.md](metadata-cache.md) | In-memory cache, confidence model, file watcher integration |
-| [artifact-store.md](artifact-store.md) | Disk layout, redb index, eviction, corruption detection |
+| [artifact-store.md](artifact-store.md) | Disk layout, bincode index, eviction, corruption detection |
 | [rust-artifact-plan.md](rust-artifact-plan.md) | Rust plan ownership, thin/full semantics, backends, diagnostics, CLI contract |
 | [embedded-service.md](embedded-service.md) | Embedded host-daemon API, audit continuity, soldr/fbuild integration contract |
 | [audit-schema.md](audit-schema.md) | `soldr.audit.v1` JSONL contract: event shape, AuditContext, modes, redaction, additive-compatibility policy (zccache#906) |

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -1,6 +1,6 @@
 # Disk Artifact Cache
 
-The artifact store persists compiled output files on disk, keyed by content-addressed blake3 hash. Uses redb for indexing and LRU eviction.
+The artifact store persists compiled output files on disk, keyed by content-addressed blake3 hash. The index is an in-memory `DashMap` snapshotted to a bincode blob (`index.bin`); it drives LRU eviction.
 
 For how cache keys are computed see [overview.md](overview.md) (section 2.8). For crash recovery see [runtime.md](runtime.md).
 
@@ -230,7 +230,7 @@ Save/restore summaries expose exported bytes and the stable skip reasons
           stderr                 # captured stderr (may be empty)
   tmp/
     {random}/                    # in-progress writes
-  index.redb                     # redb database
+  index.bin                      # bincode index snapshot
 ```
 
 **cache_root** defaults to `~/.zccache` on all platforms.
@@ -247,7 +247,7 @@ To prevent partially-written artifacts from being read:
 2. Write all output files and the manifest into the temp directory.
 3. `fsync` the temp directory (and files, on Linux, where `fsync` semantics require it).
 4. Rename the temp directory to its final path under `artifacts/`. On POSIX, `rename()` is atomic within the same filesystem. On Windows, `MoveFileExW` with `MOVEFILE_REPLACE_EXISTING` provides equivalent semantics for directories.
-5. Insert into the redb index within a write transaction.
+5. Insert into the in-memory index. The insert is infallible and does no disk I/O; the daemon's background WAL writer snapshots the map to `index.bin` on its timer.
 
 If the daemon crashes between steps 2 and 4, the temp directory is orphaned. On startup, the daemon deletes all entries under `{cache_root}/tmp/`.
 
@@ -273,38 +273,34 @@ If the daemon crashes between steps 2 and 4, the temp directory is orphaned. On 
 
 The manifest exists primarily for debugging and corruption detection. The cache key is the directory name; the manifest records what went into it.
 
-## redb Index Schema
+## Index Schema
 
-The redb database contains two tables:
-
-**Table `artifacts`:**
-```
-Key:   [u8; 32]        // blake3 hash bytes
-Value: ArtifactMeta    // bincode-serialized
-```
+The index is a `DashMap<String, ArtifactIndex>` keyed by the artifact's hex cache key, snapshotted whole to `index.bin` as one bincode blob.
 
 ```rust
-struct ArtifactMeta {
-    total_size: u64,            // sum of all files in artifact dir
-    last_access: SystemTime,    // updated on each lookup
-    created_at: SystemTime,
-    output_file_count: u32,
+pub struct ArtifactIndex {
+    pub output_names: Arc<[String]>,  // e.g. ["foo.o"]
+    pub output_sizes: Vec<u64>,       // parallel to output_names
+    pub stdout: Arc<Vec<u8>>,         // captured compiler stdout
+    pub stderr: Arc<Vec<u8>>,         // captured compiler stderr
+    pub exit_code: i32,
+    pub total_size: u64,              // eviction budget accounting
+    pub stored_at_secs: u64,          // stored-at / access checkpoint
 }
 ```
 
-**Table `stats`:**
-```
-Key:   &str             // stat name
-Value: u64              // counter
-```
+It holds everything needed to serve a hit *except* the output bytes, which are resolved lazily through the staged/pack/flat layout resolver.
 
-Tracks: `hits`, `misses`, `evictions`, `total_bytes_written`, `total_bytes_evicted`.
+All mutation methods (`insert`, `insert_many`, `remove`, `remove_batch`, `clear`) are **infallible** — they only touch the in-memory map. Disk I/O happens exclusively in `flush()`, called by the daemon's background WAL writer. See `run_index_writer` in `zccache-daemon-core`.
 
-redb is chosen for its properties:
-- Pure Rust, no external dependencies.
-- ACID transactions — the index survives crashes without corruption.
-- Single-file database.
-- Good read concurrency (multiple concurrent readers, single writer).
+### Why not redb
+
+The rationale lives with the code, in the `## Why not redb` module doc of [`crates/zccache-artifact/src/store.rs`](../../crates/zccache-artifact/src/store.rs). In short: the daemon already holds a complete authoritative copy of the index in memory, so the on-disk file is only read at startup. A bincode blob is one sequential write per flush instead of one fsync per commit, and a single `fs::read` + deserialize at startup.
+
+The tradeoff is durability granularity — a crash *between* flushes loses the whole delta, where an ACID store would recover to the last committed transaction. This is acceptable because the artifact files themselves remain on disk: the worst case is a re-miss on the unflushed keys, which the daemon repopulates on next access. Graceful shutdown flushes synchronously.
+
+> [!NOTE]
+> A prior design used redb here (DD-008). It was superseded; see [DESIGN_DECISIONS.md](../DESIGN_DECISIONS.md) DD-008 for the original decision and why it changed. Legacy `index.redb` files are left on disk untouched — remove them with `zccache clear` or by hand.
 
 ## Daemon-owned retention policy
 
@@ -365,7 +361,7 @@ On artifact lookup:
 3. Verify each output file listed in the manifest exists and its size matches.
 4. (Optional, not default) Verify blake3 hashes of output files match manifest.
 
-If any check fails, remove the artifact directory and its redb entry, and treat as a cache miss. Log a warning.
+If any check fails, remove the artifact directory and its index entry, and treat as a cache miss. Log a warning.
 
 On startup, the daemon does NOT do a full integrity scan (too slow for large caches). Corruption is detected lazily on lookup.
 

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -62,10 +62,10 @@ User invokes:  zccache clang++ -c foo.c -o foo.o
    sorted_env, source_hash, dep_hash).
 
 10. Daemon queries ArtifactStore::lookup(key).
-    a. redb index lookup by key — found, returns artifact directory path
-       and metadata.
+    a. In-memory index lookup by key — found, returns artifact directory
+       path and metadata.
     b. Verify artifact directory exists and manifest is intact.
-    c. Update last-access-time in redb index.
+    c. Update last-access-time in the in-memory index.
 
 11. Daemon copies cached output files to the requested output paths
     (e.g., copies cached object file to foo.o).
@@ -98,7 +98,8 @@ Steps 1–9: identical to cache hit path.
     d. Compute artifact content hash (the cache key).
     e. Rename temp dir to {cache_root}/artifacts/{hash[0..2]}/{hash[2..4]}/{hash}.
        Atomic on same filesystem.
-    f. Insert entry into redb index with current timestamp as last-access-time.
+    f. Insert entry into the in-memory index with the current timestamp as
+       last-access-time; the background WAL writer snapshots it to index.bin.
     g. If total cache size exceeds max, trigger async eviction.
 
 14. Daemon sends Response::CacheMiss { exit_code: 0, stdout, stderr }.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -27,7 +27,7 @@ zccache intercepts C/C++ compiler invocations, computes a deterministic cache ke
                                     |  |  (DashMap)  |            |            |
                                     |  +------+------+    +-------+--------+   |
                                     |         |           | Artifact Store |   |
-                                    |         v           | (disk + redb)  |   |
+                                    |         v           | (disk + bincode)|   |
                                     |  +------+------+    +-------+--------+   |
                                     |  | File Watcher|            |            |
                                     |  | (notify)    |            |            |
@@ -199,7 +199,7 @@ struct FileWatcher {
 ```rust
 struct ArtifactStore {
     root: PathBuf,
-    index: redb::Database,
+    index: DashMap<String, ArtifactIndex>,
     max_size: u64,
 }
 

--- a/docs/architecture/portability.md
+++ b/docs/architecture/portability.md
@@ -169,7 +169,7 @@ The MVP hashes preprocessor output as the dependency hash. This is correct but s
 
 1. **Dependency file parsing:** After a cache miss, parse the `-MD`-generated `.d` file to discover the exact set of headers used. Cache this set. On subsequent compilations with the same source, hash only the individual headers instead of running the preprocessor.
 2. **Include scanning:** Parse `#include` directives without running the preprocessor. Faster but less accurate (misses conditional includes).
-3. **Persistent dependency graph:** Store the source-to-headers mapping in redb. Invalidate edges when headers change.
+3. **Persistent dependency graph:** Store the source-to-headers mapping in a persistent graph. Invalidate edges when headers change. *(Implemented — see `zccache-depgraph`, which snapshots the graph with rkyv rather than a database.)*
 
 ### Persistent Metadata Cache
 

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -42,7 +42,7 @@ For the on-disk record shape and the closed `miss_reason` enum, see
 |---|---|---|
 | Metadata cache | DashMap (sharded concurrent map) | Low — per-shard locks, short critical sections |
 | Artifact store on disk | Atomic rename, no locks | None — each artifact has unique path |
-| redb index | redb internal MVCC (readers never block, writer serialized) | Low — write transactions are short |
+| Artifact index | DashMap (sharded concurrent map); disk I/O only in the background WAL writer's `flush()` | Low — per-shard locks, no fsync on the mutation path |
 | File watcher event channel | tokio mpsc (bounded, 4096) | Low — single producer, single consumer |
 | Event log channel | tokio mpsc (unbounded) | None — lock-free send, single consumer thread |
 | Compile journal channel | tokio mpsc (unbounded) | None — lock-free send, single consumer thread (writes global + per-session files) |
@@ -51,7 +51,7 @@ For the on-disk record shape and the closed `miss_reason` enum, see
 
 There is no nested locking. The design avoids situations where one lock is held while acquiring another:
 - DashMap lookups are point operations. The shard lock is released before any I/O.
-- redb transactions do not hold DashMap locks.
+- The index writer's `flush()` does not hold DashMap shard locks across disk I/O.
 - The watcher thread never acquires DashMap locks directly; it sends events through a channel.
 
 This eliminates deadlock by design.
@@ -276,7 +276,7 @@ When in doubt, zccache assumes the file has changed and re-verifies. Specific po
 | Compiler updated in-place | Incorrect cache hit | Compiler binary is in metadata cache; stat-verified on use |
 | Clock skew / mtime unreliable | Incorrect cache hit | file_id provides second signal; Low confidence triggers re-hash |
 | Disk full during artifact write | Orphaned temp dir | Temp dir cleaned on startup; write failure returns error, CLI falls back |
-| redb corruption | Index lost | redb is ACID; if corruption occurs (hardware fault), rebuild index by scanning artifact directories |
+| `index.bin` corrupt or truncated | Index lost | `ArtifactStore` reports `started_corrupt`; the daemon rebuilds by scanning artifact directories |
 
 ### What zccache Does NOT Cache
 
@@ -431,9 +431,9 @@ The dumper is intentionally text-only for v1 — minidumps via `MiniDumpWriteDum
 
 ### Index Recovery
 
-**redb** provides ACID transactions. The database file is always in a consistent state, even after an unclean shutdown. If the daemon crashed mid-transaction, redb rolls back the incomplete transaction on next open.
+**`index.bin`** is rewritten whole by each `flush()`, so it is never half-updated. A crash *between* flushes loses that delta — the artifact files remain on disk, so the effect is a re-miss on the unflushed keys, not incorrect behavior. A blob that is present but unparseable sets `started_corrupt`, and the daemon rebuilds the index by scanning the artifact directories. Graceful shutdown flushes synchronously.
 
-**Index-artifact divergence:** If the daemon crashed after writing the artifact directory but before inserting the redb entry, the artifact exists on disk but is not in the index. This is a harmless orphan; it wastes disk space but does not cause incorrect behavior. A periodic (or on-demand) maintenance task can scan the artifact directories and reconcile with the index:
+**Index-artifact divergence:** If the daemon crashed after writing the artifact directory but before the next index flush, the artifact exists on disk but is not in the index. This is a harmless orphan; it wastes disk space but does not cause incorrect behavior. A periodic (or on-demand) maintenance task can scan the artifact directories and reconcile with the index:
 - Artifact on disk but not in index: add to index.
 - Entry in index but no artifact on disk: remove from index.
 


### PR DESCRIPTION
Closes #1351.

## Why

The architecture docs asserted that zccache's artifact index is redb-backed — `crates/CLAUDE.md` said "redb MVCC for artifact index" and `artifact-store.md` documented a two-table redb schema. It has been an in-memory `DashMap` snapshotted to a bincode blob (`index.bin`) for some time.

This cost real triage time. A user-visible `redb: Database already open. Cannot acquire lock.` was investigated against zccache first, because the docs said zccache used redb heavily. It doesn't — the error was soldr's `~/.soldr/state.redb` (zackees/soldr#2223, diagnosed in zackees/soldr#2224). The docs pointed the investigation at the wrong repository.

## What changed

**Corrected to describe the real design:**

- **`artifact-store.md`** — the fictional two-table redb schema (`ArtifactMeta` with `last_access`, a `stats` counter table) replaced with the actual `ArtifactIndex` struct. Added a "Why not redb" section that links to the module doc rather than restating it, per the "one doc owns it" rule in `docs/CLAUDE.md`.
- **`runtime.md`** — the concurrency table's "redb internal MVCC" row is now the DashMap index; the lock-ordering claim and the crash-recovery section describe flush semantics instead of ACID transactions.
- **`data-flow.md`, `overview.md`, `ARCHITECTURE.md`, `architecture/README.md`, `README.md`, `crates/CLAUDE.md`** — index lookups/inserts, the component diagram, and the `ArtifactStore` struct sketch (`index: redb::Database` → `DashMap<String, ArtifactIndex>`).
- **`portability.md`** — the "persistent dependency graph in redb" future-work item shipped as rkyv snapshots in `zccache-depgraph`.

**History preserved, not rewritten:**

- **`DESIGN_DECISIONS.md` DD-008** is marked `SUPERSEDED` with a callout at the top and a new **Superseded by** section explaining *why* the premise failed: the decision assumed the index would be queried from disk, but the daemon holds the authoritative copy in memory, so the file is read exactly once at startup and is otherwise write-only. Under that access pattern redb's per-transaction fsync was pure cost. The durability tradeoff accepted in exchange is stated explicitly. The original rationale and alternatives table are untouched.
- **Q3** gains a superseded note rather than being deleted.
- **`ROADMAP.md`**'s risk line — "`redb` edge cases under highly concurrent access… wrap `redb` access behind a service with controlled concurrency" — is annotated rather than removed. It was prescient, and it's worth recording that the risk was resolved by removing the database rather than taming it.

**Vestigial names that pointed the same wrong direction:**

- `index.redb` test paths → `index.bin` (`cache_ops.rs`, `daemon_persist_pool_bench.rs`).
- The three `run_strategy_*_redb` bench strategies → `*_store`. All three call `ArtifactStore::insert`, which is bincode — the names read as a redb comparison that does not exist, and would mislead anyone profiling persistence.

## Accuracy checks

Every rewritten claim was verified against the code, not assumed:

- `ArtifactIndex` field list read from `store.rs:42-61`.
- "flush does not hold shard locks across disk I/O" — `flush()` does `.iter().collect()` at `store.rs:331-333` and writes at `:349`. Confirmed.
- `SharedState::artifacts` (`state.rs:324`) and `run_index_writer` (`wal.rs:224`) both exist as named.
- `index.bin` path from `paths.rs:264`.

## Validation

- `soldr cargo check --workspace --all-targets` — exit 0
- `soldr cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `soldr cargo fmt --all` — exit 0
- `./test` — re-run after the bench/test renames; passing

Part of the cross-repo redb cleanup tracked in zackees/soldr#2228. Stacked conceptually on #1353 (dead-dep removal) but touches disjoint files, so either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
