### PR TITLE
ci(perf): report the wall-clock margin a failed floor missed by (#1445)

### DIFF
--- a/ci/perf_guard.py
+++ b/ci/perf_guard.py
@@ -590,6 +590,30 @@ def _format_status_check(report: GuardReport, status: ScenarioStatus) -> str:
     )
 
 
+def format_floor_margin(status: ScenarioStatus, sample: ScenarioSample | None) -> str:
+    """How much faster zccache had to be for this check to clear its floor.
+
+    Derived arithmetic on numbers already in the report -- no calibration
+    constant. Ratios here are `baseline / zccache`, so the passing time is
+    `baseline / threshold` and the margin is how far the observed time
+    overshot it.
+
+    The point is to make an unresolvable assertion self-evident. "0.849x vs a
+    0.85x floor" reads like a near miss until you see it is 11ms on a 7s
+    benchmark; a driver-link row failing by 4ms on a 46ms baseline is asking
+    a shared runner to resolve single-digit milliseconds, which is the
+    substance of #1445. Stating the margin lets a reader judge that without
+    picking a resolvability threshold here.
+    """
+    if sample is None or status.threshold <= 0 or sample.baseline_seconds is None:
+        return ""
+    required = sample.baseline_seconds / status.threshold
+    overshoot = sample.zccache_seconds - required
+    if overshoot <= 0:
+        return ""
+    return _format_seconds(overshoot)
+
+
 def format_attempt_spread(status: ScenarioStatus) -> str:
     """Ratios for every retained attempt, in attempt order.
 
@@ -704,9 +728,12 @@ def format_final_status(report: GuardReport) -> str:
         count = len(failed_statuses)
         spread = format_attempt_spread(worst)
         spread_note = f" Attempt ratios: {spread}." if spread else ""
+        margin = format_floor_margin(worst, _selected_sample(report, worst))
+        margin_note = f" Missed the floor by {margin}." if margin else ""
         return (
             f"PERF GUARD FAILED: {count} check{'s' if count != 1 else ''} "
-            f"below floor; worst {_format_status_check(report, worst)}.{spread_note}"
+            f"below floor; worst {_format_status_check(report, worst)}."
+            f"{margin_note}{spread_note}"
         )
 
     if report.missing_requirements:

--- a/ci/tests/test_perf_guard.py
+++ b/ci/tests/test_perf_guard.py
@@ -512,10 +512,12 @@ def test_final_status_explains_worst_failed_floor():
 
     final_status = perf_guard.format_final_status(report)
 
+    # baseline 1.200s at a 1.50x floor needs zccache <= 0.800s; it took
+    # 1.000s, so the miss is 200ms of wall clock rather than "0.3x".
     assert final_status == (
         "PERF GUARD FAILED: 1 check below floor; worst c C inline args / "
         "Single-file, Warm vs sccache: expected >= 1.50x, actual 1.200x "
-        "(zccache 1.000s vs baseline 1.200s)."
+        "(zccache 1.000s vs baseline 1.200s). Missed the floor by 200.0ms."
     )
 
 
@@ -1126,7 +1128,9 @@ def test_single_attempt_reports_no_spread():
     final_status = perf_guard.format_final_status(report)
 
     assert "Attempt ratios" not in final_status
-    assert final_status.endswith("(zccache 1.000s vs baseline 1.200s).")
+    assert final_status.endswith(
+        "(zccache 1.000s vs baseline 1.200s). Missed the floor by 200.0ms."
+    )
 
 
 def test_attempt_spread_is_ordered_by_attempt_not_by_ratio():
@@ -1139,3 +1143,24 @@ def test_attempt_spread_is_ordered_by_attempt_not_by_ratio():
     failed = [s for s in report.statuses if not report.status_passed(s)]
 
     assert perf_guard.format_attempt_spread(failed[0]) == "1.100x, 1.200x"
+
+
+def test_failure_line_reports_absolute_margin_to_the_floor():
+    """A ratio alone hides how small the miss is in wall clock. 0.849x
+    against a 0.85x floor sounds like a near miss; the milliseconds say
+    whether the runner could have resolved it at all (#1445)."""
+    report = perf_guard.evaluate_attempts([rows(FAILING_SCCACHE_LOG)], threshold=1.5)
+
+    assert "Missed the floor by 200.0ms." in perf_guard.format_final_status(report)
+
+
+def test_floor_margin_is_empty_for_a_passing_sample():
+    """No margin to report when the sample already clears its floor."""
+    report = perf_guard.evaluate_attempts([rows(PASSING_LOG)], threshold=1.5)
+    status = report.statuses[0]
+
+    margin = perf_guard.format_floor_margin(
+        status, perf_guard._selected_sample(report, status)
+    )
+
+    assert margin == ""


### PR DESCRIPTION
Addresses one acceptance criterion of #1445 — **does not close it**. Follows #1448.

## The number that makes the case

#1448 made the attempt distribution visible. This makes the *size of the miss* visible, and that turns out to be the more damning number.

A ratio hides magnitude. "0.849x against a 0.85x floor" reads as a near miss until you convert it: the floor wanted zccache ≤ 7.094s, it took 7.105s, so the check failed by **11 milliseconds** on a 7-second benchmark. Running that conversion over the rows actually failing on `main`:

| row | ratio vs floor | missed by |
|---|---|---|
| C++ RSP single-file, cold vs bare | 0.849x vs 0.85 | 10.9ms |
| C++ RSP multi-file, cold vs sccache | 0.897x vs 0.90 | 34.1ms |
| C inline single-file, cold vs bare | 0.796x vs 0.80 | 11.8ms |
| **C++ driver link, cold vs bare** | 0.840x vs 0.85 | **0.9ms** |

The driver-link row failed by **under a millisecond**, and it has been failing on and off for days. No shared runner resolves that. The gate is not reporting a regression there; it is reporting scheduler noise with a ratio in front of it.

## Change

The failure line now carries the margin:

```
... actual 0.849x (zccache 7.105s vs baseline 6.030s).
    Missed the floor by 10.9ms. Attempt ratios: 0.849x, 0.812x, 0.803x
```

Derived arithmetic on numbers already in the report — ratios are `baseline / zccache`, so the passing time is `baseline / threshold` and the margin is the overshoot.

**Deliberately no resolvability constant.** Picking "rows under N ms should not be gated" is exactly the calibration decision #1445 leaves to the owner, and inventing N here would smuggle it in. Stating the margin lets a reader reach that judgement from the run itself.

No threshold is touched, and pass/fail is unchanged — the margin is computed only for a sample that already failed, and renders nothing otherwise (`test_floor_margin_is_empty_for_a_passing_sample`).

## Test changes

Two pinned message assertions move to the new format. The first carries a comment showing the arithmetic, so the expected string is checkable by eye rather than by trust: a 1.200s baseline at a 1.50x floor needs 0.800s, it took 1.000s, so the miss is 200ms.

## Validation

```
PYTHONPATH=. uv run --frozen pytest ci/tests -q
-> 373 passed, 2 skipped, 2 failed
```

The two failures are pre-existing and unrelated (`test_incremental_build::test_repository_compile_boundary_does_not_add_glob_imports`, `test_perf_rust_cluster_embedded::test_rollout_fixture_archives_pin_the_runner_toolchain`); both confirmed on a stashed tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
