### PR TITLE
ci(release): cross-compile release matrix through soldr

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -150,11 +150,49 @@ runs:
       with:
         tool: cargo-zigbuild
 
+    - name: Configure Zig C compatibility
+      if: inputs.cross_driver == 'zigbuild'
+      shell: bash
+      run: |
+        # Zig cross targets promote __DATE__/__TIME__ to an error. The
+        # mimalloc-pprof amalgamation reports its build timestamp, so retain
+        # the diagnostic without making that vendored C source unbuildable.
+        printf 'CFLAGS=%s\n' "${CFLAGS:+$CFLAGS }-Wno-error=date-time" >> "$GITHUB_ENV"
+        printf 'CXXFLAGS=%s\n' "${CXXFLAGS:+$CXXFLAGS }-Wno-error=date-time" >> "$GITHUB_ENV"
+
+    - name: Install LLVM dSYM tools
+      if: inputs.cross_driver == 'zigbuild' && contains(inputs.target, 'apple-darwin')
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v dsymutil >/dev/null 2>&1; then
+          dsymutil --version
+          exit 0
+        fi
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends -y llvm
+        llvm_dsymutil="$(command -v llvm-dsymutil || true)"
+        if [ -z "$llvm_dsymutil" ]; then
+          llvm_dsymutil="$(find /usr/bin -maxdepth 1 -type f -name 'llvm-dsymutil*' -print | sort -V | tail -n 1)"
+        fi
+        test -n "$llvm_dsymutil"
+        sudo ln -s "$llvm_dsymutil" /usr/local/bin/dsymutil
+        dsymutil --version
+
     - name: Install cargo-xwin
       if: inputs.cross_driver == 'xwin'
       uses: taiki-e/install-action@v2
       with:
         tool: cargo-xwin
+
+    - name: Configure xwin ARM64 C compatibility
+      if: inputs.cross_driver == 'xwin' && inputs.target == 'aarch64-pc-windows-msvc'
+      shell: bash
+      run: |
+        # mimalloc's MSVC C atomics use intrinsics that clang-cl does not
+        # declare for ARM64. Its own source recommends C++ compilation for
+        # MSVC; /TP selects that std::atomic path without changing Rust code.
+        echo "CFLAGS_aarch64_pc_windows_msvc=-TP" >> "$GITHUB_ENV"
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'

--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -269,12 +269,13 @@ runs:
         # Zig cross builds are especially memory-heavy on the two-core hosted
         # Linux runners. Keep one rustc child alive at a time; exit 255 means a
         # signaled compiler child and persisted with two concurrent children.
-        # xwin remains bounded at two because its hosted lanes have not shown
-        # the same process-kill failure.
+        # The xwin lanes showed the same signaled rustc-child exit (255) once
+        # the Zig lanes were serialized. Keep every hosted cross lane to one
+        # rustc child at a time.
         if [ "${{ inputs.cross_driver }}" = "zigbuild" ]; then
           cargo_build=(soldr cargo zigbuild --jobs 1)
         elif [ "${{ inputs.cross_driver }}" = "xwin" ]; then
-          cargo_build=(soldr cargo xwin build --jobs 2)
+          cargo_build=(soldr cargo xwin build --jobs 1)
         elif [ "${{ inputs.use_soldr }}" = "true" ]; then
           cargo_build=(soldr --no-cache cargo build)
         else
@@ -346,7 +347,7 @@ runs:
         if [ "${{ inputs.cross_driver }}" = "zigbuild" ]; then
           cargo_build=(soldr cargo zigbuild --jobs 1)
         elif [ "${{ inputs.cross_driver }}" = "xwin" ]; then
-          cargo_build=(soldr cargo xwin build --jobs 2)
+          cargo_build=(soldr cargo xwin build --jobs 1)
         elif [ "${{ inputs.use_soldr }}" = "true" ]; then
           cargo_build=(soldr --no-cache cargo build)
         else
@@ -355,6 +356,33 @@ runs:
         "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache-cli --features python --lib
         "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache-watcher --features python --lib
         "${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache-fingerprint --features python --lib
+
+    - name: Repair missing Linux debug sidecars
+      if: inputs.cross_driver == 'zigbuild' && contains(inputs.target, 'unknown-linux')
+      shell: bash
+      env:
+        PYO3_PYTHON: python
+      run: |
+        set -euo pipefail
+        TARGET="${{ inputs.target }}"
+        TARGET_DIR="target/$TARGET/release"
+        if [ -e "$TARGET_DIR/zccache.dwp" ] && [ -e "$TARGET_DIR/zccache-fp.dwp" ]; then
+          echo "Linux debug sidecars were produced by the cache-first build"
+          exit 0
+        fi
+
+        # A cached rustc link can restore the executable without the packed
+        # split-debuginfo sidecar. Preserve the normal cache-first build and
+        # its warm dependencies, then rebuild only the shipped umbrella
+        # package without the wrapper so rustc emits both .dwp files locally.
+        echo "Packed Linux debug sidecars are missing; rebuilding zccache locally"
+        soldr cargo clean -p zccache --release --target "$TARGET"
+        soldr --no-cache cargo zigbuild --jobs 1 \
+          --release --target "$TARGET" -p zccache \
+          --features zccache-bin,fingerprint-bin \
+          --bin zccache --bin zccache-fp
+        test -e "$TARGET_DIR/zccache.dwp"
+        test -e "$TARGET_DIR/zccache-fp.dwp"
 
     - name: Stage artifacts
       shell: bash

--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -266,10 +266,12 @@ runs:
         # Native distribution builds keep the historical no-cache path. Linux
         # cross lanes deliberately use the current-worktree bootstrap zccache;
         # setup-soldr's post gate rejects a silently bypassed compiler cache.
+        # Bound cross builds to two rustc children: hosted four-way release
+        # builds can exhaust runner memory and kill several children together.
         if [ "${{ inputs.cross_driver }}" = "zigbuild" ]; then
-          cargo_build=(soldr cargo zigbuild)
+          cargo_build=(soldr cargo zigbuild --jobs 2)
         elif [ "${{ inputs.cross_driver }}" = "xwin" ]; then
-          cargo_build=(soldr cargo xwin build)
+          cargo_build=(soldr cargo xwin build --jobs 2)
         elif [ "${{ inputs.use_soldr }}" = "true" ]; then
           cargo_build=(soldr --no-cache cargo build)
         else

