### PR TITLE
fix(release): stop ARM64 xwin C++ mode from breaking ring

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -190,18 +190,6 @@ runs:
       with:
         tool: cargo-xwin
 
-    - name: Configure xwin ARM64 C compatibility
-      if: inputs.cross_driver == 'xwin' && inputs.target == 'aarch64-pc-windows-msvc'
-      shell: bash
-      run: |
-        # mimalloc's MSVC C atomics use intrinsics that clang-cl does not
-        # declare for ARM64. Its own source recommends C++ compilation for
-        # MSVC; /TP selects that std::atomic path without changing Rust code.
-        # cargo-xwin owns CFLAGS_<target> and replaces that variable when it
-        # injects the SDK include paths. General CFLAGS is additive in cc-rs
-        # and this job builds only the selected ARM64 target.
-        echo "CFLAGS=-TP" >> "$GITHUB_ENV"
-
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
       uses: zackees/setup-soldr@01aea6d47db8fedcafd350e2d42e19290c68824e

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc-pprof"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71dc9f58355ea3d31ad23ff4d447d6549d8ba9e803d0d9cd616db5af98ae6751"
+checksum = "05d30b36d87ca14bd04fec54438531e7ef88ee0f28b34d75a37ddc98ac3fa93d"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,13 @@ ruzstd = "0.7"
 lzma-rs = "0.3"
 sevenz-rust = "0.6"
 rkyv = "0.8"
-mimalloc-pprof = "0.9"
+# 0.9.3 is the floor, not a preference (#1439): earlier releases compile the
+# vendored mimalloc amalgamation with MSVC's deprecated C-mode Interlocked
+# atomics wrapper, whose `_acq`/`_rel` ARM64 intrinsics clang-cl does not
+# declare, so the cargo-xwin `aarch64-pc-windows-msvc` release lane cannot
+# build them. 0.9.3 selects clang's C11 `stdatomic` for that target inside its
+# own build script -- the only package-scoped place the choice can be made.
+mimalloc-pprof = "0.9.3"
 running-process = { version = "4.10.5", default-features = false, features = ["client-async"] }
 zccache = { path = "crates/zccache" }
 zccache-artifact = { path = "crates/zccache-artifact" }

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import tarfile
 import zipfile
 from pathlib import Path
@@ -284,11 +285,40 @@ def test_linux_cross_build_repairs_debug_sidecars_missing_from_cache_hits() -> N
     assert 'test -e "$TARGET_DIR/zccache-fp.dwp"' in action
 
 
-def test_xwin_arm64_compiles_mimalloc_c_as_recommended_cxx() -> None:
+def test_xwin_arm64_lane_injects_no_global_cxx_language_mode() -> None:
+    """zccache#1439: `CFLAGS` reaches every `cc-rs` build script.
+
+    A global `-TP`/`/TP` compiles `ring`'s C sources as C++, which fails with
+    `void *` initialisation and `-Wc++11-narrowing` errors and stops the
+    release before publication. Windows ARM64 uses the system allocator.
+    """
     action = _repo_text(".github/actions/build-target/action.yml")
 
-    assert 'echo "CFLAGS=-TP" >> "$GITHUB_ENV"' in action
-    assert "CFLAGS_aarch64_pc_windows_msvc=-TP" not in action
+    assert "-TP" not in action
+    assert "/TP" not in action
+    assert "Configure xwin ARM64 C compatibility" not in action
+
+
+def test_locked_mimalloc_pprof_selects_arm64_c11_atomics() -> None:
+    """zccache#1439: mimalloc's MSVC C-mode atomics wrapper calls Interlocked
+    intrinsics that clang-cl does not declare for ARM64.
+
+    mimalloc-pprof 0.9.3 selects clang's C11 `stdatomic` for that target in
+    its own build script, which is the only package-scoped place the choice
+    can be made. Anything older forces the consumer back to a global
+    `CFLAGS=-TP`, which breaks every other `cc-rs` dependency.
+    """
+    lockfile = _repo_text("Cargo.lock")
+    locked = re.search(
+        r'\[\[package\]\]\nname = "mimalloc-pprof"\nversion = "([^"]+)"', lockfile
+    )
+
+    assert locked is not None, "mimalloc-pprof missing from Cargo.lock"
+    major, minor, patch = (int(part) for part in locked.group(1).split(".")[:3])
+    assert (major, minor, patch) >= (0, 9, 3), (
+        f"mimalloc-pprof {locked.group(1)} predates the ARM64 C11-atomics fix; "
+        "aarch64-pc-windows-msvc cannot cross-compile against it"
+    )
 
 
 def test_release_workflow_dry_run_builds_without_publishing() -> None:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -930,3 +930,54 @@ Issue: https://github.com/zackees/zccache/issues/1433
   where the already-derived 32-byte key stores its opaque result bytes.
 - Failure policy: daemon/protocol/store failures surface to Python and never
   invoke an uncached fallback behind the caller's back.
