### PR TITLE
ci(perf): show every attempt ratio when a perf floor fails (#1445)

### DIFF
--- a/ci/perf_guard.py
+++ b/ci/perf_guard.py
@@ -590,14 +590,33 @@ def _format_status_check(report: GuardReport, status: ScenarioStatus) -> str:
     )
 
 
+def format_attempt_spread(status: ScenarioStatus) -> str:
+    """Ratios for every retained attempt, in attempt order.
+
+    Empty when there is nothing to compare -- fewer than two samples means
+    there is no spread to report and the caller should say nothing.
+
+    A single "actual 0.849x" cannot distinguish a regression from run-to-run
+    variance, so reading the failure meant downloading the job log and
+    diffing against neighbouring commits (#1445). The distribution is already
+    retained on `status.samples` (#1115); this only renders it.
+    """
+    if len(status.samples) < 2:
+        return ""
+    ordered = sorted(status.samples, key=lambda sample: sample.attempt)
+    return ", ".join(f"{sample.ratio:.3f}x" for sample in ordered)
+
+
 def _format_status_summary_line(report: GuardReport, status: ScenarioStatus) -> str:
     sample = _selected_sample(report, status)
     attempt = "n/a" if sample is None else str(sample.attempt)
     state = "PASS" if report.status_passed(status) else "FAIL"
     attempt_label = "worst" if report.require_all_attempts else "best"
+    spread = format_attempt_spread(status)
+    spread_note = f"; ratios {spread}" if spread else ""
     return (
         f"- {state}: {_format_status_check(report, status)} "
-        f"({attempt_label} attempt {attempt}; seen {status.attempts_seen})"
+        f"({attempt_label} attempt {attempt}; seen {status.attempts_seen}{spread_note})"
     )
 
 
@@ -683,9 +702,11 @@ def format_final_status(report: GuardReport) -> str:
             ),
         )
         count = len(failed_statuses)
+        spread = format_attempt_spread(worst)
+        spread_note = f" Attempt ratios: {spread}." if spread else ""
         return (
             f"PERF GUARD FAILED: {count} check{'s' if count != 1 else ''} "
-            f"below floor; worst {_format_status_check(report, worst)}."
+            f"below floor; worst {_format_status_check(report, worst)}.{spread_note}"
         )
 
     if report.missing_requirements:

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -1081,3 +1081,61 @@ def test_benchmark_env_enables_cc_profile_for_cc_languages(tmp_path):
 def test_benchmark_env_does_not_enable_cc_profile_for_rust(tmp_path):
     env = perf_guard._benchmark_env(tmp_path, "rust")
     assert "ZCCACHE_PROFILE_CC_MISS" not in env
