### PR TITLE
fix(rustc): exclude test harnesses from cache admission

### DIFF
--- a/crates/zccache-compiler/src/parse_rustc.rs
+++ b/crates/zccache-compiler/src/parse_rustc.rs
@@ -25,6 +25,8 @@ use super::{CacheableCompilation, CompilerFamily, ParsedInvocation};
 ///   its declared library and toolchain-qualified byte-copy sidecar are
 ///   modeled as one complete artifact set by the daemon.
 const RUSTC_CACHEABLE_CRATE_TYPES: &[&str] = &["lib", "rlib", "staticlib", "proc-macro", "bin"];
+const RUSTC_TEST_HARNESS_NON_CACHEABLE_REASON: &str =
+    "non-cacheable rustc test harness (--test policy)";
 
 /// Host dynamic-library file-name pattern for proc-macros, matching
 /// rustc's output naming. Linux/macOS use the `lib` prefix; Windows
@@ -210,7 +212,7 @@ const RUSTC_FLAGS_WITH_VALUE: &[&str] = &[
 /// Parse a rustc invocation to determine cacheability.
 ///
 /// Cacheable: `--crate-type` is `lib`, `rlib`, `staticlib`, `proc-macro`, or `bin`.
-/// Non-cacheable: `dylib`, `cdylib`.
+/// Non-cacheable: `dylib`, `cdylib`, and every `--test` harness invocation.
 pub(crate) fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedInvocation {
     let execution_args = args;
     let args = match super::dylint_inner_rustc_args(compiler, args) {
@@ -234,10 +236,17 @@ pub(crate) fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedI
     let mut explicit_link_output: Option<String> = None;
     let mut explicit_output: Option<String> = None;
     let mut unknown_flags: Vec<String> = Vec::new();
+    let mut is_test_harness = false;
 
     let mut i = 0;
     while i < args.len() {
         let arg = &args[i];
+
+        if arg == "--test" {
+            is_test_harness = true;
+            i += 1;
+            continue;
+        }
 
         // --crate-type <type> or --crate-type=<type>
         // Rustc accepts comma-separated types: --crate-type lib,rlib
@@ -401,6 +410,16 @@ pub(crate) fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedI
             };
         }
     };
+
+    // `--test` requests a linked test-harness executable, even when an
+    // explicit crate type is present. Its source closure changes with the
+    // workspace library, so it is intentionally excluded from reusable store
+    // content rather than falling through to the default `bin` crate type.
+    if is_test_harness {
+        return ParsedInvocation::NonCacheable {
+            reason: RUSTC_TEST_HARNESS_NON_CACHEABLE_REASON.to_string(),
+        };
+    }
 
     // autocfg 1.5+ deliberately puts a process-random UUID in each probe
     // crate name. rustc embeds that identity in the emitted LLVM IR, so the

--- a/crates/zccache-compiler/src/tests/rustc.rs
+++ b/crates/zccache-compiler/src/tests/rustc.rs
@@ -592,15 +592,35 @@ fn rustc_comma_separated_crate_type_equals_form() {
 }
 
 #[test]
+fn rustc_cargo_shaped_test_harness_is_non_cacheable() {
+    // zccache#1525: Cargo passes --test without an explicit --crate-type.
+    let result = parse_invocation(
+        "rustc",
+        &args(&[
+            "--crate-name",
+            "parser_tests",
+            "--test",
+            "src/parser_tests.rs",
+        ]),
+    );
+    assert!(matches!(
+        result,
+        ParsedInvocation::NonCacheable { ref reason }
+            if reason == "non-cacheable rustc test harness (--test policy)"
+    ));
+}
+
+#[test]
 fn rustc_test_flag_makes_non_cacheable() {
-    // --test compiles a test harness (implicitly bin, not cacheable)
+    // An explicit cacheable crate type does not override the --test policy:
+    // rustc still links a test-harness executable.
     let result = parse_invocation(
         "rustc",
         &args(&["--crate-type", "lib", "--test", "src/lib.rs"]),
     );
-    // --test gets captured as unknown_flag. Since --crate-type lib is specified
-    // the compilation IS cacheable. The --test flag is in unknown_flags which
-    // is part of the cache key, so different --test values produce different keys.
-    // This is correct: `--test` with `--crate-type lib` is a valid cacheable invocation.
-    assert!(matches!(result, ParsedInvocation::Cacheable(_)));
+    assert!(matches!(
+        result,
+        ParsedInvocation::NonCacheable { ref reason }
+            if reason == "non-cacheable rustc test harness (--test policy)"
+    ));
 }

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -161,6 +161,12 @@ its own:
   `bin`.** `dylib`/`cdylib` are deliberately not cached (platform
   linker state is not modeled) — PyO3/maturin `cdylib` final artifacts
   recompile every time while their rlib deps still hit.
+- **Test-harness link products are never cacheable.** `--test` is refused at
+  admission with the `--test policy` reason, before a Cargo-shaped invocation
+  with no `--crate-type` can fall through to the default `bin` type. An
+  explicit otherwise-cacheable crate type (such as `--crate-type lib --test`)
+  does not override the policy: rustc still links a test-harness executable
+  whose workspace-library closure is expected to change frequently.
 - **Native libraries in link steps are a documented blind spot.**
   `bin`/`staticlib` units linking system libraries via `-L`/`-l` do not
   content-hash the resolved library bytes (matching sccache). An


### PR DESCRIPTION
Fixes #1525.

## Release note

- Store content: linked rustc `--test` harness executables are no longer admitted to the reusable artifact store. This changes default cache contents; ordinary non-test `bin` compilation is unchanged.

## Policy

- All rustc `--test` invocations are refused with the named `--test policy`, including `--crate-type lib --test`; an explicit crate type does not change that rustc links a test-harness executable.

## Downstream tracking

- `zackees/soldr#2935` will bump the zccache pin after the next patch release (also unblocks `zackees/soldr#2931`, `#2824`, and `#2941`).

## Validation

- RED: Cargo-shaped `--test` without `--crate-type` was admitted on the base revision.
- GREEN: focused cargo-shaped and explicit-`lib` tests.
- `soldr cargo test -p zccache-compiler` (373 passed)
- `soldr cargo fmt --all -- --check`
- `soldr cargo clippy -p zccache-compiler --all-targets -- -D warnings`
- Independent clud-review: clean (one reviewer).