### PR TITLE
refactor(platform): checkpoint process facade

### DIFF
--- a/crates/zccache-platform/src/platform/process.rs
+++ b/crates/zccache-platform/src/platform/process.rs
@@ -1,7 +1,0 @@
-//! Neutral process mechanics: spawn/detach, containment, priority, PID
-//! liveness, executable-image lookup, CPU probes, stdio detach, exit/signal
-//! interpretation, and jobserver pipes.
-//!
-//! Policy — compile-priority decisions, watchdog budgets, retry/escalation,
-//! lifecycle wording, and which program to launch — stays with the callers.
-//! Populated in the process phase (#1369); empty index until then.

--- a/crates/zccache-platform/src/platform/process/README.md
+++ b/crates/zccache-platform/src/platform/process/README.md
@@ -1,0 +1,9 @@
+# Process facade
+
+Neutral, statically dispatched host-process mechanics. Product decisions such
+as compile priority selection, watchdog budgets, daemon identity, logging, and
+diagnostic wording remain in their owning crates.
+
+Leaves cover command preparation, spawning, priority, inspection,
+termination, standard-I/O detachment, native jobserver primitives, and native
+exit/crash interpretation.

--- a/crates/zccache-platform/src/platform/process/command.rs
+++ b/crates/zccache-platform/src/platform/process/command.rs
@@ -1,0 +1,1 @@
+//! Prepared-command native configuration.

--- a/crates/zccache-platform/src/platform/process/exit.rs
+++ b/crates/zccache-platform/src/platform/process/exit.rs
@@ -1,0 +1,9 @@
+//! Native exit and crash interpretation.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NativeExit { Success }
+
+#[must_use]
+pub fn crash_label(exit: NativeExit) -> &'static str {
+    match exit { NativeExit::Success => "success" }
+}

--- a/crates/zccache-platform/src/platform/process/inspect.rs
+++ b/crates/zccache-platform/src/platform/process/inspect.rs
@@ -1,0 +1,12 @@
+//! Process liveness, image-path, and CPU-tick inspection.
+
+use crate::platform_imp;
+
+#[must_use]
+pub fn is_alive(pid: u32) -> bool { platform_imp::process::inspect::is_alive(pid) }
+
+pub fn executable_path(pid: u32) -> Option<std::path::PathBuf> {
+    platform_imp::process::inspect::executable_path(pid)
+}
+
+pub fn cpu_ticks(pid: u32) -> Option<u64> { platform_imp::process::inspect::cpu_ticks(pid) }

--- a/crates/zccache-platform/src/platform/process/jobserver.rs
+++ b/crates/zccache-platform/src/platform/process/jobserver.rs
@@ -1,0 +1,4 @@
+//! Native jobserver primitives.
+
+#[must_use]
+pub fn is_supported() -> bool { crate::platform_imp::process::jobserver::is_supported() }

--- a/crates/zccache-platform/src/platform/process/mod.rs
+++ b/crates/zccache-platform/src/platform/process/mod.rs
@@ -1,0 +1,13 @@
+//! Neutral process-mechanics facade.
+
+#[cfg(test)]
+mod tests;
+
+pub mod command;
+pub mod exit;
+pub mod inspect;
+pub mod jobserver;
+pub mod priority;
+pub mod spawn;
+pub mod stdio;
+pub mod terminate;

--- a/crates/zccache-platform/src/platform/process/priority.rs
+++ b/crates/zccache-platform/src/platform/process/priority.rs
@@ -1,0 +1,9 @@
+//! Neutral priority classes and native application.
+
+/// Host-neutral scheduling priority ordered from normal to most deprioritized.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum Priority {
+    Normal,
+    Low,
+    Idle,
+}

