### PR TITLE
test(cli): assert the embedded dispatch spawns nothing, structurally (#1452)

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/tests/run_with_args.rs
+++ b/crates/zccache-cli-core/src/cli/commands/tests/run_with_args.rs
@@ -1,14 +1,77 @@
 //! Explicit-argv dispatch coverage for embedded CLI hosts (soldr#1593).
 
+use std::path::Path;
 use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
 use super::super::run_with_args;
 
+/// Spawn-shaped calls. A dispatch that "regains process-spawn cost" has to
+/// write one of these somewhere on the path.
+const SPAWN_CALLS: [&str; 3] = ["Command::new(", ".spawn(", "exec("];
+
+/// Source of a function body in this crate, brace-matched.
+fn fn_body(relative: &str, name: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(relative);
+    let source = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+    let needle = format!("fn {name}(");
+    let at = source
+        .find(&needle)
+        .unwrap_or_else(|| panic!("{} does not define `{needle}`", path.display()));
+    let open = source[at..]
+        .find('{')
+        .map(|i| at + i)
+        .unwrap_or_else(|| panic!("no body for `{needle}`"));
+    let mut depth = 0usize;
+    for (i, ch) in source[open..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return source[open..=open + i].to_owned();
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("unterminated body for `{needle}`")
+}
+
 #[test]
-fn perf_explicit_argv_dispatches_in_process_under_250ms() {
-    // Regression/perf contract for soldr#1593: an explicit embedded dispatch
-    // must stay a local function call rather than regaining process-spawn cost.
+fn explicit_argv_dispatch_spawns_no_process() {
+    // Regression contract for soldr#1593: an explicit embedded dispatch must
+    // stay a local function call rather than regaining process-spawn cost.
+    //
+    // Asserted structurally rather than by wall clock, because the wall clock
+    // could not see it. `cmd_cache_root` does no IPC and spawns nothing --
+    // resolve the root, format JSON, print -- so the work is ~1ms, while
+    // spawning a debug binary in this repo measures ~145ms control-adjusted.
+    // A regression that regained a re-exec would land near 150ms and *pass*
+    // the 250ms bound this replaces. See PERF.md "Choosing a deadline" and
+    // issue #1452.
+    for (file, function) in [
+        ("src/cli/commands/mod.rs", "run_with_args"),
+        ("src/cli/commands/cache_ops.rs", "cmd_cache_root"),
+    ] {
+        let body = fn_body(file, function);
+        for spawn in SPAWN_CALLS {
+            assert!(
+                !body.contains(spawn),
+                "{function} in {file} must not contain `{spawn}`                  (soldr#1593: the embedded dispatch must stay in-process)"
+            );
+        }
+    }
+}
+
+#[test]
+fn perf_explicit_argv_dispatch_is_not_catastrophically_slow() {
+    // Coarse backstop only. The spawn contract is enforced by
+    // `explicit_argv_dispatch_spawns_no_process` above; this bound exists so a
+    // dispatch that somehow blocks for seconds still fails, and is deliberately
+    // far above both the ~1ms of real work and the ~145ms a re-exec would add.
+    // Sized against a loaded CI runner, not this machine (PERF.md).
     let args = [
         "zccache".to_string(),
         "cache-root".to_string(),
@@ -18,7 +81,7 @@ fn perf_explicit_argv_dispatches_in_process_under_250ms() {
     assert_eq!(run_with_args(&args), ExitCode::SUCCESS);
     let elapsed = started.elapsed();
     assert!(
-        elapsed < Duration::from_millis(250),
+        elapsed < Duration::from_secs(30),
         "embedded cache-root dispatch took {elapsed:?}"
     );
 }


### PR DESCRIPTION
Closes #1452 instance 4.

## The old test could not do its job

`perf_explicit_argv_dispatches_in_process_under_250ms` claimed to guard soldr#1593 — that an explicit embedded dispatch stays a local function call *"rather than regaining process-spawn cost"*.

Measured on this repo, control-adjusted against `cmd /c exit` (7.7 ms):

| | cost |
|---|---|
| `cmd_cache_root` actual work | **~1 ms** |
| spawn of a debug binary, attributable to the binary | **~145 ms** |

A regression that regained a re-exec lands near 150 ms and **passes** a 250 ms bound.

**Demonstrated, not argued.** I injected a real re-exec of the debug binary into `run_with_args` and restored the original 250 ms assertion:

```
explicit_argv_dispatch_spawns_no_process               ... FAILED
perf_explicit_argv_dispatch_is_not_catastrophically_slow ... ok      <- the 250ms bound, blind
```

The old test passed with the regression present.

## The contract, asserted directly

`explicit_argv_dispatch_spawns_no_process` brace-matches the bodies of `run_with_args` and `cmd_cache_root` out of their source files and rejects `Command::new(`, `.spawn(`, `exec(`. Deterministic, load-immune, and it *does* fail on the regression — caught by the same injection, naming the offending function:

```
run_with_args in src/cli/commands/mod.rs must not contain `Command::new(`
(soldr#1593: the embedded dispatch must stay in-process)
```

## On the widened timing bound

The timing assertion is kept and demoted to what it always was: a coarse catastrophic-slowness backstop at 30 s, far above both the ~1 ms of real work and the ~145 ms a re-exec would add.

**This is not a weakening.** The 250 ms bound detected nothing a 30 s bound does not. What it did reliably detect was a descheduled thread, which is why it failed CI on #1451.

I want to be straight that this reverses my own position: I twice refused to touch this test on the grounds that its bound *was* its detection, and wrote that into PERF.md (#1455). That was an unmeasured assumption; #1456 corrected the doc, and this PR corrects the test.

## Scope, stated plainly

The guard sees spawn calls written literally in those two function bodies. A spawn added three frames down still escapes it. That is the realistic regression surface for this dispatch — both functions are where an "explicit argv dispatch" decision lives — and it is strictly more than the previous zero.

## Validation

```
RUSTFLAGS="-D warnings" soldr cargo test -p zccache-cli-core --features cli --lib
-> 262 passed, 0 failed, 2 ignored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
