### PR TITLE
fix(perf): keep a failing sample in the campaign index (#1116)

### DIFF
--- a/ci/perf_standalone.py
+++ b/ci/perf_standalone.py
@@ -285,6 +285,19 @@ def _reject_contaminated_sample(sample_dir: Path, contamination: list[str]) -> N
     )
 
 
+class SampleGuardFailure(RuntimeError):
+    """A sample that ran cleanly and then failed its perf floor.
+
+    Carries the recorded result so the campaign can index the evidence before
+    it stops. Distinct from an infrastructure failure, where there is no valid
+    sample to record.
+    """
+
+    def __init__(self, item: dict[str, Any], cause: Exception) -> None:
+        super().__init__(str(cause))
+        self.item = item
+
+
 def validate_completed_results(
     campaign_dir: Path, campaign: dict[str, Any], expected_attempts: int
 ) -> None:
@@ -822,8 +835,7 @@ def _run_sample(
         )
         _write_json(summary_path, summary)
         _reject_contaminated_sample(sample_dir, contamination)
-    validate_sample_summary(summary, attempts)
-    return {
+    item = {
         "language": language,
         "test": test_name,
         "passed": True,
@@ -832,6 +844,16 @@ def _run_sample(
         "cache_telemetry": telemetry,
         "artifacts": artifact_paths(campaign_dir, sample_dir),
     }
+    try:
+        validate_sample_summary(summary, attempts)
+    except (ValueError, RuntimeError) as error:
+        # The sample is real evidence -- it ran, produced artifacts, and was
+        # measured. Losing it from the index because it missed a floor is
+        # exactly backwards: a failing row is the row you most want linked.
+        item["passed"] = False
+        item["failure"] = str(error)
+        raise SampleGuardFailure(item, error) from error
+    return item
 
 
 def _render_markdown(campaign: dict[str, Any]) -> str:
@@ -855,7 +877,8 @@ def _render_markdown(campaign: dict[str, Any]) -> str:
             for index, path in enumerate(artifacts["raw_logs"], start=1)
         )
         lines.append(
-            f"| {item['language']} | `{item['test']}` | PASS | {rss_text} | "
+            f"| {item['language']} | `{item['test']}` | "
+            f"{'PASS' if item.get('passed', True) else 'FAIL'} | {rss_text} | "
             f"[JSON]({artifacts['summary_json']}) | {log_links} |"
         )
     return "\n".join(lines) + "\n"
@@ -934,19 +957,39 @@ def run_campaign(args: argparse.Namespace) -> Path:
     }
     if args.resume:
         validate_completed_results(campaign_dir, campaign, args.attempts)
-    completed = {(item["language"], item["test"]) for item in campaign["results"]}
-    for language, test_name in inventory:
-        if (language, test_name) in completed:
-            continue
-        _require_quiet_host()
-        item = _run_sample(
-            campaign_dir, language, test_name, args.attempts, identity
-        )
+    # Only passing samples count as done, so `--resume` retries a row that
+    # missed its floor rather than treating the failure as settled.
+    completed = {
+        (item["language"], item["test"])
+        for item in campaign["results"]
+        if item.get("passed", True)
+    }
+
+    def record(item: dict[str, Any]) -> None:
+        campaign["results"] = [
+            existing
+            for existing in campaign["results"]
+            if (existing["language"], existing["test"])
+            != (item["language"], item["test"])
+        ]
         campaign["results"].append(item)
         _write_json(campaign_path, campaign)
         (campaign_dir / "README.md").write_text(
             _render_markdown(campaign), encoding="utf-8"
         )
+
+    for language, test_name in inventory:
+        if (language, test_name) in completed:
+            continue
+        _require_quiet_host()
+        try:
+            item = _run_sample(
+                campaign_dir, language, test_name, args.attempts, identity
+            )
+        except SampleGuardFailure as failure:
+            record(failure.item)
+            raise
+        record(item)
     return campaign_dir
 
 

--- a/ci/tests/test_perf_standalone.py
+++ b/ci/tests/test_perf_standalone.py
@@ -685,3 +685,73 @@ def test_resume_revalidates_completed_sample_artifacts(tmp_path):
     (sample_dir / "attempt-1.log").unlink()
     with pytest.raises(ValueError, match="missing artifacts"):
         perf_standalone.validate_completed_results(tmp_path, campaign, 1)
