### PR TITLE
fix(ci): take the Intel wheel smoke test off the publish dependency edge

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -512,20 +512,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [preflight, build-wheels]
     if: needs.preflight.outputs.pypi_complete != 'true'
-    # #1535: the Intel macOS leg must not be able to hold the publish chain
-    # hostage. `publish-crates` needs `publish-pypi` needs `test-wheels`, so
-    # one unschedulable runner blocks *every* crates.io release. GitHub is
-    # retiring Intel macOS hosts: during 1.13.14 the `macos-14` arm64 leg
-    # finished in minutes while this one never started at all, and a
-    # cancel-and-rerun re-queued it with the same result. The wheel is still
-    # built and still published -- it is only its smoke test that stops being
-    # a gate, because a gate that cannot run is not a gate.
-    #
-    # Deliberately expressed per-leg rather than by deleting the entry: the
-    # matrix is kept in set-equality lockstep with `PLATFORMS` in
-    # `ci/release_workflow.py` by `test_release_workflow.py`, and dropping
-    # Intel coverage is a product decision, not a CI workaround.
-    continue-on-error: ${{ matrix.os == 'macos-15-intel' }}
     strategy:
       fail-fast: false
       matrix:
@@ -534,14 +520,62 @@ jobs:
             wheel_plat: manylinux_2_17_x86_64
           - os: ubuntu-24.04-arm
             wheel_plat: manylinux_2_17_aarch64
-          - os: macos-15-intel
-            wheel_plat: macosx_10_12_x86_64
           - os: macos-14
             wheel_plat: macosx_11_0_arm64
           - os: windows-latest
             wheel_plat: win_amd64
           - os: windows-11-arm
             wheel_plat: win_arm64
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.preflight.outputs.checkout_ref }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: pypi-wheels
+          path: dist/wheels
+
+      - name: Install and test the platform wheel
+        run: |
+          python -m pip install --disable-pip-version-check --no-index --find-links dist/wheels "zccache==${{ needs.preflight.outputs.version }}"
+          python ci/test_exec_cached_wheel.py
+
+  # #1535: wheel families whose runner cannot be relied on to schedule. Split
+  # into a separate job rather than flagged inside `test-wheels`, because
+  # nothing in the publish chain may `needs:` this one.
+  #
+  # `continue-on-error` was the first attempt and does not work here. It
+  # neutralizes a job that RUNS and FAILS; the observed failure is a job that
+  # never starts. A queued job has no result, so `needs: test-wheels` simply
+  # waits -- for the 24h queue limit, not for the fix. During 1.13.14 the
+  # `macos-14` arm64 leg finished in minutes while `macos-15-intel` never
+  # picked up a host, twice, and the crates.io publish sat behind it both
+  # times. A gate that cannot run is not a gate, and the only way to stop it
+  # gating is to take it out of the dependency edge.
+  #
+  # The wheel is still built, still published, and still smoke-tested when a
+  # host is available -- the result just cannot block the release. Coverage
+  # stays enforced: `test_release_workflow.py` unions this matrix with
+  # `test-wheels` and holds the total in set-equality lockstep with
+  # `PLATFORMS`, so a family cannot lose its smoke test by being moved here.
+  # Dropping Intel macOS entirely remains a product decision, not a CI one.
+  test-wheels-ungated:
+    name: Test PyPI Wheel (${{ matrix.wheel_plat }})
+    runs-on: ${{ matrix.os }}
+    needs: [preflight, build-wheels]
+    if: needs.preflight.outputs.pypi_complete != 'true'
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15-intel
+            wheel_plat: macosx_10_12_x86_64
     steps:
       - uses: actions/checkout@v6
         with:

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -205,7 +205,30 @@ def test_release_workflow_uses_bootstrap_zccache_for_cross_builds() -> None:
     assert "SOLDR_RUSTC_WRAPPER=" in release_workflow
     assert 'use_soldr: "true"' in release_workflow
     assert "runs-on: ubuntu-24.04" in release_workflow
