### PR TITLE
fix(journal): retain miss reason across response-file cleanup

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -104,6 +104,10 @@ jobs:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/test-${{ inputs.os }}
           SOLDR_CACHE_LIFECYCLE: command
           SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
+          # The workspace lib/bin test profile includes the daemon-core
+          # library test, whose compiler admission must be memory-bounded.
+          CARGO_BUILD_JOBS: "1"
+          SOLDR_JOBS: "1"
         run: |
           set +e
           unset ZCCACHE_CACHE_DIR

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -53,6 +53,10 @@ jobs:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/coverage
           SOLDR_CACHE_LIFECYCLE: command
           SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
+          # llvm-cov builds the workspace lib/bin test profile in its own
+          # target directory, including the daemon-core library test.
+          CARGO_BUILD_JOBS: "1"
+          SOLDR_JOBS: "1"
         run: |
           unset ZCCACHE_CACHE_DIR
           echo "Using isolated coverage SOLDR_CACHE_DIR=$SOLDR_CACHE_DIR"

--- a/.github/workflows/fs-matrix.yml
+++ b/.github/workflows/fs-matrix.yml
@@ -75,6 +75,9 @@ jobs:
           # No-op on Linux/macOS, which use TMPDIR instead.
           TEMP: ${{ runner.temp }}
           TMP: ${{ runner.temp }}
+          # This compiles the daemon-core library test on each hosted OS.
+          CARGO_BUILD_JOBS: "1"
+          SOLDR_JOBS: "1"
         run: >-
           soldr cargo test -p zccache-daemon-core --features test-support
           filesystem_materialization_matrix_prints_loud_summary -- --nocapture --test-threads=1
@@ -85,6 +88,8 @@ jobs:
           ZCCACHE_REQUIRE_REFS: "1"
           TEMP: ${{ runner.temp }}
           TMP: ${{ runner.temp }}
+          CARGO_BUILD_JOBS: "1"
+          SOLDR_JOBS: "1"
         run: >-
           soldr cargo test -p zccache-daemon-core --features test-support
           refs_non_cluster_multiple_round_trips -- --nocapture --test-threads=1
@@ -115,6 +120,8 @@ jobs:
           ZCCACHE_REQUIRE_LARGE_COW: "1"
           TEMP: ${{ runner.temp }}
           TMP: ${{ runner.temp }}
+          CARGO_BUILD_JOBS: "1"
+          SOLDR_JOBS: "1"
         run: >-
           soldr cargo test -p zccache-daemon-core --features test-support
           reflink_larger_than_four_gib_uses_chunked_clone -- --nocapture --test-threads=1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -116,6 +116,11 @@ jobs:
           SOLDR_CACHE_LIFECYCLE: command
           SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
           SOLDR_TARGET_BLOCK_FREE_GB: "2"
+          # Cargo schedules compiler processes separately from the test
+          # harness's --test-threads setting. Bound both admission layers for
+          # the daemon-core lib test on the hosted runner.
+          CARGO_BUILD_JOBS: "1"
+          SOLDR_JOBS: "1"
         run: |
           set +e
           unset ZCCACHE_CACHE_DIR
@@ -200,6 +205,9 @@ jobs:
           SOLDR_CACHE_LIFECYCLE: command
           SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
           SOLDR_TARGET_BLOCK_FREE_GB: "2"
+          # This repeats the full-workspace compilation shape above.
+          CARGO_BUILD_JOBS: "1"
+          SOLDR_JOBS: "1"
         run: |
           set +e
           unset ZCCACHE_CACHE_DIR

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,6 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
       - uses: zackees/setup-soldr@5f1f68dcb8377818413c28ce52214261ae8ff771
         with:
           zccache-seed-strict: true
@@ -106,10 +107,8 @@ jobs:
           # The isolated cache is seeded with build artifacts, but runtime
           # journals describe a prior job. Keep the artifacts warm while
           # ensuring the audit below evaluates only this job's behavior.
-          journal_root="$SOLDR_CACHE_DIR/cache/zccache/daemon-state"
-          if [[ -d "$journal_root" ]]; then
-            find "$journal_root" -type f -path '*/logs/*.jsonl' -print -delete
-          fi
+          uv run --no-project python ci/clear_runtime_telemetry.py \
+            --cache-root "$SOLDR_CACHE_DIR/cache/zccache"
       - name: Test (full workspace)
         shell: bash
         env:
