### PR TITLE
feat(kv): back KvStore with content-addressed files, dropping redb from the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,15 +2440,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
-name = "redb"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4183,7 +4174,6 @@ dependencies = [
  "fs2",
  "prost",
  "rayon",
- "redb",
  "reflink-copy",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 clap = { version = "4", features = ["derive", "env"] }
 dashmap = "6"
 arc-swap = "1"
-redb = "4.1.0"
 clang = { version = "2", features = ["runtime"] }
 notify = "7"
 memmap2 = "0.9"

--- a/crates/zccache-artifact/Cargo.toml
+++ b/crates/zccache-artifact/Cargo.toml
@@ -32,7 +32,6 @@ fs2 = { workspace = true }
 prost = { workspace = true }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }
-redb = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tar = { workspace = true, optional = true }

--- a/crates/zccache-artifact/src/kv.rs
+++ b/crates/zccache-artifact/src/kv.rs
@@ -1,20 +1,40 @@
-//! Namespaced blake3-keyed key/value store backed by redb.
+//! Namespaced blake3-keyed key/value store backed by content-addressed files.
 //!
-//! Lives next to [`ArtifactStore`](super::ArtifactStore) and reuses the same
-//! redb file (`~/.zccache/index.redb`) via a separate `kv` table. Values
-//! ≤ [`INLINE_THRESHOLD`] bytes are stored inline in redb; larger values
-//! spill to `~/.zccache/kv/<namespace>/<hex>.bin` with a blake3 corruption
-//! check on read. Hard cap [`MAX_VALUE_BYTES`].
+//! Lives next to [`ArtifactStore`](super::ArtifactStore). Every value is one
+//! file at `<cache_dir>/kv/<namespace>/<hex>.bin`, written tempfile+rename so a
+//! crash mid-write never publishes a partial value. Each file carries a small
+//! header (magic, schema version, payload length, blake3 of the payload) so a
+//! truncated or tampered file is detected on read rather than returned as data.
+//! Hard cap [`MAX_VALUE_BYTES`].
 //!
-//! The on-disk row format carries a `schema_version`; opening a row with
-//! a higher version than this binary supports is a hard error
-//! ([`KvError::Corrupt`]) rather than silent garbage.
+//! # Why there is no database here
+//!
+//! This store previously kept small values inline in a redb table
+//! (`index.redb`) and spilled larger ones to sidecar files. redb takes an
+//! **exclusive whole-file lock per `Database` handle** — by design, it is a
+//! single-owner store. That made every `zccache kv` invocation take a process
+//! lock, pay a write-transaction commit just to assert the table existed, and
+//! fail opaquely if any other process had the file open.
+//!
+//! The access pattern never needed a database: keys are content-addressed, so
+//! there are no range queries, no transactions spanning keys, and no secondary
+//! indexes. The filesystem is already a content-addressed key/value store with
+//! per-key locking granularity. Dropping redb removes the last exclusive file
+//! lock from zccache and removes redb from the workspace entirely.
+//!
+//! The tradeoff: `list_namespace`, `stats`, and `total_bytes` are directory
+//! walks rather than table scans. For a store whose namespaces hold tens to
+//! thousands of keys this is comparable, and it removes a per-call fsync from
+//! every read.
+//!
+//! **On-disk break.** Values written by the redb-backed version are not read by
+//! this one. There is no migration: the store had no consumers, so there is no
+//! data to carry forward. A stale `index.redb` is left untouched on disk;
+//! remove it with `zccache clear` or by hand.
 
 use std::path::Path;
 use std::sync::Arc;
 
-use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
-use serde::{Deserialize, Serialize};
 use zccache_core::NormalizedPath;
 
 /// Windows long-path (`\\?\`) helpers. On non-Windows platforms every entry
@@ -61,17 +81,28 @@ mod long_path {
     }
 }
 
-const KV_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("kv");
-
-/// Inline-vs-spill threshold. Values ≤ this stay in redb; larger values
-/// spill to a sidecar file under `kv/<namespace>/<hex>.bin`.
+/// Historical inline-vs-spill boundary, retained as a size landmark.
+///
+/// When this store was redb-backed, values at or below this size lived inline
+/// in a redb row and larger ones spilled to a sidecar file. **Every value is
+/// now a file**, so this constant no longer changes storage behaviour. It is
+/// kept because callers (notably the stress suite) use it as a convenient
+/// "comfortably larger than a small value" boundary, and because removing a
+/// public constant is a breaking change with no benefit.
 pub const INLINE_THRESHOLD: usize = 4 * 1024;
 
 /// Hard cap on a single value (64 MiB). Over-cap → [`KvError::TooLarge`].
 pub const MAX_VALUE_BYTES: usize = 64 * 1024 * 1024;
 
-const SCHEMA_VERSION: u32 = 1;
+const SCHEMA_VERSION: u32 = 2;
 const NAMESPACE_MAX: usize = 64;
