### PR TITLE
test(rust-plan): report the observed error when the endpoint assert fails (#1452)

### DIFF
--- a/crates/zccache/tests/cli_rust_plan_lifecycle.rs
+++ b/crates/zccache/tests/cli_rust_plan_lifecycle.rs
@@ -601,12 +601,15 @@ fn rust_plan_session_stats_lookup_errors_surface_in_json() {
         stats.get("session_id").and_then(Value::as_str),
         Some("session-123")
     );
+    // Bind the observed value so a mismatch reports what actually arrived.
+    // This assertion failed once on `main` (run 32419543163) and the panic
+    // named only the expectation, so there was nothing to diagnose from and
+    // no way to tell a changed message from a changed failure mode (#1452).
+    let observed_error = stats.get("error").and_then(Value::as_str);
     assert!(
-        stats
-            .get("error")
-            .and_then(Value::as_str)
+        observed_error
             .is_some_and(|error| error.contains("cannot connect to daemon at tcp:127.0.0.1:9")),
-        "expected endpoint lookup failure to be surfaced in compile_cache_stats"
+        "expected endpoint lookup failure in compile_cache_stats; \n         got error={observed_error:?}, stats={stats:?}"
     );
 }
 


### PR DESCRIPTION
Addresses #1452 instance 2 — **does not close it**.

## The failure carried no information

`rust_plan_session_stats_lookup_errors_surface_in_json` failed on `main` ([run 32419543163](https://github.com/zackees/zccache/actions/runs/32419543163)) with exactly this:

```
expected endpoint lookup failure to be surfaced in compile_cache_stats
```

That is the whole panic. The assertion named what it wanted and never what it got, so there is no way to distinguish:

- a reworded error message (harmless, test needs updating), from
- the connect to `tcp:127.0.0.1:9` failing some *other* way than refused (a real behaviour change).

I could not diagnose it, and neither could anyone else reading that log.

## Change

Bind the value before asserting, so the panic carries the observed error and the whole `compile_cache_stats` object. The check itself is byte-for-byte the same condition.

```rust
let observed_error = stats.get("error").and_then(Value::as_str);
assert!(
    observed_error.is_some_and(|error| error.contains("cannot connect to daemon at tcp:127.0.0.1:9")),
    "expected endpoint lookup failure in compile_cache_stats; \
     got error={observed_error:?}, stats={stats:?}"
);
```

## Correcting my own filing

I listed this in #1452 alongside three wall-clock deadline failures. **It is not one** — it is a string-content assertion. It shares the property of being expensive to diagnose, which is how it got noticed in the same sweep, but not the cause. It should *not* be fixed by the convention that issue proposes, and I have corrected the tally there.

## Validation

```
RUSTFLAGS="-D warnings" soldr cargo check -p zccache --tests --features cli,daemon-bin
-> clean
```

**Not reproduced locally**, and I would rather say that than imply otherwise: this was a single occurrence on a CI runner. That is precisely why the change is "make the failure describe itself" rather than a guess at a fix — the next occurrence will say what it actually saw, and can then be fixed properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