+
+
+# ── a failing sample is still evidence (#1116) ─────────────────────────────
+#
+# The campaign stops at the first row that misses its floor. That row ran,
+# produced artifacts, and was measured -- dropping it from the index is
+# backwards, and it left `campaign.json` with no record that the run reached
+# emscripten at all.
+
+
+def _guard_failure_item(language="emscripten", test="perf_emcc_link"):
+    return {
+        "language": language,
+        "test": test,
+        "passed": False,
+        "failure": "sample did not pass the strict perf guard",
+        "peak_rss_bytes": None,
+        "command": ["docker", "run"],
+        "cache_telemetry": {},
+        "artifacts": {
+            "summary_json": f"{language}/{test}/perf-guard-summary.json",
+            "raw_logs": [f"{language}/{test}/attempt-1.log"],
+            "attempt_json": [f"{language}/{test}/attempt-1.json"],
+        },
+    }
+
+
+def test_sample_guard_failure_carries_the_recorded_item():
+    """The exception exists to keep the evidence, not just to signal."""
+    item = _guard_failure_item()
+    error = perf_standalone.SampleGuardFailure(item, ValueError("below floor"))
+
+    assert error.item is item
+    assert error.item["passed"] is False
+    assert "below floor" in str(error)
+
+
+def test_markdown_reports_a_failed_sample_as_failed():
+    """The status column was the literal string PASS, so a campaign index
+    could not represent the failure it stopped on."""
+    campaign = {
+        "identity": {
+            "commit": "abc123",
+            "image_digest": "sha256:deadbeef",
+            "attempts": 1,
+            "host_fingerprint": "host",
+        },
+        "results": [_guard_failure_item()],
+    }
+
+    markdown = perf_standalone._render_markdown(campaign)
+
+    assert "| FAIL |" in markdown, markdown
+    assert "| PASS |" not in markdown
+
+
+def test_markdown_still_reports_a_passing_sample_as_passing():
+    item = _guard_failure_item()
+    item["passed"] = True
+    campaign = {
+        "identity": {
+            "commit": "abc123",
+            "image_digest": "sha256:deadbeef",
+            "attempts": 1,
+            "host_fingerprint": "host",
+        },
+        "results": [item],
+    }
+
+    assert "| PASS |" in perf_standalone._render_markdown(campaign)


### PR DESCRIPTION
Addresses #1116's *"emit one campaign JSON and Markdown index linking every raw sample"* — **does not close it**.

## Found by running the harness

The standalone campaign stops at the first row that misses its floor. Mine reached emscripten and stopped — and **the row it stopped on vanished from the evidence.**

`_run_sample` raised out of `validate_sample_summary` before returning, so nothing was appended to `campaign["results"]`. The artifacts were sitting on disk — `attempt-1.json`, the raw log, `log-audits/`, `perf-guard-summary.json` — and nothing linked them. `campaign.json` recorded 6 of 12 samples with no indication the run had reached emscripten at all.

## This wasn't the intent

Two hardcoded literals give it away:

```python
"passed": True,                    # in the result dict
f"| ... | PASS | ..."              # in the markdown status column
```

Both declare a per-sample status field that could never say anything but success, because failure raised before either was written. **The schema was designed to carry pass/fail; the control flow made the failing half unreachable.**

## Change

`SampleGuardFailure` carries the recorded item, the campaign loop records it before re-raising, and the Markdown renders the real status.

A failing row is the row you most want linked.

## Deliberately unchanged

**The campaign still stops on a failing sample.** Whether it should instead continue and gather full four-language coverage is a behaviour question — I raised it on #1116 with both dispositions and did not decide it. This PR only stops the evidence being discarded on the way out.

One consequence worth flagging: `completed` now counts only *passing* samples, so `--resume` retries a row that missed its floor rather than treating the failure as settled. That is the resumability the issue asks for — and no regression, since resume previously re-ran the failing sample anyway (it was never recorded).

## Validation

```
PYTHONPATH=. uv run --frozen pytest ci/tests -q
-> 383 passed, 2 skipped, 2 failed
```

The two failures are pre-existing and unrelated (`test_incremental_build` glob-imports, `test_perf_rust_cluster_embedded` toolchain pin).

RED proof — reverting `ci/perf_standalone.py` while keeping the tests:

```
FAILED test_sample_guard_failure_carries_the_recorded_item
FAILED test_markdown_reports_a_failed_sample_as_failed
```

The third new test (`..._still_reports_a_passing_sample_as_passing`) passes either way by design — it pins the unchanged path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
