### PR TITLE
Fix post-platform Perf Guard regressions

### DIFF
--- a/ci/perf_standalone.py
+++ b/ci/perf_standalone.py
@@ -29,7 +29,7 @@ BUILD_VOLUMES = {
     "zccache-standalone-artifacts": "/artifacts",
 }
 TOOL_VERSION_MARKERS = {
-    "rustc": "rustc 1.94.1",
+    "rustc": "rustc 1.95.0",
     "clang": "clang version 14.",
     "sccache": "sccache 0.10.0",
     "emscripten": "3.1.74",

--- a/ci/tests/test_perf_embedded.py
+++ b/ci/tests/test_perf_embedded.py
@@ -72,7 +72,7 @@ def _result(language: str) -> dict:
         "host_fingerprint": "f" * 64,
         "tool_versions": {
             "soldr": "soldr 0.8.16",
-            "rustc": "rustc 1.94.1",
+            "rustc": "rustc 1.95.0",
             "clang": "clang version 14.0.0",
             "emscripten": "3.1.74",
         },

--- a/ci/tests/test_perf_standalone.py
+++ b/ci/tests/test_perf_standalone.py
@@ -59,7 +59,7 @@ def test_docker_command_uses_read_only_source_and_named_build_volumes(tmp_path):
 
 def test_pinned_tool_versions_are_required():
     versions = {
-        "rustc": "rustc 1.94.1 (fake)",
+        "rustc": "rustc 1.95.0 (fake)",
         "clang": "Ubuntu clang version 14.0.0",
         "sccache": "sccache 0.10.0",
         "emscripten": "emcc 3.1.74",

--- a/crates/zccache-platform/src/platform/host.rs
+++ b/crates/zccache-platform/src/platform/host.rs
@@ -29,20 +29,20 @@ pub fn arch() -> &'static str {
 
 /// Whether this process is running on Windows.
 #[must_use]
-pub fn is_windows() -> bool {
-    os() == "windows"
+pub const fn is_windows() -> bool {
+    cfg!(windows)
 }
 
 /// Whether this process is running on macOS.
 #[must_use]
-pub fn is_macos() -> bool {
-    os() == "macos"
+pub const fn is_macos() -> bool {
+    cfg!(target_os = "macos")
 }
 
 /// Whether this process is running on Linux.
 #[must_use]
-pub fn is_linux() -> bool {
-    os() == "linux"
+pub const fn is_linux() -> bool {
+    cfg!(target_os = "linux")
 }
 
 /// Best-effort current user's home directory.
@@ -115,5 +115,8 @@ mod tests {
         assert!(!cpu_identity_material().is_empty());
         assert_eq!(cpu_identity_material(), cpu_identity_material());
         assert!(available_parallelism().is_some_and(|value| value >= 1));
+        assert_eq!(is_windows(), os() == "windows");
+        assert_eq!(is_macos(), os() == "macos");
+        assert_eq!(is_linux(), os() == "linux");
     }
 }


### PR DESCRIPTION
## Summary
- make neutral host OS predicates compile-time constants to remove repeated runtime string-comparison overhead from compiler hot paths
- align the standalone perf harness Rust marker and fixtures with the repo-pinned Rust 1.95.0 toolchain

## Evidence
- Perf Guard rerun: Rust workspace-link and all C++ scenarios passed; repeatable cold margins isolated to C and Rust check
- soldr cargo fmt --all -- --check`n- soldr cargo test -p zccache-platform host::tests::host_identity_facts_are_present_and_stable (with documented SOLDR_RUSTC_WRAPPER=none after broker route failure)
- soldr cargo check --workspace --all-targets (same diagnostic wrapper bypass)
- uv run --no-project pytest ci/tests/test_perf_standalone.py ci/tests/test_perf_embedded.py with repo PYTHONPATH: 31 passed
- clud-review: clean

## Local perf infrastructure
The corrected harness reaches runtime verification, but the local runtime image reports ustc not found; the sample is rejected rather than treated as performance evidence.