+
+# #1439 stop ARM64 xwin C++ mode from breaking ring
+
+- [x] Reproduce RED: auto-release run 32446557448 fails in `ring` with
+  `void *` init and `-Wc++11-narrowing` errors caused by global `CFLAGS=-TP`.
+- [x] Root-cause: the language mode can only be chosen package-scoped, inside
+  `mimalloc-pprof`'s own build script. `CFLAGS` reaches every `cc-rs` build
+  script, so no consumer-side flag can fix this without breaking `ring`.
+- [x] Confirm upstream already fixed it: zackees/mimalloc-pprof#224 selects
+  clang's C11 `stdatomic` for `aarch64-pc-windows-msvc` and bumped to 0.9.3 --
+  but 0.9.3 was never tagged, so crates.io still tops out at 0.9.2.
+- [x] Drop the global `-TP` injection from the xwin ARM64 lane.
+- [x] Raise the workspace `mimalloc-pprof` floor to 0.9.3.
+- [x] Add contract tests: no global `/TP`/`-TP` in the action, and a locked
+  `mimalloc-pprof` >= 0.9.3.
+- [x] Upstream docs PR zackees/mimalloc-pprof#228 records the cross-compilation
+  contract in both READMEs.
+- [x] Merge #228, tag `v0.9.3`, and let auto-release publish to crates.io.
+- [ ] `cargo update -p mimalloc-pprof` here, run validation, open/merge the
+  zccache PR, close #1439, resync `main`.
+
+## Review
+
+The `-TP` in the ARM64 xwin lane was never the fix -- it was a consumer trying
+to make a package-scoped decision with a process-global lever. `CFLAGS` is
+read by every `cc-rs` build script in the graph, so forcing mimalloc's C++
+atomics path also compiled `ring`'s C sources as C++ (`void *` initialisation
+errors, `-Wc++11-narrowing`) and stopped the 1.13.6 release before it
+published anything.
+
+The choice belongs in the crate that owns the source. zackees/mimalloc-pprof
+had already made it (#224: select clang's C11 `stdatomic` for
+`aarch64-pc-windows-msvc`, released as 0.9.3 in the changelog) -- but `v0.9.3`
+was never tagged, so crates.io topped out at 0.9.2 and no downstream lockfile
+could reach the fix. Tagging it was the actual unblock.
+
+Landed here:
+
+- deleted the `Configure xwin ARM64 C compatibility` step, so no global
+  language-mode flag reaches any `cc-rs` dependency
+- raised the workspace `mimalloc-pprof` floor to `0.9.3` and relocked
+- two contract tests: the action carries no `/TP`/`-TP` and declares no such
+  step; the locked `mimalloc-pprof` is >= 0.9.3
+
+mimalloc stays the global allocator on every shipped target, Windows ARM64
+included. Upstream `build (aarch64-pc-windows-msvc)` passed on #228, which is
+the direct evidence that 0.9.3 cross-compiles for that target.
+
+Upstream follow-through: #227 (my duplicate) closed against #223; #228 merged,
+documenting the cross-compilation contract and why `CFLAGS=-TP` is the wrong
+lever, in both the crate and repo READMEs.


### PR DESCRIPTION
## Summary

The 1.13.6 auto-release died deterministically in the `aarch64-pc-windows-msvc` lane ([run 32446557448](https://github.com/zackees/zccache/actions/runs/32446557448/job/96667840012)). #1415 added `CFLAGS=-TP` there so mimalloc would take its C++/`std::atomic` path — but `CFLAGS` is read by **every** `cc-rs` build script in the graph, so it also compiled `ring`'s C sources as C++:

```
internal.h(264,21): error: cannot initialize a variable of type 'aliasing_uint8_t *' with an lvalue of type 'void *'
curve25519.c(747,8): error: non-constant-expression cannot be narrowed from 'crypto_word_t' to 'uint8_t' [-Wc++11-narrowing]
```

The release stopped before publishing wheels, crates, or the GitHub release.

## Root cause

A consumer cannot scope a language mode — `CFLAGS` has no package granularity. The choice belongs to the crate that owns the source, and `mimalloc-pprof` had already made it: [#224](https://github.com/zackees/mimalloc-pprof/pull/224) selects clang's C11 `stdatomic` for `aarch64-pc-windows-msvc` inside its own `build.rs`, because mimalloc's plain-C MSVC fallback uses `Interlocked` `_acq`/`_rel` ARM64 intrinsics that `clang-cl` does not declare.

That shipped as **0.9.3** in the upstream changelog but **was never tagged**, so crates.io topped out at 0.9.2 and no downstream lockfile could reach the fix. Tagging `v0.9.3` was the actual unblock.

## Changes

- delete the `Configure xwin ARM64 C compatibility` step — no global language flag reaches any `cc-rs` dependency
- raise the workspace `mimalloc-pprof` floor to `0.9.3` and relock (0.9.2 → 0.9.3)
- two contract tests in `ci/tests/test_package_release.py`:
  - `test_xwin_arm64_lane_injects_no_global_cxx_language_mode` — the action carries no `/TP`/`-TP` and declares no such step
  - `test_locked_mimalloc_pprof_selects_arm64_c11_atomics` — locked `mimalloc-pprof` >= 0.9.3

mimalloc stays the global allocator on **every** shipped target, Windows ARM64 included. No target loses its allocator and no other lane's build configuration or artifact shape changes.

## Validation

- `uv run --no-project --with pytest python -m pytest ci/tests/test_package_release.py -q` — 28 passed (both new tests RED before the fix: `-TP` present, locked 0.9.2)
- `soldr cargo check --workspace --all-targets` — clean, exit 0
- edited YAML parses (`action.yml`, `release-auto.yml`, `build.yml`)
- upstream `build (aarch64-pc-windows-msvc)` passes on 0.9.3 (mimalloc-pprof#228) — direct evidence the target cross-compiles

## Upstream follow-through

- zackees/mimalloc-pprof#228 (merged) documents the cross-compilation contract in both READMEs, including why `CFLAGS=-TP` is the wrong lever
- `v0.9.3` tagged and published to crates.io

Closes #1439

🤖 Generated with [Claude Code](https://claude.com/claude-code)