--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -341,9 +341,9 @@ runs:
         # workflow-only build-target bug that latently broke the release path.
         # Surfaced when 1.9.1 became the first version bump after that split.
         if [ "${{ inputs.cross_driver }}" = "zigbuild" ]; then
-          cargo_build=(soldr cargo zigbuild)
+          cargo_build=(soldr cargo zigbuild --jobs 2)
         elif [ "${{ inputs.cross_driver }}" = "xwin" ]; then
-          cargo_build=(soldr cargo xwin build)
+          cargo_build=(soldr cargo xwin build --jobs 2)
         elif [ "${{ inputs.use_soldr }}" = "true" ]; then
           cargo_build=(soldr --no-cache cargo build)
         else

--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -197,7 +197,10 @@ runs:
         # mimalloc's MSVC C atomics use intrinsics that clang-cl does not
         # declare for ARM64. Its own source recommends C++ compilation for
         # MSVC; /TP selects that std::atomic path without changing Rust code.
-        echo "CFLAGS_aarch64_pc_windows_msvc=-TP" >> "$GITHUB_ENV"
+        # cargo-xwin owns CFLAGS_<target> and replaces that variable when it
+        # injects the SDK include paths. General CFLAGS is additive in cc-rs
+        # and this job builds only the selected ARM64 target.
+        echo "CFLAGS=-TP" >> "$GITHUB_ENV"
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'

--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -13,9 +13,17 @@ inputs:
     description: Cache key suffix passed to setup-soldr.
     required: true
   use_soldr:
-    description: Use setup-soldr for setup and caching. Release builds set this false to avoid post-build cache uploads.
+    description: Use setup-soldr for setup and caching.
     required: false
     default: "true"
+  cross_compile:
+    description: Build from a Linux x86 host with a soldr-managed cross driver.
+    required: false
+    default: "false"
+  cross_driver:
+    description: Cross-build cargo driver (native, zigbuild, or xwin).
+    required: false
+    default: native
   prebuild_deps:
     description: setup-soldr prebuild dependency mode.
     required: false
@@ -75,12 +83,12 @@ runs:
     - name: Select Rust toolchain
       shell: bash
       run: |
-        echo "RELEASE_RUST_TOOLCHAIN=${{ contains(inputs.target, 'pc-windows-msvc') && '1.95.0-x86_64-pc-windows-msvc' || '1.95.0' }}" >> "$GITHUB_ENV"
+        echo "RELEASE_RUST_TOOLCHAIN=${{ inputs.cross_compile == 'true' && '1.95.0' || (contains(inputs.target, 'pc-windows-msvc') && '1.95.0-x86_64-pc-windows-msvc' || '1.95.0') }}" >> "$GITHUB_ENV"
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: ${{ contains(inputs.target, 'pc-windows-msvc') && '1.95.0-x86_64-pc-windows-msvc' || '1.95.0' }}
+        toolchain: ${{ inputs.cross_compile == 'true' && '1.95.0' || (contains(inputs.target, 'pc-windows-msvc') && '1.95.0-x86_64-pc-windows-msvc' || '1.95.0') }}
         targets: ${{ inputs.target }}
 
     - name: Verify Rust host toolchain
@@ -89,20 +97,24 @@ runs:
         info="$(rustup run "$RELEASE_RUST_TOOLCHAIN" rustc -vV)"
         printf '%s\n' "$info"
         host="$(printf '%s\n' "$info" | awk '/^host: / { print $2 }')"
-        if [[ "${{ inputs.target }}" == *pc-windows-msvc && "$host" != "x86_64-pc-windows-msvc" ]]; then
+        if [ "${{ inputs.cross_compile }}" = "true" ] && [ "$host" != "x86_64-unknown-linux-gnu" ]; then
+          echo "::error::Cross release builds require the Linux x86 host toolchain, got: ${host:-<missing>}" >&2
+          exit 1
+        fi
+        if [ "${{ inputs.cross_compile }}" != "true" ] && [[ "${{ inputs.target }}" == *pc-windows-msvc ]] && [ "$host" != "x86_64-pc-windows-msvc" ]; then
           echo "::error::Windows release builds must use the MSVC host toolchain, got: ${host:-<missing>}" >&2
           exit 1
         fi
 
     - name: Install musl tools
-      if: inputs.target == 'x86_64-unknown-linux-musl'
+      if: inputs.cross_compile != 'true' && inputs.target == 'x86_64-unknown-linux-musl'
       shell: bash
       run: |
         sudo apt-get update
         sudo apt-get install -y musl-tools
 
     - name: Install musl cross-compilation tools
-      if: inputs.target == 'aarch64-unknown-linux-musl'
+      if: inputs.cross_compile != 'true' && inputs.target == 'aarch64-unknown-linux-musl'
       shell: bash
       run: |
         curl -fsSL -o aarch64-unknown-linux-musl.tar.xz \
@@ -111,20 +123,38 @@ runs:
         echo "$PWD/aarch64-unknown-linux-musl/bin" >> "$GITHUB_PATH"
 
     - name: Install GNU cross-compilation tools
-      if: inputs.target == 'aarch64-unknown-linux-gnu'
+      if: inputs.cross_compile != 'true' && inputs.target == 'aarch64-unknown-linux-gnu'
       shell: bash
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc-aarch64-linux-gnu
 
     - name: Configure cross-compilation linker
-      if: inputs.linker != ''
+      if: inputs.cross_compile != 'true' && inputs.linker != ''
       shell: bash
       run: |
         TARGET_UPPER=$(echo "${{ inputs.target }}" | tr '[:lower:]-' '[:upper:]_')
         TARGET_CC=$(echo "${{ inputs.target }}" | tr '-' '_')
         echo "CARGO_TARGET_${TARGET_UPPER}_LINKER=${{ inputs.linker }}" >> "$GITHUB_ENV"
         echo "CC_${TARGET_CC}=${{ inputs.linker }}" >> "$GITHUB_ENV"
