### PR TITLE
ci: auto-cancel superseded PR runs; stop dropping queued main runs

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -29,7 +29,9 @@ on:
       - "tasks/**"
 
 concurrency:
-  group: ci-linux-${{ github.ref }}
+  # run_id fallback on non-PR events: GitHub keeps at most ONE pending run
+  # per group, so a ref-only group silently cancels queued main-push SHAs.
+  group: ci-linux-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -34,7 +34,9 @@ on:
 # main are never cancelled: release-auto.yml triggers on push-to-main
 # version bumps, so every commit that lands must be fully tested.
 concurrency:
-  group: ci-macos-${{ github.ref }}
+  # run_id fallback on non-PR events: GitHub keeps at most ONE pending run
+  # per group, so a ref-only group silently cancels queued main-push SHAs.
+  group: ci-macos-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -29,7 +29,9 @@ on:
       - "tasks/**"
 
 concurrency:
-  group: ci-windows-${{ github.ref }}
+  # run_id fallback on non-PR events: GitHub keeps at most ONE pending run
+  # per group, so a ref-only group silently cancels queued main-push SHAs.
+  group: ci-windows-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,14 @@ on:
       - ".editorconfig"
       - "tasks/**"
 
+# Auto-cancel superseded PR runs: pushing again to a feature branch
+# supersedes the in-flight run instead of queueing behind it. Non-PR events
+# key on run_id so each gets its own group -- GitHub keeps only ONE pending
+# run per group, so a shared group silently drops queued main-push SHAs.
+concurrency:
+  group: ci-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"

--- a/.github/workflows/feature-matrix-check.yml
+++ b/.github/workflows/feature-matrix-check.yml
@@ -27,6 +27,14 @@ on:
       - "README.md"
       - ".github/workflows/feature-matrix-check.yml"
 
+# Auto-cancel superseded PR runs: pushing again to a feature branch
+# supersedes the in-flight run instead of queueing behind it. Non-PR events
+# key on run_id so each gets its own group -- GitHub keeps only ONE pending
+# run per group, so a shared group silently drops queued main-push SHAs.
+concurrency:
+  group: feature-matrix-check-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     name: Feature matrix is rendered

--- a/.github/workflows/fs-matrix.yml
+++ b/.github/workflows/fs-matrix.yml
@@ -32,7 +32,9 @@ on:
       - "tasks/**"
 
 concurrency:
-  group: fs-matrix-${{ github.ref }}
+  # run_id fallback on non-PR events: GitHub keeps at most ONE pending run
+  # per group, so a ref-only group silently cancels queued main-push SHAs.
+  group: fs-matrix-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/wire-stability.yml
+++ b/.github/workflows/wire-stability.yml
@@ -23,6 +23,14 @@ on:
   push:
     branches: [main]
 
+# Auto-cancel superseded PR runs: pushing again to a feature branch
+# supersedes the in-flight run instead of queueing behind it. Non-PR events
+# key on run_id so each gets its own group -- GitHub keeps only ONE pending
+# run per group, so a shared group silently drops queued main-push SHAs.
+concurrency:
+  group: wire-stability-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     name: Verify wire stability snapshot

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -38,7 +38,9 @@ on:
       - "tasks/**"
 
 concurrency:
-  group: wrapper-e2e-${{ github.ref }}
+  # run_id fallback on non-PR events: GitHub keeps at most ONE pending run
+  # per group, so a ref-only group silently cancels queued main-push SHAs.
+  group: wrapper-e2e-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
Closes #1484

**Added block (3):** `ci.yml`, `feature-matrix-check.yml`, `wire-stability.yml`
**Added run_id fallback (5):** `ci-linux.yml`, `ci-macos.yml`, `ci-windows.yml`, `fs-matrix.yml`, `wrapper-e2e.yml`

## The two bugs

### 1. PR-triggered workflows with no `concurrency:` block

Pushing again to a feature branch queued a **fresh** copy while the superseded run kept burning runner minutes. Agents iterating on a branch make this acute — a one-line fixup costs as much as the original push. These now carry the canonical block.

### 2. Ref-only groups silently drop queued `main`-push runs

```yaml
group: ci-linux-${{ github.ref }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

On `pull_request` that is correct. On **push to `main`** it is not: `cancel-in-progress` is false there, so runs *queue* — and GitHub keeps at most **one pending run per group**: *"Any previously pending job or workflow in the concurrency group will be canceled."*

During a burst of merges: SHA A runs → SHA B goes pending → SHA C arrives → **B is cancelled and never runs.** No red X, just a run that never happened.

Fix keeps each existing group prefix and only makes it vary per run on non-PR events:

```yaml
group: ci-linux-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
```

PR behavior is unchanged.

## Verification

Every workflow file re-parsed as YAML; a re-audit shows 0 remaining ref-only-plus-conditional-cancel groups and 0 PR-triggered workflows without a block.

Part of a cross-repo sweep with FastLED/fbuild#1363, zackees/soldr#2751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deliberately untouched

`broker-stress`, `perf-guard`, `test-action` and `integration` use unconditional `cancel-in-progress: true` — they supersede on *every* ref by design, so the latest SHA always runs and nothing is silently dropped; a `run_id` fallback would **change** their behavior. `integration.yml` also already carries an event discriminator in its group.