### PR TITLE
feat(embedded): expose pprof heap snapshots

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -23,7 +23,7 @@ env:
   # `integration.yml`'s ZCCACHE_INTEGRATION_FEATURES — without it,
   # `clippy --workspace --all-targets` fails to compile those tests with
   # `unresolved import` (the long-standing red Clippy job).
-  ZCCACHE_CLIPPY_FEATURES: "zccache/zccache-bin,zccache/daemon-bin,zccache/download-bin,zccache/download-daemon-bin,zccache/fingerprint-bin,zccache/stamp-bin,zccache/ci-bin,zccache/crash-tools,zccache/tokio-console,zccache/test-support"
+  ZCCACHE_CLIPPY_FEATURES: "zccache/zccache-bin,zccache/daemon-bin,zccache/download-bin,zccache/download-daemon-bin,zccache/fingerprint-bin,zccache/stamp-bin,zccache/ci-bin,zccache/crash-tools,zccache/tokio-console,zccache/test-support,zccache/heap-profile"
   # NOTE: -D warnings deliberately omitted (#944). The workspace
   # [lints.clippy] block in Cargo.toml uses `deny` for the panic-class
   # lints (unwrap_used / unwrap_in_result / panic_in_result_fn) which

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,7 +47,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
-  ZCCACHE_INTEGRATION_FEATURES: "zccache/zccache-bin,zccache/daemon-bin,zccache/download-bin,zccache/download-daemon-bin,zccache/fingerprint-bin,zccache/stamp-bin,zccache/ci-bin,zccache/crash-tools,zccache/tokio-console,zccache/test-support"
+  ZCCACHE_INTEGRATION_FEATURES: "zccache/zccache-bin,zccache/daemon-bin,zccache/download-bin,zccache/download-daemon-bin,zccache/fingerprint-bin,zccache/stamp-bin,zccache/ci-bin,zccache/crash-tools,zccache/tokio-console,zccache/test-support,zccache/heap-profile"
 
 jobs:
   integration:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,16 +1532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,12 +1706,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "mimalloc"
-version = "0.1.48"
+name = "mimalloc-pprof"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+checksum = "71dc9f58355ea3d31ad23ff4d447d6549d8ba9e803d0d9cd616db5af98ae6751"
 dependencies = [
- "libmimalloc-sys",
+ "cc",
 ]
 
 [[package]]
