### PR TITLE
test(exec): name the two timeout intents in the guard-handoff tests (#1452)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_exec_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_exec_tests.rs
@@ -1,6 +1,23 @@
 //! Key-composition and exact-exec staging planner tests.
 use super::*;
+use std::time::Duration;
 use tempfile::tempdir;
+
+/// How long a task is given to *stay blocked* while a guard is held.
+///
+/// A real assertion: the point is that `clear` has not finished yet. Load only
+/// makes it more true, so this stays tight.
+const MUST_REMAIN_BLOCKED: Duration = Duration::from_millis(25);
+
+/// How long a task is given to finish once its guard is released.
+///
+/// Purely a hang detector. Once the blocking guard is gone the work either
+/// completes promptly or the handoff is broken and it never completes at all;
+/// nothing interesting lives in between, so this is deliberately generous.
+/// The 5s values this replaces expired on a loaded runner where this suite
+/// took 523s (#1452), while sibling assertions in the same file had already
+/// drifted to 30s -- one name instead of three magic numbers.
+const HANDOFF_HANG_DETECTOR: Duration = Duration::from_secs(60);
 
 fn h(byte: u8) -> ContentHash {
     ContentHash::from_bytes([byte; 32])
@@ -45,16 +62,16 @@ async fn detached_exec_publisher_cannot_resurrect_artifact_after_clear() {
     let mut clear =
         tokio::spawn(async move { super::super::handle_clear::handle_clear(&clear_state).await });
     assert!(
-        tokio::time::timeout(std::time::Duration::from_millis(25), &mut clear)
+        tokio::time::timeout(MUST_REMAIN_BLOCKED, &mut clear)
             .await
             .is_err(),
         "Clear must wait for the detached publisher's pre-spawn guard handoff"
     );
 
     drop(blocked_persist);
-    let response = tokio::time::timeout(std::time::Duration::from_secs(5), clear)
+    let response = tokio::time::timeout(HANDOFF_HANG_DETECTOR, clear)
         .await
-        .unwrap()
+        .expect("clear never finished after the persist guard was released")
         .unwrap();
     assert!(matches!(response, Response::Cleared { .. }));
     assert!(!server.state.artifacts.contains_key(&key));
@@ -103,26 +120,23 @@ async fn detached_exec_handoff_does_not_reacquire_behind_queued_clear() {
     let mut clear =
         tokio::spawn(async move { super::super::handle_clear::handle_clear(&clear_state).await });
     assert!(
-        tokio::time::timeout(std::time::Duration::from_millis(25), &mut clear)
+        tokio::time::timeout(MUST_REMAIN_BLOCKED, &mut clear)
             .await
             .is_err(),
         "Clear must queue behind the publisher's first read guard"
     );
 
     gate.resume();
-    tokio::time::timeout(std::time::Duration::from_secs(5), &mut publisher)
+    tokio::time::timeout(HANDOFF_HANG_DETECTOR, &mut publisher)
         .await
         .expect("publisher must transfer its guard instead of reacquiring")
         .unwrap()
         .unwrap();
     drop(blocked_persist);
-    tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        gate.wait_until_persisted(),
-    )
-    .await
-    .expect("transferred publication guard must reach persistence completion");
-    let response = tokio::time::timeout(std::time::Duration::from_secs(30), clear)
+    tokio::time::timeout(HANDOFF_HANG_DETECTOR, gate.wait_until_persisted())
+        .await
+        .expect("transferred publication guard must reach persistence completion");
+    let response = tokio::time::timeout(HANDOFF_HANG_DETECTOR, clear)
         .await
         .expect("Clear must finish after the transferred publication guard drops")
         .unwrap();


### PR DESCRIPTION
Addresses #1452 instance 3 — **does not close it**.

## What failed

`detached_exec_publisher_cannot_resurrect_artifact_after_clear` failed on PR #1451:

```
called `Result::unwrap()` on an `Err` value: Elapsed(())
  at handle_exec_tests.rs:57  —  tokio::time::timeout(Duration::from_secs(5), clear)
```

The unit suite took **523s** in that job and the Windows ReFS fixture failed on the same commit in the same window, so the runner was degraded rather than the code slow.

## What the file actually contained

Three magic durations for **two** intents:

| value | intent | count |
|---|---|---|
| 25ms | assert a task *stays blocked* while a guard is held | 2 |
| 5s | wait for it to finish once the guard is released | 2 |
| 30s | wait for it to finish once the guard is released | 2 |

The 30s pair is the same intent as the 5s pair — someone already hit this and raised those two without unifying. Rather than add a fourth number, both intents are named:

```rust
const MUST_REMAIN_BLOCKED: Duration = Duration::from_millis(25);
const HANDOFF_HANG_DETECTOR: Duration = Duration::from_secs(60);
```

## Why widening one and not the other is safe

`MUST_REMAIN_BLOCKED` is a **real assertion** — the point is that `clear` has *not* finished while the guard is held. Load only makes that more true, so it stays tight.

`HANDOFF_HANG_DETECTOR` is **purely a hang detector**. Once the blocking guard is released, the work either completes promptly or the handoff is broken and it never completes at all. Nothing interesting lives between 5s and 60s, so the tight value bought no detection and cost a CI cycle.

That is rule 3 of the convention proposed in #1452, applied to the instance that prompted it — deliberately *not* a blanket timeout multiplier, which that issue lists as a non-goal.

The `.unwrap()` on the widened wait also becomes `.expect(...)`, so a genuine hang says what broke instead of printing `Elapsed(())`.

## Validation

```
RUSTFLAGS="-D warnings" soldr cargo test -p zccache-daemon-core \
  --features test-support,daemon-entry --lib
-> 783 passed, 0 failed, 26 ignored
```

`-D warnings` set explicitly, since omitting it is how #1447 shipped a `dead_code` error to CI.

No RED proof is possible here and I would rather say so than imply one: the failure is load-triggered and does not reproduce on an idle machine. The argument for the change is the intent split above, not a reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
