### PR TITLE
feat(wrap): split the wrapper dispatch into connect, wait, and post (#1460 phase 2)

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/wrap.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap.rs
@@ -75,17 +75,13 @@ pub(crate) fn run_wrap(args: &[String], overrides: WrapperOverrides) -> ExitCode
     // Issue #1460: the per-invocation path is otherwise unmeasured, and it is
     // where ~63% of #1437's emscripten cold gap lives. Inert unless the
     // daemon's own profiling env is set.
-    let wrapper_profile = profile::WrapperProfile::start();
-    let code = run_wrap_routed(args, overrides, &wrapper_profile);
-    wrapper_profile.emit();
+    profile::start();
+    let code = run_wrap_routed(args, overrides);
+    profile::emit();
     code
 }
 
-fn run_wrap_routed(
-    args: &[String],
-    overrides: WrapperOverrides,
-    wrapper_profile: &profile::WrapperProfile,
-) -> ExitCode {
+fn run_wrap_routed(args: &[String], overrides: WrapperOverrides) -> ExitCode {
     diag::emit(args);
 
     if args.is_empty() {
@@ -96,7 +92,7 @@ fn run_wrap_routed(
     if env::wrapper_disabled() {
         // Never silent (issue #1211): the user opted out, but each uncached
         // invocation still announces itself and the reason.
-        wrapper_profile.set_route("disabled");
+        profile::set_route("disabled");
         return passthrough::run_passthrough(args, Some("ZCCACHE_DISABLE is set"));
     }
 
@@ -120,15 +116,15 @@ fn run_wrap_routed(
     let _ = std::env::set_current_dir(std::env::temp_dir());
 
     // Everything above is wrapper setup; everything below is the routed call.
-    wrapper_profile.mark_setup_done();
+    profile::mark_setup_done();
 
     match routing::classify_invocation(&args[0], &tool_args) {
         WrapperRoute::Formatter => {
-            wrapper_profile.set_route("formatter");
+            profile::set_route("formatter");
             rustfmt::run_rustfmt_cached(&wrapped_tool, &tool_args, &cwd, None)
         }
         WrapperRoute::LinkOrArchive => {
-            wrapper_profile.set_route("link_or_archive");
+            profile::set_route("link_or_archive");
             run_async(ipc::cmd_link_ephemeral(
                 &endpoint,
                 &wrapped_tool,
@@ -140,11 +136,11 @@ fn run_wrap_routed(
         // Silent by design: probe callers parse the tool's stderr, so a
         // warning line here would corrupt the probe (see run_passthrough).
         WrapperRoute::ProbeBypass => {
-            wrapper_profile.set_route(profile::ROUTE_PROBE_BYPASS);
+            profile::set_route(profile::ROUTE_PROBE_BYPASS);
             passthrough::run_passthrough(args, None)
         }
         WrapperRoute::Compile => {
-            wrapper_profile.set_route("compile");
+            profile::set_route("compile");
             run_compile_route(
                 &endpoint,
                 &args[0],

--- a/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
@@ -24,7 +24,10 @@ pub(super) async fn cmd_compile(
     // client's timeout becomes a kill chain through a `-j16` herd.
     let served_by = current_daemon_instance();
     let mut conn = match connect(endpoint).await {
-        Ok(c) => c,
+        Ok(c) => {
+            super::profile::mark_connected();
+            c
+        }
         Err(e) => {
             let reason = format!("cannot connect to daemon at {endpoint}: {e}");
             emit_client_disconnected_event(
@@ -77,6 +80,8 @@ pub(super) async fn cmd_compile(
         retry_bincode_on_explicit_wire_mismatch(endpoint, &request, selection, outcome).await;
     match outcome {
         CompileRecvOutcome::Done(recv_result) => {
+            // End of the daemon wait; everything after this is output work.
+            super::profile::mark_response();
             report_relay_outcome(relay_compile_response_to_stdio(recv_result))
         }
         CompileRecvOutcome::Wedged => {
@@ -571,6 +576,8 @@ async fn cmd_compile_ephemeral_with_stdin(
 
     match outcome {
         CompileRecvOutcome::Done(recv_result) => {
+            // End of the daemon wait; everything after this is output work.
+            super::profile::mark_response();
             report_relay_outcome(relay_compile_response_to_stdio(recv_result))
         }
         // #1170 change 2: this arm used to kill unconditionally. A busy
@@ -721,7 +728,10 @@ async fn run_ephemeral_attempt(
         );
     }
     let mut conn = match connect(endpoint).await {
-        Ok(c) => c,
+        Ok(c) => {
+            super::profile::mark_connected();
+            c
+        }
         Err(e) => {
             return failed_with_disconnect_event(
                 endpoint,

--- a/crates/zccache-cli-core/src/cli/commands/wrap/profile.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/profile.rs
@@ -2,18 +2,28 @@
 //!
 //! Every `ZCCACHE_PROFILE_*` surface in the tree is daemon-side, so the
 //! per-invocation path — argv parse, tool resolution, endpoint resolve, IPC
-//! roundtrip, output materialization — has never been measured. Attributing
-//! #1437's emscripten multi-file cold regression with the daemon's own
-//! `zccache_cc_miss_profile` accounted for 0.401s of a 1.071s gap; the
-//! remaining 0.670s is in this path, which nothing could see.
+//! roundtrip, output materialization — had no timing at all. This measures it.
 //!
-//! The line is emitted with `eprintln!` in the same `key=value` shape the
-//! daemon uses, so it lands in the same benchmark log and `benchmark_stats`
-//! can parse both. It is gated on the same env the daemon reads, which
-//! `benchmark_stats.py` already sets unconditionally — so existing campaign
-//! runs start carrying wrapper rows without a harness change.
+//! Correction to this module's original rationale: it justified itself by the
+//! unattributed remainder of #1437's emscripten cold gap. That was wrong. The
+//! perf benchmark reaches the daemon through an in-process `ClientConn`
+//! (`perf_bench/cpp_project.rs`) and never runs the wrapper, so nothing here
+//! can explain that gap. What holds is the coverage claim: the path every
+//! real user takes, once per compile, was unmeasured.
+//!
+//! The row is emitted with `eprintln!` in the same `key=value` shape the
+//! daemon uses, so it lands in the same log and one parse gets both halves.
+//! It is gated on the same env the daemon reads.
+//!
+//! State is process-global rather than a handle threaded through the call
+//! graph. The wrapper process serves exactly one invocation, and the marks
+//! that matter sit several frames deep inside the IPC path — behind an
+//! ephemeral-session fallback that recurses — so threading a handle there
+//! would reshape signatures across the whole route for instrumentation that
+//! is off by default. Atomics also survive `run_async` moving the work onto a
+//! tokio worker thread, which a `thread_local` would not.
 
-use std::cell::Cell;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 use std::time::Instant;
 
@@ -21,183 +31,188 @@ use std::time::Instant;
 /// halves of a single invocation's timing.
 const PROFILE_ENV: &str = "ZCCACHE_PROFILE_CC_MISS";
 
-/// The one route that must stay silent on stderr; see [`WrapperProfile::emit`].
+/// The one route that must stay silent on stderr; see [`emit`].
 pub(crate) const ROUTE_PROBE_BYPASS: &str = "probe_bypass";
 
+/// Sentinel for a phase that was never reached — a compile that fails to
+/// connect never records a response, and `0` would read as "instant".
+const UNSET: u64 = u64::MAX;
+
+static START: OnceLock<Option<Instant>> = OnceLock::new();
+static ROUTE: OnceLock<&'static str> = OnceLock::new();
+static SETUP_NS: AtomicU64 = AtomicU64::new(UNSET);
+static CONNECTED_NS: AtomicU64 = AtomicU64::new(UNSET);
+static RESPONSE_NS: AtomicU64 = AtomicU64::new(UNSET);
+
 /// Cached env lookup, matching the `OnceLock` pattern `zccache-depgraph`
-/// already uses for this variable (`graph/mod.rs`). The wrapper runs once per
-/// compile, so this is read on the hot path.
+/// already uses for this variable (`graph/mod.rs`).
 fn enabled() -> bool {
     static FLAG: OnceLock<bool> = OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os(PROFILE_ENV).is_some())
 }
 
-/// Phase timing for one wrapper invocation.
-///
-/// Inert unless [`PROFILE_ENV`] is set: `start` is `None`, every mark is a
-/// branch, and nothing is printed. Interior mutability keeps the handle
-/// shareable by `&` through the routing code without threading `&mut`.
-pub(crate) struct WrapperProfile {
-    start: Option<Instant>,
-    setup_ns: Cell<u64>,
-    route: Cell<&'static str>,
+fn started_at() -> Option<Instant> {
+    *START.get_or_init(|| enabled().then(Instant::now))
 }
 
-impl WrapperProfile {
-    pub(crate) fn start() -> Self {
-        Self {
-            start: enabled().then(Instant::now),
-            setup_ns: Cell::new(0),
-            route: Cell::new("none"),
-        }
-    }
+fn elapsed_ns(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_nanos()).unwrap_or(UNSET - 1)
+}
 
-    /// Everything before the invocation is routed: argv checks, strict-paths
-    /// resolution, tool-path resolution, client env, endpoint resolve.
-    pub(crate) fn mark_setup_done(&self) {
-        if let Some(start) = self.start {
-            self.setup_ns.set(elapsed_ns(start));
-        }
-    }
-
-    /// Routes seen in the field: `compile`, `link_or_archive`, `formatter`,
-    /// `probe_bypass`, `disabled`, and `none` for an argv error that returns
-    /// before routing. Labelling the early returns keeps a row from looking
-    /// like a routing bug when it is really an opt-out.
-    pub(crate) fn set_route(&self, route: &'static str) {
-        if self.start.is_some() {
-            self.route.set(route);
-        }
-    }
-
-    /// Whether [`emit`](Self::emit) would print. Exists so the silence
-    /// contract is assertable without capturing stderr.
-    pub(crate) fn would_emit(&self) -> bool {
-        self.start.is_some() && self.route.get() != ROUTE_PROBE_BYPASS
-    }
-
-    /// Emit the row. `dispatch_ns` is the whole routed call — IPC connect,
-    /// request, the daemon's own work, response, and output materialization.
-    /// Subtracting the daemon's `total_ns` for the same compile leaves the
-    /// out-of-daemon cost that #1460 exists to expose.
-    ///
-    /// Never emits on the probe-bypass route. Probe callers parse the tool's
-    /// stderr, which is why `run_passthrough` is silent there — and
-    /// `benchmark_stats.py` sets the profiling env *unconditionally*, so
-    /// without this guard a probe during a benchmark run would be corrupted
-    /// by the very instrumentation added to measure that run.
-    pub(crate) fn emit(&self) {
-        let Some(start) = self.start else {
-            return;
-        };
-        if !self.would_emit() {
-            return;
-        }
-        let total_ns = elapsed_ns(start);
-        let setup_ns = self.setup_ns.get();
-        eprintln!(
-            "zccache_wrapper_profile route={} total_ns={} setup_ns={} dispatch_ns={}",
-            self.route.get(),
-            total_ns,
-            setup_ns,
-            total_ns.saturating_sub(setup_ns),
+fn mark(slot: &AtomicU64) {
+    if let Some(start) = started_at() {
+        // First writer wins. A failed connect retries through the ephemeral
+        // fallback and connects twice; the first is the one the setup phase
+        // precedes, so later marks must not overwrite it.
+        let _ = slot.compare_exchange(
+            UNSET,
+            elapsed_ns(start),
+            Ordering::AcqRel,
+            Ordering::Acquire,
         );
     }
 }
 
-fn elapsed_ns(start: Instant) -> u64 {
-    u64::try_from(start.elapsed().as_nanos()).unwrap_or(u64::MAX)
+/// Begin timing. Inert unless [`PROFILE_ENV`] is set.
+pub(crate) fn start() {
+    let _ = started_at();
+}
+
+/// Everything before the invocation is routed: argv checks, strict-paths
+/// resolution, tool-path resolution, client env, endpoint resolve.
+pub(crate) fn mark_setup_done() {
+    mark(&SETUP_NS);
+}
+
+/// The daemon connection is open — end of client-side connect cost.
+pub(crate) fn mark_connected() {
+    mark(&CONNECTED_NS);
+}
+
+/// The daemon's response has arrived — end of the wait, start of output work.
+pub(crate) fn mark_response() {
+    mark(&RESPONSE_NS);
+}
+
+pub(crate) fn set_route(route: &'static str) {
+    if started_at().is_some() {
+        let _ = ROUTE.set(route);
+    }
+}
+
+fn route() -> &'static str {
+    ROUTE.get().copied().unwrap_or("none")
+}
+
+/// Whether [`emit`] would print. Exists so the silence contract is assertable
+/// without capturing stderr.
+pub(crate) fn would_emit() -> bool {
+    started_at().is_some() && route() != ROUTE_PROBE_BYPASS
+}
+
+/// Difference between two marks, or `None` if either was never reached.
+fn span(from: u64, to: u64) -> Option<u64> {
+    (from != UNSET && to != UNSET).then(|| to.saturating_sub(from))
+}
+
+fn render(total_ns: u64, setup: u64, connected: u64, response: u64) -> String {
+    // A phase that was not reached prints -1 rather than 0, so "never
+    // happened" cannot be misread as "took no time".
+    let field = |value: Option<u64>| value.map_or_else(|| "-1".to_string(), |ns| ns.to_string());
+    format!(
+        "zccache_wrapper_profile route={} total_ns={} setup_ns={} connect_ns={} \
+         wait_ns={} post_ns={}",
+        route(),
+        total_ns,
+        field(span(0, setup)),
+        field(span(setup, connected)),
+        field(span(connected, response)),
+        field(span(response, total_ns)),
+    )
+}
+
+/// Emit the row.
+///
+/// Never emits on the probe-bypass route. Probe callers parse the tool's
+/// stderr, which is why `run_passthrough` is silent there — and
+/// `benchmark_stats.py` sets the profiling env *unconditionally*, so without
+/// this guard a probe during a benchmark run would be corrupted by the very
+/// instrumentation added to measure that run.
+pub(crate) fn emit() {
+    let Some(start) = started_at() else {
+        return;
+    };
+    if !would_emit() {
+        return;
+    }
+    eprintln!(
+        "{}",
+        render(
+            elapsed_ns(start),
+            SETUP_NS.load(Ordering::Acquire),
+            CONNECTED_NS.load(Ordering::Acquire),
+            RESPONSE_NS.load(Ordering::Acquire),
+        )
+    );
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // `render` and `span` are pure, so the phase arithmetic is testable
+    // without touching the process-global marks — which a single test binary
+    // shares and which are deliberately write-once.
+
     #[test]
-    fn a_disabled_profile_records_nothing() {
-        // Constructed directly rather than via `start()`, which reads a
-        // process-global env through a OnceLock and would make this test
-        // order-dependent.
-        let profile = WrapperProfile {
-            start: None,
-            setup_ns: Cell::new(0),
-            route: Cell::new("none"),
-        };
-
-        profile.mark_setup_done();
-        profile.set_route("compile");
-
-        assert_eq!(profile.setup_ns.get(), 0);
-        assert_eq!(
-            profile.route.get(),
-            "none",
-            "a disabled profile must not even record the route"
-        );
-        profile.emit();
+    fn spans_are_differences_between_marks() {
+        assert_eq!(span(0, 100), Some(100));
+        assert_eq!(span(100, 250), Some(150));
     }
 
     #[test]
-    fn an_enabled_profile_records_setup_and_route() {
-        let profile = WrapperProfile {
-            start: Some(Instant::now()),
-            setup_ns: Cell::new(0),
-            route: Cell::new("none"),
-        };
-
-        profile.set_route("compile");
-        profile.mark_setup_done();
-
-        assert_eq!(profile.route.get(), "compile");
-        // Any real elapsed time is fine; the contract is that it was taken,
-        // not how long it was. Asserting a duration here would be exactly the
-        // wall-clock mistake PERF.md warns about.
-        assert!(profile.setup_ns.get() > 0);
+    fn an_unreached_mark_has_no_span() {
+        assert_eq!(span(100, UNSET), None);
+        assert_eq!(span(UNSET, 100), None);
     }
 
     #[test]
-    fn dispatch_is_the_remainder_after_setup() {
-        let start = Instant::now();
-        let profile = WrapperProfile {
-            start: Some(start),
-            setup_ns: Cell::new(0),
-            route: Cell::new("compile"),
-        };
-        profile.mark_setup_done();
-
-        let total = elapsed_ns(start);
-        assert!(
-            total >= profile.setup_ns.get(),
-            "setup is a prefix of total, so dispatch can never be negative"
-        );
+    fn a_span_never_goes_negative() {
+        // Marks are monotonic in practice; saturating means a reordering bug
+        // surfaces as 0 rather than an absurd u64.
+        assert_eq!(span(250, 100), Some(0));
     }
 
     #[test]
-    fn the_probe_bypass_route_is_never_emitted() {
-        // `run_passthrough` is silent on this route because probe callers
-        // parse the tool's stderr, and `benchmark_stats.py` sets the profiling
-        // env unconditionally -- so an unguarded emit would corrupt probes
-        // during exactly the benchmark runs this instrumentation serves.
-        let profile = WrapperProfile {
-            start: Some(Instant::now()),
-            setup_ns: Cell::new(0),
-            route: Cell::new(ROUTE_PROBE_BYPASS),
-        };
+    fn unreached_phases_render_as_minus_one_not_zero() {
+        // A compile that never connected must not report "connect took 0ns".
+        let line = render(500, 100, UNSET, UNSET);
 
-        assert!(
-            !profile.would_emit(),
-            "probe-bypass must stay silent even with profiling enabled"
-        );
+        assert!(line.contains("setup_ns=100"), "{line}");
+        assert!(line.contains("connect_ns=-1"), "{line}");
+        assert!(line.contains("wait_ns=-1"), "{line}");
+        assert!(line.contains("post_ns=-1"), "{line}");
     }
 
     #[test]
-    fn other_routes_do_emit_when_enabled() {
-        for route in ["compile", "link_or_archive", "formatter"] {
-            let profile = WrapperProfile {
-                start: Some(Instant::now()),
-                setup_ns: Cell::new(0),
-                route: Cell::new(route),
-            };
-            assert!(profile.would_emit(), "{route} should emit");
-        }
+    fn a_complete_invocation_renders_every_phase() {
+        let line = render(1000, 100, 250, 900);
+
+        assert!(line.contains("total_ns=1000"), "{line}");
+        assert!(line.contains("setup_ns=100"), "{line}");
+        assert!(line.contains("connect_ns=150"), "{line}");
+        assert!(line.contains("wait_ns=650"), "{line}");
+        assert!(line.contains("post_ns=100"), "{line}");
+    }
+
+    #[test]
+    fn phases_sum_to_the_total() {
+        let (total, setup, connected, response) = (1000u64, 100u64, 250u64, 900u64);
+        let parts = span(0, setup).unwrap()
+            + span(setup, connected).unwrap()
+            + span(connected, response).unwrap()
+            + span(response, total).unwrap();
+
+        assert_eq!(parts, total, "phases must account for the whole invocation");
     }
 }


### PR DESCRIPTION
Addresses #1460 phase 2 — **does not close it**.

## What it adds

Phase 1 (#1461) reported one `dispatch_ns` covering the whole routed call. This decomposes it, which is what makes the row useful:

```
route=compile total_ns=6702641800 setup_ns=60629900 \
  connect_ns=3826376900 wait_ns=2814970400 post_ns=664600
```

`wait_ns` is the **join against the daemon's own `total_ns`** for the same compile — the difference is the out-of-daemon cost #1460 exists to expose. On that cold invocation the daemon spawn inside `connect` dominates everything else, which no existing instrument could show.

## Design: process-global atomics

The marks sit several frames deep — inside `run_ephemeral_attempt`, behind a fallback that recurses — so threading a handle would reshape signatures across the whole route for instrumentation that is off by default. Atomics also survive `run_async` moving work onto a tokio worker thread, which a `thread_local` would not.

Marks are **first-writer-wins**, so a retry that connects twice keeps the first connect — the one `setup` precedes.

## Unreached phases render as -1, not 0

Verified against a real failure rather than a contrived one. With the daemon in a recovery cool-down the wrapper exits **125** and prints:

```
connect_ns=-1 wait_ns=-1 post_ns=-1
```

Had those been `0`, the row would have claimed an instant connect on a run that never connected.

## End-to-end testing caught a gap unit tests could not

I first instrumented only `cmd_compile`, which requires `ZCCACHE_SESSION_ID`. Without it the route goes to `cmd_compile_ephemeral` — so **the common shape reported -1 for every phase**. Both paths are marked now. Nothing in the unit tests would have surfaced that.

## Corrects the module's rationale in place

The doc comment justified this instrumentation by #1437's unattributed remainder. That was wrong — the perf benchmark reaches the daemon through an in-process `ClientConn` and never runs the wrapper. I retracted it on the issues; leaving a retracted premise sitting in the source would be worse. The coverage claim is what holds, and the comment now says so.

## Validation

```
soldr cargo test -p zccache-cli-core --features cli --lib  -> 268 passed, 0 failed
soldr cargo clippy -p zccache-cli-core --features cli --all-targets -> clean
```

Live invocations cover success, daemon-unavailable (exit 125), `ZCCACHE_DISABLE`, and env-unset silence.

A note on clippy: I had been running it with `RUSTFLAGS="-D warnings"`, which is **stricter than this repo's policy** — CI deliberately omits `-D warnings` on clippy per #944, relying on the workspace `[lints.clippy]` deny-list. Under that flag three pre-existing style lints in `engine_profile.rs` surface on clean `main`; they are unrelated to this change and not failures by repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
