### PR TITLE
fix: materialize compiler-observed rustc outputs

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
@@ -248,7 +248,17 @@ pub(super) fn materialize_cached_compile_hit(
                     );
                     return Err(missing_entry(artifact_key_hex));
                 };
-                targets.push(requested);
+                let target = if requested
+                    .file_name()
+                    .is_some_and(|name| name == std::ffi::OsStr::new(names[i].as_str()))
+                {
+                    requested
+                } else {
+                    requested
+                        .parent()
+                        .map_or_else(|| requested.clone(), |parent| parent.join(&names[i]).into())
+                };
+                targets.push(target);
                 selected_payloads.push(payloads[i].clone());
             }
             (targets, selected_payloads)
@@ -256,7 +266,20 @@ pub(super) fn materialize_cached_compile_hit(
             let targets = (0..payloads.len())
                 .map(|i| {
                     let out: NormalizedPath = if i == 0 {
-                        output_path.clone()
+                        // The compiler may have materialized a physical name
+                        // different from its declared primary path (for
+                        // example by appending a suffix). The cold staged
+                        // plan records that observed filename in `names`; use
+                        // it on a fresh-root hit rather than replaying the
+                        // extensionless declaration.
+                        if output_path
+                            .file_name()
+                            .is_some_and(|name| name == std::ffi::OsStr::new(names[i].as_str()))
+                        {
+                            output_path.clone()
+                        } else {
+                            secondary_output_dir.join(&names[i])
+                        }
                     } else if i == 1 && payloads.len() == 2 {
                         current_depfile_dest
                             .clone()
@@ -452,6 +475,14 @@ pub(super) fn rustc_compat_payload_index_for(
 ) -> Option<usize> {
     let requested_name = requested.file_name()?.to_str()?;
     if let Some(index) = names.iter().position(|name| name == requested_name) {
+        return Some(index);
+    }
+    let prefixed_observed = format!("{requested_name}.");
+    let mut observed = names.iter().enumerate().filter(|(_, name)| {
+        name.starts_with(&prefixed_observed)
+            && rustc_output_kind(std::path::Path::new(name)).is_none()
+    });
+    if let (Some((index, _)), None) = (observed.next(), observed.next()) {
         return Some(index);
     }
     let wanted = rustc_output_kind(requested)?;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -185,7 +185,13 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
 
     let state = state_arc.as_ref();
 
-    if let Some(plan) = staged_plan.as_ref() {
+    if let Some(plan) = staged_plan.as_mut() {
+        if let Err(error) = plan.observe_compiler_output_names() {
+            let _ = plan.cleanup();
+            return Some(Response::Error {
+                message: format!("failed to observe staged compiler outputs: {error}"),
+            });
+        }
         if let Err(error) = plan.rewrite_logical_side_outputs() {
             use crate::daemon::staged_stats::{StagedCounter, StagedFailure};
             state
@@ -217,7 +223,11 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
     // (e.g. via -include-pch) sees the change immediately — no need
     // to wait for a watcher event.
     let t_apply_changes = std::time::Instant::now();
-    state.cache_system.apply_changes(vec![output_path.clone()]);
+    let changed_outputs = staged_plan
+        .as_ref()
+        .map(StagedCompilePlan::requested_output_paths)
+        .unwrap_or_else(|| vec![output_path.clone()]);
+    state.cache_system.apply_changes(changed_outputs);
     let apply_changes_ns = t_apply_changes.elapsed().as_nanos() as u64;
 
     // Capture output metadata. Rust payload bytes are snapshotted into
@@ -230,7 +240,10 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         rustc_args_owned.clone(),
         compiler_output_path.clone(),
         cwd_path.clone(),
-        staged_output_paths,
+        staged_plan
+            .as_ref()
+            .map(StagedCompilePlan::output_paths)
+            .or(staged_output_paths),
     )
     .await
     {
@@ -566,7 +579,9 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
                         .staged
                         .timing(StagedTiming::MissMaterialization, staged_materialization_ns);
                     compiler_output_path = output_path.clone();
-                    state.cache_system.apply_changes(vec![output_path.clone()]);
+                    state
+                        .cache_system
+                        .apply_changes(plan.requested_output_paths());
                     Some(plan)
                 }
                 Err(error) => {

--- a/crates/zccache-daemon-core/src/daemon/server/persist/README.md
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/README.md
@@ -37,8 +37,9 @@ re-exports `*` from each submodule.
   staging marker normalization and requested-path rehydration.
 - **[`staged_link_args.rs`](staged_link_args.rs)** — Linker argument planning
   for private staged outputs.
-- **[`staged_plan.rs`](staged_plan.rs)** / **[`staged_multi.rs`](staged_multi.rs)** —
-  Compiler output-role planning and multi-output staging.
+- **[`staged_plan.rs`](staged_plan.rs)** / **[`staged_plan_observed.rs`](staged_plan_observed.rs)** /
+  **[`staged_multi.rs`](staged_multi.rs)** — Compiler output-role planning,
+  physical output-name observation, and multi-output staging.
 - **[`staged_store.rs`](staged_store.rs)** and
   **[`staged_store/`](staged_store/)** — Immutable generations, atomic pointer
   publication, materialization, root safety, maintenance, and test fault hooks.

--- a/crates/zccache-daemon-core/src/daemon/server/persist/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/mod.rs
@@ -37,6 +37,7 @@ mod staged_link_args;
 mod staged_multi;
 mod staged_paths;
 mod staged_plan;
+mod staged_plan_observed;
 mod staged_store;
 mod write_cached;
 

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan.rs
@@ -157,7 +157,7 @@ pub(in crate::daemon::server) struct StagedOutputPlan {
 pub(in crate::daemon::server) struct StagedCompilePlan {
     pub(in crate::daemon::server) outputs: Vec<StagedOutputPlan>,
     pub(in crate::daemon::server) rewritten_args: Vec<String>,
-    root: NormalizedPath,
+    pub(super) root: NormalizedPath,
 }
 
 impl StagedCompilePlan {

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan_observed.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan_observed.rs
@@ -1,0 +1,71 @@
+//! Reconcile compiler-declared staged outputs with physical filenames.
+
+use super::staged_plan::StagedCompilePlan;
+use crate::core::path::NormalizedPath;
+use std::io;
+
+impl StagedCompilePlan {
+    /// Reconcile a compiler-declared output with the filename the compiler
+    /// actually created in this private staging directory. Some compilers
+    /// treat `-o <stem>` as a logical output declaration and append their own
+    /// suffix (rather than writing precisely `<stem>`). Keep that observed
+    /// mapping in the plan so both miss materialization and the persisted
+    /// artifact metadata use the physical filename.
+    ///
+    /// This is intentionally filename- and compiler-agnostic: an observed
+    /// file is accepted only when it is the sole direct child whose name is
+    /// `<declared-name>.<suffix>`. Ambiguous or unrelated side outputs remain
+    /// unsupported rather than guessing a target-specific convention.
+    pub(in crate::daemon::server) fn observe_compiler_output_names(&mut self) -> io::Result<()> {
+        let declared_staged_paths: Vec<_> = self
+            .outputs
+            .iter()
+            .map(|output| output.staged.clone())
+            .collect();
+        for output in &mut self.outputs {
+            if output.staged.is_file() {
+                continue;
+            }
+            let Some(declared_name) = output.staged.file_name() else {
+                continue;
+            };
+            let mut prefix = declared_name.to_os_string();
+            prefix.push(".");
+            let candidates: Vec<_> = std::fs::read_dir(&self.root)?
+                .filter_map(Result::ok)
+                .map(|entry| entry.path())
+                .filter(|path| {
+                    path.is_file()
+                        && !declared_staged_paths
+                            .iter()
+                            .any(|declared| declared.as_path() == path)
+                        && path.file_name().is_some_and(|name| {
+                            name.to_string_lossy()
+                                .starts_with(prefix.to_string_lossy().as_ref())
+                        })
+                })
+                .collect();
+            if candidates.len() != 1 {
+                continue;
+            }
+            let observed = &candidates[0];
+            let Some(observed_name) = observed.file_name() else {
+                continue;
+            };
+            output.staged = observed.into();
+            output.requested = output.requested.parent().map_or_else(
+                || output.requested.clone(),
+                |parent| parent.join(observed_name).into(),
+            );
+        }
+        Ok(())
+    }
+
+    /// Return the caller-visible destinations after output-name observation.
+    pub(in crate::daemon::server) fn requested_output_paths(&self) -> Vec<NormalizedPath> {
+        self.outputs
+            .iter()
+            .map(|output| output.requested.clone())
+            .collect()
+    }
+}

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_plan_tests.rs
@@ -236,6 +236,36 @@ fn deferred_materialization_keeps_staged_source_for_durable_publication() {
 }
 
 #[test]
+fn observed_output_name_updates_tracked_requested_destination() {
+    let temp = tempdir().unwrap();
+    let root: NormalizedPath = temp.path().join("private").into();
+    std::fs::create_dir_all(root.as_path()).unwrap();
+    let requested: NormalizedPath = temp.path().join("target/wasm_restore").into();
+    let staged: NormalizedPath = root.join("wasm_restore");
+    let observed: NormalizedPath = root.join("wasm_restore.wasm");
+    std::fs::write(observed.as_path(), b"wasm artifact").unwrap();
+    let mut plan = StagedCompilePlan::for_test(
+        root,
+        vec![StagedOutputPlan {
+            requested,
+            staged,
+            role: StagedOutputRole::Regular,
+        }],
+    );
+
+    plan.observe_compiler_output_names().unwrap();
+
+    assert_eq!(
+        plan.requested_output_paths(),
+        vec![NormalizedPath::from(
+            temp.path().join("target/wasm_restore.wasm"),
+        )],
+        "watcher invalidation must target the compiler-observed public filename"
+    );
+    plan.cleanup().unwrap();
+}
+
+#[test]
 fn cc_custom_mf_destination_is_classified_as_a_depfile() {
     if !staged_tests_enabled() {
         return;

--- a/crates/zccache/tests/daemon_rustc_restore_test.rs
+++ b/crates/zccache/tests/daemon_rustc_restore_test.rs
@@ -15,6 +15,7 @@
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use tokio::task::JoinHandle;
 
@@ -297,6 +298,28 @@ fn expected_outputs(project_dir: &Path) -> Vec<PathBuf> {
     ]
 }
 
+fn wasm_link_args() -> Vec<String> {
+    vec![
+        "--edition=2021".into(),
+        "--target=wasm32-unknown-unknown".into(),
+        "--crate-type=bin".into(),
+        "--crate-name=wasm_restore".into(),
+        "--emit=dep-info,link".into(),
+        "--out-dir=target/wasm32-unknown-unknown/debug/deps".into(),
+        "src/main.rs".into(),
+    ]
+}
+
+fn rustc_target_is_available(rustc: &Path, target: &str) -> bool {
+    Command::new(rustc)
+        .args(["--print", "target-libdir", "--target", target])
+        .output()
+        .is_ok_and(|output| {
+            output.status.success()
+                && Path::new(String::from_utf8_lossy(&output.stdout).trim()).is_dir()
+        })
+}
+
 fn assert_outputs_exist(outputs: &[PathBuf], context: &str) {
     for output in outputs {
         assert!(
@@ -483,6 +506,94 @@ async fn rustc_multi_output_hit_survives_cache_restore_without_target_dir() {
             "second compile should be restored from the cache after target/ deletion",
         );
         assert_outputs_exist(&outputs, "cached restore");
+        end_session(&mut client2, session2).await;
+        shutdown_daemon(client2, handle2).await;
+    })
+    .await;
+}
+
+/// soldr#2919: rustc's `-o` plan is not necessarily the physical output
+/// filename. For `wasm32-unknown-unknown`, `--emit=dep-info,link` writes both
+/// `<crate>.d` and `<crate>.wasm` beside the extensionless primary path.
+/// The staged lane must observe and persist that mapping, then replay it from
+/// a fresh daemon after the complete target tree has been removed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wasm_link_hit_restores_compiler_observed_output_after_fresh_daemon() {
+    let rustc = match zccache::test_support::find_rustc() {
+        Some(path) => path,
+        None => {
+            eprintln!("skipping test: rustc not found");
+            return;
+        }
+    };
+    if !rustc_target_is_available(rustc.as_path(), "wasm32-unknown-unknown") {
+        eprintln!("skipping test: wasm32-unknown-unknown target not installed");
+        return;
+    }
+
+    zccache::test_support::test_timeout(async move {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cache_dir = tmp.path().join("zccache-cache");
+        let project_dir = tmp.path().join("workspace");
+        std::fs::create_dir_all(project_dir.join("src")).expect("create src");
+        std::fs::write(project_dir.join("src/main.rs"), "fn main() {}\n")
+            .expect("write wasm source");
+        let _cache_env = CacheEnvGuard::new(&cache_dir);
+        let args = wasm_link_args();
+        let wasm = project_dir.join("target/wasm32-unknown-unknown/debug/deps/wasm_restore.wasm");
+
+        let (endpoint1, handle1) = start_daemon_like_zccache_daemon().await;
+        let mut client1 = connect(&endpoint1).await;
+        let session1 = start_session(&mut client1, &project_dir).await;
+        let first = compile_rustc(
+            &mut client1,
+            &session1,
+            rustc.as_path(),
+            &args,
+            &project_dir,
+        )
+        .await;
+        assert_eq!(
+            first.exit_code,
+            0,
+            "first wasm compile failed: {}",
+            String::from_utf8_lossy(&first.stderr)
+        );
+        assert!(!first.cached, "first wasm compile must populate the cache");
+        assert!(
+            wasm.is_file(),
+            "cold staged compile must materialize compiler-observed {wasm:?}"
+        );
+        end_session(&mut client1, session1).await;
+        shutdown_daemon(client1, handle1).await;
+
+        std::fs::remove_dir_all(project_dir.join("target")).expect("remove target tree");
+
+        let (endpoint2, handle2) = start_daemon_like_zccache_daemon().await;
+        let mut client2 = connect(&endpoint2).await;
+        let session2 = start_session(&mut client2, &project_dir).await;
+        let second = compile_rustc(
+            &mut client2,
+            &session2,
+            rustc.as_path(),
+            &args,
+            &project_dir,
+        )
+        .await;
+        assert_eq!(
+            second.exit_code,
+            0,
+            "warm wasm compile failed: {}",
+            String::from_utf8_lossy(&second.stderr)
+        );
+        assert!(
+            second.cached,
+            "fresh daemon must reload the staged wasm artifact"
+        );
+        assert!(
+            wasm.is_file(),
+            "warm hit must materialize compiler-observed {wasm:?}"
+        );
         end_session(&mut client2, session2).await;
         shutdown_daemon(client2, handle2).await;
     })


### PR DESCRIPTION
## Summary
- observe the physical name produced when a staged compiler expands a logical primary output (for example, `wasm_restore` -> `wasm_restore.wasm`)
- persist that observed output name through the Rust artifact metadata and replay it on both normal and rustc-metadata cache hits
- cover real `wasm32-unknown-unknown` cold compilation plus a fresh-daemon, deleted-target-tree cache hit

## Validation
- RED on current main: `wasm_link_hit_restores_compiler_observed_output_after_fresh_daemon` failed materializing the extensionless declared staged output (`os error 2`)
- GREEN: `soldr cargo test -p zccache --test daemon_rustc_restore_test wasm_link_hit_restores_compiler_observed_output_after_fresh_daemon -- --nocapture`
- `soldr cargo test -p zccache-daemon-core --features test-support observed_output_name_updates_tracked_requested_destination -- --nocapture`
- `soldr cargo clippy -p zccache-daemon-core --features test-support --all-targets -- -D warnings`
- `soldr cargo fmt --all -- --check`
- `git diff --check`
- independent `clud-review`: clean (one reviewer)

Coordinated with zackees/soldr#2919. This prerequisite must land before Soldr advances its exact zccache pin.