### PR TITLE
fix(release): stop musllinux smoke legs from blocking every release (#1441)

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -490,7 +490,13 @@ jobs:
           if-no-files-found: error
 
   test-wheels:
-    name: Test PyPI Wheel (${{ matrix.os }})
+    # One leg per wheel family actually produced by `build-wheels`, keyed by
+    # the platform tag so the coverage invariant is mechanical. A leg for a
+    # family that is not built can never pass: `pip --no-index --find-links`
+    # finds no candidate, so the whole release is blocked before publish.
+    # Keep this list in lockstep with `PLATFORMS` in `ci/release_workflow.py`
+    # -- `test_release_workflow.py` enforces set equality.
+    name: Test PyPI Wheel (${{ matrix.wheel_plat }})
     runs-on: ${{ matrix.os }}
     needs: [preflight, build-wheels]
     if: needs.preflight.outputs.pypi_complete != 'true'
@@ -499,23 +505,17 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            label: linux-x86_64
+            wheel_plat: manylinux_2_17_x86_64
           - os: ubuntu-24.04-arm
-            label: linux-aarch64
+            wheel_plat: manylinux_2_17_aarch64
           - os: macos-15-intel
-            label: macos-x86_64
+            wheel_plat: macosx_10_12_x86_64
           - os: macos-14
-            label: macos-aarch64
+            wheel_plat: macosx_11_0_arm64
           - os: windows-latest
-            label: windows-x86_64
+            wheel_plat: win_amd64
           - os: windows-11-arm
-            label: windows-aarch64
-          - os: ubuntu-latest
-            label: linux-musl-x86_64
-            alpine: true
-          - os: ubuntu-24.04-arm
-            label: linux-musl-aarch64
-            alpine: true
+            wheel_plat: win_arm64
     steps:
       - uses: actions/checkout@v6
         with:
@@ -531,20 +531,9 @@ jobs:
           path: dist/wheels
 
       - name: Install and test the platform wheel
-        if: matrix.alpine != true
         run: |
           python -m pip install --disable-pip-version-check --no-index --find-links dist/wheels "zccache==${{ needs.preflight.outputs.version }}"
           python ci/test_exec_cached_wheel.py
-
-      - name: Install and test the musllinux wheel
-        if: matrix.alpine == true
-        shell: bash
-        run: |
-          docker run --rm \
-            --volume "$GITHUB_WORKSPACE:/workspace" \
-            --workdir /workspace \
-            python:3.13-alpine \
-            sh -ec 'python -m pip install --disable-pip-version-check --no-index --find-links dist/wheels "zccache==${{ needs.preflight.outputs.version }}" && python ci/test_exec_cached_wheel.py'
 
   publish-pypi:
     name: Publish PyPI

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -210,6 +210,14 @@ def test_release_workflow_uses_bootstrap_zccache_for_cross_builds() -> None:
 
 
 def test_release_tests_exec_cached_in_every_native_wheel_family() -> None:
+    """Every shipped wheel family runs the exec_cached smoke on real hardware.
+
+    Which families exist is asserted against `ci/release_workflow.PLATFORMS`
+    by `test_release_workflow.py`; this test owns the runner-OS coverage and
+    the publish gating. musllinux is deliberately absent: `build-wheels` does
+    not produce one (the musl build legs set `include_python: "false"`), so an
+    alpine smoke leg could only ever fail and block the release.
+    """
     workflow = _repo_text(".github/workflows/release-auto.yml")
 
     assert "test-wheels:" in workflow
@@ -222,10 +230,9 @@ def test_release_tests_exec_cached_in_every_native_wheel_family() -> None:
         "windows-11-arm",
     ):
         assert f"- os: {platform}" in workflow
-    assert "label: linux-musl-x86_64" in workflow
-    assert "label: linux-musl-aarch64" in workflow
     assert "python ci/test_exec_cached_wheel.py" in workflow
-    assert "python:3.13-alpine" in workflow
+    assert "musllinux" not in workflow
+    assert "alpine" not in workflow
     assert "needs: [preflight, publish-release, build-wheels, test-wheels]" in workflow
     assert "needs.test-wheels.result == 'success'" in workflow
 

--- a/ci/tests/test_release_workflow.py
+++ b/ci/tests/test_release_workflow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import csv
 import io
 import os
+import re
 import zipfile
 from pathlib import Path
 
