### PR TITLE
perf(c): collect exact headers with compact depfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,10 +743,13 @@ A few things worth knowing:
 
 ### C/C++ dependency policy
 
-By default zccache asks GCC and Clang for an `-MD` dependency manifest and
-tracks every compiler-selected user and system header. The manifest is the
-pay-once cost: later C and C++ requests use the same direct-mode depgraph and
-do not rediscover the include closure.
+By default zccache asks GCC and Clang for a compact `-MMD` user-header manifest
+plus the compiler's exact `-H` include trace. zccache removes only those
+injected trace records from stderr, merges both sources, and tracks every
+compiler-selected user and system header. Invocations that already request
+`-H` or alter the diagnostic format retain the conservative `-MD` path. The
+combined manifest is the pay-once cost: later C and C++ requests use the same
+direct-mode depgraph and do not rediscover the include closure.
 
 `--fast` is a broad opt-in preset. It currently omits system headers from new
 C/C++ manifests by using `-MMD`; `--skip-system-headers` selects that behavior

--- a/README.md
+++ b/README.md
@@ -743,13 +743,14 @@ A few things worth knowing:
 
 ### C/C++ dependency policy
 
-By default zccache asks GCC and Clang for a compact `-MMD` user-header manifest
-plus the compiler's exact include trace. Ordinary Clang C compilations direct
-that trace to a private file; GCC and C++ use the public `-H` stream, from which
-zccache removes only verified trace records. zccache merges both sources and
-tracks every compiler-selected user and system header. Invocations that already
-request `-H` or alter the diagnostic format retain the conservative `-MD` path.
-The combined manifest is the pay-once cost: later C and C++ requests use the
+By default zccache asks GCC and Clang for the compiler's exact include trace.
+Ordinary Clang C compilations direct a complete user-and-system-header trace to
+a private file; GCC and C++ combine a compact `-MMD` user-header manifest with
+the public `-H` stream, from which zccache removes only verified trace records.
+zccache tracks every compiler-selected user and system header. Invocations that
+already request `-H` or alter the diagnostic format retain the conservative
+`-MD` path.
+The resulting manifest is the pay-once cost: later C and C++ requests use the
 same direct-mode depgraph and do not rediscover the include closure.
 
 `--fast` is a broad opt-in preset. It currently omits system headers from new

--- a/README.md
+++ b/README.md
@@ -744,12 +744,13 @@ A few things worth knowing:
 ### C/C++ dependency policy
 
 By default zccache asks GCC and Clang for a compact `-MMD` user-header manifest
-plus the compiler's exact `-H` include trace. zccache removes only those
-injected trace records from stderr, merges both sources, and tracks every
-compiler-selected user and system header. Invocations that already request
-`-H` or alter the diagnostic format retain the conservative `-MD` path. The
-combined manifest is the pay-once cost: later C and C++ requests use the same
-direct-mode depgraph and do not rediscover the include closure.
+plus the compiler's exact include trace. Ordinary Clang C compilations direct
+that trace to a private file; GCC and C++ use the public `-H` stream, from which
+zccache removes only verified trace records. zccache merges both sources and
+tracks every compiler-selected user and system header. Invocations that already
+request `-H` or alter the diagnostic format retain the conservative `-MD` path.
+The combined manifest is the pay-once cost: later C and C++ requests use the
+same direct-mode depgraph and do not rediscover the include closure.
 
 `--fast` is a broad opt-in preset. It currently omits system headers from new
 C/C++ manifests by using `-MMD`; `--skip-system-headers` selects that behavior

--- a/ci/docker/standalone_perf_entrypoint.sh
+++ b/ci/docker/standalone_perf_entrypoint.sh
@@ -37,6 +37,7 @@ case "${command}" in
         seed_soldr_home
         cd /src
         soldr cargo test -p zccache --test perf_bench_test --release --no-run
+        soldr cargo build -p zccache --features ci-bin --bin zccache-ci --release
         benchmark="$({
             find /target/release/deps -maxdepth 1 -type f \
                 -name 'perf_bench_test-*' -perm /111 -printf '%T@ %p\n'
@@ -46,6 +47,7 @@ case "${command}" in
             exit 2
         fi
         install -m 0755 "${benchmark}" /artifacts/perf_bench_test
+        install -m 0755 /target/release/zccache-ci /artifacts/zccache-ci
         ;;
     verify)
         seed_soldr_home
@@ -64,9 +66,11 @@ case "${command}" in
         ;;
     run)
         require_mount /artifacts/perf_bench_test
+        require_mount /artifacts/zccache-ci
         language="${2:?language is required}"
         test_name="${3:?test name is required}"
         attempts="${4:?attempt count is required}"
+        export ZCCACHE_CI_BIN=/artifacts/zccache-ci
         cd /src
         /usr/bin/time -v -o /results/resource-usage.txt \
             uv run --no-project python -m ci.perf_guard \

--- a/ci/tests/test_perf_standalone.py
+++ b/ci/tests/test_perf_standalone.py
@@ -265,6 +265,17 @@ def test_runtime_rust_state_is_owned_and_seeded_by_soldr():
     assert "/opt/rust" not in entrypoint
 
 
