### PR TITLE
feat(wrap): separate request send from the daemon wait (#1460)

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
@@ -60,7 +60,9 @@ pub(super) async fn cmd_compile(
         env: Some(client_env.clone()),
         stdin: stdin_bytes.clone(),
     };
-    if let Err(e) = conn.send_request(&request, wire).await {
+    let send_result = conn.send_request(&request, wire).await;
+    super::profile::mark_request_sent();
+    if let Err(e) = send_result {
         let failure = TransportFailure {
             message: format!("failed to send to daemon: {e}"),
             phase: FailurePhase::DeliveryUnknown,
@@ -743,7 +745,9 @@ async fn run_ephemeral_attempt(
     };
     let selection = crate::protocol::wire_prost::full_family_wire_selection_from_env();
     let wire = selection.preferred_format();
-    if let Err(e) = conn.send_request(request, wire).await {
+    let send_result = conn.send_request(request, wire).await;
+    super::profile::mark_request_sent();
+    if let Err(e) = send_result {
         return failed_with_disconnect_event(
             endpoint,
             crate::core::lifecycle::CAUSE_PIPE_CLOSED_MID_WRITE,

--- a/crates/zccache-cli-core/src/cli/commands/wrap/profile.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/profile.rs
@@ -42,6 +42,7 @@ static START: OnceLock<Option<Instant>> = OnceLock::new();
 static ROUTE: OnceLock<&'static str> = OnceLock::new();
 static SETUP_NS: AtomicU64 = AtomicU64::new(UNSET);
 static CONNECTED_NS: AtomicU64 = AtomicU64::new(UNSET);
+static SENT_NS: AtomicU64 = AtomicU64::new(UNSET);
 static RESPONSE_NS: AtomicU64 = AtomicU64::new(UNSET);
 
 /// Cached env lookup, matching the `OnceLock` pattern `zccache-depgraph`
@@ -89,6 +90,15 @@ pub(crate) fn mark_connected() {
     mark(&CONNECTED_NS);
 }
 
+/// The request is on the wire — end of encode/send, start of the daemon wait.
+///
+/// Splitting this out is what makes `wait_ns` comparable to the daemon's own
+/// `total_ns`: without it, request encoding and transmission were folded into
+/// the same number as the daemon's work.
+pub(crate) fn mark_request_sent() {
+    mark(&SENT_NS);
+}
+
 /// The daemon's response has arrived — end of the wait, start of output work.
 pub(crate) fn mark_response() {
     mark(&RESPONSE_NS);
@@ -115,18 +125,19 @@ fn span(from: u64, to: u64) -> Option<u64> {
     (from != UNSET && to != UNSET).then(|| to.saturating_sub(from))
 }
 
-fn render(total_ns: u64, setup: u64, connected: u64, response: u64) -> String {
+fn render(total_ns: u64, setup: u64, connected: u64, sent: u64, response: u64) -> String {
     // A phase that was not reached prints -1 rather than 0, so "never
     // happened" cannot be misread as "took no time".
     let field = |value: Option<u64>| value.map_or_else(|| "-1".to_string(), |ns| ns.to_string());
     format!(
         "zccache_wrapper_profile route={} total_ns={} setup_ns={} connect_ns={} \
-         wait_ns={} post_ns={}",
+         send_ns={} wait_ns={} post_ns={}",
         route(),
         total_ns,
         field(span(0, setup)),
         field(span(setup, connected)),
-        field(span(connected, response)),
+        field(span(connected, sent)),
+        field(span(sent, response)),
         field(span(response, total_ns)),
     )
 }
@@ -151,6 +162,7 @@ pub(crate) fn emit() {
             elapsed_ns(start),
             SETUP_NS.load(Ordering::Acquire),
             CONNECTED_NS.load(Ordering::Acquire),
+            SENT_NS.load(Ordering::Acquire),
             RESPONSE_NS.load(Ordering::Acquire),
         )
     );
@@ -186,31 +198,46 @@ mod tests {
     #[test]
     fn unreached_phases_render_as_minus_one_not_zero() {
         // A compile that never connected must not report "connect took 0ns".
-        let line = render(500, 100, UNSET, UNSET);
+        let line = render(500, 100, UNSET, UNSET, UNSET);
 
         assert!(line.contains("setup_ns=100"), "{line}");
         assert!(line.contains("connect_ns=-1"), "{line}");
+        assert!(line.contains("send_ns=-1"), "{line}");
         assert!(line.contains("wait_ns=-1"), "{line}");
         assert!(line.contains("post_ns=-1"), "{line}");
     }
 
     #[test]
+    fn a_send_that_never_completed_leaves_wait_unreported() {
+        // Connected, then the send failed: connect is real, everything after
+        // it is not. Reporting wait_ns=0 here would invent a daemon that
+        // answered instantly.
+        let line = render(500, 100, 250, UNSET, UNSET);
+
+        assert!(line.contains("connect_ns=150"), "{line}");
+        assert!(line.contains("send_ns=-1"), "{line}");
+        assert!(line.contains("wait_ns=-1"), "{line}");
+    }
+
+    #[test]
     fn a_complete_invocation_renders_every_phase() {
-        let line = render(1000, 100, 250, 900);
+        let line = render(1000, 100, 250, 300, 900);
 
         assert!(line.contains("total_ns=1000"), "{line}");
         assert!(line.contains("setup_ns=100"), "{line}");
         assert!(line.contains("connect_ns=150"), "{line}");
-        assert!(line.contains("wait_ns=650"), "{line}");
+        assert!(line.contains("send_ns=50"), "{line}");
+        assert!(line.contains("wait_ns=600"), "{line}");
         assert!(line.contains("post_ns=100"), "{line}");
     }
 
     #[test]
     fn phases_sum_to_the_total() {
-        let (total, setup, connected, response) = (1000u64, 100u64, 250u64, 900u64);
+        let (total, setup, connected, sent, response) = (1000u64, 100u64, 250u64, 300u64, 900u64);
         let parts = span(0, setup).unwrap()
             + span(setup, connected).unwrap()
-            + span(connected, response).unwrap()
+            + span(connected, sent).unwrap()
+            + span(sent, response).unwrap()
             + span(response, total).unwrap();
 
         assert_eq!(parts, total, "phases must account for the whole invocation");


### PR DESCRIPTION
Addresses #1460 — **does not close it**.

## Why

#1464 split the wrapper row into `setup / connect / wait / post`. But `wait_ns` folded request encoding and transmission in with the daemon's own work, which defeats the one thing that phase exists for: subtracting the daemon's `total_ns` from it to leave the out-of-daemon cost. Anything spent encoding and writing the request landed on the *daemon's* side of that subtraction.

## Live result

```
route=compile total_ns=13688265900 setup_ns=63576300 \
  connect_ns=9939483000 send_ns=641100 wait_ns=3683762500 post_ns=803000
```

`send` is 0.64ms against a 3.68s daemon wait. Small here — but it was previously *indistinguishable* from daemon time, and a request carrying 50 sources is not this shape.

## A claim of mine that stopped being true

I recorded on #1460 that this "wants the marks threaded through the IPC layer". That was true of the handle-passing design, and stopped being true when #1464 moved state to process-global atomics. Both send sites now take a one-line call, no signatures change, and the **ephemeral path** — the one that runs without `ZCCACHE_SESSION_ID`, i.e. the common case — is covered alongside the session path.

## Two things caught along the way

**A silent no-op.** My first edit changed `render`'s signature but failed to update its format string, leaving `sent` unused — the row would have been a four-phase line behind a five-phase signature, compiling and passing. `-D warnings` caught it.

**A 240-second hang that wasn't mine.** The live check hung and `my change hangs` was the obvious reading. It was two wedged `zccache-daemon` processes; clearing them fixed it immediately. Recording it because the tempting move was to revert.

Unreached phases still render `-1` rather than `0`, with a new test for the case this change introduces: connect succeeded, send failed. Reporting `wait_ns=0` there would invent a daemon that answered instantly.

## Validation

```
soldr cargo test -p zccache-cli-core --features cli --lib  -> 269 passed, 0 failed
soldr cargo clippy -p zccache-cli-core --features cli --all-targets -> clean
```

Live invocation covers compile, `ZCCACHE_DISABLE`, and env-unset silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
