### PR TITLE
docs: fix stale zccache package commands (#1428)

### DIFF
--- a/crates/zccache/tests/daemon_adversarial_corner_cases.rs
+++ b/crates/zccache/tests/daemon_adversarial_corner_cases.rs
@@ -5,8 +5,8 @@
 //! - Cache persistence across session boundaries
 //! - Thundering herd (concurrent same-file compilation from multiple sessions)
 //!
-//! Run all:    soldr cargo test -p zccache-daemon --test adversarial_corner_cases -- --nocapture
-//! Run single: soldr cargo test -p zccache-daemon --test adversarial_corner_cases -- <test_name> --nocapture
+//! Run all:    soldr cargo test -p zccache --test adversarial_corner_cases -- --nocapture
+//! Run single: soldr cargo test -p zccache --test adversarial_corner_cases -- <test_name> --nocapture
 
 #![allow(
     clippy::unwrap_used,

--- a/crates/zccache/tests/daemon_adversarial_mutations.rs
+++ b/crates/zccache/tests/daemon_adversarial_mutations.rs
@@ -6,8 +6,8 @@
 //! (touch/delete-recreate with same content), independent file isolation,
 //! include-path differentiation, and preprocessor-flag differentiation.
 //!
-//! Run all:    soldr cargo test -p zccache-daemon --test adversarial_mutations -- --nocapture
-//! Run single: soldr cargo test -p zccache-daemon --test adversarial_mutations -- <test_name> --nocapture
+//! Run all:    soldr cargo test -p zccache --test adversarial_mutations -- --nocapture
+//! Run single: soldr cargo test -p zccache --test adversarial_mutations -- <test_name> --nocapture
 
 #![allow(
     clippy::unwrap_used,

--- a/crates/zccache/tests/daemon_cold_path_profile_test.rs
+++ b/crates/zccache/tests/daemon_cold_path_profile_test.rs
@@ -8,7 +8,7 @@
 //!   - Artifact persistence overhead
 //!   - Scaling behavior (10, 50, 100, 200 files)
 //!
-//! Run with: soldr cargo test -p zccache-daemon --test cold_path_profile_test -- --nocapture --ignored
+//! Run with: soldr cargo test -p zccache --test cold_path_profile_test -- --nocapture --ignored
 
 #![allow(
     clippy::unwrap_used,

--- a/crates/zccache/tests/daemon_depgraph_persistence_test.rs
+++ b/crates/zccache/tests/daemon_depgraph_persistence_test.rs
@@ -6,7 +6,7 @@
 //! next daemon process loads it back and reports `dep_graph_persisted = true`
 //! over the IPC `Status` response.
 //!
-//! Run: soldr cargo test -p zccache-daemon --test depgraph_persistence_test -- --ignored --nocapture
+//! Run: soldr cargo test -p zccache --test depgraph_persistence_test -- --ignored --nocapture
 
 #![allow(
     clippy::unwrap_used,

--- a/crates/zccache/tests/daemon_ninja_rebuild_direct_test.rs
+++ b/crates/zccache/tests/daemon_ninja_rebuild_direct_test.rs
@@ -16,8 +16,8 @@
 //! Each invocation goes through the real CLI binary in drop-in wrapper mode,
 //! exercising the full `CompileEphemeral` single-roundtrip IPC path.
 //!
-//! Run all:    soldr cargo test -p zccache-daemon --test daemon_ninja_rebuild_direct_test -- --nocapture
-//! Run stress: soldr cargo test -p zccache-daemon --test daemon_ninja_rebuild_direct_test -- --ignored --nocapture
+//! Run all:    soldr cargo test -p zccache --test daemon_ninja_rebuild_direct_test -- --nocapture
+//! Run stress: soldr cargo test -p zccache --test daemon_ninja_rebuild_direct_test -- --ignored --nocapture
 
 #![allow(
     clippy::unwrap_used,
@@ -726,7 +726,7 @@ async fn ninja_clear_forces_cold_rebuild() {
 
 /// Stress test: 250 files with heavy bodies, cold + warm + warm.
 ///
-/// Run:  soldr cargo test -p zccache-daemon --test daemon_ninja_rebuild_direct_test -- stress_large_project --ignored --nocapture
+/// Run:  soldr cargo test -p zccache --test daemon_ninja_rebuild_direct_test -- stress_large_project --ignored --nocapture
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore]
 async fn stress_large_project_cold_warm() {
@@ -817,7 +817,7 @@ async fn stress_large_project_cold_warm() {
 /// Benchmark: 100 files, medium bodies, cold + 5 warm iterations.
 /// Prints per-iteration timing for trend analysis.
 ///
-/// Run:  soldr cargo test -p zccache-daemon --test daemon_ninja_rebuild_direct_test -- bench_medium --ignored --nocapture
+/// Run:  soldr cargo test -p zccache --test daemon_ninja_rebuild_direct_test -- bench_medium --ignored --nocapture
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore]
 async fn bench_medium_project_warm_iterations() {

--- a/crates/zccache/tests/daemon_ninja_rebuild_meson_test.rs
+++ b/crates/zccache/tests/daemon_ninja_rebuild_meson_test.rs
@@ -5,7 +5,7 @@
 //! The direct CLI/IPC ephemeral and stress/bench scenarios live in the sibling
 //! `daemon_ninja_rebuild_direct_test.rs` file.
 //!
-//! Run:    soldr cargo test -p zccache-daemon --test daemon_ninja_rebuild_meson_test -- --ignored --nocapture
+//! Run:    soldr cargo test -p zccache --test daemon_ninja_rebuild_meson_test -- --ignored --nocapture
 
 #![allow(
     clippy::unwrap_used,
@@ -116,7 +116,7 @@ fn find_ninja() -> Option<NormalizedPath> {
 ///   4. `ninja -t clean` + `ninja` warm rebuild (all cache hits)
 ///   5. Verify warm is significantly faster than cold
 ///
-/// Run:  soldr cargo test -p zccache-daemon --test daemon_ninja_rebuild_meson_test -- meson_ninja_cold --ignored --nocapture
+/// Run:  soldr cargo test -p zccache --test daemon_ninja_rebuild_meson_test -- meson_ninja_cold --ignored --nocapture
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore]
 async fn meson_ninja_cold_then_warm_rebuild() {
@@ -228,7 +228,7 @@ async fn meson_ninja_cold_then_warm_rebuild() {
 
 /// Meson+ninja benchmark: larger project, cold + 3 warm iterations.
 ///
-/// Run:  soldr cargo test -p zccache-daemon --test daemon_ninja_rebuild_meson_test -- meson_ninja_bench --ignored --nocapture
+/// Run:  soldr cargo test -p zccache --test daemon_ninja_rebuild_meson_test -- meson_ninja_bench --ignored --nocapture
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore]
 async fn meson_ninja_bench_warm_iterations() {

--- a/crates/zccache/tests/daemon_perf_test.rs
+++ b/crates/zccache/tests/daemon_perf_test.rs
@@ -1,7 +1,7 @@
 //! Performance comparison: bare clang vs sccache vs zccache.
 //!
 //! Three-way benchmark measuring compile latency across cache-miss and cache-hit scenarios.
-//! Run with: soldr cargo test -p zccache-daemon --test perf_test -- --nocapture --ignored
+//! Run with: soldr cargo test -p zccache --test perf_test -- --nocapture --ignored
 
 #![allow(
     clippy::unwrap_used,
@@ -592,7 +592,7 @@ fn print_three_way(bare: &BenchResult, sccache: &BenchResult, zccache: &BenchRes
 
 /// Full three-way benchmark: bare clang vs sccache vs zccache.
 ///
-/// Run with: soldr cargo test -p zccache-daemon --test perf_test -- perf_full_benchmark --nocapture --ignored
+/// Run with: soldr cargo test -p zccache --test perf_test -- perf_full_benchmark --nocapture --ignored
 #[tokio::test]
 #[ignore]
 async fn perf_full_benchmark() {

--- a/crates/zccache/tests/daemon_persist_pool_bench.rs
+++ b/crates/zccache/tests/daemon_persist_pool_bench.rs
@@ -21,7 +21,7 @@
 //! through several persist strategies on the same machine, same disk.
 //!
 //! Run with:
-//!   soldr cargo test -p zccache-daemon --test persist_pool_bench -- --nocapture --ignored
+//!   soldr cargo test -p zccache --test persist_pool_bench -- --nocapture --ignored
 //!
 //! Tune the workload via env vars:
 //!   PERSIST_BENCH_FILES        (default 191)

--- a/crates/zccache/tests/daemon_profile_multi_test.rs
+++ b/crates/zccache/tests/daemon_profile_multi_test.rs
@@ -1,6 +1,6 @@
 //! Profile the multi-file warm cache path to identify bottlenecks.
 //!
-//! Run: soldr cargo test -p zccache-daemon --test profile_multi_test -- --nocapture --ignored
+//! Run: soldr cargo test -p zccache --test profile_multi_test -- --nocapture --ignored
 
 #![allow(
     clippy::unwrap_used,

--- a/crates/zccache/tests/daemon_profile_test.rs
+++ b/crates/zccache/tests/daemon_profile_test.rs
@@ -1,6 +1,6 @@
 //! Profiling stress test: drives many compilations and reports phase-level timing breakdown.
 //!
-//! Run with: soldr cargo test -p zccache-daemon --test profile_test -- --nocapture --ignored
+//! Run with: soldr cargo test -p zccache --test profile_test -- --nocapture --ignored
 
 #![allow(
     clippy::unwrap_used,
@@ -212,7 +212,7 @@ fn print_profile(profile: &zccache::daemon::ProfileSnapshot) {
 
 /// Profiling stress test: cold + warm compilations with phase-level timing breakdown.
 ///
-/// Run with: soldr cargo test -p zccache-daemon --test profile_test -- --nocapture --ignored
+/// Run with: soldr cargo test -p zccache --test profile_test -- --nocapture --ignored
 #[tokio::test]
 #[ignore]
 async fn profile_compile_phases() {

--- a/crates/zccache/tests/daemon_response_file_cache.rs
+++ b/crates/zccache/tests/daemon_response_file_cache.rs
@@ -3,8 +3,8 @@
 //! Verifies that the daemon correctly expands response files before computing
 //! cache keys, so that changes to response file content invalidate the cache.
 //!
-//! Run all:    soldr cargo test -p zccache-daemon --test response_file_cache -- --ignored --nocapture
-//! Run single: soldr cargo test -p zccache-daemon --test response_file_cache -- <test_name> --ignored --nocapture
+//! Run all:    soldr cargo test -p zccache --test response_file_cache -- --ignored --nocapture
+//! Run single: soldr cargo test -p zccache --test response_file_cache -- <test_name> --ignored --nocapture
 
 #![allow(
     clippy::unwrap_used,

--- a/crates/zccache/tests/daemon_rustc_issue_210_async_populate_test.rs
+++ b/crates/zccache/tests/daemon_rustc_issue_210_async_populate_test.rs
@@ -2,7 +2,7 @@
 //! daemon cache before observable warm-cache behavior is reported.
 //!
 //! Run all:
-//!   cargo test -p zccache-daemon --test rustc_issue_210_async_populate_test -- --ignored --nocapture
+//!   soldr cargo test -p zccache --test rustc_issue_210_async_populate_test -- --ignored --nocapture
 
 #![allow(
     clippy::unwrap_used,

--- a/crates/zccache/tests/daemon_watcher_adversarial.rs
+++ b/crates/zccache/tests/daemon_watcher_adversarial.rs
@@ -6,8 +6,8 @@
 //! covered: header edits, touch-without-change, deep directories, ephemeral
 //! file creation/deletion, and multi-session cache sharing.
 //!
-//! Run all:    soldr cargo test -p zccache-daemon --test watcher_adversarial -- --nocapture
-//! Run single: soldr cargo test -p zccache-daemon --test watcher_adversarial -- <test_name> --nocapture
+//! Run all:    soldr cargo test -p zccache --test watcher_adversarial -- --nocapture
+//! Run single: soldr cargo test -p zccache --test watcher_adversarial -- <test_name> --nocapture
 
 #![allow(
     clippy::unwrap_used,

--- a/crates/zccache/tests/perf_bench/README.md
+++ b/crates/zccache/tests/perf_bench/README.md
@@ -7,7 +7,7 @@ are discovered by cargo under the same `perf_bench_test` test binary, so the
 canonical invocation pattern still works:
 
 ```
-soldr cargo test -p zccache-daemon --test perf_bench_test -- \
+soldr cargo test -p zccache --test perf_bench_test -- \
     perf_c_zccache_vs_bare --nocapture --ignored
 ```
 

--- a/crates/zccache/tests/perf_bench/mod.rs
+++ b/crates/zccache/tests/perf_bench/mod.rs
@@ -5,7 +5,7 @@
 //! under the same `perf_bench_test` test binary (the thin shim
 //! `tests/perf_bench_test.rs` re-exports this module).
 //!
-//! Run with: soldr cargo test -p zccache-daemon --test perf_bench_test -- --nocapture --ignored
+//! Run with: soldr cargo test -p zccache --test perf_bench_test -- --nocapture --ignored
 
 // Shared helpers (constants, timing, daemon boot, tool finders, etc.)
 #![allow(

--- a/crates/zccache/tests/perf_bench/tests_c.rs
+++ b/crates/zccache/tests/perf_bench/tests_c.rs
@@ -20,7 +20,7 @@ use super::common::{
 };
 
 #[tokio::test]
-#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_c_zccache_vs_bare --nocapture --ignored
+#[ignore] // Run explicitly: soldr cargo test -p zccache --test perf_bench_test -- perf_c_zccache_vs_bare --nocapture --ignored
 async fn perf_c_zccache_vs_bare() {
     zccache::test_support::ensure_clang_tool_chain_on_path();
     let compiler_path = match zccache::test_support::find_on_path("clang") {

--- a/crates/zccache/tests/perf_bench/tests_cpp.rs
+++ b/crates/zccache/tests/perf_bench/tests_cpp.rs
@@ -22,7 +22,7 @@ use super::cpp_project::{
 };
 
 #[tokio::test]
-#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- --nocapture --ignored
+#[ignore] // Run explicitly: soldr cargo test -p zccache --test perf_bench_test -- --nocapture --ignored
 async fn perf_warm_cache_zccache_vs_sccache() {
     let compiler_path = match zccache::test_support::find_clang() {
         Some(p) => p,

--- a/crates/zccache/tests/perf_bench/tests_emcc.rs
+++ b/crates/zccache/tests/perf_bench/tests_emcc.rs
@@ -32,7 +32,7 @@ use super::sibling_remap::{make_git_workspace, path_remap_auto_env};
 /// Emscripten warm-cache benchmark: bare em++ vs sccache vs zccache.
 /// Mirrors `perf_warm_cache_zccache_vs_sccache` (C++) but uses em++.
 #[tokio::test]
-#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_emcc_warm_cache_zccache_vs_sccache --nocapture --ignored
+#[ignore] // Run explicitly: soldr cargo test -p zccache --test perf_bench_test -- perf_emcc_warm_cache_zccache_vs_sccache --nocapture --ignored
 async fn perf_emcc_warm_cache_zccache_vs_sccache() {
     let compiler_path = match find_empp() {
         Some(p) => p,
@@ -293,7 +293,7 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
 /// `ZCCACHE_PATH_REMAP=auto` injects `-ffile-prefix-map` for em++ (Clang-family)
 /// so equivalent compiles share cache across sibling git roots.
 #[tokio::test]
-#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_emcc_sibling_remap_warm --nocapture --ignored
+#[ignore] // Run explicitly: soldr cargo test -p zccache --test perf_bench_test -- perf_emcc_sibling_remap_warm --nocapture --ignored
 async fn perf_emcc_sibling_remap_warm() {
     let compiler_path = match find_empp() {
         Some(p) => p,

--- a/crates/zccache/tests/perf_bench/tests_link.rs
+++ b/crates/zccache/tests/perf_bench/tests_link.rs
@@ -28,7 +28,7 @@ use super::link::{
 use super::common::clean_link_outputs;
 
 #[tokio::test]
-#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_c_archive_link --nocapture --ignored
+#[ignore] // Run explicitly: soldr cargo test -p zccache --test perf_bench_test -- perf_c_archive_link --nocapture --ignored
 async fn perf_c_archive_link() {
     let archiver = match find_archiver() {
         Some(path) => path,
@@ -85,7 +85,7 @@ async fn perf_c_archive_link() {
 }
 
 #[tokio::test]
-#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_cpp_driver_link --nocapture --ignored
+#[ignore] // Run explicitly: soldr cargo test -p zccache --test perf_bench_test -- perf_cpp_driver_link --nocapture --ignored
 async fn perf_cpp_driver_link() {
     let compiler_path = match zccache::test_support::find_clang() {
         Some(path) => path,
@@ -156,7 +156,7 @@ async fn perf_cpp_driver_link() {
 }
 
 #[tokio::test]
-#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_emcc_link --nocapture --ignored
+#[ignore] // Run explicitly: soldr cargo test -p zccache --test perf_bench_test -- perf_emcc_link --nocapture --ignored
 async fn perf_emcc_link() {
     let compiler_path = match find_empp() {
         Some(path) => path,
@@ -251,7 +251,7 @@ async fn perf_emcc_link() {
 }
 
 #[tokio::test]
-#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_rust_workspace_link --nocapture --ignored
+#[ignore] // Run explicitly: soldr cargo test -p zccache --test perf_bench_test -- perf_rust_workspace_link --nocapture --ignored
 async fn perf_rust_workspace_link() {
     let rustc_path = match zccache::test_support::find_rustc() {
         Some(path) => path,

--- a/crates/zccache/tests/perf_bench/tests_response_file.rs
+++ b/crates/zccache/tests/perf_bench/tests_response_file.rs
@@ -24,7 +24,7 @@ use super::response_file::{
 };
 
 #[tokio::test]
-#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_response_file --nocapture --ignored
+#[ignore] // Run explicitly: soldr cargo test -p zccache --test perf_bench_test -- perf_response_file --nocapture --ignored
 async fn perf_response_file() {
     let compiler_path = match zccache::test_support::find_clang() {
         Some(p) => p,

--- a/crates/zccache/tests/perf_bench/tests_sibling_remap.rs
+++ b/crates/zccache/tests/perf_bench/tests_sibling_remap.rs
@@ -25,7 +25,7 @@ use super::sibling_remap::{
 /// ZCCACHE_PATH_REMAP=auto, primed from sibling workspace A) against bare clang
 /// and sccache (also primed from workspace A, then measured in workspace B).
 #[tokio::test]
-#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_cpp_sibling_remap_warm --nocapture --ignored
+#[ignore] // Run explicitly: soldr cargo test -p zccache --test perf_bench_test -- perf_cpp_sibling_remap_warm --nocapture --ignored
 async fn perf_cpp_sibling_remap_warm() {
     let compiler_path = match zccache::test_support::find_clang() {
         Some(p) => p,
@@ -102,7 +102,7 @@ async fn perf_cpp_sibling_remap_warm() {
 /// ZCCACHE_PATH_REMAP=auto, primed from sibling workspace A) against bare rustc
 /// and sccache (each warm in workspace B).
 #[tokio::test]
-#[ignore] // Run explicitly: soldr cargo test -p zccache-daemon --test perf_bench_test -- perf_rustc_sibling_remap_warm --nocapture --ignored
+#[ignore] // Run explicitly: soldr cargo test -p zccache --test perf_bench_test -- perf_rustc_sibling_remap_warm --nocapture --ignored
 async fn perf_rustc_sibling_remap_warm() {
     let rustc_path = match zccache::test_support::find_rustc() {
         Some(p) => p,

--- a/crates/zccache/tests/perf_bench_test.rs
+++ b/crates/zccache/tests/perf_bench_test.rs
@@ -7,7 +7,7 @@
 //!
 //! See [`perf_bench/README.md`](perf_bench/README.md) for the module map.
 //!
-//! Run with: soldr cargo test -p zccache-daemon --test perf_bench_test -- --nocapture --ignored
+//! Run with: soldr cargo test -p zccache --test perf_bench_test -- --nocapture --ignored
 
 #![allow(
     clippy::unwrap_used,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -826,3 +826,22 @@ Issue: https://github.com/zackees/zccache/issues/1025
   after a proven cache miss, and warm metadata-cache hits retain the existing path.
 - Native diagnostic: driver-link unaccounted time fell from ~22 ms to ~9 ms;
   warm driver hits remained ~3 ms. Hosted Linux remains the timing authority.
+
+# #1428 fix stale test package commands
+
+Issue: https://github.com/zackees/zccache/issues/1428
+
+- [x] Inventory all 38 stale `zccache-daemon` package examples under `crates/zccache/tests`.
+- [x] Replace them with the current `zccache` package name without changing daemon binaries.
+- [x] Prove the corrected focused command resolves.
+- [ ] Merge and close #1428.
+
+## Review
+
+- RED: `soldr cargo test -p zccache-daemon ...` fails because the package was
+  renamed to `zccache` by #365.
+- GREEN target: every affected test comment and README uses `-p zccache`, and
+  the focused performance-test target compiles through the documented command.
+- GREEN: Cargo metadata resolves `zccache` and its `perf_bench_test` target;
+  the corrected no-run command reaches dependency compilation instead of
+  failing package selection, and the stale package string inventory is empty.


### PR DESCRIPTION
Closes #1428.

## What changed
- update all 38 stale zccache-daemon package examples under crates/zccache/tests
- use the current zccache package and Soldr-only command form
- leave the real zccache-daemon binary and zccache-daemon-core crate names untouched

## Validation
- RED: soldr cargo test -p zccache-daemon fails package selection
- GREEN: soldr cargo metadata --no-deps --format-version 1 resolves zccache and perf_bench_test
- GREEN: the corrected no-run command reaches dependency compilation instead of package-selection failure
- the stale package-command inventory under crates/zccache/tests is empty
- git diff --check passes

Merge is intentionally held until the authoritative #1025 main Perf Guard finishes, because another main push would cancel that timing run.
