### PR TITLE
chore(release): bump 1.13.6 -> 1.13.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,7 +4105,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "bincode",
  "blake3",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-audit"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -4215,7 +4215,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4224,7 +4224,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli-core"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "bincode",
  "blake3",
@@ -4278,14 +4278,14 @@ dependencies = [
 
 [[package]]
 name = "zccache-compile-trace"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "zccache-audit",
 ]
 
 [[package]]
 name = "zccache-compiler"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "clang",
  "serde_json",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "crash-handler",
  "dashmap",
@@ -4312,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon-core"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "bincode",
  "blake3",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "blake3",
  "futures",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "bincode",
  "bytes",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "filetime",
  "fs2",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "bincode",
  "dashmap",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "reqwest",
  "serde",
@@ -4460,7 +4460,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "blake3",
  "memmap2",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "bytes",
  "dashmap",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-platform"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "crash-handler",
  "interprocess",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "bincode",
  "bytes",
@@ -4521,7 +4521,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-symbols"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "tempfile",
  "zccache-core",
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "tempfile",
  "zccache-audit",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "globset",
  "jwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.6"
+version = "1.13.7"
 edition = "2021"
 rust-version = "1.95.0"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Bumps the workspace version so a release can actually ship.

## Why now

`1.13.6` is **fully published** on both PyPI and crates.io, so re-running the
release on it publishes nothing — `preflight` reports `pypi_complete` /
`crates_complete` and both publish jobs skip. The version has to move first.

Main carries exactly one unreleased commit on top of the `1.13.6` tag: #1493.

## What ships

#1493 wires the `ci/tests` pytest suite into CI — ~430 tests that no workflow,
no hook, and not `./test` had ever executed — and fixes the three bugs that
suite was already holding:

- **perf fixtures could not build offline.** `perf/fixtures/{medium,sqlite-link}`
  stayed pinned to `1.94.1` after the runner image moved to `1.95.0`, costing
  ~75s and 570MB of in-container toolchain download per benchmark run with
  network, and failing outright without it.
- **An idle host reported itself busy.** The CPU-progress threshold is derived
  from the measured sample gap and was never floored; a coarse monotonic clock
  reports that gap as exactly `0.0`, and `delta >= 0.0` is true for a process
  that burned no CPU, so `_require_quiet_host` refused to benchmark on an idle
  machine.
- **A toolchain guard was matching a checksum.** `"1.94.1"` was grepped as a
  regex, so its dots were wildcards and it matched `1394014` inside a
  `Cargo.lock` checksum.

Note `ci` is a packaged module (`pyproject.toml` → `packages = ["ci", ...]`), so
the `perf_standalone` fix is part of the published wheel, not only repo tooling.

## Verification

- `Cargo.lock` regenerated — all 22 workspace entries move to `1.13.7`.
- `ci/tests`: **421 passed, 8 skipped**, run with the job's exact command.
- The dry run on the parent commit (`32659667527`) **completed successfully** —
  the checkpoint `CLAUDE.md` calls for before crossing the publish boundary.

## What merging does

`detect-bump` compares `[workspace.package].version` against the parent commit,
sees the bump, and proceeds. On a `push` event `inputs` is null, so
`inputs['dry-run'] != true` holds and the publish jobs run for real: GitHub
Release → PyPI → crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