--- a/crates/zccache-platform/src/platform/process/spawn.rs
+++ b/crates/zccache-platform/src/platform/process/spawn.rs
@@ -1,0 +1,7 @@
+//! Native spawn and ownership mechanics.
+
+/// Spawn a disposable sleeping child. Used by cross-platform characterization
+/// tests; callers own and must reap the returned child.
+pub fn sleeping_child(duration: std::time::Duration) -> std::io::Result<std::process::Child> {
+    crate::platform_imp::process::spawn::sleeping_child(duration)
+}

--- a/crates/zccache-platform/src/platform/process/stdio.rs
+++ b/crates/zccache-platform/src/platform/process/stdio.rs
@@ -1,0 +1,1 @@
+//! Native standard-I/O detachment.

--- a/crates/zccache-platform/src/platform/process/terminate.rs
+++ b/crates/zccache-platform/src/platform/process/terminate.rs
@@ -1,0 +1,5 @@
+//! Native process termination.
+
+pub fn force(pid: u32) -> std::io::Result<()> {
+    crate::platform_imp::process::terminate::force(pid)
+}

--- a/crates/zccache-platform/src/platform/process/tests.rs
+++ b/crates/zccache-platform/src/platform/process/tests.rs
@@ -1,0 +1,43 @@
+use std::time::Duration;
+
+use super::{exit, inspect, jobserver, priority::Priority, spawn, terminate};
+
+#[test]
+fn neutral_priorities_are_distinct_and_ordered() {
+    assert!(Priority::Normal < Priority::Low);
+    assert!(Priority::Low < Priority::Idle);
+}
+
+#[test]
+fn current_process_is_live_and_has_an_executable() {
+    let pid = std::process::id();
+    assert!(inspect::is_alive(pid));
+    let executable = inspect::executable_path(pid).expect("current executable path");
+    assert!(executable.is_absolute());
+}
+
+#[test]
+fn owned_child_can_be_observed_and_terminated() {
+    let mut child = spawn::sleeping_child(Duration::from_secs(30)).expect("spawn child");
+    let pid = child.id();
+    assert!(inspect::is_alive(pid));
+    terminate::force(pid).expect("terminate owned child");
+    child.wait().expect("reap child");
+    assert!(!inspect::is_alive(pid));
+}
+
+#[test]
+fn child_cpu_ticks_are_nondecreasing() {
+    let mut child = spawn::sleeping_child(Duration::from_secs(30)).expect("spawn child");
+    let first = inspect::cpu_ticks(child.id()).expect("first CPU reading");
+    let second = inspect::cpu_ticks(child.id()).expect("second CPU reading");
+    assert!(second >= first);
+    child.kill().expect("kill child");
+    child.wait().expect("reap child");
+}
+
+#[test]
+fn native_capabilities_have_stable_labels() {
+    assert!(!exit::crash_label(exit::NativeExit::Success).is_empty());
+    assert_eq!(jobserver::is_supported(), !cfg!(windows));
+}

--- a/crates/zccache-platform/src/platform_linux.rs
+++ b/crates/zccache-platform/src/platform_linux.rs
@@ -7,3 +7,4 @@
 
 pub mod fs;
 pub mod ipc;
+pub mod process;

--- a/crates/zccache-platform/src/platform_linux/process/README.md
+++ b/crates/zccache-platform/src/platform_linux/process/README.md
@@ -1,0 +1,4 @@
+# Linux process mechanics
+
+Private Linux implementations for process spawn, inspection, termination,
+priority, stdio, jobserver, command setup, and exit interpretation.

--- a/crates/zccache-platform/src/platform_linux/process/command.rs
+++ b/crates/zccache-platform/src/platform_linux/process/command.rs
@@ -1,0 +1,1 @@
+//! Linux command setup.

--- a/crates/zccache-platform/src/platform_linux/process/exit.rs
+++ b/crates/zccache-platform/src/platform_linux/process/exit.rs
@@ -1,0 +1,1 @@
+//! Linux exit interpretation.

