### PR TITLE
test(cli): serialize cargo-registry env overrides

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/cargo_registry.rs
+++ b/crates/zccache-cli-core/src/cli/commands/cargo_registry.rs
@@ -233,13 +233,57 @@ pub(crate) fn cmd_cargo_registry_clean() -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::{OsStr, OsString};
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvRestore(Vec<(&'static str, Option<OsString>)>);
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            for (var, previous) in self.0.drain(..).rev() {
+                // SAFETY: every test in this module that reads or writes these
+                // process-global variables holds `ENV_LOCK` for the full scope.
+                unsafe {
+                    match previous {
+                        Some(value) => std::env::set_var(var, value),
+                        None => std::env::remove_var(var),
+                    }
+                }
+            }
+        }
+    }
+
+    fn with_env_overrides<F: FnOnce()>(overrides: &[(&'static str, Option<&OsStr>)], f: F) {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let previous = overrides
+            .iter()
+            .map(|(var, _)| (*var, std::env::var_os(var)))
+            .collect();
+        let _restore = EnvRestore(previous);
+
+        for (var, value) in overrides {
+            // SAFETY: `ENV_LOCK` serializes every test-local access to these
+            // process-global variables, and `EnvRestore` restores them on unwind.
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(var, value),
+                    None => std::env::remove_var(var),
+                }
+            }
+        }
+        f();
+    }
 
     #[test]
     fn cargo_registry_command_uses_core_cache_layout() {
-        assert_eq!(
-            cargo_registry_cache_dir(),
-            crate::core::config::cargo_registry_cache_dir()
-        );
+        with_env_overrides(&[], || {
+            assert_eq!(
+                cargo_registry_cache_dir(),
+                crate::core::config::cargo_registry_cache_dir()
+            );
+        });
     }
 
     /// Process-shared env-var helper. The save fn reads
@@ -247,22 +291,8 @@ mod tests {
     /// below toggle it and must not race each other.
     fn with_skip_env<F: FnOnce()>(set: bool, f: F) {
         let var = "SOLDR_SKIP_CARGO_REGISTRY_SAVE";
-        let prev = std::env::var_os(var);
-        // SAFETY: documented in test-local guard; restored below.
-        unsafe {
-            if set {
-                std::env::set_var(var, "1");
-            } else {
-                std::env::remove_var(var);
-            }
-        }
-        f();
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var(var, v),
-                None => std::env::remove_var(var),
-            }
-        }
+        let value = set.then_some(OsStr::new("1"));
+        with_env_overrides(&[(var, value)], f);
     }
 
     /// `--output` suppresses the `SOLDR_SKIP_CARGO_REGISTRY_SAVE` skip:
@@ -305,13 +335,11 @@ mod tests {
     #[test]
     fn default_path_still_respects_soldr_skip_env() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        // Redirect zccache's cache root into the tempdir so the test
-        // does not touch the real home directory if the save WERE to
-        // run (it should not, per the env var).
-        let prev_cache_dir = std::env::var_os("ZCCACHE_CACHE_DIR");
-        unsafe { std::env::set_var("ZCCACHE_CACHE_DIR", tmp.path()) };
-
-        with_skip_env(true, || {
+        let overrides = [
+            ("ZCCACHE_CACHE_DIR", Some(tmp.path().as_os_str())),
+            ("SOLDR_SKIP_CARGO_REGISTRY_SAVE", Some(OsStr::new("1"))),
+        ];
+        with_env_overrides(&overrides, || {
             let _ = cmd_cargo_registry_save("noop-key", None, None);
             // The skip path returns before touching the disk, so no
             // archive should appear anywhere under the redirected root.
@@ -322,13 +350,20 @@ mod tests {
                 "skip path must not write any .gz archive; found: {stray:?}"
             );
         });
+    }
 
-        unsafe {
-            match prev_cache_dir {
-                Some(v) => std::env::set_var("ZCCACHE_CACHE_DIR", v),
-                None => std::env::remove_var("ZCCACHE_CACHE_DIR"),
-            }
-        }
+    #[test]
+    fn env_overrides_restore_after_panic() {
+        let var = "ZCCACHE_TEST_CARGO_REGISTRY_ENV_RESTORE";
+        let before = std::env::var_os(var);
+        let result = std::panic::catch_unwind(|| {
+            with_env_overrides(&[(var, Some(OsStr::new("panic-sentinel")))], || {
+                panic!("exercise unwind restoration");
+            });
+        });
+
+        assert!(result.is_err());
+        assert_eq!(std::env::var_os(var), before);
     }
 
     /// Shallow recursive walk for tests — avoid adding a `walkdir` dep

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -708,3 +708,25 @@ Issue: https://github.com/zackees/zccache/issues/1422
   emitted its listening marker.
 - GREEN target: use one named 30-second startup budget for dormant and active
   daemon log readiness while retaining the short negative TCP probe.
+
+# #1423 serialize cargo-registry test environment
+
+Issue: https://github.com/zackees/zccache/issues/1423
+
+- [x] Reproduce the cache-layout failure in the default parallel CLI suite.
+- [x] Serialize cargo-registry test environment reads and writes.
+- [x] Restore overrides during unwinding and cover the panic path.
+- [x] Run the full CLI suite, formatting, Clippy, and the review gate.
+- [ ] Push, merge, close #1423, and verify hosted CI.
+
+## Review
+
+- RED: the default parallel CLI suite observed the real cache root while a
+  sibling test temporarily installed a test `ZCCACHE_CACHE_DIR`; 258 passed,
+  one failed, and two were ignored. The failing assertion passed alone.
+- GREEN: one module-wide lock covers both environment variables and every
+  participating read; an RAII guard restores prior values during unwinding.
+- Focused GREEN: all four cargo-registry tests pass with 16 test threads.
+- Full GREEN: 258 CLI tests pass with two ignored; formatting, diff checks,
+  and repository-policy Clippy pass with only three unrelated baseline warnings.
+- clud-review: clean (one reviewer).


### PR DESCRIPTION
Fixes #1423.

## Summary
- serialize cargo-registry tests that read or mutate process-global cache/skip environment variables
- restore every overridden value with an RAII guard before releasing the shared lock, including during panic unwinding
- add an explicit unwind-restoration regression and record the burn-down evidence

## Validation
- RED: `soldr cargo test -p zccache-cli-core --lib --features cli` failed in `cargo_registry_command_uses_core_cache_layout` when a sibling test temporarily set `ZCCACHE_CACHE_DIR`; 258 passed, 1 failed, 2 ignored
- isolated control: the failing assertion passed alone
- focused GREEN: `soldr cargo test -p zccache-cli-core --lib --features cli cli::commands::cargo_registry::tests -- --test-threads=16` (4 passed)
- full GREEN: `soldr cargo test -p zccache-cli-core --lib --features cli` (258 passed, 2 ignored)
- `soldr cargo clippy -p zccache-cli-core --all-targets --features cli` (passed under repository policy; three unrelated baseline warnings)
- `soldr cargo fmt --all -- --check`
- `git diff --check`
- `/clud-review` clean