### PR TITLE
fix(perf): reject mid-sample host contention

### DIFF
--- a/ci/perf_sample_monitor.py
+++ b/ci/perf_sample_monitor.py
@@ -1,0 +1,55 @@
+"""Host-contention monitoring for standalone performance samples."""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from collections.abc import Callable
+
+
+SAMPLE_MONITOR_INTERVAL_SECONDS = 2.0
+SAMPLE_CONTAINER_MONITOR_INTERVAL_SECONDS = 10.0
+
+
+def process_names_outside_container(
+    processes: list[tuple[int, str]],
+    container_pids_before: set[int],
+    container_pids_after: set[int],
+) -> list[str]:
+    excluded_pids = container_pids_before | container_pids_after
+    return [name for pid, name in processes if pid not in excluded_pids]
+
+
+def monitor_sample_process(
+    process: subprocess.Popen[str],
+    container_name: str,
+    process_probe: Callable[[bool], list[str]],
+    container_probe: Callable[[], list[tuple[str, float]]],
+    busy_reasons: Callable[[list[tuple[str, float]], list[str]], list[str]],
+) -> tuple[int, list[str]]:
+    """Wait for a timed sample while recording any competing host activity."""
+    detected: set[str] = set()
+    next_container_probe = 0.0
+    while True:
+        try:
+            return_code = process.wait(timeout=SAMPLE_MONITOR_INTERVAL_SECONDS)
+            finished = True
+        except subprocess.TimeoutExpired:
+            finished = False
+
+        try:
+            detected.update(busy_reasons([], process_probe(finished)))
+        except (RuntimeError, subprocess.SubprocessError) as error:
+            detected.add(f"host process monitor failed: {error}")
+        now = time.monotonic()
+        if finished or now >= next_container_probe:
+            try:
+                containers = [
+                    item for item in container_probe() if item[0] != container_name
+                ]
+                detected.update(busy_reasons(containers, []))
+            except (RuntimeError, subprocess.SubprocessError) as error:
+                detected.add(f"container monitor failed: {error}")
+            next_container_probe = now + SAMPLE_CONTAINER_MONITOR_INTERVAL_SECONDS
+        if finished:
+            return return_code, sorted(detected)

--- a/ci/perf_sample_monitor.py
+++ b/ci/perf_sample_monitor.py
@@ -12,12 +12,21 @@ SAMPLE_CONTAINER_MONITOR_INTERVAL_SECONDS = 10.0
 
 
 def process_names_outside_container(
-    processes: list[tuple[int, str]],
+    processes: list[tuple[int, int, str]],
     container_pids_before: set[int],
     container_pids_after: set[int],
 ) -> list[str]:
     excluded_pids = container_pids_before | container_pids_after
-    return [name for pid, name in processes if pid not in excluded_pids]
+    while True:
+        descendants = {
+            pid
+            for pid, parent_pid, _name in processes
+            if parent_pid in excluded_pids and pid not in excluded_pids
+        }
+        if not descendants:
+            break
+        excluded_pids.update(descendants)
+    return [name for pid, _parent_pid, name in processes if pid not in excluded_pids]
 
 
 def monitor_sample_process(

--- a/ci/perf_standalone.py
+++ b/ci/perf_standalone.py
@@ -262,6 +262,14 @@ def artifact_paths(campaign_dir: Path, sample_dir: Path) -> dict[str, Any]:
     }
 
 
+def _quarantine_contaminated_sample(sample_dir: Path) -> Path:
+    destination = sample_dir.with_name(
+        f"{sample_dir.name}.contaminated-{time.time_ns()}"
+    )
+    sample_dir.rename(destination)
+    return destination
+
+
 def validate_completed_results(
     campaign_dir: Path, campaign: dict[str, Any], expected_attempts: int
 ) -> None:
