### PR TITLE
docs: fix four documented commands that name things which do not exist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ soldr cargo check --workspace --all-targets
 soldr cargo clippy --workspace --all-targets -- -D warnings
 soldr cargo fmt --all
 RUSTDOCFLAGS="-D warnings" soldr cargo doc --workspace --no-deps
-soldr cargo bench -p zccache-hash
+soldr cargo bench -p zccache            # criterion benches live in crates/zccache/benches/
 ./perf.sh                   # performance benchmark (zccache vs sccache vs bare clang)
 ```
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -19,7 +19,7 @@ soldr cargo fmt --all
 PowerShell example:
 
 ```powershell
-soldr cargo check -p zccache-download-client
+soldr cargo check -p zccache-cli-core --features download-client
 soldr cargo test -p zccache-download
 ```
 

--- a/bench/persist-rust-project/README.md
+++ b/bench/persist-rust-project/README.md
@@ -7,8 +7,8 @@ totalling a few hundred MB, which is the realistic shape that exercises the
 daemon's persist semaphore and background index writer.
 
 Microbench-style measurement of the *daemon's* persist path lives in
-`crates/zccache-daemon/tests/persist_pool_bench.rs` (run with `soldr cargo
-test --release -p zccache-daemon --test persist_pool_bench -- --nocapture
+`crates/zccache/tests/daemon_persist_pool_bench.rs` (run with `soldr cargo
+test --release -p zccache --test daemon_persist_pool_bench -- --nocapture
 --ignored`). This crate is the end-to-end shape: invoke `soldr cargo build`
 in this directory after clearing `~/.zccache/artifacts/` to measure the
 full pipeline.

--- a/ci/tests/README.md
+++ b/ci/tests/README.md
@@ -30,3 +30,8 @@ matching in both `CLAUDE.md` files.
 `test_readme_coverage.py` asserts every directory with tracked files carries a
 `README.md`. The `readme_guard.py` hook only fires on an *edited* directory, so
 untouched ones could sit without one indefinitely — seven did.
+
+`test_documented_commands.py` checks that `-p <crate>` in any documented
+command names a real workspace member, and that documented `cargo bench`
+targets a crate that actually has benches — `cargo bench` on a crate with none
+exits 0 and measures nothing.

