### PR TITLE
Fix release package warnings and publish 1.13.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.3"
+version = "1.13.4"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/ci/publish_amalgamate.py
+++ b/ci/publish_amalgamate.py
@@ -58,7 +58,11 @@ INTERNAL_MODULES: tuple[AmalgamatedModule, ...] = (
     AmalgamatedModule("zccache-ipc", "ipc", "pub mod ipc;"),
     # zccache#1365 — the host-platform leaf is internal machinery, copied as a
     # private root module (never a public crates.io API).
-    AmalgamatedModule("zccache-platform", "platform", "mod platform;"),
+    AmalgamatedModule(
+        "zccache-platform",
+        "platform",
+        "#[allow(dead_code)]\nmod platform;",
+    ),
     AmalgamatedModule("zccache-protocol", "protocol", "pub mod protocol;"),
     AmalgamatedModule(
         "zccache-symbols",

--- a/ci/tests/test_publish_amalgamate.py
+++ b/ci/tests/test_publish_amalgamate.py
@@ -265,7 +265,9 @@ def test_platform_module_is_declared_as_a_private_root_module() -> None:
     )
     assert platform.module == "platform"
     # The platform leaf is internal machinery, not a public crates.io API.
-    assert platform.declaration == "mod platform;"
+    # The amalgamated module is private, so platform primitives unused by the
+    # public crate would otherwise fail release packaging under `-D warnings`.
+    assert platform.declaration == "#[allow(dead_code)]\nmod platform;"
     assert platform.drop_python_bindings is False
 
 


### PR DESCRIPTION
The 1.13.3 crates.io verification passed the native dependency and visibility fixes, then failed because intentionally unused APIs in the private amalgamated platform module are denied by release RUSTFLAGS=-D warnings. Scope allow(dead_code) to that generated private module, preserve warnings elsewhere, update the contract test, and bump to 1.13.4.\n\nValidation: 16 release tests passed (1 expected skip), fmt, diff check, release metadata validation, clud-review clean.