### PR TITLE
Fix platform-boundary Dylint errors

### DIFF
--- a/crates/zccache-platform/src/platform/host.rs
+++ b/crates/zccache-platform/src/platform/host.rs
@@ -30,19 +30,19 @@ pub fn arch() -> &'static str {
 /// Whether this process is running on Windows.
 #[must_use]
 pub const fn is_windows() -> bool {
-    cfg!(windows)
+    crate::platform_imp::host::IS_WINDOWS
 }
 
 /// Whether this process is running on macOS.
 #[must_use]
 pub const fn is_macos() -> bool {
-    cfg!(target_os = "macos")
+    crate::platform_imp::host::IS_MACOS
 }
 
 /// Whether this process is running on Linux.
 #[must_use]
 pub const fn is_linux() -> bool {
-    cfg!(target_os = "linux")
+    crate::platform_imp::host::IS_LINUX
 }
 
 /// Best-effort current user's home directory.

--- a/crates/zccache-platform/src/platform_linux/host.rs
+++ b/crates/zccache-platform/src/platform_linux/host.rs
@@ -2,6 +2,10 @@
 
 use std::path::PathBuf;
 
+pub const IS_WINDOWS: bool = false;
+pub const IS_MACOS: bool = false;
+pub const IS_LINUX: bool = true;
+
 pub const fn os() -> &'static str { std::env::consts::OS }
 pub const fn arch() -> &'static str { std::env::consts::ARCH }
 pub fn home_dir() -> Option<PathBuf> { std::env::var_os("HOME").map(PathBuf::from) }

--- a/crates/zccache-platform/src/platform_macos/host.rs
+++ b/crates/zccache-platform/src/platform_macos/host.rs
@@ -2,6 +2,10 @@
 
 use std::path::PathBuf;
 
+pub const IS_WINDOWS: bool = false;
+pub const IS_MACOS: bool = true;
+pub const IS_LINUX: bool = false;
+
 pub const fn os() -> &'static str { std::env::consts::OS }
 pub const fn arch() -> &'static str { std::env::consts::ARCH }
 pub fn home_dir() -> Option<PathBuf> { std::env::var_os("HOME").map(PathBuf::from) }

--- a/crates/zccache-platform/src/platform_win/host.rs
+++ b/crates/zccache-platform/src/platform_win/host.rs
@@ -2,6 +2,10 @@
 
 use std::path::PathBuf;
 
+pub const IS_WINDOWS: bool = true;
+pub const IS_MACOS: bool = false;
+pub const IS_LINUX: bool = false;
+
 pub const fn os() -> &'static str { std::env::consts::OS }
 pub const fn arch() -> &'static str { std::env::consts::ARCH }
 


### PR DESCRIPTION
## Summary
- keep neutral host predicates const without using forbidden cfg! outside the platform selector
- define one-hot host facts in each selected platform implementation

## Validation
- focused zccache-platform host test passes
- format and diff checks pass
- clud-review: clean
- directly fixes all three enforce_platform_boundary diagnostics from main CI

The local Linux container installed the pinned nightly but hit a soldr/rustup home-layout infrastructure error before Dylint invocation; main CI is the authoritative Linux gate.