@@ -155,4 +156,55 @@ def test_command_check_registries_writes_registry_completion_outputs(
     assert output_path.read_text(encoding="utf-8") == (
         "pypi_complete=true\n"
         "crates_complete=true\n"
+    )
+
+
+def _release_workflow_job(job: str) -> str:
+    """Return the YAML text of one top-level job in `release-auto.yml`.
+
+    Text slicing rather than PyYAML: the repo does not carry a YAML runtime
+    dependency for CI tests, and the surrounding tests parse workflows the
+    same way.
+    """
+    path = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "release-auto.yml"
+    text = path.read_text(encoding="utf-8")
+    marker = f"\n  {job}:\n"
+    start = text.index(marker) + 1
+    match = re.search(r"\n  [a-z][a-z0-9-]*:\n", text[start + 1 :])
+    end = len(text) if match is None else start + 1 + match.start()
+    return text[start:end]
+
+
+def test_wheel_smoke_matrix_covers_exactly_the_built_wheel_families() -> None:
+    """Every smoke leg must name a wheel family `build-wheels` produces.
+
+    A leg for an unbuilt family (once: musllinux) can never pass, because
+    `pip --no-index --find-links dist/wheels` finds no candidate. That failure
+    is not cosmetic: `publish-pypi` needs `test-wheels`, so a stray leg blocks
+    every release. A missing leg is the opposite hole -- a family ships to
+    PyPI without ever being installed.
+    """
+    smoke_tags = set(
+        re.findall(r"^\s+wheel_plat:\s*(\S+)$", _release_workflow_job("test-wheels"), re.M)
+    )
+    built_tags = {
+        ".".join(plat_tags) for plat_tags in release_workflow.PLATFORMS.values()
+    }
+
+    assert smoke_tags == built_tags, (
+        "release-auto.yml test-wheels matrix drifted from "
+        f"ci/release_workflow.py PLATFORMS: unbuilt legs {sorted(smoke_tags - built_tags)}, "
+        f"untested wheels {sorted(built_tags - smoke_tags)}"
+    )
+
+
+def test_wheel_smoke_matrix_has_one_leg_per_wheel() -> None:
+    """No duplicate legs: a repeated family hides a missing one behind a
+    passing job name, which is how the musllinux legs stayed unnoticed."""
+    smoke_tags = re.findall(
+        r"^\s+wheel_plat:\s*(\S+)$", _release_workflow_job("test-wheels"), re.M
+    )
+
+    assert len(smoke_tags) == len(set(smoke_tags)), (
+        f"duplicate wheel_plat legs in release-auto.yml test-wheels: {sorted(smoke_tags)}"
     )


### PR DESCRIPTION
Closes #1441

## Problem

`Auto-Release` has been red on `main` since #1436 (`d8068fd8`), and it fails at the one gate that matters: `publish-pypi` and `publish-crates` both `needs: test-wheels`, so **no release can ship**. Run [32503446486](https://github.com/zackees/zccache/actions/runs/32503446486) on `d5e0c1cb`: every build job green, `Publish GitHub Release` green, `Build PyPI Wheels` green — then two red smoke legs and two skipped publish jobs.

```
Looking in links: dist/wheels
ERROR: Could not find a version that satisfies the requirement zccache==1.13.6 (from versions: none)
```

## Root cause

#1436 added two `alpine: true` legs to `test-wheels` that install the wheel inside `python:3.13-alpine`. zccache builds **no musllinux wheel**:

- `PLATFORMS` (`ci/release_workflow.py:49-56`) has six entries — manylinux ×2, macosx ×2, win ×2.
- `ARTIFACT_MAP` has no musl artifact.
- The musl build legs set `include_python: "false"` / `upload_binaries: "false"` — release tarballs only, never wheel inputs.
- PyPI agrees: `zccache 1.13.5` ships exactly those six wheels.

Inside alpine, `pip --no-index --find-links dist/wheels` sees no compatible tag.

Two things hid it: the job name was `${{ matrix.os }}`, so each run showed `Test PyPI Wheel (ubuntu-latest)` **twice**, once green once red; and `test_release_tests_exec_cached_in_every_native_wheel_family` asserted `label: linux-musl-x86_64` and `python:3.13-alpine` were *present*, so the suite pinned the broken state.

## Change

- Key each `test-wheels` leg by `wheel_plat` (the platform tag) instead of an unused `label`, and put it in the job name so legs are distinguishable.
- Drop the two alpine legs and the dead musllinux step (and the now-vacuous `if: matrix.alpine != true`).
- New `test_wheel_smoke_matrix_covers_exactly_the_built_wheel_families` — set equality between the legs and `ci/release_workflow.PLATFORMS`, failing on drift in **either** direction (an unbuilt leg blocks the release; a missing leg ships an untested wheel).
- New `test_wheel_smoke_matrix_has_one_leg_per_wheel` — catches the duplicate-name shadowing directly.
- `test_release_tests_exec_cached_in_every_native_wheel_family` now owns runner-OS coverage and publish gating, and records why musllinux is absent.

Text slicing rather than PyYAML, matching how the surrounding CI tests parse workflows — the repo carries no YAML runtime dep for them.

## Out of scope

Shipping musllinux wheels is a separate decision, not a fix for a red pipeline: it needs `include_python: "true"` on the musl build legs (PyO3 natives cross-built against musl via zigbuild) plus `ARTIFACT_MAP` / `PLATFORMS` / `REQUIRED_*` entries. `ci/build_dist.py:26-33` already carries `musllinux_1_2_*` tags for the separate `build.yml` path if we ever want it.

## Validation

RED proof — re-added a `musllinux_1_2_x86_64` leg on top of the fix:

```
E         Extra items in the left set:
E         'musllinux_1_2_x86_64'
FAILED ci/tests/test_release_workflow.py::test_wheel_smoke_matrix_covers_exactly_the_built_wheel_families
1 failed, 1 passed
```

GREEN — full CI suite:

```
PYTHONPATH=. uv run --frozen pytest ci/tests -q
361 passed, 2 skipped, 2 failed
```

The two failures (`test_incremental_build.py::test_repository_compile_boundary_does_not_add_glob_imports`, `test_perf_rust_cluster_embedded.py::test_rollout_fixture_archives_pin_the_runner_toolchain` — expects `rust:1.94.1`, tree pins `1.95.0`) are pre-existing on `main`; confirmed identical on a stashed tree.

YAML re-parsed after the edit:

```
legs: ['manylinux_2_17_x86_64', 'manylinux_2_17_aarch64', 'macosx_10_12_x86_64',
       'macosx_11_0_arm64', 'win_amd64', 'win_arm64']
steps: [checkout, setup-python, download-artifact, 'Install and test the platform wheel']
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
