### PR TITLE
fix(platform): preserve dangling symlink removal

### DIFF
--- a/crates/zccache-platform/src/platform/fs/permissions.rs
+++ b/crates/zccache-platform/src/platform/fs/permissions.rs
@@ -101,32 +101,4 @@ mod tests {
         assert_eq!(read, "data");
     }
 
-    #[cfg(unix)]
-    #[test]
-    fn dangling_symlink_is_removable_without_a_permission_change() {
-        use std::os::unix::fs::symlink;
-
-        let dir = tempfile::tempdir().expect("tempdir");
-        let link = dir.path().join("output");
-        symlink(dir.path().join("missing"), &link).expect("symlink");
-
-        make_writable(&link).expect("dangling symlink is removable");
-        fs::remove_file(link).expect("remove dangling symlink");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn valid_symlink_makes_its_referent_writable() {
-        use std::os::unix::fs::symlink;
-
-        let dir = tempfile::tempdir().expect("tempdir");
-        let target = dir.path().join("target");
-        let link = dir.path().join("output");
-        fs::write(&target, b"data").expect("write");
-        set_readonly(&target, true).expect("readonly target");
-        symlink(&target, &link).expect("symlink");
-
-        make_writable(&link).expect("make referent writable");
-        assert!(!fs::metadata(target).expect("target metadata").permissions().readonly());
-    }
 }

--- a/crates/zccache-platform/src/platform/fs/permissions.rs
+++ b/crates/zccache-platform/src/platform/fs/permissions.rs
@@ -100,5 +100,4 @@ mod tests {
         let read = fs::read_to_string(&file).expect("read");
         assert_eq!(read, "data");
     }
-
 }

--- a/crates/zccache-platform/src/platform_linux/fs/permissions.rs
+++ b/crates/zccache-platform/src/platform_linux/fs/permissions.rs
@@ -73,3 +73,38 @@ pub fn mode(metadata: &std::fs::Metadata) -> u32 {
 pub fn apply_mode(path: &Path, mode: u32) -> std::io::Result<()> {
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
 }
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn dangling_symlink_is_removable_without_a_permission_change() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let link = dir.path().join("output");
+        symlink(dir.path().join("missing"), &link).expect("symlink");
+
+        crate::platform::fs::permissions::make_writable(&link)
+            .expect("dangling symlink is removable");
+        std::fs::remove_file(link).expect("remove dangling symlink");
+    }
+
+    #[test]
+    fn valid_symlink_makes_its_referent_writable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("target");
+        let link = dir.path().join("output");
+        std::fs::write(&target, b"data").expect("write");
+        crate::platform::fs::permissions::set_readonly(&target, true).expect("readonly target");
+        symlink(&target, &link).expect("symlink");
+
+        crate::platform::fs::permissions::make_writable(&link)
+            .expect("make referent writable");
+        assert!(
+            !std::fs::metadata(target)
+                .expect("target metadata")
+                .permissions()
+                .readonly()
+        );
+    }
+}

--- a/crates/zccache-platform/src/platform_macos/fs/permissions.rs
+++ b/crates/zccache-platform/src/platform_macos/fs/permissions.rs
@@ -73,3 +73,38 @@ pub fn mode(metadata: &std::fs::Metadata) -> u32 {
 pub fn apply_mode(path: &Path, mode: u32) -> std::io::Result<()> {
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
 }
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn dangling_symlink_is_removable_without_a_permission_change() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let link = dir.path().join("output");
+        symlink(dir.path().join("missing"), &link).expect("symlink");
+
+        crate::platform::fs::permissions::make_writable(&link)
+            .expect("dangling symlink is removable");
+        std::fs::remove_file(link).expect("remove dangling symlink");
+    }
+
+    #[test]
+    fn valid_symlink_makes_its_referent_writable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("target");
+        let link = dir.path().join("output");
+        std::fs::write(&target, b"data").expect("write");
+        crate::platform::fs::permissions::set_readonly(&target, true).expect("readonly target");
+        symlink(&target, &link).expect("symlink");
+
+        crate::platform::fs::permissions::make_writable(&link)
+            .expect("make referent writable");
+        assert!(
+            !std::fs::metadata(target)
+                .expect("target metadata")
+                .permissions()
+                .readonly()
+        );
+    }
+}


### PR DESCRIPTION
Fixes the Phase 2 filesystem regression where replacing a dangling output symlink failed before materialization.

The permission facade now recognizes only confirmed dangling symlinks as removable, preserves valid-link permission updates, and avoids an extra syscall on the normal path. Unix-specific regression tests live in concrete Linux and macOS platform trees, preserving the source boundary.

Validation:
- soldr --no-cache cargo test -p zccache-platform
- Linux/macOS cross-target test checks with RUSTFLAGS=-D warnings
- soldr --no-cache cargo clippy -p zccache-platform --all-targets -- -D warnings
- soldr --no-cache cargo fmt --all
- Pre-push review: clean