### PR TITLE
ci(release): stop the Intel macOS wheel test from gating the publish chain (#1535)

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -512,6 +512,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [preflight, build-wheels]
     if: needs.preflight.outputs.pypi_complete != 'true'
+    # #1535: the Intel macOS leg must not be able to hold the publish chain
+    # hostage. `publish-crates` needs `publish-pypi` needs `test-wheels`, so
+    # one unschedulable runner blocks *every* crates.io release. GitHub is
+    # retiring Intel macOS hosts: during 1.13.14 the `macos-14` arm64 leg
+    # finished in minutes while this one never started at all, and a
+    # cancel-and-rerun re-queued it with the same result. The wheel is still
+    # built and still published -- it is only its smoke test that stops being
+    # a gate, because a gate that cannot run is not a gate.
+    #
+    # Deliberately expressed per-leg rather than by deleting the entry: the
+    # matrix is kept in set-equality lockstep with `PLATFORMS` in
+    # `ci/release_workflow.py` by `test_release_workflow.py`, and dropping
+    # Intel coverage is a product decision, not a CI workaround.
+    continue-on-error: ${{ matrix.os == 'macos-15-intel' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes #1535.

## The deadlock

```
publish-crates: needs: [preflight, publish-release, publish-pypi]
publish-pypi:   needs: [..., test-wheels]
```

So **every** crates.io release is gated on every wheel-test leg — including one on `macos-15-intel`, a runner class GitHub is retiring.

During 1.13.14 that gate never opened:

```
success  Test PyPI Wheel (macosx_11_0_arm64)     <- macos-14, minutes
queued   Test PyPI Wheel (macosx_10_12_x86_64)   <- macos-15-intel, never started
```

Cancelling the run and re-running the failed jobs re-queued the Intel leg, which began queueing again immediately rather than picking up a host. This is not general contention — its arm64 sibling scheduled fine both times.

The result is a *stuck* release, not a slow one: **1.13.14's GitHub Release is published with all sixteen assets, and the crate cannot reach crates.io.** That in turn blocks [zackees/soldr#2935](https://github.com/zackees/soldr/issues/2935), which needs the published crate to move its exact pin.

## The change

One line — `continue-on-error` on the Intel leg only.

The wheel is still built and still published. Only its smoke test stops being a gate, because a gate that cannot run is not a gate; it is a deadlock.

## Why not just delete the matrix entry

The matrix is held in set-equality lockstep with `PLATFORMS` in `ci/release_workflow.py`, enforced by `ci/tests/test_release_workflow.py`. Removing the leg would break that invariant — and more importantly, **whether to keep shipping a `macosx_10_12` wheel at all is a product decision**. It should be made deliberately, not as a side effect of unblocking a release. Keeping the leg preserves both the invariant and the option.

If Intel macOS is genuinely no longer supported, the follow-up is to drop the platform from `PLATFORMS` and the matrix together, which this change leaves open.

`ci/tests/test_release_workflow.py`: 8 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