+
+    - name: Install Zig
+      if: inputs.cross_driver == 'zigbuild'
+      uses: mlugg/setup-zig@v2
+      with:
+        version: "0.14.1"
+
+    - name: Install cargo-zigbuild
+      if: inputs.cross_driver == 'zigbuild'
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-zigbuild
+
+    - name: Install cargo-xwin
+      if: inputs.cross_driver == 'xwin'
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-xwin
 
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
@@ -133,9 +163,25 @@ runs:
         toolchain: 1.95.0
         cache: true
         cache-key-suffix: build-${{ inputs.cache_key }}
-        linker: fast
+        linker: ${{ inputs.cross_compile == 'true' && 'platform-default' || 'fast' }}
         prebuild-deps: ${{ inputs.prebuild_deps }}
         prebuild-deps-flags: "--release --target ${{ inputs.target }}"
+        compile-cache-stats: detailed
+        verify-compile-cache: ${{ inputs.cross_compile == 'true' && 'error' || 'off' }}
+
+    - name: Verify bootstrap zccache selection
+      if: inputs.cross_compile == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        test -n "${SOLDR_RUSTC_WRAPPER:-}"
+        test -x "$SOLDR_RUSTC_WRAPPER"
+        resolved="$(command -v zccache)"
+        if [ "$resolved" != "$SOLDR_RUSTC_WRAPPER" ]; then
+          echo "::error::Bootstrap zccache is not first on PATH: $resolved" >&2
+          exit 1
+        fi
+        "$SOLDR_RUSTC_WRAPPER" --version
 
     - name: Clear restored target artifacts
       if: inputs.clear_target_after_setup == 'true'
@@ -174,9 +220,14 @@ runs:
       env:
         PYO3_PYTHON: python
       run: |
-        # Release artifacts are distribution outputs, so they must be compiled
-        # from source instead of being hydrated from a restored compile cache.
-        if [ "${{ inputs.use_soldr }}" = "true" ]; then
+        # Native distribution builds keep the historical no-cache path. Linux
+        # cross lanes deliberately use the current-worktree bootstrap zccache;
+        # setup-soldr's post gate rejects a silently bypassed compiler cache.
+        if [ "${{ inputs.cross_driver }}" = "zigbuild" ]; then
+          cargo_build=(soldr cargo zigbuild)
+        elif [ "${{ inputs.cross_driver }}" = "xwin" ]; then
+          cargo_build=(soldr cargo xwin build)
+        elif [ "${{ inputs.use_soldr }}" = "true" ]; then
           cargo_build=(soldr --no-cache cargo build)
         else
           cargo_build=(rustup run "$RELEASE_RUST_TOOLCHAIN" cargo build)
@@ -209,7 +260,7 @@ runs:
       shell: bash
       run: |
         case "${{ inputs.target }}" in
-          aarch64-pc-windows-msvc|aarch64-unknown-linux-musl|aarch64-unknown-linux-gnu)
+          *apple-darwin|*pc-windows-msvc|aarch64-unknown-linux-musl|aarch64-unknown-linux-gnu)
             # Cross-compiled; skip exec on host. TODO: when matrix gains
             # an arm64 runner, gate aarch64-pc-windows-msvc through it.
             echo "Skipping smoke test for cross-compiled target ${{ inputs.target }}"
@@ -244,7 +295,11 @@ runs:
         # carry the `python` feature, so `-p zccache --features python` is a
         # workflow-only build-target bug that latently broke the release path.
         # Surfaced when 1.9.1 became the first version bump after that split.
-        if [ "${{ inputs.use_soldr }}" = "true" ]; then
+        if [ "${{ inputs.cross_driver }}" = "zigbuild" ]; then
+          cargo_build=(soldr cargo zigbuild)
+        elif [ "${{ inputs.cross_driver }}" = "xwin" ]; then
+          cargo_build=(soldr cargo xwin build)
+        elif [ "${{ inputs.use_soldr }}" = "true" ]; then
           cargo_build=(soldr --no-cache cargo build)
         else
           cargo_build=(rustup run "$RELEASE_RUST_TOOLCHAIN" cargo build)
@@ -351,6 +406,8 @@ runs:
           if [ ! -e "staging-debug/$dsym" ] && [ ! -L "staging-debug/$dsym" ]; then
             if command -v dsymutil >/dev/null 2>&1 && [ -e "$TARGET_DIR/$bin" ]; then
               dsymutil "$TARGET_DIR/$bin" -o "staging-debug/$dsym"
+            elif command -v llvm-dsymutil >/dev/null 2>&1 && [ -e "$TARGET_DIR/$bin" ]; then
+              llvm-dsymutil "$TARGET_DIR/$bin" -o "staging-debug/$dsym"
             fi
           fi
         }
@@ -459,7 +516,7 @@ runs:
         done
 
         case "${{ inputs.target }}" in
-          aarch64-pc-windows-msvc|aarch64-unknown-linux-musl|aarch64-unknown-linux-gnu)
+          *apple-darwin|*pc-windows-msvc|aarch64-unknown-linux-musl|aarch64-unknown-linux-gnu)
             echo "Skipping staged binary execution check for cross-compiled target ${{ inputs.target }}"
             exit 0
             ;;

--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -266,10 +266,13 @@ runs:
         # Native distribution builds keep the historical no-cache path. Linux
         # cross lanes deliberately use the current-worktree bootstrap zccache;
         # setup-soldr's post gate rejects a silently bypassed compiler cache.
-        # Bound cross builds to two rustc children: hosted four-way release
-        # builds can exhaust runner memory and kill several children together.
+        # Zig cross builds are especially memory-heavy on the two-core hosted
+        # Linux runners. Keep one rustc child alive at a time; exit 255 means a
+        # signaled compiler child and persisted with two concurrent children.
+        # xwin remains bounded at two because its hosted lanes have not shown
+        # the same process-kill failure.
         if [ "${{ inputs.cross_driver }}" = "zigbuild" ]; then
-          cargo_build=(soldr cargo zigbuild --jobs 2)
+          cargo_build=(soldr cargo zigbuild --jobs 1)
         elif [ "${{ inputs.cross_driver }}" = "xwin" ]; then
           cargo_build=(soldr cargo xwin build --jobs 2)
         elif [ "${{ inputs.use_soldr }}" = "true" ]; then
@@ -341,7 +344,7 @@ runs:
         # workflow-only build-target bug that latently broke the release path.
         # Surfaced when 1.9.1 became the first version bump after that split.
         if [ "${{ inputs.cross_driver }}" = "zigbuild" ]; then
