### PR TITLE
fix(staging): allow a separate private output root

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,13 @@ remain supported through the 1.13.x release line and will not be considered for
 removal before 1.14. Legacy v1 and pack entries remain readable while staging
 is disabled.
 
+Private compiler outputs normally live below `{cache_root}/staging`. Set
+`ZCCACHE_STAGING_DIR` to choose a shorter base (for example, for a Windows
+linker); zccache creates and cleans only its `zccache-staging` child there.
+Durable artifacts remain in the configured cache and staged publication stays
+enabled. Embedded hosts can set `ZccacheStartOptions::staging_root` through
+`ZccacheService::start_with_options`.
+
 #### Safe filesystem materialization
 
 Cache-hit delivery is capability driven. zccache probes the actual source and

--- a/crates/zccache-core/src/config/mod.rs
+++ b/crates/zccache-core/src/config/mod.rs
@@ -21,6 +21,12 @@ use super::NormalizedPath;
 /// Environment variable used to override the zccache cache root.
 pub const CACHE_DIR_ENV: &str = "ZCCACHE_CACHE_DIR";
 
+/// Optional parent directory for daemon-private compiler staging.
+///
+/// Keeping this separate from [`CACHE_DIR_ENV`] lets hosts shorten paths
+/// passed to external tools without relocating the durable artifact store.
+pub const STAGING_DIR_ENV: &str = "ZCCACHE_STAGING_DIR";
+
 /// Environment variable used to select a daemon/socket namespace.
 ///
 /// The default daemon identity remains unchanged when this is unset or empty.
@@ -117,8 +123,9 @@ pub use resolve::{
     daemon_state_dir_from_cache_dir_with_namespace, default_cache_dir,
     effective_cache_root_from_top_level, is_version_dir_name, prune_stale_version_dirs,
     prune_stale_version_dirs_in, read_last_version_marker, resolve_cache_root,
-    resolve_cache_root_top_level, versioned_subdir, write_last_version_marker,
-    write_last_version_marker_in, CacheRootSource, PruneReport, LAST_VERSION_MARKER,
+    resolve_cache_root_top_level, staging_dir_override, versioned_subdir,
+    write_last_version_marker, write_last_version_marker_in, CacheRootSource, PruneReport,
+    LAST_VERSION_MARKER,
 };
 
 /// Top-level configuration for zccache.

--- a/crates/zccache-core/src/config/resolve.rs
+++ b/crates/zccache-core/src/config/resolve.rs
@@ -7,7 +7,9 @@
 //! the per-daemon-version subdir layout (issues #761 / #762 Phase 0).
 
 use super::namespace::home_dir_short_hash;
-use super::{CACHE_DIR_ENV, COLOCATE_ENV, DAEMON_NAMESPACE_ENV, DAEMON_STATE_DIR_ENV};
+use super::{
+    CACHE_DIR_ENV, COLOCATE_ENV, DAEMON_NAMESPACE_ENV, DAEMON_STATE_DIR_ENV, STAGING_DIR_ENV,
+};
 use crate::NormalizedPath;
 use std::ffi::OsString;
 use std::path::Path;
