### PR TITLE
test(daemon): make the queued-clear timeout say why it fired (#1476)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
@@ -624,6 +624,17 @@ pub(super) async fn try_handle_staged_misses(
 mod tests {
     use super::*;
 
+    /// How long the queued clear is given to finish once the publication
+    /// guard is dropped. This is a hang detector, not a measurement -- the
+    /// assertion is `Response::Cleared`, and this bound only exists so a
+    /// lost wakeup fails the test instead of hanging the suite.
+    const CLEAR_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
+
+    /// Extra time granted *after* CLEAR_BUDGET expires, solely to classify
+    /// the failure. See the call site: a bare `Elapsed(())` cannot tell a
+    /// slow runner from a barrier that never released (#1476).
+    const HANG_CONFIRM: std::time::Duration = std::time::Duration::from_secs(55);
+
     #[tokio::test]
     async fn staged_multi_visibility_stays_inside_queued_clear_barrier() {
         let temp = tempfile::tempdir().unwrap();
@@ -670,10 +681,30 @@ mod tests {
         assert!(server.state.fast_hit_cache.contains_key(&context_key));
 
         drop(publication_guard);
-        let response = tokio::time::timeout(std::time::Duration::from_secs(5), clear)
-            .await
-            .unwrap()
-            .unwrap();
+        // A bare `Elapsed(())` here says nothing about *why* the clear did not
+        // finish, which left #1476 unactionable: "CI was slow" and "the barrier
+        // never released" produce the identical panic. So on expiry, poll the
+        // same handle again for much longer and report which one happened.
+        // Either way the test still fails -- this classifies the failure, it
+        // does not tolerate it.
+        let joined = match tokio::time::timeout(CLEAR_BUDGET, &mut clear).await {
+            Ok(joined) => joined,
+            Err(_) => match tokio::time::timeout(HANG_CONFIRM, &mut clear).await {
+                Ok(_) => panic!(
+                    "clear missed {CLEAR_BUDGET:?} but finished within {:?}: the \
+                     barrier released and this host was merely slow, so the budget \
+                     is undersized rather than the code being wrong (#1476)",
+                    CLEAR_BUDGET + HANG_CONFIRM
+                ),
+                Err(_) => panic!(
+                    "clear never finished within {:?} of the publication guard being \
+                     dropped: the barrier did not release. This is a lost wakeup, not \
+                     load -- do not raise the budget (#1476)",
+                    CLEAR_BUDGET + HANG_CONFIRM
+                ),
+            },
+        };
+        let response = joined.unwrap();
         assert!(matches!(response, Response::Cleared { .. }));
         assert!(!server.state.artifacts.contains_key(&key));
         assert!(!server.state.fast_hit_cache.contains_key(&context_key));


### PR DESCRIPTION
Does not resolve #1476 — it makes the *next* occurrence resolve it.

## Why not just raise the budget

The flake panics with a bare `Elapsed(())`. That message cannot distinguish:

- **the runner was slow** — the barrier released, the 5s budget is just undersized; or
- **the barrier never released** — a lost `publication_guard` wakeup, i.e. a real bug.

Those want opposite fixes. Raising the budget is correct for the first and **actively harmful** for the second: a genuine lost wakeup would take longer to surface while looking like it had been addressed. I measured 40/40 local passes at ~1.4s, but that is an idle Windows box and the CI job that failed took 523s for the lib suite — so it does not distinguish the two either.

That ambiguity is exactly what left this issue stuck, so this PR removes the ambiguity instead of guessing.

## What it does

On expiry, poll the same `JoinHandle` again for a much longer window and report which case it is:

| second poll | verdict |
|---|---|
| finishes | barrier released; host merely slow; budget undersized, code fine |
| still hung | barrier did not release; **explicitly says not to raise the budget** |

**The test still fails either way.** This classifies the failure; it does not tolerate it. The 5s deadline is deliberately unchanged.

## Both branches verified by inducing them

Shrinking `CLEAR_BUDGET` to `1ns` so the work outlives it but still completes:

```
clear missed 1ns but finished within 55.000000001s: the barrier released and this
host was merely slow, so the budget is undersized rather than the code being wrong (#1476)
```

Holding the publication guard instead of dropping it, so the barrier genuinely never releases:

```
clear never finished within 2.2s of the publication guard being dropped: the barrier
did not release. This is a lost wakeup, not load -- do not raise the budget (#1476)
```

Both proofs were reverted; `git diff --stat` is one file, and clippy + the test pass under `-D warnings`.

## Follow-up

There are ~20 other sites in `zccache-daemon-core` using 5s/1s `tokio::time::timeout` as hang detectors. I have not touched them — if this one turns out to be load, they are the same latent flake and deserve a shared named budget rather than 20 independent literals. That decision should follow the evidence this PR is designed to produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
