### PR TITLE
fix(cli): keep shared caches outside daemon namespaces

### DIFF
--- a/crates/zccache-cli-core/src/cli/symbols.rs
+++ b/crates/zccache-cli-core/src/cli/symbols.rs
@@ -761,11 +761,55 @@ mod tests {
     }
 
     /// The archive cache lives under the configured `default_cache_dir`
-    /// (overridable via `ZCCACHE_CACHE_DIR`), never `$TMPDIR`. This is the
-    /// invariant that the `ban_unrooted_tempdir` dylint enforces from the
-    /// other direction.
+    /// (overridable via `ZCCACHE_CACHE_DIR`), never daemon-owned state or
+    /// `$TMPDIR`. This is the invariant that the `ban_unrooted_tempdir`
+    /// dylint enforces from the other direction.
     #[test]
     fn archive_cache_path_is_under_zccache_cache_dir() {
+        const CHILD_MARKER: &str = "ZCCACHE_TEST_SYMBOLS_NAMESPACE_CHILD";
+
+        if std::env::var_os(CHILD_MARKER).is_some() {
+            let path =
+                archive_cache_path("1.6.0", "x86_64-pc-windows-msvc", ArchiveKind::WindowsPdb);
+            let expected_leaf = "zccache-v1.6.0-x86_64-pc-windows-msvc-debug.zip";
+            assert_eq!(
+                path.file_name().and_then(|s| s.to_str()),
+                Some(expected_leaf)
+            );
+
+            let expected_dir = crate::core::config::default_cache_dir().join("symbols");
+            assert_eq!(
+                path.parent(),
+                Some(expected_dir.as_path()),
+                "shared symbols cache must not move below daemon-owned state",
+            );
+            return;
+        }
+
+        // `ZCCACHE_DAEMON_NAMESPACE` is process-global and other tests run in
+        // parallel, so exercise the real environment-dependent resolver in an
+        // isolated copy of this test process.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let output = std::process::Command::new(std::env::current_exe().expect("current test exe"))
+            .arg("cli::symbols::tests::archive_cache_path_is_under_zccache_cache_dir")
+            .arg("--exact")
+            .arg("--nocapture")
+            .env(CHILD_MARKER, "1")
+            .env("ZCCACHE_CACHE_DIR", temp.path())
+            .env("ZCCACHE_DAEMON_NAMESPACE", "dev-binary-hash")
+            .env_remove("ZCCACHE_COLOCATE")
+            .output()
+            .expect("spawn isolated symbols cache path test");
+        assert!(
+            output.status.success(),
+            "isolated symbols cache path test failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    #[test]
+    fn archive_cache_path_has_expected_filename() {
         let path = archive_cache_path("1.6.0", "x86_64-pc-windows-msvc", ArchiveKind::WindowsPdb);
         let expected_leaf = "zccache-v1.6.0-x86_64-pc-windows-msvc-debug.zip";
         assert_eq!(
@@ -778,14 +822,6 @@ mod tests {
             .and_then(|p| p.file_name())
             .and_then(|s| s.to_str());
         assert_eq!(parent, Some("symbols"));
-
-        let expected_root = crate::core::config::daemon_state_dir();
-        assert!(
-            path.starts_with(expected_root.as_path()),
-            "cache path {} should be under default_cache_dir {}",
-            path.display(),
-            expected_root.as_path().display(),
-        );
     }
 
     /// #1172: `prefix.join(&inner)` trusted archive-controlled path

--- a/crates/zccache-core/src/config/paths.rs
+++ b/crates/zccache-core/src/config/paths.rs
@@ -121,13 +121,19 @@ pub fn symbols_cache_dir() -> NormalizedPath {
 /// Returns the symbols-archive cache under an explicit cache root.
 #[must_use]
 pub fn symbols_cache_dir_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
-    daemon_state_dir_from_cache_dir(cache_dir).join("symbols")
+    // Downloaded symbol bundles are CLI-owned shared payloads, not mutable
+    // daemon state. Keep them stable across development daemon namespaces so
+    // rebuilding the binary does not orphan or redownload the same archive.
+    cache_dir.join("symbols")
 }
 
 /// Returns the cargo registry archive cache under an explicit cache root.
 #[must_use]
 pub fn cargo_registry_cache_dir_from_cache_dir(cache_dir: &NormalizedPath) -> NormalizedPath {
-    daemon_state_dir_from_cache_dir(cache_dir).join("cargo-registry")
+    // The public `cargo-registry` contract is relative to `cache-root` and the
+    // archives are shared action/CLI payloads. A daemon namespace must not
+    // move them below daemon-state/<namespace> (#1400).
+    cache_dir.join("cargo-registry")
 }
 
 /// Returns the path to the artifact index database.

--- a/crates/zccache-core/src/config/tests.rs
+++ b/crates/zccache-core/src/config/tests.rs
@@ -276,8 +276,14 @@ fn log_dir_is_under_cache_dir() {
 fn cargo_registry_cache_dir_is_under_cache_dir() {
     let (_temp, cache) = temp_cache_dir();
     let dir = cargo_registry_cache_dir_from_cache_dir(&cache);
-    assert!(dir.ends_with("cargo-registry"));
-    assert!(dir.starts_with(&cache));
+    assert_eq!(dir, cache.join("cargo-registry"));
+}
+
+#[test]
+fn symbols_cache_dir_is_stable_under_cache_dir() {
+    let (_temp, cache) = temp_cache_dir();
+    let dir = symbols_cache_dir_from_cache_dir(&cache);
+    assert_eq!(dir, cache.join("symbols"));
 }
 
 #[test]

--- a/crates/zccache/tests/cli_cache_root.rs
+++ b/crates/zccache/tests/cli_cache_root.rs
@@ -170,6 +170,52 @@ fn cache_root_json_reports_daemon_namespace_and_derived_endpoint() {
 }
 
 #[test]
+fn daemon_namespace_does_not_move_cargo_registry_archives() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let cache_root = temp.path().join("zc");
+    let cargo_home = temp.path().join("cargo-home");
+    let registry_index = cargo_home.join("registry").join("index");
+    std::fs::create_dir_all(&registry_index).expect("create fake cargo registry");
+    std::fs::write(registry_index.join("marker"), b"registry payload")
+        .expect("write fake cargo registry payload");
+
+    let bin = zccache_bin();
+    let output = Command::new(bin.as_path())
+        .env("ZCCACHE_CACHE_DIR", &cache_root)
+        .env("ZCCACHE_DAEMON_NAMESPACE", "dev-binary-hash")
+        .env_remove("ZCCACHE_COLOCATE")
+        .env_remove("SOLDR_SKIP_CARGO_REGISTRY_SAVE")
+        .args([
+            "cargo-registry",
+            "save",
+            "--key",
+            "namespace-stable",
+            "--cargo-home",
+        ])
+        .arg(&cargo_home)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn zccache cargo-registry save");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let expected = cache_root
+        .join(versioned_subdir())
+        .join("cargo-registry")
+        .join("namespace-stable.tar.gz");
+    assert!(
+        expected.is_file(),
+        "cargo-registry archive must remain at the stable cache-root path; stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
 fn cache_root_relative_env_path_is_absolute_in_output() {
     // `ZCCACHE_CACHE_DIR=./relative-zc` should still print an absolute
     // path so wrappers don't have to re-resolve it against the cwd.

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -493,6 +493,11 @@ the cache root. This is the soldr development isolation knob: soldr can set
 development builds do not attach to, replace, or stop the daemon used by normal
 app builds on the same machine.
 
+The namespace may partition daemon-owned mutable state, but it does not move
+CLI-owned shared payloads. In particular, downloaded symbols remain under
+`<cache-root>/symbols/` and Cargo registry archives remain under
+`<cache-root>/cargo-registry/`, matching the paths reported by `cache-root`.
+
 Unset or empty means the default namespace and keeps all historical names. A
 non-empty value is trimmed, sanitized to an ASCII path component, and folded
 into:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -422,3 +422,31 @@ Issue: https://github.com/zackees/zccache/issues/1117
   and review gate in Linux Docker.
 - [ ] Merge the upstream PR, bump soldr's vendored commit, rerun the hosted
   real Dylint/watchdog acceptance, and close the meta issue.
+
+# #1400 stable CLI-owned cache paths
+
+- [x] Reproduce the current-main cargo-registry path mismatch from Actions on all three OSes.
+- [x] File #1400 and add it to the #1205 burn-down tracker.
+- [x] Add RED tests proving daemon namespaces do not move CLI-owned shared cache paths.
+- [x] Keep daemon-owned state namespaced while restoring cargo-registry and symbols to the stable cache root.
+- [x] Run focused tests, formatter, checks, clippy, and the locally available workflow contract.
+- [ ] Review, commit, push, merge the PR, close #1400, and verify current main.
+
+## Review
+
+- Current-main evidence: `cargo-registry save` writes below
+  `daemon-state/<dev-binary-hash>/cargo-registry`, while `cache-root` reports
+  the stable effective root expected by the public CLI and action contract.
+- RED: the real CLI test failed with the archive under
+  `daemon-state/dev-binary-hash/cargo-registry`; the production path helpers
+  now keep both Cargo-registry and symbol payloads under the stable root.
+- GREEN: the focused core path tests, the real cargo-registry CLI regression,
+  the symbols caller contract, `zccache-core`'s full suite, the full
+  `cli_cache_root` integration test, formatting, `zccache-core` clippy, and
+  the feature-complete `zccache` check pass. The local workflow harness reaches
+  its Docker preflight, but Docker Desktop is unavailable; the hosted
+  three-OS action job remains the authoritative workflow validation.
+- Review follow-up: an isolated symbols caller subprocess sets a non-empty
+  daemon namespace and requires the shared cache directory to be exactly
+  `<default_cache_dir>/symbols`, rejecting a stale
+  `daemon-state/<namespace>` intermediate path.


### PR DESCRIPTION
## Summary
- keep Cargo registry archives at `<cache-root>/cargo-registry` even when a development daemon namespace is active
- keep downloaded symbol bundles at `<cache-root>/symbols` while leaving daemon-owned mutable state namespaced
- add real CLI and isolated symbols-caller regressions plus architecture documentation

Closes #1400

## Validation
- RED: the real CLI regression wrote `namespace-stable.tar.gz` below `daemon-state/dev-binary-hash/cargo-registry` before the production fix
- `soldr cargo test -p zccache-core`
- `soldr cargo test -p zccache --features zccache-bin --test cli_cache_root`
- `soldr cargo test -p zccache-cli-core --features cli archive_cache_path_is_under_zccache_cache_dir -- --nocapture`
- `soldr cargo check -p zccache --features zccache-bin --all-targets`
- `soldr cargo clippy -p zccache-core --all-targets -- -D warnings`
- `soldr cargo fmt --all -- --check`
- `uv run --no-project python ci/local_pre_pr.py --suites cargo-registry` reached the Docker preflight; Docker Desktop is unavailable locally, so the hosted Linux/macOS/Windows action job is authoritative

## Review
- `clud-review: clean` (one Rust reviewer)