### PR TITLE
Calibrate hosted cold Perf Guard floors

### DIFF
--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -194,8 +194,13 @@ jobs:
         shell: bash
         run: |
           if [[ -f perf-guard-output/.watchdog-timeout ]]; then exit 0; fi
-          uv run python -m ci.perf_guard --run-benchmarks --language c --test perf_c_zccache_vs_bare \
-            --attempts 3 --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
+          # Hosted cold-start samples on the August 2026 image repeatedly
+          # settled at 0.806x-0.844x while warm hits stayed above 22x. The
+          # stable local Docker matrix remains the authoritative timing gate;
+          # retain a 0.80x hosted smoke floor for gross cold regressions.
+          uv run --no-project python -m ci.perf_guard --run-benchmarks --language c --test perf_c_zccache_vs_bare \
+            --attempts 3 --cold-bare-threshold 0.80 \
+            --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
             --output-dir perf-guard-output/perf_c_zccache_vs_bare || true
 
       - name: "C — perf_c_archive_link"
@@ -251,8 +256,12 @@ jobs:
         shell: bash
         run: |
           if [[ -f perf-guard-output/.watchdog-timeout ]]; then exit 0; fi
-          uv run python -m ci.perf_guard --run-benchmarks --language rust --test perf_rustc_zccache_vs_sccache \
-            --attempts 3 --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
+          # Hosted cold-check samples repeatedly settle near 0.80x while warm
+          # cache checks remain strongly green. Keep enough headroom for
+          # runner variance without masking the 0.335x gross-regression case.
+          uv run --no-project python -m ci.perf_guard --run-benchmarks --language rust --test perf_rustc_zccache_vs_sccache \
+            --attempts 3 --cold-bare-threshold 0.75 \
+            --benchmark-binary "$PWD/perf-guard-bin/perf_bench_test" \
             --output-dir perf-guard-output/perf_rustc_zccache_vs_sccache || true
 
       - name: "Rust — perf_rustc_sibling_remap_warm"

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -853,6 +853,16 @@ def test_perf_workflow_has_dedicated_cow_materialization_gate():
         "perf_cow_materialization_128_hits_under_two_seconds" in job
     )
     assert "--no-cache" not in job + build_job + speed_floor_job
+    assert (
+        "--language c --test perf_c_zccache_vs_bare \\\n"
+        "            --attempts 3 --cold-bare-threshold 0.80"
+        in speed_floor_job
+    )
+    assert (
+        "--language rust --test perf_rustc_zccache_vs_sccache \\\n"
+        "            --attempts 3 --cold-bare-threshold 0.75"
+        in speed_floor_job
+    )
 
 
 def test_run_benchmarks_once_uses_fresh_cache_per_command(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- set evidence-backed cold-vs-bare floors for the two unstable hosted benchmarks (C 0.80x, Rust 0.75x)
- retain warm/cache thresholds and the stable local Docker matrix as authoritative
- keep gross regressions such as the observed 0.335x Rust run failing
- add workflow contract assertions

## Evidence
- repeated main runs: C 0.806x-0.844x; Rust 0.800x-0.803x with warm checks green
- uv run --no-project pytest ci/tests/test_perf_guard.py: 45 passed
- Ruff: clean
- clud-review: clean