### PR TITLE
docs: fix 21 broken internal links, and stop them rotting silently

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ A few things worth knowing:
   misses and recompiles — the cache cannot be poisoned across siblings (the
   invariant fixed in #197).
 - Measured win. The
-  [`perf_cpp_sibling_remap_warm` / `perf_rustc_sibling_remap_warm`](crates/zccache-daemon/tests/perf_bench_test.rs)
+  [`perf_cpp_sibling_remap_warm` / `perf_rustc_sibling_remap_warm`](crates/zccache/tests/perf_bench_test.rs)
   benchmarks (introduced in #238) confirm warm-state hits across sibling
   worktrees run an order of magnitude faster than bare compiles and sccache
   even though sccache cannot share across sibling roots at all.

--- a/ci/render_feature_matrix.py
+++ b/ci/render_feature_matrix.py
@@ -183,6 +183,25 @@ def _render_value(value: str) -> str:
     return VALUE_DISPLAY[value]
 
 
+def _repo_relative_to_docs(citation: str) -> str:
+    """Rewrite a repo-relative citation for a page that lives in `docs/`.
+
+    Citations in the YAML are written repo-relative (`README.md#anchor`,
+    `docs/journal-schema.md`) because that is how a human reads them. This
+    table is emitted to `docs/FEATURE-MATRIX.md`, so a verbatim href resolves
+    against `docs/` and 404s -- `README.md` became `docs/README.md`, and
+    `docs/journal-schema.md` became `docs/docs/journal-schema.md`.
+    """
+    path, sep, frag = citation.partition("#")
+    if not path:
+        return citation
+    if path.startswith("docs/"):
+        path = path[len("docs/") :]
+    else:
+        path = f"../{path}"
+    return f"{path}{sep}{frag}"
+
+
 def _evidence_link(evidence: str) -> str:
     """Render an evidence cell. If it looks like a URL, wrap as a Markdown link."""
     if not evidence:
@@ -190,7 +209,8 @@ def _evidence_link(evidence: str) -> str:
     if evidence.startswith("http://") or evidence.startswith("https://"):
         return f"[link]({evidence})"
     # Path-style citation like `README.md#anchor` or `docs/journal-schema.md`.
-    return f"[{evidence}]({evidence})"
+    # Label stays repo-relative; only the target is rewritten.
+    return f"[{evidence}]({_repo_relative_to_docs(evidence)})"
 
 
 def _ordered_categories(rows: Iterable[Row]) -> list[str]:

--- a/ci/tests/README.md
+++ b/ci/tests/README.md
@@ -18,3 +18,7 @@ tested rather than the file's text. It needs a POSIX bash and skips on Windows;
 the step it covers runs on `ubuntu-latest`. `test_release_publish_gating.py` guards the
 release recovery contract in CLAUDE.md § Publishing — that a failed run publishes
 nothing, that `dry-run` defaults to rehearsing, and that a partial release resumes.
+
+`test_doc_links.py` resolves every internal Markdown link in tracked files
+(`vendor/` excluded) and fails on a missing file or heading anchor, so the
+three-hop navigation guarantee in `docs/CLAUDE.md` cannot rot silently.

--- a/ci/tests/test_doc_links.py
+++ b/ci/tests/test_doc_links.py
@@ -1,0 +1,122 @@
+"""Every internal link in the docs must resolve.
+
+`docs/CLAUDE.md` promises an agent can reach any feature from `CLAUDE.md` in at
+most three hops. That guarantee is only as good as the links, and links rot
+silently: nothing fails when a heading is renamed or a file moves between
+crates. Twenty-two were already broken when this test was written, most of them
+fallout from the crate splits -- `crates/zccache/proto/...` after the proto
+moved to `zccache-protocol`, `src/audit.rs` after it moved to `zccache-audit`,
+and an index entry still advertising `ZCCACHE_FALLBACK`, a knob removed with
+the uncached fallback itself.
+
+Only tracked files are scanned, and `vendor/` is excluded: that is third-party
+source we do not edit.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+MARKDOWN_LINK = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+HEADING = re.compile(r"^(#{1,6})\s+(.*)$")
+EXCLUDED_PREFIXES = ("vendor/", ".claude/worktrees/")
+SKIPPED_SCHEMES = ("http://", "https://", "mailto:", "#")
+
+
+def _slug(heading: str) -> str:
+    """GitHub's anchor algorithm.
+
+    Two details matter and are easy to get wrong: underscores survive (only
+    backticks and emphasis are stripped), and *each* space becomes a hyphen, so
+    a heading containing `&` yields a double hyphen once the `&` is dropped.
+    """
+    text = heading.strip().lower()
+    text = re.sub(r"[`*]", "", text)
+    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)  # inline link -> its text
+    text = re.sub(r"[^\w\s-]", "", text)
+    return re.sub(r"\s", "-", text)
+
+
+def _anchors(path: Path) -> set[str]:
+    found: set[str] = set()
+    seen: dict[str, int] = {}
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = HEADING.match(line)
+        if not match:
+            continue
+        base = _slug(match.group(2))
+        count = seen.get(base, 0)
+        seen[base] = count + 1
+        # GitHub disambiguates repeats with -1, -2, ...
+        found.add(base if count == 0 else f"{base}-{count}")
+    return found
+
+
+def _tracked_markdown() -> list[Path]:
+    listed = subprocess.run(
+        ["git", "ls-files", "*.md"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [
+        ROOT / rel
+        for rel in listed.stdout.splitlines()
+        if rel and not rel.startswith(EXCLUDED_PREFIXES)
+    ]
+
+
+def _broken_links() -> list[str]:
+    anchors_by_file: dict[Path, set[str]] = {}
+    broken: list[str] = []
+
+    for source in _tracked_markdown():
+        if not source.exists():
+            continue
+        for raw in MARKDOWN_LINK.findall(
+            source.read_text(encoding="utf-8", errors="replace")
+        ):
+            if raw.startswith(SKIPPED_SCHEMES) or raw.startswith("/"):
+                continue
+            target, _, fragment = raw.partition("#")
+            destination = (source.parent / target).resolve() if target else source
+            where = source.relative_to(ROOT).as_posix()
+            if not destination.exists():
+                broken.append(f"{where} -> {raw} (missing file)")
+                continue
+            if fragment and destination.suffix == ".md":
+                if destination not in anchors_by_file:
+                    anchors_by_file[destination] = _anchors(destination)
+                if fragment.lower() not in anchors_by_file[destination]:
+                    broken.append(f"{where} -> {raw} (missing anchor)")
+    return broken
+
+
+def test_no_broken_internal_doc_links() -> None:
+    broken = _broken_links()
+
+    assert not broken, "broken internal doc links:\n  " + "\n  ".join(broken)
+
+
+def test_the_slug_algorithm_matches_github() -> None:
+    """Guards the two rules above; getting either wrong makes this test report
+    false breakage, which is worse than not having it."""
+    assert _slug("Standalone daemon identity, deployment & lifecycle") == (
+        "standalone-daemon-identity-deployment--lifecycle"
+    )
+    assert _slug("Host no-spawn guard (`ZCCACHE_NO_SPAWN`)") == (
+        "host-no-spawn-guard-zccache_no_spawn"
+    )
+    assert _slug("Why is zccache so much faster?") == "why-is-zccache-so-much-faster"
+
+
+def test_duplicate_headings_get_suffixed_anchors(tmp_path: Path) -> None:
+    page = tmp_path / "page.md"
+    page.write_text("# Notes\n\n## Notes\n\n### Notes\n", encoding="utf-8")
+
+    assert _anchors(page) == {"notes", "notes-1", "notes-2"}

--- a/crates/zccache/tests/audit-fixtures/README.md
+++ b/crates/zccache/tests/audit-fixtures/README.md
@@ -1,9 +1,9 @@
 # Audit-trace fixtures
 
 Canonical JSONL fixtures referenced by
-[`docs/architecture/audit-schema.md`](../../../docs/architecture/audit-schema.md).
+[`docs/architecture/audit-schema.md`](../../../../docs/architecture/audit-schema.md).
 Each line is a single audit event matching the `soldr.audit.v1` schema
-defined in [`crates/zccache/src/audit.rs`](../../src/audit.rs).
+defined in [`crates/zccache/src/audit.rs`](../../../zccache-audit/src/log_audit.rs).
 
 ## Normalization
 
@@ -27,7 +27,7 @@ asserts byte-for-byte equality against the fixture.
 ## Contributing new fixtures
 
 Host products that surface a new validation scenario during the
-[vendored-hotfix-workflow](../../../docs/architecture/vendored-hotfix-workflow.md)
+[vendored-hotfix-workflow](../../../../docs/architecture/vendored-hotfix-workflow.md)
 contribute the captured trace back here under the naming convention
 `embedded-<scenario>.jsonl`. The fixture's first event MUST be the
 `host.lifecycle.run.started` that opens the scope, and the last event

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,7 +46,7 @@ failed cache-root audit retain its diagnostic JSONL evidence.
 - **Async/process bridge — watchdogs, cancellation & timeouts (deadlock hardening)** → [runtime.md § Async / process bridge](architecture/runtime.md#async--process-bridge-watchdogs-cancellation--timeouts)
 - **Where zccache writes on disk (`ZCCACHE_CACHE_DIR` contract)** → [runtime.md § Cache root invariants](architecture/runtime.md#cache-root-invariants)
 - **Host no-spawn guard (`ZCCACHE_NO_SPAWN`, embedding hosts)** → [runtime.md § Host no-spawn guard](architecture/runtime.md#host-no-spawn-guard-zccache_no_spawn)
-- **Uncached-fallback policy (`ZCCACHE_FALLBACK`, CI hard-error)** → [runtime.md § Wrapper fallback policy](architecture/runtime.md#wrapper-fallback-policy-zccache_fallback-issue-1211)
+- **Daemon-unavailable policy (hard error, exit 125; the `ZCCACHE_FALLBACK` gate was removed with the fallback)** → [runtime.md § Daemon unavailable is a hard error](architecture/runtime.md#daemon-unavailable-is-a-hard-error-issue-1170)
 - **Standalone daemon identity, deployment & lifecycle (argv[0] single binary, version-rooted deploy, versioned endpoints)** → [runtime.md § Standalone daemon identity, deployment & lifecycle](architecture/runtime.md#standalone-daemon-identity-deployment--lifecycle)
 - **Rejected depgraph snapshots — quarantine, recovery, why no migration** → [runtime.md § Depgraph snapshot quarantine](architecture/runtime.md#depgraph-snapshot-quarantine)
 - **Windows/macOS/Linux differences** → [portability.md](architecture/portability.md)

--- a/docs/FEATURE-MATRIX.md
+++ b/docs/FEATURE-MATRIX.md
@@ -11,21 +11,21 @@ sccache claims are best-effort and sourced from the upstream README and docs at 
 | Feature | zccache | sccache | Notes | Evidence |
 |---|:---:|:---:|---|---|
 | C/C++ object caching | yes | yes | Core feature of both caches; per-translation-unit `.o` caching. | [link](https://github.com/mozilla/sccache/blob/main/README.md) |
-| Link caching (artifact + sibling files) | yes | no | zccache snapshots the output dir before the linker, captures sibling .pdb/.wasm/.map/runtime DLLs, restores them on hit. | [README.md#link-time-side-effects](README.md#link-time-side-effects) |
+| Link caching (artifact + sibling files) | yes | no | zccache snapshots the output dir before the linker, captures sibling .pdb/.wasm/.map/runtime DLLs, restores them on hit. | [README.md#link-time-side-effects](../README.md#link-time-side-effects) |
 | Rust rustc caching (--emit=metadata, --emit=link, extern crate hashing) | yes | yes | Both wrap `rustc`. zccache adds extern-crate content hashing for cross-worktree sharing. | [link](https://github.com/mozilla/sccache/blob/main/README.md#rust) |
 | Emscripten (emcc / em++) | yes | no | zccache caches `emcc`/`em++` end-to-end. sccache's README documents C/C++/Rust/CUDA but not Emscripten. | [link](https://github.com/mozilla/sccache/blob/main/README.md) |
-| wasm-ld linking | yes | no | WebAssembly linking cached as part of zccache's link-caching path. | [README.md#link-time-side-effects](README.md#link-time-side-effects) |
+| wasm-ld linking | yes | no | WebAssembly linking cached as part of zccache's link-caching path. | [README.md#link-time-side-effects](../README.md#link-time-side-effects) |
 | CUDA / nvcc | no | yes | sccache supports CUDA caching; zccache does not yet (out of current scope). | [link](https://github.com/mozilla/sccache/blob/main/README.md) |
 | MSVC cl.exe / link.exe | partial | yes | zccache parses MSVC-style args and supports `clang-cl`; native `cl.exe`/`link.exe` integration is partial. sccache has first-class MSVC support. | [link](https://github.com/mozilla/sccache/blob/main/README.md) |
-| Multi-file compilation fast path | yes | no | `clang++ -c a.cpp b.cpp c.cpp` — per-file parallel cache lookups, only misses go to the compiler. | [README.md](README.md) |
-| Response file (.rsp) expansion | yes | partial | zccache fully expands nested response files. sccache passes them through but does not deeply normalize them. | [README.md](README.md) |
+| Multi-file compilation fast path | yes | no | `clang++ -c a.cpp b.cpp c.cpp` — per-file parallel cache lookups, only misses go to the compiler. | [README.md](../README.md) |
+| Response file (.rsp) expansion | yes | partial | zccache fully expands nested response files. sccache passes them through but does not deeply normalize them. | [README.md](../README.md) |
 
 ## Tool coverage
 
 | Feature | zccache | sccache | Notes | Evidence |
 |---|:---:|:---:|---|---|
-| clang-tidy (static analysis results cached) | yes | no | Static analysis diagnostics cached per translation unit and replayed on hit. | [README.md](README.md) |
-| include-what-you-use (IWYU) | yes | no | IWYU output cached and replayed per translation unit. | [README.md](README.md) |
+| clang-tidy (static analysis results cached) | yes | no | Static analysis diagnostics cached per translation unit and replayed on hit. | [README.md](../README.md) |
+| include-what-you-use (IWYU) | yes | no | IWYU output cached and replayed per translation unit. | [README.md](../README.md) |
 | rustfmt | yes | no | zccache routes rustfmt; recursive invocations always run so changed child modules cannot hide behind unchanged crate-root markers, while explicit skip_children=true invocations can use content markers. sccache caches rustc only. | [link](https://github.com/mozilla/sccache/blob/main/README.md#rust) |
 | clippy | yes | no | zccache caches clippy lint output. sccache caches rustc but not the lint pass. | [link](https://github.com/mozilla/sccache/blob/main/README.md#rust) |
 | cargo check / cargo build | yes | yes | Both work as `RUSTC_WRAPPER` for `cargo check`/`cargo build`. | [link](https://github.com/mozilla/sccache/blob/main/README.md#rust) |
@@ -45,26 +45,26 @@ sccache claims are best-effort and sourced from the upstream README and docs at 
 
 | Feature | zccache | sccache | Notes | Evidence |
 |---|:---:|:---:|---|---|
-| Persistent daemon with sub-ms IPC | yes | partial | zccache's daemon serves hits in ~1ms over a single IPC roundtrip. sccache has a server, but each call pays ~170ms (spawn + handshake + disk I/O). | [README.md#why-is-zccache-so-much-faster-on-warm-hits](README.md#why-is-zccache-so-much-faster-on-warm-hits) |
+| Persistent daemon with sub-ms IPC | yes | partial | zccache's daemon serves hits in ~1ms over a single IPC roundtrip. sccache has a server, but each call pays ~170ms (spawn + handshake + disk I/O). | [README.md#why-is-zccache-so-much-faster-on-warm-hits](../README.md#why-is-zccache-so-much-faster-on-warm-hits) |
 | Single-roundtrip IPC (length-prefixed prost) | yes | no | One length-prefixed prost message per compile, with a bincode retry only after an explicit old-daemon version rejection. sccache's protocol uses multiple subprocess invocations per call. | [link](https://github.com/mozilla/sccache/blob/main/README.md) |
-| Safe hardlink delivery on hit | yes | no | Cache hits use a capability-driven reflink, protected-hardlink, or copy ladder. sccache copies bytes back over IPC. | [README.md#why-is-zccache-so-much-faster-on-warm-hits](README.md#why-is-zccache-so-much-faster-on-warm-hits) |
-| Reflink delivery (ReFS, btrfs/XFS, APFS) | yes | no | zccache probes volume-pair capabilities and prefers true block-level COW while preserving stored mtimes. | [README.md#safe-filesystem-materialization](README.md#safe-filesystem-materialization) |
-| In-memory metadata cache (DashMap) | yes | no | File sizes, mtimes, and content hashes live in a lock-free DashMap. Cache key computation is a memory lookup. | [README.md#why-is-zccache-so-much-faster-on-warm-hits](README.md#why-is-zccache-so-much-faster-on-warm-hits) |
-| Filesystem watcher (notify-backed) | yes | no | Background `notify` watcher tracks file changes in real time, so the daemon already knows whether inputs are dirty before compile is invoked. | [README.md#why-is-zccache-so-much-faster-on-warm-hits](README.md#why-is-zccache-so-much-faster-on-warm-hits) |
+| Safe hardlink delivery on hit | yes | no | Cache hits use a capability-driven reflink, protected-hardlink, or copy ladder. sccache copies bytes back over IPC. | [README.md#why-is-zccache-so-much-faster-on-warm-hits](../README.md#why-is-zccache-so-much-faster-on-warm-hits) |
+| Reflink delivery (ReFS, btrfs/XFS, APFS) | yes | no | zccache probes volume-pair capabilities and prefers true block-level COW while preserving stored mtimes. | [README.md#safe-filesystem-materialization](../README.md#safe-filesystem-materialization) |
+| In-memory metadata cache (DashMap) | yes | no | File sizes, mtimes, and content hashes live in a lock-free DashMap. Cache key computation is a memory lookup. | [README.md#why-is-zccache-so-much-faster-on-warm-hits](../README.md#why-is-zccache-so-much-faster-on-warm-hits) |
+| Filesystem watcher (notify-backed) | yes | no | Background `notify` watcher tracks file changes in real time, so the daemon already knows whether inputs are dirty before compile is invoked. | [README.md#why-is-zccache-so-much-faster-on-warm-hits](../README.md#why-is-zccache-so-much-faster-on-warm-hits) |
 | Content-addressed artifact store | yes | yes | Both hash-key cache entries by input content. | [link](https://github.com/mozilla/sccache/blob/main/README.md) |
 | Protocol versioning (wire-format bump policy) | yes | partial | zccache embeds `PROTOCOL_VERSION` in every IPC frame and bumps it on any wire-format change. sccache versions its server but the policy is less explicit. | [link](https://github.com/mozilla/sccache/blob/main/README.md) |
-| Compile journal (JSONL diagnostics) | yes | no | Every compile is recorded as secret-safe JSONL for diagnostics and partial replay; exact replay requires an independently captured trusted environment. | [docs/journal-schema.md](docs/journal-schema.md) |
+| Compile journal (JSONL diagnostics) | yes | no | Every compile is recorded as secret-safe JSONL for diagnostics and partial replay; exact replay requires an independently captured trusted environment. | [docs/journal-schema.md](journal-schema.md) |
 | Session stats / per-build hit rates | yes | partial | sccache exposes lifetime `--show-stats`. zccache adds per-session/per-build hit rates over the daemon connection. | [link](https://github.com/mozilla/sccache/blob/main/README.md) |
-| Crash dumper (CLI + daemon) | yes | no | `zccache_core::crash::install` captures structured crash dumps for both binaries. | [docs/architecture/runtime.md](docs/architecture/runtime.md) |
+| Crash dumper (CLI + daemon) | yes | no | `zccache_core::crash::install` captures structured crash dumps for both binaries. | [docs/architecture/runtime.md](architecture/runtime.md) |
 
 ## Worktree / multi-checkout
 
 | Feature | zccache | sccache | Notes | Evidence |
 |---|:---:|:---:|---|---|
-| ZCCACHE_PATH_REMAP=auto cross-worktree sharing | yes | no | One cache entry serves every worktree of the same repo. Hashes are computed against a canonical path; absolute paths are remapped on the fly. | [README.md](README.md) |
-| C/C++ -ffile-prefix-map injection | yes | no | zccache injects `-ffile-prefix-map` automatically so debug info points at the canonical path, not the worktree path. | [README.md](README.md) |
-| Rust --remap-path-prefix injection | yes | no | zccache injects `--remap-path-prefix` so rustc output is worktree-independent. | [README.md](README.md) |
-| Strict path validation | yes | no | `--strict-paths` rejects cache entries with non-canonical paths instead of silently leaking worktree paths. | [README.md](README.md) |
+| ZCCACHE_PATH_REMAP=auto cross-worktree sharing | yes | no | One cache entry serves every worktree of the same repo. Hashes are computed against a canonical path; absolute paths are remapped on the fly. | [README.md](../README.md) |
+| C/C++ -ffile-prefix-map injection | yes | no | zccache injects `-ffile-prefix-map` automatically so debug info points at the canonical path, not the worktree path. | [README.md](../README.md) |
+| Rust --remap-path-prefix injection | yes | no | zccache injects `--remap-path-prefix` so rustc output is worktree-independent. | [README.md](../README.md) |
+| Strict path validation | yes | no | `--strict-paths` rejects cache entries with non-canonical paths instead of silently leaking worktree paths. | [README.md](../README.md) |
 
 ## Storage backends
 
@@ -89,22 +89,22 @@ sccache claims are best-effort and sourced from the upstream README and docs at 
 | macOS arm64 (Apple Silicon) | yes | yes |  |  |
 | Windows x86_64 | yes | yes |  |  |
 | Windows arm64 | yes | partial | zccache ships native Windows arm64 wheels and binaries. sccache's release coverage of Windows arm64 is partial. | [link](https://github.com/mozilla/sccache/blob/main/README.md) |
-| Windows Defender exclusion helper | yes | no | `zccache defender-exclusions add` excludes the cache root from Defender real-time scans, recovering minutes of wall-time on Windows. | [README.md#windows-defender-exclusions](README.md#windows-defender-exclusions) |
+| Windows Defender exclusion helper | yes | no | `zccache defender-exclusions add` excludes the cache root from Defender real-time scans, recovering minutes of wall-time on Windows. | [README.md#windows-defender-exclusions](../README.md#windows-defender-exclusions) |
 | PyPI wheels | yes | no | zccache ships native wheels per-platform; PyPI is the distribution channel. sccache distributes via crates.io and GitHub releases. | [link](https://github.com/mozilla/sccache/blob/main/README.md) |
 | crates.io publishing | yes | yes | Both publish to crates.io (`zccache-cli` / `zccache-daemon` / `zccache-core` vs `sccache`). | [link](https://crates.io/crates/sccache) |
 | GitHub Action (composite) | yes | yes | zccache ships a composite action that replaces `sccache-action` + `Swatinem/rust-cache`. sccache is wired via `mozilla-actions/sccache-action`. | [link](https://github.com/mozilla-actions/sccache-action) |
-| Target snapshot caching + zccache warm backfill | yes | no | zccache snapshots `target/` and backfills the daemon cache on restore. sccache leaves target/ caching to `Swatinem/rust-cache`. | [README.md](README.md) |
+| Target snapshot caching + zccache warm backfill | yes | no | zccache snapshots `target/` and backfills the daemon cache on restore. sccache leaves target/ caching to `Swatinem/rust-cache`. | [README.md](../README.md) |
 
 ## Performance posture
 
 | Feature | zccache | sccache | Notes | Evidence |
 |---|:---:|:---:|---|---|
-| Per-hit cost | yes | partial | zccache serves hits in ~1ms (in-memory lookup + hardlink). sccache pays ~170ms per call (spawn + hash + IPC + disk I/O). | [README.md#why-is-zccache-so-much-faster-on-warm-hits](README.md#why-is-zccache-so-much-faster-on-warm-hits) |
-| mtime preservation on hits | yes | partial | zccache preserves the cached artifact's mtime so cargo's incremental fingerprint doesn't invalidate downstream crates. | [CLAUDE.md](CLAUDE.md) |
-| Compiler child priority (auto-throttle at 95% CPU) | yes | no | zccache demotes compiler children when system CPU is saturated, keeping the host responsive during big rebuilds. | [README.md](README.md) |
+| Per-hit cost | yes | partial | zccache serves hits in ~1ms (in-memory lookup + hardlink). sccache pays ~170ms per call (spawn + hash + IPC + disk I/O). | [README.md#why-is-zccache-so-much-faster-on-warm-hits](../README.md#why-is-zccache-so-much-faster-on-warm-hits) |
+| mtime preservation on hits | yes | partial | zccache preserves the cached artifact's mtime so cargo's incremental fingerprint doesn't invalidate downstream crates. | [CLAUDE.md](../CLAUDE.md) |
+| Compiler child priority (auto-throttle at 95% CPU) | yes | no | zccache demotes compiler children when system CPU is saturated, keeping the host responsive during big rebuilds. | [README.md](../README.md) |
 
 ## Reliability
 
 | Feature | zccache | sccache | Notes | Evidence |
 |---|:---:|:---:|---|---|
-| Hardlink cache-poisoning prevention and detection | yes | partial | Read-only blobs, native-file-ID registry, mediated detach, and watcher-assisted suspect verification prevent silent poisoning. | [README.md#safe-filesystem-materialization](README.md#safe-filesystem-materialization) |
+| Hardlink cache-poisoning prevention and detection | yes | partial | Read-only blobs, native-file-ID registry, mediated detach, and watcher-assisted suspect verification prevent silent poisoning. | [README.md#safe-filesystem-materialization](../README.md#safe-filesystem-materialization) |

--- a/docs/WIRE_STABILITY.md
+++ b/docs/WIRE_STABILITY.md
@@ -22,9 +22,9 @@ in-process or out-of-process client:
   so the SDK's compile-time collision checks fire on every build.
 - The inner payload. Prost-encoded `zccache.v1.Request` / `zccache.v1.Response`
   messages (plus their transitive types) defined in
-  [`crates/zccache/proto/zccache_v1.proto`](../crates/zccache/proto/zccache_v1.proto)
+  [`crates/zccache/proto/zccache_v1.proto`](../crates/zccache-protocol/proto/zccache_v1.proto)
   and the auxiliary
-  [`crates/zccache/src/artifact/rust_plan_manifest.proto`](../crates/zccache/src/artifact/rust_plan_manifest.proto).
+  [`crates/zccache/src/artifact/rust_plan_manifest.proto`](../crates/zccache-artifact/src/rust_plan_manifest.proto).
   These messages are the focus of the rest of this document.
 
 ## The contract
@@ -59,7 +59,7 @@ What **is** allowed without bumping the protocol version:
 ## Versioning
 
 The package is `zccache.v1` and the file's frozen body lives at
-[`crates/zccache/proto/zccache_v1.proto`](../crates/zccache/proto/zccache_v1.proto).
+[`crates/zccache/proto/zccache_v1.proto`](../crates/zccache-protocol/proto/zccache_v1.proto).
 A future incompatible change — if one is ever needed — would ship as a
 parallel `zccache.v2` namespace with its own `.proto`, never as an in-place
 mutation of v1. Old daemons keep speaking v1 forever; clients that need v2

--- a/docs/architecture/audit-schema.md
+++ b/docs/architecture/audit-schema.md
@@ -9,7 +9,7 @@
 This document is the public contract for the JSON Lines (JSONL) audit
 events that an embedded zccache emits when a host product configures
 `AuditConfig::mode > Off`. The on-disk source of truth is
-[`crates/zccache/src/audit.rs`](../../crates/zccache/src/audit.rs); this
+[`crates/zccache/src/audit.rs`](../../crates/zccache-audit/src/log_audit.rs); this
 doc explains the wire shape, the compatibility policy, the redaction
 contract, and how host products correlate event causality across crate
 boundaries.


### PR DESCRIPTION
Found while auditing `ZCCACHE_*` variables for #1478 — one documented knob had no reader anywhere, which turned out to be the tip of a larger problem.

## The guarantee that was already false

`docs/CLAUDE.md` promises an agent can reach any feature from `CLAUDE.md` in at most three hops. **22 internal links were broken**, so it was already partly false. Most are fallout from the crate splits, which moved files without moving the references:

```
crates/zccache/proto/zccache_v1.proto     -> zccache-protocol/proto/
crates/zccache/src/artifact/*.proto       -> zccache-artifact/src/
crates/zccache/src/audit.rs               -> zccache-audit/src/log_audit.rs
crates/zccache-daemon/tests/perf_bench_*  -> crates/zccache/tests/
```

## One was worse than a dead link

`ARCHITECTURE.md` advertised **"Uncached-fallback policy (`ZCCACHE_FALLBACK`, CI hard-error)"** as current policy, linking to a heading that no longer exists. `runtime.md` says plainly that the knob *"is gone with it"* — #1170 made daemon-unavailable a hard error and removed the fallback entirely.

So the index was offering an operator a switch that does nothing, in the one area where believing the docs gets your build silently uncached. That is also how I found it: `ZCCACHE_FALLBACK` appears in the docs and in **no** source file, Rust or shell.

## The FEATURE-MATRIX links were a generator bug, not rot

Citations in `feature-matrix.yaml` are written repo-relative because that is how a human reads them, but the renderer emitted them **verbatim** into a page that lives in `docs/`. So `README.md#anchor` resolved to `docs/README.md` — which has exactly one heading and none of the anchors — and `docs/journal-schema.md` resolved to `docs/docs/journal-schema.md`.

Fixed in `_evidence_link`, so the label stays repo-relative and only the href is rewritten. Rewriting the YAML instead would have left the next entry to reintroduce it. `--check` confirms the regenerated file is in sync.

## The checker, and why its own algorithm is tested

`test_doc_links.py` resolves every internal link in tracked Markdown and fails on a missing file or anchor. Both failure modes verified **RED**:

```
docs/ARCHITECTURE.md -> architecture/runtime.md#this-heading-does-not-exist (missing anchor)
docs/ARCHITECTURE.md -> architecture/gone.md#... (missing file)
```

Two details of GitHub's slug algorithm are easy to get wrong, and are pinned by their own test: **underscores survive** (only backticks and emphasis are stripped), and **each space maps to one hyphen**, so a heading containing `&` yields a double hyphen.

I know they are easy to get wrong because my first attempt got both wrong and reported **1,395** broken links — nearly all false, against headings that plainly existed. A checker that cries wolf is worse than no checker, so the algorithm is now guarded rather than assumed.

## Scope

The one remaining broken link is in `vendor/notify/README.md` — third-party source we do not edit, so `vendor/` is excluded.

`ci/tests` is still not run by CI (#1474, blocked on one decision). Locally: `410 passed`, with the single known unrelated failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
