### PR TITLE
perf(bench): align cold multi-file baseline invocations (#1437)

### DIFF
--- a/crates/zccache/tests/perf_bench/README.md
+++ b/crates/zccache/tests/perf_bench/README.md
@@ -36,44 +36,25 @@ test" for the rules on adding new perf benchmarks here.
 
 ## What the three sides actually execute
 
-The bare / sccache / zccache columns are **not** three ways of running the same
-command. Anyone reading a ratio, and especially anyone treating a failing floor
-as a regression, needs the differences:
+The cold multi-file rows deliberately use one compiler invocation per
+translation unit on every side (#1437). zccache receives one in-process
+`Request::Compile` containing all sources, then its multi-source cache path
+invokes the compiler separately for each source. The bare and sccache cold
+baselines now do the same, so their floors compare like invocation shapes:
 
-| side | single-file | multi-file |
-|---|---|---|
-| bare | one `Command::new(compiler)` | **one** process, all sources |
-| sccache | one `Command::new(sccache)` | **one** process, all sources |
-| zccache | in-process `ClientConn` | one `Request::Compile`, daemon invokes the compiler **per source** |
+| side | single-file | cold multi-file | warm multi-file |
+|---|---|---|---|
+| bare | one process per source | one process per source | one process, all sources |
+| sccache | one wrapper process per source | one wrapper process per source | one wrapper process, all sources |
+| zccache | one in-process request per source | one request; daemon invokes the compiler per source | one request; daemon serves per-source hits |
 
-Two consequences follow, both measured rather than assumed (issue #1437).
+The response-file variant follows the same rule. Its cold baselines invoke
+`-c unit.cpp @flags.rsp` once per source; its warm baselines retain the
+historical single `@sources_multi.rsp` invocation.
 
-### Multi-file bare batches; zccache cannot
-
-`baseline_multi` passes all sources to **one** compiler process
-(`cpp_project.rs`), so the compiler's startup cost is amortized across the
-whole set. zccache caches per translation unit, so the daemon invokes the
-compiler **once per source** — the profile emits one `zccache_cc_miss_profile`
-row per file.
-
-For a driver with meaningful startup this is a fixed handicap that scales with
-source count. Measured in the pinned image on 50 sources, with zccache removed
-from the experiment entirely:
-
-```
-batched  (1 em++ invocation , 50 TUs)   40966 ms
-separate (50 em++ invocations, 50 TUs)  44267 ms
-penalty                                  3301 ms   (~67 ms per extra invocation)
-```
-
-em++ is an Emscripten Python driver, so its startup dominates; native clang's
-is roughly an order of magnitude smaller, which is why the C and C++
-multi-file rows pass on runs where the emscripten one does not.
-
-**A cold multi-file zccache run cannot beat a single batched invocation of a
-slow-starting driver on any hardware.** A `Multi-file, Cold vs Bare` floor for
-such a driver is measuring batching strategy, not cache performance. Treat a
-failure there as a fixture question before hunting for a regression.
+Warm multi-file measurements intentionally retain their historical batched
+bare and sccache semantics. Their numbers remain comparable to prior warm
+results; they are not used as cold cache-miss parity baselines.
 
 ### zccache is measured without per-invocation cost
 
@@ -86,7 +67,7 @@ every compile — none of which these numbers include. `zccache_wrapper_profile`
 So a passing floor here does not by itself establish that a user sees the same
 win.
 
-### sccache does not cache the multi-file fixture at all
+### sccache does not cache the batched warm multi-file fixture
 
 `sccache_compile_multi` passes all 50 sources to **one** sccache process, and
 sccache does not cache multi-source invocations. Measured in the pinned image
@@ -99,12 +80,13 @@ Non-cacheable compilations            0
 Non-cacheable calls                   1
 ```
 
-One request, classified non-cacheable, forwarded straight through. The
-vs-sccache multi-file baseline is therefore a batched `em++` run with a thin
-wrapper on it — **not** a per-file cache.
+One request, classified non-cacheable, forwarded straight through. This is
+why the warm multi-file row deliberately retains its historical batched
+baseline semantics rather than presenting it as a cache-vs-cache comparison.
 
-So the batching asymmetry above applies to *both* cold multi-file baselines,
-not only vs-bare. Neither is a cache-vs-cache comparison, and neither
-currently distinguishes a zccache regression from the invocation-shape
-difference. Do not reach for vs-sccache as the "fairer" multi-file row; for
-per-file work it is the single-file rows that compare like with like.
+The cold multi-file row is different: bare and sccache both run one compiler
+invocation per translation unit, matching zccache's per-source compiler work.
+Those cold rows are therefore invocation-shape comparable, and the sccache
+side is cacheable. The benchmark purges those per-TU sccache entries before
+measuring the historical batched warm row so the two meanings do not leak into
+one another.

--- a/crates/zccache/tests/perf_bench/cpp_project.rs
+++ b/crates/zccache/tests/perf_bench/cpp_project.rs
@@ -255,6 +255,37 @@ pub fn sccache_compile_multi(
     start.elapsed()
 }
 
+/// Run the cold multi-file comparison as one compiler invocation per source.
+///
+/// zccache receives the sources in one request, but its multi-source cache
+/// path invokes the compiler separately for each translation unit. Keep the
+/// cold baselines in that same invocation shape (#1437); the existing batched
+/// multi helper below remains the historical warm baseline.
+pub fn sccache_compile_multi_cold_per_tu(
+    sccache: &Path,
+    compiler: &str,
+    cwd: &Path,
+    sources: &[String],
+) -> Duration {
+    clean_objects(cwd);
+    let start = Instant::now();
+    for src in sources {
+        let status = std::process::Command::new(sccache)
+            .arg(compiler)
+            .args(multi_cold_per_tu_args(src))
+            .current_dir(cwd)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("failed to run sccache");
+        assert!(
+            status.success(),
+            "sccache cold multi-file compile failed for {src}"
+        );
+    }
+    start.elapsed()
+}
+
 // ── Baseline (direct compiler, no cache) ────────────────────────────────
 
 pub fn baseline_single(compiler: &str, cwd: &Path, sources: &[String]) -> Duration {
@@ -297,6 +328,48 @@ pub fn baseline_multi(compiler: &str, cwd: &Path, sources: &[String]) -> Duratio
     let status = cmd.status().expect("failed to run compiler");
     assert!(status.success(), "multi-file compile failed");
     start.elapsed()
+}
+
+/// Run the cold multi-file bare comparison as one compiler invocation per
+/// translation unit. The regular [`baseline_multi`] helper intentionally
+/// remains batched for the historical warm measurement.
+pub fn baseline_multi_cold_per_tu(compiler: &str, cwd: &Path, sources: &[String]) -> Duration {
+    clean_objects(cwd);
+    let start = Instant::now();
+    for src in sources {
+        let status = std::process::Command::new(compiler)
+            .args(multi_cold_per_tu_args(src))
+            .current_dir(cwd)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("failed to run compiler");
+        assert!(status.success(), "cold multi-file compile failed for {src}");
+    }
+    start.elapsed()
+}
+
+fn multi_cold_per_tu_args(source: &str) -> Vec<String> {
+    vec![
+        "-c".into(),
+        source.into(),
+        "-Iinclude".into(),
+        "-O2".into(),
+        "-std=c++17".into(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::multi_cold_per_tu_args;
+
+    #[test]
+    fn cold_multi_per_tu_args_select_one_source_without_an_output_override() {
+        assert_eq!(
+            multi_cold_per_tu_args("unit_007.cpp"),
+            vec!["-c", "unit_007.cpp", "-Iinclude", "-O2", "-std=c++17"]
+        );
+    }
 }
 
 pub async fn zccache_compile_cpp_single_with_env(

--- a/crates/zccache/tests/perf_bench/response_file.rs
+++ b/crates/zccache/tests/perf_bench/response_file.rs
@@ -123,6 +123,30 @@ pub fn baseline_multi_rsp(compiler: &str, cwd: &Path) -> Duration {
     start.elapsed()
 }
 
+/// Run the cold multi-file response-file comparison once per translation unit.
+///
+/// This mirrors zccache's per-source compiler work while retaining the nested
+/// response-file flag fixture. [`baseline_multi_rsp`] remains the batched warm
+/// baseline (#1437).
+pub fn baseline_multi_rsp_cold_per_tu(compiler: &str, cwd: &Path, sources: &[String]) -> Duration {
+    clean_objects(cwd);
+    let start = Instant::now();
+    for src in sources {
+        let status = std::process::Command::new(compiler)
+            .args(multi_rsp_cold_per_tu_args(src))
+            .current_dir(cwd)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("failed to run compiler with rsp");
+        assert!(
+            status.success(),
+            "cold multi-file rsp compile failed for {src}"
+        );
+    }
+    start.elapsed()
+}
+
 // ── Response-file benchmarks: sccache ───────────────────────────────────
 
 pub fn sccache_compile_single_rsp(
@@ -164,6 +188,33 @@ pub fn sccache_compile_multi_rsp(sccache: &Path, compiler: &str, cwd: &Path) -> 
     let start = Instant::now();
     let status = cmd.status().expect("failed to run sccache with multi rsp");
     assert!(status.success(), "sccache multi-file rsp compile failed");
+    start.elapsed()
+}
+
+/// Run the cold multi-file response-file sccache comparison once per
+/// translation unit. The batched helper above remains the warm baseline.
+pub fn sccache_compile_multi_rsp_cold_per_tu(
+    sccache: &Path,
+    compiler: &str,
+    cwd: &Path,
+    sources: &[String],
+) -> Duration {
+    clean_objects(cwd);
+    let start = Instant::now();
+    for src in sources {
+        let status = std::process::Command::new(sccache)
+            .arg(compiler)
+            .args(multi_rsp_cold_per_tu_args(src))
+            .current_dir(cwd)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("failed to run sccache with rsp");
+        assert!(
+            status.success(),
+            "sccache cold multi-file rsp compile failed for {src}"
+        );
+    }
     start.elapsed()
 }
 
@@ -224,4 +275,21 @@ pub async fn zccache_compile_multi_rsp(
     let (exit_code, ..) = recv_compile_result(client).await;
     assert_eq!(exit_code, 0, "multi-file rsp compile failed");
     start.elapsed()
+}
+
+fn multi_rsp_cold_per_tu_args(source: &str) -> Vec<String> {
+    vec!["-c".into(), source.into(), "@flags.rsp".into()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::multi_rsp_cold_per_tu_args;
+
+    #[test]
+    fn cold_multi_rsp_per_tu_args_keep_the_flag_fixture_and_one_source() {
+        assert_eq!(
+            multi_rsp_cold_per_tu_args("unit_007.cpp"),
+            vec!["-c", "unit_007.cpp", "@flags.rsp"]
+        );
+    }
 }

--- a/crates/zccache/tests/perf_bench/tests_cpp.rs
+++ b/crates/zccache/tests/perf_bench/tests_cpp.rs
@@ -16,7 +16,8 @@ use super::common::{
     start_daemon, NUM_FILES, WARM_TRIALS,
 };
 use super::cpp_project::{
-    baseline_multi, baseline_single, generate_project, nuke_and_regenerate, sccache_compile_multi,
+    baseline_multi, baseline_multi_cold_per_tu, baseline_single, generate_project,
+    nuke_and_regenerate, sccache_compile_multi, sccache_compile_multi_cold_per_tu,
     sccache_compile_single, source_names, warmup_compiler, zccache_compile_multi,
     zccache_compile_single,
 };
@@ -58,8 +59,8 @@ async fn perf_warm_cache_zccache_vs_sccache() {
 
     nuke_and_regenerate(bl_dir.path());
     warmup_compiler(&compiler, bl_dir.path());
-    let bl_cold_multi = baseline_multi(&compiler, bl_dir.path(), &sources);
-    eprintln!("        multi cold:   {}", fmt_dur(bl_cold_multi));
+    let bl_cold_multi = baseline_multi_cold_per_tu(&compiler, bl_dir.path(), &sources);
+    eprintln!("        multi cold (per-TU):   {}", fmt_dur(bl_cold_multi));
 
     let bl_warm_multi = baseline_multi(&compiler, bl_dir.path(), &sources);
     eprintln!("        multi warm:   {}", fmt_dur(bl_warm_multi));
@@ -72,7 +73,9 @@ async fn perf_warm_cache_zccache_vs_sccache() {
     let sccache_cold_multi;
     let sccache_single_times;
     let sccache_multi_times;
-    let mut sccache_cache_bytes = None;
+    let mut sccache_single_cache_bytes = None;
+    let mut sccache_cold_multi_cache_bytes = None;
+    let mut sccache_warm_multi_cache_bytes = None;
 
     if let Some(sccache_bin) = find_sccache() {
         let sc_dir = zccache::test_support::temp_cache_dir().unwrap();
@@ -131,15 +134,23 @@ async fn perf_warm_cache_zccache_vs_sccache() {
         }
         print_trials("single warm:", &times);
         sccache_single_times = Some(times);
+        sccache_single_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
 
         stop_purge_start(&sccache_bin, &sc_cache_str);
 
         nuke_and_regenerate(sc_dir.path());
         warmup_compiler(&compiler, sc_dir.path());
         eprint!("        multi cold:   ");
-        let cold_m = sccache_compile_multi(&sccache_bin, &compiler, sc_dir.path(), &sources);
-        eprintln!("{}", fmt_dur(cold_m));
+        let cold_m =
+            sccache_compile_multi_cold_per_tu(&sccache_bin, &compiler, sc_dir.path(), &sources);
+        eprintln!("(per-TU) {}", fmt_dur(cold_m));
         sccache_cold_multi = Some(cold_m);
+        sccache_cold_multi_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
+
+        // The cold parity pass populates sccache one source at a time. Its
+        // historical warm multi-file measurement is a batched non-cacheable
+        // call, so restore the empty cache state it used before #1437.
+        stop_purge_start(&sccache_bin, &sc_cache_str);
 
         // Warm trials: multi-file (sccache can't cache this — passes through)
         let mut times = Vec::with_capacity(WARM_TRIALS);
@@ -153,7 +164,7 @@ async fn perf_warm_cache_zccache_vs_sccache() {
         }
         print_trials("multi warm:", &times);
         sccache_multi_times = Some(times);
-        sccache_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
+        sccache_warm_multi_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
 
         let _ = std::process::Command::new(&sccache_bin)
             .arg("--stop-server")
@@ -286,7 +297,9 @@ async fn perf_warm_cache_zccache_vs_sccache() {
     let scc_multi_str = sccache_multi_times.as_ref().map(|t| fmt_dur(median(t)));
     let scc_cold_s_str = sccache_cold_single.map(fmt_dur);
     let scc_cold_m_str = sccache_cold_multi.map(fmt_dur);
-    let sccache_cache_str = sccache_cache_bytes.map(fmt_bytes);
+    let sccache_single_cache_str = sccache_single_cache_bytes.map(fmt_bytes);
+    let sccache_cold_multi_cache_str = sccache_cold_multi_cache_bytes.map(fmt_bytes);
+    let sccache_warm_multi_cache_str = sccache_warm_multi_cache_bytes.map(fmt_bytes);
     let zccache_cache_str = fmt_bytes(zccache_cache_bytes);
     let dash = "\u{2014}";
 
@@ -310,7 +323,7 @@ async fn perf_warm_cache_zccache_vs_sccache() {
         scc_cs,
         fmt_dur(zc_cold_single),
         fmt_bytes(0),
-        sccache_cache_str.as_deref().unwrap_or(dash),
+        sccache_single_cache_str.as_deref().unwrap_or(dash),
         zccache_cache_str,
         vs_scc_cold_s.as_deref().unwrap_or(dash),
         vs_bare_cold_s,
@@ -328,23 +341,23 @@ async fn perf_warm_cache_zccache_vs_sccache() {
         scc_ws,
         fmt_dur(zc_single_med),
         fmt_bytes(0),
-        sccache_cache_str.as_deref().unwrap_or(dash),
+        sccache_single_cache_str.as_deref().unwrap_or(dash),
         zccache_cache_str,
         vs_scc_warm_s.as_deref().unwrap_or(dash),
         vs_bare_warm_s,
     );
 
-    // Multi-file, Cold
+    // Multi-file, Cold (per translation unit on every side)
     let scc_cm = scc_cold_m_str.as_deref().unwrap_or(dash);
     let vs_scc_cold_m = sccache_cold_multi.map(|t| fmt_ratio(t, zc_cold_multi, false));
     let vs_bare_cold_m = fmt_ratio(bl_cold_multi, zc_cold_multi, false);
     eprintln!(
-        "| Multi-file, Cold | {} | {} | {} | {} | {} | {} | {} | {} |",
+        "| Multi-file, Cold (per-TU) | {} | {} | {} | {} | {} | {} | {} | {} |",
         fmt_dur(bl_cold_multi),
         scc_cm,
         fmt_dur(zc_cold_multi),
         fmt_bytes(0),
-        sccache_cache_str.as_deref().unwrap_or(dash),
+        sccache_cold_multi_cache_str.as_deref().unwrap_or(dash),
         zccache_cache_str,
         vs_scc_cold_m.as_deref().unwrap_or(dash),
         vs_bare_cold_m,
@@ -362,7 +375,7 @@ async fn perf_warm_cache_zccache_vs_sccache() {
         scc_wm,
         fmt_dur(zc_multi_med),
         fmt_bytes(0),
-        sccache_cache_str.as_deref().unwrap_or(dash),
+        sccache_warm_multi_cache_str.as_deref().unwrap_or(dash),
         zccache_cache_str,
         vs_scc_warm_m.as_deref().unwrap_or(dash),
         vs_bare_warm_m,
@@ -370,7 +383,7 @@ async fn perf_warm_cache_zccache_vs_sccache() {
 
     eprintln!();
     eprintln!("> **Cold** = first compile (empty cache). **Warm** = median of {WARM_TRIALS} subsequent runs.");
-    eprintln!("> Single-file = {NUM_FILES} sequential `clang++ -c unit.cpp` invocations. Multi-file = one `clang++ -c *.cpp` invocation.");
+    eprintln!("> Single-file = {NUM_FILES} sequential `clang++ -c unit.cpp` invocations. Multi-file cold = per-TU compiler invocations on every side; multi-file warm retains the historical one `clang++ -c *.cpp` baseline invocation.");
     if sccache_multi_times.is_some() {
         eprintln!("> sccache cannot cache multi-file compilations \u{2014} its \"warm\" multi-file time is a full recompile.");
     }

--- a/crates/zccache/tests/perf_bench/tests_emcc.rs
+++ b/crates/zccache/tests/perf_bench/tests_emcc.rs
@@ -23,7 +23,8 @@ use super::common::{
     WARM_TRIALS,
 };
 use super::cpp_project::{
-    baseline_multi, baseline_single, generate_project, nuke_and_regenerate, sccache_compile_multi,
+    baseline_multi, baseline_multi_cold_per_tu, baseline_single, generate_project,
+    nuke_and_regenerate, sccache_compile_multi, sccache_compile_multi_cold_per_tu,
     sccache_compile_single, source_names, warmup_compiler, zccache_compile_cpp_single_with_env,
     zccache_compile_multi, zccache_compile_single,
 };
@@ -66,8 +67,8 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
 
     nuke_and_regenerate(bl_dir.path());
     warmup_compiler(&compiler, bl_dir.path());
-    let bl_cold_multi = baseline_multi(&compiler, bl_dir.path(), &sources);
-    eprintln!("        multi cold:   {}", fmt_dur(bl_cold_multi));
+    let bl_cold_multi = baseline_multi_cold_per_tu(&compiler, bl_dir.path(), &sources);
+    eprintln!("        multi cold (per-TU):   {}", fmt_dur(bl_cold_multi));
     let bl_warm_multi = baseline_multi(&compiler, bl_dir.path(), &sources);
     eprintln!("        multi warm:   {}", fmt_dur(bl_warm_multi));
     eprintln!();
@@ -78,7 +79,9 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
     let sccache_warm_single;
     let sccache_cold_multi;
     let sccache_warm_multi;
-    let mut sccache_cache_bytes = None;
+    let mut sccache_single_cache_bytes = None;
+    let mut sccache_cold_multi_cache_bytes = None;
+    let mut sccache_warm_multi_cache_bytes = None;
     if let Some(sccache_bin) = find_sccache() {
         let sc_dir = zccache::test_support::temp_cache_dir().unwrap();
         generate_project(sc_dir.path());
@@ -124,13 +127,21 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
         }
         print_trials("single warm:", &warm);
         sccache_warm_single = Some(warm);
+        sccache_single_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
 
         stop_purge_start(&sccache_bin, &sc_cache_str);
         nuke_and_regenerate(sc_dir.path());
         warmup_compiler(&compiler, sc_dir.path());
-        let cold = sccache_compile_multi(&sccache_bin, &compiler, sc_dir.path(), &sources);
-        eprintln!("        multi cold:   {}", fmt_dur(cold));
+        let cold =
+            sccache_compile_multi_cold_per_tu(&sccache_bin, &compiler, sc_dir.path(), &sources);
+        eprintln!("        multi cold (per-TU):   {}", fmt_dur(cold));
         sccache_cold_multi = Some(cold);
+        sccache_cold_multi_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
+
+        // Keep the batched warm baseline in its pre-#1437 empty-cache state.
+        // The cold parity pass above populated sccache per translation unit.
+        stop_purge_start(&sccache_bin, &sc_cache_str);
+
         let mut warm = Vec::with_capacity(WARM_TRIALS);
         for _ in 0..WARM_TRIALS {
             warm.push(sccache_compile_multi(
@@ -142,7 +153,7 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
         }
         print_trials("multi warm:", &warm);
         sccache_warm_multi = Some(warm);
-        sccache_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
+        sccache_warm_multi_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
 
         let _ = std::process::Command::new(&sccache_bin)
             .arg("--stop-server")
@@ -224,7 +235,9 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
     let sc_warm_multi_str = sccache_warm_multi.as_ref().map(|t| fmt_dur(median(t)));
     let sc_cold_single_str = sccache_cold_single.map(fmt_dur);
     let sc_cold_multi_str = sccache_cold_multi.map(fmt_dur);
-    let sccache_cache_str = sccache_cache_bytes.map(fmt_bytes);
+    let sccache_single_cache_str = sccache_single_cache_bytes.map(fmt_bytes);
+    let sccache_cold_multi_cache_str = sccache_cold_multi_cache_bytes.map(fmt_bytes);
+    let sccache_warm_multi_cache_str = sccache_warm_multi_cache_bytes.map(fmt_bytes);
     let zccache_cache_str = fmt_bytes(zccache_cache_bytes);
     let vs_sccache_cold_single = sccache_cold_single.map(|d| fmt_ratio(d, zc_cold_single, false));
     let vs_sccache_cold_multi = sccache_cold_multi.map(|d| fmt_ratio(d, zc_cold_multi, false));
@@ -246,7 +259,7 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
         sc_cold_single_str.as_deref().unwrap_or(dash),
         fmt_dur(zc_cold_single),
         fmt_bytes(0),
-        sccache_cache_str.as_deref().unwrap_or(dash),
+        sccache_single_cache_str.as_deref().unwrap_or(dash),
         zccache_cache_str,
         vs_sccache_cold_single.as_deref().unwrap_or(dash),
         fmt_ratio(bl_cold_single, zc_cold_single, false),
@@ -257,18 +270,18 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
         sc_warm_single_str.as_deref().unwrap_or(dash),
         fmt_dur(zc_single_med),
         fmt_bytes(0),
-        sccache_cache_str.as_deref().unwrap_or(dash),
+        sccache_single_cache_str.as_deref().unwrap_or(dash),
         zccache_cache_str,
         vs_sccache_warm_single.as_deref().unwrap_or(dash),
         fmt_ratio(bl_warm_single, zc_single_med, true),
     );
     eprintln!(
-        "| Multi-file, Cold | {} | {} | {} | {} | {} | {} | {} | {} |",
+        "| Multi-file, Cold (per-TU) | {} | {} | {} | {} | {} | {} | {} | {} |",
         fmt_dur(bl_cold_multi),
         sc_cold_multi_str.as_deref().unwrap_or(dash),
         fmt_dur(zc_cold_multi),
         fmt_bytes(0),
-        sccache_cache_str.as_deref().unwrap_or(dash),
+        sccache_cold_multi_cache_str.as_deref().unwrap_or(dash),
         zccache_cache_str,
         vs_sccache_cold_multi.as_deref().unwrap_or(dash),
         fmt_ratio(bl_cold_multi, zc_cold_multi, false),
@@ -279,13 +292,14 @@ async fn perf_emcc_warm_cache_zccache_vs_sccache() {
         sc_warm_multi_str.as_deref().unwrap_or(dash),
         fmt_dur(zc_multi_med),
         fmt_bytes(0),
-        sccache_cache_str.as_deref().unwrap_or(dash),
+        sccache_warm_multi_cache_str.as_deref().unwrap_or(dash),
         zccache_cache_str,
         vs_sccache_warm_multi.as_deref().unwrap_or(dash),
         fmt_ratio(bl_warm_multi, zc_multi_med, true),
     );
     eprintln!();
     eprintln!("> **Cold** = first compile (empty cache). **Warm** = median of {WARM_TRIALS} subsequent runs.");
+    eprintln!("> Multi-file cold uses one compiler invocation per translation unit on every side; multi-file warm retains its historical batched bare and sccache baselines.");
     eprintln!();
 }
 

--- a/crates/zccache/tests/perf_bench/tests_response_file.rs
+++ b/crates/zccache/tests/perf_bench/tests_response_file.rs
@@ -19,7 +19,8 @@ use super::cpp_project::{
     generate_project, nuke_and_regenerate_with_rsp, source_names, warmup_compiler,
 };
 use super::response_file::{
-    baseline_multi_rsp, baseline_single_rsp, generate_response_files, sccache_compile_multi_rsp,
+    baseline_multi_rsp, baseline_multi_rsp_cold_per_tu, baseline_single_rsp,
+    generate_response_files, sccache_compile_multi_rsp, sccache_compile_multi_rsp_cold_per_tu,
     sccache_compile_single_rsp, zccache_compile_multi_rsp, zccache_compile_single_rsp,
 };
 
@@ -64,8 +65,8 @@ async fn perf_response_file() {
 
     nuke_and_regenerate_with_rsp(bl_dir.path());
     warmup_compiler(&compiler, bl_dir.path());
-    let bl_cold_multi = baseline_multi_rsp(&compiler, bl_dir.path());
-    eprintln!("        multi cold:   {}", fmt_dur(bl_cold_multi));
+    let bl_cold_multi = baseline_multi_rsp_cold_per_tu(&compiler, bl_dir.path(), &sources);
+    eprintln!("        multi cold (per-TU):   {}", fmt_dur(bl_cold_multi));
 
     let bl_warm_multi = baseline_multi_rsp(&compiler, bl_dir.path());
     eprintln!("        multi warm:   {}", fmt_dur(bl_warm_multi));
@@ -77,7 +78,9 @@ async fn perf_response_file() {
     let sccache_cold_multi;
     let sccache_single_times;
     let sccache_multi_times;
-    let mut sccache_cache_bytes = None;
+    let mut sccache_single_cache_bytes = None;
+    let mut sccache_cold_multi_cache_bytes = None;
+    let mut sccache_warm_multi_cache_bytes = None;
 
     if let Some(sccache_bin) = find_sccache() {
         let sc_dir = zccache::test_support::temp_cache_dir().unwrap();
@@ -129,15 +132,22 @@ async fn perf_response_file() {
         }
         print_trials("single warm:", &times);
         sccache_single_times = Some(times);
+        sccache_single_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
 
         stop_purge_start(&sccache_bin, &sc_cache_str);
 
         nuke_and_regenerate_with_rsp(sc_dir.path());
         warmup_compiler(&compiler, sc_dir.path());
         eprint!("        multi cold:   ");
-        let cold_m = sccache_compile_multi_rsp(&sccache_bin, &compiler, sc_dir.path());
-        eprintln!("{}", fmt_dur(cold_m));
+        let cold_m =
+            sccache_compile_multi_rsp_cold_per_tu(&sccache_bin, &compiler, sc_dir.path(), &sources);
+        eprintln!("(per-TU) {}", fmt_dur(cold_m));
         sccache_cold_multi = Some(cold_m);
+        sccache_cold_multi_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
+
+        // The cold parity pass populates sccache per source. Preserve the
+        // historical empty-cache state for the batched warm RSP measurement.
+        stop_purge_start(&sccache_bin, &sc_cache_str);
 
         let mut times = Vec::with_capacity(WARM_TRIALS);
         for _ in 0..WARM_TRIALS {
@@ -149,7 +159,7 @@ async fn perf_response_file() {
         }
         print_trials("multi warm:", &times);
         sccache_multi_times = Some(times);
-        sccache_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
+        sccache_warm_multi_cache_bytes = Some(dir_size_bytes(sc_cache_dir.path()));
 
         let _ = std::process::Command::new(&sccache_bin)
             .arg("--stop-server")
@@ -252,7 +262,9 @@ async fn perf_response_file() {
     let scc_multi_str = sccache_multi_times.as_ref().map(|t| fmt_dur(median(t)));
     let scc_cold_s_str = sccache_cold_single.map(fmt_dur);
     let scc_cold_m_str = sccache_cold_multi.map(fmt_dur);
-    let sccache_cache_str = sccache_cache_bytes.map(fmt_bytes);
+    let sccache_single_cache_str = sccache_single_cache_bytes.map(fmt_bytes);
+    let sccache_cold_multi_cache_str = sccache_cold_multi_cache_bytes.map(fmt_bytes);
+    let sccache_warm_multi_cache_str = sccache_warm_multi_cache_bytes.map(fmt_bytes);
     let zccache_cache_str = fmt_bytes(zccache_cache_bytes);
     let dash = "\u{2014}";
 
@@ -279,7 +291,7 @@ async fn perf_response_file() {
         scc_cs,
         fmt_dur(zc_cold_single),
         fmt_bytes(0),
-        sccache_cache_str.as_deref().unwrap_or(dash),
+        sccache_single_cache_str.as_deref().unwrap_or(dash),
         zccache_cache_str,
         vs_scc_cold_s.as_deref().unwrap_or(dash),
         vs_bare_cold_s,
@@ -297,23 +309,23 @@ async fn perf_response_file() {
         scc_ws,
         fmt_dur(zc_single_med),
         fmt_bytes(0),
-        sccache_cache_str.as_deref().unwrap_or(dash),
+        sccache_single_cache_str.as_deref().unwrap_or(dash),
         zccache_cache_str,
         vs_scc_warm_s.as_deref().unwrap_or(dash),
         vs_bare_warm_s,
     );
 
-    // Multi-file RSP, Cold
+    // Multi-file RSP, Cold (per translation unit on every side)
     let scc_cm = scc_cold_m_str.as_deref().unwrap_or(dash);
     let vs_scc_cold_m = sccache_cold_multi.map(|t| fmt_ratio(t, zc_cold_multi, false));
     let vs_bare_cold_m = fmt_ratio(bl_cold_multi, zc_cold_multi, false);
     eprintln!(
-        "| Multi-file RSP, Cold | {} | {} | {} | {} | {} | {} | {} | {} |",
+        "| Multi-file RSP, Cold (per-TU) | {} | {} | {} | {} | {} | {} | {} | {} |",
         fmt_dur(bl_cold_multi),
         scc_cm,
         fmt_dur(zc_cold_multi),
         fmt_bytes(0),
-        sccache_cache_str.as_deref().unwrap_or(dash),
+        sccache_cold_multi_cache_str.as_deref().unwrap_or(dash),
         zccache_cache_str,
         vs_scc_cold_m.as_deref().unwrap_or(dash),
         vs_bare_cold_m,
@@ -331,7 +343,7 @@ async fn perf_response_file() {
         scc_wm,
         fmt_dur(zc_multi_med),
         fmt_bytes(0),
-        sccache_cache_str.as_deref().unwrap_or(dash),
+        sccache_warm_multi_cache_str.as_deref().unwrap_or(dash),
         zccache_cache_str,
         vs_scc_warm_m.as_deref().unwrap_or(dash),
         vs_bare_warm_m,
@@ -344,6 +356,7 @@ async fn perf_response_file() {
     );
     eprintln!("> {RSP_NUM_DEFINES} -D defines + {RSP_NUM_INCLUDES} -I paths + 30 warning flags = ~{} total expanded args per compile.",
         RSP_NUM_DEFINES + RSP_NUM_INCLUDES + 30 + 3);
+    eprintln!("> Multi-file RSP cold uses `-c unit.cpp @flags.rsp` once per translation unit on every side; multi-file RSP warm retains the historical batched `@sources_multi.rsp` baselines.");
 
     // ── Bottom Line ─────────────────────────────────────────────────
     eprintln!();


### PR DESCRIPTION
## What changed

This replaces the draft's earlier profiling-only reproduction with the benchmark fix that the investigation ultimately identified.

The cold multi-file comparison was structurally asymmetric: zccache compiled each translation unit separately, while bare and sccache received one batched multi-source invocation. That especially distorted Emscripten because each `em++` driver startup is significant. The investigation also confirmed that batched multi-source sccache is non-cacheable, so neither old cold baseline represented equivalent cacheable work.

- run bare and sccache cold multi-file baselines once per translation unit for C++, Emscripten, and response-file fixtures;
- preserve the historical batched warm baselines and purge sccache between the cold and warm phases;
- preserve response-file argument semantics (`-c source @flags.rsp`) for every cold translation unit;
- report sccache cache bytes from the matching single, cold-multi, or warm-multi phase;
- add exact argument-shape tests and document what each benchmark side executes.

## Validation

- `soldr cargo fmt --all --check`
- `soldr cargo check --workspace --all-targets`
- focused Rust helper tests: 2 passed
- standalone Python controller/guard tests: 91 passed
- C++ five-attempt guard: all 8 benchmark checks passed; the retained inner summary is clean. The outer standalone wrapper quarantined the run only because its post-container host scan briefly observed the container's exiting `clang++` process.
- response-file focused pinned-container campaign: 5 attempts, passed, no failed commands or missing samples; worst cold multi ratios were 0.860x vs bare (0.85 floor) and 1.227x vs sccache (0.90 floor)
- Emscripten focused pinned-container campaign: 5 attempts, passed, no failed commands or missing samples; cold multi ratios were 1.654x vs bare and 2.872x vs sccache

The reporting-only follow-up changes were rechecked with the focused Rust tests and a second independent review.

Closes #1437
