### PR TITLE
fix(cache): preserve packed DWARF and compiler flag order

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/compiler_output_tests/README.md
+++ b/crates/zccache-daemon-core/src/daemon/server/compiler_output_tests/README.md
@@ -1,0 +1,8 @@
+# Compiler output tests
+
+This directory holds focused tests split from the parent compiler-output
+module so the production implementation stays within the repository
+source-file size limit.
+
+`tests.rs` covers target-specific sidecars included in cached compiler output
+sets, including packed Linux DWARF and MSVC program databases.

--- a/crates/zccache-daemon-core/src/daemon/server/compiler_output_tests/tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/compiler_output_tests/tests.rs
@@ -1,0 +1,302 @@
+use super::*;
+
+fn parsed_link_for_target(
+    cwd: &Path,
+    target: &str,
+    crate_type: &str,
+    packed: bool,
+) -> crate::depgraph::RustcParsedArgs {
+    let mut args = vec![
+        "--crate-name=app".to_string(),
+        format!("--crate-type={crate_type}"),
+        "--emit=link".to_string(),
+        "--out-dir=/repo/target/deps".to_string(),
+        format!("--target={target}"),
+        "src/main.rs".to_string(),
+    ];
+    if packed {
+        args.push("-Csplit-debuginfo=packed".to_string());
+        args.push("-Cdebuginfo=2".to_string());
+    }
+    crate::depgraph::parse_rustc_args(&args, cwd)
+}
+
+#[test]
+fn linux_link_declares_packed_dwarf_sidecar() {
+    let cwd = Path::new("/repo");
+    let parsed = parsed_link_for_target(cwd, "x86_64-unknown-linux-gnu", "bin", true);
+    let primary = Path::new("/repo/target/deps/app");
+
+    let declared = rustc_expected_output_paths(&parsed, primary, cwd, None);
+
+    assert!(
+        declared
+            .iter()
+            .any(|path| path == &NormalizedPath::new("/repo/target/deps/app.dwp")),
+        "Linux linked output must declare its packed DWARF sidecar: {declared:?}"
+    );
+}
+
+#[test]
+fn legacy_collection_includes_existing_packed_dwarf_sidecar() {
+    let temp = tempfile::tempdir().unwrap();
+    let primary = temp.path().join("app");
+    let sidecar = temp.path().join("app.dwp");
+    std::fs::write(&primary, b"image").unwrap();
+    std::fs::write(&sidecar, b"packed-dwarf").unwrap();
+    let parsed = parsed_link_for_target(temp.path(), "x86_64-unknown-linux-gnu", "bin", true);
+
+    let collected = collect_rustc_output_files(&parsed, &primary, temp.path());
+
+    assert!(
+        collected.iter().any(|output| output.path == sidecar),
+        "existing packed DWARF sidecar must be collected with the image"
+    );
+}
+
+#[test]
+fn packed_dwarf_declaration_is_target_and_link_kind_aware() {
+    let cwd = Path::new("/repo");
+    let primary = Path::new("/repo/target/deps/app");
+    for parsed in [
+        parsed_link_for_target(cwd, "x86_64-unknown-linux-gnu", "bin", false),
+        parsed_link_for_target(cwd, "x86_64-unknown-linux-gnu", "rlib", true),
+        parsed_link_for_target(cwd, "x86_64-pc-windows-msvc", "bin", true),
+    ] {
+        assert!(linux_packed_dwarf_sidecar_output_path(&parsed, primary).is_none());
+    }
+
+    let dylib = parsed_link_for_target(cwd, "x86_64-unknown-linux-gnu", "cdylib", true);
+    assert_eq!(
+        linux_packed_dwarf_sidecar_output_path(&dylib, Path::new("/repo/target/deps/libplugin.so")),
+        Some(NormalizedPath::new("/repo/target/deps/libplugin.so.dwp"))
+    );
+}
+
+#[cfg(test)]
+mod dylint_sidecar_tests {
+    use super::*;
+
+    #[test]
+    fn perf_dylint_cdylib_models_toolchain_sidecar_as_complete_output_set() {
+        if crate::platform::host::is_windows() {
+            return;
+        }
+        let cwd = Path::new("/repo");
+        let out_dir = "/repo/target/dylint/libraries/nightly/release/deps";
+        let args = vec![
+            "--crate-name=lint".to_string(),
+            "--crate-type=cdylib".to_string(),
+            "--emit=link".to_string(),
+            format!("--out-dir={out_dir}"),
+            "-Clinker=/tools/dylint-link".to_string(),
+            "src/lib.rs".to_string(),
+        ];
+        let parsed = crate::depgraph::parse_rustc_args(&args, cwd);
+        let extension = if crate::platform::host::is_macos() {
+            "dylib"
+        } else {
+            "so"
+        };
+        let primary = Path::new(out_dir).join(format!("liblint.{extension}"));
+        let env = vec![
+            ("CARGO_PKG_NAME".to_string(), "lint".to_string()),
+            (
+                "RUSTUP_TOOLCHAIN".to_string(),
+                "nightly-2026-01-18-x86_64-unknown-linux-gnu".to_string(),
+            ),
+        ];
+
+        let outputs = rustc_expected_output_paths(&parsed, &primary, cwd, Some(&env));
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs[0], NormalizedPath::new(&primary));
+        assert!(outputs[1].ends_with(format!(
+            "release/liblint@nightly-2026-01-18-x86_64-unknown-linux-gnu.{extension}"
+        )));
+
+        let without_identity = rustc_expected_output_paths(&parsed, &primary, cwd, None);
+        assert_eq!(without_identity, vec![NormalizedPath::new(primary)]);
+    }
+}
+
+#[test]
+fn packed_dwarf_declaration_requires_link_and_enabled_debug_info() {
+    let cwd = Path::new("/repo");
+    let primary = Path::new("/repo/target/deps/app");
+    for extra in [
+        [
+            "--emit=metadata",
+            "-Csplit-debuginfo=packed",
+            "-Cdebuginfo=2",
+        ],
+        ["--emit=link", "-Csplit-debuginfo=packed", "-Cdebuginfo=0"],
+    ] {
+        let mut args = vec![
+            "--crate-name=app".to_string(),
+            "--crate-type=bin".to_string(),
+            "--target=x86_64-unknown-linux-gnu".to_string(),
+            "--out-dir=/repo/target/deps".to_string(),
+            "src/main.rs".to_string(),
+        ];
+        args.extend(extra.into_iter().map(str::to_string));
+        let parsed = crate::depgraph::parse_rustc_args(&args, cwd);
+        assert!(linux_packed_dwarf_sidecar_output_path(&parsed, primary).is_none());
+    }
+}
+
+#[test]
+fn packed_dwarf_declaration_uses_effective_last_codegen_values() {
+    let cwd = Path::new("/repo");
+    let primary = Path::new("/repo/target/deps/app");
+    let parse = |split_values: [&str; 2]| {
+        let mut args = vec![
+            "--crate-name=app".to_string(),
+            "--crate-type=bin".to_string(),
+            "--emit=link".to_string(),
+            "--target=x86_64-unknown-linux-gnu".to_string(),
+            "-Cdebuginfo=2".to_string(),
+            "src/main.rs".to_string(),
+        ];
+        args.extend(
+            split_values
+                .into_iter()
+                .map(|value| format!("-Csplit-debuginfo={value}")),
+        );
+        crate::depgraph::parse_rustc_args(&args, cwd)
+    };
+
+    assert!(linux_packed_dwarf_sidecar_output_path(&parse(["packed", "off"]), primary).is_none());
+    assert!(linux_packed_dwarf_sidecar_output_path(&parse(["off", "packed"]), primary).is_some());
+}
+
+#[test]
+fn packed_dwarf_declaration_honors_debug_shorthand_precedence() {
+    let cwd = Path::new("/repo");
+    let primary = Path::new("/repo/target/deps/app");
+    let parse = |debug_args: &[&str]| {
+        let mut args = vec![
+            "--crate-name=app".to_string(),
+            "--crate-type=bin".to_string(),
+            "--emit=link".to_string(),
+            "--target=x86_64-unknown-linux-gnu".to_string(),
+            "-Csplit-debuginfo=packed".to_string(),
+            "src/main.rs".to_string(),
+        ];
+        args.extend(debug_args.iter().map(|arg| (*arg).to_string()));
+        crate::depgraph::parse_rustc_args(&args, cwd)
+    };
+
+    assert!(linux_packed_dwarf_sidecar_output_path(&parse(&["-g"]), primary).is_some());
+    assert!(
+        linux_packed_dwarf_sidecar_output_path(&parse(&["-g", "-Cdebuginfo=0"]), primary).is_none()
+    );
+    assert!(
+        linux_packed_dwarf_sidecar_output_path(&parse(&["-Cdebuginfo=0", "-g"]), primary).is_some()
+    );
+}
+
+#[test]
+fn dylint_key_material_preserves_repeated_codegen_precedence() {
+    let cwd = Path::new("/repo");
+    let parse = |values: [&str; 2]| {
+        let args = vec![
+            format!("-Copt-level={}", values[0]),
+            format!("-Copt-level={}", values[1]),
+            "-Clink-arg=z-last-lexically".to_string(),
+            "-Clink-arg=a-first-lexically".to_string(),
+            "src/lib.rs".to_string(),
+        ];
+        crate::depgraph::parse_rustc_args(&args, cwd)
+    };
+    let key = |values| {
+        let mut parsed = parse(values);
+        add_dylint_linker_key_material(&mut parsed, ContentHash::from_bytes([7; 32]));
+        crate::depgraph::RustcCompileContext::from_parsed_args(
+            &parsed,
+            &[],
+            ContentHash::from_bytes([9; 32]),
+        )
+        .context_key()
+    };
+
+    assert_ne!(key(["2", "3"]), key(["3", "2"]));
+}
+
+/// soldr#2148. Deliberately NOT `cfg(not(target_os = "windows"))` like the
+/// dylint sidecar tests above: `msvc_pdb_sidecar_output_path` is pure path
+/// manipulation, and Windows is precisely where its absence was the bug.
+#[cfg(test)]
+mod pdb_sidecar_tests {
+    use super::*;
+
+    #[test]
+    fn msvc_pdb_is_declared_for_linked_images_only() {
+        // soldr#2148: a cached build produced the .exe without its .pdb, so
+        // crash dumps resolved to `module+0xNNNN`. The pdb was never in the
+        // output model, so it was never staged, stored or replayed.
+        for image in ["app.exe", "plugin.dll", "APP.EXE"] {
+            let pdb = msvc_pdb_sidecar_output_path(Path::new(image))
+                .unwrap_or_else(|| panic!("{image} should declare a pdb"));
+            assert_eq!(
+                pdb.extension().and_then(|e| e.to_str()),
+                Some("pdb"),
+                "{image} -> {pdb:?}"
+            );
+        }
+
+        // Artifacts that never have one. Declaring a pdb for these would be
+        // harmless (missing outputs are filtered at collection) but it would
+        // also be a lie about what the compile produces.
+        for other in ["libfoo.rlib", "libfoo.rmeta", "libfoo.a", "foo.d", "noext"] {
+            assert!(
+                msvc_pdb_sidecar_output_path(Path::new(other)).is_none(),
+                "{other} must not declare a pdb"
+            );
+        }
+    }
+
+    /// soldr#2347: the pdb declaration is target-aware. A windows-gnu
+    /// image is linked by mingw (DWARF in the image, no pdb ever); the
+    /// staged plan hard-fails materialization on a declared output that
+    /// never appears, which killed every Linux-hosted
+    /// `--target x86_64-pc-windows-gnu` linked-image compile.
+    #[test]
+    fn pdb_declaration_is_msvc_target_only() {
+        let cwd = Path::new("/repo");
+        let base = |target: Option<&str>| {
+            let mut args = vec![
+                "--crate-name=wg".to_string(),
+                "--crate-type=bin".to_string(),
+                "--emit=link".to_string(),
+                "--out-dir=/repo/target/deps".to_string(),
+                "src/main.rs".to_string(),
+            ];
+            if let Some(target) = target {
+                args.push(format!("--target={target}"));
+            }
+            crate::depgraph::parse_rustc_args(&args, cwd)
+        };
+
+        let msvc = base(Some("x86_64-pc-windows-msvc"));
+        assert!(msvc_target_writes_pdb(&msvc));
+        let primary = Path::new("/repo/target/deps/wg.exe");
+        let declared = rustc_expected_output_paths(&msvc, primary, cwd, None);
+        assert!(
+            declared
+                .iter()
+                .any(|p| p.extension() == Some("pdb".as_ref())),
+            "msvc target must declare the pdb sidecar: {declared:?}"
+        );
+
+        let gnu = base(Some("x86_64-pc-windows-gnu"));
+        assert!(!msvc_target_writes_pdb(&gnu));
+        let declared = rustc_expected_output_paths(&gnu, primary, cwd, None);
+        assert!(
+            !declared.iter().any(|p| p.extension() == Some("pdb".as_ref())),
+            "windows-gnu never writes a pdb; declaring one hard-fails the              staged materialization (soldr#2347): {declared:?}"
+        );
+
+        let aarch_gnu = base(Some("aarch64-pc-windows-gnullvm"));
+        assert!(!msvc_target_writes_pdb(&aarch_gnu));
+    }
+}

