### PR TITLE
chore(release): bump 1.13.7 -> 1.13.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,7 +4105,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "bincode",
  "blake3",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-audit"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -4215,7 +4215,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4224,7 +4224,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli-core"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "bincode",
  "blake3",
@@ -4278,14 +4278,14 @@ dependencies = [
 
 [[package]]
 name = "zccache-compile-trace"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "zccache-audit",
 ]
 
 [[package]]
 name = "zccache-compiler"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "clang",
  "serde_json",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "crash-handler",
  "dashmap",
@@ -4312,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon-core"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "bincode",
  "blake3",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "blake3",
  "futures",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "bincode",
  "bytes",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "filetime",
  "fs2",
@@ -4431,7 +4431,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint-py"
-version = "1.13.6"
+version = "1.13.8"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4441,7 +4441,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "bincode",
  "dashmap",
@@ -4457,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "reqwest",
  "serde",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "blake3",
  "memmap2",
@@ -4478,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "bytes",
  "dashmap",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-platform"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "crash-handler",
  "interprocess",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "bincode",
  "bytes",
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-symbols"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "tempfile",
  "zccache-core",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "tempfile",
  "zccache-audit",
@@ -4546,7 +4546,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "globset",
  "jwalk",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher-py"
-version = "1.13.6"
+version = "1.13.8"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.7"
+version = "1.13.8"
 edition = "2021"
 rust-version = "1.95.0"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Ships the setup-soldr migration (#1497 / #1501), which merged after 1.13.7 was cut. Same file set as the 1.13.7 bump (#1502): `Cargo.toml` + `Cargo.lock`.

Merging this triggers `release-auto` on push-to-main.

## What lands for users

**Windows binaries link the CRT statically — and are now checked.**
1.13.7 itself is fine (built through the old cargo-xwin path), but the migration initially regressed `aarch64-pc-windows-msvc` to a *dynamic* CRT. Silently: x64 failed loudly with a duplicate-symbol error, aarch64 just went green and produced a binary importing `VCRUNTIME140.dll` plus seven `api-ms-win-crt-*` apisets. Nothing could have caught it — `Smoke test built binary` skips every cross target, so no Windows binary had ever been inspected.

There is now a PE-import gate on both Windows triples. It needs no execution, so it works cross-compiled, and it was validated against both real artifacts before being trusted: it flags the regressed binary and passes the shipped 1.13.6 one. That is the regression test zccache#269 never had.

**One toolchain provider.** `dtolnay/rust-toolchain`, `mlugg/setup-zig`, `cargo-zigbuild` and `cargo-xwin` are gone. setup-soldr owns the target lifecycle and cross builds go through `soldr build --target`. The two providers previously wrote to the same `solo-toolchain-*` cache key, and the 6-file 2.5 MB entry that produced cost four release attempts on 1.13.6 before it was diagnosed.

**PyO3 extensions in dedicated crates.** `zccache-watcher-py` and `zccache-fingerprint-py` are cdylib-only, so a build that only wants the rlib no longer links a cdylib nothing consumes. Output filenames are unchanged (`[lib] name`), so packaging is unaffected.

## Verification

Run [32687504125](https://github.com/zackees/zccache/actions/runs/32687504125): **8/8 targets green**, gate confirms static CRT on both Windows lanes. Independently checked the downloaded aarch64 artifact: 0 dynamic-CRT imports, down from 8. PR #1501 finished 35 checks green.

## Note

`build-target` carries a temporary counter-flag block that neutralizes soldr's dynamic-CRT link args from the caller side. It is marked removable in place: [zackees/soldr#2798](https://github.com/zackees/soldr/pull/2798) fixes this upstream by making the static and dynamic branches mutually exclusive. Once that ships in setup-soldr the block goes, and the gate proves the replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