-    assert release_workflow.count("runs-on: ${{ matrix.os }}") == 1
+
+    # `runs-on: ${{ matrix.os }}` belongs to the wheel smoke jobs alone: those
+    # must install the wheel on its own hardware. `build` must NOT use it --
+    # cross builds run on the ubuntu-24.04 bootstrap host, which is what this
+    # test is about.
+    #
+    # Named rather than counted. The count was `== 1` until #1535 split the
+    # smoke matrix into a gating job and an ungated one, at which point a bare
+    # count has to be relaxed to 2 -- and `== 2` is then satisfied by `build`
+    # regressing onto a matrix runner while a smoke job moves off it, which is
+    # exactly the swap this line exists to catch.
+    matrix_os_jobs = {
+        name
+        for name, body in re.findall(
+            r"^  ([a-z][a-z0-9-]*):\n(.*?)(?=^  [a-z][a-z0-9-]*:\n|\Z)",
+            release_workflow,
+            re.M | re.S,
+        )
+        if "runs-on: ${{ matrix.os }}" in body
+    }
+    assert matrix_os_jobs == {"test-wheels", "test-wheels-ungated"}, (
+        "only the wheel smoke jobs may run on a per-target matrix runner; "
+        f"got {sorted(matrix_os_jobs)}"
+    )
     assert "if: inputs.use_soldr == 'true'" in action
     assert "Use setup-soldr for setup and caching" in action
 

--- a/ci/tests/test_release_workflow.py
+++ b/ci/tests/test_release_workflow.py
@@ -175,6 +175,24 @@ def _release_workflow_job(job: str) -> str:
     return text[start:end]
 
 
+def _smoke_legs() -> list[str]:
+    """Every `wheel_plat` leg across both smoke jobs, in file order.
+
+    #1535 split the smoke matrix in two: `test-wheels` gates the publish
+    chain, `test-wheels-ungated` carries families whose runner cannot be
+    relied on to schedule and which therefore must not sit on a `needs:`
+    edge. Coverage is a property of the union -- checking only the gating job
+    would let a family lose its smoke test simply by being moved.
+    """
+    return [
+        tag
+        for job in ("test-wheels", "test-wheels-ungated")
+        for tag in re.findall(
+            r"^\s+wheel_plat:\s*(\S+)$", _release_workflow_job(job), re.M
+        )
+    ]
+
+
 def test_wheel_smoke_matrix_covers_exactly_the_built_wheel_families() -> None:
     """Every smoke leg must name a wheel family `build-wheels` produces.
 
@@ -184,9 +202,7 @@ def test_wheel_smoke_matrix_covers_exactly_the_built_wheel_families() -> None:
     every release. A missing leg is the opposite hole -- a family ships to
     PyPI without ever being installed.
     """
-    smoke_tags = set(
-        re.findall(r"^\s+wheel_plat:\s*(\S+)$", _release_workflow_job("test-wheels"), re.M)
-    )
+    smoke_tags = set(_smoke_legs())
     built_tags = {
         ".".join(plat_tags) for plat_tags in release_workflow.PLATFORMS.values()
     }
@@ -201,10 +217,38 @@ def test_wheel_smoke_matrix_covers_exactly_the_built_wheel_families() -> None:
 def test_wheel_smoke_matrix_has_one_leg_per_wheel() -> None:
     """No duplicate legs: a repeated family hides a missing one behind a
     passing job name, which is how the musllinux legs stayed unnoticed."""
-    smoke_tags = re.findall(
-        r"^\s+wheel_plat:\s*(\S+)$", _release_workflow_job("test-wheels"), re.M
-    )
+    smoke_tags = _smoke_legs()
 
     assert len(smoke_tags) == len(set(smoke_tags)), (
         f"duplicate wheel_plat legs in release-auto.yml test-wheels: {sorted(smoke_tags)}"
+    )
+
+
+def test_no_job_depends_on_the_ungated_wheel_smoke() -> None:
+    """`test-wheels-ungated` must not sit on any `needs:` edge.
+
+    This is the entire point of #1535 and it is one word away from being
+    undone. `continue-on-error` was the first attempt and does not help: it
+    neutralizes a job that runs and fails, while the observed failure is a
+    job that never starts, which has no result for `needs:` to evaluate and
+    so blocks until the 24h queue limit. Taking it off the dependency edge is
+    what makes it non-blocking, so the edge is what has to be guarded.
+    """
+    path = (
+        Path(__file__).resolve().parents[2]
+        / ".github"
+        / "workflows"
+        / "release-auto.yml"
+    )
+    text = path.read_text(encoding="utf-8")
+
+    offenders = [
+        line.strip()
+        for line in text.splitlines()
+        if re.match(r"^\s+needs:", line) and "test-wheels-ungated" in line
+    ]
+
+    assert not offenders, (
+        "a job now needs test-wheels-ungated, which restores the #1535 "
+        f"deadlock -- an unschedulable runner blocks the release again: {offenders}"
     )


