### PR TITLE
ci(boundary): stop flagging idiomatic test-module globs, prune the allowlist (#1474)

### DIFF
--- a/ci/compile_boundary.py
+++ b/ci/compile_boundary.py
@@ -20,13 +20,16 @@ COMPILE_ROOT_FILES = {
     "handle_compile_multi_staged.rs",
     "handle_compile_multi_types.rs",
 }
+# Production glob imports only. Test-module globs (`use super::*;` inside
+# `#[cfg(test)] mod tests`) are excluded by strip_test_items, so they must
+# never be listed here -- an entry that no longer corresponds to a real
+# production glob silently exempts that file from the check, which is how
+# cached_hit.rs / error_cache.rs / handle_compile_multi_args.rs ended up
+# here. test_allowlist_has_no_dead_entries guards against that recurring.
 ALLOWED_GLOB_IMPORTS = {
     "handle_compile.rs",
-    "handle_compile/cached_hit.rs",
-    "handle_compile/error_cache.rs",
     "handle_compile_ephemeral.rs",
     "handle_compile_multi.rs",
-    "handle_compile_multi_args.rs",
     "handle_compile_multi_preflight.rs",
     "handle_compile_multi_staged.rs",
     "handle_compile_multi_types.rs",
@@ -36,6 +39,72 @@ PRIVATE_ITEM = re.compile(
     r"\bpub\(super\)\s+(?:async\s+)?"
     r"(?:struct|enum|trait|fn|const|static|type)\s+([A-Za-z_][A-Za-z0-9_]*)"
 )
+CFG_TEST = re.compile(r"^\s*#\[cfg\(test\)\]\s*$")
+PATH_ATTR = re.compile(r'^\s*#\[path\s*=\s*"([^"]+)"\]')
+
+
+def strip_test_items(text: str) -> str:
+    """Drop `#[cfg(test)]` items so test code is not scanned as production code.
+
+    A `use super::*;` inside `#[cfg(test)] mod tests { ... }` is the ordinary
+    Rust idiom for reaching a module's own items from its test module. It is
+    not compile-handler coupling, and treating it as such is what pushed three
+    test-only files into ALLOWED_GLOB_IMPORTS -- which then had the side effect
+    of exempting those files from the check for real.
+
+    Brace counting ignores braces inside string literals, the same simplifying
+    assumption `module_private_items` already makes.
+    """
+    lines = text.splitlines()
+    kept: list[str] = []
+    index = 0
+    total = len(lines)
+    while index < total:
+        if not CFG_TEST.match(lines[index]):
+            kept.append(lines[index])
+            index += 1
+            continue
+        # Skip the attribute plus any attributes stacked under it.
+        index += 1
+        while index < total and lines[index].lstrip().startswith("#["):
+            index += 1
+        if index >= total:
+            break
+        # `mod name;` declares a whole test-only file; nothing to brace-match.
+        code = lines[index].split("//", 1)[0]
+        if "{" not in code:
+            index += 1
+            continue
+        depth = 0
+        while index < total:
+            code = lines[index].split("//", 1)[0]
+            depth += code.count("{") - code.count("}")
+            index += 1
+            if depth <= 0:
+                break
+    return "\n".join(kept)
+
+
+def test_only_module_files(path: Path) -> set[Path]:
+    """Files pulled in as `#[cfg(test)] #[path = "x.rs"] mod ...`.
+
+    Such a file is entirely test code, so its top-level globs are test globs.
+    Detected structurally rather than by a `*_tests.rs` naming convention, so
+    renaming a file cannot silently re-arm the false positive.
+    """
+    found: set[Path] = set()
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for position, line in enumerate(lines):
+        if not CFG_TEST.match(line):
+            continue
+        for lookahead in lines[position + 1 : position + 4]:
+            match = PATH_ATTR.match(lookahead)
+            if match:
+                found.add((path.parent / match.group(1)).resolve())
+            if lookahead.lstrip().startswith("mod "):
+                break
+    return found
+
 
 
 def compile_files(root: Path) -> list[Path]:
@@ -61,7 +130,17 @@ def module_private_items(text: str) -> set[str]:
 def inventory(root: Path) -> dict[str, object]:
     server = root / SERVER
     files = compile_files(root)
-    glob_files = [path.relative_to(server).as_posix() for path in files if GLOB_IMPORT.search(path.read_text(encoding="utf-8"))]
+    # Files that exist only as test modules are test code end to end, so their
+    # top-level globs are test globs too.
+    test_only: set[Path] = set()
+    for path in files:
+        test_only |= test_only_module_files(path)
+    glob_files = [
+        path.relative_to(server).as_posix()
+        for path in files
+        if path.resolve() not in test_only
+        and GLOB_IMPORT.search(strip_test_items(path.read_text(encoding="utf-8")))
+    ]
     private_symbols: set[str] = set()
     compile_set = {path.resolve() for path in files}
     for path in server.rglob("*.rs"):

--- a/ci/tests/test_incremental_build.py
+++ b/ci/tests/test_incremental_build.py
@@ -78,3 +78,108 @@ def test_repository_compile_boundary_does_not_add_glob_imports():
     result = compile_boundary.inventory(compile_boundary.ROOT)
 
     assert result["unexpected_glob_imports"] == []
+
+
+def test_a_test_module_glob_is_not_compile_coupling(tmp_path):
+    """`use super::*;` inside `#[cfg(test)] mod tests` is the ordinary Rust
+    idiom for a module reaching its own items. Flagging it forced test-only
+    files onto the allowlist, which then exempted them from the real check."""
+    server = tmp_path / compile_boundary.SERVER
+    (server / "handle_compile").mkdir(parents=True)
+    for name in compile_boundary.COMPILE_ROOT_FILES:
+        (server / name).write_text("fn placeholder() {}\n", encoding="utf-8")
+    (server / "handle_compile" / "pipeline.rs").write_text(
+        "fn run() {}\n"
+        "\n"
+        "#[cfg(test)]\n"
+        "mod tests {\n"
+        "    use super::*;\n"
+        "\n"
+        "    #[test]\n"
+        "    fn it_runs() { run(); }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    result = compile_boundary.inventory(tmp_path)
+
+    assert "handle_compile/pipeline.rs" not in result["glob_imports"]
+    assert result["unexpected_glob_imports"] == []
+
+
+def test_a_production_glob_is_still_rejected(tmp_path):
+    """The ratchet must survive the fix above: a top-level glob in a file that
+    also has a test module is still coupling."""
+    server = tmp_path / compile_boundary.SERVER
+    (server / "handle_compile").mkdir(parents=True)
+    for name in compile_boundary.COMPILE_ROOT_FILES:
+        (server / name).write_text("fn placeholder() {}\n", encoding="utf-8")
+    (server / "handle_compile" / "pipeline.rs").write_text(
+        "use super::*;\n"
+        "\n"
+        "#[cfg(test)]\n"
+        "mod tests {\n"
+        "    use super::*;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    result = compile_boundary.inventory(tmp_path)
+
+    assert result["unexpected_glob_imports"] == ["handle_compile/pipeline.rs"]
+
+
+def test_a_cfg_test_path_module_is_treated_as_test_code(tmp_path):
+    """A whole file included as `#[cfg(test)] #[path = "x.rs"] mod` is test
+    code, so its top-level glob is a test glob. Detected structurally, not by
+    a `*_tests.rs` naming convention."""
+    server = tmp_path / compile_boundary.SERVER
+    (server / "handle_compile").mkdir(parents=True)
+    for name in compile_boundary.COMPILE_ROOT_FILES:
+        (server / name).write_text("fn placeholder() {}\n", encoding="utf-8")
+    (server / "handle_compile" / "store.rs").write_text(
+        "fn run() {}\n"
+        "\n"
+        '#[cfg(test)]\n'
+        '#[path = "store_tests.rs"]\n'
+        "mod store_tests;\n",
+        encoding="utf-8",
+    )
+    (server / "handle_compile" / "store_tests.rs").write_text(
+        "use crate::daemon::server::*;\n\n#[test]\nfn it_runs() {}\n",
+        encoding="utf-8",
+    )
+
+    result = compile_boundary.inventory(tmp_path)
+
+    assert result["unexpected_glob_imports"] == []
+
+
+def test_strip_test_items_leaves_production_code_intact():
+    source = (
+        "use super::*;\n"
+        "fn run() {}\n"
+        "#[cfg(test)]\n"
+        "mod tests {\n"
+        "    fn helper() { let _ = \"}\"; }\n"
+        "}\n"
+        "fn after() {}\n"
+    )
+
+    stripped = compile_boundary.strip_test_items(source)
+
+    assert "use super::*;" in stripped
+    assert "fn run()" in stripped
+    assert "fn after()" in stripped, "code after a test module must survive"
+    assert "fn helper()" not in stripped
+
+
+def test_allowlist_has_no_dead_entries():
+    """An allowlist entry that no longer matches a real production glob
+    silently exempts that file from the check. That is exactly how three
+    test-only files came to be listed."""
+    result = compile_boundary.inventory(compile_boundary.ROOT)
+
+    dead = sorted(set(result["allowed_glob_imports"]) - set(result["glob_imports"]))
+
+    assert dead == [], f"allowlist entries with no production glob: {dead}"


### PR DESCRIPTION
First of the three parts of #1474. This one is unambiguous; the other two are not, and I have written up what I found below.

## The bug

`compile_boundary.py` matched `use super::*;` **anywhere** in a file, including inside `#[cfg(test)] mod tests { ... }` — the ordinary Rust idiom for a module reaching its own items. That is not compile-handler coupling.

The second-order effect is the real problem. Files whose *only* glob was the test-module one kept getting added to `ALLOWED_GLOB_IMPORTS` to silence the false positive. **Three entries were already there for that reason:**

| allowlisted file | production glob? |
|---|---|
| `handle_compile/cached_hit.rs` | none — only `#[cfg(test)] mod tests` |
| `handle_compile/error_cache.rs` | none — only `#[cfg(test)] mod tests` |
| `handle_compile_multi_args.rs` | none — only `#[cfg(test)] mod tests` |

Being allowlisted, a genuine production glob added to any of those would never have been caught. **The ratchet was loosening every time someone added a test module.**

## The fix

Exclude test code from the scan — `#[cfg(test)]` bodies, and whole files pulled in as `#[cfg(test)] #[path = "x.rs"] mod`. The latter is detected structurally rather than by a `*_tests.rs` naming convention, so renaming a file cannot silently re-arm the false positive.

Then prune the allowlist to the six files that actually have a production glob.

**Net effect is a tighter gate, not a looser one:** 9 allowlist entries → 6, the four newly-flagged files stop failing, and a real top-level glob is still rejected — including in a file that also has a test module. `test_allowlist_has_no_dead_entries` stops the allowlist re-accumulating exemptions.

```
before:  unexpected_glob_imports = 4 files   allowlist = 9
after:   unexpected_glob_imports = []        allowlist = 6  (== production globs)
```

## What I did NOT fix, and why

**1. `test_rollout_fixture_archives_pin_the_runner_toolchain` — two deliberate decisions are in direct conflict.**

I initially "fixed" this by bumping `perf/fixtures/{medium,sqlite-link}/rust-toolchain.toml` to 1.95.0 and regenerating the archives. **That was wrong, and the suite caught me:** those exact files are listed in `INTENTIONAL_LEGACY` in `test_toolchain_consistency.py`, described as *"fixture toolchains modeling a user's compiler"*. Meanwhile `ci/docker/runner.Dockerfile` is in `MUST_PIN` and must declare 1.95.0.

So one test requires the runner image to equal the fixture channel (#1283), and another requires the fixture channel to stay 1.94.1 (#1365). Since the MSRV bump moved the runner to 1.95.0, both cannot hold. The runner installs only 1.95.0, so a 1.94.1 fixture would make cargo fetch a second toolchain inside the container — which is presumably why #1283 tied them together.

Resolving this is a design call about the perf runner (pin the fixtures forward, install both toolchains in the image, or drop the invariant), so I reverted my change rather than pick one. I verified the revert is byte-clean.

**2. `test_perf_watchdog.py::test_timeout_captures_summary_and_terminates_child` is flaky — 2 failures in 5 runs.**

```
run 1: passed   run 2: FAILED   run 3: FAILED   run 4: passed   run 5: passed
AssertionError: assert 'waiting' in ''
```

The child does `print('waiting', flush=True); time.sleep(30)` and the config sets `timeout_seconds=0.2`. On Windows, interpreter startup alone can exceed 0.2s, so the watchdog sometimes kills the child before it flushes. The deadline is racing process startup. Fixing it properly is a separate change.

Both need to land before a workflow can run this suite, since a red suite is worse than an unrun one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