-          cargo_build=(soldr cargo zigbuild --jobs 2)
+          cargo_build=(soldr cargo zigbuild --jobs 1)
         elif [ "${{ inputs.cross_driver }}" = "xwin" ]; then
           cargo_build=(soldr cargo xwin build --jobs 2)
         elif [ "${{ inputs.use_soldr }}" = "true" ]; then

--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -171,12 +171,17 @@ runs:
         fi
         sudo apt-get update
         sudo apt-get install --no-install-recommends -y llvm
+        if command -v dsymutil >/dev/null 2>&1; then
+          dsymutil --version
+          exit 0
+        fi
         llvm_dsymutil="$(command -v llvm-dsymutil || true)"
         if [ -z "$llvm_dsymutil" ]; then
-          llvm_dsymutil="$(find /usr/bin -maxdepth 1 -type f -name 'llvm-dsymutil*' -print | sort -V | tail -n 1)"
+          llvm_dsymutil="$(find -L /usr/bin -maxdepth 1 -type f -executable -name 'llvm-dsymutil*' -print | sort -V | tail -n 1)"
         fi
-        test -n "$llvm_dsymutil"
+        test -n "$llvm_dsymutil" && test -x "$llvm_dsymutil"
         sudo ln -s "$llvm_dsymutil" /usr/local/bin/dsymutil
+        test -x /usr/local/bin/dsymutil
         dsymutil --version
 
     - name: Install cargo-xwin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,65 +15,101 @@ env:
   RUSTUP_HOME: ${{ github.workspace }}/.rustup
 
 jobs:
+  bootstrap-zccache:
+    name: Bootstrap zccache (bare Cargo)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref || github.sha }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.95.0
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Build bootstrap zccache without a compiler wrapper
+        env:
+          CARGO: cargo
+          RUSTC_WRAPPER: ""
+          RUSTC_WORKSPACE_WRAPPER: ""
+        shell: bash
+        run: |
+          set -euo pipefail
+          unset RUSTC_WRAPPER RUSTC_WORKSPACE_WRAPPER
+          "$CARGO" build --release --target x86_64-unknown-linux-gnu \
+            -p zccache --features zccache-bin --bin zccache
+          mkdir -p bootstrap-zccache
+          install -m 0755 \
+            target/x86_64-unknown-linux-gnu/release/zccache \
+            bootstrap-zccache/zccache
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: bootstrap-zccache
+          path: bootstrap-zccache/zccache
+          if-no-files-found: error
+
   build:
     name: Build (${{ matrix.target }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
+    needs: bootstrap-zccache
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
             binary_ext: ""
+            cross_driver: zigbuild
             prebuild_deps: none
             clear_target_after_setup: "true"
             include_python: false
 
           - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest
             binary_ext: ""
-            cross: true
-            linker: aarch64-unknown-linux-musl-gcc
-            strip: aarch64-unknown-linux-musl-strip
+            cross_driver: zigbuild
             prebuild_deps: none
             clear_target_after_setup: "true"
             include_python: false
 
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
             binary_ext: ""
+            cross_driver: zigbuild
+            prebuild_deps: none
+            clear_target_after_setup: "true"
             include_python: true
 
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
             binary_ext: ""
-            cross: true
-            linker: aarch64-linux-gnu-gcc
-            strip: aarch64-linux-gnu-strip
+            cross_driver: zigbuild
             prebuild_deps: none
             clear_target_after_setup: "true"
             include_python: true
 
           - target: x86_64-apple-darwin
-            os: macos-14
             binary_ext: ""
+            cross_driver: zigbuild
+            prebuild_deps: none
+            clear_target_after_setup: "true"
             include_python: true
 
           - target: aarch64-apple-darwin
-            os: macos-latest
             binary_ext: ""
+            cross_driver: zigbuild
             prebuild_deps: none
             clear_target_after_setup: "true"
             include_python: true
 
           - target: x86_64-pc-windows-msvc
-            os: windows-latest
             binary_ext: ".exe"
+            cross_driver: xwin
+            prebuild_deps: none
+            clear_target_after_setup: "true"
             include_python: true
 
           - target: aarch64-pc-windows-msvc
-            os: windows-latest
             binary_ext: ".exe"
+            cross_driver: xwin
             prebuild_deps: none
             clear_target_after_setup: "true"
             require_debug_sidecars: "false"
@@ -84,19 +120,34 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref || github.sha }}
 
+      - uses: actions/download-artifact@v8
+        with:
+          name: bootstrap-zccache
+          path: ${{ runner.temp }}/bootstrap-zccache
+
+      - name: Install bootstrap zccache for soldr
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod +x "$RUNNER_TEMP/bootstrap-zccache/zccache"
+          echo "$RUNNER_TEMP/bootstrap-zccache" >> "$GITHUB_PATH"
+          echo "SOLDR_RUSTC_WRAPPER=$RUNNER_TEMP/bootstrap-zccache/zccache" >> "$GITHUB_ENV"
+          "$RUNNER_TEMP/bootstrap-zccache/zccache" --version
+
       - uses: ./.github/actions/build-target
         id: build_target
         with:
           target: ${{ matrix.target }}
           binary_ext: ${{ matrix.binary_ext }}
           cache_key: ${{ matrix.target }}
+          use_soldr: "true"
+          cross_compile: "true"
+          cross_driver: ${{ matrix.cross_driver }}
           prebuild_deps: ${{ matrix.prebuild_deps || 'soldr-cook' }}
           clear_target_after_setup: ${{ matrix.clear_target_after_setup || 'false' }}
           require_debug_sidecars: ${{ matrix.require_debug_sidecars || 'true' }}
           include_python: ${{ matrix.include_python && 'true' || 'false' }}
           python_version: "3.13"
