### PR TITLE
feat(daemon): serialize amalgamated Rust and C compiles

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/compile_resource_gate.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/compile_resource_gate.rs
@@ -1,0 +1,365 @@
+//! Build-wide admission for unusually memory-intensive compiler units.
+//!
+//! C libraries such as SQLite ship as one multi-megabyte translation unit.
+//! Published Rust crates can have the same shape without a large root file:
+//! zccache's release crate folds its internal workspace into one rustc unit.
+//! Ordinary compiles take shared admission; either kind of amalgamation takes
+//! exclusive admission immediately before the compiler child is spawned.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
+
+use crate::compiler::CompilerFamily;
+
+use super::SharedState;
+
+const AMALGAMATION_BYTES: u64 = 1_000_000;
+const KNOWN_C_AMALGAMATIONS: &[&str] = &["sqlite3.c", "zstd.c", "rocksdb.cc"];
+const KNOWN_RUST_AMALGAMATIONS: &[&str] = &["zccache"];
+
+/// Fair shared/exclusive admission around real compiler execution.
+///
+/// Tokio's write-preferring lock prevents newly arriving ordinary compiles
+/// from starving an amalgamation after it reaches the queue.
+#[derive(Clone, Default)]
+pub(super) struct CompileResourceGate {
+    inner: Arc<RwLock<()>>,
+}
+
+pub(super) enum CompileResourcePermit {
+    Shared { _guard: OwnedRwLockReadGuard<()> },
+    Exclusive { _guard: OwnedRwLockWriteGuard<()> },
+}
+
+/// Owns both layers of compiler admission in their canonical lock order.
+///
+/// The bounded FIFO semaphore comes first, then the fair resource gate. This
+/// prevents ordinary readers from accumulating ahead of an exclusive unit
+/// while also ensuring nobody holds the resource gate while waiting for a
+/// scarce compile slot.
+pub(super) struct CompilerAdmission {
+    _resource: CompileResourcePermit,
+    _compile: super::compile_progress::CompileGateGuard,
+}
+
+impl CompileResourceGate {
+    pub(super) async fn acquire(&self, exclusive: bool) -> CompileResourcePermit {
+        if exclusive {
+            CompileResourcePermit::Exclusive {
+                _guard: Arc::clone(&self.inner).write_owned().await,
+            }
+        } else {
+            CompileResourcePermit::Shared {
+                _guard: Arc::clone(&self.inner).read_owned().await,
+            }
+        }
+    }
+}
+
+pub(super) async fn acquire_compiler_admission(
+    state: &SharedState,
+    exclusive: bool,
+) -> (CompilerAdmission, Option<usize>) {
+    let (compile, available_before) = super::compile_progress::acquire_compile_gate(
+        state.compile_concurrency.as_ref(),
+        &state.compile_queue,
+    )
+    .await;
+    let resource = state.compile_resource_gate.acquire(exclusive).await;
+    (
+        CompilerAdmission {
+            _resource: resource,
+            _compile: compile,
+        },
+        available_before,
+    )
+}
+
+/// Decide whether one compiler invocation must run without sibling compilers.
+pub(super) fn requires_exclusive_access(
+    family: CompilerFamily,
+    args: &[String],
+    source_path: &Path,
+) -> bool {
+    match family {
+        CompilerFamily::Rustc => {
+            rust_crate_name(args).is_some_and(|name| KNOWN_RUST_AMALGAMATIONS.contains(&name))
+        }
+        CompilerFamily::Gcc | CompilerFamily::Clang | CompilerFamily::Msvc => {
+            let known = source_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| KNOWN_C_AMALGAMATIONS.contains(&name));
+            known
+                || std::fs::metadata(source_path)
+                    .is_ok_and(|metadata| metadata.len() >= AMALGAMATION_BYTES)
+        }
+        CompilerFamily::Rustfmt => false,
+    }
+}
+
+fn rust_crate_name(args: &[String]) -> Option<&str> {
+    let mut args = args.iter();
+    while let Some(arg) = args.next() {
+        if arg == "--crate-name" {
+            return args.next().map(String::as_str);
+        }
+        if let Some(name) = arg.strip_prefix("--crate-name=") {
+            return Some(name);
+        }
+    }
+    None
+}
+
+/// Classify an invocation when parsing fell back to direct execution.
+pub(super) fn requires_exclusive_access_from_args(
+    family: CompilerFamily,
+    args: &[String],
+    cwd: &Path,
+) -> bool {
+    if family == CompilerFamily::Rustc {
+        return rust_crate_name(args).is_some_and(|name| KNOWN_RUST_AMALGAMATIONS.contains(&name));
+    }
+    if !matches!(
+        family,
+        CompilerFamily::Gcc | CompilerFamily::Clang | CompilerFamily::Msvc
+    ) {
+        return false;
+    }
+    args.iter()
+        .filter(|arg| {
+            !(arg.starts_with('-') || family == CompilerFamily::Msvc && arg.starts_with('/'))
+        })
+        .filter_map(|arg| {
+            let path = Path::new(arg);
+            let extension = path.extension()?.to_str()?.to_ascii_lowercase();
+            matches!(
+                extension.as_str(),
+                "c" | "cc" | "cpp" | "cxx" | "c++" | "m" | "mm"
+            )
+            .then_some(path)
+        })
+        .any(|path| {
+            let source = if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                cwd.join(path)
+            };
+            requires_exclusive_access(family, args, &source)
+        })
+}
+
+pub(super) fn requires_exclusive_access_for_misses<'a>(
+    family: CompilerFamily,
+    args: &[String],
+    sources: impl IntoIterator<Item = Option<&'a Path>>,
+) -> bool {
+    sources
+        .into_iter()
+        .flatten()
+        .any(|source| requires_exclusive_access(family, args, source))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_published_zccache_crate_is_a_rust_amalgamation() {
+        assert!(requires_exclusive_access(
+            CompilerFamily::Rustc,
+            &["--crate-name".into(), "zccache".into()],
+            Path::new("/registry/zccache/src/lib.rs"),
+        ));
+    }
+
+    #[test]
+    fn an_ordinary_rust_crate_remains_shared() {
+        assert!(!requires_exclusive_access(
+            CompilerFamily::Rustc,
+            &["--crate-name=serde".into()],
+            Path::new("/registry/serde/src/lib.rs"),
+        ));
+    }
+
+    #[test]
+    fn an_oversized_private_c_unit_is_detected_by_shape() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source = dir.path().join("private-amalgamation.c");
+        std::fs::write(&source, vec![b'x'; AMALGAMATION_BYTES as usize])
+            .expect("write source fixture");
+
+        assert!(requires_exclusive_access(
+            CompilerFamily::Clang,
+            &[],
+            &source,
+        ));
+    }
+
+    #[test]
+    fn a_small_known_c_amalgamation_is_still_recognized() {
+        assert!(requires_exclusive_access(
+            CompilerFamily::Gcc,
+            &[],
+            Path::new("sqlite3.c"),
+        ));
+    }
+
+    #[tokio::test]
+    async fn exclusive_admission_drains_shared_work_and_blocks_new_readers() {
+        use std::time::Duration;
+
+        let gate = CompileResourceGate::default();
+        let first_shared = gate.acquire(false).await;
+
+        let writer_gate = gate.clone();
+        let (writer_acquired_tx, mut writer_acquired_rx) = tokio::sync::oneshot::channel();
+        let (release_writer_tx, release_writer_rx) = tokio::sync::oneshot::channel();
+        let writer = tokio::spawn(async move {
+            let _permit = writer_gate.acquire(true).await;
+            let _ = writer_acquired_tx.send(());
+            let _ = release_writer_rx.await;
+        });
+        tokio::task::yield_now().await;
+
+        let later_reader_gate = gate.clone();
+        let (reader_acquired_tx, mut reader_acquired_rx) = tokio::sync::oneshot::channel();
+        let reader = tokio::spawn(async move {
+            let _permit = later_reader_gate.acquire(false).await;
+            let _ = reader_acquired_tx.send(());
+        });
+
+        assert!(writer_acquired_rx.try_recv().is_err());
+        assert!(reader_acquired_rx.try_recv().is_err());
+        drop(first_shared);
+
+        tokio::time::timeout(Duration::from_secs(1), &mut writer_acquired_rx)
+            .await
+            .expect("writer should acquire after the active reader drains")
+            .expect("writer task should report acquisition");
+        assert!(
+            reader_acquired_rx.try_recv().is_err(),
+            "a queued writer must block later readers"
+        );
+
+        let _ = release_writer_tx.send(());
+        tokio::time::timeout(Duration::from_secs(1), reader_acquired_rx)
+            .await
+            .expect("reader should resume after exclusive work")
+            .expect("reader task should report acquisition");
+        writer.await.expect("writer task");
+        reader.await.expect("reader task");
+    }
+
+    #[tokio::test]
+    async fn ordinary_units_can_hold_shared_admission_together() {
+        use std::time::Duration;
+
+        let gate = CompileResourceGate::default();
+        let _first = gate.acquire(false).await;
+        tokio::time::timeout(Duration::from_secs(1), gate.acquire(false))
+            .await
+            .expect("ordinary compiles must not serialize");
+    }
+
+    #[test]
+    fn direct_rust_and_c_invocations_use_the_same_classifier() {
+        assert!(requires_exclusive_access_from_args(
+            CompilerFamily::Rustc,
+            &["--crate-name=zccache".into(), "src/lib.rs".into()],
+            Path::new("."),
+        ));
+        assert!(requires_exclusive_access_from_args(
+            CompilerFamily::Clang,
+            &["-c".into(), "sqlite3.c".into()],
+            Path::new("."),
+        ));
+    }
+
+    #[test]
+    fn cached_amalgamation_does_not_make_an_ordinary_multi_source_miss_exclusive() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let sqlite = temp.path().join("sqlite3.c");
+        let ordinary = temp.path().join("ordinary.c");
+        std::fs::write(&sqlite, "/* cached */").expect("write sqlite fixture");
+        std::fs::write(&ordinary, "int ordinary(void) { return 0; }")
+            .expect("write ordinary fixture");
+
+        let args = vec!["-c".to_string()];
+        assert!(!requires_exclusive_access_for_misses(
+            CompilerFamily::Gcc,
+            &args,
+            [None, Some(ordinary.as_path())],
+        ));
+        assert!(requires_exclusive_access_for_misses(
+            CompilerFamily::Gcc,
+            &args,
+            [Some(sqlite.as_path()), Some(ordinary.as_path())],
+        ));
+    }
+
+    #[test]
+    fn cache_hit_branches_precede_compiler_admission() {
+        let pipeline = include_str!("handle_compile/pipeline/mod.rs");
+        let compile_miss = pipeline
+            .find("run_compile_exec(CompileExecRequest")
+            .expect("pipeline must dispatch real cache misses");
+        for hit in [
+            "try_request_cache_hit(",
+            "try_fast_hit(",
+            "try_depgraph_cached_hit(",
+        ] {
+            let last_hit = pipeline
+                .rfind(hit)
+                .unwrap_or_else(|| panic!("pipeline must retain its {hit} branch"));
+            assert!(
+                last_hit < compile_miss,
+                "{hit} must return before compiler admission is reachable"
+            );
+        }
+    }
+
+    #[test]
+    fn every_compile_spawn_surface_uses_shared_admission() {
+        for (name, source) in [
+            (
+                "single cache miss",
+                include_str!("handle_compile/pipeline/compile_exec.rs"),
+            ),
+            (
+                "direct fallback",
+                include_str!("handle_compile_ephemeral.rs"),
+            ),
+            (
+                "legacy multi-source",
+                include_str!("handle_compile_multi.rs"),
+            ),
+            (
+                "staged multi-source",
+                include_str!("handle_compile_multi_staged.rs"),
+            ),
+        ] {
+            assert!(
+                source.contains("acquire_compiler_admission("),
+                "{name} compiler path bypasses shared admission"
+            );
+        }
+    }
+
+    #[test]
+    fn bounded_compile_admission_precedes_the_resource_gate() {
+        let source = include_str!("compile_resource_gate.rs");
+        let compile = source
+            .find("compile_progress::acquire_compile_gate(")
+            .expect("shared admission must acquire the compile gate");
+        let resource = source
+            .find("compile_resource_gate.acquire(exclusive)")
+            .expect("shared admission must acquire the resource gate");
+        assert!(
+            compile < resource,
+            "canonical lock order must remain stable"
+        );
+    }
+}

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -247,6 +247,28 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         CompilePriority::from_client_env_for_link_like(client_env.as_deref(), is_link_like);
     let compiler_priority_decision = compiler_priority.resolve_for_current_load();
 
