### PR TITLE
fix(hooks): stop tool_guard from scanning heredoc bodies as commands (#1450)

### DIFF
--- a/ci/hooks/tool_guard.py
+++ b/ci/hooks/tool_guard.py
@@ -342,6 +342,47 @@ def _nested_shell_command(words):
     return None
 
 
+# `<<WORD`, `<<'WORD'`, `<<"WORD"`, `<<-WORD` -- the operator that starts a
+# heredoc. The body that follows is stdin for the command, not a command.
+HEREDOC_RE = re.compile(r"""<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\1""")
+
+
+def _split_heredocs(command):
+    """Split `command` into (command_text, [(owner_program, body), ...]).
+
+    A heredoc body is data being fed to a program, so scanning it for tool
+    invocations is a category error -- `gh issue create --body-file - <<EOF`
+    whose prose happens to mention a blocked command was rejected as if the
+    prose were the command.
+
+    The exception is a shell reading its script from stdin (`bash <<EOF`),
+    where the body genuinely *is* executed. Those bodies are returned with
+    their owner so the caller keeps checking them; dropping every body
+    wholesale would turn this fix into a bypass.
+    """
+    lines = command.split("\n")
+    kept = []
+    bodies = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        kept.append(line)
+        delimiters = [match.group(2) for match in HEREDOC_RE.finditer(line)]
+        index += 1
+        if not delimiters:
+            continue
+        owner_words = _command_words(line)
+        owner = _program_name(owner_words[0]) if owner_words else ""
+        for delimiter in delimiters:
+            body = []
+            while index < len(lines) and lines[index].strip() != delimiter:
+                body.append(lines[index])
+                index += 1
+            index += 1  # consume the delimiter line
+            bodies.append((owner, "\n".join(body)))
+    return "\n".join(kept), bodies
+
+
 def check_command(command):
     """Return (tool, reason) if forbidden, otherwise None.
 
@@ -355,6 +396,15 @@ def check_command(command):
     argument. Now only `python tests/foo.py` (and `uv run python
     tests/foo.py`) trigger the block.
     """
+    command, heredoc_bodies = _split_heredocs(command)
+    for owner, body in heredoc_bodies:
+        # Only a shell executes its heredoc; every other program is being
+        # fed data. See `_split_heredocs`.
+        if owner in SHELL_WRAPPERS:
+            result = check_command(body)
+            if result:
+                return result
+
     segments = _split_shell_segments(command)
 
     for seg in segments:

--- a/ci/tests/test_tool_guard.py
+++ b/ci/tests/test_tool_guard.py
@@ -387,3 +387,53 @@ def test_uv_run_module_flag_still_sees_python():
     result = _check("uv run --frozen python -m pytest tests/foo.py")
     assert result is not None
     assert result[0] == "python"
+
+
+# ── heredoc bodies: data, not commands ─────────────────────────────────────
+#
+# `check_command` splits on `;`, `&&`, `|` with no awareness of quoting, so a
+# heredoc body reading "don't run `cargo build`" was parsed as an invocation
+# and rejected. The body is stdin for the program, not a command -- unless the
+# program is a shell, which really does execute it.
+
+
+def test_heredoc_body_fed_to_a_non_shell_is_data():
+    """`gh issue create --body-file - <<EOF` whose prose mentions a blocked
+    command must not be rejected for the prose."""
+    command = "gh issue create --body-file - <<'EOF'\nuv run --frozen cargo build\nEOF"
+    assert _check(command) is None
+
+
+def test_heredoc_body_with_unquoted_delimiter_is_data():
+    assert _check("gh pr comment 1 --body-file - <<EOF\ncargo build\nEOF") is None
+
+
+def test_heredoc_body_with_dash_delimiter_is_data():
+    """`<<-EOF` strips leading tabs; the delimiter line is indented too."""
+    assert _check("cat <<-EOF\n\tcargo build\n\tEOF") is None
+
+
+def test_shell_heredoc_body_is_still_executed_and_checked():
+    """The bypass this fix must not open: `bash <<EOF` runs its body, so the
+    body stays subject to the guard."""
+    for shell in ("bash", "sh", "zsh"):
+        result = _check(f"{shell} <<'EOF'\nuv run cargo build\nEOF")
+        assert result is not None, shell
+        assert result[0] == "cargo"
+
+
+def test_command_after_a_heredoc_is_still_checked():
+    """Consuming the body must not swallow what follows the delimiter."""
+    result = _check("cat <<'EOF' > f.txt\nhello\nEOF\ncargo build")
+    assert result is not None
+    assert result[0] == "cargo"
+
+
+def test_data_heredoc_then_shell_heredoc_still_blocks():
+    command = "cat <<'A' > x\ncargo build\nA\nbash <<'B'\ncargo build\nB"
+    assert _check(command) is not None
+
+
+def test_heredoc_body_mentioning_a_test_path_is_data():
+    command = "gh issue create --body-file - <<'EOF'\npython tests/foo.py is blocked\nEOF"
+    assert _check(command) is None


### PR DESCRIPTION
Closes #1450

## Problem

`check_command` splits on `;`, `&&`, `|` with no awareness of quoting, so a **heredoc body is scanned as if it were a command**. Prose that merely quotes a blocked invocation gets the whole thing rejected — `gh issue create --body-file -` with a body mentioning a flagged command comes back with *"Use `soldr cargo ...` instead of `uv run cargo ...`"*.

Nothing there is executed; the body is stdin for `gh`.

This blocked filing #1443, whose text necessarily quotes the commands the guard rejects. The workaround — write the body to a file, pass `--body-file <path>` — is a standing tax on documenting anything about the build tooling.

The class predates #1444, which correctly taught the guard to recognise `--frozen` / `--no-project` spellings and thereby widened the set of strings that trip it. That is what made this worth fixing rather than tolerating; flagged at the time [here](https://github.com/zackees/zccache/pull/1444#issuecomment-5374267089).

## The trap in the obvious fix

"Strip heredoc bodies before scanning" **opens a bypass**: a shell reading its script from stdin really does execute the body, so a blocked command under `bash <<...` would sail through.

`_split_heredocs` therefore returns each body together with the program that owns it:

- owned by a shell (`bash`, `sh`, `zsh`, …) → still checked, recursively;
- owned by anything else → data, excluded from scanning.

Handles the quoted, unquoted, and `<<-` forms, and keeps checking whatever follows the delimiter line so a real command after the body still blocks.

## Tests

Seven added. Note the split, because it matters for reading the RED proof:

- **Four false-positive tests** fail without the fix — data bodies to `gh` / `cat`, unquoted and `<<-` delimiters, and a body mentioning a `tests/*.py` path.
- **Three bypass-guard tests** pass with *and* without the fix, deliberately. They assert behaviour that must be **preserved** (`bash`/`sh`/`zsh` bodies stay blocked, commands after the delimiter stay checked), so they are regression cover, not RED proof. A fix that opened the bypass would fail them.

## Validation

```
PYTHONPATH=. uv run --frozen pytest ci/tests -q
-> 380 passed, 2 skipped, 2 failed
```

The two failures are pre-existing and unrelated (`test_incremental_build::test_repository_compile_boundary_does_not_add_glob_imports`, `test_perf_rust_cluster_embedded::test_rollout_fixture_archives_pin_the_runner_toolchain`).

Verified in situ as well: this hook is live in my own session, and [a comment on #1450](https://github.com/zackees/zccache/issues/1450#issuecomment-5376481635) was posted through the previously-rejected heredoc form.

One incidental confirmation that the parser is faithful to shell semantics: my first attempt at the commit for this PR used `EOF` for the outer delimiter while quoting `bash <<'EOF' … EOF` in the body. The guard rejected it — correctly, because the inner `EOF` line terminates the outer heredoc in real bash too, leaving the remainder as live commands. Switching the outer delimiter fixed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