@@ -387,6 +389,18 @@ pub(super) fn sanitize_path_component(s: &str) -> String {
 #[must_use]
 pub fn cache_dir_override() -> Option<NormalizedPath> {
     cache_dir_from_env_value(std::env::var_os(CACHE_DIR_ENV))
+}
+
+/// Returns the base for zccache-owned private compiler staging from
+/// `ZCCACHE_STAGING_DIR`, if set.
+///
+/// The daemon creates and cleans only its `zccache-staging` child beneath
+/// this base. The durable cache root remains unchanged. Relative paths are
+/// resolved against the daemon's current directory using the same contract
+/// as [`cache_dir_override`].
+#[must_use]
+pub fn staging_dir_override() -> Option<NormalizedPath> {
+    cache_dir_from_env_value(std::env::var_os(STAGING_DIR_ENV))
 }
 
 fn dirs_fallback() -> NormalizedPath {

--- a/crates/zccache-daemon-core/src/daemon/server/embedded.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/embedded.rs
@@ -36,6 +36,7 @@ impl EmbeddedDaemon {
         Self::start_with_maintenance(
             endpoint,
             cache_dir,
+            None,
             runtime_handle,
             maintenance_policy,
             true,
@@ -46,14 +47,16 @@ impl EmbeddedDaemon {
     pub(crate) async fn start_with_maintenance(
         endpoint: String,
         cache_dir: crate::core::NormalizedPath,
+        staging_root: Option<&crate::core::NormalizedPath>,
         runtime_handle: Option<tokio::runtime::Handle>,
         maintenance_policy: MaintenancePolicy,
         automatic_maintenance: bool,
     ) -> Result<Self, crate::ipc::IpcError> {
         let backend_identity = crate::ipc::current_backend_identity(&endpoint)
             .map_err(|err| super::lifecycle::daemon_identity_error(&endpoint, &err))?;
-        let (state, index_writer_rx) = new_shared_state(&endpoint, &cache_dir, backend_identity)
-            .map_err(|error| super::lifecycle::cache_root_error(&cache_dir, &error))?;
+        let (state, index_writer_rx) =
+            new_shared_state(&endpoint, &cache_dir, staging_root, backend_identity)
+                .map_err(|error| super::lifecycle::cache_root_error(&cache_dir, &error))?;
         // Arm the startup depgraph-load gate as early as possible — before
         // this state can serve any compile. The shared `dep_graph_load_complete`
         // flag inits `true` ("assume loaded"); the standalone daemon flips it
@@ -827,6 +830,7 @@ mod flush_ownership_tests {
             crate::ipc::unique_test_endpoint(),
             crate::core::NormalizedPath::new(temp.path()),
             None,
+            None,
             MaintenancePolicy::default(),
             false,
         )
@@ -839,5 +843,62 @@ mod flush_ownership_tests {
         );
         let report = daemon.shutdown().await;
         assert!(report.is_complete());
+    }
+
+    #[tokio::test]
+    async fn concurrent_embedded_daemons_keep_explicit_staging_roots_independent() {
+        let cache_a = tempfile::tempdir().expect("cache a");
+        let cache_b = tempfile::tempdir().expect("cache b");
+        let staging_a = tempfile::tempdir().expect("staging a");
+        let staging_b = tempfile::tempdir().expect("staging b");
+        let cache_a = crate::core::NormalizedPath::new(cache_a.path());
+        let cache_b = crate::core::NormalizedPath::new(cache_b.path());
+        let staging_a = crate::core::NormalizedPath::new(staging_a.path());
+        let staging_b = crate::core::NormalizedPath::new(staging_b.path());
+
+        let start_a = EmbeddedDaemon::start_with_maintenance(
+            crate::ipc::unique_test_endpoint(),
+            cache_a,
+            Some(&staging_a),
+            None,
+            MaintenancePolicy::default(),
+            false,
+        );
+        let start_b = EmbeddedDaemon::start_with_maintenance(
+            crate::ipc::unique_test_endpoint(),
+            cache_b,
+            Some(&staging_b),
+            None,
+            MaintenancePolicy::default(),
+            false,
+        );
+        let (daemon_a, daemon_b) = tokio::join!(start_a, start_b);
+        let daemon_a = daemon_a.expect("embedded daemon a");
+        let daemon_b = daemon_b.expect("embedded daemon b");
+
+        assert!(daemon_a
+            .state
+            .staging
+            .path()
+            .starts_with(staging_a.as_path()));
+        assert!(daemon_b
+            .state
+            .staging
+            .path()
+            .starts_with(staging_b.as_path()));
+        assert!(!daemon_a
+            .state
+            .staging
+            .path()
+            .starts_with(staging_b.as_path()));
+        assert!(!daemon_b
+            .state
+            .staging
+            .path()
+            .starts_with(staging_a.as_path()));
+
+        let (report_a, report_b) = tokio::join!(daemon_a.shutdown(), daemon_b.shutdown());
+        assert!(report_a.is_complete());
+        assert!(report_b.is_complete());
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -25,7 +25,9 @@ impl DaemonServer {
     /// `tests::bind_isolated_server`, which needs no global state at all and
     /// therefore cannot participate in the race.
     pub fn bind(endpoint: &str) -> Result<Self, crate::ipc::IpcError> {
-        Self::bind_with_cache_dir(endpoint, &crate::core::config::default_cache_dir())
+        let cache_dir = crate::core::config::default_cache_dir();
+        let staging_root = crate::core::config::staging_dir_override();
+        Self::bind_with_roots(endpoint, &cache_dir, staging_root.as_ref())
     }
 
     /// Create a new daemon server bound to the given endpoint, rooted at an
@@ -35,11 +37,20 @@ impl DaemonServer {
         endpoint: &str,
         cache_dir: &crate::core::NormalizedPath,
     ) -> Result<Self, crate::ipc::IpcError> {
+        Self::bind_with_roots(endpoint, cache_dir, None)
+    }
+
+    fn bind_with_roots(
+        endpoint: &str,
+        cache_dir: &crate::core::NormalizedPath,
+        staging_root: Option<&crate::core::NormalizedPath>,
+    ) -> Result<Self, crate::ipc::IpcError> {
         let listener = IpcListener::bind(endpoint)?;
         let backend_identity = crate::ipc::current_backend_identity(endpoint)
             .map_err(|err| daemon_identity_error(endpoint, &err))?;
-        let (state, index_writer_rx) = new_shared_state(endpoint, cache_dir, backend_identity)
-            .map_err(|error| cache_root_error(cache_dir, &error))?;
+        let (state, index_writer_rx) =
+            new_shared_state(endpoint, cache_dir, staging_root, backend_identity)
+                .map_err(|error| cache_root_error(cache_dir, &error))?;
 
         Ok(Self {
             listener,
@@ -100,6 +111,7 @@ pub(super) fn depgraph_file_path_for_cache_dir(
 pub(super) fn new_shared_state(
     endpoint: &str,
     cache_dir: &crate::core::NormalizedPath,
+    staging_root: Option<&crate::core::NormalizedPath>,
     backend_identity: running_process::broker::protocol_v2::backend_handle::DaemonProcess,
 ) -> std::io::Result<(
     Arc<SharedState>,
@@ -248,7 +260,11 @@ pub(super) fn new_shared_state(
             stats: StatsCollector::new(),
             profiler: PhaseProfiler::new(),
             artifact_dir,
-            staging: StagingRoot::new(cache_dir.as_path(), instance)?,
+            staging: StagingRoot::new(
+                cache_dir.as_path(),
+                staging_root.map(|path| path.as_path()),
+                instance,
+            )?,
             cache_root_lock,
             metadata_path,
             compiler_hash_cache_path,

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -9,6 +9,7 @@
 use super::*;
 
 const STAGING_LOCK_FILE: &str = ".active.lock";
+const CONFIGURED_STAGING_CHILD: &str = "zccache-staging";
 
 /// Lock file naming the single live writer of a cache root (#1162).
 const CACHE_ROOT_WRITER_LOCK_FILE: &str = ".writer.lock";
@@ -38,7 +39,11 @@ pub(super) struct StagingRoot {
 }
 
 impl StagingRoot {
-    pub(super) fn new(cache_dir: &Path, instance: u64) -> std::io::Result<Self> {
+    pub(super) fn new(
+        cache_dir: &Path,
+        configured_parent: Option<&Path>,
+        instance: u64,
+    ) -> std::io::Result<Self> {
         use fs2::FileExt;
         use std::io::Write;
 
@@ -46,9 +51,10 @@ impl StagingRoot {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_nanos();
-        let path = cache_dir
-            .join("staging")
-            .join(format!("{}-{instance}-{nonce}", std::process::id()));
+        let parent = configured_parent
+            .map(|root| root.join(CONFIGURED_STAGING_CHILD))
+            .unwrap_or_else(|| cache_dir.join("staging"));
+        let path = parent.join(format!("{}-{instance}-{nonce}", std::process::id()));
         std::fs::create_dir_all(&path)?;
         let mut file = std::fs::OpenOptions::new()
             .read(true)
@@ -731,10 +737,63 @@ mod staging_tests {
     }
 
     #[test]
+    fn embedded_host_can_place_private_staging_outside_a_deep_cache_root() {
+        let cache = tempfile::tempdir().unwrap();
+        let staging = tempfile::tempdir().unwrap();
+
+        let root = StagingRoot::new(cache.path(), Some(staging.path()), 7).unwrap();
+
+        assert!(root.path().starts_with(staging.path()));
+        assert!(root
+            .path()
+            .starts_with(staging.path().join(CONFIGURED_STAGING_CHILD)));
+        assert!(!root.path().starts_with(cache.path()));
+        assert!(root.path().join(STAGING_LOCK_FILE).is_file());
+    }
+
+    #[test]
+    fn configured_staging_cleanup_is_bounded_to_the_owned_child() {
+        let cache = tempfile::tempdir().unwrap();
+        let configured = tempfile::tempdir().unwrap();
+        let unrelated = configured.path().join("unrelated-user-data");
+        std::fs::create_dir_all(&unrelated).unwrap();
+        std::fs::write(unrelated.join("keep.txt"), b"keep").unwrap();
+
+        let debris = configured
+            .path()
+            .join(CONFIGURED_STAGING_CHILD)
+            .join("abandoned");
+        std::fs::create_dir_all(&debris).unwrap();
+        std::fs::write(debris.join("orphan.o"), b"orphan").unwrap();
+        backdate(&debris, Duration::from_secs(3600));
+
+        let cleaner = StagingRoot::new(cache.path(), Some(configured.path()), 1).unwrap();
+        assert_eq!(cleaner.cleanup_abandoned().unwrap(), 1);
+        assert!(unrelated.join("keep.txt").is_file());
+        assert!(!debris.exists());
+    }
+
+    #[test]
+    fn explicit_staging_roots_remain_independent_in_one_process() {
+        let cache_a = tempfile::tempdir().unwrap();
+        let cache_b = tempfile::tempdir().unwrap();
+        let staging_a = tempfile::tempdir().unwrap();
+        let staging_b = tempfile::tempdir().unwrap();
+
+        let root_a = StagingRoot::new(cache_a.path(), Some(staging_a.path()), 1).unwrap();
+        let root_b = StagingRoot::new(cache_b.path(), Some(staging_b.path()), 2).unwrap();
+
+        assert!(root_a.path().starts_with(staging_a.path()));
+        assert!(root_b.path().starts_with(staging_b.path()));
+        assert!(!root_a.path().starts_with(staging_b.path()));
+        assert!(!root_b.path().starts_with(staging_a.path()));
+    }
+
+    #[test]
     fn abandoned_cleanup_preserves_live_roots_and_removes_crash_debris() {
         let temp = tempfile::tempdir().unwrap();
-        let live_a = StagingRoot::new(temp.path(), 1).unwrap();
-        let live_b = StagingRoot::new(temp.path(), 2).unwrap();
+        let live_a = StagingRoot::new(temp.path(), None, 1).unwrap();
+        let live_b = StagingRoot::new(temp.path(), None, 2).unwrap();
         std::fs::write(live_b.path().join("active.o"), b"active").unwrap();
 
         let abandoned = temp.path().join("staging").join("abandoned");
@@ -756,7 +815,7 @@ mod staging_tests {
     #[test]
     fn a_staging_root_being_born_survives_a_concurrent_cleaner() {
         let temp = tempfile::tempdir().unwrap();
-        let cleaner = StagingRoot::new(temp.path(), 1).unwrap();
+        let cleaner = StagingRoot::new(temp.path(), None, 1).unwrap();
 
         // Exactly the on-disk state `StagingRoot::new` leaves behind after
         // `create_dir_all` and before it opens `.active.lock`.
@@ -777,7 +836,7 @@ mod staging_tests {
     #[test]
     fn the_cleaner_does_not_create_the_lock_file_it_tests_for() {
         let temp = tempfile::tempdir().unwrap();
-        let cleaner = StagingRoot::new(temp.path(), 1).unwrap();
+        let cleaner = StagingRoot::new(temp.path(), None, 1).unwrap();
         let being_born = temp.path().join("staging").join("999-0-12345");
         std::fs::create_dir_all(&being_born).unwrap();
 
@@ -800,7 +859,7 @@ mod staging_tests {
     #[test]
     fn lockless_debris_is_still_reclaimed_once_it_is_old_enough() {
         let temp = tempfile::tempdir().unwrap();
-        let cleaner = StagingRoot::new(temp.path(), 1).unwrap();
+        let cleaner = StagingRoot::new(temp.path(), None, 1).unwrap();
 
         let debris = temp.path().join("staging").join("dead-0-1");
         std::fs::create_dir_all(&debris).unwrap();
@@ -817,7 +876,7 @@ mod staging_tests {
     #[test]
     fn the_age_gate_is_what_decides_the_lockless_case() {
         let temp = tempfile::tempdir().unwrap();
-        let cleaner = StagingRoot::new(temp.path(), 1).unwrap();
+        let cleaner = StagingRoot::new(temp.path(), None, 1).unwrap();
         let young = temp.path().join("staging").join("young-0-1");
         std::fs::create_dir_all(&young).unwrap();
 
@@ -842,8 +901,8 @@ mod staging_tests {
     #[test]
     fn a_held_lock_still_protects_a_live_root_regardless_of_age() {
         let temp = tempfile::tempdir().unwrap();
-        let cleaner = StagingRoot::new(temp.path(), 1).unwrap();
-        let live = StagingRoot::new(temp.path(), 2).unwrap();
+        let cleaner = StagingRoot::new(temp.path(), None, 1).unwrap();
+        let live = StagingRoot::new(temp.path(), None, 2).unwrap();
         std::fs::write(live.path().join("active.o"), b"active").unwrap();
 
         // Age must never override a held lock: a long-running daemon is old.

--- a/crates/zccache-daemon-core/src/daemon/server/tests/maintenance_schedule.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/maintenance_schedule.rs
@@ -33,7 +33,7 @@ fn test_state(cache_dir: &crate::core::NormalizedPath) -> Arc<SharedState> {
     let endpoint = crate::ipc::unique_test_endpoint();
     let identity = crate::ipc::current_backend_identity(&endpoint).expect("backend identity");
     let (state, _index_writer_rx) =
-        new_shared_state(&endpoint, cache_dir, identity).expect("shared state");
+        new_shared_state(&endpoint, cache_dir, None, identity).expect("shared state");
     state
 }
 

--- a/crates/zccache-daemon-core/src/embedded.rs
+++ b/crates/zccache-daemon-core/src/embedded.rs
@@ -392,6 +392,29 @@ pub enum MaintenanceOwnership {
     Host,
 }
 
+/// Additive startup options for embedded hosts that need non-default storage
+/// or maintenance ownership without expanding [`ZccacheConfig`].
+#[derive(Debug, Clone)]
+pub struct ZccacheStartOptions {
+    pub disk_limits: DiskCacheLimits,
+    pub maintenance_ownership: MaintenanceOwnership,
+    /// Optional base for private compiler outputs.
+    ///
+    /// The service creates and cleans only its own `zccache-staging` child
+    /// beneath this directory. `None` keeps staging under the cache root.
+    pub staging_root: Option<NormalizedPath>,
+}
+
+impl Default for ZccacheStartOptions {
+    fn default() -> Self {
+        Self {
+            disk_limits: DiskCacheLimits::default(),
+            maintenance_ownership: MaintenanceOwnership::Embedded,
+            staging_root: None,
+        }
+    }
+}
+
 /// Pressure tier observed during a disk-maintenance pass.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiskMaintenancePressure {
@@ -454,7 +477,7 @@ impl ZccacheService {
     /// runtime (for tokio-console attach unity, graceful-shutdown signalling,
     /// and related diagnostics).
     pub async fn start(config: ZccacheConfig) -> Result<Self> {
-        Self::start_with_disk_limits(config, DiskCacheLimits::default()).await
+        Self::start_with_options(config, ZccacheStartOptions::default()).await
     }
 
     /// Start an embedded service with an explicit artifact-store budget.
@@ -466,10 +489,12 @@ impl ZccacheService {
         config: ZccacheConfig,
         disk_limits: DiskCacheLimits,
     ) -> Result<Self> {
-        Self::start_with_disk_limits_and_maintenance(
+        Self::start_with_options(
             config,
-            disk_limits,
-            MaintenanceOwnership::Embedded,
+            ZccacheStartOptions {
+                disk_limits,
+                ..ZccacheStartOptions::default()
+            },
         )
         .await
     }
@@ -480,20 +505,40 @@ impl ZccacheService {
         disk_limits: DiskCacheLimits,
         maintenance_ownership: MaintenanceOwnership,
     ) -> Result<Self> {
+        Self::start_with_options(
+            config,
+            ZccacheStartOptions {
+                disk_limits,
+                maintenance_ownership,
+                staging_root: None,
+            },
+        )
+        .await
+    }
+
+    /// Start an embedded service with additive storage and ownership options.
+    ///
+    /// Existing constructors preserve their source-compatible defaults;
+    /// hosts that need a short private compiler-output root use this method.
+    pub async fn start_with_options(
+        config: ZccacheConfig,
+        options: ZccacheStartOptions,
+    ) -> Result<Self> {
         let endpoint = embedded_endpoint(&config.host);
         let cache_root =
             crate::core::config::effective_cache_root_from_top_level(&config.cache_root);
         let maintenance_policy = MaintenancePolicy::from_limits(
-            disk_limits.max_cache_bytes,
-            disk_limits.max_cache_percent,
+            options.disk_limits.max_cache_bytes,
+            options.disk_limits.max_cache_percent,
         )
         .map_err(EmbeddedError::Start)?;
         let daemon = EmbeddedDaemon::start_with_maintenance(
             endpoint,
             cache_root,
+            options.staging_root.as_ref(),
             config.runtime.handle.clone(),
             maintenance_policy,
-            maintenance_ownership == MaintenanceOwnership::Embedded,
+            options.maintenance_ownership == MaintenanceOwnership::Embedded,
         )
         .await
         .map_err(|err| EmbeddedError::Start(err.to_string()))?;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,6 +30,7 @@ failed cache-root audit retain its diagnostic JSONL evidence.
 - **Compile queue visibility, progress-based wedge detection** → [ipc.md § Compile progress heartbeats](architecture/ipc.md#compile-progress-heartbeats-issue-1216)
 - **File change detection** → [metadata-cache.md](architecture/metadata-cache.md)
 - **Disk cache & eviction** → [artifact-store.md](architecture/artifact-store.md)
+- **Private compiler staging root** → [portability.md](architecture/portability.md#path-handling)
 - **Daemon-owned bounded disk retention** → [artifact-store.md](architecture/artifact-store.md#daemon-owned-retention-policy)
 - **Transactional directory outputs** → [artifact-store.md](architecture/artifact-store.md#immutable-staged-output-rollout)
 - **Reflink / hardlink COW safety** → [artifact-store.md](architecture/artifact-store.md#capability-driven-cow-materialization)

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -14,6 +14,7 @@ Architecture docs are split by subsystem. Read only what's relevant to your curr
 | `zccache-watcher` | [metadata-cache.md](architecture/metadata-cache.md) (watcher section) |
 | `zccache-artifact` | [artifact-store.md](architecture/artifact-store.md) |
 | Cross-filesystem COW materialization | [artifact-store.md](architecture/artifact-store.md), [portability.md](architecture/portability.md) |
+| Private compiler staging paths | [artifact-store.md](architecture/artifact-store.md), [portability.md](architecture/portability.md) |
 | Daemon-owned disk retention | [artifact-store.md](architecture/artifact-store.md), [runtime.md](architecture/runtime.md), [embedded-service.md](architecture/embedded-service.md) |
 | `zccache-hash` | [overview.md](architecture/overview.md) (2.8) |
 | `zccache-compiler` | [overview.md](architecture/overview.md) (2.9), [data-flow.md](architecture/data-flow.md) |

--- a/docs/architecture/artifact-store.md
+++ b/docs/architecture/artifact-store.md
@@ -112,6 +112,12 @@ remain mandatory for the narrow semantic allowlist.
 
 Private compiler/linker files normally live under a per-daemon
 `{cache_root}/staging/` directory, outside the clearable artifact store.
+`ZCCACHE_STAGING_DIR` chooses a base beneath which zccache owns the
+`zccache-staging` child; cleanup never scans unrelated siblings in that base.
+The durable artifact store and its cache identity stay under
+`ZCCACHE_CACHE_DIR`. Embedded hosts may instead pass
+`ZccacheStartOptions::staging_root` to `ZccacheService::start_with_options`
+when an external tool cannot consume a deeply nested path.
 Directory producers use a hidden private sibling beside the requested bundle
 to preserve same-filesystem atomic installation. An advisory lock protects
 each live daemon's directory: startup cleanup reclaims only unlocked crash

--- a/docs/architecture/embedded-service.md
+++ b/docs/architecture/embedded-service.md
@@ -139,6 +139,12 @@ pub struct DiskCacheLimits {
     pub max_cache_percent: Option<u8>,
 }
 
+pub struct ZccacheStartOptions {
+    pub disk_limits: DiskCacheLimits,
+    pub maintenance_ownership: MaintenanceOwnership,
+    pub staging_root: Option<NormalizedPath>,
+}
+
 pub enum DiskMaintenanceKind {
     Pressure,
     Full,
@@ -231,6 +237,10 @@ impl ZccacheService {
         disk_limits: DiskCacheLimits,
         maintenance_ownership: MaintenanceOwnership,
     ) -> Result<Self>;
+    pub async fn start_with_options(
+        config: ZccacheConfig,
+        options: ZccacheStartOptions,
+    ) -> Result<Self>;
     pub async fn compile(&self, request: CompileRequest) -> Result<CompileResponse>;
     pub async fn compile_streaming<F>(&self, request: CompileRequest, on_chunk: F) -> Result<()>
     where
@@ -253,7 +263,10 @@ impl ZccacheService {
 `DiskCacheLimits::max_cache_bytes` and `max_cache_percent` are mutually
 exclusive. `start` uses the shared dynamic artifact-store budget;
 `start_with_disk_limits` accepts overrides without adding fields to the
-existing public `ServiceLimits` struct. The budget
+existing public `ServiceLimits` struct. `start_with_options` is the additive
+surface for a host-owned maintenance schedule and a private staging base;
+existing `ZccacheConfig` literals remain source-compatible. zccache owns only
+the `zccache-staging` child beneath an explicit staging base. The budget
 accounts for allocated artifact files and pending writes, not small root-local
 indexes, depgraphs, logs, journals, or daemon metadata. By default the service
 starts its own pressure/full maintenance loop on the host runtime. A host that

--- a/docs/architecture/portability.md
+++ b/docs/architecture/portability.md
@@ -32,6 +32,15 @@ misses rather than being reinterpreted.
 
 ## Path Handling
 
+Private compiler outputs default to `{cache_root}/staging`. Set
+`ZCCACHE_STAGING_DIR` to a shorter base when a platform tool cannot consume
+the cache-root-derived path. zccache creates and cleans only a
+`zccache-staging` child beneath that base. The override does not relocate
+durable artifacts or disable staged publication; each daemon still owns a
+locked child and removes it at shutdown. Embedded services should pass the
+same base explicitly through `ZccacheStartOptions::staging_root` so concurrent
+instances remain independent.
+
 **Canonicalization:** All paths stored in the metadata cache are canonicalized (`std::fs::canonicalize`). This resolves symlinks and relative components, ensuring that `/home/user/./foo.c` and `/home/user/foo.c` map to the same entry.
 
 **Case sensitivity:**

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,12 @@
+# soldr#2188 short compiler staging root
+
+- [x] Read the issue, staged-output architecture, portability contract, and performance gate.
+- [x] RED: prove an embedded host can place private compiler staging outside a deep cache root.
+- [x] GREEN: add an explicit embedded staging root while preserving cache-local staging by default.
+- [x] Document the ownership and cleanup contract.
+- [ ] Run focused tests, formatting, clippy, and the sanctioned performance matrix.
+- [ ] Review, push, merge, and validate the upstream change before updating Soldr.
+
 # #1215 staged materialization lock contention
 
 Issue: https://github.com/zackees/zccache/issues/1215 — `perf(persist): bound staged materialization lock contention before GC hardening`


### PR DESCRIPTION
## Summary
- add source-compatible ZccacheStartOptions for an explicit private compiler-staging base
- keep existing constructors and cache-local staging defaults unchanged
- bound cleanup to a zccache-owned zccache-staging child
- prove concurrent embedded services keep independent staging roots

Supports zackees/soldr#2188 without disabling staged publication.

## Validation
- focused staging suite: 17 passed
- cargo test --workspace --lib -j 2 --features test-support: passed
- cargo clippy --workspace --all-targets --features test-support -j 2 -- -D warnings: passed
- formatter and diff checks: passed
- clud-review: clean
- sanctioned 8-cell matrix: infrastructure valid in all cells, zero aborts/timeouts/no-cache retries/daemon fallbacks; medium cold passed 11.54x, while existing warm/SQLite thresholds failed (same baseline pattern, and this override is inactive on Linux by default)