+    // soldr#2781: this point is reached only after every cache-hit branch has
+    // missed. Ordinary compiler children share the gate; an amalgamated C
+    // translation unit or known amalgamated Rust release crate drains those
+    // readers and runs alone. The shared helper acquires the bounded FIFO
+    // compile slot first and the resource gate second, then both remain held
+    // across overlapping input hashing and the compiler child.
+    let exclusive = crate::daemon::server::compile_resource_gate::requires_exclusive_access(
+        compilation.family,
+        effective_args,
+        source_path.as_path(),
+    );
+    let (_compiler_admission, available_before) =
+        crate::daemon::server::compile_resource_gate::acquire_compiler_admission(state, exclusive)
+            .await;
+    if exclusive {
+        tracing::info!(
+            event = "compile_exclusive",
+            source = %source_path.display(),
+            "amalgamated compiler unit acquired exclusive build access"
+        );
+    }
+
     // Issue #532: kick off hashing of pre-known inputs (source +
     // rustc_extern_paths) on a blocking thread, in parallel with the
     // rustc spawn. The 50-rlib externs of a workspace link dominate
@@ -299,12 +321,6 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     // request's queue position while it sits here. `_compile_gate` restores
     // the permit and counters on every exit path, including cancellation.
     let client_pid = lineage.client_pid.unwrap_or(0);
