### PR TITLE
docs: give the seven undocumented directories a README, and check the rule

### DIFF
--- a/.github/actions/build-target/README.md
+++ b/.github/actions/build-target/README.md
@@ -1,0 +1,26 @@
+# `build-target` composite action
+
+Builds the zccache binaries for **one** Rust target triple and stages the
+release artifacts for it. Used by `build.yml` (the 8-target dist matrix) and
+by `release-auto.yml`, so both paths produce identically-shaped artifacts
+rather than each workflow rolling its own packaging steps.
+
+## Inputs
+
+- `target` (required) — the Rust target triple.
+- `cache_key` (required) — cache key suffix passed to setup-soldr.
+- `binary_ext` — executable suffix, e.g. `.exe`.
+- `use_soldr` — use setup-soldr for setup and caching (default `true`).
+- `cross_compile` / `cross_driver` — build from a Linux x86 host with a
+  soldr-managed cross driver (`native`, `zigbuild`, or `xwin`).
+- `prebuild_deps` — setup-soldr prebuild dependency mode.
+
+## Outputs
+
+- `staging_dir` — staged binaries plus any Python artifacts.
+- `standalone_dir` — packaged standalone archives.
+
+The `cross_driver` choice is not cosmetic: the `xwin` driver is how the
+aarch64-pc-windows-msvc leg is produced, and a flag set for one crate there
+is read by every `cc-rs` build script in the graph — which is what broke the
+1.13.6 release (#1440, #1472).

--- a/ci/tests/README.md
+++ b/ci/tests/README.md
@@ -26,3 +26,7 @@ three-hop navigation guarantee in `docs/CLAUDE.md` cannot rot silently.
 `test_crate_docs.py` checks `crates/CLAUDE.md` against the actual workspace
 members — no phantom crates, no undocumented ones, and the stated count
 matching in both `CLAUDE.md` files.
+
+`test_readme_coverage.py` asserts every directory with tracked files carries a
+`README.md`. The `readme_guard.py` hook only fires on an *edited* directory, so
+untouched ones could sit without one indefinitely — seven did.

--- a/ci/tests/test_readme_coverage.py
+++ b/ci/tests/test_readme_coverage.py
@@ -1,0 +1,60 @@
+"""Every directory with tracked files carries a README.md.
+
+`CLAUDE.md` states the rule and says it is "enforced by hook", but
+`ci/hooks/readme_guard.py` only fires when a file in that directory is
+*edited*. A directory nobody has touched since the rule landed can sit without
+one indefinitely, which is how seven of them did -- including
+`perf/scenarios/build-then-check` (the one scenario of six without a README)
+and `.github/actions/build-target` (a composite action used by both the dist
+matrix and the release pipeline).
+
+This closes the gap the hook cannot: it checks the whole tree rather than the
+files in front of it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+# `.cargo` holds only `config.toml`; it is a repo-local cargo home, not a
+# source directory, and the rest of it is generated and gitignored.
+EXEMPT = {".cargo"}
+
+
+def _directories_with_tracked_files() -> set[str]:
+    listed = subprocess.run(
+        ["git", "ls-files"], cwd=ROOT, capture_output=True, text=True, check=True
+    )
+    directories = set()
+    for rel in listed.stdout.splitlines():
+        parent = str(Path(rel).parent).replace("\\", "/")
+        if parent not in (".", ""):
+            directories.add(parent)
+    return directories
+
+
+def test_every_directory_with_files_has_a_readme() -> None:
+    missing = sorted(
+        directory
+        for directory in _directories_with_tracked_files()
+        if directory not in EXEMPT and not (ROOT / directory / "README.md").is_file()
+    )
+
+    assert not missing, "directories without README.md:\n  " + "\n  ".join(missing)
+
+
+def test_the_exemption_list_is_still_justified() -> None:
+    """An exemption that stops being true is a hole nobody notices. `.cargo`
+    earns its place only while `config.toml` is the sole tracked file in it."""
+    listed = subprocess.run(
+        ["git", "ls-files", ".cargo"], cwd=ROOT, capture_output=True, text=True, check=True
+    )
+    tracked = [line for line in listed.stdout.splitlines() if line]
+
+    assert tracked == [".cargo/config.toml"], (
+        f".cargo now tracks more than config.toml ({tracked}); "
+        "it should either get a README.md or a narrower exemption"
+    )

--- a/crates/zccache-compiler/src/response_file/README.md
+++ b/crates/zccache-compiler/src/response_file/README.md
@@ -1,0 +1,15 @@
+# response_file
+
+Compiler-specific formatting for response files — the `@file` argument
+indirection used when a command line would otherwise exceed the OS limit.
+
+Each compiler family quotes and escapes differently, so a single formatter
+would silently corrupt arguments for one of them.
+
+## Layout
+
+- `format.rs` — `gnu` plus the `*_if_safe` variants (`gnu_if_safe`,
+  `msvc_if_safe`, `rustc_if_safe`). The `_if_safe` forms return `None` rather
+  than emitting a response file when an argument cannot be represented
+  losslessly in that family's grammar, so the caller falls back to a direct
+  command line instead of shipping a mangled one.

--- a/crates/zccache/tests/common/README.md
+++ b/crates/zccache/tests/common/README.md
@@ -1,0 +1,12 @@
+# Shared integration-test helpers
+
+Small utilities used by more than one integration test in
+`crates/zccache/tests/`. Included with `mod common;`, so unused items need
+`#[allow(dead_code)]` — a test binary that does not call a helper would
+otherwise fail the workspace's `-D warnings`.
+
+- `create_file` — write a file, creating parent directories.
+- `rel_paths` — relative paths from `ScannedFile`s, for assertions.
+- `wait_for_mtime_change` — sleeps past filesystem mtime granularity. Windows
+  NTFS does not always advance mtime on rapid successive writes, so tests that
+  depend on an mtime change must wait rather than assume.

--- a/dylints/ban_std_pathbuf/ui/README.md
+++ b/dylints/ban_std_pathbuf/ui/README.md
@@ -1,0 +1,9 @@
+# UI tests
+
+`*.rs` here are minimal programs that exercise specific lint behavior. For
+each, `dylint_testing::ui_test` compiles the file and asserts the resulting
+diagnostics match the adjacent `*.stderr` snapshot.
+
+- `disallowed.rs` — a bare `std::path::PathBuf` binding, which must trigger
+  the lint. Raw `PathBuf` does not carry zccache's normalization invariant,
+  so it is banned outside the platform leaf and an explicit legacy allowlist.

--- a/perf/scenarios/build-then-check/README.md
+++ b/perf/scenarios/build-then-check/README.md
@@ -1,0 +1,6 @@
+scenario that runs a cold `cargo build --release` and then an immediate
+`cargo check --release` over an unchanged source tree. red here means the
+check pass cannot reuse the metadata the build pass already cached: zccache
+keys on rustc's `--emit`, so `check` and `build` land on different keys and
+check misses even though the metadata it needs is already present
+(soldr#758).

--- a/python/zccache/fingerprint/README.md
+++ b/python/zccache/fingerprint/README.md
@@ -1,0 +1,13 @@
+# `zccache.fingerprint`
+
+Python API over the Rust fingerprinting engine — content hashes and change
+detection for a file set, without shelling out to the `zccache-fp` binary.
+
+`__init__.py` is the public surface (`Api`, `FingerprintCache`,
+`FingerprintDecision`, `FingerprintManager`, `FingerprintResult`); the
+underscore modules are implementation detail and may change without notice.
+
+- `_manager.py` — `FingerprintManager`: `read` / `write` / `check` /
+  `save_all`, plus an mtime fast path that avoids hashing when the cheap
+  stat already proves nothing changed.
+- `_result.py` — `FingerprintResult`, the dataclass returned to callers.

--- a/python/zccache/watcher/README.md
+++ b/python/zccache/watcher/README.md
@@ -1,0 +1,7 @@
+# `zccache.watcher`
+
+Cross-platform Python watcher API backed by the Rust polling engine, so
+callers get identical semantics on Linux, macOS, and Windows rather than the
+platform-specific behaviour of a native OS notification API.
+
+`__init__.py` is the whole public surface.


### PR DESCRIPTION
Third in the docs-accuracy sweep, and the same shape as the first two: a rule that is stated and believed, with an enforcement gap nobody could see.

## The gap

`CLAUDE.md` requires every directory with files to carry a `README.md`, "enforced by hook". `ci/hooks/readme_guard.py` only fires when a file in that directory is **edited** — so a directory nobody has touched since the rule landed sits without one indefinitely.

Seven had:

| directory | why it matters |
|---|---|
| `.github/actions/build-target` | composite action used by **both** `build.yml` and `release-auto.yml` |
| `perf/scenarios/build-then-check` | the one scenario of six with no README |
| `crates/zccache-compiler/src/response_file` | sibling modules both have one |
| `crates/zccache/tests/common` | both sibling test dirs have one |
| `dylints/ban_std_pathbuf/ui` | 8 of 9 dylint `ui/` dirs have one |
| `python/zccache/fingerprint` | `cpp_lint/` has one |
| `python/zccache/watcher` | same |

The convention was being followed everywhere else, which is what makes these gaps rather than deliberate omissions.

## Written from the source, not the directory name

This is the third PR in a row about documentation that was confidently wrong, so guessing here would have been self-defeating. I read each directory before describing it — and it caught me once: my first draft of the `fingerprint` README said the manager exposed *"scan, mark, and check"*. It actually exposes `read` / `write` / `check` / `save_all`, plus an mtime fast path. Corrected before commit.

Two claims I verified rather than assumed:

- `*_if_safe` in `response_file/format.rs` really do return `Option`, falling back to a direct command line rather than emitting a mangled response file.
- `ban_std_pathbuf` bans raw `PathBuf` *outside the platform leaf and an explicit legacy allowlist* — not unconditionally, which is what a careless README would have implied.

## The test

`test_readme_coverage.py` checks the whole tree rather than the files in front of it, which is precisely what the hook cannot do.

`.cargo` is exempt — a repo-local cargo home whose only tracked file is `config.toml`. **A second test asserts that exemption is still true**, so it cannot quietly widen into a hole once something else lands there. An exemption that stops being justified is worse than no exemption, because it looks deliberate.

Both verified **RED**: removing a README, and staging a second file under `.cargo`:

```
AssertionError: directories without README.md: perf/scenarios/build-then-check
AssertionError: .cargo now tracks more than config.toml ([...]); it should either
                get a README.md or a narrower exemption
```

`416 passed`, with the single known unrelated failure (blocker A of #1474).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
