### PR TITLE
fix(ci): isolate session reaping lifecycle events (#1414)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/disk_maintenance.rs
@@ -957,7 +957,8 @@ fn reap_finished_sessions_with_grace(
         // stderr goes anywhere unbounded. The durable event is what makes
         // "this daemon reclaims a session per compile" attributable after the
         // fact, which is the growth mode the finding is about.
-        zccache_core::lifecycle::write_event(
+        zccache_core::lifecycle::write_event_in_cache_root(
+            state.cache_dir.as_path(),
             zccache_core::lifecycle::EVENT_SESSIONS_REAPED,
             serde_json::json!({
                 "expired": expired.len(),

--- a/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/disk_maintenance_unit.rs
@@ -963,15 +963,9 @@ async fn tombstone_reaping_is_a_noop_when_nothing_is_stale() {
     assert!(daemon.state.ended_sessions.contains_key(&fresh));
 }
 
-/// Count `sessions_reaped` rows currently in the lifecycle log.
-///
-/// The log path resolves from the process-global cache root, so a test cannot
-/// assume it owns the file — a concurrently running test may have written to
-/// it, and the resolved path can outlive any one test's env guard. Asserting
-/// on the *delta* across a single call is therefore the only stable shape;
-/// asserting a total, or an absence, is a flake waiting to happen.
-fn sessions_reaped_rows() -> usize {
-    let Ok(log) = std::fs::read_to_string(crate::core::lifecycle::log_file_path()) else {
+/// Count `sessions_reaped` rows in one explicitly selected lifecycle log.
+fn sessions_reaped_rows(log_path: &std::path::Path) -> usize {
+    let Ok(log) = std::fs::read_to_string(log_path) else {
         return 0;
     };
     log.lines()
@@ -992,8 +986,13 @@ fn sessions_reaped_rows() -> usize {
 #[tokio::test]
 async fn reaping_writes_a_durable_event_only_when_it_reclaims_something() {
     let root = tempfile::tempdir().unwrap();
-    let _cache_env = crate::daemon::server::tests::CacheDirEnvGuard::set(root.path());
-    let cache_dir: crate::core::NormalizedPath = root.path().join("cache").into();
+    let global_root = root.path().join("process-global");
+    let _cache_env = crate::daemon::server::tests::CacheDirEnvGuard::set(&global_root);
+    let cache_dir: crate::core::NormalizedPath = root.path().join("daemon-owned").into();
+    let daemon_log = cache_dir
+        .join("logs")
+        .join(crate::core::lifecycle::LIVE_LOG_FILENAME);
+    let global_log = crate::core::lifecycle::log_file_path();
     let daemon = Arc::new(
         EmbeddedDaemon::start(
             crate::ipc::unique_test_endpoint(),
@@ -1005,7 +1004,7 @@ async fn reaping_writes_a_durable_event_only_when_it_reclaims_something() {
         .unwrap(),
     );
 
-    let quiet_before = sessions_reaped_rows();
+    let quiet_before = sessions_reaped_rows(daemon_log.as_path());
     // #1324: zero grace so these exercise reclamation itself, not the
     // idle window that protects an in-use session from its exited starter.
     reap_finished_sessions_with_grace(
@@ -1014,7 +1013,7 @@ async fn reaping_writes_a_durable_event_only_when_it_reclaims_something() {
         std::time::Duration::ZERO,
     );
     assert_eq!(
-        sessions_reaped_rows(),
+        sessions_reaped_rows(daemon_log.as_path()),
         quiet_before,
         "a pass that reclaims nothing must not write an event"
     );
@@ -1042,11 +1041,16 @@ async fn reaping_writes_a_durable_event_only_when_it_reclaims_something() {
     );
 
     assert_eq!(
-        sessions_reaped_rows(),
+        sessions_reaped_rows(daemon_log.as_path()),
         quiet_before + 1,
         "reclaiming a dead client's session must leave exactly one record"
     );
-    let log = std::fs::read_to_string(crate::core::lifecycle::log_file_path()).unwrap();
+    assert_eq!(
+        sessions_reaped_rows(global_log.as_path()),
+        0,
+        "a state-owned reap event must not follow process-global cache state"
+    );
+    let log = std::fs::read_to_string(daemon_log.as_path()).unwrap();
     let event: serde_json::Value = log
         .lines()
         .filter_map(|line| serde_json::from_str(line).ok())

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -523,7 +523,7 @@ Issue: https://github.com/zackees/zccache/issues/1411
 - [x] Add a RED regression proving a state-owned reap event follows the daemon's explicit cache root, not the process-global environment.
 - [x] Route the event through the explicit-root lifecycle writer and preserve its payload/cardinality contract.
 - [x] Run the focused regression repeatedly, the daemon-core suite, formatting, and clippy/checks.
-- [ ] Run the repository review gate.
+- [x] Run the repository review gate.
 - [ ] Push, merge, close #1414, and verify the Linux x86 gate.
 
 ## Review
@@ -533,3 +533,5 @@ Issue: https://github.com/zackees/zccache/issues/1411
 - GREEN: the focused test passes against the daemon-owned root; the full
   daemon-core suite passes (754 active, 25 ignored), as do formatting,
   warnings-denied clippy for every daemon-core target, and whitespace checks.
+- Post-merge GREEN: the focused regression passes against current main.
+- clud-review: clean (one reviewer).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -489,3 +489,18 @@ Issue: https://github.com/zackees/zccache/issues/1117
   and toolchain Python contracts pass; all three ignored wrapper-boundary
   tests pass; feature-complete check, clippy with warnings denied, formatting,
   and diff whitespace checks pass.
+# #1414 isolate session-reaping lifecycle events
+
+- [x] Add a RED regression proving a state-owned reap event follows the daemon's explicit cache root, not the process-global environment.
+- [x] Route the event through the explicit-root lifecycle writer and preserve its payload/cardinality contract.
+- [x] Run the focused regression repeatedly, the daemon-core suite, formatting, and clippy/checks.
+- [ ] Run the repository review gate.
+- [ ] Push, merge, close #1414, and verify the Linux x86 gate.
+
+## Review
+
+- RED: with the old process-global writer, the isolated daemon log retained
+  zero rows after a one-session reap (`left: 0`, `right: 1`).
+- GREEN: the focused test passes against the daemon-owned root; the full
+  daemon-core suite passes (754 active, 25 ignored), as do formatting,
+  warnings-denied clippy for every daemon-core target, and whitespace checks.


### PR DESCRIPTION
Closes #1414.

Routes the session-reaping lifecycle event through the daemon-owned cache root instead of process-global cache state. The regression test isolates distinct roots and proves only the daemon-owned log receives the event.

Validation:
- RED with the old writer: daemon-owned log had 0 events instead of 1
- focused regression passes after merging current main
- full daemon-core suite: 754 passed, 25 ignored
- formatting, warnings-denied clippy, and diff checks pass
- clud-review: clean (one reviewer)