--- a/crates/zccache-platform/src/platform_linux/process/inspect.rs
+++ b/crates/zccache-platform/src/platform_linux/process/inspect.rs
@@ -1,0 +1,11 @@
+pub fn is_alive(pid: u32) -> bool {
+    i32::try_from(pid).is_ok_and(|pid| unsafe { libc::kill(pid, 0) == 0 })
+}
+pub fn executable_path(pid: u32) -> Option<std::path::PathBuf> {
+    std::fs::read_link(format!("/proc/{pid}/exe")).ok()
+}
+pub fn cpu_ticks(pid: u32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let fields: Vec<&str> = stat.rsplit_once(')')?.1.split_whitespace().collect();
+    Some(fields.get(11)?.parse::<u64>().ok()?.wrapping_add(fields.get(12)?.parse::<u64>().ok()?))
+}

--- a/crates/zccache-platform/src/platform_linux/process/jobserver.rs
+++ b/crates/zccache-platform/src/platform_linux/process/jobserver.rs
@@ -1,0 +1,1 @@
+pub fn is_supported() -> bool { true }

--- a/crates/zccache-platform/src/platform_linux/process/mod.rs
+++ b/crates/zccache-platform/src/platform_linux/process/mod.rs
@@ -1,0 +1,8 @@
+pub mod command;
+pub mod exit;
+pub mod inspect;
+pub mod jobserver;
+pub mod priority;
+pub mod spawn;
+pub mod stdio;
+pub mod terminate;

--- a/crates/zccache-platform/src/platform_linux/process/priority.rs
+++ b/crates/zccache-platform/src/platform_linux/process/priority.rs
@@ -1,0 +1,1 @@
+//! Linux scheduling priority.

--- a/crates/zccache-platform/src/platform_linux/process/spawn.rs
+++ b/crates/zccache-platform/src/platform_linux/process/spawn.rs
@@ -1,0 +1,6 @@
+use std::process::{Child, Command};
+use std::time::Duration;
+
+pub fn sleeping_child(duration: Duration) -> std::io::Result<Child> {
+    Command::new("sleep").arg(duration.as_secs().max(1).to_string()).spawn()
+}

--- a/crates/zccache-platform/src/platform_linux/process/stdio.rs
+++ b/crates/zccache-platform/src/platform_linux/process/stdio.rs
@@ -1,0 +1,1 @@
+//! Linux standard-I/O mechanics.

--- a/crates/zccache-platform/src/platform_linux/process/terminate.rs
+++ b/crates/zccache-platform/src/platform_linux/process/terminate.rs
@@ -1,0 +1,5 @@
+pub fn force(pid: u32) -> std::io::Result<()> {
+    let pid = i32::try_from(pid).map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "PID exceeds i32"))?;
+    // SAFETY: fixed signal and scalar PID; no pointers are involved.
+    if unsafe { libc::kill(pid, libc::SIGKILL) } == 0 { Ok(()) } else { Err(std::io::Error::last_os_error()) }
+}

--- a/crates/zccache-platform/src/platform_macos.rs
+++ b/crates/zccache-platform/src/platform_macos.rs
@@ -7,3 +7,4 @@
 
 pub mod fs;
 pub mod ipc;
+pub mod process;

--- a/crates/zccache-platform/src/platform_macos/process/README.md
+++ b/crates/zccache-platform/src/platform_macos/process/README.md
@@ -1,0 +1,4 @@
+# macOS process mechanics
+
+Private macOS implementations for process spawn, inspection, termination,
+priority, stdio, jobserver, command setup, and exit interpretation.

--- a/crates/zccache-platform/src/platform_macos/process/command.rs
+++ b/crates/zccache-platform/src/platform_macos/process/command.rs
@@ -1,0 +1,1 @@
+//! macOS command setup.

--- a/crates/zccache-platform/src/platform_macos/process/exit.rs
+++ b/crates/zccache-platform/src/platform_macos/process/exit.rs
@@ -1,0 +1,1 @@
+//! macOS exit interpretation.

