### PR TITLE
perf: remove top cold and startup regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,13 @@ jobs:
       - name: Install stable Rust components
         run: soldr rustup component add rustfmt
       - name: Install Dylint
-        if: steps.setup-soldr.outputs.dylint-cache-hit != 'true'
         run: |
-          soldr cargo install cargo-dylint --version 6.0.1 --locked
-          soldr cargo install dylint-link --version 6.0.1 --locked
+          if ! command -v cargo-dylint >/dev/null 2>&1; then
+            soldr cargo install cargo-dylint --version 6.0.1 --locked
+          fi
+          if ! command -v dylint-link >/dev/null 2>&1; then
+            soldr cargo install dylint-link --version 6.0.1 --locked
+          fi
       - name: Check Dylint wiring
         run: uv run python ci/check_dylint_wiring.py
       - name: Check Dylint Library Formatting (ban_std_pathbuf)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4480,6 +4480,7 @@ dependencies = [
 name = "zccache-ipc"
 version = "1.13.11"
 dependencies = [
+ "blake3",
  "bytes",
  "dashmap",
  "interprocess",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4488,7 +4488,6 @@ dependencies = [
  "running-process",
  "serde",
  "serde_json",
- "sha2",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4487,6 +4487,7 @@ dependencies = [
  "running-process",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror",
  "tokio",

--- a/bosn.toml
+++ b/bosn.toml
@@ -12,6 +12,8 @@ ZCCACHE_PROFILE_WORKLOAD = "perf_rustc_zccache_vs_sccache"
 [stack.perf.volumes]
 target = { scope = "stack", destination = "/target" }
 soldr-home = { scope = "machine", destination = "/root/.soldr" }
+soldr-cargo-home = { scope = "machine", destination = "/work/.cargo" }
+soldr-rustup-home = { scope = "machine", destination = "/work/.rustup" }
 
 [stack.perf.mounts]
 repo = { source = ".", destination = "/work" }

--- a/bosn.toml
+++ b/bosn.toml
@@ -36,6 +36,14 @@ cmd = "bash /work/ci/docker/profile/run_bosn_profile.sh offcpu"
 stack = "perf"
 cmd = "bash /work/ci/docker/profile/run_bosn_profile.sh memory"
 
+[task.heaptrack-profile]
+stack = "perf"
+cmd = "bash /work/ci/docker/profile/run_bosn_profile.sh heaptrack"
+
+[task.massif-profile]
+stack = "perf"
+cmd = "bash /work/ci/docker/profile/run_bosn_profile.sh massif"
+
 [task.profile]
 stack = "perf"
 cmd = "bash /work/ci/docker/profile/run_bosn_profile.sh all"

--- a/bosn.toml
+++ b/bosn.toml
@@ -12,8 +12,8 @@ ZCCACHE_PROFILE_WORKLOAD = "perf_rustc_zccache_vs_sccache"
 [stack.perf.volumes]
 target = { scope = "stack", destination = "/target" }
 soldr-home = { scope = "machine", destination = "/root/.soldr" }
-soldr-cargo-home = { scope = "machine", destination = "/work/.cargo" }
-soldr-rustup-home = { scope = "machine", destination = "/work/.rustup" }
+soldr-cargo-home = { scope = "machine", destination = "/bosn/cargo" }
+soldr-rustup-home = { scope = "machine", destination = "/bosn/rustup" }
 
 [stack.perf.mounts]
 repo = { source = ".", destination = "/work" }

--- a/bosn.toml
+++ b/bosn.toml
@@ -1,0 +1,41 @@
+[stack.perf]
+dockerfile = "ci/docker/profile/Dockerfile.bosn-perf-linux"
+family = "zccache-perf"
+default = true
+workdir = "/work"
+
+[stack.perf.env]
+CARGO_TARGET_DIR = "/target"
+RUSTFLAGS = "-C force-frame-pointers=yes -C debuginfo=2"
+ZCCACHE_PROFILE_WORKLOAD = "perf_rustc_zccache_vs_sccache"
+
+[stack.perf.volumes]
+target = { scope = "stack", destination = "/target" }
+soldr-home = { scope = "machine", destination = "/root/.soldr" }
+
+[stack.perf.mounts]
+repo = { source = ".", destination = "/work" }
+
+[task.build-profile]
+stack = "perf"
+cmd = "bash /work/ci/docker/profile/run_bosn_profile.sh build"
+
+[task.bench-profile]
+stack = "perf"
+cmd = "bash /work/ci/docker/profile/run_bosn_profile.sh bench"
+
+[task.oncpu-profile]
+stack = "perf"
+cmd = "bash /work/ci/docker/profile/run_bosn_profile.sh oncpu"
+
+[task.offcpu-profile]
+stack = "perf"
+cmd = "bash /work/ci/docker/profile/run_bosn_profile.sh offcpu"
+
+[task.memory-profile]
+stack = "perf"
+cmd = "bash /work/ci/docker/profile/run_bosn_profile.sh memory"
+
+[task.profile]
+stack = "perf"
+cmd = "bash /work/ci/docker/profile/run_bosn_profile.sh all"

--- a/bosn.toml
+++ b/bosn.toml
@@ -12,8 +12,8 @@ ZCCACHE_PROFILE_WORKLOAD = "perf_rustc_zccache_vs_sccache"
 [stack.perf.volumes]
 target = { scope = "stack", destination = "/target" }
 soldr-home = { scope = "machine", destination = "/root/.soldr" }
-soldr-cargo-home = { scope = "machine", destination = "/bosn/cargo" }
-soldr-rustup-home = { scope = "machine", destination = "/bosn/rustup" }
+soldr-cargo-home = { scope = "machine", destination = "/zccache-profile/cargo" }
+soldr-rustup-home = { scope = "machine", destination = "/zccache-profile/rustup" }
 
 [stack.perf.mounts]
 repo = { source = ".", destination = "/work" }

--- a/ci/docker/profile/Dockerfile.bosn-perf-linux
+++ b/ci/docker/profile/Dockerfile.bosn-perf-linux
@@ -1,0 +1,71 @@
+# syntax=docker/dockerfile:1.7
+
+# Bosn-owned Linux environment for the repository's existing performance
+# benchmark and its CPU, blocking, and allocation diagnostics.
+FROM emscripten/emsdk:3.1.74@sha256:af45409f3199d88db4b1b03af0098532c8fb33a375ac257463eeb0a622870d06
+
+ARG RUST_VERSION=1.95.0
+ARG CLANG_MAJOR=14
+ARG SCCACHE_VERSION=0.10.0
+ARG SCCACHE_SHA256=1fbb35e135660d04a2d5e42b59c7874d39b3deb17de56330b25b713ec59f849b
+ARG SOLDR_VERSION=0.8.16
+ARG SOLDR_SHA256=95e338a6a1dd941c248f95148557c434ce735392cba867007b7997d531200830
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    RUST_VERSION=${RUST_VERSION} \
+    SOLDR_VERSION=${SOLDR_VERSION} \
+    SOLDR_COMMAND_OUTPUT_TIMEOUT_SECS=600 \
+    PATH=/emsdk:/emsdk/upstream/emscripten:/usr/local/bin:${PATH}
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        clang-14 \
+        curl \
+        git \
+        heaptrack \
+        jq \
+        libssl-dev \
+        llvm-14 \
+        pkg-config \
+        procps \
+        strace \
+        time \
+        valgrind \
+        zstd \
+ && rm -rf /var/lib/apt/lists/* \
+ && ln -sf /usr/bin/clang-${CLANG_MAJOR} /usr/local/bin/clang \
+ && ln -sf /usr/bin/clang++-${CLANG_MAJOR} /usr/local/bin/clang++ \
+ && ln -sf /usr/bin/llvm-ar-${CLANG_MAJOR} /usr/local/bin/llvm-ar
+
+RUN curl --fail --location --silent --show-error \
+        "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+        -o /tmp/sccache.tar.gz \
+ && echo "${SCCACHE_SHA256}  /tmp/sccache.tar.gz" | sha256sum --check - \
+ && tar -xzf /tmp/sccache.tar.gz -C /tmp \
+ && install -m 0755 \
+        "/tmp/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache" \
+        /usr/local/bin/sccache \
+ && rm -rf /tmp/sccache*
+
+RUN curl --fail --location --silent --show-error \
+        "https://github.com/zackees/soldr/releases/download/v${SOLDR_VERSION}/soldr-v${SOLDR_VERSION}-x86_64-unknown-linux-musl.tar.zst" \
+        -o /tmp/soldr.tar.zst \
+ && echo "${SOLDR_SHA256}  /tmp/soldr.tar.zst" | sha256sum --check - \
+ && mkdir /tmp/soldr \
+ && tar --zstd -xf /tmp/soldr.tar.zst -C /tmp/soldr \
+ && install -m 0755 "$(find /tmp/soldr -type f -name soldr -print -quit)" /usr/local/bin/soldr \
+ && rm -rf /tmp/soldr /tmp/soldr.tar.zst
+
+COPY rust-toolchain.toml /tmp/soldr-bootstrap/rust-toolchain.toml
+RUN HOME=/opt/soldr-seed soldr bootstrap \
+ && HOME=/opt/soldr-seed soldr rustup set default-host x86_64-unknown-linux-gnu \
+ && cd /tmp/soldr-bootstrap \
+ && HOME=/opt/soldr-seed soldr toolchain prepare \
+ && HOME=/opt/soldr-seed soldr cargo --version \
+ && HOME=/opt/soldr-seed soldr rustc --version \
+ && rm -rf /tmp/soldr-bootstrap \
+ && touch "/opt/soldr-seed/.standalone-toolchain-${SOLDR_VERSION}-${RUST_VERSION}"
+
+WORKDIR /work

--- a/ci/docker/profile/Dockerfile.bosn-perf-linux
+++ b/ci/docker/profile/Dockerfile.bosn-perf-linux
@@ -45,7 +45,7 @@ RUN apt-get update \
 # /usr/bin/perf wrapper.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends linux-tools-generic \
- && perf_bin="$(find /usr/lib/linux-tools -type f -name perf -print -quit)" \
+ && perf_bin="$(find /usr/lib -path '*/linux-tools*/*' -type f -name perf -print -quit)" \
  && test -n "${perf_bin}" \
  && ln -sf "${perf_bin}" /usr/local/bin/perf \
  && rm -rf /var/lib/apt/lists/*

--- a/ci/docker/profile/Dockerfile.bosn-perf-linux
+++ b/ci/docker/profile/Dockerfile.bosn-perf-linux
@@ -39,6 +39,17 @@ RUN apt-get update \
  && ln -sf /usr/bin/clang++-${CLANG_MAJOR} /usr/local/bin/clang++ \
  && ln -sf /usr/bin/llvm-ar-${CLANG_MAJOR} /usr/local/bin/llvm-ar
 
+# Ubuntu keeps perf in a kernel-versioned linux-tools directory. The userspace
+# perf ABI remains useful on Docker Desktop's newer WSL kernel, so expose the
+# pinned image's binary directly instead of relying on the version-checking
+# /usr/bin/perf wrapper.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends linux-tools-generic \
+ && perf_bin="$(find /usr/lib/linux-tools -type f -name perf -print -quit)" \
+ && test -n "${perf_bin}" \
+ && ln -sf "${perf_bin}" /usr/local/bin/perf \
+ && rm -rf /var/lib/apt/lists/*
+
 RUN curl --fail --location --silent --show-error \
         "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
         -o /tmp/sccache.tar.gz \

--- a/ci/docker/profile/README.md
+++ b/ci/docker/profile/README.md
@@ -1,9 +1,29 @@
-# Linux profiler (Docker)
+# Linux profiler (bosn-managed Docker)
 
 Generates **on-CPU** and **off-CPU** flame charts of the zccache daemon under
 a representative cold-build workload, using a containerized Linux toolchain
 (perf + bpftrace + FlameGraph) so results are reproducible from a Windows
 or macOS host.
+
+The current repository entrypoint is the bosn stack in `/bosn.toml`. It runs
+the existing `perf_bench_test` workload with soldr and retains CPU, syscall
+wait, peak-RSS, heap-allocation, and Massif evidence below
+`.perf-local/bosn-profile/`:
+
+```powershell
+bosn doctor
+bosn tasks
+bosn build-profile
+bosn bench-profile
+bosn oncpu-profile
+bosn offcpu-profile
+bosn memory-profile
+```
+
+Set `ZCCACHE_PROFILE_WORKLOAD` in `bosn.toml` for a different registered
+ignored benchmark. The build and toolchain caches are bosn-managed volumes;
+the source checkout is mounted directly so retained evidence lands in the
+repository's existing ignored performance tree.
 
 ## Files
 
@@ -15,9 +35,10 @@ or macOS host.
   a parallel `bpftrace` off-CPU sampler, then renders two SVG flame charts
   + raw .data + .folded files into `/out`.
 
-## Usage
+## Legacy privileged flame-chart usage
 
-From repo root on the host:
+`run_profile.sh` predates the bosn stack and remains available when kernel
+`perf`/BPF privileges are required. From repo root on the host:
 
 ```bash
 docker build -f ci/docker/profile/Dockerfile.perf-linux \

--- a/ci/docker/profile/run_bosn_profile.sh
+++ b/ci/docker/profile/run_bosn_profile.sh
@@ -55,7 +55,8 @@ prepare_run() {
     # Docker Desktop can leave index stat data stale after rustc has read many
     # source files. Refresh metadata so provenance reports content changes,
     # not a transient host/VM timestamp disagreement.
-    git -C /work -c core.filemode=false update-index --refresh -q
+    git -C /work -c core.filemode=false update-index --refresh -q \
+        >/dev/null 2>&1 || true
     {
         echo "revision=$(git -C /work rev-parse HEAD)"
         echo "dirty=$(if git -C /work -c core.filemode=false diff --quiet && git -C /work -c core.filemode=false diff --cached --quiet; then echo false; else echo true; fi)"

--- a/ci/docker/profile/run_bosn_profile.sh
+++ b/ci/docker/profile/run_bosn_profile.sh
@@ -21,6 +21,11 @@ seed_soldr_home() {
     fi
     export CARGO_HOME=/root/.soldr/cargo
     export RUSTUP_HOME=/root/.soldr/rustup
+    export PATH="${CARGO_HOME}/bin:/root/.soldr/bin:${PATH}"
+    if ! command -v rustc >/dev/null 2>&1; then
+        echo "ERROR: soldr's seeded rustc proxy is not on PATH" >&2
+        exit 2
+    fi
 }
 
 find_benchmark() {
@@ -49,7 +54,7 @@ prepare_run() {
     mkdir -p "${OUT_DIR}"
     {
         echo "revision=$(git -C /work rev-parse HEAD)"
-        echo "dirty=$(if git -C /work diff --quiet && git -C /work diff --cached --quiet; then echo false; else echo true; fi)"
+        echo "dirty=$(if git -C /work -c core.filemode=false diff --quiet && git -C /work -c core.filemode=false diff --cached --quiet; then echo false; else echo true; fi)"
         echo "workload=${WORKLOAD}"
         echo "kernel=$(uname -r)"
         echo "soldr=$(soldr version | head -n 1)"

--- a/ci/docker/profile/run_bosn_profile.sh
+++ b/ci/docker/profile/run_bosn_profile.sh
@@ -52,14 +52,12 @@ prepare_run() {
     RUN_ID=$(date -u +%Y%m%dT%H%M%SZ)
     OUT_DIR="/work/.perf-local/bosn-profile/${revision}/${WORKLOAD}/${RUN_ID}"
     mkdir -p "${OUT_DIR}"
-    # Docker Desktop can leave index stat data stale after rustc has read many
-    # source files. Refresh metadata so provenance reports content changes,
-    # not a transient host/VM timestamp disagreement.
-    git -C /work -c core.filemode=false update-index --refresh -q \
-        >/dev/null 2>&1 || true
     {
         echo "revision=$(git -C /work rev-parse HEAD)"
-        echo "dirty=$(if git -C /work -c core.filemode=false diff --quiet && git -C /work -c core.filemode=false diff --cached --quiet; then echo false; else echo true; fi)"
+        # The Windows checkout contains a small CRLF subset that Linux Git
+        # sees as rewritten. Ignore only end-of-line whitespace so provenance
+        # still fails closed on semantic staged or unstaged content changes.
+        echo "dirty=$(if git -C /work -c core.filemode=false diff --ignore-space-at-eol --quiet HEAD --; then echo false; else echo true; fi)"
         echo "workload=${WORKLOAD}"
         echo "kernel=$(uname -r)"
         echo "soldr=$(soldr version | head -n 1)"

--- a/ci/docker/profile/run_bosn_profile.sh
+++ b/ci/docker/profile/run_bosn_profile.sh
@@ -130,7 +130,8 @@ run_heaptrack() {
         > "${OUT_DIR}/heaptrack.stdout.log" \
         2> "${OUT_DIR}/heaptrack.stderr.log"
     local heaptrack_file
-    heaptrack_file=$(find "${OUT_DIR}" -maxdepth 1 -type f -name 'heaptrack*.gz' -print -quit)
+    heaptrack_file=$(find "${OUT_DIR}" -maxdepth 1 -type f \
+        \( -name 'heaptrack*.gz' -o -name 'heaptrack*.zst' \) -print -quit)
     if [[ -n "${heaptrack_file}" ]]; then
         heaptrack_print "${heaptrack_file}" > "${OUT_DIR}/heaptrack-report.txt"
     fi

--- a/ci/docker/profile/run_bosn_profile.sh
+++ b/ci/docker/profile/run_bosn_profile.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+# Run the existing perf_bench_test binary under complementary Linux profilers.
+# Bosn owns this script's container and persistent build/toolchain volumes.
+set -euo pipefail
+
+MODE=${1:-all}
+WORKLOAD=${ZCCACHE_PROFILE_WORKLOAD:-perf_rustc_zccache_vs_sccache}
+SAMPLE_HZ=${ZCCACHE_PROFILE_HZ:-99}
+SOLDR_SENTINEL=".standalone-toolchain-${SOLDR_VERSION}-${RUST_VERSION}"
+
+seed_soldr_home() {
+    if [[ ! -f "/opt/soldr-seed/${SOLDR_SENTINEL}" ]]; then
+        echo "ERROR: cached soldr toolchain seed is incomplete" >&2
+        exit 2
+    fi
+    if [[ ! -f "/root/.soldr/${SOLDR_SENTINEL}" ]]; then
+        mkdir -p /root/.soldr
+        cp -a /opt/soldr-seed/.soldr/. /root/.soldr/
+        touch "/root/.soldr/${SOLDR_SENTINEL}"
+    fi
+    export CARGO_HOME=/root/.soldr/cargo
+    export RUSTUP_HOME=/root/.soldr/rustup
+}
+
+find_benchmark() {
+    find /target/release/deps -maxdepth 1 -type f \
+        -name 'perf_bench_test-*' -perm /111 -printf '%T@ %p\n' \
+        | sort -nr | head -n 1 | cut -d' ' -f2-
+}
+
+build_benchmark() {
+    seed_soldr_home
+    cd /work
+    soldr cargo test -p zccache --test perf_bench_test --release --no-run
+    TEST_BIN=$(find_benchmark)
+    if [[ -z "${TEST_BIN}" || ! -x "${TEST_BIN}" ]]; then
+        echo "ERROR: perf_bench_test executable was not produced" >&2
+        exit 2
+    fi
+}
+
+prepare_run() {
+    build_benchmark
+    local revision
+    revision=$(git -C /work rev-parse --short=12 HEAD)
+    RUN_ID=$(date -u +%Y%m%dT%H%M%SZ)
+    OUT_DIR="/work/.perf-local/bosn-profile/${revision}/${WORKLOAD}/${RUN_ID}"
+    mkdir -p "${OUT_DIR}"
+    {
+        echo "revision=$(git -C /work rev-parse HEAD)"
+        echo "dirty=$(if git -C /work diff --quiet && git -C /work diff --cached --quiet; then echo false; else echo true; fi)"
+        echo "workload=${WORKLOAD}"
+        echo "kernel=$(uname -r)"
+        echo "soldr=$(soldr version | head -n 1)"
+        echo "rustc=$(soldr rustc --version | head -n 1)"
+        echo "clang=$(clang++ --version | head -n 1)"
+        echo "sccache=$(sccache --version | head -n 1)"
+        echo "emscripten=$(em++ --version | head -n 1)"
+        echo "benchmark=${TEST_BIN}"
+        sha256sum "${TEST_BIN}"
+    } > "${OUT_DIR}/provenance.txt"
+    echo "evidence: ${OUT_DIR}"
+}
+
+run_bench() {
+    prepare_run
+    /usr/bin/time -v -o "${OUT_DIR}/resource-usage.txt" \
+        "${TEST_BIN}" "${WORKLOAD}" --nocapture --ignored --test-threads=1 \
+        > "${OUT_DIR}/benchmark.stdout.log" \
+        2> "${OUT_DIR}/benchmark.stderr.log"
+}
+
+run_oncpu() {
+    prepare_run
+    local perf_exit=127
+    if command -v perf >/dev/null 2>&1; then
+        set +e
+        perf record -F "${SAMPLE_HZ}" -g --call-graph fp \
+            -o "${OUT_DIR}/perf.data" -- \
+            "${TEST_BIN}" "${WORKLOAD}" --nocapture --ignored --test-threads=1 \
+            > "${OUT_DIR}/oncpu.stdout.log" \
+            2> "${OUT_DIR}/oncpu.stderr.log"
+        perf_exit=$?
+        set -e
+    else
+        echo "perf is not installed for this pinned base image" \
+            > "${OUT_DIR}/oncpu.stderr.log"
+    fi
+    echo "${perf_exit}" > "${OUT_DIR}/perf.exit"
+    if [[ ${perf_exit} -eq 0 && -s "${OUT_DIR}/perf.data" ]]; then
+        perf report --stdio --no-children --percent-limit 0.25 \
+            -i "${OUT_DIR}/perf.data" > "${OUT_DIR}/perf-report.txt"
+        perf script -i "${OUT_DIR}/perf.data" > "${OUT_DIR}/perf-script.txt"
+        return
+    fi
+
+    echo "perf unavailable (exit ${perf_exit}); using Callgrind" >&2
+    valgrind --tool=callgrind --trace-children=no \
+        --callgrind-out-file="${OUT_DIR}/callgrind.out" \
+        "${TEST_BIN}" "${WORKLOAD}" --nocapture --ignored --test-threads=1 \
+        > "${OUT_DIR}/callgrind.stdout.log" \
+        2> "${OUT_DIR}/callgrind.stderr.log"
+    callgrind_annotate --auto=yes --inclusive=yes \
+        "${OUT_DIR}/callgrind.out" > "${OUT_DIR}/callgrind-report.txt"
+}
+
+run_offcpu() {
+    prepare_run
+    /usr/bin/time -v -o "${OUT_DIR}/offcpu-resource-usage.txt" \
+        strace -f -w -c -o "${OUT_DIR}/strace-wall-summary.txt" \
+        "${TEST_BIN}" "${WORKLOAD}" --nocapture --ignored --test-threads=1 \
+        > "${OUT_DIR}/offcpu.stdout.log" \
+        2> "${OUT_DIR}/offcpu.stderr.log"
+}
+
+run_memory() {
+    prepare_run
+    /usr/bin/time -v -o "${OUT_DIR}/heaptrack-resource-usage.txt" \
+        heaptrack -o "${OUT_DIR}/heaptrack" \
+        "${TEST_BIN}" "${WORKLOAD}" --nocapture --ignored --test-threads=1 \
+        > "${OUT_DIR}/heaptrack.stdout.log" \
+        2> "${OUT_DIR}/heaptrack.stderr.log"
+    local heaptrack_file
+    heaptrack_file=$(find "${OUT_DIR}" -maxdepth 1 -type f -name 'heaptrack*.gz' -print -quit)
+    if [[ -n "${heaptrack_file}" ]]; then
+        heaptrack_print "${heaptrack_file}" > "${OUT_DIR}/heaptrack-report.txt"
+    fi
+
+    valgrind --tool=massif --stacks=yes --pages-as-heap=yes --time-unit=ms \
+        --massif-out-file="${OUT_DIR}/massif.out" \
+        "${TEST_BIN}" "${WORKLOAD}" --nocapture --ignored --test-threads=1 \
+        > "${OUT_DIR}/massif.stdout.log" \
+        2> "${OUT_DIR}/massif.stderr.log"
+    ms_print "${OUT_DIR}/massif.out" > "${OUT_DIR}/massif-report.txt"
+}
+
+case "${MODE}" in
+    build)
+        build_benchmark
+        ;;
+    bench)
+        run_bench
+        ;;
+    oncpu)
+        run_oncpu
+        ;;
+    offcpu)
+        run_offcpu
+        ;;
+    memory)
+        run_memory
+        ;;
+    all)
+        run_bench
+        run_oncpu
+        run_offcpu
+        run_memory
+        ;;
+    *)
+        echo "usage: run_bosn_profile.sh {build|bench|oncpu|offcpu|memory|all}" >&2
+        exit 2
+        ;;
+esac

--- a/ci/docker/profile/run_bosn_profile.sh
+++ b/ci/docker/profile/run_bosn_profile.sh
@@ -7,21 +7,22 @@ set -euo pipefail
 MODE=${1:-all}
 WORKLOAD=${ZCCACHE_PROFILE_WORKLOAD:-perf_rustc_zccache_vs_sccache}
 SAMPLE_HZ=${ZCCACHE_PROFILE_HZ:-99}
-SOLDR_SENTINEL=".standalone-toolchain-${SOLDR_VERSION}-${RUST_VERSION}"
+SOLDR_SENTINEL="/work/.rustup/.standalone-toolchain-${SOLDR_VERSION}-${RUST_VERSION}"
 
 seed_soldr_home() {
-    if [[ ! -f "/opt/soldr-seed/${SOLDR_SENTINEL}" ]]; then
+    if [[ ! -f "/opt/soldr-seed/.standalone-toolchain-${SOLDR_VERSION}-${RUST_VERSION}" ]]; then
         echo "ERROR: cached soldr toolchain seed is incomplete" >&2
         exit 2
     fi
-    if [[ ! -f "/root/.soldr/${SOLDR_SENTINEL}" ]]; then
-        mkdir -p /root/.soldr
-        cp -a /opt/soldr-seed/.soldr/. /root/.soldr/
-        touch "/root/.soldr/${SOLDR_SENTINEL}"
+    if [[ ! -f "${SOLDR_SENTINEL}" ]]; then
+        mkdir -p /work/.cargo /work/.rustup
+        cp -a /opt/soldr-seed/.soldr/cargo/. /work/.cargo/
+        cp -a /opt/soldr-seed/.soldr/rustup/. /work/.rustup/
+        touch "${SOLDR_SENTINEL}"
     fi
-    export CARGO_HOME=/root/.soldr/cargo
-    export RUSTUP_HOME=/root/.soldr/rustup
-    export PATH="${CARGO_HOME}/bin:/root/.soldr/bin:${PATH}"
+    export CARGO_HOME=/work/.cargo
+    export RUSTUP_HOME=/work/.rustup
+    export PATH="${CARGO_HOME}/bin:${PATH}"
     if ! command -v rustc >/dev/null 2>&1; then
         echo "ERROR: soldr's seeded rustc proxy is not on PATH" >&2
         exit 2
@@ -37,7 +38,11 @@ find_benchmark() {
 build_benchmark() {
     seed_soldr_home
     cd /work
-    soldr cargo test -p zccache --test perf_bench_test --release --no-run
+    # The Windows checkout may contain repo-local .cargo/.rustup homes. This
+    # container intentionally injects its seeded Linux homes, so retain them
+    # instead of re-resolving the bind-mounted host workspace.
+    soldr --trust-inherited-soldr-env cargo test \
+        -p zccache --test perf_bench_test --release --no-run
     TEST_BIN=$(find_benchmark)
     if [[ -z "${TEST_BIN}" || ! -x "${TEST_BIN}" ]]; then
         echo "ERROR: perf_bench_test executable was not produced" >&2

--- a/ci/docker/profile/run_bosn_profile.sh
+++ b/ci/docker/profile/run_bosn_profile.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 MODE=${1:-all}
 WORKLOAD=${ZCCACHE_PROFILE_WORKLOAD:-perf_rustc_zccache_vs_sccache}
 SAMPLE_HZ=${ZCCACHE_PROFILE_HZ:-99}
-SOLDR_SENTINEL="/bosn/rustup/.standalone-toolchain-${SOLDR_VERSION}-${RUST_VERSION}"
+SOLDR_SENTINEL="/zccache-profile/rustup/.standalone-toolchain-${SOLDR_VERSION}-${RUST_VERSION}"
 
 seed_soldr_home() {
     if [[ ! -f "/opt/soldr-seed/.standalone-toolchain-${SOLDR_VERSION}-${RUST_VERSION}" ]]; then
@@ -15,13 +15,13 @@ seed_soldr_home() {
         exit 2
     fi
     if [[ ! -f "${SOLDR_SENTINEL}" ]]; then
-        mkdir -p /bosn/cargo /bosn/rustup
-        cp -a /opt/soldr-seed/.soldr/cargo/. /bosn/cargo/
-        cp -a /opt/soldr-seed/.soldr/rustup/. /bosn/rustup/
+        mkdir -p /zccache-profile/cargo /zccache-profile/rustup
+        cp -a /opt/soldr-seed/.soldr/cargo/. /zccache-profile/cargo/
+        cp -a /opt/soldr-seed/.soldr/rustup/. /zccache-profile/rustup/
         touch "${SOLDR_SENTINEL}"
     fi
-    export CARGO_HOME=/bosn/cargo
-    export RUSTUP_HOME=/bosn/rustup
+    export CARGO_HOME=/zccache-profile/cargo
+    export RUSTUP_HOME=/zccache-profile/rustup
     export PATH="${CARGO_HOME}/bin:${PATH}"
     if ! command -v rustc >/dev/null 2>&1; then
         echo "ERROR: soldr's seeded rustc proxy is not on PATH" >&2

--- a/ci/docker/profile/run_bosn_profile.sh
+++ b/ci/docker/profile/run_bosn_profile.sh
@@ -122,7 +122,7 @@ run_offcpu() {
         2> "${OUT_DIR}/offcpu.stderr.log"
 }
 
-run_memory() {
+run_heaptrack() {
     prepare_run
     /usr/bin/time -v -o "${OUT_DIR}/heaptrack-resource-usage.txt" \
         heaptrack -o "${OUT_DIR}/heaptrack" \
@@ -134,13 +134,21 @@ run_memory() {
     if [[ -n "${heaptrack_file}" ]]; then
         heaptrack_print "${heaptrack_file}" > "${OUT_DIR}/heaptrack-report.txt"
     fi
+}
 
+run_massif() {
+    prepare_run
     valgrind --tool=massif --stacks=yes --pages-as-heap=yes --time-unit=ms \
         --massif-out-file="${OUT_DIR}/massif.out" \
         "${TEST_BIN}" "${WORKLOAD}" --nocapture --ignored --test-threads=1 \
         > "${OUT_DIR}/massif.stdout.log" \
         2> "${OUT_DIR}/massif.stderr.log"
     ms_print "${OUT_DIR}/massif.out" > "${OUT_DIR}/massif-report.txt"
+}
+
+run_memory() {
+    run_heaptrack
+    run_massif
 }
 
 case "${MODE}" in
@@ -159,6 +167,12 @@ case "${MODE}" in
     memory)
         run_memory
         ;;
+    heaptrack)
+        run_heaptrack
+        ;;
+    massif)
+        run_massif
+        ;;
     all)
         run_bench
         run_oncpu
@@ -166,7 +180,7 @@ case "${MODE}" in
         run_memory
         ;;
     *)
-        echo "usage: run_bosn_profile.sh {build|bench|oncpu|offcpu|memory|all}" >&2
+        echo "usage: run_bosn_profile.sh {build|bench|oncpu|offcpu|heaptrack|massif|memory|all}" >&2
         exit 2
         ;;
 esac

--- a/ci/docker/profile/run_bosn_profile.sh
+++ b/ci/docker/profile/run_bosn_profile.sh
@@ -52,6 +52,10 @@ prepare_run() {
     RUN_ID=$(date -u +%Y%m%dT%H%M%SZ)
     OUT_DIR="/work/.perf-local/bosn-profile/${revision}/${WORKLOAD}/${RUN_ID}"
     mkdir -p "${OUT_DIR}"
+    # Docker Desktop can leave index stat data stale after rustc has read many
+    # source files. Refresh metadata so provenance reports content changes,
+    # not a transient host/VM timestamp disagreement.
+    git -C /work -c core.filemode=false update-index --refresh -q
     {
         echo "revision=$(git -C /work rev-parse HEAD)"
         echo "dirty=$(if git -C /work -c core.filemode=false diff --quiet && git -C /work -c core.filemode=false diff --cached --quiet; then echo false; else echo true; fi)"

--- a/ci/docker/profile/run_bosn_profile.sh
+++ b/ci/docker/profile/run_bosn_profile.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 MODE=${1:-all}
 WORKLOAD=${ZCCACHE_PROFILE_WORKLOAD:-perf_rustc_zccache_vs_sccache}
 SAMPLE_HZ=${ZCCACHE_PROFILE_HZ:-99}
-SOLDR_SENTINEL="/work/.rustup/.standalone-toolchain-${SOLDR_VERSION}-${RUST_VERSION}"
+SOLDR_SENTINEL="/bosn/rustup/.standalone-toolchain-${SOLDR_VERSION}-${RUST_VERSION}"
 
 seed_soldr_home() {
     if [[ ! -f "/opt/soldr-seed/.standalone-toolchain-${SOLDR_VERSION}-${RUST_VERSION}" ]]; then
@@ -15,13 +15,13 @@ seed_soldr_home() {
         exit 2
     fi
     if [[ ! -f "${SOLDR_SENTINEL}" ]]; then
-        mkdir -p /work/.cargo /work/.rustup
-        cp -a /opt/soldr-seed/.soldr/cargo/. /work/.cargo/
-        cp -a /opt/soldr-seed/.soldr/rustup/. /work/.rustup/
+        mkdir -p /bosn/cargo /bosn/rustup
+        cp -a /opt/soldr-seed/.soldr/cargo/. /bosn/cargo/
+        cp -a /opt/soldr-seed/.soldr/rustup/. /bosn/rustup/
         touch "${SOLDR_SENTINEL}"
     fi
-    export CARGO_HOME=/work/.cargo
-    export RUSTUP_HOME=/work/.rustup
+    export CARGO_HOME=/bosn/cargo
+    export RUSTUP_HOME=/bosn/rustup
     export PATH="${CARGO_HOME}/bin:${PATH}"
     if ! command -v rustc >/dev/null 2>&1; then
         echo "ERROR: soldr's seeded rustc proxy is not on PATH" >&2

--- a/ci/docker/profile/run_bosn_profile.sh
+++ b/ci/docker/profile/run_bosn_profile.sh
@@ -37,11 +37,15 @@ find_benchmark() {
 
 build_benchmark() {
     seed_soldr_home
-    cd /work
+    # Run soldr outside the bind-mounted checkout so its repo-local home
+    # discovery cannot select a host-created `.rustup` directory. Cargo still
+    # receives the exact workspace manifest and target directory explicitly.
+    cd /tmp
     # The Windows checkout may contain repo-local .cargo/.rustup homes. This
     # container intentionally injects its seeded Linux homes, so retain them
     # instead of re-resolving the bind-mounted host workspace.
     soldr --trust-inherited-soldr-env cargo test \
+        --manifest-path /work/Cargo.toml \
         -p zccache --test perf_bench_test --release --no-run
     TEST_BIN=$(find_benchmark)
     if [[ -z "${TEST_BIN}" || ! -x "${TEST_BIN}" ]]; then

--- a/ci/perf_local.py
+++ b/ci/perf_local.py
@@ -121,16 +121,14 @@ DEFAULT_SCENARIO = "cold-tar-untar-warm"
 DEFAULT_FIXTURE = "medium"
 
 
-from perf_local_results import (
-    LOCAL_MAX_MATERIALIZATION_COPIED_BYTES, LOCAL_MAX_STAGED_OVERHEAD_MS_PER_PUBLICATION,
-    LOCAL_MAX_WARM_MS, LOCAL_MIN_SPEEDUP, PERF_THRESHOLDS,
-    _distribution, _shell_quote, _write_repeat_summary,
-    evaluate_rollout_result, fmt_bytes, fmt_count_pct, fmt_ms,
-    remove_previous_results as _remove_previous_results,
-    render_phase_breakdown, render_summary,
-    run_scenario as _run_scenario,
-    validate_infrastructure_result,
-)
+if __package__:
+    from . import perf_local_results as _results
+else:
+    import perf_local_results as _results
+
+
+def __getattr__(name: str):
+    return getattr(_results, name)
 
 
 # ---------------------------------------------------------------------------
@@ -620,7 +618,7 @@ def run_scenario(
     jobs: int,
     results_dir: Path | None = None,
 ) -> Path:
-    return _run_scenario(
+    return _results.run_scenario(
         layout,
         scenario,
         fixture,
@@ -634,7 +632,7 @@ def run_scenario(
 
 
 def remove_previous_results(results_dir: Path) -> None:
-    _remove_previous_results(
+    _results.remove_previous_results(
         results_dir,
         run_command=run,
         host_volume_spec=host_volume,
@@ -761,7 +759,7 @@ def run_clippy(args: list[str]) -> int:
         cargo_args += ["-p", "zccache", "--lib", "--tests"]
     if not has_separator:
         cargo_args += ["--", "-D", "warnings"]
-    script = f"{_ENSURE_RUSTFMT_CLIPPY} && cargo {' '.join(_shell_quote(a) for a in cargo_args)}"
+    script = f"{_ENSURE_RUSTFMT_CLIPPY} && cargo {' '.join(_results._shell_quote(a) for a in cargo_args)}"
     cmd = build_zccache_docker_cmd(bash_script=script)
     return run_zccache_docker_cmd(cmd)
 
@@ -801,7 +799,7 @@ def run_exec(args: list[str]) -> int:
     if len(args) != 1 or not args[0].startswith("/src/"):
         print("usage: perf_local.py exec /src/ci/local_pre_pr_steps/<suite>.sh", file=sys.stderr)
         return 2
-    cmd = build_zccache_docker_cmd(bash_script=f"bash {_shell_quote(args[0])}")
+    cmd = build_zccache_docker_cmd(bash_script=f"bash {_results._shell_quote(args[0])}")
     return run_zccache_docker_cmd(cmd)
 
 
@@ -824,8 +822,8 @@ def run_rollout_matrix(layout: dict[str, Path], jobs: int, repeat: int) -> int:
                     print(f"[perf-local] FAIL {cell} sample {sample_number}: scenario exited {error.returncode}")
                     cell_failed = True
                     break
-                render_summary(results_dir, scenario, fixture)
-                failures = evaluate_rollout_result(results_dir, scenario, fixture)
+                _results.render_summary(results_dir, scenario, fixture)
+                failures = _results.evaluate_rollout_result(results_dir, scenario, fixture)
                 if failures:
                     cell_failed = True
                     for failure in failures:
@@ -835,7 +833,7 @@ def run_rollout_matrix(layout: dict[str, Path], jobs: int, repeat: int) -> int:
                 samples.append((results_dir, result))
             if not cell_failed:
                 if repeat > 1:
-                    _write_repeat_summary(base_dir, samples, scenario, fixture)
+                    _results._write_repeat_summary(base_dir, samples, scenario, fixture)
                 warm = [int(result["b_ms" if scenario == "worktree-share" else "warm_ms"]) for _, result in samples]
                 print(f"[perf-local] HARD-GATE PASS {cell} ({repeat} sample(s), warm median={statistics.median(warm):.0f}ms)")
             else:
@@ -989,7 +987,7 @@ def main() -> int:
         return 0
 
     results_dir = run_scenario(layout, args.scenario, args.fixture, args.jobs)
-    return render_summary(results_dir, args.scenario, args.fixture)
+    return _results.render_summary(results_dir, args.scenario, args.fixture)
 
 
 if __name__ == "__main__":

--- a/ci/perf_local.py
+++ b/ci/perf_local.py
@@ -72,6 +72,7 @@ import statistics
 import subprocess
 import sys
 import time
+import tomllib
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -453,12 +454,30 @@ def git_is_worktree_root(repo: Path) -> bool:
 def pin_soldr_zccache_source(soldr_src: Path, *, initialize_submodules: bool = True) -> None:
     """Build soldr with the zccache checkout under test embedded in it.
 
-    soldr consumes zccache as a git submodule, so cloning soldr alone is no
-    longer enough. Materialize all soldr
-    submodules, then move its zccache submodule to this checkout's exact SHA.
+    Older soldr refs consume zccache as a git submodule. Materialize and pin
+    that checkout when the ref still declares it. Current soldr releases use
+    the registry instead, so write a harness-owned source override for the
+    read-only checkout mounted by ``run_soldr_builder``.
     """
     if git_is_dirty(REPO_ROOT):
         raise RuntimeError("the zccache checkout is dirty; commit or stash changes before running perf_local.py so embedded source cannot differ from the requested run")
+    gitmodules = soldr_src / ".gitmodules"
+    if not gitmodules.is_file() or "_vender/zccache" not in gitmodules.read_text(
+        encoding="utf-8"
+    ):
+        config_path = soldr_src / ".cargo" / "config.toml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        marker = "# perf-local exact zccache source"
+        existing = config_path.read_text(encoding="utf-8") if config_path.is_file() else ""
+        existing = existing.split(marker, 1)[0].rstrip()
+        override = (
+            f"{marker}\n"
+            "[patch.crates-io.zccache]\n"
+            'path = "/zccache-src/crates/zccache"\n'
+        )
+        config_path.write_text(f"{existing}\n\n{override}", encoding="utf-8")
+        print("[perf-local] soldr registry dependency patched to the local zccache checkout")
+        return
     zccache_sha = git_head(REPO_ROOT)
     vendored = soldr_src / "_vender" / "zccache"
     if initialize_submodules or not git_is_worktree_root(vendored):
@@ -605,6 +624,8 @@ def run_soldr_builder(layout: dict[str, Path], *, force: bool = False) -> None:
             # requested soldr ref moves, so a rewritten lock never accumulates.
             host_volume(layout["soldr_src"], "/src"),
             "-v",
+            host_volume(REPO_ROOT, "/zccache-src", "ro"),
+            "-v",
             f"{VOLUME_TARGET_SOLDR}:/target",
             "-v",
             f"{VOLUME_CARGO_HOME_SOLDR}:/cargo-home",
@@ -615,6 +636,12 @@ def run_soldr_builder(layout: dict[str, Path], *, force: bool = False) -> None:
     )
     if not binary.is_file():
         raise FileNotFoundError(f"soldr builder succeeded without publishing {binary}")
+    lock = tomllib.loads((layout["soldr_src"] / "Cargo.lock").read_text(encoding="utf-8"))
+    resolved = [package for package in lock["package"] if package["name"] == "zccache"]
+    if len(resolved) != 1 or "source" in resolved[0]:
+        raise RuntimeError(
+            "soldr builder did not resolve zccache from the mounted checkout under test"
+        )
     stamp_tmp = stamp.with_suffix(".json.tmp")
     stamp_tmp.write_text(json.dumps(identity, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     stamp_tmp.replace(stamp)

--- a/ci/perf_local.py
+++ b/ci/perf_local.py
@@ -31,31 +31,12 @@ volumes contain the live build state going forward.
 
 Usage::
 
-    uv run --no-project python ci/perf_local.py                    # default: cold-tar-untar-warm x medium
-    uv run --no-project python ci/perf_local.py --matrix           # release gate: all 8 rollout cells
-    uv run --no-project python ci/perf_local.py --matrix --repeat 5 # repeated distribution audit
+    uv run --no-project python ci/perf_local.py
+    uv run --no-project python ci/perf_local.py --matrix --repeat 5
     uv run --no-project python ci/perf_local.py --scenario worktree-share
-    uv run --no-project python ci/perf_local.py --scenario cold-tar-untar-warm --fixture sqlite-link
-    uv run --no-project python ci/perf_local.py --soldr-ref fix/1651-portable-zccache-identity
-    uv run --no-project python ci/perf_local.py --jobs 2           # fit an 8 GiB Docker VM
-    uv run --no-project python ci/perf_local.py --rebuild-images   # force docker build of all 3 images
-
-    # Ad-hoc cargo in the same warmed target/ volume — much faster than
-    # `soldr cargo` on the host because the daemon is undisturbed:
     uv run --no-project python ci/perf_local.py cargo test --lib --no-run
-    uv run --no-project python ci/perf_local.py cargo test --release --lib fscache::metadata::tests::mtimes
-    uv run --no-project python ci/perf_local.py cargo clippy --workspace -- -D warnings
 
-    # Issue #477: dedicated subcommands that bake in the right `docker run`
-    # incantation (named volumes + MSYS_NO_PATHCONV + persistent rustup
-    # state). All run inside the same `zccache-perf-zccache-builder` image:
-    uv run --no-project python ci/perf_local.py fmt             # cargo fmt --all -- --check
-    uv run --no-project python ci/perf_local.py fmt --fix       # cargo fmt --all (rewrites in place)
-    uv run --no-project python ci/perf_local.py clippy          # cargo clippy -p zccache --lib --tests -- -D warnings
-    uv run --no-project python ci/perf_local.py clippy --workspace --all-targets
-    uv run --no-project python ci/perf_local.py test [PATTERN]  # cargo test --lib [PATTERN]
-    uv run --no-project python ci/perf_local.py shell           # interactive bash in the builder image
-
+See ``ci/docker/README.md`` for the full command and maintenance reference.
 The eight-cell ``--matrix`` run is the sanctioned release gate. GitHub Actions
 does not execute wall-clock benchmarks; it only runs deterministic tests and
 platform correctness checks.
@@ -66,12 +47,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import shutil
 import statistics
 import subprocess
 import sys
-import time
 import tomllib
 from pathlib import Path
 
@@ -142,29 +121,16 @@ DEFAULT_SCENARIO = "cold-tar-untar-warm"
 DEFAULT_FIXTURE = "medium"
 
 
-def load_perf_thresholds() -> dict:
-    """Load and validate the single source of truth for local timing gates."""
-    thresholds = json.loads(PERF_THRESHOLDS_PATH.read_text(encoding="utf-8"))
-    if thresholds.get("schema_version") != 1:
-        raise ValueError("unsupported perf threshold manifest schema")
-    warm_limits = thresholds.get("maximum_warm_ms")
-    if not isinstance(warm_limits, dict) or set(warm_limits) != set(ROLLOUT_SCENARIOS):
-        raise ValueError("threshold manifest must define every rollout scenario")
-    if not isinstance(thresholds.get("minimum_speedup"), (int, float)):
-        raise ValueError("threshold manifest minimum_speedup must be numeric")
-    staged_limits = thresholds.get("maximum_staged_overhead_ms_per_publication")
-    if not isinstance(staged_limits, dict) or set(staged_limits) != set(VALID_FIXTURES):
-        raise ValueError("threshold manifest must define staged overhead per publication for every fixture")
-    if not all(type(value) is int and value > 0 for value in staged_limits.values()):
-        raise ValueError("staged overhead per-publication limits must be positive integers")
-    return thresholds
-
-
-PERF_THRESHOLDS = load_perf_thresholds()
-LOCAL_MIN_SPEEDUP = float(PERF_THRESHOLDS["minimum_speedup"])
-LOCAL_MAX_WARM_MS = PERF_THRESHOLDS["maximum_warm_ms"]
-LOCAL_MAX_STAGED_OVERHEAD_MS_PER_PUBLICATION = PERF_THRESHOLDS["maximum_staged_overhead_ms_per_publication"]
-LOCAL_MAX_MATERIALIZATION_COPIED_BYTES = int(PERF_THRESHOLDS["maximum_materialization_copied_bytes"])
+from perf_local_results import (
+    LOCAL_MAX_MATERIALIZATION_COPIED_BYTES, LOCAL_MAX_STAGED_OVERHEAD_MS_PER_PUBLICATION,
+    LOCAL_MAX_WARM_MS, LOCAL_MIN_SPEEDUP, PERF_THRESHOLDS,
+    _distribution, _shell_quote, _write_repeat_summary,
+    evaluate_rollout_result, fmt_bytes, fmt_count_pct, fmt_ms,
+    remove_previous_results as _remove_previous_results,
+    render_phase_breakdown, render_summary,
+    run_scenario as _run_scenario,
+    validate_infrastructure_result,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -654,491 +620,26 @@ def run_scenario(
     jobs: int,
     results_dir: Path | None = None,
 ) -> Path:
-    """Run the per-scenario container. Returns the results dir for this run."""
-    results_dir = results_dir or layout["results"] / fixture / scenario
-    # Wipe last run's results so partial output from a crashing run doesn't
-    # masquerade as a complete result.
-    if results_dir.exists():
-        remove_previous_results(results_dir)
-    results_dir.mkdir(parents=True)
-
-    soldr_bin = layout["bin_soldr"] / "soldr"
-    if not soldr_bin.is_file():
-        raise FileNotFoundError(f"soldr binary missing at {soldr_bin}. Did the soldr-builder step succeed?")
-
-    print(f"[perf-local] running scenario {scenario} x {fixture} -> {results_dir}")
-    start = time.monotonic()
-    # Pass any ZCCACHE_* env through to the container so the daemon's
-    # env-gated instrumentation (e.g. ZCCACHE_HIT_TRACE=1 for the sub-phase
-    # dump from issue #468) reaches the in-container daemon process.
-    pass_through_env = [(k, v) for k, v in os.environ.items() if k.startswith("ZCCACHE_")]
-    # Docker Desktop commonly has an 8 GiB VM even when the Windows host has
-    # substantially more RAM. An unconstrained medium-fixture build can run
-    # enough rustc processes to exhaust that VM and surface os error 12 through
-    # soldr. Keep local measurements reproducible and within the selected
-    # budget; callers with a larger VM can raise --jobs explicitly.
-    # A performance sample must never silently switch to uncached rustc. This
-    # is a benchmark-integrity requirement, not a production default.
-    env_flags: list[str] = [
-        "-e",
-        f"CARGO_BUILD_JOBS={jobs}",
-        "-e",
-        "SOLDR_DAEMON_REQUIRED=1",
-    ]
-    for k, v in pass_through_env:
-        env_flags.extend(["-e", f"{k}={v}"])
-    run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "-v",
-            host_volume(soldr_bin, "/usr/local/bin/soldr", "ro"),
-            "-v",
-            host_volume(REPO_ROOT, "/zccache-src", "ro"),
-            "-v",
-            host_volume(results_dir, "/results"),
-            "-e",
-            f"SCENARIO={scenario}",
-            "-e",
-            f"FIXTURE={fixture}",
-            *env_flags,
-            IMAGE_RUNNER,
-        ]
+    return _run_scenario(
+        layout,
+        scenario,
+        fixture,
+        jobs,
+        results_dir,
+        run_command=run,
+        host_volume_spec=host_volume,
+        repo_root=REPO_ROOT,
+        image_runner=IMAGE_RUNNER,
     )
-    elapsed = time.monotonic() - start
-    print(f"[perf-local] scenario completed in {elapsed:.1f}s")
-    return results_dir
 
 
 def remove_previous_results(results_dir: Path) -> None:
-    """Remove prior bind-mount output, repairing container ownership once.
-
-    The scenario container runs as root and may create nested result
-    directories with mode 0755. A normal host-side ``shutil.rmtree`` can then
-    remove writable files around them but fail when it reaches a root-owned
-    directory. Bind only the exact results directory into the same local
-    runner image, make that tree host-removable, and retry. The container
-    command is constant; destructive removal stays in Python against the
-    already-resolved path.
-    """
-    try:
-        shutil.rmtree(results_dir)
-        return
-    except PermissionError:
-        run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "-v",
-                host_volume(results_dir, "/results"),
-                "--entrypoint",
-                "/bin/chmod",
-                IMAGE_RUNNER,
-                "-R",
-                "a+rwX",
-                "/results",
-            ]
-        )
-    shutil.rmtree(results_dir)
-
-
-# ---------------------------------------------------------------------------
-# Result rendering for local diagnostics and retained matrix evidence.
-
-
-def fmt_ms(ms) -> str:
-    if ms is None or ms == "":
-        return "—"
-    ms = int(ms)
-    if ms >= 60_000:
-        return f"{ms // 60_000}m{(ms % 60_000) // 1000:02d}s"
-    if ms >= 1_000:
-        return f"{ms / 1000:.2f}s"
-    return f"{ms}ms"
-
-
-def fmt_bytes(b) -> str:
-    if b is None or b == "":
-        return "—"
-    b = int(b)
-    if b >= 1 << 30:
-        return f"{b / (1 << 30):.2f} GiB"
-    if b >= 1 << 20:
-        return f"{b / (1 << 20):.1f} MiB"
-    if b >= 1 << 10:
-        return f"{b / (1 << 10):.1f} KiB"
-    return f"{b} B" if b > 0 else "0 B"
-
-
-def fmt_count_pct(n, total) -> str:
-    if n is None or n == "":
-        return "—"
-    if not total:
-        return str(n)
-    return f"{int(n)} ({int(n) / int(total) * 100:.1f}%)"
-
-
-def validate_infrastructure_result(result: dict, results_dir: Path) -> None:
-    """Reject samples contaminated by soldr abort/retry behavior.
-
-    Timing is meaningless when the build silently timed out or retried without
-    the cache, so this schema and its artifact-relative evidence are validated
-    before any performance threshold.
-    """
-    if not isinstance(result, dict):
-        raise ValueError("infrastructure result must be an object")
-    reasons = result.get("invalid_reasons")
-    evidence = result.get("soldr_abort_evidence")
-    fallback_evidence = result.get("soldr_daemon_fallback_evidence")
-    valid = result.get("infrastructure_valid")
-    count_names = (
-        "soldr_abort_count",
-        "soldr_timeout_count",
-        "soldr_no_cache_retry_count",
-        "soldr_daemon_fallback_count",
+    _remove_previous_results(
+        results_dir,
+        run_command=run,
+        host_volume_spec=host_volume,
+        image_runner=IMAGE_RUNNER,
     )
-    counts = {name: result.get(name) for name in count_names}
-
-    malformed = (
-        type(valid) is not bool
-        or not isinstance(reasons, list)
-        or not all(isinstance(reason, str) for reason in reasons)
-        or not isinstance(evidence, list)
-        or not evidence
-        or not all(isinstance(item, str) and re.fullmatch(r"soldr-aborts-[A-Za-z0-9_-]+[.]jsonl", item) for item in evidence)
-        or not isinstance(fallback_evidence, list)
-        or not fallback_evidence
-        or not all(isinstance(item, str) and re.fullmatch(r"soldr-daemon-fallbacks-[A-Za-z0-9_-]+[.]jsonl", item) for item in fallback_evidence)
-        or not all(type(value) is int and value >= 0 for value in counts.values())
-    )
-    if malformed:
-        raise ValueError("missing or malformed infrastructure-validity fields")
-    if counts["soldr_timeout_count"] > counts["soldr_abort_count"]:
-        raise ValueError("timeout count exceeds abort count")
-    if counts["soldr_no_cache_retry_count"] > counts["soldr_abort_count"]:
-        raise ValueError("no-cache retry count exceeds abort count")
-    if valid != (len(reasons) == 0):
-        raise ValueError("infrastructure validity and reasons disagree")
-    missing = [item for item in evidence if not (results_dir / item).is_file()]
-    if missing:
-        raise ValueError(f"declared soldr abort evidence is missing: {missing[0]}")
-    missing_fallback = [item for item in fallback_evidence if not (results_dir / item).is_file()]
-    if missing_fallback:
-        raise ValueError(f"declared soldr daemon fallback evidence is missing: {missing_fallback[0]}")
-    if not valid or any(counts.values()):
-        detail = "; ".join(reasons) or "soldr abort detected"
-        raise ValueError(
-            f"contaminated benchmark sample: {detail}; aborts={counts['soldr_abort_count']}, timeouts={counts['soldr_timeout_count']}, no-cache retries={counts['soldr_no_cache_retry_count']}, daemon fallbacks={counts['soldr_daemon_fallback_count']}"
-        )
-
-
-def _read_session_report(results_dir: Path, names: tuple[str, ...]) -> dict | None:
-    for name in names:
-        path = results_dir / name
-        if not path.is_file():
-            continue
-        try:
-            payload = json.loads(path.read_text())
-        except json.JSONDecodeError:
-            return None
-        session = payload.get("last_session")
-        return session if isinstance(session, dict) else None
-    return None
-
-
-def _staged_profile(report: dict | None) -> dict | None:
-    if not report:
-        return None
-    profile = report.get("phase_profile")
-    if not isinstance(profile, dict):
-        return None
-    staged = profile.get("staged")
-    return staged if isinstance(staged, dict) else None
-
-
-def evaluate_rollout_result(results_dir: Path, scenario: str, fixture: str) -> list[str]:
-    """Return every hard-gate failure for one sanctioned local matrix cell."""
-    failures: list[str] = []
-    result_path = results_dir / "result.json"
-    if not result_path.is_file():
-        return ["result.json missing"]
-    try:
-        result = json.loads(result_path.read_text())
-    except json.JSONDecodeError as error:
-        return [f"result.json is malformed: {error}"]
-    if not isinstance(result, dict):
-        return ["result.json must contain one object"]
-
-    try:
-        validate_infrastructure_result(result, results_dir)
-    except ValueError as error:
-        failures.append(str(error))
-
-    cold_key = "a_ms" if scenario == "worktree-share" else "cold_ms"
-    warm_key = "b_ms" if scenario == "worktree-share" else "warm_ms"
-    cold_ms = result.get(cold_key)
-    warm_ms = result.get(warm_key)
-    if type(cold_ms) is not int or type(warm_ms) is not int or warm_ms <= 0:
-        failures.append(f"invalid timing fields {cold_key}={cold_ms} {warm_key}={warm_ms}")
-    else:
-        speedup = cold_ms / warm_ms
-        if speedup < LOCAL_MIN_SPEEDUP:
-            failures.append(f"speedup {speedup:.2f}x is below {LOCAL_MIN_SPEEDUP:.2f}x")
-        warm_limit = LOCAL_MAX_WARM_MS[scenario]
-        if warm_limit is not None and warm_ms > warm_limit:
-            failures.append(f"warm time {warm_ms}ms exceeds {warm_limit}ms")
-
-    cold_report = _read_session_report(results_dir, ("cold-cache-report.json", "a-cache-report.json"))
-    warm_report = _read_session_report(results_dir, ("warm-cache-report.json", "b-cache-report.json"))
-    cold_staged = _staged_profile(cold_report)
-    warm_staged = _staged_profile(warm_report)
-    if cold_staged is None:
-        failures.append("missing cold staged telemetry")
-        return failures
-
-    cold_timings = cold_staged.get("timings_ns", {})
-    cold_counters = cold_staged.get("counters", {})
-    if not isinstance(cold_timings, dict) or not isinstance(cold_counters, dict):
-        failures.append("malformed cold staged telemetry")
-        return failures
-    overhead_ns = sum(int(cold_timings.get(name, 0) or 0) for name in ("hashing", "publication", "miss_materialization"))
-    publications = int(cold_counters.get("publication_success", 0) or 0)
-    if publications <= 0:
-        failures.append("cold path published no staged generations")
-    else:
-        # These timings accumulate independently across concurrent compiler
-        # requests. Normalize their sum so an identical per-publication cost
-        # receives the same verdict in a four-crate and a 143-crate fixture.
-        overhead_ms_per_publication = (overhead_ns + publications * 1_000_000 - 1) // (publications * 1_000_000)
-        overhead_limit = int(LOCAL_MAX_STAGED_OVERHEAD_MS_PER_PUBLICATION[fixture])
-        if overhead_ms_per_publication > overhead_limit:
-            failures.append("staged miss overhead " f"{overhead_ms_per_publication}ms/publication exceeds " f"{overhead_limit}ms/publication for {fixture}")
-
-    counter_sets = [cold_counters]
-    if warm_staged is not None:
-        warm_counters = warm_staged.get("counters", {})
-        warm_bytes = warm_staged.get("bytes", {})
-        if not isinstance(warm_counters, dict) or not isinstance(warm_bytes, dict):
-            failures.append("malformed warm staged telemetry")
-            return failures
-        counter_sets.append(warm_counters)
-        copied = int(warm_bytes.get("materialization_copied", 0) or 0)
-        tiers = sum(
-            int(warm_counters.get(name, 0) or 0)
-            for name in (
-                "materialize_reflink",
-                "materialize_hardlink_shared",
-                "materialize_copy",
-            )
-        )
-    elif scenario == "restore-no-clean-warm":
-        copied = 0
-        tiers = 0
-    else:
-        failures.append("missing warm staged telemetry")
-        return failures
-
-    salvage = sum(int(counters.get("salvage_attempt", 0) or 0) for counters in counter_sets)
-    critical = sum(int(counters.get(name, 0) or 0) for counters in counter_sets for name in ("publication_failure", "publication_conflict", "materialize_failure"))
-    if salvage != 0 or critical != 0:
-        failures.append(f"salvage={salvage} critical_failures={critical}")
-    if copied > LOCAL_MAX_MATERIALIZATION_COPIED_BYTES:
-        failures.append(f"materialization copied {copied} bytes, max {LOCAL_MAX_MATERIALIZATION_COPIED_BYTES}")
-    if scenario == "restore-no-clean-warm":
-        if result.get("warm_misses") != 0:
-            failures.append(f"restore warm build had cache misses: {result.get('warm_misses')}")
-    elif tiers <= 0:
-        failures.append("warm build reported no materialization tier")
-
-    return failures
-
-
-def render_summary(results_dir: Path, scenario: str, fixture: str) -> int:
-    """Print a one-row summary table + the inline annotation that the GHA
-    Evaluate step would emit. Returns 0 if the speedup hit the 3x gate."""
-    result_json = results_dir / "result.json"
-    if not result_json.is_file():
-        print(f"[perf-local] FAIL: result.json missing at {result_json}")
-        return 1
-    result = json.loads(result_json.read_text())
-
-    # Per-scenario key naming, matches Evaluate's cold_key_for/warm_key_for.
-    cold_key = "a_ms" if scenario == "worktree-share" else "cold_ms"
-    warm_key = "b_ms" if scenario == "worktree-share" else "warm_ms"
-    cold_ms = result.get(cold_key)
-    warm_ms = result.get(warm_key)
-    if cold_ms is None or warm_ms is None or warm_ms <= 0:
-        print(f"[perf-local] FAIL: bad timing in result.json (cold={cold_ms} warm={warm_ms})")
-        return 1
-    speedup = cold_ms / warm_ms
-
-    # Warm-side cache report carries the rich session counters.
-    report_candidates = [
-        results_dir / "warm-cache-report.json",
-        results_dir / "b-cache-report.json",
-    ]
-    report = None
-    for candidate in report_candidates:
-        if candidate.is_file():
-            report = json.loads(candidate.read_text()).get("last_session", {})
-            break
-    if report is None:
-        report = {}
-
-    # `last-session-stats.json` is zccache's own JSON output (written by
-    # `zccache session-end --json`); it includes `phase_profile` from
-    # PROTOCOL_VERSION 9 onward. Soldr's `cache report` is the
-    # canonical structured form but it copies a fixed set of keys into
-    # `last_session` and strips unknown fields, so a fresh phase_profile
-    # field arrives in `last-session-stats.json` before it surfaces in
-    # the report block. Pull it directly to avoid that lag.
-    if "phase_profile" not in report:
-        stats_candidates = [
-            results_dir / "warm-zccache-logs" / "last-session-stats.json",
-            results_dir / "b-zccache-logs" / "last-session-stats.json",
-        ]
-        for candidate in stats_candidates:
-            if not candidate.is_file():
-                continue
-            try:
-                raw = json.loads(candidate.read_text())
-            except json.JSONDecodeError:
-                continue
-            phase = raw.get("phase_profile")
-            if phase is not None:
-                report["phase_profile"] = phase
-                break
-
-    compiles = report.get("compilations")
-    hits = report.get("hits")
-    misses = report.get("misses")
-    non_cache = report.get("non_cacheable")
-    errs = report.get("errors")
-    bytes_w = report.get("bytes_written")
-    time_saved = report.get("time_saved_ms")
-    unique_srcs = report.get("unique_sources")
-    daemon_rss = result.get("peak_daemon_rss_bytes")
-    compile_rss = result.get("peak_compile_rss_bytes")
-
-    threshold = LOCAL_MIN_SPEEDUP
-    verdict = "PASS" if speedup >= threshold else "FAIL"
-
-    print()
-    print(f"## Perf result — local Docker harness — {fixture} / {scenario}")
-    print()
-    header = "| Fixture | Scenario | Verdict | Speedup | Need | Cold | Warm | Compiles | Hits | Misses | Ignored | Errors | Unique Srcs | Bytes W | Time Saved | Daemon RSS | Compile RSS |"
-    sep = "| --- | --- | :---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
-    row = (
-        f"| {fixture} | {scenario} | **{verdict}** | {speedup:.2f}x | >={threshold:.2f}x "
-        f"| {fmt_ms(cold_ms)} | {fmt_ms(warm_ms)} "
-        f"| {compiles if compiles is not None else '—'} "
-        f"| {fmt_count_pct(hits, compiles)} "
-        f"| {fmt_count_pct(misses, compiles)} "
-        f"| {fmt_count_pct(non_cache, compiles)} "
-        f"| {errs if errs is not None else '—'} "
-        f"| {unique_srcs if unique_srcs is not None else '—'} "
-        f"| {fmt_bytes(bytes_w)} | {fmt_ms(time_saved)} "
-        f"| {fmt_bytes(daemon_rss)} | {fmt_bytes(compile_rss)} |"
-    )
-    print(header)
-    print(sep)
-    print(row)
-    print()
-    print(
-        f"{fixture}/{scenario}: speedup={speedup:.2f}x (need >={threshold:.2f}x); "
-        f"cold={fmt_ms(cold_ms)} warm={fmt_ms(warm_ms)}; "
-        f"compiles={compiles or 0} hits={hits or 0} misses={misses or 0} "
-        f"ignored={non_cache or 0} errors={errs or 0}; "
-        f"bytes_W={fmt_bytes(bytes_w)} daemon_RSS={fmt_bytes(daemon_rss)}"
-    )
-
-    render_phase_breakdown(report.get("phase_profile"))
-
-    return 0 if verdict == "PASS" else 1
-
-
-def render_phase_breakdown(phase_profile) -> None:
-    """Print a phase-breakdown table from `SessionStats.phase_profile`.
-
-    Skipped silently when the daemon didn't populate the field (old
-    PROTOCOL_VERSION) or when both hit and miss counts are zero.
-    """
-    if not isinstance(phase_profile, dict):
-        return
-    hit_count = int(phase_profile.get("hit_count") or 0)
-    miss_count = int(phase_profile.get("miss_count") or 0)
-    if hit_count == 0 and miss_count == 0:
-        return
-
-    # (label, total-ns, denom-count). Hit phases use hit_count for the
-    # per-event average; miss phases use miss_count. The two metadata-cache
-    # sub-phases are summed so the table speaks the language used in design
-    # discussion ("metadata cache (source+hdrs)").
-    src_ns = int(phase_profile.get("hash_source_ns") or 0)
-    hdr_ns = int(phase_profile.get("hash_headers_ns") or 0)
-    rows = [
-        ("parse_args", int(phase_profile.get("parse_args_ns") or 0), hit_count),
-        ("build_context", int(phase_profile.get("build_context_ns") or 0), hit_count),
-        ("metadata cache (source+hdrs)", src_ns + hdr_ns, hit_count),
-        ("depgraph_check", int(phase_profile.get("depgraph_check_ns") or 0), hit_count),
-        (
-            "request_cache_lookup",
-            int(phase_profile.get("request_cache_lookup_ns") or 0),
-            hit_count,
-        ),
-        (
-            "cross_root_validate",
-            int(phase_profile.get("cross_root_validate_ns") or 0),
-            hit_count,
-        ),
-        (
-            "artifact_lookup",
-            int(phase_profile.get("artifact_lookup_ns") or 0),
-            hit_count,
-        ),
-        (
-            "write_output (materialize)",
-            int(phase_profile.get("write_output_ns") or 0),
-            hit_count,
-        ),
-        ("bookkeeping", int(phase_profile.get("bookkeeping_ns") or 0), hit_count),
-        ("compiler_exec", int(phase_profile.get("compiler_exec_ns") or 0), miss_count),
-        ("include_scan", int(phase_profile.get("include_scan_ns") or 0), miss_count),
-        ("hash_all", int(phase_profile.get("hash_all_ns") or 0), miss_count),
-        (
-            "artifact_store",
-            int(phase_profile.get("artifact_store_ns") or 0),
-            miss_count,
-        ),
-    ]
-    rows.sort(key=lambda r: r[1], reverse=True)
-
-    print()
-    print(f"### Phase breakdown (warm-side daemon — {hit_count} hits, {miss_count} misses)")
-    print()
-    print("| Phase | Total ms | Avg per event (µs) |")
-    print("| --- | ---: | ---: |")
-    for label, total_ns, denom in rows:
-        if total_ns == 0:
-            continue
-        total_ms = total_ns / 1_000_000
-        if denom > 0:
-            avg_us = total_ns / denom / 1_000
-            avg_cell = f"{avg_us:.1f}"
-        else:
-            avg_cell = "—"
-        print(f"| {label} | {total_ms:.1f} | {avg_cell} |")
-
-    total_hit_ns = int(phase_profile.get("total_hit_ns") or 0)
-    total_miss_ns = int(phase_profile.get("total_miss_ns") or 0)
-    print()
-    print(f"total_hit_ns={total_hit_ns / 1_000_000:.1f}ms total_miss_ns={total_miss_ns / 1_000_000:.1f}ms")
-
-
-# ---------------------------------------------------------------------------
-
 
 def build_zccache_docker_cmd(
     *,
@@ -1302,53 +803,6 @@ def run_exec(args: list[str]) -> int:
         return 2
     cmd = build_zccache_docker_cmd(bash_script=f"bash {_shell_quote(args[0])}")
     return run_zccache_docker_cmd(cmd)
-
-
-def _shell_quote(arg: str) -> str:
-    """Minimal quoting for embedding an argv element inside a `bash -c`
-    string. Wraps in single quotes and escapes any embedded single
-    quotes — exactly what `shlex.quote` produces, inlined here so we
-    don't pull in `shlex` for this one call site."""
-    if arg and all(c.isalnum() or c in "@%+=:,./-_" for c in arg):
-        return arg
-    return "'" + arg.replace("'", "'\"'\"'") + "'"
-
-
-def _distribution(values: list[int]) -> dict[str, float | int]:
-    """Return stable summary statistics for repeated timing samples."""
-    ordered = sorted(values)
-    median = statistics.median(ordered)
-    deviations = [abs(value - median) for value in ordered]
-    return {
-        "count": len(ordered),
-        "min_ms": ordered[0],
-        "median_ms": median,
-        "p95_ms": ordered[max(0, (len(ordered) * 95 + 99) // 100 - 1)],
-        "mad_ms": statistics.median(deviations),
-        "max_ms": ordered[-1],
-    }
-
-
-def _write_repeat_summary(
-    base_dir: Path,
-    samples: list[tuple[Path, dict]],
-    scenario: str,
-    fixture: str,
-) -> None:
-    timings: dict[str, list[int]] = {"cold_ms": [], "warm_ms": []}
-    for sample_dir, result in samples:
-        cold_key = "a_ms" if scenario == "worktree-share" else "cold_ms"
-        warm_key = "b_ms" if scenario == "worktree-share" else "warm_ms"
-        timings["cold_ms"].append(int(result[cold_key]))
-        timings["warm_ms"].append(int(result[warm_key]))
-    summary = {
-        "schema_version": 1,
-        "fixture": fixture,
-        "scenario": scenario,
-        "samples": [str(path.relative_to(base_dir)) for path, _ in samples],
-        "distributions": {name: _distribution(values) for name, values in timings.items()},
-    }
-    (base_dir / "repeat-summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def run_rollout_matrix(layout: dict[str, Path], jobs: int, repeat: int) -> int:

--- a/ci/perf_local_results.py
+++ b/ci/perf_local_results.py
@@ -1,0 +1,602 @@
+"""Scenario execution, result validation, and rendering for perf_local."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import statistics
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PERF_THRESHOLDS_PATH = REPO_ROOT / "ci" / "perf_thresholds.json"
+ROLLOUT_SCENARIOS = (
+    "cold-tar-untar-warm",
+    "worktree-share",
+    "touch-no-change",
+    "restore-no-clean-warm",
+)
+VALID_FIXTURES = ("medium", "sqlite-link")
+
+
+def load_perf_thresholds() -> dict:
+    """Load and validate the single source of truth for local timing gates."""
+    thresholds = json.loads(PERF_THRESHOLDS_PATH.read_text(encoding="utf-8"))
+    if thresholds.get("schema_version") != 1:
+        raise ValueError("unsupported perf threshold manifest schema")
+    warm_limits = thresholds.get("maximum_warm_ms")
+    if not isinstance(warm_limits, dict) or set(warm_limits) != set(ROLLOUT_SCENARIOS):
+        raise ValueError("threshold manifest must define every rollout scenario")
+    if not isinstance(thresholds.get("minimum_speedup"), (int, float)):
+        raise ValueError("threshold manifest minimum_speedup must be numeric")
+    staged_limits = thresholds.get("maximum_staged_overhead_ms_per_publication")
+    if not isinstance(staged_limits, dict) or set(staged_limits) != set(VALID_FIXTURES):
+        raise ValueError("threshold manifest must define staged overhead per publication for every fixture")
+    if not all(type(value) is int and value > 0 for value in staged_limits.values()):
+        raise ValueError("staged overhead per-publication limits must be positive integers")
+    return thresholds
+
+
+PERF_THRESHOLDS = load_perf_thresholds()
+LOCAL_MIN_SPEEDUP = float(PERF_THRESHOLDS["minimum_speedup"])
+LOCAL_MAX_WARM_MS = PERF_THRESHOLDS["maximum_warm_ms"]
+LOCAL_MAX_STAGED_OVERHEAD_MS_PER_PUBLICATION = PERF_THRESHOLDS["maximum_staged_overhead_ms_per_publication"]
+LOCAL_MAX_MATERIALIZATION_COPIED_BYTES = int(PERF_THRESHOLDS["maximum_materialization_copied_bytes"])
+
+def run_scenario(
+    layout: dict[str, Path],
+    scenario: str,
+    fixture: str,
+    jobs: int,
+    results_dir: Path | None = None,
+    *,
+    run_command,
+    host_volume_spec,
+    repo_root: Path,
+    image_runner: str,
+) -> Path:
+    """Run the per-scenario container. Returns the results dir for this run."""
+    results_dir = results_dir or layout["results"] / fixture / scenario
+    # Wipe last run's results so partial output from a crashing run doesn't
+    # masquerade as a complete result.
+    if results_dir.exists():
+        remove_previous_results(
+            results_dir,
+            run_command=run_command,
+            host_volume_spec=host_volume_spec,
+            image_runner=image_runner,
+        )
+    results_dir.mkdir(parents=True)
+
+    soldr_bin = layout["bin_soldr"] / "soldr"
+    if not soldr_bin.is_file():
+        raise FileNotFoundError(f"soldr binary missing at {soldr_bin}. Did the soldr-builder step succeed?")
+
+    print(f"[perf-local] running scenario {scenario} x {fixture} -> {results_dir}")
+    start = time.monotonic()
+    # Pass any ZCCACHE_* env through to the container so the daemon's
+    # env-gated instrumentation (e.g. ZCCACHE_HIT_TRACE=1 for the sub-phase
+    # dump from issue #468) reaches the in-container daemon process.
+    pass_through_env = [(k, v) for k, v in os.environ.items() if k.startswith("ZCCACHE_")]
+    # Docker Desktop commonly has an 8 GiB VM even when the Windows host has
+    # substantially more RAM. An unconstrained medium-fixture build can run
+    # enough rustc processes to exhaust that VM and surface os error 12 through
+    # soldr. Keep local measurements reproducible and within the selected
+    # budget; callers with a larger VM can raise --jobs explicitly.
+    # A performance sample must never silently switch to uncached rustc. This
+    # is a benchmark-integrity requirement, not a production default.
+    env_flags: list[str] = [
+        "-e",
+        f"CARGO_BUILD_JOBS={jobs}",
+        "-e",
+        "SOLDR_DAEMON_REQUIRED=1",
+    ]
+    for k, v in pass_through_env:
+        env_flags.extend(["-e", f"{k}={v}"])
+    run_command(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            host_volume_spec(soldr_bin, "/usr/local/bin/soldr", "ro"),
+            "-v",
+            host_volume_spec(repo_root, "/zccache-src", "ro"),
+            "-v",
+            host_volume_spec(results_dir, "/results"),
+            "-e",
+            f"SCENARIO={scenario}",
+            "-e",
+            f"FIXTURE={fixture}",
+            *env_flags,
+            image_runner,
+        ]
+    )
+    elapsed = time.monotonic() - start
+    print(f"[perf-local] scenario completed in {elapsed:.1f}s")
+    return results_dir
+
+
+def remove_previous_results(
+    results_dir: Path,
+    *,
+    run_command,
+    host_volume_spec,
+    image_runner: str,
+) -> None:
+    """Remove prior bind-mount output, repairing container ownership once.
+
+    The scenario container runs as root and may create nested result
+    directories with mode 0755. A normal host-side ``shutil.rmtree`` can then
+    remove writable files around them but fail when it reaches a root-owned
+    directory. Bind only the exact results directory into the same local
+    runner image, make that tree host-removable, and retry. The container
+    command is constant; destructive removal stays in Python against the
+    already-resolved path.
+    """
+    try:
+        shutil.rmtree(results_dir)
+        return
+    except PermissionError:
+        run_command(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "-v",
+                host_volume_spec(results_dir, "/results"),
+                "--entrypoint",
+                "/bin/chmod",
+                image_runner,
+                "-R",
+                "a+rwX",
+                "/results",
+            ]
+        )
+    shutil.rmtree(results_dir)
+
+
+# ---------------------------------------------------------------------------
+# Result rendering for local diagnostics and retained matrix evidence.
+
+
+def fmt_ms(ms) -> str:
+    if ms is None or ms == "":
+        return "—"
+    ms = int(ms)
+    if ms >= 60_000:
+        return f"{ms // 60_000}m{(ms % 60_000) // 1000:02d}s"
+    if ms >= 1_000:
+        return f"{ms / 1000:.2f}s"
+    return f"{ms}ms"
+
+
+def fmt_bytes(b) -> str:
+    if b is None or b == "":
+        return "—"
+    b = int(b)
+    if b >= 1 << 30:
+        return f"{b / (1 << 30):.2f} GiB"
+    if b >= 1 << 20:
+        return f"{b / (1 << 20):.1f} MiB"
+    if b >= 1 << 10:
+        return f"{b / (1 << 10):.1f} KiB"
+    return f"{b} B" if b > 0 else "0 B"
+
+
+def fmt_count_pct(n, total) -> str:
+    if n is None or n == "":
+        return "—"
+    if not total:
+        return str(n)
+    return f"{int(n)} ({int(n) / int(total) * 100:.1f}%)"
+
+
+def validate_infrastructure_result(result: dict, results_dir: Path) -> None:
+    """Reject samples contaminated by soldr abort/retry behavior.
+
+    Timing is meaningless when the build silently timed out or retried without
+    the cache, so this schema and its artifact-relative evidence are validated
+    before any performance threshold.
+    """
+    if not isinstance(result, dict):
+        raise ValueError("infrastructure result must be an object")
+    reasons = result.get("invalid_reasons")
+    evidence = result.get("soldr_abort_evidence")
+    fallback_evidence = result.get("soldr_daemon_fallback_evidence")
+    valid = result.get("infrastructure_valid")
+    count_names = (
+        "soldr_abort_count",
+        "soldr_timeout_count",
+        "soldr_no_cache_retry_count",
+        "soldr_daemon_fallback_count",
+    )
+    counts = {name: result.get(name) for name in count_names}
+
+    malformed = (
+        type(valid) is not bool
+        or not isinstance(reasons, list)
+        or not all(isinstance(reason, str) for reason in reasons)
+        or not isinstance(evidence, list)
+        or not evidence
+        or not all(isinstance(item, str) and re.fullmatch(r"soldr-aborts-[A-Za-z0-9_-]+[.]jsonl", item) for item in evidence)
+        or not isinstance(fallback_evidence, list)
+        or not fallback_evidence
+        or not all(isinstance(item, str) and re.fullmatch(r"soldr-daemon-fallbacks-[A-Za-z0-9_-]+[.]jsonl", item) for item in fallback_evidence)
+        or not all(type(value) is int and value >= 0 for value in counts.values())
+    )
+    if malformed:
+        raise ValueError("missing or malformed infrastructure-validity fields")
+    if counts["soldr_timeout_count"] > counts["soldr_abort_count"]:
+        raise ValueError("timeout count exceeds abort count")
+    if counts["soldr_no_cache_retry_count"] > counts["soldr_abort_count"]:
+        raise ValueError("no-cache retry count exceeds abort count")
+    if valid != (len(reasons) == 0):
+        raise ValueError("infrastructure validity and reasons disagree")
+    missing = [item for item in evidence if not (results_dir / item).is_file()]
+    if missing:
+        raise ValueError(f"declared soldr abort evidence is missing: {missing[0]}")
+    missing_fallback = [item for item in fallback_evidence if not (results_dir / item).is_file()]
+    if missing_fallback:
+        raise ValueError(f"declared soldr daemon fallback evidence is missing: {missing_fallback[0]}")
+    if not valid or any(counts.values()):
+        detail = "; ".join(reasons) or "soldr abort detected"
+        raise ValueError(
+            f"contaminated benchmark sample: {detail}; aborts={counts['soldr_abort_count']}, timeouts={counts['soldr_timeout_count']}, no-cache retries={counts['soldr_no_cache_retry_count']}, daemon fallbacks={counts['soldr_daemon_fallback_count']}"
+        )
+
+
+def _read_session_report(results_dir: Path, names: tuple[str, ...]) -> dict | None:
+    for name in names:
+        path = results_dir / name
+        if not path.is_file():
+            continue
+        try:
+            payload = json.loads(path.read_text())
+        except json.JSONDecodeError:
+            return None
+        session = payload.get("last_session")
+        return session if isinstance(session, dict) else None
+    return None
+
+
+def _staged_profile(report: dict | None) -> dict | None:
+    if not report:
+        return None
+    profile = report.get("phase_profile")
+    if not isinstance(profile, dict):
+        return None
+    staged = profile.get("staged")
+    return staged if isinstance(staged, dict) else None
+
+
+def evaluate_rollout_result(results_dir: Path, scenario: str, fixture: str) -> list[str]:
+    """Return every hard-gate failure for one sanctioned local matrix cell."""
+    failures: list[str] = []
+    result_path = results_dir / "result.json"
+    if not result_path.is_file():
+        return ["result.json missing"]
+    try:
+        result = json.loads(result_path.read_text())
+    except json.JSONDecodeError as error:
+        return [f"result.json is malformed: {error}"]
+    if not isinstance(result, dict):
+        return ["result.json must contain one object"]
+
+    try:
+        validate_infrastructure_result(result, results_dir)
+    except ValueError as error:
+        failures.append(str(error))
+
+    cold_key = "a_ms" if scenario == "worktree-share" else "cold_ms"
+    warm_key = "b_ms" if scenario == "worktree-share" else "warm_ms"
+    cold_ms = result.get(cold_key)
+    warm_ms = result.get(warm_key)
+    if type(cold_ms) is not int or type(warm_ms) is not int or warm_ms <= 0:
+        failures.append(f"invalid timing fields {cold_key}={cold_ms} {warm_key}={warm_ms}")
+    else:
+        speedup = cold_ms / warm_ms
+        if speedup < LOCAL_MIN_SPEEDUP:
+            failures.append(f"speedup {speedup:.2f}x is below {LOCAL_MIN_SPEEDUP:.2f}x")
+        warm_limit = LOCAL_MAX_WARM_MS[scenario]
+        if warm_limit is not None and warm_ms > warm_limit:
+            failures.append(f"warm time {warm_ms}ms exceeds {warm_limit}ms")
+
+    cold_report = _read_session_report(results_dir, ("cold-cache-report.json", "a-cache-report.json"))
+    warm_report = _read_session_report(results_dir, ("warm-cache-report.json", "b-cache-report.json"))
+    cold_staged = _staged_profile(cold_report)
+    warm_staged = _staged_profile(warm_report)
+    if cold_staged is None:
+        failures.append("missing cold staged telemetry")
+        return failures
+
+    cold_timings = cold_staged.get("timings_ns", {})
+    cold_counters = cold_staged.get("counters", {})
+    if not isinstance(cold_timings, dict) or not isinstance(cold_counters, dict):
+        failures.append("malformed cold staged telemetry")
+        return failures
+    overhead_ns = sum(int(cold_timings.get(name, 0) or 0) for name in ("hashing", "publication", "miss_materialization"))
+    publications = int(cold_counters.get("publication_success", 0) or 0)
+    if publications <= 0:
+        failures.append("cold path published no staged generations")
+    else:
+        # These timings accumulate independently across concurrent compiler
+        # requests. Normalize their sum so an identical per-publication cost
+        # receives the same verdict in a four-crate and a 143-crate fixture.
+        overhead_ms_per_publication = (overhead_ns + publications * 1_000_000 - 1) // (publications * 1_000_000)
+        overhead_limit = int(LOCAL_MAX_STAGED_OVERHEAD_MS_PER_PUBLICATION[fixture])
+        if overhead_ms_per_publication > overhead_limit:
+            failures.append("staged miss overhead " f"{overhead_ms_per_publication}ms/publication exceeds " f"{overhead_limit}ms/publication for {fixture}")
+
+    counter_sets = [cold_counters]
+    if warm_staged is not None:
+        warm_counters = warm_staged.get("counters", {})
+        warm_bytes = warm_staged.get("bytes", {})
+        if not isinstance(warm_counters, dict) or not isinstance(warm_bytes, dict):
+            failures.append("malformed warm staged telemetry")
+            return failures
+        counter_sets.append(warm_counters)
+        copied = int(warm_bytes.get("materialization_copied", 0) or 0)
+        tiers = sum(
+            int(warm_counters.get(name, 0) or 0)
+            for name in (
+                "materialize_reflink",
+                "materialize_hardlink_shared",
+                "materialize_copy",
+            )
+        )
+    elif scenario == "restore-no-clean-warm":
+        copied = 0
+        tiers = 0
+    else:
+        failures.append("missing warm staged telemetry")
+        return failures
+
+    salvage = sum(int(counters.get("salvage_attempt", 0) or 0) for counters in counter_sets)
+    critical = sum(int(counters.get(name, 0) or 0) for counters in counter_sets for name in ("publication_failure", "publication_conflict", "materialize_failure"))
+    if salvage != 0 or critical != 0:
+        failures.append(f"salvage={salvage} critical_failures={critical}")
+    if copied > LOCAL_MAX_MATERIALIZATION_COPIED_BYTES:
+        failures.append(f"materialization copied {copied} bytes, max {LOCAL_MAX_MATERIALIZATION_COPIED_BYTES}")
+    if scenario == "restore-no-clean-warm":
+        if result.get("warm_misses") != 0:
+            failures.append(f"restore warm build had cache misses: {result.get('warm_misses')}")
+    elif tiers <= 0:
+        failures.append("warm build reported no materialization tier")
+
+    return failures
+
+
+def render_summary(results_dir: Path, scenario: str, fixture: str) -> int:
+    """Print a one-row summary table + the inline annotation that the GHA
+    Evaluate step would emit. Returns 0 if the speedup hit the 3x gate."""
+    result_json = results_dir / "result.json"
+    if not result_json.is_file():
+        print(f"[perf-local] FAIL: result.json missing at {result_json}")
+        return 1
+    result = json.loads(result_json.read_text())
+
+    # Per-scenario key naming, matches Evaluate's cold_key_for/warm_key_for.
+    cold_key = "a_ms" if scenario == "worktree-share" else "cold_ms"
+    warm_key = "b_ms" if scenario == "worktree-share" else "warm_ms"
+    cold_ms = result.get(cold_key)
+    warm_ms = result.get(warm_key)
+    if cold_ms is None or warm_ms is None or warm_ms <= 0:
+        print(f"[perf-local] FAIL: bad timing in result.json (cold={cold_ms} warm={warm_ms})")
+        return 1
+    speedup = cold_ms / warm_ms
+
+    # Warm-side cache report carries the rich session counters.
+    report_candidates = [
+        results_dir / "warm-cache-report.json",
+        results_dir / "b-cache-report.json",
+    ]
+    report = None
+    for candidate in report_candidates:
+        if candidate.is_file():
+            report = json.loads(candidate.read_text()).get("last_session", {})
+            break
+    if report is None:
+        report = {}
+
+    # `last-session-stats.json` is zccache's own JSON output (written by
+    # `zccache session-end --json`); it includes `phase_profile` from
+    # PROTOCOL_VERSION 9 onward. Soldr's `cache report` is the
+    # canonical structured form but it copies a fixed set of keys into
+    # `last_session` and strips unknown fields, so a fresh phase_profile
+    # field arrives in `last-session-stats.json` before it surfaces in
+    # the report block. Pull it directly to avoid that lag.
+    if "phase_profile" not in report:
+        stats_candidates = [
+            results_dir / "warm-zccache-logs" / "last-session-stats.json",
+            results_dir / "b-zccache-logs" / "last-session-stats.json",
+        ]
+        for candidate in stats_candidates:
+            if not candidate.is_file():
+                continue
+            try:
+                raw = json.loads(candidate.read_text())
+            except json.JSONDecodeError:
+                continue
+            phase = raw.get("phase_profile")
+            if phase is not None:
+                report["phase_profile"] = phase
+                break
+
+    compiles = report.get("compilations")
+    hits = report.get("hits")
+    misses = report.get("misses")
+    non_cache = report.get("non_cacheable")
+    errs = report.get("errors")
+    bytes_w = report.get("bytes_written")
+    time_saved = report.get("time_saved_ms")
+    unique_srcs = report.get("unique_sources")
+    daemon_rss = result.get("peak_daemon_rss_bytes")
+    compile_rss = result.get("peak_compile_rss_bytes")
+
+    threshold = LOCAL_MIN_SPEEDUP
+    verdict = "PASS" if speedup >= threshold else "FAIL"
+
+    print()
+    print(f"## Perf result — local Docker harness — {fixture} / {scenario}")
+    print()
+    header = "| Fixture | Scenario | Verdict | Speedup | Need | Cold | Warm | Compiles | Hits | Misses | Ignored | Errors | Unique Srcs | Bytes W | Time Saved | Daemon RSS | Compile RSS |"
+    sep = "| --- | --- | :---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+    row = (
+        f"| {fixture} | {scenario} | **{verdict}** | {speedup:.2f}x | >={threshold:.2f}x "
+        f"| {fmt_ms(cold_ms)} | {fmt_ms(warm_ms)} "
+        f"| {compiles if compiles is not None else '—'} "
+        f"| {fmt_count_pct(hits, compiles)} "
+        f"| {fmt_count_pct(misses, compiles)} "
+        f"| {fmt_count_pct(non_cache, compiles)} "
+        f"| {errs if errs is not None else '—'} "
+        f"| {unique_srcs if unique_srcs is not None else '—'} "
+        f"| {fmt_bytes(bytes_w)} | {fmt_ms(time_saved)} "
+        f"| {fmt_bytes(daemon_rss)} | {fmt_bytes(compile_rss)} |"
+    )
+    print(header)
+    print(sep)
+    print(row)
+    print()
+    print(
+        f"{fixture}/{scenario}: speedup={speedup:.2f}x (need >={threshold:.2f}x); "
+        f"cold={fmt_ms(cold_ms)} warm={fmt_ms(warm_ms)}; "
+        f"compiles={compiles or 0} hits={hits or 0} misses={misses or 0} "
+        f"ignored={non_cache or 0} errors={errs or 0}; "
+        f"bytes_W={fmt_bytes(bytes_w)} daemon_RSS={fmt_bytes(daemon_rss)}"
+    )
+
+    render_phase_breakdown(report.get("phase_profile"))
+
+    return 0 if verdict == "PASS" else 1
+
+
+def render_phase_breakdown(phase_profile) -> None:
+    """Print a phase-breakdown table from `SessionStats.phase_profile`.
+
+    Skipped silently when the daemon didn't populate the field (old
+    PROTOCOL_VERSION) or when both hit and miss counts are zero.
+    """
+    if not isinstance(phase_profile, dict):
+        return
+    hit_count = int(phase_profile.get("hit_count") or 0)
+    miss_count = int(phase_profile.get("miss_count") or 0)
+    if hit_count == 0 and miss_count == 0:
+        return
+
+    # (label, total-ns, denom-count). Hit phases use hit_count for the
+    # per-event average; miss phases use miss_count. The two metadata-cache
+    # sub-phases are summed so the table speaks the language used in design
+    # discussion ("metadata cache (source+hdrs)").
+    src_ns = int(phase_profile.get("hash_source_ns") or 0)
+    hdr_ns = int(phase_profile.get("hash_headers_ns") or 0)
+    rows = [
+        ("parse_args", int(phase_profile.get("parse_args_ns") or 0), hit_count),
+        ("build_context", int(phase_profile.get("build_context_ns") or 0), hit_count),
+        ("metadata cache (source+hdrs)", src_ns + hdr_ns, hit_count),
+        ("depgraph_check", int(phase_profile.get("depgraph_check_ns") or 0), hit_count),
+        (
+            "request_cache_lookup",
+            int(phase_profile.get("request_cache_lookup_ns") or 0),
+            hit_count,
+        ),
+        (
+            "cross_root_validate",
+            int(phase_profile.get("cross_root_validate_ns") or 0),
+            hit_count,
+        ),
+        (
+            "artifact_lookup",
+            int(phase_profile.get("artifact_lookup_ns") or 0),
+            hit_count,
+        ),
+        (
+            "write_output (materialize)",
+            int(phase_profile.get("write_output_ns") or 0),
+            hit_count,
+        ),
+        ("bookkeeping", int(phase_profile.get("bookkeeping_ns") or 0), hit_count),
+        ("compiler_exec", int(phase_profile.get("compiler_exec_ns") or 0), miss_count),
+        ("include_scan", int(phase_profile.get("include_scan_ns") or 0), miss_count),
+        ("hash_all", int(phase_profile.get("hash_all_ns") or 0), miss_count),
+        (
+            "artifact_store",
+            int(phase_profile.get("artifact_store_ns") or 0),
+            miss_count,
+        ),
+    ]
+    rows.sort(key=lambda r: r[1], reverse=True)
+
+    print()
+    print(f"### Phase breakdown (warm-side daemon — {hit_count} hits, {miss_count} misses)")
+    print()
+    print("| Phase | Total ms | Avg per event (µs) |")
+    print("| --- | ---: | ---: |")
+    for label, total_ns, denom in rows:
+        if total_ns == 0:
+            continue
+        total_ms = total_ns / 1_000_000
+        if denom > 0:
+            avg_us = total_ns / denom / 1_000
+            avg_cell = f"{avg_us:.1f}"
+        else:
+            avg_cell = "—"
+        print(f"| {label} | {total_ms:.1f} | {avg_cell} |")
+
+    total_hit_ns = int(phase_profile.get("total_hit_ns") or 0)
+    total_miss_ns = int(phase_profile.get("total_miss_ns") or 0)
+    print()
+    print(f"total_hit_ns={total_hit_ns / 1_000_000:.1f}ms total_miss_ns={total_miss_ns / 1_000_000:.1f}ms")
+
+
+# ---------------------------------------------------------------------------
+
+
+
+def _shell_quote(arg: str) -> str:
+    """Minimal quoting for embedding an argv element inside a `bash -c`
+    string. Wraps in single quotes and escapes any embedded single
+    quotes — exactly what `shlex.quote` produces, inlined here so we
+    don't pull in `shlex` for this one call site."""
+    if arg and all(c.isalnum() or c in "@%+=:,./-_" for c in arg):
+        return arg
+    return "'" + arg.replace("'", "'\"'\"'") + "'"
+
+
+def _distribution(values: list[int]) -> dict[str, float | int]:
+    """Return stable summary statistics for repeated timing samples."""
+    ordered = sorted(values)
+    median = statistics.median(ordered)
+    deviations = [abs(value - median) for value in ordered]
+    return {
+        "count": len(ordered),
+        "min_ms": ordered[0],
+        "median_ms": median,
+        "p95_ms": ordered[max(0, (len(ordered) * 95 + 99) // 100 - 1)],
+        "mad_ms": statistics.median(deviations),
+        "max_ms": ordered[-1],
+    }
+
+
+def _write_repeat_summary(
+    base_dir: Path,
+    samples: list[tuple[Path, dict]],
+    scenario: str,
+    fixture: str,
+) -> None:
+    timings: dict[str, list[int]] = {"cold_ms": [], "warm_ms": []}
+    for sample_dir, result in samples:
+        cold_key = "a_ms" if scenario == "worktree-share" else "cold_ms"
+        warm_key = "b_ms" if scenario == "worktree-share" else "warm_ms"
+        timings["cold_ms"].append(int(result[cold_key]))
+        timings["warm_ms"].append(int(result[warm_key]))
+    summary = {
+        "schema_version": 1,
+        "fixture": fixture,
+        "scenario": scenario,
+        "samples": [str(path.relative_to(base_dir)) for path, _ in samples],
+        "distributions": {name: _distribution(values) for name, values in timings.items()},
+    }
+    (base_dir / "repeat-summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/ci/tests/test_perf_local.py
+++ b/ci/tests/test_perf_local.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 
@@ -19,7 +20,11 @@ def _load_perf_local():
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    sys.path.insert(0, str(module_path.parent))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
     return module
 
 

--- a/ci/tests/test_perf_local.py
+++ b/ci/tests/test_perf_local.py
@@ -144,6 +144,11 @@ def test_git_is_worktree_root_rejects_empty_submodule_directory(tmp_path):
 
 def test_pin_soldr_zccache_source_initializes_and_pins_current_checkout(tmp_path, monkeypatch):
     soldr_src = tmp_path / "soldr-src"
+    soldr_src.mkdir()
+    (soldr_src / ".gitmodules").write_text(
+        '[submodule "_vender/zccache"]\npath = _vender/zccache\n',
+        encoding="utf-8",
+    )
     commands = []
 
     monkeypatch.setattr(
@@ -176,6 +181,11 @@ def test_pin_soldr_zccache_source_initializes_and_pins_current_checkout(tmp_path
 
 def test_pin_soldr_zccache_source_rejects_wrong_checkout(tmp_path, monkeypatch):
     soldr_src = tmp_path / "soldr-src"
+    soldr_src.mkdir()
+    (soldr_src / ".gitmodules").write_text(
+        '[submodule "_vender/zccache"]\npath = _vender/zccache\n',
+        encoding="utf-8",
+    )
     heads = iter(["abc123", "000000", "def456"])
     monkeypatch.setattr(perf_local, "run", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(perf_local, "git_head", lambda _repo: next(heads))
@@ -200,6 +210,21 @@ def test_pin_soldr_zccache_source_rejects_dirty_checkout(tmp_path, monkeypatch):
         assert "commit or stash" in str(error)
     else:
         raise AssertionError("dirty zccache source must not be silently ignored")
+
+
+def test_pin_soldr_zccache_source_patches_current_registry_dependency(tmp_path, monkeypatch):
+    soldr_src = tmp_path / "soldr-src"
+    config = soldr_src / ".cargo" / "config.toml"
+    config.parent.mkdir(parents=True)
+    config.write_text("[build]\nrustflags = []\n", encoding="utf-8")
+    monkeypatch.setattr(perf_local, "git_is_dirty", lambda _repo: False)
+
+    perf_local.pin_soldr_zccache_source(soldr_src)
+
+    contents = config.read_text(encoding="utf-8")
+    assert "[build]" in contents
+    assert "[patch.crates-io.zccache]" in contents
+    assert 'path = "/zccache-src/crates/zccache"' in contents
 
 
 def test_ensure_soldr_source_refreshes_requested_ref(tmp_path, monkeypatch):

--- a/ci/tests/test_perf_local.py
+++ b/ci/tests/test_perf_local.py
@@ -7,6 +7,7 @@ container.
 
 from __future__ import annotations
 
+import importlib
 import importlib.util
 import json
 import subprocess
@@ -29,6 +30,11 @@ def _load_perf_local():
 
 
 perf_local = _load_perf_local()
+
+
+def test_perf_local_supports_package_import() -> None:
+    imported = importlib.import_module("ci.perf_local")
+    assert imported.PERF_THRESHOLDS["schema_version"] == 1
 
 
 def test_buildkit_gc_is_scoped_to_zccache_builder() -> None:

--- a/ci/tests/test_perf_rust_cluster_embedded.py
+++ b/ci/tests/test_perf_rust_cluster_embedded.py
@@ -11,6 +11,8 @@ WORKFLOW = ROOT / ".github" / "workflows" / "perf-rust-cluster.yml"
 LOCAL_ENTRYPOINT = ROOT / "ci" / "docker" / "perf_entrypoint.sh"
 LOCAL_RUNNER = ROOT / "ci" / "docker" / "runner.Dockerfile"
 LOCAL_ORCHESTRATOR = ROOT / "ci" / "perf_local.py"
+LOCAL_RESULTS = ROOT / "ci" / "perf_local_results.py"
+LOCAL_ORCHESTRATOR_SOURCES = (LOCAL_ORCHESTRATOR, LOCAL_RESULTS)
 COMMON_SH = ROOT / "perf" / "lib" / "common.sh"
 FIXTURE_ROOT = ROOT / "perf" / "fixtures"
 FIXTURE_REGEN = FIXTURE_ROOT / "regen.sh"
@@ -23,6 +25,10 @@ ROLLOUT_SCENARIOS = SNAPSHOT_SCENARIOS + (
     ROOT / "perf" / "scenarios" / "worktree-share" / "run.sh",
     ROOT / "perf" / "scenarios" / "touch-no-change" / "run.sh",
 )
+
+
+def local_orchestrator_source() -> str:
+    return "\n".join(path.read_text(encoding="utf-8") for path in LOCAL_ORCHESTRATOR_SOURCES)
 
 
 def test_hosted_perf_cluster_is_removed() -> None:
@@ -111,7 +117,7 @@ def test_fixture_regeneration_requires_and_deterministically_archives_pin() -> N
 
 
 def test_perf_local_final_rollout_matrix_and_gates_are_required() -> None:
-    orchestrator = LOCAL_ORCHESTRATOR.read_text(encoding="utf-8")
+    orchestrator = local_orchestrator_source()
 
     assert '"--matrix"' in orchestrator
     assert 'VALID_FIXTURES = ("medium", "sqlite-link")' in orchestrator
@@ -138,7 +144,7 @@ def test_perf_local_final_rollout_matrix_and_gates_are_required() -> None:
 
 
 def test_perf_local_fails_closed_on_soldr_abort_contamination() -> None:
-    orchestrator = LOCAL_ORCHESTRATOR.read_text(encoding="utf-8")
+    orchestrator = local_orchestrator_source()
 
     for required in (
         "infrastructure_valid",
@@ -173,7 +179,7 @@ def test_perf_local_fails_closed_on_soldr_abort_contamination() -> None:
 
 
 def test_perf_local_requires_soldr_daemon_for_measured_runs() -> None:
-    orchestrator = LOCAL_ORCHESTRATOR.read_text(encoding="utf-8")
+    orchestrator = local_orchestrator_source()
 
     assert '"SOLDR_DAEMON_REQUIRED=1"' in orchestrator
 

--- a/crates/zccache-daemon-core/src/daemon/process.rs
+++ b/crates/zccache-daemon-core/src/daemon/process.rs
@@ -195,11 +195,12 @@ impl CompilePriority {
                 return Self::parse_or_warn(value, ZCCACHE_COMPILE_PRIORITY_LINK);
             }
 
-            // Issue #813 / #810: linker priority is the single biggest UI
-            // win on Windows (link.exe is the worst single-thread hog).
-            // Interactive hosts default to `Low`; CI keeps the historical
-            // `Normal` so dedicated runners don't yield.
-            return if is_ci { Self::Normal } else { Self::Low };
+            // #1511: feed interactive link-like work through the existing Auto
+            // wave policy. A lone link/rustc leader stays Normal while parallel
+            // followers remain Low, preserving #813's responsiveness without
+            // demoting every sequential Rust build miss. CI keeps its explicit
+            // historical Normal default.
+            return if is_ci { Self::Normal } else { Self::Auto };
         }
 
         Self::from_client_env_with_daemon_env(env, daemon_compile_value)

--- a/crates/zccache-daemon-core/src/daemon/process.rs
+++ b/crates/zccache-daemon-core/src/daemon/process.rs
@@ -216,17 +216,6 @@ impl CompilePriority {
         }
     }
 
-    /// Observation variant — samples the in-flight counter without
-    /// incrementing it. Spawn sites must call [`Self::resolve_and_track`]
-    /// instead so the decision is race-free against concurrent spawns.
-    pub(crate) fn resolve_for_current_load(self) -> CompilePriorityDecision {
-        let cpu_usage_percent = matches!(self, Self::Auto)
-            .then(current_cpu_usage_percent)
-            .flatten();
-        let in_flight = total_in_flight(current_in_flight_compiles());
-        self.resolve_with_cpu_usage_and_ci(cpu_usage_percent, is_ci_host().is_some(), in_flight)
-    }
-
     /// Spawn-site resolution. Acquires an [`InFlightCompileTicket`] so the
     /// `Auto` decision uses the pre-increment count (race-free under
     /// parallel spawns) and the counter accurately reflects in-flight work
@@ -507,13 +496,6 @@ impl Drop for HostInFlightGuard {
     }
 }
 
-/// Observation-only sampler. `Auto` resolution at *spawn sites* must use
-/// the pre-increment value returned by [`InFlightCompileTicket::acquire`]
-/// instead, so concurrent decisions are race-free (fetch-add ordering).
-pub(crate) fn current_in_flight_compiles() -> usize {
-    IN_FLIGHT_COMPILES.load(Ordering::Acquire)
-}
-
 /// RAII ticket representing one in-flight compile spawn. Acquire **before**
 /// resolving `Auto` priority; the pre-increment count is exposed via
 /// [`Self::in_flight_before`] and is the deterministic input for the
@@ -593,6 +575,16 @@ pub(crate) async fn tokio_command_output_with_priority(
     tokio_command_output_with_priority_stdin(cmd, priority, None).await
 }
 
+/// Compiler-spawn variant that returns the race-free `Auto` decision used for
+/// the child. Callers that emit miss profiles must use this instead of
+/// sampling [`CompilePriority::resolve_for_current_load`] before admission.
+pub(crate) async fn tokio_command_output_with_priority_decision(
+    cmd: &mut tokio::process::Command,
+    priority: CompilePriority,
+) -> (io::Result<Output>, CompilePriorityDecision) {
+    tokio_command_output_with_priority_stdin_inner(cmd, priority, None, None).await
+}
+
 /// Wait for an async command after applying compiler child priority, killing
 /// the child and returning `TimedOut` when `timeout` elapses.
 pub(crate) async fn tokio_command_output_with_priority_timeout(
@@ -621,7 +613,9 @@ pub(crate) async fn tokio_command_output_with_priority_stdin(
     priority: CompilePriority,
     stdin_bytes: Option<&[u8]>,
 ) -> io::Result<Output> {
-    tokio_command_output_with_priority_stdin_inner(cmd, priority, stdin_bytes, None).await
+    tokio_command_output_with_priority_stdin_inner(cmd, priority, stdin_bytes, None)
+        .await
+        .0
 }
 
 /// Streaming counterpart used by the embedded compile API. Process setup,
@@ -633,7 +627,19 @@ pub(crate) async fn tokio_command_output_streaming_with_priority_stdin(
     stdin_bytes: Option<&[u8]>,
     sender: tokio::sync::mpsc::Sender<crate::daemon::compile_output::RawOutputChunk>,
 ) -> io::Result<Output> {
-    tokio_command_output_with_priority_stdin_inner(cmd, priority, stdin_bytes, Some(sender)).await
+    tokio_command_output_with_priority_stdin_inner(cmd, priority, stdin_bytes, Some(sender))
+        .await
+        .0
+}
+
+/// Streaming compiler-spawn variant that reports the decision made while its
+/// in-flight ticket was acquired.
+pub(crate) async fn tokio_command_output_streaming_with_priority_decision(
+    cmd: &mut tokio::process::Command,
+    priority: CompilePriority,
+    sender: tokio::sync::mpsc::Sender<crate::daemon::compile_output::RawOutputChunk>,
+) -> (io::Result<Output>, CompilePriorityDecision) {
+    tokio_command_output_with_priority_stdin_inner(cmd, priority, None, Some(sender)).await
 }
 
 async fn tokio_command_output_with_priority_stdin_inner(
@@ -641,7 +647,7 @@ async fn tokio_command_output_with_priority_stdin_inner(
     priority: CompilePriority,
     stdin_bytes: Option<&[u8]>,
     stream: Option<tokio::sync::mpsc::Sender<crate::daemon::compile_output::RawOutputChunk>>,
-) -> io::Result<Output> {
+) -> (io::Result<Output>, CompilePriorityDecision) {
     let (decision, _ticket) = priority.resolve_and_track();
     let priority = decision.effective;
     let pipe_stdin = matches!(stdin_bytes, Some(b) if !b.is_empty());
@@ -659,7 +665,10 @@ async fn tokio_command_output_with_priority_stdin_inner(
     }
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
-    let mut child = running_process::spawn_tokio(cmd, owned_child_spawn_options())?;
+    let mut child = match running_process::spawn_tokio(cmd, owned_child_spawn_options()) {
+        Ok(child) => child,
+        Err(error) => return (Err(error), decision),
+    };
     attach_child_owner_death(&child);
     apply_priority_to_child(&child, priority);
     if pipe_stdin {
@@ -668,7 +677,7 @@ async fn tokio_command_output_with_priority_stdin_inner(
             let _ = stdin.shutdown().await;
         }
     }
-    match stream {
+    let result = match stream {
         Some(sender) => {
             crate::daemon::child_watchdog::wait_with_output_watchdog_streaming(
                 child, &cmd_desc, sender,
@@ -676,7 +685,8 @@ async fn tokio_command_output_with_priority_stdin_inner(
             .await
         }
         None => crate::daemon::child_watchdog::wait_with_output_watchdog(child, &cmd_desc).await,
-    }
+    };
+    (result, decision)
 }
 
 /// Run a leaf tool without the orphan-pipe watchdog used for compilers.

--- a/crates/zccache-daemon-core/src/daemon/process_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/process_tests.rs
@@ -279,17 +279,17 @@ fn auto_priority_decision_normal_on_interactive_when_idle() {
 
 #[test]
 fn in_flight_ticket_returns_pre_increment_count_atomically() {
-    let baseline = current_in_flight_compiles();
+    let baseline = IN_FLIGHT_COMPILES.load(Ordering::Acquire);
     let t1 = InFlightCompileTicket::acquire();
     assert_eq!(t1.in_flight_before(), baseline);
-    assert_eq!(current_in_flight_compiles(), baseline + 1);
+    assert_eq!(IN_FLIGHT_COMPILES.load(Ordering::Acquire), baseline + 1);
     let t2 = InFlightCompileTicket::acquire();
     assert_eq!(t2.in_flight_before(), baseline + 1);
-    assert_eq!(current_in_flight_compiles(), baseline + 2);
+    assert_eq!(IN_FLIGHT_COMPILES.load(Ordering::Acquire), baseline + 2);
     drop(t2);
-    assert_eq!(current_in_flight_compiles(), baseline + 1);
+    assert_eq!(IN_FLIGHT_COMPILES.load(Ordering::Acquire), baseline + 1);
     drop(t1);
-    assert_eq!(current_in_flight_compiles(), baseline);
+    assert_eq!(IN_FLIGHT_COMPILES.load(Ordering::Acquire), baseline);
 }
 
 /// zccache#924: serialize tests that touch the process-wide host
@@ -393,19 +393,6 @@ fn host_counter_saturates_without_overflow() {
     );
     let decision = CompilePriority::Auto.resolve_with_cpu_usage_and_ci(Some(10.0), false, summed);
     assert_eq!(decision.effective, CompilePriority::Low);
-}
-
-#[test]
-fn auto_priority_can_sample_current_load() {
-    let decision = CompilePriority::Auto.resolve_for_current_load();
-    assert_eq!(decision.requested, CompilePriority::Auto);
-    assert!(matches!(
-        decision.effective,
-        CompilePriority::Normal | CompilePriority::Low
-    ));
-    if let Some(cpu_usage_percent) = decision.cpu_usage_percent {
-        assert!((0.0..=100.0).contains(&cpu_usage_percent));
-    }
 }
 
 #[test]

--- a/crates/zccache-daemon-core/src/daemon/process_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/process_tests.rs
@@ -479,10 +479,9 @@ fn link_like_compile_priority_on_ci_defaults_to_normal_without_link_override() {
 }
 
 #[test]
-fn link_like_compile_priority_on_interactive_defaults_to_low_without_link_override() {
-    // Issue #813 / #810: link.exe is the single worst single-thread
-    // hog on Windows MSVC. Interactive hosts demote it to Low so the
-    // late-build link step doesn't lock up the UI.
+fn link_like_compile_priority_on_interactive_defaults_to_auto_without_link_override() {
+    // #1511: Auto keeps a lone link-like compile at Normal and demotes only
+    // followers in a parallel wave, retaining #813's UI protection.
     let env = vec![(COMPILE_PRIORITY_ENV.to_string(), "idle".to_string())];
 
     assert_eq!(
@@ -493,7 +492,7 @@ fn link_like_compile_priority_on_interactive_defaults_to_low_without_link_overri
             None,
             false, // interactive
         ),
-        CompilePriority::Low
+        CompilePriority::Auto
     );
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_profile.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_profile.rs
@@ -20,6 +20,7 @@ pub(super) struct RustMissProfile<'a> {
     pub(super) post_exec_ns: u64,
     pub(super) apply_changes_ns: u64,
     pub(super) collect_outputs_ns: u64,
+    pub(super) staged_materialization_ns: u64,
     pub(super) rust_output_count: usize,
     pub(super) rust_output_bytes: u64,
     pub(super) include_scan_ns: u64,
@@ -63,6 +64,7 @@ pub(super) fn emit_rust_miss_profile(profile: RustMissProfile<'_>) {
         post_exec_ns,
         apply_changes_ns,
         collect_outputs_ns,
+        staged_materialization_ns,
         rust_output_count,
         rust_output_bytes,
         include_scan_ns,
@@ -116,6 +118,7 @@ pub(super) fn emit_rust_miss_profile(profile: RustMissProfile<'_>) {
         .saturating_add(post_exec_ns)
         .saturating_add(apply_changes_ns)
         .saturating_add(collect_outputs_ns)
+        .saturating_add(staged_materialization_ns)
         .saturating_add(include_scan_ns)
         .saturating_add(register_tracked_ns)
         .saturating_add(dep_dirs_ns)
@@ -135,7 +138,7 @@ pub(super) fn emit_rust_miss_profile(profile: RustMissProfile<'_>) {
             "system_watch_ns={} parse_args_ns={} build_context_ns={} ",
             "hash_source_ns={} hash_headers_ns={} depgraph_check_ns={} ",
             "pre_exec_other_ns={} break_outputs_ns={} compiler_prep_ns={} compiler_process_ns={} ",
-            "post_exec_ns={} apply_changes_ns={} collect_outputs_ns={} ",
+            "post_exec_ns={} apply_changes_ns={} collect_outputs_ns={} staged_materialization_ns={} ",
             "outputs={} output_bytes={} include_scan_ns={} ",
             "register_tracked_ns={} dep_dirs_ns={} hash_all_ns={} ",
             "artifact_store_ns={} depgraph_update_ns={} artifact_build_ns={} ",
@@ -168,6 +171,7 @@ pub(super) fn emit_rust_miss_profile(profile: RustMissProfile<'_>) {
         post_exec_ns,
         apply_changes_ns,
         collect_outputs_ns,
+        staged_materialization_ns,
         rust_output_count,
         rust_output_bytes,
         include_scan_ns,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -246,7 +246,6 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         .is_some_and(|rustc_args| rustc_args.emit_types.iter().any(|emit| emit == "link"));
     let compiler_priority =
         CompilePriority::from_client_env_for_link_like(client_env.as_deref(), is_link_like);
-    let compiler_priority_decision = compiler_priority.resolve_for_current_load();
 
     // soldr#2781: this point is reached only after every cache-hit branch has
     // missed. Ordinary compiler children share the gate; an amalgamated C
@@ -332,7 +331,8 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     }
     let compile_span_start = std::time::Instant::now();
 
-    let (result, streamed_output) = if let Some(context) = crate::daemon::compile_output::current()
+    let (result, compiler_priority_decision, streamed_output) = if let Some(context) =
+        crate::daemon::compile_output::current()
     {
         let (sender, receiver) = tokio::sync::mpsc::channel(8);
         let filter = if depfile_strategy == DepfileStrategy::ShowIncludes {
@@ -348,24 +348,22 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         } else {
             crate::daemon::compile_output::StderrFilter::None
         };
-        let process = crate::daemon::process::tokio_command_output_streaming_with_priority_stdin(
+        let process = crate::daemon::process::tokio_command_output_streaming_with_priority_decision(
             &mut cmd,
-            compiler_priority_decision.effective,
-            None,
+            compiler_priority,
             sender,
         );
         let consume = crate::daemon::compile_output::consume(receiver, context, filter);
         let (process_result, capture_result) = tokio::join!(process, consume);
-        (process_result, Some(capture_result))
+        (process_result.0, process_result.1, Some(capture_result))
     } else {
-        (
-            crate::daemon::process::tokio_command_output_with_priority(
+        let (result, decision) =
+            crate::daemon::process::tokio_command_output_with_priority_decision(
                 &mut cmd,
-                compiler_priority_decision.effective,
+                compiler_priority,
             )
-            .await,
-            None,
-        )
+            .await;
+        (result, decision, None)
     };
     let compiler_process_ns = t_compiler_process.elapsed().as_nanos() as u64;
     if staged_plan.is_some() {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -50,13 +50,6 @@ pub(super) enum CompileExecResult {
 
 struct PrivateHeaderTrace {
     path: NormalizedPath,
-    kind: PrivateHeaderTraceKind,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum PrivateHeaderTraceKind {
-    DependencyDot,
-    HeaderIncludeFile,
 }
 
 impl Drop for PrivateHeaderTrace {
@@ -96,9 +89,10 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     let pre_exec_ns = compile_start.elapsed().as_nanos() as u64;
     let t_exec = std::time::Instant::now();
     let supports_depfile = compilation.family.supports_depfile();
-    let inject_header_trace = should_inject_header_trace(
+    let inject_header_trace = should_inject_header_trace_for_source(
         dependency_mode,
         compilation.family,
+        source_path.as_path(),
         effective_args,
         dep_flags,
     );
@@ -115,13 +109,12 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     );
     let header_trace_enabled =
         inject_header_trace && matches!(depfile_strategy, DepfileStrategy::InjectedMmd { .. });
-    let private_header_trace_kind =
-        private_clang_header_trace_kind(compilation.family, source_path.as_path(), effective_args);
-    let private_header_trace = if header_trace_enabled && private_header_trace_kind.is_some() {
+    let private_header_trace = if header_trace_enabled
+        && use_private_clang_header_trace(compilation.family, source_path.as_path(), effective_args)
+    {
         Some(prepare_private_clang_header_trace(
             &mut extra_args,
             &mut depfile_strategy,
-            private_header_trace_kind.expect("checked above"),
         ))
     } else {
         None
@@ -441,22 +434,11 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         (output.stdout, None, output.stderr)
     };
     let dependency_scan = if let Some(trace) = private_header_trace.as_ref() {
-        let scan = match trace.kind {
-            PrivateHeaderTraceKind::DependencyDot => {
-                crate::depgraph::header_trace::parse_dependency_graph_file(
-                    trace.path.as_path(),
-                    source_path,
-                    cwd_path,
-                )
-            }
-            PrivateHeaderTraceKind::HeaderIncludeFile => {
-                crate::depgraph::header_trace::parse_header_include_file(
-                    trace.path.as_path(),
-                    source_path,
-                    cwd_path,
-                )
-            }
-        };
+        let scan = crate::depgraph::header_trace::parse_dependency_graph_file(
+            trace.path.as_path(),
+            source_path,
+            cwd_path,
+        );
         Some(scan)
     } else {
         dependency_scan
@@ -497,7 +479,6 @@ fn header_trace_path(depfile: &NormalizedPath) -> NormalizedPath {
 fn prepare_private_clang_header_trace(
     extra_args: &mut Vec<String>,
     depfile_strategy: &mut DepfileStrategy,
-    kind: PrivateHeaderTraceKind,
 ) -> PrivateHeaderTrace {
     let DepfileStrategy::InjectedMmd { path } =
         std::mem::replace(depfile_strategy, DepfileStrategy::CompilerTrace)
@@ -506,65 +487,50 @@ fn prepare_private_clang_header_trace(
     };
     let trace = PrivateHeaderTrace {
         path: header_trace_path(&path),
-        kind,
     };
-    // Each private trace is complete on its own, so no second manifest is
-    // needed. C keeps the compact dependency graph; C++ avoids building that
-    // graph and writes Clang's flat include stream instead (#1511).
+    // Clang's dependency graph includes system headers without the
+    // `-sys-header-deps` switch that makes the compact MMD path expensive.
+    // It is complete on its own, so no second manifest is needed.
     extra_args.clear();
-    match kind {
-        PrivateHeaderTraceKind::DependencyDot => extra_args.extend([
-            "-Xclang".to_string(),
-            "-dependency-dot".to_string(),
-            "-Xclang".to_string(),
-            trace.path.to_string_lossy().into_owned(),
-        ]),
-        PrivateHeaderTraceKind::HeaderIncludeFile => extra_args.extend([
-            "-Xclang".to_string(),
-            "-header-include-file".to_string(),
-            "-Xclang".to_string(),
-            trace.path.to_string_lossy().into_owned(),
-            "-Xclang".to_string(),
-            "-sys-header-deps".to_string(),
-        ]),
-    }
+    extra_args.extend([
+        "-Xclang".to_string(),
+        "-dependency-dot".to_string(),
+        "-Xclang".to_string(),
+        trace.path.to_string_lossy().into_owned(),
+    ]);
     trace
 }
 
-/// Clang's file-backed frontend trace avoids `-H` stderr traffic on C and C++
-/// misses while retaining system-header correctness. Restrict it to source
-/// extensions whose language is unambiguous; explicit `-x`, sysroots, and
-/// caller-owned private tracing keep the public fallback.
-fn private_clang_header_trace_kind(
+/// Clang's file-backed frontend trace avoids `-H` stderr traffic on the hot C
+/// miss path. C++ uses its exact full depfile instead (#1511): it is faster than
+/// both public `-H` and Clang's private trace on the sanctioned C++ fixture.
+fn use_private_clang_header_trace(
     family: crate::compiler::CompilerFamily,
     source: &Path,
     args: &[String],
-) -> Option<PrivateHeaderTraceKind> {
-    let extension = source
-        .extension()
-        .and_then(std::ffi::OsStr::to_str)
-        .map(str::to_ascii_lowercase)?;
-    if family != crate::compiler::CompilerFamily::Clang
-        || !matches!(
-            extension.as_str(),
-            "c" | "cc" | "cp" | "cpp" | "cxx" | "c++"
-        )
-        || args.iter().any(|arg| {
+) -> bool {
+    family == crate::compiler::CompilerFamily::Clang
+        && source.extension().is_some_and(|extension| extension == "c")
+        && !args.iter().any(|arg| {
             arg == "-x"
                 || arg.starts_with("-x")
                 || contains_private_header_trace_flag(arg)
                 || contains_sysroot_flag(arg)
         })
-    {
-        return None;
+}
+
+fn use_full_clang_depfile_for_cpp(family: crate::compiler::CompilerFamily, source: &Path) -> bool {
+    if family != crate::compiler::CompilerFamily::Clang {
+        return false;
     }
-    Some(
-        if extension == "c" && source.extension() != Some(std::ffi::OsStr::new("C")) {
-            PrivateHeaderTraceKind::DependencyDot
-        } else {
-            PrivateHeaderTraceKind::HeaderIncludeFile
-        },
-    )
+    let Some(extension) = source.extension().and_then(std::ffi::OsStr::to_str) else {
+        return false;
+    };
+    extension == "C"
+        || matches!(
+            extension.to_ascii_lowercase().as_str(),
+            "cc" | "cp" | "cpp" | "cxx" | "c++"
+        )
 }
 
 fn contains_private_header_trace_flag(arg: &str) -> bool {
@@ -626,11 +592,23 @@ fn should_inject_header_trace(
         && header_trace_is_supported(family, args)
 }
 
+fn should_inject_header_trace_for_source(
+    dependency_mode: DependencyDiscoveryMode,
+    family: crate::compiler::CompilerFamily,
+    source: &Path,
+    args: &[String],
+    dep_flags: &UserDepFlags,
+) -> bool {
+    should_inject_header_trace(dependency_mode, family, args, dep_flags)
+        && !use_full_clang_depfile_for_cpp(family, source)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        header_trace_is_supported, prepare_private_clang_header_trace,
-        private_clang_header_trace_kind, should_inject_header_trace, PrivateHeaderTraceKind,
+        header_trace_is_supported, prepare_private_clang_header_trace, should_inject_header_trace,
+        should_inject_header_trace_for_source, use_full_clang_depfile_for_cpp,
+        use_private_clang_header_trace,
     };
     use crate::compiler::CompilerFamily;
     use crate::daemon::server::dependency_policy::DependencyDiscoveryMode;
@@ -718,55 +696,37 @@ mod tests {
     }
 
     #[test]
-    fn private_clang_trace_covers_plain_c_and_cpp_translation_units() {
-        assert_eq!(
-            private_clang_header_trace_kind(
-                CompilerFamily::Clang,
-                std::path::Path::new("main.c"),
-                &args(&["-c", "main.c"]),
-            ),
-            Some(PrivateHeaderTraceKind::DependencyDot)
-        );
-        assert_eq!(
-            private_clang_header_trace_kind(
-                CompilerFamily::Clang,
-                std::path::Path::new("main.cpp"),
-                &args(&["-c", "main.cpp"]),
-            ),
-            Some(PrivateHeaderTraceKind::HeaderIncludeFile)
-        );
-        assert_eq!(
-            private_clang_header_trace_kind(
-                CompilerFamily::Clang,
-                std::path::Path::new("main.C"),
-                &args(&["-c", "main.C"]),
-            ),
-            Some(PrivateHeaderTraceKind::HeaderIncludeFile)
-        );
-        assert_eq!(
-            private_clang_header_trace_kind(
-                CompilerFamily::Clang,
-                std::path::Path::new("main.cxx"),
-                &args(&["-c", "main.cxx"]),
-            ),
-            Some(PrivateHeaderTraceKind::HeaderIncludeFile)
-        );
-        assert_eq!(
-            private_clang_header_trace_kind(
-                CompilerFamily::Clang,
-                std::path::Path::new("main.c"),
-                &args(&["-x", "c++", "-c", "main.c"]),
-            ),
-            None
-        );
-        assert_eq!(
-            private_clang_header_trace_kind(
-                CompilerFamily::Gcc,
-                std::path::Path::new("main.c"),
-                &args(&["-c", "main.c"]),
-            ),
-            None
-        );
+    fn private_clang_trace_is_bounded_to_plain_c_translation_units() {
+        assert!(use_private_clang_header_trace(
+            CompilerFamily::Clang,
+            std::path::Path::new("main.c"),
+            &args(&["-c", "main.c"]),
+        ));
+        assert!(!use_private_clang_header_trace(
+            CompilerFamily::Clang,
+            std::path::Path::new("main.cpp"),
+            &args(&["-c", "main.cpp"]),
+        ));
+        assert!(!use_private_clang_header_trace(
+            CompilerFamily::Clang,
+            std::path::Path::new("main.C"),
+            &args(&["-c", "main.C"]),
+        ));
+        assert!(!use_private_clang_header_trace(
+            CompilerFamily::Clang,
+            std::path::Path::new("main.cxx"),
+            &args(&["-c", "main.cxx"]),
+        ));
+        assert!(!use_private_clang_header_trace(
+            CompilerFamily::Clang,
+            std::path::Path::new("main.c"),
+            &args(&["-x", "c++", "-c", "main.c"]),
+        ));
+        assert!(!use_private_clang_header_trace(
+            CompilerFamily::Gcc,
+            std::path::Path::new("main.c"),
+            &args(&["-c", "main.c"]),
+        ));
         for incompatible in [
             "-Xclang=-header-include-file",
             "-Xclang=-sys-header-deps",
@@ -782,15 +742,45 @@ mod tests {
             "-Wp,-isysroot,/sdk",
             "-Wp,--sysroot,/sdk",
         ] {
-            assert_eq!(
-                private_clang_header_trace_kind(
-                    CompilerFamily::Clang,
-                    std::path::Path::new("main.c"),
-                    &args(&["-c", "main.c", incompatible]),
-                ),
-                None
-            );
+            assert!(!use_private_clang_header_trace(
+                CompilerFamily::Clang,
+                std::path::Path::new("main.c"),
+                &args(&["-c", "main.c", incompatible]),
+            ));
         }
+    }
+
+    #[test]
+    fn plain_clang_cpp_uses_exact_full_depfile_without_header_trace() {
+        let dep_flags = UserDepFlags::default();
+        for source in ["main.cc", "main.cpp", "main.cxx", "main.c++", "main.C"] {
+            assert!(use_full_clang_depfile_for_cpp(
+                CompilerFamily::Clang,
+                std::path::Path::new(source),
+            ));
+            assert!(!should_inject_header_trace_for_source(
+                DependencyDiscoveryMode::AllHeaders,
+                CompilerFamily::Clang,
+                std::path::Path::new(source),
+                &args(&["-c", source]),
+                &dep_flags,
+            ));
+        }
+        assert!(!use_full_clang_depfile_for_cpp(
+            CompilerFamily::Clang,
+            std::path::Path::new("main.c"),
+        ));
+        assert!(should_inject_header_trace_for_source(
+            DependencyDiscoveryMode::AllHeaders,
+            CompilerFamily::Clang,
+            std::path::Path::new("main.c"),
+            &args(&["-c", "main.c"]),
+            &dep_flags,
+        ));
+        assert!(!use_full_clang_depfile_for_cpp(
+            CompilerFamily::Gcc,
+            std::path::Path::new("main.cpp"),
+        ));
     }
 
     #[test]
@@ -802,11 +792,7 @@ mod tests {
             path: depfile.into(),
         };
 
-        let trace = prepare_private_clang_header_trace(
-            &mut extra_args,
-            &mut strategy,
-            PrivateHeaderTraceKind::DependencyDot,
-        );
+        let trace = prepare_private_clang_header_trace(&mut extra_args, &mut strategy);
 
         assert_eq!(strategy, crate::depgraph::DepfileStrategy::CompilerTrace);
         assert!(!extra_args.iter().any(|arg| arg == "-MMD" || arg == "-MF"));

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -50,6 +50,13 @@ pub(super) enum CompileExecResult {
 
 struct PrivateHeaderTrace {
     path: NormalizedPath,
+    kind: PrivateHeaderTraceKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PrivateHeaderTraceKind {
+    DependencyDot,
+    HeaderIncludeFile,
 }
 
 impl Drop for PrivateHeaderTrace {
@@ -108,12 +115,13 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     );
     let header_trace_enabled =
         inject_header_trace && matches!(depfile_strategy, DepfileStrategy::InjectedMmd { .. });
-    let private_header_trace = if header_trace_enabled
-        && use_private_clang_header_trace(compilation.family, source_path.as_path(), effective_args)
-    {
+    let private_header_trace_kind =
+        private_clang_header_trace_kind(compilation.family, source_path.as_path(), effective_args);
+    let private_header_trace = if header_trace_enabled && private_header_trace_kind.is_some() {
         Some(prepare_private_clang_header_trace(
             &mut extra_args,
             &mut depfile_strategy,
+            private_header_trace_kind.expect("checked above"),
         ))
     } else {
         None
@@ -433,11 +441,22 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         (output.stdout, None, output.stderr)
     };
     let dependency_scan = if let Some(trace) = private_header_trace.as_ref() {
-        let scan = crate::depgraph::header_trace::parse_dependency_graph_file(
-            trace.path.as_path(),
-            source_path,
-            cwd_path,
-        );
+        let scan = match trace.kind {
+            PrivateHeaderTraceKind::DependencyDot => {
+                crate::depgraph::header_trace::parse_dependency_graph_file(
+                    trace.path.as_path(),
+                    source_path,
+                    cwd_path,
+                )
+            }
+            PrivateHeaderTraceKind::HeaderIncludeFile => {
+                crate::depgraph::header_trace::parse_header_include_file(
+                    trace.path.as_path(),
+                    source_path,
+                    cwd_path,
+                )
+            }
+        };
         Some(scan)
     } else {
         dependency_scan
@@ -478,6 +497,7 @@ fn header_trace_path(depfile: &NormalizedPath) -> NormalizedPath {
 fn prepare_private_clang_header_trace(
     extra_args: &mut Vec<String>,
     depfile_strategy: &mut DepfileStrategy,
+    kind: PrivateHeaderTraceKind,
 ) -> PrivateHeaderTrace {
     let DepfileStrategy::InjectedMmd { path } =
         std::mem::replace(depfile_strategy, DepfileStrategy::CompilerTrace)
@@ -486,17 +506,28 @@ fn prepare_private_clang_header_trace(
     };
     let trace = PrivateHeaderTrace {
         path: header_trace_path(&path),
+        kind,
     };
-    // Clang's dependency graph includes system headers without the
-    // `-sys-header-deps` switch that makes the compact MMD path expensive.
-    // It is complete on its own, so no second manifest is needed.
+    // Each private trace is complete on its own, so no second manifest is
+    // needed. C keeps the compact dependency graph; C++ avoids building that
+    // graph and writes Clang's flat include stream instead (#1511).
     extra_args.clear();
-    extra_args.extend([
-        "-Xclang".to_string(),
-        "-dependency-dot".to_string(),
-        "-Xclang".to_string(),
-        trace.path.to_string_lossy().into_owned(),
-    ]);
+    match kind {
+        PrivateHeaderTraceKind::DependencyDot => extra_args.extend([
+            "-Xclang".to_string(),
+            "-dependency-dot".to_string(),
+            "-Xclang".to_string(),
+            trace.path.to_string_lossy().into_owned(),
+        ]),
+        PrivateHeaderTraceKind::HeaderIncludeFile => extra_args.extend([
+            "-Xclang".to_string(),
+            "-header-include-file".to_string(),
+            "-Xclang".to_string(),
+            trace.path.to_string_lossy().into_owned(),
+            "-Xclang".to_string(),
+            "-sys-header-deps".to_string(),
+        ]),
+    }
     trace
 }
 
@@ -504,28 +535,36 @@ fn prepare_private_clang_header_trace(
 /// misses while retaining system-header correctness. Restrict it to source
 /// extensions whose language is unambiguous; explicit `-x`, sysroots, and
 /// caller-owned private tracing keep the public fallback.
-fn use_private_clang_header_trace(
+fn private_clang_header_trace_kind(
     family: crate::compiler::CompilerFamily,
     source: &Path,
     args: &[String],
-) -> bool {
-    let supported_source = source
+) -> Option<PrivateHeaderTraceKind> {
+    let extension = source
         .extension()
         .and_then(std::ffi::OsStr::to_str)
-        .is_some_and(|extension| {
-            matches!(
-                extension.to_ascii_lowercase().as_str(),
-                "c" | "cc" | "cp" | "cpp" | "cxx" | "c++"
-            )
-        });
-    family == crate::compiler::CompilerFamily::Clang
-        && supported_source
-        && !args.iter().any(|arg| {
+        .map(str::to_ascii_lowercase)?;
+    if family != crate::compiler::CompilerFamily::Clang
+        || !matches!(
+            extension.as_str(),
+            "c" | "cc" | "cp" | "cpp" | "cxx" | "c++"
+        )
+        || args.iter().any(|arg| {
             arg == "-x"
                 || arg.starts_with("-x")
                 || contains_private_header_trace_flag(arg)
                 || contains_sysroot_flag(arg)
         })
+    {
+        return None;
+    }
+    Some(
+        if extension == "c" && source.extension() != Some(std::ffi::OsStr::new("C")) {
+            PrivateHeaderTraceKind::DependencyDot
+        } else {
+            PrivateHeaderTraceKind::HeaderIncludeFile
+        },
+    )
 }
 
 fn contains_private_header_trace_flag(arg: &str) -> bool {
@@ -590,8 +629,8 @@ fn should_inject_header_trace(
 #[cfg(test)]
 mod tests {
     use super::{
-        header_trace_is_supported, prepare_private_clang_header_trace, should_inject_header_trace,
-        use_private_clang_header_trace,
+        header_trace_is_supported, prepare_private_clang_header_trace,
+        private_clang_header_trace_kind, should_inject_header_trace, PrivateHeaderTraceKind,
     };
     use crate::compiler::CompilerFamily;
     use crate::daemon::server::dependency_policy::DependencyDiscoveryMode;
@@ -680,36 +719,54 @@ mod tests {
 
     #[test]
     fn private_clang_trace_covers_plain_c_and_cpp_translation_units() {
-        assert!(use_private_clang_header_trace(
-            CompilerFamily::Clang,
-            std::path::Path::new("main.c"),
-            &args(&["-c", "main.c"]),
-        ));
-        assert!(use_private_clang_header_trace(
-            CompilerFamily::Clang,
-            std::path::Path::new("main.cpp"),
-            &args(&["-c", "main.cpp"]),
-        ));
-        assert!(use_private_clang_header_trace(
-            CompilerFamily::Clang,
-            std::path::Path::new("main.C"),
-            &args(&["-c", "main.C"]),
-        ));
-        assert!(use_private_clang_header_trace(
-            CompilerFamily::Clang,
-            std::path::Path::new("main.cxx"),
-            &args(&["-c", "main.cxx"]),
-        ));
-        assert!(!use_private_clang_header_trace(
-            CompilerFamily::Clang,
-            std::path::Path::new("main.c"),
-            &args(&["-x", "c++", "-c", "main.c"]),
-        ));
-        assert!(!use_private_clang_header_trace(
-            CompilerFamily::Gcc,
-            std::path::Path::new("main.c"),
-            &args(&["-c", "main.c"]),
-        ));
+        assert_eq!(
+            private_clang_header_trace_kind(
+                CompilerFamily::Clang,
+                std::path::Path::new("main.c"),
+                &args(&["-c", "main.c"]),
+            ),
+            Some(PrivateHeaderTraceKind::DependencyDot)
+        );
+        assert_eq!(
+            private_clang_header_trace_kind(
+                CompilerFamily::Clang,
+                std::path::Path::new("main.cpp"),
+                &args(&["-c", "main.cpp"]),
+            ),
+            Some(PrivateHeaderTraceKind::HeaderIncludeFile)
+        );
+        assert_eq!(
+            private_clang_header_trace_kind(
+                CompilerFamily::Clang,
+                std::path::Path::new("main.C"),
+                &args(&["-c", "main.C"]),
+            ),
+            Some(PrivateHeaderTraceKind::HeaderIncludeFile)
+        );
+        assert_eq!(
+            private_clang_header_trace_kind(
+                CompilerFamily::Clang,
+                std::path::Path::new("main.cxx"),
+                &args(&["-c", "main.cxx"]),
+            ),
+            Some(PrivateHeaderTraceKind::HeaderIncludeFile)
+        );
+        assert_eq!(
+            private_clang_header_trace_kind(
+                CompilerFamily::Clang,
+                std::path::Path::new("main.c"),
+                &args(&["-x", "c++", "-c", "main.c"]),
+            ),
+            None
+        );
+        assert_eq!(
+            private_clang_header_trace_kind(
+                CompilerFamily::Gcc,
+                std::path::Path::new("main.c"),
+                &args(&["-c", "main.c"]),
+            ),
+            None
+        );
         for incompatible in [
             "-Xclang=-header-include-file",
             "-Xclang=-sys-header-deps",
@@ -725,11 +782,14 @@ mod tests {
             "-Wp,-isysroot,/sdk",
             "-Wp,--sysroot,/sdk",
         ] {
-            assert!(!use_private_clang_header_trace(
-                CompilerFamily::Clang,
-                std::path::Path::new("main.c"),
-                &args(&["-c", "main.c", incompatible]),
-            ));
+            assert_eq!(
+                private_clang_header_trace_kind(
+                    CompilerFamily::Clang,
+                    std::path::Path::new("main.c"),
+                    &args(&["-c", "main.c", incompatible]),
+                ),
+                None
+            );
         }
     }
 
@@ -742,7 +802,11 @@ mod tests {
             path: depfile.into(),
         };
 
-        let trace = prepare_private_clang_header_trace(&mut extra_args, &mut strategy);
+        let trace = prepare_private_clang_header_trace(
+            &mut extra_args,
+            &mut strategy,
+            PrivateHeaderTraceKind::DependencyDot,
+        );
 
         assert_eq!(strategy, crate::depgraph::DepfileStrategy::CompilerTrace);
         assert!(!extra_args.iter().any(|arg| arg == "-MMD" || arg == "-MF"));

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -500,17 +500,26 @@ fn prepare_private_clang_header_trace(
     trace
 }
 
-/// Clang's file-backed frontend trace avoids `-H` stderr traffic on the hot C
-/// miss path. Keep it deliberately narrower than the rejected all-language
-/// candidate: C++ continues to use the public trace because its much larger
-/// header graph previously made the private path exceed the hosted watchdog.
+/// Clang's file-backed frontend trace avoids `-H` stderr traffic on C and C++
+/// misses while retaining system-header correctness. Restrict it to source
+/// extensions whose language is unambiguous; explicit `-x`, sysroots, and
+/// caller-owned private tracing keep the public fallback.
 fn use_private_clang_header_trace(
     family: crate::compiler::CompilerFamily,
     source: &Path,
     args: &[String],
 ) -> bool {
+    let supported_source = source
+        .extension()
+        .and_then(std::ffi::OsStr::to_str)
+        .is_some_and(|extension| {
+            matches!(
+                extension.to_ascii_lowercase().as_str(),
+                "c" | "cc" | "cp" | "cpp" | "cxx" | "c++"
+            )
+        });
     family == crate::compiler::CompilerFamily::Clang
-        && source.extension().is_some_and(|extension| extension == "c")
+        && supported_source
         && !args.iter().any(|arg| {
             arg == "-x"
                 || arg.starts_with("-x")
@@ -670,21 +679,26 @@ mod tests {
     }
 
     #[test]
-    fn private_clang_trace_is_bounded_to_plain_c_translation_units() {
+    fn private_clang_trace_covers_plain_c_and_cpp_translation_units() {
         assert!(use_private_clang_header_trace(
             CompilerFamily::Clang,
             std::path::Path::new("main.c"),
             &args(&["-c", "main.c"]),
         ));
-        assert!(!use_private_clang_header_trace(
+        assert!(use_private_clang_header_trace(
             CompilerFamily::Clang,
             std::path::Path::new("main.cpp"),
             &args(&["-c", "main.cpp"]),
         ));
-        assert!(!use_private_clang_header_trace(
+        assert!(use_private_clang_header_trace(
             CompilerFamily::Clang,
             std::path::Path::new("main.C"),
             &args(&["-c", "main.C"]),
+        ));
+        assert!(use_private_clang_header_trace(
+            CompilerFamily::Clang,
+            std::path::Path::new("main.cxx"),
+            &args(&["-c", "main.cxx"]),
         ));
         assert!(!use_private_clang_header_trace(
             CompilerFamily::Clang,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -487,6 +487,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
     // second copy/hash publication on the response path.
     let staged_cc_materialized = if !is_rustc { staged_plan.take() } else { None };
     let mut staged_cc_materialization = None;
+    let mut staged_materialization_ns = 0;
     if let Some(plan) = staged_cc_materialized {
         use crate::daemon::staged_stats::{
             StagedBytes, StagedCounter, StagedFailure, StagedTiming,
@@ -494,6 +495,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         let started = std::time::Instant::now();
         match plan.materialize() {
             Ok(materialized) => {
+                staged_materialization_ns = started.elapsed().as_nanos() as u64;
                 state.profiler.staged.add_count(
                     StagedCounter::MaterializeReflink,
                     materialized.reflink_count,
@@ -506,15 +508,16 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
                     .profiler
                     .staged
                     .bytes(StagedBytes::Materialization, materialized.copy_bytes);
-                state.profiler.staged.timing(
-                    StagedTiming::MissMaterialization,
-                    started.elapsed().as_nanos() as u64,
-                );
+                state
+                    .profiler
+                    .staged
+                    .timing(StagedTiming::MissMaterialization, staged_materialization_ns);
                 compiler_output_path = output_path.clone();
                 state.cache_system.apply_changes(vec![output_path.clone()]);
                 staged_cc_materialization = Some(());
             }
             Err(error) => {
+                staged_materialization_ns = started.elapsed().as_nanos() as u64;
                 state
                     .profiler
                     .staged
@@ -523,10 +526,10 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
                     .profiler
                     .staged
                     .failure(StagedFailure::RequestedMaterialization);
-                state.profiler.staged.timing(
-                    StagedTiming::MissMaterialization,
-                    started.elapsed().as_nanos() as u64,
-                );
+                state
+                    .profiler
+                    .staged
+                    .timing(StagedTiming::MissMaterialization, staged_materialization_ns);
                 return Some(Response::Error {
                     message: format!("failed to materialize compiler output: {error}"),
                 });
@@ -545,6 +548,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
             let started = std::time::Instant::now();
             match plan.materialize_without_cleanup() {
                 Ok(materialized) => {
+                    staged_materialization_ns = started.elapsed().as_nanos() as u64;
                     state.profiler.staged.add_count(
                         StagedCounter::MaterializeReflink,
                         materialized.reflink_count,
@@ -557,15 +561,16 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
                         .profiler
                         .staged
                         .bytes(StagedBytes::Materialization, materialized.copy_bytes);
-                    state.profiler.staged.timing(
-                        StagedTiming::MissMaterialization,
-                        started.elapsed().as_nanos() as u64,
-                    );
+                    state
+                        .profiler
+                        .staged
+                        .timing(StagedTiming::MissMaterialization, staged_materialization_ns);
                     compiler_output_path = output_path.clone();
                     state.cache_system.apply_changes(vec![output_path.clone()]);
                     Some(plan)
                 }
                 Err(error) => {
+                    staged_materialization_ns = started.elapsed().as_nanos() as u64;
                     state
                         .profiler
                         .staged
@@ -574,10 +579,10 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
                         .profiler
                         .staged
                         .failure(StagedFailure::RequestedMaterialization);
-                    state.profiler.staged.timing(
-                        StagedTiming::MissMaterialization,
-                        started.elapsed().as_nanos() as u64,
-                    );
+                    state
+                        .profiler
+                        .staged
+                        .timing(StagedTiming::MissMaterialization, staged_materialization_ns);
                     return Some(Response::Error {
                         message: format!("failed to materialize compiler output: {error}"),
                     });
@@ -732,6 +737,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
             post_exec_ns,
             apply_changes_ns,
             collect_outputs_ns,
+            staged_materialization_ns,
             rust_output_count,
             rust_output_bytes,
             include_scan_ns,

--- a/crates/zccache-depgraph/src/header_trace.rs
+++ b/crates/zccache-depgraph/src/header_trace.rs
@@ -173,6 +173,50 @@ pub fn parse_header_trace(stderr: &[u8], source: &Path, cwd: &Path) -> (ScanResu
     (parser.finish(&mut filtered), filtered)
 }
 
+/// Parse Clang's private `-header-include-file` output.
+///
+/// The file contains one compiler-opened header path per line. Pairing it with
+/// `-sys-header-deps` retains the same user + system header set as `-H` without
+/// routing trace records through the diagnostic stream or constructing a DOT
+/// graph. Missing, overlong, or malformed records fail closed.
+#[must_use]
+pub fn parse_header_include_file(path: &Path, source: &Path, cwd: &Path) -> ScanResult {
+    use std::io::BufRead as _;
+
+    let mut parser = HeaderTraceParser::new(source, cwd);
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(_) => {
+            parser.incomplete = true;
+            return parser.finish(&mut Vec::new());
+        }
+    };
+    let mut reader = std::io::BufReader::new(file);
+    let mut line = Vec::new();
+    loop {
+        line.clear();
+        match reader.read_until(b'\n', &mut line) {
+            Ok(0) => break,
+            Ok(_) => {
+                if line.len() > MAX_PARTIAL_LINE_BYTES {
+                    parser.incomplete = true;
+                    continue;
+                }
+                let record = line.strip_suffix(b"\n").unwrap_or(&line);
+                let record = record.strip_suffix(b"\r").unwrap_or(record);
+                if record.is_empty() || !parser.record_path_bytes(record) {
+                    parser.incomplete = true;
+                }
+            }
+            Err(_) => {
+                parser.incomplete = true;
+                break;
+            }
+        }
+    }
+    parser.finish(&mut Vec::new())
+}
+
 /// Parse Clang's private `-dependency-dot` output.
 ///
 /// This sink contains compiler-selected user and system headers without
@@ -331,6 +375,39 @@ fn resolve_dependency_graph_path(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_private_header_include_file_with_system_paths() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source = temp.path().join("main.cpp");
+        let user = temp.path().join("user.hpp");
+        let system = temp.path().join("system.hpp");
+        let trace = temp.path().join("headers.txt");
+        std::fs::write(&source, "").unwrap();
+        std::fs::write(&user, "").unwrap();
+        std::fs::write(&system, "").unwrap();
+        std::fs::write(
+            &trace,
+            format!(
+                "{}\n{}\n{}\n",
+                user.display(),
+                system.display(),
+                user.display()
+            ),
+        )
+        .unwrap();
+
+        let scan = parse_header_include_file(&trace, &source, temp.path());
+
+        assert_eq!(
+            scan.resolved,
+            vec![
+                crate::depfile::canonicalize_path(&user, temp.path()),
+                crate::depfile::canonicalize_path(&system, temp.path()),
+            ]
+        );
+        assert!(!scan.has_computed);
+    }
 
     #[test]
     fn parses_paths_with_spaces_and_preserves_diagnostics() {

--- a/crates/zccache-depgraph/src/header_trace.rs
+++ b/crates/zccache-depgraph/src/header_trace.rs
@@ -173,50 +173,6 @@ pub fn parse_header_trace(stderr: &[u8], source: &Path, cwd: &Path) -> (ScanResu
     (parser.finish(&mut filtered), filtered)
 }
 
-/// Parse Clang's private `-header-include-file` output.
-///
-/// The file contains one compiler-opened header path per line. Pairing it with
-/// `-sys-header-deps` retains the same user + system header set as `-H` without
-/// routing trace records through the diagnostic stream or constructing a DOT
-/// graph. Missing, overlong, or malformed records fail closed.
-#[must_use]
-pub fn parse_header_include_file(path: &Path, source: &Path, cwd: &Path) -> ScanResult {
-    use std::io::BufRead as _;
-
-    let mut parser = HeaderTraceParser::new(source, cwd);
-    let file = match std::fs::File::open(path) {
-        Ok(file) => file,
-        Err(_) => {
-            parser.incomplete = true;
-            return parser.finish(&mut Vec::new());
-        }
-    };
-    let mut reader = std::io::BufReader::new(file);
-    let mut line = Vec::new();
-    loop {
-        line.clear();
-        match reader.read_until(b'\n', &mut line) {
-            Ok(0) => break,
-            Ok(_) => {
-                if line.len() > MAX_PARTIAL_LINE_BYTES {
-                    parser.incomplete = true;
-                    continue;
-                }
-                let record = line.strip_suffix(b"\n").unwrap_or(&line);
-                let record = record.strip_suffix(b"\r").unwrap_or(record);
-                if record.is_empty() || !parser.record_path_bytes(record) {
-                    parser.incomplete = true;
-                }
-            }
-            Err(_) => {
-                parser.incomplete = true;
-                break;
-            }
-        }
-    }
-    parser.finish(&mut Vec::new())
-}
-
 /// Parse Clang's private `-dependency-dot` output.
 ///
 /// This sink contains compiler-selected user and system headers without
@@ -375,39 +331,6 @@ fn resolve_dependency_graph_path(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parses_private_header_include_file_with_system_paths() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let source = temp.path().join("main.cpp");
-        let user = temp.path().join("user.hpp");
-        let system = temp.path().join("system.hpp");
-        let trace = temp.path().join("headers.txt");
-        std::fs::write(&source, "").unwrap();
-        std::fs::write(&user, "").unwrap();
-        std::fs::write(&system, "").unwrap();
-        std::fs::write(
-            &trace,
-            format!(
-                "{}\n{}\n{}\n",
-                user.display(),
-                system.display(),
-                user.display()
-            ),
-        )
-        .unwrap();
-
-        let scan = parse_header_include_file(&trace, &source, temp.path());
-
-        assert_eq!(
-            scan.resolved,
-            vec![
-                crate::depfile::canonicalize_path(&user, temp.path()),
-                crate::depfile::canonicalize_path(&system, temp.path()),
-            ]
-        );
-        assert!(!scan.has_computed);
-    }
 
     #[test]
     fn parses_paths_with_spaces_and_preserves_diagnostics() {

--- a/crates/zccache-ipc/Cargo.toml
+++ b/crates/zccache-ipc/Cargo.toml
@@ -23,7 +23,6 @@ prost = { workspace = true }
 running-process = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["tracing"] }
 tracing = { workspace = true }

--- a/crates/zccache-ipc/Cargo.toml
+++ b/crates/zccache-ipc/Cargo.toml
@@ -15,6 +15,7 @@ zccache-core = { workspace = true }
 zccache-platform = { workspace = true }
 zccache-protocol = { workspace = true }
 
+blake3 = { workspace = true }
 bytes = { workspace = true }
 dashmap = { workspace = true }
 interprocess = "2.4.2"

--- a/crates/zccache-ipc/Cargo.toml
+++ b/crates/zccache-ipc/Cargo.toml
@@ -15,7 +15,7 @@ zccache-core = { workspace = true }
 zccache-platform = { workspace = true }
 zccache-protocol = { workspace = true }
 
-blake3 = { workspace = true }
+blake3 = { workspace = true, features = ["mmap"] }
 bytes = { workspace = true }
 dashmap = { workspace = true }
 interprocess = "2.4.2"

--- a/crates/zccache-ipc/Cargo.toml
+++ b/crates/zccache-ipc/Cargo.toml
@@ -22,6 +22,7 @@ prost = { workspace = true }
 running-process = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["tracing"] }
 tracing = { workspace = true }

--- a/crates/zccache-ipc/src/lib.rs
+++ b/crates/zccache-ipc/src/lib.rs
@@ -566,11 +566,11 @@ fn running_process_endpoint_path(endpoint: &str) -> String {
 /// namespace.
 ///
 /// ISSUE-601 / #1511: the identity is keyed by endpoint and cached for the
-/// process lifetime. The first call builds the same running-process wire
-/// identity by streaming both required hashes in one pass instead of
+/// process lifetime. The first call streams the BLAKE3 identity instead of
 /// `DaemonProcess::current_process`, whose `fs::read` temporarily allocated the
-/// full daemon executable. First-call errors still bubble up; only successful
-/// values are inserted, so a transient failure retries on the next call.
+/// full daemon executable and whose legacy SHA-256 duplicated the hashing work.
+/// First-call errors still bubble up; only successful values are inserted, so a
+/// transient failure retries on the next call.
 pub fn current_backend_identity(
     endpoint: &str,
 ) -> Result<
@@ -605,7 +605,7 @@ fn current_process_identity_streaming(
     use running_process::broker::protocol_v2::backend_handle::{DaemonProcess, IdentityError};
 
     let exe_path = std::env::current_exe().map_err(IdentityError::CurrentExe)?;
-    let (exe_hash, legacy_exe_sha256) = executable_hashes_streaming(&exe_path)?;
+    let exe_hash = executable_hash_streaming(&exe_path)?;
     let started_at_unix_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|duration| duration.as_millis() as u64)
@@ -615,7 +615,10 @@ fn current_process_identity_streaming(
         pid: std::process::id(),
         exe_path,
         exe_hash,
-        legacy_exe_sha256,
+        // zccache and current running-process brokers identify executables with
+        // BLAKE3. Keep the required legacy wire slot empty rather than paying
+        // for a second digest used only by pre-BLAKE3 brokers.
+        legacy_exe_sha256: [0; 32],
         boot_id: running_process::broker::host_identity::current().boot_id,
         ipc_endpoint,
         started_at_unix_ms,
@@ -623,13 +626,11 @@ fn current_process_identity_streaming(
     })
 }
 
-fn executable_hashes_streaming(path: &std::path::Path) -> std::io::Result<([u8; 32], [u8; 32])> {
-    use sha2::{Digest as _, Sha256};
+fn executable_hash_streaming(path: &std::path::Path) -> std::io::Result<[u8; 32]> {
     use std::io::Read as _;
 
     let mut file = std::fs::File::open(path)?;
     let mut blake3 = blake3::Hasher::new();
-    let mut sha256 = Sha256::new();
     let mut buffer = [0_u8; IDENTITY_HASH_BUFFER_BYTES];
     loop {
         let read = file.read(&mut buffer)?;
@@ -637,9 +638,8 @@ fn executable_hashes_streaming(path: &std::path::Path) -> std::io::Result<([u8; 
             break;
         }
         blake3.update(&buffer[..read]);
-        sha256.update(&buffer[..read]);
     }
-    Ok((*blake3.finalize().as_bytes(), sha256.finalize().into()))
+    Ok(*blake3.finalize().as_bytes())
 }
 
 /// Persist the daemon identity used by future `BackendHandle` probes.

--- a/crates/zccache-ipc/src/lib.rs
+++ b/crates/zccache-ipc/src/lib.rs
@@ -567,7 +567,7 @@ fn running_process_endpoint_path(endpoint: &str) -> String {
 ///
 /// ISSUE-601 / #1511: the identity is keyed by endpoint and cached for the
 /// process lifetime. The first call builds the same running-process wire
-/// identity with a streaming legacy SHA-256 instead of
+/// identity by streaming both required hashes in one pass instead of
 /// `DaemonProcess::current_process`, whose `fs::read` temporarily allocated the
 /// full daemon executable. First-call errors still bubble up; only successful
 /// values are inserted, so a transient failure retries on the next call.
@@ -605,9 +605,7 @@ fn current_process_identity_streaming(
     use running_process::broker::protocol_v2::backend_handle::{DaemonProcess, IdentityError};
 
     let exe_path = std::env::current_exe().map_err(IdentityError::CurrentExe)?;
-    let exe_hash =
-        running_process::broker::backend_lifecycle::identity::executable_hash_file(&exe_path)?;
-    let legacy_exe_sha256 = sha256_file_streaming(&exe_path)?;
+    let (exe_hash, legacy_exe_sha256) = executable_hashes_streaming(&exe_path)?;
     let started_at_unix_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|duration| duration.as_millis() as u64)
@@ -625,21 +623,23 @@ fn current_process_identity_streaming(
     })
 }
 
-fn sha256_file_streaming(path: &std::path::Path) -> std::io::Result<[u8; 32]> {
+fn executable_hashes_streaming(path: &std::path::Path) -> std::io::Result<([u8; 32], [u8; 32])> {
     use sha2::{Digest as _, Sha256};
     use std::io::Read as _;
 
     let mut file = std::fs::File::open(path)?;
-    let mut hasher = Sha256::new();
+    let mut blake3 = blake3::Hasher::new();
+    let mut sha256 = Sha256::new();
     let mut buffer = [0_u8; IDENTITY_HASH_BUFFER_BYTES];
     loop {
         let read = file.read(&mut buffer)?;
         if read == 0 {
             break;
         }
-        hasher.update(&buffer[..read]);
+        blake3.update(&buffer[..read]);
+        sha256.update(&buffer[..read]);
     }
-    Ok(hasher.finalize().into())
+    Ok((*blake3.finalize().as_bytes(), sha256.finalize().into()))
 }
 
 /// Persist the daemon identity used by future `BackendHandle` probes.

--- a/crates/zccache-ipc/src/lib.rs
+++ b/crates/zccache-ipc/src/lib.rs
@@ -565,16 +565,12 @@ fn running_process_endpoint_path(endpoint: &str) -> String {
 /// Slice 24 of zccache#782: migrated to the `protocol_v2::backend_handle`
 /// namespace.
 ///
-/// ISSUE-601 / Linux Docker profile 2026-06-25: the underlying
-/// `DaemonProcess::current_process` SHA-256-hashes the daemon binary (via
-/// `running_process::broker::backend_lifecycle::identity::sha256_file`). The
-/// flame chart showed that single chain owning **43.06% of on-CPU** because
-/// `DaemonServer::bind` / `bind_with_cache_dir` / `EmbeddedDaemon::start`
-/// were repeatedly recomputing it. The daemon exe is immutable inside a
-/// running process, so the hash is keyed-by-endpoint cached for the process
-/// lifetime here. First-call errors still bubble up; only success values
-/// are inserted into the cache, so a transient failure (e.g. the exe was
-/// briefly unreadable) will retry on the next call.
+/// ISSUE-601 / #1511: the identity is keyed by endpoint and cached for the
+/// process lifetime. The first call builds the same running-process wire
+/// identity with a streaming legacy SHA-256 instead of
+/// `DaemonProcess::current_process`, whose `fs::read` temporarily allocated the
+/// full daemon executable. First-call errors still bubble up; only successful
+/// values are inserted, so a transient failure retries on the next call.
 pub fn current_backend_identity(
     endpoint: &str,
 ) -> Result<
@@ -593,13 +589,57 @@ pub fn current_backend_identity(
         return Ok((**cached).clone());
     }
 
-    let identity =
-        running_process::broker::protocol_v2::backend_handle::DaemonProcess::current_process(
-            running_process_endpoint(endpoint),
-            None,
-        )?;
+    let identity = current_process_identity_streaming(running_process_endpoint(endpoint))?;
     IDENTITY_CACHE.insert(endpoint.to_string(), std::sync::Arc::new(identity.clone()));
     Ok(identity)
+}
+
+const IDENTITY_HASH_BUFFER_BYTES: usize = 64 * 1024;
+
+fn current_process_identity_streaming(
+    ipc_endpoint: running_process::broker::protocol::Endpoint,
+) -> Result<
+    running_process::broker::protocol_v2::backend_handle::DaemonProcess,
+    running_process::broker::protocol_v2::backend_handle::IdentityError,
+> {
+    use running_process::broker::protocol_v2::backend_handle::{DaemonProcess, IdentityError};
+
+    let exe_path = std::env::current_exe().map_err(IdentityError::CurrentExe)?;
+    let exe_hash =
+        running_process::broker::backend_lifecycle::identity::executable_hash_file(&exe_path)?;
+    let legacy_exe_sha256 = sha256_file_streaming(&exe_path)?;
+    let started_at_unix_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0);
+
+    Ok(DaemonProcess {
+        pid: std::process::id(),
+        exe_path,
+        exe_hash,
+        legacy_exe_sha256,
+        boot_id: running_process::broker::host_identity::current().boot_id,
+        ipc_endpoint,
+        started_at_unix_ms,
+        idle_timeout_secs: None,
+    })
+}
+
+fn sha256_file_streaming(path: &std::path::Path) -> std::io::Result<[u8; 32]> {
+    use sha2::{Digest as _, Sha256};
+    use std::io::Read as _;
+
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; IDENTITY_HASH_BUFFER_BYTES];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hasher.finalize().into())
 }
 
 /// Persist the daemon identity used by future `BackendHandle` probes.

--- a/crates/zccache-ipc/src/lib.rs
+++ b/crates/zccache-ipc/src/lib.rs
@@ -589,14 +589,12 @@ pub fn current_backend_identity(
         return Ok((**cached).clone());
     }
 
-    let identity = current_process_identity_streaming(running_process_endpoint(endpoint))?;
+    let identity = current_process_identity_blake3(running_process_endpoint(endpoint))?;
     IDENTITY_CACHE.insert(endpoint.to_string(), std::sync::Arc::new(identity.clone()));
     Ok(identity)
 }
 
-const IDENTITY_HASH_BUFFER_BYTES: usize = 64 * 1024;
-
-fn current_process_identity_streaming(
+fn current_process_identity_blake3(
     ipc_endpoint: running_process::broker::protocol::Endpoint,
 ) -> Result<
     running_process::broker::protocol_v2::backend_handle::DaemonProcess,
@@ -605,7 +603,7 @@ fn current_process_identity_streaming(
     use running_process::broker::protocol_v2::backend_handle::{DaemonProcess, IdentityError};
 
     let exe_path = std::env::current_exe().map_err(IdentityError::CurrentExe)?;
-    let exe_hash = executable_hash_streaming(&exe_path)?;
+    let exe_hash = executable_hash_blake3(&exe_path)?;
     let started_at_unix_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|duration| duration.as_millis() as u64)
@@ -626,20 +624,10 @@ fn current_process_identity_streaming(
     })
 }
 
-fn executable_hash_streaming(path: &std::path::Path) -> std::io::Result<[u8; 32]> {
-    use std::io::Read as _;
-
-    let mut file = std::fs::File::open(path)?;
-    let mut blake3 = blake3::Hasher::new();
-    let mut buffer = [0_u8; IDENTITY_HASH_BUFFER_BYTES];
-    loop {
-        let read = file.read(&mut buffer)?;
-        if read == 0 {
-            break;
-        }
-        blake3.update(&buffer[..read]);
-    }
-    Ok(*blake3.finalize().as_bytes())
+fn executable_hash_blake3(path: &std::path::Path) -> std::io::Result<[u8; 32]> {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update_mmap_rayon(path)?;
+    Ok(*hasher.finalize().as_bytes())
 }
 
 /// Persist the daemon identity used by future `BackendHandle` probes.

--- a/crates/zccache-ipc/src/mod_tests.rs
+++ b/crates/zccache-ipc/src/mod_tests.rs
@@ -6,7 +6,7 @@ use super::test_env::ENV_LOCK;
 use super::*;
 
 #[test]
-fn identity_sha256_streams_files_larger_than_its_fixed_buffer() {
+fn identity_hashes_stream_files_larger_than_their_fixed_buffer() {
     use sha2::{Digest as _, Sha256};
 
     let dir = tempfile::tempdir().unwrap();
@@ -16,10 +16,12 @@ fn identity_sha256_streams_files_larger_than_its_fixed_buffer() {
         .collect();
     std::fs::write(&path, &bytes).unwrap();
 
-    let actual = sha256_file_streaming(&path).unwrap();
-    let expected: [u8; 32] = Sha256::digest(&bytes).into();
+    let (actual_blake3, actual_sha256) = executable_hashes_streaming(&path).unwrap();
+    let expected_blake3 = *blake3::hash(&bytes).as_bytes();
+    let expected_sha256: [u8; 32] = Sha256::digest(&bytes).into();
 
-    assert_eq!(actual, expected);
+    assert_eq!(actual_blake3, expected_blake3);
+    assert_eq!(actual_sha256, expected_sha256);
 }
 use std::ffi::OsString;
 use std::sync::MutexGuard;

--- a/crates/zccache-ipc/src/mod_tests.rs
+++ b/crates/zccache-ipc/src/mod_tests.rs
@@ -4,6 +4,23 @@
 
 use super::test_env::ENV_LOCK;
 use super::*;
+
+#[test]
+fn identity_sha256_streams_files_larger_than_its_fixed_buffer() {
+    use sha2::{Digest as _, Sha256};
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("large-daemon-image");
+    let bytes: Vec<u8> = (0..(IDENTITY_HASH_BUFFER_BYTES * 3 + 17))
+        .map(|index| (index % 251) as u8)
+        .collect();
+    std::fs::write(&path, &bytes).unwrap();
+
+    let actual = sha256_file_streaming(&path).unwrap();
+    let expected: [u8; 32] = Sha256::digest(&bytes).into();
+
+    assert_eq!(actual, expected);
+}
 use std::ffi::OsString;
 use std::sync::MutexGuard;
 

--- a/crates/zccache-ipc/src/mod_tests.rs
+++ b/crates/zccache-ipc/src/mod_tests.rs
@@ -6,15 +6,15 @@ use super::test_env::ENV_LOCK;
 use super::*;
 
 #[test]
-fn identity_blake3_streams_files_larger_than_its_fixed_buffer() {
+fn identity_blake3_mmaps_large_files_without_changing_the_digest() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("large-daemon-image");
-    let bytes: Vec<u8> = (0..(IDENTITY_HASH_BUFFER_BYTES * 3 + 17))
+    let bytes: Vec<u8> = (0..(256 * 1024 + 17))
         .map(|index| (index % 251) as u8)
         .collect();
     std::fs::write(&path, &bytes).unwrap();
 
-    let actual_blake3 = executable_hash_streaming(&path).unwrap();
+    let actual_blake3 = executable_hash_blake3(&path).unwrap();
     let expected_blake3 = *blake3::hash(&bytes).as_bytes();
 
     assert_eq!(actual_blake3, expected_blake3);

--- a/crates/zccache-ipc/src/mod_tests.rs
+++ b/crates/zccache-ipc/src/mod_tests.rs
@@ -6,9 +6,7 @@ use super::test_env::ENV_LOCK;
 use super::*;
 
 #[test]
-fn identity_hashes_stream_files_larger_than_their_fixed_buffer() {
-    use sha2::{Digest as _, Sha256};
-
+fn identity_blake3_streams_files_larger_than_its_fixed_buffer() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("large-daemon-image");
     let bytes: Vec<u8> = (0..(IDENTITY_HASH_BUFFER_BYTES * 3 + 17))
@@ -16,12 +14,10 @@ fn identity_hashes_stream_files_larger_than_their_fixed_buffer() {
         .collect();
     std::fs::write(&path, &bytes).unwrap();
 
-    let (actual_blake3, actual_sha256) = executable_hashes_streaming(&path).unwrap();
+    let actual_blake3 = executable_hash_streaming(&path).unwrap();
     let expected_blake3 = *blake3::hash(&bytes).as_bytes();
-    let expected_sha256: [u8; 32] = Sha256::digest(&bytes).into();
 
     assert_eq!(actual_blake3, expected_blake3);
-    assert_eq!(actual_sha256, expected_sha256);
 }
 use std::ffi::OsString;
 use std::sync::MutexGuard;

--- a/crates/zccache-ipc/src/mod_tests.rs
+++ b/crates/zccache-ipc/src/mod_tests.rs
@@ -4,23 +4,11 @@
 
 use super::test_env::ENV_LOCK;
 use super::*;
-
-#[test]
-fn identity_blake3_mmaps_large_files_without_changing_the_digest() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("large-daemon-image");
-    let bytes: Vec<u8> = (0..(256 * 1024 + 17))
-        .map(|index| (index % 251) as u8)
-        .collect();
-    std::fs::write(&path, &bytes).unwrap();
-
-    let actual_blake3 = executable_hash_blake3(&path).unwrap();
-    let expected_blake3 = *blake3::hash(&bytes).as_bytes();
-
-    assert_eq!(actual_blake3, expected_blake3);
-}
 use std::ffi::OsString;
 use std::sync::MutexGuard;
+
+#[path = "mod_tests/identity.rs"]
+mod identity;
 
 struct EnvGuard {
     _lock: MutexGuard<'static, ()>,
@@ -962,25 +950,6 @@ fn identity_matches_only_the_same_instance() {
         !daemon_identity_matches(&after_reboot),
         "a different boot is a different instance even with identical pid/start"
     );
-}
-
-#[test]
-fn pre_4_10_4_identity_defaults_missing_legacy_digest() {
-    let temp = tempfile::tempdir().unwrap();
-    let _env = EnvGuard::set_cache_dir(temp.path());
-    let expected = fake_identity(4321, 1_700_000_000_000, "boot-a");
-    let mut legacy_json = serde_json::to_value(&expected).unwrap();
-    legacy_json
-        .as_object_mut()
-        .unwrap()
-        .remove("legacy_exe_sha256");
-    let path = backend_identity_path();
-    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-    std::fs::write(&path, serde_json::to_vec_pretty(&legacy_json).unwrap()).unwrap();
-
-    let decoded = read_backend_identity().expect("4.10.3 identity must remain readable");
-    assert_eq!(decoded.legacy_exe_sha256, [0; 32]);
-    assert!(daemon_identity_matches(&expected));
 }
 
 #[test]

--- a/crates/zccache-ipc/src/mod_tests/identity.rs
+++ b/crates/zccache-ipc/src/mod_tests/identity.rs
@@ -1,0 +1,37 @@
+use super::super::executable_hash_blake3;
+use super::{fake_identity, EnvGuard};
+use crate::{backend_identity_path, daemon_identity_matches, read_backend_identity};
+
+#[test]
+fn identity_blake3_mmaps_large_files_without_changing_the_digest() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("large-daemon-image");
+    let bytes: Vec<u8> = (0..(256 * 1024 + 17))
+        .map(|index| (index % 251) as u8)
+        .collect();
+    std::fs::write(&path, &bytes).unwrap();
+
+    let actual_blake3 = executable_hash_blake3(&path).unwrap();
+    let expected_blake3 = *blake3::hash(&bytes).as_bytes();
+
+    assert_eq!(actual_blake3, expected_blake3);
+}
+
+#[test]
+fn pre_4_10_4_identity_defaults_missing_legacy_digest() {
+    let temp = tempfile::tempdir().unwrap();
+    let _env = EnvGuard::set_cache_dir(temp.path());
+    let expected = fake_identity(4321, 1_700_000_000_000, "boot-a");
+    let mut legacy_json = serde_json::to_value(&expected).unwrap();
+    legacy_json
+        .as_object_mut()
+        .unwrap()
+        .remove("legacy_exe_sha256");
+    let path = backend_identity_path();
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, serde_json::to_vec_pretty(&legacy_json).unwrap()).unwrap();
+
+    let decoded = read_backend_identity().expect("4.10.3 identity must remain readable");
+    assert_eq!(decoded.legacy_exe_sha256, [0; 32]);
+    assert!(daemon_identity_matches(&expected));
+}

--- a/crates/zccache-ipc/src/transport/probe.rs
+++ b/crates/zccache-ipc/src/transport/probe.rs
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn probe_reply_leaves_the_legacy_sha256_identity_empty() {
-        let mut daemon = crate::current_process_identity_streaming(Endpoint {
+        let mut daemon = crate::current_process_identity_blake3(Endpoint {
             namespace_id: "zccache-ipc-test".to_owned(),
             path: "zccache-ipc-test.sock".to_owned(),
         })

--- a/crates/zccache-ipc/src/transport/probe.rs
+++ b/crates/zccache-ipc/src/transport/probe.rs
@@ -170,17 +170,12 @@ mod tests {
     }
 
     #[test]
-    fn probe_reply_uses_cached_legacy_sha256_identity() {
-        let mut daemon =
-            running_process::broker::protocol_v2::backend_handle::DaemonProcess::current_process(
-                Endpoint {
-                    namespace_id: "zccache-ipc-test".to_owned(),
-                    path: "zccache-ipc-test.sock".to_owned(),
-                },
-                None,
-            )
-            .expect("current daemon identity");
-        let expected_legacy_sha256 = daemon.legacy_exe_sha256;
+    fn probe_reply_leaves_the_legacy_sha256_identity_empty() {
+        let mut daemon = crate::current_process_identity_streaming(Endpoint {
+            namespace_id: "zccache-ipc-test".to_owned(),
+            path: "zccache-ipc-test.sock".to_owned(),
+        })
+        .expect("current daemon identity");
         daemon.exe_path = std::path::PathBuf::from("missing-after-daemon-start");
         let nonce = vec![0xa5; 32];
         let request = running_process::broker::protocol::Frame {
@@ -193,6 +188,6 @@ mod tests {
             .expect("stable broker decodes probe identity");
 
         assert_eq!(legacy.exe_sha256.len(), 32);
-        assert_eq!(legacy.exe_sha256, expected_legacy_sha256);
+        assert_eq!(legacy.exe_sha256, [0; 32]);
     }
 }

--- a/crates/zccache/tests/daemon_adversarial_mutations.rs
+++ b/crates/zccache/tests/daemon_adversarial_mutations.rs
@@ -406,7 +406,7 @@ async fn mutation_include_path_creates_different_cache_entry() {
 /// dependency: after it changes, the same compile must not restore stale code.
 #[tokio::test]
 #[ignore] // integration: spawns clang, run with --full
-async fn mutation_system_header_forces_miss() {
+async fn mutation_cpp_system_header_forces_miss() {
     let mut h = match TestHarness::new().await {
         Some(h) => h,
         None => return,
@@ -416,8 +416,8 @@ async fn mutation_system_header_forces_miss() {
     let header = system_dir.join("system_value.h");
     std::fs::write(&header, "#define SYSTEM_VALUE 7\n").unwrap();
     h.write_file(
-        "system_header.c",
-        "#include <system_value.h>\nint system_value(void) { return SYSTEM_VALUE; }\n",
+        "system_header.cpp",
+        "#include <system_value.h>\nint system_value() { return SYSTEM_VALUE; }\n",
     );
     let isystem_arg = format!("-isystem{}", system_dir.display());
     let compiler = h.compiler_str();
@@ -425,7 +425,7 @@ async fn mutation_system_header_forces_miss() {
     let object = h.path("system_header.o");
     let args = [
         "-c",
-        "system_header.c",
+        "system_header.cpp",
         "-o",
         "system_header.o",
         isystem_arg.as_str(),

--- a/crates/zccache/tests/perf_bench/mod.rs
+++ b/crates/zccache/tests/perf_bench/mod.rs
@@ -1,6 +1,6 @@
 //! Performance benchmark: warm-cache compilation latency.
 //!
-//! Twelve `#[ignore]` perf benchmarks plus one always-on regression test.
+//! Ignored perf benchmarks plus one always-on regression test.
 //! The test functions are split across submodules but cargo discovers them all
 //! under the same `perf_bench_test` test binary (the thin shim
 //! `tests/perf_bench_test.rs` re-exports this module).

--- a/crates/zccache/tests/perf_bench/tests_cpp.rs
+++ b/crates/zccache/tests/perf_bench/tests_cpp.rs
@@ -399,3 +399,55 @@ async fn perf_warm_cache_zccache_vs_sccache() {
     }
     eprintln!();
 }
+
+/// Minimal cold-miss workload for instruction and allocation profilers.
+///
+/// The comparative benchmark above is the wall-clock authority, but running
+/// all bare/sccache phases under Callgrind can exceed Bosn's command deadline.
+/// This keeps daemon startup, identity hashing, exact dependency discovery,
+/// and one successful C++ miss while omitting unrelated comparison phases.
+#[tokio::test]
+#[ignore]
+async fn profile_single_cpp_cold_miss() {
+    let Some(compiler_path) = zccache::test_support::find_clang() else {
+        eprintln!("SKIP: no C++ compiler found");
+        return;
+    };
+    let compiler = compiler_path.to_string_lossy().into_owned();
+    let project = zccache::test_support::temp_cache_dir().unwrap();
+    generate_project(project.path());
+    let cwd = project.path().to_string_lossy().into_owned();
+    let sources = vec!["unit_000.cpp".to_string()];
+
+    let (_cache_dir, endpoint, server_handle, shutdown) = start_daemon().await;
+    let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+    client
+        .send(&Request::SessionStart {
+            client_pid: std::process::id(),
+            working_dir: cwd.clone().into(),
+            log_file: None,
+            track_stats: true,
+            journal_path: None,
+            profile: false,
+            private_daemon: None,
+        })
+        .await
+        .unwrap();
+    let session_id = match client.recv().await.unwrap() {
+        Some(Response::SessionStarted { session_id, .. }) => session_id,
+        other => panic!("expected SessionStarted, got: {other:?}"),
+    };
+
+    let elapsed = zccache_compile_single(&mut client, &session_id, &compiler, &cwd, &sources).await;
+    eprintln!("single C++ cold miss: {}", fmt_dur(elapsed));
+
+    client
+        .send(&Request::SessionEnd {
+            session_id: session_id.clone(),
+        })
+        .await
+        .unwrap();
+    let _ = client.recv::<Response>().await;
+    shutdown.notify_one();
+    server_handle.await.unwrap();
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -989,3 +989,12 @@ lever, in both the crate and repo READMEs.
 - [x] Prove ordinary compiles remain concurrent and cache hits skip the barrier.
 - [x] Run focused tests, formatting, Clippy, full validation, and review.
 - [ ] Merge and publish the next zccache release.
+
+# Current-main performance regression profile
+
+- [x] Audit the sanctioned benchmark, existing #1036/#1099 campaign, and open profiling work.
+- [x] Add a bosn-managed Linux stack for the existing benchmark with persistent soldr/target caches.
+- [ ] Capture current-main repeated wall-time, on-CPU, off-CPU/syscall-wait, RSS, heap, and Massif evidence.
+- [ ] Rank the top three owned slowdowns and file the evidence-backed implementation issue.
+- [ ] Add RED performance tests, implement the fixes, and capture paired GREEN evidence.
+- [ ] Run the full sanctioned matrix, review, merge, close issues, and restore clean `origin/main`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -999,7 +999,8 @@ Issue: https://github.com/zackees/zccache/issues/1511
 - [x] Capture current-main wall-time, on-CPU, off-CPU/syscall-wait, RSS, heap, and Massif evidence.
 - [x] Rank the top three owned slowdowns and file the evidence-backed implementation issue.
 - [x] Add RED performance tests, implement the fixes, and capture paired GREEN evidence.
-- [ ] Run the full sanctioned matrix, review, merge, close issues, and restore clean `origin/main`.
+- [x] Attempt the full sanctioned repeat-5 matrix and retain every clean or invalid sample.
+- [ ] Merge, close the issue, and restore clean `origin/main`.
 
 ## Review
 
@@ -1025,8 +1026,11 @@ Issue: https://github.com/zackees/zccache/issues/1511
   samples: cold median 95.834 s (MAD 2.709 s, 87.403-106.237 s), warm median
   13.747 s (MAD 0.244 s, 13.381-13.996 s), with 141 hits, zero misses, and no
   aborts, retries, or daemon fallbacks in every sample.
-- The remaining repeat-5 matrix was stopped after current Soldr/Cargo lifecycle
-  overhead missed unrelated absolute ceilings (zccache phase totals were only
-  1.73 s for touch and 0.13 s for restore). A focused retry then became invalid:
-  `reqwest` was killed by signal, while cgroup `memory.events` reported no OOM.
-  No threshold was widened and no contaminated sample is claimed as evidence.
+- A clean exact-source repeat-5 attempt completed the medium worktree cell:
+  cold median 96.791 s (MAD 3.223 s, 88.017-130.487 s), warm median 14.013 s
+  (MAD 0.113 s, 12.947-14.126 s). The overall matrix still failed 7/8 cells.
+  One medium cold sample was invalid because `tokio`'s rustc was killed by
+  signal while cgroup `memory.events` reported no OOM. The remaining failures
+  were current Soldr/Cargo lifecycle ceilings despite cache success: sqlite
+  warm phases took 55-69 s with 100% zccache hits. No threshold was widened,
+  and the invalid sample is not claimed as performance evidence.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -998,5 +998,35 @@ Issue: https://github.com/zackees/zccache/issues/1511
 - [x] Add a bosn-managed Linux stack for the existing benchmark with persistent soldr/target caches.
 - [x] Capture current-main wall-time, on-CPU, off-CPU/syscall-wait, RSS, heap, and Massif evidence.
 - [x] Rank the top three owned slowdowns and file the evidence-backed implementation issue.
-- [ ] Add RED performance tests, implement the fixes, and capture paired GREEN evidence.
+- [x] Add RED performance tests, implement the fixes, and capture paired GREEN evidence.
 - [ ] Run the full sanctioned matrix, review, merge, close issues, and restore clean `origin/main`.
+
+## Review
+
+- Daemon identity now computes only BLAKE3, using its memory-mapped parallel
+  reader; the required legacy SHA-256 slot stays zero. Bounded Linux Callgrind
+  moved `current_backend_identity` from 56.59% of instructions to 0.05%, while
+  heaptrack moved the executable-sized allocation from 57.37 MiB to a 1.05 MiB
+  peak heap.
+- Ordinary Clang C++ misses now consume the compiler's exact `-MD/-MF`
+  dependency file instead of paying for public `-H` stderr tracing. The clean
+  50-file cold benchmark improved from 58.515 s to 16.795 s; its compiler-span
+  ratio is 1.064x bare, below the 1.25x target. The ignored system-header
+  mutation test passes under Bosn Linux.
+- Interactive Rust link-like work uses the existing Auto priority policy
+  instead of unconditional Low priority. Clean final observations were 7.620 s
+  for build mode and 5.377 s for check mode, with explicit foreground
+  materialization timing and effective Normal priority in every serial row.
+- The sanctioned harness had silently continued to build registry zccache
+  1.13.11 after Soldr externalized the dependency. It now patches the exact
+  read-only checkout and rejects a lockfile that still names a registry source;
+  all 52 focused harness tests pass.
+- The exact-source medium `cold-tar-untar-warm` cell passed all five clean
+  samples: cold median 95.834 s (MAD 2.709 s, 87.403-106.237 s), warm median
+  13.747 s (MAD 0.244 s, 13.381-13.996 s), with 141 hits, zero misses, and no
+  aborts, retries, or daemon fallbacks in every sample.
+- The remaining repeat-5 matrix was stopped after current Soldr/Cargo lifecycle
+  overhead missed unrelated absolute ceilings (zccache phase totals were only
+  1.73 s for touch and 0.13 s for restore). A focused retry then became invalid:
+  `reqwest` was killed by signal, while cgroup `memory.events` reported no OOM.
+  No threshold was widened and no contaminated sample is claimed as evidence.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -992,9 +992,11 @@ lever, in both the crate and repo READMEs.
 
 # Current-main performance regression profile
 
+Issue: https://github.com/zackees/zccache/issues/1511
+
 - [x] Audit the sanctioned benchmark, existing #1036/#1099 campaign, and open profiling work.
 - [x] Add a bosn-managed Linux stack for the existing benchmark with persistent soldr/target caches.
-- [ ] Capture current-main repeated wall-time, on-CPU, off-CPU/syscall-wait, RSS, heap, and Massif evidence.
-- [ ] Rank the top three owned slowdowns and file the evidence-backed implementation issue.
+- [x] Capture current-main wall-time, on-CPU, off-CPU/syscall-wait, RSS, heap, and Massif evidence.
+- [x] Rank the top three owned slowdowns and file the evidence-backed implementation issue.
 - [ ] Add RED performance tests, implement the fixes, and capture paired GREEN evidence.
 - [ ] Run the full sanctioned matrix, review, merge, close issues, and restore clean `origin/main`.


### PR DESCRIPTION
## Summary

- make daemon identity BLAKE3-only, memory-mapped, parallel, and endpoint-cached; keep the legacy SHA-256 field zero so old peers safely refuse the new identity
- replace Clang C++ header tracing with exact depfiles and preserve the private/fallback paths that still require tracing
- use automatic priority for interactive Rust link-like work and expose materialization timings in nanoseconds
- add a bosn-managed Linux profiler plus an exact-source sanctioned benchmark harness

## Performance evidence

- daemon identity: bounded Callgrind attributed 0.05% of instructions to identity work, versus 56.59% in the earlier full-workload profile; heap allocation fell from 57.37 MB to 1.05 MB (directional comparison across the documented bounded/full workloads)
- C++ cold miss: 50-file workload improved from 58.515 s to 16.795 s; compiler span was 1.064x bare compilation
- Rust interactive workload: build 7.620 s and check 5.377 s with normal serial admission

The exact-source repeat-5 matrix was attempted without widening thresholds. The medium/worktree-share cell passed all five repetitions; 7/8 cells still missed existing lifecycle ceilings even with cache hits. One invalid medium sample was signal-killed with no cgroup OOM event. All samples and the limitation are retained in the issue and task evidence.

## Validation

- `./test`
- `./test --integration`
- `soldr cargo fmt --all -- --check`
- `soldr cargo clippy --workspace --all-targets -- -D warnings`
- 53 Python harness tests
- Linux ignored system-header mutation correctness test under bosn
- clud-review: clean (one review agent)

Fixes #1511
