### PR TITLE
docs(perf): explain why the Windows sample path skips container exclusion

### DIFF
--- a/ci/perf_standalone.py
+++ b/ci/perf_standalone.py
@@ -511,6 +511,28 @@ def _linux_sample_process_names(container_name: str) -> list[str]:
 
 
 def _sample_process_names(container_name: str, finished: bool) -> list[str]:
+    """Competing processes seen during a timed sample.
+
+    The Windows branch deliberately skips the container-tree exclusion that
+    #1438 added for Linux, and that is safe for a reason worth stating rather
+    than leaving implicit: under Docker Desktop's WSL2 backend, container
+    processes live in the WSL VM and are **invisible** to Windows process
+    enumeration. Verified directly -- a container running a process named
+    `rustc` yields zero hits from `Get-Process rustc` on the host -- so the
+    sample cannot flag its own container work no matter what it compiles.
+
+    Two consequences:
+
+    - Adding the exclusion here would be dead code. Container PIDs are Linux
+      PIDs in the VM and would never match a Windows PID.
+    - The safety is a property of the *backend*, not of a guard in this file.
+      If the Docker backend ever changes to one whose container processes are
+      visible to the host (Windows containers, process isolation), a campaign
+      would start flagging itself and this branch would need a real exclusion.
+
+    `finished` takes the same path because a completed sample has no container
+    tree left to exclude.
+    """
     if os.name == "nt" or finished:
         return _active_process_names()
     return _linux_sample_process_names(container_name)


### PR DESCRIPTION
Found while ruling out a suspect during #1116's contamination debugging.

## The thing that looks like a bug

`_sample_process_names` sends Windows down a path that does **not** exclude the sample container's process tree, unlike the Linux path #1438 added:

```python
if os.name == "nt" or finished:
    return _active_process_names()      # no container filtering
return _linux_sample_process_names(container_name)
```

I spent real time treating that as the cause of my contamination failures — "the campaign is flagging its own container work" is a tidy explanation that fits the symptoms.

## Why it isn't

Under Docker Desktop's WSL2 backend, container processes live in the WSL VM and are **invisible** to Windows process enumeration. Verified directly rather than assumed — ran a container with a process named `rustc` and checked the host:

```
Windows sees container rustc processes: 0
```

So the sample cannot flag its own container work, whatever it compiles.

## Two consequences, now written down

- **Adding the exclusion here would be dead code.** Container PIDs are Linux PIDs in the VM and never match a Windows PID, so the filter could not fire.
- **The safety is a property of the backend, not of any guard in this file.** A backend whose container processes are host-visible — Windows containers, process isolation — would make campaigns start flagging themselves, and this branch would then need a real exclusion.

## Scope

Documentation only, no behaviour change. The value is that the next person to notice the asymmetry doesn't repeat the investigation, and doesn't "fix" it by adding a filter that cannot match anything.

## Validation

```
PYTHONPATH=. uv run --frozen pytest ci/tests -q
-> 395 passed, 2 skipped, 2 failed
```

Both failures pre-existing and unrelated (`test_incremental_build` glob-imports, `test_perf_rust_cluster_embedded` toolchain pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
