### PR TITLE
feat(cli): cache archive extraction in `zccache fetch` (#1469)

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/args/mod.rs
+++ b/crates/zccache-cli-core/src/cli/commands/args/mod.rs
@@ -454,7 +454,17 @@ pub(crate) enum Commands {
         /// never reachable.
         #[arg(long, value_name = "DIGEST")]
         expect: Option<String>,
+        /// Unpack the fetched archive into the tree cache and print the
+        /// extracted directory instead of the archive blob.
+        ///
+        /// The extraction is itself cached, keyed by the archive digest
+        /// plus the format -- extraction and AV scanning dominate the
+        /// transfer for large toolchains, so caching only the bytes
+        /// leaves most of the cost in place (issue #1469).
+        #[arg(long)]
+        extract: bool,
         /// Emit `{"path":..,"digest":..,"outcome":..}` instead of the path.
+        /// With `--extract`, also `extracted` and `extraction`.
         #[arg(long)]
         json: bool,
     },

--- a/crates/zccache-cli-core/src/cli/commands/fetch.rs
+++ b/crates/zccache-cli-core/src/cli/commands/fetch.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use crate::download::{DownloadOptions, DownloadPhase};
+use crate::download_client::ArchiveFormat;
 
 /// KV namespace holding one revalidation record per URL. Lowercase and
 /// hyphenated to satisfy `zccache_artifact::kv::is_valid_namespace`.
@@ -84,18 +85,25 @@ impl FetchOutcome {
 ///
 /// Pure so the layout is testable without touching a filesystem.
 pub(crate) fn cas_path_for(root: &Path, digest_hex: &str) -> PathBuf {
-    let mut path = root.join(FETCH_DIR).join(CAS_DIR);
+    sharded(root.join(FETCH_DIR).join(CAS_DIR), digest_hex)
+}
+
+/// Shard `hex` under `base` as `<aa>/<bb>/<hex>`.
+///
+/// Shared by the blob CAS and the tree cache so the two layouts cannot drift.
+fn sharded(base: PathBuf, hex: &str) -> PathBuf {
+    let mut path = base;
     for level in 0..SHARD_LEVELS {
         let start = level * SHARD_BYTES * 2;
         let end = start + SHARD_BYTES * 2;
-        match digest_hex.get(start..end) {
+        match hex.get(start..end) {
             Some(part) => path.push(part),
             // A digest too short to shard is a caller bug; keep it addressable
             // rather than panicking in a CLI path.
             None => break,
         }
     }
-    path.join(digest_hex)
+    path.join(hex)
 }
 
 /// Stable per-URL key. blake3 of the URL bytes — an index into the record
@@ -192,7 +200,12 @@ async fn read_validators(url: &str) -> (Option<String>, Option<String>) {
     )
 }
 
-pub(crate) async fn cmd_fetch(url: &str, expect: Option<&str>, json: bool) -> ExitCode {
+pub(crate) async fn cmd_fetch(
+    url: &str,
+    expect: Option<&str>,
+    extract: bool,
+    json: bool,
+) -> ExitCode {
     // Validate the pin before any network work, so a typo fails immediately
     // rather than after a 30 MB transfer.
     if let Some(pin) = expect {
@@ -236,7 +249,15 @@ pub(crate) async fn cmd_fetch(url: &str, expect: Option<&str>, json: bool) -> Ex
                     }
                 }
             }
-            return report(&cached, &record.digest, FetchOutcome::Revalidated, json);
+            return finish(
+                &root,
+                url,
+                &cached,
+                &record.digest,
+                FetchOutcome::Revalidated,
+                extract,
+                json,
+            );
         }
     }
 
@@ -326,21 +347,219 @@ pub(crate) async fn cmd_fetch(url: &str, expect: Option<&str>, json: bool) -> Ex
         },
     );
 
-    report(&cas, &digest, outcome, json)
+    finish(&root, url, &cas, &digest, outcome, extract, json)
 }
 