@@ -146,10 +145,8 @@ jobs:
           # orchestration, whereas the strict fixture below owns and audits
           # its own runtime cache. Preserve artifacts but exclude harness
           # telemetry from the integration runtime audit.
-          journal_root="$SOLDR_CACHE_DIR/cache/zccache/daemon-state"
-          if [[ -d "$journal_root" ]]; then
-            find "$journal_root" -type f -path '*/logs/*.jsonl' -print -delete
-          fi
+          uv run --no-project python ci/clear_runtime_telemetry.py \
+            --cache-root "$SOLDR_CACHE_DIR/cache/zccache"
       - name: Wrapper daemon-unavailable contract (exit 125)
         shell: bash
         env:
@@ -174,6 +171,14 @@ jobs:
           # workspace-wide log.
           unset ZCCACHE_CACHE_DIR
           soldr cargo test -p zccache --features "$ZCCACHE_INTEGRATION_FEATURES" --test cli_wrapper_failure_boundaries -- --ignored --test-threads=1
+      - name: Remove wrapper-contract telemetry before strict audit
+        if: always()
+        shell: bash
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/integration
+        run: >
+          uv run --no-project python ci/clear_runtime_telemetry.py
+          --cache-root "$SOLDR_CACHE_DIR/cache/zccache"
       - name: Strict artifact-layout validation
         shell: bash
         env:
@@ -222,10 +227,8 @@ jobs:
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/zccache-self-tests/integration
         run: |
-          journal_root="$SOLDR_CACHE_DIR/cache/zccache/daemon-state"
-          if [[ -d "$journal_root" ]]; then
-            find "$journal_root" -type f -path '*/logs/*.jsonl' -print -delete
-          fi
+          uv run --no-project python ci/clear_runtime_telemetry.py \
+            --cache-root "$SOLDR_CACHE_DIR/cache/zccache"
       - name: Stop isolated test cache
         if: always()
         shell: bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -86,6 +86,11 @@ jobs:
           # so use the same guard as the isolated test phase below rather
           # than setup-soldr's 5 GiB default.
           SOLDR_TARGET_BLOCK_FREE_GB: "2"
+          # The prebuild also compiles the daemon-core library test. Cargo's
+          # worker count remains relevant even though this phase bypasses the
+          # cache service.
+          CARGO_BUILD_JOBS: "1"
+          SOLDR_JOBS: "1"
         run: |
           # The build cache can contain zccache COW materializations, whose
           # artifacts are intentionally read-only while shared with the cache.

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -47,6 +47,11 @@ jobs:
       # matrix so pull requests cannot merge before exercising the budget.
       - name: Run COW materialization budget
         shell: bash
+        env:
+          # The required gate compiles the daemon-core library test from a
+          # cold target tree on a constrained hosted runner.
+          CARGO_BUILD_JOBS: "1"
+          SOLDR_JOBS: "1"
         run: |
           set -euo pipefail
           soldr cargo test -p zccache-daemon-core --features test-support perf_cow_materialization_128_hits_under_two_seconds

