### PR TITLE
perf(persist): share staged materialization leases

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
@@ -258,10 +258,46 @@ impl CachedArtifact {
 /// Resolve payloads for materialization, translating a resolver failure or a
 /// missing-blob outcome into a typed [`MaterializationFailure`] the caller can
 /// report and (for genuine blob loss) use as depgraph-invalidation evidence.
+#[cfg(test)]
 pub(super) fn ensure_payloads_for_materialization(
     cached: &CachedArtifact,
     artifact_dir: &Path,
     key_hex: &str,
+) -> MaterializationResult<MaterializationPayloads> {
+    ensure_payloads_for_materialization_with_guard(
+        cached,
+        artifact_dir,
+        key_hex,
+        acquire_staged_materialization_guard_if_present,
+        acquire_staged_materialization_guard_for_cached_path,
+    )
+}
+
+pub(super) fn ensure_payloads_for_materialization_for_state(
+    state: &SharedState,
+    cached: &CachedArtifact,
+    key_hex: &str,
+) -> MaterializationResult<MaterializationPayloads> {
+    ensure_payloads_for_materialization_with_guard(
+        cached,
+        &state.artifact_dir,
+        key_hex,
+        |artifact_dir, key_hex| {
+            acquire_staged_materialization_guard_if_present_for_state(state, artifact_dir, key_hex)
+        },
+        |_| acquire_staged_materialization_guard_for_state(state, &state.artifact_dir),
+    )
+}
+
+fn ensure_payloads_for_materialization_with_guard(
+    cached: &CachedArtifact,
+    artifact_dir: &Path,
+    key_hex: &str,
+    acquire_guard_if_present: impl Fn(
+        &Path,
+        &str,
+    ) -> std::io::Result<Option<StagedMaterializationGuard>>,
+    acquire_guard: impl Fn(&Path) -> std::io::Result<StagedMaterializationGuard>,
 ) -> MaterializationResult<MaterializationPayloads> {
     let existing = cached.payloads.get().cloned();
     let existing_is_staged = existing.as_ref().is_some_and(|payloads| {
@@ -270,12 +306,9 @@ pub(super) fn ensure_payloads_for_materialization(
         )
     });
     let mut staged_guard = if existing_is_staged {
-        Some(
-            acquire_staged_materialization_guard_for_cached_path(artifact_dir)
-                .map_err(|error| cache_read_failure(artifact_dir, error))?,
-        )
+        Some(acquire_guard(artifact_dir).map_err(|error| cache_read_failure(artifact_dir, error))?)
     } else if existing.is_none() && staged_artifacts_enabled() {
-        acquire_staged_materialization_guard_if_present(artifact_dir, key_hex)
+        acquire_guard_if_present(artifact_dir, key_hex)
             .map_err(|error| cache_read_failure(artifact_dir, error))?
     } else {
         None
@@ -303,7 +336,7 @@ pub(super) fn ensure_payloads_for_materialization(
                 // with staged paths after this request chose its lookup lane.
                 // Acquire ownership before those canonical paths can escape.
                 staged_guard = Some(
-                    acquire_staged_materialization_guard_for_cached_path(artifact_dir)
+                    acquire_guard(artifact_dir)
                         .map_err(|error| cache_read_failure(artifact_dir, error))?,
                 );
             } else if !is_staged {
@@ -549,6 +582,99 @@ mod tests {
         assert!(ensure_payloads_with_staged_policy(&cached, dir.path(), key, false).is_some());
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn concurrent_staged_materialization_leases_share_the_store_lock() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        const CONCURRENT_HITS: usize = 8;
+
+        let dir = tempfile::tempdir().unwrap();
+        let server = crate::daemon::server::tests::bind_isolated_server(dir.path());
+        let state = server.state.as_ref();
+        let artifact_dir = state.artifact_dir.clone();
+        let source = dir.path().join("source.rlib");
+        let bytes = b"shared staged materialization lock";
+        std::fs::write(&source, bytes).unwrap();
+        let key = "8".repeat(64);
+        persist_staged_artifact_paths(&artifact_dir, &key, &[source.into()]).unwrap();
+        let cached = lazy_artifact(bytes.len() as u64);
+        let staged_root = crate::artifact::staged_lock::staged_root(&artifact_dir);
+        reset_test_shared_lock_acquisitions(&staged_root);
+
+        let start = Arc::new(std::sync::Barrier::new(CONCURRENT_HITS + 1));
+        let ready = Arc::new(std::sync::Barrier::new(CONCURRENT_HITS + 1));
+        let release = Arc::new(std::sync::Barrier::new(CONCURRENT_HITS + 1));
+        let (held_tx, held_rx) = mpsc::sync_channel(CONCURRENT_HITS);
+        let hits: Vec<_> = (0..CONCURRENT_HITS)
+            .map(|_| {
+                let cached = cached.clone();
+                let key = key.clone();
+                let start = Arc::clone(&start);
+                let ready = Arc::clone(&ready);
+                let release = Arc::clone(&release);
+                let held_tx = held_tx.clone();
+                let state = server.state.clone();
+                std::thread::spawn(move || {
+                    start.wait();
+                    let payloads = ensure_payloads_for_materialization_for_state(
+                        state.as_ref(),
+                        &cached,
+                        &key,
+                    )
+                    .unwrap();
+                    held_tx.send(()).unwrap();
+                    ready.wait();
+                    release.wait();
+                    drop(payloads);
+                })
+            })
+            .collect();
+        drop(held_tx);
+        start.wait();
+
+        for _ in 0..CONCURRENT_HITS {
+            held_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("concurrent staged hit did not acquire its materialization lease");
+        }
+        ready.wait();
+
+        assert_eq!(
+            test_shared_lock_acquisition_count(&staged_root),
+            1,
+            "simultaneous staged hits must share one daemon-local OS lock lease"
+        );
+
+        let clear_hook =
+            StagedHookGuard::arm(&artifact_dir, StagedHookPoint::MaintenanceStoreLockPending);
+        let (clear_done_tx, clear_done_rx) = mpsc::sync_channel(1);
+        let clear_artifact_dir = artifact_dir.clone();
+        let clear = std::thread::spawn(move || {
+            let result = clear_staged_artifacts(&clear_artifact_dir);
+            let _ = clear_done_tx.send(result);
+        });
+        clear_hook.wait_until_reached();
+        clear_hook.resume();
+        assert!(
+            matches!(
+                clear_done_rx.recv_timeout(Duration::from_millis(100)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ),
+            "exclusive maintenance must remain blocked while any shared delivery lease is live"
+        );
+
+        release.wait();
+        for hit in hits {
+            hit.join().unwrap();
+        }
+        clear_done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("maintenance did not resume after all shared delivery leases were released")
+            .unwrap();
+        clear.join().unwrap();
+    }
+
     #[test]
     fn staged_materialization_lease_blocks_clear_until_delivery_finishes() {
         use std::sync::mpsc;
@@ -698,7 +824,7 @@ mod tests {
     }
 
     #[test]
-    fn every_cache_hit_delivery_path_uses_the_typed_materialization_lease() {
+    fn every_cache_hit_delivery_path_uses_the_daemon_shared_materialization_lease() {
         let consumers = [
             (
                 "single compile",
@@ -710,7 +836,7 @@ mod tests {
         ];
         for (name, source) in consumers {
             assert!(
-                source.contains("ensure_payloads_for_materialization("),
+                source.contains("ensure_payloads_for_materialization_for_state("),
                 "{name} bypasses the typed staged materialization lease"
             );
         }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
@@ -117,17 +117,16 @@ pub(super) fn materialize_cached_compile_hit(
     };
     let cached = lookup_artifact_with_disk_fallback(state, artifact_key_hex)
         .ok_or_else(&missing_artifact)?;
-    let payloads =
-        ensure_payloads_for_materialization(&cached, &state.artifact_dir, artifact_key_hex)
-            .map_err(|error| {
-                report_materialization_failure(
-                    &state.cache_dir,
-                    artifact_key_hex,
-                    "compile-hit",
-                    &error,
-                );
-                CachedHitFailure::from(error)
-            })?;
+    let payloads = ensure_payloads_for_materialization_for_state(state, &cached, artifact_key_hex)
+        .map_err(|error| {
+            report_materialization_failure(
+                &state.cache_dir,
+                artifact_key_hex,
+                "compile-hit",
+                &error,
+            );
+            CachedHitFailure::from(error)
+        })?;
     record_artifact_access(state, artifact_key_hex, &cached, t0);
     let t1 = Instant::now();
     let artifact_lookup_ns = (t1 - t0).as_nanos() as u64;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -121,9 +121,9 @@ fn check_unit_cache(
                 // runs in its own blocking task, so writes are already
                 // parallel across units.
                 if let Some(cached) = lookup_artifact_with_disk_fallback(state, artifact_key_hex) {
-                    match ensure_payloads_for_materialization(
+                    match ensure_payloads_for_materialization_for_state(
+                        state,
                         &cached,
-                        &state.artifact_dir,
                         artifact_key_hex,
                     ) {
                         Ok(payloads) => {
@@ -302,11 +302,7 @@ fn check_unit_cache(
         let artifact_key_hex = artifact_key.hash().to_hex();
         if let Some(cached) = lookup_artifact_with_disk_fallback(state, &artifact_key_hex) {
             let t_lookup = t0.elapsed();
-            match ensure_payloads_for_materialization(
-                &cached,
-                &state.artifact_dir,
-                &artifact_key_hex,
-            ) {
+            match ensure_payloads_for_materialization_for_state(state, &cached, &artifact_key_hex) {
                 Ok(payloads) => {
                     record_artifact_access(
                         state,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec.rs
@@ -768,7 +768,7 @@ async fn try_exec_cache_hit(
     let stderr_full = entry.stderr.clone();
     let names = Arc::clone(&entry.meta.output_names);
 
-    let payloads = ensure_payloads_for_materialization(&entry, &state.artifact_dir, key_hex)
+    let payloads = ensure_payloads_for_materialization_for_state(state, &entry, key_hex)
         .map_err(|failure| {
             report_materialization_failure(&state.cache_dir, key_hex, "exec-hit", &failure);
         })

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -374,14 +374,11 @@ pub(super) async fn handle_link_ephemeral(
     let t_cache_lookup = profile_enabled.then(std::time::Instant::now);
     if let Some(entry) = lookup_artifact_with_disk_fallback(state, &key_hex) {
         // Load payloads from disk if not already loaded.
-        if let Ok(payloads) = ensure_payloads_for_materialization(
-            &entry,
-            &state.artifact_dir,
-            &key_hex,
-        )
-        .map_err(|failure| {
-            report_materialization_failure(&state.cache_dir, &key_hex, "link-hit", &failure);
-        }) {
+        if let Ok(payloads) = ensure_payloads_for_materialization_for_state(state, &entry, &key_hex)
+            .map_err(|failure| {
+                report_materialization_failure(&state.cache_dir, &key_hex, "link-hit", &failure);
+            })
+        {
             record_artifact_access(state, &key_hex, &entry, std::time::Instant::now());
             discard_speculative_archive(&mut speculative_archive);
             let names = Arc::clone(&entry.meta.output_names);

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -273,6 +273,7 @@ pub(super) fn new_shared_state(
             in_flight_bytes: AtomicUsize::new(0),
             disk_maintenance: Mutex::new(()),
             artifact_publication: Arc::new(tokio::sync::RwLock::new(())),
+            staged_materialization_lock: Arc::new(StdMutex::new(None)),
             persist_semaphore: Arc::new(tokio::sync::Semaphore::new(persist_workers_default())),
             compile_concurrency,
             compile_queue: Arc::new(

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -273,7 +273,7 @@ pub(super) fn new_shared_state(
             in_flight_bytes: AtomicUsize::new(0),
             disk_maintenance: Mutex::new(()),
             artifact_publication: Arc::new(tokio::sync::RwLock::new(())),
-            staged_materialization_lock: Arc::new(StdMutex::new(None)),
+            staged_materialization_lock: Arc::new(StdMutex::new(std::sync::Weak::new())),
             persist_semaphore: Arc::new(tokio::sync::Semaphore::new(persist_workers_default())),
             compile_concurrency,
             compile_queue: Arc::new(

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store.rs
@@ -24,10 +24,20 @@ pub(in crate::daemon::server) use materialize::{
 };
 mod read_guard;
 use read_guard::validate_key;
+#[cfg(test)]
 pub(in crate::daemon::server) use read_guard::{
     acquire_staged_materialization_guard_for_cached_path,
-    acquire_staged_materialization_guard_if_present, is_staged_artifact_path,
+    acquire_staged_materialization_guard_if_present,
+};
+pub(in crate::daemon::server) use read_guard::{
+    acquire_staged_materialization_guard_for_state,
+    acquire_staged_materialization_guard_if_present_for_state, is_staged_artifact_path,
     is_staged_artifact_root, staged_key_supported, StagedMaterializationGuard,
+    StagedMaterializationLock,
+};
+#[cfg(test)]
+pub(in crate::daemon::server) use read_guard::{
+    reset_test_shared_lock_acquisitions, test_shared_lock_acquisition_count,
 };
 mod root_safety;
 pub(in crate::daemon::server) use root_safety::validate_staged_artifact_root;

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/read_guard.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/read_guard.rs
@@ -4,7 +4,53 @@ use super::{is_staged_link_or_reparse, open_store_lock, pointer_path, staged_roo
 use std::fs::{self, File};
 use std::io;
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Instant;
+
+#[cfg(test)]
+use crate::core::NormalizedPath;
+#[cfg(test)]
+use std::collections::HashMap;
+#[cfg(test)]
+use std::sync::{Mutex, OnceLock};
+
+#[cfg(test)]
+static TEST_SHARED_LOCK_ACQUISITIONS: OnceLock<Mutex<HashMap<NormalizedPath, u64>>> =
+    OnceLock::new();
+
+#[cfg(test)]
+fn test_shared_lock_acquisitions() -> &'static Mutex<HashMap<NormalizedPath, u64>> {
+    TEST_SHARED_LOCK_ACQUISITIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[cfg(test)]
+pub(in crate::daemon::server) fn reset_test_shared_lock_acquisitions(root: &NormalizedPath) {
+    test_shared_lock_acquisitions()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(root.clone(), 0);
+}
+
+#[cfg(test)]
+fn record_test_shared_lock_acquisition(root: &NormalizedPath) {
+    if let Some(count) = test_shared_lock_acquisitions()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get_mut(root)
+    {
+        *count = count.saturating_add(1);
+    }
+}
+
+#[cfg(test)]
+pub(in crate::daemon::server) fn test_shared_lock_acquisition_count(root: &NormalizedPath) -> u64 {
+    test_shared_lock_acquisitions()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(root)
+        .copied()
+        .unwrap_or(0)
+}
 
 pub(in crate::daemon::server) fn staged_key_supported(key_hex: &str) -> bool {
     !key_hex.is_empty()
@@ -73,6 +119,16 @@ pub(super) fn validate_key(key_hex: &str) -> io::Result<()> {
     Ok(())
 }
 
+/// A process-local shared lock lease over the staged store.
+///
+/// The daemon keeps one of these in [`SharedState`] while one or more cache
+/// hits deliver staged outputs. Individual materialization payloads clone the
+/// `Arc`, so only the transition from zero to one active hit opens and locks
+/// `.store.lock`; dropping the final payload releases cross-process exclusion.
+pub(in crate::daemon::server) struct StagedMaterializationLock {
+    _store_lock: File,
+}
+
 /// Shared ownership of the staged store while resolved generation paths are
 /// being delivered to caller-owned destinations.
 ///
@@ -80,9 +136,28 @@ pub(super) fn validate_key(key_hex: &str) -> io::Result<()> {
 /// guard in the typed materialization payload prevents a generation from
 /// disappearing between resolution and the final reflink/hardlink/copy.
 pub(in crate::daemon::server) struct StagedMaterializationGuard {
-    _store_lock: File,
+    store_lock: Arc<StagedMaterializationLock>,
+    state_lock: Option<Arc<std::sync::Mutex<Option<Arc<StagedMaterializationLock>>>>>,
     wait_ns: u64,
     acquired_at: Instant,
+}
+
+impl Drop for StagedMaterializationGuard {
+    fn drop(&mut self) {
+        let Some(state_lock) = self.state_lock.as_ref() else {
+            return;
+        };
+        let mut held = state_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if held
+            .as_ref()
+            .is_some_and(|active| Arc::ptr_eq(active, &self.store_lock))
+            && Arc::strong_count(&self.store_lock) == 2
+        {
+            *held = None;
+        }
+    }
 }
 
 impl StagedMaterializationGuard {
@@ -94,12 +169,14 @@ impl StagedMaterializationGuard {
     }
 }
 
+#[cfg(test)]
 fn acquire_staged_materialization_guard(
     artifact_dir: &Path,
 ) -> io::Result<StagedMaterializationGuard> {
     acquire_staged_materialization_guard_from(artifact_dir, Instant::now())
 }
 
+#[cfg(test)]
 /// Acquire the shared read lock, attributing everything since `wait_started`
 /// to the wait.
 ///
@@ -117,14 +194,20 @@ fn acquire_staged_materialization_guard_from(
     let root = staged_root(artifact_dir);
     let store_lock = open_store_lock(&root)?;
     fs2::FileExt::lock_shared(&store_lock)?;
+    #[cfg(test)]
+    record_test_shared_lock_acquisition(&root);
     let wait_ns = wait_started.elapsed().as_nanos().min(u64::MAX as u128) as u64;
     Ok(StagedMaterializationGuard {
-        _store_lock: store_lock,
+        store_lock: Arc::new(StagedMaterializationLock {
+            _store_lock: store_lock,
+        }),
+        state_lock: None,
         wait_ns,
         acquired_at: Instant::now(),
     })
 }
 
+#[cfg(test)]
 /// Acquire staged-store read ownership only when this key currently has a
 /// staged pointer. If no pointer exists, callers deliberately resolve with
 /// staged lookup disabled for that attempt: a concurrent publisher may become
@@ -152,6 +235,81 @@ pub(in crate::daemon::server) fn acquire_staged_materialization_guard_if_present
     }
 }
 
+pub(in crate::daemon::server) fn acquire_staged_materialization_guard_if_present_for_state(
+    state: &super::super::SharedState,
+    artifact_dir: &Path,
+    key_hex: &str,
+) -> io::Result<Option<StagedMaterializationGuard>> {
+    let wait_started = Instant::now();
+    validate_key(key_hex)?;
+    let pointer = pointer_path(artifact_dir, key_hex);
+    match fs::symlink_metadata(&pointer) {
+        Ok(metadata) if is_staged_link_or_reparse(&metadata) => Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing staged artifact materialization through linked/reparse pointer: {}",
+                pointer.display()
+            ),
+        )),
+        Ok(_) => {
+            acquire_staged_materialization_guard_for_state_from(state, artifact_dir, wait_started)
+                .map(Some)
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn acquire_staged_materialization_guard_for_state_from(
+    state: &super::super::SharedState,
+    artifact_dir: &Path,
+    wait_started: Instant,
+) -> io::Result<StagedMaterializationGuard> {
+    let mut held = state
+        .staged_materialization_lock
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(store_lock) = held.as_ref() {
+        return Ok(StagedMaterializationGuard {
+            store_lock: Arc::clone(store_lock),
+            state_lock: Some(Arc::clone(&state.staged_materialization_lock)),
+            // Reusing the daemon-local lease performs no filesystem work.
+            wait_ns: 0,
+            acquired_at: Instant::now(),
+        });
+    }
+
+    let root = staged_root(artifact_dir);
+    let store_lock = open_store_lock(&root)?;
+    fs2::FileExt::lock_shared(&store_lock)?;
+    #[cfg(test)]
+    record_test_shared_lock_acquisition(&root);
+    let store_lock = Arc::new(StagedMaterializationLock {
+        _store_lock: store_lock,
+    });
+    *held = Some(Arc::clone(&store_lock));
+    Ok(StagedMaterializationGuard {
+        store_lock,
+        state_lock: Some(Arc::clone(&state.staged_materialization_lock)),
+        wait_ns: wait_started.elapsed().as_nanos().min(u64::MAX as u128) as u64,
+        acquired_at: Instant::now(),
+    })
+}
+
+/// Acquire one payload lease from a daemon-local shared staged-store lock.
+///
+/// The `SharedState` cell owns a process-local reference while one or more
+/// [`StagedMaterializationGuard`] values own delivery leases. The final lease
+/// clears that cell and releases the shared OS lock, so cross-process GC can
+/// acquire its exclusive lock. Reused leases avoid the per-hit open/lock work.
+pub(in crate::daemon::server) fn acquire_staged_materialization_guard_for_state(
+    state: &super::super::SharedState,
+    artifact_dir: &Path,
+) -> io::Result<StagedMaterializationGuard> {
+    acquire_staged_materialization_guard_for_state_from(state, artifact_dir, Instant::now())
+}
+
+#[cfg(test)]
 pub(in crate::daemon::server) fn acquire_staged_materialization_guard_for_cached_path(
     artifact_dir: &Path,
 ) -> io::Result<StagedMaterializationGuard> {
@@ -166,7 +324,9 @@ mod tests {
     #[test]
     fn a_key_without_a_staged_pointer_acquires_no_guard() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(staged_root(dir.path())).unwrap();
+        let root = staged_root(dir.path());
+        std::fs::create_dir_all(&root).unwrap();
+        reset_test_shared_lock_acquisitions(&root);
 
         let guard =
             acquire_staged_materialization_guard_if_present(dir.path(), &"a".repeat(64)).unwrap();
@@ -176,5 +336,6 @@ mod tests {
             "no staged pointer means no lock is taken; callers resolve with \
              staged lookup disabled for that attempt"
         );
+        assert_eq!(test_shared_lock_acquisition_count(&root), 0);
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/read_guard.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/read_guard.rs
@@ -252,8 +252,9 @@ fn acquire_staged_materialization_guard_for_state_from(
     if let Some(store_lock) = held.upgrade() {
         return Ok(StagedMaterializationGuard {
             _store_lock: store_lock,
-            // Reusing the daemon-local lease performs no filesystem work.
-            wait_ns: 0,
+            // Reuse avoids an OS lock syscall, but pointer validation and the
+            // daemon-local mutex are still part of guard-acquisition time.
+            wait_ns: wait_started.elapsed().as_nanos().min(u64::MAX as u128) as u64,
             acquired_at: Instant::now(),
         });
     }
@@ -276,10 +277,10 @@ fn acquire_staged_materialization_guard_for_state_from(
 
 /// Acquire one payload lease from a daemon-local shared staged-store lock.
 ///
-/// The `SharedState` cell owns a process-local reference while one or more
-/// [`StagedMaterializationGuard`] values own delivery leases. The final lease
-/// clears that cell and releases the shared OS lock, so cross-process GC can
-/// acquire its exclusive lock. Reused leases avoid the per-hit open/lock work.
+/// The `SharedState` cell holds a weak reference while one or more payload
+/// leases own the shared OS lock. When the final lease drops, the file handle
+/// closes and cross-process GC can acquire its exclusive lock. Reused leases
+/// avoid redundant open/lock syscalls.
 pub(in crate::daemon::server) fn acquire_staged_materialization_guard_for_state(
     state: &super::super::SharedState,
     artifact_dir: &Path,

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/read_guard.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/read_guard.rs
@@ -136,28 +136,9 @@ pub(in crate::daemon::server) struct StagedMaterializationLock {
 /// guard in the typed materialization payload prevents a generation from
 /// disappearing between resolution and the final reflink/hardlink/copy.
 pub(in crate::daemon::server) struct StagedMaterializationGuard {
-    store_lock: Arc<StagedMaterializationLock>,
-    state_lock: Option<Arc<std::sync::Mutex<Option<Arc<StagedMaterializationLock>>>>>,
+    _store_lock: Arc<StagedMaterializationLock>,
     wait_ns: u64,
     acquired_at: Instant,
-}
-
-impl Drop for StagedMaterializationGuard {
-    fn drop(&mut self) {
-        let Some(state_lock) = self.state_lock.as_ref() else {
-            return;
-        };
-        let mut held = state_lock
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if held
-            .as_ref()
-            .is_some_and(|active| Arc::ptr_eq(active, &self.store_lock))
-            && Arc::strong_count(&self.store_lock) == 2
-        {
-            *held = None;
-        }
-    }
 }
 
 impl StagedMaterializationGuard {
@@ -198,10 +179,9 @@ fn acquire_staged_materialization_guard_from(
     record_test_shared_lock_acquisition(&root);
     let wait_ns = wait_started.elapsed().as_nanos().min(u64::MAX as u128) as u64;
     Ok(StagedMaterializationGuard {
-        store_lock: Arc::new(StagedMaterializationLock {
+        _store_lock: Arc::new(StagedMaterializationLock {
             _store_lock: store_lock,
         }),
-        state_lock: None,
         wait_ns,
         acquired_at: Instant::now(),
     })
@@ -269,10 +249,9 @@ fn acquire_staged_materialization_guard_for_state_from(
         .staged_materialization_lock
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if let Some(store_lock) = held.as_ref() {
+    if let Some(store_lock) = held.upgrade() {
         return Ok(StagedMaterializationGuard {
-            store_lock: Arc::clone(store_lock),
-            state_lock: Some(Arc::clone(&state.staged_materialization_lock)),
+            _store_lock: store_lock,
             // Reusing the daemon-local lease performs no filesystem work.
             wait_ns: 0,
             acquired_at: Instant::now(),
@@ -287,10 +266,9 @@ fn acquire_staged_materialization_guard_for_state_from(
     let store_lock = Arc::new(StagedMaterializationLock {
         _store_lock: store_lock,
     });
-    *held = Some(Arc::clone(&store_lock));
+    *held = Arc::downgrade(&store_lock);
     Ok(StagedMaterializationGuard {
-        store_lock,
-        state_lock: Some(Arc::clone(&state.staged_materialization_lock)),
+        _store_lock: store_lock,
         wait_ns: wait_started.elapsed().as_nanos().min(u64::MAX as u128) as u64,
         acquired_at: Instant::now(),
     })

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -436,6 +436,10 @@ pub(super) struct SharedState {
     /// Shared by publishers and exclusively owned by maintenance/Clear from
     /// cache-file mutation through index/live-map mutation.
     pub(super) artifact_publication: Arc<tokio::sync::RwLock<()>>,
+    /// Reuses one shared OS staged-store lock for all active staged deliveries
+    /// in this daemon and cache root. The final lease drop releases it, letting
+    /// cross-process maintenance acquire the exclusive lock.
+    pub(super) staged_materialization_lock: Arc<StdMutex<Option<Arc<StagedMaterializationLock>>>>,
     /// Limits concurrent disk persistence tasks to prevent memory pileup
     /// when disk I/O is slow and compilation requests are fast.
     pub(super) persist_semaphore: Arc<tokio::sync::Semaphore>,

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -439,7 +439,8 @@ pub(super) struct SharedState {
     /// Reuses one shared OS staged-store lock for all active staged deliveries
     /// in this daemon and cache root. The final lease drop releases it, letting
     /// cross-process maintenance acquire the exclusive lock.
-    pub(super) staged_materialization_lock: Arc<StdMutex<Option<Arc<StagedMaterializationLock>>>>,
+    pub(super) staged_materialization_lock:
+        Arc<StdMutex<std::sync::Weak<StagedMaterializationLock>>>,
     /// Limits concurrent disk persistence tasks to prevent memory pileup
     /// when disk I/O is slow and compilation requests are fast.
     pub(super) persist_semaphore: Arc<tokio::sync::Semaphore>,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,20 @@
+# #1215 staged materialization lock contention
+
+Issue: https://github.com/zackees/zccache/issues/1215 — `perf(persist): bound staged materialization lock contention before GC hardening`
+
+- [x] Read the issue, PERF.md, prior #1215 PRs, staged-store ownership code, and retained evidence.
+- [x] RED: add a deterministic regression/performance test proving concurrent staged deliveries share one process-local OS read lease while preserving maintenance exclusion.
+- [x] GREEN: retain one shared staged-store file lock per active daemon/root, releasing it only after the final materialization lease.
+- [ ] Verify the complete staged delivery matrix, formatter, clippy/check, integration tests, and the sanctioned repeat-5 Docker matrix (or document a concrete infrastructure blocker).
+- [ ] Self-review the final diff for correctness, lock lifetime, cross-process GC behavior, and scope.
+- [ ] Commit, push, open and merge the #1215 PR; synchronize local `main`, delete this branch, and verify a clean checkout.
+
+## Review
+
+- Focused RED signal: `concurrent_staged_materialization_leases_share_the_store_lock` failed with eight OS shared-lock acquisitions before the state-aware lease implementation, then passed after it.
+- Production behavior: all five daemon hit delivery entry points now acquire a `SharedState`-owned staged lease; direct test helpers retain an independent acquisition path only under `cfg(test)`.
+- Pending full validation and review.
+
 # soldr#2031 running-process boundary
 
 - [x] Inventory raw daemon process creation and existing Dylint exemptions.


### PR DESCRIPTION
## Summary
- Reuse a SharedState-owned staged-store OS lock for concurrent staged cache-hit deliveries.
- Retain the shared lease until the final materialization payload completes, preserving exclusive maintenance exclusion.
- Add deterministic eight-delivery coverage that asserts one OS-lock acquisition and blocks maintenance until release.

## Validation
- soldr cargo fmt --all
- soldr --no-cache cargo test -p zccache-daemon-core --features test-support,daemon-entry --lib daemon::server::cached_artifact::tests::concurrent_staged_materialization_leases_share_the_store_lock -- --exact
- uv run --no-project ci/perf_local.py --matrix --repeat 5 (in progress; required before merge)

Closes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)