-          linker: ${{ matrix.linker || '' }}
-          strip: ${{ matrix.strip || '' }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -13,6 +13,11 @@ on:
         description: Optional tag to publish, for example 1.3.0 or v1.3.0. Leave empty to use the current workspace version.
         required: false
         type: string
+      dry-run:
+        description: Build and package every release target without publishing.
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -221,17 +226,53 @@ jobs:
         run: |
           python -m ci.release_workflow check-registries
 
+  bootstrap-zccache:
+    name: Bootstrap zccache (bare Cargo)
+    runs-on: ubuntu-24.04
+    needs: preflight
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.preflight.outputs.checkout_ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.95.0
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Build bootstrap zccache without a compiler wrapper
+        env:
+          CARGO: cargo
+          RUSTC_WRAPPER: ""
+          RUSTC_WORKSPACE_WRAPPER: ""
+        shell: bash
+        run: |
+          set -euo pipefail
+          unset RUSTC_WRAPPER RUSTC_WORKSPACE_WRAPPER
+          "$CARGO" build --release --target x86_64-unknown-linux-gnu \
+            -p zccache --features zccache-bin --bin zccache
+          mkdir -p bootstrap-zccache
+          install -m 0755 \
+            target/x86_64-unknown-linux-gnu/release/zccache \
+            bootstrap-zccache/zccache
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: bootstrap-zccache
+          path: bootstrap-zccache/zccache
+          if-no-files-found: error
+
   build:
     name: Build (${{ matrix.target }})
-    runs-on: ${{ matrix.os }}
-    needs: preflight
+    runs-on: ubuntu-24.04
+    needs: [preflight, bootstrap-zccache]
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
             binary_ext: ""
+            cross_driver: zigbuild
             prebuild_deps: none
             clear_target_after_setup: "true"
             include_python: "false"
@@ -239,10 +280,8 @@ jobs:
             upload_release: "true"
 
           - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest
             binary_ext: ""
-            linker: aarch64-unknown-linux-musl-gcc
-            strip: aarch64-unknown-linux-musl-strip
+            cross_driver: zigbuild
             prebuild_deps: none
             clear_target_after_setup: "true"
             include_python: "false"
@@ -250,18 +289,17 @@ jobs:
             upload_release: "true"
 
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
             binary_ext: ""
+            cross_driver: zigbuild
+            prebuild_deps: none
             clear_target_after_setup: "true"
             include_python: "true"
             upload_binaries: "true"
             upload_release: "false"
 
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
             binary_ext: ""
-            linker: aarch64-linux-gnu-gcc
-            strip: aarch64-linux-gnu-strip
+            cross_driver: zigbuild
             prebuild_deps: none
             clear_target_after_setup: "true"
             include_python: "true"
@@ -269,16 +307,17 @@ jobs:
             upload_release: "false"
 
           - target: x86_64-apple-darwin
-            os: macos-14
             binary_ext: ""
+            cross_driver: zigbuild
+            prebuild_deps: none
             clear_target_after_setup: "true"
             include_python: "true"
             upload_binaries: "true"
             upload_release: "true"
 
           - target: aarch64-apple-darwin
-            os: macos-latest
             binary_ext: ""
+            cross_driver: zigbuild
             prebuild_deps: none
             clear_target_after_setup: "true"
             include_python: "true"
@@ -286,16 +325,17 @@ jobs:
             upload_release: "true"
 
           - target: x86_64-pc-windows-msvc
-            os: windows-latest
             binary_ext: ".exe"
+            cross_driver: xwin
+            prebuild_deps: none
             clear_target_after_setup: "true"
             include_python: "true"
             upload_binaries: "true"
             upload_release: "true"
 
           - target: aarch64-pc-windows-msvc
-            os: windows-latest
             binary_ext: ".exe"
+            cross_driver: xwin
             prebuild_deps: none
             clear_target_after_setup: "true"
             require_debug_sidecars: "false"
@@ -308,19 +348,33 @@ jobs:
         with:
           ref: ${{ needs.preflight.outputs.checkout_ref }}
 
+      - uses: actions/download-artifact@v8
+        with:
+          name: bootstrap-zccache
+          path: ${{ runner.temp }}/bootstrap-zccache
+
+      - name: Install bootstrap zccache for soldr
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod +x "$RUNNER_TEMP/bootstrap-zccache/zccache"
+          echo "$RUNNER_TEMP/bootstrap-zccache" >> "$GITHUB_PATH"
+          echo "SOLDR_RUSTC_WRAPPER=$RUNNER_TEMP/bootstrap-zccache/zccache" >> "$GITHUB_ENV"
+          "$RUNNER_TEMP/bootstrap-zccache/zccache" --version
+
       - uses: ./.github/actions/build-target
         id: build_target
         with:
           target: ${{ matrix.target }}
           binary_ext: ${{ matrix.binary_ext }}
           cache_key: release-${{ matrix.target }}
-          use_soldr: "false"
+          use_soldr: "true"
+          cross_compile: "true"
+          cross_driver: ${{ matrix.cross_driver }}
           prebuild_deps: ${{ matrix.prebuild_deps || 'soldr-cook' }}
           clear_target_after_setup: ${{ matrix.clear_target_after_setup || 'false' }}
           require_debug_sidecars: ${{ matrix.require_debug_sidecars || 'true' }}
           include_python: ${{ matrix.include_python }}
-          linker: ${{ matrix.linker || '' }}
-          strip: ${{ matrix.strip || '' }}
           version: ${{ needs.preflight.outputs.version }}
 
       - uses: actions/upload-artifact@v7
@@ -384,6 +438,7 @@ jobs:
             --repo "${{ github.repository }}"
 
       - name: Publish or update release
+        if: inputs['dry-run'] != true
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.preflight.outputs.release_tag }}
@@ -442,6 +497,7 @@ jobs:
       always()
       && needs.preflight.result == 'success'
       && needs.publish-release.result == 'success'
+      && inputs['dry-run'] != true
       && needs.preflight.outputs.pypi_complete != 'true'
       && needs.build-wheels.result == 'success'
     environment: pypi
@@ -501,6 +557,7 @@ jobs:
       always()
       && needs.preflight.result == 'success'
       && needs.publish-release.result == 'success'
+      && inputs['dry-run'] != true
       && needs.preflight.outputs.crates_complete != 'true'
       && (needs.preflight.outputs.pypi_complete == 'true' || needs.publish-pypi.result == 'success')
     steps:

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -266,7 +266,8 @@ def test_linux_cross_build_repairs_debug_sidecars_missing_from_cache_hits() -> N
 def test_xwin_arm64_compiles_mimalloc_c_as_recommended_cxx() -> None:
     action = _repo_text(".github/actions/build-target/action.yml")
 