--- a/crates/zccache-daemon-core/src/daemon/server/rustc.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/rustc.rs
@@ -258,7 +258,6 @@ fn add_dylint_linker_key_material(
     args.codegen_flags
         .push(format!("dylint-linker-hash={linker_hash}"));
     args.codegen_flags.extend(args.linker_args.clone());
-    args.codegen_flags.sort();
 }
 
 fn rustc_args(compilation: &crate::compiler::CacheableCompilation) -> &[String] {
@@ -587,6 +586,10 @@ pub(super) fn rustc_expected_output_paths(
         }
     }
 
+    if let Some(dwp) = linux_packed_dwarf_sidecar_output_path(rustc_args, primary_output_path) {
+        push_unique_output_path(&mut paths, dwp);
+    }
+
     paths
 }
 
@@ -686,6 +689,35 @@ pub(super) fn msvc_pdb_sidecar_output_path(primary_output_path: &Path) -> Option
     Some(NormalizedPath::new(
         primary_output_path.with_extension("pdb"),
     ))
+}
+
+/// Packed DWARF product (`<complete-image-name>.dwp`) beside a Linux image.
+/// Static archives must not declare it because they skip the final pack step.
+pub(super) fn linux_packed_dwarf_sidecar_output_path(
+    rustc_args: &crate::depgraph::RustcParsedArgs,
+    primary_output_path: &Path,
+) -> Option<NormalizedPath> {
+    let is_linux = match rustc_args.target.as_deref() {
+        Some(triple) => triple.split('-').any(|part| part == "linux"),
+        None => crate::platform::host::is_linux(),
+    };
+    let links_image = rustc_args
+        .crate_types
+        .iter()
+        .any(|kind| matches!(kind.as_str(), "bin" | "dylib" | "cdylib" | "proc-macro"));
+    let emits_link =
+        rustc_args.emit_types.is_empty() || rustc_args.emit_types.iter().any(|kind| kind == "link");
+    let packed = rustc_args.effective_codegen_value("split-debuginfo") == Some("packed");
+    let debuginfo_enabled = rustc_args
+        .effective_codegen_value("debuginfo")
+        .is_some_and(|value| !matches!(value, "0" | "none"));
+    if !is_linux || !links_image || !emits_link || !packed || !debuginfo_enabled {
+        return None;
+    }
+
+    let mut sidecar_name = primary_output_path.as_os_str().to_owned();
+    sidecar_name.push(".dwp");
+    Some(NormalizedPath::new(std::path::PathBuf::from(sidecar_name)))
 }
 
 pub(super) fn dylint_cdylib_has_complete_output_identity(
@@ -822,6 +854,25 @@ pub(super) fn collect_rustc_output_files(
         }
     }
 