-fn report(path: &Path, digest: &str, outcome: FetchOutcome, json: bool) -> ExitCode {
+/// Extracted trees live beside the blob CAS, sharded the same way.
+const TREES_DIR: &str = "trees";
+
+/// Domain separator for tree keys. Without it a tree key could collide with a
+/// blob digest, which is a bare blake3 of file bytes.
+const TREE_KEY_DOMAIN: &str = "zccache-fetch-tree-v1";
+
+/// Whether an extraction was served from cache or actually performed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExtractOutcome {
+    Cached,
+    Extracted,
+}
+
+impl ExtractOutcome {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Cached => "cached",
+            Self::Extracted => "extracted",
+        }
+    }
+}
+
+/// Stable tag per archive format, used in the tree key.
+///
+/// Written out rather than derived from `Debug` so that renaming a variant
+/// cannot silently invalidate every cached tree on disk.
+pub(crate) fn format_tag(format: ArchiveFormat) -> &'static str {
+    match format {
+        ArchiveFormat::Auto => "auto",
+        ArchiveFormat::None => "none",
+        ArchiveFormat::Zst => "zst",
+        ArchiveFormat::Zip => "zip",
+        ArchiveFormat::Xz => "xz",
+        ArchiveFormat::TarGz => "tar.gz",
+        ArchiveFormat::TarXz => "tar.xz",
+        ArchiveFormat::TarZst => "tar.zst",
+        ArchiveFormat::SevenZip => "7z",
+    }
+}
+
+/// Key for an extracted tree: archive digest + the extraction options that
+/// produced it.
+///
+/// This is the issue's open question answered as "yes" -- an extracted tree is
+/// a CAS entry in its own right. Keying on the *archive digest* rather than on
+/// the URL means two URLs serving identical bytes share one extraction, and an
+/// origin that changes its validator without changing content still hits.
+/// Including the format means a future flag that changes extraction output
+/// (strip-components, filters) extends this key instead of silently reusing a
+/// tree produced under different options.
+pub(crate) fn tree_key(archive_digest: &str, format: ArchiveFormat) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(TREE_KEY_DOMAIN.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(archive_digest.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(format_tag(format).as_bytes());
+    hasher.finalize().to_hex().to_string()
+}
+
+/// `<root>/fetch/trees/<aa>/<bb>/<hex>` for an extracted tree.
+pub(crate) fn tree_path_for(root: &Path, tree_key_hex: &str) -> PathBuf {
+    sharded(root.join(FETCH_DIR).join(TREES_DIR), tree_key_hex)
+}
+
+/// The archive file name implied by a URL, used only for format detection.
+///
+/// The CAS path has no extension -- it is a bare digest -- so the format has
+/// to come from the URL. Query and fragment are stripped first, because
+/// `...node.tar.gz?token=x` is common and would otherwise detect as `None`.
+pub(crate) fn archive_name_from_url(url: &str) -> String {
+    let without_fragment = url.split('#').next().unwrap_or(url);
+    let without_query = without_fragment
+        .split('?')
+        .next()
+        .unwrap_or(without_fragment);
+    without_query
+        .rsplit('/')
+        .find(|segment| !segment.is_empty())
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// Resolve the extraction format for a URL, or explain why it cannot be.
+fn extraction_format(url: &str) -> Result<ArchiveFormat, String> {
+    let name = archive_name_from_url(url);
+    let format = crate::download_client::artifact::archive::auto_archive_format(Path::new(&name))
+        .unwrap_or(ArchiveFormat::None);
+    if matches!(format, ArchiveFormat::None | ArchiveFormat::Auto) {
+        return Err(format!(
+            "--extract: cannot determine an archive format from {name:?} \
+             (supported: .zip, .tar.gz, .tar.xz, .tar.zst, .tzst, .7z, .xz, .zst)"
+        ));
+    }
+    Ok(format)
+}
+
+/// Extract `archive` into the tree cache, or report that it is already there.
+///
+/// Publication is a single directory rename. That is what makes "the tree
+/// directory exists" mean "the extraction finished": a run interrupted partway
+/// leaves its debris in `tmp/`, never at the final path, so the next run
+/// cannot mistake a half-extracted tree for a complete one. Checking for the
+/// directory and extracting *into* it would have exactly that bug.
+fn ensure_extracted(
+    root: &Path,
+    archive: &Path,
+    digest: &str,
+    format: ArchiveFormat,
+) -> Result<(PathBuf, ExtractOutcome), String> {
+    let key = tree_key(digest, format);
+    let final_path = tree_path_for(root, &key);
+    if final_path.is_dir() {
+        return Ok((final_path, ExtractOutcome::Cached));
+    }
+
+    let tmp_root = root.join(FETCH_DIR).join(TMP_DIR);
+    std::fs::create_dir_all(&tmp_root)
+        .map_err(|e| format!("cannot create extraction staging dir: {e}"))?;
+    let staging = tmp_root.join(format!("{key}.tree"));
+    // Debris from an interrupted earlier run must not be extracted over.
+    let _ = std::fs::remove_dir_all(&staging);
+
+    crate::download_client::artifact::archive::extract_archive_at(archive, format, &staging)
+        .map_err(|e| {
+            let _ = std::fs::remove_dir_all(&staging);
+            format!("extraction failed: {e}")
+        })?;
+
+    if let Some(parent) = final_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("cannot create tree cache directory: {e}"))?;
+    }
+    match std::fs::rename(&staging, &final_path) {
+        Ok(()) => Ok((final_path, ExtractOutcome::Extracted)),
+        // Another process published the same tree while we were extracting.
+        // Its bytes are ours by construction (same key), so ours is redundant.
+        Err(_) if final_path.is_dir() => {
+            let _ = std::fs::remove_dir_all(&staging);
+            Ok((final_path, ExtractOutcome::Cached))
+        }
+        Err(err) => {
+            let _ = std::fs::remove_dir_all(&staging);
+            Err(format!("cannot publish extracted tree: {err}"))
+        }
+    }
+}
+
+/// Common tail for every route into a cached blob: optionally extract, then
+/// report. Shared so `--extract` cannot be honoured on one path and skipped on
+/// another -- the bug `--expect` already had on the revalidated path.
+fn finish(
+    root: &Path,
+    url: &str,
+    cas: &Path,
+    digest: &str,
+    outcome: FetchOutcome,
+    extract: bool,
+    json: bool,
+) -> ExitCode {
+    if !extract {
+        return report(cas, digest, outcome, None, None, json);
+    }
+    let format = match extraction_format(url) {
+        Ok(format) => format,
+        Err(err) => {
+            eprintln!("zccache: {err}");
+            return ExitCode::FAILURE;
+        }
+    };
+    match ensure_extracted(root, cas, digest, format) {
+        Ok((tree, extract_outcome)) => report(
+            cas,
+            digest,
+            outcome,
+            Some(&tree),
+            Some(extract_outcome),
+            json,
+        ),
+        Err(err) => {
+            eprintln!("zccache: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn report(
+    path: &Path,
+    digest: &str,
+    outcome: FetchOutcome,
+    tree: Option<&Path>,
+    extract_outcome: Option<ExtractOutcome>,
+    json: bool,
+) -> ExitCode {
     if json {
-        println!(
-            "{}",
-            serde_json::json!({
-                "path": path,
-                "digest": digest,
-                "outcome": outcome.as_str(),
-            })
-        );
+        let mut payload = serde_json::json!({
+            "path": path,
+            "digest": digest,
+            "outcome": outcome.as_str(),
+        });
+        if let (Some(tree), Some(extract_outcome)) = (tree, extract_outcome) {
+            payload["extracted"] = serde_json::json!(tree);
+            payload["extraction"] = serde_json::json!(extract_outcome.as_str());
+        }
+        println!("{payload}");
     } else {
-        println!("{}", path.display());
+        // With --extract the useful path is the tree, not the archive blob:
+        // the caller wants something to run, not something to unpack.
+        println!("{}", tree.unwrap_or(path).display());
     }
     ExitCode::SUCCESS
 }
@@ -459,5 +678,170 @@ mod tests {
 
         assert_eq!(pin_matches(&"a".repeat(64), cached), Ok(false));
         assert_eq!(pin_matches(cached, cached), Ok(true));
+    }
+
+    // --- extraction cache (issue #1469, acceptance criterion 7) ---
+
+    /// Build a real `.tar.gz` so the extraction tests exercise the actual
+    /// decoder rather than a stand-in.
+    fn write_targz(path: &Path, entries: &[(&str, &[u8])]) {
+        let file = std::fs::File::create(path).expect("create archive");
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::fast());
+        let mut builder = tar::Builder::new(encoder);
+        for (name, body) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, name, *body)
+                .expect("append entry");
+        }
+        builder
+            .into_inner()
+            .expect("finish tar")
+            .finish()
+            .expect("finish gz");
+    }
+
+    #[test]
+    fn a_tree_key_is_not_the_archive_digest() {
+        // Domain separation: a tree key must never collide with a blob digest,
+        // since both are 64 hex chars living under the same root.
+        let digest = "ab".repeat(32);
+
+        assert_ne!(tree_key(&digest, ArchiveFormat::TarGz), digest);
+    }
+
+    #[test]
+    fn a_tree_key_depends_on_the_extraction_format() {
+        // Same bytes unpacked under different options are different trees.
+        let digest = "cd".repeat(32);
+
+        assert_ne!(
+            tree_key(&digest, ArchiveFormat::TarGz),
+            tree_key(&digest, ArchiveFormat::Zip)
+        );
+    }
+
+    #[test]
+    fn identical_archives_share_one_tree_key() {
+        // This is what makes two URLs serving identical bytes -- or an origin
+        // that changed only its ETag -- reuse one extraction.
+        let digest = "ef".repeat(32);
+
+        assert_eq!(
+            tree_key(&digest, ArchiveFormat::TarGz),
+            tree_key(&digest, ArchiveFormat::TarGz)
+        );
+    }
+
+    #[test]
+    fn a_url_name_drops_query_and_fragment() {
+        // `?token=` on a release URL is common; without stripping it the
+        // format would detect as None and --extract would refuse a valid
+        // archive.
+        assert_eq!(
+            archive_name_from_url("https://h/x/node.tar.gz?token=abc"),
+            "node.tar.gz"
+        );
+        assert_eq!(
+            archive_name_from_url("https://h/x/node.tar.gz#frag"),
+            "node.tar.gz"
+        );
+        assert_eq!(archive_name_from_url("https://h/x/node.zip"), "node.zip");
+    }
+
+    #[test]
+    fn an_unrecognized_extension_is_refused_rather_than_guessed() {
+        // Silently treating an unknown payload as a single-file copy would
+        // produce a "tree" that is really one file at a directory path.
+        assert!(extraction_format("https://h/tool.bin").is_err());
+        assert!(extraction_format("https://h/tool.tar.gz").is_ok());
+    }
+
+    #[test]
+    fn an_archive_is_extracted_once_and_reused() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let archive = root.join("payload.tar.gz");
+        write_targz(&archive, &[("bin/tool", b"payload")]);
+        let digest = "11".repeat(32);
+
+        let (first, first_outcome) =
+            ensure_extracted(root, &archive, &digest, ArchiveFormat::TarGz).expect("extract");
+        let (second, second_outcome) =
+            ensure_extracted(root, &archive, &digest, ArchiveFormat::TarGz).expect("reuse");
+
+        assert_eq!(first_outcome, ExtractOutcome::Extracted);
+        assert_eq!(
+            second_outcome,
+            ExtractOutcome::Cached,
+            "second call re-extracted"
+        );
+        assert_eq!(first, second);
+        assert_eq!(
+            std::fs::read(first.join("bin/tool")).expect("read entry"),
+            b"payload"
+        );
+    }
+
+    #[test]
+    fn a_partial_extraction_is_never_served_as_complete() {
+        // The failure this guards: check-then-extract-in-place leaves a
+        // half-populated directory at the final path when interrupted, and
+        // the next run sees "directory exists" and hands it out. Publication
+        // by rename means debris can only ever sit in tmp/.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let archive = root.join("payload.tar.gz");
+        write_targz(&archive, &[("bin/tool", b"payload")]);
+        let digest = "22".repeat(32);
+        let key = tree_key(&digest, ArchiveFormat::TarGz);
+
+        // Simulate an interrupted run: staging debris, nothing published.
+        let staging = root
+            .join(FETCH_DIR)
+            .join(TMP_DIR)
+            .join(format!("{key}.tree"));
+        std::fs::create_dir_all(staging.join("bin")).expect("staging");
+        std::fs::write(staging.join("bin/truncated"), b"partial").expect("debris");
+
+        let (tree, outcome) =
+            ensure_extracted(root, &archive, &digest, ArchiveFormat::TarGz).expect("extract");
+
+        assert_eq!(
+            outcome,
+            ExtractOutcome::Extracted,
+            "debris was served as a hit"
+        );
+        assert!(tree.join("bin/tool").is_file(), "real entry missing");
+        assert!(
+            !tree.join("bin/truncated").exists(),
+            "debris from the interrupted run leaked into the published tree"
+        );
+    }
+
+    #[test]
+    fn extraction_outcomes_have_distinct_labels() {
+        assert_ne!(
+            ExtractOutcome::Cached.as_str(),
+            ExtractOutcome::Extracted.as_str()
+        );
+    }
+
+    #[test]
+    fn a_tree_path_sits_under_two_shard_levels() {
+        let key = "ab".repeat(32);
+        let path = tree_path_for(Path::new("/root"), &key);
+        let parts: Vec<_> = path
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy().into_owned())
+            .collect();
+
+        assert!(parts.contains(&TREES_DIR.to_string()));
+        assert_eq!(parts[parts.len() - 1], key);
+        assert_eq!(parts[parts.len() - 2], "ab");
+        assert_eq!(parts[parts.len() - 3], "ab");
     }
 }

