### PR TITLE
fix(cache): separate rustc artifacts from Dylint verdicts

### DIFF
--- a/crates/zccache-artifact/src/lib.rs
+++ b/crates/zccache-artifact/src/lib.rs
@@ -56,7 +56,7 @@ pub use rust_plan::{
 #[cfg(feature = "cli")]
 #[allow(unused_imports)]
 pub use rust_plan::{tar_gz_decode, tar_gz_encode};
-pub use store::{ArtifactIndex, ArtifactStore};
+pub use store::{ArtifactIndex, ArtifactStore, ArtifactVerdict};
 
 use std::path::Path;
 use zccache_core::NormalizedPath;

--- a/crates/zccache-artifact/src/reconcile.rs
+++ b/crates/zccache-artifact/src/reconcile.rs
@@ -181,6 +181,7 @@ fn rebuilt_entry(sizes: Vec<u64>, stored_at: SystemTime) -> ArtifactIndex {
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs(),
+        rustc_verdicts: Default::default(),
     }
 }
 

--- a/crates/zccache-artifact/src/store.rs
+++ b/crates/zccache-artifact/src/store.rs
@@ -25,13 +25,26 @@
 //! on the keys that hadn't been flushed — the daemon repopulates them on
 //! next access. Graceful shutdown flushes synchronously.
 
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use bincode::Options;
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 use zccache_core::NormalizedPath;
+
+/// Compiler result associated with one rustc/Dylint verdict identity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtifactVerdict {
+    /// Captured compiler stdout.
+    pub stdout: Arc<Vec<u8>>,
+    /// Captured compiler stderr.
+    pub stderr: Arc<Vec<u8>>,
+    /// Compiler exit code.
+    pub exit_code: i32,
+}
 
 /// Lightweight metadata stored in the index for each cached artifact.
 ///
@@ -58,6 +71,59 @@ pub struct ArtifactIndex {
     /// Unix epoch seconds when this artifact was stored or last access was
     /// checkpointed for retention. Reused for backward-compatible persistence.
     pub stored_at_secs: u64,
+    /// Rustc result streams keyed independently from shared output bytes.
+    /// [`ArtifactStore::load_from_disk`] migrates pre-verdict snapshots with
+    /// an empty map, which makes those old rows safely miss under the rustc
+    /// context-key domain introduced alongside this field.
+    pub rustc_verdicts: BTreeMap<String, ArtifactVerdict>,
+}
+
+/// Artifact-index row written before verdicts became a second cache layer.
+///
+/// Bincode encodes structs positionally, so `#[serde(default)]` cannot append
+/// a field compatibly. Decode the exact legacy shape and migrate it instead.
+#[derive(Debug, Serialize, Deserialize)]
+struct LegacyArtifactIndex {
+    output_names: Arc<[String]>,
+    output_sizes: Vec<u64>,
+    stdout: Arc<Vec<u8>>,
+    stderr: Arc<Vec<u8>>,
+    exit_code: i32,
+    total_size: u64,
+    stored_at_secs: u64,
+}
+
+impl From<LegacyArtifactIndex> for ArtifactIndex {
+    fn from(legacy: LegacyArtifactIndex) -> Self {
+        Self {
+            output_names: legacy.output_names,
+            output_sizes: legacy.output_sizes,
+            stdout: legacy.stdout,
+            stderr: legacy.stderr,
+            exit_code: legacy.exit_code,
+            total_size: legacy.total_size,
+            stored_at_secs: legacy.stored_at_secs,
+            rustc_verdicts: BTreeMap::new(),
+        }
+    }
+}
+
+fn decode_index_rows(bytes: &[u8]) -> bincode::Result<Vec<(String, ArtifactIndex)>> {
+    match bincode::deserialize(bytes) {
+        Ok(rows) => Ok(rows),
+        Err(current_error) => {
+            let legacy_options = bincode::DefaultOptions::new()
+                .with_fixint_encoding()
+                .reject_trailing_bytes();
+            match legacy_options.deserialize::<Vec<(String, LegacyArtifactIndex)>>(bytes) {
+                Ok(rows) => Ok(rows
+                    .into_iter()
+                    .map(|(key, meta)| (key, meta.into()))
+                    .collect()),
+                Err(_) => Err(current_error),
+            }
+        }
+    }
 }
 
 impl ArtifactIndex {
@@ -82,6 +148,7 @@ impl ArtifactIndex {
             exit_code,
             total_size,
             stored_at_secs,
+            rustc_verdicts: BTreeMap::new(),
         }
     }
 }