-    let (_compile_gate, available_before) =
-        crate::daemon::server::compile_progress::acquire_compile_gate(
-            state.compile_concurrency.as_ref(),
-            &state.compile_queue,
-        )
-        .await;
     if let Some(available_before) = available_before {
         tracing::info!(
             event = "compile_start",

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -464,6 +464,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         HashSourceOutcome::Ready(outcome) => outcome,
         HashSourceOutcome::Fallback => {
             return run_compiler_direct(
+                state,
                 &compiler,
                 args,
                 cwd,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/request_prep.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/request_prep.rs
@@ -214,6 +214,7 @@ pub(super) async fn prepare_dylint_request(
         &format!("non-cacheable: Dylint cache disabled: {reason}"),
     );
     let response = run_compiler_direct(
+        state,
         &bypass_compiler,
         raw_args,
         cwd,
@@ -269,6 +270,7 @@ pub(super) async fn bypass_time_macro_request(
     warn_time_macro_uncacheable(&found);
     Some(
         run_compiler_direct(
+            state,
             &bypass_compiler,
             raw_args,
             cwd,
@@ -322,6 +324,7 @@ pub(super) async fn discover_request_system_includes(
         "non-cacheable: system include discovery returned zero paths",
     );
     Err(run_compiler_direct(
+        state,
         compiler,
         raw_args,
         cwd,
@@ -373,6 +376,7 @@ pub(super) async fn parse_single_compile_request(
             });
             write_session_log(&state.sessions, sid, &format!("non-cacheable: {reason}"));
             return Err(run_compiler_direct(
+                state,
                 compiler,
                 raw_args,
                 cwd,
@@ -447,6 +451,7 @@ pub(super) async fn parse_single_compile_request(
                 "non-cacheable: Dylint cdylib output identity is incomplete",
             );
             return Err(run_compiler_direct(
+                state,
                 compiler,
                 raw_args,
                 cwd,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
@@ -73,6 +73,7 @@ pub(super) async fn handle_compile_ephemeral(
 /// covered by the wrapper's Defender exclusion — see issue #275.
 #[allow(clippy::too_many_arguments)] // Mirrors handle_compile's surface — refactor parked.
 pub(super) async fn run_compiler_direct(
+    state: &SharedState,
     compiler: &NormalizedPath,
     args: &[String],
     cwd: &Path,
@@ -90,6 +91,7 @@ pub(super) async fn run_compiler_direct(
     // names, which matches the historical behaviour.
     let family_hint = crate::compiler::detect_family(&compiler.to_string_lossy());
     run_compiler_direct_with_family(
+        state,
         compiler,
         args,
         cwd,
@@ -105,6 +107,7 @@ pub(super) async fn run_compiler_direct(
 
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn run_compiler_direct_with_family(
+    state: &SharedState,
     compiler: &NormalizedPath,
     args: &[String],
     cwd: &Path,
@@ -145,6 +148,16 @@ pub(super) async fn run_compiler_direct_with_family(
     } else {
         Some(stdin_bytes)
     };
+    let exclusive =
+        super::compile_resource_gate::requires_exclusive_access_from_args(family_hint, args, cwd);
+    let (_compiler_admission, _) =
+        super::compile_resource_gate::acquire_compiler_admission(state, exclusive).await;
+    if exclusive {
+        tracing::info!(
+            event = "compile_exclusive",
+            "direct amalgamated compiler unit acquired exclusive build access"
+        );
+    }
     let (result, streamed_output) = if let Some(context) = crate::daemon::compile_output::current()
     {
         let (sender, receiver) = tokio::sync::mpsc::channel(8);

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -755,9 +755,22 @@ pub(super) async fn handle_compile_multi(
     }
     apply_client_env(&mut cmd, &client_env, &lineage);
     let compiler_priority = CompilePriority::from_client_env(client_env.as_deref());
+    let exclusive =
+        crate::daemon::server::compile_resource_gate::requires_exclusive_access_for_misses(
+            compilations[0].family,
+            &compiler_args,
+            unit_results.iter().map(|unit| match unit {
+                UnitCacheResult::Miss { source_path, .. } => Some(source_path.as_path()),
+                UnitCacheResult::Hit { .. } => None,
+            }),
+        );
+    let (compiler_admission, _) =
+        crate::daemon::server::compile_resource_gate::acquire_compiler_admission(&state, exclusive)
+            .await;
     let result =
         super::super::process::tokio_command_output_with_priority(&mut cmd, compiler_priority)
             .await;
+    drop(compiler_admission);
 
     let output = match result {
         Ok(o) => o,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_preflight.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_preflight.rs
@@ -399,6 +399,7 @@ pub(super) async fn run_depfile_stdout_batch(
     }
     Some(
         run_compiler_direct(
+            state,
             compiler,
             original_args,
             cwd,
@@ -483,6 +484,7 @@ pub(super) async fn run_unsupported_batch(
                 });
             }
             let response = run_compiler_direct_with_family(
+                state,
                 compiler,
                 original_args,
                 cwd,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
@@ -207,28 +207,27 @@ pub(super) async fn try_handle_staged_misses(
         }
         apply_client_env(&mut command, client_env, &lineage);
         command.kill_on_drop(true);
-        let compile_concurrency = state.compile_concurrency.clone();
+        let admission_state = Arc::clone(state);
+        let family = compilations[miss.unit_index].family;
+        let exclusive = crate::daemon::server::compile_resource_gate::requires_exclusive_access(
+            family,
+            &compiler_args,
+            miss.source_path.as_path(),
+        );
         // Issue #1216: keep the global queue gauge accurate for the staged
         // lane too. These waits run on spawned tasks, so the per-request
         // task-local slot is out of reach — the daemon-wide `queue_depth` /
         // `in_flight` counters still are not, and those are what other
         // clients' heartbeats report.
-        let compile_queue = Arc::clone(&state.compile_queue);
         let unit_index = miss.unit_index;
         compiler_set.spawn(async move {
-            let available_before = compile_concurrency
-                .as_ref()
-                .map_or(usize::MAX, |semaphore| semaphore.available_permits());
-            let mut queue_guard = compile_queue.enqueue();
-            let _permit = if let Some(semaphore) = compile_concurrency.as_ref() {
-                let permit = Arc::clone(semaphore).acquire_owned().await.ok();
-                queue_guard.admit();
-                permit
-            } else {
-                queue_guard.admit();
-                None
-            };
-            if compile_concurrency.is_some() {
+            let (_compiler_admission, available_before) =
+                crate::daemon::server::compile_resource_gate::acquire_compiler_admission(
+                    &admission_state,
+                    exclusive,
+                )
+                .await;
+            if let Some(available_before) = available_before {
                 tracing::info!(
                     event = "compile_start",
                     client_pid,
@@ -239,7 +238,7 @@ pub(super) async fn try_handle_staged_misses(
             let compiler_started = std::time::Instant::now();
             let output = process::tokio_command_output_with_priority(&mut command, priority).await;
             let elapsed_ns = compiler_started.elapsed().as_nanos() as u64;
-            if compile_concurrency.is_some() {
+            if admission_state.compile_concurrency.is_some() {
                 let exit_code = output
                     .as_ref()
                     .ok()

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -297,6 +297,8 @@ pub(super) fn new_shared_state(
             staged_materialization_lock: Arc::new(StdMutex::new(std::sync::Weak::new())),
             persist_semaphore: Arc::new(tokio::sync::Semaphore::new(persist_workers_default())),
             compile_concurrency,
+            compile_resource_gate:
+                crate::daemon::server::compile_resource_gate::CompileResourceGate::default(),
             compile_queue: Arc::new(
                 crate::daemon::server::compile_progress::CompileQueueGauge::default(),
             ),

--- a/crates/zccache-daemon-core/src/daemon/server/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/mod.rs
@@ -152,6 +152,7 @@ mod cached_artifact;
 mod client_env;
 mod compile_concurrency;
 mod compile_progress;
+mod compile_resource_gate;
 mod compiler_hash;
 mod connection;
 mod dependency_policy;

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -461,6 +461,9 @@ pub(super) struct SharedState {
     /// `None` when the override is `0` (or `unlimited`) — preserves the
     /// historical uncapped behavior for users who want it.
     pub(super) compile_concurrency: Option<Arc<tokio::sync::Semaphore>>,
+    /// Shared admission for ordinary compiler children and exclusive
+    /// admission for unusually memory-intensive C/Rust amalgamations.
+    pub(super) compile_resource_gate: super::compile_resource_gate::CompileResourceGate,
     /// Issue #1216 — compile-queue counters backing the `CompileProgress`
     /// heartbeats. `tokio::sync::Semaphore` reports available permits but
     /// not its waiter count or original capacity, so the gate maintains

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -981,3 +981,11 @@ the direct evidence that 0.9.3 cross-compiles for that target.
 Upstream follow-through: #227 (my duplicate) closed against #223; #228 merged,
 documenting the cross-compilation contract and why `CFLAGS=-TP` is the wrong
 lever, in both the crate and repo READMEs.
+
+# Rust/C amalgamation compile admission
+
+- [x] Add RED coverage for the published zccache crate as a Rust amalgamation.
+- [x] Give known Rust amalgamations and oversized C translation units exclusive compiler access.
+- [x] Prove ordinary compiles remain concurrent and cache hits skip the barrier.
+- [x] Run focused tests, formatting, Clippy, full validation, and review.
+- [ ] Merge and publish the next zccache release.


### PR DESCRIPTION
## Summary
- classify the published zccache Rust crate, known C amalgamations, and C/C++ translation units at least 1 MiB as exclusive compiler work
- use a fair shared/exclusive gate behind the existing FIFO compile admission across cached misses, direct execution, and both multi-source paths
- preserve cache-hit bypass and release admission immediately after compiler execution

## Validation
- soldr cargo test -p zccache-daemon-core --features test-support compile_resource_gate (11 passed)
- soldr cargo test -p zccache-daemon-core --features test-support --lib (787 passed, 26 ignored)
- soldr cargo clippy -p zccache-daemon-core --all-targets --features test-support -- -D warnings`n- soldr cargo fmt --all -- --check`n- clud-review follow-up: clean

Part of zackees/soldr#2781.