### PR TITLE
feat(python): persist exec_cached results

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -489,10 +489,67 @@ jobs:
           path: dist/wheels/*
           if-no-files-found: error
 
+  test-wheels:
+    name: Test PyPI Wheel (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: [preflight, build-wheels]
+    if: needs.preflight.outputs.pypi_complete != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux-x86_64
+          - os: ubuntu-24.04-arm
+            label: linux-aarch64
+          - os: macos-15-intel
+            label: macos-x86_64
+          - os: macos-14
+            label: macos-aarch64
+          - os: windows-latest
+            label: windows-x86_64
+          - os: windows-11-arm
+            label: windows-aarch64
+          - os: ubuntu-latest
+            label: linux-musl-x86_64
+            alpine: true
+          - os: ubuntu-24.04-arm
+            label: linux-musl-aarch64
+            alpine: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.preflight.outputs.checkout_ref }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: pypi-wheels
+          path: dist/wheels
+
+      - name: Install and test the platform wheel
+        if: matrix.alpine != true
+        run: |
+          python -m pip install --disable-pip-version-check --no-index --find-links dist/wheels "zccache==${{ needs.preflight.outputs.version }}"
+          python ci/test_exec_cached_wheel.py
+
+      - name: Install and test the musllinux wheel
+        if: matrix.alpine == true
+        shell: bash
+        run: |
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace \
+            python:3.13-alpine \
+            sh -ec 'python -m pip install --disable-pip-version-check --no-index --find-links dist/wheels "zccache==${{ needs.preflight.outputs.version }}" && python ci/test_exec_cached_wheel.py'
+
   publish-pypi:
     name: Publish PyPI
     runs-on: ubuntu-latest
-    needs: [preflight, publish-release, build-wheels]
+    needs: [preflight, publish-release, build-wheels, test-wheels]
     if: |
       always()
       && needs.preflight.result == 'success'
@@ -500,6 +557,7 @@ jobs:
       && inputs['dry-run'] != true
       && needs.preflight.outputs.pypi_complete != 'true'
       && needs.build-wheels.result == 'success'
+      && needs.test-wheels.result == 'success'
     environment: pypi
     permissions:
       actions: read

--- a/ci/test_exec_cached_wheel.py
+++ b/ci/test_exec_cached_wheel.py
@@ -1,0 +1,150 @@
+"""Installed-wheel smoke contract for ``zccache.exec_cached`` (#1433).
+
+The release workflow runs this file on Linux, macOS, and Windows after
+installing the wheel assembled from that platform's native artifacts.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+import uuid
+from pathlib import Path
+
+
+def _run(binary: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [binary, *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def main() -> None:
+    import zccache
+
+    binary = shutil.which("zccache")
+    if binary is None:
+        raise AssertionError("installed wheel did not place zccache on PATH")
+
+    namespace = f"python-exec-cached-{uuid.uuid4().hex}"
+    with tempfile.TemporaryDirectory(prefix="zccache-exec-cached-") as temp:
+        os.environ["ZCCACHE_CACHE_DIR"] = str(Path(temp) / "cache")
+        os.environ["ZCCACHE_DAEMON_NAMESPACE"] = namespace
+        source = Path(temp) / "input.txt"
+        source.write_bytes(b"input-v1")
+
+        _run(binary, "start")
+        try:
+            calls = 0
+
+            def runner() -> bytes:
+                nonlocal calls
+                calls += 1
+                return b"opaque-result"
+
+            kwargs = {
+                "name": "wheel-smoke",
+                "input_files": [source],
+                "input_env": {"MODE": "strict"},
+                "extra_key": b"schema-v1",
+                "runner": runner,
+            }
+            assert zccache.exec_cached(**kwargs) == b"opaque-result"
+            assert zccache.exec_cached(**kwargs) == b"opaque-result"
+            assert calls == 1, "warm hit must not invoke the Python runner"
+
+            _run(binary, "stop")
+            _run(binary, "start")
+            assert zccache.exec_cached(**kwargs) == b"opaque-result"
+            assert calls == 1, "stored bytes must survive a daemon restart"
+
+            barrier = threading.Barrier(2)
+            parallel_results: list[bytes] = []
+            parallel_errors: list[BaseException] = []
+
+            def parallel_call(index: int) -> None:
+                def parallel_runner() -> bytes:
+                    barrier.wait(timeout=10)
+                    return f"parallel-{index}".encode()
+
+                try:
+                    result = zccache.exec_cached(
+                        "wheel-parallel",
+                        [source],
+                        {"MODE": "strict"},
+                        f"key-{index}".encode(),
+                        parallel_runner,
+                    )
+                    parallel_results.append(result)
+                except BaseException as error:  # retain thread failures for the main thread
+                    parallel_errors.append(error)
+
+            threads = [threading.Thread(target=parallel_call, args=(index,)) for index in range(2)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=15)
+            assert not parallel_errors, parallel_errors
+            assert all(not thread.is_alive() for thread in threads), "parallel calls deadlocked"
+            assert sorted(parallel_results) == [b"parallel-0", b"parallel-1"]
+
+            class RunnerFailure(Exception):
+                pass
+
+            def failing_runner() -> bytes:
+                raise RunnerFailure("runner failed exactly")
+
+            try:
+                zccache.exec_cached(
+                    "wheel-exception",
+                    [source],
+                    {},
+                    b"exception",
+                    failing_runner,
+                )
+            except RunnerFailure as error:
+                assert str(error) == "runner failed exactly"
+            else:
+                raise AssertionError("runner exception was not propagated")
+
+            missing_namespace = f"{namespace}-missing"
+            os.environ["ZCCACHE_DAEMON_NAMESPACE"] = missing_namespace
+            unavailable_runner_called = False
+
+            def unavailable_runner() -> bytes:
+                nonlocal unavailable_runner_called
+                unavailable_runner_called = True
+                return b"must-not-run"
+
+            try:
+                zccache.exec_cached(
+                    "wheel-unavailable",
+                    [source],
+                    {},
+                    b"missing-daemon",
+                    unavailable_runner,
+                )
+            except RuntimeError as error:
+                assert "daemon" in str(error).lower() or "connect" in str(error).lower()
+            else:
+                raise AssertionError("daemon-unavailable call unexpectedly succeeded")
+            assert not unavailable_runner_called
+        finally:
+            os.environ["ZCCACHE_DAEMON_NAMESPACE"] = namespace
+            subprocess.run(
+                [binary, "stop"],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -203,9 +203,30 @@ def test_release_workflow_uses_bootstrap_zccache_for_cross_builds() -> None:
     assert "SOLDR_RUSTC_WRAPPER=" in release_workflow
     assert 'use_soldr: "true"' in release_workflow
     assert "runs-on: ubuntu-24.04" in release_workflow
-    assert "runs-on: ${{ matrix.os }}" not in release_workflow
+    assert release_workflow.count("runs-on: ${{ matrix.os }}") == 1
     assert "if: inputs.use_soldr == 'true'" in action
     assert "Use setup-soldr for setup and caching" in action
+
+
+def test_release_tests_exec_cached_in_every_native_wheel_family() -> None:
+    workflow = _repo_text(".github/workflows/release-auto.yml")
+
+    assert "test-wheels:" in workflow
+    for platform in (
+        "ubuntu-latest",
+        "ubuntu-24.04-arm",
+        "macos-15-intel",
+        "macos-14",
+        "windows-latest",
+        "windows-11-arm",
+    ):
+        assert f"- os: {platform}" in workflow
+    assert "label: linux-musl-x86_64" in workflow
+    assert "label: linux-musl-aarch64" in workflow
+    assert "python ci/test_exec_cached_wheel.py" in workflow
+    assert "python:3.13-alpine" in workflow
+    assert "needs: [preflight, publish-release, build-wheels, test-wheels]" in workflow
+    assert "needs.test-wheels.result == 'success'" in workflow
 
 
 def test_cross_build_driver_uses_soldr_cache_and_preserves_artifact_contracts() -> None:

--- a/crates/zccache-cli-core/src/cli/client.rs
+++ b/crates/zccache-cli-core/src/cli/client.rs
@@ -7,6 +7,7 @@
 
 use crate::core::NormalizedPath;
 use std::path::Path;
+use std::sync::Arc;
 
 use super::{ensure_daemon, resolve_endpoint, run_async};
 
@@ -14,6 +15,97 @@ use super::{ensure_daemon, resolve_endpoint, run_async};
 pub struct SessionStartResponse {
     pub session_id: String,
     pub journal_path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecProbeResponse {
+    pub cache_key_hex: String,
+    pub cached_bytes: Option<Vec<u8>>,
+}
+
+/// Probe caller-owned opaque bytes without silently starting or bypassing the
+/// daemon. Library consumers get a clear error when the configured daemon is
+/// unavailable and decide their own fallback policy.
+pub fn client_exec_probe(
+    endpoint: Option<&str>,
+    name: &str,
+    input_files: &[std::path::PathBuf],
+    input_env: &[(String, String)],
+    input_extra: &[u8],
+) -> Result<ExecProbeResponse, String> {
+    let endpoint = resolve_endpoint(endpoint);
+    let request = crate::protocol::Request::ExecProbe {
+        name: name.to_string(),
+        input_files: input_files.iter().map(NormalizedPath::from).collect(),
+        input_env: input_env.to_vec(),
+        input_extra: Arc::new(input_extra.to_vec()),
+    };
+    run_async(async move {
+        match crate::ipc::full_family_roundtrip(&endpoint, &request, None).await {
+            Ok(Some(crate::protocol::Response::ExecProbeResult {
+                cache_key_hex,
+                cached_bytes,
+                persistent: true,
+            })) => Ok(ExecProbeResponse {
+                cache_key_hex,
+                cached_bytes: cached_bytes.map(Arc::unwrap_or_clone),
+            }),
+            Ok(Some(crate::protocol::Response::ExecProbeResult { .. })) => Err(
+                "exec cache daemon does not guarantee durable storage; restart it with this zccache version"
+                    .to_string(),
+            ),
+            Ok(Some(crate::protocol::Response::Error { message })) => Err(message),
+            Ok(None) => Err(format!(
+                "exec cache probe lost connection to daemon at {endpoint}"
+            )),
+            Ok(Some(other)) => Err(format!(
+                "unexpected exec cache probe response from daemon at {endpoint}: {other:?}"
+            )),
+            Err(error) => Err(format!(
+                "exec cache probe could not reach daemon at {endpoint}: {error}"
+            )),
+        }
+    })
+}
+
+/// Persist caller-owned opaque bytes under a key returned by
+/// [`client_exec_probe`]. The daemon acknowledges only after the KV write is
+/// durable.
+pub fn client_exec_store(
+    endpoint: Option<&str>,
+    cache_key_hex: &str,
+    result_bytes: &[u8],
+) -> Result<(), String> {
+    let endpoint = resolve_endpoint(endpoint);
+    let request = crate::protocol::Request::ExecStore {
+        cache_key_hex: cache_key_hex.to_string(),
+        result_bytes: Arc::new(result_bytes.to_vec()),
+    };
+    run_async(async move {
+        match crate::ipc::full_family_roundtrip(&endpoint, &request, None).await {
+            Ok(Some(crate::protocol::Response::ExecStoreAck {
+                stored: true,
+                persistent: true,
+            })) => Ok(()),
+            Ok(Some(crate::protocol::Response::ExecStoreAck { stored: false, .. })) => {
+                Err("daemon declined the exec cache store".to_string())
+            }
+            Ok(Some(crate::protocol::Response::ExecStoreAck { .. })) => Err(
+                "exec cache daemon does not guarantee durable storage; restart it with this zccache version"
+                    .to_string(),
+            ),
+            Ok(Some(crate::protocol::Response::Error { message })) => Err(message),
+            Ok(None) => Err(format!(
+                "exec cache store lost connection to daemon at {endpoint}"
+            )),
+            Ok(Some(other)) => Err(format!(
+                "unexpected exec cache store response from daemon at {endpoint}: {other:?}"
+            )),
+            Err(error) => Err(format!(
+                "exec cache store could not reach daemon at {endpoint}: {error}"
+            )),
+        }
+    })
 }
 
 pub fn client_start(endpoint: Option<&str>) -> Result<(), String> {

--- a/crates/zccache-cli-core/src/cli/mod.rs
+++ b/crates/zccache-cli-core/src/cli/mod.rs
@@ -111,10 +111,11 @@ pub use crate::download_client::{
     FetchStatus, WaitMode,
 };
 pub use client::{
-    client_session_end, client_session_start, client_session_stats, client_start, client_status,
-    client_stop, fingerprint_check, fingerprint_invalidate, fingerprint_mark_failure,
-    fingerprint_mark_success, is_daemon_unreachable_err, session_end_idempotent,
-    FingerprintCheckResponse, SessionStartResponse,
+    client_exec_probe, client_exec_store, client_session_end, client_session_start,
+    client_session_stats, client_start, client_status, client_stop, fingerprint_check,
+    fingerprint_invalidate, fingerprint_mark_failure, fingerprint_mark_success,
+    is_daemon_unreachable_err, session_end_idempotent, ExecProbeResponse, FingerprintCheckResponse,
+    SessionStartResponse,
 };
 
 #[derive(Debug, Clone)]

--- a/crates/zccache-cli/src/exec_cached.rs
+++ b/crates/zccache-cli/src/exec_cached.rs
@@ -1,0 +1,53 @@
+//! Python `zccache.exec_cached` bridge (#1433).
+
+use std::path::PathBuf;
+
+use pyo3::exceptions::PyTypeError;
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+
+use zccache::cli::{client_exec_probe, client_exec_store};
+
+use super::runtime_to_py_err;
+
+/// Cache one caller-owned Python computation through the daemon.
+///
+/// IPC and persistent-store waits run without the GIL. The GIL is held only
+/// while invoking the supplied Python callback and copying its returned bytes.
+#[pyfunction]
+#[pyo3(signature = (name, input_files, input_env, extra_key, runner))]
+fn exec_cached(
+    py: Python<'_>,
+    name: String,
+    input_files: Vec<String>,
+    input_env: Vec<(String, String)>,
+    extra_key: Vec<u8>,
+    runner: Py<PyAny>,
+) -> PyResult<Py<PyBytes>> {
+    let input_files: Vec<PathBuf> = input_files.into_iter().map(PathBuf::from).collect();
+    let probe = py
+        .allow_threads(|| {
+            client_exec_probe(None, &name, &input_files, &input_env, extra_key.as_slice())
+        })
+        .map_err(runtime_to_py_err)?;
+
+    if let Some(bytes) = probe.cached_bytes {
+        return Ok(PyBytes::new(py, &bytes).unbind());
+    }
+
+    let result = runner.call0(py)?;
+    let result = result
+        .bind(py)
+        .downcast::<PyBytes>()
+        .map_err(|_| PyTypeError::new_err("exec_cached runner must return bytes"))?;
+    let result_bytes = result.as_bytes().to_vec();
+
+    py.allow_threads(|| client_exec_store(None, &probe.cache_key_hex, result_bytes.as_slice()))
+        .map_err(runtime_to_py_err)?;
+
+    Ok(PyBytes::new(py, &result_bytes).unbind())
+}
+
+pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(exec_cached, m)?)
+}

--- a/crates/zccache-cli/src/lib.rs
+++ b/crates/zccache-cli/src/lib.rs
@@ -13,6 +13,8 @@ use zccache::cli::{
     run_ino_convert_cached, DownloadParams, DownloadSource, InoConvertOptions, WaitMode,
 };
 
+mod exec_cached;
+
 fn runtime_to_py_err(message: String) -> PyErr {
     PyErr::new::<PyRuntimeError, _>(message)
 }
@@ -784,5 +786,6 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(convert_ino, m)?)?;
     m.add_function(wrap_pyfunction!(default_endpoint, m)?)?;
     m.add_function(wrap_pyfunction!(check_running_daemon, m)?)?;
+    exec_cached::register(m)?;
     Ok(())
 }

--- a/crates/zccache-daemon-core/src/daemon/server/connection/dispatch.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/connection/dispatch.rs
@@ -508,7 +508,8 @@ pub(super) async fn dispatch_request(
                 &input_files,
                 &input_env,
                 &input_extra,
-            ),
+            )
+            .await,
             None,
         ),
         Request::ExecStore {
@@ -519,7 +520,8 @@ pub(super) async fn dispatch_request(
                 state,
                 &cache_key_hex,
                 &result_bytes,
-            ),
+            )
+            .await,
             None,
         ),
     };

--- a/crates/zccache-daemon-core/src/daemon/server/handle_clear.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_clear.rs
@@ -35,6 +35,14 @@ pub(super) async fn handle_clear(state: &SharedState) -> Response {
             .sum(),
         Err(_) => 0,
     };
+    match state
+        .exec_store
+        .namespace_bytes_async(handle_exec_probe::EXEC_PROBE_NAMESPACE)
+        .await
+    {
+        Ok(bytes) => on_disk_bytes_freed = on_disk_bytes_freed.saturating_add(bytes),
+        Err(error) => tracing::warn!(%error, "failed to measure caller-owned exec cache"),
+    }
 
     // Clear all subsystems.
     //
@@ -55,6 +63,13 @@ pub(super) async fn handle_clear(state: &SharedState) -> Response {
     state.rsp_cache.clear();
     state.watched_raw_dirs.clear();
     state.watched_dirs.lock().await.clear();
+    if let Err(error) = state
+        .exec_store
+        .clear_namespace_async(handle_exec_probe::EXEC_PROBE_NAMESPACE)
+        .await
+    {
+        tracing::warn!(%error, "failed to clear caller-owned exec cache");
+    }
 
     // Reset stats and profiler.
     state.stats.reset();

--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec_probe.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec_probe.rs
@@ -1,10 +1,10 @@
-//! `Request::ExecProbe` / `Request::ExecStore` handlers (issue #838).
+//! `Request::ExecProbe` / `Request::ExecStore` handlers (issue #1433).
 //!
 //! Caller-owned tool caching: the *caller* runs the tool, the daemon only
 //! computes a stable cache key from declared inputs and stores opaque
 //! result bytes. This complements [`handle_generic_tool_exec`](super::handle_exec)
 //! (which spawns the tool inside the daemon) and powers the upcoming PyO3
-//! `zccache.exec` binding for Python build orchestrators that already own
+//! `zccache.exec_cached` binding for Python build orchestrators that already own
 //! their subprocess lifecycle.
 //!
 //! Cache-key composition (domain tag `zccache-exec-probe-v1`):
@@ -13,24 +13,25 @@
 //!   - sorted `(name, value)` declared env pairs
 //!   - opaque `input_extra` bytes
 //!
-//! Slice 1 holds the (key → bytes) map in an in-memory `DashMap` on
-//! `SharedState::exec_cache`. A follow-up slice swaps that to a
-//! [`KvStore`](crate::artifact::kv::KvStore)-backed table for persistence
-//! across daemon restarts.
+//! Results live in the daemon's crash-safe namespaced
+//! [`KvStore`](crate::artifact::KvStore), so a successful store is durable
+//! before acknowledgement and survives daemon restarts.
 
 use std::sync::Arc;
 
 use super::util::hash_file_via_cache;
 use super::SharedState;
+use crate::artifact::Key;
 use crate::core::NormalizedPath;
 use crate::protocol::Response;
 
 /// Domain separation tag for ExecProbe/ExecStore cache keys.
 const EXEC_PROBE_KEY_DOMAIN: &[u8] = b"zccache-exec-probe-v1";
+pub(super) const EXEC_PROBE_NAMESPACE: &str = "exec-probe-v1";
 
 /// Compute the cache key for an ExecProbe / ExecStore call and look it up
-/// in the in-memory exec cache.
-pub(super) fn handle_exec_probe(
+/// in the persistent caller-owned exec cache.
+pub(super) async fn handle_exec_probe(
     state: &Arc<SharedState>,
     name: &str,
     input_files: &[NormalizedPath],
@@ -38,23 +39,37 @@ pub(super) fn handle_exec_probe(
     input_extra: &Arc<Vec<u8>>,
 ) -> Response {
     let _active_request = state.begin_cache_request();
+    let _publication_guard = state.artifact_publication.read().await;
     let cache_key_hex =
         match compose_exec_probe_key(state, name, input_files, input_env, input_extra) {
             Ok(hex) => hex,
             Err(message) => return Response::Error { message },
         };
-    let cached_bytes = state
-        .exec_cache
-        .get(&cache_key_hex)
-        .map(|entry| Arc::clone(entry.value()));
+    let key = match Key::from_hex(&cache_key_hex) {
+        Ok(key) => key,
+        Err(error) => {
+            return Response::Error {
+                message: format!("invalid derived exec cache key: {error}"),
+            };
+        }
+    };
+    let cached_bytes = match state.exec_store.get_async(EXEC_PROBE_NAMESPACE, &key).await {
+        Ok(bytes) => bytes.map(Arc::new),
+        Err(error) => {
+            return Response::Error {
+                message: format!("exec cache read failed for {cache_key_hex}: {error}"),
+            };
+        }
+    };
     Response::ExecProbeResult {
         cache_key_hex,
         cached_bytes,
+        persistent: true,
     }
 }
 
 /// Write opaque result bytes under the caller-supplied cache key. Last-writer-wins.
-pub(super) fn handle_exec_store(
+pub(super) async fn handle_exec_store(
     state: &Arc<SharedState>,
     cache_key_hex: &str,
     result_bytes: &Arc<Vec<u8>>,
@@ -67,10 +82,28 @@ pub(super) fn handle_exec_store(
             ),
         };
     }
-    state
-        .exec_cache
-        .insert(cache_key_hex.to_string(), Arc::clone(result_bytes));
-    Response::ExecStoreAck { stored: true }
+    let key = match Key::from_hex(cache_key_hex) {
+        Ok(key) => key,
+        Err(error) => {
+            return Response::Error {
+                message: format!("invalid cache_key_hex: {error}"),
+            };
+        }
+    };
+    let _publication_guard = state.artifact_publication.read().await;
+    match state
+        .exec_store
+        .put_async(EXEC_PROBE_NAMESPACE, &key, result_bytes.as_slice())
+        .await
+    {
+        Ok(_) => Response::ExecStoreAck {
+            stored: true,
+            persistent: true,
+        },
+        Err(error) => Response::Error {
+            message: format!("exec cache store failed for {cache_key_hex}: {error}"),
+        },
+    }
 }
 
 /// Compose the deterministic blake3 cache key from declared inputs.

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -198,6 +198,10 @@ pub(super) fn new_shared_state(
     // `MetadataCache::get_cached_hash_if_stat_valid` keeps cache
     // keys correct either way.
     let cache_system = CacheSystem::new();
+    let exec_store = KvStore::open(cache_dir).map_err(|error| match error {
+        KvError::Io(error) => error,
+        other => std::io::Error::other(format!("cannot open exec cache: {other}")),
+    })?;
 
     // Issue #813 / #810: log the effective compile-priority default
     // policy at daemon start so the behaviour is observable without
@@ -314,7 +318,7 @@ pub(super) fn new_shared_state(
             depgraph_load_warning: StdMutex::new(None),
             in_flight_exec: DashMap::new(),
             pending_cache_writes: DashMap::new(),
-            exec_cache: DashMap::new(),
+            exec_store,
         }),
         index_writer_rx,
     ))

--- a/crates/zccache-daemon-core/src/daemon/server/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/mod.rs
@@ -13,7 +13,7 @@ use super::compile_journal::{
 use super::fingerprint::FingerprintManager;
 use super::process::CompilePriority;
 use super::stats::{HitPhases, MissPhases, PhaseProfiler, StatsCollector};
-use crate::artifact::{ArtifactIndex, ArtifactStore, ArtifactVerdict};
+use crate::artifact::{ArtifactIndex, ArtifactStore, ArtifactVerdict, KvError, KvStore};
 use crate::core::NormalizedPath;
 use crate::depgraph::{
     CompileContext, ContextKey, DepGraph, DepfileStrategy, SessionId, SessionManager,

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -603,12 +603,10 @@ pub(super) struct SharedState {
     /// `daemon/server/tests/deferred_cold_path.rs` (PR #618).
     ///
     pub(super) pending_cache_writes: DashMap<String, pending_writes::PendingWrite>,
-    /// In-memory exec-probe/store cache for caller-owned tool caching
-    /// (issue #838 slice 1). Keyed by hex-encoded blake3 cache key,
-    /// values are the opaque result bytes the caller supplied via
-    /// `Request::ExecStore`. Slice 1 keeps this in-memory only; a
-    /// follow-up slice swaps to `KvStore` for persistence.
-    pub(super) exec_cache: DashMap<String, Arc<Vec<u8>>>,
+    /// Persistent caller-owned opaque exec results (#1433 / #838).
+    /// Keys retain the `zccache-exec-probe-v1` derivation contract; values
+    /// live in a dedicated namespace under this daemon's normal cache root.
+    pub(super) exec_store: KvStore,
 }
 
 impl SharedState {

--- a/crates/zccache-daemon-core/src/daemon/server/tests/exec_probe.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/exec_probe.rs
@@ -12,7 +12,7 @@ use super::CacheDirEnvGuard;
 use crate::core::NormalizedPath;
 use crate::protocol::Response;
 
-fn probe(
+async fn probe(
     state: &Arc<super::super::SharedState>,
     name: &str,
     input_files: &[NormalizedPath],
@@ -25,11 +25,13 @@ fn probe(
         input_files,
         input_env,
         input_extra,
-    );
+    )
+    .await;
     match resp {
         Response::ExecProbeResult {
             cache_key_hex,
             cached_bytes,
+            persistent: true,
         } => (cache_key_hex, cached_bytes),
         other => panic!("expected ExecProbeResult, got: {other:?}"),
     }
@@ -51,7 +53,7 @@ async fn probe_miss_then_store_then_probe_hit() {
         let extra = Arc::new(b"schema-v1".to_vec());
 
         // First probe: miss. cache_key_hex returned regardless.
-        let (key_miss, cached_miss) = probe(&state, name, &[], &env, &extra);
+        let (key_miss, cached_miss) = probe(&state, name, &[], &env, &extra).await;
         assert!(cached_miss.is_none(), "fresh daemon must miss");
         assert_eq!(key_miss.len(), 64, "cache key must be 64-char hex");
         assert!(
@@ -64,14 +66,17 @@ async fn probe_miss_then_store_then_probe_hit() {
         // Store the caller's result bytes under that key.
         let payload = Arc::new(b"opaque-ast-bytes".to_vec());
         let store_resp =
-            super::super::handle_exec_probe::handle_exec_store(&state, &key_miss, &payload);
+            super::super::handle_exec_probe::handle_exec_store(&state, &key_miss, &payload).await;
         match store_resp {
-            Response::ExecStoreAck { stored } => assert!(stored, "store must ack"),
+            Response::ExecStoreAck { stored, persistent } => {
+                assert!(stored, "store must ack");
+                assert!(persistent, "store must be durable");
+            }
             other => panic!("expected ExecStoreAck, got: {other:?}"),
         }
 
         // Second probe with the same declared inputs: hit, same key, same bytes.
-        let (key_hit, cached_hit) = probe(&state, name, &[], &env, &extra);
+        let (key_hit, cached_hit) = probe(&state, name, &[], &env, &extra).await;
         assert_eq!(key_miss, key_hit, "key must be stable across probes");
         let cached = cached_hit.expect("post-store probe must hit");
         assert_eq!(
@@ -82,12 +87,50 @@ async fn probe_miss_then_store_then_probe_hit() {
 
         // Different declared input → different key → still a miss.
         let extra2 = Arc::new(b"schema-v2".to_vec());
-        let (key_other, cached_other) = probe(&state, name, &[], &env, &extra2);
+        let (key_other, cached_other) = probe(&state, name, &[], &env, &extra2).await;
         assert_ne!(key_miss, key_other, "changing input_extra must change key");
         assert!(
             cached_other.is_none(),
             "different key must not surface the prior store"
         );
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore] // integration-level: binds two real daemon servers to one cache root
+async fn stored_bytes_survive_daemon_restart() {
+    crate::test_support::test_timeout(async {
+        let cache_tmp = tempfile::tempdir().unwrap();
+        let cache_dir = NormalizedPath::new(cache_tmp.path());
+        let name = "python-exec-cached-restart";
+        let extra = Arc::new(b"schema-v1".to_vec());
+        let payload = Arc::new(b"persistent-result".to_vec());
+
+        let first_endpoint = crate::ipc::unique_test_endpoint();
+        let first = DaemonServer::bind_with_cache_dir(&first_endpoint, &cache_dir).unwrap();
+        let first_state = first.test_state_arc();
+        let (key, cached) = probe(&first_state, name, &[], &[], &extra).await;
+        assert!(cached.is_none(), "fresh cache root must miss");
+        let stored =
+            super::super::handle_exec_probe::handle_exec_store(&first_state, &key, &payload).await;
+        assert_eq!(
+            stored,
+            Response::ExecStoreAck {
+                stored: true,
+                persistent: true,
+            }
+        );
+        drop(first_state);
+        drop(first);
+
+        let second_endpoint = crate::ipc::unique_test_endpoint();
+        let second = DaemonServer::bind_with_cache_dir(&second_endpoint, &cache_dir).unwrap();
+        let second_state = second.test_state_arc();
+        let (restarted_key, restarted_bytes) = probe(&second_state, name, &[], &[], &extra).await;
+
+        assert_eq!(restarted_key, key);
+        assert_eq!(restarted_bytes.as_deref(), Some(payload.as_ref()));
     })
     .await;
 }

--- a/crates/zccache-protocol/proto/zccache_v1.proto
+++ b/crates/zccache-protocol/proto/zccache_v1.proto
@@ -434,8 +434,11 @@ message ExecProbeResult {
   // Absent on miss. `optional` is load-bearing: an empty cached result is a
   // legitimate hit, so it must stay distinguishable from "not cached".
   optional bytes cached_bytes = 2;
+  // False is the safe default for daemons predating durable exec caching.
+  bool persistent = 3;
 }
 
 message ExecStoreAck {
   bool stored = 1;
+  bool persistent = 2;
 }

--- a/crates/zccache-protocol/src/lib.rs
+++ b/crates/zccache-protocol/src/lib.rs
@@ -21,7 +21,7 @@ pub const UNKNOWN_MISS_WARNING_PREFIX: &str = "zccache[warn][M]:";
 ///
 /// This remains the compatibility version used by the legacy encode/decode
 /// helpers while full-family clients prefer the separately versioned prost lane.
-pub const BINCODE_PROTOCOL_VERSION: u32 = 23;
+pub const BINCODE_PROTOCOL_VERSION: u32 = 25;
 
 /// Prost daemon wire version.
 ///

--- a/crates/zccache-protocol/src/messages/compat/exec_probe.rs
+++ b/crates/zccache-protocol/src/messages/compat/exec_probe.rs
@@ -44,18 +44,23 @@ fn exec_probe_result_roundtrip_miss_and_hit() {
     let miss = Response::ExecProbeResult {
         cache_key_hex: "0".repeat(64),
         cached_bytes: None,
+        persistent: true,
     };
     roundtrip(&miss);
 
     let hit = Response::ExecProbeResult {
         cache_key_hex: "f".repeat(64),
         cached_bytes: Some(Arc::new(b"cached-ast-bytes".to_vec())),
+        persistent: true,
     };
     roundtrip(&hit);
 }
 
 #[test]
 fn exec_store_ack_roundtrip() {
-    let ack = Response::ExecStoreAck { stored: true };
+    let ack = Response::ExecStoreAck {
+        stored: true,
+        persistent: true,
+    };
     roundtrip(&ack);
 }

--- a/crates/zccache-protocol/src/messages/compat/mod.rs
+++ b/crates/zccache-protocol/src/messages/compat/mod.rs
@@ -107,7 +107,7 @@ pub(super) fn sample_artifact() -> ArtifactData {
 
 // Compile-time check: PROTOCOL_VERSION must be positive.
 const _: () = assert!(super::super::PROTOCOL_VERSION > 0);
-// Compile-time check: PROTOCOL_VERSION == 23 after `DaemonStatus` gained
+// Compile-time check: PROTOCOL_VERSION == 25 after durable exec-cache
 // `index_writer_gone` (issue #1177: a daemon that has stopped recording what
 // it caches still looks healthy, so the condition has to be reportable rather
 // than only inferable from the lifecycle log). v21 was the pin after
@@ -129,4 +129,4 @@ const _: () = assert!(super::super::PROTOCOL_VERSION > 0);
 // pin after SessionStats gained `phase_profile`. v8 was the pin after
 // Compile/CompileEphemeral gained `stdin` and ArtifactPayload replaced
 // ArtifactOutput.data: Arc<Vec<u8>> (issue #296 Option B).
-const _FINGERPRINT_VERSION: () = assert!(super::super::PROTOCOL_VERSION == 23);
+const _FINGERPRINT_VERSION: () = assert!(super::super::PROTOCOL_VERSION == 25);

--- a/crates/zccache-protocol/src/messages/compat/variant_indices.rs
+++ b/crates/zccache-protocol/src/messages/compat/variant_indices.rs
@@ -279,9 +279,16 @@ fn response_variant_indices_are_append_only() {
             Response::ExecProbeResult {
                 cache_key_hex: "0".repeat(64),
                 cached_bytes: None,
+                persistent: true,
             },
         ),
-        (19, Response::ExecStoreAck { stored: true }),
+        (
+            19,
+            Response::ExecStoreAck {
+                stored: true,
+                persistent: true,
+            },
+        ),
         (
             20,
             Response::CompileProgress {

--- a/crates/zccache-protocol/src/messages/mod.rs
+++ b/crates/zccache-protocol/src/messages/mod.rs
@@ -465,6 +465,10 @@ pub enum Response {
     },
     /// Result of an `ExecProbe` request (issue #838).
     ///
+    /// `persistent` must be true before a client may rely on a stored result
+    /// surviving daemon restart. It defaults to false on old prost daemons,
+    /// allowing newer clients to reject their legacy in-memory implementation.
+    ///
     /// `cached_bytes.is_some()` means the daemon found a stored result for
     /// the derived key — the caller should return those bytes to its
     /// consumer without invoking the runner. `cached_bytes.is_none()` means
@@ -482,6 +486,8 @@ pub enum Response {
         cache_key_hex: String,
         /// `Some(bytes)` on cache hit; `None` on miss.
         cached_bytes: Option<Arc<Vec<u8>>>,
+        /// True only when the daemon's exec cache is durable across restart.
+        persistent: bool,
     },
     /// Acknowledgement of an `ExecStore` request (issue #838).
     ///
@@ -496,6 +502,8 @@ pub enum Response {
     ExecStoreAck {
         /// Operational outcome of the store.
         stored: bool,
+        /// True only when the acknowledged store is durable across restart.
+        persistent: bool,
     },
     /// Interim, **non-terminal** progress heartbeat for an in-flight
     /// `Compile` / `CompileEphemeral` request (issue #1216).

--- a/crates/zccache-protocol/src/wire_prost/response.rs
+++ b/crates/zccache-protocol/src/wire_prost/response.rs
@@ -140,12 +140,17 @@ pub fn response_to_prost(response: &crate::Response, request_id: &str) -> zccach
         crate::Response::ExecProbeResult {
             cache_key_hex,
             cached_bytes,
+            persistent,
         } => Body::ExecProbeResult(zccache_v1::ExecProbeResult {
             cache_key_hex: cache_key_hex.clone(),
             cached_bytes: cached_bytes.as_ref().map(|bytes| bytes.as_ref().clone()),
+            persistent: *persistent,
         }),
-        crate::Response::ExecStoreAck { stored } => {
-            Body::ExecStoreAck(zccache_v1::ExecStoreAck { stored: *stored })
+        crate::Response::ExecStoreAck { stored, persistent } => {
+            Body::ExecStoreAck(zccache_v1::ExecStoreAck {
+                stored: *stored,
+                persistent: *persistent,
+            })
         }
     };
 
@@ -253,8 +258,39 @@ pub fn response_from_prost(response: zccache_v1::Response) -> Result<crate::Resp
         Some(Body::ExecProbeResult(result)) => Ok(crate::Response::ExecProbeResult {
             cache_key_hex: result.cache_key_hex,
             cached_bytes: result.cached_bytes.map(std::sync::Arc::new),
+            persistent: result.persistent,
         }),
-        Some(Body::ExecStoreAck(ack)) => Ok(crate::Response::ExecStoreAck { stored: ack.stored }),
+        Some(Body::ExecStoreAck(ack)) => Ok(crate::Response::ExecStoreAck {
+            stored: ack.stored,
+            persistent: ack.persistent,
+        }),
         None => Err("v16 prost response is missing its response body".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_exec_probe_response_defaults_to_not_persistent() {
+        let legacy = zccache_v1::Response {
+            body: Some(zccache_v1::response::Body::ExecProbeResult(
+                zccache_v1::ExecProbeResult {
+                    cache_key_hex: "0".repeat(64),
+                    cached_bytes: None,
+                    persistent: false,
+                },
+            )),
+            request_id: String::new(),
+        };
+
+        assert!(matches!(
+            response_from_prost(legacy),
+            Ok(crate::Response::ExecProbeResult {
+                persistent: false,
+                ..
+            })
+        ));
     }
 }

--- a/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
+++ b/crates/zccache/tests/daemon_wire_prost_roundtrip.rs
@@ -738,10 +738,12 @@ mod exhaustive_prost_coverage {
             Response::ExecProbeResult {
                 cache_key_hex: "a".repeat(64),
                 cached_bytes: Some(Arc::new(b"cached".to_vec())),
+                persistent: true,
             },
             Response::ExecProbeResult {
                 cache_key_hex: "b".repeat(64),
                 cached_bytes: None,
+                persistent: true,
             },
             // An empty cached payload is a HIT, not a miss. If `optional`
             // were dropped from the proto field this would decode as
@@ -749,9 +751,16 @@ mod exhaustive_prost_coverage {
             Response::ExecProbeResult {
                 cache_key_hex: "c".repeat(64),
                 cached_bytes: Some(Arc::new(Vec::new())),
+                persistent: true,
             },
-            Response::ExecStoreAck { stored: true },
-            Response::ExecStoreAck { stored: false },
+            Response::ExecStoreAck {
+                stored: true,
+                persistent: true,
+            },
+            Response::ExecStoreAck {
+                stored: false,
+                persistent: true,
+            },
         ]
     }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,6 +23,8 @@ failed cache-root audit retain its diagnostic JSONL evidence.
 
 ## Quick Reference
 
+- **Python caller-owned byte caching** → [runtime.md § `exec_cached`](architecture/runtime.md#python-caller-owned-exec_cached)
+
 - **High-level design** → [overview.md](architecture/overview.md)
 - **"How does a cache hit work?"** → [data-flow.md](architecture/data-flow.md)
 - **Nested Dylint driver caching** → [data-flow.md](architecture/data-flow.md#nested-dylint-driver-caching)

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -28,6 +28,7 @@ Architecture docs are split by subsystem. Read only what's relevant to your curr
 | Host-platform boundary (`zccache-platform`, `crate::platform`) | [portability.md](architecture/portability.md) — one selector, five facades, host-vs-compiler-target rule |
 | Generic tool exec (`zccache exec`, issue #272) | [runtime.md § Generic tool exec](architecture/runtime.md#generic-tool-exec-zccache-exec) — `handle_exec.rs` + `cli/commands/exec.rs` |
 | Platform-specific issues | [portability.md](architecture/portability.md) |
+| Python `exec_cached` caller-owned results | [runtime.md](architecture/runtime.md#python-caller-owned-exec_cached), [ipc.md](architecture/ipc.md#wire-selection-and-compatibility-fallback) |
 | Compile journal record shape | [journal-schema.md](journal-schema.md) |
 | `ZCCACHE_CACHE_DIR` contract + `zccache cache-root` | [runtime.md § Cache root invariants](architecture/runtime.md#cache-root-invariants) |
 | zccache vs sccache feature matrix | [FEATURE-MATRIX.md](FEATURE-MATRIX.md) — generated from [feature-matrix.yaml](feature-matrix.yaml) by `ci/render_feature_matrix.py` |

--- a/docs/architecture/ipc.md
+++ b/docs/architecture/ipc.md
@@ -94,6 +94,12 @@ needed before the legacy lane is deleted. A separate prost availability bit
 keeps an old/legacy response distinguishable from a genuine empty map; the CLI
 prints telemetry as unavailable (and JSON `null`) unless that bit is present.
 
+`ExecProbe` and `ExecStore` use this same full-family selection path. Each is
+one ordinary request/response roundtrip; there is no preliminary handshake.
+Python callback execution happens between the miss response and the store
+request. Application errors and ambiguous transport failures are terminal, so
+the binding never runs or stores a callback result after an uncertain replay.
+
 ## Connection Lifecycle
 
 **CLI side (drop-in wrapper mode):**

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -337,6 +337,24 @@ Cache policies (`ExecCachePolicy`):
 
 The daemon runs the tool with `env_clear()` and only the declared env subset, so the cache key is the exact functional input of the run. Concurrent callers with the same full key coalesce on `state.in_flight_exec` — the first inserter spawns the tool; the rest wait on a shared `tokio::sync::Notify` and re-attempt the cache lookup once it fires, guaranteeing exactly one tool spawn per herd.
 
+### Python caller-owned `exec_cached`
+
+`zccache.exec_cached(name, input_files, input_env, extra_key, runner) -> bytes`
+uses the related `ExecProbe` / `ExecStore` request pair when the work is an
+in-process Python callback rather than a daemon-spawned command. The probe key
+keeps its original `zccache-exec-probe-v1` domain and hashes the name, sorted
+path/content pairs, sorted environment pairs, and opaque `extra_key`. Values
+are stored verbatim in the crash-safe `exec-probe-v1` KV namespace, so a
+successful store survives daemon restart without changing key compatibility.
+
+Both IPC/storage waits release the GIL. A hit returns the stored bytes without
+calling `runner`; a miss reacquires the GIL for exactly one callback invocation,
+requires a `bytes` result, persists it, and returns it. Callback exceptions are
+propagated unchanged and are never stored. Daemon/protocol/storage failures
+raise `RuntimeError` and do not trigger an implicit uncached fallback. The API
+expects the normal zccache daemon to be running; callers may start it with
+`zccache start` according to their own lifecycle policy.
+
 **Measured warm-hit latency**: ~190 µs / request on Windows NTFS (criterion `benches/exec.rs::exec_warm_hit`), versus ~15 ms / cold-miss request (dominated by tool spawn cost). The IPC roundtrip + cache-key compose + artifact-replay path lands well under the issue's "sub-millisecond" warm-hit target.
 
 The integration suite covering this handler spans two files:

--- a/python/tests/README.md
+++ b/python/tests/README.md
@@ -1,0 +1,6 @@
+# Python Package Tests
+
+Public-package and installed-native-extension contracts for the combined
+`zccache` wheel. Tests that require native modules skip in a pure-source
+checkout; the release workflow runs the installed-wheel smoke on Linux,
+macOS, and Windows before publishing.

--- a/python/tests/test_public_api.py
+++ b/python/tests/test_public_api.py
@@ -25,6 +25,7 @@ def test_top_level_import_exposes_expected_symbols() -> None:
     assert zccache.DownloadApi is DownloadApi
     assert zccache.FetchResult is FetchResult
     assert zccache.FetchState is FetchState
+    assert callable(zccache.exec_cached)
 
 
 def test_top_level_import_exposes_expected_submodules() -> None:

--- a/python/zccache/README.md
+++ b/python/zccache/README.md
@@ -13,6 +13,7 @@ python/zccache/
 ├── __init__.py              # public re-exports (see __all__)
 ├── client.py                # ZcCacheClient + DaemonStatus + SessionStats
 ├── downloader.py            # DownloadApi + FetchResult + FetchState
+├── exec_cache.py            # caller-owned `exec_cached` byte results
 ├── fingerprint/             # FingerprintCache + FingerprintManager
 ├── watcher/                 # FileWatcher + DebouncedFileWatcherProcess
 ├── ino.py                   # InoConvertResult + convert_ino
@@ -30,6 +31,7 @@ is a breaking change. New surface lands additively.
 |------------------|------------------------------------------------------------------|
 | `client`         | `ZcCacheClient`, `DaemonStatus`, `SessionStartResult`, `SessionStats`. |
 | `downloader`     | `DownloadApi`, `DownloadHandle`, `FetchResult`, `FetchState`.    |
+| `exec_cache`     | `exec_cached` for daemon-backed caller-owned byte results.       |
 | `fingerprint`    | `FingerprintCache`, `FingerprintManager`, `FingerprintResult`.   |
 | `watcher`        | `FileWatcher`, `DebouncedFileWatcherProcess`, `watch_files`.     |
 | `cpp_lint`       | `cpp_lint`, `LintInput`, `AstQuery`, `IwyuItem`, `ResultItem`, `Summary`, ... (see `cpp_lint/README.md`). |

--- a/python/zccache/__init__.py
+++ b/python/zccache/__init__.py
@@ -25,6 +25,7 @@ from zccache.downloader import (
     FetchResult,
     FetchState,
 )
+from zccache.exec_cache import exec_cached
 from zccache.fingerprint import (
     Api,
     FingerprintCache,
@@ -76,6 +77,7 @@ __all__ = [
     "cpp_lint",
     "cpp_lint_run",
     "downloader",
+    "exec_cached",
     "fingerprint",
     "ino",
     "watcher",

--- a/python/zccache/exec_cache.py
+++ b/python/zccache/exec_cache.py
@@ -1,0 +1,28 @@
+"""Caller-owned function caching backed by the zccache daemon."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Iterable, Mapping
+
+from zccache._native import exec_cached as _exec_cached
+
+
+def exec_cached(
+    name: str,
+    input_files: Iterable[str | os.PathLike[str]],
+    input_env: Mapping[str, str],
+    extra_key: bytes,
+    runner: Callable[[], bytes],
+) -> bytes:
+    """Return cached bytes for declared inputs, invoking ``runner`` on a miss.
+
+    ``name`` and ``extra_key`` identify the caller's result schema. File
+    contents and the selected environment mapping are hashed by the daemon.
+    A daemon or protocol failure raises ``RuntimeError`` and never invokes an
+    implicit uncached fallback.
+    """
+
+    files = [os.fspath(path) for path in input_files]
+    env = list(input_env.items())
+    return _exec_cached(name, files, env, bytes(extra_key), runner)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -912,3 +912,21 @@ Issue: https://github.com/zackees/zccache/issues/1429
   are not part of the solo snapshot and explicitly directs such jobs to opt out.
 - GREEN target: a hosted warm Coverage run generates `lcov.info` and reaches a
   successful Codecov upload without adding LLVM tools to unrelated jobs.
+
+# #1433 publish the Python exec_cached API
+
+Issue: https://github.com/zackees/zccache/issues/1433
+
+- [ ] Add RED contracts for daemon-restart persistence and the public Python API.
+- [ ] Persist ExecProbe/ExecStore bytes in the normal namespaced KV store.
+- [ ] Expose `zccache.exec_cached(...)` with GIL-free IPC and exact bytes replay.
+- [ ] Gate release wheels on Linux, macOS, and Windows behavior smoke tests.
+- [ ] Run focused/full correctness and review gates, merge, and close #1433.
+- [ ] Publish the API and replace FastLED's bespoke AST cache with timing evidence.
+
+## Review
+
+- Key compatibility: retain `zccache-exec-probe-v1`; persistence changes only
+  where the already-derived 32-byte key stores its opaque result bytes.
+- Failure policy: daemon/protocol/store failures surface to Python and never
+  invoke an uncached fallback behind the caller's back.


### PR DESCRIPTION
Closes #1433\n\nAdds the public zccache.exec_cached API backed by durable daemon KV storage, fails closed against pre-persistence daemons, releases the GIL around IPC/store work, and gates PyPI publication on native wheel smoke coverage for all shipped families.\n\nValidated locally:\n- soldr cargo check -p zccache-cli --features python\n- soldr cargo test -p zccache-daemon-core --features test-support stored_bytes_survive_daemon_restart -- --ignored\n- soldr cargo test -p zccache-daemon-core --features test-support probe_miss_then_store_then_probe_hit -- --ignored\n- soldr cargo test -p zccache-protocol legacy_exec_probe_response_defaults_to_not_persistent\n- uv run --no-project pytest ci/tests/test_package_release.py\n- direct native daemon smoke: miss/store/hit with one runner invocation\n\nReview: clud-review clean (one reviewer).