@@ -182,11 +249,14 @@ impl ArtifactStore {
     pub fn load_from_disk(&self) -> std::io::Result<()> {
         let path = self.path.as_path();
         match std::fs::read(path) {
-            Ok(bytes) => match bincode::deserialize::<Vec<(String, ArtifactIndex)>>(&bytes) {
+            Ok(bytes) => match decode_index_rows(&bytes) {
                 Ok(rows) => {
                     let count = rows.len();
                     for (k, v) in rows {
-                        self.entries.insert(k, v);
+                        // Deferred loading can race request-time publication.
+                        // Disk state fills holes but must not replace a row
+                        // already advanced by the running process.
+                        self.entries.entry(k).or_insert(v);
                     }
                     if count > 0 {
                         tracing::info!(
@@ -432,6 +502,76 @@ mod tests {
         let (_dir, store) = temp_store();
         assert_eq!(store.len(), 0);
         assert!(store.is_empty());
+    }
+
+    #[test]
+    fn legacy_index_snapshot_defaults_to_no_rustc_verdicts() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("index.bin");
+        let legacy = LegacyArtifactIndex {
+            output_names: Arc::from(vec!["foo.o".to_string()]),
+            output_sizes: vec![4],
+            stdout: Arc::new(Vec::new()),
+            stderr: Arc::new(Vec::new()),
+            exit_code: 0,
+            total_size: 4,
+            stored_at_secs: 42,
+        };
+        std::fs::write(
+            &path,
+            bincode::serialize(&vec![("legacy".to_string(), legacy)]).unwrap(),
+        )
+        .unwrap();
+
+        let store = ArtifactStore::open(&path).unwrap();
+        let loaded = store.get("legacy").expect("legacy index row should decode");
+        assert!(loaded.rustc_verdicts.is_empty());
+        assert_eq!(loaded.total_size, 4);
+    }
+
+    #[test]
+    fn rustc_verdicts_survive_index_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("index.bin");
+        let store = ArtifactStore::open(&path).unwrap();
+        let mut meta = sample_meta();
+        meta.rustc_verdicts.insert(
+            "dylint-hash".to_string(),
+            ArtifactVerdict {
+                stdout: Arc::new(b"verdict stdout".to_vec()),
+                stderr: Arc::new(b"lint diagnostic".to_vec()),
+                exit_code: 1,
+            },
+        );
+        store.insert("artifact", &meta);
+        store.flush().unwrap();
+        drop(store);
+
+        let reopened = ArtifactStore::open(&path).unwrap();
+        let verdict = &reopened
+            .get("artifact")
+            .expect("artifact should survive")
+            .rustc_verdicts["dylint-hash"];
+        assert_eq!(verdict.stdout.as_slice(), b"verdict stdout");
+        assert_eq!(verdict.stderr.as_slice(), b"lint diagnostic");
+        assert_eq!(verdict.exit_code, 1);
+    }
+
+    #[test]
+    fn corrupted_current_snapshot_is_not_accepted_as_legacy() {
+        let mut meta = sample_meta();
+        meta.rustc_verdicts.insert(
+            "dylint-hash".to_string(),
+            ArtifactVerdict {
+                stdout: Arc::new(Vec::new()),
+                stderr: Arc::new(b"lint diagnostic".to_vec()),
+                exit_code: 1,
+            },
+        );
+        let mut bytes = bincode::serialize(&vec![("artifact".to_string(), meta)]).unwrap();
+        bytes.pop();
+
+        assert!(decode_index_rows(&bytes).is_err());
     }
 
     #[test]

--- a/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
@@ -165,6 +165,7 @@ impl CachedArtifact {
     }
 
     /// Create from index metadata and already-created payload files.
+    #[cfg(test)]
     pub(super) fn from_file_payloads(meta: ArtifactIndex, payloads: Vec<NormalizedPath>) -> Self {
         Self::with_payloads(
             meta,
@@ -227,9 +228,10 @@ impl CachedArtifact {
         }
     }
 
-    /// Record one hit and return updated index metadata when its durable
-    /// checkpoint is due.
-    pub(crate) fn record_access(&self, now: std::time::Instant) -> Option<ArtifactIndex> {
+    /// Record one hit and return its wall-clock timestamp when a durable
+    /// checkpoint is due. The index writer applies only this timestamp to its
+    /// newest row so a stale hit clone cannot overwrite newer metadata.
+    pub(crate) fn record_access(&self, now: std::time::Instant) -> Option<u64> {
         const PERSIST_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
         let mut access = self.access();
@@ -246,12 +248,12 @@ impl CachedArtifact {
         access.last_used_wall = wall_now;
         drop(access);
 
-        let mut meta = self.meta.clone();
-        meta.stored_at_secs = wall_now
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        Some(meta)
+        Some(
+            wall_now
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        )
     }
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/embedded.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/embedded.rs
@@ -129,7 +129,8 @@ impl EmbeddedDaemon {
             for (key, meta) in entries {
                 state
                     .artifacts
-                    .insert(key, CachedArtifact::from_index(meta));
+                    .entry(key)
+                    .or_insert_with(|| CachedArtifact::from_index(meta));
             }
             state.artifacts_loaded.store(true, Ordering::Release);
             state.artifact_store_loaded.store(true, Ordering::Release);

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile.rs
@@ -11,6 +11,7 @@ mod miss_profile;
 mod miss_store;
 mod pipeline;
 mod request;
+mod rustc_index;
 
 use super::*;
 use request::CompileRequest;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/README.md
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/README.md
@@ -13,5 +13,6 @@ Split-out modules from the original `handle_compile.rs`. The compile pipeline is
 | `error_cache.rs` | Caching + materialization of cached compiler errors |
 | `miss_profile.rs` | Opt-in detailed per-phase profile of a miss (gated by `ZCCACHE_PROFILE_RUST_MISS`) |
 | `miss_store.rs` | Post-exec artifact store path |
+| `rustc_index.rs` | Merge rules for shared rustc output metadata and verdict rows |
 
 Tests live in `cached_hit.rs::tests` (mtime preservation, materialization shape) and in `pipeline.rs::tests` (phase wiring).

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
@@ -30,6 +30,9 @@ pub(super) struct CachedHitMaterializeRequest<'a> {
     pub(super) state: &'a SharedState,
     pub(super) sid: &'a SessionId,
     pub(super) artifact_key_hex: &'a str,
+    /// Rustc diagnostics/exit-status entry paired with the output artifact.
+    /// `None` keeps the legacy single-layer path for non-rust compilers.
+    pub(super) verdict_key_hex: Option<&'a str>,
     pub(super) source_path: &'a NormalizedPath,
     pub(super) output_path: &'a NormalizedPath,
     pub(super) secondary_output_dir: NormalizedPath,
@@ -59,6 +62,10 @@ pub(super) struct CachedHitMaterializeRequest<'a> {
 
 #[derive(Debug)]
 pub(super) enum CachedHitFailure {
+    /// The shared rustc output exists, but this plain/Dylint identity has not
+    /// produced diagnostics and an exit status yet. This is a soft miss and
+    /// is not evidence that the artifact payload disappeared.
+    VerdictMissing,
     CacheBlobMissing(CacheBlobMissing),
     CacheRead,
     DestinationWrite,
@@ -81,6 +88,7 @@ pub(super) fn materialize_cached_compile_hit(
         state,
         sid,
         artifact_key_hex,
+        verdict_key_hex,
         source_path,
         output_path,
         secondary_output_dir,
@@ -104,19 +112,90 @@ pub(super) fn materialize_cached_compile_hit(
     // reuses `t0` for the maintenance-visible `last_used` write without an
     // additional clock read (issue #1148).
     let t0 = Instant::now();
-    let missing_artifact = || {
+    let missing_entry = |key: &str| {
         let failure = cache_blob_missing(
-            &state.artifact_dir.join(artifact_key_hex),
+            &state.artifact_dir.join(key),
             std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 "cached artifact metadata or payload is unavailable",
             ),
         );
-        report_materialization_failure(&state.cache_dir, artifact_key_hex, "compile-hit", &failure);
+        report_materialization_failure(&state.cache_dir, key, "compile-hit", &failure);
         failure.into()
     };
     let cached = lookup_artifact_with_disk_fallback(state, artifact_key_hex)
-        .ok_or_else(&missing_artifact)?;
+        .ok_or_else(|| missing_entry(artifact_key_hex))?;
+    let verdict = verdict_key_hex
+        .map(|key| {
+            cached
+                .meta
+                .rustc_verdicts
+                .get(key)
+                .cloned()
+                .ok_or(CachedHitFailure::VerdictMissing)
+        })
+        .transpose()?;
+    let (exit_code, mut stdout, mut stderr) = verdict.as_ref().map_or_else(
+        || {
+            (
+                cached.meta.exit_code,
+                cached.stdout.clone(),
+                cached.stderr.clone(),
+            )
+        },
+        |verdict| {
+            (
+                verdict.exit_code,
+                verdict.stdout.clone(),
+                verdict.stderr.clone(),
+            )
+        },
+    );
+    if exit_code != 0 {
+        if let Some(requested_outputs) = rustc_metadata_compat_outputs.as_deref() {
+            stdout = Arc::new(rehydrate_staged_output_bytes(
+                stdout.as_slice(),
+                requested_outputs,
+            ));
+            stderr = Arc::new(rehydrate_staged_output_bytes(
+                stderr.as_slice(),
+                requested_outputs,
+            ));
+        }
+        // A verdict is diagnostics and status, not an authorization to write
+        // shared output bytes. In particular, a Dylint error may share an
+        // artifact key with a successful plain-rustc compile whose outputs
+        // must remain absent from this failed invocation.
+        record_artifact_access(state, artifact_key_hex, &cached, t0);
+        let t1 = Instant::now();
+        let artifact_lookup_ns = (t1 - t0).as_nanos() as u64;
+        crate::daemon::server::inner_trace::record_ns("cache_load", artifact_lookup_ns);
+        drop(cached);
+
+        if record_compilation {
+            state.stats.record_compilation();
+        }
+        state.stats.record_cached_error();
+        record_session_stat(&state.sessions, sid, |t| {
+            t.record_cached_error();
+        });
+        write_session_log(
+            &state.sessions,
+            sid,
+            &format!(
+                "[{}] {} -> {}",
+                cached_error_label,
+                source_path.display(),
+                output_path.display()
+            ),
+        );
+        return Ok(Response::CompileResult {
+            exit_code,
+            stdout,
+            stderr,
+            cached: true,
+        });
+    }
     let payloads = ensure_payloads_for_materialization_for_state(state, &cached, artifact_key_hex)
         .map_err(|error| {
             report_materialization_failure(
@@ -138,9 +217,6 @@ pub(super) fn materialize_cached_compile_hit(
     crate::daemon::server::inner_trace::record_ns("cache_load", artifact_lookup_ns);
 
     let names = Arc::clone(&cached.meta.output_names);
-    let exit_code = cached.meta.exit_code;
-    let mut stdout = cached.stdout.clone();
-    let mut stderr = cached.stderr.clone();
     let artifact_bytes = cached.meta.total_size;
     drop(cached);
 
@@ -169,7 +245,7 @@ pub(super) fn materialize_cached_compile_hit(
                             requested.display()
                         ),
                     );
-                    return Err(missing_artifact());
+                    return Err(missing_entry(artifact_key_hex));
                 };
                 targets.push(requested);
                 selected_payloads.push(payloads[i].clone());
@@ -307,8 +383,7 @@ pub(super) fn materialize_cached_compile_hit(
             .timing(StagedTiming::HitMaterialization, write_output_ns);
     }
 
-    let cached_error = exit_code != 0;
-    if !cached_error && downgrade_output_metadata {
+    if downgrade_output_metadata {
         state.cache_system.metadata().downgrade(output_path);
     }
 
@@ -319,28 +394,17 @@ pub(super) fn materialize_cached_compile_hit(
     // (record_hit / record_session_stat / write_session_log). Same boundary
     // as before — derived from `t2` instead of a fresh clock read.
     let latency_ns = (t2 - compile_start).as_nanos() as u64;
-    if cached_error {
-        state.stats.record_cached_error();
-        record_session_stat(&state.sessions, sid, |t| {
-            t.record_cached_error();
-        });
-    } else {
-        state.stats.record_hit(latency_ns, artifact_bytes);
-        let src = source_path.clone();
-        record_session_stat(&state.sessions, sid, move |t| {
-            t.record_hit(src, latency_ns, artifact_bytes);
-        });
-    }
+    state.stats.record_hit(latency_ns, artifact_bytes);
+    let src = source_path.clone();
+    record_session_stat(&state.sessions, sid, move |t| {
+        t.record_hit(src, latency_ns, artifact_bytes);
+    });
     write_session_log(
         &state.sessions,
         sid,
         &format!(
             "[{}] {} -> {}",
-            if cached_error {
-                cached_error_label
-            } else {
-                hit_label
-            },
+            hit_label,
             source_path.display(),
             output_path.display()
         ),
@@ -349,21 +413,19 @@ pub(super) fn materialize_cached_compile_hit(
     let bookkeeping_ns = (t3 - t2).as_nanos() as u64;
 
     let total_ns = (t3 - compile_start).as_nanos() as u64;
-    if !cached_error {
-        state.profiler.record_hit(&HitPhases {
-            parse_args_ns: phases.parse_args_ns,
-            build_context_ns: phases.build_context_ns,
-            hash_source_ns: phases.hash_source_ns,
-            hash_headers_ns: phases.hash_headers_ns,
-            depgraph_check_ns: phases.depgraph_check_ns,
-            request_cache_lookup_ns: phases.request_cache_lookup_ns,
-            cross_root_validate_ns: phases.cross_root_validate_ns,
-            artifact_lookup_ns,
-            write_output_ns,
-            bookkeeping_ns,
-            total_ns,
-        });
-    }
+    state.profiler.record_hit(&HitPhases {
+        parse_args_ns: phases.parse_args_ns,
+        build_context_ns: phases.build_context_ns,
+        hash_source_ns: phases.hash_source_ns,
+        hash_headers_ns: phases.hash_headers_ns,
+        depgraph_check_ns: phases.depgraph_check_ns,
+        request_cache_lookup_ns: phases.request_cache_lookup_ns,
+        cross_root_validate_ns: phases.cross_root_validate_ns,
+        artifact_lookup_ns,
+        write_output_ns,
+        bookkeeping_ns,
+        total_ns,
+    });
 
     Ok(Response::CompileResult {
         exit_code,
@@ -404,6 +466,129 @@ mod tests {
 
     fn file_time(path: &Path) -> filetime::FileTime {
         filetime::FileTime::from_last_modification_time(&std::fs::metadata(path).unwrap())
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rustc_hit_requires_matching_verdict_and_replays_its_streams() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = crate::daemon::server::tests::bind_isolated_server(dir.path());
+        let state = server.state.as_ref();
+        let source_path: NormalizedPath = dir.path().join("source.rs").into();
+        let output_path: NormalizedPath = dir.path().join("output.rlib").into();
+        let cache_path = state.artifact_dir.join("artifact-key_0");
+        std::fs::write(&cache_path, b"artifact bytes").unwrap();
+        write_authoritative_blob_digest(&cache_path).unwrap();
+        let sid = state.sessions.create(crate::depgraph::SessionConfig {
+            client_pid: std::process::id(),
+            working_dir: dir.path().into(),
+            log_file: None,
+            track_stats: true,
+            journal_path: None,
+            profile: false,
+            private_env: Vec::new(),
+            owner_pids: Vec::new(),
+        });
+        let mut artifact_meta = ArtifactIndex::new(
+            vec!["output.rlib".to_string()],
+            vec![14],
+            Arc::new(Vec::new()),
+            Arc::new(Vec::new()),
+            0,
+        );
+        state.artifacts.insert(
+            "artifact-key".to_string(),
+            CachedArtifact::from_file_payloads(artifact_meta.clone(), vec![cache_path.clone()]),
+        );
+
+        let materialize = || {
+            materialize_cached_compile_hit(CachedHitMaterializeRequest {
+                state,
+                sid: &sid,
+                artifact_key_hex: "artifact-key",
+                verdict_key_hex: Some("verdict-key"),
+                source_path: &source_path,
+                output_path: &output_path,
+                secondary_output_dir: dir.path().into(),
+                current_depfile_dest: None,
+                compile_start: Instant::now(),
+                hit_label: "HIT_TEST",
+                cached_error_label: "CACHED_ERROR_TEST",
+                record_compilation: false,
+                downgrade_output_metadata: false,
+                mtime_floor_paths: Vec::new(),
+                rustc_metadata_compat_outputs: Some(vec![output_path.clone()]),
+                rustc_archive_hardlink_eligible: Some(true),
+                phases: CachedHitPhases::request_cache(0, 0),
+            })
+        };
+
+        assert!(matches!(
+            materialize(),
+            Err(CachedHitFailure::VerdictMissing)
+        ));
+        assert!(
+            !output_path.is_file(),
+            "missing verdict must gate artifact replay"
+        );
+
+        let requested_stdout = format!("error stdout: {}", output_path.display()).into_bytes();
+        let requested_stderr = format!("lint error: {}", output_path.display()).into_bytes();
+        let canonical_stdout = canonicalize_staged_output_bytes(&requested_stdout, dir.path());
+        let canonical_stderr = canonicalize_staged_output_bytes(&requested_stderr, dir.path());
+        assert!(contains_staged_output_marker(&canonical_stdout));
+        assert!(contains_staged_output_marker(&canonical_stderr));
+        artifact_meta.rustc_verdicts.insert(
+            "verdict-key".to_string(),
+            ArtifactVerdict {
+                stdout: Arc::new(canonical_stdout),
+                stderr: Arc::new(canonical_stderr),
+                exit_code: 1,
+            },
+        );
+        state.artifacts.insert(
+            "artifact-key".to_string(),
+            CachedArtifact::from_file_payloads(artifact_meta.clone(), vec![cache_path.clone()]),
+        );
+        let response = materialize().unwrap();
+        assert!(matches!(
+            response,
+            Response::CompileResult {
+                exit_code: 1,
+                cached: true,
+                ref stdout,
+                ref stderr,
+            } if stdout.as_slice() == requested_stdout
+                && stderr.as_slice() == requested_stderr
+        ));
+        assert!(
+            !output_path.is_file(),
+            "an error verdict must never materialize shared success outputs"
+        );
+
+        artifact_meta.rustc_verdicts.insert(
+            "verdict-key".to_string(),
+            ArtifactVerdict {
+                stdout: Arc::new(b"verdict stdout".to_vec()),
+                stderr: Arc::new(b"lint diagnostic".to_vec()),
+                exit_code: 0,
+            },
+        );
+        state.artifacts.insert(
+            "artifact-key".to_string(),
+            CachedArtifact::from_file_payloads(artifact_meta, vec![cache_path]),
+        );
+        let response = materialize().unwrap();
+        assert!(matches!(
+            response,
+            Response::CompileResult {
+                exit_code: 0,
+                cached: true,
+                ref stdout,
+                ref stderr,
+            } if stdout.as_slice() == b"verdict stdout"
+                && stderr.as_slice() == b"lint diagnostic"
+        ));
+        assert_eq!(std::fs::read(output_path).unwrap(), b"artifact bytes");
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -449,6 +634,7 @@ mod tests {
             state,
             sid: &sid,
             artifact_key_hex: "artifact-key",
+            verdict_key_hex: None,
             source_path: &source_path,
             output_path: &output_path,
             secondary_output_dir: dir.path().into(),
@@ -564,6 +750,7 @@ mod tests {
             state,
             sid: &sid,
             artifact_key_hex: "depfile-key",
+            verdict_key_hex: None,
             source_path: &source_path,
             output_path: &output_path,
             secondary_output_dir: dir.path().into(),
@@ -664,6 +851,7 @@ mod tests {
             state,
             sid: &sid,
             artifact_key_hex: "legacy-key",
+            verdict_key_hex: None,
             source_path: &source_path,
             output_path: &output_path,
             secondary_output_dir: dir.path().into(),
@@ -748,6 +936,7 @@ mod tests {
                     state,
                     sid: &sid,
                     artifact_key_hex: "budget-key",
+                    verdict_key_hex: None,
                     source_path: &source_path,
                     output_path: &output_path,
                     secondary_output_dir: dir.path().into(),

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/error_cache.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/error_cache.rs
@@ -43,6 +43,40 @@ fn should_cache_rustc_error(
         && !rustc_args.emit_types.iter().any(|emit| emit == "link")
 }
 
+fn commit_rustc_verdict(
+    state: &SharedState,
+    artifact_key_hex: &str,
+    verdict_key_hex: String,
+    verdict: ArtifactVerdict,
+) {
+    use dashmap::mapref::entry::Entry;
+    let durable = super::rustc_index::durable_rustc_index(state, artifact_key_hex);
+    let mut incoming = ArtifactIndex::new(
+        Vec::new(),
+        Vec::new(),
+        Arc::new(Vec::new()),
+        Arc::new(Vec::new()),
+        0,
+    );
+    incoming.rustc_verdicts.insert(verdict_key_hex, verdict);
+    if let Some(durable) = durable {
+        incoming = super::rustc_index::merge_rustc_index(incoming, durable);
+    }
+
+    match state.artifacts.entry(artifact_key_hex.to_string()) {
+        Entry::Occupied(mut entry) => {
+            let artifact_meta =
+                super::rustc_index::merge_rustc_index(incoming, entry.get().meta.clone());
+            enqueue_index_insert(state, artifact_key_hex.to_string(), artifact_meta.clone());
+            entry.insert(CachedArtifact::from_index(artifact_meta));
+        }
+        Entry::Vacant(entry) => {
+            enqueue_index_insert(state, artifact_key_hex.to_string(), incoming.clone());
+            entry.insert(CachedArtifact::from_index(incoming));
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)] // Localized error-cache insertion path.
 pub(super) async fn maybe_store_rustc_error_artifact(
     state: &SharedState,
@@ -51,6 +85,7 @@ pub(super) async fn maybe_store_rustc_error_artifact(
     cwd_path: &NormalizedPath,
     ctx: &CompileContext,
     rustc_args: &crate::depgraph::RustcParsedArgs,
+    dylint_input_hash: Option<&str>,
     stdout: &Arc<Vec<u8>>,
     stderr: &Arc<Vec<u8>>,
     exit_code: i32,
@@ -60,8 +95,9 @@ pub(super) async fn maybe_store_rustc_error_artifact(
         return None;
     }
 
-    // Error artifacts publish synchronously, but still participate in the
-    // same Clear/GC/flush ordering contract as successful artifacts.
+    // Error artifacts participate in the same Clear/GC barrier and ordered
+    // index-writer WAL as successful artifacts. Sharing one writer prevents
+    // an older queued success row from overwriting a newer error verdict.
     let _publication_guard = begin_artifact_publication(state).await?;
 
     // Error-cache path ignores env-dep names: failed compiles are keyed
@@ -90,24 +126,123 @@ pub(super) async fn maybe_store_rustc_error_artifact(
         .load()
         .update(context_key, scan_result, get_hash)?;
     let artifact_key_hex = artifact_key.hash().to_hex();
-    let meta = ArtifactIndex::new(
-        Vec::new(),
-        Vec::new(),
-        Arc::clone(stdout),
-        Arc::clone(stderr),
+    let verdict_key_hex =
+        crate::depgraph::compute_rustc_verdict_key(&artifact_key_hex, dylint_input_hash)
+            .hash()
+            .to_hex();
+    let verdict = ArtifactVerdict {
+        stdout: Arc::clone(stdout),
+        stderr: Arc::clone(stderr),
         exit_code,
-    );
-    state.artifact_store.insert(&artifact_key_hex, &meta);
-    state.artifacts.insert(
-        artifact_key_hex.clone(),
-        CachedArtifact::from_file_payloads(meta, Vec::new()),
-    );
+    };
+    commit_rustc_verdict(state, &artifact_key_hex, verdict_key_hex, verdict);
     Some(artifact_key_hex)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn cold_error_verdict_merges_durable_outputs_and_sibling_verdicts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut server = crate::daemon::server::tests::bind_isolated_server(tmp.path());
+        let mut durable = ArtifactIndex::new(
+            vec!["shared.rmeta".to_string()],
+            vec![17],
+            Arc::new(Vec::new()),
+            Arc::new(Vec::new()),
+            0,
+        );
+        durable.rustc_verdicts.insert(
+            "plain".to_string(),
+            ArtifactVerdict {
+                stdout: Arc::new(Vec::new()),
+                stderr: Arc::new(Vec::new()),
+                exit_code: 0,
+            },
+        );
+        server.state.artifact_store.insert("artifact", &durable);
+        assert!(!server.state.artifacts.contains_key("artifact"));
+
+        commit_rustc_verdict(
+            &server.state,
+            "artifact",
+            "dylint".to_string(),
+            ArtifactVerdict {
+                stdout: Arc::new(Vec::new()),
+                stderr: Arc::new(b"lint error".to_vec()),
+                exit_code: 1,
+            },
+        );
+
+        let cached = server.state.artifacts.get("artifact").unwrap();
+        assert_eq!(cached.meta.output_names.as_ref(), &["shared.rmeta"]);
+        assert_eq!(cached.meta.rustc_verdicts.len(), 2);
+        drop(cached);
+        let command = server.index_writer_rx.as_mut().unwrap().try_recv().unwrap();
+        let IndexWriterCommand::Insert(key, merged) = command else {
+            panic!("cold verdict publication must use the ordered index writer");
+        };
+        assert_eq!(key, "artifact");
+        assert_eq!(merged.output_names.as_ref(), &["shared.rmeta"]);
+        assert_eq!(merged.rustc_verdicts.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn error_verdict_preserves_existing_shared_artifact_metadata() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut server = crate::daemon::server::tests::bind_isolated_server(tmp.path());
+        let mut meta = ArtifactIndex::new(
+            vec!["shared.rmeta".to_string()],
+            vec![17],
+            Arc::new(Vec::new()),
+            Arc::new(Vec::new()),
+            0,
+        );
+        meta.rustc_verdicts.insert(
+            "plain".to_string(),
+            ArtifactVerdict {
+                stdout: Arc::new(Vec::new()),
+                stderr: Arc::new(Vec::new()),
+                exit_code: 0,
+            },
+        );
+        enqueue_index_insert(&server.state, "artifact".to_string(), meta.clone());
+        server
+            .state
+            .artifacts
+            .insert("artifact".to_string(), CachedArtifact::from_index(meta));
+
+        commit_rustc_verdict(
+            &server.state,
+            "artifact",
+            "dylint".to_string(),
+            ArtifactVerdict {
+                stdout: Arc::new(Vec::new()),
+                stderr: Arc::new(b"lint error".to_vec()),
+                exit_code: 1,
+            },
+        );
+
+        let cached = server.state.artifacts.get("artifact").unwrap();
+        assert_eq!(cached.meta.output_names.as_ref(), &["shared.rmeta"]);
+        assert_eq!(cached.meta.output_sizes, vec![17]);
+        assert_eq!(cached.meta.rustc_verdicts.len(), 2);
+        drop(cached);
+        let first = server.index_writer_rx.as_mut().unwrap().try_recv().unwrap();
+        let IndexWriterCommand::Insert(_, first) = first else {
+            panic!("successful artifact publication must precede the verdict");
+        };
+        assert_eq!(first.rustc_verdicts.len(), 1);
+        let second = server.index_writer_rx.as_mut().unwrap().try_recv().unwrap();
+        let IndexWriterCommand::Insert(key, durable) = second else {
+            panic!("verdict publication must use the ordered index writer");
+        };
+        assert_eq!(key, "artifact");
+        assert_eq!(durable.output_names.as_ref(), &["shared.rmeta"]);
+        assert_eq!(durable.rustc_verdicts.len(), 2);
+    }
 
     #[tokio::test]
     async fn rustc_error_publication_waits_for_clear_barrier() {
@@ -154,6 +289,7 @@ mod tests {
                 &NormalizedPath::new(tmp.path()),
                 &ctx,
                 &rustc_args,
+                None,
                 &stdout,
                 &stderr,
                 1,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
@@ -7,6 +7,25 @@ use super::cached_hit::{
 use crate::depgraph::depfile::user_depfile_destination;
 use crate::depgraph::UserDepFlags;
 
+const DYLINT_CACHE_INPUT_HASH_ENV: &str = "ZCCACHE_DYLINT_CACHE_INPUT_HASH";
+
+fn rustc_verdict_key_hex(
+    is_rustc: bool,
+    artifact_key_hex: &str,
+    client_env: Option<&[(String, String)]>,
+) -> Option<String> {
+    is_rustc.then(|| {
+        let dylint_hash = client_env.and_then(|env| {
+            env.iter()
+                .find_map(|(name, value)| (name == DYLINT_CACHE_INPUT_HASH_ENV).then_some(value))
+                .map(String::as_str)
+        });
+        crate::depgraph::compute_rustc_verdict_key(artifact_key_hex, dylint_hash)
+            .hash()
+            .to_hex()
+    })
+}
+
 pub(super) struct RequestCacheHitProbe<'a> {
     pub(super) state: &'a SharedState,
     pub(super) sid: &'a SessionId,
@@ -130,10 +149,12 @@ pub(super) async fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Op
         rustc_requested_outputs(rustc_args, &output_path, cwd, client_env);
     let rustc_archive_hardlink_eligible =
         is_rustc.then(|| crate::compiler::rustc_archive_hardlink_eligible(rustc_args));
+    let verdict_key_hex = rustc_verdict_key_hex(is_rustc, artifact_key_hex, client_env);
     materialize_cached_compile_hit(CachedHitMaterializeRequest {
         state,
         sid,
         artifact_key_hex,
+        verdict_key_hex: verdict_key_hex.as_deref(),
         source_path: &source_path,
         output_path: &output_path,
         secondary_output_dir: output_path.parent().unwrap_or(cwd).into(),
@@ -259,10 +280,12 @@ pub(super) async fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
     } else {
         None
     };
+    let verdict_key_hex = rustc_verdict_key_hex(is_rustc, &entry_artifact_key_hex, client_env);
     let response = materialize_cached_compile_hit(CachedHitMaterializeRequest {
         state,
         sid,
         artifact_key_hex: &entry_artifact_key_hex,
+        verdict_key_hex: verdict_key_hex.as_deref(),
         source_path,
         output_path,
         secondary_output_dir,
@@ -399,10 +422,13 @@ pub(super) async fn try_depgraph_cached_hit(
     // and unnecessarily recompile. The fast-hit path has the same guard.
     pending_writes::await_pending_payload(&state.pending_cache_writes, artifact_key_hex).await;
 
+    let verdict_key_hex = rustc_verdict_key_hex(is_rustc, artifact_key_hex, client_env);
+
     let response = materialize_cached_compile_hit(CachedHitMaterializeRequest {
         state,
         sid,
         artifact_key_hex,
+        verdict_key_hex: verdict_key_hex.as_deref(),
         source_path,
         output_path,
         secondary_output_dir,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
@@ -29,6 +29,9 @@ pub(super) struct MissArtifactStoreRequest<'a> {
     /// has durably consumed them.
     pub(super) staged_persist_plan: Option<StagedCompilePlan>,
     pub(super) rustc_all_outputs: Option<&'a [RustcOutputFile]>,
+    /// Dylint input identity for the rustc verdict layer. `None` selects the
+    /// plain-rustc verdict while non-rust compilers never call the rust path.
+    pub(super) rustc_dylint_input_hash: Option<&'a str>,
     pub(super) stdout: &'a Arc<Vec<u8>>,
     pub(super) stderr: &'a Arc<Vec<u8>>,
     pub(super) exit_code: i32,
@@ -73,6 +76,7 @@ pub(super) fn store_miss_artifact(request: MissArtifactStoreRequest<'_>) -> Miss
         user_depfile_persist_temp,
         staged_persist_plan,
         rustc_all_outputs,
+        rustc_dylint_input_hash,
         stdout,
         stderr,
         exit_code,
@@ -132,6 +136,7 @@ pub(super) fn store_miss_artifact(request: MissArtifactStoreRequest<'_>) -> Miss
                 source_path,
                 all_outputs,
                 &artifact_key_hex,
+                rustc_dylint_input_hash,
                 stdout,
                 stderr,
                 exit_code,
@@ -302,6 +307,7 @@ fn store_rustc_outputs(
     source_path: &NormalizedPath,
     all_outputs: &[RustcOutputFile],
     artifact_key_hex: &str,
+    dylint_input_hash: Option<&str>,
     stdout: &Arc<Vec<u8>>,
     stderr: &Arc<Vec<u8>>,
     exit_code: i32,
@@ -339,12 +345,24 @@ fn store_rustc_outputs(
     // publishing the in-memory artifact so depgraph hits never point at a
     // key whose payload files have not landed yet.
     let t_artifact_index_build = Instant::now();
-    let meta = ArtifactIndex::new(
+    let mut meta = ArtifactIndex::new(
         output_names,
         output_sizes,
-        Arc::clone(stdout),
-        Arc::clone(stderr),
-        exit_code,
+        Arc::new(Vec::new()),
+        Arc::new(Vec::new()),
+        0,
+    );
+    let verdict_key_hex =
+        crate::depgraph::compute_rustc_verdict_key(artifact_key_hex, dylint_input_hash)
+            .hash()
+            .to_hex();
+    meta.rustc_verdicts.insert(
+        verdict_key_hex,
+        ArtifactVerdict {
+            stdout: Arc::clone(stdout),
+            stderr: Arc::clone(stderr),
+            exit_code,
+        },
     );
     stats.artifact_index_build_ns = t_artifact_index_build.elapsed().as_nanos() as u64;
     stats.artifact_build_ns = t_artifact_build.elapsed().as_nanos() as u64;
@@ -373,29 +391,23 @@ fn store_rustc_outputs(
                 let _staged_plan = staged_plan;
                 let snapshot =
                     persist_artifact_paths_with_stats(&artifact_dir, &key_hex, &source_paths)?;
-                if snapshot.staged {
-                    send_staged_index_insert(
-                        state_for_publish.as_ref(),
-                        key_hex.clone(),
-                        meta.clone(),
-                    )
-                    .map_err(|reason| {
-                        std::io::Error::other(format!(
-                            "staged artifact index commit failed: {}",
-                            reason.id()
-                        ))
-                    })?;
-                } else {
-                    enqueue_index_insert(state_for_publish.as_ref(), key_hex, meta.clone());
-                }
-                Ok::<_, std::io::Error>((snapshot, meta))
+                commit_rustc_artifact_index(
+                    state_for_publish.as_ref(),
+                    key_hex,
+                    meta,
+                    snapshot.staged,
+                )
+                .map_err(|reason| {
+                    std::io::Error::other(format!(
+                        "staged artifact index commit failed: {}",
+                        reason.id()
+                    ))
+                })?;
+                Ok::<_, std::io::Error>(snapshot)
             })
             .await;
             match published {
-                Ok(Ok((snapshot, meta))) => {
-                    state_ref
-                        .artifacts
-                        .insert(completion_key.clone(), CachedArtifact::from_index(meta));
+                Ok(Ok(snapshot)) => {
                     use crate::daemon::staged_stats::{StagedBytes, StagedCounter, StagedTiming};
                     if snapshot.staged {
                         state_ref
@@ -473,14 +485,14 @@ fn store_rustc_outputs(
             stats.rust_snapshot_copy_bytes = snapshot_stats.copy_bytes;
             stats.rust_snapshot_digest_ns = snapshot_stats.staged_hash_ns;
             stats.rust_snapshot_publication_ns = snapshot_stats.staged_publication_ns;
-            let (index_failure, index_commit_ns) = if snapshot_stats.staged {
-                match send_staged_index_insert(state, artifact_key_hex.to_string(), meta.clone()) {
-                    Ok(elapsed_ns) => (None, elapsed_ns),
-                    Err(reason) => (Some(reason), 0),
-                }
-            } else {
-                enqueue_index_insert(state, artifact_key_hex.to_string(), meta.clone());
-                (None, 0)
+            let (index_failure, index_commit_ns) = match commit_rustc_artifact_index(
+                state,
+                artifact_key_hex.to_string(),
+                meta,
+                snapshot_stats.staged,
+            ) {
+                Ok(elapsed_ns) => (None, elapsed_ns),
+                Err(reason) => (Some(reason), 0),
             };
             if let Some(reason) = index_failure {
                 record_staged_publication_failure(state, reason);
@@ -536,10 +548,7 @@ fn store_rustc_outputs(
 
     let t_artifact_insert_stats = Instant::now();
     if persisted {
-        let t_artifact_memory_insert = Instant::now();
-        let cached = CachedArtifact::from_index(meta);
-        state.artifacts.insert(artifact_key_hex.to_string(), cached);
-        stats.artifact_memory_insert_ns = t_artifact_memory_insert.elapsed().as_nanos() as u64;
+        stats.artifact_memory_insert_ns = t_artifact_insert_stats.elapsed().as_nanos() as u64;
     }
 
     let latency_ns = compile_start.elapsed().as_nanos() as u64;
@@ -550,6 +559,42 @@ fn store_rustc_outputs(
     });
     stats.artifact_insert_stats_ns = t_artifact_insert_stats.elapsed().as_nanos() as u64;
     drop(publication_guard);
+}
+
+fn commit_rustc_artifact_index(
+    state: &SharedState,
+    key_hex: String,
+    mut meta: ArtifactIndex,
+    staged: bool,
+) -> Result<u64, StagedPublishFailure> {
+    use dashmap::mapref::entry::Entry;
+
+    if let Some(durable) = super::rustc_index::durable_rustc_index(state, &key_hex) {
+        meta = super::rustc_index::merge_rustc_index(meta, durable);
+    }
+
+    let commit = |metadata: ArtifactIndex| {
+        if staged {
+            send_staged_index_insert(state, key_hex.clone(), metadata)
+        } else {
+            enqueue_index_insert(state, key_hex.clone(), metadata);
+            Ok(0)
+        }
+    };
+
+    match state.artifacts.entry(key_hex.clone()) {
+        Entry::Occupied(mut entry) => {
+            meta = super::rustc_index::merge_rustc_index(meta, entry.get().meta.clone());
+            let commit_ns = commit(meta.clone())?;
+            entry.insert(CachedArtifact::from_index(meta));
+            Ok(commit_ns)
+        }
+        Entry::Vacant(entry) => {
+            let commit_ns = commit(meta.clone())?;
+            entry.insert(CachedArtifact::from_index(meta));
+            Ok(commit_ns)
+        }
+    }
 }
 
 /// Preserve canonical staged depfile bytes after requested-output
@@ -846,10 +891,34 @@ fn store_single_output(
 #[cfg(test)]
 mod staged_publication_diagnostic_tests {
     use super::{
-        enqueue_persisted_index, preserve_staged_depfile_for_persistence,
-        truncate_staged_publication_error, PersistOutcome, MAX_STAGED_PUBLICATION_ERROR_CHARS,
+        commit_rustc_artifact_index, enqueue_persisted_index,
+        preserve_staged_depfile_for_persistence, truncate_staged_publication_error, ArtifactIndex,
+        ArtifactVerdict, PersistOutcome, MAX_STAGED_PUBLICATION_ERROR_CHARS,
     };
     use crate::core::NormalizedPath;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn rustc_index_commit_merges_verdicts_for_shared_artifact_bytes() {
+        let temp = tempfile::tempdir().unwrap();
+        let server = crate::daemon::server::tests::bind_isolated_server(temp.path());
+        let mut meta = ArtifactIndex::new(vec![], vec![], vec![], vec![], 0);
+        for key in ["plain", "dylint"] {
+            meta.rustc_verdicts.insert(
+                key.to_string(),
+                ArtifactVerdict {
+                    stdout: Arc::new(Vec::new()),
+                    stderr: Arc::new(key.as_bytes().to_vec()),
+                    exit_code: 0,
+                },
+            );
+            commit_rustc_artifact_index(&server.state, "artifact".to_string(), meta, false)
+                .unwrap();
+            meta = ArtifactIndex::new(vec![], vec![], vec![], vec![], 0);
+        }
+        let cached = server.state.artifacts.get("artifact").unwrap();
+        assert_eq!(cached.meta.rustc_verdicts.len(), 2);
+    }
 
     #[test]
     fn failed_async_persist_never_enqueues_an_index_insert() {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/README.md
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/README.md
@@ -10,6 +10,7 @@ parent `handle_compile.rs` need no changes.
 | File | Responsibility |
 |---|---|
 | `mod.rs` | `handle_compile_request` orchestrator; wires the phases together |
+| `request_prep.rs` | Validate request inputs, prepare Dylint identity/environment, reject time macros, discover system includes, and parse single- vs multi-file invocations |
 | `system_includes.rs` | Per-compiler system include discovery + initial watch |
 | `hash_verify.rs` | Hash source + headers in parallel, run depgraph verdict |
 | `compile_exec.rs` | Prepare depfile / response file, spawn compiler, parse output |

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -4,6 +4,7 @@
 //! hit-branch dispatch, miss exec, store) was originally a single 1.2k LOC
 //! function. The implementation is now split per phase under this directory:
 //!
+//! - `request_prep.rs` — validation, Dylint/time-macro prep, invocation parse
 //! - `system_includes.rs` — per-compiler system include discovery + watch
 //! - `hash_verify.rs` — source + header hashing and depgraph verdict
 //! - `compile_exec.rs` — depfile/response-file prep + compiler spawn
@@ -15,6 +16,7 @@
 
 mod compile_exec;
 mod hash_verify;
+mod request_prep;
 mod store_outcome;
 mod system_includes;
 mod time_macros;
@@ -23,7 +25,7 @@ use super::super::*;
 use super::cached_hit::{
     materialize_cached_compile_hit, CachedHitFailure, CachedHitMaterializeRequest, CachedHitPhases,
 };
-use super::error_cache::{compile_failure_stderr, maybe_store_rustc_error_artifact};
+use super::error_cache::maybe_store_rustc_error_artifact;
 use super::hit_branches::{
     try_depgraph_cached_hit, try_fast_hit, try_request_cache_hit, DepgraphHitProbe, FastHitProbe,
     RequestCacheHitProbe,
@@ -32,11 +34,13 @@ use super::request::CompileRequest;
 
 use compile_exec::{run_compile_exec, CompileExecOutcome, CompileExecRequest, CompileExecResult};
 use hash_verify::{hash_and_verify, HashSourceOutcome, HashVerifyInput, HashVerifyOutcome};
+use request_prep::{
+    begin_prepared_request, discover_request_system_includes, invalidate_missing_depgraph_artifact,
+    parse_single_compile_request, prepare_request_arguments, record_dylint_input_hash,
+    wait_for_startup_depgraph_load, ParsedRequestArguments, ParsedSingleRequest,
+};
 use store_outcome::{store_successful_compile, StoreOutcomeRequest};
-use system_includes::{discover_system_includes, SystemIncludesOutcome};
-use time_macros::{find_time_macro_use, warn_time_macro_uncacheable};
-
-const DEPGRAPH_STARTUP_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+use system_includes::SystemIncludesOutcome;
 
 /// Handle a Compile request: parse args, check depgraph, run compiler or return cached.
 pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response {
@@ -49,183 +53,29 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         client_env,
         stdin,
     } = req;
-    let mut client_env = client_env;
     let state = state_arc.as_ref();
     let compile_start = std::time::Instant::now();
-    let sid = match session_id.parse::<SessionId>() {
-        Ok(id) => id,
-        Err(_) => {
-            return Response::Error {
-                message: format!("invalid session ID: {session_id}"),
-            };
-        }
-    };
-    // Expand response files before request-level caching so `@file` mutations
-    // can't reuse stale fast-hit entries keyed only by raw argv.
-    let expanded_args = expand_args_cached(state, args, cwd);
-
-    let strict_paths_mode = match strict_paths_mode_from_client_env(client_env.as_deref()) {
-        Ok(mode) => mode,
-        Err(err) => return compile_failure_stderr(format!("zccache: {err}")),
-    };
-    if let Err(err) =
-        crate::compiler::strict_paths::validate_args(&expanded_args, strict_paths_mode)
-    {
-        let compiler = compiler_path.display().to_string();
-        return compile_failure_stderr(err.diagnostic(&compiler, &expanded_args));
-    }
-    let dependency_mode = match DependencyDiscoveryMode::from_client_env(client_env.as_deref()) {
-        Ok(mode) => mode,
-        Err(err) => return compile_failure_stderr(format!("zccache: {err}")),
-    };
-
-    let worktree_root = compile_worktree_root(state, &sid, cwd, client_env.as_deref());
-    let effective_args = effective_compile_args(
-        &expanded_args,
+    let ParsedRequestArguments {
+        sid,
+        client_env,
+        dependency_mode,
+        worktree_root,
+        effective_args,
+        request_cache_key_root,
+    } = match prepare_request_arguments(
+        state,
+        session_id,
         compiler_path,
+        args,
         cwd,
-        worktree_root.as_ref(),
-        client_env.as_deref(),
-    );
-
-    if crate::compiler::is_dylint_driver(&compiler_path.to_string_lossy()) {
-        let dylint_result = async {
-            let (inner_rustc, _) = crate::compiler::dylint_inner_rustc_args(
-                &compiler_path.to_string_lossy(),
-                &effective_args,
-            )
-            .map_err(str::to_string)?
-            .ok_or_else(|| "Dylint nested invocation was not recognized".to_string())?;
-            let inner_rustc = {
-                let path = Path::new(inner_rustc);
-                if path.is_absolute() {
-                    path.to_path_buf()
-                } else {
-                    cwd.join(path)
-                }
-            };
-            let driver_identity = state
-                .compiler_hash_cache
-                .get_or_hash_with_async(compiler_path, {
-                    let probe_env = client_env.clone().unwrap_or_default();
-                    |path| hash_dylint_driver_identity_async(path, probe_env)
-                })
-                .await
-                .ok_or_else(|| {
-                    format!("cannot identify Dylint driver {}", compiler_path.display())
-                })?;
-            let inner_rustc_identity = state
-                .compiler_hash_cache
-                .get_or_hash_rustc_identity_async(&inner_rustc)
-                .await
-                .ok_or_else(|| {
-                    format!(
-                        "cannot identify Dylint inner rustc {}",
-                        inner_rustc.display()
-                    )
-                })?;
-            let env = client_env.get_or_insert_with(Vec::new);
-            crate::compiler::prepare_dylint_cache_env_with_identities(
-                &NormalizedPath::new(compiler_path),
-                &effective_args,
-                cwd,
-                env,
-                driver_identity,
-                inner_rustc_identity,
-                |path| {
-                    state
-                        .compiler_hash_cache
-                        .get_or_hash_with(path, |path| crate::hash::hash_file(path).ok())
-                        .ok_or_else(|| {
-                            format!(
-                                "cannot hash Dylint library {}; running uncached",
-                                path.display()
-                            )
-                        })
-                },
-            )
-        }
-        .await;
-        if dylint_result.is_ok() {
-            if let Some(env) = client_env.as_deref() {
-                for (name, value) in env.iter().filter(|(name, _)| {
-                    crate::compiler::dylint_env_affects_output(name)
-                        || matches!(name.as_str(), "DYLINT_LIBS" | "ZCCACHE_WORKTREE_ROOT")
-                }) {
-                    record_dylint_input_hash(name, value.as_bytes());
-                }
-            }
-        }
-        if let Err(reason) = dylint_result {
-            let diagnostic = format!("zccache: Dylint cache disabled: {reason}\n");
-            let bypass_compiler: NormalizedPath = compiler_path.into();
-            state.stats.record_compilation();
-            state.stats.record_non_cacheable();
-            record_session_stat(&state.sessions, &sid, |t| t.record_non_cacheable());
-            write_session_log(
-                &state.sessions,
-                &sid,
-                &format!("non-cacheable: Dylint cache disabled: {reason}"),
-            );
-            let response = run_compiler_direct(
-                &bypass_compiler,
-                args,
-                cwd,
-                &state.sessions,
-                &sid,
-                &client_env,
-                &stdin,
-                state.depfile_tmpdir.as_path(),
-            )
-            .await;
-            return prepend_compile_stderr(response, diagnostic.as_bytes());
-        }
-    }
-    let request_cache_key_root =
-        request_key_root(compiler_path, &effective_args, worktree_root.as_ref());
-
-    // `__DATE__`, `__TIME__`, and `__TIMESTAMP__` are source-level inputs
-    // whose expansion changes between otherwise-identical compiler requests.
-    // This check intentionally precedes the request cache: all later cache
-    // layers would be too late to prevent replaying an old timestamp object.
-    let preflight_parsed =
-        crate::compiler::parse_invocation(compiler_path.to_str().unwrap_or(""), &effective_args);
-    let time_macro_use = match &preflight_parsed {
-        crate::compiler::ParsedInvocation::Cacheable(compilation) => {
-            find_time_macro_use(compilation, cwd)
-        }
-        crate::compiler::ParsedInvocation::MultiFile { compilations, .. } => compilations
-            .iter()
-            .find_map(|compilation| find_time_macro_use(compilation, cwd)),
-        crate::compiler::ParsedInvocation::NonCacheable { .. } => None,
+        client_env,
+        &stdin,
+    )
+    .await
+    {
+        Ok(prepared) => prepared,
+        Err(response) => return response,
     };
-    if let Some(found) = time_macro_use {
-        let bypass_compiler: NormalizedPath = compiler_path.into();
-        state.stats.record_compilation();
-        state.stats.record_non_cacheable();
-        record_session_stat(&state.sessions, &sid, |t| t.record_non_cacheable());
-        write_session_log(
-            &state.sessions,
-            &sid,
-            &format!(
-                "non-cacheable: {} in {}",
-                found.macro_name,
-                found.input_file.display()
-            ),
-        );
-        warn_time_macro_uncacheable(&found);
-        return run_compiler_direct(
-            &bypass_compiler,
-            args,
-            cwd,
-            &state.sessions,
-            &sid,
-            &client_env,
-            &stdin,
-            state.depfile_tmpdir.as_path(),
-        )
-        .await;
-    }
 
     // Snap the journal clock once so all file hashes in this request see a
     // consistent view (avoids per-file current_clock() syscalls).
@@ -249,179 +99,62 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         return response;
     }
 
-    state.stats.record_compilation();
+    let (compiler, lineage, want_rust_miss_profile) =
+        begin_prepared_request(state, &sid, session_id, compiler_path);
 
-    // Note: we do not require `state.sessions.exists(&sid)` here. A daemon
-    // restart (e.g. zccache-ci killing the daemon to unlock target binaries
-    // on Windows) drops the session map but client wrappers keep using the
-    // session UUID they were issued. The session-stat and touch helpers
-    // below already no-op for unknown sessions, so the compile itself
-    // proceeds; only per-session stats are lost. Mirrors PR #137's
-    // idempotent SessionEnd fix. See issues #166 and #167.
-
-    let compiler: NormalizedPath = compiler_path.into();
-
-    // Lineage carried into every child spawned for this compile request —
-    // compiler, depfile probe, etc. See `super::super::lineage` and issue #7.
-    let lineage = crate::daemon::lineage::Lineage::current(
-        session_client_pid(state, &sid),
-        Some(session_id.into()),
-    );
-
-    // Issue #461: the timed phases below feed only `RustMissProfile`, which is
-    // emitted only when `ZCCACHE_PROFILE_RUST_MISS` is set. Decide once here
-    // whether to capture phase boundaries — otherwise we pay 4 unconditional
-    // clock reads (~50ns Linux / ~500ns Windows each) on EVERY request,
-    // including warm hits that never reach the miss emitter. Cheap env var
-    // probe is ~50ns; tied here for amortization across the rest of the
-    // function. Note this is broader than `rust_profile_enabled` below (which
-    // also requires `is_rustc`); allowing the env-only check to gate these
-    // early phases costs at most a handful of bytes when a non-rustc
-    // compile happens with the env set — acceptable since that's the rare
-    // diagnostic path.
-    let want_rust_miss_profile = std::env::var_os(RUST_MISS_PROFILE_ENV).is_some();
-
-    let compiler_priority = CompilePriority::from_client_env(client_env.as_deref());
     let SystemIncludesOutcome {
         includes: system_includes,
-        empty_discovery,
         system_includes_ns,
         system_watch_ns,
-    } = discover_system_includes(
+        ..
+    } = match discover_request_system_includes(
         state,
+        &sid,
         &compiler,
         &lineage,
-        compiler_priority,
         want_rust_miss_profile,
+        args,
+        cwd,
+        &client_env,
+        &stdin,
     )
-    .await;
-
-    if empty_discovery {
-        // Issue #1167: an empty successful C/C++ probe is ambiguous, not an
-        // assertion that the compiler has no default includes. Do not build a
-        // context or artifact key from it; run this request directly and let
-        // the next request re-probe.
-        state.stats.record_compilation();
-        state.stats.record_non_cacheable();
-        record_session_stat(&state.sessions, &sid, |t| t.record_non_cacheable());
-        write_session_log(
-            &state.sessions,
-            &sid,
-            "non-cacheable: system include discovery returned zero paths",
-        );
-        return run_compiler_direct(
-            &compiler,
-            args,
-            cwd,
-            &state.sessions,
-            &sid,
-            &client_env,
-            &stdin,
-            state.depfile_tmpdir.as_path(),
-        )
-        .await;
-    }
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(response) => return response,
+    };
 
     state.sessions.touch(&sid);
 
-    // ── Phase: expand response files + parse args ─────────────────────
-    let t0 = std::time::Instant::now();
-    let compiler_str = compiler.to_str().unwrap_or("");
-    let parsed = crate::compiler::parse_invocation(compiler_str, &effective_args);
-    let compilation = match parsed {
-        crate::compiler::ParsedInvocation::Cacheable(c) => c,
-        crate::compiler::ParsedInvocation::NonCacheable { reason } => {
-            state.stats.record_non_cacheable();
-            record_session_stat(&state.sessions, &sid, |t| t.record_non_cacheable());
-            write_session_log(&state.sessions, &sid, &format!("non-cacheable: {reason}"));
-            // Use raw args — compiler handles @file natively
-            return run_compiler_direct(
-                &compiler,
-                args,
-                cwd,
-                &state.sessions,
-                &sid,
-                &client_env,
-                &stdin,
-                state.depfile_tmpdir.as_path(),
-            )
-            .await;
-        }
-        crate::compiler::ParsedInvocation::MultiFile {
-            compilations,
-            original_args,
-            source_indices,
-        } => {
-            wait_for_startup_depgraph_load(state, &sid).await;
-            return handle_compile_multi(
-                Arc::clone(state_arc),
-                sid,
-                compiler,
-                compilations,
-                original_args,
-                source_indices,
-                cwd.into(),
-                worktree_root.clone(),
-                system_includes,
-                client_env,
-                stdin,
-                compile_start,
-                dependency_mode,
-            )
-            .await;
-        }
+    let ParsedSingleRequest {
+        compilation,
+        cwd_path,
+        source_path,
+        output_path,
+        system_includes,
+        client_env,
+        stdin,
+        parse_args_ns,
+    } = match parse_single_compile_request(
+        state_arc,
+        state,
+        &sid,
+        &compiler,
+        &effective_args,
+        args,
+        cwd,
+        worktree_root.as_ref(),
+        system_includes,
+        client_env,
+        stdin,
+        compile_start,
+        dependency_mode,
+    )
+    .await
+    {
+        Ok(parsed) => parsed,
+        Err(response) => return response,
     };
-    let parse_args_ns = t0.elapsed().as_nanos() as u64;
-
-    let cwd_path: NormalizedPath = cwd.into();
-    let source_path = if compilation.source_file.is_absolute() {
-        compilation.source_file.clone()
-    } else {
-        cwd_path.join(&compilation.source_file)
-    };
-    let output_path = if compilation.output_file.is_absolute() {
-        compilation.output_file.clone()
-    } else {
-        cwd_path.join(&compilation.output_file)
-    };
-    if compilation.family == crate::compiler::CompilerFamily::Rustc {
-        let rustc_args = crate::depgraph::parse_rustc_args(
-            crate::compiler::dylint_inner_rustc_args(compiler_str, &effective_args)
-                .ok()
-                .flatten()
-                .map_or(effective_args.as_slice(), |(_, inner)| inner),
-            cwd,
-        );
-        if rustc_args.crate_types == ["cdylib"]
-            && !dylint_cdylib_has_complete_output_identity(
-                &rustc_args,
-                output_path.as_path(),
-                cwd,
-                client_env.as_deref(),
-            )
-        {
-            state.stats.record_non_cacheable();
-            record_session_stat(&state.sessions, &sid, |tracker| {
-                tracker.record_non_cacheable()
-            });
-            write_session_log(
-                &state.sessions,
-                &sid,
-                "non-cacheable: Dylint cdylib output identity is incomplete",
-            );
-            return run_compiler_direct(
-                &compiler,
-                args,
-                cwd,
-                &state.sessions,
-                &sid,
-                &client_env,
-                &stdin,
-                state.depfile_tmpdir.as_path(),
-            )
-            .await;
-        }
-    }
 
     // ── Phase: build context + register ──────────────────────────────
     wait_for_startup_depgraph_load(state, &sid).await;
@@ -823,6 +556,10 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 t.record_depgraph_hit_artifact_miss();
             });
             let failure_name = match &failure {
+                CachedHitFailure::VerdictMissing => {
+                    record_miss_reason(miss_reason::NO_ARTIFACT_FOR_KEY);
+                    "verdict_not_found"
+                }
                 CachedHitFailure::CacheBlobMissing(_) => {
                     record_miss_reason(miss_reason::NO_ARTIFACT_FOR_KEY);
                     "artifact_not_found"
@@ -984,11 +721,21 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                         cwd,
                         client_env.as_deref(),
                     );
+                    let dylint_hash = client_env.as_deref().and_then(|env| {
+                        env.iter().find_map(|(name, value)| {
+                            (name == "ZCCACHE_DYLINT_CACHE_INPUT_HASH").then_some(value.as_str())
+                        })
+                    });
+                    let verdict_key_hex =
+                        crate::depgraph::compute_rustc_verdict_key(&artifact_key_hex, dylint_hash)
+                            .hash()
+                            .to_hex();
                     if let Ok(response) =
                         materialize_cached_compile_hit(CachedHitMaterializeRequest {
                             state,
                             sid: &sid,
                             artifact_key_hex: &artifact_key_hex,
+                            verdict_key_hex: Some(&verdict_key_hex),
                             source_path: &source_path,
                             output_path: &output_path,
                             secondary_output_dir: output_path
@@ -1131,6 +878,11 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         state.stats.record_error();
         record_session_stat(&state.sessions, &sid, |t| t.record_error());
         if let Some(rustc_args) = rustc_args_opt.as_ref() {
+            let dylint_input_hash = client_env.as_deref().and_then(|env| {
+                env.iter().find_map(|(name, value)| {
+                    (name == "ZCCACHE_DYLINT_CACHE_INPUT_HASH").then_some(value.as_str())
+                })
+            });
             if let Some(artifact_key_hex) = maybe_store_rustc_error_artifact(
                 state,
                 &context_key,
@@ -1138,6 +890,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 &cwd_path,
                 &ctx,
                 rustc_args,
+                dylint_input_hash,
                 &artifact_stdout,
                 &artifact_stderr,
                 exit_code,
@@ -1161,6 +914,11 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     // Only cache successful compilations
     if exit_code == 0 {
         let synchronous_persist = staged_plan.is_some();
+        let rustc_dylint_input_hash = client_env.as_deref().and_then(|env| {
+            env.iter().find_map(|(name, value)| {
+                (name == "ZCCACHE_DYLINT_CACHE_INPUT_HASH").then_some(value.as_str())
+            })
+        });
         if let Some(response) = store_successful_compile(StoreOutcomeRequest {
             state_arc,
             sid: &sid,
@@ -1178,6 +936,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             compilation: &compilation,
             dependency_mode,
             rustc_args_opt: rustc_args_opt.as_deref(),
+            rustc_dylint_input_hash,
             rustc_extern_paths: &rustc_extern_paths,
             client_env: client_env.as_deref(),
             is_rustc,
@@ -1229,80 +988,5 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         stdout: response_stdout,
         stderr: response_stderr,
         cached: false,
-    }
-}
-
-fn record_dylint_input_hash(name: &str, value: &[u8]) {
-    let value_hash = crate::hash::hash_bytes(value).to_hex();
-    super::super::inner_trace::record_ns(
-        &format!(
-            "dylint_input_{}_{}",
-            name.to_ascii_lowercase(),
-            &value_hash[..12]
-        ),
-        0,
-    );
-}
-
-fn prepend_compile_stderr(mut response: Response, diagnostic: &[u8]) -> Response {
-    if let Response::CompileResult { stderr, .. } = &mut response {
-        let existing = std::mem::take(Arc::make_mut(stderr));
-        let mut combined = Vec::with_capacity(diagnostic.len() + existing.len());
-        combined.extend_from_slice(diagnostic);
-        combined.extend(existing);
-        *Arc::make_mut(stderr) = combined;
-    }
-    response
-}
-
-fn invalidate_missing_depgraph_artifact(
-    state: &SharedState,
-    sid: &SessionId,
-    artifact_key_hex: &str,
-    _evidence: &CacheBlobMissing,
-) {
-    let mut stale_keys = std::collections::HashSet::with_capacity(1);
-    stale_keys.insert(artifact_key_hex.to_string());
-    let cleared = state.dep_graph.load().invalidate_artifact_keys(&stale_keys);
-    write_session_log(
-        &state.sessions,
-        sid,
-        &format!("[DIAG] depgraph_invalidate_artifact: key={artifact_key_hex} cleared={cleared}"),
-    );
-}
-
-async fn wait_for_startup_depgraph_load(state: &SharedState, sid: &SessionId) {
-    if state.dep_graph_load_complete.load(Ordering::Acquire) {
-        return;
-    }
-
-    write_session_log(
-        &state.sessions,
-        sid,
-        "[DIAG] depgraph_load_pending: waiting before compile context registration",
-    );
-
-    let deadline = tokio::time::sleep(DEPGRAPH_STARTUP_WAIT_TIMEOUT);
-    tokio::pin!(deadline);
-    loop {
-        let notified = state.dep_graph_load_notify.notified();
-        if state.dep_graph_load_complete.load(Ordering::Acquire) {
-            return;
-        }
-        tokio::select! {
-            () = notified => {
-                if state.dep_graph_load_complete.load(Ordering::Acquire) {
-                    return;
-                }
-            }
-            () = &mut deadline => {
-                write_session_log(
-                    &state.sessions,
-                    sid,
-                    "[WARN] depgraph_load_pending: timed out; continuing with current graph",
-                );
-                return;
-            }
-        }
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/request_prep.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/request_prep.rs
@@ -1,0 +1,548 @@
+//! Request preparation helpers shared by the compile-pipeline orchestrator.
+
+use super::super::super::*;
+use super::super::error_cache::compile_failure_stderr;
+use super::system_includes::{discover_system_includes, SystemIncludesOutcome};
+use super::time_macros::{find_time_macro_use, warn_time_macro_uncacheable};
+
+const DEPGRAPH_STARTUP_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+pub(super) fn begin_prepared_request(
+    state: &SharedState,
+    sid: &SessionId,
+    session_id: &str,
+    compiler_path: &Path,
+) -> (NormalizedPath, crate::daemon::lineage::Lineage, bool) {
+    // Sessions can disappear across a daemon restart while wrappers retain
+    // their UUID. The stat/touch helpers no-op for unknown sessions, so the
+    // compile remains valid and only per-session accounting is lost.
+    state.stats.record_compilation();
+    let compiler = compiler_path.into();
+    let lineage = crate::daemon::lineage::Lineage::current(
+        session_client_pid(state, sid),
+        Some(session_id.into()),
+    );
+    // Miss profiling alone needs the early phase clock reads. Decide once to
+    // avoid paying them on every warm request.
+    let want_rust_miss_profile = std::env::var_os(RUST_MISS_PROFILE_ENV).is_some();
+    (compiler, lineage, want_rust_miss_profile)
+}
+
+pub(super) struct ParsedRequestArguments {
+    pub(super) sid: SessionId,
+    pub(super) client_env: Option<Vec<(String, String)>>,
+    pub(super) dependency_mode: DependencyDiscoveryMode,
+    pub(super) worktree_root: Option<NormalizedPath>,
+    pub(super) effective_args: Vec<String>,
+    pub(super) request_cache_key_root: Option<NormalizedPath>,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn prepare_request_arguments(
+    state: &SharedState,
+    session_id: &str,
+    compiler_path: &Path,
+    raw_args: &[String],
+    cwd: &Path,
+    mut client_env: Option<Vec<(String, String)>>,
+    stdin: &[u8],
+) -> Result<ParsedRequestArguments, Response> {
+    let sid = session_id
+        .parse::<SessionId>()
+        .map_err(|_| Response::Error {
+            message: format!("invalid session ID: {session_id}"),
+        })?;
+
+    // Expand before request caching so mutations to an @file cannot reuse a
+    // fast-hit entry keyed only by the raw argument list.
+    let expanded_args = expand_args_cached(state, raw_args, cwd);
+    let strict_paths_mode = strict_paths_mode_from_client_env(client_env.as_deref())
+        .map_err(|err| compile_failure_stderr(format!("zccache: {err}")))?;
+    crate::compiler::strict_paths::validate_args(&expanded_args, strict_paths_mode).map_err(
+        |err| {
+            let compiler = compiler_path.display().to_string();
+            compile_failure_stderr(err.diagnostic(&compiler, &expanded_args))
+        },
+    )?;
+    let dependency_mode = DependencyDiscoveryMode::from_client_env(client_env.as_deref())
+        .map_err(|err| compile_failure_stderr(format!("zccache: {err}")))?;
+    let worktree_root = compile_worktree_root(state, &sid, cwd, client_env.as_deref());
+    let effective_args = effective_compile_args(
+        &expanded_args,
+        compiler_path,
+        cwd,
+        worktree_root.as_ref(),
+        client_env.as_deref(),
+    );
+
+    if let Some(response) = prepare_dylint_request(
+        state,
+        &sid,
+        compiler_path,
+        &effective_args,
+        raw_args,
+        cwd,
+        &mut client_env,
+        stdin,
+    )
+    .await
+    {
+        return Err(response);
+    }
+    let request_cache_key_root =
+        request_key_root(compiler_path, &effective_args, worktree_root.as_ref());
+    if let Some(response) = bypass_time_macro_request(
+        state,
+        &sid,
+        compiler_path,
+        &effective_args,
+        raw_args,
+        cwd,
+        &client_env,
+        stdin,
+    )
+    .await
+    {
+        return Err(response);
+    }
+
+    Ok(ParsedRequestArguments {
+        sid,
+        client_env,
+        dependency_mode,
+        worktree_root,
+        effective_args,
+        request_cache_key_root,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn prepare_dylint_request(
+    state: &SharedState,
+    sid: &SessionId,
+    compiler_path: &Path,
+    effective_args: &[String],
+    raw_args: &[String],
+    cwd: &Path,
+    client_env: &mut Option<Vec<(String, String)>>,
+    stdin: &[u8],
+) -> Option<Response> {
+    if !crate::compiler::is_dylint_driver(&compiler_path.to_string_lossy()) {
+        return None;
+    }
+
+    let dylint_result = async {
+        let (inner_rustc, _) = crate::compiler::dylint_inner_rustc_args(
+            &compiler_path.to_string_lossy(),
+            effective_args,
+        )
+        .map_err(str::to_string)?
+        .ok_or_else(|| "Dylint nested invocation was not recognized".to_string())?;
+        let inner_rustc = {
+            let path = Path::new(inner_rustc);
+            if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                cwd.join(path)
+            }
+        };
+        let driver_identity = state
+            .compiler_hash_cache
+            .get_or_hash_with_async(compiler_path, {
+                let probe_env = client_env.clone().unwrap_or_default();
+                |path| hash_dylint_driver_identity_async(path, probe_env)
+            })
+            .await
+            .ok_or_else(|| format!("cannot identify Dylint driver {}", compiler_path.display()))?;
+        let inner_rustc_identity = state
+            .compiler_hash_cache
+            .get_or_hash_rustc_identity_async(&inner_rustc)
+            .await
+            .ok_or_else(|| {
+                format!(
+                    "cannot identify Dylint inner rustc {}",
+                    inner_rustc.display()
+                )
+            })?;
+        let env = client_env.get_or_insert_with(Vec::new);
+        crate::compiler::prepare_dylint_cache_env_with_identities(
+            &NormalizedPath::new(compiler_path),
+            effective_args,
+            cwd,
+            env,
+            driver_identity,
+            inner_rustc_identity,
+            |path| {
+                state
+                    .compiler_hash_cache
+                    .get_or_hash_with(path, |path| crate::hash::hash_file(path).ok())
+                    .ok_or_else(|| {
+                        format!(
+                            "cannot hash Dylint library {}; running uncached",
+                            path.display()
+                        )
+                    })
+            },
+        )
+    }
+    .await;
+
+    let reason = match dylint_result {
+        Ok(_) => {
+            if let Some(env) = client_env.as_deref() {
+                for (name, value) in env.iter().filter(|(name, _)| {
+                    crate::compiler::dylint_env_affects_output(name)
+                        || matches!(name.as_str(), "DYLINT_LIBS" | "ZCCACHE_WORKTREE_ROOT")
+                }) {
+                    record_dylint_input_hash(name, value.as_bytes());
+                }
+            }
+            return None;
+        }
+        Err(reason) => reason,
+    };
+    let diagnostic = format!("zccache: Dylint cache disabled: {reason}\n");
+    let bypass_compiler: NormalizedPath = compiler_path.into();
+    state.stats.record_compilation();
+    state.stats.record_non_cacheable();
+    record_session_stat(&state.sessions, sid, |tracker| {
+        tracker.record_non_cacheable()
+    });
+    write_session_log(
+        &state.sessions,
+        sid,
+        &format!("non-cacheable: Dylint cache disabled: {reason}"),
+    );
+    let response = run_compiler_direct(
+        &bypass_compiler,
+        raw_args,
+        cwd,
+        &state.sessions,
+        sid,
+        client_env,
+        stdin,
+        state.depfile_tmpdir.as_path(),
+    )
+    .await;
+    Some(prepend_compile_stderr(response, diagnostic.as_bytes()))
+}
+
+/// Bypass every cache layer when a C/C++ source uses a time-dependent macro.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn bypass_time_macro_request(
+    state: &SharedState,
+    sid: &SessionId,
+    compiler_path: &Path,
+    effective_args: &[String],
+    raw_args: &[String],
+    cwd: &Path,
+    client_env: &Option<Vec<(String, String)>>,
+    stdin: &[u8],
+) -> Option<Response> {
+    let parsed =
+        crate::compiler::parse_invocation(compiler_path.to_str().unwrap_or(""), effective_args);
+    let found = match &parsed {
+        crate::compiler::ParsedInvocation::Cacheable(compilation) => {
+            find_time_macro_use(compilation, cwd)
+        }
+        crate::compiler::ParsedInvocation::MultiFile { compilations, .. } => compilations
+            .iter()
+            .find_map(|compilation| find_time_macro_use(compilation, cwd)),
+        crate::compiler::ParsedInvocation::NonCacheable { .. } => None,
+    }?;
+
+    let bypass_compiler: NormalizedPath = compiler_path.into();
+    state.stats.record_compilation();
+    state.stats.record_non_cacheable();
+    record_session_stat(&state.sessions, sid, |tracker| {
+        tracker.record_non_cacheable()
+    });
+    write_session_log(
+        &state.sessions,
+        sid,
+        &format!(
+            "non-cacheable: {} in {}",
+            found.macro_name,
+            found.input_file.display()
+        ),
+    );
+    warn_time_macro_uncacheable(&found);
+    Some(
+        run_compiler_direct(
+            &bypass_compiler,
+            raw_args,
+            cwd,
+            &state.sessions,
+            sid,
+            client_env,
+            stdin,
+            state.depfile_tmpdir.as_path(),
+        )
+        .await,
+    )
+}
+
+/// Discover system include roots, converting an ambiguous empty C/C++ probe
+/// into an uncached compile response.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn discover_request_system_includes(
+    state: &SharedState,
+    sid: &SessionId,
+    compiler: &NormalizedPath,
+    lineage: &crate::daemon::lineage::Lineage,
+    want_rust_miss_profile: bool,
+    raw_args: &[String],
+    cwd: &Path,
+    client_env: &Option<Vec<(String, String)>>,
+    stdin: &[u8],
+) -> Result<SystemIncludesOutcome, Response> {
+    let compiler_priority = CompilePriority::from_client_env(client_env.as_deref());
+    let outcome = discover_system_includes(
+        state,
+        compiler,
+        lineage,
+        compiler_priority,
+        want_rust_miss_profile,
+    )
+    .await;
+    if !outcome.empty_discovery {
+        return Ok(outcome);
+    }
+
+    // Issue #1167: an empty successful C/C++ probe is ambiguous, not proof
+    // that the compiler has no default includes. Run directly and re-probe.
+    state.stats.record_compilation();
+    state.stats.record_non_cacheable();
+    record_session_stat(&state.sessions, sid, |tracker| {
+        tracker.record_non_cacheable()
+    });
+    write_session_log(
+        &state.sessions,
+        sid,
+        "non-cacheable: system include discovery returned zero paths",
+    );
+    Err(run_compiler_direct(
+        compiler,
+        raw_args,
+        cwd,
+        &state.sessions,
+        sid,
+        client_env,
+        stdin,
+        state.depfile_tmpdir.as_path(),
+    )
+    .await)
+}
+
+pub(super) struct ParsedSingleRequest {
+    pub(super) compilation: crate::compiler::CacheableCompilation,
+    pub(super) cwd_path: NormalizedPath,
+    pub(super) source_path: NormalizedPath,
+    pub(super) output_path: NormalizedPath,
+    pub(super) system_includes: Vec<NormalizedPath>,
+    pub(super) client_env: Option<Vec<(String, String)>>,
+    pub(super) stdin: Vec<u8>,
+    pub(super) parse_args_ns: u64,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn parse_single_compile_request(
+    state_arc: &Arc<SharedState>,
+    state: &SharedState,
+    sid: &SessionId,
+    compiler: &NormalizedPath,
+    effective_args: &[String],
+    raw_args: &[String],
+    cwd: &Path,
+    worktree_root: Option<&NormalizedPath>,
+    system_includes: Vec<NormalizedPath>,
+    client_env: Option<Vec<(String, String)>>,
+    stdin: Vec<u8>,
+    compile_start: std::time::Instant,
+    dependency_mode: DependencyDiscoveryMode,
+) -> Result<ParsedSingleRequest, Response> {
+    let t0 = std::time::Instant::now();
+    let compiler_str = compiler.to_str().unwrap_or("");
+    let parsed = crate::compiler::parse_invocation(compiler_str, effective_args);
+    let compilation = match parsed {
+        crate::compiler::ParsedInvocation::Cacheable(compilation) => compilation,
+        crate::compiler::ParsedInvocation::NonCacheable { reason } => {
+            state.stats.record_non_cacheable();
+            record_session_stat(&state.sessions, sid, |tracker| {
+                tracker.record_non_cacheable()
+            });
+            write_session_log(&state.sessions, sid, &format!("non-cacheable: {reason}"));
+            return Err(run_compiler_direct(
+                compiler,
+                raw_args,
+                cwd,
+                &state.sessions,
+                sid,
+                &client_env,
+                &stdin,
+                state.depfile_tmpdir.as_path(),
+            )
+            .await);
+        }
+        crate::compiler::ParsedInvocation::MultiFile {
+            compilations,
+            original_args,
+            source_indices,
+        } => {
+            wait_for_startup_depgraph_load(state, sid).await;
+            return Err(handle_compile_multi(
+                Arc::clone(state_arc),
+                *sid,
+                compiler.clone(),
+                compilations,
+                original_args,
+                source_indices,
+                cwd.into(),
+                worktree_root.cloned(),
+                system_includes,
+                client_env,
+                stdin,
+                compile_start,
+                dependency_mode,
+            )
+            .await);
+        }
+    };
+    let parse_args_ns = t0.elapsed().as_nanos() as u64;
+
+    let cwd_path: NormalizedPath = cwd.into();
+    let source_path = if compilation.source_file.is_absolute() {
+        compilation.source_file.clone()
+    } else {
+        cwd_path.join(&compilation.source_file)
+    };
+    let output_path = if compilation.output_file.is_absolute() {
+        compilation.output_file.clone()
+    } else {
+        cwd_path.join(&compilation.output_file)
+    };
+    if compilation.family == crate::compiler::CompilerFamily::Rustc {
+        let rustc_args = crate::depgraph::parse_rustc_args(
+            crate::compiler::dylint_inner_rustc_args(compiler_str, effective_args)
+                .ok()
+                .flatten()
+                .map_or(effective_args, |(_, inner)| inner),
+            cwd,
+        );
+        if rustc_args.crate_types == ["cdylib"]
+            && !dylint_cdylib_has_complete_output_identity(
+                &rustc_args,
+                output_path.as_path(),
+                cwd,
+                client_env.as_deref(),
+            )
+        {
+            state.stats.record_non_cacheable();
+            record_session_stat(&state.sessions, sid, |tracker| {
+                tracker.record_non_cacheable()
+            });
+            write_session_log(
+                &state.sessions,
+                sid,
+                "non-cacheable: Dylint cdylib output identity is incomplete",
+            );
+            return Err(run_compiler_direct(
+                compiler,
+                raw_args,
+                cwd,
+                &state.sessions,
+                sid,
+                &client_env,
+                &stdin,
+                state.depfile_tmpdir.as_path(),
+            )
+            .await);
+        }
+    }
+
+    Ok(ParsedSingleRequest {
+        compilation,
+        cwd_path,
+        source_path,
+        output_path,
+        system_includes,
+        client_env,
+        stdin,
+        parse_args_ns,
+    })
+}
+
+pub(super) fn record_dylint_input_hash(name: &str, value: &[u8]) {
+    let value_hash = crate::hash::hash_bytes(value).to_hex();
+    super::super::inner_trace::record_ns(
+        &format!(
+            "dylint_input_{}_{}",
+            name.to_ascii_lowercase(),
+            &value_hash[..12]
+        ),
+        0,
+    );
+}
+
+fn prepend_compile_stderr(mut response: Response, diagnostic: &[u8]) -> Response {
+    if let Response::CompileResult { stderr, .. } = &mut response {
+        let existing = std::mem::take(Arc::make_mut(stderr));
+        let mut combined = Vec::with_capacity(diagnostic.len() + existing.len());
+        combined.extend_from_slice(diagnostic);
+        combined.extend(existing);
+        *Arc::make_mut(stderr) = combined;
+    }
+    response
+}
+
+pub(super) async fn wait_for_startup_depgraph_load(state: &SharedState, sid: &SessionId) {
+    if state.dep_graph_load_complete.load(Ordering::Acquire) {
+        return;
+    }
+
+    write_session_log(
+        &state.sessions,
+        sid,
+        "[DIAG] depgraph_load_pending: waiting before compile context registration",
+    );
+
+    let deadline = tokio::time::sleep(DEPGRAPH_STARTUP_WAIT_TIMEOUT);
+    tokio::pin!(deadline);
+    loop {
+        let notified = state.dep_graph_load_notify.notified();
+        if state.dep_graph_load_complete.load(Ordering::Acquire) {
+            return;
+        }
+        tokio::select! {
+            () = notified => {
+                if state.dep_graph_load_complete.load(Ordering::Acquire) {
+                    return;
+                }
+            }
+            () = &mut deadline => {
+                write_session_log(
+                    &state.sessions,
+                    sid,
+                    "[WARN] depgraph_load_pending: timed out; continuing with current graph",
+                );
+                return;
+            }
+        }
+    }
+}
+
+pub(super) fn invalidate_missing_depgraph_artifact(
+    state: &SharedState,
+    sid: &SessionId,
+    artifact_key_hex: &str,
+    _evidence: &CacheBlobMissing,
+) {
+    let mut stale_keys = std::collections::HashSet::with_capacity(1);
+    stale_keys.insert(artifact_key_hex.to_string());
+    let cleared = state.dep_graph.load().invalidate_artifact_keys(&stale_keys);
+    write_session_log(
+        &state.sessions,
+        sid,
+        &format!("[DIAG] depgraph_invalidate_artifact: key={artifact_key_hex} cleared={cleared}"),
+    );
+}

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -32,6 +32,7 @@ pub(super) struct StoreOutcomeRequest<'a> {
     pub(super) compilation: &'a crate::compiler::CacheableCompilation,
     pub(super) dependency_mode: DependencyDiscoveryMode,
     pub(super) rustc_args_opt: Option<&'a crate::depgraph::RustcParsedArgs>,
+    pub(super) rustc_dylint_input_hash: Option<&'a str>,
     pub(super) rustc_extern_paths: &'a [NormalizedPath],
     /// Request env the compile ran under — the value source for rustc
     /// env-dep snapshots (zccache#1021).
@@ -151,6 +152,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         compilation,
         dependency_mode,
         rustc_args_opt,
+        rustc_dylint_input_hash,
         rustc_extern_paths,
         client_env,
         is_rustc,
@@ -611,6 +613,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
                 user_depfile_persist_temp,
                 staged_persist_plan: staged_rust_persist_plan,
                 rustc_all_outputs: rustc_all_outputs.as_deref(),
+                rustc_dylint_input_hash,
                 stdout: &stdout,
                 stderr: &stderr,
                 exit_code,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/rustc_index.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/rustc_index.rs
@@ -1,0 +1,45 @@
+//! Shared merge rules for the rustc artifact/verdict index row.
+
+use super::super::*;
+
+/// Load the durable row before publishing a cold-depgraph update.
+///
+/// Startup hydration is deferred, so a persisted artifact may not yet exist
+/// in `state.artifacts`. Loading it here prevents a new verdict from replacing
+/// sibling verdicts or output metadata that only exist on disk.
+pub(super) fn durable_rustc_index(
+    state: &SharedState,
+    artifact_key_hex: &str,
+) -> Option<ArtifactIndex> {
+    if !state.artifact_store_loaded.load(Ordering::Acquire) {
+        let _ = state.artifact_store.load_from_disk();
+        state.artifact_store_loaded.store(true, Ordering::Release);
+    }
+    state.artifact_store.get(artifact_key_hex)
+}
+
+/// Merge a fallback row without allowing it to replace the current verdict.
+///
+/// `preferred` is the result produced by the current request. A durable or
+/// live fallback contributes sibling verdicts and, when the current request
+/// is an error with no outputs, the existing shared artifact metadata.
+pub(super) fn merge_rustc_index(
+    mut preferred: ArtifactIndex,
+    mut fallback: ArtifactIndex,
+) -> ArtifactIndex {
+    if preferred.output_names.is_empty() && !fallback.output_names.is_empty() {
+        let preferred_verdicts = std::mem::take(&mut preferred.rustc_verdicts);
+        fallback.rustc_verdicts.extend(preferred_verdicts);
+        fallback.stored_at_secs = fallback.stored_at_secs.max(preferred.stored_at_secs);
+        return fallback;
+    }
+
+    for (verdict_key, verdict) in fallback.rustc_verdicts {
+        preferred
+            .rustc_verdicts
+            .entry(verdict_key)
+            .or_insert(verdict);
+    }
+    preferred.stored_at_secs = preferred.stored_at_secs.max(fallback.stored_at_secs);
+    preferred
+}

--- a/crates/zccache-daemon-core/src/daemon/server/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/mod.rs
@@ -13,7 +13,7 @@ use super::compile_journal::{
 use super::fingerprint::FingerprintManager;
 use super::process::CompilePriority;
 use super::stats::{HitPhases, MissPhases, PhaseProfiler, StatsCollector};
-use crate::artifact::{ArtifactIndex, ArtifactStore};
+use crate::artifact::{ArtifactIndex, ArtifactStore, ArtifactVerdict};
 use crate::core::NormalizedPath;
 use crate::depgraph::{
     CompileContext, ContextKey, DepGraph, DepfileStrategy, SessionId, SessionManager,

--- a/crates/zccache-daemon-core/src/daemon/server/run.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/run.rs
@@ -882,7 +882,8 @@ pub(super) async fn spawn_artifact_loader(
                 for (key, meta) in entries {
                     state_ref
                         .artifacts
-                        .insert(key, CachedArtifact::from_index(meta));
+                        .entry(key)
+                        .or_insert_with(|| CachedArtifact::from_index(meta));
                 }
                 count
             } else {

--- a/crates/zccache-daemon-core/src/daemon/server/tests/artifact_store_deferred.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/artifact_store_deferred.rs
@@ -176,5 +176,6 @@ fn synthetic_index_entry(total_size: u64) -> crate::artifact::ArtifactIndex {
         exit_code: 0,
         total_size,
         stored_at_secs: 0,
+        rustc_verdicts: Default::default(),
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/util.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/util.rs
@@ -309,9 +309,10 @@ pub(super) fn record_artifact_access(
     artifact: &CachedArtifact,
     now: Instant,
 ) {
-    if let Some(meta) = artifact.record_access(now) {
-        let _ = state
-            .index_writer_tx
-            .send(IndexWriterCommand::Insert(key_hex.to_string(), meta));
+    if let Some(stored_at_secs) = artifact.record_access(now) {
+        let _ = state.index_writer_tx.send(IndexWriterCommand::Touch(
+            key_hex.to_string(),
+            stored_at_secs,
+        ));
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/wal.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/wal.rs
@@ -4,6 +4,8 @@ use super::*;
 
 pub(super) enum IndexWriterCommand {
     Insert(String, ArtifactIndex),
+    /// Refresh retention age without replacing newer artifact metadata.
+    Touch(String, u64),
     Remove(Vec<String>),
     Clear(tokio::sync::oneshot::Sender<()>),
     Flush(tokio::sync::oneshot::Sender<()>),
@@ -294,6 +296,17 @@ async fn process_index_writer_command(
                 flush_wal_to_disk(store, wal).await;
             }
         }
+        IndexWriterCommand::Touch(k, stored_at_secs) => {
+            if let Some(meta) = wal.get_mut(&k) {
+                meta.stored_at_secs = meta.stored_at_secs.max(stored_at_secs);
+            } else if let Some(mut meta) = store.get(&k) {
+                meta.stored_at_secs = meta.stored_at_secs.max(stored_at_secs);
+                wal.insert(k, meta);
+            }
+            if wal.len() >= max_pending {
+                flush_wal_to_disk(store, wal).await;
+            }
+        }
         IndexWriterCommand::Remove(keys) => {
             for key in &keys {
                 wal.remove(key);
@@ -367,6 +380,52 @@ pub(super) async fn flush_wal_to_disk(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn access_touch_merges_into_newest_pending_verdict_row() {
+        let temp = tempfile::tempdir().expect("temporary index directory");
+        let store = Arc::new(ArtifactStore::open_empty(&temp.path().join("index.bin")));
+        let mut wal = std::collections::HashMap::new();
+        let key = "b".repeat(64);
+        let mut stale = ArtifactIndex::new(
+            vec!["output.rmeta".to_string()],
+            vec![4096],
+            Vec::new(),
+            Vec::new(),
+            0,
+        );
+        stale.stored_at_secs = 10;
+        store.insert(&key, &stale);
+
+        let mut newest = stale;
+        newest.rustc_verdicts.insert(
+            "dylint".to_string(),
+            ArtifactVerdict {
+                stdout: Arc::new(Vec::new()),
+                stderr: Arc::new(b"lint verdict".to_vec()),
+                exit_code: 1,
+            },
+        );
+        process_index_writer_command(
+            IndexWriterCommand::Insert(key.clone(), newest),
+            &store,
+            &mut wal,
+            usize::MAX,
+        )
+        .await;
+        process_index_writer_command(
+            IndexWriterCommand::Touch(key.clone(), 20),
+            &store,
+            &mut wal,
+            usize::MAX,
+        )
+        .await;
+
+        let pending = wal.get(&key).unwrap();
+        assert_eq!(pending.stored_at_secs, 20);
+        assert_eq!(pending.rustc_verdicts.len(), 1);
+        assert_eq!(pending.output_names.as_ref(), &["output.rmeta"]);
+    }
 
     #[tokio::test]
     async fn remove_cancels_pending_insert_and_persists_deletion() {

--- a/crates/zccache-depgraph/src/context/README.md
+++ b/crates/zccache-depgraph/src/context/README.md
@@ -1,9 +1,10 @@
 ## context/
 
 Compile-context types and cache-key computation. `mod.rs` exposes the public
-API (`ContextKey`, `ArtifactKey`, `CompileContext`, `RustcCompileContext`,
-`compute_context_key`, `compute_artifact_key`, `compute_rustc_artifact_key`,
-`compute_rustc_artifact_key_with_root`) along with the
+API (`ContextKey`, `ArtifactKey`, `CompileContext`, `RustcCompileContext`, and
+context-key helpers). `artifact_keys.rs` owns generic C/C++ artifact identity;
+`rustc_keys.rs` owns rustc artifact, verdict, and env-dependency identity. The
+module also carries the
 `VOLATILE_CARGO_ENV_VARS` allow-list that pins which `CARGO_*` env vars must
 not contribute to cache identity. `tests/` (cfg(test)-only) splits per surface
 — `cc` for C/C++, `rustc` for rustc.

--- a/crates/zccache-depgraph/src/context/artifact_keys.rs
+++ b/crates/zccache-depgraph/src/context/artifact_keys.rs
@@ -1,0 +1,153 @@
+//! Generic C/C++ artifact-key computation.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use zccache_hash::ContentHash;
+
+use super::{normalize_key_path, ArtifactKey, ContextKey};
+
+/// Compute the artifact key from a context key and file content hashes.
+///
+/// The artifact key uniquely identifies a specific compilation output.
+/// `file_hashes` should contain `(path, content_hash)` pairs for the
+/// source file and all resolved headers, sorted by path.
+pub fn compute_artifact_key<P: AsRef<Path> + Ord>(
+    context_key: &ContextKey,
+    file_hashes: &mut [(P, ContentHash)],
+    key_root: Option<&Path>,
+) -> ArtifactKey {
+    compute_artifact_key_with(context_key, file_hashes, key_root, |path, key_root| {
+        normalize_key_path(path, key_root).into()
+    })
+}
+
+/// Like [`compute_artifact_key`] but the per-header path normalization
+/// is delegated to a caller-supplied closure. The daemon plumbs in a
+/// closure that consults `DepGraph::cached_normalize_key_path` so the
+/// per-compile allocations amortize across the daemon's lifetime
+/// (issue #550). The closure is `FnMut` only because the impl forwards
+/// it through the iterator; in practice it's a `Fn`-shaped lookup.
+/// Fast-path variant of [`compute_artifact_key_with`] for the common case
+/// where the caller already holds owned [`zccache_core::NormalizedPath`] values and has
+/// no `key_root` (the cc/cpp compile path without `-ffile-prefix-map`).
+///
+/// Issue #585: post-#576 each [`zccache_core::NormalizedPath`] caches its
+/// `normalize_for_key` result in the struct's `key` field. With no
+/// `key_root`, that cached key IS the bytes we want to hash — no
+/// allocation, no DashMap lookup, no closure call. The previous shape
+/// went through `cached_normalize_key_path` which allocated 4 owned
+/// objects per lookup just to construct the `DashMap` key.
+///
+/// Output is bit-identical to `compute_artifact_key_with` when called
+/// with `key_root: None` and a closure that returns
+/// `normalize_for_key(path).into()`.
+#[must_use]
+pub fn compute_artifact_key_normalized_inplace(
+    context_key: &ContextKey,
+    file_hashes: &mut [(zccache_core::NormalizedPath, ContentHash)],
+) -> ArtifactKey {
+    compute_artifact_key_normalized_with_root(context_key, file_hashes, None)
+}
+
+/// Issue #591: extension of [`compute_artifact_key_normalized_inplace`]
+/// that also handles `key_root: Some`. For paths NOT under `key_root`
+/// (the common case for system headers), the path-key bytes are just
+/// `NormalizedPath::case_key()` — no allocation. For paths under
+/// `key_root`, we fall back to `normalize_key_path(path, Some(root))`.
+///
+/// Replaces the closure-based slow path through
+/// `compute_artifact_key_with` + `cached_normalize_key_path` which
+/// allocated 1 String per entry even after #590's cache bypass.
+#[must_use]
+pub fn compute_artifact_key_normalized_with_root(
+    context_key: &ContextKey,
+    file_hashes: &[(zccache_core::NormalizedPath, ContentHash)],
+    key_root: Option<&Path>,
+) -> ArtifactKey {
+    use std::borrow::Cow;
+
+    // Materialize path-keys: borrow from NormalizedPath::key for paths
+    // not under key_root (zero alloc); compute fresh for project-local.
+    let mut indexed: Vec<(Cow<'_, str>, ContentHash)> = file_hashes
+        .iter()
+        .map(|(np, h)| {
+            let path_key: Cow<'_, str> = match key_root {
+                Some(root) if np.as_path().starts_with(root) => {
+                    Cow::Owned(normalize_key_path(np.as_path(), Some(root)))
+                }
+                _ => {
+                    #[expect(
+                        clippy::expect_used,
+                        reason = "NormalizedPath::case_key() returns Option only as a forward-compat marker; post-#576 it is always Some. Returning a fallback would silently corrupt cache keys, which is catastrophic per CLAUDE.md correctness model."
+                    )]
+                    let key = np
+                        .case_key()
+                        .expect("NormalizedPath::key is always populated post-#576");
+                    Cow::Borrowed(key)
+                }
+            };
+            (path_key, *h)
+        })
+        .collect();
+    indexed.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"zccache-artifact-key-v1\0");
+    hasher.update(context_key.0.as_bytes());
+    hasher.update(b"\0");
+
+    for (path_key, hash) in &indexed {
+        hasher.update(path_key.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(hash.as_bytes());
+        hasher.update(b"\0");
+    }
+
+    ArtifactKey(ContentHash::from_bytes(*hasher.finalize().as_bytes()))
+}
+
+pub fn compute_artifact_key_with<P, F>(
+    context_key: &ContextKey,
+    file_hashes: &mut [(P, ContentHash)],
+    key_root: Option<&Path>,
+    mut normalize: F,
+) -> ArtifactKey
+where
+    P: AsRef<Path> + Ord,
+    F: FnMut(&Path, Option<&Path>) -> Arc<str>,
+{
+    // Issue #571: pre-normalize each path once (O(n) via the cached
+    // closure), then sort by the cheap Arc<str> key (O(n log n) byte
+    // compares). The prior path called `NormalizedPath::cmp` inside
+    // `sort_by`, which invoked `normalize_for_key` on BOTH operands of
+    // every comparison — O(n log n) normalizations bypassed the
+    // #553 cache entirely. With ~600 transitive headers per cpp/rust
+    // compile, that was ~10k normalize_for_key calls per miss; this
+    // collapses to ~600 calls (most hit the cache after the first
+    // compile in a session) plus cheap byte compares.
+    //
+    // Hash output is bit-identical to the prior path: the sort order
+    // is determined by the same normalized path-keys, and the blake3
+    // input bytes (path-key, separator, content-hash, separator) are
+    // emitted in the same order.
+    let mut indexed: Vec<(Arc<str>, ContentHash)> = file_hashes
+        .iter()
+        .map(|(p, h)| (normalize(p.as_ref(), key_root), *h))
+        .collect();
+    indexed.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"zccache-artifact-key-v1\0");
+    hasher.update(context_key.0.as_bytes());
+    hasher.update(b"\0");
+
+    for (path_key, hash) in &indexed {
+        hasher.update(path_key.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(hash.as_bytes());
+        hasher.update(b"\0");
+    }
+
+    ArtifactKey(ContentHash::from_bytes(*hasher.finalize().as_bytes()))
+}

--- a/crates/zccache-depgraph/src/context/mod.rs
+++ b/crates/zccache-depgraph/src/context/mod.rs
@@ -5,14 +5,15 @@
 //! hashes of all files for artifact store lookup.
 //!
 //! Split into focused submodules so each file stays under 1,000 LOC:
-//! - this file: type definitions, key computation, path-normalization helpers,
-//!   and the `VOLATILE_CARGO_ENV_VARS` allow-list.
+//! - this file: type definitions, context-key computation,
+//!   path-normalization helpers, and the `VOLATILE_CARGO_ENV_VARS` allow-list.
+//! - `artifact_keys`: generic C/C++ artifact identity.
+//! - `rustc_keys`: rustc artifact, verdict, and env-dependency identity.
 //! - `tests` (cfg(test) only): split per surface — `cc` (C/C++ tests) and
 //!   `rustc` (rustc tests).
 
 use std::path::Path;
 use std::sync::Arc;
-
 use zccache_core::path::normalize_for_key;
 use zccache_core::NormalizedPath;
 use zccache_hash::ContentHash;
@@ -21,6 +22,21 @@ use super::args::ParsedArgs;
 use super::native_cpu::{host_cpu_identity_salt, is_cxx_native_cpu_flag, is_rustc_native_cpu_flag};
 use super::rustc_args::RustcParsedArgs;
 use super::search_paths::IncludeSearchPaths;
+
+const DYLINT_CACHE_INPUT_HASH_ENV: &str = "ZCCACHE_DYLINT_CACHE_INPUT_HASH";
+
+mod artifact_keys;
+mod rustc_keys;
+
+pub use artifact_keys::{
+    compute_artifact_key, compute_artifact_key_normalized_inplace,
+    compute_artifact_key_normalized_with_root, compute_artifact_key_with,
+};
+pub use rustc_keys::{
+    compute_rustc_artifact_key, compute_rustc_artifact_key_with_root,
+    compute_rustc_artifact_key_with_root_with, compute_rustc_verdict_key,
+    fold_rustc_env_deps_into_artifact_key,
+};
 
 #[cfg(test)]
 mod tests;
@@ -363,151 +379,6 @@ where
     ContextKey(ContentHash::from_bytes(*hasher.finalize().as_bytes()))
 }
 
-/// Compute the artifact key from a context key and file content hashes.
-///
-/// The artifact key uniquely identifies a specific compilation output.
-/// `file_hashes` should contain `(path, content_hash)` pairs for the
-/// source file and all resolved headers, sorted by path.
-pub fn compute_artifact_key<P: AsRef<Path> + Ord>(
-    context_key: &ContextKey,
-    file_hashes: &mut [(P, ContentHash)],
-    key_root: Option<&Path>,
-) -> ArtifactKey {
-    compute_artifact_key_with(context_key, file_hashes, key_root, |path, key_root| {
-        normalize_key_path(path, key_root).into()
-    })
-}
-
-/// Like [`compute_artifact_key`] but the per-header path normalization
-/// is delegated to a caller-supplied closure. The daemon plumbs in a
-/// closure that consults `DepGraph::cached_normalize_key_path` so the
-/// per-compile allocations amortize across the daemon's lifetime
-/// (issue #550). The closure is `FnMut` only because the impl forwards
-/// it through the iterator; in practice it's a `Fn`-shaped lookup.
-/// Fast-path variant of [`compute_artifact_key_with`] for the common case
-/// where the caller already holds owned [`NormalizedPath`] values and has
-/// no `key_root` (the cc/cpp compile path without `-ffile-prefix-map`).
-///
-/// Issue #585: post-#576 each [`NormalizedPath`] caches its
-/// `normalize_for_key` result in the struct's `key` field. With no
-/// `key_root`, that cached key IS the bytes we want to hash — no
-/// allocation, no DashMap lookup, no closure call. The previous shape
-/// went through `cached_normalize_key_path` which allocated 4 owned
-/// objects per lookup just to construct the `DashMap` key.
-///
-/// Output is bit-identical to `compute_artifact_key_with` when called
-/// with `key_root: None` and a closure that returns
-/// `normalize_for_key(path).into()`.
-#[must_use]
-pub fn compute_artifact_key_normalized_inplace(
-    context_key: &ContextKey,
-    file_hashes: &mut [(zccache_core::NormalizedPath, ContentHash)],
-) -> ArtifactKey {
-    compute_artifact_key_normalized_with_root(context_key, file_hashes, None)
-}
-
-/// Issue #591: extension of [`compute_artifact_key_normalized_inplace`]
-/// that also handles `key_root: Some`. For paths NOT under `key_root`
-/// (the common case for system headers), the path-key bytes are just
-/// `NormalizedPath::case_key()` — no allocation. For paths under
-/// `key_root`, we fall back to `normalize_key_path(path, Some(root))`.
-///
-/// Replaces the closure-based slow path through
-/// `compute_artifact_key_with` + `cached_normalize_key_path` which
-/// allocated 1 String per entry even after #590's cache bypass.
-#[must_use]
-pub fn compute_artifact_key_normalized_with_root(
-    context_key: &ContextKey,
-    file_hashes: &[(zccache_core::NormalizedPath, ContentHash)],
-    key_root: Option<&Path>,
-) -> ArtifactKey {
-    use std::borrow::Cow;
-
-    // Materialize path-keys: borrow from NormalizedPath::key for paths
-    // not under key_root (zero alloc); compute fresh for project-local.
-    let mut indexed: Vec<(Cow<'_, str>, ContentHash)> = file_hashes
-        .iter()
-        .map(|(np, h)| {
-            let path_key: Cow<'_, str> = match key_root {
-                Some(root) if np.as_path().starts_with(root) => {
-                    Cow::Owned(normalize_key_path(np.as_path(), Some(root)))
-                }
-                _ => {
-                    #[expect(
-                        clippy::expect_used,
-                        reason = "NormalizedPath::case_key() returns Option only as a forward-compat marker; post-#576 it is always Some. Returning a fallback would silently corrupt cache keys, which is catastrophic per CLAUDE.md correctness model."
-                    )]
-                    let key = np
-                        .case_key()
-                        .expect("NormalizedPath::key is always populated post-#576");
-                    Cow::Borrowed(key)
-                }
-            };
-            (path_key, *h)
-        })
-        .collect();
-    indexed.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(b"zccache-artifact-key-v1\0");
-    hasher.update(context_key.0.as_bytes());
-    hasher.update(b"\0");
-
-    for (path_key, hash) in &indexed {
-        hasher.update(path_key.as_bytes());
-        hasher.update(b"\0");
-        hasher.update(hash.as_bytes());
-        hasher.update(b"\0");
-    }
-
-    ArtifactKey(ContentHash::from_bytes(*hasher.finalize().as_bytes()))
-}
-
-pub fn compute_artifact_key_with<P, F>(
-    context_key: &ContextKey,
-    file_hashes: &mut [(P, ContentHash)],
-    key_root: Option<&Path>,
-    mut normalize: F,
-) -> ArtifactKey
-where
-    P: AsRef<Path> + Ord,
-    F: FnMut(&Path, Option<&Path>) -> Arc<str>,
-{
-    // Issue #571: pre-normalize each path once (O(n) via the cached
-    // closure), then sort by the cheap Arc<str> key (O(n log n) byte
-    // compares). The prior path called `NormalizedPath::cmp` inside
-    // `sort_by`, which invoked `normalize_for_key` on BOTH operands of
-    // every comparison — O(n log n) normalizations bypassed the
-    // #553 cache entirely. With ~600 transitive headers per cpp
-    // compile, that was ~10k normalize_for_key calls per miss; this
-    // collapses to ~600 calls (most hit the cache after the first
-    // compile in a session) plus cheap byte compares.
-    //
-    // Hash output is bit-identical to the prior path: the sort order
-    // is determined by the same normalized path-keys, and the blake3
-    // input bytes (path-key, separator, content-hash, separator) are
-    // emitted in the same order.
-    let mut indexed: Vec<(Arc<str>, ContentHash)> = file_hashes
-        .iter()
-        .map(|(p, h)| (normalize(p.as_ref(), key_root), *h))
-        .collect();
-    indexed.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(b"zccache-artifact-key-v1\0");
-    hasher.update(context_key.0.as_bytes());
-    hasher.update(b"\0");
-
-    for (path_key, hash) in &indexed {
-        hasher.update(path_key.as_bytes());
-        hasher.update(b"\0");
-        hasher.update(hash.as_bytes());
-        hasher.update(b"\0");
-    }
-
-    ArtifactKey(ContentHash::from_bytes(*hasher.finalize().as_bytes()))
-}
-
 /// CARGO_* environment variables that must NOT participate in the cache key.
 ///
 /// These are volatile (absolute paths or build-host transients) and either do
@@ -627,11 +498,10 @@ impl RustcCompileContext {
         let mut env_vars: Vec<(String, String)> = client_env
             .iter()
             .filter(|(k, _)| {
-                (k.starts_with("CARGO_")
+                k.starts_with("CARGO_")
                     && k != "CARGO_MAKEFLAGS"
                     && k != "CARGO_INCREMENTAL"
-                    && !VOLATILE_CARGO_ENV_VARS.contains(&k.as_str()))
-                    || k == "ZCCACHE_DYLINT_CACHE_INPUT_HASH"
+                    && !VOLATILE_CARGO_ENV_VARS.contains(&k.as_str())
             })
             .cloned()
             .collect();
@@ -690,7 +560,7 @@ impl RustcCompileContext {
     ) -> ContextKey {
         let mut hasher = blake3::Hasher::new();
 
-        hasher.update(b"zccache-rustc-context-key-v3\0");
+        hasher.update(b"zccache-rustc-context-key-v4\0");
 
         // Compiler binary hash (different rustc versions -> different
         // output). Unconditional (non-Option field, issue #1166).
@@ -852,7 +722,8 @@ impl RustcCompileContext {
         // for the rationale (issue #139).
         hasher.update(b"env\0");
         for (key, val) in &self.env_vars {
-            if VOLATILE_CARGO_ENV_VARS.contains(&key.as_str()) {
+            if VOLATILE_CARGO_ENV_VARS.contains(&key.as_str()) || key == DYLINT_CACHE_INPUT_HASH_ENV
+            {
                 continue;
             }
             hasher.update(key.as_bytes());
@@ -1028,7 +899,8 @@ impl RustcCompileContext {
 
         hasher.update(b"env\0");
         for (key, val) in &self.env_vars {
-            if VOLATILE_CARGO_ENV_VARS.contains(&key.as_str()) {
+            if VOLATILE_CARGO_ENV_VARS.contains(&key.as_str()) || key == DYLINT_CACHE_INPUT_HASH_ENV
+            {
                 continue;
             }
             hasher.update(key.as_bytes());
@@ -1052,134 +924,4 @@ fn normalized_check_metadata_emit(emit_types: &[String]) -> Option<&'static [&'s
         3 if has("dep-info") && has("metadata") && has("link") => Some(&["dep-info", "metadata"]),
         _ => None,
     }
-}
-
-/// Compute the artifact key for a rustc compilation.
-///
-/// Like `compute_artifact_key` for C/C++, but also incorporates
-/// extern crate content hashes (analogous to header content hashes).
-pub fn compute_rustc_artifact_key<P: AsRef<Path> + Ord>(
-    context_key: &ContextKey,
-    file_hashes: &mut [(P, ContentHash)],
-    extern_hashes: &mut [(String, ContentHash)],
-) -> ArtifactKey {
-    compute_rustc_artifact_key_with_root(context_key, file_hashes, extern_hashes, None)
-}
-
-/// Compute the rustc artifact key, optionally normalizing project-local files.
-///
-/// When `key_root` is provided, source and dependency file paths under that
-/// root are hashed relative to it. Extern hashes remain keyed by crate name.
-pub fn compute_rustc_artifact_key_with_root<P: AsRef<Path> + Ord>(
-    context_key: &ContextKey,
-    file_hashes: &mut [(P, ContentHash)],
-    extern_hashes: &mut [(String, ContentHash)],
-    key_root: Option<&Path>,
-) -> ArtifactKey {
-    compute_rustc_artifact_key_with_root_with(
-        context_key,
-        file_hashes,
-        extern_hashes,
-        key_root,
-        |path, key_root| normalize_key_path(path, key_root).into(),
-    )
-}
-
-/// Like [`compute_rustc_artifact_key_with_root`] but the per-header path
-/// normalization is delegated to a caller-supplied closure. Used by the
-/// daemon's rustc miss/update paths to consult
-/// `DepGraph::cached_normalize_key_path` for the per-header allocation
-/// amortization (issue #550).
-pub fn compute_rustc_artifact_key_with_root_with<P, F>(
-    context_key: &ContextKey,
-    file_hashes: &mut [(P, ContentHash)],
-    extern_hashes: &mut [(String, ContentHash)],
-    key_root: Option<&Path>,
-    mut normalize: F,
-) -> ArtifactKey
-where
-    P: AsRef<Path> + Ord,
-    F: FnMut(&Path, Option<&Path>) -> Arc<str>,
-{
-    // Issue #571: pre-normalize each path once (O(n) via the cached
-    // closure), then sort on the cached Arc<str> keys (O(n log n) byte
-    // compares). The previous shape called `normalize` twice per
-    // sort-comparison AND once per hash-loop entry — 3 calls per
-    // element. With ~600 transitive headers per cpp/rust compile,
-    // this collapses ~10k normalize calls into ~600. Hash output is
-    // bit-identical: same sort order, same blake3 input bytes.
-    let mut indexed: Vec<(Arc<str>, ContentHash)> = file_hashes
-        .iter()
-        .map(|(p, h)| (normalize(p.as_ref(), key_root), *h))
-        .collect();
-    indexed.sort_by(|a, b| a.0.cmp(&b.0));
-    extern_hashes.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(b"zccache-rustc-artifact-key-v1\0");
-    hasher.update(context_key.0.as_bytes());
-    hasher.update(b"\0");
-
-    // Source + dependency file hashes.
-    for (path_key, hash) in &indexed {
-        hasher.update(path_key.as_bytes());
-        hasher.update(b"\0");
-        hasher.update(hash.as_bytes());
-        hasher.update(b"\0");
-    }
-
-    // Extern crate content hashes.
-    hasher.update(b"externs\0");
-    for (name, hash) in extern_hashes.iter() {
-        hasher.update(name.as_bytes());
-        hasher.update(b"\0");
-        hasher.update(hash.as_bytes());
-        hasher.update(b"\0");
-    }
-
-    ArtifactKey(ContentHash::from_bytes(*hasher.finalize().as_bytes()))
-}
-
-/// Fold rustc env-dep values into an already-computed rustc artifact key
-/// (zccache#1021).
-///
-/// rustc records every `env!()`/`option_env!()` read as a
-/// `# env-dep:NAME[=value]` line in its dep-info. The values are compile
-/// inputs exactly like extern rlib bytes: `cargo:rustc-env` vars (vergen's
-/// `VERGEN_GIT_SHA` and friends) change without any argv/source change,
-/// and serving the old artifact ships the stale value inside the rlib.
-///
-/// Layered on top of the base key rather than folded inside it so that
-/// contexts with **no** recorded env-deps (the overwhelmingly common
-/// case) keep byte-identical artifact keys with prior releases — no cache
-/// invalidation for env-free crates.
-///
-/// `env_hashes` entries are `(name, value_hash)` where `None` means the
-/// variable was **unset** at read time (`option_env!` → `None`) — a
-/// distinct variant from every set value. Entries are sorted by name for
-/// determinism.
-#[must_use]
-pub fn fold_rustc_env_deps_into_artifact_key(
-    base: ArtifactKey,
-    env_hashes: &mut [(String, Option<ContentHash>)],
-) -> ArtifactKey {
-    if env_hashes.is_empty() {
-        return base;
-    }
-    env_hashes.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(b"zccache-rustc-env-deps-v1\0");
-    hasher.update(base.0.as_bytes());
-    hasher.update(b"\0");
-    for (name, value_hash) in env_hashes.iter() {
-        hasher.update(name.as_bytes());
-        hasher.update(b"\0");
-        match value_hash {
-            Some(h) => hasher.update(h.as_bytes()),
-            None => hasher.update(b"unset"),
-        };
-        hasher.update(b"\0");
-    }
-    ArtifactKey(ContentHash::from_bytes(*hasher.finalize().as_bytes()))
 }

--- a/crates/zccache-depgraph/src/context/rustc_keys.rs
+++ b/crates/zccache-depgraph/src/context/rustc_keys.rs
@@ -1,0 +1,165 @@
+//! Rustc artifact and verdict key computation.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use zccache_hash::ContentHash;
+
+use super::{normalize_key_path, ArtifactKey, ContextKey};
+
+/// Compute the artifact key for a rustc compilation.
+///
+/// Like `compute_artifact_key` for C/C++, but also incorporates
+/// extern crate content hashes (analogous to header content hashes).
+pub fn compute_rustc_artifact_key<P: AsRef<Path> + Ord>(
+    context_key: &ContextKey,
+    file_hashes: &mut [(P, ContentHash)],
+    extern_hashes: &mut [(String, ContentHash)],
+) -> ArtifactKey {
+    compute_rustc_artifact_key_with_root(context_key, file_hashes, extern_hashes, None)
+}
+
+/// Compute the result-verdict key for a rustc artifact.
+///
+/// Output bytes are keyed only by compiler inputs. Diagnostics and exit
+/// status live behind this second key so a Dylint invocation cannot consume
+/// a plain rustc verdict (or vice versa) while both may share identical
+/// artifact bytes.
+#[must_use]
+pub fn compute_rustc_verdict_key(
+    artifact_key_hex: &str,
+    dylint_input_hash: Option<&str>,
+) -> ArtifactKey {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"zccache-rustc-verdict-key-v1\0");
+    hasher.update(artifact_key_hex.as_bytes());
+    hasher.update(b"\0mode\0");
+    match dylint_input_hash {
+        Some(hash) => {
+            hasher.update(b"dylint\0");
+            hasher.update(hash.as_bytes());
+        }
+        None => {
+            hasher.update(b"plain");
+        }
+    };
+    ArtifactKey(ContentHash::from_bytes(*hasher.finalize().as_bytes()))
+}
+
+/// Compute the rustc artifact key, optionally normalizing project-local files.
+///
+/// When `key_root` is provided, source and dependency file paths under that
+/// root are hashed relative to it. Extern hashes remain keyed by crate name.
+pub fn compute_rustc_artifact_key_with_root<P: AsRef<Path> + Ord>(
+    context_key: &ContextKey,
+    file_hashes: &mut [(P, ContentHash)],
+    extern_hashes: &mut [(String, ContentHash)],
+    key_root: Option<&Path>,
+) -> ArtifactKey {
+    compute_rustc_artifact_key_with_root_with(
+        context_key,
+        file_hashes,
+        extern_hashes,
+        key_root,
+        |path, key_root| normalize_key_path(path, key_root).into(),
+    )
+}
+
+/// Like [`compute_rustc_artifact_key_with_root`] but the per-header path
+/// normalization is delegated to a caller-supplied closure. Used by the
+/// daemon's rustc miss/update paths to consult
+/// `DepGraph::cached_normalize_key_path` for the per-header allocation
+/// amortization (issue #550).
+pub fn compute_rustc_artifact_key_with_root_with<P, F>(
+    context_key: &ContextKey,
+    file_hashes: &mut [(P, ContentHash)],
+    extern_hashes: &mut [(String, ContentHash)],
+    key_root: Option<&Path>,
+    mut normalize: F,
+) -> ArtifactKey
+where
+    P: AsRef<Path> + Ord,
+    F: FnMut(&Path, Option<&Path>) -> Arc<str>,
+{
+    // Issue #571: pre-normalize each path once (O(n) via the cached
+    // closure), then sort on the cached Arc<str> keys (O(n log n) byte
+    // compares). The previous shape called `normalize` twice per
+    // sort-comparison AND once per hash-loop entry — 3 calls per
+    // element. With ~600 transitive headers per cpp/rust compile,
+    // this collapses ~10k normalize calls into ~600. Hash output is
+    // bit-identical: same sort order, same blake3 input bytes.
+    let mut indexed: Vec<(Arc<str>, ContentHash)> = file_hashes
+        .iter()
+        .map(|(p, h)| (normalize(p.as_ref(), key_root), *h))
+        .collect();
+    indexed.sort_by(|a, b| a.0.cmp(&b.0));
+    extern_hashes.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"zccache-rustc-artifact-key-v1\0");
+    hasher.update(context_key.0.as_bytes());
+    hasher.update(b"\0");
+
+    // Source + dependency file hashes.
+    for (path_key, hash) in &indexed {
+        hasher.update(path_key.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(hash.as_bytes());
+        hasher.update(b"\0");
+    }
+
+    // Extern crate content hashes.
+    hasher.update(b"externs\0");
+    for (name, hash) in extern_hashes.iter() {
+        hasher.update(name.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(hash.as_bytes());
+        hasher.update(b"\0");
+    }
+
+    ArtifactKey(ContentHash::from_bytes(*hasher.finalize().as_bytes()))
+}
+
+/// Fold rustc env-dep values into an already-computed rustc artifact key
+/// (zccache#1021).
+///
+/// rustc records every `env!()`/`option_env!()` read as a
+/// `# env-dep:NAME[=value]` line in its dep-info. The values are compile
+/// inputs exactly like extern rlib bytes: `cargo:rustc-env` vars (vergen's
+/// `VERGEN_GIT_SHA` and friends) change without any argv/source change,
+/// and serving the old artifact ships the stale value inside the rlib.
+///
+/// Layered on top of the base key rather than folded inside it so that
+/// contexts with **no** recorded env-deps (the overwhelmingly common
+/// case) keep byte-identical artifact keys with prior releases — no cache
+/// invalidation for env-free crates.
+///
+/// `env_hashes` entries are `(name, value_hash)` where `None` means the
+/// variable was **unset** at read time (`option_env!` → `None`) — a
+/// distinct variant from every set value. Entries are sorted by name for
+/// determinism.
+#[must_use]
+pub fn fold_rustc_env_deps_into_artifact_key(
+    base: ArtifactKey,
+    env_hashes: &mut [(String, Option<ContentHash>)],
+) -> ArtifactKey {
+    if env_hashes.is_empty() {
+        return base;
+    }
+    env_hashes.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"zccache-rustc-env-deps-v1\0");
+    hasher.update(base.0.as_bytes());
+    hasher.update(b"\0");
+    for (name, value_hash) in env_hashes.iter() {
+        hasher.update(name.as_bytes());
+        hasher.update(b"\0");
+        match value_hash {
+            Some(h) => hasher.update(h.as_bytes()),
+            None => hasher.update(b"unset"),
+        };
+        hasher.update(b"\0");
+    }
+    ArtifactKey(ContentHash::from_bytes(*hasher.finalize().as_bytes()))
+}

--- a/crates/zccache-depgraph/src/context/tests/rustc.rs
+++ b/crates/zccache-depgraph/src/context/tests/rustc.rs
@@ -9,7 +9,8 @@ use crate::rustc_args::{parse_rustc_args, ExternCrate, RustcParsedArgs};
 use zccache_core::NormalizedPath;
 
 use super::super::{
-    compute_rustc_artifact_key, compute_rustc_artifact_key_with_root, RustcCompileContext,
+    compute_rustc_artifact_key, compute_rustc_artifact_key_with_root, compute_rustc_verdict_key,
+    RustcCompileContext,
 };
 use super::{make_context, make_rustc_context, make_rustc_context_with_env, test_compiler_hash};
 
@@ -584,12 +585,35 @@ fn rustc_from_parsed_args_drops_cargo_target_dir() {
         ctx.env_vars
     );
     assert!(
-        ctx.env_vars
+        !ctx.env_vars
             .iter()
             .any(|(k, _)| k == "ZCCACHE_DYLINT_CACHE_INPUT_HASH"),
-        "from_parsed_args must keep the internal Dylint cache salt; got {:?}",
+        "the Dylint verdict salt must not enter artifact identity; got {:?}",
         ctx.env_vars
     );
+}
+
+#[test]
+fn rustc_dylint_hash_selects_verdict_without_rekeying_artifact_context() {
+    let plain = make_rustc_context_with_env(Vec::new());
+    let dylint_a = make_rustc_context_with_env(vec![(
+        "ZCCACHE_DYLINT_CACHE_INPUT_HASH".into(),
+        "lint-a".into(),
+    )]);
+    let dylint_b = make_rustc_context_with_env(vec![(
+        "ZCCACHE_DYLINT_CACHE_INPUT_HASH".into(),
+        "lint-b".into(),
+    )]);
+
+    assert_eq!(plain.context_key(), dylint_a.context_key());
+    assert_eq!(dylint_a.context_key(), dylint_b.context_key());
+
+    let artifact = "0707070707070707070707070707070707070707070707070707070707070707";
+    let plain_verdict = compute_rustc_verdict_key(artifact, None);
+    let dylint_a_verdict = compute_rustc_verdict_key(artifact, Some("lint-a"));
+    let dylint_b_verdict = compute_rustc_verdict_key(artifact, Some("lint-b"));
+    assert_ne!(plain_verdict, dylint_a_verdict);
+    assert_ne!(dylint_a_verdict, dylint_b_verdict);
 }
 
 /// T3 — Negative control: `CARGO_PKG_VERSION` MUST still affect the key

--- a/crates/zccache-depgraph/src/lib.rs
+++ b/crates/zccache-depgraph/src/lib.rs
@@ -26,8 +26,9 @@ pub(crate) use zccache_platform as platform;
 pub use args::{ParsedArgs, UserDepFlags};
 pub use compile_commands::{parse_compile_commands_json, CompileCommand};
 pub use context::{
-    compute_artifact_key, compute_rustc_artifact_key, fold_rustc_env_deps_into_artifact_key,
-    ArtifactKey, CompileContext, ContextKey, RustcCompileContext,
+    compute_artifact_key, compute_rustc_artifact_key, compute_rustc_verdict_key,
+    fold_rustc_env_deps_into_artifact_key, ArtifactKey, CompileContext, ContextKey,
+    RustcCompileContext,
 };
 pub use depfile::{prepare_depfile, prepare_depfile_with_mmd, DepfileError, DepfileStrategy};
 pub use graph::{hash_env_dep_value, CacheVerdict, ContextState, DepGraph, DepGraphStats};

--- a/crates/zccache/tests/daemon_dylint_cache_test.rs
+++ b/crates/zccache/tests/daemon_dylint_cache_test.rs
@@ -324,6 +324,134 @@ async fn nested_dylint_hits_and_invalidates_every_external_input() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "integration-level: starts a real daemon and rustc"]
+async fn plain_and_dylint_share_artifact_bytes_but_not_verdicts() {
+    let Some(rustc) = zccache::test_support::find_rustc() else {
+        eprintln!("skipping test: rustc not found");
+        return;
+    };
+
+    zccache::test_support::test_timeout(async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        let _cache_env = CacheDirEnvGuard::set(&cache);
+        let driver = tmp.path().join("dylint-driver");
+        let library = tmp.path().join("libworkspace_lint.so");
+        let source = tmp.path().join("lib.rs");
+        let output = tmp.path().join("libchecked.rlib");
+        write_driver(&driver, "workspace lint verdict");
+        std::fs::write(&library, b"lint-library").unwrap();
+        std::fs::write(&source, "pub fn checked() -> u32 { 42 }\n").unwrap();
+
+        let plain_args = vec![
+            "--edition=2021".to_string(),
+            "--crate-type=lib".to_string(),
+            "--crate-name=checked".to_string(),
+            "--emit=link".to_string(),
+            source.display().to_string(),
+            "-o".to_string(),
+            output.display().to_string(),
+        ];
+        let mut dylint_args = vec![rustc.display().to_string()];
+        dylint_args.extend(plain_args.clone());
+        let dylint_libs = serde_json::to_string(&vec![library]).unwrap();
+
+        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let session_log = tmp.path().join("session.log");
+        let session_id = start_session(&mut client, Some(session_log.clone().into())).await;
+
+        let plain_miss = compile(
+            &mut client,
+            &session_id,
+            &rustc,
+            &plain_args,
+            tmp.path(),
+            "[]",
+            "plain",
+            false,
+        )
+        .await;
+        assert_eq!(plain_miss.0, 0);
+        assert!(!plain_miss.1);
+        assert!(!String::from_utf8_lossy(&plain_miss.3).contains("workspace lint verdict"));
+
+        std::fs::remove_file(&output).unwrap();
+        let dylint_miss = compile(
+            &mut client,
+            &session_id,
+            &driver,
+            &dylint_args,
+            tmp.path(),
+            &dylint_libs,
+            "lint-metadata",
+            false,
+        )
+        .await;
+        assert_eq!(dylint_miss.0, 0);
+        assert!(
+            !dylint_miss.1,
+            "a plain artifact must not satisfy a missing Dylint verdict"
+        );
+        assert!(String::from_utf8_lossy(&dylint_miss.3).contains("workspace lint verdict"));
+
+        std::fs::remove_file(&output).unwrap();
+        let dylint_hit = compile(
+            &mut client,
+            &session_id,
+            &driver,
+            &dylint_args,
+            tmp.path(),
+            &dylint_libs,
+            "lint-metadata",
+            false,
+        )
+        .await;
+        assert!(dylint_hit.1);
+        assert_eq!(dylint_hit.3, dylint_miss.3);
+
+        std::fs::remove_file(&output).unwrap();
+        let plain_hit = compile(
+            &mut client,
+            &session_id,
+            &rustc,
+            &plain_args,
+            tmp.path(),
+            "[]",
+            "plain",
+            false,
+        )
+        .await;
+        assert!(plain_hit.1);
+        assert!(
+            !String::from_utf8_lossy(&plain_hit.3).contains("workspace lint verdict"),
+            "plain hits must replay the plain verdict, never Dylint diagnostics"
+        );
+
+        let log = std::fs::read_to_string(session_log).unwrap();
+        let update_keys = log
+            .lines()
+            .filter(|line| line.contains("[DIAG] update:"))
+            .filter_map(|line| line.split("artifact_key=").nth(1))
+            .filter_map(|tail| tail.split_whitespace().next())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            update_keys.len(),
+            2,
+            "plain and Dylint should each run once"
+        );
+        assert_eq!(
+            update_keys[0], update_keys[1],
+            "plain and Dylint misses must publish the same artifact-byte key"
+        );
+
+        shutdown.notify_one();
+        server_handle.await.unwrap();
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "integration-level: starts a real daemon and rustc"]
 async fn nested_dylint_hits_across_sibling_worktrees() {
     let Some(rustc) = zccache::test_support::find_rustc() else {
         eprintln!("skipping test: rustc not found");

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -578,3 +578,43 @@ Issue: https://github.com/zackees/zccache/issues/1419
 - GREEN: all 448 depgraph tests, six focused DWP tests, the ignored daemon
   integration build, formatting, diff checks, and warnings-denied Clippy pass.
 - clud-review: clean after ordered-key follow-up fixes (one reviewer).
+
+# #1361 separate Dylint artifact and verdict identity
+
+Issue: https://github.com/zackees/zccache/issues/1361
+
+- [x] Add RED coverage proving plain artifacts cannot satisfy a Dylint verdict.
+- [x] Remove the Dylint input hash from artifact and metadata-compat identity.
+- [x] Add a Dylint-keyed verdict layer that gates diagnostics and exit status.
+- [ ] Prove build/Dylint artifact sharing without skipped lint execution.
+- [x] Run focused tests, formatting, Clippy/checks, and the review gate.
+- [ ] Push, merge, and close #1361.
+
+## Review
+
+- RED: the Dylint input hash changed the rustc artifact context key, preventing
+  plain and linted invocations from sharing byte-identical outputs.
+- GREEN: rustc artifact identity excludes the Dylint hash; an embedded verdict
+  map keys stdout, stderr, and exit status by plain/Dylint identity and gates
+  materialization before any output is replayed.
+- Legacy index snapshots migrate with an empty verdict map, while malformed
+  current snapshots cannot fall back to the positional legacy decoder.
+- Missing verdicts are soft misses that preserve the shared artifact and its
+  depgraph entry; error verdict publication preserves existing output metadata
+  and follows the same ordered index-writer WAL as success publication.
+- Review follow-up: cached error verdicts now return before output payload
+  materialization, rehydrate staged-path markers in their diagnostic streams,
+  and replay byte-exact status/diagnostics without writing a sibling success
+  artifact to the destination.
+- Review follow-up: access checkpoints use timestamp-only WAL touches that
+  merge into the newest row, and cold commits merge durable output metadata
+  plus sibling verdicts before publication.
+- Repo hygiene: request validation, Dylint/time-macro setup, include discovery,
+  and invocation parsing moved into `pipeline/request_prep.rs`; both pipeline
+  modules are below the 1,000-line source ceiling.
+- GREEN: 104 active artifact tests (1 ignored), 449 depgraph tests, and 766
+  active daemon-core tests (25 ignored), plus focused merge/gating/loader
+  regressions, formatting, diff checks, and warnings-denied Clippy.
+- Pending: Unix ignored integration proof.
+- clud-review: clean after cached-error rehydration and panic-free split
+  follow-ups (one reviewer).


### PR DESCRIPTION
## Summary

- share byte-identical rustc outputs across plain and Dylint invocations while keying diagnostics and exit status by verdict identity
- migrate artifact indexes with backward-compatible verdict maps and preserve ordered, concurrency-safe WAL publication
- treat missing verdicts as soft misses and cached error verdicts as no-output responses with staged-path rehydration
- bump the Rust context-key domain and split the compile pipeline/context modules under repository size limits

Fixes #1361

## Validation

- `soldr cargo test -p zccache-artifact` (104 passed, 1 ignored)
- `soldr cargo test -p zccache-daemon-core --features test-support` (766 passed, 25 ignored)
- focused verdict, WAL touch, durable merge, and deferred-loader regressions
- `soldr cargo clippy -p zccache-artifact -p zccache-daemon-core --all-targets --features zccache-daemon-core/test-support -- -D warnings`
- `soldr cargo fmt --all` and `git diff --check`
- clud-review clean after follow-ups

## Hosted proof

The Unix-only ignored Dylint sharing integration test is intentionally left for hosted Linux CI before merge.