### PR TITLE
fix(msvc): cache cl.exe compiles and track /showIncludes dependencies

### DIFF
--- a/crates/zccache-compiler/src/detect.rs
+++ b/crates/zccache-compiler/src/detect.rs
@@ -54,11 +54,7 @@ pub fn dylint_inner_rustc_args<'a>(
 #[must_use]
 pub fn detect_family(compiler: &str) -> CompilerFamily {
     // Split on both `/` and `\` so Windows-style paths work on all platforms.
-    let basename = compiler.rsplit(['/', '\\']).next().unwrap_or(compiler);
-    let name = match basename.rsplit_once('.') {
-        Some((stem, _)) => stem,
-        None => basename,
-    };
+    let name = compiler_stem(compiler);
     if name == "rustfmt" || name.starts_with("rustfmt-") {
         CompilerFamily::Rustfmt
     } else if is_dylint_driver(compiler)
@@ -91,12 +87,21 @@ pub fn detect_family(compiler: &str) -> CompilerFamily {
 /// discovery mode at all and takes its search roots from `%INCLUDE%`.
 #[must_use]
 pub fn is_msvc_cl(compiler: &str) -> bool {
+    compiler_stem(compiler).eq_ignore_ascii_case("cl")
+}
+
+/// The compiler's basename with any final `.<ext>` stripped.
+///
+/// Splits on both `/` and `\` so Windows-style paths work on every host. Unlike
+/// [`executable_stem`], which only removes a `.exe` suffix, this drops whatever
+/// extension is present — the family table matches on names like `clang-18`
+/// and `cl` that may or may not carry one.
+fn compiler_stem(compiler: &str) -> &str {
     let basename = compiler.rsplit(['/', '\\']).next().unwrap_or(compiler);
-    let name = match basename.rsplit_once('.') {
+    match basename.rsplit_once('.') {
         Some((stem, _)) => stem,
         None => basename,
-    };
-    name.eq_ignore_ascii_case("cl")
+    }
 }
 
 /// Whether the executable basename refers to clang-cl (the MSVC-syntax driver).

--- a/crates/zccache-compiler/src/detect.rs
+++ b/crates/zccache-compiler/src/detect.rs
@@ -83,6 +83,22 @@ pub fn detect_family(compiler: &str) -> CompilerFamily {
     }
 }
 
+/// Whether `compiler` is Microsoft's own `cl.exe` rather than `clang-cl`.
+///
+/// Both classify as [`CompilerFamily::Msvc`] because they share the argument
+/// syntax, but they differ where it matters for system-include discovery:
+/// `clang-cl` is a clang driver and answers `-v -E`, while `cl.exe` has no
+/// discovery mode at all and takes its search roots from `%INCLUDE%`.
+#[must_use]
+pub fn is_msvc_cl(compiler: &str) -> bool {
+    let basename = compiler.rsplit(['/', '\\']).next().unwrap_or(compiler);
+    let name = match basename.rsplit_once('.') {
+        Some((stem, _)) => stem,
+        None => basename,
+    };
+    name.eq_ignore_ascii_case("cl")
+}
+
 /// Whether the executable basename refers to clang-cl (the MSVC-syntax driver).
 ///
 /// Matches `clang-cl`, `clang-cl-17`, `Clang-CL.EXE`, etc. `name` is the

--- a/crates/zccache-compiler/src/lib.rs
+++ b/crates/zccache-compiler/src/lib.rs
@@ -41,7 +41,7 @@ mod tests;
 use std::sync::Arc;
 use zccache_core::NormalizedPath;
 
-pub use detect::{detect_family, dylint_inner_rustc_args, is_dylint_driver};
+pub use detect::{detect_family, dylint_inner_rustc_args, is_dylint_driver, is_msvc_cl};
 pub use dylint::{
     dylint_env_affects_output, prepare_dylint_cache_env, prepare_dylint_cache_env_with_identities,
     DYLINT_CACHE_INPUT_HASH_ENV, DYLINT_LIBS_ENV,

--- a/crates/zccache-compiler/src/tests/detect.rs
+++ b/crates/zccache-compiler/src/tests/detect.rs
@@ -1,6 +1,6 @@
 //! `detect_family` + `supports_depfile` for clang/gcc/msvc/emcc.
 
-use super::super::{detect_family, CompilerFamily};
+use super::super::{detect_family, is_msvc_cl, CompilerFamily};
 
 #[test]
 fn detect_clang_family() {
@@ -66,4 +66,38 @@ fn clang_supports_depfile() {
 #[test]
 fn msvc_no_depfile() {
     assert!(!CompilerFamily::Msvc.supports_depfile());
+}
+
+// --- Issue #1530: cl.exe vs clang-cl for system-include discovery ---------
+
+#[test]
+fn is_msvc_cl_matches_only_microsofts_driver() {
+    for compiler in [
+        "cl",
+        "cl.exe",
+        "CL.EXE",
+        "Cl.exe",
+        r"C:\Program Files\MSVC\bin\cl.EXE",
+        "/mnt/c/MSVC/cl",
+    ] {
+        assert!(is_msvc_cl(compiler), "expected cl.exe: {compiler}");
+    }
+}
+
+#[test]
+fn is_msvc_cl_excludes_clang_cl_and_others() {
+    // clang-cl parses MSVC syntax (family Msvc) but is a clang driver: it
+    // answers the `-v -E` include probe, so it must keep using it.
+    for compiler in [
+        "clang-cl",
+        "clang-cl.exe",
+        r"C:\LLVM\bin\clang-cl.exe",
+        "clang-cl-17",
+        "gcc",
+        "clang",
+        "cl-wrapper",
+        "mycl.exe",
+    ] {
+        assert!(!is_msvc_cl(compiler), "expected not cl.exe: {compiler}");
+    }
 }

--- a/crates/zccache-daemon-core/src/daemon/compile_output.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_output.rs
@@ -61,10 +61,46 @@ pub(crate) fn current() -> Option<OutputContext> {
     OUTPUT_CONTEXT.try_with(Clone::clone).ok()
 }
 
+/// Which compiler stream the dependency scanner reads, and whether its lines
+/// are ours to remove.
+///
+/// `clang -H` writes its trace to **stderr**. MSVC / clang-cl `/showIncludes`
+/// writes `Note: including file:` to **stdout** (issue #1530 — the daemon used
+/// to scan stderr for it, found nothing, and recorded zero dependencies, which
+/// turned every subsequent MSVC compile into a stale cache hit after a header
+/// edit).
 pub(crate) enum StderrFilter<'a> {
     None,
-    ShowIncludes { source: &'a Path, cwd: &'a Path },
-    HeaderTrace { source: &'a Path, cwd: &'a Path },
+    ShowIncludes {
+        source: &'a Path,
+        cwd: &'a Path,
+        /// True when the daemon added `/showIncludes` itself, so the notes are
+        /// its own bookkeeping and must not reach the caller. False when the
+        /// caller passed the flag — CMake + Ninja MSVC builds parse those notes
+        /// into their own depfiles, so they are scanned but passed through.
+        injected: bool,
+    },
+    HeaderTrace {
+        source: &'a Path,
+        cwd: &'a Path,
+    },
+}
+
+impl StderrFilter<'_> {
+    /// The stream the parser attaches to. Everything except `/showIncludes`
+    /// reads stderr.
+    fn reads_stdout(&self) -> bool {
+        matches!(self, Self::ShowIncludes { .. })
+    }
+
+    /// Whether the scanned lines are removed from the stream the caller sees.
+    fn strips_scanned_lines(&self) -> bool {
+        match self {
+            Self::None => false,
+            Self::ShowIncludes { injected, .. } => *injected,
+            Self::HeaderTrace { .. } => true,
+        }
+    }
 }
 
 pub(crate) struct CapturedOutput {
@@ -102,9 +138,11 @@ pub(crate) async fn consume(
     context.mark_live();
     let mut stdout = BoundedCapture::new(context.capture_limit, "stdout");
     let mut stderr = BoundedCapture::new(context.capture_limit, "stderr");
+    let parser_reads_stdout = stderr_filter.reads_stdout();
+    let strips_scanned_lines = stderr_filter.strips_scanned_lines();
     let mut dependency_parser = match stderr_filter {
         StderrFilter::None => None,
-        StderrFilter::ShowIncludes { source, cwd } => Some(DependencyParser::ShowIncludes(
+        StderrFilter::ShowIncludes { source, cwd, .. } => Some(DependencyParser::ShowIncludes(
             crate::depgraph::show_includes::ShowIncludesParser::new(source, cwd),
         )),
         StderrFilter::HeaderTrace { source, cwd } => Some(DependencyParser::HeaderTrace(
@@ -112,21 +150,41 @@ pub(crate) async fn consume(
         )),
     };
 
+    // Run `bytes` through the dependency parser and return what the caller
+    // should see: the parser's residue when we own the scanned lines, the
+    // original bytes when the caller asked for them itself.
+    fn scan_chunk(parser: &mut Option<DependencyParser>, strip: bool, bytes: Vec<u8>) -> Vec<u8> {
+        let Some(parser) = parser.as_mut() else {
+            return bytes;
+        };
+        let mut residue = Vec::new();
+        parser.push(&bytes, &mut residue);
+        if strip {
+            residue
+        } else {
+            bytes
+        }
+    }
+
     while let Some(chunk) = receiver.recv().await {
         match chunk {
             RawOutputChunk::Stdout(bytes) => {
+                let bytes = if parser_reads_stdout {
+                    scan_chunk(&mut dependency_parser, strips_scanned_lines, bytes)
+                } else {
+                    bytes
+                };
                 if let Some(bytes) = stdout.push(&bytes) {
                     send(&context.sender, OutputChunk::Stdout(bytes)).await?;
                 }
             }
             RawOutputChunk::Stderr(bytes) => {
-                let mut filtered = Vec::new();
-                if let Some(parser) = dependency_parser.as_mut() {
-                    parser.push(&bytes, &mut filtered);
+                let bytes = if parser_reads_stdout {
+                    bytes
                 } else {
-                    filtered = bytes;
-                }
-                if let Some(bytes) = stderr.push(&filtered) {
+                    scan_chunk(&mut dependency_parser, strips_scanned_lines, bytes)
+                };
+                if let Some(bytes) = stderr.push(&bytes) {
                     send(&context.sender, OutputChunk::Stderr(bytes)).await?;
                 }
             }
@@ -134,10 +192,25 @@ pub(crate) async fn consume(
     }
 
     let dependency_scan = if let Some(parser) = dependency_parser {
-        let mut filtered = Vec::new();
-        let scan = parser.finish(&mut filtered);
-        if let Some(bytes) = stderr.push(&filtered) {
-            send(&context.sender, OutputChunk::Stderr(bytes)).await?;
+        // Flush whatever the line splitter is still holding. When we are not
+        // stripping, that tail already went through verbatim, so the residue
+        // is dropped rather than duplicated.
+        let mut residue = Vec::new();
+        let scan = parser.finish(&mut residue);
+        if strips_scanned_lines {
+            let capture = if parser_reads_stdout {
+                &mut stdout
+            } else {
+                &mut stderr
+            };
+            if let Some(bytes) = capture.push(&residue) {
+                let chunk = if parser_reads_stdout {
+                    OutputChunk::Stdout(bytes)
+                } else {
+                    OutputChunk::Stderr(bytes)
+                };
+                send(&context.sender, chunk).await?;
+            }
         }
         Some(scan)
     } else {
@@ -350,6 +423,129 @@ mod tests {
         );
         assert_eq!(captured.stderr, b"warning: retained\n");
         assert_eq!(emitted, captured.stderr);
+    }
+
+    // ── Issue #1530: /showIncludes lives on stdout ──────────────────────
+
+    /// Feed a `/showIncludes` transcript in on one stream and return
+    /// `(scan, stdout, stderr)`.
+    async fn run_show_includes(
+        transcript_on_stdout: bool,
+        injected: bool,
+        source: &Path,
+        cwd: &Path,
+        transcript: &str,
+    ) -> (Option<crate::depgraph::ScanResult>, Vec<u8>, Vec<u8>) {
+        let (sender, _chunks) = mpsc::channel(256);
+        let context = OutputContext::new(sender);
+        let (raw_sender, raw_receiver) = mpsc::channel(256);
+        // Chunk it finely so the line splitter has to reassemble across
+        // boundaries, the way a real pipe delivers it.
+        for bytes in transcript.as_bytes().chunks(7) {
+            let chunk = if transcript_on_stdout {
+                RawOutputChunk::Stdout(bytes.to_vec())
+            } else {
+                RawOutputChunk::Stderr(bytes.to_vec())
+            };
+            raw_sender.send(chunk).await.expect("raw receiver");
+        }
+        drop(raw_sender);
+        let captured = super::consume(
+            raw_receiver,
+            context,
+            StderrFilter::ShowIncludes {
+                source,
+                cwd,
+                injected,
+            },
+        )
+        .await
+        .expect("capture");
+        (captured.dependency_scan, captured.stdout, captured.stderr)
+    }
+
+    #[tokio::test]
+    async fn show_includes_is_scanned_from_stdout_and_stripped_when_injected() {
+        // The regression: cl.exe prints these notes on stdout. Scanning
+        // stderr recorded zero dependencies, so a header edit did not
+        // invalidate the cached object.
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let source = temp.path().join("main.c");
+        let header = temp.path().join("dep.h");
+        std::fs::write(&source, "").expect("source");
+        std::fs::write(&header, "").expect("header");
+        let transcript = format!("main.c\r\nNote: including file: {}\r\n", header.display());
+
+        let (scan, stdout, stderr) =
+            run_show_includes(true, true, &source, temp.path(), &transcript).await;
+        let scan = scan.expect("show-includes scan");
+        assert_eq!(
+            scan.resolved,
+            vec![crate::depgraph::depfile::canonicalize_path(
+                &header,
+                temp.path()
+            )]
+        );
+        assert_eq!(stdout, b"main.c\r\n");
+        assert!(stderr.is_empty());
+    }
+
+    #[tokio::test]
+    async fn show_includes_notes_survive_when_the_caller_asked_for_them() {
+        // CMake + Ninja MSVC builds pass /showIncludes themselves and parse
+        // the notes into their own depfiles. Stripping them would break the
+        // build system's dependency tracking.
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let source = temp.path().join("main.c");
+        let header = temp.path().join("dep.h");
+        std::fs::write(&source, "").expect("source");
+        std::fs::write(&header, "").expect("header");
+        let transcript = format!("main.c\r\nNote: including file: {}\r\n", header.display());
+
+        let (scan, stdout, _stderr) =
+            run_show_includes(true, false, &source, temp.path(), &transcript).await;
+        assert_eq!(
+            scan.expect("show-includes scan").resolved,
+            vec![crate::depgraph::depfile::canonicalize_path(
+                &header,
+                temp.path()
+            )]
+        );
+        assert_eq!(stdout, transcript.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn show_includes_leaves_stderr_untouched() {
+        // Real diagnostics go to stderr and must pass through whole even
+        // though the dependency parser is attached to stdout.
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let source = temp.path().join("main.c");
+        std::fs::write(&source, "").expect("source");
+        let (sender, _chunks) = mpsc::channel(64);
+        let context = OutputContext::new(sender);
+        let (raw_sender, raw_receiver) = mpsc::channel(64);
+        raw_sender
+            .send(RawOutputChunk::Stderr(
+                b"main.c(1): warning C4101: unreferenced\r\n".to_vec(),
+            ))
+            .await
+            .expect("raw receiver");
+        drop(raw_sender);
+        let captured = super::consume(
+            raw_receiver,
+            context,
+            StderrFilter::ShowIncludes {
+                source: &source,
+                cwd: temp.path(),
+                injected: true,
+            },
+        )
+        .await
+        .expect("capture");
+        assert_eq!(
+            captured.stderr,
+            b"main.c(1): warning C4101: unreferenced\r\n"
+        );
     }
 
     #[tokio::test]

--- a/crates/zccache-daemon-core/src/daemon/compile_output.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_output.rs
@@ -69,7 +69,7 @@ pub(crate) fn current() -> Option<OutputContext> {
 /// to scan stderr for it, found nothing, and recorded zero dependencies, which
 /// turned every subsequent MSVC compile into a stale cache hit after a header
 /// edit).
-pub(crate) enum StderrFilter<'a> {
+pub(crate) enum OutputFilter<'a> {
     None,
     ShowIncludes {
         source: &'a Path,
@@ -86,7 +86,7 @@ pub(crate) enum StderrFilter<'a> {
     },
 }
 
-impl StderrFilter<'_> {
+impl OutputFilter<'_> {
     /// The stream the parser attaches to. Everything except `/showIncludes`
     /// reads stderr.
     fn reads_stdout(&self) -> bool {
@@ -133,34 +133,42 @@ impl DependencyParser {
 pub(crate) async fn consume(
     mut receiver: mpsc::Receiver<RawOutputChunk>,
     context: OutputContext,
-    stderr_filter: StderrFilter<'_>,
+    output_filter: OutputFilter<'_>,
 ) -> io::Result<CapturedOutput> {
     context.mark_live();
     let mut stdout = BoundedCapture::new(context.capture_limit, "stdout");
     let mut stderr = BoundedCapture::new(context.capture_limit, "stderr");
-    let parser_reads_stdout = stderr_filter.reads_stdout();
-    let strips_scanned_lines = stderr_filter.strips_scanned_lines();
-    let mut dependency_parser = match stderr_filter {
-        StderrFilter::None => None,
-        StderrFilter::ShowIncludes { source, cwd, .. } => Some(DependencyParser::ShowIncludes(
+    let parser_reads_stdout = output_filter.reads_stdout();
+    let strips_scanned_lines = output_filter.strips_scanned_lines();
+    let mut dependency_parser = match output_filter {
+        OutputFilter::None => None,
+        OutputFilter::ShowIncludes { source, cwd, .. } => Some(DependencyParser::ShowIncludes(
             crate::depgraph::show_includes::ShowIncludesParser::new(source, cwd),
         )),
-        StderrFilter::HeaderTrace { source, cwd } => Some(DependencyParser::HeaderTrace(
+        OutputFilter::HeaderTrace { source, cwd } => Some(DependencyParser::HeaderTrace(
             crate::depgraph::header_trace::HeaderTraceParser::new(source, cwd),
         )),
     };
 
     // Run `bytes` through the dependency parser and return what the caller
     // should see: the parser's residue when we own the scanned lines, the
-    // original bytes when the caller asked for them itself.
-    fn scan_chunk(parser: &mut Option<DependencyParser>, strip: bool, bytes: Vec<u8>) -> Vec<u8> {
+    // original bytes when the caller asked for them itself. `residue` is
+    // reused across chunks so the no-strip path does not allocate per chunk
+    // just to throw the buffer away.
+    let mut residue = Vec::new();
+    fn scan_chunk(
+        parser: &mut Option<DependencyParser>,
+        strip: bool,
+        residue: &mut Vec<u8>,
+        bytes: Vec<u8>,
+    ) -> Vec<u8> {
         let Some(parser) = parser.as_mut() else {
             return bytes;
         };
-        let mut residue = Vec::new();
-        parser.push(&bytes, &mut residue);
+        residue.clear();
+        parser.push(&bytes, residue);
         if strip {
-            residue
+            std::mem::take(residue)
         } else {
             bytes
         }
@@ -170,7 +178,12 @@ pub(crate) async fn consume(
         match chunk {
             RawOutputChunk::Stdout(bytes) => {
                 let bytes = if parser_reads_stdout {
-                    scan_chunk(&mut dependency_parser, strips_scanned_lines, bytes)
+                    scan_chunk(
+                        &mut dependency_parser,
+                        strips_scanned_lines,
+                        &mut residue,
+                        bytes,
+                    )
                 } else {
                     bytes
                 };
@@ -182,7 +195,12 @@ pub(crate) async fn consume(
                 let bytes = if parser_reads_stdout {
                     bytes
                 } else {
-                    scan_chunk(&mut dependency_parser, strips_scanned_lines, bytes)
+                    scan_chunk(
+                        &mut dependency_parser,
+                        strips_scanned_lines,
+                        &mut residue,
+                        bytes,
+                    )
                 };
                 if let Some(bytes) = stderr.push(&bytes) {
                     send(&context.sender, OutputChunk::Stderr(bytes)).await?;
@@ -195,7 +213,7 @@ pub(crate) async fn consume(
         // Flush whatever the line splitter is still holding. When we are not
         // stripping, that tail already went through verbatim, so the residue
         // is dropped rather than duplicated.
-        let mut residue = Vec::new();
+        residue.clear();
         let scan = parser.finish(&mut residue);
         if strips_scanned_lines {
             let capture = if parser_reads_stdout {
@@ -360,7 +378,7 @@ mod tests {
             .expect("raw output receiver");
         drop(raw_sender);
 
-        let captured = super::consume(raw_receiver, context, StderrFilter::None)
+        let captured = super::consume(raw_receiver, context, OutputFilter::None)
             .await
             .expect("capture");
         let mut emitted = Vec::new();
@@ -398,7 +416,7 @@ mod tests {
         let captured = super::consume(
             raw_receiver,
             context,
-            StderrFilter::HeaderTrace {
+            OutputFilter::HeaderTrace {
                 source: &source,
                 cwd: temp.path(),
             },
@@ -453,7 +471,7 @@ mod tests {
         let captured = super::consume(
             raw_receiver,
             context,
-            StderrFilter::ShowIncludes {
+            OutputFilter::ShowIncludes {
                 source,
                 cwd,
                 injected,
@@ -534,7 +552,7 @@ mod tests {
         let captured = super::consume(
             raw_receiver,
             context,
-            StderrFilter::ShowIncludes {
+            OutputFilter::ShowIncludes {
                 source: &source,
                 cwd: temp.path(),
                 injected: true,
@@ -568,7 +586,7 @@ mod tests {
             None,
             raw_sender,
         );
-        let consume = super::consume(raw_receiver, context, StderrFilter::None);
+        let consume = super::consume(raw_receiver, context, OutputFilter::None);
         let operation = async {
             let (process, capture) = tokio::join!(process, consume);
             (
@@ -616,7 +634,7 @@ mod tests {
                     None,
                     raw_sender,
                 );
-            let consume = super::consume(raw_receiver, context, StderrFilter::None);
+            let consume = super::consume(raw_receiver, context, OutputFilter::None);
             tokio::join!(process, consume)
         };
         let mut operation = Box::pin(operation);

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -127,11 +127,19 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     // For MSVC, use /showIncludes to get complete dependency info
     // (equivalent to depfiles for gcc/clang). This enables cache hits
     // for files with computed includes like `#include MACRO`.
+    //
+    // `injected_show_includes` records whether *we* added the flag. When the
+    // caller passed it (CMake + Ninja MSVC builds do, and parse the notes into
+    // their own depfiles), the notes are output the build system is waiting
+    // for: scan them, but pass them through untouched. Only notes we asked for
+    // get stripped.
+    let mut injected_show_includes = false;
     if compilation.family == crate::compiler::CompilerFamily::Msvc
         && depfile_strategy == DepfileStrategy::Unsupported
     {
         if !dep_flags.has_md {
             extra_args.push("/showIncludes".to_string());
+            injected_show_includes = true;
         }
         depfile_strategy = DepfileStrategy::ShowIncludes;
     }
@@ -339,6 +347,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
             crate::daemon::compile_output::StderrFilter::ShowIncludes {
                 source: source_path.as_path(),
                 cwd: cwd_path.as_path(),
+                injected: injected_show_includes,
             }
         } else if stderr_header_trace {
             crate::daemon::compile_output::StderrFilter::HeaderTrace {
@@ -415,12 +424,22 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     let (stdout_bytes, dependency_scan, stderr_bytes) = if let Some(streamed) = streamed_output {
         (streamed.stdout, streamed.dependency_scan, streamed.stderr)
     } else if depfile_strategy == DepfileStrategy::ShowIncludes {
+        // Issue #1530: MSVC / clang-cl write `/showIncludes` notes to STDOUT,
+        // not stderr. Scanning stderr found nothing, so every MSVC compile
+        // recorded zero dependencies and went on serving a stale object after
+        // a header edit. The notes are stripped only when the daemon injected
+        // the flag — a caller that passed it (CMake + Ninja) is parsing them.
         let (scan, filtered) = crate::depgraph::show_includes::parse_show_includes(
-            &output.stderr,
+            &output.stdout,
             source_path,
             cwd_path,
         );
-        (output.stdout, Some(scan), filtered)
+        let stdout = if injected_show_includes {
+            filtered
+        } else {
+            output.stdout
+        };
+        (stdout, Some(scan), output.stderr)
     } else if stderr_header_trace {
         let (scan, filtered) = crate::depgraph::header_trace::parse_header_trace(
             &output.stderr,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -132,16 +132,31 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     // caller passed it (CMake + Ninja MSVC builds do, and parse the notes into
     // their own depfiles), the notes are output the build system is waiting
     // for: scan them, but pass them through untouched. Only notes we asked for
-    // get stripped.
+    // get stripped. `keys::msvc_show_includes_key_flags` keeps the two
+    // populations in separate cache entries so a stripped one is never
+    // replayed to a caller that is parsing the notes.
     let mut injected_show_includes = false;
     if compilation.family == crate::compiler::CompilerFamily::Msvc
         && depfile_strategy == DepfileStrategy::Unsupported
     {
-        if !dep_flags.has_md {
-            extra_args.push("/showIncludes".to_string());
-            injected_show_includes = true;
+        use crate::depgraph::msvc_args::ShowIncludesMode;
+        match crate::depgraph::msvc_args::msvc_show_includes_mode(effective_args) {
+            None => {
+                extra_args.push("/showIncludes".to_string());
+                injected_show_includes = true;
+                depfile_strategy = DepfileStrategy::ShowIncludes;
+            }
+            Some(ShowIncludesMode::All) => {
+                depfile_strategy = DepfileStrategy::ShowIncludes;
+            }
+            // `/showIncludes:user` omits system headers on purpose, so its
+            // trace is not a dependency set we can trust — and we cannot add a
+            // second `/showIncludes` to get a full one without overriding what
+            // the caller asked for. Leave the strategy `Unsupported` so the
+            // daemon's own header scanner supplies the dependencies, and leave
+            // the caller's stdout alone.
+            Some(ShowIncludesMode::UserOnly) => {}
         }
-        depfile_strategy = DepfileStrategy::ShowIncludes;
     }
 
     let expected_outputs = if let Some(rustc_args) = rustc_args_opt {
@@ -344,18 +359,18 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     {
         let (sender, receiver) = tokio::sync::mpsc::channel(8);
         let filter = if depfile_strategy == DepfileStrategy::ShowIncludes {
-            crate::daemon::compile_output::StderrFilter::ShowIncludes {
+            crate::daemon::compile_output::OutputFilter::ShowIncludes {
                 source: source_path.as_path(),
                 cwd: cwd_path.as_path(),
                 injected: injected_show_includes,
             }
         } else if stderr_header_trace {
-            crate::daemon::compile_output::StderrFilter::HeaderTrace {
+            crate::daemon::compile_output::OutputFilter::HeaderTrace {
                 source: source_path.as_path(),
                 cwd: cwd_path.as_path(),
             }
         } else {
-            crate::daemon::compile_output::StderrFilter::None
+            crate::daemon::compile_output::OutputFilter::None
         };
         let process = crate::daemon::process::tokio_command_output_streaming_with_priority_decision(
             &mut cmd,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/request_prep.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/request_prep.rs
@@ -305,6 +305,7 @@ pub(super) async fn discover_request_system_includes(
         lineage,
         compiler_priority,
         want_rust_miss_profile,
+        client_env.as_deref(),
     )
     .await;
     if !outcome.empty_discovery {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/system_includes.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/system_includes.rs
@@ -44,6 +44,7 @@ pub(super) async fn discover_system_includes(
     lineage: &crate::daemon::lineage::Lineage,
     compiler_priority: CompilePriority,
     want_rust_miss_profile: bool,
+    client_env: Option<&[(String, String)]>,
 ) -> SystemIncludesOutcome {
     // Discover system includes for this compiler (cached per compiler path).
     //
@@ -58,7 +59,10 @@ pub(super) async fn discover_system_includes(
     let t_system_includes = want_rust_miss_profile.then(std::time::Instant::now);
     let compiler_family = crate::compiler::detect_family(&compiler.to_string_lossy());
     let needs_discovery = compiler_family.needs_system_include_discovery();
-    let (system_includes, empty_discovery) = if !needs_discovery {
+    let msvc_cl_includes = msvc_cl_system_includes(&compiler.to_string_lossy(), client_env);
+    let (system_includes, empty_discovery) = if let Some(includes) = msvc_cl_includes {
+        (includes, false)
+    } else if !needs_discovery {
         (Vec::new(), false)
     } else {
         // Issue #541 option B: for the clang family the daemon prefers
@@ -232,6 +236,51 @@ async fn discover_system_include_paths(
     }
 }
 
+/// System include roots for Microsoft's `cl.exe`, read from `%INCLUDE%`.
+///
+/// Returns `None` for every other compiler, meaning "use the spawn-based
+/// discovery path".
+///
+/// Issue #1530: `cl.exe` has no `-v -E` discovery mode. Probing it spawns a
+/// compiler that rejects the C/C++-preprocessor flags and prints no
+/// `#include <...> search starts here:` section, so the parse yields zero
+/// paths. Under the issue #1167 guard that "process succeeded, zero paths"
+/// result is a *degraded* probe, and the caller diverts the compile to the
+/// uncached bypass. Because #1167 also (correctly) refuses to memoize an empty
+/// result, the probe re-ran and the bypass re-fired on every single compile —
+/// so an MSVC build cached nothing, ever.
+///
+/// `cl.exe` resolves `#include <...>` against `%INCLUDE%`, which `vcvars`
+/// exports. Reading it from the forwarded client environment is both correct
+/// and free, so `cl.exe` never spawns a discovery process at all.
+///
+/// The result is deliberately **not** memoized in the L1/L2 system-include
+/// cache: `%INCLUDE%` is a property of the client shell (which `vcvars` ran,
+/// for which architecture), not of the compiler binary, so a
+/// per-compiler-path entry would leak one shell's roots into another's.
+///
+/// An absent or empty `INCLUDE` yields `Some(vec![])` — a *known* empty
+/// result, not a degraded one. `cl.exe` genuinely has no other search roots,
+/// and the miss path recovers the real header set from `/showIncludes`
+/// regardless. Reporting it as degraded would resurrect the bypass this fixes.
+///
+/// `clang-cl` also classifies as [`crate::compiler::CompilerFamily::Msvc`],
+/// but it *is* a clang driver and answers the probe, so it is excluded here
+/// and keeps its discovered builtin header directory.
+fn msvc_cl_system_includes(
+    compiler: &str,
+    client_env: Option<&[(String, String)]>,
+) -> Option<Vec<NormalizedPath>> {
+    if !crate::compiler::is_msvc_cl(compiler) {
+        return None;
+    }
+    Some(
+        client_env
+            .map(crate::depgraph::msvc_system_includes_from_env)
+            .unwrap_or_default(),
+    )
+}
+
 async fn run_discovery_command(
     compiler: &NormalizedPath,
     args: &[&str],
@@ -265,5 +314,60 @@ mod tests {
     fn nonempty_discovery_is_cacheable() {
         let paths = [NormalizedPath::new("/toolchain/include")];
         assert!(discovery_result_is_cacheable(Some(&paths)));
+    }
+
+    // ── Issue #1530: MSVC cl.exe takes its roots from %INCLUDE% ─────────
+
+    fn env(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn msvc_cl_reads_include_env_instead_of_probing() {
+        let block = env(&[("INCLUDE", "C:\\VC\\include;C:\\Windows Kits\\10\\ucrt;")]);
+        let includes = msvc_cl_system_includes(
+            "C:\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX64\\x64\\cl.EXE",
+            Some(&block),
+        )
+        .expect("cl.exe must bypass the spawn-based probe");
+        assert_eq!(
+            includes,
+            vec![
+                NormalizedPath::new("C:\\VC\\include"),
+                NormalizedPath::new("C:\\Windows Kits\\10\\ucrt"),
+            ]
+        );
+    }
+
+    #[test]
+    fn msvc_cl_without_include_env_is_known_empty_not_degraded() {
+        // The regression: a `Some(vec![])` here must NOT be reported as
+        // `empty_discovery`, or every cl.exe compile takes the #1167
+        // uncached bypass and the cache stays at zero artifacts forever.
+        assert_eq!(msvc_cl_system_includes("cl.exe", Some(&[])), Some(vec![]));
+        assert_eq!(msvc_cl_system_includes("cl", None), Some(vec![]));
+    }
+
+    #[test]
+    fn clang_cl_still_uses_the_spawn_probe() {
+        // clang-cl classifies as Msvc but is a real clang driver: it answers
+        // `-v -E` and owns builtin headers that %INCLUDE% does not list.
+        let block = env(&[("INCLUDE", "C:\\VC\\include")]);
+        assert_eq!(
+            msvc_cl_system_includes("C:\\LLVM\\bin\\clang-cl.exe", Some(&block)),
+            None
+        );
+        assert_eq!(msvc_cl_system_includes("clang-cl", Some(&block)), None);
+    }
+
+    #[test]
+    fn non_msvc_compilers_still_use_the_spawn_probe() {
+        let block = env(&[("INCLUDE", "C:\\VC\\include")]);
+        for compiler in ["gcc", "/usr/bin/clang++", "rustc", "cl-something"] {
+            assert_eq!(msvc_cl_system_includes(compiler, Some(&block)), None);
+        }
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
@@ -170,7 +170,7 @@ pub(super) async fn run_compiler_direct_with_family(
         let consume = crate::daemon::compile_output::consume(
             receiver,
             context,
-            crate::daemon::compile_output::StderrFilter::None,
+            crate::daemon::compile_output::OutputFilter::None,
         );
         let (process_result, capture_result) = tokio::join!(process, consume);
         (process_result, Some(capture_result))

--- a/crates/zccache-daemon-core/src/daemon/server/keys.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/keys.rs
@@ -510,6 +510,33 @@ pub(super) fn msvc_env_key_flags(
     flags
 }
 
+/// Key flag separating MSVC compiles by who asked for `/showIncludes`.
+///
+/// Issue #1530: `parse_msvc_args` consumes `/showIncludes` without recording it
+/// in `flags`, so `cl /c a.c` and `cl /showIncludes /c a.c` hash to the same
+/// `ContextKey`. Their stored stdout is not interchangeable: when the daemon
+/// injects the flag it strips the `Note: including file:` lines, and when the
+/// caller passes it they are kept. Replaying a stripped entry to a CMake +
+/// Ninja caller would hand it an empty depfile and silently under-rebuild;
+/// replaying the other direction would spam notes into a plain caller's stdout.
+///
+/// Salting the key keeps the two populations in separate entries. Within a
+/// single build every compile is spelled the same way, so this costs no hits.
+pub(super) fn msvc_show_includes_key_flags(
+    family: crate::compiler::CompilerFamily,
+    args: &[String],
+) -> Option<String> {
+    use crate::depgraph::msvc_args::ShowIncludesMode;
+    if family != crate::compiler::CompilerFamily::Msvc {
+        return None;
+    }
+    let mode = match crate::depgraph::msvc_args::msvc_show_includes_mode(args)? {
+        ShowIncludesMode::All => "all",
+        ShowIncludesMode::UserOnly => "user",
+    };
+    Some(format!("zccache:msvc-showincludes:{mode}"))
+}
+
 /// Compute a fast fingerprint of a compile request for the request-level cache.
 ///
 /// Streams bytes directly into blake3 without intermediate buffer allocation.
@@ -786,4 +813,65 @@ pub(super) fn strict_paths_mode_from_client_env(
             .map(|(key, value)| (key.as_str(), value.as_str())),
     )
     .map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod show_includes_key_tests {
+    use super::msvc_show_includes_key_flags;
+    use crate::compiler::CompilerFamily;
+
+    fn args(s: &[&str]) -> Vec<String> {
+        s.iter().map(|x| (*x).to_string()).collect()
+    }
+
+    #[test]
+    fn injected_and_caller_passed_compiles_key_differently() {
+        // Issue #1530: the parser drops `/showIncludes`, so without this salt
+        // both spellings hash to one ContextKey while storing different
+        // stdout — and a stripped entry replayed to a CMake + Ninja caller
+        // hands it an empty depfile.
+        let plain = msvc_show_includes_key_flags(CompilerFamily::Msvc, &args(&["/c", "a.c"]));
+        let caller = msvc_show_includes_key_flags(
+            CompilerFamily::Msvc,
+            &args(&["/c", "/showIncludes", "a.c"]),
+        );
+        let user_only = msvc_show_includes_key_flags(
+            CompilerFamily::Msvc,
+            &args(&["/c", "/showIncludes:user", "a.c"]),
+        );
+        assert_eq!(plain, None);
+        assert_eq!(
+            caller,
+            Some("zccache:msvc-showincludes:all".to_string()),
+            "caller-passed /showIncludes must salt the key"
+        );
+        assert_ne!(
+            caller, user_only,
+            "the full and user-only traces produce different stdout"
+        );
+    }
+
+    #[test]
+    fn spelling_variants_share_one_salt() {
+        // `-showincludes` and `/showIncludes` are the same flag, so they must
+        // not fragment the cache.
+        assert_eq!(
+            msvc_show_includes_key_flags(CompilerFamily::Msvc, &args(&["-showincludes", "a.c"])),
+            msvc_show_includes_key_flags(CompilerFamily::Msvc, &args(&["/showIncludes", "a.c"]))
+        );
+    }
+
+    #[test]
+    fn non_msvc_families_are_never_salted() {
+        for family in [
+            CompilerFamily::Gcc,
+            CompilerFamily::Clang,
+            CompilerFamily::Rustc,
+        ] {
+            assert_eq!(
+                msvc_show_includes_key_flags(family, &args(&["/showIncludes", "a.c"])),
+                None
+            );
+        }
+    }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/rustc.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/rustc.rs
@@ -73,6 +73,13 @@ fn build_cc_compile_context(
     let mut ctx = CompileContext::from_parsed_args(parsed, compiler_hash);
     ctx.flags
         .extend(msvc_env_key_flags(compilation.family, client_env));
+    // Issue #1530: a caller-passed `/showIncludes` changes what the stored
+    // stdout must contain, but the parser drops the flag, so without this the
+    // two shapes would share one entry.
+    ctx.flags.extend(super::keys::msvc_show_includes_key_flags(
+        compilation.family,
+        &compilation.original_args,
+    ));
     ctx.flags.sort();
 
     // For multi-file compilations, the parsed source_file might be wrong

--- a/crates/zccache-depgraph/src/lib.rs
+++ b/crates/zccache-depgraph/src/lib.rs
@@ -44,7 +44,8 @@ pub use snapshot::{
     DepGraphLoadOutcome, SnapshotError, DEPGRAPH_VERSION,
 };
 pub use system_includes::{
-    discovery_args, discovery_args_fast, parse_cc1_system_include_output,
-    parse_system_include_output, SystemIncludeCache,
+    discovery_args, discovery_args_fast, msvc_system_includes_from_env,
+    parse_cc1_system_include_output, parse_msvc_include_env, parse_system_include_output,
+    SystemIncludeCache, MSVC_INCLUDE_ENV,
 };
 pub use watcher_support::WatchSet;

--- a/crates/zccache-depgraph/src/msvc_args.rs
+++ b/crates/zccache-depgraph/src/msvc_args.rs
@@ -10,6 +10,55 @@ use zccache_core::NormalizedPath;
 use super::args::{ParsedArgs, UserDepFlags};
 use super::search_paths::IncludeSearchPaths;
 
+/// How a caller spelled its own `/showIncludes`.
+///
+/// The distinction is load-bearing (issue #1530): the daemon must not inject a
+/// second `/showIncludes`, must not strip notes the caller is parsing, and must
+/// not treat a deliberately partial trace as a complete dependency set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShowIncludesMode {
+    /// Plain `/showIncludes` — every header, system ones included. A complete
+    /// dependency set.
+    All,
+    /// A suffixed form, i.e. clang-cl's `/showIncludes:user`. It deliberately
+    /// omits system headers, so it is *not* a complete dependency set and the
+    /// daemon falls back to its own scanner rather than trusting it.
+    UserOnly,
+}
+
+/// Recognise a caller-supplied `/showIncludes` argument.
+///
+/// `cl.exe` accepts `-` for every `/` option and matches option names
+/// case-insensitively, so `-showincludes` is the same flag as `/showIncludes`.
+/// A `:`-suffixed form is reported as [`ShowIncludesMode::UserOnly`] — that
+/// covers clang-cl's `/showIncludes:user` and treats any future suffix
+/// conservatively rather than assuming it yields a full trace.
+#[must_use]
+pub fn parse_show_includes_arg(arg: &str) -> Option<ShowIncludesMode> {
+    let body = arg.strip_prefix('/').or_else(|| arg.strip_prefix('-'))?;
+    let (head, suffix) = match body.split_once(':') {
+        Some((head, suffix)) => (head, Some(suffix)),
+        None => (body, None),
+    };
+    if !head.eq_ignore_ascii_case("showIncludes") {
+        return None;
+    }
+    Some(if suffix.is_some() {
+        ShowIncludesMode::UserOnly
+    } else {
+        ShowIncludesMode::All
+    })
+}
+
+/// Find a caller-supplied `/showIncludes` anywhere in `args`.
+///
+/// `args` must already have response files expanded — MSVC builds routinely
+/// pass the whole command line via `@rsp`.
+#[must_use]
+pub fn msvc_show_includes_mode(args: &[String]) -> Option<ShowIncludesMode> {
+    args.iter().find_map(|arg| parse_show_includes_arg(arg))
+}
+
 /// Parse MSVC-style compile arguments into structured form.
 ///
 /// MSVC uses `/` prefix for flags (e.g., `/I`, `/D`, `/O2`).
@@ -180,7 +229,7 @@ pub fn parse_msvc_args(args: &[String], cwd: &Path) -> ParsedArgs {
         }
 
         // /showIncludes â€” MSVC's dep tracking (like -MD for gcc)
-        if arg == "/showIncludes" {
+        if parse_show_includes_arg(arg).is_some() {
             result.dep_flags.has_md = true;
             i += 1;
             continue;
@@ -264,6 +313,76 @@ mod tests {
 
     fn args(s: &[&str]) -> Vec<String> {
         s.iter().map(|x| x.to_string()).collect()
+    }
+
+    // ── Issue #1530: /showIncludes recognition ──────────────────────────
+
+    #[test]
+    fn show_includes_accepts_both_prefixes_and_any_case() {
+        // cl.exe takes `-` for every `/` option and matches option names
+        // case-insensitively. Missing one of these spellings makes the daemon
+        // inject a second /showIncludes and strip notes the caller is parsing.
+        for arg in [
+            "/showIncludes",
+            "-showIncludes",
+            "/showincludes",
+            "-SHOWINCLUDES",
+            "/ShowIncludes",
+        ] {
+            assert_eq!(
+                parse_show_includes_arg(arg),
+                Some(ShowIncludesMode::All),
+                "expected full-trace /showIncludes: {arg}"
+            );
+        }
+    }
+
+    #[test]
+    fn show_includes_suffixed_form_is_user_only() {
+        // clang-cl's `/showIncludes:user` omits system headers, so it is not a
+        // usable dependency set. Any other suffix is treated the same way
+        // rather than optimistically assumed complete.
+        for arg in ["/showIncludes:user", "-showincludes:USER", "/showIncludes:"] {
+            assert_eq!(
+                parse_show_includes_arg(arg),
+                Some(ShowIncludesMode::UserOnly),
+                "expected partial trace: {arg}"
+            );
+        }
+    }
+
+    #[test]
+    fn show_includes_does_not_match_unrelated_args() {
+        for arg in [
+            "showIncludes",
+            "/showIncludesExtra",
+            "/show",
+            "/nologo",
+            "showIncludes.c",
+        ] {
+            assert_eq!(parse_show_includes_arg(arg), None, "false positive: {arg}");
+        }
+    }
+
+    #[test]
+    fn show_includes_mode_scans_the_whole_argv() {
+        assert_eq!(
+            msvc_show_includes_mode(&args(&["/nologo", "/c", "-showincludes", "a.c"])),
+            Some(ShowIncludesMode::All)
+        );
+        assert_eq!(
+            msvc_show_includes_mode(&args(&["/nologo", "/c", "a.c"])),
+            None
+        );
+    }
+
+    #[test]
+    fn every_show_includes_spelling_sets_has_md() {
+        // `has_md` is what stops the daemon appending its own copy of the flag.
+        for arg in ["-showincludes", "/showIncludes:user", "/SHOWINCLUDES"] {
+            let parsed = parse_msvc_args(&args(&[arg, "/c", "foo.c"]), Path::new("/tmp"));
+            assert!(parsed.dep_flags.has_md, "has_md not set for {arg}");
+        }
     }
 
     #[test]

--- a/crates/zccache-depgraph/src/system_includes.rs
+++ b/crates/zccache-depgraph/src/system_includes.rs
@@ -73,6 +73,44 @@ pub fn parse_system_include_output(output: &str) -> Vec<NormalizedPath> {
     paths
 }
 
+/// Name of the MSVC environment variable that lists the system include roots.
+///
+/// `vcvarsall.bat` (and every `vcvars<arch>.bat` wrapper) exports `INCLUDE` as
+/// a `;`-separated list of directories. `cl.exe` resolves every
+/// `#include <...>` against that list -- it has no compiled-in default search
+/// path and no `-v -E` style discovery mode.
+pub const MSVC_INCLUDE_ENV: &str = "INCLUDE";
+
+/// Split an MSVC `INCLUDE` value into system include roots.
+///
+/// The value is `;`-separated. Segments are trimmed and empty segments are
+/// dropped -- a trailing `;` is idiomatic in `vcvars`-generated values and must
+/// not produce a bogus empty root.
+#[must_use]
+pub fn parse_msvc_include_env(value: &str) -> Vec<NormalizedPath> {
+    value
+        .split(';')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .map(NormalizedPath::new)
+        .collect()
+}
+
+/// Extract the MSVC system include roots from a client environment block.
+///
+/// Windows environment variable names are case-insensitive, and the block is
+/// forwarded verbatim from the client shell, so the lookup must be too. The
+/// last matching entry wins, mirroring how a process environment collapses
+/// duplicate names.
+#[must_use]
+pub fn msvc_system_includes_from_env(env: &[(String, String)]) -> Vec<NormalizedPath> {
+    env.iter()
+        .rev()
+        .find(|(name, _)| name.eq_ignore_ascii_case(MSVC_INCLUDE_ENV))
+        .map(|(_, value)| parse_msvc_include_env(value))
+        .unwrap_or_default()
+}
+
 /// Build the compiler discovery command arguments.
 ///
 /// Returns the arguments to pass to the compiler to discover system include
@@ -506,6 +544,61 @@ fn write_atomic_durable(tmp: &Path, target: &Path, bytes: &[u8]) -> std::io::Res
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Issue #1530: MSVC %INCLUDE% parsing ─────────────────────────────
+
+    #[test]
+    fn msvc_include_env_splits_on_semicolons() {
+        assert_eq!(
+            parse_msvc_include_env("C:\\VC\\include;C:\\Kits\\10\\ucrt"),
+            vec![
+                NormalizedPath::new("C:\\VC\\include"),
+                NormalizedPath::new("C:\\Kits\\10\\ucrt"),
+            ]
+        );
+    }
+
+    #[test]
+    fn msvc_include_env_drops_empty_and_trims_segments() {
+        // vcvars emits a trailing `;`, and hand-edited values pick up spaces.
+        assert_eq!(
+            parse_msvc_include_env(";C:\\a ; ;  C:\\b with spaces\\inc ;"),
+            vec![
+                NormalizedPath::new("C:\\a"),
+                NormalizedPath::new("C:\\b with spaces\\inc"),
+            ]
+        );
+        assert!(parse_msvc_include_env("").is_empty());
+        assert!(parse_msvc_include_env(";;  ;").is_empty());
+    }
+
+    #[test]
+    fn msvc_include_env_lookup_is_case_insensitive() {
+        let block = vec![("Include".to_string(), "C:\\a".to_string())];
+        assert_eq!(
+            msvc_system_includes_from_env(&block),
+            vec![NormalizedPath::new("C:\\a")]
+        );
+    }
+
+    #[test]
+    fn msvc_include_env_lookup_takes_the_last_duplicate() {
+        let block = vec![
+            ("INCLUDE".to_string(), "C:\\stale".to_string()),
+            ("include".to_string(), "C:\\live".to_string()),
+        ];
+        assert_eq!(
+            msvc_system_includes_from_env(&block),
+            vec![NormalizedPath::new("C:\\live")]
+        );
+    }
+
+    #[test]
+    fn msvc_include_env_absent_is_empty() {
+        let block = vec![("PATH".to_string(), "C:\\bin".to_string())];
+        assert!(msvc_system_includes_from_env(&block).is_empty());
+        assert!(msvc_system_includes_from_env(&[]).is_empty());
+    }
 
     #[test]
     fn parse_gcc_output() {

--- a/crates/zccache/tests/daemon_msvc_cl_cache_test.rs
+++ b/crates/zccache/tests/daemon_msvc_cl_cache_test.rs
@@ -1,0 +1,266 @@
+//! Integration test for issue #1530: MSVC `cl.exe` compiles must cache.
+//!
+//! zccache 1.13.12 passed every `cl.exe` compile through as non-cacheable:
+//! zero artifacts stored, zero hits, on a 2,300-compile LLVM build. The cause
+//! was not the argument parser (`compiler_clang_cl_classification.rs` already
+//! pins that `cl.exe /nologo /c src.c /Fosrc.obj` classifies as `Cacheable`)
+//! but system-include discovery: the daemon probed `cl.exe -v -E -x c++ NUL`,
+//! `cl.exe` has no such discovery mode, the probe printed no
+//! `#include <...> search starts here:` section, and the resulting
+//! "succeeded but zero paths" outcome tripped the issue #1167 degraded-probe
+//! guard, which diverts the compile to the uncached bypass. #1167 also (by
+//! design) never memoizes an empty result, so the probe re-ran and the bypass
+//! re-fired on every single compile.
+//!
+//! `cl.exe` resolves `#include <...>` against `%INCLUDE%`, exported by
+//! `vcvars`, so the daemon now reads the roots from the forwarded client
+//! environment and never probes.
+//!
+//! This test is `#[ignore]`d and additionally skips unless `cl.exe` is on
+//! PATH — it needs a Developer Command Prompt (`vcvars64`). Run with
+//! `./test --full` from a vcvars shell on Windows.
+
+#![cfg(windows)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result
+)]
+
+use zccache::daemon::DaemonServer;
+use zccache::protocol::{Request, Response};
+
+type ClientConn = zccache::ipc::IpcClientConnection;
+
+async fn start_daemon() -> (
+    String,
+    tokio::task::JoinHandle<()>,
+    std::sync::Arc<tokio::sync::Notify>,
+    tempfile::TempDir,
+) {
+    let endpoint = zccache::ipc::unique_test_endpoint();
+    let cache_root = tempfile::tempdir().expect("daemon cache tempdir");
+    let cache_dir: zccache::core::NormalizedPath = cache_root.path().join("zccache-cache").into();
+    let mut server = DaemonServer::bind_with_cache_dir(&endpoint, &cache_dir).unwrap();
+    let shutdown = server.shutdown_handle();
+    let handle = tokio::spawn(async move { server.run(0).await.unwrap() });
+    (endpoint, handle, shutdown, cache_root)
+}
+
+async fn start_session(client: &mut ClientConn, cwd: &str, log_file: &str) -> String {
+    client
+        .send(&Request::SessionStart {
+            client_pid: std::process::id(),
+            working_dir: cwd.to_string().into(),
+            log_file: Some(log_file.to_string().into()),
+            track_stats: false,
+            journal_path: None,
+            profile: false,
+            private_daemon: None,
+        })
+        .await
+        .unwrap();
+    match client.recv().await.unwrap() {
+        Some(Response::SessionStarted { session_id, .. }) => session_id,
+        other => panic!("expected SessionStarted, got: {other:?}"),
+    }
+}
+
+async fn compile(
+    client: &mut ClientConn,
+    session_id: &str,
+    compiler: &str,
+    args: Vec<String>,
+    cwd: &str,
+) -> (i32, bool, Vec<u8>) {
+    // The wrapper forwards the full client environment; the daemon reads
+    // `%INCLUDE%` out of it for `cl.exe`. Passing `None` here would leave the
+    // compiler unable to find `<stdio.h>` and is not what a real client does.
+    let env: Vec<(String, String)> = std::env::vars().collect();
+    client
+        .send(&Request::Compile {
+            session_id: session_id.to_string(),
+            args,
+            cwd: cwd.to_string().into(),
+            compiler: compiler.to_string().into(),
+            env: Some(env),
+            stdin: Vec::new(),
+        })
+        .await
+        .unwrap();
+    loop {
+        match client.recv().await.unwrap() {
+            Some(Response::CompileProgress { .. }) => continue,
+            Some(Response::CompileResult {
+                exit_code,
+                cached,
+                stderr,
+                ..
+            }) => break (exit_code, cached, (*stderr).clone()),
+            Some(Response::Error { message }) => panic!("compile error: {message}"),
+            other => panic!("expected CompileResult, got: {other:?}"),
+        }
+    }
+}
+
+/// The issue's exact repro: the same `cl.exe` compile twice. The second one
+/// must be a cache hit. Before the fix both were reported non-cacheable and
+/// the artifact store stayed empty.
+#[tokio::test]
+#[ignore] // integration: needs a vcvars Developer Command Prompt with cl.exe
+async fn msvc_cl_second_identical_compile_is_a_cache_hit() {
+    let Some(cl) = zccache::test_support::find_on_path("cl.exe") else {
+        eprintln!("skipping: cl.exe not found (run from a vcvars shell)");
+        return;
+    };
+    if std::env::var_os("INCLUDE").is_none() {
+        eprintln!("skipping: INCLUDE unset (run from a vcvars shell)");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let cwd = tmp.path().to_string_lossy().into_owned();
+    let log_dir = tmp.path().join("logs");
+    std::fs::create_dir_all(&log_dir).unwrap();
+    let log = log_dir.join("session.log");
+
+    let source = tmp.path().join("simple.c");
+    let object = tmp.path().join("simple.obj");
+    std::fs::write(&source, "#include <stdio.h>\nint f(void){return 42;}\n").unwrap();
+
+    let compiler = cl.to_string_lossy().into_owned();
+    let args = vec![
+        "/nologo".to_string(),
+        "/c".to_string(),
+        source.to_string_lossy().into_owned(),
+        format!("/Fo{}", object.display()),
+    ];
+
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
+    let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+    let sid = start_session(&mut client, &cwd, &log.to_string_lossy()).await;
+
+    let (code, cached, stderr) = compile(&mut client, &sid, &compiler, args.clone(), &cwd).await;
+    assert_eq!(
+        code,
+        0,
+        "first compile failed: {}",
+        String::from_utf8_lossy(&stderr)
+    );
+    assert!(!cached, "first compile must be a miss");
+    assert!(object.exists(), "first compile produced no object");
+    let expected = std::fs::read(&object).unwrap();
+
+    // Delete the object so a hit has to materialize it, not just leave it be.
+    std::fs::remove_file(&object).unwrap();
+
+    let (code, cached, stderr) = compile(&mut client, &sid, &compiler, args, &cwd).await;
+    assert_eq!(
+        code,
+        0,
+        "second compile failed: {}",
+        String::from_utf8_lossy(&stderr)
+    );
+    assert!(
+        cached,
+        "issue #1530: the second identical cl.exe compile must be a cache hit, \
+         not another non-cacheable passthrough"
+    );
+    assert_eq!(
+        std::fs::read(&object).unwrap(),
+        expected,
+        "cache hit materialized a different object"
+    );
+
+    shutdown.notify_one();
+    server_handle.await.unwrap();
+}
+
+/// Editing a header must invalidate the cached object.
+///
+/// The same issue #1530 change is what makes this reachable at all — but it
+/// also exposed a second defect: MSVC writes its `/showIncludes` notes to
+/// **stdout**, while the daemon scanned stderr. Zero dependencies were
+/// recorded, so the compile below used to come back as a (wrong) cache hit
+/// carrying the pre-edit object.
+#[tokio::test]
+#[ignore] // integration: needs a vcvars Developer Command Prompt with cl.exe
+async fn msvc_cl_header_edit_invalidates_the_cached_object() {
+    let Some(cl) = zccache::test_support::find_on_path("cl.exe") else {
+        eprintln!("skipping: cl.exe not found (run from a vcvars shell)");
+        return;
+    };
+    if std::env::var_os("INCLUDE").is_none() {
+        eprintln!("skipping: INCLUDE unset (run from a vcvars shell)");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let cwd = tmp.path().to_string_lossy().into_owned();
+    let log_dir = tmp.path().join("logs");
+    std::fs::create_dir_all(&log_dir).unwrap();
+    let log = log_dir.join("session.log");
+
+    let header = tmp.path().join("local.h");
+    let source = tmp.path().join("hdr.c");
+    let object = tmp.path().join("hdr.obj");
+    std::fs::write(&header, "#define LOCAL_VALUE 42\n").unwrap();
+    std::fs::write(
+        &source,
+        "#include <stdio.h>\n#include \"local.h\"\nint f(void){ return LOCAL_VALUE + (int)sizeof(FILE); }\n",
+    )
+    .unwrap();
+
+    let compiler = cl.to_string_lossy().into_owned();
+    let args = vec![
+        "/nologo".to_string(),
+        "/c".to_string(),
+        source.to_string_lossy().into_owned(),
+        format!("/Fo{}", object.display()),
+    ];
+
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
+    let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+    let sid = start_session(&mut client, &cwd, &log.to_string_lossy()).await;
+
+    let (code, cached, stderr) = compile(&mut client, &sid, &compiler, args.clone(), &cwd).await;
+    assert_eq!(
+        code,
+        0,
+        "cold compile failed: {}",
+        String::from_utf8_lossy(&stderr)
+    );
+    assert!(!cached, "cold compile must be a miss");
+    let before = std::fs::read(&object).unwrap();
+
+    let (_, cached, _) = compile(&mut client, &sid, &compiler, args.clone(), &cwd).await;
+    assert!(cached, "unchanged recompile must be a hit");
+
+    // Change the header's *content*, not just its timestamp.
+    std::fs::write(&header, "#define LOCAL_VALUE 43\n").unwrap();
+    // NTFS mtime granularity does not always advance on rapid rewrites.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+
+    let (code, cached, stderr) = compile(&mut client, &sid, &compiler, args, &cwd).await;
+    assert_eq!(
+        code,
+        0,
+        "post-edit compile failed: {}",
+        String::from_utf8_lossy(&stderr)
+    );
+    assert!(
+        !cached,
+        "issue #1530: editing local.h must invalidate the cached object — a hit \
+         here means /showIncludes dependencies were never recorded"
+    );
+    assert_ne!(
+        std::fs::read(&object).unwrap(),
+        before,
+        "post-edit object is byte-identical to the pre-edit one"
+    );
+
+    shutdown.notify_one();
+    server_handle.await.unwrap();
+}

--- a/crates/zccache/tests/daemon_msvc_cl_cache_test.rs
+++ b/crates/zccache/tests/daemon_msvc_cl_cache_test.rs
@@ -68,13 +68,20 @@ async fn start_session(client: &mut ClientConn, cwd: &str, log_file: &str) -> St
     }
 }
 
-async fn compile(
+struct CompileOutcome {
+    exit_code: i32,
+    cached: bool,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+async fn compile_full(
     client: &mut ClientConn,
     session_id: &str,
     compiler: &str,
     args: Vec<String>,
     cwd: &str,
-) -> (i32, bool, Vec<u8>) {
+) -> CompileOutcome {
     // The wrapper forwards the full client environment; the daemon reads
     // `%INCLUDE%` out of it for `cl.exe`. Passing `None` here would leave the
     // compiler unable to find `<stdio.h>` and is not what a real client does.
@@ -96,13 +103,31 @@ async fn compile(
             Some(Response::CompileResult {
                 exit_code,
                 cached,
+                stdout,
                 stderr,
-                ..
-            }) => break (exit_code, cached, (*stderr).clone()),
+            }) => {
+                break CompileOutcome {
+                    exit_code,
+                    cached,
+                    stdout: (*stdout).clone(),
+                    stderr: (*stderr).clone(),
+                }
+            }
             Some(Response::Error { message }) => panic!("compile error: {message}"),
             other => panic!("expected CompileResult, got: {other:?}"),
         }
     }
+}
+
+async fn compile(
+    client: &mut ClientConn,
+    session_id: &str,
+    compiler: &str,
+    args: Vec<String>,
+    cwd: &str,
+) -> (i32, bool, Vec<u8>) {
+    let outcome = compile_full(client, session_id, compiler, args, cwd).await;
+    (outcome.exit_code, outcome.cached, outcome.stderr)
 }
 
 /// The issue's exact repro: the same `cl.exe` compile twice. The second one
@@ -207,9 +232,13 @@ async fn msvc_cl_header_edit_invalidates_the_cached_object() {
     let source = tmp.path().join("hdr.c");
     let object = tmp.path().join("hdr.obj");
     std::fs::write(&header, "#define LOCAL_VALUE 42\n").unwrap();
+    // A *computed* include: zccache's own header scanner cannot resolve
+    // `#include H` without preprocessing, so this dependency can only come from
+    // the `/showIncludes` scan. A plain `#include "local.h"` would be resolved
+    // by the scanner and would pass even with the stdout defect still present.
     std::fs::write(
         &source,
-        "#include <stdio.h>\n#include \"local.h\"\nint f(void){ return LOCAL_VALUE + (int)sizeof(FILE); }\n",
+        "#include <stdio.h>\n#define H \"local.h\"\n#include H\nint f(void){ return LOCAL_VALUE + (int)sizeof(FILE); }\n",
     )
     .unwrap();
 
@@ -259,6 +288,103 @@ async fn msvc_cl_header_edit_invalidates_the_cached_object() {
         std::fs::read(&object).unwrap(),
         before,
         "post-edit object is byte-identical to the pre-edit one"
+    );
+
+    shutdown.notify_one();
+    server_handle.await.unwrap();
+}
+
+/// A caller that passes `/showIncludes` itself must keep receiving the notes —
+/// on a cache hit as well as on a miss.
+///
+/// CMake + Ninja MSVC builds pass the flag and parse `Note: including file:`
+/// out of stdout to build their own depfiles. Two failure modes are guarded
+/// here: stripping notes the caller asked for, and letting a plain compile's
+/// stripped stdout be replayed to a `/showIncludes` caller, which is possible
+/// because the argument parser consumes the flag before it reaches the cache
+/// key (hence `keys::msvc_show_includes_key_flags`).
+#[tokio::test]
+#[ignore] // integration: needs a vcvars Developer Command Prompt with cl.exe
+async fn msvc_cl_caller_supplied_show_includes_survives_a_cache_hit() {
+    let Some(cl) = zccache::test_support::find_on_path("cl.exe") else {
+        eprintln!("skipping: cl.exe not found (run from a vcvars shell)");
+        return;
+    };
+    if std::env::var_os("INCLUDE").is_none() {
+        eprintln!("skipping: INCLUDE unset (run from a vcvars shell)");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let cwd = tmp.path().to_string_lossy().into_owned();
+    let log_dir = tmp.path().join("logs");
+    std::fs::create_dir_all(&log_dir).unwrap();
+    let log = log_dir.join("session.log");
+
+    let source = tmp.path().join("notes.c");
+    let object = tmp.path().join("notes.obj");
+    std::fs::write(
+        &source,
+        "#include <stdio.h>\nint f(void){return (int)sizeof(FILE);}\n",
+    )
+    .unwrap();
+
+    let compiler = cl.to_string_lossy().into_owned();
+    let plain = vec![
+        "/nologo".to_string(),
+        "/c".to_string(),
+        source.to_string_lossy().into_owned(),
+        format!("/Fo{}", object.display()),
+    ];
+    let mut with_notes = plain.clone();
+    with_notes.insert(1, "/showIncludes".to_string());
+
+    const NOTE: &str = "Note: including file:";
+
+    let (endpoint, server_handle, shutdown, _cache_root) = start_daemon().await;
+    let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+    let sid = start_session(&mut client, &cwd, &log.to_string_lossy()).await;
+
+    // Populate the cache with a PLAIN compile. Its stored stdout has the
+    // daemon's injected notes stripped; it must never be replayed below.
+    let cold = compile_full(&mut client, &sid, &compiler, plain.clone(), &cwd).await;
+    assert_eq!(
+        cold.exit_code,
+        0,
+        "plain compile failed: {}",
+        String::from_utf8_lossy(&cold.stderr)
+    );
+    let warm = compile_full(&mut client, &sid, &compiler, plain, &cwd).await;
+    assert!(warm.cached, "plain recompile must be a hit");
+    assert!(
+        !String::from_utf8_lossy(&warm.stdout).contains(NOTE),
+        "daemon-injected /showIncludes notes leaked into a plain caller's stdout"
+    );
+
+    // The same compile with the caller's own /showIncludes: a miss (different
+    // key), and the notes must be present.
+    let cold = compile_full(&mut client, &sid, &compiler, with_notes.clone(), &cwd).await;
+    assert_eq!(
+        cold.exit_code,
+        0,
+        "/showIncludes compile failed: {}",
+        String::from_utf8_lossy(&cold.stderr)
+    );
+    assert!(
+        !cold.cached,
+        "a caller-passed /showIncludes compile must not reuse the plain compile's entry"
+    );
+    assert!(
+        String::from_utf8_lossy(&cold.stdout).contains(NOTE),
+        "caller-requested /showIncludes notes were stripped on a miss"
+    );
+
+    let warm = compile_full(&mut client, &sid, &compiler, with_notes, &cwd).await;
+    assert!(warm.cached, "second /showIncludes compile must be a hit");
+    assert!(
+        String::from_utf8_lossy(&warm.stdout).contains(NOTE),
+        "caller-requested /showIncludes notes were missing from the replayed hit — \
+         Ninja would write an empty depfile and silently under-rebuild"
     );
 
     shutdown.notify_one();

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,6 +51,8 @@ failed cache-root audit retain its diagnostic JSONL evidence.
 - **Standalone daemon identity, deployment & lifecycle (argv[0] single binary, version-rooted deploy, versioned endpoints)** → [runtime.md § Standalone daemon identity, deployment & lifecycle](architecture/runtime.md#standalone-daemon-identity-deployment--lifecycle)
 - **Rejected depgraph snapshots — quarantine, recovery, why no migration** → [runtime.md § Depgraph snapshot quarantine](architecture/runtime.md#depgraph-snapshot-quarantine)
 - **Windows/macOS/Linux differences** → [portability.md](architecture/portability.md)
+- **MSVC `cl.exe` system includes (`%INCLUDE%`, issue #1530)** → [portability.md](architecture/portability.md#system-include-discovery-clexe-reads-include-never-a-probe)
+- **MSVC `/showIncludes` on stdout, strip-only-when-injected (issue #1530)** → [portability.md](architecture/portability.md#showincludes-is-read-from-stdout-and-stripped-only-when-injected)
 - **Host-platform boundary (zccache-platform)** → [portability.md](architecture/portability.md#host-platform-boundary-zccache-platform)
 - **kernal-api migration inventory and baselines** → [kernal-api-migration.md](architecture/kernal-api-migration.md)
 - **Compile journal fields & `miss_reason` enum** → [journal-schema.md](journal-schema.md)

--- a/docs/architecture/portability.md
+++ b/docs/architecture/portability.md
@@ -52,8 +52,14 @@ consequences worth keeping in mind:
 - **The result is not memoized in the L1/L2 system-include cache.** `%INCLUDE%`
   belongs to the client shell — which `vcvars` ran, for which architecture —
   not to the compiler binary, so a per-compiler-path entry would leak one
-  shell's roots into another's. `INCLUDE` is already a cache-key input
-  (`compile_journal/env.rs`), so a different shell yields a different key.
+  shell's roots into another's. Two shells cannot collide on one cache entry:
+  the discovered roots are pushed into `ctx.include_search.system`
+  (`daemon/server/rustc.rs`) and hashed **in order** into `ContextKey`
+  (`depgraph/src/context/mod.rs`), so a different `%INCLUDE%` — different
+  directories, or the same ones in a different order — yields a different key.
+  (Note this is the keying path; the `INCLUDE` entry in
+  `compile_journal/env.rs` is the durable-journal allowlist and does *not*
+  feed the cache key.)
 - **An absent `INCLUDE` is a known-empty result, not a degraded one.** `cl.exe`
   genuinely has no other search roots, and the miss path recovers the real
   header set from `/showIncludes` regardless.
@@ -84,6 +90,21 @@ for the flag**, tracked as `injected_show_includes` at the injection site in
 - **Caller passed it** (CMake + Ninja MSVC builds do, and parse the notes into
   their own depfiles): the notes are scanned but passed through byte-for-byte.
   Stripping them would silently break the build system's dependency tracking.
+
+Because the argument parser consumes `/showIncludes` without recording it as a
+cache-relevant flag, those two shapes would otherwise hash to the *same*
+`ContextKey` while storing different stdout — so a stripped entry could be
+replayed to a Ninja caller as an empty depfile. `keys::msvc_show_includes_key_flags`
+salts the key with who asked for the flag, keeping the populations separate. It
+costs no hits: every compile in a given build is spelled the same way.
+
+The flag is matched case-insensitively with either prefix (`cl.exe` accepts
+`-showincludes` for `/showIncludes`). clang-cl's suffixed
+`/showIncludes:user` deliberately omits system headers, so it is *not* treated
+as a usable dependency set: the daemon neither injects a competing
+`/showIncludes` nor trusts the partial trace — it leaves the strategy
+`Unsupported`, falls back to its own header scanner, and leaves the caller's
+stdout untouched.
 
 `StderrFilter::reads_stdout()` / `strips_scanned_lines()` in
 `daemon/compile_output.rs` encode this for the streaming path; the buffered

--- a/docs/architecture/portability.md
+++ b/docs/architecture/portability.md
@@ -30,6 +30,66 @@ values are portable and retained through 1.13.x. The kill switch leaves legacy
 v1/pack reads available on Linux, macOS, and Windows; v2-only entries become
 misses rather than being reinterpreted.
 
+### System include discovery: `cl.exe` reads `%INCLUDE%`, never a probe
+
+For gcc and clang the daemon discovers the default `#include <...>` search
+roots by spawning the compiler (`-v -E -x c++ NUL`, or the faster `-###` for
+the clang family) and parsing the printed search list. **Microsoft's `cl.exe`
+has no equivalent discovery mode**: it resolves `#include <...>` purely against
+the `;`-separated `%INCLUDE%` that `vcvars` exports. Probing it spawns a
+compiler that rejects the preprocessor flags and prints no search list, and the
+resulting "process succeeded, zero paths" outcome is indistinguishable from a
+degraded probe — which is exactly how the issue #1167 guard read it, sending
+every MSVC compile down the uncached bypass and (because #1167 correctly never
+memoizes an empty result) re-firing on every single compile. That was issue
+#1530: a 2,300-compile MSVC build cached zero artifacts.
+
+So `cl.exe` short-circuits discovery and reads `INCLUDE` out of the forwarded
+client environment (`msvc_cl_system_includes` in the compile pipeline;
+`zccache_depgraph::msvc_system_includes_from_env` does the parsing). Two
+consequences worth keeping in mind:
+
+- **The result is not memoized in the L1/L2 system-include cache.** `%INCLUDE%`
+  belongs to the client shell — which `vcvars` ran, for which architecture —
+  not to the compiler binary, so a per-compiler-path entry would leak one
+  shell's roots into another's. `INCLUDE` is already a cache-key input
+  (`compile_journal/env.rs`), so a different shell yields a different key.
+- **An absent `INCLUDE` is a known-empty result, not a degraded one.** `cl.exe`
+  genuinely has no other search roots, and the miss path recovers the real
+  header set from `/showIncludes` regardless.
+
+`clang-cl` also classifies as `CompilerFamily::Msvc` (it speaks MSVC argument
+syntax) but *is* a clang driver: it answers the probe and owns builtin header
+directories that `%INCLUDE%` does not list, so it stays on the discovery path.
+`zccache_compiler::is_msvc_cl` is the discriminator.
+
+### `/showIncludes` is read from stdout, and stripped only when injected
+
+MSVC's dependency mechanism is `/showIncludes`, which prints one
+`Note: including file: <path>` line per header. Unlike `gcc -H` / `clang -H`
+(stderr), **`cl.exe` and `clang-cl` write these notes to stdout.** The daemon
+scanned stderr, found nothing, and recorded zero dependencies for every MSVC
+compile — harmless only for as long as MSVC never cached at all. The moment the
+`%INCLUDE%` fix above made MSVC cacheable, that turned into a stale hit: edit a
+header, get the pre-edit object back. Both halves of issue #1530 therefore ship
+together; the `%INCLUDE%` change is not safe to land alone.
+
+Whether the notes are stripped from the caller's stdout depends on **who asked
+for the flag**, tracked as `injected_show_includes` at the injection site in
+`compile_exec.rs`:
+
+- **Daemon injected it** (the caller passed no `/showIncludes`): the notes are
+  internal bookkeeping and are filtered out, so the caller's stdout looks
+  exactly as it would without zccache.
+- **Caller passed it** (CMake + Ninja MSVC builds do, and parse the notes into
+  their own depfiles): the notes are scanned but passed through byte-for-byte.
+  Stripping them would silently break the build system's dependency tracking.
+
+`StderrFilter::reads_stdout()` / `strips_scanned_lines()` in
+`daemon/compile_output.rs` encode this for the streaming path; the buffered
+path in `compile_exec.rs` mirrors it. `clang -H` header traces keep reading
+stderr and keep being stripped unconditionally — they are only ever injected.
+
 ---
 
 ## Host-Platform Boundary (`zccache-platform`)


### PR DESCRIPTION
Closes #1530

## The bug

MSVC `cl.exe` compiles were classified **non-cacheable on every invocation** — a 2,300-compile LLVM build stored zero artifacts and never hit once.

Two defects, both required for MSVC caching to actually work. **The first is not safe to land alone**, which is why they ship together.

### 1. System-include discovery probed a compiler that has no discovery mode

The daemon runs `<compiler> -v -E -x c++ NUL` and scrapes the `#include <...> search starts here:` section. `cl.exe` has no such mode: it rejects the flags, prints no section, and the parse yields zero paths. The issue #1167 guard reads "process succeeded, zero paths" as a *degraded* probe and diverts the compile to the uncached bypass — and #1167 also (correctly) never memoizes an empty result, so the probe re-ran and the bypass re-fired on **every single compile**.

`cl.exe` resolves `#include <...>` against `%INCLUDE%`, which `vcvars` exports. The daemon now reads the roots out of the forwarded client environment and never spawns anything.

- Not memoized in the L1/L2 system-include cache: `%INCLUDE%` belongs to the client shell, not the compiler binary. Two shells can't collide on one entry — the roots go into `ctx.include_search.system` and are hashed *in order* into `ContextKey`.
- An absent `INCLUDE` is a **known** empty result, not a degraded one. Reporting it as degraded would resurrect the bypass.
- `clang-cl` also classifies as `Msvc` but *is* a clang driver: it answers the probe and owns builtin header dirs `%INCLUDE%` doesn't list, so it keeps the discovery path.

### 2. `/showIncludes` notes are on stdout, but the daemon scanned stderr

`cl.exe` and `clang-cl` write `Note: including file:` to **stdout** (verified: 9 lines on stdout, 0 on stderr). Scanning stderr recorded **zero dependencies** — invisible only for as long as MSVC never cached. The moment fix (1) made MSVC cacheable, that became a stale hit: edit a header, get the pre-edit object back.

Stripping is now decided by **who asked for the flag**:

| | notes on the caller's stdout | why |
|---|---|---|
| daemon injected it | stripped | internal bookkeeping; caller's output looks as it would without zccache |
| caller passed it | passed through byte-for-byte | CMake + Ninja parse them into their own depfiles |

Because the parser consumes `/showIncludes` without recording it, those two shapes would otherwise hash to the **same** key while storing different stdout — a stripped entry replayed to a Ninja caller is an empty depfile and a silent under-rebuild. `keys::msvc_show_includes_key_flags` salts the key with who asked. Within a build every compile is spelled the same way, so it costs no hits.

Flag matching is case-insensitive on both prefixes (`cl.exe` takes `-showincludes`). clang-cl's `/showIncludes:user` deliberately omits system headers, so it is not treated as a usable dependency set: no competing flag is injected, the partial trace is not trusted, the scanner supplies dependencies, and the caller's stdout is untouched.

## Validation

Against **real MSVC 19.29** (VS2019 Build Tools) from a `vcvars64` shell on Windows 10:

```
before (issue report, 1.13.12, same machine)
  Compilations:  2 total (0 cached, 0 cold, 2 non-cacheable)
  Artifacts:     0 (0 B)

after — the issue's exact repro
  Compilations:  2 total (1 cached, 1 cold, 0 non-cacheable)
  Artifacts:     1 (697 B)

after — computed include (`#define H "local.h"` / `#include H`, so the
built-in scanner cannot resolve it and only /showIncludes can), then edit the header
  compile 1 cold -> compile 2 HIT -> edit local.h -> compile 3 MISS
  Compilations:  3 total (1 cached, 2 cold, 0 non-cacheable)
  Artifacts:     2 (1.4 KB)
```

No `Note: including file:` leaked into the plain caller's output.

**Gates:** `soldr cargo fmt --all`, `soldr cargo clippy --workspace --all-targets -- -D warnings`, and the full `./test` unit suite all pass (0 failures).

**CI caveat, stated plainly:** no workflow in this repo sets up vcvars, so the new `crates/zccache/tests/daemon_msvc_cl_cache_test.rs` cases are `#[ignore]`d *and* self-skip without `cl.exe` + `INCLUDE`. **CI will never execute them.** The manual runs above are the only execution that path gets; the unit tests below are what CI actually enforces.

## Tests

Unit (run in CI):
- `parse_msvc_include_env` / `msvc_system_includes_from_env` — `;` splitting, trailing `;`, empty and whitespace segments, case-insensitive lookup, last-duplicate-wins.
- `msvc_cl_system_includes` — cl.exe reads `INCLUDE` instead of probing; absent `INCLUDE` is known-empty, **not** degraded (the regression); clang-cl and non-MSVC keep the probe.
- `is_msvc_cl` — matches every `cl` spelling, excludes `clang-cl*`, `cl-wrapper`, `mycl.exe`.
- `consume()` — `/showIncludes` scanned from stdout and stripped when injected; preserved when caller-passed; stderr untouched while the parser is on stdout.
- `parse_show_includes_arg` — both prefixes, any case, `:user` as partial, no false positives; every spelling sets `has_md`.
- `msvc_show_includes_key_flags` — injected vs caller-passed key differently, `all` vs `user` differ, spelling variants share one salt, non-MSVC never salted.

Integration (`#[ignore]`, vcvars-gated): identical-compile hit; header-edit-invalidates via a computed include; caller-passed `/showIncludes` notes survive a cache **hit** and don't reuse the plain compile's entry.

No `PROTOCOL_VERSION` bump — nothing serialized over IPC changed; `client_env` rides an existing parameter, no new roundtrip.

Docs: `docs/architecture/portability.md` gains both mechanisms, with breadcrumbs in `docs/ARCHITECTURE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
