### PR TITLE
fix(cli): isolate development daemon identities

### DIFF
--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -51,7 +51,7 @@ gha = ["dep:zccache-gha", "zccache-artifact/gha"]
 symbols = ["dep:zccache-symbols"]
 tokio-console = ["dep:console-subscriber", "zccache-daemon-core/tokio-console"]
 zccache-bin = ["cli", "dep:mimalloc"]
-daemon-bin = ["daemon-entry", "dep:mimalloc"]
+daemon-bin = ["daemon-entry", "symbols", "dep:mimalloc"]
 download-bin = ["dep:clap", "dep:mimalloc", "download-client"]
 download-daemon-bin = [
     "dep:clap",

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -9,6 +9,11 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-fn main() {
+fn main() -> std::process::ExitCode {
+    if let Err(error) = zccache::dev_daemon_identity::initialize() {
+        eprintln!("zccache-daemon: failed to establish development daemon identity: {error}");
+        return std::process::ExitCode::FAILURE;
+    }
     zccache::daemon::entry::run();
+    std::process::ExitCode::SUCCESS
 }

--- a/crates/zccache/src/bin/zccache.rs
+++ b/crates/zccache/src/bin/zccache.rs
@@ -20,6 +20,10 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
+    if let Err(error) = zccache::dev_daemon_identity::initialize() {
+        eprintln!("zccache: failed to establish development daemon identity: {error}");
+        return ExitCode::FAILURE;
+    }
     zccache::platform::process::spawn::run_cli_entry(run_main)
 }
 

--- a/crates/zccache/src/dev_daemon_identity.rs
+++ b/crates/zccache/src/dev_daemon_identity.rs
@@ -1,0 +1,143 @@
+//! Development-build daemon namespace initialization (issue #1362).
+
+use std::ffi::OsString;
+use std::io;
+
+const HASH_PREFIX_BYTES: usize = 8;
+
+fn namespace_for_process<F>(
+    inherited: Option<OsString>,
+    release_build: bool,
+    hash_current_exe: F,
+) -> io::Result<Option<String>>
+where
+    F: FnOnce() -> io::Result<[u8; 32]>,
+{
+    if inherited
+        .as_deref()
+        .and_then(|value| {
+            crate::core::config::namespace::sanitize_daemon_namespace(&value.to_string_lossy())
+        })
+        .is_some()
+    {
+        return Ok(None);
+    }
+    if release_build {
+        return Ok(None);
+    }
+
+    let hash = blake3::Hash::from_bytes(hash_current_exe()?);
+    let hex = hash.to_hex();
+    let hash_prefix = &hex.as_str()[..HASH_PREFIX_BYTES * 2];
+    Ok(Some(format!("{}-{hash_prefix}", crate::core::VERSION)))
+}
+
+/// Establish the daemon namespace before CLI or daemon configuration is read.
+pub fn initialize() -> io::Result<()> {
+    let inherited = std::env::var_os(crate::core::config::DAEMON_NAMESPACE_ENV);
+    if inherited
+        .as_deref()
+        .and_then(|value| {
+            crate::core::config::namespace::sanitize_daemon_namespace(&value.to_string_lossy())
+        })
+        .is_some()
+    {
+        return Ok(());
+    }
+
+    let current_exe = crate::platform::executable::current_image().map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("cannot locate the development zccache executable: {error}"),
+        )
+    })?;
+    let release_build = crate::symbols::read_marker_from_path(&current_exe).is_some();
+    let namespace = namespace_for_process(inherited, release_build, || {
+        running_process::blake3_file(&current_exe)
+            .map(|hash| *hash.as_bytes())
+            .map_err(|error| {
+                io::Error::new(
+                    error.kind(),
+                    format!(
+                        "cannot hash development zccache executable {}: {error}",
+                        current_exe.display()
+                    ),
+                )
+            })
+    })?;
+    if let Some(namespace) = namespace {
+        // The binary entrypoints call this before CLI/daemon initialization.
+        // The value then flows to compiler children and the spawned daemon.
+        std::env::set_var(crate::core::config::DAEMON_NAMESPACE_ENV, namespace);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    fn hash(byte: u8) -> [u8; 32] {
+        [byte; 32]
+    }
+
+    #[test]
+    fn inherited_namespace_wins_without_hashing() {
+        let hashed = Cell::new(false);
+        let namespace = namespace_for_process(Some("soldr-owned".into()), false, || {
+            hashed.set(true);
+            Ok(hash(0xaa))
+        })
+        .unwrap();
+
+        assert_eq!(namespace, None);
+        assert!(
+            !hashed.get(),
+            "an inherited value must avoid per-wrapper hashing"
+        );
+    }
+
+    #[test]
+    fn official_release_keeps_the_bare_namespace_without_hashing() {
+        let hashed = Cell::new(false);
+        let namespace = namespace_for_process(None, true, || {
+            hashed.set(true);
+            Ok(hash(0xaa))
+        })
+        .unwrap();
+
+        assert_eq!(namespace, None);
+        assert!(!hashed.get(), "official releases retain upgrade semantics");
+    }
+
+    #[test]
+    fn development_build_uses_version_and_first_sixteen_hash_digits() {
+        let namespace = namespace_for_process(None, false, || Ok(hash(0xab))).unwrap();
+
+        assert_eq!(
+            namespace.as_deref(),
+            Some(concat!(env!("CARGO_PKG_VERSION"), "-abababababababab"))
+        );
+    }
+
+    #[test]
+    fn empty_inherited_namespace_is_not_treated_as_an_identity() {
+        let namespace = namespace_for_process(Some("  ".into()), false, || Ok(hash(0x12))).unwrap();
+
+        assert_eq!(
+            namespace.as_deref(),
+            Some(concat!(env!("CARGO_PKG_VERSION"), "-1212121212121212"))
+        );
+    }
+
+    #[test]
+    fn development_hash_failure_is_not_silently_downgraded() {
+        let error = namespace_for_process(None, false, || {
+            Err(io::Error::new(io::ErrorKind::PermissionDenied, "locked"))
+        })
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
+}

--- a/crates/zccache/src/lib.rs
+++ b/crates/zccache/src/lib.rs
@@ -41,6 +41,9 @@ pub use zccache_daemon_core::daemon;
 /// unchanged.
 pub use zccache_daemon_core::embedded;
 pub use zccache_depgraph as depgraph;
+#[cfg(feature = "symbols")]
+#[doc(hidden)]
+pub mod dev_daemon_identity;
 #[cfg(feature = "download")]
 pub use zccache_download as download;
 #[cfg(feature = "download-protocol")]

--- a/crates/zccache/tests/cli_cache_root.rs
+++ b/crates/zccache/tests/cli_cache_root.rs
@@ -37,6 +37,15 @@ fn zccache_bin() -> NormalizedPath {
     NormalizedPath::new(path)
 }
 
+fn expected_dev_namespace(bin: &Path) -> String {
+    let hash = running_process::blake3_file(bin).expect("hash development zccache binary");
+    format!(
+        "{}-{}",
+        zccache::core::VERSION,
+        &hash.to_hex().as_str()[..16]
+    )
+}
+
 fn run_cache_root(cache_dir: Option<&Path>, json: bool) -> std::process::Output {
     let bin = zccache_bin();
     let mut cmd = Command::new(bin.as_path());
@@ -98,7 +107,8 @@ fn cache_root_env_branch_reports_env_source() {
     assert_eq!(v["source"], "env:ZCCACHE_CACHE_DIR");
     let got = v["cache_root"].as_str().expect("cache_root is a string");
     assert_eq!(Path::new(got), want.join(versioned_subdir()).as_path());
-    assert_eq!(v["daemon_namespace"], "default");
+    let namespace = expected_dev_namespace(zccache_bin().as_path());
+    assert_eq!(v["daemon_namespace"], namespace);
     assert!(
         v["daemon_endpoint"].as_str().is_some(),
         "daemon_endpoint must be present and stringy"
@@ -121,7 +131,8 @@ fn cache_root_default_branch_reports_default_source_when_env_unset() {
         v["cache_root"].as_str().is_some(),
         "cache_root must be present and stringy"
     );
-    assert_eq!(v["daemon_namespace"], "default");
+    let namespace = expected_dev_namespace(zccache_bin().as_path());
+    assert_eq!(v["daemon_namespace"], namespace);
 }
 
 #[test]

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -205,6 +205,15 @@ normalized through `effective_cache_root_from_top_level` (`normalized_override_r
 endpoint, lock, backend identity, and daemon state all live coherently under
 `/foo/v<version>`.
 
+Unstamped development binaries add a content-derived identity to
+`ZCCACHE_DAEMON_NAMESPACE` before resolving any of those names. The value is
+`<version>-<first-16-hex-of-blake3(current-exe)>`, so two local builds sharing
+one home root cannot displace each other's daemon. An inherited non-empty
+namespace always wins: managed hosts such as soldr compute it once above a
+build and every wrapper plus the spawned daemon reuse that value. Official
+binaries carry the release footer and retain the bare, version-only identity
+so normal upgrade semantics are unchanged.
+
 ### Conflict prevention & the retired broker (#1002)
 
 Standalone conflict prevention is the version-aware endpoint scheme above, not a


### PR DESCRIPTION
## What changed
- derive an unstamped development daemon namespace from the current executable's BLAKE3 identity
- preserve an inherited `ZCCACHE_DAEMON_NAMESPACE` so wrapper/daemon descendants stay in one namespace
- leave official release binaries on the existing version-only upgrade path
- cover namespace selection and real CLI cache-root behavior

## Root cause
Development binaries used only the package version for daemon identity, so unrelated builds of the same version could connect to the same daemon and cache root.

## Validation
- Windows unit tests: 5 passed
- Linux Docker unit tests: 5 passed
- Windows CLI cache-root integration tests: 5 passed
- focused library and binary clippy with warnings denied
- rustdoc with warnings denied
- Linux binary check for `zccache-bin,daemon-bin`
- real Windows start/status/cache-root/stop smoke test
- `/clud-review`: clean

The broader all-target clippy run still reports three pre-existing warnings in untouched `zccache-cli-core` code.

Closes #1362