### PR TITLE
feat(daemon): log the legacy-lane counts when a daemon dies (#840 Slice 5)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/connection/dispatch.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/connection/dispatch.rs
@@ -58,11 +58,17 @@ pub(super) async fn dispatch_request(
                 .shutdown_event_logged
                 .swap(true, std::sync::atomic::Ordering::AcqRel)
             {
+                let (bincode_requests, bincode_requests_by_type) = state.bincode_request_totals();
                 crate::daemon::lifecycle::write_event(
                     crate::daemon::lifecycle::EVENT_DIED_SHUTDOWN,
                     serde_json::json!({
                         "reason": crate::daemon::lifecycle::REASON_GRACEFUL_SHUTDOWN,
                         "uptime_secs": now_secs().saturating_sub(state.start_time),
+                        // #840 Slice 5: the legacy-lane curve has to be
+                        // readable after the fact, and the live counter dies
+                        // with the daemon.
+                        "bincode_requests": bincode_requests,
+                        "bincode_requests_by_type": bincode_requests_by_type,
                     }),
                 );
             }

--- a/crates/zccache-daemon-core/src/daemon/server/maintenance_schedule.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/maintenance_schedule.rs
@@ -447,12 +447,18 @@ impl MaintenanceSchedule {
                     // see why the daemon exited. Pair this with the "spawn"
                     // entry to reconstruct daemon lifetime from the lifecycle
                     // log alone — tracing stderr is NUL'd.
+                    let (bincode_requests, bincode_requests_by_type) =
+                        state.bincode_request_totals();
                     crate::core::lifecycle::write_event(
                         crate::core::lifecycle::EVENT_DIED_IDLE,
                         serde_json::json!({
                             "reason": crate::core::lifecycle::REASON_IDLE_TIMEOUT,
                             "idle_secs": idle,
                             "idle_timeout_secs": timeout,
+                            // #840 Slice 5: idle timeout is the common death,
+                            // so this is where most of the curve would be lost.
+                            "bincode_requests": bincode_requests,
+                            "bincode_requests_by_type": bincode_requests_by_type,
                         }),
                     );
                     state.shutdown_requested.store(true, Ordering::Release);

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -625,6 +625,19 @@ impl SharedState {
             .collect()
     }
 
+    /// Legacy-lane counts for a durable lifecycle payload: `(total, by_type)`.
+    ///
+    /// The live counter is only reachable through `Request::Status`, so it
+    /// dies with the daemon. #840 Slice 5 has to watch this fall to zero
+    /// across a release cycle before the bincode lane can be deleted, and an
+    /// idle-timed-out daemon takes its counts with it. Emitting the totals on
+    /// death makes the curve reconstructable from `daemon-lifecycle.log`
+    /// alone, which is the same contract every other death statistic uses.
+    pub(super) fn bincode_request_totals(&self) -> (u64, std::collections::BTreeMap<String, u64>) {
+        let by_type = self.bincode_request_snapshot();
+        (by_type.values().sum(), by_type)
+    }
+
     pub(super) fn begin_cache_request(&self) -> ActiveCacheRequest<'_> {
         self.active_cache_requests.fetch_add(1, Ordering::AcqRel);
         ActiveCacheRequest { state: self }

--- a/crates/zccache-daemon-core/src/daemon/server/tests/connection_ipc.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/connection_ipc.rs
@@ -164,3 +164,34 @@ async fn handle_connection_accepts_v15_and_v16_control_requests() {
     })
     .await;
 }
+
+/// #840 Slice 5: the legacy-lane counter is only reachable through
+/// `Request::Status`, so an idle-timed-out daemon takes its counts with it and
+/// the soak curve cannot be reconstructed afterwards. `bincode_request_totals`
+/// is what the death events log; it has to agree with the live snapshot.
+#[tokio::test]
+async fn bincode_request_totals_sum_the_live_snapshot() {
+    let endpoint = crate::ipc::unique_test_endpoint();
+    let temp = tempfile::tempdir().unwrap();
+    let cache_dir: crate::core::NormalizedPath = temp.path().into();
+    let DaemonServer { state, .. } =
+        DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+
+    let (total, by_type) = state.bincode_request_totals();
+    assert_eq!(total, 0, "a fresh daemon has seen no legacy traffic");
+    assert!(by_type.is_empty());
+
+    state.record_bincode_request(&crate::protocol::Request::Ping);
+    state.record_bincode_request(&crate::protocol::Request::Ping);
+    state.record_bincode_request(&crate::protocol::Request::Status);
+
+    let (total, by_type) = state.bincode_request_totals();
+    assert_eq!(total, 3, "total must sum every request family");
+    assert_eq!(by_type.get("control-ping"), Some(&2));
+    assert_eq!(by_type.get("control-status"), Some(&1));
+    assert_eq!(
+        total,
+        by_type.values().sum::<u64>(),
+        "the logged total must agree with the logged breakdown"
+    );
+}


### PR DESCRIPTION
Addresses #840 Slice 5 — **does not close it**.

## The soak cannot currently be run

Slice 4 added a per-request-type bincode counter so Slice 5 could *"see the curve flatten near zero before deleting the lane"*. I went to check whether that curve is observable. It isn't.

The counter lives in a `DashMap` on `SharedState` and is reachable **only** through `Request::Status`. Nothing writes it to the lifecycle log, the compile journal, or any other durable store — `grep` for it outside the status path returns only its initialiser and test fixtures. So it dies with the daemon, and **idle timeout is the common death**, which means the counts are routinely lost regardless of anyone's intent to measure them.

A soak that must watch a number fall to zero across a release cycle cannot be run against a number that only exists while you are looking at it.

## Change

Both death events now carry the totals:

| site | event |
|---|---|
| `connection/dispatch.rs` | `died-shutdown` |
| `maintenance_schedule.rs` | `died-idle` |

as `bincode_requests` plus the `bincode_requests_by_type` breakdown. Summing those across a parsed `daemon-lifecycle.log` reconstructs the curve after the fact — the same contract `uptime_secs` and `idle_secs` already use in those very payloads.

`bincode_request_totals()` returns `(total, by_type)` from the live snapshot, so the logged total cannot drift from the logged breakdown. The test asserts that agreement, not just the counts.

## Scope

**This does not shorten the soak or license deleting the lane.** Slices 6–7 still wait on real field data over a release cycle. It makes the evidence Slice 5 depends on collectable at all, which it was not.

## Incidental confirmation

While checking this I found `~/.zccache/v1.13.6/logs/daemon-lifecycle.log` on this box — a 1.13.6 daemon (the release carrying the prost flip) has genuinely run here, and the log carries 16 event kinds. There is no bincode row in it. That is exactly the gap this closes.

## Validation

```
RUSTFLAGS="-D warnings" soldr cargo test -p zccache-daemon-core \
  --features test-support,daemon-entry --lib
-> 784 passed, 0 failed, 26 ignored
```

`-D warnings` set explicitly (omitting it is how #1447 shipped a `dead_code` error to CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
