### PR TITLE
fix(daemon): contain compiler children on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,8 +1407,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
 dependencies = [
  "doctest-file",
+ "futures-core",
  "libc",
  "recvmsg",
+ "tokio",
  "widestring",
  "windows-sys 0.61.2",
 ]
@@ -2606,14 +2608,16 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.10.1"
+version = "4.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8ddef1be10a8e64bb8e2976419dbbef4cea7884e03ec5cef0722677b606154"
+checksum = "3e275dee5fdb4657b67ae2fdb660f23192fbc0225b34491d0c38824d98cff58b"
 dependencies = [
  "anyhow",
  "blake3",
+ "bytes",
  "clap",
  "dirs",
+ "futures-util",
  "getrandom 0.4.2",
  "interprocess",
  "libc",
@@ -2622,16 +2626,32 @@ dependencies = [
  "prost-build",
  "prost-types",
  "protox",
+ "running-process-platform-internal",
  "serde",
  "serde_json",
  "sha2",
  "sysinfo",
  "thiserror",
  "tokio",
+ "tokio-util",
  "toml",
  "winapi",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
  "x11rb",
+]
+
+[[package]]
+name = "running-process-platform-internal"
+version = "4.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e579bf42634c7ecc0d110a52149a6228183a8bc8973473546a4269e34cc1deab"
+dependencies = [
+ "interprocess",
+ "libc",
+ "sysinfo",
+ "tokio",
+ "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4093,7 +4113,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4141,6 +4161,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "wait-timeout",
+ "windows-sys 0.61.2",
  "zccache",
  "zccache-artifact",
  "zccache-audit",
@@ -4167,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "bincode",
  "blake3",
@@ -4192,7 +4213,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-audit"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -4202,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4211,7 +4232,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli-core"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "bincode",
  "blake3",
@@ -4265,14 +4286,14 @@ dependencies = [
 
 [[package]]
 name = "zccache-compile-trace"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "zccache-audit",
 ]
 
 [[package]]
 name = "zccache-compiler"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "clang",
  "serde_json",
@@ -4285,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "crash-handler",
  "dashmap",
@@ -4299,7 +4320,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon-core"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4350,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "bincode",
  "blake3",
@@ -4372,7 +4393,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "blake3",
  "futures",
@@ -4387,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "bincode",
  "bytes",
@@ -4400,7 +4421,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "filetime",
  "fs2",
@@ -4420,7 +4441,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "bincode",
  "dashmap",
@@ -4436,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "reqwest",
  "serde",
@@ -4447,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "blake3",
  "memmap2",
@@ -4457,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "bytes",
  "dashmap",
@@ -4478,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-platform"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "crash-handler",
  "interprocess",
@@ -4490,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "bincode",
  "bytes",
@@ -4508,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-symbols"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "tempfile",
  "zccache-core",
@@ -4516,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "tempfile",
  "zccache-audit",
@@ -4525,7 +4546,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.13.1"
+version = "1.13.5"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ lzma-rs = "0.3"
 sevenz-rust = "0.6"
 rkyv = "0.8"
 mimalloc = "0.1"
-running-process = { version = "4.10", default-features = false, features = ["client-async"] }
+running-process = { version = "4.10.3", default-features = false, features = ["client-async"] }
 zccache = { path = "crates/zccache" }
 zccache-artifact = { path = "crates/zccache-artifact" }
 zccache-audit = { path = "crates/zccache-audit" }

--- a/crates/zccache-cli-core/src/cli/runtime/mod.rs
+++ b/crates/zccache-cli-core/src/cli/runtime/mod.rs
@@ -1043,7 +1043,7 @@ mod tests {
         running_process::broker::protocol_v2::backend_handle::DaemonProcess {
             pid,
             exe_path: std::path::PathBuf::from("zccache-daemon"),
-            exe_sha256: [0u8; 32],
+            exe_hash: [0u8; 32],
             boot_id: "boot-that-never-was".to_string(),
             ipc_endpoint: crate::ipc::running_process_endpoint("test-endpoint"),
             started_at_unix_ms: 1,

--- a/crates/zccache-daemon-core/src/daemon/process.rs
+++ b/crates/zccache-daemon-core/src/daemon/process.rs
@@ -558,8 +558,10 @@ pub(crate) struct CompilePriorityParseError {
 /// The compiler-identity probe (`rustc -vV` in [`super::server`]'s
 /// compiler-hash module) is covered by the same boundary.
 ///
-/// Priority and daemon Job Object assignment remain local post-spawn policy;
-/// the actual process execution and console decision do not.
+/// Priority remains local post-spawn policy. Owner-death containment is
+/// configured transactionally by running-process on Linux and macOS; Windows
+/// retains zccache's established process-wide kill-on-close Job Object until
+/// the dependency's Windows spawn path can propagate assignment failures.
 ///
 /// Wait for an async command after applying a compiler child priority.
 ///
@@ -569,14 +571,12 @@ pub(crate) struct CompilePriorityParseError {
 /// reap the child when the daemon drops the compile future (a client
 /// disconnect / Ctrl-C) and when the daemon process itself dies, so a cancelled
 /// or crashed compile never orphans a rustc process. running-process provides
-/// the primitives: `kill_on_drop` (Tokio drop), Linux `PR_SET_PDEATHSIG`, and
-/// on Windows the kill-on-close job object.
+/// both primitives: `kill_on_drop` handles a dropped Tokio future, while the
+/// platform owner-death policy binds the child to the daemon process.
 ///
-/// `kill_on_drop` is enabled on every platform (the primary case: a dropped
-/// compile future must reap its child). `kill_when_owner_dies` is scoped to
-/// Linux here because the Windows path already assigns each child to the
-/// daemon's kill-on-close job below (`assign_child_to_daemon_job`); enabling it
-/// there too would place the child in a second job for no benefit.
+/// Linux and macOS install that containment transactionally in the dependency
+/// spawn boundary. Windows keeps the existing local kill-on-close Job Object,
+/// so it must not request the dependency's second Job Object as well.
 fn owned_child_spawn_options() -> running_process::TokioSpawnOptions {
     running_process::TokioSpawnOptions {
         kill_on_drop: true,

--- a/crates/zccache-daemon-core/src/daemon/process_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/process_tests.rs
@@ -1,5 +1,137 @@
 use super::*;
 
+#[test]
+fn daemon_owned_children_are_bound_to_both_future_and_process_lifetimes() {
+    let options = owned_child_spawn_options();
+    assert!(
+        options.kill_on_drop,
+        "dropping a cancelled compile future must reap its child"
+    );
+    assert_eq!(
+        options.kill_when_owner_dies,
+        crate::platform::process::spawn::uses_pre_spawn_owner_death(),
+        "the dependency option must match the platform's pre-spawn policy"
+    );
+}
+
+struct KillAndWaitGuard(Option<std::process::Child>);
+
+impl KillAndWaitGuard {
+    fn child_mut(&mut self) -> &mut std::process::Child {
+        self.0.as_mut().expect("owner helper is still armed")
+    }
+
+    fn kill_and_wait(&mut self) {
+        if let Some(mut child) = self.0.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+impl Drop for KillAndWaitGuard {
+    fn drop(&mut self) {
+        self.kill_and_wait();
+    }
+}
+
+#[test]
+fn daemon_owned_child_dies_when_helper_owner_is_killed() {
+    const HELPER_ENV: &str = "ZCCACHE_OWNER_DEATH_TEST_HELPER";
+    const PID_FILE_ENV: &str = "ZCCACHE_OWNER_DEATH_TEST_PID_FILE";
+
+    if std::env::var_os(HELPER_ENV).is_some() {
+        let mut command = owner_death_test_child_command(PID_FILE_ENV);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("owner-death helper runtime");
+        let result = runtime.block_on(tokio_leaf_command_output_with_priority(
+            &mut command,
+            CompilePriority::Normal,
+        ));
+        panic!("owner-death test child returned before its owner was killed: {result:?}");
+    }
+
+    let temp = tempfile::tempdir().expect("owner-death test tempdir");
+    let pid_file = temp.path().join("child.pid");
+    let test_name = "daemon::process::tests::daemon_owned_child_dies_when_helper_owner_is_killed";
+    let owner = std::process::Command::new(std::env::current_exe().expect("current test binary"))
+        .arg(test_name)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env(HELPER_ENV, "1")
+        .env(PID_FILE_ENV, &pid_file)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn owner-death helper process");
+    let mut owner = KillAndWaitGuard(Some(owner));
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let child_pid = loop {
+        if let Ok(contents) = std::fs::read_to_string(&pid_file) {
+            if let Ok(pid) = contents.trim().parse::<u32>() {
+                break pid;
+            }
+        }
+        if let Ok(Some(status)) = owner.child_mut().try_wait() {
+            panic!("owner-death helper exited before publishing its child PID: {status}");
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "owner-death helper did not publish its child PID"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    };
+    assert!(
+        crate::platform::process::inspect::is_alive(child_pid),
+        "test child must be alive before its owner is killed"
+    );
+
+    owner.kill_and_wait();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while crate::platform::process::inspect::is_alive(child_pid)
+        && std::time::Instant::now() < deadline
+    {
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+    let survived = crate::platform::process::inspect::is_alive(child_pid);
+    if survived {
+        let _ = crate::platform::process::terminate::force(child_pid);
+    }
+    assert!(
+        !survived,
+        "daemon-owned child {child_pid} survived after helper owner death"
+    );
+}
+
+fn owner_death_test_child_command(pid_file_env: &str) -> tokio::process::Command {
+    #[cfg(windows)]
+    {
+        let mut command = tokio::process::Command::new("powershell");
+        command.args([
+            "-NoProfile",
+            "-Command",
+            &format!(
+                "$PID | Set-Content -LiteralPath $env:{pid_file_env}; Start-Sleep -Seconds 30"
+            ),
+        ]);
+        command
+    }
+    #[cfg(unix)]
+    {
+        let mut command = tokio::process::Command::new("sh");
+        command.args([
+            "-c",
+            &format!("printf '%s\\n' \"$$\" > \"${pid_file_env}\"; exec sleep 30"),
+        ]);
+        command
+    }
+}
+
 // ── run_cpu_blocking (#955) ──
 
 #[test]

--- a/crates/zccache-ipc/src/mod_tests.rs
+++ b/crates/zccache-ipc/src/mod_tests.rs
@@ -895,7 +895,7 @@ fn fake_identity(
     running_process::broker::protocol_v2::backend_handle::DaemonProcess {
         pid,
         exe_path: std::path::PathBuf::from("zccache-daemon"),
-        exe_sha256: [0u8; 32],
+        exe_hash: [0u8; 32],
         boot_id: boot_id.to_string(),
         ipc_endpoint: running_process_endpoint("test-endpoint"),
         started_at_unix_ms,

--- a/crates/zccache-platform/src/platform/process/spawn.rs
+++ b/crates/zccache-platform/src/platform/process/spawn.rs
@@ -11,15 +11,16 @@ pub fn echo_output(marker: &str) -> std::io::Result<std::process::Output> {
     crate::platform_imp::process::spawn::echo_output(marker)
 }
 
-/// Attach a daemon-owned child to the host's owner-death primitive.
+/// Attach a daemon-owned child to the host's post-spawn owner-death primitive.
 ///
-/// Windows uses a process-wide kill-on-close Job Object. Unix ownership is
-/// configured before spawn, so this post-spawn operation is a no-op there.
+/// Windows uses zccache's process-wide kill-on-close Job Object. Linux and
+/// macOS configure ownership before spawn, so this is a no-op there.
 pub fn attach_owner_death(child: &tokio::process::Child) -> std::io::Result<()> {
     crate::platform_imp::process::spawn::attach_owner_death(child)
 }
 
-/// Whether the host's owner-death guarantee is installed before process spawn.
+/// Whether owner-death containment is installed by running-process before the
+/// child can execute.
 #[must_use]
 pub fn uses_pre_spawn_owner_death() -> bool {
     crate::platform_imp::process::spawn::uses_pre_spawn_owner_death()

--- a/crates/zccache-platform/src/platform_macos/process/spawn.rs
+++ b/crates/zccache-platform/src/platform_macos/process/spawn.rs
@@ -13,7 +13,7 @@ pub fn attach_owner_death(_child: &tokio::process::Child) -> std::io::Result<()>
 }
 
 pub fn uses_pre_spawn_owner_death() -> bool {
-    false
+    true
 }
 
 pub fn run_cli_entry(entry: fn() -> std::process::ExitCode) -> std::process::ExitCode {

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -77,9 +77,12 @@ This is the async-bridge design tracked under meta #889. Its pieces:
 `_priority` / `_timeout` wrappers) is the single entry point async daemon code
 uses to run a child process — compile (`compile_exec`), link (`handle_link`),
 multi-compile (`handle_compile_multi`), generic exec (`handle_exec`), and the
-system-include probe. It always spawns with piped stdio + `kill_on_drop(true)`;
-on Windows every child is also assigned to a process-wide **job object**
-(`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) so the whole tree dies with the daemon.
+system-include probe. It always spawns with piped stdio + `kill_on_drop(true)`.
+Daemon-process death is covered separately on every supported host: Linux uses
+`PR_SET_PDEATHSIG`, macOS uses running-process's transactional kqueue
+supervisor, and Windows retains zccache's process-wide **job object**
+(`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`). Thus the compiler child is reaped both
+when a request future is cancelled and when the daemon process itself dies.
 
 ### 2. Child-wait watchdog (`daemon::child_watchdog`)
 


### PR DESCRIPTION
## Summary
- upgrade `running-process` to 4.10.3 and enable transactional owner-death containment on macOS
- preserve zccache's existing Windows kill-on-close Job Object while Linux and macOS use the dependency's pre-spawn policy
- add a production-path process lifetime test and document the platform-specific containment mechanisms

This consumes zackees/running-process#1039 and the published 4.10.3 release.

## Validation
- `soldr cargo check -p zccache-platform -p zccache-daemon-core`
- `soldr cargo test -p zccache-daemon-core --features test-support daemon_owned_ -- --nocapture`
- `soldr cargo clippy -p zccache-platform -p zccache-daemon-core --all-targets --features zccache-daemon-core/test-support -- -D warnings`
- `soldr cargo fmt --all -- --check`
- `soldr cargo check --target x86_64-apple-darwin -p zccache-platform -p zccache-daemon-core`
- `git diff --check`

Closes #1360