### PR TITLE
feat(daemon): durability + identity for restart-warmth (soldr#2436 phase 5)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/compile_journal/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/mod.rs
@@ -153,6 +153,23 @@ fn miss_reason_priority(reason: &str) -> u8 {
     }
 }
 
+/// zackees/soldr#2436 D4: the identity stamped into every journal row.
+///
+/// First-set wins: the embedded host (soldr-daemon) calls
+/// [`set_daemon_generation`] with its route-generation identity before the
+/// first compile; a standalone daemon that never does mints a per-process
+/// UUID lazily so rows are still attributable across restarts.
+static DAEMON_GENERATION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+/// Set the generation identity journal rows carry. No-op after first use.
+pub fn set_daemon_generation(value: String) {
+    let _ = DAEMON_GENERATION.set(value);
+}
+
+fn daemon_generation() -> &'static str {
+    DAEMON_GENERATION.get_or_init(|| uuid::Uuid::new_v4().to_string())
+}
+
 /// A single journal entry serialized as one JSON line.
 ///
 /// The fields below the legacy block are populated only when `--profile`
@@ -178,6 +195,14 @@ pub struct JournalEntry {
     pub exit_code: i32,
     /// Session UUID or null for ephemeral.
     pub session_id: Option<String>,
+    /// zackees/soldr#2436 D4: which daemon process generation served this
+    /// compile. Restart-warmth analysis needs to attribute journal rows to
+    /// generations — a `context_not_found` in generation N+1 for a context
+    /// generation N registered is the restart-loss signature. Set by the
+    /// embedded host via [`set_daemon_generation`]; standalone daemons mint
+    /// a per-process UUID on first use.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub daemon_generation: Option<String>,
     /// Wall-clock nanoseconds.
     pub latency_ns: u128,
     /// Root-normalized dependency-graph context identity.
@@ -291,6 +316,7 @@ impl JournalEntry {
             env: ctx.env,
             exit_code,
             session_id: ctx.session_id,
+            daemon_generation: Some(daemon_generation().to_string()),
             latency_ns,
             context_key: None,
             crate_name: None,

--- a/crates/zccache-daemon-core/src/daemon/compile_journal/tests/entry.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/tests/entry.rs
@@ -1,7 +1,9 @@
 //! Tests for `JournalEntry` serialization (legacy + extended profile fields)
 //! and the `SelfProfileSpans` accumulator / `with_profile_fields` builder.
 
-use super::super::{miss_reason, JournalEntry, MissDiff, SelfProfileNs, SelfProfileSpans};
+use super::super::{
+    miss_reason, JournalContext, JournalEntry, MissDiff, SelfProfileNs, SelfProfileSpans,
+};
 use super::{legacy_entry, make_ctx};
 
 // ─── Legacy JournalEntry serialization ────────────────────────────────────
@@ -273,6 +275,7 @@ fn serializes_extended_fields_when_present() {
         env: None,
         exit_code: 0,
         session_id: Some("sess-1".to_string()),
+        daemon_generation: None,
         latency_ns: 1_234_567,
         context_key: None,
         crate_name: Some("soldr_cli".to_string()),
@@ -494,4 +497,42 @@ fn self_profile_spans_saturate_on_overflow() {
     spans.add_hash_inputs_ns(u128::MAX);
     spans.add_hash_inputs_ns(5);
     assert_eq!(spans.hash_inputs_ns, u128::MAX);
+}
+
+// ─── zackees/soldr#2436 D4: generation identity on every row ─────────────
+
+#[test]
+fn journal_rows_carry_generation_and_session() {
+    let ctx = JournalContext::new(
+        "/usr/bin/rustc".to_string(),
+        vec!["--crate-name".into(), "demo".into()],
+        "/project".to_string(),
+        None,
+        Some("sess-gen".to_string()),
+    );
+    let entry = JournalEntry::new(ctx, "miss", 0, 1, Some(miss_reason::CONTEXT_NOT_FOUND));
+    let generation = entry
+        .daemon_generation
+        .as_deref()
+        .expect("every row carries a daemon generation");
+    // Standalone daemons mint a per-process UUID; the embedded host may
+    // override it earlier via set_daemon_generation, which is also a valid
+    // (host-shaped) identity — either way it must be non-empty and stable
+    // across rows in one process.
+    assert!(!generation.is_empty());
+    assert_eq!(entry.session_id.as_deref(), Some("sess-gen"));
+    let second = JournalEntry::new(
+        JournalContext::new(
+            "/usr/bin/rustc".to_string(),
+            vec![],
+            "/project".to_string(),
+            None,
+            None,
+        ),
+        "hit",
+        0,
+        1,
+        None,
+    );
+    assert_eq!(second.daemon_generation.as_deref(), Some(generation));
 }

--- a/crates/zccache-daemon-core/src/daemon/compile_journal/tests/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/tests/mod.rs
@@ -58,6 +58,7 @@ pub(super) fn legacy_entry(
         env: sanitize_journal_env(env),
         exit_code,
         session_id,
+        daemon_generation: None,
         latency_ns,
         context_key: None,
         crate_name: None,

--- a/crates/zccache-daemon-core/src/daemon/depgraph_load.rs
+++ b/crates/zccache-daemon-core/src/daemon/depgraph_load.rs
@@ -73,11 +73,14 @@ pub(crate) fn load_for_startup(path: &Path) -> StartupLoad {
             let stats = graph.stats();
             let (cold_ctxs, warm_ctxs, stale_ctxs) = graph.state_breakdown();
             let ctxs_with_key = graph.contexts_with_artifact_key();
+            // zackees/soldr#2436 D5: `contexts_restored` + `warm_count`
+            // are the single datapoint that separates write-side loss (few
+            // restored) from load-side loss (restored but later missed).
             tracing::info!(
-                contexts = stats.context_count,
+                contexts_restored = stats.context_count,
                 files = stats.file_count,
                 cold = cold_ctxs,
-                warm = warm_ctxs,
+                warm_count = warm_ctxs,
                 stale = stale_ctxs,
                 with_artifact_key = ctxs_with_key,
                 elapsed_ms = start.elapsed().as_millis() as u64,

--- a/crates/zccache-daemon-core/src/daemon/entry.rs
+++ b/crates/zccache-daemon-core/src/daemon/entry.rs
@@ -515,6 +515,31 @@ fn run_server(args: Args) {
             }
         });
 
+        // zackees/soldr#2436 D6: SIGTERM takes the same graceful drain as
+        // Ctrl+C. Supervisors (soldr's displacement policy, systemd, CI
+        // reapers) speak SIGTERM; before this it fell through to the default
+        // disposition — immediate death — losing up to a full save interval
+        // of depgraph registrations on every routine daemon displacement.
+        #[cfg(unix)]
+        {
+            let shutdown = server.shutdown_handle();
+            tokio::spawn(async move {
+                let mut sigterm =
+                    match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                    {
+                        Ok(stream) => stream,
+                        Err(error) => {
+                            tracing::warn!("could not install SIGTERM handler: {error}");
+                            return;
+                        }
+                    };
+                if sigterm.recv().await.is_some() {
+                    tracing::info!("received SIGTERM — shutting down");
+                    shutdown.notify_waiters();
+                }
+            });
+        }
+
         tracing::info!(%endpoint, "listening for connections");
 
         // Take `mut server` here so `server.run(&mut self)` can borrow.

--- a/crates/zccache-daemon-core/src/daemon/server/maintenance_schedule.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/maintenance_schedule.rs
@@ -39,6 +39,27 @@ pub(super) const TASK_STAGED_TEMP_SWEEP: &str = "staged-temp-sweep";
 pub(super) const TASK_MEMORY_EVICTION: &str = "memory-eviction";
 pub(super) const TASK_DISK_MAINTENANCE: &str = "disk-maintenance";
 pub(super) const TASK_DEPGRAPH_SAVE: &str = "depgraph-save";
+
+/// zackees/soldr#2436 D5: registrations that force a save before the timer.
+pub(super) const DEPGRAPH_SAVE_BATCH: usize = 32;
+/// How often the batch condition is polled between interval saves.
+pub(super) const DEPGRAPH_SAVE_BATCH_POLL: Duration = Duration::from_secs(5);
+
+/// Pure decision core for the save loop: `Some(reason)` when a save is due.
+pub(super) fn depgraph_save_due(
+    waited: Duration,
+    interval: Duration,
+    contexts: usize,
+    last_saved_contexts: usize,
+) -> Option<&'static str> {
+    if contexts.saturating_sub(last_saved_contexts) >= DEPGRAPH_SAVE_BATCH {
+        return Some("batch");
+    }
+    if waited >= interval {
+        return Some("interval");
+    }
+    None
+}
 pub(super) const TASK_LEGACY_TEMP_ROOT_CLEANUP: &str = "legacy-temp-root-cleanup";
 pub(super) const TASK_IDLE_WATCHDOG: &str = "idle-watchdog";
 pub(super) const TASK_PRIVATE_DAEMON_OWNERS: &str = "private-daemon-owner-reaper";
@@ -354,16 +375,35 @@ impl MaintenanceSchedule {
                 let state = Arc::clone(&state);
                 async move {
                     let path = depgraph_file_path_for_cache_dir(&state.cache_dir);
+                    // zackees/soldr#2436 D5: the interval alone left up to a
+                    // full period of registrations to die with any un-drained
+                    // daemon. A batch trigger bounds that loss: once
+                    // DEPGRAPH_SAVE_BATCH new contexts have registered since
+                    // the last save, save now instead of waiting the timer
+                    // out. Ticks are the smaller of the interval and the
+                    // batch poll so short test intervals stay honored.
+                    let tick = interval.min(DEPGRAPH_SAVE_BATCH_POLL);
+                    let mut last_saved_contexts = 0usize;
+                    let mut waited = Duration::ZERO;
                     loop {
-                        tokio::time::sleep(interval).await;
+                        tokio::time::sleep(tick).await;
+                        waited += tick;
+                        let dg = state.dep_graph.load();
+                        let contexts = dg.stats().context_count;
+                        let decision =
+                            depgraph_save_due(waited, interval, contexts, last_saved_contexts);
+                        let Some(reason) = decision else {
+                            continue;
+                        };
+                        waited = Duration::ZERO;
                         if let Some(parent) = path.parent() {
                             std::fs::create_dir_all(parent).ok();
                         }
-                        let dg = state.dep_graph.load();
                         match crate::depgraph::save_to_file(&dg, &path) {
                             Ok(()) => {
                                 state.dep_graph_persisted.store(true, Ordering::Release);
-                                tracing::debug!("periodic depgraph save");
+                                last_saved_contexts = contexts;
+                                tracing::info!(contexts, reason, "depgraph save");
                             }
                             Err(e) => tracing::warn!("periodic depgraph save failed: {e}"),
                         }

--- a/crates/zccache-daemon-core/src/daemon/server/tests/maintenance_schedule.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/maintenance_schedule.rs
@@ -253,3 +253,50 @@ async fn host_owned_disk_maintenance_keeps_the_in_memory_members() {
 
     stop(&state);
 }
+
+// ─── zackees/soldr#2436 D5: batch-save decision core ─────────────────────
+
+#[test]
+fn a_batch_of_registrations_triggers_a_save_before_the_timer() {
+    use super::super::maintenance_schedule::{depgraph_save_due, DEPGRAPH_SAVE_BATCH};
+    use std::time::Duration;
+    // Timer nowhere near due, but a full batch registered since last save.
+    assert_eq!(
+        depgraph_save_due(
+            Duration::from_secs(5),
+            Duration::from_secs(300),
+            DEPGRAPH_SAVE_BATCH,
+            0
+        ),
+        Some("batch")
+    );
+    // Growth measured against the last SAVED count, not zero.
+    assert_eq!(
+        depgraph_save_due(
+            Duration::from_secs(5),
+            Duration::from_secs(300),
+            100 + DEPGRAPH_SAVE_BATCH,
+            100
+        ),
+        Some("batch")
+    );
+}
+
+#[test]
+fn below_batch_growth_waits_for_the_interval() {
+    use super::super::maintenance_schedule::{depgraph_save_due, DEPGRAPH_SAVE_BATCH};
+    use std::time::Duration;
+    assert_eq!(
+        depgraph_save_due(
+            Duration::from_secs(5),
+            Duration::from_secs(300),
+            DEPGRAPH_SAVE_BATCH - 1,
+            0
+        ),
+        None
+    );
+    assert_eq!(
+        depgraph_save_due(Duration::from_secs(300), Duration::from_secs(300), 1, 0),
+        Some("interval")
+    );
+}

--- a/crates/zccache-depgraph/src/graph/register.rs
+++ b/crates/zccache-depgraph/src/graph/register.rs
@@ -159,7 +159,7 @@ impl DepGraph {
         ctx: CompileContext,
         key_root: Option<NormalizedPath>,
     ) -> ContextRegistration {
-        const MAX_EQUIVALENT_CONTEXTS: usize = 4;
+        let max_equivalent_contexts = max_equivalent_contexts();
 
         let instance = super::ContextInstanceKey::new(key, &ctx.source_file, key_root.as_ref());
         let instance_key = instance.map_key();
@@ -239,7 +239,7 @@ impl DepGraph {
                 }
             })
             .or_insert_with(|| vec![instance_key]);
-        let evicted = if evicted.len() > MAX_EQUIVALENT_CONTEXTS {
+        let evicted = if evicted.len() > max_equivalent_contexts {
             Some(evicted.remove(0))
         } else {
             None
@@ -280,4 +280,24 @@ impl DepGraph {
             None => true,
         }
     }
+}
+
+/// zackees/soldr#2436 D11: how many equivalent-root context instances one
+/// logical context key may hold before the oldest is evicted.
+///
+/// The historical limit of 4 was measured against single-checkout use; the
+/// multi-worktree finding showed a shared parent cache legitimately
+/// registering one instance per live worktree (plus renames), so 4 caused
+/// silent eviction churn — every eviction is a future `context_not_found`
+/// miss for the evicted root. 16 covers the observed worktree counts with
+/// headroom; `ZCCACHE_MAX_EQUIVALENT_CONTEXTS` overrides for unusual fleets.
+pub(crate) fn max_equivalent_contexts() -> usize {
+    static LIMIT: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *LIMIT.get_or_init(|| {
+        std::env::var("ZCCACHE_MAX_EQUIVALENT_CONTEXTS")
+            .ok()
+            .and_then(|value| value.trim().parse::<usize>().ok())
+            .filter(|value| *value >= 1)
+            .unwrap_or(16)
+    })
 }

--- a/crates/zccache-depgraph/src/graph/tests/worktree_variants.rs
+++ b/crates/zccache-depgraph/src/graph/tests/worktree_variants.rs
@@ -197,16 +197,19 @@ fn concurrent_equivalent_registration_keeps_independent_instances() {
 
 #[test]
 fn equivalent_variant_bound_evicts_to_a_conservative_miss() {
+    // zackees/soldr#2436 D11: the bound is resolver-driven (default 16,
+    // ZCCACHE_MAX_EQUIVALENT_CONTEXTS override); register one past it.
+    let limit = crate::graph::register::max_equivalent_contexts();
     let graph = DepGraph::new();
     let mut registrations = Vec::new();
-    for index in 0..5 {
+    for index in 0..=limit {
         let root = format!("/evict-{index}");
         let registration = graph
             .register_with_root_result(context(&root), Some(NormalizedPath::from(root.as_str())));
         graph.update(&registration.map_key, scan(&root), equivalent_hash);
         registrations.push(registration);
     }
-    assert_eq!(graph.stats().context_count, 4);
+    assert_eq!(graph.stats().context_count, limit);
     assert!(matches!(
         graph.check(&registrations[0].map_key, |_| true, equivalent_hash),
         CacheVerdict::Cold

--- a/docs/journal-schema.md
+++ b/docs/journal-schema.md
@@ -18,6 +18,7 @@ scripts) can rely on.
 | `env`          | array of `[k, v]` | no           | Sanitized build-diagnostic allowlist. Secret-looking names/values and all non-allowlisted variables are omitted. |
 | `exit_code`    | integer         | yes            | Process exit code. `-1` is reserved for daemon-side errors. |
 | `session_id`   | string \| null  | yes            | UUID for session-attached requests; `null` for ephemeral. |
+| `daemon_generation` | string     | no             | Which daemon process generation served the compile (zackees/soldr#2436 D4). The embedded host passes its route-generation identity; a standalone daemon mints one per-process UUID. Restart-warmth analysis joins rows to generations with it. |
 | `latency_ns`   | integer         | yes            | Wall-clock nanoseconds (per the project's `_ns` convention). |
 | `context_key`  | string          | no             | Full root-normalized dep-graph context hash. Present once cache-key construction completes; useful for comparing ephemeral cross-worktree requests. |
 | `crate_name`   | string          | no             | Populated when parseable from `--crate-name` (rustc). |


### PR DESCRIPTION
## Summary

zackees/soldr#2436 **phase 5** — bound the depgraph loss window and make journal rows attributable, so the phase-6 restart-warmth E2E can distinguish write-side from load-side loss.

- **D5 batch-save**: the periodic depgraph save was interval-only, so every un-drained daemon death lost up to a full period of registrations. The save task now also fires once `DEPGRAPH_SAVE_BATCH` (32) new contexts have registered since the last save (polled every 5s; short test intervals still honored — the tick is `min(interval, poll)`). Save lines log `contexts` + `reason` (`batch`/`interval`); the load line's fields are renamed to `contexts_restored` + `warm_count` — the datapoint that resolves write-side vs load-side loss.
- **D6 SIGTERM**: takes the same graceful drain as Ctrl+C. Supervisors (soldr's displacement policy, systemd, CI reapers) speak SIGTERM; previously it hit the default disposition — immediate, un-drained death.
- **D4 journal identity**: every `compile_journal.jsonl` row now carries `daemon_generation` (`skip_serializing_if` none-omitted; the embedded host passes its route-generation via the new `set_daemon_generation`, standalone daemons mint a per-process UUID lazily) beside the existing `session_id`. `docs/journal-schema.md` updated.
- **D11 equivalent-context bound**: 4 → 16, with `ZCCACHE_MAX_EQUIVALENT_CONTEXTS` override — the multi-worktree finding showed a shared parent cache legitimately holds one instance per live worktree, and each silent eviction is a future `context_not_found` miss for the evicted root.

## Tests

- `a_batch_of_registrations_triggers_a_save_before_the_timer` + `below_batch_growth_waits_for_the_interval` — the pure decision core (growth measured against last-saved, not zero).
- `journal_rows_carry_generation_and_session` — rows carry a stable non-empty generation and the session id.
- `equivalent_variant_bound_evicts_to_a_conservative_miss` — now derives from the resolver instead of pinning 4.
- Full lib suites green: zccache-daemon-core 752 (test-support), zccache-depgraph 420; fmt + clippy clean.

The SIGTERM drain's E2E (register warm → SIGTERM → restart → warm) lands with soldr's phase-6 `daemon_restart_warmth` test through the real wrapper, which exercises this handler end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)