### PR TITLE
test(release): reject git sources under [patch.crates-io]

### DIFF
--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import re
 import tarfile
+import tomllib
 import zipfile
 from pathlib import Path
 
@@ -629,3 +630,31 @@ def test_windows_release_asserts_static_crt_linkage() -> None:
     # The .pyd extensions must keep the dynamic CRT, so the gate covers only
     # the shipped executables.
     assert "for bin in zccache zccache-fp; do" in action
+
+
+def test_patch_tables_carry_no_git_sources() -> None:
+    """A git pin under `[patch]` makes the workspace build code the published
+    crate does not depend on, so a local GREEN stops proving anything about
+    what users install, and the fork stays free to diverge on its next commit.
+    Vendored `path` patches ship in-tree and stay allowed.
+
+    zccache#1439 pinned `mimalloc-pprof` at a fork rev while the byte-identical
+    0.9.3 was already on the registry. Publish the fix upstream, then depend on
+    the registry.
+
+    Parsed rather than string-scanned: `[patch.crates-io.name]` with `git` on
+    its own line is valid Cargo and evades a line-oriented check, which is the
+    one spelling a reviewer is least likely to notice.
+    """
+    patch_tables = tomllib.loads(_repo_text("Cargo.toml")).get("patch", {})
+
+    offenders = [
+        f"[patch.{registry}] {name}"
+        for registry, deps in patch_tables.items()
+        for name, spec in deps.items()
+        if isinstance(spec, dict) and "git" in spec
+    ]
+    assert not offenders, (
+        "patch tables must not pin git sources; "
+        f"publish the fix upstream and depend on the registry instead: {offenders}"
+    )


### PR DESCRIPTION
Salvaged from the superseded #1489 (closed in favour of #1440).

## Why

A `[patch.crates-io]` git pin makes the workspace build code the **published crate does not depend on**. A local GREEN then proves nothing about what users install, and the fork stays free to diverge on its next commit — silently, since the lock records a rev rather than a checksum.

#1439 hit exactly this: `mimalloc-pprof` was pinned at fork rev `9ecc9ca8` while the byte-identical 0.9.3 was already on the registry. I verified the equivalence directly — every source file in the published archive matches `rust/mimalloc-pprof` at that rev, including the `MI_USE_C11_ATOMICS` define in `build.rs`; only the publish-normalized manifest and the README differ. So that pin was harmless *and* redundant. Nothing stops the next one being neither.

## What

The two existing tests are specific — one pins the mimalloc version floor, the other bans the global `-TP` override. Neither catches the general case. This adds that contract.

Vendored `path` patches ship in-tree and stay allowed, so the `notify` patch is unaffected — the check only rejects lines carrying `git =`.

## Verification

RED/GREEN proven against current main: passes as-is, fails when a git source is added to the patch block. Test-only, no production code touched.

```
29 passed in 0.38s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
