### PR TITLE
fix(perf): preserve standalone fixture across resume

### DIFF
--- a/PERF.md
+++ b/PERF.md
@@ -195,7 +195,10 @@ uv run --no-project python -m ci.perf_standalone --resume
 
 Evidence is retained under `.perf-standalone/results/`. Each campaign has a
 JSON index and Markdown table linking raw logs, parsed rows, cache phase/byte
-telemetry, command provenance, and resource usage for every test.
+telemetry, command provenance, and resource usage for every test. Its prebuilt
+benchmark and `zccache-ci` executables live in that campaign's `fixture/`
+directory; resume mounts them read-only and verifies both recorded SHA-256
+digests before running another sample.
 
 ## Soldr-embedded lifecycle campaign
 

--- a/ci/docker/standalone_perf_entrypoint.sh
+++ b/ci/docker/standalone_perf_entrypoint.sh
@@ -52,8 +52,12 @@ case "${command}" in
     verify)
         seed_soldr_home
         benchmark_sha256=""
+        zccache_ci_sha256=""
         if [[ -f /artifacts/perf_bench_test ]]; then
             benchmark_sha256="$(sha256sum /artifacts/perf_bench_test | cut -d' ' -f1)"
+        fi
+        if [[ -f /artifacts/zccache-ci ]]; then
+            zccache_ci_sha256="$(sha256sum /artifacts/zccache-ci | cut -d' ' -f1)"
         fi
         jq -n \
             --arg rustc "$(soldr rustc --version | head -n 1)" \
@@ -62,7 +66,8 @@ case "${command}" in
             --arg emscripten "$(em++ --version | head -n 1)" \
             --arg soldr "$(soldr version | head -n 1)" \
             --arg benchmark_sha256 "${benchmark_sha256}" \
-            '{rustc: $rustc, clang: $clang, sccache: $sccache, emscripten: $emscripten, soldr: $soldr, benchmark_sha256: $benchmark_sha256}'
+            --arg zccache_ci_sha256 "${zccache_ci_sha256}" \
+            '{rustc: $rustc, clang: $clang, sccache: $sccache, emscripten: $emscripten, soldr: $soldr, benchmark_sha256: $benchmark_sha256, zccache_ci_sha256: $zccache_ci_sha256}'
         ;;
     run)
         require_mount /artifacts/perf_bench_test

--- a/ci/perf_standalone.py
+++ b/ci/perf_standalone.py
@@ -26,7 +26,10 @@ DEFAULT_ATTEMPTS = 5
 BUILD_VOLUMES = {
     "zccache-standalone-soldr-home": "/root/.soldr",
     "zccache-standalone-target": "/target",
-    "zccache-standalone-artifacts": "/artifacts",
+}
+FIXTURE_HASH_FIELDS = {
+    "perf_bench_test": "benchmark_sha256",
+    "zccache-ci": "zccache_ci_sha256",
 }
 TOOL_VERSION_MARKERS = {
     "rustc": "rustc 1.95.0",
@@ -109,15 +112,30 @@ def docker_run_command(
     results_dir: Path,
     container_name: str,
     entrypoint_args: list[str],
+    artifacts_dir: Path | None = None,
     artifacts_read_only: bool = True,
+    results_read_only: bool = False,
 ) -> list[str]:
+    artifacts_dir = artifacts_dir or results_dir / "fixture"
     command = ["docker", "run", "--rm", "--name", container_name]
     command.extend(
         [
             "--mount",
             _mount(repo_root.resolve(), "/src", kind="bind", readonly=True),
             "--mount",
-            _mount(results_dir.resolve(), "/results", kind="bind", readonly=False),
+            _mount(
+                results_dir.resolve(),
+                "/results",
+                kind="bind",
+                readonly=results_read_only,
+            ),
+            "--mount",
+            _mount(
+                artifacts_dir.resolve(),
+                "/artifacts",
+                kind="bind",
+                readonly=artifacts_read_only,
+            ),
         ]
     )
     for volume, destination in BUILD_VOLUMES.items():
@@ -128,7 +146,7 @@ def docker_run_command(
                     volume,
                     destination,
                     kind="volume",
-                    readonly=destination == "/artifacts" and artifacts_read_only,
+                    readonly=False,
                 ),
             ]
         )
@@ -549,33 +567,43 @@ def _host_identity() -> dict[str, Any]:
     return payload
 
 
