### PR TITLE
Fix final release package warning and publish 1.13.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.4"
+version = "1.13.5"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/ci/publish_amalgamate.py
+++ b/ci/publish_amalgamate.py
@@ -61,7 +61,7 @@ INTERNAL_MODULES: tuple[AmalgamatedModule, ...] = (
     AmalgamatedModule(
         "zccache-platform",
         "platform",
-        "#[allow(dead_code)]\nmod platform;",
+        "#[allow(dead_code, unused_imports)]\nmod platform;",
     ),
     AmalgamatedModule("zccache-protocol", "protocol", "pub mod protocol;"),
     AmalgamatedModule(

--- a/ci/tests/test_publish_amalgamate.py
+++ b/ci/tests/test_publish_amalgamate.py
@@ -267,7 +267,9 @@ def test_platform_module_is_declared_as_a_private_root_module() -> None:
     # The platform leaf is internal machinery, not a public crates.io API.
     # The amalgamated module is private, so platform primitives unused by the
     # public crate would otherwise fail release packaging under `-D warnings`.
-    assert platform.declaration == "#[allow(dead_code)]\nmod platform;"
+    assert platform.declaration == (
+        "#[allow(dead_code, unused_imports)]\nmod platform;"
+    )
     assert platform.drop_python_bindings is False
 
 


### PR DESCRIPTION
The 1.13.4 crates.io verification passed the prior native dependency, visibility, and dead-code gates, then failed on one unused re-export inside the same intentionally private amalgamated platform subtree. Extend the generated module-scoped allowance to unused_imports, keep warnings enforced everywhere else, update the exact declaration contract, and bump to 1.13.5.\n\nValidation: 16 release tests passed (1 expected skip), fmt, diff check, release metadata validation, clud-review clean. A disposable Linux package reproduction was prepared, but Docker doctor classified the local engine as unavailable and restart is confirmation-gated.