--- a/crates/zccache-platform/src/platform_macos/process/inspect.rs
+++ b/crates/zccache-platform/src/platform_macos/process/inspect.rs
@@ -1,0 +1,21 @@
+pub fn is_alive(pid: u32) -> bool {
+    i32::try_from(pid).is_ok_and(|pid| unsafe { libc::kill(pid, 0) == 0 })
+}
+pub fn executable_path(pid: u32) -> Option<std::path::PathBuf> {
+    const MAX: usize = 4096;
+    let mut buffer = vec![0u8; MAX];
+    let pid = i32::try_from(pid).ok()?;
+    unsafe extern "C" { fn proc_pidpath(pid: i32, buffer: *mut std::ffi::c_void, size: u32) -> i32; }
+    // SAFETY: buffer is writable for the supplied size and PID is scalar.
+    let written = unsafe { proc_pidpath(pid, buffer.as_mut_ptr().cast(), MAX as u32) };
+    if written <= 0 { return None; }
+    buffer.truncate(written as usize);
+    Some(std::path::PathBuf::from(std::str::from_utf8(&buffer).ok()?))
+}
+pub fn cpu_ticks(pid: u32) -> Option<u64> {
+    let pid = i32::try_from(pid).ok()?;
+    // SAFETY: zeroed POD filled by proc_pid_rusage for the matching flavor.
+    let mut info: libc::rusage_info_v2 = unsafe { std::mem::zeroed() };
+    let result = unsafe { libc::proc_pid_rusage(pid, libc::RUSAGE_INFO_V2, std::ptr::from_mut(&mut info).cast()) };
+    (result == 0).then(|| info.ri_user_time.wrapping_add(info.ri_system_time))
+}

--- a/crates/zccache-platform/src/platform_macos/process/jobserver.rs
+++ b/crates/zccache-platform/src/platform_macos/process/jobserver.rs
@@ -1,0 +1,1 @@
+pub fn is_supported() -> bool { true }

--- a/crates/zccache-platform/src/platform_macos/process/mod.rs
+++ b/crates/zccache-platform/src/platform_macos/process/mod.rs
@@ -1,0 +1,8 @@
+pub mod command;
+pub mod exit;
+pub mod inspect;
+pub mod jobserver;
+pub mod priority;
+pub mod spawn;
+pub mod stdio;
+pub mod terminate;

--- a/crates/zccache-platform/src/platform_macos/process/priority.rs
+++ b/crates/zccache-platform/src/platform_macos/process/priority.rs
@@ -1,0 +1,1 @@
+//! macOS scheduling priority.

--- a/crates/zccache-platform/src/platform_macos/process/spawn.rs
+++ b/crates/zccache-platform/src/platform_macos/process/spawn.rs
@@ -1,0 +1,5 @@
+use std::process::{Child, Command};
+use std::time::Duration;
+pub fn sleeping_child(duration: Duration) -> std::io::Result<Child> {
+    Command::new("sleep").arg(duration.as_secs().max(1).to_string()).spawn()
+}

--- a/crates/zccache-platform/src/platform_macos/process/stdio.rs
+++ b/crates/zccache-platform/src/platform_macos/process/stdio.rs
@@ -1,0 +1,1 @@
+//! macOS standard-I/O mechanics.

--- a/crates/zccache-platform/src/platform_macos/process/terminate.rs
+++ b/crates/zccache-platform/src/platform_macos/process/terminate.rs
@@ -1,0 +1,5 @@
+pub fn force(pid: u32) -> std::io::Result<()> {
+    let pid = i32::try_from(pid).map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "PID exceeds i32"))?;
+    // SAFETY: fixed signal and scalar PID; no pointers are involved.
+    if unsafe { libc::kill(pid, libc::SIGKILL) } == 0 { Ok(()) } else { Err(std::io::Error::last_os_error()) }
+}

--- a/crates/zccache-platform/src/platform_win.rs
+++ b/crates/zccache-platform/src/platform_win.rs
@@ -6,3 +6,4 @@
 
 pub mod fs;
 pub mod ipc;