-def _build_benchmark(campaign_dir: Path) -> list[str]:
-    command = docker_run_command(
+def _benchmark_build_command(campaign_dir: Path) -> list[str]:
+    return docker_run_command(
         repo_root=REPO_ROOT,
         results_dir=campaign_dir,
         container_name="zccache-standalone-build",
         entrypoint_args=["build"],
+        artifacts_dir=campaign_dir / "fixture",
         artifacts_read_only=False,
     )
+
+
+def _build_benchmark(campaign_dir: Path) -> list[str]:
+    command = _benchmark_build_command(campaign_dir)
     _run(command)
     return command
 
 
-def _tool_versions(campaign_dir: Path) -> tuple[dict[str, str], str, list[str]]:
+def _tool_versions(
+    campaign_dir: Path,
+) -> tuple[dict[str, str], dict[str, str], list[str]]:
     command = docker_run_command(
         repo_root=REPO_ROOT,
         results_dir=campaign_dir,
         container_name="zccache-standalone-verify",
         entrypoint_args=["verify"],
+        artifacts_dir=campaign_dir / "fixture",
+        results_read_only=True,
     )
     versions = json.loads(_run(command, capture=True).stdout)
     validate_tool_versions(versions)
-    benchmark_sha256 = versions.pop("benchmark_sha256", "")
-    if not isinstance(benchmark_sha256, str) or not re.fullmatch(
-        r"[0-9a-f]{64}", benchmark_sha256
-    ):
-        raise ValueError("benchmark fixture SHA-256 is missing or invalid")
-    return versions, benchmark_sha256, command
+    fixture_hashes = {}
+    for artifact, field in FIXTURE_HASH_FIELDS.items():
+        sha256 = versions.pop(field, "")
+        if not isinstance(sha256, str) or not re.fullmatch(r"[0-9a-f]{64}", sha256):
+            raise ValueError(f"{artifact} fixture SHA-256 is missing or invalid")
+        fixture_hashes[artifact] = sha256
+    return versions, fixture_hashes, command
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -686,6 +714,7 @@ def _run_sample(
         results_dir=sample_dir,
         container_name=f"zccache-standalone-{language.replace('+', 'p')}-{test_name}"[:63],
         entrypoint_args=["run", language, test_name, str(attempts)],
+        artifacts_dir=campaign_dir / "fixture",
     )
     result = _run(command, check=False)
     summary_path = sample_dir / "perf-guard-summary.json"
@@ -750,15 +779,32 @@ def _selected_inventory(language: str | None, test_name: str | None) -> list[tup
 def run_campaign(args: argparse.Namespace) -> Path:
     commit = _ensure_clean_checkout()
     inventory = _selected_inventory(args.language, args.test)
-    _build_image(args.rebuild_image)
-    _ensure_volumes()
     campaign_dir = (
         args.output_dir
         or default_campaign_dir(commit, args.language, args.test, args.attempts)
     ).resolve()
-    campaign_dir.mkdir(parents=True, exist_ok=True)
-    benchmark_build_command = _build_benchmark(campaign_dir)
-    versions, benchmark_sha256, verify_command = _tool_versions(campaign_dir)
+    identity_path = campaign_dir / "campaign-identity.json"
+    if args.resume:
+        if not identity_path.is_file():
+            raise RuntimeError(
+                f"cannot resume campaign without {identity_path}"
+            )
+    else:
+        campaign_dir.mkdir(parents=True, exist_ok=True)
+        if identity_path.exists():
+            raise RuntimeError(
+                f"campaign already exists: {campaign_dir}; pass --resume"
+            )
+        (campaign_dir / "fixture").mkdir(parents=True, exist_ok=True)
+
+    _build_image(args.rebuild_image)
+    _ensure_volumes()
+    benchmark_build_command = (
+        _benchmark_build_command(campaign_dir)
+        if args.resume
+        else _build_benchmark(campaign_dir)
+    )
+    versions, fixture_hashes, verify_command = _tool_versions(campaign_dir)
     host = _host_identity()
     identity = {
         "commit": commit,
@@ -769,14 +815,10 @@ def run_campaign(args: argparse.Namespace) -> Path:
         "inventory": [list(item) for item in inventory],
         "attempts": args.attempts,
         "fixture": {
-            "binary": "perf_bench_test",
-            "sha256": benchmark_sha256,
+            "artifacts": fixture_hashes,
         },
     }
-    identity_path = campaign_dir / "campaign-identity.json"
-    if identity_path.exists():
-        if not args.resume:
-            raise RuntimeError(f"campaign already exists: {campaign_dir}; pass --resume")
+    if args.resume:
         validate_resume_identity(_load_json(identity_path), identity)
     else:
         _write_json(identity_path, identity)

--- a/ci/tests/test_perf_standalone.py
+++ b/ci/tests/test_perf_standalone.py
@@ -1,4 +1,5 @@
 import json
+from argparse import Namespace
 
 import pytest
 
@@ -52,9 +53,20 @@ def test_docker_command_uses_read_only_source_and_named_build_volumes(tmp_path):
 
     assert f"type=bind,src={tmp_path / 'source'},dst=/src,readonly" in joined
     assert f"type=bind,src={tmp_path / 'results'},dst=/results" in joined
+    assert (
+        f"type=bind,src={tmp_path / 'results' / 'fixture'},dst=/artifacts,readonly"
+        in joined
+    )
     for volume, destination in perf_standalone.BUILD_VOLUMES.items():
         assert f"type=volume,src={volume},dst={destination}" in joined
-    assert "dst=/artifacts,readonly" in joined
+    assert "zccache-standalone-artifacts" not in joined
+
+    build = " ".join(perf_standalone._benchmark_build_command(tmp_path / "results"))
+    fixture_mount = (
+        f"type=bind,src={tmp_path / 'results' / 'fixture'},dst=/artifacts"
+    )
+    assert fixture_mount in build
+    assert f"{fixture_mount},readonly" not in build
 
 
 def test_pinned_tool_versions_are_required():
@@ -83,7 +95,12 @@ def test_resume_identity_rejects_commit_image_host_or_inventory_changes():
         "host_fingerprint": "host-a",
         "inventory": [["c", "perf_c_zccache_vs_bare"]],
         "attempts": 5,
-        "fixture": {"binary": "perf_bench_test", "sha256": "a" * 64},
+        "fixture": {
+            "artifacts": {
+                "perf_bench_test": "a" * 64,
+                "zccache-ci": "b" * 64,
+            }
+        },
     }
 
     perf_standalone.validate_resume_identity(identity, dict(identity))
@@ -93,6 +110,158 @@ def test_resume_identity_rejects_commit_image_host_or_inventory_changes():
         changed[field] = "different"
         with pytest.raises(ValueError, match=field):
             perf_standalone.validate_resume_identity(identity, changed)
+
+
+def test_resume_reuses_recorded_fixture_without_rebuilding(tmp_path, monkeypatch):
+    commit = "a" * 40
+    fixture_hashes = {
+        "perf_bench_test": "b" * 64,
+        "zccache-ci": "c" * 64,
+    }
+    identity = {
+        "commit": commit,
+        "ref": "fix/perf-resume",
+        "dirty": False,
+        "image_digest": "sha256:image",
+        "host_fingerprint": "host-a",
+        "inventory": [],
+        "attempts": 5,
+        "fixture": {"artifacts": fixture_hashes},
+    }
+    (tmp_path / "campaign-identity.json").write_text(
+        json.dumps(identity), encoding="utf-8"
+    )
+
+    monkeypatch.setattr(perf_standalone, "_ensure_clean_checkout", lambda: commit)
+    monkeypatch.setattr(perf_standalone, "_selected_inventory", lambda *_: [])
+    monkeypatch.setattr(perf_standalone, "_build_image", lambda *_: None)
+    monkeypatch.setattr(perf_standalone, "_ensure_volumes", lambda: None)
+    monkeypatch.setattr(
+        perf_standalone,
+        "_build_benchmark",
+        lambda *_: pytest.fail("resume rebuilt the recorded benchmark fixture"),
+    )
+    monkeypatch.setattr(
+        perf_standalone,
+        "_tool_versions",
+        lambda *_: ({"rustc": "pinned"}, fixture_hashes, ["docker", "verify"]),
+    )
+    monkeypatch.setattr(
+        perf_standalone,
+        "_host_identity",
+        lambda: {"fingerprint": "host-a"},
+    )
+    monkeypatch.setattr(perf_standalone, "_image_digest", lambda: "sha256:image")
+    monkeypatch.setattr(perf_standalone, "_git_output", lambda *_: "fix/perf-resume")
+
+    result = perf_standalone.run_campaign(
+        Namespace(
+            language=None,
+            test=None,
+            attempts=5,
+            output_dir=tmp_path,
+            resume=True,
+            rebuild_image=False,
+        )
+    )
+
+    assert result == tmp_path
+
+    tampered_hashes = dict(fixture_hashes)
+    tampered_hashes["zccache-ci"] = "d" * 64
+    monkeypatch.setattr(
+        perf_standalone,
+        "_tool_versions",
+        lambda *_: ({"rustc": "pinned"}, tampered_hashes, ["docker", "verify"]),
+    )
+    monkeypatch.setattr(
+        perf_standalone,
+        "_run_sample",
+        lambda *_: pytest.fail("resume sampled with a tampered fixture"),
+    )
+
+    with pytest.raises(ValueError, match="resume identity mismatch for fixture"):
+        perf_standalone.run_campaign(
+            Namespace(
+                language=None,
+                test=None,
+                attempts=5,
+                output_dir=tmp_path,
+                resume=True,
+                rebuild_image=False,
+            )
+        )
+
+
+def test_verify_requires_hashes_for_every_reused_executable(tmp_path, monkeypatch):
+    valid_versions = {
+        "rustc": "rustc 1.95.0 (fake)",
+        "clang": "Ubuntu clang version 14.0.0",
+        "sccache": "sccache 0.10.0",
+        "emscripten": "emcc 3.1.74",
+        "soldr": "soldr 0.8.16",
+        "benchmark_sha256": "a" * 64,
+        "zccache_ci_sha256": "b" * 64,
+    }
+
+    monkeypatch.setattr(
+        perf_standalone,
+        "_run",
+        lambda *_args, **_kwargs: Namespace(stdout=json.dumps(valid_versions)),
+    )
+    versions, fixture_hashes, command = perf_standalone._tool_versions(tmp_path)
+
+    assert "benchmark_sha256" not in versions
+    assert "zccache_ci_sha256" not in versions
+    assert fixture_hashes == {
+        "perf_bench_test": "a" * 64,
+        "zccache-ci": "b" * 64,
+    }
+    assert (
+        f"type=bind,src={tmp_path / 'fixture'},dst=/artifacts,readonly"
+        in " ".join(command)
+    )
+    assert (
+        f"type=bind,src={tmp_path},dst=/results,readonly" in " ".join(command)
+    )
+
+    for artifact, missing_field in perf_standalone.FIXTURE_HASH_FIELDS.items():
+        incomplete = dict(valid_versions)
+        incomplete[missing_field] = ""
+        monkeypatch.setattr(
+            perf_standalone,
+            "_run",
+            lambda *_args, payload=incomplete, **_kwargs: Namespace(
+                stdout=json.dumps(payload)
+            ),
+        )
+
+        with pytest.raises(ValueError, match=artifact):
+            perf_standalone._tool_versions(tmp_path)
+
+
+def test_resume_requires_recorded_identity_before_container_work(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(perf_standalone, "_ensure_clean_checkout", lambda: "a" * 40)
+    monkeypatch.setattr(perf_standalone, "_selected_inventory", lambda *_: [])
+    monkeypatch.setattr(
+        perf_standalone,
+        "_build_image",
+        lambda *_: pytest.fail("resume touched Docker without recorded identity"),
+    )
+
+    with pytest.raises(RuntimeError, match="cannot resume campaign without"):
+        perf_standalone.run_campaign(
+            Namespace(
+                language=None,
+                test=None,
+                attempts=5,
+                output_dir=tmp_path,
+                resume=True,
+                rebuild_image=False,
+            )
+        )
 
 
 def test_invalid_or_fallback_sample_cannot_enter_campaign():

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -450,3 +450,27 @@ Issue: https://github.com/zackees/zccache/issues/1117
   daemon namespace and requires the shared cache directory to be exactly
   `<default_cache_dir>/symbols`, rejecting a stale
   `daemon-state/<namespace>` intermediate path.
+
+# #1411 resumable standalone performance fixture
+
+Issue: https://github.com/zackees/zccache/issues/1411
+
+- [x] Add RED coverage proving resume never rebuilds or replaces the recorded fixture.
+- [x] Keep every retained executable campaign-local and verify it read-only.
+- [x] Preserve the normal build-and-record path for fresh campaigns.
+- [x] Run focused tests, lint/format checks, and the review gate.
+- [ ] Push, merge, close #1411, and resume the #1116 campaign.
+
+## Review
+
+- RED: resume called `_build_benchmark` before comparing the recorded fixture
+  digest, replacing the shared artifact before it could detect drift.
+- GREEN: 35 focused standalone/embedded tests pass; shell syntax, Python
+  syntax, E/F lint, and diff checks are clean.
+- Docker: a fresh interrupted campaign built and verified both local fixture
+  executables; `--resume` ran verify without a build and preserved both hashes
+  exactly before correctly refusing timing on unrelated active host compilers.
+- Review follow-ups: retain both runtime executables per campaign, hash both,
+  reject missing or changed artifacts before sampling, and mount both the
+  fixture and its parent results alias read-only during verification.
+- clud-review: clean (one reviewer).


### PR DESCRIPTION
Closes #1411.

## Summary

- keep standalone benchmark artifacts inside each campaign instead of a shared replaceable Docker volume
- skip fixture builds on `--resume` and require an existing campaign identity before touching Docker
- hash both reused executables (`perf_bench_test` and `zccache-ci`) and reject missing or changed artifacts before sampling
- mount both the fixture and its parent campaign results path read-only during verification
- document the retained-fixture contract and add fresh/resume/missing/tampered mount tests

## Validation

- `uv run --no-project --with pytest --with pillow python -m pytest ci/tests/test_perf_standalone.py ci/tests/test_perf_embedded.py -q` - 35 passed
- `bash -n ci/docker/standalone_perf_entrypoint.sh`
- Python syntax, Ruff E/F, and `git diff --check`
- fresh Docker campaign built and verified both executables in its campaign-local fixture
- resuming that interrupted campaign invoked verify without build; both SHA-256 values remained unchanged; timing then failed closed on unrelated active host compiler processes
- `clud-review` - clean (one reviewer)