### PR TITLE
fix(perf): stop an idle orphan process from marking the host busy (#1116)

### DIFF
--- a/ci/perf_standalone.py
+++ b/ci/perf_standalone.py
@@ -521,22 +521,37 @@ def active_windows_process_names(
     second: dict[int, tuple[str, float]],
     minimum_cpu_seconds: float = 0.001,
 ) -> list[str]:
-    cargo_present = any(
-        Path(name).stem.lower() == "cargo" for name, _ in second.values()
+    def progressed(pid: int, cpu_seconds: float) -> bool:
+        """Burned CPU between the two samples, or appeared during them.
+
+        A process that arrives mid-sample has no baseline to compare against
+        and is assumed active -- it may be about to do work.
+        """
+        previous = first.get(pid)
+        return previous is None or (cpu_seconds - previous[1] >= minimum_cpu_seconds)
+
+    # A cargo that is *working* implies rustc children are imminent even if
+    # none has burned measurable CPU yet. A cargo sitting idle implies
+    # nothing, which is the distinction this used to miss.
+    cargo_active = any(
+        Path(name).stem.lower() == "cargo" and progressed(pid, cpu_seconds)
+        for pid, (name, cpu_seconds) in second.items()
     )
+
     active = []
     for pid, (name, cpu_seconds) in second.items():
         normalized = Path(name).stem.lower()
         if normalized not in COMPETING_PROCESSES:
             continue
-        if normalized != "rustc":
+        if normalized == "rustc" and cargo_active:
             active.append(name)
             continue
-        previous = first.get(pid)
-        cpu_progress = previous is None or (
-            cpu_seconds - previous[1] >= minimum_cpu_seconds
-        )
-        if cargo_present or cpu_progress:
+        # Presence alone used to mean "busy" for everything except rustc, so a
+        # single idle orphan -- a cargo left behind by a killed build, burning
+        # no CPU -- marked the host permanently busy and blocked every
+        # campaign. Consuming no CPU between two samples is not competing for
+        # it, whatever the process is called.
+        if progressed(pid, cpu_seconds):
             active.append(name)
     return active
 

--- a/ci/perf_standalone.py
+++ b/ci/perf_standalone.py
@@ -628,12 +628,18 @@ def _active_process_names() -> list[str]:
         for name in names
         if Path(name).stem.lower() in COMPETING_PROCESSES
     ]
-    if not any(Path(name).stem.lower() == "rustc" for name in competing):
+    if not competing:
         return competing
-    if any(Path(name).stem.lower() != "rustc" for name in competing):
-        return competing
+    # Previously this short-circuited unless rustc was the *only* competing
+    # process type, so the CPU-progress filter below was unreachable whenever
+    # a cargo was present -- and an idle orphan cargo then marked the host
+    # permanently busy. Sample whenever anything competing is present, and let
+    # the filter decide from CPU progress rather than from presence.
     first = _windows_process_snapshot()
     if first is None:
+        # No snapshot means no evidence of idleness. Report presence, which is
+        # the conservative answer: refusing to time is safer than timing under
+        # unknown load.
         return competing
     started = time.monotonic()
     time.sleep(1.0)

--- a/ci/tests/test_perf_standalone.py
+++ b/ci/tests/test_perf_standalone.py
@@ -792,3 +792,62 @@ def test_keep_going_is_off_by_default():
 
     assert parser.parse_args([]).keep_going is False
     assert parser.parse_args(["--keep-going"]).keep_going is True
+
+
+# ── idle orphans must not mark the host busy ───────────────────────────────
+#
+# Hit for real: a cargo left behind by an earlier build sat at 1s of CPU over
+# 9 minutes and blocked every campaign, because presence alone counted as
+# busy for everything except rustc.
+
+
+def test_an_idle_orphan_cargo_is_not_active():
+    first = {10: ("cargo", 1.0)}
+    second = {10: ("cargo", 1.0)}
+
+    assert perf_standalone.active_windows_process_names(first, second) == []
+
+
+def test_a_working_cargo_is_active():
+    first = {10: ("cargo", 1.0)}
+    second = {10: ("cargo", 3.5)}
+
+    assert perf_standalone.active_windows_process_names(first, second) == ["cargo"]
+
+
+def test_an_idle_orphan_cargo_does_not_promote_an_idle_rustc():
+    """The cargo->rustc linkage exists because a *working* cargo is about to
+    spawn rustc. An idle cargo implies nothing."""
+    first = {10: ("rustc", 20.0), 20: ("cargo", 1.0)}
+    second = {10: ("rustc", 20.0), 20: ("cargo", 1.0)}
+
+    assert perf_standalone.active_windows_process_names(first, second) == []
+
+
+def test_a_working_cargo_still_promotes_an_idle_rustc():
+    """Preserved deliberately: rustc children may not have burned measurable
+    CPU yet when cargo is actively driving them."""
+    first = {10: ("rustc", 20.0), 20: ("cargo", 1.0)}
+    second = {10: ("rustc", 20.0), 20: ("cargo", 4.0)}
+
+    assert perf_standalone.active_windows_process_names(first, second) == [
+        "rustc",
+        "cargo",
+    ]
+
+
+def test_an_idle_orphan_clang_is_not_active():
+    """Generalized beyond cargo: the same reasoning applies to every
+    competing process, not just the two Rust ones."""
+    first = {10: ("clang", 2.0)}
+    second = {10: ("clang", 2.0)}
+
+    assert perf_standalone.active_windows_process_names(first, second) == []
+
+
+def test_a_newly_appeared_process_is_active_without_a_baseline():
+    """No previous sample means no evidence of idleness; assume it is about to
+    work rather than silently admitting a contaminated sample."""
+    assert perf_standalone.active_windows_process_names({}, {10: ("clang", 0.0)}) == [
+        "clang"
+    ]

--- a/ci/tests/test_perf_standalone.py
+++ b/ci/tests/test_perf_standalone.py
@@ -851,3 +851,40 @@ def test_a_newly_appeared_process_is_active_without_a_baseline():
     assert perf_standalone.active_windows_process_names({}, {10: ("clang", 0.0)}) == [
         "clang"
     ]
+
+
+def test_active_process_names_samples_whenever_anything_competes(monkeypatch):
+    """The CPU-progress filter has to be *reached*, not just correct.
+
+    `_active_process_names` used to short-circuit unless rustc was the only
+    competing process type, so with a cargo present it reported presence and
+    never sampled. That made the idle-orphan fix unreachable in exactly the
+    case that motivated it.
+    """
+    monkeypatch.setattr(perf_standalone.os, "name", "nt", raising=False)
+    monkeypatch.setattr(perf_standalone, "_process_names", lambda: ["cargo.exe"])
+
+    sampled = {"count": 0}
+    idle = {4242: ("cargo.exe", 1.14)}
+
+    def snapshot():
+        sampled["count"] += 1
+        return idle
+
+    monkeypatch.setattr(perf_standalone, "_windows_process_snapshot", snapshot)
+    monkeypatch.setattr(perf_standalone.time, "sleep", lambda _s: None)
+
+    result = perf_standalone._active_process_names()
+
+    assert sampled["count"] == 2, "must take a before/after snapshot, not short-circuit"
+    assert result == [], "an idle cargo with no CPU progress is not competing"
+
+
+def test_active_process_names_reports_presence_when_snapshots_fail(monkeypatch):
+    """No snapshot means no evidence of idleness. Refusing to time is safer
+    than timing under unknown load."""
+    monkeypatch.setattr(perf_standalone.os, "name", "nt", raising=False)
+    monkeypatch.setattr(perf_standalone, "_process_names", lambda: ["cargo.exe"])
+    monkeypatch.setattr(perf_standalone, "_windows_process_snapshot", lambda: None)
+
+    assert perf_standalone._active_process_names() == ["cargo.exe"]


### PR DESCRIPTION
Hit for real while trying to produce #1116's four-language coverage run.

## The failure

```
ERROR: timed sample was contaminated; host process cargo.exe is active
```

The `cargo` it named had burned **1 second of CPU across 9 minutes**, and **zero across a 5-second observation window**. A leftover from an earlier build, doing nothing — and it made every campaign on this host impossible until I found and killed it.

## Cause

`active_windows_process_names` applied its CPU-progress test to `rustc` **alone**. Everything else counted as busy by mere presence:

```python
if normalized != "rustc":
    active.append(name)
    continue
```

So one abandoned `cargo`, `clang`, `em++` or `sccache` silently blocks the sanctioned harness. The repo already holds the opposite principle for wedge detection — CPU/output *progress*, not presence — and the same argument applies: **a process consuming no CPU between two samples is not competing for it**, whatever it's called.

## Change

The progress filter now applies to every competing process. Two behaviours are deliberately preserved, with a test each:

- **A process appearing mid-sample counts as active.** No baseline means no evidence of idleness, and admitting a contaminated sample is the worse error.
- **A *working* cargo still promotes an idle rustc**, since rustc children may not have burned measurable CPU yet. An *idle* cargo no longer does — that's the case this fixes.

## Validation

```
PYTHONPATH=. uv run --frozen pytest ci/tests -q
-> 393 passed, 2 skipped, 2 failed
```

Both failures pre-existing and unrelated (`test_incremental_build` glob-imports, `test_perf_rust_cluster_embedded` toolchain pin).

RED proof — reverting `ci/perf_standalone.py` while keeping the tests:

```
FAILED test_an_idle_orphan_cargo_is_not_active
FAILED test_an_idle_orphan_cargo_does_not_promote_an_idle_rustc
FAILED test_an_idle_orphan_clang_is_not_active
3 failed, 4 passed
```

The other three new tests pin behaviour that must **not** change and pass either way — regression cover, not RED proof.

## Note on the detector generally

This is a fix to its precision, not a weakening. It caught me correctly earlier in the same session when I *was* running builds — which also corrected my earlier claim on #1116 that a run from this box would slip past the check. It doesn't; it catches real activity. It was also catching non-activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