+pub mod process;

--- a/crates/zccache-platform/src/platform_win/process/README.md
+++ b/crates/zccache-platform/src/platform_win/process/README.md
@@ -1,0 +1,4 @@
+# Windows process mechanics
+
+Private Windows implementations for process spawn, inspection, termination,
+priority, stdio, jobserver, command setup, and exit interpretation.

--- a/crates/zccache-platform/src/platform_win/process/command.rs
+++ b/crates/zccache-platform/src/platform_win/process/command.rs
@@ -1,0 +1,1 @@
+//! Windows command setup.

--- a/crates/zccache-platform/src/platform_win/process/exit.rs
+++ b/crates/zccache-platform/src/platform_win/process/exit.rs
@@ -1,0 +1,1 @@
+//! Windows exit interpretation.

--- a/crates/zccache-platform/src/platform_win/process/inspect.rs
+++ b/crates/zccache-platform/src/platform_win/process/inspect.rs
@@ -1,0 +1,52 @@
+use std::os::windows::ffi::OsStringExt;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct FileTime { low: u32, high: u32 }
+
+#[link(name = "kernel32")]
+unsafe extern "system" {
+    fn OpenProcess(access: u32, inherit: i32, pid: u32) -> isize;
+    fn CloseHandle(handle: isize) -> i32;
+    fn WaitForSingleObject(handle: isize, milliseconds: u32) -> u32;
+    fn QueryFullProcessImageNameW(handle: isize, flags: u32, buffer: *mut u16, size: *mut u32) -> i32;
+    fn GetProcessTimes(handle: isize, creation: *mut FileTime, exit: *mut FileTime, kernel: *mut FileTime, user: *mut FileTime) -> i32;
+}
+const QUERY: u32 = 0x1000;
+const SYNCHRONIZE: u32 = 0x0010_0000;
+
+pub fn is_alive(pid: u32) -> bool {
+    // SAFETY: handle is checked and closed exactly once.
+    unsafe {
+        let handle = OpenProcess(QUERY | SYNCHRONIZE, 0, pid);
+        if handle == 0 { return false; }
+        let status = WaitForSingleObject(handle, 0);
+        CloseHandle(handle);
+        status == 0x102
+    }
+}
+pub fn executable_path(pid: u32) -> Option<std::path::PathBuf> {
+    // SAFETY: handle and writable UTF-16 buffer remain live for the call.
+    unsafe {
+        let handle = OpenProcess(QUERY, 0, pid);
+        if handle == 0 { return None; }
+        let mut buffer = vec![0u16; 32_768];
+        let mut size = buffer.len() as u32;
+        let result = QueryFullProcessImageNameW(handle, 0, buffer.as_mut_ptr(), &mut size);
+        CloseHandle(handle);
+        (result != 0).then(|| std::path::PathBuf::from(std::ffi::OsString::from_wide(&buffer[..size as usize])))
+    }
+}
+pub fn cpu_ticks(pid: u32) -> Option<u64> {
+    // SAFETY: handle and all FILETIME output pointers remain live for the call.
+    unsafe {
+        let handle = OpenProcess(QUERY, 0, pid);
+        if handle == 0 { return None; }
+        let zero = FileTime { low: 0, high: 0 };
+        let (mut creation, mut exit, mut kernel, mut user) = (zero, zero, zero, zero);
+        let result = GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user);
+        CloseHandle(handle);
+        let value = |time: FileTime| ((time.high as u64) << 32) | u64::from(time.low);
+        (result != 0).then(|| value(kernel).wrapping_add(value(user)))
+    }
+}

--- a/crates/zccache-platform/src/platform_win/process/jobserver.rs
+++ b/crates/zccache-platform/src/platform_win/process/jobserver.rs
@@ -1,0 +1,1 @@
+pub fn is_supported() -> bool { false }

