### PR TITLE
fix(ci): stop ARM64 xwin C++ mode from breaking ring (#1439)

### DIFF
--- a/.github/actions/build-target/action.yml
+++ b/.github/actions/build-target/action.yml
@@ -190,18 +190,6 @@ runs:
       with:
         tool: cargo-xwin
 
-    - name: Configure xwin ARM64 C compatibility
-      if: inputs.cross_driver == 'xwin' && inputs.target == 'aarch64-pc-windows-msvc'
-      shell: bash
-      run: |
-        # mimalloc's MSVC C atomics use intrinsics that clang-cl does not
-        # declare for ARM64. Its own source recommends C++ compilation for
-        # MSVC; /TP selects that std::atomic path without changing Rust code.
-        # cargo-xwin owns CFLAGS_<target> and replaces that variable when it
-        # injects the SDK include paths. General CFLAGS is additive in cc-rs
-        # and this job builds only the selected ARM64 target.
-        echo "CFLAGS=-TP" >> "$GITHUB_ENV"
-
     - name: Setup soldr build cache
       if: inputs.use_soldr == 'true'
       uses: zackees/setup-soldr@01aea6d47db8fedcafd350e2d42e19290c68824e

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,7 +1708,8 @@ dependencies = [
 [[package]]
 name = "mimalloc-pprof"
 version = "0.9.3"
-source = "git+https://github.com/zackees/mimalloc-pprof?rev=9ecc9ca810b97bb9fd1c7daaa6b10dc6af4bfc2c#9ecc9ca810b97bb9fd1c7daaa6b10dc6af4bfc2c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d30b36d87ca14bd04fec54438531e7ef88ee0f28b34d75a37ddc98ac3fa93d"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,9 +1707,8 @@ dependencies = [
 
 [[package]]
 name = "mimalloc-pprof"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71dc9f58355ea3d31ad23ff4d447d6549d8ba9e803d0d9cd616db5af98ae6751"
+version = "0.9.3"
+source = "git+https://github.com/zackees/mimalloc-pprof?rev=9ecc9ca810b97bb9fd1c7daaa6b10dc6af4bfc2c#9ecc9ca810b97bb9fd1c7daaa6b10dc6af4bfc2c"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ ruzstd = "0.7"
 lzma-rs = "0.3"
 sevenz-rust = "0.6"
 rkyv = "0.8"
-mimalloc-pprof = "0.9"
+mimalloc-pprof = "0.9.3"
 running-process = { version = "4.10.5", default-features = false, features = ["client-async"] }
 zccache = { path = "crates/zccache" }
 zccache-artifact = { path = "crates/zccache-artifact" }
@@ -114,6 +114,7 @@ zccache-fingerprint = { path = "crates/zccache-fingerprint" }
 # the tree tracks soldr's _vender/notify (patched for windows-sys 0.61).
 [patch.crates-io]
 notify = { path = "vendor/notify" }
+mimalloc-pprof = { git = "https://github.com/zackees/mimalloc-pprof", rev = "9ecc9ca810b97bb9fd1c7daaa6b10dc6af4bfc2c" }
 
 [workspace.metadata.dylint]
 libraries = [{ path = "dylints/*" }]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,6 @@ zccache-fingerprint = { path = "crates/zccache-fingerprint" }
 # the tree tracks soldr's _vender/notify (patched for windows-sys 0.61).
 [patch.crates-io]
 notify = { path = "vendor/notify" }
-mimalloc-pprof = { git = "https://github.com/zackees/mimalloc-pprof", rev = "9ecc9ca810b97bb9fd1c7daaa6b10dc6af4bfc2c" }
 
 [workspace.metadata.dylint]
 libraries = [{ path = "dylints/*" }]

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -284,11 +284,12 @@ def test_linux_cross_build_repairs_debug_sidecars_missing_from_cache_hits() -> N
     assert 'test -e "$TARGET_DIR/zccache-fp.dwp"' in action
 
 
-def test_xwin_arm64_compiles_mimalloc_c_as_recommended_cxx() -> None:
+def test_xwin_arm64_never_forces_every_native_dependency_to_cxx() -> None:
     action = _repo_text(".github/actions/build-target/action.yml")
 
-    assert 'echo "CFLAGS=-TP" >> "$GITHUB_ENV"' in action
-    assert "CFLAGS_aarch64_pc_windows_msvc=-TP" not in action
+    assert 'CFLAGS=-TP' not in action
+    assert 'CFLAGS_aarch64_pc_windows_msvc=-TP' not in action
+    assert 'CXXFLAGS=-TP' not in action
 
 
 def test_release_workflow_dry_run_builds_without_publishing() -> None:

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -472,3 +472,28 @@ def test_stage_debug_tree_skips_missing_input(tmp_path: Path) -> None:
         )
         is None
     )
+
+
+def test_patch_crates_io_carries_no_git_sources() -> None:
+    """A `[patch.crates-io]` git pin makes the workspace build code that the
+    published crate does not depend on, so a local GREEN stops proving anything
+    about what users install. Vendored `path` patches ship in-tree and are fine.
+
+    #1439 pinned `mimalloc-pprof` at a fork rev while the identical 0.9.3 was
+    already on crates.io; the pin was redundant and silently divergence-prone.
+    """
+    manifest = _repo_text("Cargo.toml")
+
+    start = manifest.index("[patch.crates-io]")
+    end = manifest.find("\n[", start + 1)
+    patch_block = manifest[start:] if end == -1 else manifest[start:end]
+
+    offenders = [
+        line.strip()
+        for line in patch_block.splitlines()
+        if "git =" in line and not line.lstrip().startswith("#")
+    ]
+    assert not offenders, (
+        "[patch.crates-io] must not pin git sources; "
+        f"publish the fix upstream and depend on the registry instead: {offenders}"
+    )

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -939,6 +939,7 @@ Issue: https://github.com/zackees/zccache/issues/1439
 - [x] Add a RED contract rejecting global C/C++ language overrides.
 - [x] Remove the global `/TP` injection without weakening the target matrix.
 - [x] Prove the full ARM64 cargo-xwin release build, including Python libraries.
+- [x] Drop the redundant `[patch.crates-io]` git pin; registry 0.9.3 is identical.
 - [ ] Run focused lint/tests/review, merge, and rerun the 1.13.6 release.
 
 ## Review

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -930,3 +930,23 @@ Issue: https://github.com/zackees/zccache/issues/1433
   where the already-derived 32-byte key stores its opaque result bytes.
 - Failure policy: daemon/protocol/store failures surface to Python and never
   invoke an uncached fallback behind the caller's back.
+
+# #1439 stop ARM64 xwin C++ mode from breaking ring
+
+Issue: https://github.com/zackees/zccache/issues/1439
+
+- [x] Capture the failed 1.13.6 ARM64 release lane as RED evidence.
+- [x] Add a RED contract rejecting global C/C++ language overrides.
+- [x] Remove the global `/TP` injection without weakening the target matrix.
+- [x] Prove the full ARM64 cargo-xwin release build, including Python libraries.
+- [ ] Run focused lint/tests/review, merge, and rerun the 1.13.6 release.
+
+## Review
+
+- RED: release run 32446557448 compiles `ring` `.c` sources with `-TP` and
+  fails on C++ pointer conversions and narrowing after #1415 exported
+  `CFLAGS=-TP` for the entire ARM64 xwin job.
+- GREEN: the managed Linux xwin harness built both release binaries and all
+  three Python extension libraries for `aarch64-pc-windows-msvc` against
+  reviewed `mimalloc-pprof` 0.9.3 commit `9ecc9ca8`; `ring` remained C and
+  mimalloc used its package-local C11 atomics define.


### PR DESCRIPTION
Fixes #1439.

## The bug this replaces

#1440 fixed mimalloc's ARM64 atomics by exporting `CFLAGS=-TP` for the entire xwin job. `-TP` is a **global C-to-C++ language override**, so every native dependency in the graph got compiled as C++ — and `ring` is C. Release run [32446557448](https://github.com/zackees/zccache/actions/runs/32446557448) died on C++ pointer conversions and narrowing in ring's `.c` sources.

The workaround was correctly scoped to the *symptom* (mimalloc needs C++ atomics on ARM64) but applied at a scope that could not distinguish mimalloc from every other cc-rs crate.

## The fix

Remove the global override and take it upstream instead. `mimalloc-pprof` 0.9.3 carries its own package-local C11 atomics define, so `ring` stays C and mimalloc still builds for `aarch64-pc-windows-msvc`.

The contract test inverts accordingly. It previously asserted the `/TP` injection was *present*; it now rejects any global C/C++ language override, covering the `CFLAGS`, `CFLAGS_<target>`, and `CXXFLAGS` spellings — so the next person reaching for this shortcut gets a RED test rather than a broken release six weeks later.

## Verification

GREEN against the managed Linux xwin harness: both release binaries and all three Python extension libraries built for `aarch64-pc-windows-msvc`, with `ring` remaining C and mimalloc using its package-local atomics define.

## Before merge

`Cargo.toml` currently carries a `[patch.crates-io]` git pin to `mimalloc-pprof` rev `9ecc9ca8`, from when the fix existed only upstream. **0.9.3 is now published on crates.io**, and `9ecc9ca8` is 0.9.3 plus a CI-only commit, so the pin is redundant and should be dropped in favor of the plain `mimalloc-pprof = "0.9.3"` dependency — a git dependency here would complicate publishing and vendoring. Left in place for now so this lands in exactly the configuration that was verified; dropping it is a lockfile regen away.

Draft until that cleanup and a CI pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