--- a/ci/clear_runtime_telemetry.py
+++ b/ci/clear_runtime_telemetry.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Remove only cache telemetry that ``zccache-ci audit-logs`` consumes.
+
+The integration workflow seeds a warm cache, so its runtime telemetry must be
+cleared without deleting the cached artifacts that make the test phase warm.
+Keep these filename rules aligned with ``zccache-audit::classify_source``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def _is_audit_source(path: Path) -> bool:
+    """Whether the Rust log audit classifies ``path`` as telemetry."""
+    name = path.name
+    return (
+        name == "audit.jsonl"
+        or name.startswith(("audit.jsonl.", "daemon.log."))
+        or name.endswith(".jsonl")
+        or ".jsonl." in name
+        or (name.startswith("daemon-lifecycle") and ".log" in name)
+        or name == "daemon.log"
+    )
+
+
+def clear_runtime_telemetry(cache_root: Path) -> list[Path]:
+    """Delete audit input files below ``cache_root``, preserving cache data."""
+    if not cache_root.is_dir():
+        return []
+
+    removed = []
+    for path in cache_root.rglob("*"):
+        if path.is_symlink() or not path.is_file() or not _is_audit_source(path):
+            continue
+        path.unlink()
+        removed.append(path)
+    return removed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cache-root", type=Path, required=True)
+    args = parser.parse_args()
+
+    removed = clear_runtime_telemetry(args.cache_root)
+    print(f"clear_runtime_telemetry: removed {len(removed)} audit telemetry file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tests/test_clear_runtime_telemetry.py
+++ b/ci/tests/test_clear_runtime_telemetry.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from ci.clear_runtime_telemetry import clear_runtime_telemetry
+
+
+def _write(path: Path, content: str = "telemetry\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_cleanup_removes_every_audit_consumed_telemetry_form_only(tmp_path: Path) -> None:
+    cache_root = tmp_path / "cache" / "zccache"
+    telemetry = [
+        cache_root / "history" / "session" / "compile_journal.jsonl",
+        cache_root / "logs" / "compile_journal.jsonl.2026-08-27T00-00-00Z",
+        cache_root / "sessions" / "request.jsonl",
+        cache_root / "logs" / "audit.jsonl",
+        cache_root / "logs" / "audit.jsonl.1",
+        cache_root / "daemon-state" / "v1" / "logs" / "daemon-lifecycle.log",
+        cache_root / "daemon-state" / "v1" / "logs" / "daemon-lifecycle-soldr-dev.log.1",
+        cache_root / "daemon-state" / "v1" / "logs" / "daemon.log",
+        cache_root / "daemon-state" / "v1" / "logs" / "daemon.log.1",
+    ]
+    artifacts = [
+        cache_root / "artifacts" / "cached-object",
+        cache_root / "daemon-state" / "v1" / "blobs" / "cached-artifact",
+        cache_root / "logs" / "unrelated.txt",
+    ]
+    for path in [*telemetry, *artifacts]:
+        _write(path)
+
+    removed = clear_runtime_telemetry(cache_root)
+
+    assert set(removed) == set(telemetry)
+    assert all(not path.exists() for path in telemetry)
+    assert all(path.exists() for path in artifacts)
+
+
+def test_cleanup_leaves_a_missing_cache_root_unchanged(tmp_path: Path) -> None:
+    assert clear_runtime_telemetry(tmp_path / "missing") == []

--- a/ci/tests/test_hosted_compile_concurrency.py
+++ b/ci/tests/test_hosted_compile_concurrency.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _step_block(workflow: str, name: str, next_name: str | None = None) -> str:
+    block = workflow.split(f"      - name: {name}\n", 1)[1]
+    if next_name is not None:
+        block = block.split(f"      - name: {next_name}\n", 1)[0]
+    return block
+
+
+def test_hosted_daemon_core_and_workspace_test_compiles_are_serialized() -> None:
+    """Every hosted lib-test/full-workspace compile names both admission limits."""
+    required_steps = {
+        "integration.yml": (
+            (
+                "Build integration test binaries",
+                "Stop setup-soldr builder cache before tests",
+                "soldr cargo test --workspace",
+            ),
+            (
+                "Test (full workspace)",
+                "Remove build-harness journals before strict audit",
+                "soldr cargo test --workspace",
+            ),
+            (
+                "Test ignored integration and stress suite",
+                "Remove ignored-suite harness journals before strict audit",
+                "soldr cargo test --workspace",
+            ),
+        ),
+        "ci-check.yml": (("Test", "Stop isolated test cache", "soldr cargo test --workspace --lib --bins"),),
+        "coverage.yml": (("Generate coverage", "Stop isolated coverage cache", "soldr cargo llvm-cov --workspace --lib --bins"),),
+        "fs-matrix.yml": (
+            (
+                "Run capability and behavior matrix",
+                "ReFS cluster-rounding acceptance",
+                "soldr cargo test -p zccache-daemon-core",
+            ),
+            (
+                "ReFS cluster-rounding acceptance",
+                None,
+                "soldr cargo test -p zccache-daemon-core",
+            ),
+            (
+                "Run required >4 GiB COW acceptance",
+                None,
+                "soldr cargo test -p zccache-daemon-core",
+            ),
+        ),
+        "perf-guard.yml": (
+            (
+                "Run COW materialization budget",
+                "Build perf benchmark binary",
+                "soldr cargo test -p zccache-daemon-core",
+            ),
+        ),
+    }
+
+    for workflow_name, steps in required_steps.items():
+        workflow = (ROOT / ".github" / "workflows" / workflow_name).read_text(encoding="utf-8")
+        for name, next_name, command in steps:
+            step = _step_block(workflow, name, next_name)
+            environment = step.split("        run:", 1)[0]
+            assert command in step
+            assert 'CARGO_BUILD_JOBS: "1"' in environment
+            assert 'SOLDR_JOBS: "1"' in environment

--- a/ci/tests/test_integration_workflow.py
+++ b/ci/tests/test_integration_workflow.py
@@ -54,3 +54,22 @@ def test_ignored_suite_cleanup_uses_the_same_full_telemetry_helper() -> None:
     assert "if: always()" in cleanup
     assert "ci/clear_runtime_telemetry.py" in cleanup
     assert '--cache-root "$SOLDR_CACHE_DIR/cache/zccache"' in cleanup
+
+
+def test_workspace_test_phases_bound_compile_and_runtime_concurrency() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    full_suite = _step_block(
+        workflow,
+        "Test (full workspace)",
+        "Remove build-harness journals before strict audit",
+    )
+    ignored_suite = _step_block(
+        workflow,
+        "Test ignored integration and stress suite",
+        "Remove ignored-suite harness journals before strict audit",
+    )
+
+    for suite in (full_suite, ignored_suite):
+        assert 'CARGO_BUILD_JOBS: "1"' in suite
+        assert 'SOLDR_JOBS: "1"' in suite
+        assert "--test-threads=1" in suite

--- a/ci/tests/test_integration_workflow.py
+++ b/ci/tests/test_integration_workflow.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "integration.yml"
 
@@ -25,5 +24,33 @@ def test_build_harness_journal_cleanup_runs_after_test_failure() -> None:
     )
 
     assert "        if: always()\n" in cleanup
-    assert "find \"$journal_root\" -type f -path '*/logs/*.jsonl' -print -delete" in cleanup
+    assert "ci/clear_runtime_telemetry.py" in cleanup
+    assert '--cache-root "$SOLDR_CACHE_DIR/cache/zccache"' in cleanup
     assert "        if: always()\n" in audit
+    assert "astral-sh/setup-uv@v6" in workflow
+
+
+def test_wrapper_contract_telemetry_is_cleared_before_the_strict_audit() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    cleanup = _step_block(
+        workflow,
+        "Remove wrapper-contract telemetry before strict audit",
+        "Strict artifact-layout validation",
+    )
+
+    assert "        if: always()\n" in cleanup
+    assert "ci/clear_runtime_telemetry.py" in cleanup
+    assert '--cache-root "$SOLDR_CACHE_DIR/cache/zccache"' in cleanup
+
+
+def test_ignored_suite_cleanup_uses_the_same_full_telemetry_helper() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    cleanup = _step_block(
+        workflow,
+        "Remove ignored-suite harness journals before strict audit",
+        "Stop isolated test cache",
+    )
+
+    assert "if: always()" in cleanup
+    assert "ci/clear_runtime_telemetry.py" in cleanup
+    assert '--cache-root "$SOLDR_CACHE_DIR/cache/zccache"' in cleanup

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/request_prep.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/request_prep.rs
@@ -370,6 +370,12 @@ pub(super) async fn parse_single_compile_request(
     let compilation = match parsed {
         crate::compiler::ParsedInvocation::Cacheable(compilation) => compilation,
         crate::compiler::ParsedInvocation::NonCacheable { reason } => {
+            // Preserve the parser's decision before the direct compiler can
+            // remove an @response file that later journal attribution would
+            // otherwise need to re-read (issue #1529).
+            crate::daemon::compile_journal::record_miss_reason(
+                crate::daemon::compile_journal::miss_reason::UNCACHEABLE_INPUT,
+            );
             state.stats.record_non_cacheable();
             record_session_stat(&state.sessions, sid, |tracker| {
                 tracker.record_non_cacheable()

--- a/crates/zccache-daemon-core/src/daemon/server/tests/connection_self_profile.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/connection_self_profile.rs
@@ -231,6 +231,96 @@ fn rsp_missing_at_journal_time_keeps_default_reason() {
     );
 }
 
+// Issue #1529: the compiler can remove a response file after the daemon has
+// expanded and classified it, but before the asynchronous journal row is
+// attributed. The parser's non-cacheable result must survive that cleanup.
+#[cfg(unix)]
+#[tokio::test]
+async fn deleted_non_cacheable_response_file_keeps_parse_time_reason() {
+    use std::os::unix::fs::PermissionsExt;
+
+    crate::test_support::test_timeout(async {
+        let temp = tempfile::tempdir().unwrap();
+        let endpoint = crate::ipc::unique_test_endpoint();
+        let mut server = super::bind_isolated_server_at(&endpoint, temp.path());
+        let shutdown = server.shutdown_handle();
+        let server_task = tokio::spawn(async move { server.run(0).await.unwrap() });
+
+        let compiler = temp.path().join("rustc");
+        std::fs::write(&compiler, "#!/bin/sh\nrm -- \"${1#@}\"\nexit 0\n").unwrap();
+        std::fs::set_permissions(&compiler, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let rsp = temp.path().join("preprocess.rsp");
+        let source = temp.path().join("fixture.rs");
+        std::fs::write(&source, "fn main() {}\n").unwrap();
+        std::fs::write(&rsp, format!("--test\n{}\n", source.display())).unwrap();
+
+        let mut client = crate::ipc::connect(&endpoint).await.unwrap();
+        client
+            .send(&Request::SessionStart {
+                client_pid: std::process::id(),
+                working_dir: temp.path().into(),
+                log_file: None,
+                track_stats: false,
+                journal_path: None,
+                profile: false,
+                private_daemon: None,
+            })
+            .await
+            .unwrap();
+        let session_id = match client.recv().await.unwrap() {
+            Some(Response::SessionStarted { session_id, .. }) => session_id,
+            response => panic!("expected SessionStarted, got {response:?}"),
+        };
+
+        client
+            .send(&Request::Compile {
+                session_id,
+                args: vec![format!("@{}", rsp.display())],
+                cwd: temp.path().into(),
+                compiler: compiler.into(),
+                env: None,
+                stdin: Vec::new(),
+            })
+            .await
+            .unwrap();
+        assert!(matches!(
+            client.recv().await.unwrap(),
+            Some(Response::CompileResult {
+                exit_code: 0,
+                cached: false,
+                ..
+            })
+        ));
+        assert!(
+            !rsp.exists(),
+            "the direct compiler must remove the response file"
+        );
+
+        let journal = temp
+            .path()
+            .join("zccache-cache")
+            .join("logs")
+            .join("compile_journal.jsonl");
+        let row = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if let Ok(contents) = std::fs::read_to_string(&journal) {
+                    if let Some(line) = contents.lines().next() {
+                        break serde_json::from_str::<serde_json::Value>(line).unwrap();
+                    }
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("compile journal row");
+        assert_eq!(row["miss_reason"], miss_reason::UNCACHEABLE_INPUT);
+
+        shutdown.notify_one();
+        server_task.await.unwrap();
+    })
+    .await;
+}
+
 #[test]
 fn hit_split_has_non_zero_hash_lookup_decompress() {
     let s = derive_approx_spans("hit", 999).unwrap();


### PR DESCRIPTION
Fixes #1529.

A parser-recognized non-cacheable invocation records uncacheable_input before direct compiler execution, so a compiler deleting an already-expanded response file cannot turn later compile-journal attribution into unknown.

The first exact-head Integration run also exposed seeded runtime telemetry from Soldr's released embedded zccache (v1.13.11): its cleanup removed only JSONL files while audit-logs also consumes lifecycle and daemon log archives. This PR now clears every audit-consumed telemetry form through a tested Python helper at each integration boundary, preserving cache artifacts; workflow YAML stays orchestration-only.

Regression coverage includes a real Unix daemon/IPC Rust --test @rsp case whose fake direct compiler deletes the file, plus fixture coverage for every audit-consumed telemetry filename and workflow placement guards.

Validation:
- focused daemon regression (1 passed)
- telemetry/workflow tests (5 passed)
- full ci/tests (445 passed, 8 skipped)
- ruff check/format and git diff --check
- independent clud-review: clean

Fixes #1533.

Additional validation for the bounded Integration policy:
- workflow policy RED then GREEN (4 passed)
- full ci/tests (446 passed, 8 skipped)
- independent clud-review: clean

#1533 broadened after the required Perf Guard COW gate reproduced the daemon-core library-test compiler kill on f812e254. This exact head adds a nine-phase hosted CI inventory contract covering Integration prebuild/full/ignored, reusable CI Check, Coverage, all three Filesystem Matrix phases, and the required COW gate; unrelated focused and performance-binary work stays unchanged.

Additional validation: inventory RED then GREEN (5 focused tests), full ci/tests (447 passed, 8 skipped), ruff check/format, git diff --check, and fresh independent clud-review: clean.