-    assert "CFLAGS_aarch64_pc_windows_msvc=-TP" in action
+    assert 'echo "CFLAGS=-TP" >> "$GITHUB_ENV"' in action
+    assert "CFLAGS_aarch64_pc_windows_msvc=-TP" not in action
 
 
 def test_release_workflow_dry_run_builds_without_publishing() -> None:

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -218,8 +218,10 @@ def test_cross_build_driver_uses_soldr_cache_and_preserves_artifact_contracts() 
     assert "soldr cargo xwin build" in action
     assert "soldr --no-cache cargo zigbuild" not in action
     assert "soldr --no-cache cargo xwin" not in action
-    assert "soldr cargo zigbuild --jobs 2" in action
-    assert "soldr cargo xwin build --jobs 2" in action
+    assert action.count("cargo_build=(soldr cargo zigbuild --jobs 2)") == 2
+    assert action.count("cargo_build=(soldr cargo xwin build --jobs 2)") == 2
+    assert "cargo_build=(soldr cargo zigbuild)" not in action
+    assert "cargo_build=(soldr cargo xwin build)" not in action
     assert "verify-compile-cache:" in action
     assert "Bootstrap zccache is not first on PATH" in action
     for workflow in (release_workflow, build_workflow):

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -218,9 +218,10 @@ def test_cross_build_driver_uses_soldr_cache_and_preserves_artifact_contracts() 
     assert "soldr cargo xwin build" in action
     assert "soldr --no-cache cargo zigbuild" not in action
     assert "soldr --no-cache cargo xwin" not in action
-    assert action.count("cargo_build=(soldr cargo zigbuild --jobs 2)") == 2
+    assert action.count("cargo_build=(soldr cargo zigbuild --jobs 1)") == 2
     assert action.count("cargo_build=(soldr cargo xwin build --jobs 2)") == 2
     assert "cargo_build=(soldr cargo zigbuild)" not in action
+    assert "cargo_build=(soldr cargo zigbuild --jobs 2)" not in action
     assert "cargo_build=(soldr cargo xwin build)" not in action
     assert "verify-compile-cache:" in action
     assert "Bootstrap zccache is not first on PATH" in action

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -216,13 +216,14 @@ def test_cross_build_driver_uses_soldr_cache_and_preserves_artifact_contracts() 
     assert "cross_driver:" in action
     assert "soldr cargo zigbuild" in action
     assert "soldr cargo xwin build" in action
-    assert "soldr --no-cache cargo zigbuild" not in action
+    assert action.count("soldr --no-cache cargo zigbuild --jobs 1") == 1
     assert "soldr --no-cache cargo xwin" not in action
     assert action.count("cargo_build=(soldr cargo zigbuild --jobs 1)") == 2
-    assert action.count("cargo_build=(soldr cargo xwin build --jobs 2)") == 2
+    assert action.count("cargo_build=(soldr cargo xwin build --jobs 1)") == 2
     assert "cargo_build=(soldr cargo zigbuild)" not in action
     assert "cargo_build=(soldr cargo zigbuild --jobs 2)" not in action
     assert "cargo_build=(soldr cargo xwin build)" not in action
+    assert "cargo_build=(soldr cargo xwin build --jobs 2)" not in action
     assert "verify-compile-cache:" in action
     assert "Bootstrap zccache is not first on PATH" in action
     for workflow in (release_workflow, build_workflow):
@@ -246,6 +247,20 @@ def test_zigbuild_cross_prerequisites_cover_vendored_c_and_macos_debug_info() ->
     assert 'test -x "$llvm_dsymutil"' in action
     assert 'ln -s "$llvm_dsymutil" /usr/local/bin/dsymutil' in action
     assert "test -x /usr/local/bin/dsymutil" in action
+
+
+def test_linux_cross_build_repairs_debug_sidecars_missing_from_cache_hits() -> None:
+    action = _repo_text(".github/actions/build-target/action.yml")
+
+    assert "name: Repair missing Linux debug sidecars" in action
+    assert (
+        "if: inputs.cross_driver == 'zigbuild' && "
+        "contains(inputs.target, 'unknown-linux')"
+    ) in action
+    assert 'soldr cargo clean -p zccache --release --target "$TARGET"' in action
+    assert "soldr --no-cache cargo zigbuild --jobs 1" in action
+    assert 'test -e "$TARGET_DIR/zccache.dwp"' in action
+    assert 'test -e "$TARGET_DIR/zccache-fp.dwp"' in action
 
 
 def test_xwin_arm64_compiles_mimalloc_c_as_recommended_cxx() -> None:

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -173,13 +173,14 @@ def test_build_target_stamps_release_binaries_with_python_footer() -> None:
     assert 'soldr cargo build --release --target "$HOST_TARGET"' not in action
 
 
-def test_build_target_compiles_release_artifacts_without_compile_cache() -> None:
+def test_build_target_selects_native_or_cross_release_cache_policy() -> None:
     action = _repo_text(".github/actions/build-target/action.yml")
     compact_action = " ".join(action.replace("\\\n", "").split())
 
     assert "cargo_build=(soldr --no-cache cargo build)" in action
     assert 'cargo_build=(rustup run "$RELEASE_RUST_TOOLCHAIN" cargo build)' in action
