### PR TITLE
ci: declare an explicit permissions scope on every workflow

### DIFF
--- a/.github/workflows/bench-action.yml
+++ b/.github/workflows/bench-action.yml
@@ -9,6 +9,9 @@ on:
       - "action/**"
       - ".github/workflows/bench-action.yml"
 
+permissions:
+  contents: read
+
 concurrency:
   group: bench-action-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/bench-fingerprint.yml
+++ b/.github/workflows/bench-fingerprint.yml
@@ -3,6 +3,9 @@ name: Fingerprint Investigation Matrix
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: bench-fingerprint-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/broker-stress.yml
+++ b/.github/workflows/broker-stress.yml
@@ -22,6 +22,9 @@ on:
     - cron: "23 4 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: soldr-broker-stress-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
         required: false
         default: "main"
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"

--- a/.github/workflows/ci-check-cross.yml
+++ b/.github/workflows/ci-check-cross.yml
@@ -29,6 +29,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,6 +17,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -28,6 +28,9 @@ on:
       - ".editorconfig"
       - "tasks/**"
 
+permissions:
+  contents: read
+
 concurrency:
   # run_id fallback on non-PR events: GitHub keeps at most ONE pending run
   # per group, so a ref-only group silently cancels queued main-push SHAs.

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -33,6 +33,9 @@ on:
 # what produced the 16 -> 32 -> 49 -> 59 minute queue staircase. Pushes to
 # main are never cancelled: release-auto.yml triggers on push-to-main
 # version bumps, so every commit that lands must be fully tested.
+permissions:
+  contents: read
+
 concurrency:
   # run_id fallback on non-PR events: GitHub keeps at most ONE pending run
   # per group, so a ref-only group silently cancels queued main-push SHAs.

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -28,6 +28,9 @@ on:
       - ".editorconfig"
       - "tasks/**"
 
+permissions:
+  contents: read
+
 concurrency:
   # run_id fallback on non-PR events: GitHub keeps at most ONE pending run
   # per group, so a ref-only group silently cancels queued main-push SHAs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ on:
 # supersedes the in-flight run instead of queueing behind it. Non-PR events
 # key on run_id so each gets its own group -- GitHub keeps only ONE pending
 # run per group, so a shared group silently drops queued main-push SHAs.
+# Workflow-level floor. The msrv job overrides this with its own block
+# (job-level permissions replace, not merge) because it needs
+# actions: write for cache eviction.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,6 +15,9 @@ on:
       - ".editorconfig"
       - "tasks/**"
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   # Feature set that makes `--all-targets` compile the feature-gated

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,9 @@ on:
       - ".editorconfig"
       - "tasks/**"
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/feature-matrix-check.yml
+++ b/.github/workflows/feature-matrix-check.yml
@@ -31,6 +31,9 @@ on:
 # supersedes the in-flight run instead of queueing behind it. Non-PR events
 # key on run_id so each gets its own group -- GitHub keeps only ONE pending
 # run per group, so a shared group silently drops queued main-push SHAs.
+permissions:
+  contents: read
+
 concurrency:
   group: feature-matrix-check-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/fs-matrix.yml
+++ b/.github/workflows/fs-matrix.yml
@@ -31,6 +31,9 @@ on:
       - ".editorconfig"
       - "tasks/**"
 
+permissions:
+  contents: read
+
 concurrency:
   # run_id fallback on non-PR events: GitHub keeps at most ONE pending run
   # per group, so a ref-only group silently cancels queued main-push SHAs.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,6 +38,9 @@ on:
       - ".editorconfig"
       - "tasks/**"
 
+permissions:
+  contents: read
+
 concurrency:
   # Keep scheduled/manual discovery runs together while separating them from
   # normal push/PR gates on the same ref.

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -27,7 +27,7 @@ name: Python Tests
 #
 # Re-run locally with the same command the job uses:
 #   PYTHONPATH=. uv run --no-project --python 3.13 --with pytest --with pillow \
-#     python -m pytest ci/tests
+#     --with pyyaml python -m pytest ci/tests
 
 on:
   push:
@@ -76,4 +76,5 @@ jobs:
           uv run --no-project --python 3.13 \
             --with pytest \
             --with pillow \
+            --with pyyaml \
             python -m pytest ci/tests -q -rs --durations=10

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -18,6 +18,9 @@ on:
       - ".github/workflows/test-action.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: test-action-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/wire-stability.yml
+++ b/.github/workflows/wire-stability.yml
@@ -27,6 +27,9 @@ on:
 # supersedes the in-flight run instead of queueing behind it. Non-PR events
 # key on run_id so each gets its own group -- GitHub keeps only ONE pending
 # run per group, so a shared group silently drops queued main-push SHAs.
+permissions:
+  contents: read
+
 concurrency:
   group: wire-stability-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -37,6 +37,9 @@ on:
       - ".editorconfig"
       - "tasks/**"
 
+permissions:
+  contents: read
+
 concurrency:
   # run_id fallback on non-PR events: GitHub keeps at most ONE pending run
   # per group, so a ref-only group silently cancels queued main-push SHAs.

--- a/ci/tests/README.md
+++ b/ci/tests/README.md
@@ -8,7 +8,7 @@ all benchmarks and application tests are written in Rust.
 Run with the same command CI uses, so a local pass means what the job means:
 
 ```bash
-PYTHONPATH=. uv run --no-project --python 3.13 --with pytest --with pillow python -m pytest ci/tests
+PYTHONPATH=. uv run --no-project --python 3.13 --with pytest --with pillow --with pyyaml python -m pytest ci/tests
 ```
 
 `--no-project` because the suite reads the repo from source and needs nothing
