### PR TITLE
test(persist): assert the COW probe cache directly instead of timing it

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/persist/fs_caps.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/fs_caps.rs
@@ -116,6 +116,8 @@ pub(in crate::daemon::server) fn fs_caps(src: &Path, dst: &Path) -> VolumeCaps {
         return (*caps).effective();
     }
     let caps = probe_caps(src, dst);
+    #[cfg(test)]
+    record_probe(&key);
     let _insert_guard = CAPS_INSERT_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
@@ -133,6 +135,39 @@ pub(in crate::daemon::server) fn fs_caps(src: &Path, dst: &Path) -> VolumeCaps {
     }
     cache().insert(key, caps);
     caps.effective()
+}
+
+/// Per-volume-pair probe tally, for tests only.
+///
+/// A process-wide total cannot answer "was this pair re-probed?" while ~770
+/// other tests run in parallel and probe their own directories -- measured at
+/// 102 unrelated probes during one suite run. Counting per key isolates the
+/// question from that noise.
+#[cfg(test)]
+static PROBES_BY_KEY: OnceLock<dashmap::DashMap<VolumePair, u64>> = OnceLock::new();
+
+#[cfg(test)]
+fn record_probe(key: &VolumePair) {
+    *PROBES_BY_KEY
+        .get_or_init(dashmap::DashMap::new)
+        .entry(key.clone())
+        .or_insert(0) += 1;
+}
+
+/// The highest number of probes any single volume pair has incurred.
+///
+/// The cache promises one probe per pair, so this stays at 1 no matter how many
+/// deliveries or concurrent tests run. A regression that re-probes per delivery
+/// pushes exactly one key up to the delivery count, which is visible here
+/// without needing to know which key belongs to which test.
+#[cfg(test)]
+pub(in crate::daemon::server) fn max_probes_for_any_volume_pair() -> u64 {
+    PROBES_BY_KEY
+        .get_or_init(dashmap::DashMap::new)
+        .iter()
+        .map(|entry| *entry.value())
+        .max()
+        .unwrap_or(0)
 }
 
 fn probe_caps(src: &Path, dst: &Path) -> VolumeCaps {

--- a/crates/zccache-daemon-core/src/daemon/server/persist/tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/tests.rs
@@ -244,27 +244,51 @@ fn fs_caps_stays_correct_across_many_distinct_destination_dirs() {
     }
 }
 
-/// Function-level warm-hit budget for #1039. The generous 2-second ceiling is
-/// over 3x the observed Windows/NTFS debug-build time for 128 deliveries while
-/// still catching accidental per-hit hashing or probe-cache regressions.
+/// The warm-hit path must probe volume capabilities **once**, not per delivery
+/// (#1039).
+///
+/// This was previously asserted as "128 materializations in under 2 seconds",
+/// on the reasoning that a per-hit re-probe would be slow. That proxy failed
+/// intermittently on Windows CI -- observed at 2.33s and 7.56s against the 2s
+/// ceiling -- because `cargo test` runs it alongside ~770 other tests and the
+/// number it measured was mostly runner load. Per PERF.md, a wall-clock
+/// throughput claim belongs in the Docker matrix, not in a unit test on a
+/// shared runner.
+///
+/// The underlying property is exact and countable, so it is counted:
+/// `fs_caps` caches per volume pair, so 128 deliveries to the same directory
+/// must trigger at most one probe. A regression that re-probes per hit shows
+/// up as 128 and fails deterministically on any machine, fast or slow.
 #[test]
-fn perf_cow_materialization_128_hits_under_two_seconds() {
+fn cow_materialization_probes_the_volume_once_not_per_delivery() {
     let dir = tempfile::tempdir().unwrap();
     let cache = dir.path().join("cache/blob.rlib");
     std::fs::create_dir_all(cache.parent().unwrap()).unwrap();
     std::fs::write(&cache, vec![0x5a; 256 * 1024]).unwrap();
     write_authoritative_blob_digest(&cache).unwrap();
-    let started = std::time::Instant::now();
+
+    let probes_before = super::fs_caps::max_probes_for_any_volume_pair();
     for index in 0..128 {
         let output = dir.path().join(format!("target/output-{index}.rlib"));
         std::fs::create_dir_all(output.parent().unwrap()).unwrap();
         write_cached_file(&output, &cache).unwrap();
         crate::platform::fs::permissions::make_writable(&output).unwrap();
     }
-    let elapsed = started.elapsed();
+    let probes = super::fs_caps::max_probes_for_any_volume_pair();
     crate::platform::fs::permissions::make_writable(&cache).unwrap();
+
+    // Per *volume pair*, not process-wide: ~770 tests run in parallel and probe
+    // their own directories -- measured at 102 unrelated probes during one
+    // suite run -- so a global tally cannot answer this question. The cache
+    // promises one probe per pair, so the worst key stays at 1 however many
+    // deliveries or concurrent tests there are.
     assert!(
-        elapsed < Duration::from_secs(2),
-        "128 capability-driven materializations took {elapsed:?}"
+        probes <= 2,
+        "some volume pair was probed {probes} times; a count that scales with \
+         deliveries (128 here) means the per-volume probe cache is not in use"
+    );
+    assert!(
+        probes >= probes_before,
+        "probe tally went backwards: {probes} < {probes_before}"
     );
 }


### PR DESCRIPTION
The second flake blocking PRs on Windows. It is what red-lit **#1492** — a PR that changes one tokio test attribute and cannot affect COW materialization.

## The proxy, and why raising it was the wrong instinct

`perf_cow_materialization_128_hits_under_two_seconds` asserted *"128 materializations in under 2 seconds"* as a stand-in for *"the volume-capability probe is cached, not re-run per delivery"*. Observed failures: **2.33s** and **7.56s** against the 2s ceiling — `cargo test` runs it alongside ~770 other tests, so most of what it measured was runner load.

Raising the ceiling would have been wrong twice over:

1. The right number is unknowable on a shared runner — 2.33s and 7.56s are the same test on the same CI.
2. **A generous bound would not catch the regression anyway.** 128 × 256 KiB is well under a second even in a debug build, so per-hit hashing slips through any ceiling loose enough to be stable. The ceiling's only real value was as a probe-cache proxy.

## Counting the thing instead of timing it

`fs_caps` already had a `PROBE_COUNT`, so my first attempt asserted a delta on it. **That was wrong, and the full suite caught it:** a process-wide total cannot answer "was *this* pair re-probed?" while other tests probe their own directories. I measured **102 unrelated probes** in one suite run, which blew a global-delta bound of 8 — I would have shipped a worse flake than the one I was fixing.

Counting **per volume pair** isolates the question. The cache promises one probe per pair, so the worst key stays at 1 however many deliveries run and however many tests run beside it.

## Verification

**RED**, by disabling the cache lookup:

```
some volume pair was probed 128 times; a count that scales with deliveries
(128 here) means the per-volume probe cache is not in use
```

Deterministic, machine-independent, and it fails in **0.47s** rather than by exceeding a stopwatch.

**GREEN** under the condition that broke the first attempt: full `zccache-daemon-core` lib suite at normal parallelism — **784 passed, 0 failed**.

The counter map is `#[cfg(test)]`, so production keeps only the existing `PROBE_COUNT`. Clippy clean under `-D warnings`.

## On dropping the timing claim

The wall-clock assertion is removed rather than relaxed. Per PERF.md a throughput number belongs in the sanctioned Docker matrix, not a unit test on a shared runner — and as above, the loose version would not have caught anything the new assertion misses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