--- a/ci/tests/test_documented_commands.py
+++ b/ci/tests/test_documented_commands.py
@@ -1,0 +1,93 @@
+"""Commands in the docs must name things that exist.
+
+A wrong `-p <crate>` is a special kind of bad documentation: it looks
+authoritative, and following it produces either "package not found" or -- worse
+-- a command that succeeds while doing nothing. `cargo bench -p zccache-hash`
+exits 0 and benchmarks nothing, because that crate has no bench targets; every
+bench in the workspace lives in `crates/zccache`.
+
+Four such commands were live when this was written, in `CLAUDE.md`, `CODEX.md`,
+`bench/persist-rust-project/README.md`, and -- most pointedly --
+`crates/zccache/benches/README.md`, which told you to bench a different crate
+than the one it sits in.
+
+`tasks/` is excluded: it is a historical log, and some entries deliberately
+quote commands that failed at the time.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+PACKAGE_FLAG = re.compile(r"-p (zccache[a-z0-9-]*)")
+BENCH_COMMAND = re.compile(r"cargo bench[^\n`]*?-p (zccache[a-z0-9-]*)")
+EXCLUDED_PREFIXES = ("vendor/", ".claude/worktrees/", "tasks/")
+
+
+def _workspace_members() -> set[str]:
+    manifest = tomllib.loads((ROOT / "Cargo.toml").read_text(encoding="utf-8"))
+    return {
+        Path(member).name
+        for member in manifest["workspace"]["members"]
+        if member.startswith("crates/")
+    }
+
+
+def _tracked_markdown() -> list[Path]:
+    listed = subprocess.run(
+        ["git", "ls-files", "*.md"], cwd=ROOT, capture_output=True, text=True, check=True
+    )
+    return [
+        ROOT / rel
+        for rel in listed.stdout.splitlines()
+        if rel and not rel.startswith(EXCLUDED_PREFIXES)
+    ]
+
+
+def _crates_with_bench_targets() -> set[str]:
+    with_benches = set()
+    for member in _workspace_members():
+        manifest = ROOT / "crates" / member / "Cargo.toml"
+        if not manifest.is_file():
+            continue
+        text = manifest.read_text(encoding="utf-8")
+        if "[[bench]]" in text or (ROOT / "crates" / member / "benches").is_dir():
+            with_benches.add(member)
+    return with_benches
+
+
+def test_documented_package_flags_name_real_crates() -> None:
+    members = _workspace_members()
+    bad: list[str] = []
+    for doc in _tracked_markdown():
+        for crate in PACKAGE_FLAG.findall(doc.read_text(encoding="utf-8", errors="replace")):
+            if crate not in members:
+                bad.append(f"{doc.relative_to(ROOT).as_posix()} -> -p {crate}")
+
+    assert not bad, "docs reference crates that do not exist:\n  " + "\n  ".join(sorted(set(bad)))
+
+
+def test_documented_bench_commands_target_a_crate_that_has_benches() -> None:
+    """The failure this catches is silent: `cargo bench` on a crate with no
+    bench targets exits 0 and measures nothing."""
+    benched = _crates_with_bench_targets()
+    bad: list[str] = []
+    for doc in _tracked_markdown():
+        for crate in BENCH_COMMAND.findall(doc.read_text(encoding="utf-8", errors="replace")):
+            if crate not in benched:
+                bad.append(f"{doc.relative_to(ROOT).as_posix()} -> cargo bench -p {crate}")
+
+    assert not bad, (
+        "docs bench crates with no bench targets (would exit 0 and measure nothing):\n  "
+        + "\n  ".join(sorted(set(bad)))
+    )
+
+
+def test_the_workspace_actually_has_benches_somewhere() -> None:
+    """Guards the test above from passing vacuously if benches were removed."""
+    assert _crates_with_bench_targets(), "no crate declares bench targets"

--- a/crates/zccache/benches/README.md
+++ b/crates/zccache/benches/README.md
@@ -1,5 +1,17 @@
 # Benchmarks
 
-Criterion benchmarks for `zccache-hash`.
+Criterion benchmarks for the `zccache` crate, covering hashing, filesystem
+scanning, fingerprinting, payload read/write, warm restore, and generic tool
+exec.
 
-Run with: `soldr cargo bench -p zccache-hash`
+Run them all with:
+
+```bash
+soldr cargo bench -p zccache
+```
+
+or one at a time, e.g. `soldr cargo bench -p zccache --bench hashing`.
+
+Targets: `hashing`, `scan_metadata`, `scan_recursive`, `fingerprint`,
+`write_payloads`, `read_outputs`, `persist_payloads`, `warm_restore`, `exec`.
+Each is declared `harness = false` in `crates/zccache/Cargo.toml`.


### PR DESCRIPTION
## Problem

Four documented commands name things that do not exist. A wrong `-p <crate>` is a particularly bad kind of stale documentation: it looks authoritative, and following it either fails outright or — worse — succeeds while doing nothing.

| File | Command |
|---|---|
| `CLAUDE.md` | `cargo bench -p zccache-hash` |
| `crates/zccache/benches/README.md` | `cargo bench -p zccache-hash` |
| `CODEX.md` | `cargo check -p zccache-download-client` |
| `bench/persist-rust-project/README.md` | `cargo test -p zccache-daemon --test persist_pool_bench` |

`zccache-download-client` and `zccache-daemon` are not crates — the first is a feature-gated module of `zccache-cli-core`, the second a bin target of `zccache` — so those two fail immediately.

**The bench pair is the quiet one.** `zccache-hash` exists but has no bench targets; every criterion bench in the workspace lives in `crates/zccache`. So `cargo bench -p zccache-hash` exits 0 having measured nothing, and reads as a passing benchmark run. `crates/zccache/benches/README.md` is the sharpest case: it sits in the very directory holding the nine bench targets and pointed you at a different crate.

Also corrected the persist bench path, which moved with the crate split: `crates/zccache-daemon/tests/persist_pool_bench.rs` → `crates/zccache/tests/daemon_persist_pool_bench.rs`.

## Guard

`ci/tests/test_documented_commands.py` checks both properties:

- every `-p <crate>` in a documented command names a real workspace member;
- a documented `cargo bench` targets a crate that actually has bench targets.

Plus a guard against that second assertion passing vacuously if benches were ever removed wholesale. All three verified RED by reintroducing each mistake.

## Checked and deliberately left alone

`./test`'s `--integration` / `--full` / `-p` forms, `build_dist.py`'s `--ref` / `--run-id` / `--skip-build`, `perf_local.py`'s `--matrix` / `--repeat`, and the claim that `zccache c++` is public surface — there is no `c++` subcommand, but unknown `argv[1]` routes into wrap mode by design, so the documented invocation does work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