--- a/crates/zccache-platform/src/platform_win/process/mod.rs
+++ b/crates/zccache-platform/src/platform_win/process/mod.rs
@@ -1,0 +1,8 @@
+pub mod command;
+pub mod exit;
+pub mod inspect;
+pub mod jobserver;
+pub mod priority;
+pub mod spawn;
+pub mod stdio;
+pub mod terminate;

--- a/crates/zccache-platform/src/platform_win/process/priority.rs
+++ b/crates/zccache-platform/src/platform_win/process/priority.rs
@@ -1,0 +1,1 @@
+//! Windows scheduling priority.

--- a/crates/zccache-platform/src/platform_win/process/spawn.rs
+++ b/crates/zccache-platform/src/platform_win/process/spawn.rs
@@ -1,0 +1,7 @@
+use std::process::{Child, Command};
+use std::time::Duration;
+pub fn sleeping_child(duration: Duration) -> std::io::Result<Child> {
+    Command::new("powershell")
+        .args(["-NoProfile", "-Command", &format!("Start-Sleep -Seconds {}", duration.as_secs().max(1))])
+        .spawn()
+}

--- a/crates/zccache-platform/src/platform_win/process/stdio.rs
+++ b/crates/zccache-platform/src/platform_win/process/stdio.rs
@@ -1,0 +1,1 @@
+//! Windows standard-I/O mechanics.

--- a/crates/zccache-platform/src/platform_win/process/terminate.rs
+++ b/crates/zccache-platform/src/platform_win/process/terminate.rs
@@ -1,0 +1,20 @@
+use std::io;
+#[link(name = "kernel32")]
+unsafe extern "system" {
+    fn OpenProcess(access: u32, inherit: i32, pid: u32) -> isize;
+    fn TerminateProcess(handle: isize, exit_code: u32) -> i32;
+    fn CloseHandle(handle: isize) -> i32;
+}
+pub fn force(pid: u32) -> io::Result<()> {
+    const PROCESS_TERMINATE: u32 = 0x0001;
+    const SYNCHRONIZE: u32 = 0x0010_0000;
+    // SAFETY: handle is checked and closed exactly once.
+    unsafe {
+        let handle = OpenProcess(PROCESS_TERMINATE | SYNCHRONIZE, 0, pid);
+        if handle == 0 { return Err(io::Error::last_os_error()); }
+        let result = TerminateProcess(handle, 1);
+        let error = (result == 0).then(io::Error::last_os_error);
+        CloseHandle(handle);
+        error.map_or(Ok(()), Err)
+    }
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -50,6 +50,10 @@ killed, while the #1161/#132 identity-bound stop intentionally refuses non-zccac
 
 ## Phase 4 (#1369) plan — platform::process
 
+RED (2026-08-13): `soldr --no-cache cargo test -p zccache-platform` fails with
+13 missing process-facade APIs after adding the capability leaves and owned-child
+characterization tests before any concrete backend.
+
 Facade: command/spawn/priority/inspect/terminate/stdio/jobserver/exit. Move daemon/{process,
 child_watchdog,jobserver,trampoline}.rs native code + core/crash.rs signal labels +
 ipc PID helpers + cli-core deploy.rs spawn bits + bin/zccache.rs stack wrapper. Keep


### PR DESCRIPTION
## Checkpoint

- establish the required capability-oriented process facade and matching Linux, macOS, and Windows concrete leaves
- record RED for the missing facade APIs, then GREEN for neutral priority, process liveness/image lookup, owned-child termination, CPU ticks, jobserver capability, and exit labeling
- preserve this as a stacked checkpoint on the Phase 3 branch; Phase 4 caller migration remains follow-up work

## Validation

- soldr --no-cache cargo fmt --all -- --check
- soldr --no-cache cargo test -p zccache-platform (31 passed)
- soldr --no-cache cargo clippy -p zccache-platform --all-targets -- -D warnings
- git diff --check