### PR DESCRIPTION
Reopens the substance of #1535. My previous fix did not work, and the 1.13.14 release proved it.

## What was wrong with the first attempt

PR #1536 put `continue-on-error: ${{ matrix.os == 'macos-15-intel' }}` on the leg. That neutralizes a job which **runs and fails**. The observed failure is a job that **never starts** — and a queued job has no result, so `publish-pypi`'s `needs: test-wheels` keeps waiting. It waits for GitHub's 24h queue limit, not for the fix.

The comment I wrote in that PR named the right problem — "a gate that cannot run is not a gate" — and then applied a mechanism that only handles gates that *do* run.

Confirmed empirically. The current 1.13.14 release run was dispatched **after** #1536 merged (its head is #1536's merge commit, and that commit is an ancestor of main), so it ran with the fix in place:

```
success  Test PyPI Wheel (macosx_11_0_arm64)     <- macos-14
queued   Test PyPI Wheel (macosx_10_12_x86_64)   <- macos-15-intel
```

17 of 19 jobs green, crates.io blocked behind the queued leg, same as the first attempt.

## The change

The leg moves into its own `test-wheels-ungated` job that nothing `needs:`. Removing the dependency edge is the only thing that actually stops it gating.

The wheel is still built, still published, and still smoke-tested whenever a host is available. Only its *result* stops being load-bearing.

## Coverage is not quietly narrowed

The obvious risk with splitting the matrix is that a family loses its smoke test and no one notices — which is exactly the hole `test_wheel_smoke_matrix_covers_exactly_the_built_wheel_families` exists to close. So it now unions both jobs' legs before comparing against `PLATFORMS`:

```python
def _smoke_legs() -> list[str]:
    return [tag
            for job in ("test-wheels", "test-wheels-ungated")
            for tag in re.findall(r"^\s+wheel_plat:\s*(\S+)$", _release_workflow_job(job), re.M)]
```

Set equality with `PLATFORMS` and the no-duplicates check both now hold over the union, so moving a family between the two jobs is fine and dropping one is still a failure.

And a new test guards the invariant the whole fix rests on:

```
test_no_job_depends_on_the_ungated_wheel_smoke
```

Adding `test-wheels-ungated` to any `needs:` list restores the deadlock, and it is one word away. I verified this one RED — putting the edge back fails it with:

```
AssertionError: a job now needs test-wheels-ungated, which restores the #1535
deadlock -- an unschedulable runner blocks the release again:
['needs: [preflight, publish-release, build-wheels, test-wheels, test-wheels-ungated]']
```

## Verification

`ci/tests/test_release_workflow.py`: 9 passed, 1 skipped. The workflow parses under PyYAML, and the resulting edges are:

```
test-wheels legs      : manylinux_2_17_x86_64, manylinux_2_17_aarch64, macosx_11_0_arm64, win_amd64, win_arm64
ungated legs          : macosx_10_12_x86_64
publish-pypi needs    : preflight, publish-release, build-wheels, test-wheels
publish-crates needs  : preflight, publish-release, publish-pypi
```

## Still a product decision

Whether to keep shipping a `macosx_10_12` wheel at all is not a CI question, and this change deliberately does not answer it. If Intel macOS is genuinely no longer supported, the follow-up is to drop the platform from `PLATFORMS` and both matrices together.

## Why this is urgent

1.13.14's GitHub Release is published with all its assets; PyPI and crates.io are not. [zackees/soldr#2935](https://github.com/zackees/soldr/issues/2935) needs the published crate to move its exact pin, and is blocked until this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
