### PR TITLE
fix(cache): restore immediate staged Rust hits

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
@@ -221,6 +221,21 @@ impl CachedArtifact {
         Arc::ptr_eq(&self.inner, &other.inner)
     }
 
+    /// Whether a specific output can be materialized without waiting for a
+    /// same-key publisher. Lazy durable rows return false until payload
+    /// resolution initializes them; resident bytes and live staged paths are
+    /// immediately usable. Hit branches consult this only while publication
+    /// for the key is active.
+    pub(super) fn materialization_payload_ready(&self, index: usize) -> bool {
+        self.payloads
+            .get()
+            .and_then(|payloads| payloads.get(index))
+            .is_some_and(|payload| match payload {
+                CachedPayload::Bytes(_) => true,
+                CachedPayload::File(path) => path.as_path().exists(),
+            })
+    }
+
     /// Create from index metadata and an already-resolved payload list.
     #[cfg(test)]
     pub(crate) fn from_cached_payloads(meta: ArtifactIndex, payloads: Vec<CachedPayload>) -> Self {

--- a/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/cached_artifact.rs
@@ -19,12 +19,15 @@ pub(crate) enum CachedPayload {
 
 /// Payloads resolved for one requested-output delivery.
 ///
-/// Staged file payloads carry a shared store-lock guard. Its ownership is tied
-/// to this value so callers cannot retain generation paths while accidentally
-/// dropping the lock before reflink/hardlink/copy or directory unpacking.
+/// Staged file payloads carry the ownership needed to keep their source paths
+/// alive through delivery. Durable generation paths use the shared store-lock
+/// guard; provisional compile paths retain their private staging plan. Both
+/// lifetimes are tied to this value so callers cannot drop either protection
+/// before reflink/hardlink/copy or directory unpacking.
 pub(crate) struct MaterializationPayloads {
     payloads: Arc<[CachedPayload]>,
     staged_guard: Option<StagedMaterializationGuard>,
+    _provisional_staged_owner: Option<Arc<StagedCompilePlan>>,
 }
 
 impl std::ops::Deref for MaterializationPayloads {
@@ -36,6 +39,10 @@ impl std::ops::Deref for MaterializationPayloads {
 }
 
 impl MaterializationPayloads {
+    pub(crate) fn is_provisional_staged(&self) -> bool {
+        self._provisional_staged_owner.is_some()
+    }
+
     pub(crate) fn staged_lock_timings(&self) -> Option<(u64, u64)> {
         self.staged_guard
             .as_ref()
@@ -97,6 +104,10 @@ pub(crate) struct CachedArtifactInner {
     /// immediately. Filesystem discovery then initializes this cell without
     /// holding a map shard lock.
     payloads: OnceLock<Arc<[CachedPayload]>>,
+    /// Keeps private staged files alive while a detached durable publication
+    /// is still consuming them. Owned hit clones retain the same plan, so a
+    /// concurrent publisher cannot clean the paths during materialization.
+    _provisional_staged_owner: Option<Arc<StagedCompilePlan>>,
     /// Per-artifact access state used by durable retention.
     ///
     /// This lock is independent of the DashMap shard, so one hot artifact
@@ -114,6 +125,14 @@ impl std::ops::Deref for CachedArtifact {
 
 impl CachedArtifact {
     fn with_payloads(meta: ArtifactIndex, payloads: Arc<[CachedPayload]>) -> Self {
+        Self::with_payloads_and_owner(meta, payloads, None)
+    }
+
+    fn with_payloads_and_owner(
+        meta: ArtifactIndex,
+        payloads: Arc<[CachedPayload]>,
+        provisional_staged_owner: Option<Arc<StagedCompilePlan>>,
+    ) -> Self {
         let stdout = Arc::clone(&meta.stdout);
         let stderr = Arc::clone(&meta.stderr);
         let now = std::time::Instant::now();
@@ -123,6 +142,7 @@ impl CachedArtifact {
                 stdout,
                 stderr,
                 payloads: OnceLock::from(payloads),
+                _provisional_staged_owner: provisional_staged_owner,
                 access: std::sync::Mutex::new(ArtifactAccess {
                     last_used: now,
                     last_used_wall: std::time::SystemTime::now(),
@@ -178,6 +198,29 @@ impl CachedArtifact {
         )
     }
 
+    /// Publish private staged paths for immediate in-process hits while their
+    /// durable generation is still being copied, synced, and hashed.
+    pub(super) fn from_provisional_staged(
+        meta: ArtifactIndex,
+        payloads: Vec<NormalizedPath>,
+        owner: Arc<StagedCompilePlan>,
+    ) -> Self {
+        Self::with_payloads_and_owner(
+            meta,
+            Arc::from(
+                payloads
+                    .into_iter()
+                    .map(CachedPayload::File)
+                    .collect::<Vec<_>>(),
+            ),
+            Some(owner),
+        )
+    }
+
+    pub(super) fn same_instance(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
     /// Create from index metadata and an already-resolved payload list.
     #[cfg(test)]
     pub(crate) fn from_cached_payloads(meta: ArtifactIndex, payloads: Vec<CachedPayload>) -> Self {
@@ -197,6 +240,7 @@ impl CachedArtifact {
                 stdout,
                 stderr,
                 payloads: OnceLock::new(),
+                _provisional_staged_owner: None,
                 access: std::sync::Mutex::new(ArtifactAccess {
                     last_used: std::time::Instant::now(),
                     // Keep durable age in wall-clock form. Reconstructing it as an
@@ -350,6 +394,7 @@ fn ensure_payloads_for_materialization_with_guard(
             Ok(MaterializationPayloads {
                 payloads,
                 staged_guard,
+                _provisional_staged_owner: cached._provisional_staged_owner.clone(),
             })
         }
         None => Err(cache_blob_missing(
@@ -528,6 +573,62 @@ mod tests {
             ensure_payloads_with_staged_policy(&owned_clone, dir.path(), key, false).unwrap();
 
         assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn provisional_staged_payload_owns_private_files_through_hit_delivery() {
+        let dir = tempfile::tempdir().unwrap();
+        let root: NormalizedPath = dir.path().join("private").into();
+        std::fs::create_dir_all(&root).unwrap();
+        let staged: NormalizedPath = root.join("output.rlib");
+        let requested: NormalizedPath = dir.path().join("requested.rlib").into();
+        std::fs::write(&staged, b"staged payload").unwrap();
+        let plan = Arc::new(StagedCompilePlan::for_test(
+            root.clone(),
+            vec![StagedOutputPlan {
+                requested,
+                staged: staged.clone(),
+                role: StagedOutputRole::Regular,
+            }],
+        ));
+        let cached = CachedArtifact::from_provisional_staged(
+            ArtifactIndex::new(
+                vec!["output.rlib".to_string()],
+                vec![14],
+                Arc::new(Vec::new()),
+                Arc::new(Vec::new()),
+                0,
+            ),
+            vec![staged.clone()],
+            plan,
+        );
+        let hit = cached.clone();
+        drop(cached);
+
+        let payloads = ensure_payloads_for_materialization(
+            &hit,
+            &dir.path().join("artifacts"),
+            &"7".repeat(64),
+        )
+        .unwrap();
+        drop(hit);
+        assert!(
+            root.as_path().exists(),
+            "the payload guard must retain the private plan after its artifact is replaced"
+        );
+        assert_eq!(
+            std::fs::read(match &payloads[0] {
+                CachedPayload::File(path) => path,
+                CachedPayload::Bytes(_) => panic!("provisional payload must stay path-backed"),
+            })
+            .unwrap(),
+            b"staged payload"
+        );
+        drop(payloads);
+        assert!(
+            !root.as_path().exists(),
+            "the private plan should clean up after the final hit clone drops"
+        );
     }
 
     #[test]

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/README.md
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/README.md
@@ -15,4 +15,6 @@ Split-out modules from the original `handle_compile.rs`. The compile pipeline is
 | `miss_store.rs` | Post-exec artifact store path |
 | `rustc_index.rs` | Merge rules for shared rustc output metadata and verdict rows |
 
-Tests live in `cached_hit.rs::tests` (mtime preservation, materialization shape) and in `pipeline.rs::tests` (phase wiring).
+Tests live in `cached_hit.rs::tests` (mtime preservation, materialization shape),
+`miss_store_tests.rs` (artifact publication), and `pipeline/` (phase wiring and
+request preparation).

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
@@ -231,6 +231,7 @@ pub(super) fn materialize_cached_compile_hit(
     // build tool is looking for, leaving the user's `-MF` target absent
     // and reproducing the exact stale-incremental-build bug this fix
     // closes.
+    let provisional_staged = payloads.is_provisional_staged();
     let (targets, payloads_to_write): (Vec<NormalizedPath>, Vec<CachedPayload>) =
         if let Some(requested_outputs) = rustc_metadata_compat_outputs {
             let mut targets = Vec::with_capacity(requested_outputs.len());
@@ -279,15 +280,25 @@ pub(super) fn materialize_cached_compile_hit(
             )
         })
         .collect::<Vec<_>>();
-    let has_staged_payload = payloads_to_write.iter().any(
-        |payload| matches!(payload, CachedPayload::File(path) if is_staged_artifact_path(path)),
-    );
-    let observed_result = write_payloads_par_with_mtime_floor_and_policies_observed(
-        &targets,
-        &payloads_to_write,
-        &mtime_floor_paths,
-        &delivery_policies,
-    );
+    let has_staged_payload = provisional_staged
+        || payloads_to_write.iter().any(
+            |payload| matches!(payload, CachedPayload::File(path) if is_staged_artifact_path(path)),
+        );
+    let observed_result = if provisional_staged {
+        write_provisional_payloads_par_with_mtime_floor_observed(
+            &targets,
+            &payloads_to_write,
+            &mtime_floor_paths,
+            &delivery_policies,
+        )
+    } else {
+        write_payloads_par_with_mtime_floor_and_policies_observed(
+            &targets,
+            &payloads_to_write,
+            &mtime_floor_paths,
+            &delivery_policies,
+        )
+    };
     payloads.record_staged_lock_timings(&state.profiler.staged);
     drop(payloads);
     let observed = match observed_result {
@@ -435,7 +446,10 @@ pub(super) fn materialize_cached_compile_hit(
     })
 }
 
-fn rustc_compat_payload_index_for(names: &[String], requested: &NormalizedPath) -> Option<usize> {
+pub(super) fn rustc_compat_payload_index_for(
+    names: &[String],
+    requested: &NormalizedPath,
+) -> Option<usize> {
     let requested_name = requested.file_name()?.to_str()?;
     if let Some(index) = names.iter().position(|name| name == requested_name) {
         return Some(index);

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
@@ -2,12 +2,59 @@
 
 use super::super::*;
 use super::cached_hit::{
-    materialize_cached_compile_hit, CachedHitFailure, CachedHitMaterializeRequest, CachedHitPhases,
+    materialize_cached_compile_hit, rustc_compat_payload_index_for, CachedHitFailure,
+    CachedHitMaterializeRequest, CachedHitPhases,
 };
 use crate::depgraph::depfile::user_depfile_destination;
 use crate::depgraph::UserDepFlags;
 
 const DYLINT_CACHE_INPUT_HASH_ENV: &str = "ZCCACHE_DYLINT_CACHE_INPUT_HASH";
+
+pub(super) fn artifact_ready_for_request(
+    state: &SharedState,
+    key_hex: &str,
+    verdict_key_hex: Option<&str>,
+    requested_outputs: Option<&[NormalizedPath]>,
+) -> bool {
+    let Some(cached) = state.artifacts.get(key_hex) else {
+        return false;
+    };
+    if let Some(verdict_key) = verdict_key_hex {
+        let Some(verdict) = cached.meta.rustc_verdicts.get(verdict_key) else {
+            return false;
+        };
+        if verdict.exit_code != 0 {
+            return true;
+        }
+    }
+    requested_outputs.is_none_or(|outputs| {
+        outputs.iter().all(|output| {
+            rustc_compat_payload_index_for(&cached.meta.output_names, output).is_some()
+        })
+    })
+}
+
+pub(super) async fn await_artifact_publication_if_needed(
+    state: &SharedState,
+    key_hex: &str,
+    verdict_key_hex: Option<&str>,
+    requested_outputs: Option<&[NormalizedPath]>,
+) {
+    let deadline = tokio::time::Instant::now() + pending_writes::PENDING_PAYLOAD_WAIT_TIMEOUT;
+    while !artifact_ready_for_request(state, key_hex, verdict_key_hex, requested_outputs) {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero()
+            || !pending_writes::await_pending_payload(
+                &state.pending_cache_writes,
+                key_hex,
+                remaining,
+            )
+            .await
+        {
+            break;
+        }
+    }
+}
 
 fn rustc_verdict_key_hex(
     is_rustc: bool,
@@ -134,12 +181,8 @@ pub(super) async fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Op
     }
 
     // A cold miss may have installed a provisional in-memory payload while
-    // its durable write is pending. It is immediately usable in-process; only
-    // wait when that entry is not yet visible, then re-lookup after publish.
-    if !state.artifacts.contains_key(artifact_key_hex) {
-        pending_writes::await_pending_payload(&state.pending_cache_writes, artifact_key_hex).await;
-    }
-
+    // its durable write is pending. Wait only when the artifact, requested
+    // verdict, or requested output mapping is not ready for this hit.
     let hit_label = if same_root {
         "HIT_REQUEST"
     } else {
@@ -150,6 +193,13 @@ pub(super) async fn try_request_cache_hit(probe: RequestCacheHitProbe<'_>) -> Op
     let rustc_archive_hardlink_eligible =
         is_rustc.then(|| crate::compiler::rustc_archive_hardlink_eligible(rustc_args));
     let verdict_key_hex = rustc_verdict_key_hex(is_rustc, artifact_key_hex, client_env);
+    await_artifact_publication_if_needed(
+        state,
+        artifact_key_hex,
+        verdict_key_hex.as_deref(),
+        rustc_requested_outputs.as_deref(),
+    )
+    .await;
     materialize_cached_compile_hit(CachedHitMaterializeRequest {
         state,
         sid,
@@ -245,19 +295,10 @@ pub(super) async fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
         return None;
     }
 
-    // Issue #610, DD-025: if a cold-miss for this artifact key is still
-    // publishing to the in-memory cache, briefly wait so the materialize
-    // step below hits instead of falling through to a recompile-on-race.
-    // A provisional in-memory payload remains usable for this process while
-    // persistence is in flight. Wait only if it is not yet visible; then a
-    // completion can publish it before we re-lookup. `await_pending` clones
-    // the inner `Arc<Notify>` before yielding so no DashMap shard lock
-    // straddles the await.
-    if !state.artifacts.contains_key(&entry_artifact_key_hex) {
-        pending_writes::await_pending_payload(&state.pending_cache_writes, &entry_artifact_key_hex)
-            .await;
-    }
-
+    // Issue #610, DD-025: if a cold miss is still publishing this artifact's
+    // request-specific verdict/output metadata, wait so materialization does
+    // not fall through to a recompile-on-race. Ready provisional payloads
+    // remain immediately usable while durable persistence is in flight.
     let secondary_output_dir = if is_rustc {
         output_path.parent().unwrap_or(cwd_path).into()
     } else {
@@ -281,6 +322,13 @@ pub(super) async fn try_fast_hit(probe: FastHitProbe<'_>) -> Option<Response> {
         None
     };
     let verdict_key_hex = rustc_verdict_key_hex(is_rustc, &entry_artifact_key_hex, client_env);
+    await_artifact_publication_if_needed(
+        state,
+        &entry_artifact_key_hex,
+        verdict_key_hex.as_deref(),
+        rustc_requested_outputs.as_deref(),
+    )
+    .await;
     let response = materialize_cached_compile_hit(CachedHitMaterializeRequest {
         state,
         sid,
@@ -420,9 +468,14 @@ pub(super) async fn try_depgraph_cached_hit(
     // background task. If the build removes its just-produced output before
     // that task completes, a depgraph hit can otherwise fail to materialize
     // and unnecessarily recompile. The fast-hit path has the same guard.
-    pending_writes::await_pending_payload(&state.pending_cache_writes, artifact_key_hex).await;
-
     let verdict_key_hex = rustc_verdict_key_hex(is_rustc, artifact_key_hex, client_env);
+    await_artifact_publication_if_needed(
+        state,
+        artifact_key_hex,
+        verdict_key_hex.as_deref(),
+        rustc_requested_outputs.as_deref(),
+    )
+    .await;
 
     let response = materialize_cached_compile_hit(CachedHitMaterializeRequest {
         state,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/hit_branches.rs
@@ -27,11 +27,14 @@ pub(super) fn artifact_ready_for_request(
             return true;
         }
     }
-    requested_outputs.is_none_or(|outputs| {
+    if let Some(outputs) = requested_outputs {
         outputs.iter().all(|output| {
-            rustc_compat_payload_index_for(&cached.meta.output_names, output).is_some()
+            rustc_compat_payload_index_for(&cached.meta.output_names, output)
+                .is_some_and(|index| cached.materialization_payload_ready(index))
         })
-    })
+    } else {
+        (0..cached.meta.output_names.len()).all(|index| cached.materialization_payload_ready(index))
+    }
 }
 
 pub(super) async fn await_artifact_publication_if_needed(
@@ -41,7 +44,9 @@ pub(super) async fn await_artifact_publication_if_needed(
     requested_outputs: Option<&[NormalizedPath]>,
 ) {
     let deadline = tokio::time::Instant::now() + pending_writes::PENDING_PAYLOAD_WAIT_TIMEOUT;
-    while !artifact_ready_for_request(state, key_hex, verdict_key_hex, requested_outputs) {
+    while state.pending_cache_writes.contains_key(key_hex)
+        && !artifact_ready_for_request(state, key_hex, verdict_key_hex, requested_outputs)
+    {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero()
             || !pending_writes::await_pending_payload(

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
@@ -341,9 +341,9 @@ fn store_rustc_outputs(
     }
     stats.artifact_meta_build_ns = t_artifact_meta_build.elapsed().as_nanos() as u64;
 
-    // Rustc outputs are already on disk under target/. Persist them before
-    // publishing the in-memory artifact so depgraph hits never point at a
-    // key whose payload files have not landed yet.
+    // Rustc outputs already exist in the private compile plan. Publish those
+    // owned paths provisionally for immediate in-process hits; the detached
+    // publisher later replaces that entry with the durable generation/index.
     let t_artifact_index_build = Instant::now();
     let mut meta = ArtifactIndex::new(
         output_names,
@@ -369,6 +369,24 @@ fn store_rustc_outputs(
 
     if let Some(staged_plan) = staged_persist_plan {
         let _pending = pending_writes::register(&state.pending_cache_writes, artifact_key_hex);
+        let staged_plan = Arc::new(staged_plan);
+        // The publisher and provisional hit need the same metadata, paths,
+        // and private-plan lifetime. These clones deliberately split that
+        // ownership before the publisher moves its copies into the task.
+        let provisional = CachedArtifact::from_provisional_staged(
+            meta.clone(),
+            source_paths.clone(),
+            Arc::clone(&staged_plan),
+        );
+        let provisional = match state.artifacts.entry(artifact_key_hex.to_string()) {
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                // Retain one identity clone so a failed older publisher can
+                // remove only its own provisional row, never a replacement.
+                entry.insert(provisional.clone());
+                Some(provisional)
+            }
+            dashmap::mapref::entry::Entry::Occupied(_) => None,
+        };
         let state_ref = Arc::clone(state_arc);
         let state_for_publish = Arc::clone(state_arc);
         let artifact_dir = state.artifact_dir.clone();
@@ -377,6 +395,7 @@ fn store_rustc_outputs(
         let completion_key = artifact_key_hex.to_string();
         let t_persist_enqueue = Instant::now();
         tokio::spawn(async move {
+            let plan_for_publish = Arc::clone(&staged_plan);
             #[expect(
                 clippy::expect_used,
                 reason = "persist_semaphore is owned by ServerState for the daemon's lifetime; AcquireError here would be a logic bug"
@@ -388,7 +407,7 @@ fn store_rustc_outputs(
                 .expect("persist_semaphore is owned by ServerState and never closed");
             let published = tokio::task::spawn_blocking(move || {
                 let _publication_guard = publication_guard;
-                let _staged_plan = staged_plan;
+                let _staged_plan = plan_for_publish;
                 let snapshot =
                     persist_artifact_paths_with_stats(&artifact_dir, &key_hex, &source_paths)?;
                 commit_rustc_artifact_index(
@@ -454,13 +473,28 @@ fn store_rustc_outputs(
                             );
                         }
                     }
-                    state_ref.artifacts.remove(&completion_key);
+                    if reason == StagedPublishFailure::Conflict {
+                        state_ref.artifacts.remove(&completion_key);
+                    } else if let Some(provisional) = provisional.as_ref() {
+                        remove_provisional_artifact(
+                            state_ref.as_ref(),
+                            &completion_key,
+                            provisional,
+                        );
+                    }
                 }
                 Err(error) => {
                     tracing::warn!(%error, key = %completion_key, "staged artifact persistence task failed to join");
-                    state_ref.artifacts.remove(&completion_key);
+                    if let Some(provisional) = provisional.as_ref() {
+                        remove_provisional_artifact(
+                            state_ref.as_ref(),
+                            &completion_key,
+                            provisional,
+                        );
+                    }
                 }
             }
+            drop(staged_plan);
             pending_writes::complete(&state_ref.pending_cache_writes, &completion_key);
         });
         stats.persist_enqueue_ns = t_persist_enqueue.elapsed().as_nanos() as u64;
@@ -559,6 +593,16 @@ fn store_rustc_outputs(
     });
     stats.artifact_insert_stats_ns = t_artifact_insert_stats.elapsed().as_nanos() as u64;
     drop(publication_guard);
+}
+
+fn remove_provisional_artifact(state: &SharedState, key_hex: &str, provisional: &CachedArtifact) {
+    if let dashmap::mapref::entry::Entry::Occupied(entry) =
+        state.artifacts.entry(key_hex.to_owned())
+    {
+        if entry.get().same_instance(provisional) {
+            entry.remove();
+        }
+    }
 }
 
 fn commit_rustc_artifact_index(
@@ -889,95 +933,5 @@ fn store_single_output(
 }
 
 #[cfg(test)]
-mod staged_publication_diagnostic_tests {
-    use super::{
-        commit_rustc_artifact_index, enqueue_persisted_index,
-        preserve_staged_depfile_for_persistence, truncate_staged_publication_error, ArtifactIndex,
-        ArtifactVerdict, PersistOutcome, MAX_STAGED_PUBLICATION_ERROR_CHARS,
-    };
-    use crate::core::NormalizedPath;
-    use std::sync::Arc;
-
-    #[tokio::test]
-    async fn rustc_index_commit_merges_verdicts_for_shared_artifact_bytes() {
-        let temp = tempfile::tempdir().unwrap();
-        let server = crate::daemon::server::tests::bind_isolated_server(temp.path());
-        let mut meta = ArtifactIndex::new(vec![], vec![], vec![], vec![], 0);
-        for key in ["plain", "dylint"] {
-            meta.rustc_verdicts.insert(
-                key.to_string(),
-                ArtifactVerdict {
-                    stdout: Arc::new(Vec::new()),
-                    stderr: Arc::new(key.as_bytes().to_vec()),
-                    exit_code: 0,
-                },
-            );
-            commit_rustc_artifact_index(&server.state, "artifact".to_string(), meta, false)
-                .unwrap();
-            meta = ArtifactIndex::new(vec![], vec![], vec![], vec![], 0);
-        }
-        let cached = server.state.artifacts.get("artifact").unwrap();
-        assert_eq!(cached.meta.rustc_verdicts.len(), 2);
-    }
-
-    #[test]
-    fn failed_async_persist_never_enqueues_an_index_insert() {
-        let (index_tx, mut index_rx) = tokio::sync::mpsc::unbounded_channel();
-        let queued = enqueue_persisted_index(
-            PersistOutcome::failed(),
-            &index_tx,
-            "failed-persist-key".to_string(),
-        );
-
-        assert!(!queued, "a failed persist must not be indexed");
-        assert!(
-            index_rx.try_recv().is_err(),
-            "failed persist must not send IndexWriterCommand::Insert"
-        );
-    }
-
-    #[test]
-    fn publication_error_is_bounded_without_splitting_utf8() {
-        let error = format!("{}suffix", "å".repeat(MAX_STAGED_PUBLICATION_ERROR_CHARS));
-        let rendered = truncate_staged_publication_error(&error);
-
-        assert!(rendered.ends_with('…'));
-        assert_eq!(
-            rendered.trim_end_matches('…').chars().count(),
-            MAX_STAGED_PUBLICATION_ERROR_CHARS
-        );
-    }
-
-    #[test]
-    fn staged_depfile_persistence_source_survives_plan_cleanup() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let private_root = temp.path().join("private");
-        let staged_depfile: NormalizedPath = private_root.join("output-1").into();
-        let requested_depfile: NormalizedPath = temp.path().join("build/custom.mk").into();
-        std::fs::create_dir_all(&private_root).expect("private root");
-        std::fs::write(&staged_depfile, b"staged object: logical source\n")
-            .expect("staged depfile");
-        let mut capture = Some((staged_depfile, b"staged object: logical source\n".to_vec()));
-
-        let guard = preserve_staged_depfile_for_persistence(
-            &mut capture,
-            Some(&requested_depfile),
-            temp.path(),
-        )
-        .expect("preserve depfile")
-        .expect("persistence guard");
-        let preserved = capture.as_ref().expect("capture").0.clone();
-        assert_eq!(
-            preserved.file_name().and_then(|name| name.to_str()),
-            Some("custom.mk")
-        );
-
-        std::fs::remove_dir_all(&private_root).expect("simulate staged-plan cleanup");
-        assert_eq!(
-            std::fs::read(&preserved).expect("preserved canonical bytes"),
-            b"staged object: logical source\n"
-        );
-        drop(guard);
-        assert!(!preserved.as_path().exists());
-    }
-}
+#[path = "miss_store_tests.rs"]
+mod staged_publication_diagnostic_tests;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store_tests.rs
@@ -1,0 +1,322 @@
+//! Focused regressions for compile-miss artifact publication.
+
+use super::{
+    commit_rustc_artifact_index, enqueue_persisted_index, preserve_staged_depfile_for_persistence,
+    remove_provisional_artifact, store_rustc_outputs, truncate_staged_publication_error,
+    MissArtifactStoreStats, PersistOutcome, MAX_STAGED_PUBLICATION_ERROR_CHARS,
+};
+use crate::core::NormalizedPath;
+use crate::daemon::server::*;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[tokio::test]
+async fn rustc_index_commit_merges_verdicts_for_shared_artifact_bytes() {
+    let temp = tempfile::tempdir().unwrap();
+    let server = crate::daemon::server::tests::bind_isolated_server(temp.path());
+    let mut meta = ArtifactIndex::new(vec![], vec![], vec![], vec![], 0);
+    for key in ["plain", "dylint"] {
+        meta.rustc_verdicts.insert(
+            key.to_string(),
+            ArtifactVerdict {
+                stdout: Arc::new(Vec::new()),
+                stderr: Arc::new(key.as_bytes().to_vec()),
+                exit_code: 0,
+            },
+        );
+        commit_rustc_artifact_index(&server.state, "artifact".to_string(), meta, false).unwrap();
+        meta = ArtifactIndex::new(vec![], vec![], vec![], vec![], 0);
+    }
+    let cached = server.state.artifacts.get("artifact").unwrap();
+    assert_eq!(cached.meta.rustc_verdicts.len(), 2);
+}
+
+#[tokio::test]
+async fn perf_staged_rust_hit_uses_provisional_payload_before_durable_publication() {
+    let temp = tempfile::tempdir().unwrap();
+    let server = crate::daemon::server::tests::bind_isolated_server(temp.path());
+    let state = Arc::clone(&server.state);
+    let work = tempfile::tempdir().unwrap();
+    let permits = state.persist_semaphore.available_permits() as u32;
+    assert!(permits > 0, "test server must expose a persist permit");
+    let blocked_publisher = Arc::clone(&state.persist_semaphore)
+        .acquire_many_owned(permits)
+        .await
+        .unwrap();
+    let private_root: NormalizedPath = work.path().join("private-rust-output").into();
+    std::fs::create_dir_all(&private_root).unwrap();
+    let staged: NormalizedPath = private_root.join("libworkspace.a");
+    let requested: NormalizedPath = work.path().join("libworkspace.a").into();
+    let expected = b"workspace staticlib";
+    std::fs::write(&staged, expected).unwrap();
+    let plan = StagedCompilePlan::for_test(
+        private_root,
+        vec![StagedOutputPlan {
+            requested: requested.clone(),
+            staged: staged.clone(),
+            role: StagedOutputRole::Regular,
+        }],
+    );
+    let outputs = vec![RustcOutputFile {
+        name: "libworkspace.a".to_string(),
+        path: staged.clone(),
+        size: expected.len() as u64,
+    }];
+    let key = "8".repeat(64);
+    let sid = crate::depgraph::SessionId::new();
+    let source_path: NormalizedPath = work.path().join("lib.rs").into();
+    let mut stats = MissArtifactStoreStats::default();
+    let publication_guard = begin_artifact_publication(&state).await.unwrap();
+
+    store_rustc_outputs(
+        &state,
+        &sid,
+        &source_path,
+        &outputs,
+        &key,
+        None,
+        &Arc::new(Vec::new()),
+        &Arc::new(Vec::new()),
+        0,
+        Instant::now(),
+        &mut stats,
+        Instant::now(),
+        false,
+        Some(plan),
+        publication_guard,
+    );
+    assert!(
+        staged.is_file(),
+        "publishing the provisional entry must retain its private source"
+    );
+
+    let verdict_key = crate::depgraph::compute_rustc_verdict_key(&key, None)
+        .hash()
+        .to_hex();
+    let requested_outputs = vec![requested.clone()];
+    let started = Instant::now();
+    super::super::hit_branches::await_artifact_publication_if_needed(
+        &state,
+        &key,
+        Some(&verdict_key),
+        Some(&requested_outputs),
+    )
+    .await;
+    assert!(
+        staged.is_file(),
+        "bypassing the pending wait must not release the private source"
+    );
+    let response = super::super::cached_hit::materialize_cached_compile_hit(
+        super::super::cached_hit::CachedHitMaterializeRequest {
+            state: &state,
+            sid: &sid,
+            artifact_key_hex: &key,
+            verdict_key_hex: Some(&verdict_key),
+            source_path: &source_path,
+            output_path: &requested,
+            secondary_output_dir: work.path().into(),
+            current_depfile_dest: None,
+            compile_start: Instant::now(),
+            hit_label: "HIT_TEST",
+            cached_error_label: "CACHED_ERROR_TEST",
+            record_compilation: false,
+            downgrade_output_metadata: true,
+            mtime_floor_paths: Vec::new(),
+            // Exercise the explicit emit-compat mapping used by the pipeline's
+            // alternate rustc context hit branch while publication is blocked.
+            rustc_metadata_compat_outputs: Some(requested_outputs),
+            rustc_archive_hardlink_eligible: Some(false),
+            phases: super::super::cached_hit::CachedHitPhases::request_cache(0, 0),
+        },
+    )
+    .unwrap();
+    assert!(
+        started.elapsed() < Duration::from_millis(500),
+        "a proven hit must not wait for the blocked durable publisher"
+    );
+    assert!(matches!(
+        response,
+        Response::CompileResult {
+            exit_code: 0,
+            cached: true,
+            ..
+        }
+    ));
+    assert_eq!(std::fs::read(&requested).unwrap(), expected);
+    drop(blocked_publisher);
+    assert!(
+        pending_writes::await_all(&state.pending_cache_writes, Duration::from_secs(10)).await,
+        "detached publisher did not complete after its permit was released"
+    );
+}
+
+#[tokio::test]
+async fn failed_older_publisher_does_not_remove_replacement_artifact() {
+    let temp = tempfile::tempdir().unwrap();
+    let server = crate::daemon::server::tests::bind_isolated_server(temp.path());
+    let artifact = |byte| {
+        CachedArtifact::from_cached_payloads(
+            ArtifactIndex::new(
+                vec!["output.rmeta".to_string()],
+                vec![1],
+                Arc::new(Vec::new()),
+                Arc::new(Vec::new()),
+                0,
+            ),
+            vec![CachedPayload::Bytes(Arc::new(vec![byte]))],
+        )
+    };
+    let key = "replacement-key";
+    let provisional = artifact(1);
+    let replacement = artifact(2);
+    server
+        .state
+        .artifacts
+        .insert(key.to_string(), replacement.clone());
+
+    remove_provisional_artifact(&server.state, key, &provisional);
+
+    let live = server.state.artifacts.get(key).unwrap();
+    assert!(
+        live.same_instance(&replacement),
+        "a stale publisher failure must preserve the newer artifact"
+    );
+}
+
+#[tokio::test]
+async fn visible_artifact_waits_for_pending_sibling_verdict() {
+    let temp = tempfile::tempdir().unwrap();
+    let server = crate::daemon::server::tests::bind_isolated_server(temp.path());
+    let state = Arc::clone(&server.state);
+    let key = "shared-rust-artifact";
+    let plain_verdict_key = "plain-verdict";
+    let requested_verdict_key = "dylint-verdict";
+    let requested_output: NormalizedPath = temp.path().join("output.rmeta").into();
+    let requested_outputs = vec![requested_output];
+    let verdict = |stderr: &[u8]| ArtifactVerdict {
+        stdout: Arc::new(Vec::new()),
+        stderr: Arc::new(stderr.to_vec()),
+        exit_code: 0,
+    };
+    let artifact = |include_requested_verdict| {
+        let mut meta = ArtifactIndex::new(
+            vec!["output.rmeta".to_string()],
+            vec![1],
+            Arc::new(Vec::new()),
+            Arc::new(Vec::new()),
+            0,
+        );
+        meta.rustc_verdicts
+            .insert(plain_verdict_key.to_string(), verdict(b"plain"));
+        if include_requested_verdict {
+            meta.rustc_verdicts
+                .insert(requested_verdict_key.to_string(), verdict(b"dylint"));
+        }
+        CachedArtifact::from_cached_payloads(meta, vec![CachedPayload::Bytes(Arc::new(vec![1]))])
+    };
+    state.artifacts.insert(key.to_string(), artifact(false));
+    let _plain_publisher = pending_writes::register(&state.pending_cache_writes, key);
+    let _dylint_publisher = pending_writes::register(&state.pending_cache_writes, key);
+
+    let state_for_waiter = Arc::clone(&state);
+    let requested_outputs_for_waiter = requested_outputs.clone();
+    let mut waiter = tokio::spawn(async move {
+        super::super::hit_branches::await_artifact_publication_if_needed(
+            &state_for_waiter,
+            key,
+            Some(requested_verdict_key),
+            Some(&requested_outputs_for_waiter),
+        )
+        .await;
+    });
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), &mut waiter)
+            .await
+            .is_err(),
+        "an occupied row missing the requested sibling verdict must wait"
+    );
+
+    pending_writes::complete(&state.pending_cache_writes, key);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), &mut waiter)
+            .await
+            .is_err(),
+        "an unrelated publisher completing first must not end the wait"
+    );
+
+    state.artifacts.insert(key.to_string(), artifact(true));
+    pending_writes::complete(&state.pending_cache_writes, key);
+    tokio::time::timeout(Duration::from_secs(1), waiter)
+        .await
+        .expect("request-specific wait timed out")
+        .expect("request-specific wait task panicked");
+    assert!(
+        super::super::hit_branches::artifact_ready_for_request(
+            &state,
+            key,
+            Some(requested_verdict_key),
+            Some(&requested_outputs),
+        ),
+        "the merged sibling verdict and output must satisfy the request"
+    );
+}
+
+#[test]
+fn failed_async_persist_never_enqueues_an_index_insert() {
+    let (index_tx, mut index_rx) = tokio::sync::mpsc::unbounded_channel();
+    let queued = enqueue_persisted_index(
+        PersistOutcome::failed(),
+        &index_tx,
+        "failed-persist-key".to_string(),
+    );
+
+    assert!(!queued, "a failed persist must not be indexed");
+    assert!(
+        index_rx.try_recv().is_err(),
+        "failed persist must not send IndexWriterCommand::Insert"
+    );
+}
+
+#[test]
+fn publication_error_is_bounded_without_splitting_utf8() {
+    let error = format!("{}suffix", "å".repeat(MAX_STAGED_PUBLICATION_ERROR_CHARS));
+    let rendered = truncate_staged_publication_error(&error);
+
+    assert!(rendered.ends_with('…'));
+    assert_eq!(
+        rendered.trim_end_matches('…').chars().count(),
+        MAX_STAGED_PUBLICATION_ERROR_CHARS
+    );
+}
+
+#[test]
+fn staged_depfile_persistence_source_survives_plan_cleanup() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let private_root = temp.path().join("private");
+    let staged_depfile: NormalizedPath = private_root.join("output-1").into();
+    let requested_depfile: NormalizedPath = temp.path().join("build/custom.mk").into();
+    std::fs::create_dir_all(&private_root).expect("private root");
+    std::fs::write(&staged_depfile, b"staged object: logical source\n").expect("staged depfile");
+    let mut capture = Some((staged_depfile, b"staged object: logical source\n".to_vec()));
+
+    let guard = preserve_staged_depfile_for_persistence(
+        &mut capture,
+        Some(&requested_depfile),
+        temp.path(),
+    )
+    .expect("preserve depfile")
+    .expect("persistence guard");
+    let preserved = capture.as_ref().expect("capture").0.clone();
+    assert_eq!(
+        preserved.file_name().and_then(|name| name.to_str()),
+        Some("custom.mk")
+    );
+
+    std::fs::remove_dir_all(&private_root).expect("simulate staged-plan cleanup");
+    assert_eq!(
+        std::fs::read(&preserved).expect("preserved canonical bytes"),
+        b"staged object: logical source\n"
+    );
+    drop(guard);
+    assert!(!preserved.as_path().exists());
+}

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store_tests.rs
@@ -261,6 +261,76 @@ async fn visible_artifact_waits_for_pending_sibling_verdict() {
     );
 }
 
+#[tokio::test]
+async fn visible_metadata_waits_for_pending_payload_replacement() {
+    let temp = tempfile::tempdir().unwrap();
+    let server = crate::daemon::server::tests::bind_isolated_server(temp.path());
+    let state = Arc::clone(&server.state);
+    let key = "stale-rust-artifact";
+    let verdict_key = "rustc-verdict";
+    let requested_output: NormalizedPath = temp.path().join("output.rmeta").into();
+    let requested_outputs = vec![requested_output];
+    let metadata = || {
+        let mut meta = ArtifactIndex::new(
+            vec!["output.rmeta".to_string()],
+            vec![1],
+            Arc::new(Vec::new()),
+            Arc::new(Vec::new()),
+            0,
+        );
+        meta.rustc_verdicts.insert(
+            verdict_key.to_string(),
+            ArtifactVerdict {
+                stdout: Arc::new(Vec::new()),
+                stderr: Arc::new(Vec::new()),
+                exit_code: 0,
+            },
+        );
+        meta
+    };
+    state
+        .artifacts
+        .insert(key.to_string(), CachedArtifact::from_index(metadata()));
+    let _publisher = pending_writes::register(&state.pending_cache_writes, key);
+
+    let state_for_waiter = Arc::clone(&state);
+    let requested_outputs_for_waiter = requested_outputs.clone();
+    let mut waiter = tokio::spawn(async move {
+        super::super::hit_branches::await_artifact_publication_if_needed(
+            &state_for_waiter,
+            key,
+            Some(verdict_key),
+            Some(&requested_outputs_for_waiter),
+        )
+        .await;
+    });
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), &mut waiter)
+            .await
+            .is_err(),
+        "visible metadata without a usable payload must wait for replacement"
+    );
+
+    state.artifacts.insert(
+        key.to_string(),
+        CachedArtifact::from_cached_payloads(
+            metadata(),
+            vec![CachedPayload::Bytes(Arc::new(vec![1]))],
+        ),
+    );
+    pending_writes::complete(&state.pending_cache_writes, key);
+    tokio::time::timeout(Duration::from_secs(1), waiter)
+        .await
+        .expect("payload replacement wait timed out")
+        .expect("payload replacement wait task panicked");
+    assert!(super::super::hit_branches::artifact_ready_for_request(
+        &state,
+        key,
+        Some(verdict_key),
+        Some(&requested_outputs),
+    ));
+}
+
 #[test]
 fn failed_async_persist_never_enqueues_an_index_insert() {
     let (index_tx, mut index_rx) = tokio::sync::mpsc::unbounded_channel();

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -27,8 +27,8 @@ use super::cached_hit::{
 };
 use super::error_cache::maybe_store_rustc_error_artifact;
 use super::hit_branches::{
-    try_depgraph_cached_hit, try_fast_hit, try_request_cache_hit, DepgraphHitProbe, FastHitProbe,
-    RequestCacheHitProbe,
+    await_artifact_publication_if_needed, try_depgraph_cached_hit, try_fast_hit,
+    try_request_cache_hit, DepgraphHitProbe, FastHitProbe, RequestCacheHitProbe,
 };
 use super::request::CompileRequest;
 
@@ -709,12 +709,6 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                 );
                 if let crate::depgraph::CacheVerdict::Hit { artifact_key } = compat_verdict {
                     let artifact_key_hex = artifact_key.hash().to_hex();
-                    pending_writes::await_pending(
-                        &state.pending_cache_writes,
-                        &artifact_key_hex,
-                        pending_writes::PENDING_WAIT_TIMEOUT,
-                    )
-                    .await;
                     let requested_outputs = rustc_expected_output_paths(
                         rustc_args,
                         output_path.as_path(),
@@ -730,6 +724,13 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
                         crate::depgraph::compute_rustc_verdict_key(&artifact_key_hex, dylint_hash)
                             .hash()
                             .to_hex();
+                    await_artifact_publication_if_needed(
+                        state,
+                        &artifact_key_hex,
+                        Some(&verdict_key_hex),
+                        Some(&requested_outputs),
+                    )
+                    .await;
                     if let Ok(response) =
                         materialize_cached_compile_hit(CachedHitMaterializeRequest {
                             state,

--- a/crates/zccache-daemon-core/src/daemon/server/pending_writes.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/pending_writes.rs
@@ -1,15 +1,9 @@
 //! Pending cache-write registry (issue #610, DD-025 condition 1).
 //!
-//! The helper functions are exercised by the test module here and by
-//! the cross-cutting integration tests in
-//! `daemon/server/tests/pending_cache_writes.rs`. They are not yet
-//! referenced from production code paths because the wiring lives in a
-//! follow-up PR that defers `state.artifacts.insert` (see
-//! `daemon/server/handle_compile/miss_store.rs` `store_*` functions).
-//! Allow `dead_code` here so the scaffolding can land and be reviewed
-//! independently of the wiring, matching the existing #610 cadence
-//! (#611, #612, #613, #618, #651 landed adversarial tests on the same
-//! "tests first, wiring second" model).
+//! The registry is wired into deferred artifact publication in
+//! `daemon/server/handle_compile/miss_store.rs`; focused unit and
+//! cross-cutting tests live here and in
+//! `daemon/server/tests/pending_cache_writes.rs`.
 //!
 //! Bridges the visibility gap between the daemon's response-return and
 //! the *deferred* publication of a cold-miss artifact into
@@ -18,11 +12,10 @@
 //! and [`complete`] after the spawn's work has updated the in-memory
 //! cache (or after the spawn has failed and the lookup should re-miss).
 //!
-//! Concurrent lookups call [`await_pending`] before falling through to
-//! a regular `state.artifacts.get()`. If a pending entry exists, they
-//! wait briefly on the entry's `Notify` (capped by
-//! [`PENDING_WAIT_TIMEOUT`]) and then re-attempt the lookup. If the
-//! wait times out, they fall through to a normal miss.
+//! Proven cache-hit lookups whose request-specific metadata is not yet
+//! visible call [`await_pending_payload`] before re-attempting the lookup.
+//! The test-only `await_pending` helper retains coverage of the original
+//! bounded-wait registry contract.
 //!
 //! ## Failure-mode invariant (DD-025 condition 2)
 //!
@@ -42,13 +35,11 @@
 //!
 //! ## Blast-radius bound (DD-025 condition 3)
 //!
-//! - **Time**: entries live ≤ [`PENDING_ENTRY_TTL_MS`] (100 ms — 30× the
-//!   measured p99 of `depgraph_update_ns + persist_enqueue` from #605
-//!   iter T2). The TTL is informational; staleness is bounded in
-//!   practice by the spawn's actual runtime.
-//! - **Count**: bounded above by the daemon's persist semaphore
-//!   available-permits — the same semaphore that already bounds C/C++
-//!   persist spawns.
+//! - **Time**: proven-payload waits are capped by
+//!   [`PENDING_PAYLOAD_WAIT_TIMEOUT`]; entries remain until every same-key
+//!   publisher finishes, and shutdown applies a separate bounded drain.
+//! - **Count**: one entry per artifact key; the daemon's persist semaphore
+//!   bounds active persistence work.
 //! - **Scope**: per-daemon-process. Restart empties the registry.
 
 use std::sync::Arc;
@@ -56,6 +47,13 @@ use std::time::Duration;
 
 use dashmap::DashMap;
 use tokio::sync::Notify;
+
+/// Per-key publication state. Multiple compiles can publish independent
+/// verdict/output metadata for the same shared Rust artifact concurrently.
+pub(super) struct PendingWrite {
+    active_publishers: usize,
+    notify: Arc<Notify>,
+}
 
 /// Maximum time a lookup will wait on a pending registry entry before
 /// falling through to a normal miss. Sized to be a small fraction of the
@@ -67,12 +65,13 @@ use tokio::sync::Notify;
 /// Lookups that can't afford even this much (e.g., the request-cache
 /// fast-path) should pass `Duration::ZERO` to [`await_pending`] and
 /// fall through to miss immediately.
+#[cfg(test)]
 pub(super) const PENDING_WAIT_TIMEOUT: Duration = Duration::from_millis(5);
 
 /// Longer wait used when the depgraph has already proven a cache hit and the
 /// only remaining race is rustc staged-payload publication. This prevents an
 /// immediate duplicate compile while a large artifact is being durably
-/// snapshotted; ordinary pending-write probes retain their 5 ms bound.
+/// snapshotted.
 pub(super) const PENDING_PAYLOAD_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Informational upper bound on how long a pending entry is expected to
@@ -86,32 +85,38 @@ pub(super) const PENDING_ENTRY_TTL_MS: u64 = 100;
 ///
 /// **Must** be called by the cold-miss handler *before* spawning the
 /// deferred work that will eventually insert into `state.artifacts`.
-/// The returned [`Arc<Notify>`] is held by the spawned task so it can
-/// call [`complete`] after the in-memory cache has been updated.
+/// The returned [`Arc<Notify>`] is held by the spawned task so it can call
+/// [`complete`] after the in-memory cache has been updated. Same-key
+/// registrations increment the active-publisher count and share the notifier.
 ///
-/// If a pending entry already exists for `key` (e.g., two parallel
-/// cold-misses for the same artifact landed in a tight window), the
-/// existing entry's `Notify` is returned. Both spawned tasks will then
-/// call `notify_waiters()` on the same handle — idempotent.
-pub(super) fn register(pending: &DashMap<String, Arc<Notify>>, key: &str) -> Arc<Notify> {
-    pending
+pub(super) fn register(pending: &DashMap<String, PendingWrite>, key: &str) -> Arc<Notify> {
+    let mut entry = pending
         .entry(key.to_string())
-        .or_insert_with(|| Arc::new(Notify::new()))
-        .clone()
+        .or_insert_with(|| PendingWrite {
+            active_publishers: 0,
+            notify: Arc::new(Notify::new()),
+        });
+    entry.active_publishers += 1;
+    Arc::clone(&entry.notify)
 }
 
 /// Mark the pending cache-write for `key` as complete.
 ///
-/// Notifies any waiting lookups and removes the registry entry. Must be
-/// called by the spawned task after `state.artifacts.insert(...)` has
-/// run (success path) or after the spawn has decided the artifact will
-/// never be inserted (error path). In the latter case, waiters wake up
-/// and re-attempt the lookup, which will miss and recompile — the
-/// DD-025-correct failure mode.
-pub(super) fn complete(pending: &DashMap<String, Arc<Notify>>, key: &str) {
-    if let Some((_, notify)) = pending.remove(key) {
-        notify.notify_waiters();
-    }
+/// Notifies waiting lookups after every publisher finishes, but retains the
+/// registry entry until the final same-key publisher completes. Must be called
+/// after the publisher has updated `state.artifacts` or decided it cannot.
+pub(super) fn complete(pending: &DashMap<String, PendingWrite>, key: &str) {
+    use dashmap::mapref::entry::Entry;
+
+    let notify = match pending.entry(key.to_string()) {
+        Entry::Occupied(mut entry) if entry.get().active_publishers > 1 => {
+            entry.get_mut().active_publishers -= 1;
+            Arc::clone(&entry.get().notify)
+        }
+        Entry::Occupied(entry) => entry.remove().notify,
+        Entry::Vacant(_) => return,
+    };
+    notify.notify_waiters();
 }
 
 /// If a pending cache-write exists for `key`, wait on its `Notify` up
@@ -128,8 +133,9 @@ pub(super) fn complete(pending: &DashMap<String, Arc<Notify>>, key: &str) {
 /// but the spawn took longer than expected). Callers re-attempt the
 /// lookup; if the second attempt also misses, they fall through to
 /// recompile — the DD-025 failure-mode-is-miss invariant holds.
+#[cfg(test)]
 pub(super) async fn await_pending(
-    pending: &DashMap<String, Arc<Notify>>,
+    pending: &DashMap<String, PendingWrite>,
     key: &str,
     timeout: Duration,
 ) -> bool {
@@ -140,25 +146,20 @@ pub(super) async fn await_pending(
 /// cache key has already been proven, so waiting for durable publication is
 /// preferable to recompiling the same artifact through an uncached path.
 pub(super) async fn await_pending_payload(
-    pending: &DashMap<String, Arc<Notify>>,
+    pending: &DashMap<String, PendingWrite>,
     key: &str,
+    timeout: Duration,
 ) -> bool {
-    await_pending_capped(
-        pending,
-        key,
-        PENDING_PAYLOAD_WAIT_TIMEOUT,
-        PENDING_PAYLOAD_WAIT_TIMEOUT,
-    )
-    .await
+    await_pending_capped(pending, key, timeout, PENDING_PAYLOAD_WAIT_TIMEOUT).await
 }
 
 async fn await_pending_capped(
-    pending: &DashMap<String, Arc<Notify>>,
+    pending: &DashMap<String, PendingWrite>,
     key: &str,
     timeout: Duration,
     maximum: Duration,
 ) -> bool {
-    let Some(notify) = pending.get(key).map(|entry| Arc::clone(&entry)) else {
+    let Some(entry) = pending.get(key) else {
         return false;
     };
     // Cap the caller's requested timeout at the pending-entry blast radius so
@@ -167,14 +168,23 @@ async fn await_pending_capped(
     if capped.is_zero() {
         return true;
     }
-    let _ = tokio::time::timeout(capped, notify.notified()).await;
+    // Register the waiter while the map guard prevents `complete` from
+    // removing/notifying this entry. Otherwise a completion between cloning
+    // the Notify and first polling the future could be lost until timeout.
+    let notified = Arc::clone(&entry.notify).notified_owned();
+    tokio::pin!(notified);
+    let notified_before_unlock = notified.as_mut().enable();
+    drop(entry);
+    if !notified_before_unlock {
+        let _ = tokio::time::timeout(capped, notified).await;
+    }
     true
 }
 
 /// Wait until all currently pending cache writes have completed, bounded by
 /// `timeout`. Used during graceful shutdown before draining the artifact-index
 /// WAL so deferred persist tasks can publish their `(key, ArtifactIndex)` rows.
-pub(super) async fn await_all(pending: &DashMap<String, Arc<Notify>>, timeout: Duration) -> bool {
+pub(super) async fn await_all(pending: &DashMap<String, PendingWrite>, timeout: Duration) -> bool {
     let deadline = tokio::time::sleep(timeout);
     tokio::pin!(deadline);
     loop {
@@ -195,21 +205,26 @@ mod tests {
     use super::*;
     use std::time::Instant;
 
-    /// `register` returns the same `Arc<Notify>` for repeat calls with
-    /// the same key — two racing cold-misses share the wait point.
+    /// Repeat registrations share the notifier and retain the entry until the
+    /// final same-key publisher completes.
     #[tokio::test]
-    async fn register_is_idempotent_for_same_key() {
-        let pending: DashMap<String, Arc<Notify>> = DashMap::new();
+    async fn same_key_registrations_are_counted() {
+        let pending: DashMap<String, PendingWrite> = DashMap::new();
         let a = register(&pending, "deadbeef");
         let b = register(&pending, "deadbeef");
         assert!(Arc::ptr_eq(&a, &b));
         assert_eq!(pending.len(), 1);
+        assert_eq!(pending.get("deadbeef").unwrap().active_publishers, 2);
+        complete(&pending, "deadbeef");
+        assert_eq!(pending.get("deadbeef").unwrap().active_publishers, 1);
+        complete(&pending, "deadbeef");
+        assert!(pending.is_empty());
     }
 
     /// `complete` removes the entry and wakes waiters.
     #[tokio::test]
     async fn complete_notifies_waiters_and_removes_entry() {
-        let pending: Arc<DashMap<String, Arc<Notify>>> = Arc::new(DashMap::new());
+        let pending: Arc<DashMap<String, PendingWrite>> = Arc::new(DashMap::new());
         let _notify = register(&pending, "feedface");
         let pending_for_waiter = Arc::clone(&pending);
         let wait = tokio::spawn(async move {
@@ -236,7 +251,7 @@ mod tests {
     async fn await_pending_times_out_and_does_not_leak() {
         const SCHEDULER_TOLERANCE: Duration = Duration::from_millis(50);
 
-        let pending: DashMap<String, Arc<Notify>> = DashMap::new();
+        let pending: DashMap<String, PendingWrite> = DashMap::new();
         let _registered = register(&pending, "cafebabe");
         let start = Instant::now();
         let observed = await_pending(&pending, "cafebabe", PENDING_WAIT_TIMEOUT).await;
@@ -268,7 +283,7 @@ mod tests {
     /// lookups; the registry must be near-zero overhead at rest.
     #[tokio::test]
     async fn await_pending_returns_false_immediately_when_not_registered() {
-        let pending: DashMap<String, Arc<Notify>> = DashMap::new();
+        let pending: DashMap<String, PendingWrite> = DashMap::new();
         let start = Instant::now();
         let observed = await_pending(&pending, "nothere", PENDING_WAIT_TIMEOUT).await;
         let elapsed = start.elapsed();
@@ -284,7 +299,7 @@ mod tests {
     /// a buggy caller can't blow the DD-025 blast-radius bound.
     #[tokio::test]
     async fn await_pending_caps_caller_timeout_at_the_blast_radius_bound() {
-        let pending: DashMap<String, Arc<Notify>> = DashMap::new();
+        let pending: DashMap<String, PendingWrite> = DashMap::new();
         let _registered = register(&pending, "longshot");
         let start = Instant::now();
         // Ask for a one-second timeout — the registry must cap to 5 ms.

--- a/crates/zccache-daemon-core/src/daemon/server/persist/write_cached.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/write_cached.rs
@@ -486,6 +486,49 @@ where
     P: AsRef<Path> + Sync,
     R: AsRef<Path>,
 {
+    write_payloads_par_with_mtime_floor_and_policies_observed_impl(
+        targets,
+        payloads,
+        floor_paths,
+        policies,
+        false,
+    )
+}
+
+/// Deliver compiler-private staged paths before their durable cache blobs have
+/// been registered. These sources are protected by the payload guard's plan
+/// ownership, so they must use independent reflink/copy delivery and must not
+/// pass through durable-blob digest verification or hardlink registration.
+pub(in crate::daemon::server) fn write_provisional_payloads_par_with_mtime_floor_observed<P, R>(
+    targets: &[P],
+    payloads: &[CachedPayload],
+    floor_paths: &[R],
+    policies: &[crate::compiler::DeliveryPolicy],
+) -> MaterializationResult<StagedMaterializationStats>
+where
+    P: AsRef<Path> + Sync,
+    R: AsRef<Path>,
+{
+    write_payloads_par_with_mtime_floor_and_policies_observed_impl(
+        targets,
+        payloads,
+        floor_paths,
+        policies,
+        true,
+    )
+}
+
+fn write_payloads_par_with_mtime_floor_and_policies_observed_impl<P, R>(
+    targets: &[P],
+    payloads: &[CachedPayload],
+    floor_paths: &[R],
+    policies: &[crate::compiler::DeliveryPolicy],
+    provisional_staged: bool,
+) -> MaterializationResult<StagedMaterializationStats>
+where
+    P: AsRef<Path> + Sync,
+    R: AsRef<Path>,
+{
     if targets.len() != payloads.len() {
         return Err(payload_count_mismatch(targets.len(), payloads.len()));
     }
@@ -510,7 +553,22 @@ where
             std::fs::create_dir_all(parent)
                 .map_err(|error| destination_write_failure(out, error))?;
         }
-        write_cached_payload_with_policy_stats(out, payload, policy)
+        if provisional_staged {
+            match payload {
+                CachedPayload::File(path) => {
+                    crate::daemon::server::persist::materialize_independent_with_stats(
+                        path.as_path(),
+                        out,
+                    )
+                    .map_err(|error| classify_file_materialization_error(out, path, error))
+                }
+                CachedPayload::Bytes(_) => {
+                    write_cached_payload_with_policy_stats(out, payload, policy)
+                }
+            }
+        } else {
+            write_cached_payload_with_policy_stats(out, payload, policy)
+        }
     };
     let observed = if targets.len() < PAR_WRITE_THRESHOLD {
         let mut observed = StagedMaterializationStats::default();

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -583,20 +583,18 @@ pub(super) struct SharedState {
     ///
     /// Keyed by `artifact_key_hex` — every cold-miss path that defers its
     /// `state.artifacts` insert into a `tokio::spawn` task **must** register
-    /// an entry here *before* spawning and notify+remove after the spawned
-    /// work completes. Concurrent lookups for the same key check the
-    /// registry first: they may wait briefly on the `Notify` (~5 ms ceiling
-    /// per condition 3's blast-radius bound) and then either re-attempt the
-    /// in-memory lookup or fall through to "miss → recompile". The failure
-    /// mode (DD-025 condition 2) is always a miss, never a wrong-hit — the
+    /// a publisher here *before* spawning and complete it after the spawned
+    /// work finishes. Same-key publishers share an entry and are counted so
+    /// one completion cannot hide another publisher. Proven-hit lookups wait
+    /// for request-specific verdict/output readiness, bounded by the payload
+    /// wait timeout, then either materialize or fall through to recompile.
+    /// The failure mode (DD-025 condition 2) is always a miss, never a wrong-hit — the
     /// artifact's content identity stays bound by `blake3` (DD-005); only
     /// the *publication* is deferred.
     ///
-    /// At rest the map is empty. Entries live ≤ 100 ms (30× p99 of
-    /// `depgraph_update_ns + persist_enqueue` from #605 iter T2). At most
-    /// `persist_semaphore.available_permits()` entries may exist
-    /// concurrently — the same semaphore that bounds existing C/C++ persist
-    /// spawns provides the backpressure.
+    /// At rest the map is empty. Entries live until every registered
+    /// publisher for the key completes; the persist semaphore bounds active
+    /// persistence work and shutdown applies its own bounded drain.
     ///
     /// On daemon restart the registry is empty: recovered state comes from
     /// the WAL + on-disk artifacts (DD-008 / DD-017). Crash-mid-flight
@@ -604,7 +602,7 @@ pub(super) struct SharedState {
     /// `crash_mid_flight_recovery_never_surfaces_wrong_content` in
     /// `daemon/server/tests/deferred_cold_path.rs` (PR #618).
     ///
-    pub(super) pending_cache_writes: DashMap<String, Arc<Notify>>,
+    pub(super) pending_cache_writes: DashMap<String, pending_writes::PendingWrite>,
     /// In-memory exec-probe/store cache for caller-owned tool caching
     /// (issue #838 slice 1). Keyed by hex-encoded blake3 cache key,
     /// values are the opaque result bytes the caller supplied via

--- a/crates/zccache-ipc/src/transport/mod.rs
+++ b/crates/zccache-ipc/src/transport/mod.rs
@@ -439,16 +439,52 @@ fn emit_insecure_socket_dir(endpoint: &str, outcome: &str, error: Option<&std::i
 pub async fn connect(endpoint: &str) -> Result<IpcConnection, IpcError> {
     let native = crate::platform::ipc::Endpoint::from_native(endpoint);
     let timeout = native.connect_timeout();
-    let stream =
-        tokio::time::timeout(timeout, crate::platform::ipc::connect(&native))
-            .await
-            .map_err(|_| {
-                IpcError::Io(std::io::Error::new(
-            std::io::ErrorKind::TimedOut,
-            format!("cannot connect to daemon at {endpoint}: connect timed out after {timeout:?}"),
-        ))
-            })??;
+    let stream = tokio::time::timeout(timeout, crate::platform::ipc::connect(&native))
+        .await
+        .map_err(|_| {
+            contextualize_connect_error(
+                endpoint,
+                std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("connect timed out after {timeout:?}"),
+                ),
+            )
+        })?
+        .map_err(|error| contextualize_connect_error(endpoint, error))?;
     Ok(IpcConnection::from_stream(stream))
+}
+
+fn contextualize_connect_error(endpoint: &str, error: std::io::Error) -> IpcError {
+    let kind = error.kind();
+    IpcError::Io(std::io::Error::new(
+        kind,
+        EndpointConnectError {
+            endpoint: endpoint.to_owned(),
+            source: error,
+        },
+    ))
+}
+
+#[derive(Debug)]
+struct EndpointConnectError {
+    endpoint: String,
+    source: std::io::Error,
+}
+
+impl std::fmt::Display for EndpointConnectError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "cannot connect to daemon at {}: {}",
+            self.endpoint, self.source
+        )
+    }
+}
+
+impl std::error::Error for EndpointConnectError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
 }
 
 /// Generate a unique test endpoint name.

--- a/crates/zccache-ipc/src/transport/tests.rs
+++ b/crates/zccache-ipc/src/transport/tests.rs
@@ -4,6 +4,50 @@ use super::*;
 use zccache_protocol::{wire_prost::zccache_v1 as pb, DecodedWireMessage, Request, Response};
 
 #[tokio::test]
+async fn connect_error_includes_endpoint_context() {
+    let endpoint = unique_test_endpoint();
+
+    let error = match connect(&endpoint).await {
+        Ok(_) => panic!("an unbound endpoint must reject the connection"),
+        Err(error) => error,
+    };
+
+    assert!(
+        error
+            .to_string()
+            .contains(&format!("cannot connect to daemon at {endpoint}")),
+        "connection error should identify its endpoint: {error}"
+    );
+}
+
+#[test]
+fn connect_error_context_preserves_io_error_kind() {
+    let error = contextualize_connect_error(
+        "test-endpoint",
+        std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "test refusal"),
+    );
+
+    match error {
+        IpcError::Io(error) => {
+            assert_eq!(error.kind(), std::io::ErrorKind::ConnectionRefused);
+            assert!(error.to_string().contains("test-endpoint"));
+            assert!(error.to_string().contains("test refusal"));
+            let context = error
+                .get_ref()
+                .and_then(|inner| inner.downcast_ref::<EndpointConnectError>())
+                .expect("I/O error should retain its endpoint context");
+            assert_eq!(context.endpoint, "test-endpoint");
+            let source = std::error::Error::source(&error)
+                .and_then(|source| source.downcast_ref::<std::io::Error>())
+                .expect("original I/O error should remain in the error source chain");
+            assert_eq!(source.kind(), std::io::ErrorKind::ConnectionRefused);
+            assert_eq!(source.to_string(), "test refusal");
+        }
+        other => panic!("expected I/O error, got {other}"),
+    }
+}
+
+#[tokio::test]
 async fn test_ping_pong() {
     let endpoint = unique_test_endpoint();
     let mut listener = IpcListener::bind(&endpoint).unwrap();

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -851,6 +851,6 @@ Issue: https://github.com/zackees/zccache/issues/1432
   Its materialization guard owns the private plan through byte delivery and
   uses independent reflink/copy without durable-blob verification. Publication
   failures remove only their own provisional instance.
-- GREEN: the seven-test staged-publication module and the independent ownership
+- GREEN: the eight-test staged-publication module and the independent ownership
   regression pass. The real ignored `perf_rust_workspace_link` fixture records
   one cold miss followed by five cached warm trials (21 ms median locally).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -826,3 +826,31 @@ Issue: https://github.com/zackees/zccache/issues/1025
   after a proven cache miss, and warm metadata-cache hits retain the existing path.
 - Native diagnostic: driver-link unaccounted time fell from ~22 ms to ~9 ms;
   warm driver hits remained ~3 ms. Hosted Linux remains the timing authority.
+
+# #1432 restore immediate Rust workspace-link cache hits
+
+Issue: https://github.com/zackees/zccache/issues/1432
+
+- [x] Add a RED regression for a staged payload whose durable publication is still blocked.
+- [x] Publish an owned provisional artifact without weakening conflict handling.
+- [x] Run focused correctness and performance coverage.
+- [ ] Run review, push, merge, and verify the hosted Rust speed floor.
+
+## Review
+
+- Hosted RED: main Perf Guard runs 32415853442 and 32419543154 each reproduced
+  three warm workspace-link misses after an exact five-second pending wait.
+- Root cause: detached Rust staged publication keeps the private files alive but
+  withholds the in-memory artifact until copy/sync/hash publication completes.
+  The next proven depgraph hit times out and recompiles the same staticlib.
+- RED: once a provisional path was visible, the normal cache-blob delivery path
+  rejected it because compiler-private files do not yet have durable digest
+  registration; an in-flight hit could also outlive the artifact clone that
+  owned its staging plan.
+- GREEN: vacant keys publish a path-backed provisional artifact immediately.
+  Its materialization guard owns the private plan through byte delivery and
+  uses independent reflink/copy without durable-blob verification. Publication
+  failures remove only their own provisional instance.
+- GREEN: the seven-test staged-publication module and the independent ownership
+  regression pass. The real ignored `perf_rust_workspace_link` fixture records
+  one cold miss followed by five cached warm trials (21 ms median locally).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -854,3 +854,24 @@ Issue: https://github.com/zackees/zccache/issues/1432
 - GREEN: the eight-test staged-publication module and the independent ownership
   regression pass. The real ignored `perf_rust_workspace_link` fixture records
   one cold miss followed by five cached warm trials (21 ms median locally).
+
+# #1435 preserve endpoint context on immediate connection failures
+
+Issue: https://github.com/zackees/zccache/issues/1435
+
+- [x] Reproduce the rust-plan session-stats JSON regression locally.
+- [x] Add shared transport coverage for an immediate connection failure.
+- [x] Preserve the endpoint and original I/O error kind at the transport boundary.
+- [ ] Run focused correctness, review, merge, and close #1435.
+
+## Review
+
+- RED: `rust_plan_session_stats_lookup_errors_surface_in_json` loses the endpoint
+  after session stats moved to the shared full-family roundtrip in #1425.
+- Root cause: transport timeouts add endpoint context, but immediate platform
+  connection errors are propagated raw.
+- GREEN: the shared transport adds endpoint context while preserving the I/O
+  kind and original error source; all 58 IPC tests and the unchanged rust-plan
+  JSON regression pass.
+- clud-review: clean after retaining the original platform error in the source
+  chain (one reviewer).


### PR DESCRIPTION
## Summary

- publish owned provisional Rust artifacts as soon as compiler-private staged outputs are available
- materialize provisional paths independently while retaining the staged-plan owner through byte delivery
- wait only for request-specific verdict/output metadata, with counted same-key publishers and race-safe wakeups
- wait for an active replacement when visible metadata points at an unresolved or missing payload
- preserve endpoint context, I/O classification, and the original platform error for immediate IPC connection failures

## RED / GREEN

- Hosted RED: main Perf Guard runs 32415853442 and 32419543154 reproduced three warm workspace-link recompiles after the five-second publication wait.
- Focused GREEN: `staged_publication_diagnostic_tests` 8/8, including blocked durable publication, same-key publishers completing out of order, and stale payload replacement.
- Hosted-failure GREEN: `depgraph_hit_artifact_not_found_invalidates_stale_entry` 1/1 locally.
- Ownership GREEN: `provisional_staged_payload_owns_private_files_through_hit_delivery` 1/1.
- Registry GREEN: `pending_writes::tests` 5/5 and `pending_cache_writes` 4/4.
- Real ignored fixture GREEN: one cold miss followed by five cached warm workspace-link trials, 21 ms local median.
- IPC GREEN: all 58 `zccache-ipc` tests pass; immediate connection failures keep endpoint context, `ErrorKind`, and the original error source.
- Integration-regression GREEN: `rust_plan_session_stats_lookup_errors_surface_in_json` passes unchanged after reproducing locally and in hosted run 32429390173.
- Lint/review: all-target clippy is clean for the changed crates; `/clud-review` is clean after follow-up.

Closes #1432
Closes #1435