### PR TITLE
feat(perf): add --keep-going so a campaign can finish its inventory (#1116)

### DIFF
--- a/ci/perf_standalone.py
+++ b/ci/perf_standalone.py
@@ -298,6 +298,19 @@ class SampleGuardFailure(RuntimeError):
         self.item = item
 
 
+def failed_rows(campaign: dict[str, Any]) -> list[tuple[str, str]]:
+    """`(language, test)` for every recorded sample that missed its floor.
+
+    Reads the campaign index rather than a parallel tally, so a run cannot
+    report success while `campaign.json` records a failure.
+    """
+    return [
+        (item["language"], item["test"])
+        for item in campaign.get("results", [])
+        if not item.get("passed", True)
+    ]
+
+
 def validate_completed_results(
     campaign_dir: Path, campaign: dict[str, Any], expected_attempts: int
 ) -> None:
@@ -988,12 +1001,25 @@ def run_campaign(args: argparse.Namespace) -> Path:
             )
         except SampleGuardFailure as failure:
             record(failure.item)
-            raise
+            if not getattr(args, "keep_going", False):
+                raise
+            # Coverage mode: a row that misses its floor is recorded and the
+            # campaign moves on. #1116's close criterion wants evidence for
+            # all four language families, and at least one row is failing for
+            # structural reasons rather than fixable ones (#1437), so
+            # stopping at the first red row makes that criterion unreachable.
+            print(
+                f"WARNING: {language}/{test_name} missed its floor; continuing "
+                "because --keep-going was passed",
+                file=sys.stderr,
+            )
+            continue
         record(item)
     return campaign_dir
 
 
-def main() -> int:
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Campaign CLI. Split out of `main` so flag defaults are testable."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--language", choices=benchmark_stats.LANGUAGES)
     parser.add_argument("--test")
@@ -1001,6 +1027,20 @@ def main() -> int:
     parser.add_argument("--output-dir", type=Path)
     parser.add_argument("--resume", action="store_true")
     parser.add_argument("--rebuild-image", action="store_true")
+    parser.add_argument(
+        "--keep-going",
+        action="store_true",
+        help=(
+            "record a sample that misses its perf floor and continue, instead "
+            "of stopping. Still exits non-zero. Use to gather full "
+            "four-language coverage when a row is failing (#1116)."
+        ),
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_arg_parser()
     args = parser.parse_args()
     if args.attempts < 1:
         parser.error("--attempts must be at least 1")
@@ -1010,6 +1050,15 @@ def main() -> int:
         output = run_campaign(args)
     except (RuntimeError, ValueError, subprocess.CalledProcessError) as error:
         print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    # Derived from the recorded results rather than tracked separately, so the
+    # exit code cannot disagree with the campaign index (#1458 records a
+    # failing sample; this reads it back).
+    failed = failed_rows(_load_json(output / "campaign.json"))
+    if failed:
+        rows = ", ".join(f"{language}/{test}" for language, test in failed)
+        print(f"campaign complete with failing rows: {output}")
+        print(f"ERROR: {len(failed)} sample(s) below floor: {rows}", file=sys.stderr)
         return 1
     print(f"campaign complete: {output}")
     return 0

--- a/ci/tests/test_perf_standalone.py
+++ b/ci/tests/test_perf_standalone.py
@@ -755,3 +755,40 @@ def test_markdown_still_reports_a_passing_sample_as_passing():
     }
 
     assert "| PASS |" in perf_standalone._render_markdown(campaign)
+
+
+# ── --keep-going: coverage without pretending the run passed (#1116) ───────
+
+
+def test_failed_rows_reads_the_campaign_index():
+    campaign = {
+        "results": [
+            {"language": "c", "test": "perf_c_archive_link", "passed": True},
+            {"language": "emscripten", "test": "perf_emcc_link", "passed": False},
+            {"language": "rust", "test": "perf_rustc_zccache_vs_sccache"},
+        ]
+    }
+
+    assert perf_standalone.failed_rows(campaign) == [("emscripten", "perf_emcc_link")]
+
+
+def test_failed_rows_treats_a_missing_flag_as_passing():
+    """Pre-#1458 campaign files have no `passed` key; they only ever recorded
+    successes, so absence means pass."""
+    assert perf_standalone.failed_rows({"results": [{"language": "c", "test": "t"}]}) == []
+
+
+def test_failed_rows_is_empty_for_a_clean_campaign():
+    campaign = {"results": [{"language": "c", "test": "t", "passed": True}]}
+
+    assert perf_standalone.failed_rows(campaign) == []
+
+
+def test_keep_going_is_off_by_default():
+    """Fail-fast stays the default: --keep-going only exists so a campaign can
+    gather four-language coverage when a row is failing for structural reasons
+    (#1437), and it still exits non-zero."""
+    parser = perf_standalone.build_arg_parser()
+
+    assert parser.parse_args([]).keep_going is False
+    assert parser.parse_args(["--keep-going"]).keep_going is True


### PR DESCRIPTION
Addresses #1116's four-language close criterion — **does not close it**.

## Why this stopped being a judgment call

The campaign stops at the first row that misses its floor, so a run cannot produce evidence for all four language families while any row is red. When I raised this on #1116 I framed it as a behaviour question and deliberately left it alone.

The #1437 measurements since have made it sharper. That emscripten multi-file cold row fails for a **structural** reason: the bare baseline runs *one batched* `em++` invocation while zccache is forced into 50, because caching is per translation unit. Measured directly with zccache removed from the experiment entirely, that costs **3.3s on 50 sources**:

```
batched  (1 invocation , 50 TUs)   40966 ms
separate (50 invocations, 50 TUs)  44267 ms
penalty                             3301 ms
```

If that row cannot pass in its present form, fail-fast doesn't merely inconvenience #1116 — it makes its close criterion **unreachable**.

## Change

`--keep-going` records the failing sample (already indexed since #1458), warns naming the row, and continues.

**Default behaviour is unchanged** — without the flag the campaign still stops at the first red row. That keeps this additive rather than a decision about how the harness *should* behave, which remains the owner's call.

**The run still fails.** `failed_rows()` reads the campaign index back and `main` exits non-zero listing every red row, so coverage mode can't be mistaken for a pass. Deriving the verdict from the recorded results rather than a parallel tally means the exit code cannot disagree with `campaign.json`.

## Two things worth flagging

**My first attempt broke a test, and the test was right.** I returned `(campaign_dir, failed)` from `run_campaign`, which broke `test_resume_reuses_recorded_fixture_without_rebuilding` — it asserts the return value. Reading the index back instead leaves the signature alone and removes the possibility of the tally drifting from the file.

**`build_arg_parser()` is split out of `main`** so flag defaults are testable; the parser was previously unreachable from tests, which is why nothing pinned them.

## Validation

```
PYTHONPATH=. uv run --frozen pytest ci/tests -q
-> 386 passed, 2 skipped, 3 failed
```

All three failures are pre-existing and unrelated: `test_incremental_build` glob-imports, `test_perf_rust_cluster_embedded` toolchain pin, and the flaky `test_perf_watchdog` timeout tracked in #1452.

RED proof — reverting `ci/perf_standalone.py` while keeping the tests:

```
FAILED test_failed_rows_reads_the_campaign_index
FAILED test_failed_rows_treats_a_missing_flag_as_passing
FAILED test_failed_rows_is_empty_for_a_clean_campaign
FAILED test_keep_going_is_off_by_default
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