--- a/crates/zccache-cli-core/src/cli/commands/mod.rs
+++ b/crates/zccache-cli-core/src/cli/commands/mod.rs
@@ -472,9 +472,12 @@ fn dispatch(command: Commands, global_overrides: wrap::WrapperOverrides) -> Exit
             } => symbols::cmd_symbols_install(version, target, prefix, force),
             SymbolsCommands::Symbolicate { dumps } => symbols::cmd_symbols_symbolicate(dumps),
         },
-        Commands::Fetch { url, expect, json } => {
-            run_async(fetch::cmd_fetch(&url, expect.as_deref(), json))
-        }
+        Commands::Fetch {
+            url,
+            expect,
+            extract,
+            json,
+        } => run_async(fetch::cmd_fetch(&url, expect.as_deref(), extract, json)),
         Commands::CacheRoot { json } => cache_ops::cmd_cache_root(json),
         Commands::DefenderExclusions { action } => match action {
             DefenderExclusionsCommands::Check { json } => defender::cmd_check(json),

--- a/crates/zccache-cli-core/src/download_client/artifact/archive.rs
+++ b/crates/zccache-cli-core/src/download_client/artifact/archive.rs
@@ -14,7 +14,7 @@ pub(super) fn detect_archive_format(
     }
 }
 