+def test_standalone_run_builds_and_wires_log_auditor():
+    entrypoint = (
+        perf_standalone.REPO_ROOT / "ci/docker/standalone_perf_entrypoint.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "soldr cargo build -p zccache --features ci-bin --bin zccache-ci --release" in entrypoint
+    assert "install -m 0755 /target/release/zccache-ci /artifacts/zccache-ci" in entrypoint
+    assert "require_mount /artifacts/zccache-ci" in entrypoint
+    assert "export ZCCACHE_CI_BIN=/artifacts/zccache-ci" in entrypoint
+
+
 def test_campaign_artifact_paths_are_relative_and_complete(tmp_path):
     sample_dir = tmp_path / "c" / "perf_c_zccache_vs_bare"
     sample_dir.mkdir(parents=True)

--- a/crates/zccache-daemon-core/src/daemon/compile_output.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_output.rs
@@ -343,7 +343,10 @@ mod tests {
 
         assert_eq!(
             scan.resolved,
-            vec![crate::core::NormalizedPath::from(header)]
+            vec![crate::depgraph::depfile::canonicalize_path(
+                &header,
+                temp.path()
+            )]
         );
         assert_eq!(captured.stderr, b"warning: retained\n");
         assert_eq!(emitted, captured.stderr);

--- a/crates/zccache-daemon-core/src/daemon/compile_output.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_output.rs
@@ -64,12 +64,34 @@ pub(crate) fn current() -> Option<OutputContext> {
 pub(crate) enum StderrFilter<'a> {
     None,
     ShowIncludes { source: &'a Path, cwd: &'a Path },
+    HeaderTrace { source: &'a Path, cwd: &'a Path },
 }
 
 pub(crate) struct CapturedOutput {
     pub(crate) stdout: Vec<u8>,
     pub(crate) stderr: Vec<u8>,
-    pub(crate) show_includes_scan: Option<crate::depgraph::ScanResult>,
+    pub(crate) dependency_scan: Option<crate::depgraph::ScanResult>,
+}
+
+enum DependencyParser {
+    ShowIncludes(crate::depgraph::show_includes::ShowIncludesParser),
+    HeaderTrace(crate::depgraph::header_trace::HeaderTraceParser),
+}
+
+impl DependencyParser {
+    fn push(&mut self, bytes: &[u8], output: &mut Vec<u8>) {
+        match self {
+            Self::ShowIncludes(parser) => parser.push(bytes, output),
+            Self::HeaderTrace(parser) => parser.push(bytes, output),
+        }
+    }
+
+    fn finish(self, output: &mut Vec<u8>) -> crate::depgraph::ScanResult {
+        match self {
+            Self::ShowIncludes(parser) => parser.finish(output),
+            Self::HeaderTrace(parser) => parser.finish(output),
+        }
+    }
 }
 
 pub(crate) async fn consume(
@@ -80,11 +102,14 @@ pub(crate) async fn consume(
     context.mark_live();
     let mut stdout = BoundedCapture::new(context.capture_limit, "stdout");
     let mut stderr = BoundedCapture::new(context.capture_limit, "stderr");
-    let mut show_includes = match stderr_filter {
+    let mut dependency_parser = match stderr_filter {
         StderrFilter::None => None,
-        StderrFilter::ShowIncludes { source, cwd } => Some(
+        StderrFilter::ShowIncludes { source, cwd } => Some(DependencyParser::ShowIncludes(
             crate::depgraph::show_includes::ShowIncludesParser::new(source, cwd),
-        ),
+        )),
+        StderrFilter::HeaderTrace { source, cwd } => Some(DependencyParser::HeaderTrace(
+            crate::depgraph::header_trace::HeaderTraceParser::new(source, cwd),
+        )),
     };
 
     while let Some(chunk) = receiver.recv().await {
@@ -96,7 +121,7 @@ pub(crate) async fn consume(
             }
             RawOutputChunk::Stderr(bytes) => {
                 let mut filtered = Vec::new();
-                if let Some(parser) = show_includes.as_mut() {
+                if let Some(parser) = dependency_parser.as_mut() {
                     parser.push(&bytes, &mut filtered);
                 } else {
                     filtered = bytes;
@@ -108,7 +133,7 @@ pub(crate) async fn consume(
         }
     }
 
-    let show_includes_scan = if let Some(parser) = show_includes {
+    let dependency_scan = if let Some(parser) = dependency_parser {
         let mut filtered = Vec::new();
         let scan = parser.finish(&mut filtered);
         if let Some(bytes) = stderr.push(&filtered) {
@@ -129,7 +154,7 @@ pub(crate) async fn consume(
     Ok(CapturedOutput {
         stdout: stdout.into_bytes(),
         stderr: stderr.into_bytes(),
-        show_includes_scan,
+        dependency_scan,
     })
 }
 
@@ -276,6 +301,52 @@ mod tests {
         assert!(captured.stderr.len() < 2048);
         assert!(String::from_utf8_lossy(&captured.stderr).contains("truncated to 1024 bytes"));
         assert!(captured.stderr.ends_with(&vec![b'x'; 512]));
+    }
+
+    #[tokio::test]
+    async fn header_trace_filter_streams_only_real_diagnostics() {
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let source = temp.path().join("main.c");
+        let header = temp.path().join("header with spaces.h");
+        std::fs::write(&source, "").expect("source");
+        std::fs::write(&header, "").expect("header");
+        let trace = format!(". {}\nwarning: retained\n", header.display());
+        let (sender, mut chunks) = mpsc::channel(8);
+        let context = OutputContext::new(sender);
+        let (raw_sender, raw_receiver) = mpsc::channel(128);
+        for bytes in trace.as_bytes().chunks(5) {
+            raw_sender
+                .send(RawOutputChunk::Stderr(bytes.to_vec()))
+                .await
+                .expect("raw receiver");
+        }
+        drop(raw_sender);
+
+        let captured = super::consume(
+            raw_receiver,
+            context,
+            StderrFilter::HeaderTrace {
+                source: &source,
+                cwd: temp.path(),
+            },
+        )
+        .await
+        .expect("capture");
+        let scan = captured.dependency_scan.expect("header scan");
+        let mut emitted = Vec::new();
+        while let Ok(chunk) = chunks.try_recv() {
+            let OutputChunk::Stderr(bytes) = chunk else {
+                panic!("expected stderr")
+            };
+            emitted.extend(bytes);
+        }
+
+        assert_eq!(
+            scan.resolved,
+            vec![crate::core::NormalizedPath::from(header)]
+        );
+        assert_eq!(captured.stderr, b"warning: retained\n");
+        assert_eq!(emitted, captured.stderr);
     }
 
     #[tokio::test]

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -31,7 +31,7 @@ pub(super) struct CompileExecOutcome {
     pub(super) stdout: Arc<Vec<u8>>,
     pub(super) stderr: Arc<Vec<u8>>,
     pub(super) depfile_strategy: DepfileStrategy,
-    pub(super) show_includes_scan: Option<crate::depgraph::ScanResult>,
+    pub(super) dependency_scan: Option<crate::depgraph::ScanResult>,
     pub(super) pre_hash_task: Option<tokio::task::JoinHandle<HashMap<NormalizedPath, ContentHash>>>,
     pub(super) compiler_priority_decision: crate::daemon::process::CompilePriorityDecision,
     pub(super) pre_exec_ns: u64,
@@ -79,10 +79,16 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     let pre_exec_ns = compile_start.elapsed().as_nanos() as u64;
     let t_exec = std::time::Instant::now();
     let supports_depfile = compilation.family.supports_depfile();
+    let inject_header_trace = should_inject_header_trace(
+        dependency_mode,
+        compilation.family,
+        effective_args,
+        dep_flags,
+    );
     let use_mmd = matches!(
         compilation.family,
         crate::compiler::CompilerFamily::Gcc | crate::compiler::CompilerFamily::Clang
-    ) && dependency_mode.use_mmd();
+    ) && (dependency_mode.use_mmd() || inject_header_trace);
     let (mut extra_args, mut depfile_strategy) = crate::depgraph::depfile::prepare_depfile_with_mmd(
         use_mmd,
         supports_depfile,
@@ -90,6 +96,11 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         output_path,
         &state.depfile_tmpdir,
     );
+    let header_trace_enabled =
+        inject_header_trace && matches!(depfile_strategy, DepfileStrategy::InjectedMmd { .. });
+    if header_trace_enabled {
+        extra_args.push("-H".to_string());
+    }
 
     // For MSVC, use /showIncludes to get complete dependency info
     // (equivalent to depfiles for gcc/clang). This enables cache hits
@@ -291,6 +302,11 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
                 source: source_path.as_path(),
                 cwd: cwd_path.as_path(),
             }
+        } else if header_trace_enabled {
+            crate::daemon::compile_output::StderrFilter::HeaderTrace {
+                source: source_path.as_path(),
+                cwd: cwd_path.as_path(),
+            }
         } else {
             crate::daemon::compile_output::StderrFilter::None
         };
@@ -360,14 +376,17 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
 
     let t_post_exec = std::time::Instant::now();
     let exit_code = output.status.code().unwrap_or(-1);
-    let (stdout_bytes, show_includes_scan, stderr_bytes) = if let Some(streamed) = streamed_output {
-        (
-            streamed.stdout,
-            streamed.show_includes_scan,
-            streamed.stderr,
-        )
+    let (stdout_bytes, dependency_scan, stderr_bytes) = if let Some(streamed) = streamed_output {
+        (streamed.stdout, streamed.dependency_scan, streamed.stderr)
     } else if depfile_strategy == DepfileStrategy::ShowIncludes {
         let (scan, filtered) = crate::depgraph::show_includes::parse_show_includes(
+            &output.stderr,
+            source_path,
+            cwd_path,
+        );
+        (output.stdout, Some(scan), filtered)
+    } else if header_trace_enabled {
+        let (scan, filtered) = crate::depgraph::header_trace::parse_header_trace(
             &output.stderr,
             source_path,
             cwd_path,
@@ -392,7 +411,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         stdout,
         stderr,
         depfile_strategy,
-        show_includes_scan,
+        dependency_scan,
         pre_hash_task,
         compiler_priority_decision,
         pre_exec_ns,
@@ -403,4 +422,116 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         post_exec_ns,
         staged_plan,
     })
+}
+
+fn header_trace_is_supported(family: crate::compiler::CompilerFamily, args: &[String]) -> bool {
+    if !matches!(
+        family,
+        crate::compiler::CompilerFamily::Gcc | crate::compiler::CompilerFamily::Clang
+    ) {
+        return false;
+    }
+    !args.iter().any(|arg| {
+        arg == "-H"
+            || (arg.starts_with("-Wp,") && arg.split(',').any(|part| part == "-H"))
+            || arg == "-Xpreprocessor=-H"
+            || arg == "-Xclang=-H"
+            || arg == "-fshow-skipped-includes"
+            || arg == "-fdiagnostics-format"
+            || arg.starts_with("-fdiagnostics-format=")
+    })
+}
+
+fn should_inject_header_trace(
+    dependency_mode: DependencyDiscoveryMode,
+    family: crate::compiler::CompilerFamily,
+    args: &[String],
+    dep_flags: &UserDepFlags,
+) -> bool {
+    dependency_mode == DependencyDiscoveryMode::AllHeaders
+        && !dep_flags.has_md
+        && dep_flags.mf_path.is_none()
+        && !dep_flags.depfile_to_stdout
+        && header_trace_is_supported(family, args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{header_trace_is_supported, should_inject_header_trace};
+    use crate::compiler::CompilerFamily;
+    use crate::daemon::server::dependency_policy::DependencyDiscoveryMode;
+    use crate::depgraph::UserDepFlags;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn header_trace_is_limited_to_unmodified_gnu_diagnostic_streams() {
+        assert!(header_trace_is_supported(
+            CompilerFamily::Clang,
+            &args(&["-c", "main.c", "-Iinclude"]),
+        ));
+        assert!(header_trace_is_supported(
+            CompilerFamily::Gcc,
+            &args(&["-c", "main.cc"]),
+        ));
+        assert!(!header_trace_is_supported(
+            CompilerFamily::Msvc,
+            &args(&["/c", "main.c"]),
+        ));
+        for incompatible in [
+            "-H",
+            "-Wp,-H",
+            "-Wp,-DTRACE,-H,-UOLD",
+            "-Xpreprocessor=-H",
+            "-Xclang=-H",
+            "-fshow-skipped-includes",
+            "-fdiagnostics-format=json",
+        ] {
+            assert!(!header_trace_is_supported(
+                CompilerFamily::Clang,
+                &args(&["-c", "main.c", incompatible]),
+            ));
+        }
+        assert!(!header_trace_is_supported(
+            CompilerFamily::Gcc,
+            &args(&["-c", "main.c", "-Xpreprocessor", "-H"]),
+        ));
+    }
+
+    #[test]
+    fn user_depfiles_never_enable_private_header_trace() {
+        let compile_args = args(&["-c", "main.c"]);
+        assert!(should_inject_header_trace(
+            DependencyDiscoveryMode::AllHeaders,
+            CompilerFamily::Clang,
+            &compile_args,
+            &UserDepFlags::default(),
+        ));
+        for dep_flags in [
+            UserDepFlags {
+                has_md: true,
+                has_mmd: true,
+                ..Default::default()
+            },
+            UserDepFlags {
+                has_md: true,
+                has_mmd: true,
+                mf_path: Some("custom.d".into()),
+                ..Default::default()
+            },
+            UserDepFlags {
+                depfile_to_stdout: true,
+                ..Default::default()
+            },
+        ] {
+            assert!(!should_inject_header_trace(
+                DependencyDiscoveryMode::AllHeaders,
+                CompilerFamily::Clang,
+                &compile_args,
+                &dep_flags,
+            ));
+        }
+    }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -417,7 +417,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         (output.stdout, None, output.stderr)
     };
     let dependency_scan = if let Some(trace) = private_header_trace.as_ref() {
-        let scan = crate::depgraph::header_trace::parse_header_trace_file(
+        let scan = crate::depgraph::header_trace::parse_dependency_graph_file(
             trace.path.as_path(),
             source_path,
             cwd_path,
@@ -471,17 +471,15 @@ fn prepare_private_clang_header_trace(
     let trace = PrivateHeaderTrace {
         path: header_trace_path(&path),
     };
-    // `-sys-header-deps` also promotes MMD to a full system-header depfile.
-    // The trace already contains every compiler-selected user and system
-    // header, so retaining `-MMD -MF` would serialize the same graph twice.
+    // Clang's dependency graph includes system headers without the
+    // `-sys-header-deps` switch that makes the compact MMD path expensive.
+    // It is complete on its own, so no second manifest is needed.
     extra_args.clear();
     extra_args.extend([
         "-Xclang".to_string(),
-        "-header-include-file".to_string(),
+        "-dependency-dot".to_string(),
         "-Xclang".to_string(),
         trace.path.to_string_lossy().into_owned(),
-        "-Xclang".to_string(),
-        "-sys-header-deps".to_string(),
     ]);
     trace
 }
@@ -500,11 +498,36 @@ fn use_private_clang_header_trace(
         && !args.iter().any(|arg| {
             arg == "-x"
                 || arg.starts_with("-x")
-                || arg == "-header-include-file"
-                || arg == "-sys-header-deps"
-                || arg == "-Xclang=-header-include-file"
-                || arg == "-Xclang=-sys-header-deps"
+                || contains_private_header_trace_flag(arg)
+                || contains_sysroot_flag(arg)
         })
+}
+
+fn contains_private_header_trace_flag(arg: &str) -> bool {
+    const PRIVATE_FLAGS: [&str; 3] = [
+        "-dependency-dot",
+        "-header-include-file",
+        "-sys-header-deps",
+    ];
+    PRIVATE_FLAGS.contains(&arg)
+        || arg
+            .strip_prefix("-Xclang=")
+            .is_some_and(|arg| PRIVATE_FLAGS.contains(&arg))
+        || arg
+            .strip_prefix("-Wp,")
+            .is_some_and(|args| args.split(',').any(|arg| PRIVATE_FLAGS.contains(&arg)))
+}
+
+fn contains_sysroot_flag(arg: &str) -> bool {
+    fn is_sysroot_flag(arg: &str) -> bool {
+        arg.starts_with("-isysroot") || arg == "--sysroot" || arg.starts_with("--sysroot=")
+    }
+
+    is_sysroot_flag(arg)
+        || arg.strip_prefix("-Xclang=").is_some_and(is_sysroot_flag)
+        || arg
+            .strip_prefix("-Wp,")
+            .is_some_and(|args| args.split(',').any(is_sysroot_flag))
 }
 
 fn header_trace_is_supported(family: crate::compiler::CompilerFamily, args: &[String]) -> bool {
@@ -520,10 +543,7 @@ fn header_trace_is_supported(family: crate::compiler::CompilerFamily, args: &[St
             || arg == "-Xpreprocessor=-H"
             || arg == "-Xclang=-H"
             || arg == "-fshow-skipped-includes"
-            || arg == "-header-include-file"
-            || arg == "-sys-header-deps"
-            || arg == "-Xclang=-header-include-file"
-            || arg == "-Xclang=-sys-header-deps"
+            || contains_private_header_trace_flag(arg)
             || arg == "-fdiagnostics-format"
             || arg.starts_with("-fdiagnostics-format=")
     })
@@ -581,6 +601,10 @@ mod tests {
             "-sys-header-deps",
             "-Xclang=-header-include-file",
             "-Xclang=-sys-header-deps",
+            "-dependency-dot",
+            "-Xclang=-dependency-dot",
+            "-Wp,-dependency-dot,custom.dot",
+            "-Wp,-header-include-file,custom.headers,-sys-header-deps",
             "-fdiagnostics-format=json",
         ] {
             assert!(!header_trace_is_supported(
@@ -656,7 +680,21 @@ mod tests {
             std::path::Path::new("main.c"),
             &args(&["-c", "main.c"]),
         ));
-        for incompatible in ["-Xclang=-header-include-file", "-Xclang=-sys-header-deps"] {
+        for incompatible in [
+            "-Xclang=-header-include-file",
+            "-Xclang=-sys-header-deps",
+            "-Xclang=-dependency-dot",
+            "-Wp,-dependency-dot,custom.dot",
+            "-Wp,-header-include-file,custom.headers,-sys-header-deps",
+            "--sysroot=/sdk",
+            "-isysroot/sdk",
+            "-Xclang=-isysroot",
+            "-Xclang=-isysroot=/sdk",
+            "-Xclang=--sysroot",
+            "-Xclang=--sysroot=/sdk",
+            "-Wp,-isysroot,/sdk",
+            "-Wp,--sysroot,/sdk",
+        ] {
             assert!(!use_private_clang_header_trace(
                 CompilerFamily::Clang,
                 std::path::Path::new("main.c"),
@@ -678,7 +716,8 @@ mod tests {
 
         assert_eq!(strategy, crate::depgraph::DepfileStrategy::CompilerTrace);
         assert!(!extra_args.iter().any(|arg| arg == "-MMD" || arg == "-MF"));
-        assert!(extra_args.iter().any(|arg| arg == "-sys-header-deps"));
+        assert!(extra_args.iter().any(|arg| arg == "-dependency-dot"));
+        assert!(!extra_args.iter().any(|arg| arg == "-sys-header-deps"));
         assert_eq!(
             trace.path.extension(),
             Some(std::ffi::OsStr::new("headers"))

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -111,22 +111,10 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     let private_header_trace = if header_trace_enabled
         && use_private_clang_header_trace(compilation.family, source_path.as_path(), effective_args)
     {
-        let depfile = match &depfile_strategy {
-            DepfileStrategy::InjectedMmd { path } => path,
-            _ => unreachable!("private header trace requires an injected MMD depfile"),
-        };
-        let trace = PrivateHeaderTrace {
-            path: header_trace_path(depfile),
-        };
-        extra_args.extend([
-            "-Xclang".to_string(),
-            "-header-include-file".to_string(),
-            "-Xclang".to_string(),
-            trace.path.to_string_lossy().into_owned(),
-            "-Xclang".to_string(),
-            "-sys-header-deps".to_string(),
-        ]);
-        Some(trace)
+        Some(prepare_private_clang_header_trace(
+            &mut extra_args,
+            &mut depfile_strategy,
+        ))
     } else {
         None
     };
@@ -471,6 +459,33 @@ fn header_trace_path(depfile: &NormalizedPath) -> NormalizedPath {
     depfile.as_path().with_extension("headers").into()
 }
 
+fn prepare_private_clang_header_trace(
+    extra_args: &mut Vec<String>,
+    depfile_strategy: &mut DepfileStrategy,
+) -> PrivateHeaderTrace {
+    let DepfileStrategy::InjectedMmd { path } =
+        std::mem::replace(depfile_strategy, DepfileStrategy::CompilerTrace)
+    else {
+        unreachable!("private header trace requires an injected MMD depfile");
+    };
+    let trace = PrivateHeaderTrace {
+        path: header_trace_path(&path),
+    };
+    // `-sys-header-deps` also promotes MMD to a full system-header depfile.
+    // The trace already contains every compiler-selected user and system
+    // header, so retaining `-MMD -MF` would serialize the same graph twice.
+    extra_args.clear();
+    extra_args.extend([
+        "-Xclang".to_string(),
+        "-header-include-file".to_string(),
+        "-Xclang".to_string(),
+        trace.path.to_string_lossy().into_owned(),
+        "-Xclang".to_string(),
+        "-sys-header-deps".to_string(),
+    ]);
+    trace
+}
+
 /// Clang's file-backed frontend trace avoids `-H` stderr traffic on the hot C
 /// miss path. Keep it deliberately narrower than the rejected all-language
 /// candidate: C++ continues to use the public trace because its much larger
@@ -530,7 +545,8 @@ fn should_inject_header_trace(
 #[cfg(test)]
 mod tests {
     use super::{
-        header_trace_is_supported, should_inject_header_trace, use_private_clang_header_trace,
+        header_trace_is_supported, prepare_private_clang_header_trace, should_inject_header_trace,
+        use_private_clang_header_trace,
     };
     use crate::compiler::CompilerFamily;
     use crate::daemon::server::dependency_policy::DependencyDiscoveryMode;
@@ -647,5 +663,25 @@ mod tests {
                 &args(&["-c", "main.c", incompatible]),
             ));
         }
+    }
+
+    #[test]
+    fn private_clang_trace_does_not_duplicate_the_header_graph_in_mmd() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let depfile = temp.path().join("main.d");
+        let mut extra_args = args(&["-MMD", "-MF", depfile.to_str().unwrap()]);
+        let mut strategy = crate::depgraph::DepfileStrategy::InjectedMmd {
+            path: depfile.into(),
+        };
+
+        let trace = prepare_private_clang_header_trace(&mut extra_args, &mut strategy);
+
+        assert_eq!(strategy, crate::depgraph::DepfileStrategy::CompilerTrace);
+        assert!(!extra_args.iter().any(|arg| arg == "-MMD" || arg == "-MF"));
+        assert!(extra_args.iter().any(|arg| arg == "-sys-header-deps"));
+        assert_eq!(
+            trace.path.extension(),
+            Some(std::ffi::OsStr::new("headers"))
+        );
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -48,6 +48,16 @@ pub(super) enum CompileExecResult {
     Error(Response),
 }
 
+struct PrivateHeaderTrace {
+    path: NormalizedPath,
+}
+
+impl Drop for PrivateHeaderTrace {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(self.path.as_path());
+    }
+}
+
 /// Prepare depfile/response-file/output-paths, spawn the compiler, and gather
 /// timings. The `pre_hash_task` returned is the rustc-only background hash of
 /// source + externs (issue #532) — `await`ed later in the store phase so its
@@ -98,7 +108,30 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     );
     let header_trace_enabled =
         inject_header_trace && matches!(depfile_strategy, DepfileStrategy::InjectedMmd { .. });
-    if header_trace_enabled {
+    let private_header_trace = if header_trace_enabled
+        && use_private_clang_header_trace(compilation.family, source_path.as_path(), effective_args)
+    {
+        let depfile = match &depfile_strategy {
+            DepfileStrategy::InjectedMmd { path } => path,
+            _ => unreachable!("private header trace requires an injected MMD depfile"),
+        };
+        let trace = PrivateHeaderTrace {
+            path: header_trace_path(depfile),
+        };
+        extra_args.extend([
+            "-Xclang".to_string(),
+            "-header-include-file".to_string(),
+            "-Xclang".to_string(),
+            trace.path.to_string_lossy().into_owned(),
+            "-Xclang".to_string(),
+            "-sys-header-deps".to_string(),
+        ]);
+        Some(trace)
+    } else {
+        None
+    };
+    let stderr_header_trace = header_trace_enabled && private_header_trace.is_none();
+    if stderr_header_trace {
         extra_args.push("-H".to_string());
     }
 
@@ -302,7 +335,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
                 source: source_path.as_path(),
                 cwd: cwd_path.as_path(),
             }
-        } else if header_trace_enabled {
+        } else if stderr_header_trace {
             crate::daemon::compile_output::StderrFilter::HeaderTrace {
                 source: source_path.as_path(),
                 cwd: cwd_path.as_path(),
@@ -385,7 +418,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
             cwd_path,
         );
         (output.stdout, Some(scan), filtered)
-    } else if header_trace_enabled {
+    } else if stderr_header_trace {
         let (scan, filtered) = crate::depgraph::header_trace::parse_header_trace(
             &output.stderr,
             source_path,
@@ -394,6 +427,16 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         (output.stdout, Some(scan), filtered)
     } else {
         (output.stdout, None, output.stderr)
+    };
+    let dependency_scan = if let Some(trace) = private_header_trace.as_ref() {
+        let scan = crate::depgraph::header_trace::parse_header_trace_file(
+            trace.path.as_path(),
+            source_path,
+            cwd_path,
+        );
+        Some(scan)
+    } else {
+        dependency_scan
     };
     let stdout = Arc::new(stdout_bytes);
     let stderr = Arc::new(stderr_bytes);
@@ -424,6 +467,31 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     })
 }
 
+fn header_trace_path(depfile: &NormalizedPath) -> NormalizedPath {
+    depfile.as_path().with_extension("headers").into()
+}
+
+/// Clang's file-backed frontend trace avoids `-H` stderr traffic on the hot C
+/// miss path. Keep it deliberately narrower than the rejected all-language
+/// candidate: C++ continues to use the public trace because its much larger
+/// header graph previously made the private path exceed the hosted watchdog.
+fn use_private_clang_header_trace(
+    family: crate::compiler::CompilerFamily,
+    source: &Path,
+    args: &[String],
+) -> bool {
+    family == crate::compiler::CompilerFamily::Clang
+        && source.extension().is_some_and(|extension| extension == "c")
+        && !args.iter().any(|arg| {
+            arg == "-x"
+                || arg.starts_with("-x")
+                || arg == "-header-include-file"
+                || arg == "-sys-header-deps"
+                || arg == "-Xclang=-header-include-file"
+                || arg == "-Xclang=-sys-header-deps"
+        })
+}
+
 fn header_trace_is_supported(family: crate::compiler::CompilerFamily, args: &[String]) -> bool {
     if !matches!(
         family,
@@ -437,6 +505,10 @@ fn header_trace_is_supported(family: crate::compiler::CompilerFamily, args: &[St
             || arg == "-Xpreprocessor=-H"
             || arg == "-Xclang=-H"
             || arg == "-fshow-skipped-includes"
+            || arg == "-header-include-file"
+            || arg == "-sys-header-deps"
+            || arg == "-Xclang=-header-include-file"
+            || arg == "-Xclang=-sys-header-deps"
             || arg == "-fdiagnostics-format"
             || arg.starts_with("-fdiagnostics-format=")
     })
@@ -457,7 +529,9 @@ fn should_inject_header_trace(
 
 #[cfg(test)]
 mod tests {
-    use super::{header_trace_is_supported, should_inject_header_trace};
+    use super::{
+        header_trace_is_supported, should_inject_header_trace, use_private_clang_header_trace,
+    };
     use crate::compiler::CompilerFamily;
     use crate::daemon::server::dependency_policy::DependencyDiscoveryMode;
     use crate::depgraph::UserDepFlags;
@@ -487,6 +561,10 @@ mod tests {
             "-Xpreprocessor=-H",
             "-Xclang=-H",
             "-fshow-skipped-includes",
+            "-header-include-file",
+            "-sys-header-deps",
+            "-Xclang=-header-include-file",
+            "-Xclang=-sys-header-deps",
             "-fdiagnostics-format=json",
         ] {
             assert!(!header_trace_is_supported(
@@ -531,6 +609,42 @@ mod tests {
                 CompilerFamily::Clang,
                 &compile_args,
                 &dep_flags,
+            ));
+        }
+    }
+
+    #[test]
+    fn private_clang_trace_is_bounded_to_plain_c_translation_units() {
+        assert!(use_private_clang_header_trace(
+            CompilerFamily::Clang,
+            std::path::Path::new("main.c"),
+            &args(&["-c", "main.c"]),
+        ));
+        assert!(!use_private_clang_header_trace(
+            CompilerFamily::Clang,
+            std::path::Path::new("main.cpp"),
+            &args(&["-c", "main.cpp"]),
+        ));
+        assert!(!use_private_clang_header_trace(
+            CompilerFamily::Clang,
+            std::path::Path::new("main.C"),
+            &args(&["-c", "main.C"]),
+        ));
+        assert!(!use_private_clang_header_trace(
+            CompilerFamily::Clang,
+            std::path::Path::new("main.c"),
+            &args(&["-x", "c++", "-c", "main.c"]),
+        ));
+        assert!(!use_private_clang_header_trace(
+            CompilerFamily::Gcc,
+            std::path::Path::new("main.c"),
+            &args(&["-c", "main.c"]),
+        ));
+        for incompatible in ["-Xclang=-header-include-file", "-Xclang=-sys-header-deps"] {
+            assert!(!use_private_clang_header_trace(
+                CompilerFamily::Clang,
+                std::path::Path::new("main.c"),
+                &args(&["-c", "main.c", incompatible]),
             ));
         }
     }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -1086,7 +1086,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         stdout,
         stderr,
         depfile_strategy,
-        show_includes_scan,
+        dependency_scan,
         pre_hash_task,
         compiler_priority_decision,
         pre_exec_ns,
@@ -1187,7 +1187,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             stderr: Arc::clone(&artifact_stderr),
             exit_code,
             depfile_strategy,
-            show_includes_scan,
+            compiler_dependency_scan: dependency_scan,
             pre_hash_task,
             // Issue #401: hand the cc/cpp miss path the hashes already
             // computed in `hash_and_verify` so `store_outcome.rs` skips

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -43,7 +43,7 @@ pub(super) struct StoreOutcomeRequest<'a> {
     pub(super) stderr: Arc<Vec<u8>>,
     pub(super) exit_code: i32,
     pub(super) depfile_strategy: DepfileStrategy,
-    pub(super) show_includes_scan: Option<crate::depgraph::ScanResult>,
+    pub(super) compiler_dependency_scan: Option<crate::depgraph::ScanResult>,
     pub(super) pre_hash_task: Option<tokio::task::JoinHandle<HashMap<NormalizedPath, ContentHash>>>,
     /// Issue #401: pre-compile hashes already produced by `hash_and_verify`
     /// on the cc/cpp miss path. `None` means the pre-compile hash phase did
@@ -160,7 +160,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         stderr,
         exit_code,
         depfile_strategy,
-        show_includes_scan,
+        compiler_dependency_scan,
         pre_hash_task,
         pre_hashed,
         compiler_priority_decision,
@@ -300,7 +300,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         source_path: source_path.clone(),
         cwd_path: cwd_path.clone(),
         depfile_strategy,
-        show_includes_scan,
+        compiler_dependency_scan,
         include_search: ctx.include_search.clone(),
         dependency_mode,
     })

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome_scan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome_scan.rs
@@ -162,10 +162,11 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
                 }
             }
         }
-        DepfileStrategy::ShowIncludes => compiler_dependency_scan.unwrap_or_else(|| {
-            used_static_fallback = true;
-            crate::depgraph::scanner::scan_recursive(&source_path, &include_search)
-        }),
+        DepfileStrategy::CompilerTrace | DepfileStrategy::ShowIncludes => compiler_dependency_scan
+            .unwrap_or_else(|| {
+                used_static_fallback = true;
+                crate::depgraph::scanner::scan_recursive(&source_path, &include_search)
+            }),
         DepfileStrategy::Unsupported => {
             used_static_fallback = true;
             crate::depgraph::scanner::scan_recursive(&source_path, &include_search)

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome_scan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome_scan.rs
@@ -186,6 +186,17 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
     }
 }
 
+pub(super) fn apply_static_fallback_policy(
+    dependency_mode: DependencyDiscoveryMode,
+    used_static_fallback: bool,
+    result: &mut crate::depgraph::ScanResult,
+    include_search: &crate::depgraph::IncludeSearchPaths,
+) {
+    if used_static_fallback {
+        dependency_mode.apply_static_fallback(result, include_search);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,16 +232,5 @@ mod tests {
         assert!(collection.scan_result.resolved.contains(&header));
         assert!(collection.scan_result.has_computed);
         assert!(collection.depfile_parse_warning.is_some());
-    }
-}
-
-pub(super) fn apply_static_fallback_policy(
-    dependency_mode: DependencyDiscoveryMode,
-    used_static_fallback: bool,
-    result: &mut crate::depgraph::ScanResult,
-    include_search: &crate::depgraph::IncludeSearchPaths,
-) {
-    if used_static_fallback {
-        dependency_mode.apply_static_fallback(result, include_search);
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome_scan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome_scan.rs
@@ -11,7 +11,7 @@ pub(super) struct CompileScanRequest {
     pub(super) source_path: NormalizedPath,
     pub(super) cwd_path: NormalizedPath,
     pub(super) depfile_strategy: DepfileStrategy,
-    pub(super) show_includes_scan: Option<crate::depgraph::ScanResult>,
+    pub(super) compiler_dependency_scan: Option<crate::depgraph::ScanResult>,
     pub(super) include_search: crate::depgraph::IncludeSearchPaths,
     pub(super) dependency_mode: DependencyDiscoveryMode,
 }
@@ -48,7 +48,7 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
         source_path,
         cwd_path,
         depfile_strategy,
-        show_includes_scan,
+        compiler_dependency_scan,
         include_search,
         dependency_mode,
     } = req;
@@ -137,17 +137,32 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
             match crate::depgraph::depfile::parse_depfile_path(path, &source_path, &cwd_path) {
                 Ok(result) => {
                     let _ = std::fs::remove_file(path);
-                    result
+                    if let Some(compiler_scan) = compiler_dependency_scan {
+                        crate::depgraph::depfile::merge_scan_results(result, compiler_scan)
+                    } else {
+                        result
+                    }
                 }
                 Err(e) => {
                     used_static_fallback = true;
                     depfile_parse_warning = Some(format!("path={} error={e}", path.display()));
                     let _ = std::fs::remove_file(path);
-                    crate::depgraph::scanner::scan_recursive(&source_path, &include_search)
+                    let fallback =
+                        crate::depgraph::scanner::scan_recursive(&source_path, &include_search);
+                    let mut result = if let Some(scan) = compiler_dependency_scan {
+                        crate::depgraph::depfile::merge_scan_results(scan, fallback)
+                    } else {
+                        fallback
+                    };
+                    // A malformed private depfile means one of the two exact
+                    // compiler manifests was incomplete. Retain every path we
+                    // did recover, but never permit a direct-mode hit from it.
+                    result.has_computed = true;
+                    result
                 }
             }
         }
-        DepfileStrategy::ShowIncludes => show_includes_scan.unwrap_or_else(|| {
+        DepfileStrategy::ShowIncludes => compiler_dependency_scan.unwrap_or_else(|| {
             used_static_fallback = true;
             crate::depgraph::scanner::scan_recursive(&source_path, &include_search)
         }),
@@ -168,6 +183,44 @@ fn collect_compile_scan(req: CompileScanRequest) -> CompileScanCollection {
         rustc_env_dep_names: Vec::new(),
         user_depfile_capture,
         depfile_parse_warning,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn malformed_mmd_retains_compiler_trace_and_fails_closed() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.c");
+        let header = temp.path().join("system.h");
+        let depfile = temp.path().join("main.d");
+        std::fs::write(&source, "#include <system.h>\n").unwrap();
+        std::fs::write(&header, "#define VALUE 1\n").unwrap();
+        std::fs::write(&depfile, [0xff, 0xfe]).unwrap();
+        let header: NormalizedPath = header.into();
+
+        let collection = collect_compile_scan(CompileScanRequest {
+            is_rustc: false,
+            rustc_args: None,
+            source_path: source.into(),
+            cwd_path: temp.path().into(),
+            depfile_strategy: DepfileStrategy::InjectedMmd {
+                path: depfile.into(),
+            },
+            compiler_dependency_scan: Some(crate::depgraph::ScanResult {
+                resolved: vec![header.clone()],
+                unresolved: Vec::new(),
+                has_computed: false,
+            }),
+            include_search: Default::default(),
+            dependency_mode: DependencyDiscoveryMode::AllHeaders,
+        });
+
+        assert!(collection.scan_result.resolved.contains(&header));
+        assert!(collection.scan_result.has_computed);
+        assert!(collection.depfile_parse_warning.is_some());
     }
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
@@ -18,6 +18,7 @@ use super::staged_store::materialization_error_progress;
 use super::staged_store::{inject_staged_fault, StagedFaultGuard, StagedFaultPoint};
 use super::staged_store::{materialization_error, staged_lane_enabled, StagedMaterializationStats};
 use crate::core::path::NormalizedPath;
+use crate::depgraph::DepfileStrategy;
 use std::io;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -754,15 +755,15 @@ impl StagedCompilePlan {
 
     pub(in crate::daemon::server) fn rewrite_depfile_strategy(
         &self,
-        strategy: crate::depgraph::DepfileStrategy,
-    ) -> crate::depgraph::DepfileStrategy {
+        strategy: DepfileStrategy,
+    ) -> DepfileStrategy {
+        use DepfileStrategy::*;
         let path = match &strategy {
-            crate::depgraph::DepfileStrategy::Injected { path }
-            | crate::depgraph::DepfileStrategy::InjectedMmd { path }
-            | crate::depgraph::DepfileStrategy::UserSpecified { path, .. }
-            | crate::depgraph::DepfileStrategy::UserDefault { path, .. } => path,
-            crate::depgraph::DepfileStrategy::ShowIncludes
-            | crate::depgraph::DepfileStrategy::Unsupported => return strategy,
+            Injected { path }
+            | InjectedMmd { path }
+            | UserSpecified { path, .. }
+            | UserDefault { path, .. } => path,
+            CompilerTrace | ShowIncludes | Unsupported => return strategy,
         };
         let Some(staged) = self
             .outputs
@@ -773,28 +774,23 @@ impl StagedCompilePlan {
             return strategy;
         };
         match strategy {
-            crate::depgraph::DepfileStrategy::Injected { .. } => {
-                crate::depgraph::DepfileStrategy::Injected { path: staged }
-            }
-            crate::depgraph::DepfileStrategy::InjectedMmd { .. } => {
-                crate::depgraph::DepfileStrategy::InjectedMmd { path: staged }
-            }
-            crate::depgraph::DepfileStrategy::UserSpecified {
+            Injected { .. } => Injected { path: staged },
+            InjectedMmd { .. } => InjectedMmd { path: staged },
+            UserSpecified {
                 augment_system_headers,
                 ..
-            } => crate::depgraph::DepfileStrategy::UserSpecified {
+            } => UserSpecified {
                 path: staged,
                 augment_system_headers,
             },
-            crate::depgraph::DepfileStrategy::UserDefault {
+            UserDefault {
                 augment_system_headers,
                 ..
-            } => crate::depgraph::DepfileStrategy::UserDefault {
+            } => UserDefault {
                 path: staged,
                 augment_system_headers,
             },
-            crate::depgraph::DepfileStrategy::ShowIncludes
-            | crate::depgraph::DepfileStrategy::Unsupported => strategy,
+            CompilerTrace | ShowIncludes | Unsupported => strategy,
         }
     }
 

--- a/crates/zccache-daemon-core/src/daemon/server/tests/multi_restart_context_key.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/multi_restart_context_key.rs
@@ -68,8 +68,9 @@ use super::CacheDirEnvGuard;
 /// * Discovery probes (`-v -E ...`, `-###`) see no `.c` args and no `-o`,
 ///   and become successful no-ops.
 ///
-/// `-MF`/`-MT` values are skipped so a depfile path ending in a source-like
-/// name can never be mistaken for an input.
+/// `-MF` is captured and `-MT` is skipped so their values can never be
+/// mistaken for inputs. Depfile sources are cwd-relative, matching the test
+/// working directory without exposing host TEMP-path escaping to the shim.
 #[cfg(unix)]
 pub(super) fn write_fake_multi_cc(dir: &Path) -> PathBuf {
     use std::os::unix::fs::PermissionsExt;
@@ -79,30 +80,54 @@ pub(super) fn write_fake_multi_cc(dir: &Path) -> PathBuf {
         &tool,
         r#"#!/bin/sh
 out=
-srcs=
-while [ "$#" -gt 0 ]; do
-    case "$1" in
+depfile=
+operand=
+for arg do
+    if [ -n "$operand" ]; then
+        case "$operand" in
+            out) out=$arg ;;
+            depfile) depfile=$arg ;;
+            skip) ;;
+        esac
+        operand=
+        continue
+    fi
+    case "$arg" in
         -v)
             printf '%s\n' '#include <...> search starts here:' >&2
             printf '%s\n' ' /usr/include' >&2
             printf '%s\n' 'End of search list.' >&2
             exit 0
             ;;
-        -o) shift; out=$1 ;;
-        -MF|-MT) shift ;;
-        *.c) srcs="$srcs $1" ;;
+        -o) operand=out ;;
+        -MF) operand=depfile ;;
+        -MT) operand=skip ;;
     esac
-    shift || true
 done
-if [ -n "$out" ]; then
-    for s in $srcs; do
-        printf 'object-for:%s\n' "$s" > "$out"
-    done
-else
-    for s in $srcs; do
-        printf 'object-for:%s\n' "$s" > "${s%.c}.o"
-    done
+if [ -n "$depfile" ]; then
+    printf 'object:' > "$depfile"
 fi
+operand=
+for arg do
+    if [ -n "$operand" ]; then
+        operand=
+        continue
+    fi
+    case "$arg" in
+        -o|-MF|-MT) operand=value ;;
+        *.c)
+            if [ -n "$out" ]; then
+                printf 'object-for:%s\n' "$arg" > "$out"
+            else
+                printf 'object-for:%s\n' "$arg" > "${arg%.c}.o"
+            fi
+            if [ -n "$depfile" ]; then
+                printf ' %s' "${arg##*/}" >> "$depfile"
+            fi
+            ;;
+    esac
+done
+if [ -n "$depfile" ]; then printf '\n' >> "$depfile"; fi
 exit 0
 "#,
     )
@@ -122,6 +147,7 @@ pub(super) fn write_fake_multi_cc(dir: &Path) -> PathBuf {
 setlocal enabledelayedexpansion
 set "OUT="
 set "SRCS="
+set "DEPFILE="
 :loop
 if "%~1"=="" goto run
 if "%~1"=="-o" (
@@ -137,6 +163,7 @@ if "%~1"=="-v" (
     exit /b 0
 )
 if "%~1"=="-MF" (
+    set "DEPFILE=%~2"
     shift
     shift
     goto loop
@@ -155,10 +182,17 @@ if defined OUT (
     for %%S in (!SRCS!) do (
         > "!OUT!" echo object-for:%%~S
     )
-    exit /b 0
+) else (
+    for %%S in (!SRCS!) do (
+        > "%%~dpnS.o" echo object-for:%%~S
+    )
 )
-for %%S in (!SRCS!) do (
-    > "%%~dpnS.o" echo object-for:%%~S
+if defined DEPFILE (
+    > "!DEPFILE!" <nul set /p ="object:"
+    for %%S in (!SRCS!) do (
+        >> "!DEPFILE!" <nul set /p =" %%~nxS"
+    )
+    >> "!DEPFILE!" echo.
 )
 exit /b 0
 "#,
@@ -250,7 +284,7 @@ async fn multi_file_compile_hits_warm_after_restart() {
         crate::core::config::depgraph_dir_from_cache_dir(&cache_root).join("depgraph.bin");
 
     let cc = write_fake_multi_cc(tmp.path());
-    let work = tmp.path().join("work");
+    let work = tmp.path().join("work with spaces");
     std::fs::create_dir_all(&work).unwrap();
     let a = work.join("multi_a.c");
     let b = work.join("multi_b.c");

--- a/crates/zccache-depgraph/src/args.rs
+++ b/crates/zccache-depgraph/src/args.rs
@@ -3,9 +3,12 @@
 //! Extracts include paths, defines, and cache-relevant flags from
 //! compiler command-line arguments.
 
+mod dep_flags;
+
 use std::path::Path;
 
 use super::search_paths::IncludeSearchPaths;
+use dep_flags::parse_user_dep_flags;
 use zccache_compiler::gnu_flag_takes_value;
 use zccache_core::NormalizedPath;
 
@@ -64,7 +67,7 @@ pub fn parse_gnu_args(args: &[String], cwd: &Path) -> ParsedArgs {
         flags: Vec::new(),
         force_includes: Vec::new(),
         compiler: None,
-        dep_flags: UserDepFlags::default(),
+        dep_flags: parse_user_dep_flags(args, cwd),
         unknown_flags: Vec::new(),
     };
 
@@ -284,23 +287,15 @@ pub fn parse_gnu_args(args: &[String], cwd: &Path) -> ParsedArgs {
 
         // Dependency-generation flags: track but don't include in cache key.
         if arg == "-MD" || arg == "-MMD" {
-            result.dep_flags.has_md = true;
-            result.dep_flags.has_mmd = arg == "-MMD";
             i += 1;
             continue;
         }
 
         // -MF takes a following argument â€” capture path.
         if arg == "-MF" {
-            if let Some(next) = args.get(i + 1) {
-                result.dep_flags.depfile_to_stdout = next == "-";
-                result.dep_flags.mf_path = (next != "-").then(|| resolve_path(next, cwd));
-            }
             i += 2;
             continue;
-        } else if let Some(path) = arg.strip_prefix("-MF").filter(|path| !path.is_empty()) {
-            result.dep_flags.depfile_to_stdout = path == "-";
-            result.dep_flags.mf_path = (path != "-").then(|| resolve_path(path, cwd));
+        } else if arg.strip_prefix("-MF").is_some_and(|path| !path.is_empty()) {
             i += 1;
             continue;
         }

--- a/crates/zccache-depgraph/src/args/README.md
+++ b/crates/zccache-depgraph/src/args/README.md
@@ -1,0 +1,5 @@
+# Dependency argument helpers
+
+This directory contains focused helpers for GNU-compatible compiler argument
+parsing. `dep_flags.rs` distinguishes driver dependency flags from options
+forwarded directly to the preprocessor, whose value arity differs.

--- a/crates/zccache-depgraph/src/args/dep_flags.rs
+++ b/crates/zccache-depgraph/src/args/dep_flags.rs
@@ -1,0 +1,189 @@
+use std::path::Path;
+
+use zccache_compiler::gnu_flag_takes_value;
+
+use super::{resolve_path, UserDepFlags};
+
+pub(super) fn parse_user_dep_flags(args: &[String], cwd: &Path) -> UserDepFlags {
+    let mut result = UserDepFlags::default();
+    let mut index = 0;
+    while index < args.len() {
+        if let Some(options) = args[index].strip_prefix("-Wp,") {
+            parse_forwarded_stream(&options.split(',').collect::<Vec<_>>(), cwd, &mut result);
+            index += 1;
+            continue;
+        }
+        if xpreprocessor_arg(args, index).is_some() {
+            let mut options = Vec::new();
+            while let Some((option, consumed)) = xpreprocessor_arg(args, index) {
+                options.push(option);
+                index += consumed;
+            }
+            parse_forwarded_stream(&options, cwd, &mut result);
+            continue;
+        }
+        index += parse_driver_option(
+            &args[index],
+            args.get(index + 1).map(String::as_str),
+            cwd,
+            &mut result,
+        );
+    }
+    result
+}
+
+fn xpreprocessor_arg(args: &[String], index: usize) -> Option<(&str, usize)> {
+    if args.get(index)? == "-Xpreprocessor" {
+        args.get(index + 1).map(|arg| (arg.as_str(), 2))
+    } else {
+        args[index]
+            .strip_prefix("-Xpreprocessor=")
+            .map(|arg| (arg, 1))
+    }
+}
+
+fn parse_forwarded_stream(options: &[&str], cwd: &Path, result: &mut UserDepFlags) {
+    let mut index = 0;
+    while index < options.len() {
+        let option = options[index];
+        let next = options.get(index + 1).copied();
+        if matches!(option, "-MD" | "-MMD") {
+            result.has_md = true;
+            result.has_mmd = option == "-MMD";
+            if let Some(path) = next {
+                record_depfile_path(path, cwd, result);
+                index += 2;
+            } else {
+                index += 1;
+            }
+        } else if option == "-MF" || option == "-dependency-file" {
+            if let Some(path) = next {
+                record_depfile_path(path, cwd, result);
+                index += 2;
+            } else {
+                index += 1;
+            }
+        } else if let Some(path) = option.strip_prefix("-MF").filter(|path| !path.is_empty()) {
+            record_depfile_path(path, cwd, result);
+            index += 1;
+        } else if forwarded_option_takes_value(option) && next.is_some() {
+            index += 2;
+        } else {
+            index += 1;
+        }
+    }
+}
+
+fn parse_driver_option(
+    option: &str,
+    next: Option<&str>,
+    cwd: &Path,
+    result: &mut UserDepFlags,
+) -> usize {
+    if matches!(option, "-MD" | "-MMD") {
+        result.has_md = true;
+        result.has_mmd = option == "-MMD";
+        return 1;
+    }
+    if option == "-MF" {
+        if let Some(path) = next {
+            record_depfile_path(path, cwd, result);
+            return 2;
+        }
+        return 1;
+    }
+    if let Some(path) = option.strip_prefix("-MF").filter(|path| !path.is_empty()) {
+        record_depfile_path(path, cwd, result);
+        return 1;
+    }
+    if (gnu_flag_takes_value(option) || matches!(option, "-MT" | "-MQ")) && next.is_some() {
+        2
+    } else {
+        1
+    }
+}
+
+fn forwarded_option_takes_value(option: &str) -> bool {
+    gnu_flag_takes_value(option)
+        || matches!(
+            option,
+            "-D" | "-U"
+                | "-I"
+                | "-MT"
+                | "-MQ"
+                | "-include"
+                | "-imacros"
+                | "-isystem"
+                | "-iquote"
+                | "-idirafter"
+                | "-iprefix"
+                | "-iwithprefix"
+                | "-iwithprefixbefore"
+                | "-isysroot"
+                | "--sysroot"
+        )
+}
+
+fn record_depfile_path(path: &str, cwd: &Path, result: &mut UserDepFlags) {
+    result.depfile_to_stdout = path == "-";
+    result.mf_path = (path != "-").then(|| resolve_path(path, cwd));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn forwarded_md_consumes_its_output_path() {
+        for forwarded in [
+            args(&["-Wp,-MMD,forwarded.d", "-c", "foo.c"]),
+            args(&[
+                "-Xpreprocessor",
+                "-MMD",
+                "-Xpreprocessor",
+                "forwarded.d",
+                "-c",
+                "foo.c",
+            ]),
+            args(&[
+                "-Xpreprocessor=-MMD",
+                "-Xpreprocessor=forwarded.d",
+                "-c",
+                "foo.c",
+            ]),
+        ] {
+            let parsed = parse_user_dep_flags(&forwarded, Path::new("/p"));
+
+            assert!(parsed.has_md);
+            assert!(parsed.has_mmd);
+            assert_eq!(parsed.mf_path.as_deref(), Some(Path::new("/p/forwarded.d")));
+        }
+    }
+
+    #[test]
+    fn driver_md_remains_valueless_and_target_operands_are_skipped() {
+        let parsed = parse_user_dep_flags(
+            &args(&["-MD", "-MT", "-MF", "-MF", "custom.d", "-c", "foo.c"]),
+            Path::new("/p"),
+        );
+
+        assert!(parsed.has_md);
+        assert!(!parsed.has_mmd);
+        assert_eq!(parsed.mf_path.as_deref(), Some(Path::new("/p/custom.d")));
+    }
+
+    #[test]
+    fn forwarded_target_operands_are_skipped() {
+        let parsed = parse_user_dep_flags(
+            &args(&["-Wp,-MMD,first.d,-MT,-MF,-MF,custom.d", "-c", "foo.c"]),
+            Path::new("/p"),
+        );
+
+        assert!(parsed.has_mmd);
+        assert_eq!(parsed.mf_path.as_deref(), Some(Path::new("/p/custom.d")));
+    }
+}

--- a/crates/zccache-depgraph/src/depfile/strategy.rs
+++ b/crates/zccache-depgraph/src/depfile/strategy.rs
@@ -13,8 +13,10 @@ use zccache_core::NormalizedPath;
 pub enum DepfileStrategy {
     /// We injected `-MD -MF <path>` — read and clean up after compilation.
     Injected { path: NormalizedPath },
-    /// We injected a private MMD depfile; merge a conservative local include scan.
+    /// We injected a private MMD depfile to merge with an exact compiler trace.
     InjectedMmd { path: NormalizedPath },
+    /// The compiler emitted an exact header trace without an on-disk depfile.
+    CompilerTrace,
     /// User already had `-MF <path>` — read it (don't delete).
     UserSpecified {
         path: NormalizedPath,

--- a/crates/zccache-depgraph/src/header_trace.rs
+++ b/crates/zccache-depgraph/src/header_trace.rs
@@ -239,9 +239,13 @@ pub fn parse_dependency_graph_file(path: &Path, source: &Path, cwd: &Path) -> Sc
         }
         parser.record_resolved_path(path);
     }
+    // Clang emits a syntactically complete empty graph for a translation
+    // unit with no includes. Once any node exists, however, the source node
+    // is required so a truncated graph cannot be mistaken for a complete
+    // dependency manifest.
     parser.incomplete |= !saw_header
         || !saw_footer
-        || !saw_source
+        || (!node_ids.is_empty() && !saw_source)
         || edges
             .iter()
             .any(|(from, to)| !node_ids.contains(from) || !node_ids.contains(to));
@@ -473,7 +477,10 @@ mod tests {
 
         assert_eq!(
             scan.resolved,
-            vec![NormalizedPath::new(&valid), NormalizedPath::new(&invalid)]
+            vec![
+                crate::depfile::canonicalize_path(&valid, temp.path()),
+                crate::depfile::canonicalize_path(&invalid, temp.path()),
+            ]
         );
         assert!(!scan.has_computed);
         assert!(filtered.is_empty());
@@ -622,6 +629,20 @@ mod tests {
 
         assert!(scan.resolved.is_empty());
         assert!(scan.has_computed, "graph should fail closed: {graph:?}");
+    }
+
+    #[test]
+    fn empty_dependency_graph_is_a_complete_no_include_manifest() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.c");
+        let trace = temp.path().join("empty.headers");
+        std::fs::write(&source, "int main(void) { return 0; }\n").unwrap();
+        std::fs::write(&trace, "digraph \"dependencies\" {\n}\n").unwrap();
+
+        let scan = parse_dependency_graph_file(&trace, &source, temp.path());
+
+        assert!(scan.resolved.is_empty());
+        assert!(!scan.has_computed);
     }
 
     #[test]

--- a/crates/zccache-depgraph/src/header_trace.rs
+++ b/crates/zccache-depgraph/src/header_trace.rs
@@ -1,0 +1,335 @@
+//! GCC/Clang `-H` include-trace parsing and stderr filtering.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use zccache_core::NormalizedPath;
+
+use crate::scanner::ScanResult;
+
+const MAX_PARTIAL_LINE_BYTES: usize = 64 * 1024;
+
+/// Incremental parser for compiler-emitted `-H` records.
+pub struct HeaderTraceParser {
+    source: NormalizedPath,
+    cwd: NormalizedPath,
+    seen: HashSet<NormalizedPath>,
+    resolved: Vec<NormalizedPath>,
+    partial: Vec<u8>,
+    passthrough_line: bool,
+    gcc_guard_summary: bool,
+    incomplete: bool,
+}
+
+impl HeaderTraceParser {
+    #[must_use]
+    pub fn new(source: &Path, cwd: &Path) -> Self {
+        Self {
+            source: crate::depfile::canonicalize_path(source, cwd),
+            cwd: NormalizedPath::new(cwd),
+            seen: HashSet::new(),
+            resolved: Vec::new(),
+            partial: Vec::new(),
+            passthrough_line: false,
+            gcc_guard_summary: false,
+            incomplete: false,
+        }
+    }
+
+    pub fn push(&mut self, mut chunk: &[u8], output: &mut Vec<u8>) {
+        while !chunk.is_empty() {
+            if self.passthrough_line {
+                if let Some(newline) = chunk.iter().position(|byte| *byte == b'\n') {
+                    output.extend_from_slice(&chunk[..=newline]);
+                    chunk = &chunk[newline + 1..];
+                    self.passthrough_line = false;
+                } else {
+                    output.extend_from_slice(chunk);
+                    return;
+                }
+                continue;
+            }
+
+            if let Some(newline) = chunk.iter().position(|byte| *byte == b'\n') {
+                self.partial.extend_from_slice(&chunk[..=newline]);
+                chunk = &chunk[newline + 1..];
+                self.finish_line(output);
+            } else {
+                self.partial.extend_from_slice(chunk);
+                if self.partial.len() > MAX_PARTIAL_LINE_BYTES {
+                    output.extend_from_slice(&self.partial);
+                    self.partial.clear();
+                    self.passthrough_line = true;
+                }
+                return;
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn finish(mut self, output: &mut Vec<u8>) -> ScanResult {
+        if !self.partial.is_empty() {
+            self.finish_line(output);
+        }
+        ScanResult {
+            resolved: self.resolved,
+            unresolved: Vec::new(),
+            has_computed: self.incomplete,
+        }
+    }
+
+    fn finish_line(&mut self, output: &mut Vec<u8>) {
+        let raw = std::mem::take(&mut self.partial);
+        if !self.record_header(&raw) {
+            output.extend_from_slice(&raw);
+        }
+    }
+
+    fn record_header(&mut self, raw: &[u8]) -> bool {
+        let text = raw.strip_suffix(b"\n").unwrap_or(raw);
+        let text = text.strip_suffix(b"\r").unwrap_or(text);
+        if text == b"Multiple include guards may be useful for:" {
+            self.gcc_guard_summary = true;
+            return true;
+        }
+        if self.gcc_guard_summary {
+            if self.record_path_bytes(text) {
+                return true;
+            }
+            if looks_like_path(text) {
+                self.incomplete = true;
+            }
+            self.gcc_guard_summary = false;
+        }
+        let depth = text.iter().take_while(|byte| **byte == b'.').count();
+        let path_start = match text.get(depth..) {
+            Some([b' ', ..]) if depth > 0 => depth + 1,
+            Some([b'!' | b'x', b' ', ..]) if depth > 0 => depth + 2,
+            _ => return false,
+        };
+        if self.record_path_bytes(&text[path_start..]) {
+            true
+        } else {
+            // The line has the compiler's exact trace shape, but zccache
+            // could not retain its path. Keep the bytes visible as a possible
+            // diagnostic and disable direct-mode hits for this manifest.
+            self.incomplete = true;
+            false
+        }
+    }
+
+    #[cfg(unix)]
+    fn record_path_bytes(&mut self, bytes: &[u8]) -> bool {
+        std::str::from_utf8(bytes)
+            .ok()
+            .is_some_and(|path| self.record_path(Path::new(path)))
+    }
+
+    #[cfg(not(unix))]
+    fn record_path_bytes(&mut self, bytes: &[u8]) -> bool {
+        std::str::from_utf8(bytes)
+            .ok()
+            .is_some_and(|path| self.record_path(Path::new(path)))
+    }
+
+    fn record_path(&mut self, path: &Path) -> bool {
+        if path.as_os_str().is_empty() {
+            return false;
+        }
+        let path = if path.is_absolute() {
+            crate::depfile::canonicalize_path(path, self.cwd.as_path())
+        } else {
+            crate::depfile::canonicalize_path(&self.cwd.join(path), self.cwd.as_path())
+        };
+        // `-H` records name files that the compiler successfully opened. An
+        // existence check prevents trace-shaped diagnostics from being
+        // swallowed if they do not name an actual include.
+        if !path.is_file() {
+            return false;
+        }
+        if path != self.source && self.seen.insert(path.clone()) {
+            self.resolved.push(path);
+        }
+        true
+    }
+}
+
+fn looks_like_path(bytes: &[u8]) -> bool {
+    bytes
+        .first()
+        .is_some_and(|byte| matches!(*byte, b'/' | b'\\'))
+        || bytes.get(1) == Some(&b':')
+        || bytes.iter().any(|byte| matches!(*byte, b'/' | b'\\'))
+}
+
+#[must_use]
+pub fn parse_header_trace(stderr: &[u8], source: &Path, cwd: &Path) -> (ScanResult, Vec<u8>) {
+    let mut parser = HeaderTraceParser::new(source, cwd);
+    let mut filtered = Vec::new();
+    parser.push(stderr, &mut filtered);
+    (parser.finish(&mut filtered), filtered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_paths_with_spaces_and_preserves_diagnostics() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.c");
+        let header = temp.path().join("header with spaces.h");
+        std::fs::write(&source, "").unwrap();
+        std::fs::write(&header, "").unwrap();
+        let stderr = format!(
+            ". {}\nwarning: useful diagnostic\n.. {}\n",
+            header.display(),
+            header.display()
+        );
+
+        let (scan, filtered) = parse_header_trace(stderr.as_bytes(), &source, temp.path());
+
+        assert_eq!(scan.resolved, vec![NormalizedPath::new(&header)]);
+        assert_eq!(filtered, b"warning: useful diagnostic\n");
+        assert!(!scan.has_computed);
+    }
+
+    #[test]
+    fn streaming_chunks_match_batch_output() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.c");
+        let header = temp.path().join("header.h");
+        std::fs::write(&source, "").unwrap();
+        std::fs::write(&header, "").unwrap();
+        let stderr = format!(". {}\r\nnote: retained\r\n", header.display());
+        let expected = parse_header_trace(stderr.as_bytes(), &source, temp.path());
+        let mut parser = HeaderTraceParser::new(&source, temp.path());
+        let mut filtered = Vec::new();
+        for chunk in stderr.as_bytes().chunks(3) {
+            parser.push(chunk, &mut filtered);
+        }
+        let scan = parser.finish(&mut filtered);
+
+        assert_eq!(scan.resolved, expected.0.resolved);
+        assert_eq!(filtered, expected.1);
+    }
+
+    #[test]
+    fn malformed_trace_shaped_lines_are_not_removed() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.c");
+        std::fs::write(&source, "").unwrap();
+        let stderr = b". not a path\n...\n.. warning: still useful\n";
+
+        let (scan, filtered) = parse_header_trace(stderr, &source, temp.path());
+
+        assert!(scan.resolved.is_empty());
+        assert_eq!(filtered, stderr);
+        assert!(scan.has_computed);
+    }
+
+    #[test]
+    fn source_record_is_filtered_but_not_tracked() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.c");
+        std::fs::write(&source, "").unwrap();
+        let stderr = format!(". {}\n", source.display());
+
+        let (scan, filtered) = parse_header_trace(stderr.as_bytes(), &source, temp.path());
+
+        assert!(scan.resolved.is_empty());
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn filters_gcc_include_guard_advisory_records_only() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.c");
+        let header = temp.path().join("unguarded.h");
+        std::fs::write(&source, "").unwrap();
+        std::fs::write(&header, "").unwrap();
+        let stderr = format!(
+            "Multiple include guards may be useful for:\n{}\nwarning: retained\n",
+            header.display()
+        );
+
+        let (scan, filtered) = parse_header_trace(stderr.as_bytes(), &source, temp.path());
+
+        assert_eq!(scan.resolved, vec![NormalizedPath::new(&header)]);
+        assert_eq!(filtered, b"warning: retained\n");
+    }
+
+    #[test]
+    fn disappeared_trace_path_fails_closed_and_remains_visible() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.c");
+        std::fs::write(&source, "").unwrap();
+        let missing = temp.path().join("removed-system-header.h");
+        let stderr = format!(". {}\n", missing.display());
+
+        let (scan, filtered) = parse_header_trace(stderr.as_bytes(), &source, temp.path());
+
+        assert!(scan.resolved.is_empty());
+        assert!(scan.has_computed);
+        assert_eq!(filtered, stderr.as_bytes());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn distinct_non_utf8_header_paths_fail_closed_without_lossy_deduplication() {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.c");
+        let first = temp
+            .path()
+            .join(std::ffi::OsString::from_vec(b"header-\xff.h".to_vec()));
+        let second = temp
+            .path()
+            .join(std::ffi::OsString::from_vec(b"header-\xfe.h".to_vec()));
+        std::fs::write(&source, "").unwrap();
+        std::fs::write(&first, "").unwrap();
+        std::fs::write(&second, "").unwrap();
+        let mut stderr = b". ".to_vec();
+        stderr.extend_from_slice(first.as_os_str().as_bytes());
+        stderr.extend_from_slice(b"\n. ");
+        stderr.extend_from_slice(second.as_os_str().as_bytes());
+        stderr.push(b'\n');
+
+        let (scan, filtered) = parse_header_trace(&stderr, &source, temp.path());
+
+        assert!(scan.resolved.is_empty());
+        assert!(scan.has_computed);
+        assert_eq!(filtered, stderr);
+    }
+
+    #[test]
+    fn gcc_pch_markers_are_filtered_and_tracked() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.c");
+        let valid = temp.path().join("valid.h.gch");
+        let invalid = temp.path().join("invalid.h.gch");
+        std::fs::write(&source, "").unwrap();
+        std::fs::write(&valid, "").unwrap();
+        std::fs::write(&invalid, "").unwrap();
+        let stderr = format!("..! {}\n...x {}\n", valid.display(), invalid.display());
+
+        let (scan, filtered) = parse_header_trace(stderr.as_bytes(), &source, temp.path());
+
+        assert_eq!(
+            scan.resolved,
+            vec![NormalizedPath::new(&valid), NormalizedPath::new(&invalid)]
+        );
+        assert!(!scan.has_computed);
+        assert!(filtered.is_empty());
+
+        let mut parser = HeaderTraceParser::new(&source, temp.path());
+        let mut streamed = Vec::new();
+        for chunk in stderr.as_bytes().chunks(2) {
+            parser.push(chunk, &mut streamed);
+        }
+        let streamed_scan = parser.finish(&mut streamed);
+        assert_eq!(streamed_scan.resolved, scan.resolved);
+        assert!(streamed.is_empty());
+    }
+}

--- a/crates/zccache-depgraph/src/header_trace.rs
+++ b/crates/zccache-depgraph/src/header_trace.rs
@@ -451,8 +451,12 @@ mod tests {
         let first = temp.path().join(first_name);
         let second = temp.path().join(second_name);
         std::fs::write(&source, "").unwrap();
-        std::fs::write(&first, "").unwrap();
-        std::fs::write(&second, "").unwrap();
+        // Some Unix filesystems reject byte sequences that `OsString` can
+        // represent (APFS reports EILSEQ, for example). Exercise the
+        // fail-closed path wherever the fixture itself is supported.
+        if std::fs::write(&first, "").is_err() || std::fs::write(&second, "").is_err() {
+            return;
+        }
         let stderr = b". header-\xff.h\n. header-\xfe.h\n".to_vec();
 
         let (scan, filtered) = parse_header_trace(&stderr, &source, temp.path());

--- a/crates/zccache-depgraph/src/header_trace.rs
+++ b/crates/zccache-depgraph/src/header_trace.rs
@@ -118,14 +118,6 @@ impl HeaderTraceParser {
         }
     }
 
-    #[cfg(unix)]
-    fn record_path_bytes(&mut self, bytes: &[u8]) -> bool {
-        std::str::from_utf8(bytes)
-            .ok()
-            .is_some_and(|path| self.record_path(Path::new(path)))
-    }
-
-    #[cfg(not(unix))]
     fn record_path_bytes(&mut self, bytes: &[u8]) -> bool {
         std::str::from_utf8(bytes)
             .ok()
@@ -170,6 +162,30 @@ pub fn parse_header_trace(stderr: &[u8], source: &Path, cwd: &Path) -> (ScanResu
     (parser.finish(&mut filtered), filtered)
 }
 
+/// Parse Clang's private `-header-include-file` output.
+///
+/// Unlike `-H`, this sink contains one bare path per line and does not share
+/// stderr with user diagnostics. Missing or malformed output fails closed so
+/// a compiler-version mismatch can never create a direct-mode false hit.
+#[must_use]
+pub fn parse_header_trace_file(path: &Path, source: &Path, cwd: &Path) -> ScanResult {
+    let mut parser = HeaderTraceParser::new(source, cwd);
+    let trace = match std::fs::read(path) {
+        Ok(trace) => trace,
+        Err(_) => {
+            parser.incomplete = true;
+            return parser.finish(&mut Vec::new());
+        }
+    };
+    for line in trace.split(|byte| *byte == b'\n') {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        if !line.is_empty() && !parser.record_path_bytes(line) {
+            parser.incomplete = true;
+        }
+    }
+    parser.finish(&mut Vec::new())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -189,7 +205,10 @@ mod tests {
 
         let (scan, filtered) = parse_header_trace(stderr.as_bytes(), &source, temp.path());
 
-        assert_eq!(scan.resolved, vec![NormalizedPath::new(&header)]);
+        assert_eq!(
+            scan.resolved,
+            vec![crate::depfile::canonicalize_path(&header, temp.path())]
+        );
         assert_eq!(filtered, b"warning: useful diagnostic\n");
         assert!(!scan.has_computed);
     }
@@ -255,7 +274,10 @@ mod tests {
 
         let (scan, filtered) = parse_header_trace(stderr.as_bytes(), &source, temp.path());
 
-        assert_eq!(scan.resolved, vec![NormalizedPath::new(&header)]);
+        assert_eq!(
+            scan.resolved,
+            vec![crate::depfile::canonicalize_path(&header, temp.path())]
+        );
         assert_eq!(filtered, b"warning: retained\n");
     }
 
@@ -274,27 +296,22 @@ mod tests {
         assert_eq!(filtered, stderr.as_bytes());
     }
 
-    #[cfg(unix)]
     #[test]
     fn distinct_non_utf8_header_paths_fail_closed_without_lossy_deduplication() {
-        use std::os::unix::ffi::{OsStrExt, OsStringExt};
-
         let temp = tempfile::TempDir::new().unwrap();
         let source = temp.path().join("main.c");
-        let first = temp
-            .path()
-            .join(std::ffi::OsString::from_vec(b"header-\xff.h".to_vec()));
-        let second = temp
-            .path()
-            .join(std::ffi::OsString::from_vec(b"header-\xfe.h".to_vec()));
+        let Some(first_name) = crate::platform::fs::path::from_raw_bytes(b"header-\xff.h") else {
+            return;
+        };
+        let Some(second_name) = crate::platform::fs::path::from_raw_bytes(b"header-\xfe.h") else {
+            return;
+        };
+        let first = temp.path().join(first_name);
+        let second = temp.path().join(second_name);
         std::fs::write(&source, "").unwrap();
         std::fs::write(&first, "").unwrap();
         std::fs::write(&second, "").unwrap();
-        let mut stderr = b". ".to_vec();
-        stderr.extend_from_slice(first.as_os_str().as_bytes());
-        stderr.extend_from_slice(b"\n. ");
-        stderr.extend_from_slice(second.as_os_str().as_bytes());
-        stderr.push(b'\n');
+        let stderr = b". header-\xff.h\n. header-\xfe.h\n".to_vec();
 
         let (scan, filtered) = parse_header_trace(&stderr, &source, temp.path());
 
@@ -331,5 +348,41 @@ mod tests {
         let streamed_scan = parser.finish(&mut streamed);
         assert_eq!(streamed_scan.resolved, scan.resolved);
         assert!(streamed.is_empty());
+    }
+
+    #[test]
+    fn private_trace_file_tracks_paths_and_fails_closed_on_bad_records() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.c");
+        let header = temp.path().join("header with spaces.h");
+        let trace = temp.path().join("main.headers");
+        std::fs::write(&source, "").unwrap();
+        std::fs::write(&header, "").unwrap();
+        std::fs::write(
+            &trace,
+            format!("{}\n{}\nmissing.h\n", source.display(), header.display()),
+        )
+        .unwrap();
+
+        let scan = parse_header_trace_file(&trace, &source, temp.path());
+
+        assert_eq!(
+            scan.resolved,
+            vec![crate::depfile::canonicalize_path(&header, temp.path())]
+        );
+        assert!(scan.has_computed);
+    }
+
+    #[test]
+    fn missing_private_trace_file_fails_closed() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.c");
+        std::fs::write(&source, "").unwrap();
+
+        let scan =
+            parse_header_trace_file(&temp.path().join("missing.headers"), &source, temp.path());
+
+        assert!(scan.resolved.is_empty());
+        assert!(scan.has_computed);
     }
 }

--- a/crates/zccache-depgraph/src/header_trace.rs
+++ b/crates/zccache-depgraph/src/header_trace.rs
@@ -125,8 +125,16 @@ impl HeaderTraceParser {
     }
 
     fn record_path(&mut self, path: &Path) -> bool {
-        if path.as_os_str().is_empty() {
+        let Some(path) = self.resolve_path(path) else {
             return false;
+        };
+        self.record_resolved_path(path);
+        true
+    }
+
+    fn resolve_path(&self, path: &Path) -> Option<NormalizedPath> {
+        if path.as_os_str().is_empty() {
+            return None;
         }
         let path = if path.is_absolute() {
             crate::depfile::canonicalize_path(path, self.cwd.as_path())
@@ -137,12 +145,15 @@ impl HeaderTraceParser {
         // existence check prevents trace-shaped diagnostics from being
         // swallowed if they do not name an actual include.
         if !path.is_file() {
-            return false;
+            return None;
         }
+        Some(path)
+    }
+
+    fn record_resolved_path(&mut self, path: NormalizedPath) {
         if path != self.source && self.seen.insert(path.clone()) {
             self.resolved.push(path);
         }
-        true
     }
 }
 
@@ -162,28 +173,155 @@ pub fn parse_header_trace(stderr: &[u8], source: &Path, cwd: &Path) -> (ScanResu
     (parser.finish(&mut filtered), filtered)
 }
 
-/// Parse Clang's private `-header-include-file` output.
+/// Parse Clang's private `-dependency-dot` output.
 ///
-/// Unlike `-H`, this sink contains one bare path per line and does not share
-/// stderr with user diagnostics. Missing or malformed output fails closed so
-/// a compiler-version mismatch can never create a direct-mode false hit.
+/// This sink contains compiler-selected user and system headers without
+/// sharing stderr with diagnostics. Missing or malformed output fails closed
+/// so a compiler-version mismatch can never create a direct-mode false hit.
 #[must_use]
-pub fn parse_header_trace_file(path: &Path, source: &Path, cwd: &Path) -> ScanResult {
+pub fn parse_dependency_graph_file(path: &Path, source: &Path, cwd: &Path) -> ScanResult {
     let mut parser = HeaderTraceParser::new(source, cwd);
-    let trace = match std::fs::read(path) {
-        Ok(trace) => trace,
+    let graph = match std::fs::read(path) {
+        Ok(graph) => graph,
         Err(_) => {
             parser.incomplete = true;
             return parser.finish(&mut Vec::new());
         }
     };
-    for line in trace.split(|byte| *byte == b'\n') {
+    let mut saw_header = false;
+    let mut saw_footer = false;
+    let mut saw_source = false;
+    let mut node_ids = HashSet::new();
+    let mut edges = Vec::new();
+    for line in graph.split(|byte| *byte == b'\n') {
         let line = line.strip_suffix(b"\r").unwrap_or(line);
-        if !line.is_empty() && !parser.record_path_bytes(line) {
+        if line.is_empty() {
+            continue;
+        }
+        if !saw_header {
+            saw_header = line == b"digraph \"dependencies\" {";
+            parser.incomplete |= !saw_header;
+            continue;
+        }
+        if line == b"}" {
+            if saw_footer {
+                parser.incomplete = true;
+            }
+            saw_footer = true;
+            continue;
+        }
+        if saw_footer {
             parser.incomplete = true;
+            continue;
+        }
+        let Some(line) = line.strip_prefix(b"  ") else {
+            parser.incomplete = true;
+            continue;
+        };
+        if let Some(edge) = parse_dependency_graph_edge(line) {
+            edges.push(edge);
+            continue;
+        }
+        let Some((id, label)) = parse_dependency_graph_node(line) else {
+            parser.incomplete = true;
+            continue;
+        };
+        if !node_ids.insert(id) {
+            parser.incomplete = true;
+            continue;
+        }
+        let Some(path) = resolve_dependency_graph_path(&parser, &label) else {
+            parser.incomplete = true;
+            continue;
+        };
+        if path == parser.source {
+            saw_source = true;
+        }
+        parser.record_resolved_path(path);
+    }
+    parser.incomplete |= !saw_header
+        || !saw_footer
+        || !saw_source
+        || edges
+            .iter()
+            .any(|(from, to)| !node_ids.contains(from) || !node_ids.contains(to));
+    parser.finish(&mut Vec::new())
+}
+
+fn parse_dependency_graph_node(line: &[u8]) -> Option<(u64, Vec<u8>)> {
+    let line = line.strip_prefix(b"header_")?;
+    let id_len = line.iter().take_while(|byte| byte.is_ascii_digit()).count();
+    if id_len == 0 {
+        return None;
+    }
+    let id = std::str::from_utf8(&line[..id_len]).ok()?.parse().ok()?;
+    let line = &line[id_len..];
+    let prefix = b" [ shape=\"box\", label=\"";
+    let mut index = prefix.len();
+    line.starts_with(prefix).then_some(())?;
+    let mut label = Vec::new();
+    while index < line.len() {
+        match line[index] {
+            b'"' => {
+                return (line.get(index + 1..) == Some(b"];")).then_some((id, label));
+            }
+            b'\\' => {
+                index += 1;
+                let escaped = *line.get(index)?;
+                match escaped {
+                    b'n' => label.push(b'\n'),
+                    b'\\' | b'"' | b'{' | b'}' | b'<' | b'>' | b'|' => label.push(escaped),
+                    // LLVM deliberately leaves `\l` untouched.
+                    b'l' => label.extend_from_slice(b"\\l"),
+                    _ => return None,
+                }
+            }
+            byte => label.push(byte),
+        }
+        index += 1;
+    }
+    None
+}
+
+fn parse_dependency_graph_edge(line: &[u8]) -> Option<(u64, u64)> {
+    let line = line.strip_prefix(b"header_")?;
+    let from_len = line.iter().take_while(|byte| byte.is_ascii_digit()).count();
+    if from_len == 0 {
+        return None;
+    }
+    let from = std::str::from_utf8(&line[..from_len]).ok()?.parse().ok()?;
+    let line = line[from_len..].strip_prefix(b" -> header_")?;
+    let to_len = line.iter().take_while(|byte| byte.is_ascii_digit()).count();
+    if to_len == 0 || line.get(to_len..) != Some(b";") {
+        return None;
+    }
+    let to = std::str::from_utf8(&line[..to_len]).ok()?.parse().ok()?;
+    Some((from, to))
+}
+
+fn resolve_dependency_graph_path(
+    parser: &HeaderTraceParser,
+    bytes: &[u8],
+) -> Option<NormalizedPath> {
+    let path = Path::new(std::str::from_utf8(bytes).ok()?);
+    let mut candidates = Vec::new();
+    if let Some(candidate) = parser.resolve_path(path) {
+        candidates.push(candidate);
+    }
+    if !path.is_absolute() {
+        if let Some(candidate) = crate::platform::fs::path::system_root_candidate(path)
+            .and_then(|rooted| parser.resolve_path(&rooted))
+        {
+            if !candidates.contains(&candidate) {
+                candidates.push(candidate);
+            }
         }
     }
-    parser.finish(&mut Vec::new())
+    if candidates.len() == 1 {
+        candidates.pop()
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -351,7 +489,7 @@ mod tests {
     }
 
     #[test]
-    fn private_trace_file_tracks_paths_and_fails_closed_on_bad_records() {
+    fn private_dependency_graph_tracks_paths_and_fails_closed_on_bad_records() {
         let temp = tempfile::TempDir::new().unwrap();
         let source = temp.path().join("main.c");
         let header = temp.path().join("header with spaces.h");
@@ -360,11 +498,15 @@ mod tests {
         std::fs::write(&header, "").unwrap();
         std::fs::write(
             &trace,
-            format!("{}\n{}\nmissing.h\n", source.display(), header.display()),
+            format!(
+                "digraph \"dependencies\" {{\n  header_0 [ shape=\"box\", label=\"{}\"];\n  header_1 [ shape=\"box\", label=\"{}\"];\n  malformed node\n}}\n",
+                dot_escape_path(&source),
+                dot_escape_path(&header)
+            ),
         )
         .unwrap();
 
-        let scan = parse_header_trace_file(&trace, &source, temp.path());
+        let scan = parse_dependency_graph_file(&trace, &source, temp.path());
 
         assert_eq!(
             scan.resolved,
@@ -374,15 +516,130 @@ mod tests {
     }
 
     #[test]
-    fn missing_private_trace_file_fails_closed() {
+    fn rootless_dependency_graph_paths_resolve_from_the_system_root() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.c");
+        let header = temp.path().join("system.h");
+        std::fs::write(&source, "").unwrap();
+        std::fs::write(&header, "").unwrap();
+        let rootless = header
+            .to_string_lossy()
+            .trim_start_matches(['/', '\\'])
+            .to_string();
+        let Some(candidate) =
+            crate::platform::fs::path::system_root_candidate(Path::new(&rootless))
+        else {
+            return;
+        };
+        if !candidate.is_file() {
+            return;
+        }
+        let trace = temp.path().join("rootless.headers");
+        std::fs::write(
+            &trace,
+            format!(
+                "digraph \"dependencies\" {{\n  header_0 [ shape=\"box\", label=\"{}\"];\n  header_1 [ shape=\"box\", label=\"{}\"];\n  header_0 -> header_1;\n}}\n",
+                dot_escape_path(&source),
+                rootless.replace('\\', "\\\\").replace('"', "\\\"")
+            ),
+        )
+        .unwrap();
+
+        let scan = parse_dependency_graph_file(&trace, &source, temp.path());
+
+        assert_eq!(
+            scan.resolved,
+            vec![crate::depfile::canonicalize_path(&header, temp.path())]
+        );
+        assert!(!scan.has_computed);
+    }
+
+    #[test]
+    fn ambiguous_rootless_dependency_graph_path_fails_closed() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.c");
+        let header = temp.path().join("system.h");
+        std::fs::write(&source, "").unwrap();
+        std::fs::write(&header, "").unwrap();
+        let rootless = header
+            .to_string_lossy()
+            .trim_start_matches(['/', '\\'])
+            .to_string();
+        let Some(candidate) =
+            crate::platform::fs::path::system_root_candidate(Path::new(&rootless))
+        else {
+            return;
+        };
+        if !candidate.is_file() {
+            return;
+        }
+        let shadow = temp.path().join(&rootless);
+        std::fs::create_dir_all(shadow.parent().unwrap()).unwrap();
+        std::fs::write(&shadow, "shadow").unwrap();
+        let trace = temp.path().join("ambiguous.headers");
+        std::fs::write(
+            &trace,
+            format!(
+                "digraph \"dependencies\" {{\n  header_0 [ shape=\"box\", label=\"{}\"];\n  header_1 [ shape=\"box\", label=\"{}\"];\n  header_0 -> header_1;\n}}\n",
+                dot_escape_path(&source),
+                rootless.replace('\\', "\\\\").replace('"', "\\\"")
+            ),
+        )
+        .unwrap();
+
+        let scan = parse_dependency_graph_file(&trace, &source, temp.path());
+
+        assert!(scan.resolved.is_empty());
+        assert!(scan.has_computed);
+    }
+
+    #[test]
+    fn dependency_graph_requires_nodes_source_and_one_footer() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.c");
+        std::fs::write(&source, "").unwrap();
+        for graph in [
+            "digraph \"dependencies\" {\n  header_0 -> header_1;\n}\n",
+            "digraph \"dependencies\" {\n  header_0 -> broken;\n}\n",
+        ] {
+            let trace = temp.path().join("invalid.headers");
+            std::fs::write(&trace, graph).unwrap();
+
+            let scan = parse_dependency_graph_file(&trace, &source, temp.path());
+
+            assert!(scan.resolved.is_empty());
+            assert!(scan.has_computed, "graph should fail closed: {graph:?}");
+        }
+
+        let trace = temp.path().join("duplicate-footer.headers");
+        let graph = format!(
+            "digraph \"dependencies\" {{\n  header_0 [ shape=\"box\", label=\"{}\"];\n}}\n}}\n",
+            dot_escape_path(&source)
+        );
+        std::fs::write(&trace, &graph).unwrap();
+
+        let scan = parse_dependency_graph_file(&trace, &source, temp.path());
+
+        assert!(scan.resolved.is_empty());
+        assert!(scan.has_computed, "graph should fail closed: {graph:?}");
+    }
+
+    #[test]
+    fn missing_private_dependency_graph_fails_closed() {
         let temp = tempfile::TempDir::new().unwrap();
         let source = temp.path().join("main.c");
         std::fs::write(&source, "").unwrap();
 
         let scan =
-            parse_header_trace_file(&temp.path().join("missing.headers"), &source, temp.path());
+            parse_dependency_graph_file(&temp.path().join("missing.headers"), &source, temp.path());
 
         assert!(scan.resolved.is_empty());
         assert!(scan.has_computed);
+    }
+
+    fn dot_escape_path(path: &Path) -> String {
+        path.to_string_lossy()
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
     }
 }

--- a/crates/zccache-depgraph/src/lib.rs
+++ b/crates/zccache-depgraph/src/lib.rs
@@ -9,6 +9,7 @@ pub mod compile_commands;
 pub mod context;
 pub mod depfile;
 pub mod graph;
+pub mod header_trace;
 pub mod msvc_args;
 pub mod native_cpu;
 pub mod rustc_args;

--- a/crates/zccache-platform/src/platform/fs/path.rs
+++ b/crates/zccache-platform/src/platform/fs/path.rs
@@ -45,6 +45,12 @@ pub fn from_raw_bytes(bytes: &[u8]) -> Option<PathBuf> {
     platform_imp::fs::path::from_raw_bytes(bytes)
 }
 
+/// Resolves a compiler path that is relative only because its leading host
+/// root separator was omitted. Windows drive-relative paths are ambiguous.
+pub fn system_root_candidate(path: &Path) -> Option<PathBuf> {
+    platform_imp::fs::path::system_root_candidate(path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -69,5 +75,12 @@ mod tests {
             from_raw_bytes(b"dir/header.h"),
             Some(PathBuf::from("dir/header.h"))
         );
+    }
+
+    #[test]
+    fn system_root_candidate_preserves_the_path_suffix() {
+        if let Some(rooted) = system_root_candidate(Path::new("dir/header.h")) {
+            assert!(rooted.ends_with(Path::new("dir/header.h")));
+        }
     }
 }

--- a/crates/zccache-platform/src/platform/fs/path.rs
+++ b/crates/zccache-platform/src/platform/fs/path.rs
@@ -38,6 +38,13 @@ pub fn verbatim_path(path: &Path) -> std::io::Result<PathBuf> {
     platform_imp::fs::path::verbatim_path(path)
 }
 
+/// Converts compiler-emitted path bytes into the host's native path form.
+/// Unix preserves arbitrary bytes; Windows accepts UTF-8 because a byte
+/// stream cannot represent native UTF-16 losslessly.
+pub fn from_raw_bytes(bytes: &[u8]) -> Option<PathBuf> {
+    platform_imp::fs::path::from_raw_bytes(bytes)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -55,5 +62,12 @@ mod tests {
         let once = case_fold(&p);
         let twice = case_fold(&p);
         assert_eq!(once, twice);
+    }
+    #[test]
+    fn utf8_raw_bytes_form_a_native_path() {
+        assert_eq!(
+            from_raw_bytes(b"dir/header.h"),
+            Some(PathBuf::from("dir/header.h"))
+        );
     }
 }

--- a/crates/zccache-platform/src/platform_linux/fs/path.rs
+++ b/crates/zccache-platform/src/platform_linux/fs/path.rs
@@ -1,6 +1,7 @@
 //! Linux path-key normalization: all no-ops (case-sensitive, no verbatim
 //! prefix, no MSYS).
 
+use std::os::unix::ffi::OsStringExt;
 use std::path::{Path, PathBuf};
 
 /// Linux has no `\\?\` verbatim prefix.
@@ -26,4 +27,8 @@ pub fn canonicalize_private_prefix(path: &Path) -> PathBuf {
 /// Linux has no verbatim (`\\?\`) path form.
 pub fn verbatim_path(path: &Path) -> std::io::Result<PathBuf> {
     Ok(path.to_path_buf())
+}
+
+pub fn from_raw_bytes(bytes: &[u8]) -> Option<PathBuf> {
+    Some(std::ffi::OsString::from_vec(bytes.to_vec()).into())
 }

--- a/crates/zccache-platform/src/platform_linux/fs/path.rs
+++ b/crates/zccache-platform/src/platform_linux/fs/path.rs
@@ -32,3 +32,7 @@ pub fn verbatim_path(path: &Path) -> std::io::Result<PathBuf> {
 pub fn from_raw_bytes(bytes: &[u8]) -> Option<PathBuf> {
     Some(std::ffi::OsString::from_vec(bytes.to_vec()).into())
 }
+
+pub fn system_root_candidate(path: &Path) -> Option<PathBuf> {
+    Some(Path::new("/").join(path))
+}

--- a/crates/zccache-platform/src/platform_macos/fs/path.rs
+++ b/crates/zccache-platform/src/platform_macos/fs/path.rs
@@ -41,3 +41,7 @@ pub fn verbatim_path(path: &Path) -> std::io::Result<PathBuf> {
 pub fn from_raw_bytes(bytes: &[u8]) -> Option<PathBuf> {
     Some(std::ffi::OsString::from_vec(bytes.to_vec()).into())
 }
+
+pub fn system_root_candidate(path: &Path) -> Option<PathBuf> {
+    Some(Path::new("/").join(path))
+}

--- a/crates/zccache-platform/src/platform_macos/fs/path.rs
+++ b/crates/zccache-platform/src/platform_macos/fs/path.rs
@@ -1,6 +1,7 @@
 //! macOS path-key normalization: Unicode case folding and the
 //! `/private/var` prefix mapping.
 
+use std::os::unix::ffi::OsStringExt;
 use std::path::{Path, PathBuf};
 
 /// macOS has no `\\?\` verbatim prefix.
@@ -35,4 +36,8 @@ pub fn canonicalize_private_prefix(path: &Path) -> PathBuf {
 /// macOS has no verbatim (`\\?\`) path form.
 pub fn verbatim_path(path: &Path) -> std::io::Result<PathBuf> {
     Ok(path.to_path_buf())
+}
+
+pub fn from_raw_bytes(bytes: &[u8]) -> Option<PathBuf> {
+    Some(std::ffi::OsString::from_vec(bytes.to_vec()).into())
 }

--- a/crates/zccache-platform/src/platform_win/fs/path.rs
+++ b/crates/zccache-platform/src/platform_win/fs/path.rs
@@ -57,3 +57,7 @@ pub(crate) use super::verbatim_path;
 pub fn from_raw_bytes(bytes: &[u8]) -> Option<PathBuf> {
     std::str::from_utf8(bytes).ok().map(PathBuf::from)
 }
+
+pub fn system_root_candidate(_path: &Path) -> Option<PathBuf> {
+    None
+}

--- a/crates/zccache-platform/src/platform_win/fs/path.rs
+++ b/crates/zccache-platform/src/platform_win/fs/path.rs
@@ -53,3 +53,7 @@ pub fn canonicalize_private_prefix(path: &Path) -> PathBuf {
 /// lives in `super::verbatim` and is re-exported so the neutral facade can
 /// reach it through the `path` module.
 pub(crate) use super::verbatim_path;
+
+pub fn from_raw_bytes(bytes: &[u8]) -> Option<PathBuf> {
+    std::str::from_utf8(bytes).ok().map(PathBuf::from)
+}

--- a/crates/zccache/tests/daemon_integration_test.rs
+++ b/crates/zccache/tests/daemon_integration_test.rs
@@ -273,7 +273,7 @@ async fn test_full_client_flow() {
 /// 5. Read log_file → verify cache miss then cache hit entries
 #[tokio::test]
 #[ignore] // integration-level: starts real daemon with IPC + compiler
-async fn test_compile_hello_cpp_cached() {
+async fn test_compile_hello_cpp_cached_with_forwarded_depfile() {
     let clang_path = match zccache::test_support::find_clang() {
         Some(p) => p,
         None => {
@@ -286,20 +286,11 @@ async fn test_compile_hello_cpp_cached() {
         // Create temp dir with hello.cpp
         let tmp = tempfile::tempdir().unwrap();
         let hello_cpp = tmp.path().join("hello.cpp");
-        std::fs::write(
-            &hello_cpp,
-            r#"#include <stdio.h>
-int main() {
-    printf("hello world\n");
-    return 0;
-}
-"#,
-        )
-        .unwrap();
+        std::fs::write(&hello_cpp, "int main() { return 0; }\n").unwrap();
 
         let log_file = tmp.path().join("session.log");
         let output_obj = tmp.path().join("hello.o");
-        let depfile = tmp.path().join("hello.d");
+        let depfile = tmp.path().join("forwarded-custom.d");
 
         let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
         let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
@@ -334,9 +325,7 @@ int main() {
                     hello_cpp.to_string_lossy().into_owned(),
                     "-o".to_string(),
                     output_obj.to_string_lossy().into_owned(),
-                    "-MD".to_string(),
-                    "-MF".to_string(),
-                    depfile.to_string_lossy().into_owned(),
+                    format!("-Wp,-MMD,{}", depfile.to_string_lossy()),
                 ],
                 cwd: tmp.path().to_string_lossy().into_owned().into(),
                 compiler: compiler_str.clone().into(),
@@ -383,9 +372,7 @@ int main() {
                     hello_cpp.to_string_lossy().into_owned(),
                     "-o".to_string(),
                     output_obj.to_string_lossy().into_owned(),
-                    "-MD".to_string(),
-                    "-MF".to_string(),
-                    depfile.to_string_lossy().into_owned(),
+                    format!("-Wp,-MMD,{}", depfile.to_string_lossy()),
                 ],
                 cwd: tmp.path().to_string_lossy().into_owned().into(),
                 compiler: compiler_str.into(),
@@ -405,7 +392,11 @@ int main() {
                     exit_code, cached, ..
                 }) => {
                     assert_eq!(exit_code, 0, "second compile should succeed");
-                    assert!(cached, "second compile should be a cache hit");
+                    assert!(
+                        cached,
+                        "second compile should be a cache hit; session log:\n{}",
+                        std::fs::read_to_string(&log_file).unwrap_or_default()
+                    );
                     break;
                 }
                 other => panic!("expected CompileResult, got: {other:?}"),


### PR DESCRIPTION
Closes #1146

## Summary
- inject compact `-MMD` plus exact compiler-selected header tracing for supported GCC/Clang C/C++ compiles
- use Clang's file-backed dependency graph for ordinary C misses, capturing user and system headers without `-sys-header-deps`, duplicate MMD serialization, or stderr traffic
- retain the public streaming `-H` path for GCC and C++, preserving diagnostics and failing closed on malformed, missing, ambiguous, or non-UTF-8 records
- accept Clang's exact empty dependency graph for translation units with no includes while still requiring a source node whenever the graph contains nodes
- parse native and preprocessor-forwarded dependency options with their correct arity so custom depfiles are captured and restored on cache hits
- build and wire `zccache-ci` into the standalone performance harness so cache-log audit telemetry is valid
- refresh the tracked workspace lockfile so the read-only standalone build is reproducible

## Validation
- `soldr cargo fmt --all -- --check`
- `soldr cargo check --workspace --all-targets`
- `soldr cargo clippy --workspace --all-targets -- -D warnings`
- focused header-trace and dependency-argument unit suites on Windows and managed Linux
- restart-warm fake-compiler suites on Windows and managed Linux, including a two-source working directory containing spaces
- `mutation_system_header_forces_miss` ignored integration test on Windows and managed Linux
- forwarded `-Wp,-MMD,<non-default-path>` miss/delete/hit-restore integration test on Windows and managed Linux
- standalone harness contract: 17/17 Python tests; shell syntax check clean
- `/clud-review`: clean after all finding/fix follow-ups (one reviewer)
- head `77a9f3f7`: Linux, Windows, macOS Intel/ARM, wrapper E2E, filesystem matrix, Dylint, formatting, MSRV, and action checks pass
- the four remaining head failures reproduce on current `main`: three cargo-registry archive-path failures plus #1394's namespaced daemon-lock expectation in Integration Linux

## Performance acceptance
- Hosted Perf Guard C passed at `e82e1fe5`: cold zccache/bare 0.801x at the hosted 0.80 floor, warm 22.459x, zero failed attempts, and valid audit telemetry.
- A clean standalone Linux Docker diagnostic at exact head `77a9f3f7` passed: cold zccache/bare 0.906x (floor 0.85), cold zccache/sccache 1.543x, warm zccache/bare 37.897x, warm zccache/sccache 4.299x, zero fallback, and valid cold-miss/warm-hit telemetry.
- The completed local five-sample campaign is not claimed as acceptance evidence: unrelated host/compiler work began after its initial quiet-host check, the benchmark container received only 56% CPU, and tool timings swung by roughly 3x. Three attempts passed the cold floor; two contaminated attempts failed it. Additional starts were correctly rejected before timing when the same external workload was visible.