@@ -4136,7 +4126,7 @@ dependencies = [
  "lzma-rs",
  "md5",
  "memmap2",
- "mimalloc",
+ "mimalloc-pprof",
  "notify",
  "prost",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ ruzstd = "0.7"
 lzma-rs = "0.3"
 sevenz-rust = "0.6"
 rkyv = "0.8"
-mimalloc = "0.1"
+mimalloc-pprof = "0.9"
 running-process = { version = "4.10.3", default-features = false, features = ["client-async"] }
 zccache = { path = "crates/zccache" }
 zccache-artifact = { path = "crates/zccache-artifact" }

--- a/ci/local_pre_pr.py
+++ b/ci/local_pre_pr.py
@@ -34,7 +34,8 @@ def run_linux_suites(selected: list[str]) -> None:
     features = (
         "zccache/zccache-bin,zccache/daemon-bin,zccache/download-bin,"
         "zccache/download-daemon-bin,zccache/fingerprint-bin,zccache/stamp-bin,"
-        "zccache/ci-bin,zccache/crash-tools,zccache/tokio-console,zccache/test-support"
+        "zccache/ci-bin,zccache/crash-tools,zccache/tokio-console,zccache/test-support,"
+        "zccache/heap-profile"
     )
     run_perf_local("cargo", "build", "-p", "zccache", "--features", features, "--bin", "zccache")
     for suite in selected:

--- a/ci/local_pre_pr_steps/integration.sh
+++ b/ci/local_pre_pr_steps/integration.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-features="zccache/zccache-bin,zccache/daemon-bin,zccache/download-bin,zccache/download-daemon-bin,zccache/fingerprint-bin,zccache/stamp-bin,zccache/ci-bin,zccache/crash-tools,zccache/tokio-console,zccache/test-support"
+features="zccache/zccache-bin,zccache/daemon-bin,zccache/download-bin,zccache/download-daemon-bin,zccache/fingerprint-bin,zccache/stamp-bin,zccache/ci-bin,zccache/crash-tools,zccache/tokio-console,zccache/test-support,zccache/heap-profile"
 cargo test --workspace --features "$features" --no-fail-fast --no-run
 cargo test --workspace --features "$features" --no-fail-fast -- --test-threads=1

--- a/crates/zccache/Cargo.toml
+++ b/crates/zccache/Cargo.toml
@@ -50,16 +50,17 @@ download-protocol = ["download", "dep:zccache-download-protocol"]
 gha = ["dep:zccache-gha", "zccache-artifact/gha"]
 symbols = ["dep:zccache-symbols"]
 tokio-console = ["dep:console-subscriber", "zccache-daemon-core/tokio-console"]
-zccache-bin = ["cli", "dep:mimalloc"]
-daemon-bin = ["daemon-entry", "symbols", "dep:mimalloc"]
-download-bin = ["dep:clap", "dep:mimalloc", "download-client"]
+heap-profile = ["dep:mimalloc-pprof"]
+zccache-bin = ["cli", "dep:mimalloc-pprof"]
+daemon-bin = ["daemon-entry", "symbols", "dep:mimalloc-pprof"]
+download-bin = ["dep:clap", "dep:mimalloc-pprof", "download-client"]
 download-daemon-bin = [
     "dep:clap",
-    "dep:mimalloc",
+    "dep:mimalloc-pprof",
     "dep:tracing-subscriber",
     "download-daemon",
 ]
-fingerprint-bin = ["dep:clap", "dep:mimalloc"]
+fingerprint-bin = ["dep:clap", "dep:mimalloc-pprof"]
 stamp-bin = ["symbols"]
 ci-bin = ["ci", "dep:md5"]
 crash-tools = ["dep:sadness-generator"]
@@ -176,14 +177,16 @@ wait-timeout = { version = "0.2", optional = true }
 # shared: used by test_support, download-daemon bin, etc.
 tracing-subscriber = { workspace = true, optional = true }
 
-# Global allocator on every target. mimalloc is pure C with no autotools
-# step, so it cross-compiles cleanly in every direction. tikv-jemalloc
+# Global allocator on every target. mimalloc-pprof vendors mimalloc and is
+# pure C with no autotools step, so it cross-compiles cleanly in every
+# direction. tikv-jemalloc
 # was the previous choice on unix but its bundled autoconf invokes a
 # hidden `$(CC) -MM` dep-tracking pass that silently drops the
 # `--sysroot` flag — broke Linux->*-apple-darwin (and would equally
 # break Windows->Linux); see tikv/jemallocator#170. Using one allocator
-# everywhere also removes a per-platform variable from perf analysis.
-mimalloc = { workspace = true, optional = true }
+# everywhere also removes a per-platform variable from perf analysis. The
+# profiler stays dormant unless explicitly enabled by API or environment.
+mimalloc-pprof = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/zccache/src/bin/zccache-daemon.rs
+++ b/crates/zccache/src/bin/zccache-daemon.rs
@@ -7,7 +7,7 @@
 //! not the library) and delegates.
 
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: mimalloc_pprof::MiMalloc = mimalloc_pprof::MiMalloc;
 
 fn main() -> std::process::ExitCode {
     if let Err(error) = zccache::dev_daemon_identity::initialize() {

--- a/crates/zccache/src/bin/zccache-download-daemon.rs
+++ b/crates/zccache/src/bin/zccache-download-daemon.rs
@@ -1,5 +1,5 @@
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: mimalloc_pprof::MiMalloc = mimalloc_pprof::MiMalloc;
 
 use clap::Parser;
 use zccache::download_protocol::daemon_mgmt;

--- a/crates/zccache/src/bin/zccache-fp.rs
+++ b/crates/zccache/src/bin/zccache-fp.rs
@@ -1,5 +1,5 @@
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: mimalloc_pprof::MiMalloc = mimalloc_pprof::MiMalloc;
 
 use std::path::Path;
 use std::process::ExitCode;

--- a/crates/zccache/src/bin/zccache.rs
+++ b/crates/zccache/src/bin/zccache.rs
@@ -15,7 +15,7 @@
 //!    it to the daemon via the session from ZCCACHE_SESSION_ID.
 
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: mimalloc_pprof::MiMalloc = mimalloc_pprof::MiMalloc;
 
 use std::process::ExitCode;
 

--- a/crates/zccache/src/lib.rs
+++ b/crates/zccache/src/lib.rs
@@ -52,6 +52,23 @@ pub use zccache_fingerprint as fingerprint;
 pub use zccache_fscache as fscache;
 #[cfg(feature = "gha")]
 pub use zccache_gha as gha;
+/// Process-wide sampled heap profiling for embedded hosts.
+///
+/// Enable the `heap-profile` feature, install [`MiMalloc`] as the final
+/// binary's `#[global_allocator]`, then use [`prof`] to start profiling and
+/// write pprof-compatible snapshots. The allocator declaration belongs in
+/// the embedding executable because a Rust library cannot select a global
+/// allocator on its consumer's behalf.
+///
+/// [`MiMalloc`]: heap_profile::MiMalloc
+/// [`prof`]: heap_profile::prof
+#[cfg(feature = "heap-profile")]
+pub mod heap_profile {
+    pub use mimalloc_pprof::{
+        enable_heap_profiling, enable_heap_profiling_with, prof, DumpFormat, MiMalloc, ProfConfig,
+        ProfConfigMode,
+    };
+}
 pub use zccache_hash as hash;
 pub use zccache_ipc as ipc;
 /// zccache#1365 — the host-platform leaf (one cfg_select! selector, five

--- a/crates/zccache/tests/heap_profile_test.rs
+++ b/crates/zccache/tests/heap_profile_test.rs
@@ -1,0 +1,42 @@
+//! Public embedded heap-profiling contract (issue #1359).
+//!
+//! An integration test is a separate final executable, so its allocator
+//! declaration also guards the documented downstream linkage pattern.
+
+#![cfg(feature = "heap-profile")]
+
+use zccache::heap_profile::{prof, MiMalloc};
+
+#[global_allocator]
+static ALLOCATOR: MiMalloc = MiMalloc;
+
+struct ProfilerGuard;
+
+impl Drop for ProfilerGuard {
+    fn drop(&mut self) {
+        prof::stop();
+    }
+}
+
+#[test]
+fn embedded_host_can_capture_a_pprof_heap_snapshot() {
+    if prof::is_enabled() {
+        prof::stop();
+    }
+    assert!(prof::start(1), "heap profiler should start exactly once");
+    let _guard = ProfilerGuard;
+
+    let retained = vec![0x5a_u8; 1024 * 1024];
+    std::hint::black_box(&retained);
+
+    let stats = prof::stats();
+    assert!(
+        stats.live_samples > 0,
+        "retained allocation was not sampled"
+    );
+    let snapshot = prof::dump_proto_to_vec();
+    assert!(
+        !snapshot.is_empty(),
+        "pprof profile.proto snapshot must contain the sampled allocation"
+    );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,6 +36,7 @@ failed cache-root audit retain its diagnostic JSONL evidence.
 - **Reflink / hardlink COW safety** → [artifact-store.md](architecture/artifact-store.md#capability-driven-cow-materialization)
 - **soldr target artifact contract** → [rust-artifact-plan.md](architecture/rust-artifact-plan.md)
 - **Embedded soldr/fbuild service integration** → [embedded-service.md](architecture/embedded-service.md)
+- **Embedded heap snapshots** → [embedded-service.md § Heap snapshots](architecture/embedded-service.md#heap-snapshots)
 - **Embedded maintenance limits and shutdown reporting** → [embedded-service.md § Maintenance limits and task ownership](architecture/embedded-service.md#maintenance-limits-and-task-ownership)
 - **Shared periodic maintenance schedule (both service modes)** → [embedded-service.md § Maintenance limits and task ownership](architecture/embedded-service.md#maintenance-limits-and-task-ownership)
 - **Legacy action target snapshots** → [target-cache.md](architecture/target-cache.md)

--- a/docs/architecture/embedded-service.md
+++ b/docs/architecture/embedded-service.md
@@ -19,6 +19,7 @@ The MVP boundary is:
 |---|---|---|
 | Architecture contract | Landed | This document records lifecycle, ownership, audit, and shutdown expectations. |
 | Public Rust API | MVP landed | `zccache::embedded` exports `ZccacheService` and stable config/request/stats types for start, compile, stats, disk maintenance, flush, and shutdown. |
+| Heap snapshots | Landed | The `heap-profile` feature exports `zccache::heap_profile`, a process-wide mimalloc sampler that emits pprof `profile.proto` snapshots. |
 | Durable audit schema | MVP landed | `zccache::audit` exports serializable schema/config/event/finding/manifest types. |
 | Audit emission | Partial | `ZccacheService::compile` emits `compile.started`, `cache.hit`/`cache.miss` and `compile.finished` carrying the host's `AuditContext` (#905). Engine-internal events (`cache.lookup` with the key, `compiler.spawn`/`compiler.exit`, depgraph) still need plumbing through `EmbeddedCompileRequest`. |
 | soldr embedded integration | Landed | soldr uses the direct embedded service and owns its cache root, runtime handle, audit context, and shutdown sequence. |
@@ -29,6 +30,38 @@ The MVP boundary is:
 Tests in this repository cover the public Rust service boundary, maintenance,
 flush/shutdown reporting, and durable audit schema. Broader host workload
 validation remains owned by each consuming repository.
+
+### Heap snapshots
+
+An embedded host can opt into sampled heap profiling without adding a second
+allocator dependency:
+
+```rust
+use zccache::heap_profile::{prof, MiMalloc};
+
+#[global_allocator]
+static ALLOCATOR: MiMalloc = MiMalloc;
+
+fn snapshot() -> std::io::Result<()> {
+    let _started = prof::start(0); // default sampling interval
+    prof::dump_proto_file(std::path::Path::new("heap.pb"))
+}
+```
+
+The host enables zccache's `heap-profile` Cargo feature and owns profiler
+lifecycle because both the allocator and sampler are process-global. Snapshot
+files use pprof's binary `profile.proto` format and carry module mappings for
+external symbolization. Hosts should retain line tables (and frame pointers on
+Linux/macOS where practical) so the same binaries and debug sidecars used for
+CPU profiles also resolve heap stacks.
+
+`mimalloc-pprof` must be the process's sole mimalloc provider. A host that
+already depends on the ordinary `mimalloc` crate must remove that dependency
+and use `zccache::heap_profile::MiMalloc`; Cargo rejects two native libraries
+that both declare `links = "mimalloc"`. Zccache's shipped binaries use this
+same allocator implementation to keep every feature combination linkable. The
+sampling hooks remain dormant unless profiling is enabled through the API or
+the `MIMALLOC_PROF` environment variable.
 
 ## Problem
 


### PR DESCRIPTION
Closes #1359.

## Summary
- replace the workspace allocator with `mimalloc-pprof` and migrate every shipped zccache binary to its compatible allocator
- expose a safe `zccache::heap_profile` facade for embedded hosts without exporting the raw FFI surface
- add a downstream-linkage integration test that records a live allocation and emits non-empty pprof `profile.proto` bytes
- exercise the feature in hosted and local integration/clippy feature sets and document the sole-provider constraint

## Validation
- `soldr cargo test -p zccache --features heap-profile --test heap_profile_test -- --nocapture`
- `soldr cargo check -p zccache --all-targets --all-features`
- `soldr cargo clippy -p zccache --lib --test heap_profile_test --features heap-profile --no-deps -- -D warnings`
- `soldr cargo doc -p zccache --features heap-profile --no-deps`
- `soldr cargo check --target x86_64-apple-darwin -p zccache --features heap-profile`
- `soldr cargo fmt --all -- --check`

A local native-Linux Docker attempt could not start because Docker Desktop stalled while exporting the helper image. Hosted Integration enables `heap-profile`, so its Linux job is the native runtime/linkage gate; hosted Perf Guard covers the allocator migration in the shipped binary.