+    if let Some(dwp) = linux_packed_dwarf_sidecar_output_path(rustc_args, primary_output_path) {
+        if let Ok(meta) = std::fs::metadata(&dwp) {
+            if meta.is_file() {
+                let name = dwp
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .into_owned();
+                if !outputs.iter().any(|existing| existing.name == name) {
+                    outputs.push(RustcOutputFile {
+                        name,
+                        path: dwp,
+                        size: meta.len(),
+                    });
+                }
+            }
+        }
+    }
+
     outputs
 }
 pub(super) fn rust_remap_value_matches_old(value: &str, old: &Path) -> bool {
@@ -945,126 +996,5 @@ pub(super) fn rust_remap_gate(
 }
 
 #[cfg(test)]
-mod dylint_sidecar_tests {
-    use super::*;
-
-    #[test]
-    fn perf_dylint_cdylib_models_toolchain_sidecar_as_complete_output_set() {
-        if crate::platform::host::is_windows() {
-            return;
-        }
-        let cwd = Path::new("/repo");
-        let out_dir = "/repo/target/dylint/libraries/nightly/release/deps";
-        let args = vec![
-            "--crate-name=lint".to_string(),
-            "--crate-type=cdylib".to_string(),
-            "--emit=link".to_string(),
-            format!("--out-dir={out_dir}"),
-            "-Clinker=/tools/dylint-link".to_string(),
-            "src/lib.rs".to_string(),
-        ];
-        let parsed = crate::depgraph::parse_rustc_args(&args, cwd);
-        let extension = if crate::platform::host::is_macos() {
-            "dylib"
-        } else {
-            "so"
-        };
-        let primary = Path::new(out_dir).join(format!("liblint.{extension}"));
-        let env = vec![
-            ("CARGO_PKG_NAME".to_string(), "lint".to_string()),
-            (
-                "RUSTUP_TOOLCHAIN".to_string(),
-                "nightly-2026-01-18-x86_64-unknown-linux-gnu".to_string(),
-            ),
-        ];
-
-        let outputs = rustc_expected_output_paths(&parsed, &primary, cwd, Some(&env));
-        assert_eq!(outputs.len(), 2);
-        assert_eq!(outputs[0], NormalizedPath::new(&primary));
-        assert!(outputs[1].ends_with(format!(
-            "release/liblint@nightly-2026-01-18-x86_64-unknown-linux-gnu.{extension}"
-        )));
-
-        let without_identity = rustc_expected_output_paths(&parsed, &primary, cwd, None);
-        assert_eq!(without_identity, vec![NormalizedPath::new(primary)]);
-    }
-}
-
-/// soldr#2148. Deliberately NOT `cfg(not(target_os = "windows"))` like the
-/// dylint sidecar tests above: `msvc_pdb_sidecar_output_path` is pure path
-/// manipulation, and Windows is precisely where its absence was the bug.
-#[cfg(test)]
-mod pdb_sidecar_tests {
-    use super::*;
-
-    #[test]
-    fn msvc_pdb_is_declared_for_linked_images_only() {
-        // soldr#2148: a cached build produced the .exe without its .pdb, so
-        // crash dumps resolved to `module+0xNNNN`. The pdb was never in the
-        // output model, so it was never staged, stored or replayed.
-        for image in ["app.exe", "plugin.dll", "APP.EXE"] {
-            let pdb = msvc_pdb_sidecar_output_path(Path::new(image))
-                .unwrap_or_else(|| panic!("{image} should declare a pdb"));
-            assert_eq!(
-                pdb.extension().and_then(|e| e.to_str()),
-                Some("pdb"),
-                "{image} -> {pdb:?}"
-            );
-        }
-
-        // Artifacts that never have one. Declaring a pdb for these would be
-        // harmless (missing outputs are filtered at collection) but it would
-        // also be a lie about what the compile produces.
-        for other in ["libfoo.rlib", "libfoo.rmeta", "libfoo.a", "foo.d", "noext"] {
-            assert!(
-                msvc_pdb_sidecar_output_path(Path::new(other)).is_none(),
-                "{other} must not declare a pdb"
-            );
-        }
-    }
-
-    /// soldr#2347: the pdb declaration is target-aware. A windows-gnu
-    /// image is linked by mingw (DWARF in the image, no pdb ever); the
-    /// staged plan hard-fails materialization on a declared output that
-    /// never appears, which killed every Linux-hosted
-    /// `--target x86_64-pc-windows-gnu` linked-image compile.
-    #[test]
-    fn pdb_declaration_is_msvc_target_only() {
-        let cwd = Path::new("/repo");
-        let base = |target: Option<&str>| {
-            let mut args = vec![
-                "--crate-name=wg".to_string(),
-                "--crate-type=bin".to_string(),
-                "--emit=link".to_string(),
-                "--out-dir=/repo/target/deps".to_string(),
-                "src/main.rs".to_string(),
-            ];
-            if let Some(target) = target {
-                args.push(format!("--target={target}"));
-            }
-            crate::depgraph::parse_rustc_args(&args, cwd)
-        };
-
-        let msvc = base(Some("x86_64-pc-windows-msvc"));
-        assert!(msvc_target_writes_pdb(&msvc));
-        let primary = Path::new("/repo/target/deps/wg.exe");
-        let declared = rustc_expected_output_paths(&msvc, primary, cwd, None);
-        assert!(
-            declared
-                .iter()
-                .any(|p| p.extension() == Some("pdb".as_ref())),
-            "msvc target must declare the pdb sidecar: {declared:?}"
-        );
-
-        let gnu = base(Some("x86_64-pc-windows-gnu"));
-        assert!(!msvc_target_writes_pdb(&gnu));
-        let declared = rustc_expected_output_paths(&gnu, primary, cwd, None);
-        assert!(
-            !declared.iter().any(|p| p.extension() == Some("pdb".as_ref())),
-            "windows-gnu never writes a pdb; declaring one hard-fails the              staged materialization (soldr#2347): {declared:?}"
-        );
-
-        let aarch_gnu = base(Some("aarch64-pc-windows-gnullvm"));
-        assert!(!msvc_target_writes_pdb(&aarch_gnu));
-    }
-}
+#[path = "compiler_output_tests/tests.rs"]
+mod tests;

--- a/crates/zccache-daemon-core/src/daemon/server/rustc.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/rustc.rs
@@ -717,7 +717,7 @@ pub(super) fn linux_packed_dwarf_sidecar_output_path(
 
     let mut sidecar_name = primary_output_path.as_os_str().to_owned();
     sidecar_name.push(".dwp");
-    Some(NormalizedPath::new(std::path::PathBuf::from(sidecar_name)))
+    Some(NormalizedPath::new(Path::new(&sidecar_name)))
 }
 
 pub(super) fn dylint_cdylib_has_complete_output_identity(

--- a/crates/zccache-depgraph/src/context/mod.rs
+++ b/crates/zccache-depgraph/src/context/mod.rs
@@ -567,7 +567,7 @@ pub struct RustcCompileContext {
     pub cfgs: Vec<String>,
     /// Sorted `--check-cfg` values.
     pub check_cfgs: Vec<String>,
-    /// Sorted cache-relevant `-C` codegen options.
+    /// Cache-relevant `-C` codegen options in command-line order.
     pub codegen_flags: Vec<String>,
     /// Cargo's `-C metadata=` disambiguator for this compilation unit.
     pub cargo_metadata: Option<String>,
@@ -690,7 +690,7 @@ impl RustcCompileContext {
     ) -> ContextKey {
         let mut hasher = blake3::Hasher::new();
 
-        hasher.update(b"zccache-rustc-context-key-v2\0");
+        hasher.update(b"zccache-rustc-context-key-v3\0");
 
         // Compiler binary hash (different rustc versions -> different
         // output). Unconditional (non-Option field, issue #1166).
@@ -759,7 +759,8 @@ impl RustcCompileContext {
             hasher.update(b"\0");
         }
 
-        // Codegen flags (sorted).
+        // Codegen flags retain command-line order. Repeated options can be
+        // additive or last-one-wins, so reordering would risk false hits.
         hasher.update(b"codegen\0");
         for flag in &self.codegen_flags {
             hasher.update(flag.as_bytes());

--- a/crates/zccache-depgraph/src/context/tests/rustc.rs
+++ b/crates/zccache-depgraph/src/context/tests/rustc.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 
-use crate::rustc_args::{ExternCrate, RustcParsedArgs};
+use crate::rustc_args::{parse_rustc_args, ExternCrate, RustcParsedArgs};
 use zccache_core::NormalizedPath;
 
 use super::super::{
@@ -192,6 +192,24 @@ fn rustc_different_codegen_different_key() {
     let mut ctx2 = make_rustc_context("/src/lib.rs", "2021");
     ctx2.codegen_flags = vec!["opt-level=3".to_string()];
     assert_ne!(ctx1.context_key(), ctx2.context_key());
+}
+
+#[test]
+fn rustc_reversed_repeated_codegen_values_have_distinct_keys() {
+    let parse = |values: [&str; 2]| {
+        let args = vec![
+            format!("-Copt-level={}", values[0]),
+            format!("-Copt-level={}", values[1]),
+            "src/lib.rs".to_string(),
+        ];
+        parse_rustc_args(&args, Path::new("/workspace"))
+    };
+    let first =
+        RustcCompileContext::from_parsed_args(&parse(["2", "3"]), &[], test_compiler_hash());
+    let reversed =
+        RustcCompileContext::from_parsed_args(&parse(["3", "2"]), &[], test_compiler_hash());
+
+    assert_ne!(first.context_key(), reversed.context_key());
 }
 
 /// Issue #1174: `target-cpu=native` resolves against the host. An injectable

--- a/crates/zccache-depgraph/src/rustc_args.rs
+++ b/crates/zccache-depgraph/src/rustc_args.rs
@@ -38,7 +38,7 @@ pub struct RustcParsedArgs {
     pub cfgs: Vec<String>,
     /// `--check-cfg` values (sorted).
     pub check_cfgs: Vec<String>,
-    /// Cache-relevant `-C` codegen options (sorted).
+    /// Cache-relevant `-C` codegen options in command-line order.
     /// Includes: opt-level, codegen-units, target-cpu, target-feature,
     /// lto, panic, debuginfo, strip, overflow-checks, embed-bitcode.
     /// Excludes: incremental and linker/pass-through options. Cargo metadata
@@ -87,6 +87,17 @@ pub struct RustcParsedArgs {
     pub sysroot: Option<NormalizedPath>,
     /// `-o` output file (explicit).
     pub output_file: Option<NormalizedPath>,
+}
+
+impl RustcParsedArgs {
+    /// Return the effective value for a last-one-wins codegen option.
+    #[must_use]
+    pub fn effective_codegen_value(&self, key: &str) -> Option<&str> {
+        self.codegen_flags.iter().rev().find_map(|flag| {
+            let (candidate, value) = flag.split_once('=').unwrap_or((flag, ""));
+            (candidate == key).then_some(value)
+        })
+    }
 }
 
 /// Codegen options excluded from cache key (cosmetic or path-dependent).
@@ -325,6 +336,20 @@ pub fn parse_rustc_args(args: &[String], cwd: &Path) -> RustcParsedArgs {
             }
         }
 
+        // Compiler shorthands participate in the same last-one-wins order as
+        // their explicit -C forms. Normalize them in place so hashing and
+        // output discovery see the effective value correctly.
+        if arg == "-g" {
+            handle_codegen_option("debuginfo=2", cwd, &mut result);
+            i += 1;
+            continue;
+        }
+        if arg == "-O" {
+            handle_codegen_option("opt-level=2", cwd, &mut result);
+            i += 1;
+            continue;
+        }
+
         // Lint flags: -A, -W, -D, -F
         if matches!(arg.as_str(), "-A" | "-W" | "-D" | "-F") {
             if let Some(next) = args.get(i + 1) {
@@ -358,11 +383,11 @@ pub fn parse_rustc_args(args: &[String], cwd: &Path) -> RustcParsedArgs {
         i += 1;
     }
 
-    // Sort all collections for deterministic hashing
+    // Sort order-insensitive collections for deterministic hashing. Codegen
+    // flags stay in command-line order because some options are additive and
+    // others are last-one-wins; reordering them can create false cache hits.
     result.cfgs.sort();
     result.check_cfgs.sort();
-    result.codegen_flags.sort();
-    result.linker_args.sort();
     result.lint_flags.sort();
     result.unknown_flags.sort();
 
@@ -413,7 +438,6 @@ fn handle_codegen_option(opt: &str, cwd: &Path, result: &mut RustcParsedArgs) {
         return;
     }
 
-    // Cache-relevant codegen options
     result.codegen_flags.push(opt.to_string());
 }
 
@@ -428,490 +452,5 @@ fn resolve_path(path: &str, cwd: &Path) -> NormalizedPath {
 }
 
 #[cfg(test)]
-mod tests {
-    use zccache_core::NormalizedPath;
-
-    use super::*;
-
-    fn args(s: &[&str]) -> Vec<String> {
-        s.iter().map(|x| x.to_string()).collect()
-    }
-
-    fn cwd() -> NormalizedPath {
-        NormalizedPath::from("/project")
-    }
-
-    #[test]
-    fn basic_parse_source_file() {
-        let parsed = parse_rustc_args(&args(&["src/lib.rs"]), &cwd());
-        assert_eq!(
-            parsed.source_file,
-            NormalizedPath::from("/project/src/lib.rs")
-        );
-    }
-
-    #[test]
-    fn parse_edition() {
-        let parsed = parse_rustc_args(&args(&["--edition", "2021", "src/lib.rs"]), &cwd());
-        assert_eq!(parsed.edition.as_deref(), Some("2021"));
-    }
-
-    #[test]
-    fn parse_edition_equals_form() {
-        let parsed = parse_rustc_args(&args(&["--edition=2021", "src/lib.rs"]), &cwd());
-        assert_eq!(parsed.edition.as_deref(), Some("2021"));
-    }
-
-    #[test]
-    fn parse_crate_type() {
-        let parsed = parse_rustc_args(
-            &args(&["--crate-type", "lib", "--crate-type", "rlib", "src/lib.rs"]),
-            &cwd(),
-        );
-        assert_eq!(parsed.crate_types, vec!["lib", "rlib"]);
-    }
-
-    #[test]
-    fn parse_crate_name() {
-        let parsed = parse_rustc_args(&args(&["--crate-name", "mylib", "src/lib.rs"]), &cwd());
-        assert_eq!(parsed.crate_name.as_deref(), Some("mylib"));
-    }
-
-    #[test]
-    fn parse_emit_types() {
-        let parsed = parse_rustc_args(
-            &args(&["--emit=dep-info,metadata,link", "src/lib.rs"]),
-            &cwd(),
-        );
-        assert_eq!(parsed.emit_types, vec!["dep-info", "metadata", "link"]);
-    }
-
-    #[test]
-    fn parse_emit_with_paths() {
-        // --emit=dep-info=/path/to/deps.d,metadata,link
-        let parsed = parse_rustc_args(
-            &args(&["--emit=dep-info=/tmp/deps.d,metadata,link", "src/lib.rs"]),
-            &cwd(),
-        );
-        assert_eq!(parsed.emit_types, vec!["dep-info", "metadata", "link"]);
-        assert_eq!(parsed.explicit_emit_paths.len(), 1);
-        assert_eq!(parsed.explicit_emit_paths[0].0, "dep-info");
-    }
-
-    #[test]
-    fn parse_cfg_values() {
-        let parsed = parse_rustc_args(
-            &args(&["--cfg", "feature=\"derive\"", "--cfg", "unix", "src/lib.rs"]),
-            &cwd(),
-        );
-        // Sorted
-        assert_eq!(parsed.cfgs, vec!["feature=\"derive\"", "unix"]);
-    }
-
-    #[test]
-    fn parse_codegen_flags() {
-        let parsed = parse_rustc_args(
-            &args(&["-C", "opt-level=2", "-C", "debuginfo=2", "src/lib.rs"]),
-            &cwd(),
-        );
-        // Sorted
-        assert!(parsed.codegen_flags.contains(&"debuginfo=2".to_string()));
-        assert!(parsed.codegen_flags.contains(&"opt-level=2".to_string()));
-    }
-
-    #[test]
-    fn parse_codegen_concatenated() {
-        let parsed = parse_rustc_args(&args(&["-Copt-level=3", "src/lib.rs"]), &cwd());
-        assert!(parsed.codegen_flags.contains(&"opt-level=3".to_string()));
-    }
-
-    #[test]
-    fn dylint_linker_inputs_have_dedicated_fields() {
-        let parsed = parse_rustc_args(
-            &args(&[
-                "-Clinker=tools/dylint-link",
-                "-C",
-                "link-arg=-Wl,--build-id=none",
-                "-Clink-args=-Wl,-z,now",
-                "src/lib.rs",
-            ]),
-            &cwd(),
-        );
-        assert_eq!(
-            parsed.linker,
-            Some(NormalizedPath::from("/project/tools/dylint-link"))
-        );
-        assert_eq!(
-            parsed.linker_args,
-            vec![
-                "link-arg=-Wl,--build-id=none".to_string(),
-                "link-args=-Wl,-z,now".to_string()
-            ]
-        );
-    }
-
-    #[test]
-    fn excluded_codegen_not_in_cache_key() {
-        let parsed = parse_rustc_args(
-            &args(&[
-                "-C",
-                "metadata=abc123",
-                "-C",
-                "extra-filename=-abc123",
-                "-C",
-                "incremental=/tmp/incr",
-                "-C",
-                "linker=cc",
-                "src/lib.rs",
-            ]),
-            &cwd(),
-        );
-        // None of these should be in ordinary codegen_flags.
-        assert!(parsed.codegen_flags.is_empty());
-        // But they should be in their dedicated fields.
-        assert_eq!(parsed.cargo_metadata.as_deref(), Some("abc123"));
-        assert_eq!(parsed.extra_filename.as_deref(), Some("-abc123"));
-        assert_eq!(
-            parsed.incremental_dir,
-            Some(NormalizedPath::from("/tmp/incr"))
-        );
-        assert_eq!(parsed.linker, Some(NormalizedPath::from("/project/cc")));
-    }
-
-    #[test]
-    fn parse_extern_crates() {
-        let parsed = parse_rustc_args(
-            &args(&[
-                "--extern",
-                "serde=/target/deps/libserde.rlib",
-                "--extern",
-                "log=/target/deps/liblog.rmeta",
-                "src/lib.rs",
-            ]),
-            &cwd(),
-        );
-        assert_eq!(parsed.externs.len(), 2);
-        assert_eq!(parsed.externs[0].name, "serde");
-        assert_eq!(
-            parsed.externs[0].path,
-            NormalizedPath::from("/target/deps/libserde.rlib")
-        );
-        assert_eq!(parsed.externs[1].name, "log");
-    }
-
-    #[test]
-    fn parse_extern_noprelude() {
-        let parsed = parse_rustc_args(
-            &args(&[
-                "--extern",
-                "noprelude:core=/path/libcore.rlib",
-                "src/lib.rs",
-            ]),
-            &cwd(),
-        );
-        assert_eq!(parsed.externs[0].name, "core");
-    }
-
-    #[test]
-    fn search_paths_excluded_from_cache_key() {
-        let parsed = parse_rustc_args(
-            &args(&[
-                "-L",
-                "dependency=/target/deps",
-                "-L",
-                "native=/usr/lib",
-                "src/lib.rs",
-            ]),
-            &cwd(),
-        );
-        assert_eq!(parsed.search_paths.len(), 2);
-        // search_paths are stored but NOT in codegen_flags/cfgs/unknown_flags
-        assert!(parsed.codegen_flags.is_empty());
-        assert!(parsed.unknown_flags.is_empty());
-    }
-
-    #[test]
-    fn out_dir_excluded_from_cache_key() {
-        let parsed = parse_rustc_args(
-            &args(&["--out-dir", "/target/debug/deps", "src/lib.rs"]),
-            &cwd(),
-        );
-        assert_eq!(
-            parsed.out_dir,
-            Some(NormalizedPath::from("/target/debug/deps"))
-        );
-        assert!(parsed.unknown_flags.is_empty());
-    }
-
-    #[test]
-    fn cosmetic_flags_excluded() {
-        let parsed = parse_rustc_args(
-            &args(&[
-                "--error-format=json",
-                "--json=diagnostic-rendered-ansi",
-                "--color=always",
-                "--diagnostic-width=80",
-                "src/lib.rs",
-            ]),
-            &cwd(),
-        );
-        assert_eq!(parsed.error_format.as_deref(), Some("json"));
-        assert_eq!(
-            parsed.json_format.as_deref(),
-            Some("diagnostic-rendered-ansi")
-        );
-        assert_eq!(parsed.color.as_deref(), Some("always"));
-        assert_eq!(parsed.diagnostic_width.as_deref(), Some("80"));
-        // None of these should be in unknown_flags
-        assert!(parsed.unknown_flags.is_empty());
-    }
-
-    #[test]
-    fn parse_target() {
-        let parsed = parse_rustc_args(
-            &args(&["--target", "x86_64-unknown-linux-gnu", "src/lib.rs"]),
-            &cwd(),
-        );
-        assert_eq!(parsed.target.as_deref(), Some("x86_64-unknown-linux-gnu"));
-    }
-
-    #[test]
-    fn parse_cap_lints() {
-        let parsed = parse_rustc_args(&args(&["--cap-lints", "allow", "src/lib.rs"]), &cwd());
-        assert_eq!(parsed.cap_lints.as_deref(), Some("allow"));
-    }
-
-    #[test]
-    fn parse_lint_flags() {
-        let parsed = parse_rustc_args(
-            &args(&[
-                "-A",
-                "dead_code",
-                "-W",
-                "unused",
-                "-D",
-                "warnings",
-                "src/lib.rs",
-            ]),
-            &cwd(),
-        );
-        assert_eq!(parsed.lint_flags.len(), 3);
-        assert!(parsed.lint_flags.contains(&"-A dead_code".to_string()));
-        assert!(parsed.lint_flags.contains(&"-D warnings".to_string()));
-        assert!(parsed.lint_flags.contains(&"-W unused".to_string()));
-    }
-
-    #[test]
-    fn parse_output_file() {
-        let parsed = parse_rustc_args(&args(&["-o", "libfoo.rlib", "src/lib.rs"]), &cwd());
-        assert_eq!(
-            parsed.output_file,
-            Some(NormalizedPath::from("/project/libfoo.rlib"))
-        );
-    }
-
-    #[test]
-    fn full_cargo_invocation() {
-        let parsed = parse_rustc_args(
-            &args(&[
-                "--edition",
-                "2021",
-                "--crate-type",
-                "lib",
-                "--crate-name",
-                "serde",
-                "--emit=dep-info,metadata,link",
-                "-C",
-                "opt-level=2",
-                "-C",
-                "metadata=abc123def",
-                "-C",
-                "extra-filename=-abc123def",
-                "--out-dir",
-                "/target/release/deps",
-                "-L",
-                "dependency=/target/release/deps",
-                "--extern",
-                "serde_derive=/target/release/deps/libserde_derive-xyz.so",
-                "--cap-lints",
-                "allow",
-                "--cfg",
-                "feature=\"derive\"",
-                "--cfg",
-                "feature=\"std\"",
-                "--error-format=json",
-                "--json=diagnostic-rendered-ansi,artifacts,future-incompat",
-                "--diagnostic-width=211",
-                "-C",
-                "linker=cc",
-                "src/lib.rs",
-            ]),
-            &cwd(),
-        );
-
-        // Cache-key fields populated
-        assert_eq!(parsed.edition.as_deref(), Some("2021"));
-        assert_eq!(parsed.crate_types, vec!["lib"]);
-        assert_eq!(parsed.crate_name.as_deref(), Some("serde"));
-        assert_eq!(parsed.emit_types, vec!["dep-info", "metadata", "link"]);
-        assert!(parsed.codegen_flags.contains(&"opt-level=2".to_string()));
-        assert_eq!(parsed.cap_lints.as_deref(), Some("allow"));
-        assert!(parsed.cfgs.contains(&"feature=\"derive\"".to_string()));
-        assert!(parsed.cfgs.contains(&"feature=\"std\"".to_string()));
-        assert_eq!(parsed.externs.len(), 1);
-        assert_eq!(parsed.externs[0].name, "serde_derive");
-
-        // Excluded fields populated but NOT in cache-key collections
-        assert_eq!(parsed.cargo_metadata.as_deref(), Some("abc123def"));
-        assert_eq!(parsed.extra_filename.as_deref(), Some("-abc123def"));
-        assert_eq!(parsed.error_format.as_deref(), Some("json"));
-        assert!(parsed.search_paths.len() == 1);
-        assert!(parsed.unknown_flags.is_empty());
-    }
-
-    #[test]
-    fn z_flag_with_value_captured() {
-        let parsed = parse_rustc_args(
-            &args(&["-Z", "macro-backtrace", "--crate-type", "lib", "src/lib.rs"]),
-            &cwd(),
-        );
-        // -Z and its value should be combined into one entry
-        assert!(
-            parsed
-                .unknown_flags
-                .contains(&"-Z macro-backtrace".to_string()),
-            "got: {:?}",
-            parsed.unknown_flags
-        );
-    }
-
-    #[test]
-    fn z_flag_different_values_different_keys() {
-        let parsed1 = parse_rustc_args(&args(&["-Z", "query-threads=4", "src/lib.rs"]), &cwd());
-        let parsed2 = parse_rustc_args(&args(&["-Z", "query-threads=8", "src/lib.rs"]), &cwd());
-        assert_ne!(parsed1.unknown_flags, parsed2.unknown_flags);
-    }
-
-    #[test]
-    fn comma_separated_crate_types_split() {
-        let parsed = parse_rustc_args(&args(&["--crate-type", "lib,rlib", "src/lib.rs"]), &cwd());
-        assert_eq!(parsed.crate_types, vec!["lib", "rlib"]);
-    }
-
-    #[test]
-    fn relative_paths_resolved_against_cwd() {
-        let parsed = parse_rustc_args(&args(&["src/lib.rs"]), &cwd());
-        assert_eq!(
-            parsed.source_file,
-            NormalizedPath::from("/project/src/lib.rs")
-        );
-    }
-
-    #[test]
-    fn absolute_paths_unchanged() {
-        let parsed = parse_rustc_args(&args(&["/absolute/src/lib.rs"]), &cwd());
-        assert_eq!(
-            parsed.source_file,
-            NormalizedPath::from("/absolute/src/lib.rs")
-        );
-    }
-
-    #[test]
-    fn check_cfg_parsed() {
-        let parsed = parse_rustc_args(
-            &args(&["--check-cfg", "cfg(feature, values(\"std\"))", "src/lib.rs"]),
-            &cwd(),
-        );
-        assert_eq!(parsed.check_cfgs.len(), 1);
-    }
-
-    #[test]
-    fn sysroot_parsed() {
-        let parsed = parse_rustc_args(
-            &args(&[
-                "--sysroot",
-                "/home/user/.rustup/toolchains/stable",
-                "src/lib.rs",
-            ]),
-            &cwd(),
-        );
-        assert_eq!(
-            parsed.sysroot,
-            Some(NormalizedPath::from("/home/user/.rustup/toolchains/stable"))
-        );
-    }
-
-    #[test]
-    fn remap_path_prefix_parsed() {
-        let parsed = parse_rustc_args(
-            &args(&["--remap-path-prefix", "/home/user=/anon", "src/lib.rs"]),
-            &cwd(),
-        );
-        assert_eq!(parsed.remap_path_prefixes, vec!["/home/user=/anon"]);
-    }
-
-    #[test]
-    fn remap_path_prefix_equals_form_parsed() {
-        let parsed = parse_rustc_args(
-            &args(&["--remap-path-prefix=/home/user=/anon", "src/lib.rs"]),
-            &cwd(),
-        );
-        assert_eq!(parsed.remap_path_prefixes, vec!["/home/user=/anon"]);
-    }
-    // ─── zackees/soldr#2313: native link-lib flags must key the unit ─────
-
-    #[test]
-    fn link_lib_value_is_captured_not_dropped() {
-        let parsed = parse_rustc_args(
-            &args(&["--crate-name", "demo", "src/main.rs", "-l", "dylib=c++"]),
-            cwd().as_path(),
-        );
-        assert!(
-            parsed.unknown_flags.contains(&"-l dylib=c++".to_string()),
-            "the library NAME must be key material: {:?}",
-            parsed.unknown_flags
-        );
-        // The value must not leak into positional/source handling: the
-        // source stays main.rs (host path separators vary).
-        assert_eq!(
-            parsed
-                .source_file
-                .as_path()
-                .file_name()
-                .and_then(|n| n.to_str()),
-            Some("main.rs")
-        );
-    }
-
-    #[test]
-    fn fused_link_lib_spelling_is_captured() {
-        let parsed = parse_rustc_args(&args(&["src/main.rs", "-lstatic=sqlite3"]), cwd().as_path());
-        assert!(parsed
-            .unknown_flags
-            .contains(&"-l static=sqlite3".to_string()));
-    }
-
-    #[test]
-    fn changing_the_linked_library_changes_the_context_key() {
-        let base = ["--crate-name", "demo", "--crate-type", "bin", "src/main.rs"];
-        let key = |extra: &[&str]| {
-            let mut all: Vec<&str> = base.to_vec();
-            all.extend_from_slice(extra);
-            let parsed = parse_rustc_args(&args(&all), cwd().as_path());
-            crate::context::RustcCompileContext::from_parsed_args(
-                &parsed,
-                &[],
-                zccache_hash::ContentHash::from_bytes([7u8; 32]),
-            )
-            .context_key()
-        };
-        let none = key(&[]);
-        let cxx = key(&["-l", "dylib=c++"]);
-        let stdcxx = key(&["-l", "dylib=stdc++"]);
-        assert_ne!(none, cxx, "adding a native lib must change the key");
-        assert_ne!(
-            cxx, stdcxx,
-            "changing the native lib NAME must change the key — the              soldr#2313 stale-link-hit bug"
-        );
-    }
-}
+#[path = "rustc_args/tests.rs"]
+mod tests;

--- a/crates/zccache-depgraph/src/rustc_args/README.md
+++ b/crates/zccache-depgraph/src/rustc_args/README.md
@@ -1,0 +1,5 @@
+# Rust compiler argument parser tests
+
+This directory contains focused unit tests for the Rust compiler argument
+parser in the parent module. It is split out to keep production source below
+the repository line-count ceiling.

--- a/crates/zccache-depgraph/src/rustc_args/tests.rs
+++ b/crates/zccache-depgraph/src/rustc_args/tests.rs
@@ -1,0 +1,552 @@
+use zccache_core::NormalizedPath;
+
+use super::*;
+
+fn args(s: &[&str]) -> Vec<String> {
+    s.iter().map(|x| x.to_string()).collect()
+}
+
+fn cwd() -> NormalizedPath {
+    NormalizedPath::from("/project")
+}
+
+#[test]
+fn basic_parse_source_file() {
+    let parsed = parse_rustc_args(&args(&["src/lib.rs"]), &cwd());
+    assert_eq!(
+        parsed.source_file,
+        NormalizedPath::from("/project/src/lib.rs")
+    );
+}
+
+#[test]
+fn parse_edition() {
+    let parsed = parse_rustc_args(&args(&["--edition", "2021", "src/lib.rs"]), &cwd());
+    assert_eq!(parsed.edition.as_deref(), Some("2021"));
+}
+
+#[test]
+fn parse_edition_equals_form() {
+    let parsed = parse_rustc_args(&args(&["--edition=2021", "src/lib.rs"]), &cwd());
+    assert_eq!(parsed.edition.as_deref(), Some("2021"));
+}
+
+#[test]
+fn parse_crate_type() {
+    let parsed = parse_rustc_args(
+        &args(&["--crate-type", "lib", "--crate-type", "rlib", "src/lib.rs"]),
+        &cwd(),
+    );
+    assert_eq!(parsed.crate_types, vec!["lib", "rlib"]);
+}
+
+#[test]
+fn parse_crate_name() {
+    let parsed = parse_rustc_args(&args(&["--crate-name", "mylib", "src/lib.rs"]), &cwd());
+    assert_eq!(parsed.crate_name.as_deref(), Some("mylib"));
+}
+
+#[test]
+fn parse_emit_types() {
+    let parsed = parse_rustc_args(
+        &args(&["--emit=dep-info,metadata,link", "src/lib.rs"]),
+        &cwd(),
+    );
+    assert_eq!(parsed.emit_types, vec!["dep-info", "metadata", "link"]);
+}
+
+#[test]
+fn parse_emit_with_paths() {
+    // --emit=dep-info=/path/to/deps.d,metadata,link
+    let parsed = parse_rustc_args(
+        &args(&["--emit=dep-info=/tmp/deps.d,metadata,link", "src/lib.rs"]),
+        &cwd(),
+    );
+    assert_eq!(parsed.emit_types, vec!["dep-info", "metadata", "link"]);
+    assert_eq!(parsed.explicit_emit_paths.len(), 1);
+    assert_eq!(parsed.explicit_emit_paths[0].0, "dep-info");
+}
+
+#[test]
+fn parse_cfg_values() {
+    let parsed = parse_rustc_args(
+        &args(&["--cfg", "feature=\"derive\"", "--cfg", "unix", "src/lib.rs"]),
+        &cwd(),
+    );
+    // Sorted
+    assert_eq!(parsed.cfgs, vec!["feature=\"derive\"", "unix"]);
+}
+
+#[test]
+fn parse_codegen_flags() {
+    let parsed = parse_rustc_args(
+        &args(&["-C", "opt-level=2", "-C", "debuginfo=2", "src/lib.rs"]),
+        &cwd(),
+    );
+    // Sorted
+    assert!(parsed.codegen_flags.contains(&"debuginfo=2".to_string()));
+    assert!(parsed.codegen_flags.contains(&"opt-level=2".to_string()));
+}
+
+#[test]
+fn parse_codegen_concatenated() {
+    let parsed = parse_rustc_args(&args(&["-Copt-level=3", "src/lib.rs"]), &cwd());
+    assert!(parsed.codegen_flags.contains(&"opt-level=3".to_string()));
+}
+
+#[test]
+fn repeated_codegen_flags_preserve_order_and_effective_last_value() {
+    let first = parse_rustc_args(
+        &args(&["-Copt-level=2", "-C", "opt-level=3", "src/lib.rs"]),
+        &cwd(),
+    );
+    let reversed = parse_rustc_args(
+        &args(&["-Copt-level=3", "-C", "opt-level=2", "src/lib.rs"]),
+        &cwd(),
+    );
+
+    assert_eq!(first.codegen_flags, ["opt-level=2", "opt-level=3"]);
+    assert_eq!(reversed.codegen_flags, ["opt-level=3", "opt-level=2"]);
+    assert_eq!(first.effective_codegen_value("opt-level"), Some("3"));
+    assert_eq!(reversed.effective_codegen_value("opt-level"), Some("2"));
+    assert_ne!(first.codegen_flags, reversed.codegen_flags);
+}
+
+#[test]
+fn additive_codegen_flags_preserve_command_line_order() {
+    let parsed = parse_rustc_args(
+        &args(&[
+            "-Cllvm-args=-first",
+            "-C",
+            "llvm-args=-second",
+            "src/lib.rs",
+        ]),
+        &cwd(),
+    );
+
+    assert_eq!(
+        parsed.codegen_flags,
+        ["llvm-args=-first", "llvm-args=-second"]
+    );
+}
+
+#[test]
+fn shorthand_codegen_flags_keep_precedence_with_explicit_values() {
+    for (alias, key, alias_value) in [("-g", "debuginfo", "2"), ("-O", "opt-level", "2")] {
+        let explicit_last =
+            parse_rustc_args(&args(&[alias, &format!("-C{key}=0"), "src/lib.rs"]), &cwd());
+        let alias_last =
+            parse_rustc_args(&args(&[&format!("-C{key}=0"), alias, "src/lib.rs"]), &cwd());
+
+        assert_eq!(explicit_last.effective_codegen_value(key), Some("0"));
+        assert_eq!(alias_last.effective_codegen_value(key), Some(alias_value));
+        assert_ne!(explicit_last.codegen_flags, alias_last.codegen_flags);
+    }
+}
+
+#[test]
+fn linker_arguments_preserve_command_line_order() {
+    let parsed = parse_rustc_args(
+        &args(&[
+            "-Clink-arg=z-last-lexically",
+            "-Clink-arg=a-first-lexically",
+            "src/lib.rs",
+        ]),
+        &cwd(),
+    );
+
+    assert_eq!(
+        parsed.linker_args,
+        ["link-arg=z-last-lexically", "link-arg=a-first-lexically"]
+    );
+}
+
+#[test]
+fn dylint_linker_inputs_have_dedicated_fields() {
+    let parsed = parse_rustc_args(
+        &args(&[
+            "-Clinker=tools/dylint-link",
+            "-C",
+            "link-arg=-Wl,--build-id=none",
+            "-Clink-args=-Wl,-z,now",
+            "src/lib.rs",
+        ]),
+        &cwd(),
+    );
+    assert_eq!(
+        parsed.linker,
+        Some(NormalizedPath::from("/project/tools/dylint-link"))
+    );
+    assert_eq!(
+        parsed.linker_args,
+        vec![
+            "link-arg=-Wl,--build-id=none".to_string(),
+            "link-args=-Wl,-z,now".to_string()
+        ]
+    );
+}
+
+#[test]
+fn excluded_codegen_not_in_cache_key() {
+    let parsed = parse_rustc_args(
+        &args(&[
+            "-C",
+            "metadata=abc123",
+            "-C",
+            "extra-filename=-abc123",
+            "-C",
+            "incremental=/tmp/incr",
+            "-C",
+            "linker=cc",
+            "src/lib.rs",
+        ]),
+        &cwd(),
+    );
+    // None of these should be in ordinary codegen_flags.
+    assert!(parsed.codegen_flags.is_empty());
+    // But they should be in their dedicated fields.
+    assert_eq!(parsed.cargo_metadata.as_deref(), Some("abc123"));
+    assert_eq!(parsed.extra_filename.as_deref(), Some("-abc123"));
+    assert_eq!(
+        parsed.incremental_dir,
+        Some(NormalizedPath::from("/tmp/incr"))
+    );
+    assert_eq!(parsed.linker, Some(NormalizedPath::from("/project/cc")));
+}
+
+#[test]
+fn parse_extern_crates() {
+    let parsed = parse_rustc_args(
+        &args(&[
+            "--extern",
+            "serde=/target/deps/libserde.rlib",
+            "--extern",
+            "log=/target/deps/liblog.rmeta",
+            "src/lib.rs",
+        ]),
+        &cwd(),
+    );
+    assert_eq!(parsed.externs.len(), 2);
+    assert_eq!(parsed.externs[0].name, "serde");
+    assert_eq!(
+        parsed.externs[0].path,
+        NormalizedPath::from("/target/deps/libserde.rlib")
+    );
+    assert_eq!(parsed.externs[1].name, "log");
+}
+
+#[test]
+fn parse_extern_noprelude() {
+    let parsed = parse_rustc_args(
+        &args(&[
+            "--extern",
+            "noprelude:core=/path/libcore.rlib",
+            "src/lib.rs",
+        ]),
+        &cwd(),
+    );
+    assert_eq!(parsed.externs[0].name, "core");
+}
+
+#[test]
+fn search_paths_excluded_from_cache_key() {
+    let parsed = parse_rustc_args(
+        &args(&[
+            "-L",
+            "dependency=/target/deps",
+            "-L",
+            "native=/usr/lib",
+            "src/lib.rs",
+        ]),
+        &cwd(),
+    );
+    assert_eq!(parsed.search_paths.len(), 2);
+    // search_paths are stored but NOT in codegen_flags/cfgs/unknown_flags
+    assert!(parsed.codegen_flags.is_empty());
+    assert!(parsed.unknown_flags.is_empty());
+}
+
+#[test]
+fn out_dir_excluded_from_cache_key() {
+    let parsed = parse_rustc_args(
+        &args(&["--out-dir", "/target/debug/deps", "src/lib.rs"]),
+        &cwd(),
+    );
+    assert_eq!(
+        parsed.out_dir,
+        Some(NormalizedPath::from("/target/debug/deps"))
+    );
+    assert!(parsed.unknown_flags.is_empty());
+}
+
+#[test]
+fn cosmetic_flags_excluded() {
+    let parsed = parse_rustc_args(
+        &args(&[
+            "--error-format=json",
+            "--json=diagnostic-rendered-ansi",
+            "--color=always",
+            "--diagnostic-width=80",
+            "src/lib.rs",
+        ]),
+        &cwd(),
+    );
+    assert_eq!(parsed.error_format.as_deref(), Some("json"));
+    assert_eq!(
+        parsed.json_format.as_deref(),
+        Some("diagnostic-rendered-ansi")
+    );
+    assert_eq!(parsed.color.as_deref(), Some("always"));
+    assert_eq!(parsed.diagnostic_width.as_deref(), Some("80"));
+    // None of these should be in unknown_flags
+    assert!(parsed.unknown_flags.is_empty());
+}
+
+#[test]
+fn parse_target() {
+    let parsed = parse_rustc_args(
+        &args(&["--target", "x86_64-unknown-linux-gnu", "src/lib.rs"]),
+        &cwd(),
+    );
+    assert_eq!(parsed.target.as_deref(), Some("x86_64-unknown-linux-gnu"));
+}
+
+#[test]
+fn parse_cap_lints() {
+    let parsed = parse_rustc_args(&args(&["--cap-lints", "allow", "src/lib.rs"]), &cwd());
+    assert_eq!(parsed.cap_lints.as_deref(), Some("allow"));
+}
+
+#[test]
+fn parse_lint_flags() {
+    let parsed = parse_rustc_args(
+        &args(&[
+            "-A",
+            "dead_code",
+            "-W",
+            "unused",
+            "-D",
+            "warnings",
+            "src/lib.rs",
+        ]),
+        &cwd(),
+    );
+    assert_eq!(parsed.lint_flags.len(), 3);
+    assert!(parsed.lint_flags.contains(&"-A dead_code".to_string()));
+    assert!(parsed.lint_flags.contains(&"-D warnings".to_string()));
+    assert!(parsed.lint_flags.contains(&"-W unused".to_string()));
+}
+
+#[test]
+fn parse_output_file() {
+    let parsed = parse_rustc_args(&args(&["-o", "libfoo.rlib", "src/lib.rs"]), &cwd());
+    assert_eq!(
+        parsed.output_file,
+        Some(NormalizedPath::from("/project/libfoo.rlib"))
+    );
+}
+
+#[test]
+fn full_cargo_invocation() {
+    let parsed = parse_rustc_args(
+        &args(&[
+            "--edition",
+            "2021",
+            "--crate-type",
+            "lib",
+            "--crate-name",
+            "serde",
+            "--emit=dep-info,metadata,link",
+            "-C",
+            "opt-level=2",
+            "-C",
+            "metadata=abc123def",
+            "-C",
+            "extra-filename=-abc123def",
+            "--out-dir",
+            "/target/release/deps",
+            "-L",
+            "dependency=/target/release/deps",
+            "--extern",
+            "serde_derive=/target/release/deps/libserde_derive-xyz.so",
+            "--cap-lints",
+            "allow",
+            "--cfg",
+            "feature=\"derive\"",
+            "--cfg",
+            "feature=\"std\"",
+            "--error-format=json",
+            "--json=diagnostic-rendered-ansi,artifacts,future-incompat",
+            "--diagnostic-width=211",
+            "-C",
+            "linker=cc",
+            "src/lib.rs",
+        ]),
+        &cwd(),
+    );
+
+    // Cache-key fields populated
+    assert_eq!(parsed.edition.as_deref(), Some("2021"));
+    assert_eq!(parsed.crate_types, vec!["lib"]);
+    assert_eq!(parsed.crate_name.as_deref(), Some("serde"));
+    assert_eq!(parsed.emit_types, vec!["dep-info", "metadata", "link"]);
+    assert!(parsed.codegen_flags.contains(&"opt-level=2".to_string()));
+    assert_eq!(parsed.cap_lints.as_deref(), Some("allow"));
+    assert!(parsed.cfgs.contains(&"feature=\"derive\"".to_string()));
+    assert!(parsed.cfgs.contains(&"feature=\"std\"".to_string()));
+    assert_eq!(parsed.externs.len(), 1);
+    assert_eq!(parsed.externs[0].name, "serde_derive");
+
+    // Excluded fields populated but NOT in cache-key collections
+    assert_eq!(parsed.cargo_metadata.as_deref(), Some("abc123def"));
+    assert_eq!(parsed.extra_filename.as_deref(), Some("-abc123def"));
+    assert_eq!(parsed.error_format.as_deref(), Some("json"));
+    assert!(parsed.search_paths.len() == 1);
+    assert!(parsed.unknown_flags.is_empty());
+}
+
+#[test]
+fn z_flag_with_value_captured() {
+    let parsed = parse_rustc_args(
+        &args(&["-Z", "macro-backtrace", "--crate-type", "lib", "src/lib.rs"]),
+        &cwd(),
+    );
+    // -Z and its value should be combined into one entry
+    assert!(
+        parsed
+            .unknown_flags
+            .contains(&"-Z macro-backtrace".to_string()),
+        "got: {:?}",
+        parsed.unknown_flags
+    );
+}
+
+#[test]
+fn z_flag_different_values_different_keys() {
+    let parsed1 = parse_rustc_args(&args(&["-Z", "query-threads=4", "src/lib.rs"]), &cwd());
+    let parsed2 = parse_rustc_args(&args(&["-Z", "query-threads=8", "src/lib.rs"]), &cwd());
+    assert_ne!(parsed1.unknown_flags, parsed2.unknown_flags);
+}
+
+#[test]
+fn comma_separated_crate_types_split() {
+    let parsed = parse_rustc_args(&args(&["--crate-type", "lib,rlib", "src/lib.rs"]), &cwd());
+    assert_eq!(parsed.crate_types, vec!["lib", "rlib"]);
+}
+
+#[test]
+fn relative_paths_resolved_against_cwd() {
+    let parsed = parse_rustc_args(&args(&["src/lib.rs"]), &cwd());
+    assert_eq!(
+        parsed.source_file,
+        NormalizedPath::from("/project/src/lib.rs")
+    );
+}
+
+#[test]
+fn absolute_paths_unchanged() {
+    let parsed = parse_rustc_args(&args(&["/absolute/src/lib.rs"]), &cwd());
+    assert_eq!(
+        parsed.source_file,
+        NormalizedPath::from("/absolute/src/lib.rs")
+    );
+}
+
+#[test]
+fn check_cfg_parsed() {
+    let parsed = parse_rustc_args(
+        &args(&["--check-cfg", "cfg(feature, values(\"std\"))", "src/lib.rs"]),
+        &cwd(),
+    );
+    assert_eq!(parsed.check_cfgs.len(), 1);
+}
+
+#[test]
+fn sysroot_parsed() {
+    let parsed = parse_rustc_args(
+        &args(&[
+            "--sysroot",
+            "/home/user/.rustup/toolchains/stable",
+            "src/lib.rs",
+        ]),
+        &cwd(),
+    );
+    assert_eq!(
+        parsed.sysroot,
+        Some(NormalizedPath::from("/home/user/.rustup/toolchains/stable"))
+    );
+}
+
+#[test]
+fn remap_path_prefix_parsed() {
+    let parsed = parse_rustc_args(
+        &args(&["--remap-path-prefix", "/home/user=/anon", "src/lib.rs"]),
+        &cwd(),
+    );
+    assert_eq!(parsed.remap_path_prefixes, vec!["/home/user=/anon"]);
+}
+
+#[test]
+fn remap_path_prefix_equals_form_parsed() {
+    let parsed = parse_rustc_args(
+        &args(&["--remap-path-prefix=/home/user=/anon", "src/lib.rs"]),
+        &cwd(),
+    );
+    assert_eq!(parsed.remap_path_prefixes, vec!["/home/user=/anon"]);
+}
+// ─── zackees/soldr#2313: native link-lib flags must key the unit ─────
+
+#[test]
+fn link_lib_value_is_captured_not_dropped() {
+    let parsed = parse_rustc_args(
+        &args(&["--crate-name", "demo", "src/main.rs", "-l", "dylib=c++"]),
+        cwd().as_path(),
+    );
+    assert!(
+        parsed.unknown_flags.contains(&"-l dylib=c++".to_string()),
+        "the library NAME must be key material: {:?}",
+        parsed.unknown_flags
+    );
+    // The value must not leak into positional/source handling: the
+    // source stays main.rs (host path separators vary).
+    assert_eq!(
+        parsed
+            .source_file
+            .as_path()
+            .file_name()
+            .and_then(|n| n.to_str()),
+        Some("main.rs")
+    );
+}
+
+#[test]
+fn fused_link_lib_spelling_is_captured() {
+    let parsed = parse_rustc_args(&args(&["src/main.rs", "-lstatic=sqlite3"]), cwd().as_path());
+    assert!(parsed
+        .unknown_flags
+        .contains(&"-l static=sqlite3".to_string()));
+}
+
+#[test]
+fn changing_the_linked_library_changes_the_context_key() {
+    let base = ["--crate-name", "demo", "--crate-type", "bin", "src/main.rs"];
+    let key = |extra: &[&str]| {
+        let mut all: Vec<&str> = base.to_vec();
+        all.extend_from_slice(extra);
+        let parsed = parse_rustc_args(&args(&all), cwd().as_path());
+        crate::context::RustcCompileContext::from_parsed_args(
+            &parsed,
+            &[],
+            zccache_hash::ContentHash::from_bytes([7u8; 32]),
+        )
+        .context_key()
+    };
+    let none = key(&[]);
+    let cxx = key(&["-l", "dylib=c++"]);
+    let stdcxx = key(&["-l", "dylib=stdc++"]);
+    assert_ne!(none, cxx, "adding a native lib must change the key");
+    assert_ne!(
+            cxx, stdcxx,
+            "changing the native lib NAME must change the key — the              soldr#2313 stale-link-hit bug"
+        );
+}

--- a/crates/zccache/tests/daemon_rustc_cache_basic_test.rs
+++ b/crates/zccache/tests/daemon_rustc_cache_basic_test.rs
@@ -36,6 +36,71 @@ async fn start_daemon() -> (
     (endpoint, handle, shutdown)
 }
 
+/// #1418: packed Linux debug information is part of the linked output set,
+/// not an optional byproduct. A hit must restore it byte-for-byte with the
+/// primary image.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore] // integration-level: starts a real daemon and compiler
+async fn test_packed_linux_dwarf_sidecar_cached() {
+    if !zccache::platform::host::is_linux() {
+        return;
+    }
+    let compiler = match zccache::test_support::find_rustc() {
+        Some(path) => path,
+        None => return,
+    };
+
+    zccache::test_support::test_timeout(async move {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("main.rs");
+        let output = temp.path().join("packed-app");
+        let sidecar = temp.path().join("packed-app.dwp");
+        std::fs::write(&source, "fn main() { println!(\"packed\"); }\n").unwrap();
+
+        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let session_id = start_session(&mut client).await;
+        let compiler = compiler.to_string_lossy().into_owned();
+        let source = source.to_string_lossy().into_owned();
+        let output_arg = output.to_string_lossy().into_owned();
+        let args = [
+            "--edition=2021",
+            "--crate-type=bin",
+            "--crate-name=packed_app",
+            "--emit=link",
+            "-Cdebuginfo=2",
+            "-Csplit-debuginfo=packed",
+            source.as_str(),
+            "-o",
+            output_arg.as_str(),
+        ];
+
+        let (exit_code, cached) =
+            compile(&mut client, &session_id, &compiler, &args, temp.path()).await;
+        assert_eq!(exit_code, 0);
+        assert!(
+            !cached,
+            "first compile must populate the complete output set"
+        );
+        assert!(output.is_file());
+        assert!(sidecar.is_file());
+        let expected_sidecar = std::fs::read(&sidecar).unwrap();
+
+        std::fs::remove_file(&output).unwrap();
+        std::fs::remove_file(&sidecar).unwrap();
+        let (exit_code, cached) =
+            compile(&mut client, &session_id, &compiler, &args, temp.path()).await;
+        assert_eq!(exit_code, 0);
+        assert!(cached, "second compile must use the cached output set");
+        assert!(output.is_file());
+        assert_eq!(std::fs::read(&sidecar).unwrap(), expected_sidecar);
+
+        shutdown.notify_one();
+        server_handle.await.unwrap();
+    })
+    .await;
+}
+
 /// Helper: start session and return session ID.
 async fn start_session(client: &mut ClientConn) -> String {
     client

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -535,3 +535,46 @@ Issue: https://github.com/zackees/zccache/issues/1411
   warnings-denied clippy for every daemon-core target, and whitespace checks.
 - Post-merge GREEN: the focused regression passes against current main.
 - clud-review: clean (one reviewer).
+
+# #1418 cache packed Linux debug sidecars
+
+Issue: https://github.com/zackees/zccache/issues/1418
+
+- [x] Add RED coverage for staged expected outputs and legacy collected files.
+- [x] Model `<primary>.dwp` for explicit Linux targets without affecting other targets.
+- [ ] Prove miss/hit persistence and hosted cache-first release behavior.
+- [x] Run focused tests, formatting, Clippy/checks, and the review gate.
+- [ ] Push, merge, close #1418, and remove the #864 repair once hosted evidence is green.
+
+## Review
+
+- Hosted RED: release dry run 32355952002 restored both shipped Linux binaries
+  without their packed debug sidecars and entered the wrapper-free repair.
+- Local GREEN: three target/output-set regressions pass; the Linux-only real
+  daemon miss/delete/hit test builds on Windows and will execute on hosted
+  Linux. All-target Clippy passes with warnings denied.
+- Review follow-up: packed sidecars now require effective link emission and
+  enabled debug info, and repeated `split-debuginfo` values use command order.
+- clud-review: clean after two finding/fix passes (one reviewer).
+
+# #1419 preserve ordered codegen option semantics
+
+Issue: https://github.com/zackees/zccache/issues/1419
+
+- [x] Add RED parser and context-key coverage for reversed repeated options.
+- [x] Preserve ordered codegen/linker arguments and normalize `-g`/`-O` aliases.
+- [x] Bump the Rust context-key domain to prevent reuse of pre-fix artifacts.
+- [x] Run focused tests, formatting, Clippy/checks, and the review gate.
+- [ ] Push, merge, and close #1419.
+
+## Review
+
+- RED: reversed last-one-wins values sorted to the same parsed representation;
+  the Dylint lane repeated that sort, and linker arguments also lost order.
+- RED: `-g` and `-O` stayed in separately sorted unknown flags, so their order
+  relative to explicit `-C` values was invisible to both keys and DWP modeling.
+- GREEN: ordered parser, effective-value, alias-precedence, linker-order,
+  Dylint-key, and context-key regressions pass; the key domain is now v3.
+- GREEN: all 448 depgraph tests, six focused DWP tests, the ignored daemon
+  integration build, formatting, diff checks, and warnings-denied Clippy pass.
+- clud-review: clean after ordered-key follow-up fixes (one reviewer).


### PR DESCRIPTION
## Summary
- preserve Linux packed split-DWARF `.dwp` artifacts in staged and legacy compiler output collection
- model effective `--emit`, crate type, debuginfo, and repeated `-Csplit-debuginfo` precedence before declaring a DWP output
- preserve command-line order for codegen/linker arguments, normalize `-g` and `-O` in place, and bump the rustc context-key domain to prevent stale cross-version hits
- add cache-key, output-planning, Dylint, and ignored real-daemon regressions

## Validation
- `soldr cargo test -p zccache-depgraph` (448 passed)
- focused daemon-core DWP tests (6 passed)
- focused Dylint cache-key regression (passed)
- ignored daemon integration regression (Windows skip passed; Linux execution delegated to CI)
- warnings-denied targeted all-target Clippy
- `soldr cargo fmt --all -- --check`
- `git diff --check`
- `/clud-review` clean

Closes #1418
Closes #1419