@@ -40,6 +40,12 @@ untouched ones could sit without one indefinitely — seven did.
 command names a real workspace member, and that documented `cargo bench`
 targets a crate that actually has benches — `cargo bench` on a crate with none
 exits 0 and measures nothing.
+
+`test_workflow_permissions.py` asserts every workflow declares an explicit
+`permissions:` scope, at the top level or on every job (job-level blocks replace
+the workflow-level one rather than merging). Without a block a job inherits the
+default token scope, which is far broader than the read-only access nearly all
+of them need.
 
 CI runs this suite via `.github/workflows/python-tests.yml` on every push and
 pull request. It is deliberately not a job in `ci.yml`: that workflow sets

--- a/ci/tests/test_workflow_permissions.py
+++ b/ci/tests/test_workflow_permissions.py
@@ -1,0 +1,68 @@
+"""Every workflow must declare an explicit `permissions:` scope.
+
+Without one, a job inherits the repository/organisation default token scope,
+which is typically far broader than "read the checkout" -- the only thing most
+of these jobs do. Declaring it bounds the blast radius if a third-party action
+or a transitive dependency in one of these jobs is ever compromised, which
+matters most for the ones triggered by `pull_request`.
+
+17 of 22 workflows had no block at all when this was written; the repo already
+had the right instinct in `perf-guard.yml` and in `ci.yml`'s msrv job, it just
+was not applied workflow-wide.
+
+Job-level `permissions` REPLACE the workflow-level block rather than merging
+with it, so a workflow satisfies this rule when it declares one at the top
+level or on every single job.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Imported hard, not via importorskip: a guard that silently skips itself when
+# a dependency is missing is the failure this whole line of work is about. If
+# pyyaml is absent the suite fails loudly at collection instead. The CI job
+# passes it with `--with pyyaml`.
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+
+
+def _workflows() -> list[Path]:
+    return sorted(
+        [p for p in WORKFLOW_DIR.iterdir() if p.suffix in {".yml", ".yaml"}]
+    )
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_every_workflow_declares_permissions() -> None:
+    missing: list[str] = []
+    for path in _workflows():
+        doc = _load(path)
+        if doc.get("permissions") is not None:
+            continue
+        jobs = doc.get("jobs") or {}
+        # A reusable workflow called by another may legitimately inherit, but
+        # only if every job pins its own scope -- otherwise the caller's
+        # default leaks through.
+        if jobs and all(
+            isinstance(job, dict) and job.get("permissions") is not None
+            for job in jobs.values()
+        ):
+            continue
+        missing.append(path.name)
+
+    assert not missing, (
+        "workflows with no explicit `permissions:` (they inherit the default "
+        "token scope):\n  " + "\n  ".join(missing)
+    )
+
+
+def test_the_check_sees_the_workflows() -> None:
+    """Guards the test above from passing vacuously if the glob ever breaks."""
+    found = _workflows()
+    assert len(found) >= 20, f"only found {len(found)} workflows in {WORKFLOW_DIR}"


### PR DESCRIPTION
Closes #1496.

## The gap

17 of 22 workflows declared no `permissions:` block, so their jobs inherited the
repository/organisation default token scope — far broader than "read the
checkout", which is all nearly any of them do. Most run on `pull_request`, which
is the exposure that matters: an explicit scope bounds the blast radius if a
third-party action or a transitive dependency in one of those jobs is ever
compromised.

The repo already had the instinct — `perf-guard.yml` declares `contents: read`,
and `ci.yml`'s msrv job deliberately narrows to `contents: read` +
`actions: write` with a comment explaining why the scope was kept tight
(setup-soldr#347). That reasoning just was never applied workflow-wide.

## Checked, not assumed

`contents: read` is sufficient for all 17. Before applying it I checked each for
the signals that would need more — none pushes, comments on a PR, sets
`cache-eviction-policy`, or downloads artifacts across runs.

`coverage.yml` was the one I expected to need `id-token: write`, since it uploads
to codecov. It passes an explicit `CODECOV_TOKEN` secret rather than using OIDC,
so it does not.

`ci.yml` gains a workflow-level floor covering `fmt`/`dylint`/`docs`. Its msrv
job is unaffected — job-level permissions **replace** the workflow-level block
rather than merging, so msrv keeps its `actions: write`. Verified by parsing the
result.

## The guard

`test_workflow_permissions.py` stops the next new workflow quietly omitting one.
A workflow satisfies the rule by declaring a scope at the top level or on every
job, which keeps reusable workflows (`ci-check.yml`, `ci-check-cross.yml`)
honest without forcing a shape on them.

It imports `yaml` directly rather than through `importorskip`. A guard that
skips itself when a dependency is missing is precisely the failure this line of
work exists to close — so `python-tests.yml` also regains `--with pyyaml`, which
#1493 dropped as dead weight back when no test needed it. Written the other way,
this guard would have gone green in CI while testing nothing.

## Validation

Extracted the job's `run:` block straight out of the YAML and executed it
verbatim, rather than approximating it:

```
423 passed, 8 skipped in 34.86s
```

(421 from #1493, plus the two new tests.) That also caught a real defect in an
intermediate revision — a lost `\` had split the command in two, which would
have run pytest with the ambient interpreter and none of the declared deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
