### PR TITLE
fix(rustc): refuse --test harness link products at cache admission (#1525)

### DIFF
--- a/crates/zccache-compiler/src/parse_rustc.rs
+++ b/crates/zccache-compiler/src/parse_rustc.rs
@@ -26,6 +26,56 @@ use super::{CacheableCompilation, CompilerFamily, ParsedInvocation};
 ///   modeled as one complete artifact set by the daemon.
 const RUSTC_CACHEABLE_CRATE_TYPES: &[&str] = &["lib", "rlib", "staticlib", "proc-macro", "bin"];
 
+/// Why a `--test` harness link is refused regardless of crate type
+/// (zccache#1525, soldr#2931).
+///
+/// Cargo compiles an integration-test target by invoking rustc with `--test`
+/// and **no** `--crate-type`, so the "default crate type is bin" fallback below
+/// classified it as a cacheable `bin` and `--test` merely landed in
+/// `unknown_flags` as cache-key salt. Every linked test executable therefore
+/// entered the content-addressed artifact store.
+///
+/// That is the single worst entry shape a content-addressed store can take:
+/// maximal volatility crossed with maximal size. A harness statically links
+/// the full dependency graph, so its input closure contains the workspace
+/// library it tests — *any* workspace source edit relinks it, minting a fresh
+/// multi-megabyte entry under a key that can essentially never be requested a
+/// second time. It is not a cache; it is a write-only log of every build that
+/// ever ran. Downstream (soldr#2931) this contributed to a 3.3 GB CI archive
+/// re-uploaded to `actions/cache` on every run.
+///
+/// This is a different failure from the `dylib`/`cdylib` exclusion documented
+/// on [`RUSTC_CACHEABLE_CRATE_TYPES`]. Those are refused because the artifact
+/// store does not *model* their platform linker state — a correctness
+/// argument. A harness is modeled correctly and would replay fine; it is
+/// refused because storing it can never pay, which is an economics argument.
+/// Both gates therefore live side by side rather than being folded into the
+/// crate-type table.
+///
+/// The exclusion keys on `--test` itself, not on the crate type. See
+/// [`CACHE_TEST_BINS_ENV`] for the opt-in escape hatch.
+const RUSTC_TEST_HARNESS_REASON: &str = "test harness link product not cacheable";
+
+/// Opt-in re-admission of `--test` harness invocations (zccache#1525).
+///
+/// Set it if you can demonstrate a real hit rate on your workload — e.g. a
+/// build where the harness's input closure genuinely does not move between
+/// runs. Off by default because the common case is the opposite.
+///
+/// Value grammar is the canonical zccache-owned boolean, parsed by
+/// [`zccache_core::config::owned_env_flag_enabled`]: `1` or case-insensitive
+/// `true` enables it, and everything else — unset, empty, `0`, `false`, or any
+/// typo — leaves the exclusion in force. Deliberately NOT a hand-rolled
+/// parser: soldr#2740 found five mutually disagreeing truthy parsers in the
+/// sibling repo, one of which made `FOO=false` turn a switch *on*.
+pub(crate) const CACHE_TEST_BINS_ENV: &str = "ZCCACHE_CACHE_TEST_BINS";
+
+/// True when [`CACHE_TEST_BINS_ENV`] opts this process back into caching
+/// `--test` harness links.
+fn test_harness_caching_enabled() -> bool {
+    zccache_core::config::owned_env_flag_enabled(CACHE_TEST_BINS_ENV)
+}
+
 /// Host dynamic-library file-name pattern for proc-macros, matching
 /// rustc's output naming. Linux/macOS use the `lib` prefix; Windows
 /// doesn't.
@@ -210,8 +260,24 @@ const RUSTC_FLAGS_WITH_VALUE: &[&str] = &[
 /// Parse a rustc invocation to determine cacheability.
 ///
 /// Cacheable: `--crate-type` is `lib`, `rlib`, `staticlib`, `proc-macro`, or `bin`.
-/// Non-cacheable: `dylib`, `cdylib`.
+/// Non-cacheable: `dylib`, `cdylib`, and any `--test` harness link
+/// (see [`RUSTC_TEST_HARNESS_REASON`]).
 pub(crate) fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedInvocation {
+    parse_rustc_invocation_with_policy(compiler, args, test_harness_caching_enabled())
+}
+
+/// Testable core of [`parse_rustc_invocation`] — no environment access.
+///
+/// `cache_test_bins` is the already-resolved value of [`CACHE_TEST_BINS_ENV`].
+/// Threading it in as an argument keeps the crate's parallel test suite
+/// deterministic: no test has to mutate process-global environment state to
+/// exercise either side of the policy. Mirrors the
+/// `no_spawn_from_env_value` seam in `zccache_core::config`.
+pub(crate) fn parse_rustc_invocation_with_policy(
+    compiler: &str,
+    args: &[String],
+    cache_test_bins: bool,
+) -> ParsedInvocation {
     let execution_args = args;
     let args = match super::dylint_inner_rustc_args(compiler, args) {
         Ok(Some((_inner_rustc, rustc_args))) => rustc_args,
@@ -234,6 +300,7 @@ pub(crate) fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedI
     let mut explicit_link_output: Option<String> = None;
     let mut explicit_output: Option<String> = None;
     let mut unknown_flags: Vec<String> = Vec::new();
+    let mut is_test_harness = false;
 
     let mut i = 0;
     while i < args.len() {
@@ -377,6 +444,20 @@ pub(crate) fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedI
             continue;
         }
 
+        // --test — cargo's test-harness switch. Lifted out of the unknown-flag
+        // catch-all below so the cacheability gate can read it as a
+        // first-class fact instead of re-scanning argv; being invisible in
+        // `unknown_flags` is exactly how zccache#1525 shipped. Still pushed
+        // into `unknown_flags` (which is cache-key material) so that under
+        // the CACHE_TEST_BINS_ENV opt-in a harness build and a non-harness
+        // build of the same source cannot collide on one key.
+        if arg == "--test" {
+            is_test_harness = true;
+            unknown_flags.push(arg.clone());
+            i += 1;
+            continue;
+        }
+
         // Any flag starting with -
         if arg.starts_with('-') {
             unknown_flags.push(arg.clone());
@@ -452,6 +533,24 @@ pub(crate) fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedI
                 reason: format!("non-cacheable crate type: {ct}"),
             };
         }
+    }
+
+    // Sibling gate to the crate-type check above: refuse `--test` harness
+    // links. See RUSTC_TEST_HARNESS_REASON for the full rationale.
+    //
+    // Decision on `--test` PLUS an explicit `--crate-type` (zccache#1525):
+    // the exclusion applies there too. `rustc --crate-type lib --test
+    // src/lib.rs` — a unit-test harness for a lib — is checked here, AFTER
+    // the crate-type loop has already accepted `lib`, and is still refused.
+    // `--test` overrides what rustc emits: the product is a test executable
+    // that statically links the dependency graph no matter which crate type
+    // was declared, so the identical volatility-times-size argument holds.
+    // Keying the exclusion on the crate type instead would have missed the
+    // real-world cargo shape entirely, which passes no `--crate-type` at all.
+    if is_test_harness && !cache_test_bins {
+        return ParsedInvocation::NonCacheable {
+            reason: RUSTC_TEST_HARNESS_REASON.to_string(),
+        };
     }
 
     // Determine primary output filename based on --emit and --crate-type.

--- a/crates/zccache-compiler/src/tests/rustc.rs
+++ b/crates/zccache-compiler/src/tests/rustc.rs
@@ -1,5 +1,6 @@
 //! Rustc invocation parsing: crate types, --emit, --out-dir, proc-macro/bin output naming.
 
+use super::super::parse_rustc::{parse_rustc_invocation_with_policy, CACHE_TEST_BINS_ENV};
 use super::super::{detect_family, parse_invocation, CompilerFamily, ParsedInvocation};
 use super::args;
 use zccache_core::NormalizedPath;
@@ -591,16 +592,131 @@ fn rustc_comma_separated_crate_type_equals_form() {
     assert!(matches!(result, ParsedInvocation::Cacheable(_)));
 }
 
+// ─── `--test` harness admission (zccache#1525) ────────────────────────
+//
+// These drive `parse_rustc_invocation_with_policy` rather than
+// `parse_invocation` so the policy value is explicit in each case. The env
+// read is the one-line `owned_env_flag_enabled(CACHE_TEST_BINS_ENV)` call that
+// feeds this seam; keeping it out of the assertions means no test has to
+// mutate process-global environment state that the rest of the suite races on.
+
 #[test]
 fn rustc_test_flag_makes_non_cacheable() {
-    // --test compiles a test harness (implicitly bin, not cacheable)
-    let result = parse_invocation(
+    // Policy: a `--test` invocation produces a test harness executable, which
+    // relinks on any workspace source edit while statically linking the whole
+    // dependency graph. Multi-megabyte entries under keys that can never be
+    // requested twice, so it is refused at admission (soldr#2931).
+    //
+    // The explicit `--crate-type lib` here is the deliberate hard case: `lib`
+    // is cacheable on its own, but `--test` overrides what rustc actually
+    // emits, so the exclusion wins over the declared crate type.
+    let result = parse_rustc_invocation_with_policy(
         "rustc",
         &args(&["--crate-type", "lib", "--test", "src/lib.rs"]),
+        false,
     );
-    // --test gets captured as unknown_flag. Since --crate-type lib is specified
-    // the compilation IS cacheable. The --test flag is in unknown_flags which
-    // is part of the cache key, so different --test values produce different keys.
-    // This is correct: `--test` with `--crate-type lib` is a valid cacheable invocation.
+    match result {
+        ParsedInvocation::NonCacheable { reason } => {
+            assert!(
+                reason.contains("test harness"),
+                "expected the test-harness policy reason, got: {reason}"
+            );
+        }
+        other => panic!("expected --test to be non-cacheable, got: {other:?}"),
+    }
+}
+
+#[test]
+fn rustc_cargo_shaped_test_harness_is_non_cacheable() {
+    // The real-world shape from zccache#1525: cargo compiles an integration
+    // test with `--test` and NO `--crate-type`, so the default-to-`bin`
+    // fallback used to admit every linked test executable into the store.
+    let result = parse_rustc_invocation_with_policy(
+        "rustc",
+        &args(&[
+            "--edition",
+            "2021",
+            "--crate-name",
+            "integration",
+            "--test",
+            "--emit=dep-info,link",
+            "-C",
+            "extra-filename=-abc123",
+            "--out-dir",
+            "/target/debug/deps",
+            "tests/integration.rs",
+        ]),
+        false,
+    );
+    match result {
+        ParsedInvocation::NonCacheable { reason } => {
+            assert!(
+                reason.contains("test harness"),
+                "expected the test-harness policy reason, got: {reason}"
+            );
+        }
+        other => panic!("expected cargo-shaped --test to be non-cacheable, got: {other:?}"),
+    }
+}
+
+#[test]
+fn rustc_test_harness_opt_in_readmits_the_harness() {
+    // ZCCACHE_CACHE_TEST_BINS is the explicit escape hatch for anyone who can
+    // demonstrate a real hit rate. `--test` stays in unknown_flags so the
+    // harness cannot collide with a non-harness build of the same source.
+    let result = parse_rustc_invocation_with_policy(
+        "rustc",
+        &args(&[
+            "--crate-name",
+            "integration",
+            "--test",
+            "--out-dir",
+            "/target/debug/deps",
+            "tests/integration.rs",
+        ]),
+        true,
+    );
+    let cc = match result {
+        ParsedInvocation::Cacheable(c) => c,
+        other => panic!("expected the opt-in to re-admit the harness, got: {other:?}"),
+    };
+    assert!(
+        cc.unknown_flags.iter().any(|flag| flag == "--test"),
+        "--test must stay in the cache key: {:?}",
+        cc.unknown_flags
+    );
+}
+
+#[test]
+fn rustc_test_harness_opt_in_uses_the_canonical_owned_flag_grammar() {
+    // One grammar for every zccache-owned switch (zccache#1478). Re-asserted
+    // here because soldr#2740 is what hand-rolling a sixth truthy parser
+    // costs: `FOO=false` ended up turning a switch on.
+    assert_eq!(CACHE_TEST_BINS_ENV, "ZCCACHE_CACHE_TEST_BINS");
+    for enabled in ["1", "true", "TRUE", " true "] {
+        assert!(
+            zccache_core::config::owned_flag_enabled(Some(enabled)),
+            "{enabled:?} must enable the opt-in"
+        );
+    }
+    for disabled in ["0", "false", "no", "yes", "on", ""] {
+        assert!(
+            !zccache_core::config::owned_flag_enabled(Some(disabled)),
+            "{disabled:?} must leave the exclusion in force"
+        );
+    }
+    assert!(!zccache_core::config::owned_flag_enabled(None));
+}
+
+#[test]
+fn rustc_lib_without_test_flag_stays_cacheable() {
+    // Guard against over-broadening zccache#1525: the exclusion keys on
+    // `--test` alone, so an ordinary library compile is untouched even with
+    // the opt-in off.
+    let result = parse_rustc_invocation_with_policy(
+        "rustc",
+        &args(&["--crate-type", "lib", "src/lib.rs"]),
+        false,
+    );
     assert!(matches!(result, ParsedInvocation::Cacheable(_)));
 }

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -161,6 +161,25 @@ its own:
   `bin`.** `dylib`/`cdylib` are deliberately not cached (platform
   linker state is not modeled) — PyO3/maturin `cdylib` final artifacts
   recompile every time while their rlib deps still hit.
+- **`--test` harness links are refused at admission** (zccache#1525,
+  soldr#2931), reason string `test harness link product not cacheable`.
+  Cargo builds an integration test with `--test` and no `--crate-type`,
+  so the parser's default-to-`bin` fallback used to admit every linked
+  test executable. A harness is the worst possible store entry: it
+  statically links the full dependency graph (maximal size) and its
+  input closure includes the workspace library it tests, so any
+  workspace source edit relinks it (maximal volatility). Each run minted
+  a fresh multi-megabyte entry under a key that could never be requested
+  again — a 3.3 GB CI archive downstream, uploaded to `actions/cache`
+  every run. Unlike the `dylib`/`cdylib` exclusion this is an economics
+  rule, not a correctness one: harness replay would be sound, it just
+  can never pay. The gate keys on `--test` itself, so it also covers
+  `--crate-type lib --test` (a lib's unit-test harness) — `--test`
+  overrides what rustc emits regardless of the declared crate type.
+  Opt back in with `ZCCACHE_CACHE_TEST_BINS=1` (canonical zccache-owned
+  boolean grammar: `1`/`true` only) if you can demonstrate a real hit
+  rate; `--test` stays in `unknown_flags` so harness and non-harness
+  builds of the same source keep distinct keys.
 - **Native libraries in link steps are a documented blind spot.**
   `bin`/`staticlib` units linking system libraries via `-L`/`-l` do not
   content-hash the resolved library bytes (matching sccache). An


### PR DESCRIPTION
Fixes #1525.

## The leak

Cargo compiles an integration-test target with `--test` and **no** `--crate-type`. `parse_rustc.rs`'s default-to-`bin` fallback classified that as a cacheable crate type, so every linked test executable entered the content-addressed store while `--test` sat harmlessly in `unknown_flags` as key salt.

A test harness statically links the full dependency graph, and its input closure includes the workspace library it links — so **any** workspace source edit invalidates **every** test binary. Each CI run therefore minted one fresh multi-megabyte entry per test binary whose key can never be requested again. Downstream (zackees/soldr#2931) that bloat is uploaded to actions/cache on every run by setup-soldr's default-on build cache, and the same per-file link duplication produced a 3.3 GB CI archive that exhausted a hosted Windows runner's disk.

## The rule

This is an **economics** rule, not a correctness rule: replaying a harness would be sound, storing it simply can never pay. It now sits beside the existing `dylib`/`cdylib` exclusion — which *is* a correctness rule (unmodeled linker state) — and the comment draws that distinction explicitly rather than folding `--test` into the crate-type table.

The exclusion also covers `--test` with an explicit cacheable `--crate-type`: `--test` decides what rustc emits, so the product is a test executable regardless of the declared type. Keying on crate type instead would have missed the real cargo shape entirely, since cargo passes no `--crate-type` at all.

`ZCCACHE_CACHE_TEST_BINS=1` re-admits harnesses for anyone who can demonstrate a real hit rate. It parses through the canonical `owned_env_flag_enabled` helper rather than a sixth hand-rolled parser (the soldr#2740 lesson). `--test` is still pushed into `unknown_flags` so that under the opt-in a harness and a non-harness build of the same source cannot collide on one key.

## The test that asserted the opposite of its name

`rustc_test_flag_makes_non_cacheable` was named for the exclusion, its first comment said "--test compiles a test harness (implicitly bin, not cacheable)", and it then asserted `Cacheable` with a second comment rationalizing the leak. It now asserts the exclusion. Added alongside it: the real cargo-shaped invocation, the opt-in path, the flag grammar, and an over-broadening guard proving a plain `--crate-type lib` build is still cacheable.

All five drive a new pure `parse_rustc_invocation_with_policy(...)` seam so no test mutates process-global env — these tests run in parallel in one process, and an env-mutating test would have raced every other assertion.

## Verification

`soldr cargo test -p zccache-compiler --lib` → **376 passed, 0 failed**.

Note: this repo has no `CHANGELOG.md`, so per `docs/CLAUDE.md` ("feature documentation belongs in the subsystem doc that owns the feature") the behavior change is recorded in `docs/architecture/data-flow.md` under "Rustc Cache-Key Specifics". Say the word if you'd rather have a root changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)