+
+
+# ── attempt spread in failure output (#1445) ───────────────────────────────
+#
+# A lone "actual 0.849x" cannot distinguish a regression from run-to-run
+# variance. The distribution is already retained (#1115); these pin that it
+# reaches the line a reader actually sees.
+
+SLOWER_SCCACHE_LOG = PASSING_LOG.replace(
+    "| Single-file, Warm | 3.000s | 2.000s | **1.000s** | **2.0x faster** | **3.0x faster** |",
+    "| Single-file, Warm | 3.000s | 1.100s | **1.000s** | **1.1x faster** | **3.0x faster** |",
+)
+
+
+def test_failure_line_reports_every_attempt_ratio():
+    report = perf_guard.evaluate_attempts(
+        [rows(FAILING_SCCACHE_LOG), rows(SLOWER_SCCACHE_LOG)],
+        threshold=1.5,
+    )
+
+    final_status = perf_guard.format_final_status(report)
+
+    assert "Attempt ratios: 1.200x, 1.100x" in final_status, final_status
+
+
+def test_summary_line_reports_every_attempt_ratio():
+    report = perf_guard.evaluate_attempts(
+        [rows(FAILING_SCCACHE_LOG), rows(SLOWER_SCCACHE_LOG)],
+        threshold=1.5,
+    )
+    failed = [s for s in report.statuses if not report.status_passed(s)]
+
+    line = perf_guard._format_status_summary_line(report, failed[0])
+
+    assert "ratios 1.200x, 1.100x" in line, line
+
+
+def test_single_attempt_reports_no_spread():
+    """One sample has no spread to report, so the line stays as it was --
+    which is why the pre-existing message assertions still hold."""
+    report = perf_guard.evaluate_attempts([rows(FAILING_SCCACHE_LOG)], threshold=1.5)
+
+    final_status = perf_guard.format_final_status(report)
+
+    assert "Attempt ratios" not in final_status
+    assert final_status.endswith("(zccache 1.000s vs baseline 1.200s).")
+
+
+def test_attempt_spread_is_ordered_by_attempt_not_by_ratio():
+    """Attempt order is the informative order: it shows drift across a run.
+    Sorting by ratio would hide which attempt was which."""
+    report = perf_guard.evaluate_attempts(
+        [rows(SLOWER_SCCACHE_LOG), rows(FAILING_SCCACHE_LOG)],
+        threshold=1.5,
+    )
+    failed = [s for s in report.statuses if not report.status_passed(s)]
+
+    assert perf_guard.format_attempt_spread(failed[0]) == "1.100x, 1.200x"


### PR DESCRIPTION
Addresses one acceptance criterion of #1445 — **does not close it**.

## Problem

Perf Guard has been red on every `main` run for days, and reading a failure takes four log downloads to answer one question: regression, or spread? The error line reports a point estimate:

```
PERF GUARD FAILED: 1 check below floor; worst c++ C++ response files /
Single-file RSP, Cold vs Bare clang: expected >= 0.85x, actual 0.849x
```

0.849x against a 0.85x floor is 0.1% under — exactly the case where the distribution decides the answer and a single number cannot.

## Change

The distribution is **already retained** — #1115 put every attempt on `status.samples`; nothing rendered it. So this is a display change, not new measurement.

The failure line and each per-check summary line now carry the ratio from every retained attempt:

```
... actual 0.849x (zccache 7.105s vs baseline 6.030s).
    Attempt ratios: 0.849x, 0.812x, 0.803x
```

**Attempt order, not sorted.** Three ratios sliding downward across a run reads differently from three scattered around the floor, and sorting destroys exactly that signal.

**Nothing renders below two samples**, so single-attempt output is byte-identical and every pre-existing message assertion still holds unchanged — see `test_single_attempt_reports_no_spread`, which pins that explicitly.

## Scope

No threshold is touched. #1437 established that lowering a floor is the wrong lever and the same holds here; this only makes the existing numbers legible enough to decide what the right lever is.

The other #1445 criteria — gating rows only where their baseline duration can resolve the ratio (several are measured at 46–200 ms), and whether the hosted job should block at all — are calibration and policy calls. Those want the owner, not a unilateral change from me, so #1445 stays open.

## Validation

```
PYTHONPATH=. uv run --frozen pytest ci/tests -q
-> 371 passed, 2 skipped, 2 failed
```

The two failures are pre-existing and unrelated (`test_incremental_build::test_repository_compile_boundary_does_not_add_glob_imports`, `test_perf_rust_cluster_embedded::test_rollout_fixture_archives_pin_the_runner_toolchain` — expects `rust:1.94.1`, tree pins `1.95.0`); both confirmed on a stashed tree.

RED proof — reverting `ci/perf_guard.py` while keeping the tests:

```
FAILED test_failure_line_reports_every_attempt_ratio
FAILED test_summary_line_reports_every_attempt_ratio
FAILED test_attempt_spread_is_ordered_by_attempt_not_by_ratio
3 failed, 1 passed
```

(The fourth passes either way — it asserts the *unchanged* single-attempt format, which is the point of it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