-pub(super) fn auto_archive_format(path: &Path) -> Result<ArchiveFormat, String> {
+pub(crate) fn auto_archive_format(path: &Path) -> Result<ArchiveFormat, String> {
     let name = path
         .file_name()
         .map(|n| n.to_string_lossy().to_ascii_lowercase())
@@ -42,17 +42,34 @@ pub(super) fn extract_archive(
     request: &ResolvedFetchRequest,
     expanded_path: &Path,
 ) -> Result<(), String> {
-    match detect_archive_format(request)? {
-        ArchiveFormat::None => {
-            copy_file(&request.cache_path, expanded_path).map_err(|e| e.to_string())
-        }
+    extract_archive_at(
+        &request.cache_path,
+        detect_archive_format(request)?,
+        expanded_path,
+    )
+}
+
+/// Extract `archive_path` into `destination` using an already-resolved format.
+///
+/// Split out of [`extract_archive`] so a caller holding only a path -- the
+/// `zccache fetch` extraction cache -- reuses this exact traversal-checked
+/// implementation rather than growing a second extractor. Every guard here
+/// (no absolute entries, no `..`, no symlink or hard-link entries) applies
+/// to both callers by construction.
+pub(crate) fn extract_archive_at(
+    archive_path: &Path,
+    format: ArchiveFormat,
+    expanded_path: &Path,
+) -> Result<(), String> {
+    match format {
+        ArchiveFormat::None => copy_file(archive_path, expanded_path).map_err(|e| e.to_string()),
         ArchiveFormat::Zst => {
-            let input = File::open(&request.cache_path).map_err(|e| e.to_string())?;
+            let input = File::open(archive_path).map_err(|e| e.to_string())?;
             let mut decoder = ruzstd::StreamingDecoder::new(input).map_err(|e| e.to_string())?;
             write_decoded_to_file(&mut decoder, expanded_path).map_err(|e| e.to_string())
         }
         ArchiveFormat::Xz => {
-            let input = File::open(&request.cache_path).map_err(|e| e.to_string())?;
+            let input = File::open(archive_path).map_err(|e| e.to_string())?;
             if let Some(parent) = expanded_path.parent() {
                 fs::create_dir_all(parent).map_err(|e| e.to_string())?;
             }
@@ -60,25 +77,25 @@ pub(super) fn extract_archive(
             let mut input = io::BufReader::new(input);
             lzma_rs::xz_decompress(&mut input, &mut output).map_err(|e| e.to_string())
         }
-        ArchiveFormat::Zip => extract_zip(&request.cache_path, expanded_path),
+        ArchiveFormat::Zip => extract_zip(archive_path, expanded_path),
         ArchiveFormat::TarGz => {
-            let input = File::open(&request.cache_path).map_err(|e| e.to_string())?;
+            let input = File::open(archive_path).map_err(|e| e.to_string())?;
             let decoder = flate2::read::GzDecoder::new(input);
             extract_tar(decoder, expanded_path)
         }
         ArchiveFormat::TarXz => {
-            let input = File::open(&request.cache_path).map_err(|e| e.to_string())?;
+            let input = File::open(archive_path).map_err(|e| e.to_string())?;
             let mut decoded = Vec::new();
             let mut input = io::BufReader::new(input);
             lzma_rs::xz_decompress(&mut input, &mut decoded).map_err(|e| e.to_string())?;
             extract_tar(io::Cursor::new(decoded), expanded_path)
         }
         ArchiveFormat::TarZst => {
-            let input = File::open(&request.cache_path).map_err(|e| e.to_string())?;
+            let input = File::open(archive_path).map_err(|e| e.to_string())?;
             let decoder = ruzstd::StreamingDecoder::new(input).map_err(|e| e.to_string())?;
             extract_tar(decoder, expanded_path)
         }
-        ArchiveFormat::SevenZip => extract_7z(&request.cache_path, expanded_path),
+        ArchiveFormat::SevenZip => extract_7z(archive_path, expanded_path),
         ArchiveFormat::Auto => Err("archive format auto-detection failed".to_string()),
     }
 }

--- a/crates/zccache-cli-core/src/download_client/artifact/mod.rs
+++ b/crates/zccache-cli-core/src/download_client/artifact/mod.rs
@@ -12,7 +12,7 @@ use crate::download::{DownloadOptions, DownloadPhase};
 
 use super::DownloadClient;
 
-mod archive;
+pub(crate) mod archive;
 mod hashing;
 mod lock;
 mod marker;

--- a/crates/zccache-cli-core/src/download_client/mod.rs
+++ b/crates/zccache-cli-core/src/download_client/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::missing_errors_doc)]
 
-mod artifact;
+pub(crate) mod artifact;
 
 use std::path::Path;
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -27,6 +27,7 @@ Architecture docs are split by subsystem. Read only what's relevant to your curr
 | Crash dumper (CLI + daemon) | [runtime.md](architecture/runtime.md) (Crash Dumper) — `zccache_core::crash::install` covers both binaries |
 | Host-platform boundary (`zccache-platform`, `crate::platform`) | [portability.md](architecture/portability.md) — one selector, five facades, host-vs-compiler-target rule |
 | Generic tool exec (`zccache exec`, issue #272) | [runtime.md § Generic tool exec](architecture/runtime.md#generic-tool-exec-zccache-exec) — `handle_exec.rs` + `cli/commands/exec.rs` |
+| External tool fetch (`zccache fetch`, issue #1469) | [runtime.md § External tool fetch](architecture/runtime.md#external-tool-fetch-zccache-fetch-issue-1469) — `cli/commands/fetch.rs`, blob + extraction CAS |
 | Platform-specific issues | [portability.md](architecture/portability.md) |
 | Python `exec_cached` caller-owned results | [runtime.md](architecture/runtime.md#python-caller-owned-exec_cached), [ipc.md](architecture/ipc.md#wire-selection-and-compatibility-fallback) |
 | Compile journal record shape | [journal-schema.md](journal-schema.md) |

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -365,6 +365,75 @@ The test fixture is the `exec_test_tool` binary (built under `--features test-su
 
 ---
 
+## External tool fetch (`zccache fetch`, issue #1469)
+
+`zccache fetch <url>` acquires an external tool through a global,
+content-addressed cache and prints a path. It is independent of the compile
+cache: no daemon, no IPC. `cli/commands/fetch.rs` owns it.
+
+### Three layers, deliberately not conflated
+
+| Layer | Mechanism | What it buys |
+|---|---|---|
+| Freshness | conditional GET (`If-None-Match` / `If-Modified-Since`) | a 304 skips the transfer entirely |
+| Identity | blake3 of the payload bytes | the CAS key; dedups across mirrors and re-uploads |
+| Pinning | `--expect <digest>` | the only layer that defends against a compromised origin |
+
+**The validator is never the cache key.** ETag is server-chosen and opaque:
+GitHub Releases serves an Azure blob timestamp, so re-uploading identical
+content changes it (a false miss), while nginx's default `mtime-size` can stay
+identical across a content swap (a false *hit*, which is worse). Hashing the
+bytes ourselves is the only thing that resolves both directions.
+
+`--expect` is enforced on **every** route into the cache, including a
+revalidated warm hit. A pin checked only on cold fetches is bypassed exactly
+when the artifact is most likely to be reused.
+
+### Layout under the cache root
+
+```
+<root>/fetch/cas/<aa>/<bb>/<digest>      immutable blobs, keyed by content
+<root>/fetch/trees/<aa>/<bb>/<tree-key>  extracted trees
+<root>/fetch/kv/                         per-URL validators (never a key)
+<root>/fetch/tmp/                        staging; never observed as complete
+```
+
+### Extraction cache (`--extract`)
+
+Extraction and AV scanning dominate the transfer for large toolchains — the
+issue measured 3.1 s to unpack 2,134 files against 14.2 s to download them, and
+the download is the half that segmented transfer already fixes. So extracted
+trees are CAS entries in their own right.
+
+The tree key is domain-separated blake3 over **archive digest + format tag**,
+not the URL. Two consequences, both verified against a live origin:
+
+- Two URLs serving identical bytes share one extraction. A refetch forced by a
+  changed validator still reports `extraction: cached` — you lose the transfer
+  but keep everything derived from it.
+- The format tag is a written-out string, not a `Debug` derive, so renaming an
+  `ArchiveFormat` variant cannot silently invalidate every cached tree on disk.
+  A future flag that changes extraction output (strip-components, filters)
+  extends this key rather than reusing a tree built under different options.
+
+**Publication is a single directory rename.** That is what makes "the tree
+directory exists" mean "the extraction finished". Checking for the directory
+and then extracting *into* it would leave a half-populated tree at the final
+path when interrupted, and the next run would hand it out as a hit; debris can
+only ever sit in `tmp/`. A concurrent process that publishes the same key first
+wins, and the loser discards its own staging — the keys are equal, so the bytes
+are too.
+
+Extraction reuses the traversal-checked extractor in
+`download_client/artifact/archive.rs` (`extract_archive_at`) rather than
+growing a second one, so the guards against absolute entries, `..`, symlink and
+hard-link entries apply to both callers by construction. A URL whose extension
+is not a recognized archive is refused rather than guessed — treating an
+unknown payload as a single-file copy would produce a "tree" that is really one
+file at a directory path.
+
+---
+
 ## Daemon unavailable is a hard error (issue #1170)
 
 When the daemon/cache pipeline fails **before request dispatch** (daemon spawn failure, connect timeout, `ZCCACHE_NO_SPAWN` refusal), the wrapper **refuses to run the tool**. There is no uncached fallback.


### PR DESCRIPTION
Closes the last open acceptance criterion on #1469: **archive extraction is cached too**.

#1470 shipped the blob half. But extraction and AV scanning dominate the transfer for large toolchains — the issue's own measurement is 3.1s to unpack 2,134 files against 14.2s to download them, and the download is the half that segmented transfer already fixes. Caching only the bytes leaves most of the cost in place.

## The tree key answers the issue's open question

> Should extracted trees be CAS entries in their own right, keyed by archive digest + extraction options?

Yes. The key is domain-separated blake3 over **archive digest + format tag**, never the URL. Two consequences:

- **Two URLs serving identical bytes share one extraction.** A refetch forced by a changed validator still reports `extraction: cached` — you lose the transfer but keep everything derived from it, which is the expensive part.
- **The format tag is a written-out string, not a `Debug` derive.** Renaming an `ArchiveFormat` variant therefore cannot silently invalidate every cached tree on disk, and a future flag that changes extraction output (strip-components, filters) extends the key rather than reusing a tree built under different options.

## Publication is a single directory rename

This is the part worth reviewing. Checking for the directory and extracting *into* it would leave a half-populated tree at the final path when interrupted, and the next run would see "directory exists" and hand it out as a hit. Renaming means debris can only ever sit in `tmp/`, so **"the tree directory exists" means "the extraction finished"** by construction.

The regression test for this was **verified RED** by removing the guard it protects:

```
test a_partial_extraction_is_never_served_as_complete ... FAILED
panicked at fetch.rs:797: debris from the interrupted run leaked into the published tree
```

A concurrent process publishing the same key first wins; the loser discards its own staging, since equal keys mean equal bytes.

## No second extractor

`extract_archive` is split into `extract_archive_at`, which takes a plain path. The `fetch` path reuses it, so the existing guards — no absolute entries, no `..`, no symlink or hard-link entries — apply to both callers rather than being reimplemented. A URL whose extension is not a recognized archive is refused rather than guessed: treating an unknown payload as a single-file copy would produce a "tree" that is really one file at a directory path.

## Verified against a live origin

| check | result |
|---|---|
| cold | `outcome=downloaded-new, extraction=extracted` (1.9s) |
| warm | `outcome=revalidated, extraction=cached` (0.65s) |
| **different URL, identical bytes** | `outcome=downloaded-duplicate, **extraction=cached**` — 1 CAS blob, 1 tree |
| tree contents | 27 files under `log-0.4.22/` |
| `--expect` + `--extract` | wrong pin exits 1 *on the revalidated path*; correct pin exits 0 |
| unrecognized extension | refused with the supported-format list |
| staging | 0 entries left in `tmp/` |

289 crate tests pass. Workspace clippy, rustdoc, and the crate tests all clean under `-D warnings`.

## Docs

#1470 shipped `zccache fetch` with no documentation. This adds the `runtime.md` section (all three layers, the layout, the extraction cache and its rename invariant) plus the `docs/CLAUDE.md` breadcrumb row, per the "document in the subsystem doc" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
