### PR TITLE
fix(platform): preserve dangling symlink removal

### DIFF
--- a/crates/zccache-platform/src/platform/fs/permissions.rs
+++ b/crates/zccache-platform/src/platform/fs/permissions.rs
@@ -28,7 +28,22 @@ pub fn set_readonly(path: &Path, readonly: bool) -> std::io::Result<()> {
 
 /// Makes `path` writable while preserving every unrelated permission bit.
 pub fn make_writable(path: &Path) -> std::io::Result<()> {
-    platform_imp::fs::permissions::make_writable(path)
+    // A materialization destination can be a dangling link.  Callers remove
+    // that directory entry immediately after this step, so there is no
+    // referent whose permissions could be changed. Treat that specific
+    // entry as writable; an actually absent path remains an error.
+    match platform_imp::fs::permissions::make_writable(path) {
+        Ok(()) => Ok(()),
+        Err(error)
+            if error.kind() == std::io::ErrorKind::NotFound
+                && std::fs::symlink_metadata(path)
+                    .map(|metadata| metadata.file_type().is_symlink())
+                    .unwrap_or(false) =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
 }
 
 /// Makes `path` executable, touching only the executable bits.
@@ -84,5 +99,34 @@ mod tests {
         make_executable(&file).expect("exec");
         let read = fs::read_to_string(&file).expect("read");
         assert_eq!(read, "data");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_symlink_is_removable_without_a_permission_change() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let link = dir.path().join("output");
+        symlink(dir.path().join("missing"), &link).expect("symlink");
+
+        make_writable(&link).expect("dangling symlink is removable");
+        fs::remove_file(link).expect("remove dangling symlink");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn valid_symlink_makes_its_referent_writable() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("target");
+        let link = dir.path().join("output");
+        fs::write(&target, b"data").expect("write");
+        set_readonly(&target, true).expect("readonly target");
+        symlink(&target, &link).expect("symlink");
+
+        make_writable(&link).expect("make referent writable");
+        assert!(!fs::metadata(target).expect("target metadata").permissions().readonly());
     }
 }


### PR DESCRIPTION
Fixes the Phase 2 filesystem regression where replacing a dangling output symlink failed before materialization.

platform::fs::permissions::make_writable now treats only a confirmed dangling symlink as removable, while preserving valid-symlink permission updates and the normal no-extra-syscall path.

Validation:
- soldr --no-cache cargo test -p zccache-platform
- Linux test-target check with RUSTFLAGS=-D warnings
- soldr --no-cache cargo clippy -p zccache-platform --all-targets -- -D warnings
- soldr --no-cache cargo fmt --all -- --check
- Pre-push review: clean