### PR TITLE
feat(embedded): complete host service contract

### DIFF
--- a/crates/zccache-daemon-core/src/embedded.rs
+++ b/crates/zccache-daemon-core/src/embedded.rs
@@ -7,16 +7,20 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use crate::core::NormalizedPath;
 use crate::daemon::server::{
-    DiskMaintenanceReport as InternalDiskMaintenanceReport, EmbeddedCompileRequest, EmbeddedDaemon,
-    EmbeddedFlushReport, EmbeddedStatsSnapshot, MaintenanceKind as InternalMaintenanceKind,
-    MaintenancePolicy, MaintenancePressure as InternalMaintenancePressure,
+    EmbeddedCompileRequest, EmbeddedDaemon, EmbeddedFlushReport,
+    MaintenanceKind as InternalMaintenanceKind, MaintenancePolicy,
 };
 
-pub use crate::audit::{AuditConfig, AuditContext};
+pub use crate::audit::{AuditConfig, AuditContext, AuditEvent};
+pub use control::EmbeddedEventSink;
+
+mod control;
+mod reporting;
 
 /// Result type used by the embedded service API.
 pub type Result<T> = std::result::Result<T, EmbeddedError>;
@@ -30,13 +34,11 @@ pub enum EmbeddedError {
     Compile(String),
     #[error("embedded zccache service is already shut down")]
     ShutDown,
-    /// The host-provided cancellation token (see
-    /// [`ZccacheConfig::cancellation`]) fired before the operation
-    /// finished. Subprocesses already in flight when the token is
-    /// observed are reaped via `kill_on_drop` when the suspended future
-    /// drops; the host should treat this as a terminal outcome and not
-    /// retry the same compile. Issue zccache#923.
-    #[error("embedded zccache operation cancelled by host token")]
+    /// The host-provided cancellation token fired, or forced shutdown
+    /// cancelled the operation. Subprocesses already in flight are reaped
+    /// when the suspended future drops; the host should treat this as a
+    /// terminal outcome and not retry the same compile.
+    #[error("embedded zccache operation cancelled")]
     Cancelled,
 }
 
