### PR TITLE
Fix crates.io packaging and release 1.13.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.2"
+version = "1.13.3"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/ci/tests/test_publish_amalgamate.py
+++ b/ci/tests/test_publish_amalgamate.py
@@ -231,6 +231,34 @@ sha2 = { workspace = true, optional = true }
     )
 
 
+def test_public_crate_matches_platform_native_dependencies() -> None:
+    root = Path(__file__).parents[2]
+    public_manifest = tomllib.loads(
+        (root / "crates" / "zccache" / "Cargo.toml").read_text(encoding="utf-8")
+    )
+    platform_manifest = tomllib.loads(
+        (root / "crates" / "zccache-platform" / "Cargo.toml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    for target in ("cfg(unix)", "cfg(windows)"):
+        assert public_manifest["target"][target]["dependencies"] == (
+            platform_manifest["target"][target]["dependencies"]
+        )
+
+
+def test_platform_host_modules_can_be_reexported_after_amalgamation() -> None:
+    root = Path(__file__).parents[2]
+    platform_lib = (
+        root / "crates" / "zccache-platform" / "src" / "lib.rs"
+    ).read_text(encoding="utf-8")
+
+    assert "pub(crate) mod platform_win;" in platform_lib
+    assert "pub(crate) mod platform_linux;" in platform_lib
+    assert "pub(crate) mod platform_macos;" in platform_lib
+
+
 def test_platform_module_is_declared_as_a_private_root_module() -> None:
     platform = next(
         module for module in INTERNAL_MODULES if module.crate == "zccache-platform"

--- a/crates/zccache-platform/src/lib.rs
+++ b/crates/zccache-platform/src/lib.rs
@@ -17,17 +17,17 @@ pub use platform::{executable, fs, host, ipc, process};
 // arm's alias is allowed to be unused.
 cfg_select! {
     target_os = "windows" => {
-        mod platform_win;
+        pub(crate) mod platform_win;
         #[allow(unused_imports)]
         pub(crate) use platform_win as platform_imp;
     }
     target_os = "linux" => {
-        mod platform_linux;
+        pub(crate) mod platform_linux;
         #[allow(unused_imports)]
         pub(crate) use platform_linux as platform_imp;
     }
     target_os = "macos" => {
-        mod platform_macos;
+        pub(crate) mod platform_macos;
         #[allow(unused_imports)]
         pub(crate) use platform_macos as platform_imp;
     }

--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -200,8 +200,21 @@ zccache = { path = ".", features = ["test-support"] }
 # so it does not bloat production builds.
 tokio = { workspace = true, features = ["test-util"] }
 
-[target.'cfg(unix)'.dev-dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+    "Win32_System_Ioctl",
+    "Win32_System_JobObjects",
+    "Win32_System_Console",
+    "Win32_System_Threading",
+] }
 
 [[bench]]
 name = "hashing"


### PR DESCRIPTION
Fixes the crates.io publish failure from 1.13.2 by preserving the amalgamated platform crate's native dependencies and making selected host modules visible to sibling facades after amalgamation. Adds exact dependency-parity regression coverage and bumps the release to 1.13.3.\n\nValidation: 10 focused packaging tests; 16 release tests (1 expected skip); zccache-platform check; fmt; diff check; clud-review clean.