### PR TITLE
fix(hooks): stop boolean uv flags from defeating tool_guard (#1443)

### DIFF
--- a/ci/hooks/tool_guard.py
+++ b/ci/hooks/tool_guard.py
@@ -25,49 +25,122 @@ RUST_TOOLS = {
 PYTHON_TOOLS = {"python", "python3", "pip", "pip3"}
 LEGACY_RUST_TRAMPOLINES = {"_cargo", "_rustc", "_rustfmt"}
 SHELL_WRAPPERS = {"cmd", "powershell", "pwsh", "bash", "sh", "zsh"}
+# `uv run` option arity, transcribed from `uv help run`.
+#
+# Arity is load-bearing, not cosmetic. `_resolve_uv_run_tool` skips two words
+# for a value-taking option and one for a boolean; misfiling a boolean as
+# value-taking makes it swallow the very word it was supposed to inspect, so
+# `uv run --frozen cargo build` resolves its "tool" to `build` and sails past
+# the soldr gate. Misfiling the other way is milder but still wrong: the
+# option's value is mistaken for the tool.
+#
+# Both sets are asserted against the guard's own behaviour by
+# `test_no_uv_run_option_prefix_hides_a_rust_tool`, so a wrong entry here
+# fails the suite rather than silently opening a hole.
+
+# Options that consume the following word.
 UV_RUN_OPTIONS_WITH_VALUE = {
-    "--active",
+    "--allow-insecure-host",
+    "--cache-dir",
+    "--color",
     "--config-file",
+    "--config-setting",
+    "--config-settings-package",
+    "--default-index",
     "--directory",
     "--env-file",
     "--exclude-newer",
+    "--exclude-newer-package",
     "--extra",
-    "--frozen",
+    "--extra-index-url",
+    "--find-links",
+    "--fork-strategy",
+    "--group",
     "--index",
     "--index-strategy",
-    "--isolated",
+    "--index-url",
     "--keyring-provider",
     "--link-mode",
+    "--no-binary-package",
+    "--no-build-isolation-package",
+    "--no-build-package",
+    "--no-editable-package",
+    "--no-extra",
+    "--no-group",
+    "--no-sources-package",
+    "--only-group",
+    "--package",
+    "--prerelease",
+    "--prerelease-package",
+    "--project",
+    "--python",
+    "--python-platform",
+    "--refresh-package",
+    "--reinstall-package",
+    "--resolution",
+    "--upgrade-group",
+    "--upgrade-package",
+    "--with",
+    "--with-editable",
+    "--with-requirements",
+    "-C",
+    "-P",
+    "-f",
+    "-i",
+    "-p",
+    "-w",
+}
+
+# Options that stand alone. Listed rather than inferred so the
+# arity test can prove neither kind hides the tool. `--module`/`-m` and
+# `--script`/`-s` belong here: the word after them is the module or script
+# being run, i.e. exactly the token the guard must look at.
+UV_RUN_BOOLEAN_OPTIONS = {
+    "--active",
+    "--all-extras",
+    "--all-groups",
+    "--all-packages",
+    "--compile-bytecode",
+    "--exact",
+    "--frozen",
+    "--gui-script",
+    "--help",
+    "--isolated",
+    "--locked",
     "--managed-python",
     "--module",
     "--no-binary",
-    "--no-binary-package",
     "--no-build",
-    "--no-build-isolation-package",
-    "--no-build-package",
+    "--no-build-isolation",
     "--no-cache",
     "--no-config",
     "--no-default-groups",
     "--no-dev",
     "--no-editable",
-    "--no-extra",
-    "--no-group",
+    "--no-env-file",
     "--no-index",
     "--no-managed-python",
+    "--no-progress",
     "--no-project",
     "--no-python-downloads",
+    "--no-sources",
+    "--no-sync",
+    "--offline",
     "--only-dev",
-    "--only-group",
-    "--project",
-    "--python",
-    "--python-platform",
-    "--refresh-package",
-    "--resolution",
+    "--quiet",
+    "--refresh",
+    "--reinstall",
     "--script",
-    "--upgrade-package",
-    "--with",
-    "--with-editable",
-    "--with-requirements",
+    "--system-certs",
+    "--upgrade",
+    "--verbose",
+    "-U",
+    "-h",
+    "-m",
+    "-n",
+    "-q",
+    "-s",
+    "-v",
 }
 
 # Path-shape: any path component named `bench`, `test`, or `tests` followed

--- a/ci/tests/test_tool_guard.py
+++ b/ci/tests/test_tool_guard.py
@@ -320,3 +320,70 @@ def test_uv_run_python_with_no_test_path_passes():
     """`uv run python ci/build_dist.py` — Python via uv on a non-test
     file (CI script), allowed."""
     assert _check("uv run python ci/build_dist.py") is None
+
+
+# ── uv run option arity ────────────────────────────────────────────────────
+#
+# `_resolve_uv_run_tool` skips two words for a value-taking option and one
+# for a boolean. A boolean filed as value-taking swallows the word after it
+# — which is the tool the guard exists to inspect.
+
+
+def test_uv_run_boolean_flag_does_not_hide_cargo():
+    """`uv run --frozen cargo build` — the flag is boolean, so `cargo` is
+    still the tool and the soldr gate must fire. It did not: `--frozen` was
+    filed as value-taking, so the resolver skipped past `cargo` to `build`
+    and returned no violation."""
+    result = _check("uv run --frozen cargo build")
+    assert result is not None
+    assert result[0] == "cargo"
+
+
+def test_uv_run_short_python_flag_does_not_hide_cargo():
+    """`uv run -p 3.13 cargo build` — short options were not in the arity
+    table at all, so `-p` fell through and `3.13` was resolved as the tool."""
+    result = _check("uv run -p 3.13 cargo build")
+    assert result is not None
+    assert result[0] == "cargo"
+
+
+def test_no_uv_run_option_prefix_hides_a_rust_tool():
+    """The invariant both arity sets exist to hold: no combination of a
+    single `uv run` option and its value may stop the guard from seeing the
+    tool behind it. Iterating the sets means a future mis-filed option fails
+    here instead of silently opening a bypass."""
+    hidden = []
+    for opt in sorted(tool_guard.UV_RUN_BOOLEAN_OPTIONS):
+        if _check(f"uv run {opt} cargo build") is None:
+            hidden.append(opt)
+    for opt in sorted(tool_guard.UV_RUN_OPTIONS_WITH_VALUE):
+        if _check(f"uv run {opt} VALUE cargo build") is None:
+            hidden.append(opt)
+        if _check(f"uv run {opt}=VALUE cargo build") is None:
+            hidden.append(f"{opt}=VALUE")
+
+    assert hidden == [], f"uv run options that hide a rust tool: {hidden}"
+
+
+def test_uv_run_option_arity_sets_are_disjoint():
+    """An option in both sets means one of the two entries is wrong; the
+    value-taking branch wins, so the boolean listing would be a lie."""
+    overlap = tool_guard.UV_RUN_BOOLEAN_OPTIONS & tool_guard.UV_RUN_OPTIONS_WITH_VALUE
+    assert overlap == set(), f"options listed with both arities: {sorted(overlap)}"
+
+
+def test_uv_run_pytest_with_sync_flags_passes():
+    """The hybrid-project gate requires one of `--frozen` / `--no-sync` /
+    `--no-project` on every `uv run`, so these are the forms actually used
+    to run the repo's own CI suite. All three were blocked with the
+    Python-in-tests message before the arity fix."""
+    for flag in ("--frozen", "--no-sync", "--no-project"):
+        assert _check(f"uv run {flag} pytest ci/tests/test_tool_guard.py") is None
+
+
+def test_uv_run_module_flag_still_sees_python():
+    """`-m`/`--module` is boolean and the word after it is the module being
+    run, so the guard must still resolve `python`-shaped invocations."""
+    result = _check("uv run --frozen python -m pytest tests/foo.py")
+    assert result is not None
+    assert result[0] == "python"


### PR DESCRIPTION
Closes #1443

## Problem

`ci/hooks/tool_guard.py` exists to force Rust commands through `soldr`. One `uv run` flag turned it off:

| command | before | after |
|---|---|---|
| `uv run cargo build` | BLOCKED | BLOCKED |
| `uv run --frozen cargo build` | **ALLOWED** | BLOCKED |
| `uv run --no-project cargo build` | **ALLOWED** | BLOCKED |
| `uv run -p 3.13 cargo build` | **ALLOWED** | BLOCKED |

These are not obscure flags. The repo's own hybrid-project gate refuses a bare `uv run` and tells the caller to pass exactly `--no-project`, `--no-sync`, or `--frozen` — so the flags that disabled the soldr guard were the flags every caller is instructed to use. `--no-sync` happened to be safe; the other two were not.

## Root cause

`_resolve_uv_run_tool` skips **two** words for a value-taking option and one for a boolean. 18 booleans were filed as value-taking, so the resolver swallowed the word after them — the tool it exists to inspect. `--frozen cargo build` resolved down to `build`, which matches nothing, so no violation was reported.

Short options were absent from the table entirely (`-p`, `-w`, `-f`, `-i`, `-C`, `-P`), so `-p 3.13 cargo build` resolved its tool as `3.13`. In the other direction ~20 genuinely value-taking options were missing (`--group`, `--package`, `--prerelease`, `--find-links`, `--cache-dir`, ...), mis-resolving an option's value as the tool.

## Second symptom

`ci/tests/README.md` documents running pytest over `ci/tests` through uv, and `test_uv_run_pytest_against_tests_dir_passes` pins that it is allowed. Add the sync flag the *other* gate mandates and the resolver landed on the test path, hit the `--script` branch, and rejected it as a forbidden Python test file:

```
uv run pytest ci/tests/test_x.py            -> allowed  (pinned by an existing test)
uv run --frozen pytest ci/tests/test_x.py   -> BLOCKED
```

No spelling satisfied both gates. The existing test passes only because it omits the flag. All three sync flags now work.

## Change

- Both arities transcribed from `uv help run` into named sets: a corrected `UV_RUN_OPTIONS_WITH_VALUE` and a new explicit `UV_RUN_BOOLEAN_OPTIONS`, short forms included.
- `test_no_uv_run_option_prefix_hides_a_rust_tool` walks **both** sets and asserts every option prefix — with and without `=value` — still leaves the guard looking at the tool behind it. A future mis-filed option fails there instead of quietly opening a bypass.
- `test_uv_run_option_arity_sets_are_disjoint` catches an option listed under both arities.
- Named regressions for the `--frozen` and `-p 3.13` bypasses, for pytest under all three sync flags, and for `-m` still resolving `python`.

`python`, `--script`, and `-m` behaviour is unchanged: `--module` and `--script` are boolean, and the word after them is the module or script being run — precisely the token the guard must see.

## Validation

RED proof — restored `--frozen` to the value-taking set on top of the fix:

```
FAILED test_uv_run_boolean_flag_does_not_hide_cargo
FAILED test_no_uv_run_option_prefix_hides_a_rust_tool
FAILED test_uv_run_option_arity_sets_are_disjoint
FAILED test_uv_run_pytest_with_sync_flags_passes
FAILED test_uv_run_module_flag_still_sees_python
5 failed, 43 passed
```

GREEN:

```
PYTHONPATH=. uv run --frozen pytest ci/tests -q
366 passed, 2 skipped, 3 failed
```

The three failures are pre-existing and unrelated — `test_incremental_build::test_repository_compile_boundary_does_not_add_glob_imports`, `test_perf_rust_cluster_embedded::test_rollout_fixture_archives_pin_the_runner_toolchain` (expects `rust:1.94.1`, tree pins `1.95.0`), and a flaky `test_perf_watchdog::test_timeout_captures_summary_and_terminates_child` (passed on an earlier run of the same tree). All three confirmed on a stashed tree.

Stacked alongside #1442; the two touch disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
