### PR TITLE
test(perf): compare every fixture archive member against its source

### DIFF
--- a/ci/tests/test_perf_rust_cluster_embedded.py
+++ b/ci/tests/test_perf_rust_cluster_embedded.py
@@ -72,6 +72,76 @@ def test_perf_local_runner_installs_scenario_dependencies() -> None:
     assert "        procps \\\n" in runner
 
 
+# Mirrors the excludes in regen.sh. If that script grows another one, this
+# list has to grow with it or the comparison below reports a phantom drift.
+FIXTURE_ARCHIVE_EXCLUDES = ("target", ".DS_Store")
+
+
+def _source_files(fixture: str) -> dict[str, bytes]:
+    """Every file regen.sh would put in the archive, keyed by archive path."""
+    root = FIXTURE_ROOT / fixture
+    found: dict[str, bytes] = {}
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root)
+        if relative.parts[0] in FIXTURE_ARCHIVE_EXCLUDES:
+            continue
+        if path.suffix == ".gz":
+            continue
+        found[f"{fixture}/{relative.as_posix()}"] = path.read_bytes()
+    return found
+
+
+def _archive_files(fixture: str) -> dict[str, bytes]:
+    found: dict[str, bytes] = {}
+    with tarfile.open(FIXTURE_ROOT / f"{fixture}.tar.gz", "r:gz") as tar:
+        for member in tar.getmembers():
+            if not member.isfile():
+                continue
+            handle = tar.extractfile(member)
+            assert handle is not None, f"unreadable member {member.name}"
+            found[member.name] = handle.read()
+    return found
+
+
+def test_rollout_fixture_archives_match_their_source_tree() -> None:
+    """The checked-in tarball must be exactly what regen.sh would produce.
+
+    Workers materialise a fixture by untarring, never by building the source
+    tree, so the archive *is* what gets benchmarked. Only the toolchain pin
+    used to be compared, which left every other file free to drift: edit
+    src/main.rs, forget regen.sh, and the archive keeps shipping the old code
+    with no failing test and no reviewable diff -- `git grep -I` skips the
+    binary archive, so it surfaces as `Bin 14914 -> 14915 bytes` or not at all.
+
+    regen.sh pins --sort=name --owner=0 --group=0 --numeric-owner --mtime=@0,
+    so this is a stable byte equality rather than a heuristic.
+    """
+    for fixture in ROLLOUT_FIXTURES:
+        source = _source_files(fixture)
+        archived = _archive_files(fixture)
+
+        assert source, f"{fixture}: no source files found -- test would pass vacuously"
+
+        missing = sorted(set(source) - set(archived))
+        extra = sorted(set(archived) - set(source))
+        assert not missing, (
+            f"{fixture}.tar.gz is missing files present in the source tree "
+            f"(re-run perf/fixtures/regen.sh {fixture}): {missing}"
+        )
+        assert not extra, (
+            f"{fixture}.tar.gz carries files no longer in the source tree "
+            f"(re-run perf/fixtures/regen.sh {fixture}): {extra}"
+        )
+
+        differing = sorted(name for name in source if source[name] != archived[name])
+        assert not differing, (
+            f"{fixture}.tar.gz content differs from the source tree "
+            f"(re-run perf/fixtures/regen.sh {fixture}): {differing}"
+        )
+
+
 def test_rollout_fixture_archives_pin_the_runner_toolchain() -> None:
     runner = LOCAL_RUNNER.read_text(encoding="utf-8")
     channels: set[str] = set()


### PR DESCRIPTION
Closes #1495.

## The gap

The checked-in fixture tarballs are what perf workers actually benchmark — they
materialise a fixture by untarring, never by building the source tree. Keeping
archive and source in sync is a manual `regen.sh` step, and the only thing
guarding it extracted exactly one member:

```python
archived_pin = tar.extractfile(f"{fixture}/rust-toolchain.toml")
assert archived_pin.read() == source_bytes
```

The manifest, the lockfile and everything under `src/` were free to drift. Edit a
fixture's source, forget `regen.sh`, and the archive keeps shipping the old code
— no failing test, and nothing reviewable either: `git grep -I` skips the binary
archive, so it surfaces as `Bin 14914 -> 14915 bytes` or not at all. A perf
result could then be measured against code that is not in the tree.

Same shape as #1474 itself: a guard that looks like coverage but covers one line
of it.

## The fix

Compare the full member list and every member's bytes, honouring the same
excludes `regen.sh` applies (`target/`, `.DS_Store`, `*.tar.gz`). `regen.sh`
pins `--sort=name --owner=0 --group=0 --numeric-owner --mtime=@0`, so this is a
stable byte equality rather than a heuristic — a regen with no source change
produces no diff.

The existing toolchain/image test keeps its narrower job; this is additive.

## Validation

Verified RED by appending one line to `perf/fixtures/medium/src/main.rs` without
regenerating:

```
AssertionError: medium.tar.gz content differs from the source tree
(re-run perf/fixtures/regen.sh medium): ['medium/src/main.rs']
```

The message names both the drifted file and the command to fix it. Green on the
current archives, which confirms they are in sync after #1493.

Also asserts the source list is non-empty, so the comparison cannot pass
vacuously if the fixture layout ever moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
