### PR TITLE
feat(wrap): emit a wrapper-side phase profile (#1460 phase 1)

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/wrap.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap.rs
@@ -8,6 +8,7 @@ mod diag;
 mod env;
 pub(crate) mod ipc;
 mod passthrough;
+mod profile;
 mod routing;
 mod rustfmt;
 mod tool_resolution;
@@ -71,6 +72,20 @@ fn emit_wrapper_warning(text: &str) {
 /// If `ZCCACHE_SESSION_ID` is set, uses that session and sends the tool as a
 /// per-request override. If unset, auto-creates an ephemeral session.
 pub(crate) fn run_wrap(args: &[String], overrides: WrapperOverrides) -> ExitCode {
+    // Issue #1460: the per-invocation path is otherwise unmeasured, and it is
+    // where ~63% of #1437's emscripten cold gap lives. Inert unless the
+    // daemon's own profiling env is set.
+    let wrapper_profile = profile::WrapperProfile::start();
+    let code = run_wrap_routed(args, overrides, &wrapper_profile);
+    wrapper_profile.emit();
+    code
+}
+
+fn run_wrap_routed(
+    args: &[String],
+    overrides: WrapperOverrides,
+    wrapper_profile: &profile::WrapperProfile,
+) -> ExitCode {
     diag::emit(args);
 
     if args.is_empty() {
@@ -81,6 +96,7 @@ pub(crate) fn run_wrap(args: &[String], overrides: WrapperOverrides) -> ExitCode
     if env::wrapper_disabled() {
         // Never silent (issue #1211): the user opted out, but each uncached
         // invocation still announces itself and the reason.
+        wrapper_profile.set_route("disabled");
         return passthrough::run_passthrough(args, Some("ZCCACHE_DISABLE is set"));
     }
 
@@ -103,29 +119,42 @@ pub(crate) fn run_wrap(args: &[String], overrides: WrapperOverrides) -> ExitCode
     // being deleted. We've captured everything we need into local variables.
     let _ = std::env::set_current_dir(std::env::temp_dir());
 
+    // Everything above is wrapper setup; everything below is the routed call.
+    wrapper_profile.mark_setup_done();
+
     match routing::classify_invocation(&args[0], &tool_args) {
         WrapperRoute::Formatter => {
+            wrapper_profile.set_route("formatter");
             rustfmt::run_rustfmt_cached(&wrapped_tool, &tool_args, &cwd, None)
         }
-        WrapperRoute::LinkOrArchive => run_async(ipc::cmd_link_ephemeral(
-            &endpoint,
-            &wrapped_tool,
-            tool_args,
-            cwd.into(),
-            client_env,
-        )),
+        WrapperRoute::LinkOrArchive => {
+            wrapper_profile.set_route("link_or_archive");
+            run_async(ipc::cmd_link_ephemeral(
+                &endpoint,
+                &wrapped_tool,
+                tool_args,
+                cwd.into(),
+                client_env,
+            ))
+        }
         // Silent by design: probe callers parse the tool's stderr, so a
         // warning line here would corrupt the probe (see run_passthrough).
-        WrapperRoute::ProbeBypass => passthrough::run_passthrough(args, None),
-        WrapperRoute::Compile => run_compile_route(
-            &endpoint,
-            &args[0],
-            &tool_args,
-            strict_paths_mode,
-            wrapped_tool,
-            cwd.into(),
-            client_env,
-        ),
+        WrapperRoute::ProbeBypass => {
+            wrapper_profile.set_route(profile::ROUTE_PROBE_BYPASS);
+            passthrough::run_passthrough(args, None)
+        }
+        WrapperRoute::Compile => {
+            wrapper_profile.set_route("compile");
+            run_compile_route(
+                &endpoint,
+                &args[0],
+                &tool_args,
+                strict_paths_mode,
+                wrapped_tool,
+                cwd.into(),
+                client_env,
+            )
+        }
     }
 }
 

--- a/crates/zccache-cli-core/src/cli/commands/wrap/profile.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/profile.rs
@@ -1,0 +1,203 @@
+//! Wrapper-side phase timing (issue #1460).
+//!
+//! Every `ZCCACHE_PROFILE_*` surface in the tree is daemon-side, so the
+//! per-invocation path — argv parse, tool resolution, endpoint resolve, IPC
+//! roundtrip, output materialization — has never been measured. Attributing
+//! #1437's emscripten multi-file cold regression with the daemon's own
+//! `zccache_cc_miss_profile` accounted for 0.401s of a 1.071s gap; the
+//! remaining 0.670s is in this path, which nothing could see.
+//!
+//! The line is emitted with `eprintln!` in the same `key=value` shape the
+//! daemon uses, so it lands in the same benchmark log and `benchmark_stats`
+//! can parse both. It is gated on the same env the daemon reads, which
+//! `benchmark_stats.py` already sets unconditionally — so existing campaign
+//! runs start carrying wrapper rows without a harness change.
+
+use std::cell::Cell;
+use std::sync::OnceLock;
+use std::time::Instant;
+
+/// Shared with the daemon's cc-miss profile so one switch turns on both
+/// halves of a single invocation's timing.
+const PROFILE_ENV: &str = "ZCCACHE_PROFILE_CC_MISS";
+
+/// The one route that must stay silent on stderr; see [`WrapperProfile::emit`].
+pub(crate) const ROUTE_PROBE_BYPASS: &str = "probe_bypass";
+
+/// Cached env lookup, matching the `OnceLock` pattern `zccache-depgraph`
+/// already uses for this variable (`graph/mod.rs`). The wrapper runs once per
+/// compile, so this is read on the hot path.
+fn enabled() -> bool {
+    static FLAG: OnceLock<bool> = OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os(PROFILE_ENV).is_some())
+}
+
+/// Phase timing for one wrapper invocation.
+///
+/// Inert unless [`PROFILE_ENV`] is set: `start` is `None`, every mark is a
+/// branch, and nothing is printed. Interior mutability keeps the handle
+/// shareable by `&` through the routing code without threading `&mut`.
+pub(crate) struct WrapperProfile {
+    start: Option<Instant>,
+    setup_ns: Cell<u64>,
+    route: Cell<&'static str>,
+}
+
+impl WrapperProfile {
+    pub(crate) fn start() -> Self {
+        Self {
+            start: enabled().then(Instant::now),
+            setup_ns: Cell::new(0),
+            route: Cell::new("none"),
+        }
+    }
+
+    /// Everything before the invocation is routed: argv checks, strict-paths
+    /// resolution, tool-path resolution, client env, endpoint resolve.
+    pub(crate) fn mark_setup_done(&self) {
+        if let Some(start) = self.start {
+            self.setup_ns.set(elapsed_ns(start));
+        }
+    }
+
+    /// Routes seen in the field: `compile`, `link_or_archive`, `formatter`,
+    /// `probe_bypass`, `disabled`, and `none` for an argv error that returns
+    /// before routing. Labelling the early returns keeps a row from looking
+    /// like a routing bug when it is really an opt-out.
+    pub(crate) fn set_route(&self, route: &'static str) {
+        if self.start.is_some() {
+            self.route.set(route);
+        }
+    }
+
+    /// Whether [`emit`](Self::emit) would print. Exists so the silence
+    /// contract is assertable without capturing stderr.
+    pub(crate) fn would_emit(&self) -> bool {
+        self.start.is_some() && self.route.get() != ROUTE_PROBE_BYPASS
+    }
+
+    /// Emit the row. `dispatch_ns` is the whole routed call — IPC connect,
+    /// request, the daemon's own work, response, and output materialization.
+    /// Subtracting the daemon's `total_ns` for the same compile leaves the
+    /// out-of-daemon cost that #1460 exists to expose.
+    ///
+    /// Never emits on the probe-bypass route. Probe callers parse the tool's
+    /// stderr, which is why `run_passthrough` is silent there — and
+    /// `benchmark_stats.py` sets the profiling env *unconditionally*, so
+    /// without this guard a probe during a benchmark run would be corrupted
+    /// by the very instrumentation added to measure that run.
+    pub(crate) fn emit(&self) {
+        let Some(start) = self.start else {
+            return;
+        };
+        if !self.would_emit() {
+            return;
+        }
+        let total_ns = elapsed_ns(start);
+        let setup_ns = self.setup_ns.get();
+        eprintln!(
+            "zccache_wrapper_profile route={} total_ns={} setup_ns={} dispatch_ns={}",
+            self.route.get(),
+            total_ns,
+            setup_ns,
+            total_ns.saturating_sub(setup_ns),
+        );
+    }
+}
+
+fn elapsed_ns(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_nanos()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_disabled_profile_records_nothing() {
+        // Constructed directly rather than via `start()`, which reads a
+        // process-global env through a OnceLock and would make this test
+        // order-dependent.
+        let profile = WrapperProfile {
+            start: None,
+            setup_ns: Cell::new(0),
+            route: Cell::new("none"),
+        };
+
+        profile.mark_setup_done();
+        profile.set_route("compile");
+
+        assert_eq!(profile.setup_ns.get(), 0);
+        assert_eq!(
+            profile.route.get(),
+            "none",
+            "a disabled profile must not even record the route"
+        );
+        profile.emit();
+    }
+
+    #[test]
+    fn an_enabled_profile_records_setup_and_route() {
+        let profile = WrapperProfile {
+            start: Some(Instant::now()),
+            setup_ns: Cell::new(0),
+            route: Cell::new("none"),
+        };
+
+        profile.set_route("compile");
+        profile.mark_setup_done();
+
+        assert_eq!(profile.route.get(), "compile");
+        // Any real elapsed time is fine; the contract is that it was taken,
+        // not how long it was. Asserting a duration here would be exactly the
+        // wall-clock mistake PERF.md warns about.
+        assert!(profile.setup_ns.get() > 0);
+    }
+
+    #[test]
+    fn dispatch_is_the_remainder_after_setup() {
+        let start = Instant::now();
+        let profile = WrapperProfile {
+            start: Some(start),
+            setup_ns: Cell::new(0),
+            route: Cell::new("compile"),
+        };
+        profile.mark_setup_done();
+
+        let total = elapsed_ns(start);
+        assert!(
+            total >= profile.setup_ns.get(),
+            "setup is a prefix of total, so dispatch can never be negative"
+        );
+    }
+
+    #[test]
+    fn the_probe_bypass_route_is_never_emitted() {
+        // `run_passthrough` is silent on this route because probe callers
+        // parse the tool's stderr, and `benchmark_stats.py` sets the profiling
+        // env unconditionally -- so an unguarded emit would corrupt probes
+        // during exactly the benchmark runs this instrumentation serves.
+        let profile = WrapperProfile {
+            start: Some(Instant::now()),
+            setup_ns: Cell::new(0),
+            route: Cell::new(ROUTE_PROBE_BYPASS),
+        };
+
+        assert!(
+            !profile.would_emit(),
+            "probe-bypass must stay silent even with profiling enabled"
+        );
+    }
+
+    #[test]
+    fn other_routes_do_emit_when_enabled() {
+        for route in ["compile", "link_or_archive", "formatter"] {
+            let profile = WrapperProfile {
+                start: Some(Instant::now()),
+                setup_ns: Cell::new(0),
+                route: Cell::new(route),
+            };
+            assert!(profile.would_emit(), "{route} should emit");
+        }
+    }
+}


### PR DESCRIPTION
Addresses #1460 phase 1 — **does not close it**.

## Why

Attributing #1437's emscripten multi-file cold gap with the daemon's `zccache_cc_miss_profile` reached **0.401s of a 1.071s gap**. The other 0.670s is in the per-invocation path — process start, argv, tool resolution, endpoint resolve, IPC, output materialization — and nothing measured it. Every `ZCCACHE_PROFILE_*` reader lives in `zccache-daemon-core` or `zccache-depgraph`; the compile wrapper had no timing at all.

## What

`run_wrap` emits one row per invocation:

```
zccache_wrapper_profile route=compile total_ns=6118209900 setup_ns=29837400 dispatch_ns=6088372500
```

`setup_ns` is everything before routing; `dispatch_ns` is the routed call. **Subtracting the daemon's own `total_ns` for the same compile leaves the out-of-daemon cost** — the join #1460 asks for.

Gated on `ZCCACHE_PROFILE_CC_MISS`, the same env the daemon reads, cached through a `OnceLock` exactly as `zccache-depgraph` does for it (`graph/mod.rs:245`). Two consequences worth noting:

- `benchmark_stats.py` already sets it **unconditionally**, so campaign logs start carrying wrapper rows with **no harness change**.
- `eprintln!` in the daemon's `key=value` shape puts both halves in the same stream, so one parse gets both.

Inert when unset — `start` is `None` and every mark is a branch.

## A hazard I hit on the way

The **probe-bypass route is deliberately silent** because probe callers parse the tool's stderr (see `run_passthrough`). Combined with the harness setting the profiling env unconditionally, an unguarded emit would have **corrupted probes during exactly the benchmark runs this instrumentation serves.**

`emit` refuses that route, and `would_emit` exists so the silence contract is assertable without capturing stderr. There is a test per route.

Early returns are labelled too (`disabled` for `ZCCACHE_DISABLE`), so a row doesn't read as a routing bug when it's really an opt-out.

## Scope

This is the coarse setup/dispatch split. Decomposing `dispatch` into connect / encode / wait / decode / materialize is the finer half of #1460 and wants the marks threaded through the IPC layer — deliberately not in this PR.

## Validation

End-to-end with a real wrapped invocation, not just unit tests:

| condition | result |
|---|---|
| env unset | **0 lines** — silent |
| env set, compile | `route=compile total_ns=6118209900 setup_ns=29837400 dispatch_ns=6088372500` |
| env set, `ZCCACHE_DISABLE=1` | `route=disabled` |

```
soldr cargo test -p zccache-cli-core --features cli --lib   -> 267 passed, 0 failed
soldr cargo clippy -p zccache-cli-core --features cli --all-targets -> clean
```

Both under `RUSTFLAGS="-D warnings"`.

**First real number it produced:** 29.8ms of wrapper setup on a cold debug-build invocation. Steady-state will be lower, but on a 50-source multi-file build that is the right order of magnitude to matter for #1437 — and it was previously invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