@@ -331,13 +339,19 @@ def _monitor_sample_process(
         except subprocess.TimeoutExpired:
             finished = False
 
-        detected.update(busy_reasons([], process_probe()))
+        try:
+            detected.update(busy_reasons([], process_probe(finished)))
+        except (RuntimeError, subprocess.SubprocessError) as error:
+            detected.add(f"host process monitor failed: {error}")
         now = time.monotonic()
         if finished or now >= next_container_probe:
-            containers = [
-                item for item in container_probe() if item[0] != container_name
-            ]
-            detected.update(busy_reasons(containers, []))
+            try:
+                containers = [
+                    item for item in container_probe() if item[0] != container_name
+                ]
+                detected.update(busy_reasons(containers, []))
+            except (RuntimeError, subprocess.SubprocessError) as error:
+                detected.add(f"container monitor failed: {error}")
             next_container_probe = now + SAMPLE_CONTAINER_MONITOR_INTERVAL_SECONDS
         if finished:
             return return_code, sorted(detected)
@@ -351,7 +365,7 @@ def _run_sample_command(
     return_code, contamination = _monitor_sample_process(
         process,
         container_name,
-        _active_process_names,
+        lambda finished: _sample_process_names(container_name, finished),
         _container_stats,
     )
     return subprocess.CompletedProcess(command, return_code), contamination
@@ -447,6 +461,50 @@ def _process_names() -> list[str]:
         check=False,
     ).stdout
     return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def _process_names_outside_pids(
+    processes: list[tuple[int, str]], excluded_pids: set[int]
+) -> list[str]:
+    return [name for pid, name in processes if pid not in excluded_pids]
+
+
+def _linux_sample_process_names(container_name: str) -> list[str]:
+    top = subprocess.run(
+        ["docker", "top", container_name, "-eo", "pid"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=HOST_PROCESS_ENUMERATION_TIMEOUT_SECONDS,
+    )
+    if top.returncode != 0:
+        raise RuntimeError("sample container process enumeration failed")
+    excluded_pids = {
+        int(line.strip())
+        for line in top.stdout.splitlines()
+        if line.strip().isdigit()
+    }
+    host = subprocess.run(
+        ["ps", "-eo", "pid=,comm="],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=HOST_PROCESS_ENUMERATION_TIMEOUT_SECONDS,
+    )
+    if host.returncode != 0:
+        raise RuntimeError("host process enumeration failed")
+    processes = []
+    for line in host.stdout.splitlines():
+        fields = line.strip().split(maxsplit=1)
+        if len(fields) == 2 and fields[0].isdigit():
+            processes.append((int(fields[0]), fields[1]))
+    return _process_names_outside_pids(processes, excluded_pids)
+
+
+def _sample_process_names(container_name: str, finished: bool) -> list[str]:
+    if os.name == "nt" or finished:
+        return _active_process_names()
+    return _linux_sample_process_names(container_name)
 
 
 def active_windows_process_names(
@@ -778,8 +836,10 @@ def _run_sample(
             f"timed sample overlapped {reason}" for reason in contamination
         )
         _write_json(summary_path, summary)
+        quarantine = _quarantine_contaminated_sample(sample_dir)
         raise RuntimeError(
-            "timed sample was contaminated: " + "; ".join(contamination)
+            "timed sample was contaminated; evidence retained at "
+            f"{quarantine}: " + "; ".join(contamination)
         )
     validate_sample_summary(summary, attempts)
     return {

--- a/ci/perf_standalone.py
+++ b/ci/perf_standalone.py
@@ -465,7 +465,7 @@ def _sample_container_process_ids(container_name: str) -> set[int]:
 def _linux_sample_process_names(container_name: str) -> list[str]:
     container_pids_before = _sample_container_process_ids(container_name)
     host = subprocess.run(
-        ["ps", "-eo", "pid=,comm="],
+        ["ps", "-eo", "pid=,ppid=,comm="],
         capture_output=True,
         text=True,
         check=False,
@@ -475,9 +475,9 @@ def _linux_sample_process_names(container_name: str) -> list[str]:
         raise RuntimeError("host process enumeration failed")
     processes = []
     for line in host.stdout.splitlines():
-        fields = line.strip().split(maxsplit=1)
-        if len(fields) == 2 and fields[0].isdigit():
-            processes.append((int(fields[0]), fields[1]))
+        fields = line.strip().split(maxsplit=2)
+        if len(fields) == 3 and fields[0].isdigit() and fields[1].isdigit():
+            processes.append((int(fields[0]), int(fields[1]), fields[2]))
     container_pids_after = _sample_container_process_ids(container_name)
     return perf_sample_monitor.process_names_outside_container(
         processes, container_pids_before, container_pids_after

--- a/ci/perf_standalone.py
+++ b/ci/perf_standalone.py
@@ -15,7 +15,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from ci import benchmark_stats
+from ci import benchmark_stats, perf_sample_monitor
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -51,8 +51,6 @@ COMPETING_PROCESSES = {
 }
 BUSY_CPU_PERCENT = 5.0
 HOST_PROCESS_ENUMERATION_TIMEOUT_SECONDS = 30
-SAMPLE_MONITOR_INTERVAL_SECONDS = 2.0
-SAMPLE_CONTAINER_MONITOR_INTERVAL_SECONDS = 10.0
 RECIPE_FILES = (
     DOCKERFILE,
     REPO_ROOT / "ci/docker/standalone_perf_entrypoint.sh",
@@ -270,6 +268,23 @@ def _quarantine_contaminated_sample(sample_dir: Path) -> Path:
     return destination
 
 
+def _reject_contaminated_sample(sample_dir: Path, contamination: list[str]) -> None:
+    _write_json(
+        sample_dir / "infrastructure-invalid.json",
+        {
+            "valid": False,
+            "invalid_reasons": [
+                f"timed sample overlapped {reason}" for reason in contamination
+            ],
+        },
+    )
+    quarantine = _quarantine_contaminated_sample(sample_dir)
+    raise RuntimeError(
+        "timed sample was contaminated; evidence retained at "
+        f"{quarantine}: " + "; ".join(contamination)
+    )
+
+
 def validate_completed_results(
     campaign_dir: Path, campaign: dict[str, Any], expected_attempts: int
 ) -> None:
@@ -323,50 +338,17 @@ def _run(
     )
 
 
-def _monitor_sample_process(
-    process: subprocess.Popen[str],
-    container_name: str,
-    process_probe: Any,
-    container_probe: Any,
-) -> tuple[int, list[str]]:
-    """Wait for a timed sample while recording any competing host activity."""
-    detected: set[str] = set()
-    next_container_probe = 0.0
-    while True:
-        try:
-            return_code = process.wait(timeout=SAMPLE_MONITOR_INTERVAL_SECONDS)
-            finished = True
-        except subprocess.TimeoutExpired:
-            finished = False
-
-        try:
-            detected.update(busy_reasons([], process_probe(finished)))
-        except (RuntimeError, subprocess.SubprocessError) as error:
-            detected.add(f"host process monitor failed: {error}")
-        now = time.monotonic()
-        if finished or now >= next_container_probe:
-            try:
-                containers = [
-                    item for item in container_probe() if item[0] != container_name
-                ]
-                detected.update(busy_reasons(containers, []))
-            except (RuntimeError, subprocess.SubprocessError) as error:
-                detected.add(f"container monitor failed: {error}")
-            next_container_probe = now + SAMPLE_CONTAINER_MONITOR_INTERVAL_SECONDS
-        if finished:
-            return return_code, sorted(detected)
-
-
 def _run_sample_command(
     command: list[str], container_name: str
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     print("+ " + subprocess.list2cmdline(command), flush=True)
     process = subprocess.Popen(command, cwd=REPO_ROOT, text=True, encoding="utf-8")
-    return_code, contamination = _monitor_sample_process(
+    return_code, contamination = perf_sample_monitor.monitor_sample_process(
         process,
         container_name,
         lambda finished: _sample_process_names(container_name, finished),
         _container_stats,
+        busy_reasons,
     )
     return subprocess.CompletedProcess(command, return_code), contamination
 
@@ -463,13 +445,7 @@ def _process_names() -> list[str]:
     return [line.strip() for line in output.splitlines() if line.strip()]
 
 
-def _process_names_outside_pids(
-    processes: list[tuple[int, str]], excluded_pids: set[int]
-) -> list[str]:
-    return [name for pid, name in processes if pid not in excluded_pids]
-
-
-def _linux_sample_process_names(container_name: str) -> list[str]:
+def _sample_container_process_ids(container_name: str) -> set[int]:
     top = subprocess.run(
         ["docker", "top", container_name, "-eo", "pid"],
         capture_output=True,
@@ -479,11 +455,15 @@ def _linux_sample_process_names(container_name: str) -> list[str]:
     )
     if top.returncode != 0:
         raise RuntimeError("sample container process enumeration failed")
-    excluded_pids = {
+    return {
         int(line.strip())
         for line in top.stdout.splitlines()
         if line.strip().isdigit()
     }
+
+
+def _linux_sample_process_names(container_name: str) -> list[str]:
+    container_pids_before = _sample_container_process_ids(container_name)
     host = subprocess.run(
         ["ps", "-eo", "pid=,comm="],
         capture_output=True,
@@ -498,7 +478,10 @@ def _linux_sample_process_names(container_name: str) -> list[str]:
         fields = line.strip().split(maxsplit=1)
         if len(fields) == 2 and fields[0].isdigit():
             processes.append((int(fields[0]), fields[1]))
-    return _process_names_outside_pids(processes, excluded_pids)
+    container_pids_after = _sample_container_process_ids(container_name)
+    return perf_sample_monitor.process_names_outside_container(
+        processes, container_pids_before, container_pids_after
+    )
 
 
 def _sample_process_names(container_name: str, finished: bool) -> list[str]:
@@ -821,6 +804,8 @@ def _run_sample(
     )
     result, contamination = _run_sample_command(command, container_name)
     summary_path = sample_dir / "perf-guard-summary.json"
+    if contamination and not summary_path.is_file():
+        _reject_contaminated_sample(sample_dir, contamination)
     if not summary_path.is_file():
         raise RuntimeError(
             f"benchmark did not produce {summary_path} (exit={result.returncode})"
@@ -836,11 +821,7 @@ def _run_sample(
             f"timed sample overlapped {reason}" for reason in contamination
         )
         _write_json(summary_path, summary)
-        quarantine = _quarantine_contaminated_sample(sample_dir)
-        raise RuntimeError(
-            "timed sample was contaminated; evidence retained at "
-            f"{quarantine}: " + "; ".join(contamination)
-        )
+        _reject_contaminated_sample(sample_dir, contamination)
     validate_sample_summary(summary, attempts)
     return {
         "language": language,

--- a/ci/perf_standalone.py
+++ b/ci/perf_standalone.py
@@ -51,6 +51,8 @@ COMPETING_PROCESSES = {
 }
 BUSY_CPU_PERCENT = 5.0
 HOST_PROCESS_ENUMERATION_TIMEOUT_SECONDS = 30
+SAMPLE_MONITOR_INTERVAL_SECONDS = 2.0
+SAMPLE_CONTAINER_MONITOR_INTERVAL_SECONDS = 10.0
 RECIPE_FILES = (
     DOCKERFILE,
     REPO_ROOT / "ci/docker/standalone_perf_entrypoint.sh",
@@ -311,6 +313,48 @@ def _run(
         check=check,
         timeout=timeout_seconds,
     )
+
+
+def _monitor_sample_process(
+    process: subprocess.Popen[str],
+    container_name: str,
+    process_probe: Any,
+    container_probe: Any,
+) -> tuple[int, list[str]]:
+    """Wait for a timed sample while recording any competing host activity."""
+    detected: set[str] = set()
+    next_container_probe = 0.0
+    while True:
+        try:
+            return_code = process.wait(timeout=SAMPLE_MONITOR_INTERVAL_SECONDS)
+            finished = True
+        except subprocess.TimeoutExpired:
+            finished = False
+
+        detected.update(busy_reasons([], process_probe()))
+        now = time.monotonic()
+        if finished or now >= next_container_probe:
+            containers = [
+                item for item in container_probe() if item[0] != container_name
+            ]
+            detected.update(busy_reasons(containers, []))
+            next_container_probe = now + SAMPLE_CONTAINER_MONITOR_INTERVAL_SECONDS
+        if finished:
+            return return_code, sorted(detected)
+
+
+def _run_sample_command(
+    command: list[str], container_name: str
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    print("+ " + subprocess.list2cmdline(command), flush=True)
+    process = subprocess.Popen(command, cwd=REPO_ROOT, text=True, encoding="utf-8")
+    return_code, contamination = _monitor_sample_process(
+        process,
+        container_name,
+        _active_process_names,
+        _container_stats,
+    )
+    return subprocess.CompletedProcess(command, return_code), contamination
 
 
 def _git_output(*args: str) -> str:
@@ -709,14 +753,15 @@ def _run_sample(
 ) -> dict[str, Any]:
     sample_dir = campaign_dir / language.replace("+", "p") / test_name
     sample_dir.mkdir(parents=True, exist_ok=True)
+    container_name = f"zccache-standalone-{language.replace('+', 'p')}-{test_name}"[:63]
     command = docker_run_command(
         repo_root=REPO_ROOT,
         results_dir=sample_dir,
-        container_name=f"zccache-standalone-{language.replace('+', 'p')}-{test_name}"[:63],
+        container_name=container_name,
         entrypoint_args=["run", language, test_name, str(attempts)],
         artifacts_dir=campaign_dir / "fixture",
     )
-    result = _run(command, check=False)
+    result, contamination = _run_sample_command(command, container_name)
     summary_path = sample_dir / "perf-guard-summary.json"
     if not summary_path.is_file():
         raise RuntimeError(
@@ -726,6 +771,16 @@ def _run_sample(
     summary = _enrich_summary(
         summary_path, result.returncode, identity, command, telemetry
     )
+    if contamination:
+        infrastructure = summary["infrastructure"]
+        infrastructure["valid"] = False
+        infrastructure["invalid_reasons"].extend(
+            f"timed sample overlapped {reason}" for reason in contamination
+        )
+        _write_json(summary_path, summary)
+        raise RuntimeError(
+            "timed sample was contaminated: " + "; ".join(contamination)
+        )
     validate_sample_summary(summary, attempts)
     return {
         "language": language,

--- a/ci/tests/test_perf_standalone.py
+++ b/ci/tests/test_perf_standalone.py
@@ -4,7 +4,7 @@ from argparse import Namespace
 
 import pytest
 
-from ci import benchmark_stats, perf_standalone
+from ci import benchmark_stats, perf_sample_monitor, perf_standalone
 
 
 def test_campaign_inventory_matches_registered_benchmarks():
@@ -377,18 +377,19 @@ def test_sample_monitor_rejects_activity_that_starts_after_launch():
         waits = 0
 
         def wait(self, timeout):
-            assert timeout == perf_standalone.SAMPLE_MONITOR_INTERVAL_SECONDS
+            assert timeout == perf_sample_monitor.SAMPLE_MONITOR_INTERVAL_SECONDS
             self.waits += 1
             if self.waits == 1:
                 raise subprocess.TimeoutExpired("sample", timeout)
             return 0
 
     process_samples = iter([[], ["perf_bench_test"]])
-    return_code, reasons = perf_standalone._monitor_sample_process(
+    return_code, reasons = perf_sample_monitor.monitor_sample_process(
         Process(),
         "zccache-standalone-own-sample",
         lambda _finished: next(process_samples),
         lambda: [("zccache-standalone-own-sample", 90.0)],
+        perf_standalone.busy_reasons,
     )
 
     assert return_code == 0
@@ -402,8 +403,8 @@ def test_linux_monitor_excludes_the_sample_container_process_tree():
         (201, "sccache"),
     ]
 
-    assert perf_standalone._process_names_outside_pids(
-        processes, {101, 102}
+    assert perf_sample_monitor.process_names_outside_container(
+        processes, {101}, {101, 102}
     ) == ["sccache"]
 
 
@@ -422,11 +423,12 @@ def test_sample_monitor_records_probe_failure_and_reaps_process():
     def failed_probe(_finished):
         raise RuntimeError("process enumeration unavailable")
 
-    return_code, reasons = perf_standalone._monitor_sample_process(
+    return_code, reasons = perf_sample_monitor.monitor_sample_process(
         process,
         "zccache-standalone-own-sample",
         failed_probe,
         lambda: [],
+        perf_standalone.busy_reasons,
     )
 
     assert return_code == 0
@@ -436,17 +438,25 @@ def test_sample_monitor_records_probe_failure_and_reaps_process():
     ]
 
 
-def test_quarantine_preserves_contaminated_evidence_across_retry(tmp_path):
+def test_no_summary_contamination_is_quarantined_before_retry(tmp_path):
     sample_dir = tmp_path / "sample"
     sample_dir.mkdir()
     evidence = sample_dir / "attempt-1.log"
     evidence.write_bytes(b"contaminated evidence")
 
-    quarantine = perf_standalone._quarantine_contaminated_sample(sample_dir)
+    with pytest.raises(RuntimeError, match="evidence retained"):
+        perf_standalone._reject_contaminated_sample(
+            sample_dir, ["host process perf_bench_test is active"]
+        )
+    quarantine, = tmp_path.glob("sample.contaminated-*")
     sample_dir.mkdir()
     (sample_dir / "attempt-1.log").write_bytes(b"clean retry")
 
     assert (quarantine / "attempt-1.log").read_bytes() == b"contaminated evidence"
+    invalid = json.loads(
+        (quarantine / "infrastructure-invalid.json").read_text(encoding="utf-8")
+    )
+    assert invalid["valid"] is False
     assert evidence.read_bytes() == b"clean retry"
 
 

--- a/ci/tests/test_perf_standalone.py
+++ b/ci/tests/test_perf_standalone.py
@@ -387,12 +387,67 @@ def test_sample_monitor_rejects_activity_that_starts_after_launch():
     return_code, reasons = perf_standalone._monitor_sample_process(
         Process(),
         "zccache-standalone-own-sample",
-        lambda: next(process_samples),
+        lambda _finished: next(process_samples),
         lambda: [("zccache-standalone-own-sample", 90.0)],
     )
 
     assert return_code == 0
     assert reasons == ["host process perf_bench_test is active"]
+
+
+def test_linux_monitor_excludes_the_sample_container_process_tree():
+    processes = [
+        (101, "perf_bench_test"),
+        (102, "em++"),
+        (201, "sccache"),
+    ]
+
+    assert perf_standalone._process_names_outside_pids(
+        processes, {101, 102}
+    ) == ["sccache"]
+
+
+def test_sample_monitor_records_probe_failure_and_reaps_process():
+    class Process:
+        waits = 0
+
+        def wait(self, timeout):
+            self.waits += 1
+            if self.waits == 1:
+                raise subprocess.TimeoutExpired("sample", timeout)
+            return 0
+
+    process = Process()
+
+    def failed_probe(_finished):
+        raise RuntimeError("process enumeration unavailable")
+
+    return_code, reasons = perf_standalone._monitor_sample_process(
+        process,
+        "zccache-standalone-own-sample",
+        failed_probe,
+        lambda: [],
+    )
+
+    assert return_code == 0
+    assert process.waits == 2
+    assert reasons == [
+        "host process monitor failed: process enumeration unavailable"
+    ]
+
+
+def test_quarantine_preserves_contaminated_evidence_across_retry(tmp_path):
+    sample_dir = tmp_path / "sample"
+    sample_dir.mkdir()
+    evidence = sample_dir / "attempt-1.log"
+    evidence.write_bytes(b"contaminated evidence")
+
+    quarantine = perf_standalone._quarantine_contaminated_sample(sample_dir)
+    sample_dir.mkdir()
+    (sample_dir / "attempt-1.log").write_bytes(b"clean retry")
+
+    assert (quarantine / "attempt-1.log").read_bytes() == b"contaminated evidence"
+    assert evidence.read_bytes() == b"clean retry"
 
 
 def test_host_fingerprint_input_ignores_dynamic_docker_state():

--- a/ci/tests/test_perf_standalone.py
+++ b/ci/tests/test_perf_standalone.py
@@ -398,13 +398,14 @@ def test_sample_monitor_rejects_activity_that_starts_after_launch():
 
 def test_linux_monitor_excludes_the_sample_container_process_tree():
     processes = [
-        (101, "perf_bench_test"),
-        (102, "em++"),
-        (201, "sccache"),
+        (101, 1, "perf_bench_test"),
+        (102, 101, "em++"),
+        (103, 102, "clang"),
+        (201, 1, "sccache"),
     ]
 
     assert perf_sample_monitor.process_names_outside_container(
-        processes, {101}, {101, 102}
+        processes, {101}, {101}
     ) == ["sccache"]
 
 

--- a/ci/tests/test_perf_standalone.py
+++ b/ci/tests/test_perf_standalone.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 from argparse import Namespace
 
 import pytest
@@ -369,6 +370,29 @@ def test_windows_process_activity_ignores_only_idle_orphan_rustc():
         "rustc",
         "cargo",
     ]
+
+
+def test_sample_monitor_rejects_activity_that_starts_after_launch():
+    class Process:
+        waits = 0
+
+        def wait(self, timeout):
+            assert timeout == perf_standalone.SAMPLE_MONITOR_INTERVAL_SECONDS
+            self.waits += 1
+            if self.waits == 1:
+                raise subprocess.TimeoutExpired("sample", timeout)
+            return 0
+
+    process_samples = iter([[], ["perf_bench_test"]])
+    return_code, reasons = perf_standalone._monitor_sample_process(
+        Process(),
+        "zccache-standalone-own-sample",
+        lambda: next(process_samples),
+        lambda: [("zccache-standalone-own-sample", 90.0)],
+    )
+
+    assert return_code == 0
+    assert reasons == ["host process perf_bench_test is active"]
 
 
 def test_host_fingerprint_input_ignores_dynamic_docker_state():


### PR DESCRIPTION
## Summary- continuously monitor timed standalone samples for competing host processes and Docker workloads- exclude the sample container's own Linux PID/PPID descendant tree, including short-lived compiler churn- fail closed on monitoring errors while still reaping the timed child- quarantine contaminated and partial/no-summary evidence before `--resume` retries## WhyThe #1116/#1036 Emscripten campaign exposed that the runner checked host quietness only before a multi-minute sample. Unrelated Cargo/rustc work could begin mid-sample, distort timings, and still be accepted as valid. The observed #1437 RED cannot be treated as production evidence until this integrity hole is closed.## Validation- `uv run --no-project --with pytest python -m pytest ci/tests/test_perf_standalone.py ci/tests/test_perf_guard.py -q` � 69 passed- `uvx ruff check ci/perf_standalone.py ci/perf_sample_monitor.py ci/tests/test_perf_standalone.py` � clean- `git diff --check origin/main...HEAD` � clean- `/clud-review` � clean after addressing Linux self-container exclusion, probe failure/reaping, immutable quarantine, no-summary retention, and transient-child races## Follow-up gateAfter merge, rerun the five-attempt Emscripten screen and then resume the full all-language campaign. Do not lower any threshold. If continuously verified quiet-host evidence passes, close #1437 as an invalid contaminated measurement; otherwise continue with the production-path diagnosis.Refs #1437