### PR TITLE
ci: restore coverage llvm-profdata (#1429)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,8 +37,11 @@ jobs:
           # build-cache so the daemon-isolated llvm-cov phase starts warm.
           seed-isolated-build-cache: ${{ runner.temp }}/zccache-self-tests/coverage
           verify-compile-cache: warn
-          # setup-soldr#305: see Formatting job comment in ci.yml.
-          solo-toolchain-cache: true
+          # llvm-tools-preview is installed after setup-soldr. A solo-cache
+          # restore can preserve its manifest without llvm-profdata; the
+          # action explicitly requires opting out for post-setup components.
+          # See #1429 and setup-soldr#334.
+          solo-toolchain-cache: false
       - name: Install Rust coverage component
         run: soldr rustup component add llvm-tools-preview
       - name: Install cargo-llvm-cov

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -894,3 +894,21 @@ Issue: https://github.com/zackees/zccache/issues/1435
   JSON regression pass.
 - clud-review: clean after retaining the original platform error in the source
   chain (one reviewer).
+
+# #1429 restore coverage llvm-profdata
+
+Issue: https://github.com/zackees/zccache/issues/1429
+
+- [x] Confirm the repeated hosted failure occurs after all unit tests pass.
+- [x] Trace the missing binary to a component installed after solo-cache restore.
+- [x] Opt Coverage out of the incompatible solo toolchain cache.
+- [ ] Merge, observe a successful hosted Coverage run, and close #1429.
+
+## Review
+
+- RED: main runs 32415853396 and 32419543131 report
+  `llvm-tools-preview` current, then fail because `llvm-profdata` is absent.
+- Root cause: setup-soldr documents that components installed after its action
+  are not part of the solo snapshot and explicitly directs such jobs to opt out.
+- GREEN target: a hosted warm Coverage run generates `lcov.info` and reaches a
+  successful Codecov upload without adding LLVM tools to unrelated jobs.


### PR DESCRIPTION
Closes #1429.

## What changed
- opt the Coverage job out of setup-soldr solo toolchain caching
- retain the isolated Soldr build cache and existing coverage scope
- document why components installed after setup cannot use this cache mode

## Evidence
- RED: main runs 32415853396 and 32419543131 passed all tests, then could not execute missing llvm-profdata
- setup-soldr's action contract explicitly says to pass false when a workflow installs components after setup
- setup-soldr#334 documents the identical manifest-without-binary failure mechanism

## Validation
- uv run --no-project pytest ci/tests/test_toolchain_consistency.py -q (2 passed)
- git diff --check

Hosted GREEN is the first post-merge Coverage run producing lcov.info and uploading it to Codecov. Merge is held until the authoritative #1025 Perf Guard completes so this push cannot cancel it.
