### PR TITLE
refactor(platform): centralize executable and host facts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4283,6 +4283,7 @@ dependencies = [
  "thiserror",
  "zccache-core",
  "zccache-hash",
+ "zccache-platform",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4373,6 +4373,7 @@ dependencies = [
  "zccache-compiler",
  "zccache-core",
  "zccache-hash",
+ "zccache-platform",
 ]
 
 [[package]]

--- a/crates/zccache-cli-core/src/cli/commands/cargo_registry.rs
+++ b/crates/zccache-cli-core/src/cli/commands/cargo_registry.rs
@@ -16,9 +16,8 @@ pub(crate) fn resolve_cargo_home(explicit: Option<&str>) -> Result<NormalizedPat
             return Ok(NormalizedPath::from(ch));
         }
     }
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .map_err(|_| "cannot determine home directory (set HOME or CARGO_HOME)".to_string())?;
+    let home = crate::platform::host::home_dir()
+        .ok_or_else(|| "cannot determine home directory (set HOME or CARGO_HOME)".to_string())?;
     Ok(NormalizedPath::from(home).join(".cargo"))
 }
 

--- a/crates/zccache-cli-core/src/cli/commands/daemon.rs
+++ b/crates/zccache-cli-core/src/cli/commands/daemon.rs
@@ -14,16 +14,12 @@ const PROFILE_START_REASON: &str = "tokio-console-profile-start";
 
 /// Find the daemon binary. Looks next to the CLI binary first, then on PATH.
 pub(crate) fn find_daemon_binary() -> Option<NormalizedPath> {
-    let name = if cfg!(windows) {
-        "zccache-daemon.exe"
-    } else {
-        "zccache-daemon"
-    };
+    let name = crate::platform::executable::native_name(std::ffi::OsStr::new("zccache-daemon"));
 
     // Look next to the CLI binary
-    if let Ok(exe) = std::env::current_exe() {
+    if let Ok(exe) = crate::platform::executable::current_image() {
         if let Some(dir) = exe.parent() {
-            let candidate = dir.join(name);
+            let candidate = dir.join(&name);
             if candidate.exists() {
                 return Some(candidate.into());
             }
@@ -31,28 +27,13 @@ pub(crate) fn find_daemon_binary() -> Option<NormalizedPath> {
     }
 
     // Fall back to PATH
-    which_on_path(name)
+    crate::platform::executable::find_on_path(&name).map(Into::into)
 }
 
 /// Simple PATH lookup (no external crate needed).
 /// On Windows, also tries appending `.exe` if the name has no extension.
 pub(crate) fn which_on_path(name: &str) -> Option<NormalizedPath> {
-    let path_var = std::env::var_os("PATH")?;
-    for dir in std::env::split_paths(&path_var) {
-        let candidate = dir.join(name);
-        if candidate.is_file() {
-            return Some(candidate.into());
-        }
-        // On Windows, try with .exe suffix
-        #[cfg(windows)]
-        if std::path::Path::new(name).extension().is_none() {
-            let with_exe = dir.join(format!("{name}.exe"));
-            if with_exe.is_file() {
-                return Some(with_exe.into());
-            }
-        }
-    }
-    None
+    crate::platform::executable::find_on_path(std::ffi::OsStr::new(name)).map(Into::into)
 }
 
 pub(crate) async fn cmd_start(endpoint: &str) -> ExitCode {

--- a/crates/zccache-cli-core/src/cli/defender.rs
+++ b/crates/zccache-cli-core/src/cli/defender.rs
@@ -30,11 +30,11 @@ fn windows_only_noop() -> ExitCode {
 }
 
 pub fn cmd_check(json: bool) -> ExitCode {
-    if !cfg!(windows) {
+    if !crate::platform::host::defender_supported() {
         if json {
             let doc = serde_json::json!({
                 "supported": false,
-                "platform": std::env::consts::OS,
+                "platform": crate::platform::host::os(),
                 "message": "Defender exclusion is Windows-only.",
             });
             println!("{doc}");
@@ -76,7 +76,7 @@ pub fn cmd_check(json: bool) -> ExitCode {
 }
 
 pub fn cmd_add() -> ExitCode {
-    if !cfg!(windows) {
+    if !crate::platform::host::defender_supported() {
         return windows_only_noop();
     }
     if !is_elevated() {
@@ -100,7 +100,7 @@ pub fn cmd_add() -> ExitCode {
 }
 
 pub fn cmd_remove() -> ExitCode {
-    if !cfg!(windows) {
+    if !crate::platform::host::defender_supported() {
         return windows_only_noop();
     }
     if !is_elevated() {
@@ -156,7 +156,7 @@ fn print_check_json(
         .collect();
     let doc = serde_json::json!({
         "supported": true,
-        "platform": std::env::consts::OS,
+        "platform": crate::platform::host::os(),
         "cache_root": cache_root.display().to_string(),
         "paths": paths,
         "all_excluded": statuses.iter().all(|s| s.excluded) && !statuses.is_empty(),

--- a/crates/zccache-cli-core/src/cli/multicall.rs
+++ b/crates/zccache-cli-core/src/cli/multicall.rs
@@ -12,7 +12,6 @@
 //! match (or the explicit `zccache daemon-run` escape hatch).
 
 use std::ffi::OsStr;
-use std::path::Path;
 
 /// The file stem the self-copied daemon binary is deployed under. Must match
 /// `verify_pid_exe_stem(pid, "zccache-daemon")` in `zccache-ipc` and the
@@ -38,17 +37,7 @@ pub fn invoked_as_daemon() -> bool {
 ///   `zccache-daemon.old.<rand>.exe` (issue #999 Windows unlock rename) does
 ///   NOT match — a dead relocated binary must never dispatch as the daemon.
 fn stem_matches(arg0: &OsStr, target: &str) -> bool {
-    let Some(stem) = Path::new(arg0).file_stem() else {
-        return false;
-    };
-    let Some(stem) = stem.to_str() else {
-        return false;
-    };
-    if cfg!(windows) {
-        stem.eq_ignore_ascii_case(target)
-    } else {
-        stem == target
-    }
+    crate::platform::executable::stem_matches(arg0, target)
 }
 
 #[cfg(test)]

--- a/crates/zccache-cli-core/src/cli/runtime/deploy.rs
+++ b/crates/zccache-cli-core/src/cli/runtime/deploy.rs
@@ -106,12 +106,8 @@ fn cli_spawn_lineage_env() -> Vec<(String, String)> {
 /// of the CLI (self) placed under the versioned cache dir with the daemon's own
 /// name, so argv[0] dispatch (#998) routes the copy to the daemon and
 /// `verify_pid_exe_stem(pid, "zccache-daemon")` (zccache-ipc) recognizes it.
-fn deployed_daemon_file_name() -> &'static str {
-    if cfg!(windows) {
-        "zccache-daemon.exe"
-    } else {
-        "zccache-daemon"
-    }
+fn deployed_daemon_file_name() -> std::ffi::OsString {
+    crate::platform::executable::native_name(std::ffi::OsStr::new("zccache-daemon"))
 }
 
 /// Path the daemon binary is materialized to:
@@ -272,11 +268,7 @@ pub fn materialize_daemon_exe_to(
             .subsec_nanos();
     let tmp = dest.with_file_name(format!("zccache-daemon.tmp.{rand_id}"));
     std::fs::copy(source, &tmp)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755));
-    }
+    let _ = crate::platform::fs::permissions::make_executable(&tmp);
     match std::fs::rename(&tmp, dest) {
         Ok(()) => Ok(dest.to_path_buf()),
         Err(e) => {
@@ -419,7 +411,7 @@ pub fn spawn_daemon(endpoint: &str) -> Result<(), String> {
     // `pip install --upgrade zccache` / `rm -rf <project>` still succeed
     // (issue #134). Fall back to spawning the current exe in place if the
     // copy fails — the daemon's own `unlock_exe()` then handles the rename.
-    let self_exe = std::env::current_exe()
+    let self_exe = crate::platform::executable::current_image()
         .map_err(|e| format!("cannot resolve current executable to deploy daemon: {e}"))?;
     let bin_owned: std::path::PathBuf;
     // `spawned_as_daemon` is true when we run the materialized copy, whose

--- a/crates/zccache-cli-core/src/cli/symbols.rs
+++ b/crates/zccache-cli-core/src/cli/symbols.rs
@@ -142,7 +142,7 @@ fn resolved_prefix(opts_prefix: Option<&Path>) -> Result<PathBuf, SymbolsError> 
     if let Some(p) = opts_prefix {
         return Ok(p.to_path_buf());
     }
-    let exe = env::current_exe().map_err(SymbolsError::LocateExe)?;
+    let exe = crate::platform::executable::current_image().map_err(SymbolsError::LocateExe)?;
     Ok(exe
         .parent()
         .map(Path::to_path_buf)

--- a/crates/zccache-cli-core/src/download_client/mod.rs
+++ b/crates/zccache-cli-core/src/download_client/mod.rs
@@ -56,40 +56,19 @@ fn run_async<T>(future: impl std::future::Future<Output = Result<T, String>>) ->
 }
 
 fn find_daemon_binary() -> Option<NormalizedPath> {
-    let name = if cfg!(windows) {
-        "zccache-download-daemon.exe"
-    } else {
-        "zccache-download-daemon"
-    };
+    let name =
+        crate::platform::executable::native_name(std::ffi::OsStr::new("zccache-download-daemon"));
 
-    if let Ok(exe) = std::env::current_exe() {
+    if let Ok(exe) = crate::platform::executable::current_image() {
         if let Some(dir) = exe.parent() {
-            let candidate = dir.join(name);
+            let candidate = dir.join(&name);
             if candidate.exists() {
                 return Some(candidate.into());
             }
         }
     }
 
-    which_on_path(name)
-}
-
-fn which_on_path(name: &str) -> Option<NormalizedPath> {
-    let path_var = std::env::var_os("PATH")?;
-    for dir in std::env::split_paths(&path_var) {
-        let candidate = dir.join(name);
-        if candidate.is_file() {
-            return Some(candidate.into());
-        }
-        #[cfg(windows)]
-        if Path::new(name).extension().is_none() {
-            let with_exe = dir.join(format!("{name}.exe"));
-            if with_exe.is_file() {
-                return Some(with_exe.into());
-            }
-        }
-    }
-    None
+    crate::platform::executable::find_on_path(&name).map(Into::into)
 }
 
 fn spawn_daemon(bin: &Path, endpoint: &str) -> Result<(), String> {

--- a/crates/zccache-compiler/Cargo.toml
+++ b/crates/zccache-compiler/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 zccache-core = { workspace = true }
 zccache-hash = { workspace = true }
+zccache-platform = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/zccache-compiler/src/arduino.rs
+++ b/crates/zccache-compiler/src/arduino.rs
@@ -206,8 +206,9 @@ fn discover_libclang_path() -> Option<NormalizedPath> {
                 }
             }
 
-            default_libclang_candidates()
+            crate::platform::executable::clang_library_candidates()
                 .into_iter()
+                .map(NormalizedPath::from)
                 .find(|candidate| candidate.exists())
         })
         .clone()
@@ -234,48 +235,8 @@ fn ensure_libclang_env() -> Result<(), ArduinoError> {
     Ok(())
 }
 
-fn default_libclang_candidates() -> Vec<NormalizedPath> {
-    #[cfg(windows)]
-    {
-        vec![
-            NormalizedPath::from(r"C:\Program Files\LLVM\bin\libclang.dll"),
-            NormalizedPath::from(r"C:\Program Files\LLVM\lib\libclang.dll"),
-            NormalizedPath::from(r"C:\Program Files\doxygen\bin\libclang.dll"),
-        ]
-    }
-    #[cfg(target_os = "macos")]
-    {
-        vec![
-            NormalizedPath::from("/opt/homebrew/opt/llvm/lib/libclang.dylib"),
-            NormalizedPath::from("/usr/local/opt/llvm/lib/libclang.dylib"),
-            NormalizedPath::from("/Library/Developer/CommandLineTools/usr/lib/libclang.dylib"),
-        ]
-    }
-    #[cfg(all(unix, not(target_os = "macos")))]
-    {
-        vec![
-            NormalizedPath::from("/usr/lib/llvm-18/lib/libclang.so"),
-            NormalizedPath::from("/usr/lib/llvm-17/lib/libclang.so"),
-            NormalizedPath::from("/usr/lib/llvm-16/lib/libclang.so"),
-            NormalizedPath::from("/usr/lib/libclang.so"),
-            NormalizedPath::from("/usr/local/lib/libclang.so"),
-        ]
-    }
-}
-
-#[cfg(windows)]
-fn libclang_filename() -> &'static str {
-    "libclang.dll"
-}
-
-#[cfg(target_os = "macos")]
-fn libclang_filename() -> &'static str {
-    "libclang.dylib"
-}
-
-#[cfg(all(unix, not(target_os = "macos")))]
-fn libclang_filename() -> &'static str {
-    "libclang.so"
+fn libclang_filename() -> std::ffi::OsString {
+    crate::platform::executable::native_library_name(std::ffi::OsStr::new("libclang"))
 }
 
 fn collect_existing_declarations(entities: &[Entity<'_>]) -> HashSet<String> {

--- a/crates/zccache-compiler/src/lib.rs
+++ b/crates/zccache-compiler/src/lib.rs
@@ -18,6 +18,8 @@
 
 #![allow(clippy::missing_errors_doc)]
 
+pub(crate) use zccache_platform as platform;
+
 pub mod arduino;
 mod detect;
 mod dylint;

--- a/crates/zccache-core/src/config/resolve.rs
+++ b/crates/zccache-core/src/config/resolve.rs
@@ -404,10 +404,9 @@ pub fn staging_dir_override() -> Option<NormalizedPath> {
 }
 
 fn dirs_fallback() -> NormalizedPath {
-    std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
+    crate::platform::host::home_dir()
         .map(NormalizedPath::from)
-        .unwrap_or_else(|_| ".".into())
+        .unwrap_or_else(|| ".".into())
 }
 
 pub(super) fn cache_dir_from_env_value(value: Option<OsString>) -> Option<NormalizedPath> {

--- a/crates/zccache-core/src/crash.rs
+++ b/crates/zccache-core/src/crash.rs
@@ -227,8 +227,8 @@ fn write_signal_dump(ctx: &crash_handler::CrashContext) {
          a debugger or attach RUST_BACKTRACE-enabled child for stack>\n",
         bin = bin_stem(),
         version = env!("CARGO_PKG_VERSION"),
-        os = std::env::consts::OS,
-        arch = std::env::consts::ARCH,
+        os = crate::platform::host::os(),
+        arch = crate::platform::host::arch(),
         pid = std::process::id(),
         sig = sig_label,
         ts = SystemTime::now()
@@ -278,8 +278,8 @@ fn write_panic_dump(panic_info: &str, backtrace: &str) -> Option<NormalizedPath>
          {backtrace}\n",
         bin = bin_stem(),
         version = env!("CARGO_PKG_VERSION"),
-        os = std::env::consts::OS,
-        arch = std::env::consts::ARCH,
+        os = crate::platform::host::os(),
+        arch = crate::platform::host::arch(),
         pid = std::process::id(),
     );
 

--- a/crates/zccache-core/src/defender.rs
+++ b/crates/zccache-core/src/defender.rs
@@ -61,40 +61,9 @@ pub fn compute_exclusion_paths(cache_root: &Path) -> Vec<PathBuf> {
 /// On Windows we query the process token for `TokenElevation`. On every
 /// other platform we return `true` — non-Windows callers never need
 /// elevation for the Defender flow because the flow is a no-op there.
-#[cfg(windows)]
 #[must_use]
 pub fn is_elevated() -> bool {
-    use std::mem::size_of;
-    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
-    use windows_sys::Win32::Security::{
-        GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY,
-    };
-    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
-
-    unsafe {
-        let mut token: HANDLE = std::ptr::null_mut();
-        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
-            return false;
-        }
-        let mut elevation = TOKEN_ELEVATION { TokenIsElevated: 0 };
-        let mut size: u32 = 0;
-        #[allow(clippy::cast_possible_truncation)]
-        let ok = GetTokenInformation(
-            token,
-            TokenElevation,
-            std::ptr::from_mut::<TOKEN_ELEVATION>(&mut elevation).cast(),
-            size_of::<TOKEN_ELEVATION>() as u32,
-            &mut size,
-        );
-        CloseHandle(token);
-        ok != 0 && elevation.TokenIsElevated != 0
-    }
-}
-
-#[cfg(not(windows))]
-#[must_use]
-pub fn is_elevated() -> bool {
-    true
+    crate::platform::host::is_elevated()
 }
 
 /// True when `ZCCACHE_QUIET` is set to a non-empty value other than `"0"`.
@@ -121,9 +90,6 @@ pub fn quiet_value_silences(value: Option<&str>) -> bool {
 /// the daemon's redirected stderr — eventually the user's terminal — on
 /// every fresh start.
 pub fn maybe_emit_first_run_banner(cache_root: &Path) {
-    if !cfg!(windows) {
-        return;
-    }
     if is_quiet_env() {
         return;
     }
@@ -207,147 +173,70 @@ pub struct ExclusionStatus {
     pub excluded: bool,
 }
 
-#[cfg(windows)]
-mod windows_impl {
-    use super::{DefenderError, ExclusionStatus};
-    use std::path::{Path, PathBuf};
-    use std::process::Command;
+pub fn query_excluded(paths: &[PathBuf]) -> Result<Vec<ExclusionStatus>, DefenderError> {
+    let excluded = crate::platform::host::defender_exclusions().map_err(map_native_error)?;
+    Ok(paths
+        .iter()
+        .map(|path| ExclusionStatus {
+            path: path.clone(),
+            excluded: excluded.iter().any(|entry| paths_equal(path, entry)),
+        })
+        .collect())
+}
 
-    /// Run `Get-MpPreference | Select-Object -ExpandProperty ExclusionPath`
-    /// once and check membership locally. One subprocess regardless of how
-    /// many paths are being checked — Defender's exclusion list is small
-    /// and stable.
-    pub fn query_excluded(paths: &[PathBuf]) -> Result<Vec<ExclusionStatus>, DefenderError> {
-        let raw = run_powershell(&[
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            "(Get-MpPreference).ExclusionPath",
-        ])?;
-        let excluded: Vec<String> = raw
-            .lines()
-            .map(|l| l.trim().to_string())
-            .filter(|l| !l.is_empty())
-            .collect();
-        Ok(paths
-            .iter()
-            .map(|p| ExclusionStatus {
-                path: p.clone(),
-                excluded: path_matches_any(p, &excluded),
-            })
-            .collect())
+pub fn add_exclusions(paths: &[PathBuf]) -> Result<(), DefenderError> {
+    for path in paths {
+        crate::platform::host::add_defender_exclusion(path).map_err(map_native_error)?;
     }
+    Ok(())
+}
 
-    pub fn add_exclusions(paths: &[PathBuf]) -> Result<(), DefenderError> {
-        for p in paths {
-            let arg = quote_for_powershell(p);
-            run_powershell(&[
-                "-NoProfile",
-                "-NonInteractive",
-                "-Command",
-                &format!("Add-MpPreference -ExclusionPath {arg}"),
-            ])?;
+pub fn remove_exclusions(paths: &[PathBuf]) -> Result<(), DefenderError> {
+    for path in paths {
+        crate::platform::host::remove_defender_exclusion(path).map_err(map_native_error)?;
+    }
+    Ok(())
+}
+
+fn map_native_error(error: crate::platform::host::DefenderError) -> DefenderError {
+    match error {
+        crate::platform::host::DefenderError::Unsupported => DefenderError::Unsupported,
+        crate::platform::host::DefenderError::PowerShellNotFound => {
+            DefenderError::PowerShellNotFound
         }
-        Ok(())
-    }
-
-    pub fn remove_exclusions(paths: &[PathBuf]) -> Result<(), DefenderError> {
-        for p in paths {
-            let arg = quote_for_powershell(p);
-            run_powershell(&[
-                "-NoProfile",
-                "-NonInteractive",
-                "-Command",
-                &format!("Remove-MpPreference -ExclusionPath {arg}"),
-            ])?;
+        crate::platform::host::DefenderError::CommandFailed { exit_code, stderr } => {
+            DefenderError::PowerShellFailed { exit_code, stderr }
         }
-        Ok(())
-    }
-
-    fn run_powershell(args: &[&str]) -> Result<String, DefenderError> {
-        let output = Command::new("powershell.exe").args(args).output()?;
-        if !output.status.success() {
-            return Err(DefenderError::PowerShellFailed {
-                exit_code: output.status.code(),
-                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-            });
+        crate::platform::host::DefenderError::OutputParse(message) => {
+            DefenderError::OutputParse(message)
         }
-        String::from_utf8(output.stdout).map_err(|e| DefenderError::OutputParse(e.to_string()))
-    }
-
-    /// Defender exclusion paths are stored in whatever form the user
-    /// supplied to `Add-MpPreference`. Normalise both sides before
-    /// comparing so `C:\Users\me\.zccache` matches `C:/Users/me/.zccache`
-    /// and trailing separators don't cause false negatives.
-    fn path_matches_any(needle: &Path, haystack: &[String]) -> bool {
-        let needle_norm = normalize_for_compare(needle);
-        haystack
-            .iter()
-            .any(|h| normalize_for_compare(Path::new(h)) == needle_norm)
-    }
-
-    fn normalize_for_compare(p: &Path) -> String {
-        let s: String = p.to_string_lossy().replace('/', "\\");
-        let trimmed = s.trim_end_matches('\\');
-        trimmed.to_ascii_lowercase()
-    }
-
-    fn quote_for_powershell(p: &Path) -> String {
-        // Single-quote so PowerShell does not expand `$`; double single
-        // quotes inside escape the quote character. Paths in Windows do
-        // not contain single quotes in practice, but guard anyway.
-        let s = p.to_string_lossy();
-        format!("'{}'", s.replace('\'', "''"))
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        #[test]
-        fn normalize_for_compare_canonicalizes() {
-            assert_eq!(
-                normalize_for_compare(Path::new("C:/Users/me/.zccache")),
-                normalize_for_compare(Path::new("C:\\Users\\me\\.zccache\\"))
-            );
-        }
-
-        #[test]
-        fn path_matches_any_is_case_insensitive() {
-            let cands = vec!["C:\\Users\\Me\\.zccache".to_string()];
-            assert!(path_matches_any(Path::new("c:/users/me/.zccache"), &cands));
-        }
-
-        #[test]
-        fn quote_for_powershell_escapes_single_quote() {
-            let p = Path::new("C:/it's/weird");
-            assert_eq!(quote_for_powershell(p), "'C:/it''s/weird'");
-        }
+        crate::platform::host::DefenderError::Io(error) => DefenderError::Io(error),
     }
 }
 
-#[cfg(windows)]
-pub use windows_impl::{add_exclusions, query_excluded, remove_exclusions};
-
-#[cfg(not(windows))]
-pub fn query_excluded(_paths: &[PathBuf]) -> Result<Vec<ExclusionStatus>, DefenderError> {
-    Err(DefenderError::Unsupported)
+fn paths_equal(left: &Path, right: &Path) -> bool {
+    normalize_for_compare(left) == normalize_for_compare(right)
 }
 
-#[cfg(not(windows))]
-pub fn add_exclusions(_paths: &[PathBuf]) -> Result<(), DefenderError> {
-    Err(DefenderError::Unsupported)
-}
-
-#[cfg(not(windows))]
-pub fn remove_exclusions(_paths: &[PathBuf]) -> Result<(), DefenderError> {
-    Err(DefenderError::Unsupported)
+fn normalize_for_compare(path: &Path) -> String {
+    path.to_string_lossy()
+        .replace('/', "\\")
+        .trim_end_matches('\\')
+        .to_ascii_lowercase()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn defender_path_comparison_normalizes_case_and_separators() {
+        assert!(paths_equal(
+            Path::new("C:/Users/me/.zccache"),
+            Path::new("c:\\users\\me\\.zccache\\"),
+        ));
+    }
 
     #[test]
     fn compute_paths_includes_cache_root() {

--- a/crates/zccache-core/src/lifecycle.rs
+++ b/crates/zccache-core/src/lifecycle.rs
@@ -428,7 +428,7 @@ pub fn emit_takeover_lifecycle_events(
 /// back to `"<unknown>"` so the field is always present.
 #[must_use]
 pub fn client_meta(client_version: &str) -> serde_json::Value {
-    let binary_path = std::env::current_exe()
+    let binary_path = crate::platform::executable::current_image()
         .ok()
         .and_then(|p| p.to_str().map(str::to_string))
         .unwrap_or_else(|| "<unknown>".to_string());

--- a/crates/zccache-daemon-core/src/daemon/crash.rs
+++ b/crates/zccache-daemon-core/src/daemon/crash.rs
@@ -76,8 +76,8 @@ pub fn write_crash_dump(panic_info: &str, backtrace: &str) -> Option<NormalizedP
          Backtrace:\n\
          {backtrace}\n",
         version = env!("CARGO_PKG_VERSION"),
-        os = std::env::consts::OS,
-        arch = std::env::consts::ARCH,
+        os = crate::platform::host::os(),
+        arch = crate::platform::host::arch(),
         pid = std::process::id(),
     );
     std::fs::write(&path, content).ok()?;

--- a/crates/zccache-daemon-core/src/daemon/entry.rs
+++ b/crates/zccache-daemon-core/src/daemon/entry.rs
@@ -49,9 +49,7 @@ use crate::core::NormalizedPath;
 /// - 32 cores → 256
 /// - ≥ 64 cores → 512 (ceiling — matches tokio's stated default).
 fn daemon_max_blocking_threads() -> usize {
-    let parallelism = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(8);
+    let parallelism = crate::platform::host::available_parallelism().unwrap_or(8);
     parallelism.saturating_mul(8).clamp(128, 512)
 }
 
@@ -425,7 +423,7 @@ fn run_server(args: Args) {
         // RUNNING_PROCESS_DISABLE=1. The version-policy refinement (#720
         // Phase 0) is the follow-up that turns the current exact-version
         // pin into a real compatibility floor + range.
-        if let Ok(binary) = std::env::current_exe() {
+        if let Ok(binary) = crate::platform::executable::current_image() {
             let _ = crate::ipc::publish_service_definition(&binary);
         }
 

--- a/crates/zccache-daemon-core/src/daemon/server/compile_concurrency.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/compile_concurrency.rs
@@ -117,9 +117,7 @@ fn default_cap(is_ci: bool, num_cpus: usize) -> usize {
 }
 
 fn num_cpus_default() -> usize {
-    std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(1)
+    crate::platform::host::available_parallelism().unwrap_or(1)
 }
 
 #[cfg(test)]

--- a/crates/zccache-daemon-core/src/daemon/server/util.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/util.rs
@@ -83,9 +83,7 @@ pub(super) fn persist_workers_default() -> usize {
         // the `max(32, …)` floor covers the same burst on smaller hosts
         // (32 simultaneous hardlinks is well under the per-process fd
         // ceiling even on default-configured Linux).
-        let parallelism = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(8);
+        let parallelism = crate::platform::host::available_parallelism().unwrap_or(8);
         parallelism.saturating_mul(2).max(32)
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/trampoline.rs
+++ b/crates/zccache-daemon-core/src/daemon/trampoline.rs
@@ -39,10 +39,6 @@ use std::path::Path;
 /// No-op on non-Windows. Set `ZCCACHE_NO_UNLOCK=1` to opt out (mirrors
 /// clud's `CLUD_NO_UNLOCK`).
 pub fn unlock_exe() {
-    if !cfg!(target_os = "windows") {
-        return;
-    }
-
     // Escape hatch for CI / test harnesses that spawn many short-lived
     // zccache invocations: the rename+copy+GC dance on every start costs
     // real time and (under investigation in clud's #37) appears to keep
@@ -65,25 +61,16 @@ pub fn unlock_exe() {
         return;
     }
 
-    // Rename zccache-daemon.exe → zccache-daemon.exe.old.<rand>. We keep
-    // running from the renamed file.
-    let rand_id: u32 = std::process::id()
-        ^ (std::time::UNIX_EPOCH
-            .elapsed()
-            .unwrap_or_default()
-            .subsec_nanos());
-    let old_exe = my_exe.with_extension(format!("exe.old.{rand_id}"));
-
-    if fs::rename(&my_exe, &old_exe).is_err() {
-        tracing::warn!(
-            "could not unlock exe for hot-reload; pip install may fail while zccache is running"
-        );
-        return;
+    match crate::platform::executable::unlock_for_replacement(&my_exe) {
+        Ok(true) => {}
+        Ok(false) => return,
+        Err(_) => {
+            tracing::warn!(
+                "could not unlock exe for hot-reload; pip install may fail while zccache is running"
+            );
+            return;
+        }
     }
-
-    // Copy back: zccache-daemon.exe.old.<rand> → zccache-daemon.exe (new
-    // file, unlocked).
-    let _ = fs::copy(&old_exe, &my_exe);
 
     // GC stale .old files in background. Fire and forget.
     let parent = match my_exe.parent() {
@@ -135,11 +122,7 @@ pub fn release_cwd() {
 /// project-local cache), and the whole point of [`release_cwd`] is to
 /// chdir OUT of any workspace so its directory handle is released.
 fn zccache_home_dir() -> Option<std::path::PathBuf> {
-    let home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))?;
-    if home.is_empty() {
-        return None;
-    }
-    Some(std::path::Path::new(&home).join(".zccache"))
+    crate::platform::host::home_dir().map(|home| home.join(".zccache"))
 }
 
 /// Detach inherited stdio (stdin/stdout/stderr) by re-opening them to the

--- a/crates/zccache-daemon-core/src/daemon/trampoline.rs
+++ b/crates/zccache-daemon-core/src/daemon/trampoline.rs
@@ -52,7 +52,7 @@ pub fn unlock_exe() {
         return;
     }
 
-    let my_exe = match std::env::current_exe() {
+    let my_exe = match crate::platform::executable::current_image() {
         Ok(p) => p,
         Err(_) => return,
     };

--- a/crates/zccache-daemon-core/src/embedded.rs
+++ b/crates/zccache-daemon-core/src/embedded.rs
@@ -158,7 +158,7 @@ impl HostIdentity {
         let mut hasher = Hasher::new();
         hasher.update(product.as_bytes());
         hasher.update(b"\0zccache-host-identity-v1\0");
-        if let Ok(exe) = std::env::current_exe() {
+        if let Ok(exe) = crate::platform::executable::current_image() {
             hasher.update(exe.as_os_str().to_string_lossy().as_bytes());
         }
         let bytes = hasher.finalize();

--- a/crates/zccache-depgraph/Cargo.toml
+++ b/crates/zccache-depgraph/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 zccache-core = { workspace = true }
 zccache-compiler = { workspace = true }
 zccache-hash = { workspace = true }
+zccache-platform = { workspace = true }
 bincode = { workspace = true }
 blake3 = { workspace = true }
 dashmap = { workspace = true }

--- a/crates/zccache-depgraph/src/lib.rs
+++ b/crates/zccache-depgraph/src/lib.rs
@@ -20,6 +20,8 @@ pub mod snapshot;
 pub mod system_includes;
 pub mod watcher_support;
 
+pub(crate) use zccache_platform as platform;
+
 pub use args::{ParsedArgs, UserDepFlags};
 pub use compile_commands::{parse_compile_commands_json, CompileCommand};
 pub use context::{

--- a/crates/zccache-depgraph/src/native_cpu.rs
+++ b/crates/zccache-depgraph/src/native_cpu.rs
@@ -48,73 +48,8 @@ pub fn is_rustc_native_cpu_flag(flag: &str) -> bool {
 }
 
 fn host_cpu_identity_material() -> String {
-    let mut material = format!(
-        "arch={}\0os={}",
-        std::env::consts::ARCH,
-        std::env::consts::OS
-    );
-
-    // Linux exposes a per-install machine id, which avoids sharing a native
-    // artifact even when two machines happen to report the same CPU model.
-    // Keep the raw value local: the caller hashes all material before it can
-    // become part of a cache key or snapshot.
-    #[cfg(target_os = "linux")]
-    if let Ok(machine_id) = std::fs::read_to_string("/etc/machine-id") {
-        let machine_id = machine_id.trim();
-        if !machine_id.is_empty() {
-            material.push_str("\0machine-id=");
-            material.push_str(machine_id);
-        }
-    }
-
-    // Windows normally provides COMPUTERNAME and Unix systems commonly expose
-    // HOSTNAME. This is intentionally only an additional discriminator; the
-    // identity is already domain-separated and opaque after hashing.
-    for variable in ["COMPUTERNAME", "HOSTNAME"] {
-        if let Some(value) = std::env::var_os(variable) {
-            material.push('\0');
-            material.push_str(variable);
-            material.push('=');
-            material.push_str(&value.to_string_lossy());
-        }
-    }
-
-    append_observed_cpu_features(&mut material);
-
-    // A host without an exposed identifier must never collapse into a common
-    // cross-host salt. PID costs only a restart hit in that rare fallback.
-    if !material.contains("machine-id=")
-        && !material.contains("COMPUTERNAME=")
-        && !material.contains("HOSTNAME=")
-    {
-        material.push_str("\0pid=");
-        material.push_str(&std::process::id().to_string());
-    }
-
-    material
+    crate::platform::host::cpu_identity_material()
 }
-
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-fn append_observed_cpu_features(material: &mut String) {
-    for (name, present) in [
-        ("sse2", std::arch::is_x86_feature_detected!("sse2")),
-        ("sse4.2", std::arch::is_x86_feature_detected!("sse4.2")),
-        ("avx", std::arch::is_x86_feature_detected!("avx")),
-        ("avx2", std::arch::is_x86_feature_detected!("avx2")),
-        ("avx512f", std::arch::is_x86_feature_detected!("avx512f")),
-        ("fma", std::arch::is_x86_feature_detected!("fma")),
-        ("bmi1", std::arch::is_x86_feature_detected!("bmi1")),
-        ("bmi2", std::arch::is_x86_feature_detected!("bmi2")),
-    ] {
-        if present {
-            material.push_str("\0feature=");
-            material.push_str(name);
-        }
-    }
-}
-
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-fn append_observed_cpu_features(_: &mut String) {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/zccache-download-protocol/src/daemon_mgmt.rs
+++ b/crates/zccache-download-protocol/src/daemon_mgmt.rs
@@ -18,9 +18,9 @@ pub fn default_endpoint() -> String {
         zccache_platform::ipc::current_user_name().unwrap_or_else(|| String::from("unknown"));
     let pipe_user = zccache_core::config::sanitize_ipc_component(&raw_user)
         .unwrap_or_else(|| String::from("unknown"));
-    let file_path = std::env::var("XDG_RUNTIME_DIR")
+    let file_path = zccache_platform::host::runtime_dir()
         .map(|runtime_dir| format!("{runtime_dir}/zccache-download/sock"))
-        .unwrap_or_else(|_| format!("/tmp/zccache-download-{raw_user}/sock"));
+        .unwrap_or_else(|| format!("/tmp/zccache-download-{raw_user}/sock"));
     zccache_platform::ipc::Endpoint::select(file_path, format!("zccache-download-{pipe_user}"))
         .to_string()
 }

--- a/crates/zccache-ipc/src/lib.rs
+++ b/crates/zccache-ipc/src/lib.rs
@@ -483,10 +483,10 @@ fn pipe_name(base: &str, namespace: Option<&str>) -> String {
 }
 
 fn default_file_endpoint(namespace: Option<&str>) -> String {
-    if let Ok(runtime_dir) = std::env::var("XDG_RUNTIME_DIR") {
+    if let Some(runtime_dir) = zccache_platform::host::runtime_dir() {
         return format!("{runtime_dir}/zccache/{}", socket_name(namespace));
     }
-    let user = std::env::var("USER").unwrap_or_else(|_| String::from("unknown"));
+    let user = zccache_platform::host::current_user().unwrap_or_else(|| String::from("unknown"));
     format!("/tmp/zccache-{user}/{}", socket_name(namespace))
 }
 

--- a/crates/zccache-platform/src/platform/executable.rs
+++ b/crates/zccache-platform/src/platform/executable.rs
@@ -1,7 +1,64 @@
-//! Neutral executable mechanics: native executable/script/library suffixes,
-//! PATH/PATHEXT lookup, running-image discovery and equality, and
-//! runnable-image materialization/replacement.
-//!
-//! Version-rooted deployment policy, GC, and daemon lifecycle decisions
-//! stay with the CLI. Populated in the executable phase (#1370); empty index
-//! until then.
+//! Neutral host-executable naming, discovery, and comparison primitives.
+
+use std::ffi::{OsStr, OsString};
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Returns `stem` with the host's native executable suffix when needed.
+#[must_use]
+pub fn native_name(stem: &OsStr) -> OsString {
+    crate::platform_imp::executable::native_name(stem)
+}
+
+/// Finds a runnable host image in an explicit ordered directory list.
+#[must_use]
+pub fn find_in_paths(name: &OsStr, directories: &[PathBuf]) -> Option<PathBuf> {
+    crate::platform_imp::executable::find_in_paths(name, directories)
+}
+
+/// Finds a runnable host image using the process `PATH`.
+#[must_use]
+pub fn find_on_path(name: &OsStr) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    let directories: Vec<_> = std::env::split_paths(&path).collect();
+    find_in_paths(name, &directories)
+}
+
+/// Returns the current process image path.
+pub fn current_image() -> io::Result<PathBuf> {
+    std::env::current_exe()
+}
+
+/// Reports whether two paths identify the same executable image.
+pub fn images_equal(left: &Path, right: &Path) -> io::Result<bool> {
+    crate::fs::identity::same_file(left, right)
+}
+
+/// Compares a host executable's file stem with a product stem.
+#[must_use]
+pub fn stem_matches(path: &OsStr, expected: &str) -> bool {
+    crate::platform_imp::executable::stem_matches(path, expected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_name_and_current_image_are_host_runnable() {
+        let name = native_name(OsStr::new("zccache-probe"));
+        assert!(!name.is_empty());
+
+        let image = current_image().expect("current executable image");
+        assert!(image.is_file());
+        assert!(images_equal(&image, &image).expect("same-image comparison"));
+    }
+
+    #[test]
+    fn explicit_path_lookup_finds_the_current_image() {
+        let image = current_image().expect("current executable image");
+        let directory = image.parent().expect("image directory").to_path_buf();
+        let name = image.file_name().expect("image name");
+        assert_eq!(find_in_paths(name, &[directory]), Some(image));
+    }
+}

--- a/crates/zccache-platform/src/platform/executable.rs
+++ b/crates/zccache-platform/src/platform/executable.rs
@@ -10,6 +10,18 @@ pub fn native_name(stem: &OsStr) -> OsString {
     crate::platform_imp::executable::native_name(stem)
 }
 
+/// Returns `stem` with the host's native dynamic-library suffix.
+#[must_use]
+pub fn native_library_name(stem: &OsStr) -> OsString {
+    crate::platform_imp::executable::native_library_name(stem)
+}
+
+/// Conventional host locations for the libclang shared library.
+#[must_use]
+pub fn clang_library_candidates() -> Vec<PathBuf> {
+    crate::platform_imp::executable::clang_library_candidates()
+}
+
 /// Finds a runnable host image in an explicit ordered directory list.
 #[must_use]
 pub fn find_in_paths(name: &OsStr, directories: &[PathBuf]) -> Option<PathBuf> {
@@ -40,6 +52,11 @@ pub fn stem_matches(path: &OsStr, expected: &str) -> bool {
     crate::platform_imp::executable::stem_matches(path, expected)
 }
 
+/// Relocates a running image when the host locks executable files.
+pub fn unlock_for_replacement(image: &Path) -> io::Result<bool> {
+    crate::platform_imp::executable::unlock_for_replacement(image)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -48,6 +65,7 @@ mod tests {
     fn native_name_and_current_image_are_host_runnable() {
         let name = native_name(OsStr::new("zccache-probe"));
         assert!(!name.is_empty());
+        assert!(!native_library_name(OsStr::new("libclang")).is_empty());
 
         let image = current_image().expect("current executable image");
         assert!(image.is_file());
@@ -60,5 +78,15 @@ mod tests {
         let directory = image.parent().expect("image directory").to_path_buf();
         let name = image.file_name().expect("image name");
         assert_eq!(find_in_paths(name, &[directory]), Some(image));
+    }
+
+    #[test]
+    fn replacement_unlock_matches_host_locking_semantics() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let image = directory.path().join(native_name(OsStr::new("probe")));
+        std::fs::write(&image, b"image").expect("write image");
+        let relocated = unlock_for_replacement(&image).expect("unlock");
+        assert_eq!(relocated, cfg!(windows));
+        assert!(image.is_file());
     }
 }

--- a/crates/zccache-platform/src/platform/host.rs
+++ b/crates/zccache-platform/src/platform/host.rs
@@ -1,7 +1,90 @@
-//! Neutral host facts: OS/architecture identity, home/runtime directories,
-//! current-user identity, elevation state, Defender query/mutation
-//! primitives, and host resource/pressure facts.
-//!
-//! Cache-root precedence, first-run UX, Defender policy wording, and
-//! scheduling thresholds stay with the callers. Populated in the host phase
-//! (#1370); empty index until then.
+//! Neutral facts about the machine running zccache.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+/// Native Defender command failure without product-specific wording.
+#[derive(Debug)]
+pub enum DefenderError {
+    Unsupported,
+    PowerShellNotFound,
+    CommandFailed {
+        exit_code: Option<i32>,
+        stderr: String,
+    },
+    OutputParse(String),
+    Io(std::io::Error),
+}
+
+/// Stable Rust host OS identifier.
+#[must_use]
+pub fn os() -> &'static str {
+    crate::platform_imp::host::os()
+}
+
+/// Stable Rust host architecture identifier.
+#[must_use]
+pub fn arch() -> &'static str {
+    crate::platform_imp::host::arch()
+}
+
+/// Best-effort current user's home directory.
+#[must_use]
+pub fn home_dir() -> Option<PathBuf> {
+    crate::platform_imp::host::home_dir()
+}
+
+/// Best-effort current user identifier suitable for endpoint names.
+#[must_use]
+pub fn current_user() -> Option<OsString> {
+    crate::platform_imp::host::current_user()
+}
+
+/// Opaque raw host inputs used by callers to domain-separate native CPU keys.
+#[must_use]
+pub fn cpu_identity_material() -> String {
+    crate::platform_imp::host::cpu_identity_material()
+}
+
+/// Logical concurrency exposed by the host.
+#[must_use]
+pub fn available_parallelism() -> Option<usize> {
+    std::thread::available_parallelism()
+        .ok()
+        .map(std::num::NonZeroUsize::get)
+}
+
+/// Whether the current process has host administrator privileges.
+#[must_use]
+pub fn is_elevated() -> bool {
+    crate::platform_imp::host::is_elevated()
+}
+
+/// Returns the host's configured Defender exclusion paths.
+pub fn defender_exclusions() -> Result<Vec<PathBuf>, DefenderError> {
+    crate::platform_imp::host::defender_exclusions()
+}
+
+/// Adds one native Defender exclusion path.
+pub fn add_defender_exclusion(path: &std::path::Path) -> Result<(), DefenderError> {
+    crate::platform_imp::host::add_defender_exclusion(path)
+}
+
+/// Removes one native Defender exclusion path.
+pub fn remove_defender_exclusion(path: &std::path::Path) -> Result<(), DefenderError> {
+    crate::platform_imp::host::remove_defender_exclusion(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_identity_facts_are_present_and_stable() {
+        assert!(!os().is_empty());
+        assert!(!arch().is_empty());
+        assert!(!cpu_identity_material().is_empty());
+        assert_eq!(cpu_identity_material(), cpu_identity_material());
+        assert!(available_parallelism().is_some_and(|value| value >= 1));
+    }
+}

--- a/crates/zccache-platform/src/platform/host.rs
+++ b/crates/zccache-platform/src/platform/host.rs
@@ -1,6 +1,5 @@
 //! Neutral facts about the machine running zccache.
 
-use std::ffi::OsString;
 use std::path::PathBuf;
 
 /// Native Defender command failure without product-specific wording.
@@ -34,9 +33,15 @@ pub fn home_dir() -> Option<PathBuf> {
     crate::platform_imp::host::home_dir()
 }
 
+/// Best-effort per-user runtime directory for local sockets and locks.
+#[must_use]
+pub fn runtime_dir() -> Option<String> {
+    crate::platform_imp::host::runtime_dir()
+}
+
 /// Best-effort current user identifier suitable for endpoint names.
 #[must_use]
-pub fn current_user() -> Option<OsString> {
+pub fn current_user() -> Option<String> {
     crate::platform_imp::host::current_user()
 }
 
@@ -58,6 +63,12 @@ pub fn available_parallelism() -> Option<usize> {
 #[must_use]
 pub fn is_elevated() -> bool {
     crate::platform_imp::host::is_elevated()
+}
+
+/// Whether native Defender exclusion management exists on this host.
+#[must_use]
+pub fn defender_supported() -> bool {
+    crate::platform_imp::host::defender_supported()
 }
 
 /// Returns the host's configured Defender exclusion paths.

--- a/crates/zccache-platform/src/platform_linux.rs
+++ b/crates/zccache-platform/src/platform_linux.rs
@@ -5,6 +5,8 @@
 //! where they share call sites. Populated per capability phase; empty until
 //! then.
 
+pub mod executable;
 pub mod fs;
+pub mod host;
 pub mod ipc;
 pub mod process;

--- a/crates/zccache-platform/src/platform_linux/executable.rs
+++ b/crates/zccache-platform/src/platform_linux/executable.rs
@@ -7,6 +7,26 @@ pub fn native_name(stem: &OsStr) -> OsString {
     stem.to_os_string()
 }
 
+pub fn native_library_name(stem: &OsStr) -> OsString {
+    let mut name = stem.to_os_string();
+    if std::path::Path::new(stem).extension().is_none() {
+        name.push(".so");
+    }
+    name
+}
+
+pub fn clang_library_candidates() -> Vec<PathBuf> {
+    [
+        "/usr/lib/llvm-18/lib/libclang.so",
+        "/usr/lib/llvm-17/lib/libclang.so",
+        "/usr/lib/llvm-16/lib/libclang.so",
+        "/usr/lib/libclang.so",
+        "/usr/local/lib/libclang.so",
+    ]
+    .map(PathBuf::from)
+    .to_vec()
+}
+
 pub fn find_in_paths(name: &OsStr, directories: &[PathBuf]) -> Option<PathBuf> {
     directories
         .iter()
@@ -16,4 +36,8 @@ pub fn find_in_paths(name: &OsStr, directories: &[PathBuf]) -> Option<PathBuf> {
 
 pub fn stem_matches(path: &OsStr, expected: &str) -> bool {
     std::path::Path::new(path).file_stem() == Some(OsStr::new(expected))
+}
+
+pub fn unlock_for_replacement(_: &std::path::Path) -> std::io::Result<bool> {
+    Ok(false)
 }

--- a/crates/zccache-platform/src/platform_linux/executable.rs
+++ b/crates/zccache-platform/src/platform_linux/executable.rs
@@ -1,0 +1,19 @@
+//! Linux executable naming and `PATH` lookup.
+
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+
+pub fn native_name(stem: &OsStr) -> OsString {
+    stem.to_os_string()
+}
+
+pub fn find_in_paths(name: &OsStr, directories: &[PathBuf]) -> Option<PathBuf> {
+    directories
+        .iter()
+        .map(|directory| directory.join(name))
+        .find(|candidate| candidate.is_file())
+}
+
+pub fn stem_matches(path: &OsStr, expected: &str) -> bool {
+    std::path::Path::new(path).file_stem() == Some(OsStr::new(expected))
+}

--- a/crates/zccache-platform/src/platform_linux/host.rs
+++ b/crates/zccache-platform/src/platform_linux/host.rs
@@ -1,13 +1,14 @@
 //! Linux host facts.
 
-use std::ffi::OsString;
 use std::path::PathBuf;
 
 pub const fn os() -> &'static str { std::env::consts::OS }
 pub const fn arch() -> &'static str { std::env::consts::ARCH }
 pub fn home_dir() -> Option<PathBuf> { std::env::var_os("HOME").map(PathBuf::from) }
-pub fn current_user() -> Option<OsString> { std::env::var_os("USER") }
+pub fn current_user() -> Option<String> { std::env::var("USER").ok() }
+pub fn runtime_dir() -> Option<String> { std::env::var("XDG_RUNTIME_DIR").ok() }
 pub const fn is_elevated() -> bool { true }
+pub const fn defender_supported() -> bool { false }
 
 pub fn cpu_identity_material() -> String {
     let mut material = format!("arch={}\0os={}", arch(), os());

--- a/crates/zccache-platform/src/platform_linux/host.rs
+++ b/crates/zccache-platform/src/platform_linux/host.rs
@@ -1,0 +1,48 @@
+//! Linux host facts.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+pub const fn os() -> &'static str { std::env::consts::OS }
+pub const fn arch() -> &'static str { std::env::consts::ARCH }
+pub fn home_dir() -> Option<PathBuf> { std::env::var_os("HOME").map(PathBuf::from) }
+pub fn current_user() -> Option<OsString> { std::env::var_os("USER") }
+pub const fn is_elevated() -> bool { true }
+
+pub fn cpu_identity_material() -> String {
+    let mut material = format!("arch={}\0os={}", arch(), os());
+    if let Ok(machine_id) = std::fs::read_to_string("/etc/machine-id") {
+        let machine_id = machine_id.trim();
+        if !machine_id.is_empty() { material.push_str("\0machine-id="); material.push_str(machine_id); }
+    }
+    append_host_or_pid(&mut material);
+    append_cpu_features(&mut material);
+    material
+}
+
+fn append_host_or_pid(material: &mut String) {
+    if let Some(name) = std::env::var_os("HOSTNAME") {
+        material.push_str("\0HOSTNAME="); material.push_str(&name.to_string_lossy());
+    } else if !material.contains("machine-id=") {
+        material.push_str("\0pid="); material.push_str(&std::process::id().to_string());
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn append_cpu_features(material: &mut String) {
+    for (name, present) in [("sse2", std::arch::is_x86_feature_detected!("sse2")), ("sse4.2", std::arch::is_x86_feature_detected!("sse4.2")), ("avx", std::arch::is_x86_feature_detected!("avx")), ("avx2", std::arch::is_x86_feature_detected!("avx2")), ("avx512f", std::arch::is_x86_feature_detected!("avx512f")), ("fma", std::arch::is_x86_feature_detected!("fma")), ("bmi1", std::arch::is_x86_feature_detected!("bmi1")), ("bmi2", std::arch::is_x86_feature_detected!("bmi2"))] {
+        if present { material.push_str("\0feature="); material.push_str(name); }
+    }
+}
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn append_cpu_features(_: &mut String) {}
+
+pub fn defender_exclusions() -> Result<Vec<PathBuf>, crate::host::DefenderError> {
+    Err(crate::host::DefenderError::Unsupported)
+}
+pub fn add_defender_exclusion(_: &std::path::Path) -> Result<(), crate::host::DefenderError> {
+    Err(crate::host::DefenderError::Unsupported)
+}
+pub fn remove_defender_exclusion(_: &std::path::Path) -> Result<(), crate::host::DefenderError> {
+    Err(crate::host::DefenderError::Unsupported)
+}

--- a/crates/zccache-platform/src/platform_linux/ipc/mod.rs
+++ b/crates/zccache-platform/src/platform_linux/ipc/mod.rs
@@ -11,7 +11,7 @@ pub use peer::PeerIdentity;
 pub use stream::Stream;
 
 pub fn current_user_name() -> Option<String> {
-    std::env::var("USER").ok()
+    super::host::current_user()
 }
 
 pub fn select_host_text(file_value: String, _windows_value: String) -> String {

--- a/crates/zccache-platform/src/platform_macos.rs
+++ b/crates/zccache-platform/src/platform_macos.rs
@@ -5,6 +5,8 @@
 //! where they share call sites. Populated per capability phase; empty until
 //! then.
 
+pub mod executable;
 pub mod fs;
+pub mod host;
 pub mod ipc;
 pub mod process;

--- a/crates/zccache-platform/src/platform_macos/executable.rs
+++ b/crates/zccache-platform/src/platform_macos/executable.rs
@@ -7,6 +7,24 @@ pub fn native_name(stem: &OsStr) -> OsString {
     stem.to_os_string()
 }
 
+pub fn native_library_name(stem: &OsStr) -> OsString {
+    let mut name = stem.to_os_string();
+    if std::path::Path::new(stem).extension().is_none() {
+        name.push(".dylib");
+    }
+    name
+}
+
+pub fn clang_library_candidates() -> Vec<PathBuf> {
+    [
+        "/opt/homebrew/opt/llvm/lib/libclang.dylib",
+        "/usr/local/opt/llvm/lib/libclang.dylib",
+        "/Library/Developer/CommandLineTools/usr/lib/libclang.dylib",
+    ]
+    .map(PathBuf::from)
+    .to_vec()
+}
+
 pub fn find_in_paths(name: &OsStr, directories: &[PathBuf]) -> Option<PathBuf> {
     directories
         .iter()
@@ -16,4 +34,8 @@ pub fn find_in_paths(name: &OsStr, directories: &[PathBuf]) -> Option<PathBuf> {
 
 pub fn stem_matches(path: &OsStr, expected: &str) -> bool {
     std::path::Path::new(path).file_stem() == Some(OsStr::new(expected))
+}
+
+pub fn unlock_for_replacement(_: &std::path::Path) -> std::io::Result<bool> {
+    Ok(false)
 }

--- a/crates/zccache-platform/src/platform_macos/executable.rs
+++ b/crates/zccache-platform/src/platform_macos/executable.rs
@@ -1,0 +1,19 @@
+//! macOS executable naming and `PATH` lookup.
+
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+
+pub fn native_name(stem: &OsStr) -> OsString {
+    stem.to_os_string()
+}
+
+pub fn find_in_paths(name: &OsStr, directories: &[PathBuf]) -> Option<PathBuf> {
+    directories
+        .iter()
+        .map(|directory| directory.join(name))
+        .find(|candidate| candidate.is_file())
+}
+
+pub fn stem_matches(path: &OsStr, expected: &str) -> bool {
+    std::path::Path::new(path).file_stem() == Some(OsStr::new(expected))
+}

--- a/crates/zccache-platform/src/platform_macos/host.rs
+++ b/crates/zccache-platform/src/platform_macos/host.rs
@@ -1,0 +1,40 @@
+//! macOS host facts.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+pub const fn os() -> &'static str { std::env::consts::OS }
+pub const fn arch() -> &'static str { std::env::consts::ARCH }
+pub fn home_dir() -> Option<PathBuf> { std::env::var_os("HOME").map(PathBuf::from) }
+pub fn current_user() -> Option<OsString> { std::env::var_os("USER") }
+pub const fn is_elevated() -> bool { true }
+
+pub fn cpu_identity_material() -> String {
+    let mut material = format!("arch={}\0os={}", arch(), os());
+    if let Some(name) = std::env::var_os("HOSTNAME") {
+        material.push_str("\0HOSTNAME="); material.push_str(&name.to_string_lossy());
+    } else {
+        material.push_str("\0pid="); material.push_str(&std::process::id().to_string());
+    }
+    append_cpu_features(&mut material);
+    material
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn append_cpu_features(material: &mut String) {
+    for (name, present) in [("sse2", std::arch::is_x86_feature_detected!("sse2")), ("sse4.2", std::arch::is_x86_feature_detected!("sse4.2")), ("avx", std::arch::is_x86_feature_detected!("avx")), ("avx2", std::arch::is_x86_feature_detected!("avx2")), ("avx512f", std::arch::is_x86_feature_detected!("avx512f")), ("fma", std::arch::is_x86_feature_detected!("fma")), ("bmi1", std::arch::is_x86_feature_detected!("bmi1")), ("bmi2", std::arch::is_x86_feature_detected!("bmi2"))] {
+        if present { material.push_str("\0feature="); material.push_str(name); }
+    }
+}
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn append_cpu_features(_: &mut String) {}
+
+pub fn defender_exclusions() -> Result<Vec<PathBuf>, crate::host::DefenderError> {
+    Err(crate::host::DefenderError::Unsupported)
+}
+pub fn add_defender_exclusion(_: &std::path::Path) -> Result<(), crate::host::DefenderError> {
+    Err(crate::host::DefenderError::Unsupported)
+}
+pub fn remove_defender_exclusion(_: &std::path::Path) -> Result<(), crate::host::DefenderError> {
+    Err(crate::host::DefenderError::Unsupported)
+}

--- a/crates/zccache-platform/src/platform_macos/host.rs
+++ b/crates/zccache-platform/src/platform_macos/host.rs
@@ -1,13 +1,14 @@
 //! macOS host facts.
 
-use std::ffi::OsString;
 use std::path::PathBuf;
 
 pub const fn os() -> &'static str { std::env::consts::OS }
 pub const fn arch() -> &'static str { std::env::consts::ARCH }
 pub fn home_dir() -> Option<PathBuf> { std::env::var_os("HOME").map(PathBuf::from) }
-pub fn current_user() -> Option<OsString> { std::env::var_os("USER") }
+pub fn current_user() -> Option<String> { std::env::var("USER").ok() }
+pub fn runtime_dir() -> Option<String> { std::env::var("XDG_RUNTIME_DIR").ok() }
 pub const fn is_elevated() -> bool { true }
+pub const fn defender_supported() -> bool { false }
 
 pub fn cpu_identity_material() -> String {
     let mut material = format!("arch={}\0os={}", arch(), os());

--- a/crates/zccache-platform/src/platform_macos/ipc/mod.rs
+++ b/crates/zccache-platform/src/platform_macos/ipc/mod.rs
@@ -10,5 +10,5 @@ pub use listener::Listener;
 pub use peer::PeerIdentity;
 pub use stream::Stream;
 
-pub fn current_user_name() -> Option<String> { std::env::var("USER").ok() }
+pub fn current_user_name() -> Option<String> { super::host::current_user() }
 pub fn select_host_text(file_value: String, _windows_value: String) -> String { file_value }

--- a/crates/zccache-platform/src/platform_win.rs
+++ b/crates/zccache-platform/src/platform_win.rs
@@ -4,6 +4,8 @@
 //! `windows-sys`) live here and in `platform_win/`. Populated per capability
 //! phase; empty until then.
 
+pub mod executable;
 pub mod fs;
+pub mod host;
 pub mod ipc;
 pub mod process;

--- a/crates/zccache-platform/src/platform_win/executable.rs
+++ b/crates/zccache-platform/src/platform_win/executable.rs
@@ -1,0 +1,49 @@
+//! Windows executable naming and `PATH`/`PATHEXT` lookup.
+
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+
+pub fn native_name(stem: &OsStr) -> OsString {
+    if std::path::Path::new(stem).extension().is_some() {
+        stem.to_os_string()
+    } else {
+        let mut name = stem.to_os_string();
+        name.push(".exe");
+        name
+    }
+}
+
+pub fn find_in_paths(name: &OsStr, directories: &[PathBuf]) -> Option<PathBuf> {
+    let path = std::path::Path::new(name);
+    let suffixes: Vec<OsString> = if path.extension().is_some() {
+        vec![OsString::new()]
+    } else {
+        std::env::var_os("PATHEXT")
+            .map(|value| {
+                value
+                    .to_string_lossy()
+                    .split(';')
+                    .filter(|suffix| !suffix.is_empty())
+                    .map(OsString::from)
+                    .collect()
+            })
+            .filter(|suffixes: &Vec<OsString>| !suffixes.is_empty())
+            .unwrap_or_else(|| [".COM", ".EXE", ".BAT", ".CMD"].map(OsString::from).to_vec())
+    };
+
+    directories.iter().find_map(|directory| {
+        suffixes.iter().find_map(|suffix| {
+            let mut candidate_name = name.to_os_string();
+            candidate_name.push(suffix);
+            let candidate = directory.join(candidate_name);
+            candidate.is_file().then_some(candidate)
+        })
+    })
+}
+
+pub fn stem_matches(path: &OsStr, expected: &str) -> bool {
+    std::path::Path::new(path)
+        .file_stem()
+        .and_then(OsStr::to_str)
+        .is_some_and(|stem| stem.eq_ignore_ascii_case(expected))
+}

--- a/crates/zccache-platform/src/platform_win/executable.rs
+++ b/crates/zccache-platform/src/platform_win/executable.rs
@@ -13,6 +13,24 @@ pub fn native_name(stem: &OsStr) -> OsString {
     }
 }
 
+pub fn native_library_name(stem: &OsStr) -> OsString {
+    let mut name = stem.to_os_string();
+    if std::path::Path::new(stem).extension().is_none() {
+        name.push(".dll");
+    }
+    name
+}
+
+pub fn clang_library_candidates() -> Vec<PathBuf> {
+    [
+        r"C:\Program Files\LLVM\bin\libclang.dll",
+        r"C:\Program Files\LLVM\lib\libclang.dll",
+        r"C:\Program Files\doxygen\bin\libclang.dll",
+    ]
+    .map(PathBuf::from)
+    .to_vec()
+}
+
 pub fn find_in_paths(name: &OsStr, directories: &[PathBuf]) -> Option<PathBuf> {
     let path = std::path::Path::new(name);
     let suffixes: Vec<OsString> = if path.extension().is_some() {
@@ -46,4 +64,16 @@ pub fn stem_matches(path: &OsStr, expected: &str) -> bool {
         .file_stem()
         .and_then(OsStr::to_str)
         .is_some_and(|stem| stem.eq_ignore_ascii_case(expected))
+}
+
+pub fn unlock_for_replacement(image: &std::path::Path) -> std::io::Result<bool> {
+    let nonce = std::process::id()
+        ^ std::time::UNIX_EPOCH
+            .elapsed()
+            .unwrap_or_default()
+            .subsec_nanos();
+    let retired = image.with_extension(format!("exe.old.{nonce}"));
+    std::fs::rename(image, &retired)?;
+    let _ = std::fs::copy(&retired, image);
+    Ok(true)
 }

--- a/crates/zccache-platform/src/platform_win/host.rs
+++ b/crates/zccache-platform/src/platform_win/host.rs
@@ -1,0 +1,121 @@
+//! Windows host facts and privilege probes.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+pub const fn os() -> &'static str { std::env::consts::OS }
+pub const fn arch() -> &'static str { std::env::consts::ARCH }
+
+pub fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+pub fn current_user() -> Option<OsString> {
+    std::env::var_os("USERNAME")
+}
+
+pub fn cpu_identity_material() -> String {
+    let mut material = format!("arch={}\0os={}", arch(), os());
+    if let Some(name) = std::env::var_os("COMPUTERNAME") {
+        material.push_str("\0COMPUTERNAME=");
+        material.push_str(&name.to_string_lossy());
+    } else {
+        material.push_str("\0pid=");
+        material.push_str(&std::process::id().to_string());
+    }
+    append_cpu_features(&mut material);
+    material
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn append_cpu_features(material: &mut String) {
+    for (name, present) in [
+        ("sse2", std::arch::is_x86_feature_detected!("sse2")),
+        ("sse4.2", std::arch::is_x86_feature_detected!("sse4.2")),
+        ("avx", std::arch::is_x86_feature_detected!("avx")),
+        ("avx2", std::arch::is_x86_feature_detected!("avx2")),
+        ("avx512f", std::arch::is_x86_feature_detected!("avx512f")),
+        ("fma", std::arch::is_x86_feature_detected!("fma")),
+        ("bmi1", std::arch::is_x86_feature_detected!("bmi1")),
+        ("bmi2", std::arch::is_x86_feature_detected!("bmi2")),
+    ] {
+        if present { material.push_str("\0feature="); material.push_str(name); }
+    }
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn append_cpu_features(_: &mut String) {}
+
+pub fn is_elevated() -> bool {
+    use std::mem::size_of;
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows_sys::Win32::Security::{GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY};
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+    unsafe {
+        let mut token: HANDLE = std::ptr::null_mut();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 { return false; }
+        let mut elevation = TOKEN_ELEVATION { TokenIsElevated: 0 };
+        let mut returned = 0;
+        #[allow(clippy::cast_possible_truncation)]
+        let ok = GetTokenInformation(token, TokenElevation, (&raw mut elevation).cast(), size_of::<TOKEN_ELEVATION>() as u32, &mut returned);
+        CloseHandle(token);
+        ok != 0 && elevation.TokenIsElevated != 0
+    }
+}
+
+pub fn defender_exclusions() -> Result<Vec<PathBuf>, crate::host::DefenderError> {
+    let raw = run_powershell(&[
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "(Get-MpPreference).ExclusionPath",
+    ])?;
+    Ok(raw
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(PathBuf::from)
+        .collect())
+}
+
+pub fn add_defender_exclusion(path: &std::path::Path) -> Result<(), crate::host::DefenderError> {
+    mutate_defender("Add-MpPreference", path)
+}
+
+pub fn remove_defender_exclusion(path: &std::path::Path) -> Result<(), crate::host::DefenderError> {
+    mutate_defender("Remove-MpPreference", path)
+}
+
+fn mutate_defender(command: &str, path: &std::path::Path) -> Result<(), crate::host::DefenderError> {
+    let quoted = format!("'{}'", path.to_string_lossy().replace('\'', "''"));
+    run_powershell(&[
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        &format!("{command} -ExclusionPath {quoted}"),
+    ])?;
+    Ok(())
+}
+
+fn run_powershell(args: &[&str]) -> Result<String, crate::host::DefenderError> {
+    let output = std::process::Command::new("powershell.exe")
+        .args(args)
+        .output()
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                crate::host::DefenderError::PowerShellNotFound
+            } else {
+                crate::host::DefenderError::Io(error)
+            }
+        })?;
+    if !output.status.success() {
+        return Err(crate::host::DefenderError::CommandFailed {
+            exit_code: output.status.code(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        });
+    }
+    String::from_utf8(output.stdout)
+        .map_err(|error| crate::host::DefenderError::OutputParse(error.to_string()))
+}

--- a/crates/zccache-platform/src/platform_win/host.rs
+++ b/crates/zccache-platform/src/platform_win/host.rs
@@ -1,6 +1,5 @@
 //! Windows host facts and privilege probes.
 
-use std::ffi::OsString;
 use std::path::PathBuf;
 
 pub const fn os() -> &'static str { std::env::consts::OS }
@@ -12,8 +11,12 @@ pub fn home_dir() -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
-pub fn current_user() -> Option<OsString> {
-    std::env::var_os("USERNAME")
+pub fn current_user() -> Option<String> {
+    std::env::var("USERNAME").ok()
+}
+
+pub fn runtime_dir() -> Option<String> {
+    None
 }
 
 pub fn cpu_identity_material() -> String {
@@ -63,6 +66,10 @@ pub fn is_elevated() -> bool {
         CloseHandle(token);
         ok != 0 && elevation.TokenIsElevated != 0
     }
+}
+
+pub const fn defender_supported() -> bool {
+    true
 }
 
 pub fn defender_exclusions() -> Result<Vec<PathBuf>, crate::host::DefenderError> {

--- a/crates/zccache-platform/src/platform_win/ipc/mod.rs
+++ b/crates/zccache-platform/src/platform_win/ipc/mod.rs
@@ -11,5 +11,5 @@ pub use listener::Listener;
 pub use peer::PeerIdentity;
 pub use stream::Stream;
 
-pub fn current_user_name() -> Option<String> { std::env::var("USERNAME").ok() }
+pub fn current_user_name() -> Option<String> { super::host::current_user() }
 pub fn select_host_text(_file_value: String, windows_value: String) -> String { windows_value }

--- a/dylints/enforce_platform_boundary/Cargo.toml
+++ b/dylints/enforce_platform_boundary/Cargo.toml
@@ -3,7 +3,7 @@
 # compiled-library cache on this manifest, not on the embedded baseline, so a
 # baseline edit without a version bump would keep running the stale library.
 name = "enforce_platform_boundary"
-version = "0.1.7"
+version = "0.1.8"
 description = "Confine host-platform selection and native APIs to the zccache-platform leaf crate"
 edition = "2021"
 publish = false

--- a/dylints/enforce_platform_boundary/Cargo.toml
+++ b/dylints/enforce_platform_boundary/Cargo.toml
@@ -3,7 +3,7 @@
 # compiled-library cache on this manifest, not on the embedded baseline, so a
 # baseline edit without a version bump would keep running the stale library.
 name = "enforce_platform_boundary"
-version = "0.1.8"
+version = "0.1.10"
 description = "Confine host-platform selection and native APIs to the zccache-platform leaf crate"
 edition = "2021"
 publish = false

--- a/dylints/enforce_platform_boundary/src/baseline.txt
+++ b/dylints/enforce_platform_boundary/src/baseline.txt
@@ -6,20 +6,12 @@
 # occurrences fail the lint; stale entries (their occurrence migrated away)
 # fail the lint at runtime. No wildcard, directory, crate, or file exemptions.
 # Generated via ZCCACHE_PLATFORM_BOUNDARY_DUMP_DIR (see lint README).
-# total = 106
+# total = 97
 crates/zccache-artifact/src/kv.rs	attr_cfg	windows	0
 crates/zccache-artifact/src/kv.rs	attr_cfg	windows	1
 crates/zccache-artifact/src/kv.rs	attr_cfg	windows	2
 crates/zccache-artifact/src/kv.rs	attr_cfg	windows	3
 crates/zccache-artifact/src/kv.rs	attr_cfg	windows	4
-crates/zccache-compiler/src/arduino.rs	attr_cfg	target_os	0
-crates/zccache-compiler/src/arduino.rs	attr_cfg	target_os	1
-crates/zccache-compiler/src/arduino.rs	attr_cfg	target_os	2
-crates/zccache-compiler/src/arduino.rs	attr_cfg	target_os	3
-crates/zccache-compiler/src/arduino.rs	attr_cfg	unix	0
-crates/zccache-compiler/src/arduino.rs	attr_cfg	unix	1
-crates/zccache-compiler/src/arduino.rs	attr_cfg	windows	0
-crates/zccache-compiler/src/arduino.rs	attr_cfg	windows	1
 crates/zccache-compiler/src/parse.rs	attr_cfg	windows	0
 crates/zccache-compiler/src/parse.rs	attr_cfg	windows	1
 crates/zccache-compiler/src/parse_rustc.rs	cfg_macro	target_os	0
@@ -95,7 +87,6 @@ crates/zccache-daemon-core/src/daemon/server/util.rs	native_import	std::os::wind
 crates/zccache-daemon-core/src/daemon/server/util.rs	native_import	std::os::windows	3
 crates/zccache-daemon-core/src/daemon/server/watch.rs	attr_cfg	windows	0
 crates/zccache-daemon-core/src/daemon/server/watch.rs	attr_cfg	windows	1
-crates/zccache-daemon-core/src/daemon/trampoline.rs	cfg_macro	target_os	0
 crates/zccache-depgraph/src/depfile/canonicalize.rs	attr_cfg	windows	0
 crates/zccache-depgraph/src/msvc_args.rs	attr_cfg	windows	0
 crates/zccache-depgraph/src/msvc_args.rs	attr_cfg	windows	1

--- a/dylints/enforce_platform_boundary/src/baseline.txt
+++ b/dylints/enforce_platform_boundary/src/baseline.txt
@@ -6,7 +6,7 @@
 # occurrences fail the lint; stale entries (their occurrence migrated away)
 # fail the lint at runtime. No wildcard, directory, crate, or file exemptions.
 # Generated via ZCCACHE_PLATFORM_BOUNDARY_DUMP_DIR (see lint README).
-# total = 127
+# total = 106
 crates/zccache-artifact/src/kv.rs	attr_cfg	windows	0
 crates/zccache-artifact/src/kv.rs	attr_cfg	windows	1
 crates/zccache-artifact/src/kv.rs	attr_cfg	windows	2
@@ -36,22 +36,6 @@ crates/zccache-compiler/src/response_file.rs	attr_cfg	windows	5
 crates/zccache-compiler/src/response_file.rs	attr_cfg	windows	6
 crates/zccache-core/src/config/namespace.rs	cfg_macro	windows	0
 crates/zccache-core/src/config/resolve.rs	cfg_macro	windows	0
-crates/zccache-core/src/defender.rs	attr_cfg	windows	0
-crates/zccache-core/src/defender.rs	attr_cfg	windows	1
-crates/zccache-core/src/defender.rs	attr_cfg	windows	2
-crates/zccache-core/src/defender.rs	attr_cfg	windows	3
-crates/zccache-core/src/defender.rs	attr_cfg	windows	4
-crates/zccache-core/src/defender.rs	attr_cfg	windows	5
-crates/zccache-core/src/defender.rs	attr_cfg	windows	6
-crates/zccache-core/src/defender.rs	attr_cfg	windows	7
-crates/zccache-core/src/defender.rs	attr_cfg	windows	8
-crates/zccache-core/src/defender.rs	cfg_macro	windows	0
-crates/zccache-core/src/defender.rs	native_import	windows_sys	0
-crates/zccache-core/src/defender.rs	native_import	windows_sys	1
-crates/zccache-core/src/defender.rs	native_import	windows_sys	2
-crates/zccache-core/src/defender.rs	native_import	windows_sys	3
-crates/zccache-core/src/defender.rs	native_import	windows_sys	4
-crates/zccache-core/src/defender.rs	native_import	windows_sys	5
 crates/zccache-core/src/lifecycle.rs	attr_cfg	windows	0
 crates/zccache-core/src/lifecycle.rs	native_import	std::os::windows	0
 crates/zccache-core/src/lifecycle.rs	native_import	std::os::windows	1
@@ -117,11 +101,6 @@ crates/zccache-depgraph/src/msvc_args.rs	attr_cfg	windows	0
 crates/zccache-depgraph/src/msvc_args.rs	attr_cfg	windows	1
 crates/zccache-depgraph/src/msvc_args.rs	attr_cfg	windows	2
 crates/zccache-depgraph/src/msvc_args.rs	attr_cfg	windows	3
-crates/zccache-depgraph/src/native_cpu.rs	attr_cfg	target_arch	0
-crates/zccache-depgraph/src/native_cpu.rs	attr_cfg	target_arch	1
-crates/zccache-depgraph/src/native_cpu.rs	attr_cfg	target_arch	2
-crates/zccache-depgraph/src/native_cpu.rs	attr_cfg	target_arch	3
-crates/zccache-depgraph/src/native_cpu.rs	attr_cfg	target_os	0
 crates/zccache-depgraph/src/scanner.rs	attr_cfg	windows	0
 crates/zccache-depgraph/src/show_includes.rs	attr_cfg	windows	0
 crates/zccache-depgraph/src/show_includes.rs	attr_cfg	windows	1

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -82,11 +82,13 @@ defender.rs elevation + Defender primitives, path/env OS facts, home/runtime dir
 
 RED (2026-08-13): focused platform compilation failed with nine missing concrete
 `executable`/`host` backend references after adding neutral characterization tests first.
-GREEN checkpoint: all three private host trees now implement executable naming/search/stem
-comparison and host identity/home/user/elevation/resource facts; Windows Defender command
-mechanics moved into the concrete Windows host tree while core retains product errors and UX.
+GREEN checkpoint: all three private host trees now implement executable naming/search/stem,
+shared-library candidates, running-image replacement, and host OS/arch/home/runtime/user/
+elevation/resource facts. Windows Defender command mechanics moved into the concrete Windows
+host tree while core retains product errors and UX.
 Platform/core/depgraph tests and CLI-core all-feature/all-target checks pass on Windows. The
-exact-occurrence baseline fell from 127 to 106 after migrating Defender and native CPU inputs.
+exact-occurrence baseline fell from 127 to 97 after migrating Defender, native CPU inputs,
+libclang discovery, and executable replacement.
 
 ## Phase 6 (create #1371 sub-issue) plan — zero baseline
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -8,8 +8,8 @@ Parent: https://github.com/zackees/zccache/issues/1365 — 6 phase sub-issues (#
 - [x] Phase 1 (#1366): PR #1370 merged.
 - [x] Phase 2 (#1367): PR #1371 merged; corrective PR #1373 merged green.
 - [~] Phase 3 (#1368): platform::ipc — implementation, local gates, and pre-push review complete. PR will close #1368.
-- [ ] Phase 4 (#1369): platform::process — command/spawn/priority/inspect/terminate/stdio/jobserver/exit; keep watchdog/priority/jobserver policy; coordinate #1360; files <1000 LOC. PR closes #1369.
-- [ ] Phase 5 (create #1370): platform::executable + platform::host (deploy.rs, suffixes/PATH, image lookup, defender, elevation, native_cpu, resource probes).
+- [~] Phase 4 (#1369): platform::process — checkpoint PR #1377 merged into the Phase 3 branch; PR #1375 is undergoing CI repair before merge to main.
+- [~] Phase 5 (#1378): platform::executable + platform::host (deploy.rs, suffixes/PATH, image lookup, defender, elevation, native_cpu, resource probes).
 - [ ] Phase 6 (create #1371): delete baseline at zero; Linux-hosted --target windows regression; libc/windows-sys confined; publish crate self-contained; RED→GREEN evidence; #1365 auto-closes.
 - [ ] Finish: git status clean; local repo back on `refactor/platform/phase2-fs` rebased to final main.
 
@@ -75,10 +75,18 @@ The two touched oversized production files were split without moving product pol
 `process.rs` is 721 lines and `child_watchdog.rs` is 696 lines; their existing test modules
 now live in purpose-named sibling `_tests.rs` files.
 
-## Phase 5 (create #1370 sub-issue) plan — platform::executable + platform::host
+## Phase 5 (#1378) plan — platform::executable + platform::host
 
 executable: deploy.rs suffixes/PATH/PATHEXT/image lookup/unlock_exe. host: native_cpu.rs,
 defender.rs elevation + Defender primitives, path/env OS facts, home/runtime dirs, resource probes.
+
+RED (2026-08-13): focused platform compilation failed with nine missing concrete
+`executable`/`host` backend references after adding neutral characterization tests first.
+GREEN checkpoint: all three private host trees now implement executable naming/search/stem
+comparison and host identity/home/user/elevation/resource facts; Windows Defender command
+mechanics moved into the concrete Windows host tree while core retains product errors and UX.
+Platform/core/depgraph tests and CLI-core all-feature/all-target checks pass on Windows. The
+exact-occurrence baseline fell from 127 to 106 after migrating Defender and native CPU inputs.
 
 ## Phase 6 (create #1371 sub-issue) plan — zero baseline
 


### PR DESCRIPTION
## Summary
- add neutral executable and host platform facades
- move executable replacement, discovery, user/runtime, CPU, elevation, and Defender facts into concrete platform backends
- route production callers through the platform facade and reduce the boundary baseline from 127 to 97

Closes #1378

## Validation
- platform facade RED then GREEN tests
- focused crate tests for platform, core, depgraph, compiler, IPC, CLI, and daemon
- warnings-denied clippy across affected crates
- Windows all-feature checks
- Linux and macOS cross-target checks for platform and compiler

Checkpoint merge requested without waiting for CI.