### PR TITLE
perf: restore current C++ gates (#1025)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/request_prep.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/request_prep.rs
@@ -68,7 +68,7 @@ pub(super) async fn prepare_request_arguments(
         .map_err(|err| compile_failure_stderr(format!("zccache: {err}")))?;
     let worktree_root = compile_worktree_root(state, &sid, cwd, client_env.as_deref());
     let effective_args = effective_compile_args(
-        &expanded_args,
+        expanded_args,
         compiler_path,
         cwd,
         worktree_root.as_ref(),

--- a/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_link.rs
@@ -4,41 +4,6 @@ use super::link_hash::*;
 use super::link_process::*;
 use super::*;
 
-fn publish_and_materialize_staged_link(
-    state: &SharedState,
-    plan: &StagedCompilePlan,
-    key: &str,
-    metadata: ArtifactIndex,
-    sources: &[NormalizedPath],
-) -> std::io::Result<bool> {
-    let publication = publish_artifact_paths_observed(state, key, metadata, sources);
-    let salvage_reason = publication.as_ref().err().map(|reason| reason.id());
-    materialize_link_plan_observed(state, plan, salvage_reason)?;
-    Ok(publication.is_ok())
-}
-
-fn with_link_warning(result: Response, warning: Option<String>) -> Response {
-    match (result, warning) {
-        (
-            Response::LinkResult {
-                exit_code,
-                stdout,
-                stderr,
-                cached,
-                ..
-            },
-            warning @ Some(_),
-        ) => Response::LinkResult {
-            exit_code,
-            stdout,
-            stderr,
-            cached,
-            warning,
-        },
-        (result, _) => result,
-    }
-}
-
 /// Handle a single-roundtrip ephemeral link/archive request.
 ///
 /// Parses the tool invocation, computes a cache key from the tool binary and
@@ -52,17 +17,12 @@ pub(super) async fn handle_link_ephemeral(
     env: Option<Vec<(String, String)>>,
 ) -> Response {
     let _active_request = state.begin_cache_request();
-    // Issue #535: collect phase counters when `ZCCACHE_PROFILE_CC_MISS` is set
-    // so the bench / perf-guard logs carry breakdown data for cold link/
-    // archive operations (c-static-library-link, cpp-driver-link).
+    // Emit hosted cold link/archive phase profiles when requested (#535).
     let profile_enabled = std::env::var_os(CC_MISS_PROFILE_ENV).is_some();
     let link_start = std::time::Instant::now();
     let mut output_read_ns = 0;
     let mut artifact_store_ns = 0;
     let lineage = super::super::lineage::Lineage::current(Some(client_pid), None);
-    use crate::compiler::parse_archiver::{parse_archive_invocation, ParsedArchiveInvocation};
-    use crate::compiler::parse_linker::{parse_linker_invocation, ParsedLinkerInvocation};
-
     state.stats.record_link();
     let worktree_root = resolve_worktree_root(cwd, env.as_deref());
     let link_path_remap_key_root = if path_remap_auto_enabled(env.as_deref()) {
@@ -71,92 +31,33 @@ pub(super) async fn handle_link_ephemeral(
         None
     };
 
-    // 1. Parse the tool invocation — try archiver first, then linker
-    struct ParsedTool {
-        input_files: Vec<NormalizedPath>,
-        output_file: NormalizedPath,
-        secondary_outputs: Vec<NormalizedPath>,
-        cache_relevant_flags: Vec<String>,
-        non_deterministic: bool,
-        non_determinism_hint: String,
-        // True iff parsed as a pure archiver invocation (ar, lib, llvm-ar).
-        // Archive tools only bundle their declared inputs into the output
-        // archive — they never deploy runtime DLLs, PDBs, or other side-effect
-        // files alongside the output. The pre-link `snapshot_directory` and
-        // post-link `detect_side_effects` work is wasted for archive cold-misses.
-        is_archive: bool,
-        output_kind: crate::compiler::parse_linker::LinkOutputKind,
-    }
-
-    let parsed_tool = match parse_archive_invocation(tool.to_str().unwrap_or(""), args) {
-        ParsedArchiveInvocation::Cacheable(c) => ParsedTool {
-            non_determinism_hint: match c.family {
-                crate::compiler::parse_archiver::ArchiverFamily::MsvcLib => "/BREPRO".to_string(),
-                _ => "D".to_string(),
-            },
-            input_files: c.input_files,
-            output_file: c.output_file,
-            secondary_outputs: Vec::new(),
-            cache_relevant_flags: c.cache_relevant_flags,
-            non_deterministic: c.non_deterministic,
-            is_archive: true,
-            output_kind: crate::compiler::parse_linker::LinkOutputKind::File,
-        },
-        ParsedArchiveInvocation::NonCacheable { reason: ar_reason } => {
-            // Try linker parser
-            match parse_linker_invocation(tool.to_str().unwrap_or(""), args.to_vec()) {
-                ParsedLinkerInvocation::Cacheable(c) => ParsedTool {
-                    non_determinism_hint: match c.family {
-                        crate::compiler::parse_linker::LinkerFamily::MsvcLink => {
-                            "/DETERMINISTIC".to_string()
-                        }
-                        crate::compiler::parse_linker::LinkerFamily::Dsymutil => {
-                            "deterministic input debug information".to_string()
-                        }
-                        _ => "--build-id=sha1 (avoid --build-id=uuid)".to_string(),
-                    },
-                    input_files: c.input_files,
-                    output_file: c.output_file,
-                    secondary_outputs: c.secondary_outputs,
-                    cache_relevant_flags: c.cache_relevant_flags,
-                    non_deterministic: c.non_deterministic,
-                    is_archive: false,
-                    output_kind: c.output_kind,
-                },
-                ParsedLinkerInvocation::NonCacheable {
-                    reason: link_reason,
-                } => {
-                    tracing::debug!(
-                        ar_reason = %ar_reason,
-                        link_reason = %link_reason,
-                        "link non-cacheable, passing through"
-                    );
-                    state.stats.record_link_non_cacheable();
-                    return run_tool_passthrough(
-                        tool,
-                        args,
-                        cwd,
-                        env,
-                        &lineage,
-                        state.depfile_tmpdir.as_path(),
-                    )
-                    .await;
-                }
-            }
+    // 1. Parse the tool invocation — try archiver first, then linker.
+    let parsed_tool = match parse_link_tool(tool, args) {
+        ParseLinkToolOutcome::Cacheable(parsed) => parsed,
+        ParseLinkToolOutcome::NonCacheable {
+            archive_reason,
+            link_reason,
+        } => {
+            tracing::debug!(
+                %archive_reason,
+                %link_reason,
+                "link non-cacheable, passing through"
+            );
+            state.stats.record_link_non_cacheable();
+            return run_tool_passthrough(
+                tool,
+                args,
+                cwd,
+                env,
+                &lineage,
+                state.depfile_tmpdir.as_path(),
+            )
+            .await;
         }
     };
 
-    // 2. Non-determinism check: warn but still cache
-    let nd_warning = if parsed_tool.non_deterministic {
-        let w = format!(
-            "non-deterministic invocation (missing {} flag) — output is cached but may differ from a fresh link",
-            parsed_tool.non_determinism_hint
-        );
-        tracing::warn!(%w);
-        Some(w)
-    } else {
-        None
-    };
+    // 2. Non-determinism check: warn but still cache.
+    let nd_warning = link_non_determinism_warning(&parsed_tool);
 
     let parse_args_ns = if profile_enabled {
         link_start.elapsed().as_nanos() as u64
@@ -164,13 +65,7 @@ pub(super) async fn handle_link_ephemeral(
         0
     };
 
-    // 3+4. Hash tool binary and input files concurrently via rayon::join
-    // (issue #566). Both phases are file reads plus CPU-bound blake3 work.
-    // Before this overlap, they ran strictly sequentially —
-    // `tool_hash` (~150 MB rustc binary, 10–20 ms) blocked the start of
-    // input hashing (50 .rlibs in parallel via #564, also 5–15 ms wall).
-    // `rayon::join` reduces the combined wall-clock to ~max(tool_hash,
-    // input_hashes) instead of the prior sum.
+    // 3+4. Hash the tool and inputs concurrently; both are file/CPU bound.
     let tool_path = std::path::Path::new(tool);
     let cwd_path = std::path::Path::new(cwd);
 
@@ -193,31 +88,23 @@ pub(super) async fn handle_link_ephemeral(
         })
         .collect();
 
-    // Pure archives can safely run against an isolated staged output while
-    // their strong cache key is discovered. Restrict speculation to requests
-    // with at least one absent metadata-cache hash: established warm hits keep
-    // the existing 1 ms path and never launch the tool. A staged result is
-    // discarded if strong key discovery still finds an artifact cache hit.
+    // Only cold pure archives may execute while their strong key is discovered;
+    // warm hits never launch the tool, and cache hits discard the staged result.
     let output_path = if parsed_tool.output_file.is_absolute() {
         parsed_tool.output_file.clone()
     } else {
         cwd_path.join(&parsed_tool.output_file).into()
     };
     let output_dir = output_path.parent().unwrap_or(cwd_path);
-    // Inputs which reside directly in the output directory are declared by
-    // the linker invocation, so they cannot be implicit output side effects.
-    // Skip them in both directory scans. This avoids re-hashing every object
-    // around a large driver link while retaining full coverage of undeclared
-    // sibling files (DLLs, PDBs, wrapper-deployed runtimes, etc.).
+    // Exclude declared sibling inputs from implicit-output scans while still
+    // covering undeclared DLLs, PDBs, and wrapper-deployed runtimes.
     let sibling_input_names: std::collections::HashSet<std::ffi::OsString> = inputs
         .iter()
         .filter(|input| input.as_path().parent() == Some(output_dir))
         .filter_map(|input| input.file_name().map(std::ffi::OsStr::to_os_string))
         .collect();
 
-    // A cache hit also writes the complete artifact set into the output
-    // directory. It must therefore share the same exclusion window as a cold
-    // link's snapshot/link/capture sequence.
+    // Hits share the cold link's output-directory exclusion window.
     let _side_effect_guard = if parsed_tool.is_archive {
         None
     } else {
@@ -228,8 +115,8 @@ pub(super) async fn handle_link_ephemeral(
                 .await,
         )
     };
-    let archive_hash_speculating =
-        parsed_tool.is_archive && archive_hash_cache_is_cold(state, tool_path, &inputs);
+    let hash_cache_is_cold = link_hash_cache_is_cold(state, tool_path, &inputs);
+    let archive_hash_speculating = parsed_tool.is_archive && hash_cache_is_cold;
     let mut speculative_archive_plan = None;
     if archive_hash_speculating {
         use crate::daemon::staged_stats::{StagedCounter, StagedTiming};
@@ -269,48 +156,69 @@ pub(super) async fn handle_link_ephemeral(
         }
     }
 
-    let (hashes, mut speculative_archive) = if let Some(plan) = speculative_archive_plan {
-        let hash_state = Arc::clone(state);
-        let hash_tool = tool.to_path_buf();
-        let hash_inputs = inputs.clone();
-        let hash_task = tokio::task::spawn_blocking(move || {
-            hash_link_inputs(&hash_state, &hash_tool, &hash_inputs, profile_enabled)
-        });
-        let process_started = std::time::Instant::now();
-        let archive = async {
-            let result = run_archive_tool_passthrough(
-                tool,
-                &plan.rewritten_args,
-                cwd,
-                env.clone(),
-                &lineage,
+    let (hashes, mut speculative_archive, mut prepared_link_miss) =
+        if let Some(plan) = speculative_archive_plan {
+            let hash_state = Arc::clone(state);
+            let hash_tool = tool.to_path_buf();
+            let hash_inputs = inputs.clone();
+            let hash_task = tokio::task::spawn_blocking(move || {
+                hash_link_inputs(&hash_state, &hash_tool, &hash_inputs, profile_enabled)
+            });
+            let process_started = std::time::Instant::now();
+            let archive = async {
+                let result = run_archive_tool_passthrough(
+                    tool,
+                    &plan.rewritten_args,
+                    cwd,
+                    env.clone(),
+                    &lineage,
+                )
+                .await;
+                (result, process_started.elapsed().as_nanos() as u64)
+            };
+            let ((result, process_ns), hash_result) = tokio::join!(archive, hash_task);
+            let hashes = match hash_result {
+                Ok(hashes) => hashes,
+                Err(error) => {
+                    let _ = plan.cleanup();
+                    tracing::warn!(%error, "archive hash task failed; retrying without cache");
+                    return run_archive_tool_passthrough(tool, args, cwd, env, &lineage).await;
+                }
+            };
+            (
+                hashes,
+                Some(CompletedSpeculativeArchive {
+                    plan,
+                    result,
+                    process_ns,
+                }),
+                None,
             )
-            .await;
-            (result, process_started.elapsed().as_nanos() as u64)
+        } else if should_prepare_link_miss_during_hash(parsed_tool.is_archive, hash_cache_is_cold) {
+            let (hashes, prepared) = rayon::join(
+                || hash_link_inputs(state, tool_path, &inputs, profile_enabled),
+                || {
+                    prepare_link_miss(LinkMissPreparationRequest {
+                        staging_dir: state.staging.path(),
+                        args,
+                        output_path: &output_path,
+                        secondary_outputs: &parsed_tool.secondary_outputs,
+                        cwd: cwd_path,
+                        is_directory_bundle: parsed_tool.output_kind
+                            == crate::compiler::parse_linker::LinkOutputKind::DirectoryBundle,
+                        output_dir,
+                        sibling_input_names: &sibling_input_names,
+                    })
+                },
+            );
+            (hashes, None, Some(prepared))
+        } else {
+            (
+                hash_link_inputs(state, tool_path, &inputs, profile_enabled),
+                None,
+                None,
+            )
         };
-        let ((result, process_ns), hash_result) = tokio::join!(archive, hash_task);
-        let hashes = match hash_result {
-            Ok(hashes) => hashes,
-            Err(error) => {
-                let _ = plan.cleanup();
-                tracing::warn!(%error, "archive hash task failed; retrying without cache");
-                return run_archive_tool_passthrough(tool, args, cwd, env, &lineage).await;
-            }
-        };
-        (
-            hashes,
-            Some(CompletedSpeculativeArchive {
-                plan,
-                result,
-                process_ns,
-            }),
-        )
-    } else {
-        (
-            hash_link_inputs(state, tool_path, &inputs, profile_enabled),
-            None,
-        )
-    };
     let hash_wall_ns = hashes.wall_ns;
     let tool_hash_ns = hashes.tool_ns;
     let input_hash_ns = hashes.inputs_ns;
@@ -512,16 +420,39 @@ pub(super) async fn handle_link_ephemeral(
             ),
             None => (None, None, None),
         };
+    let (
+        prepared_during_hash,
+        prepared_directory_plan_result,
+        prepared_staged_plan_result,
+        prepared_dir_snapshot_result,
+        prepared_planning_ns,
+    ) = match prepared_link_miss.take() {
+        Some(prepared) => (
+            true,
+            prepared.directory_plan_result,
+            prepared.staged_plan_result,
+            prepared.dir_snapshot_result,
+            prepared.planning_ns,
+        ),
+        None => (false, None, None, None, 0),
+    };
     use crate::daemon::staged_stats::{StagedBytes, StagedCounter, StagedFailure, StagedTiming};
     let planning_started = std::time::Instant::now();
     let plans_now = speculative_plan.is_none();
     if plans_now {
         state.profiler.staged.count(StagedCounter::PlanAttempted);
     }
-    let directory_plan_result = (parsed_tool.output_kind
-        == crate::compiler::parse_linker::LinkOutputKind::DirectoryBundle)
-        .then(|| StagedDirectoryPlan::dsymutil(state.staging.path(), args, &output_path, cwd_path));
-    let staged_plan_result =
+    let directory_plan_result = if prepared_during_hash {
+        prepared_directory_plan_result
+    } else {
+        (parsed_tool.output_kind == crate::compiler::parse_linker::LinkOutputKind::DirectoryBundle)
+            .then(|| {
+                StagedDirectoryPlan::dsymutil(state.staging.path(), args, &output_path, cwd_path)
+            })
+    };
+    let staged_plan_result = if prepared_during_hash {
+        prepared_staged_plan_result
+    } else {
         (speculative_plan.is_none() && directory_plan_result.is_none()).then(|| {
             if parsed_tool.is_archive && parsed_tool.secondary_outputs.is_empty() {
                 StagedCompilePlan::archive(state.staging.path(), args, &output_path, cwd_path)
@@ -534,11 +465,16 @@ pub(super) async fn handle_link_ephemeral(
                     cwd_path,
                 )
             }
-        });
+        })
+    };
     if plans_now {
         state.profiler.staged.timing(
             StagedTiming::Planning,
-            planning_started.elapsed().as_nanos() as u64,
+            if prepared_during_hash {
+                prepared_planning_ns
+            } else {
+                planning_started.elapsed().as_nanos() as u64
+            },
         );
     }
     let mut staged_plan = match (speculative_plan, staged_plan_result) {
@@ -596,29 +532,27 @@ pub(super) async fn handle_link_ephemeral(
         },
         |plan| plan.rewritten_args.clone(),
     );
-    // Snapshot the output directory before the link so we can detect
-    // side-effect files (e.g., runtime DLLs deployed by compiler wrappers).
-    // Issue #605 pass 1: archive tools (ar, lib, llvm-ar) only bundle their
-    // declared inputs into the output archive; they never deploy sibling
-    // side-effect files. Skip both pre-link snapshot and post-link rescan
-    // for archives — saves a `read_dir` + per-entry `stat` on every archive
-    // cold-miss.
+    // Snapshot before non-archive links to detect undeclared sibling outputs.
     let mut side_effects_cacheable = true;
     let mut side_effects_uncacheable_reason = None;
-    let dir_snapshot = if parsed_tool.is_archive || directory_plan.is_some() {
+    let dir_snapshot_result = if prepared_during_hash {
+        prepared_dir_snapshot_result
+    } else if parsed_tool.is_archive || directory_plan.is_some() {
         None
     } else {
-        match super::super::side_effect::snapshot_directory_excluding(
+        Some(super::super::side_effect::snapshot_directory_excluding(
             output_dir,
             &sibling_input_names,
-        ) {
-            Ok(snapshot) => Some(snapshot),
-            Err(error) => {
-                side_effects_cacheable = false;
-                side_effects_uncacheable_reason =
-                    Some(format!("failed to snapshot link output directory: {error}"));
-                None
-            }
+        ))
+    };
+    let dir_snapshot = match dir_snapshot_result {
+        None => None,
+        Some(Ok(snapshot)) => Some(snapshot),
+        Some(Err(error)) => {
+            side_effects_cacheable = false;
+            side_effects_uncacheable_reason =
+                Some(format!("failed to snapshot link output directory: {error}"));
+            None
         }
     };
 
@@ -671,12 +605,7 @@ pub(super) async fn handle_link_ephemeral(
         );
     }
 
-    // 6b. Invoke optional post-link deploy command on successful link.
-    // This handles the case where the compiler driver does NOT auto-deploy
-    // runtime DLLs (e.g. a native trampoline that skips the Python wrapper
-    // layer where clang-tool-chain's `post_link_dll_deployment` lives).
-    // The hook runs BEFORE the side-effect scan so scanning picks up
-    // whatever it deployed.
+    // Run the optional deploy hook before scanning for its sibling outputs.
     if directory_plan.is_none() {
         if let (Some(cmd), Response::LinkResult { exit_code: 0, .. }) = (&deploy_cmd, &result) {
             run_post_link_deploy_hook(cmd, &output_path, env_for_hook.as_deref(), &lineage).await;
@@ -753,10 +682,7 @@ pub(super) async fn handle_link_ephemeral(
             return with_link_warning(result, nd_warning);
         }
 
-        // Enumerate primary, declared secondaries, and detected side effects
-        // in cache-index order so `outputs[i]` maps to `{key}_i` on disk.
-        // Every entry must be captured successfully; partial artifacts are
-        // uncacheable. Declared names are excluded from implicit discovery.
+        // Preserve cache-index order; any partial capture is uncacheable.
         let primary_name_os = parsed_tool
             .output_file
             .file_name()
@@ -868,9 +794,7 @@ pub(super) async fn handle_link_ephemeral(
             ));
         }
 
-        // Read all output files; preserve order. Falls back to a serial
-        // loop when there's only the primary output — rayon dispatch cost
-        // (~150 µs) is comparable to one fs::read for small outputs.
+        // Read all output files in cache-index order.
         let output_read_started = profile_enabled.then(std::time::Instant::now);
         let reads: std::io::Result<Vec<ArtifactOutput>> = read_targets
             .iter()
@@ -909,9 +833,7 @@ pub(super) async fn handle_link_ephemeral(
             }
         };
 
-        // Primary read gates the cache populate. If it fails, the link
-        // succeeded but the output file is no longer readable — skip
-        // caching, same as the prior serial behavior.
+        // A successful link with unreadable outputs remains uncacheable.
         if let Some(outputs) = outputs {
             // Log side-effect captures (preserves prior tracing).
             let side_effect_start = 1 + parsed_tool.secondary_outputs.len();
@@ -929,20 +851,10 @@ pub(super) async fn handle_link_ephemeral(
             // Build CachedArtifact once (no deep copies — all Arc clones).
             let cached = CachedArtifact::from_artifact_data(&artifact);
 
-            // Persist to disk in background (meta.clone() is cheap — Arc fields only).
-            //
-            // Issue #296: hardlink each `read_targets` source path into the cache
-            // instead of re-writing the in-memory bytes. We still keep the
-            // resident `Bytes` payload in the in-memory cache to serve subsequent
-            // warm hits inline; the disk persist routes through
-            // `persist_artifact_paths` so the cold-miss disk-write count drops
-            // from 2 (compiler + cache) to 1 (compiler + hardlink). Cross-volume
-            // case falls back to `std::fs::copy` — identical to prior semantics.
+            // Persist source paths in the background via hardlink/copy (#296),
+            // retaining resident bytes for immediate warm hits.
             let artifact_store_started = profile_enabled.then(std::time::Instant::now);
-            // One owned guard covers both the live-map insert and disk/index
-            // publication. The exact same guard is transferred to detached
-            // work, avoiding the fair-RwLock self-deadlock caused by acquiring
-            // a second read while a writer is queued.
+            // Transfer one owned guard through live-map and disk/index publication.
             let Some(guard) = begin_artifact_publication(state).await else {
                 if let Some(plan) = staged_plan.as_ref() {
                     if let Err(error) = materialize_link_plan_observed(state, plan, None) {

--- a/crates/zccache-daemon-core/src/daemon/server/keys.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/keys.rs
@@ -308,45 +308,45 @@ pub(super) fn request_key_root(
 }
 
 pub(super) fn effective_compile_args(
-    expanded_args: &[String],
+    mut expanded_args: Vec<String>,
     compiler_path: &Path,
     cwd: &Path,
     worktree_root: Option<&NormalizedPath>,
     client_env: Option<&[(String, String)]>,
 ) -> Vec<String> {
     if !path_remap_auto_enabled(client_env) {
-        return expanded_args.to_vec();
+        return expanded_args;
     }
 
     let Some(root) = worktree_root else {
-        return expanded_args.to_vec();
+        return expanded_args;
     };
 
     let root_path = root.as_path();
     if compiler_is_rustc_like(compiler_path) {
-        if rust_args_have_remap_for_old(expanded_args, root_path) {
-            return expanded_args.to_vec();
+        if rust_args_have_remap_for_old(&expanded_args, root_path) {
+            return expanded_args;
         }
 
         let mut effective = Vec::with_capacity(expanded_args.len() + 2);
         if crate::compiler::is_dylint_driver(&compiler_path.to_string_lossy()) {
-            let Some((inner_rustc, rustc_args)) = expanded_args.split_first() else {
-                return expanded_args.to_vec();
+            if expanded_args.is_empty() {
+                return expanded_args;
             };
-            effective.push(inner_rustc.clone());
+            effective.push(expanded_args.remove(0));
             effective.push("--remap-path-prefix".to_string());
             effective.push(format!("{}=.", root_path.to_string_lossy()));
-            effective.extend_from_slice(rustc_args);
+            effective.append(&mut expanded_args);
             return effective;
         }
         effective.push("--remap-path-prefix".to_string());
         effective.push(format!("{}=.", root_path.to_string_lossy()));
-        effective.extend_from_slice(expanded_args);
+        effective.append(&mut expanded_args);
         return effective;
     }
 
     if !compiler_supports_ffile_prefix_map(compiler_path) {
-        return expanded_args.to_vec();
+        return expanded_args;
     }
 
     // Inject the three siblings together. Modern clang treats
@@ -363,27 +363,26 @@ pub(super) fn effective_compile_args(
 
     let mut auto_args = Vec::with_capacity(AUTO_PREFIX_MAP_FLAGS.len() * 2);
     for flag in AUTO_PREFIX_MAP_FLAGS {
-        if !has_cc_prefix_map_for_old(expanded_args, flag, root_path) {
+        if !has_cc_prefix_map_for_old(&expanded_args, flag, root_path) {
             auto_args.push(format!("{}={}=.", flag, root_path.to_string_lossy()));
         }
     }
 
     if !same_key_path(root_path, cwd) {
         for flag in AUTO_PREFIX_MAP_FLAGS {
-            if !has_cc_prefix_map_for_old(expanded_args, flag, cwd) {
+            if !has_cc_prefix_map_for_old(&expanded_args, flag, cwd) {
                 auto_args.push(format!("{}={}=.", flag, cwd.to_string_lossy()));
             }
         }
     }
 
     if auto_args.is_empty() {
-        return expanded_args.to_vec();
+        return expanded_args;
     }
 
-    let mut effective = Vec::with_capacity(auto_args.len() + expanded_args.len());
-    effective.extend(auto_args);
-    effective.extend_from_slice(expanded_args);
-    effective
+    auto_args.reserve(expanded_args.len());
+    auto_args.append(&mut expanded_args);
+    auto_args
 }
 
 pub(super) fn normalize_request_arg(arg: &str, key_root: Option<&Path>) -> String {

--- a/crates/zccache-daemon-core/src/daemon/server/link_hash.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/link_hash.rs
@@ -16,6 +16,25 @@ pub(super) struct LinkHashResults {
     pub(super) inputs_ns: u64,
 }
 
+pub(super) struct PreparedLinkMiss {
+    pub(super) directory_plan_result: Option<StagedPlanOutcome<StagedDirectoryPlan>>,
+    pub(super) staged_plan_result: Option<StagedPlanOutcome<StagedCompilePlan>>,
+    pub(super) dir_snapshot_result:
+        Option<std::io::Result<crate::daemon::side_effect::DirSnapshot>>,
+    pub(super) planning_ns: u64,
+}
+
+pub(super) struct LinkMissPreparationRequest<'a> {
+    pub(super) staging_dir: &'a Path,
+    pub(super) args: &'a [String],
+    pub(super) output_path: &'a NormalizedPath,
+    pub(super) secondary_outputs: &'a [NormalizedPath],
+    pub(super) cwd: &'a Path,
+    pub(super) is_directory_bundle: bool,
+    pub(super) output_dir: &'a Path,
+    pub(super) sibling_input_names: &'a std::collections::HashSet<std::ffi::OsString>,
+}
+
 pub(super) fn hash_link_inputs(
     state: &SharedState,
     tool: &Path,
@@ -60,7 +79,7 @@ pub(super) fn hash_link_inputs(
     }
 }
 
-pub(super) fn archive_hash_cache_is_cold(
+pub(super) fn link_hash_cache_is_cold(
     state: &SharedState,
     tool: &Path,
     inputs: &[NormalizedPath],
@@ -74,8 +93,60 @@ pub(super) fn archive_hash_cache_is_cold(
             .any(|input| metadata.get_cached_hash(input).is_none())
 }
 
+pub(super) fn should_prepare_link_miss_during_hash(
+    is_archive: bool,
+    hash_cache_is_cold: bool,
+) -> bool {
+    !is_archive && hash_cache_is_cold
+}
+
+pub(super) fn prepare_link_miss(request: LinkMissPreparationRequest<'_>) -> PreparedLinkMiss {
+    let LinkMissPreparationRequest {
+        staging_dir,
+        args,
+        output_path,
+        secondary_outputs,
+        cwd,
+        is_directory_bundle,
+        output_dir,
+        sibling_input_names,
+    } = request;
+    let planning_started = std::time::Instant::now();
+    let directory_plan_result = is_directory_bundle
+        .then(|| StagedDirectoryPlan::dsymutil(staging_dir, args, output_path, cwd));
+    let directory_plan_enabled = matches!(
+        directory_plan_result.as_ref(),
+        Some(StagedPlanOutcome::Enabled(_))
+    );
+    let staged_plan_result = directory_plan_result
+        .is_none()
+        .then(|| StagedCompilePlan::link(staging_dir, args, output_path, secondary_outputs, cwd));
+    let planning_ns = planning_started.elapsed().as_nanos() as u64;
+    let dir_snapshot_result = (!directory_plan_enabled).then(|| {
+        crate::daemon::side_effect::snapshot_directory_excluding(output_dir, sibling_input_names)
+    });
+    PreparedLinkMiss {
+        directory_plan_result,
+        staged_plan_result,
+        dir_snapshot_result,
+        planning_ns,
+    }
+}
+
 pub(super) fn discard_speculative_archive(speculative: &mut Option<CompletedSpeculativeArchive>) {
     if let Some(speculative) = speculative.take() {
         let _ = speculative.plan.cleanup();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_prepare_link_miss_during_hash;
+
+    #[test]
+    fn cold_non_archive_hash_prepares_link_miss_in_parallel() {
+        assert!(should_prepare_link_miss_during_hash(false, true));
+        assert!(!should_prepare_link_miss_during_hash(false, false));
+        assert!(!should_prepare_link_miss_during_hash(true, true));
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/link_helpers.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/link_helpers.rs
@@ -2,6 +2,94 @@
 
 use super::*;
 
+pub(super) struct ParsedLinkTool {
+    pub(super) input_files: Vec<NormalizedPath>,
+    pub(super) output_file: NormalizedPath,
+    pub(super) secondary_outputs: Vec<NormalizedPath>,
+    pub(super) cache_relevant_flags: Vec<String>,
+    pub(super) non_deterministic: bool,
+    pub(super) non_determinism_hint: String,
+    /// Pure archivers only bundle declared inputs; they do not deploy sibling
+    /// runtime files, so link side-effect scans are unnecessary.
+    pub(super) is_archive: bool,
+    pub(super) output_kind: crate::compiler::parse_linker::LinkOutputKind,
+}
+
+pub(super) enum ParseLinkToolOutcome {
+    Cacheable(ParsedLinkTool),
+    NonCacheable {
+        archive_reason: String,
+        link_reason: String,
+    },
+}
+
+pub(super) fn parse_link_tool(tool: &Path, args: &[String]) -> ParseLinkToolOutcome {
+    use crate::compiler::parse_archiver::{parse_archive_invocation, ParsedArchiveInvocation};
+    use crate::compiler::parse_linker::{parse_linker_invocation, ParsedLinkerInvocation};
+
+    match parse_archive_invocation(tool.to_str().unwrap_or(""), args) {
+        ParsedArchiveInvocation::Cacheable(parsed) => {
+            ParseLinkToolOutcome::Cacheable(ParsedLinkTool {
+                non_determinism_hint: match parsed.family {
+                    crate::compiler::parse_archiver::ArchiverFamily::MsvcLib => {
+                        "/BREPRO".to_string()
+                    }
+                    _ => "D".to_string(),
+                },
+                input_files: parsed.input_files,
+                output_file: parsed.output_file,
+                secondary_outputs: Vec::new(),
+                cache_relevant_flags: parsed.cache_relevant_flags,
+                non_deterministic: parsed.non_deterministic,
+                is_archive: true,
+                output_kind: crate::compiler::parse_linker::LinkOutputKind::File,
+            })
+        }
+        ParsedArchiveInvocation::NonCacheable {
+            reason: archive_reason,
+        } => match parse_linker_invocation(tool.to_str().unwrap_or(""), args.to_vec()) {
+            ParsedLinkerInvocation::Cacheable(parsed) => {
+                ParseLinkToolOutcome::Cacheable(ParsedLinkTool {
+                    non_determinism_hint: match parsed.family {
+                        crate::compiler::parse_linker::LinkerFamily::MsvcLink => {
+                            "/DETERMINISTIC".to_string()
+                        }
+                        crate::compiler::parse_linker::LinkerFamily::Dsymutil => {
+                            "deterministic input debug information".to_string()
+                        }
+                        _ => "--build-id=sha1 (avoid --build-id=uuid)".to_string(),
+                    },
+                    input_files: parsed.input_files,
+                    output_file: parsed.output_file,
+                    secondary_outputs: parsed.secondary_outputs,
+                    cache_relevant_flags: parsed.cache_relevant_flags,
+                    non_deterministic: parsed.non_deterministic,
+                    is_archive: false,
+                    output_kind: parsed.output_kind,
+                })
+            }
+            ParsedLinkerInvocation::NonCacheable {
+                reason: link_reason,
+            } => ParseLinkToolOutcome::NonCacheable {
+                archive_reason,
+                link_reason,
+            },
+        },
+    }
+}
+
+pub(super) fn link_non_determinism_warning(parsed: &ParsedLinkTool) -> Option<String> {
+    if !parsed.non_deterministic {
+        return None;
+    }
+    let warning = format!(
+        "non-deterministic invocation (missing {} flag) — output is cached but may differ from a fresh link",
+        parsed.non_determinism_hint
+    );
+    tracing::warn!(%warning);
+    Some(warning)
+}
+
 pub(super) fn normalize_link_path_value_for_key(value: &str, key_root: Option<&Path>) -> String {
     let Some(root) = key_root else {
         return value.to_string();

--- a/crates/zccache-daemon-core/src/daemon/server/link_process.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/link_process.rs
@@ -2,6 +2,28 @@
 
 use super::*;
 
+pub(super) fn with_link_warning(result: Response, warning: Option<String>) -> Response {
+    match (result, warning) {
+        (
+            Response::LinkResult {
+                exit_code,
+                stdout,
+                stderr,
+                cached,
+                ..
+            },
+            warning @ Some(_),
+        ) => Response::LinkResult {
+            exit_code,
+            stdout,
+            stderr,
+            cached,
+            warning,
+        },
+        (result, _) => result,
+    }
+}
+
 /// Run a tool directly (passthrough) and return a LinkResult response.
 ///
 /// `tmp_dir` is where the synthesized Windows response file lands when the

--- a/crates/zccache-daemon-core/src/daemon/server/staged_publish.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/staged_publish.rs
@@ -2,6 +2,19 @@
 
 use super::*;
 
+pub(super) fn publish_and_materialize_staged_link(
+    state: &SharedState,
+    plan: &StagedCompilePlan,
+    key: &str,
+    metadata: ArtifactIndex,
+    sources: &[NormalizedPath],
+) -> std::io::Result<bool> {
+    let publication = publish_artifact_paths_observed(state, key, metadata, sources);
+    let salvage_reason = publication.as_ref().err().map(|reason| reason.id());
+    materialize_link_plan_observed(state, plan, salvage_reason)?;
+    Ok(publication.is_ok())
+}
+
 pub(super) fn record_staged_publication_failure(state: &SharedState, reason: StagedPublishFailure) {
     use crate::daemon::staged_stats::{StagedCounter, StagedFailure};
     state

--- a/crates/zccache-daemon-core/src/daemon/server/tests/fingerprint.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/fingerprint.rs
@@ -283,6 +283,30 @@ fn request_fingerprint_keeps_malformed_rust_remap_detached_values_distinct() {
 }
 
 #[test]
+fn effective_compile_args_reuses_owned_strings_when_no_maps_are_added() {
+    let args = vec![
+        "-c".to_string(),
+        "src/main.cc".to_string(),
+        "-DBENCH_DEFINE_0001=1".to_string(),
+    ];
+    let string_buffers: Vec<*const u8> = args.iter().map(|arg| arg.as_ptr()).collect();
+
+    let effective = effective_compile_args(
+        args,
+        Path::new("/usr/bin/clang++"),
+        Path::new("/workspace"),
+        None,
+        None,
+    );
+
+    assert_eq!(
+        effective.iter().map(|arg| arg.as_ptr()).collect::<Vec<_>>(),
+        string_buffers,
+        "warm response-file preparation must not deep-clone every expanded argument",
+    );
+}
+
+#[test]
 fn effective_compile_args_auto_adds_root_and_cwd_maps() {
     // Issue #474: alongside `-ffile-prefix-map`, the auto-inject now
     // also emits `-fmacro-prefix-map` and `-fdebug-prefix-map` for both
@@ -298,7 +322,7 @@ fn effective_compile_args_auto_adds_root_and_cwd_maps() {
     let args = vec!["-c".to_string(), "src/main.cc".to_string()];
 
     let effective = effective_compile_args(
-        &args,
+        args,
         Path::new("/usr/bin/clang++"),
         &cwd,
         Some(&root),
@@ -349,7 +373,7 @@ fn effective_compile_args_auto_cc_maps_are_fallbacks_before_user_maps() {
     ];
 
     let effective = effective_compile_args(
-        &args,
+        args,
         Path::new("/usr/bin/clang++"),
         &root_path,
         Some(&root),
@@ -381,7 +405,7 @@ fn effective_compile_args_auto_cc_debug_map_does_not_suppress_file_map() {
     ];
 
     let effective = effective_compile_args(
-        &args,
+        args,
         Path::new("/usr/bin/clang++"),
         &root_path,
         Some(&root),
@@ -408,7 +432,7 @@ fn effective_compile_args_auto_adds_rust_root_remap_as_fallback() {
     ];
 
     let effective = effective_compile_args(
-        &args,
+        args,
         Path::new("rustc"),
         &root_path,
         Some(&root),
@@ -435,7 +459,7 @@ fn effective_compile_args_auto_rust_remap_is_before_user_subtree_remap() {
     let args = vec![user_remap.clone(), "src/lib.rs".to_string()];
 
     let effective = effective_compile_args(
-        &args,
+        args,
         Path::new("rustc"),
         &root_path,
         Some(&root),
@@ -468,7 +492,7 @@ fn effective_compile_args_auto_keeps_existing_rust_root_remap() {
     ];
 
     let effective = effective_compile_args(
-        &args,
+        args.clone(),
         Path::new("clippy-driver"),
         &root_path,
         Some(&root),

--- a/crates/zccache-daemon-core/src/daemon/server/tests/path_remap.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/path_remap.rs
@@ -37,7 +37,7 @@ fn dylint_remap_is_injected_after_the_inner_rustc() {
     ];
 
     let effective = effective_compile_args(
-        &args,
+        args.clone(),
         Path::new("/tmp/dylint-driver"),
         &root_path,
         Some(&root),
@@ -65,7 +65,7 @@ fn injects_macro_prefix_map_for_clang() {
     let args = vec!["-c".to_string(), "src/main.cc".to_string()];
 
     let effective = effective_compile_args(
-        &args,
+        args.clone(),
         Path::new("/usr/bin/clang++"),
         &root_path,
         Some(&root),
@@ -91,7 +91,7 @@ fn injects_debug_prefix_map_for_clang() {
     let args = vec!["-c".to_string(), "src/main.cc".to_string()];
 
     let effective = effective_compile_args(
-        &args,
+        args.clone(),
         Path::new("/usr/bin/clang++"),
         &root_path,
         Some(&root),
@@ -114,7 +114,7 @@ fn injects_macro_prefix_map_for_gcc() {
     let args = vec!["-c".to_string(), "src/main.cc".to_string()];
 
     let effective = effective_compile_args(
-        &args,
+        args.clone(),
         Path::new("/usr/bin/g++"),
         &root_path,
         Some(&root),
@@ -146,7 +146,7 @@ fn does_not_inject_redundant_macro_prefix_map_for_clang() {
     ];
 
     let effective = effective_compile_args(
-        &args,
+        args.clone(),
         Path::new("/usr/bin/clang++"),
         &root_path,
         Some(&root),
@@ -178,7 +178,7 @@ fn does_not_inject_for_msvc() {
     let args = vec!["/c".to_string(), "src\\main.cpp".to_string()];
 
     let effective = effective_compile_args(
-        &args,
+        args.clone(),
         Path::new("cl.exe"),
         &root_path,
         Some(&root),
@@ -213,7 +213,7 @@ fn injects_remap_path_prefix_for_rustc() {
     ];
 
     let effective = effective_compile_args(
-        &args,
+        args.clone(),
         Path::new("rustc"),
         &root_path,
         Some(&root),

--- a/crates/zccache-daemon-core/src/daemon/server/tests/rsp_cache.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/rsp_cache.rs
@@ -22,3 +22,57 @@ async fn cached_expansion_parses_utf16le_response_file_for_cache_keys() {
         "UTF-16 response-file flags must be visible to daemon key parsing"
     );
 }
+
+#[tokio::test]
+async fn cached_expansion_reloads_a_changed_response_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_dir: NormalizedPath = dir.path().join("cache").into();
+    let response = dir.path().join("compile.rsp");
+    std::fs::write(&response, "-DVALUE=one").unwrap();
+    let server =
+        DaemonServer::bind_with_cache_dir(&crate::ipc::unique_test_endpoint(), &cache_dir).unwrap();
+    let args = vec![format!("@{}", response.display())];
+
+    assert_eq!(
+        expand_args_cached(server.test_state(), &args, dir.path()),
+        vec!["-DVALUE=one"]
+    );
+    std::fs::write(&response, "-DVALUE=two").unwrap();
+    server
+        .test_state()
+        .cache_system
+        .apply_changes(vec![response.clone().into()]);
+
+    assert_eq!(
+        expand_args_cached(server.test_state(), &args, dir.path()),
+        vec!["-DVALUE=two"]
+    );
+}
+
+#[tokio::test]
+async fn cached_expansion_reloads_a_changed_nested_response_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_dir: NormalizedPath = dir.path().join("cache").into();
+    let outer = dir.path().join("outer.rsp");
+    let nested = dir.path().join("nested.rsp");
+    std::fs::write(&outer, "@nested.rsp").unwrap();
+    std::fs::write(&nested, "-DVALUE=one").unwrap();
+    let server =
+        DaemonServer::bind_with_cache_dir(&crate::ipc::unique_test_endpoint(), &cache_dir).unwrap();
+    let args = vec![format!("@{}", outer.display())];
+
+    assert_eq!(
+        expand_args_cached(server.test_state(), &args, dir.path()),
+        vec!["-DVALUE=one"]
+    );
+    std::fs::write(&nested, "-DVALUE=two").unwrap();
+    server
+        .test_state()
+        .cache_system
+        .apply_changes(vec![nested.clone().into()]);
+
+    assert_eq!(
+        expand_args_cached(server.test_state(), &args, dir.path()),
+        vec!["-DVALUE=two"]
+    );
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -796,3 +796,33 @@ Issue: https://github.com/zackees/zccache/issues/1417
 - GREEN: only `PreDispatch` failures recover; send/receive/wedge outcomes are
   terminal after delivery becomes ambiguous. A responsive daemon is preserved
   without replaying the current request.
+
+# #1025 restore current C++ performance gates
+
+Issue: https://github.com/zackees/zccache/issues/1025
+
+- [x] Add a focused regression proving cached response-file expansion is not
+  deep-cloned again while preparing effective compile arguments.
+- [x] Preserve response-file mutation invalidation and nested dependency checks.
+- [x] Attribute the current compiler-driver cold-link gap from hosted miss profiles.
+- [x] Implement only measured zccache-owned hot-path reductions without changing APIs.
+- [ ] Run focused correctness, unchanged performance gates, review, merge, and close.
+
+## Review
+
+- RED: hosted Perf Guard run 32395073944 reports single-file response-file warm
+  at 1.417x versus sccache (1.50x required) and compiler-driver cold at 0.819x
+  versus bare clang++ (0.85x required).
+- Source trace: response-file hits clone the cached ~283-string expansion, then
+  `effective_compile_args` deep-clones that vector again before request-cache
+  lookup even when no path-remap flags are injected.
+- Driver-link attribution: hosted attempts spent 7.6–8.1 ms discovering the
+  tool/input hashes and another ~4.6 ms outside the compiler and named phases.
+- GREEN: effective argument preparation now consumes the cached expansion and
+  moves its string buffers through unchanged when no maps are inserted. Top-level
+  and nested response-file mutation regressions remain green.
+- GREEN: cold non-archive links prepare their staged output plan and read-only
+  side-effect snapshot alongside hash discovery. The compiler still starts only
+  after a proven cache miss, and warm metadata-cache hits retain the existing path.
+- Native diagnostic: driver-link unaccounted time fell from ~22 ms to ~9 ms;
+  warm driver hits remained ~3 ms. Hosted Linux remains the timing authority.


### PR DESCRIPTION
Closes #1025

## Summary
- move cached expanded response-file arguments into effective argument preparation instead of deep-cloning every string again
- preserve top-level and nested response-file mutation invalidation with focused regressions
- overlap cold non-archive staged-plan and read-only side-effect-snapshot preparation with strong hash discovery, without starting the compiler before a proven miss
- keep warm metadata-cache hits on the existing path and split link helpers so production files remain within the repository line ceiling

## Evidence
- RED: `effective_compile_args_reuses_owned_strings_when_no_maps_are_added` observed different string-buffer addresses before the ownership change
- GREEN: focused effective-argument tests (7/7)
- response-file cache tests (3/3), including top-level and nested mutations
- link-cache unit tests (5/5)
- path-remap tests (21/21)
- `soldr cargo test -p zccache-daemon-core --features test-support` (770 passed, 25 ignored)
- strict fmt and clippy (`-D warnings`) clean
- local ignored response-file benchmark: warm single-file zccache 0.764s vs sccache 1.404s (1.8x faster)
- local driver diagnostic: unaccounted cold-link phase reduced from ~22ms to ~9ms; warm hits remained ~3ms
- clud-review: clean (one reviewer)

Hosted Perf Guard retains its existing thresholds and is the authoritative Linux timing gate.