### PR TITLE
docs(perf): classify a test deadline before choosing its number (#1452)

### DIFF
--- a/PERF.md
+++ b/PERF.md
@@ -255,8 +255,48 @@ deterministic test at the narrowest useful layer:
 - Use the existing ignored benchmark tests plus `ci/perf_guard.py` for
   compile-time comparisons that are stable enough for a cheap hosted check.
 - Use a focused duration/counter assertion for a specific function or path.
-- Prefer approximately 3× headroom over the post-fix local measurement.
 - Prefix performance tests with `perf_` and reference the motivating issue.
 
 Do not add a second ad-hoc benchmark framework. Extend this harness or the
 existing focused regression tests.
+
+### Choosing a deadline — classify it before you pick a number
+
+Most wall-clock assertions that fail on CI were never measuring what they
+claimed to. Before choosing a duration, decide which of three things the
+deadline is. The right number differs, and so does the right fix when it goes
+red (issue #1452 collected the instances behind this).
+
+**1. The deadline *is* the assertion.** The property is latency, and the bound
+is what separates pass from fail. `perf_explicit_argv_dispatches_in_process_under_250ms`
+is the example: a process spawn costs ~10-50 ms, so the 250 ms bound is the
+whole test. Keep these tight, give them roughly 3× headroom over the post-fix
+local measurement, and **never widen one to quiet a flake** — the widened test
+passes with the regression present and is then decoration. If such a test is
+flaky, it needs a better instrument, not a bigger number.
+
+**2. The deadline is a proxy for a structural property.** The real claim is
+"no synchronous load here", "no subprocess spawned", "this ran in-process",
+and time is standing in for it. These are the worst offenders, because the
+proxy tracks machine speed rather than the property: a fast machine can satisfy
+the bound *with* the regression, and a loaded one violates it without.
+Assert the property directly where you can — a lifecycle event, a counter, a
+source-window scan. Where you cannot, measure a **differential** against a
+control so machine speed cancels. `daemon_spawn_lockfile_budget_test` is the
+worked example of both halves.
+
+**3. The deadline is only a hang detector.** Once a guard is released or a task
+is unblocked, the work either completes promptly or is broken and never
+completes. Nothing interesting lives between 5 s and 60 s, so a tight bound
+buys no detection and costs CI cycles. Be generous, and name the constant so
+the intent is legible — see `HANDOFF_HANG_DETECTOR` in
+`handle_exec_tests.rs`.
+
+Two rules that apply to all three:
+
+- **Do not apply a blanket multiplier** when a deadline goes red. It hides
+  genuine hangs, and for kind 1 it destroys the test outright.
+- **Size against CI, not your machine.** A dev box is routinely several times
+  faster than a loaded hosted runner; a unit suite measured at 57 s locally has
+  been observed taking 523 s in CI. 3× headroom over a local measurement is a
+  floor for kind 1 and not enough on its own for anything else.


### PR DESCRIPTION
Addresses #1452's *"the convention is written down where test authors will see it"* criterion — **does not close it**.

## Why a convention rather than four patches

Four wall-clock assertions failed CI in one session. Three were genuine deadline problems, and each needed a **different** fix:

| test | deadline | kind | fix |
|---|---|---|---|
| lockfile budget (#1447) | 8s | proxy for a structural property | differential + structural guard |
| detached exec publisher (#1453) | 5s | hang detector | widen to 60s |
| argv dispatch | 250ms | **the assertion itself** | do *not* widen |

Applying any one of those fixes to the wrong row makes things worse. Widening the argv-dispatch bound would leave a test that passes with the regression present.

## What changed

PERF.md's "Regression tests" section previously offered a single rule for all three:

> Prefer approximately 3× headroom over the post-fix local measurement.

That is correct for the *first* kind and actively misleading for the other two — a proxy deadline tracks machine speed rather than the property it stands for, so headroom over a **local** measurement is the wrong baseline entirely, and a hang detector does not need headroom at all. This PR **moves** that bullet into the kind it belongs to rather than deleting it.

The new subsection names the three kinds, gives the treatment for each with a worked in-repo example, and adds the two cross-cutting rules:

- **No blanket multiplier** when a deadline goes red — it hides genuine hangs, and for kind 1 it destroys the test.
- **Size against CI, not your machine** — a unit suite measured at 57s locally has been observed taking **523s** on a loaded runner.

## Verification

Every identifier referenced is checked against current `main`, not written from memory:

- `HANDOFF_HANG_DETECTOR` — `handle_exec_tests.rs:20` (landed in #1453)
- `daemon_spawn_lockfile_budget_test` — present
- `perf_explicit_argv_dispatches_in_process_under_250ms` — `run_with_args.rs:9`

```
PYTHONPATH=. uv run --frozen pytest ci/tests -q
-> 380 passed, 2 skipped, 2 failed
```

The two failures are pre-existing and unrelated (`test_incremental_build` glob-imports, `test_perf_rust_cluster_embedded` toolchain pin).

Docs-only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
