### PR TITLE
Release 1.13.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.1"
+version = "1.13.2"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Release
- bump workspace version from 1.13.1 to 1.13.2
- includes the platform-boundary Dylint fix and hosted Perf Guard calibration

## Validation
- full main CI/Dylint: green
- C and Rust calibrated Perf Guard jobs: green; C++ active after its response-file scenario passed
- release metadata validation: passed
- no local/remote 1.13.2 or v1.13.2 tag
- no existing GitHub 1.13.2 release
- locked Cargo metadata resolves all workspace crates as 1.13.2
- clud-review: clean