+
+/// `b"ZCKV"`. Distinguishes a value file from anything else that lands in the
+/// namespace directory.
+const MAGIC: [u8; 4] = *b"ZCKV";
+
+/// magic(4) + version(4) + payload len(8) + blake3(32).
+const HEADER_LEN: usize = 4 + 4 + 8 + 32;
 
 /// 32-byte content key. Stable hex form is always lowercase 64 chars.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -140,16 +171,13 @@ pub enum KvError {
     /// IO error from disk or filesystem.
     #[error("io: {0}")]
     Io(#[from] std::io::Error),
-    /// Underlying redb error (commit, transaction, table).
-    #[error("redb: {0}")]
-    Redb(String),
     /// Namespace failed validation. See [`is_valid_namespace`].
     #[error("namespace must be 1..=64 chars of [a-z0-9-] without `::`")]
     BadNamespace,
     /// Hex-key parsing failed (length, character class).
     #[error("key must be 32 bytes (64 hex chars)")]
     BadKey,
-    /// Stored row was malformed. Includes the offending key for debugging.
+    /// Stored value was malformed. Includes the offending key for debugging.
     #[error("corrupt entry for key {0}: {1}")]
     Corrupt(String, String),
     /// Value exceeded [`MAX_VALUE_BYTES`].
@@ -160,56 +188,8 @@ pub enum KvError {
     BlockingJoin(String),
 }
 
-impl From<redb::Error> for KvError {
-    fn from(e: redb::Error) -> Self {
-        Self::Redb(e.to_string())
-    }
-}
-
-impl From<redb::DatabaseError> for KvError {
-    fn from(e: redb::DatabaseError) -> Self {
-        Self::Redb(e.to_string())
-    }
-}
-
-impl From<redb::TransactionError> for KvError {
-    fn from(e: redb::TransactionError) -> Self {
-        Self::Redb(e.to_string())
-    }
-}
-
-impl From<redb::TableError> for KvError {
-    fn from(e: redb::TableError) -> Self {
-        Self::Redb(e.to_string())
-    }
-}
-
-impl From<redb::StorageError> for KvError {
-    fn from(e: redb::StorageError) -> Self {
-        Self::Redb(e.to_string())
-    }
-}
-
-impl From<redb::CommitError> for KvError {
-    fn from(e: redb::CommitError) -> Self {
-        Self::Redb(e.to_string())
-    }
-}
-
 /// Result type for KV operations.
 pub type KvResult<T> = std::result::Result<T, KvError>;
-
-#[derive(Debug, Serialize, Deserialize)]
-struct KvRow {
-    schema_version: u32,
-    body: KvBody,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-enum KvBody {
-    Inline(Vec<u8>),
-    Spilled { len: u64, blake3: [u8; 32] },
-}
 
 /// Validate that `ns` matches `[a-z0-9-]{1,64}` and contains no `::`.
 #[must_use]
@@ -232,131 +212,251 @@ fn check_namespace(ns: &str) -> KvResult<()> {
     }
 }
 
-fn composite(ns: &str, key: &Key) -> String {
-    let mut s = String::with_capacity(ns.len() + 2 + 64);
-    s.push_str(ns);
-    s.push_str("::");
-    s.push_str(&key.to_hex());
-    s
+/// Serialize the on-disk header for a payload.
+fn encode_header(payload: &[u8]) -> [u8; HEADER_LEN] {
+    let mut header = [0u8; HEADER_LEN];
+    header[0..4].copy_from_slice(&MAGIC);
+    header[4..8].copy_from_slice(&SCHEMA_VERSION.to_le_bytes());
+    header[8..16].copy_from_slice(&(payload.len() as u64).to_le_bytes());
+    header[16..48].copy_from_slice(::blake3::hash(payload).as_bytes());
+    header
 }
 
-/// Namespaced key/value store backed by redb plus optional spilled side files.
+/// Validate a value file's header against its payload.
 ///
-/// Cheap to clone (`Arc<Database>` + `Arc<NormalizedPath>`); intended to be passed
-/// across threads. All writes are committed before the call returns
-/// (single-fsync per `put`/`remove`/`clear_namespace`).
+/// `label` names the entry in any [`KvError::Corrupt`] raised, so callers pass
+/// something the operator can act on (`<namespace>::<hex>`).
+fn decode_and_verify(label: &str, raw: &[u8]) -> KvResult<Vec<u8>> {
+    if raw.len() < HEADER_LEN {
+        return Err(KvError::Corrupt(
+            label.to_string(),
+            format!("truncated: {} bytes, header needs {HEADER_LEN}", raw.len()),
+        ));
+    }
+    if raw[0..4] != MAGIC {
+        return Err(KvError::Corrupt(
+            label.to_string(),
+            "bad magic (not a kv value file)".to_string(),
+        ));
+    }
+    let version = u32::from_le_bytes([raw[4], raw[5], raw[6], raw[7]]);
+    if version != SCHEMA_VERSION {
+        return Err(KvError::Corrupt(
+            label.to_string(),
+            format!("schema_version={version}"),
+        ));
+    }
+    let declared_len = u64::from_le_bytes([
+        raw[8], raw[9], raw[10], raw[11], raw[12], raw[13], raw[14], raw[15],
+    ]);
+    let payload = &raw[HEADER_LEN..];
+    if payload.len() as u64 != declared_len {
+        return Err(KvError::Corrupt(
+            label.to_string(),
+            format!(
+                "length mismatch: got {}, expected {declared_len}",
+                payload.len()
+            ),
+        ));
+    }
+    let expected = &raw[16..48];
+    if ::blake3::hash(payload).as_bytes() != expected {
+        return Err(KvError::Corrupt(
+            label.to_string(),
+            "blake3 mismatch".to_string(),
+        ));
+    }
+    Ok(payload.to_vec())
+}
+
+/// Sharded per-key mutexes serializing the *rename* step of concurrent writes
+/// to the same key within one process.
+///
+/// This is deliberately not a store lock. The shard is chosen from the
+/// destination path, so writers to distinct keys never contend, and the guard
+/// is held only across the rename — never across the payload write or its
+/// fsync, which are the expensive parts.
+///
+/// Why it exists: `MOVEFILE_REPLACE_EXISTING` cannot start while another
+/// handle is open on the destination, and 16 threads hammering one key
+/// (`c1_thundering_herd_same_key`) keep it open essentially always, so the
+/// bounded retry below alone cannot converge. Cross-process same-key writers
+/// are still handled by that retry; they are far rarer than the in-process
+/// case and do not sustain the same rename rate.
+fn rename_shard(dest: &Path) -> &'static std::sync::Mutex<()> {
+    use std::hash::{Hash, Hasher};
+
+    const SHARDS: usize = 64;
+    static LOCKS: std::sync::OnceLock<Vec<std::sync::Mutex<()>>> = std::sync::OnceLock::new();
+
+    let locks = LOCKS.get_or_init(|| (0..SHARDS).map(|_| std::sync::Mutex::new(())).collect());
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    dest.hash(&mut hasher);
+    &locks[(hasher.finish() as usize) % SHARDS]
+}
+
+/// Publish `tmp` at `dest`, retrying the transient Windows sharing failures.
+///
+/// The rename itself is atomic on every platform we support. What is *not*
+/// guaranteed on Windows is that it can start: `MoveFileExW` with
+/// `MOVEFILE_REPLACE_EXISTING` fails with `ERROR_ACCESS_DENIED` (5) or
+/// `ERROR_SHARING_VIOLATION` (32) while another handle is open on the
+/// destination — a concurrent reader, another writer replacing the same key,
+/// or an antivirus scanner mid-scan.
+///
+/// The redb-backed implementation never hit this because every write to a key
+/// was serialized through a single database write transaction. File-per-key
+/// removes that serialization, which is the point — but it means same-key
+/// writers now race at the rename. `c1_thundering_herd_same_key` in
+/// `tests/artifact_kv_stress.rs` (16 threads x 100 writes to one key) fails
+/// without this retry.
+///
+/// Bounded so a genuine permissions error still surfaces rather than hanging:
+/// ~1 s total across exponentially-growing sleeps, then the real error.
+fn persist_atomically(mut tmp: tempfile::NamedTempFile, dest: &Path) -> KvResult<()> {
+    const MAX_ELAPSED: std::time::Duration = std::time::Duration::from_secs(1);
+
+    // Held across the rename only. The payload write and fsync already
+    // happened in the caller, outside this critical section.
+    let _shard = rename_shard(dest)
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    let started = std::time::Instant::now();
+    let mut delay = std::time::Duration::from_millis(1);
+    loop {
+        match tmp.persist(dest) {
+            Ok(_) => return Ok(()),
+            Err(e) if is_transient_share_error(&e.error) && started.elapsed() < MAX_ELAPSED => {
+                // `persist` gives the temp file back on failure, so the retry
+                // republishes the same already-fsynced bytes.
+                tmp = e.file;
+                std::thread::sleep(delay);
+                delay = (delay * 2).min(std::time::Duration::from_millis(64));
+            }
+            Err(e) => return Err(KvError::Io(e.error)),
+        }
+    }
+}
+
+/// Whether `error` is a Windows sharing/locking failure that a retry may clear.
+///
+/// On Unix `rename(2)` over an open file succeeds, so this is always false and
+/// the retry loop never engages.
+fn is_transient_share_error(error: &std::io::Error) -> bool {
+    #[cfg(windows)]
+    {
+        const ERROR_ACCESS_DENIED: i32 = 5;
+        const ERROR_SHARING_VIOLATION: i32 = 32;
+        matches!(
+            error.raw_os_error(),
+            Some(ERROR_ACCESS_DENIED) | Some(ERROR_SHARING_VIOLATION)
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = error;
+        false
+    }
+}
+
+/// Payload length recorded in a value file's header, without reading the body.
+///
+/// Used by the listing/stats walks so they cost one `read` of the header
+/// instead of the whole value. Returns `Ok(None)` for anything that is not a
+/// well-formed value file.
+fn read_declared_len(path: &Path) -> std::io::Result<Option<u64>> {
+    use std::io::Read;
+
+    let mut file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    let mut header = [0u8; HEADER_LEN];
+    if file.read_exact(&mut header).is_err() {
+        return Ok(None);
+    }
+    if header[0..4] != MAGIC {
+        return Ok(None);
+    }
+    Ok(Some(u64::from_le_bytes([
+        header[8], header[9], header[10], header[11], header[12], header[13], header[14],
+        header[15],
+    ])))
+}
+
+/// Namespaced key/value store over content-addressed files.
+///
+/// Cheap to clone (one `Arc<NormalizedPath>`); intended to be passed across
+/// threads. Writes are durable before the call returns (payload fsync +
+/// atomic rename). Unlike the previous redb-backed implementation this takes
+/// no process-wide or cross-process lock, so concurrent readers and writers on
+/// distinct keys never contend.
 #[derive(Clone)]
 pub struct KvStore {
-    db: Arc<Database>,
     cache_dir: Arc<NormalizedPath>,
 }
 
 impl KvStore {
-    /// Open under the canonical zccache root (`default_cache_dir()`).
+    /// Open under the canonical zccache root (`daemon_state_dir()`).
     pub fn open_default() -> KvResult<Self> {
         let dir = zccache_core::config::daemon_state_dir();
         Self::open(dir)
     }
 
-    /// Open at an explicit dir. Creates the dir + redb file if missing.
+    /// Open at an explicit dir. Creates the dir if missing.
+    ///
+    /// Opening is now just directory setup — there is no database file to
+    /// create and no lock to acquire, so two processes may hold a `KvStore`
+    /// over the same directory concurrently.
     pub fn open<P: AsRef<Path>>(dir: P) -> KvResult<Self> {
         let mut dir = NormalizedPath::new(dir.as_ref());
         std::fs::create_dir_all(&dir)?;
         // On Windows, normalize to a `\\?\`-prefixed (verbatim) form so that
-        // every spill path joined off `cache_dir` exceeds `MAX_PATH` safely.
+        // every value path joined off `cache_dir` exceeds `MAX_PATH` safely.
         // No-op on Unix.
         dir = long_path::ensure_long_path(dir.as_path())?;
-        let db_path = dir.join("index.redb");
-        let db = Database::create(&db_path).map_err(|e| KvError::Redb(e.to_string()))?;
-        let store = Self {
-            db: Arc::new(db),
+        Ok(Self {
             cache_dir: Arc::new(dir),
-        };
-        store.ensure_table()?;
-        Ok(store)
+        })
     }
 
-    /// Share an already-open redb database with the caller (typically
-    /// [`ArtifactStore`](super::ArtifactStore)). Both stores see each other's
-    /// commits; spill files live under `cache_dir/kv/...`.
-    pub fn from_database<P: AsRef<Path>>(db: Arc<Database>, cache_dir: P) -> KvResult<Self> {
-        let mut cache_dir = NormalizedPath::new(cache_dir.as_ref());
-        std::fs::create_dir_all(&cache_dir)?;
-        // Match the verbatim normalization done by [`KvStore::open`] so callers
-        // who route long paths through `from_database` get the same long-path
-        // safety on Windows.
-        cache_dir = long_path::ensure_long_path(cache_dir.as_path())?;
-        let store = Self {
-            db,
-            cache_dir: Arc::new(cache_dir),
-        };
-        store.ensure_table()?;
-        Ok(store)
+    fn kv_root(&self) -> NormalizedPath {
+        self.cache_dir.join("kv")
     }
 
-    fn ensure_table(&self) -> KvResult<()> {
-        let txn = self.db.begin_write()?;
-        {
-            let _t = txn.open_table(KV_TABLE)?;
-        }
-        txn.commit()?;
-        Ok(())
+    fn namespace_dir(&self, namespace: &str) -> NormalizedPath {
+        self.kv_root().join(namespace)
     }
 
-    fn spill_path(&self, namespace: &str, key: &Key) -> NormalizedPath {
-        self.cache_dir
-            .join("kv")
-            .join(namespace)
+    fn value_path(&self, namespace: &str, key: &Key) -> NormalizedPath {
+        self.namespace_dir(namespace)
             .join(format!("{}.bin", key.to_hex()))
+    }
+
+    fn label(namespace: &str, key: &Key) -> String {
+        let mut s = String::with_capacity(namespace.len() + 2 + 64);
+        s.push_str(namespace);
+        s.push_str("::");
+        s.push_str(&key.to_hex());
+        s
     }
 
     /// Return the value for `(namespace, key)`, or `Ok(None)` on miss.
     pub fn get(&self, namespace: &str, key: &Key) -> KvResult<Option<Vec<u8>>> {
         check_namespace(namespace)?;
-        let composite = composite(namespace, key);
-        let txn = self.db.begin_read()?;
-        let table = txn.open_table(KV_TABLE)?;
-        let raw = match table.get(composite.as_str())? {
-            Some(v) => v.value().to_vec(),
-            None => return Ok(None),
+        let path = self.value_path(namespace, key);
+        let raw = match std::fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(KvError::Io(e)),
         };
-        let row: KvRow = bincode::deserialize(&raw)
-            .map_err(|e| KvError::Corrupt(composite.clone(), format!("bincode: {e}")))?;
-        if row.schema_version != SCHEMA_VERSION {
-            return Err(KvError::Corrupt(
-                composite,
-                format!("schema_version={}", row.schema_version),
-            ));
-        }
-        match row.body {
-            KvBody::Inline(bytes) => Ok(Some(bytes)),
-            KvBody::Spilled { len, blake3 } => {
-                let path = self.spill_path(namespace, key);
-                let bytes = std::fs::read(&path)?;
-                if bytes.len() as u64 != len {
-                    return Err(KvError::Corrupt(
-                        composite,
-                        format!(
-                            "spill length mismatch: got {}, expected {}",
-                            bytes.len(),
-                            len
-                        ),
-                    ));
-                }
-                let actual = *::blake3::hash(&bytes).as_bytes();
-                if actual != blake3 {
-                    return Err(KvError::Corrupt(
-                        composite,
-                        "spill blake3 mismatch".to_string(),
-                    ));
-                }
-                Ok(Some(bytes))
-            }
-        }
+        decode_and_verify(&Self::label(namespace, key), &raw).map(Some)
     }
 
-    /// Async wrapper for [`Self::get`] that runs redb reads and spill-file I/O
-    /// on Tokio's blocking pool.
+    /// Async wrapper for [`Self::get`] that runs file I/O on Tokio's blocking
+    /// pool.
     pub async fn get_async(&self, namespace: &str, key: &Key) -> KvResult<Option<Vec<u8>>> {
         let store = self.clone();
         let namespace = namespace.to_string();
@@ -366,65 +466,29 @@ impl KvStore {
             .map_err(|e| KvError::BlockingJoin(e.to_string()))?
     }
 
-    /// Last-writer-wins. Writes spill side files via tempfile + rename so a
-    /// crash mid-write leaves no dangling state in the redb row.
+    /// Last-writer-wins. Writes via tempfile + rename so a crash mid-write
+    /// leaves either the previous value or none — never a partial one.
     pub fn put(&self, namespace: &str, key: &Key, value: &[u8]) -> KvResult<usize> {
+        use std::io::Write;
+
         check_namespace(namespace)?;
         if value.len() > MAX_VALUE_BYTES {
             return Err(KvError::TooLarge(value.len(), MAX_VALUE_BYTES));
         }
-        let composite = composite(namespace, key);
+        let path = self.value_path(namespace, key);
+        let dir = self.namespace_dir(namespace);
+        std::fs::create_dir_all(&dir)?;
 
-        let body = if value.len() <= INLINE_THRESHOLD {
-            // If a previous spill file exists for this key, drop it; we're
-            // about to inline.
-            let prev_path = self.spill_path(namespace, key);
-            if prev_path.exists() {
-                let _ = std::fs::remove_file(&prev_path);
-            }
-            KvBody::Inline(value.to_vec())
-        } else {
-            let path = self.spill_path(namespace, key);
-            if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            // Tempfile + rename so partial writes never become visible.
-            #[expect(
-                clippy::expect_used,
-                reason = "spill_path(namespace, key) joins onto the kv root, so .parent() is structurally guaranteed to be Some"
-            )]
-            let dir = path
-                .parent()
-                .expect("spill path always has a parent because we joined kv/<ns>/");
-            let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
-            use std::io::Write;
-            tmp.write_all(value)?;
-            tmp.as_file().sync_all()?;
-            tmp.persist(&path).map_err(|e| KvError::Io(e.error))?;
-            let blake3 = *::blake3::hash(value).as_bytes();
-            KvBody::Spilled {
-                len: value.len() as u64,
-                blake3,
-            }
-        };
-        let row = KvRow {
-            schema_version: SCHEMA_VERSION,
-            body,
-        };
-        let bytes =
-            bincode::serialize(&row).map_err(|e| KvError::Redb(format!("serialize row: {e}")))?;
-
-        let txn = self.db.begin_write()?;
-        {
-            let mut table = txn.open_table(KV_TABLE)?;
-            table.insert(composite.as_str(), bytes.as_slice())?;
-        }
-        txn.commit()?;
+        let mut tmp = tempfile::NamedTempFile::new_in(dir.as_path())?;
+        tmp.write_all(&encode_header(value))?;
+        tmp.write_all(value)?;
+        tmp.as_file().sync_all()?;
+        persist_atomically(tmp, path.as_path())?;
         Ok(value.len())
     }
 
-    /// Async wrapper for [`Self::put`] that runs redb commit/fsync and spill
-    /// file I/O on Tokio's blocking pool.
+    /// Async wrapper for [`Self::put`] that runs file I/O and fsync on Tokio's
+    /// blocking pool.
     pub async fn put_async(&self, namespace: &str, key: &Key, value: &[u8]) -> KvResult<usize> {
         let store = self.clone();
         let namespace = namespace.to_string();
@@ -438,31 +502,16 @@ impl KvStore {
     /// Idempotent: missing key returns `Ok(())`.
     pub fn remove(&self, namespace: &str, key: &Key) -> KvResult<()> {
         check_namespace(namespace)?;
-        let composite = composite(namespace, key);
-
-        // First read the row so we know whether to clean up a spill file.
-        let txn = self.db.begin_write()?;
-        let mut had_spill = None;
-        {
-            let mut table = txn.open_table(KV_TABLE)?;
-            let removed = table.remove(composite.as_str())?;
-            if let Some(existing) = removed {
-                if let Ok(row) = bincode::deserialize::<KvRow>(existing.value()) {
-                    if matches!(row.body, KvBody::Spilled { .. }) {
-                        had_spill = Some(self.spill_path(namespace, key));
-                    }
-                }
-            }
+        let path = self.value_path(namespace, key);
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(KvError::Io(e)),
         }
-        txn.commit()?;
-        if let Some(path) = had_spill {
-            let _ = std::fs::remove_file(&path);
-        }
-        Ok(())
     }
 
-    /// Async wrapper for [`Self::remove`] that runs redb commit/fsync and spill
-    /// cleanup on Tokio's blocking pool.
+    /// Async wrapper for [`Self::remove`] that runs file I/O on Tokio's
+    /// blocking pool.
     pub async fn remove_async(&self, namespace: &str, key: &Key) -> KvResult<()> {
         let store = self.clone();
         let namespace = namespace.to_string();
@@ -475,38 +524,16 @@ impl KvStore {
     /// Drop every entry under `namespace`. Other namespaces are untouched.
     pub fn clear_namespace(&self, namespace: &str) -> KvResult<()> {
         check_namespace(namespace)?;
-        let prefix = format!("{namespace}::");
-        let mut to_remove: Vec<String> = Vec::new();
-        {
-            let txn = self.db.begin_read()?;
-            let table = txn.open_table(KV_TABLE)?;
-            for entry in table.iter()? {
-                let (k, _v) = entry?;
-                let k_str = k.value().to_string();
-                if k_str.starts_with(&prefix) {
-                    to_remove.push(k_str);
-                }
-            }
+        let dir = self.namespace_dir(namespace);
+        match std::fs::remove_dir_all(dir.as_path()) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(KvError::Io(e)),
         }
-        let txn = self.db.begin_write()?;
-        {
-            let mut table = txn.open_table(KV_TABLE)?;
-            for k in &to_remove {
-                table.remove(k.as_str())?;
-            }
-        }
-        txn.commit()?;
-        // Remove the spill directory wholesale; this is correct because every
-        // key under <ns>/ corresponds to an entry we just removed.
-        let ns_dir = self.cache_dir.join("kv").join(namespace);
-        if ns_dir.exists() {
-            let _ = std::fs::remove_dir_all(&ns_dir);
-        }
-        Ok(())
     }
 
-    /// Async wrapper for [`Self::clear_namespace`] that runs redb commit/fsync
-    /// and namespace spill cleanup on Tokio's blocking pool.
+    /// Async wrapper for [`Self::clear_namespace`] that runs the directory
+    /// removal on Tokio's blocking pool.
     pub async fn clear_namespace_async(&self, namespace: &str) -> KvResult<()> {
         let store = self.clone();
         let namespace = namespace.to_string();
@@ -516,23 +543,31 @@ impl KvStore {
     }
 
     /// Sorted by hex-key. Returns `(key, value-len)` pairs.
+    ///
+    /// Files that are not well-formed value files (foreign files, leftover
+    /// temp files from an interrupted `put`) are skipped rather than failing
+    /// the listing — the directory is not exclusively ours in the way a
+    /// database table was.
     pub fn list_namespace(&self, namespace: &str) -> KvResult<Vec<(Key, u64)>> {
         check_namespace(namespace)?;
-        let prefix = format!("{namespace}::");
-        let txn = self.db.begin_read()?;
-        let table = txn.open_table(KV_TABLE)?;
+        let dir = self.namespace_dir(namespace);
+        let entries = match std::fs::read_dir(dir.as_path()) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(KvError::Io(e)),
+        };
         let mut out: Vec<(Key, u64)> = Vec::new();
-        for entry in table.iter()? {
-            let (k, v) = entry?;
-            let k_str = k.value().to_string();
-            if let Some(hex) = k_str.strip_prefix(&prefix) {
-                let key = Key::from_hex(hex)?;
-                let row: KvRow = bincode::deserialize(v.value())
-                    .map_err(|e| KvError::Corrupt(k_str.clone(), format!("bincode: {e}")))?;
-                let len = match row.body {
-                    KvBody::Inline(ref b) => b.len() as u64,
-                    KvBody::Spilled { len, .. } => len,
-                };
+        for entry in entries {
+            let entry = entry?;
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            let Some(hex) = name.strip_suffix(".bin") else {
+                continue;
+            };
+            let Ok(key) = Key::from_hex(hex) else {
+                continue;
+            };
+            if let Some(len) = read_declared_len(&entry.path())? {
                 out.push((key, len));
             }
         }
@@ -540,8 +575,8 @@ impl KvStore {
         Ok(out)
     }
 
-    /// Async wrapper for [`Self::list_namespace`] that keeps redb scans off
-    /// Tokio runtime threads.
+    /// Async wrapper for [`Self::list_namespace`] that keeps the directory walk
+    /// off Tokio runtime threads.
     pub async fn list_namespace_async(&self, namespace: &str) -> KvResult<Vec<(Key, u64)>> {
         let store = self.clone();
         let namespace = namespace.to_string();
@@ -550,14 +585,14 @@ impl KvStore {
             .map_err(|e| KvError::BlockingJoin(e.to_string()))?
     }
 
-    /// Sum of value lengths in `namespace`. Does not include redb overhead.
+    /// Sum of value lengths in `namespace`. Does not include header overhead.
     pub fn namespace_bytes(&self, namespace: &str) -> KvResult<u64> {
         let entries = self.list_namespace(namespace)?;
         Ok(entries.iter().map(|(_, l)| *l).sum())
     }
 
-    /// Async wrapper for [`Self::namespace_bytes`] that keeps redb scans off
-    /// Tokio runtime threads.
+    /// Async wrapper for [`Self::namespace_bytes`] that keeps the directory
+    /// walk off Tokio runtime threads.
     pub async fn namespace_bytes_async(&self, namespace: &str) -> KvResult<u64> {
         let store = self.clone();
         let namespace = namespace.to_string();
@@ -566,25 +601,40 @@ impl KvStore {
             .map_err(|e| KvError::BlockingJoin(e.to_string()))?
     }
 
+    /// Namespace directory names under `kv/`, sorted lexically.
+    fn namespaces(&self) -> KvResult<Vec<String>> {
+        let entries = match std::fs::read_dir(self.kv_root().as_path()) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(KvError::Io(e)),
+        };
+        let mut out: Vec<String> = Vec::new();
+        for entry in entries {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            if is_valid_namespace(name) {
+                out.push(name.to_string());
+            }
+        }
+        out.sort();
+        Ok(out)
+    }
+
     /// Sum of value lengths across every namespace.
     pub fn total_bytes(&self) -> KvResult<u64> {
-        let txn = self.db.begin_read()?;
-        let table = txn.open_table(KV_TABLE)?;
         let mut total: u64 = 0;
-        for entry in table.iter()? {
-            let (_, v) = entry?;
-            if let Ok(row) = bincode::deserialize::<KvRow>(v.value()) {
-                total += match row.body {
-                    KvBody::Inline(b) => b.len() as u64,
-                    KvBody::Spilled { len, .. } => len,
-                };
-            }
+        for ns in self.namespaces()? {
+            total += self.namespace_bytes(&ns)?;
         }
         Ok(total)
     }
 
-    /// Async wrapper for [`Self::total_bytes`] that keeps redb scans off Tokio
-    /// runtime threads.
+    /// Async wrapper for [`Self::total_bytes`] that keeps the directory walk
+    /// off Tokio runtime threads.
     pub async fn total_bytes_async(&self) -> KvResult<u64> {
         let store = self.clone();
         tokio::task::spawn_blocking(move || store.total_bytes())
@@ -594,29 +644,16 @@ impl KvStore {
 
     /// Per-namespace statistics. Returned namespaces are sorted lexically.
     pub fn stats(&self) -> KvResult<Vec<(String, u64)>> {
-        let txn = self.db.begin_read()?;
-        let table = txn.open_table(KV_TABLE)?;
-        let mut by_ns: std::collections::BTreeMap<String, u64> = Default::default();
-        for entry in table.iter()? {
-            let (k, v) = entry?;
-            let k_str = k.value().to_string();
-            let ns = match k_str.split_once("::") {
-                Some((ns, _)) => ns.to_string(),
-                None => continue,
-            };
-            if let Ok(row) = bincode::deserialize::<KvRow>(v.value()) {
-                let len = match row.body {
-                    KvBody::Inline(b) => b.len() as u64,
-                    KvBody::Spilled { len, .. } => len,
-                };
-                *by_ns.entry(ns).or_insert(0) += len;
-            }
+        let mut out: Vec<(String, u64)> = Vec::new();
+        for ns in self.namespaces()? {
+            let bytes = self.namespace_bytes(&ns)?;
+            out.push((ns, bytes));
         }
-        Ok(by_ns.into_iter().collect())
+        Ok(out)
     }
 
-    /// Async wrapper for [`Self::stats`] that keeps redb scans off Tokio
-    /// runtime threads.
+    /// Async wrapper for [`Self::stats`] that keeps the directory walk off
+    /// Tokio runtime threads.
     pub async fn stats_async(&self) -> KvResult<Vec<(String, u64)>> {
         let store = self.clone();
         tokio::task::spawn_blocking(move || store.stats())
@@ -639,22 +676,18 @@ mod tests {
         Key::from_hash(::blake3::hash(seed))
     }
 
+    fn value_file(dir: &tempfile::TempDir, ns: &str, k: &Key) -> std::path::PathBuf {
+        dir.path()
+            .join("kv")
+            .join(ns)
+            .join(format!("{}.bin", k.to_hex()))
+    }
+
     // ---- F1: round-trip across size boundaries ----
     #[test]
     fn f1_round_trip_sizes() {
         let (_d, s) = store();
-        // Boundary-focused sizes; the 4-MiB / 64-MiB cases live in the
-        // `--full` stress tests (`tests/kv_stress.rs`) so the default test
-        // run stays fast on Windows where every redb commit is an fsync.
-        let sizes = [
-            0,
-            1,
-            100,
-            INLINE_THRESHOLD - 1,
-            INLINE_THRESHOLD,
-            INLINE_THRESHOLD + 1,
-            64 * 1024,
-        ];
+        let sizes = [0, 1, 100, 4095, 4096, 4097, 64 * 1024];
         for (i, n) in sizes.iter().enumerate() {
             let k = key_from(&i.to_le_bytes());
             let val: Vec<u8> = (0..*n).map(|j| (j % 251) as u8).collect();
@@ -690,7 +723,6 @@ mod tests {
         s.put("ns", &k, b"x").unwrap();
         s.remove("ns", &k).unwrap();
         assert!(s.get("ns", &k).unwrap().is_none());
-        // Removing again is OK.
         s.remove("ns", &k).unwrap();
     }
 
@@ -706,27 +738,38 @@ mod tests {
         assert_eq!(s.get("b", &k).unwrap().unwrap(), b"in-b");
     }
 
+    // ---- F5b: clearing a namespace that was never written is a no-op ----
+    #[test]
+    fn f5b_clear_absent_namespace_is_ok() {
+        let (_d, s) = store();
+        s.clear_namespace("never-written").unwrap();
+    }
+
     // ---- F6: list_namespace sorted, lengths correct ----
     #[test]
     fn f6_list_sorted_and_lengths() {
         let (_d, s) = store();
         let mut keys: Vec<Key> = (0u32..5).map(|i| key_from(&i.to_le_bytes())).collect();
-        // Mix sizes: half inline, half spilled.
+        let mut expected: std::collections::HashMap<String, u64> = Default::default();
         for (i, k) in keys.iter().enumerate() {
-            let n = if i % 2 == 0 {
-                10
-            } else {
-                INLINE_THRESHOLD + 100
-            };
-            let val = vec![i as u8; n];
-            s.put("ns", k, &val).unwrap();
+            let n = if i % 2 == 0 { 10 } else { 4196 };
+            s.put("ns", k, &vec![i as u8; n]).unwrap();
+            expected.insert(k.to_hex(), n as u64);
         }
         let listed = s.list_namespace("ns").unwrap();
         assert_eq!(listed.len(), 5);
         keys.sort_by_key(|k| k.to_hex());
-        for (i, (k, _)) in listed.iter().enumerate() {
+        for (i, (k, len)) in listed.iter().enumerate() {
             assert_eq!(k.to_hex(), keys[i].to_hex(), "list not sorted at {i}");
+            assert_eq!(*len, expected[&k.to_hex()], "payload length for entry {i}");
         }
+    }
+
+    // ---- F6b: listing an absent namespace is empty, not an error ----
+    #[test]
+    fn f6b_list_absent_namespace_is_empty() {
+        let (_d, s) = store();
+        assert!(s.list_namespace("absent").unwrap().is_empty());
     }
 
     // ---- F7: total_bytes == sum of namespace_bytes ----
@@ -745,54 +788,91 @@ mod tests {
             .map(|ns| s.namespace_bytes(ns).unwrap())
             .sum();
         assert_eq!(total, sum);
+        // Header bytes must not be counted: 3 namespaces x (50 + 51 + 52).
+        assert_eq!(total, 3 * (50 + 51 + 52));
     }
 
-    // ---- F8: byte-exact inline/spill threshold ----
+    // ---- F8: every value is a file of header + payload ----
     #[test]
-    fn f8_byte_exact_threshold() {
+    fn f8_values_are_files() {
         let (d, s) = store();
-        let inline_key = key_from(b"inline");
-        let spill_key = key_from(b"spill");
-        s.put("ns", &inline_key, &vec![1u8; INLINE_THRESHOLD])
-            .unwrap();
-        s.put("ns", &spill_key, &vec![2u8; INLINE_THRESHOLD + 1])
-            .unwrap();
+        let small = key_from(b"small");
+        let large = key_from(b"large");
+        s.put("ns", &small, &[1u8; 16]).unwrap();
+        s.put("ns", &large, &vec![2u8; 40_000]).unwrap();
 
-        let inline_path = d
-            .path()
-            .join("kv")
-            .join("ns")
-            .join(format!("{}.bin", inline_key.to_hex()));
-        let spill_path = d
-            .path()
-            .join("kv")
-            .join("ns")
-            .join(format!("{}.bin", spill_key.to_hex()));
-        assert!(!inline_path.exists(), "inline value must NOT spill");
-        assert!(spill_path.exists(), "spill threshold + 1 must spill");
-        assert_eq!(
-            std::fs::metadata(&spill_path).unwrap().len(),
-            (INLINE_THRESHOLD + 1) as u64
-        );
+        for (k, payload) in [(&small, 16usize), (&large, 40_000usize)] {
+            let path = value_file(&d, "ns", k);
+            assert!(path.exists(), "value must be on disk at {}", path.display());
+            assert_eq!(
+                std::fs::metadata(&path).unwrap().len(),
+                (payload + HEADER_LEN) as u64,
+                "file is header + payload"
+            );
+        }
     }
 
-    // ---- F9: tampered spill file → Corrupt ----
+    // ---- F9: tampered payload → Corrupt ----
     #[test]
-    fn f9_tampered_spill_detected() {
+    fn f9_tampered_payload_detected() {
         let (d, s) = store();
         let k = key_from(b"corrupt");
-        s.put("ns", &k, &vec![7u8; INLINE_THRESHOLD + 100]).unwrap();
-        let path = d
-            .path()
-            .join("kv")
-            .join("ns")
-            .join(format!("{}.bin", k.to_hex()));
-        // Tamper one byte.
+        s.put("ns", &k, &vec![7u8; 4196]).unwrap();
+        let path = value_file(&d, "ns", &k);
         let mut bytes = std::fs::read(&path).unwrap();
-        bytes[0] ^= 0xff;
+        // Flip a payload byte, leaving the header's recorded blake3 intact.
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xff;
         std::fs::write(&path, &bytes).unwrap();
         let err = s.get("ns", &k).unwrap_err();
-        assert!(matches!(err, KvError::Corrupt(_, _)), "got {err:?}");
+        match err {
+            KvError::Corrupt(_, msg) => assert!(msg.contains("blake3 mismatch"), "msg={msg}"),
+            other => panic!("expected Corrupt, got {other:?}"),
+        }
+    }
+
+    // ---- F9b: truncated payload → Corrupt, not a short read ----
+    #[test]
+    fn f9b_truncated_file_detected() {
+        let (d, s) = store();
+        let k = key_from(b"trunc");
+        s.put("ns", &k, &vec![3u8; 1000]).unwrap();
+        let path = value_file(&d, "ns", &k);
+        let bytes = std::fs::read(&path).unwrap();
+        std::fs::write(&path, &bytes[..bytes.len() - 10]).unwrap();
+        let err = s.get("ns", &k).unwrap_err();
+        match err {
+            KvError::Corrupt(_, msg) => assert!(msg.contains("length mismatch"), "msg={msg}"),
+            other => panic!("expected Corrupt, got {other:?}"),
+        }
+    }
+
+    // ---- F9c: a header-only truncation is still Corrupt ----
+    #[test]
+    fn f9c_header_truncation_detected() {
+        let (d, s) = store();
+        let k = key_from(b"hdr");
+        s.put("ns", &k, b"payload").unwrap();
+        std::fs::write(value_file(&d, "ns", &k), b"ZCKV").unwrap();
+        let err = s.get("ns", &k).unwrap_err();
+        match err {
+            KvError::Corrupt(_, msg) => assert!(msg.contains("truncated"), "msg={msg}"),
+            other => panic!("expected Corrupt, got {other:?}"),
+        }
+    }
+
+    // ---- F9d: a file that is not ours at all is Corrupt, not silently data ----
+    #[test]
+    fn f9d_foreign_magic_detected() {
+        let (d, s) = store();
+        let k = key_from(b"foreign");
+        s.put("ns", &k, b"payload").unwrap();
+        std::fs::write(value_file(&d, "ns", &k), vec![0u8; HEADER_LEN + 8]).unwrap();
+        let err = s.get("ns", &k).unwrap_err();
+        match err {
+            KvError::Corrupt(_, msg) => assert!(msg.contains("bad magic"), "msg={msg}"),
+            other => panic!("expected Corrupt, got {other:?}"),
+        }
     }
 
     // ---- F10: hex round-trip + bad inputs ----
@@ -805,15 +885,9 @@ mod tests {
         assert!(hex
             .chars()
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()));
-        let k2 = Key::from_hex(&hex).unwrap();
-        assert_eq!(k, k2);
+        assert_eq!(Key::from_hex(&hex).unwrap(), k);
+        assert_eq!(Key::from_hex(&hex.to_ascii_uppercase()).unwrap(), k);
 
-        // Upper-case is accepted (case-insensitive parse).
-        let upper = hex.to_ascii_uppercase();
-        let k3 = Key::from_hex(&upper).unwrap();
-        assert_eq!(k, k3);
-
-        // Bad inputs.
         assert!(matches!(Key::from_hex(""), Err(KvError::BadKey)));
         assert!(matches!(Key::from_hex("zz"), Err(KvError::BadKey)));
         assert!(matches!(
@@ -849,27 +923,34 @@ mod tests {
     // ---- F12: schema_version mismatch surfaces as Corrupt ----
     #[test]
     fn f12_schema_version_mismatch() {
-        let (_d, s) = store();
+        let (d, s) = store();
         let k = key_from(b"sv");
-        // Write a row by hand with a forged schema_version.
-        let row = KvRow {
-            schema_version: SCHEMA_VERSION + 1,
-            body: KvBody::Inline(b"hi".to_vec()),
-        };
-        let bytes = bincode::serialize(&row).unwrap();
-        let composite_key = composite("ns", &k);
-        let txn = s.db.begin_write().unwrap();
-        {
-            let mut t = txn.open_table(KV_TABLE).unwrap();
-            t.insert(composite_key.as_str(), bytes.as_slice()).unwrap();
-        }
-        txn.commit().unwrap();
+        s.put("ns", &k, b"hi").unwrap();
+        let path = value_file(&d, "ns", &k);
+        let mut bytes = std::fs::read(&path).unwrap();
+        bytes[4..8].copy_from_slice(&(SCHEMA_VERSION + 1).to_le_bytes());
+        std::fs::write(&path, &bytes).unwrap();
 
         let err = s.get("ns", &k).unwrap_err();
         match err {
             KvError::Corrupt(_, msg) => assert!(msg.contains("schema_version="), "msg={msg}"),
             other => panic!("expected Corrupt, got {other:?}"),
         }
+    }
+
+    // ---- F13: a foreign file in the namespace dir is ignored by listing ----
+    #[test]
+    fn f13_foreign_files_are_skipped() {
+        let (d, s) = store();
+        let k = key_from(b"real");
+        s.put("ns", &k, b"value").unwrap();
+        let ns_dir = d.path().join("kv").join("ns");
+        std::fs::write(ns_dir.join("README.txt"), b"not a value").unwrap();
+        std::fs::write(ns_dir.join("deadbeef.bin"), b"bad hex name").unwrap();
+
+        let listed = s.list_namespace("ns").unwrap();
+        assert_eq!(listed.len(), 1, "only the real value is listed");
+        assert_eq!(listed[0].0.to_hex(), k.to_hex());
     }
 
     // ---- I1..I4: namespace edge cases via put ----
@@ -906,9 +987,9 @@ mod tests {
         ));
     }
 
-    // ---- I5/I6: max value bytes (allocates 64 MiB, runs only under --full) ----
+    // ---- I6: max value bytes (allocates 64 MiB, runs only under --full) ----
     #[test]
-    #[ignore = "allocates 64 MiB; see tests/kv_stress.rs for max-cap coverage"]
+    #[ignore = "allocates 64 MiB; see tests/artifact_kv_stress.rs for max-cap coverage"]
     fn i6_too_large_rejected() {
         let (_d, s) = store();
         let k = key_from(b"big");
@@ -929,42 +1010,52 @@ mod tests {
         assert_eq!(s.get("b", &k).unwrap().unwrap(), b"b-val");
     }
 
-    // ---- D3 / P8: reopen sees prior writes ----
+    // ---- P8 / I8: reopen sees prior writes ----
     #[test]
     fn p8_reopen_round_trip() {
         let dir = tempfile::tempdir().unwrap();
         let k = key_from(b"persist");
         {
             let s = KvStore::open(dir.path()).unwrap();
-            s.put("ns", &k, &vec![3u8; INLINE_THRESHOLD + 10]).unwrap();
+            s.put("ns", &k, &vec![3u8; 4106]).unwrap();
         }
         let s = KvStore::open(dir.path()).unwrap();
-        let got = s.get("ns", &k).unwrap().unwrap();
-        assert_eq!(got, vec![3u8; INLINE_THRESHOLD + 10]);
+        assert_eq!(s.get("ns", &k).unwrap().unwrap(), vec![3u8; 4106]);
     }
 
     // ---- P3: case-insensitive key parsing means UPPER and lower collide ----
     #[test]
     fn p3_case_insensitive_key_parses_to_same_key() {
-        let h = ::blake3::hash(b"x");
-        let k = Key::from_hash(h);
+        let k = Key::from_hash(::blake3::hash(b"x"));
         let lower = k.to_hex();
         let upper = lower.to_ascii_uppercase();
-        let k_lower = Key::from_hex(&lower).unwrap();
-        let k_upper = Key::from_hex(&upper).unwrap();
-        assert_eq!(k_lower, k_upper);
+        assert_eq!(
+            Key::from_hex(&lower).unwrap(),
+            Key::from_hex(&upper).unwrap()
+        );
     }
 
-    // ---- I8: put then reopen with fresh KvStore reads back ----
+    // ---- #1352: two stores over one directory coexist ----
+    //
+    // This is the regression the redb-backed implementation could not pass: a
+    // second `Database::create` on the same file returned
+    // `DatabaseAlreadyOpen`, which is the whole reason this store dropped its
+    // database. Two `KvStore`s are now independent handles onto a shared
+    // directory, so this must simply work.
     #[test]
-    fn i8_durability_after_commit() {
+    fn concurrent_stores_over_one_dir_do_not_lock_each_other() {
         let dir = tempfile::tempdir().unwrap();
-        let k = key_from(b"d");
-        {
-            let s = KvStore::open(dir.path()).unwrap();
-            s.put("ns", &k, b"durable").unwrap();
-        }
-        let s = KvStore::open(dir.path()).unwrap();
-        assert_eq!(s.get("ns", &k).unwrap().unwrap(), b"durable");
+        let a = KvStore::open(dir.path()).unwrap();
+        let b = KvStore::open(dir.path()).unwrap();
+
+        let ka = key_from(b"from-a");
+        let kb = key_from(b"from-b");
+        a.put("ns", &ka, b"a-wrote").unwrap();
+        b.put("ns", &kb, b"b-wrote").unwrap();
+
+        // Each store sees the other's committed write.
+        assert_eq!(b.get("ns", &ka).unwrap().unwrap(), b"a-wrote");
+        assert_eq!(a.get("ns", &kb).unwrap().unwrap(), b"b-wrote");
+        assert_eq!(a.list_namespace("ns").unwrap().len(), 2);
     }
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -178,3 +178,52 @@ This was already recorded in memory as "Validating soldr output on Windows" and
 I still repeated it, which is the actual lesson: the failure mode is silent and
 looks exactly like success, so the filter has to be structurally incapable of
 lying rather than merely correct on the day it was written.
+
+## Removing a database can remove serialization you never knew you relied on
+
+#1352 replaced `KvStore`'s redb backend with one file per key. The public API,
+the CLI surface, and every functional test were preserved, and the unit tests
+passed first try. The stress suite did not: `c1_thundering_herd_same_key`
+(16 threads x 100 writes to one key) failed immediately with
+`ERROR_ACCESS_DENIED` on Windows.
+
+The cause was not in the new code. It was in what the old code had been doing
+for free. Every write to a key went through one redb write transaction, so
+same-key writers were **serialized by the database** as a side effect of
+durability. File-per-key deletes that serialization — which is the entire point
+of the change — but `MOVEFILE_REPLACE_EXISTING` cannot start while another
+handle is open on the destination, so concurrent same-key renames collide.
+
+The fix needed two mechanisms, and the first alone was not enough: a bounded
+retry on the transient Windows sharing errors could not converge against 1,600
+renames onto one path, because the destination is open essentially always. It
+took sharded per-key mutexes held across the rename only. **I found that out by
+running the test, not by reasoning about it** — the retry looked obviously
+sufficient right up until it wasn't.
+
+Lesson: when you remove a component, enumerate the *incidental* guarantees it
+was providing, not just the advertised ones. A database gives you serialization,
+ordering, and atomicity across keys whether or not you asked for them. Then
+trust the concurrency tests over your model of the change: the functional tests
+all passed while the design was still wrong.
+
+## Docs that describe a removed subsystem are an active liability
+
+A user reported `redb: Database already open. Cannot acquire lock.` The
+investigation started in zccache and stayed there for a while, because
+`crates/CLAUDE.md` said "redb MVCC for artifact index" and
+`architecture/artifact-store.md` documented a two-table redb schema. Both had
+been false since the index moved to a bincode blob. The error was in a different
+repository entirely (soldr's `state.redb`).
+
+Worse, soldr#1814 had already done exactly this audit months earlier and reached
+the same conclusion. The stale docs did not just slow one investigation down —
+they caused a completed one to be repeated from scratch.
+
+Lesson: when a subsystem is replaced, the doc sweep is part of the change, not
+cleanup to schedule later. Grep for the old technology's name across `docs/`,
+`README.md`, and every `CLAUDE.md`, and check test/bench identifiers too —
+`run_strategy_*_redb` names survived on functions that call the bincode store,
+which would have misled the next person profiling persistence. Mark superseded
+ADRs superseded rather than rewriting them; the reason a decision changed is
+usually more useful than the decision.


### PR DESCRIPTION
Closes #1352. **Stacked on #1353** (`fix/1350-remove-dead-redb-deps`) — merge that first, or merge this and #1353 becomes a no-op.

## The decision

#1352 asked for a decision between three options. This implements **Option B — keep the surface, drop the database.**

I recommended Option A (delete `zccache kv` outright) in the issue, and I still think it's defensible: the subcommand has no consumers, and porting unused code has a real cost. **I did not take it because deleting a shipped CLI surface is a product call, not an engineering one, and it isn't mine to make.** Option B reaches the same structural goal — redb is gone from the workspace — without that decision, and leaves A available as a trivial follow-up on a module that no longer has a database in it. If you'd rather delete it, say so and I'll cut that PR instead; this one becomes moot.

## What changed

Every value is one file at `kv/<namespace>/<hex>.bin`, written tempfile → fsync → rename, with a 48-byte header: magic (`ZCKV`), schema version, payload length, blake3 of the payload. Truncation, tampering, and foreign files are detected on read rather than returned as data.

The inline-vs-spill split is gone. The spill path was already most of this implementation; the inline half only existed because there was a database to put small values in.

**Why not keep redb.** It takes an exclusive whole-file lock per `Database` handle — by design, it is a single-owner store. That made every `zccache kv` invocation take a process lock, pay a write-transaction commit just to assert the table existed (`ensure_table` ran on *every* open, including reads), and fail opaquely if any other process had the file open. The access pattern never needed a database: keys are content-addressed, so there are no range queries, no cross-key transactions, no secondary indexes.

## A Windows race this exposed — and why the stress suite earned its keep

`MOVEFILE_REPLACE_EXISTING` cannot start while another handle is open on the destination, so concurrent same-key writers get `ERROR_ACCESS_DENIED`. **redb never hit this because a write transaction serialized same-key writes.** File-per-key removes that serialization — which is the point — but it means same-key writers now race at the rename.

`c1_thundering_herd_same_key` (16 threads × 100 writes to one key) caught it immediately. My first implementation failed it outright. Two mechanisms restore the guarantee without reintroducing a store lock:

1. A **bounded retry** (~1 s, exponential, capped at 64 ms/step) on `ERROR_ACCESS_DENIED` / `ERROR_SHARING_VIOLATION`. Compiled out on Unix, where `rename(2)` over an open file just works. This also covers *cross-process* same-key writers.
2. **Sharded per-key mutexes** (64 shards, keyed off the destination path) held across the **rename only** — never across the payload write or its fsync. Distinct keys never contend.

The retry alone was not enough: with 1,600 renames onto one path the destination is open essentially always, so it could not converge. I found that out by running the test rather than by reasoning about it.

## API changes

| Item | Change | Rationale |
|---|---|---|
| `KvStore::from_database(Arc<Database>, ..)` | **removed** | Took a `redb::Database`. Zero callers. |
| `KvError::Redb(String)` | **removed** | Named a backend that no longer exists. |
| `INLINE_THRESHOLD` | **kept**, repurposed | No longer affects storage; documented as such. The stress suite uses it as a "comfortably large" size boundary, and removing a public const would break callers for no gain. |
| everything else | unchanged | `get`/`put`/`remove`/`clear_namespace`/`list_namespace`/`namespace_bytes`/`total_bytes`/`stats` and all eight `_async` wrappers keep their signatures. |

**On-disk break:** values written by the redb version are not read by this one. There is no migration because the store had no consumers, so there is no data to carry forward. A stale `index.redb` is left untouched on disk — `zccache clear` or delete it by hand.

## Validation

Run with `soldr --no-cache` because the shared cache was reclaiming intermediates mid-build under parallel load (soldr#1969).

| Check | Result |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo fmt --all` | clean |
| `cargo test -p zccache-artifact --lib kv` | **26 passed**, 0 failed |
| `cargo test -p zccache --test cli_kv -- --ignored` | **6 passed**, 0 failed |
| `cargo test -p zccache --test artifact_kv_stress -- --ignored` | **6 passed**, 0 failed |
| `cargo test -p zccache --test artifact_kv_stress` | 5 passed, 0 failed |

The `cli_kv` run is the load-bearing one: it drives the real `zccache` binary through get/put/rm/ls/clear/stats end-to-end, so it proves the public CLI behaviour is unchanged. Note those six tests are `#[ignore]`d and need `cargo build -p zccache --bin zccache --features zccache-bin` first — they fail with "binary not found" otherwise, which is a harness quirk, not a regression.

New tests beyond the ported originals: header-truncation, foreign-magic, and payload-tamper detection; foreign files skipped by listing; absent-namespace list/clear; `total_bytes` excluding header bytes; and `concurrent_stores_over_one_dir_do_not_lock_each_other`, which is the regression the redb version could not pass.

Part of the cross-repo redb cleanup tracked in zackees/soldr#2228. With this and #1353, `grep -rn redb crates/*/Cargo.toml Cargo.toml` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