@@ -45,13 +47,16 @@ pub enum EmbeddedError {
 pub struct ZccacheService {
     daemon: Arc<EmbeddedDaemon>,
     shutdown: Arc<AtomicBool>,
-    /// Snapshot of the host-supplied cancellation token captured at
-    /// [`ZccacheService::start`]. Compile calls race it via `tokio::select!`;
-    /// flush checks only whether it was already latched before persistence
-    /// begins, then keeps ownership until the flush completes. `None`
-    /// preserves the pre-#923 behavior where only
-    /// `shutdown(ShutdownMode::Force)` aborts in-flight work.
-    cancellation: Option<CancellationToken>,
+    /// Snapshot of the host-supplied cancellation token captured at startup.
+    /// Compile calls race it; flush checks only whether it was already latched
+    /// before persistence begins, then keeps ownership until flush completes.
+    host_cancellation: Option<CancellationToken>,
+    /// Service-owned token fired by `shutdown(Force)`. Unlike the optional
+    /// host token, this is always present so forced shutdown can abort work
+    /// submitted through any cloned handle.
+    force_cancellation: CancellationToken,
+    /// Optional admission gate implementing `max_parallel_compiles`.
+    compile_permits: Option<Arc<Semaphore>>,
     /// RAII handle for the optional host-in-flight counter registration
     /// (zccache#924). Wrapped in `Arc` so the `Clone` impl on
     /// `ZccacheService` does not double-register; the slot is cleared
@@ -63,6 +68,9 @@ pub struct ZccacheService {
     /// service's lifetime; flush + shutdown are forwarded from the
     /// matching `ZccacheService` methods.
     audit_sink: Option<Arc<crate::audit_writer::AuditSink>>,
+    /// Optional host callback for the same redacted structured events sent to
+    /// the durable audit sink.
+    event_sink: Option<Arc<dyn EmbeddedEventSink>>,
     /// The host's audit configuration, retained so emitted events can carry
     /// the selected mode and honor the host's redaction policy. `Arc` keeps
     /// `Clone` on the service cheap.
@@ -88,10 +96,8 @@ pub struct ZccacheConfig {
     /// flush is owned to completion so cancellation cannot strand a partial
     /// checkpoint.
     ///
-    /// `None` preserves the pre-#923 behavior: the service participates
-    /// in cancellation only via `shutdown(ShutdownMode::Force)`, which
-    /// requires moving the service handle and so cannot be triggered
-    /// mid-call.
+    /// `None` opts out of host-token cancellation. Forced shutdown still
+    /// cancels compiles running through cloned service handles.
     ///
     /// Hosts that own a top-level shutdown signal (soldr's daemon
     /// `Notify`, fbuild's coordinator runtime) should clone their token
@@ -202,6 +208,10 @@ pub struct RuntimeHooks {
 /// Optional service limits. `None` means zccache's existing daemon defaults.
 #[derive(Debug, Clone, Default)]
 pub struct ServiceLimits {
+    /// Maximum compile calls admitted to the daemon engine concurrently.
+    ///
+    /// Additional callers wait asynchronously and remain cancellable. `None`
+    /// preserves unconstrained admission; `Some(0)` is rejected at startup.
     pub max_parallel_compiles: Option<usize>,
     /// Optional host-supplied in-flight counter (zccache#924).
     ///
@@ -524,50 +534,7 @@ impl ZccacheService {
         config: ZccacheConfig,
         options: ZccacheStartOptions,
     ) -> Result<Self> {
-        let endpoint = embedded_endpoint(&config.host);
-        let cache_root =
-            crate::core::config::effective_cache_root_from_top_level(&config.cache_root);
-        let maintenance_policy = MaintenancePolicy::from_limits(
-            options.disk_limits.max_cache_bytes,
-            options.disk_limits.max_cache_percent,
-        )
-        .map_err(EmbeddedError::Start)?;
-        let daemon = EmbeddedDaemon::start_with_maintenance(
-            endpoint,
-            cache_root,
-            options.staging_root.as_ref(),
-            config.runtime.handle.clone(),
-            maintenance_policy,
-            options.maintenance_ownership == MaintenanceOwnership::Embedded,
-        )
-        .await
-        .map_err(|err| EmbeddedError::Start(err.to_string()))?;
-        // zccache#924: register the optional host-in-flight counter so
-        // CompilePriority::Auto sees host-side subprocess pressure when
-        // deciding Normal vs Low. The RAII guard is held on the service
-        // until the last clone drops, then the slot is cleared.
-        let host_inflight_guard = config
-            .limits
-            .host_in_flight
-            .map(crate::daemon::process::register_host_in_flight_counter)
-            .map(Arc::new);
-        // zccache#926: spawn the durable audit JSONL writer when the
-        // host configured a mode that requires emission. The writer
-        // task runs on the host's tokio runtime via the same
-        // `runtime.handle` plumbing as the rest of the embedded
-        // service so tokio-console attach unity holds.
-        let audit_sink =
-            crate::audit_writer::AuditSink::start(&config.audit, config.runtime.handle.clone())
-                .map_err(|err| EmbeddedError::Start(err.to_string()))?
-                .map(Arc::new);
-        Ok(Self {
-            daemon: Arc::new(daemon),
-            shutdown: Arc::new(AtomicBool::new(false)),
-            cancellation: config.cancellation,
-            _host_inflight_guard: host_inflight_guard,
-            audit_sink,
-            audit: Arc::new(config.audit),
-        })
+        Self::start_internal(config, options, None).await
     }
 
     /// Emit one durable audit event, if the host enabled audit.
@@ -592,9 +559,9 @@ impl ZccacheService {
         duration_ns: Option<u64>,
         fields: &[(&'static str, serde_json::Value)],
     ) {
-        let Some(sink) = &self.audit_sink else {
+        if self.audit_sink.is_none() && self.event_sink.is_none() {
             return;
-        };
+        }
         let (Ok(event_id), Ok(span_id), Ok(category), Ok(event)) = (
             crate::audit::AuditId::new(uuid::Uuid::new_v4().to_string()),
             crate::audit::AuditId::new(uuid::Uuid::new_v4().to_string()),
@@ -627,15 +594,25 @@ impl ZccacheService {
         for (key, value) in fields {
             record = record.with_field(*key, value.clone());
         }
-        let _ = sink.emit(record.apply_redaction(&self.audit.redaction));
+        let record = record.apply_redaction(&self.audit.redaction);
+        if let Some(sink) = &self.event_sink {
+            if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| sink.emit(&record)))
+                .is_err()
+            {
+                tracing::warn!("embedded host event sink panicked; event dropped");
+            }
+        }
+        if let Some(sink) = &self.audit_sink {
+            let _ = sink.emit(record);
+        }
     }
 
     /// Compile using the embedded daemon engine.
     ///
-    /// Honors [`ZccacheConfig::cancellation`] (zccache#923): if the
-    /// host-supplied token fires before the compile finishes, the call
-    /// returns [`EmbeddedError::Cancelled`] and the in-flight compile
-    /// future is dropped. The daemon's [`tokio::process::Child`] handles
+    /// Honors [`ZccacheConfig::cancellation`] and forced shutdown: if either
+    /// cancellation source fires before the compile finishes, the call returns
+    /// [`EmbeddedError::Cancelled`] and drops the in-flight compile future.
+    /// The daemon's [`tokio::process::Child`] handles
     /// use `kill_on_drop(true)`, so the subprocess is reaped as a side
     /// effect — there is no orphaned `rustc` left behind. Hosts should
     /// treat `Cancelled` as terminal (no retry inside the same shutdown).
@@ -668,6 +645,7 @@ impl ZccacheService {
     }
 
     async fn compile_inner(&self, request: CompileRequest) -> Result<CompileResponse> {
+        let _compile_permit = self.acquire_compile_permit().await?;
         let compile_id = request
             .audit
             .compile_id
@@ -680,10 +658,13 @@ impl ZccacheService {
         }
         // Fast-path: token already fired before we did anything else.
         // Avoids spawning the compile only to immediately cancel it.
-        if let Some(token) = &self.cancellation {
+        if let Some(token) = &self.host_cancellation {
             if token.is_cancelled() {
                 return Err(EmbeddedError::Cancelled);
             }
+        }
+        if self.force_cancellation.is_cancelled() {
+            return Err(EmbeddedError::Cancelled);
         }
         // Carry the resolved `compile_id` on every event for this compile, so
         // the host's own records correlate by id rather than by timestamp.
@@ -711,17 +692,7 @@ impl ZccacheService {
             env: Some(request.env),
             stdin: request.stdin,
         });
-        let outcome = match &self.cancellation {
-            Some(token) => {
-                let cancelled = token.cancelled();
-                tokio::select! {
-                    biased;
-                    () = cancelled => Err(EmbeddedError::Cancelled),
-                    result = compile_future => result.map_err(EmbeddedError::Compile),
-                }
-            }
-            None => compile_future.await.map_err(EmbeddedError::Compile),
-        };
+        let outcome = self.await_compile(compile_future).await;
         // Every `compile.started` must get a `compile.finished`, including on
         // the cancel and spawn-failure paths. An audit log with dangling
         // starts cannot be used to measure anything, and those are exactly
@@ -895,7 +866,7 @@ impl ZccacheService {
         if self.shutdown.load(Ordering::Acquire) {
             return Err(EmbeddedError::ShutDown);
         }
-        if let Some(token) = &self.cancellation {
+        if let Some(token) = &self.host_cancellation {
             if token.is_cancelled() {
                 return Err(EmbeddedError::Cancelled);
             }
@@ -929,12 +900,15 @@ impl ZccacheService {
 
     /// Shut down the service and flush relevant persisted state.
     ///
-    /// `ShutdownMode::Graceful` waits for the durable audit sink to
-    /// drain before returning. `ShutdownMode::Force` does not — the
-    /// host signalled "stop now, lost events are acceptable."
+    /// `ShutdownMode::Graceful` waits for the durable audit sink to drain.
+    /// `ShutdownMode::Force` first cancels in-flight and queued compiles
+    /// through every cloned service handle, then skips the audit drain.
     async fn shutdown_internal(self, mode: ShutdownMode) -> Result<EmbeddedFlushReport> {
         if self.shutdown.swap(true, Ordering::AcqRel) {
             return Err(EmbeddedError::ShutDown);
+        }
+        if matches!(mode, ShutdownMode::Force) {
+            self.force_cancellation.cancel();
         }
         let report = self.daemon.shutdown().await;
         // zccache#926: shut the audit sink down when going Graceful.
@@ -980,145 +954,9 @@ where
     }
 }
 
-impl ServiceStats {
-    fn from_snapshot(snapshot: EmbeddedStatsSnapshot) -> Self {
-        let status = snapshot.status;
-        Self {
-            cache_root: status.cache_dir,
-            uptime_secs: status.uptime_secs,
-            total_compilations: status.total_compilations,
-            cache_hits: status.cache_hits,
-            cache_misses: status.cache_misses,
-            non_cacheable: status.non_cacheable,
-            compile_errors: status.compile_errors,
-            compile_errors_cached: status.compile_errors_cached,
-            time_saved_ms: status.time_saved_ms,
-            artifact_count: status.artifact_count,
-            cache_size_bytes: status.cache_size_bytes,
-            metadata_entries: status.metadata_entries,
-            dep_graph_contexts: status.dep_graph_contexts,
-            dep_graph_files: status.dep_graph_files,
-            sessions_total: status.sessions_total,
-            sessions_active: status.sessions_active,
-            phase_profile: snapshot.phase_profile,
-        }
-    }
-}
-
-impl FlushReport {
-    fn from_report(report: EmbeddedFlushReport) -> Self {
-        Self {
-            pending_writes_drained: report.pending_writes_drained,
-            artifact_entries: report.artifact_entries,
-            metadata_entries: report.metadata_entries,
-        }
-    }
-}
-
 #[cfg(test)]
-mod flush_report_compatibility_tests {
-    use super::FlushReport;
-
-    #[test]
-    fn legacy_flush_report_literal_and_exhaustive_pattern_still_compile() {
-        let report = FlushReport {
-            pending_writes_drained: true,
-            artifact_entries: 2,
-            metadata_entries: 3,
-        };
-        let FlushReport {
-            pending_writes_drained,
-            artifact_entries,
-            metadata_entries,
-        } = report;
-        assert!(pending_writes_drained);
-        assert_eq!((artifact_entries, metadata_entries), (2, 3));
-    }
-}
-
-impl DetailedFlushReport {
-    fn from_report(report: EmbeddedFlushReport) -> Self {
-        debug_assert_eq!(report.is_complete(), {
-            report.pending_writes_drained
-                && report.index_writer_drained
-                && report.steps.iter().all(|step| {
-                    matches!(
-                        step.outcome,
-                        crate::daemon::server::FlushStepOutcome::Completed
-                    )
-                })
-        });
-        Self {
-            pending_writes_drained: report.pending_writes_drained,
-            index_writer_drained: report.index_writer_drained,
-            steps: report
-                .steps
-                .into_iter()
-                .map(|step| FlushStepReport {
-                    step: step.step,
-                    outcome: match step.outcome {
-                        crate::daemon::server::FlushStepOutcome::Completed => {
-                            FlushStepOutcome::Completed
-                        }
-                        crate::daemon::server::FlushStepOutcome::Failed(error) => {
-                            FlushStepOutcome::Failed(error)
-                        }
-                        crate::daemon::server::FlushStepOutcome::TimedOut => {
-                            FlushStepOutcome::TimedOut
-                        }
-                    },
-                })
-                .collect(),
-            artifact_entries: report.artifact_entries,
-            metadata_entries: report.metadata_entries,
-        }
-    }
-}
-
-impl DiskMaintenanceReport {
-    fn from_report(report: InternalDiskMaintenanceReport) -> Self {
-        Self {
-            kind: match report.kind {
-                InternalMaintenanceKind::Pressure => DiskMaintenanceKind::Pressure,
-                InternalMaintenanceKind::Full => DiskMaintenanceKind::Full,
-            },
-            pressure: match report.pressure {
-                InternalMaintenancePressure::None => DiskMaintenancePressure::None,
-                InternalMaintenancePressure::Soft => DiskMaintenancePressure::Soft,
-                InternalMaintenancePressure::Hard => DiskMaintenancePressure::Hard,
-            },
-            budget_bytes: report.budget_bytes,
-            usage_before_bytes: report.usage_before_bytes,
-            usage_after_bytes: report.usage_after_bytes,
-            bytes_reclaimed: report.bytes_reclaimed,
-            artifacts_removed: report.artifacts_removed,
-            expired_artifacts_removed: report.expired_artifacts_removed,
-            pending_write_bytes: report.pending_write_bytes,
-        }
-    }
-}
-
-fn embedded_endpoint(host: &HostIdentity) -> String {
-    format!(
-        "embedded:{}:{}:{}",
-        sanitize_identity(&host.product),
-        sanitize_identity(&host.instance_id),
-        sanitize_identity(&host.workspace_id)
-    )
-}
-
-fn sanitize_identity(value: &str) -> String {
-    value
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
-                ch
-            } else {
-                '_'
-            }
-        })
-        .collect()
-}
+#[path = "embedded/contract_tests.rs"]
+mod contract_tests;
 
 #[cfg(test)]
 #[path = "embedded/tests.rs"]

--- a/crates/zccache-daemon-core/src/embedded/contract_tests.rs
+++ b/crates/zccache-daemon-core/src/embedded/contract_tests.rs
@@ -1,0 +1,204 @@
+//! Issue #905 regression tests for the completed embedded host contract.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use tempfile::TempDir;
+use tokio::sync::Semaphore;
+
+use super::*;
+
+fn config(temp: &TempDir, instance: &str, max_parallel_compiles: Option<usize>) -> ZccacheConfig {
+    let mut audit = AuditConfig::default();
+    audit.mode = crate::audit::AuditMode::Off;
+    ZccacheConfig {
+        host: HostIdentity {
+            product: "service-contract-test".into(),
+            instance_id: instance.into(),
+            workspace_id: instance.into(),
+        },
+        cache_root: temp.path().join("zccache").into(),
+        audit,
+        limits: ServiceLimits {
+            max_parallel_compiles,
+            ..ServiceLimits::default()
+        },
+        runtime: RuntimeHooks::default(),
+        cancellation: None,
+    }
+}
+
+#[tokio::test]
+async fn zero_parallel_compiles_is_rejected_before_startup() {
+    let temp = TempDir::new().expect("temp cache root");
+    let result = ZccacheService::start(config(&temp, "zero-limit", Some(0))).await;
+    assert!(
+        matches!(result, Err(EmbeddedError::Start(message)) if message.contains("greater than zero")),
+        "zero is not a usable compile limit"
+    );
+}
+
+#[tokio::test]
+async fn oversized_parallel_compile_limit_is_rejected_without_panicking() {
+    let temp = TempDir::new().expect("temp cache root");
+    let result = ZccacheService::start(config(
+        &temp,
+        "oversized-limit",
+        Some(Semaphore::MAX_PERMITS + 1),
+    ))
+    .await;
+    assert!(
+        matches!(result, Err(EmbeddedError::Start(message)) if message.contains("must not exceed")),
+        "an oversized public limit must return a startup error"
+    );
+}
+
+#[tokio::test]
+async fn max_parallel_compiles_gates_compile_admission() {
+    let temp = TempDir::new().expect("temp cache root");
+    let service = ZccacheService::start(config(&temp, "compile-limit", Some(1)))
+        .await
+        .expect("service start");
+
+    let first = service
+        .acquire_compile_permit()
+        .await
+        .expect("first admission")
+        .expect("configured limit returns a permit");
+    let queued_service = service.clone();
+    let mut queued = tokio::spawn(async move { queued_service.acquire_compile_permit().await });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(50), &mut queued)
+            .await
+            .is_err(),
+        "a second compile must wait while the only permit is held"
+    );
+
+    drop(first);
+    let second = tokio::time::timeout(std::time::Duration::from_secs(1), queued)
+        .await
+        .expect("queued compile admitted after release")
+        .expect("queued task joined")
+        .expect("second admission")
+        .expect("configured limit returns a permit");
+    drop(second);
+
+    service
+        .shutdown(ShutdownMode::Graceful)
+        .await
+        .expect("shutdown");
+}
+
+#[tokio::test]
+async fn forced_shutdown_cancels_a_compile_waiting_for_admission() {
+    let temp = TempDir::new().expect("temp cache root");
+    let service = ZccacheService::start(config(&temp, "queued-force", Some(1)))
+        .await
+        .expect("service start");
+    let first = service
+        .acquire_compile_permit()
+        .await
+        .expect("first admission")
+        .expect("configured limit returns a permit");
+    let queued_service = service.clone();
+    let queued = tokio::spawn(async move { queued_service.acquire_compile_permit().await });
+    tokio::task::yield_now().await;
+
+    let shutdown = tokio::spawn(service.shutdown(ShutdownMode::Force));
+    let outcome = tokio::time::timeout(std::time::Duration::from_secs(1), queued)
+        .await
+        .expect("forced shutdown must wake queued admission")
+        .expect("queued task joined");
+    assert!(matches!(outcome, Err(EmbeddedError::Cancelled)));
+    drop(first);
+    shutdown
+        .await
+        .expect("shutdown task joined")
+        .expect("forced shutdown");
+}
+
+#[tokio::test]
+async fn forced_shutdown_cancels_an_inflight_compile_future() {
+    let temp = TempDir::new().expect("temp cache root");
+    let service = ZccacheService::start(config(&temp, "forced-shutdown", None))
+        .await
+        .expect("service start");
+    let compile_service = service.clone();
+    let compile = tokio::spawn(async move {
+        compile_service
+            .await_compile(std::future::pending::<std::result::Result<(), String>>())
+            .await
+    });
+    tokio::task::yield_now().await;
+
+    let shutdown = tokio::spawn(service.shutdown(ShutdownMode::Force));
+    let outcome = tokio::time::timeout(std::time::Duration::from_secs(1), compile)
+        .await
+        .expect("forced shutdown must wake the compile")
+        .expect("compile task joined");
+    assert!(matches!(outcome, Err(EmbeddedError::Cancelled)));
+    shutdown
+        .await
+        .expect("shutdown task joined")
+        .expect("forced shutdown");
+}
+
+fn unspawnable_request(run: &str) -> CompileRequest {
+    CompileRequest {
+        audit: AuditContext::new(
+            crate::audit::AuditId::new(run).expect("non-empty"),
+            crate::audit::AuditId::new("audit-trace").expect("non-empty"),
+        ),
+        compiler: PathBuf::from("/nonexistent/compiler-that-never-runs").into(),
+        args: vec!["--version".into()],
+        cwd: std::env::current_dir().expect("cwd").into(),
+        env: Vec::new(),
+        stdin: Vec::new(),
+    }
+}
+
+#[tokio::test]
+async fn host_event_sink_receives_redacted_events_when_file_audit_is_off() {
+    let temp = TempDir::new().expect("temp root");
+    let events = Arc::new(Mutex::new(Vec::<AuditEvent>::new()));
+    let captured = Arc::clone(&events);
+    let sink: Arc<dyn EmbeddedEventSink> = Arc::new(move |event: &AuditEvent| {
+        captured.lock().expect("event lock").push(event.clone());
+    });
+    let mut service_config = config(&temp, "host-events", None);
+    service_config
+        .audit
+        .redaction
+        .redact_field_keys
+        .push("compiler".into());
+    let service = ZccacheService::start_with_event_sink(service_config, sink)
+        .await
+        .expect("service with host sink starts");
+
+    let _ = service.compile(unspawnable_request("host-event-run")).await;
+    {
+        let events = events.lock().expect("event lock");
+        let names: Vec<&str> = events.iter().map(|event| event.event.0.as_str()).collect();
+        assert!(names.contains(&"compile.started"), "events: {names:?}");
+        assert!(names.contains(&"compile.finished"), "events: {names:?}");
+        assert!(
+            events
+                .iter()
+                .all(|event| event.run_id.0 == "host-event-run"),
+            "the host's causal context must be preserved"
+        );
+        let started = events
+            .iter()
+            .find(|event| event.event.0 == "compile.started")
+            .expect("started event");
+        assert_eq!(
+            started.fields.get("compiler"),
+            Some(&serde_json::Value::String("<redacted>".into()))
+        );
+    }
+
+    service
+        .shutdown(ShutdownMode::Graceful)
+        .await
+        .expect("shutdown");
+}

--- a/crates/zccache-daemon-core/src/embedded/control.rs
+++ b/crates/zccache-daemon-core/src/embedded/control.rs
@@ -1,0 +1,198 @@
+//! Additive host integration and compile-control plumbing for embedded mode.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio_util::sync::CancellationToken;
+
+use super::{
+    EmbeddedError, HostIdentity, MaintenanceOwnership, MaintenancePolicy, Result, ZccacheConfig,
+    ZccacheService, ZccacheStartOptions,
+};
+use crate::daemon::server::EmbeddedDaemon;
+
+/// Receives structured events emitted by an embedded service.
+///
+/// The callback runs inline on the compile task and should return quickly.
+/// Panics are contained and do not fail the compile. Events are redacted using
+/// the service's audit configuration before this callback runs. Registering a
+/// host sink is explicit, so it receives events even when file audit is off.
+pub trait EmbeddedEventSink: Send + Sync + 'static {
+    fn emit(&self, event: &crate::audit::AuditEvent);
+}
+
+impl<F> EmbeddedEventSink for F
+where
+    F: Fn(&crate::audit::AuditEvent) + Send + Sync + 'static,
+{
+    fn emit(&self, event: &crate::audit::AuditEvent) {
+        self(event);
+    }
+}
+
+impl ZccacheService {
+    /// Start an embedded service with a host-owned structured event sink.
+    ///
+    /// This additive constructor keeps [`ZccacheConfig`] and
+    /// [`ZccacheStartOptions`] struct literals source-compatible. The sink
+    /// receives redacted compile events regardless of whether file audit
+    /// output is enabled.
+    pub async fn start_with_event_sink(
+        config: ZccacheConfig,
+        event_sink: Arc<dyn EmbeddedEventSink>,
+    ) -> Result<Self> {
+        Self::start_internal(config, ZccacheStartOptions::default(), Some(event_sink)).await
+    }
+
+    /// Start with both additive service options and a host event sink.
+    pub async fn start_with_options_and_event_sink(
+        config: ZccacheConfig,
+        options: ZccacheStartOptions,
+        event_sink: Arc<dyn EmbeddedEventSink>,
+    ) -> Result<Self> {
+        Self::start_internal(config, options, Some(event_sink)).await
+    }
+
+    pub(super) async fn start_internal(
+        config: ZccacheConfig,
+        options: ZccacheStartOptions,
+        event_sink: Option<Arc<dyn EmbeddedEventSink>>,
+    ) -> Result<Self> {
+        let compile_permits = match config.limits.max_parallel_compiles {
+            Some(0) => {
+                return Err(EmbeddedError::Start(
+                    "max_parallel_compiles must be greater than zero".to_string(),
+                ));
+            }
+            Some(limit) if limit > Semaphore::MAX_PERMITS => {
+                return Err(EmbeddedError::Start(format!(
+                    "max_parallel_compiles must not exceed {}",
+                    Semaphore::MAX_PERMITS
+                )));
+            }
+            Some(limit) => Some(Arc::new(Semaphore::new(limit))),
+            None => None,
+        };
+        let endpoint = embedded_endpoint(&config.host);
+        let cache_root =
+            crate::core::config::effective_cache_root_from_top_level(&config.cache_root);
+        let maintenance_policy = MaintenancePolicy::from_limits(
+            options.disk_limits.max_cache_bytes,
+            options.disk_limits.max_cache_percent,
+        )
+        .map_err(EmbeddedError::Start)?;
+        let daemon = EmbeddedDaemon::start_with_maintenance(
+            endpoint,
+            cache_root,
+            options.staging_root.as_ref(),
+            config.runtime.handle.clone(),
+            maintenance_policy,
+            options.maintenance_ownership == MaintenanceOwnership::Embedded,
+        )
+        .await
+        .map_err(|err| EmbeddedError::Start(err.to_string()))?;
+        let host_inflight_guard = config
+            .limits
+            .host_in_flight
+            .map(crate::daemon::process::register_host_in_flight_counter)
+            .map(Arc::new);
+        let audit_sink =
+            crate::audit_writer::AuditSink::start(&config.audit, config.runtime.handle.clone())
+                .map_err(|err| EmbeddedError::Start(err.to_string()))?
+                .map(Arc::new);
+        Ok(Self {
+            daemon: Arc::new(daemon),
+            shutdown: Arc::new(AtomicBool::new(false)),
+            host_cancellation: config.cancellation,
+            force_cancellation: CancellationToken::new(),
+            compile_permits,
+            _host_inflight_guard: host_inflight_guard,
+            audit_sink,
+            event_sink,
+            audit: Arc::new(config.audit),
+        })
+    }
+
+    pub(super) async fn acquire_compile_permit(&self) -> Result<Option<OwnedSemaphorePermit>> {
+        if self.shutdown.load(Ordering::Acquire) {
+            return Err(EmbeddedError::ShutDown);
+        }
+        if self.force_cancellation.is_cancelled()
+            || self
+                .host_cancellation
+                .as_ref()
+                .is_some_and(CancellationToken::is_cancelled)
+        {
+            return Err(EmbeddedError::Cancelled);
+        }
+        let Some(semaphore) = &self.compile_permits else {
+            return Ok(None);
+        };
+        let permit = Arc::clone(semaphore).acquire_owned();
+        let permit = match &self.host_cancellation {
+            Some(token) => {
+                tokio::select! {
+                    biased;
+                    () = self.force_cancellation.cancelled() => return Err(EmbeddedError::Cancelled),
+                    () = token.cancelled() => return Err(EmbeddedError::Cancelled),
+                    permit = permit => permit,
+                }
+            }
+            None => {
+                tokio::select! {
+                    biased;
+                    () = self.force_cancellation.cancelled() => return Err(EmbeddedError::Cancelled),
+                    permit = permit => permit,
+                }
+            }
+        }
+        .map_err(|_| EmbeddedError::ShutDown)?;
+        Ok(Some(permit))
+    }
+
+    pub(super) async fn await_compile<T, F>(&self, compile: F) -> Result<T>
+    where
+        F: std::future::Future<Output = std::result::Result<T, String>>,
+    {
+        match &self.host_cancellation {
+            Some(token) => {
+                tokio::select! {
+                    biased;
+                    () = self.force_cancellation.cancelled() => Err(EmbeddedError::Cancelled),
+                    () = token.cancelled() => Err(EmbeddedError::Cancelled),
+                    result = compile => result.map_err(EmbeddedError::Compile),
+                }
+            }
+            None => {
+                tokio::select! {
+                    biased;
+                    () = self.force_cancellation.cancelled() => Err(EmbeddedError::Cancelled),
+                    result = compile => result.map_err(EmbeddedError::Compile),
+                }
+            }
+        }
+    }
+}
+
+fn embedded_endpoint(host: &HostIdentity) -> String {
+    format!(
+        "embedded:{}:{}:{}",
+        sanitize_identity(&host.product),
+        sanitize_identity(&host.instance_id),
+        sanitize_identity(&host.workspace_id)
+    )
+}
+
+fn sanitize_identity(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}

--- a/crates/zccache-daemon-core/src/embedded/reporting.rs
+++ b/crates/zccache-daemon-core/src/embedded/reporting.rs
@@ -1,0 +1,121 @@
+//! Internal conversions from daemon-engine reports to the public facade.
+
+use super::{
+    DetailedFlushReport, DiskMaintenanceKind, DiskMaintenancePressure, DiskMaintenanceReport,
+    FlushReport, FlushStepOutcome, FlushStepReport, ServiceStats,
+};
+use crate::daemon::server::{
+    DiskMaintenanceReport as InternalDiskMaintenanceReport, EmbeddedFlushReport,
+    EmbeddedStatsSnapshot, FlushStepOutcome as InternalFlushStepOutcome,
+    MaintenanceKind as InternalMaintenanceKind, MaintenancePressure as InternalMaintenancePressure,
+};
+
+impl ServiceStats {
+    pub(super) fn from_snapshot(snapshot: EmbeddedStatsSnapshot) -> Self {
+        let status = snapshot.status;
+        Self {
+            cache_root: status.cache_dir,
+            uptime_secs: status.uptime_secs,
+            total_compilations: status.total_compilations,
+            cache_hits: status.cache_hits,
+            cache_misses: status.cache_misses,
+            non_cacheable: status.non_cacheable,
+            compile_errors: status.compile_errors,
+            compile_errors_cached: status.compile_errors_cached,
+            time_saved_ms: status.time_saved_ms,
+            artifact_count: status.artifact_count,
+            cache_size_bytes: status.cache_size_bytes,
+            metadata_entries: status.metadata_entries,
+            dep_graph_contexts: status.dep_graph_contexts,
+            dep_graph_files: status.dep_graph_files,
+            sessions_total: status.sessions_total,
+            sessions_active: status.sessions_active,
+            phase_profile: snapshot.phase_profile,
+        }
+    }
+}
+
+impl FlushReport {
+    pub(super) fn from_report(report: EmbeddedFlushReport) -> Self {
+        Self {
+            pending_writes_drained: report.pending_writes_drained,
+            artifact_entries: report.artifact_entries,
+            metadata_entries: report.metadata_entries,
+        }
+    }
+}
+
+impl DetailedFlushReport {
+    pub(super) fn from_report(report: EmbeddedFlushReport) -> Self {
+        debug_assert_eq!(report.is_complete(), {
+            report.pending_writes_drained
+                && report.index_writer_drained
+                && report
+                    .steps
+                    .iter()
+                    .all(|step| matches!(step.outcome, InternalFlushStepOutcome::Completed))
+        });
+        Self {
+            pending_writes_drained: report.pending_writes_drained,
+            index_writer_drained: report.index_writer_drained,
+            steps: report
+                .steps
+                .into_iter()
+                .map(|step| FlushStepReport {
+                    step: step.step,
+                    outcome: match step.outcome {
+                        InternalFlushStepOutcome::Completed => FlushStepOutcome::Completed,
+                        InternalFlushStepOutcome::Failed(error) => FlushStepOutcome::Failed(error),
+                        InternalFlushStepOutcome::TimedOut => FlushStepOutcome::TimedOut,
+                    },
+                })
+                .collect(),
+            artifact_entries: report.artifact_entries,
+            metadata_entries: report.metadata_entries,
+        }
+    }
+}
+
+impl DiskMaintenanceReport {
+    pub(super) fn from_report(report: InternalDiskMaintenanceReport) -> Self {
+        Self {
+            kind: match report.kind {
+                InternalMaintenanceKind::Pressure => DiskMaintenanceKind::Pressure,
+                InternalMaintenanceKind::Full => DiskMaintenanceKind::Full,
+            },
+            pressure: match report.pressure {
+                InternalMaintenancePressure::None => DiskMaintenancePressure::None,
+                InternalMaintenancePressure::Soft => DiskMaintenancePressure::Soft,
+                InternalMaintenancePressure::Hard => DiskMaintenancePressure::Hard,
+            },
+            budget_bytes: report.budget_bytes,
+            usage_before_bytes: report.usage_before_bytes,
+            usage_after_bytes: report.usage_after_bytes,
+            bytes_reclaimed: report.bytes_reclaimed,
+            artifacts_removed: report.artifacts_removed,
+            expired_artifacts_removed: report.expired_artifacts_removed,
+            pending_write_bytes: report.pending_write_bytes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FlushReport;
+
+    #[test]
+    fn legacy_flush_report_literal_and_exhaustive_pattern_still_compile() {
+        let report = FlushReport {
+            pending_writes_drained: true,
+            artifact_entries: 2,
+            metadata_entries: 3,
+        };
+        let FlushReport {
+            pending_writes_drained,
+            artifact_entries,
+            metadata_entries,
+        } = report;
+        assert!(pending_writes_drained);
+        assert_eq!((artifact_entries, metadata_entries), (2, 3));
+    }
+}

--- a/docs/architecture/embedded-service.md
+++ b/docs/architecture/embedded-service.md
@@ -20,7 +20,7 @@ The MVP boundary is:
 | Architecture contract | Landed | This document records lifecycle, ownership, audit, and shutdown expectations. |
 | Public Rust API | MVP landed | `zccache::embedded` exports `ZccacheService` and stable config/request/stats types for start, compile, stats, disk maintenance, flush, and shutdown. |
 | Durable audit schema | MVP landed | `zccache::audit` exports serializable schema/config/event/finding/manifest types. |
-| Audit emission | Partial | `ZccacheService::compile` emits `compile.started`, `cache.hit`/`cache.miss` and `compile.finished` carrying the host's `AuditContext` (#905). Engine-internal events (`cache.lookup` with the key, `compiler.spawn`/`compiler.exit`, depgraph) still need plumbing through `EmbeddedCompileRequest`. |
+| Audit emission | Host boundary landed | `ZccacheService::compile` emits `compile.started`, `cache.hit`/`cache.miss` and `compile.finished` carrying the host's `AuditContext` to durable JSONL and an optional host-owned `EmbeddedEventSink` (#905). Engine-internal events (`cache.lookup` with the key, `compiler.spawn`/`compiler.exit`, depgraph) still need plumbing through `EmbeddedCompileRequest`. |
 | soldr embedded integration | Landed | soldr uses the direct embedded service and owns its cache root, runtime handle, audit context, and shutdown sequence. |
 | fbuild embedded integration | Open | zccache#908 follows the same service contract, adjusted for fbuild's daemon/runtime model. |
 | Vendored hotfix workflow | Documented | zccache#909 is recorded in [`vendored-hotfix-workflow.md`](vendored-hotfix-workflow.md). |
@@ -347,6 +347,13 @@ without a real compiler invocation:
 - `flush()` is callable before host audit/report generation.
 - `shutdown(ShutdownMode::Graceful)` releases tasks and reports whether any
   work was dropped or left unflushed.
+- `shutdown(ShutdownMode::Force)` cancels queued and in-flight compiles across
+  cloned handles before stopping the engine, and does not wait for audit drain.
+- `ServiceLimits::max_parallel_compiles` bounds admission with an async
+  semaphore; `None` is unlimited and zero is rejected at startup.
+- Hosts can supply an `EmbeddedEventSink` callback without enabling file audit
+  output; callbacks receive redacted structured events and cannot panic the
+  compile path.
 - Host identity and audit configuration are required at construction time, even
   if early implementations accept a minimal/no-op audit sink.
 


### PR DESCRIPTION
Closes #905.

Completes the remaining embedded-service contract: a host-owned redacted structured event sink, enforced max_parallel_compiles admission, and forced-shutdown cancellation for queued and in-flight compiles across cloned handles.

Validation: 29 embedded tests pass; targeted clippy with warnings denied passes; zccache all-features check passes; pre-push review is clean.