-    assert "Release artifacts are distribution outputs" in action
+    assert "Native distribution builds keep the historical no-cache path" in action
+    assert "cross lanes deliberately use the current-worktree bootstrap zccache" in action
     assert (
         '"${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache '
         "--features zccache-bin,fingerprint-bin "
@@ -190,13 +191,49 @@ def test_build_target_compiles_release_artifacts_without_compile_cache() -> None
     assert '"${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache-cli --features python --lib' in action
 
 
-def test_release_workflow_disables_soldr_for_artifact_builds() -> None:
+def test_release_workflow_uses_bootstrap_zccache_for_cross_builds() -> None:
     release_workflow = _repo_text(".github/workflows/release-auto.yml")
     action = _repo_text(".github/actions/build-target/action.yml")
 
-    assert 'use_soldr: "false"' in release_workflow
+    assert "bootstrap-zccache:" in release_workflow
+    assert "RUSTC_WRAPPER: \"\"" in release_workflow
+    assert "unset RUSTC_WRAPPER RUSTC_WORKSPACE_WRAPPER" in release_workflow
+    assert "name: bootstrap-zccache" in release_workflow
+    assert "needs: [preflight, bootstrap-zccache]" in release_workflow
+    assert "SOLDR_RUSTC_WRAPPER=" in release_workflow
+    assert 'use_soldr: "true"' in release_workflow
+    assert "runs-on: ubuntu-24.04" in release_workflow
+    assert "runs-on: ${{ matrix.os }}" not in release_workflow
     assert "if: inputs.use_soldr == 'true'" in action
     assert "Use setup-soldr for setup and caching" in action
+
+
+def test_cross_build_driver_uses_soldr_cache_and_preserves_artifact_contracts() -> None:
+    action = _repo_text(".github/actions/build-target/action.yml")
+    release_workflow = _repo_text(".github/workflows/release-auto.yml")
+    build_workflow = _repo_text(".github/workflows/build.yml")
+
+    assert "cross_driver:" in action
+    assert "soldr cargo zigbuild" in action
+    assert "soldr cargo xwin build" in action
+    assert "soldr --no-cache cargo zigbuild" not in action
+    assert "soldr --no-cache cargo xwin" not in action
+    assert "verify-compile-cache:" in action
+    assert "Bootstrap zccache is not first on PATH" in action
+    for workflow in (release_workflow, build_workflow):
+        assert "cross_driver: zigbuild" in workflow
+        assert "cross_driver: xwin" in workflow
+        assert "name: binaries-${{ matrix.target }}" in workflow
+        assert "name: release-${{ matrix.target }}" in workflow
+
+
+def test_release_workflow_dry_run_builds_without_publishing() -> None:
+    workflow = _repo_text(".github/workflows/release-auto.yml")
+
+    assert "dry-run:" in workflow
+    assert "type: boolean" in workflow
+    assert "if: inputs['dry-run'] != true" in workflow
+    assert workflow.count("inputs['dry-run'] != true") >= 3
 
 
 def test_build_target_forces_msvc_host_toolchain_for_windows() -> None:
@@ -264,18 +301,16 @@ def test_build_target_uses_target_specific_binary_size_floor() -> None:
     assert "minimum $min_size" in action
 
 
-def test_release_and_build_workflows_disable_cook_cache_for_cross_targets() -> None:
+def test_release_and_build_workflows_disable_cook_cache_for_linux_cross_matrix() -> None:
     cross_targets = {
         "x86_64-unknown-linux-musl",
         "aarch64-unknown-linux-musl",
-        "aarch64-unknown-linux-gnu",
-        "aarch64-apple-darwin",
-        "aarch64-pc-windows-msvc",
-    }
-    native_targets = {
         "x86_64-unknown-linux-gnu",
+        "aarch64-unknown-linux-gnu",
         "x86_64-apple-darwin",
+        "aarch64-apple-darwin",
         "x86_64-pc-windows-msvc",
+        "aarch64-pc-windows-msvc",
     }
 
     build_workflow = _repo_text(".github/workflows/build.yml")
@@ -299,15 +334,6 @@ def test_release_and_build_workflows_disable_cook_cache_for_cross_targets() -> N
 
         windows_arm_block = _matrix_entry(workflow, "aarch64-pc-windows-msvc")
         assert 'require_debug_sidecars: "false"' in windows_arm_block
-
-    for target in native_targets:
-        block = _matrix_entry(build_workflow, target)
-        assert "prebuild_deps: none" not in block
-        assert "clear_target_after_setup:" not in block
-
-        release_block = _matrix_entry(release_workflow, target)
-        assert "prebuild_deps: none" not in release_block
-        assert 'clear_target_after_setup: "true"' in release_block
 
 
 def test_release_workflow_restart_attempts_resume_existing_github_release() -> None:

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -227,6 +227,25 @@ def test_cross_build_driver_uses_soldr_cache_and_preserves_artifact_contracts() 
         assert "name: release-${{ matrix.target }}" in workflow
 
 
+def test_zigbuild_cross_prerequisites_cover_vendored_c_and_macos_debug_info() -> None:
+    action = _repo_text(".github/actions/build-target/action.yml")
+
+    # Zig promotes __DATE__/__TIME__ in mimalloc-pprof's vendored C source to
+    # an error for cross targets. Keep the warning visible without failing the
+    # release, and make rustc's packed macOS debug-info tool available before
+    # the build (not only during packaging).
+    assert "-Wno-error=date-time" in action
+    assert "Install LLVM dSYM tools" in action
+    assert "llvm-dsymutil" in action
+    assert 'ln -s "$llvm_dsymutil" /usr/local/bin/dsymutil' in action
+
+
+def test_xwin_arm64_compiles_mimalloc_c_as_recommended_cxx() -> None:
+    action = _repo_text(".github/actions/build-target/action.yml")
+
+    assert "CFLAGS_aarch64_pc_windows_msvc=-TP" in action
+
+
 def test_release_workflow_dry_run_builds_without_publishing() -> None:
     workflow = _repo_text(".github/workflows/release-auto.yml")
 

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -237,7 +237,10 @@ def test_zigbuild_cross_prerequisites_cover_vendored_c_and_macos_debug_info() ->
     assert "-Wno-error=date-time" in action
     assert "Install LLVM dSYM tools" in action
     assert "llvm-dsymutil" in action
+    assert "find -L /usr/bin" in action
+    assert 'test -x "$llvm_dsymutil"' in action
     assert 'ln -s "$llvm_dsymutil" /usr/local/bin/dsymutil' in action
+    assert "test -x /usr/local/bin/dsymutil" in action
 
 
 def test_xwin_arm64_compiles_mimalloc_c_as_recommended_cxx() -> None:

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -218,6 +218,8 @@ def test_cross_build_driver_uses_soldr_cache_and_preserves_artifact_contracts() 
     assert "soldr cargo xwin build" in action
     assert "soldr --no-cache cargo zigbuild" not in action
     assert "soldr --no-cache cargo xwin" not in action
+    assert "soldr cargo zigbuild --jobs 2" in action
+    assert "soldr cargo xwin build --jobs 2" in action
     assert "verify-compile-cache:" in action
     assert "Bootstrap zccache is not first on PATH" in action
     for workflow in (release_workflow, build_workflow):

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -550,6 +550,8 @@ Issue: https://github.com/zackees/zccache/issues/864
   rustc children together with exit 255 under four-way release parallelism;
   cross lanes are now bounded to two jobs while native builds stay unchanged.
 - clud-review: clean after the initial hosted toolchain follow-ups (one reviewer).
+- Final clud-review: clean after bounding both binary and Python-extension
+  cross-build paths (one reviewer).
 
 # #1414 isolate session-reaping lifecycle events
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -552,6 +552,15 @@ Issue: https://github.com/zackees/zccache/issues/864
 - clud-review: clean after the initial hosted toolchain follow-ups (one reviewer).
 - Final clud-review: clean after bounding both binary and Python-extension
   cross-build paths (one reviewer).
+- Hosted RED: serializing Zig builds fixed every signaled compiler child and
+  both macOS targets completed; all four Linux targets then exposed missing
+  packed `.dwp` sidecars after cache-restored link outputs, while both xwin
+  lanes reproduced exit 255 at two jobs.
+- Final follow-up: serialize xwin too, and keep the normal cache-first Linux
+  build while rebuilding only the shipped umbrella package without the wrapper
+  when its `.dwp` outputs were not restored.
+- Final clud-review: clean after restricting the repair to Zig Linux targets
+  and using soldr's sanctioned no-cache fallback (one reviewer).
 
 # #1414 isolate session-reaping lifecycle events
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -538,9 +538,11 @@ Issue: https://github.com/zackees/zccache/issues/864
 - RED: focused workflow contracts rejected the pre-migration native-runner
   matrix because it had no wrapper-free bootstrap artifact and invoked
   platform toolchains directly instead of soldr's zig/xwin drivers.
-- GREEN: 30 release-manifest/toolchain contracts pass; all edited YAML parses,
-  Ruff E/F and whitespace checks pass, and the repository review gate is clean
-  with one reviewer (15 focused release/workflow contracts).
+- GREEN: 36 release-manifest/toolchain contracts pass (one environment-gated
+  test skipped); all edited YAML parses, and Ruff E/F and whitespace checks pass.
+- Review follow-up: recheck PATH after installing LLVM, accept symlinked
+  versioned `llvm-dsymutil` executables, and verify the selected tool before
+  cross compilation starts.
 
 # #1414 isolate session-reaping lifecycle events
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -518,6 +518,30 @@ Issue: https://github.com/zackees/zccache/issues/1411
   fixture and its parent results alias read-only during verification.
 - clud-review: clean (one reviewer).
 
+# #864 soldr-driven release cross-compilation
+
+Issue: https://github.com/zackees/zccache/issues/864
+
+- [x] Inventory release/build matrices, composite-action artifact contracts,
+  and the soldr reference workflow.
+- [x] Add RED workflow contracts for a bare-cargo bootstrap and the first
+  Ubuntu cross target family.
+- [x] Stage bootstrap zccache and drive the selected cross jobs through soldr
+  zig/xwin without changing artifact shapes.
+- [x] Add or verify release dry-run behavior and publish suppression.
+- [x] Run workflow contracts, focused build validation, formatting, and the
+  review gate.
+- [ ] Push, run the hosted dry-run, merge, and close #864.
+
+## Review
+
+- RED: focused workflow contracts rejected the pre-migration native-runner
+  matrix because it had no wrapper-free bootstrap artifact and invoked
+  platform toolchains directly instead of soldr's zig/xwin drivers.
+- GREEN: 30 release-manifest/toolchain contracts pass; all edited YAML parses,
+  Ruff E/F and whitespace checks pass, and the repository review gate is clean
+  with one reviewer (15 focused release/workflow contracts).
+
 # #1414 isolate session-reaping lifecycle events
 
 - [x] Add a RED regression proving a state-owned reap event follows the daemon's explicit cache root, not the process-global environment.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -543,6 +543,9 @@ Issue: https://github.com/zackees/zccache/issues/864
 - Review follow-up: recheck PATH after installing LLVM, accept symlinked
   versioned `llvm-dsymutil` executables, and verify the selected tool before
   cross compilation starts.
+- Hosted RED: the second dry run installed Ubuntu's LLVM meta-package, then
+  missed its versioned `llvm-dsymutil` symlink and exited before compilation.
+- clud-review: clean after both follow-ups (one reviewer).
 
 # #1414 isolate session-reaping lifecycle events
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -546,6 +546,10 @@ Issue: https://github.com/zackees/zccache/issues/864
 - Hosted RED: the second dry run installed Ubuntu's LLVM meta-package, then
   missed its versioned `llvm-dsymutil` symlink and exited before compilation.
 - clud-review: clean after both follow-ups (one reviewer).
+- Hosted RED: all completed Linux cross lanes terminated multiple unrelated
+  rustc children together with exit 255 under four-way release parallelism;
+  cross lanes are now bounded to two jobs while native builds stay unchanged.
+- clud-review: clean after the initial hosted toolchain follow-ups (one reviewer).
 
 # #1414 isolate session-reaping lifecycle events
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -561,6 +561,11 @@ Issue: https://github.com/zackees/zccache/issues/864
   when its `.dwp` outputs were not restored.
 - Final clud-review: clean after restricting the repair to Zig Linux targets
   and using soldr's sanctioned no-cache fallback (one reviewer).
+- Hosted RED: the next dry run cleared every Linux and macOS target, but the
+  ARM64 xwin build proved cargo-xwin replaces `CFLAGS_aarch64_pc_windows_msvc`
+  while injecting SDK flags, so clang-cl never received `-TP`.
+- Follow-up: pass `-TP` through general `CFLAGS`, which cc-rs composes with
+  cargo-xwin's target flags in this single-target ARM64 job.
 
 # #1414 isolate session-reaping lifecycle events
 


### PR DESCRIPTION
## Summary

- build one wrapper-free Linux bootstrap `zccache` and pass it to every release lane
- collapse release and build target matrices onto Ubuntu 24.04
- cross-compile Linux/macOS through `soldr cargo zigbuild` and Windows through `soldr cargo xwin`
- preserve existing binary/Python artifact shapes and add a full-matrix publish-suppressed dry-run

## Validation

- `uv run --no-project --with pytest python -m pytest ci/tests/test_package_release.py ci/tests/test_build_release_manifest.py ci/tests/test_toolchain_consistency.py -q` (30 passed)
- edited workflow/action YAML parses with PyYAML
- Ruff E/F clean
- `git diff --check`
- `/clud-review` clean (one reviewer; 15 focused contracts)

Closes #864