### PR TITLE
fix(env): one grammar for owned boolean switches, and trim it (#1478)

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/wrap/env.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/env.rs
@@ -149,7 +149,7 @@ pub(super) fn client_env(overrides: WrapperOverrides) -> Vec<(String, String)> {
 }
 
 pub(super) fn wrapper_disabled() -> bool {
-    std::env::var("ZCCACHE_DISABLE").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    crate::core::config::owned_env_flag_enabled("ZCCACHE_DISABLE")
 }
 
 fn set_client_env(env: &mut Vec<(String, String)>, key: &str, value: String) {

--- a/crates/zccache-cli-core/src/cli/commands/wrap/routing.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/routing.rs
@@ -46,7 +46,7 @@ pub(super) fn classify_invocation(tool: &str, tool_args: &[String]) -> WrapperRo
 /// without restarting the daemon. Default: disabled — opt-in only until
 /// the heuristic has shipped to enough downstream consumers.
 fn probe_bypass_enabled() -> bool {
-    std::env::var("ZCCACHE_PROBE_BYPASS").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    crate::core::config::owned_env_flag_enabled("ZCCACHE_PROBE_BYPASS")
 }
 
 /// Returns `true` when `tool_args` describes a probe-shaped compile that

--- a/crates/zccache-core/src/config/mod.rs
+++ b/crates/zccache-core/src/config/mod.rs
@@ -70,6 +70,38 @@ pub const COLOCATE_ENV: &str = "ZCCACHE_COLOCATE";
 /// spawning, not talking.
 pub const NO_SPAWN_ENV: &str = "ZCCACHE_NO_SPAWN";
 
+/// The canonical grammar for a zccache-**owned** boolean switch: `1` or
+/// case-insensitive `true` enables it; everything else — unset, empty, `0`,
+/// `false`, or any unrecognised value — leaves it disabled.
+///
+/// Unknown values must read as *disabled*, not enabled. Most of these knobs
+/// are named `*_DISABLE` / `*_NO_*`, so a permissive parser would let a typo
+/// turn the cache off. That is the opposite convention from a *foreign*
+/// variable whose value space we do not own (`CI`, `GITHUB_ACTIONS`), where
+/// presence with an unrecognised value is normally meant as "on" — those go
+/// through the denylist parser in `daemon::process`, not this one.
+///
+/// The value is trimmed. Environment variables acquire stray whitespace very
+/// easily (CI YAML, `set VAR=1 ` on Windows), and `ZCCACHE_DISABLE` is the
+/// documented emergency bypass — it silently doing nothing because of a
+/// trailing space is exactly the failure an operator cannot afford there.
+///
+/// Issue #1478: this grammar was previously written out three times as an
+/// inline expression, so nothing kept the copies in agreement.
+#[must_use]
+pub fn owned_flag_enabled(value: Option<&str>) -> bool {
+    value.is_some_and(|raw| {
+        let trimmed = raw.trim();
+        trimmed == "1" || trimmed.eq_ignore_ascii_case("true")
+    })
+}
+
+/// [`owned_flag_enabled`] applied to an environment variable.
+#[must_use]
+pub fn owned_env_flag_enabled(name: &str) -> bool {
+    owned_flag_enabled(std::env::var(name).ok().as_deref())
+}
+
 /// True when the host forbids standalone daemon spawns via [`NO_SPAWN_ENV`].
 #[must_use]
 pub fn daemon_spawn_disabled() -> bool {
@@ -79,9 +111,9 @@ pub fn daemon_spawn_disabled() -> bool {
 /// Testable core of [`daemon_spawn_disabled`] — no environment access.
 #[must_use]
 pub(crate) fn no_spawn_from_env_value(value: Option<&std::ffi::OsStr>) -> bool {
-    value
-        .map(|v| v.to_string_lossy())
-        .is_some_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    // One grammar, three former copies (#1478). OsStr -> str first.
+    let value = value.map(|v| v.to_string_lossy());
+    owned_flag_enabled(value.as_deref())
 }
 
 /// Standard error for a refused spawn. Names [`NO_SPAWN_ENV`] so operators

--- a/crates/zccache-core/src/config/tests.rs
+++ b/crates/zccache-core/src/config/tests.rs
@@ -847,3 +847,81 @@ fn no_spawn_error_names_the_env_var() {
     assert!(message.contains("ZCCACHE_NO_SPAWN"));
     assert!(message.contains("zccache-daemon"));
 }
+
+// --- owned boolean switch grammar (#1478) ---
+
+#[test]
+fn an_owned_flag_accepts_only_one_and_true() {
+    use super::owned_flag_enabled;
+
+    for value in ["1", "true", "TRUE", "True"] {
+        assert!(
+            owned_flag_enabled(Some(value)),
+            "expected enabled: {value:?}"
+        );
+    }
+    for value in ["0", "", "false", "no", "off", "yes", "on", "maybe", "2"] {
+        assert!(
+            !owned_flag_enabled(Some(value)),
+            "expected disabled: {value:?}"
+        );
+    }
+    assert!(!owned_flag_enabled(None));
+}
+
+#[test]
+fn an_unrecognised_value_never_enables_an_owned_flag() {
+    use super::owned_flag_enabled;
+
+    // These knobs are mostly named *_DISABLE / *_NO_*, so "unknown means on"
+    // would let a typo switch the cache off. This is the opposite convention
+    // from foreign variables like CI, which are read with a denylist.
+    for typo in ["ture", "TRUE!", "1 1", "enabled", "y"] {
+        assert!(
+            !owned_flag_enabled(Some(typo)),
+            "typo enabled the flag: {typo:?}"
+        );
+    }
+}
+
+#[test]
+fn an_owned_flag_tolerates_surrounding_whitespace() {
+    use super::owned_flag_enabled;
+
+    // Regression for #1478: the three inline copies of this grammar did not
+    // trim, so `ZCCACHE_DISABLE=1 ` -- trivially produced by CI YAML or
+    // `set VAR=1 ` on Windows -- silently did nothing. That variable is the
+    // documented emergency bypass, so failing open there is the worst place
+    // for a whitespace bug.
+    for value in [" 1", "1 ", "  1  ", "\ttrue\n", " TRUE "] {
+        assert!(
+            owned_flag_enabled(Some(value)),
+            "whitespace defeated: {value:?}"
+        );
+    }
+    // Trimming must not invent a value out of blank input.
+    for value in ["   ", "\t", "\n"] {
+        assert!(
+            !owned_flag_enabled(Some(value)),
+            "blank enabled the flag: {value:?}"
+        );
+    }
+}
+
+#[test]
+fn no_spawn_really_shares_the_owned_flag_grammar() {
+    use super::{no_spawn_from_env_value, owned_flag_enabled};
+    use std::ffi::OsStr;
+
+    // `no_spawn_value_grammar_matches_zccache_disable` asserts a *cross-variable*
+    // invariant while only exercising one implementation, so it could not catch
+    // the copies drifting apart. Compare the two predicates directly instead.
+    for value in ["1", "true", "TRUE", " 1 ", "0", "", "yes", "on", "maybe"] {
+        assert_eq!(
+            no_spawn_from_env_value(Some(OsStr::new(value))),
+            owned_flag_enabled(Some(value)),
+            "no_spawn disagrees with the shared grammar on {value:?}"
+        );
+    }
+    assert_eq!(no_spawn_from_env_value(None), owned_flag_enabled(None));
+}


### PR DESCRIPTION
First slice of #1478. Needs no API decision, and it fixes an observable defect in the emergency bypass.

## What I found that the issue did not

The issue names three parsers. There are **six** distinct semantics across ~165 `env::var` sites:

| idiom | truthy set | unknown → | sites |
|---|---|---|---|
| `var_os(..).is_some()` | *any value, incl. `0`/`false`* | **enabled** | 4 `ZCCACHE_*` |
| `is_some_and(v == "1")` | `{1}` | disabled | 1 |
| inline `v == "1" \|\| eq("true")` | `{1, true}` | disabled | **3** |
| `flag_truthy` | `{1,true,yes,on}` | disabled | 1 |
| `parse_bool` | `{1,true,yes,on}` | **`Err`** | 2 |
| `is_truthy` | denylist | **enabled** | 1 |

Two corrections worth recording:

**zccache does not have soldr's live defect.** The four presence-only switches are all diagnostics (`ZCCACHE_HIT_TRACE`, `ZCCACHE_PROFILE_CC_MISS`, `ZCCACHE_NO_UNLOCK`, `ZCCACHE_REQUIRE_FS_MATRIX`). No `*_DISABLE` is read with a denylist or presence-only parser, so no unrecognised value can switch the cache off.

**The owned/foreign split the issue proposes already exists de-facto** — it is just unwritten and unenforced. `is_truthy`'s denylist is used *only* for foreign CI variables (`CI`, `GITHUB_ACTIONS`), which is exactly the recommended treatment. `flag_truthy` is used only for a `SOLDR_*` variable and documents itself as matching setup-soldr's normalization. And `{1,true}` is the documented zccache-owned grammar. The families are principled; nothing keeps them that way.

## The actual defect

That documented owned grammar — *"Value grammar matches `ZCCACHE_DISABLE`: `1` or case-insensitive `true`"* — was written out **three times** as an inline expression and defined nowhere:

```
cli-core  wrap/env.rs      ZCCACHE_DISABLE
cli-core  wrap/routing.rs  ZCCACHE_PROBE_BYPASS
core      config/mod.rs    ZCCACHE_NO_SPAWN
```

**None of the three trims**, while the foreign-variable parser next door does. So `ZCCACHE_DISABLE=1 ` — one trailing space, trivially produced by CI YAML or `set VAR=1 ` on Windows — silently did nothing. That is the documented emergency bypass for a wedged build, so it fails open with no diagnostic in precisely the situation where an operator is already in trouble.

## The fix

`owned_flag_enabled` in `zccache-core`, with all three sites routed through it. Trimming is a **strict widening** — it can only turn a padded value that already meant "on" into "on"; nothing that currently enables becomes disabled.

Verified live against the built wrapper:

```
ZCCACHE_DISABLE="1 "     -> zccache[warn][F]: ZCCACHE_DISABLE is set; running cc directly, uncached
ZCCACHE_DISABLE="maybe"  -> routed to the daemon, no bypass
```

The second is the property that matters for this family: these knobs are mostly `*_DISABLE`/`*_NO_*`, so an unrecognised value must never mean "disable".

## A test that could not do its job

`no_spawn_value_grammar_matches_zccache_disable` asserts a **cross-variable** invariant while exercising only one of the three implementations — the copies could drift apart underneath it and it would still pass, with its name becoming a lie. This is the same tell the issue flags in soldr. Replaced with one that compares the two predicates directly.

Whitespace behaviour verified **RED** by dropping the trim: only `an_owned_flag_tolerates_surrounding_whitespace` fails, on `" 1"`.

## Deliberately not in scope

The presence-only diagnostics, `parse_bool`'s unknown-is-an-error semantics (arguably the *better* behaviour — loud rather than silent, so I did not quietly convert it to `false`), and whether to centralise all ~165 sites behind a declaration table plus a dylint. Those are the API decisions the issue is really asking about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
