### PR TITLE
docs(perf): correct the kind-1 deadline example — it is not kind 1 (#1452)

### DIFF
--- a/PERF.md
+++ b/PERF.md
@@ -267,13 +267,23 @@ claimed to. Before choosing a duration, decide which of three things the
 deadline is. The right number differs, and so does the right fix when it goes
 red (issue #1452 collected the instances behind this).
 
-**1. The deadline *is* the assertion.** The property is latency, and the bound
-is what separates pass from fail. `perf_explicit_argv_dispatches_in_process_under_250ms`
-is the example: a process spawn costs ~10-50 ms, so the 250 ms bound is the
-whole test. Keep these tight, give them roughly 3× headroom over the post-fix
-local measurement, and **never widen one to quiet a flake** — the widened test
-passes with the regression present and is then decoration. If such a test is
-flaky, it needs a better instrument, not a bigger number.
+**1. The deadline *is* the assertion.** The property is latency and the bound
+is what separates pass from fail. Keep these tight, give them roughly 3×
+headroom over the post-fix local measurement, and **never widen one to quiet a
+flake** — the widened test passes with the regression present and is then
+decoration. If such a test is flaky it needs a better instrument, not a bigger
+number.
+
+Before assuming a deadline is this kind, **measure the regression it is meant
+to catch**. `perf_explicit_argv_dispatches_in_process_under_250ms` looks like
+this kind and is not. Its stated property is that an embedded dispatch stays a
+local function call "rather than regaining process-spawn cost", but
+`cmd_cache_root` does no IPC and no spawn — it resolves the cache root, formats
+JSON, and prints — so the work is around a millisecond, while spawning a debug
+binary on this repo measures ~145 ms once control-adjusted against
+`cmd /c exit`. A regression that regained a re-exec would therefore land near
+150 ms and **pass** the 250 ms bound. The bound only catches something
+catastrophically slow, which makes it kind 2 wearing kind 1's clothes.
 
 **2. The deadline is a proxy for a structural property.** The real claim is
 "no synchronous load here", "no subprocess spawned", "this ran in-process",
@@ -283,7 +293,9 @@ the bound *with* the regression, and a loaded one violates it without.
 Assert the property directly where you can — a lifecycle event, a counter, a
 source-window scan. Where you cannot, measure a **differential** against a
 control so machine speed cancels. `daemon_spawn_lockfile_budget_test` is the
-worked example of both halves.
+worked example of both halves, and the argv-dispatch test above is the
+cautionary one: a proxy whose bound was never checked against the cost of the
+thing it proxies for.
 
 **3. The deadline is only a hang detector.** Once a guard is released or a task
 is unblocked, the work either completes promptly or is broken and never


### PR DESCRIPTION
Follows #1455, **which I got wrong.**

## The error

#1455 used `perf_explicit_argv_dispatches_in_process_under_250ms` as the example of a deadline that *is* the assertion, justified like this:

> a process spawn costs ~10-50 ms, so the 250 ms bound is the whole test

I asserted that figure rather than measuring it. It is wrong.

## The measurement

Control-adjusted against `cmd /c exit` (7.7 ms median, so subprocess overhead is negligible):

| | cost |
|---|---|
| spawn of a debug binary, attributable to the binary itself | **~145 ms** |
| `cmd_cache_root` actual work | **~1 ms** |

`cmd_cache_root` does no IPC and spawns nothing — it resolves the cache root, formats JSON, prints. So a regression that regained a re-exec would land near **150 ms and pass the 250 ms bound**.

**The test cannot detect the regression its own comment claims it guards.** It only catches something catastrophically slow. It is kind 2 — a proxy whose bound was never checked against the cost of the thing it proxies for — wearing kind 1's clothes.

## What changed

- Kind 1 is described without leaning on a false example.
- It gains the rule that produced this correction: **before assuming a deadline is the assertion, measure the regression it is meant to catch.**
- The argv test moves to kind 2 as the cautionary case.

## This also changes #1452's instance 4

I twice declined to touch that test on the grounds that widening it would destroy its detection. **There is no detection there to destroy**, so widening is not the hazard I claimed. The real fix is still a structural assertion — a bound that cannot see a 150 ms regression is not worth calibrating — but my stated reason for leaving it alone was based on a number I had not checked.

## Caveat on the measurement

Windows, debug profile, measured by spawning `zccache-daemon --help` because the CLI binary is not built in this tree. It is the cost of the cheapest possible re-exec, **not** of an actual regression — no such code path exists to measure. Linux spawn is cheaper still, so the conclusion holds *a fortiori* on the platform where the flake was seen.

## Validation

Docs-only. Worth repeating from #1455: **no CI runs on this path** — every workflow is path-filtered and `PERF.md` matches none of them — so referenced identifiers were checked against `main` by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
