### PR TITLE
fix: serialize large vendored zccache crates

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/compile_resource_gate.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/compile_resource_gate.rs
@@ -17,7 +17,7 @@ use super::SharedState;
 
 const AMALGAMATION_BYTES: u64 = 1_000_000;
 const KNOWN_C_AMALGAMATIONS: &[&str] = &["sqlite3.c", "zstd.c", "rocksdb.cc"];
-const KNOWN_RUST_AMALGAMATIONS: &[&str] = &["zccache"];
+const KNOWN_RUST_AMALGAMATIONS: &[&str] = &["zccache", "zccache_cli_core", "zccache_daemon_core"];
 
 /// Fair shared/exclusive admission around real compiler execution.
 ///
@@ -209,6 +209,20 @@ mod tests {
             ],
             Path::new("/registry/zccache/src/lib.rs"),
         ));
+    }
+
+    #[test]
+    fn the_large_vendored_zccache_engine_crates_are_rust_amalgamations() {
+        for crate_name in ["zccache_cli_core", "zccache_daemon_core"] {
+            assert!(requires_exclusive_access(
+                CompilerFamily::Rustc,
+                &[
+                    format!("--crate-name={crate_name}"),
+                    "--crate-type=lib".into(),
+                ],
+                Path::new("/vendor/zccache/src/lib.rs"),
+            ));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary`n`n- grant the split zccache CLI and daemon engine libraries exclusive compiler admission`n- preserve shared admission for binaries, test harnesses, and other linking crate types`n- add regression coverage for both rustc crate names`n`n## Evidence`n`nA Soldr Docker build against 1.13.10 OOMed while zccache_cli_core and zccache_daemon_core overlapped. This extends the Rust amalgamation classifier to those two large vendored library units.`n`n## Validation`n`n- 16 focused compile-resource-gate tests pass with test-support`n- strict Clippy for zccache-daemon-core all targets/test-support`n- cargo fmt check and git diff check`n- clud-review: clean