### PR TITLE
docs(perf-bench): record what the three benchmark sides actually execute (#1437)

### DIFF
--- a/crates/zccache/tests/perf_bench/README.md
+++ b/crates/zccache/tests/perf_bench/README.md
@@ -33,3 +33,56 @@ test" for the rules on adding new perf benchmarks here.
 | `tests_sibling_remap.rs` | `perf_cpp_sibling_remap_warm`, `perf_rustc_sibling_remap_warm`. |
 | `tests_emcc.rs` | `perf_emcc_warm_cache_zccache_vs_sccache`, `perf_emcc_sibling_remap_warm`. |
 | `tests_link.rs` | `perf_c_archive_link`, `perf_cpp_driver_link`, `perf_emcc_link`, `perf_rust_workspace_link`. |
+
+## What the three sides actually execute
+
+The bare / sccache / zccache columns are **not** three ways of running the same
+command. Anyone reading a ratio, and especially anyone treating a failing floor
+as a regression, needs the differences:
+
+| side | invocation |
+|---|---|
+| bare | `Command::new(compiler)` — a subprocess |
+| sccache | `Command::new(sccache)` — a subprocess, one per source file |
+| zccache | in-process `ClientConn`, one `Request::Compile` |
+
+Two consequences follow, both measured rather than assumed (issue #1437).
+
+### Multi-file bare batches; zccache cannot
+
+`baseline_multi` passes all sources to **one** compiler process
+(`cpp_project.rs`), so the compiler's startup cost is amortized across the
+whole set. zccache caches per translation unit, so the daemon invokes the
+compiler **once per source** — the profile emits one `zccache_cc_miss_profile`
+row per file.
+
+For a driver with meaningful startup this is a fixed handicap that scales with
+source count. Measured in the pinned image on 50 sources, with zccache removed
+from the experiment entirely:
+
+```
+batched  (1 em++ invocation , 50 TUs)   40966 ms
+separate (50 em++ invocations, 50 TUs)  44267 ms
+penalty                                  3301 ms   (~67 ms per extra invocation)
+```
+
+em++ is an Emscripten Python driver, so its startup dominates; native clang's
+is roughly an order of magnitude smaller, which is why the C and C++
+multi-file rows pass on runs where the emscripten one does not.
+
+**A cold multi-file zccache run cannot beat a single batched invocation of a
+slow-starting driver on any hardware.** A `Multi-file, Cold vs Bare` floor for
+such a driver is measuring batching strategy, not cache performance. Treat a
+failure there as a fixture question before hunting for a regression.
+
+### zccache is measured without per-invocation cost
+
+zccache goes through an in-process client; sccache and bare are subprocesses.
+Real users reach zccache through the `zccache <compiler> ...` wrapper, which
+pays process start, argv parse, tool resolution, endpoint resolve and IPC on
+every compile — none of which these numbers include. `zccache_wrapper_profile`
+(issue #1460) measures that path, but the benchmark does not exercise it.
+
+So a passing floor here does not by itself establish that a user sees the same
+win, and the vs-sccache comparison is the fairer of the two for per-file work
+because both sides spawn per file.


### PR DESCRIPTION
Addresses #1437 disposition 3 — **does not close it**.

## Why

The bare / sccache / zccache columns are **not** three ways of running the same command, and the differences change what a ratio means. Neither was written down anywhere, and I misdiagnosed #1437 twice before finding them.

| side | invocation |
|---|---|
| bare | `Command::new(compiler)` — subprocess |
| sccache | `Command::new(sccache)` — subprocess, one per source |
| zccache | in-process `ClientConn`, one `Request::Compile` |

## Two documented consequences, both measured

**1. Multi-file bare batches; zccache cannot.** `baseline_multi` passes all sources to *one* compiler process, amortizing startup across the set. zccache caches per translation unit, so it invokes the compiler once per source. Measured in the pinned image on 50 sources, **with zccache removed from the experiment entirely**:

```
batched  (1 em++ invocation , 50 TUs)   40966 ms
separate (50 em++ invocations, 50 TUs)  44267 ms
penalty                                  3301 ms   (~67 ms per invocation)
```

em++ is a Python driver; native clang's startup is roughly an order of magnitude smaller — which is why the C and C++ multi-file rows pass on runs where the emscripten one doesn't. A cold multi-file zccache run **cannot** beat a single batched invocation of a slow-starting driver on any hardware, so that floor measures batching strategy rather than cache performance.

**2. zccache is measured without per-invocation cost.** It goes through an in-process client while sccache and bare are subprocesses. Real users reach zccache through the wrapper and pay process start, argv parse, tool resolution, endpoint resolve and IPC on every compile — none of it in these numbers. So a passing floor here doesn't establish that a user sees the same win, and vs-sccache is the fairer comparison for per-file work since both sides spawn per file.

## Scope

**Documentation only.** No floor, fixture, or threshold changes — #1093 owns that policy and #1437 explicitly forbids weakening floors. This is the one disposition from that issue that needs no owner decision: it records measured facts so the next reader doesn't spend the investigation I did rediscovering them.

The other dispositions (compare against 50 separate bare invocations; drop vs-bare for high-startup drivers; leave as-is) all change what a published benchmark means and remain open on #1437.

## Validation

```
PYTHONPATH=. uv run --frozen pytest ci/tests -q -k perf_standalone
-> 32 passed
```

Markdown only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
