### PR TITLE
feat(embedded): add host compiler admission classifier

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/compile_resource_gate.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/compile_resource_gate.rs
@@ -19,6 +19,76 @@ const AMALGAMATION_BYTES: u64 = 1_000_000;
 const KNOWN_C_AMALGAMATIONS: &[&str] = &["sqlite3.c", "zstd.c", "rocksdb.cc"];
 const KNOWN_RUST_AMALGAMATIONS: &[&str] = &["zccache", "zccache_cli_core", "zccache_daemon_core"];
 
+/// Stable compiler facts supplied to an embedded host admission policy.
+///
+/// This deliberately exposes neither the daemon's semaphore nor its resource
+/// lock. The host can classify the child zccache is about to spawn, but only
+/// zccache can acquire its canonical admission in the safe order.
+#[derive(Debug)]
+pub struct HostCompilerRequest<'a> {
+    family: CompilerFamily,
+    args: &'a [String],
+    source: Option<&'a Path>,
+}
+
+impl<'a> HostCompilerRequest<'a> {
+    fn new(family: CompilerFamily, args: &'a [String], source: Option<&'a Path>) -> Self {
+        Self {
+            family,
+            args,
+            source,
+        }
+    }
+
+    #[must_use]
+    pub fn family(&self) -> CompilerFamily {
+        self.family
+    }
+
+    #[must_use]
+    pub fn args(&self) -> &'a [String] {
+        self.args
+    }
+
+    #[must_use]
+    pub fn source(&self) -> Option<&'a Path> {
+        self.source
+    }
+}
+
+/// A host policy could not classify an otherwise valid compiler request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostAdmissionError(String);
+
+impl HostAdmissionError {
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl std::fmt::Display for HostAdmissionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for HostAdmissionError {}
+
+/// Optional embedded-host classification layered onto zccache's own policy.
+///
+/// Called only for a request that has already missed every cache-hit path and
+/// is immediately about to acquire zccache-owned compiler admission. A host
+/// returns `true` only to request exclusive admission; it cannot acquire or
+/// reorder zccache's synchronization primitives. Returning an error rejects
+/// the compile before any admission permit is acquired.
+pub trait HostAdmissionClassifier: Send + Sync + 'static {
+    fn requires_exclusive(
+        &self,
+        request: &HostCompilerRequest<'_>,
+    ) -> Result<bool, HostAdmissionError>;
+}
+
 /// Fair shared/exclusive admission around real compiler execution.
 ///
 /// Tokio's write-preferring lock prevents newly arriving ordinary compiles
@@ -194,6 +264,37 @@ pub(super) fn requires_exclusive_access_for_misses<'a>(
         .any(|source| requires_exclusive_access(family, args, source))
 }
 
+/// Combine zccache's built-in predicate with an opt-in embedded-host policy.
+///
+/// Every caller reaches this only after cache-hit classification. The policy
+/// has no effect when absent, and the result still feeds the single canonical
+/// semaphore-then-RwLock admission helper below.
+pub(super) fn requires_exclusive_admission(
+    state: &SharedState,
+    family: CompilerFamily,
+    args: &[String],
+    source: Option<&Path>,
+    built_in: bool,
+) -> Result<bool, HostAdmissionError> {
+    combines_exclusive_admission(
+        built_in,
+        state.host_admission_classifier.as_deref(),
+        HostCompilerRequest::new(family, args, source),
+    )
+}
+
+fn combines_exclusive_admission(
+    built_in: bool,
+    classifier: Option<&dyn HostAdmissionClassifier>,
+    request: HostCompilerRequest<'_>,
+) -> Result<bool, HostAdmissionError> {
+    let host = classifier
+        .map(|classifier| classifier.requires_exclusive(&request))
+        .transpose()?
+        .unwrap_or(false);
+    Ok(built_in || host)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -285,6 +386,88 @@ mod tests {
             &["--crate-name=serde".into()],
             Path::new("/registry/serde/src/lib.rs"),
         ));
