### PR TITLE
release: bump version to 1.13.6 (#840)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,7 +4105,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "bincode",
  "blake3",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-audit"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -4215,7 +4215,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4224,7 +4224,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli-core"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "bincode",
  "blake3",
@@ -4278,14 +4278,14 @@ dependencies = [
 
 [[package]]
 name = "zccache-compile-trace"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "zccache-audit",
 ]
 
 [[package]]
 name = "zccache-compiler"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "clang",
  "serde_json",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "crash-handler",
  "dashmap",
@@ -4312,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon-core"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "bincode",
  "blake3",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "blake3",
  "futures",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "bincode",
  "bytes",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "filetime",
  "fs2",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "bincode",
  "dashmap",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "reqwest",
  "serde",
@@ -4460,7 +4460,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "blake3",
  "memmap2",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "bytes",
  "dashmap",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-platform"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "crash-handler",
  "interprocess",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "bincode",
  "bytes",
@@ -4521,7 +4521,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-symbols"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "tempfile",
  "zccache-core",
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "tempfile",
  "zccache-audit",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.5"
+version = "1.13.6"
 edition = "2021"
 rust-version = "1.95.0"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Part of #840.

Bumps the workspace version from 1.13.5 to 1.13.6 and refreshes workspace package versions in the lockfile so the prost-first full-family rollout and persistent Python exec_cached API can ship for their required compatibility/telemetry release cycle.

Validation:
- soldr cargo metadata --format-version 1 --no-deps
- release/package/manifest tests: 38 passed, 1 skipped
- diff check clean

This PR does not remove the bincode compatibility lane; that remains gated on the shipped-release soak required by #840.