+    }
+
+    struct KernalApiPolicy;
+
+    impl HostAdmissionClassifier for KernalApiPolicy {
+        fn requires_exclusive(
+            &self,
+            request: &HostCompilerRequest<'_>,
+        ) -> Result<bool, HostAdmissionError> {
+            Ok(request.family() == CompilerFamily::Rustc
+                && rust_crate_name(request.args()) == Some("kernal_api"))
+        }
+    }
+
+    struct FailingPolicy;
+
+    impl HostAdmissionClassifier for FailingPolicy {
+        fn requires_exclusive(
+            &self,
+            _request: &HostCompilerRequest<'_>,
+        ) -> Result<bool, HostAdmissionError> {
+            Err(HostAdmissionError::new("host policy unavailable"))
+        }
+    }
+
+    #[test]
+    fn host_only_rust_crate_can_request_exclusive_admission() {
+        let args = [
+            "--crate-name=kernal_api".to_string(),
+            "--crate-type=lib".to_string(),
+        ];
+        let request =
+            HostCompilerRequest::new(CompilerFamily::Rustc, &args, Some(Path::new("src/lib.rs")));
+        assert!(!requires_exclusive_access(
+            CompilerFamily::Rustc,
+            request.args(),
+            Path::new("src/lib.rs"),
+        ));
+        assert!(
+            combines_exclusive_admission(false, Some(&KernalApiPolicy), request)
+                .expect("host policy result")
+        );
+    }
+
+    #[test]
+    fn absent_host_policy_preserves_builtin_admission() {
+        let args = ["--crate-name=ordinary".to_string()];
+        let request = HostCompilerRequest::new(CompilerFamily::Rustc, &args, None);
+        assert!(!combines_exclusive_admission(false, None, request).expect("no host policy"));
+
+        let request = HostCompilerRequest::new(CompilerFamily::Rustc, &args, None);
+        assert!(combines_exclusive_admission(true, None, request).expect("no host policy"));
+    }
+
+    #[test]
+    fn builtin_and_host_policies_are_or_combined() {
+        let args = ["--crate-name=ordinary".to_string()];
+        let request = HostCompilerRequest::new(CompilerFamily::Rustc, &args, None);
+        assert!(
+            combines_exclusive_admission(true, Some(&KernalApiPolicy), request)
+                .expect("combined result")
+        );
+    }
+
+    #[test]
+    fn failing_host_policy_rejects_before_admission() {
+        let args = ["--crate-name=ordinary".to_string()];
+        let error = combines_exclusive_admission(
+            false,
+            Some(&FailingPolicy),
+            HostCompilerRequest::new(CompilerFamily::Rustc, &args, None),
+        )
+        .expect_err("a host classification failure must reject before admission");
+        assert_eq!(error.to_string(), "host policy unavailable");
+
+        let error = combines_exclusive_admission(
+            true,
+            Some(&FailingPolicy),
+            HostCompilerRequest::new(CompilerFamily::Rustc, &args, None),
+        )
+        .expect_err("a built-in exclusive unit must not hide a host-policy failure");
+        assert_eq!(error.to_string(), "host policy unavailable");
     }
 
     #[test]
@@ -429,7 +612,7 @@ mod tests {
     }
 
     #[test]
-    fn every_compile_spawn_surface_uses_shared_admission() {
+    fn every_compile_spawn_surface_combines_host_policy_before_shared_admission() {
         for (name, source) in [
             (
                 "single cache miss",
@@ -448,6 +631,10 @@ mod tests {
                 include_str!("handle_compile_multi_staged.rs"),
             ),
         ] {
+            assert!(
+                source.contains("requires_exclusive_admission("),
+                "{name} compiler path bypasses the host policy"
+            );
             assert!(
                 source.contains("acquire_compiler_admission("),
                 "{name} compiler path bypasses shared admission"

--- a/crates/zccache-daemon-core/src/daemon/server/embedded.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/embedded.rs
@@ -40,6 +40,7 @@ impl EmbeddedDaemon {
             runtime_handle,
             maintenance_policy,
             true,
+            None,
         )
         .await
     }
@@ -51,12 +52,20 @@ impl EmbeddedDaemon {
         runtime_handle: Option<tokio::runtime::Handle>,
         maintenance_policy: MaintenancePolicy,
         automatic_maintenance: bool,
+        host_admission_classifier: Option<
+            Arc<dyn super::compile_resource_gate::HostAdmissionClassifier>,
+        >,
     ) -> Result<Self, crate::ipc::IpcError> {
         let backend_identity = crate::ipc::current_backend_identity(&endpoint)
             .map_err(|err| super::lifecycle::daemon_identity_error(&endpoint, &err))?;
-        let (state, index_writer_rx) =
-            new_shared_state(&endpoint, &cache_dir, staging_root, backend_identity)
-                .map_err(|error| super::lifecycle::cache_root_error(&cache_dir, &error))?;
+        let (state, index_writer_rx) = new_shared_state(
+            &endpoint,
+            &cache_dir,
+            staging_root,
+            backend_identity,
+            host_admission_classifier,
+        )
+        .map_err(|error| super::lifecycle::cache_root_error(&cache_dir, &error))?;
         // Arm the startup depgraph-load gate as early as possible — before
         // this state can serve any compile. The shared `dep_graph_load_complete`
         // flag inits `true` ("assume loaded"); the standalone daemon flips it
@@ -836,6 +845,7 @@ mod flush_ownership_tests {
             None,
             MaintenancePolicy::default(),
             false,
+            None,
         )
         .await
         .expect("embedded daemon");
@@ -866,6 +876,7 @@ mod flush_ownership_tests {
             None,
             MaintenancePolicy::default(),
             false,
+            None,
         );
         let start_b = EmbeddedDaemon::start_with_maintenance(
             crate::ipc::unique_test_endpoint(),
@@ -874,6 +885,7 @@ mod flush_ownership_tests {
             None,
             MaintenancePolicy::default(),
             false,
+            None,
         );
         let (daemon_a, daemon_b) = tokio::join!(start_a, start_b);
         let daemon_a = daemon_a.expect("embedded daemon a");

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -253,11 +253,26 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     // readers and runs alone. The shared helper acquires the bounded FIFO
     // compile slot first and the resource gate second, then both remain held
     // across overlapping input hashing and the compiler child.
-    let exclusive = crate::daemon::server::compile_resource_gate::requires_exclusive_access(
+    let built_in_exclusive =
+        crate::daemon::server::compile_resource_gate::requires_exclusive_access(
+            compilation.family,
+            effective_args,
+            source_path.as_path(),
+        );
+    let exclusive = match crate::daemon::server::compile_resource_gate::requires_exclusive_admission(
+        state,
         compilation.family,
         effective_args,
-        source_path.as_path(),
-    );
+        Some(source_path.as_path()),
+        built_in_exclusive,
+    ) {
+        Ok(exclusive) => exclusive,
+        Err(error) => {
+            return CompileExecResult::Error(Response::Error {
+                message: format!("host compiler-admission classification failed: {error}"),
+            });
+        }
+    };
     let (_compiler_admission, available_before) =
         crate::daemon::server::compile_resource_gate::acquire_compiler_admission(state, exclusive)
             .await;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
@@ -148,8 +148,22 @@ pub(super) async fn run_compiler_direct_with_family(
     } else {
         Some(stdin_bytes)
     };
-    let exclusive =
+    let built_in_exclusive =
         super::compile_resource_gate::requires_exclusive_access_from_args(family_hint, args, cwd);
+    let exclusive = match super::compile_resource_gate::requires_exclusive_admission(
+        state,
+        family_hint,
+        args,
+        None,
+        built_in_exclusive,
+    ) {
+        Ok(exclusive) => exclusive,
+        Err(error) => {
+            return Response::Error {
+                message: format!("host compiler-admission classification failed: {error}"),
+            };
+        }
+    };
     let (_compiler_admission, _) =
         super::compile_resource_gate::acquire_compiler_admission(state, exclusive).await;
     if exclusive {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -755,7 +755,7 @@ pub(super) async fn handle_compile_multi(
     }
     apply_client_env(&mut cmd, &client_env, &lineage);
     let compiler_priority = CompilePriority::from_client_env(client_env.as_deref());
-    let exclusive =
+    let built_in_exclusive =
         crate::daemon::server::compile_resource_gate::requires_exclusive_access_for_misses(
             compilations[0].family,
             &compiler_args,
@@ -764,6 +764,20 @@ pub(super) async fn handle_compile_multi(
                 UnitCacheResult::Hit { .. } => None,
             }),
         );
+    let exclusive = match crate::daemon::server::compile_resource_gate::requires_exclusive_admission(
+        &state,
+        compilations[0].family,
+        &compiler_args,
+        None,
+        built_in_exclusive,
+    ) {
+        Ok(exclusive) => exclusive,
+        Err(error) => {
+            return Response::Error {
+                message: format!("host compiler-admission classification failed: {error}"),
+            };
+        }
+    };
     let (compiler_admission, _) =
         crate::daemon::server::compile_resource_gate::acquire_compiler_admission(&state, exclusive)
             .await;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
@@ -209,11 +209,27 @@ pub(super) async fn try_handle_staged_misses(
         command.kill_on_drop(true);
         let admission_state = Arc::clone(state);
         let family = compilations[miss.unit_index].family;
-        let exclusive = crate::daemon::server::compile_resource_gate::requires_exclusive_access(
-            family,
-            &compiler_args,
-            miss.source_path.as_path(),
-        );
+        let built_in_exclusive =
+            crate::daemon::server::compile_resource_gate::requires_exclusive_access(
+                family,
+                &compiler_args,
+                miss.source_path.as_path(),
+            );
+        let exclusive =
+            match crate::daemon::server::compile_resource_gate::requires_exclusive_admission(
+                state.as_ref(),
+                family,
+                &compiler_args,
+                Some(miss.source_path.as_path()),
+                built_in_exclusive,
+            ) {
+                Ok(exclusive) => exclusive,
+                Err(error) => {
+                    return Some(Response::Error {
+                        message: format!("host compiler-admission classification failed: {error}"),
+                    });
+                }
+            };
         // Issue #1216: keep the global queue gauge accurate for the staged
         // lane too. These waits run on spawned tasks, so the per-request
         // task-local slot is out of reach — the daemon-wide `queue_depth` /

--- a/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/lifecycle.rs
@@ -49,7 +49,7 @@ impl DaemonServer {
         let backend_identity = crate::ipc::current_backend_identity(endpoint)
             .map_err(|err| daemon_identity_error(endpoint, &err))?;
         let (state, index_writer_rx) =
-            new_shared_state(endpoint, cache_dir, staging_root, backend_identity)
+            new_shared_state(endpoint, cache_dir, staging_root, backend_identity, None)
                 .map_err(|error| cache_root_error(cache_dir, &error))?;
 
         Ok(Self {
@@ -113,6 +113,7 @@ pub(super) fn new_shared_state(
     cache_dir: &crate::core::NormalizedPath,
     staging_root: Option<&crate::core::NormalizedPath>,
     backend_identity: running_process::broker::protocol_v2::backend_handle::DaemonProcess,
+    host_admission_classifier: Option<Arc<dyn compile_resource_gate::HostAdmissionClassifier>>,
 ) -> std::io::Result<(
     Arc<SharedState>,
     tokio::sync::mpsc::UnboundedReceiver<IndexWriterCommand>,
@@ -299,6 +300,7 @@ pub(super) fn new_shared_state(
             compile_concurrency,
             compile_resource_gate:
                 crate::daemon::server::compile_resource_gate::CompileResourceGate::default(),
+            host_admission_classifier,
             compile_queue: Arc::new(
                 crate::daemon::server::compile_progress::CompileQueueGauge::default(),
             ),

--- a/crates/zccache-daemon-core/src/daemon/server/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/mod.rs
@@ -152,7 +152,7 @@ mod cached_artifact;
 mod client_env;
 mod compile_concurrency;
 mod compile_progress;
-mod compile_resource_gate;
+pub(crate) mod compile_resource_gate;
 mod compiler_hash;
 mod connection;
 mod dependency_policy;

--- a/crates/zccache-daemon-core/src/daemon/server/state.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/state.rs
@@ -464,6 +464,10 @@ pub(super) struct SharedState {
     /// Shared admission for ordinary compiler children and exclusive
     /// admission for unusually memory-intensive C/Rust amalgamations.
     pub(super) compile_resource_gate: super::compile_resource_gate::CompileResourceGate,
+    /// Optional host-only classifier for embedded compiler admission. It can
+    /// request exclusivity but never owns or acquires the daemon's gates.
+    pub(super) host_admission_classifier:
+        Option<Arc<dyn super::compile_resource_gate::HostAdmissionClassifier>>,
     /// Issue #1216 — compile-queue counters backing the `CompileProgress`
     /// heartbeats. `tokio::sync::Semaphore` reports available permits but
     /// not its waiter count or original capacity, so the gate maintains

--- a/crates/zccache-daemon-core/src/daemon/server/tests/maintenance_schedule.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/maintenance_schedule.rs
@@ -33,7 +33,7 @@ fn test_state(cache_dir: &crate::core::NormalizedPath) -> Arc<SharedState> {
     let endpoint = crate::ipc::unique_test_endpoint();
     let identity = crate::ipc::current_backend_identity(&endpoint).expect("backend identity");
     let (state, _index_writer_rx) =
-        new_shared_state(&endpoint, cache_dir, None, identity).expect("shared state");
+        new_shared_state(&endpoint, cache_dir, None, identity, None).expect("shared state");
     state
 }
 

--- a/crates/zccache-daemon-core/src/embedded.rs
+++ b/crates/zccache-daemon-core/src/embedded.rs
@@ -17,6 +17,9 @@ use crate::daemon::server::{
 };
 
 pub use crate::audit::{AuditConfig, AuditContext, AuditEvent};
+pub use crate::daemon::server::compile_resource_gate::{
+    HostAdmissionClassifier, HostAdmissionError, HostCompilerRequest,
+};
 pub use control::EmbeddedEventSink;
 
 mod control;
@@ -520,7 +523,7 @@ impl ZccacheService {
             ZccacheStartOptions {
                 disk_limits,
                 maintenance_ownership,
-                staging_root: None,
+                ..ZccacheStartOptions::default()
             },
         )
         .await
@@ -534,7 +537,35 @@ impl ZccacheService {
         config: ZccacheConfig,
         options: ZccacheStartOptions,
     ) -> Result<Self> {
-        Self::start_internal(config, options, None).await
+        Self::start_internal(config, options, None, None).await
+    }
+
+    /// Start with an opt-in host compiler-admission policy.
+    ///
+    /// The policy is evaluated only after cache-hit classification and before
+    /// zccache acquires its canonical compiler admission. This additive
+    /// constructor keeps existing [`ZccacheConfig`] and
+    /// [`ZccacheStartOptions`] struct literals source-compatible.
+    pub async fn start_with_host_admission_classifier(
+        config: ZccacheConfig,
+        classifier: Arc<dyn HostAdmissionClassifier>,
+    ) -> Result<Self> {
+        Self::start_internal(
+            config,
+            ZccacheStartOptions::default(),
+            None,
+            Some(classifier),
+        )
+        .await
+    }
+
+    /// Start with explicit service options and a host compiler-admission policy.
+    pub async fn start_with_options_and_host_admission_classifier(
+        config: ZccacheConfig,
+        options: ZccacheStartOptions,
+        classifier: Arc<dyn HostAdmissionClassifier>,
+    ) -> Result<Self> {
+        Self::start_internal(config, options, None, Some(classifier)).await
     }
 
     /// Emit one durable audit event, if the host enabled audit.
@@ -961,3 +992,7 @@ mod contract_tests;
 #[cfg(test)]
 #[path = "embedded/tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "embedded/admission_tests.rs"]
+mod admission_tests;

--- a/crates/zccache-daemon-core/src/embedded/admission_tests.rs
+++ b/crates/zccache-daemon-core/src/embedded/admission_tests.rs
@@ -1,0 +1,91 @@
+//! Public embedded host-admission policy contract tests (zccache#1539).
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use super::*;
+use tempfile::TempDir;
+
+struct CountingHostPolicy {
+    calls: Arc<AtomicUsize>,
+}
+
+impl HostAdmissionClassifier for CountingHostPolicy {
+    fn requires_exclusive(
+        &self,
+        _request: &HostCompilerRequest<'_>,
+    ) -> std::result::Result<bool, HostAdmissionError> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        Ok(false)
+    }
+}
+
+async fn start_service_with_policy(temp: &TempDir, calls: Arc<AtomicUsize>) -> ZccacheService {
+    let mut audit = AuditConfig::default();
+    audit.mode = crate::audit::AuditMode::Off;
+    ZccacheService::start_with_options_and_host_admission_classifier(
+        ZccacheConfig {
+            host: HostIdentity {
+                product: "host-admission-policy-test".into(),
+                instance_id: uuid::Uuid::new_v4().to_string(),
+                workspace_id: "host-admission-policy-workspace".into(),
+            },
+            cache_root: temp.path().join("cache").into(),
+            audit,
+            limits: ServiceLimits::default(),
+            runtime: RuntimeHooks::default(),
+            cancellation: None,
+        },
+        ZccacheStartOptions::default(),
+        Arc::new(CountingHostPolicy { calls }),
+    )
+    .await
+    .expect("service start")
+}
+
+#[tokio::test]
+async fn host_policy_runs_for_a_miss_but_not_its_cache_hit() {
+    let Some(compiler) = crate::test_support::find_clang() else {
+        return;
+    };
+    let temp = TempDir::new().expect("tempdir");
+    let source = temp.path().join("unit.c");
+    let output = temp.path().join("unit.o");
+    std::fs::write(&source, "int admission_policy_unit(void) { return 1; }\n")
+        .expect("source fixture");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let service = start_service_with_policy(&temp, Arc::clone(&calls)).await;
+    let request = CompileRequest {
+        audit: AuditContext::new(
+            crate::audit::AuditId::new("host-policy-run").expect("id"),
+            crate::audit::AuditId::new("host-policy-trace").expect("id"),
+        ),
+        compiler,
+        args: vec![
+            "-c".into(),
+            source.to_string_lossy().into_owned(),
+            "-o".into(),
+            output.to_string_lossy().into_owned(),
+        ],
+        cwd: temp.path().into(),
+        env: Vec::new(),
+        stdin: Vec::new(),
+    };
+
+    let miss = service.compile(request.clone()).await.expect("cache miss");
+    assert!(!miss.cached, "first compile must execute the compiler");
+    assert_eq!(calls.load(Ordering::Relaxed), 1, "miss invokes policy once");
+
+    std::fs::remove_file(&output).expect("remove cold output");
+    let hit = service.compile(request).await.expect("cache hit");
+    assert!(hit.cached, "second compile must replay the cached output");
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        1,
+        "cache hit must bypass the host policy and compiler admission"
+    );
+    service
+        .shutdown(ShutdownMode::Graceful)
+        .await
+        .expect("shutdown");
+}

--- a/crates/zccache-daemon-core/src/embedded/control.rs
+++ b/crates/zccache-daemon-core/src/embedded/control.rs
@@ -7,8 +7,8 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    EmbeddedError, HostIdentity, MaintenanceOwnership, MaintenancePolicy, Result, ZccacheConfig,
-    ZccacheService, ZccacheStartOptions,
+    EmbeddedError, HostAdmissionClassifier, HostIdentity, MaintenanceOwnership, MaintenancePolicy,
+    Result, ZccacheConfig, ZccacheService, ZccacheStartOptions,
 };
 use crate::daemon::server::EmbeddedDaemon;
 
@@ -42,7 +42,13 @@ impl ZccacheService {
         config: ZccacheConfig,
         event_sink: Arc<dyn EmbeddedEventSink>,
     ) -> Result<Self> {
-        Self::start_internal(config, ZccacheStartOptions::default(), Some(event_sink)).await
+        Self::start_internal(
+            config,
+            ZccacheStartOptions::default(),
+            Some(event_sink),
+            None,
+        )
+        .await
     }
 
     /// Start with both additive service options and a host event sink.
@@ -51,13 +57,14 @@ impl ZccacheService {
         options: ZccacheStartOptions,
         event_sink: Arc<dyn EmbeddedEventSink>,
     ) -> Result<Self> {
-        Self::start_internal(config, options, Some(event_sink)).await
+        Self::start_internal(config, options, Some(event_sink), None).await
     }
 
     pub(super) async fn start_internal(
         config: ZccacheConfig,
         options: ZccacheStartOptions,
         event_sink: Option<Arc<dyn EmbeddedEventSink>>,
+        host_admission_classifier: Option<Arc<dyn HostAdmissionClassifier>>,
     ) -> Result<Self> {
         let compile_permits = match config.limits.max_parallel_compiles {
             Some(0) => {
@@ -89,6 +96,7 @@ impl ZccacheService {
             config.runtime.handle.clone(),
             maintenance_policy,
             options.maintenance_ownership == MaintenanceOwnership::Embedded,
+            host_admission_classifier,
         )
         .await
         .map_err(|err| EmbeddedError::Start(err.to_string()))?;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,6 +41,7 @@ failed cache-root audit retain its diagnostic JSONL evidence.
 - **Embedded soldr/fbuild service integration** → [embedded-service.md](architecture/embedded-service.md)
 - **Embedded heap snapshots** → [embedded-service.md § Heap snapshots](architecture/embedded-service.md#heap-snapshots)
 - **Embedded maintenance limits and shutdown reporting** → [embedded-service.md § Maintenance limits and task ownership](architecture/embedded-service.md#maintenance-limits-and-task-ownership)
+- **Embedded host compiler-admission policy and cache-hit bypass** → [embedded-service.md § Host compiler-admission policy](architecture/embedded-service.md#host-compiler-admission-policy)
 - **Shared periodic maintenance schedule (both service modes)** → [embedded-service.md § Maintenance limits and task ownership](architecture/embedded-service.md#maintenance-limits-and-task-ownership)
 - **Legacy action target snapshots** → [target-cache.md](architecture/target-cache.md)
 - **Thread safety & crash safety** → [runtime.md](architecture/runtime.md)

--- a/docs/architecture/embedded-service.md
+++ b/docs/architecture/embedded-service.md
@@ -142,6 +142,31 @@ Any persistent write in embedded mode must be rooted under the host-provided
 cache root or audit output root unless the design explicitly documents an
 exception.
 
+### Host compiler-admission policy
+
+An embedded host may call
+`ZccacheService::start_with_host_admission_classifier` (or its explicit
+options counterpart) to request exclusive admission for a product-specific
+compiler unit. The policy receives stable compiler facts (`CompilerFamily`,
+argument vector, and an optional source path) and returns only a boolean; it
+never receives a permit, lock, or daemon state handle. The ordinary `start`
+and `start_with_options` constructors remain no-ops for this policy, preserving
+standalone and existing embedded-service behavior and source compatibility.
+
+Zccache invokes this policy only after the request has missed all cache-hit
+paths and immediately before a real compiler child would be spawned. A cache
+hit therefore neither invokes the host policy nor waits for compiler
+admission. The host result is ORed with zccache's built-in large-C and known
+Rust-amalgamation predicate, so either owner can request exclusive execution.
+
+Zccache remains the sole owner of scheduling. It acquires the bounded compile
+semaphore first and then its fair shared/exclusive `RwLock`; policies cannot
+reverse that order or retain permits during cancellation or shutdown. Hosts
+should keep classification pure and quick, and own the product-specific
+predicate and its regression tests. A classifier error rejects the request
+before either admission layer is acquired, so it cannot leak a permit or
+silently change the host's intended scheduling policy.
+
 ## API Sketch
 
 The exact Rust API will be finalized in zccache#905. The design should
@@ -176,6 +201,17 @@ pub struct ZccacheStartOptions {
     pub disk_limits: DiskCacheLimits,
     pub maintenance_ownership: MaintenanceOwnership,
     pub staging_root: Option<NormalizedPath>,
+}
+
+pub struct HostCompilerRequest<'a> {
+    // compiler family, argv, optional source path; accessors only
+}
+
+pub trait HostAdmissionClassifier: Send + Sync + 'static {
+    fn requires_exclusive(
+        &self,
+        request: &HostCompilerRequest<'_>,
+    ) -> Result<bool, HostAdmissionError>;
 }
 
 pub enum DiskMaintenanceKind {
@@ -273,6 +309,15 @@ impl ZccacheService {
     pub async fn start_with_options(
         config: ZccacheConfig,
         options: ZccacheStartOptions,
+    ) -> Result<Self>;
+    pub async fn start_with_host_admission_classifier(
+        config: ZccacheConfig,
+        classifier: Arc<dyn HostAdmissionClassifier>,
+    ) -> Result<Self>;
+    pub async fn start_with_options_and_host_admission_classifier(
+        config: ZccacheConfig,
+        options: ZccacheStartOptions,
+        classifier: Arc<dyn HostAdmissionClassifier>,
     ) -> Result<Self>;
     pub async fn compile(&self, request: CompileRequest) -> Result<CompileResponse>;
     pub async fn compile_streaming<F>(&self, request: CompileRequest, on_chunk: F) -> Result<()>

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,13 @@
+# #1539 embedded host compiler-admission classifier
+
+- [x] Read the issue, service admission paths, and embedded configuration surface.
+- [x] Add a RED policy/ordering contract covering host-only exclusivity and cache-hit bypass.
+- [x] Add the opt-in host classifier and pass it through canonical post-hit admission.
+- [x] Cover built-in predicate composition, contention/cancellation, and default compatibility.
+- [x] Document the host-policy, hit-bypass, and semaphore-then-RwLock contract.
+- [x] Run focused and broader validation.
+- [ ] Obtain independent review, push, open the resolving PR, and monitor CI.
+
 # #1513 replace vulnerable sevenz-rust
 
 - [x] RED: `soldr cargo audit` reports RUSTSEC-2026-0245 through sevenz-rust 0.6.1.


### PR DESCRIPTION
## Summary

- add an opt-in, source-compatible embedded host admission classifier through additive service constructors
- combine the host result with zccache's built-in classifier only on real post-hit compiler paths, preserving zccache's semaphore → fair RwLock ordering
- reject classifier errors before admission, document predicate ownership/hit bypass, and prove cold-miss versus warm-hit behavior

Closes #1539.
Coordinates with zackees/soldr#2932.

## RED → GREEN evidence

The new host_policy_runs_for_a_miss_but_not_its_cache_hit regression is RED before this change because the public embedded API has no policy hook. It is GREEN here: its cold compile invokes the policy once, while the restored cache hit invokes it zero additional times.

Validated locally:

- soldr cargo test -p zccache-daemon-core --features test-support compile_resource_gate --lib (20 passed)
- soldr cargo test -p zccache-daemon-core --features test-support host_policy_runs_for_a_miss_but_not_its_cache_hit --lib (1 passed)
- soldr cargo clippy -p zccache-daemon-core --all-targets --features test-support -- -D warnings
- soldr cargo fmt --all -- --check
- git diff --check

Independent clud-review: clean, including a follow-up on the additive-constructor source-compatibility correction.